### PR TITLE
fix(runtime-api): reap orphaned process group on bot self-exit

### DIFF
--- a/services/runtime-api/runtime_api/backends/process.py
+++ b/services/runtime-api/runtime_api/backends/process.py
@@ -280,6 +280,16 @@ class ProcessBackend(Backend):
                     except ChildProcessError:
                         pass
 
+                # A process that exits on its own (crash, self-initiated
+                # leave) never goes through stop(), so background children
+                # spawned by its entrypoint (Xvfb, x11vnc, websockify,
+                # fluxbox, socat) are orphaned to PID 1 and live forever.
+                # pid is also the group's pgid (create() runs setsid() in
+                # preexec_fn), so killpg reaches them even though the
+                # leader itself is already dead.
+                if pid:
+                    await asyncio.to_thread(_kill_leftover_group, pid)
+
                 data["status"] = "exited"
                 data["stopped_at"] = time.time()
                 data["exit_code"] = exit_code
@@ -315,6 +325,26 @@ def _pid_alive(pid: int) -> bool:
     except (FileNotFoundError, OSError):
         return False
     return True
+
+
+def _kill_leftover_group(pid: int, grace: float = 2.0) -> None:
+    """Clean up orphaned children of a process that already exited on its
+    own (reaper path). Unlike _terminate_process_group, the group leader is
+    already dead here, so os.getpgid(pid) would raise — but pid IS the pgid
+    (create() calls setsid() in preexec_fn), so signal the group directly.
+    ProcessLookupError means the group is empty: the common, no-leak case."""
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    except PermissionError:
+        logger.warning(f"Permission denied cleaning up process group {pid}")
+        return
+    time.sleep(grace)
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass  # group members exited during the grace period
 
 
 def _terminate_process_group(pid: int, timeout: int = 10) -> bool:


### PR DESCRIPTION
Fixes #486

## Problem

`_reap_dead()` handles a bot that exited on its own by `waitpid()`ing the zombie and updating Redis — but never signals the process group. The helpers `entrypoint.sh` spawned as background jobs (`Xvfb`, `x11vnc`, `websockify`, `fluxbox`, `socat`) are orphaned to PID 1 and run forever. Since `x11vnc`/`websockify` bind fixed ports (5900/6080), one leaked pair breaks the next bot's VNC stack with `Address already in use`. Full details and production evidence in #486.

`stop()` already does the right thing via `killpg`, but only server-initiated stops (max_bot_time scheduler, `DELETE /containers`) take that path.

## Fix

30 added lines, no behavior change on any other path:

- `_kill_leftover_group(pid)`: `killpg(pid, SIGTERM)`, 2s grace, then `killpg(pid, SIGKILL)`. The existing `_terminate_process_group` is not reusable here because it calls `os.getpgid(pid)` on a leader that is already dead (raises `ProcessLookupError`); on this path the leader's pid *is* the pgid (`create()` runs `setsid()` in `preexec_fn`), so the group is signaled directly. `ProcessLookupError` on the first `killpg` means the group is already empty — the common, well-behaved case — and returns silently.
- One call from `_reap_dead()` right after the `waitpid()` block, off-loop via `asyncio.to_thread` (it can sleep up to 2s).

## Testing

- Mechanism test inside the lite container: a `setsid`'d leader spawning two background `sleep`s then self-exiting; `killpg` by the dead leader's pid reaches and kills both orphans.
- Live end-to-end against the running reaper loop (patched lite container in production): registered a self-exiting spec through the real `ProcessBackend.create()` + shared Redis, then only observed. The server's own 30s reaper cycle killed both orphans with no direct intervention:
  ```
  20:01:33 INFO runtime_api.backends.process: Reaper: process leak-test-... (PID=962) is dead
  20:01:34 INFO reaped unknown pid 963 (terminated by SIGTERM)
  20:01:34 INFO reaped unknown pid 964 (terminated by SIGTERM)
  ```
- Regression check: a subsequent real Meet bot on the patched container joined, recorded, and completed normally.

## Known limitation

`pulseaudio --start` self-daemonizes out of the process group, so it escapes group-based cleanup on this path — same as it already does on the `stop()` path. Noted in #486; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)