### PR TITLE
[#407 407-B] Joining callback survives transient meeting-api blip; abort only on deliberate reject

### DIFF
--- a/services/vexa-bot/core/src/services/unified-callback.ts
+++ b/services/vexa-bot/core/src/services/unified-callback.ts
@@ -119,10 +119,19 @@ export async function callStatusChangeCallback(
     return;
   }
 
-  // Retry logic: try up to 3 times with exponential backoff
-  const maxRetries = 3;
+  // Retry logic with exponential backoff.
+  // #407 407-B: joining/awaiting_admission/active are the critical pre-/in-meeting
+  // lifecycle callbacks. A TRANSIENT meeting-api blip here (timeout / 5xx / network —
+  // e.g. during a meeting-api rollout, which is where these failures clustered) must
+  // NOT abort an otherwise-fine join. Give the critical statuses a wider budget, and
+  // classify transient vs DELIBERATE (4xx / explicit reject body) so the caller can
+  // proceed on transient and only abort on a deliberate server rejection.
+  const critical = status === "joining" || status === "awaiting_admission" || status === "active";
+  const maxRetries = critical ? 5 : 3;
   const baseDelay = 1000; // 1 second
-  
+  const maxDelay = 4000;  // cap backoff so the total budget stays bounded
+  let sawDeliberate = false; // true once the server deliberately rejects (4xx / explicit non-accepted body)
+
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     let timeoutId: NodeJS.Timeout | null = null;
     try {
@@ -186,9 +195,10 @@ export async function callStatusChangeCallback(
           }
           return; // Success, exit retry loop
         } else {log(`Callback returned unexpected status: ${responseBody.status}, detail: ${responseBody.detail || 'none'}`);
+          sawDeliberate = true; // 200 OK with an explicit non-accepted status = deliberate server rejection
           // If not last attempt, retry
           if (attempt < maxRetries - 1) {
-            const delay = baseDelay * Math.pow(2, attempt);
+            const delay = Math.min(baseDelay * Math.pow(2, attempt), maxDelay);
             log(`Retrying in ${delay}ms...`);
             await new Promise(resolve => setTimeout(resolve, delay));
             continue;
@@ -196,9 +206,11 @@ export async function callStatusChangeCallback(
         }
       } else {
         const errorText = await response.text().catch(() => 'Unable to read error response');log(`Callback failed with HTTP ${response.status}: ${errorText}`);
+        // 4xx = the server deliberately refused (bad request / invalid transition); 5xx = transient.
+        if (response.status >= 400 && response.status < 500) sawDeliberate = true;
         // If not last attempt, retry
         if (attempt < maxRetries - 1) {
-          const delay = baseDelay * Math.pow(2, attempt);
+          const delay = Math.min(baseDelay * Math.pow(2, attempt), maxDelay);
           log(`Retrying in ${delay}ms...`);
           await new Promise(resolve => setTimeout(resolve, delay));
           continue;
@@ -210,16 +222,20 @@ export async function callStatusChangeCallback(
       
       // If not last attempt, retry
       if (attempt < maxRetries - 1) {
-        const delay = baseDelay * Math.pow(2, attempt);
+        const delay = Math.min(baseDelay * Math.pow(2, attempt), maxDelay);
         log(`Retrying in ${delay}ms...`);
         await new Promise(resolve => setTimeout(resolve, delay));
       } else {log(`All ${maxRetries} callback attempts failed for ${status} status change.`);
-        throw new Error(`All ${maxRetries} callback attempts failed for ${status} status change`);
+        const err: any = new Error(`All ${maxRetries} callback attempts failed for ${status} status change`);
+        err.transient = !sawDeliberate;   // timeout/network exhaustion = transient unless a deliberate reject was seen
+        throw err;
       }
     }
   }
   // If we get here without returning (success), all retries were exhausted via non-exception path
-  throw new Error(`${status} callback failed: server rejected after ${maxRetries} attempts`);
+  const err: any = new Error(`${status} callback failed: server rejected after ${maxRetries} attempts`);
+  err.transient = !sawDeliberate;   // 5xx-only exhaustion is transient; a 4xx/explicit-reject sets sawDeliberate
+  throw err;
 }
 
 /**

--- a/services/vexa-bot/core/src/utils.ts
+++ b/services/vexa-bot/core/src/utils.ts
@@ -32,7 +32,23 @@ export async function callStartupCallback(botConfig: any): Promise<void> {
   await callStatusChangeCallback(botConfig, "active");
 }
 
-export async function callJoiningCallback(botConfig: any): Promise<void> {await callStatusChangeCallback(botConfig, "joining");}
+export async function callJoiningCallback(botConfig: any): Promise<void> {
+  // #407 407-B: the join must abort on a DELIBERATE server rejection (the original
+  // "Fix 2"), but a TRANSIENT meeting-api blip (timeout / 5xx / network — e.g. a
+  // meeting-api rollout window, where these failures clustered) must NOT abort an
+  // otherwise-fine join. Proceed on transient; the later awaiting_admission/active
+  // callbacks reconcile the status. (Decision tracked in #407; bound to
+  // registry check gmeet.join_callback_resilient.)
+  try {
+    await callStatusChangeCallback(botConfig, "joining");
+  } catch (e: any) {
+    if (e?.transient) {
+      log(`WARNING: joining callback failed transiently (${e?.message}); proceeding with join — status will reconcile on the next lifecycle callback.`);
+      return;
+    }
+    throw e; // deliberate rejection (4xx / explicit reject body) — abort the join
+  }
+}
 
 export async function callAwaitingAdmissionCallback(botConfig: any): Promise<void> {
   await callStatusChangeCallback(botConfig, "awaiting_admission");


### PR DESCRIPTION
Pack #407 stream **407-B** — 13/35 post-hotfix failures.

**Cause:** the JOINING callback aborted the join on any 3×5s exhaustion; during the meeting-api rollout it was unavailable longer than that budget → otherwise-fine joins killed. It didn't distinguish a transient blip from a deliberate rejection.
**Fix:** classify transient (timeout/5xx/network) vs deliberate (4xx / explicit reject body); widen the critical-lifecycle budget; **proceed on transient, abort only on deliberate** (centralized in `callJoiningCallback`).
**proves[]:** gmeet.join_callback_resilient
Full typecheck/build at stitch (fresh worktree has no node_modules). Do not merge before eyeball.