### PR TITLE
fix(gmeet): treat Gemini "take notes" consent prompt as a pre-admission gate

### DIFF
--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
@@ -113,5 +113,44 @@ expectFileContains(
   'hasExplicitDenyText',
 );
 
+console.log('\n=== Google Meet Gemini consent-gate handling (#429) ===');
+
+expectFileContains(
+  'selectors define a consent-prompt indicator list',
+  SELECTORS_TS,
+  'googleConsentPromptIndicators',
+);
+
+expectFileContains(
+  'consent selectors target the take-notes prompt copy',
+  SELECTORS_TS,
+  'take notes for me',
+);
+
+expectFileContains(
+  'admission.ts has a consent-prompt detector',
+  ADMISSION_TS,
+  'export async function hasConsentPrompt',
+);
+
+expectOrder(
+  'admission suppresses ACTIVE when a consent prompt is present',
+  admissionBody,
+  'const consentPending = await hasConsentPrompt(page)',
+  'return false',
+);
+
+expectFileContains(
+  'consent gate escalates to needs_human_help (consent_required)',
+  ADMISSION_TS,
+  'triggerEscalation(botConfig, "consent_required")',
+);
+
+expectFileContains(
+  'consent is escalated, not auto-clicked (human decision)',
+  ADMISSION_TS,
+  'not auto-consenting',
+);
+
 console.log(`\n=== googlemeet admission summary: ${passed} passed, ${failed} failed ===`);
 process.exit(failed > 0 ? 1 : 0);

--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.ts
@@ -5,7 +5,8 @@ import { checkEscalation, triggerEscalation, getEscalationExtensionMs } from "..
 import {
   googleInitialAdmissionIndicators,
   googleWaitingRoomIndicators,
-  googleRejectionIndicators
+  googleRejectionIndicators,
+  googleConsentPromptIndicators
 } from "./selectors";
 
 /**
@@ -169,6 +170,16 @@ export async function checkForGoogleAdmissionIndicators(page: Page): Promise<boo
     return false;
   }
 
+  // 1b. NEGATIVE GUARD: a Gemini "take notes" consent prompt is a pre-admission
+  // consent gate. Meeting controls can be visible behind it, but the bot is not
+  // truly participating until a human accepts/declines — reporting admitted here
+  // yields "status active, 0 transcriptions" (issue #429). Suppress admission.
+  const consentPending = await hasConsentPrompt(page);
+  if (consentPending) {
+    log(`⚠️ Gemini consent prompt visible — suppressing admission (consent pending; bot not truly in the call)`);
+    return false;
+  }
+
   // Wake the UI before probing. Google Meet auto-hides the in-call toolbar
   // (mic/camera/present/leave) after a few seconds of no pointer activity — and the
   // bot never moves a real mouse. Once admitted (especially when a participant is
@@ -241,6 +252,25 @@ export async function checkForWaitingRoomIndicators(page: Page): Promise<boolean
   return false;
 }
 
+// Detect Google's Gemini "take notes for me" in-call consent prompt — a consent
+// gate where the bot isn't truly participating until a human accepts/declines
+// (issue #429). Mirrors checkForWaitingRoomIndicators: a pre-admission state that
+// suppresses the "admitted" signal. Consent must be a human decision, so callers
+// escalate to needs_human_help rather than auto-clicking it.
+export async function hasConsentPrompt(page: Page): Promise<boolean> {
+  for (const selector of googleConsentPromptIndicators) {
+    try {
+      const element = await page.locator(selector).first();
+      if (await element.isVisible()) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
 async function throwIfGoogleAdmissionRejected(page: Page, context: string): Promise<void> {
   const isRejected = await checkForGoogleRejection(page);
   if (isRejected) {
@@ -287,7 +317,17 @@ export async function waitForGoogleMeetingAdmission(
       log("Successfully admitted to the Google Meet meeting - no waiting room required");
       return true;
     }
-    
+
+    // Consent gate: if Google's Gemini "take notes" consent prompt is present,
+    // the bot is held behind a human decision (accept/decline) — not admitted.
+    // Do NOT auto-click it; consent is the user's choice (issue #429). Summon a
+    // human via needs_human_help and keep polling, so admission proceeds once
+    // consent is granted (mirrors the reCAPTCHA "stay for human solve" handling).
+    if (await hasConsentPrompt(page)) {
+      log("🧑‍⚖️ Gemini consent prompt detected — bot is behind a consent gate (not admitted). Escalating to needs_human_help; not auto-consenting.");
+      await triggerEscalation(botConfig, "consent_required");
+    }
+
     log("Bot not yet admitted - checking for Google Meet waiting room indicators...");
     
     // Check for waiting room indicators using visibility checks

--- a/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
@@ -28,6 +28,27 @@ export const googleWaitingRoomIndicators: string[] = [
   '[aria-label*="waiting for admission"]',
 ];
 
+// Google's Gemini "take notes for me" in-call consent prompt. This is a consent
+// gate, not mere chrome: until a human accepts or declines, the bot is not truly
+// participating, yet the surrounding meeting controls can read as "admitted"
+// (issue #429: status active, 0 transcriptions). Detected so the bot routes to
+// needs_human_help instead of false-reporting ACTIVE.
+//
+// Targeted at the prompt's distinctive copy ("take notes for me" / "taking
+// notes") so it does NOT match the always-present Gemini toolbar button.
+//
+// NOTE: these selectors are best-effort and SHOULD be confirmed against the live
+// prompt DOM — reproduce per #429 (packages/meet-join standalone runner) and
+// adjust if Google changes the copy.
+export const googleConsentPromptIndicators: string[] = [
+  'text*="take notes for me"',
+  'text*="Take notes for me"',
+  'text*="taking notes"',
+  '[role="dialog"]:has-text("take notes for me")',
+  '[role="alertdialog"]:has-text("take notes for me")',
+  'button:has-text("take notes for me")',
+];
+
 export const googleRejectionIndicators: string[] = [
   // Waiting-room denial patterns. Google Meet can leave some lobby text in
   // the DOM after a host rejects the bot, so these must be checked before


### PR DESCRIPTION
Closes #429.

## Problem
Per the issue's **corrected** problem statement: Google's Gemini "take notes for me" prompt is a **consent gate**, not cosmetic chrome. The bot false-detects "admitted" (it sees meeting-like controls) and reports **ACTIVE** while still behind the consent prompt → *status active, 0 transcriptions* (prod meeting 14560).

## Fix
Detect "consent pending" as a distinct **pre-admission** state and route to `needs_human_help` instead of ACTIVE — **without auto-consenting** (consent is a human decision; the issue explicitly says do not auto-click it).

- **`selectors.ts`** — `googleConsentPromptIndicators`, targeted at the prompt's copy (`take notes for me`) so it does **not** match the always-present Gemini toolbar button.
- **`admission.ts`** — `hasConsentPrompt()` detector + a **negative guard** in `checkForGoogleAdmissionIndicators` (mirrors the existing waiting-room guard) so a pending consent prompt suppresses the "admitted" signal. When detected, escalate to `needs_human_help` (`consent_required`) and keep polling so admission proceeds once a human grants consent — mirroring the existing reCAPTCHA "stay for human solve" handling.
- **`admission.test.ts`** — extends the existing source-shape suite to pin the consent-gate wiring.

This is the same false-positive class as the admission settle-fix, specialized to consent-pending — and it reuses the existing escalation + reCAPTCHA patterns rather than introducing new machinery.

## Verification
`npx tsx src/platforms/googlemeet/admission.test.ts` → **11 passed, 0 failed** (5 existing + 6 new), following the repo's source-shape test convention for admission ("a full Playwright DOM test would require brittle UI fixtures").

## Caveats (please confirm on your repro)
- **Selectors need live-DOM confirmation.** I can't reproduce the Gemini banner here, so the `googleConsentPromptIndicators` are best-effort, based on the prompt copy + the reCAPTCHA precedent. Please verify against the live prompt via the #439 standalone runner (`npx tsx standalone-join.ts <meet-url>`) and tweak the copy/selectors if Google's wording differs. They're deliberately specific (the prompt's "take notes for me" text) to avoid matching the Gemini toolbar button, which would otherwise break *all* joins.
- I couldn't run the full `tsc` build locally (heavy native deps — `onnxruntime-node`, playwright browsers). The changes are type-trivial mirrors of existing typed functions in this file.