### PR TITLE
feat(vexa-bot): configurable transcription model id

### DIFF
--- a/services/vexa-bot/core/src/docker.ts
+++ b/services/vexa-bot/core/src/docker.ts
@@ -52,6 +52,7 @@ export const BotConfigSchema = z.object({
   recordingUploadUrl: z.string().url().optional(),
   transcriptionServiceUrl: z.string().optional(),
   transcriptionServiceToken: z.string().optional(),
+  transcriptionModel: z.string().optional(),
   voiceAgentEnabled: z.boolean().optional(),
   voiceAgentSettings: z.object({
     url: z.string().optional(),

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -1232,6 +1232,7 @@ async function initPerSpeakerPipeline(botConfig: BotConfig): Promise<boolean> {
     transcriptionClient = new TranscriptionClient({
       serviceUrl: transcriptionServiceUrl,
       apiToken: botConfig.transcriptionServiceToken || process.env.TRANSCRIPTION_SERVICE_TOKEN,
+      model: botConfig.transcriptionModel || process.env.TRANSCRIPTION_MODEL,
       maxSpeechDurationSec,
       minSilenceDurationMs,
     });

--- a/services/vexa-bot/core/src/services/transcription-client.ts
+++ b/services/vexa-bot/core/src/services/transcription-client.ts
@@ -30,6 +30,11 @@ export interface TranscriptionClientConfig {
   serviceUrl: string;
   /** Optional bearer token for authentication */
   apiToken?: string;
+  /** Model id sent in the multipart body. The bundled transcription-service
+   *  ignores it beyond requiring presence, but external OpenAI-compatible
+   *  providers validate it (Groq: "whisper-large-v3", OpenAI: "whisper-1").
+   *  Default: "whisper-1" */
+  model?: string;
   /** Max retry attempts for transient failures. Default: 3 */
   maxRetries?: number;
   /** Base delay between retries in ms. Default: 1000 */
@@ -52,6 +57,7 @@ export interface TranscriptionClientConfig {
 export class TranscriptionClient {
   private serviceUrl: string;
   private apiToken: string | undefined;
+  private model: string;
   private maxRetries: number;
   private retryDelayMs: number;
   private sampleRate: number;
@@ -64,6 +70,7 @@ export class TranscriptionClient {
       this.serviceUrl += '/v1/audio/transcriptions';
     }
     this.apiToken = config.apiToken;
+    this.model = config.model || 'whisper-1';
     this.maxRetries = config.maxRetries ?? 3;
     this.retryDelayMs = config.retryDelayMs ?? 1000;
     this.sampleRate = config.sampleRate ?? 16000;
@@ -126,7 +133,7 @@ export class TranscriptionClient {
     parts.push(Buffer.from(
       `--${boundary}\r\n` +
       `Content-Disposition: form-data; name="model"\r\n\r\n` +
-      `whisper-1\r\n`
+      `${this.model}\r\n`
     ));
 
     // Response format part

--- a/services/vexa-bot/core/src/types.ts
+++ b/services/vexa-bot/core/src/types.ts
@@ -30,6 +30,7 @@ export type BotConfig = {
   // Per-speaker transcription
   transcriptionServiceUrl?: string;   // HTTP endpoint for transcription-service
   transcriptionServiceToken?: string; // Bearer token for transcription-service
+  transcriptionModel?: string;        // Model id sent to the endpoint (default "whisper-1"; e.g. Groq needs "whisper-large-v3")
 
   // Voice agent / meeting interaction interface
   voiceAgentEnabled?: boolean;  // Enable TTS, chat, screen share capabilities


### PR DESCRIPTION
## Motivation

`TranscriptionClient` already supports a custom endpoint (`transcriptionServiceUrl`) and bearer auth (`transcriptionServiceToken`), so it is one field away from working directly against any OpenAI-compatible transcription provider. That field is the model id, hardcoded to `whisper-1` in the multipart body (`transcription-client.ts`). The bundled transcription-service only requires the field to be present, but external providers validate it — Groq wants `whisper-large-v3`, OpenAI wants `whisper-1`/`gpt-4o-transcribe` — so pointing the bot straight at them fails with 404 `model_not_found`. We run vexa-lite in production against Groq and currently maintain a proxy shim whose main job is rewriting this one field.

Realtime-path counterpart of #355 / #488 (which fixed the same hardcoding on meeting-api's deferred-transcribe path) and uses the same `TRANSCRIPTION_MODEL` env name, so one env var configures both paths consistently.

## Changes

- `TranscriptionClientConfig.model` — optional, **default `"whisper-1"`** (zero behavior change for existing deployments)
- Wired in `index.ts` as `botConfig.transcriptionModel || process.env.TRANSCRIPTION_MODEL` — the exact pattern used by `transcriptionServiceToken` on the line above
- `transcriptionModel` added to the `BotConfig` type and the `docker.ts` zod schema

4 files, +11/-2.

## Testing

- Typecheck: `tsc --noEmit` output is byte-identical before/after the change (9 pre-existing errors on `main`, none introduced).
- Provider behavior: we run this exact configuration surface (custom URL + bearer + provider-specific model id) in production daily against Groq `whisper-large-v3`; the default path (`whisper-1`, bundled service) is unchanged by construction.

CLA: signed and emailed to info@vexa.ai on 2026-07-09 (also covers #487, #488).

🤖 Generated with [Claude Code](https://claude.com/claude-code)