### PR TITLE
webhooks: event_id stable per logical event, not per emission (#519)

### DIFF
--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -18,7 +18,7 @@
   "core/meetings/contracts/invocation.v1": "eb3be72142f831bc51b913306bbb200fe0d4ca8853616e0c9628439b35c59f89",
   "core/meetings/contracts/lifecycle.v1": "5d36907c06e8157958845f09ae888c0dde1bbf1e4fce3ed98d29aeb62e5f6a49",
   "core/meetings/contracts/transcript.v1": "7d07d0fbac77f6562af64ae6c6286051e0e07763f427347d4e7b7735eaa0f9c8",
-  "core/meetings/contracts/webhook.v1": "d043f0f5c51b08532b04ff00a5f6b62f99d0cccc79c58c82bd28a55b17755deb",
+  "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",
   "core/runtime/contracts/runtime.v1": "9d67b9379e0d34c4d715764a467e7f6e6543a5db8177fc284fb4a7418067bc18",
   "core/runtime/contracts/schedule.v1": "6f2c0277d3d186ca2a9333342930f135ea66bfd931135c451bd12b05ff862648",
   "deploy/contracts/config.v1": "cf5961992377978a3dabc11cf7291f4781cc1115d6407b6888d3dc7a4c38328d",

--- a/core/meetings/contracts/webhook.v1/README.md
+++ b/core/meetings/contracts/webhook.v1/README.md
@@ -6,8 +6,25 @@ authenticates the delivery. Derived from the parent meeting-api's real envelope
 (billing/analytics) and **per-client** hooks (user-configured `webhook_url` + `webhook_secret`) share
 this shape.
 
-> **UNSEALED** (in development). Sealing is the human `lane:contract` step (`pnpm seal:contracts`).
-> Until then `gate:contract-version` reports it but does not fail.
+> **SEALED** — pinned in `contracts.seal.json`; changes ride the human `lane:contract` review
+> (`pnpm seal:contracts` re-pins the hash).
+
+## Delivery semantics (#519)
+- **At-least-once.** A logical event may be POSTed more than once — the initial send, a
+  retry-queue drain, a restart replay, or a cross-replica race can all re-emit it.
+- **`event_id` is the receiver's idempotency key.** The SAME logical event carries the SAME
+  `event_id` across every (re)delivery — it is derived from what makes the event unique
+  (`connection_id · event_type · new_status`), not minted fresh per send. **Receivers MUST dedupe
+  on `event_id`** and process each logical event once. (This closes the #330 4×-billing class,
+  where a per-emission `uuid4` made redeliveries look like distinct events.)
+- **Do NOT key on the body or the signature.** `created_at` and the `X-Webhook-Timestamp` (hence the
+  HMAC signature) legitimately differ across redeliveries — that is the replay-bounding design, not
+  a new event. Only `event_id` is stable.
+- **Two events per FSM advance.** One advance (e.g. → `active`) emits both `meeting.status_change`
+  and the typed `meeting.started`; these are DISTINCT logical events with DISTINCT `event_id`s
+  (`event_type` is part of the identity).
+- **Retention.** Retain seen `event_id`s ≥ 48h (the retry schedule tops out at 24h, `retry.py`, plus
+  slack) to dedupe a late redelivery.
 
 ## Shapes (`$defs`)
 - **`Envelope`** — `event_id · event_type · api_version · created_at · data`. The body POSTed is

--- a/core/meetings/contracts/webhook.v1/webhook.schema.json
+++ b/core/meetings/contracts/webhook.v1/webhook.schema.json
@@ -23,7 +23,7 @@
       "properties": {
         "event_id": {
           "type": "string",
-          "description": "unique per delivery: `evt_<hex>` (idempotency key for the receiver)"
+          "description": "stable identity of the logical event (`evt_<hex>`); delivery is at-least-once and the receiver dedupes on this key. The SAME logical event carries the SAME event_id across every (re)delivery — see the webhook.v1 README 'Delivery semantics'."
         },
         "event_type": { "$ref": "#/$defs/EventType" },
         "api_version": {

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/webhook.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/webhook.py
@@ -18,11 +18,11 @@ completed → ``meeting.completed`` (the post-meeting ``{meeting}`` envelope), f
 """
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
-from uuid import uuid4
 
 import jsonschema
 from referencing import Registry, Resource
@@ -62,6 +62,26 @@ def _conforms(obj: Dict[str, Any], shape: str) -> None:
     ).validate(obj)
 
 
+def derive_event_id(connection_id: Any, event_type: str, new_status: Any) -> str:
+    """#519: the ``event_id`` is the STABLE identity of a logical event, not a per-emission nonce.
+
+    Delivery is at-least-once (the initial POST, the Redis retry-queue drain which reuses the stored
+    envelope, a restart replay, a cross-replica race, an ambiguous timeout) — every one of these must
+    present the SAME ``event_id`` so a receiver can dedupe on it (the #330 4×-billing class, where a
+    fresh uuid4 per emission made four deliveries look like four distinct events). We derive it from
+    exactly what makes the event unique: ``(connection_id, event_type, new_status)``. Two DIFFERENT
+    logical events of one FSM advance (e.g. ``meeting.status_change`` + ``meeting.completed``) get
+    different ids because ``event_type`` is in the key — correct: they ARE distinct events.
+
+    32 hex chars = 128 bits, matching the sealed ``evt_<hex>`` wire shape (no schema change)."""
+    key = f"{connection_id}|{event_type}|{new_status}"
+    return "evt_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+
+
+def _new_status_value(change: StatusChange) -> Any:
+    return change.new_status.value if change.new_status is not None else None
+
+
 def build_status_change_envelope(
     change: StatusChange,
     *,
@@ -79,7 +99,8 @@ def build_status_change_envelope(
     if meeting is None:
         meeting = _minimal_meeting_projection(change)
     envelope = {
-        "event_id": event_id or f"evt_{uuid4().hex}",
+        "event_id": event_id
+        or derive_event_id(change.record.connection_id, "meeting.status_change", _new_status_value(change)),
         "event_type": "meeting.status_change",
         "api_version": WEBHOOK_API_VERSION,
         "created_at": created_at
@@ -156,7 +177,8 @@ def build_typed_envelope(
             "transition_source": change.transition_source.value,
         }
     envelope = {
-        "event_id": event_id or f"evt_{uuid4().hex}",
+        "event_id": event_id
+        or derive_event_id(change.record.connection_id, event_type, _new_status_value(change)),
         "event_type": event_type,
         "api_version": WEBHOOK_API_VERSION,
         "created_at": ts,

--- a/core/meetings/services/meeting-api/src/meeting_api/webhooks/delivery.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/webhooks/delivery.py
@@ -44,6 +44,12 @@ def build_envelope(event_type: str, data: Dict[str, Any], event_id: Optional[str
 
     `{event_id, event_type, api_version, created_at, data}` — the only shape delivered,
     system or per-client.
+
+    #519: ``event_id`` is the STABLE identity of a logical event (the receiver's idempotency key),
+    NOT a per-emission nonce. Callers MUST pass a deterministic ``event_id`` derived from what makes
+    the event unique (see ``lifecycle/webhook.derive_event_id``) so redeliveries dedupe. The
+    ``uuid4`` fallback here is a last resort for a caller that has no stable identity to offer; there
+    is no such production caller in-tree today.
     """
     return {
         "event_id": event_id or f"evt_{uuid4().hex}",

--- a/core/meetings/services/meeting-api/tests/test_webhook_identity.py
+++ b/core/meetings/services/meeting-api/tests/test_webhook_identity.py
@@ -1,0 +1,61 @@
+"""#519 · C1/A1 — the webhook ``event_id`` is the STABLE identity of a logical event (the receiver's
+idempotency key), derived deterministically from what makes the event unique — NOT a fresh ``uuid4``
+per emission. That per-emission nonce was the #330 4×-billing class: one logical ``meeting.completed``
+emitted more than once looked like N distinct events to a deduping receiver.
+"""
+from __future__ import annotations
+
+import hashlib
+
+from meeting_api.lifecycle import LifecycleSink, MeetingStore, TransitionSource
+from meeting_api.lifecycle.webhook import (
+    build_status_change_envelope,
+    build_typed_envelope,
+    derive_event_id,
+)
+
+
+def _apply(goldens, *cases):
+    """A fresh sink advanced through `cases` in order; returns the last StatusChange."""
+    sink = LifecycleSink(store=MeetingStore())
+    ch = None
+    for case in cases:
+        ch = sink.apply_change(goldens[case], transition_source=TransitionSource.BOT_CALLBACK)
+    return ch
+
+
+def test_same_logical_event_yields_identical_event_id(goldens):
+    """The SAME logical event built twice (e.g. an initial POST and a retry-queue redelivery) presents
+    an IDENTICAL event_id, so a deduping receiver processes it once. This is the whole fix."""
+    e1 = build_status_change_envelope(_apply(goldens, "joining"))
+    e2 = build_status_change_envelope(_apply(goldens, "joining"))
+    assert e1["event_id"] == e2["event_id"]
+    assert e1["event_id"].startswith("evt_") and len(e1["event_id"]) == 4 + 32  # evt_ + 32 hex
+
+
+def test_event_id_matches_derivation_and_is_deterministic():
+    """derive_event_id is a stable sha256 over (connection_id, event_type, new_status)."""
+    a = derive_event_id("conn-1", "meeting.status_change", "active")
+    assert a == derive_event_id("conn-1", "meeting.status_change", "active")  # deterministic
+    assert a == "evt_" + hashlib.sha256(b"conn-1|meeting.status_change|active").hexdigest()[:32]
+    # each component participates in the identity
+    assert derive_event_id("conn-2", "meeting.status_change", "active") != a
+    assert derive_event_id("conn-1", "meeting.started", "active") != a
+    assert derive_event_id("conn-1", "meeting.status_change", "completed") != a
+
+
+def test_distinct_event_types_of_one_advance_get_distinct_ids(goldens):
+    """One advance to `active` emits BOTH meeting.status_change AND meeting.started — two DISTINCT
+    logical events → distinct event_ids (event_type is part of the identity)."""
+    ch = _apply(goldens, "joining", "active")
+    sc = build_status_change_envelope(ch)
+    typed = build_typed_envelope(ch)
+    assert typed is not None and typed["event_type"] == "meeting.started"
+    assert sc["event_id"] != typed["event_id"]
+
+
+def test_production_builders_never_mint_a_random_id(goldens):
+    """Negative control for a revert to uuid4: the same advance built N times is a SINGLE id. With the
+    old `evt_{uuid4().hex}` default this set would have N distinct ids → red."""
+    ids = {build_typed_envelope(_apply(goldens, "joining", "active"))["event_id"] for _ in range(4)}
+    assert len(ids) == 1


### PR DESCRIPTION
Closes #519. Refs #330 (the 4×-billing report).

## Value

> When the platform emits one logical event more than once, the subscriber has an idempotency key that survives the duplicate — the SAME `event_id` on every (re)delivery — so a careful receiver can be made correct.

## Root cause

Every emission minted a fresh `evt_{uuid4().hex}`, so one logical `meeting.completed` delivered N times looked like N distinct events (the #330 4×-billing class). The sealed schema even said both *"unique per delivery"* and *"idempotency key for the receiver"* — a contradiction.

## Fix — code

`derive_event_id(connection_id, event_type, new_status) → "evt_"+sha256(...)[:32]`, used as the default at the two production builders (`build_status_change_envelope`, `build_typed_envelope`). Every redelivery path presents the same id:
- initial POST, **retry-queue drain** (replays the stored envelope verbatim), restart replay, cross-replica race → identical `event_id`.
- Two distinct logical events of one advance (`meeting.status_change` + `meeting.started`/`completed`) get **distinct** ids (`event_type` is in the key).

`delivery.build_envelope` keeps its `uuid4` as a documented last resort (no production caller mints via it).

## Fix — contract truth (the issue's other half)

- `webhook.schema.json`: `event_id` description no longer self-contradicts — *stable identity of the logical event; at-least-once; dedupe on this key*.
- `webhook.v1/README.md`: stale **UNSEALED** → **SEALED**, plus a **Delivery semantics** section (at-least-once; dedupe on `event_id`; never key on body/signature — `created_at` + HMAC timestamp differ across redeliveries by design; ≥48h retention).
- `contracts.seal.json` re-sealed (only webhook.v1's hash changes) — rides **lane:contract** human review.

## Acceptance

| # | Observation | Status |
|---|---|---|
| C1/A1 | `test_webhook_identity.py`: same logical event twice → identical id; derivation deterministic + every component participates; distinct event_types → distinct ids; N rebuilds → 1 id (negative control for a uuid4 revert) | ✅ |
| gates | `gate:schema` (goldens ≡ schema) + `gate:contract-version` (24 frozen) green after re-seal | ✅ |
| A- | meeting-api lane **638 passed / 2 skipped** | ✅ |
| A2 (live) | one meeting → real receiver logs repeated `event_id` across a forced redelivery; dedupe drops the dup | operator |

## Notes / deferred

- **Cross-replica duplicate emission is not prevented** (deliberate — stock helm runs 2 replicas). Deterministic identity makes the duplicate *harmless to a deduping receiver*; a status-guarded UPDATE latch is a welcome follow-up, not required here.
- **Deferred:** two completeness goldens + the docs.vexa.ai `webhooks.mdx` / `receive-webhooks.mdx` pages (separate docs surface).