### PR TITLE
feat(docker): add SKIP_TRANSCRIPTION_CHECK to bypass startup connectivity check 

### DIFF
--- a/docker/lite/entrypoint.sh
+++ b/docker/lite/entrypoint.sh
@@ -303,12 +303,32 @@ echo ""
 # -----------------------------------------------------------------------------
 
 echo "Verifying transcription service..."
-TRANSCRIBER_URL="${TRANSCRIBER_URL:-${REMOTE_TRANSCRIBER_URL:-}}"
-if [ -z "$TRANSCRIBER_URL" ]; then
-    echo "  ❌ ERROR: TRANSCRIBER_URL (or REMOTE_TRANSCRIBER_URL) is not set"
-    echo "     This is required for transcription functionality"
-    exit 1
-fi
+if [ "${SKIP_TRANSCRIPTION_CHECK:-false}" = "true" ]; then
+    echo "  ⚠️ Skipping transcription service verification (SKIP_TRANSCRIPTION_CHECK=true)"
+    echo "     Ensuring minimal variables are set..."
+    
+    # Still check for URL presence as it's critical, but don't ping it
+    TRANSCRIBER_URL="${TRANSCRIBER_URL:-${REMOTE_TRANSCRIBER_URL:-}}"
+    if [ -z "$TRANSCRIBER_URL" ]; then
+        echo "  ❌ ERROR: TRANSCRIBER_URL (or REMOTE_TRANSCRIBER_URL) is not set"
+        exit 1
+    fi
+    
+    TRANSCRIBER_API_KEY="${TRANSCRIBER_API_KEY:-${REMOTE_TRANSCRIBER_API_KEY:-}}"
+    if [ -z "$TRANSCRIBER_API_KEY" ]; then
+         echo "  ❌ ERROR: TRANSCRIBER_API_KEY (or REMOTE_TRANSCRIBER_API_KEY) is not set"
+         exit 1
+    fi
+    
+    echo "  ✅ Transcription configuration presence verified (connectivity check skipped)"
+else
+    # Standard verification logic
+    TRANSCRIBER_URL="${TRANSCRIBER_URL:-${REMOTE_TRANSCRIBER_URL:-}}"
+    if [ -z "$TRANSCRIBER_URL" ]; then
+        echo "  ❌ ERROR: TRANSCRIBER_URL (or REMOTE_TRANSCRIBER_URL) is not set"
+        echo "     This is required for transcription functionality"
+        exit 1
+    fi
 
 TRANSCRIBER_API_KEY="${TRANSCRIBER_API_KEY:-${REMOTE_TRANSCRIBER_API_KEY:-}}"
 if [ -z "$TRANSCRIBER_API_KEY" ]; then


### PR DESCRIPTION
## Problem
When using external transcription services like OVH, the startup health check fails because these endpoints often return 404 on the root URL, preventing the container from starting even if the service is operational.

## Solution
This PR adds a `SKIP_TRANSCRIPTION_CHECK` environment variable to docker/lite/entrypoint.sh
- If set to `true`, it bypasses the strict `curl` connectivity check.
- It still verifies that `TRANSCRIBER_URL` and `TRANSCRIBER_API_KEY` are defined.
- Default behavior remains unchanged.

## How to test
Run the container with `-e SKIP_TRANSCRIPTION_CHECK=true`. The container should start successfully without "Cannot reach transcription service" error.