### PR TITLE
feat(meeting-api): add endpoint to retrieve meeting participants

### DIFF
--- a/services/api-gateway/main.py
+++ b/services/api-gateway/main.py
@@ -28,6 +28,7 @@ from meeting_api.schemas import (
     ErrorResponse,
     Platform,
     BotStatusResponse,
+    ParticipantsResponse,
     SpeakRequest, ChatSendRequest, ChatMessagesResponse, ScreenContentRequest,
 )
 
@@ -496,6 +497,19 @@ async def get_bots_status_proxy(request: Request):
     url = f"{MEETING_API_URL}/bots/status"
     return await forward_request(app.state.http_client, "GET", url, request)
 # --- END Route for GET /bots/status ---
+
+# --- Route for GET /bots/{platform}/{native_meeting_id}/participants ---
+@app.get("/bots/{platform}/{native_meeting_id}/participants",
+         tags=["Bot Management"],
+         summary="Get participants detected in a meeting",
+         description="Retrieves the distinct participants (speakers) detected in a meeting, aggregated from its transcript segments.",
+         response_model=ParticipantsResponse,
+         dependencies=[Depends(api_key_scheme)])
+async def get_participants_proxy(platform: Platform, native_meeting_id: str, request: Request):
+    """Forward request to Bot Manager to get the meeting's participants."""
+    url = f"{MEETING_API_URL}/bots/{platform.value}/{native_meeting_id}/participants"
+    return await forward_request(app.state.http_client, "GET", url, request)
+# --- END Route for GET /bots/{platform}/{native_meeting_id}/participants ---
 
 @app.get("/bots/id/{meeting_id}",
          tags=["Bot Management"],

--- a/services/api-gateway/tests/test_routes.py
+++ b/services/api-gateway/tests/test_routes.py
@@ -33,6 +33,12 @@ class TestBotManagementRoutes:
     def test_get_bot_status_exists(self):
         assert ("GET", "/bots/status") in ROUTES
 
+    def test_get_participants_exists(self):
+        assert (
+            "GET",
+            "/bots/{platform}/{native_meeting_id}/participants",
+        ) in ROUTES
+
 
 class TestTranscriptionRoutes:
     def test_get_meetings_exists(self):

--- a/services/meeting-api/meeting_api/meetings.py
+++ b/services/meeting-api/meeting_api/meetings.py
@@ -33,6 +33,8 @@ from .schemas import (
     MeetingResponse,
     Platform,
     BotStatusResponse,
+    ParticipantInfo,
+    ParticipantsResponse,
     MeetingConfigUpdate,
     MeetingStatus,
     MeetingCompletionReason,
@@ -1496,6 +1498,70 @@ async def get_user_bots_status(
     except Exception as e:
         logger.error(f"Error fetching bot status for user {current_user.id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve bot status")
+
+
+@router.get(
+    "/bots/{platform}/{native_meeting_id}/participants",
+    response_model=ParticipantsResponse,
+    summary="Get the participants (speakers) detected in a meeting",
+    dependencies=[Depends(get_user_and_token)],
+)
+async def get_meeting_participants(
+    platform: Platform,
+    native_meeting_id: str,
+    auth_data: tuple = Depends(get_user_and_token),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the distinct participants detected in a meeting.
+
+    Participants are aggregated from the meeting's transcript segments (which
+    carry the speaker attribution produced by the bot's speaker tracking): for
+    each distinct speaker we report the segment count, first/last seen times,
+    and total speaking time. Scoped to the authenticated user; resolves the
+    most recent meeting for the given platform + native meeting id.
+    """
+    from .models import Transcription
+
+    _, current_user = auth_data
+    meeting = await _find_meeting_any_status(
+        db, current_user.id, platform.value, native_meeting_id
+    )
+
+    stmt = (
+        select(
+            Transcription.speaker,
+            func.count(Transcription.id),
+            func.min(Transcription.created_at),
+            func.max(Transcription.created_at),
+            func.coalesce(
+                func.sum(Transcription.end_time - Transcription.start_time), 0.0
+            ),
+        )
+        .where(Transcription.meeting_id == meeting.id)
+        .group_by(Transcription.speaker)
+    )
+    rows = (await db.execute(stmt)).all()
+
+    participants = [
+        ParticipantInfo(
+            name=speaker if speaker else "Unknown",
+            segment_count=count,
+            first_seen=first_seen,
+            last_seen=last_seen,
+            speaking_time_seconds=round(float(duration or 0.0), 3),
+        )
+        for speaker, count, first_seen, last_seen, duration in rows
+    ]
+    # Most active speakers first, then by name for stable ordering.
+    participants.sort(key=lambda p: (-p.segment_count, p.name))
+
+    return ParticipantsResponse(
+        id=meeting.id,
+        platform=meeting.platform,
+        native_meeting_id=meeting.platform_specific_id,
+        participant_count=len(participants),
+        participants=participants,
+    )
 
 
 @router.put(

--- a/services/meeting-api/meeting_api/schemas.py
+++ b/services/meeting-api/meeting_api/schemas.py
@@ -1085,7 +1085,30 @@ class TranscriptionResponse(BaseModel): # Doesn't inherit MeetingResponse to avo
         from_attributes = True # Allows creation from ORM models (e.g., joined query result)
         use_enum_values = True
 
-# --- Utility Schemas --- 
+# --- Participant Schemas ---
+class ParticipantInfo(BaseModel):
+    """A single participant (speaker) detected in a meeting."""
+    name: str = Field(..., description="Participant/speaker name as detected in the meeting.")
+    segment_count: int = Field(..., description="Number of transcript segments attributed to this participant.")
+    first_seen: Optional[datetime] = Field(None, description="UTC time of this participant's first transcript segment.")
+    last_seen: Optional[datetime] = Field(None, description="UTC time of this participant's most recent transcript segment.")
+    speaking_time_seconds: float = Field(0.0, description="Total speaking time in seconds (sum of segment durations).")
+
+    class Config:
+        from_attributes = True
+
+class ParticipantsResponse(BaseModel):
+    """Response for getting a meeting's participants."""
+    id: int = Field(..., description="Internal database ID for the meeting.")
+    platform: str = Field(..., description="Meeting platform.")
+    native_meeting_id: Optional[str] = Field(None, description="Native (platform-specific) meeting ID.")
+    participant_count: int = Field(..., description="Number of distinct participants detected.")
+    participants: List[ParticipantInfo] = Field(default_factory=list, description="Participants detected in the meeting.")
+
+    class Config:
+        from_attributes = True
+
+# --- Utility Schemas ---
 
 class HealthResponse(BaseModel):
     status: str

--- a/services/meeting-api/tests/test_meetings.py
+++ b/services/meeting-api/tests/test_meetings.py
@@ -354,3 +354,65 @@ class TestUpdateBotConfig:
             json={"language": "es"},
         )
         assert resp.status_code == 403
+
+
+class TestGetParticipants:
+    @pytest.mark.asyncio
+    async def test_get_participants_success(self, client, mock_db):
+        """GET participants → 200 with speakers aggregated from transcript segments."""
+        meeting = make_meeting(id=42)
+        rows = [
+            ("Alice", 3, datetime(2024, 1, 1, 12, 0, 0), datetime(2024, 1, 1, 12, 5, 0), 42.5),
+            ("Bob", 1, datetime(2024, 1, 1, 12, 1, 0), datetime(2024, 1, 1, 12, 1, 30), 8.0),
+        ]
+        # First execute() resolves the meeting; second returns aggregated rows.
+        mock_db.execute = AsyncMock(side_effect=[MockResult([meeting]), MockResult(rows)])
+
+        resp = await client.get(
+            f"/bots/{TEST_PLATFORM}/{TEST_NATIVE_MEETING_ID}/participants"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == 42
+        assert data["participant_count"] == 2
+        # Most active speaker first.
+        assert data["participants"][0]["name"] == "Alice"
+        assert data["participants"][0]["segment_count"] == 3
+        assert data["participants"][0]["speaking_time_seconds"] == 42.5
+        assert {p["name"] for p in data["participants"]} == {"Alice", "Bob"}
+
+    @pytest.mark.asyncio
+    async def test_get_participants_unknown_speaker(self, client, mock_db):
+        """Segments with a null speaker are reported under 'Unknown'."""
+        meeting = make_meeting(id=7)
+        rows = [(None, 2, datetime(2024, 1, 1, 12, 0, 0), datetime(2024, 1, 1, 12, 2, 0), 5.0)]
+        mock_db.execute = AsyncMock(side_effect=[MockResult([meeting]), MockResult(rows)])
+
+        resp = await client.get(
+            f"/bots/{TEST_PLATFORM}/{TEST_NATIVE_MEETING_ID}/participants"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["participant_count"] == 1
+        assert data["participants"][0]["name"] == "Unknown"
+
+    @pytest.mark.asyncio
+    async def test_get_participants_meeting_not_found(self, client, mock_db):
+        """GET participants for a non-existent meeting → 404."""
+        mock_db.execute = AsyncMock(return_value=MockResult([]))
+
+        resp = await client.get(
+            f"/bots/{TEST_PLATFORM}/{TEST_NATIVE_MEETING_ID}/participants"
+        )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_participants_auth_required(self, unauthed_client):
+        """GET participants without auth → 403."""
+        resp = await unauthed_client.get(
+            f"/bots/{TEST_PLATFORM}/{TEST_NATIVE_MEETING_ID}/participants"
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
Addresses #451.

## What
Adds a REST endpoint to retrieve the **participants (speakers) detected in a meeting** — the primary ask in #451 (track attendance / know who was present).

`GET /bots/{platform}/{native_meeting_id}/participants` →

```json
{
  "id": 42,
  "platform": "google_meet",
  "native_meeting_id": "abc-defg-hij",
  "participant_count": 2,
  "participants": [
    { "name": "Alice", "segment_count": 3, "first_seen": "...", "last_seen": "...", "speaking_time_seconds": 42.5 },
    { "name": "Bob",   "segment_count": 1, "first_seen": "...", "last_seen": "...", "speaking_time_seconds": 8.0 }
  ]
}
```

Participants are aggregated from the meeting's **transcript segments** (which already carry the bot's speaker attribution), so this exposes data that is *already tracked* — no new ingestion path. Per participant: segment count, first/last seen, and total speaking time. Sorted most-active first.

## Changes
- **`meeting-api`** — `ParticipantInfo` / `ParticipantsResponse` schemas; `get_meeting_participants` endpoint in `meetings.py`, reusing the existing `_find_meeting_any_status` resolver and scoping to the authenticated user (404 if the meeting isn't theirs).
- **`api-gateway`** — proxy route forwarding to meeting-api under the existing `/bots` scope (mirrors `get_bots_status_proxy`).
- **Tests** — meeting-api endpoint tests (success, null-speaker → "Unknown", 404, auth-required) + the gateway route-registration test.

## Verification
- `meeting-api`: `pytest tests/test_meetings.py::TestGetParticipants` → **4 passed** (mocked DB, no live Postgres).
- `api-gateway`: `pytest tests/test_routes.py::TestBotManagementRoutes` → **5 passed** (incl. the new participants route).

## Scope note (WebSocket events — follow-up)
The issue also asks for WS events when a participant joins/leaves. I deliberately scoped that **out** of this PR: the bot currently emits `SPEAKER_START`/`SPEAKER_END` (speaking state), not explicit join/leave, so faithful join/leave eventing needs bot-side changes across the Google Meet / Teams / Zoom adapters plus a new Redis pub/sub channel (`participant:meeting:{id}:events`) wired into the gateway's `/ws` fan-in. That's a larger, browser-automation-dependent change that can't be verified without a live meeting, so it's better as a separate PR. Happy to follow up if the maintainers want it.