### PR TITLE
fix(calendar): auto-join bot uses the owning user's name

### DIFF
--- a/services/calendar-service/app/sync.py
+++ b/services/calendar-service/app/sync.py
@@ -159,12 +159,17 @@ async def schedule_upcoming_bots(db: AsyncSession) -> int:
 
         try:
             async with httpx.AsyncClient() as client:
+                # Bot display name = the owning user's name (e.g. "Hugo"), so an
+                # auto-joined bot appears to participants as the agent, not "Vexa".
+                # One user = one agent (seeded from the agents master table);
+                # user.name is an existing column — no schema change. Falls back to
+                # the legacy label only when a user has no name set.
                 resp = await client.post(
                     f"{MEETING_API_URL}/bots",
                     json={
                         "platform": event.platform,
                         "native_meeting_id": _extract_native_id(event.meeting_url, event.platform),
-                        "bot_name": f"Vexa - {event.title or 'Calendar'}",
+                        "bot_name": (user.name or f"Vexa - {event.title or 'Calendar'}"),
                     },
                     headers={"X-API-Key": BOT_API_TOKEN},
                     timeout=30,


### PR DESCRIPTION
## What

`schedule_upcoming_bots` (calendar auto-join) hardcodes the bot display name to `f"Vexa - {event.title}"`. This changes it to use the owning user's `name` when set, falling back to the existing `"Vexa - {title}"` label otherwise.

## Why

When a Vexa user models a specific named participant (e.g. an assistant that should appear in the meeting under its own name), the auto-joined bot should show that name rather than the meeting title. Today the only way to influence the auto-join bot name is the calendar event title, which isn't the right knob.

The `user` row is already loaded in the loop (for its API key), so this adds no query. `name` is an existing column — no schema change.

## Backward compatibility

Fully backward compatible: behaviour changes **only** for users that have a `name` set; users without a name keep the current `"Vexa - {title}"` label.

## Change

```diff
-                        "bot_name": f"Vexa - {event.title or 'Calendar'}",
+                        "bot_name": (user.name or f"Vexa - {event.title or 'Calendar'}"),
```

## Alternative considered

Reading the name from `user.data` (e.g. `user.data["bot_display_name"]`) for an explicit, non-overloaded knob. Happy to switch to that if preferred — `user.name` was chosen as the minimal, zero-config default.