### PR TITLE
fix: use distinct scheme_name on APIKeyHeader so Swagger shows correct curl headers (#80)

### DIFF
--- a/services/admin-api/app/main.py
+++ b/services/admin-api/app/main.py
@@ -63,8 +63,8 @@ class PaginatedMeetingUserStatResponse(BaseModel):
     items: List[MeetingUserStat]
 
 # Security - Reuse logic from meeting-api/auth.py for admin token verification
-API_KEY_HEADER = APIKeyHeader(name="X-Admin-API-Key", auto_error=False) # Use a distinct header
-USER_API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False) # For user-facing endpoints
+API_KEY_HEADER = APIKeyHeader(name="X-Admin-API-Key", scheme_name="AdminApiKey", auto_error=False)
+USER_API_KEY_HEADER = APIKeyHeader(name="X-API-Key", scheme_name="UserApiKey", auto_error=False)
 ADMIN_API_TOKEN = os.getenv("ADMIN_API_TOKEN") # Read from environment
 ANALYTICS_API_TOKEN = os.getenv("ANALYTICS_API_TOKEN") # Read-only analytics token
 

--- a/services/admin-api/tests/test_openapi_schema.py
+++ b/services/admin-api/tests/test_openapi_schema.py
@@ -1,0 +1,33 @@
+"""Regression test for issue #80 — OpenAPI security scheme names must be distinct.
+
+FastAPI collapses APIKeyHeader instances that share the same scheme_name into one
+OpenAPI security scheme. Without explicit scheme_name values, Swagger UI shows the
+wrong header (X-API-Key) in curl examples for admin endpoints.
+"""
+
+import os
+
+os.environ.setdefault("ADMIN_API_TOKEN", "test-admin-token")
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_NAME", "test")
+os.environ.setdefault("DB_USER", "test")
+os.environ.setdefault("DB_PASSWORD", "test")
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_openapi_security_schemes_are_distinct():
+    """AdminApiKey and UserApiKey must be separate schemes so Swagger shows the right header."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/openapi.json")
+    assert resp.status_code == 200
+    schemes = resp.json()["components"]["securitySchemes"]
+    assert "AdminApiKey" in schemes, "AdminApiKey scheme missing — admin curl examples will show wrong header"
+    assert "UserApiKey" in schemes, "UserApiKey scheme missing — user curl examples will show wrong header"
+    assert schemes["AdminApiKey"]["name"] == "X-Admin-API-Key"
+    assert schemes["UserApiKey"]["name"] == "X-API-Key"


### PR DESCRIPTION
Brief updates:

- Add scheme_name="AdminApiKey" to API_KEY_HEADER (X-Admin-API-Key)
- Add scheme_name="UserApiKey" to USER_API_KEY_HEADER (X-API-Key)
- FastAPI collapses both into one scheme when scheme_name is missing, causing Swagger to show X-API-Key for all routes including admin ones
- Add regression test (test_openapi_schema.py) that validates both schemes exist in /openapi.json with correct header names. It's additional but, it's good way to test it programmatically. 

Manual tests:

Addresses this [comment](https://github.com/Vexa-ai/vexa/issues/80#issuecomment-4382307561).

<img width="833" height="520" alt="image" src="https://github.com/user-attachments/assets/eb6d89b7-99b2-4335-b605-0053f26834ad" />

```
# Request
curl -X 'POST' \
  'http://localhost:8057/admin/users' \
  -H 'accept: application/json' \
  -H 'X-Admin-API-Key: newadmintoken' \
  -H 'Content-Type: application/json' \
  -d '{
  "email": "user@example.com",
  "name": "string",
  "image_url": "string",
  "max_concurrent_bots": 0,
  "data": {
    "additionalProp1": {}
  }
}'
```
```
# Response
{
  "email": "user@example.com",
  "name": "string",
  "image_url": "string",
  "max_concurrent_bots": 0,
  "data": {},
  "id": 3,
  "created_at": "2026-05-05T20:30:37.591537"
}
```


Closes #80

And, attaching my virtually consented/signed Individual CLA per CONTRIBUTING.md

[individual-cla.pdf](https://github.com/user-attachments/files/27415193/individual-cla.pdf)

