### PR TITLE
fix: harden dashboard authz and schedule callbacks

### DIFF
--- a/services/agent-api/agent_api/main.py
+++ b/services/agent-api/agent_api/main.py
@@ -6,14 +6,17 @@ message recreates it seamlessly.
 """
 
 import asyncio
+import ipaddress
 import json
 import logging
 import os
 import re
+import socket
 import time
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
@@ -353,6 +356,52 @@ async def write_workspace_template_file(name: str, req: FileWriteRequest):
     return {"path": req.path, "status": "written"}
 
 
+def _is_blocked_callback_ip(address: str) -> bool:
+    ip = ipaddress.ip_address(address)
+    return any((
+        ip.is_private,
+        ip.is_loopback,
+        ip.is_link_local,
+        ip.is_multicast,
+        ip.is_reserved,
+        ip.is_unspecified,
+    ))
+
+
+def _validate_public_http_url(url: str) -> str:
+    """Validate scheduler callback URL against internal-network SSRF targets."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(400, "Only http and https callback URLs are allowed")
+    if parsed.username or parsed.password:
+        raise HTTPException(400, "Callback URLs cannot include userinfo")
+
+    hostname = parsed.hostname or ""
+    if not hostname:
+        raise HTTPException(400, "Callback URL host is required")
+    if hostname.endswith(".internal") or "." not in hostname:
+        raise HTTPException(400, "Cannot schedule requests to internal service names")
+
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        addr_infos = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except (OSError, ValueError):
+        raise HTTPException(400, "Callback URL host could not be resolved")
+
+    addresses = {info[4][0] for info in addr_infos if info and info[4]}
+    if not addresses:
+        raise HTTPException(400, "Callback URL host could not be resolved")
+
+    for address in addresses:
+        try:
+            if _is_blocked_callback_ip(str(address)):
+                raise HTTPException(400, "Cannot schedule requests to private or internal network URLs")
+        except ValueError:
+            raise HTTPException(400, "Callback URL resolved to an invalid address")
+
+    return url
+
+
 # ── Schedule bridge ───────────────────────────────────────────────────────
 
 
@@ -382,19 +431,9 @@ async def schedule_bridge(req: ScheduleRequest):
     elif req.action == "http":
         if not req.url:
             raise HTTPException(400, "url required for action=http")
-        # SSRF protection: reject internal/private URLs
-        from urllib.parse import urlparse
-        parsed = urlparse(req.url)
-        hostname = parsed.hostname or ""
-        if hostname in ("localhost", "127.0.0.1", "0.0.0.0") or hostname.endswith(".internal"):
-            raise HTTPException(400, "Cannot schedule requests to internal URLs")
-        if any(hostname.startswith(prefix) for prefix in ("10.", "172.", "192.168.")):
-            raise HTTPException(400, "Cannot schedule requests to private network URLs")
-        if "." not in hostname:
-            raise HTTPException(400, "Cannot schedule requests to internal service names")
         target_request = {
             "method": req.method or "POST",
-            "url": req.url,
+            "url": _validate_public_http_url(req.url),
         }
     else:
         raise HTTPException(400, f"Unknown action: {req.action}")

--- a/services/agent-api/tests/test_endpoints.py
+++ b/services/agent-api/tests/test_endpoints.py
@@ -225,10 +225,69 @@ class TestWorkspaceEndpoints:
 
 
 # ---------------------------------------------------------------------------
+# Schedule SSRF protection
+# ---------------------------------------------------------------------------
+class TestScheduleSsrfProtection:
+    @pytest.mark.parametrize("url", [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.1/",
+        "http://[::1]/",
+        "http://[fe80::1]/",
+    ])
+    def test_schedule_http_rejects_non_public_ip_literals(self, client, url):
+        from agent_api.main import cm
+
+        cm._http = MagicMock()
+        cm._http.post = AsyncMock(return_value=MagicMock(status_code=201, json=lambda: {"ok": True}))
+
+        resp = client.post(
+            "/api/schedule",
+            json={"user_id": "test-user", "action": "http", "url": url, "method": "GET"},
+        )
+
+        assert resp.status_code == 400
+        cm._http.post.assert_not_called()
+
+    def test_schedule_http_rejects_dns_that_resolves_to_private_address(self, client, monkeypatch):
+        from agent_api.main import cm
+        import socket
+
+        cm._http = MagicMock()
+        cm._http.post = AsyncMock(return_value=MagicMock(status_code=201, json=lambda: {"ok": True}))
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *args, **kwargs: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.8", 443))],
+        )
+
+        resp = client.post(
+            "/api/schedule",
+            json={"user_id": "test-user", "action": "http", "url": "https://callback.example.test/hook"},
+        )
+
+        assert resp.status_code == 400
+        cm._http.post.assert_not_called()
+
+    def test_schedule_http_rejects_malformed_ports_without_scheduler_call(self, client):
+        from agent_api.main import cm
+
+        cm._http = MagicMock()
+        cm._http.post = AsyncMock(return_value=MagicMock(status_code=201, json=lambda: {"ok": True}))
+
+        resp = client.post(
+            "/api/schedule",
+            json={"user_id": "test-user", "action": "http", "url": "https://callback.example.test:bad/hook"},
+        )
+
+        assert resp.status_code == 400
+        cm._http.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Internal endpoints
 # ---------------------------------------------------------------------------
-
 class TestInternalEndpoints:
+
     def test_workspace_save_no_container(self, client):
         resp = client.post(
             "/internal/workspace/save",

--- a/services/dashboard/src/app/api/agent/[...path]/route.ts
+++ b/services/dashboard/src/app/api/agent/[...path]/route.ts
@@ -1,5 +1,7 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAuthenticatedUserId } from "@/lib/auth-utils";
+import { getAuthCookieName } from "@/lib/auth-cookies";
 
 const AGENT_API_URL = process.env.AGENT_API_URL || "http://localhost:8100";
 // Service-to-service token — must match BOT_API_TOKEN in the agent-api container
@@ -7,7 +9,38 @@ const AGENT_API_TOKEN = process.env.AGENT_API_TOKEN || "";
 
 async function getUserToken(): Promise<string> {
   const cookieStore = await cookies();
-  return cookieStore.get("vexa-token")?.value || "";
+  return cookieStore.get(getAuthCookieName())?.value || "";
+}
+
+async function requireUserId(): Promise<string | Response> {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+  return userId;
+}
+
+function pathString(path: string[]): string {
+  return path.join("/");
+}
+
+function bindQueryUserId(req: NextRequest, userId: string): string {
+  const url = new URL(req.url);
+  url.searchParams.set("user_id", userId);
+  const query = url.searchParams.toString();
+  return query ? `?${query}` : "";
+}
+
+async function bindJsonBody(req: NextRequest, userId: string): Promise<string | undefined> {
+  const rawBody = await req.text();
+  if (!rawBody) return undefined;
+
+  const contentType = req.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) return rawBody;
+
+  const body = JSON.parse(rawBody);
+  body.user_id = userId;
+  return JSON.stringify(body);
 }
 
 async function safeJsonResponse(resp: globalThis.Response): Promise<Response> {
@@ -23,9 +56,11 @@ async function safeJsonResponse(resp: globalThis.Response): Promise<Response> {
 }
 
 export async function GET(req: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+  const userIdOrResponse = await requireUserId();
+  if (typeof userIdOrResponse !== "string") return userIdOrResponse;
+
   const { path } = await context.params;
-  const url = new URL(req.url);
-  const target = `${AGENT_API_URL}/api/${path.join("/")}${url.search}`;
+  const target = `${AGENT_API_URL}/api/${pathString(path)}${bindQueryUserId(req, userIdOrResponse)}`;
   const resp = await fetch(target, {
     headers: { "Content-Type": "application/json", "X-API-Key": AGENT_API_TOKEN },
   });
@@ -33,16 +68,19 @@ export async function GET(req: NextRequest, context: { params: Promise<{ path: s
 }
 
 export async function POST(req: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+  const userIdOrResponse = await requireUserId();
+  if (typeof userIdOrResponse !== "string") return userIdOrResponse;
+
   const { path } = await context.params;
-  const url = new URL(req.url);
-  const rawBody = await req.text();
-  const target = `${AGENT_API_URL}/api/${path.join("/")}${url.search}`;
+  const pathName = pathString(path);
+  const target = `${AGENT_API_URL}/api/${pathName}${bindQueryUserId(req, userIdOrResponse)}`;
 
   // For chat endpoint: inject user's bot token into request so agent container gets it
-  if (path.join("/") === "chat") {
-    const userToken = await getUserToken();
-    const body = JSON.parse(rawBody);
-    body.bot_token = userToken; // Agent API will pass this to the container for vexa CLI calls
+  if (pathName === "chat") {
+    const rawBody = await req.text();
+    const body = rawBody ? JSON.parse(rawBody) : {};
+    body.user_id = userIdOrResponse;
+    body.bot_token = await getUserToken(); // Agent API will pass this to the container for vexa CLI calls
 
     const resp = await fetch(target, {
       method: "POST",
@@ -63,33 +101,36 @@ export async function POST(req: NextRequest, context: { params: Promise<{ path: 
   const resp = await fetch(target, {
     method: "POST",
     headers: { "Content-Type": "application/json", "X-API-Key": AGENT_API_TOKEN },
-    body: rawBody,
+    body: await bindJsonBody(req, userIdOrResponse),
   });
   return safeJsonResponse(resp);
 }
 
 export async function PUT(req: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+  const userIdOrResponse = await requireUserId();
+  if (typeof userIdOrResponse !== "string") return userIdOrResponse;
+
   const { path } = await context.params;
-  const url = new URL(req.url);
-  const body = await req.text();
-  const target = `${AGENT_API_URL}/api/${path.join("/")}${url.search}`;
+  const target = `${AGENT_API_URL}/api/${pathString(path)}${bindQueryUserId(req, userIdOrResponse)}`;
   const resp = await fetch(target, {
     method: "PUT",
     headers: { "Content-Type": "application/json", "X-API-Key": AGENT_API_TOKEN },
-    body,
+    body: await bindJsonBody(req, userIdOrResponse),
   });
   return safeJsonResponse(resp);
 }
 
 export async function DELETE(req: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+  const userIdOrResponse = await requireUserId();
+  if (typeof userIdOrResponse !== "string") return userIdOrResponse;
+
   const { path } = await context.params;
-  const url = new URL(req.url);
-  const body = await req.text();
-  const target = `${AGENT_API_URL}/api/${path.join("/")}${url.search}`;
+  const target = `${AGENT_API_URL}/api/${pathString(path)}${bindQueryUserId(req, userIdOrResponse)}`;
+  const body = await bindJsonBody(req, userIdOrResponse);
   const resp = await fetch(target, {
     method: "DELETE",
     headers: { "Content-Type": "application/json", "X-API-Key": AGENT_API_TOKEN },
-    body: body || undefined,
+    body,
   });
   return safeJsonResponse(resp);
 }

--- a/services/dashboard/src/app/api/profile/keys/[id]/route.ts
+++ b/services/dashboard/src/app/api/profile/keys/[id]/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getAuthCookieName } from "@/lib/auth-cookies";
+import { getAuthenticatedUserId } from "@/lib/auth-utils";
 
 /**
- * DELETE /api/profile/keys/:id — revoke an API key via admin API
+ * DELETE /api/profile/keys/:id — revoke an authenticated user's own API key via admin API
  */
 export async function DELETE(
   _request: NextRequest,
@@ -16,6 +17,11 @@ export async function DELETE(
     return NextResponse.json({ error: "Admin API URL/key not configured" }, { status: 503 });
   }
 
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
   const cookieStore = await cookies();
   const token = cookieStore.get(getAuthCookieName())?.value;
   if (!token) {
@@ -25,6 +31,24 @@ export async function DELETE(
   const { id } = await params;
 
   try {
+    const userResponse = await fetch(`${VEXA_ADMIN_API_URL}/admin/users/${userId}`, {
+      headers: { "X-Admin-API-Key": VEXA_ADMIN_API_KEY },
+      cache: "no-store",
+    });
+
+    if (!userResponse.ok) {
+      return NextResponse.json({ error: "Failed to verify API key ownership" }, { status: userResponse.status });
+    }
+
+    const userData = await userResponse.json();
+    const ownsToken = (userData.api_tokens || []).some(
+      (apiToken: { id: number | string }) => String(apiToken.id) === String(id)
+    );
+
+    if (!ownsToken) {
+      return NextResponse.json({ error: "API key not found" }, { status: 404 });
+    }
+
     const response = await fetch(`${VEXA_ADMIN_API_URL}/admin/tokens/${id}`, {
       method: "DELETE",
       headers: {

--- a/services/dashboard/tests/test_agent_proxy_authz.test.ts
+++ b/services/dashboard/tests/test_agent_proxy_authz.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: vi.fn(() => ({ value: "user-api-token" })),
+  })),
+}));
+
+const getAuthenticatedUserId = vi.fn();
+vi.mock("@/lib/auth-utils", () => ({
+  getAuthenticatedUserId: () => getAuthenticatedUserId(),
+}));
+
+function mockFetchJson(status = 200, body: unknown = { ok: true }) {
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+async function loadAgentRoute() {
+  vi.resetModules();
+  process.env.AGENT_API_URL = "http://agent-api.test";
+  process.env.AGENT_API_TOKEN = "service-token";
+  return import("../src/app/api/agent/[...path]/route");
+}
+
+describe("dashboard agent proxy authorization", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getAuthenticatedUserId.mockReset();
+  });
+
+  it("returns 401 before proxying unauthenticated requests", async () => {
+    getAuthenticatedUserId.mockResolvedValue(null);
+    const fetchMock = mockFetchJson();
+    const { GET } = await loadAgentRoute();
+
+    const response = await GET(
+      new Request("http://dashboard.test/api/agent/sessions?user_id=victim") as never,
+      { params: Promise.resolve({ path: ["sessions"] }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("binds GET user_id query params to the authenticated dashboard user", async () => {
+    getAuthenticatedUserId.mockResolvedValue("user-1");
+    const fetchMock = mockFetchJson();
+    const { GET } = await loadAgentRoute();
+
+    const response = await GET(
+      new Request("http://dashboard.test/api/agent/sessions?user_id=user-2&limit=10") as never,
+      { params: Promise.resolve({ path: ["sessions"] }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const forwardedUrl = fetchMock.mock.calls[0][0] as string;
+    expect(forwardedUrl).toContain("user_id=user-1");
+    expect(forwardedUrl).toContain("limit=10");
+    expect(forwardedUrl).not.toContain("user_id=user-2");
+  });
+
+  it("overwrites JSON body user_id with the authenticated dashboard user", async () => {
+    getAuthenticatedUserId.mockResolvedValue("user-1");
+    const fetchMock = mockFetchJson();
+    const { POST } = await loadAgentRoute();
+
+    const response = await POST(
+      new Request("http://dashboard.test/api/agent/schedule", {
+        method: "POST",
+        body: JSON.stringify({ user_id: "user-2", action: "chat", message: "hello" }),
+        headers: { "Content-Type": "application/json" },
+      }) as never,
+      { params: Promise.resolve({ path: ["schedule"] }) }
+    );
+
+    expect(response.status).toBe(200);
+    const forwarded = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(forwarded.user_id).toBe("user-1");
+    expect(forwarded.message).toBe("hello");
+  });
+});

--- a/services/dashboard/tests/test_profile_key_delete_authz.test.ts
+++ b/services/dashboard/tests/test_profile_key_delete_authz.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: vi.fn(() => ({ value: "user-api-token" })),
+  })),
+}));
+
+const getAuthenticatedUserId = vi.fn();
+vi.mock("@/lib/auth-utils", () => ({
+  getAuthenticatedUserId: () => getAuthenticatedUserId(),
+}));
+
+async function loadRoute() {
+  vi.resetModules();
+  process.env.VEXA_ADMIN_API_URL = "http://admin-api.test";
+  process.env.VEXA_ADMIN_API_KEY = "admin-secret";
+  return import("../src/app/api/profile/keys/[id]/route");
+}
+
+describe("profile API key deletion authorization", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getAuthenticatedUserId.mockReset();
+  });
+
+  it("does not delete API keys that are absent from the authenticated user's token list", async () => {
+    getAuthenticatedUserId.mockResolvedValue("user-1");
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "http://admin-api.test/admin/users/user-1" && !init?.method) {
+        return new Response(
+          JSON.stringify({ api_tokens: [{ id: 111, token: "owned-token", created_at: "2026-01-01T00:00:00Z" }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { DELETE } = await loadRoute();
+
+    const response = await DELETE(
+      new Request("http://dashboard.test/api/profile/keys/222") as never,
+      { params: Promise.resolve({ id: "222" }) }
+    );
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "http://admin-api.test/admin/tokens/222",
+      expect.anything()
+    );
+  });
+});

--- a/services/runtime-api/runtime_api/scheduler.py
+++ b/services/runtime-api/runtime_api/scheduler.py
@@ -210,7 +210,7 @@ async def _fire_request(request: dict[str, Any]) -> dict[str, Any]:
     timeout = request.get("timeout", 30)
 
     start = time.time()
-    async with httpx.AsyncClient(follow_redirects=True) as client:
+    async with httpx.AsyncClient(follow_redirects=False) as client:
         if body is not None:
             if "Content-Type" not in headers and "content-type" not in headers:
                 headers["Content-Type"] = "application/json"

--- a/services/runtime-api/tests/test_scheduler_api.py
+++ b/services/runtime-api/tests/test_scheduler_api.py
@@ -7,6 +7,7 @@ import time
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -150,3 +151,33 @@ def test_list_jobs_filter_by_status(client):
     assert resp.status_code == 200
     for job in resp.json():
         assert job["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_fire_request_does_not_follow_redirect_to_private_host(monkeypatch):
+    """Scheduled callbacks must not follow redirects to internal/private URLs."""
+    from runtime_api import scheduler
+
+    requested_urls = []
+    original_async_client = httpx.AsyncClient
+
+    async def handler(request):
+        requested_urls.append(str(request.url))
+        if str(request.url) == "https://public.example/callback":
+            return httpx.Response(
+                302,
+                headers={"Location": "http://127.0.0.1:8080/internal"},
+                request=request,
+            )
+        return httpx.Response(200, text="private metadata", request=request)
+
+    def client_with_mock_transport(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(scheduler.httpx, "AsyncClient", client_with_mock_transport)
+
+    result = await scheduler._fire_request({"method": "POST", "url": "https://public.example/callback"})
+
+    assert result["status_code"] == 302
+    assert requested_urls == ["https://public.example/callback"]


### PR DESCRIPTION
### Summary
- Hardened dashboard agent proxy authorization so scoped API keys cannot access unrelated users' agent routes.
- Hardened profile API key deletion authorization.
- Added schedule callback SSRF protections at submission time.
- Closed the runtime scheduler redirect SSRF bypass by disabling automatic redirects for scheduled HTTP callbacks.
- Added regression coverage proving scheduler callback execution does not follow a public 3xx redirect to a loopback/internal URL.

### Security Notes
- Callback URL validation remains enforced before scheduling in `services/agent-api/agent_api/main.py`.
- Runtime execution in `services/runtime-api/runtime_api/scheduler.py` now preserves the original callback boundary by using `follow_redirects=False`; 3xx responses are returned as-is and are not followed to private, link-local, metadata, or loopback targets.

### Test Plan
- `cd services/runtime-api && uv run --with pytest --with pytest-asyncio --with 'fakeredis[lua]' --with httpx python -m pytest tests/test_scheduler_api.py::test_fire_request_does_not_follow_redirect_to_private_host -q` — 1 passed, 1 warning.
- `cd services/runtime-api && uv run --with pytest --with pytest-asyncio --with 'fakeredis[lua]' --with httpx python -m pytest tests/test_scheduler_api.py -q` — 13 passed, 1 warning.
- `cd services/agent-api && uv run --with pytest --with pytest-asyncio python -m pytest tests/test_endpoints.py::TestScheduleSsrfProtection -q` — 6 passed, 5 warnings.
- Prior parent validation: dashboard unit tests/lint and full agent endpoint suite passed on the same branch before the runtime redirect fix.

### Files Changed In Final Fix
- `services/runtime-api/runtime_api/scheduler.py`
- `services/runtime-api/tests/test_scheduler_api.py`

### Final Fix Commit
- `7c814c6` — `fix: prevent scheduler callback redirect ssrf`