### PR TITLE
fix(gmeet): report signed-out authenticated sessions

### DIFF
--- a/core/meetings/modules/join/src/googlemeet/join.ts
+++ b/core/meetings/modules/join/src/googlemeet/join.ts
@@ -9,6 +9,15 @@ import {
 } from "./selectors";
 import { HumanizedInteractor, MOCAP_LIBRARY } from "./humanized";
 
+/** Error thrown when authenticated mode detects a signed-out browser profile. */
+class AuthSessionError extends Error {
+  readonly outcome = "auth_session_missing" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthSessionError";
+  }
+}
+
 // Google Meet now blocks browser-synthetic input (Playwright/CDP clicks have
 // isTrusted=false and no real pointer movement). "humanized" mode routes join
 // interactions through real OS-level XTEST input along recorded-style mouse
@@ -165,7 +174,9 @@ export async function joinGoogleMeeting(
     // Authenticated users may see different buttons:
     // - "Join now" — standard authenticated join
     // - "Switch here" — same account already in the meeting
-    // - "Ask to join" — cookies didn't load (fallback to anonymous)
+    // - "Ask to join" — two cases:
+    //   a) Guest lobby (name input visible) → browser profile signed out → fail closed
+    //   b) Signed-in account not pre-admitted (no name input) → proceed
     const joinNowSelector = 'button:has-text("Join now")';
     const switchHereSelector = 'button:has-text("Switch here")';
     // Text-matched directly: googleJoinButtonSelectors[0] is :not([aria-label]) and the
@@ -187,27 +198,26 @@ export async function joinGoogleMeeting(
         await clickHandle(joinButton.el!, "switch_here");
         log("Bot joined Google Meet as authenticated user (Switch here — same account already in call).");
       } else {
-        // "Ask to join" in authenticated mode = the signed-in account isn't pre-admitted
-        // to THIS meeting (not host / same-org / invited), so it must knock — like an
-        // anonymous join but carrying the real account identity. (Also the path if cookies
-        // genuinely failed to load.) A signed-in account shows no name field; the fill
-        // below is a harmless safety for the cookies-failed case.
-        log("Authenticated account not pre-admitted — knocking via 'Ask to join'.");
-        try {
-          const nameFieldSelector = googleNameInputSelectors[0];
-          const nameField = await page.$(nameFieldSelector);
-          if (nameField) {
-            await fillField(nameField, nameFieldSelector, botName, "name");
-            log(`Filled bot name: ${botName}`);
-          }
-        } catch (e) {
-          // no name field for a signed-in account — expected
+        // "Ask to join" in authenticated mode — determine whether this is a signed-out guest lobby
+        // (name input visible) or a signed-in account not pre-admitted (no name input).
+        const nameField = await page.$(googleNameInputSelectors[0]).catch(() => null);
+        if (nameField && (await nameField.isVisible?.() ?? true)) {
+          // Guest lobby detected — browser profile is signed out, fail closed.
+          // Take a diagnostic screenshot before throwing so the operator can see the lobby state.
+          await page.screenshot({ path: '/app/storage/screenshots/bot-checkpoint-auth-signed-out.png', fullPage: true });
+          log("📸 Screenshot: authenticated mode but browser profile is signed out (guest lobby).");
+          throw new AuthSessionError(
+            "Browser profile signed out — cannot authenticate with Google. Re-authenticate the profile and retry."
+          );
         }
-
+        // Signed-in account not pre-admitted (host approval required) — proceed
+        log("Authenticated account not pre-admitted — knocking via 'Ask to join'.");
         await clickHandle(joinButton.el!, "ask_to_join");
         log("Bot requested to join Google Meet (Ask to join) as the signed-in account.");
       }
     } catch (e) {
+      // Re-throw auth-session errors without masking them as "button not found".
+      if (e instanceof AuthSessionError) throw e;
       // No button found — take diagnostic screenshot and fail
       await page.screenshot({ path: '/app/storage/screenshots/bot-checkpoint-auth-failed.png', fullPage: true });
       log("📸 Screenshot: No join button found after 30s");

--- a/core/meetings/modules/join/src/googlemeet/join.ts
+++ b/core/meetings/modules/join/src/googlemeet/join.ts
@@ -218,9 +218,9 @@ export async function joinGoogleMeeting(
     } catch (e) {
       // Re-throw auth-session errors without masking them as "button not found".
       if (e instanceof AuthSessionError) throw e;
-      // No button found — take diagnostic screenshot and fail
+      // No join button found — take diagnostic screenshot and fail
       await page.screenshot({ path: '/app/storage/screenshots/bot-checkpoint-auth-failed.png', fullPage: true });
-      log("📸 Screenshot: No join button found after 30s");
+      log("📸 Screenshot: No join button found after 30s (or join button vanished before click).");
       throw e;
     }
 

--- a/docs/changelog.d/607-auth-session-fallback.md
+++ b/docs/changelog.d/607-auth-session-fallback.md
@@ -1,0 +1,6 @@
+- **Google Meet authenticated join: fail closed on signed-out browser profile (#607).** When
+  `authenticated: true` the bot now refuses to degrade to an anonymous join if the browser profile
+  is signed out — instead it throws a typed `AuthSessionError("auth_session_missing")` that the
+  orchestrator maps to a permanent failure. The guard distinguishes a signed-out guest lobby
+  (name input visible) from a signed-in-but-not-pre-admitted account (no name input), which still
+  knocks via "Ask to join".

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -94,6 +94,13 @@ curl -X DELETE "$API_BASE/bots/google_meet/abc-defg-hij" -H "X-API-Key: $API_KEY
 The audio **recording** lands in your object storage — retrieve it via `GET /recordings`
 ([Meetings API](/api/meetings#recordings)).
 
+## Authenticated mode
+
+When `authenticated: true` is set in the request, the bot uses a persistent browser profile to join
+the call as your Google account. If the profile is signed out (session expired, cookies cleared), the
+bot **refuses to join** with an `auth_session_missing` error — it never silently degrades to an anonymous
+join. Re-authenticate the browser profile and retry.
+
 ## Next
 
 The transcript compiles into your [workspace](/concepts#workspace), where agents act on it. Turn that into


### PR DESCRIPTION
## What changed

When Google Meet is requested in authenticated mode but the persisted browser profile is signed out, detect the guest lobby and fail with an actionable error instead of continuing with an anonymous identity.

## Validation

- Join-module tests, including the guest-lobby regression test.
- TypeScript build.
- Static gates.

Related: #540.