### PR TITLE
fix(docs): escape `<N` patterns for MDX parser

### DIFF
--- a/docs/architecture-refactoring-plan.md
+++ b/docs/architecture-refactoring-plan.md
@@ -536,7 +536,7 @@ No big bang rewrite. Extract piece by piece while production keeps running.
 | Temporal | Meeting lifecycle becomes complex (retries, sagas) | Durable workflow above Runtime API |
 | Argo Workflows | Post-meeting pipeline grows | DAG-based processing chain |
 | K8s Operator (CRD) | K8s becomes primary backend | Declarative state, kubectl visibility |
-| Pre-warm pool | Startup latency critical (<5s) | Warm container inventory |
+| Pre-warm pool | Startup latency critical (\<5s) | Warm container inventory |
 
 ---
 

--- a/docs/archive/VALIDATION.md
+++ b/docs/archive/VALIDATION.md
@@ -568,7 +568,7 @@ Human checklist:
 | TTS heard | [ ] | [ ] |
 | Transcript rendered | [ ] | [ ] |
 | Speaker labels correct | [ ] | [ ] |
-| Latency acceptable (<30s) | [ ] | [ ] |
+| Latency acceptable (\<30s) | [ ] | [ ] |
 
 ---
 

--- a/docs/youtube-agent-runtime.md
+++ b/docs/youtube-agent-runtime.md
@@ -25,7 +25,7 @@
 >
 > google meet &nbsp; ms teams &nbsp; zoom &nbsp; streaming
 > *anything streamed in browser*
-> <5 sec latency
+> \<5 sec latency
 > WS &nbsp; API &nbsp; MCP
 
 **Narration:**
@@ -525,7 +525,7 @@ An agent that was costing you a dedicated VM 24/7? Now it costs you 3 minutes of
 >
 > google meet &nbsp; ms teams &nbsp; zoom &nbsp; streaming
 > *anything streamed in browser*
-> <5 sec latency
+> \<5 sec latency
 > WS &nbsp; API &nbsp; MCP
 
 **On screen (right side):** Container architecture diagram + live transcript screenshot


### PR DESCRIPTION
## Summary
- Fix 3 pre-existing MDX parse errors that started failing Mintlify deployment on the 0.10.6.3 merge to main.
- Each is a `<N` pattern that MDX interprets as a JSX tag opener; escaped with `\<` so they render as literal `<N`.

## Files changed
- `docs/youtube-agent-runtime.md` line 28
- `docs/architecture-refactoring-plan.md` line 539
- `docs/archive/VALIDATION.md` line 571

## Verification
`mintlify broken-links` locally: 0 syntax errors after the fix (was 3 before).

## Test plan
- [x] Local `mintlify broken-links` clean of syntax errors
- [ ] Mintlify deployment check passes on this PR
- [ ] Mintlify deployment on main retries successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)