### PR TITLE
chore(tests3): re-sync registry.yaml with its generator + add parity gate

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -27,3 +27,16 @@ jobs:
           if [ "$found" -eq 0 ]; then
             echo "gate:isolation — no bricks with check-isolation yet (pre-MVP1); gate is armed and green."
           fi
+
+  gate-registry-parity:
+    name: "gate:registry-parity"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install deps
+        run: pip install "pyyaml>=6,<7"
+      - name: Check tests3/registry.yaml is in sync with its generator
+        run: python3 tests3/lib/migrate-registry.py --check

--- a/tests3/lib/migrate-registry.py
+++ b/tests3/lib/migrate-registry.py
@@ -25,6 +25,12 @@ Type mappings:
   health  → http           (url + expect_code)  OR  script (url is a special method name)
   contract→ http  OR script (same disambiguation)
   (entries in test-registry.yaml) → script (script: path)
+
+Usage:
+  python3 tests3/lib/migrate-registry.py            # regenerate tests3/registry.yaml
+  python3 tests3/lib/migrate-registry.py --check    # verify registry.yaml is in sync
+                                                     # with its sources (CI parity gate;
+                                                     # exits 1 on drift, writes nothing)
 """
 from __future__ import annotations
 
@@ -163,6 +169,7 @@ def migrate_test(name: str, spec: dict) -> dict:
 
 
 def main() -> int:
+    check_only = "--check" in sys.argv[1:]
     checks_path = T3 / "checks" / "registry.json"
     tests_path = T3 / "test-registry.yaml"
     out_path = T3 / "registry.yaml"
@@ -201,7 +208,21 @@ def main() -> int:
         "# by tests3/lib/migrate-registry.py. See tests3/README.md §3.3.\n\n"
     )
     body = yaml.safe_dump(ordered, default_flow_style=False, sort_keys=False, width=120)
-    out_path.write_text(header + body)
+    content = header + body
+
+    if check_only:
+        current = out_path.read_text() if out_path.exists() else ""
+        if current != content:
+            print(
+                f"ERROR: {out_path.relative_to(ROOT)} is out of sync with its generator.\n"
+                "  Run `python3 tests3/lib/migrate-registry.py` and commit the result.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"  {out_path.relative_to(ROOT)} is in sync with its sources")
+        return 0
+
+    out_path.write_text(content)
 
     # Stats
     by_type = {}

--- a/tests3/registry.yaml
+++ b/tests3/registry.yaml
@@ -1,570 +1,9 @@
-ADMIN_API_DB_EXISTS:
-  proves: "The `vexa` database exists and is reachable from admin-api \u2014 /login won't 500 on fresh boot"
-  symptom: "/login returns 500 'Server Configuration Error'; admin-api crashes with asyncpg.InvalidCatalogNameError: database\
-    \ \\\"vexa\\\" does not exist (DB got dropped after initial bootstrap \u2014 e.g. Linode low-disk auto-recovery wiped\
-    \ it)"
-  found: '2026-04-17'
-  type: script
-  dispatch: ADMIN_API_DB_EXISTS_CHECK
-  from_tier: health
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-ADMIN_API_UP:
-  proves: "admin-api responds with valid token \u2014 user management and login work"
-  symptom: Admin API not responding
-  type: http
-  url: $ADMIN_URL/admin/users?limit=1
-  expect_code: 200
-  needs_admin_token: true
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-AUTH_REJECTS_NO_TOKEN:
-  proves: "API rejects unauthenticated requests \u2014 auth middleware is active"
-  symptom: API accepts requests without auth token
-  type: http
-  url: $GATEWAY_URL/meetings
-  method: GET
-  expect_code:
-  - 401
-  - 403
-  - 422
-  auth: ''
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-BOTS_STATUS_NOT_422:
-  proves: "GET /bots/status returns 200 \u2014 no route collision with /bots/{meeting_id}"
-  symptom: GET /bots/status returns 422 due to route collision with /bots/{meeting_id}
-  found: '2026-04-06'
-  type: http
-  url: $GATEWAY_URL/bots/status
-  method: GET
-  expect_code: 200
-  auth: api_token
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-BOT_CREATE_OK:
-  proves: "POST /bots creates a bot without server error \u2014 runtime-api orchestrator is functional"
-  symptom: "Bot creation returns 500 \u2014 runtime-api cannot spawn bot containers (wrong orchestrator, missing image, or\
-    \ broken config)"
-  type: http
-  url: $GATEWAY_URL/bots
-  method: POST
-  expect_code:
-  - 200
-  - 201
-  - 202
-  - 403
-  - 409
-  auth: api_token
-  data: '{"platform":"google_meet","native_meeting_id":"healthcheck-bot","bot_name":"Health Check","automatic_leave":{"no_one_joined_timeout":30000}}'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-BOT_ENTRYPOINT_DISPLAY_EXPORTED:
-  proves: "entrypoint.sh exports DISPLAY before starting node — bot finds Xvfb (:99) on the humanized XTEST path (#407 407-C)"
-  symptom: "bot crashes at startup with DISPLAY not set; Xvfb (:99) is running but node process cannot find it because DISPLAY was never exported"
-  found: '2026-06-06'
-  type: grep
-  file: services/vexa-bot/core/entrypoint.sh
-  must_match: export DISPLAY
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_ENTRYPOINT_EXIT_CODE_LOGGED:
-  proves: "entrypoint.sh captures node exit code and echoes it — a zero-log instant crash is visible in container stdout (#407 407-C)"
-  symptom: "bot container exits silently; no exit code in stdout; operator cannot determine whether node crashed or was OOM-killed"
-  found: '2026-06-06'
-  type: grep
-  file: services/vexa-bot/core/entrypoint.sh
-  must_match: EXIT_CODE=\$\?
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_STARTUP_BREADCRUMB_IN_DOCKER_TS:
-  proves: "docker.ts emits a structured startup breadcrumb JSON on the very first line of main() — pre-config crashes are never zero-log (#407 407-C)"
-  symptom: "bot container crashes before config parsing; container stdout is empty; no structured log line to signal the process even started"
-  found: '2026-06-06'
-  type: grep
-  file: services/vexa-bot/core/src/docker.ts
-  must_match: startupBreadcrumb
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_STARTUP_FAILURE_REPORTER_HAS_SECRET:
-  proves: "reportStartupFailure in docker.ts includes X-Internal-Secret header so the failure callback reaches meeting-api on authenticated stacks (#407 407-C)"
-  symptom: "reportStartupFailure sends the failure payload but meeting-api returns 403 (missing X-Internal-Secret); failure reason is lost silently"
-  found: '2026-06-06'
-  type: grep
-  file: services/vexa-bot/core/src/docker.ts
-  must_match: X-Internal-Secret
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_FAILURE_STAGE_TRACKER_UPDATES_ON_TRANSITIONS:
-  proves: "bot's in-process failure_stage tracker advances on each successful status_change callback for joining/awaiting_admission/active — crashes past joining no longer get persisted as failure_stage='joining' (v0.10.6 #294)"
-  symptom: "every meeting that fails post-admission shows failure_stage='joining' in JSONB; #276's server-side derivation hides the user-visible impact but raw data->>'failure_stage' is still wrong; analytics + 3rd-party consumers see the wrong value"
-  found: '2026-05-01'
-  type: grep
-  file: services/vexa-bot/core/src/services/unified-callback.ts
-  must_match: advanceLifecycleStage\s*\(\s*status\s*\)
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-GMEET_JOIN_CALLBACK_RESILIENT:
-  proves: "callJoiningCallback proceeds on transient blips (5xx/timeout → err.transient=true) and aborts on deliberate server rejections (4xx → err.transient=false) — control-plane restart during bot join no longer kills an otherwise-fine session (#3)"
-  symptom: "bot join aborted on meeting-api 5xx during rollout; 4xx (bad-request / invalid transition) correctly aborted but was indistinguishable from transient at the call site"
-  found: '2026-06-06'
-  type: script
-  script: tests/gmeet-join-callback-resilient.sh
-  step: join_callback_resilient
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 15
-BOT_GMEET_RECORDING_ENABLED_SURVIVES_TRACK_EVENT:
-  proves: "bot dispatched against a GMeet meeting with recording_enabled=true survives the first video track event AND remains in 'active' for ≥120s — confirms screen-content.ts:1218-1228 SDP-munge site-2 is removed (v0.10.6 #291/#284)"
-  symptom: "bot reaches active, runs 1-4 minutes, then crashes with 'page.evaluate Execution context destroyed' at recording.js:102 — site-2 transceiver.direction mutation produces malformed offer SDP, Chrome rejects setLocalDescription, peer enters degraded state, page navigates"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.6-bot-stability.sh
-  step: gmeet_recording_survival
-  modes:
-  - compose
-  - lite
-  - helm
-  state: stateful
-  max_duration_sec: 180
-BOT_DELETE_DURABLE_RETRY:
-  proves: "meeting-api DELETE container-stop survives meeting-api restart and runtime-api transient 5xx \u2014 stop intent\
-    \ persists in Redis Stream, sweep consumer retries with exponential backoff, DLQ surfaces persistent failures (Pack D.2 / #266)"
-  symptom: "Bot pod runs forever after meeting marked COMPLETED \u2014 production scale test caught 3-of-20 DELETEs returning\
-    \ 500 with pods recording for 12+ minutes; meeting-api restart in BOT_STOP_DELAY_SECONDS window dropped pending stops on\
-    \ the floor"
-  found: '2026-04-27'
-  type: script
-  script: tests/bot-delete-durable-retry.sh
-  modes:
-  - compose
-  state: stateful
-  mutates:
-  - meeting(fixture)
-  - meeting-api:redis:meeting-api:container-stops/*
-  - meeting-api:redis:meeting-api:container-stop-dlq
-  max_duration_sec: 300
-BOT_LOGS_STRUCTURED_JSON:
-  proves: "vexa-bot core ships a structured-JSON logger module at services/vexa-bot/core/src/utils/log.ts AND the legacy\
-    \ log() shim in utils.ts routes through it \u2014 every bot stdout line is a single-line JSON object so K8s `kubectl logs`\
-    \ capture (Pack G.2) is parseable without ad-hoc text munging (Pack G.1 / #272 issue 6)"
-  symptom: "Bot pod dies with [Graceful Leave] free-text logs that no operator tool can parse \u2014 every recording-loss bug\
-    \ becomes a 'we don't know why' post-mortem because the captured stdout is unstructured prefix-tagged text"
-  found: '2026-04-27'
-  type: grep
-  file: services/vexa-bot/core/src/utils.ts
-  must_match: from\s+["']\./utils/log["']
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-BOT_NO_TRANSCEIVER_DIRECTION_MUTATION:
-  proves: "no `transceiver.direction = ` or `t.direction = ` assignment exists anywhere in services/vexa-bot — defends against re-introduction of the SDP-munge bug class (v0.10.6 #291)"
-  symptom: "any future PR that re-introduces transceiver.direction mutation will revive #284 / #291 / #281 cross-platform crash class — bot survival chain depends on this NEVER coming back"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.6-bot-stability.sh
-  step: no_transceiver_direction_mutation
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_RECORDING_ENABLED:
-  proves: "bots are created with recordingEnabled=true \u2014 audio will be captured and uploaded"
-  symptom: "No audio recording for meeting \u2014 RECORDING_ENABLED env var not set or recordingEnabled=false in BOT_CONFIG"
-  type: script
-  dispatch: BOT_RECORDING_CHECK
-  from_tier: contract
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-BOT_RECORDS_INCREMENTALLY:
-  proves: "every bot recording.ts wires MediaRecorder.start() with a \u226515_000 ms timeslice AND calls __vexaSaveRecordingChunk\
-    \ in ondataavailable"
-  symptom: "bot reverts to buffering full WebM until shutdown \u2192 long-meeting recording loss on SIGKILL"
-  found: '2026-04-21'
-  type: script
-  script: tests/bot-records-incrementally.sh
-  modes:
-  - lite
-  - compose
-  state: stateless
-  max_duration_sec: 10
-BOT_SDP_MUNGE_SITE2_REMOVED:
-  proves: "site-2 of the SDP-munge `for (const t of transceivers)` block is removed from services/vexa-bot/core/src/services/screen-content.ts — closes the v0.10.5 incomplete revert that left this site active in production (v0.10.6 #291)"
-  symptom: "v0.10.5 reverted SDP-munge at screen-content.ts site-1 (~line 1339) but missed identical site-2 (~lines 1218-1228); customer GMeet meetings with recording_enabled=true crashed mid-meeting at recording.js:102 with 'Execution context destroyed' — verified live on 2026-05-01 meeting 11356"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.6-bot-stability.sh
-  step: sdp_munge_site2_removed
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_TEAMS_ADMISSION_NOT_44MS_DROP:
-  proves: "bot dispatched at a Teams meeting (consumer or corporate URL) survives ≥60s post-admission — confirms screen-content.ts site-2 fix closes the 44ms drop in #281"
-  symptom: "Teams enterprise meetings drop in 44-51ms after admission (#281) — first video track event fires synchronously at admission, site-2 mutates transceiver.direction, peer-connection InvalidAccessError, bot exits in 44ms; 2+ Vexa Cloud customers reproducing pre-v0.10.6"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.6-bot-stability.sh
-  step: teams_admission_survival
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 120
-BOT_STATUS_TRANSITIONS:
-  proves: "bot status transitions from requested within 30s \u2014 callbacks from bot\u2192meeting-api work"
-  symptom: "Bot stuck in 'requested' \u2014 status change callbacks not reaching meeting-api (wrong image, missing callback\
-    \ URL, network issue)"
-  type: script
-  dispatch: BOT_STATUS_CHECK
-  from_tier: contract
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-BOT_ZOOM_WEB_SURVIVES_TRACK_EVENT:
-  proves: "bot dispatched at a Zoom Web meeting survives the first video track event AND remains in 'active' for ≥60s — confirms cross-platform fix coverage (v0.10.6 #291)"
-  symptom: "Zoom Web hits the same SDP-munge site-2 via services/vexa-bot/core/src/platforms/zoom/web/prepare.ts:198-199 → getVideoBlockInitScript → live RTCPeerConnection wrapper — pre-v0.10.6 every Zoom Web bot would degrade peer connection on first video track"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.6-bot-stability.sh
-  step: zoom_web_survival
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 120
-BROWSER_IMAGE_IN_ENV:
-  proves: "BROWSER_IMAGE is set explicitly in env-example \u2014 not derived from IMAGE_TAG substitution"
-  symptom: "BROWSER_IMAGE not in .env \u2014 docker-compose.yml variable substitution fails silently, bots get wrong image"
-  found: '2026-04-13'
-  type: grep
-  file: deploy/env-example
-  must_match: BROWSER_IMAGE=
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BROWSER_SESSION_CDP:
-  proves: "browser session CDP proxy is reachable \u2014 gateway can connect to browser container"
-  symptom: "Failed to reach browser container: Name or service not known \u2014 pod IP not resolved in K8s"
-  type: script
-  dispatch: BROWSER_SESSION_CDP_CHECK
-  from_tier: contract
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-BROWSER_SESSION_OK:
-  proves: "POST /bots with mode=browser_session returns 201 \u2014 browser-session profile exists and works"
-  symptom: "Failed to start browser session container \u2014 browser-session profile missing from runtime-api"
-  type: http
-  url: $GATEWAY_URL/bots
-  method: POST
-  expect_code:
-  - 200
-  - 201
-  - 202
-  - 403
-  auth: api_token
-  data: '{"mode":"browser_session","bot_name":"Session Check"}'
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-DASHBOARD_BROWSER_VIEW_RUNTIME_GATEWAY:
-  proves: "dashboard browser view creates/opens a live browser_session meeting using the browser-facing gateway URL from /api/config, not internal DNS or localhost"
-  symptom: "Browser view iframe points at dashboard same-origin /b, api-gateway, svc.cluster.local, or localhost; human sees refused connection or DNS failure"
-  found: '2026-05-21'
-  type: script
-  script: tests/dashboard-browser-view.sh
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 90
-DASHBOARD_BROWSER_VIEW_CSP_ALLOWS_SAME_HOST:
-  proves: "gateway VNC responses allow iframe embedding from the same public dashboard host on a different port while preserving cross-host denial"
-  symptom: "Browser iframe request is blocked by Content-Security-Policy frame-ancestors; Playwright reports net::ERR_BLOCKED_BY_RESPONSE"
-  found: '2026-05-21'
-  type: script
-  script: tests/dashboard-browser-view.sh
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 90
-DASHBOARD_BROWSER_VIEW_IFRAME_LOADS:
-  proves: "Playwright can load /meetings/{id}, click Browser, observe a gateway /b/{token}/vnc iframe HTTP 200, and see no CSP/request failures"
-  symptom: "Meeting detail browser tab renders blank, refused connection, DNS error, or blocked iframe despite /api/config looking correct"
-  found: '2026-05-21'
-  type: script
-  script: tests/dashboard-browser-view.sh
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 90
-LITE_RECORDING_STORAGE_PERSISTENT:
-  proves: "Lite docker run mounts persistent storage at /var/lib/vexa/recordings so redeploy/restart does not erase local recording artifacts"
-  symptom: "Completed Lite meetings show 'Recording is processing...' forever after container replacement because meeting.data points at local files that were lost with the old container"
-  found: '2026-05-21'
-  type: script
-  script: tests/static/lite-recording-storage-persistent.sh
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-LITE_RECORDING_STORAGE_DIR_SSOT:
-  proves: "Lite runtime LOCAL_STORAGE_DIR matches the persistent recording mount path"
-  symptom: "Lite mounts one path but recording storage writes to another, so files still disappear or playback cannot find them"
-  found: '2026-05-21'
-  type: script
-  script: tests/static/lite-recording-storage-persistent.sh
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-CACHE_HEADERS:
-  proves: "dashboard HTML has cache control \u2014 deploy won't serve stale JS bundles"
-  symptom: "Old JS bundle served after deploy \u2014 HTML page cached by browser"
-  found: '2026-04-07'
-  type: http
-  url: $DASHBOARD_URL/
-  method: HEAD
-  expect_code: 200
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-CDP_NO_SLASH_REDIRECT:
-  proves: "Bare /b/{token}/cdp (no trailing slash) is a first-class route \u2014 no 307 downgrade"
-  symptom: "GET /b/<tok>/cdp 307-redirects to /b/<tok>/cdp/ and downgrades https\u2192http behind TLS terminators"
-  found: '2026-04-19'
-  type: grep
-  file: services/api-gateway/main.py
-  must_match: browser_cdp_http_bare
-  modes:
-  - lite
-  - compose
-  state: stateless
-  max_duration_sec: 5
-CDP_WS_SCHEME_PRESERVED:
-  proves: "CDP proxy webSocketDebuggerUrl rewrite preserves inbound scheme (wss:// on HTTPS gateways) \u2014 Playwright connectOverCDP\
-    \ works through TLS"
-  symptom: Hard-coded plaintext WebSocket scheme in proxy URL breaks every external CDP client on HTTPS deployments
-  found: '2026-04-19'
-  type: grep
-  file: services/api-gateway/main.py
-  must_match: x-forwarded-proto|request\.url\.scheme
-  modes:
-  - lite
-  - compose
-  state: stateless
-  max_duration_sec: 5
-BOT_MEETING_CDP_ARGS:
-  proves: "meeting + browser bots share CDP_DEBUG_ARGS (remote-debugging-port=9222) so an agent can attach over /b/{meeting_id}/cdp"
-  symptom: "meeting bots launch with no CDP port; /b/{id}/cdp has nothing to proxy; agent/human cannot attach to a stuck bot"
-  found: '2026-06-07'
-  type: grep
-  file: services/vexa-bot/core/src/constans.ts
-  must_match: CDP_DEBUG_ARGS
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_CDP_RELAY_SHARED:
-  proves: "entrypoint starts the socat CDP relay (127.0.0.1:9222 -> 0.0.0.0:9223) via the shared helper, so the gateway can reach CDP across the docker network in BOTH meeting + browser_session modes"
-  symptom: "Chrome binds CDP to 127.0.0.1 only; gateway /b/{id}/cdp gets connection-refused; meeting-bot CDP attach impossible"
-  found: '2026-06-07'
-  type: grep
-  file: services/vexa-bot/core/entrypoint.sh
-  must_match: start_cdp_relay
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_CAPTCHA_NOT_REJECTION:
-  proves: "a reCAPTCHA challenge is NOT classified as an admin rejection (hasRecaptchaChallenge guard) — the bot stays on the page and escalates instead of self-quitting"
-  symptom: "captcha-blocked bot reads the 'Return to home screen' affordance as a host denial and quits in ~2s, losing the meeting before a human/agent can solve the captcha"
-  found: '2026-06-07'
-  type: grep
-  file: services/vexa-bot/core/src/platforms/googlemeet/admission.ts
-  must_match: hasRecaptchaChallenge
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_GRACEFUL_LEAVE_BOOLEAN:
-  proves: "leaveGoogleMeet returns a strict boolean (Boolean(result)) per its Promise<boolean> contract, not undefined on a black/captcha page"
-  symptom: "page.evaluate returns undefined on a black/captcha page and propagates as 'result: undefined' to callers that treat leave as a tri-state"
-  found: '2026-06-07'
-  type: grep
-  file: services/vexa-bot/core/src/platforms/googlemeet/leave.ts
-  must_match: return Boolean\(result\)
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-CDP_ATTACH_REQUIRES_OWNER_TOKEN:
-  proves: "the /b/{token}/cdp proxy gates on _authorize_browser_token — a valid X-API-Key for the OWNING user, not the guessable meeting_id alone"
-  symptom: "anyone who guesses the integer meeting_id can connectOverCDP to a live bot's browser (read the meeting, drive the page) with no API key — full account-crossing browser takeover"
-  found: '2026-06-07'
-  type: grep
-  file: services/api-gateway/main.py
-  must_match: _authorize_browser_token
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-VNC_REJECTS_GUESSABLE_TOKEN:
-  proves: "the browser-opened /b/{token} routes (vnc / dashboard / save / storage) reject the numeric meeting_id and require the unguessable capability token"
-  symptom: "anyone who guesses the integer meeting_id can open /b/{id}/vnc and watch or drive the bot's live browser with no auth"
-  found: '2026-06-07'
-  type: grep
-  file: services/api-gateway/main.py
-  must_match: requires the unguessable session token
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-ESCALATION_USES_SECRET_TOKEN:
-  proves: "needs_human_help escalation issues an unguessable session_token (secrets.token_urlsafe) for the VNC capability URL, never the guessable meeting_id"
-  symptom: "escalation set session_token=str(meeting.id) → /b/{meeting_id}/vnc world-reachable by guessing the integer"
-  found: '2026-06-07'
-  type: grep
-  file: services/meeting-api/meeting_api/callbacks.py
-  must_match: token_urlsafe
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-CHART_PUBLISH_WORKFLOW_EXISTS:
-  proves: .github/workflows/chart-release.yml exists, references helm/chart-releaser-action, parses as valid YAML
-  symptom: No gh-pages Helm repo; consumers must clone + helm package locally (#228)
-  found: '2026-04-22'
-  type: script
-  dispatch: SHELL_CHECK
-  script: tests3/checks/scripts/chart-publish-workflow-exists.sh
-  from_tier: static
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-CHART_VERSION_CURRENT:
-  proves: deploy/helm/charts/vexa/Chart.yaml version is SemVer >= latest v* git tag
-  symptom: Chart.yaml pinned at 0.1.0 for ~100 commits; consumers cannot detect drift (#228)
-  found: '2026-04-22'
-  type: script
-  dispatch: SHELL_CHECK
-  script: tests3/checks/scripts/chart-version-current.sh
-  from_tier: static
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-COMPOSE_ADMIN_KEY_DEFAULT:
-  proves: dashboard and admin-api share same ADMIN_API_TOKEN default in compose
-  symptom: "Dashboard login 503 \u2014 VEXA_ADMIN_API_KEY had different default than admin-api"
-  found: '2026-04-07'
-  type: grep
-  file: deploy/compose/docker-compose.yml
-  must_match: VEXA_ADMIN_API_KEY=${ADMIN_API_TOKEN:-changeme}
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-CORS_PREFLIGHT:
-  proves: "OPTIONS preflight returns 200 for any origin \u2014 CORS_ORIGINS defaults to wildcard"
-  symptom: "OPTIONS /bots/status returns 400 for external origins \u2014 browser clients blocked by CORS"
-  found: '2026-04-13'
-  type: script
-  dispatch: CORS_PREFLIGHT
-  from_tier: contract
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
+# tests3 Registry — consolidated.
+# Single source of truth for all automated evidence.
+# Schema: each entry has `type:` (grep | http | env | script).
+# Generated from tests3/checks/registry.json + tests3/test-registry.yaml
+# by tests3/lib/migrate-registry.py. See tests3/README.md §3.3.
+
 DASHBOARD_ADMIN_KEY_MATCHES:
   proves: "dashboard VEXA_ADMIN_API_KEY equals admin-api ADMIN_API_TOKEN \u2014 login will work"
   symptom: "Dashboard login fails silently \u2014 VEXA_ADMIN_API_KEY in dashboard differs from admin-api ADMIN_API_TOKEN"
@@ -632,148 +71,260 @@ DASHBOARD_API_URL_SET:
   - helm
   state: stateless
   max_duration_sec: 10
-DASHBOARD_LOGIN:
-  proves: "magic link login endpoint returns 200 \u2014 admin key is correctly configured"
-  symptom: "Dashboard magic link login returns 503 \u2014 admin key misconfigured"
+MINIO_BUCKET_SET:
+  proves: "MinIO bucket configured \u2014 file operations have a destination"
+  symptom: "Browser session save fails \u2014 MINIO_BUCKET not configured in meeting-api"
+  type: env
+  env_checks:
+  - service: meeting-api
+    var: MINIO_BUCKET
+    not_empty: true
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 10
+MINIO_ENDPOINT_SET:
+  proves: "meeting-api can reach MinIO \u2014 browser state save/restore and recordings will work"
+  symptom: "Authenticated bot join has no S3 config \u2014 MINIO_ENDPOINT not set in meeting-api"
   found: '2026-04-07'
-  type: http
-  url: $DASHBOARD_URL/api/auth/send-magic-link
-  method: POST
-  expect_code: 200
-  data: '{"email":"test@vexa.ai"}'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-DASHBOARD_MEETINGS_NOT_ALL_FAILED:
-  proves: "Either /meetings is empty (clean reset) OR at least one non-failed meeting exists \u2014 the UI won't surface a\
-    \ 'everything broken' picture to a human validator"
-  symptom: /meetings page shows 20+ rows and every single one is status=failed (test-pollution from prior runs accumulating;
-    or systemic failure). Either way, a human looking at the dashboard gets a misleading signal.
-  found: '2026-04-17'
-  type: script
-  dispatch: DASHBOARD_MEETINGS_NOT_ALL_FAILED_CHECK
-  from_tier: contract
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-DASHBOARD_UP:
-  proves: "dashboard serves pages \u2014 user can access the UI"
-  symptom: Dashboard not responding
-  type: http
-  url: $DASHBOARD_URL/
-  expect_code: 200
+  type: env
+  env_checks:
+  - service: meeting-api
+    var: MINIO_ENDPOINT
+    not_empty: true
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 30
-DASHBOARD_WEBHOOKS_ALL_EVENT_TYPES:
-  proves: "The /webhooks dashboard page surfaces status-change/started/bot.failed deliveries, not just meeting.completed \u2014\
-    \ UI reads meeting.data.webhook_deliveries[] (plural), not only webhook_delivery (singular)"
-  symptom: User sees only `meeting.completed` rows on /webhooks even when backend delivered other event types (regression
-    of dashboard /api/webhooks/deliveries rollup)
-  found: '2026-04-17'
-  type: script
-  dispatch: DASHBOARD_WEBHOOKS_ALL_EVENT_TYPES_CHECK
-  from_tier: contract
-  modes:
-  - lite
-  - compose
-  state: stateful
-  max_duration_sec: 30
-DASHBOARD_WS_URL:
-  proves: "dashboard /api/config returns a browser-resolvable wsUrl \u2014 WebSocket will connect"
-  symptom: "Dashboard WS broken \u2014 wsUrl contains internal Docker hostname (api-gateway, etc.) instead of localhost or\
-    \ public host"
-  found: '2026-04-08'
-  type: script
-  dispatch: DASHBOARD_WS_URL
-  from_tier: health
+  max_duration_sec: 10
+RUNTIME_API_URL_SET:
+  proves: "meeting-api can reach runtime-api \u2014 bot container creation will work"
+  symptom: "Bot creation fails \u2014 meeting-api cannot reach runtime-api"
+  type: env
+  env_checks:
+  - service: meeting-api
+    var: RUNTIME_API_URL
+    not_empty: true
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 30
-DB_POOL_NO_EXHAUSTION:
-  proves: meeting-api DB connection pool does not exhaust under sequential requests
-  symptom: "meeting-api returns 504 after a few requests \u2014 DB connection pool exhausted (idle in transaction leak)"
-  type: script
-  dispatch: DB_POOL_CHECK
-  from_tier: contract
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-DB_SCHEMA_ALIGNED:
-  proves: "database schema has all required columns \u2014 schema sync ran successfully"
-  symptom: "Services crash or return 500 \u2014 missing columns, tables, or indexes after DB migration"
-  type: script
-  dispatch: DB_SCHEMA_CHECK
-  from_tier: health
+  max_duration_sec: 10
+AGGREGATION_FAILURE_CLASS_VIA_TYPED_HELPER:
+  proves: "post_meeting.py exports `set_aggregation_failure_class(meeting, cls)` \u2014 single-write-path discipline for `data['aggregation_failure_class']`;\
+    \ class taxonomy is `AggregationFailureClass` enum/constants (Pack H)."
+  symptom: Multiple call sites poke `data['aggregation_failure_class']` directly with magic strings; classifier drift; sweeps
+    query a key that doesn't always exist (#H1).
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/post_meeting.py
+  must_match: def set_aggregation_failure_class(meeting
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 30
-DB_TOKENS_HAVE_SCOPES:
-  proves: "API tokens have scopes assigned \u2014 backfill migration ran"
-  symptom: "Tokens have empty scopes \u2014 scope enforcement will reject all requests"
-  type: script
-  dispatch: DB_TOKEN_SCOPES_CHECK
-  from_tier: health
+  max_duration_sec: 5
+BOTS_LIST_ENDPOINT_SLIM:
+  proves: "meetings.py list endpoint projects `data` through `_data_summary(d)` by default; full data only on explicit `include\
+    \ == \"data\"` (include_full_data branch) \u2014 payload size bounded for bulk listings (Pack L)."
+  symptom: "Every /meetings list response carries full meetings.data JSONB blob (potentially MB per row \xD7 N rows); dashboard\
+    \ list page payloads grow unbounded; gateway timeouts at scale (#272#... user concern)."
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/meetings.py
+  must_match: if include_full_data else _data_summary
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 30
-DB_USERS_EXIST:
-  proves: "users table has data \u2014 not an empty database"
-  symptom: "No users in database \u2014 dump not loaded or load failed silently"
-  type: script
-  dispatch: DB_USERS_CHECK
-  from_tier: health
+  max_duration_sec: 5
+BOT_DELETE_DURABLE_RETRY:
+  proves: "meeting-api carries a Redis Stream outbox for container-stop intents (`container_stop_outbox.py` with `enqueue_stop`\
+    \ producer + `consume_pending_stops` consumer); DELETE is durable across runtime-api outages (Pack D.2 \u2014 mirrors\
+    \ 260421 Pack J shape)."
+  symptom: DELETE container is fire-and-forget HTTP to runtime-api; if runtime-api is unreachable the stop is silently dropped;
+    bot pod runs forever (#266).
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/container_stop_outbox.py
+  must_match: async def consume_pending_stops
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 30
-DOCS_ENV_GATED_EVERYWHERE:
-  proves: "every FastAPI app reads VEXA_ENV and passes docs_url/redoc_url/openapi_url derived from it \u2014 /docs default-deny\
-    \ in production"
-  symptom: /docs exposed on a production deployment; internal admin endpoints listed to any client
+  max_duration_sec: 5
+BOT_LOGS_STRUCTURED_JSON:
+  proves: "vexa-bot core exposes `setLogContext({...})` + `logJSON({...})` \u2014 every bot log line is structured JSON with\
+    \ auto-injected meeting_id/session_uid/platform/container_name (Pack G.1)."
+  symptom: Bot logs are free-form strings; runtime-api log capture cannot index by meeting_id; debugging a single bot in a
+    busy cluster requires grepping unstructured stdout (#272#6).
+  found: '2026-04-27'
+  type: grep
+  file: services/vexa-bot/core/src/utils/log.ts
+  must_match: export function logJSON
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+BOT_VIDEO_DEFAULT_OFF:
+  proves: "POST /bots `video` field defaults to False \u2014 video recording is opt-in; audio-only is the default for transcription-focused\
+    \ deployments"
+  symptom: Every default-posted bot gets video capture via Xvfb screen-grab, creating unwanted recordings of the bot's browser
+    view + inflated storage + confused dashboards showing video UI for unwanted recordings
+  found: '2026-04-21'
+  type: grep
+  file: services/meeting-api/meeting_api/schemas.py
+  must_not_match: 'video: Optional\[bool\] = Field\(\s*True'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+BROWSER_IMAGE_IN_ENV:
+  proves: "BROWSER_IMAGE is set explicitly in env-example \u2014 not derived from IMAGE_TAG substitution"
+  symptom: "BROWSER_IMAGE not in .env \u2014 docker-compose.yml variable substitution fails silently, bots get wrong image"
+  found: '2026-04-13'
+  type: grep
+  file: deploy/env-example
+  must_match: BROWSER_IMAGE=
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+CDP_NO_SLASH_REDIRECT:
+  proves: "Bare /b/{token}/cdp (no trailing slash) is a first-class route \u2014 no 307 scheme downgrade"
+  symptom: GET /b/<tok>/cdp 307-redirects to /b/<tok>/cdp/ and downgrades https->http behind TLS terminators
   found: '2026-04-19'
-  type: script
-  script: tests/security-hygiene.sh
-  step: docs_gate
+  type: grep
+  file: services/api-gateway/main.py
+  must_match: browser_cdp_http_bare
   modes:
   - lite
   - compose
+  - helm
   state: stateless
-  max_duration_sec: 20
+  max_duration_sec: 5
+CDP_WS_SCHEME_PRESERVED:
+  proves: "CDP proxy webSocketDebuggerUrl rewrite preserves inbound scheme (wss:// on HTTPS gateways) \u2014 Playwright connectOverCDP\
+    \ works through TLS"
+  symptom: Hard-coded ws:// in proxy URL breaks every external CDP client on HTTPS deployments
+  found: '2026-04-19'
+  type: grep
+  file: services/api-gateway/main.py
+  must_match: x-forwarded-proto
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+CLASSIFIER_RECORDING_AWARE_NO_AUDIO:
+  proves: "services/meeting-api/meeting_api/callbacks.py _classify_stopped_exit checks meeting.data.recordings[*].media_files[*].file_size_bytes\
+    \ > 0 BEFORE classifying as STOPPED_WITH_NO_AUDIO. Pre-fix: any meeting with transcribe_enabled and 0 transcripts was\
+    \ failed/stopped_with_no_audio \u2014 including meetings where recording_enabled produced a multi-MB durable audio file.\
+    \ Customer impact: dashboard showed 'failed' for meetings where the WAV/webm was successfully captured and on disk, then\
+    \ hid the recording because of the failed status. Post-fix: recording-aware delivery check \u2014 if recording is delivered\
+    \ (any media_files entry has file_size_bytes > 0), classify as COMPLETED even when transcripts=0 (silent/quiet meeting\
+    \ is success-with-no-speech, not failure-with-no-audio)."
+  symptom: Customer dashboards show meetings as 'failed' when they actually completed and produced a downloadable recording.
+    Recording hidden from UI even though file is in MinIO. Specifically affects meetings where audio was captured but no one
+    spoke (silent rooms, brief check-ins, recording sessions where the speaker started after meeting bot was admitted).
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/callbacks.py
+  must_match: DELIVERY-AWARE classification
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+COMPOSE_ADMIN_KEY_DEFAULT:
+  proves: dashboard and admin-api share same ADMIN_API_TOKEN default in compose
+  symptom: "Dashboard login 503 \u2014 VEXA_ADMIN_API_KEY had different default than admin-api"
+  found: '2026-04-07'
+  type: grep
+  file: deploy/compose/docker-compose.yml
+  must_match: VEXA_ADMIN_API_KEY=${ADMIN_API_TOKEN:-changeme}
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+COMPOSE_PORTS_LOOPBACK_ONLY:
+  proves: "compose dev-mode ports (Postgres 5458, MinIO 9000/9001, admin-api 8057, runtime-api 8090, MCP 18888) publish to\
+    \ 127.0.0.1 only \u2014 only api-gateway + dashboard reach the public interface"
+  symptom: "same exposure class as lite \u2014 dev-mode ports on a public-IP VM get scanned + attacked"
+  found: '2026-04-21'
+  type: grep
+  file: deploy/compose/docker-compose.yml
+  must_not_match: '- "\$\{(POSTGRES_HOST_PORT|MINIO_HOST_PORT|MINIO_CONSOLE_HOST_PORT|ADMIN_API_PORT|RUNTIME_API_PORT|MCP_HOST_PORT)'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+CONTAINERS_TEST_ACCEPTS_CLEAN_STOP_FAILED:
+  proves: "tests3/tests/containers.sh status_completed step accepts `failed` as terminal-clean WHEN paired with a clean-stop\
+    \ completion_reason (stopped / stopped_with_no_audio / stopped_before_admission). R5 fix \u2014 the recording-aware classifier\
+    \ (FM-002 v2 / commit 9b16eba) correctly marks zero-audio user-stopped meetings as failed; the lifecycle test guards 'not\
+    \ stuck in stopping forever', not 'must have audio'. Without this multi-state acceptance, the helm gate fails forever\
+    \ on synthetic test bots that never deliver audio (the recording path may not work in helm test cluster). Lock prevents\
+    \ a future test refactor from re-tightening to completed-only and breaking the helm gate again."
+  symptom: Helm release-validate matrix red on `bot-lifecycle/status-completed` with status=failed reason=stopped_with_no_audio;
+    gate fails at 88% < 90% threshold. Test contract claims meeting must be `completed` after stop; classifier correctly says
+    `failed` because no audio was delivered; impasse. Same issue could fire on lite/compose if their fixtures stop delivering
+    test audio.
+  found: '2026-04-30'
+  type: grep
+  file: tests3/tests/containers.sh
+  must_match: v0.10.5 R5
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+DELAYED_STOP_FINALIZER_REMOVED:
+  proves: "meetings.py contains documentation marker explaining the removal of `_delayed_stop_finalizer` (redundant after\
+    \ 260421 Pack J durable exit-callback) \u2014 replaced by idle_loop sweep (Pack E.3.1)."
+  symptom: Both _delayed_stop_finalizer AND the new sweep run; double-finalize race; meeting flips status twice in <1s; webhooks
+    fire duplicate events (#268 [PLATFORM] comment).
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/meetings.py
+  must_match: "v0.10.5 Pack E.3.1 \u2014 REMOVED"
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
 ENGINE_POOL_RESET_ON_RETURN_ROLLBACK:
-  proves: "meeting-api SQLAlchemy engine sets pool_reset_on_return='rollback' \u2014 the engine-level defense against idle-in-transaction\
-    \ leaks"
+  proves: "meeting-api SQLAlchemy engine keeps pool_reset_on_return=\"rollback\" \u2014 guards idle-in-transaction leak defense"
   symptom: engine config refactored without pool_reset_on_return; AsyncSession leaks re-emerge silently
   found: '2026-04-21'
   type: grep
   file: services/meeting-api/meeting_api/database.py
-  must_match: pool_reset_on_return\s*=\s*["']rollback["']
+  must_match: pool_reset_on_return="rollback"
   modes:
   - lite
   - compose
+  - helm
   state: stateless
   max_duration_sec: 5
 ENV_EXAMPLE_LATEST_ON_MAIN:
@@ -785,6 +336,26 @@ ENV_EXAMPLE_LATEST_ON_MAIN:
   must_match: IMAGE_TAG=latest
   only_branches:
   - main
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+FIND_MEDIA_ELEMENTS_TWO_PASS_FILTER:
+  proves: "services/vexa-bot/core/src/services/audio.ts findMediaElements() implements a two-pass filter: pass 1 strict (srcObject\
+    \ MediaStream + audio tracks), pass 2 relaxed (accepts captureStream() / mozCaptureStream() fallback). Mirrors the downstream\
+    \ createCombinedAudioStream's already-present fallback chain so this finder doesn't artificially filter out elements the\
+    \ consumer can use. Pre-fix, the strict-only filter returned 0 elements on Google Meet pages where video tiles are paused\
+    \ or use captureStream \u2014 recording.ts went into degradedNoMedia mode and MediaRecorder was never created, leaving\
+    \ meeting.data.recordings = []. Post-fix, every chunk-emitting GMeet meeting produces >=1 chunk durably stored."
+  symptom: 'Empty recordings on Google Meet despite recording_enabled=true and active meeting. meeting.data.recordings = []
+    for every affected meeting; chunks never produced. Customer impact: recording feature looks completely broken on GMeet
+    platform.'
+  found: '2026-04-30'
+  type: grep
+  file: services/vexa-bot/core/src/services/audio.ts
+  must_match: "Pass 2 \u2014 relaxed"
   modes:
   - lite
   - compose
@@ -804,50 +375,91 @@ GATEWAY_TIMEOUT_ADEQUATE:
   - helm
   state: stateless
   max_duration_sec: 5
-GATEWAY_UP:
-  proves: "API gateway accepts connections \u2014 all client requests can reach backend"
-  symptom: API gateway not responding
-  type: http
-  url: $GATEWAY_URL/
-  expect_code: 200
+GMEET_BOT_ANTI_AUTOMATION_FLAG:
+  proves: "baseBrowserArgs in constans.ts contains --disable-blink-features=AutomationControlled \u2014 suppresses Chrome's\
+    \ navigator.webdriver=true automation flag which Google uses as a bot signal"
+  symptom: Chrome launched with navigator.webdriver=true (automation flag exposed); Google Meet fingerprints the bot session
+    as automated and blocks admission on datacenter IPs
+  found: '2026-06-06'
+  type: grep
+  file: services/vexa-bot/core/src/constans.ts
+  must_match: disable-blink-features=AutomationControlled
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 30
-GMEET_BOT_STARTUP_LOGGED:
-  proves: "vexa-bot emits a structured startup breadcrumb before config parsing and reports the failure reason to meeting-api on invalid-config crash \u2014 zero-log silent startup crashes are eliminated (#407 407-C)"
-  symptom: "bot container crashes on startup with an invalid BOT_CONFIG; meetings.data.bot_logs is empty; operator cannot diagnose the failure cause (3 such crashes seen post-hotfix)"
+  max_duration_sec: 5
+GMEET_BOT_NO_CERT_ERROR_FLAGS:
+  proves: "baseBrowserArgs in constans.ts does NOT contain --ignore-certificate-errors as a string literal \u2014 the flag\
+    \ is detectable by Google and triggers the 'You can't join this meeting' interstitial on k8s/datacenter egress IPs (Pack\
+    \ F diagnosis)"
+  symptom: "Bot launched from k8s (Linode LKE datacenter IP) hits Google's 'You can't join this meeting' interstitial instead\
+    \ of the lobby \u2014 Chrome fingerprint flags --ignore-certificate-errors / --disable-web-security are detected by Google\
+    \ bot-detection"
   found: '2026-06-06'
-  type: script
-  script: tests/bot-startup-crash.sh
-  step: GMEET_BOT_STARTUP_LOGGED
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 90
-GMEET_URL_PARSED:
-  proves: "Google Meet URL accepted by POST /bots \u2014 parser handles GMeet format"
-  symptom: Google Meet URL not accepted by POST /bots
-  type: http
-  url: $GATEWAY_URL/bots
-  method: POST
-  expect_code:
-  - 200
-  - 201
-  - 202
-  - 403
-  - 409
-  - 500
-  auth: api_token
-  data: '{"platform":"google_meet","meeting_url":"https://meet.google.com/abc-defg-hij","bot_name":"url-check-gm"}'
+  type: grep
+  file: services/vexa-bot/core/src/constans.ts
+  must_not_match: '"--ignore-certificate-errors"'
   modes:
   - lite
   - compose
   - helm
-  state: stateful
-  max_duration_sec: 30
+  state: stateless
+  max_duration_sec: 5
+GMEET_FALSE_LEFT_ALONE_AUDIO_CROSS_VALIDATE:
+  proves: "services/vexa-bot/core/src/platforms/googlemeet/recording.ts implements Layer 2 of the false-LEFT_ALONE_TIMEOUT\
+    \ fix: tracks __vexaLastAudioActivityTs from the audio data processor and refuses to increment alone-time when audio activity\
+    \ has occurred in the last 120s. Pre-fix (#285), the participant counter relied solely on the [data-participant-id] DOM\
+    \ selector; any GMeet UI change that renamed/relocated this attribute returned 0 unique IDs even when multiple speakers\
+    \ were active, firing LEFT_ALONE_TIMEOUT on healthy meetings within 60s after admission. Layer 2 cross-validate provides\
+    \ an independent ground truth \u2014 audio is actively flowing means the meeting has speakers, regardless of what the\
+    \ DOM count says."
+  symptom: 'FM-285 regression: bot exits healthy GMeet meetings prematurely with GOOGLE_MEET_BOT_LEFT_ALONE_TIMEOUT while
+    audio is being captured and transcripts are being produced. Customer impact: lost mid-meeting recording on every affected
+    session; recording cuts off mid-stream while the meeting continues with active speakers.'
+  found: '2026-04-30'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/googlemeet/recording.ts
+  must_match: __vexaLastAudioActivityTs
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+GMEET_K8S_EGRESS_PROXY_KNOB:
+  proves: "runtimeProfiles in values.yaml exposes HTTP_PROXY/HTTPS_PROXY env knobs for bot pods \u2014 operators can route\
+    \ k8s bot egress through a residential or less-flagged proxy to pass Google IP-reputation checks"
+  symptom: No operator knob exists to route bot pod traffic through a proxy; k8s datacenter IPs have no escape route from
+    Google IP-reputation blocks even after Chrome flag cleanup
+  found: '2026-06-06'
+  type: grep
+  file: deploy/helm/charts/vexa/values.yaml
+  must_match: BOT_HTTP_PROXY
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+GMEET_PARTICIPANT_COUNTER_MULTI_SELECTOR_FALLBACK:
+  proves: 'services/vexa-bot/core/src/platforms/googlemeet/recording.ts countParticipantTiles() falls back to data-self-name
+    (and role=region with aria-label containing ''articipant'') when the primary [data-participant-id] selector returns 0.
+    Layer 1 of the false-LEFT_ALONE_TIMEOUT fix (#285): any GMeet UI change to the primary attribute no longer takes the count
+    to 0 globally, since the self-name marker is always present once admitted.'
+  symptom: Single-selector GMeet UI change cascades to bot global LEFT_ALONE detection; bots leave every healthy meeting within
+    60s of admission until manually patched.
+  found: '2026-04-30'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/googlemeet/recording.ts
+  must_match: data-self-name
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
 GRACEFUL_LEAVE:
   proves: self_initiated_leave during stopping treated as completed, not failed
   symptom: "Bot shows failed after successful meeting \u2014 exit during stopping treated as failure"
@@ -861,46 +473,28 @@ GRACEFUL_LEAVE:
   - helm
   state: stateless
   max_duration_sec: 5
-H11_PINNED_SAFE_EVERYWHERE:
-  proves: "every httpx/uvicorn requirements*.txt pins h11>=0.16.0 \u2014 CVE-2025-43859 closed transitively"
-  symptom: pip install resolves h11<0.16.0 on any service; HTTP/1.1 pipelining header leak reintroduced
-  found: '2026-04-19'
-  type: script
-  script: tests/security-hygiene.sh
-  step: h11_pin
-  modes:
-  - lite
-  - compose
-  state: stateless
-  max_duration_sec: 20
-HELM_ALL_SERVICES_DB_POOL_TUNED:
-  proves: "every pool-holder service in the chart has an explicit DB_POOL_SIZE env \u2014 no silent framework defaults"
-  symptom: configured pool ceilings sum past managed-DB slot cap; pool-exhaustion 500s under load
-  found: '2026-04-21'
-  type: script
-  script: tests/chart-all-services-db-pool-tuned.sh
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 15
 HELM_API_GATEWAY_REPLICA_COUNT_HA:
-  proves: "apiGateway.replicaCount default \u2265 2 so maxSurge: 0 rolling updates remain zero-downtime for the front door"
-  symptom: apiGateway rolled with replicaCount=1 and maxSurge=0 = 5-15s platform-wide outage during upgrade
+  proves: "apiGateway.replicaCount default is 2 \u2014 maxSurge: 0 rollouts stay zero-downtime for the front door"
+  symptom: apiGateway rolled with replicaCount=1 + maxSurge=0 = 5-15s platform-wide outage during upgrade
   found: '2026-04-21'
   type: grep
   file: deploy/helm/charts/vexa/values.yaml
-  must_match: apiGateway:\s*\n(?:[ \t]+[^\n]+\n)*[ \t]+replicaCount:\s*[2-9]
-  multiline: true
+  must_match: 'replicaCount: 2'
   modes:
+  - lite
+  - compose
   - helm
   state: stateless
   max_duration_sec: 5
-HELM_CHART_VALID:
-  proves: "helm chart passes lint \u2014 templates are well-formed"
-  symptom: "helm lint fails \u2014 chart has structural errors"
-  type: script
-  dispatch: HELM_LINT
-  from_tier: static
+HELM_CHART_RUNTIME_API_MEMORY_2560MI:
+  proves: "helm chart values.yaml sets runtime-api meeting profile memory_limit to 2560Mi, matching services/runtime-api/profiles.yaml\
+    \ \u2014 source-of-truth drift guard (edit one, forget the other = bug B recurrence)"
+  symptom: Chart deployed with 1536Mi memory even though profiles.yaml bumped to 2560Mi; helm runtime-api OOMs Teams bot while
+    compose/lite work fine
+  found: '2026-04-22'
+  type: grep
+  file: deploy/helm/charts/vexa/values.yaml
+  must_match: 'memory_limit: "2560Mi"'
   modes:
   - lite
   - compose
@@ -908,13 +502,15 @@ HELM_CHART_VALID:
   state: stateless
   max_duration_sec: 5
 HELM_DEPLOYMENT_STRATEGY_HELPER_DEFINED:
-  proves: _helpers.tpl defines the vexa.deploymentStrategy helper
-  symptom: helper deletion causes every Deployment to revert to K8s default maxSurge=25%
+  proves: "_helpers.tpl defines vexa.deploymentStrategy \u2014 centralized rolling-update contract"
+  symptom: helper deleted; every Deployment reverts to K8s default maxSurge=25%
   found: '2026-04-21'
   type: grep
   file: deploy/helm/charts/vexa/templates/_helpers.tpl
-  must_match: define\s+"vexa\.deploymentStrategy"
+  must_match: vexa.deploymentStrategy
   modes:
+  - lite
+  - compose
   - helm
   state: stateless
   max_duration_sec: 5
@@ -962,40 +558,6 @@ HELM_PDB_TEMPLATE_EXISTS:
   - helm
   state: stateless
   max_duration_sec: 5
-HELM_PGBOUNCER_OPTIONAL_AND_WIRED:
-  proves: 'chart supports optional PgBouncer (pgbouncer.enabled: false default); when enabled, DB_HOST of every service rewires
-    to pgbouncer via vexa.dbHostEffective'
-  symptom: operator can't put a pooler in front of Postgres without forking the chart
-  found: '2026-04-21'
-  type: script
-  script: tests/chart-pgbouncer-optional.sh
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 30
-HELM_PROD_SECRETS_REQUIRED_AT_RENDER:
-  proves: helm template fails with a `required` error when DB_PASSWORD / TRANSCRIPTION_SERVICE_TOKEN secret material is missing
-  symptom: chart silently renders with empty secret values; broken Deployment hits K8s unnoticed
-  found: '2026-04-21'
-  type: script
-  script: tests/chart-prod-secrets-secretref.sh
-  step: required_at_render
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 30
-HELM_PROD_SECRETS_SECRETREF_ONLY:
-  proves: every prod secret env (DB_PASSWORD, TRANSCRIPTION_SERVICE_TOKEN) in the rendered chart sources from secretKeyRef,
-    not plain value
-  symptom: 'an env var renders as plain `value: ""` silently; pod CrashLoops on secret-driven auth'
-  found: '2026-04-21'
-  type: script
-  script: tests/chart-prod-secrets-secretref.sh
-  step: secretref_only
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 20
 HELM_REDIS_MAXMEMORY_SET:
   proves: "redis deployment is capped at a specific maxmemory with an eviction policy \u2014 no unbounded growth"
   symptom: "redis grows unbounded until its pod OOMs \u2014 which kills WebSocket pub/sub, transcription segments, and session\
@@ -1010,31 +572,23 @@ HELM_REDIS_MAXMEMORY_SET:
   - helm
   state: stateless
   max_duration_sec: 5
-HELM_ROLLING_UPDATE_ZERO_DOWNTIME:
-  proves: "every app-facing Deployment in rendered chart sets strategy.rollingUpdate.maxUnavailable: 0 \u2014 OLD pod stays Ready until NEW pod is Ready (zero-downtime)"
-  symptom: "v0.10.5.2 ship outage class: replicaCount: 1 + maxUnavailable: 1 killed OLD pod before NEW Ready, 502s during any image bump (e.g. dashboard + webapp on 2026-05-01)"
-  found: '2026-05-01'
-  superseded_check: HELM_ROLLING_UPDATE_ZERO_SURGE
-  superseded_at: '2026-05-01'
-  superseded_rationale: |
-    Pre-v0.10.5.3 this check enforced maxSurge: 0 to prevent DB pool footprint
-    doubling during rolling upgrade. v0.10.5 Pack C.x shrank per-pod DB pool
-    4x (8 -> 2 connections per holder), so 2x footprint during rolling is
-    well below managed-DB slot cap. The new Pack H invariant (maxUnavailable: 0)
-    addresses a more painful failure class \u2014 zero-downtime rolling \u2014 and the
-    DB pool concern is now adequately covered by per-pod pool sizing.
-  type: script
-  script: tests/chart-rolling-update-zero-downtime.sh
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 15
-HELM_TEMPLATE_RENDERS:
-  proves: "helm template renders without errors \u2014 values and templates are consistent"
-  symptom: "helm template fails \u2014 missing required values or template syntax error"
-  type: script
-  dispatch: HELM_TEMPLATE
-  from_tier: static
+HELM_SETUP_PASSES_TX_TOKEN_TO_SECRET:
+  proves: "tests3/lib/lke-setup-helm.sh passes the transcription token to BOTH the meeting-api Deployment env (meetingApi.transcriptionServiceToken)\
+    \ AND the cluster Secret resource (secrets.transcriptionServiceToken). The chart's templates/secret.yaml reads from .Values.secrets.transcriptionServiceToken\
+    \ (since chart standardisation in ea62d76, 2026-04-08); runtime-api Deployment + the runtimeProfiles ConfigMap that bot\
+    \ pods inherit BOTH sourceFrom the Opaque Secret. Pre-fix (R6): the script only set meetingApi.* \u2014 meeting-api itself\
+    \ had the token but runtime-api and bot pods saw empty strings. Bots authenticated with `Bearer ` (empty) and got rejected\
+    \ silently by transcription-service. The recording-aware classifier (FM-002 v2) correctly tagged the meetings COMPLETED\
+    \ (because recording was delivered), masking the no-transcripts failure unless a human spot-checked. Discovered during\
+    \ v0.10.5 human validation, helm meeting 8: 9.5MB recording delivered, 0 transcripts."
+  symptom: 'helm meetings show recording delivered to MinIO + 0 transcripts despite transcribe_enabled=true. Bot pods have
+    TRANSCRIPTION_SERVICE_URL set but TRANSCRIPTION_SERVICE_TOKEN empty in their env. transcription-service rejects every
+    bot connection with auth failure. Customer-impact: helm-mode operators get recordings without transcripts; classifier
+    hides the failure as a successful capture.'
+  found: '2026-04-30'
+  type: grep
+  file: tests3/lib/lke-setup-helm.sh
+  must_match: secrets.transcriptionServiceToken=$TX_TOKEN
   modes:
   - lite
   - compose
@@ -1068,22 +622,1071 @@ IDENTITY_NO_FALLBACK:
   - helm
   state: stateless
   max_duration_sec: 5
+K8S_BACKEND_CONTAINER_ID_IS_NAME:
+  proves: "runtime-api kubernetes backend `create()` returns `pod.metadata.name` as container_id \u2014 meeting-api stores\
+    \ a kubectl-resolvable identifier for later DELETE (Pack D.1)."
+  symptom: container_id is `pod.metadata.uid` (a UUID); subsequent stop+delete fails because k8s API only accepts pod-name
+    identifiers; orphan bot pods accumulate (#261).
+  found: '2026-04-27'
+  type: grep
+  file: services/runtime-api/runtime_api/backends/kubernetes.py
+  must_match: return created.metadata.name
+  must_not_match: return\s+created\.metadata\.uid
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+LITE_INTERNAL_SERVICES_LOOPBACK_ONLY:
+  proves: "lite supervisord binds every internal service (admin-api, runtime-api, meeting-api, agent-api, tts-service, mcp)\
+    \ to 127.0.0.1 \u2014 only api-gateway + dashboard listen on 0.0.0.0"
+  symptom: internal services expose authenticated endpoints on 0.0.0.0 on a public-IP VM; enlarges attack surface even though
+    auth protects against ransomware-class data loss
+  found: '2026-04-21'
+  type: grep
+  file: deploy/lite/supervisord.conf
+  must_not_match: host 0\.0\.0\.0 --port (8057|8090|8080|8100|8059|18888)
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+LITE_POSTGRES_NOT_PUBLIC:
+  proves: "deploy/lite/Makefile launches Postgres with listen_addresses=127.0.0.1 \u2014 not reachable from the public internet\
+    \ on the host interface"
+  symptom: lite's Postgres on 0.0.0.0:5432 was scanned + ransomware-wiped (172.232.0.163 on 2026-04-21; database 'vexa' dropped;
+    'readme_to_recover' left with BTC demand)
+  found: '2026-04-21'
+  type: grep
+  file: deploy/lite/Makefile
+  must_match: listen_addresses=127.0.0.1
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+LITE_PROCESS_BACKEND:
+  proves: "Dockerfile.lite uses process backend \u2014 lite is single-container, no Docker needed"
+  symptom: "Lite tries to spawn Docker containers for bots \u2014 fails without Docker socket, defeats single-container purpose"
+  found: '2026-04-13'
+  type: grep
+  file: deploy/lite/Dockerfile.lite
+  must_match: ORCHESTRATOR_BACKEND=process
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+LITE_RECORDING_ENABLED:
+  proves: "Dockerfile.lite has RECORDING_ENABLED=true \u2014 lite records audio by default"
+  symptom: "Recording disabled in lite \u2014 bots join meetings but produce no audio recordings"
+  found: '2026-04-13'
+  type: grep
+  file: deploy/lite/Dockerfile.lite
+  must_match: RECORDING_ENABLED=true
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+LITE_REDIS_NOT_PUBLIC:
+  proves: "lite's Redis binds to 127.0.0.1 with protected-mode \u2014 not reachable from the public internet; same ransomware\
+    \ class as Postgres if left on 0.0.0.0 without AUTH"
+  symptom: --bind 0.0.0.0 Redis with no AUTH gets FLUSHALL-ed by scanner + ransom key written
+  found: '2026-04-21'
+  type: grep
+  file: deploy/lite/supervisord.conf
+  must_match: redis-server --bind 127.0.0.1
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+LOGIN_REDIRECT:
+  proves: login redirects to / (then /meetings), not to disabled /agent page
+  symptom: After login, user redirected to /agent (disabled feature) instead of /meetings
+  found: '2026-04-07'
+  type: grep
+  file: services/dashboard/src/app/login/page.tsx
+  must_match: push("/")
+  must_not_match: push\("/agent"\)
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+MAP_MEETING:
+  proves: dashboard API client maps native_meeting_id to platform_specific_id via mapMeeting
+  symptom: "Transcript page empty \u2014 getMeeting() skipped mapMeeting(), native_meeting_id not mapped"
+  found: '2026-04-07'
+  type: grep
+  file: services/dashboard/src/lib/api.ts
+  must_match: mapMeeting
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+MEETING_API_COLLECTOR_LIVENESS:
+  proves: "meeting-api `/health/collector` returns 503 when Redis stream lag>100 AND idle>60s \u2014 liveness signal models\
+    \ the consumer's actual ability to drain the queue (Pack C.3)."
+  symptom: Liveness probe is bare process-up; consumer hangs on a Redis blocking read but probe stays green; pod silently
+    stops processing while K8s reports Ready (#269).
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/main.py
+  must_match: /health/collector
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+MEETING_API_READYZ_GATES_CONSUMER:
+  proves: meeting-api exposes `/readyz` distinct from `/health`; `_startup_complete` flag flips True only after Redis ping
+    + consumer-task spawn; readinessProbe targets /readyz (Pack C.4).
+  symptom: Service marks Ready before Redis consumer is up; K8s routes traffic to a pod that can't process callbacks; outbox
+    reads silently fail (#248).
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/main.py
+  must_match: _startup_complete
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+MEETING_API_STORES_NAME_NOT_CONTAINER_ID:
+  proves: "services/meeting-api/meeting_api/meetings.py stores the runtime-api container NAME (not the Docker container_id\
+    \ hex) as meeting.bot_container_id on bot-create. Property: the value persisted as bot_container_id MUST be the same identifier\
+    \ runtime-api accepts at GET /containers/{name} \u2014 i.e., the name (e.g., 'meeting-40-d969b41a'), not the 64-char Docker\
+    \ container_id. Pre-fix (R1): all three create sites (lines 751, 828, 1207) wrote `result.get('container_id') or result.get('name')`\
+    \ \u2014 the truthy hex container_id was always preferred. runtime-api's Redis state is keyed by name only (api.py:315\
+    \ `state.get_container(redis, name)`), so every meeting-api inspect call (`GET /containers/<container_id>`) returned 404.\
+    \ meeting-api then routed the DELETE through the Pack J no-container branch, which marks the meeting completed and runs\
+    \ run_all_tasks but does NOT send the stop signal to the live bot. Bots stayed alive uploading chunks; each chunk-upload\
+    \ at recordings.py:327 overwrote `recording.status='completed'` back to 'in_progress' based on the chunk's is_final=false\
+    \ flag. Symptom triplet: (1) bots don't leave after DELETE, (2) dashboard stuck 'preparing audio', (3) Zoom Web 0-recording-entries\
+    \ on bots that didn't get the parecord-finalize path."
+  symptom: Bot containers remain alive (Up Nm) for many minutes after DELETE/stop. Meeting status flips to completed in DB
+    but recording.status stays in_progress and media_files[*].is_final stays false. Dashboard shows 'preparing audio' indefinitely.
+    Zoom Web meetings that didn't reach the bot's clean-shutdown self-leave path produce zero recording entries even with
+    recording_enabled=true. All three platforms affected; observed 2026-04-30 on bots 40 (GMeet), 41 (Teams), 42 (Zoom). Root
+    regression introduced 9b8ba83 (initial meeting-api commit); was masked by alternate stop paths until recent stage-hygiene
+    work started exercising the runtime-api inspect path on user-DELETE.
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/meetings.py
+  must_match: "v0.10.5 R1 fix \u2014 store NAME as bot_container_id"
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+MEETING_URL_REJECTS_MALFORMED:
+  proves: "services/meeting-api/meeting_api/schemas.py rejects literal-garbage meeting_url values (no scheme + no netloc)\
+    \ at the pydantic field-validator layer, returning HTTP 422 \u2014 distinct from the trust-model accept-path for any well-formed\
+    \ URL with platform. Without this gate the request fell through to the body handler where the next downstream error (concurrency\
+    \ 403, redis-publish, db write) surfaced \u2014 burning a meeting row and a container slot before failing. Trust model\
+    \ preserved: any urlparse-able URL with scheme + netloc passes through (zoom-lfx, white-label portals, custom domains\
+    \ all keep working). Only the genuinely-not-a-URL case (e.g. 'not-a-url') is rejected. R4 fix."
+  symptom: POST /bots with meeting_url='not-a-url' returns HTTP 403 (concurrency or auth) instead of HTTP 422 (validation
+    error). Test INVALID_URL_REJECTED fails on lite + compose + helm with 'HTTP 403 (expected one of [400, 422])'.
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/schemas.py
+  must_match: "v0.10.5 R4 \u2014 minimal URL well-formedness gate"
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+NO_DEV_FALLBACK_COMPOSE:
+  proves: docker-compose.yml has no silent :-dev fallbacks on active (uncommented) lines
+  symptom: "IMAGE_TAG unset silently falls back to :dev \u2014 deploys untested dev images in production"
+  found: '2026-04-13'
+  type: grep
+  file: deploy/compose/docker-compose.yml
+  must_not_match: ^[^#]*:-dev\}
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+NO_EXPORT_IMAGE_TAG:
+  proves: "compose Makefile does not export IMAGE_TAG globally \u2014 prevents empty env var poisoning"
+  symptom: Make exports empty IMAGE_TAG before .env is read. Docker Compose inherits empty string which takes precedence over
+    --env-file, causing ${IMAGE_TAG:-dev} to resolve to dev
+  found: '2026-04-13'
+  type: grep
+  file: deploy/compose/Makefile
+  must_not_match: ^export IMAGE_TAG
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+NO_IMAGETOOLS_CREATE:
+  proves: publish/promote uses docker tag+push, not imagetools create (same SHA across tags)
+  symptom: "imagetools create wraps image in manifest list \u2014 latest/dev get different SHA than build tag, breaking traceability"
+  found: '2026-04-13'
+  type: grep
+  file: deploy/compose/Makefile
+  must_not_match: ^[^#]*imagetools create
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+NO_NESTED_COMPOSE_VARS:
+  proves: docker-compose.yml has no nested ${VAR:-${VAR}} on active (uncommented) lines
+  symptom: "BROWSER_IMAGE silently falls back to :dev \u2014 bots use wrong image, container creation 404/500"
+  found: '2026-04-13'
+  type: grep
+  file: deploy/compose/docker-compose.yml
+  must_not_match: ^[^#]*\$\{[^}]+:-[^}]*\$\{
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+NO_VIDEO_TRANSCEIVER_DIRECTION_FLIP:
+  proves: "services/vexa-bot/core/src/services/screen-content.ts must NOT modify transceiver.direction in the WebRTC ontrack\
+    \ handler. v0.10.5 commit 8ab7f49 reverted the SDP-munge added by 42a2c76 (2026-04-12) which set transceiver direction\
+    \ to 'inactive'/'sendonly' \u2014 produced malformed SDP (BUNDLE without rtcp-mux), peer entered inconsistent state, ~60-90s\
+    \ later GMeet severed the session and the page eval context was destroyed. Prod telemetry 2026-04-30: 44% of GMeet 24h\
+    \ meetings (19 of 43) matched this exact failure shape. This regression guard ensures any future re-introduction of the\
+    \ direction flip fails closed. Acceptable alternatives if memory pressure returns: chromium launch flags --disable-features=Vp8,Vp9\
+    \ (codec-level disable, no JS-side WebRTC mutation), or system-level audio capture (attendee paradigm)."
+  symptom: "GMeet bots crash 60-90s after admission with 'page.evaluate: Execution context was destroyed' and exit reason\
+    \ post_join_setup_error. Recording chunks may have started uploading; subsequent ones shrink as audio degrades; bot exits\
+    \ before is_final fires. In prod manifests as 'failed/joining' with stale failure_stage (FM-003) and NULL completion_reason\
+    \ \u2014 looks indistinguishable from a real join failure even though the bot was active for a minute."
+  found: '2026-04-30'
+  type: grep
+  file: services/vexa-bot/core/src/services/screen-content.ts
+  must_not_match: transceiver(Ref|s)?\.direction\s*=\s*['\"]?(inactive|sendonly)
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK2_GMEET_ADMISSION_OUTCOME_TYPED:
+  proves: googlemeet/admission.ts exports AdmissionError with typed AdmissionOutcome (denial | lobby_timeout | join_failure).
+    Each throw site uses the correct outcome so callers can distinguish host rejection from lobby timeout from total join
+    failure without parsing error message text.
+  symptom: All admission failures surface identical Error objects; callers cannot distinguish host denial from lobby timeout,
+    causing uniform retry behaviour regardless of root cause.
+  found: '2026-06-06'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/googlemeet/admission.ts
+  must_match: AdmissionOutcome
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK2_GMEET_HUMANIZED_ENDPOINT_VERIFY:
+  proves: "googlemeet/humanized/humanizedInteraction.ts implements pointerHitsTarget endpoint verification: reads the REAL\
+    \ X11 pointer after trajectory replay, asserts it is inside the live button rect, and throws (with miss screenshot) if\
+    \ not \u2014 recalibrate-or-fail-loud, never a self-blind click."
+  symptom: 'Humanized click lands off-target silently: trajectory replay ends near but not on the button (wrong screen-page
+    offset), button-down is emitted at the wrong coordinates, Google Meet registers a click on empty space or a different
+    element.'
+  found: '2026-06-06'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/googlemeet/humanized/humanizedInteraction.ts
+  must_match: pointerHitsTarget
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK2_GMEET_LOCALE_AGNOSTIC_JOIN_SELECTOR:
+  proves: 'googlemeet/selectors.ts: googleJoinButtonSelectors has a locale-agnostic structural selector (button[jsname]) as
+    its first entry, before any English has-text fallback. Pre-fix: only English-text selectors existed; Hungarian/non-EN
+    lobby never matched the join button (prod ids 13951 13952 14018 14153).'
+  symptom: "Bot sits in non-English Google Meet lobby until manual_leave \u2014 join button never found because all selectors\
+    \ required English text."
+  found: '2026-06-06'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
+  must_match: button[jsname]
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK2_GMEET_LOCALE_AGNOSTIC_NAME_SELECTOR:
+  proves: 'googlemeet/selectors.ts: googleNameInputSelectors has a locale-agnostic structural selector (input[jsname][type="text"])
+    as its first entry, before the English aria-label="Your name" fallback. Pre-fix: only English aria-label/placeholder selectors
+    existed; non-English lobby name input was never found.'
+  symptom: "Bot cannot fill its name in non-English Google Meet lobby \u2014 name input field never matched because selectors\
+    \ required English aria-label."
+  found: '2026-06-06'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
+  must_match: input[jsname][type="text"]
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK2_GMEET_WAIT_FOR_ANY_SELECTOR:
+  proves: googlemeet/join.ts exports waitForAnySelector which races all selectors in parallel and screenshots + throws loudly
+    on total miss (no silent skip). Used for both name-input and join-button resolution so a locale-agnostic selector fires
+    first on any UI locale.
+  symptom: "Join failure on non-English Meet lobby is silent \u2014 bot uses only the first selector from the list, never\
+    \ trying locale-agnostic alternatives, and no diagnostic screenshot is taken on miss."
+  found: '2026-06-06'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/googlemeet/join.ts
+  must_match: waitForAnySelector
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACKAGES_CI_WORKFLOW_EXISTS:
+  proves: .github/workflows/test-packages.yml exists and runs npm test on packages/*
+  symptom: packages/ has no PR-time CI; regressions slip in
+  found: '2026-04-21'
+  type: grep
+  file: .github/workflows/test-packages.yml
+  must_match: packages/
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_E1A_CHUNK_WRITE_LOG_LINE:
+  proves: "recordings.py emits a structured single-line log per chunk write (`[E1A] chunk_write meeting_id=... recording_id=...\
+    \ media_type=... chunk_seq=... prior_count=... action=...`). [PLATFORM] ASK 2 (#272 issuecomment-4327839749 reply 14:32Z)\
+    \ \u2014 greppable signal for ad-hoc validation + post-deploy production observer."
+  symptom: Production observer cannot detect race recurrence without scanning DB+S3 on every meeting end; structured log line
+    eliminates that scan path. Missing line means observability regression for the v0.10.5 hardening.
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/recordings.py
+  must_match: '[E1A] chunk_write'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_E1A_PER_CHUNK_MEDIA_FILES_WRITE:
+  proves: "services/meeting-api/meeting_api/recordings.py performs a per-chunk durable write of the `media_files` array on\
+    \ every successful upload (intermediate or final), not only on the final chunk. v0.10.5 Pack E.1.a (#268 reproduce + reconciler):\
+    \ pre-fix, intermediate chunks reached MinIO/S3 but `media_files=[]` in DB \u2014 orphaned. Post-fix, every chunk write\
+    \ performs a `existing_media_files.append({...})` + `rec_payload[\"media_files\"] = existing_media_files` + `await db.commit()`\
+    \ cycle so the DB row tracks every chunk that landed in storage. Audit-3 (ARCH-2 2026-04-29 ~11:20 UTC) flagged recording-link-gap\
+    \ as \U0001F7E1 (fixed in 0.10.5, no direct test); this static-grep stamp closes the source-shape regression coverage."
+  symptom: "recording-link-gap regression: per-chunk media_files write removed by refactor; intermediate chunks land in S3\
+    \ but DB shows media_files=[] \u2014 dashboard/SDK sees an orphaned recording with content unreachable. Companion to PACK_E1A_CHUNK_WRITE_LOG_LINE\
+    \ which pins the structured-log shape for ad-hoc validation."
+  found: '2026-04-29'
+  type: grep
+  file: services/meeting-api/meeting_api/recordings.py
+  must_match: rec_payload["media_files"] = existing_media_files
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_Q_POD_NAME_USES_MEETING_ID:
+  proves: "services/runtime-api/runtime_api/api.py builds runtime pod names with `meeting_id` (when present in `req.config`\
+    \ or `req.metadata`), not `user_id`. v0.10.5 Pack Q (FM-275 / #275): pre-fix produced `meeting-{user_id}-{uuid}` (e.g.\
+    \ `meeting-2087-ee434b6d` for actual meeting_id 11058) \u2014 operator-confusing because the natural inference 'pod name's\
+    \ integer = meeting_id' was wrong, and audit-tooling that joined on the pod name's integer field broke silently. Post-fix:\
+    \ `meeting-{meeting_id}-{uuid}` aligns kubectl logs + browse-by-name + Redis state-index reconciliation with the canonical\
+    \ meeting identifier. Audit-3 flagged FM-275 as \U0001F7E1 (fixed, no direct test); this stamp pins the source-shape."
+  symptom: "FM-275 regression: pod-naming refactor reverts to `user_id`-based naming. Operator browsing kubectl logs by pod\
+    \ name infers wrong meeting_id; runtime audit tooling cross-references break silently. Compounds during incident triage\
+    \ when 5+ bots are spawning concurrently and the pod-name \u2192 meeting_id mapping is the operator's only readily-available\
+    \ join key."
+  found: '2026-04-29'
+  type: grep
+  file: services/runtime-api/runtime_api/api.py
+  must_match: meeting_id = req.config.get("meeting_id")
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_S_WEBHOOK_RETRY_LOG_NON_EMPTY_ERROR:
+  proves: "services/meeting-api/meeting_api/webhooks.py logs every webhook delivery exception via `logger.error(... exc_info=True)`,\
+    \ ensuring the failure path always carries a non-empty error string + full traceback. v0.10.5 Pack S (FM-277 / #277):\
+    \ pre-fix, webhook retry path could swallow exceptions silently (logger called with empty message or exc_info=False),\
+    \ making prod webhook-failure observability blind. Post-fix: both `send_status_webhook` and `send_event_webhook` wrap\
+    \ their delivery loops in `try/except` with `logger.error(f\"Unexpected error sending ... for meeting {meeting.id}: {e}\"\
+    , exc_info=True)`. Audit-3 flagged FM-277 as \U0001F7E1 (fixed in 0.10.5, no direct test); this stamp pins the source-shape."
+  symptom: 'FM-277 regression: webhook exception handler reverts to silent-swallow shape (no logger.error, missing exc_info).
+    Webhook failures invisible in operator logs; customers report ''webhooks not arriving'' with no server-side trail to diagnose.
+    Trades-off observability for lower log volume in a way that defeats the reason webhooks have a retry budget.'
+  found: '2026-04-29'
+  type: grep
+  file: services/meeting-api/meeting_api/webhooks.py
+  must_match: logger.error(f"Unexpected error sending
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_T_TERMINAL_IDEMPOTENT_REFIRE_BENIGN:
+  proves: "services/meeting-api/meeting_api/meetings.py update_meeting_status() treats `completed \u2192 completed` and `failed\
+    \ \u2192 failed` as benign idempotent re-fires (returns True at DEBUG level), instead of WARNING-and-returning-False.\
+    \ Pack T fix for FM-278 (#278). Pre-fix: three independent code paths \u2014 chat persistence, status update, post-meeting\
+    \ tasks \u2014 could each fire a redundant `completed \u2192 completed` transition under the documented _delayed_stop_finalizer\
+    \ / runtime-api callback race. Each fired a WARNING (~30 per 90-minute window in prod) and the False return short-circuited\
+    \ post-meeting tasks via `if not success`, leaving aggregation undone for some completed meetings. Post-fix: idempotent\
+    \ re-fires log at DEBUG and return True so caller code paths complete normally; warnings reserved for actual invalid transitions."
+  symptom: Production meeting-api logs flooded with 'Invalid status transition completed -> completed' WARNINGs (~30/90min).
+    Some completed meetings have post-meeting tasks (transcript aggregation, webhooks) silently skipped because the False
+    return path short-circuits run_all_tasks.
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/meetings.py
+  must_match: "v0.10.5 Pack T (#278) \u2014 Already-terminal idempotent re-fire is benign"
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_X_DRY_RUN_FLAG_GATED:
+  proves: "MeetingCreate schema accepts `dry_run` field; request_bot handler enforces `VEXA_ENV != 'production'` gate (HTTP\
+    \ 422 in production). Synthetic-rig safety net \u2014 even if a test-shape leaks past route gating, the value is rejected\
+    \ at the application layer."
+  symptom: 'Test-mode flag accepted in production: synthetic test traffic could create meetings without launching real bots,
+    hiding production usage anomalies. Bypasses the no-platform-bot test boundary.'
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/meetings.py
+  must_match: dry_run=true is a test-mode flag; not allowed in production
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_X_DRY_RUN_SCHEMA_FIELD:
+  proves: 'MeetingCreate Pydantic schema declares `dry_run: Optional[bool] = Field(False, ...)` so callers can opt in deterministically.
+    The synthetic-rig depends on this field being a first-class schema element (not a magic header).'
+  symptom: If someone removes the field, all 7 Pack X scenarios fail with HTTP 422; rig becomes unrunnable; entropy testing
+    offline.
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/schemas.py
+  must_match: 'dry_run: Optional[bool] = Field('
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PASSWORD_STORE_BASIC:
+  proves: "Chrome uses basic password store \u2014 cookies decryptable across sessions"
+  symptom: "Authenticated join fails \u2014 Chrome cookies encrypted, login not restored across sessions"
+  found: '2026-04-07'
+  type: grep
+  file: services/vexa-bot/core/src/constans.ts
+  must_match: password-store=basic
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+POST_MEETING_FINALIZES_IN_PROGRESS_RECORDINGS:
+  proves: "services/meeting-api/meeting_api/post_meeting.py defines `finalize_in_progress_recordings(meeting, db)` and calls\
+    \ it as Task 0 of run_all_tasks. Reconciles the case where a bot's terminal-chunk-with-is_final-true never reached the\
+    \ server (bot was killed by SIGKILL grace timeout, page eval context died, network failed mid-flush). Pre-fix, recordings\
+    \ stayed status=IN_PROGRESS with media_files[*].is_final=false indefinitely after the meeting itself transitioned to terminal\
+    \ \u2014 consumers polling for is_final=true never saw the recording 'complete' even though the audio chunks were durably\
+    \ persisted. Post-fix, post-meeting tasks unconditionally walk meeting.data.recordings, flip rec.status to COMPLETED for\
+    \ any IN_PROGRESS, and set is_final=true on every media_files entry. Tagged with finalized_by: post_meeting_reconciler\
+    \ for forensic traceability."
+  symptom: "Recording entries stuck in IN_PROGRESS indefinitely after meetings that completed successfully. Consumers polling\
+    \ for is_final=true to know when the recording is ready never see it flip \u2014 assume the recording is broken or still\
+    \ being written. SDK / dashboard / billing / archival pipelines that gate on the is_final flag stall."
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/post_meeting.py
+  must_match: finalize_in_progress_recordings
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+POST_MEETING_RECORDING_STATUS_IMPORT_PATH:
+  proves: "services/meeting-api/meeting_api/post_meeting.py imports RecordingStatus from .schemas (not .models). The enum\
+    \ lives at schemas.py:1202; models.py has no RecordingStatus symbol. Pre-fix (R0): finalize_in_progress_recordings used\
+    \ `from .models import RecordingStatus`, raising ImportError every time the reconciler fired. Production logs (2026-04-30)\
+    \ showed the error firing on meetings 33/34/35/36/37/40/41 \u2014 every meeting ended with recording.status='in_progress'\
+    \ + media_files[*].is_final=false stuck forever, dashboard 'preparing audio' indefinitely. Post-fix: import path corrected;\
+    \ reconciler runs cleanly, [Bug-B-Fix] log line confirms `count=N` finalized recordings."
+  symptom: 'ERROR meeting_api.post_meeting: Recording finalization failed for meeting <id>: cannot import name ''RecordingStatus''
+    from ''meeting_api.models''. Reconciler claims success on log line `Post-meeting tasks completed for meeting <id>` but
+    recording metadata stays unfinalized; dashboard indefinitely ''preparing audio''.'
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/post_meeting.py
+  must_match: from .schemas import RecordingStatus
+  must_not_match: from .models import RecordingStatus
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RECORDING_FINALIZE_OUTBOX_CONSUMER_IDEMPOTENT:
+  proves: container-stop outbox consumer in `sweeps.py` imports `consume_pending_stops` from `container_stop_outbox` and is
+    wired into the idle_loop pattern (Pack D.2 wiring).
+  symptom: Outbox stream entries pile up unconsumed because no idle_loop sweep reads them; Redis memory grows; stops never
+    reach runtime-api (#266 follow-on).
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/sweeps.py
+  must_match: from .container_stop_outbox import consume_pending_stops
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RECORDING_MEDIA_FILES_CUMULATIVE_BYTES:
+  proves: "services/meeting-api/meeting_api/recordings.py per-chunk write accumulates `cumulative_bytes` across chunks of\
+    \ the same media_type rather than overwriting `file_size_bytes` with the latest chunk's size only. Pre-fix (Pack E.1.a\
+    \ v1, 2026-04-27): each chunk replaced the same-type media_files entry with the new chunk's metadata, so file_size_bytes\
+    \ reflected only the LAST chunk (~480KB) instead of the cumulative size (e.g. 36 chunks \u2248 17MB). Dashboard / SDK\
+    \ consumers reading meeting.data.recordings[].media_files[].file_size_bytes saw a tiny recording for what was actually\
+    \ a 15-minute capture. Post-fix (2026-04-30, post-prod-telemetry): the in_place branch now reads prior_bytes + adds file_size,\
+    \ also tracks chunk_count and first_chunk_at, exposes last_chunk_size_bytes for diagnostics."
+  symptom: Customer-reported 'my hour-long meeting only saved a 500KB file' even though the actual chunk files in MinIO total
+    tens of MB. API/dashboard queries report misleading recording size, breaking download UX expectations and any analytics
+    that key off file_size_bytes for billing or diagnostic gates.
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/recordings.py
+  must_match: cumulative_bytes
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RECORDING_STATUS_TERMINAL_STICKY:
+  proves: "services/meeting-api/meeting_api/recordings.py chunk handler refuses to downgrade recording.status from COMPLETED\
+    \ back to IN_PROGRESS. Defense-in-depth pairing with R1: even if a stray late chunk arrives after the reconciler set status=COMPLETED\
+    \ (or after the bot's own is_final terminal chunk), the terminal state is sticky. Pre-fix (R2): the else branch unconditionally\
+    \ wrote rec_payload['status'] = IN_PROGRESS for every non-final chunk \u2014 every late chunk re-marked status=IN_PROGRESS,\
+    \ post_meeting_reconciler's status flip got clobbered, dashboard stuck on 'preparing audio'. Post-fix: only flip to IN_PROGRESS\
+    \ when the recording is not already COMPLETED."
+  symptom: "Dashboard shows 'preparing audio' indefinitely on a meeting whose audio is durably stored in MinIO and whose post_meeting_reconciler\
+    \ logged success. Status race between chunk-upload writer and reconciler \u2014 chunk wins because it commits last."
+  found: '2026-04-30'
+  type: grep
+  file: services/meeting-api/meeting_api/recordings.py
+  must_match: "v0.10.5 R2 \u2014 defense-in-depth"
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RECORDING_UPLOAD_SUPPORTS_CHUNK_SEQ:
+  proves: '/internal/recordings/upload accepts chunk_seq: int form parameter'
+  symptom: bot incremental chunk uploads rejected because endpoint drops chunk_seq
+  found: '2026-04-21'
+  type: grep
+  file: services/meeting-api/meeting_api/recordings.py
+  must_match: 'chunk_seq: int'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+REDIS_CLIENT_HARDENED_TIMEOUTS:
+  proves: "meeting-api aioredis.from_url() carries socket_timeout, socket_connect_timeout, socket_keepalive, health_check_interval,\
+    \ retry_on_timeout \u2014 Redis client cannot hang indefinitely on a partitioned/slow Redis (Pack C.1)."
+  symptom: "Bare aioredis.from_url(url) with no timeouts; one Redis socket stall blocks the meeting-api event loop until OS-level\
+    \ TCP keepalive (~hours) eventually closes the socket \u2014 no consumer, no /readyz signal, no recovery without pod restart\
+    \ (#267)."
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/main.py
+  must_match: socket_timeout=10
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+REQUIRE_FM001_STAMP:
+  proves: "services/meeting-api/meeting_api/callbacks.py routes every non-stopping bot exit through `_classify_stopped_exit`\
+    \ \u2014 the central FM-001/FM-002/FM-003 classifier. The classifier's PRESENCE in callbacks.py is the proof-of-fix; reverting\
+    \ any of the three FMs requires deleting or bypassing this function. Default-on (static tier runs on every release-validate);\
+    \ audit-1 (ARCH-2 2026-04-29 ~13:15 UTC) recommended flipping this from opt-in to default-on for v0.10.5 ship."
+  symptom: 'FM-001 / FM-002 / FM-003 silently regress: callbacks.py refactor drops the central classifier, exit handler reverts
+    to `else: status=failed, completion_reason=NULL`, prod resumes 47% misclassification. Companion happy-path + parametrized
+    unit tests in services/meeting-api/tests/test_callbacks.py back this static stamp; if either is removed, the stamp fails
+    closed.'
+  found: '2026-04-29'
+  type: grep
+  file: services/meeting-api/meeting_api/callbacks.py
+  must_match: _classify_stopped_exit
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+ROUTE_COLLISION:
+  proves: bot detail route is /bots/id/{id}, not /bots/{id} which collides with /bots/status
+  symptom: "GET /bots/status returns 422 \u2014 Starlette matches /bots/{meeting_id} before /bots/status"
+  found: '2026-04-06'
+  type: grep
+  file: services/meeting-api/meeting_api/meetings.py
+  must_match: /bots/id/{meeting_id}
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RUNTIME_API_IDLE_LOOP_SWEEPS_PENDING_CALLBACKS:
+  proves: "runtime-api idle_loop references list_pending_callbacks \u2014 the durable-delivery sweep is wired"
+  symptom: meeting stuck status='active' forever after callback delivery gives up
+  found: '2026-04-21'
+  type: grep
+  file: services/runtime-api/runtime_api/lifecycle.py
+  must_match: list_pending_callbacks
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RUNTIME_API_MEETING_PROFILE_MEMORY_2560MI:
+  proves: "runtime-api meeting profile memory_limit is at least 2560Mi \u2014 prevents Teams bot SIGKILL exit 137 during graceful\
+    \ leave sequence (admission + ffmpeg mux + final-chunk upload spike above 1.5Gi)"
+  symptom: Teams bot exits 137 (OOM) 10-13s after admission; observed meeting-11 baseline died at 11s post-active; no audio
+    captured, no transcript, recording loss
+  found: '2026-04-22'
+  type: grep
+  file: services/runtime-api/profiles.yaml
+  must_match: 'memory_limit: "2560Mi"'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RUNTIME_API_STATE_KEYED_BY_NAME:
+  proves: "services/runtime-api/runtime_api/state.py keys all container Redis state by the runtime-supplied name parameter,\
+    \ never by Docker container_id or pod uid. Pairs with K8S_BACKEND_CONTAINER_ID_IS_NAME (locks the K8s create() return)\
+    \ and MEETING_API_STORES_NAME_NOT_CONTAINER_ID (locks the meeting-api persist site). Together these three checks lock\
+    \ the identifier-handshake contract: meeting-api stores name \u2192 runtime-api Redis state is keyed by name \u2192 GET/DELETE/touch\
+    \ routes resolve by name. The set+get+delete+set_stopped Redis ops all use `f\"{KEY_PREFIX}{name}\"` consistently. v0.10.5\
+    \ R1 + Gap B regression catch \u2014 without this lock, a future refactor that keyed state by container_id would silently\
+    \ break the meeting-api/runtime-api round-trip even though MEETING_API_STORES_NAME_NOT_CONTAINER_ID still passes. Compose-mode\
+    \ counterpart of the K8s check (which proves the create() return on the K8s side)."
+  symptom: 'Same symptom triplet as R1: bots don''t leave after DELETE, dashboard stuck ''preparing audio'', recording metadata
+    never finalized. Runtime-api keys state by container_id; meeting-api looks up by name; lookups 404; Pack J no-container
+    branch fires for every stop; bots run forever uploading chunks that overwrite the reconciler''s terminal state.'
+  found: '2026-04-30'
+  type: grep
+  file: services/runtime-api/runtime_api/state.py
+  must_match: '{KEY_PREFIX}{name}'
+  must_not_match: \{KEY_PREFIX\}\{(container_id|cid|pod_id|id)\}
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+RUNTIME_API_STOP_GRACE_MATCHES_POD_SPEC:
+  proves: "runtime-api kubernetes.py stop() passes its `timeout` parameter through as grace_period_seconds on pod deletion\
+    \ \u2014 bot graceful-leave has the full grace window. Current default: 60s (matches pod spec's terminationGracePeriodSeconds=60)."
+  symptom: grace period cut back to 10s; final chunk upload aborted on pod deletion
+  found: '2026-04-21'
+  type: grep
+  file: services/runtime-api/runtime_api/backends/kubernetes.py
+  must_match: grace_period_seconds=timeout
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+SECURE_COOKIE_ADMIN_VERIFY:
+  proves: cookie Secure flag based on actual protocol, not NODE_ENV (admin-verify)
+  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
+  found: '2026-04-07'
+  type: grep
+  file: services/dashboard/src/app/api/auth/admin-verify/route.ts
+  must_match: isSecureRequest()
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+SECURE_COOKIE_NEXTAUTH:
+  proves: cookie Secure flag based on actual protocol, not NODE_ENV (nextauth)
+  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
+  found: '2026-04-07'
+  type: grep
+  file: services/dashboard/src/app/api/auth/[...nextauth]/route.ts
+  must_match: isSecureRequest()
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+SECURE_COOKIE_SEND_MAGIC_LINK:
+  proves: cookie Secure flag based on actual protocol, not NODE_ENV (send-magic-link)
+  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
+  found: '2026-04-07'
+  type: grep
+  file: services/dashboard/src/app/api/auth/send-magic-link/route.ts
+  must_match: isSecureRequest()
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+SECURE_COOKIE_VERIFY:
+  proves: cookie Secure flag based on actual protocol, not NODE_ENV (verify)
+  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
+  found: '2026-04-07'
+  type: grep
+  file: services/dashboard/src/app/api/auth/verify/route.ts
+  must_match: isSecureRequest()
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+TEAMS_CONTINUE_WITHOUT_MEDIA_HANDLER:
+  proves: "services/vexa-bot/core/src/platforms/msteams/join.ts polls for and dismisses the Teams 'Continue without audio\
+    \ or video' confirmation modal inside waitForTeamsPreJoinReadiness. The modal renders intermittently when Chromium's media-permission\
+    \ state for Teams is 'denied' at prejoin boot \u2014 wireframe text is 'Are you sure you don't want audio or video?' with\
+    \ a 'Continue without audio or video' button. Pre-fix: when the modal appears it BLOCKS the prejoin name input from rendering;\
+    \ the bot waits the full 45s readiness timeout, fails to find the name input, and times out without ever joining. Customer\
+    \ impact: intermittent Teams join failures with no clear error \u2014 bot exits before name typing because of a blocking\
+    \ modal that the join flow had no handler for. Discovery: 2026-04-30 compose verification, modal observed during third\
+    \ Teams verification run (bot 34); manual click unblocked the prejoin and bot proceeded normally."
+  symptom: 'Intermittent Teams join failures: bot navigates to meeting URL, sees the prejoin page never become ready, times
+    out at the readiness check, and exits without typing its name. Modal text ''Continue without audio or video'' is visible
+    in VNC during the timeout window. Symptom is platform-wide for Teams since it depends on Chromium media-permission state,
+    not meeting state.'
+  found: '2026-04-30'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/msteams/join.ts
+  must_match: continueWithoutMediaClickAttempts
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+URL_PARSER_BEST_EFFORT_NOT_GATE:
+  proves: "parse_meeting_url is best-effort metadata extraction, not a validation gate. When the parser raises ValueError\
+    \ (URL shape unrecognized), the model_validator catches it silently \u2014 downstream validation accepts (URL + platform)\
+    \ without parser output. Pure URL-only requests still work via the parser; the parser failing doesn't block (URL + platform)\
+    \ requests."
+  symptom: Parser failure rejects valid (URL + platform) requests; user sees 422 even though they supplied enough info. Defeats
+    the white-label escape hatch.
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/schemas.py
+  must_match: Parser doesn't recognize this URL shape
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+URL_PARSER_EXISTS:
+  proves: "MeetingCreate schema has parse_meeting_url \u2014 accepts meeting_url field directly"
+  symptom: "All Teams URL formats return 422 \u2014 MeetingCreate schema had no URL parser"
+  found: '2026-04-06'
+  type: grep
+  file: services/meeting-api/meeting_api/schemas.py
+  must_match: parse_meeting_url
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+URL_PLUS_PLATFORM_TRUST_MODEL:
+  proves: "MeetingCreate accepts (platform + meeting_url) as a valid request shape \u2014 schema validator does NOT require\
+    \ parser-extracted native_meeting_id. White-label / enterprise / never-seen-before Zoom URLs (LFX, AWS, Bloomberg, etc.)\
+    \ work via this path. Bot navigates the user-supplied URL directly; vendor backend resolves to canonical join. Avoids\
+    \ per-vendor URL-parser proliferation."
+  symptom: Each new white-label Zoom domain (zoom-lfx.platform.linuxfoundation.org today, AWS Chime tomorrow, etc.) requires
+    a per-vendor parser entry. Schema rejection forces users to translate URLs to canonical zoom.us shape they may not know.
+    Anti-architecture per project-owner principle 2026-04-27.
+  found: '2026-04-27'
+  type: grep
+  file: services/meeting-api/meeting_api/schemas.py
+  must_match: platform + meeting_url
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+VM_LITE_USES_MAKE:
+  proves: "VM lite setup uses make lite \u2014 tests the same path as new users"
+  symptom: VM setup uses manual docker commands that diverge from user docs, hiding deployment bugs
+  found: '2026-04-13'
+  type: grep
+  file: tests3/lib/vm-setup-lite.sh
+  must_match: make lite
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+ZOOM_LEAVE_MULTI_SELECTOR_FALLBACK:
+  proves: "services/vexa-bot/core/src/platforms/zoom/web/leave.ts uses a multi-selector fallback array for both the Leave\
+    \ button and the Confirm-Leave dialog button. Tries the strict footer-section selector first, then the broader button[aria-label=Leave]\
+    \ as fallback. Pre-fix the brittle attribute-scoped selector failed under transient DOM state when N bots targeted the\
+    \ same Zoom meeting concurrently \u2014 ~2/N hit a window where the footer-section attribute was momentarily absent, click\
+    \ never fired, bot exited with WebRTC peer still active = orphan participant in Zoom for 30-60s until keepalive timeout."
+  symptom: 'Zoom Web orphan-bot regression: multiple bots receive DELETE, exit cleanly from meeting-api''s perspective, but
+    stay visible as participants in the Zoom meeting from Zoom''s perspective until WebRTC keepalive expires.'
+  found: '2026-04-30'
+  type: grep
+  file: services/vexa-bot/core/src/platforms/zoom/web/leave.ts
+  must_match: "v0.10.5 \u2014 Multi-selector fallback"
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+ZOOM_WEB_AUDIO_RESEARCH_NOTE_EXISTS:
+  proves: "Wave 1 (release/260426-zoom) audio-research.md exists and contains a `## Recommendation` section \u2014 the structural\
+    \ marker that the note arrived at a recommendation, not just an inventory of findings."
+  symptom: 'Wave 1 closes without a research conclusion: audio-research.md is missing, empty, or contains scattered findings
+    with no recommendation section; Wave 2 has no documented direction.'
+  found: '2026-04-26'
+  type: grep
+  file: tests3/releases/260426-zoom/audio-research.md
+  must_match: '## Recommendation'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+ADMIN_API_UP:
+  proves: "admin-api responds with valid token \u2014 user management and login work"
+  symptom: Admin API not responding
+  type: http
+  url: $ADMIN_URL/admin/users?limit=1
+  expect_code: 200
+  needs_admin_token: true
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+AUTH_REJECTS_NO_TOKEN:
+  proves: "API rejects unauthenticated requests \u2014 auth middleware is active"
+  symptom: API accepts requests without auth token
+  type: http
+  url: $GATEWAY_URL/meetings
+  method: GET
+  expect_code:
+  - 401
+  - 403
+  - 422
+  auth: ''
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+BOTS_STATUS_NOT_422:
+  proves: "GET /bots/status returns 200 \u2014 no route collision with /bots/{meeting_id}"
+  symptom: GET /bots/status returns 422 due to route collision with /bots/{meeting_id}
+  found: '2026-04-06'
+  type: http
+  url: $GATEWAY_URL/bots/status
+  method: GET
+  expect_code: 200
+  auth: api_token
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+BOT_CREATE_OK:
+  proves: "POST /bots creates a bot without server error \u2014 runtime-api orchestrator is functional"
+  symptom: "Bot creation returns 500 \u2014 runtime-api cannot spawn bot containers (wrong orchestrator, missing image, or\
+    \ broken config)"
+  type: http
+  url: $GATEWAY_URL/bots
+  method: POST
+  expect_code:
+  - 200
+  - 201
+  - 202
+  - 403
+  - 409
+  auth: api_token
+  data: '{"platform":"google_meet","native_meeting_id":"healthcheck-bot","bot_name":"Health Check","automatic_leave":{"no_one_joined_timeout":30000}}'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+BROWSER_SESSION_OK:
+  proves: "POST /bots with mode=browser_session returns 201 \u2014 browser-session profile exists and works"
+  symptom: "Failed to start browser session container \u2014 browser-session profile missing from runtime-api"
+  type: http
+  url: $GATEWAY_URL/bots
+  method: POST
+  expect_code:
+  - 200
+  - 201
+  - 202
+  - 403
+  auth: api_token
+  data: '{"mode":"browser_session","bot_name":"Session Check"}'
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+CACHE_HEADERS:
+  proves: "dashboard HTML has cache control \u2014 deploy won't serve stale JS bundles"
+  symptom: "Old JS bundle served after deploy \u2014 HTML page cached by browser"
+  found: '2026-04-07'
+  type: http
+  url: $DASHBOARD_URL/
+  method: HEAD
+  expect_code: 200
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+DASHBOARD_LOGIN:
+  proves: "magic link login endpoint returns 200 \u2014 admin key is correctly configured"
+  symptom: "Dashboard magic link login returns 503 \u2014 admin key misconfigured"
+  found: '2026-04-07'
+  type: http
+  url: $DASHBOARD_URL/api/auth/send-magic-link
+  method: POST
+  expect_code: 200
+  data: '{"email":"test@vexa.ai"}'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+DASHBOARD_UP:
+  proves: "dashboard serves pages \u2014 user can access the UI"
+  symptom: Dashboard not responding
+  type: http
+  url: $DASHBOARD_URL/
+  expect_code: 200
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+GATEWAY_UP:
+  proves: "API gateway accepts connections \u2014 all client requests can reach backend"
+  symptom: API gateway not responding
+  type: http
+  url: $GATEWAY_URL/
+  expect_code: 200
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+GMEET_URL_PARSED:
+  proves: "Google Meet URL accepted by POST /bots \u2014 parser handles GMeet format"
+  symptom: Google Meet URL not accepted by POST /bots
+  type: http
+  url: $GATEWAY_URL/bots
+  method: POST
+  expect_code:
+  - 200
+  - 201
+  - 202
+  - 403
+  - 409
+  - 500
+  auth: api_token
+  data: '{"platform":"google_meet","meeting_url":"https://meet.google.com/abc-defg-hij","bot_name":"url-check-gm"}'
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
 INTERNAL_TRANSCRIPT_REQUIRES_AUTH:
   proves: "meeting-api /internal/transcripts/{id} rejects unauthenticated callers \u2014 CVE-2026-25058 / GHSA-w73r-2449-qwgh\
     \ closed"
   symptom: "Internal transcript endpoint returns 200 with transcripts to any unauthenticated caller \u2014 cross-tenant IDOR"
   found: '2026-04-19'
   type: http
-  url: http://meeting-api:8080/internal/transcripts/1
-  from_container: api-gateway
-  expect_code_any_of:
-  - 401
-  - 403
-  - 503
+  url: ''
+  method: INTERNAL_TRANSCRIPT_AUTH_CHECK
   modes:
   - compose
-  state: stateless
-  max_duration_sec: 5
+  - helm
+  state: stateful
+  max_duration_sec: 30
 INVALID_URL_REJECTED:
   proves: "garbage URLs rejected with 400/422 \u2014 input validation works"
   symptom: Invalid URL accepted instead of rejected
@@ -1141,71 +1744,6 @@ K8S_SECRETS_EXIST:
   - helm
   state: stateless
   max_duration_sec: 30
-LITE_PROCESS_BACKEND:
-  proves: "Dockerfile.lite uses process backend \u2014 lite is single-container, no Docker needed"
-  symptom: "Lite tries to spawn Docker containers for bots \u2014 fails without Docker socket, defeats single-container purpose"
-  found: '2026-04-13'
-  type: grep
-  file: deploy/lite/Dockerfile.lite
-  must_match: ORCHESTRATOR_BACKEND=process
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-LITE_RECORDING_ENABLED:
-  proves: "Dockerfile.lite has RECORDING_ENABLED=true \u2014 lite records audio by default"
-  symptom: "Recording disabled in lite \u2014 bots join meetings but produce no audio recordings"
-  found: '2026-04-13'
-  type: grep
-  file: deploy/lite/Dockerfile.lite
-  must_match: RECORDING_ENABLED=true
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-LOGIN_REDIRECT:
-  proves: login redirects to / (then /meetings), not to disabled /agent page
-  symptom: After login, user redirected to /agent (disabled feature) instead of /meetings
-  found: '2026-04-07'
-  type: grep
-  file: services/dashboard/src/app/login/page.tsx
-  must_match: push("/")
-  must_not_match: push\("/agent"\)
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-MAP_MEETING:
-  proves: dashboard API client maps native_meeting_id to platform_specific_id via mapMeeting
-  symptom: "Transcript page empty \u2014 getMeeting() skipped mapMeeting(), native_meeting_id not mapped"
-  found: '2026-04-07'
-  type: grep
-  file: services/dashboard/src/lib/api.ts
-  must_match: mapMeeting
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-MEETING_FAILURE_STAGE_MATCHES_TIMELINE:
-  proves: "after a meeting fails, JSONB data->>'failure_stage' matches the latest entry's 'to' field in data->'status_transition' — bot's in-process tracker stays in sync with callback emissions (v0.10.6 #294)"
-  symptom: "JSONB data.failure_stage stores the stale 'joining' value for meetings that failed during 'active' stage — tracker drifted out of sync with status_transition timeline; verified live on 2026-05-01 meeting 11356 (active for 83s, JSONB stored 'joining')"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.6-bot-stability.sh
-  step: meeting_failure_stage_matches_timeline
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 60
 MEETINGS_LIST:
   proves: "GET /meetings returns 200 \u2014 meeting list API works"
   symptom: GET /meetings not returning 200
@@ -1220,47 +1758,6 @@ MEETINGS_LIST:
   - helm
   state: stateful
   max_duration_sec: 30
-MINIO_BUCKET_SET:
-  proves: "MinIO bucket configured \u2014 file operations have a destination"
-  symptom: "Browser session save fails \u2014 MINIO_BUCKET not configured in meeting-api"
-  type: env
-  env_checks:
-  - service: meeting-api
-    var: MINIO_BUCKET
-    not_empty: true
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 10
-MINIO_BUCKET_WRITABLE:
-  proves: "MinIO bucket exists and is writable \u2014 recordings and browser state can be stored"
-  symptom: "No audio recording for meeting \u2014 MinIO bucket not created or not writable"
-  type: script
-  dispatch: MINIO_WRITABLE
-  from_tier: contract
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 30
-MINIO_ENDPOINT_SET:
-  proves: "meeting-api can reach MinIO \u2014 browser state save/restore and recordings will work"
-  symptom: "Authenticated bot join has no S3 config \u2014 MINIO_ENDPOINT not set in meeting-api"
-  found: '2026-04-07'
-  type: env
-  env_checks:
-  - service: meeting-api
-    var: MINIO_ENDPOINT
-    not_empty: true
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 10
 MINIO_UP:
   proves: "MinIO responds \u2014 recordings and browser state storage work"
   symptom: "MinIO not responding \u2014 recordings and browser state will fail"
@@ -1271,292 +1768,6 @@ MINIO_UP:
   - compose
   - helm
   state: stateless
-  max_duration_sec: 30
-NO_DEV_FALLBACK_COMPOSE:
-  proves: docker-compose.yml has no silent :-dev fallbacks on active (uncommented) lines
-  symptom: "IMAGE_TAG unset silently falls back to :dev \u2014 deploys untested dev images in production"
-  found: '2026-04-13'
-  type: grep
-  file: deploy/compose/docker-compose.yml
-  must_not_match: ^[^#]*:-dev\}
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-NO_EXPORT_IMAGE_TAG:
-  proves: "compose Makefile does not export IMAGE_TAG globally \u2014 prevents empty env var poisoning"
-  symptom: Make exports empty IMAGE_TAG before .env is read. Docker Compose inherits empty string which takes precedence over
-    --env-file, causing ${IMAGE_TAG:-dev} to resolve to dev
-  found: '2026-04-13'
-  type: grep
-  file: deploy/compose/Makefile
-  must_not_match: ^export IMAGE_TAG
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-NO_IMAGETOOLS_CREATE:
-  proves: publish/promote uses docker tag+push, not imagetools create (same SHA across tags)
-  symptom: "imagetools create wraps image in manifest list \u2014 latest/dev get different SHA than build tag, breaking traceability"
-  found: '2026-04-13'
-  type: grep
-  file: deploy/compose/Makefile
-  must_not_match: ^[^#]*imagetools create
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-NO_NESTED_COMPOSE_VARS:
-  proves: docker-compose.yml has no nested ${VAR:-${VAR}} on active (uncommented) lines
-  symptom: "BROWSER_IMAGE silently falls back to :dev \u2014 bots use wrong image, container creation 404/500"
-  found: '2026-04-13'
-  type: grep
-  file: deploy/compose/docker-compose.yml
-  must_not_match: ^[^#]*\$\{[^}]+:-[^}]*\$\{
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-PACKAGES_CI_WORKFLOW_EXISTS:
-  proves: .github/workflows/test-packages.yml exists and runs npm test per package in a matrix
-  symptom: packages/* has no PR-time CI; regressions slip in
-  found: '2026-04-21'
-  type: grep
-  file: .github/workflows/test-packages.yml
-  must_match: matrix:|packages/[a-z*-]+
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-PASSWORD_STORE_BASIC:
-  proves: "Chrome uses basic password store \u2014 cookies decryptable across sessions"
-  symptom: "Authenticated join fails \u2014 Chrome cookies encrypted, login not restored across sessions"
-  found: '2026-04-07'
-  type: grep
-  file: services/vexa-bot/core/src/constans.ts
-  must_match: password-store=basic
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-POSTGRES_NO_DISK_WARNING:
-  proves: "Postgres has no Linode disk-pressure recovery marker (`readme_to_recover` database absent) \u2014 volume is healthy"
-  symptom: Linode detected low disk / volume corruption; replaced the data volume and left a `readme_to_recover` database
-    behind. Application data is likely gone.
-  found: '2026-04-17'
-  type: script
-  dispatch: POSTGRES_NO_DISK_WARNING_CHECK
-  from_tier: health
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-RECORDING_SURVIVES_MID_MEETING_KILL:
-  proves: SIGKILL mid-recording leaves already-uploaded chunks durable in MinIO; Recording.status stays IN_PROGRESS (never
-    COMPLETED)
-  symptom: SIGKILL loses 100% of recording; Recording row orphans at uploading state with no media_files
-  found: '2026-04-21'
-  type: script
-  script: tests/recording-survives-sigkill.sh
-  modes:
-  - compose
-  state: stateful
-  mutates:
-  - minio:recordings/test-user/**
-  - meetings(test)
-  max_duration_sec: 180
-RECORDING_UPLOAD_SUPPORTS_CHUNK_SEQ:
-  proves: '/internal/recordings/upload endpoint signature accepts a chunk_seq: int form parameter'
-  symptom: bot chunk uploads fail because endpoint drops chunk_seq support
-  found: '2026-04-21'
-  type: grep
-  file: services/meeting-api/meeting_api/recordings.py
-  must_match: chunk_seq\s*:\s*int
-  modes:
-  - lite
-  - compose
-  state: stateless
-  max_duration_sec: 5
-REDIS_CLIENT_HARDENED_TIMEOUTS:
-  proves: "Every aioredis.from_url() call site across services configures bounded socket_timeout + health_check_interval; no production client can sit forever inside `await` on a dead TCP connection (#267 silent-hang root cause class)"
-  symptom: "Without bounded socket config, redis-py awaits the socket forever; OS TCP keepalive default is 7200s. Any Redis pod kill, kube-proxy conntrack flip, NAT timeout silently hangs the consumer for hours. Reproduced 2026-04-26: 10.5h silent data loss, 20 lost transcripts."
-  found: '2026-04-26'
-  fix_release: v0.10.5
-  type: grep
-  file: services
-  must_match: 'aioredis\.from_url\([^)]*socket_timeout[^)]*health_check_interval'
-  multiline: true
-  recursive: true
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 10
-REDIS_UP:
-  proves: "Redis responds to PING \u2014 WebSocket pub/sub, session state, and caching work"
-  symptom: "Redis not responding \u2014 WS, session state, and pub/sub will fail"
-  type: script
-  dispatch: REDIS_PING
-  from_tier: health
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-ROUTE_COLLISION:
-  proves: bot detail route is /bots/id/{id}, not /bots/{id} which collides with /bots/status
-  symptom: "GET /bots/status returns 422 \u2014 Starlette matches /bots/{meeting_id} before /bots/status"
-  found: '2026-04-06'
-  type: grep
-  file: services/meeting-api/meeting_api/meetings.py
-  must_match: /bots/id/{meeting_id}
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-RUNTIME_API_EXIT_CALLBACK_DURABLE:
-  proves: "runtime-api exit callback delivery survives a meeting-api outage \u2014 pending record replays after consumer recovers"
-  symptom: short meeting-api outage during bot exit orphans the meeting in status='active' forever
-  found: '2026-04-21'
-  type: script
-  script: tests/runtime-api-exit-callback-durable.sh
-  modes:
-  - compose
-  state: stateful
-  mutates:
-  - meeting(fixture)
-  - runtime-api:redis:pending_callbacks/*
-  max_duration_sec: 180
-RUNTIME_API_IDLE_LOOP_SWEEPS_PENDING_CALLBACKS:
-  proves: "runtime-api lifecycle.py idle_loop references pending-callback iteration \u2014 the sweep is wired"
-  symptom: meeting stuck status='active' forever after callback delivery gives up
-  found: '2026-04-21'
-  type: grep
-  file: services/runtime-api/runtime_api/lifecycle.py
-  must_match: list_pending_callbacks|pending_callbacks.*idle_loop|idle_loop.*pending_callback
-  multiline: true
-  modes:
-  - lite
-  - compose
-  state: stateless
-  max_duration_sec: 5
-RUNTIME_API_STOP_GRACE_MATCHES_POD_SPEC:
-  proves: "runtime-api kubernetes.py stop() grace_period_seconds default \u226530 matches the pod spec's terminationGracePeriodSeconds"
-  symptom: grace-period override cuts bot shutdown short; final chunk upload aborted
-  found: '2026-04-21'
-  type: grep
-  file: services/runtime-api/runtime_api/backends/kubernetes.py
-  must_match: timeout:\s*int\s*=\s*(3[0-9]|[4-9][0-9]|[1-9][0-9]{2,})
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 5
-RUNTIME_API_UP:
-  proves: "runtime-api responds \u2014 bot container lifecycle management works"
-  symptom: "Runtime API not responding \u2014 bot creation will fail"
-  type: script
-  dispatch: RUNTIME_API_HEALTH
-  from_tier: health
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-RUNTIME_API_URL_SET:
-  proves: "meeting-api can reach runtime-api \u2014 bot container creation will work"
-  symptom: "Bot creation fails \u2014 meeting-api cannot reach runtime-api"
-  type: env
-  env_checks:
-  - service: meeting-api
-    var: RUNTIME_API_URL
-    not_empty: true
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 10
-SECURE_COOKIE_ADMIN_VERIFY:
-  proves: cookie Secure flag based on actual protocol, not NODE_ENV (admin-verify)
-  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
-  found: '2026-04-07'
-  type: grep
-  file: services/dashboard/src/app/api/auth/admin-verify/route.ts
-  must_match: isSecureRequest()
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-SECURE_COOKIE_NEXTAUTH:
-  proves: cookie Secure flag based on actual protocol, not NODE_ENV (nextauth)
-  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
-  found: '2026-04-07'
-  type: grep
-  file: services/dashboard/src/app/api/auth/[...nextauth]/route.ts
-  must_match: isSecureRequest()
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-SECURE_COOKIE_SEND_MAGIC_LINK:
-  proves: cookie Secure flag based on actual protocol, not NODE_ENV (send-magic-link)
-  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
-  found: '2026-04-07'
-  type: grep
-  file: services/dashboard/src/app/api/auth/send-magic-link/route.ts
-  must_match: isSecureRequest()
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-SECURE_COOKIE_VERIFY:
-  proves: cookie Secure flag based on actual protocol, not NODE_ENV (verify)
-  symptom: "Login loop on HTTP \u2014 Secure cookie flag set based on NODE_ENV instead of actual protocol"
-  found: '2026-04-07'
-  type: grep
-  file: services/dashboard/src/app/api/auth/verify/route.ts
-  must_match: isSecureRequest()
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-SEGMENT_PIPELINE:
-  proves: "segments injected into Redis appear in the REST transcript \u2014 collector pipeline works end-to-end"
-  symptom: "Transcript empty despite audio being captured \u2014 collector not processing Redis stream, or segments not reaching\
-    \ Postgres"
-  type: script
-  dispatch: SEGMENT_PIPELINE
-  from_tier: contract
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
   max_duration_sec: 30
 TEAMS_URL_CHANNEL:
   proves: Teams channel meeting URL accepted or known gap
@@ -1666,6 +1877,262 @@ TEAMS_URL_STANDARD:
   - helm
   state: stateful
   max_duration_sec: 30
+WEBHOOK_SSRF_INPUT_REJECTED:
+  proves: "PUT /user/webhook rejects SSRF URLs (private/link-local/metadata/internal hostnames) \u2014 CVE-2026-25883 / GHSA-fhr6-8hff-cvg4\
+    \ regression guard"
+  symptom: A valid API key can store a webhook_url pointing at internal services (redis, postgres, 169.254.169.254) without
+    rejection
+  found: '2026-04-19'
+  type: http
+  url: ''
+  method: WEBHOOK_SSRF_CHECK
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+ADMIN_API_DB_EXISTS:
+  proves: "The `vexa` database exists and is reachable from admin-api \u2014 /login won't 500 on fresh boot"
+  symptom: "/login returns 500 'Server Configuration Error'; admin-api crashes with asyncpg.InvalidCatalogNameError: database\
+    \ \\\"vexa\\\" does not exist (DB got dropped after initial bootstrap \u2014 e.g. Linode low-disk auto-recovery wiped\
+    \ it)"
+  found: '2026-04-17'
+  type: script
+  dispatch: ADMIN_API_DB_EXISTS_CHECK
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+BOT_RECORDING_ENABLED:
+  proves: "bots are created with recordingEnabled=true \u2014 audio will be captured and uploaded"
+  symptom: "No audio recording for meeting \u2014 RECORDING_ENABLED env var not set or recordingEnabled=false in BOT_CONFIG"
+  type: script
+  dispatch: BOT_RECORDING_CHECK
+  from_tier: contract
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+BOT_STATUS_TRANSITIONS:
+  proves: "bot status transitions from requested within 30s \u2014 callbacks from bot\u2192meeting-api work"
+  symptom: "Bot stuck in 'requested' \u2014 status change callbacks not reaching meeting-api (wrong image, missing callback\
+    \ URL, network issue)"
+  type: script
+  dispatch: BOT_STATUS_CHECK
+  from_tier: contract
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+BROWSER_SESSION_CDP:
+  proves: "browser session CDP proxy is reachable \u2014 gateway can connect to browser container"
+  symptom: "Failed to reach browser container: Name or service not known \u2014 pod IP not resolved in K8s"
+  type: script
+  dispatch: BROWSER_SESSION_CDP_CHECK
+  from_tier: contract
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+CORS_PREFLIGHT:
+  proves: "OPTIONS preflight returns 200 for any origin \u2014 CORS_ORIGINS defaults to wildcard"
+  symptom: "OPTIONS /bots/status returns 400 for external origins \u2014 browser clients blocked by CORS"
+  found: '2026-04-13'
+  type: script
+  dispatch: CORS_PREFLIGHT
+  from_tier: contract
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+DASHBOARD_MEETINGS_NOT_ALL_FAILED:
+  proves: "Either /meetings is empty (clean reset) OR at least one non-failed meeting exists \u2014 the UI won't surface a\
+    \ 'everything broken' picture to a human validator"
+  symptom: /meetings page shows 20+ rows and every single one is status=failed (test-pollution from prior runs accumulating;
+    or systemic failure). Either way, a human looking at the dashboard gets a misleading signal.
+  found: '2026-04-17'
+  type: script
+  dispatch: DASHBOARD_MEETINGS_NOT_ALL_FAILED_CHECK
+  from_tier: contract
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+DASHBOARD_WEBHOOKS_ALL_EVENT_TYPES:
+  proves: "The /webhooks dashboard page surfaces status-change/started/bot.failed deliveries, not just meeting.completed \u2014\
+    \ UI reads meeting.data.webhook_deliveries[] (plural), not only webhook_delivery (singular)"
+  symptom: User sees only `meeting.completed` rows on /webhooks even when backend delivered other event types (regression
+    of dashboard /api/webhooks/deliveries rollup)
+  found: '2026-04-17'
+  type: script
+  dispatch: DASHBOARD_WEBHOOKS_ALL_EVENT_TYPES_CHECK
+  from_tier: contract
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 30
+DASHBOARD_WS_URL:
+  proves: "dashboard /api/config returns a browser-resolvable wsUrl \u2014 WebSocket will connect"
+  symptom: "Dashboard WS broken \u2014 wsUrl contains internal Docker hostname (api-gateway, etc.) instead of localhost or\
+    \ public host"
+  found: '2026-04-08'
+  type: script
+  dispatch: DASHBOARD_WS_URL
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+DB_POOL_NO_EXHAUSTION:
+  proves: meeting-api DB connection pool does not exhaust under sequential requests
+  symptom: "meeting-api returns 504 after a few requests \u2014 DB connection pool exhausted (idle in transaction leak)"
+  type: script
+  dispatch: DB_POOL_CHECK
+  from_tier: contract
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+DB_SCHEMA_ALIGNED:
+  proves: "database schema has all required columns \u2014 schema sync ran successfully"
+  symptom: "Services crash or return 500 \u2014 missing columns, tables, or indexes after DB migration"
+  type: script
+  dispatch: DB_SCHEMA_CHECK
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+DB_TOKENS_HAVE_SCOPES:
+  proves: "API tokens have scopes assigned \u2014 backfill migration ran"
+  symptom: "Tokens have empty scopes \u2014 scope enforcement will reject all requests"
+  type: script
+  dispatch: DB_TOKEN_SCOPES_CHECK
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+DB_USERS_EXIST:
+  proves: "users table has data \u2014 not an empty database"
+  symptom: "No users in database \u2014 dump not loaded or load failed silently"
+  type: script
+  dispatch: DB_USERS_CHECK
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+HELM_CHART_VALID:
+  proves: "helm chart passes lint \u2014 templates are well-formed"
+  symptom: "helm lint fails \u2014 chart has structural errors"
+  type: script
+  dispatch: HELM_LINT
+  from_tier: static
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+HELM_TEMPLATE_RENDERS:
+  proves: "helm template renders without errors \u2014 values and templates are consistent"
+  symptom: "helm template fails \u2014 missing required values or template syntax error"
+  type: script
+  dispatch: HELM_TEMPLATE
+  from_tier: static
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+MINIO_BUCKET_WRITABLE:
+  proves: "MinIO bucket exists and is writable \u2014 recordings and browser state can be stored"
+  symptom: "No audio recording for meeting \u2014 MinIO bucket not created or not writable"
+  type: script
+  dispatch: MINIO_WRITABLE
+  from_tier: contract
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+POSTGRES_NO_DISK_WARNING:
+  proves: "Postgres has no Linode disk-pressure recovery marker (`readme_to_recover` database absent) \u2014 volume is healthy"
+  symptom: Linode detected low disk / volume corruption; replaced the data volume and left a `readme_to_recover` database
+    behind. Application data is likely gone.
+  found: '2026-04-17'
+  type: script
+  dispatch: POSTGRES_NO_DISK_WARNING_CHECK
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+REDIS_UP:
+  proves: "Redis responds to PING \u2014 WebSocket pub/sub, session state, and caching work"
+  symptom: "Redis not responding \u2014 WS, session state, and pub/sub will fail"
+  type: script
+  dispatch: REDIS_PING
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+RUNTIME_API_UP:
+  proves: "runtime-api responds \u2014 bot container lifecycle management works"
+  symptom: "Runtime API not responding \u2014 bot creation will fail"
+  type: script
+  dispatch: RUNTIME_API_HEALTH
+  from_tier: health
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 30
+SEGMENT_PIPELINE:
+  proves: "segments injected into Redis appear in the REST transcript \u2014 collector pipeline works end-to-end"
+  symptom: "Transcript empty despite audio being captured \u2014 collector not processing Redis stream, or segments not reaching\
+    \ Postgres"
+  type: script
+  dispatch: SEGMENT_PIPELINE
+  from_tier: contract
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
 TRANSCRIPTION_TOKEN_VALID:
   proves: "transcription API token accepted \u2014 bots can convert audio to text"
   symptom: "Transcription returns 403 \u2014 TRANSCRIPTION_SERVICE_TOKEN expired or invalid. Bots capture audio but produce\
@@ -1692,75 +2159,6 @@ TRANSCRIPTION_UP:
   - helm
   state: stateless
   max_duration_sec: 30
-TRANSCRIPT_RENDERING_DEDUP_TESTS_PASS:
-  proves: "packages/transcript-rendering npm test passes \u2014 dedup-prefers-confirmed fix + existing invariants"
-  symptom: "dedup regression \u2014 pending segments stuck italic or confirmed dropped"
-  found: '2026-04-21'
-  type: script
-  script: tests/package-tests.sh
-  step: transcript_rendering
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 120
-URL_PARSER_EXISTS:
-  proves: "MeetingCreate schema has parse_meeting_url \u2014 accepts meeting_url field directly"
-  symptom: "All Teams URL formats return 422 \u2014 MeetingCreate schema had no URL parser"
-  found: '2026-04-06'
-  type: grep
-  file: services/meeting-api/meeting_api/schemas.py
-  must_match: parse_meeting_url
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-VEXA_BOT_NO_HIGH_NPM_VULNS:
-  proves: services/vexa-bot + services/vexa-bot/core npm audit report 0 HIGH and 0 CRITICAL vulnerabilities
-  symptom: vexa-bot ships transitive basic-ftp with CRLF injection / DoS (GHSA-6v7q-wjvx-w8wg, GHSA-chqc-8p9q-pq6q, GHSA-rp42-5vxx-qpwr)
-  found: '2026-04-19'
-  type: script
-  script: tests/security-hygiene.sh
-  step: vexa_bot_npm_audit
-  modes:
-  - lite
-  - compose
-  state: stateless
-  max_duration_sec: 60
-VM_LITE_USES_MAKE:
-  proves: "VM lite setup uses make lite \u2014 tests the same path as new users"
-  symptom: VM setup uses manual docker commands that diverge from user docs, hiding deployment bugs
-  found: '2026-04-13'
-  type: grep
-  file: tests3/lib/vm-setup-lite.sh
-  must_match: make lite
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-WEBHOOK_SSRF_INPUT_REJECTED:
-  proves: "PUT /user/webhook rejects SSRF URLs (private/link-local/metadata/internal hostnames) \u2014 CVE-2026-25883 / GHSA-fhr6-8hff-cvg4\
-    \ regression guard"
-  symptom: A valid API key can store a webhook_url pointing at internal services (redis, postgres, 169.254.169.254) without
-    rejection
-  found: '2026-04-19'
-  type: http
-  method: PUT
-  url: $GATEWAY_URL/user/webhook
-  headers:
-    X-API-Key: $API_TOKEN
-    Content-Type: application/json
-  body: '{"webhook_url":"http://redis:6379/"}'
-  expect_code_any_of:
-  - 400
-  - 422
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 10
 WS_PING_PONG:
   proves: "WebSocket connection works \u2014 dashboard live updates will function"
   symptom: WebSocket not responding to ping
@@ -1773,604 +2171,20 @@ WS_PING_PONG:
   - helm
   state: stateful
   max_duration_sec: 30
-# \u2500\u2500 v0.10.5.3 cycle additions (Pack M, O, T, P, C, D-1, D-2, D-3, H) \u2500\u2500
-BOT_RECORDING_CHUNK_BUFFER_TRIMMED:
-  proves: "bot recording.ts splices chunks from __vexaRecordedChunks after upload (gmeet + teams) so the buffer cap stays at 10 max"
-  symptom: "__vexaRecordedChunks grows unbounded for the meeting lifetime; 10+ MB at 24 min real-conversation; tab-process pressure \u2192 page navigation \u2192 recording.js:102 Execution context destroyed"
-  found: '2026-05-01'
+advisory-dependency-floors:
   type: script
-  script: tests/v0.10.5.3-static-greps.sh
-  step: chunk_buffer_trim
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_GMEET_LONG_RECORDING_NO_LEAK:
-  proves: "GMeet bot dispatched at FIXTURE_GMEET_MULTIPARTY_URL with recording_enabled=true survives 25+ min without page-navigation crash; bot_resources.peak_memory_bytes stays bounded"
-  symptom: "long-duration crash class \u2014 Execution context destroyed at recording.js:102 around 14-24 min mark on real-conversation meetings"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-runtime-smokes.sh
-  step: gmeet_long_recording
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 1800
-BOT_TEAMS_LONG_RECORDING_NO_LEAK:
-  proves: "Teams bot dispatched at FIXTURE_TEAMS_MULTIPARTY_URL with recording_enabled=true survives 25+ min cleanly"
-  symptom: "same chunk-buffer leak class on Teams platform"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-runtime-smokes.sh
-  step: teams_long_recording
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 1800
-BOT_ZOOM_LONG_RECORDING_NO_LEAK:
-  proves: "Zoom Web bot dispatched at FIXTURE_ZOOM_URL with recording_enabled=true survives \u226560s; verifies no equivalent leak in Zoom's parecord paradigm"
-  symptom: "if Zoom has a different unbounded accumulator (defensive check)"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-runtime-smokes.sh
-  step: zoom_long_recording
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 1800
-BOT_STDOUT_STREAM_TO_REDIS:
-  proves: "bot maintains an in-process ring buffer of last ~200 structured-JSON log lines (logBuffer in utils/log.ts) \u2014 Pack O Phase 1; getLogBuffer() exported for performGracefulLeave"
-  symptom: "every long-duration crash investigation since v0.10.5 ship has been forensic-blind because bot stdout dies with the pod and was not flushed to JSONB"
-  found: '2026-05-01'
-  type: grep
-  file: services/vexa-bot/core/src/utils/log.ts
-  must_match: 'export function getLogBuffer'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-MEETING_API_FLUSH_BOT_LOGS_ON_TERMINAL:
-  proves: "meeting-api bot_status_change_callback persists payload.bot_logs into meetings.data.bot_logs JSONB on terminal status (failed/completed) with a 50 KB cap"
-  symptom: "bot ring-buffer is sent on the wire but meeting-api drops it; meetings.data.bot_logs never populated"
-  found: '2026-05-01'
-  type: grep
-  file: services/meeting-api/meeting_api/callbacks.py
-  must_match: 'BOT_LOGS_MAX_BYTES'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-MEETING_BOT_LOGS_FIELD_PRESENT_ON_FAILED:
-  proves: "after a forced bot crash, meeting row's data.bot_logs field is populated with the structured-log lines preserving the crash moment"
-  symptom: "operator-side forensic gap: failed meetings have no log evidence to diagnose"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-runtime-smokes.sh
-  step: meeting_bot_logs_present
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 120
-BOT_RESOURCE_SAMPLER_RUNS:
-  proves: "bot's main loop has a 30s cgroup-stat poller (startBotResourceSampler in index.ts) emitting structured log lines with memory_bytes + cpu_usage_usec from /sys/fs/cgroup"
-  symptom: "no per-meeting memory/CPU telemetry; cannot answer 'did the bot OOM at minute 23'"
-  found: '2026-05-01'
-  type: grep
-  file: services/vexa-bot/core/src/index.ts
-  must_match: 'cgroup.*memory\.current'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-MEETING_BOT_RESOURCES_FIELD_PRESENT:
-  proves: "meeting row's data.bot_resources field has peak_memory_bytes + cpu_usage_usec_total + samples after meeting completes"
-  symptom: "Pack T resource summary not making it through to the JSONB"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-runtime-smokes.sh
-  step: meeting_bot_resources_present
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 120
-BOT_NO_UNJUSTIFIED_FALLBACKS:
-  proves: "soft-grep across services/vexa-bot/core/src/ surfaces fallback patterns; pass with WARN on existing 117 patterns; develop-stage rule is primary enforcement"
-  symptom: "new fallback added without #NNN issue ref \u2014 repeats the v0.10.5.2 chunk-buffer leak pattern"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-no-fallbacks-pii.sh
-  step: bot_fallback_audit
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 10
-HALLUCINATION_CORPUS_PRESENT:
-  proves: "services/vexa-bot/core/src/services/hallucinations/{en,es,pt,ru}.txt exist + non-empty (each \u2265 5 phrase lines). Bot image build copies these to dist; whisper hallucination filter loads them at runtime to drop 'thanks for watching' / 'subscribe to my channel' class artifacts before publishing to Redis."
-  symptom: "FM-274 regression class: phrase corpus deleted/renamed/moved. Bot ships with empty filter. Long-form whisper hallucinations leak into prod transcripts. Originally regressed when WhisperLive was removed (v0.10.0 commit e55e878) and corpus went with it; FM-274 detected by orphan static check that wasn't bound to any DoD until v0.10.5.3."
-  found: '2026-05-02'
-  fix_release: v0.10.5.3
-  type: script
-  script: tests/v0.10.5.3-hallucination-corpus.sh
-  step: HALLUCINATION_CORPUS_PRESENT
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-HALLUCINATION_CORPUS_GITIGNORE_EXCEPTION:
-  proves: ".gitignore has the '!services/vexa-bot/core/src/services/hallucinations/*.txt' exception, protecting corpus from the global '*.txt' rule that would otherwise silently drop the files on git add."
-  symptom: "global '*.txt' rule silently re-disappears the corpus on next git add (exactly how the original v0.10.0 regression slipped past CI \u2014 deleted corpus was never visible as 'missing files' because *.txt is gitignored)."
-  found: '2026-05-02'
-  fix_release: v0.10.5.3
-  type: script
-  script: tests/v0.10.5.3-hallucination-corpus.sh
-  step: HALLUCINATION_CORPUS_GITIGNORE_EXCEPTION
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-HALLUCINATION_CORPUS_BUILD_FAIL_LOUD:
-  proves: "services/vexa-bot/core/package.json `build` script chains the cp step with '&&' (fails fast on missing source), NOT '2>/dev/null;' (silent failure that masked FM-274 from v0.10.0 to v0.10.5.2)."
-  symptom: "build script swallows cp's missing-source error \u2014 build always succeeds even when corpus didn't make it to dist. Empty filter ships to runtime. Audit-categories \u00a76 (operational hygiene): silent-failure pattern."
-  found: '2026-05-02'
-  fix_release: v0.10.5.3
-  type: script
-  script: tests/v0.10.5.3-hallucination-corpus.sh
-  step: HALLUCINATION_CORPUS_BUILD_FAIL_LOUD
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-RELEASE_DOCS_NO_PII:
-  proves: "tests3/releases/<id>/* artifacts use anonymized customer refs (customer-A, customer-B, ...); no real-looking emails outside @redacted/@example.com/@vexa.ai/@anthropic.com"
-  symptom: "PII leak into OSS public repo (real names + emails) like the v0.10.5.2 cycle"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-no-fallbacks-pii.sh
-  step: release_docs_pii
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 10
-MEETING_API_USER_STOP_IS_COMPLETED:
-  proves: "user-initiated DELETE during awaiting_admission produces meeting status=completed (not failed) with completion_reason=stopped_before_admission"
-  symptom: "v0.10.5.2 cycle bug: user-stops were classified as failed because STOPPED_BEFORE_ADMISSION was in _explicit_failure_reasons set"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-runtime-smokes.sh
-  step: user_stop_completed
+  script: tests/static/advisory-dependency-floors.sh
   modes:
   - lite
   - compose
   - helm
   state: stateful
-  max_duration_sec: 120
-DASHBOARD_RENDERS_LOCAL_TZ:
-  proves: "dashboard meeting card uses parseUTCTimestamp + toLocaleString with Intl.DateTimeFormat resolved tz"
-  symptom: "meeting times rendered in tz-shifted form (#265) due to inconsistent parseUTCTimestamp usage"
-  found: '2026-05-01'
-  type: grep
-  file: services/dashboard/src/components/meetings/meeting-card.tsx
-  must_match: 'toLocaleString.*Intl\.DateTimeFormat'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
   max_duration_sec: 5
-DASHBOARD_NO_INLINE_DOCS_LINKS:
-  proves: "dashboard header docs link uses getDocsUrl helper (external docs.vexa.ai); no inline href=/docs at startup pages"
-  symptom: "dashboard.vexa.ai/docs route reachable; users land on internal docs instead of canonical docs.vexa.ai"
-  found: '2026-05-01'
-  type: grep
-  file: services/dashboard/src/components/layout/header.tsx
-  must_match: 'getDocsUrl'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-MEETING_API_PRESIGNED_AUDIO_URL:
-  proves: "meeting-api /recordings/{id}/media/{mid}/download returns a presigned S3/MinIO URL when storage_backend in {s3, minio}"
-  symptom: "audio playback always proxies through /raw which buffers the whole file in service memory (#288 \u2014 10s dead-air on 24-min recordings)"
-  found: '2026-05-01'
-  type: grep
-  file: services/meeting-api/meeting_api/recordings.py
-  must_match: 'get_presigned_url\(mf\.storage_path'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-DASHBOARD_AUDIO_STREAMS:
-  proves: "dashboard's getRecordingAudioUrl async-fetches /download response and returns presigned URL (or /raw for local backend) \u2014 browser streams directly with HTTP Range"
-  symptom: "every audio fragment src points at /raw proxy; full-file pre-download before playback"
-  found: '2026-05-01'
-  type: grep
-  file: services/dashboard/src/lib/api.ts
-  must_match: 'getRecordingAudioUrl.*async'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-HELM_DEPLOYMENT_MAX_UNAVAILABLE_ZERO:
-  proves: "vexa.deploymentStrategy helper renders maxUnavailable: 0 + maxSurge: 1 (zero-downtime rolling update)"
-  symptom: "v0.10.5.2 outage class: maxUnavailable: 1 + replicaCount: 1 killed OLD pod before NEW Ready, 502s during any image bump"
-  found: '2026-05-01'
-  type: grep
-  file: deploy/helm/charts/vexa/templates/_helpers.tpl
-  must_match: 'maxUnavailable: 0'
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 5
-HELM_REPLICA_COUNT_TWO_FOR_STATELESS:
-  proves: "values.yaml mcp.replicaCount: 2 (matches the rest of stateless services)"
-  symptom: "single-replica stateless service has zero-downtime exposure during rolling-update; v0.10.5.2 outage shape"
-  found: '2026-05-01'
-  type: script
-  script: tests/v0.10.5.3-static-greps.sh
-  step: helm_replica_count_two
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 5
-HELM_UPGRADE_PREFLIGHT_IMAGE_CHECK:
-  proves: "Makefile release-helm-upgrade-safe target verifies every chart-rendered image:tag exists on Docker Hub via docker manifest inspect before applying helm"
-  symptom: "v0.10.5.2 outage: silent build failures pushed non-existent image tags into helm values; upgrade applied them anyway \u2192 ImagePullBackOff outage"
-  found: '2026-05-01'
-  type: grep
-  file: Makefile
-  must_match: 'docker manifest inspect'
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 5
-HELM_UPGRADE_ATOMIC_DEFAULT:
-  proves: "release-helm-upgrade-safe always calls helm upgrade with --atomic --wait --timeout 5m flags"
-  symptom: "non-atomic upgrade leaves prod broken on failed image-pull; manual rollback needed"
-  found: '2026-05-01'
-  type: grep
-  file: Makefile
-  must_match: 'helm upgrade.*--atomic.*--wait.*--timeout'
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 5
-# ── v0.10.6 cycle additions (Pack U — audio recording unification) ────
-SHARED_AUDIO_PIPELINE_MODULE_EXISTS:
-  proves: "shared services/audio-pipeline.ts exports AudioChunk, AudioCaptureSource, UnifiedRecordingPipeline — single module driving capture lifecycle for all 3 platforms"
-  symptom: "recording capture logic duplicated across googlemeet/recording.ts (1003 LOC) + msteams/recording.ts (1490 LOC) + zoom/web/recording.ts (225 LOC); fixes must be applied N times; Pack M trim diverged between platforms"
-  found: '2026-05-02'
-  type: grep
-  file: services/vexa-bot/core/src/services/audio-pipeline.ts
-  must_match: 'class UnifiedRecordingPipeline'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-GMEET_RECORDING_USES_SHARED_PIPELINE:
-  proves: "googlemeet/recording.ts imports UnifiedRecordingPipeline + MediaRecorderCapture from services/audio-pipeline; no longer hand-rolls MediaRecorder + chunk-buffer logic"
-  symptom: "GMeet has its own copy of MediaRecorder boilerplate; Pack M's chunk-buffer cap was applied here separately from Teams"
-  found: '2026-05-02'
-  type: grep
-  file: services/vexa-bot/core/src/platforms/googlemeet/recording.ts
-  must_match: 'from .*services/audio-pipeline'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-TEAMS_RECORDING_USES_SHARED_PIPELINE:
-  proves: "msteams/recording.ts imports UnifiedRecordingPipeline + MediaRecorderCapture from services/audio-pipeline; no longer hand-rolls MediaRecorder + chunk-buffer logic"
-  symptom: "Teams duplicates ~80% of GMeet recording.ts; chunk-buffer trim drift risk"
-  found: '2026-05-02'
-  type: grep
-  file: services/vexa-bot/core/src/platforms/msteams/recording.ts
-  must_match: 'from .*services/audio-pipeline'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-ZOOM_WEB_RECORDING_USES_SHARED_PIPELINE:
-  proves: "zoom/web/recording.ts imports UnifiedRecordingPipeline + PulseAudioCapture from services/audio-pipeline; chunked upload model"
-  symptom: "Zoom Web's parecord uploads only one final WAV at meeting-end; bot crash = total audio loss (GH #296)"
-  found: '2026-05-02'
-  type: grep
-  file: services/vexa-bot/core/src/platforms/zoom/web/recording.ts
-  must_match: 'from .*services/audio-pipeline'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-ZOOM_WEB_UPLOADS_CHUNKS_PERIODICALLY:
-  proves: "PulseAudioCapture in services/audio-pipeline.ts emits 15s WAV chunks during a Zoom Web meeting (uploadChunk fires multiple times before finalize)"
-  symptom: "Zoom Web today uploads zero chunks during a meeting and one final WAV at the end; SIGKILL mid-meeting = all audio lost"
-  found: '2026-05-02'
-  type: grep
-  file: services/vexa-bot/core/src/services/audio-pipeline.ts
-  must_match: 'class PulseAudioCapture'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-PLATFORM_RECORDING_TS_LINE_BUDGET:
-  proves: "after Pack U unification, every platform recording.ts is ≤200 LOC (just selectors + DOM glue + capture-source instantiation; all upload + buffer + lifecycle logic moved to shared)"
-  symptom: "duplicated capture code rots out of sync; Pack M-style fix-once-apply-N drift"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: platform_recording_line_budget
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-NO_PER_PLATFORM_MASTER_CONSTRUCTION:
-  proves: "no platform recording.ts retains __vexaSaveRecordingBlob or equivalent bot-side master assembly — master is constructed exclusively server-side by recording_finalizer.py"
-  symptom: "bot-side master construction depends on graceful-leave firing; Pack M shrunk the buffer it relies on; crash-mid-meeting produces no master at all"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: no_bot_master_construction
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-SERVER_SIDE_MASTER_FINALIZER_EXISTS:
-  proves: "services/meeting-api/meeting_api/recording_finalizer.py defines async finalize_recording_master(meeting_id, db) that lists chunks, dispatches concat by format (webm|wav), and updates media_file.storage_path"
-  symptom: "no server-side path to assemble the master; download/transcribe pipelines depend on bot-side construction"
-  found: '2026-05-02'
-  type: grep
-  file: services/meeting-api/meeting_api/recording_finalizer.py
-  must_match: 'async def finalize_recording_master'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BOT_EXIT_CALLBACK_INVOKES_FINALIZER:
-  proves: "callbacks.py:bot_exit_callback awaits finalize_recording_master BEFORE update_meeting_status — so by the time meeting.status is terminal, master.{webm|wav} exists at media_file.storage_path"
-  symptom: "race window between status flip and master build allows /transcribe to read stale storage_path"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: finalizer_invoked_in_exit_callback
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-FINALIZER_BEFORE_STATUS_FLIP:
-  proves: "in callbacks.py:bot_exit_callback the finalize_recording_master await appears textually BEFORE the update_meeting_status await on every code path"
-  symptom: "if status flips first, /transcribe + dashboard playback can fetch a recording.storage_path that still points at a single chunk"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: finalizer_before_status
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-FINALIZER_IS_IDEMPOTENT:
-  proves: "second invocation of finalize_recording_master for the same meeting is a no-op — master.webm already exists, function returns early without re-uploading"
-  symptom: "non-idempotent retry doubles storage cost + risks corrupting master under concurrent invocation (idle_loop retry race)"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-runtime-smokes.sh
-  step: finalizer_idempotency
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 60
-MASTER_AT_STORAGE_PATH:
-  proves: "after a normal-completion meeting, media_file.storage_path points at audio/master.{webm|wav}, NOT at audio/000000.{webm|wav} (which is the first chunk)"
-  symptom: "post-Pack-M, storage_path points at the broken bot-uploaded master fragment; pre-Pack-M, same path but bot-built whole-master; either way bot-controlled"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-runtime-smokes.sh
-  step: master_at_storage_path
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 300
-BOT_KILL_RECORDING_PLAYABLE_GMEET:
-  proves: "after SIGKILL'ing a GMeet bot mid-recording, idle_loop fires exit callback → finalize_recording_master builds master.webm from chunks already in MinIO → master is ffprobe-playable with duration ≥ chunks_uploaded × 15s"
-  symptom: "today, crash-mid-meeting GMeet recording is unrecoverable: storage_path stays at last chunk (Cluster-only, no init segment); ffprobe fails"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-runtime-smokes.sh
-  step: bot_kill_gmeet_master_playable
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 600
-BOT_KILL_RECORDING_PLAYABLE_TEAMS:
-  proves: "after SIGKILL'ing a Teams bot mid-recording, idle_loop fires exit callback → master.webm built → ffprobe-playable"
-  symptom: "same crash-recovery class as GMeet on Teams platform"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-runtime-smokes.sh
-  step: bot_kill_teams_master_playable
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 600
-BOT_KILL_RECORDING_PLAYABLE_ZOOM:
-  proves: "after SIGKILL'ing a Zoom Web bot mid-recording, master.wav built from chunked PulseAudio uploads → ffprobe-playable; depends on Pack U.4 (chunked upload from parecord)"
-  symptom: "today Zoom Web crash = total audio loss (parecord WAV is on bot-pod local disk, never uploaded incrementally)"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-runtime-smokes.sh
-  step: bot_kill_zoom_master_playable
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 600
-DEFERRED_TRANSCRIBE_USES_MASTER:
-  proves: "POST /meetings/{id}/transcribe on a SIGKILL-mid-meeting recording fetches master.{webm|wav} from storage_path, ffmpeg-converts, returns segments — proving deferred transcription works on crashed-bot recordings (didn't pre-Pack-U)"
-  symptom: "post-meeting transcribe pipeline is fundamentally not chunk-aware: it reads single-file storage_path. Today crash = no transcribable audio."
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-runtime-smokes.sh
-  step: deferred_transcribe_master
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 600
-DOWNLOAD_RETURNS_PRESIGNED_URL_TO_MASTER:
-  proves: "GET /recordings/{id}/media/{file_id}/download returns a 200/302 with a presigned URL whose path component ends in /audio/master.{webm|wav}; URL is browser-reachable (uses MINIO_PUBLIC_ENDPOINT for helm/compose)"
-  symptom: "today /download still proxies bytes through meeting-api OR points at a chunk fragment"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-runtime-smokes.sh
-  step: download_presigned_master
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 60
-FINALIZER_HANDLES_MEETING_DATA_MODE:
-  proves: "recording_finalizer.py has the meeting_data JSONB path (Pack U.5 followup, commit 5af580e). Production runs in `meeting_data` mode where recordings live in meeting.data->'recordings' JSONB array; SQL Recording table is empty. Pre-fix the finalizer queried only the SQL table, found 0 rows, logged 'meeting_data mode or recording never started', and silently no-op'd on every real meeting. Asserts the [DATA] log emit + flag_modified(meeting,'data') is present."
-  symptom: "meetings reach completed but storage_path stays at last chunk (audio/0000NN.{ext}); dashboard hangs at 'preparing audio'; finalized_by absent or set to post_meeting_reconciler. Reproduced on helm tonight when stale meeting-api image was deployed without the followup."
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: finalizer_meeting_data_path
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-UNIFIED_ALIGNMENT_HOOK_IN_PIPELINE:
-  proves: "segment-to-audio alignment lives in ONE place — UnifiedRecordingPipeline subscribes to source.on('started') and calls publisher.resetSessionStart(). Per-platform recording.ts files do NOT have their own page.exposeFunction('__vexaRecordingStarted', ...) handler with publisher.resetSessionStart inside, and do NOT call publisher.resetSessionStart() at function entry. Matches Pack U design intent: tiny per-platform shims, all behavior in shared modules."
-  symptom: "pre-fix: GMeet/Teams had platform-side __vexaRecordingStarted handlers, Zoom had source.on('started') handler — three separate-but-identical handlers. Drift risk + duplicated maintenance. Captured 2026-05-02 after real-meeting test exposed Zoom segment-to-audio drift (Zoom mtg 23: segments 169s vs audio 159s = clicks past end-of-file)."
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: unified_alignment_hook
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-BROWSER_UTILS_INJECTED_BEFORE_PIPELINE_START:
-  proves: "every platform recording.ts that uses MediaRecorderCapture calls ensureBrowserUtils() BEFORE pipeline.start() — guards Pack U.2/U.3 regression where wrong ordering caused the pipeline's page.evaluate to access an undefined window.VexaBrowserUtils, throw silently, and produce 0 audio chunks (every real meeting then classified STOPPED_WITH_NO_AUDIO → status=failed)"
-  symptom: "meetings reach status=active for ~3 min then go status=failed with chunks=0; bot logs show 'Browser utils available:' (empty list); recordings field absent"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: browser_utils_before_pipeline
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-DASHBOARD_MEETINGS_PAGINATION_TRACKS_UNFILTERED_OFFSET:
-  proves: "dashboard meetings-store.ts paginates by an explicit _offset cursor that advances by the unfiltered API page size (50), NOT by post-filter meetings.length; next-page merge dedupes by meeting.id"
-  symptom: "GH issue #304 — /meetings list shows duplicate rows (3-6×) when redacted shells (`data.redacted=true` or `platform_specific_id==null`) are filtered out client-side, because next page request asks for offset N positions before where the previous page actually ended"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6-static-greps.sh
-  step: dashboard_meetings_pagination_offset
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-DASHBOARD_AUDIO_STREAMS_FROM_BUCKET:
-  proves: "dashboard ui reads /api/vexa/recordings/{id}/media/{file_id}/download (NOT /raw); response is a presigned URL; <audio src> binds to it; native HTTP Range fires on user seek"
-  symptom: "dashboard pre-downloads the full file before play; user perceives long loading delay; bandwidth cost amplified"
-  found: '2026-05-02'
-  type: grep
-  file: services/dashboard/src/lib/api.ts
-  must_match: 'getRecordingAudioUrl|recordings/.*/download'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-CHUNK_WRITE_PRESERVES_MASTER_PATH:
-  proves: "recordings.py chunk-write handler refuses to overwrite storage_path back to a chunk path when the prior media_file already had storage_path ending at /master.{webm|wav} OR is_final=True. Real-meeting test on helm 2026-05-03 caught the race: chunk N+1 landed AFTER Pack U.5 wrote master → dashboard saw chunk path, audio playback stuck at 'Preparing audio'."
-  symptom: "late-arriving chunk POST after bot graceful exit overwrites master storage_path; downstream consumers (dashboard /download, post-meeting transcribe) read chunk_seq=0 path instead of master.{webm|wav}"
-  found: '2026-05-03'
-  type: grep
-  file: services/meeting-api/meeting_api/recordings.py
-  must_match: 'master_finalized\s*='
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-RECORDING_FINALIZER_SETS_IS_FINAL:
-  proves: "recording_finalizer.py — when committing storage_path to master.{webm|wav}, also sets mf['is_final']=True so chunk_write's defensive guard activates"
-  symptom: "Pack U.5 finalizer leaves is_final=False after writing master; late-chunk handler doesn't recognize 'master already committed' state; chunk-write race overwrites the master path"
-  found: '2026-05-03'
-  type: grep
-  file: services/meeting-api/meeting_api/recording_finalizer.py
-  must_match: 'mf\["is_final"\]\s*=\s*True'
-  modes:
-  - lite
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-HELM_LKE_SETUP_EXPOSES_MINIO_NODEPORT:
-  proves: "tests3/lib/lke-setup-helm.sh sets minio.service.type=NodePort + nodePort + meetingApi.minioPublicEndpoint so presigned URLs are externally reachable from browser"
-  symptom: "helm cluster's MinIO presigned URLs point at vexa-vexa-minio:9000 (in-cluster DNS); browser audio playback hangs at 'Preparing audio' indefinitely"
-  found: '2026-05-03'
-  type: grep
-  file: tests3/lib/lke-setup-helm.sh
-  must_match: 'meetingApi\.minioPublicEndpoint'
-  modes:
-  - helm
-  state: stateless
-  max_duration_sec: 5
+  features:
+  - dashboard
+  - infrastructure
+  - realtime-transcription
+  tier: cheap
 auth-meeting:
   type: script
   script: tests/auth-meeting.sh
@@ -2381,6 +2195,37 @@ auth-meeting:
   max_duration_sec: 300
   features:
   - authenticated-meetings
+  tier: cheap
+bot-records-incrementally:
+  type: script
+  script: tests/bot-records-incrementally.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 15
+  features:
+  - bot-lifecycle
+  tier: cheap
+bot-startup-crash:
+  type: script
+  script: tests/bot-startup-crash.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 90
+  steps:
+  - display_exported
+  - start_log
+  - exit_code_log
+  - startup_breadcrumb
+  - startup_failure_reporter
+  - GMEET_BOT_STARTUP_LOGGED
+  features:
+  - bot-lifecycle
+  - realtime-transcription/gmeet
   tier: cheap
 bot-stop-timing:
   type: script
@@ -2411,6 +2256,46 @@ browser-session:
   features:
   - browser-session
   - remote-browser
+  tier: cheap
+chart-all-services-db-pool-tuned:
+  type: script
+  script: tests/chart-all-services-db-pool-tuned.sh
+  modes:
+  - helm
+  state: stateful
+  max_duration_sec: 20
+  features:
+  - infrastructure
+  tier: cheap
+chart-pgbouncer-optional:
+  type: script
+  script: tests/chart-pgbouncer-optional.sh
+  modes:
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - infrastructure
+  tier: cheap
+chart-prod-secrets-secretref:
+  type: script
+  script: tests/chart-prod-secrets-secretref.sh
+  modes:
+  - helm
+  state: stateful
+  max_duration_sec: 60
+  features:
+  - security-hygiene
+  tier: cheap
+chart-rolling-update-zero-downtime:
+  type: script
+  script: tests/chart-rolling-update-zero-downtime.sh
+  modes:
+  - helm
+  state: stateful
+  max_duration_sec: 20
+  features:
+  - infrastructure
   tier: cheap
 collect:
   type: script
@@ -2458,6 +2343,67 @@ dashboard-auth:
   features:
   - dashboard
   tier: cheap
+dashboard-browser-auth:
+  type: script
+  script: tests/dashboard-browser-auth.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 45
+  features:
+  - dashboard
+  tier: cheap
+dashboard-browser-view:
+  type: script
+  script: tests/dashboard-browser-view.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 90
+  features:
+  - dashboard
+  - browser-session
+  - remote-browser
+  tier: meeting
+dashboard-config-ssot:
+  type: script
+  script: tests/static/dashboard-config-ssot.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - dashboard
+  - infrastructure
+  - realtime-transcription
+  tier: cheap
+dashboard-cookie-isolation:
+  type: script
+  script: tests/dashboard-cookie-isolation.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  features:
+  - dashboard
+  tier: cheap
+dashboard-playback-canonical:
+  type: script
+  script: tests/static/dashboard-playback-canonical.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - dashboard
+  - post-meeting-transcription
+  tier: cheap
 dashboard-proxy:
   type: script
   script: tests/dashboard-proxy.sh
@@ -2475,6 +2421,109 @@ dashboard-proxy:
   - no_false_failed
   features:
   - dashboard
+  tier: cheap
+dashboard-recording-playback-ready:
+  type: script
+  script: tests/dashboard-recording-playback-ready.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  features:
+  - dashboard
+  - post-meeting-transcription
+  tier: cheap
+dashboard-recording-state-ssot:
+  type: script
+  script: tests/static/dashboard-recording-state-ssot.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - dashboard
+  - post-meeting-transcription
+  tier: cheap
+dashboard-stale-auth-detail:
+  type: script
+  script: tests/dashboard-stale-auth-detail.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 45
+  features:
+  - dashboard
+  tier: cheap
+deferred-transcribe-master-gate:
+  type: script
+  script: tests/static/deferred-transcribe-master-gate.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - post-meeting-transcription
+  - bot-lifecycle
+  tier: cheap
+gmeet-join-callback-resilient:
+  type: script
+  script: tests/gmeet-join-callback-resilient.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 15
+  steps:
+  - 5xx_proceed
+  - 4xx_abort
+  - transient_flag_thrown
+  - joining_catches_transient
+  features:
+  - bot-lifecycle
+  - realtime-transcription/gmeet
+  tier: cheap
+lite-recording-storage-persistent:
+  type: script
+  script: tests/static/lite-recording-storage-persistent.sh
+  modes:
+  - lite
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - dashboard
+  - post-meeting-transcription
+  - infrastructure
+  tier: cheap
+live-bot-transcript-pipeline:
+  type: script
+  script: tests/live-bot-transcript-pipeline.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  - realtime-transcription
+  - post-meeting-transcription
+  - dashboard
+  tier: meeting
+local-human-mechanical-gate:
+  type: script
+  script: tests/local-human-mechanical-gate.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - dashboard
+  - infrastructure
+  - post-meeting-transcription
+  - realtime-transcription
   tier: cheap
 meeting-tts:
   type: script
@@ -2497,6 +2546,78 @@ meeting-tts-teams:
   features:
   - realtime-transcription/msteams
   tier: meeting
+no-media-files-table-references:
+  type: script
+  script: tests/static/no-media-files-table-references.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - post-meeting-transcription
+  tier: cheap
+no-placeholder-transcription-token:
+  type: script
+  script: tests/static/no-placeholder-transcription-token.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - bot-lifecycle
+  - post-meeting-transcription
+  - realtime-transcription
+  - infrastructure
+  tier: cheap
+no-recordings-table-references:
+  type: script
+  script: tests/static/no-recordings-table-references.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - post-meeting-transcription
+  tier: cheap
+pack-2-gmeet-join:
+  type: script
+  script: tests/pack-2-gmeet-join.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 60
+  steps:
+  - gmeet.localized_join_selectors.join_jsname_before_english
+  - gmeet.localized_join_selectors.name_jsname_before_english
+  - gmeet.admission_outcome_classified.type_exported
+  - gmeet.admission_outcome_classified.denial
+  - gmeet.admission_outcome_classified.lobby_timeout
+  - gmeet.admission_outcome_classified.join_failure
+  - gmeet.humanized_join_click_hits.endpoint_verify_present
+  - gmeet.humanized_join_click_hits.fail_loud
+  - gmeet.humanized_join_click_hits.unit_tests
+  - gmeet.admission_outcome_classified.admission_tests
+  features:
+  - realtime-transcription/gmeet
+  - bot-lifecycle
+  tier: cheap
+package-tests:
+  type: script
+  script: tests/package-tests.sh
+  modes:
+  - lite
+  state: stateful
+  max_duration_sec: 150
+  features:
+  - dashboard
+  tier: cheap
 post-meeting:
   type: script
   script: tests/post-meeting.sh
@@ -2507,20 +2628,72 @@ post-meeting:
   - post-meeting-transcription
   - webhooks
   tier: meeting
-security-hygiene:
+recording-finalizing-state:
   type: script
-  script: tests/security-hygiene.sh
+  script: tests/recording-finalizing-state.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - post-meeting-transcription
+  - dashboard
+  tier: cheap
+recording-playback-url-canonical:
+  type: script
+  script: tests/recording-playback-url-canonical.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  features:
+  - post-meeting-transcription
+  - dashboard
+  tier: cheap
+recording-survives-sigkill:
+  type: script
+  script: tests/recording-survives-sigkill.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 180
+  features:
+  - bot-lifecycle
+  tier: cheap
+recordings-tables-dropped:
+  type: script
+  script: tests/recordings-tables-dropped.sh
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 15
+  features:
+  - post-meeting-transcription
+  tier: cheap
+runtime-api-exit-callback-durable:
+  type: script
+  script: tests/runtime-api-exit-callback-durable.sh
   modes:
   - lite
   - compose
-  state: stateless
-  max_duration_sec: 90
-  steps:
-  - h11_pin
-  - docs_gate
-  - vexa_bot_npm_audit
+  state: stateful
+  max_duration_sec: 60
   features:
-  - security-hygiene
+  - bot-lifecycle
+  tier: cheap
+smoke-bot-transcription-roundtrip-roundtrip:
+  type: script
+  script: tests/smoke-bot-transcription-roundtrip.sh roundtrip
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  - post-meeting-transcription
+  - realtime-transcription
   tier: cheap
 smoke-contract:
   type: script
@@ -2583,6 +2756,31 @@ smoke-static:
   - auth-and-limits
   - dashboard
   tier: cheap
+synthetic:
+  type: script
+  script: synthetic/run-all.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 240
+  features:
+  - bot-lifecycle
+  - post-meeting-transcription
+  tier: cheap
+test-account-bot-limit:
+  type: script
+  script: tests/test-account-bot-limit.sh
+  modes:
+  - lite
+  - compose
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - bot-lifecycle
+  - auth-and-limits
+  - dashboard
+  tier: cheap
 transcription-replay:
   type: script
   script: tests/transcription-replay.sh
@@ -2602,6 +2800,469 @@ tts-reliability:
   - realtime-transcription
   - speaking-bot
   tier: meeting
+v0.10.5.3-hallucination-corpus:
+  type: script
+  script: tests/v0.10.5.3-hallucination-corpus.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - bot-lifecycle
+  tier: cheap
+v0.10.6-runtime-smokes:
+  type: script
+  script: tests/v0.10.6-runtime-smokes.sh
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 600
+  features:
+  - bot-lifecycle
+  - post-meeting-transcription
+  - dashboard
+  tier: meeting
+v0.10.6-static-greps:
+  type: script
+  script: tests/v0.10.6-static-greps.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  - post-meeting-transcription
+  - dashboard
+  tier: cheap
+v0.10.6.1-agent-proxy-auth-auth_threaded:
+  type: script
+  script: tests/v0.10.6.1-agent-proxy-auth.sh auth_threaded
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - dashboard
+  - infrastructure
+  tier: cheap
+v0.10.6.1-agent-proxy-auth-no_localhost_fallback:
+  type: script
+  script: tests/v0.10.6.1-agent-proxy-auth.sh no_localhost_fallback
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - dashboard
+  - infrastructure
+  tier: cheap
+v0.10.6.1-api-gateway-cors-listsize-cors_wildcard_with_no_creds:
+  type: script
+  script: tests/v0.10.6.1-api-gateway-cors-listsize.sh cors_wildcard_with_no_creds
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - infrastructure
+  - dashboard
+  tier: cheap
+v0.10.6.1-api-gateway-cors-listsize-list_size_capped:
+  type: script
+  script: tests/v0.10.6.1-api-gateway-cors-listsize.sh list_size_capped
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - infrastructure
+  tier: cheap
+v0.10.6.1-arm64-manifest-arm64_in_manifest:
+  type: script
+  script: tests/v0.10.6.1-arm64-manifest.sh arm64_in_manifest
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  features:
+  - infrastructure
+  tier: cheap
+v0.10.6.1-bot-acceptance-signals-bot_collects_signals:
+  type: script
+  script: tests/v0.10.6.1-bot-acceptance-signals.sh bot_collects_signals
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-bot-acceptance-signals-callbacks_persist_signals:
+  type: script
+  script: tests/v0.10.6.1-bot-acceptance-signals.sh callbacks_persist_signals
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-bot-cpu-budget-bot_launches_inprocgpu:
+  type: script
+  script: tests/v0.10.6.1-bot-cpu-budget.sh bot_launches_inprocgpu
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-bot-cpu-budget-profiles_cap_cpu_1500m:
+  type: script
+  script: tests/v0.10.6.1-bot-cpu-budget.sh profiles_cap_cpu_1500m
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - infrastructure
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-dashboard-playback-canonical-no_pick_master_media_file:
+  type: script
+  script: tests/v0.10.6.1-dashboard-playback-canonical.sh no_pick_master_media_file
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - dashboard
+  tier: cheap
+v0.10.6.1-dashboard-playback-canonical-reads_playback_url:
+  type: script
+  script: tests/v0.10.6.1-dashboard-playback-canonical.sh reads_playback_url
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - dashboard
+  tier: cheap
+v0.10.6.1-direct-login-refused-helm_default_false:
+  type: script
+  script: tests/v0.10.6.1-direct-login-refused.sh helm_default_false
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - dashboard
+  - infrastructure
+  tier: cheap
+v0.10.6.1-direct-login-refused-no_hostname_fallback:
+  type: script
+  script: tests/v0.10.6.1-direct-login-refused.sh no_hostname_fallback
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - dashboard
+  - infrastructure
+  tier: cheap
+v0.10.6.1-dispatch-check-admin-deny-admin_bots_endpoint_honors_deny:
+  type: script
+  script: tests/v0.10.6.1-dispatch-check-admin-deny.sh admin_bots_endpoint_honors_deny
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  - auth-and-limits
+  - dashboard
+  tier: cheap
+v0.10.6.1-dispatch-check-deny-bots_endpoint_honors_deny:
+  type: script
+  script: tests/v0.10.6.1-dispatch-check-deny.sh bots_endpoint_honors_deny
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  - auth-and-limits
+  tier: cheap
+v0.10.6.1-dispatch-check-noop-noop_when_unset:
+  type: script
+  script: tests/v0.10.6.1-dispatch-check-noop.sh noop_when_unset
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  - auth-and-limits
+  tier: cheap
+v0.10.6.1-gmeet-fast-fail-eviction_retry_or_fail_clean:
+  type: script
+  script: tests/v0.10.6.1-gmeet-fast-fail.sh eviction_retry_or_fail_clean
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 10
+  features:
+  - realtime-transcription/gmeet
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-gmeet-fast-fail-rejection_under_30s:
+  type: script
+  script: tests/v0.10.6.1-gmeet-fast-fail.sh rejection_under_30s
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 10
+  features:
+  - realtime-transcription/gmeet
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-m328-m331-migrations-migration_surface_intact:
+  type: script
+  script: tests/v0.10.6.1-m328-m331-migrations.sh migration_surface_intact
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - infrastructure
+  tier: cheap
+v0.10.6.1-m328-m331-migrations-model_refs_dropped:
+  type: script
+  script: tests/v0.10.6.1-m328-m331-migrations.sh model_refs_dropped
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - infrastructure
+  tier: cheap
+v0.10.6.1-multichunk-playback-url-finalizer_writes_playback_url:
+  type: script
+  script: tests/v0.10.6.1-multichunk-playback-url.sh finalizer_writes_playback_url
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - post-meeting-transcription
+  - dashboard
+  tier: cheap
+v0.10.6.1-multichunk-playback-url-master_endpoint_present:
+  type: script
+  script: tests/v0.10.6.1-multichunk-playback-url.sh master_endpoint_present
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - post-meeting-transcription
+  - dashboard
+  tier: cheap
+v0.10.6.1-post-meeting-idempotency-fires_once_per_session:
+  type: script
+  script: tests/v0.10.6.1-post-meeting-idempotency.sh fires_once_per_session
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 60
+  features:
+  - post-meeting-transcription
+  - webhooks
+  tier: cheap
+v0.10.6.1-speak-defaults-defaults_propagate:
+  type: script
+  script: tests/v0.10.6.1-speak-defaults.sh defaults_propagate
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - speaking-bot
+  - realtime-transcription
+  tier: cheap
+v0.10.6.1-speak-e2e-speak_delivers_audio:
+  type: script
+  script: tests/v0.10.6.1-speak-e2e.sh speak_delivers_audio
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 240
+  features:
+  - speaking-bot
+  - realtime-transcription
+  tier: cheap
+v0.10.6.1-stale-audit-decisions_filed:
+  type: script
+  script: tests/v0.10.6.1-stale-audit.sh decisions_filed
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 60
+  features: []
+  tier: cheap
+v0.10.6.1-static-greps:
+  type: script
+  script: tests/v0.10.6.1-static-greps.sh
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 30
+  features:
+  - bot-lifecycle
+  - post-meeting-transcription
+  - dashboard
+  - webhooks
+  - speaking-bot
+  tier: cheap
+v0.10.6.1-teams-modal-modal_dismissed:
+  type: script
+  script: tests/v0.10.6.1-teams-modal.sh modal_dismissed
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 180
+  features:
+  - realtime-transcription/msteams
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-tts-auto-lang-detects_and_picks_voice:
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh detects_and_picks_voice
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 60
+  features:
+  - speaking-bot
+  tier: cheap
+v0.10.6.1-tts-auto-lang-major_voice_first_call_prompt:
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh major_voice_first_call_prompt
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 10
+  features:
+  - speaking-bot
+  tier: cheap
+v0.10.6.1-tts-auto-lang-major_voices_configured:
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh major_voices_configured
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 10
+  features:
+  - speaking-bot
+  tier: cheap
+v0.10.6.1-tts-auto-lang-runtime_tts_env_wired:
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh runtime_tts_env_wired
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 10
+  features:
+  - speaking-bot
+  tier: cheap
+v0.10.6.1-tts-auto-lang-voice_download_caches:
+  type: script
+  script: tests/v0.10.6.1-tts-auto-lang.sh voice_download_caches
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 120
+  features:
+  - speaking-bot
+  tier: cheap
+v0.10.6.1-tts-byo-playback-handles_wav_and_mp3:
+  type: script
+  script: tests/v0.10.6.1-tts-byo-playback.sh handles_wav_and_mp3
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - speaking-bot
+  tier: cheap
+v0.10.6.1-tts-pod-pod_ready_after_first_boot:
+  type: script
+  script: tests/v0.10.6.1-tts-pod.sh pod_ready_after_first_boot
+  modes:
+  - helm
+  state: stateful
+  max_duration_sec: 180
+  features:
+  - speaking-bot
+  - infrastructure
+  tier: cheap
+v0.10.6.1-webhook-no-autotouch-no_autotouch:
+  type: script
+  script: tests/v0.10.6.1-webhook-no-autotouch.sh no_autotouch
+  modes:
+  - compose
+  state: stateful
+  max_duration_sec: 5
+  features:
+  - webhooks
+  - bot-lifecycle
+  tier: cheap
+v0.10.6.1-webm-duration-ebml_duration_present:
+  type: script
+  script: tests/v0.10.6.1-webm-duration.sh ebml_duration_present
+  modes:
+  - compose
+  - helm
+  state: stateful
+  max_duration_sec: 120
+  features:
+  - post-meeting-transcription
+  - dashboard
+  tier: cheap
 webhooks:
   type: script
   script: tests/webhooks.sh
@@ -2621,1159 +3282,160 @@ webhooks:
   - no_leak_response
   - e2e_completion
   - e2e_status
-  - e2e_status_non_completed
   features:
   - webhooks
   tier: cheap
-
-# ── 260508-v0.10.6.1 new checks (scope.yaml proves[] bindings) ────────
-# Stub entries — full wiring (script paths, grep patterns, http endpoints)
-# is filled in during develop as each fix lands. Each entry carries the
-# proves/symptom from plan-approval.yaml registry_changes_approved.
-
-BOT_CONFIG_CAMERA_ENABLED_INDEPENDENT_OF_VOICE_AGENT:
-  proves: "meeting-api meetings.py does NOT force-couple bot_config['cameraEnabled'] to voice_agent_enabled. camera_enabled is honored only when the operator passes it explicitly; default stays off."
-  symptom: "voice_agent_enabled=true silently turns on the outgoing virtual camera / avatar stream — /speak should not require enabling a video camera."
-  found: '2026-05-17'
-  type: grep
-  # Replaces the prior BOT_CONFIG_CAMERA_ENABLED_WHEN_VOICE_AGENT check
-  # from PR #239 which encoded the inverse (and incorrect) coupling.
-  # The bot reads botConfig.cameraEnabled; meeting-api writes it.
-  file: services/meeting-api/meeting_api/meetings.py
-  must_not_match: 'bot_config\["cameraEnabled"\] = bool\(req\.voice_agent_enabled\)'
-  must_match: 'if req\.camera_enabled is not None:'
-  modes:
-  - compose
-  - lite
-  - helm
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-BOT_TEAMS_JOIN_CAMERA_GATED_BY_CAMERA_ENABLED:
-  proves: "Teams pre-join camera handling turns video on only when botConfig.cameraEnabled is true; voice_agent_enabled/speak does not publish an outgoing avatar/video tile."
-  symptom: "A Teams voice-only bot can speak but still appears as a video/avatar participant because pre-join handling treats voiceAgentEnabled as the camera gate."
-  found: '2026-05-19'
-  type: grep
-  file: services/vexa-bot/core/src/platforms/msteams/join.ts
-  must_not_match: 'if \(botConfig\.voiceAgentEnabled\) \{'
-  must_match: 'if \(botConfig\.cameraEnabled\) \{'
-  modes:
-  - compose
-  - lite
-  - helm
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-BOT_SPEAK_DELIVERS_AUDIO_TO_MEETING:
-  proves: "End-to-end /speak smoke test confirms audible audio reaches the meeting (not just 202 from dispatch)"
-  symptom: "/speak returns 202 but no audio audible in meeting"
-  found: '2026-05-04'
-  type: script
-  script: tests/v0.10.6.1-speak-e2e.sh
-  step: speak_delivers_audio
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 240
-  release: 260508-v0.10.6.1
-
-BOT_SPEAK_HONORS_PROVIDER_PARAM:
-  proves: "Bot /speak handler reads and acts on the provider param; fall-through paths log a structured WARN, not silently ignore"
-  symptom: "Bot ignores provider param on /speak; falls back without signaling to caller"
-  found: '2026-05-04'
-  type: grep
-  file: services/vexa-bot/core/src/services/speak.ts
-  must_match: provider
-  modes:
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-CALLBACKS_FINALIZE_NARROW_EXCEPT:
-  proves: "callbacks.py re-raises asyncio.CancelledError and MemoryError around finalize_recording_master rather than swallowing them; #306 audit MAJOR finding addressed"
-  symptom: "callbacks.py finalize_recording_master handler swallowed CancelledError + MemoryError under bare except Exception (#306)"
-  found: '2026-05-02'
-  type: grep
-  file: services/meeting-api/meeting_api/callbacks.py
-  must_match: 'asyncio\.CancelledError, MemoryError'
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-CHUNK_WRITE_PRIOR_COUNT_LOG_ACCURATE:
-  proves: "chunk_write log uses prior_chunks (same-type chunk count) instead of misleading prior_count (count of media_file type-entries)"
-  symptom: "Log showed prior_count=1 even on chunks 5+ because the field counted media_file type-entries, not chunks (#312)"
-  found: '2026-05-04'
-  type: grep
-  file: services/meeting-api/meeting_api/recordings.py
-  must_match: 'prior_chunks=%s'
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-# DASHBOARD_PLAYBACK_PREFERS_MASTER — retired in 260508-v0.10.6.1.
-# Tested the now-deleted pickMasterMediaFile() shape on the dashboard.
-# Superseded by DASHBOARD_READS_PLAYBACK_URL_NOT_MEDIA_FILES (canonical
-# playback_url contract; pickMasterMediaFile no longer exists).
-
-DOCKER_IMAGES_MANIFEST_INCLUDES_ARM64:
-  proves: "Each vexaai/* image's manifest includes a linux/arm64 layer"
-  symptom: "vexaai/* images are AMD64-only; Apple Silicon contributors hit Rosetta overhead (#321)"
-  found: '2026-05-06'
-  type: script
-  script: tests/v0.10.6.1-arm64-manifest.sh
-  step: arm64_in_manifest
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-GMEET_REJECTION_PAGE_FAST_FAIL_UNDER_30S:
-  proves: "GMeet bot detects the host-not-started page, grants a 30s grace for the host to join, and fast-fails with a classified reason (gmeet_host_not_started) rather than burning the full max_wait_for_admission"
-  symptom: "Bot stalled 120s on hidden name input when meeting host hadn't started; no fast-fail, no classified reason (#316)"
-  found: '2026-05-04'
-  type: script
-  script: tests/v0.10.6.1-gmeet-fast-fail.sh
-  step: rejection_under_30s
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-GMEET_WAITING_ROOM_EVICTION_RETRY_OR_FAIL_CLEAN:
-  proves: "GMeet admission flow tracks everInWaitingRoom, applies a 30s eviction grace once waiting-room indicator disappears, and throws gmeet_waiting_room_evicted instead of polling silently until the outer timeout"
-  symptom: "Google evicts the bot from the waiting room after ~5min; pre-fix bot polled in unknown state without classifying the eviction"
-  found: '2026-05-06'
-  type: script
-  script: tests/v0.10.6.1-gmeet-fast-fail.sh
-  step: eviction_retry_or_fail_clean
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-MASTER_WEBM_HAS_EBML_DURATION:
-  proves: "ffprobe of finalized master.webm reports a non-zero Duration in EBML SegmentInfo"
-  symptom: "Dashboard scrubber loads with delay because master.webm has no Duration tag (#302 follow-up)"
-  found: '2026-05-02'
-  type: script
-  script: tests/v0.10.6.1-webm-duration.sh
-  step: ebml_duration_present
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 120
-  release: 260508-v0.10.6.1
-
-# MEDIA_FILES_MASTER_INDEX_BACKFILLED — retired in 260508-v0.10.6.1.
-# Tied to the deleted pickMasterMediaFile() shape and its v0.10.6.1-dashboard-master.sh
-# host script. The backfill itself (tests3/lib/backfill-master-index.py) is preserved as
-# operator-run for the historical recordings; canonical playback now flows via
-# recording.playback_url proven by RECORDING_HAS_PLAYBACK_URL_AFTER_FINALIZE.
-
-# MIN_AUDIO_S_HONORED_IN_VEXA_LITE — REMOVED 2026-05-08 during develop.
-# Investigation: MIN_AUDIO_S env var does not exist in code OR current docs.
-# Customer-E (Discord 2026-05-06) misremembered. No drift to fix.
-# Replaced by VEXA_LITE_APPLE_SILICON_CAVEAT_DOCUMENTED (the real gap).
-
-RUNTIME_API_DELETE_EMITS_EXIT_CALLBACK:
-  proves: "meeting-api browser_session dispatch (meetings.py) plumbs connection_id='bs:<meeting_id>' through metadata; callbacks._find_meeting_by_session recognizes the bs: prefix and routes by meeting_id; runtime-api DELETE handler then fires the exit callback (no longer silently skipped)"
-  symptom: "browser_session DELETE left meetings stuck in 'stopping' because meeting-api dispatch never set connection_id, runtime-api skipped the callback, and the Pack E.3.2 sweep was defeated by webhook-retry updated_at bumps (#313)"
-  found: '2026-05-04'
-  type: grep
-  file: services/meeting-api/meeting_api/meetings.py
-  must_match: 'connection_id.*bs:'
-  modes:
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-SINGLE_WRITER_FOR_RECORDING_MASTER_PATH:
-  proves: "post_meeting.finalize_in_progress_recordings observes media_files entries whose storage_path is a master.{webm,wav} path and does NOT mutate them — recording_finalizer is the sole writer for master entries (Pack U.7 second race fixed)"
-  symptom: "Race window: master uploaded to storage + storage_path set in JSONB but is_final not yet flipped; post_meeting saw is_final=False and stomped finalized_by='post_meeting_reconciler' (#311)"
-  found: '2026-05-04'
-  type: grep
-  file: services/meeting-api/meeting_api/post_meeting.py
-  must_match: 'sp\.endswith\("/audio/master\.webm"\)'
-  modes:
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-STALE_AUDIT_SWEEP_DECISIONS_FILED:
-  proves: "Each of #166 #113 #128 #96 #198 has either a closing comment with rationale or a reconfirm note + label"
-  symptom: "Backlog noise — issues unconfirmed since pre-0.10 refactor"
-  found: '2026-05-08'
-  type: script
-  script: tests/v0.10.6.1-stale-audit.sh
-  step: decisions_filed
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-STUCK_MEETING_SWEEP_USES_PROGRESS_TIMESTAMP:
-  proves: "Pack E.3.2 sweep computes staleness from data.status_transition (immutable append-only history) — last_progress_at — rather than meeting.updated_at which is poisoned by webhook-retry bumps"
-  symptom: "Pack E.3.2 sweep defeated by webhook-retry updated_at bumps; meetings genuinely stuck in 'stopping' looked fresh and were never finalized (#313)"
-  found: '2026-05-04'
-  type: grep
-  file: services/meeting-api/meeting_api/sweeps.py
-  must_match: last_progress_at
-  modes:
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-SWAGGER_CURL_EXAMPLE_SHOWS_CORRECT_HEADER:
-  proves: "admin-api /openapi.json exposes a distinct AdminApiKey scheme with name=X-Admin-API-Key so Swagger renders correct curl examples"
-  symptom: "Swagger curl examples showed api-gateway header instead of admin-api header (#80, PR #319)"
-  found: '2025-12-05'
-  type: http
-  url: $ADMIN_URL/openapi.json
-  method: GET
-  expect_code: 200
-  expect_jsonpath: '$.components.securitySchemes.AdminApiKey.name'
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-
-TEAMS_CONTINUE_NO_AV_MODAL_DISMISSED:
-  proves: "Teams bot dismisses 'Continue without audio or video?' modal and proceeds to Join within normal admission window"
-  symptom: "Bot stuck on Teams light-meetings/launch by Continue-w/o-AV modal (#226, PR #283)"
-  found: '2026-04-21'
-  type: script
-  script: tests/v0.10.6.1-teams-modal.sh
-  step: modal_dismissed
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 180
-  release: 260508-v0.10.6.1
-
-TTS_POD_READY_AFTER_FIRST_BOOT:
-  proves: "Helm-deployed vexa-tts pod reaches Ready within 90s on a fresh cluster (model download path resilient)"
-  symptom: "TTS pod CrashLoopBackOff (154 restarts) on prod cluster; 9fde7d2 probe-delay fix incomplete (#315 #308)"
-  found: '2026-05-04'
-  type: script
-  script: tests/v0.10.6.1-tts-pod.sh
-  step: pod_ready_after_first_boot
-  modes:
-  - helm
-  state: stateful
-  max_duration_sec: 180
-  release: 260508-v0.10.6.1
-
-VEXA_LITE_APPLE_SILICON_CAVEAT_DOCUMENTED:
-  proves: "vexa-lite deployment docs explicitly call out the Apple Silicon Rosetta-emulation caveat and link to #321"
-  symptom: "Customers (customer-B 2026-04-27) hit silent self_initiated_leave on M-series Macs; docs gave no warning"
-  found: '2026-05-06'
-  type: grep
-  file: docs/vexa-lite-deployment.mdx
-  must_match: 'Apple Silicon'
-  modes:
-  - lite
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-  notes: |
-    Investigation 2026-05-08: original VEXA_LITE_ENV_DOC_DRIFT_CHECK was based on
-    customer-B + customer-E reports. OPENAI_API_KEY is still used by tts-service
-    (genuine). MIN_AUDIO_S is in neither code nor docs (customer-E misremembered).
-    The only real gap was the missing Apple Silicon caveat — narrowed to that.
-
-# ── 260508-v0.10.6.1 OPTION-3 SCOPE EXTENSION (2026-05-08) ────────────
-# Authorized mid-develop. See releases/260508-v0.10.6.1/protocol-exception.md.
-
-TTS_RUNTIME_ENV_WIRED:
-  proves: "Runtime-launched bot profiles receive TTS_SERVICE_URL across compose and helm, so /speak acceptance reaches the meeting audio data plane"
-  symptom: "/speak returns 202 but Helm bot pods have no TTS_SERVICE_URL and therefore cannot render audio"
-  found: '2026-05-20'
-  type: script
-  script: tests/v0.10.6.1-tts-auto-lang.sh
-  step: runtime_tts_env_wired
-  modes:
-  - compose
-  - helm
-  state: static
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-  option3: true
-
-TTS_MAJOR_VOICES_CONFIGURED:
-  proves: "tts-service is configured to strict-prepare the supported major language voices before accepting release-gate traffic"
-  symptom: "First non-English /speak can block on voice download or fall back to wrong-language output"
-  found: '2026-05-20'
-  type: script
-  script: tests/v0.10.6.1-tts-auto-lang.sh
-  step: major_voices_configured
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-  option3: true
-
-TTS_MAJOR_VOICE_FIRST_CALL_PROMPT:
-  proves: "A Portuguese auto-language /v1/audio/speech request returns non-empty audio promptly on the first release-gate call"
-  symptom: "Portuguese /speak is accepted but either spells letters, stalls on model download, or produces no prompt audible output"
-  found: '2026-05-20'
-  type: script
-  script: tests/v0.10.6.1-tts-auto-lang.sh
-  step: major_voice_first_call_prompt
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-  option3: true
-
-TTS_AUTO_LANG_PICKS_RIGHT_VOICE:
-  proves: "tts-service detects language from input text and selects a Piper voice matching that language (es text → es voice, etc.)"
-  symptom: "/v1/audio/speech defaults to en_US voice regardless of input language; non-English text gets phonemized via espeak-ng-EN, mispronounced silently"
-  found: '2026-05-08'
-  type: script
-  script: tests/v0.10.6.1-tts-auto-lang.sh
-  step: detects_and_picks_voice
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-  option3: true
-
-TTS_NEW_LANG_VOICE_AUTO_DOWNLOAD_CACHED:
-  proves: "First request for a new language triggers Piper voice download + cache; subsequent calls hit cached voice without re-download"
-  symptom: "No automated coverage of the auto-download-on-new-language path"
-  found: '2026-05-08'
-  type: script
-  script: tests/v0.10.6.1-tts-auto-lang.sh
-  step: voice_download_caches
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 120
-  release: 260508-v0.10.6.1
-  option3: true
-
-TTS_PLAYBACK_HANDLES_WAV_AND_MP3_RESPONSES:
-  proves: "Bot tts-playback dispatches by Content-Type — audio/pcm → streaming paplay; audio/wav or audio/mpeg → buffer-to-file then existing playFile path"
-  symptom: "synthesizeViaTtsService hardcodes response_format=pcm; users with BYO TTS returning wav/mp3 cannot play through the bot"
-  found: '2026-05-08'
-  type: script
-  script: tests/v0.10.6.1-tts-byo-playback.sh
-  step: handles_wav_and_mp3
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-  option3: true
-
-WEBHOOK_NO_UPDATED_AT_AUTOTOUCH:
-  proves: "webhooks.py persists webhook bookkeeping (webhook_delivery + webhook_deliveries) via a raw UPDATE that explicitly sets updated_at=meeting.updated_at, overriding the SQLAlchemy onupdate=func.now() default — so meetings.updated_at remains a 'domain progress' signal and is not poisoned by webhook retry storms"
-  symptom: "Pre-fix: webhook delivery writes appended to data->'webhook_deliveries' via the ORM, which bumped updated_at on every retry. Pack E.3.2 stale-stopping sweep filtered on `updated_at < threshold` and silently failed to fire because retry storms kept the row 'fresh' (#327, #313 root cause #2)"
-  found: '2026-05-08'
-  type: script
-  script: tests/v0.10.6.1-webhook-no-autotouch.sh
-  step: no_autotouch
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-  option3: true
-
-# MEDIA_FILES_UNIQUE_CONSTRAINT_ENFORCED — retired in 260508-v0.10.6.1.
-# Constraint was on the relational media_files table, which v0.10.6.1
-# drops outright (ADR-1, drop-relational-recordings-tables scope item).
-# Superseded by MEDIA_FILES_TABLE_NOT_REFERENCED + RECORDINGS_TABLE_DROPPED_IN_PROD.
-
-SPEAK_DEFAULTS_PROPAGATE_AUTO_LANGUAGE:
-  proves: "/speak default voice='auto' + provider='piper' propagate from meeting-api voice_agent.bot_speak through bot tts-playback.synthesizeAndPlay; redis pubsub command carries voice='auto' so tts-service language detection actually fires"
-  symptom: "Pre-fix: meeting-api /speak hardcoded voice='alloy' overriding bot's 'auto' default; even with TTS auto-language correct, end-to-end customer path was pinned English (#314 follow-up)"
-  found: '2026-05-10'
-  type: script
-  script: tests/v0.10.6.1-speak-defaults.sh
-  step: defaults_propagate
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-  option3: true
-
-# ── 260508-v0.10.6.1 CEO MID-TASK SCOPE EXTENSION (2026-05-11) ────────
-# Two scope items added during T-038 dispatch-surface repair. Their
-# prove-checks are expected to FAIL until parallel code-fix agents land
-# the underlying code changes.
-
-POST_MEETING_HOOKS_FIRE_ONCE_PER_SESSION:
-  proves: "fire_post_meeting_hooks claims one meeting.data.outbound_events entry per internal hook destination before HTTP delivery; concurrent callers skip pending/queued/delivered entries, Redis retry owns queued failures, and the stale-pending sweep recovers claim-before-send crashes without adding a database column"
-  symptom: "fire_post_meeting_hooks fired 4× per session from 6 call sites (exit_callback + status_change_callback + sweep retries); paying customer overcharged 3× (#330)"
-  found: '2026-05-11'
-  type: script
-  script: tests/v0.10.6.1-post-meeting-idempotency.sh
-  step: fires_once_per_session
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-  option3: true
-  pending_code_fix: true   # cleared when develop validation passes
-
-BOT_CREATE_HONORS_DISPATCH_CHECK_DENY:
-  proves: "POST /bots reads DISPATCH_CHECK_URL env; when the mock returns {allow:false,reason:X}, /bots returns 402 with reason in body — OSS-generic (no Stripe/billing semantics in code)"
-  symptom: "POST /bots has no pre-creation authority call-out; deny decisions made elsewhere don't reach the OSS dispatcher (T-033 B1)"
-  found: '2026-05-11'
-  type: script
-  script: tests/v0.10.6.1-dispatch-check-deny.sh
-  step: bots_endpoint_honors_deny
-  modes:
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-  option3: true
-  pending_code_fix: true   # parallel code-fix agent dispatching
-
-BOT_CREATE_NOOP_WHEN_DISPATCH_CHECK_UNSET:
-  proves: "POST /bots is a no-op pass-through when DISPATCH_CHECK_URL env is unset — self-hosters get no behavior change"
-  symptom: "OSS self-hosters must not see new external HTTP dependency; un-configured dispatch check must allow (T-033 B1 backward-compat)"
-  found: '2026-05-11'
-  type: script
-  script: tests/v0.10.6.1-dispatch-check-noop.sh
-  step: noop_when_unset
-  modes:
-  - compose
-  - lite
-  - helm
-  state: stateless
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-  option3: true
-  pending_code_fix: true
-
-ADMIN_BOT_CREATE_HONORS_DISPATCH_CHECK_DENY:
-  proves: "admin-api bot-create path reads DISPATCH_CHECK_URL env identically; admin-side dispatches honor opaque allow/deny decisions"
-  symptom: "Admin-side bot-create bypassed any external authority entirely (T-033 B7)"
-  found: '2026-05-11'
-  type: script
-  script: tests/v0.10.6.1-dispatch-check-admin-deny.sh
-  step: admin_bots_endpoint_honors_deny
-  modes:
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-  option3: true
-  pending_code_fix: true
-
-# ── 260508-v0.10.6.1 PROTOCOL-EXCEPTION #4 (2026-05-11) ──────────────
-# Validate-coverage closure: smoke-bot-transcription-roundtrip.
-# Caught at T-038 human-gate when bot 10060 produced zero transcripts
-# because TRANSCRIPTION_SERVICE_TOKEN was placeholder + validate matrix
-# had zero end-to-end roundtrip check against the transcription endpoint.
-
-SMOKE_BOT_TRANSCRIPTION_ROUNDTRIP:
-  proves: "bot's TranscriptionClient credentials + URL + auth-routing can complete a synth-audio → whisper-transcribe roundtrip; catches token-mismatch (HTTP 401), endpoint-unreachable (transport-err), and model-load failure (HTTP 500 OOM)"
-  symptom: "bot dispatches successfully and uploads chunks but every transcription call fails (401/500/timeout); transcripts never populate even though everything looks 'wired' in compose env (#regression caught at T-038 human-gate 2026-05-11)"
-  found: '2026-05-11'
-  type: script
-  script: tests/smoke-bot-transcription-roundtrip.sh
-  step: roundtrip
-  modes:
-  - compose
-  - helm
-  state: stateless
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-  protocol_exception: 4
-
-TRANSCRIPTION_TOKEN_NO_PLACEHOLDER_FALLBACK:
-  proves: "deploy/compose/.env is the LOCAL deployment SSOT for transcription URL/token; local deploy writes both compose and lite from that file, and smoke verifies runtime env matches it without caller-env overrides or fallback files"
-  symptom: "local deploy/test harness accepts parameters from multiple sources, masking a runtime deployed without the SSOT transcription credentials"
-  found: '2026-05-13'
-  type: static-grep
-  script: tests/static/no-placeholder-transcription-token.sh
-  step: TRANSCRIPTION_TOKEN_NO_PLACEHOLDER_FALLBACK
-  modes: [lite, compose]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_CONFIG_NO_STALE_LOCALHOST_DEFAULTS:
-  proves: "dashboard source/config contains no stale localhost:8066, localhost:18056, or ws://localhost:3001 defaults"
-  symptom: "dashboard builds or validates against the wrong local API gateway target, causing /ws and /api proxy failures after deployment"
-  found: '2026-05-14'
-  type: static-grep
-  script: tests/static/dashboard-config-ssot.sh
-  step: DASHBOARD_CONFIG_NO_STALE_LOCALHOST_DEFAULTS
-  modes: [lite, compose]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_REWRITES_REQUIRE_BUILD_SSOT:
-  proves: "dashboard /api/config derives browser API/WebSocket URLs from runtime public API config, infers Compose public API URLs from API_GATEWAY_HOST_PORT, normalizes loopback public URLs against the request host for remote self-hosted browsers, and keeps Next.js build-time rewrites as fallback only"
-  symptom: "portable dashboard image bakes one substrate's internal API hostname, remote Compose exposes http://api-gateway:8000 to a tester's browser, or remote Lite exposes ws://localhost:8056, so browser behavior passes in one substrate and fails in another"
-  found: '2026-05-14'
-  type: static-grep
-  script: tests/static/dashboard-config-ssot.sh
-  step: DASHBOARD_REWRITES_REQUIRE_BUILD_SSOT
-  modes: [lite, compose, helm]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_ADMIN_URL_EXPLICIT_SSOT:
-  proves: "dashboard admin routes use VEXA_ADMIN_API_URL explicitly instead of borrowing VEXA_API_URL as a second source"
-  symptom: "auth/profile/webhook routes silently switch between admin-api and gateway URLs, masking deployment drift and surfacing Invalid API key errors to the user"
-  found: '2026-05-14'
-  type: static-grep
-  script: tests/static/dashboard-config-ssot.sh
-  step: DASHBOARD_ADMIN_URL_EXPLICIT_SSOT
-  modes: [lite, compose]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_CLIENT_URLS_FROM_RUNTIME_CONFIG:
-  proves: "dashboard browser helpers get websocket/session URLs from /api/config or request origin, not hardcoded localhost endpoints"
-  symptom: "human gate browser receives stale local deployment URLs and cannot observe live transcript/status updates without refreshes"
-  found: '2026-05-14'
-  type: static-grep
-  script: tests/static/dashboard-config-ssot.sh
-  step: DASHBOARD_CLIENT_URLS_FROM_RUNTIME_CONFIG
-  modes: [lite, compose]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-TEST_ACCOUNT_BOT_LIMIT_IS_CANONICAL:
-  proves: "local validation account test@vexa.ai has max_concurrent_bots equal to tests3/lib/test-account.env TEST_ACCOUNT_MAX_CONCURRENT_BOTS in each in-scope deployment"
-  symptom: "parallel compose/lite/fresh-bot human validation trips the concurrent bot limiter even though the stack and bot pipeline are otherwise healthy"
-  found: '2026-05-14'
-  type: script
-  script: tests/test-account-bot-limit.sh
-  step: TEST_ACCOUNT_BOT_LIMIT_IS_CANONICAL
-  modes: [lite, compose]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-TEST_ACCOUNT_NO_STALE_SLOT_CONSUMERS:
-  proves: "test@vexa.ai has no stale requested/joining/awaiting_admission/active non-browser bot rows older than 2h consuming concurrent-bot slots"
-  symptom: "third bot cannot be dispatched even though max_concurrent_bots=3 because abandoned old meetings still count against the limiter"
-  found: '2026-05-14'
-  type: script
-  script: tests/test-account-bot-limit.sh
-  step: TEST_ACCOUNT_NO_STALE_SLOT_CONSUMERS
-  modes: [lite, compose]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-# ── 260508-v0.10.6.1 (v3 — 2026-05-12) ───────────────────────────────
-# Six new check ids added at develop-code for the three new architectural
-# items: recordings-playback-url-canonical, drop-relational-recordings-tables,
-# migrations-convention-readme. See scope.yaml for full per-issue blocks.
-
-RECORDING_HAS_PLAYBACK_URL_AFTER_FINALIZE:
-  proves: "recording_finalizer writes playback_url onto the JSONB recording element when master assembly succeeds; the field is non-empty for every completed recording"
-  symptom: "recording.status='completed' but recording.playback_url is null/missing on the JSONB; dashboard shows 'finalizing' indefinitely"
-  found: '2026-05-12'
-  type: script
-  script: tests/recording-playback-url-canonical.sh
-  step: recording_has_playback_url_after_finalize
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-DASHBOARD_READS_PLAYBACK_URL_NOT_MEDIA_FILES:
-  proves: "dashboard meeting page uses recording.playback_url directly; pickMasterMediaFile() function is no longer in the dashboard codebase"
-  symptom: "static-grep finds pickMasterMediaFile or .find(m => m.storage_path...) in services/dashboard/"
-  found: '2026-05-12'
-  type: static-grep
-  script: tests/static/dashboard-playback-canonical.sh
-  step: dashboard_reads_playback_url
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_RENDERS_FINALIZING_STATE_ON_NULL_PLAYBACK_URL:
-  proves: "dashboard audio-player renders an explicit 'finalizing' UI state when recording.playback_url is null on a completed recording, rather than silently failing"
-  symptom: "null playback_url + status=completed → dashboard either crashes, shows blank player, or falls back to picking media_files[0]"
-  found: '2026-05-12'
-  type: script
-  script: tests/recording-finalizing-state.sh
-  step: dashboard_renders_finalizing_state
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-
-DASHBOARD_COMPLETED_RECORDING_PLAYBACK_READY:
-  proves: "a real browser opens a completed meeting with recording.playback_url.audio, fetches the master recording route successfully, loads audio metadata, and renders playback controls instead of 'Recording is processing...' or 'Preparing audio...'"
-  symptom: "completed recording has backend master/playback_url but dashboard remains stuck in Recording is processing or Preparing audio"
-  found: '2026-05-13'
-  type: script
-  script: tests/dashboard-recording-playback-ready.sh
-  step: DASHBOARD_COMPLETED_RECORDING_PLAYBACK_READY
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-DASHBOARD_POST_MEETING_ARTIFACT_POLL_PRESENT:
-  proves: "the meeting detail page keeps polling post-meeting artifacts after stop/completion until recording playback can render, so the UI updates without a manual reload when finalization finishes seconds later"
-  symptom: "human page remains stuck on 'Recording is processing...' even though the backend finished the recording shortly after"
-  found: '2026-05-14'
-  type: script
-  script: tests/dashboard-recording-playback-ready.sh
-  step: DASHBOARD_POST_MEETING_ARTIFACT_POLL_PRESENT
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-DASHBOARD_TRANSCRIPT_RENDERED_VISIBLE:
-  proves: "a real browser opens the completed delivery meeting, the dashboard transcript API returns segment(s), and at least one transcript text snippet is visible in the rendered human page"
-  symptom: "backend GET /transcripts is green, but the human dashboard page still shows no transcript"
-  found: '2026-05-14'
-  type: script
-  script: tests/dashboard-recording-playback-ready.sh
-  step: DASHBOARD_TRANSCRIPT_RENDERED_VISIBLE
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_BROWSER_HANDOFF_ENDPOINTS_SSOT:
-  proves: "every URL handed to the local human browser during validation is derived from the canonical handoff surface and is browser-reachable from that surface; internal Docker hostnames, host-local storage endpoints, and ad hoc public-endpoint fallbacks are not accepted as human-gate proof"
-  symptom: "machine-local checks pass because the test runner can reach an internal/host-local endpoint, but the human browser sees a stuck UI because it was handed a URL outside the canonical handoff surface"
-  found: '2026-05-13'
-  type: script
-  script: tests/dashboard-recording-playback-ready.sh
-  step: LOCAL_HUMAN_BROWSER_HANDOFF_ENDPOINTS_SSOT
-  modes:
-  - compose
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-PRE_RELEASE_SECURITY_DEPENDENCY_FLOORS:
-  proves: "pre-release security dependency controls are enforced for the GHSA-9wv6-78fw-fq5c dependency-blocker class: dashboard postcss is >= 8.5.10 and transcription-service no longer installs python-multipart or reads the full multipart body before enforcing its size limit"
-  symptom: "dependency scanner reports the release tree still contains vulnerable postcss or python-multipart versions after the advisory was pulled into v0.10.6.1"
-  found: '2026-05-14'
-  type: static-grep
-  script: tests/static/advisory-dependency-floors.sh
-  step: PRE_RELEASE_SECURITY_DEPENDENCY_FLOORS
+BOT_IMAGE_HAS_HALLUCINATION_PHRASES:
+  proves: 'services/vexa-bot/core/src/services/hallucinations/ contains the 4-language phrase corpus (en.txt, es.txt, pt.txt,
+    ru.txt) the whisper hallucination filter loads at runtime. FM-274: production bots shipped without the phrase files, hallucination
+    filter ran with empty corpus, long-form hallucinations leaked into transcripts. v0.10.5 Pack P fixed the build path (`build`
+    script copies hallucinations/ into dist/); this check pins the source-side invariant that the corpus exists.'
+  symptom: 'FM-274 regression: phrase files deleted, renamed, or moved out of services/vexa-bot/core/src/services/hallucinations/.
+    Bot image rebuilds with empty hallucination corpus; long-form whisper hallucinations like ''thanks for watching'' / ''subscribe
+    to my channel'' leak into prod transcripts.'
+  found: '2026-04-29'
+  type: unknown
+  _orig:
+    id: BOT_IMAGE_HAS_HALLUCINATION_PHRASES
+    tier: static
+    found: '2026-04-29'
+    fix_release: v0.10.5
+    proves: 'services/vexa-bot/core/src/services/hallucinations/ contains the 4-language phrase corpus (en.txt, es.txt, pt.txt,
+      ru.txt) the whisper hallucination filter loads at runtime. FM-274: production bots shipped without the phrase files,
+      hallucination filter ran with empty corpus, long-form hallucinations leaked into transcripts. v0.10.5 Pack P fixed the
+      build path (`build` script copies hallucinations/ into dist/); this check pins the source-side invariant that the corpus
+      exists.'
+    symptom: 'FM-274 regression: phrase files deleted, renamed, or moved out of services/vexa-bot/core/src/services/hallucinations/.
+      Bot image rebuilds with empty hallucination corpus; long-form whisper hallucinations like ''thanks for watching'' /
+      ''subscribe to my channel'' leak into prod transcripts.'
+    method: SHELL_CHECK
+    script: tests3/checks/scripts/bot-image-has-hallucination-phrases.sh
+    max_duration_sec: 5
   modes:
   - lite
   - compose
   - helm
   state: stateless
   max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-RECORDINGS_TABLE_NOT_REFERENCED:
-  proves: "no select(Recording), from .models import Recording, or Recording.* reference exists in services/ outside of archived legacy paths"
-  symptom: "static-grep finds a Recording ORM reference, meaning the codebase still queries the dropped table"
-  found: '2026-05-12'
-  type: static-grep
-  script: tests/static/no-recordings-table-references.sh
-  step: recordings_table_not_referenced
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-MEDIA_FILES_TABLE_NOT_REFERENCED:
-  proves: "no select(MediaFile), from .models import MediaFile, or MediaFile.* reference exists in services/ outside of archived legacy paths"
-  symptom: "static-grep finds a MediaFile ORM reference; codebase still queries the dropped table"
-  found: '2026-05-12'
-  type: static-grep
-  script: tests/static/no-media-files-table-references.sh
-  step: media_files_table_not_referenced
-  modes:
-  - compose
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-RECORDINGS_TABLE_DROPPED_IN_PROD:
-  proves: "the recordings and media_files tables do not exist in the runtime DB (after m331-drop-relational-recordings.py runs)"
-  symptom: "SELECT 1 FROM recordings LIMIT 1 succeeds (table still present) — drop migration didn't run or rolled back"
-  found: '2026-05-12'
-  type: script
-  script: tests/recordings-tables-dropped.sh
-  step: tables_dropped
-  modes:
-  - compose
-  - helm
-  state: stateful
-  max_duration_sec: 15
-  release: 260508-v0.10.6.1
-
-# ── 260508-v0.10.6.1 walkability-smoke gate (2026-05-12) ─────────────
-# Harness-gap fix surfaced at develop-human: LOCAL=1 deploys could exit
-# success on a stack no human could walk. These six proves run AFTER
-# release-deploy and BEFORE release-validate; develop-human gate is
-# refused if any fails. See tests3/tests/walkability-smoke.sh.
-
-WALKABILITY_AUTH_ROUND_TRIP_WORKS:
-  proves: "api-gateway returns 401 without token and 200 with a valid token from api_tokens; auth round-trip works end-to-end"
-  symptom: "dashboard shows 'Invalid API key' or 'Missing API key' for an authenticated user; auth flow regressed silently"
-  found: '2026-05-12'
-  type: script
-  script: tests/walkability-smoke.sh
-  step: WALKABILITY_AUTH_ROUND_TRIP_WORKS
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-WALKABILITY_MEETINGS_PAGE_HAS_DATA:
-  proves: "deployed stack has at least 1 meeting row; humans walking the dashboard have something to click"
-  symptom: "fresh LOCAL=1 lite stack with empty DB; human-checklist items requiring a meeting record are dead in the water"
-  found: '2026-05-12'
-  type: script
-  script: tests/walkability-smoke.sh
-  step: WALKABILITY_MEETINGS_PAGE_HAS_DATA
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-WALKABILITY_MEETING_DETAIL_API_LOADS:
-  proves: "GET /meetings/<id> with auth returns 200 + JSON with id; the detail view a human clicks actually loads"
-  symptom: "dashboard /meetings/<id> shows 'Something went wrong' or empty state; backend route broken"
-  found: '2026-05-12'
-  type: script
-  script: tests/walkability-smoke.sh
-  step: WALKABILITY_MEETING_DETAIL_API_LOADS
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-WALKABILITY_TRANSCRIPTION_URL_CONFIGURED:
-  proves: "TRANSCRIPTION_SERVICE_URL is set + non-placeholder; LOCAL=1 inner loop check (reachability is canonical-stage-only)"
-  symptom: "stack deployed with dummy/placeholder transcription URL; transcription pipeline silently broken; canonical-stage gate would have caught it but LOCAL=1 didn't"
-  found: '2026-05-12'
-  type: script
-  script: tests/walkability-smoke.sh
-  step: WALKABILITY_TRANSCRIPTION_URL_CONFIGURED
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-WALKABILITY_TTS_SPEAK_ROUND_TRIP:
-  proves: "POST /v1/audio/speech to TTS service returns 200 + >1KB audio; /speak path is functional"
-  symptom: "/speak endpoint silently broken; bot can't speak in meetings; customer-A escalation reproduces"
-  found: '2026-05-12'
-  type: script
-  script: tests/walkability-smoke.sh
-  step: WALKABILITY_TTS_SPEAK_ROUND_TRIP
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-
-WALKABILITY_DASHBOARD_LOGIN_RENDERS:
-  proves: "GET /login returns 2xx + non-trivial HTML; dashboard front door renders for a human"
-  symptom: "dashboard /login returns 500 or empty body; humans cannot log in to walk the checklist"
-  found: '2026-05-12'
-  type: script
-  script: tests/walkability-smoke.sh
-  step: WALKABILITY_DASHBOARD_LOGIN_RENDERS
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-# ── 260508-v0.10.6.1 registry-canonical gate (2026-05-12) ──────────────
-# Prereq for develop-human: registry.yaml is canonical source of truth
-# for check IDs across scope.yaml + prove scripts. Drift between them
-# means the matrix returns "missing" on a real-running prove (or
-# accepts a phantom check id with no implementation). See
-# tests3/tests/static/registry-canonical.sh.
-
-REGISTRY_COVERS_ALL_SCOPE_PROVES:
-  proves: "every {check: X} in the current release's scope.yaml proves[] is registered in registry.yaml"
-  symptom: "scope.yaml references a check id that doesn't exist in registry → matrix returns missing forever; or a prove runs but the matrix can't find it in catalog"
-  found: '2026-05-12'
-  type: script
-  script: tests/static/registry-canonical.sh
-  step: REGISTRY_COVERS_ALL_SCOPE_PROVES
-  modes: [any]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-REGISTRY_COVERS_ALL_SCRIPT_STEP_IDS:
-  proves: "every step_pass/step_fail <ID> emitted by tests3/tests/**/*.sh is registered in registry.yaml"
-  symptom: "a script emits a check id that's not in registry → JSON written but report-renderer can't classify it"
-  found: '2026-05-12'
-  type: script
-  script: tests/static/registry-canonical.sh
-  step: REGISTRY_COVERS_ALL_SCRIPT_STEP_IDS
-  modes: [any]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-REGISTRY_HAS_NO_ORPHAN_IDS:
-  proves: "every check id in registry.yaml has at least one referrer (in current scope.yaml OR in a script)"
-  symptom: "registry accumulates dead entries over time; orphan ids confuse contributors browsing registry"
-  found: '2026-05-12'
-  type: script
-  script: tests3/tests/static/registry-canonical.sh
-  step: REGISTRY_HAS_NO_ORPHAN_IDS
-  modes: [any]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-# ── 260508-v0.10.6.1 scope-proof gate (2026-05-13) ────────────────────
-# develop-human must not open just because the registry is consistent and the
-# stack is walkable. This gate proves the current release's scope-bound LOCAL
-# (`lite` / `compose`) proof cells are actually present and green in the
-# latest reports. Missing/skip/fail all block the human checkpoint.
-
-SCOPE_LOCAL_PROOFS_ALL_GREEN:
-  proves: "every scope.yaml prove runnable on LOCAL=1 (`lite` / `compose`) is present and `pass` in the latest LOCAL reports before develop-human opens"
-  symptom: "human checkpoint opens on a colour-blind matrix: a required scope proof is missing, skipped, or failing, but the stack still looked walkable"
-  found: '2026-05-13'
-  type: script
-  script: tests/static/scope-proof-gate.sh
-  step: SCOPE_LOCAL_PROOFS_ALL_GREEN
-  modes: [any]
-  state: stateless
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-# ── 260508-v0.10.6.1 local-human mechanical gate (2026-05-13) ─────────
-# Machine-owned checks removed from the human checklist. Humans should spend
-# attention on end-to-end UI behavior; these checks are observable from Docker,
-# HTTP, logs, DB metadata, and generated env files.
-
-LOCAL_HUMAN_TARGET_URLS_READY:
-  proves: "the lite and compose target URLs handed to the human return 2xx before the checkpoint opens"
-  symptom: "human receives a checklist but the URL handoff points at dead or wrong surfaces"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_TARGET_URLS_READY
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_CONTAINERS_HEALTHY:
-  proves: "LOCAL lite + compose containers needed for human validation are running and healthy"
-  symptom: "human validation starts against a partially dead LOCAL stack"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_CONTAINERS_HEALTHY
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_TRANSCRIPTION_LB_READY:
-  proves: "when LOCAL compose points at transcription-lb, the lb/workers are healthy, attached to the runtime bot network, resolvable from runtime-api, and meeting-api/runtime-api match the deploy/compose/.env SSOT before human validation"
-  symptom: "live bots upload recording chunks but every Whisper call fails with transport errors; human sees zero transcript segments"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_TRANSCRIPTION_LB_READY
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_RECENT_LOGS_CLEAN:
-  proves: "recent LOCAL service logs have no ERROR/TRACEBACK/CRITICAL/FATAL lines before human validation begins"
-  symptom: "humans eyeball the UI while services are already emitting obvious runtime errors"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_RECENT_LOGS_CLEAN
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_MEMORY_WITHIN_LIMIT:
-  proves: "vexa-lite memory is below 2GiB before human validation"
-  symptom: "human validates a lite stack already beyond the documented memory envelope"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_MEMORY_WITHIN_LIMIT
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_LITE_RECORDING_FILES_PRESENT:
-  proves: "lite DB final local recording storage paths exist under /var/lib/vexa/recordings before human playback validation"
-  symptom: "lite DB advertises playback_url/final media but the disposable container layer lost the actual recording file after redeploy"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_LITE_RECORDING_FILES_PRESENT
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 10
-  release: 260508-v0.10.6.1
-
-DASHBOARD_BROWSER_MEETINGS_AUTH_OK:
-  proves: "a real browser can direct-login, open /meetings and a meeting detail page, and avoid Authentication failed/session-expired/Invalid API key UI"
-  symptom: "curl sees 200 HTML but the hydrated dashboard rejects the session at /meetings or /meetings/<id>"
-  found: '2026-05-13'
-  type: script
-  script: tests/dashboard-browser-auth.sh
-  step: DASHBOARD_BROWSER_MEETINGS_AUTH_OK
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 45
-  release: 260508-v0.10.6.1
-
-DASHBOARD_DETAIL_STALE_AUTH_RECOVERS:
-  proves: "a stale dashboard cookie/localStorage token on a meeting detail route is cleared or redirected instead of rendering raw Invalid API key"
-  symptom: "human opens /meetings/<id> after auth/token drift and sees Something went wrong / Invalid API key"
-  found: '2026-05-13'
-  type: script
-  script: tests/dashboard-stale-auth-detail.sh
-  step: DASHBOARD_DETAIL_STALE_AUTH_RECOVERS
-  modes: [compose, lite]
-  state: stateful
-  max_duration_sec: 45
-  release: 260508-v0.10.6.1
-
-DASHBOARD_AUTH_COOKIES_ISOLATED:
-  proves: "one browser can log into both LOCAL dashboards on localhost and keep both /meetings sessions authenticated with deployment-specific token cookies"
-  symptom: "logging into one localhost deployment overwrites the other deployment's vexa-token cookie, causing Authentication failed/session-expired after successful login"
-  found: '2026-05-13'
-  type: script
-  script: tests/dashboard-cookie-isolation.sh
-  step: DASHBOARD_AUTH_COOKIES_ISOLATED
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 60
-  release: 260508-v0.10.6.1
-
-LIVE_BOT_TRANSCRIPT_SEGMENTS_PRESENT:
-  proves: "the configured delivery meeting, or newest real admitted transcribe_enabled bot with recording chunks, has non-empty transcript segments through GET /transcripts"
-  symptom: "human opens a meeting detail page after bot admission and sees recordings/chunks but no transcription"
-  found: '2026-05-13'
-  type: script
-  script: tests/live-bot-transcript-pipeline.sh
-  step: LIVE_BOT_TRANSCRIPT_SEGMENTS_PRESENT
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 30
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_COMPOSE_ENV_SSOT:
-  proves: "deploy/compose/.env contains every deploy/env-example key plus non-empty LOCAL overrides"
-  symptom: "LOCAL compose validation runs with env drift from the declared deployment contract"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_COMPOSE_ENV_SSOT
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_NO_TEST_CONTAINERS:
-  proves: "no leftover lifecycle/webhook/spoof test containers are present before human validation"
-  symptom: "stale test containers contaminate human validation or Docker ps inspection"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_NO_TEST_CONTAINERS
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-LOCAL_HUMAN_RECORDINGS_TABLES_DROPPED:
-  proves: "compose DB has no recordings/media_files relational tables before human playback validation"
-  symptom: "human validates recording playback while the dead relational tables are still present"
-  found: '2026-05-13'
-  type: script
-  script: tests/local-human-mechanical-gate.sh
-  step: LOCAL_HUMAN_RECORDINGS_TABLES_DROPPED
-  modes: [compose]
-  state: stateful
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_DETAIL_FETCHES_CANONICAL_RECORDING_STATE:
-  proves: "dashboard meeting detail fetches the authoritative meeting row and hydrates recording state from meeting.data.recordings"
-  symptom: "SPA navigation to an active deferred-recording meeting trusts the thin meetings-list row, leaving recordings/transcribe_enabled empty until a hard reload"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/dashboard-recording-state-ssot.sh
-  step: DASHBOARD_DETAIL_FETCHES_CANONICAL_RECORDING_STATE
-  modes: [compose, lite]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_ACTIVE_RECORDING_UI_USES_MEETING_DATA:
-  proves: "dashboard meeting page derives active recording UI from canonical meeting.data.recordings when transcript-derived recording state has not arrived"
-  symptom: "active recording with transcribe_enabled=false renders 'No transcript yet / Waiting for speech to transcribe...' instead of 'Recording in progress'"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/dashboard-recording-state-ssot.sh
-  step: DASHBOARD_ACTIVE_RECORDING_UI_USES_MEETING_DATA
-  modes: [compose, lite]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DASHBOARD_DEFERRED_RECORDING_EMPTY_STATE:
-  proves: "transcript empty state distinguishes deferred recording from realtime transcription waiting state"
-  symptom: "deferred recording flow looks broken during capture/finalization because the transcript panel says it is waiting for speech"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/dashboard-recording-state-ssot.sh
-  step: DASHBOARD_DEFERRED_RECORDING_EMPTY_STATE
-  modes: [compose, lite]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DEFERRED_TRANSCRIBE_WAITS_FOR_RECORDING_MASTER:
-  proves: "POST /meetings/{id}/transcribe accepts only audio media finalized by recording_finalizer.master; it does not consume last-chunk storage_path or post_meeting_reconciler metadata"
-  symptom: "deferred transcription starts before recording finalization, reads an incomplete chunk path, and returns zero/broken transcript despite the recording later becoming playable"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/deferred-transcribe-master-gate.sh
-  step: DEFERRED_TRANSCRIBE_WAITS_FOR_RECORDING_MASTER
-  modes: [compose, lite, helm]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DISRUPTIVE_DEFERRED_TRANSCRIPTION_HARNESS_EXISTS:
-  proves: "autonomous_real_meeting.py can dispatch a recording-only bot, SIGKILL it, wait for finalized master, POST deferred transcribe, and assert persisted transcript segments"
-  symptom: "release registry claims crash robustness but only proves recording playback, not deferred transcript persistence after bot disruption"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/deferred-transcribe-master-gate.sh
-  step: DISRUPTIVE_DEFERRED_TRANSCRIPTION_HARNESS_EXISTS
-  modes: [compose, lite, helm]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-RUNTIME_EXIT_CALLBACK_SENDS_INTERNAL_SECRET:
-  proves: "runtime-api persists callback_headers and sends X-Internal-Secret back to meeting-api exit callbacks"
-  symptom: "bot exits but meeting-api rejects runtime callback with 403, leaving meetings stuck requested/active and recording finalization unobservable"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/deferred-transcribe-master-gate.sh
-  step: RUNTIME_EXIT_CALLBACK_SENDS_INTERNAL_SECRET
-  modes: [compose, lite, helm]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-BOT_STATUS_CALLBACK_HAS_INTERNAL_SECRET_FALLBACK:
-  proves: "bot status callbacks carry X-Internal-Secret from BOT_CONFIG or INTERNAL_API_SECRET env"
-  symptom: "bot joins or waits but meeting-api rejects status_change with 403, so tests never reach active and dashboard state drifts"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/deferred-transcribe-master-gate.sh
-  step: BOT_STATUS_CALLBACK_HAS_INTERNAL_SECRET_FALLBACK
-  modes: [compose, lite, helm]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-DISRUPTIVE_CRASH_KILLS_CANONICAL_BOT_CONTAINER:
-  proves: "compose disruptive harness kills the meeting-api bot_container_id before fallback discovery"
-  symptom: "crash robustness test records chunks but fails to drop the active bot, creating false red/green evidence about recording persistence"
-  found: '2026-05-14'
-  type: script
-  script: tests/static/deferred-transcribe-master-gate.sh
-  step: DISRUPTIVE_CRASH_KILLS_CANONICAL_BOT_CONTAINER
-  modes: [compose]
-  state: stateless
-  max_duration_sec: 5
-  release: 260508-v0.10.6.1
-
-GMEET_HUMANIZED_JOIN_LANE_GREEN:
-  proves: "humanized join path is structurally complete on compose + Lite lanes: xdotool+xclip declared in Dockerfile.lite, HumanizedInteractor module present, waitForAnySelector wired, locale-agnostic selectors first (Pack 7 / issue #7)"
-  symptom: "GMeet bot falls back to synthetic Playwright click (isTrusted=false) because xdotool/xclip missing from Lite image OR humanized/ module not present OR join.ts still uses single-selector waitForSelector; bot-detection triggers rejection"
-  found: '2026-06-06'
-  type: script
-  script: tests/static/humanized-join-lane-green.sh
+CHART_PUBLISH_WORKFLOW_EXISTS:
+  proves: .github/workflows/chart-release.yml exists, references helm/chart-releaser-action, parses as valid YAML
+  symptom: No gh-pages Helm repo; consumers must clone + helm package locally (#228)
+  found: '2026-04-22'
+  type: unknown
+  _orig:
+    id: CHART_PUBLISH_WORKFLOW_EXISTS
+    tier: static
+    found: '2026-04-22'
+    proves: .github/workflows/chart-release.yml exists, references helm/chart-releaser-action, parses as valid YAML
+    symptom: No gh-pages Helm repo; consumers must clone + helm package locally (#228)
+    method: SHELL_CHECK
+    script: tests3/checks/scripts/chart-publish-workflow-exists.sh
+    max_duration_sec: 5
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 10
-  release: pack-7-humanized-join
-
-GMEET_TRANSCRIBE_E2E:
-  proves: "end-to-end transcript pipeline is structurally complete: join.ts uses ordered multi-selector resolver with screenshot-on-failure, humanized text-entry (xclip) is wired, x11Input tracks simPointer in dryRun, humanized module ships all 6 files (Pack 7 / issue #7)"
-  symptom: "bot joins GMeet but name-entry or join-button click silently fails; no transcript segments produced; join.ts swallows errors without screenshot evidence"
-  found: '2026-06-06'
-  type: script
-  script: tests/static/transcribe-e2e-harness.sh
+  max_duration_sec: 5
+CHART_VERSION_CURRENT:
+  proves: deploy/helm/charts/vexa/Chart.yaml version is SemVer >= latest v* git tag
+  symptom: Chart.yaml pinned at 0.1.0 for ~100 commits; consumers cannot detect drift (#228)
+  found: '2026-04-22'
+  type: unknown
+  _orig:
+    id: CHART_VERSION_CURRENT
+    tier: static
+    found: '2026-04-22'
+    proves: deploy/helm/charts/vexa/Chart.yaml version is SemVer >= latest v* git tag
+    symptom: Chart.yaml pinned at 0.1.0 for ~100 commits; consumers cannot detect drift (#228)
+    method: SHELL_CHECK
+    script: tests3/checks/scripts/chart-version-current.sh
+    max_duration_sec: 5
   modes:
   - lite
   - compose
   - helm
   state: stateless
-  max_duration_sec: 10
-  release: pack-7-humanized-join
+  max_duration_sec: 5
+DOCS_ENV_GATED_EVERYWHERE:
+  proves: "every FastAPI app reads VEXA_ENV and passes docs_url/redoc_url/openapi_url derived from it \u2014 /docs default-deny\
+    \ in production"
+  symptom: /docs exposed on a production deployment; internal admin endpoints listed to any client
+  found: '2026-04-19'
+  type: unknown
+  _orig:
+    id: DOCS_ENV_GATED_EVERYWHERE
+    tier: static
+    found: '2026-04-19'
+    proves: "every FastAPI app reads VEXA_ENV and passes docs_url/redoc_url/openapi_url derived from it \u2014 /docs default-deny\
+      \ in production"
+    symptom: /docs exposed on a production deployment; internal admin endpoints listed to any client
+    method: DOCS_GATE_CHECK
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+H11_PINNED_SAFE_EVERYWHERE:
+  proves: "every httpx/uvicorn requirements*.txt pins h11>=0.16.0 \u2014 CVE-2025-43859 closed transitively"
+  symptom: pip install resolves h11<0.16.0 on any service; HTTP/1.1 pipelining header leak reintroduced
+  found: '2026-04-19'
+  type: unknown
+  _orig:
+    id: H11_PINNED_SAFE_EVERYWHERE
+    tier: static
+    found: '2026-04-19'
+    proves: "every httpx/uvicorn requirements*.txt pins h11>=0.16.0 \u2014 CVE-2025-43859 closed transitively"
+    symptom: pip install resolves h11<0.16.0 on any service; HTTP/1.1 pipelining header leak reintroduced
+    method: H11_PIN_CHECK
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+PACK_E1A_CONCURRENT_CHUNKS_REPRODUCER_PASSES:
+  proves: "services/meeting-api/tests/test_recordings_concurrent_chunks.py \u2014 3 pytest cases (AST static check + sequential\
+    \ sanity + concurrent asyncio.gather race) \u2014 all pass against current HEAD. Wires the [PLATFORM]-approved Pack E.1.a\
+    \ v2 lock-before-snapshot reproducer test as a required-by-mode gate."
+  symptom: 'Pack E.1.a regression: SELECT FOR UPDATE moved back to AFTER snapshot, OR the lock-acquisition / re-snapshot pattern
+    broken in some other refactor. Concurrent audio+video chunks lose one media_files entry. (#272 issuecomment-4327366063)'
+  found: '2026-04-27'
+  type: unknown
+  _orig:
+    id: PACK_E1A_CONCURRENT_CHUNKS_REPRODUCER_PASSES
+    tier: static
+    found: '2026-04-27'
+    proves: "services/meeting-api/tests/test_recordings_concurrent_chunks.py \u2014 3 pytest cases (AST static check + sequential\
+      \ sanity + concurrent asyncio.gather race) \u2014 all pass against current HEAD. Wires the [PLATFORM]-approved Pack\
+      \ E.1.a v2 lock-before-snapshot reproducer test as a required-by-mode gate."
+    symptom: 'Pack E.1.a regression: SELECT FOR UPDATE moved back to AFTER snapshot, OR the lock-acquisition / re-snapshot
+      pattern broken in some other refactor. Concurrent audio+video chunks lose one media_files entry. (#272 issuecomment-4327366063)'
+    method: SHELL_CHECK
+    script: tests3/checks/scripts/pack-e1a-concurrent-chunks-reproducer.sh
+    max_duration_sec: 60
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5
+VEXA_BOT_NO_HIGH_NPM_VULNS:
+  proves: services/vexa-bot + services/vexa-bot/core npm audit report 0 HIGH and 0 CRITICAL vulnerabilities
+  symptom: vexa-bot ships transitive basic-ftp with CRLF injection / DoS (GHSA-6v7q-wjvx-w8wg, GHSA-chqc-8p9q-pq6q, GHSA-rp42-5vxx-qpwr)
+  found: '2026-04-19'
+  type: unknown
+  _orig:
+    id: VEXA_BOT_NO_HIGH_NPM_VULNS
+    tier: static
+    found: '2026-04-19'
+    proves: services/vexa-bot + services/vexa-bot/core npm audit report 0 HIGH and 0 CRITICAL vulnerabilities
+    symptom: vexa-bot ships transitive basic-ftp with CRLF injection / DoS (GHSA-6v7q-wjvx-w8wg, GHSA-chqc-8p9q-pq6q, GHSA-rp42-5vxx-qpwr)
+    method: VEXA_BOT_NPM_AUDIT
+  modes:
+  - lite
+  - compose
+  - helm
+  state: stateless
+  max_duration_sec: 5


### PR DESCRIPTION
Closes #422.

## Problem
`tests3/registry.yaml` is the generated view of `tests3/checks/registry.json` (+ `test-registry.yaml`), produced by `tests3/lib/migrate-registry.py`. The committed file had **drifted** from what the generator emits — running it on a clean tree rewrote **~2.2k insertions / 2.6k deletions** of pure formatting/ordering churn. So:
- Anyone regenerating `registry.yaml` (the documented way to add a check) got a giant unrelated diff and had to hand-edit instead.
- The source of truth and the generated view could silently diverge, with no gating check.

## Fix (issue's suggested option 1)
1. **Re-synced `registry.yaml`** by running the generator and committing the normalized output, so the committed view matches the generator exactly. The bulk of this PR's diff is that one-time auto-generated normalization (239 entries: 113 script, 88 grep, 24 http, 7 env, 7 unknown).
2. **Added a `--check` mode** to `migrate-registry.py` — regenerates in memory, compares to the committed file, **exits 1 on drift and writes nothing** (safe for CI).
3. **Added a `gate:registry-parity` job** to `gates.yml` (runs on PRs + pushes to `main`) that runs `--check`, so drift is caught going forward — a parity ratchet.

## Verification
```
$ python3 tests3/lib/migrate-registry.py            # regenerate
$ python3 tests3/lib/migrate-registry.py            # idempotent — second run is a no-op
$ python3 tests3/lib/migrate-registry.py --check
  tests3/registry.yaml is in sync with its sources   # exit 0

# on the pre-fix (stale) file:
$ python3 tests3/lib/migrate-registry.py --check
ERROR: tests3/registry.yaml is out of sync with its generator.  # exit 1
```
Confirmed: generator is idempotent, `--check` passes when in sync and fails (exit 1) on drift. `gates.yml` validated as well-formed YAML.

## Note
The normalized output is produced by PyYAML's `safe_dump`, so it's mildly version-sensitive; the new CI gate pins `pyyaml>=6,<7` to keep the parity check stable. Regenerated locally with PyYAML 6.0.3.