### PR TITLE
fix: set cameraEnabled in bot config when voice_agent_enabled is true

### DIFF
--- a/services/meeting-api/meeting_api/meetings.py
+++ b/services/meeting-api/meeting_api/meetings.py
@@ -992,6 +992,7 @@ async def request_bot(
         bot_config["recordingEnabled"] = bool(req.recording_enabled)
     if req.voice_agent_enabled is not None:
         bot_config["voiceAgentEnabled"] = bool(req.voice_agent_enabled)
+        bot_config["cameraEnabled"] = bool(req.voice_agent_enabled)
     if req.default_avatar_url:
         bot_config["defaultAvatarUrl"] = req.default_avatar_url
     if os.getenv("SHOW_AVATAR", "true").lower() == "false":


### PR DESCRIPTION
## Summary
- When `voice_agent_enabled=true` is passed to `POST /bots`, `cameraEnabled` is now also set to `true` in the bot config
- This ensures the virtual camera pipeline initializes, enabling avatar and screen share features

## Problem
The bot process checks `botConfig.cameraEnabled` (not `voiceAgentEnabled`) to decide whether to initialize the virtual camera. Without this flag, the bot starts in transcription-only mode and all visual features silently fail — even though the API returns `202 Accepted` for avatar/screen commands.

Bot log before fix:
```
[BotCore] [Bot] Skipping virtual camera init (camera not enabled)
[BotCore] [BrowserConsole] [Vexa] Video block init script START (transcription-only mode)
```

## Change
One line in `services/meeting-api/meeting_api/meetings.py`:
```python
if req.voice_agent_enabled is not None:
    bot_config["voiceAgentEnabled"] = bool(req.voice_agent_enabled)
    bot_config["cameraEnabled"] = bool(req.voice_agent_enabled)  # <-- added
```

Fixes #238