### PR TITLE
fix: distinguish Google Meet lobby timeout from explicit host denial

### DIFF
--- a/services/meeting-api/meeting_api/schemas.py
+++ b/services/meeting-api/meeting_api/schemas.py
@@ -82,6 +82,8 @@ class MeetingCompletionReason(str, Enum):
     STOPPED_WITH_NO_AUDIO = "stopped_with_no_audio"  # Bot ran ≥30s with transcribe enabled but produced 0 segments (125 cases / 30d)
     # Pack D (#5) — canonicalized pre-admission failure reasons:
     JOIN_FAILURE = "join_failure"  # Bot failed to navigate to the meeting (pre-lobby fast fail, distinct from user-stopped)
+    # v0.10.6 (#421) — split lobby timeout from explicit host denial:
+    NEVER_ADMITTED = "never_admitted"  # Bot waited full lobby timeout; host did not explicitly deny
 
 class MeetingFailureStage(str, Enum):
     """

--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
@@ -88,5 +88,23 @@ expectFileContains(
   'Ask to join again',
 );
 
+expectFileContains(
+  'admission.ts exports never_admitted outcome',
+  ADMISSION_TS,
+  '"never_admitted"',
+);
+
+expectFileContains(
+  'admission.ts has classifyRejectionOutcome',
+  ADMISSION_TS,
+  'classifyRejectionOutcome',
+);
+
+expectFileContains(
+  'admission.ts has explicit deny text check',
+  ADMISSION_TS,
+  'hasExplicitDenyText',
+);
+
 console.log(`\n=== googlemeet admission summary: ${passed} passed, ${failed} failed ===`);
 process.exit(failed > 0 ? 1 : 0);

--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.ts
@@ -11,10 +11,12 @@ import {
 /**
  * Distinct admission outcomes emitted by the detector.
  * denial        — host explicitly rejected the bot from the waiting room.
+ * never_admitted — bot waited full lobby timeout (~10 min) without explicit
+ *                  denial text; "Return to home screen" appeared after timeout.
  * lobby_timeout — bot stayed in the waiting room past the admission timeout.
  * join_failure  — bot never reached the lobby / no admission indicators appeared.
  */
-export type AdmissionOutcome = "denial" | "lobby_timeout" | "join_failure";
+export type AdmissionOutcome = "denial" | "never_admitted" | "lobby_timeout" | "join_failure";
 
 export class AdmissionError extends Error {
   readonly outcome: AdmissionOutcome;
@@ -37,6 +39,56 @@ export async function hasRecaptchaChallenge(page: Page): Promise<boolean> {
     }
     const iframe = page.locator('iframe[src*="recaptcha"]').first();
     return await iframe.isVisible().catch(() => false);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Explicit denial-text selectors — when ANY of these are visible the host
+ * deliberately rejected the bot.  Separated from UI affordances ("Return to
+ * home screen", "Ask to join again") that appear both on explicit denial AND
+ * on lobby timeout.
+ */
+const EXPLICIT_DENY_SELECTORS: string[] = [
+  'text*="denied your request"',
+  'text*="denied your request to join"',
+  'text*="Your request to join was denied"',
+  'text*="You were denied"',
+  'text*="weren\'t allowed to join"',
+  'text*="not allowed to join"',
+  'text*="not admitted"',
+  'text*="can\'t join this call"',
+  'text*="cannot join this call"',
+];
+
+/**
+ * UI affordance selectors that signal the bot is no longer in the waiting
+ * room but do NOT, on their own, prove an explicit host denial.  These also
+ * appear after a ~10-min lobby timeout when the host never acted.
+ */
+const TIMEOUT_OR_DENY_SELECTORS: string[] = [
+  'text*="Ask to join again"',
+  'button:has-text("Ask to join again")',
+  'button:has-text("Return to home screen")',
+];
+
+/**
+ * Check whether explicit deny text is visible on the page.  Returns true
+ * only when a linguistic denial indicator (e.g. "denied your request") is
+ * present — "Return to home screen" alone does NOT count.
+ */
+async function hasExplicitDenyText(page: Page): Promise<boolean> {
+  try {
+    for (const selector of EXPLICIT_DENY_SELECTORS) {
+      try {
+        const element = page.locator(selector).first();
+        if (await element.isVisible().catch(() => false)) {
+          return true;
+        }
+      } catch { continue; }
+    }
+    return false;
   } catch {
     return false;
   }
@@ -72,6 +124,39 @@ export async function checkForGoogleRejection(page: Page): Promise<boolean> {
     log(`Error checking for Google Meet rejection: ${error.message}`);
     return false;
   }
+}
+
+/**
+ * Classify a detected rejection into the right AdmissionOutcome.
+ *
+ * When "Return to home screen" or "Ask to join again" is visible:
+ *   - If explicit deny text is ALSO visible → "denial" (host deliberately rejected).
+ *   - If no explicit deny text AND the bot waited ≥ MIN_LOBBY_TIMEOUT_MS → "never_admitted".
+ *   - Otherwise → "denial" (conservative; treat ambiguous early rejection as denial).
+ */
+export function classifyRejectionOutcome(
+  pageHasExplicitDeny: boolean,
+  waitingRoomElapsedMs: number,
+): AdmissionOutcome {
+  // 590 s gives a 10 s margin below the ~600 s Google Meet lobby timeout.
+  const MIN_LOBBY_TIMEOUT_MS = 590_000;
+
+  if (pageHasExplicitDeny) {
+    log("🚨 Explicit deny text found — classifying as host denial.");
+    return "denial";
+  }
+
+  if (waitingRoomElapsedMs >= MIN_LOBBY_TIMEOUT_MS) {
+    log(
+      `⏰ No explicit deny text and waited ${Math.round(waitingRoomElapsedMs / 1000)}s ≥ ${MIN_LOBBY_TIMEOUT_MS / 1000}s — classifying as lobby timeout (never_admitted).`,
+    );
+    return "never_admitted";
+  }
+
+  log(
+    `⚠️ No explicit deny text but only waited ${Math.round(waitingRoomElapsedMs / 1000)}s — classifying conservatively as denial.`,
+  );
+  return "denial";
 }
 
 // Helper function to check for any visible and enabled admission indicators
@@ -228,6 +313,10 @@ export async function waitForGoogleMeetingAdmission(
       stillInWaitingRoom = true;
     }
     
+    // Track when the bot first entered the waiting room (or started polling).
+    // Used by the final rejection check to distinguish lobby timeout from denial.
+    let waitingRoomEnterTime = Date.now();
+
     // If we're in waiting room, wait for the full timeout period for admission
     if (stillInWaitingRoom) {
       log(`Bot is in Google Meet waiting room. Waiting for ${timeout}ms for admission...`);
@@ -365,6 +454,21 @@ export async function waitForGoogleMeetingAdmission(
     log("No admission indicators after timeout - checking rejection one last time...");
     const finalRejected = await checkForGoogleRejection(page);
     if (finalRejected) {
+      // Distinguish explicit host denial from lobby timeout.
+      // "Return to home screen" appears in both cases; explicit deny text
+      // ("denied your request") proves deliberate rejection.
+      const explicitDeny = await hasExplicitDenyText(page);
+      const waitingRoomElapsed = Date.now() - waitingRoomEnterTime;
+      const outcome = classifyRejectionOutcome(explicitDeny, waitingRoomElapsed);
+      if (outcome === "never_admitted") {
+        log(
+          `⏰ Bot waited ${Math.round(waitingRoomElapsed / 1000)}s in lobby but was never admitted — no explicit deny text found.`,
+        );
+        throw new AdmissionError(
+          "never_admitted",
+          "Bot was not admitted to the meeting after lobby timeout — host did not explicitly deny",
+        );
+      }
       throw new AdmissionError("denial", "Bot admission was rejected by meeting admin");
     }
 

--- a/services/vexa-bot/core/src/platforms/shared/meetingFlow.ts
+++ b/services/vexa-bot/core/src/platforms/shared/meetingFlow.ts
@@ -91,6 +91,9 @@ export async function runMeetingFlow(
           if (msg.includes("rejected by meeting admin")) {
             return { admitted: false, rejected: true, reason: "admission_rejected_by_admin" } as AdmissionDecision;
           }
+          if (msg.includes("never_admitted") || msg.includes("not admitted to the meeting after lobby timeout")) {
+            return { admitted: false, rejected: false, reason: "admission_never_admitted" } as AdmissionDecision;
+          }
           return { admitted: false, rejected: false, reason: "admission_timeout" } as AdmissionDecision;
         }),
       strategies.prepare(page, botConfig),

--- a/services/vexa-bot/core/src/services/unified-callback.ts
+++ b/services/vexa-bot/core/src/services/unified-callback.ts
@@ -13,6 +13,7 @@ export type CompletionReason =
   | "validation_error"
   | "awaiting_admission_timeout"
   | "awaiting_admission_rejected"
+  | "never_admitted"
   | "left_alone"
   | "evicted"
   | "max_bot_time_exceeded"
@@ -266,6 +267,8 @@ export function mapExitReasonToStatus(
         return { status: "completed", completionReason: "evicted" };
       case "admission_rejected_by_admin":
         return { status: "completed", completionReason: "awaiting_admission_rejected" };
+      case "admission_never_admitted":
+        return { status: "completed", completionReason: "never_admitted" };
       default:
         return { status: "completed", completionReason: "stopped" };
     }


### PR DESCRIPTION
## Summary

Currently `awaiting_admission_rejected` is the single largest no-join outcome (~195 meetings / 41 users in 30d), but the majority are **not** host denials — the bot waits the full ~10 min lobby timeout and then sees "Return to home screen", which the current code treats as a denial.

This PR adds a new `never_admitted` outcome to distinguish lobby timeouts from explicit host denials.

Fixes #421

## Changes

- **admission.ts**: Add `never_admitted` to `AdmissionOutcome`. Add `classifyRejectionOutcome()` and `hasExplicitDenyText()` helpers. Track waiting room entry time and check for explicit deny text before classifying as denial. Use 590s threshold for lobby timeout.
- **meetingFlow.ts**: Handle `admission_never_admitted` reason string.
- **unified-callback.ts**: Add `never_admitted` to `CompletionReason` type with mapping in `mapExitReasonToStatus()`.
- **schemas.py**: Add `NEVER_ADMITTED` to `MeetingCompletionReason` enum.
- **admission.test.ts**: Add structural regression tests for new exports.

## How it works

When a rejection indicator is detected at the end of the waiting period:
1. Check if **explicit deny text** is visible (e.g. "denied your request")
2. If yes → `denial` (host deliberately rejected)
3. If no AND elapsed time ≥ 590s → `never_admitted` (lobby timeout)
4. Otherwise → `denial` (conservative for ambiguous early cases)

Co-Authored-By: Claude <noreply@anthropic.com>