### PR TITLE
meeting-api: fix REST transcript absolute_start_time corrupted to year 2083 (double-counted epoch base)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -151,6 +151,38 @@ def _upsert_processed_view(
     return out
 
 
+# A relative in-meeting offset never approaches this; anything at/above is an absolute epoch.
+_EPOCH_THRESHOLD_S = 1_000_000_000  # ~2001-09-09
+
+
+def _fill_absolute_times(segments: list, base) -> None:
+    """Fill each segment's ``absolute_start_time``/``absolute_end_time`` (in place) when a producer
+    didn't supply them, so a renderer that keys on absolute time shows the segment.
+
+    ``start``/``end`` carry TWO semantics by producer: a RELATIVE offset into the meeting (the carve —
+    small seconds-since-start, bounded by the 4h ceiling) OR an ABSOLUTE epoch-seconds wall-clock (the
+    live pipeline — ~1.78e9). Doing ``base + start`` unconditionally treated an absolute epoch as a
+    relative offset and added it to ``base`` → year ~2083 (2026 + 56.5 years). Discriminate by
+    magnitude: at/above ``_EPOCH_THRESHOLD_S`` the value is already absolute — use it directly; below,
+    anchor the relative offset to ``base`` (the meeting start)."""
+    from datetime import timedelta
+
+    for s in segments:
+        if s.get("absolute_start_time") or s.get("start") is None:
+            continue
+        try:
+            st = float(s["start"])
+            en = float(s["end"]) if s.get("end") is not None else st
+        except (TypeError, ValueError):
+            continue
+        if st >= _EPOCH_THRESHOLD_S:
+            s["absolute_start_time"] = datetime.fromtimestamp(st, timezone.utc).isoformat()
+            s["absolute_end_time"] = datetime.fromtimestamp(en, timezone.utc).isoformat()
+        elif base is not None:
+            s["absolute_start_time"] = (base + timedelta(seconds=st)).isoformat()
+            s["absolute_end_time"] = (base + timedelta(seconds=en)).isoformat()
+
+
 def _segment_to_api(seg: dict) -> dict:
     """Map a stored/Redis segment to an api.v1 ``TranscriptionSegment`` (start/end/text/language
     required; the optional fields ride along)."""
@@ -254,19 +286,9 @@ class SqlAlchemyTranscriptStore:
                 pass
         segments = sorted((seg_by_id[k] for k in order), key=lambda s: (s.get("start") or 0.0))
         # The dashboard's renderer SKIPS any segment without absolute_start_time
-        # (use-vexa-websocket.ts: `if (!seg.absolute_start_time) continue`). Derive it from the
-        # meeting start + the relative offset when a producer didn't supply it, so the historical
-        # transcript renders (the carve served only relative start/end → the UI dropped every segment).
-        from datetime import timedelta
-        base = meeting.start_time or meeting.created_at
-        if base is not None:
-            for s in segments:
-                if not s.get("absolute_start_time") and s.get("start") is not None:
-                    try:
-                        s["absolute_start_time"] = (base + timedelta(seconds=float(s["start"]))).isoformat()
-                        s["absolute_end_time"] = (base + timedelta(seconds=float(s.get("end") or s["start"]))).isoformat()
-                    except Exception:
-                        pass
+        # (use-vexa-websocket.ts: `if (!seg.absolute_start_time) continue`). Derive it when a producer
+        # didn't supply it, so the historical transcript renders. See `_fill_absolute_times`.
+        _fill_absolute_times(segments, meeting.start_time or meeting.created_at)
         return {
             "id": meeting.id,
             "platform": meeting.platform,

--- a/core/meetings/services/meeting-api/tests/test_absolute_times.py
+++ b/core/meetings/services/meeting-api/tests/test_absolute_times.py
@@ -1,0 +1,42 @@
+"""Golden for `_fill_absolute_times` — the REST transcript absolute-time derivation.
+
+Regression: a live-pipeline segment carries `start` as ABSOLUTE epoch-seconds (~1.78e9). The old
+derivation did `base + timedelta(seconds=start)` unconditionally, adding an absolute epoch to the
+meeting-start datetime → year 2083 (witnessed on v0.12.2: `2083-01-23T...` served over REST while
+redis held the correct 2026 time). The fix discriminates absolute vs relative by magnitude.
+"""
+from datetime import datetime, timezone
+
+from meeting_api.collector.adapters import _fill_absolute_times
+
+
+def test_absolute_epoch_start_is_used_directly_not_added_to_base():
+    # The witnessed segment: start = absolute epoch-seconds for 2026-07-13T20:46:21Z.
+    base = datetime(2026, 7, 13, 20, 46, 15, tzinfo=timezone.utc)  # meeting start
+    segs = [{"start": 1783975581.012, "end": 1783975592.788, "text": "1, 2, 3, 4, 5"}]
+
+    _fill_absolute_times(segs, base)
+
+    # Must be the SAME instant as `start` (2026), NOT base+start (2083).
+    got = datetime.fromisoformat(segs[0]["absolute_start_time"])
+    assert got.year == 2026, f"regressed to {got.isoformat()} (the 2083 double-count)"
+    assert abs(got.timestamp() - 1783975581.012) < 1.0
+    assert datetime.fromisoformat(segs[0]["absolute_end_time"]).year == 2026
+
+
+def test_negative_control_relative_offset_still_anchors_to_base():
+    # A genuine relative offset (the carve): small seconds-since-start → base + offset.
+    base = datetime(2026, 7, 13, 20, 46, 15, tzinfo=timezone.utc)
+    segs = [{"start": 12.0, "end": 18.5, "text": "hi"}]
+
+    _fill_absolute_times(segs, base)
+
+    got = datetime.fromisoformat(segs[0]["absolute_start_time"])
+    assert got.year == 2026
+    assert abs((got - base).total_seconds() - 12.0) < 0.001  # anchored, not treated as epoch
+
+
+def test_producer_supplied_absolute_time_is_left_untouched():
+    segs = [{"start": 1783975581.0, "absolute_start_time": "2026-07-13T20:46:21+00:00"}]
+    _fill_absolute_times(segs, datetime(2026, 7, 13, tzinfo=timezone.utc))
+    assert segs[0]["absolute_start_time"] == "2026-07-13T20:46:21+00:00"


### PR DESCRIPTION
Witness-found on v0.12.2 (2083 finding from #585's witness). `GET /transcripts/{platform}/{id}` returned every segment's `absolute_start_time` as **year 2083** (`2083-01-23T...`) while redis held the correct 2026 time.

**Root cause** (`collector/adapters.py`, `_transcript_doc`): the derivation did `base + timedelta(seconds=float(start))` unconditionally. But `start` carries two semantics by producer — a *relative* in-meeting offset (the carve) OR an *absolute* epoch-seconds wall-clock (the live pipeline, ~1.78e9). Adding an absolute epoch to the meeting-start datetime = 2026 + 56.5 years → **2083**. The live SSE path was already correct (it emits `tsMs`), so only the REST read corrupted — which is why the live panel (once #585 unblocks it) renders fine but any REST/time-anchored consumer breaks.

**Fix:** extracted `_fill_absolute_times` (pure, testable seam) that discriminates by magnitude — `>= 1e9` is already absolute (use directly), below is a relative offset (anchor to base).

**Golden test** (`test_absolute_times.py`): the witnessed absolute-epoch segment → 2026 not 2083; negative control (a relative offset still anchors to base, proving the discriminator); producer-supplied time left untouched. meeting-api collector suite green (10 passed).

Part of the v0.12.2 witness-fix batch with #586 (live-stream) — not a live-render blocker on its own (live uses tsMs) but a real correctness bug for REST/dashboard consumers.