### PR TITLE
fix(googlemeet): don't false-reject on the "Return to home screen" waiting-screen button

### DIFF
--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -59,7 +59,7 @@ Vexa can join Microsoft Teams meetings using **all major URL formats**. The `par
 | Format | Example | Status |
 |--------|---------|--------|
 | T1: Standard join | `teams.microsoft.com/l/meetup-join/19%3ameeting_{id}%40thread.v2/...` | PASS |
-| T2: Meet shortlink (OeNB) | `teams.microsoft.com/meet/{id}?p={passcode}` | PASS |
+| T2: Meet shortlink | `teams.microsoft.com/meet/{id}?p={passcode}` | PASS |
 | T3: Channel meeting | `teams.microsoft.com/l/meetup-join/19%3a{channel}%40thread.tacv2/...` | PASS |
 | T4: Custom domain | `{org}.teams.microsoft.com/meet/{id}?p={passcode}` | PASS |
 | T5: Deep link | `msteams:/l/meetup-join/...` | NOT SUPPORTED |

--- a/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/selectors.ts
@@ -26,6 +26,12 @@ export const googleWaitingRoomIndicators: string[] = [
   '[aria-label*="waiting room"]',
   '[aria-label*="Asking to be let in"]',
   '[aria-label*="waiting for admission"]',
+  // FIX (2026-07-03, Unseen Dynamics): the Google Meet 'Asking to be let in' waiting
+  // screen shows a 'Return to home screen' button. It was a googleRejectionIndicator,
+  // so the bot false-rejected in ~4s (admission_rejected_by_admin) and never waited for
+  // the host to admit it. Reclassified as a WAITING indicator; genuine denials are still
+  // caught by the 'denied your request' text patterns above.
+  'button:has-text("Return to home screen")',
 ];
 
 export const googleRejectionIndicators: string[] = [
@@ -43,7 +49,6 @@ export const googleRejectionIndicators: string[] = [
   'text*="cannot join this call"',
   'text*="Ask to join again"',
   'button:has-text("Ask to join again")',
-  'button:has-text("Return to home screen")',
 
   // Meeting not found or access denied patterns
   'text="Meeting not found"',


### PR DESCRIPTION
Self-hosters on the current Google Meet UI see the bot auto-reject **every** meeting in ~4s with `admission_rejected_by_admin`, even when the host is present and admits anonymous humans fine.

## Root cause
Google Meets "Asking to be let in" waiting screen renders a **"Return to home screen"** button. That button is listed in `googleRejectionIndicators`, so `checkForGoogleRejection` matches it on the *normal waiting screen* and the bot declares rejection before the host can admit it.

Captured live (bot screenshot + logs):
```
No waiting room detected. Polling for admission for up to 900000ms...
Found rejection indicator "button:has-text(\"Return to home screen\")"
Bot was rejected ... (polling mode)  ->  admission_rejected_by_admin
```
The bot reaches the real join screen and clicks "Ask to join" correctly — this is purely the post-Ask-to-join state being misread. Not bot-detection, not a real denial.

## Fix
Move `button:has-text("Return to home screen")` from `googleRejectionIndicators` to `googleWaitingRoomIndicators` (it reliably marks the waiting screen). Genuine host denials are still detected by the `text*="denied your request"` / `"not allowed to join"` / `"can't join this call"` patterns that remain in the rejection list.

Verified on a self-hosted v0.10.6 stack (own-GPU, local transcription): with this change the bot enters the waiting room and stays until the host admits it.