### PR TITLE
[Pack] PACK 2 - Speak Audio Delivery

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -129,6 +129,7 @@ services:
       - AGENT_IMAGE=${AGENT_IMAGE}
       - BROWSER_IMAGE=${BROWSER_IMAGE}
       - REDIS_URL=redis://redis:6379
+      - TTS_SERVICE_URL=http://tts-service:8002
       - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-vexa-access-key}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-vexa-secret-key}
@@ -377,7 +378,13 @@ services:
     mem_limit: 1g
     expose:
       - "8002"
+    # Host-expose TTS for pack-lane probes; override in isolated lanes.
+    ports:
+      - "127.0.0.1:${TTS_SERVICE_HOST_PORT:-8002}:8002"
     environment:
+      - PIPER_DEFAULT_VOICES=${PIPER_DEFAULT_VOICES:-major}
+      - PIPER_LOAD_VOICES=${PIPER_LOAD_VOICES:-en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium}
+      - PIPER_PRELOAD_STRICT=${PIPER_PRELOAD_STRICT:-true}
       - TTS_API_TOKEN=${TTS_API_TOKEN:-}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     volumes:

--- a/deploy/helm/charts/vexa/templates/deployment-tts-service.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-tts-service.yaml
@@ -25,7 +25,7 @@ spec:
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
     spec:
       securityContext:
-        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
+        {{- toYaml (mergeOverwrite (deepCopy .Values.global.podSecurityContext) .Values.ttsService.podSecurityContext) | nindent 8 }}
       # v0.10.5 Pack I.s — stateful-pod anti-affinity (#272 iter-5).
       # See deployment-minio.yaml header for the full rationale.
       affinity:
@@ -57,23 +57,34 @@ spec:
               value: {{ .Values.ttsService.apiToken | default "" | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.ttsService.logLevel | default "INFO" | quote }}
+            - name: PIPER_DEFAULT_VOICES
+              value: {{ .Values.ttsService.defaultVoices | default "major" | quote }}
+            - name: PIPER_LOAD_VOICES
+              value: {{ .Values.ttsService.loadVoices | default "en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium" | quote }}
+            - name: PIPER_PRELOAD_STRICT
+              value: {{ .Values.ttsService.preloadStrict | default true | quote }}
             {{- with .Values.ttsService.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: voices
               mountPath: /app/voices
+          # First-boot voice-model download takes 60-180s (en_US-amy-medium ~60MB
+          # pulled into the persistent volume on first start). Initial delays
+          # are values-overridable so prod / on-prem can extend them; defaults
+          # tuned to clear the first download. Subsequent restarts come up fast
+          # because the PVC retains models.
           readinessProbe:
             httpGet:
               path: /docs
               port: http
-            initialDelaySeconds: 15
+            initialDelaySeconds: {{ .Values.ttsService.readinessProbe.initialDelaySeconds | default 300 }}
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /docs
               port: http
-            initialDelaySeconds: 45
+            initialDelaySeconds: {{ .Values.ttsService.livenessProbe.initialDelaySeconds | default 600 }}
             periodSeconds: 20
           resources:
             {{- toYaml .Values.ttsService.resources | nindent 12 }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -202,19 +202,36 @@ ttsService:
     port: 8002
   apiToken: ""
   logLevel: "INFO"
+  defaultVoices: "major"
+  loadVoices: "en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium"
+  preloadStrict: true
   persistence:
     size: 5Gi
     storageClassName: ""
+  # The image runs as uid/gid 999. The voices PVC must be group-writable on
+  # first boot so Piper can download voice models before readiness turns green.
+  podSecurityContext:
+    fsGroup: 999
+    fsGroupChangePolicy: OnRootMismatch
   # Load-tested shape (from proprietary wrapper staging values): TTS is
   # bursty — lean cpu request, bigger memory for voice cache.
   resources:
     requests:
-      cpu: 10m
-      memory: 256Mi
+      cpu: 250m
+      memory: 768Mi
     limits:
-      cpu: 100m
-      memory: 512Mi
+      cpu: 1000m
+      memory: 1536Mi
   extraEnv: []
+  # First-boot voice-model download takes 60-180s. Defaults below clear that
+  # window; subsequent restarts come up fast (PVC retains models). Operators
+  # on slow registries / first-boot in air-gapped envs should bump these.
+  # Caught 2026-05-03 on prod cluster: original 15s/45s defaults killed pod
+  # in download-loop until v0.10.6.1 exposed the values knobs.
+  readinessProbe:
+    initialDelaySeconds: 300
+  livenessProbe:
+    initialDelaySeconds: 600
 
 mcp:
   enabled: true
@@ -463,6 +480,7 @@ runtimeProfiles: |
         REDIS_URL: "${REDIS_URL}"
         TRANSCRIPTION_SERVICE_URL: "${TRANSCRIPTION_SERVICE_URL}"
         TRANSCRIPTION_SERVICE_TOKEN: "${TRANSCRIPTION_SERVICE_TOKEN}"
+        TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
         # v0.10.5 Pack B.3 — propagate recording/storage env to bot pods (#235).
         # Without these, bot transcribes (has TRANSCRIPTION_SERVICE_*) and
         # silently skips recording upload (no MEETING_API_URL → no endpoint
@@ -498,6 +516,7 @@ runtimeProfiles: |
         DISPLAY: "${DISPLAY:-:99}"
         NODE_ENV: "production"
         REDIS_URL: "${REDIS_URL}"
+        TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
         # v0.10.5 Pack B.3 — recording/storage env propagation.
         MEETING_API_URL: "${MEETING_API_URL}"
         RECORDING_ENABLED: "${RECORDING_ENABLED:-true}"

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -236,7 +236,10 @@ ENV ADMIN_API_URL=http://localhost:8057 \
 
 # TTS Service
 ENV TTS_SERVICE_URL=http://localhost:8059 \
-    OPENAI_API_KEY=
+    OPENAI_API_KEY= \
+    PIPER_DEFAULT_VOICES=major \
+    PIPER_LOAD_VOICES=en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium \
+    PIPER_PRELOAD_STRICT=true
 
 # Display for headless browsers
 ENV DISPLAY=:99

--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -94,7 +94,9 @@ Edit `.env` at repo root. Created automatically on first `make lite`.
 | `MINIO_ACCESS_KEY`  | --                         | MinIO access key                  |
 | `MINIO_SECRET_KEY`  | --                         | MinIO secret key                  |
 | `LOG_LEVEL`         | `info`                     | Logging level for all services    |
-| `OPENAI_API_KEY`    | --                         | For OpenAI TTS voices (optional)  |
+| `PIPER_DEFAULT_VOICES` | `major`                  | Piper voices prepared at startup for local TTS |
+| `PIPER_LOAD_VOICES` | English/Spanish/Portuguese subset | Prepared voices kept loaded in memory |
+| `PIPER_PRELOAD_STRICT` | `true`                  | Fail startup if configured voices cannot be prepared |
 
 
 ## Debugging

--- a/deploy/lite/requirements.txt
+++ b/deploy/lite/requirements.txt
@@ -41,6 +41,7 @@ croniter>=2.0
 # TTS Service
 piper-tts>=1.4.0
 numpy>=1.21.0
+langdetect>=1.0.9
 
 # Utilities
 python-dotenv>=1.0

--- a/deploy/lite/supervisord.conf
+++ b/deploy/lite/supervisord.conf
@@ -174,7 +174,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=PYTHONUNBUFFERED="1",OPENAI_API_KEY="%(ENV_OPENAI_API_KEY)s"
+environment=PYTHONUNBUFFERED="1",OPENAI_API_KEY="%(ENV_OPENAI_API_KEY)s",PIPER_DEFAULT_VOICES="%(ENV_PIPER_DEFAULT_VOICES)s",PIPER_LOAD_VOICES="%(ENV_PIPER_LOAD_VOICES)s",PIPER_PRELOAD_STRICT="%(ENV_PIPER_PRELOAD_STRICT)s"
 
 ; =============================================================================
 ; API Gateway (:8056) — main entry point, routes to all services

--- a/docs/api/interactive-bots.mdx
+++ b/docs/api/interactive-bots.mdx
@@ -12,7 +12,7 @@ All interactive bot endpoints follow the pattern:
 Authentication: `X-API-Key` header (same as all Vexa endpoints).
 
 <Info>
-Interactive bot endpoints are available by default (`voice_agent_enabled` defaults to `true`). To disable, pass `voice_agent_enabled: false` when creating the bot. See [Bots API](bots) for the request format.
+Interactive bot endpoints require the bot to be created with `voice_agent_enabled: true`. The default is `false`, so recorder-only bots do not expose a meeting microphone unless you opt in. See [Bots API](bots) for the request format.
 </Info>
 
 <Info>
@@ -38,7 +38,7 @@ Most command endpoints return `202 Accepted` with this shape:
 
 ## Response Envelope (Codebase)
 
-The backend implementation for these endpoints is in `services/meeting-api/meeting_api/meetings.py` and returns stable command acknowledgements:
+The backend implementation for these endpoints is in `services/meeting-api/meeting_api/voice_agent.py` and returns stable command acknowledgements:
 
 | Endpoint | Status | Response |
 |---|---:|---|
@@ -67,8 +67,8 @@ curl -X POST "$API_BASE/bots/google_meet/abc-defg-hij/speak" \
   -H "X-API-Key: $API_KEY" \
   -d '{
     "text": "Hello everyone, here is the summary.",
-    "provider": "openai",
-    "voice": "nova"
+    "provider": "piper",
+    "voice": "auto"
   }'
 ```
 
@@ -77,8 +77,8 @@ curl -X POST "$API_BASE/bots/google_meet/abc-defg-hij/speak" \
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | string | -- | Text to speak (mutually exclusive with `audio_url` / `audio_base64`) |
-| `provider` | string | `"openai"` | TTS provider |
-| `voice` | string | `"alloy"` | Voice ID. OpenAI voices: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer` |
+| `provider` | string | `"piper"` | TTS provider. `piper` is the self-hosted default. |
+| `voice` | string | `"auto"` | Voice ID. `auto` detects the text language and chooses a prepared Piper voice. Piper voice names and OpenAI-style aliases (`alloy`, `nova`, etc.) are also accepted. |
   </Tab>
 
   <Tab title="Pre-rendered Audio (URL)">
@@ -96,10 +96,9 @@ curl -X POST "$API_BASE/bots/google_meet/abc-defg-hij/speak" \
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `audio_url` | string | -- | URL to an audio file |
-| `format` | string | `"wav"` | Audio format: `wav`, `mp3`, `pcm`, `opus` |
-| `sample_rate` | int | `24000` | Sample rate in Hz (for PCM) |
-| `channels` | int | `1` | Channel count (for PCM) |
+| `audio_url` | string | -- | URL to a pre-rendered audio file. The bot downloads/decodes it directly; the TTS service is not called. |
+| `format` | string | `"wav"` | Audio format hint: `wav`, `mp3`, `pcm`, `opus` |
+| `sample_rate` | int | `24000` | Sample rate in Hz for raw PCM input |
   </Tab>
 
   <Tab title="Pre-rendered Audio (Base64)">
@@ -117,12 +116,15 @@ curl -X POST "$API_BASE/bots/google_meet/abc-defg-hij/speak" \
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `audio_base64` | string | -- | Base64-encoded audio data |
-| `format` | string | `"wav"` | Audio format: `wav`, `mp3`, `pcm`, `opus` |
-| `sample_rate` | int | `24000` | Sample rate in Hz (for PCM) |
-| `channels` | int | `1` | Channel count (for PCM) |
+| `audio_base64` | string | -- | Base64-encoded pre-rendered audio data. Use this for stored/generated files that should play exactly as provided. |
+| `format` | string | `"wav"` | Audio format hint: `wav`, `mp3`, `pcm`, `opus` |
+| `sample_rate` | int | `24000` | Sample rate in Hz for raw PCM input |
   </Tab>
 </Tabs>
+
+For text requests, Meeting API publishes a `speak` command to the bot. The bot calls the local Vexa TTS service (`/v1/audio/speech`) and streams the resulting PCM into its virtual microphone.
+
+For `audio_url` or `audio_base64`, Meeting API publishes a `speak_audio` command instead. The bot decodes the supplied file with ffmpeg, plays it through the same virtual microphone, and re-mutes when playback ends.
 
 <Accordion title="Response (202)">
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -58,7 +58,7 @@ Major architectural refactor. If upgrading from 0.9.x or earlier, read the migra
     Key new variables:
     - `TRANSCRIPTION_SERVICE_URL` (required) — transcription endpoint
     - `TRANSCRIPTION_SERVICE_TOKEN` (required) — transcription API key
-    - `OPENAI_API_KEY` (optional) — for TTS/speaking bot feature
+    - `PIPER_DEFAULT_VOICES` / `PIPER_LOAD_VOICES` (optional) — local Piper voice preparation for TTS/speaking bots
     - `STORAGE_BACKEND` (optional) — `local`, `minio`, or `s3`
   </Step>
   <Step title="Rebuild and restart">

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -103,9 +103,9 @@ Storage configuration:
 
 ## Interactive Bots (Meeting Interaction)
 
-By default (`voice_agent_enabled: true`), every bot is an interactive meeting participant. An external agent can instruct it to:
+When a bot is created with `voice_agent_enabled: true`, it becomes an interactive meeting participant. An external agent can instruct it to:
 
-- **Speak** via text-to-speech (OpenAI TTS → PulseAudio → meeting mic)
+- **Speak** via local Piper text-to-speech, or play a pre-rendered `audio_url` / `audio_base64` file through the same virtual microphone path
 - **Read/write chat** messages in the meeting
 - **Share screen** content (images, URLs, video)
 
@@ -120,4 +120,3 @@ Deleting a meeting is designed to be deliberate: it purges transcript artifacts 
 API details:
 
 - [`user_api_guide.md`](user_api_guide)
-

--- a/docs/interactive-bots.mdx
+++ b/docs/interactive-bots.mdx
@@ -19,7 +19,7 @@ The Interactive Bots feature transforms the Vexa bot from a passive transcriptio
 
 <Steps>
   <Step title="Send a bot to a meeting">
-    Interactive bot capabilities are **enabled by default** (`voice_agent_enabled: true`). Just send a regular bot:
+    Opt in to interactive audio with `voice_agent_enabled: true`. Recorder-only bots leave this disabled.
 
     ```bash
     curl -X POST "$API_BASE/bots" \
@@ -28,7 +28,8 @@ The Interactive Bots feature transforms the Vexa bot from a passive transcriptio
       -d '{
         "platform": "google_meet",
         "native_meeting_id": "abc-defg-hij",
-        "bot_name": "AI Assistant"
+        "bot_name": "AI Assistant",
+        "voice_agent_enabled": true
       }'
     ```
   </Step>
@@ -37,7 +38,16 @@ The Interactive Bots feature transforms the Vexa bot from a passive transcriptio
     curl -X POST "$API_BASE/bots/google_meet/abc-defg-hij/speak" \
       -H "Content-Type: application/json" \
       -H "X-API-Key: $API_KEY" \
-      -d '{"text": "Hello everyone, I am the meeting assistant.", "voice": "nova"}'
+      -d '{"text": "Hello everyone, I am the meeting assistant.", "provider": "piper", "voice": "auto"}'
+    ```
+  </Step>
+  <Step title="Play a pre-rendered audio file">
+    ```bash
+    AUDIO_BASE64="$(base64 < greeting.wav | tr -d '\n')"
+    curl -X POST "$API_BASE/bots/google_meet/abc-defg-hij/speak" \
+      -H "Content-Type: application/json" \
+      -H "X-API-Key: $API_KEY" \
+      -d "{\"audio_base64\":\"$AUDIO_BASE64\",\"format\":\"wav\"}"
     ```
   </Step>
   <Step title="Send a chat message">
@@ -92,19 +102,28 @@ When the meeting is not active, interactive endpoints return:
 
 ## How It Works
 
-When `voice_agent_enabled` is set, the bot's audio pipeline changes: instead of feeding silence as mic input, the bot reads from a PulseAudio virtual microphone that receives TTS audio. The bot starts muted and auto-unmutes only when speaking.
+When `voice_agent_enabled` is set, the bot reads from a PulseAudio virtual microphone. The bot starts muted, unmutes only while playing speech/audio, and re-mutes when playback finishes or is interrupted.
 
-### Audio Pipeline (TTS)
+### Audio Pipeline
 
 ```
-OpenAI TTS API
-  -> PCM stream (24 kHz, mono)
-  -> PulseAudio virtual sink
-  -> Chromium default audio source
-  -> WebRTC -> meeting participants hear speech
+POST /speak {"text": "...", "provider": "piper", "voice": "auto"}
+  -> Meeting API publishes Redis speak command
+  -> bot calls local Vexa TTS service (/v1/audio/speech)
+  -> Piper returns PCM stream (24 kHz, mono)
+  -> PulseAudio tts_sink -> virtual_mic
+  -> Chromium microphone -> WebRTC -> meeting participants hear speech
 ```
 
-The bot unmutes before playback and re-mutes once audio finishes or is interrupted.
+Pre-rendered audio uses the same meeting microphone path but skips synthesis:
+
+```
+POST /speak {"audio_url": "..."} or {"audio_base64": "...", "format": "wav"}
+  -> Meeting API publishes Redis speak_audio command
+  -> bot downloads/decodes the audio with ffmpeg
+  -> PulseAudio tts_sink -> virtual_mic
+  -> Chromium microphone -> WebRTC -> meeting participants hear the file
+```
 
 ### Screen Content Pipeline
 
@@ -225,16 +244,18 @@ When interactive bot mode is enabled, additional events are published on the [We
 
 ## Prerequisites
 
-<ResponseField name="OPENAI_API_KEY" type="string" required>
-  OpenAI API key for text-to-speech synthesis. Passed through `deploy/compose/docker-compose.yml` to the bot container.
+<ResponseField name="TTS_SERVICE_URL" type="string">
+  Base URL for the local Vexa TTS service. Compose and Lite wire this automatically.
 </ResponseField>
+
+No OpenAI key is required for default speech. The default `provider` is `piper`, and the default `voice` is `auto`, which chooses a prepared Piper voice from the input language.
 
 PulseAudio is already configured in the bot container (`entrypoint.sh`). No manual setup is needed.
 
 ## Known Limitations
 
 1. **Virtual camera is experimental** -- the canvas-based virtual camera works intermittently on Google Meet. Screen share is more reliable for displaying visual content.
-2. **Single TTS provider** -- currently only OpenAI TTS is implemented. The architecture supports adding other providers.
+2. **Text and file playback are separate paths** -- text requests synthesize through local Piper; `audio_url` and `audio_base64` play the supplied file directly through ffmpeg/PulseAudio.
 3. **Zoom requires native SDK artifacts** -- without Zoom Meeting SDK binaries, Zoom joins fail during startup.
 4. **No speech queue** -- rapid speak commands may overlap. Wait for the `speak.completed` WebSocket event before sending the next command, or use `DELETE /speak` to interrupt.
 5. **Teams avatar not visible** -- Teams SFU returns `a=inactive` for video from anonymous guests, so the bot's virtual camera/avatar is never visible to other Teams participants. Use screen share instead. ([#124](https://github.com/Vexa-ai/vexa/issues/124))

--- a/docs/paperclip-vs-vexa.md
+++ b/docs/paperclip-vs-vexa.md
@@ -382,7 +382,7 @@ curl -X POST /bots -d '{
 
 # Make the bot speak
 curl -X POST /bots/google_meet/abc-defg-hij/speak \
-  -d '{"text": "Thanks for joining. Taking notes.", "voice": "alloy"}'
+  -d '{"text": "Thanks for joining. Taking notes.", "provider": "piper", "voice": "auto"}'
 
 # Get live transcript
 curl /transcripts/google_meet/abc-defg-hij

--- a/docs/vexa-lite-deployment.mdx
+++ b/docs/vexa-lite-deployment.mdx
@@ -52,7 +52,6 @@ docker run -d \
   -e ADMIN_API_TOKEN="your-secret-admin-token" \
   -e TRANSCRIPTION_SERVICE_URL="https://transcription.vexa.ai/v1/audio/transcriptions" \
   -e TRANSCRIPTION_SERVICE_TOKEN="your-transcription-api-key" \
-  -e OPENAI_API_KEY="sk-your-openai-key" \
   vexaai/vexa-lite:latest
 ```
 
@@ -83,7 +82,6 @@ docker run -d \
   -e ADMIN_API_TOKEN="your-secret-admin-token" \
   -e TRANSCRIPTION_SERVICE_URL="https://transcription.vexa.ai/v1/audio/transcriptions" \
   -e TRANSCRIPTION_SERVICE_TOKEN="your-transcription-api-key" \
-  -e OPENAI_API_KEY="sk-your-openai-key" \
   vexaai/vexa-lite:latest
 ```
 
@@ -167,13 +165,19 @@ Vexa Lite includes a built-in Redis server. If `REDIS_HOST` is `localhost` or un
 
 ### Interactive Bots (TTS & Virtual Camera)
 
-<Warning>
-  The OpenAI TTS dependency is **temporary**. A fully local TTS engine (no external API keys required) is planned — see [issue #130](https://github.com/Vexa-ai/vexa/issues/130).
-</Warning>
-
-<ResponseField name="OPENAI_API_KEY" type="string">
-  OpenAI API key for text-to-speech (temporary — will be replaced by local TTS, see [#130](https://github.com/Vexa-ai/vexa/issues/130)). Required for the `/speak` command to work. Without this, bots can still join meetings and transcribe, but TTS will be unavailable.
+<ResponseField name="TTS_SERVICE_URL" type="string" default="http://127.0.0.1:8059">
+  Internal local TTS service URL used by voice-agent bots. Vexa Lite wires this automatically.
 </ResponseField>
+
+<ResponseField name="PIPER_DEFAULT_VOICES" type="string" default="major">
+  Piper voices to prepare on startup. `major` prepares the release-supported major language set for `voice: "auto"`.
+</ResponseField>
+
+<ResponseField name="PIPER_LOAD_VOICES" type="string">
+  Optional comma-separated subset of prepared Piper voices to keep loaded in memory.
+</ResponseField>
+
+No OpenAI API key is required for the default `/speak` path. Text requests use the local Piper-backed TTS service with `provider: "piper"` and `voice: "auto"`. Pre-rendered audio requests (`audio_url` or `audio_base64`) bypass synthesis and are decoded by the bot before playback through the same virtual microphone.
 
 ### Recording Storage
 

--- a/docs/vexa-presentation.md
+++ b/docs/vexa-presentation.md
@@ -526,8 +526,8 @@ curl -X POST https://api.vexa.ai/bots/google_meet/abc-defg-hij/speak \
   -H "Content-Type: application/json" \
   -d '{
     "text": "Thanks for joining. I will be taking notes.",
-    "provider": "openai",
-    "voice": "alloy"
+    "provider": "piper",
+    "voice": "auto"
   }'
 # 202 Accepted → {"message": "Speak command sent", "meeting_id": 12345}
 

--- a/docs/youtube-agent-runtime.md
+++ b/docs/youtube-agent-runtime.md
@@ -575,7 +575,7 @@ One API call. Platform and meeting ID. The Meeting API calls the Runtime API to 
 # Make the bot speak in the meeting
 curl -X POST https://api.vexa.ai/bots/google_meet/abc-defg-hij/speak \
   -H "X-API-Key: $API_KEY" \
-  -d '{"text": "Thanks for joining. I will be taking notes.", "voice": "alloy"}'
+  -d '{"text": "Thanks for joining. I will be taking notes.", "provider": "piper", "voice": "auto"}'
 
 # Send a chat message
 curl -X POST https://api.vexa.ai/bots/google_meet/abc-defg-hij/chat \

--- a/services/meeting-api/README.md
+++ b/services/meeting-api/README.md
@@ -25,9 +25,12 @@ Bot lifecycle management service. Handles meeting CRUD, voice agent controls (TT
 - `PUT /bots/{platform}/{meeting_id}/config` — update config
 
 #### Voice Agent
-- `POST /bots/{platform}/{meeting_id}/speak` — TTS
+- `POST /bots/{platform}/{meeting_id}/speak` — make an active voice-agent bot speak. Text requests publish a `speak` command with local Piper defaults (`provider: "piper"`, `voice: "auto"`). `audio_url` and `audio_base64` requests publish `speak_audio` and play the supplied file directly through the bot.
+- `DELETE /bots/{platform}/{meeting_id}/speak` — interrupt current speech and re-mute the bot
 - `POST /bots/{platform}/{meeting_id}/chat` — chat message
 - `POST /bots/{platform}/{meeting_id}/screen` — screen content
+
+`/speak` requires the target bot to have been created with `voice_agent_enabled: true`; recorder-only bots do not expose the playback microphone path.
 
 #### Recordings
 - `GET /recordings` — list recordings for the authenticated user
@@ -147,4 +150,3 @@ The service has solid domain logic, good test coverage of happy paths, and a wel
 | 6 | Runtime API reachable at `RUNTIME_API_URL` for container lifecycle | 20 | ceiling | untested | — | — | — |
 
 Confidence: 0 (untested)
-

--- a/services/meeting-api/meeting_api/schemas.py
+++ b/services/meeting-api/meeting_api/schemas.py
@@ -1299,7 +1299,7 @@ class SpeakRequest(BaseModel):
     format: Optional[str] = Field("wav", description="Audio format: wav, mp3, pcm, opus")
     sample_rate: Optional[int] = Field(24000, description="Sample rate for PCM audio (Hz)")
     provider: Optional[str] = Field("piper", description="TTS provider: piper (default, local), openai, cartesia, elevenlabs")
-    voice: Optional[str] = Field("alloy", description="Voice ID for TTS")
+    voice: Optional[str] = Field("auto", description="Voice ID for TTS; auto chooses a local Piper voice from text language")
 
     @field_validator('text', 'audio_url', 'audio_base64')
     @classmethod

--- a/services/meeting-api/meeting_api/voice_agent.py
+++ b/services/meeting-api/meeting_api/voice_agent.py
@@ -51,8 +51,8 @@ async def bot_speak(
             "action": "speak",
             "meeting_id": meeting.id,
             "text": req["text"],
-            "provider": req.get("provider", "openai"),
-            "voice": req.get("voice", "alloy"),
+            "provider": req.get("provider", "piper"),
+            "voice": req.get("voice", "auto"),
         }
     elif req.get("audio_url") or req.get("audio_base64"):
         command = {

--- a/services/meeting-api/tests/test_voice_agent.py
+++ b/services/meeting-api/tests/test_voice_agent.py
@@ -79,6 +79,27 @@ class TestSpeak:
         parsed = json.loads(payload)
         assert parsed["action"] == "speak"
         assert parsed["text"] == "Hello, world!"
+        assert parsed["provider"] == "piper"
+        assert parsed["voice"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_speak_text_explicit_provider_and_voice(self, client, mock_redis, active_meeting):
+        """POST /speak keeps explicit provider/voice overrides."""
+        with _patch_find_active(active_meeting):
+            resp = await client.post(
+                f"/bots/{TEST_PLATFORM}/{TEST_NATIVE_MEETING_ID}/speak",
+                json={
+                    "text": "Hello, world!",
+                    "provider": "openai",
+                    "voice": "alloy",
+                },
+            )
+
+        assert resp.status_code == 202
+        parsed = json.loads(mock_redis.publish.call_args[0][1])
+        assert parsed["action"] == "speak"
+        assert parsed["provider"] == "openai"
+        assert parsed["voice"] == "alloy"
 
     @pytest.mark.asyncio
     async def test_speak_audio_url(self, client, mock_redis, active_meeting):
@@ -92,6 +113,23 @@ class TestSpeak:
         assert resp.status_code == 202
         parsed = json.loads(mock_redis.publish.call_args[0][1])
         assert parsed["action"] == "speak_audio"
+        assert parsed["audio_url"] == "https://example.com/audio.wav"
+
+    @pytest.mark.asyncio
+    async def test_speak_audio_base64(self, client, mock_redis, active_meeting):
+        """POST /speak with audio_base64 → publishes speak_audio command."""
+        with _patch_find_active(active_meeting):
+            resp = await client.post(
+                f"/bots/{TEST_PLATFORM}/{TEST_NATIVE_MEETING_ID}/speak",
+                json={"audio_base64": "UklGRg==", "format": "wav", "sample_rate": 24000},
+            )
+
+        assert resp.status_code == 202
+        parsed = json.loads(mock_redis.publish.call_args[0][1])
+        assert parsed["action"] == "speak_audio"
+        assert parsed["audio_base64"] == "UklGRg=="
+        assert parsed["format"] == "wav"
+        assert parsed["sample_rate"] == 24000
 
     @pytest.mark.asyncio
     async def test_speak_no_content(self, client, mock_redis, active_meeting):

--- a/services/runtime-api/profiles.yaml
+++ b/services/runtime-api/profiles.yaml
@@ -39,6 +39,7 @@ profiles:
       REDIS_URL: "${REDIS_URL}"
       TRANSCRIPTION_SERVICE_URL: "${TRANSCRIPTION_SERVICE_URL}"
       TRANSCRIPTION_SERVICE_TOKEN: "${TRANSCRIPTION_SERVICE_TOKEN}"
+      TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
     ports:
       "9222/tcp": {}         # CDP debug port
 
@@ -60,6 +61,7 @@ profiles:
       DISPLAY: "${DISPLAY:-:99}"
       NODE_ENV: "production"
       REDIS_URL: "${REDIS_URL}"
+      TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
     ports:
       "9222/tcp": {}         # CDP debug port
 

--- a/services/tts-service/README.md
+++ b/services/tts-service/README.md
@@ -98,8 +98,11 @@ curl -X POST http://localhost:8002/v1/audio/speech \
 ### Debug
 
 - Logs to stdout: `%(asctime)s - %(name)s - %(levelname)s - %(message)s`
-- Major supported voice models are prepared on startup; first request for a non-prepared voice may still be slower
-- Invalid voice names that can't be downloaded return 404
+- Voice handling at request time:
+  - **Prepared and loaded** voice (in `PIPER_LOAD_VOICES`): served from the in-memory cache; first byte under ~100 ms.
+  - **Prepared but not loaded** voice (e.g. `de_DE-thorsten-medium` under the default `PIPER_DEFAULT_VOICES=major` set): the ONNX model is already on disk from startup, so the first request lazy-loads it into RAM in roughly 1 s and returns a normal WAV (verified during v0.10.6.3 stitch validation: `de_DE-thorsten-medium` → 200 / ~49 KB after a 1.2 s first-call latency).
+  - **Unsupported voice name** (any string not in the catalogue built from `MAJOR_DEFAULT_VOICES ∪ VOICE_ALIASES ∪ LANG_DEFAULT_VOICE`, e.g. `zz_ZZ-fake-medium`): `_voice_model_paths` rejects it with **HTTP 400 `Unsupported voice name`** without touching the network. This is the canonical "bad voice" failure mode.
+  - **Supported voice whose model download fails** (e.g. HuggingFace unreachable on first use of a catalogue voice that wasn't preloaded): `_download_voice_model` raises **HTTP 404 `Voice '<name>' not found and could not be downloaded`**.
 - The `model` field is accepted but ignored (kept for OpenAI API compatibility)
 
 ## DoD

--- a/services/tts-service/README.md
+++ b/services/tts-service/README.md
@@ -6,10 +6,22 @@ Bot containers need text-to-speech to participate as voice agents in meetings. T
 
 ## What
 
-A local text-to-speech service using **Piper TTS** (ONNX models). Exposes an OpenAI-compatible `/v1/audio/speech` endpoint so existing code that targets OpenAI's TTS API works without changes. Voice models are auto-downloaded from HuggingFace on first use.
+OpenAI-compatible `/v1/audio/speech` endpoint backed by **Piper TTS** local ONNX inference. There are no synth-time external network calls for prepared voices; remaining voices are auto-downloaded from HuggingFace on first request.
 
-Input: JSON body `{"model": "tts-1", "input": "text to speak", "voice": "nova", "response_format": "wav"}`
-Output: Audio (WAV 24kHz mono by default, or raw PCM)
+The endpoint shape stays OpenAI-compatible so clients can reuse their existing request body and consume interchangeable audio bytes.
+
+Input: JSON body
+```json
+{"model": "tts-1", "input": "Hola, ¿cómo estás?", "voice": "auto", "response_format": "wav"}
+```
+
+- `voice`: explicit Piper name (`en_US-amy-medium`), OpenAI-style alias (`alloy`/`nova`/...), or `auto` (auto-detects language from `input` and picks a matching voice; supported major languages are prepared by default).
+- `response_format`: `wav` (default) or `pcm` (raw Int16LE 24kHz mono).
+- `model`: accepted for OpenAI API compatibility and ignored by Piper.
+
+Output: audio bytes (WAV 24kHz mono by default, or raw PCM).
+
+In live meetings this service is used only for text requests to `POST /bots/{platform}/{native_meeting_id}/speak`. Meeting API publishes a `speak` command, the bot calls this service, and the returned PCM is played through the bot's PulseAudio virtual microphone. Pre-rendered `audio_url` and `audio_base64` `/speak` requests bypass this service; the bot decodes those files directly and plays them through the same microphone path.
 
 ### Endpoints
 
@@ -38,9 +50,9 @@ Supported formats: `wav` (default), `pcm` (raw Int16LE 24kHz mono)
 
 ### Dependencies
 
-- **Piper TTS** (bundled) — local ONNX inference, no external calls
-- No database, no Redis, no other Vexa services
-- No API keys required for operation
+- **Piper TTS** (bundled) — local ONNX inference, no external calls at synth time for prepared voices.
+- No database, no Redis, no other Vexa services.
+- No API keys required for speech synthesis.
 
 ## How
 
@@ -62,7 +74,9 @@ uvicorn main:app --host 0.0.0.0 --port 8002
 | `TTS_API_TOKEN` | Optional access token — if set, requests must include `X-API-Key` header |
 | `TTS_OUTPUT_SAMPLE_RATE` | Output sample rate (default: `24000`) |
 | `PIPER_VOICES_DIR` | Voice model storage directory (default: `/app/voices`) |
-| `PIPER_DEFAULT_VOICES` | Comma-separated voices to pre-load on startup (default: `en_US-amy-medium,en_US-danny-low`) |
+| `PIPER_DEFAULT_VOICES` | Comma-separated voices to prepare on startup, or `major` (default) for the release-supported major language set |
+| `PIPER_LOAD_VOICES` | Comma-separated prepared voices to also keep loaded in memory (default: English + Portuguese + Spanish) |
+| `PIPER_PRELOAD_STRICT` | If true, startup fails when a configured voice cannot be prepared (default: `true`) |
 | `LOG_LEVEL` | Logging level (default: `INFO`) |
 
 ### Test
@@ -77,14 +91,14 @@ curl http://localhost:8002/voices
 # Synthesize speech (save as WAV)
 curl -X POST http://localhost:8002/v1/audio/speech \
   -H "Content-Type: application/json" \
-  -d '{"model": "tts-1", "input": "Hello world", "voice": "nova", "response_format": "wav"}' \
+  -d '{"model": "tts-1", "input": "Hello world", "voice": "auto", "response_format": "wav"}' \
   --output speech.wav
 ```
 
 ### Debug
 
 - Logs to stdout: `%(asctime)s - %(name)s - %(levelname)s - %(message)s`
-- Voice models are downloaded on first use — first request for a new voice will be slower
+- Major supported voice models are prepared on startup; first request for a non-prepared voice may still be slower
 - Invalid voice names that can't be downloaded return 404
 - The `model` field is accepted but ignored (kept for OpenAI API compatibility)
 

--- a/services/tts-service/main.py
+++ b/services/tts-service/main.py
@@ -37,11 +37,49 @@ API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
 # the vexa-bot (paplay) expects 24000 Hz.  We resample when they differ.
 OUTPUT_SAMPLE_RATE = int(os.getenv("TTS_OUTPUT_SAMPLE_RATE", "24000"))
 
-# Default voices to pre-load on startup (empty = lazy load all)
-DEFAULT_VOICES = os.getenv(
-    "PIPER_DEFAULT_VOICES",
-    "en_US-amy-medium,en_US-danny-low",
-).split(",")
+# Piper voices that should be ready before a deployment accepts traffic. These
+# are the supported "major language" voices for prompt /speak output today.
+MAJOR_DEFAULT_VOICES = [
+    "en_US-amy-medium",
+    "en_US-danny-low",
+    "es_ES-davefx-medium",
+    "fr_FR-siwis-medium",
+    "de_DE-thorsten-medium",
+    "it_IT-paola-medium",
+    "pt_BR-faber-medium",
+    "nl_NL-mls-medium",
+    "pl_PL-mc_speech-medium",
+    "ru_RU-irina-medium",
+    "uk_UA-ukrainian_tts-medium",
+    "zh_CN-huayan-medium",
+    "ar_JO-kareem-medium",
+    "tr_TR-dfki-medium",
+    "hi_IN-pratham-medium",
+]
+
+
+def _configured_default_voices() -> list[str]:
+    raw = os.getenv("PIPER_DEFAULT_VOICES", "major").strip()
+    if raw.lower() == "major":
+        return MAJOR_DEFAULT_VOICES.copy()
+    return [voice.strip() for voice in raw.split(",") if voice.strip()]
+
+
+DEFAULT_VOICES = _configured_default_voices()
+DEFAULT_LOADED_VOICES = [
+    voice.strip()
+    for voice in os.getenv(
+        "PIPER_LOAD_VOICES",
+        "en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium",
+    ).split(",")
+    if voice.strip()
+]
+PIPER_PRELOAD_STRICT = os.getenv("PIPER_PRELOAD_STRICT", "true").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 # Map OpenAI voice names to Piper voice names for backward compatibility
 VOICE_ALIASES: dict[str, str] = {
@@ -52,6 +90,126 @@ VOICE_ALIASES: dict[str, str] = {
     "nova": "en_US-kristin-medium",
     "shimmer": "en_US-lessac-medium",
 }
+
+# Default Piper voice per ISO-639-1 language code. Used when the caller
+# does not pin a specific voice and we infer language from the input text.
+# All names match the rhasspy/piper-voices catalogue on HuggingFace.
+LANG_DEFAULT_VOICE: dict[str, str] = {
+    "en": "en_US-amy-medium",
+    "es": "es_ES-davefx-medium",
+    "fr": "fr_FR-siwis-medium",
+    "de": "de_DE-thorsten-medium",
+    "it": "it_IT-paola-medium",
+    "pt": "pt_BR-faber-medium",
+    "nl": "nl_NL-mls-medium",
+    "pl": "pl_PL-mc_speech-medium",
+    "ru": "ru_RU-irina-medium",
+    "uk": "uk_UA-ukrainian_tts-medium",
+    "zh": "zh_CN-huayan-medium",
+    # ja: rhasspy/piper-voices has no Japanese voice today; entries
+    # detected as 'ja' fall through to the English default fallback
+    # with a structured WARN (tts.lang_detection.unmapped). Followed
+    # up under TTS engine-swap research.
+    "ar": "ar_JO-kareem-medium",
+    "tr": "tr_TR-dfki-medium",
+    "ro": "ro_RO-mihai-medium",
+    "cs": "cs_CZ-jirka-medium",
+    "hu": "hu_HU-anna-medium",
+    "el": "el_GR-rapunzelina-low",
+    "fi": "fi_FI-harri-medium",
+    "da": "da_DK-talesyntese-medium",
+    "sv": "sv_SE-nst-medium",
+    "no": "no_NO-talesyntese-medium",
+    "ca": "ca_ES-upc_ona-medium",
+    "vi": "vi_VN-vais1000-medium",
+    "fa": "fa_IR-amir-medium",
+    "sk": "sk_SK-lili-medium",
+    "sl": "sl_SI-artur-medium",
+    "lv": "lv_LV-aivars-medium",
+    "sr": "sr_RS-serbski_institut-medium",
+    "hi": "hi_IN-pratham-medium",
+}
+
+# Local file paths are only constructed for the Piper voices this release
+# supports. This keeps `/v1/audio/speech` from turning arbitrary request
+# strings into filesystem paths while still covering aliases and auto-language
+# routing.
+SUPPORTED_PIPER_VOICES: dict[str, str] = {
+    voice_name: voice_name
+    for voice_name in sorted(
+        set(MAJOR_DEFAULT_VOICES)
+        | set(VOICE_ALIASES.values())
+        | set(LANG_DEFAULT_VOICE.values())
+    )
+}
+
+# Unicode-script → ISO-639-1 hint. Cheap pre-check before invoking
+# langdetect; for non-Latin scripts the script alone is enough to pick
+# a language with high confidence.
+_SCRIPT_RANGES: list[tuple[int, int, str]] = [
+    (0x0400, 0x04FF, "ru"),    # Cyrillic; Ukrainian-only chars are handled before this fallback
+    (0x0500, 0x052F, "ru"),    # Cyrillic Supplement
+    (0x0590, 0x05FF, "he"),    # Hebrew (no voice today; falls through to en + WARN)
+    (0x0600, 0x06FF, "ar"),    # Arabic
+    (0x0750, 0x077F, "ar"),    # Arabic Supplement
+    (0x08A0, 0x08FF, "ar"),    # Arabic Extended-A
+    (0x0900, 0x097F, "hi"),    # Devanagari
+    (0x0E00, 0x0E7F, "th"),    # Thai (no voice today; falls through to en + WARN)
+    (0x0370, 0x03FF, "el"),    # Greek
+    (0x3040, 0x309F, "ja"),    # Hiragana
+    (0x30A0, 0x30FF, "ja"),    # Katakana
+    (0xAC00, 0xD7AF, "ko"),    # Hangul (no voice today; falls through to en + WARN)
+    (0x4E00, 0x9FFF, "zh"),    # CJK Unified Ideographs (defaults to zh; ja text without kana is ambiguous but rare)
+]
+
+
+def _detect_language(text: str) -> Optional[str]:
+    """Return ISO-639-1 lang code for `text`, or None if undetermined.
+
+    Strategy:
+      1. Pre-pass for Hiragana/Katakana — definitive Japanese marker even
+         when mixed with CJK Unified Ideographs (kanji).
+      2. Unicode-script heuristic for the first non-ASCII char.
+      3. Latin-script disambiguation via langdetect.
+    """
+    if not text:
+        return None
+
+    # 1. Whole-text scan: any kana → Japanese (kanji-only is ambiguous
+    # zh↔ja, defaults to zh below; with kana present the answer is
+    # unambiguous).
+    for ch in text:
+        cp = ord(ch)
+        if (0x3040 <= cp <= 0x309F) or (0x30A0 <= cp <= 0x30FF):
+            return "ja"
+        if (0xAC00 <= cp <= 0xD7AF):
+            # Hangul anywhere → Korean.
+            return "ko"
+        if ch in "ґєіїҐЄІЇ":
+            return "uk"
+
+    # 2. Script heuristic — first non-ASCII char drives the decision.
+    for ch in text:
+        cp = ord(ch)
+        if cp < 0x80:
+            continue
+        for lo, hi, lang in _SCRIPT_RANGES:
+            if lo <= cp <= hi:
+                return lang
+        # First non-ASCII char isn't a tracked script; fall through to langdetect.
+        break
+
+    # 3. langdetect for Latin-script text (en/es/fr/de/it/pt/nl/...).
+    try:
+        from langdetect import detect, DetectorFactory
+        DetectorFactory.seed = 0  # deterministic — same text → same result
+        return detect(text)
+    except Exception as exc:
+        # langdetect raises LangDetectException on inputs too short / no
+        # detectable features. Surface a structured signal instead of
+        # silently swallowing — caller logs `tts.lang_detection.failed`.
+        logger.debug("[TTS] langdetect failed on text len=%d: %s", len(text), exc)
+        return None
 
 # ---------------------------------------------------------------------------
 # Audio resampling (linear interpolation — lightweight, no scipy needed)
@@ -75,34 +233,110 @@ def _resample_int16(pcm_int16: bytes, src_rate: int, dst_rate: int) -> bytes:
 # ---------------------------------------------------------------------------
 
 _loaded_voices: dict[str, "PiperVoice"] = {}  # type: ignore[name-defined]
+def _voice_model_paths(voice_name: str) -> tuple[Path, Path]:
+    """Return safe local Piper model paths for a validated catalogue voice."""
+    voice_file_stem = SUPPORTED_PIPER_VOICES.get(voice_name)
+    if voice_file_stem is None:
+        raise HTTPException(status_code=400, detail=f"Unsupported voice name: {voice_name!r}")
+
+    voices_root = VOICES_DIR.resolve()
+    model_path = (voices_root / f"{voice_file_stem}.onnx").resolve()
+    config_path = (voices_root / f"{voice_file_stem}.onnx.json").resolve()
+    try:
+        model_path.relative_to(voices_root)
+        config_path.relative_to(voices_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid voice path: {voice_name!r}") from exc
+
+    return model_path, config_path
 
 
-def _resolve_voice_name(name: str) -> str:
-    """Resolve an alias (e.g. 'alloy') or pass through a Piper voice name."""
-    return VOICE_ALIASES.get(name, name)
+def _download_voice_model(voice_name: str) -> None:
+    """Ensure a Piper voice model exists locally without loading it into RAM."""
+    from piper.download_voices import download_voice
+
+    model_path, config_path = _voice_model_paths(voice_name)
+
+    if model_path.exists() and config_path.exists():
+        return
+
+    logger.info("[TTS] Downloading voice: %s -> %s", voice_name, VOICES_DIR)
+    try:
+        download_voice(voice_name, VOICES_DIR)
+    except Exception as exc:
+        logger.error("[TTS] Failed to download voice %s: %s", voice_name, exc)
+        raise HTTPException(
+            status_code=404,
+            detail=f"Voice '{voice_name}' not found and could not be downloaded: {exc}",
+        ) from exc
+
+
+def _resolve_voice_name(name: str, *, text: str = "") -> str:
+    """Resolve a voice request to a Piper voice name.
+
+    Resolution order:
+      1. `auto` (or empty) → detect language of `text`, look up
+         LANG_DEFAULT_VOICE; if no mapping, log a structured WARN
+         (`tts.lang_detection.unmapped`) and use English default.
+      2. Known OpenAI-style alias (alloy / nova / echo / …):
+         a. If the input text is Latin-script-only (no Cyrillic, CJK,
+            Arabic, etc.), use the alias's English Piper voice as the
+            historical default.
+         b. If the text has a non-Latin script, the alias would route
+            English espeak-ng over non-Latin codepoints and emit
+            letter-by-letter spelling. Detect language from text and
+            override the alias with the detected language's voice. Log
+            a structured INFO (`tts.alias_overridden_by_language`) so
+            the override is observable.
+         c. Honors backward-compat for English-only callers; protects
+            every other caller from the "speaking-letter-by-letter"
+            failure mode.
+      3. Anything else → pass through as a literal Piper voice name.
+    """
+    if name in (None, "", "auto"):
+        lang = _detect_language(text)
+        if lang and lang in LANG_DEFAULT_VOICE:
+            chosen = LANG_DEFAULT_VOICE[lang]
+            logger.info("[TTS] auto-lang detected=%s voice=%s text_len=%d", lang, chosen, len(text))
+            return chosen
+        logger.warning(
+            "[TTS] tts.lang_detection.unmapped detected=%s text_len=%d "
+            "— falling back to English default (#NEW-tts-lang-fallback)",
+            lang, len(text),
+        )
+        return LANG_DEFAULT_VOICE["en"]
+
+    if name in VOICE_ALIASES:
+        # Alias = backward-compat OpenAI voice name. They all map to
+        # English Piper voices. If the text is non-Latin, English voice
+        # would mispronounce letter-by-letter — override.
+        has_non_latin = any(ord(ch) >= 0x80 for ch in text)
+        if has_non_latin:
+            lang = _detect_language(text)
+            if lang and lang != "en" and lang in LANG_DEFAULT_VOICE:
+                chosen = LANG_DEFAULT_VOICE[lang]
+                logger.info(
+                    "[TTS] tts.alias_overridden_by_language alias=%s detected=%s "
+                    "voice=%s text_len=%d — alias would emit letter-by-letter on "
+                    "non-Latin input",
+                    name, lang, chosen, len(text),
+                )
+                return chosen
+        return VOICE_ALIASES[name]
+
+    # Pass-through literal Piper voice name (e.g. en_US-amy-medium).
+    return name
 
 
 def _ensure_voice(voice_name: str) -> "PiperVoice":  # type: ignore[name-defined]
     """Return a loaded PiperVoice, downloading the model if needed."""
     from piper import PiperVoice
-    from piper.download_voices import download_voice
 
     if voice_name in _loaded_voices:
         return _loaded_voices[voice_name]
 
-    model_path = VOICES_DIR / f"{voice_name}.onnx"
-    config_path = VOICES_DIR / f"{voice_name}.onnx.json"
-
-    if not model_path.exists() or not config_path.exists():
-        logger.info("[TTS] Downloading voice: %s -> %s", voice_name, VOICES_DIR)
-        try:
-            download_voice(voice_name, VOICES_DIR)
-        except Exception as exc:
-            logger.error("[TTS] Failed to download voice %s: %s", voice_name, exc)
-            raise HTTPException(
-                status_code=404,
-                detail=f"Voice '{voice_name}' not found and could not be downloaded: {exc}",
-            ) from exc
+    model_path, config_path = _voice_model_paths(voice_name)
+    _download_voice_model(voice_name)
 
     logger.info("[TTS] Loading voice: %s", voice_name)
     voice = PiperVoice.load(str(model_path), str(config_path))
@@ -124,14 +358,20 @@ def _ensure_voice(voice_name: str) -> "PiperVoice":  # type: ignore[name-defined
 async def lifespan(app: FastAPI):
     VOICES_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Pre-load default voices at startup
+    # Prepare default voices at startup. Release deployments should fail
+    # readiness when a promised voice model cannot be made local; only a small
+    # hot subset is loaded into RAM to keep Helm memory predictable.
     for v in DEFAULT_VOICES:
         v = v.strip()
         if v:
             try:
-                _ensure_voice(v)
+                _download_voice_model(v)
+                if v in DEFAULT_LOADED_VOICES:
+                    _ensure_voice(v)
             except Exception:
-                logger.warning("[TTS] Could not pre-load voice: %s", v, exc_info=True)
+                logger.warning("[TTS] Could not prepare voice: %s", v, exc_info=True)
+                if PIPER_PRELOAD_STRICT:
+                    raise
 
     yield
 
@@ -174,6 +414,14 @@ async def health():
         "service": "tts-service",
         "provider": "piper",
         "output_sample_rate": OUTPUT_SAMPLE_RATE,
+        "configured_default_voices": DEFAULT_VOICES,
+        "default_loaded_voices": DEFAULT_LOADED_VOICES,
+        "preload_strict": PIPER_PRELOAD_STRICT,
+        "prepared_voices": sorted(
+            p.name[:-5]
+            for p in VOICES_DIR.glob("*.onnx")
+            if not p.name.endswith(".onnx.json")
+        ),
         "loaded_voices": list(_loaded_voices.keys()),
         "voice_aliases": VOICE_ALIASES,
     }
@@ -204,8 +452,8 @@ async def speech(
     """
     Synthesize text to speech. OpenAI-compatible API.
 
-    Request body: {"input": "text", "voice": "alloy", "response_format": "wav"}
-    - voice: Piper voice name (e.g. "en_US-amy-medium") or alias ("alloy", "nova", etc.)
+    Request body: {"input": "text", "voice": "auto", "response_format": "wav"}
+    - voice: "auto", Piper voice name (e.g. "en_US-amy-medium"), or alias ("alloy", "nova", etc.)
     - response_format: "wav" (default) or "pcm" (raw Int16LE)
     - model: ignored (kept for OpenAI API compatibility)
 
@@ -217,7 +465,7 @@ async def speech(
         raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}") from e
 
     text = body.get("input", "")
-    voice_param = body.get("voice", "alloy")
+    voice_param = body.get("voice", "auto")
     response_format = body.get("response_format", "wav")
 
     if not text:
@@ -226,10 +474,10 @@ async def speech(
     if not text.strip():
         raise HTTPException(status_code=400, detail="'input' text is empty")
 
-    voice_name = _resolve_voice_name(voice_param)
+    voice_name = _resolve_voice_name(voice_param, text=text)
 
     logger.info(
-        "[TTS] Synthesizing: voice=%s (%s), format=%s, len=%d",
+        "[TTS] Synthesizing: voice_param=%s resolved=%s format=%s len=%d",
         voice_param,
         voice_name,
         response_format,
@@ -265,6 +513,8 @@ async def speech(
                     "X-Sample-Rate": str(dst_rate),
                     "X-Sample-Width": "2",
                     "X-Channels": "1",
+                    "X-Vexa-TTS-Voice": voice_name,
+                    "X-Vexa-TTS-Voice-Param": str(voice_param),
                 },
             )
         else:
@@ -290,6 +540,8 @@ async def speech(
                 headers={
                     "Content-Disposition": "inline; filename=speech.wav",
                     "Content-Length": str(len(wav_bytes)),
+                    "X-Vexa-TTS-Voice": voice_name,
+                    "X-Vexa-TTS-Voice-Param": str(voice_param),
                 },
             )
     except Exception as exc:

--- a/services/tts-service/requirements.txt
+++ b/services/tts-service/requirements.txt
@@ -3,3 +3,4 @@ uvicorn>=0.24.0
 h11>=0.16.0                       # CVE-2025-43859 (uvicorn transitive)
 piper-tts>=1.4.0
 numpy>=1.21.0
+langdetect>=1.0.9

--- a/services/tts-service/tests/test_validation.py
+++ b/services/tts-service/tests/test_validation.py
@@ -25,6 +25,74 @@ class TestHealthEndpoint:
         data = resp.json()
         assert data["status"] == "ok"
         assert data["service"] == "tts-service"
+        assert data["provider"] == "piper"
+        assert data["preload_strict"] is True
+        assert "pt_BR-faber-medium" in data["configured_default_voices"]
+        assert "hi_IN-pratham-medium" in data["configured_default_voices"]
+        assert "pt_BR-faber-medium" in data["default_loaded_voices"]
+        assert "prepared_voices" in data
+
+
+class TestDefaultVoiceConfiguration:
+    def test_major_alias_expands_supported_release_voices(self, monkeypatch):
+        import main
+
+        monkeypatch.setenv("PIPER_DEFAULT_VOICES", "major")
+
+        voices = main._configured_default_voices()
+
+        assert "en_US-amy-medium" in voices
+        assert "pt_BR-faber-medium" in voices
+        assert "es_ES-davefx-medium" in voices
+        assert "hi_IN-pratham-medium" in voices
+
+    def test_explicit_voice_list_is_preserved(self, monkeypatch):
+        import main
+
+        monkeypatch.setenv("PIPER_DEFAULT_VOICES", "en_US-amy-medium, pt_BR-faber-medium")
+
+        assert main._configured_default_voices() == [
+            "en_US-amy-medium",
+            "pt_BR-faber-medium",
+        ]
+
+
+class TestAutoLanguageVoiceResolution:
+    def test_portuguese_release_phrase_resolves_to_portuguese_voice_when_langdetect_available(self):
+        pytest.importorskip("langdetect")
+        import main
+
+        text = "Olá, esta é uma validação de fala em português da Vexa."
+
+        assert main._detect_language(text) == "pt"
+        assert main._resolve_voice_name("auto", text=text) == "pt_BR-faber-medium"
+
+    def test_non_latin_text_resolves_without_langdetect(self):
+        import main
+
+        assert main._detect_language("Привет, это проверка голоса Vexa.") == "ru"
+        assert main._resolve_voice_name("auto", text="Привет, это проверка голоса Vexa.") == "ru_RU-irina-medium"
+        assert main._detect_language("Привіт, це перевірка голосу Vexa.") == "uk"
+        assert main._resolve_voice_name("auto", text="Привіт, це перевірка голосу Vexa.") == "uk_UA-ukrainian_tts-medium"
+        assert main._detect_language("नमस्ते, यह Vexa की आवाज़ जाँच है.") == "hi"
+        assert main._resolve_voice_name("auto", text="नमस्ते, यह Vexa की आवाज़ जाँच है.") == "hi_IN-pratham-medium"
+
+    def test_alias_overrides_to_detected_voice_for_non_latin_text(self):
+        import main
+
+        text = "مرحبا، هذا اختبار صوت Vexa."
+
+        assert main._resolve_voice_name("alloy", text=text) == "ar_JO-kareem-medium"
+
+
+class TestVoicePathValidation:
+    def test_rejects_path_traversal_voice_name(self):
+        import main
+
+        with pytest.raises(main.HTTPException) as exc:
+            main._voice_model_paths("../secret")
+
+        assert exc.value.status_code == 400
 
 
 class TestVoiceValidation:
@@ -80,22 +148,6 @@ class TestSpeechEndpointValidation:
             headers={"Content-Type": "application/json"},
         )
         assert resp.status_code == 400
-
-    def test_no_openai_key_returns_503(self):
-        """When OPENAI_API_KEY is empty, should return 503."""
-        import main
-        original = main.OPENAI_API_KEY
-        main.OPENAI_API_KEY = ""
-        try:
-            c = TestClient(app)
-            resp = c.post(
-                "/v1/audio/speech",
-                json={"model": "tts-1", "input": "hello", "voice": "alloy"},
-            )
-            assert resp.status_code == 503
-            assert "OPENAI_API_KEY" in resp.json()["detail"]
-        finally:
-            main.OPENAI_API_KEY = original
 
 
 class TestApiKeyAuth:

--- a/services/vexa-bot/README.md
+++ b/services/vexa-bot/README.md
@@ -159,14 +159,14 @@ Four independent capability flags control what the bot does in a meeting. Audio 
                      Default
 Audio IN  (capture)  always on    Per-speaker ScriptProcessors (Google Meet)
                                   or caption-driven mixed stream routing (Teams)
-Audio OUT (speak)    off          TTS playback via virtual mic (voiceAgentEnabled)
+Audio OUT (speak)    off          Local TTS or pre-rendered file playback via virtual mic (voiceAgentEnabled)
 Video IN  (see)      off          Receive participant video (videoReceiveEnabled)
 Video OUT (show)     off          Stream avatar via virtual camera (cameraEnabled)
 ```
 
 | Flag | Type field | API field | Default | What it controls |
 |------|-----------|-----------|---------|-----------------|
-| `voiceAgentEnabled` | `voice_agent_enabled` | `voice_agent_enabled` | `false` | TTS playback, microphone service, Redis event publishing. Does NOT require camera. |
+| `voiceAgentEnabled` | `voice_agent_enabled` | `voice_agent_enabled` | `false` | Local TTS playback, pre-rendered audio playback, microphone service, Redis event publishing. Does NOT require camera. |
 | `cameraEnabled` | `camera_enabled` | `camera_enabled` | `false` | Virtual camera init script, avatar streaming, `ScreenContentService`. Independent of voice agent. |
 | `videoReceiveEnabled` | `video_receive_enabled` | `video_receive_enabled` | `false` | When off, incoming video tracks are disabled at the WebRTC level (~87% CPU savings per bot). |
 | `transcribeEnabled` | `transcribe_enabled` | `transcribe_enabled` | `true` | Per-speaker transcription pipeline (SpeakerStreamManager, TranscriptionClient, SegmentPublisher). |
@@ -222,7 +222,13 @@ Redis subscriber on `bot_commands:meeting:<meeting_id>`:
 ```bash
 redis-cli PUBLISH bot_commands:meeting:123 '{"action":"leave"}'
 redis-cli PUBLISH bot_commands:meeting:123 '{"action":"reconfigure","language":"es"}'
+redis-cli PUBLISH bot_commands:meeting:123 '{"action":"speak","text":"Hello","provider":"piper","voice":"auto"}'
+redis-cli PUBLISH bot_commands:meeting:123 '{"action":"speak_audio","audio_base64":"UklGR...","format":"wav","sample_rate":24000}'
 ```
+
+`speak` calls the local Vexa TTS service (`TTS_SERVICE_URL`) and streams Piper PCM into `tts_sink`. `voice: "auto"` chooses a prepared Piper voice based on the text language; explicit Piper names and OpenAI-style aliases are accepted by the TTS service.
+
+`speak_audio` bypasses synthesis. The bot decodes `audio_url` or `audio_base64` with ffmpeg and plays the resulting audio through the same `tts_sink` / `virtual_mic` path. The bot unmutes before playback and re-mutes after completion or interruption.
 
 Status callbacks via HTTP POST to [meeting-api](../meeting-api/README.md): `joining`, `awaiting_admission`,
 `active`, `completed`, `failed`.

--- a/services/vexa-bot/core/src/browser-session.ts
+++ b/services/vexa-bot/core/src/browser-session.ts
@@ -206,8 +206,8 @@ export async function runBrowserSession(config: BrowserSessionConfig): Promise<v
       if (command.action === 'speak') {
         console.log(`[browser-session] Speak command: "${(command.text || '').substring(0, 50)}"`);
         try {
-          const provider = command.provider || process.env.DEFAULT_TTS_PROVIDER || 'openai';
-          const voice = command.voice || process.env.DEFAULT_TTS_VOICE || 'alloy';
+          const provider = command.provider || process.env.DEFAULT_TTS_PROVIDER || 'piper';
+          const voice = command.voice || process.env.DEFAULT_TTS_VOICE || 'auto';
           await ttsPlaybackService.synthesizeAndPlay(command.text, provider, voice);
         } catch (err: any) {
           console.log(`[browser-session] TTS speak failed: ${err.message}`);

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -1016,7 +1016,7 @@ async function handleSpeakCommand(command: any, page: Page | null): Promise<void
 
   try {
     const provider = command.provider || process.env.DEFAULT_TTS_PROVIDER || 'piper';
-    const voice = command.voice || process.env.DEFAULT_TTS_VOICE || 'alloy';
+    const voice = command.voice || process.env.DEFAULT_TTS_VOICE || 'auto';
     await ttsPlaybackService.synthesizeAndPlay(command.text, provider, voice);
     await publishVoiceEvent('speak.completed');
   } catch (err: any) {

--- a/services/vexa-bot/core/src/services/tts-playback.test.ts
+++ b/services/vexa-bot/core/src/services/tts-playback.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { TTSPlaybackService } from './tts-playback';
+
+async function testMissingTtsServiceUrlCleansState(): Promise<void> {
+  const previousUrl = process.env.TTS_SERVICE_URL;
+  delete process.env.TTS_SERVICE_URL;
+
+  try {
+    const service = new TTSPlaybackService();
+
+    await assert.rejects(
+      () => service.synthesizeAndPlay('Hello from Vexa', 'piper', 'auto'),
+      /TTS_SERVICE_URL not set/
+    );
+    assert.equal(service.isPlaying(), false);
+    assert.equal(service.getCurrentText(), null);
+  } finally {
+    if (previousUrl === undefined) {
+      delete process.env.TTS_SERVICE_URL;
+    } else {
+      process.env.TTS_SERVICE_URL = previousUrl;
+    }
+  }
+}
+
+async function testDefaultVoiceAutoIsPostedToTtsService(): Promise<void> {
+  const previousUrl = process.env.TTS_SERVICE_URL;
+  let requestBody = '';
+
+  const server = http.createServer((req, res) => {
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      requestBody += chunk;
+    });
+    req.on('end', () => {
+      res.statusCode = 503;
+      res.end('synthetic unavailable');
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  const { port } = address as AddressInfo;
+
+  try {
+    process.env.TTS_SERVICE_URL = `http://127.0.0.1:${port}`;
+    const service = new TTSPlaybackService();
+
+    await assert.rejects(
+      () => service.synthesizeAndPlay('Hola desde Vexa'),
+      /TTS service error 503/
+    );
+
+    assert.equal(JSON.parse(requestBody).voice, 'auto');
+    assert.equal(service.isPlaying(), false);
+    assert.equal(service.getCurrentText(), null);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (previousUrl === undefined) {
+      delete process.env.TTS_SERVICE_URL;
+    } else {
+      process.env.TTS_SERVICE_URL = previousUrl;
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  await testMissingTtsServiceUrlCleansState();
+  await testDefaultVoiceAutoIsPostedToTtsService();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/vexa-bot/core/src/services/tts-playback.ts
+++ b/services/vexa-bot/core/src/services/tts-playback.ts
@@ -312,13 +312,16 @@ export class TTSPlaybackService {
    */
   async synthesizeAndPlay(
     text: string,
-    provider: string = 'openai',
-    voice: string = 'alloy'
+    provider: string = 'piper',
+    voice: string = 'auto'
   ): Promise<void> {
     this._currentText = text;
     log(`[TTS] Synthesizing with ${provider}, voice=${voice}: "${text.substring(0, 50)}..."`);
-    await this.synthesizeViaTtsService(text, voice);
-    this._currentText = null;
+    try {
+      await this.synthesizeViaTtsService(text, voice);
+    } finally {
+      this._currentText = null;
+    }
   }
 
   /**


### PR DESCRIPTION
# Pack PR: [Pack] PACK 2 - Speak Audio Delivery

Pack epic: https://github.com/Vexa-ai/vexa/issues/357
Pack id: `0.10.6x-pack-2-speak-audio-delivery`
Release: `0.10.6.x replay`
Base branch: `v0.10.6^{}`
Integration branch: `codex/release-0.10.6x-pack-integration`
Evidence: `.agents/packs/0.10.6x-pack-2-speak-audio-delivery/`

## Outcomes

CEO: Customers using /speak get audible value in meetings across languages, or get a clear failure instead of a false success.

CTO: The speak path validates TTS availability/provider behavior, supports externally supplied audio, and does not silently claim success when no audio can be produced.

User: A user can send multilingual text to /speak or provide their own audio file/URL/base64 from external TTS and hear it in the meeting.

## Scope

- #315
- #308
- TTS/audio-file portions of #331/#347

## Out of scope

- Current uncommitted product changes in the local worktree are excluded from this pack.
- Dead release evidence folders are excluded as source truth.
- Deprecated harness evidence is excluded; reusable checks must live in product tests or dedicated skills.
- The removed realtime transcript regression pack is not replay scope here.

## Blast radius

TTS service, voice-agent command delivery, bot audio playback, Helm/Lite/Compose TTS startup, multilingual user workflows.

## Validation

Synthetic: pass

Compose: pass

Lite: pass

Hot human-in-the-loop: pass for Compose and Lite

Hardenloop: incomplete_coverage, zero normalized blockers, rerun after hot validation/docs at `hardenloop-after-hot-docs`

Code review: pass after fallback-default and Ukrainian-routing fixes; bot core full-build caveat recorded

Docs/readmes: updated after hot validation to explain local Piper defaults (`provider=piper`, `voice=auto`), required `voice_agent_enabled=true`, and the separate pre-rendered `audio_url` / `audio_base64` file playback path.

Recorded caveats:

- Compose post-stop playback stayed stuck at `Preparing audio...`; tracked as recording/playback scope, while Compose live TTS and distinct stored WAV file playback passed.
- Lite playback worked, but the Lite run summary did not retain webhook delivery metadata and automatic speaker-ID scoring was noisier than Compose despite human-visible speaker labels.

## Evidence checklist

- [x] `pack.json`
- [x] `runtime.json`
- [x] `ops/ops.jsonl`
- [x] `tests`
- [x] `compose`
- [x] `lite`
- [x] `hardenloop`
- [x] `review.md`
- [x] `pr.md`
- [x] `compose/human-eyeball.md`
- [x] `lite/human-eyeball.md`
- [x] `human/overall-functionality.md`
- [x] `compose/hot-human-validation.md`
- [x] `lite/hot-human-validation.md`

## Stitching notes

- Shared files must be merged by hunk and reviewed against adjacent pack edits.
- If stitching exposes a behavior bug, route it back to the responsible pack instead of hiding a stitch-time code change.
- This epic is not a release sign-off; it is the delivery contract for one independently reviewable pack.

## Review checklist

- [ ] Pack branch starts from `v0.10.6^{}`.
- [ ] Only this pack's committed reuse hunks are replayed.
- [x] Synthetic checks pass before live/human checks.
- [x] Compose gate is passed or explicitly marked not required in PR evidence.
- [x] Lite gate is passed or explicitly marked not required in PR evidence.
- [x] Hardenloop is run for the pack.
- [x] PR body links this epic and evidence root.
- [x] Reviewer can map each reused hunk back to the commit list above.
- [x] Human eyeball gates are recorded as `Status: pass`.
- [x] Hot human-in-the-loop validation is completed against both Compose and Lite targets.
