### PR TITLE
fix(release): use Helm SemVer for v0.10.6.2 chart

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vexa
 description: Vexa - self-hosted real-time meeting transcription platform
 type: application
-version: 0.10.6.2
+version: 0.10.6+2
 appVersion: "0.10.6.2"
 home: https://github.com/Vexa-ai/vexa
 sources:

--- a/tests3/checks/scripts/chart-version-current.sh
+++ b/tests3/checks/scripts/chart-version-current.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# CHART_VERSION_CURRENT — Chart.yaml.version == latest vexa-X.Y.Z git tag (#228 B.1).
+# CHART_VERSION_CURRENT — Chart.yaml.version inherits latest vexa release tag (#228 B.1).
 #
 # Policy: chart version INHERITS from the most recent repo release tag.
 # Never ahead (would conflict with future tags), never behind (would
 # reproduce the #228 drift). When a new vexa-X.Y.Z tag is cut, the same
-# commit bumps Chart.yaml.version to match. Equality is the invariant.
+# commit bumps Chart.yaml.version to match. Equality is the invariant after
+# normalizing four-component app releases (X.Y.Z.N) into Helm SemVer build
+# metadata (X.Y.Z+N); Helm chart versions cannot use four numeric segments.
 #
-# Reads deploy/helm/charts/vexa/Chart.yaml version, compares for exact
-# equality against the newest vexa-X.Y.Z git tag. Fails loud on any mismatch.
+# Reads deploy/helm/charts/vexa/Chart.yaml version, compares against the
+# newest vexa-X.Y.Z[.N] git tag after Helm SemVer normalization. Fails loud on
+# any mismatch.
 set -euo pipefail
 
 ROOT=$(git rev-parse --show-toplevel)
@@ -22,20 +25,29 @@ if [ -z "$CHART_VER" ]; then
     echo "FAIL: no version: line in Chart.yaml" >&2; exit 1
 fi
 
-# Latest vexa-prefixed git tag (the actual release-tag convention in this
-# repo). v0.10.5 R1 fix: earlier code used `git tag -l 'v*'` which
-# accidentally matched `vexa-X.Y.Z` because the `v*` glob = literal `v`
-# + anything. After matching, `${LATEST_TAG#v}` stripped only the
-# leading `v` → `exa-X.Y.Z` (gibberish), guaranteeing the equality test
-# always failed even when Chart.yaml + tag agreed.
-LATEST_TAG=$(git -C "$ROOT" tag -l 'vexa-[0-9]*' | sort -V | tail -1)
+# Latest release tag. Historical releases used both `vexa-X.Y.Z` and `vX.Y.Z`
+# conventions, so normalize both and choose by semantic version.
+LATEST_TAG=$(
+    {
+        git -C "$ROOT" tag -l 'vexa-[0-9]*'
+        git -C "$ROOT" tag -l 'v[0-9]*'
+    } | awk '
+        /^vexa-/ { print substr($0, 6) "\t" $0; next }
+        /^v[0-9]/ { print substr($0, 2) "\t" $0; next }
+    ' | sort -V | tail -1 | cut -f2-
+)
 if [ -z "$LATEST_TAG" ]; then
-    echo "ok: chart version $CHART_VER (no vexa-* tags to compare against)"; exit 0
+    echo "ok: chart version $CHART_VER (no release tags to compare against)"; exit 0
 fi
-LATEST_VER=${LATEST_TAG#vexa-}   # strip vexa- prefix → bare semver
+LATEST_VER=${LATEST_TAG#vexa-}
+LATEST_VER=${LATEST_VER#v}
 # Defensive: the strip should leave a bare X.Y.Z. If it doesn't, the
 # tag-naming convention has drifted; fail loud rather than silently
 # comparing junk.
+if [[ "$LATEST_VER" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.([0-9]+)$ ]]; then
+    LATEST_VER="${BASH_REMATCH[1]}+${BASH_REMATCH[2]}"
+fi
+
 if ! [[ "$LATEST_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.+-].*)?$ ]]; then
     echo "FAIL: latest tag '$LATEST_TAG' does not strip cleanly to semver (got '$LATEST_VER')" >&2
     exit 1


### PR DESCRIPTION
## Summary
- fix Helm chart version for the v0.10.6.2 release from invalid four-component `0.10.6.2` to Helm SemVer `0.10.6+2`
- keep runtime `appVersion` at `0.10.6.2`
- update the chart-version release check to normalize four-component app tags into Helm build metadata

## Why
The public Helm chart release workflow failed on main because chart-releaser rejects `chart.metadata.version "0.10.6.2"`. Docker artifacts were handled by digest-preserving retag from the already human-validated `0.10.6.1-20051411` images.

## Validation
- `helm lint deploy/helm/charts/vexa`
- `bash tests3/checks/scripts/chart-version-current.sh`