### PR TITLE
feat(bot): make segment-latency knobs env-configurable for real-time use

### DIFF
--- a/services/runtime-api/profiles.yaml
+++ b/services/runtime-api/profiles.yaml
@@ -41,6 +41,10 @@ profiles:
       TRANSCRIPTION_SERVICE_TOKEN: "${TRANSCRIPTION_SERVICE_TOKEN}"
       TTS_SERVICE_URL: "${TTS_SERVICE_URL}"
       INTERNAL_API_SECRET: "${INTERNAL_API_SECRET}"
+      # Segment-latency knobs (optional) — lower for real-time/voice-agent use.
+      MIN_AUDIO_DURATION_SEC: "${MIN_AUDIO_DURATION_SEC:-3}"
+      SUBMIT_INTERVAL_SEC: "${SUBMIT_INTERVAL_SEC:-2}"
+      IDLE_TIMEOUT_SEC: "${IDLE_TIMEOUT_SEC:-15}"
     ports:
       "9222/tcp": {}         # CDP debug port
 

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -1303,11 +1303,11 @@ async function initPerSpeakerPipeline(botConfig: BotConfig): Promise<boolean> {
     const isGoogleMeet = botConfig.platform === 'google_meet';
     speakerManager = new SpeakerStreamManager({
       sampleRate: 16000,
-      minAudioDuration: 3,     // 3s of unconfirmed audio before submission
-      submitInterval: 2,       // submit every 2s — lower latency
+      minAudioDuration: process.env.MIN_AUDIO_DURATION_SEC ? parseFloat(process.env.MIN_AUDIO_DURATION_SEC) : 3,  // s of unconfirmed audio before submission
+      submitInterval: process.env.SUBMIT_INTERVAL_SEC ? parseFloat(process.env.SUBMIT_INTERVAL_SEC) : 2,          // submit every Ns
       confirmThreshold: 2,     // 2 consecutive matches — faster confirmation
       maxBufferDuration: 30,   // force-flush at 30s — matches Whisper training window
-      idleTimeoutSec: 15,      // 15s idle → emit + reset
+      idleTimeoutSec: process.env.IDLE_TIMEOUT_SEC ? parseFloat(process.env.IDLE_TIMEOUT_SEC) : 15,                // Ns idle → emit + reset
     });
     // VAD gating moved to handlePerSpeakerAudioData entry (per-speaker streaming).
     // SpeakerStreamManager no longer does VAD — it only receives real speech.


### PR DESCRIPTION
## Problem

`SpeakerStreamManager` (per-speaker transcription pipeline) hardcodes three timing constants in [`services/vexa-bot/core/src/index.ts`](https://github.com/Vexa-ai/vexa/blob/main/services/vexa-bot/core/src/index.ts):

```ts
minAudioDuration: 3,   // wait for 3s of unconfirmed audio before submitting
submitInterval:   2,   // poll every 2s
idleTimeoutSec:   15,  // force-flush 15s after the speaker goes silent
```

These defaults are tuned for **transcription quality** — longer unconfirmed buffers give the STT backend more context and higher accuracy. That's the right default for meeting recording/transcription.

But they make Vexa hard to use as a **real-time / voice-agent** substrate. A short utterance (e.g. *"Hi, can you help me?"*, ~2s) never reaches the 3s `minAudioDuration`, so it isn't submitted on the normal path — it falls through to the **15s idle timeout** before it's ever sent to the transcription service. The consumer sees the transcript ~15s after the speaker stops talking, which is far too slow for an agent that needs to respond mid-meeting.

## Solution

Make the three knobs **env-overridable while keeping the existing defaults**, so transcription-quality behavior is completely unchanged unless an operator opts in. This mirrors the env-override style already used a few lines above for `MAX_SPEECH_DURATION_SEC` and `MIN_SILENCE_DURATION_MS`:

| Env var | Default |
|---|---|
| `MIN_AUDIO_DURATION_SEC` | `3` |
| `SUBMIT_INTERVAL_SEC` | `2` |
| `IDLE_TIMEOUT_SEC` | `15` |

`profiles.yaml` plumbs them through to the `meeting` bot container (same defaults), so a deployment can opt into low-latency mode, e.g.:

```bash
MIN_AUDIO_DURATION_SEC=0.5
SUBMIT_INTERVAL_SEC=1
IDLE_TIMEOUT_SEC=1.5
```

which drops end-of-speech latency from ~15s to ~2s for short utterances.

## Changes

- `services/vexa-bot/core/src/index.ts` — read the three knobs from env, falling back to the current hardcoded defaults.
- `services/runtime-api/profiles.yaml` — pass the three env vars through to the `meeting` profile (defaults preserved via `${VAR:-default}`).

## Compatibility

No behavior change by default — all three vars fall back to today's values (`3` / `2` / `15`). Opt-in only.