### PR TITLE
meeting-api + runtime: harden bare Redis clients + standing gate (#528)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -78,7 +78,15 @@ def build_production_app():
 
     engine = create_async_engine(database_url, pool_pre_ping=True)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    redis_client = aioredis.from_url(redis_url, decode_responses=True)
+    # #528: harden the shared Redis client so a Redis outage surfaces as a bounded exception the
+    # per-tick handlers already catch — not a hung/zombie socket that only a restart heals. Same
+    # kwargs as the gateway (adapters.py): socket_timeout bounds every await, keepalive + health
+    # checks detect a dead peer, connect timeout bounds re-dial, retry_on_timeout re-issues once.
+    redis_client = aioredis.from_url(
+        redis_url, decode_responses=True,
+        socket_timeout=10, socket_connect_timeout=5, socket_keepalive=True,
+        health_check_interval=30, retry_on_timeout=True,
+    )
 
     # Per-module production adapters (each module's adapters.* builders) injected into create_app.
     transcript_store = SqlAlchemyTranscriptStore(session_factory, redis_client=redis_client)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -975,7 +975,13 @@ def build_production_app(
 
     engine = create_async_engine(database_url, pool_pre_ping=True)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    redis_client = aioredis.from_url(redis_url, decode_responses=True)
+    # #528: hardened Redis client (see meeting_api/__main__.py) — bounded timeouts + keepalive +
+    # health checks so a Redis blip self-heals within socket_timeout instead of hanging the consumer.
+    redis_client = aioredis.from_url(
+        redis_url, decode_responses=True,
+        socket_timeout=10, socket_connect_timeout=5, socket_keepalive=True,
+        health_check_interval=30, retry_on_timeout=True,
+    )
 
     store = SqlAlchemyTranscriptStore(session_factory, redis_client=redis_client)
     bus = RedisStreamBus(redis_client)

--- a/core/meetings/services/meeting-api/tests/test_redis_client_hardening.py
+++ b/core/meetings/services/meeting-api/tests/test_redis_client_hardening.py
@@ -1,0 +1,79 @@
+"""#528 · B1 (meeting-api lane) — the standing gate: no bare Redis client construction.
+
+A stdlib-``ast`` gate over ``src/meeting_api/**/*.py``. It fails on any Redis client construction
+(``redis.from_url`` / ``aioredis.from_url`` / any ``*.from_url`` alias, or ``Redis(...)`` /
+``StrictRedis(...)``) whose kwargs lack BOTH ``socket_timeout`` AND ``health_check_interval`` — the
+"bare client" shape that, on the 2026-04-21 / 04-26 incidents, kept broken connections after a Redis
+outage until every service was manually restarted (no timeout → the socket never raises; no health
+check → the pool never revalidates).
+
+Rooted at meeting_api only (the runtime lane has a twin at core/runtime/tests). Zero new deps —
+stdlib ``ast`` — so it runs in the SQLAlchemy-free gate venv. A legitimate future bare client goes
+in ALLOWLIST as a reviewed decision, never a silent hole.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "meeting_api"
+
+# Reviewed exceptions: "<relpath>:<lineno>" → justification. Empty by design: both in-src sites hardened.
+ALLOWLIST: dict[str, str] = {}
+
+REQUIRED = {"socket_timeout", "health_check_interval"}
+
+
+def _is_redis_construction(call: ast.Call) -> bool:
+    f = call.func
+    if isinstance(f, ast.Attribute):
+        if f.attr == "from_url":
+            return True
+        if f.attr in {"Redis", "StrictRedis"}:
+            return True
+    if isinstance(f, ast.Name) and f.id in {"Redis", "StrictRedis"}:
+        return True
+    return False
+
+
+def _kwarg_names(call: ast.Call) -> set[str]:
+    names = {kw.arg for kw in call.keywords if kw.arg is not None}
+    # a **kwargs splat could carry them dynamically — treat as satisfied (can't prove otherwise),
+    # but that is a deliberate escape hatch, not the shape we're guarding.
+    if any(kw.arg is None for kw in call.keywords):
+        names |= REQUIRED
+    return names
+
+
+def scan(root: Path = SRC) -> list[str]:
+    findings: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = str(path.relative_to(root.parent.parent))
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_redis_construction(node):
+                if f"{rel}:{node.lineno}" in ALLOWLIST:
+                    continue
+                missing = REQUIRED - _kwarg_names(node)
+                if missing:
+                    findings.append(f"{rel}:{node.lineno} bare redis client — missing {sorted(missing)}")
+    return sorted(findings)
+
+
+def test_no_bare_redis_clients():
+    """Every Redis client in meeting_api sets socket_timeout + health_check_interval. RED at base
+    (2 findings: __main__.py + collector/adapters.py), GREEN at head. Negative control: dropping the
+    kwargs from either site re-adds its finding."""
+    findings = scan()
+    assert findings == [], "bare Redis client construction (see #528):\n" + "\n".join(findings)
+
+
+def test_gate_detects_a_bare_client(tmp_path):
+    """The gate actually fires on the bare shape (so green means clean, not broken)."""
+    (tmp_path / "m").mkdir(parents=True)
+    (tmp_path / "m" / "x.py").write_text("import redis.asyncio as r\nc = r.from_url('redis://x', decode_responses=True)\n")
+    bad = scan(tmp_path / "m")
+    assert len(bad) == 1 and "missing" in bad[0]
+    (tmp_path / "m" / "x.py").write_text(
+        "import redis.asyncio as r\nc = r.from_url('redis://x', socket_timeout=10, health_check_interval=30)\n")
+    assert scan(tmp_path / "m") == []

--- a/core/runtime/src/runtime_kernel/__main__.py
+++ b/core/runtime/src/runtime_kernel/__main__.py
@@ -59,7 +59,14 @@ def _build_scheduler():
 
     from .scheduler import Scheduler
 
-    client = redis_lib.from_url(redis_url, decode_responses=True)
+    # #528: hardened Redis client (mirrors gateway/meeting-api) — bounded socket + connect timeouts,
+    # keepalive, and periodic health checks so a Redis outage makes the scheduler tick raise (caught
+    # per-tick) and /health go red, instead of the tick thread hanging on a dead socket forever.
+    client = redis_lib.from_url(
+        redis_url, decode_responses=True,
+        socket_timeout=10, socket_connect_timeout=5, socket_keepalive=True,
+        health_check_interval=30, retry_on_timeout=True,
+    )
     return Scheduler(client, dispatch=_http_dispatch)
 
 

--- a/core/runtime/tests/test_redis_client_hardening.py
+++ b/core/runtime/tests/test_redis_client_hardening.py
@@ -1,0 +1,66 @@
+"""#528 · B1 (runtime lane) — the standing gate: no bare Redis client construction.
+
+Twin of core/meetings/services/meeting-api/tests/test_redis_client_hardening.py, rooted at the
+runtime_kernel package. Kept identical by contract (no cross-brick import) — a bare Redis client
+(no socket_timeout / health_check_interval) is the shape that turned a Redis blip into a hung
+scheduler tick that only a restart healed (2026-04-21). Zero deps — stdlib ``ast``.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "runtime_kernel"
+
+# Reviewed exceptions: "<relpath>:<lineno>" → justification. Empty by design: the one site is hardened.
+ALLOWLIST: dict[str, str] = {}
+
+REQUIRED = {"socket_timeout", "health_check_interval"}
+
+
+def _is_redis_construction(call: ast.Call) -> bool:
+    f = call.func
+    if isinstance(f, ast.Attribute):
+        if f.attr == "from_url" or f.attr in {"Redis", "StrictRedis"}:
+            return True
+    if isinstance(f, ast.Name) and f.id in {"Redis", "StrictRedis"}:
+        return True
+    return False
+
+
+def _kwarg_names(call: ast.Call) -> set[str]:
+    names = {kw.arg for kw in call.keywords if kw.arg is not None}
+    if any(kw.arg is None for kw in call.keywords):
+        names |= REQUIRED
+    return names
+
+
+def scan(root: Path = SRC) -> list[str]:
+    findings: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = str(path.relative_to(root.parent.parent))
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_redis_construction(node):
+                if f"{rel}:{node.lineno}" in ALLOWLIST:
+                    continue
+                missing = REQUIRED - _kwarg_names(node)
+                if missing:
+                    findings.append(f"{rel}:{node.lineno} bare redis client — missing {sorted(missing)}")
+    return sorted(findings)
+
+
+def test_no_bare_redis_clients():
+    """Every Redis client in runtime_kernel sets socket_timeout + health_check_interval. RED at base
+    (1 finding: __main__.py), GREEN at head."""
+    findings = scan()
+    assert findings == [], "bare Redis client construction (see #528):\n" + "\n".join(findings)
+
+
+def test_gate_detects_a_bare_client(tmp_path):
+    (tmp_path / "p").mkdir(parents=True)
+    (tmp_path / "p" / "x.py").write_text("import redis\nc = redis.from_url('redis://x', decode_responses=True)\n")
+    assert len(scan(tmp_path / "p")) == 1
+    (tmp_path / "p" / "x.py").write_text(
+        "import redis\nc = redis.from_url('redis://x', socket_timeout=10, health_check_interval=30)\n")
+    assert scan(tmp_path / "p") == []

--- a/deploy/compose/tests/chaos_test.py
+++ b/deploy/compose/tests/chaos_test.py
@@ -44,6 +44,46 @@ def _blip(service: str, secs: float):
     subprocess.run(["docker", "unpause", cid], capture_output=True, timeout=30)
 
 
+# --- #528 helpers: harsher redis faults + the zero-restart evidence -----------------------------
+def _inspect(cid: str, fmt: str) -> str:
+    r = subprocess.run(["docker", "inspect", "-f", fmt, cid], capture_output=True, text=True, timeout=30)
+    return (r.stdout or "").strip()
+
+
+def _restart_state(service: str) -> tuple[int, str]:
+    """(RestartCount, StartedAt) for a service container — unchanged across a fault == it self-healed
+    WITHOUT a restart, which is the #528 property (a bare client would need a manual restart to heal)."""
+    cid = _container_id(service)
+    assert cid, f"could not resolve the {service} container"
+    rc = _inspect(cid, "{{.RestartCount}}") or "0"
+    return int(rc), _inspect(cid, "{{.State.StartedAt}}")
+
+
+def _redis_network(cid: str) -> str:
+    nets = _inspect(cid, "{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}").split()
+    return nets[0] if nets else ""
+
+
+def _compose(*args: str):
+    subprocess.run(["docker", "compose", "-p", PROJECT, "-f", str(COMPOSE_FILE), *args],
+                   capture_output=True, timeout=60)
+
+
+def _wait_redis_dependents_healthy(stack, timeout: float = 45):
+    from conftest import http
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        c, _b = http("GET", f"{stack.meeting_api}/health", timeout=5)
+        if c == 200:
+            return True
+        time.sleep(2)
+    return False
+
+
+# Services that hold a Redis client and MUST NOT be restarted to recover from a redis fault (#528).
+_REDIS_DEPENDENTS = ("meeting-api", "gateway", "runtime")
+
+
 @chaos_only
 def test_chaos_redis_blip_survived(stack):
     """A redis blip during the active phase → the bot + collector reconnect; the run still reaches terminal."""
@@ -81,3 +121,56 @@ def test_chaos_meeting_api_blip_survived(stack):
     term = _wait_meeting(stack, user_id, native_id, statuses={"completed", "failed"}, timeout=120)
     assert term and term["status"] in ("completed", "failed"), f"meeting-api blip not survived — meeting stalled: {term}"
     print(f"\n[chaos/meeting-api-blip] 3s meeting-api outage → callbacks retried → meeting reached {term['status']}")
+
+
+@chaos_only
+def test_chaos_redis_refused_then_restored_no_restart(stack):
+    """#528 · B2a — redis STOPPED then STARTED (connection refused, then back) mid-run. Every
+    Redis-dependent service must self-heal WITHOUT a restart (bounded socket_timeout + health checks)
+    and the meeting must still reach terminal. Base (bare clients): the run stalls and/or a dependent
+    needs a manual restart — red on the terminal assert or the RestartCount assert."""
+    before = {s: _restart_state(s) for s in _REDIS_DEPENDENTS}
+    user_id = _create_user(stack, max_bots=5)
+    native_id, _ = _spawn(stack, user_id, "immediate-stop")
+    assert _wait_meeting(stack, user_id, native_id,
+                         statuses={"active", "joining", "awaiting_admission"}, timeout=60), "no live meeting"
+
+    _compose("stop", "redis")     # connection refused for everyone holding a client
+    time.sleep(45)
+    _compose("start", "redis")
+    assert _wait_redis_dependents_healthy(stack), "meeting-api /health never recovered after redis restart"
+
+    _stop_bot(stack, user_id, native_id)
+    term = _wait_meeting(stack, user_id, native_id, statuses={"completed", "failed"}, timeout=90)
+    assert term and term["status"] in ("completed", "failed"), f"redis stop/start not survived: {term}"
+    for s in _REDIS_DEPENDENTS:
+        assert _restart_state(s) == before[s], f"{s} was RESTARTED to recover from the redis outage (#528 not met)"
+    print(f"\n[chaos/redis-refused] stop→45s→start → meeting reached {term['status']}, zero dependent restarts")
+
+
+@chaos_only
+def test_chaos_redis_silent_drop_no_restart(stack):
+    """#528 · B2b — the LOAD-BEARING negative control: redis silently NETWORK-PARTITIONED (no RST, no
+    refused — the socket just goes dead), the exact 2026-04-26 shape a bare client never notices. With
+    socket_timeout + health checks the dead socket raises and the pool revalidates; the run recovers
+    with zero dependent restarts. Base: the client hangs on the dead socket indefinitely → stall."""
+    cid = _container_id("redis")
+    net = _redis_network(cid)
+    assert cid and net, "could not resolve redis container/network"
+    before = {s: _restart_state(s) for s in _REDIS_DEPENDENTS}
+    user_id = _create_user(stack, max_bots=5)
+    native_id, _ = _spawn(stack, user_id, "immediate-stop")
+    assert _wait_meeting(stack, user_id, native_id,
+                         statuses={"active", "joining", "awaiting_admission"}, timeout=60), "no live meeting"
+
+    subprocess.run(["docker", "network", "disconnect", net, cid], capture_output=True, timeout=30)
+    time.sleep(60)  # long enough that a bare (no-timeout) client would sit on the dead socket forever
+    subprocess.run(["docker", "network", "connect", net, cid], capture_output=True, timeout=30)
+    assert _wait_redis_dependents_healthy(stack), "meeting-api /health never recovered after redis reconnect"
+
+    _stop_bot(stack, user_id, native_id)
+    term = _wait_meeting(stack, user_id, native_id, statuses={"completed", "failed"}, timeout=90)
+    assert term and term["status"] in ("completed", "failed"), f"redis silent-drop not survived: {term}"
+    for s in _REDIS_DEPENDENTS:
+        assert _restart_state(s) == before[s], f"{s} was RESTARTED to recover from the redis partition (#528 not met)"
+    print(f"\n[chaos/redis-silent-drop] disconnect→60s→connect → meeting reached {term['status']}, zero dependent restarts")


### PR DESCRIPTION
Closes #528 (offline arm). Refs the 2026-04-21 / 04-26 Redis-cascade incidents.

## Value

> A Redis outage self-heals within the socket timeout instead of leaving hung/zombie clients that only a process restart can recover — and the bare-client shape can never be reintroduced.

## Root cause

On 04-21/04-26 no service recovered when Redis came back: clients were built bare — no `socket_timeout` (a dead socket never raises), no `health_check_interval` (the pool never revalidates), no keepalive. Every Redis-client service had to be manually rolling-restarted. The gateway client was already hardened (#495 era); meeting-api and runtime were not.

## Fix

Mirror the gateway client at the three bare sites:
- `meeting-api/__main__.py:81` — the shared client (transcript store, segment bus, retry queue, publishes)
- `meeting-api/collector/adapters.py:978` — standalone/conformance entrypoint
- `runtime_kernel/__main__.py:62` — the scheduler tick client

each `+ socket_timeout=10, socket_connect_timeout=5, socket_keepalive=True, health_check_interval=30, retry_on_timeout=True`. Timeouts surface as exceptions the existing per-tick `except` handlers already catch; `/health` goes red instead of hanging.

## Acceptance

| # | Observation | Status |
|---|---|---|
| B1 (offline) | Two stdlib-ast gates fail on any Redis client missing `socket_timeout`+`health_check_interval`. **RED at base, exactly 3 findings** (the 3 sites), **GREEN at head**; each has a planted-bare-client self-test | ✅ (proven red→green) |
| B- | No-regression: meeting-api **636 passed/2 skipped**, runtime **141 passed/1 skipped** | ✅ |
| B2a (live) | redis STOP→45s→START: meeting still reaches terminal, dependents' RestartCount/StartedAt unchanged | operator (opt-in `@chaos_only`) |
| B2b (live) | redis network DISCONNECT→60s→CONNECT (silent drop — the 04-26 killer): same, self-heal not restart | operator (opt-in `@chaos_only`) |

B2 rows are added to `deploy/compose/tests/chaos_test.py`, gated `COMPOSE_CHAOS=1` so **they never run in CI** — the operator runs them at base+head with `docker inspect` RestartCount as the zero-restart evidence.

## Scope / notes

- **In:** meeting-api + runtime (the issue's stated scope) + the standing gate.
- **Out:** `core/agent/**` has its own bare-client sites (short-lived per-read SSE client at `shared/adapters.py:382`, several in `control_plane/api.py`) — a sibling scope, not this issue; the gates are rooted only at `meeting_api` and `runtime_kernel`.
- Unblocks #520 (webhook retry durability) and #527 (pipeline liveness), which build on a Redis client that fails fast.