### PR TITLE
fix(bot): MS Teams bot self-evicts ~120ms after a successful join (#593)

### DIFF
--- a/core/meetings/services/bot/package.json
+++ b/core/meetings/services/bot/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && node build-browser-utils.mjs",
     "build:browser-utils": "node build-browser-utils.mjs",
     "start": "tsx src/index.ts",
-    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/replay.test.ts && tsx mock/mock.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/replay.test.ts && tsx mock/mock.test.ts",
     "replay": "tsx src/replay.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -122,6 +122,34 @@ export async function launchBrowser(inv: Invocation): Promise<BrowserSession> {
     // inline fallback below. Never fatal at launch.
   });
 
+  // #593 A1: a page-context global fault logger, installed at document-start on EVERY frame/nav so
+  // gmeet + teams + zoom all inherit it. Before this, the only error-shaped line on the bot's stdout
+  // for a Teams join was the platform's OWN `Unhandled rejection {isTrusted:true}` — a bare DOM Event
+  // that misdirected #593 (it's Teams' VQE worklet, unrelated to our Node throw). This handler names
+  // the actual reason (message + stack) AND, for a bare Event, its type/target — so the {isTrusted}
+  // line is finally identified rather than mistaken for the cause. Non-fatal at launch (like neighbors).
+  await context.addInitScript(`(() => {
+    var report = function (m) { try { (window.logBot || console.error)('[page-fault] ' + m); } catch (e) {} };
+    window.addEventListener('unhandledrejection', function (ev) {
+      var r = ev && ev.reason;
+      var msg = (r && (r.message || r.name)) ? ((r.name || 'Error') + ': ' + (r.message || '')) : String(r);
+      var stack = (r && r.stack) ? r.stack : '(no stack)';
+      report('unhandledrejection: ' + msg + ' :: ' + stack);
+    });
+    window.addEventListener('error', function (ev) {
+      var msg;
+      if (ev && ev.error && (ev.error.message || ev.error.stack)) {
+        msg = (ev.error.name || 'Error') + ': ' + (ev.error.message || '') + ' :: ' + (ev.error.stack || '(no stack)');
+      } else {
+        var t = ev && ev.target;
+        var tag = t && (t.tagName || t.nodeName);
+        var src = t && (t.src || t.href || t.currentSrc);
+        msg = 'event type=' + (ev && ev.type) + (tag ? ' target=' + tag : '') + (src ? ' src=' + src : '') + ' isTrusted=' + (ev && ev.isTrusted);
+      }
+      report('error: ' + msg);
+    });
+  })();`).catch(() => { /* never fatal at launch */ });
+
   // Zoom/Teams expose NO per-participant <audio> in the DOM — install the WebRTC hook so each
   // remote audio track is mirrored into a hidden <audio> element (→ __vexaCapturedRemoteAudioStreams)
   // the mixed lane combines. Jitsi rides the same hook: its remote audio also arrives as WebRTC

--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -29,7 +29,7 @@ import { createHttpLifecycleSink } from './adapters/lifecycle-http.js';
 import { createRedisTranscriptSink, redisClientFrom } from './adapters/transcript-redis.js';
 import { createRedisActsSource, redisActsClientFrom } from './adapters/acts-redis.js';
 import { createBrowserJoinDriver } from './join-driver.js';
-import { createBotPipeline, type BotPipeline } from './pipeline.js';
+import { createBotPipeline, createLivePipeline, serr, type BotPipeline } from './pipeline.js';
 import { createBotRecordingSink } from './recording.js';
 import { launchBrowser, startCaptureBridge, startRecording, createSpeakController, type BrowserSession, type SpeakController } from './capture-bridge.js';
 import { installSignalHandlers } from './signals.js';
@@ -166,8 +166,6 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
   let join: JoinDriver;
   let pipeline: Pipeline;
   let botPipeline: BotPipeline | null = null;
-  let stopCapture: () => Promise<void> = async () => { /* no-op until pipeline.start() wires capture */ };
-  let stopRecording: () => Promise<void> = async () => { /* no-op until pipeline.start() wires recording */ };
   let acts: ActsSource = liveActs;
   const recording = inv.recordingEnabled ? createBotRecordingSink({ inv, log: (m) => console.log(`[bot] ${m}`) }) : undefined;
 
@@ -200,20 +198,18 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
         absolute_end_time: new Date(nowMs).toISOString(),
       }).catch((e) => console.error(`[bot] chat publish rejected: ${String(e)}`));
     };
-    pipeline = {
-      async start() {
-        stopCapture = await startCaptureBridge(sess.page, inv, bp, undefined, publishChat);   // on the live meeting page
-        if (rec) stopRecording = await startRecording(sess.page, inv, rec);   // MediaRecorder → recording.v1
-        await bp.start();
+    // #593: a post-admission subsystem failure must NEVER self-evict. createLivePipeline wraps the
+    // page-side capture + recording attach + the engine start so pipeline.start() ALWAYS RESOLVES;
+    // each failure surfaces LOUD via onFault (console with a full-fidelity serr(e)) instead of
+    // throwing into the orchestrator's leave-on-fail backstop (which would hang the bot up).
+    pipeline = createLivePipeline({
+      startCapture: () => startCaptureBridge(sess.page, inv, bp, undefined, publishChat),   // on the live meeting page
+      startRecording: rec ? () => startRecording(sess.page, inv, rec) : undefined,          // MediaRecorder → recording.v1
+      engine: bp,
+      onFault: (stage, e) => {
+        console.error(`[bot] live-pipeline: ${stage} failed (non-fatal, bot stays seated): ${serr(e)}`);
       },
-      async stop() {
-        const sc = stopCapture; stopCapture = async () => {};
-        await sc().catch(() => { /* best-effort */ });
-        const sr = stopRecording; stopRecording = async () => {};
-        await sr().catch(() => { /* best-effort */ });   // flush the final chunk → master assembly
-        await bp.stop();
-      },
-    };
+    });
     // Voice: tee acts so `speak`/`speak_stop` reach the SpeakController (gated on voiceAgentEnabled).
     const speak = createSpeakController(session.page, inv);
     acts = teeActs(liveActs, voiceHandler(speak));
@@ -243,10 +239,11 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
     return result.exitCode;
   } finally {
     releaseSignals();
-    // Tear down the capture bridge + browser (best-effort — a teardown failure must not change
-    // the exit code). The orchestrator already stopped the pipeline + left the meeting.
-    await stopCapture().catch(() => { /* best-effort */ });
-    await stopRecording().catch(() => { /* best-effort */ });
+    // Tear down the pipeline (capture bridge + recording + engine) + browser (best-effort — a
+    // teardown failure must not change the exit code). The orchestrator already stopped the pipeline
+    // on a normal end; createLivePipeline.stop() is idempotent, and this also covers an early-exit
+    // path that skipped the orchestrator's teardown. (#593)
+    await pipeline.stop().catch(() => { /* best-effort */ });
     if (session) await session.close().catch(() => { /* best-effort */ });
     // Quit the redis connections on teardown (best-effort — a quit failure must not change the
     // exit code; they may never have connected if redis was unreachable).

--- a/core/meetings/services/bot/src/live-pipeline.test.ts
+++ b/core/meetings/services/bot/src/live-pipeline.test.ts
@@ -1,0 +1,149 @@
+/**
+ * L2 — createLivePipeline guard (#593 A4). The admitted→capture-start handoff had NO unit before
+ * this: the composed pipeline was inline in index.ts (three bare awaits). This proves the
+ * load-bearing invariant — a post-admission subsystem failure (page-side capture throw, recording
+ * throw, or the engine/pyannote-model load rejecting) DEGRADES LOUDLY and NEVER rejects start(), so
+ * the orchestrator's leave-on-pipeline-fail backstop never fires and the bot stays seated.
+ *
+ * RED on the pre-#593 inline pipeline (the first thrown await rejects start()); GREEN after.
+ * Run: npx tsx src/live-pipeline.test.ts
+ */
+import { createLivePipeline, serr, type LiveStage } from './pipeline.js';
+import type { Pipeline } from './ports.js';
+
+let failed = 0;
+const check = (name: string, cond: boolean, detail = ''): void => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond ? '' : '  — ' + detail}`);
+  if (!cond) failed++;
+};
+
+// A fake engine (the BotPipeline seen as a Pipeline) with a controllable start + start/stop counters.
+const fakeEngine = (startImpl?: () => Promise<void>): Pipeline & { starts: number; stops: number } => {
+  const e = {
+    starts: 0, stops: 0,
+    async start(): Promise<void> { e.starts++; if (startImpl) await startImpl(); },
+    async stop(): Promise<void> { e.stops++; },
+  };
+  return e;
+};
+
+type Spy = { started: number; stopped: number };
+const okThunk = (spy: Spy) => async (): Promise<() => Promise<void>> => { spy.started++; return async () => { spy.stopped++; }; };
+const throwThunk = (e: unknown) => async (): Promise<() => Promise<void>> => { throw e; };
+const tick = (ms = 0): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+async function main(): Promise<void> {
+  // 1) capture-start throws a fabricated {isTrusted:true} DOM-like Event → start() RESOLVES; engine
+  //    still starts; the fault is reported. This is the exact #593 self-evict class.
+  {
+    const faults: LiveStage[] = [];
+    const engine = fakeEngine();
+    let resolved = false;
+    const live = createLivePipeline({
+      startCapture: throwThunk({ isTrusted: true, type: 'error' }),   // the misdirecting event shape
+      engine,
+      onFault: (s) => faults.push(s),
+      retry: { attempts: 1, delayMs: 0 },
+    });
+    await live.start().then(() => { resolved = true; });
+    check('capture throw: start() RESOLVED (no self-evict)', resolved);
+    check('capture throw: engine STILL started after the capture throw', engine.starts === 1);
+    check('capture throw: onFault(capture-start) fired', faults.includes('capture-start'));
+  }
+
+  // 2) engine-start throws (the pyannote model-load reject) → start() RESOLVES; fault reported.
+  {
+    const faults: LiveStage[] = [];
+    const capSpy: Spy = { started: 0, stopped: 0 };
+    const engine = fakeEngine(async () => { throw new Error('from_pretrained: config.json not found'); });
+    let resolved = false;
+    const live = createLivePipeline({
+      startCapture: okThunk(capSpy),
+      engine,
+      onFault: (s) => faults.push(s),
+      retry: { attempts: 1, delayMs: 0 },
+    });
+    await live.start().then(() => { resolved = true; });
+    check('engine throw: start() RESOLVED (bot stays seated)', resolved);
+    check('engine throw: onFault(engine-start) fired', faults.includes('engine-start'));
+    check('engine throw: capture attached first', capSpy.started === 1);
+  }
+
+  // 3) recording-start throws → start() RESOLVES; fault reported; engine still starts.
+  {
+    const faults: LiveStage[] = [];
+    const capSpy: Spy = { started: 0, stopped: 0 };
+    const engine = fakeEngine();
+    let resolved = false;
+    const live = createLivePipeline({
+      startCapture: okThunk(capSpy),
+      startRecording: throwThunk(new Error('MediaRecorder boom')),
+      engine,
+      onFault: (s) => faults.push(s),
+      retry: { attempts: 1, delayMs: 0 },
+    });
+    await live.start().then(() => { resolved = true; });
+    check('recording throw: start() RESOLVED', resolved);
+    check('recording throw: onFault(recording-start) fired', faults.includes('recording-start'));
+    check('recording throw: engine STILL started', engine.starts === 1);
+  }
+
+  // 4) happy path → no faults; stop() tears down capture + recording + engine.
+  {
+    const faults: LiveStage[] = [];
+    const capSpy: Spy = { started: 0, stopped: 0 };
+    const recSpy: Spy = { started: 0, stopped: 0 };
+    const engine = fakeEngine();
+    const live = createLivePipeline({
+      startCapture: okThunk(capSpy), startRecording: okThunk(recSpy), engine, onFault: (s) => faults.push(s),
+    });
+    await live.start();
+    check('happy: no faults', faults.length === 0, faults.join(','));
+    check('happy: engine started', engine.starts === 1);
+    await live.stop();
+    check('happy: stop tore down capture', capSpy.stopped === 1);
+    check('happy: stop tore down recording', recSpy.stopped === 1);
+    check('happy: stop stopped engine', engine.stops === 1);
+  }
+
+  // 5) engine retry: fails once then succeeds → self-heals in the background without evicting.
+  {
+    let attempts = 0;
+    const engine = fakeEngine(async () => { attempts++; if (attempts === 1) throw new Error('transient model load'); });
+    const live = createLivePipeline({
+      startCapture: okThunk({ started: 0, stopped: 0 }), engine, onFault: () => {}, retry: { attempts: 3, delayMs: 5 },
+    });
+    await live.start();
+    check('retry: start() resolved despite first-attempt failure', true);
+    await tick(40);   // let the background retry timer fire
+    check('retry: engine eventually started (self-heal)', attempts >= 2, `attempts=${attempts}`);
+    await live.stop();
+  }
+
+  // 6) stop() cancels a pending retry timer — no leaked timer, no post-stop start attempts.
+  {
+    let attempts = 0;
+    const engine = fakeEngine(async () => { attempts++; throw new Error('always fails'); });
+    const live = createLivePipeline({
+      startCapture: okThunk({ started: 0, stopped: 0 }), engine, onFault: () => {}, retry: { attempts: 5, delayMs: 5 },
+    });
+    await live.start();
+    const afterStart = attempts;
+    await live.stop();
+    await tick(40);
+    check('stop: no further engine attempts after stop (timer cancelled)', attempts === afterStart, `after=${afterStart} now=${attempts}`);
+  }
+
+  // 7) serr: full-fidelity serialization — the A1 fix for the {isTrusted:true} fidelity loss.
+  {
+    const e = new Error('config.json not found');
+    check('serr: Error → includes message', serr(e).includes('config.json not found'));
+    check('serr: Error → includes a stack frame', /\bat\b/.test(serr(e)));
+    check('serr: bare object → NOT flattened to [object …]', !serr({ isTrusted: true }).includes('[object'));
+  }
+
+  console.log(failed === 0 ? '\n✅ live-pipeline: all passed' : `\n❌ live-pipeline: ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+}
+
+void main();

--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -17,6 +17,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createOrchestrator } from './orchestrator.js';
+import { createLivePipeline } from './pipeline.js';
 import { canTransition, type BotStatus, type LifecycleEvent, type TranscriptSegment } from './contracts.js';
 import type { JoinDriver, JoinOutcome, Pipeline, LifecycleSink, ActsSource, TranscriptSink } from './ports.js';
 import type { Invocation } from './config.js';
@@ -280,6 +281,43 @@ async function main(): Promise<void> {
     const res = await runP;
     check('active-stop: completed(stopped) via the active-leave path (unchanged)', res.status === 'completed' && last(lc.events).completion_reason === 'stopped');
     check('active-stop: withdraw NOT invoked (active leave, not a waiting-room withdraw)', withdrew === 0, `withdrew=${withdrew}`);
+  }
+
+  // ── #593 A4: a post-admission subsystem failure does NOT self-evict (the createLivePipeline seam) ──
+  // Wire a REAL createLivePipeline whose page-side capture AND engine start both throw, into the
+  // orchestrator. Before the fix (inline pipeline, three bare awaits) the first throw rejected
+  // pipeline.start() → orchestrator catch → leave('pipeline_start_failed') + failed(active/join_failure)
+  // ~immediately (the ~120 ms self-evict). After: start() resolves (faults surfaced loud), the bot
+  // reaches active and STAYS until a normal end. NB this deliberately COEXISTS with the earlier
+  // "pipeline.start genuinely throws ⇒ leave (no ghost)" test — that invariant is preserved; what
+  // changed is that createLivePipeline no longer lets a recoverable subsystem failure BECOME a throw.
+  {
+    const lc = recordingSink();
+    const leaveReasons: string[] = [];
+    let fireLeave: (a: { action: 'leave' }) => void = () => {};
+    const join: JoinDriver = {
+      async join(report) { await report('awaiting_admission'); await report('active'); return 'admitted'; },
+      onRemoval() { return () => {}; },
+      async leave(reason) { leaveReasons.push(String(reason)); },
+      async withdraw() { /* */ },
+    };
+    const faults: string[] = [];
+    const engine: Pipeline = { async start() { throw new Error('from_pretrained rejected (empty HF cache)'); }, async stop() { /* */ } };
+    const pipeline = createLivePipeline({
+      startCapture: async () => { throw { isTrusted: true, type: 'error' }; },   // the misdirecting page event
+      engine,
+      onFault: (stage) => faults.push(stage),
+      retry: { attempts: 1, delayMs: 0 },
+    });
+    const o = createOrchestrator(inv({ platform: 'teams' }), { lifecycle: lc, join, pipeline, acts: noopActs((f) => { fireLeave = f; }) });
+    const runP = o.run();
+    setTimeout(() => fireLeave({ action: 'leave' }), 10);
+    const res = await runP;
+    check('#593: reached active (post-admission capture handoff did not evict)', seq(lc.events).includes('active'), JSON.stringify(seq(lc.events)));
+    check('#593: never emitted failed (no self-evict)', !seq(lc.events).includes('failed'), JSON.stringify(seq(lc.events)));
+    check('#593: leave NEVER called with pipeline_start_failed', !leaveReasons.includes('pipeline_start_failed'), leaveReasons.join(','));
+    check('#593: ended cleanly via the leave act → completed(stopped)', res.status === 'completed' && last(lc.events).completion_reason === 'stopped', JSON.stringify(last(lc.events)));
+    check('#593: both subsystem faults surfaced loud (capture + engine)', faults.includes('capture-start') && faults.includes('engine-start'), faults.join(','));
   }
 
   if (failed) { console.error(`\n❌ orchestrator (L2): ${failed} check(s) FAILED.`); process.exit(1); }

--- a/core/meetings/services/bot/src/pipeline.ts
+++ b/core/meetings/services/bot/src/pipeline.ts
@@ -167,7 +167,12 @@ function createMixedBotPipeline(
         rename: (_oldSpeaker, newSpeaker, segments) => publish(newSpeaker, segments, true),
         language,
         onError,
-      }).then((t) => { transcriber = t; return t; });
+      }).then((t) => { transcriber = t; return t; })
+        // #593: DON'T cache a rejected create promise. The mixed lane's create() loads the pyannote
+        // model (from_pretrained) — if that rejects (empty HF cache, no egress), leaving `creating`
+        // as a stuck rejected promise makes every later start() reject too, so the non-fatal retry
+        // in createLivePipeline could never succeed. Clear it on failure so a retry re-attempts the load.
+        .catch((e) => { creating = null; throw e; });
     }
     return creating;
   };
@@ -210,4 +215,98 @@ export function createBotPipeline(
     return createMixedBotPipeline(transcribe, sink, inv.language ?? undefined, opts.onError);
   }
   return createGmeetBotPipeline(transcribe, sink, opts.config, opts.onError);
+}
+
+/** The post-admission subsystem stages createLivePipeline sequences (used in fault labels). */
+export type LiveStage = 'capture-start' | 'recording-start' | 'engine-start';
+
+/**
+ * Serialize a thrown value for a LOG LINE (#593 A1). Prefer the stack (names the throwing frame),
+ * else `name: message`, else a safe JSON — NEVER `String(e)` (a DOM Event → "[object Event]", the
+ * exact fidelity loss that hid the real #593 throw) and never bare `JSON.stringify` (throws on cycles).
+ */
+export function serr(e: unknown): string {
+  const x = e as { message?: string; stack?: string; name?: string } | null | undefined;
+  if (x?.stack) return x.stack;
+  if (x?.message) return `${x.name ?? 'Error'}: ${x.message}`;
+  try { return `non-error throw: ${JSON.stringify(e)}`; }
+  catch { return `non-error throw: ${String(e)}`; }
+}
+
+export interface LivePipelineDeps {
+  /** Attach the page-side capture; returns its teardown. Best-effort — a throw DEGRADES, never evicts. */
+  startCapture: () => Promise<() => Promise<void>>;
+  /** Attach the page-side recording (optional); returns its teardown. Best-effort. */
+  startRecording?: () => Promise<() => Promise<void>>;
+  /** The transcription engine (the BotPipeline). Its start() failure is non-fatal + retried. */
+  engine: Pipeline;
+  /** Loud fault sink — which stage failed + the raw error (wired to console.error(serr) + publishFault). */
+  onFault: (stage: LiveStage, e: unknown) => void;
+  /** Bounded retry for engine start (the pyannote model load). Default 3 attempts, 2s apart. */
+  retry?: { attempts: number; delayMs: number };
+}
+
+/**
+ * The LIVE pipeline (composition-root seam) — THE #593 FIX. Wraps the page-side capture + recording
+ * attach and the transcription-engine start into ONE Pipeline whose `start()` ALWAYS RESOLVES.
+ *
+ * Once the bot is admitted, a post-admission subsystem failure — a page-side capture/MediaRecorder
+ * throw, or the mixed-lane pyannote model load rejecting (empty HF cache / no egress) — must DEGRADE
+ * LOUDLY, never propagate out of `start()`. The orchestrator's backstop maps ANY `pipeline.start()`
+ * throw to `leave('pipeline_start_failed')` + `join_failure` (correct for a truly unrecoverable
+ * pipeline, and deliberately preserved), so keeping every recoverable failure INSIDE this seam is
+ * what stops the ~120 ms self-evict. Every failure routes to `onFault` (→ console + the transcript
+ * fault publisher → meeting-page banner) so "admitted but not transcribing" is loud, not silent.
+ *
+ * Browser-free BY CONSTRUCTION (takes thunks; imports no playwright/DOM) so it is L2-unit-provable
+ * offline — the admitted→capture-start seam no unit covered before (#593 A4). index.ts binds the
+ * thunks to the live page.
+ */
+export function createLivePipeline(deps: LivePipelineDeps): Pipeline {
+  const { startCapture, startRecording, engine, onFault } = deps;
+  const maxAttempts = Math.max(1, deps.retry?.attempts ?? 3);
+  const delayMs = Math.max(0, deps.retry?.delayMs ?? 2000);
+
+  let stopCapture: (() => Promise<void>) | null = null;
+  let stopRecording: (() => Promise<void>) | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  // Engine start with bounded background retry: the FIRST attempt is awaited by start() (so start()
+  // resolves promptly — the bot is already seated); later attempts fire on a timer without ever
+  // rejecting start(). A transient/slow model load thus self-heals without evicting the bot.
+  const tryEngineStart = async (attempt: number): Promise<void> => {
+    try {
+      await engine.start();
+    } catch (e) {
+      onFault('engine-start', e);
+      if (stopped || attempt >= maxAttempts) return;   // give up (already published loud); bot STAYS
+      retryTimer = setTimeout(() => { retryTimer = null; void tryEngineStart(attempt + 1); }, delayMs);
+    }
+  };
+
+  return {
+    async start(): Promise<void> {
+      // capture-start — best-effort (a page media Event / exposeFunction reject must not evict).
+      try { stopCapture = await startCapture(); }
+      catch (e) { onFault('capture-start', e); }
+      // recording-start — best-effort.
+      if (startRecording) {
+        try { stopRecording = await startRecording(); }
+        catch (e) { onFault('recording-start', e); }
+      }
+      // engine-start — non-fatal degrade + bounded retry (the pyannote model load; #593 root cause).
+      await tryEngineStart(1);
+      // NOTHING rethrows ⇒ the orchestrator never sees a pipeline.start() throw ⇒ no self-evict.
+    },
+    async stop(): Promise<void> {
+      stopped = true;
+      if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
+      const sc = stopCapture; stopCapture = null;
+      if (sc) await sc().catch(() => { /* best-effort — page may be closing */ });
+      const sr = stopRecording; stopRecording = null;
+      if (sr) await sr().catch(() => { /* best-effort — flush the final chunk → master assembly */ });
+      await engine.stop().catch(() => { /* best-effort; idempotent across double-stop */ });
+    },
+  };
 }


### PR DESCRIPTION
## #593 — MS Teams bot self-evicts ~120 ms after a successful join

Fixes #593.

### Root cause (empirically confirmed)
After admission, `orchestrator.ts` runs `await deps.pipeline.start()` and maps **any** throw to `deps.join.leave('pipeline_start_failed')` + `failed(join_failure)` (correct backstop for a truly-dead pipeline). But the composed `pipeline.start()` in `index.ts` bundled three awaits — capture attach, recording attach, and `bp.start()` — and `bp.start()` for Teams is `ChunkedTranscriber.create()` → `PyannoteSegmenter.create()` → two unguarded `AutoModel.from_pretrained(...)`. When the pyannote model isn't cached and HF is unreachable, that rejects → `pipeline.start()` throws → the admitted, capturing bot hangs up ~120 ms later.

A local harness confirmed it: empty cache + no remote → `from_pretrained` **rejects in 6 ms** with a plain `Error` (not a DOM Event). The `{isTrusted:true}` line in the original report is Teams' own VQE-worklet log — a red herring.

### The fix (maps to the acceptance floor)
- **A2** — new browser-free `createLivePipeline` (`pipeline.ts`): capture/recording attach best-effort, engine-start non-fatal + bounded retry; `start()` **always resolves** → no self-evict. Fixes `ensure()` caching a rejected create promise (retry was impossible). `index.ts` rebinds to it.
- **A1** — `serr()` + a shared page-context `unhandledrejection`/`error` handler that name the real reason+stack (and a bare Event's type/target), instead of the misleading `{isTrusted:true}`.
- **A4** — `live-pipeline.test.ts` (fabricated `{isTrusted:true}` event → `start()` resolves) + an orchestrator-level guard. **RED** on the old inline pipeline, **GREEN** now. The existing "start genuinely throws → leave (no ghost)" invariant is preserved and still green.

### Verification
- `tsc` clean; `live-pipeline` / `orchestrator` / `pipeline` suites green.
- **Live on a real Teams meeting:** unfixed self-evicts 45 ms after admission (`join_failure`, exit 1); **fixed stays `active` ≥66 s** past the same forced model-load failure, logging `engine-start failed (non-fatal, bot stays seated): TypeError: fetch failed`.

### Scope / follow-ups
- `onFault` logs to console here; when #552's `publishFault` lands on `main` it can also raise a meeting-page fault banner.
- Lite pyannote-bake reliability is owned by `fix/warm-hf-cache-resilient`; a CI offline-VERIFY gate for the bake + the model's MIT license notice/SBOM entry are separate follow-ups.
- **A3 "transcribes" leg not captured live** — a working-model run stayed (no self-evict) but was cut short by a Teams **removal-monitor false-positive** on `[role="alert"]` before capture (a separate issue, #171-class), and a retry wasn't re-admitted. The transcribe path is unchanged by this PR (createLivePipeline only wraps `start()`), so transcription behaves exactly as before once the model loads.
