### PR TITLE
install pulls the published, release-validated images — services, agent-worker, bot (closes #569)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # =============================================================================
 # Vexa open-core — top-level deploy entrypoint (Docker Compose)
 # =============================================================================
-.PHONY: all up down bot lite help
+.PHONY: all up dev down bot lite help
 
 help:
 	@echo "Vexa deploy:"
-	@echo "  make all   full Docker Compose stack"
-	@echo "  make bot   build the meeting bot from source (needed before bots can join)"
+	@echo "  make all   full Docker Compose stack from the PUBLISHED images (bot included — pulled)"
+	@echo "  make dev   full stack built from THIS checkout, tagged :dev (contributors)"
+	@echo "  make bot   build the meeting bot from source into vexa/vexa-bot:dev (dev path)"
 	@echo "  make lite  single-container Vexa Lite from the published image"
 	@echo "  make down  stop the compose stack"
 
@@ -16,7 +17,10 @@ all up:              ## full compose stack
 lite:                ## single-container Vexa Lite (provision + run + verify) — see deploy/lite
 	@$(MAKE) --no-print-directory -C deploy/lite all
 
-bot:                 ## build the meeting bot image from source (matches the stack's lifecycle.v1)
+dev:                 ## full stack built from this checkout (:dev tags — never shadows published v012)
+	@$(MAKE) --no-print-directory -C deploy/compose dev
+
+bot:                 ## build the meeting bot from source → vexa/vexa-bot:dev (dev path; install pulls the published bot)
 	@$(MAKE) --no-print-directory -C deploy/compose bot
 
 down:                ## stop the compose stack

--- a/deploy/compose/Makefile
+++ b/deploy/compose/Makefile
@@ -8,11 +8,13 @@ BROWSER_IMAGE ?= mock-bot:dev
 EMAIL ?= self-host@vexa.ai
 SCOPES ?= bot,tx
 COMPOSE  = docker compose -p $(PROJECT) -f docker-compose.yml
-# The meeting bot is built FROM SOURCE (matching this stack's lifecycle.v1), never pulled — see `bot`.
+# Install pulls the published bot (vexaai/vexa-bot:v012 — release-validated since v0.12.1).
+# `make bot` builds from source into the LOCAL namespace (vexa/, like vexa/meet-join-env:dev) so a
+# source build can never shadow the published pointer (#569).
 REPO_ROOT := $(abspath ../..)
-BOT_IMAGE ?= vexaai/vexa-bot:v012
+BOT_IMAGE ?= vexa/vexa-bot:dev
 
-.PHONY: stack-test stack-test-bot stack-test-mock stack-test-v010 dashboard-harness provision-token up down build ps logs bot _preflight _bot_check _creds_check _access
+.PHONY: stack-test stack-test-bot stack-test-mock stack-test-v010 dashboard-harness provision-token up dev digest-audit down build ps logs bot _preflight _bot_check _creds_check _access
 
 ## provision-token — mint (idempotently) the self-host dashboard's API token (compose bring-up step 2).
 ## Needs ADMIN_TOKEN (the stack admin secret). Prints ONLY the token, so it pipes into the deploy:
@@ -60,17 +62,49 @@ stack-test-mock:
 stack-test-v010:
 	V010_COMPAT=1 MOCK_BOT=1 BROWSER_IMAGE=$(BROWSER_IMAGE) ./bin/stack-test compat
 
-## up / down / build — hand-drive the stack (dev only; the proof manages its own lifecycle).
-## `up` is the zero-friction entrypoint: seeds .env from .env.example if absent, brings the stack up,
-## then mints + prints an API key (via the idempotent bin/provision-token) with the URLs.
+## up — the INSTALL entrypoint: PULLS the published, release-validated images (#569 — what users
+## run must be the bytes the release machinery proved; a local build must never shadow a published
+## :v012 pointer). Seeds .env from .env.example if absent, pulls everything (services + the
+## build-only agent-worker profile + the bot), brings the stack up WITHOUT building, then mints +
+## prints an API key. Building from source is `make dev` (images tagged :dev, never v012 names).
 up:
 	@$(MAKE) --no-print-directory _preflight
 	@[ -f .env ] || { echo "→ no .env found; seeding from .env.example"; cp .env.example .env; }
-	$(COMPOSE) up -d --build
-	$(COMPOSE) build agent-worker  # profiles:[build-only] keeps it out of `up` — build it explicitly or first chat fails to spawn
+	$(COMPOSE) pull
+	@_tag=$$(grep -E '^IMAGE_TAG=' .env | cut -d= -f2- | tr -d '[:space:]'); _tag=$${_tag:-v012}; \
+	 echo "→ pulling spawn-time images (agent-worker is a build-only compose profile pull skips)"; \
+	 docker pull "vexaai/v012-agent-worker:$$_tag"; \
+	 _bi=$$(grep -E '^BROWSER_IMAGE=' .env | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$$//; s/[[:space:]]+$$//'); \
+	 case "$$_bi" in vexaai/*) docker pull "$$_bi";; esac
+	$(COMPOSE) up -d --no-build
 	@$(MAKE) --no-print-directory _bot_check
 	@$(MAKE) --no-print-directory _creds_check
 	@$(MAKE) --no-print-directory _access
+
+## dev — build the whole stack FROM THIS CHECKOUT, tagged :dev (the repo-wide 'dev = locally-built'
+## convention) so a source build can never impersonate a published :v012 image. The running stack's
+## interpolated refs (AGENT_WORKER_IMAGE etc.) follow IMAGE_TAG=dev coherently.
+dev:
+	@$(MAKE) --no-print-directory _preflight
+	@[ -f .env ] || { echo "→ no .env found; seeding from .env.example"; cp .env.example .env; }
+	IMAGE_TAG=dev $(COMPOSE) up -d --build
+	IMAGE_TAG=dev $(COMPOSE) build agent-worker  # profiles:[build-only] keeps it out of `up`
+	@$(MAKE) --no-print-directory _bot_check
+	@$(MAKE) --no-print-directory _creds_check
+	@$(MAKE) --no-print-directory _access
+
+## digest-audit — the #569 negative control: every vexaai/*:$IMAGE_TAG image on this host must
+## carry a RepoDigest (= came from the registry). A locally-built image has NO RepoDigest, so a
+## shadowed pointer fails here loudly. Run after `make up` to prove the install is artifact-true.
+digest-audit:
+	@_tag=$$(grep -E '^IMAGE_TAG=' .env 2>/dev/null | cut -d= -f2- | tr -d '[:space:]'); _tag=$${_tag:-v012}; \
+	 fail=0; \
+	 for img in $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E "^vexaai/.*:$$_tag$$"); do \
+	   d=$$(docker image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' "$$img"); \
+	   if [ -z "$$d" ]; then echo "✗ $$img has NO registry digest — locally built, shadows the published pointer"; fail=1; \
+	   else echo "✓ $$img ⇐ $$d"; fi; \
+	 done; \
+	 [ "$$fail" = 0 ] && echo "✓ digest audit clean — every $$_tag image on this host is the published artifact" || exit 1
 
 ## _preflight — fail fast on a too-old Docker engine: agent workers mount workspaces via the Mounts
 ## API's named-volume Subpath, which needs engine ≥ v26 — an older engine fails every worker create
@@ -91,10 +125,11 @@ _preflight:
 	      fi;; \
 	 esac
 
-## bot — build the meeting bot FROM SOURCE (the v0.12 bot that matches this stack's lifecycle.v1).
-## The published vexaai/vexa-bot:dev on Docker Hub is the OLDER 0.10 line and is NOT compatible — the
-## bot is built here, never pulled. Builds the join-env base first, then the bot, tagged BOT_IMAGE.
-## Point BROWSER_IMAGE (.env) at BOT_IMAGE so the runtime spawns it.
+## bot — build the meeting bot FROM SOURCE for development, tagged into the LOCAL vexa/ namespace
+## (BOT_IMAGE, default vexa/vexa-bot:dev) so it can never shadow the published vexaai/vexa-bot:v012
+## the install pulls. (vexaai/vexa-bot:dev on Docker Hub is the OLDER 0.10 line — neither pulled nor
+## overwritten here.) Builds the join-env base first, then the bot. Point BROWSER_IMAGE (.env) at
+## BOT_IMAGE so the runtime spawns your build.
 bot:
 	@echo "→ [1/2] join-env base: vexa/meet-join-env:dev"
 	docker build -f $(REPO_ROOT)/core/meetings/modules/join/Dockerfile.env -t vexa/meet-join-env:dev $(REPO_ROOT)/core/meetings/modules/join
@@ -118,11 +153,13 @@ _bot_check:
 	 if [ -n "$$_bi" ] && ! docker image inspect "$$_bi" >/dev/null 2>&1; then \
 	   echo ""; \
 	   echo "═══════════════════════════════════════════════════════════"; \
-	   echo "  ⚠️  meeting bot image '$$_bi' is NOT built locally."; \
-	   echo "      The bot is built FROM SOURCE here, never pulled (the published"; \
-	   echo "      vexaai/vexa-bot:dev is the old 0.10 line, incompatible with this stack)."; \
-	   echo "      Bots will FAIL TO JOIN until you build it:"; \
-	   echo "          make -C deploy/compose bot"; \
+	   echo "  ⚠️  meeting bot image '$$_bi' is not present on this host."; \
+	   case "$$_bi" in \
+	     vexaai/*) echo "      It is PUBLISHED — pull it:  docker pull $$_bi";; \
+	     *)        echo "      It looks locally-built (dev path) — build it:"; \
+	               echo "          make -C deploy/compose bot   (tags $(BOT_IMAGE))";; \
+	   esac; \
+	   echo "      Bots will FAIL TO JOIN until the image exists."; \
 	   echo "═══════════════════════════════════════════════════════════"; \
 	   echo ""; \
 	 fi

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -15,7 +15,7 @@ evaluation — everything runs in containers either way. Published `vexaai/v012-
 `linux/arm64` variants alongside `linux/amd64`, so Docker on Apple Silicon pulls arm64 where
 available — but the arm64 images are published **best-effort**: release CI currently validates
 only the amd64 images (no arm64 execution leg yet), so treat Apple Silicon as experimental.
-`vexaai/vexa-bot` remains amd64-only (built locally via `make bot`). For GPU transcription on
+`vexaai/vexa-bot` remains amd64-only (the install pulls the published image; `make bot` builds a local `vexa/vexa-bot:dev` for development). For GPU transcription on
 Mac, point `TRANSCRIPTION_SERVICE_URL` at any OpenAI-compatible local endpoint
 (see [Configuration](/configuration)).
 

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -12,9 +12,9 @@ with one command.
 - A Linux host (Ubuntu 24.04 recommended for production), `git`, **`make`**, and **Docker engine ≥ v26**
   (`make all` checks and refuses older engines). A Mac with Docker Desktop works for a local
   evaluation — everything runs in containers either way.
-- **Build machine:** at least **8 vCPUs and 16 GB RAM**. `make all` builds the full Docker Compose
-  stack; `make lite` pulls the pre-built single-container all-in-one image and is much lighter —
-  prefer it on a resource-constrained host.
+- `make all` **pulls the published, release-validated images** — no build, any modest machine works;
+  `make lite` pulls the single-container all-in-one image and is lighter still. Building from
+  source (`make dev`) is for contributors and wants **8 vCPUs / 16 GB RAM**.
 - On Apple Silicon: arm64 images are published best-effort (not yet CI-validated) — see
   [Deployment](/deployment#quick-start-docker-compose) for details.
 - A **transcription (STT) token** — get one free at [`vexa.ai/account`](https://vexa.ai/account), or
@@ -26,8 +26,8 @@ with one command.
 ```bash
 curl -fsSL https://get.docker.com | sh
 git clone https://github.com/Vexa-ai/vexa.git && cd vexa
-make all          # full Docker Compose stack — seeds .env, builds, and prints your API key
-make bot          # build the meeting bot from source — needed before a bot can join (§2′)
+make all          # full Docker Compose stack — pulls the published images (bot included), prints your API key
+                  # contributors: `make dev` builds everything from this checkout instead (:dev tags)
 ```
 
 `make all` brings up the whole stack and **prints an API key + your URLs** when it finishes:


### PR DESCRIPTION
Closes #569 (owner-directed: 'workers, bots and agents must be pulled from Docker Hub' on install).

**make up (install):** `compose pull` + `up -d --no-build`, plus explicit pulls for the two images compose skips — the build-only agent-worker profile and the bot (`BROWSER_IMAGE` when it's a `vexaai/` ref). A fresh install now runs exactly the bytes release-validate proved, and stops paying the 30–60 min compile wall.

**make dev (new):** the contributor path — everything built from the checkout with `IMAGE_TAG=dev`, so a source build can never impersonate a published `:v012` image. `make bot` now tags `vexa/vexa-bot:dev` (the local namespace the join-env base already uses); the pre-v0.12.1 'bot is never pulled' rule is retired with its reason.

**make digest-audit (new):** the #569 negative control — every `vexaai/*:IMAGE_TAG` image on the host must carry a registry RepoDigest; a locally-built shadow has none and fails loudly. This becomes a release/validate row.

**Honest scope:** pr-value/stack-test are untouched (they build from tree — that's their job). The 0.10 constitutional guard is intact.

Machine proof: gates + pr-value on this PR; the full pull-path proof (clean-host digest audit green) rides the v0.12.2 fresh-VM leg.