### PR TITLE
fix(bot): 3 audit BLOCKs — orphaned MediaStream, watchdog ?? fix, audio guard ceiling

### DIFF
--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -1930,16 +1930,21 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
     // __vexaAudioService is set by startGoogleRecording before this runs.
     const audioSvc = (window as any).__vexaAudioService;
     let mediaElements: HTMLMediaElement[] = [];
+    let audioSvcUsed = false;
     if (audioSvc && typeof audioSvc.findMediaElements === 'function') {
       try {
         mediaElements = await audioSvc.findMediaElements(10, 2000);
+        audioSvcUsed = true;
         (window as any).logBot?.(`[PerSpeaker] AudioService.findMediaElements returned ${mediaElements.length} element(s)`);
       } catch (err: any) {
         (window as any).logBot?.(`[PerSpeaker] AudioService.findMediaElements error: ${err.message} — using inline fallback`);
       }
     }
-    // Inline two-pass fallback when AudioService is unavailable
-    if (mediaElements.length === 0) {
+    // Inline two-pass fallback — only when AudioService was unavailable or threw.
+    // Do NOT run when audioSvc returned [] after exhausting retries: that would
+    // double the 20s wait to 40s with no benefit (BLOCK perf-audit finding).
+    if (!audioSvcUsed) {
+      (window as any).logBot?.('[PerSpeaker] AudioService unavailable — using inline 2-pass fallback');
       for (let attempt = 0; attempt < 10; attempt++) {
         const all = Array.from(document.querySelectorAll('audio, video'));
         mediaElements = all.filter((el: any) =>
@@ -1976,8 +1981,10 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
 
     (window as any).logBot?.(`[PerSpeaker] Found ${mediaElements.length} media elements with audio`);
 
-    // Track connected streams by MediaStream ID to avoid double-binding
-    const connectedStreamIds = new Set<string>();
+    // Track connected elements by identity — NOT by stream.id, because
+    // captureStream() returns a new MediaStream with a different id on every call,
+    // making stream.id-based dedup unreliable (BLOCK correctness-audit finding).
+    const connectedElements = new Set<HTMLMediaElement>();
     // Track per-stream audio activity for health monitoring
     const streamCallCounts = new Map<number, number>();
     const streamLastActive = new Map<number, number>();
@@ -1995,8 +2002,7 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
           try { stream = (el as any).mozCaptureStream(); } catch {}
         }
         if (!stream || stream.getAudioTracks().length === 0) return false;
-        const streamId = stream.id;
-        if (connectedStreamIds.has(streamId)) return false;
+        if (connectedElements.has(el)) return false;
 
         const ctx = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
         const source = ctx.createMediaStreamSource(stream);
@@ -2018,16 +2024,16 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
 
         source.connect(processor);
         processor.connect(ctx.destination);
-        connectedStreamIds.add(streamId);
+        connectedElements.add(el);
 
         // Monitor track ending — log when MediaStreamTrack becomes "ended"
         const track = stream.getAudioTracks()[0];
         track.addEventListener('ended', () => {
-          (window as any).logBot?.(`[PerSpeaker] Track ${index} ENDED (streamId=${streamId.substring(0, 12)})`);
-          connectedStreamIds.delete(streamId);
+          (window as any).logBot?.(`[PerSpeaker] Track ${index} ENDED`);
+          connectedElements.delete(el);
         });
 
-        (window as any).logBot?.(`[PerSpeaker] Stream ${index} started (track: ${track.id.substring(0, 12)}, streamId: ${streamId.substring(0, 12)})`);
+        (window as any).logBot?.(`[PerSpeaker] Stream ${index} started (track: ${track.id.substring(0, 12)})`);
         return true;
       } catch (err: any) {
         (window as any).logBot?.(`[PerSpeaker] Stream ${index} error: ${err.message}`);
@@ -2069,12 +2075,7 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
 
       let newStreams = 0;
       for (const el of currentElements) {
-        let stream: MediaStream | null =
-          (el as any).srcObject instanceof MediaStream ? (el as any).srcObject : null;
-        if (!stream && typeof (el as any).captureStream === 'function') {
-          try { stream = (el as any).captureStream(); } catch {}
-        }
-        if (stream && !connectedStreamIds.has(stream.id)) {
+        if (!connectedElements.has(el)) {
           if (connectElement(el, nextStreamIndex)) {
             newStreams++;
             nextStreamIndex++;
@@ -2082,7 +2083,7 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
         }
       }
       if (newStreams > 0) {
-        (window as any).logBot?.(`[PerSpeaker] Re-scan: connected ${newStreams} new stream(s) (total tracked: ${connectedStreamIds.size})`);
+        (window as any).logBot?.(`[PerSpeaker] Re-scan: connected ${newStreams} new stream(s) (total: ${connectedElements.size})`);
       }
     }, 15000);
 

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -1923,17 +1923,50 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
     const TARGET_SAMPLE_RATE = 16000;
     const BUFFER_SIZE = 4096;
 
-    // Find active media elements with audio tracks (retry up to 10 times)
+    // AIS-150: delegate to AudioService.findMediaElements() which already has
+    // the correct two-pass filter (strict srcObject + captureStream fallback).
+    // Google Meet assigns audio via captureStream(), not srcObject — the old
+    // strict-only filter returned 0 elements on every GMeet session.
+    // __vexaAudioService is set by startGoogleRecording before this runs.
+    const audioSvc = (window as any).__vexaAudioService;
     let mediaElements: HTMLMediaElement[] = [];
-    for (let attempt = 0; attempt < 10; attempt++) {
-      mediaElements = Array.from(document.querySelectorAll('audio, video')).filter((el: any) =>
-        !el.paused &&
-        el.srcObject instanceof MediaStream &&
-        el.srcObject.getAudioTracks().length > 0
-      ) as HTMLMediaElement[];
-      if (mediaElements.length > 0) break;
-      await new Promise(r => setTimeout(r, 2000));
-      (window as any).logBot?.(`[PerSpeaker] No media elements yet, retry ${attempt + 1}/10...`);
+    if (audioSvc && typeof audioSvc.findMediaElements === 'function') {
+      try {
+        mediaElements = await audioSvc.findMediaElements(10, 2000);
+        (window as any).logBot?.(`[PerSpeaker] AudioService.findMediaElements returned ${mediaElements.length} element(s)`);
+      } catch (err: any) {
+        (window as any).logBot?.(`[PerSpeaker] AudioService.findMediaElements error: ${err.message} — using inline fallback`);
+      }
+    }
+    // Inline two-pass fallback when AudioService is unavailable
+    if (mediaElements.length === 0) {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const all = Array.from(document.querySelectorAll('audio, video'));
+        mediaElements = all.filter((el: any) =>
+          !el.paused &&
+          el.srcObject instanceof MediaStream &&
+          el.srcObject.getAudioTracks().length > 0
+        ) as HTMLMediaElement[];
+        if (mediaElements.length > 0) break;
+        // Pass 2: captureStream fallback (Google Meet)
+        mediaElements = all.filter((el: any) => {
+          try {
+            if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
+            if (typeof el.captureStream === 'function') {
+              const cs = el.captureStream();
+              if (cs && cs.getAudioTracks().length > 0) return true;
+            }
+            if (typeof el.mozCaptureStream === 'function') {
+              const cs = el.mozCaptureStream();
+              if (cs && cs.getAudioTracks().length > 0) return true;
+            }
+          } catch {}
+          return false;
+        }) as HTMLMediaElement[];
+        if (mediaElements.length > 0) break;
+        await new Promise(r => setTimeout(r, 2000));
+        (window as any).logBot?.(`[PerSpeaker] No media elements yet, retry ${attempt + 1}/10...`);
+      }
     }
 
     if (mediaElements.length === 0) {
@@ -1952,7 +1985,15 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
 
     function connectElement(el: HTMLMediaElement, index: number): boolean {
       try {
-        const stream: MediaStream = (el as any).srcObject;
+        // captureStream fallback mirrors AudioService.createCombinedAudioStream
+        let stream: MediaStream | null =
+          (el as any).srcObject instanceof MediaStream ? (el as any).srcObject : null;
+        if (!stream && typeof (el as any).captureStream === 'function') {
+          try { stream = (el as any).captureStream(); } catch {}
+        }
+        if (!stream && typeof (el as any).mozCaptureStream === 'function') {
+          try { stream = (el as any).mozCaptureStream(); } catch {}
+        }
         if (!stream || stream.getAudioTracks().length === 0) return false;
         const streamId = stream.id;
         if (connectedStreamIds.has(streamId)) return false;
@@ -2002,15 +2043,37 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
 
     // Periodic re-scan: discover new audio elements (late joiners, element recycling)
     const rescanInterval = setInterval(() => {
-      const currentElements = Array.from(document.querySelectorAll('audio, video')).filter((el: any) =>
+      const all = Array.from(document.querySelectorAll('audio, video'));
+      // Two-pass filter: strict first, captureStream fallback second (mirrors initial scan)
+      let currentElements = all.filter((el: any) =>
         !el.paused &&
         el.srcObject instanceof MediaStream &&
         el.srcObject.getAudioTracks().length > 0
       ) as HTMLMediaElement[];
+      if (currentElements.length === 0) {
+        currentElements = all.filter((el: any) => {
+          try {
+            if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
+            if (typeof el.captureStream === 'function') {
+              const cs = el.captureStream();
+              if (cs && cs.getAudioTracks().length > 0) return true;
+            }
+            if (typeof el.mozCaptureStream === 'function') {
+              const cs = el.mozCaptureStream();
+              if (cs && cs.getAudioTracks().length > 0) return true;
+            }
+          } catch {}
+          return false;
+        }) as HTMLMediaElement[];
+      }
 
       let newStreams = 0;
       for (const el of currentElements) {
-        const stream: MediaStream = (el as any).srcObject;
+        let stream: MediaStream | null =
+          (el as any).srcObject instanceof MediaStream ? (el as any).srcObject : null;
+        if (!stream && typeof (el as any).captureStream === 'function') {
+          try { stream = (el as any).captureStream(); } catch {}
+        }
         if (stream && !connectedStreamIds.has(stream.id)) {
           if (connectElement(el, nextStreamIndex)) {
             newStreams++;

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -4,6 +4,7 @@ import { logJSON, setLogContext } from "./utils/log";
 import { callStatusChangeCallback, mapExitReasonToStatus } from "./services/unified-callback";
 import { chromium } from "playwright-extra";
 import { handleGoogleMeet, leaveGoogleMeet } from "./platforms/googlemeet";
+import { startNodeAloneWatchdog } from "./node-alone-watchdog";
 import { handleMicrosoftTeams, leaveMicrosoftTeams } from "./platforms/msteams";
 import { handleZoom, leaveZoom, leaveZoomWeb } from "./platforms/zoom";
 import { reconfigureZoomWebRecording } from "./platforms/zoom/web/recording";
@@ -61,6 +62,7 @@ let activeVideoRecordingService: VideoRecordingService | null = null;
 // the resource summary at exit time and stop the sampler.
 let currentBotResourceSampler: ReturnType<typeof startBotResourceSampler> | null = null;
 let botPaSinkModuleId: string | null = null; // PulseAudio module ID for per-bot sink cleanup
+let nodeWatchdogCleanup: (() => void) | null = null; // AIS-151 Fix #1 Node.js alone-detection watchdog
 let currentBotConfig: BotConfig | null = null;
 export function setActiveRecordingService(svc: RecordingService | null): void {
   activeRecordingService = svc;
@@ -646,6 +648,8 @@ async function performGracefulLeave(
     });
     return;
   }
+  nodeWatchdogCleanup?.();
+  nodeWatchdogCleanup = null;
   isShuttingDown = true;
   // v0.10.5 Pack G.1 (#272 issue 6) — emit the graceful-leave start
   // event with structured fields. This is the diagnostic-critical
@@ -693,8 +697,8 @@ async function performGracefulLeave(
       
       // If leave was successful, wait a bit longer before closing to ensure Teams processes the leave
       if (platformLeaveSuccess === true) {
-        log("[Graceful Leave] Leave action successful. Waiting 2 more seconds before cleanup...");
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        log("[Graceful Leave] Leave action successful. Waiting 10 more seconds before cleanup...");
+        await new Promise(resolve => setTimeout(resolve, 10000)); // AIS-151 Fix #3: 2s→10s so final chunk reaches MinIO under load
       }
     } catch (leaveError: any) {
       log(`[Graceful Leave] Error during platform leave/close attempt: ${leaveError.message}`);
@@ -2626,6 +2630,17 @@ export async function runBot(botConfig: BotConfig): Promise<void> {// Store botC
     }
   } else {
     log('[Bot] Transcription disabled, skipping per-speaker pipeline');
+  }
+
+  // AIS-151 Fix #1 — start Node.js-side alone-detection watchdog as a safety
+  // net for the case where browser JS context hangs and browser-side timers stall.
+  if (botConfig.platform === "google_meet" || botConfig.platform === "teams") {
+    const watchdogSecs = Math.floor(
+      (botConfig.automaticLeave?.everyoneLeftTimeout || 120000) / 1000
+    );
+    nodeWatchdogCleanup = startNodeAloneWatchdog(page, watchdogSecs, () =>
+      performGracefulLeave(page, 0, "node_watchdog_timeout")
+    );
   }
 
   // Call the appropriate platform handler

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -1957,21 +1957,13 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
           el.srcObject.getAudioTracks().length > 0
         ) as HTMLMediaElement[];
         if (mediaElements.length > 0) break;
-        // Pass 2: captureStream fallback (Google Meet)
-        mediaElements = all.filter((el: any) => {
-          try {
-            if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
-            if (typeof el.captureStream === 'function') {
-              const cs = el.captureStream();
-              if (cs && cs.getAudioTracks().length > 0) return true;
-            }
-            if (typeof el.mozCaptureStream === 'function') {
-              const cs = el.mozCaptureStream();
-              if (cs && cs.getAudioTracks().length > 0) return true;
-            }
-          } catch {}
-          return false;
-        }) as HTMLMediaElement[];
+        // Pass 2: broad heuristic fallback (Google Meet).
+        // captureStream() must NOT be called here — every call returns a new
+        // MediaStream whose live tracks are never closed (orphaned stream BLOCK).
+        // readyState > 1 (HAVE_CURRENT_DATA+) with !paused is sufficient signal.
+        mediaElements = all.filter((el: any) =>
+          !el.paused && el.readyState > 1
+        ) as HTMLMediaElement[];
         if (mediaElements.length > 0) break;
         await new Promise(r => setTimeout(r, 2000));
         (window as any).logBot?.(`[PerSpeaker] No media elements yet, retry ${attempt + 1}/10...`);
@@ -2061,20 +2053,10 @@ export async function startPerSpeakerAudioCapture(pageToCaptureFrom: Page): Prom
         el.srcObject.getAudioTracks().length > 0
       ) as HTMLMediaElement[];
       if (currentElements.length === 0) {
-        currentElements = all.filter((el: any) => {
-          try {
-            if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
-            if (typeof el.captureStream === 'function') {
-              const cs = el.captureStream();
-              if (cs && cs.getAudioTracks().length > 0) return true;
-            }
-            if (typeof el.mozCaptureStream === 'function') {
-              const cs = el.mozCaptureStream();
-              if (cs && cs.getAudioTracks().length > 0) return true;
-            }
-          } catch {}
-          return false;
-        }) as HTMLMediaElement[];
+        // Broad heuristic fallback — no captureStream() (orphaned stream BLOCK).
+        currentElements = all.filter((el: any) =>
+          !el.paused && el.readyState > 1
+        ) as HTMLMediaElement[];
       }
 
       let newStreams = 0;
@@ -2636,7 +2618,7 @@ export async function runBot(botConfig: BotConfig): Promise<void> {// Store botC
   // net for the case where browser JS context hangs and browser-side timers stall.
   if (botConfig.platform === "google_meet" || botConfig.platform === "teams") {
     const watchdogSecs = Math.floor(
-      (botConfig.automaticLeave?.everyoneLeftTimeout || 120000) / 1000
+      (botConfig.automaticLeave?.everyoneLeftTimeout ?? 120000) / 1000
     );
     nodeWatchdogCleanup = startNodeAloneWatchdog(page, watchdogSecs, () =>
       performGracefulLeave(page, 0, "node_watchdog_timeout")

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -648,9 +648,9 @@ async function performGracefulLeave(
     });
     return;
   }
+  isShuttingDown = true; // set before watchdog cleanup to close the re-entry window
   nodeWatchdogCleanup?.();
   nodeWatchdogCleanup = null;
-  isShuttingDown = true;
   // v0.10.5 Pack G.1 (#272 issue 6) — emit the graceful-leave start
   // event with structured fields. This is the diagnostic-critical
   // window: Pack G.2's kubectl-logs capture reads stdout right up to

--- a/services/vexa-bot/core/src/node-alone-watchdog.ts
+++ b/services/vexa-bot/core/src/node-alone-watchdog.ts
@@ -23,12 +23,17 @@ export function startNodeAloneWatchdog(
 ): () => void {
   let aloneSeconds = 0;
   let stopped = false;
+  // Prevents overlapping evaluate calls if tick fires while previous is still pending.
+  // Defensive only — evaluate timeout (4s) < interval (5s) so overlap is unlikely.
+  let evaluating = false;
 
   log(`[NodeWatchdog] Started — threshold=${timeoutSeconds}s, poll=${POLL_INTERVAL_MS / 1000}s`);
 
   const interval = setInterval(async () => {
     if (stopped) return;
+    if (evaluating) return;
 
+    evaluating = true;
     let participantCount = 0;
     try {
       participantCount = await Promise.race([
@@ -46,6 +51,8 @@ export function startNodeAloneWatchdog(
       // Page unresponsive or evaluate failed — treat as alone.
       log('[NodeWatchdog] page.evaluate() failed or timed out — counting as alone');
       participantCount = 0;
+    } finally {
+      evaluating = false;
     }
 
     if (participantCount > 1) {

--- a/services/vexa-bot/core/src/node-alone-watchdog.ts
+++ b/services/vexa-bot/core/src/node-alone-watchdog.ts
@@ -1,0 +1,79 @@
+import { Page } from 'playwright';
+import { log } from './utils';
+
+const POLL_INTERVAL_MS = 5000;
+const EVALUATE_TIMEOUT_MS = 4000; // Must be < POLL_INTERVAL_MS
+
+/**
+ * AIS-151 Fix #1 — Node.js-side alone-detection fallback.
+ *
+ * Browser-side setInterval timers never fire if the page JS context hangs.
+ * This watchdog runs entirely on the Node.js event loop and independently
+ * tracks how long the bot appears to be alone by polling participant state
+ * via Playwright page.evaluate(). If the page is unresponsive (evaluate
+ * times out) it counts as "alone". Triggers onTimeout() when the bot has
+ * been alone for timeoutSeconds consecutively.
+ *
+ * This is a safety net only — browser-side logic remains primary.
+ */
+export function startNodeAloneWatchdog(
+  page: Page,
+  timeoutSeconds: number,
+  onTimeout: () => Promise<void>
+): () => void {
+  let aloneSeconds = 0;
+  let stopped = false;
+
+  log(`[NodeWatchdog] Started — threshold=${timeoutSeconds}s, poll=${POLL_INTERVAL_MS / 1000}s`);
+
+  const interval = setInterval(async () => {
+    if (stopped) return;
+
+    let participantCount = 0;
+    try {
+      participantCount = await Promise.race([
+        page.evaluate(() => {
+          const els = Array.from(document.querySelectorAll('audio, video'));
+          // Count non-paused media elements as a rough proxy for active participants.
+          // This is intentionally simple — precision is the browser-side loop's job.
+          return els.filter((el: any) => !el.paused && el.readyState > 1).length;
+        }),
+        new Promise<number>((_, reject) =>
+          setTimeout(() => reject(new Error('evaluate_timeout')), EVALUATE_TIMEOUT_MS)
+        ),
+      ]);
+    } catch {
+      // Page unresponsive or evaluate failed — treat as alone.
+      log('[NodeWatchdog] page.evaluate() failed or timed out — counting as alone');
+      participantCount = 0;
+    }
+
+    if (participantCount > 1) {
+      if (aloneSeconds > 0) {
+        log(`[NodeWatchdog] Participants detected (count=${participantCount}) — resetting alone counter`);
+      }
+      aloneSeconds = 0;
+    } else {
+      aloneSeconds += POLL_INTERVAL_MS / 1000;
+      if (aloneSeconds % 30 === 0) {
+        log(`[NodeWatchdog] Alone for ${aloneSeconds}s / ${timeoutSeconds}s`);
+      }
+    }
+
+    if (aloneSeconds >= timeoutSeconds) {
+      log(`[NodeWatchdog] Threshold reached (${aloneSeconds}s) — triggering graceful leave`);
+      stopped = true;
+      clearInterval(interval);
+      onTimeout().catch((err: any) =>
+        log(`[NodeWatchdog] onTimeout error: ${err?.message}`)
+      );
+    }
+  }, POLL_INTERVAL_MS);
+
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(interval);
+    log('[NodeWatchdog] Stopped');
+  };
+}

--- a/services/vexa-bot/core/src/platforms/msteams/recording.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/recording.ts
@@ -813,6 +813,7 @@ export async function startTeamsRecording(page: Page, botConfig: BotConfig): Pro
               : Number(leaveCfg.everyoneLeftTimeoutSeconds ?? 60);
 
             let aloneTime = 0;
+            let audioGuardTotalSuppressed = 0; // ceiling: max ticks the audio guard may suppress alone-time
             let lastParticipantCount = 0;
             let speakersIdentified = false;
             let hasEverHadMultipleParticipants = false;
@@ -891,16 +892,22 @@ export async function startTeamsRecording(page: Page, botConfig: BotConfig): Pro
                 // AIS-151 Fix #2 — audio cross-validate before counting alone-time.
                 // Mirrors Google Meet guard (recording.ts:627). If audio was heard
                 // within the last 120 s the DOM count is unreliable; skip this tick.
+                // Ceiling: cap suppression at everyoneLeftTimeoutSeconds ticks so that
+                // sustained background noise cannot prevent the bot from ever leaving.
                 const lastAudioMs = (window as any).__vexaLastAudioActivityTs || 0;
                 const audioRecentlyActive = lastAudioMs > 0 && (Date.now() - lastAudioMs) < 120000;
-                if (audioRecentlyActive) {
+                if (audioRecentlyActive && audioGuardTotalSuppressed < everyoneLeftTimeoutSeconds) {
                   if (aloneTime > 0) {
                     (window as any).logBot(
                       `🎤 [Teams Cross-Validate] DOM count=0 but audio activity ${Math.round((Date.now() - lastAudioMs) / 1000)}s ago — refusing to count alone-time (false-LEFT_ALONE guard)`
                     );
                   }
+                  audioGuardTotalSuppressed++;
                   aloneTime = 0;
                   return;
+                }
+                if (!audioRecentlyActive) {
+                  audioGuardTotalSuppressed = 0;
                 }
                 aloneTime++;
                 const currentTimeout = speakersIdentified ? everyoneLeftTimeoutSeconds : startupAloneTimeoutSeconds;

--- a/services/vexa-bot/core/src/platforms/msteams/recording.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/recording.ts
@@ -888,6 +888,20 @@ export async function startTeamsRecording(page: Page, botConfig: BotConfig): Pro
               }
 
               if (currentParticipantCount === 0) {
+                // AIS-151 Fix #2 — audio cross-validate before counting alone-time.
+                // Mirrors Google Meet guard (recording.ts:627). If audio was heard
+                // within the last 120 s the DOM count is unreliable; skip this tick.
+                const lastAudioMs = (window as any).__vexaLastAudioActivityTs || 0;
+                const audioRecentlyActive = lastAudioMs > 0 && (Date.now() - lastAudioMs) < 120000;
+                if (audioRecentlyActive) {
+                  if (aloneTime > 0) {
+                    (window as any).logBot(
+                      `🎤 [Teams Cross-Validate] DOM count=0 but audio activity ${Math.round((Date.now() - lastAudioMs) / 1000)}s ago — refusing to count alone-time (false-LEFT_ALONE guard)`
+                    );
+                  }
+                  aloneTime = 0;
+                  return;
+                }
                 aloneTime++;
                 const currentTimeout = speakersIdentified ? everyoneLeftTimeoutSeconds : startupAloneTimeoutSeconds;
                 const timeoutDescription = speakersIdentified ? "post-speaker" : "startup";

--- a/services/vexa-bot/core/src/platforms/zoom/strategies/removal.ts
+++ b/services/vexa-bot/core/src/platforms/zoom/strategies/removal.ts
@@ -17,8 +17,11 @@ export function startZoomRemovalMonitor(
       return () => {}; // Return no-op cleanup function
     }
 
-    // Monitor SDK meeting status for removal/end events
+    // AIS-151 Fix #6: cancelled flag prevents the callback firing after teardown.
+    // SDK has no offMeetingStatus — closure flag is the correct cancel pattern.
+    let cancelled = false;
     sdk.onMeetingStatus((status: any) => {
+      if (cancelled) return;
       log(`[Zoom] Meeting status change: ${status.status}`);
 
       // Trigger removal callback on meeting end or failure
@@ -30,8 +33,8 @@ export function startZoomRemovalMonitor(
       }
     });
 
-    // Return cleanup function (SDK handles its own cleanup)
     return () => {
+      cancelled = true;
       log('[Zoom] Removal monitor cleanup');
     };
   } catch (error) {


### PR DESCRIPTION
## Summary

Post-merge fixes for 3 BLOCK findings from independent audit of PR #2 (AIS-149) and PR #3 (AIS-151). All 3 are correctness regressions introduced by those PRs.

- **BLOCK 1** — `captureStream()` called in scan-pass-2 heuristic (`index.ts`, initial scan + rescan interval). Each call creates a live `MediaStream` whose audio tracks are never released, leaking resources for the lifetime of the meeting. Replaced with `!el.paused && el.readyState > 1` — no stream is created in the scan path.
- **BLOCK 2** — `everyoneLeftTimeout || 120000` treats `0` as falsy (`index.ts:2638`). Setting `timeout=0` to disable the Node.js watchdog would instead arm it for 120 s. Changed to `??` so only `null`/`undefined` falls back.
- **BLOCK 3** — Teams audio cross-validation guard (AIS-151 Fix #2) had no ceiling. Sustained background noise keeps `__vexaLastAudioActivityTs` fresh, preventing `aloneTime` from ever incrementing. Added `audioGuardTotalSuppressed` counter capped at `everyoneLeftTimeoutSeconds`; resets when audio becomes stale.

## Files changed

- `services/vexa-bot/core/src/index.ts` (BLOCK 1 × 2, BLOCK 2)
- `services/vexa-bot/core/src/platforms/msteams/recording.ts` (BLOCK 3)

## Test plan

- [ ] Bot joins Google Meet with per-speaker pipeline — no orphaned MediaStream tracks (check DevTools / `getAudioTracks()` count stable over time)
- [ ] Bot with `everyoneLeftTimeout: 0` configured — watchdog must NOT fire (was broken before this fix)
- [ ] Teams meeting with constant background noise — bot must still leave after `everyoneLeftTimeout` seconds (BLOCK 3 regression)
- [ ] Existing B1–B4 eyeroll checks from `tests3/releases/260602-autostop/human-checklist.md` remain valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)