### PR TITLE
lite: add jitsi-capture to the page-side brick filter (v0.12.2 build-lite failure)

### DIFF
--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -37,7 +37,7 @@ COPY scripts ./scripts
 RUN --mount=type=cache,id=pnpm-store-lite,target=/pnpm/store \
     pnpm install --frozen-lockfile=false
 # Build the page-side capture bricks first (browser bundles, not bot deps), then @vexa/bot + deps.
-RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" run build
+RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" run build
 RUN pnpm --filter "@vexa/bot..." run build
 RUN test -f /build/core/meetings/services/bot/dist/index.js \
  && test -s /build/core/meetings/services/bot/dist/browser-utils.global.js


### PR DESCRIPTION
The #543 Jitsi merge added `@vexa/jitsi-capture` to the bot's browser bundle and updated the bot Dockerfile's brick filter — but `Dockerfile.lite` carries its OWN copy of that filter list, which stayed stale. The v0.12.2 tag run failed at `build lite` exactly there (`pnpm --filter @vexa/bot... run build` → build-browser-utils.mjs can't resolve the unbuilt jitsi-capture dist).

Why no gate caught it: `pr-value` builds the compose stack (lite builds only at release) — a named gap. Follow-up worth considering: deduplicate the filter list (single source both Dockerfiles consume) so this class can't recur; noting rather than doing it here to keep the release moving.

After merge: re-tag v0.12.2 (never published/promoted — no pointer moved) and re-run the pipeline; all other images already built green on the first run and rebuild from warm cache.