### PR TITLE
Harden Python service Docker builds

### DIFF
--- a/services/admin-api/Dockerfile
+++ b/services/admin-api/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel jaraco.context
+
 # Install schema-sync library
 COPY ./libs/schema-sync /app/libs/schema-sync
 RUN pip install --no-cache-dir /app/libs/schema-sync

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel jaraco.context
+
 # Install meeting-api (schemas, security headers)
 COPY ./services/meeting-api /app/services/meeting-api
 RUN pip install --no-cache-dir /app/services/meeting-api

--- a/services/meeting-api/Dockerfile
+++ b/services/meeting-api/Dockerfile
@@ -3,7 +3,14 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install system deps (gcc for building, ffmpeg for audio conversion in deferred transcription)
-RUN apt-get update && apt-get install -y --no-install-recommends gcc ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends gcc ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Keep Python build tooling current; scanners flag vulnerable transitive
+# versions bundled in the base image even when application deps are clean.
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel jaraco.context
 
 # Install schema-sync library
 COPY libs/schema-sync /schema-sync

--- a/services/runtime-api/Dockerfile
+++ b/services/runtime-api/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel jaraco.context
+
 # Copy source and install
 COPY pyproject.toml README.md ./
 COPY runtime_api/ runtime_api/


### PR DESCRIPTION
## Summary

Hardens the Python service Docker builds for:

- `services/admin-api`
- `services/api-gateway`
- `services/meeting-api`
- `services/runtime-api`

The change upgrades Debian packages during the image build and upgrades Python build tooling (`pip`, `setuptools`, `wheel`, `jaraco.context`) before installing application dependencies. This removes the currently fix-available Trivy HIGH/CRITICAL findings caused by stale base-image packages and bundled Python build tooling.

## Validation

Built local `linux/amd64` images from this branch and scanned them with Trivy 0.71.0 using the 2026-06-11 vulnerability DB.

Comparison against the published `0.10.6.3.14` images:

| Image | Upstream HIGH/CRITICAL | Upstream with fix available | Patched HIGH/CRITICAL | Patched with fix available |
|---|---:|---:|---:|---:|
| `meeting-api` | 63 | 37 | 26 | 0 |
| `admin-api` | 32 | 22 | 10 | 0 |
| `api-gateway` | 32 | 22 | 10 | 0 |
| `runtime-api` | 29 | 19 | 10 | 0 |

Commands used:

```bash
docker buildx build --platform linux/amd64 -t klai-vexa-meeting-api:security-test --load -f services/meeting-api/Dockerfile .
docker buildx build --platform linux/amd64 -t klai-vexa-admin-api:security-test --load -f services/admin-api/Dockerfile .
docker buildx build --platform linux/amd64 -t klai-vexa-api-gateway:security-test --load -f services/api-gateway/Dockerfile .
cd services/runtime-api && docker buildx build --platform linux/amd64 -t klai-vexa-runtime-api:security-test --load .
trivy image --image-src docker --scanners vuln --severity CRITICAL,HIGH <image>
```

The remaining findings in patched images are Debian advisories without a fixed package version reported by Trivy, so this PR targets the actionable/fix-available CVEs rather than suppressing them.
