### PR TITLE
fix(msteams): dismiss 'Continue without audio or video' modal before Join (closes #226)

### DIFF
--- a/services/vexa-bot/core/src/platforms/msteams/join.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/join.ts
@@ -430,6 +430,25 @@ export async function joinMicrosoftTeams(page: Page, botConfig: BotConfig): Prom
     log(`ℹ️ Could not enforce Computer audio: ${error.message}. Continuing...`);
   }
 
+  // Dismiss any blocking pre-join confirmation modal
+  // ("Are you sure you don't want audio or video?" / "Continue without audio
+  // or video?") that Teams shows on light-meetings/launch when the bot
+  // declines mic+camera. Underlying Join now button stays in the DOM, so
+  // earlier readiness checks pass — but the actual click is intercepted by
+  // the modal overlay. Repros 50%+ at scale per upstream issue #226.
+  try {
+    const modalContinue = page
+      .locator(
+        'button:has-text("Continue without audio or video"), button:has-text("Continue")',
+      )
+      .first();
+    if (await modalContinue.isVisible().catch(() => false)) {
+      log("ℹ️ Dismissing pre-join 'Continue without audio or video' modal");
+      await modalContinue.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(500);
+    }
+  } catch {}
+
   log("Step 6: Clicking 'Join now' to enter the meeting...");
   try {
     // Use the more specific "Join now" selector first to avoid ambiguity

--- a/services/vexa-bot/core/src/platforms/msteams/join.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/join.ts
@@ -435,17 +435,25 @@ export async function joinMicrosoftTeams(page: Page, botConfig: BotConfig): Prom
   // or video?") that Teams shows on light-meetings/launch when the bot
   // declines mic+camera. Underlying Join now button stays in the DOM, so
   // earlier readiness checks pass — but the actual click is intercepted by
-  // the modal overlay. Repros 50%+ at scale per upstream issue #226.
+  // the modal overlay. The modal is rendered inside the nested
+  // `light-meetings/launch` iframe, so we iterate every frame on the page
+  // (including the top frame) to find and dismiss it. Upstream issue #226.
   try {
-    const modalContinue = page
-      .locator(
-        'button:has-text("Continue without audio or video"), button:has-text("Continue")',
-      )
-      .first();
-    if (await modalContinue.isVisible().catch(() => false)) {
-      log("ℹ️ Dismissing pre-join 'Continue without audio or video' modal");
-      await modalContinue.click({ force: true }).catch(() => {});
-      await page.waitForTimeout(500);
+    const frames = [page.mainFrame(), ...page.frames()];
+    for (const frame of frames) {
+      try {
+        const modalContinue = frame
+          .locator(
+            'button:has-text("Continue without audio or video"), button:has-text("Continue")',
+          )
+          .first();
+        if (await modalContinue.isVisible({ timeout: 500 }).catch(() => false)) {
+          log("ℹ️ Dismissing pre-join 'Continue without audio or video' modal");
+          await modalContinue.click({ force: true }).catch(() => {});
+          await page.waitForTimeout(500);
+          break;
+        }
+      } catch {}
     }
   } catch {}
 


### PR DESCRIPTION
## Summary
- Closes #226. Reproduced verbatim in a fresh self-hosted compose deploy of `v0.10.3` against `teams.microsoft.com/meet/<numeric>?p=<passcode>` URLs.
- Bot was timing out at `awaiting_admission` for 15 min on every attempt because the underlying `Join now` button stays in the DOM (so `waitForTeamsPreJoinReadiness` returns "ready") but the actual click is intercepted by the post-decline confirmation modal in the nested `light-meetings/launch` iframe.
- Patch dismisses the modal in the joiner's modal-handling step before `Step 6: Clicking 'Join now'`. Probe is gated on `isVisible({ timeout: 500 })` and falls through silently when no modal is present, so flows that don't hit this overlay are unaffected.
- Iterates `page.frames()` because the modal renders inside `light-meetings/launch`, not the top frame — first patch attempt missed it for that reason.

## Repro before the patch
```
[BotCore] Step 6: Clicking 'Join now' to enter the meeting...
[BotCore] ⚠️ Join button not found — bot may not be able to enter the meeting
[BotCore] Found Teams waiting room indicator: lobby text or Join now button visible - Bot is still in waiting room
[BotCore] Bot is in Teams waiting room. Waiting for 900000ms for admission...
[BotCore] Still in Teams waiting room... 2s elapsed
... (loops to 15-min timeout)
```

## After
```
[BotCore] Step 6: Clicking 'Join now' to enter the meeting...
[BotCore] ✅ Clicked 'Join now' button
[BotCore] 🔥 UNIFIED CALLBACK: AWAITING_ADMISSION - reason: none
```
Bot reaches the host's lobby and is admittable. Verified end-to-end: bot joined → admitted by host → meeting completed → audio recorded to MinIO → readable from `/recordings/{id}/media/{media_id}/raw`.

## Notes
- Selector covers both the long-form "Continue without audio or video" button and the short "Continue" fallback, in case Teams shortens the label in a UI rev.
- The probe runs once per join attempt right before the existing Step 6, so it composes cleanly with the upstream Teams reliability epic in #252 — this fix can land without blocking the larger reliability cycle.