### PR TITLE
lite: fix `make up` — bare # comment orphaned $IMG (v0.12.2 validate-lite blocker)

### DIFF
--- a/deploy/lite/Makefile
+++ b/deploy/lite/Makefile
@@ -76,6 +76,16 @@ preflight:
 
 ## up — a bridge network, postgres + minio sidecars (by name), then the all-in-one container with
 ## only the front doors published. Internal services live on the container's own loopback.
+##
+## The recipe is ONE `\`-continued shell command: a bare `#` line inside it (no trailing `\`) ends
+## the continuation, so make runs the rest in a SEPARATE shell where IMG/ADMIN_TK/… are already
+## lost — which once shipped `docker run … $IMG` with an EMPTY image (vexa-lite never created,
+## every front door down). Keep all commentary OUT of the recipe body; annotate here instead.
+##
+## Claude-credential automount (C2/#502): if the host has ~/.claude/.credentials.json, mount it and
+## point HOST_CLAUDE_CREDENTIALS at the IN-CONTAINER path — in LITE the process backend reads the
+## file directly. (Compose is the opposite: there the var is a docker-HOST path the compose file
+## mounts. Don't copy the semantics across.)
 up: preflight
 	@set -e; \
 	docker network inspect $(NETWORK) >/dev/null 2>&1 || docker network create $(NETWORK) >/dev/null; \
@@ -84,10 +94,6 @@ up: preflight
 	TX_TOKEN=$$(grep -E '^TRANSCRIPTION_SERVICE_TOKEN=' $(ENV_FILE) 2>/dev/null | cut -d= -f2-); \
 	IMAGE_TAG=$$(grep -E '^IMAGE_TAG=' $(ENV_FILE) 2>/dev/null | cut -d= -f2-); IMAGE_TAG=$${IMAGE_TAG:-latest}; \
 	IMG=$$(docker image inspect $(LOCAL_TAG) >/dev/null 2>&1 && echo $(LOCAL_TAG) || echo $(DOCKERHUB_USER)/$(IMAGE_NAME):$$IMAGE_TAG); \
-	# Autodetect host Claude credentials and wire the mount automatically (C2/#502).
-	# NOTE: in LITE, HOST_CLAUDE_CREDENTIALS must be the IN-CONTAINER path — the process backend
-	# reads the file directly (see deploy/lite/entrypoint.sh). Compose is the opposite: there the
-	# var is a docker-HOST path (deploy/compose/docker-compose.yml mounts it). Don't copy across.
 	CLAUDE_CREDS="$$HOME/.claude/.credentials.json"; \
 	if [ -f "$$CLAUDE_CREDS" ]; then \
 		echo "  Detected Claude subscription credentials — mounting into container"; \


### PR DESCRIPTION
**v0.12.2's `validate-lite` failed** with the lite container never created (all front doors down, `No such container: vexa-lite`). Root cause: #504 inserted four tab-indented `#` comment lines between `IMG=…` and the `docker run`s inside the `up` recipe. A make recipe line without a trailing `\` **ends the shell command**, so make ran the remainder in a fresh shell where `IMG` (and `ADMIN_TK`/`TX_*`) were empty → `docker run --name vexa-lite … $IMG` had no image argument → `See 'docker run --help'` → container never created. Postgres/minio survived only because their image names are hardcoded.

**Fix:** all commentary moved above the target; the recipe body is one unbroken `\`-continued command again.

**Proven** (verify-before-ship): locally booted `vexaai/vexa-lite:v0.12.2` (the already-published image from the failed run's build half) with this fix → `vexa-lite Up (healthy)`, all three front doors green. Red→green: pre-fix `docker run` with empty image; post-fix container healthy.

**Coverage gap this exposes:** the third lite-only bug the release caught that `pr-value` structurally can't (lite builds/boots only at release). Follow-up issue for a lite-boot smoke on `deploy/lite/**` PRs: filed.

After merge: re-tag v0.12.2, pipeline re-runs (warm image cache), validate-lite now passes.