### PR TITLE
process: validation ladder — per-PR autonomous value leg (pr-value) + value-witness law

### DIFF
--- a/.github/workflows/pr-value.yml
+++ b/.github/workflows/pr-value.yml
@@ -30,10 +30,21 @@ on:
       - "libs/**"
       - "package.json"
       - "pnpm-lock.yaml"
+  # Backfill mode: validate an ALREADY-OPEN PR (the queue that predates this workflow) without
+  # waiting for the contributor to push. Checks out the PR's MERGE ref (their change on top of
+  # current main — the thing that would actually land). SECURITY: this mode runs untrusted PR
+  # code; the job uses NO secrets (no registry login — anonymous pulls), so there is nothing
+  # to exfiltrate beyond the read-only GITHUB_TOKEN.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Open PR number to validate (checks out refs/pull/<pr>/merge)"
+        required: true
+        type: string
 
 # a superseded run's verdict is worthless — cancel it
 concurrency:
-  group: pr-value-${{ github.ref }}
+  group: pr-value-${{ inputs.pr || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -46,6 +57,9 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          # pull_request event → default (the PR merge ref). dispatch → the named PR's merge ref.
+          ref: ${{ inputs.pr && format('refs/pull/{0}/merge', inputs.pr) || '' }}
       - uses: jlumbroso/free-disk-space@v1.3.1
       - uses: astral-sh/setup-uv@v5
       # agent-api reads deploy/compose/.env via env_file (single source of truth) — it must exist.
@@ -69,7 +83,7 @@ jobs:
           {
             echo "## pr-value — machine-presented live-leg row (TAKE step 2)"
             echo
-            echo "Stack built from \`${{ github.event.pull_request.head.sha }}\`;"
+            echo "PR: \`${{ inputs.pr || github.event.pull_request.number }}\` · stack built from \`${{ github.event.pull_request.head.sha || 'merge ref (dispatch backfill)' }}\`;"
             echo "scenario suite: \`deploy/compose/tests/mock_scenarios_test.py\`"
             echo "(lifecycle FSM · failure attribution · join-timeout · segment emission ·"
             echo "immediate-stop · max-bots · speak-ack · canaccess-deny) + always-on stack subset."

--- a/.github/workflows/pr-value.yml
+++ b/.github/workflows/pr-value.yml
@@ -1,0 +1,85 @@
+# pr-value — the per-PR AUTONOMOUS VALUE LEG (the live row of the TAKE bundle, machine-presented).
+#
+# gates.yml proves the PR is architecturally sound (L1/L2: isolation, contracts, unit green).
+# This workflow proves the PR's tree still DELIVERS: the real compose stack comes up from the
+# PR's own code and a contract-faithful bot drives the full product FSM through the real
+# backend — join lifecycle, failure attribution, transcript-segment emission, concurrent bots,
+# acts round-trip (the MOCK_BOT scenario suite, deploy/compose/tests/mock_scenarios_test.py).
+#
+# Why the mock bot is the right instrument here: it reuses the REAL orchestrator and the REAL
+# lifecycle/transcript/acts adapters — only join + audio capture are faked (mock/README.md).
+# So every backend-visible behavior is prod-identical, no browser/STT/GPU needed, and the leg
+# runs anywhere in ~10-15 min. What it CANNOT see (real Meet admission, real audio → words)
+# stays at the release bar (release-validate + the eval lane), stated honestly in delivery.mdx.
+#
+# TAKE step 2 consumes this run: a green pr-value IS the "live leg" row of the acceptance map
+# for backend-visible behavior — contributors no longer hand-assemble that row. The scenario
+# table lands in the job summary as the machine-presented bundle fragment.
+#
+# Scope guard: runs only when runtime surfaces change (path filter). Docs/governance/workflow
+# -only PRs skip it entirely — gates.yml remains their only required machinery.
+name: pr-value
+
+on:
+  pull_request:
+    paths:
+      - "core/**"
+      - "clients/terminal/**"
+      - "deploy/compose/**"
+      - "deploy/lite/**"
+      - "libs/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+
+# a superseded run's verdict is worthless — cancel it
+concurrency:
+  group: pr-value-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # The value FSM through the real backend, built from the PR's tree.
+  value-fsm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jlumbroso/free-disk-space@v1.3.1
+      - uses: astral-sh/setup-uv@v5
+      # agent-api reads deploy/compose/.env via env_file (single source of truth) — it must exist.
+      - name: Seed compose .env
+        run: cp deploy/compose/.env.example deploy/compose/.env
+      - name: Build the mock bot (local instrument image, never published)
+        run: docker build -f core/meetings/services/bot/Dockerfile.mock -t mock-bot:dev .
+      # No COMPOSE_NO_BUILD: the stack builds FROM THIS PR's TREE — that is the point.
+      # The stack fixture's `up -d --build` proves the PR's images assemble and come healthy;
+      # the scenario suite then proves the product FSM end to end on them.
+      - name: Value scenarios on the PR's stack (MOCK_BOT suite + always-on subset)
+        working-directory: deploy/compose
+        env:
+          MOCK_BOT: "1"
+          BROWSER_IMAGE: mock-bot:dev
+          COMPOSE_DYNAMIC_PORTS: "1"
+        run: ./bin/stack-test
+      - name: Present the machine bundle (job summary)
+        if: always()
+        run: |
+          {
+            echo "## pr-value — machine-presented live-leg row (TAKE step 2)"
+            echo
+            echo "Stack built from \`${{ github.event.pull_request.head.sha }}\`;"
+            echo "scenario suite: \`deploy/compose/tests/mock_scenarios_test.py\`"
+            echo "(lifecycle FSM · failure attribution · join-timeout · segment emission ·"
+            echo "immediate-stop · max-bots · speak-ack · canaccess-deny) + always-on stack subset."
+            echo
+            echo "Verdict: **${{ job.status }}** — a green run is the live-leg evidence row for"
+            echo "backend-visible behavior. Real-Meet admission and audio→words remain release-bar"
+            echo "legs (release-validate + eval lane) and are NOT claimed by this check."
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Compose state on failure
+        if: failure()
+        run: |
+          docker ps -a
+          docker compose -p vexa-compose-gate -f deploy/compose/docker-compose.yml logs --no-color --tail 200 || true

--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -657,7 +657,7 @@ rungs, and where the machinery runs them:
 | **L3 — delivers** | the PR's own tree assembles and drives the full product FSM — join lifecycle, failure attribution, transcript-segment emission, concurrent bots, acts — through the **real** backend (mock bot: real orchestrator + real adapters; only join/audio faked) | `pr-value` | every runtime-surface PR, ~10–15 min |
 | **L3.5 — transcribes** *(to build)* | fixture audio → real pipeline → real CPU STT → **golden words** land via the API — no Meet, no human | wav→words leg | PRs touching the transcription path; every release |
 | **L4 — artifact truth** | the *published* images deliver on every deployment shape (compose · mock-FSM · 0.10-compat · bot-spawn · lite · helm) + fresh-VM concurrent-bots | `release-validate` + VM leg | every release, ≤10 min re-runnable |
-| **L5 — witnessed value** | a real Meet, real audio, real admission → words a human saw land | eval lane (`bot/eval/run.sh`: autonomous verdict, ONE human act — admit) | per minor release; per join-surface batch |
+| **L5 — witnessed value** | a real Meet, real audio, real admission → words a human saw land, plus the batch's user-visible values walked once | the release **witness script** over the eval lane (`bot/eval/run.sh`: autonomous verdict; human acts: admit + speak + walk the script, ~10 min) | once per release — the combined pass |
 
 Two laws fall out of the ladder:
 
@@ -718,18 +718,21 @@ honored.**
    it is an unclosed loop.
 6. **The milestone ticks** — the public progress bar is the release ledger.
 
-**The value-witness law.** "All value witnessed" is a *named rung*, never an inference from
+**The value-witness law.** "All value witnessed" is a *named act*, never an inference from
 machinery green (the v0.12.1 incident: promoted and published on L4 alone, witness unsigned):
 
-- **A patch release** ships on L4 green **plus** the highest automated value rung available
-  (today the mock-FSM leg; L3.5 wav→words once built) — and its notes' coverage statement MUST
-  say which rung witnessed the value and that L5 was not re-run.
-- **A minor release, or any batch touching the join surface,** ships only with an **L5
-  witness**: the eval lane run on the release candidate (autonomous verdict; the one human act
-  is admitting the bot), signed by the human who admitted.
+- **PR-level value is machine-witnessed.** A PR's value rows are proven by the harness on its
+  own sha (`pr-value`, path-aware legs); no human eyeballs individual PRs. A PR reaches the
+  human only as *proven value + reviewed diff* — or when it needs a genuine ruling.
+- **Every release carries ONE combined-value witness pass.** The release generates a **witness
+  script** from the batch: a single live session (one real meeting on the release candidate +
+  one product walkthrough) in which every user-visible value shipped in the batch is
+  experienced once. The autonomous legs surround it; the human contributes the irreducible
+  minimum — admit the bot, speak, walk the script (~10 min). Backend-invisible changes are
+  listed under the script with their machine evidence, witnessed by proxy and named as such.
 - **Publish and promote are the same act** for witness purposes: neither happens before the
-  release's declared witness rung is green. A release published below its declared rung is
-  retracted to pre-release until the rung is met.
+  witness pass is signed. A release published unwitnessed is retracted to pre-release until
+  the pass is met.
 
 **The verdict-latency law.** The release loop is only honest if it is also *fast to re-ask*:
 

--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -567,6 +567,12 @@ value real?) and the **diff** (is it correct and safe?). **A diff with no bundle
 reviewable, whatever it says** — request the bundle, warmly, and stop. Do not review code on
 vibes and do not let a good-looking diff substitute for evidence.
 
+**The machine rows count.** The bundle is assembled from two sources: the harness's runs on the
+PR's head sha (`gates`, `pr-value` — the machine-presented rows) and the contributor's own
+witness (everything above the automation line). Before requesting a bundle, check what the
+harness already presented — asking a contributor to hand-write evidence `pr-value` carries on
+their sha is our process bug, not their gap.
+
 #### Step 2 — Floor mapping, in the issue's own numbering
 
 Rebuild the issue's acceptance table AS DECLARED (A1…An) and map every row to the PR's
@@ -574,10 +580,12 @@ evidence. **Detect renumbering and thinning** — a PR body that re-labels or qu
 rows hides its gaps; the map is always in the issue's numbering, never the PR's. Per row:
 
 - **presented** — red→green pair shown, negative control shown red, anchors present
-  (base+head shas, ids, timestamps);
+  (base+head shas, ids, timestamps); **a green `pr-value`/`gates` run on the head sha is
+  `presented` for every row those legs carry** — link the run, don't re-demand the row;
 - **partial** — claimed but missing its control, its anchor, or its red side;
 - **missing** — including the rows only a live leg can carry. The live row exists precisely
-  because unit greens can lie; never waive it for a plausible diff.
+  because unit greens can lie; never waive it for a plausible diff — but route it to the
+  cheapest rung that carries it (the ladder, §Validation) before routing it to a human.
 
 #### Step 3 — The diff on its own axis
 
@@ -637,9 +645,41 @@ the issue itself was wrong, saying so publicly IS the deliverable (D11).
 
 ## Validation
 
-Before merge, a **non-author** runs the change live and signs what they witnessed — after the
-**author's own witness**: the author runs their change live first and their run is the bundle's
-first row; you never ask another human to witness value you haven't witnessed yourself.
+### The ladder — machine first, human last
+
+Validation is a ladder; each rung runs **as early and as often as it can be automated**, and a
+human is asked only for what no rung below can see (D9: the human is the scarce oracle). The
+rungs, and where the machinery runs them:
+
+| Rung | Proves | Machinery | When |
+|---|---|---|---|
+| **L1/L2 — sound** | isolation, contracts, units, licenses, build | `gates` | every PR push, ~5 min |
+| **L3 — delivers** | the PR's own tree assembles and drives the full product FSM — join lifecycle, failure attribution, transcript-segment emission, concurrent bots, acts — through the **real** backend (mock bot: real orchestrator + real adapters; only join/audio faked) | `pr-value` | every runtime-surface PR, ~10–15 min |
+| **L3.5 — transcribes** *(to build)* | fixture audio → real pipeline → real CPU STT → **golden words** land via the API — no Meet, no human | wav→words leg | PRs touching the transcription path; every release |
+| **L4 — artifact truth** | the *published* images deliver on every deployment shape (compose · mock-FSM · 0.10-compat · bot-spawn · lite · helm) + fresh-VM concurrent-bots | `release-validate` + VM leg | every release, ≤10 min re-runnable |
+| **L5 — witnessed value** | a real Meet, real audio, real admission → words a human saw land | eval lane (`bot/eval/run.sh`: autonomous verdict, ONE human act — admit) | per minor release; per join-surface batch |
+
+Two laws fall out of the ladder:
+
+- **The machine presents what the machine can prove.** A green `pr-value` run on the PR's head
+  sha **is** the live-leg evidence row for backend-visible behavior — TAKE step 2 consumes it
+  directly. Contributors hand-assemble only the rows above the automation line: platform-specific
+  behavior, UX, real external services. Never ask a contributor or a human validator to
+  re-witness a rung the harness already witnessed on their exact sha.
+- **Claim only your rung** (P19/D12 restated for the ladder). `pr-value` green does not claim
+  audio→words; L3.5 green does not claim real-Meet admission. Every rung's report names what it
+  proved AND the rungs it explicitly does not reach — an over-claimed rung is a false green,
+  treated as an incident (the v0.12.1 lesson: a machinery-green release was published as if
+  value-witnessed; the witness was still unsigned).
+
+### The human signature
+
+Before merge, a **non-author** signs what they witnessed **above the automation line** — after
+the **author's own witness**: the author runs their change live first and their run is the
+bundle's first row; you never ask another human to witness value you haven't witnessed yourself.
+Where every acceptance row sits at or below the automation line (behavior `pr-value`/L3.5 proves
+on the PR's sha), the machine rows stand as the live witness and the non-author signs the
+*review of the evidence*, not a re-run.
 
 The attestation is **multichannel** — what the bot did (logs), what the human saw (the meeting,
 the transcript), what the instruments recorded (test output, API responses) — and the channels
@@ -652,9 +692,10 @@ preferred signer (D16); an invalidation is a first-class, credited result (D11).
 ## Integration — the merge bar
 
 Main is **always releasable, never auto-released**. A PR enters it when: the acceptance floor is
-presented (TAKE, step 2) · the diff passes review + the named security checks (D-S) · the value
-is signed (D9) · sealed-contract changes rode `lane:contract` with a human review · the full CI
-gate suite is green — the machine contract between every PR and main
+presented (TAKE, step 2 — machine rows + contributor rows) · the diff passes review + the named
+security checks (D-S) · the value is signed (D9) · sealed-contract changes rode `lane:contract`
+with a human review · the full CI gate suite is green **and `pr-value` is green when the PR
+touches a runtime surface** — the machine contract between every PR and main
 ([the live map](/governance/arch-compliance)). **Merge is the promise to the contributor,
 honored.**
 
@@ -676,6 +717,19 @@ honored.**
    to validate on the shipped artifact (D16). An issue closed without its reporter hearing about
    it is an unclosed loop.
 6. **The milestone ticks** — the public progress bar is the release ledger.
+
+**The value-witness law.** "All value witnessed" is a *named rung*, never an inference from
+machinery green (the v0.12.1 incident: promoted and published on L4 alone, witness unsigned):
+
+- **A patch release** ships on L4 green **plus** the highest automated value rung available
+  (today the mock-FSM leg; L3.5 wav→words once built) — and its notes' coverage statement MUST
+  say which rung witnessed the value and that L5 was not re-run.
+- **A minor release, or any batch touching the join surface,** ships only with an **L5
+  witness**: the eval lane run on the release candidate (autonomous verdict; the one human act
+  is admitting the bot), signed by the human who admitted.
+- **Publish and promote are the same act** for witness purposes: neither happens before the
+  release's declared witness rung is green. A release published below its declared rung is
+  retracted to pre-release until the rung is met.
 
 **The verdict-latency law.** The release loop is only honest if it is also *fast to re-ask*:
 


### PR DESCRIPTION
## Why

Eight PRs are queued on human review bandwidth while the harness that could validate their value sits unused until release. And v0.12.1 was published on machinery-green with the value witness unsigned — nothing in the law distinguished the two. This PR makes the TAKE→release loop both **fast** (machines witness what machines can witness, per PR, autonomously) and **bulletproof** (a release must name its witness rung; publishing below it is structurally a retraction).

## What

### `pr-value.yml` (new) — the per-PR autonomous value leg (L3)
Every PR touching a runtime surface (`core/`, `clients/terminal/`, `deploy/compose|lite`, `libs/`) builds the compose stack **from its own tree** and drives the full product FSM through the **real** backend using the existing mock-bot instrument (real orchestrator + real lifecycle/transcript/acts adapters; only join/audio faked): lifecycle FSM · failure attribution · join-timeout · **transcript-segment emission** · immediate-stop · max-bots · speak-ack · canaccess-deny, plus the always-on stack subset. ~10–15 min, path-filtered, cancel-superseded. The job summary states exactly what the run proves and what it does NOT claim (no real-Meet admission, no audio→words).

### `delivery.mdx` — the validation ladder + two laws
- **§Validation** rewritten as the ladder: L1/L2 `gates` → **L3 `pr-value`** → L3.5 wav→words *(to build — prepared issue follows)* → L4 `release-validate` + fresh-VM leg → L5 eval-lane human witness (one human act: admit).
- **The machine presents what the machine can prove** — a green `pr-value` on the head sha IS the live-leg bundle row; TAKE step 1/2 consume it and stop demanding hand-written evidence the harness carries.
- **Claim only your rung** — every rung's report names what it proved and what it doesn't reach; an over-claimed rung is a false green, treated as an incident.
- **Ship bar: the value-witness law** — a release names its witness rung: patch = L4 + highest automated value rung; minor or join-surface batch = L5 human witness. Publish/promote below the declared rung ⇒ retract to pre-release. (The v0.12.1 incident, made structural.)
- Merge bar names `pr-value` for runtime-surface PRs.

## What this changes for the 8 open PRs
#555 (gateway guard), #543 (Jitsi), #504 (wizard), #485–#489 (bot/meeting-api fixes) all touch runtime surfaces → each gets an autonomous L3 value verdict on its own sha the moment this merges and they rebase/re-push. TAKE reviews then start from a machine-presented bundle instead of a cold diff.

## Owner decisions (not taken here)
- Making `pr-value` a **required** status (it's path-filtered; requiring it would need GitHub's path-aware required-check handling or a skipped-job-reports-success shim).
- L3.5 wav→words fixture: prepared issue follows this PR.

## Self-compliance
Workflow-only + governance-docs change: no runtime surface touched; `gates` carries it. The pr-value workflow itself reuses existing sealed instruments (`stack-test`, mock scenarios) — no new test semantics invented.