### PR TITLE
gateway: isolate auth pool + 503-not-401 on auth-infra failure (#495)

### DIFF
--- a/core/gateway/services/gateway/src/gateway/adapters.py
+++ b/core/gateway/services/gateway/src/gateway/adapters.py
@@ -22,6 +22,7 @@ import os
 from typing import Optional
 
 from .obs import TRACE_HEADER, get_trace_id
+from .ports import AuthUnavailable
 
 
 class HttpxDownstreamClient:
@@ -62,26 +63,40 @@ class AdminApiAuthorizer:
         self._meeting_api_url = meeting_api_url.rstrip("/")
 
     async def resolve(self, api_key: str) -> Optional[dict]:
+        import httpx
+
+        headers = {TRACE_HEADER: get_trace_id() or ""}
+        internal_secret = os.getenv("INTERNAL_API_SECRET", "")
+        if internal_secret:
+            headers["X-Internal-Secret"] = internal_secret
         try:
-            headers = {TRACE_HEADER: get_trace_id() or ""}
-            internal_secret = os.getenv("INTERNAL_API_SECRET", "")
-            if internal_secret:
-                headers["X-Internal-Secret"] = internal_secret
             resp = await self._client.post(
                 f"{self._admin_api_url}/internal/validate",
                 json={"token": api_key},
                 headers=headers,
                 timeout=5.0,
             )
-            if resp.status_code == 200:
-                return resp.json()
-        except Exception:
-            return None
+        except httpx.HTTPError as e:
+            # Transport-layer failure or timeout: we did NOT reach a verdict on the key. Surfacing
+            # this as an invalid key is the #495/#483 bug — raise so the app answers 503 (retry),
+            # never 401. (httpx.HTTPError covers TimeoutException, ConnectError, PoolTimeout, …)
+            raise AuthUnavailable(f"admin-api validate unreachable: {e!r}") from e
+        if resp.status_code == 200:
+            return resp.json()
+        # admin-api answered a fault (5xx) — again no verdict on the key → unavailable, not invalid.
+        if resp.status_code >= 500:
+            raise AuthUnavailable(f"admin-api validate returned {resp.status_code}")
+        # A definitive client-error answer (401/403/404/422 …): the key is genuinely invalid → 401.
         return None
 
     async def authorize_subscribe(self, api_key: str, meetings: list) -> dict:
         auth_headers = {"X-API-Key": api_key, TRACE_HEADER: get_trace_id() or ""}
-        user_data = await self.resolve(api_key)
+        try:
+            user_data = await self.resolve(api_key)
+        except AuthUnavailable as e:
+            # #495: resolve now raises on infra failure (rather than returning None). Keep the WS
+            # subscribe path fail-safe — surface it as an authorization error, not an unhandled 500.
+            return {"authorized": [], "errors": [f"authorization_unavailable:{e}"]}
         if user_data:
             auth_headers["x-user-id"] = str(user_data["user_id"])
             auth_headers["x-user-scopes"] = ",".join(user_data.get("scopes", []))
@@ -123,15 +138,28 @@ def build_production_app(
     agent_api_url = os.getenv("AGENT_API_URL", "http://agent-api:8100")
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")
 
-    http_client = httpx.AsyncClient(timeout=30.0)
+    # #495: TWO clients with SEPARATE connection pools. The single shared pool was the root cause —
+    # long forwards to a slow meeting-api (timeout up to 30s) saturated the pool's 10 connections,
+    # so the ~5ms admin-api validation POST queued, timed out, and mass-401'd valid keys.
+    #   • forward_client — the proxy hop; long-lived, generous timeout, larger pool.
+    #   • auth_client    — the admin-api /internal/validate hop ONLY; short timeout, its own pool,
+    #     so validation latency is decoupled from downstream load and can never be starved by it.
+    forward_client = httpx.AsyncClient(
+        timeout=30.0,
+        limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+    )
+    auth_client = httpx.AsyncClient(
+        timeout=5.0,
+        limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
+    )
     redis_client = aioredis.from_url(
         redis_url, encoding="utf-8", decode_responses=True,
         socket_timeout=10, socket_connect_timeout=5, socket_keepalive=True,
         health_check_interval=30, retry_on_timeout=True,
     )
 
-    authorizer = AdminApiAuthorizer(http_client, admin_api_url, meeting_api_url)
-    downstream = HttpxDownstreamClient(http_client)
+    authorizer = AdminApiAuthorizer(auth_client, admin_api_url, meeting_api_url)
+    downstream = HttpxDownstreamClient(forward_client)
 
     from .ratelimit import from_env as _rate_limiter_from_env
 

--- a/core/gateway/services/gateway/src/gateway/adapters.py
+++ b/core/gateway/services/gateway/src/gateway/adapters.py
@@ -82,12 +82,17 @@ class AdminApiAuthorizer:
             # never 401. (httpx.HTTPError covers TimeoutException, ConnectError, PoolTimeout, …)
             raise AuthUnavailable(f"admin-api validate unreachable: {e!r}") from e
         if resp.status_code == 200:
-            return resp.json()
-        # admin-api answered a fault (5xx) — again no verdict on the key → unavailable, not invalid.
-        if resp.status_code >= 500:
-            raise AuthUnavailable(f"admin-api validate returned {resp.status_code}")
-        # A definitive client-error answer (401/403/404/422 …): the key is genuinely invalid → 401.
-        return None
+            try:
+                return resp.json()
+            except ValueError as e:
+                # A 200 with an unparseable body is not a verdict on the key either — no-verdict → 503.
+                raise AuthUnavailable(f"admin-api validate returned unparseable 200 body: {e!r}") from e
+        # Only a definitive CLIENT-error answer (400–499: 401/403/404/422 …) means the key is
+        # genuinely invalid → None → 401. Everything else — 5xx faults, and non-answers like a 3xx
+        # redirect — is NO verdict on the key → unavailable → 503, never a 401 that blames the key.
+        if 400 <= resp.status_code < 500:
+            return None
+        raise AuthUnavailable(f"admin-api validate returned {resp.status_code}")
 
     async def authorize_subscribe(self, api_key: str, meetings: list) -> dict:
         auth_headers = {"X-API-Key": api_key, TRACE_HEADER: get_trace_id() or ""}
@@ -114,6 +119,35 @@ class AdminApiAuthorizer:
             return {"authorized": [], "errors": [f"authorization_call_failed:{e}"]}
 
 
+def build_auth_and_downstream(admin_api_url: str, meeting_api_url: str):
+    """#495: build the authorizer + downstream over TWO httpx clients with SEPARATE connection
+    pools, and return ``(authorizer, downstream)``. This is the load-bearing decision the whole fix
+    turns on — extracted here so it is unit-testable WITHOUT redis (build_production_app needs redis;
+    this does not). Reverting to a single shared client (the pre-#495 bug) means editing this one
+    function, which turns ``test_build_wires_separate_pools`` RED — the genuine A1 negative control.
+
+    The single shared pool was the root cause: long forwards to a slow meeting-api (timeout up to
+    30s) saturated the pool's 10 connections, so the ~5ms admin-api validation POST queued, timed
+    out, and mass-401'd valid keys.
+      • forward_client — the proxy hop; long-lived, generous timeout, larger pool.
+      • auth_client    — the admin-api /internal/validate hop ONLY; short timeout, its own pool,
+        so validation latency is decoupled from downstream load and can never be starved by it.
+    """
+    import httpx
+
+    forward_client = httpx.AsyncClient(
+        timeout=30.0,
+        limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+    )
+    auth_client = httpx.AsyncClient(
+        timeout=5.0,
+        limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
+    )
+    authorizer = AdminApiAuthorizer(auth_client, admin_api_url, meeting_api_url)
+    downstream = HttpxDownstreamClient(forward_client)
+    return authorizer, downstream
+
+
 def build_production_app(
     *,
     admin_api_url: Optional[str] = None,
@@ -128,7 +162,6 @@ def build_production_app(
     v0.12 P2: there is ONE downstream control plane — meeting-api (it hosts the folded-in
     collector). Both the proxy forward and the ``/ws/authorize-subscribe`` hop target it.
     """
-    import httpx
     import redis.asyncio as aioredis
 
     from .app import create_app
@@ -138,28 +171,13 @@ def build_production_app(
     agent_api_url = os.getenv("AGENT_API_URL", "http://agent-api:8100")
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")
 
-    # #495: TWO clients with SEPARATE connection pools. The single shared pool was the root cause —
-    # long forwards to a slow meeting-api (timeout up to 30s) saturated the pool's 10 connections,
-    # so the ~5ms admin-api validation POST queued, timed out, and mass-401'd valid keys.
-    #   • forward_client — the proxy hop; long-lived, generous timeout, larger pool.
-    #   • auth_client    — the admin-api /internal/validate hop ONLY; short timeout, its own pool,
-    #     so validation latency is decoupled from downstream load and can never be starved by it.
-    forward_client = httpx.AsyncClient(
-        timeout=30.0,
-        limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
-    )
-    auth_client = httpx.AsyncClient(
-        timeout=5.0,
-        limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
-    )
+    # #495: authorizer + downstream over SEPARATE httpx pools (see build_auth_and_downstream).
+    authorizer, downstream = build_auth_and_downstream(admin_api_url, meeting_api_url)
     redis_client = aioredis.from_url(
         redis_url, encoding="utf-8", decode_responses=True,
         socket_timeout=10, socket_connect_timeout=5, socket_keepalive=True,
         health_check_interval=30, retry_on_timeout=True,
     )
-
-    authorizer = AdminApiAuthorizer(auth_client, admin_api_url, meeting_api_url)
-    downstream = HttpxDownstreamClient(forward_client)
 
     from .ratelimit import from_env as _rate_limiter_from_env
 

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -555,7 +555,21 @@ async def run_multiplex(ws: WebSocket, authorizer: Authorizer, redis: RedisBus) 
     # front (the SAME resolver /auth/me + the proxy use — ports.py resolve / app.py:96-99,119-125)
     # so we can auto-subscribe the socket to its USER-SCOPED channel. Fail-closed like the proxy:
     # a present-but-invalid key → invalid_api_key + close 4401, not a silently half-open socket.
-    user_data = await authorizer.resolve(api_key)
+    try:
+        user_data = await authorizer.resolve(api_key)
+    except AuthUnavailable as e:
+        # #495: resolve() now RAISES when the validation hop is unreachable/faulted. On the REST
+        # surface that becomes a 503; on this already-accepted socket the truthful equivalent is a
+        # typed error frame + a distinct retryable close code (4503 ≈ HTTP 503), NOT 4401 (which
+        # asserts the key is bad) and NOT an uncaught raise (which drops the socket 1006/1011 with
+        # no signal). A valid key must not be told it is invalid because our auth path is down.
+        log_event("auth_infra_unavailable", audience="system", level="error", span="ws",
+                  fields={"reason": type(e).__name__, "detail": str(e)})
+        try:
+            await ws.send_text(json.dumps({"type": "error", "error": "auth_unavailable"}))
+        finally:
+            await ws.close(code=4503)  # retry later — auth infrastructure unavailable
+        return
     if not user_data:
         try:
             await ws.send_text(json.dumps({"type": "error", "error": "invalid_api_key"}))

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -36,7 +36,26 @@ from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse
 
 from .obs import TRACE_HEADER, TraceMiddleware, get_trace_id, log_event, set_user_id
-from .ports import Authorizer, DownstreamClient, RedisBus
+from .ports import Authorizer, AuthUnavailable, DownstreamClient, RedisBus
+
+# #495: the honest answer when the auth path itself is unreachable — a retryable 503, never a
+# 401 that blames the caller's (valid) key. Shared by /auth/me and the proxy authorizer. Also
+# emits a TYPED, non-empty auth-infra log line (FM02: the old path swallowed the failure in a
+# silent `except`, erasing the one signal that would have named this incident for what it was).
+def _auth_unavailable_response(exc: Exception, *, span: str) -> Response:
+    log_event(
+        "auth_infra_unavailable",
+        audience="system",
+        level="error",
+        span=span,
+        fields={"reason": type(exc).__name__, "detail": str(exc)},
+    )
+    return Response(
+        content=json.dumps({"detail": "Authentication temporarily unavailable, retry"}),
+        status_code=503,
+        media_type="application/json",
+        headers={"Retry-After": "1"},
+    )
 
 # Route-prefix → required scope set. Mirrors main.py ROUTE_SCOPES (main.py:59-65) for the CORE
 # surface the gateway lane carves; multi-scope tokens pass for any of their domains.
@@ -105,7 +124,10 @@ def create_app(
         if not api_key:
             return Response(content=json.dumps({"detail": "Missing API key"}),
                             status_code=401, media_type="application/json")
-        user_data = await authorizer.resolve(api_key)
+        try:
+            user_data = await authorizer.resolve(api_key)
+        except AuthUnavailable as e:
+            return _auth_unavailable_response(e, span="auth")  # #495: infra down → 503, not 401
         if not user_data:
             return Response(content=json.dumps({"detail": "Invalid API key"}),
                             status_code=401, media_type="application/json")
@@ -131,7 +153,12 @@ def create_app(
                 media_type="application/json",
             )
 
-        user_data = await authorizer.resolve(client_key)
+        try:
+            user_data = await authorizer.resolve(client_key)
+        except AuthUnavailable as e:
+            # #495: the validation hop is unreachable/faulted — tell the caller the truth (503,
+            # retry), never 401. A valid key must not be reported as invalid because we are slow.
+            return None, _auth_unavailable_response(e, span="auth")
         if not user_data:
             return None, Response(
                 content=json.dumps({"detail": "Invalid API key"}),

--- a/core/gateway/services/gateway/src/gateway/ports.py
+++ b/core/gateway/services/gateway/src/gateway/ports.py
@@ -19,6 +19,18 @@ from __future__ import annotations
 from typing import Any, AsyncIterator, Optional, Protocol, runtime_checkable
 
 
+class AuthUnavailable(Exception):
+    """The authentication infrastructure could not be reached or answered a fault (#495).
+
+    ``resolve`` raises this — as distinct from returning ``None`` — when it CANNOT DETERMINE
+    whether the key is valid: the admin-api validation hop timed out, failed at the transport
+    layer, or answered 5xx. ``None`` means the opposite: admin-api answered and the key is
+    genuinely invalid. The app maps this exception to ``503`` (retry), NEVER to
+    ``401 Invalid API key`` — telling a caller with a valid key that their key is bad, because
+    OUR auth path is slow or down, is the #483/#495 failure this seam exists to prevent.
+    """
+
+
 @runtime_checkable
 class Authorizer(Protocol):
     """Resolve identity + subscribe-authorization for the caller's ``x-api-key``.
@@ -28,7 +40,9 @@ class Authorizer(Protocol):
       * ``resolve(api_key)`` — mirrors ``main._resolve_token`` (admin-api ``/internal/validate``):
         a non-None result is a dict carrying at least ``user_id`` and ``scopes`` (and optionally
         ``max_concurrent``, ``email``, webhook config). A ``None`` return is the fail-closed
-        signal — the REST app rejects with 401.
+        signal for a GENUINELY INVALID key — the REST app rejects with 401. When the validation
+        hop itself is unreachable/faulted, ``resolve`` raises ``AuthUnavailable`` instead (→ 503),
+        so an infra failure is never reported to the caller as a bad key (#495).
 
       * ``authorize_subscribe(api_key, meetings)`` — mirrors the ``/ws`` subscribe hop to
         transcription-collector's ``/ws/authorize-subscribe`` (main.py:2257-2271): returns

--- a/core/gateway/services/gateway/tests/test_adapters_resolve.py
+++ b/core/gateway/services/gateway/tests/test_adapters_resolve.py
@@ -1,0 +1,97 @@
+"""#495 — the root-cause behavior at the adapter: ``AdminApiAuthorizer.resolve`` must translate
+the admin-api validation hop into a THREE-way verdict, not the old two-way (200 → ok, anything
+else → None-that-becomes-401):
+
+  * 200                    → the resolved user dict            (valid key)
+  * 4xx (401/403/404/422)  → ``None``                          (genuinely invalid key → app 401)
+  * 5xx  / transport error / timeout → raise ``AuthUnavailable`` (no verdict → app 503, retry)
+
+The last row is the fix: under load/outage the hop times out, and reporting that as an invalid
+key mass-401'd valid keys in production (#483/#495). These use httpx.MockTransport so no network
+and no redis are needed (build_production_app is exercised at container boot / conformance).
+"""
+import asyncio
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from gateway.adapters import AdminApiAuthorizer, HttpxDownstreamClient
+from gateway.ports import AuthUnavailable
+
+ADMIN = "http://admin-api:8001"
+
+
+def _authorizer(handler):
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return AdminApiAuthorizer(client, ADMIN, "http://meeting-api:8080")
+
+
+async def test_resolve_200_returns_user():
+    auth = _authorizer(lambda req: httpx.Response(200, json={"user_id": 7, "scopes": ["bot"]}))
+    assert (await auth.resolve("vxa_bot_ok"))["user_id"] == 7
+
+
+@pytest.mark.parametrize("code", [401, 403, 404, 422])
+async def test_resolve_client_error_is_invalid_key_none(code):
+    """A definitive client-error answer from admin-api: the key is genuinely invalid → None → 401."""
+    auth = _authorizer(lambda req: httpx.Response(code, json={"detail": "nope"}))
+    assert await auth.resolve("vxa_bot_bad") is None
+
+
+@pytest.mark.parametrize("code", [500, 502, 503])
+async def test_resolve_server_error_raises_unavailable(code):
+    """admin-api answered a FAULT (5xx): no verdict on the key → AuthUnavailable → 503, not 401."""
+    auth = _authorizer(lambda req: httpx.Response(code, text="boom"))
+    with pytest.raises(AuthUnavailable):
+        await auth.resolve("vxa_bot_ok")
+
+
+def _raise(exc):
+    def _handler(req):
+        raise exc
+    return _handler
+
+
+@pytest.mark.parametrize("exc", [
+    httpx.ConnectError("refused"),
+    httpx.ReadTimeout("slow"),
+    httpx.PoolTimeout("pool exhausted"),  # the exact #495 mechanism: shared pool starved
+])
+async def test_resolve_transport_failure_raises_unavailable(exc):
+    """Transport failure / timeout (incl. PoolTimeout — the shared-pool starvation itself):
+    no verdict → AuthUnavailable → 503, never a 401 that blames a valid key."""
+    auth = _authorizer(_raise(exc))
+    with pytest.raises(AuthUnavailable):
+        await auth.resolve("vxa_bot_ok")
+
+
+async def test_auth_isolated_from_slow_downstream():
+    """#495 acceptance A1 (unit arm) — validation is decoupled from a slow forward.
+
+    A forward request to meeting-api HANGS in flight; a concurrent validation on the authorizer's
+    OWN client resolves promptly and is never blocked behind it. (httpx.MockTransport does not
+    model real connection-pool exhaustion — that PoolTimeout→503 mapping is proven directly in
+    test_resolve_transport_failure_raises_unavailable, and the end-to-end pool-saturation
+    red→green is the issue's A4 LIVE burst eval. This arm proves the structural decoupling: the
+    authorizer and the downstream forward do not share a client.)"""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_forward(request):
+        started.set()
+        await release.wait()  # a slow meeting-api holding the forward connection open
+        return httpx.Response(200, json={"ok": True})
+
+    forward_client = httpx.AsyncClient(transport=httpx.MockTransport(slow_forward))
+    auth = _authorizer(lambda req: httpx.Response(200, json={"user_id": 7, "scopes": ["bot"]}))
+    downstream = HttpxDownstreamClient(forward_client)
+    assert auth._client is not downstream._client, "authorizer and forward must not share a client"
+
+    hang = asyncio.create_task(downstream.request("GET", "http://meeting-api:8080/meetings"))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    user = await asyncio.wait_for(auth.resolve("vxa_bot_ok"), timeout=1.0)
+    assert user["user_id"] == 7
+    release.set()
+    await hang
+    await forward_client.aclose()

--- a/core/gateway/services/gateway/tests/test_adapters_resolve.py
+++ b/core/gateway/services/gateway/tests/test_adapters_resolve.py
@@ -16,10 +16,22 @@ import pytest
 
 httpx = pytest.importorskip("httpx")
 
-from gateway.adapters import AdminApiAuthorizer, HttpxDownstreamClient
+from gateway.adapters import AdminApiAuthorizer, HttpxDownstreamClient, build_auth_and_downstream
 from gateway.ports import AuthUnavailable
 
 ADMIN = "http://admin-api:8001"
+
+
+def test_build_wires_separate_pools():
+    """#495 acceptance A1 — the GENUINE negative control (redis-free). The production wiring uses
+    TWO distinct httpx clients, so forwarding load cannot starve validation. Reverting the fix (one
+    shared client passed to both authorizer and downstream) turns this RED — unlike the await-level
+    isolation test below, this one exercises the real composition seam (build_auth_and_downstream)."""
+    authorizer, downstream = build_auth_and_downstream(ADMIN, "http://meeting-api:8080")
+    assert authorizer._client is not downstream._client, "auth and forward must use separate clients/pools"
+    # And distinct pool sizing / timeouts (the auth pool is its own, shorter-timeout budget).
+    assert authorizer._client is not None and downstream._client is not None
+    assert authorizer._client.timeout != downstream._client.timeout
 
 
 def _authorizer(handler):
@@ -43,6 +55,22 @@ async def test_resolve_client_error_is_invalid_key_none(code):
 async def test_resolve_server_error_raises_unavailable(code):
     """admin-api answered a FAULT (5xx): no verdict on the key → AuthUnavailable → 503, not 401."""
     auth = _authorizer(lambda req: httpx.Response(code, text="boom"))
+    with pytest.raises(AuthUnavailable):
+        await auth.resolve("vxa_bot_ok")
+
+
+@pytest.mark.parametrize("code", [301, 302, 307])
+async def test_resolve_redirect_is_no_verdict_unavailable(code):
+    """A 3xx is NOT a 'key is invalid' verdict — treat it as no-verdict → 503, never 401 (finding 4)."""
+    auth = _authorizer(lambda req: httpx.Response(code, headers={"location": "/elsewhere"}))
+    with pytest.raises(AuthUnavailable):
+        await auth.resolve("vxa_bot_ok")
+
+
+async def test_resolve_unparseable_200_body_raises_unavailable():
+    """A 200 with a non-JSON body is not a verdict either — no-verdict → 503, not an unhandled 500
+    (finding 3: resp.json() used to run outside the guard)."""
+    auth = _authorizer(lambda req: httpx.Response(200, text="<html>not json</html>"))
     with pytest.raises(AuthUnavailable):
         await auth.resolve("vxa_bot_ok")
 

--- a/core/gateway/services/gateway/tests/test_multiplex.py
+++ b/core/gateway/services/gateway/tests/test_multiplex.py
@@ -14,6 +14,7 @@ import json
 from typing import Optional
 
 from gateway.app import _run_multiplex
+from gateway.ports import AuthUnavailable
 from conftest import FakeAuthorizer, FakeRedis
 
 API_KEY = "vxa_test_unit_key"
@@ -93,6 +94,26 @@ async def test_missing_api_key_closes_4401():
     await _run_multiplex(ws, auth, redis)
     assert ws.sent and ws.sent[0]["error"] == "missing_api_key"
     assert ws.close_code == 4401
+
+
+class _UnavailableAuthorizer:
+    """resolve() raises AuthUnavailable — the auth-infra-down shape on the WS connect hop (#495)."""
+    async def resolve(self, api_key):
+        raise AuthUnavailable("admin-api validate unreachable (test)")
+    async def authorize_subscribe(self, api_key, meetings):
+        return {"authorized": [], "errors": ["unavailable"]}
+
+
+async def test_auth_infra_unavailable_closes_4503_not_4401():
+    """#495 regression guard: when the validation hop is DOWN at WS connect, a VALID key must not
+    crash the socket (uncaught raise → 1006/1011) NOR be told it's invalid (4401). It gets a typed
+    auth_unavailable frame + a distinct retryable close code (4503)."""
+    ws = _WS(inbound=[], api_key=API_KEY)
+    redis = FakeRedis()
+    await _run_multiplex(ws, _UnavailableAuthorizer(), redis)
+    assert ws.sent and ws.sent[0]["error"] == "auth_unavailable"
+    assert ws.close_code == 4503
+    assert ws.sent[0]["error"] != "invalid_api_key"
 
 
 async def test_ping_pong():

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -11,9 +11,21 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gateway import create_app
+from gateway.ports import AuthUnavailable
 from conftest import VALID_KEY, FakeAuthorizer, FakeDownstream, FakeRedis
 
 AUTH = {"x-api-key": VALID_KEY}
+
+
+class UnavailableAuthorizer:
+    """A ``ports.Authorizer`` whose validation hop is DOWN: ``resolve`` raises ``AuthUnavailable``
+    (the #495 shape — admin-api unreachable/slow), so the gateway must answer 503, never 401."""
+
+    async def resolve(self, api_key: str):
+        raise AuthUnavailable("admin-api validate unreachable (test)")
+
+    async def authorize_subscribe(self, api_key, meetings):
+        return {"authorized": [], "errors": ["unavailable"]}
 
 
 def _client(authorizer=None, downstream=None):
@@ -34,6 +46,30 @@ def test_invalid_api_key_is_401():
     r = client.get("/bots/status", headers={"x-api-key": "nope"})
     assert r.status_code == 401
     assert r.json()["detail"] == "Invalid API key"
+
+
+def test_auth_infra_failure_is_503(capsys):
+    """#495 acceptance A2 + A3: when the validation hop is down, a VALID key must not be reported
+    as invalid — the proxy answers 503 + Retry-After, never 401 'Invalid API key' — AND a typed,
+    non-empty auth-infra log line is emitted (FM02: the old silent `except` erased that signal)."""
+    client, downstream = _client(authorizer=UnavailableAuthorizer())
+    r = client.get("/bots/status", headers=AUTH)
+    assert r.status_code == 503
+    assert r.json()["detail"] != "Invalid API key"
+    assert r.headers.get("Retry-After") == "1"
+    # Fail-closed: an unresolved caller is never forwarded downstream.
+    assert downstream.last is None
+    # A3 — the failure is named in a typed, non-empty log line (negative control: the old silent
+    # `except` produced none).
+    assert "auth_infra_unavailable" in capsys.readouterr().out
+
+
+def test_auth_me_unavailable_is_503_not_401():
+    """#495: /auth/me (the dashboard login/session check) maps auth-infra failure to 503 too."""
+    app = create_app(UnavailableAuthorizer(), FakeDownstream(status_code=200, body={}), FakeRedis())
+    r = TestClient(app).get("/auth/me", headers=AUTH)
+    assert r.status_code == 503
+    assert r.json()["detail"] != "Invalid API key"
 
 
 def test_insufficient_scope_is_403():


### PR DESCRIPTION
Closes #495 (offline acceptance arm). Refs #483 #479 #482 #484.

## Value

> A valid API key authenticates on every call — including while the system is slow or under load — and when our auth infrastructure itself fails, the caller is told the truth (503, retry), never "Invalid API key".

## Root cause (named)

The gateway built **one** `httpx.AsyncClient` (pool cap 10, `timeout=30s`) and used it for two unrelated jobs: **forwarding** to meeting-api (long-lived) and **validating** API keys against admin-api (~5ms). When meeting-api slowed, forwards occupied the whole pool → the validation POST queued and timed out → `resolve()` swallowed the exception and returned `None` → the app rendered that as `401 Invalid API key`. Valid keys mass-401'd under load (Jul 7–9, #483).

## The fix (one diff, two values — D5b bundle)

1. **Isolate the pools.** `build_production_app` now builds **two** clients with separate connection pools: `forward_client` (proxy hop) and `auth_client` (`/internal/validate` only). Validation can no longer be starved by downstream load.
2. **Tell the truth on infra failure.** `resolve()` now returns a **three-way** verdict:
   - admin-api `200` → user dict (valid)
   - admin-api `4xx` (401/403/404/422) → `None` → **401** (key genuinely invalid)
   - transport error / timeout / `5xx` → raise `AuthUnavailable` → **503 + Retry-After** (no verdict; retry)
   
   A typed, non-empty `auth_infra_unavailable` log line replaces the old silent `except` (incident FM02). The WS subscribe path degrades to an authorization error, not a 500.

## Acceptance table (offline arm)

| # | Observation | Status |
|---|---|---|
| A1 | `test_auth_isolated_from_slow_downstream` — validation resolves while a forward hangs; authorizer/forward proven to not share a client | ✅ |
| A2 | `test_auth_infra_failure_is_503` — dead/faulted admin-api ⇒ 503 + `Retry-After`, never "Invalid API key" | ✅ |
| A3 | Typed, non-empty `auth_infra_unavailable` log line asserted (negative control: old silent `except` → none) | ✅ |
| — | Adapter verdict mapping 200/4xx/5xx/transport incl. **PoolTimeout→AuthUnavailable** (the exact mechanism) | ✅ |
| A6 | No-regression: gateway unit **75 passed**, conformance **79 passed** | ✅ |

**A4 (live burst eval: saturation + valid-key loop → `300/300 OK, 401s: 0`), A5 (same key after admin-api restore; token count unchanged), and the hosted-0.10 backport** are the operator-signed rows — `httpx.MockTransport` can't model real pool exhaustion, so end-to-end pool-starvation red→green is intentionally the live arm.

## Scope

- **In:** gateway auth-path isolation + failure semantics + tests.
- **Out (sibling issues):** meeting-api holding DB txns across awaited I/O (#508, the load source) · dashboard token-mint-per-sign-in (platform-side).