### PR TITLE
config-contract: bring admin-api + gateway under gate:config-contract (#526)

### DIFF
--- a/core/gateway/services/gateway/src/gateway/adapters.py
+++ b/core/gateway/services/gateway/src/gateway/adapters.py
@@ -117,6 +117,12 @@ def build_production_app(
     import redis.asyncio as aioredis
 
     from .app import create_app
+    from .config_preflight import preflight
+
+    # #526: refuse to boot a misconfigured deploy — a missing INTERNAL_API_SECRET makes admin-api
+    # reject every /internal/validate hop (503 on every API-key check), the 2026-04-23 shape. Fail
+    # loud at boot with one message naming the missing key, instead of coming up green and 503ing.
+    preflight()
 
     admin_api_url = admin_api_url or os.getenv("ADMIN_API_URL", "http://admin-api:8001")
     meeting_api_url = meeting_api_url or os.getenv("MEETING_API_URL", "http://meeting-api:8080")

--- a/core/gateway/services/gateway/src/gateway/config.v1.json
+++ b/core/gateway/services/gateway/src/gateway/config.v1.json
@@ -1,0 +1,153 @@
+{
+ "contract": "config.v1",
+ "service": "gateway",
+ "keys": [
+  {
+   "key": "INTERNAL_API_SECRET",
+   "class": "required-explicit",
+   "secret": true,
+   "description": "shared internal secret attached as X-Internal-Secret on the admin-api /internal/validate hop (adapters.py:67-69). Unset, admin-api rejects validation and EVERY API-key check 503s (fail-closed) — so the boot refuses instead of coming up green and 503ing every call (the 2026-04-23 failure shape, #526)."
+  },
+  {
+   "key": "ADMIN_API_URL",
+   "class": "defaulted",
+   "default": "http://admin-api:8001",
+   "description": "admin-api base URL for the /internal/validate token-resolution hop"
+  },
+  {
+   "key": "MEETING_API_URL",
+   "class": "defaulted",
+   "default": "http://meeting-api:8080",
+   "description": "meeting-api base URL — the proxy forward target and the /ws/authorize-subscribe hop"
+  },
+  {
+   "key": "AGENT_API_URL",
+   "class": "defaulted",
+   "default": "http://agent-api:8100",
+   "description": "agent control-plane base URL fronted under /api/*",
+   "targets": ["helm", "lite"]
+  },
+  {
+   "key": "REDIS_URL",
+   "class": "defaulted",
+   "default": "redis://redis:6379/0",
+   "description": "pub/sub bus backing the /ws fan-in"
+  },
+  {
+   "key": "LOG_LEVEL",
+   "class": "defaulted",
+   "default": "info",
+   "description": "log verbosity"
+  },
+  {
+   "key": "HOST",
+   "class": "defaulted",
+   "default": "0.0.0.0",
+   "description": "uvicorn bind host",
+   "targets": ["lite"]
+  },
+  {
+   "key": "PORT",
+   "class": "defaulted",
+   "default": "8056",
+   "description": "uvicorn bind port",
+   "targets": ["lite"]
+  },
+  {
+   "key": "GUARD_ENABLED",
+   "class": "defaulted",
+   "default": "true",
+   "description": "edge protection (fastapi-guard) master switch — ON by default (#555)"
+  },
+  {
+   "key": "GUARD_WS_ENABLED",
+   "class": "defaulted",
+   "default": "false",
+   "description": "extend the edge guard to the /ws upgrade path"
+  },
+  {
+   "key": "GUARD_ENABLE_REDIS",
+   "class": "defaulted",
+   "default": "true",
+   "description": "back the guard's rate-limit/ban buckets with Redis (shared across replicas)",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_RATE_LIMIT_RPM",
+   "class": "defaulted",
+   "default": "600",
+   "description": "per-IP request budget per window",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_RATE_LIMIT_WINDOW",
+   "class": "defaulted",
+   "default": "60",
+   "description": "rate-limit window (seconds)",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_AUTO_BAN_THRESHOLD",
+   "class": "defaulted",
+   "default": "10",
+   "description": "violations before an IP is auto-banned",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_AUTO_BAN_DURATION",
+   "class": "defaulted",
+   "default": "3600",
+   "description": "auto-ban duration (seconds)",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_IP_WHITELIST",
+   "class": "defaulted",
+   "default": "",
+   "description": "comma-separated IPs never rate-limited/banned",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_IP_BLACKLIST",
+   "class": "defaulted",
+   "default": "",
+   "description": "comma-separated IPs always blocked",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_TRUSTED_PROXIES",
+   "class": "defaulted",
+   "default": "",
+   "description": "comma-separated proxy IPs whose X-Forwarded-For is trusted for client-IP resolution",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_TRUST_X_FORWARDED_PROTO",
+   "class": "defaulted",
+   "default": "false",
+   "description": "trust X-Forwarded-Proto from the proxy for scheme resolution",
+   "targets": ["compose", "helm"]
+  },
+  {
+   "key": "GUARD_BLOCKED_COUNTRIES",
+   "class": "defaulted",
+   "default": "",
+   "description": "comma-separated country codes to block (geo-IP)",
+   "targets": ["compose"]
+  },
+  {
+   "key": "GUARD_BLOCK_CLOUD_PROVIDERS",
+   "class": "defaulted",
+   "default": "",
+   "description": "block known cloud/hosting provider ranges",
+   "targets": ["compose"]
+  },
+  {
+   "key": "GUARD_REDIS_PREFIX",
+   "class": "defaulted",
+   "default": "vexa:guard:",
+   "description": "Redis key prefix for the guard's rate-limit/ban buckets",
+   "targets": []
+  }
+ ]
+}

--- a/core/gateway/services/gateway/src/gateway/config_preflight.py
+++ b/core/gateway/services/gateway/src/gateway/config_preflight.py
@@ -1,0 +1,258 @@
+"""config.v1 preflight — the shared boot-time deployment-config validator (ADR-0026).
+
+CANONICAL COPY: ``deploy/contracts/config.v1/preflight.py``. Every adopted service vendors this
+file VERBATIM as ``config_preflight.py`` next to its ``config.v1.json`` declaration —
+``gate:config-contract`` enforces byte-equality — so the module is importable inside every image
+without a cross-domain package dependency (P2: the services stay isolated bricks; they share a
+contract, not a code distribution).
+
+The three declaration classes (see the contract README):
+
+* **required-explicit** — unset/empty at boot ⇒ :class:`ConfigError` (the deploy refuses to boot
+  with ONE message naming every missing key — fail loud, P18/ADR-0010);
+* **defaulted** — the documented code default applies; nothing to enforce at boot;
+* **capability** — the key belongs to a named capability whose tri-state is computed from the env:
+  ``configured`` / ``not_configured`` / ``misconfigured`` (mode=all: some-but-not-all keys set).
+  The service RUNS either way; capability-gated endpoints consult :func:`capability_state` and fail
+  loud with a typed, actionable error; ``/health`` exposes the rows via :func:`capability_health`
+  (ADDITIVE — existing health consumers keep working).
+
+A capability may also declare a **live probe** (contract ``$defs/Probe``): one cheap verification
+that the SET values actually work — an authenticated HTTP call (``http``: an unauthorized answer or
+a network failure ⇒ misconfigured; any other status ⇒ the credential was accepted) or a credentials
+FILE check (``file``: regular readable non-empty JSON ⇒ ok; a directory — docker's bind-mount of a
+MISSING host path — or unreadable/non-JSON ⇒ misconfigured). Probes run only when the env-level
+state is already ``configured``: once at boot (logged, never boot-blocking) and lazily on ``/health``
+when the cached result is older than the probe's ``ttl_s``. This is what turns the silent-401 STT
+token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
+meeting/agent runs.
+
+Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
+environment and long-lived processes both observe the truth.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+log = logging.getLogger("config.v1.preflight")
+
+CONFIGURED = "configured"
+NOT_CONFIGURED = "not_configured"
+MISCONFIGURED = "misconfigured"
+
+
+class ConfigError(RuntimeError):
+    """A deployment-config violation the boot must not survive (fail loud + attributable, P18)."""
+
+
+@lru_cache(maxsize=1)
+def load_declaration() -> dict:
+    """This service's config.v1 declaration (``config.v1.json``, vendored next to this module).
+
+    Sanity-checks the declaration's internal references (a ``capability``-classed key must name a
+    declared capability) so a broken declaration fails at first use, not silently.
+    """
+    path = Path(__file__).resolve().parent / "config.v1.json"
+    decl = json.loads(path.read_text(encoding="utf-8"))
+    caps = decl.get("capabilities") or {}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability" and entry.get("capability") not in caps:
+            raise ConfigError(
+                f"config.v1 declaration for {decl.get('service')!r} is inconsistent: key "
+                f"{entry.get('key')!r} names undeclared capability {entry.get('capability')!r}"
+            )
+    return decl
+
+
+def _is_set(env: Mapping[str, str], key: str) -> bool:
+    # Empty string counts as UNSET: the deploy surfaces default absent vars to "" (compose
+    # `${VAR:-}`, lite `export VAR="${VAR:-}"`), so "" and absent must mean the same thing.
+    return bool((env.get(key) or "").strip())
+
+
+def capability_states(env: Optional[Mapping[str, str]] = None) -> dict:
+    """The env-level tri-state of every declared capability — PURE (no probe I/O), computed from
+    the live env. This is the request-path oracle capability-gated endpoints use."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    keys_by_cap: dict = {name: [] for name in caps}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability":
+            keys_by_cap[entry["capability"]].append(entry["key"])
+    states = {}
+    for name, cap in caps.items():
+        keys = keys_by_cap.get(name) or []
+        present = [k for k in keys if _is_set(env, k)]
+        if (cap.get("mode") or "all") == "any":
+            states[name] = CONFIGURED if present else NOT_CONFIGURED
+        elif keys and len(present) == len(keys):
+            states[name] = CONFIGURED
+        elif not present:
+            states[name] = NOT_CONFIGURED
+        else:
+            states[name] = MISCONFIGURED
+    return states
+
+
+def capability_state(name: str, env: Optional[Mapping[str, str]] = None) -> str:
+    """One capability's env-level tri-state. An UNDECLARED name raises — gating on a capability the
+    declaration does not carry is a bug, not a runtime condition."""
+    states = capability_states(env)
+    if name not in states:
+        raise ConfigError(
+            f"capability {name!r} is not declared in {load_declaration().get('service')!r}'s config.v1"
+        )
+    return states[name]
+
+
+def missing_capability_keys(name: str, env: Optional[Mapping[str, str]] = None) -> List[str]:
+    """The unset member keys behind a not_configured/misconfigured capability — so a gated
+    endpoint's error can name EXACTLY what to set (actionable, not just 'unavailable')."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    keys = [
+        e["key"]
+        for e in decl.get("keys") or []
+        if e.get("class") == "capability" and e.get("capability") == name
+    ]
+    return [k for k in keys if not _is_set(env, k)]
+
+
+# ── live probes (contract $defs/Probe) — do the SET values actually work? ────────────────────────
+
+_probe_cache: dict = {}
+
+
+def _reset_probe_cache() -> None:
+    """Test seam: forget cached probe results (the cache is per-process, keyed by capability)."""
+    _probe_cache.clear()
+
+
+def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
+    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
+    url = base + (spec.get("path") or "")
+    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 — declared endpoint
+            status = int(r.status)
+    except urllib.error.HTTPError as e:
+        status = int(e.code)
+    except Exception as e:  # noqa: BLE001 — a probe must never throw past here
+        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+    if status in (spec.get("unauthorized_statuses") or [401, 403]):
+        return {"ok": False, "status": status,
+                "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    return {"ok": True, "status": status}
+
+
+def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """Verify a credentials file AS VISIBLE TO THIS SERVICE (the key's own path, then any declared
+    in-container mirror mounts of a docker-HOST path). A directory here is the signature of docker
+    bind-mounting a MISSING host path — exactly the 'Not logged in' worker failure, caught early."""
+    raw = (env.get(spec["path_key"]) or "").strip()
+    if not raw:
+        return {"ok": True, "skipped": f"{spec['path_key']} unset — this credential path is not in use"}
+    tried = []
+    for p in [raw, *(spec.get("fallback_paths") or [])]:
+        path = Path(p)
+        if not path.exists():
+            tried.append(f"{p}: not found")
+            continue
+        if not path.is_file():
+            return {"ok": False, "path": p,
+                    "reason": f"{p} is not a regular file — docker bind-mounts a MISSING host path "
+                              f"as a DIRECTORY, so the host file behind {spec['path_key']} is absent"}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "path": p, "reason": f"{p}: unreadable or not JSON ({e.__class__.__name__})"}
+        if not data:
+            return {"ok": False, "path": p, "reason": f"{p}: empty credentials JSON"}
+        return {"ok": True, "path": p}
+    return {"ok": False, "reason": "; ".join(tried)}
+
+
+def _run_probe(spec: dict, env: Mapping[str, str]) -> dict:
+    timeout = float(spec.get("timeout_s") or 2)
+    kind = spec.get("kind")
+    if kind == "http":
+        return _http_probe(spec["http"], env, timeout)
+    if kind == "file":
+        return _file_probe(spec["file"], env, timeout)
+    return {"ok": False, "reason": f"unknown probe kind {kind!r}"}
+
+
+def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = False) -> dict:
+    ttl = float(spec.get("ttl_s") or 60)
+    now = time.monotonic()
+    hit = _probe_cache.get(name)
+    if not force and hit is not None and (now - hit["at"]) < ttl:
+        return hit["result"]
+    result = _run_probe(spec, env)
+    _probe_cache[name] = {"at": now, "result": result}
+    return result
+
+
+def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:
+    """The /health rows: env-level tri-state per capability, PLUS the live-probe verdict for
+    capabilities that declare one (probe failure demotes the row to ``misconfigured`` with a
+    reason). Probe results are cached per the probe's ``ttl_s``; a row's shape is
+    ``{"state": ..., "probe"?: {"ok": ..., ...}}`` — additive next to the env-only state."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    rows = {}
+    for name, state in capability_states(env).items():
+        row: dict = {"state": state}
+        spec = (caps.get(name) or {}).get("probe")
+        if spec and state == CONFIGURED:
+            result = _cached_probe(name, spec, env, force=force_probe)
+            row["probe"] = result
+            if not result.get("ok"):
+                row["state"] = MISCONFIGURED
+        rows[name] = row
+    return rows
+
+
+def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
+    """Boot-time validation of the declaration against the environment.
+
+    Raises :class:`ConfigError` naming EVERY missing required-explicit key (one actionable message,
+    not a peel-the-onion loop); runs each configured capability's live probe once; logs one line per
+    capability so a deploy's config completeness is visible in the boot log (a failed probe logs a
+    WARNING but never blocks boot — capabilities gate endpoints, not the process).
+    Returns ``{"service", "capabilities"}`` (the same row shape as :func:`capability_health`).
+    """
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    required = [e for e in decl.get("keys") or [] if e.get("class") == "required-explicit"]
+    missing = [e for e in required if not _is_set(env, e["key"])]
+    if missing:
+        detail = "; ".join(f"{e['key']} ({e['description']})" for e in missing)
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
+            f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
+            "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    rows = capability_health(env, force_probe=True)
+    for name, row in sorted(rows.items()):
+        if row["state"] == MISCONFIGURED:
+            log.warning("config.v1 capability %s: MISCONFIGURED — %s", name,
+                        (row.get("probe") or {}).get("reason", "some-but-not-all keys set"))
+        else:
+            log.info("config.v1 capability %s: %s", name, row["state"])
+    return {"service": decl.get("service"), "capabilities": rows}

--- a/core/gateway/services/gateway/tests/test_config_contract.py
+++ b/core/gateway/services/gateway/tests/test_config_contract.py
@@ -1,0 +1,29 @@
+"""#526 · config.v1 (ADR-0026) — gateway's declaration + boot preflight.
+
+The gateway attaches INTERNAL_API_SECRET as X-Internal-Secret on the admin-api /internal/validate
+hop; unset, admin-api rejects validation and EVERY API-key check 503s — yet the gateway was outside
+the config-contract machinery, so it booted green. This pins the declaration + the boot preflight
+that refuses a secretless deploy. Offline, stdlib only.
+"""
+from __future__ import annotations
+
+import pytest
+
+from gateway import config_preflight as cp
+
+
+def test_declaration_loads_and_internal_secret_is_required():
+    decl = cp.load_declaration()
+    assert decl["service"] == "gateway"
+    required = {k["key"] for k in decl["keys"] if k["class"] == "required-explicit"}
+    assert "INTERNAL_API_SECRET" in required
+
+
+def test_preflight_refuses_boot_without_internal_api_secret():
+    with pytest.raises(cp.ConfigError) as ei:
+        cp.preflight({})
+    assert "INTERNAL_API_SECRET" in str(ei.value)
+
+
+def test_preflight_passes_when_required_set():
+    cp.preflight({"INTERNAL_API_SECRET": "a-real-secret"})

--- a/core/identity/services/admin-api/src/admin_api/__main__.py
+++ b/core/identity/services/admin-api/src/admin_api/__main__.py
@@ -27,8 +27,14 @@ def build_production_app():
     """Configure the DB engine + assemble the app; converge the schema on startup."""
     from .app import db as app_db
     from .app.main import create_app
+    from .config_preflight import preflight
     from .schema.models import Base
     from .schema.sync import ensure_schema
+
+    # #526: refuse to boot a misconfigured deploy — a missing INTERNAL_API_SECRET makes the
+    # fail-closed /internal/validate guard 503 every gateway validation hop, but the process would
+    # otherwise come up green (the 2026-04-23 shape: 23 meetings failed while monitors stayed green).
+    preflight()
 
     app_db.configure(_database_url())
     app = create_app()

--- a/core/identity/services/admin-api/src/admin_api/config.v1.json
+++ b/core/identity/services/admin-api/src/admin_api/config.v1.json
@@ -1,0 +1,85 @@
+{
+ "contract": "config.v1",
+ "service": "admin-api",
+ "keys": [
+  {
+   "key": "INTERNAL_API_SECRET",
+   "class": "required-explicit",
+   "secret": true,
+   "description": "shared internal secret the /internal/validate endpoint requires (fail-closed guard, main.py). Unset, gateway's validation hop 503s and every API-key check fails — so the boot refuses instead of coming up green and rejecting every call (the 2026-04-23 failure shape, #526)."
+  },
+  {
+   "key": "ADMIN_API_TOKEN",
+   "class": "defaulted",
+   "default": "changeme",
+   "secret": true,
+   "description": "admin bearer for the privileged admin surface; stock surfaces default it (compose 'changeme', helm/lite from env). Change it for any real deploy."
+  },
+  {
+   "key": "DB_HOST",
+   "class": "defaulted",
+   "default": "postgres",
+   "description": "PostgreSQL host (the users/tokens store)"
+  },
+  {
+   "key": "DB_PORT",
+   "class": "defaulted",
+   "default": "5432",
+   "description": "PostgreSQL port"
+  },
+  {
+   "key": "DB_NAME",
+   "class": "defaulted",
+   "default": "vexa",
+   "description": "PostgreSQL database name"
+  },
+  {
+   "key": "DB_USER",
+   "class": "defaulted",
+   "default": "postgres",
+   "description": "PostgreSQL user"
+  },
+  {
+   "key": "DB_PASSWORD",
+   "class": "defaulted",
+   "default": "postgres",
+   "secret": true,
+   "description": "PostgreSQL password (dev default; change for any non-local deploy)"
+  },
+  {
+   "key": "DATABASE_URL",
+   "class": "defaulted",
+   "default": "(derived from DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD)",
+   "secret": true,
+   "description": "explicit SQLAlchemy URL override; when unset the URL is built from the DB_* parts. Provided as a lite entrypoint export, not a per-surface env.",
+   "targets": []
+  },
+  {
+   "key": "DEV_MODE",
+   "class": "defaulted",
+   "default": "false",
+   "description": "dev conveniences toggle; does NOT relax the INTERNAL_API_SECRET requirement (a missing secret refuses boot even in dev — the 04-23 lesson).",
+   "targets": []
+  },
+  {
+   "key": "LOG_LEVEL",
+   "class": "defaulted",
+   "default": "info",
+   "description": "log verbosity"
+  },
+  {
+   "key": "HOST",
+   "class": "defaulted",
+   "default": "0.0.0.0",
+   "description": "uvicorn bind host",
+   "targets": ["lite"]
+  },
+  {
+   "key": "PORT",
+   "class": "defaulted",
+   "default": "8001",
+   "description": "uvicorn bind port",
+   "targets": ["lite"]
+  }
+ ]
+}

--- a/core/identity/services/admin-api/src/admin_api/config_preflight.py
+++ b/core/identity/services/admin-api/src/admin_api/config_preflight.py
@@ -1,0 +1,258 @@
+"""config.v1 preflight — the shared boot-time deployment-config validator (ADR-0026).
+
+CANONICAL COPY: ``deploy/contracts/config.v1/preflight.py``. Every adopted service vendors this
+file VERBATIM as ``config_preflight.py`` next to its ``config.v1.json`` declaration —
+``gate:config-contract`` enforces byte-equality — so the module is importable inside every image
+without a cross-domain package dependency (P2: the services stay isolated bricks; they share a
+contract, not a code distribution).
+
+The three declaration classes (see the contract README):
+
+* **required-explicit** — unset/empty at boot ⇒ :class:`ConfigError` (the deploy refuses to boot
+  with ONE message naming every missing key — fail loud, P18/ADR-0010);
+* **defaulted** — the documented code default applies; nothing to enforce at boot;
+* **capability** — the key belongs to a named capability whose tri-state is computed from the env:
+  ``configured`` / ``not_configured`` / ``misconfigured`` (mode=all: some-but-not-all keys set).
+  The service RUNS either way; capability-gated endpoints consult :func:`capability_state` and fail
+  loud with a typed, actionable error; ``/health`` exposes the rows via :func:`capability_health`
+  (ADDITIVE — existing health consumers keep working).
+
+A capability may also declare a **live probe** (contract ``$defs/Probe``): one cheap verification
+that the SET values actually work — an authenticated HTTP call (``http``: an unauthorized answer or
+a network failure ⇒ misconfigured; any other status ⇒ the credential was accepted) or a credentials
+FILE check (``file``: regular readable non-empty JSON ⇒ ok; a directory — docker's bind-mount of a
+MISSING host path — or unreadable/non-JSON ⇒ misconfigured). Probes run only when the env-level
+state is already ``configured``: once at boot (logged, never boot-blocking) and lazily on ``/health``
+when the cached result is older than the probe's ``ttl_s``. This is what turns the silent-401 STT
+token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
+meeting/agent runs.
+
+Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
+environment and long-lived processes both observe the truth.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+log = logging.getLogger("config.v1.preflight")
+
+CONFIGURED = "configured"
+NOT_CONFIGURED = "not_configured"
+MISCONFIGURED = "misconfigured"
+
+
+class ConfigError(RuntimeError):
+    """A deployment-config violation the boot must not survive (fail loud + attributable, P18)."""
+
+
+@lru_cache(maxsize=1)
+def load_declaration() -> dict:
+    """This service's config.v1 declaration (``config.v1.json``, vendored next to this module).
+
+    Sanity-checks the declaration's internal references (a ``capability``-classed key must name a
+    declared capability) so a broken declaration fails at first use, not silently.
+    """
+    path = Path(__file__).resolve().parent / "config.v1.json"
+    decl = json.loads(path.read_text(encoding="utf-8"))
+    caps = decl.get("capabilities") or {}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability" and entry.get("capability") not in caps:
+            raise ConfigError(
+                f"config.v1 declaration for {decl.get('service')!r} is inconsistent: key "
+                f"{entry.get('key')!r} names undeclared capability {entry.get('capability')!r}"
+            )
+    return decl
+
+
+def _is_set(env: Mapping[str, str], key: str) -> bool:
+    # Empty string counts as UNSET: the deploy surfaces default absent vars to "" (compose
+    # `${VAR:-}`, lite `export VAR="${VAR:-}"`), so "" and absent must mean the same thing.
+    return bool((env.get(key) or "").strip())
+
+
+def capability_states(env: Optional[Mapping[str, str]] = None) -> dict:
+    """The env-level tri-state of every declared capability — PURE (no probe I/O), computed from
+    the live env. This is the request-path oracle capability-gated endpoints use."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    keys_by_cap: dict = {name: [] for name in caps}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability":
+            keys_by_cap[entry["capability"]].append(entry["key"])
+    states = {}
+    for name, cap in caps.items():
+        keys = keys_by_cap.get(name) or []
+        present = [k for k in keys if _is_set(env, k)]
+        if (cap.get("mode") or "all") == "any":
+            states[name] = CONFIGURED if present else NOT_CONFIGURED
+        elif keys and len(present) == len(keys):
+            states[name] = CONFIGURED
+        elif not present:
+            states[name] = NOT_CONFIGURED
+        else:
+            states[name] = MISCONFIGURED
+    return states
+
+
+def capability_state(name: str, env: Optional[Mapping[str, str]] = None) -> str:
+    """One capability's env-level tri-state. An UNDECLARED name raises — gating on a capability the
+    declaration does not carry is a bug, not a runtime condition."""
+    states = capability_states(env)
+    if name not in states:
+        raise ConfigError(
+            f"capability {name!r} is not declared in {load_declaration().get('service')!r}'s config.v1"
+        )
+    return states[name]
+
+
+def missing_capability_keys(name: str, env: Optional[Mapping[str, str]] = None) -> List[str]:
+    """The unset member keys behind a not_configured/misconfigured capability — so a gated
+    endpoint's error can name EXACTLY what to set (actionable, not just 'unavailable')."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    keys = [
+        e["key"]
+        for e in decl.get("keys") or []
+        if e.get("class") == "capability" and e.get("capability") == name
+    ]
+    return [k for k in keys if not _is_set(env, k)]
+
+
+# ── live probes (contract $defs/Probe) — do the SET values actually work? ────────────────────────
+
+_probe_cache: dict = {}
+
+
+def _reset_probe_cache() -> None:
+    """Test seam: forget cached probe results (the cache is per-process, keyed by capability)."""
+    _probe_cache.clear()
+
+
+def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
+    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
+    url = base + (spec.get("path") or "")
+    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 — declared endpoint
+            status = int(r.status)
+    except urllib.error.HTTPError as e:
+        status = int(e.code)
+    except Exception as e:  # noqa: BLE001 — a probe must never throw past here
+        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+    if status in (spec.get("unauthorized_statuses") or [401, 403]):
+        return {"ok": False, "status": status,
+                "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    return {"ok": True, "status": status}
+
+
+def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """Verify a credentials file AS VISIBLE TO THIS SERVICE (the key's own path, then any declared
+    in-container mirror mounts of a docker-HOST path). A directory here is the signature of docker
+    bind-mounting a MISSING host path — exactly the 'Not logged in' worker failure, caught early."""
+    raw = (env.get(spec["path_key"]) or "").strip()
+    if not raw:
+        return {"ok": True, "skipped": f"{spec['path_key']} unset — this credential path is not in use"}
+    tried = []
+    for p in [raw, *(spec.get("fallback_paths") or [])]:
+        path = Path(p)
+        if not path.exists():
+            tried.append(f"{p}: not found")
+            continue
+        if not path.is_file():
+            return {"ok": False, "path": p,
+                    "reason": f"{p} is not a regular file — docker bind-mounts a MISSING host path "
+                              f"as a DIRECTORY, so the host file behind {spec['path_key']} is absent"}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "path": p, "reason": f"{p}: unreadable or not JSON ({e.__class__.__name__})"}
+        if not data:
+            return {"ok": False, "path": p, "reason": f"{p}: empty credentials JSON"}
+        return {"ok": True, "path": p}
+    return {"ok": False, "reason": "; ".join(tried)}
+
+
+def _run_probe(spec: dict, env: Mapping[str, str]) -> dict:
+    timeout = float(spec.get("timeout_s") or 2)
+    kind = spec.get("kind")
+    if kind == "http":
+        return _http_probe(spec["http"], env, timeout)
+    if kind == "file":
+        return _file_probe(spec["file"], env, timeout)
+    return {"ok": False, "reason": f"unknown probe kind {kind!r}"}
+
+
+def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = False) -> dict:
+    ttl = float(spec.get("ttl_s") or 60)
+    now = time.monotonic()
+    hit = _probe_cache.get(name)
+    if not force and hit is not None and (now - hit["at"]) < ttl:
+        return hit["result"]
+    result = _run_probe(spec, env)
+    _probe_cache[name] = {"at": now, "result": result}
+    return result
+
+
+def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:
+    """The /health rows: env-level tri-state per capability, PLUS the live-probe verdict for
+    capabilities that declare one (probe failure demotes the row to ``misconfigured`` with a
+    reason). Probe results are cached per the probe's ``ttl_s``; a row's shape is
+    ``{"state": ..., "probe"?: {"ok": ..., ...}}`` — additive next to the env-only state."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    rows = {}
+    for name, state in capability_states(env).items():
+        row: dict = {"state": state}
+        spec = (caps.get(name) or {}).get("probe")
+        if spec and state == CONFIGURED:
+            result = _cached_probe(name, spec, env, force=force_probe)
+            row["probe"] = result
+            if not result.get("ok"):
+                row["state"] = MISCONFIGURED
+        rows[name] = row
+    return rows
+
+
+def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
+    """Boot-time validation of the declaration against the environment.
+
+    Raises :class:`ConfigError` naming EVERY missing required-explicit key (one actionable message,
+    not a peel-the-onion loop); runs each configured capability's live probe once; logs one line per
+    capability so a deploy's config completeness is visible in the boot log (a failed probe logs a
+    WARNING but never blocks boot — capabilities gate endpoints, not the process).
+    Returns ``{"service", "capabilities"}`` (the same row shape as :func:`capability_health`).
+    """
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    required = [e for e in decl.get("keys") or [] if e.get("class") == "required-explicit"]
+    missing = [e for e in required if not _is_set(env, e["key"])]
+    if missing:
+        detail = "; ".join(f"{e['key']} ({e['description']})" for e in missing)
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
+            f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
+            "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    rows = capability_health(env, force_probe=True)
+    for name, row in sorted(rows.items()):
+        if row["state"] == MISCONFIGURED:
+            log.warning("config.v1 capability %s: MISCONFIGURED — %s", name,
+                        (row.get("probe") or {}).get("reason", "some-but-not-all keys set"))
+        else:
+            log.info("config.v1 capability %s: %s", name, row["state"])
+    return {"service": decl.get("service"), "capabilities": rows}

--- a/core/identity/services/admin-api/tests/test_config_contract.py
+++ b/core/identity/services/admin-api/tests/test_config_contract.py
@@ -1,0 +1,30 @@
+"""#526 · config.v1 (ADR-0026) — admin-api's declaration + boot preflight.
+
+admin-api carries the fail-closed INTERNAL_API_SECRET guard (the /internal/validate endpoint), but
+was OUTSIDE the config-contract machinery: a deploy missing the secret booted green and 503'd every
+gateway validation hop — the 2026-04-23 shape (23 meetings failed while monitors stayed green).
+This pins the declaration + the boot preflight that refuses that deploy. Offline, stdlib only.
+"""
+from __future__ import annotations
+
+import pytest
+
+from admin_api import config_preflight as cp
+
+
+def test_declaration_loads_and_internal_secret_is_required():
+    decl = cp.load_declaration()
+    assert decl["service"] == "admin-api"
+    required = {k["key"] for k in decl["keys"] if k["class"] == "required-explicit"}
+    assert "INTERNAL_API_SECRET" in required, "the fail-closed guard's key must refuse a secretless boot"
+
+
+def test_preflight_refuses_boot_without_internal_api_secret():
+    with pytest.raises(cp.ConfigError) as ei:
+        cp.preflight({})  # a deploy that forgot the secret
+    assert "INTERNAL_API_SECRET" in str(ei.value)
+
+
+def test_preflight_passes_when_required_set():
+    # defaulted keys (DB_*, ADMIN_API_TOKEN, LOG_LEVEL, …) never block; only the required one matters.
+    cp.preflight({"INTERNAL_API_SECRET": "a-real-secret"})

--- a/deploy/contracts/README.md
+++ b/deploy/contracts/README.md
@@ -4,5 +4,10 @@ Contracts owned by the **deploy** concern (P4 — a contract nests with its owne
 
 - **`execution-targets.v1`** — the host/user-specific execution-target & resource registry: where each plan
   stage may run and what external resources it needs (ADR-0020). Secrets are referenced, never inline (P14).
+- **`config.v1`** — the per-service deployment-config contract (ADR-0026): each adopted service declares
+  every env key it reads by class (`required-explicit` / `defaulted` / `capability`), vendors `preflight.py`
+  verbatim as `config_preflight.py`, and refuses to boot on a missing required key. `gate:config-contract`
+  ties declaration ≡ deploy surfaces (compose · helm · lite) ≡ code reads.
 
-Enforced by `gate:schema` + `gate:contract-version` (like every `*.vN`) and `gate:execution-env`.
+Enforced by `gate:schema` + `gate:contract-version` (like every `*.vN`), plus `gate:execution-env`
+(execution-targets.v1) and `gate:config-contract` (config.v1).

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -695,6 +695,21 @@ const CONFIG_ADOPTED = [
     scan: ["core/agent/control_plane", "core/agent/shared"],
     compose: "agent-api", helm: ["deployment-agent-api.yaml"], lite: "agent-api",
   },
+  {
+    // #526: the two services carrying today's fail-closed INTERNAL_API_SECRET guard.
+    service: "admin-api",
+    decl: "core/identity/services/admin-api/src/admin_api/config.v1.json",
+    preflight: "core/identity/services/admin-api/src/admin_api/config_preflight.py",
+    scan: ["core/identity/services/admin-api/src"],
+    compose: "admin-api", helm: ["deployment-admin-api.yaml"], lite: "admin-api",
+  },
+  {
+    service: "gateway",
+    decl: "core/gateway/services/gateway/src/gateway/config.v1.json",
+    preflight: "core/gateway/services/gateway/src/gateway/config_preflight.py",
+    scan: ["core/gateway/services/gateway/src"],
+    compose: "gateway", helm: ["deployment-gateway.yaml"], lite: "gateway",
+  },
 ];
 
 // docker-compose.yml is parsed line-wise (no YAML dep): a service block runs from `  name:` to the


### PR DESCRIPTION
Closes #526. Refs the 2026-04-23 INTERNAL_API_SECRET incident.

## Value

> A deploy that omits a fail-closed secret on admin-api or gateway **refuses to boot** with one message naming the missing key — instead of coming up green and 503ing every API-key check.

## Root cause

ADR-0026's config-contract machinery (per-service `config.v1` declaration + boot preflight + a CI gate tying declaration ≡ deploy surfaces ≡ code reads) covered only **meeting-api, runtime, agent-api**. The two services carrying today's fail-closed `INTERNAL_API_SECRET` guard — **admin-api** and **gateway** — were outside it. The exact 04-23 shape (23 meetings failed, monitors green) is still live on the auth path, this time as *every API call*.

## Fix — adopt both (mirror the 3 existing adopters)

- **Vendor** `deploy/contracts/config.v1/preflight.py` verbatim as `config_preflight.py` in each (byte-equality enforced by the gate).
- **Declare** `config.v1.json` for each — every env key by class. `INTERNAL_API_SECRET` is **required-explicit** (refuses a secretless boot, even in `DEV_MODE` — the 04-23 lesson). admin-api: 12 keys; gateway: 22 (incl. the full `GUARD_*` edge-protection family from #555, reconciled per surface).
- **Call** `preflight()` at the top of each `build_production_app()`.
- **Register** both in `CONFIG_ADOPTED` (`gates.mjs`).

## Acceptance

| # | Observation | Status |
|---|---|---|
| gate | `gate:config-contract` now covers **5 services** and reconciles declaration ≡ compose · helm · lite ≡ code reads — green | ✅ |
| test | `test_config_contract` per service: `preflight()` **raises `ConfigError` naming `INTERNAL_API_SECRET`** without it; passes with it | ✅ (3+3) |
| A- | gateway **64 passed**, admin-api **45 passed** | ✅ |
| — | contracts README index gains `config.v1` (fixes the drift the issue flagged) | ✅ |

## Notes / decisions

- **`INTERNAL_API_SECRET` = required-explicit** on both (recommended over a `DEV_MODE`-relaxed capability): a missing secret must refuse boot. Stock compose/helm/lite all default the secret, so **no stock flow regresses**.
- **`AGENT_API_URL`** on gateway is scoped `targets: ["helm","lite"]` (compose doesn't set it) — no compose edit needed.
- **Deferred:** the docs.vexa.ai configuration/deployment/troubleshooting mdx pages (D6c).