### PR TITLE
bot build: warm-hf-cache retries then degrades gracefully (HF rate-limit must not fail a release)

### DIFF
--- a/core/meetings/services/bot/warm-hf-cache.mjs
+++ b/core/meetings/services/bot/warm-hf-cache.mjs
@@ -12,12 +12,16 @@
  * Two modes, both driven by env:
  *   - WARM  (default, builder stage, network available):
  *       env.allowRemoteModels = true → downloads + caches into $VEXA_HF_CACHE.
+ *       Retries with backoff, then DEGRADES GRACEFULLY (loud warn + exit 0) if
+ *       HuggingFace is unreachable/rate-limiting — pre-baking is a first-meeting
+ *       LATENCY optimization for a PUBLIC model the bot can fetch at runtime, so
+ *       an external CDN blip must NOT hard-fail the release build.
  *   - VERIFY (VEXA_HF_OFFLINE=1, runtime, `docker run --network none`):
  *       env.allowRemoteModels = false → MUST load from $VEXA_HF_CACHE only.
- *       Any network fetch attempt fails → non-zero exit → bake is broken.
+ *       Any failure → non-zero exit → the bake we claimed is broken (STAYS FATAL).
  *
- * Exit 0 = model loaded; non-zero = failure (so it gates the docker build and
- * doubles as the offline proof).
+ * Exit 0 = model loaded OR (WARM only) warm-skip after retries; non-zero = a
+ * VERIFY failure or a config error. VERIFY doubles as the offline proof.
  *
  * NB on module resolution: `@huggingface/transformers` is NOT a direct dep of
  * @vexa/bot — it's transitive through @vexa/mixed-pipeline, and only that
@@ -58,14 +62,52 @@ env.allowRemoteModels = !OFFLINE; // VERIFY mode forbids any remote fetch
 console.log(`[warm-hf-cache] mode=${OFFLINE ? 'VERIFY(offline)' : 'WARM(download)'} cacheDir=${CACHE_DIR} model=${MODEL_ID}`);
 
 const t0 = Date.now();
-try {
-  const model = await AutoModel.from_pretrained(MODEL_ID, { device: 'cpu' });
-  const processor = await AutoProcessor.from_pretrained(MODEL_ID);
-  if (!model || !processor) throw new Error('from_pretrained returned empty');
-  console.log(`[warm-hf-cache] OK: model + processor loaded in ${Date.now() - t0}ms`);
-} catch (err) {
-  console.error(`[warm-hf-cache] FAILED to load ${MODEL_ID}: ${err?.message ?? err}`);
-  process.exit(1);
+// WARM (build-time download) RETRIES then DEGRADES GRACEFULLY: HuggingFace rate-limits shared CI
+// egress IPs with a 403, which would hard-fail the release for a PUBLIC model the bot can fetch at
+// runtime anyway. Pre-baking is a first-meeting LATENCY optimization, not a correctness gate — so an
+// external CDN blip must not block a build. We retry with exponential backoff, and only if every
+// attempt fails do we WARN LOUDLY and continue (exit 0): the image ships without the warm cache and
+// the bot cold-fetches the model on its first Zoom/Teams meeting (Google Meet is unaffected).
+//
+// VERIFY (OFFLINE, `--network none`) STAYS FATAL: no network, no retry — a failure there means a
+// bake we CLAIMED to have made can't load, i.e. a genuinely broken image. That must fail loudly.
+const WARM_ATTEMPTS = OFFLINE ? 1 : 4;
+let lastErr;
+for (let attempt = 1; attempt <= WARM_ATTEMPTS; attempt++) {
+  try {
+    const model = await AutoModel.from_pretrained(MODEL_ID, { device: 'cpu' });
+    const processor = await AutoProcessor.from_pretrained(MODEL_ID);
+    if (!model || !processor) throw new Error('from_pretrained returned empty');
+    console.log(`[warm-hf-cache] OK: model + processor loaded in ${Date.now() - t0}ms (attempt ${attempt})`);
+    lastErr = undefined;
+    break;
+  } catch (err) {
+    lastErr = err;
+    console.error(`[warm-hf-cache] load attempt ${attempt}/${WARM_ATTEMPTS} failed: ${err?.message ?? err}`);
+    if (attempt < WARM_ATTEMPTS) {
+      const backoffMs = 1000 * 2 ** (attempt - 1); // 1s, 2s, 4s
+      console.error(`[warm-hf-cache] retrying in ${backoffMs}ms…`);
+      await new Promise((r) => setTimeout(r, backoffMs));
+    }
+  }
+}
+if (lastErr) {
+  if (OFFLINE) {
+    // The offline proof: a baked cache we can't load is a broken image — fail loudly.
+    console.error(`[warm-hf-cache] FATAL (VERIFY): baked cache missing/unloadable for ${MODEL_ID}: ${lastErr?.message ?? lastErr}`);
+    process.exit(1);
+  }
+  console.error(
+    `\n============================================================\n` +
+    `[warm-hf-cache] ⚠️  WARN: could not pre-bake ${MODEL_ID} after ${WARM_ATTEMPTS} attempts\n` +
+    `    (last error: ${lastErr?.message ?? lastErr}).\n` +
+    `    This is almost always HuggingFace rate-limiting the CI egress IP (403), NOT a code fault.\n` +
+    `    The image ships WITHOUT the warm cache; the bot will download the model on its FIRST\n` +
+    `    Zoom/Teams meeting (a one-time few-second stall). Google Meet is unaffected.\n` +
+    `    Not failing the build — pre-baking is an optimization, not a correctness gate.\n` +
+    `============================================================\n`,
+  );
+  process.exit(0);
 }
 
 // Report cache contents + size so the build log shows the bake landed.


### PR DESCRIPTION
v0.12.3's build-bot failed **twice** on HuggingFace 403 for `onnx-community/pyannote-segmentation-3.0` — a **public, non-gated** model (verified 302/accessible outside CI). HF rate-limits shared CI egress IPs. `warm-hf-cache` was fatal on any download failure, so an external CDN blip blocked the whole release for a first-meeting *latency* optimization.

**WARM (build-time download):** now retries 4× with 1s/2s/4s backoff, then **warns loudly and exits 0**. The image ships without the warm cache; the bot cold-fetches the model on its first Zoom/Teams meeting (Google Meet unaffected — per-speaker channels, not this model).

**VERIFY (offline, `--network none`):** UNCHANGED — stays fatal. A baked cache we claimed and can't load offline is a genuinely broken image and must fail.

Third external-infra flake this cycle (fork-approval queue, Docker Hub 502, now HF 403); same principle as the compose registry-5xx retry — external infra must not fail the build (#583). node --check clean.