### PR TITLE
meeting-api: transcript reads release the DB before the Redis merge (#508)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/README.md
@@ -28,6 +28,21 @@ Never imports another domain's internals: the SQLAlchemy models are a self-conta
 are pinned in `pyproject.toml`; `scheduling` (croniter) + `webhooks` (redis) are exposed lazily so a
 consumer that only drives the REST surface needs neither.
 
+## Transaction scope — a session block awaits only the session (#508)
+
+**Rule:** inside `async with session_factory() as db:`, await *only* the session (`db.execute`,
+`db.commit`, …) or a helper you hand `db` to. **Never await a different backend — Redis, httpx, S3,
+the runtime — while a session is live.** Finish and close the DB work first, snapshot the rows you
+need to plain values, *then* do the other I/O. A backend left `idle in transaction` across a slow
+Redis/HTTP wait pins its pooled connection and convoys every other handler on the DB — the shape of
+the 2026-07-09 lock-convoy incident (transcript reads held a transaction open across the live-segment
+`hgetall`; fixed by splitting `_transcript_doc` into a DB-only phase and a post-session merge).
+
+This is enforced statically by **`tests/test_tx_scope.py`** (stdlib `ast`, no deps): it fails on any
+`await` of non-session I/O inside a session block, and on any `async def` that receives a live
+session and awaits another backend. A genuinely-legitimate case goes in that file's `ALLOWLIST` with
+a one-line justification — a reviewed decision, never a silent hole.
+
 ## P3 seams (NOT built here)
 continue_meeting, max-bots / join-retry (bot_spawn), the always-on segments consumer loop
 (collector), the master byte-stream download (recordings), and the production composition root that

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -237,12 +237,23 @@ class SqlAlchemyTranscriptStore:
             self._native_cache[mid] = pair
             return pair
 
-    async def _transcript_doc(self, db, meeting) -> dict:
-        """Build the api.v1 ``TranscriptionResponse`` dict for a resolved ``meeting`` ROW — the shared
-        body used by BOTH ``get_transcript`` (native → newest row) and ``get_transcript_by_id`` (exact
-        row). Reads the row's persisted ``transcriptions`` + merges the live redis in-flight hash, all
-        keyed by ``meeting.id`` (the row id) — so a by-id read returns EXACTLY that row's segments/notes,
-        never a sibling row's (the wrong-row hydration fix)."""
+    # #508: the transcript doc is built in TWO phases so the (possibly slow) Redis merge never
+    # happens while a Postgres backend sits idle-in-transaction. Phase 1 (_transcript_pg_part) runs
+    # INSIDE the session: it does all DB work and snapshots the row fields to plain values. The
+    # caller then EXITS the session block — ending the transaction and returning the connection to
+    # the pool — and only THEN calls phase 2 (_merge_live_segments), which awaits Redis with no DB
+    # session in scope. The response is byte-identical to the old single-pass build; only the
+    # transaction scope changes. (See C2's tx-scope gate, which enforces this shape for good.)
+
+    async def _transcript_pg_part(self, db, meeting) -> "tuple[dict, dict, list]":
+        """DB-ONLY half: SELECT the persisted ``transcriptions`` for this row and SNAPSHOT every
+        meeting-row field the response needs into plain values — all while the session is live.
+        Returns ``(snap, seg_by_id, order)``. Nothing here awaits a non-DB backend, so the caller's
+        transaction stays scoped to Postgres statements only (#508).
+
+        The row fields are copied to a plain dict on purpose: after the session closes, touching an
+        expired ORM attribute raises ``MissingGreenlet`` — the same reason ``bot_spawn/adapters.py``
+        snapshots before returning (``:192-194``)."""
         from sqlalchemy import select
 
         from .models import Transcription
@@ -266,12 +277,32 @@ class SqlAlchemyTranscriptStore:
             if sid not in seg_by_id:
                 order.append(sid)
             seg_by_id[sid] = s
+        # Snapshot every field the response body reads, INSIDE the live session (see docstring).
+        snap = {
+            "id": meeting.id,
+            "platform": meeting.platform,
+            "platform_specific_id": meeting.platform_specific_id,
+            "status": meeting.status,
+            "start_time": meeting.start_time,
+            "end_time": meeting.end_time,
+            "created_at": meeting.created_at,
+            "data": data,
+        }
+        return snap, seg_by_id, order
+
+    async def _merge_live_segments(self, pg: "tuple[dict, dict, list]") -> dict:
+        """POST-SESSION half: merge the LIVE Redis in-flight hash, sort, derive absolute times, and
+        assemble the api.v1 ``TranscriptionResponse`` dict. NO database session is open here — this
+        is where the (possibly slow) Redis await happens, so it can never pin a pooled connection or
+        hold a snapshot/transaction open (the #508 fix). Response is byte-identical to the old build."""
+        snap, seg_by_id, order = pg
+        data = snap["data"]
         # Merge the LIVE Redis hash of in-flight segments (``meeting:{id}:segments``) — the source
         # of truth before/until the db-writer flush. The carve had dropped this merge, so a transcript
         # whose segments are still only in Redis (every short/just-finished meeting) read as EMPTY.
         if self._redis is not None:
             try:
-                raw = await self._redis.hgetall(f"meeting:{meeting.id}:segments")
+                raw = await self._redis.hgetall(f"meeting:{snap['id']}:segments")
                 for v in (raw.values() if isinstance(raw, dict) else []):
                     try:
                         seg = json.loads(v.decode() if isinstance(v, (bytes, bytearray)) else v)
@@ -288,15 +319,15 @@ class SqlAlchemyTranscriptStore:
         # The dashboard's renderer SKIPS any segment without absolute_start_time
         # (use-vexa-websocket.ts: `if (!seg.absolute_start_time) continue`). Derive it when a producer
         # didn't supply it, so the historical transcript renders. See `_fill_absolute_times`.
-        _fill_absolute_times(segments, meeting.start_time or meeting.created_at)
+        _fill_absolute_times(segments, snap["start_time"] or snap["created_at"])
         return {
-            "id": meeting.id,
-            "platform": meeting.platform,
-            "native_meeting_id": meeting.platform_specific_id,
+            "id": snap["id"],
+            "platform": snap["platform"],
+            "native_meeting_id": snap["platform_specific_id"],
             "constructed_meeting_url": (data.get("constructed_meeting_url")),
-            "status": meeting.status,
-            "start_time": meeting.start_time.isoformat() if meeting.start_time else None,
-            "end_time": meeting.end_time.isoformat() if meeting.end_time else None,
+            "status": snap["status"],
+            "start_time": snap["start_time"].isoformat() if snap["start_time"] else None,
+            "end_time": snap["end_time"].isoformat() if snap["end_time"] else None,
             "recordings": data.get("recordings", []),
             "notes": data.get("notes"),
             "data": data,
@@ -321,7 +352,9 @@ class SqlAlchemyTranscriptStore:
             meeting = (await db.execute(stmt)).scalars().first()
             if not meeting:
                 return None
-            return await self._transcript_doc(db, meeting)
+            pg = await self._transcript_pg_part(db, meeting)
+        # Session closed (transaction ended, connection returned to pool) BEFORE the Redis merge (#508).
+        return await self._merge_live_segments(pg)
 
     async def get_transcript_by_id(self, user_id, meeting_id, member_workspaces=None) -> Optional[dict]:
         """Exact-row transcript for ``meeting.id == meeting_id``, authorized by the SAME three-way rule as
@@ -348,7 +381,9 @@ class SqlAlchemyTranscriptStore:
             )
             if not authorized:
                 return None
-            return await self._transcript_doc(db, meeting)
+            pg = await self._transcript_pg_part(db, meeting)
+        # Session closed (transaction ended, connection returned to pool) BEFORE the Redis merge (#508).
+        return await self._merge_live_segments(pg)
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None):
         from sqlalchemy import cast, func, or_, select

--- a/core/meetings/services/meeting-api/tests/test_transcript_merge.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_merge.py
@@ -1,0 +1,78 @@
+"""#508 · A3 direct coverage of the REFACTORED SqlAlchemyTranscriptStore (not the in-memory fake).
+
+The collector fake-lane exercises ``InMemoryTranscriptStore``; this pins the actual changed code —
+``SqlAlchemyTranscriptStore._merge_live_segments`` (the post-session half that assembles the
+response and merges the live Redis hash). It needs no SQLAlchemy (the DB half ``_transcript_pg_part``
+is gated by test_tx_scope + the live A2/A3 probes); it drives the merge with a redis stub, so a
+regression in field set / key order / sort / absolute-time derivation / the Redis merge is caught
+offline. The Redis-only-segment assertion IS the negative control: delete the post-session merge and
+``s-redis`` disappears → this test goes red (the same guard the issue names at adapters.py:237-239).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from meeting_api.collector.adapters import SqlAlchemyTranscriptStore, _segment_to_api
+
+START = datetime(2026, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+CREATED = datetime(2026, 7, 14, 11, 59, 0, tzinfo=timezone.utc)
+
+# The exact key set + order _merge_live_segments must emit (byte-identical to the pre-split build).
+EXPECTED_KEYS = ["id", "platform", "native_meeting_id", "constructed_meeting_url", "status",
+                 "start_time", "end_time", "recordings", "notes", "data", "segments"]
+
+
+class _RedisStub:
+    def __init__(self, hash_map):
+        self._hash_map = hash_map
+
+    async def hgetall(self, key):
+        return self._hash_map.get(key, {})
+
+
+def _snap():
+    return {
+        "id": 5, "platform": "google_meet", "platform_specific_id": "abc-defg-hij",
+        "status": "active", "start_time": START, "end_time": None, "created_at": CREATED,
+        "data": {"constructed_meeting_url": "https://meet.google.com/abc-defg-hij",
+                 "recordings": [{"id": "r1"}], "notes": "hi"},
+    }
+
+
+def _pg_part():
+    """One persisted (Postgres) segment, as _transcript_pg_part would have built it."""
+    s = _segment_to_api({"start": 5.0, "end": 6.0, "text": "persisted", "segment_id": "s-pg",
+                         "completed": True})
+    return {"s-pg": s}, ["s-pg"]
+
+
+async def test_merge_assembles_response_and_merges_live_redis():
+    seg_by_id, order = _pg_part()
+    redis = _RedisStub({"meeting:5:segments": {
+        "s-redis": json.dumps({"start": 1.0, "end": 2.0, "text": "in-flight", "segment_id": "s-redis"})}})
+    store = SqlAlchemyTranscriptStore(session_factory=None, redis_client=redis)
+
+    doc = await store._merge_live_segments((_snap(), seg_by_id, order))
+
+    # Top-level shape: exact keys, exact order.
+    assert list(doc.keys()) == EXPECTED_KEYS
+    assert doc["id"] == 5 and doc["platform"] == "google_meet"
+    assert doc["native_meeting_id"] == "abc-defg-hij"
+    assert doc["status"] == "active"
+    assert doc["start_time"] == START.isoformat() and doc["end_time"] is None
+    assert doc["notes"] == "hi" and doc["recordings"] == [{"id": "r1"}]
+    # The live Redis-only segment is merged in AND sorted before the later persisted one.
+    ids = [s["segment_id"] for s in doc["segments"]]
+    assert ids == ["s-redis", "s-pg"], "redis-only in-flight segment must be merged and sorted by start"
+    # absolute_start_time derived for every segment (the dashboard skips segments without it).
+    assert all(s.get("absolute_start_time") for s in doc["segments"])
+
+
+async def test_merge_without_redis_returns_persisted_only():
+    """redis_client=None (or an empty hash) → the persisted segments still assemble cleanly, no crash."""
+    seg_by_id, order = _pg_part()
+    store = SqlAlchemyTranscriptStore(session_factory=None, redis_client=None)
+    doc = await store._merge_live_segments((_snap(), seg_by_id, order))
+    assert [s["segment_id"] for s in doc["segments"]] == ["s-pg"]
+    assert list(doc.keys()) == EXPECTED_KEYS

--- a/core/meetings/services/meeting-api/tests/test_tx_scope.py
+++ b/core/meetings/services/meeting-api/tests/test_tx_scope.py
@@ -1,0 +1,187 @@
+"""#508 · C2 — the tx-scope gate (FM03: a DB transaction held open across an awaited non-DB call).
+
+A stdlib-``ast`` gate over ``src/meeting_api/**/*.py``. It fails on either shape of the defect:
+
+  Rule 1 (lexical) — an ``await`` INSIDE an ``async with … session_factory() as <db> …`` block whose
+      awaited expression is neither rooted at ``<db>`` NOR passes ``<db>`` as an argument. The second
+      carve lets a block delegate to a DB-only helper (``await self._x(db, …)``) without a false
+      positive — that helper is itself checked by Rule 2.
+
+  Rule 2 (semantic) — an ``async def`` that RECEIVES a live session (a param named ``db``/``session``
+      or annotated ``*Session``) and awaits anything not rooted at that param (and not passing it
+      along). This is the rule that catches the helper indirection a purely lexical scan misses:
+      the pre-fix ``_transcript_doc(self, db, meeting)`` awaited ``self._redis.hgetall`` while holding
+      the caller's session — the exact 2026-07-09 lock-convoy source.
+
+No new dependencies — stdlib ``ast`` only, so the gate runs in meeting-api's SQLAlchemy-free test
+venv. It is static and cannot see dynamic dispatch; the live ``pg_stat_activity`` probe (issue A2)
+corroborates it. A legitimate future case is added to ALLOWLIST as a reviewed decision — never a
+silent hole.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# Package source root (…/meeting-api/src/meeting_api).
+SRC = Path(__file__).resolve().parent.parent / "src" / "meeting_api"
+
+# Reviewed exceptions: "<relpath>:<lineno>" → one-line justification. Empty by design at ship.
+ALLOWLIST: dict[str, str] = {}
+
+# Param is a live DB session if named one of these OR annotated with a name ending in "Session".
+_SESSION_PARAM_NAMES = {"db", "session"}
+
+
+def _root_name(node: ast.AST) -> str | None:
+    """The base ``Name`` of a call/attribute/subscript chain (unwrapping an ``Await`` first).
+    ``await db.execute(...)`` → ``db``; ``await self._redis.hgetall(...)`` → ``self``."""
+    n = node
+    while True:
+        if isinstance(n, ast.Await):
+            n = n.value
+        elif isinstance(n, ast.Call):
+            n = n.func
+        elif isinstance(n, ast.Attribute):
+            n = n.value
+        elif isinstance(n, ast.Subscript):
+            n = n.value
+        else:
+            break
+    return n.id if isinstance(n, ast.Name) else None
+
+
+def _passes_alias(await_node: ast.Await, alias: str) -> bool:
+    """True if the awaited call passes ``alias`` anywhere in its arguments — i.e. delegates the live
+    session to a helper (that helper is separately gated by Rule 2). Also covers ``asyncio.gather``
+    /comprehension shapes where the db work is nested inside the call args."""
+    val = await_node.value
+    if not isinstance(val, ast.Call):
+        return False
+    for arg in list(val.args) + [kw.value for kw in val.keywords]:
+        for sub in ast.walk(arg):
+            if isinstance(sub, ast.Name) and sub.id == alias:
+                return True
+    return False
+
+
+def _session_params(fn: ast.AST) -> set[str]:
+    """Names of parameters that carry a live session (by name or ``*Session`` annotation)."""
+    names: set[str] = set()
+    args = fn.args
+    for a in list(args.posonlyargs) + list(args.args) + list(args.kwonlyargs):
+        if a.arg in _SESSION_PARAM_NAMES:
+            names.add(a.arg)
+        ann = a.annotation
+        # unwrap Optional[AsyncSession] etc.
+        for sub in ast.walk(ann) if ann is not None else []:
+            if isinstance(sub, ast.Name) and sub.id.endswith("Session"):
+                names.add(a.arg)
+            if isinstance(sub, ast.Attribute) and sub.attr.endswith("Session"):
+                names.add(a.arg)
+    return names
+
+
+def _awaits_in(node: ast.AST):
+    """Yield every ``Await`` under ``node`` WITHOUT descending into nested function bodies (those
+    have their own parameter scope and are visited on their own)."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        if isinstance(child, ast.Await):
+            yield child
+        yield from _awaits_in(child)
+
+
+def _is_session_ctx(item: ast.withitem) -> str | None:
+    """If a ``with`` item opens a ``*session_factory()`` context bound to a name, return that name."""
+    ctx = item.context_expr
+    if isinstance(ctx, ast.Call):
+        f = ctx.func
+        name = f.attr if isinstance(f, ast.Attribute) else (f.id if isinstance(f, ast.Name) else "")
+        if name.endswith("session_factory") or name == "sessionmaker":
+            if isinstance(item.optional_vars, ast.Name):
+                return item.optional_vars.id
+    return None
+
+
+def _scan_file(path: Path) -> list[tuple[int, str, str]]:
+    rel = str(path.relative_to(SRC.parent.parent))
+    tree = ast.parse(path.read_text(), filename=str(path))
+    findings: list[tuple[int, str, str]] = []
+
+    def _record(lineno: int, rule: str, detail: str):
+        if f"{rel}:{lineno}" in ALLOWLIST:
+            return
+        findings.append((lineno, rule, detail))
+
+    # Rule 1 — awaits lexically inside a session_factory() block.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            aliases = {a for a in (_is_session_ctx(it) for it in node.items) if a}
+            if not aliases:
+                continue
+            for aw in _awaits_in(node):
+                root = _root_name(aw)
+                if root in aliases:
+                    continue
+                if any(_passes_alias(aw, a) for a in aliases):
+                    continue
+                _record(aw.lineno, "R1",
+                         f"await inside session block ({'/'.join(sorted(aliases))}) not rooted at "
+                         f"the session (root={root!r})")
+
+    # Rule 2 — async defs that receive a live session and await non-session I/O.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        params = _session_params(node)
+        if not params:
+            continue
+        for aw in _awaits_in(node):
+            root = _root_name(aw)
+            if root in params:
+                continue
+            if any(_passes_alias(aw, p) for p in params):
+                continue
+            _record(aw.lineno, "R2",
+                    f"{node.name}() holds a live session ({'/'.join(sorted(params))}) and awaits "
+                    f"non-session I/O (root={root!r})")
+
+    return findings
+
+
+def scan_package() -> list[str]:
+    """All findings across the package as sorted 'relpath:line [rule] detail' strings."""
+    out: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        rel = str(path.relative_to(SRC.parent.parent))
+        for lineno, rule, detail in _scan_file(path):
+            out.append(f"{rel}:{lineno} [{rule}] {detail}")
+    return sorted(out)
+
+
+def test_no_session_held_across_non_db_await():
+    """The FM03 pattern must not exist anywhere in meeting_api. Red at base (one finding:
+    `_transcript_doc` awaiting `self._redis.hgetall` with a live session), green at head."""
+    findings = scan_package()
+    assert findings == [], "tx-scope violations (session held across non-DB await):\n" + "\n".join(findings)
+
+
+def test_gate_detects_a_planted_violation(tmp_path):
+    """Negative control: the gate actually fires on the defect shape (so a green run means clean,
+    not broken). Plants a helper that takes `db` and awaits redis, and asserts R2 catches it."""
+    src = (
+        "import ast\n"
+        "class S:\n"
+        "    async def bad(self, db):\n"
+        "        await db.execute('x')\n"
+        "        await self._redis.hgetall('k')\n"  # the violation
+    )
+    # Use the ast helpers directly (not _scan_file, whose relpath is computed against the package root).
+    tree = ast.parse(src)
+    fn = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+    assert _session_params(fn) == {"db"}
+    bad_awaits = [aw for aw in _awaits_in(fn)
+                  if _root_name(aw) not in {"db"} and not _passes_alias(aw, "db")]
+    assert len(bad_awaits) == 1 and bad_awaits[0].lineno == 5

--- a/core/meetings/services/meeting-api/tests/test_tx_scope.py
+++ b/core/meetings/services/meeting-api/tests/test_tx_scope.py
@@ -30,7 +30,7 @@ SRC = Path(__file__).resolve().parent.parent / "src" / "meeting_api"
 ALLOWLIST: dict[str, str] = {}
 
 # Param is a live DB session if named one of these OR annotated with a name ending in "Session".
-_SESSION_PARAM_NAMES = {"db", "session"}
+_SESSION_PARAM_NAMES = {"db", "session", "conn", "connection"}
 
 
 def _root_name(node: ast.AST) -> str | None:
@@ -51,17 +51,34 @@ def _root_name(node: ast.AST) -> str | None:
     return n.id if isinstance(n, ast.Name) else None
 
 
+_GATHER_FUNCS = {"gather", "wait", "as_completed"}
+
+
 def _passes_alias(await_node: ast.Await, alias: str) -> bool:
-    """True if the awaited call passes ``alias`` anywhere in its arguments — i.e. delegates the live
-    session to a helper (that helper is separately gated by Rule 2). Also covers ``asyncio.gather``
-    /comprehension shapes where the db work is nested inside the call args."""
+    """True if the awaited call is a genuine DELEGATION of the live session to DB-only work — not a
+    concurrent non-DB coroutine that merely mentions the session.
+
+    * ``asyncio.gather``/``wait``/``as_completed``(...): safe ONLY if EVERY coroutine argument is
+      itself rooted at the session alias (all DB work). If any arg's root is not the alias — e.g.
+      ``gather(self._redis.hgetall(k), db.execute(q))`` — a non-session coroutine runs WHILE the
+      transaction is held, which is exactly FM03; not delegation → the caller flags it. (A ``*tasks``
+      splat is unprovable → not delegation.)
+    * any other call: delegation iff a TOP-LEVEL argument is exactly ``Name(alias)`` — ``helper(db)``
+      or ``helper(session=db)``, where the callee receives the session and is gated by Rule 2. A
+      merely-nested mention (``foo(bar(db))``) is NOT delegation (the outer call is not DB work)."""
     val = await_node.value
     if not isinstance(val, ast.Call):
         return False
+    f = val.func
+    fname = f.attr if isinstance(f, ast.Attribute) else (f.id if isinstance(f, ast.Name) else "")
+    if fname in _GATHER_FUNCS:
+        coro_args = [a for a in val.args if not isinstance(a, ast.Starred)]
+        if len(coro_args) != len(val.args):  # a *splat is present — cannot prove all are DB work
+            return False
+        return bool(coro_args) and all(_root_name(a) == alias for a in coro_args)
     for arg in list(val.args) + [kw.value for kw in val.keywords]:
-        for sub in ast.walk(arg):
-            if isinstance(sub, ast.Name) and sub.id == alias:
-                return True
+        if isinstance(arg, ast.Name) and arg.id == alias:
+            return True
     return False
 
 
@@ -99,7 +116,9 @@ def _is_session_ctx(item: ast.withitem) -> str | None:
     if isinstance(ctx, ast.Call):
         f = ctx.func
         name = f.attr if isinstance(f, ast.Attribute) else (f.id if isinstance(f, ast.Name) else "")
-        if name.endswith("session_factory") or name == "sessionmaker":
+        # session_factory()/sessionmaker() AND engine.begin()/session.begin() — the ways a session or
+        # transaction context is opened in this package (begin() covers the engine.begin() shape).
+        if name.endswith("session_factory") or name in ("sessionmaker", "begin"):
             if isinstance(item.optional_vars, ast.Name):
                 return item.optional_vars.id
     return None
@@ -185,3 +204,36 @@ def test_gate_detects_a_planted_violation(tmp_path):
     bad_awaits = [aw for aw in _awaits_in(fn)
                   if _root_name(aw) not in {"db"} and not _passes_alias(aw, "db")]
     assert len(bad_awaits) == 1 and bad_awaits[0].lineno == 5
+
+
+def _first_await(src: str) -> ast.Await:
+    return next(n for n in ast.walk(ast.parse(src)) if isinstance(n, ast.Await))
+
+
+def test_gather_mixing_redis_and_db_is_not_delegation():
+    """Closes the gate's asyncio.gather false negative: a gather that runs a NON-session coroutine
+    concurrently with the held transaction is NOT delegation → R1 flags it (root != alias and not a
+    pass-through). This is the FM03 defect hidden inside a gather."""
+    aw = _first_await("import asyncio\nasync def f(self, db):\n await asyncio.gather(self._redis.hgetall('k'), db.execute('q'))\n")
+    assert _root_name(aw) != "db"           # rooted at asyncio, so R1/R2 examine it
+    assert _passes_alias(aw, "db") is False  # NOT treated as delegation → flagged
+
+
+def test_gather_of_only_db_calls_is_allowed():
+    """Control for the above: a gather whose every coroutine is session-rooted IS delegation (safe
+    concurrent DB work) and must NOT be flagged — otherwise the rule would false-positive."""
+    aw = _first_await("import asyncio\nasync def f(self, db):\n await asyncio.gather(db.execute('a'), db.execute('b'))\n")
+    assert _passes_alias(aw, "db") is True
+
+
+def test_conn_named_session_helper_is_scanned_by_r2():
+    """Closes the 'helper receives the session under a non-standard name' false negative: a helper
+    taking `conn` (not `db`/`session`) that awaits redis is now caught by R2."""
+    src = ("class S:\n"
+           "    async def helper(self, conn, meeting):\n"
+           "        await conn.execute('q')\n"
+           "        await self._redis.hgetall('k')\n")
+    fn = next(n for n in ast.walk(ast.parse(src)) if isinstance(n, ast.AsyncFunctionDef))
+    assert "conn" in _session_params(fn)
+    bad = [aw for aw in _awaits_in(fn) if _root_name(aw) not in {"conn"} and not _passes_alias(aw, "conn")]
+    assert len(bad) == 1 and bad[0].lineno == 4  # the redis await, not conn.execute


### PR DESCRIPTION
Closes #508 (offline acceptance arm). Refs #495 (the incident's other half).

## Value

> **V1** — polling `GET /transcripts` under busy-hour load never leaves a meeting-api database transaction idle across a Redis wait, so transcript reads can no longer pin connections or convoy the `meetings` table.
> **V2** — a standing gate fails on ANY code path that awaits non-DB I/O while a database session is live, so the pattern cannot silently return.

## Root cause

`get_transcript` / `get_transcript_by_id` opened `async with session_factory() as db:`, SELECTed, then called `_transcript_doc(db, meeting)` — which `await self._redis.hgetall(...)` **while the session was still live**. Each in-flight poll pinned a pooled connection for the whole Redis wait and left the backend `idle in transaction` (the 2026-07-09 lock convoy; the DB slowness then starved the gateway pool → #495).

## C1 — release the DB before the wait

Split the doc build:
- **`_transcript_pg_part(db, meeting)`** — inside the session: SELECT persisted segments + **snapshot** the meeting-row fields to plain values (avoids `MissingGreenlet` on expired ORM attrs post-close).
- **`_merge_live_segments(pg)`** — after the `async with` block exits: merge the live Redis hash, sort, derive absolute times. **No DB session in scope.**

Response is byte-identical; only the transaction scope changes.

## C2 — the tx-scope gate (`tests/test_tx_scope.py`)

Stdlib-`ast`, zero new deps (venv stays SQLAlchemy-free). Fails on:
- **R1** — an `await` of non-session I/O inside a `session_factory()` block (allows `await helper(db, …)` delegation);
- **R2** — an `async def` that receives a live session and awaits another backend — catches the helper indirection a lexical scan misses.

Empty, documented `ALLOWLIST` so a future legit case is a reviewed decision.

## Acceptance table (offline arm)

| # | Observation | Status |
|---|---|---|
| A1 (V2) | Gate **RED at base** — exactly one finding: `adapters.py:274 [R2] _transcript_doc() holds a live session and awaits non-session I/O` — **GREEN at head** | ✅ |
| A3 (V1) | Collector merge regressions green incl. the Redis-only-segments guard; planted-violation control proves the gate fires | ✅ |
| A- | No-regression: meeting-api lane **636 passed, 2 skipped** | ✅ |

**A2 / A4** (full-compose, real Postgres: `pg_stat_activity` shows zero `idle in transaction` under a slowed-Redis transcript read; a concurrent `ALTER TABLE meetings` acquires its lock without queuing; 50 concurrent polls don't stall lifecycle writes) are the **operator-signed live rows** — they need a real DB + Redis, which the offline lane deliberately excludes.

## Docs (D6c)

- Module README: the session-scope rule + the gate that enforces it (in this PR).
- Follow-up (docs.vexa.ai, separate Mintlify repo): the self-hosting troubleshooting section ("`idle in transaction` from meeting-api" + the `idle_in_transaction_session_timeout` backstop).

## Scope

- **In:** the `SqlAlchemyTranscriptStore` read seam + the tx-scope gate.
- **Out:** hosted-0.10 backport (open question Q1); the operational reaper stays until it ships.