### PR TITLE
ci: cap framework deps on the merge path, add weekly deps canary

### DIFF
--- a/.github/workflows/deps-canary.yml
+++ b/.github/workflows/deps-canary.yml
@@ -1,0 +1,86 @@
+# Weekly canary: run the Python test suites against the LATEST resolvable
+# dependencies (no constraints.txt), off the merge path. The merge-path
+# test-* workflows are capped via PIP_CONSTRAINT; this job is the early
+# warning that tells us when a new fastapi/starlette/pydantic release breaks
+# us, and when it is safe to raise the ceilings in constraints.txt.
+name: Deps Canary
+
+on:
+  schedule:
+    - cron: '17 5 * * 1' # Mondays 05:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-latest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: admin-api
+            requirements: services/admin-api/requirements.txt
+            tests: pytest services/admin-api/tests/ -v
+          - suite: meeting-api
+            requirements: ''
+            tests: pytest services/meeting-api/tests/ -v --ignore=services/meeting-api/tests/test_integration_live.py
+          - suite: api-gateway
+            requirements: services/api-gateway/requirements.txt
+            tests: pytest services/api-gateway/tests/ -v
+    name: ${{ matrix.suite }} (latest deps)
+    env:
+      # Only used by the api-gateway suite; harmless for the others.
+      ADMIN_API_URL: http://admin-api:8001
+      MEETING_API_URL: http://meeting-api:8080
+      TRANSCRIPTION_COLLECTOR_URL: http://meeting-api:8080
+      MCP_URL: http://mcp:18888
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Install latest dependencies (unconstrained)
+        run: |
+          pip install -e libs/admin-models/
+          pip install -e services/meeting-api/
+          if [ -n "${{ matrix.requirements }}" ]; then pip install -r "${{ matrix.requirements }}"; fi
+          pip install pytest pytest-asyncio httpx
+      - name: Show resolved versions
+        run: pip list --format=freeze | grep -iE '^(fastapi|starlette|pydantic|pytest|httpx|uvicorn|sqlalchemy|redis)'
+      - name: Run tests
+        run: ${{ matrix.tests }}
+
+  report:
+    needs: test-latest
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: File or update the canary-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="deps-canary: latest dependencies break the test suites"
+          body="The scheduled [Deps Canary run]($RUN_URL) failed against the latest unconstrained dependencies.
+
+          A new release of fastapi/starlette/pydantic (or another unpinned dep) likely
+          introduced a breaking change. The merge path is protected by constraints.txt,
+          so required checks are unaffected — but do not raise the ceilings in
+          constraints.txt past the breaking version until this is resolved.
+
+          Check the run's 'Show resolved versions' step to see what changed."
+          existing=$(gh issue list --repo "$REPO" --state open --json number,title \
+            --jq ".[] | select(.title == \"$title\") | .number" | head -n1)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+          else
+            gh issue create --repo "$REPO" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/test-admin-api.yml
+++ b/.github/workflows/test-admin-api.yml
@@ -6,11 +6,14 @@ on:
     paths:
       - 'services/admin-api/**'
       - 'libs/admin-models/**'
+      - 'constraints.txt'
       - '.github/workflows/test-admin-api.yml'
   pull_request:
     paths:
       - 'services/admin-api/**'
       - 'libs/admin-models/**'
+      - 'constraints.txt'
+      - '.github/workflows/test-admin-api.yml'
 
 permissions:
   contents: read
@@ -18,6 +21,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Cap framework versions so unpinned floors can't pull a breaking
+      # release onto the merge path (see constraints.txt).
+      PIP_CONSTRAINT: ${{ github.workspace }}/constraints.txt
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -29,7 +36,8 @@ jobs:
         run: |
           pip install -e libs/admin-models/
           pip install -e services/meeting-api/
-          pip install -e services/admin-api/ 2>/dev/null || pip install -r services/admin-api/requirements.txt
+          pip install -r services/admin-api/requirements.txt
           pip install pytest pytest-asyncio httpx
+          pip list --format=freeze | grep -iE '^(fastapi|starlette|pydantic|pytest|httpx|uvicorn)'
       - name: Run tests
         run: pytest services/admin-api/tests/ -v

--- a/.github/workflows/test-api-gateway.yml
+++ b/.github/workflows/test-api-gateway.yml
@@ -6,11 +6,14 @@ on:
     paths:
       - 'services/api-gateway/**'
       - 'services/meeting-api/meeting_api/schemas.py'
+      - 'constraints.txt'
       - '.github/workflows/test-api-gateway.yml'
   pull_request:
     paths:
       - 'services/api-gateway/**'
       - 'services/meeting-api/**'
+      - 'constraints.txt'
+      - '.github/workflows/test-api-gateway.yml'
 
 permissions:
   contents: read
@@ -18,6 +21,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Cap framework versions so unpinned floors can't pull a breaking
+      # release onto the merge path (see constraints.txt).
+      PIP_CONSTRAINT: ${{ github.workspace }}/constraints.txt
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -31,6 +38,7 @@ jobs:
           pip install -e services/meeting-api/
           pip install -r services/api-gateway/requirements.txt
           pip install pytest pytest-asyncio httpx
+          pip list --format=freeze | grep -iE '^(fastapi|starlette|pydantic|pytest|httpx|uvicorn)'
       - name: Run tests
         env:
           ADMIN_API_URL: http://admin-api:8001

--- a/.github/workflows/test-meeting-api.yml
+++ b/.github/workflows/test-meeting-api.yml
@@ -6,11 +6,14 @@ on:
     paths:
       - 'services/meeting-api/**'
       - 'libs/admin-models/**'
+      - 'constraints.txt'
       - '.github/workflows/test-meeting-api.yml'
   pull_request:
     paths:
       - 'services/meeting-api/**'
       - 'libs/admin-models/**'
+      - 'constraints.txt'
+      - '.github/workflows/test-meeting-api.yml'
 
 permissions:
   contents: read
@@ -18,6 +21,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Cap framework versions so unpinned floors can't pull a breaking
+      # release onto the merge path (see constraints.txt).
+      PIP_CONSTRAINT: ${{ github.workspace }}/constraints.txt
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -30,5 +37,6 @@ jobs:
           pip install -e libs/admin-models/
           pip install -e services/meeting-api/
           pip install pytest pytest-asyncio httpx
+          pip list --format=freeze | grep -iE '^(fastapi|starlette|pydantic|pytest|httpx|uvicorn)'
       - name: Run unit tests
         run: pytest services/meeting-api/tests/ -v --ignore=services/meeting-api/tests/test_integration_live.py

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,8 @@ test_data/
 *.mp4
 *.txt
 !**/requirements.txt
+# CI dependency ceilings applied via PIP_CONSTRAINT in the test workflows.
+!constraints.txt
 # v0.10.5.3 fix: hallucinations corpus files were silently dropped when
 # *.txt was added globally. The corpus is loaded by hallucination-filter.ts
 # at runtime — without these files the bot ships with empty filter,

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,34 @@
+# CI dependency ceilings — single source of truth for the Python test workflows.
+#
+# Why this exists: service manifests pin floors only (e.g. fastapi>=0.128.8),
+# so CI resolved whatever PyPI had on the day a PR ran. FastAPI 0.137.0
+# changed include_router() internals and broke the required "Test Admin API"
+# check with no code change on our side (test fix: 8eb8ae03). FastAPI also
+# no longer upper-bounds starlette (0.139 declares only starlette>=0.46.0),
+# so starlette releases land on the merge path unfiltered.
+#
+# How it is applied: the test-* workflows set PIP_CONSTRAINT to this file,
+# which bounds every `pip install` in the job, including editable installs
+# resolving pyproject dependencies. A constraints file never adds packages —
+# it only caps versions of packages required elsewhere. Floors stay in each
+# service's requirements.txt / pyproject.toml.
+#
+# How to bump: the weekly "Deps Canary" workflow runs the same suites against
+# latest unconstrained deps. When it is green on a newer version, raise the
+# ceiling here in a normal PR — the required checks then prove the bump.
+#
+# Ceilings below were verified green on main on 2026-07-04 with:
+# fastapi 0.139.0, starlette 1.3.1, pydantic 2.13.4, pytest 9.1.1.
+
+# Web framework trio. FastAPI 0.x minors are breaking by convention, and
+# starlette is no longer capped by fastapi itself: cap both at next-minor.
+# Pydantic follows semver: cap at next-major.
+fastapi<0.140
+starlette<1.4
+pydantic<3
+
+# Test-environment tools — capped at the next major above the verified set.
+pytest<10
+pytest-asyncio<2
+httpx<1
+uvicorn<1


### PR DESCRIPTION
## Problem

The required **Test Admin API** check broke in early July with no code change on our side. The service manifests pin floors only (`fastapi>=0.128.8`), so the test workflows resolve whatever PyPI has on the day a PR runs. FastAPI 0.137.0 changed `include_router()` to lazy `_IncludedRouter` placeholders and broke the route-introspection tests (fixed test-side in 8eb8ae03). Two aggravating factors:

- `test-admin-api.yml` ran `pip install -e services/admin-api/ 2>/dev/null || pip install -r ...` — admin-api has no `pyproject.toml`, so the editable install **always** failed and the silent fallback obscured what was actually installed.
- FastAPI no longer upper-bounds starlette: 0.139 declares only `starlette>=0.46.0`, so starlette releases (now at **1.3.1**) land on the merge path completely unfiltered.

## Policy

**1. Merge path resolves within ceilings — [`constraints.txt`](../blob/ci/deps-constraints-policy/constraints.txt) at the repo root.**
The three Python test workflows set `PIP_CONSTRAINT` to it (job-level env), which bounds *every* `pip install` in the job, including editable installs resolving `pyproject.toml` deps (meeting-api) and requirements installs (admin-api, api-gateway). One file, no per-service duplication; floors stay in each service's manifests. Constraints never add packages, so licensing is untouched (no new deps; Category A only).

Ceilings: `fastapi<0.140`, `starlette<1.4` (next-minor — FastAPI 0.x minors are breaking by convention, and starlette is no longer capped by fastapi itself), `pydantic<3`, plus next-major caps on test tooling (`pytest<10`, `pytest-asyncio<2`, `httpx<1`, `uvicorn<1`). All verified green on main as of 2026-07-04.

**2. Drift is caught off the merge path — `deps-canary.yml`.**
Weekly scheduled run (Mon 05:17 UTC, plus `workflow_dispatch`) of the same three suites against latest *unconstrained* deps. On scheduled failure it files (or comments on) a single tracking issue. When the canary is green on newer versions, raise the ceiling in a one-line PR — `constraints.txt` is in each test workflow's path filters, so the required checks prove every bump.

**3. Hygiene.**
The always-failing editable install + silent fallback in `test-admin-api.yml` is replaced with a direct requirements install, and each workflow now logs resolved framework versions (`pip list --format=freeze | grep ...`) so the next incident diagnosis doesn't require spelunking pip's install output. `constraints.txt` needed an explicit `.gitignore` negation (the global `*.txt` rule — same trap as the v0.10.5.3 hallucinations-corpus incident).

## Verification

Local Python 3.11 venvs mirroring each workflow's exact install recipe with `PIP_CONSTRAINT` set:
- Resolution picks the currently-green set (fastapi 0.139.0, starlette 1.3.1, pydantic 2.13.4, pytest 9.1.1) — no downgrade, no conflicts (incl. `fastapi-guard` 7.2.2).
- admin-api: **54 passed**, meeting-api: **297 passed**, api-gateway: **100 passed**.
- All four workflow files parse as valid YAML; this PR itself triggers all three test workflows via the new path filters.

## Not in scope / follow-up

The Dockerfiles have the same unpinned exposure at **image build** time (breaks deploys, not required checks). The constraints file is deliberately at the repo root so image builds can adopt it later via `PIP_CONSTRAINT`/`--constraint` in a follow-up.