### PR TITLE
Fix DATABASE_URL parsing when port is omitted

### DIFF
--- a/docker/lite/entrypoint.sh
+++ b/docker/lite/entrypoint.sh
@@ -101,8 +101,12 @@ else
     # Parse host:port/dbname
     DB_HOSTPORT="${DB_HOSTPORTDB%%/*}"
     export DB_NAME="${DB_HOSTPORTDB#*/}"
-    export DB_HOST="${DB_HOSTPORT%%:*}"
-    export DB_PORT="${DB_HOSTPORT#*:}"
+    if [[ "$DB_HOSTPORT" == *":"* ]]; then
+        export DB_HOST="${DB_HOSTPORT%%:*}"
+        export DB_PORT="${DB_HOSTPORT#*:}"
+    else
+        export DB_HOST="$DB_HOSTPORT"
+    fi
     
     # Extract sslmode from DATABASE_URL if present
     if [[ "$DATABASE_URL" == *"sslmode="* ]]; then


### PR DESCRIPTION
## Summary
- keep DB_PORT default when DATABASE_URL omits an explicit port
- avoid misassigning DB_PORT to the host value

## Failure mode
- when DATABASE_URL lacked a port (e.g. "postgresql://user:pass@host/db"), parsing set DB_PORT to the full host string, making the app attempt to connect to host:host instead of host:5432

## Testing
- not run (entrypoint shell change)