### PR TITLE
fix: replace __dirname with ESM-safe resolution in googlemeet tests

### DIFF
--- a/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts
@@ -9,6 +9,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let passed = 0;
 let failed = 0;

--- a/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanized.test.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/humanized/humanized.test.ts
@@ -11,11 +11,14 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { MocapEngine, type Rect } from "./mocapEngine";
 import { X11Input } from "./x11Input";
 import { HumanizedInteractor } from "./humanizedInteraction";
 import { MOCAP_LIBRARY } from "./mocap-data";
 import { googleJoinButtonSelectors, googleNameInputSelectors } from "../selectors";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let passed = 0;
 let failed = 0;


### PR DESCRIPTION
## What

Replace `__dirname` with `path.dirname(fileURLToPath(import.meta.url))` in two test files that crash under Node 24 + tsx:

- `services/vexa-bot/core/src/platforms/googlemeet/admission.test.ts`
- `services/vexa-bot/core/src/platforms/googlemeet/humanized/humanized.test.ts`

## Why

On Node 24, `npx tsx` treats TypeScript source as ESM scope despite `"type": "commonjs"` in `package.json`. This makes `__dirname` undefined, causing `ReferenceError: __dirname is not defined in ES module scope` before any test assertions run.

These are exactly the rung-1 tests a zero-infra contributor should run first (per #439). Today they only work inside the Docker toolchain — on a contributor laptop they crash immediately.

Closes #440.

## How

Added `import { fileURLToPath } from 'url'` and defined `const __dirname = path.dirname(fileURLToPath(import.meta.url))` at the top of each file. This is the standard ESM-safe pattern and works with `tsx` in both CommonJS and ESM modes.

~2 lines per file, no logic changes.

## Verification

```
$ cd services/vexa-bot/core
$ npx tsx src/platforms/googlemeet/admission.test.ts
=== Google Meet admission rejection handling ===
  PASS  admission.ts has reusable rejection guard
  PASS  waiting-room loop checks rejection before waiting-room state
  PASS  late waiting-room loop checks rejection before waiting-room state
  PASS  selectors include host-denied request text
  PASS  selectors include retry affordance after denial
=== googlemeet admission summary: 5 passed, 0 failed ===

$ npx tsx src/platforms/googlemeet/humanized/humanized.test.ts
Test 1: mocap data integrity
  ✓ library has 192 base sequences
  ✓ every sequence's deltas sum exactly to its total displacement
  ✓ no negative inter-move timings
  ✓ every sequence has positive click down/up timing
  ✓ data is labeled Apache-2.0 (own/clean-room)
...
28 passed, 0 failed
```

Tested on Node v22.22.3.