### PR TITLE
fix(vexa-bot): browser-session entrypoint exits when node exits (#258)

### DIFF
--- a/services/vexa-bot/core/entrypoint.sh
+++ b/services/vexa-bot/core/entrypoint.sh
@@ -93,13 +93,22 @@ FBAPPS
   echo "[entrypoint] Starting SSH server on port 22"
   /usr/sbin/sshd
 
-  # Run node and keep container alive even if node crashes
+  # Run node, then exit so K8s sees the pod terminate.
+  # Optional post-exit VNC debug window: set
+  # VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS to a positive integer to
+  # keep the container alive that long after node exits. Default 0 =
+  # exit immediately so that "stop" from the dashboard frees the slot.
   echo "[entrypoint] Starting browser session node process..."
   node dist/docker.js
   EXIT_CODE=$?
-  echo "[entrypoint] node dist/docker.js exited with code $EXIT_CODE — keeping container alive for VNC access"
-  # Keep alive so VNC + websockify remain accessible
-  wait
+  KEEPALIVE="${VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS:-0}"
+  if [[ "$KEEPALIVE" =~ ^[0-9]+$ ]] && [ "$KEEPALIVE" -gt 0 ]; then
+    echo "[entrypoint] node dist/docker.js exited with code $EXIT_CODE — keeping container alive ${KEEPALIVE}s for VNC access"
+    sleep "$KEEPALIVE"
+  else
+    echo "[entrypoint] node dist/docker.js exited with code $EXIT_CODE — exiting (set VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS>0 to debug)"
+  fi
+  exit "$EXIT_CODE"
 else
   # Meeting mode — start VNC for browser view on dashboard
   echo "[entrypoint] Meeting mode — starting VNC for browser view"


### PR DESCRIPTION
## Summary

- Fixes #258: `wait` in the browser-session entrypoint blocks forever on `x11vnc -forever` and `websockify`, so the container never exits after `node dist/docker.js` returns. K8s sees the pod as Running indefinitely and "stop" from the dashboard appears to do nothing.
- New env var `VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS` (default `0`) controls a bounded post-exit debug window. Default behavior: container exits as soon as `node` does.
- Preserves the original exit code so K8s sees `0` for clean exits and `≠0` for crashes.

## Diff

`services/vexa-bot/core/entrypoint.sh` (browser-session branch only — meeting-mode branch unchanged):

```bash
node dist/docker.js
EXIT_CODE=$?
KEEPALIVE="${VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS:-0}"
if [[ "$KEEPALIVE" =~ ^[0-9]+$ ]] && [ "$KEEPALIVE" -gt 0 ]; then
  echo "[entrypoint] node dist/docker.js exited with code $EXIT_CODE — keeping container alive ${KEEPALIVE}s for VNC access"
  sleep "$KEEPALIVE"
else
  echo "[entrypoint] node dist/docker.js exited with code $EXIT_CODE — exiting (set VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS>0 to debug)"
fi
exit "$EXIT_CODE"
```

## Implementation note

The issue body sketched `timeout $N wait` — that doesn't actually work because `wait` is a shell builtin and `timeout` only runs binaries. `sleep $N` achieves the equivalent bounded keep-alive: the parent shell sleeps, then exits, and the kernel cleans up the still-running `x11vnc` / `websockify` / `sshd` children.

Non-numeric values fall through to the default branch (`[[ ... =~ ^[0-9]+$ ]]` guard) so a typo can't crash the script.

## How to opt back into the post-exit debug window

In `services/runtime-api/runtime_api/profiles.py` profile YAML:

```yaml
browser-session:
  image: ...
  env:
    VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS: "3600"
```

`profiles.py` already passes the `env` block straight into the container — no code change needed there.

## Test plan

- [x] `bash -n services/vexa-bot/core/entrypoint.sh` (syntax)
- [x] Smoke-test the three branches (default-0, valid N, non-numeric) — verified the if/else picks the right branch and `EXIT_CODE` is preserved
- [ ] Build the runtime image and exercise a real browser session: confirm pod terminates within seconds of bot stop on staging
- [ ] Set `VEXA_BROWSER_SESSION_VNC_KEEPALIVE_SECONDS=60` in a profile, exercise stop, confirm container stays for ~60s then exits with the original exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)