### PR TITLE
fix(gmeet): prevent X11 input commands from hanging

### DIFF
--- a/core/meetings/modules/join/src/googlemeet/humanized/humanized.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/humanized/humanized.test.ts
@@ -95,6 +95,11 @@ console.log("\nTest 4: X11Input command emission (dryRun)");
   assert(argvs.some((a) => a === "xdotool mouseup 1"), "button up via xdotool mouseup");
   assert(argvs.some((a) => a === "xdotool type --clearmodifiers --delay 55 -- VexaBot"), "text entry uses XTEST xdotool type (not the hang-prone clipboard path)");
 
+  // The real runner applies a bounded timeout to every external X11 command.
+  // This is not observable in dryRun, so pin the public option/default seam.
+  const bounded = new X11Input({ dryRun: true, commandTimeoutMs: 750 });
+  assert((bounded as any).commandTimeoutMs === 750, "X11 commands accept an explicit timeout");
+
   // ── 5. End-to-end replay against a fake Page (dryRun) ──────
   console.log("\nTest 5: navigateAndClick replay (fake page, dryRun)");
   const fakePage = makeFakePage({ left: 800, top: 420, width: 120, height: 44, dpr: 1, screenX: 0, screenY: 0 });

--- a/core/meetings/modules/join/src/googlemeet/humanized/x11Input.ts
+++ b/core/meetings/modules/join/src/googlemeet/humanized/x11Input.ts
@@ -17,11 +17,14 @@ export interface X11InputOptions {
   display?: string;
   /** When true, commands are recorded instead of executed (unit tests). */
   dryRun?: boolean;
+  /** Maximum time an individual xdotool/xclip command may block. */
+  commandTimeoutMs?: number;
 }
 
 export class X11Input {
   private display: string;
   private dryRun: boolean;
+  private commandTimeoutMs: number;
   /** Recorded argv lines when dryRun is on. */
   readonly log: string[][] = [];
   /** Simulated pointer position, maintained only in dryRun for faithful tests. */
@@ -30,6 +33,7 @@ export class X11Input {
   constructor(opts: X11InputOptions = {}) {
     this.display = opts.display ?? process.env.DISPLAY ?? ":99";
     this.dryRun = opts.dryRun ?? false;
+    this.commandTimeoutMs = opts.commandTimeoutMs ?? 5000;
   }
 
   private run(args: string[], stdin?: Buffer): Promise<string> {
@@ -41,7 +45,10 @@ export class X11Input {
       const child = execFile(
         args[0],
         args.slice(1),
-        { env: { ...process.env, DISPLAY: this.display } },
+        {
+          env: { ...process.env, DISPLAY: this.display },
+          timeout: this.commandTimeoutMs,
+        },
         (err, stdout) => {
           if (err) reject(err);
           else resolve(stdout);


### PR DESCRIPTION
## What changed

Prevent Google Meet input commands from waiting forever when the X11 display becomes unavailable. Every external X11 command now has a configurable timeout.

- Default timeout: 5 seconds.
- Per-instance override: `commandTimeoutMs`.
- Existing dry-run behavior and pointer/click semantics are unchanged.
- Added a regression assertion for the timeout seam.

## Root cause

`xdotool`/`xclip` commands were launched without a timeout. If Xvfb or the X11 connection became unhealthy, a single input operation could remain pending indefinitely and leave the bot stuck in the join flow. This is directly relevant to [#556](https://github.com/Vexa-ai/vexa/issues/556).

This PR deliberately addresses only the unbounded wait. It does not claim to solve the separate pointer-calibration miss reported in #556; it ensures that an external-command failure becomes a reported error instead of leaving the bot stuck indefinitely.

## Use case

When a headful browser runs against a temporarily unavailable or unhealthy X11 display, the bot must terminate the current interaction attempt with a bounded error. Operators then get the existing diagnostic path instead of a workload that remains stuck until an external timeout.

The change is platform-generic, contains no deployment-specific paths or credentials, and does not change the intended click trajectory when X11 is healthy.

## Validation

- `pnpm --filter @vexa/join test` — all join-module tests passed.
- `pnpm --filter @vexa/join build` — TypeScript build passed.
- Pre-push static gates passed.
