### PR TITLE
fix(meeting-api): stop unfinalized-recordings sweep from wedging the event loop

### DIFF
--- a/services/meeting-api/meeting_api/storage.py
+++ b/services/meeting-api/meeting_api/storage.py
@@ -76,6 +76,19 @@ class StorageClient(ABC):
         memory growth from a user with very many chunks."""
         ...
 
+    @abstractmethod
+    def list_common_prefixes(self, prefix: str) -> list:
+        """List the immediate child "directories" under prefix (delimiter '/').
+
+        Returns a sorted list of common-prefix strings, each ending in '/'.
+        Lets callers enumerate per-recording prefixes
+        (`recordings/<user>/<rec>/`) cheaply — one entry per recording
+        rather than one object per chunk — so a session-scoped chunk search
+        doesn't have to page a heavy user's entire object list (which both
+        blocks the caller and can truncate before reaching a late-sorting
+        session's chunks)."""
+        ...
+
 
 class MinIOStorageClient(StorageClient):
     """MinIO/S3-compatible storage client using boto3."""
@@ -260,6 +273,19 @@ class MinIOStorageClient(StorageClient):
         keys.sort()
         return keys
 
+    def list_common_prefixes(self, prefix: str) -> list:
+        prefixes = []
+        paginator = self.client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(
+            Bucket=self.bucket, Prefix=prefix, Delimiter="/"
+        ):
+            for cp in page.get("CommonPrefixes", []):
+                key = cp.get("Prefix")
+                if key:
+                    prefixes.append(key)
+        prefixes.sort()
+        return prefixes
+
 
 class LocalStorageClient(StorageClient):
     """Filesystem-based storage client for development/testing."""
@@ -353,6 +379,20 @@ class LocalStorageClient(StorageClient):
             )
         keys.sort()
         return keys
+
+    def list_common_prefixes(self, prefix: str) -> list:
+        normalized_prefix = self._normalize_path(prefix) if prefix else ""
+        full_prefix = os.path.join(self.base_dir, normalized_prefix) if normalized_prefix else self.base_dir
+        if not os.path.isdir(full_prefix):
+            return []
+        base = normalized_prefix.rstrip("/")
+        prefixes = []
+        for entry in os.scandir(full_prefix):
+            if entry.is_dir():
+                child = f"{base}/{entry.name}/" if base else f"{entry.name}/"
+                prefixes.append(child)
+        prefixes.sort()
+        return prefixes
 
 
 def create_storage_client(backend: Optional[str] = None) -> StorageClient:

--- a/services/meeting-api/meeting_api/sweeps.py
+++ b/services/meeting-api/meeting_api/sweeps.py
@@ -33,7 +33,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Callable, Optional
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import attributes
 
@@ -52,6 +52,21 @@ STALE_STOPPING_THRESHOLD_SECONDS = 300  # 5 min
 STALE_STOPPING_POLL_INTERVAL = 60  # check every 60 s
 UNFINALIZED_RECORDINGS_MIN_AGE_SECONDS = 5
 UNFINALIZED_RECORDINGS_LIMIT = 100
+
+# Terminal cap for the unfinalized-recordings sweep. A terminal meeting whose
+# session chunks never reconcile to a playable recording (no chunks in storage,
+# or a partial/abandoned upload) would otherwise be re-selected and re-listed
+# every poll interval forever. After this many failed reconciliation attempts
+# we mark the meeting and exclude it from selection so the loop converges.
+UNFINALIZED_RECORDINGS_MAX_ATTEMPTS = 5
+UNFINALIZED_RECORDINGS_ABANDONED_KEY = "recording_finalize_abandoned"
+UNFINALIZED_RECORDINGS_ATTEMPTS_KEY = "recording_finalize_attempts"
+
+# Cap on how many per-recording prefixes a single session-scoped chunk search
+# will probe. A user with more recordings than this is pathological; we log and
+# scan only the newest slice rather than block. Combined with the terminal cap
+# above, no meeting is ever re-listed without bound.
+SESSION_CHUNK_SCAN_PREFIX_CAP = 500
 
 # v0.10.5 Pack K.5 (meeting-api side analog).
 # Module-level state for /health probe / Pack M metrics.
@@ -345,6 +360,50 @@ def _parse_recording_chunk_key(user_id: int, session_uid: str, key: str) -> Opti
     return recording_id, media_type, filename.rsplit(".", 1)[-1].lower()
 
 
+async def _list_session_chunks(storage, user_id: int, session_uid: str) -> list:
+    """Session-scoped chunk listing — non-blocking and bounded.
+
+    The storage layout is
+    ``recordings/<user>/<rec_id>/<session_uid>/<media_type>/<seq>.<ext>``;
+    the rec_id sits *between* the user and the session, so we cannot prefix
+    straight to a session. Earlier code listed the whole-user prefix
+    ``recordings/<user>/`` (up to max_keys=10000 chunk objects) and filtered
+    in Python — two bugs:
+      * the boto3 list ran SYNCHRONOUSLY on the async event loop, freezing
+        /health + /readyz for ~1.5 s on heavy users → liveness probe killed
+        the pod → CrashLoopBackOff;
+      * truncation at max_keys could drop a late-sorting session's chunks
+        entirely, so that meeting never reconciled and was re-swept forever.
+
+    This enumerates the user's per-recording prefixes (cheap CommonPrefixes —
+    one entry per recording, not one per chunk) and lists only the
+    ``recordings/<user>/<rec_id>/<session_uid>/`` slice for each. Every
+    blocking boto3 call is offloaded with ``asyncio.to_thread`` so the event
+    loop never stalls.
+    """
+    user_prefix = f"recordings/{user_id}/"
+    rec_prefixes = await asyncio.to_thread(storage.list_common_prefixes, user_prefix)
+
+    if len(rec_prefixes) > SESSION_CHUNK_SCAN_PREFIX_CAP:
+        # Newest recordings sort last lexicographically (zero-padded ids), and
+        # the session we're recovering is almost always recent — scan the tail.
+        logger.warning(
+            "[sweep] user %s has %d recording prefixes (> cap %d); scanning the "
+            "newest %d for session %s, remainder skipped this iteration",
+            user_id, len(rec_prefixes), SESSION_CHUNK_SCAN_PREFIX_CAP,
+            SESSION_CHUNK_SCAN_PREFIX_CAP, session_uid,
+        )
+        rec_prefixes = rec_prefixes[-SESSION_CHUNK_SCAN_PREFIX_CAP:]
+
+    keys: list[str] = []
+    for rec_prefix in rec_prefixes:
+        session_prefix = f"{rec_prefix}{session_uid}/"
+        chunk_keys = await asyncio.to_thread(storage.list_objects_bounded, session_prefix)
+        if chunk_keys:
+            keys.extend(chunk_keys)
+    return keys
+
+
 def _recording_has_playback_url(rec: dict) -> bool:
     playback_url = rec.get("playback_url") if isinstance(rec, dict) else None
     if not isinstance(playback_url, dict):
@@ -392,13 +451,12 @@ async def recover_recordings_jsonb_from_storage(
     for session in sessions:
         if session.session_uid in existing_sessions:
             continue
-        prefix = f"recordings/{meeting.user_id}/"
         try:
-            keys = storage.list_objects_bounded(prefix)
+            keys = await _list_session_chunks(storage, meeting.user_id, session.session_uid)
         except Exception as e:
             logger.warning(
-                "[finalizer-recovery] storage list failed meeting_id=%s prefix=%s error=%s",
-                meeting.id, prefix, str(e)[:200],
+                "[finalizer-recovery] storage list failed meeting_id=%s session_uid=%s error=%s",
+                meeting.id, session.session_uid, str(e)[:200],
             )
             continue
 
@@ -492,6 +550,16 @@ async def _sweep_unfinalized_recordings(
             select(Meeting.id)
             .where(Meeting.status.in_([MeetingStatus.COMPLETED.value, MeetingStatus.FAILED.value]))
             .where(Meeting.created_at < cutoff)
+            # Terminal cap: skip meetings already abandoned after
+            # UNFINALIZED_RECORDINGS_MAX_ATTEMPTS failed reconciliations, so an
+            # un-finalizable recording stops being re-selected (and re-listed)
+            # every poll interval forever.
+            .where(
+                or_(
+                    Meeting.data[UNFINALIZED_RECORDINGS_ABANDONED_KEY].astext.is_(None),
+                    Meeting.data[UNFINALIZED_RECORDINGS_ABANDONED_KEY].astext != "true",
+                )
+            )
             .order_by(Meeting.id.desc())
             .limit(UNFINALIZED_RECORDINGS_LIMIT)
         )).fetchall()
@@ -521,6 +589,7 @@ async def _sweep_unfinalized_recordings(
             )
 
             changed = False
+            unresolved_session = False
             sessions = (await db.execute(
                 select(MeetingSession).where(MeetingSession.meeting_id == meeting.id)
             )).scalars().all()
@@ -535,14 +604,16 @@ async def _sweep_unfinalized_recordings(
                 if session.session_uid in existing_sessions:
                     continue
 
-                prefix = f"recordings/{meeting.user_id}/"
                 try:
-                    keys = storage.list_objects_bounded(prefix)
+                    keys = await _list_session_chunks(storage, meeting.user_id, session.session_uid)
                 except Exception as e:
+                    # Transient storage error — do NOT count toward the terminal
+                    # cap; we retry next iteration rather than abandon a meeting
+                    # whose chunks may still be reachable.
                     logger.warning(
                         "[sweep] unfinalized-recordings storage list failed "
-                        "meeting_id=%s prefix=%s error=%s",
-                        meeting.id, prefix, str(e)[:200],
+                        "meeting_id=%s session_uid=%s error=%s",
+                        meeting.id, session.session_uid, str(e)[:200],
                     )
                     continue
 
@@ -554,6 +625,9 @@ async def _sweep_unfinalized_recordings(
                     grouped.setdefault(parsed, []).append(key)
 
                 if not grouped:
+                    # Session has no reconcilable chunks in storage — the state
+                    # that, pre-fix, kept this meeting in the sweep set forever.
+                    unresolved_session = True
                     continue
 
                 now = datetime.utcnow().isoformat()
@@ -582,6 +656,7 @@ async def _sweep_unfinalized_recordings(
                     })
 
                 if recording_id is None or not media_files:
+                    unresolved_session = True
                     continue
 
                 recordings.append({
@@ -624,6 +699,32 @@ async def _sweep_unfinalized_recordings(
                         meeting.id, str(e)[:200], exc_info=True,
                     )
                     await db.rollback()
+            elif unresolved_session:
+                # Nothing reconciled and no JSONB to finalize: this terminal
+                # meeting has a session whose chunks will never become a
+                # recording. Count the attempt and, at the cap, mark it
+                # abandoned so the selection query above stops returning it —
+                # converging the loop instead of re-listing storage forever.
+                attempts = int(data.get(UNFINALIZED_RECORDINGS_ATTEMPTS_KEY) or 0) + 1
+                data[UNFINALIZED_RECORDINGS_ATTEMPTS_KEY] = attempts
+                if attempts >= UNFINALIZED_RECORDINGS_MAX_ATTEMPTS:
+                    data[UNFINALIZED_RECORDINGS_ABANDONED_KEY] = True
+                    data[UNFINALIZED_RECORDINGS_ABANDONED_KEY + "_at"] = datetime.utcnow().isoformat()
+                    logger.warning(
+                        "[sweep] unfinalized-recordings ABANDONING meeting_id=%s after "
+                        "%d attempts — no reconcilable chunks for its session(s); "
+                        "excluding from future sweeps",
+                        meeting.id, attempts,
+                    )
+                else:
+                    logger.info(
+                        "[sweep] unfinalized-recordings meeting_id=%s attempt %d/%d — "
+                        "no reconcilable chunks yet",
+                        meeting.id, attempts, UNFINALIZED_RECORDINGS_MAX_ATTEMPTS,
+                    )
+                meeting.data = data
+                attributes.flag_modified(meeting, "data")
+                await db.commit()
 
     return swept
 

--- a/services/meeting-api/tests/test_storage_bounded.py
+++ b/services/meeting-api/tests/test_storage_bounded.py
@@ -1,11 +1,18 @@
-"""Tests for StorageClient.list_objects_bounded — D20 finding-2 protection."""
+"""Tests for StorageClient.list_objects_bounded — D20 finding-2 protection.
+
+Also covers StorageClient.list_common_prefixes — the delimiter-based
+per-recording enumeration the unfinalized-recordings sweep uses to scope chunk
+listing to a single session instead of paging a heavy user's entire object list.
+"""
 
 import logging
 import os
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from meeting_api.storage import LocalStorageClient
+from meeting_api.storage import LocalStorageClient, MinIOStorageClient
 
 
 @pytest.fixture
@@ -38,3 +45,51 @@ def test_truncates_at_max_keys_and_warns(storage, caplog):
 
 def test_empty_prefix_returns_empty(storage):
     assert storage.list_objects_bounded("missing/", max_keys=10) == []
+
+
+def test_local_list_common_prefixes_returns_immediate_recording_dirs(storage):
+    # Layout: recordings/<user>/<rec>/<session>/<media_type>/<chunk>
+    for rec in ("735125303957", "999999999999"):
+        d = os.path.join(storage.base_dir, "recordings", "1523", rec, "sess", "audio")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "000000.webm"), "wb") as f:
+            f.write(b"x")
+
+    prefixes = storage.list_common_prefixes("recordings/1523/")
+    assert prefixes == [
+        "recordings/1523/735125303957/",
+        "recordings/1523/999999999999/",
+    ]
+
+
+def test_local_list_common_prefixes_missing_returns_empty(storage):
+    assert storage.list_common_prefixes("recordings/404/") == []
+
+
+def test_minio_list_common_prefixes_uses_delimiter():
+    # Build without __init__ to avoid constructing a real boto3 client.
+    client = MinIOStorageClient.__new__(MinIOStorageClient)
+    client.bucket = "vexa-recordings"
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {"CommonPrefixes": [
+            {"Prefix": "recordings/1523/735125303957/"},
+            {"Prefix": "recordings/1523/999999999999/"},
+        ]},
+        {"CommonPrefixes": [{"Prefix": "recordings/1523/111111111111/"}]},
+        {},  # a page with no CommonPrefixes must be tolerated
+    ]
+    client.client = MagicMock()
+    client.client.get_paginator.return_value = paginator
+
+    out = client.list_common_prefixes("recordings/1523/")
+
+    assert out == [
+        "recordings/1523/111111111111/",
+        "recordings/1523/735125303957/",
+        "recordings/1523/999999999999/",
+    ]
+    paginator.paginate.assert_called_once_with(
+        Bucket="vexa-recordings", Prefix="recordings/1523/", Delimiter="/"
+    )

--- a/services/meeting-api/tests/test_sweeps_unfinalized_recordings.py
+++ b/services/meeting-api/tests/test_sweeps_unfinalized_recordings.py
@@ -49,11 +49,14 @@ async def test_sweep_unfinalized_recordings_recovers_missing_jsonb_from_storage_
     async def db_session_factory():
         yield db
 
+    # The recording id sits BETWEEN user and session in the key layout, so the
+    # sweep enumerates per-recording prefixes, then lists only the matching
+    # <user>/<rec>/<session>/ slice — never the whole-user prefix.
     storage = MagicMock()
+    storage.list_common_prefixes.return_value = ["recordings/1523/735125303957/"]
     storage.list_objects_bounded.return_value = [
         "recordings/1523/735125303957/213160c7-e317-4427-a928-ffbeb5ae61d8/audio/000000.webm",
         "recordings/1523/735125303957/213160c7-e317-4427-a928-ffbeb5ae61d8/audio/master.webm",
-        "recordings/1523/999999999999/other-session/audio/000000.webm",
     ]
 
     with patch("meeting_api.storage.create_storage_client", return_value=storage), \
@@ -66,6 +69,12 @@ async def test_sweep_unfinalized_recordings_recovers_missing_jsonb_from_storage_
     assert meeting.data["recordings"][0]["session_uid"] == session.session_uid
     assert meeting.data["recordings"][0]["media_files"][0]["storage_path"].endswith("/audio/000000.webm")
     assert meeting.data["recordings"][0]["media_files"][0]["is_final"] is False
+    # Scoping: the only object listing is the session-scoped slice, not the
+    # user-wide prefix that previously froze the event loop / truncated at 10k.
+    storage.list_common_prefixes.assert_called_once_with("recordings/1523/")
+    storage.list_objects_bounded.assert_called_once_with(
+        "recordings/1523/735125303957/213160c7-e317-4427-a928-ffbeb5ae61d8/"
+    )
     db.commit.assert_awaited_once()
     finalize.assert_awaited_once_with(10062, db)
     flag_modified.assert_called_once_with(meeting, "data")
@@ -115,6 +124,157 @@ async def test_sweep_unfinalized_recordings_finalizes_existing_jsonb_without_sto
         swept = await sweeps._sweep_unfinalized_recordings(db_session_factory)
 
     assert swept == 1
+    # JSONB already present → no storage walk at all.
+    storage.list_common_prefixes.assert_not_called()
     storage.list_objects_bounded.assert_not_called()
     db.commit.assert_not_called()
     finalize.assert_awaited_once_with(10063, db)
+
+
+@pytest.mark.asyncio
+async def test_list_session_chunks_is_session_scoped_and_offloaded(monkeypatch):
+    """The hot path that caused the outage: prove the chunk listing is scoped
+    to <user>/<rec>/<session>/ (never the bare user prefix) AND that every
+    blocking boto3 call is dispatched through asyncio.to_thread so the event
+    loop (and its /health + /readyz probes) never stalls."""
+    storage = MagicMock()
+    storage.list_common_prefixes.return_value = ["recordings/9/aaa/", "recordings/9/bbb/"]
+
+    def fake_bounded(prefix):
+        return ["recordings/9/bbb/sess-X/audio/000000.webm"] if "bbb/sess-X/" in prefix else []
+
+    storage.list_objects_bounded.side_effect = fake_bounded
+
+    offloaded = []
+    real_to_thread = sweeps.asyncio.to_thread
+
+    async def spy_to_thread(fn, *args, **kwargs):
+        offloaded.append(fn)
+        return await real_to_thread(fn, *args, **kwargs)
+
+    monkeypatch.setattr(sweeps.asyncio, "to_thread", spy_to_thread)
+
+    keys = await sweeps._list_session_chunks(storage, 9, "sess-X")
+
+    assert keys == ["recordings/9/bbb/sess-X/audio/000000.webm"]
+    # User prefix used only for the cheap CommonPrefixes enumeration.
+    storage.list_common_prefixes.assert_called_once_with("recordings/9/")
+    # Object listing is scoped per <rec>/<session>/ — and crucially is NEVER
+    # the bare "recordings/9/" user prefix.
+    listed = [c.args[0] for c in storage.list_objects_bounded.call_args_list]
+    assert listed == ["recordings/9/aaa/sess-X/", "recordings/9/bbb/sess-X/"]
+    assert "recordings/9/" not in listed
+    assert all(p.endswith("/sess-X/") for p in listed)
+    # Both blocking calls went through to_thread — no synchronous boto3 on the loop.
+    assert storage.list_common_prefixes in offloaded
+    assert storage.list_objects_bounded in offloaded
+
+
+@pytest.mark.asyncio
+async def test_list_session_chunks_caps_pathological_prefix_count(monkeypatch):
+    """A user with more recording prefixes than the cap is scanned in a bounded
+    slice (newest tail) — never an unbounded scan."""
+    n = sweeps.SESSION_CHUNK_SCAN_PREFIX_CAP + 50
+    storage = MagicMock()
+    storage.list_common_prefixes.return_value = [f"recordings/9/{i:06d}/" for i in range(n)]
+    storage.list_objects_bounded.return_value = []
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(sweeps.asyncio, "to_thread", fake_to_thread)
+
+    await sweeps._list_session_chunks(storage, 9, "sess-X")
+
+    # Only the capped slice was probed for chunks.
+    assert storage.list_objects_bounded.call_count == sweeps.SESSION_CHUNK_SCAN_PREFIX_CAP
+
+
+@pytest.mark.asyncio
+async def test_sweep_unfinalized_recordings_increments_attempt_when_no_chunks():
+    """A terminal meeting whose session has no reconcilable chunks must count an
+    attempt (toward the terminal cap) rather than silently re-list forever."""
+    meeting = make_meeting(
+        id=10070,
+        user_id=1523,
+        status=MeetingStatus.COMPLETED.value,
+        data={"recording_enabled": True},
+        created_at=datetime.utcnow() - timedelta(minutes=10),
+    )
+    session = make_session(meeting_id=10070, session_uid="sess-nochunks")
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            FetchAllResult([(10070,)]),
+            MockResult(items=[meeting]),
+            MockResult(items=[session]),
+        ]
+    )
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+
+    @asynccontextmanager
+    async def db_session_factory():
+        yield db
+
+    storage = MagicMock()
+    storage.list_common_prefixes.return_value = ["recordings/1523/111/"]
+    storage.list_objects_bounded.return_value = []  # nothing for this session
+
+    with patch("meeting_api.storage.create_storage_client", return_value=storage), \
+         patch("meeting_api.recording_finalizer.finalize_recording_master", new=AsyncMock()) as finalize, \
+         patch.object(sweeps.attributes, "flag_modified", new=MagicMock()):
+        swept = await sweeps._sweep_unfinalized_recordings(db_session_factory)
+
+    assert swept == 0
+    assert meeting.data[sweeps.UNFINALIZED_RECORDINGS_ATTEMPTS_KEY] == 1
+    assert sweeps.UNFINALIZED_RECORDINGS_ABANDONED_KEY not in meeting.data
+    finalize.assert_not_awaited()
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sweep_unfinalized_recordings_abandons_after_max_attempts():
+    """At the attempt cap the meeting is flagged abandoned so the selection
+    query stops returning it — converging the forever-loop."""
+    meeting = make_meeting(
+        id=10071,
+        user_id=1523,
+        status=MeetingStatus.COMPLETED.value,
+        data={
+            "recording_enabled": True,
+            sweeps.UNFINALIZED_RECORDINGS_ATTEMPTS_KEY: sweeps.UNFINALIZED_RECORDINGS_MAX_ATTEMPTS - 1,
+        },
+        created_at=datetime.utcnow() - timedelta(minutes=10),
+    )
+    session = make_session(meeting_id=10071, session_uid="sess-nochunks")
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            FetchAllResult([(10071,)]),
+            MockResult(items=[meeting]),
+            MockResult(items=[session]),
+        ]
+    )
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+
+    @asynccontextmanager
+    async def db_session_factory():
+        yield db
+
+    storage = MagicMock()
+    storage.list_common_prefixes.return_value = ["recordings/1523/111/"]
+    storage.list_objects_bounded.return_value = []
+
+    with patch("meeting_api.storage.create_storage_client", return_value=storage), \
+         patch("meeting_api.recording_finalizer.finalize_recording_master", new=AsyncMock()), \
+         patch.object(sweeps.attributes, "flag_modified", new=MagicMock()):
+        swept = await sweeps._sweep_unfinalized_recordings(db_session_factory)
+
+    assert swept == 0
+    assert meeting.data[sweeps.UNFINALIZED_RECORDINGS_ATTEMPTS_KEY] == sweeps.UNFINALIZED_RECORDINGS_MAX_ATTEMPTS
+    assert meeting.data[sweeps.UNFINALIZED_RECORDINGS_ABANDONED_KEY] is True
+    assert f"{sweeps.UNFINALIZED_RECORDINGS_ABANDONED_KEY}_at" in meeting.data


### PR DESCRIPTION
## Problem (production CrashLoopBackOff → dashboard /meetings outage)

`_sweep_unfinalized_recordings` and `recover_recordings_jsonb_from_storage`
(`meeting_api/sweeps.py`) listed the **whole-user** S3 prefix
`recordings/{user_id}/` (10k+ objects for heavy users) via a **synchronous**
boto3 call **directly on the async event loop**, every 60s.

On a heavy user (>10k objects) the list froze the loop for ~1.5s, so `/health`
and `/readyz` timed out → kubelet liveness probe killed the pod →
CrashLoopBackOff → the meeting-api Service had zero endpoints → the dashboard
`/meetings` page intermittently failed to load. `main.py` even documents the
trap: `/health` is *"always 200 unless event loop is wedged"*.

Three compounding bugs, all fixed here:

1. **Blocking I/O on the loop.** Both list calls (and the inline finalizer
   recovery path) now run via `asyncio.to_thread`, so the event loop — and its
   probes — never stalls.

2. **User-scoped prefix.** The real key layout (write side `recordings.py`,
   parser `_parse_recording_chunk_key`) is
   `recordings/<user>/<rec>/<session>/<media>/<seq>`. The `rec` id sits
   *between* user and session, so a session can't be prefixed directly. New
   `StorageClient.list_common_prefixes()` (delimiter listing) enumerates
   per-recording prefixes cheaply, then `_list_session_chunks()` lists only the
   `recordings/<user>/<rec>/<session>/` slice. This also fixes a **correctness**
   bug: the old `max_keys=10000` truncation could drop a late-sorting session's
   chunks entirely, so it never reconciled and was re-swept forever.

3. **No terminal cap.** A terminal meeting whose session never reconciles now
   counts attempts in `meeting.data`; after `UNFINALIZED_RECORDINGS_MAX_ATTEMPTS`
   it's marked `recording_finalize_abandoned` and excluded from the selection
   query, so the loop converges instead of re-listing storage forever.

## Tests

New/updated tests in `services/meeting-api/tests/`:
- session-scoped listing + `asyncio.to_thread` offload (no sync boto3 on loop)
- pathological prefix-count cap
- attempt-increment when a session has no reconcilable chunks
- abandon-at-cap exclusion
- `list_common_prefixes` for both Local and MinIO backends

Full meeting-api suite: **288 passed, 10 skipped** (Python 3.10).

## Notes for the hosted deploy

The hosted platform additionally re-vendors its Helm subchart to expose
meeting-api probe `timeoutSeconds`/`failureThreshold` knobs (mirroring the
`ttsService` fix from v0.10.6.1) so a single replica rides out slow spells —
tracked separately in the platform repo. This PR is the durable root-cause fix
for the OSS service.