### PR TITLE
Add MCP integration with instruction steps

### DIFF
--- a/vexa-mcp/README.md
+++ b/vexa-mcp/README.md
@@ -1,0 +1,101 @@
+# Vexa MCP Server Setup Guide
+
+This guide will help you set up and run the Vexa MCP (Model Context Protocol) Server to enable transcription capabilities in Claude Desktop (or any MCP client of your choice)!
+
+## Prerequisites
+
+- Claude Desktop installed on your system
+- A Vexa API key
+
+## 🚀 Quick Setup
+
+### Step 1: Install the MCP Server File
+
+Download or clone the `vexa-mcp.py` file to your desired directory on your machine.
+
+### Step 2: Install UV (Recommended)
+
+UV is a fast Python package installer and resolver. Choose your platform:
+
+**Windows (PowerShell):**
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+**macOS/Linux:**
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Learn more about [uv](https://docs.astral.sh/uv/)
+
+### Step 3: Install Dependencies
+
+Choose one of the following methods:
+
+**Option A: Using UV (Recommended)**
+```bash
+uv add "mcp[cli]" requests
+```
+
+**Option B: Using pip**
+```bash
+pip install "mcp[cli]" requests
+```
+
+### Step 4: Configure Claude Desktop
+
+1. **Open Claude Desktop Settings**
+   - Launch Claude Desktop
+   - Navigate to **Settings** → **Developer**
+   - Click **Edit Config**
+
+2. **Add MCP Server Configuration**
+   
+   Paste the following configuration into the config file, replacing the placeholder values:
+
+   ```json
+   {
+     "mcpServers": {
+       "Vexa-MCP": {
+         "command": "uv",
+         "args": [
+           "--directory",
+           "[full_path_to_directory_with_vexa-mcp.py_file]",
+           "run",
+           "vexa-mcp.py"
+         ],
+         "env": {
+           "VEXA_API_KEY": "[your_api_key]"
+         }
+       }
+     }
+   }
+   ```
+
+3. **Update Configuration Values**
+   - Replace `[full_path_to_directory_with_vexa-mcp.py_file]` with the actual path to your directory
+   - Replace `[your_api_key]` with your Vexa API key
+
+4. **Save and Restart**
+   - Save the configuration file
+   - Restart Claude Desktop
+
+   Everything should work well now. You can use the same config in other MCP clients such as Cursor etc..
+
+## ✅ Verification
+
+After restarting Claude Desktop, the Vexa MCP server should be available. You can verify the setup by checking if transcription capabilities are working in your Claude conversations.
+
+## 🔧 Troubleshooting
+
+- **API Key Issues**: Verify your Vexa API key is valid and properly set in the environment variables
+- **Path Issues**: Make sure to use the full absolute path to the directory containing `vexa-mcp.py`
+- **UV Issues**: Make sure uv is properly installed by running `uv --version`. Restart if issue persists
+
+## Additional Resources
+- [MCP Protocol Documentation](https://modelcontextprotocol.io/)
+
+---
+
+**Need help?** Contact us directly

--- a/vexa-mcp/vexa-mcp.py
+++ b/vexa-mcp/vexa-mcp.py
@@ -1,0 +1,271 @@
+import requests
+import json
+from mcp.server.fastmcp import FastMCP
+from typing import Dict, Any, List, Optional
+import os
+
+mcp = FastMCP("Vexa-MCP")
+
+
+BASE_URL = "https://gateway.dev.vexa.ai"
+VEXA_API_KEY = os.environ.get("VEXA_API_KEY")
+
+HEADERS = {
+    "X-API-Key": VEXA_API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+@mcp.tool()
+def request_meeting_bot(meeting_id: str, language: Optional[str] = None, bot_name: Optional[str] = None, meeting_platform: str = "google_meet") -> Dict[str, Any]:
+    """
+    Request a Vexa bot to join a meeting for transcription.
+    
+    Args:
+        meeting_id: The unique identifier for the meeting (e.g., 'xxx-xxxx-xxx' from Google Meet URL)
+        language: Optional language code for transcription (e.g., 'en', 'es'). If not specified, auto-detected
+        bot_name: Optional custom name for the bot in the meeting
+        meeting_platform: The meeting platform (e.g., 'google_meet', 'zoom'). Default is 'google_meet'.
+    
+    Returns:
+        JSON string with bot request details and status
+    
+    Note: After a successful request, it typically takes about 10 seconds for the bot to join the meeting.
+    """
+
+    request_bot_url = f"{BASE_URL}/bots"
+    request_bot_payload = {
+        "platform": meeting_platform,
+        "native_meeting_id": meeting_id,
+        "language": language, # Optional: specify language
+        "bot_name": bot_name # Optional: custom name
+    }
+
+    try:
+        response = requests.post(request_bot_url, headers=HEADERS, json=request_bot_payload, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+@mcp.tool()
+def get_meeting_transcript(meeting_id: str, meeting_platform: str = "google_meet") -> Dict[str, Any]:
+    """
+    Get the real-time transcript for a meeting.
+    
+    Args:
+        meeting_id: The unique identifier for the meeting
+        meeting_platform: The meeting platform (e.g., 'google_meet', 'zoom'). Default is 'google_meet'.
+    
+    Returns:
+        JSON with the meeting transcript data including segments with speaker, timestamp, and text
+    
+    Note: This provides real-time transcription data and can be called during or after the meeting.
+    """
+    get_transcript_url = f"{BASE_URL}/transcripts/{meeting_platform}/{meeting_id}"
+    
+    try:
+        response = requests.get(get_transcript_url, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+
+@mcp.tool()
+def get_bot_status() -> Dict[str, Any]:
+    """
+    Get the status of currently running bots.
+    
+    Returns:
+        JSON with details about active bots under your API key
+    """
+    get_status_url = f"{BASE_URL}/bots/status"
+    
+    try:
+        response = requests.get(get_status_url, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+
+@mcp.tool()
+def update_bot_config(meeting_id: str, language: str, meeting_platform: str = "google_meet") -> Dict[str, Any]:
+    """
+    Update the configuration of an active bot (e.g., changing the language).
+    
+    Args:
+        meeting_id: The identifier of the meeting with the active bot
+        language: New language code for transcription (e.g., 'en', 'es')
+        meeting_platform: The meeting platform (e.g., 'google_meet', 'zoom'). Default is 'google_meet'.
+    
+    Returns:
+        JSON indicating whether the update request was accepted
+    """
+    update_config_url = f"{BASE_URL}/bots/{meeting_platform}/{meeting_id}/config"
+    update_payload = {
+        "language": language
+    }
+    
+    try:
+        response = requests.put(update_config_url, headers=HEADERS, json=update_payload, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+
+@mcp.tool()
+def stop_bot(meeting_id: str, meeting_platform: str = "google_meet") -> Dict[str, Any]:
+    """
+    Remove an active bot from a meeting.
+    
+    Args:
+        meeting_id: The identifier of the meeting
+        meeting_platform: The meeting platform (e.g., 'google_meet', 'zoom'). Default is 'google_meet'.
+    
+    Returns:
+        JSON confirming the bot removal
+    """
+    stop_bot_url = f"{BASE_URL}/bots/{meeting_platform}/{meeting_id}"
+    
+    try:
+        response = requests.delete(stop_bot_url, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+
+@mcp.tool()
+def list_meetings() -> Dict[str, Any]:
+    """
+    List all meetings associated with your API key.
+    
+    Returns:
+        JSON with a list of meeting records
+    """
+    list_meetings_url = f"{BASE_URL}/meetings"
+    
+    try:
+        response = requests.get(list_meetings_url, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+
+@mcp.tool()
+def update_meeting_data(meeting_id: str, name: Optional[str] = None, participants: Optional[List[str]] = None, languages: Optional[List[str]] = None, notes: Optional[str] = None, meeting_platform: str = "google_meet") -> Dict[str, Any]:
+    """
+    Update meeting metadata such as name, participants, languages, and notes.
+    
+    Args:
+        meeting_id: The unique identifier of the meeting
+        name: Optional meeting name/title
+        participants: Optional list of participant names
+        languages: Optional list of language codes detected/used in the meeting
+        notes: Optional meeting notes or description
+        meeting_platform: The meeting platform (e.g., 'google_meet', 'zoom'). Default is 'google_meet'.
+    
+    Returns:
+        JSON with the updated meeting record
+    """
+    update_meeting_url = f"{BASE_URL}/meetings/{meeting_platform}/{meeting_id}"
+    
+    # Build data payload with only provided fields
+    data = {}
+    if name is not None:
+        data["name"] = name
+    if participants is not None:
+        data["participants"] = participants
+    if languages is not None:
+        data["languages"] = languages
+    if notes is not None:
+        data["notes"] = notes
+    
+    update_payload = {"data": data}
+    
+    try:
+        response = requests.patch(update_meeting_url, headers=HEADERS, json=update_payload, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+
+@mcp.tool()
+def delete_meeting(meeting_id: str, meeting_platform: str = "google_meet") -> Dict[str, Any]:
+    """
+    Permanently delete a meeting and all its associated transcripts.
+    
+    Args:
+        meeting_id: The unique identifier of the meeting
+        meeting_platform: The meeting platform (e.g., 'google_meet', 'zoom'). Default is 'google_meet'.
+    
+    Returns:
+        JSON with confirmation message
+    
+    Warning: This action cannot be undone.
+    """
+    delete_meeting_url = f"{BASE_URL}/meetings/{meeting_platform}/{meeting_id}"
+    
+    try:
+        response = requests.delete(delete_meeting_url, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as http_err:
+        return {"error": "HTTP error occurred", "details": str(http_err), "status_code": getattr(http_err.response, 'status_code', None)}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": "Request failed", "details": str(req_err)}
+    except Exception as e:
+        return {"error": "An unexpected error occurred", "details": str(e)}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")


### PR DESCRIPTION
This PR adds a new folder `vexa-mcp/` containing:
- `vexa-mcp.py`: File with MCP integration.
- `README.md`: Steps to run MCP server locally.
