### PR TITLE
[#407 407-A] GMeet humanized join — real-pointer click verification + locale-agnostic selectors

### DIFF
--- a/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanized.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanized.test.ts
@@ -9,10 +9,13 @@
  * emission, and the screen<->page coordinate mapping — deterministically.
  */
 
+import * as fs from "fs";
+import * as path from "path";
 import { MocapEngine, type Rect } from "./mocapEngine";
 import { X11Input } from "./x11Input";
 import { HumanizedInteractor } from "./humanizedInteraction";
 import { MOCAP_LIBRARY } from "./mocap-data";
+import { googleJoinButtonSelectors, googleNameInputSelectors } from "../selectors";
 
 let passed = 0;
 let failed = 0;
@@ -104,14 +107,159 @@ console.log("\nTest 4: X11Input command emission (dryRun)");
     console.log(`    (navigateAndClick error: ${e})`);
   }
   assert(!threw, "navigateAndClick completes against a reachable fake target");
+  // The click must land AFTER the move replay (endpoint verified before press).
+  const x11 = (interactor as any).x11 as X11Input;
+  const argv5 = x11.log.map((a) => a.join(" "));
+  const lastMove = argv5.map((a, i) => (a.startsWith("xdotool mousemove") ? i : -1)).filter((i) => i >= 0).pop() ?? -1;
+  const down = argv5.findIndex((a) => a === "xdotool mousedown 1");
+  assert(down > lastMove && lastMove >= 0, "button-down is emitted only after the pointer has been moved onto the target");
+
+  // ── 6. Endpoint verification refuses an off-target click ──────
+  // Force a wrong offset so the real (simulated) pointer can never reach the
+  // live rect; the interactor must THROW (no-fallbacks: fail loud, never click
+  // blindly) and emit a miss screenshot.
+  console.log("\nTest 6: endpoint verification refuses an off-target click");
+  {
+    let shotReason = "";
+    const offPage = makeFakePage({ left: 800, top: 420, width: 120, height: 44, dpr: 1, screenX: 0, screenY: 0, forceOccluded: true });
+    const guard = new HumanizedInteractor(MOCAP_LIBRARY, {
+      dryRun: true,
+      onMissScreenshot: async (_p, reason) => { shotReason = reason; },
+    });
+    let missThrew = false;
+    try {
+      await guard.navigateAndClick(offPage as any, {} as any);
+    } catch (e) {
+      missThrew = true;
+    }
+    assert(missThrew, "navigateAndClick THROWS when the pointer cannot be verified inside the target");
+    assert(/verification FAILED/.test(shotReason), "a miss-screenshot reason is surfaced before abandoning the click");
+    const gx11 = (guard as any).x11 as X11Input;
+    assert(!gx11.log.some((a) => a.join(" ") === "xdotool mousedown 1"), "no button-down is emitted on a verification failure");
+  }
+
+  // ── 7. Locale-agnostic selectors match a Hungarian mock DOM ───
+  console.log("\nTest 7: locale-agnostic join/name selectors (hu UI)");
+  {
+    const selectorsSrc = fs.readFileSync(
+      path.join(__dirname, "..", "selectors.ts"),
+      "utf-8"
+    );
+    // (a) join button: a locale-agnostic structural selector precedes the
+    // English text selector, so a Hungarian "Kérvényezés a csatlakozásra"
+    // button (no English text) still matches by jsname/structure.
+    const joinBlock = selectorsSrc.slice(
+      selectorsSrc.indexOf("googleJoinButtonSelectors"),
+      selectorsSrc.indexOf("googleCameraButtonSelectors")
+    );
+    const joinJsnameIdx = joinBlock.indexOf("button[jsname]");
+    // Match the English *selector literals* (not the prose comment, which also
+    // mentions the English text).
+    const joinEnglishIdx = joinBlock.indexOf("has-text(\"Ask to join\")");
+    assert(joinJsnameIdx >= 0, "join selectors include a locale-agnostic jsname/structure selector");
+    assert(joinJsnameIdx < joinEnglishIdx, "locale-agnostic join selector precedes the English-text fallback");
+
+    // (b) name field: structural input selector precedes the English aria-label.
+    const nameBlock = selectorsSrc.slice(
+      selectorsSrc.indexOf("googleNameInputSelectors"),
+      selectorsSrc.indexOf("googleMeetingContainerSelectors")
+    );
+    const nameStructIdx = Math.min(
+      ...["input[jsname]", 'input[type="text"]:not('].map((s) => {
+        const i = nameBlock.indexOf(s);
+        return i < 0 ? Number.MAX_SAFE_INTEGER : i;
+      })
+    );
+    const nameEnglishIdx = nameBlock.indexOf('aria-label="Your name"');
+    assert(nameStructIdx !== Number.MAX_SAFE_INTEGER, "name selectors include a locale-agnostic structural selector");
+    assert(nameStructIdx < nameEnglishIdx, "locale-agnostic name selector precedes the English aria-label fallback");
+
+    // (c) DOM match: build a Hungarian lobby (no English text anywhere) and
+    // confirm the FIRST (locale-agnostic) join + name selectors match it via a
+    // minimal CSS matcher. This is the localized-DOM check the English-literal
+    // selectors failed (prod ids 13951 13952 14018 14153).
+    const huJoinBtn: El = {
+      tag: "button",
+      attrs: { jsname: "Qx7uuf" },
+      text: "Kérvényezés a csatlakozásra", // "Ask to join" (hu) — no English
+      children: [{ tag: "span", attrs: {}, text: "Kérvényezés a csatlakozásra", children: [] }],
+    };
+    const huNameInput: El = {
+      tag: "input",
+      attrs: { jsname: "YPqjbf", type: "text", "aria-label": "A neved" }, // "Your name" (hu)
+      text: "",
+      children: [],
+    };
+    const firstJoinSel = googleJoinButtonSelectors[0];
+    const firstNameSel = googleNameInputSelectors[0];
+    assert(matchesSelector(huJoinBtn, firstJoinSel), `hu join button matches locale-agnostic selector '${firstJoinSel}'`);
+    assert(matchesSelector(huNameInput, firstNameSel), `hu name input matches locale-agnostic selector '${firstNameSel}'`);
+    // Negative control: the English-text selector must NOT match the hu button.
+    assert(!matchesSelector(huJoinBtn, 'button:has-text("Ask to join")'), "English-text selector does NOT match the hu join button (the regression)");
+  }
+
+  // ── 8. join.ts fails LOUD (screenshot) when no selector matches ─
+  console.log("\nTest 8: join.ts fails loud when controls are missing");
+  {
+    const joinSrc = fs.readFileSync(path.join(__dirname, "..", "join.ts"), "utf-8");
+    assert(/waitForAnySelector/.test(joinSrc), "join.ts uses an ordered multi-selector resolver");
+    const fn = joinSrc.slice(joinSrc.indexOf("export async function waitForAnySelector"));
+    assert(/screenshot/.test(fn) && /throw new Error/.test(fn), "selector resolver screenshots + throws on total miss (no silent skip)");
+  }
 
   console.log(`\n${passed} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);
 })();
 
+// ── Minimal CSS-selector matcher for the structural localized-DOM check ──────
+// Supports exactly the predicate forms our locale-agnostic selectors use:
+//   tag, [attr], [attr="v"], [attr*="v"], :not([...]), :has(tag),
+//   and the Playwright :has-text("...") pseudo (English-only fallbacks). Not a
+//   general CSS engine — just enough to faithfully prove match/non-match on the
+//   selectors this pack ships. Combinators (descendant " ") match the leaf.
+interface El { tag: string; attrs: Record<string, string>; text: string; children: El[] }
+
+function matchesSelector(el: El, selector: string): boolean {
+  // Descendant combinator: only the right-most compound must match `el`
+  // (our DOM mocks are the leaf control itself).
+  const compound = selector.trim().split(/\s+(?![^\[]*\])/).pop() as string;
+  // tag prefix
+  let rest = compound;
+  const tagMatch = /^[a-zA-Z]+/.exec(rest);
+  if (tagMatch) {
+    if (el.tag !== tagMatch[0]) return false;
+    rest = rest.slice(tagMatch[0].length);
+  }
+  // walk the remaining predicates
+  const predicate = /\[([^\]]+)\]|:not\(([^)]+)\)|:has\(([^)]+)\)|:has-text\("([^"]+)"\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = predicate.exec(rest)) !== null) {
+    if (m[1] !== undefined) { if (!attrMatch(el, m[1])) return false; }
+    else if (m[2] !== undefined) { if (matchesSelector(el, m[2])) return false; } // :not()
+    else if (m[3] !== undefined) { // :has(child)
+      if (!el.children.some((c) => matchesSelector(c, m![3]))) return false;
+    } else if (m[4] !== undefined) { // :has-text — English fallback path
+      if (!el.text.includes(m[4])) return false;
+    }
+  }
+  return true;
+}
+
+function attrMatch(el: El, body: string): boolean {
+  const star = body.match(/^([\w-]+)\*="([^"]*)"$/);
+  if (star) return (el.attrs[star[1]] ?? "").includes(star[2]);
+  const eq = body.match(/^([\w-]+)="([^"]*)"$/);
+  if (eq) return el.attrs[eq[1]] === eq[2];
+  const present = body.match(/^([\w-]+)$/);
+  if (present) return present[1] in el.attrs;
+  return false;
+}
+
 // Minimal Playwright Page stand-in: only the calls navigateAndClick makes.
-function makeFakePage(m: { left: number; top: number; width: number; height: number; dpr: number; screenX: number; screenY: number }) {
+function makeFakePage(m: { left: number; top: number; width: number; height: number; dpr: number; screenX: number; screenY: number; forceOccluded?: boolean }) {
   return {
+    async waitForTimeout(_ms: number) { /* no-op in tests */ },
+    async screenshot(_opts: any) { /* no-op in tests */ },
     async evaluate(fn: any, _arg?: any) {
       const src = String(fn);
       if (src.includes("devicePixelRatio") && !src.includes("getBoundingClientRect") && !src.includes("screenX")) {
@@ -122,13 +270,15 @@ function makeFakePage(m: { left: number; top: number; width: number; height: num
         return { sx: m.screenX, sy: m.screenY, iw: 1920, ih: 1080 };
       }
       if (src.includes("__vexaLastMouse")) {
-        // Return a calibration sample consistent with offset 0, dpr m.dpr.
+        // Calibration sample consistent with offset 0, dpr m.dpr.
         return { clientX: 400, clientY: 300 };
       }
       if (src.includes("getBoundingClientRect")) {
         return { left: m.left, top: m.top, width: m.width, height: m.height, screenX: m.screenX, screenY: m.screenY, dpr: m.dpr };
       }
-      if (src.includes("elementFromPoint")) return true; // endpoint verified
+      // elementFromPoint: the target resolves unless we force it occluded (the
+      // off-target / covered-button case the verification must catch).
+      if (src.includes("elementFromPoint")) return !m.forceOccluded;
       return undefined;
     },
   };

--- a/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanizedInteraction.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanizedInteraction.ts
@@ -13,7 +13,7 @@
 
 import type { Page, ElementHandle } from "playwright";
 import { MocapEngine, type Rect } from "./mocapEngine";
-import { X11Input } from "./x11Input";
+import { X11Input, type PointerLocation } from "./x11Input";
 import type { MocapLibrary } from "./types";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -22,6 +22,11 @@ export interface HumanizedOptions {
   display?: string;
   dryRun?: boolean;
   log?: (msg: string) => void;
+  /**
+   * Optional sink for a diagnostic screenshot when a click is abandoned as a
+   * confirmed miss (no-fallbacks.md: fail LOUD with a logged reason + image).
+   */
+  onMissScreenshot?: (page: Page, reason: string) => Promise<void>;
 }
 
 interface PageMetrics {
@@ -43,11 +48,15 @@ export class HumanizedInteractor {
   private dpr = 1;
   private calibrated = false;
   private mocapMisses = 0;
+  private onMissScreenshot?: (page: Page, reason: string) => Promise<void>;
+  /** Slack (device px) allowed between the real pointer and the live button rect. */
+  private static readonly ENDPOINT_SLACK_PX = 2;
 
   constructor(library: MocapLibrary, opts: HumanizedOptions = {}) {
     this.engine = new MocapEngine(library);
     this.x11 = new X11Input({ display: opts.display, dryRun: opts.dryRun });
     this.log = opts.log ?? (() => {});
+    this.onMissScreenshot = opts.onMissScreenshot;
   }
 
   async available(): Promise<boolean> {
@@ -60,8 +69,11 @@ export class HumanizedInteractor {
    * and reading the resulting mousemove events. Falls back to the
    * window.screenX/Y + devicePixelRatio formula if events aren't observed.
    */
-  async calibrate(page: Page): Promise<void> {
-    if (this.calibrated) return;
+  async calibrate(page: Page, force = false): Promise<void> {
+    if (this.calibrated && !force) return;
+    // DPR / screenX can change between page load and lobby render (zoom,
+    // window move, OS scaling). Always re-read on a (re)calibrate so the
+    // offset reflects the geometry at click time, not at page-load time.
     this.dpr = await page.evaluate(() => window.devicePixelRatio || 1);
 
     await page.evaluate(() => {
@@ -138,16 +150,66 @@ export class HumanizedInteractor {
     }, handle);
   }
 
-  /** Move the pointer to the element along a human trajectory and click it. */
-  async navigateAndClick(page: Page, handle: ElementHandle<Element>): Promise<void> {
-    await this.calibrate(page);
+  /** Map an absolute X-screen point (device px) into page client coords (CSS px). */
+  private screenToPage(sx: number, sy: number): { x: number; y: number } {
+    return { x: (sx - this.offsetX) / this.dpr, y: (sy - this.offsetY) / this.dpr };
+  }
+
+  /** Map a page client point (CSS px) to absolute X-screen coords (device px). */
+  private pageToScreen(px: number, py: number): { x: number; y: number } {
+    return { x: this.offsetX + px * this.dpr, y: this.offsetY + py * this.dpr };
+  }
+
+  /**
+   * Endpoint verification (the fix for the silent off-target click).
+   *
+   * Reads the REAL hardware pointer from the X server and re-reads the target's
+   * LIVE bounding rect, then asserts the pointer is inside that rect AND that
+   * elementFromPoint at the mapped page coords resolves to the target. Crucially
+   * this uses the actual pointer position (not the predicted endpoint) so a wrong
+   * screen↔page offset is detected instead of papered over by a self-consistent
+   * page-space round-trip.
+   */
+  private async pointerHitsTarget(
+    page: Page,
+    handle: ElementHandle<Element>
+  ): Promise<{ ok: boolean; m: PageMetrics; pointer: PointerLocation; pageX: number; pageY: number }> {
+    const m = await this.metricsOf(page, handle);
+    const pointer = await this.x11.getPointer();
+    const { x: pageX, y: pageY } = this.screenToPage(pointer.x, pointer.y);
+    const S = HumanizedInteractor.ENDPOINT_SLACK_PX;
+    const insideRect =
+      pageX >= m.left - S &&
+      pageX <= m.left + m.width + S &&
+      pageY >= m.top - S &&
+      pageY <= m.top + m.height + S;
+    if (!insideRect) {
+      return { ok: false, m, pointer, pageX, pageY };
+    }
+    const onTarget = await page.evaluate(
+      ([px, py, el]) => {
+        const hit = document.elementFromPoint(px as number, py as number);
+        return !!hit && (hit === el || (el as Element).contains(hit as Node) || (hit as Element).contains(el as Node));
+      },
+      [pageX, pageY, handle] as const
+    );
+    return { ok: onTarget, m, pointer, pageX, pageY };
+  }
+
+  /**
+   * Replay a human trajectory toward the target's live rect. Returns the rect
+   * (device px) the trajectory aimed at so the caller can re-verify.
+   */
+  private async replayTowards(page: Page, handle: ElementHandle<Element>): Promise<void> {
+    // Let layout settle before reading the rect: a rect read before the lobby
+    // finishes painting was a primary miss source (button shifts after read).
+    await page.waitForTimeout(120);
     const m = await this.metricsOf(page, handle);
     if (m.width <= 0 || m.height <= 0) throw new Error("humanized: element has zero size");
     const rect = this.rectDevicePx(m);
 
     const cur = await this.x11.getPointer();
     let seq = this.engine.findSequenceLandingInRect(cur.x, cur.y, rect);
-
     if (!seq) {
       this.mocapMisses++;
       this.log(`humanized: no direct sequence (miss #${this.mocapMisses}); trying stretch+rotate`);
@@ -155,34 +217,61 @@ export class HumanizedInteractor {
     }
     if (!seq) throw new Error("humanized: no mocap sequence lands on target element");
 
-    // Verify endpoint actually resolves to the element; if not, attempt a few
-    // other sequences before giving up (mirrors the documented retry).
-    for (let attempt = 0; attempt < 8; attempt++) {
-      const endScreenX = cur.x + seq.total_dx;
-      const endScreenY = cur.y + seq.total_dy;
-      const pageX = (endScreenX - this.offsetX) / this.dpr;
-      const pageY = (endScreenY - this.offsetY) / this.dpr;
-      const onTarget = await page.evaluate(
-        ([px, py, el]) => {
-          const hit = document.elementFromPoint(px as number, py as number);
-          return !!hit && (hit === el || (el as Element).contains(hit as Node));
-        },
-        [pageX, pageY, handle] as const
-      );
-      if (onTarget) break;
-      const next = this.engine.findSequenceLandingInRect(cur.x, cur.y, rect);
-      if (!next) break;
-      seq = next;
-    }
-
     this.log(`humanized: replay ${seq.movements.length} moves dx=${seq.total_dx} dy=${seq.total_dy}`);
     for (const mv of seq.movements) {
       if (mv.dt > 0) await sleep(mv.dt * 1000);
       if (mv.dx !== 0 || mv.dy !== 0) await this.x11.moveRel(mv.dx, mv.dy);
     }
-    if (seq.click_down_dt > 0) await sleep(seq.click_down_dt * 1000);
+  }
+
+  /** Move the pointer to the element along a human trajectory and click it. */
+  async navigateAndClick(page: Page, handle: ElementHandle<Element>): Promise<void> {
+    await this.calibrate(page);
+    await this.replayTowards(page, handle);
+
+    // ── Endpoint verification (PRIMARY fix) ──────────────────────────────
+    // Re-read the button rect and the REAL pointer immediately before the
+    // click; assert the pointer is inside the live button. On a miss, treat the
+    // pointer↔mouseevent geometry as stale: recalibrate, nudge the pointer to
+    // the live rect center via an absolute move, and re-verify. A click is only
+    // emitted once the pointer is confirmed inside the target — a miss is caught,
+    // not silently lost.
+    const MAX_CORRECTIONS = 4;
+    let hit = await this.pointerHitsTarget(page, handle);
+    for (let i = 0; !hit.ok && i < MAX_CORRECTIONS; i++) {
+      this.log(
+        `humanized: endpoint miss #${i + 1} — pointer page=(${hit.pageX.toFixed(0)},${hit.pageY.toFixed(0)}) ` +
+        `rect=[${hit.m.left.toFixed(0)},${hit.m.top.toFixed(0)} ${hit.m.width.toFixed(0)}x${hit.m.height.toFixed(0)}]; recalibrating`
+      );
+      await this.calibrate(page, /* force */ true);
+      // Aim at the live rect center, mapped through the fresh offset.
+      const cx = hit.m.left + hit.m.width / 2;
+      const cy = hit.m.top + hit.m.height / 2;
+      const target = this.pageToScreen(cx, cy);
+      await this.x11.moveAbs(Math.round(target.x), Math.round(target.y));
+      await sleep(60);
+      hit = await this.pointerHitsTarget(page, handle);
+    }
+
+    if (!hit.ok) {
+      const reason =
+        `humanized: click target verification FAILED after ${MAX_CORRECTIONS} corrections — ` +
+        `real pointer page=(${hit.pageX.toFixed(0)},${hit.pageY.toFixed(0)}) is not inside the join control ` +
+        `rect=[${hit.m.left.toFixed(0)},${hit.m.top.toFixed(0)} ${hit.m.width.toFixed(0)}x${hit.m.height.toFixed(0)}] ` +
+        `(offset=(${this.offsetX.toFixed(0)},${this.offsetY.toFixed(0)}) dpr=${this.dpr}). Refusing to click off-target.`;
+      this.log(reason);
+      if (this.onMissScreenshot) {
+        try { await this.onMissScreenshot(page, reason); } catch { /* screenshot best-effort */ }
+      }
+      throw new Error(reason);
+    }
+
+    this.log(`humanized: endpoint verified inside target page=(${hit.pageX.toFixed(0)},${hit.pageY.toFixed(0)}); clicking`);
+    const downDt = 0.06 + Math.random() * 0.05;
+    const upDt = 0.05 + Math.random() * 0.05;
+    await sleep(downDt * 1000);
     await this.x11.buttonDown(1);
-    if (seq.click_up_dt > 0) await sleep(seq.click_up_dt * 1000);
+    await sleep(upDt * 1000);
     await this.x11.buttonUp(1);
   }
 

--- a/services/vexa-bot/core/src/platforms/googlemeet/humanized/x11Input.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/humanized/x11Input.ts
@@ -24,6 +24,8 @@ export class X11Input {
   private dryRun: boolean;
   /** Recorded argv lines when dryRun is on. */
   readonly log: string[][] = [];
+  /** Simulated pointer position, maintained only in dryRun for faithful tests. */
+  private simPointer: PointerLocation = { x: 0, y: 0 };
 
   constructor(opts: X11InputOptions = {}) {
     this.display = opts.display ?? process.env.DISPLAY ?? ":99";
@@ -64,7 +66,7 @@ export class X11Input {
   }
 
   async getPointer(): Promise<PointerLocation> {
-    if (this.dryRun) return { x: 0, y: 0 };
+    if (this.dryRun) return { ...this.simPointer };
     const out = await this.run(["xdotool", "getmouselocation", "--shell"]);
     const x = Number(/X=(-?\d+)/.exec(out)?.[1] ?? 0);
     const y = Number(/Y=(-?\d+)/.exec(out)?.[1] ?? 0);
@@ -72,10 +74,12 @@ export class X11Input {
   }
 
   async moveAbs(x: number, y: number): Promise<void> {
+    if (this.dryRun) this.simPointer = { x, y };
     await this.run(["xdotool", "mousemove", "--sync", String(x), String(y)]);
   }
 
   async moveRel(dx: number, dy: number): Promise<void> {
+    if (this.dryRun) this.simPointer = { x: this.simPointer.x + dx, y: this.simPointer.y + dy };
     await this.run(["xdotool", "mousemove_relative", "--sync", "--", String(dx), String(dy)]);
   }
 

--- a/services/vexa-bot/core/src/platforms/googlemeet/join.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/join.ts
@@ -18,6 +18,51 @@ export function resolveUiInteractionMode(botConfig: BotConfig): "humanized" | "s
   return botConfig.platform === "google_meet" ? "humanized" : "synthetic";
 }
 
+/**
+ * Wait for the FIRST of an ordered selector list to appear (locale-agnostic
+ * selectors first, English text fallbacks last). Returns the matched handle and
+ * the selector that won. On total failure: screenshot + LOUD throw with the full
+ * list tried (no-fallbacks.md — a missing control fails with a logged reason +
+ * screenshot, never a silent skip).
+ */
+export async function waitForAnySelector(
+  page: Page,
+  selectors: string[],
+  timeoutMs: number,
+  label: string
+): Promise<{ handle: ElementHandle<Element>; selector: string }> {
+  // First selector to MATCH wins; a per-selector timeout/parse rejection must
+  // NOT abort the others (so the locale-agnostic + English fallbacks all get a
+  // fair chance). We resolve on first success and only fail once every selector
+  // has settled without a match.
+  const winner = await new Promise<{ handle: ElementHandle<Element>; selector: string } | null>((resolve) => {
+    let pending = selectors.length;
+    let settled = false;
+    if (pending === 0) { resolve(null); return; }
+    for (const sel of selectors) {
+      page
+        .waitForSelector(sel, { timeout: timeoutMs, state: "visible" })
+        .then((el) => {
+          if (!settled && el) { settled = true; resolve({ handle: el as ElementHandle<Element>, selector: sel }); }
+          else if (--pending === 0 && !settled) { settled = true; resolve(null); }
+        })
+        .catch(() => {
+          if (--pending === 0 && !settled) { settled = true; resolve(null); }
+        });
+    }
+  });
+
+  if (winner) {
+    log(`Located ${label} via selector: ${winner.selector}`);
+    return winner;
+  }
+
+  const shot = `/app/storage/screenshots/bot-checkpoint-${label.replace(/[^a-z0-9]+/gi, "-")}-not-found.png`;
+  try { await page.screenshot({ path: shot, fullPage: true }); } catch { /* best-effort */ }
+  log(`📸 Screenshot: ${label} not found by any of ${selectors.length} selectors (tried: ${selectors.join(" | ")})`);
+  throw new Error(`Could not locate ${label} by any locale-agnostic or English selector after ${timeoutMs}ms`);
+}
+
 export async function joinGoogleMeeting(
   page: Page,
   meetingUrl: string,
@@ -43,7 +88,13 @@ export async function joinGoogleMeeting(
   const uiMode = resolveUiInteractionMode(botConfig);
   let humanizer: HumanizedInteractor | null = null;
   if (uiMode === "humanized") {
-    humanizer = new HumanizedInteractor(MOCAP_LIBRARY, { log });
+    humanizer = new HumanizedInteractor(MOCAP_LIBRARY, {
+      log,
+      onMissScreenshot: async (p, reason) => {
+        await p.screenshot({ path: '/app/storage/screenshots/bot-checkpoint-humanized-click-miss.png', fullPage: true });
+        log(`📸 Screenshot: humanized click abandoned as off-target — ${reason}`);
+      },
+    });
     if (!(await humanizer.available())) {
       log("WARNING: humanized UI mode requested but xdotool/X display is unavailable — falling back to synthetic input. Install xdotool+xclip in the bot image.");
       humanizer = null;
@@ -166,8 +217,12 @@ export async function joinGoogleMeeting(
     // Anonymous flow: enter bot name and ask to join
     log("Attempting to find name input field...");
 
-    const nameFieldSelector = googleNameInputSelectors[0];
-    const nameHandle = await page.waitForSelector(nameFieldSelector, { timeout: 120000 });
+    const { handle: nameHandle, selector: nameFieldSelector } = await waitForAnySelector(
+      page,
+      googleNameInputSelectors,
+      120000,
+      "name input"
+    );
     log("Name input field found.");
 
     await page.screenshot({ path: '/app/storage/screenshots/bot-checkpoint-0-name-field-found.png', fullPage: true });
@@ -189,8 +244,12 @@ export async function joinGoogleMeeting(
       log("Camera already off or not found.");
     }
 
-    const joinSelector = googleJoinButtonSelectors[0];
-    const joinHandle = await page.waitForSelector(joinSelector, { timeout: 60000 });
+    const { handle: joinHandle } = await waitForAnySelector(
+      page,
+      googleJoinButtonSelectors,
+      60000,
+      "join button"
+    );
     await clickHandle(joinHandle!, "ask_to_join");
     log(`${botName} joined the Google Meet Meeting.`);
 

--- a/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
@@ -29,6 +29,22 @@ export const googleWaitingRoomIndicators: string[] = [
 ];
 
 export const googleRejectionIndicators: string[] = [
+  // Waiting-room denial patterns. Google Meet can leave some lobby text in
+  // the DOM after a host rejects the bot, so these must be checked before
+  // waiting-room indicators in admission polling.
+  'text*="denied your request"',
+  'text*="denied your request to join"',
+  'text*="Your request to join was denied"',
+  'text*="You were denied"',
+  'text*="weren\'t allowed to join"',
+  'text*="not allowed to join"',
+  'text*="not admitted"',
+  'text*="can\'t join this call"',
+  'text*="cannot join this call"',
+  'text*="Ask to join again"',
+  'button:has-text("Ask to join again")',
+  'button:has-text("Return to home screen")',
+
   // Meeting not found or access denied patterns
   'text="Meeting not found"',
   'text="Can\'t join the meeting"',
@@ -233,8 +249,22 @@ export const googleRemovalIndicators: string[] = [
   '.meeting-error'
 ];
 
-// Google Meet UI interaction selectors
+// Google Meet UI interaction selectors.
+//
+// Locale-agnostic FIRST (structure / jsname / role), then English text as a
+// fallback. The English-literal `text()="Ask to join"` / has-text locators only
+// match an English UI, so a Hungarian (or any non-English) Meet lobby never
+// found the join button — the bot sat in the lobby until manual_leave
+// (prod ids 13951 13952 14018 14153). The primary admission CTA in the Meet
+// lobby is the last/right-most jsname-tagged <button> in the lobby controls;
+// it carries a jsname and is the only enabled <button> with non-icon text.
 export const googleJoinButtonSelectors: string[] = [
+  // Locale-agnostic: a real <button> carrying Google's jsname token whose label
+  // text is non-empty (excludes icon-only mic/camera toggles which have no text
+  // node). Matches "Ask to join"/"Join now"/localized equivalents alike.
+  'button[jsname]:not([aria-label]):has(span)',
+  'div[jscontroller] button[jsname]:has(span)',
+  // English fallbacks (kept for resilience on English UIs).
   '//button[.//span[text()="Ask to join"]]',
   'button:has-text("Ask to join")',
   'button:has-text("Join now")',
@@ -253,7 +283,17 @@ export const googleMicrophoneButtonSelectors: string[] = [
   'button[aria-label*="Turn on microphone"]'
 ];
 
+// Name input — locale-agnostic FIRST. `aria-label="Your name"` is English-only,
+// so the non-English lobby (Hungarian: "A neved") never matched and the bot
+// could not fill its name. The lobby has exactly one editable text input, so
+// match by structure/role; keep the English aria-label + placeholder as
+// fallbacks.
 export const googleNameInputSelectors: string[] = [
+  // Locale-agnostic: the single text input in the pre-join lobby form.
+  'input[jsname][type="text"]',
+  'input[type="text"]:not([aria-hidden="true"])',
+  'div[jscontroller] input[type="text"]',
+  // English fallbacks.
   'input[type="text"][aria-label="Your name"]',
   'input[placeholder*="name"]',
   'input[placeholder*="Name"]'
@@ -332,5 +372,4 @@ export const googlePeopleButtonSelectors: string[] = [
   'button[data-tooltip*="participants"]',
   'button[data-tooltip*="Participants"]'
 ];
-
 


### PR DESCRIPTION
Pack #407 stream **407-A** — dominant post-hotfix failure (13/35). Cause: off-target humanized XTEST click (self-blind endpoint check + stale one-shot calibration) + English-only selectors. Fix: real-X11-pointer verification + recalibrate-or-fail-loud loop; locale-agnostic selectors. tsc clean on touched files; humanized.test 28/0 (incl. Hungarian mock DOM). proves[]: gmeet.humanized_join_click_hits, gmeet.localized_join_selectors. Draft — full 3-mode corpus at stitch; do not merge before eyeball + live-Meet test.