### PR TITLE
fix: bot leaves active meeting when video track arrives

### DIFF
--- a/services/vexa-bot/core/src/services/screen-content.ts
+++ b/services/vexa-bot/core/src/services/screen-content.ts
@@ -1274,23 +1274,16 @@ export function getVideoBlockInitScript(): string {
         window.RTCPeerConnection = function(...args) {
           const pc = new OrigRTC(...args);
 
-          // Block incoming video: disable tracks AND stop transceivers
+          // Block incoming video: disable tracks only.
+          // Do NOT call track.stop() — it permanently destroys the track and causes
+          // Google Meet to detect a broken WebRTC state, clearing the participant DOM.
+          // Do NOT set transceiver.direction = 'inactive' — it triggers SDP renegotiation,
+          // which also causes Google Meet to rebuild the DOM and wipe participant elements.
+          // Both of these side effects cause left_alone_timeout false positives.
           pc.addEventListener('track', (event) => {
             if (event.track && event.track.kind === 'video') {
               event.track.enabled = false;
-              event.track.stop();
-              console.log('[Vexa] Incoming video track stopped (id=' + event.track.id + ')');
-
-              // Also set the transceiver to recvonly->inactive to tell the
-              // remote peer we don't want video at all
-              if (event.transceiver) {
-                try {
-                  event.transceiver.direction = 'inactive';
-                  console.log('[Vexa] Video transceiver set to inactive (mid=' + event.transceiver.mid + ')');
-                } catch (e) {
-                  console.warn('[Vexa] Could not set transceiver direction:', e);
-                }
-              }
+              console.log('[Vexa] Incoming video track disabled (id=' + event.track.id + ')');
             }
           });
 


### PR DESCRIPTION
Closes #189

I ran into this in production: our bot was leaving meetings that were still
active. After digging into the logs, the participant count was dropping to
zero right around the time a new video track arrived, not when people
actually left.

Traced it to the video-blocking code in getVideoBlockInitScript. Two lines:

  event.track.stop()
  event.transceiver.direction = 'inactive'

track.stop() permanently destroys the WebRTC track. Google Meet detects the
broken state and rebuilds the participant DOM, momentarily clearing all
participant elements. The left_alone_timeout fires on that zero count and
the bot walks out of a perfectly active meeting.

The transceiver line makes it worse: setting direction to 'inactive' triggers
SDP renegotiation, which causes Google Meet to do the same DOM rebuild.

The fix is simple: just set track.enabled = false. That stops the bot from
processing incoming video frames without touching WebRTC state. No
renegotiation, no DOM rebuild, participant count stays accurate.

Tested in production. Browser refresh mid-meeting no longer causes the bot
to leave.