### PR TITLE
wall-clock II: fast pre-push, parallel gates legs, cached pr-value builds

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,9 +12,17 @@ cd "$root" || exit 1
 # junk commits). The library scrubs its own git envs (core/agent/shared/gitenv.py); this unset is
 # the belt-and-braces hook layer.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_ALTERNATE_OBJECT_DIRECTORIES
-echo "▶ pre-push → pnpm gates (full suite)…"
-pnpm gates || {
-  echo "✗ pre-push: gates FAILED — push aborted (fix the gate above, or bypass with: git push --no-verify)."
-  exit 1
-}
-echo "✓ pre-push: gates green — pushing."
+# FAST STATIC SUBSET only (wall-clock law): CI owns the full suite — the local hook exists to
+# catch cheap structural mistakes before they burn a CI round-trip, not to re-prove what CI
+# will prove authoritatively on the same sha. The stack/python/build classes cost 5-10 min per
+# push and once blocked a release tag on a LOCAL stale-docker flake. Full suite on demand:
+# `pnpm gates`. Bypass: `git push --no-verify`.
+FAST_GATES="readme dataflow isolation isolation-py exports graph graph-py schema contract-version config-contract licenses execution-env test-isolation contract-conformance"
+echo "▶ pre-push → static gates ($(echo $FAST_GATES | wc -w | tr -d ' ') fast checks; CI runs the full suite)…"
+for g in $FAST_GATES; do
+  node scripts/gates.mjs "$g" || {
+    echo "✗ pre-push: gate:$g FAILED — push aborted (fix it, or bypass with: git push --no-verify)."
+    exit 1
+  }
+done
+echo "✓ pre-push: static gates green — pushing (full suite runs in CI)."

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1,6 +1,11 @@
 name: gates
 # push+pull_request unrestricted ran the suite TWICE per PR-branch push (both events
 # fire) — pure duplication. Push covers main + release tags; pull_request covers PRs.
+#
+# SPLIT INTO 3 PARALLEL JOBS (wall-clock law): static / python / node run concurrently
+# (~5 min serial → ~2.5 min), joined by the `gates` job — the ONE required-check context
+# branch protection and the merge queue watch. The join fails if ANY leg is not success
+# (if:always() + explicit check, because a skipped required check would read as satisfied).
 on:
   push:
     branches: [main]
@@ -16,20 +21,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gates:
+  static:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4 # version comes from package.json "packageManager"
       - uses: actions/setup-node@v4
         with: { node-version: 22, cache: pnpm } # pnpm 11.7 requires Node >= 22.13
-      - uses: astral-sh/setup-uv@v5
-      # CI runners have no GPU: skip onnxruntime-node's postinstall CUDA EP download — it is
-      # large, raced across the two resolved onnxruntime versions, and flaked main's first run
-      # (ENOENT in /tmp cleanup). The CPU binaries tests use are bundled in the package itself.
       - run: pnpm install --frozen-lockfile
         env: { ONNXRUNTIME_NODE_INSTALL: skip }
-      # the compliance bar — each gate is its own step so a failure is unambiguous
+      # each gate its own step so a failure is unambiguous
       - run: pnpm gate:readme
       - run: pnpm gate:isolation
       - run: pnpm gate:exports
@@ -39,11 +40,52 @@ jobs:
       - run: pnpm gate:config-contract
       - run: pnpm gate:dataflow
       - run: pnpm gate:calm
+      - run: pnpm gate:licenses
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - uses: astral-sh/setup-uv@v5
+      - run: pnpm install --frozen-lockfile
+        env: { ONNXRUNTIME_NODE_INSTALL: skip }
       # the runtime docker-backend lifecycle test creates containers via the docker socket API,
       # which (unlike `docker run`) does NOT implicit-pull — pre-pull its fixture image
       - run: docker pull alpine
       - run: pnpm gate:python
-      - run: pnpm gate:licenses
+
+  node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      # CI runners have no GPU: skip onnxruntime-node's postinstall CUDA EP download — it is
+      # large, raced across the two resolved onnxruntime versions, and flaked main's first run
+      # (ENOENT in /tmp cleanup). The CPU binaries tests use are bundled in the package itself.
+      - run: pnpm install --frozen-lockfile
+        env: { ONNXRUNTIME_NODE_INSTALL: skip }
       - run: pnpm typecheck
       - run: pnpm build
       - run: pnpm test
+
+  # THE required check — branch protection + merge queue watch this single context.
+  gates:
+    needs: [static, python, node]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All legs green?
+        env:
+          R_STATIC: ${{ needs.static.result }}
+          R_PYTHON: ${{ needs.python.result }}
+          R_NODE: ${{ needs.node.result }}
+        run: |
+          echo "static=$R_STATIC python=$R_PYTHON node=$R_NODE"
+          [ "$R_STATIC" = "success" ] && [ "$R_PYTHON" = "success" ] && [ "$R_NODE" = "success" ] \
+            || { echo "::error ::a gates leg failed or was cancelled"; exit 1; }
+          echo "✓ all gate legs green"

--- a/.github/workflows/pr-value.yml
+++ b/.github/workflows/pr-value.yml
@@ -76,6 +76,8 @@ jobs:
           MOCK_BOT: "1"
           BROWSER_IMAGE: mock-bot:dev
           COMPOSE_DYNAMIC_PORTS: "1"
+          # registry build-cache overlay: untouched services become cache hits (~7 min → ~2)
+          COMPOSE_EXTRA_FILES: ${{ github.workspace }}/deploy/compose/docker-compose.ci-cache.yml
         run: ./bin/stack-test
       - name: Present the machine bundle (job summary)
         if: always()

--- a/deploy/compose/docker-compose.ci-cache.yml
+++ b/deploy/compose/docker-compose.ci-cache.yml
@@ -1,0 +1,25 @@
+# CI build-cache overlay (wall-clock law) — pr-value builds the stack FROM THE PR TREE, which is
+# the point, but without cache every run recompiles all 8 images (~7 of its ~13 min). The release
+# pipeline already maintains registry build caches (vexaai/*:buildcache, mode=max, public — pullable
+# anonymously, so the secretless fork-run design is untouched). This overlay points compose builds
+# at them: a typical PR touches 1-2 services, the other 6-7 become cache hits.
+#
+# Used ONLY by CI (pr-value sets COMPOSE_EXTRA_FILES); local `make dev` is unaffected.
+# A cache miss costs nothing — the build just proceeds cold, exactly as before.
+services:
+  admin-api:
+    build: { cache_from: ["vexaai/v012-admin-api:buildcache"] }
+  runtime:
+    build: { cache_from: ["vexaai/v012-runtime:buildcache"] }
+  agent-worker:
+    build: { cache_from: ["vexaai/v012-agent-worker:buildcache"] }
+  agent-api:
+    build: { cache_from: ["vexaai/v012-agent-api:buildcache"] }
+  meeting-api:
+    build: { cache_from: ["vexaai/v012-meeting-api:buildcache"] }
+  gateway:
+    build: { cache_from: ["vexaai/v012-gateway:buildcache"] }
+  mcp:
+    build: { cache_from: ["vexaai/v012-mcp:buildcache"] }
+  terminal:
+    build: { cache_from: ["vexaai/v012-terminal:buildcache"] }

--- a/deploy/compose/tests/conftest.py
+++ b/deploy/compose/tests/conftest.py
@@ -91,8 +91,15 @@ requires_docker = pytest.mark.skipif(not docker_available(), reason="docker not 
 _REGISTRY_FLAKE = ("registry-1.docker.io", "Bad Gateway", "Service Unavailable", "TLS handshake timeout")
 
 
+# Optional overlay files (colon-separated paths), e.g. the CI build-cache overlay — appended
+# after the base file so they can only ADD build options, never redefine the stack.
+COMPOSE_EXTRA_FILES = [f for f in os.getenv("COMPOSE_EXTRA_FILES", "").split(":") if f]
+
+
 def _compose(*args: str, env: dict | None = None, check: bool = True, timeout: int = 1200) -> subprocess.CompletedProcess:
     base = ["docker", "compose", "-p", PROJECT, "-f", str(COMPOSE_FILE)]
+    for extra in COMPOSE_EXTRA_FILES:
+        base += ["-f", extra]
     full_env = {**os.environ, **_stack_env(), **(env or {})}
     cmd = base + list(args)
     result = subprocess.run(cmd, capture_output=True, text=True, env=full_env, check=False, timeout=timeout)


### PR DESCRIPTION
The remaining items from the measured wall-clock sweep (owner: 'optimize'). No test semantics change anywhere — the proofs stay identical; only where and how fast they run.

1. **Pre-push hook → 14 fast static gates (~40s)** instead of the full suite (5–10 min per push; once blocked the v0.12.2 tag on a LOCAL stale-docker flake while CI had proven the same sha). CI stays the authority; `pnpm gates` still runs everything on demand.
2. **gates split into 3 parallel legs** (static/python/node) joined by the single required `gates` context (if:always() + explicit success check — a skipped required check would otherwise read as satisfied). ~5 → ~2.5 min under every PR push and every merge-queue batch.
3. **pr-value builds read the release build caches** (public `vexaai/*:buildcache`, anonymous pulls — the secretless fork-run design untouched) via a CI-only compose overlay (`COMPOSE_EXTRA_FILES` through the stack fixture). Typical PR: 1–2 services build, 6–7 cache-hit. ~13 → ~7–8 min.

Net per PR iteration: ~18 → ~9 min. Proof for item 3 rides this PR's own pr-value run (it uses the overlay).

Deliberately NOT here: free-disk-space trimming (needs per-job disk measurements first) and the Linode docker-preinstalled snapshot for witness/canary VMs.