### PR TITLE
feat(api-gateway): add fastapi-guard for per-IP rate limiting + IP auto-ban

### DIFF
--- a/services/api-gateway/guard_config.py
+++ b/services/api-gateway/guard_config.py
@@ -1,0 +1,132 @@
+"""fastapi-guard integration config for the Vexa api-gateway.
+
+Wires guard's SecurityMiddleware as a layer complementary to the gateway's
+existing per-key rate limiter: per-IP rate limiting, auto-IP-ban, and optional
+IP/geo/cloud blocking (all env-driven, default off).
+
+Two things are intentionally disabled here and handled by Vexa's own
+middleware instead, to avoid duplicates / conflicting headers:
+
+* CORS — Vexa already runs ``CORSMiddleware``.
+* Security headers — Vexa's ``SecurityHeadersMiddleware`` carries VNC-specific
+  CSP ``frame-ancestors`` logic guard cannot replicate.
+
+Penetration / request-body WAF detection is OFF in this first pass: the gateway
+proxies arbitrary user text (chat messages, meeting ``data`` JSON, transcript
+shares) and signature-based body scanning would false-positive on legitimate
+content. It is staged for a follow-up behind a passive-mode tuning pass.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from guard import SecurityConfig, SecurityMiddleware
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+_GUARD_REDIS_PREFIX_DEFAULT = "vexa:guard:"
+_GUARD_RATE_LIMIT_RPM_DEFAULT = 600
+_GUARD_RATE_LIMIT_WINDOW_DEFAULT = 60
+_GUARD_AUTO_BAN_THRESHOLD_DEFAULT = 10
+_GUARD_AUTO_BAN_DURATION_DEFAULT = 3600
+_GUARD_REDIS_URL_DEFAULT = "redis://redis:6379/0"
+
+# Paths that skip the guard pipeline entirely. Kept in sync with the per-key
+# limiter's RATE_LIMIT_SKIP_PATHS so the two layers agree on what is public
+# infrastructure vs. real API surface.
+_GUARD_EXCLUDE_PATHS = [
+    "/",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/openapi.yaml",
+    "/favicon.ico",
+    "/static",
+]
+
+
+def _guard_csv(env: str) -> list[str]:
+    """Parse a comma-separated env var into a stripped, non-empty list."""
+    return [value.strip() for value in os.getenv(env, "").split(",") if value.strip()]
+
+
+def _env_bool(env: str, default: bool) -> bool:
+    """Read a boolean env var (``true``/``false``, case-insensitive)."""
+    raw = os.getenv(env)
+    if raw is None:
+        return default
+    return raw.strip().lower() == "true"
+
+
+def _env_int(env: str, default: int) -> int:
+    """Read an int env var, falling back to ``default`` on missing/invalid input."""
+    raw = os.getenv(env)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def build_guard_config() -> SecurityConfig:
+    """Build the guard ``SecurityConfig`` from env vars.
+
+    Filter knobs (IP allow/deny, geo, cloud, trusted proxies) are opt-in and
+    default to empty/off. Redis state uses the same ``REDIS_URL`` Vexa already
+    runs, namespaced under ``vexa:guard:`` to avoid colliding with Vexa's own
+    keys (``ratelimit:``, ``gateway:token:``). ``fail_secure=False`` so a guard
+    check bug fails open instead of taking the public gateway down.
+    """
+    rate_limit_rpm = _env_int("GUARD_RATE_LIMIT_RPM", _GUARD_RATE_LIMIT_RPM_DEFAULT)
+    return SecurityConfig(
+        enable_redis=_env_bool("GUARD_ENABLE_REDIS", True),
+        redis_url=os.getenv("REDIS_URL", _GUARD_REDIS_URL_DEFAULT),
+        redis_prefix=os.getenv("GUARD_REDIS_PREFIX", _GUARD_REDIS_PREFIX_DEFAULT),
+        enable_rate_limiting=rate_limit_rpm > 0,
+        rate_limit=rate_limit_rpm,
+        rate_limit_window=_env_int(
+            "GUARD_RATE_LIMIT_WINDOW", _GUARD_RATE_LIMIT_WINDOW_DEFAULT
+        ),
+        enable_ip_banning=True,
+        auto_ban_threshold=_env_int(
+            "GUARD_AUTO_BAN_THRESHOLD", _GUARD_AUTO_BAN_THRESHOLD_DEFAULT
+        ),
+        auto_ban_duration=_env_int(
+            "GUARD_AUTO_BAN_DURATION", _GUARD_AUTO_BAN_DURATION_DEFAULT
+        ),
+        whitelist=_guard_csv("GUARD_IP_WHITELIST") or None,
+        blacklist=_guard_csv("GUARD_IP_BLACKLIST"),
+        blocked_countries=frozenset(_guard_csv("GUARD_BLOCKED_COUNTRIES")),
+        block_cloud_providers=set(_guard_csv("GUARD_BLOCK_CLOUD_PROVIDERS")),
+        trusted_proxies=_guard_csv("GUARD_TRUSTED_PROXIES"),
+        trust_x_forwarded_proto=_env_bool("GUARD_TRUST_X_FORWARDED_PROTO", False),
+        enable_penetration_detection=False,
+        enable_cors=False,
+        security_headers={"enabled": False},
+        fail_secure=False,
+        lazy_init=True,
+        exclude_paths=_GUARD_EXCLUDE_PATHS,
+    )
+
+
+def apply_guard(app: FastAPI, config: SecurityConfig | None = None) -> None:
+    """Add fastapi-guard's ``SecurityMiddleware`` to the gateway.
+
+    No-op when ``GUARD_ENABLED=false`` (operator kill switch). When ``config`` is
+    omitted it is built from env via :func:`build_guard_config`.
+
+    Complementary to the per-key ``rate_limit_middleware``: that limiter is keyed
+    by API token, guard's by client IP, with auto-banning of repeat offenders.
+    The two gate different abuse shapes — many-tokens-from-one-IP (caught by
+    per-IP + auto-ban) vs. one-token-across-many-IPs (caught by per-key) — and
+    coexist; the per-key limiter is not replaced.
+    """
+    if not _env_bool("GUARD_ENABLED", True):
+        return
+    if config is None:
+        config = build_guard_config()
+    app.add_middleware(SecurityMiddleware, config=config)

--- a/services/api-gateway/main.py
+++ b/services/api-gateway/main.py
@@ -179,6 +179,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# --- fastapi-guard: per-IP rate limiting, IP allow/deny + auto-ban ---
+# Complementary to the per-key rate_limit_middleware below (per-key catches
+# one-token-many-IPs; guard's per-IP catches many-tokens-from-one-IP and
+# auto-bans repeat offenders). See guard_config.py for the full config and the
+# rationale for what's enabled/disabled. The per-key limiter is NOT replaced.
+from guard_config import apply_guard  # noqa: E402
+
+apply_guard(app)
+
 # --- Rate Limiting Middleware ---
 RATE_LIMIT_SKIP_PATHS = {"/", "/docs", "/openapi.json", "/redoc"}
 

--- a/services/api-gateway/requirements.txt
+++ b/services/api-gateway/requirements.txt
@@ -12,3 +12,6 @@ python-multipart>=0.0.20
 email-validator==2.0.0
 redis==5.0.6
 websockets>=12.0
+# fastapi-guard: per-IP rate limiting, IP allow/deny + auto-ban, and (staged)
+# suspicious-request detection at the public ingress. See main.py guard block.
+fastapi-guard>=7.2,<8.0

--- a/services/api-gateway/tests/conftest.py
+++ b/services/api-gateway/tests/conftest.py
@@ -8,6 +8,13 @@ os.environ.setdefault("MEETING_API_URL", "http://meeting-api:8000")
 os.environ.setdefault("TRANSCRIPTION_COLLECTOR_URL", "http://transcription-collector:8000")
 os.environ.setdefault("MCP_URL", "http://mcp:18888")
 
+# fastapi-guard: keep it installed (so the integration is exercised) but
+# in-memory and with rate limiting off, so the unit suite never depends on
+# Redis and guard can never throttle/block a unit-test request.
+os.environ.setdefault("GUARD_ENABLED", "true")
+os.environ.setdefault("GUARD_ENABLE_REDIS", "false")
+os.environ.setdefault("GUARD_RATE_LIMIT_RPM", "0")
+
 SERVICE_ROOT = os.path.join(os.path.dirname(__file__), "..")
 sys.path.insert(0, SERVICE_ROOT)
 

--- a/services/api-gateway/tests/profile_guard.py
+++ b/services/api-gateway/tests/profile_guard.py
@@ -1,0 +1,171 @@
+"""Latency + cProfile overhead measurement for the fastapi-guard integration.
+
+Measures, over ASGITransport (no network), per-request latency for:
+  A) baseline       — no guard middleware
+  B) guard idle     — guard in the stack, rate limiting OFF, Redis OFF
+  C) guard enforcing — guard in the stack, per-IP rate limiting ON (limit high
+                       so no request is rejected), Redis OFF
+
+Reports mean / p50 / p95 / p99 and the first-request (lazy-init) cost for each,
+then a cProfile top-by-cumtime breakdown of the enforcing case.
+
+Run:  ../../.venv-guard/bin/python tests/profile_guard.py
+"""
+
+from __future__ import annotations
+
+import cProfile
+import io
+import os
+import pstats
+import statistics
+import time
+
+import httpx
+from fastapi import FastAPI
+from guard import SecurityConfig
+from httpx import ASGITransport
+
+from guard_config import apply_guard
+
+os.environ.setdefault("GUARD_ENABLED", "true")
+os.environ.setdefault("GUARD_ENABLE_REDIS", "false")
+
+_N = 2000
+
+
+def _percentiles(samples: list[float]) -> dict[str, float]:
+    ordered = sorted(samples)
+    n = len(ordered)
+
+    def pct(p: float) -> float:
+        return ordered[min(n - 1, int(round((p / 100.0) * (n - 1))))]
+
+    return {
+        "mean": statistics.fmean(samples),
+        "p50": pct(50),
+        "p95": pct(95),
+        "p99": pct(99),
+    }
+
+
+async def _root() -> dict[str, str]:
+    return {"ok": "true"}
+
+
+def _make_app(config: SecurityConfig | None) -> FastAPI:
+    app = FastAPI()
+    app.add_api_route("/", _root, methods=["GET"])
+    if config is not None:
+        apply_guard(app, config=config)
+    return app
+
+
+def _measure(app: FastAPI, n: int) -> tuple[dict[str, float], float, list[float]]:
+    """Return (percentiles_us, first_request_us, all_samples_us)."""
+    transport = ASGITransport(app=app)
+    samples: list[float] = []
+    first_us = 0.0
+
+    async def run() -> None:
+        nonlocal first_us
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            t0 = time.perf_counter()
+            await ac.get("/")
+            first_us = (time.perf_counter() - t0) * 1e6
+            for _ in range(n - 1):
+                s = time.perf_counter()
+                await ac.get("/")
+                samples.append((time.perf_counter() - s) * 1e6)
+
+    import asyncio
+
+    asyncio.run(run())
+    return _percentiles(samples), first_us, samples
+
+
+def _format(label: str, pct: dict[str, float], first: float) -> str:
+    return (
+        f"  {label:<20} first={first:8.1f}us  "
+        f"mean={pct['mean']:7.2f}us  p50={pct['p50']:7.2f}us  "
+        f"p95={pct['p95']:7.2f}us  p99={pct['p99']:7.2f}us"
+    )
+
+
+def main() -> None:
+    idle = SecurityConfig(
+        enable_redis=False,
+        redis_url=None,
+        enable_rate_limiting=False,
+        enable_ip_banning=False,
+        enable_penetration_detection=False,
+        enable_cors=False,
+        security_headers={"enabled": False},
+        fail_secure=False,
+        lazy_init=True,
+        exclude_paths=[],
+    )
+    enforcing = SecurityConfig(
+        enable_redis=False,
+        redis_url=None,
+        enable_rate_limiting=True,
+        rate_limit=1_000_000,
+        rate_limit_window=60,
+        enable_ip_banning=False,
+        enable_penetration_detection=False,
+        enable_cors=False,
+        security_headers={"enabled": False},
+        fail_secure=False,
+        lazy_init=True,
+        exclude_paths=[],
+    )
+
+    print(f"Per-request latency over {_N} requests (ASGITransport, microseconds):")
+    print("-" * 92)
+
+    base_pct, base_first, _ = _measure(_make_app(None), _N)
+    print(_format("baseline (no guard)", base_pct, base_first))
+
+    idle_pct, idle_first, _ = _measure(_make_app(idle), _N)
+    print(_format("guard idle (RL off)", idle_pct, idle_first))
+
+    enf_pct, enf_first, _ = _measure(_make_app(enforcing), _N)
+    print(_format("guard enforcing (RL on)", enf_pct, enf_first))
+
+    print("-" * 92)
+    print("Overhead vs baseline (mean):")
+    print(f"  guard idle       +{idle_pct['mean'] - base_pct['mean']:7.2f}us")
+    print(f"  guard enforcing  +{enf_pct['mean'] - base_pct['mean']:7.2f}us")
+    print(f"  first-request (lazy init): idle={idle_first:.1f}us")
+    print(f"  first-request (lazy init): enforcing={enf_first:.1f}us")
+
+    print("\ncProfile top 15 by cumulative time (guard enforcing, 1000 requests):")
+    prof = cProfile.Profile()
+    app = _make_app(enforcing)
+    transport = ASGITransport(app=app)
+    import asyncio
+
+    async def profiled() -> None:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            await ac.get("/")  # warm lazy init outside the profile
+            for _ in range(1000):
+                await ac.get("/")
+
+    prof.enable()
+    asyncio.run(profiled())
+    prof.disable()
+    stream = io.StringIO()
+    stats = pstats.Stats(prof, stream=stream).sort_stats("cumulative")
+    stats.print_stats(15)
+    # Filter to guard-relevant and FastAPI/httpx frames for signal.
+    lines = stream.getvalue().splitlines()
+    header = lines[:6]
+    guard_lines = [
+        ln for ln in lines[6:] if "guard" in ln.lower() or "middleware" in ln.lower()
+    ]
+    print("\n".join(header))
+    print("\n".join(guard_lines[:15]))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/api-gateway/tests/test_guard_integration.py
+++ b/services/api-gateway/tests/test_guard_integration.py
@@ -1,0 +1,161 @@
+"""Tests for the fastapi-guard integration at the api-gateway.
+
+Two layers:
+
+* ``TestGuardWiring`` uses the real gateway app imported from ``main``. Conftest
+  runs it with ``GUARD_ENABLE_REDIS=false`` and ``GUARD_RATE_LIMIT_RPM=0`` so the
+  existing proxy suite stays deterministic and never needs Redis — this proves
+  guard is installed with safe, non-blocking defaults and does not regress the
+  gateway.
+* ``TestGuardBehavior`` builds isolated FastAPI apps with guard configured to
+  actually enforce — per-IP rate limiting (in-memory, no Redis),
+  X-Forwarded-For resolution behind a trusted proxy, and IP blacklisting. These
+  prove the feature behaves, not just that it is wired.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from guard import SecurityConfig
+from httpx import ASGITransport
+from starlette.middleware import Middleware
+
+from guard_config import apply_guard, build_guard_config
+from main import app as gateway_app
+
+
+def _guard_middleware(app: FastAPI) -> Middleware | None:
+    """Return the SecurityMiddleware entry on ``app`` if present, else None."""
+    for mw in app.user_middleware:
+        if getattr(mw.cls, "__name__", "") == "SecurityMiddleware":
+            return mw
+    return None
+
+
+def _enforcing_config(**overrides: Any) -> SecurityConfig:
+    """A guard config that enforces in-memory (no Redis) with extras off.
+
+    Rate limiting is on and keyed in-process; penetration detection, CORS,
+    security headers, and fail-secure are off so nothing but the behavior under
+    test can produce a non-200. ``exclude_paths`` is empty so ``/`` is gated.
+    """
+    base: dict[str, Any] = {
+        "enable_redis": False,
+        "redis_url": None,
+        "enable_rate_limiting": True,
+        "rate_limit": 3,
+        "rate_limit_window": 60,
+        "enable_ip_banning": False,
+        "enable_penetration_detection": False,
+        "enable_cors": False,
+        "security_headers": {"enabled": False},
+        "fail_secure": False,
+        "lazy_init": True,
+        "exclude_paths": [],
+    }
+    base.update(overrides)
+    return SecurityConfig(**base)
+
+
+async def _root_handler() -> dict[str, str]:
+    """Trivial route body for the isolated behavioral apps."""
+    return {"ok": "true"}
+
+
+def _make_app(config: SecurityConfig) -> FastAPI:
+    """A minimal FastAPI app with guard applied under ``config``."""
+    app = FastAPI()
+    app.add_api_route("/", _root_handler, methods=["GET"])
+    apply_guard(app, config=config)
+    return app
+
+
+class TestGuardWiring:
+    """Guard is installed on the real gateway with safe, non-blocking defaults."""
+
+    def test_middleware_installed(self) -> None:
+        """SecurityMiddleware is present on the gateway (GUARD_ENABLED=true)."""
+        assert _guard_middleware(gateway_app) is not None
+
+    def test_config_safe_defaults(self) -> None:
+        """The hard-coded safety knobs keep guard from breaking the gateway or
+        duplicating Vexa's existing CORS / security-headers middleware."""
+        cfg = build_guard_config()
+        # WAF body inspection is deferred (would false-positive on user text).
+        assert cfg.enable_penetration_detection is False
+        # A guard check bug must fail open, not 500 the public ingress.
+        assert cfg.fail_secure is False
+        # Vexa keeps its own CORSMiddleware + SecurityHeadersMiddleware.
+        assert cfg.enable_cors is False
+        assert cfg.security_headers is not None
+        assert cfg.security_headers["enabled"] is False
+        # Redis keys are namespaced away from Vexa's own (ratelimit:, gateway:).
+        assert cfg.redis_prefix.startswith("vexa:")
+
+    @pytest.mark.asyncio
+    async def test_smoke_root_with_guard_active(self) -> None:
+        """A public request still succeeds with guard in the stack and no Redis
+        available — guard must not crash or block the root route."""
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=gateway_app), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/")
+        assert resp.status_code == 200
+
+
+class TestGuardBehavior:
+    """Guard actually enforces per-IP limits, XFF resolution, and IP blocking."""
+
+    @pytest.mark.asyncio
+    async def test_per_ip_rate_limit_returns_429(self) -> None:
+        """The Nth+1 request from one IP is rejected with 429; the first N pass."""
+        app = _make_app(_enforcing_config(rate_limit=3))
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            for _ in range(3):
+                resp = await ac.get("/")
+                assert resp.status_code == 200
+            resp = await ac.get("/")
+        assert resp.status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_xff_resolves_to_distinct_ip_buckets(self) -> None:
+        """Behind a trusted proxy, guard keys on X-Forwarded-For, so two clients
+        sharing the proxy IP get separate rate-limit buckets."""
+        app = _make_app(_enforcing_config(rate_limit=2, trusted_proxies=["127.0.0.1"]))
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            # IP 10.0.0.1 exhausts its 2-request bucket...
+            for _ in range(2):
+                assert (
+                    await ac.get("/", headers={"X-Forwarded-For": "10.0.0.1"})
+                ).status_code == 200
+            assert (
+                await ac.get("/", headers={"X-Forwarded-For": "10.0.0.1"})
+            ).status_code == 429
+            # ...while 10.0.0.2 on the same proxy is unaffected.
+            assert (
+                await ac.get("/", headers={"X-Forwarded-For": "10.0.0.2"})
+            ).status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_blacklisted_ip_returns_403(self) -> None:
+        """A request whose resolved client IP is on the blacklist is blocked."""
+        app = _make_app(
+            _enforcing_config(
+                rate_limit=1000,
+                trusted_proxies=["127.0.0.1"],
+                blacklist=["10.0.0.9"],
+            )
+        )
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/", headers={"X-Forwarded-For": "10.0.0.9"})
+        assert resp.status_code == 403


### PR DESCRIPTION
### fastapi-guard at the api-gateway: per-IP rate limiting, IP auto-ban, optional IP/geo/cloud blocking

#### Authorship note
I author and maintain `fastapi-guard` and the `guard-core` engine it wraps — flagging the conflict of interest up front.

#### Problem
The api-gateway is Vexa's only public ingress (the sole `0.0.0.0` binding; no nginx/Caddy in front). It has no IP filtering, no IP auto-banning, and no per-IP rate limit — the existing limiter is keyed by token hash, so an attacker rotating many tokens from one IP defeats it. `fastapi-guard` provides these as one Starlette middleware, and Vexa already runs Redis, so distributed state is free — no new infra.

#### What this changes
Adds `fastapi-guard` only at the api-gateway, layered on top of the existing per-key Redis sliding-window limiter (which is preserved). Config is env-driven and lives in a new self-contained, fully-typed module `services/api-gateway/guard_config.py`; `main.py` just calls `apply_guard(app)`.

On by default (env-tunable):
- Per-IP rate limiting — `GUARD_RATE_LIMIT_RPM` (default 600, 0 disables), `GUARD_RATE_LIMIT_WINDOW` (default 60). Loose on purpose so it doesn't fight the stricter per-key limiter.
- Auto-IP-ban — `auto_ban_threshold=10`, `auto_ban_duration=3600s`.
- Optional IP/geo/cloud (all default off / empty): `GUARD_IP_WHITELIST`, `GUARD_IP_BLACKLIST`, `GUARD_BLOCKED_COUNTRIES`, `GUARD_BLOCK_CLOUD_PROVIDERS`, `GUARD_TRUSTED_PROXIES`.
- Redis via the existing `REDIS_URL`, namespaced `vexa:guard:` so it doesn't collide with Vexa's own keys (`ratelimit:`, `gateway:token:`). `GUARD_ENABLE_REDIS=false` for in-process state; guard also falls back to in-memory automatically if Redis is unreachable.
- `fail_secure=False` (a check bug fails open, not 500 the public ingress), `lazy_init=True` (warms on first request — no lifespan change). `GUARD_ENABLED=false` is a kill switch.

#### Why the per-key limiter stays
The two limiters gate different abuse shapes and this PR layers, not replaces. Existing: per token hash, 120/30/20 RPM, `client.host` fallback for unauth — catches one token hammered and unauth floods. guard: per client IP, plus auto-ban after N suspicious hits — catches an attacker rotating many tokens from one IP (defeats per-key) and gives IP-level eviction the per-key limiter can't. One token across many IPs → still caught by per-key. Many tokens from one IP → caught by per-IP + auto-ban. The per-key limiter is untouched.

#### Deferred from this PR — open to follow-ups
- Penetration / request-body WAF detection is OFF here because the gateway proxies arbitrary user text (chat, meeting `data` JSON, transcript shares) and signature body scanning would false-positive on legit content. It's the obvious next layer — I'd enable it in passive mode tuned against real traffic as a follow-up, and I'm glad to do that here.
- guard's CORS and security-headers emission are disabled because Vexa already runs `CORSMiddleware` and its own `SecurityHeadersMiddleware` (VNC CSP `frame-ancestors` logic). Modernizing the header set and revisiting `TrustedHostMiddleware` are both worth doing — I left them for a focused follow-up rather than bundling.
- No change to auth: `X-API-Key` / `X-Admin-API-Key` + scope enforcement + admin-api token validation stay as-is.
- The AI/agent surface — agent-api, `voice_agent`, MCP — has real abuse vectors (prompt injection, meeting spam via `/speak` and `/chat`, agentic tool abuse) that this middleware doesn't address. That's the bigger follow-up and I'm up for taking it on.

#### Tests
`services/api-gateway/tests/test_guard_integration.py` — runs guard in-memory (no Redis needed):
- Wiring: middleware installed; safe defaults asserted (pen-detection off, fail-open, CORS/headers off, `vexa:` namespace); no-Redis smoke on the real gateway app.
- Behavioral: per-IP 429 on the Nth+1 request; `X-Forwarded-For` resolution behind a trusted proxy yields distinct per-IP buckets; blacklisted IP → 403.

Full api-gateway suite green (95 passed, 4 pre-existing skipped), no regression. `tests/profile_guard.py` — latency/cProfile harness: steady-state guard overhead vs no-guard baseline ≈ +250–300 µs/request (sub-ms on a proxy doing network I/O); one-time lazy-init pipeline build ≈ 4–14 ms on the first request after boot.

#### Notes
- `guard-core` installs `redis`, `maxminddb`, `aiohttp` unconditionally. Vexa already has Redis (free); `maxminddb` + `aiohttp` are extra weight, and geo blocking needs an MMDB file. I'd like to make geo/cloud an optional `[geoip]` extra upstream and can do that as part of this work.
- Behind a TLS-terminating proxy/LB, operators must set `GUARD_TRUSTED_PROXIES` so guard reads the real client IP from `X-Forwarded-For` — otherwise per-IP limiting keys on the proxy IP and is ineffective. Documented in the config.

#### Scope
One service (`api-gateway`), one middleware addition, config tuned to fail-open with the existing limiter preserved, no new infra. A follow-up could roll per-service guard to the loopback-bound internal services for defense-in-depth.