### PR TITLE
fix: align api-gateway OpenAPI auth schemes

### DIFF
--- a/services/api-gateway/main.py
+++ b/services/api-gateway/main.py
@@ -79,8 +79,8 @@ if not all([ADMIN_API_URL, MEETING_API_URL, TRANSCRIPTION_COLLECTOR_URL, MCP_URL
     raise ValueError(f"Missing required environment variables: {', '.join(missing_vars)}")
 
 # Security Schemes for OpenAPI
-api_key_scheme = APIKeyHeader(name="X-API-Key", description="API Key for client operations", auto_error=False)
-admin_api_key_scheme = APIKeyHeader(name="X-Admin-API-Key", description="API Key for admin operations", auto_error=False)
+api_key_scheme = APIKeyHeader(name="X-API-Key", scheme_name="ApiKeyAuth", description="API Key for client operations", auto_error=False)
+admin_api_key_scheme = APIKeyHeader(name="X-Admin-API-Key", scheme_name="AdminApiKeyAuth", description="API Key for admin operations", auto_error=False)
 
 _VEXA_ENV = os.getenv("VEXA_ENV", "development")
 _PUBLIC_DOCS = _VEXA_ENV != "production"

--- a/services/api-gateway/tests/test_openapi.py
+++ b/services/api-gateway/tests/test_openapi.py
@@ -1,0 +1,46 @@
+"""Regression tests for api-gateway OpenAPI auth schemes."""
+from main import app
+
+
+def _fresh_openapi_schema():
+    app.openapi_schema = None
+    return app.openapi()
+
+
+def test_openapi_security_schemes_match_runtime_headers():
+    schema = _fresh_openapi_schema()
+
+    assert schema["components"]["securitySchemes"]["ApiKeyAuth"]["name"] == "X-API-Key"
+    assert (
+        schema["components"]["securitySchemes"]["AdminApiKeyAuth"]["name"]
+        == "X-Admin-API-Key"
+    )
+
+
+def test_openapi_operations_reference_defined_security_schemes():
+    schema = _fresh_openapi_schema()
+    defined_schemes = set(schema["components"]["securitySchemes"])
+    referenced_schemes = {
+        scheme_name
+        for path in schema["paths"].values()
+        for operation in path.values()
+        for requirement in operation.get("security", [])
+        for scheme_name in requirement
+    }
+
+    assert referenced_schemes <= defined_schemes
+    assert "APIKeyHeader" not in referenced_schemes
+
+
+def test_openapi_admin_routes_use_admin_api_key_header():
+    schema = _fresh_openapi_schema()
+
+    admin_security = schema["paths"]["/admin/{path}"]["get"]["security"]
+    assert admin_security == [{"AdminApiKeyAuth": []}]
+
+
+def test_openapi_client_routes_use_client_api_key_header():
+    schema = _fresh_openapi_schema()
+
+    bots_security = schema["paths"]["/bots"]["post"]["security"]
+    assert bots_security == [{"ApiKeyAuth": []}]


### PR DESCRIPTION
## Summary
- Set explicit FastAPI security scheme names for client and admin API keys
- Add OpenAPI regression tests for auth scheme references and header names

## Fixes
Fixes #62
Fixes #80

## Tests
- `PYTHONPATH='services/api-gateway;services/meeting-api;libs/admin-models' python -m pytest services/api-gateway/tests/test_openapi.py`