### PR TITLE
release: v0.12.1 version bump

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -3,8 +3,8 @@ name: vexa
 description: Vexa v0.12 — self-hostable real-time meeting transcription + agent control plane
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
-version: 0.12.0
-appVersion: "0.12.0"
+version: 0.12.1
+appVersion: "0.12.1"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
Chart.yaml (version + appVersion) and package.json → 0.12.1, per the release workflow's tag↔version match requirement. Batch: #505 (governance), #517/#521 (security deps), #494 (release machinery). Cut per the ship bar — docs/docs/governance/delivery.mdx §Release.