### PR TITLE
fix(meeting-api): deferred transcribe against Groq/OpenAI providers

### DIFF
--- a/services/meeting-api/meeting_api/meetings.py
+++ b/services/meeting-api/meeting_api/meetings.py
@@ -2320,7 +2320,17 @@ async def transcribe_meeting(
     try:
         async with httpx.AsyncClient(timeout=120.0) as client:
             files = {"file": (f"recording.{media_format}", audio_data, f"audio/{media_format}")}
-            form_data = {"model": "large-v3-turbo"}
+            # Model id must match the provider behind TRANSCRIPTION_SERVICE_URL:
+            # the bundled transcription-service accepts "large-v3-turbo", but
+            # e.g. Groq requires "whisper-large-v3-turbo" and OpenAI "whisper-1".
+            # response_format is explicit because providers like Groq default to
+            # plain {"text": ...} with no segments[], which stores 0 segments.
+            # The bundled service already defaults to verbose_json, so this is a
+            # no-op for self-hosted deployments.
+            form_data = {
+                "model": os.environ.get("TRANSCRIPTION_MODEL", "large-v3-turbo"),
+                "response_format": "verbose_json",
+            }
             if req.language:
                 form_data["language"] = req.language
             headers = {}


### PR DESCRIPTION
Fixes #355

## Problem
Both bugs from #355, still present at `meetings.py:2323` on current `main`:
1. `form_data = {"model": "large-v3-turbo"}` — hardcoded id only the bundled transcription-service accepts. Groq returns 404 `model_not_found` (it wants `whisper-large-v3-turbo`), surfaced to the user as a generic 502.
2. No `response_format` — Groq defaults to plain `{"text": ...}` with no `segments[]`, so the endpoint silently stores 0 segments even for fully transcribable audio.

## Fix
- Model id read from `TRANSCRIPTION_MODEL` env, **default unchanged** (`large-v3-turbo`) so self-hosted deployments behave identically.
- `response_format: "verbose_json"` sent explicitly. The bundled service's handler already declares `response_format: str = Form("verbose_json")`, so this is a no-op for it, and makes Groq/OpenAI return segments.

Both changes are confined to the deferred-transcribe form data; no other path touched.

## Testing
We run vexa-lite in production against Groq (`whisper-large-v3`) via this exact provider surface; the model-id and verbose_json requirements in #355 match what we see daily. The reproduction curl in #355 (correct model + `response_format=verbose_json` → segments present) is the behavior this change produces.

CLA: signed and emailed to info@vexa.ai on 2026-07-09 (also covers open PR #487).

🤖 Generated with [Claude Code](https://claude.com/claude-code)