### PR TITLE
fix(msteams): dismiss post-Join "Continue without audio or video" modal (anon light-meeting)

### DIFF
--- a/services/vexa-bot/core/src/platforms/msteams/admission.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/admission.ts
@@ -8,6 +8,23 @@ import {
   teamsRejectionIndicators,
   teamsJoinButtonSelectors
 } from "./selectors";
+import { dismissTeamsAvConfirmModal, isTeamsAvConfirmModalVisible } from "./modals";
+
+// Clear the Teams "Continue without audio or video" confirm modal if present,
+// then re-click "Join now". This modal can keep the pre-join "Join now" button
+// in the DOM, which the waiting-room checks below would otherwise read as a
+// lobby forever. See modals.ts. Returns true if a modal was dismissed.
+async function clearAvConfirmModalAndRejoin(page: Page): Promise<boolean> {
+  const dismissed = await dismissTeamsAvConfirmModal(page);
+  if (dismissed) {
+    const joinAgain = page.locator('button:has-text("Join now")').first();
+    if (await joinAgain.isVisible().catch(() => false)) {
+      await joinAgain.click().catch(() => {});
+      log("✅ Re-clicked 'Join now' after clearing AV-confirmation modal (admission)");
+    }
+  }
+  return dismissed;
+}
 
 // Function to check if bot has been rejected from the meeting
 export async function checkForTeamsRejection(page: Page): Promise<boolean> {
@@ -66,7 +83,14 @@ export async function waitForTeamsMeetingAdmission(
 ): Promise<boolean> {
   try {
     log("Waiting for Teams meeting admission...");
-    
+
+    // Belt-and-suspenders: Teams' anonymous light-meeting confirm modal
+    // ("Are you sure you don't want audio or video?") can still be on screen
+    // when we reach here (it fires after the Join-now click). If left up it
+    // blocks the join AND keeps the pre-join "Join now" button visible, which
+    // the checks below read as a permanent waiting room. Clear it first.
+    await clearAvConfirmModalAndRejoin(page);
+
     // FIRST: Check if bot is already admitted (no waiting room needed)
     log("Checking if bot is already admitted to the Teams meeting...");
     
@@ -151,6 +175,14 @@ export async function waitForTeamsMeetingAdmission(
       const effectiveTimeout = () => timeout + getEscalationExtensionMs();
 
       while (Date.now() - startTime < effectiveTimeout()) {
+        // If the only reason we look "stuck in waiting room" is the AV-confirm
+        // modal pinning the pre-join "Join now" button, clear it and re-join.
+        if (await isTeamsAvConfirmModalVisible(page)) {
+          log("ℹ️ AV-confirmation modal detected during admission wait — clearing it");
+          await clearAvConfirmModalAndRejoin(page);
+          await page.waitForTimeout(500);
+        }
+
         // Check if we're still in waiting room using visibility
         const lobbyTextStillVisible = await page.locator(teamsWaitingRoomIndicators[0]).isVisible();
 
@@ -293,6 +325,10 @@ export async function waitForTeamsMeetingAdmission(
           // Wait for admission in the lobby
           const lobbyStart = Date.now();
           while (Date.now() - lobbyStart < timeout) {
+            if (await isTeamsAvConfirmModalVisible(page)) {
+              await clearAvConfirmModalAndRejoin(page);
+              await page.waitForTimeout(500);
+            }
             const stillInLobby = await page.locator(teamsWaitingRoomIndicators[0]).isVisible().catch(() => false);
             if (!stillInLobby) {
               const admittedNow = await checkForAdmissionIndicators(page);

--- a/services/vexa-bot/core/src/platforms/msteams/join.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/join.ts
@@ -14,6 +14,7 @@ import {
   teamsSpeakerEnableSelectors,
   teamsSpeakerDisableSelectors
 } from "./selectors";
+import { dismissTeamsAvConfirmModal, isTeamsAvConfirmModalVisible } from "./modals";
 
 async function warmUpTeamsMediaDevices(page: Page): Promise<void> {
   try {
@@ -481,6 +482,45 @@ export async function joinMicrosoftTeams(page: Page, botConfig: BotConfig): Prom
     await page.waitForTimeout(1000);
   } catch (error) {
     log("⚠️ Join button not found — bot may not be able to enter the meeting");
+  }
+
+  // Step 6c: Handle the post-"Join now" AV-confirmation modal.
+  //
+  // Teams' anonymous "light meeting" flow pops "Are you sure you don't want
+  // audio or video?" AFTER the Join-now click (camera + mic are off). It blocks
+  // the join until dismissed, and leaves the pre-join "Join now" button in the
+  // DOM — which admission.ts then mistakes for a lobby and loops on forever.
+  // Poll briefly: dismiss the modal, re-click "Join now", and stop once we've
+  // reached the lobby or been admitted. See modals.ts for the full rationale.
+  log("Step 6c: Handling post-join AV-confirmation modal (if shown)...");
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const dismissed = await dismissTeamsAvConfirmModal(page);
+    if (dismissed) {
+      const joinAgain = page.locator('button:has-text("Join now")').first();
+      if (await joinAgain.isVisible().catch(() => false)) {
+        await joinAgain.click().catch(() => {});
+        log("✅ Re-clicked 'Join now' after dismissing AV-confirmation modal");
+      }
+    }
+
+    // Stop as soon as we've left pre-join: lobby reached or already admitted.
+    const inLobby = await page
+      .locator('text=/Someone will let you in shortly|Waiting for someone to let you in|Waiting to be admitted/i')
+      .first()
+      .isVisible()
+      .catch(() => false);
+    const admitted = await page
+      .locator('button[id="hangup-button"], button[aria-label="Leave"], button[data-tid="hangup-main-btn"]')
+      .first()
+      .isVisible()
+      .catch(() => false);
+    const modalStillThere = await isTeamsAvConfirmModalVisible(page);
+    if (inLobby || admitted || (!dismissed && !modalStillThere)) {
+      if (inLobby) log("✅ Reached Teams lobby after Join now");
+      if (admitted) log("✅ Admitted to Teams meeting after Join now");
+      break;
+    }
+    await page.waitForTimeout(1000);
   }
 
   // Mute mic for all bots after join. TTS bots unmute only when speaking

--- a/services/vexa-bot/core/src/platforms/msteams/modals.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/modals.ts
@@ -1,0 +1,48 @@
+import { Page } from "playwright";
+import { log } from "../../utils";
+import { teamsContinueWithoutMediaSelectors } from "./selectors";
+
+/**
+ * Dismiss the Teams "Are you sure you don't want audio or video?" confirmation
+ * modal.
+ *
+ * Teams' anonymous "light meeting" flow renders this modal when "Join now" is
+ * clicked while camera + mic are off. CRITICAL: in this flow the modal appears
+ * AFTER the Join-now click, not before — so the pre-join readiness handler in
+ * join.ts (which clicks the same button earlier) never sees it.
+ *
+ * Left undismissed it BLOCKS the join indefinitely, and worse: the underlying
+ * pre-join "Join now" button stays in the DOM behind the modal. The admission
+ * detector counts a visible "Join now" as a waiting-room indicator
+ * (selectors.ts teamsWaitingRoomIndicators), so the bot loops
+ * "Still in Teams waiting room…" forever instead of clicking through.
+ *
+ * This helper is the single point that clears it. Call it both right after the
+ * Join-now click (join.ts) and inside the admission wait loop (admission.ts) so
+ * the modal is handled no matter when Teams decides to show it.
+ *
+ * Returns true if the modal was found and a dismiss click was issued.
+ */
+export async function dismissTeamsAvConfirmModal(page: Page): Promise<boolean> {
+  const selector = teamsContinueWithoutMediaSelectors.join(", ");
+  try {
+    const btn = page.locator(selector).first();
+    if (await btn.isVisible().catch(() => false)) {
+      await btn.click({ timeout: 5000 });
+      log('✅ Dismissed "Continue without audio or video" confirmation modal');
+      await page.waitForTimeout(500);
+      return true;
+    }
+  } catch (err: any) {
+    log(`ℹ️ Could not dismiss AV-confirm modal: ${err?.message || err}`);
+  }
+  return false;
+}
+
+/**
+ * True if the Teams AV-confirm modal is currently on screen.
+ */
+export async function isTeamsAvConfirmModalVisible(page: Page): Promise<boolean> {
+  const selector = teamsContinueWithoutMediaSelectors.join(", ");
+  return await page.locator(selector).first().isVisible().catch(() => false);
+}


### PR DESCRIPTION
## Problem

When a Teams bot joins an **anonymous "light meeting"** (`/light-meetings/launch?...anon=true&lightExperience=true`), Teams renders the *"Are you sure you don't want audio or video?"* confirmation modal **after** the bot clicks **Join now** (the bot runs with camera + mic off), not before.

The existing handler in `waitForTeamsPreJoinReadiness` only dismisses this modal during pre-join, so it never fires for the post-Join occurrence. The modal then blocks the join indefinitely. Worse: the leftover pre-join **"Join now"** button stays in the DOM behind the modal, and `admission.ts` treats a visible "Join now" as a waiting-room indicator (`teamsWaitingRoomIndicators`) — so the bot loops `Still in Teams waiting room…` forever and **never appears in the host's lobby/waitlist**.

Intermittent because the modal only fires when Chromium's media-permission state is `denied` at that moment.

## Fix

- **`modals.ts`** (new): `dismissTeamsAvConfirmModal()` / `isTeamsAvConfirmModalVisible()` — single shared helper keyed on `teamsContinueWithoutMediaSelectors`.
- **`join.ts`** Step 6c: after clicking **Join now**, poll to dismiss the modal, re-click **Join now**, and stop once the lobby is reached or the bot is admitted.
- **`admission.ts`**: clear the modal at entry **and** inside the waiting loop (the actual backstop — this is what unblocks a bot already stuck in the false "waiting room").

All three only act when the specific modal is present — zero overhead on the normal path.

## Verification

- Deterministic test: the compiled `modals.js` dismisses a faithful replica of the modal in real Chromium/Edge (modal up + leftover "Join now" → dismissed → lobby).
- Live E2E: real Teams meeting → `✅ Dismissed "Continue without audio or video"` → real lobby → host admits → recording + caption routing active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)