### PR TITLE
release-images: publish linux/arm64 for v0.12 matrix (Apple Silicon)

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -7,7 +7,7 @@
 #   tag push v0.12.* (or workflow_dispatch with an explicit version) →
 #     preflight       secrets present (fail fast + loud) · tag ↔ package.json ↔ Chart.yaml
 #                     appVersion consistency · helm static gates · pinned-render assertions
-#     build (matrix)  the uniform images — buildx, amd64, registry :buildcache cache
+#     build (matrix)  the uniform images — buildx, amd64+arm64, registry :buildcache cache
 #     build-bot       vexaai/vexa-bot — special-cased: FROM the locally-built
 #                     vexa/meet-join-env:dev base, so it uses the classic docker driver
 #     validate        calls release-validate.yml (manifest verify · image-identity ·
@@ -163,6 +163,7 @@ jobs:
       - name: Free runner disk (large image)
         if: matrix.free_disk == true
         uses: jlumbroso/free-disk-space@v1.3.1
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -173,8 +174,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
-          # amd64 only for v0.12.0 — arm64 is a tracked follow-up (build time × QEMU).
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ matrix.image }}:${{ needs.preflight.outputs.version }}
           build-args: ${{ matrix.build_args }}
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -123,7 +123,10 @@ jobs:
           # instead; it is authoritative for both manifest shapes.
           for img in $ALL_IMAGES; do
             echo "== $img:$VERSION"
-            IMG="$img" docker manifest inspect -v "$img:$VERSION" | python3 -c "
+            # NOTE: a `IMG=... cmd | python3` prefix binds the var only to the first
+            # pipeline command — python3 would KeyError. Export it instead.
+            export IMG="$img"
+            docker manifest inspect -v "$img:$VERSION" | python3 -c "
           import os, sys, json
           img = os.environ['IMG']
           d = json.load(sys.stdin)

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -12,6 +12,7 @@
 #                      validate-harness fix is testable BEFORE it merges to main
 #
 #   resolve         version well-formed · every published manifest resolves + carries linux/amd64
+#                   (and linux/arm64 for matrix images except vexa-bot)
 #   image-identity  every published image CONTAINS what its NAME promises — runs in PARALLEL
 #                   with the validate legs (all consume the same published bytes); it gates
 #                   PROMOTE, not the validate verdict, so it no longer sits serially between
@@ -84,8 +85,9 @@ env:
 jobs:
   # ──────────────────────────────────────────────────────────────────────────────────────────
   # Cheap gate (~30s): the version is well-formed and every manifest it claims actually exists
-  # with linux/amd64. Everything downstream fans out from here IN PARALLEL — nothing heavier
-  # stands between "validate requested" and the first validate leg starting.
+  # with linux/amd64 (all images) and linux/arm64 (matrix images except vexa-bot). Everything
+  # downstream fans out from here IN PARALLEL — nothing heavier stands between "validate
+  # requested" and the first validate leg starting.
   resolve:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -110,7 +112,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Every published manifest resolves and carries linux/amd64
+      - name: Every published manifest resolves and carries required platforms
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -121,17 +123,24 @@ jobs:
           # instead; it is authoritative for both manifest shapes.
           for img in $ALL_IMAGES; do
             echo "== $img:$VERSION"
-            docker manifest inspect -v "$img:$VERSION" | python3 -c '
-          import sys, json
+            IMG="$img" docker manifest inspect -v "$img:$VERSION" | python3 -c "
+          import os, sys, json
+          img = os.environ['IMG']
           d = json.load(sys.stdin)
           items = d if isinstance(d, list) else [d]
-          plats = {(m.get("Descriptor", {}).get("platform", {}).get("os"),
-                    m.get("Descriptor", {}).get("platform", {}).get("architecture"))
+          plats = {(m.get('Descriptor', {}).get('platform', {}).get('os'),
+                    m.get('Descriptor', {}).get('platform', {}).get('architecture'))
                    for m in items}
-          sys.exit(0 if ("linux", "amd64") in plats else 1)
-          ' || { echo "::error ::$img:$VERSION has no linux/amd64 manifest — is the set published?"; exit 1; }
+          required = {('linux', 'amd64')}
+          if img != 'vexaai/vexa-bot':
+            required.add(('linux', 'arm64'))
+          missing = required - plats
+          if missing:
+            print(f'missing platforms: {sorted(missing)}', file=sys.stderr)
+            sys.exit(1)
+          " || { echo "::error ::$img:$VERSION missing required platform manifest(s) — is the set published?"; exit 1; }
           done
-          echo "✓ all $(wc -w <<<"$ALL_IMAGES") manifests present"
+          echo "✓ all $(wc -w <<<"$ALL_IMAGES") manifests present with required platforms"
 
   # ──────────────────────────────────────────────────────────────────────────────────────────
   # Image-identity smoke — a dumb, loud assertion that every published image CONTAINS what its

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -11,7 +11,11 @@ agent state stay on infrastructure you control.
 Prerequisites: a Linux host (Ubuntu 24.04) for production, **Docker engine ≥ v26** (agent workers
 mount each granted workspace as an isolated volume subpath — older engines fail worker creation;
 `make all` checks and refuses), `git`, `curl`. A Mac with Docker Desktop works for a local
-evaluation — everything runs in containers either way.
+evaluation — everything runs in containers either way. Published `vexaai/v012-*` images are
+multi-arch (`linux/amd64`, `linux/arm64`) — Docker on Apple Silicon pulls native arm64
+automatically. `vexaai/vexa-bot` remains amd64-only (built locally via `make bot`). For GPU
+transcription on Mac, point `TRANSCRIPTION_SERVICE_URL` at any OpenAI-compatible local endpoint
+(see [Configuration](/configuration)).
 
 ```bash
 curl -fsSL https://get.docker.com | sh

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -11,10 +11,12 @@ agent state stay on infrastructure you control.
 Prerequisites: a Linux host (Ubuntu 24.04) for production, **Docker engine ≥ v26** (agent workers
 mount each granted workspace as an isolated volume subpath — older engines fail worker creation;
 `make all` checks and refuses), `git`, `curl`. A Mac with Docker Desktop works for a local
-evaluation — everything runs in containers either way. Published `vexaai/v012-*` images are
-multi-arch (`linux/amd64`, `linux/arm64`) — Docker on Apple Silicon pulls native arm64
-automatically. `vexaai/vexa-bot` remains amd64-only (built locally via `make bot`). For GPU
-transcription on Mac, point `TRANSCRIPTION_SERVICE_URL` at any OpenAI-compatible local endpoint
+evaluation — everything runs in containers either way. Published `vexaai/v012-*` images include
+`linux/arm64` variants alongside `linux/amd64`, so Docker on Apple Silicon pulls arm64 where
+available — but the arm64 images are published **best-effort**: release CI currently validates
+only the amd64 images (no arm64 execution leg yet), so treat Apple Silicon as experimental.
+`vexaai/vexa-bot` remains amd64-only (built locally via `make bot`). For GPU transcription on
+Mac, point `TRANSCRIPTION_SERVICE_URL` at any OpenAI-compatible local endpoint
 (see [Configuration](/configuration)).
 
 ```bash

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -12,10 +12,8 @@ with one command.
 - A Linux host (Ubuntu 24.04 recommended for production), `git`, and **Docker engine ≥ v26**
   (`make all` checks and refuses older engines). A Mac with Docker Desktop works for a local
   evaluation — everything runs in containers either way.
-- Published `vexaai/v012-*` images are multi-arch (`linux/amd64`, `linux/arm64`) — Docker on
-  Apple Silicon pulls native arm64 automatically. `vexaai/vexa-bot` remains amd64-only (built
-  locally via `make bot`). For GPU transcription on Mac, point `TRANSCRIPTION_SERVICE_URL` at any
-  OpenAI-compatible local endpoint (see [Configuration](/configuration)).
+- On Apple Silicon: arm64 images are published best-effort (not yet CI-validated) — see
+  [Deployment](/deployment#quick-start-docker-compose) for details.
 - A **transcription (STT) token** — get one free at [`vexa.ai/account`](https://vexa.ai/account), or
   [self-host transcription](/deployment#air-gapped) on a GPU. Without it, bots join and record but
   produce no transcript.

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -12,6 +12,10 @@ with one command.
 - A Linux host (Ubuntu 24.04 recommended for production), `git`, and **Docker engine ≥ v26**
   (`make all` checks and refuses older engines). A Mac with Docker Desktop works for a local
   evaluation — everything runs in containers either way.
+- Published `vexaai/v012-*` images are multi-arch (`linux/amd64`, `linux/arm64`) — Docker on
+  Apple Silicon pulls native arm64 automatically. `vexaai/vexa-bot` remains amd64-only (built
+  locally via `make bot`). For GPU transcription on Mac, point `TRANSCRIPTION_SERVICE_URL` at any
+  OpenAI-compatible local endpoint (see [Configuration](/configuration)).
 - A **transcription (STT) token** — get one free at [`vexa.ai/account`](https://vexa.ai/account), or
   [self-host transcription](/deployment#air-gapped) on a GPU. Without it, bots join and record but
   produce no transcript.


### PR DESCRIPTION
## Summary

Implements the prepared solution from #536 (supersedes #321):

- Add `docker/setup-qemu-action@v3` before buildx setup in `release-images.yml`
- Change matrix `platforms` to `linux/amd64,linux/arm64`
- Extend `release-validate.yml` manifest verification to require arm64 for matrix images (`vexa-bot` remains amd64-only)
- Document platform support in quickstart and deployment docs

## Scope

- **In:** 9 matrix images in the `build` job (admin-api, runtime, agent-worker, agent-api, meeting-api, gateway, mcp, terminal, lite)
- **Out:** `vexa-bot` (Playwright join-env base), GPU transcription

## Test plan

- [x] Local buildx smoke: `v012-gateway` builds successfully for `linux/amd64` + `linux/arm64` on Apple Silicon Mac
- [ ] CI workflow review (full publish requires upstream Docker Hub secrets)
- [ ] **A2 (post-merge):** fresh clone on Apple Silicon Mac, `docker compose up`, zero AMD64 warnings — I will run this once an RC tag is published

## Notes

Uses the prepared QEMU floor from #536. If CI times out on `lite` (90-min job limit), happy to follow fork B (native arm runners + `imagetools create` merge).

Closes #536