### PR TITLE
release: v0.12.3 version bump (first witnessed release)

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.2"
+appVersion: "0.12.3"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
Bumps to 0.12.3 — first release to pass the human witness. Carries #586 (live-transcript blocker), #587 (2083 timestamp), #588 (validate-lite guards the #585 class autonomously), CPU STT default small. v0.12.2 abandoned (machine-green, promoted, witness-failed). OSS-only per owner ruling; #578/#579 deferred. After merge: tag v0.12.3 → pipeline → guarantee table → redeploy witness box → clean witness → publish.