### PR TITLE
fix(meeting-api): offload blocking boto3 S3 calls off the event loop

### DIFF
--- a/services/meeting-api/meeting_api/meetings.py
+++ b/services/meeting-api/meeting_api/meetings.py
@@ -2027,7 +2027,7 @@ async def transcribe_meeting(
     # 2. Download audio from storage
     try:
         storage = create_storage_client()
-        audio_data = storage.download_file(storage_path)
+        audio_data = await asyncio.to_thread(storage.download_file, storage_path)
     except Exception as e:
         logger.error(f"Failed to download recording for meeting {meeting_id}: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to download recording: {e}")

--- a/services/meeting-api/meeting_api/recordings.py
+++ b/services/meeting-api/meeting_api/recordings.py
@@ -241,7 +241,11 @@ async def internal_upload_recording(
 
     try:
         storage = get_storage_client()
-        storage.upload_file(storage_path, file_data, content_type=content_type)
+        # boto3 is synchronous; offload to a worker thread so the per-chunk
+        # upload does not block the event loop (and stall liveness probes).
+        await asyncio.to_thread(
+            storage.upload_file, storage_path, file_data, content_type=content_type
+        )
     except Exception as e:
         logger.error(f"Storage upload failed for {session_uid}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to upload recording to storage")
@@ -508,7 +512,7 @@ async def download_media_file(
     # the dashboard can fall back to /raw (Pack P: this is the LAST
     # allowed fallback in the playback path until master_ready flag exists).
     try:
-        master_present = storage.file_exists(storage_path)
+        master_present = await asyncio.to_thread(storage.file_exists, storage_path)
     except Exception as e:  # pragma: no cover - defensive
         logger.warning(f"file_exists check failed for {storage_path}: {e}")
         master_present = False
@@ -522,7 +526,7 @@ async def download_media_file(
         # fallback — local storage is dev-only.
         url = f"/recordings/{recording_id}/media/{media_file_id}/raw"
     else:
-        url = storage.get_presigned_url(storage_path, expires=3600)
+        url = await asyncio.to_thread(storage.get_presigned_url, storage_path, expires=3600)
 
     return {
         "url": url,
@@ -569,7 +573,7 @@ async def download_media_file_raw(
         raise HTTPException(status_code=404, detail="Media file not found")
 
     try:
-        data = get_storage_client().download_file(storage_path)
+        data = await asyncio.to_thread(get_storage_client().download_file, storage_path)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Media file content not found in storage")
     except Exception as e:

--- a/services/meeting-api/meeting_api/sweeps.py
+++ b/services/meeting-api/meeting_api/sweeps.py
@@ -394,7 +394,7 @@ async def recover_recordings_jsonb_from_storage(
             continue
         prefix = f"recordings/{meeting.user_id}/"
         try:
-            keys = storage.list_objects_bounded(prefix)
+            keys = await asyncio.to_thread(storage.list_objects_bounded, prefix)
         except Exception as e:
             logger.warning(
                 "[finalizer-recovery] storage list failed meeting_id=%s prefix=%s error=%s",
@@ -537,7 +537,7 @@ async def _sweep_unfinalized_recordings(
 
                 prefix = f"recordings/{meeting.user_id}/"
                 try:
-                    keys = storage.list_objects_bounded(prefix)
+                    keys = await asyncio.to_thread(storage.list_objects_bounded, prefix)
                 except Exception as e:
                     logger.warning(
                         "[sweep] unfinalized-recordings storage list failed "

--- a/services/meeting-api/tests/test_recordings_offload_blocking_s3.py
+++ b/services/meeting-api/tests/test_recordings_offload_blocking_s3.py
@@ -1,0 +1,66 @@
+"""Regression test for #448: storage I/O must not block the event loop.
+
+``internal_upload_recording`` performs a synchronous boto3 ``put_object`` on
+every chunk. If that call runs directly on the asyncio event loop, the blocking
+S3 round-trip stalls the loop and trips the (otherwise trivial) liveness /
+readiness probes, causing avoidable pod restarts under load. The fix offloads
+the call via ``asyncio.to_thread``; this test asserts the upload executes on a
+worker thread, not the main (event-loop) thread.
+
+With the pre-fix code (direct call on the loop) this test fails; with the
+offload it passes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meeting_api import recordings as recordings_module
+
+from .conftest import make_meeting, make_session
+from .test_recordings_concurrent_chunks import _StatefulMockDB, _make_upload_call
+
+
+@pytest.mark.asyncio
+async def test_chunk_upload_runs_off_event_loop_thread():
+    meeting = make_meeting(data={})
+    session = make_session()
+    mock_db = _StatefulMockDB(session=session, meeting=meeting)
+
+    main_thread = threading.current_thread()
+    recorded: dict[str, object] = {}
+
+    def _capture_upload(*args, **kwargs):
+        # Synchronous boto3 stand-in: record where it executed.
+        recorded["thread"] = threading.current_thread()
+        try:
+            asyncio.get_running_loop()
+            recorded["had_running_loop"] = True
+        except RuntimeError:
+            recorded["had_running_loop"] = False
+        return None
+
+    fake_storage = MagicMock()
+    fake_storage.upload_file = MagicMock(side_effect=_capture_upload)
+
+    with patch.object(recordings_module, "get_storage_client", return_value=fake_storage), \
+         patch.object(recordings_module.attributes, "flag_modified", new=MagicMock()):
+        await recordings_module.internal_upload_recording(
+            db=mock_db,
+            **_make_upload_call("audio", "wav"),
+        )
+
+    assert fake_storage.upload_file.called, "storage.upload_file was never invoked"
+    assert recorded.get("thread") is not None
+    assert recorded["thread"] is not main_thread, (
+        "storage.upload_file ran on the event-loop (main) thread — the blocking "
+        "boto3 call must be offloaded via asyncio.to_thread (see #448)."
+    )
+    assert recorded["had_running_loop"] is False, (
+        "storage.upload_file ran with a live event loop in its thread — it must "
+        "execute in a worker thread, not on the loop."
+    )


### PR DESCRIPTION
Closes #448.

## Problem

`meeting-api` makes **synchronous boto3 S3 calls directly on the asyncio event loop** from several `async def` handlers. The hottest path is the recording chunk-upload (`internal_upload_recording`), which does a blocking `put_object` on **every chunk**. Under concurrent recording load these calls serialize on the single event-loop thread and stall it for seconds — long enough for the otherwise-trivial liveness (`/health`) and readiness (`/readyz`) probes to time out, so Kubernetes restarts the pod and drops it from the Service even though it is not CPU- or memory-bound. Because the stall is network *wait*, CPU stays low → it presents as intermittent restarts under load.

## Fix

Offload every synchronous storage call made from async code to a worker thread via `asyncio.to_thread(...)`, matching the pattern already used in `recording_finalizer.py`. `boto3` clients are thread-safe across distinct operations, so this is behaviour-preserving — it just unblocks the loop.

Call sites wrapped:
- **`recordings.py`** — `internal_upload_recording` → `upload_file` (the hot path); `download_media_file` → `file_exists`, `get_presigned_url`; `download_media_file_raw` → `download_file`
- **`meetings.py`** — `transcribe_meeting` audio `download_file`
- **`sweeps.py`** — `list_objects_bounded` in both sweep paths

## Tests

Added `tests/test_recordings_offload_blocking_s3.py`: a regression test asserting the chunk upload executes on a **worker thread** (not the event-loop thread, and with no running loop in that thread). It fails on the pre-fix code and passes with the offload.

```
$ python -m pytest tests/test_recordings.py tests/test_recordings_concurrent_chunks.py \
    tests/test_recordings_offload_blocking_s3.py tests/test_sweeps_unfinalized_recordings.py \
    tests/test_sweeps_stopping.py tests/test_storage_bounded.py tests/test_meetings.py \
    tests/test_recording_media_content_type.py
37 passed
```

## Secondary hardening (not included here)

The issue also suggests slightly more forgiving probe `timeoutSeconds`/`failureThreshold` in the Deployment so a brief legitimate stall doesn't cause an avoidable restart. That's a deployment-manifest change orthogonal to this code fix, so I left it out to keep this PR focused — happy to follow up if you'd like it.