### PR TITLE
fix(vexa-bot): make googlemeet synthetic tests ESM-safe (__dirname)

### DIFF
--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
@@ -9,6 +9,13 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+
+// __dirname is undefined when this file runs in ESM scope (Node 24 + tsx treats
+// the TS source as ESM despite "type": "commonjs"). Resolve the module directory
+// in an ESM-safe way so the test works on a contributor laptop, not only inside
+// the Docker toolchain (issue #440).
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 let passed = 0;
 let failed = 0;
@@ -50,8 +57,8 @@ function expectOrder(
   failed++;
 }
 
-const ADMISSION_TS = path.join(__dirname, 'admission.ts');
-const SELECTORS_TS = path.join(__dirname, 'selectors.ts');
+const ADMISSION_TS = path.join(moduleDir, 'admission.ts');
+const SELECTORS_TS = path.join(moduleDir, 'selectors.ts');
 const admissionBody = fs.readFileSync(ADMISSION_TS, 'utf-8');
 
 console.log('\n=== Google Meet admission rejection handling ===');

--- a/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanized.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanized.test.ts
@@ -11,11 +11,17 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "node:url";
 import { MocapEngine, type Rect } from "./mocapEngine";
 import { X11Input } from "./x11Input";
 import { HumanizedInteractor } from "./humanizedInteraction";
 import { MOCAP_LIBRARY } from "./mocap-data";
 import { googleJoinButtonSelectors, googleNameInputSelectors } from "../selectors";
+
+// __dirname is undefined when this file runs in ESM scope (Node 24 + tsx treats
+// the TS source as ESM despite "type": "commonjs"). Resolve the module directory
+// in an ESM-safe way so the test works on a contributor laptop (issue #440).
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 let passed = 0;
 let failed = 0;
@@ -142,7 +148,7 @@ console.log("\nTest 4: X11Input command emission (dryRun)");
   console.log("\nTest 7: locale-agnostic join/name selectors (hu UI)");
   {
     const selectorsSrc = fs.readFileSync(
-      path.join(__dirname, "..", "selectors.ts"),
+      path.join(moduleDir, "..", "selectors.ts"),
       "utf-8"
     );
     // (a) join button: a locale-agnostic structural selector precedes the
@@ -201,7 +207,7 @@ console.log("\nTest 4: X11Input command emission (dryRun)");
   // ── 8. join.ts fails LOUD (screenshot) when no selector matches ─
   console.log("\nTest 8: join.ts fails loud when controls are missing");
   {
-    const joinSrc = fs.readFileSync(path.join(__dirname, "..", "join.ts"), "utf-8");
+    const joinSrc = fs.readFileSync(path.join(moduleDir, "..", "join.ts"), "utf-8");
     assert(/waitForAnySelector/.test(joinSrc), "join.ts uses an ordered multi-selector resolver");
     const fn = joinSrc.slice(joinSrc.indexOf("export async function waitForAnySelector"));
     assert(/screenshot/.test(fn) && /throw new Error/.test(fn), "selector resolver screenshots + throws on total miss (no silent skip)");


### PR DESCRIPTION
Closes #440.

## Problem
`googlemeet/admission.test.ts` and `googlemeet/humanized/humanized.test.ts` resolve their own directory with `__dirname`, which is **undefined** when the files run via `npx tsx` on Node 24 — the TS source is treated as ESM scope despite `"type": "commonjs"`:

```
ReferenceError: __dirname is not defined in ES module scope
```

These are exactly the rung-1 synthetic tests a zero-infra contributor runs first (per pack #439); today they only work inside the Docker toolchain.

## Fix
Resolve the module directory with `path.dirname(fileURLToPath(import.meta.url))` (the issue's recommended fix) in both files — ~2 lines each. Works in both ESM and tsx-run contexts.

## Verification
Run on **Node v24.14.0**:

```
$ npx tsx src/platforms/googlemeet/admission.test.ts
=== googlemeet admission summary: 5 passed, 0 failed ===

$ npx tsx src/platforms/googlemeet/humanized/humanized.test.ts
28 passed, 0 failed
```

Both suites now pass on a contributor laptop.