### PR TITLE
Zoom web fix transcription overlap

### DIFF
--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -16,6 +16,7 @@ import { ScreenContentService, getVirtualCameraInitScript, getVideoBlockInitScri
 import { ScreenShareService } from "./services/screen-share"; // kept for Teams; unused for Google Meet camera-feed approach
 import { createClient, RedisClientType } from 'redis';
 import { Page, Browser } from 'playwright-core';
+import { execSync } from 'child_process';
 // HTTP imports removed - using unified callback service instead
 
 // Module-level variables to store current configuration
@@ -41,6 +42,7 @@ let browserInstance: Browser | null = null;
 
 // --- Recording service reference (set by platform handlers) ---
 let activeRecordingService: RecordingService | null = null;
+let botPaSinkModuleId: string | null = null; // PulseAudio module ID for per-bot sink cleanup
 let currentBotConfig: BotConfig | null = null;
 export function setActiveRecordingService(svc: RecordingService | null): void {
   activeRecordingService = svc;
@@ -587,7 +589,18 @@ async function performGracefulLeave(
     log(`[Graceful Leave] Voice agent cleanup error: ${vaCleanupErr.message}`);
   }
 
-  // Upload recording if available
+  // Clean up per-bot PulseAudio sink if one was created
+  if (botPaSinkModuleId) {
+    try {
+      execSync(`pactl unload-module ${botPaSinkModuleId}`, { stdio: 'ignore' });
+      log(`[Graceful Leave] Unloaded PulseAudio sink module ${botPaSinkModuleId}`);
+    } catch (e: any) {
+      log(`[Graceful Leave] Warning: Could not unload PulseAudio sink module: ${e.message}`);
+    }
+    botPaSinkModuleId = null;
+  }
+
+  // Upload audio recording if available
   if (activeRecordingService && currentBotConfig?.recordingUploadUrl && currentBotConfig?.token) {
     try {
       log("[Graceful Leave] Uploading recording to bot-manager...");
@@ -1012,6 +1025,23 @@ export async function runBot(botConfig: BotConfig): Promise<void> {// Store botC
     log("Redis URL or meeting_id missing, skipping Redis setup.");
   }
   // -------------------------------------------------
+
+  // For Zoom Web: create a per-bot PulseAudio null sink so concurrent bots don't
+  // cross-contaminate each other's audio via the shared zoom_sink.monitor.
+  if (botConfig.platform === 'zoom' && process.env.ZOOM_WEB === 'true') {
+    const sinkName = `bot_sink_${botConfig.meeting_id}`;
+    try {
+      const moduleId = execSync(
+        `pactl load-module module-null-sink sink_name=${sinkName} sink_properties=device.description="BotSink_${botConfig.meeting_id}"`,
+        { stdio: ['ignore', 'pipe', 'ignore'] }
+      ).toString().trim();
+      botPaSinkModuleId = moduleId;
+      process.env.PULSE_SINK = sinkName;
+      log(`[Bot] Per-bot PulseAudio sink created: ${sinkName} (module ${moduleId})`);
+    } catch (e: any) {
+      log(`[Bot] Warning: Could not create per-bot PulseAudio sink: ${e.message}. Falling back to shared zoom_sink.`);
+    }
+  }
 
   // Simple browser setup like simple-bot.js
   if (botConfig.platform === "teams") {

--- a/services/vexa-bot/core/src/platforms/zoom/strategies/recording.ts
+++ b/services/vexa-bot/core/src/platforms/zoom/strategies/recording.ts
@@ -206,7 +206,7 @@ async function startPulseAudioCapture(whisperLive: WhisperLiveService | null): P
       '--format=s16le',
       '--rate=16000',
       '--channels=1',
-      '--device=zoom_sink.monitor'
+      `--device=${process.env.PULSE_SINK || 'zoom_sink'}.monitor`
     ]);
 
     if (!parecordProcess || !parecordProcess.stdout) {

--- a/services/vexa-bot/core/src/platforms/zoom/web/recording.ts
+++ b/services/vexa-bot/core/src/platforms/zoom/web/recording.ts
@@ -219,7 +219,7 @@ async function startPulseAudioCapture(): Promise<void> {
       '--format=s16le',
       '--rate=16000',
       '--channels=1',
-      '--device=zoom_sink.monitor',
+      `--device=${process.env.PULSE_SINK || 'zoom_sink'}.monitor`,
     ]);
 
     if (!parecordProcess?.stdout) {


### PR DESCRIPTION
I ran 2 zoom web meetings at once and noticed that transcriptions from both meetings were ending up in the logs for both meetings. This should fix that issue. I just tested with 2 zoom meetings and transcriptions were separate.