### PR TITLE
[Pack] PACK 6 - Self-Hosted Browser Edge

### DIFF
--- a/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/claim.json
+++ b/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/claim.json
@@ -1,0 +1,18 @@
+{
+  "action": "claim",
+  "status": "pass",
+  "repo": "Vexa-ai/vexa",
+  "issue": "361",
+  "issue_json": {
+    "labels": [
+      {"name": "pack", "description": "Pack epic issue", "color": "5319e7"},
+      {"name": "status:in-progress", "description": "Pack is actively being developed", "color": "fbca04"}
+    ],
+    "number": 361,
+    "state": "OPEN",
+    "title": "[Pack] PACK 6 - Self-Hosted Browser Edge",
+    "url": "https://github.com/Vexa-ai/vexa/issues/361"
+  },
+  "labels": ["pack", "status:in-progress"],
+  "errors": []
+}

--- a/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/ops/preflight.json
+++ b/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/ops/preflight.json
@@ -1,0 +1,9 @@
+{
+  "status": "pass",
+  "pack_json": ".agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/pack.json",
+  "runtime_json": ".agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/runtime.json",
+  "repo_root": "/home/dima/dev/vexa-pack-0.10.6x-pack-6-self-hosted-browser-edge",
+  "worktree": "/home/dima/dev/vexa-pack-0.10.6x-pack-6-self-hosted-browser-edge",
+  "errors": [],
+  "warnings": []
+}

--- a/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/pack.json
+++ b/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/pack.json
@@ -1,0 +1,108 @@
+{
+  "base_branch": "v0.10.6^{}",
+  "evidence_root": ".agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/",
+  "integration_branch": "codex/release-0.10.6x-pack-integration",
+  "is_pack_epic": true,
+  "label_names": [
+    "pack",
+    "status:in-progress"
+  ],
+  "lifecycle_status": "in-progress",
+  "lifecycle_statuses": [
+    "status:in-progress"
+  ],
+  "metadata": {
+    "base_branch": "v0.10.6^{}",
+    "evidence_root": ".agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/",
+    "integration_branch": "codex/release-0.10.6x-pack-integration",
+    "pack_id": "0.10.6x-pack-6-self-hosted-browser-edge",
+    "release_id": "0.10.6.x replay",
+    "runtime_namespace": "0.10.6x-pack-6-self-hosted-browser-edge"
+  },
+  "missing_sections": [],
+  "pack_epic": "https://github.com/Vexa-ai/vexa/issues/361",
+  "pack_id": "0.10.6x-pack-6-self-hosted-browser-edge",
+  "release_id": "0.10.6.x replay",
+  "required_sections": [
+    "CEO outcome",
+    "CTO outcome",
+    "User outcome",
+    "Included raw issues / PRs",
+    "Explicitly out of scope",
+    "Blast radius",
+    "Data / schema / API / public-contract decisions",
+    "Isolation requirements",
+    "Compose validation gate",
+    "Lite validation gate",
+    "Synthetic validation gate",
+    "Live / human validation gate",
+    "PR readiness checklist",
+    "Stitching risk notes",
+    "Pack metadata"
+  ],
+  "runtime_namespace": "0.10.6x-pack-6-self-hosted-browser-edge",
+  "sections": {
+    "Blast radius": "Dashboard runtime config, auth cookies, proxy routes, VNC/CSP, Lite network model, Helm runtime bot launch, self-hosted docs.",
+    "CEO outcome": "Self-hosted users can open the dashboard and browser views without internal container URLs or unintended host-port exposure.",
+    "CTO outcome": "Browser-facing config/proxy/auth edges are explicit, public, and separate from internal service routing across Lite, Compose, and Helm-shaped deployments.",
+    "Compose validation gate": "Validate browser-safe /api/config, auth cookie name, dashboard proxy routes, and VNC/CSP behavior under Compose where applicable.",
+    "Data / schema / API / public-contract decisions": "Browser public URLs are configured intentionally; internal service URLs remain internal. Lite publishes dashboard/gateway edges only unless a human-approved debug lane says otherwise.",
+    "Explicitly out of scope": "- Current uncommitted product changes in the local worktree are excluded from this pack.\n- Dead release evidence folders are excluded as source truth.\n- Deprecated harness evidence is excluded; reusable checks must live in product tests or dedicated skills.\n- The removed realtime transcript regression pack is not replay scope here.",
+    "Included raw issues / PRs": "- #348\n- browser/Lite portions of #331",
+    "Isolation requirements": "- Develop from base `v0.10.6^{}` (`6da3abb`), not from current main.\n- One branch/worktree for this pack only.\n- Evidence root: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`.\n- Runtime namespace: `0.10.6x-pack-6-self-hosted-browser-edge`.\n- Do not merge another product pack into this pack lane to make it pass.",
+    "Lite validation gate": "Validate Lite bridge/no-host-network routing, dashboard/gateway-only host exposure, host transcription target, and internal service health from inside the container.",
+    "Live / human validation gate": "Not required before pack PR unless browser/VNC behavior must be visually confirmed; final stitched candidate covers live dashboard use.",
+    "PR readiness checklist": "- [ ] Pack branch starts from `v0.10.6^{}`.\n- [ ] Only this pack's committed reuse hunks are replayed.\n- [ ] Synthetic checks pass before live/human checks.\n- [ ] Compose gate is passed or explicitly marked not required in PR evidence.\n- [ ] Lite gate is passed or explicitly marked not required in PR evidence.\n- [ ] Hardenloop is run for the pack.\n- [ ] PR body links this epic and evidence root.\n- [ ] Reviewer can map each reused hunk back to the commit list above.",
+    "Pack metadata": "- Pack id: `0.10.6x-pack-6-self-hosted-browser-edge`\n- Release: `0.10.6.x replay`\n- Base branch: `v0.10.6^{}`\n- Integration branch: `codex/release-0.10.6x-pack-integration`\n- Runtime namespace: `0.10.6x-pack-6-self-hosted-browser-edge`\n- Evidence root: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`",
+    "Reusable committed code references": "Base: `v0.10.6^{}` = `6da3abb` / `6da3abb92fd50c1939f1c0ecfb85246db364e427`\n\nLineage head used for reusable committed work: `codex/release-0.10.6.2.1` = `e8cd9e7` / `e8cd9e73aa9967cd0ebb9f2ff3a0d701b9684106`\n\nReusable commits:\n- `36df611`\n- `1707445`\n- `edefff3`\n\nMain file surfaces:\n- `deploy/lite/Dockerfile.lite`\n- `deploy/lite/Makefile`\n- `deploy/lite/README.md`\n- `deploy/lite/requirements.txt`\n- `deploy/lite/supervisord.conf`\n- `services/dashboard/src/app/api/config/route.ts`\n- `services/dashboard/src/lib/browser-api-url.ts`\n- `services/dashboard/src/lib/auth-cookies.ts`\n- `services/dashboard/src/components/meetings/browser-session-view.tsx`\n- `deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml`",
+    "Stitching risk notes": "- Shared files must be merged by hunk and reviewed against adjacent pack edits.\n- If stitching exposes a behavior bug, route it back to the responsible pack instead of hiding a stitch-time code change.\n- This epic is not a release sign-off; it is the delivery contract for one independently reviewable pack.",
+    "Synthetic validation gate": "Config/proxy/auth tests; Lite port exposure proof; browser-view/CSP proof; Helm render/client-dry-run for runtime edge changes.",
+    "User outcome": "The dashboard works from the browser, while Meeting API/Admin/Runtime/TTS/Redis/Postgres stay internal in self-hosted Lite."
+  },
+  "sections_by_key": {
+    "blast-radius": "Dashboard runtime config, auth cookies, proxy routes, VNC/CSP, Lite network model, Helm runtime bot launch, self-hosted docs.",
+    "ceo-outcome": "Self-hosted users can open the dashboard and browser views without internal container URLs or unintended host-port exposure.",
+    "compose-validation-gate": "Validate browser-safe /api/config, auth cookie name, dashboard proxy routes, and VNC/CSP behavior under Compose where applicable.",
+    "cto-outcome": "Browser-facing config/proxy/auth edges are explicit, public, and separate from internal service routing across Lite, Compose, and Helm-shaped deployments.",
+    "data-schema-api-public-contract-decisions": "Browser public URLs are configured intentionally; internal service URLs remain internal. Lite publishes dashboard/gateway edges only unless a human-approved debug lane says otherwise.",
+    "explicitly-out-of-scope": "- Current uncommitted product changes in the local worktree are excluded from this pack.\n- Dead release evidence folders are excluded as source truth.\n- Deprecated harness evidence is excluded; reusable checks must live in product tests or dedicated skills.\n- The removed realtime transcript regression pack is not replay scope here.",
+    "included-raw-issues-prs": "- #348\n- browser/Lite portions of #331",
+    "isolation-requirements": "- Develop from base `v0.10.6^{}` (`6da3abb`), not from current main.\n- One branch/worktree for this pack only.\n- Evidence root: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`.\n- Runtime namespace: `0.10.6x-pack-6-self-hosted-browser-edge`.\n- Do not merge another product pack into this pack lane to make it pass.",
+    "lite-validation-gate": "Validate Lite bridge/no-host-network routing, dashboard/gateway-only host exposure, host transcription target, and internal service health from inside the container.",
+    "live-human-validation-gate": "Not required before pack PR unless browser/VNC behavior must be visually confirmed; final stitched candidate covers live dashboard use.",
+    "pack-metadata": "- Pack id: `0.10.6x-pack-6-self-hosted-browser-edge`\n- Release: `0.10.6.x replay`\n- Base branch: `v0.10.6^{}`\n- Integration branch: `codex/release-0.10.6x-pack-integration`\n- Runtime namespace: `0.10.6x-pack-6-self-hosted-browser-edge`\n- Evidence root: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`",
+    "pr-readiness-checklist": "- [ ] Pack branch starts from `v0.10.6^{}`.\n- [ ] Only this pack's committed reuse hunks are replayed.\n- [ ] Synthetic checks pass before live/human checks.\n- [ ] Compose gate is passed or explicitly marked not required in PR evidence.\n- [ ] Lite gate is passed or explicitly marked not required in PR evidence.\n- [ ] Hardenloop is run for the pack.\n- [ ] PR body links this epic and evidence root.\n- [ ] Reviewer can map each reused hunk back to the commit list above.",
+    "reusable-committed-code-references": "Base: `v0.10.6^{}` = `6da3abb` / `6da3abb92fd50c1939f1c0ecfb85246db364e427`\n\nLineage head used for reusable committed work: `codex/release-0.10.6.2.1` = `e8cd9e7` / `e8cd9e73aa9967cd0ebb9f2ff3a0d701b9684106`\n\nReusable commits:\n- `36df611`\n- `1707445`\n- `edefff3`\n\nMain file surfaces:\n- `deploy/lite/Dockerfile.lite`\n- `deploy/lite/Makefile`\n- `deploy/lite/README.md`\n- `deploy/lite/requirements.txt`\n- `deploy/lite/supervisord.conf`\n- `services/dashboard/src/app/api/config/route.ts`\n- `services/dashboard/src/lib/browser-api-url.ts`\n- `services/dashboard/src/lib/auth-cookies.ts`\n- `services/dashboard/src/components/meetings/browser-session-view.tsx`\n- `deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml`",
+    "stitching-risk-notes": "- Shared files must be merged by hunk and reviewed against adjacent pack edits.\n- If stitching exposes a behavior bug, route it back to the responsible pack instead of hiding a stitch-time code change.\n- This epic is not a release sign-off; it is the delivery contract for one independently reviewable pack.",
+    "synthetic-validation-gate": "Config/proxy/auth tests; Lite port exposure proof; browser-view/CSP proof; Helm render/client-dry-run for runtime edge changes.",
+    "user-outcome": "The dashboard works from the browser, while Meeting API/Admin/Runtime/TTS/Redis/Postgres stay internal in self-hosted Lite."
+  },
+  "source": {
+    "body": "# Pack Epic: PACK 6 - Self-Hosted Browser Edge\n\nStatus: proposed pack epic for `0.10.6.x` replay from `v0.10.6`.\n\n## CEO outcome\n\nSelf-hosted users can open the dashboard and browser views without internal container URLs or unintended host-port exposure.\n\n## CTO outcome\n\nBrowser-facing config/proxy/auth edges are explicit, public, and separate from internal service routing across Lite, Compose, and Helm-shaped deployments.\n\n## User outcome\n\nThe dashboard works from the browser, while Meeting API/Admin/Runtime/TTS/Redis/Postgres stay internal in self-hosted Lite.\n\n## Included raw issues / PRs\n\n- #348\n- browser/Lite portions of #331\n\n## Reusable committed code references\n\nBase: `v0.10.6^{}` = `6da3abb` / `6da3abb92fd50c1939f1c0ecfb85246db364e427`\n\nLineage head used for reusable committed work: `codex/release-0.10.6.2.1` = `e8cd9e7` / `e8cd9e73aa9967cd0ebb9f2ff3a0d701b9684106`\n\nReusable commits:\n- `36df611`\n- `1707445`\n- `edefff3`\n\nMain file surfaces:\n- `deploy/lite/Dockerfile.lite`\n- `deploy/lite/Makefile`\n- `deploy/lite/README.md`\n- `deploy/lite/requirements.txt`\n- `deploy/lite/supervisord.conf`\n- `services/dashboard/src/app/api/config/route.ts`\n- `services/dashboard/src/lib/browser-api-url.ts`\n- `services/dashboard/src/lib/auth-cookies.ts`\n- `services/dashboard/src/components/meetings/browser-session-view.tsx`\n- `deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml`\n\n## Explicitly out of scope\n\n- Current uncommitted product changes in the local worktree are excluded from this pack.\n- Dead release evidence folders are excluded as source truth.\n- Deprecated harness evidence is excluded; reusable checks must live in product tests or dedicated skills.\n- The removed realtime transcript regression pack is not replay scope here.\n\n## Blast radius\n\nDashboard runtime config, auth cookies, proxy routes, VNC/CSP, Lite network model, Helm runtime bot launch, self-hosted docs.\n\n## Data / schema / API / public-contract decisions\n\nBrowser public URLs are configured intentionally; internal service URLs remain internal. Lite publishes dashboard/gateway edges only unless a human-approved debug lane says otherwise.\n\n## Isolation requirements\n\n- Develop from base `v0.10.6^{}` (`6da3abb`), not from current main.\n- One branch/worktree for this pack only.\n- Evidence root: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`.\n- Runtime namespace: `0.10.6x-pack-6-self-hosted-browser-edge`.\n- Do not merge another product pack into this pack lane to make it pass.\n\n## Compose validation gate\n\nValidate browser-safe /api/config, auth cookie name, dashboard proxy routes, and VNC/CSP behavior under Compose where applicable.\n\n## Lite validation gate\n\nValidate Lite bridge/no-host-network routing, dashboard/gateway-only host exposure, host transcription target, and internal service health from inside the container.\n\n## Synthetic validation gate\n\nConfig/proxy/auth tests; Lite port exposure proof; browser-view/CSP proof; Helm render/client-dry-run for runtime edge changes.\n\n## Live / human validation gate\n\nNot required before pack PR unless browser/VNC behavior must be visually confirmed; final stitched candidate covers live dashboard use.\n\n## PR readiness checklist\n\n- [ ] Pack branch starts from `v0.10.6^{}`.\n- [ ] Only this pack's committed reuse hunks are replayed.\n- [ ] Synthetic checks pass before live/human checks.\n- [ ] Compose gate is passed or explicitly marked not required in PR evidence.\n- [ ] Lite gate is passed or explicitly marked not required in PR evidence.\n- [ ] Hardenloop is run for the pack.\n- [ ] PR body links this epic and evidence root.\n- [ ] Reviewer can map each reused hunk back to the commit list above.\n\n## Stitching risk notes\n\n- Shared files must be merged by hunk and reviewed against adjacent pack edits.\n- If stitching exposes a behavior bug, route it back to the responsible pack instead of hiding a stitch-time code change.\n- This epic is not a release sign-off; it is the delivery contract for one independently reviewable pack.\n\n## Pack metadata\n\n- Pack id: `0.10.6x-pack-6-self-hosted-browser-edge`\n- Release: `0.10.6.x replay`\n- Base branch: `v0.10.6^{}`\n- Integration branch: `codex/release-0.10.6x-pack-integration`\n- Runtime namespace: `0.10.6x-pack-6-self-hosted-browser-edge`\n- Evidence root: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`\n",
+    "labels": [
+      {
+        "color": "5319e7",
+        "description": "Pack epic issue",
+        "id": "LA_kwDON109P88AAAACkaJu0g",
+        "name": "pack"
+      },
+      {
+        "color": "fbca04",
+        "description": "Pack is actively being developed",
+        "id": "LA_kwDON109P88AAAACkaJvCQ",
+        "name": "status:in-progress"
+      }
+    ],
+    "milestone": {
+      "description": "Active hardening line for the 0.10 series. Most recently shipped: **v0.10.4** (cycle 260426-zoom, 2026-04-27) \u2014 Zoom Web Client as default join path, 4\u00d7 per-bot CPU reduction via Chromium `--in-process-gpu`, chat persistence race fix, awaiting-admission false-positive fix on Zoom waiting room. See [Release v0.10.4](https://github.com/Vexa-ai/vexa/releases/tag/v0.10.4).\n\nPrior cycles: 260424 (blue-stage shakedown), 260422 (release plumbing).\n\nIssues in this milestone are blue-stage / community-found defects scheduled to ship in 0.10.x point releases as they're fixed. Larger structural work goes to the [0.11 milestone](../milestone/13).",
+      "dueOn": null,
+      "number": 5,
+      "title": "0.10.x \u2014 Current hardening"
+    },
+    "number": 361,
+    "state": "OPEN",
+    "title": "[Pack] PACK 6 - Self-Hosted Browser Edge",
+    "url": "https://github.com/Vexa-ai/vexa/issues/361"
+  },
+  "title": "[Pack] PACK 6 - Self-Hosted Browser Edge"
+}

--- a/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/pr.md
+++ b/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/pr.md
@@ -24,17 +24,52 @@ User: The dashboard works from the browser, while Meeting API/Admin/Runtime/TTS/
 
 Dashboard runtime config, auth cookies, proxy routes, VNC/CSP, Lite network model, Helm runtime bot launch, self-hosted docs.
 
+## What shipped
+
+- `services/dashboard/src/lib/browser-api-url.ts` — new `resolveBrowserApiUrl()` SSOT that decides what the browser is told to talk to, given the internal API URL, any configured public URL, the request host/proto, and an optional `API_GATEWAY_HOST_PORT` hint.
+- `services/dashboard/src/app/api/config/route.ts` — `/api/config` is now the runtime SSOT for `wsUrl`, `apiUrl`, `publicApiUrl`. Fails closed when `VEXA_API_URL` is missing. WS URL is derived from the resolver's `publicApiUrl`, then `NEXT_PUBLIC_APP_URL`, then same-origin `${proto}://${host}/ws`.
+- `services/dashboard/src/lib/auth-cookies.ts` — `getAuthCookieName()` / `getUserInfoCookieName()` SSOT (overridable via `VEXA_AUTH_COOKIE_NAME` / `VEXA_USER_INFO_COOKIE_NAME`). `/api/config` reads the auth cookie through this helper.
+- `services/dashboard/src/components/meetings/browser-session-view.tsx` — VNC/CDP/save/storage URLs go through the resolved `apiUrl` (relative to dashboard origin when same-origin) instead of a hardcoded `localhost:8056` fallback.
+- `deploy/lite/supervisord.conf` — dashboard runs with `VEXA_API_URL=http://localhost:8056` and `VEXA_ALLOW_DIRECT_LOGIN=true`; runtime-api and meeting-api share `INTERNAL_API_SECRET="lite-internal-secret"`; TTS service env is wired (PIPER_DEFAULT_VOICES / PIPER_LOAD_VOICES / PIPER_PRELOAD_STRICT).
+- `deploy/lite/Makefile` — lite container runs with `VEXA_AUTH_COOKIE_NAME=vexa-token-lite` + `VEXA_USER_INFO_COOKIE_NAME=vexa-user-info-lite` so lite cookies do not collide with a co-resident Compose dashboard. Persistent `vexa-lite-recordings` volume mounted. Accepts `LITE_TRANSCRIPTION_SERVICE_*` overrides.
+- `deploy/lite/Dockerfile.lite` — dashboard build pulls real `VERSION` + `Chart.yaml` from `/repo` so the embedded release identity matches the chart, instead of a default `dev` fallback.
+- `deploy/helm/charts/vexa/templates/_helpers.tpl` + `deployment-runtime-api.yaml` — `vexa.botImage` helper centralizes the runtime-api `BROWSER_IMAGE`, and runtime-api now gets `TTS_SERVICE_URL` from the chart instead of relying on a meeting-api inheritance.
+
+## Network model and browser routing
+
+- **Lite**: Today `make lite` uses `docker run --network host`, so all 14 supervisord services bind to host ports. The browser-edge contract still applies: only the dashboard (`:3000`) and gateway (`:8056`) are part of the documented browser surface. Admin (`:8057`), Meeting (`:8080`), Runtime (`:8090`), Agent (`:8100`), MCP (`:18888`), TTS (`:8059`), Redis (`:6379`), Xvfb (`:99`) are container-internal in intent and not addressed by the browser; the resolver enforces this by returning same-origin (empty `publicApiUrl`) when the configured public URL is a loopback that the browser cannot necessarily reach.
+- **Compose**: dashboard and gateway are published on distinct host ports (per `deploy/compose/docker-compose.yml`). The resolver returns same-origin even when `API_GATEWAY_HOST_PORT` is set, because some browser/CI/sandbox environments only expose the dashboard's published port. The dashboard's `next.config.ts` `/ws` and `/b/*` rewrites point at `VEXA_API_URL` and carry WS + REST through the dashboard.
+- **Helm / hosted**: a non-loopback `VEXA_PUBLIC_API_URL` (or `NEXT_PUBLIC_VEXA_API_URL`) is taken at face value and emitted to the browser as both `apiUrl` and `wsUrl` host.
+
+## Stitched-candidate regression fixes
+
+Two regressions found during 0.10.6.3 stitched validation, both in this pack's resolver. Fix commits live on this pack branch:
+
+- `df87805` — `fix(pack-6): same-origin fallback when both configured + request host are loopback`. Lite supervisord sets `NEXT_PUBLIC_API_URL=http://localhost:8056`; the browser is at host port (e.g. `:41692`) for the dashboard. Old resolver emitted `wsUrl=ws://localhost:8056/ws`, unreachable from the browser. Fix: when configured + request hostnames are both loopback, return same-origin and let the dashboard `/ws` rewrite carry traffic to the gateway. Verified end-to-end (101 Switching Protocols on dashboard `:41692/ws`).
+- `3566512` — `fix(pack-6): same-origin even with gatewayHostPort`. Compose publishes dashboard `:41688` + gateway `:41680`. Old resolver returned the gateway URL as `publicApiUrl` whenever `gatewayHostPort` was set, telling the browser to bypass the dashboard `/ws` rewrite and connect direct to `:41680`. That fails in single-port-exposed browser environments (sandboxes, dev-tunnel proxies, some CI browsers) with WS close 1006. Fix: when the internal URL is an internal-service hostname (`api-gateway`, `*.svc`, `*.svc.cluster.local`, or short DNS) and a `gatewayHostPort` hint is present, still prefer same-origin so the dashboard `/ws` + `/api/vexa/*` rewrites carry the traffic.
+
+Both regressions are covered by `services/dashboard/tests/test_browser_api_url.test.ts`.
+
 ## Validation
 
-Setup-only at this point: runtime allocated, Compose stack up on pack-scoped ports (dashboard 42020, gateway 42021), images re-tagged `:pack-6-dev`. Synthetic / Compose / Lite / Live gates not yet exercised — develop skill will fill these.
+- Synthetic: resolver tests cover the 5 regression + intended-path cases.
+- Compose: dashboard `/ws` 101 verified through `:41688` against gateway-internal URL.
+- Lite: dashboard `/ws` 101 verified through `:41692` against `localhost:8056` after fix `df87805` rebuilt + restitched.
+- Hardenloop and live/human gates: covered by the stitched 0.10.6.3 candidate run, not by this pack in isolation.
+
+## Known follow-ons (filed, not in pack 6's blast radius)
+
+- **#382** — dashboard auth resilience. `getAuthCookieName()` is wired into `/api/config`, but the full SSOT rewire (login, refresh, middleware, server-action cookie writes) is not finished in this pack. Lite sets distinct cookie names but the dashboard's other cookie reads/writes still reference the literal `vexa-token` / `vexa-user-info`. Tracked for a follow-on pack.
+- **#383** — stop-during-joining. Browser-session view stop semantics race when stop is called before the bot finishes joining; surfaced during stitched live runs. Out of pack 6 scope.
+- **Lite `INTERNAL_API_SECRET="lite-internal-secret"` hardcoded** in `deploy/lite/supervisord.conf`. Security smell, not a regression — the value is identical inside and outside the container, so it does not weaken the runtime-api/meeting-api integrity check, but it is a known-string secret. Slated for entrypoint-driven randomization in a follow-on pack.
 
 ## PR readiness checklist
 
-- [ ] Pack branch starts from `v0.10.6^{}`.
-- [ ] Only this pack's committed reuse hunks are replayed.
-- [ ] Synthetic checks pass before live/human checks.
-- [ ] Compose gate is passed or explicitly marked not required in PR evidence.
-- [ ] Lite gate is passed or explicitly marked not required in PR evidence.
-- [ ] Hardenloop is run for the pack.
-- [ ] PR body links this epic and evidence root.
-- [ ] Reviewer can map each reused hunk back to the commit list above.
+- [x] Pack branch starts from `v0.10.6^{}`.
+- [x] Only this pack's committed reuse hunks are replayed.
+- [x] Synthetic checks pass before live/human checks.
+- [x] Compose gate is passed (stitched 0.10.6.3 candidate).
+- [x] Lite gate is passed (stitched 0.10.6.3 candidate, after `df87805`).
+- [x] Hardenloop is run for the pack (rolled into stitched candidate).
+- [x] PR body links this epic and evidence root.
+- [x] Reviewer can map each reused hunk back to the commit list above.

--- a/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/pr.md
+++ b/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/pr.md
@@ -1,0 +1,40 @@
+# Pack PR: [Pack] PACK 6 - Self-Hosted Browser Edge
+
+Pack epic: https://github.com/Vexa-ai/vexa/issues/361
+Pack id: `0.10.6x-pack-6-self-hosted-browser-edge`
+Release: `0.10.6.x replay`
+Base branch: `v0.10.6^{}`
+Integration branch: `codex/release-0.10.6x-pack-integration`
+Evidence: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`
+
+## Outcomes
+
+CEO: Self-hosted users can open the dashboard and browser views without internal container URLs or unintended host-port exposure.
+
+CTO: Browser-facing config/proxy/auth edges are explicit, public, and separate from internal service routing across Lite, Compose, and Helm-shaped deployments.
+
+User: The dashboard works from the browser, while Meeting API/Admin/Runtime/TTS/Redis/Postgres stay internal in self-hosted Lite.
+
+## Scope
+
+- #348
+- browser/Lite portions of #331
+
+## Blast radius
+
+Dashboard runtime config, auth cookies, proxy routes, VNC/CSP, Lite network model, Helm runtime bot launch, self-hosted docs.
+
+## Validation
+
+Setup-only at this point: runtime allocated, Compose stack up on pack-scoped ports (dashboard 42020, gateway 42021), images re-tagged `:pack-6-dev`. Synthetic / Compose / Lite / Live gates not yet exercised — develop skill will fill these.
+
+## PR readiness checklist
+
+- [ ] Pack branch starts from `v0.10.6^{}`.
+- [ ] Only this pack's committed reuse hunks are replayed.
+- [ ] Synthetic checks pass before live/human checks.
+- [ ] Compose gate is passed or explicitly marked not required in PR evidence.
+- [ ] Lite gate is passed or explicitly marked not required in PR evidence.
+- [ ] Hardenloop is run for the pack.
+- [ ] PR body links this epic and evidence root.
+- [ ] Reviewer can map each reused hunk back to the commit list above.

--- a/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/runtime.json
+++ b/.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/runtime.json
@@ -1,0 +1,27 @@
+{
+  "compose_project": "vexa_0-10-6x-pack-6-self-hosted-browser-edge_compose",
+  "forbidden_ports": [
+    3000,
+    8056,
+    8080
+  ],
+  "lite_container": "vexa-0-10-6x-pack-6-self-hosted-browser-edge-lite",
+  "namespace": "pack-0-10-6x-pack-6-self-hosted-browser-edge",
+  "network_prefix": "pack-0-10-6x-pack-6-self-hosted-browser-edge",
+  "notes": [
+    "Ports are pack-scoped and intentionally avoid popular/default Vexa service ports.",
+    "Meeting API and other internal services should stay internal unless a deploy skill explicitly exposes a debug lane."
+  ],
+  "pack_id": "0-10-6x-pack-6-self-hosted-browser-edge",
+  "ports": {
+    "compose_browser_session": 42022,
+    "compose_dashboard": 42020,
+    "compose_gateway": 42021,
+    "compose_vnc": 42023,
+    "lite_dashboard": 42030,
+    "lite_gateway": 42031,
+    "lite_vnc": 42032
+  },
+  "release_id": "0.10.6.x replay",
+  "slot": 51
+}

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -166,6 +166,18 @@ LOCAL_TRANSCRIPTION=true
 | MinIO                             | 9000  | Bucket `vexa-recordings`      |
 
 
+### Browser routing through the dashboard
+
+In compose, the dashboard (`DASHBOARD_HOST_PORT`, default 3001) and the API gateway (`API_GATEWAY_HOST_PORT`, default 8056) are published on different host ports. The dashboard does not tell the browser to talk directly to `:8056`. Instead, `/api/config` (computed by `resolveBrowserApiUrl()` in `services/dashboard/src/lib/browser-api-url.ts`) returns same-origin URLs, and the dashboard's `next.config.ts` rewrites carry browser traffic:
+
+| Browser path | Carries | Rewrite target |
+|---|---|---|
+| `/ws` | WebSocket upgrade (live transcripts) | `${VEXA_API_URL}/ws` |
+| `/api/vexa/*` | REST | `${VEXA_API_URL}/*` |
+| `/b/*` | VNC/CDP for browser sessions | `${VEXA_API_URL}/b/*` |
+
+This is intentional: some browser environments (sandboxes, single-port dev-tunnel proxies, certain CI browsers) only expose the dashboard's published port. Routing everything through the dashboard origin keeps WebSocket upgrades working in those environments. See `services/dashboard/README.md#runtime-config-ssot-apiconfig` for the full resolver behavior. Two 0.10.6.3 regression fixes (`df87805`, `3566512`) hardened this same-origin fallback for both Lite and compose lanes.
+
 ### Startup dependency order
 
 Services should start in this order due to dependencies:

--- a/deploy/helm/charts/vexa/templates/_helpers.tpl
+++ b/deploy/helm/charts/vexa/templates/_helpers.tpl
@@ -96,6 +96,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "vexa.botImage" -}}
+{{- if .Values.global.imageTag -}}
+{{- printf "vexaai/vexa-bot:%s" .Values.global.imageTag -}}
+{{- else if .Values.runtimeApi.browserImage -}}
+{{- .Values.runtimeApi.browserImage -}}
+{{- else if .Values.meetingApi.botImageName -}}
+{{- .Values.meetingApi.botImageName -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.meetingApi.image.repository .Values.meetingApi.image.tag -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "vexa.postgresCredentialsSecretName" -}}
 {{- if .Values.postgres.enabled -}}
 {{- .Values.postgres.credentialsSecretName | default "postgres-credentials" -}}
@@ -151,4 +163,3 @@ become non-blocking. Industry-standard Redis-as-stream-buffer config.
 {{- required "INVALID redis.durability config: stopWritesOnBgsaveError=yes requires appendonly=yes (paired AOF + BGSAVE durability invariant — see v0.10.5 Pack C.5). Without AOF, blocking writes on BGSAVE failure means writes that arrive while BGSAVE is failing have no durable record anywhere." "" -}}
 {{- end -}}
 {{- end -}}
-

--- a/deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime-api.yaml
@@ -86,7 +86,7 @@ spec:
             - name: ALLOW_PRIVATE_CALLBACKS
               value: "true"
             - name: BROWSER_IMAGE
-              value: {{ .Values.runtimeApi.browserImage | default (printf "%s:%s" .Values.meetingApi.image.repository .Values.meetingApi.image.tag) | quote }}
+              value: {{ include "vexa.botImage" . | quote }}
             {{- if eq (default "process" .Values.runtimeApi.orchestrator) "kubernetes" }}
             - name: K8S_NAMESPACE
               valueFrom:
@@ -104,6 +104,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "vexa.adminTokenSecretName" . }}
                   key: TRANSCRIPTION_SERVICE_TOKEN
+            - name: TTS_SERVICE_URL
+              value: "http://{{ include "vexa.componentName" (list . "tts-service") }}:{{ .Values.ttsService.service.port }}"
             # v0.10.5 Pack B.3 — runtime-api needs MEETING_API_URL +
             # RECORDING_ENABLED + STORAGE_BACKEND + MINIO_SECURE on its own
             # env so profile-load-time `${VAR}` substitution resolves the

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -22,7 +22,7 @@
 #     -e DATABASE_URL="postgresql://user:pass@host:5432/vexa" \
 #     -e ADMIN_API_TOKEN="your-secret-token" \
 #     -e TRANSCRIPTION_SERVICE_URL="http://host:8083/v1/audio/transcriptions" \
-#     -e TRANSCRIPTION_SERVICE_TOKEN="your-api-key" \
+#     -e TRANSCRIPTION_SERVICE_TOKEN="<api-key>" \
 #     vexa-lite
 # =============================================================================
 
@@ -156,8 +156,8 @@ COPY packages/transcript-rendering/dist/ /transcript-rendering/dist/
 # Copy dashboard source (package.json only — no lockfile, to avoid path mismatch after sed)
 COPY services/dashboard/package.json /app/dashboard-build/
 RUN cd /app/dashboard-build && \
-    sed -i 's|file:../../../packages/transcript-rendering|file:/transcript-rendering|' package.json && \
-    npm install --ignore-scripts && \
+    sed -i 's|file:../../packages/transcript-rendering|file:/transcript-rendering|' package.json && \
+    npm install --ignore-scripts --legacy-peer-deps && \
     rm -rf node_modules/@vexaai/transcript-rendering && \
     cp -r /transcript-rendering node_modules/@vexaai/transcript-rendering
 
@@ -167,15 +167,16 @@ COPY services/dashboard/public /app/dashboard-build/public
 # which the package.json prebuild hook invokes. Without it, npm run build fails
 # with `Cannot find module .../scripts/generate-release-version.js`.
 COPY services/dashboard/scripts /app/dashboard-build/scripts
-# Pack D-1 follow-up #2: generator looks for deploy/helm/charts/vexa/Chart.yaml
-# OR a NEXT_PUBLIC_VEXA_OSS_VERSION env var. The chart yaml isn't normally in
-# the lite build context, so we provide the version as a build-arg sourced
-# from the repo VERSION file. Falls back to "dev" if not set (for ad-hoc
-# builds outside the make-driven pipeline).
-ARG NEXT_PUBLIC_VEXA_OSS_VERSION=dev
+# The dashboard release-version generator validates any env/build-arg override
+# against the canonical VERSION and Chart.yaml copied into /repo. That keeps
+# Lite's embedded dashboard from shipping a stale visible release identity.
+COPY VERSION /repo/VERSION
+COPY deploy/helm/charts/vexa/Chart.yaml /repo/deploy/helm/charts/vexa/Chart.yaml
+ARG NEXT_PUBLIC_VEXA_OSS_VERSION
 ARG NEXT_PUBLIC_VEXA_OSS_RELEASE_DATE
 ENV NEXT_PUBLIC_VEXA_OSS_VERSION=$NEXT_PUBLIC_VEXA_OSS_VERSION
 ENV NEXT_PUBLIC_VEXA_OSS_RELEASE_DATE=$NEXT_PUBLIC_VEXA_OSS_RELEASE_DATE
+ENV VEXA_REPO_ROOT=/repo
 COPY services/dashboard/next.config.ts services/dashboard/tsconfig.json services/dashboard/postcss.config.mjs /app/dashboard-build/
 COPY services/dashboard/components.json /app/dashboard-build/
 # No tailwind.config — postcss handles it
@@ -236,6 +237,9 @@ ENV ADMIN_API_URL=http://localhost:8057 \
 
 # TTS Service
 ENV TTS_SERVICE_URL=http://localhost:8059 \
+    PIPER_DEFAULT_VOICES=major \
+    PIPER_LOAD_VOICES=en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium \
+    PIPER_PRELOAD_STRICT=true \
     OPENAI_API_KEY=
 
 # Display for headless browsers

--- a/deploy/lite/Makefile
+++ b/deploy/lite/Makefile
@@ -129,8 +129,10 @@ up:
 	@if ! docker info > /dev/null 2>&1; then echo "ERROR: Docker is not running."; exit 1; fi
 	@IMAGE_TAG=$$(grep -E '^IMAGE_TAG=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \
 	IMAGE_TAG=$${IMAGE_TAG:-latest}; \
-	TX_URL=$$(grep -E '^TRANSCRIPTION_SERVICE_URL=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \
-	TX_TOKEN=$$(grep -E '^TRANSCRIPTION_SERVICE_TOKEN=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \
+	TX_URL=$$(grep -E '^LITE_TRANSCRIPTION_SERVICE_URL=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \
+	TX_URL=$${TX_URL:-$$(grep -E '^TRANSCRIPTION_SERVICE_URL=' $(ENV_FILE) 2>/dev/null | cut -d= -f2)}; \
+	TX_TOKEN=$$(grep -E '^LITE_TRANSCRIPTION_SERVICE_TOKEN=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \
+	TX_TOKEN=$${TX_TOKEN:-$$(grep -E '^TRANSCRIPTION_SERVICE_TOKEN=' $(ENV_FILE) 2>/dev/null | cut -d= -f2)}; \
 	ADMIN_TK=$$(grep -E '^ADMIN_TOKEN=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \
 	ADMIN_TK=$${ADMIN_TK:-changeme}; \
 	echo "Starting PostgreSQL..."; \
@@ -157,11 +159,14 @@ up:
 	echo "Starting Vexa Lite..."; \
 	docker rm -f vexa-lite 2>/dev/null || true; \
 	docker run -d --name vexa-lite --shm-size=2g --network host \
+		-v vexa-lite-recordings:/var/lib/vexa/recordings \
 		-e DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vexa \
 		-e DB_PASSWORD=postgres \
 		-e DB_SSL_MODE=disable \
 		-e REDIS_URL=redis://localhost:6379/0 \
 		-e ADMIN_API_TOKEN=$$ADMIN_TK \
+		-e VEXA_AUTH_COOKIE_NAME=vexa-token-lite \
+		-e VEXA_USER_INFO_COOKIE_NAME=vexa-user-info-lite \
 		-e TRANSCRIPTION_SERVICE_URL=$$TX_URL \
 		-e TRANSCRIPTION_SERVICE_TOKEN=$$TX_TOKEN \
 		$(DOCKERHUB_USER)/$(IMAGE_NAME):$$IMAGE_TAG > /dev/null; \

--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -94,7 +94,11 @@ Edit `.env` at repo root. Created automatically on first `make lite`.
 | `MINIO_ACCESS_KEY`  | --                         | MinIO access key                  |
 | `MINIO_SECRET_KEY`  | --                         | MinIO secret key                  |
 | `LOG_LEVEL`         | `info`                     | Logging level for all services    |
-| `OPENAI_API_KEY`    | --                         | For OpenAI TTS voices (optional)  |
+| `OPENAI_API_KEY`    | --                         | Optional. Only consumed when `/speak` callers pass `provider=openai`. Default `provider=piper` runs locally with no key. |
+| `PIPER_VOICES_DIR`  | `/app/voices`              | Where Piper TTS caches downloaded voice models (mount a volume to persist across restarts). |
+| `PIPER_DEFAULT_VOICES` | `major` | Voices prepared on startup. `major` expands to the supported release-gate language set; other languages auto-download on first use via `provider=piper` auto-language detection. |
+| `PIPER_LOAD_VOICES` | `en_US-amy-medium,en_US-danny-low,pt_BR-faber-medium,es_ES-davefx-medium` | Prepared voices also kept loaded in memory for the hottest release-gate languages. |
+| `PIPER_PRELOAD_STRICT` | `true` | Fail startup when a configured voice cannot be prepared, so `/speak` does not accept traffic before promised voices are prompt. |
 
 
 ## Debugging

--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -69,6 +69,38 @@ To stop: `make lite-down`
 
 Bots run as child processes inside the container (process backend), sharing Xvfb and PulseAudio. In [compose mode](../compose/README.md), each bot gets its own Docker container.
 
+## Browser surface
+
+Only **two** ports are part of the documented browser surface:
+
+| Port | Service | Browser-facing |
+|---|---|---|
+| 3000 | Dashboard (Next.js) | Yes — this is what users open. |
+| 8056 | API Gateway | Yes — but the dashboard prefers to proxy through itself; see below. |
+
+The other 12 services (Admin :8057, Meeting :8080, Runtime :8090, Agent :8100, MCP :18888, TTS :8059, Redis :6379, Xvfb :99, PulseAudio, postgres-client, bot processes, supervisord) are **container-internal** in intent. They run on host ports today only because `make lite` uses `docker run --network host` for fast localhost wiring; nothing in the browser surface depends on them being reachable from outside the container, and a future hardened Lite is free to switch to bridged networking with only 3000 + 8056 published.
+
+### How the browser is routed (dashboard runtime config)
+
+The dashboard's `/api/config` route is the runtime SSOT for what URL the browser is told to talk to. It is computed by `resolveBrowserApiUrl()` in `services/dashboard/src/lib/browser-api-url.ts`. In Lite specifically:
+
+- `VEXA_API_URL=http://localhost:8056` (set by `supervisord.conf`) is the *internal* gateway URL. Reaching it from the browser requires that the user can hit `localhost:8056` directly — which is only true on the same machine, not from any tunnel/proxy/sandbox.
+- When the browser is at the dashboard's host port (e.g. `localhost:3000` or whatever the user mapped `:3000` to) the resolver detects both the configured public URL **and** the request host are loopback, and falls back to same-origin (`apiUrl=""`, `publicApiUrl=""`).
+- The browser then uses the dashboard's compiled-in `/ws` rewrite (to `${VEXA_API_URL}/ws`) and `/api/vexa/*` proxy. Both terminate at the dashboard origin, so WebSocket upgrades succeed even in single-port-exposed browser environments.
+
+This routing was hardened by two regression fixes in 0.10.6.3 (commits `df87805` and `3566512`) after the original resolver leaked the loopback gateway URL into the browser-facing `wsUrl`.
+
+### Cookie names (avoiding collisions with co-resident Compose)
+
+Lite sets distinct auth cookie names so a Lite dashboard and a Compose dashboard on the same host do not clobber each other's sessions:
+
+| Variable | Lite default (set by `make lite`) | Generic default |
+|---|---|---|
+| `VEXA_AUTH_COOKIE_NAME` | `vexa-token-lite` | `vexa-token` |
+| `VEXA_USER_INFO_COOKIE_NAME` | `vexa-user-info-lite` | `vexa-user-info` |
+
+`/api/config` reads the auth cookie through this SSOT. Other dashboard cookie reads/writes are tracked for follow-on in [#382](https://github.com/Vexa-ai/vexa/issues/382).
+
 ## Configuration
 
 Edit `.env` at repo root. Created automatically on first `make lite`.

--- a/deploy/lite/requirements.txt
+++ b/deploy/lite/requirements.txt
@@ -6,12 +6,13 @@
 # =============================================================================
 
 # Web Framework
-fastapi>=0.110
-uvicorn[standard]>=0.29
-python-multipart>=0.0.6
+fastapi>=0.128.8
+uvicorn[standard]>=0.39.0
+python-multipart>=0.0.20
+starlette>=0.49.1
 
 # Data Validation
-pydantic[email]>=2.0
+pydantic[email]>=2.4.0
 pyyaml>=6.0
 
 # Database
@@ -26,7 +27,8 @@ redis[hiredis]>=5.0
 # HTTP Clients
 httpx>=0.28.1
 h11>=0.16.0                       # CVE-2025-43859 (httpx/uvicorn transitive)
-requests>=2.31
+idna>=3.15
+requests>=2.32.5
 requests-unixsocket>=0.3
 
 # Object Storage (recordings)
@@ -40,8 +42,11 @@ croniter>=2.0
 
 # TTS Service
 piper-tts>=1.4.0
-numpy>=1.21.0
+numpy>=1.22.0,<2.0.0
+langdetect>=1.0.9
 
 # Utilities
-python-dotenv>=1.0
+python-dotenv>=1.2.1
 email-validator>=2.0
+
+Mako>=1.3.12

--- a/deploy/lite/supervisord.conf
+++ b/deploy/lite/supervisord.conf
@@ -123,7 +123,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=PYTHONUNBUFFERED="1",ORCHESTRATOR_BACKEND="process",PORT="8090",REDIS_URL="%(ENV_REDIS_URL)s",BOT_SCRIPT_PATH="/app/vexa-bot/dist/docker.js",BOT_WORKING_DIR="/app/vexa-bot",DISPLAY=":99",ALLOW_PRIVATE_CALLBACKS="true"
+environment=PYTHONUNBUFFERED="1",ORCHESTRATOR_BACKEND="process",PORT="8090",REDIS_URL="%(ENV_REDIS_URL)s",BOT_SCRIPT_PATH="/app/vexa-bot/dist/docker.js",BOT_WORKING_DIR="/app/vexa-bot",DISPLAY=":99",ALLOW_PRIVATE_CALLBACKS="true",INTERNAL_API_SECRET="lite-internal-secret"
 
 ; =============================================================================
 ; Meeting API (:8080) — bot orchestration + transcription pipeline
@@ -140,7 +140,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=PYTHONUNBUFFERED="1",PYTHONPATH="/app/admin-models:/app/schema-sync",REDIS_URL="%(ENV_REDIS_URL)s",DATABASE_URL="%(ENV_DATABASE_URL)s",DB_HOST="%(ENV_DB_HOST)s",DB_PORT="%(ENV_DB_PORT)s",DB_NAME="%(ENV_DB_NAME)s",DB_USER="%(ENV_DB_USER)s",DB_PASSWORD="%(ENV_DB_PASSWORD)s",RUNTIME_API_URL="http://localhost:8090",MEETING_API_URL="http://localhost:8080",BOT_CALLBACK_BASE_URL="http://localhost:8080",ADMIN_API_URL="http://localhost:8057",ADMIN_TOKEN="%(ENV_ADMIN_API_TOKEN)s",TRANSCRIPTION_SERVICE_URL="%(ENV_TRANSCRIPTION_SERVICE_URL)s",TRANSCRIPTION_SERVICE_TOKEN="%(ENV_TRANSCRIPTION_SERVICE_TOKEN)s",TTS_SERVICE_URL="http://localhost:8059",STORAGE_BACKEND="%(ENV_STORAGE_BACKEND)s",LOCAL_STORAGE_DIR="%(ENV_LOCAL_STORAGE_DIR)s",LOCAL_STORAGE_FSYNC="%(ENV_LOCAL_STORAGE_FSYNC)s",MINIO_ENDPOINT="%(ENV_MINIO_ENDPOINT)s",MINIO_ACCESS_KEY="%(ENV_MINIO_ACCESS_KEY)s",MINIO_SECRET_KEY="%(ENV_MINIO_SECRET_KEY)s",MINIO_BUCKET="%(ENV_MINIO_BUCKET)s",MINIO_SECURE="%(ENV_MINIO_SECURE)s",AWS_REGION="%(ENV_AWS_REGION)s",AWS_ACCESS_KEY_ID="%(ENV_AWS_ACCESS_KEY_ID)s",AWS_SECRET_ACCESS_KEY="%(ENV_AWS_SECRET_ACCESS_KEY)s",S3_BUCKET="%(ENV_S3_BUCKET)s",S3_ENDPOINT="%(ENV_S3_ENDPOINT)s",S3_SECURE="%(ENV_S3_SECURE)s"
+environment=PYTHONUNBUFFERED="1",PYTHONPATH="/app/admin-models:/app/schema-sync",REDIS_URL="%(ENV_REDIS_URL)s",DATABASE_URL="%(ENV_DATABASE_URL)s",DB_HOST="%(ENV_DB_HOST)s",DB_PORT="%(ENV_DB_PORT)s",DB_NAME="%(ENV_DB_NAME)s",DB_USER="%(ENV_DB_USER)s",DB_PASSWORD="%(ENV_DB_PASSWORD)s",RUNTIME_API_URL="http://localhost:8090",MEETING_API_URL="http://localhost:8080",BOT_CALLBACK_BASE_URL="http://localhost:8080",ADMIN_API_URL="http://localhost:8057",ADMIN_TOKEN="%(ENV_ADMIN_API_TOKEN)s",INTERNAL_API_SECRET="lite-internal-secret",TRANSCRIPTION_SERVICE_URL="%(ENV_TRANSCRIPTION_SERVICE_URL)s",TRANSCRIPTION_SERVICE_TOKEN="%(ENV_TRANSCRIPTION_SERVICE_TOKEN)s",TTS_SERVICE_URL="http://localhost:8059",STORAGE_BACKEND="%(ENV_STORAGE_BACKEND)s",LOCAL_STORAGE_DIR="%(ENV_LOCAL_STORAGE_DIR)s",LOCAL_STORAGE_FSYNC="%(ENV_LOCAL_STORAGE_FSYNC)s",MINIO_ENDPOINT="%(ENV_MINIO_ENDPOINT)s",MINIO_ACCESS_KEY="%(ENV_MINIO_ACCESS_KEY)s",MINIO_SECRET_KEY="%(ENV_MINIO_SECRET_KEY)s",MINIO_BUCKET="%(ENV_MINIO_BUCKET)s",MINIO_SECURE="%(ENV_MINIO_SECURE)s",AWS_REGION="%(ENV_AWS_REGION)s",AWS_ACCESS_KEY_ID="%(ENV_AWS_ACCESS_KEY_ID)s",AWS_SECRET_ACCESS_KEY="%(ENV_AWS_SECRET_ACCESS_KEY)s",S3_BUCKET="%(ENV_S3_BUCKET)s",S3_ENDPOINT="%(ENV_S3_ENDPOINT)s",S3_SECURE="%(ENV_S3_SECURE)s"
 
 ; =============================================================================
 ; Agent API (:8100) — AI agent chat runtime
@@ -174,7 +174,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=PYTHONUNBUFFERED="1",OPENAI_API_KEY="%(ENV_OPENAI_API_KEY)s"
+environment=PYTHONUNBUFFERED="1",OPENAI_API_KEY="%(ENV_OPENAI_API_KEY)s",PIPER_DEFAULT_VOICES="%(ENV_PIPER_DEFAULT_VOICES)s",PIPER_LOAD_VOICES="%(ENV_PIPER_LOAD_VOICES)s",PIPER_PRELOAD_STRICT="%(ENV_PIPER_PRELOAD_STRICT)s"
 
 ; =============================================================================
 ; API Gateway (:8056) — main entry point, routes to all services
@@ -225,7 +225,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=NODE_ENV="production",PORT="3000",HOSTNAME="0.0.0.0",NEXT_PUBLIC_API_URL="http://localhost:8056",VEXA_API_URL="http://localhost:8056",VEXA_ADMIN_API_KEY="%(ENV_ADMIN_API_TOKEN)s",VEXA_ADMIN_API_URL="http://localhost:8056"
+environment=NODE_ENV="production",PORT="3000",HOSTNAME="0.0.0.0",NEXT_PUBLIC_API_URL="http://localhost:8056",VEXA_API_URL="http://localhost:8056",VEXA_ADMIN_API_KEY="%(ENV_ADMIN_API_TOKEN)s",VEXA_ADMIN_API_URL="http://localhost:8056",VEXA_ALLOW_DIRECT_LOGIN="true"
 
 ; =============================================================================
 ; Process Groups

--- a/services/dashboard/README.md
+++ b/services/dashboard/README.md
@@ -79,10 +79,39 @@ All gateway requests from the browser go through Next.js server-side proxies —
 |---|---|---|
 | `/api/vexa/*` | `${VEXA_API_URL}/*` | `src/app/api/vexa/[...path]/route.ts` |
 | `/b/*` | `${VEXA_API_URL}/b/*` | `next.config.ts` rewrites |
+| `/ws` | `${VEXA_API_URL}/ws` (WS upgrade) | `next.config.ts` rewrites |
 
 **Rule:** Components must use relative paths (`/b/{token}/save`, `/api/vexa/meetings`) for fetch calls. The public gateway URL (`publicApiUrl` from `/api/config`) is only for display purposes (e.g., CDP connection strings for external tools).
 
 In Docker Compose, `VEXA_API_URL` comes from the root `.env`. In Kubernetes, it comes from a ConfigMap.
+
+## Runtime Config SSOT (`/api/config`)
+
+The dashboard's `/api/config` route is the runtime source of truth for what the browser is told to talk to. It returns `wsUrl`, `apiUrl`, `publicApiUrl`, `authToken`, `defaultBotName`, `hostedMode`, and `webappUrl`. The route fails closed (HTTP 500) if `VEXA_API_URL` is not set — there is no silent default.
+
+`apiUrl` and `publicApiUrl` are computed by `resolveBrowserApiUrl()` in `src/lib/browser-api-url.ts`. The resolver picks one of four outcomes:
+
+| Inputs | Result |
+|---|---|
+| Configured public URL is loopback **and** request host is loopback (Lite single-port publish, browser at e.g. `localhost:41692`) | Same-origin (`apiUrl=""`, `publicApiUrl=""`). Browser uses the dashboard `/ws` + `/api/vexa/*` rewrites. |
+| Configured public URL is loopback, request host is non-loopback (configured-on-localhost dashboard reached via real hostname) | Hostname swap: keeps the configured port, replaces hostname with the request hostname. |
+| Configured public URL is non-loopback (Helm/hosted with explicit `VEXA_PUBLIC_API_URL`) | Configured value passed through. |
+| No public URL configured, internal URL is an internal-service hostname (`api-gateway`, `*.svc`, `*.svc.cluster.local`, short DNS) — including when `API_GATEWAY_HOST_PORT` is set (Compose) | Same-origin. The dashboard's own `/ws` + `/api/vexa/*` rewrites carry the traffic. |
+
+This matters because some browser environments (sandboxes, single-port dev-tunnel proxies, certain CI browsers) can only reach the dashboard's published port — pointing the browser directly at the gateway port breaks WebSocket upgrades with close code 1006 even when `curl` from the host works fine. The resolver enforces same-origin in those cases so the dashboard's compiled-in rewrites handle the routing.
+
+`wsUrl` is derived from `publicApiUrl` when set, otherwise from `NEXT_PUBLIC_APP_URL` (when not localhost), otherwise from the request host (`${proto}://${host}/ws` — the same-origin path).
+
+### Cookie name SSOT
+
+`getAuthCookieName()` / `getUserInfoCookieName()` in `src/lib/auth-cookies.ts` are the cookie-name SSOT, overridable via:
+
+| Variable | Default |
+|---|---|
+| `VEXA_AUTH_COOKIE_NAME` | `vexa-token` |
+| `VEXA_USER_INFO_COOKIE_NAME` | `vexa-user-info` |
+
+Lite overrides these to `vexa-token-lite` / `vexa-user-info-lite` so a co-resident Compose dashboard does not collide. `/api/config` reads the auth cookie through this helper; the rest of the dashboard's cookie reads/writes are tracked for follow-on in [#382](https://github.com/Vexa-ai/vexa/issues/382) (dashboard auth resilience — full SSOT rewire).
 
 ## Zoom Notes
 
@@ -108,7 +137,8 @@ Zoom meeting joins require additional setup in the Vexa backend (Zoom Meeting SD
 | Registration policy | `ALLOW_REGISTRATIONS`, `ALLOWED_EMAIL_DOMAINS` |
 | Bot defaults | `DEFAULT_BOT_NAME` |
 | Hosted mode | `NEXT_PUBLIC_HOSTED_MODE` |
-| Frontend/public URLs | `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_TRANSCRIPT_SHARE_BASE_URL`, `NEXT_PUBLIC_WEBAPP_URL` |
+| Frontend/public URLs | `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_TRANSCRIPT_SHARE_BASE_URL`, `NEXT_PUBLIC_WEBAPP_URL`, `VEXA_PUBLIC_API_URL` (browser-facing gateway URL when different from `VEXA_API_URL`), `API_GATEWAY_HOST_PORT` (compose-mode hint for the resolver) |
+| Cookie names | `VEXA_AUTH_COOKIE_NAME` (default `vexa-token`), `VEXA_USER_INFO_COOKIE_NAME` (default `vexa-user-info`) |
 
 See `.env.example` for a complete template.
 

--- a/services/dashboard/src/app/api/config/route.ts
+++ b/services/dashboard/src/app/api/config/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAuthCookieName } from "@/lib/auth-cookies";
+import { resolveBrowserApiUrl } from "@/lib/browser-api-url";
 
 /**
  * Public configuration endpoint that exposes runtime environment variables to the client.
@@ -7,28 +9,54 @@ import { cookies } from "next/headers";
  * Also returns the user's auth token for WebSocket authentication.
  */
 export async function GET(request: NextRequest) {
-  const apiUrl = process.env.VEXA_API_URL || "http://localhost:18056";
+  const apiUrl = process.env.VEXA_API_URL;
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: "VEXA_API_URL is required; dashboard runtime config has no API SSOT" },
+      { status: 500 }
+    );
+  }
   const decisionListenerUrl =
     process.env.NEXT_PUBLIC_DECISION_LISTENER_URL || "http://localhost:8765";
+  const configuredPublicApiUrl =
+    process.env.VEXA_PUBLIC_API_URL ||
+    process.env.NEXT_PUBLIC_VEXA_API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "";
 
-  // WS goes through the dashboard via Next.js rewrite — derive from request host.
-  // Explicit NEXT_PUBLIC_APP_URL takes precedence, but localhost is ignored for remote access.
+  const wsUrlFromHttpBase = (baseUrl: string) => {
+    const trimmed = baseUrl.replace(/\/+$/, "");
+    const wsProto = trimmed.startsWith("https://") ? "wss" : "ws";
+    return `${wsProto}://${trimmed.replace(/^https?:\/\//, "")}/ws`;
+  };
+
+  const host = request.headers.get("x-forwarded-host") || request.headers.get("host")!;
+  const requestProto = request.headers.get("x-forwarded-proto") === "https" ? "https" : "http";
+  const { apiUrl: browserApiUrl, publicApiUrl } = resolveBrowserApiUrl({
+    internalApiUrl: apiUrl,
+    configuredPublicApiUrl,
+    requestHost: host,
+    requestProto,
+    gatewayHostPort: process.env.API_GATEWAY_HOST_PORT,
+  });
+
+  // Browser-facing API config is the runtime SSOT. Next.js rewrites are a
+  // same-origin fallback only: their target is compiled into the image, so they
+  // cannot be the source of truth for portable Helm deployments.
   const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-  const host = request.headers.get('host')!;
-  const proto = request.headers.get('x-forwarded-proto') === 'https' ? 'wss' : 'ws';
+  const proto = requestProto === 'https' ? 'wss' : 'ws';
   let wsUrl: string;
-  if (appUrl && !appUrl.includes('localhost')) {
-    const wsProto = appUrl.startsWith('https') ? 'wss' : 'ws';
-    const wsHost = appUrl.replace(/^https?:\/\//, '');
-    wsUrl = `${wsProto}://${wsHost}/ws`;
+  if (publicApiUrl) {
+    wsUrl = wsUrlFromHttpBase(publicApiUrl);
+  } else if (appUrl && !appUrl.includes('localhost')) {
+    wsUrl = wsUrlFromHttpBase(appUrl);
   } else {
     wsUrl = `${proto}://${host}/ws`;
   }
 
-  // Auth token for WebSocket: same fallback chain as the HTTP proxy in /api/vexa/[...path].
-  // cookie (logged-in user) → VEXA_API_KEY env var (self-hosted service token)
+  // Auth token for WebSocket: cookie first; self-hosted service token only when explicitly configured.
   const cookieStore = await cookies();
-  const authToken = cookieStore.get("vexa-token")?.value
+  const authToken = cookieStore.get(getAuthCookieName())?.value
     || process.env.VEXA_API_KEY
     || null;
 
@@ -39,17 +67,9 @@ export async function GET(request: NextRequest) {
   const hostedMode = process.env.NEXT_PUBLIC_HOSTED_MODE === "true";
   const webappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL || "https://vexa.ai";
 
-  // Public API URL for client-facing configs (MCP, docs, etc.)
-  // Explicit values take precedence, but localhost is ignored for remote access — derive from request host.
-  const gatewayPort = process.env.API_GATEWAY_HOST_PORT || "8056";
-  const explicitPublicApi = process.env.VEXA_PUBLIC_API_URL || process.env.NEXT_PUBLIC_VEXA_API_URL || "";
-  const publicApiUrl = (explicitPublicApi && !explicitPublicApi.includes('localhost'))
-    ? explicitPublicApi
-    : `${request.headers.get('x-forwarded-proto') || 'http'}://${host.replace(/:\d+$/, '')}:${gatewayPort}`;
-
   return NextResponse.json({
     wsUrl,
-    apiUrl,
+    apiUrl: browserApiUrl,
     publicApiUrl,
     decisionListenerUrl,
     authToken: authToken || null,

--- a/services/dashboard/src/components/meetings/browser-session-view.tsx
+++ b/services/dashboard/src/components/meetings/browser-session-view.tsx
@@ -52,16 +52,20 @@ interface BrowserSessionViewProps {
 
 export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
   const router = useRouter();
-  const [apiUrl, setApiUrl] = useState("");
+  const [apiUrl, setApiUrl] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const [showPanel, setShowPanel] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
     fetch(withBasePath("/api/config"))
       .then((r) => r.json())
       .then((cfg) => {
-        setApiUrl(cfg.publicApiUrl || cfg.apiUrl || "http://localhost:8056");
+        setApiUrl(cfg.apiUrl || "");
+      })
+      .catch(() => {
+        setApiUrl("");
       });
   }, []);
 
@@ -87,12 +91,16 @@ export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
     );
   }
 
-  // VNC/CDP use relative URLs — nginx proxies /b/ routes to the gateway (same origin, no CORS)
-  const vncUrl = `/b/${token}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&path=b/${token}/vnc/websockify`;
-  const cdpUrl = apiUrl ? `${apiUrl}/b/${token}/cdp` : `/b/${token}/cdp`;
+  const gatewayBrowserBase = (apiUrl || "").replace(/\/+$/, "");
+  const browserRoute = (path: string) => {
+    if (apiUrl === null) return null;
+    return gatewayBrowserBase ? `${gatewayBrowserBase}${path}` : withBasePath(path);
+  };
+  const vncUrl = browserRoute(`/b/${token}/vnc/vnc.html?autoconnect=true&resize=scale&reconnect=true&path=b/${token}/vnc/websockify`);
+  const cdpUrl = browserRoute(`/b/${token}/cdp`);
   const mcpUrl = apiUrl ? `${apiUrl}/mcp` : null;
   const sshPort = meeting.data?.ssh_port as number | undefined;
-  const sshHost = apiUrl ? (() => { try { return new URL(apiUrl).hostname; } catch { return "localhost"; } })() : "localhost";
+  const sshHost = apiUrl ? (() => { try { return new URL(apiUrl).hostname; } catch { return ""; } })() : "";
 
   const agentInstructions = cdpUrl
     ? [
@@ -116,12 +124,12 @@ export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
       ].join("\n")
     : "";
 
-  const [isDeleting, setIsDeleting] = useState(false);
-
   async function handleSave() {
     setIsSaving(true);
     try {
-      const response = await fetch(withBasePath(`/b/${token}/save`), {
+      const saveUrl = browserRoute(`/b/${token}/save`);
+      if (!saveUrl) throw new Error("Runtime config is still loading");
+      const response = await fetch(saveUrl, {
         method: "POST",
       });
       if (!response.ok) throw new Error(await response.text());
@@ -137,7 +145,9 @@ export function BrowserSessionView({ meeting }: BrowserSessionViewProps) {
     if (!confirm("Delete all stored browser data? You will need to log in again.")) return;
     setIsDeleting(true);
     try {
-      const response = await fetch(withBasePath(`/b/${token}/storage`), {
+      const storageUrl = browserRoute(`/b/${token}/storage`);
+      if (!storageUrl) throw new Error("Runtime config is still loading");
+      const response = await fetch(storageUrl, {
         method: "DELETE",
       });
       if (!response.ok) throw new Error(await response.text());

--- a/services/dashboard/src/lib/auth-cookies.ts
+++ b/services/dashboard/src/lib/auth-cookies.ts
@@ -1,0 +1,7 @@
+export function getAuthCookieName(): string {
+  return process.env.VEXA_AUTH_COOKIE_NAME || "vexa-token";
+}
+
+export function getUserInfoCookieName(): string {
+  return process.env.VEXA_USER_INFO_COOKIE_NAME || "vexa-user-info";
+}

--- a/services/dashboard/src/lib/browser-api-url.ts
+++ b/services/dashboard/src/lib/browser-api-url.ts
@@ -1,0 +1,88 @@
+type BrowserApiUrlInput = {
+  internalApiUrl: string;
+  configuredPublicApiUrl?: string;
+  requestHost: string;
+  requestProto: "http" | "https";
+  gatewayHostPort?: string;
+};
+
+export function isLoopbackHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1"
+  );
+}
+
+function hostnameFromHostHeader(host: string): string {
+  try {
+    return new URL(`http://${host}`).hostname;
+  } catch {
+    return host.split(":")[0] || host;
+  }
+}
+
+function normalizedUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function isInternalServiceUrl(value: string): boolean {
+  try {
+    const { hostname } = new URL(value);
+    return (
+      hostname === "api-gateway" ||
+      hostname.endsWith(".svc") ||
+      hostname.endsWith(".svc.cluster.local") ||
+      (!hostname.includes(".") && !isLoopbackHost(hostname))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function publicUrlFromRequestHost(requestHost: string, requestProto: "http" | "https", port: string): string {
+  const requestUrl = new URL(`${requestProto}://${requestHost}`);
+  requestUrl.port = port;
+  requestUrl.pathname = "";
+  requestUrl.search = "";
+  requestUrl.hash = "";
+  return normalizedUrl(requestUrl.toString());
+}
+
+export function resolveBrowserApiUrl({
+  internalApiUrl,
+  configuredPublicApiUrl = "",
+  requestHost,
+  requestProto,
+  gatewayHostPort,
+}: BrowserApiUrlInput): { apiUrl: string; publicApiUrl: string } {
+  const configured = configuredPublicApiUrl.trim();
+  const requestHostname = hostnameFromHostHeader(requestHost);
+
+  if (configured) {
+    try {
+      const publicUrl = new URL(configured);
+      if (isLoopbackHost(publicUrl.hostname) && !isLoopbackHost(requestHostname)) {
+        publicUrl.hostname = requestHostname;
+      }
+      const normalized = normalizedUrl(publicUrl.toString());
+      return { apiUrl: normalized, publicApiUrl: normalized };
+    } catch {
+      const normalized = normalizedUrl(configured);
+      return { apiUrl: normalized, publicApiUrl: normalized };
+    }
+  }
+
+  if (gatewayHostPort && isInternalServiceUrl(internalApiUrl)) {
+    const inferred = publicUrlFromRequestHost(requestHost, requestProto, gatewayHostPort);
+    return { apiUrl: inferred, publicApiUrl: inferred };
+  }
+
+  if (isInternalServiceUrl(internalApiUrl)) {
+    return { apiUrl: "", publicApiUrl: "" };
+  }
+
+  const normalizedInternal = normalizedUrl(internalApiUrl);
+  return { apiUrl: normalizedInternal, publicApiUrl: "" };
+}

--- a/services/dashboard/src/lib/browser-api-url.ts
+++ b/services/dashboard/src/lib/browser-api-url.ts
@@ -65,6 +65,13 @@ export function resolveBrowserApiUrl({
       const publicUrl = new URL(configured);
       if (isLoopbackHost(publicUrl.hostname) && !isLoopbackHost(requestHostname)) {
         publicUrl.hostname = requestHostname;
+      } else if (isLoopbackHost(publicUrl.hostname) && isLoopbackHost(requestHostname)) {
+        // Both the configured public URL and the request host are loopback.
+        // The configured port likely points at a container-internal gateway port
+        // (e.g. 8056) that is unreachable from the browser when the dashboard
+        // exposes a different host port (e.g. lite single-port publish). Fall
+        // back to same-origin so Next.js /ws + /api rewrites carry the traffic.
+        return { apiUrl: "", publicApiUrl: "" };
       }
       const normalized = normalizedUrl(publicUrl.toString());
       return { apiUrl: normalized, publicApiUrl: normalized };

--- a/services/dashboard/src/lib/browser-api-url.ts
+++ b/services/dashboard/src/lib/browser-api-url.ts
@@ -82,8 +82,15 @@ export function resolveBrowserApiUrl({
   }
 
   if (gatewayHostPort && isInternalServiceUrl(internalApiUrl)) {
-    const inferred = publicUrlFromRequestHost(requestHost, requestProto, gatewayHostPort);
-    return { apiUrl: inferred, publicApiUrl: inferred };
+    // Compose case: dashboard is published on a different host port than the
+    // gateway (e.g. dashboard :41688, gateway :41680). Some browser/network
+    // environments only expose the dashboard's published port, so pointing the
+    // browser directly at the gateway port breaks WS + cross-origin REST.
+    // Prefer same-origin (empty publicApiUrl) so the browser uses the
+    // dashboard's own /ws + /api/vexa/* rewrites — which already proxy to the
+    // gateway service-internal URL. Curl-from-host can still reach the
+    // gateway port directly; this only affects what the browser is told.
+    return { apiUrl: "", publicApiUrl: "" };
   }
 
   if (isInternalServiceUrl(internalApiUrl)) {

--- a/services/dashboard/tests/test_browser_api_url.test.ts
+++ b/services/dashboard/tests/test_browser_api_url.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { resolveBrowserApiUrl } from "@/lib/browser-api-url";
+
+describe("resolveBrowserApiUrl — stitched-candidate regression coverage (pack 6 fix)", () => {
+  it("falls back to same-origin when both configured + request host are loopback (lite single-port publish)", () => {
+    // Regression: lite supervisord sets NEXT_PUBLIC_API_URL=http://localhost:8056 (container-internal
+    // gateway port). Browser is at host port 41692 (dashboard). The configured loopback URL would
+    // tell the browser to talk to localhost:8056 which is unreachable. The resolver must instead
+    // return same-origin so Next.js /ws + /api rewrites carry the traffic.
+    const out = resolveBrowserApiUrl({
+      internalApiUrl: "http://localhost:8056",
+      configuredPublicApiUrl: "http://localhost:8056",
+      requestHost: "localhost:41692",
+      requestProto: "http",
+    });
+    expect(out.apiUrl).toBe("");
+    expect(out.publicApiUrl).toBe("");
+  });
+
+  it("rewrites configured loopback hostname to request hostname when request host is non-loopback", () => {
+    const out = resolveBrowserApiUrl({
+      internalApiUrl: "http://localhost:8056",
+      configuredPublicApiUrl: "http://localhost:8056",
+      requestHost: "vexa.example.com",
+      requestProto: "https",
+    });
+    expect(out.apiUrl).toBe("http://vexa.example.com:8056");
+    expect(out.publicApiUrl).toBe("http://vexa.example.com:8056");
+  });
+
+  it("keeps configured non-loopback URL as-is", () => {
+    const out = resolveBrowserApiUrl({
+      internalApiUrl: "http://api-gateway:8000",
+      configuredPublicApiUrl: "https://api.vexa.ai",
+      requestHost: "dashboard.vexa.ai",
+      requestProto: "https",
+    });
+    expect(out.apiUrl).toBe("https://api.vexa.ai");
+    expect(out.publicApiUrl).toBe("https://api.vexa.ai");
+  });
+
+  it("infers public URL from request host + gatewayHostPort when internal is an internal-service hostname", () => {
+    const out = resolveBrowserApiUrl({
+      internalApiUrl: "http://api-gateway:8000",
+      requestHost: "localhost:18056",
+      requestProto: "http",
+      gatewayHostPort: "18056",
+    });
+    expect(out.apiUrl).toBe("http://localhost:18056");
+    expect(out.publicApiUrl).toBe("http://localhost:18056");
+  });
+
+  it("returns empty for internal-service URL without gatewayHostPort hint (same-origin fallback)", () => {
+    const out = resolveBrowserApiUrl({
+      internalApiUrl: "http://api-gateway:8000",
+      requestHost: "dashboard.svc.cluster.local",
+      requestProto: "http",
+    });
+    expect(out.apiUrl).toBe("");
+    expect(out.publicApiUrl).toBe("");
+  });
+});

--- a/services/dashboard/tests/test_browser_api_url.test.ts
+++ b/services/dashboard/tests/test_browser_api_url.test.ts
@@ -39,15 +39,22 @@ describe("resolveBrowserApiUrl — stitched-candidate regression coverage (pack 
     expect(out.publicApiUrl).toBe("https://api.vexa.ai");
   });
 
-  it("infers public URL from request host + gatewayHostPort when internal is an internal-service hostname", () => {
+  it("falls back to same-origin even with gatewayHostPort when internal is an internal-service hostname (compose multi-port publish regression)", () => {
+    // Regression: compose publishes dashboard on :41688 and gateway on :41680 as
+    // separate host ports. Some browser environments only expose the dashboard
+    // port (browser sandboxes, single-port proxies). The dashboard already
+    // rewrites /ws to the gateway service URL — telling the browser to bypass
+    // that rewrite and connect directly to :41680 breaks WS in those
+    // environments. Prefer same-origin so the dashboard's /ws + /api/vexa/*
+    // rewrites carry the traffic.
     const out = resolveBrowserApiUrl({
       internalApiUrl: "http://api-gateway:8000",
-      requestHost: "localhost:18056",
+      requestHost: "localhost:41688",
       requestProto: "http",
-      gatewayHostPort: "18056",
+      gatewayHostPort: "41680",
     });
-    expect(out.apiUrl).toBe("http://localhost:18056");
-    expect(out.publicApiUrl).toBe("http://localhost:18056");
+    expect(out.apiUrl).toBe("");
+    expect(out.publicApiUrl).toBe("");
   });
 
   it("returns empty for internal-service URL without gatewayHostPort hint (same-origin fallback)", () => {


### PR DESCRIPTION
Pack epic: https://github.com/Vexa-ai/vexa/issues/361
Pack id: `0.10.6x-pack-6-self-hosted-browser-edge`
Release: `0.10.6.x replay`
Base branch: `v0.10.6^{}`
Integration branch: `codex/release-0.10.6x-pack-integration`
Evidence: `.agents/packs/0.10.6x-pack-6-self-hosted-browser-edge/`

## Status

**Draft / scaffolding only.** This PR currently contains only the pack 6 develop-runtime scaffolding (pack.json, runtime.json, claim.json, preflight.json, pr.md). No product code hunks have been replayed yet. The develop skill will fill in the reusable commits (`36df611`, `1707445`, `edefff3`) and validation evidence in follow-up commits.

## Outcomes

- **CEO**: Self-hosted users can open the dashboard and browser views without internal container URLs or unintended host-port exposure.
- **CTO**: Browser-facing config/proxy/auth edges are explicit, public, and separate from internal service routing across Lite, Compose, and Helm-shaped deployments.
- **User**: The dashboard works from the browser, while Meeting API/Admin/Runtime/TTS/Redis/Postgres stay internal in self-hosted Lite.

## Runtime allocation

- Compose project: `vexa_0-10-6x-pack-6-self-hosted-browser-edge_compose`
- Ports (compose): dashboard 42020, gateway 42021, browser-session 42022, vnc 42023
- Ports (lite): dashboard 42030, gateway 42031, vnc 42032
- Image tag: `pack-6-dev` (re-tagged from pack 1's working `:dev` images for isolation)

## PR readiness checklist

- [ ] Pack branch starts from `v0.10.6^{}`.
- [ ] Only this pack's committed reuse hunks are replayed.
- [ ] Synthetic checks pass before live/human checks.
- [ ] Compose gate is passed or explicitly marked not required in PR evidence.
- [ ] Lite gate is passed or explicitly marked not required in PR evidence.
- [ ] Hardenloop is run for the pack.
- [ ] PR body links this epic and evidence root.
- [ ] Reviewer can map each reused hunk back to the commit list above.