### PR TITLE
fix: multi-arch Docker builds for vexa-lite (amd64+arm64)

### DIFF
--- a/docker/lite/Makefile
+++ b/docker/lite/Makefile
@@ -1,9 +1,15 @@
-.PHONY: build push build-and-push set-latest set-dev help
+.PHONY: build push build-and-push set-latest set-dev setup-builder help
 
 # DockerHub configuration
 DOCKERHUB_USER ?= vexaai
 IMAGE_NAME ?= vexa-lite
 TAG ?= dev
+
+# Multi-arch platforms
+PLATFORMS ?= linux/amd64,linux/arm64
+
+# Buildx builder name
+BUILDER_NAME ?= vexa-multiarch
 
 # Paths (Makefile is in docker/lite/, Dockerfile is in same dir, context is repo root)
 DOCKERFILE := $(shell pwd)/Dockerfile.lite
@@ -17,66 +23,83 @@ LAST_TAG_FILE := .last-tag
 
 # Function to set a tag on DockerHub using buildx imagetools
 define set_tag
-	@echo "📋 Setting '$(1)' tag to point to $(2)..."
+	@echo "Setting '$(1)' tag to point to $(2)..."
 	docker buildx imagetools create -t $(DOCKERHUB_USER)/$(IMAGE_NAME):$(1) $(DOCKERHUB_USER)/$(IMAGE_NAME):$(2)
-	@echo "✅ '$(1)' tag updated to $(2)"
+	@echo "'$(1)' tag updated to $(2)"
 endef
 
 help:
-	@echo "Vexa Lite Docker Build & Push"
+	@echo "Vexa Lite Docker Build & Push (Multi-Arch)"
 	@echo ""
 	@echo "Usage:"
-	@echo "  make build              - Build locally (tagged as dev)"
-	@echo "  make push               - Push unique timestamp tag and update 'dev' tag"
-	@echo "  make build-and-push     - Build and push in one command"
+	@echo "  make build              - Build locally for current platform (tagged as dev)"
+	@echo "  make push               - Build multi-arch (amd64+arm64), push with timestamp tag, update 'dev' tag"
+	@echo "  make build-and-push     - Alias for push"
 	@echo "  make set-latest [TAG=]  - Set 'latest' tag to specified tag (or last pushed)"
 	@echo "  make set-dev [TAG=]     - Set 'dev' tag to specified tag (or last pushed)"
+	@echo "  make setup-builder      - Create/bootstrap the multi-arch buildx builder"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make build"
 	@echo "  make push"
 	@echo "  make set-latest TAG=240115-1430"
 	@echo "  make set-latest"
+	@echo ""
+	@echo "Configuration:"
+	@echo "  PLATFORMS=$(PLATFORMS)"
+
+setup-builder:
+	@if ! docker buildx inspect $(BUILDER_NAME) >/dev/null 2>&1; then \
+		echo "Creating buildx builder '$(BUILDER_NAME)'..."; \
+		docker buildx create --name $(BUILDER_NAME) --driver docker-container --bootstrap; \
+	else \
+		echo "Builder '$(BUILDER_NAME)' already exists"; \
+	fi
 
 build:
-	@echo "📦 Building $(LOCAL_TAG)..."
+	@echo "Building $(LOCAL_TAG) for current platform..."
 	docker build -f $(DOCKERFILE) -t $(LOCAL_TAG) $(CONTEXT)
-	@echo "✅ Build complete: $(LOCAL_TAG)"
+	@echo "Build complete: $(LOCAL_TAG)"
 
-push: build
-	@echo "🚀 Pushing $(UNIQUE_DOCKERHUB_TAG)..."
-	docker tag $(LOCAL_TAG) $(UNIQUE_DOCKERHUB_TAG)
-	docker push $(UNIQUE_DOCKERHUB_TAG)
+push: setup-builder
+	@echo "Building multi-arch $(UNIQUE_DOCKERHUB_TAG) for $(PLATFORMS)..."
+	docker buildx build \
+		--builder $(BUILDER_NAME) \
+		--platform $(PLATFORMS) \
+		-f $(DOCKERFILE) \
+		-t $(UNIQUE_DOCKERHUB_TAG) \
+		--push \
+		$(CONTEXT)
 	@echo "$(UNIQUE_TAG)" > $(LAST_TAG_FILE)
-	@echo "✅ Push complete: $(UNIQUE_DOCKERHUB_TAG)"
+	@echo "Push complete: $(UNIQUE_DOCKERHUB_TAG)"
 	$(call set_tag,dev,$(UNIQUE_TAG))
 
+build-and-push: push
 
 set-latest:
 	@if [ -z "$(TAG)" ]; then \
 		if [ -f $(LAST_TAG_FILE) ]; then \
 			TAG_TO_USE=$$(cat $(LAST_TAG_FILE)); \
 		else \
-			echo "❌ Error: No TAG specified and $(LAST_TAG_FILE) not found"; exit 1; \
+			echo "Error: No TAG specified and $(LAST_TAG_FILE) not found"; exit 1; \
 		fi; \
 	else \
 		TAG_TO_USE=$(TAG); \
 	fi; \
-	echo "📋 Setting 'latest' tag to point to $$TAG_TO_USE..."; \
+	echo "Setting 'latest' tag to point to $$TAG_TO_USE..."; \
 	docker buildx imagetools create -t $(DOCKERHUB_USER)/$(IMAGE_NAME):latest $(DOCKERHUB_USER)/$(IMAGE_NAME):$$TAG_TO_USE; \
-	echo "✅ 'latest' tag updated to $$TAG_TO_USE"
+	echo "'latest' tag updated to $$TAG_TO_USE"
 
 set-dev:
 	@if [ -z "$(TAG)" ]; then \
 		if [ -f $(LAST_TAG_FILE) ]; then \
 			TAG_TO_USE=$$(cat $(LAST_TAG_FILE)); \
 		else \
-			echo "❌ Error: No TAG specified and $(LAST_TAG_FILE) not found"; exit 1; \
+			echo "Error: No TAG specified and $(LAST_TAG_FILE) not found"; exit 1; \
 		fi; \
 	else \
 		TAG_TO_USE=$(TAG); \
 	fi; \
-	echo "📋 Setting 'dev' tag to point to $$TAG_TO_USE..."; \
+	echo "Setting 'dev' tag to point to $$TAG_TO_USE..."; \
 	docker buildx imagetools create -t $(DOCKERHUB_USER)/$(IMAGE_NAME):dev $(DOCKERHUB_USER)/$(IMAGE_NAME):$$TAG_TO_USE; \
-	echo "✅ 'dev' tag updated to $$TAG_TO_USE"
-
+	echo "'dev' tag updated to $$TAG_TO_USE"


### PR DESCRIPTION
## Summary
- Fixes the vexa-lite Makefile to produce multi-arch Docker images (linux/amd64 + linux/arm64) using `docker buildx`
- The `push` target now builds for both platforms and pushes a manifest list, so amd64 hosts can pull `vexaai/vexa-lite`
- Local `build` target remains single-platform for fast dev iteration
- Added `setup-builder` target to auto-create a buildx builder on demand

## Test plan
- [x] Built multi-arch image `vexaai/vexa-lite:260217-1612`
- [x] Verified manifest contains both `linux/amd64` and `linux/arm64` entries
- [x] Pulled and ran the arm64 variant locally
- [x] Verified all services start (API gateway, admin API, bot manager, transcription collector, WhisperLive, MCP, TTS)
- [x] Tested bot join on Google Meet — speak, screen image, transcription all working
- [x] Tested bot join on Teams — speak working
- [x] Updated `latest` tag on DockerHub to point to the new multi-arch build

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)