### PR TITLE
fix(googlemeet): support 'Join now' button for OPEN meetings (accessType=OPEN)

### DIFF
--- a/services/vexa-bot/core/src/platforms/googlemeet/join.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/join.ts
@@ -110,7 +110,7 @@ export async function joinGoogleMeeting(
     await page.screenshot({ path: '/app/storage/screenshots/bot-checkpoint-0-after-join-now.png', fullPage: true });
     log("📸 Screenshot taken: After join click (authenticated)");
   } else {
-    // Anonymous flow: enter bot name and ask to join
+    // Anonymous flow: enter bot name and join
     log("Attempting to find name input field...");
 
     const nameFieldSelector = googleNameInputSelectors[0];
@@ -136,12 +136,27 @@ export async function joinGoogleMeeting(
       log("Camera already off or not found.");
     }
 
-    const joinSelector = googleJoinButtonSelectors[0];
-    await page.waitForSelector(joinSelector, { timeout: 60000 });
-    await page.click(joinSelector);
-    log(`${botName} joined the Google Meet Meeting.`);
+    // Try all join button selectors in order.
+    // googleJoinButtonSelectors[0] is 'Ask to join' (regular/lobby meetings).
+    // OPEN meetings created via Google Meet API (accessType=OPEN) show 'Join now'
+    // instead — the loop finds whichever button is present, avoiding a 60s timeout.
+    let joinClicked = false;
+    for (const sel of googleJoinButtonSelectors) {
+      try {
+        await page.waitForSelector(sel, { timeout: 8000 });
+        await page.click(sel);
+        joinClicked = true;
+        log(`${botName} joined the Google Meet Meeting (selector: ${sel}).`);
+        break;
+      } catch (e) {
+        log(`Join button not found with selector: ${sel}, trying next...`);
+      }
+    }
+    if (!joinClicked) {
+      throw new Error('No join button found after trying all selectors');
+    }
 
     await page.screenshot({ path: '/app/storage/screenshots/bot-checkpoint-0-after-ask-to-join.png', fullPage: true });
-    log("📸 Screenshot taken: After clicking 'Ask to join'");
+    log("📸 Screenshot taken: After clicking join button");
   }
 }


### PR DESCRIPTION
## Problem

When joining a Google Meet created via the **Google Meet REST API** with `accessType: OPEN`, the anonymous-flow bot fails with `self_initiated_leave` (exit code 1) and shows **Transcription failed** in the UI.

**Root cause:** The anonymous flow used only `googleJoinButtonSelectors[0]` — an XPath selector for `'Ask to join'`. OPEN meetings render a **'Join now'** button instead (also labeled _'Participar agora'_ in pt-BR). The bot waited 60 s for a button that never appears, then timed out and left.

The name input field (`'Your name'`) **is** present on OPEN meetings, so the bot fills it correctly — the only failure is in the subsequent join-button click.

## Reproduction

1. Create a meeting space via the Google Meet API with `{ "config": { "accessType": "OPEN" } }`
2. Send the bot to the resulting `meetingUri`
3. Bot reaches **Joining** state then immediately transitions to **Failed** with reason `self_initiated_leave`

Bot screenshot at the moment of failure shows the correct join screen with a **'Join now'** button (greyed out until name is filled), not an **'Ask to join'** button.

## Fix

Replace the single-selector wait in the anonymous flow with a sequential loop over all `googleJoinButtonSelectors`. The existing selector order is preserved — `'Ask to join'` is still tried first (8 s timeout), so regular and lobby meetings are unaffected. `'Join now'` (index 2) is reached only when the earlier selectors time out.

```typescript
// Before
const joinSelector = googleJoinButtonSelectors[0];
await page.waitForSelector(joinSelector, { timeout: 60000 });
await page.click(joinSelector);

// After
let joinClicked = false;
for (const sel of googleJoinButtonSelectors) {
  try {
    await page.waitForSelector(sel, { timeout: 8000 });
    await page.click(sel);
    joinClicked = true;
    break;
  } catch (e) {
    log(`Join button not found with selector: ${sel}, trying next...`);
  }
}
if (!joinClicked) throw new Error('No join button found after trying all selectors');
```

## Testing

Verified on self-hosted `vexa-lite` (patch applied to compiled JS in container):
- OPEN meeting (`accessType: OPEN`) → bot joins successfully, transcription starts ✅
- Regular meeting (waiting room / `'Ask to join'`) → unaffected, still works ✅

Fixes #380
Related #343