### PR TITLE
[Pack] PACK 3 - Meeting Admission And Platform Join Semantics

### DIFF
--- a/.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/pack.json
+++ b/.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/pack.json
@@ -1,0 +1,108 @@
+{
+  "base_branch": "v0.10.6^{}",
+  "evidence_root": ".agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/",
+  "integration_branch": "codex/release-0.10.6x-pack-integration",
+  "is_pack_epic": true,
+  "label_names": [
+    "pack",
+    "status:in-progress"
+  ],
+  "lifecycle_status": "in-progress",
+  "lifecycle_statuses": [
+    "status:in-progress"
+  ],
+  "metadata": {
+    "base_branch": "v0.10.6^{}",
+    "evidence_root": ".agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/",
+    "integration_branch": "codex/release-0.10.6x-pack-integration",
+    "pack_id": "0.10.6x-pack-3-meeting-admission-platform-join-semantics",
+    "release_id": "0.10.6.x replay",
+    "runtime_namespace": "0.10.6x-pack-3-meeting-admission-platform-join-semantics"
+  },
+  "missing_sections": [],
+  "pack_epic": "https://github.com/Vexa-ai/vexa/issues/358",
+  "pack_id": "0.10.6x-pack-3-meeting-admission-platform-join-semantics",
+  "release_id": "0.10.6.x replay",
+  "required_sections": [
+    "CEO outcome",
+    "CTO outcome",
+    "User outcome",
+    "Included raw issues / PRs",
+    "Explicitly out of scope",
+    "Blast radius",
+    "Data / schema / API / public-contract decisions",
+    "Isolation requirements",
+    "Compose validation gate",
+    "Lite validation gate",
+    "Synthetic validation gate",
+    "Live / human validation gate",
+    "PR readiness checklist",
+    "Stitching risk notes",
+    "Pack metadata"
+  ],
+  "runtime_namespace": "0.10.6x-pack-3-meeting-admission-platform-join-semantics",
+  "sections": {
+    "Blast radius": "Google Meet admission/waiting-room handling, Teams prejoin modal flow, bot metadata, operator diagnostics, live-meeting confidence.",
+    "CEO outcome": "Operators and customers can tell whether a bot joined, waited, was denied, or was blocked by platform-specific join friction.",
+    "CTO outcome": "External platform admission behavior is represented as explicit bot-observed treatment facts and deterministic join-state transitions where Vexa can know them.",
+    "Compose validation gate": "Run mocked/dry platform tests and bot config checks under Compose when replayed code touches bot launch/config surfaces.",
+    "Data / schema / API / public-contract decisions": "Bot-observed treatment facts live in existing meeting data for validation/diagnostics; no new public acceptance class is introduced by this pack.",
+    "Explicitly out of scope": "- Current uncommitted product changes in the local worktree are excluded from this pack.\n- Dead release evidence folders are excluded as source truth.\n- Deprecated harness evidence is excluded; reusable checks must live in product tests or dedicated skills.\n- The removed realtime transcript regression pack is not replay scope here.",
+    "Included raw issues / PRs": "- #316\n- #226/#283\n- camera/treatment-signal scope from #331",
+    "Isolation requirements": "- Develop from base `v0.10.6^{}` (`6da3abb`), not from current main.\n- One branch/worktree for this pack only.\n- Evidence root: `.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/`.\n- Runtime namespace: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`.\n- Do not merge another product pack into this pack lane to make it pass.",
+    "Lite validation gate": "Run the same bot admission/config checks in Lite if Lite bot packaging or runtime environment is touched.",
+    "Live / human validation gate": "Real Google Meet/Teams only for external admission behavior that cannot be deterministically simulated.",
+    "PR readiness checklist": "- [ ] Pack branch starts from `v0.10.6^{}`.\n- [ ] Only this pack's committed reuse hunks are replayed.\n- [ ] Synthetic checks pass before live/human checks.\n- [ ] Compose gate is passed or explicitly marked not required in PR evidence.\n- [ ] Lite gate is passed or explicitly marked not required in PR evidence.\n- [ ] Hardenloop is run for the pack.\n- [ ] PR body links this epic and evidence root.\n- [ ] Reviewer can map each reused hunk back to the commit list above.",
+    "Pack metadata": "- Pack id: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`\n- Release: `0.10.6.x replay`\n- Base branch: `v0.10.6^{}`\n- Integration branch: `codex/release-0.10.6x-pack-integration`\n- Runtime namespace: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`\n- Evidence root: `.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/`",
+    "Reusable committed code references": "Base: `v0.10.6^{}` = `6da3abb` / `6da3abb92fd50c1939f1c0ecfb85246db364e427`\n\nLineage head used for reusable committed work: `codex/release-0.10.6.2.1` = `e8cd9e7` / `e8cd9e73aa9967cd0ebb9f2ff3a0d701b9684106`\n\nReusable commits:\n- `36df611`\n- `dbb42f7`\n\nMain file surfaces:\n- `services/vexa-bot/core/src/platforms/googlemeet/admission.ts`\n- `services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts`\n- `services/vexa-bot/core/src/platforms/googlemeet/selectors.ts`\n- `services/vexa-bot/core/src/platforms/zoom/web/join.test.ts`\n- `services/vexa-bot/core/src/types.ts`\n- `services/vexa-bot/core/src/index.ts`",
+    "Stitching risk notes": "- Shared files must be merged by hunk and reviewed against adjacent pack edits.\n- If stitching exposes a behavior bug, route it back to the responsible pack instead of hiding a stitch-time code change.\n- This epic is not a release sign-off; it is the delivery contract for one independently reviewable pack.",
+    "Synthetic validation gate": "GMeet admission/denial tests; Teams Continue-without-AV modal handling test; camera/treatment metadata assertions.",
+    "User outcome": "A bot either joins or reports a clear platform-specific reason instead of timing out silently."
+  },
+  "sections_by_key": {
+    "blast-radius": "Google Meet admission/waiting-room handling, Teams prejoin modal flow, bot metadata, operator diagnostics, live-meeting confidence.",
+    "ceo-outcome": "Operators and customers can tell whether a bot joined, waited, was denied, or was blocked by platform-specific join friction.",
+    "compose-validation-gate": "Run mocked/dry platform tests and bot config checks under Compose when replayed code touches bot launch/config surfaces.",
+    "cto-outcome": "External platform admission behavior is represented as explicit bot-observed treatment facts and deterministic join-state transitions where Vexa can know them.",
+    "data-schema-api-public-contract-decisions": "Bot-observed treatment facts live in existing meeting data for validation/diagnostics; no new public acceptance class is introduced by this pack.",
+    "explicitly-out-of-scope": "- Current uncommitted product changes in the local worktree are excluded from this pack.\n- Dead release evidence folders are excluded as source truth.\n- Deprecated harness evidence is excluded; reusable checks must live in product tests or dedicated skills.\n- The removed realtime transcript regression pack is not replay scope here.",
+    "included-raw-issues-prs": "- #316\n- #226/#283\n- camera/treatment-signal scope from #331",
+    "isolation-requirements": "- Develop from base `v0.10.6^{}` (`6da3abb`), not from current main.\n- One branch/worktree for this pack only.\n- Evidence root: `.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/`.\n- Runtime namespace: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`.\n- Do not merge another product pack into this pack lane to make it pass.",
+    "lite-validation-gate": "Run the same bot admission/config checks in Lite if Lite bot packaging or runtime environment is touched.",
+    "live-human-validation-gate": "Real Google Meet/Teams only for external admission behavior that cannot be deterministically simulated.",
+    "pack-metadata": "- Pack id: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`\n- Release: `0.10.6.x replay`\n- Base branch: `v0.10.6^{}`\n- Integration branch: `codex/release-0.10.6x-pack-integration`\n- Runtime namespace: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`\n- Evidence root: `.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/`",
+    "pr-readiness-checklist": "- [ ] Pack branch starts from `v0.10.6^{}`.\n- [ ] Only this pack's committed reuse hunks are replayed.\n- [ ] Synthetic checks pass before live/human checks.\n- [ ] Compose gate is passed or explicitly marked not required in PR evidence.\n- [ ] Lite gate is passed or explicitly marked not required in PR evidence.\n- [ ] Hardenloop is run for the pack.\n- [ ] PR body links this epic and evidence root.\n- [ ] Reviewer can map each reused hunk back to the commit list above.",
+    "reusable-committed-code-references": "Base: `v0.10.6^{}` = `6da3abb` / `6da3abb92fd50c1939f1c0ecfb85246db364e427`\n\nLineage head used for reusable committed work: `codex/release-0.10.6.2.1` = `e8cd9e7` / `e8cd9e73aa9967cd0ebb9f2ff3a0d701b9684106`\n\nReusable commits:\n- `36df611`\n- `dbb42f7`\n\nMain file surfaces:\n- `services/vexa-bot/core/src/platforms/googlemeet/admission.ts`\n- `services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts`\n- `services/vexa-bot/core/src/platforms/googlemeet/selectors.ts`\n- `services/vexa-bot/core/src/platforms/zoom/web/join.test.ts`\n- `services/vexa-bot/core/src/types.ts`\n- `services/vexa-bot/core/src/index.ts`",
+    "stitching-risk-notes": "- Shared files must be merged by hunk and reviewed against adjacent pack edits.\n- If stitching exposes a behavior bug, route it back to the responsible pack instead of hiding a stitch-time code change.\n- This epic is not a release sign-off; it is the delivery contract for one independently reviewable pack.",
+    "synthetic-validation-gate": "GMeet admission/denial tests; Teams Continue-without-AV modal handling test; camera/treatment metadata assertions.",
+    "user-outcome": "A bot either joins or reports a clear platform-specific reason instead of timing out silently."
+  },
+  "source": {
+    "body": "# Pack Epic: PACK 3 - Meeting Admission And Platform Join Semantics\n\nStatus: proposed pack epic for `0.10.6.x` replay from `v0.10.6`.\n\n## CEO outcome\n\nOperators and customers can tell whether a bot joined, waited, was denied, or was blocked by platform-specific join friction.\n\n## CTO outcome\n\nExternal platform admission behavior is represented as explicit bot-observed treatment facts and deterministic join-state transitions where Vexa can know them.\n\n## User outcome\n\nA bot either joins or reports a clear platform-specific reason instead of timing out silently.\n\n## Included raw issues / PRs\n\n- #316\n- #226/#283\n- camera/treatment-signal scope from #331\n\n## Reusable committed code references\n\nBase: `v0.10.6^{}` = `6da3abb` / `6da3abb92fd50c1939f1c0ecfb85246db364e427`\n\nLineage head used for reusable committed work: `codex/release-0.10.6.2.1` = `e8cd9e7` / `e8cd9e73aa9967cd0ebb9f2ff3a0d701b9684106`\n\nReusable commits:\n- `36df611`\n- `dbb42f7`\n\nMain file surfaces:\n- `services/vexa-bot/core/src/platforms/googlemeet/admission.ts`\n- `services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts`\n- `services/vexa-bot/core/src/platforms/googlemeet/selectors.ts`\n- `services/vexa-bot/core/src/platforms/zoom/web/join.test.ts`\n- `services/vexa-bot/core/src/types.ts`\n- `services/vexa-bot/core/src/index.ts`\n\n## Explicitly out of scope\n\n- Current uncommitted product changes in the local worktree are excluded from this pack.\n- Dead release evidence folders are excluded as source truth.\n- Deprecated harness evidence is excluded; reusable checks must live in product tests or dedicated skills.\n- The removed realtime transcript regression pack is not replay scope here.\n\n## Blast radius\n\nGoogle Meet admission/waiting-room handling, Teams prejoin modal flow, bot metadata, operator diagnostics, live-meeting confidence.\n\n## Data / schema / API / public-contract decisions\n\nBot-observed treatment facts live in existing meeting data for validation/diagnostics; no new public acceptance class is introduced by this pack.\n\n## Isolation requirements\n\n- Develop from base `v0.10.6^{}` (`6da3abb`), not from current main.\n- One branch/worktree for this pack only.\n- Evidence root: `.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/`.\n- Runtime namespace: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`.\n- Do not merge another product pack into this pack lane to make it pass.\n\n## Compose validation gate\n\nRun mocked/dry platform tests and bot config checks under Compose when replayed code touches bot launch/config surfaces.\n\n## Lite validation gate\n\nRun the same bot admission/config checks in Lite if Lite bot packaging or runtime environment is touched.\n\n## Synthetic validation gate\n\nGMeet admission/denial tests; Teams Continue-without-AV modal handling test; camera/treatment metadata assertions.\n\n## Live / human validation gate\n\nReal Google Meet/Teams only for external admission behavior that cannot be deterministically simulated.\n\n## PR readiness checklist\n\n- [ ] Pack branch starts from `v0.10.6^{}`.\n- [ ] Only this pack's committed reuse hunks are replayed.\n- [ ] Synthetic checks pass before live/human checks.\n- [ ] Compose gate is passed or explicitly marked not required in PR evidence.\n- [ ] Lite gate is passed or explicitly marked not required in PR evidence.\n- [ ] Hardenloop is run for the pack.\n- [ ] PR body links this epic and evidence root.\n- [ ] Reviewer can map each reused hunk back to the commit list above.\n\n## Stitching risk notes\n\n- Shared files must be merged by hunk and reviewed against adjacent pack edits.\n- If stitching exposes a behavior bug, route it back to the responsible pack instead of hiding a stitch-time code change.\n- This epic is not a release sign-off; it is the delivery contract for one independently reviewable pack.\n\n## Pack metadata\n\n- Pack id: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`\n- Release: `0.10.6.x replay`\n- Base branch: `v0.10.6^{}`\n- Integration branch: `codex/release-0.10.6x-pack-integration`\n- Runtime namespace: `0.10.6x-pack-3-meeting-admission-platform-join-semantics`\n- Evidence root: `.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/`\n",
+    "labels": [
+      {
+        "color": "5319e7",
+        "description": "Pack epic issue",
+        "id": "LA_kwDON109P88AAAACkaJu0g",
+        "name": "pack"
+      },
+      {
+        "color": "fbca04",
+        "description": "Pack is actively being developed",
+        "id": "LA_kwDON109P88AAAACkaJvCQ",
+        "name": "status:in-progress"
+      }
+    ],
+    "milestone": {
+      "description": "Active hardening line for the 0.10 series. Most recently shipped: **v0.10.4** (cycle 260426-zoom, 2026-04-27) \u2014 Zoom Web Client as default join path, 4\u00d7 per-bot CPU reduction via Chromium `--in-process-gpu`, chat persistence race fix, awaiting-admission false-positive fix on Zoom waiting room. See [Release v0.10.4](https://github.com/Vexa-ai/vexa/releases/tag/v0.10.4).\n\nPrior cycles: 260424 (blue-stage shakedown), 260422 (release plumbing).\n\nIssues in this milestone are blue-stage / community-found defects scheduled to ship in 0.10.x point releases as they're fixed. Larger structural work goes to the [0.11 milestone](../milestone/13).",
+      "dueOn": null,
+      "number": 5,
+      "title": "0.10.x \u2014 Current hardening"
+    },
+    "number": 358,
+    "state": "OPEN",
+    "title": "[Pack] PACK 3 - Meeting Admission And Platform Join Semantics",
+    "url": "https://github.com/Vexa-ai/vexa/issues/358"
+  },
+  "title": "[Pack] PACK 3 - Meeting Admission And Platform Join Semantics"
+}

--- a/.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/runtime.json
+++ b/.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/runtime.json
@@ -1,0 +1,27 @@
+{
+  "compose_project": "vexa_0-10-6x-pack-3-meeting-admission-platform-join-semantics_compose",
+  "forbidden_ports": [
+    3000,
+    8056,
+    8080
+  ],
+  "lite_container": "vexa-0-10-6x-pack-3-meeting-admission-platform-join-semantics-lite",
+  "namespace": "pack-0-10-6x-pack-3-meeting-admission-platform-join-semantics",
+  "network_prefix": "pack-0-10-6x-pack-3-meeting-admission-platform-join-semantics",
+  "notes": [
+    "Ports are pack-scoped and intentionally avoid popular/default Vexa service ports.",
+    "Meeting API and other internal services should stay internal unless a deploy skill explicitly exposes a debug lane."
+  ],
+  "pack_id": "0-10-6x-pack-3-meeting-admission-platform-join-semantics",
+  "ports": {
+    "compose_browser_session": 43802,
+    "compose_dashboard": 43800,
+    "compose_gateway": 43801,
+    "compose_vnc": 43803,
+    "lite_dashboard": 43810,
+    "lite_gateway": 43811,
+    "lite_vnc": 43812
+  },
+  "release_id": "0.10.6.x replay",
+  "slot": 140
+}

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -868,6 +868,7 @@ async function performGracefulLeave(
 
     const botConfig = {
       meetingApiCallbackUrl,
+      internalSecret: currentBotConfig?.internalSecret,
       connectionId: currentConnectionId,
       container_name: process.env.HOSTNAME || 'unknown'
     };

--- a/services/vexa-bot/core/src/platforms/googlemeet/README.md
+++ b/services/vexa-bot/core/src/platforms/googlemeet/README.md
@@ -5,8 +5,8 @@ Playwright-based bot integration for Google Meet. Handles the join flow, admissi
 ## Join Flow
 
 1. `join.ts`: Navigate to meeting URL, fill name input, click "Ask to join", enter waiting room, wait for admission. 5-second settle wait after navigation.
-2. `admission.ts`: Polls for admission. Handles org-restricted blocks (unauthenticated guest).
-3. `selectors.ts`: DOM selectors for name input, join button, mic/camera toggles. These are brittle -- Google changes their DOM periodically.
+2. `admission.ts`: Polls for admission. Handles org-restricted blocks (unauthenticated guest). Each polling iteration (both the primary and the late waiting-room loops) calls `throwIfGoogleAdmissionRejected` *before* re-checking the waiting-room indicator, because host denial can leave stale lobby text in the DOM — a rejection must short-circuit polling instead of being masked by the still-visible waiting-room UI. On detected rejection the bot throws `"Bot admission was rejected by meeting admin"`.
+3. `selectors.ts`: DOM selectors for name input, join button, mic/camera toggles. These are brittle -- Google changes their DOM periodically. `googleRejectionIndicators` includes waiting-room denial patterns (`"denied your request"`, `"weren't allowed to join"`, `"Ask to join again"`, etc.) so denial is detected even when the lobby copy is still rendered.
 
 ## Audio Capture
 
@@ -60,5 +60,6 @@ If selectors break, the fix is always: inspect a real Google Meet session, compa
 | File | Purpose |
 |------|---------|
 | `join.ts` | Meeting join flow orchestration |
-| `admission.ts` | Admission/waiting room handling |
-| `selectors.ts` | DOM selectors (brittle, needs periodic updates) |
+| `admission.ts` | Admission/waiting room handling, including the `throwIfGoogleAdmissionRejected` guard run before each waiting-room re-check |
+| `admission.test.ts` | Structural regression: pins that the rejection guard runs before the waiting-room check in both polling loops, and that selectors include host-denial copy |
+| `selectors.ts` | DOM selectors (brittle, needs periodic updates); includes host-denial copy in `googleRejectionIndicators` |

--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Structural regression tests for Google Meet admission rejection handling.
+ *
+ * The 2026-05-01 live repro showed host denial can leave waiting-room text
+ * visible, so polling must check rejection before treating the page as still
+ * waiting. A full Playwright DOM test would require brittle UI fixtures; this
+ * source-shape check pins the safety invariant cheaply.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+let passed = 0;
+let failed = 0;
+
+function expectFileContains(
+  name: string,
+  filePath: string,
+  needle: string | RegExp,
+) {
+  const body = fs.readFileSync(filePath, 'utf-8');
+  const ok = typeof needle === 'string' ? body.includes(needle) : needle.test(body);
+  if (ok) {
+    console.log(`  \x1b[32mPASS\x1b[0m  ${name}`);
+    passed++;
+    return;
+  }
+  console.log(`  \x1b[31mFAIL\x1b[0m  ${name}`);
+  console.log(`        needle: ${needle}`);
+  console.log(`        in:     ${filePath}`);
+  failed++;
+}
+
+function expectOrder(
+  name: string,
+  body: string,
+  firstNeedle: string,
+  secondNeedle: string,
+) {
+  const firstIndex = body.indexOf(firstNeedle);
+  const secondIndex = firstIndex === -1 ? -1 : body.indexOf(secondNeedle, firstIndex);
+  const ok = firstIndex !== -1 && secondIndex !== -1 && firstIndex < secondIndex;
+  if (ok) {
+    console.log(`  \x1b[32mPASS\x1b[0m  ${name}`);
+    passed++;
+    return;
+  }
+  console.log(`  \x1b[31mFAIL\x1b[0m  ${name}`);
+  console.log(`        expected "${firstNeedle}" before "${secondNeedle}"`);
+  failed++;
+}
+
+const ADMISSION_TS = path.join(__dirname, 'admission.ts');
+const SELECTORS_TS = path.join(__dirname, 'selectors.ts');
+const admissionBody = fs.readFileSync(ADMISSION_TS, 'utf-8');
+
+console.log('\n=== Google Meet admission rejection handling ===');
+
+expectFileContains(
+  'admission.ts has reusable rejection guard',
+  ADMISSION_TS,
+  'throwIfGoogleAdmissionRejected',
+);
+
+expectOrder(
+  'waiting-room loop checks rejection before waiting-room state',
+  admissionBody,
+  'throwIfGoogleAdmissionRejected(page, "waiting-room polling")',
+  'const stillWaiting = await checkForWaitingRoomIndicators(page)',
+);
+
+expectOrder(
+  'late waiting-room loop checks rejection before waiting-room state',
+  admissionBody,
+  'throwIfGoogleAdmissionRejected(page, "late waiting-room polling")',
+  'const stillWaiting = await checkForWaitingRoomIndicators(page)',
+);
+
+expectFileContains(
+  'selectors include host-denied request text',
+  SELECTORS_TS,
+  'denied your request',
+);
+
+expectFileContains(
+  'selectors include retry affordance after denial',
+  SELECTORS_TS,
+  'Ask to join again',
+);
+
+console.log(`\n=== googlemeet admission summary: ${passed} passed, ${failed} failed ===`);
+process.exit(failed > 0 ? 1 : 0);

--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.ts
@@ -84,6 +84,14 @@ export async function checkForWaitingRoomIndicators(page: Page): Promise<boolean
   return false;
 }
 
+async function throwIfGoogleAdmissionRejected(page: Page, context: string): Promise<void> {
+  const isRejected = await checkForGoogleRejection(page);
+  if (isRejected) {
+    log(`🚨 Bot was rejected from the Google Meet meeting by admin (${context})`);
+    throw new Error("Bot admission was rejected by meeting admin");
+  }
+}
+
 // New function to wait for Google Meet meeting admission (canonical Teams-style)
 export async function waitForGoogleMeetingAdmission(
   page: Page,
@@ -158,19 +166,16 @@ export async function waitForGoogleMeetingAdmission(
       const effectiveTimeout = () => timeout + getEscalationExtensionMs();
 
       while (Date.now() - startTime < effectiveTimeout()) {
+        // Host denial can leave stale waiting-room text in the DOM. Check the
+        // terminal rejection state before treating the page as still waiting.
+        await throwIfGoogleAdmissionRejected(page, "waiting-room polling");
+
         // Check if we're still in waiting room using visibility
         const stillWaiting = await checkForWaitingRoomIndicators(page);
 
         if (!stillWaiting) {
           log("Google Meet waiting room indicator disappeared - checking if bot was admitted or rejected...");
           unknownStateDuration += checkInterval;
-
-          // CRITICAL: Check for rejection first since that's a definitive outcome
-          const isRejected = await checkForGoogleRejection(page);
-          if (isRejected) {
-            log("🚨 Bot was rejected from the Google Meet meeting by admin");
-            throw new Error("Bot admission was rejected by meeting admin");
-          }
 
           // Check for admission indicators since waiting room disappeared and no rejection found
           const admissionFound = await checkForGoogleAdmissionIndicators(page);
@@ -261,10 +266,10 @@ export async function waitForGoogleMeetingAdmission(
         const checkInterval = 2000;
         const startTime2 = Date.now();
         while (Date.now() - startTime2 < timeout) {
+          await throwIfGoogleAdmissionRejected(page, "late waiting-room polling");
+
           const stillWaiting = await checkForWaitingRoomIndicators(page);
           if (!stillWaiting) {
-            const isRejected2 = await checkForGoogleRejection(page);
-            if (isRejected2) throw new Error("Bot admission was rejected by meeting admin");
             const admissionFound2 = await checkForGoogleAdmissionIndicators(page);
             if (admissionFound2) return true;
           }

--- a/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
@@ -29,6 +29,22 @@ export const googleWaitingRoomIndicators: string[] = [
 ];
 
 export const googleRejectionIndicators: string[] = [
+  // Waiting-room denial patterns. Google Meet can leave some lobby text in
+  // the DOM after a host rejects the bot, so these must be checked before
+  // waiting-room indicators in admission polling.
+  'text*="denied your request"',
+  'text*="denied your request to join"',
+  'text*="Your request to join was denied"',
+  'text*="You were denied"',
+  'text*="weren\'t allowed to join"',
+  'text*="not allowed to join"',
+  'text*="not admitted"',
+  'text*="can\'t join this call"',
+  'text*="cannot join this call"',
+  'text*="Ask to join again"',
+  'button:has-text("Ask to join again")',
+  'button:has-text("Return to home screen")',
+
   // Meeting not found or access denied patterns
   'text="Meeting not found"',
   'text="Can\'t join the meeting"',
@@ -332,5 +348,4 @@ export const googlePeopleButtonSelectors: string[] = [
   'button[data-tooltip*="participants"]',
   'button[data-tooltip*="Participants"]'
 ];
-
 

--- a/services/vexa-bot/core/src/platforms/zoom/web/join.test.ts
+++ b/services/vexa-bot/core/src/platforms/zoom/web/join.test.ts
@@ -79,7 +79,7 @@ console.log('\n=== buildZoomWebClientUrl — v0.10.5 white-label passthrough ===
 // browser needs to be able to click through it. Canonical zoom.us paths
 // stay rewritten because they have no portal layer.
 const LFX_URL =
-  'https://zoom-lfx.platform.linuxfoundation.org/meeting/96088138284?password=c9e528a8-3852-4b82-89c2-96d6f22526ad';
+  'https://zoom-lfx.platform.linuxfoundation.org/meeting/96088138284?password=example-passcode';
 
 expect(
   'LFX zoom-portal — passthrough so user can VNC into portal page',

--- a/services/vexa-bot/core/src/types.ts
+++ b/services/vexa-bot/core/src/types.ts
@@ -21,6 +21,7 @@ export type BotConfig = {
   reconnectionIntervalMs?: number,
   meeting_id: number,  // Required, not optional
   meetingApiCallbackUrl?: string;
+  internalSecret?: string;
   recordingEnabled?: boolean;
   captureModes?: string[];  // e.g., ['audio'], ['audio', 'video'], ['audio', 'screenshots']
   recordingUploadUrl?: string;  // meeting-api internal upload endpoint


### PR DESCRIPTION
Pack epic: https://github.com/Vexa-ai/vexa/issues/358

## Scope

Replay of meeting-admission and platform-join semantics hunks from `codex/release-0.10.6.2.1` (lineage head `e8cd9e7`) on top of `v0.10.6^{}` (`6da3abb`).

Reusable commits per epic:
- `36df611`
- `dbb42f7`

Main file surfaces:
- `services/vexa-bot/core/src/platforms/googlemeet/admission.ts`
- `services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts`
- `services/vexa-bot/core/src/platforms/googlemeet/selectors.ts`
- `services/vexa-bot/core/src/platforms/zoom/web/join.test.ts`
- `services/vexa-bot/core/src/types.ts`
- `services/vexa-bot/core/src/index.ts`

## Isolation

- Base branch: `v0.10.6^{}` (`6da3abb`)
- Branch: `codex/pack-0.10.6x-pack-3-meeting-admission-platform-join-semantics`
- Worktree: `/home/dima/dev/vexa-pack-0.10.6x-pack-3-meeting-admission-platform-join-semantics`
- Evidence root: `.agents/packs/0.10.6x-pack-3-meeting-admission-platform-join-semantics/`
- Compose project: `vexa_0-10-6x-pack-3-meeting-admission-platform-join-semantics_compose`
- Runtime port band: `43800-43814` (slot 140)

## Status

Draft. Branch currently carries only the scope-marker commit; pack 3 replay hunks land in follow-up commits per the develop skill.

Compose stack stood up against retagged pack-1 working images (`vexaai/*:0.10.6-pack3-base-260524`) as the unchanged baseline since pack 3 only diverges in `services/vexa-bot/core`. All 10 services running; postgres / redis / admin-api / api-gateway / meeting-api / runtime-api report healthy.

Live Google Meet / Microsoft Teams admission tests are NOT run here; they require human-supplied meeting URLs and admit time and are gated to the live/human validation step of develop.

## Validation gates (per epic)

- [ ] Synthetic: GMeet admission/denial tests; Teams Continue-without-AV modal handling; camera/treatment metadata assertions
- [ ] Compose: mocked/dry platform tests under Compose where bot launch/config is touched
- [ ] Lite: same admission/config checks if Lite bot packaging is touched
- [ ] Live/human: real Google Meet & Teams admission (gated outside this PR)
- [ ] Hardenloop: pack-scoped run