### PR TITLE
fix(api-gateway): COPY guard_config.py into the image

### DIFF
--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -17,6 +17,7 @@ RUN pip install --no-cache-dir /app/services/meeting-api
 # Copy application code and requirements
 COPY ./services/api-gateway/requirements.txt /app/
 COPY ./services/api-gateway/main.py /app/
+COPY ./services/api-gateway/guard_config.py /app/
 
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Problem

`services/api-gateway/main.py` does `from guard_config import apply_guard` (added in #465), but the api-gateway `Dockerfile` only `COPY`s `main.py` and `requirements.txt` by name — `guard_config.py` is never copied into the image. The image builds, but the container crashes on startup:

```
ModuleNotFoundError: No module named 'guard_config'
```

## Fix

One line — copy the guard config module alongside `main.py`:

```dockerfile
COPY ./services/api-gateway/guard_config.py /app/
```

## Scope

`guard_config.py` was introduced in #465 (merged into `release/0.10.7` on 2026-07-04); the Dockerfile wasn't updated alongside it. The same gap is present on `main`, `release/0.10.7`, and `0.11-integration` — happy to cherry-pick onto the release branch if that's useful.