### PR TITLE
Fix: unblock Meeting API + Admin API CI suites

### DIFF
--- a/services/admin-api/tests/test_g5_gate.py
+++ b/services/admin-api/tests/test_g5_gate.py
@@ -16,7 +16,10 @@ import os
 import time
 
 import pytest
-import requests
+
+# Live-stack integration test: skip entire module when `requests` isn't
+# installed (CI runs unit tests only; there's no live stack to hit).
+requests = pytest.importorskip("requests")
 
 GATEWAY = os.getenv("GATEWAY_URL", "http://localhost:8056")
 ADMIN_TOKEN = os.getenv("ADMIN_API_TOKEN", "changeme")

--- a/services/meeting-api/tests/test_voice_agent.py
+++ b/services/meeting-api/tests/test_voice_agent.py
@@ -17,11 +17,38 @@ from .conftest import (
 
 
 def _patch_find_active(meeting):
-    return patch(
-        "meeting_api.voice_agent._find_active_meeting",
-        new_callable=AsyncMock,
-        return_value=meeting,
-    )
+    """Patch both meeting-lookup helpers used by voice_agent routes.
+
+    Most routes (/speak, /screen, /avatar, /events) use `_find_active_meeting`,
+    but /chat (GET) uses `_find_meeting_any_status` (voice_agent.py:143).
+    Patching both keeps the test helper uniform across routes.
+    """
+    return _MultiPatch([
+        patch(
+            "meeting_api.voice_agent._find_active_meeting",
+            new_callable=AsyncMock,
+            return_value=meeting,
+        ),
+        patch(
+            "meeting_api.voice_agent._find_meeting_any_status",
+            new_callable=AsyncMock,
+            return_value=meeting,
+        ),
+    ])
+
+
+class _MultiPatch:
+    """Context manager that enters/exits a list of patch objects."""
+
+    def __init__(self, patches):
+        self._patches = patches
+
+    def __enter__(self):
+        return [p.__enter__() for p in self._patches]
+
+    def __exit__(self, exc_type, exc, tb):
+        for p in reversed(self._patches):
+            p.__exit__(exc_type, exc, tb)
 
 
 @pytest.fixture


### PR DESCRIPTION
Two narrow test-hygiene fixes to get CI suites green on main:

**Meeting API** — `test_voice_agent.py::TestChat`

Returned 404 because `_patch_find_active` helper only patched `_find_active_meeting`, but `bot_chat_read` was changed to call `_find_meeting_any_status` in commit bc47b29 (6 Apr). Helper never updated. Extended to patch both paths.

**Admin API** — `test_g5_gate.py` ImportError

Module-load failure: `No module named 'requests'`. Only used by this one live-stack test. Now guarded by `pytest.importorskip("requests")` so the file skips cleanly in unit-test CI.

Both failures predate release 260418-webhooks but were churning red badges on unrelated PRs. Local verification: Meeting API 166 passed, Admin API imports clean.

**Out of scope** (separate groom): api-gateway `test_recording_routes` (28 fails — auth middleware needs mocking) and `test_websocket` (4 fails — mock config drift). Both need deeper intervention than assertion fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)