### PR TITLE
fix(jitsi): recognize members-only lobby authoritatively + typed admission timeout (#592)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/googlemeet/admission.ts
+++ b/core/meetings/modules/join/src/googlemeet/admission.ts
@@ -9,22 +9,9 @@ import {
   googleConsentPromptIndicators
 } from "./selectors";
 
-/**
- * Distinct admission outcomes emitted by the detector.
- * denial        — host explicitly rejected the bot from the waiting room.
- * lobby_timeout — bot stayed in the waiting room past the admission timeout.
- * join_failure  — bot never reached the lobby / no admission indicators appeared.
- */
-export type AdmissionOutcome = "denial" | "lobby_timeout" | "join_failure";
-
-export class AdmissionError extends Error {
-  readonly outcome: AdmissionOutcome;
-  constructor(outcome: AdmissionOutcome, message: string) {
-    super(message);
-    this.name = "AdmissionError";
-    this.outcome = outcome;
-  }
-}
+// AdmissionError + AdmissionOutcome moved to ../shared/admission so every platform (jitsi/zoom/
+// teams) throws the SAME typed error the JoinDriver maps, without one platform depending on another.
+import { AdmissionError } from "../shared/admission";
 
 // Detect an active reCAPTCHA (enterprise) challenge. Google renders it in iframes whose
 // URL contains "/recaptcha/"; it can sit on the same screen as error affordances

--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -128,8 +128,8 @@ export { joinGoogleMeeting, waitForGoogleMeetingAdmission, checkForGoogleAdmissi
 // AdmissionError carries a TYPED `outcome` (denial / lobby_timeout / join_failure). It is THROWN by the
 // admission wait; the JoinDriver adapter catches it and maps the outcome → a JoinOutcome so a host DENIAL
 // is recorded as a permanent `rejected`, not collapsed into a transient (retried) `join_failure` (G1).
-export { AdmissionError } from "./googlemeet/admission";
-export type { AdmissionOutcome } from "./googlemeet/admission";
+export { AdmissionError } from "./shared/admission";
+export type { AdmissionOutcome } from "./shared/admission";
 export { joinMicrosoftTeams, waitForTeamsMeetingAdmission, checkForTeamsAdmissionSilent, prepareForTeamsRecording, leaveMicrosoftTeams, startTeamsRemovalMonitor };
 export { joinZoomMeeting, buildZoomWebClientUrl, waitForZoomMeetingAdmission, checkForZoomAdmissionSilent, leaveZoomMeeting, dismissZoomPopups, startZoomRemovalMonitor };
 export { joinJitsiMeeting, buildJitsiMeetingUrl, waitForJitsiMeetingAdmission, checkForJitsiAdmissionSilent, leaveJitsiMeeting, startJitsiRemovalMonitor };

--- a/core/meetings/modules/join/src/jitsi/admission.test.ts
+++ b/core/meetings/modules/join/src/jitsi/admission.test.ts
@@ -1,0 +1,78 @@
+/**
+ * #592 — authoritative members-only/lobby detection + typed timeout attribution.
+ *
+ * A fresh meet.jit.si room is members-only until a moderator arrives; the conference fails with
+ * MEMBERS_ONLY and redux records the lobby room JID in features/base/conference.membersOnly. The
+ * witnessed silent loop happened when DOM/text scraping missed that state (blank/error render) —
+ * so the bot mislabelled a real lobby as "unknown" and escalated down the illegal joining→needs_help
+ * path. getLobbyState reads the app's own verdict instead. And a give-up must throw a TYPED
+ * AdmissionError('lobby_timeout') so the driver reports awaiting_admission_timeout, not a generic
+ * silently-retried join_failure.
+ *
+ * Drives the SHIPPED getLobbyState + waitForJitsiMeetingAdmission over a fabricated Page/APP stub
+ * (same no-browser pattern as the other jitsi tests).
+ *
+ * Run: npx tsx src/jitsi/admission.test.ts
+ */
+
+import { getLobbyState, waitForJitsiMeetingAdmission } from "./admission";
+import { AdmissionError } from "../shared/admission";
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail?: string) {
+  if (ok) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ""}`); failed++; }
+}
+
+// evaluate runs the probe fn in-node; getLobbyState/getAppJoinedState read globalThis.APP.
+const page: any = {
+  async evaluate(fn: any, arg?: any) { return fn(arg); },
+  async waitForTimeout(_ms: number) {},
+};
+
+function setApp(opts: { joined?: boolean; membersOnly?: string | null; knocking?: boolean }) {
+  (globalThis as any).APP = {
+    conference: { isJoined: () => !!opts.joined },
+    store: { getState: () => ({
+      "features/base/conference": { membersOnly: opts.membersOnly ?? undefined },
+      "features/lobby": { knocking: !!opts.knocking },
+    }) },
+  };
+}
+
+async function main() {
+  console.log("\n=== getLobbyState — the app's own members-only verdict ===");
+
+  setApp({ membersOnly: "room@lobby.meet.jit.si" });
+  check("members-only room JID in redux → 'lobby'", (await getLobbyState(page)) === "lobby");
+
+  setApp({ knocking: true });
+  check("explicit Lobby knocking → 'lobby'", (await getLobbyState(page)) === "lobby");
+
+  setApp({ membersOnly: null, knocking: false });
+  check("open conference → 'not-lobby'", (await getLobbyState(page)) === "not-lobby");
+
+  delete (globalThis as any).APP;
+  check("APP/redux absent → 'no-api'", (await getLobbyState(page)) === "no-api");
+
+  console.log("\n=== waitForJitsiMeetingAdmission — timeout is typed (lobby_timeout) ===");
+
+  // Not joined + members-only lobby + zero timeout → the wait gives up immediately and must throw
+  // a TYPED AdmissionError('lobby_timeout'), not a bare Error (which the driver would collapse to a
+  // silently-retried join_failure). timeoutMs=0 exits before any escalation fires.
+  setApp({ joined: false, membersOnly: "room@lobby.meet.jit.si" });
+  let caught: any = null;
+  try { await waitForJitsiMeetingAdmission(page, 0, {} as any); }
+  catch (e) { caught = e; }
+  check("timeout throws AdmissionError", caught instanceof AdmissionError, `got ${caught && caught.name}`);
+  check("outcome = 'lobby_timeout'",
+    caught instanceof AdmissionError && caught.outcome === "lobby_timeout",
+    caught instanceof AdmissionError ? caught.outcome : "n/a");
+
+  delete (globalThis as any).APP;
+  console.log(`\n=== summary: ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/core/meetings/modules/join/src/jitsi/admission.ts
+++ b/core/meetings/modules/join/src/jitsi/admission.ts
@@ -3,6 +3,7 @@ import { log, callAwaitingAdmissionCallback } from "../_host";
 import { BotConfig } from "../_host";
 import { checkEscalation, triggerEscalation, getEscalationExtensionMs } from "../shared/escalation";
 import { fillPasswordPromptIfPresent } from "./password";
+import { AdmissionError } from "../shared/admission";
 import {
   jitsiHangupButtonSelectors,
   jitsiConferenceIndicators,
@@ -24,6 +25,46 @@ export async function getAppJoinedState(page: Page): Promise<"joined" | "not-joi
       return "no-api";
     } catch { return "no-api"; }
   }).catch(() => "no-api") as "joined" | "not-joined" | "no-api";
+}
+
+/** A fresh meet.jit.si room is members-only until a moderator arrives: the conference join fails
+ *  with MEMBERS_ONLY, which jitsi reliably emits to the page console (`conference.connectionError.
+ *  membersOnly … <room>@lobby.<host>`) — observed on every run. We latch that host-side (below)
+ *  because it fires even when the DOM renders NO lobby affordances (a blank/error page) and the
+ *  redux store isn't wired up yet pre-admission — the exact state that made a real lobby look like
+ *  "unknown" and drove the illegal `joining → needs_help` escalation (#592). Attach BEFORE
+ *  navigation (from join.ts) so the event is never missed; the flag lives on the page object. */
+const MEMBERS_ONLY_RE = /conference\.connectionError\.membersOnly|MEMBERS_ONLY/i;
+
+export function attachMembersOnlyWatch(page: Page): void {
+  const p = page as any;
+  if (p.__vexaMembersOnlyWatch) return; // idempotent per page
+  p.__vexaMembersOnlyWatch = true;
+  page.on("console", (msg) => {
+    try { if (MEMBERS_ONLY_RE.test(msg.text())) p.__vexaMembersOnly = true; } catch { /* noop */ }
+  });
+}
+
+function membersOnlyLatched(page: Page): boolean {
+  return (page as any).__vexaMembersOnly === true;
+}
+
+/** The app's own lobby verdict via redux — a secondary signal (self-hosted / explicit-Lobby
+ *  deployments where the store IS populated). On stock meet.jit.si the members-only latch above
+ *  is the primary signal; this returns "no-api" pre-admission when the store isn't wired. */
+export async function getLobbyState(page: Page): Promise<"lobby" | "not-lobby" | "no-api"> {
+  return await page.evaluate(() => {
+    try {
+      const app = (globalThis as any).APP;
+      const state = app?.store?.getState?.();
+      if (!state) return "no-api";
+      const conf = state["features/base/conference"];
+      if (conf && conf.membersOnly) return "lobby"; // members-only lobby room JID when locked out
+      const lobby = state["features/lobby"];
+      if (lobby && lobby.knocking) return "lobby"; // explicit Lobby feature: knocking to be let in
+      return "not-lobby";
+    } catch { return "no-api"; }
+  }).catch(() => "no-api") as "lobby" | "not-lobby" | "no-api";
 }
 
 /** The hangup control is footer-only — never rendered on the prejoin or lobby screens. */
@@ -75,6 +116,15 @@ export async function isAdmitted(page: Page): Promise<boolean> {
 /** Check if the bot is on the lobby (knocking) screen or a waiting-for-host dialog. */
 async function isInLobby(page: Page): Promise<boolean> {
   try {
+    // Authoritative first: the members-only conference-failure latched from the page console.
+    // Reliable even on the blank/error render where the DOM affordances never appear — the
+    // render that made a real lobby look like "unknown" and took the broken escalation path (#592).
+    if (membersOnlyLatched(page)) return true;
+
+    // Secondary: the app's own redux lobby verdict (self-hosted / explicit-Lobby deployments).
+    if ((await getLobbyState(page)) === "lobby") return true;
+
+    // DOM fallback: explicit lobby/knock screens + APP-stripped custom builds.
     for (const sel of jitsiLobbyIndicators) {
       const visible = await page.locator(sel).first().isVisible({ timeout: 200 }).catch(() => false);
       if (visible) return true;
@@ -138,7 +188,9 @@ export async function waitForJitsiMeetingAdmission(
     const terminal = await isRejectedOrEnded(page);
     if (terminal) {
       log(`[Jitsi] Terminal state during admission wait (matched: "${terminal}")`);
-      throw new Error(`Bot was rejected from the Jitsi meeting or meeting ended (matched: "${terminal}")`);
+      // A lobby decline / kick is a permanent host verdict — a typed denial, not a transient
+      // join_failure — so the driver records `awaiting_admission_rejected`, not a retry.
+      throw new AdmissionError("denial", `Bot was rejected from the Jitsi meeting or meeting ended (matched: "${terminal}")`);
     }
 
     if (await isAdmitted(page)) {
@@ -175,7 +227,10 @@ export async function waitForJitsiMeetingAdmission(
     log(`[Jitsi] Still waiting for admission... ${elapsed}s elapsed`);
   }
 
-  throw new Error(`[Jitsi] Bot not admitted within ${effectiveTimeout()}ms timeout`);
+  // Timed out waiting to be let in. A typed `lobby_timeout` (not a bare Error) so the driver
+  // reports `awaiting_admission_timeout` / stage=awaiting_admission — an honest terminal reason
+  // — instead of collapsing to a generic, silently-retried `join_failure` (#592).
+  throw new AdmissionError("lobby_timeout", `[Jitsi] Bot not admitted within ${effectiveTimeout()}ms timeout`);
 }
 
 export async function checkForJitsiAdmissionSilent(page: Page): Promise<boolean> {

--- a/core/meetings/modules/join/src/jitsi/join.ts
+++ b/core/meetings/modules/join/src/jitsi/join.ts
@@ -1,7 +1,7 @@
 import { Page } from "playwright";
 import { log, callJoiningCallback } from "../_host";
 import { BotConfig } from "../_host";
-import { isAdmitted } from "./admission";
+import { isAdmitted, attachMembersOnlyWatch } from "./admission";
 import { fillPasswordPromptIfPresent } from "./password";
 import {
   jitsiNameInputSelector,
@@ -136,6 +136,10 @@ export async function joinJitsiMeeting(
   botConfig: BotConfig,
 ): Promise<void> {
   if (!page) throw new Error("[Jitsi] Page is required for Jitsi join");
+
+  // Latch the members-only conference-failure from the page console BEFORE navigation, so the
+  // admission wait recognizes the lobby even when the DOM shows no lobby affordances (#592).
+  attachMembersOnlyWatch(page);
 
   const navUrl = buildJitsiMeetingUrl(meetingUrl, { botName });
   log(`[Jitsi] Navigating to: ${navUrl}`);

--- a/core/meetings/modules/join/src/shared/admission.ts
+++ b/core/meetings/modules/join/src/shared/admission.ts
@@ -1,0 +1,22 @@
+/**
+ * Typed admission outcome shared by every platform admission wait (google_meet, jitsi, …).
+ *
+ * denial        — a moderator/host explicitly rejected the bot from the lobby/waiting room.
+ * lobby_timeout — the bot stayed in the lobby/waiting state past the admission timeout.
+ * join_failure  — the bot never reached the lobby / no admission signal ever appeared.
+ *
+ * The JoinDriver maps this `outcome` onto a completion reason, so a lobby timeout is reported
+ * as `awaiting_admission_timeout` (retry-honest) rather than a generic `join_failure`. Lives in
+ * `shared/` so each platform throws the SAME class the driver checks with `instanceof`, without
+ * coupling one platform sibling to another.
+ */
+export type AdmissionOutcome = "denial" | "lobby_timeout" | "join_failure";
+
+export class AdmissionError extends Error {
+  readonly outcome: AdmissionOutcome;
+  constructor(outcome: AdmissionOutcome, message: string) {
+    super(message);
+    this.name = "AdmissionError";
+    this.outcome = outcome;
+  }
+}


### PR DESCRIPTION
## What

Fixes the real defect behind #592. Investigating on the published v0.12.3 image against real meet.jit.si showed the issue's "open room / no lobby / admission false-positive" premise doesn't hold: **fresh meet.jit.si rooms are members-only** until a moderator arrives. The conference join fails with `MEMBERS_ONLY` and the error page renders none of the lobby affordances, so the DOM/text lobby check could miss it — the bot then treated a real lobby as an "unknown" state and escalated down the illegal `joining → needs_help` transition, which was swallowed, so it looped silently.

## Changes

- **Authoritative lobby detection** (`jitsi/admission.ts`): latch the `MEMBERS_ONLY` conference-failure host-side from the page console (reliable even when the DOM shows nothing) as the primary signal, with the app's redux verdict (`features/base/conference.membersOnly`) and the existing DOM checks as fallbacks — mirroring how admission already trusts `APP.conference.isJoined()`. Wired in from `join.ts` before navigation so the event is never missed.
- **Typed admission errors** (`shared/admission.ts` + `jitsi/admission.ts`): the Jitsi admission wait now throws a typed `AdmissionError` (moved to `shared/` so every platform throws the class the JoinDriver maps) — a lobby timeout → `awaiting_admission_timeout`, a decline → `awaiting_admission_rejected` — instead of a bare `Error` that collapses to a generic `join_failure`.
- **Test** (`jitsi/admission.test.ts`): fabricated `APP`/`Page` — members-only → `lobby`; timeout throws `AdmissionError('lobby_timeout')`.

## Testing

- Join module suite green (`npm test`), isolation gate green, `tsc` clean.
- **Live on the published v0.12.3 image against real meet.jit.si**: with no moderator, the members-only lobby is detected via the latch + redux for the full wait (the silent-loop path is gone); with a moderator present, the bot enters and produces a transcript.

## Follow-up (out of scope here)

The *accurate completion reason* for a stuck bot additionally needs a meetings-lifecycle change: a bot waiting in the lobby is torn down by the pre-active workload teardown (~5 min) **before** its own admission timeout fires, and that path stamps the fail-safe `join_failure` rather than `awaiting_admission_timeout`. Both are transient/retry, so behavior is unaffected — it's a precision issue, filed separately. This PR makes the bot-side path correct so it produces the right reason once the teardown is status-aware (or the timeouts are aligned).
