### PR TITLE
meeting-api: pipeline liveness observable + bounded stream retention (#527)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -216,6 +216,24 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
     # `failed` with the evidence note, instead of retrying an error + dead DELETE every sweep forever.
     untracked_grace = float(os.getenv("MEETING_UNTRACKED_GRACE_SEC", "600"))
 
+    # #527: per-loop liveness heartbeats. A loop hung inside an await stops stamping, so /health can
+    # SEE a dead consumer that would otherwise look alive (live WS keeps flowing on a SEPARATE path —
+    # the 2026-04-26 silent-hang, found only by a user opening an empty transcript). Stored on
+    # app.state so /health reads them; the raw redis client + stream/group let /health also report
+    # collector-group lag (XINFO) — the diagnostic signal that existed but was exposed nowhere.
+    import time as _time
+
+    from .collector.ingest import CONSUMER_GROUP as _SEG_GROUP
+    from .collector.ingest import STREAM_NAME as _SEG_STREAM
+
+    ticks: dict[str, float] = {}
+    app.state.pipeline_ticks = ticks
+    app.state.pipeline_redis = redis_client
+    app.state.pipeline_stream = _SEG_STREAM
+    app.state.pipeline_group = _SEG_GROUP
+    app.state.pipeline_tick_stale_s = float(os.getenv("PIPELINE_TICK_STALE_S", "120"))
+    app.state.pipeline_lag_alarm = int(os.getenv("PIPELINE_LAG_ALARM", "500"))
+
     async def _segment_consumer_loop() -> None:
         # Drain the transcription_segments stream → persist + publish tc:…:mutable.
         while True:
@@ -225,6 +243,7 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
                 raise
             except Exception:
                 log.exception("segment consumer tick failed")
+            ticks["segment-consumer"] = _time.monotonic()  # #527: alive this iteration
             await asyncio.sleep(seg_interval)
 
     async def _db_writer_loop() -> None:
@@ -245,6 +264,7 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
                 raise
             except Exception:
                 log.exception("db-writer tick failed")
+            ticks["db-writer"] = _time.monotonic()  # #527: alive this iteration
             await asyncio.sleep(db_writer_interval)
 
     async def _webhook_drain_loop() -> None:

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -26,6 +26,8 @@ the conformance harness — the conformance assertions therefore drive THIS ship
 """
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Optional
 
 from fastapi import FastAPI, Request
@@ -37,6 +39,39 @@ from .collector.app import build_router as _build_collector_router
 from .collector.ports import RedisBus, TranscriptStore
 from .lifecycle.machine import LifecycleSink, MeetingStore
 from .obs import TraceMiddleware
+
+
+async def _pipeline_health(app) -> "tuple[dict, bool]":
+    """#527: derive pipeline liveness from the per-loop heartbeats + collector-group lag, and decide
+    whether to DEGRADE. A loop hung inside an await stops stamping, so its tick_age_s climbs past
+    PIPELINE_TICK_STALE_S even while the process and the live-WS path look healthy — exactly the
+    2026-04-26 silent hang. Returns ``({loops, consumer_lag}, degraded)``.
+
+    The probe MUST NOT itself hang (that would defeat the point): the XINFO call is bounded by a 2s
+    wait_for and any failure degrades to ``consumer_lag: "unavailable"`` rather than blocking."""
+    st = app.state
+    now = time.monotonic()
+    stale_s = getattr(st, "pipeline_tick_stale_s", 120.0)
+    lag_alarm = getattr(st, "pipeline_lag_alarm", 500)
+    loops = {name: round(now - ts, 1) for name, ts in (st.pipeline_ticks or {}).items()}
+    degraded = any(age > stale_s for age in loops.values())
+
+    lag = None
+    redis = getattr(st, "pipeline_redis", None)
+    if redis is not None:
+        try:
+            groups = await asyncio.wait_for(redis.xinfo_groups(st.pipeline_stream), timeout=2.0)
+            for g in groups or []:
+                name = g.get("name") if isinstance(g, dict) else None
+                name = name.decode() if isinstance(name, (bytes, bytearray)) else name
+                if name == st.pipeline_group:
+                    lag = g.get("lag")
+                    break
+        except Exception:
+            lag = "unavailable"  # a dead/absent group is itself a signal, never a hang
+    if isinstance(lag, int) and lag > lag_alarm:
+        degraded = True
+    return {"loops": loops, "consumer_lag": lag}, degraded
 
 
 def create_app(
@@ -85,7 +120,19 @@ def create_app(
     async def health():
         from .config_preflight import capability_health
 
-        return {"status": "ok", "service": "meeting-api", "capabilities": capability_health()}
+        body = {"status": "ok", "service": "meeting-api", "capabilities": capability_health()}
+        # #527: additive `pipeline` section — present ONLY when the background loops are wired
+        # (build_production_app sets app.state.pipeline_ticks). On the bare app-factory path (unit
+        # tests, conformance) the section is omitted and status stays "ok" — existing /health
+        # consumers are unchanged. A stale loop or a lag over threshold flips status→degraded + 503,
+        # so a dead pipeline that keeps the live-WS path flowing no longer looks healthy.
+        if getattr(app.state, "pipeline_ticks", None) is not None:
+            pipeline, degraded = await _pipeline_health(app)
+            body["pipeline"] = pipeline
+            if degraded:
+                body["status"] = "degraded"
+                return JSONResponse(body, status_code=503)
+        return body
 
     # --- bot_spawn ports (resolved FIRST: the meeting_repo is also the lifecycle-persistence target) ---
     if meeting_repo is None:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/db_writer.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/db_writer.py
@@ -63,6 +63,72 @@ log = logging.getLogger("meeting_api.collector.db_writer")
 ACTIVE_MEETINGS_KEY = "active_meetings"
 IMMUTABILITY_THRESHOLD = float(os.environ.get("IMMUTABILITY_THRESHOLD", "30"))
 
+# #527 C2: how long an ACKED transcription_segments entry is retained before it is eligible to be
+# trimmed. Retention NEVER trims an entry the collector group has not read (the 2026-04-26 data loss,
+# where a MAXLEN trim aged out entries a hung consumer never got to) — a behind/hung group keeps its
+# full backlog, and the hang is surfaced by /health (C1) rather than papered over by trimming it.
+STREAM_RETENTION_S = float(os.environ.get("STREAM_RETENTION_S", "3600"))
+
+
+def _parse_stream_id(v) -> "Optional[tuple[int, int]]":
+    """A redis stream id ``"<ms>-<seq>"`` → ``(ms, seq)`` for ordering; None if unparseable."""
+    if v is None:
+        return None
+    if isinstance(v, (bytes, bytearray)):
+        v = v.decode()
+    try:
+        ms, seq = str(v).split("-")
+        return (int(ms), int(seq))
+    except Exception:
+        return None
+
+
+def _pending_min_id(pending) -> "Optional[tuple[int, int]]":
+    """Oldest DELIVERED-but-un-acked id for the group, from an XPENDING summary, as (ms, seq)."""
+    if not isinstance(pending, dict):
+        return None
+    return _parse_stream_id(pending.get("min"))
+
+
+async def _group_last_delivered_id(redis_c, stream: str, group: str) -> "Optional[tuple[int, int]]":
+    """The group's last-delivered-id — entries AFTER it are UNDELIVERED (the lag) and must survive."""
+    for g in (await redis_c.xinfo_groups(stream)) or []:
+        name = g.get("name") if isinstance(g, dict) else None
+        if isinstance(name, (bytes, bytearray)):
+            name = name.decode()
+        if name == group:
+            return _parse_stream_id(g.get("last-delivered-id"))
+    return None
+
+
+async def _trim_segments_stream(redis_c, retention_s: float, now_ms: int) -> None:
+    """Trim ``transcription_segments`` to entries newer than the retention floor — but NEVER past an
+    entry the collector group has not fully consumed. "Unread" is two things: DELIVERED-but-un-acked
+    (pending) and UNDELIVERED (past the group's last-delivered-id, i.e. the lag). The trim floor is
+    the OLDER of {retention time, oldest pending, last-delivered-id}, so an acked-and-aged entry is
+    trimmed while any un-consumed entry survives (the 2026-04-26 data-loss guard)."""
+    from .ingest import CONSUMER_GROUP, STREAM_NAME
+
+    floor = (max(0, now_ms - int(retention_s * 1000)), 0)  # time-based minid we would keep from
+    try:
+        oldest_pending = _pending_min_id(await redis_c.xpending(STREAM_NAME, CONSUMER_GROUP))
+        if oldest_pending is not None:
+            floor = min(floor, oldest_pending)
+        last_delivered = await _group_last_delivered_id(redis_c, STREAM_NAME, CONSUMER_GROUP)
+        if last_delivered is not None:
+            # keep everything STRICTLY AFTER last-delivered (the UNDELIVERED lag); the last-delivered
+            # entry itself is consumed, so the exclusive floor is (ms, seq+1).
+            floor = min(floor, (last_delivered[0], last_delivered[1] + 1))
+    except Exception:
+        return  # no group/stream yet, or XINFO/XPENDING unsupported — do not risk a blind trim
+    minid = f"{floor[0]}-{floor[1]}"
+    try:
+        await redis_c.xtrim(STREAM_NAME, minid=minid, approximate=True)
+    except TypeError:
+        await redis_c.xtrim(STREAM_NAME, minid=minid)  # older redis-py signature
+    except Exception:
+        pass
+
 # ── the end-of-processing protocol (ADR 0027 / processed-notes.v1) ────────────────────────────────
 # The copilot worker runs one final LLM beat AFTER session_end (~10s), then XADDs a `view_end`
 # marker: the proc stream is COMPLETE at that entry. finalize_meeting's inline drain used to be the
@@ -316,6 +382,14 @@ async def db_writer_tick(
                 await redis_c.zrem(PROC_PENDING_KEY, raw_id)
         except Exception:  # noqa: BLE001 — isolate per meeting; the next tick retries
             log.exception("pending processed re-drain failed for meeting %s", raw_id)
+
+    # #527 C2: bound the ingest stream in steady state (trims only acked entries past the retention
+    # window; never an unread one). Isolated — a trim failure never blocks the durable flush above.
+    try:
+        now_ms = int((now.timestamp() if now is not None else datetime.now(timezone.utc).timestamp()) * 1000)
+        await _trim_segments_stream(redis_c, STREAM_RETENTION_S, now_ms)
+    except Exception:  # noqa: BLE001
+        log.exception("segment stream retention trim failed")
     return total
 
 

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -338,6 +338,27 @@
    "default": "300",
    "description": "calendar-sync sweep cadence (s) — how often connected ICS feeds are re-fetched and upserted into planned meetings",
    "targets": []
+  },
+  {
+   "key": "PIPELINE_TICK_STALE_S",
+   "class": "defaulted",
+   "default": "120",
+   "description": "#527: a background loop whose last heartbeat is older than this flips /health to degraded+503 (a hung consumer no longer looks alive)",
+   "targets": []
+  },
+  {
+   "key": "PIPELINE_LAG_ALARM",
+   "class": "defaulted",
+   "default": "500",
+   "description": "#527: collector-group lag (unread transcription_segments) over this flips /health to degraded+503",
+   "targets": []
+  },
+  {
+   "key": "STREAM_RETENTION_S",
+   "class": "defaulted",
+   "default": "3600",
+   "description": "#527: acked transcription_segments entries older than this are trimmed; an unread (un-acked) entry is NEVER trimmed regardless of age (the 2026-04-26 data-loss guard)",
+   "targets": []
   }
  ],
  "capabilities": {

--- a/core/meetings/services/meeting-api/tests/test_pipeline_health.py
+++ b/core/meetings/services/meeting-api/tests/test_pipeline_health.py
@@ -1,0 +1,75 @@
+"""#527 · C1/A1 — /health exposes pipeline liveness so a dead consumer no longer looks alive.
+
+On 2026-04-26 the persistence consumer froze inside one await for 10h38m: /health kept returning
+200, the k8s probe kept passing, and live WS kept flowing (a separate path) — while zero rows
+reached the DB and 20 meetings' transcripts were lost. These drive the UNIFIED app (meeting_api.
+create_app) and inject the same app.state the background loops set, so the /health decision is
+proven offline without redis. (tests/test_health.py covers lifecycle.receiver.create_app — a
+DIFFERENT app — so this is the only lane over the unified /health pipeline section.)
+"""
+from __future__ import annotations
+
+import time
+
+from fastapi.testclient import TestClient
+
+from meeting_api import create_app
+
+
+class _FakeRedis:
+    def __init__(self, lag=0, ok=True):
+        self._lag, self._ok = lag, ok
+
+    async def xinfo_groups(self, stream):
+        if not self._ok:
+            raise RuntimeError("NOGROUP")
+        return [{"name": "collector_group", "lag": self._lag}]
+
+
+def _client(*, ticks, lag=0, ok=True, stale_s=120, lag_alarm=500):
+    app = create_app()
+    app.state.pipeline_ticks = ticks
+    app.state.pipeline_redis = _FakeRedis(lag=lag, ok=ok)
+    app.state.pipeline_stream = "transcription_segments"
+    app.state.pipeline_group = "collector_group"
+    app.state.pipeline_tick_stale_s = float(stale_s)
+    app.state.pipeline_lag_alarm = int(lag_alarm)
+    return TestClient(app)
+
+
+def test_bare_app_omits_pipeline_section_and_stays_ok():
+    """Regression guard: the app-factory path (no loops wired → no app.state.pipeline_ticks) keeps
+    the pre-#527 /health verbatim — status ok, no pipeline section — so every existing consumer works."""
+    r = TestClient(create_app()).get("/health")
+    assert r.status_code == 200 and r.json()["status"] == "ok"
+    assert "pipeline" not in r.json()
+
+
+def test_healthy_pipeline_is_ok_with_section():
+    now = time.monotonic()
+    r = _client(ticks={"segment-consumer": now, "db-writer": now}, lag=3).get("/health")
+    assert r.status_code == 200 and r.json()["status"] == "ok"
+    assert r.json()["pipeline"]["consumer_lag"] == 3
+    assert set(r.json()["pipeline"]["loops"]) == {"segment-consumer", "db-writer"}
+
+
+def test_stale_loop_degrades_503():
+    """A loop whose heartbeat is older than the threshold (a hang) flips status→degraded + 503 — the
+    signal that was missing on 2026-04-26."""
+    r = _client(ticks={"segment-consumer": time.monotonic() - 9999,
+                       "db-writer": time.monotonic()}, stale_s=120).get("/health")
+    assert r.status_code == 503 and r.json()["status"] == "degraded"
+    assert r.json()["pipeline"]["loops"]["segment-consumer"] > 120
+
+
+def test_high_consumer_lag_degrades_503():
+    r = _client(ticks={"segment-consumer": time.monotonic()}, lag=10_000, lag_alarm=500).get("/health")
+    assert r.status_code == 503 and r.json()["status"] == "degraded"
+
+
+def test_lag_probe_failure_reports_unavailable_not_a_hang():
+    """The probe itself must never hang: a dead/absent group → consumer_lag 'unavailable', 200 (the
+    loops are fresh) — observability, never a blocked request."""
+    r = _client(ticks={"segment-consumer": time.monotonic()}, ok=False).get("/health")
+    assert r.status_code == 200
+    assert r.json()["pipeline"]["consumer_lag"] == "unavailable"

--- a/core/meetings/services/meeting-api/tests/test_stream_retention.py
+++ b/core/meetings/services/meeting-api/tests/test_stream_retention.py
@@ -1,0 +1,73 @@
+"""#527 · C2/A2 — bounded stream retention that NEVER ages out an un-consumed entry.
+
+On 2026-04-26 the stream's MAXLEN trim aged out entries before the (hung) consumer read them → 20
+meetings' transcripts permanently lost. The retention here trims only entries that are BOTH older
+than the window AND already consumed (acked, and behind the group's last-delivered-id). Un-acked
+(pending) and undelivered (lag) entries always survive. Driven against fakeredis — no real redis.
+"""
+from __future__ import annotations
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+from fakeredis import aioredis as fake_aioredis  # noqa: E402
+
+from meeting_api.collector.db_writer import _trim_segments_stream  # noqa: E402
+from meeting_api.collector.ingest import CONSUMER_GROUP, STREAM_NAME  # noqa: E402
+
+# a "now" far in the future so every seeded entry is older than the retention window
+NOW_MS = 10_000_000_000_000
+RETENTION_S = 3600
+
+
+async def _seed(r, n):
+    ids = []
+    for i in range(1, n + 1):
+        ids.append(await r.xadd(STREAM_NAME, {"payload": "{}"}, id=f"{1000 + i}-0"))
+    await r.xgroup_create(STREAM_NAME, CONSUMER_GROUP, id="0")
+    return ids
+
+
+async def _ids(r):
+    return [e[0] for e in await r.xrange(STREAM_NAME)]
+
+
+async def test_acked_and_aged_entries_are_trimmed():
+    r = fake_aioredis.FakeRedis(decode_responses=True)
+    ids = await _seed(r, 5)
+    # deliver + ack the first 3 (fully consumed); 4-5 remain UNDELIVERED (the lag)
+    msgs = await r.xreadgroup(CONSUMER_GROUP, "c1", {STREAM_NAME: ">"}, count=3)
+    delivered = [m[0] for m in msgs[0][1]]
+    await r.xack(STREAM_NAME, CONSUMER_GROUP, *delivered)
+
+    await _trim_segments_stream(r, RETENTION_S, NOW_MS)
+
+    remaining = await _ids(r)
+    # the 3 acked-and-aged entries are gone; the 2 UNDELIVERED entries survive (never aged out)
+    assert ids[0] not in remaining and ids[1] not in remaining and ids[2] not in remaining
+    assert ids[3] in remaining and ids[4] in remaining
+
+
+async def test_pending_entry_is_never_trimmed():
+    r = fake_aioredis.FakeRedis(decode_responses=True)
+    ids = await _seed(r, 4)
+    # deliver 2 but ack only the first → id[1] is PENDING (delivered, un-acked)
+    msgs = await r.xreadgroup(CONSUMER_GROUP, "c1", {STREAM_NAME: ">"}, count=2)
+    delivered = [m[0] for m in msgs[0][1]]
+    await r.xack(STREAM_NAME, CONSUMER_GROUP, delivered[0])
+
+    await _trim_segments_stream(r, RETENTION_S, NOW_MS)
+
+    remaining = await _ids(r)
+    assert ids[0] not in remaining, "the acked-and-aged entry should be trimmed"
+    assert ids[1] in remaining, "a PENDING (delivered-unacked) entry must survive"
+    assert ids[2] in remaining and ids[3] in remaining, "UNDELIVERED entries must survive"
+
+
+async def test_no_group_does_not_blind_trim():
+    r = fake_aioredis.FakeRedis(decode_responses=True)
+    for i in range(1, 4):
+        await r.xadd(STREAM_NAME, {"payload": "{}"}, id=f"{1000 + i}-0")
+    # no consumer group created → the trim must NOT drop entries it can't prove are consumed
+    await _trim_segments_stream(r, RETENTION_S, NOW_MS)
+    assert len(await _ids(r)) == 3


### PR DESCRIPTION
Closes #527 (offline arm). Refs the 2026-04-26 collector silent-hang incident.

## Value

> A dead persistence consumer is **visible** (/health degrades) instead of looking alive while data is lost — and the stream is bounded **without** ever aging out an entry the consumer hasn't read.

## Root cause

The consumer froze inside one `await` for 10h38m: `/health` stayed 200, the k8s probe kept passing, live WS kept flowing (separate path) — 0 rows persisted, 20 meetings' transcripts lost because MAXLEN trimmed entries before recovery. The `XINFO … idle/lag` signal existed but was exposed nowhere.

## C1 — liveness observable

- Each loop stamps a monotonic heartbeat on `app.state` after every iteration; a hung loop stops stamping.
- `/health` gains an **additive** `pipeline` section (per-loop `tick_age_s` + collector-group `lag` via a **2s-bounded** XINFO) → flips `status: degraded` + **503** on a stale loop or lag over threshold.
- **Regression-safe:** the section appears only when loops are wired (`app.state.pipeline_ticks`); the bare app-factory path is byte-unchanged (`status: ok`, no section).
- The probe can't itself hang (`wait_for` 2s → `consumer_lag: "unavailable"`).

## C2 — bounded retention that never loses unread data

`db_writer_tick` trims `transcription_segments` to entries newer than `STREAM_RETENTION_S`, but **never past an un-consumed entry**: floor = OLDER of { retention time, oldest **pending** (delivered-unacked), **last-delivered-id + 1** (the undelivered lag) }. Acked-and-aged → trimmed; pending/undelivered → always survive. A behind/hung group keeps its full backlog (the hang is caught by C1). No group yet → no blind trim.

## Acceptance

| # | Observation | Status |
|---|---|---|
| C1/A1 | `test_pipeline_health`: bare→ok+no-section; healthy→ok+section; **stale loop→503**; high lag→503; probe-fail→unavailable-not-hang | ✅ |
| C2/A2 | `test_stream_retention` (fakeredis): acked-aged **trimmed**; **pending kept**; **undelivered kept**; no-group→no blind trim | ✅ |
| gate | config-contract green (new knobs declared) | ✅ |
| A- | meeting-api lane **642 passed / 2 skipped** | ✅ |

## Notes / deferred

- **Retention honors the slowest reader → unbounded growth during a hang is possible** — deliberate: the hang is now *visible* via C1 (an operator restarts) rather than hidden by trimming unread entries (the 04-26 data loss). No absolute MAXLEN cap that could re-introduce the loss.
- **Deferred:** the live chaos row (C3 — stall the consumer via `SEGMENT_CONSUMER_INTERVAL`, assert `/health` degraded within the window; operator-run) and the docs.vexa.ai troubleshooting/config pages.