### PR TITLE
validate-lite: guard the live-transcript stream authorization (#585 class-killer, release-time)

### DIFF
--- a/deploy/lite/tests/concurrent-bots.sh
+++ b/deploy/lite/tests/concurrent-bots.sh
@@ -114,6 +114,29 @@ dirs=$(X bash -c 'ls -d /tmp/browser-data-* 2>/dev/null | wc -l')
 [ "$dirs" -ge "$N_BOTS" ] || die "expected ≥$N_BOTS per-bot profile dirs, found $dirs"
 echo "per-bot profile dirs: $dirs ✓"
 
+# 4) the live-transcript SSE stream AUTHORIZES for the meeting's OWNER (#585 regression).
+#    agent-api owner-scopes /agent/meeting/stream by calling meeting-api GET /meetings/{id}; on lite
+#    a MISSING VEXA_MEETING_API_URL left agent-api pointing at the compose hostname http://meeting-api
+#    :8080 (no DNS in the single container) → the lookup threw → fail-closed → EVERY live stream 403'd
+#    → the terminal panel stayed blank though transcription worked. Pure authorization, no audio
+#    needed: this leg goes RED on that misconfig (the class no compose leg can see — meeting-api:8080
+#    resolves there) and GREEN once the URL is reachable. Witness-found on v0.12.2, guarded here.
+read -r ROW _NAT <<EOF
+$(printf '%s' "$statuses" | python3 -c "
+import json,sys
+d=json.load(sys.stdin); ms=d.get('meetings',d if isinstance(d,list) else [])
+m=ms[0] if ms else {}
+print(m.get('id',''), m.get('native_meeting_id',''))" 2>/dev/null)
+EOF
+[ -n "$ROW" ] || die "no meeting row available to test the live-transcript stream (#585 guard)"
+stream_out=$(curl -s -N -m 8 "$GATEWAY/agent/meeting/stream?meeting_id=$ROW&session_uid=$ROW" \
+  -H "X-API-Key: $TOKEN" 2>/dev/null | head -c 400)
+case "$stream_out" in
+  *"not authorized"*)
+    die "live-transcript stream DENIED the owner (#585) — agent-api cannot owner-scope the SSE feed; is VEXA_MEETING_API_URL reachable on this deploy? (blank terminal panel class)";;
+esac
+echo "live-transcript stream authorizes for owner ✓ (#585)"
+
 # ── cleanup (best-effort) ──
 for mid in "${ids[@]}"; do
   curl -s -X DELETE "$GATEWAY/bots/google_meet/$mid" -H "X-API-Key: $TOKEN" >/dev/null || true


### PR DESCRIPTION
Makes the RELEASE catch the exact class the v0.12.2 witness caught by eye: a blank terminal transcript panel because the live SSE feed 403'd on lite (agent-api couldn't reach meeting-api to owner-scope it — #585, fixed in #586).

**What it does:** `concurrent-bots.sh` (the validate-lite smoke) already mints a user + spawns meetings; after that it now subscribes to the owner's `/agent/meeting/stream` and **dies on 'not authorized'**. Pure authorization — no audio, no admission.

**Proven discriminator (both states, live on the witness box):** RED on the pre-#586 misconfig (`{"detail":"not authorized for this meeting"}`), GREEN once `VEXA_MEETING_API_URL` is reachable (SSE segments stream). So it would have gone red on v0.12.2 and green on v0.12.3.

**Why release-time, not PR-time (yet):** this is the class NO compose leg can see — `meeting-api:8080` resolves in compose, so the bug only reproduces on a lite boot. validate-lite is the earliest autonomous place it reproduces. The per-PR lite-boot leg (#581) that runs this on every PR is the tracked follow-up; this closes the release-gate half now, into v0.12.3.

Part of the v0.12.3 witness-fix batch (with #586, #587).