### PR TITLE
feat: Add 'deleted' query param to GET /meetings to filter stale candidates

### DIFF
--- a/services/api-gateway/main.py
+++ b/services/api-gateway/main.py
@@ -1,5 +1,5 @@
 import uvicorn
-from fastapi import FastAPI, Request, Response, HTTPException, status, Depends, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, Response, HTTPException, status, Query, Depends, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.security import APIKeyHeader
@@ -287,7 +287,13 @@ async def get_bots_status_proxy(request: Request):
         description="Returns a list of all meetings initiated by the user associated with the API key.",
         response_model=MeetingListResponse, 
         dependencies=[Depends(api_key_scheme)])
-async def get_meetings_proxy(request: Request):
+async def get_meetings_proxy(
+        request: Request,
+        deleted: Optional[bool] = Query(
+            None, 
+            description="Filter by deletion status. Set to false to return only active (non-deleted) meetings."
+        )
+    ):
     """Forward request to Transcription Collector to get meetings."""
     url = f"{TRANSCRIPTION_COLLECTOR_URL}/meetings"
     return await forward_request(app.state.http_client, "GET", url, request)

--- a/services/transcription-collector/api/endpoints.py
+++ b/services/transcription-collector/api/endpoints.py
@@ -199,10 +199,16 @@ async def health_check(request: Request, db: AsyncSession = Depends(get_db)):
             dependencies=[Depends(get_current_user)])
 async def get_meetings(
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    deleted: Optional[bool] = Query(None, description="Filter by deleted status")
 ):
     """Returns a list of all meetings initiated by the authenticated user."""
     stmt = select(Meeting).where(Meeting.user_id == current_user.id).order_by(Meeting.created_at.desc())
+    if deleted is True:
+        stmt = stmt.where(Meeting.status == 'deleted')
+    elif deleted is False:
+        stmt = stmt.where(Meeting.status != 'deleted')
+
     result = await db.execute(stmt)
     meetings = result.scalars().all()
     return MeetingListResponse(meetings=[MeetingResponse.from_orm(m) for m in meetings])


### PR DESCRIPTION
## Description
This PR addresses Issue #79 by adding a `deleted` query parameter to the `GET /meetings` endpoint. This allows clients (and cleanup scripts) to filter meetings by their status, significantly reducing payload size when searching for stale or active meetings.

## Changes
- **API Gateway (`main.py`):** Updated the `get_meetings` proxy endpoint to accept the `deleted` query parameter for OpenAPI documentation and validation.
- **Transcription Collector (`routers/meetings.py`):** Implemented the filtering logic in the SQLAlchemy query to handle `deleted=true` (show only deleted) and `deleted=false` (show only active).

## Related Issue
Closes #79

## Motivation and Context
Currently, `GET /meetings` returns the entire history of meetings. As the dataset grows, this makes it inefficient to identify stale meetings for cleanup or to simply fetch the list of active meetings for the UI. This change allows for targeted queries, reducing processing time and bandwidth.

## How Has This Been Tested?
I performed manual testing using `curl` and postman. I also perform direct database manipulation to verify the filter logic.

**Test Scenarios:**
1. **Setup:** Manually updated database records to set one meeting to `status='deleted'` and another to `status='completed'`.
2. **Test 1 (Default):** `GET /meetings` -> Returns ALL meetings (backward compatibility preserved).
![no-query-parms](https://github.com/user-attachments/assets/4fbf3e45-5c77-40ff-8d58-b595c16edb15)

3. **Test 2 (Active Only):** `GET /meetings?deleted=false` -> Returns only the meeting with `status='completed'`.
![deleted-false](https://github.com/user-attachments/assets/d7d4dba7-3334-49f8-a733-89b33bcf135e)

4. **Test 3 (Deleted Only):** `GET /meetings?deleted=true` -> Returns only the meeting with `status='deleted'`.
![deleted-true](https://github.com/user-attachments/assets/4256990b-f80e-4d6d-ae64-da4739da2ffa)
**Note on JSON Response Status:**
In the screenshot for `deleted=true`, the returned meeting (ID 1) displays `"status": "completed"` in the JSON body, despite the database record correctly having `status='deleted'`. 
This is due to existing serialization logic in the response model (Pydantic) which defaults to 'completed' when the bot container is null/not running. I confirmed via SQL that the database status is indeed `deleted`, and the API correctly filtered out all non-deleted items.
![no-its-deleted](https://github.com/user-attachments/assets/ec00e8c0-c719-4ee5-ba3c-51516501aeb1)


## Screenshots / Logs:
*Verified filtering via terminal:*
![finally](https://github.com/user-attachments/assets/f2d80b90-edb4-4ec1-afc4-27f98a8d4c2d)
