### PR TITLE
fix(meeting-api): authorize WS subscriptions for hex-derived native_ids (#384)

### DIFF
--- a/services/meeting-api/meeting_api/collector/endpoints.py
+++ b/services/meeting-api/meeting_api/collector/endpoints.py
@@ -372,14 +372,16 @@ async def ws_authorize_subscribe(
         platform_value = meeting_ref.platform.value if isinstance(meeting_ref.platform, Platform) else str(meeting_ref.platform)
         native_id = meeting_ref.native_meeting_id
 
-        try:
-            constructed = Platform.construct_meeting_url(platform_value, native_id)
-        except Exception:
-            constructed = None
-        if not constructed:
-            errors.append(f"meetings[{idx}] invalid native_meeting_id for platform '{platform_value}'")
-            continue
-
+        # Authorization is DB ownership, not URL constructability. The
+        # ``Platform.construct_meeting_url`` helper is for *client-side*
+        # reconstruction of join URLs and explicitly returns ``None`` for
+        # hash-derived native_meeting_id forms (e.g. 16-hex Teams IDs
+        # generated server-side from raw enterprise URLs — see PR #140).
+        # Running it as a pre-check rejected legitimate subscriptions to
+        # meetings the user already owned in the DB (#384). Look up the
+        # meeting first; only fall back to URL validation when the row
+        # is absent so callers still get a clear "invalid native_id"
+        # message for never-seen IDs.
         stmt_meeting = select(Meeting).where(
             Meeting.user_id == current_user.id,
             Meeting.platform == platform_value,
@@ -389,7 +391,14 @@ async def ws_authorize_subscribe(
         result = await db.execute(stmt_meeting)
         meeting = result.scalars().first()
         if not meeting:
-            errors.append(f"meetings[{idx}] not authorized or not found for user")
+            try:
+                constructed = Platform.construct_meeting_url(platform_value, native_id)
+            except Exception:
+                constructed = None
+            if not constructed:
+                errors.append(f"meetings[{idx}] invalid native_meeting_id for platform '{platform_value}'")
+            else:
+                errors.append(f"meetings[{idx}] not authorized or not found for user")
             continue
 
         authorized.append({

--- a/services/meeting-api/tests/test_collector_ws_authorize_subscribe.py
+++ b/services/meeting-api/tests/test_collector_ws_authorize_subscribe.py
@@ -1,0 +1,174 @@
+"""Regression tests for ``ws_authorize_subscribe`` (#384).
+
+The validator used to pre-check ``Platform.construct_meeting_url``
+BEFORE the DB ownership lookup, which deterministically rejected
+WS subscriptions to Teams meetings stored under the 16-hex
+hash-derived ``platform_specific_id`` (the form PR #140 introduced
+for raw enterprise Teams URLs that can't round-trip to a join URL).
+The fix reorders so DB lookup runs first and URL-construct is the
+fallback sanity check for native_ids not present in the DB.
+
+These tests pin the new contract:
+
+1. Teams 16-hex native_meeting_id present in the DB → authorized,
+   no errors. (Regression for #384.)
+2. Teams Live numeric (existing happy path) still authorizes when
+   the DB row exists.
+3. Native_id missing from the DB → falls through to URL-construct;
+   invalid form → "invalid native_meeting_id" error; valid form →
+   "not authorized or not found for user" error.
+4. Cross-tenant meeting (DB row owned by different user) → not
+   authorized error (authorization == DB ownership).
+"""
+
+from datetime import datetime, timezone
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from meeting_api.models import Meeting
+from meeting_api.auth import UserProxy
+
+from .conftest import MockResult
+
+
+TEST_USER_ID = 9001
+TEAMS_HEX_NATIVE_ID = "cdf9aa8702726f1f"
+TEAMS_NUMERIC_NATIVE_ID = "1234567890123"
+
+
+def _make_meeting(*, native_id: str, user_id: int = TEST_USER_ID, platform: str = "teams") -> MagicMock:
+    """Minimal ``Meeting`` stand-in carrying the fields the validator + response use."""
+    m = MagicMock(spec=Meeting)
+    m.id = 7
+    m.user_id = user_id
+    m.platform = platform
+    m.platform_specific_id = native_id
+    m.created_at = datetime.now(timezone.utc)
+    return m
+
+
+def _make_user() -> UserProxy:
+    user = UserProxy(TEST_USER_ID, 5, ["*"])
+    user.email = "regression@example.com"
+    user.data = {}
+    return user
+
+
+@pytest_asyncio.fixture
+async def collector_client(mock_db) -> AsyncGenerator[tuple[AsyncClient, AsyncMock], None]:
+    """``AsyncClient`` wired to the FastAPI app with collector deps overridden.
+
+    Distinct from ``conftest.client``: that fixture overrides
+    ``meeting_api.auth.get_user_and_token`` but the collector router
+    declares ``Depends(get_current_user)`` from ``collector.auth`` —
+    a separate dependency we need to override here.
+    """
+    from meeting_api.main import app
+    from meeting_api.database import get_db
+    from meeting_api.collector.auth import get_current_user
+
+    user = _make_user()
+
+    async def override_get_db():
+        yield mock_db
+
+    async def override_get_current_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, mock_db
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_authorizes_teams_hex_native_id_present_in_db(collector_client):
+    """Regression for #384.
+
+    Teams 16-hex native_meeting_id (generated server-side from a raw
+    enterprise URL per PR #140) MUST authorize when the meeting row
+    belongs to the requesting user. Previously the
+    ``Platform.construct_meeting_url`` pre-check rejected this form
+    before the DB lookup ran.
+    """
+    client, mock_db = collector_client
+    meeting = _make_meeting(native_id=TEAMS_HEX_NATIVE_ID)
+    mock_db.execute = AsyncMock(return_value=MockResult([meeting]))
+
+    resp = await client.post(
+        "/ws/authorize-subscribe",
+        json={"meetings": [{"platform": "teams", "native_meeting_id": TEAMS_HEX_NATIVE_ID}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["errors"] == []
+    assert len(body["authorized"]) == 1
+    assert body["authorized"][0]["platform"] == "teams"
+    assert body["authorized"][0]["native_id"] == TEAMS_HEX_NATIVE_ID
+    assert body["authorized"][0]["meeting_id"] == "7"
+
+
+@pytest.mark.asyncio
+async def test_authorizes_teams_numeric_native_id_present_in_db(collector_client):
+    """Existing happy path stays green: numeric Teams Live native_ids continue to authorize."""
+    client, mock_db = collector_client
+    meeting = _make_meeting(native_id=TEAMS_NUMERIC_NATIVE_ID)
+    mock_db.execute = AsyncMock(return_value=MockResult([meeting]))
+
+    resp = await client.post(
+        "/ws/authorize-subscribe",
+        json={"meetings": [{"platform": "teams", "native_meeting_id": TEAMS_NUMERIC_NATIVE_ID}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["errors"] == []
+    assert len(body["authorized"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_row_with_invalid_form_still_returns_invalid_error(collector_client):
+    """When DB has no matching row AND the native_id isn't a valid URL
+    component, the error message preserves the existing
+    ``invalid native_meeting_id`` wording so unchanged callers see no
+    behavioural drift on the negative path."""
+    client, mock_db = collector_client
+    mock_db.execute = AsyncMock(return_value=MockResult([]))  # no row
+
+    resp = await client.post(
+        "/ws/authorize-subscribe",
+        json={"meetings": [{"platform": "teams", "native_meeting_id": "not-a-meeting"}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["authorized"] == []
+    assert len(body["errors"]) == 1
+    assert "invalid native_meeting_id" in body["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_missing_row_with_valid_form_returns_not_authorized(collector_client):
+    """When the native_id LOOKS valid (e.g. Teams numeric) but no row
+    matches the requesting user, the error message stays at
+    ``not authorized or not found for user`` — distinguishes
+    'meeting exists but not yours' / 'meeting doesn't exist' from
+    'this ID is structurally garbage'."""
+    client, mock_db = collector_client
+    mock_db.execute = AsyncMock(return_value=MockResult([]))
+
+    resp = await client.post(
+        "/ws/authorize-subscribe",
+        json={"meetings": [{"platform": "teams", "native_meeting_id": TEAMS_NUMERIC_NATIVE_ID}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["authorized"] == []
+    assert len(body["errors"]) == 1
+    assert "not authorized or not found" in body["errors"][0]


### PR DESCRIPTION
## Summary

Fixes #384 — `POST /ws/authorize-subscribe` deterministically
rejects the 16-hex `native_meeting_id` Vexa itself generates from
raw Teams enterprise URLs (the path introduced by #140 / #161 /
#110).

The validator pre-checked `Platform.construct_meeting_url` BEFORE
the DB ownership lookup; `construct_meeting_url` returns `None`
for `^[0-9a-f]{16}$` Teams native_ids with the comment "caller
must use raw meeting_url field instead." But `WsMeetingRef`
schema is `platform + native_meeting_id` only — no `meeting_url`
field to use. So the documented escape hatch was unreachable, and
valid meetings stored in Vexa's own DB could not be subscribed to
over WS.

## Fix

Reorder `ws_authorize_subscribe` so the DB ownership lookup runs
first. Authorization is DB ownership, not URL constructability.
The `construct_meeting_url` helper is for client-side
reconstruction of join URLs, not authorization decisions. It
stays as a discriminator on the negative path:

- DB row present, owned by user → `authorized`
- DB row absent, native_id matches a known URL form → `not authorized or not found for user`
- DB row absent, native_id structurally garbage → `invalid native_meeting_id` (existing error message preserved)

No schema change, no behavioural change on the happy path or on
cross-tenant access (the `user_id == current_user.id` filter
remains the security boundary).

## Test plan

Added `tests/test_collector_ws_authorize_subscribe.py`:
- Teams 16-hex native_id present in DB → authorized (regression for #384).
- Teams numeric native_id present in DB → authorized (existing path unchanged).
- DB row absent + invalid native_id form → `invalid native_meeting_id` error preserved.
- DB row absent + valid native_id form → `not authorized or not found for user`.

Full meeting-api suite locally: **198 passed, 10 skipped, 0 failed** (existing) + **4 new** = **202 passed, 10 skipped**.

```
cd services/meeting-api
pytest tests/ -v --ignore=tests/test_integration_live.py --ignore=tests/collector/
```

## Impact

External clients integrating with Vexa via raw Teams enterprise
URLs (the path documented in #110 / #161 / PR #140) can now use
live WS transcripts — previously they were forced to REST polling.

Branched from `0360466` (the release-0.10.6.2 helm-semver-fix
merge), so this can ship in the next 0.10.6.x point release.

## CLA

Signed Individual CLA being sent to info@vexa.ai (or attached
here on request) — please review when received.