### PR TITLE
tuning: transcription VAD + upload cap + transcript-rendering lockfile

### DIFF
--- a/packages/transcript-rendering/package-lock.json
+++ b/packages/transcript-rendering/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vexaai/transcript-rendering",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vexaai/transcript-rendering",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.0.0",

--- a/services/transcription-service/docker-compose.yml
+++ b/services/transcription-service/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - MODEL_SIZE=${MODEL_SIZE:-large-v3-turbo}
       - DEVICE=cuda
       - COMPUTE_TYPE=${COMPUTE_TYPE:-int8}
+      - VAD_MIN_SILENCE_DURATION_MS=80
     volumes:
       - ./models:/app/models
     deploy:
@@ -52,6 +53,7 @@ services:
       - MODEL_SIZE=${MODEL_SIZE:-large-v3-turbo}
       - DEVICE=cuda
       - COMPUTE_TYPE=${COMPUTE_TYPE:-int8}
+      - VAD_MIN_SILENCE_DURATION_MS=80
     volumes:
       - ./models:/app/models
     deploy:

--- a/services/transcription-service/nginx.conf
+++ b/services/transcription-service/nginx.conf
@@ -36,7 +36,7 @@ http {
         proxy_send_timeout 300s;
         
         # Increase body size for audio files (50MB max)
-        client_max_body_size 50M;
+        client_max_body_size 500M;
         client_body_timeout 300s;
         
         # Main API endpoint


### PR DESCRIPTION
Two small tuning patches that came out of reviewing the local working tree after v0.10.1 shipped. Independent of the security release.

## Commits

1. **`chore(transcript-rendering): sync package-lock.json to 0.4.0`** — the lockfile was left at 0.3.0 while \`package.json\` already read 0.4.0 on HEAD. Pure catch-up.
2. **\`perf(transcription-service): lower VAD silence threshold + raise upload cap\`** —
   - \`VAD_MIN_SILENCE_DURATION_MS=80\` on both worker pools (down from ~160ms default). More responsive chunking; small extra CTranslate2 load, fine on the GPU tier.
   - nginx \`client_max_body_size 50M → 500M\`. Unblocks single-file uploads longer than ~10–15 min.

## Notes

- Port stays at 8083 (local copies that showed 8085 were dev-only).
- No API surface changes, no schema changes, no cross-service behavior shifts that could break existing deployments beyond the two deliberate tuning knobs above.
- Targeting \`dev\` for normal review flow. Once merged, we can cut v0.10.2 for the combined patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)