### PR TITLE
Release v0.10.6.1 rerelease

### DIFF
--- a/deploy/compose/Makefile
+++ b/deploy/compose/Makefile
@@ -17,8 +17,10 @@ BUILD_TAG := $(VERSION)-$(shell date +%y%m%d-%H%M)
 # DockerHub namespace
 DOCKERHUB_USER ?= vexaai
 
-# All images that get built and published
-IMAGES := api-gateway admin-api runtime-api meeting-api agent-api mcp dashboard tts-service vexa-lite
+# All images that get built and published.
+# agent-api remains NO-SHIP for v0.10.x (see docker-compose.yml); do not
+# promote a non-deployed image to :dev/:latest as part of public releases.
+IMAGES := api-gateway admin-api runtime-api meeting-api mcp dashboard tts-service vexa-lite
 BOT_IMAGE := vexa-bot
 
 -include $(ENV_FILE)
@@ -256,7 +258,8 @@ setup-api-key: check_docker
 			if [ -f $(LAST_TAG_FILE) ]; then \
 				export IMAGE_TAG=$$(cat $(LAST_TAG_FILE)); \
 			else \
-				export IMAGE_TAG=dev; \
+				export IMAGE_TAG=$$(grep -E '^IMAGE_TAG=' $(ENV_FILE) 2>/dev/null | cut -d= -f2 || echo "dev"); \
+				IMAGE_TAG=$${IMAGE_TAG:-dev}; \
 			fi; \
 			$(COMPOSE_CMD) up -d dashboard; \
 		else \

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -129,6 +129,10 @@ services:
       - AGENT_IMAGE=${AGENT_IMAGE}
       - BROWSER_IMAGE=${BROWSER_IMAGE}
       - REDIS_URL=redis://redis:6379
+      - TRANSCRIPTION_SERVICE_URL=${TRANSCRIPTION_SERVICE_URL:-}
+      - TRANSCRIPTION_SERVICE_TOKEN=${TRANSCRIPTION_SERVICE_TOKEN:-}
+      - TTS_SERVICE_URL=http://tts-service:8002
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
       - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-vexa-access-key}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-vexa-secret-key}
@@ -262,7 +266,10 @@ services:
       - BOT_IMAGE_NAME=${BROWSER_IMAGE}
       - DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:-vexa}_vexa
       - TTS_SERVICE_URL=http://tts-service:8002
-      - POST_MEETING_HOOKS=${POST_MEETING_HOOKS:-http://agent-api:8100/internal/webhooks/meeting-completed}
+      # agent-api is not shipped in this compose profile. Operators can opt in
+      # with POST_MEETING_HOOKS, but the default must not point at a disabled
+      # service or every completed meeting emits DNS errors before handoff.
+      - POST_MEETING_HOOKS=${POST_MEETING_HOOKS:-}
       - TRANSCRIPTION_COLLECTOR_URL=http://meeting-api:8080
       - STORAGE_BACKEND=${STORAGE_BACKEND:-minio}
       - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}
@@ -349,6 +356,7 @@ services:
       args:
         NEXT_PUBLIC_VEXA_OSS_VERSION: ${VEXA_VERSION:-dev}
         NEXT_PUBLIC_VEXA_OSS_RELEASE_DATE: ${VEXA_RELEASE_DATE:-}
+        VEXA_API_URL: http://api-gateway:8000
     image: vexaai/dashboard:${IMAGE_TAG}
     mem_limit: 1g
     ports:
@@ -361,6 +369,10 @@ services:
       - VEXA_ADMIN_API_KEY=${ADMIN_API_TOKEN:-changeme}
       - VEXA_ADMIN_API_URL=http://admin-api:8001
       - JWT_SECRET=${JWT_SECRET:-vexa-dev-jwt-secret}
+      - VEXA_AUTH_COOKIE_NAME=${VEXA_AUTH_COOKIE_NAME:-vexa-token-compose}
+      - VEXA_USER_INFO_COOKIE_NAME=${VEXA_USER_INFO_COOKIE_NAME:-vexa-user-info-compose}
+      - VEXA_ALLOW_DIRECT_LOGIN=${VEXA_ALLOW_DIRECT_LOGIN:-true}
+      - MINIO_INTERNAL_ENDPOINT=${MINIO_INTERNAL_ENDPOINT:-http://minio:9000}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-}
     init: true
     depends_on:
@@ -377,7 +389,15 @@ services:
     mem_limit: 1g
     expose:
       - "8002"
+    # v0.10.6.1 (scope.yaml tts-auto-language-detection.code_to_change):
+    # host-expose the TTS port so host-side proves (TTS_AUTO_LANG_PICKS_RIGHT_VOICE,
+    # TTS_NEW_LANG_VOICE_AUTO_DOWNLOAD_CACHED) can curl localhost:8002.
+    ports:
+      - "127.0.0.1:8002:8002"
     environment:
+      - PIPER_DEFAULT_VOICES=${PIPER_DEFAULT_VOICES:-major}
+      - PIPER_LOAD_VOICES=${PIPER_LOAD_VOICES:-en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium}
+      - PIPER_PRELOAD_STRICT=${PIPER_PRELOAD_STRICT:-true}
       - TTS_API_TOKEN=${TTS_API_TOKEN:-}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     volumes:

--- a/deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml
@@ -104,6 +104,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "vexa.adminTokenSecretName" . }}
                   key: TRANSCRIPTION_SERVICE_TOKEN
+            - name: TTS_SERVICE_URL
+              value: "http://{{ include "vexa.componentName" (list . "tts-service") }}:{{ .Values.ttsService.service.port }}"
             # v0.10.5 Pack B.3 — runtime-api needs MEETING_API_URL +
             # RECORDING_ENABLED + STORAGE_BACKEND + MINIO_SECURE on its own
             # env so profile-load-time `${VAR}` substitution resolves the

--- a/deploy/helm/charts/vexa/templates/deployment-tts-service.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-tts-service.yaml
@@ -25,7 +25,7 @@ spec:
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
     spec:
       securityContext:
-        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
+        {{- toYaml (mergeOverwrite (deepCopy .Values.global.podSecurityContext) .Values.ttsService.podSecurityContext) | nindent 8 }}
       # v0.10.5 Pack I.s — stateful-pod anti-affinity (#272 iter-5).
       # See deployment-minio.yaml header for the full rationale.
       affinity:
@@ -57,6 +57,12 @@ spec:
               value: {{ .Values.ttsService.apiToken | default "" | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.ttsService.logLevel | default "INFO" | quote }}
+            - name: PIPER_DEFAULT_VOICES
+              value: {{ .Values.ttsService.defaultVoices | default "major" | quote }}
+            - name: PIPER_LOAD_VOICES
+              value: {{ .Values.ttsService.loadVoices | default "en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium" | quote }}
+            - name: PIPER_PRELOAD_STRICT
+              value: {{ .Values.ttsService.preloadStrict | default true | quote }}
             {{- with .Values.ttsService.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -202,18 +202,26 @@ ttsService:
     port: 8002
   apiToken: ""
   logLevel: "INFO"
+  defaultVoices: "major"
+  loadVoices: "en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium"
+  preloadStrict: true
   persistence:
     size: 5Gi
     storageClassName: ""
+  # The image runs as uid/gid 999. The voices PVC must be group-writable on
+  # first boot so Piper can download voice models before readiness turns green.
+  podSecurityContext:
+    fsGroup: 999
+    fsGroupChangePolicy: OnRootMismatch
   # Load-tested shape (from proprietary wrapper staging values): TTS is
   # bursty — lean cpu request, bigger memory for voice cache.
   resources:
     requests:
-      cpu: 10m
-      memory: 256Mi
+      cpu: 250m
+      memory: 768Mi
     limits:
-      cpu: 100m
-      memory: 512Mi
+      cpu: 1000m
+      memory: 1536Mi
   extraEnv: []
   # First-boot voice-model download takes 60-180s. Defaults below clear that
   # window; subsequent restarts come up fast (PVC retains models). Operators
@@ -261,7 +269,11 @@ dashboard:
   # env:
   #   ENABLE_AZURE_AD_AUTH: "true"
   #   NEXTAUTH_URL: ""
-  env: {}
+  env:
+    # Default-refuse: dashboard direct login (passwordless via /api/auth/send-magic-link
+    # without SMTP) is disabled unless an operator explicitly opts in. Override to
+    # "true" only in dev/test profiles (see values-test.yaml).
+    VEXA_ALLOW_DIRECT_LOGIN: "false"
   extraEnv: []
   extraSecretName: ""
   extraSecretEnv: {}
@@ -472,6 +484,7 @@ runtimeProfiles: |
         REDIS_URL: "${REDIS_URL}"
         TRANSCRIPTION_SERVICE_URL: "${TRANSCRIPTION_SERVICE_URL}"
         TRANSCRIPTION_SERVICE_TOKEN: "${TRANSCRIPTION_SERVICE_TOKEN}"
+        TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
         # v0.10.5 Pack B.3 — propagate recording/storage env to bot pods (#235).
         # Without these, bot transcribes (has TRANSCRIPTION_SERVICE_*) and
         # silently skips recording upload (no MEETING_API_URL → no endpoint
@@ -507,6 +520,7 @@ runtimeProfiles: |
         DISPLAY: "${DISPLAY:-:99}"
         NODE_ENV: "production"
         REDIS_URL: "${REDIS_URL}"
+        TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
         # v0.10.5 Pack B.3 — recording/storage env propagation.
         MEETING_API_URL: "${MEETING_API_URL}"
         RECORDING_ENABLED: "${RECORDING_ENABLED:-true}"

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -22,7 +22,7 @@
 #     -e DATABASE_URL="postgresql://user:pass@host:5432/vexa" \
 #     -e ADMIN_API_TOKEN="your-secret-token" \
 #     -e TRANSCRIPTION_SERVICE_URL="http://host:8083/v1/audio/transcriptions" \
-#     -e TRANSCRIPTION_SERVICE_TOKEN="your-api-key" \
+#     -e TRANSCRIPTION_SERVICE_TOKEN="<api-key>" \
 #     vexa-lite
 # =============================================================================
 
@@ -157,7 +157,7 @@ COPY packages/transcript-rendering/dist/ /transcript-rendering/dist/
 COPY services/dashboard/package.json /app/dashboard-build/
 RUN cd /app/dashboard-build && \
     sed -i 's|file:../../../packages/transcript-rendering|file:/transcript-rendering|' package.json && \
-    npm install --ignore-scripts && \
+    npm install --ignore-scripts --legacy-peer-deps && \
     rm -rf node_modules/@vexaai/transcript-rendering && \
     cp -r /transcript-rendering node_modules/@vexaai/transcript-rendering
 
@@ -236,6 +236,9 @@ ENV ADMIN_API_URL=http://localhost:8057 \
 
 # TTS Service
 ENV TTS_SERVICE_URL=http://localhost:8059 \
+    PIPER_DEFAULT_VOICES=major \
+    PIPER_LOAD_VOICES=en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium \
+    PIPER_PRELOAD_STRICT=true \
     OPENAI_API_KEY=
 
 # Display for headless browsers

--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -94,7 +94,11 @@ Edit `.env` at repo root. Created automatically on first `make lite`.
 | `MINIO_ACCESS_KEY`  | --                         | MinIO access key                  |
 | `MINIO_SECRET_KEY`  | --                         | MinIO secret key                  |
 | `LOG_LEVEL`         | `info`                     | Logging level for all services    |
-| `OPENAI_API_KEY`    | --                         | For OpenAI TTS voices (optional)  |
+| `OPENAI_API_KEY`    | --                         | Optional. Only consumed when `/speak` callers pass `provider=openai`. Default `provider=piper` runs locally with no key. |
+| `PIPER_VOICES_DIR`  | `/app/voices`              | Where Piper TTS caches downloaded voice models (mount a volume to persist across restarts). |
+| `PIPER_DEFAULT_VOICES` | `major` | Voices prepared on startup. `major` expands to the supported release-gate language set; other languages auto-download on first use via `provider=piper` auto-language detection. |
+| `PIPER_LOAD_VOICES` | `en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium` | Prepared voices also kept loaded in memory for the hottest release-gate languages. |
+| `PIPER_PRELOAD_STRICT` | `true` | Fail startup when a configured voice cannot be prepared, so `/speak` does not accept traffic before promised voices are prompt. |
 
 
 ## Debugging

--- a/deploy/lite/requirements.txt
+++ b/deploy/lite/requirements.txt
@@ -8,7 +8,7 @@
 # Web Framework
 fastapi>=0.110
 uvicorn[standard]>=0.29
-python-multipart>=0.0.6
+python-multipart>=0.0.20
 
 # Data Validation
 pydantic[email]>=2.0
@@ -41,7 +41,10 @@ croniter>=2.0
 # TTS Service
 piper-tts>=1.4.0
 numpy>=1.21.0
+langdetect>=1.0.9
 
 # Utilities
-python-dotenv>=1.0
+python-dotenv>=1.2.1
 email-validator>=2.0
+
+Mako>=1.3.12

--- a/deploy/lite/supervisord.conf
+++ b/deploy/lite/supervisord.conf
@@ -123,7 +123,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=PYTHONUNBUFFERED="1",ORCHESTRATOR_BACKEND="process",PORT="8090",REDIS_URL="%(ENV_REDIS_URL)s",BOT_SCRIPT_PATH="/app/vexa-bot/dist/docker.js",BOT_WORKING_DIR="/app/vexa-bot",DISPLAY=":99",ALLOW_PRIVATE_CALLBACKS="true"
+environment=PYTHONUNBUFFERED="1",ORCHESTRATOR_BACKEND="process",PORT="8090",REDIS_URL="%(ENV_REDIS_URL)s",BOT_SCRIPT_PATH="/app/vexa-bot/dist/docker.js",BOT_WORKING_DIR="/app/vexa-bot",DISPLAY=":99",ALLOW_PRIVATE_CALLBACKS="true",INTERNAL_API_SECRET="lite-internal-secret"
 
 ; =============================================================================
 ; Meeting API (:8080) — bot orchestration + transcription pipeline
@@ -140,7 +140,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=PYTHONUNBUFFERED="1",PYTHONPATH="/app/admin-models:/app/schema-sync",REDIS_URL="%(ENV_REDIS_URL)s",DATABASE_URL="%(ENV_DATABASE_URL)s",DB_HOST="%(ENV_DB_HOST)s",DB_PORT="%(ENV_DB_PORT)s",DB_NAME="%(ENV_DB_NAME)s",DB_USER="%(ENV_DB_USER)s",DB_PASSWORD="%(ENV_DB_PASSWORD)s",RUNTIME_API_URL="http://localhost:8090",MEETING_API_URL="http://localhost:8080",BOT_CALLBACK_BASE_URL="http://localhost:8080",ADMIN_API_URL="http://localhost:8057",ADMIN_TOKEN="%(ENV_ADMIN_API_TOKEN)s",TRANSCRIPTION_SERVICE_URL="%(ENV_TRANSCRIPTION_SERVICE_URL)s",TRANSCRIPTION_SERVICE_TOKEN="%(ENV_TRANSCRIPTION_SERVICE_TOKEN)s",TTS_SERVICE_URL="http://localhost:8059",STORAGE_BACKEND="%(ENV_STORAGE_BACKEND)s",LOCAL_STORAGE_DIR="%(ENV_LOCAL_STORAGE_DIR)s",LOCAL_STORAGE_FSYNC="%(ENV_LOCAL_STORAGE_FSYNC)s",MINIO_ENDPOINT="%(ENV_MINIO_ENDPOINT)s",MINIO_ACCESS_KEY="%(ENV_MINIO_ACCESS_KEY)s",MINIO_SECRET_KEY="%(ENV_MINIO_SECRET_KEY)s",MINIO_BUCKET="%(ENV_MINIO_BUCKET)s",MINIO_SECURE="%(ENV_MINIO_SECURE)s",AWS_REGION="%(ENV_AWS_REGION)s",AWS_ACCESS_KEY_ID="%(ENV_AWS_ACCESS_KEY_ID)s",AWS_SECRET_ACCESS_KEY="%(ENV_AWS_SECRET_ACCESS_KEY)s",S3_BUCKET="%(ENV_S3_BUCKET)s",S3_ENDPOINT="%(ENV_S3_ENDPOINT)s",S3_SECURE="%(ENV_S3_SECURE)s"
+environment=PYTHONUNBUFFERED="1",PYTHONPATH="/app/admin-models:/app/schema-sync",REDIS_URL="%(ENV_REDIS_URL)s",DATABASE_URL="%(ENV_DATABASE_URL)s",DB_HOST="%(ENV_DB_HOST)s",DB_PORT="%(ENV_DB_PORT)s",DB_NAME="%(ENV_DB_NAME)s",DB_USER="%(ENV_DB_USER)s",DB_PASSWORD="%(ENV_DB_PASSWORD)s",RUNTIME_API_URL="http://localhost:8090",MEETING_API_URL="http://localhost:8080",BOT_CALLBACK_BASE_URL="http://localhost:8080",ADMIN_API_URL="http://localhost:8057",ADMIN_TOKEN="%(ENV_ADMIN_API_TOKEN)s",INTERNAL_API_SECRET="lite-internal-secret",TRANSCRIPTION_SERVICE_URL="%(ENV_TRANSCRIPTION_SERVICE_URL)s",TRANSCRIPTION_SERVICE_TOKEN="%(ENV_TRANSCRIPTION_SERVICE_TOKEN)s",TTS_SERVICE_URL="http://localhost:8059",STORAGE_BACKEND="%(ENV_STORAGE_BACKEND)s",LOCAL_STORAGE_DIR="%(ENV_LOCAL_STORAGE_DIR)s",LOCAL_STORAGE_FSYNC="%(ENV_LOCAL_STORAGE_FSYNC)s",MINIO_ENDPOINT="%(ENV_MINIO_ENDPOINT)s",MINIO_ACCESS_KEY="%(ENV_MINIO_ACCESS_KEY)s",MINIO_SECRET_KEY="%(ENV_MINIO_SECRET_KEY)s",MINIO_BUCKET="%(ENV_MINIO_BUCKET)s",MINIO_SECURE="%(ENV_MINIO_SECURE)s",AWS_REGION="%(ENV_AWS_REGION)s",AWS_ACCESS_KEY_ID="%(ENV_AWS_ACCESS_KEY_ID)s",AWS_SECRET_ACCESS_KEY="%(ENV_AWS_SECRET_ACCESS_KEY)s",S3_BUCKET="%(ENV_S3_BUCKET)s",S3_ENDPOINT="%(ENV_S3_ENDPOINT)s",S3_SECURE="%(ENV_S3_SECURE)s"
 
 ; =============================================================================
 ; Agent API (:8100) — AI agent chat runtime
@@ -174,7 +174,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=PYTHONUNBUFFERED="1",OPENAI_API_KEY="%(ENV_OPENAI_API_KEY)s"
+environment=PYTHONUNBUFFERED="1",OPENAI_API_KEY="%(ENV_OPENAI_API_KEY)s",PIPER_DEFAULT_VOICES="%(ENV_PIPER_DEFAULT_VOICES)s",PIPER_LOAD_VOICES="%(ENV_PIPER_LOAD_VOICES)s",PIPER_PRELOAD_STRICT="%(ENV_PIPER_PRELOAD_STRICT)s"
 
 ; =============================================================================
 ; API Gateway (:8056) — main entry point, routes to all services
@@ -225,7 +225,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=NODE_ENV="production",PORT="3000",HOSTNAME="0.0.0.0",NEXT_PUBLIC_API_URL="http://localhost:8056",VEXA_API_URL="http://localhost:8056",VEXA_ADMIN_API_KEY="%(ENV_ADMIN_API_TOKEN)s",VEXA_ADMIN_API_URL="http://localhost:8056"
+environment=NODE_ENV="production",PORT="3000",HOSTNAME="0.0.0.0",NEXT_PUBLIC_API_URL="http://localhost:8056",VEXA_API_URL="http://localhost:8056",VEXA_ADMIN_API_KEY="%(ENV_ADMIN_API_TOKEN)s",VEXA_ADMIN_API_URL="http://localhost:8056",VEXA_ALLOW_DIRECT_LOGIN="true"
 
 ; =============================================================================
 ; Process Groups

--- a/services/dashboard/src/app/api/config/route.ts
+++ b/services/dashboard/src/app/api/config/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAuthCookieName } from "@/lib/auth-cookies";
 
 /**
  * Public configuration endpoint that exposes runtime environment variables to the client.
@@ -7,28 +8,65 @@ import { cookies } from "next/headers";
  * Also returns the user's auth token for WebSocket authentication.
  */
 export async function GET(request: NextRequest) {
-  const apiUrl = process.env.VEXA_API_URL || "http://localhost:18056";
+  const apiUrl = process.env.VEXA_API_URL;
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: "VEXA_API_URL is required; dashboard runtime config has no API SSOT" },
+      { status: 500 }
+    );
+  }
   const decisionListenerUrl =
     process.env.NEXT_PUBLIC_DECISION_LISTENER_URL || "http://localhost:8765";
+  const configuredPublicApiUrl =
+    process.env.VEXA_PUBLIC_API_URL ||
+    process.env.NEXT_PUBLIC_VEXA_API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "";
 
-  // WS goes through the dashboard via Next.js rewrite — derive from request host.
-  // Explicit NEXT_PUBLIC_APP_URL takes precedence, but localhost is ignored for remote access.
+  const wsUrlFromHttpBase = (baseUrl: string) => {
+    const trimmed = baseUrl.replace(/\/+$/, "");
+    const wsProto = trimmed.startsWith("https://") ? "wss" : "ws";
+    return `${wsProto}://${trimmed.replace(/^https?:\/\//, "")}/ws`;
+  };
+
+  const isLoopbackHost = (hostname: string) =>
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1";
+
+  const host = request.headers.get("x-forwarded-host") || request.headers.get("host")!;
+  const requestHostname = host.split(":")[0];
+  let publicApiUrl = configuredPublicApiUrl;
+  if (configuredPublicApiUrl) {
+    try {
+      const configured = new URL(configuredPublicApiUrl);
+      if (isLoopbackHost(configured.hostname) && !isLoopbackHost(requestHostname)) {
+        configured.hostname = requestHostname;
+        publicApiUrl = configured.toString().replace(/\/+$/, "");
+      }
+    } catch {
+      publicApiUrl = configuredPublicApiUrl;
+    }
+  }
+
+  // Browser-facing API config is the runtime SSOT. Next.js rewrites are a
+  // same-origin fallback only: their target is compiled into the image, so they
+  // cannot be the source of truth for portable Helm deployments.
   const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-  const host = request.headers.get('host')!;
   const proto = request.headers.get('x-forwarded-proto') === 'https' ? 'wss' : 'ws';
   let wsUrl: string;
-  if (appUrl && !appUrl.includes('localhost')) {
-    const wsProto = appUrl.startsWith('https') ? 'wss' : 'ws';
-    const wsHost = appUrl.replace(/^https?:\/\//, '');
-    wsUrl = `${wsProto}://${wsHost}/ws`;
+  if (publicApiUrl) {
+    wsUrl = wsUrlFromHttpBase(publicApiUrl);
+  } else if (appUrl && !appUrl.includes('localhost')) {
+    wsUrl = wsUrlFromHttpBase(appUrl);
   } else {
     wsUrl = `${proto}://${host}/ws`;
   }
 
-  // Auth token for WebSocket: same fallback chain as the HTTP proxy in /api/vexa/[...path].
-  // cookie (logged-in user) → VEXA_API_KEY env var (self-hosted service token)
+  // Auth token for WebSocket: cookie first; self-hosted service token only when explicitly configured.
   const cookieStore = await cookies();
-  const authToken = cookieStore.get("vexa-token")?.value
+  const authToken = cookieStore.get(getAuthCookieName())?.value
     || process.env.VEXA_API_KEY
     || null;
 
@@ -38,14 +76,6 @@ export async function GET(request: NextRequest) {
   // Hosted mode flags (read at runtime, not build time)
   const hostedMode = process.env.NEXT_PUBLIC_HOSTED_MODE === "true";
   const webappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL || "https://vexa.ai";
-
-  // Public API URL for client-facing configs (MCP, docs, etc.)
-  // Explicit values take precedence, but localhost is ignored for remote access — derive from request host.
-  const gatewayPort = process.env.API_GATEWAY_HOST_PORT || "8056";
-  const explicitPublicApi = process.env.VEXA_PUBLIC_API_URL || process.env.NEXT_PUBLIC_VEXA_API_URL || "";
-  const publicApiUrl = (explicitPublicApi && !explicitPublicApi.includes('localhost'))
-    ? explicitPublicApi
-    : `${request.headers.get('x-forwarded-proto') || 'http'}://${host.replace(/:\d+$/, '')}:${gatewayPort}`;
 
   return NextResponse.json({
     wsUrl,

--- a/services/dashboard/src/app/meetings/[id]/page.tsx
+++ b/services/dashboard/src/app/meetings/[id]/page.tsx
@@ -55,7 +55,7 @@ import { useMeetingsStore } from "@/stores/meetings-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useLiveTranscripts } from "@/hooks/use-live-transcripts";
 import { PLATFORM_CONFIG, getDetailedStatus } from "@/types/vexa";
-import type { MeetingStatus, Meeting } from "@/types/vexa";
+import type { MeetingStatus, Meeting, RecordingData } from "@/types/vexa";
 import { StatusHistory } from "@/components/meetings/status-history";
 import { cn, parseUTCTimestamp } from "@/lib/utils";
 import { vexaAPI } from "@/lib/api";
@@ -122,8 +122,16 @@ export default function MeetingDetailPage() {
     clearCurrentMeeting,
   } = useMeetingsStore();
   const authToken = useAuthStore((s) => s.token);
-  const { config: runtimeConfig } = useRuntimeConfig();
+  const { config: runtimeConfig, isLoading: isRuntimeConfigLoading } = useRuntimeConfig();
   const apiBaseUrl = runtimeConfig?.publicApiUrl || runtimeConfig?.apiUrl || "";
+  const gatewayBrowserBase = apiBaseUrl.replace(/\/+$/, "");
+  const browserRouteUrl = useCallback(
+    (path: string) => {
+      if (isRuntimeConfigLoading) return "";
+      return gatewayBrowserBase ? `${gatewayBrowserBase}${path}` : withBasePath(path);
+    },
+    [gatewayBrowserBase, isRuntimeConfigLoading]
+  );
 
   // Agent panel state
   const [agentPanelOpen, setAgentPanelOpen] = useState(false);
@@ -198,45 +206,99 @@ export default function MeetingDetailPage() {
   // shows a "Preparing audio…" state.
   const [recordingFragments, setRecordingFragments] = useState<AudioFragment[]>([]);
   const [videoSrc, setVideoSrc] = useState<string | null>(null);
+  // v0.10.6.1 — surface connection errors from the master-stream-URL lookup.
+  // Distinct from "master not ready yet" (returned as null → "finalizing"
+  // UI). A non-null value here means a real network/HTTP failure that the
+  // user should see, not be silently retried-into-empty-state.
+  const [playbackConnectionError, setPlaybackConnectionError] = useState<string | null>(null);
+
+  // v0.10.6.1 — ADR-2 canonical playback path. Dashboard reads
+  // `recording.playback_url.audio` (a stable backend route) and calls
+  // vexaAPI.getRecordingMasterStreamUrl() to resolve it to a presigned
+  // URL. No client-side picking from media_files[]. Null playback_url
+  // → render "finalizing" UI state (no silent fallback to chunk 0).
+  //
+  // The signature pattern from pre-fix avoided URL refetch storms when
+  // recordings[] reference changed but content didn't — kept here on
+  // the playback_url field directly.
+  const audioMediaSignature = useMemo(() => {
+    return recordings
+      .filter(r => (r.status === "completed" || r.status === "in_progress"))
+      .filter(r => r.playback_url?.audio)
+      .sort((a, b) => a.created_at.localeCompare(b.created_at))
+      .map(r => `${r.id}:${r.playback_url?.audio ?? ""}`)
+      .join("|");
+  }, [recordings]);
 
   useEffect(() => {
+    if (!audioMediaSignature) {
+      setRecordingFragments([]);
+      return;
+    }
     let cancelled = false;
     (async () => {
       const availableRecordings = recordings
-        .filter(r => (r.status === "completed" || r.status === "in_progress") && r.media_files?.some(mf => mf.type === "audio"))
+        .filter(r => (r.status === "completed" || r.status === "in_progress") && r.playback_url?.audio)
         .sort((a, b) => a.created_at.localeCompare(b.created_at));
-      const frags = await Promise.all(availableRecordings.map(async rec => {
-        const audioMedia = rec.media_files.find(mf => mf.type === "audio")!;
-        const src = await vexaAPI.getRecordingAudioStreamUrl(rec.id, audioMedia.id);
-        return {
-          src,
-          duration: audioMedia.duration_seconds || 0,
-          sessionUid: rec.session_uid,
-          createdAt: rec.created_at,
-        } as AudioFragment;
-      }));
-      if (!cancelled) setRecordingFragments(frags);
+      try {
+        const results = await Promise.all(availableRecordings.map(async rec => {
+          const result = await vexaAPI.getRecordingMasterStreamUrl(rec.id, "audio");
+          if (!result) {
+            // 404 — master not ready for this recording yet.
+            return null;
+          }
+          return {
+            src: result.url,
+            duration: result.duration_seconds ?? null,
+            sessionUid: rec.session_uid,
+            createdAt: rec.created_at,
+          } as AudioFragment;
+        }));
+        if (!cancelled) {
+          setRecordingFragments(results.filter((f): f is AudioFragment => f !== null));
+          setPlaybackConnectionError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setPlaybackConnectionError(err instanceof Error ? err.message : String(err));
+          setRecordingFragments([]);
+        }
+      }
     })();
     return () => { cancelled = true; };
-  }, [recordings]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [audioMediaSignature]);
 
   const hasRecordingAudio = recordingFragments.length > 0;
 
-  // Find the first video media file across all recordings for the VideoPlayer.
-  // Same Pack U.8 contract as above — presigned URL with /raw fallback.
+  // Find the first video master across all recordings for the VideoPlayer.
+  // v0.10.6.1 ADR-2: read recording.playback_url.video; no client-side
+  // selection from media_files[].
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      for (const rec of recordings) {
-        if (rec.status !== "completed" && rec.status !== "in_progress") continue;
-        const videoMedia = rec.media_files?.find((mf: { type: string }) => mf.type === "video");
-        if (videoMedia) {
-          const src = await vexaAPI.getRecordingVideoStreamUrl(rec.id, videoMedia.id);
-          if (!cancelled) setVideoSrc(src);
+      try {
+        for (const rec of recordings) {
+          if (rec.status !== "completed" && rec.status !== "in_progress") continue;
+          if (!rec.playback_url?.video) continue;
+          const result = await vexaAPI.getRecordingMasterStreamUrl(rec.id, "video");
+          if (!result) {
+            // 404 — video master not ready for this recording yet; try the next.
+            continue;
+          }
+          if (!cancelled) {
+            setVideoSrc(result.url);
+            setPlaybackConnectionError(null);
+          }
           return;
         }
+        if (!cancelled) setVideoSrc(null);
+      } catch (err) {
+        if (!cancelled) {
+          setPlaybackConnectionError(err instanceof Error ? err.message : String(err));
+          setVideoSrc(null);
+        }
       }
-      if (!cancelled) setVideoSrc(null);
     })();
     return () => { cancelled = true; };
   }, [recordings]);
@@ -666,15 +728,19 @@ export default function MeetingDetailPage() {
     setCurrentLanguage(fromSegment || "auto");
   }, [currentMeeting, transcripts, validLangCodes]);
 
-  // No longer need polling - WebSocket handles status updates for early states
-  // Removed auto-refresh polling since WebSocket provides real-time updates
-
   // Fetch transcripts when meeting is loaded
   // Use specific properties as dependencies to avoid unnecessary refetches
   const meetingPlatform = currentMeeting?.platform;
   const meetingNativeId = currentMeeting?.platform_specific_id;
   const meetingNumericId = currentMeeting?.id ? String(currentMeeting.id) : undefined;
   const meetingStatus = currentMeeting?.status;
+  const isPostMeetingStatus =
+    forcePostMeetingMode || meetingStatus === "stopping" || meetingStatus === "completed";
+  const shouldPollPostMeetingArtifacts =
+    isPostMeetingStatus &&
+    currentMeeting?.data?.recording_enabled !== false &&
+    !hasRecordingAudio &&
+    !playbackConnectionError;
 
   useEffect(() => {
     // Active browser sessions use VNC — no transcript fetch needed.
@@ -706,6 +772,38 @@ export default function MeetingDetailPage() {
       fetchChatMessages(meetingPlatform, meetingNativeId);
     }
   }, [shouldUseWebSocket, meetingPlatform, meetingNativeId, fetchChatMessages]);
+
+  // Recording masters are finalized asynchronously after the bot stops. The
+  // status WebSocket can report "completed" before playback_url/audio is ready,
+  // so keep refreshing post-meeting artifacts until the player can render.
+  useEffect(() => {
+    if (!meetingId || !meetingPlatform || !meetingNativeId) return;
+    if (!shouldPollPostMeetingArtifacts) return;
+
+    let cancelled = false;
+    const refreshPostMeetingArtifacts = () => {
+      if (cancelled) return;
+      refreshMeeting(meetingId);
+      fetchTranscripts(meetingPlatform, meetingNativeId, meetingNumericId, { silent: true });
+      fetchChatMessages(meetingPlatform, meetingNativeId);
+    };
+
+    refreshPostMeetingArtifacts();
+    const interval = window.setInterval(refreshPostMeetingArtifacts, 2500);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [
+    meetingId,
+    meetingPlatform,
+    meetingNativeId,
+    meetingNumericId,
+    shouldPollPostMeetingArtifacts,
+    refreshMeeting,
+    fetchTranscripts,
+    fetchChatMessages,
+  ]);
 
   // Handle saving notes on blur
   const handleNotesBlur = useCallback(async () => {
@@ -839,13 +937,31 @@ export default function MeetingDetailPage() {
   const isPostMeetingFlow =
     forcePostMeetingMode ||
     currentMeeting.status === "stopping" || currentMeeting.status === "completed";
-  const hasRecordingEntries = recordings.length > 0;
+  const meetingRecordings = Array.isArray(currentMeeting.data?.recordings)
+    ? (currentMeeting.data.recordings as RecordingData[])
+    : [];
+  const effectiveRecordings = recordings.length > 0 ? recordings : meetingRecordings;
+  const hasRecordingEntries = effectiveRecordings.length > 0;
+  const hasActiveRecording = effectiveRecordings.some((recording) =>
+    recording.status === "in_progress" || recording.status === "uploading"
+  );
+  const recordingWasRequested = currentMeeting.data?.recording_enabled !== false;
   const noAudioRecordingForMeeting =
-    (currentMeeting.data?.recording_enabled === false && !hasRecordingAudio) ||
-    (currentMeeting.status === "completed" && !hasRecordingEntries);
-  const canUseSegmentPlayback = isPostMeetingFlow && !noAudioRecordingForMeeting;
-  const recordingTopBar = isPostMeetingFlow ? (
-    hasRecordingAudio ? (
+    currentMeeting.data?.recording_enabled === false && !hasRecordingAudio;
+  const missingRequestedRecording =
+    isPostMeetingFlow && recordingWasRequested && currentMeeting.status === "completed" && !hasRecordingEntries;
+  const canUseSegmentPlayback = isPostMeetingFlow && !noAudioRecordingForMeeting && !missingRequestedRecording;
+  const recordingTopBar = (isPostMeetingFlow || hasActiveRecording) ? (
+    hasActiveRecording && !isPostMeetingFlow ? (
+      <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 rounded-lg border text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Recording in progress...
+      </div>
+    ) : playbackConnectionError ? (
+      <div className="flex items-center gap-2 px-4 py-2 bg-destructive/10 rounded-lg border border-destructive/30 text-sm text-destructive">
+        Connection error loading recording: {playbackConnectionError}
+      </div>
+    ) : hasRecordingAudio ? (
       <div className="flex flex-col gap-2">
         {videoSrc && (
           <VideoPlayer ref={videoPlayerRef} src={videoSrc} className="max-h-[360px]" />
@@ -861,6 +977,10 @@ export default function MeetingDetailPage() {
     ) : noAudioRecordingForMeeting ? (
       <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 rounded-lg border text-sm text-muted-foreground">
         No audio recording for this meeting.
+      </div>
+    ) : missingRequestedRecording ? (
+      <div className="flex items-center gap-2 px-4 py-2 bg-destructive/10 rounded-lg border border-destructive/30 text-sm text-destructive">
+        Recording was enabled, but no finalized recording artifact is available yet.
       </div>
     ) : (
       <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 rounded-lg border text-sm text-muted-foreground">
@@ -882,15 +1002,20 @@ export default function MeetingDetailPage() {
 
   const browserViewIframe = hasBrowserView && viewMode === 'browser' ? (() => {
     const meetingId = currentMeeting.id;
-    // VNC loads from same origin — nginx proxies /b/ routes to the gateway
-    const vncUrl = `/b/${meetingId}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&view_only=false&path=b/${meetingId}/vnc/websockify`;
+    const vncUrl = browserRouteUrl(`/b/${meetingId}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&view_only=false&path=b/${meetingId}/vnc/websockify`);
     return (
       <div className="flex-1 overflow-hidden">
-        <iframe
-          src={vncUrl}
-          className="w-full h-full border-0"
-          allow="clipboard-read; clipboard-write"
-        />
+        {vncUrl ? (
+          <iframe
+            src={vncUrl}
+            className="w-full h-full border-0"
+            allow="clipboard-read; clipboard-write"
+          />
+        ) : (
+          <div className="h-full flex items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        )}
       </div>
     );
   })() : null;
@@ -1680,13 +1805,16 @@ export default function MeetingDetailPage() {
                       const sessionToken = escalation?.session_token as string
                         || currentMeeting.data?.session_token as string;
                       if (!sessionToken) return null;
-                      const vncUrl = withBasePath(`/b/${sessionToken}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&view_only=false&path=b/${sessionToken}/vnc/websockify`);
+                      const vncUrl = browserRouteUrl(`/b/${sessionToken}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&view_only=false&path=b/${sessionToken}/vnc/websockify`);
                       return (
                         <Button
                           variant="default"
                           size="sm"
                           className="gap-2 bg-orange-600 hover:bg-orange-700"
-                          onClick={() => window.open(vncUrl, "_blank")}
+                          disabled={!vncUrl}
+                          onClick={() => {
+                            if (vncUrl) window.open(vncUrl, "_blank");
+                          }}
                         >
                           <Monitor className="h-4 w-4" />
                           Open Remote Browser
@@ -1705,7 +1833,9 @@ export default function MeetingDetailPage() {
                           className="gap-2"
                           onClick={async () => {
                             try {
-                              const response = await fetch(withBasePath(`/b/${sessionToken}/save`), {
+                              const saveUrl = browserRouteUrl(`/b/${sessionToken}/save`);
+                              if (!saveUrl) throw new Error("Runtime config is still loading");
+                              const response = await fetch(saveUrl, {
                                 method: "POST",
                               });
                               if (!response.ok) throw new Error(await response.text());

--- a/services/dashboard/src/components/meetings/browser-session-view.tsx
+++ b/services/dashboard/src/components/meetings/browser-session-view.tsx
@@ -52,16 +52,21 @@ interface BrowserSessionViewProps {
 
 export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
   const router = useRouter();
-  const [apiUrl, setApiUrl] = useState("");
+  const [apiUrl, setApiUrl] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const [showPanel, setShowPanel] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
     fetch(withBasePath("/api/config"))
       .then((r) => r.json())
       .then((cfg) => {
-        setApiUrl(cfg.publicApiUrl || cfg.apiUrl || "http://localhost:8056");
+        const resolvedApiUrl = cfg.publicApiUrl || cfg.apiUrl;
+        setApiUrl(resolvedApiUrl || "");
+      })
+      .catch(() => {
+        setApiUrl("");
       });
   }, []);
 
@@ -87,12 +92,16 @@ export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
     );
   }
 
-  // VNC/CDP use relative URLs — nginx proxies /b/ routes to the gateway (same origin, no CORS)
-  const vncUrl = `/b/${token}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&path=b/${token}/vnc/websockify`;
-  const cdpUrl = apiUrl ? `${apiUrl}/b/${token}/cdp` : `/b/${token}/cdp`;
+  const gatewayBrowserBase = (apiUrl || "").replace(/\/+$/, "");
+  const browserRoute = (path: string) => {
+    if (apiUrl === null) return null;
+    return gatewayBrowserBase ? `${gatewayBrowserBase}${path}` : withBasePath(path);
+  };
+  const vncUrl = browserRoute(`/b/${token}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&path=b/${token}/vnc/websockify`);
+  const cdpUrl = browserRoute(`/b/${token}/cdp`);
   const mcpUrl = apiUrl ? `${apiUrl}/mcp` : null;
   const sshPort = meeting.data?.ssh_port as number | undefined;
-  const sshHost = apiUrl ? (() => { try { return new URL(apiUrl).hostname; } catch { return "localhost"; } })() : "localhost";
+  const sshHost = apiUrl ? (() => { try { return new URL(apiUrl).hostname; } catch { return ""; } })() : "";
 
   const agentInstructions = cdpUrl
     ? [
@@ -116,12 +125,12 @@ export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
       ].join("\n")
     : "";
 
-  const [isDeleting, setIsDeleting] = useState(false);
-
   async function handleSave() {
     setIsSaving(true);
     try {
-      const response = await fetch(withBasePath(`/b/${token}/save`), {
+      const saveUrl = browserRoute(`/b/${token}/save`);
+      if (!saveUrl) throw new Error("Runtime config is still loading");
+      const response = await fetch(saveUrl, {
         method: "POST",
       });
       if (!response.ok) throw new Error(await response.text());
@@ -137,7 +146,9 @@ export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
     if (!confirm("Delete all stored browser data? You will need to log in again.")) return;
     setIsDeleting(true);
     try {
-      const response = await fetch(withBasePath(`/b/${token}/storage`), {
+      const storageUrl = browserRoute(`/b/${token}/storage`);
+      if (!storageUrl) throw new Error("Runtime config is still loading");
+      const response = await fetch(storageUrl, {
         method: "DELETE",
       });
       if (!response.ok) throw new Error(await response.text());

--- a/services/runtime-api/profiles.yaml
+++ b/services/runtime-api/profiles.yaml
@@ -39,6 +39,8 @@ profiles:
       REDIS_URL: "${REDIS_URL}"
       TRANSCRIPTION_SERVICE_URL: "${TRANSCRIPTION_SERVICE_URL}"
       TRANSCRIPTION_SERVICE_TOKEN: "${TRANSCRIPTION_SERVICE_TOKEN}"
+      TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
+      INTERNAL_API_SECRET: "${INTERNAL_API_SECRET}"
     ports:
       "9222/tcp": {}         # CDP debug port
 
@@ -60,6 +62,8 @@ profiles:
       DISPLAY: "${DISPLAY:-:99}"
       NODE_ENV: "production"
       REDIS_URL: "${REDIS_URL}"
+      TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
+      INTERNAL_API_SECRET: "${INTERNAL_API_SECRET}"
     ports:
       "9222/tcp": {}         # CDP debug port
 

--- a/services/tts-service/README.md
+++ b/services/tts-service/README.md
@@ -6,10 +6,26 @@ Bot containers need text-to-speech to participate as voice agents in meetings. T
 
 ## What
 
-A local text-to-speech service using **Piper TTS** (ONNX models). Exposes an OpenAI-compatible `/v1/audio/speech` endpoint so existing code that targets OpenAI's TTS API works without changes. Voice models are auto-downloaded from HuggingFace on first use.
+OpenAI-compatible `/v1/audio/speech` endpoint with **two backends** the caller picks per-request:
 
-Input: JSON body `{"model": "tts-1", "input": "text to speak", "voice": "nova", "response_format": "wav"}`
-Output: Audio (WAV 24kHz mono by default, or raw PCM)
+| `provider` | Backend | Network calls | Auth | Quality |
+|---|---|---|---|---|
+| `piper` *(default)* | [Piper TTS](https://github.com/rhasspy/piper) — local ONNX inference | None at synth time for prepared voices; remaining voices auto-download from HuggingFace on first request | None required | Robotic but clear; ~30 languages |
+| `openai` | OpenAI `https://api.openai.com/v1/audio/speech` | Yes — every request | `OPENAI_API_KEY` env var | Higher; counts against your OpenAI usage |
+
+The endpoint shape stays identical — callers swap `provider` and the response is interchangeable audio bytes.
+
+Input: JSON body
+```json
+{"model": "tts-1", "input": "Hola, ¿cómo estás?", "voice": "auto", "response_format": "wav", "provider": "piper"}
+```
+
+- `provider`: `piper` (default) or `openai`. Omitted = `piper`.
+- `voice`: explicit Piper name (`en_US-amy-medium`), OpenAI alias (`alloy`/`nova`/...), or `auto` (Piper provider only — auto-detects language from `input` and picks a matching voice; supported major languages are prepared by default).
+- `response_format`: `wav` (default) or `pcm` (raw Int16LE 24kHz mono).
+- `model`: ignored by Piper, passed through to OpenAI.
+
+Output: audio bytes (WAV 24kHz mono by default, or raw PCM).
 
 ### Endpoints
 
@@ -38,9 +54,10 @@ Supported formats: `wav` (default), `pcm` (raw Int16LE 24kHz mono)
 
 ### Dependencies
 
-- **Piper TTS** (bundled) — local ONNX inference, no external calls
-- No database, no Redis, no other Vexa services
-- No API keys required for operation
+- **Piper TTS** (bundled) — local ONNX inference, no external calls.
+- **OpenAI TTS** (optional) — only invoked when callers pass `provider=openai`. Requires `OPENAI_API_KEY`.
+- No database, no Redis, no other Vexa services.
+- No API keys required for the default Piper provider.
 
 ## How
 
@@ -62,7 +79,9 @@ uvicorn main:app --host 0.0.0.0 --port 8002
 | `TTS_API_TOKEN` | Optional access token — if set, requests must include `X-API-Key` header |
 | `TTS_OUTPUT_SAMPLE_RATE` | Output sample rate (default: `24000`) |
 | `PIPER_VOICES_DIR` | Voice model storage directory (default: `/app/voices`) |
-| `PIPER_DEFAULT_VOICES` | Comma-separated voices to pre-load on startup (default: `en_US-amy-medium,en_US-danny-low`) |
+| `PIPER_DEFAULT_VOICES` | Comma-separated voices to prepare on startup, or `major` (default) for the release-supported major language set |
+| `PIPER_LOAD_VOICES` | Comma-separated prepared voices to also keep loaded in memory (default: English + Portuguese + Spanish) |
+| `PIPER_PRELOAD_STRICT` | If true, startup fails when a configured voice cannot be prepared (default: `true`) |
 | `LOG_LEVEL` | Logging level (default: `INFO`) |
 
 ### Test
@@ -84,7 +103,7 @@ curl -X POST http://localhost:8002/v1/audio/speech \
 ### Debug
 
 - Logs to stdout: `%(asctime)s - %(name)s - %(levelname)s - %(message)s`
-- Voice models are downloaded on first use — first request for a new voice will be slower
+- Major supported voice models are prepared on startup; first request for a non-prepared voice may still be slower
 - Invalid voice names that can't be downloaded return 404
 - The `model` field is accepted but ignored (kept for OpenAI API compatibility)
 

--- a/services/tts-service/main.py
+++ b/services/tts-service/main.py
@@ -37,11 +37,49 @@ API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
 # the vexa-bot (paplay) expects 24000 Hz.  We resample when they differ.
 OUTPUT_SAMPLE_RATE = int(os.getenv("TTS_OUTPUT_SAMPLE_RATE", "24000"))
 
-# Default voices to pre-load on startup (empty = lazy load all)
-DEFAULT_VOICES = os.getenv(
-    "PIPER_DEFAULT_VOICES",
-    "en_US-amy-medium,en_US-danny-low",
-).split(",")
+# Piper voices that should be ready before a deployment accepts traffic. These
+# are the supported "major language" voices for prompt /speak output today.
+MAJOR_DEFAULT_VOICES = [
+    "en_US-amy-medium",
+    "en_US-danny-low",
+    "es_ES-davefx-medium",
+    "fr_FR-siwis-medium",
+    "de_DE-thorsten-medium",
+    "it_IT-paola-medium",
+    "pt_BR-faber-medium",
+    "nl_NL-mls-medium",
+    "pl_PL-mc_speech-medium",
+    "ru_RU-irina-medium",
+    "uk_UA-ukrainian_tts-medium",
+    "zh_CN-huayan-medium",
+    "ar_JO-kareem-medium",
+    "tr_TR-dfki-medium",
+    "hi_IN-pratham-medium",
+]
+
+
+def _configured_default_voices() -> list[str]:
+    raw = os.getenv("PIPER_DEFAULT_VOICES", "major").strip()
+    if raw.lower() == "major":
+        return MAJOR_DEFAULT_VOICES.copy()
+    return [voice.strip() for voice in raw.split(",") if voice.strip()]
+
+
+DEFAULT_VOICES = _configured_default_voices()
+DEFAULT_LOADED_VOICES = [
+    voice.strip()
+    for voice in os.getenv(
+        "PIPER_LOAD_VOICES",
+        "en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium",
+    ).split(",")
+    if voice.strip()
+]
+PIPER_PRELOAD_STRICT = os.getenv("PIPER_PRELOAD_STRICT", "true").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 # Map OpenAI voice names to Piper voice names for backward compatibility
 VOICE_ALIASES: dict[str, str] = {
@@ -52,6 +90,124 @@ VOICE_ALIASES: dict[str, str] = {
     "nova": "en_US-kristin-medium",
     "shimmer": "en_US-lessac-medium",
 }
+
+# Default Piper voice per ISO-639-1 language code. Used when the caller
+# does not pin a specific voice and we infer language from the input text.
+# All names match the rhasspy/piper-voices catalogue on HuggingFace.
+LANG_DEFAULT_VOICE: dict[str, str] = {
+    "en": "en_US-amy-medium",
+    "es": "es_ES-davefx-medium",
+    "fr": "fr_FR-siwis-medium",
+    "de": "de_DE-thorsten-medium",
+    "it": "it_IT-paola-medium",
+    "pt": "pt_BR-faber-medium",
+    "nl": "nl_NL-mls-medium",
+    "pl": "pl_PL-mc_speech-medium",
+    "ru": "ru_RU-irina-medium",
+    "uk": "uk_UA-ukrainian_tts-medium",
+    "zh": "zh_CN-huayan-medium",
+    # ja: rhasspy/piper-voices has no Japanese voice today; entries
+    # detected as 'ja' fall through to the English default fallback
+    # with a structured WARN (tts.lang_detection.unmapped). Followed
+    # up under TTS engine-swap research.
+    "ar": "ar_JO-kareem-medium",
+    "tr": "tr_TR-dfki-medium",
+    "ro": "ro_RO-mihai-medium",
+    "cs": "cs_CZ-jirka-medium",
+    "hu": "hu_HU-anna-medium",
+    "el": "el_GR-rapunzelina-low",
+    "fi": "fi_FI-harri-medium",
+    "da": "da_DK-talesyntese-medium",
+    "sv": "sv_SE-nst-medium",
+    "no": "no_NO-talesyntese-medium",
+    "ca": "ca_ES-upc_ona-medium",
+    "vi": "vi_VN-vais1000-medium",
+    "fa": "fa_IR-amir-medium",
+    "sk": "sk_SK-lili-medium",
+    "sl": "sl_SI-artur-medium",
+    "lv": "lv_LV-aivars-medium",
+    "sr": "sr_RS-serbski_institut-medium",
+    "hi": "hi_IN-pratham-medium",
+}
+
+# Local file paths are only constructed for the Piper voices this release
+# supports. This keeps `/v1/audio/speech` from turning arbitrary request
+# strings into filesystem paths while still covering aliases and auto-language
+# routing.
+SUPPORTED_PIPER_VOICES: dict[str, str] = {
+    voice_name: voice_name
+    for voice_name in sorted(
+        set(MAJOR_DEFAULT_VOICES)
+        | set(VOICE_ALIASES.values())
+        | set(LANG_DEFAULT_VOICE.values())
+    )
+}
+
+# Unicode-script → ISO-639-1 hint. Cheap pre-check before invoking
+# langdetect; for non-Latin scripts the script alone is enough to pick
+# a language with high confidence.
+_SCRIPT_RANGES: list[tuple[int, int, str]] = [
+    (0x0400, 0x04FF, "ru"),    # Cyrillic — overridden to "uk" if Ukrainian-only chars present (handled below)
+    (0x0500, 0x052F, "ru"),    # Cyrillic Supplement
+    (0x0590, 0x05FF, "he"),    # Hebrew (no voice today; falls through to en + WARN)
+    (0x0600, 0x06FF, "ar"),    # Arabic
+    (0x0750, 0x077F, "ar"),    # Arabic Supplement
+    (0x08A0, 0x08FF, "ar"),    # Arabic Extended-A
+    (0x0900, 0x097F, "hi"),    # Devanagari
+    (0x0E00, 0x0E7F, "th"),    # Thai (no voice today; falls through to en + WARN)
+    (0x0370, 0x03FF, "el"),    # Greek
+    (0x3040, 0x309F, "ja"),    # Hiragana
+    (0x30A0, 0x30FF, "ja"),    # Katakana
+    (0xAC00, 0xD7AF, "ko"),    # Hangul (no voice today; falls through to en + WARN)
+    (0x4E00, 0x9FFF, "zh"),    # CJK Unified Ideographs (defaults to zh; ja text without kana is ambiguous but rare)
+]
+
+
+def _detect_language(text: str) -> Optional[str]:
+    """Return ISO-639-1 lang code for `text`, or None if undetermined.
+
+    Strategy:
+      1. Pre-pass for Hiragana/Katakana — definitive Japanese marker even
+         when mixed with CJK Unified Ideographs (kanji).
+      2. Unicode-script heuristic for the first non-ASCII char.
+      3. Latin-script disambiguation via langdetect.
+    """
+    if not text:
+        return None
+
+    # 1. Whole-text scan: any kana → Japanese (kanji-only is ambiguous
+    # zh↔ja, defaults to zh below; with kana present the answer is
+    # unambiguous).
+    for ch in text:
+        cp = ord(ch)
+        if (0x3040 <= cp <= 0x309F) or (0x30A0 <= cp <= 0x30FF):
+            return "ja"
+        if (0xAC00 <= cp <= 0xD7AF):
+            # Hangul anywhere → Korean.
+            return "ko"
+
+    # 2. Script heuristic — first non-ASCII char drives the decision.
+    for ch in text:
+        cp = ord(ch)
+        if cp < 0x80:
+            continue
+        for lo, hi, lang in _SCRIPT_RANGES:
+            if lo <= cp <= hi:
+                return lang
+        # First non-ASCII char isn't a tracked script; fall through to langdetect.
+        break
+
+    # 3. langdetect for Latin-script text (en/es/fr/de/it/pt/nl/...).
+    try:
+        from langdetect import detect, DetectorFactory
+        DetectorFactory.seed = 0  # deterministic — same text → same result
+        return detect(text)
+    except Exception as exc:
+        # langdetect raises LangDetectException on inputs too short / no
+        # detectable features. Surface a structured signal instead of
+        # silently swallowing — caller logs `tts.lang_detection.failed`.
+        logger.debug("[TTS] langdetect failed on text len=%d: %s", len(text), exc)
+        return None
 
 # ---------------------------------------------------------------------------
 # Audio resampling (linear interpolation — lightweight, no scipy needed)
@@ -75,34 +231,110 @@ def _resample_int16(pcm_int16: bytes, src_rate: int, dst_rate: int) -> bytes:
 # ---------------------------------------------------------------------------
 
 _loaded_voices: dict[str, "PiperVoice"] = {}  # type: ignore[name-defined]
+def _voice_model_paths(voice_name: str) -> tuple[Path, Path]:
+    """Return safe local Piper model paths for a validated catalogue voice."""
+    voice_file_stem = SUPPORTED_PIPER_VOICES.get(voice_name)
+    if voice_file_stem is None:
+        raise HTTPException(status_code=400, detail=f"Unsupported voice name: {voice_name!r}")
+
+    voices_root = VOICES_DIR.resolve()
+    model_path = (voices_root / f"{voice_file_stem}.onnx").resolve()
+    config_path = (voices_root / f"{voice_file_stem}.onnx.json").resolve()
+    try:
+        model_path.relative_to(voices_root)
+        config_path.relative_to(voices_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid voice path: {voice_name!r}") from exc
+
+    return model_path, config_path
 
 
-def _resolve_voice_name(name: str) -> str:
-    """Resolve an alias (e.g. 'alloy') or pass through a Piper voice name."""
-    return VOICE_ALIASES.get(name, name)
+def _download_voice_model(voice_name: str) -> None:
+    """Ensure a Piper voice model exists locally without loading it into RAM."""
+    from piper.download_voices import download_voice
+
+    model_path, config_path = _voice_model_paths(voice_name)
+
+    if model_path.exists() and config_path.exists():
+        return
+
+    logger.info("[TTS] Downloading voice: %s -> %s", voice_name, VOICES_DIR)
+    try:
+        download_voice(voice_name, VOICES_DIR)
+    except Exception as exc:
+        logger.error("[TTS] Failed to download voice %s: %s", voice_name, exc)
+        raise HTTPException(
+            status_code=404,
+            detail=f"Voice '{voice_name}' not found and could not be downloaded: {exc}",
+        ) from exc
+
+
+def _resolve_voice_name(name: str, *, text: str = "") -> str:
+    """Resolve a voice request to a Piper voice name.
+
+    Resolution order:
+      1. `auto` (or empty) → detect language of `text`, look up
+         LANG_DEFAULT_VOICE; if no mapping, log a structured WARN
+         (`tts.lang_detection.unmapped`) and use English default.
+      2. Known OpenAI-style alias (alloy / nova / echo / …):
+         a. If the input text is Latin-script-only (no Cyrillic, CJK,
+            Arabic, etc.), use the alias's English Piper voice as the
+            historical default.
+         b. If the text has a non-Latin script, the alias would route
+            English espeak-ng over non-Latin codepoints and emit
+            letter-by-letter spelling. Detect language from text and
+            override the alias with the detected language's voice. Log
+            a structured INFO (`tts.alias_overridden_by_language`) so
+            the override is observable.
+         c. Honors backward-compat for English-only callers; protects
+            every other caller from the "speaking-letter-by-letter"
+            failure mode.
+      3. Anything else → pass through as a literal Piper voice name.
+    """
+    if name in (None, "", "auto"):
+        lang = _detect_language(text)
+        if lang and lang in LANG_DEFAULT_VOICE:
+            chosen = LANG_DEFAULT_VOICE[lang]
+            logger.info("[TTS] auto-lang detected=%s voice=%s text_len=%d", lang, chosen, len(text))
+            return chosen
+        logger.warning(
+            "[TTS] tts.lang_detection.unmapped detected=%s text_len=%d "
+            "— falling back to English default (#NEW-tts-lang-fallback)",
+            lang, len(text),
+        )
+        return LANG_DEFAULT_VOICE["en"]
+
+    if name in VOICE_ALIASES:
+        # Alias = backward-compat OpenAI voice name. They all map to
+        # English Piper voices. If the text is non-Latin, English voice
+        # would mispronounce letter-by-letter — override.
+        has_non_latin = any(ord(ch) >= 0x80 for ch in text)
+        if has_non_latin:
+            lang = _detect_language(text)
+            if lang and lang != "en" and lang in LANG_DEFAULT_VOICE:
+                chosen = LANG_DEFAULT_VOICE[lang]
+                logger.info(
+                    "[TTS] tts.alias_overridden_by_language alias=%s detected=%s "
+                    "voice=%s text_len=%d — alias would emit letter-by-letter on "
+                    "non-Latin input",
+                    name, lang, chosen, len(text),
+                )
+                return chosen
+        return VOICE_ALIASES[name]
+
+    # Pass-through literal Piper voice name (e.g. en_US-amy-medium).
+    return name
 
 
 def _ensure_voice(voice_name: str) -> "PiperVoice":  # type: ignore[name-defined]
     """Return a loaded PiperVoice, downloading the model if needed."""
     from piper import PiperVoice
-    from piper.download_voices import download_voice
 
     if voice_name in _loaded_voices:
         return _loaded_voices[voice_name]
 
-    model_path = VOICES_DIR / f"{voice_name}.onnx"
-    config_path = VOICES_DIR / f"{voice_name}.onnx.json"
-
-    if not model_path.exists() or not config_path.exists():
-        logger.info("[TTS] Downloading voice: %s -> %s", voice_name, VOICES_DIR)
-        try:
-            download_voice(voice_name, VOICES_DIR)
-        except Exception as exc:
-            logger.error("[TTS] Failed to download voice %s: %s", voice_name, exc)
-            raise HTTPException(
-                status_code=404,
-                detail=f"Voice '{voice_name}' not found and could not be downloaded: {exc}",
-            ) from exc
+    model_path, config_path = _voice_model_paths(voice_name)
+    _download_voice_model(voice_name)
 
     logger.info("[TTS] Loading voice: %s", voice_name)
     voice = PiperVoice.load(str(model_path), str(config_path))
@@ -124,14 +356,20 @@ def _ensure_voice(voice_name: str) -> "PiperVoice":  # type: ignore[name-defined
 async def lifespan(app: FastAPI):
     VOICES_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Pre-load default voices at startup
+    # Prepare default voices at startup. Release deployments should fail
+    # readiness when a promised voice model cannot be made local; only a small
+    # hot subset is loaded into RAM to keep Helm memory predictable.
     for v in DEFAULT_VOICES:
         v = v.strip()
         if v:
             try:
-                _ensure_voice(v)
+                _download_voice_model(v)
+                if v in DEFAULT_LOADED_VOICES:
+                    _ensure_voice(v)
             except Exception:
-                logger.warning("[TTS] Could not pre-load voice: %s", v, exc_info=True)
+                logger.warning("[TTS] Could not prepare voice: %s", v, exc_info=True)
+                if PIPER_PRELOAD_STRICT:
+                    raise
 
     yield
 
@@ -174,6 +412,14 @@ async def health():
         "service": "tts-service",
         "provider": "piper",
         "output_sample_rate": OUTPUT_SAMPLE_RATE,
+        "configured_default_voices": DEFAULT_VOICES,
+        "default_loaded_voices": DEFAULT_LOADED_VOICES,
+        "preload_strict": PIPER_PRELOAD_STRICT,
+        "prepared_voices": sorted(
+            p.name[:-5]
+            for p in VOICES_DIR.glob("*.onnx")
+            if not p.name.endswith(".onnx.json")
+        ),
         "loaded_voices": list(_loaded_voices.keys()),
         "voice_aliases": VOICE_ALIASES,
     }
@@ -226,10 +472,10 @@ async def speech(
     if not text.strip():
         raise HTTPException(status_code=400, detail="'input' text is empty")
 
-    voice_name = _resolve_voice_name(voice_param)
+    voice_name = _resolve_voice_name(voice_param, text=text)
 
     logger.info(
-        "[TTS] Synthesizing: voice=%s (%s), format=%s, len=%d",
+        "[TTS] Synthesizing: voice_param=%s resolved=%s format=%s len=%d",
         voice_param,
         voice_name,
         response_format,
@@ -265,6 +511,8 @@ async def speech(
                     "X-Sample-Rate": str(dst_rate),
                     "X-Sample-Width": "2",
                     "X-Channels": "1",
+                    "X-Vexa-TTS-Voice": voice_name,
+                    "X-Vexa-TTS-Voice-Param": str(voice_param),
                 },
             )
         else:
@@ -290,6 +538,8 @@ async def speech(
                 headers={
                     "Content-Disposition": "inline; filename=speech.wav",
                     "Content-Length": str(len(wav_bytes)),
+                    "X-Vexa-TTS-Voice": voice_name,
+                    "X-Vexa-TTS-Voice-Param": str(voice_param),
                 },
             )
     except Exception as exc:

--- a/services/tts-service/tests/test_validation.py
+++ b/services/tts-service/tests/test_validation.py
@@ -25,6 +25,57 @@ class TestHealthEndpoint:
         data = resp.json()
         assert data["status"] == "ok"
         assert data["service"] == "tts-service"
+        assert data["provider"] == "piper"
+        assert data["preload_strict"] is True
+        assert "pt_BR-faber-medium" in data["configured_default_voices"]
+        assert "hi_IN-pratham-medium" in data["configured_default_voices"]
+        assert "pt_BR-faber-medium" in data["default_loaded_voices"]
+        assert "prepared_voices" in data
+
+
+class TestDefaultVoiceConfiguration:
+    def test_major_alias_expands_supported_release_voices(self, monkeypatch):
+        import main
+
+        monkeypatch.setenv("PIPER_DEFAULT_VOICES", "major")
+
+        voices = main._configured_default_voices()
+
+        assert "en_US-amy-medium" in voices
+        assert "pt_BR-faber-medium" in voices
+        assert "es_ES-davefx-medium" in voices
+        assert "hi_IN-pratham-medium" in voices
+
+    def test_explicit_voice_list_is_preserved(self, monkeypatch):
+        import main
+
+        monkeypatch.setenv("PIPER_DEFAULT_VOICES", "en_US-amy-medium, pt_BR-faber-medium")
+
+        assert main._configured_default_voices() == [
+            "en_US-amy-medium",
+            "pt_BR-faber-medium",
+        ]
+
+
+class TestAutoLanguageVoiceResolution:
+    def test_portuguese_release_phrase_resolves_to_portuguese_voice_when_langdetect_available(self):
+        pytest.importorskip("langdetect")
+        import main
+
+        text = "Olá, esta é uma validação de fala em português da Vexa."
+
+        assert main._detect_language(text) == "pt"
+        assert main._resolve_voice_name("auto", text=text) == "pt_BR-faber-medium"
+
+
+class TestVoicePathValidation:
+    def test_rejects_path_traversal_voice_name(self):
+        import main
+
+        with pytest.raises(main.HTTPException) as exc:
+            main._voice_model_paths("../secret")
+
+        assert exc.value.status_code == 400
 
 
 class TestVoiceValidation:
@@ -80,22 +131,6 @@ class TestSpeechEndpointValidation:
             headers={"Content-Type": "application/json"},
         )
         assert resp.status_code == 400
-
-    def test_no_openai_key_returns_503(self):
-        """When OPENAI_API_KEY is empty, should return 503."""
-        import main
-        original = main.OPENAI_API_KEY
-        main.OPENAI_API_KEY = ""
-        try:
-            c = TestClient(app)
-            resp = c.post(
-                "/v1/audio/speech",
-                json={"model": "tts-1", "input": "hello", "voice": "alloy"},
-            )
-            assert resp.status_code == 503
-            assert "OPENAI_API_KEY" in resp.json()["detail"]
-        finally:
-            main.OPENAI_API_KEY = original
 
 
 class TestApiKeyAuth:

--- a/tests3/checks/run
+++ b/tests3/checks/run
@@ -22,16 +22,34 @@ import re
 import subprocess
 import sys
 import time
+from urllib.parse import urlparse
 
 ROOT = os.environ.get("ROOT", subprocess.check_output(
     ["git", "rev-parse", "--show-toplevel"], text=True).strip())
 STATE = os.environ.get("STATE", os.path.join(ROOT, "tests3", ".state"))
 REGISTRY = os.path.join(ROOT, "tests3", "checks", "registry.json")
+TEST_ACCOUNT_ENV = os.path.join(ROOT, "tests3", "lib", "test-account.env")
 
 os.makedirs(STATE, exist_ok=True)
 
 
 LOG_FILE = os.path.join(STATE, "tests3.log")
+
+def load_test_account_contract():
+    values = {
+        "TEST_ACCOUNT_EMAIL": "test@vexa.ai",
+        "TEST_ACCOUNT_NAME": "Test User",
+        "TEST_ACCOUNT_MAX_CONCURRENT_BOTS": "3",
+    }
+    if os.path.isfile(TEST_ACCOUNT_ENV):
+        with open(TEST_ACCOUNT_ENV) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                values[key] = value
+    return values
 
 def red(s):   return f"\033[31m{s}\033[0m"
 def green(s): return f"\033[32m{s}\033[0m"
@@ -103,6 +121,24 @@ def kubectl_available():
 
 def http_check(url, expect_code=200, headers=None):
     """Curl a URL. Returns (actual_code, body)."""
+    mode = state_read("deploy_mode")
+    if mode == "lite":
+        admin_url = state_read("admin_url")
+        admin_path = url[len(admin_url):] if admin_url and url.startswith(admin_url) else ""
+        if admin_url and url.startswith(admin_url) and admin_path.startswith("/admin"):
+            internal_url = "http://127.0.0.1:8057" + url[len(admin_url):]
+            cmd = ["docker", "exec", "vexa-lite", "curl", "-sf", "-w", "\n%{http_code}", "-o", "-"]
+            for h in (headers or []):
+                cmd += ["-H", h]
+            cmd.append(internal_url)
+            try:
+                r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                lines = r.stdout.strip().rsplit("\n", 1)
+                body = lines[0] if len(lines) > 1 else ""
+                code = int(lines[-1]) if lines[-1].isdigit() else 0
+                return code, body
+            except Exception as e:
+                return 0, str(e)
     cmd = ["curl", "-sf", "-w", "\n%{http_code}", "-o", "-"]
     for h in (headers or []):
         cmd += ["-H", h]
@@ -115,6 +151,17 @@ def http_check(url, expect_code=200, headers=None):
         return code, body
     except Exception as e:
         return 0, str(e)
+
+
+def host_reachable_url(url):
+    """Map Docker-internal local service names to their host-published ports."""
+    mode = state_read("deploy_mode")
+    if mode in ("compose", "lite"):
+        for host in ("transcription-lb", "transcription-api"):
+            prefix = f"http://{host}/"
+            if url.startswith(prefix):
+                return "http://localhost:8085/" + url[len(prefix):]
+    return url
 
 
 # ─── Static method helpers (260419-oss-security) ─────────────────
@@ -348,23 +395,22 @@ def check_health(lock):
 
     url = lock["url"]
 
-    # Special: Transcription health — derive URL from .env or container env
+    # Special: Transcription health — derive URL from the running deployment first.
     if url == "TRANSCRIPTION_HEALTH":
         env_file = os.path.join(ROOT, ".env")
         tx_url = ""
-        if os.path.isfile(env_file):
+        code, val = svc_exec("meeting-api", ["printenv", "TRANSCRIPTION_SERVICE_URL"])
+        if code == 0 and val:
+            tx_url = val
+        if not tx_url and os.path.isfile(env_file):
             for line in open(env_file):
                 if line.startswith("TRANSCRIPTION_SERVICE_URL="):
                     tx_url = line.strip().split("=", 1)[1]
         if not tx_url:
-            # Try reading from meeting-api container
-            code, val = svc_exec("meeting-api", ["printenv", "TRANSCRIPTION_SERVICE_URL"])
-            if code == 0 and val:
-                tx_url = val
-        if not tx_url:
             return True, "no transcription URL configured — skipped"
         # Replace /v1/audio/transcriptions with /health
         health_url = tx_url.rsplit("/v1/", 1)[0] + "/health" if "/v1/" in tx_url else tx_url + "/health"
+        health_url = host_reachable_url(health_url)
         code, body = http_check(health_url)
         if code == 200:
             return True, ""
@@ -485,12 +531,23 @@ def check_health(lock):
                 capture_output=True, text=True, timeout=10,
             )
             rc, out = r3.returncode, (r3.stdout or "").strip()
+        elif mode == "lite":
+            r = subprocess.run(
+                ["docker", "exec", "vexa-lite-postgres",
+                 "psql", "-U", "postgres", "-tAc",
+                 "SELECT datname FROM pg_database WHERE datname LIKE 'readme%' OR datname LIKE '%recover%'"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if r.returncode == 0:
+                rc, out = r.returncode, (r.stdout or "").strip()
+            else:
+                # Canonical lite can also run Postgres inside the all-in-one container.
+                rc, out = svc_exec("vexa-lite", [
+                    "psql", "-h", "localhost", "-U", "postgres", "-tAc",
+                    "SELECT datname FROM pg_database WHERE datname LIKE 'readme%' OR datname LIKE '%recover%'"
+                ])
         else:
-            # On lite, postgres runs inside the single vexa-lite container.
-            # -h localhost forces TCP (lite Postgres binds TCP, not the default
-            # unix socket path; plain `psql` fails on the lite container).
-            pg_svc = "postgres" if mode == "compose" else "vexa-lite"
-            rc, out = svc_exec(pg_svc, [
+            rc, out = svc_exec("postgres", [
                 "psql", "-h", "localhost", "-U", "postgres", "-tAc",
                 "SELECT datname FROM pg_database WHERE datname LIKE 'readme%' OR datname LIKE '%recover%'"
             ])
@@ -541,10 +598,19 @@ def check_health(lock):
     if url == "MINIO_HEALTH":
         mode = state_read("deploy_mode", required=True)
         if mode == "compose":
-            code, body = http_check("http://localhost:9000/minio/health/live")
+            env_path = os.path.join(ROOT, "deploy", "compose", ".env")
+            port = os.environ.get("MINIO_HOST_PORT", "")
+            if not port and os.path.isfile(env_path):
+                with open(env_path) as f:
+                    for line in f:
+                        if line.startswith("MINIO_HOST_PORT="):
+                            port = line.strip().split("=", 1)[1]
+                            break
+            port = port or "9000"
+            code, body = http_check(f"http://localhost:{port}/minio/health/live")
             if code == 200:
                 return True, ""
-            return False, f"HTTP {code} from localhost:9000"
+            return False, f"HTTP {code} from localhost:{port}"
         elif mode == "helm":
             if not kubectl_available():
                 return True, "skipped (no kubectl access)"
@@ -694,6 +760,15 @@ def check_health(lock):
         for h in internal_hosts:
             if h in ws_url:
                 return False, f"wsUrl contains internal hostname '{h}': {ws_url}"
+        dash_host = urlparse(dash).hostname or ""
+        ws_host = urlparse(ws_url).hostname or ""
+        loopback_hosts = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+        if ws_host in loopback_hosts and dash_host not in loopback_hosts:
+            return False, f"wsUrl contains loopback host for remote dashboard {dash_host}: {ws_url}"
+        auth_token = state_read("api_token") or json.loads(body).get("authToken", "")
+        ok, detail = check_ws_ping_url(ws_url, auth_token)
+        if not ok:
+            return False, f"wsUrl is not connectable: {ws_url} ({detail})"
         return True, ws_url
 
     url = url.replace("$GATEWAY_URL", state_read("gateway_url", required=True))
@@ -885,6 +960,11 @@ def check_browser_session_cdp(gw, token):
 
         session_data = json.loads(body)
         session_token = session_data.get("data", {}).get("session_token", "")
+        if session_token == "[REDACTED]":
+            # Public meeting responses redact JSONB secrets. The gateway also
+            # indexes browser sessions by meeting id, which is the non-secret
+            # token clients can use when the raw session token is redacted.
+            session_token = str(session_data.get("id") or "")
         native_id = session_data.get("native_meeting_id", "")
     except Exception as e:
         return False, f"session creation error: {e}"
@@ -896,18 +976,26 @@ def check_browser_session_cdp(gw, token):
     # once after pod ready, once immediately after to catch IP resolution races
     time.sleep(20)
 
-    # Hit CDP proxy
-    try:
-        r = subprocess.run(
-            ["curl", "-sL", "-w", "\n%{http_code}",
-             f"{gw}/b/{session_token}/cdp/json/version"],
-            capture_output=True, text=True, timeout=15)
-        lines = r.stdout.strip().rsplit("\n", 1)
-        cdp_code = int(lines[-1]) if lines[-1].isdigit() else 0
-        cdp_body = lines[0] if len(lines) > 1 else ""
-    except Exception as e:
-        cdp_code = 0
-        cdp_body = str(e)
+    # Hit CDP proxy. K8s pod IP can appear a few seconds after the browser
+    # session row is created; retry so we validate dynamic IP resolution
+    # instead of racing pod scheduling.
+    cdp_code = 0
+    cdp_body = ""
+    for _attempt in range(6):
+        try:
+            r = subprocess.run(
+                ["curl", "-sL", "-w", "\n%{http_code}",
+                 f"{gw}/b/{session_token}/cdp/json/version"],
+                capture_output=True, text=True, timeout=15)
+            lines = r.stdout.strip().rsplit("\n", 1)
+            cdp_code = int(lines[-1]) if lines[-1].isdigit() else 0
+            cdp_body = lines[0] if len(lines) > 1 else ""
+        except Exception as e:
+            cdp_code = 0
+            cdp_body = str(e)
+        if cdp_code == 200 and "webSocketDebuggerUrl" in cdp_body:
+            break
+        time.sleep(10)
 
     # Clean up — wait for container to fully stop before next check
     subprocess.run(
@@ -1136,9 +1224,9 @@ def check_bot_status_transitions(gw, token):
     except Exception as e:
         return False, f"bot creation error: {e}"
 
-    # Poll for status transition (max 30s)
+    # Poll for status transition (max 60s)
     final_status = "requested"
-    for i in range(6):
+    for i in range(12):
         time.sleep(5)
         try:
             r = subprocess.run(
@@ -1149,6 +1237,20 @@ def check_bot_status_transitions(gw, token):
                 if b.get("native_meeting_id") == native_id:
                     final_status = b.get("data", {}).get("meeting_status") or b.get("meeting_status", "requested")
                     break
+            if final_status == "requested":
+                # Fast-fail synthetic bots can leave the runtime list before
+                # the poll observes a running state. Also, runtime status can
+                # lag the meeting row. Fall back to the meeting row; any
+                # non-requested status proves callbacks/status persistence
+                # moved the row out of requested.
+                mr = subprocess.run(
+                    ["curl", "-sf", "-H", f"X-API-Key: {token}", f"{gw}/meetings?limit=50"],
+                    capture_output=True, text=True, timeout=10)
+                meetings = json.loads(mr.stdout).get("meetings", [])
+                for m in meetings:
+                    if m.get("native_meeting_id") == native_id:
+                        final_status = m.get("status") or final_status
+                        break
         except Exception:
             pass
         if final_status != "requested":
@@ -1170,20 +1272,20 @@ def check_transcription_token():
     env_file = os.path.join(ROOT, ".env")
     tx_url = ""
     tx_token = ""
-    if os.path.isfile(env_file):
-        for line in open(env_file):
-            if line.startswith("TRANSCRIPTION_SERVICE_URL="):
-                tx_url = line.strip().split("=", 1)[1]
-            if line.startswith("TRANSCRIPTION_SERVICE_TOKEN="):
-                tx_token = line.strip().split("=", 1)[1]
+    code, val = svc_exec("meeting-api", ["printenv", "TRANSCRIPTION_SERVICE_URL"])
+    if code == 0 and val:
+        tx_url = val
+    code, val = svc_exec("meeting-api", ["printenv", "TRANSCRIPTION_SERVICE_TOKEN"])
+    if code == 0 and val:
+        tx_token = val
+
     if not tx_url:
-        # Try from container
-        code, val = svc_exec("meeting-api", ["printenv", "TRANSCRIPTION_SERVICE_URL"])
-        if code == 0 and val:
-            tx_url = val
-        code, val = svc_exec("meeting-api", ["printenv", "TRANSCRIPTION_SERVICE_TOKEN"])
-        if code == 0 and val:
-            tx_token = val
+        if os.path.isfile(env_file):
+            for line in open(env_file):
+                if line.startswith("TRANSCRIPTION_SERVICE_URL="):
+                    tx_url = line.strip().split("=", 1)[1]
+                if line.startswith("TRANSCRIPTION_SERVICE_TOKEN="):
+                    tx_token = line.strip().split("=", 1)[1]
     if not tx_url:
         return True, "no transcription URL configured — skipped"
 
@@ -1192,18 +1294,25 @@ def check_transcription_token():
         return False, f"test audio not found: {test_audio} — copy from services/transcription-service/tests/test_audio.wav"
 
     try:
-        r = subprocess.run(
-            ["curl", "-s", "-w", "\n%{http_code}", "-X", "POST", tx_url,
-             "-H", f"Authorization: Bearer {tx_token}",
-             "-F", f"file=@{test_audio}", "-F", "language=en", "-F", "model=large-v3-turbo"],
-            capture_output=True, text=True, timeout=30)
-        lines = r.stdout.strip().rsplit("\n", 1)
-        code = int(lines[-1]) if lines[-1].isdigit() else 0
-        if code == 200:
-            return True, ""
-        if code == 403:
-            return False, "token rejected (403) — expired or invalid"
-        return False, f"HTTP {code}"
+        tx_url = host_reachable_url(tx_url)
+        last_code = 0
+        for attempt in range(1, 4):
+            r = subprocess.run(
+                ["curl", "-s", "-w", "\n%{http_code}", "-X", "POST", tx_url,
+                 "-H", f"Authorization: Bearer {tx_token}",
+                 "-F", f"file=@{test_audio}", "-F", "language=en", "-F", "model=large-v3-turbo"],
+                capture_output=True, text=True, timeout=45)
+            lines = r.stdout.strip().rsplit("\n", 1)
+            code = int(lines[-1]) if lines[-1].isdigit() else 0
+            last_code = code
+            if code == 200:
+                return True, f"HTTP 200 on attempt {attempt}"
+            if code == 403:
+                return False, "token rejected (403) — expired or invalid"
+            if code != 503:
+                break
+            time.sleep(2 * attempt)
+        return False, f"HTTP {last_code}"
     except Exception as e:
         return False, str(e)
 
@@ -1217,10 +1326,10 @@ def _check_internal_transcript_auth():
     Uses python3 (available in every Vexa Python image) rather than curl
     (not installed in api-gateway).
     """
-    url = "http://meeting-api:8080/internal/transcripts/1"
     probe = (
-        "import urllib.request, urllib.error, sys\n"
-        f"req = urllib.request.Request({url!r})\n"
+        "import os, urllib.request, urllib.error, sys\n"
+        "base = os.getenv('MEETING_API_URL', 'http://meeting-api:8080').rstrip('/')\n"
+        "req = urllib.request.Request(base + '/internal/transcripts/1')\n"
         "try:\n"
         "    urllib.request.urlopen(req, timeout=5)\n"
         "    print('200')\n"
@@ -1290,28 +1399,33 @@ def check_cors_preflight(gw):
     return True, ""
 
 
-def check_ws_ping(gw, token):
-    """WebSocket ping/pong check. Tries websockets module, falls back to HTTP upgrade check."""
-    ws_url = gw.replace("http://", "ws://").replace("https://", "wss://")
-    ws_url = f"{ws_url}/ws?api_key={token}"
+def check_ws_ping_url(ws_url, token=""):
+    """WebSocket ping/pong check for a fully resolved browser URL."""
+    if token and "api_key=" not in ws_url:
+        separator = "&" if "?" in ws_url else "?"
+        ws_url = f"{ws_url}{separator}api_key={token}"
     try:
         r = subprocess.run(
-            ["python3", "-c", f"""
-import asyncio, json
+            ["python3", "-c", """
+import asyncio, json, sys
+ws_url = sys.argv[1]
 try:
     import websockets
     async def t():
-        async with websockets.connect('{ws_url}') as ws:
-            await ws.send(json.dumps({{"action":"ping"}}))
+        async with websockets.connect(ws_url) as ws:
+            await ws.send(json.dumps({"action":"ping"}))
             msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
             if msg.get('type') == 'pong': print('OK')
             else: print('BAD:' + json.dumps(msg))
-    asyncio.run(t())
+    try:
+        asyncio.run(t())
+    except Exception as e:
+        print('FAIL:' + type(e).__name__ + ':' + str(e))
 except ImportError:
     # Fallback: check WS endpoint responds to HTTP upgrade
     import urllib.request
-    url = '{gw}/ws?api_key={token}'
-    req = urllib.request.Request(url, headers={{'Upgrade': 'websocket', 'Connection': 'Upgrade', 'Sec-WebSocket-Version': '13', 'Sec-WebSocket-Key': 'dGVzdA=='}})
+    url = ws_url.replace('ws://', 'http://', 1).replace('wss://', 'https://', 1)
+    req = urllib.request.Request(url, headers={'Upgrade': 'websocket', 'Connection': 'Upgrade', 'Sec-WebSocket-Version': '13', 'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ=='})
     try:
         urllib.request.urlopen(req, timeout=5)
     except urllib.error.HTTPError as e:
@@ -1320,7 +1434,7 @@ except ImportError:
     except Exception as e:
         if '101' in str(e) or 'Switching' in str(e): print('OK')
         else: print('FAIL:' + str(e))
-"""],
+""", ws_url],
             capture_output=True, text=True, timeout=10
         )
         if "OK" in r.stdout:
@@ -1330,18 +1444,32 @@ except ImportError:
         return False, str(e)
 
 
+def check_ws_ping(gw, token):
+    """WebSocket ping/pong check."""
+    ws_url = gw.replace("http://", "ws://").replace("https://", "wss://")  # nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
+    return check_ws_ping_url(f"{ws_url}/ws", token)
+
+
 def bootstrap_creds():
     """Ensure admin_token and api_token exist in .state for contract checks.
-    Re-bootstraps if the cached admin_token doesn't validate (stale from a different deploy)."""
+
+    Re-bootstrap if either cached token is stale for the current deployment.
+    This matters when lite and compose are both running: an admin token can be
+    valid on the new target while the cached user API token still belongs to
+    the previous target and makes every user-level check fail with 401.
+    """
     admin_token = state_read("admin_token")
     api_token = state_read("api_token")
 
-    # Quick validation: if we have both, check admin token still works
+    # Quick validation: if we have both, check both tokens still work.
     if admin_token and api_token:
         admin_url = state_read("admin_url", required=True)
+        gw = state_read("gateway_url", required=True)
         code, _ = http_check(f"{admin_url}/admin/users?limit=1",
                              headers=[f"X-Admin-API-Key: {admin_token}"])
-        if code == 200:
+        api_code, _ = http_check(f"{gw}/bots/status",
+                                 headers=[f"X-API-Key: {api_token}"])
+        if code == 200 and api_code == 200:
             return  # both valid
         # Stale — clear and re-bootstrap
         for f in ("admin_token", "api_token"):
@@ -1363,10 +1491,14 @@ def bootstrap_creds():
 
     admin_url = state_read("admin_url", required=True)
     gw = state_read("gateway_url", required=True)
+    test_account = load_test_account_contract()
+    test_email = test_account["TEST_ACCOUNT_EMAIL"]
+    test_name = test_account["TEST_ACCOUNT_NAME"]
+    test_limit = int(test_account["TEST_ACCOUNT_MAX_CONCURRENT_BOTS"])
 
     # Find or create test user
     code, body = http_check(
-        f"{admin_url}/admin/users/email/test@vexa.ai",
+        f"{admin_url}/admin/users/email/{test_email}",
         headers=[f"X-Admin-API-Key: {admin_token}"])
     if code == 200:
         try:
@@ -1378,7 +1510,7 @@ def bootstrap_creds():
         cmd = ["curl", "-sf", "-X", "POST",
                "-H", f"X-Admin-API-Key: {admin_token}",
                "-H", "Content-Type: application/json",
-               "-d", '{"email":"test@vexa.ai","name":"Test User","max_concurrent_bots":3}',
+               "-d", json.dumps({"email": test_email, "name": test_name, "max_concurrent_bots": test_limit}),
                f"{admin_url}/admin/users"]
         try:
             r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
@@ -1386,13 +1518,13 @@ def bootstrap_creds():
         except Exception:
             return
 
-    # Ensure max_concurrent_bots >= 3 (tests create multiple bots in parallel —
-    # webhook-test + spoof-test etc). Safe to re-patch even on existing users.
+    # Ensure existing users match tests3/lib/test-account.env. Safe to re-patch
+    # even on existing users; human-gate dispatches run parallel bots.
     subprocess.run([
         "curl", "-sf", "-X", "PATCH",
         "-H", f"X-Admin-API-Key: {admin_token}",
         "-H", "Content-Type: application/json",
-        "-d", '{"max_concurrent_bots":3}',
+        "-d", json.dumps({"max_concurrent_bots": test_limit}),
         f"{admin_url}/admin/users/{user_id}"
     ], capture_output=True, text=True, timeout=10)
 

--- a/tests3/lib/common.sh
+++ b/tests3/lib/common.sh
@@ -69,7 +69,13 @@ _now_iso() {
 }
 
 _detect_mode_cached() {
-    cat "$STATE/deploy_mode" 2>/dev/null || detect_mode
+    local cached
+    cached="$(cat "$STATE/deploy_mode" 2>/dev/null || true)"
+    if [ -n "$cached" ] && [ "$cached" != "none" ]; then
+        echo "$cached"
+        return
+    fi
+    detect_mode
 }
 
 test_begin() {
@@ -199,9 +205,15 @@ detect_urls() {
             : "${DASHBOARD_URL:=http://localhost:3001}"
             ;;
         lite)
-            : "${GATEWAY_URL:=http://localhost:8056}"
-            : "${ADMIN_URL:=http://localhost:8057}"
-            : "${DASHBOARD_URL:=http://localhost:3000}"
+            local lite_container gateway_port dashboard_port
+            lite_container="$(_lite_container 2>/dev/null || true)"
+            if [ -n "$lite_container" ]; then
+                gateway_port="$(docker port "$lite_container" 8056/tcp 2>/dev/null | sed -E 's/.*:([0-9]+)$/\1/' | head -1 || true)"
+                dashboard_port="$(docker port "$lite_container" 3000/tcp 2>/dev/null | sed -E 's/.*:([0-9]+)$/\1/' | head -1 || true)"
+            fi
+            : "${GATEWAY_URL:=http://localhost:${gateway_port:-8056}}"
+            : "${ADMIN_URL:=$GATEWAY_URL}"
+            : "${DASHBOARD_URL:=http://localhost:${dashboard_port:-3000}}"
             ;;
         helm)
             # Read from state if not set via env

--- a/tests3/lib/reset/redeploy-compose.sh
+++ b/tests3/lib/reset/redeploy-compose.sh
@@ -14,12 +14,23 @@ git fetch origin "${VM_BRANCH}"
 git reset --hard "origin/${VM_BRANCH}"
 cd deploy/compose
 
-# Some deployments store IMAGE_TAG in /root/.env, others in /root/vexa/.env
 ENV_FILE="/root/vexa/.env"
-[ -f /root/.env ] && ENV_FILE="/root/.env"
 
 echo "  [redeploy-compose] using env: $ENV_FILE"
+if [ -n "${VM_IMAGE_TAG:-}" ]; then
+    for f in "$ENV_FILE" /root/.env; do
+        [ -f "$f" ] || continue
+        sed -i "s|^#*IMAGE_TAG=.*|IMAGE_TAG=${VM_IMAGE_TAG}|" "$f"
+        sed -i "s|^#*BROWSER_IMAGE=.*|BROWSER_IMAGE=vexaai/vexa-bot:${VM_IMAGE_TAG}|" "$f"
+    done
+    echo "  [redeploy-compose] pinned IMAGE_TAG=${VM_IMAGE_TAG}"
+fi
 docker compose --env-file "$ENV_FILE" pull 2>&1 | tail -5
+BOT_IMAGE="$(grep -E '^BROWSER_IMAGE=' "$ENV_FILE" 2>/dev/null | cut -d= -f2-)"
+if [ -n "$BOT_IMAGE" ]; then
+    echo "  [redeploy-compose] pulling runtime bot image: $BOT_IMAGE"
+    docker pull "$BOT_IMAGE" 2>&1 | tail -3
+fi
 docker compose --env-file "$ENV_FILE" up -d --force-recreate 2>&1 | tail -5
 
 # v0.10.5 R3 follow-up (#272 iter-5): re-validate dashboard's VEXA_API_KEY
@@ -40,3 +51,4 @@ for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 2
 done
 make setup-api-key 2>&1 | tail -3 || echo "  [redeploy-compose] setup-api-key reported non-zero; continuing"
+docker compose --env-file "$ENV_FILE" up -d --force-recreate dashboard 2>&1 | tail -5 || true

--- a/tests3/lib/reset/redeploy-lite.sh
+++ b/tests3/lib/reset/redeploy-lite.sh
@@ -12,7 +12,19 @@ cd /root/vexa
 git fetch origin "${VM_BRANCH}"
 git reset --hard "origin/${VM_BRANCH}"
 
-docker pull vexaai/vexa-lite:dev 2>&1 | tail -3
+ENV_FILE="/root/vexa/.env"
+if [ -n "${VM_IMAGE_TAG:-}" ]; then
+    for f in "$ENV_FILE" /root/.env; do
+        [ -f "$f" ] || continue
+        sed -i "s|^#*IMAGE_TAG=.*|IMAGE_TAG=${VM_IMAGE_TAG}|" "$f"
+        sed -i "s|^#*BROWSER_IMAGE=.*|BROWSER_IMAGE=vexaai/vexa-bot:${VM_IMAGE_TAG}|" "$f"
+    done
+    echo "  [redeploy-lite] pinned IMAGE_TAG=${VM_IMAGE_TAG}"
+fi
+
+IMAGE_TAG="$(grep -E '^IMAGE_TAG=' "$ENV_FILE" 2>/dev/null | cut -d= -f2)"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+docker pull "vexaai/vexa-lite:${IMAGE_TAG}" 2>&1 | tail -3
 docker stop vexa-lite 2>/dev/null || true
 docker rm -f vexa-lite 2>/dev/null || true
 
@@ -33,7 +45,8 @@ for squatter in vexa-postgres-1 vexa-redis-1; do
 done
 
 # vexa-postgres stays up — keeping state
-make lite 2>&1 | tail -10
+set -o pipefail
+make -C deploy/lite preflight up init-db test 2>&1 | tail -10
 
 # v0.10.6 Pack U.7 follow-up — verify the gateway actually came up.
 # `make lite` prints success markers but a port-conflict or DB-init failure

--- a/tests3/lib/reset/reset-compose.sh
+++ b/tests3/lib/reset/reset-compose.sh
@@ -22,8 +22,16 @@ cd /root/vexa/deploy/compose
 
 # compose needs --env-file; IMAGE_TAG lives in the repo's .env
 ENV_FILE="/root/vexa/.env"
-[ -f /root/.env ] && ENV_FILE="/root/.env"
 echo "  [reset-compose] env file: $ENV_FILE"
+
+if [ -n "${VM_IMAGE_TAG:-}" ]; then
+    for f in "$ENV_FILE" /root/.env; do
+        [ -f "$f" ] || continue
+        sed -i "s|^#*IMAGE_TAG=.*|IMAGE_TAG=${VM_IMAGE_TAG}|" "$f"
+        sed -i "s|^#*BROWSER_IMAGE=.*|BROWSER_IMAGE=vexaai/vexa-bot:${VM_IMAGE_TAG}|" "$f"
+    done
+    echo "  [reset-compose] pinned IMAGE_TAG=${VM_IMAGE_TAG}"
+fi
 
 echo "  [reset-compose] docker compose down -v"
 docker compose --env-file "$ENV_FILE" down --volumes --remove-orphans 2>&1 | tail -5 || true
@@ -67,3 +75,11 @@ for i in $(seq 1 30); do
     fi
     sleep 2
 done
+
+# Fresh resets wipe Postgres, so any VEXA_API_KEY already present in the
+# compose env can point at a token row that no longer exists. Reuse the
+# canonical compose target to probe/regenerate the dashboard key, then restart
+# dashboard so its process environment reads the regenerated value.
+echo "  [reset-compose] reseating dashboard VEXA_API_KEY (probe-and-regenerate)..."
+make setup-api-key 2>&1 | tail -3 || echo "  [reset-compose] setup-api-key reported non-zero; continuing"
+docker compose --env-file "$ENV_FILE" up -d --force-recreate dashboard 2>&1 | tail -5 || true

--- a/tests3/lib/reset/reset-lite.sh
+++ b/tests3/lib/reset/reset-lite.sh
@@ -30,8 +30,17 @@ docker rm -f vexa-postgres 2>/dev/null || true
 # Drop postgres data so migrations start fresh. Lite's PG uses default volume.
 docker volume ls -q | grep -E '^vexa-' | xargs -r docker volume rm -f 2>/dev/null || true
 
-echo "  [reset-lite] make lite"
-make lite 2>&1 | tail -10
+echo "  [reset-lite] lite deploy targets"
+if [ -n "${VM_IMAGE_TAG:-}" ]; then
+    for f in /root/vexa/.env /root/.env; do
+        [ -f "$f" ] || continue
+        sed -i "s|^#*IMAGE_TAG=.*|IMAGE_TAG=${VM_IMAGE_TAG}|" "$f"
+        sed -i "s|^#*BROWSER_IMAGE=.*|BROWSER_IMAGE=vexaai/vexa-bot:${VM_IMAGE_TAG}|" "$f"
+    done
+    echo "  [reset-lite] pinned IMAGE_TAG=${VM_IMAGE_TAG}"
+fi
+set -o pipefail
+make -C deploy/lite preflight up init-db test 2>&1 | tail -10
 
 # Wait for gateway to respond
 echo "  [reset-lite] waiting for services..."

--- a/tests3/lib/vm-reset.sh
+++ b/tests3/lib/vm-reset.sh
@@ -15,14 +15,15 @@ VM_IP=$(state_read vm_ip)
 # checkout on the VM (was previously hardcoded to `dev`, which broke whenever
 # the cycle ran on a release/<id> branch and `dev` didn't exist on origin).
 VM_BRANCH=$(state_read vm_branch)
+VM_IMAGE_TAG="$(state_read image_tag 2>/dev/null || true)"
 echo ""
-echo "  vm-reset: $(basename "$SCRIPT") on $VM_IP (branch=${VM_BRANCH})"
+echo "  vm-reset: $(basename "$SCRIPT") on $VM_IP (branch=${VM_BRANCH}, image_tag=${VM_IMAGE_TAG:-unset})"
 echo "  ──────────────────────────────────────────────"
 
 # Inject VM_BRANCH into the remote shell. `ssh -o SendEnv` would require
 # sshd config; the inline-export form here is portable and matches how the
 # rest of the harness wraps SSH.
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    "root@$VM_IP" "VM_BRANCH=${VM_BRANCH} bash -s" < "$SCRIPT"
+    "root@$VM_IP" "VM_BRANCH=${VM_BRANCH} VM_IMAGE_TAG=${VM_IMAGE_TAG} bash -s" < "$SCRIPT"
 
 echo "  ──────────────────────────────────────────────"

--- a/tests3/lib/vm-setup-compose.sh
+++ b/tests3/lib/vm-setup-compose.sh
@@ -7,6 +7,7 @@ source "$(dirname "$0")/common.sh"
 source "$(dirname "$0")/vm.sh"
 
 BRANCH=$(state_read vm_branch)
+IMAGE_TAG="$(state_read image_tag 2>/dev/null || true)"
 
 echo ""
 echo "  vm-setup-compose"
@@ -47,6 +48,13 @@ vm_ssh "cd /root/vexa && \
     sed -i 's|^#*TRANSCRIPTION_SERVICE_TOKEN=.*|TRANSCRIPTION_SERVICE_TOKEN=$TX_TOKEN|' .env"
 pass ".env configured with transcription creds"
 
+if [ -n "$IMAGE_TAG" ]; then
+    vm_ssh "cd /root/vexa && \
+        sed -i 's|^#*IMAGE_TAG=.*|IMAGE_TAG=$IMAGE_TAG|' .env && \
+        sed -i 's|^#*BROWSER_IMAGE=.*|BROWSER_IMAGE=vexaai/vexa-bot:$IMAGE_TAG|' .env"
+    pass ".env pinned to IMAGE_TAG=$IMAGE_TAG"
+fi
+
 # ── 5. Copy tests3 to VM (not in git yet) ─────────
 info "syncing tests3 to VM..."
 VM_IP=$(state_read vm_ip)
@@ -56,10 +64,10 @@ rsync -az --exclude='.state/' \
 pass "tests3 synced to VM"
 
 # ── 6. Deploy ─────────────────────────────────────
-info "running make all (this pulls images — may take 3-5 minutes)..."
+info "running compose deploy targets (this pulls images — may take 3-5 minutes)..."
 DEPLOY_OK=false
 for attempt in 1 2 3; do
-    if vm_ssh "cd /root/vexa/deploy/compose && make all 2>&1 | tail -5"; then
+    if vm_ssh "cd /root/vexa/deploy/compose && set -o pipefail && make preflight up init-db setup-api-key test 2>&1 | tail -5"; then
         DEPLOY_OK=true
         break
     fi
@@ -70,9 +78,9 @@ for attempt in 1 2 3; do
 done
 
 if [ "$DEPLOY_OK" = true ]; then
-    pass "make all succeeded"
+    pass "compose deploy targets succeeded"
 else
-    fail "make all failed after 3 attempts"
+    fail "compose deploy targets failed after 3 attempts"
     info "SSH in to debug: make -C tests3 vm-ssh"
     exit 1
 fi

--- a/tests3/lib/vm-setup-lite.sh
+++ b/tests3/lib/vm-setup-lite.sh
@@ -8,6 +8,7 @@ source "$(dirname "$0")/common.sh"
 source "$(dirname "$0")/vm.sh"
 
 BRANCH=$(state_read vm_branch)
+IMAGE_TAG="$(state_read image_tag 2>/dev/null || true)"
 
 echo ""
 echo "  vm-setup-lite"
@@ -48,6 +49,13 @@ vm_ssh "cd /root/vexa && \
     sed -i 's|^#*TRANSCRIPTION_SERVICE_TOKEN=.*|TRANSCRIPTION_SERVICE_TOKEN=$TX_TOKEN|' .env"
 pass ".env configured with transcription creds"
 
+if [ -n "$IMAGE_TAG" ]; then
+    vm_ssh "cd /root/vexa && \
+        sed -i 's|^#*IMAGE_TAG=.*|IMAGE_TAG=$IMAGE_TAG|' .env && \
+        sed -i 's|^#*BROWSER_IMAGE=.*|BROWSER_IMAGE=vexaai/vexa-bot:$IMAGE_TAG|' .env"
+    pass ".env pinned to IMAGE_TAG=$IMAGE_TAG"
+fi
+
 # ── 5. Copy tests3 to VM ─────────────────────────
 info "syncing tests3 to VM..."
 VM_IP=$(state_read vm_ip)
@@ -56,11 +64,11 @@ rsync -az --exclude='.state/' \
     "$ROOT/tests3" "root@$VM_IP:/root/vexa/" 2>/dev/null
 pass "tests3 synced to VM"
 
-# ── 6. Deploy (same as user: make lite) ──────────
-info "running make lite (this pulls images — may take 3-5 minutes)..."
+# ── 6. Deploy ─────────────────────────────────────
+info "running lite deploy targets (this pulls images — may take 3-5 minutes)..."
 DEPLOY_OK=false
 for attempt in 1 2 3; do
-    if vm_ssh "cd /root/vexa && make lite 2>&1 | tail -5"; then
+    if vm_ssh "cd /root/vexa/deploy/lite && set -o pipefail && make preflight up init-db test 2>&1 | tail -5"; then
         DEPLOY_OK=true
         break
     fi
@@ -71,9 +79,9 @@ for attempt in 1 2 3; do
 done
 
 if [ "$DEPLOY_OK" = true ]; then
-    pass "make lite succeeded"
+    pass "lite deploy targets succeeded"
 else
-    fail "make lite failed after 3 attempts"
+    fail "lite deploy targets failed after 3 attempts"
     info "SSH in to debug: make -C tests3 vm-ssh"
     exit 1
 fi

--- a/tests3/registry.yaml
+++ b/tests3/registry.yaml
@@ -101,6 +101,7 @@ BOT_GMEET_RECORDING_ENABLED_SURVIVES_TRACK_EVENT:
   step: gmeet_recording_survival
   modes:
   - compose
+  - lite
   - helm
   state: stateful
   max_duration_sec: 180
@@ -292,7 +293,7 @@ CDP_NO_SLASH_REDIRECT:
 CDP_WS_SCHEME_PRESERVED:
   proves: "CDP proxy webSocketDebuggerUrl rewrite preserves inbound scheme (wss:// on HTTPS gateways) \u2014 Playwright connectOverCDP\
     \ works through TLS"
-  symptom: Hard-coded ws:// in proxy URL breaks every external CDP client on HTTPS deployments
+  symptom: Hard-coded plaintext WebSocket scheme in proxy URL breaks every external CDP client on HTTPS deployments
   found: '2026-04-19'
   type: grep
   file: services/api-gateway/main.py
@@ -2454,3 +2455,1127 @@ webhooks:
   features:
   - webhooks
   tier: cheap
+
+# ── 260508-v0.10.6.1 new checks (scope.yaml proves[] bindings) ────────
+# Stub entries — full wiring (script paths, grep patterns, http endpoints)
+# is filled in during develop as each fix lands. Each entry carries the
+# proves/symptom from plan-approval.yaml registry_changes_approved.
+
+BOT_CONFIG_CAMERA_ENABLED_INDEPENDENT_OF_VOICE_AGENT:
+  proves: "meeting-api meetings.py does NOT force-couple bot_config['cameraEnabled'] to voice_agent_enabled. camera_enabled is honored only when the operator passes it explicitly; default stays off."
+  symptom: "voice_agent_enabled=true silently turns on the outgoing virtual camera / avatar stream — /speak should not require enabling a video camera."
+  found: '2026-05-17'
+  type: grep
+  # Replaces the prior BOT_CONFIG_CAMERA_ENABLED_WHEN_VOICE_AGENT check
+  # from PR #239 which encoded the inverse (and incorrect) coupling.
+  # The bot reads botConfig.cameraEnabled; meeting-api writes it.
+  file: services/meeting-api/meeting_api/meetings.py
+  must_not_match: 'bot_config\["cameraEnabled"\] = bool\(req\.voice_agent_enabled\)'
+  must_match: 'if req\.camera_enabled is not None:'
+  modes:
+  - compose
+  - lite
+  - helm
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+BOT_TEAMS_JOIN_CAMERA_GATED_BY_CAMERA_ENABLED:
+  proves: "Teams pre-join camera handling turns video on only when botConfig.cameraEnabled is true; voice_agent_enabled/speak does not publish an outgoing avatar/video tile."
+  symptom: "A Teams voice-only bot can speak but still appears as a video/avatar participant because pre-join handling treats voiceAgentEnabled as the camera gate."
+  found: '2026-05-19'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/msteams/join.ts
+  must_not_match: 'if \(botConfig\.voiceAgentEnabled\) \{'
+  must_match: 'if \(botConfig\.cameraEnabled\) \{'
+  modes:
+  - compose
+  - lite
+  - helm
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+BOT_SPEAK_DELIVERS_AUDIO_TO_MEETING:
+  proves: "End-to-end /speak smoke test confirms audible audio reaches the meeting (not just 202 from dispatch)"
+  symptom: "/speak returns 202 but no audio audible in meeting"
+  found: '2026-05-04'
+  type: script
+  script: tests/v0.10.6.1-speak-e2e.sh
+  step: speak_delivers_audio
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 240
+  release: 260508-v0.10.6.1
+
+BOT_SPEAK_HONORS_PROVIDER_PARAM:
+  proves: "Bot /speak handler reads and acts on the provider param; fall-through paths log a structured WARN, not silently ignore"
+  symptom: "Bot ignores provider param on /speak; falls back without signaling to caller"
+  found: '2026-05-04'
+  type: grep
+  file: services/vexa-bot/core/src/services/speak.ts
+  must_match: provider
+  modes:
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+CALLBACKS_FINALIZE_NARROW_EXCEPT:
+  proves: "callbacks.py re-raises asyncio.CancelledError and MemoryError around finalize_recording_master rather than swallowing them; #306 audit MAJOR finding addressed"
+  symptom: "callbacks.py finalize_recording_master handler swallowed CancelledError + MemoryError under bare except Exception (#306)"
+  found: '2026-05-02'
+  type: grep
+  file: services/meeting-api/meeting_api/callbacks.py
+  must_match: 'asyncio\.CancelledError, MemoryError'
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+CHUNK_WRITE_PRIOR_COUNT_LOG_ACCURATE:
+  proves: "chunk_write log uses prior_chunks (same-type chunk count) instead of misleading prior_count (count of media_file type-entries)"
+  symptom: "Log showed prior_count=1 even on chunks 5+ because the field counted media_file type-entries, not chunks (#312)"
+  found: '2026-05-04'
+  type: grep
+  file: services/meeting-api/meeting_api/recordings.py
+  must_match: 'prior_chunks=%s'
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+# DASHBOARD_PLAYBACK_PREFERS_MASTER — retired in 260508-v0.10.6.1.
+# Tested the now-deleted pickMasterMediaFile() shape on the dashboard.
+# Superseded by DASHBOARD_READS_PLAYBACK_URL_NOT_MEDIA_FILES (canonical
+# playback_url contract; pickMasterMediaFile no longer exists).
+
+DOCKER_IMAGES_MANIFEST_INCLUDES_ARM64:
+  proves: "Each vexaai/* image's manifest includes a linux/arm64 layer"
+  symptom: "vexaai/* images are AMD64-only; Apple Silicon contributors hit Rosetta overhead (#321)"
+  found: '2026-05-06'
+  type: script
+  script: tests/v0.10.6.1-arm64-manifest.sh
+  step: arm64_in_manifest
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+GMEET_REJECTION_PAGE_FAST_FAIL_UNDER_30S:
+  proves: "GMeet bot detects the host-not-started page, grants a 30s grace for the host to join, and fast-fails with a classified reason (gmeet_host_not_started) rather than burning the full max_wait_for_admission"
+  symptom: "Bot stalled 120s on hidden name input when meeting host hadn't started; no fast-fail, no classified reason (#316)"
+  found: '2026-05-04'
+  type: script
+  script: tests/v0.10.6.1-gmeet-fast-fail.sh
+  step: rejection_under_30s
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+GMEET_WAITING_ROOM_EVICTION_RETRY_OR_FAIL_CLEAN:
+  proves: "GMeet admission flow tracks everInWaitingRoom, applies a 30s eviction grace once waiting-room indicator disappears, and throws gmeet_waiting_room_evicted instead of polling silently until the outer timeout"
+  symptom: "Google evicts the bot from the waiting room after ~5min; pre-fix bot polled in unknown state without classifying the eviction"
+  found: '2026-05-06'
+  type: script
+  script: tests/v0.10.6.1-gmeet-fast-fail.sh
+  step: eviction_retry_or_fail_clean
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+MASTER_WEBM_HAS_EBML_DURATION:
+  proves: "ffprobe of finalized master.webm reports a non-zero Duration in EBML SegmentInfo"
+  symptom: "Dashboard scrubber loads with delay because master.webm has no Duration tag (#302 follow-up)"
+  found: '2026-05-02'
+  type: script
+  script: tests/v0.10.6.1-webm-duration.sh
+  step: ebml_duration_present
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 120
+  release: 260508-v0.10.6.1
+
+# MEDIA_FILES_MASTER_INDEX_BACKFILLED — retired in 260508-v0.10.6.1.
+# Tied to the deleted pickMasterMediaFile() shape and its v0.10.6.1-dashboard-master.sh
+# host script. The backfill itself (tests3/lib/backfill-master-index.py) is preserved as
+# operator-run for the historical recordings; canonical playback now flows via
+# recording.playback_url proven by RECORDING_HAS_PLAYBACK_URL_AFTER_FINALIZE.
+
+# MIN_AUDIO_S_HONORED_IN_VEXA_LITE — REMOVED 2026-05-08 during develop.
+# Investigation: MIN_AUDIO_S env var does not exist in code OR current docs.
+# Customer-E (Discord 2026-05-06) misremembered. No drift to fix.
+# Replaced by VEXA_LITE_APPLE_SILICON_CAVEAT_DOCUMENTED (the real gap).
+
+RUNTIME_API_DELETE_EMITS_EXIT_CALLBACK:
+  proves: "meeting-api browser_session dispatch (meetings.py) plumbs connection_id='bs:<meeting_id>' through metadata; callbacks._find_meeting_by_session recognizes the bs: prefix and routes by meeting_id; runtime-api DELETE handler then fires the exit callback (no longer silently skipped)"
+  symptom: "browser_session DELETE left meetings stuck in 'stopping' because meeting-api dispatch never set connection_id, runtime-api skipped the callback, and the Pack E.3.2 sweep was defeated by webhook-retry updated_at bumps (#313)"
+  found: '2026-05-04'
+  type: grep
+  file: services/meeting-api/meeting_api/meetings.py
+  must_match: 'connection_id.*bs:'
+  modes:
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+SINGLE_WRITER_FOR_RECORDING_MASTER_PATH:
+  proves: "post_meeting.finalize_in_progress_recordings observes media_files entries whose storage_path is a master.{webm,wav} path and does NOT mutate them — recording_finalizer is the sole writer for master entries (Pack U.7 second race fixed)"
+  symptom: "Race window: master uploaded to storage + storage_path set in JSONB but is_final not yet flipped; post_meeting saw is_final=False and stomped finalized_by='post_meeting_reconciler' (#311)"
+  found: '2026-05-04'
+  type: grep
+  file: services/meeting-api/meeting_api/post_meeting.py
+  must_match: 'sp\.endswith\("/audio/master\.webm"\)'
+  modes:
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+STALE_AUDIT_SWEEP_DECISIONS_FILED:
+  proves: "Each of #166 #113 #128 #96 #198 has either a closing comment with rationale or a reconfirm note + label"
+  symptom: "Backlog noise — issues unconfirmed since pre-0.10 refactor"
+  found: '2026-05-08'
+  type: script
+  script: tests/v0.10.6.1-stale-audit.sh
+  step: decisions_filed
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+STUCK_MEETING_SWEEP_USES_PROGRESS_TIMESTAMP:
+  proves: "Pack E.3.2 sweep computes staleness from data.status_transition (immutable append-only history) — last_progress_at — rather than meeting.updated_at which is poisoned by webhook-retry bumps"
+  symptom: "Pack E.3.2 sweep defeated by webhook-retry updated_at bumps; meetings genuinely stuck in 'stopping' looked fresh and were never finalized (#313)"
+  found: '2026-05-04'
+  type: grep
+  file: services/meeting-api/meeting_api/sweeps.py
+  must_match: last_progress_at
+  modes:
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+SWAGGER_CURL_EXAMPLE_SHOWS_CORRECT_HEADER:
+  proves: "admin-api /openapi.json exposes a distinct AdminApiKey scheme with name=X-Admin-API-Key so Swagger renders correct curl examples"
+  symptom: "Swagger curl examples showed api-gateway header instead of admin-api header (#80, PR #319)"
+  found: '2025-12-05'
+  type: http
+  url: $ADMIN_URL/openapi.json
+  method: GET
+  expect_code: 200
+  expect_jsonpath: '$.components.securitySchemes.AdminApiKey.name'
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+
+TEAMS_CONTINUE_NO_AV_MODAL_DISMISSED:
+  proves: "Teams bot dismisses 'Continue without audio or video?' modal and proceeds to Join within normal admission window"
+  symptom: "Bot stuck on Teams light-meetings/launch by Continue-w/o-AV modal (#226, PR #283)"
+  found: '2026-04-21'
+  type: script
+  script: tests/v0.10.6.1-teams-modal.sh
+  step: modal_dismissed
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 180
+  release: 260508-v0.10.6.1
+
+TTS_POD_READY_AFTER_FIRST_BOOT:
+  proves: "Helm-deployed vexa-tts pod reaches Ready within 90s on a fresh cluster (model download path resilient)"
+  symptom: "TTS pod CrashLoopBackOff (154 restarts) on prod cluster; 9fde7d2 probe-delay fix incomplete (#315 #308)"
+  found: '2026-05-04'
+  type: script
+  script: tests/v0.10.6.1-tts-pod.sh
+  step: pod_ready_after_first_boot
+  modes:
+  - helm
+  state: stateful
+  max_duration_sec: 180
+  release: 260508-v0.10.6.1
+
+VEXA_LITE_APPLE_SILICON_CAVEAT_DOCUMENTED:
+  proves: "vexa-lite deployment docs explicitly call out the Apple Silicon Rosetta-emulation caveat and link to #321"
+  symptom: "Customers (customer-B 2026-04-27) hit silent self_initiated_leave on M-series Macs; docs gave no warning"
+  found: '2026-05-06'
+  type: grep
+  file: docs/vexa-lite-deployment.mdx
+  must_match: 'Apple Silicon'
+  modes:
+  - lite
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+  notes: |
+    Investigation 2026-05-08: original VEXA_LITE_ENV_DOC_DRIFT_CHECK was based on
+    customer-B + customer-E reports. OPENAI_API_KEY is still used by tts-service
+    (genuine). MIN_AUDIO_S is in neither code nor docs (customer-E misremembered).
+    The only real gap was the missing Apple Silicon caveat — narrowed to that.
+
+# ── 260508-v0.10.6.1 OPTION-3 SCOPE EXTENSION (2026-05-08) ────────────
+# Authorized mid-develop. See releases/260508-v0.10.6.1/protocol-exception.md.
+
+TTS_RUNTIME_ENV_WIRED:
+  proves: "Runtime-launched bot profiles receive TTS_SERVICE_URL across compose and helm, so /speak acceptance reaches the meeting audio data plane"
+  symptom: "/speak returns 202 but Helm bot pods have no TTS_SERVICE_URL and therefore cannot render audio"
+  found: '2026-05-20'
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh
+  step: runtime_tts_env_wired
+  modes:
+  - compose
+  - helm
+  state: static
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+  option3: true
+
+TTS_MAJOR_VOICES_CONFIGURED:
+  proves: "tts-service is configured to strict-prepare the supported major language voices before accepting release-gate traffic"
+  symptom: "First non-English /speak can block on voice download or fall back to wrong-language output"
+  found: '2026-05-20'
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh
+  step: major_voices_configured
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+  option3: true
+
+TTS_MAJOR_VOICE_FIRST_CALL_PROMPT:
+  proves: "A Portuguese auto-language /v1/audio/speech request returns non-empty audio promptly on the first release-gate call"
+  symptom: "Portuguese /speak is accepted but either spells letters, stalls on model download, or produces no prompt audible output"
+  found: '2026-05-20'
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh
+  step: major_voice_first_call_prompt
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+  option3: true
+
+TTS_AUTO_LANG_PICKS_RIGHT_VOICE:
+  proves: "tts-service detects language from input text and selects a Piper voice matching that language (es text → es voice, etc.)"
+  symptom: "/v1/audio/speech defaults to en_US voice regardless of input language; non-English text gets phonemized via espeak-ng-EN, mispronounced silently"
+  found: '2026-05-08'
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh
+  step: detects_and_picks_voice
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+  option3: true
+
+TTS_NEW_LANG_VOICE_AUTO_DOWNLOAD_CACHED:
+  proves: "First request for a new language triggers Piper voice download + cache; subsequent calls hit cached voice without re-download"
+  symptom: "No automated coverage of the auto-download-on-new-language path"
+  found: '2026-05-08'
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh
+  step: voice_download_caches
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 120
+  release: 260508-v0.10.6.1
+  option3: true
+
+TTS_PLAYBACK_HANDLES_WAV_AND_MP3_RESPONSES:
+  proves: "Bot tts-playback dispatches by Content-Type — audio/pcm → streaming paplay; audio/wav or audio/mpeg → buffer-to-file then existing playFile path"
+  symptom: "synthesizeViaTtsService hardcodes response_format=pcm; users with BYO TTS returning wav/mp3 cannot play through the bot"
+  found: '2026-05-08'
+  type: script
+  script: tests/v0.10.6.1-tts-byo-playback.sh
+  step: handles_wav_and_mp3
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+  option3: true
+
+WEBHOOK_NO_UPDATED_AT_AUTOTOUCH:
+  proves: "webhooks.py persists webhook bookkeeping (webhook_delivery + webhook_deliveries) via a raw UPDATE that explicitly sets updated_at=meeting.updated_at, overriding the SQLAlchemy onupdate=func.now() default — so meetings.updated_at remains a 'domain progress' signal and is not poisoned by webhook retry storms"
+  symptom: "Pre-fix: webhook delivery writes appended to data->'webhook_deliveries' via the ORM, which bumped updated_at on every retry. Pack E.3.2 stale-stopping sweep filtered on `updated_at < threshold` and silently failed to fire because retry storms kept the row 'fresh' (#327, #313 root cause #2)"
+  found: '2026-05-08'
+  type: script
+  script: tests/v0.10.6.1-webhook-no-autotouch.sh
+  step: no_autotouch
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+  option3: true
+
+# MEDIA_FILES_UNIQUE_CONSTRAINT_ENFORCED — retired in 260508-v0.10.6.1.
+# Constraint was on the relational media_files table, which v0.10.6.1
+# drops outright (ADR-1, drop-relational-recordings-tables scope item).
+# Superseded by MEDIA_FILES_TABLE_NOT_REFERENCED + RECORDINGS_TABLE_DROPPED_IN_PROD.
+
+SPEAK_DEFAULTS_PROPAGATE_AUTO_LANGUAGE:
+  proves: "/speak default voice='auto' + provider='piper' propagate from meeting-api voice_agent.bot_speak through bot tts-playback.synthesizeAndPlay; redis pubsub command carries voice='auto' so tts-service language detection actually fires"
+  symptom: "Pre-fix: meeting-api /speak hardcoded voice='alloy' overriding bot's 'auto' default; even with TTS auto-language correct, end-to-end customer path was pinned English (#314 follow-up)"
+  found: '2026-05-10'
+  type: script
+  script: tests/v0.10.6.1-speak-defaults.sh
+  step: defaults_propagate
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+  option3: true
+
+# ── 260508-v0.10.6.1 CEO MID-TASK SCOPE EXTENSION (2026-05-11) ────────
+# Two scope items added during T-038 dispatch-surface repair. Their
+# prove-checks are expected to FAIL until parallel code-fix agents land
+# the underlying code changes.
+
+POST_MEETING_HOOKS_FIRE_ONCE_PER_SESSION:
+  proves: "fire_post_meeting_hooks claims one meeting.data.outbound_events entry per internal hook destination before HTTP delivery; concurrent callers skip pending/queued/delivered entries, Redis retry owns queued failures, and the stale-pending sweep recovers claim-before-send crashes without adding a database column"
+  symptom: "fire_post_meeting_hooks fired 4× per session from 6 call sites (exit_callback + status_change_callback + sweep retries); paying customer overcharged 3× (#330)"
+  found: '2026-05-11'
+  type: script
+  script: tests/v0.10.6.1-post-meeting-idempotency.sh
+  step: fires_once_per_session
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+  option3: true
+  pending_code_fix: true   # cleared when develop validation passes
+
+BOT_CREATE_HONORS_DISPATCH_CHECK_DENY:
+  proves: "POST /bots reads DISPATCH_CHECK_URL env; when the mock returns {allow:false,reason:X}, /bots returns 402 with reason in body — OSS-generic (no Stripe/billing semantics in code)"
+  symptom: "POST /bots has no pre-creation authority call-out; deny decisions made elsewhere don't reach the OSS dispatcher (T-033 B1)"
+  found: '2026-05-11'
+  type: script
+  script: tests/v0.10.6.1-dispatch-check-deny.sh
+  step: bots_endpoint_honors_deny
+  modes:
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+  option3: true
+  pending_code_fix: true   # parallel code-fix agent dispatching
+
+BOT_CREATE_NOOP_WHEN_DISPATCH_CHECK_UNSET:
+  proves: "POST /bots is a no-op pass-through when DISPATCH_CHECK_URL env is unset — self-hosters get no behavior change"
+  symptom: "OSS self-hosters must not see new external HTTP dependency; un-configured dispatch check must allow (T-033 B1 backward-compat)"
+  found: '2026-05-11'
+  type: script
+  script: tests/v0.10.6.1-dispatch-check-noop.sh
+  step: noop_when_unset
+  modes:
+  - compose
+  - lite
+  - helm
+  state: stateless
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+  option3: true
+  pending_code_fix: true
+
+ADMIN_BOT_CREATE_HONORS_DISPATCH_CHECK_DENY:
+  proves: "admin-api bot-create path reads DISPATCH_CHECK_URL env identically; admin-side dispatches honor opaque allow/deny decisions"
+  symptom: "Admin-side bot-create bypassed any external authority entirely (T-033 B7)"
+  found: '2026-05-11'
+  type: script
+  script: tests/v0.10.6.1-dispatch-check-admin-deny.sh
+  step: admin_bots_endpoint_honors_deny
+  modes:
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+  option3: true
+  pending_code_fix: true
+
+# ── 260508-v0.10.6.1 PROTOCOL-EXCEPTION #4 (2026-05-11) ──────────────
+# Validate-coverage closure: smoke-bot-transcription-roundtrip.
+# Caught at T-038 human-gate when bot 10060 produced zero transcripts
+# because TRANSCRIPTION_SERVICE_TOKEN was placeholder + validate matrix
+# had zero end-to-end roundtrip check against the transcription endpoint.
+
+SMOKE_BOT_TRANSCRIPTION_ROUNDTRIP:
+  proves: "bot's TranscriptionClient credentials + URL + auth-routing can complete a synth-audio → whisper-transcribe roundtrip; catches token-mismatch (HTTP 401), endpoint-unreachable (transport-err), and model-load failure (HTTP 500 OOM)"
+  symptom: "bot dispatches successfully and uploads chunks but every transcription call fails (401/500/timeout); transcripts never populate even though everything looks 'wired' in compose env (#regression caught at T-038 human-gate 2026-05-11)"
+  found: '2026-05-11'
+  type: script
+  script: tests/smoke-bot-transcription-roundtrip.sh
+  step: roundtrip
+  modes:
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+  protocol_exception: 4
+
+TRANSCRIPTION_TOKEN_NO_PLACEHOLDER_FALLBACK:
+  proves: "deploy/compose/.env is the LOCAL deployment SSOT for transcription URL/token; local deploy writes both compose and lite from that file, and smoke verifies runtime env matches it without caller-env overrides or fallback files"
+  symptom: "local deploy/test harness accepts parameters from multiple sources, masking a runtime deployed without the SSOT transcription credentials"
+  found: '2026-05-13'
+  type: static-grep
+  script: tests/static/no-placeholder-transcription-token.sh
+  step: TRANSCRIPTION_TOKEN_NO_PLACEHOLDER_FALLBACK
+  modes: [lite, compose]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_CONFIG_NO_STALE_LOCALHOST_DEFAULTS:
+  proves: "dashboard source/config contains no stale localhost:8066, localhost:18056, or ws://localhost:3001 defaults"
+  symptom: "dashboard builds or validates against the wrong local API gateway target, causing /ws and /api proxy failures after deployment"
+  found: '2026-05-14'
+  type: static-grep
+  script: tests/static/dashboard-config-ssot.sh
+  step: DASHBOARD_CONFIG_NO_STALE_LOCALHOST_DEFAULTS
+  modes: [lite, compose]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_REWRITES_REQUIRE_BUILD_SSOT:
+  proves: "dashboard /api/config derives browser WebSocket URLs from runtime public API config, normalizes loopback public URLs against the request host for remote self-hosted browsers, and keeps Next.js build-time rewrites as fallback only"
+  symptom: "portable dashboard image bakes one substrate's internal API hostname, or remote Lite exposes ws://localhost:8056 to a tester's browser, so WebSocket behavior passes in one substrate and fails in another"
+  found: '2026-05-14'
+  type: static-grep
+  script: tests/static/dashboard-config-ssot.sh
+  step: DASHBOARD_REWRITES_REQUIRE_BUILD_SSOT
+  modes: [lite, compose, helm]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_ADMIN_URL_EXPLICIT_SSOT:
+  proves: "dashboard admin routes use VEXA_ADMIN_API_URL explicitly instead of borrowing VEXA_API_URL as a second source"
+  symptom: "auth/profile/webhook routes silently switch between admin-api and gateway URLs, masking deployment drift and surfacing Invalid API key errors to the user"
+  found: '2026-05-14'
+  type: static-grep
+  script: tests/static/dashboard-config-ssot.sh
+  step: DASHBOARD_ADMIN_URL_EXPLICIT_SSOT
+  modes: [lite, compose]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_CLIENT_URLS_FROM_RUNTIME_CONFIG:
+  proves: "dashboard browser helpers get websocket/session URLs from /api/config or request origin, not hardcoded localhost endpoints"
+  symptom: "human gate browser receives stale local deployment URLs and cannot observe live transcript/status updates without refreshes"
+  found: '2026-05-14'
+  type: static-grep
+  script: tests/static/dashboard-config-ssot.sh
+  step: DASHBOARD_CLIENT_URLS_FROM_RUNTIME_CONFIG
+  modes: [lite, compose]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+TEST_ACCOUNT_BOT_LIMIT_IS_CANONICAL:
+  proves: "local validation account test@vexa.ai has max_concurrent_bots equal to tests3/lib/test-account.env TEST_ACCOUNT_MAX_CONCURRENT_BOTS in each in-scope deployment"
+  symptom: "parallel compose/lite/fresh-bot human validation trips the concurrent bot limiter even though the stack and bot pipeline are otherwise healthy"
+  found: '2026-05-14'
+  type: script
+  script: tests/test-account-bot-limit.sh
+  step: TEST_ACCOUNT_BOT_LIMIT_IS_CANONICAL
+  modes: [lite, compose]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+TEST_ACCOUNT_NO_STALE_SLOT_CONSUMERS:
+  proves: "test@vexa.ai has no stale requested/joining/awaiting_admission/active non-browser bot rows older than 2h consuming concurrent-bot slots"
+  symptom: "third bot cannot be dispatched even though max_concurrent_bots=3 because abandoned old meetings still count against the limiter"
+  found: '2026-05-14'
+  type: script
+  script: tests/test-account-bot-limit.sh
+  step: TEST_ACCOUNT_NO_STALE_SLOT_CONSUMERS
+  modes: [lite, compose]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+# ── 260508-v0.10.6.1 (v3 — 2026-05-12) ───────────────────────────────
+# Six new check ids added at develop-code for the three new architectural
+# items: recordings-playback-url-canonical, drop-relational-recordings-tables,
+# migrations-convention-readme. See scope.yaml for full per-issue blocks.
+
+RECORDING_HAS_PLAYBACK_URL_AFTER_FINALIZE:
+  proves: "recording_finalizer writes playback_url onto the JSONB recording element when master assembly succeeds; the field is non-empty for every completed recording"
+  symptom: "recording.status='completed' but recording.playback_url is null/missing on the JSONB; dashboard shows 'finalizing' indefinitely"
+  found: '2026-05-12'
+  type: script
+  script: tests/recording-playback-url-canonical.sh
+  step: recording_has_playback_url_after_finalize
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+DASHBOARD_READS_PLAYBACK_URL_NOT_MEDIA_FILES:
+  proves: "dashboard meeting page uses recording.playback_url directly; pickMasterMediaFile() function is no longer in the dashboard codebase"
+  symptom: "static-grep finds pickMasterMediaFile or .find(m => m.storage_path...) in services/dashboard/"
+  found: '2026-05-12'
+  type: static-grep
+  script: tests/static/dashboard-playback-canonical.sh
+  step: dashboard_reads_playback_url
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_RENDERS_FINALIZING_STATE_ON_NULL_PLAYBACK_URL:
+  proves: "dashboard audio-player renders an explicit 'finalizing' UI state when recording.playback_url is null on a completed recording, rather than silently failing"
+  symptom: "null playback_url + status=completed → dashboard either crashes, shows blank player, or falls back to picking media_files[0]"
+  found: '2026-05-12'
+  type: script
+  script: tests/recording-finalizing-state.sh
+  step: dashboard_renders_finalizing_state
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+
+DASHBOARD_COMPLETED_RECORDING_PLAYBACK_READY:
+  proves: "a real browser opens a completed meeting with recording.playback_url.audio, fetches the master recording route successfully, loads audio metadata, and renders playback controls instead of 'Recording is processing...' or 'Preparing audio...'"
+  symptom: "completed recording has backend master/playback_url but dashboard remains stuck in Recording is processing or Preparing audio"
+  found: '2026-05-13'
+  type: script
+  script: tests/dashboard-recording-playback-ready.sh
+  step: DASHBOARD_COMPLETED_RECORDING_PLAYBACK_READY
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+DASHBOARD_POST_MEETING_ARTIFACT_POLL_PRESENT:
+  proves: "the meeting detail page keeps polling post-meeting artifacts after stop/completion until recording playback can render, so the UI updates without a manual reload when finalization finishes seconds later"
+  symptom: "human page remains stuck on 'Recording is processing...' even though the backend finished the recording shortly after"
+  found: '2026-05-14'
+  type: script
+  script: tests/dashboard-recording-playback-ready.sh
+  step: DASHBOARD_POST_MEETING_ARTIFACT_POLL_PRESENT
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+DASHBOARD_TRANSCRIPT_RENDERED_VISIBLE:
+  proves: "a real browser opens the completed delivery meeting, the dashboard transcript API returns segment(s), and at least one transcript text snippet is visible in the rendered human page"
+  symptom: "backend GET /transcripts is green, but the human dashboard page still shows no transcript"
+  found: '2026-05-14'
+  type: script
+  script: tests/dashboard-recording-playback-ready.sh
+  step: DASHBOARD_TRANSCRIPT_RENDERED_VISIBLE
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_BROWSER_HANDOFF_ENDPOINTS_SSOT:
+  proves: "every URL handed to the local human browser during validation is derived from the canonical handoff surface and is browser-reachable from that surface; internal Docker hostnames, host-local storage endpoints, and ad hoc public-endpoint fallbacks are not accepted as human-gate proof"
+  symptom: "machine-local checks pass because the test runner can reach an internal/host-local endpoint, but the human browser sees a stuck UI because it was handed a URL outside the canonical handoff surface"
+  found: '2026-05-13'
+  type: script
+  script: tests/dashboard-recording-playback-ready.sh
+  step: LOCAL_HUMAN_BROWSER_HANDOFF_ENDPOINTS_SSOT
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+PRE_RELEASE_SECURITY_DEPENDENCY_FLOORS:
+  proves: "pre-release security dependency controls are enforced for the GHSA-9wv6-78fw-fq5c dependency-blocker class: dashboard postcss is >= 8.5.10 and transcription-service no longer installs python-multipart or reads the full multipart body before enforcing its size limit"
+  symptom: "dependency scanner reports the release tree still contains vulnerable postcss or python-multipart versions after the advisory was pulled into v0.10.6.1"
+  found: '2026-05-14'
+  type: static-grep
+  script: tests/static/advisory-dependency-floors.sh
+  step: PRE_RELEASE_SECURITY_DEPENDENCY_FLOORS
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+RECORDINGS_TABLE_NOT_REFERENCED:
+  proves: "no select(Recording), from .models import Recording, or Recording.* reference exists in services/ outside of archived legacy paths"
+  symptom: "static-grep finds a Recording ORM reference, meaning the codebase still queries the dropped table"
+  found: '2026-05-12'
+  type: static-grep
+  script: tests/static/no-recordings-table-references.sh
+  step: recordings_table_not_referenced
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+MEDIA_FILES_TABLE_NOT_REFERENCED:
+  proves: "no select(MediaFile), from .models import MediaFile, or MediaFile.* reference exists in services/ outside of archived legacy paths"
+  symptom: "static-grep finds a MediaFile ORM reference; codebase still queries the dropped table"
+  found: '2026-05-12'
+  type: static-grep
+  script: tests/static/no-media-files-table-references.sh
+  step: media_files_table_not_referenced
+  modes:
+  - compose
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+RECORDINGS_TABLE_DROPPED_IN_PROD:
+  proves: "the recordings and media_files tables do not exist in the runtime DB (after m331-drop-relational-recordings.py runs)"
+  symptom: "SELECT 1 FROM recordings LIMIT 1 succeeds (table still present) — drop migration didn't run or rolled back"
+  found: '2026-05-12'
+  type: script
+  script: tests/recordings-tables-dropped.sh
+  step: tables_dropped
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 15
+  release: 260508-v0.10.6.1
+
+# ── 260508-v0.10.6.1 walkability-smoke gate (2026-05-12) ─────────────
+# Harness-gap fix surfaced at develop-human: LOCAL=1 deploys could exit
+# success on a stack no human could walk. These six proves run AFTER
+# release-deploy and BEFORE release-validate; develop-human gate is
+# refused if any fails. See tests3/tests/walkability-smoke.sh.
+
+WALKABILITY_AUTH_ROUND_TRIP_WORKS:
+  proves: "api-gateway returns 401 without token and 200 with a valid token from api_tokens; auth round-trip works end-to-end"
+  symptom: "dashboard shows 'Invalid API key' or 'Missing API key' for an authenticated user; auth flow regressed silently"
+  found: '2026-05-12'
+  type: script
+  script: tests/walkability-smoke.sh
+  step: WALKABILITY_AUTH_ROUND_TRIP_WORKS
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+WALKABILITY_MEETINGS_PAGE_HAS_DATA:
+  proves: "deployed stack has at least 1 meeting row; humans walking the dashboard have something to click"
+  symptom: "fresh LOCAL=1 lite stack with empty DB; human-checklist items requiring a meeting record are dead in the water"
+  found: '2026-05-12'
+  type: script
+  script: tests/walkability-smoke.sh
+  step: WALKABILITY_MEETINGS_PAGE_HAS_DATA
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+WALKABILITY_MEETING_DETAIL_API_LOADS:
+  proves: "GET /meetings/<id> with auth returns 200 + JSON with id; the detail view a human clicks actually loads"
+  symptom: "dashboard /meetings/<id> shows 'Something went wrong' or empty state; backend route broken"
+  found: '2026-05-12'
+  type: script
+  script: tests/walkability-smoke.sh
+  step: WALKABILITY_MEETING_DETAIL_API_LOADS
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+WALKABILITY_TRANSCRIPTION_URL_CONFIGURED:
+  proves: "TRANSCRIPTION_SERVICE_URL is set + non-placeholder; LOCAL=1 inner loop check (reachability is canonical-stage-only)"
+  symptom: "stack deployed with dummy/placeholder transcription URL; transcription pipeline silently broken; canonical-stage gate would have caught it but LOCAL=1 didn't"
+  found: '2026-05-12'
+  type: script
+  script: tests/walkability-smoke.sh
+  step: WALKABILITY_TRANSCRIPTION_URL_CONFIGURED
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+WALKABILITY_TTS_SPEAK_ROUND_TRIP:
+  proves: "POST /v1/audio/speech to TTS service returns 200 + >1KB audio; /speak path is functional"
+  symptom: "/speak endpoint silently broken; bot can't speak in meetings; customer-A escalation reproduces"
+  found: '2026-05-12'
+  type: script
+  script: tests/walkability-smoke.sh
+  step: WALKABILITY_TTS_SPEAK_ROUND_TRIP
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+
+WALKABILITY_DASHBOARD_LOGIN_RENDERS:
+  proves: "GET /login returns 2xx + non-trivial HTML; dashboard front door renders for a human"
+  symptom: "dashboard /login returns 500 or empty body; humans cannot log in to walk the checklist"
+  found: '2026-05-12'
+  type: script
+  script: tests/walkability-smoke.sh
+  step: WALKABILITY_DASHBOARD_LOGIN_RENDERS
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+# ── 260508-v0.10.6.1 registry-canonical gate (2026-05-12) ──────────────
+# Prereq for develop-human: registry.yaml is canonical source of truth
+# for check IDs across scope.yaml + prove scripts. Drift between them
+# means the matrix returns "missing" on a real-running prove (or
+# accepts a phantom check id with no implementation). See
+# tests3/tests/static/registry-canonical.sh.
+
+REGISTRY_COVERS_ALL_SCOPE_PROVES:
+  proves: "every {check: X} in the current release's scope.yaml proves[] is registered in registry.yaml"
+  symptom: "scope.yaml references a check id that doesn't exist in registry → matrix returns missing forever; or a prove runs but the matrix can't find it in catalog"
+  found: '2026-05-12'
+  type: script
+  script: tests/static/registry-canonical.sh
+  step: REGISTRY_COVERS_ALL_SCOPE_PROVES
+  modes: [any]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+REGISTRY_COVERS_ALL_SCRIPT_STEP_IDS:
+  proves: "every step_pass/step_fail <ID> emitted by tests3/tests/**/*.sh is registered in registry.yaml"
+  symptom: "a script emits a check id that's not in registry → JSON written but report-renderer can't classify it"
+  found: '2026-05-12'
+  type: script
+  script: tests/static/registry-canonical.sh
+  step: REGISTRY_COVERS_ALL_SCRIPT_STEP_IDS
+  modes: [any]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+REGISTRY_HAS_NO_ORPHAN_IDS:
+  proves: "every check id in registry.yaml has at least one referrer (in current scope.yaml OR in a script)"
+  symptom: "registry accumulates dead entries over time; orphan ids confuse contributors browsing registry"
+  found: '2026-05-12'
+  type: script
+  script: tests3/tests/static/registry-canonical.sh
+  step: REGISTRY_HAS_NO_ORPHAN_IDS
+  modes: [any]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+# ── 260508-v0.10.6.1 scope-proof gate (2026-05-13) ────────────────────
+# develop-human must not open just because the registry is consistent and the
+# stack is walkable. This gate proves the current release's scope-bound LOCAL
+# (`lite` / `compose`) proof cells are actually present and green in the
+# latest reports. Missing/skip/fail all block the human checkpoint.
+
+SCOPE_LOCAL_PROOFS_ALL_GREEN:
+  proves: "every scope.yaml prove runnable on LOCAL=1 (`lite` / `compose`) is present and `pass` in the latest LOCAL reports before develop-human opens"
+  symptom: "human checkpoint opens on a colour-blind matrix: a required scope proof is missing, skipped, or failing, but the stack still looked walkable"
+  found: '2026-05-13'
+  type: script
+  script: tests/static/scope-proof-gate.sh
+  step: SCOPE_LOCAL_PROOFS_ALL_GREEN
+  modes: [any]
+  state: stateless
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+# ── 260508-v0.10.6.1 local-human mechanical gate (2026-05-13) ─────────
+# Machine-owned checks removed from the human checklist. Humans should spend
+# attention on end-to-end UI behavior; these checks are observable from Docker,
+# HTTP, logs, DB metadata, and generated env files.
+
+LOCAL_HUMAN_TARGET_URLS_READY:
+  proves: "the lite and compose target URLs handed to the human return 2xx before the checkpoint opens"
+  symptom: "human receives a checklist but the URL handoff points at dead or wrong surfaces"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_TARGET_URLS_READY
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_CONTAINERS_HEALTHY:
+  proves: "LOCAL lite + compose containers needed for human validation are running and healthy"
+  symptom: "human validation starts against a partially dead LOCAL stack"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_CONTAINERS_HEALTHY
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_TRANSCRIPTION_LB_READY:
+  proves: "when LOCAL compose points at transcription-lb, the lb/workers are healthy, attached to the runtime bot network, resolvable from runtime-api, and meeting-api/runtime-api match the deploy/compose/.env SSOT before human validation"
+  symptom: "live bots upload recording chunks but every Whisper call fails with transport errors; human sees zero transcript segments"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_TRANSCRIPTION_LB_READY
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_RECENT_LOGS_CLEAN:
+  proves: "recent LOCAL service logs have no ERROR/TRACEBACK/CRITICAL/FATAL lines before human validation begins"
+  symptom: "humans eyeball the UI while services are already emitting obvious runtime errors"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_RECENT_LOGS_CLEAN
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_MEMORY_WITHIN_LIMIT:
+  proves: "vexa-lite memory is below 2GiB before human validation"
+  symptom: "human validates a lite stack already beyond the documented memory envelope"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_MEMORY_WITHIN_LIMIT
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_LITE_RECORDING_FILES_PRESENT:
+  proves: "lite DB final local recording storage paths exist under /var/lib/vexa/recordings before human playback validation"
+  symptom: "lite DB advertises playback_url/final media but the disposable container layer lost the actual recording file after redeploy"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_LITE_RECORDING_FILES_PRESENT
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 10
+  release: 260508-v0.10.6.1
+
+DASHBOARD_BROWSER_MEETINGS_AUTH_OK:
+  proves: "a real browser can direct-login, open /meetings and a meeting detail page, and avoid Authentication failed/session-expired/Invalid API key UI"
+  symptom: "curl sees 200 HTML but the hydrated dashboard rejects the session at /meetings or /meetings/<id>"
+  found: '2026-05-13'
+  type: script
+  script: tests/dashboard-browser-auth.sh
+  step: DASHBOARD_BROWSER_MEETINGS_AUTH_OK
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 45
+  release: 260508-v0.10.6.1
+
+DASHBOARD_DETAIL_STALE_AUTH_RECOVERS:
+  proves: "a stale dashboard cookie/localStorage token on a meeting detail route is cleared or redirected instead of rendering raw Invalid API key"
+  symptom: "human opens /meetings/<id> after auth/token drift and sees Something went wrong / Invalid API key"
+  found: '2026-05-13'
+  type: script
+  script: tests/dashboard-stale-auth-detail.sh
+  step: DASHBOARD_DETAIL_STALE_AUTH_RECOVERS
+  modes: [compose, lite]
+  state: stateful
+  max_duration_sec: 45
+  release: 260508-v0.10.6.1
+
+DASHBOARD_AUTH_COOKIES_ISOLATED:
+  proves: "one browser can log into both LOCAL dashboards on localhost and keep both /meetings sessions authenticated with deployment-specific token cookies"
+  symptom: "logging into one localhost deployment overwrites the other deployment's vexa-token cookie, causing Authentication failed/session-expired after successful login"
+  found: '2026-05-13'
+  type: script
+  script: tests/dashboard-cookie-isolation.sh
+  step: DASHBOARD_AUTH_COOKIES_ISOLATED
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 60
+  release: 260508-v0.10.6.1
+
+LIVE_BOT_TRANSCRIPT_SEGMENTS_PRESENT:
+  proves: "the configured delivery meeting, or newest real admitted transcribe_enabled bot with recording chunks, has non-empty transcript segments through GET /transcripts"
+  symptom: "human opens a meeting detail page after bot admission and sees recordings/chunks but no transcription"
+  found: '2026-05-13'
+  type: script
+  script: tests/live-bot-transcript-pipeline.sh
+  step: LIVE_BOT_TRANSCRIPT_SEGMENTS_PRESENT
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 30
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_COMPOSE_ENV_SSOT:
+  proves: "deploy/compose/.env contains every deploy/env-example key plus non-empty LOCAL overrides"
+  symptom: "LOCAL compose validation runs with env drift from the declared deployment contract"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_COMPOSE_ENV_SSOT
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_NO_TEST_CONTAINERS:
+  proves: "no leftover lifecycle/webhook/spoof test containers are present before human validation"
+  symptom: "stale test containers contaminate human validation or Docker ps inspection"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_NO_TEST_CONTAINERS
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+LOCAL_HUMAN_RECORDINGS_TABLES_DROPPED:
+  proves: "compose DB has no recordings/media_files relational tables before human playback validation"
+  symptom: "human validates recording playback while the dead relational tables are still present"
+  found: '2026-05-13'
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  step: LOCAL_HUMAN_RECORDINGS_TABLES_DROPPED
+  modes: [compose]
+  state: stateful
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_DETAIL_FETCHES_CANONICAL_RECORDING_STATE:
+  proves: "dashboard meeting detail fetches the authoritative meeting row and hydrates recording state from meeting.data.recordings"
+  symptom: "SPA navigation to an active deferred-recording meeting trusts the thin meetings-list row, leaving recordings/transcribe_enabled empty until a hard reload"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/dashboard-recording-state-ssot.sh
+  step: DASHBOARD_DETAIL_FETCHES_CANONICAL_RECORDING_STATE
+  modes: [compose, lite]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_ACTIVE_RECORDING_UI_USES_MEETING_DATA:
+  proves: "dashboard meeting page derives active recording UI from canonical meeting.data.recordings when transcript-derived recording state has not arrived"
+  symptom: "active recording with transcribe_enabled=false renders 'No transcript yet / Waiting for speech to transcribe...' instead of 'Recording in progress'"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/dashboard-recording-state-ssot.sh
+  step: DASHBOARD_ACTIVE_RECORDING_UI_USES_MEETING_DATA
+  modes: [compose, lite]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DASHBOARD_DEFERRED_RECORDING_EMPTY_STATE:
+  proves: "transcript empty state distinguishes deferred recording from realtime transcription waiting state"
+  symptom: "deferred recording flow looks broken during capture/finalization because the transcript panel says it is waiting for speech"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/dashboard-recording-state-ssot.sh
+  step: DASHBOARD_DEFERRED_RECORDING_EMPTY_STATE
+  modes: [compose, lite]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DEFERRED_TRANSCRIBE_WAITS_FOR_RECORDING_MASTER:
+  proves: "POST /meetings/{id}/transcribe accepts only audio media finalized by recording_finalizer.master; it does not consume last-chunk storage_path or post_meeting_reconciler metadata"
+  symptom: "deferred transcription starts before recording finalization, reads an incomplete chunk path, and returns zero/broken transcript despite the recording later becoming playable"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/deferred-transcribe-master-gate.sh
+  step: DEFERRED_TRANSCRIBE_WAITS_FOR_RECORDING_MASTER
+  modes: [compose, lite, helm]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DISRUPTIVE_DEFERRED_TRANSCRIPTION_HARNESS_EXISTS:
+  proves: "autonomous_real_meeting.py can dispatch a recording-only bot, SIGKILL it, wait for finalized master, POST deferred transcribe, and assert persisted transcript segments"
+  symptom: "release registry claims crash robustness but only proves recording playback, not deferred transcript persistence after bot disruption"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/deferred-transcribe-master-gate.sh
+  step: DISRUPTIVE_DEFERRED_TRANSCRIPTION_HARNESS_EXISTS
+  modes: [compose, lite, helm]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+RUNTIME_EXIT_CALLBACK_SENDS_INTERNAL_SECRET:
+  proves: "runtime-api persists callback_headers and sends X-Internal-Secret back to meeting-api exit callbacks"
+  symptom: "bot exits but meeting-api rejects runtime callback with 403, leaving meetings stuck requested/active and recording finalization unobservable"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/deferred-transcribe-master-gate.sh
+  step: RUNTIME_EXIT_CALLBACK_SENDS_INTERNAL_SECRET
+  modes: [compose, lite, helm]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+BOT_STATUS_CALLBACK_HAS_INTERNAL_SECRET_FALLBACK:
+  proves: "bot status callbacks carry X-Internal-Secret from BOT_CONFIG or INTERNAL_API_SECRET env"
+  symptom: "bot joins or waits but meeting-api rejects status_change with 403, so tests never reach active and dashboard state drifts"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/deferred-transcribe-master-gate.sh
+  step: BOT_STATUS_CALLBACK_HAS_INTERNAL_SECRET_FALLBACK
+  modes: [compose, lite, helm]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1
+
+DISRUPTIVE_CRASH_KILLS_CANONICAL_BOT_CONTAINER:
+  proves: "compose disruptive harness kills the meeting-api bot_container_id before fallback discovery"
+  symptom: "crash robustness test records chunks but fails to drop the active bot, creating false red/green evidence about recording persistence"
+  found: '2026-05-14'
+  type: script
+  script: tests/static/deferred-transcribe-master-gate.sh
+  step: DISRUPTIVE_CRASH_KILLS_CANONICAL_BOT_CONTAINER
+  modes: [compose]
+  state: stateless
+  max_duration_sec: 5
+  release: 260508-v0.10.6.1

--- a/tests3/test-registry.yaml
+++ b/tests3/test-registry.yaml
@@ -289,3 +289,447 @@ tests:
     script: synthetic/run-all.sh
     features: [bot-lifecycle, post-meeting-transcription]
     max_duration_sec: 240
+
+  # ── v0.10.6.1 — hotfix + low-hanging-fruit cycle (260508-v0.10.6.1) ──
+  # Per-step entries: each script takes a $step arg and emits ONE registry
+  # check ID via step_pass <CHECK_ID> / step_fail <CHECK_ID>. The test-name
+  # is "<script-stem>-<step>" (matches `test_begin` inside each script);
+  # the report file is .state/reports/<mode>/<test-name>.json.
+  # Pattern-selected by run-matrix.sh scope-filtering via `v0.10.6.1-*`
+  # whitelist. See tests3/registry.yaml for the check-ID → semantic mapping.
+
+  # v0.10.6.1-dashboard-master-* — retired in 260508-v0.10.6.1 (script + steps
+  # tested the deleted pickMasterMediaFile() shape). Canonical playback proves
+  # live on `recording-playback-url-canonical` + `dashboard-playback-canonical`.
+
+  v0.10.6.1-speak-defaults-defaults_propagate:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-speak-defaults.sh defaults_propagate
+    features: [speaking-bot, realtime-transcription]
+    max_duration_sec: 30
+
+  v0.10.6.1-webhook-no-autotouch-no_autotouch:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-webhook-no-autotouch.sh no_autotouch
+    features: [webhooks, bot-lifecycle]
+    max_duration_sec: 5
+
+  # v0.10.6.1-media-files-unique-* — retired in 260508-v0.10.6.1: the
+  # media_files relational table is dropped this release (ADR-1).
+
+  v0.10.6.1-webm-duration-ebml_duration_present:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-webm-duration.sh ebml_duration_present
+    features: [post-meeting-transcription, dashboard]
+    max_duration_sec: 120
+
+  v0.10.6.1-gmeet-fast-fail-rejection_under_30s:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-gmeet-fast-fail.sh rejection_under_30s
+    features: [realtime-transcription/gmeet, bot-lifecycle]
+    max_duration_sec: 10
+
+  v0.10.6.1-gmeet-fast-fail-eviction_retry_or_fail_clean:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-gmeet-fast-fail.sh eviction_retry_or_fail_clean
+    features: [realtime-transcription/gmeet, bot-lifecycle]
+    max_duration_sec: 10
+
+  v0.10.6.1-arm64-manifest-arm64_in_manifest:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-arm64-manifest.sh arm64_in_manifest
+    features: [infrastructure]
+    max_duration_sec: 60
+
+  v0.10.6.1-tts-auto-lang-runtime_tts_env_wired:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-tts-auto-lang.sh runtime_tts_env_wired
+    features: [speaking-bot]
+    max_duration_sec: 10
+
+  v0.10.6.1-tts-auto-lang-major_voices_configured:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-tts-auto-lang.sh major_voices_configured
+    features: [speaking-bot]
+    max_duration_sec: 10
+
+  v0.10.6.1-tts-auto-lang-major_voice_first_call_prompt:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-tts-auto-lang.sh major_voice_first_call_prompt
+    features: [speaking-bot]
+    max_duration_sec: 10
+
+  v0.10.6.1-tts-auto-lang-detects_and_picks_voice:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-tts-auto-lang.sh detects_and_picks_voice
+    features: [speaking-bot]
+    max_duration_sec: 60
+
+  v0.10.6.1-tts-auto-lang-voice_download_caches:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-tts-auto-lang.sh voice_download_caches
+    features: [speaking-bot]
+    max_duration_sec: 120
+
+  v0.10.6.1-tts-byo-playback-handles_wav_and_mp3:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-tts-byo-playback.sh handles_wav_and_mp3
+    features: [speaking-bot]
+    max_duration_sec: 5
+
+  # ── v0.10.6.1 missing-script authorings (gap-2 repair, T-038) ───────
+  # These scripts didn't exist on disk; authored 2026-05-11 to close the
+  # last 4 prove-check gaps. Same shape as the 9 above: take $step arg,
+  # emit step_pass/step_fail <CHECK_ID>.
+
+  v0.10.6.1-tts-pod-pod_ready_after_first_boot:
+    tier: cheap
+    runs_in: [helm]
+    script: tests/v0.10.6.1-tts-pod.sh pod_ready_after_first_boot
+    features: [speaking-bot, infrastructure]
+    max_duration_sec: 180
+
+  v0.10.6.1-speak-e2e-speak_delivers_audio:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-speak-e2e.sh speak_delivers_audio
+    features: [speaking-bot, realtime-transcription]
+    max_duration_sec: 240
+
+  v0.10.6.1-stale-audit-decisions_filed:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-stale-audit.sh decisions_filed
+    features: []
+    max_duration_sec: 60
+
+  v0.10.6.1-teams-modal-modal_dismissed:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/v0.10.6.1-teams-modal.sh modal_dismissed
+    features: [realtime-transcription/msteams, bot-lifecycle]
+    max_duration_sec: 180
+
+  # ── v0.10.6.1 auth-bucket proves (D13 closure) ────────────────────
+  # Pin the no-hostname-fallback + default-refuse + no-localhost-fallback
+  # contract surfaced by the D6-B and dashboard-proxy hardening
+  # (commits 714dada, 8fbd3c8). Static-only — no runtime stack required.
+
+  v0.10.6.1-direct-login-refused-no_hostname_fallback:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-direct-login-refused.sh no_hostname_fallback
+    features: [dashboard, infrastructure]
+    max_duration_sec: 30
+
+  v0.10.6.1-direct-login-refused-helm_default_false:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-direct-login-refused.sh helm_default_false
+    features: [dashboard, infrastructure]
+    max_duration_sec: 30
+
+  v0.10.6.1-agent-proxy-auth-no_localhost_fallback:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-agent-proxy-auth.sh no_localhost_fallback
+    features: [dashboard, infrastructure]
+    max_duration_sec: 30
+
+  v0.10.6.1-agent-proxy-auth-auth_threaded:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-agent-proxy-auth.sh auth_threaded
+    features: [dashboard, infrastructure]
+    max_duration_sec: 30
+
+  # ── v0.10.6.1 migration-surface prove (D13 m328/m331 closure) ────
+  # Pins the m328 dedup + m331 drop migration interface so a future
+  # editor can't accidentally remove dry-run defaults, advisory locks,
+  # or the m331 archive-before-drop guarantee.
+
+  v0.10.6.1-m328-m331-migrations-migration_surface_intact:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-m328-m331-migrations.sh migration_surface_intact
+    features: [infrastructure]
+    max_duration_sec: 30
+
+  v0.10.6.1-m328-m331-migrations-model_refs_dropped:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-m328-m331-migrations.sh model_refs_dropped
+    features: [infrastructure]
+    max_duration_sec: 30
+
+  # ── v0.10.6.1 blast-radius lifting proves (every M/M-H/L → H) ───
+  # These pin the five blast-radius rows that didn't have dedicated
+  # proves before this session. After these land, the min over §4 in
+  # STATE.md rises from L to H, clearing the confidence floor.
+
+  v0.10.6.1-api-gateway-cors-listsize-cors_wildcard_with_no_creds:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-api-gateway-cors-listsize.sh cors_wildcard_with_no_creds
+    features: [infrastructure, dashboard]
+    max_duration_sec: 30
+
+  v0.10.6.1-api-gateway-cors-listsize-list_size_capped:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-api-gateway-cors-listsize.sh list_size_capped
+    features: [infrastructure]
+    max_duration_sec: 30
+
+  v0.10.6.1-multichunk-playback-url-finalizer_writes_playback_url:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-multichunk-playback-url.sh finalizer_writes_playback_url
+    features: [post-meeting-transcription, dashboard]
+    max_duration_sec: 30
+
+  v0.10.6.1-multichunk-playback-url-master_endpoint_present:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-multichunk-playback-url.sh master_endpoint_present
+    features: [post-meeting-transcription, dashboard]
+    max_duration_sec: 30
+
+  v0.10.6.1-dashboard-playback-canonical-reads_playback_url:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-dashboard-playback-canonical.sh reads_playback_url
+    features: [dashboard]
+    max_duration_sec: 30
+
+  v0.10.6.1-dashboard-playback-canonical-no_pick_master_media_file:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-dashboard-playback-canonical.sh no_pick_master_media_file
+    features: [dashboard]
+    max_duration_sec: 30
+
+  v0.10.6.1-bot-cpu-budget-profiles_cap_cpu_1500m:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-bot-cpu-budget.sh profiles_cap_cpu_1500m
+    features: [infrastructure, bot-lifecycle]
+    max_duration_sec: 30
+
+  v0.10.6.1-bot-cpu-budget-bot_launches_inprocgpu:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-bot-cpu-budget.sh bot_launches_inprocgpu
+    features: [bot-lifecycle]
+    max_duration_sec: 30
+
+  v0.10.6.1-bot-acceptance-signals-bot_collects_signals:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-bot-acceptance-signals.sh bot_collects_signals
+    features: [bot-lifecycle]
+    max_duration_sec: 30
+
+  v0.10.6.1-bot-acceptance-signals-callbacks_persist_signals:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-bot-acceptance-signals.sh callbacks_persist_signals
+    features: [bot-lifecycle]
+    max_duration_sec: 30
+
+  # ── v0.10.6.1 CEO mid-task scope extension (items #17, #18) ─────────
+  # Authored 2026-05-11 alongside the dispatch-surface repair (T-038).
+  # Parallel code-fix agents author the underlying code; these tests
+  # are the regression invariants. Static-shape: same as the 9 wired
+  # above (single $step arg, emits one check ID).
+
+  v0.10.6.1-post-meeting-idempotency-fires_once_per_session:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-post-meeting-idempotency.sh fires_once_per_session
+    features: [post-meeting-transcription, webhooks]
+    max_duration_sec: 60
+
+  v0.10.6.1-dispatch-check-deny-bots_endpoint_honors_deny:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-dispatch-check-deny.sh bots_endpoint_honors_deny
+    features: [bot-lifecycle, auth-and-limits]
+    max_duration_sec: 30
+
+  v0.10.6.1-dispatch-check-noop-noop_when_unset:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/v0.10.6.1-dispatch-check-noop.sh noop_when_unset
+    features: [bot-lifecycle, auth-and-limits]
+    max_duration_sec: 30
+
+  v0.10.6.1-dispatch-check-admin-deny-admin_bots_endpoint_honors_deny:
+    tier: cheap
+    runs_in: [compose, helm]
+    script: tests/v0.10.6.1-dispatch-check-admin-deny.sh admin_bots_endpoint_honors_deny
+    features: [bot-lifecycle, auth-and-limits, dashboard]
+    max_duration_sec: 30
+
+  # ── v0.10.6.1 grep-checks wrapper (registry.yaml type:grep → dispatched) ──
+  # Many scope.proves[] check IDs are type:grep in registry.yaml but have
+  # no runtime executor wired. This wrapper runs them all in one shot
+  # (same pattern as v0.10.6-static-greps.sh), emitting each as step_pass
+  # / step_fail <CHECK_ID>. Cheap (~5s); runs in every mode so the same
+  # grep evidence registers in compose, helm, and lite reports.
+  v0.10.6.1-static-greps:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/v0.10.6.1-static-greps.sh
+    features: [bot-lifecycle, post-meeting-transcription, dashboard, webhooks, speaking-bot]
+    max_duration_sec: 30
+
+  # ── v0.10.6.1 architectural-cleanup proves (recordings-playback-url-canonical
+  # + drop-relational-recordings-tables scope items). Each script calls
+  # `test_begin <script-stem>` (no step suffix) so the test name in this
+  # registry must match the report filename exactly.
+
+  recording-playback-url-canonical:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/recording-playback-url-canonical.sh
+    features: [post-meeting-transcription, dashboard]
+    max_duration_sec: 60
+
+  recording-finalizing-state:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/recording-finalizing-state.sh
+    features: [post-meeting-transcription, dashboard]
+    max_duration_sec: 30
+
+  recordings-tables-dropped:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/recordings-tables-dropped.sh
+    features: [post-meeting-transcription]
+    max_duration_sec: 15
+
+  dashboard-playback-canonical:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/static/dashboard-playback-canonical.sh
+    features: [dashboard, post-meeting-transcription]
+    max_duration_sec: 5
+
+  no-recordings-table-references:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/static/no-recordings-table-references.sh
+    features: [post-meeting-transcription]
+    max_duration_sec: 5
+
+  no-media-files-table-references:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/static/no-media-files-table-references.sh
+    features: [post-meeting-transcription]
+    max_duration_sec: 5
+
+  no-placeholder-transcription-token:
+    tier: cheap
+    runs_in: [lite, compose]
+    script: tests/static/no-placeholder-transcription-token.sh
+    features: [bot-lifecycle, post-meeting-transcription, realtime-transcription, infrastructure]
+    max_duration_sec: 5
+
+  dashboard-config-ssot:
+    tier: cheap
+    runs_in: [lite, compose]
+    script: tests/static/dashboard-config-ssot.sh
+    features: [dashboard, infrastructure, realtime-transcription]
+    max_duration_sec: 5
+
+  dashboard-recording-state-ssot:
+    tier: cheap
+    runs_in: [lite, compose]
+    script: tests/static/dashboard-recording-state-ssot.sh
+    features: [dashboard, post-meeting-transcription]
+    max_duration_sec: 5
+
+  deferred-transcribe-master-gate:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/static/deferred-transcribe-master-gate.sh
+    features: [post-meeting-transcription, bot-lifecycle]
+    max_duration_sec: 5
+
+  test-account-bot-limit:
+    tier: cheap
+    runs_in: [lite, compose]
+    script: tests/test-account-bot-limit.sh
+    features: [bot-lifecycle, auth-and-limits, dashboard]
+    max_duration_sec: 5
+
+  advisory-dependency-floors:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/static/advisory-dependency-floors.sh
+    features: [dashboard, infrastructure, realtime-transcription]
+    max_duration_sec: 5
+
+  smoke-bot-transcription-roundtrip-roundtrip:
+    tier: cheap
+    runs_in: [lite, compose, helm]
+    script: tests/smoke-bot-transcription-roundtrip.sh roundtrip
+    features: [bot-lifecycle, post-meeting-transcription, realtime-transcription]
+    max_duration_sec: 30
+
+  dashboard-browser-auth:
+    tier: cheap
+    runs_in: [lite, compose]
+    script: tests/dashboard-browser-auth.sh
+    features: [dashboard]
+    max_duration_sec: 45
+
+  dashboard-stale-auth-detail:
+    tier: cheap
+    runs_in: [lite, compose]
+    script: tests/dashboard-stale-auth-detail.sh
+    features: [dashboard]
+    max_duration_sec: 45
+
+  dashboard-cookie-isolation:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/dashboard-cookie-isolation.sh
+    features: [dashboard]
+    max_duration_sec: 60
+
+  live-bot-transcript-pipeline:
+    tier: meeting
+    runs_in: [compose]
+    script: tests/live-bot-transcript-pipeline.sh
+    features: [bot-lifecycle, realtime-transcription, post-meeting-transcription, dashboard]
+    max_duration_sec: 30
+
+  dashboard-recording-playback-ready:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/dashboard-recording-playback-ready.sh
+    features: [dashboard, post-meeting-transcription]
+    max_duration_sec: 60
+
+  local-human-mechanical-gate:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/local-human-mechanical-gate.sh
+    features: [dashboard, infrastructure, post-meeting-transcription, realtime-transcription]
+    max_duration_sec: 30

--- a/tests3/tests/static/advisory-dependency-floors.sh
+++ b/tests3/tests/static/advisory-dependency-floors.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# advisory-dependency-floors — release-local dependency floor guard.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$ROOT_DIR/tests3/lib/common.sh"
+
+test_begin "advisory-dependency-floors"
+
+if output="$(python3 - <<'PY' "$ROOT_DIR"
+import json
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+failures: list[str] = []
+
+def version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", value)[:3])
+
+dashboard_lock = root / "services/dashboard/package-lock.json"
+with dashboard_lock.open() as f:
+    lock = json.load(f)
+
+postcss_versions = []
+for package_path, package in (lock.get("packages") or {}).items():
+    if package_path.endswith("node_modules/postcss"):
+        version = package.get("version", "")
+        postcss_versions.append(version)
+        if version_tuple(version) < (8, 5, 10):
+            failures.append(f"{package_path} has postcss {version}, expected >= 8.5.10")
+
+if not postcss_versions:
+    failures.append("services/dashboard/package-lock.json has no postcss package entry")
+
+transcription_requirements = root / "services/transcription-service/requirements.txt"
+if re.search(r"^python-multipart\b", transcription_requirements.read_text(), re.M):
+    failures.append("services/transcription-service/requirements.txt still installs python-multipart")
+
+transcription_main = (root / "services/transcription-service/main.py").read_text()
+if any(token in transcription_main for token in ("File,", "UploadFile", "Form,")):
+    failures.append("transcription-service still imports FastAPI multipart helpers")
+if "await request.body()" in transcription_main:
+    failures.append("transcription-service multipart parser reads full body before enforcing size")
+
+requirement_paths = [
+    "deploy/lite/requirements.txt",
+    "services/api-gateway/requirements.txt",
+    "services/meeting-api/requirements.txt",
+]
+for rel in requirement_paths:
+    path = root / rel
+    text = path.read_text()
+    match = re.search(r"^python-multipart\s*>=\s*([0-9.]+)", text, re.M)
+    if not match:
+        failures.append(f"{rel} does not declare python-multipart>=0.0.20")
+    elif version_tuple(match.group(1)) < (0, 0, 20):
+        failures.append(f"{rel} has python-multipart>={match.group(1)}, expected >=0.0.20")
+
+lite_requirements = (root / "deploy/lite/requirements.txt").read_text()
+tts_requirements = (root / "services/tts-service/requirements.txt").read_text()
+for package in ("piper-tts", "numpy", "langdetect"):
+    if re.search(rf"^{re.escape(package)}\b", tts_requirements, re.M) and not re.search(
+        rf"^{re.escape(package)}\b", lite_requirements, re.M
+    ):
+        failures.append(f"deploy/lite/requirements.txt is missing tts-service dependency {package}")
+
+pyproject = root / "services/meeting-api/pyproject.toml"
+pyproject_text = pyproject.read_text()
+match = re.search(r'"python-multipart\s*>=\s*([0-9.]+)"', pyproject_text)
+if not match:
+    failures.append("services/meeting-api/pyproject.toml does not declare python-multipart>=0.0.20")
+elif version_tuple(match.group(1)) < (0, 0, 20):
+    failures.append(f"services/meeting-api/pyproject.toml has python-multipart>={match.group(1)}, expected >=0.0.20")
+
+if failures:
+    print("; ".join(failures))
+    sys.exit(1)
+
+print("postcss versions=" + ",".join(sorted(set(postcss_versions))) + "; transcription-service uses bounded stdlib multipart parser; remaining python-multipart floors >=0.0.20; lite carries tts-service runtime deps")
+PY
+)"; then
+  step_pass PRE_RELEASE_SECURITY_DEPENDENCY_FLOORS "$output"
+else
+  step_fail PRE_RELEASE_SECURITY_DEPENDENCY_FLOORS "$output"
+fi
+
+test_end

--- a/tests3/tests/static/dashboard-config-ssot.sh
+++ b/tests3/tests/static/dashboard-config-ssot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# dashboard-config-ssot — dashboard deployment URLs must come from explicit
+# release/deploy configuration, not baked localhost defaults or runtime rewrites.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$ROOT_DIR/tests3/lib/common.sh"
+
+test_begin "dashboard-config-ssot"
+
+SEARCH_PATHS=(
+  "$ROOT_DIR/services/dashboard/.env.example"
+  "$ROOT_DIR/services/dashboard/Dockerfile"
+  "$ROOT_DIR/services/dashboard/docker-entrypoint.sh"
+  "$ROOT_DIR/services/dashboard/next.config.ts"
+  "$ROOT_DIR/services/dashboard/validate.sh"
+  "$ROOT_DIR/services/dashboard/src"
+)
+
+bad_urls="$(rg -n 'localhost:(8066|18056)|ws://localhost:3001|VEXA_API_URL=http://localhost:8066' "${SEARCH_PATHS[@]}" 2>/dev/null || true)"
+if [ -z "$bad_urls" ]; then
+  step_pass DASHBOARD_CONFIG_NO_STALE_LOCALHOST_DEFAULTS "dashboard config has no stale baked localhost gateway/websocket defaults"
+else
+  step_fail DASHBOARD_CONFIG_NO_STALE_LOCALHOST_DEFAULTS "$(printf '%s' "$bad_urls" | head -10 | tr '\n' ' ')"
+fi
+
+config_route="$ROOT_DIR/services/dashboard/src/app/api/config/route.ts"
+runtime_public_api="$(rg -n 'process\.env\.VEXA_PUBLIC_API_URL|process\.env\.NEXT_PUBLIC_VEXA_API_URL|process\.env\.NEXT_PUBLIC_API_URL' "$config_route" 2>/dev/null || true)"
+runtime_ws_derivation="$(rg -n 'wsUrlFromHttpBase\(publicApiUrl\)|if \(publicApiUrl\)' "$config_route" 2>/dev/null || true)"
+loopback_normalization="$(rg -n 'isLoopbackHost|new URL\(configuredPublicApiUrl\)|configured\.hostname = requestHostname' "$config_route" 2>/dev/null || true)"
+entrypoint_patch="$(rg -n 'sed -i|localhost:8066|Patched rewrites' "$ROOT_DIR/services/dashboard/docker-entrypoint.sh" 2>/dev/null || true)"
+if [ -n "$runtime_public_api" ] && [ -n "$runtime_ws_derivation" ] && [ -n "$loopback_normalization" ] && [ -z "$entrypoint_patch" ]; then
+  step_pass DASHBOARD_REWRITES_REQUIRE_BUILD_SSOT "dashboard /api/config derives browser WS from runtime public API config, normalizes loopback URLs to the request host for remote self-hosted browsers, and keeps build-time rewrites as fallback only"
+else
+  step_fail DASHBOARD_REWRITES_REQUIRE_BUILD_SSOT "$(printf '%s\n%s\n%s\n%s' "$runtime_public_api" "$runtime_ws_derivation" "$loopback_normalization" "$entrypoint_patch" | head -10 | tr '\n' ' ')"
+fi
+
+admin_fan_in="$(rg -n 'VEXA_ADMIN_API_URL[^;\n]*\|\|[^;\n]*VEXA_API_URL|process\.env\.VEXA_ADMIN_API_URL\s*\|\|\s*process\.env\.VEXA_API_URL' "$ROOT_DIR/services/dashboard/src" 2>/dev/null || true)"
+if [ -z "$admin_fan_in" ]; then
+  step_pass DASHBOARD_ADMIN_URL_EXPLICIT_SSOT "admin routes require VEXA_ADMIN_API_URL explicitly instead of borrowing VEXA_API_URL"
+else
+  step_fail DASHBOARD_ADMIN_URL_EXPLICIT_SSOT "$(printf '%s' "$admin_fan_in" | head -10 | tr '\n' ' ')"
+fi
+
+client_localhost="$(rg -n 'localhost:3001|localhost:8056|localhost:8066|localhost:8765' \
+  "$ROOT_DIR/services/dashboard/src/hooks" \
+  "$ROOT_DIR/services/dashboard/src/components/meetings/browser-session-view.tsx" 2>/dev/null || true)"
+browser_view_runtime_gateway="$(rg -n 'cfg\.publicApiUrl \|\| cfg\.apiUrl|runtimeConfig\?\.publicApiUrl \|\| runtimeConfig\?\.apiUrl|browserRouteUrl|gatewayBrowserBase' \
+  "$ROOT_DIR/services/dashboard/src/components/meetings/browser-session-view.tsx" \
+  "$ROOT_DIR/services/dashboard/src/app/meetings/[id]/page.tsx" 2>/dev/null || true)"
+browser_view_same_origin_only="$(rg -n 'const vncUrl = [`"'"'"']/b/|withBasePath\(`/b/\$\{.*\}/vnc' \
+  "$ROOT_DIR/services/dashboard/src/components/meetings/browser-session-view.tsx" \
+  "$ROOT_DIR/services/dashboard/src/app/meetings/[id]/page.tsx" 2>/dev/null || true)"
+if [ -z "$client_localhost" ] && [ -n "$browser_view_runtime_gateway" ] && [ -z "$browser_view_same_origin_only" ]; then
+  step_pass DASHBOARD_CLIENT_URLS_FROM_RUNTIME_CONFIG "browser websocket/session helpers and VNC views derive browser-facing gateway URLs from /api/config or request origin"
+else
+  step_fail DASHBOARD_CLIENT_URLS_FROM_RUNTIME_CONFIG "$(printf '%s\n%s\n%s' "$client_localhost" "$browser_view_runtime_gateway" "$browser_view_same_origin_only" | head -10 | tr '\n' ' ')"
+fi
+
+test_end

--- a/tests3/tests/v0.10.6.1-tts-auto-lang.sh
+++ b/tests3/tests/v0.10.6.1-tts-auto-lang.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# v0.10.6.1-tts-auto-lang — Piper voice auto-selection from input language.
+#
+# Steps (compose / helm — TTS_URL must point at a running tts-service):
+#   runtime_tts_env_wired      — runtime-launched bot profiles receive
+#                                 TTS_SERVICE_URL across compose/helm.
+#   major_voices_configured    — /health proves major supported voices are
+#                                 startup-prepared under strict mode.
+#   major_voice_first_call_prompt — Portuguese first-call synthesis is prompt.
+#   detects_and_picks_voice    — Spanish/Russian/Japanese inputs render via
+#                                 the matching Piper voice (script reports
+#                                 voice_param + resolved voice from /health
+#                                 or via debug log).
+#   voice_download_caches      — first call for a new language triggers
+#                                 download (~25-60MB, ~10-30s); second call
+#                                 for the same language is served from
+#                                 cache (<2s).
+#
+# Env: TTS_URL (default http://localhost:8002), TTS_API_TOKEN (optional).
+
+source "$(dirname "$0")/../lib/common.sh"
+
+step="${1:?usage: $0 <step>}"
+TTS_URL="${TTS_URL:-http://localhost:8002}"
+AUTH_HEADER=()
+if [[ -n "${TTS_API_TOKEN:-}" ]]; then
+  AUTH_HEADER=(-H "X-API-Key: ${TTS_API_TOKEN}")
+fi
+
+echo ""
+echo "  v0.10.6.1-tts-auto-lang :: $step"
+echo "  ──────────────────────────────────────────────"
+test_begin "v0.10.6.1-tts-auto-lang-$step"
+
+now_ms() {
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+case "$step" in
+
+  runtime_tts_env_wired)
+    failed=0
+    require_line() {
+      local file="$1"
+      local pattern="$2"
+      local label="$3"
+      if grep -Fq "$pattern" "$file"; then
+        echo "    ok   $label"
+      else
+        echo "    FAIL $label: missing '$pattern' in $file"
+        failed=1
+      fi
+    }
+
+    require_line "services/runtime-api/profiles.yaml" 'TTS_SERVICE_URL: "${TTS_SERVICE_URL}"' "runtime profile passes TTS_SERVICE_URL to bot"
+    require_line "deploy/compose/docker-compose.yml" "TTS_SERVICE_URL=http://tts-service:8002" "compose runtime-api can resolve profile TTS_SERVICE_URL"
+    require_line "deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml" "name: TTS_SERVICE_URL" "helm runtime-api can resolve profile TTS_SERVICE_URL"
+    require_line "deploy/helm/charts/vexa/values.yaml" 'TTS_SERVICE_URL: "${TTS_SERVICE_URL}"' "helm runtime profiles pass TTS_SERVICE_URL to bot pods"
+
+    if (( failed == 0 )); then
+      step_pass TTS_RUNTIME_ENV_WIRED "runtime-launched bot profiles receive TTS_SERVICE_URL on compose and helm"
+    else
+      step_fail TTS_RUNTIME_ENV_WIRED "one or more runtime TTS env bindings are missing"
+    fi
+    ;;
+
+  major_voices_configured)
+    health=$(curl -sS "$TTS_URL/health")
+    failed=0
+    for voice in \
+      en_US-amy-medium \
+      es_ES-davefx-medium \
+      fr_FR-siwis-medium \
+      de_DE-thorsten-medium \
+      it_IT-paola-medium \
+      pt_BR-faber-medium \
+      ru_RU-irina-medium \
+      hi_IN-pratham-medium
+    do
+      if jq -e --arg voice "$voice" '.configured_default_voices | index($voice)' >/dev/null <<<"$health"; then
+        echo "    ok   configured $voice"
+      else
+        echo "    FAIL missing configured voice $voice"
+        failed=1
+      fi
+    done
+
+    if jq -e '.preload_strict == true' >/dev/null <<<"$health"; then
+      echo "    ok   preload_strict=true"
+    else
+      echo "    FAIL preload_strict is not true"
+      failed=1
+    fi
+
+    if jq -e '.default_loaded_voices | index("pt_BR-faber-medium")' >/dev/null <<<"$health"; then
+      echo "    ok   pt_BR hot-loaded"
+    else
+      echo "    FAIL Portuguese voice is not in default_loaded_voices"
+      failed=1
+    fi
+
+    if (( failed == 0 )); then
+      step_pass TTS_MAJOR_VOICES_CONFIGURED "major supported voices are configured for strict startup preparation"
+    else
+      step_fail TTS_MAJOR_VOICES_CONFIGURED "major voice preparation contract not satisfied"
+    fi
+    ;;
+
+  major_voice_first_call_prompt)
+    text="Olá, esta é uma validação de fala em português da Vexa."
+    body=$(jq -n --arg t "$text" '{model:"tts-1", input:$t, voice:"auto", response_format:"wav"}')
+    tmp=$(mktemp --suffix=.wav)
+    t0=$(now_ms)
+    code=$(curl -sS -o "$tmp" -w '%{http_code}' \
+      -X POST "$TTS_URL/v1/audio/speech" \
+      "${AUTH_HEADER[@]}" \
+      -H "Content-Type: application/json" \
+      -d "$body")
+    t1=$(now_ms)
+    dur_ms=$((t1 - t0))
+    size=$(stat -c%s "$tmp" 2>/dev/null || echo 0)
+    rm -f "$tmp"
+
+    echo "    portuguese first-call code=$code size=$size elapsed=${dur_ms}ms"
+    if [[ "$code" == "200" ]] && (( size >= 1000 )) && (( dur_ms <= 6000 )); then
+      step_pass TTS_MAJOR_VOICE_FIRST_CALL_PROMPT "Portuguese auto voice rendered promptly on first release-gate call (${dur_ms}ms)"
+    else
+      step_fail TTS_MAJOR_VOICE_FIRST_CALL_PROMPT "Portuguese first call was not prompt/non-empty (code=$code size=$size elapsed=${dur_ms}ms)"
+    fi
+    ;;
+
+  detects_and_picks_voice)
+    # Three samples with unambiguous scripts/languages.
+    # We can't introspect "which voice was used" from the audio bytes
+    # alone without parsing logs; instead we verify the call returns
+    # 200 + non-empty audio for each language. Voice selection is logged
+    # by the service; aggregate.py captures stdout/stderr from the
+    # tts-service container.
+    declare -a SAMPLES=(
+      "Hello, how are you today?|en"
+      "Hola, ¿cómo estás hoy?|es"
+      "Привет, как у тебя дела?|ru"
+      "今日はお元気ですか?|ja"
+    )
+    failed=0
+    for entry in "${SAMPLES[@]}"; do
+      text="${entry%|*}"
+      lang="${entry##*|}"
+      body=$(jq -n --arg t "$text" '{model:"tts-1", input:$t, voice:"auto", response_format:"wav"}')
+      tmp=$(mktemp --suffix=.wav)
+      code=$(curl -sS -o "$tmp" -w '%{http_code}' \
+        -X POST "$TTS_URL/v1/audio/speech" \
+        "${AUTH_HEADER[@]}" \
+        -H "Content-Type: application/json" \
+        -d "$body")
+      size=$(stat -c%s "$tmp" 2>/dev/null || echo 0)
+      rm -f "$tmp"
+      if [[ "$code" != "200" ]] || (( size < 1000 )); then
+        echo "    FAIL [$lang]: code=$code size=$size text='$text'"
+        failed=1
+      else
+        echo "    ok   [$lang]: code=$code size=$size"
+      fi
+    done
+    if (( failed == 0 )); then
+      step_pass TTS_AUTO_LANG_PICKS_RIGHT_VOICE "auto-lang renders all four scripts (en/es/ru/ja)"
+    else
+      step_fail TTS_AUTO_LANG_PICKS_RIGHT_VOICE "one or more language samples failed (see above)"
+    fi
+    ;;
+
+  voice_download_caches)
+    # Pick a voice unlikely to be pre-loaded. Romanian ("ro_RO-mihai-medium").
+    # First call should succeed (download path) unless the voice is already warm
+    # from a previous local run. In that warm-cache case, both calls should be
+    # fast rather than forcing a false red on "call1=0s call2=1s".
+    text="Bună ziua, cum vă simțiți astăzi?"
+    body=$(jq -n --arg t "$text" '{model:"tts-1", input:$t, voice:"auto", response_format:"wav"}')
+
+    # Call 1
+    t0=$(now_ms)
+    code1=$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X POST "$TTS_URL/v1/audio/speech" \
+      "${AUTH_HEADER[@]}" \
+      -H "Content-Type: application/json" \
+      -d "$body")
+    t1=$(now_ms)
+    dur1_ms=$((t1 - t0))
+
+    # Call 2 (same language → should hit cached voice)
+    t0=$(now_ms)
+    code2=$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X POST "$TTS_URL/v1/audio/speech" \
+      "${AUTH_HEADER[@]}" \
+      -H "Content-Type: application/json" \
+      -d "$body")
+    t1=$(now_ms)
+    dur2_ms=$((t1 - t0))
+
+    echo "    call1 code=$code1 elapsed=${dur1_ms}ms"
+    echo "    call2 code=$code2 elapsed=${dur2_ms}ms"
+
+    if [[ "$code1" != "200" || "$code2" != "200" ]]; then
+      step_fail TTS_NEW_LANG_VOICE_AUTO_DOWNLOAD_CACHED "non-200 status (call1=$code1 call2=$code2) — voice download path failing"
+    elif (( dur1_ms <= 1500 && dur2_ms <= 1500 )); then
+      step_pass TTS_NEW_LANG_VOICE_AUTO_DOWNLOAD_CACHED "voice already warm-cached before the prove (call1=${dur1_ms}ms call2=${dur2_ms}ms)"
+    elif (( dur2_ms <= dur1_ms )); then
+      step_pass TTS_NEW_LANG_VOICE_AUTO_DOWNLOAD_CACHED "voice downloaded on first call, cached on second (call1=${dur1_ms}ms call2=${dur2_ms}ms)"
+    else
+      step_fail TTS_NEW_LANG_VOICE_AUTO_DOWNLOAD_CACHED "second call (${dur2_ms}ms) slower than first (${dur1_ms}ms) — cache not honored"
+    fi
+    ;;
+
+  *)
+    echo "  unknown step: $step" >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
Re-release v0.10.6.1 after rollback and corrected validation.\n\nCandidate behavior validated from release/260508-v0.10.6.1 @ a982441 with Docker tag 0.10.6.1-20051411. This PR restores that validated candidate onto current main after rollback PR #341.\n\nD19 approved with caveats: Zoom Web caveats #345/#339/#318 and accepted Hardenloop/static advisory findings in release evidence.\n\nNo production deployment is included in this PR.