### PR TITLE
feat(bot): expose Google Meet speaker stream tuning

### DIFF
--- a/core/meetings/services/bot/src/config.test.ts
+++ b/core/meetings/services/bot/src/config.test.ts
@@ -10,7 +10,7 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseInvocation, loadInvocation, InvocationError } from './config.js';
+import { parseInvocation, loadInvocation, InvocationError, speakerStreamConfigFromEnv } from './config.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GOLDEN_DIR = join(HERE, '..', '..', '..', 'contracts', 'invocation.v1', 'golden');
@@ -69,3 +69,24 @@ for (const g of goldens) {
 
 if (failed) { console.error(`\n❌ config (L1/L2): ${failed} check(s) FAILED.`); process.exit(1); }
 console.log('\n✅ config (L1/L2): the goldens parse, the env helper round-trips, and off-contract input fails fast (ajv ≡ invocation.v1).');
+
+// ── speaker-stream env tuning ─────────────────────────────────────────────────
+{
+  const warnings: string[] = [];
+  const config = speakerStreamConfigFromEnv({
+    BOT_SPEAKER_MIN_AUDIO_SEC: '1',
+    BOT_SPEAKER_SUBMIT_INTERVAL_SEC: '1.5',
+    BOT_SPEAKER_CONFIRM_THRESHOLD: '1',
+    BOT_SPEAKER_MAX_BUFFER_SEC: '30',
+    BOT_SPEAKER_IDLE_TIMEOUT_SEC: '15',
+  }, (message) => warnings.push(message));
+  check('speaker-stream env values reach the config', config?.minAudioDuration === 1 && config.submitInterval === 1.5 && config.confirmThreshold === 1 && config.maxBufferDuration === 30 && config.idleTimeoutSec === 15);
+  check('valid speaker-stream env emits no warnings', warnings.length === 0, warnings.join('; '));
+
+  const invalidWarnings: string[] = [];
+  const invalid = speakerStreamConfigFromEnv({
+    BOT_SPEAKER_MIN_AUDIO_SEC: 'nope',
+    BOT_SPEAKER_CONFIRM_THRESHOLD: '1.5',
+  }, (message) => invalidWarnings.push(message));
+  check('invalid speaker-stream values fall back loudly', invalid === undefined && invalidWarnings.length === 2, invalidWarnings.join('; '));
+}

--- a/core/meetings/services/bot/src/config.ts
+++ b/core/meetings/services/bot/src/config.ts
@@ -24,6 +24,7 @@ import { readFileSync } from 'node:fs';
 const addFormats = addFormatsDefault as unknown as (ajv: Ajv) => Ajv;
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { SpeakerStreamManagerConfig } from '@vexa/gmeet-pipeline';
 
 export type Platform = 'google_meet' | 'zoom' | 'teams' | 'jitsi';
 export type TranscriptionTier = 'realtime' | 'deferred';
@@ -132,4 +133,35 @@ export function parseInvocation(raw: string | undefined): Invocation {
 /** Boot helper — read VEXA_BOT_CONFIG from the environment and validate it (P7: config by env). */
 export function loadInvocation(env: NodeJS.ProcessEnv = process.env): Invocation {
   return parseInvocation(env.VEXA_BOT_CONFIG);
+}
+
+const SPEAKER_STREAM_ENV: Array<[keyof SpeakerStreamManagerConfig, string]> = [
+  ['minAudioDuration', 'BOT_SPEAKER_MIN_AUDIO_SEC'],
+  ['submitInterval', 'BOT_SPEAKER_SUBMIT_INTERVAL_SEC'],
+  ['confirmThreshold', 'BOT_SPEAKER_CONFIRM_THRESHOLD'],
+  ['maxBufferDuration', 'BOT_SPEAKER_MAX_BUFFER_SEC'],
+  ['idleTimeoutSec', 'BOT_SPEAKER_IDLE_TIMEOUT_SEC'],
+];
+
+/** Read optional Meet speaker-stream tuning knobs from the bot environment. */
+export function speakerStreamConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  warn: (message: string) => void = (message) => console.warn(`[bot] ${message}`),
+): SpeakerStreamManagerConfig | undefined {
+  const config: SpeakerStreamManagerConfig = {};
+  let configured = false;
+  for (const [property, key] of SPEAKER_STREAM_ENV) {
+    const raw = env[key];
+    if (raw === undefined || raw.trim() === '') continue;
+    const value = Number(raw);
+    const valid = Number.isFinite(value) && value > 0 &&
+      (property !== 'confirmThreshold' || Number.isInteger(value));
+    if (!valid) {
+      warn(`${key}=${JSON.stringify(raw)} is invalid; using the built-in speaker-stream default`);
+      continue;
+    }
+    config[property] = value;
+    configured = true;
+  }
+  return configured ? config : undefined;
 }

--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -22,7 +22,7 @@
  * terminal `failed` (join_failure) rather than crashing the root — same disposability as the
  * lazy redis connect.
  */
-import { loadInvocation, InvocationError, type Invocation } from './config.js';
+import { loadInvocation, InvocationError, speakerStreamConfigFromEnv, type Invocation } from './config.js';
 import type { Act, LifecycleEvent } from './contracts.js';
 import { createOrchestrator } from './orchestrator.js';
 import { createHttpLifecycleSink } from './adapters/lifecycle-http.js';
@@ -170,11 +170,13 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
   let stopRecording: () => Promise<void> = async () => { /* no-op until pipeline.start() wires recording */ };
   let acts: ActsSource = liveActs;
   const recording = inv.recordingEnabled ? createBotRecordingSink({ inv, log: (m) => console.log(`[bot] ${m}`) }) : undefined;
+  const speakerStreamConfig = speakerStreamConfigFromEnv(env);
+  if (speakerStreamConfig) console.log(`[bot] speaker-stream tuning enabled: ${JSON.stringify(speakerStreamConfig)}`);
 
   try {
     session = await launchBrowser(inv);                                   // L4 (O6/VM)
     join = createBrowserJoinDriver(session.page, inv);
-    botPipeline = createBotPipeline(inv, transcript, { onError: (e) => console.error(`[bot] pipeline fault: ${String(e)}`) });
+    botPipeline = createBotPipeline(inv, transcript, { config: speakerStreamConfig, onError: (e) => console.error(`[bot] pipeline fault: ${String(e)}`) });
     // Defer the page-side capture start to pipeline.start(): the orchestrator calls it AFTER
     // admission (orchestrator.ts:125), on the LIVE meeting page — where addInitScript has injected
     // window.VexaBrowserUtils and the participant <audio> elements exist. Starting it at launch ran

--- a/core/runtime/src/runtime_kernel/config.v1.json
+++ b/core/runtime/src/runtime_kernel/config.v1.json
@@ -96,6 +96,41 @@
    "description": "the meeting-bot image the `meeting-bot` profile spawns (vexaai/vexa-bot:v012)"
   },
   {
+   "key": "BOT_SPEAKER_MIN_AUDIO_SEC",
+   "class": "defaulted",
+   "default": "(unset — bot default)",
+   "description": "minimum Google Meet speaker audio window before transcription submission; forwarded to spawned bots",
+   "targets": ["compose", "helm", "lite"]
+  },
+  {
+   "key": "BOT_SPEAKER_SUBMIT_INTERVAL_SEC",
+   "class": "defaulted",
+   "default": "(unset — bot default)",
+   "description": "Google Meet speaker-stream submission interval; forwarded to spawned bots",
+   "targets": ["compose", "helm", "lite"]
+  },
+  {
+   "key": "BOT_SPEAKER_CONFIRM_THRESHOLD",
+   "class": "defaulted",
+   "default": "(unset — bot default)",
+   "description": "consecutive transcription matches required to confirm a Google Meet segment; forwarded to spawned bots",
+   "targets": ["compose", "helm", "lite"]
+  },
+  {
+   "key": "BOT_SPEAKER_MAX_BUFFER_SEC",
+   "class": "defaulted",
+   "default": "(unset — bot default)",
+   "description": "maximum Google Meet speaker audio buffer before force flush; forwarded to spawned bots",
+   "targets": ["compose", "helm", "lite"]
+  },
+  {
+   "key": "BOT_SPEAKER_IDLE_TIMEOUT_SEC",
+   "class": "defaulted",
+   "default": "(unset — bot default)",
+   "description": "Google Meet speaker idle flush timeout; forwarded to spawned bots",
+   "targets": ["compose", "helm", "lite"]
+  },
+  {
    "key": "AGENT_IMAGE",
    "class": "capability",
    "capability": "agent_spawn",

--- a/core/runtime/src/runtime_kernel/profiles.py
+++ b/core/runtime/src/runtime_kernel/profiles.py
@@ -96,6 +96,17 @@ def default_registry() -> ProfileRegistry:
     # agent-api image). The Docker backend ensures it is present at startup, pulling it when absent
     # (build_production_app → DockerBackend.ensure_worker_image).
     agent_worker_image = worker_image_for(agent_image)
+    speaker_stream_env = {
+        key: os.environ[key]
+        for key in (
+            "BOT_SPEAKER_MIN_AUDIO_SEC",
+            "BOT_SPEAKER_SUBMIT_INTERVAL_SEC",
+            "BOT_SPEAKER_CONFIRM_THRESHOLD",
+            "BOT_SPEAKER_MAX_BUFFER_SEC",
+            "BOT_SPEAKER_IDLE_TIMEOUT_SEC",
+        )
+        if os.environ.get(key, "").strip()
+    }
     return ProfileRegistry(
         {
             # Meeting bot — Playwright browser; lifetime managed by meeting-api, so no idle timeout.
@@ -107,7 +118,7 @@ def default_registry() -> ProfileRegistry:
                     command=["/app/vexa-bot/entrypoint.sh"],
                 ),
                 idle_timeout_sec=0,  # 0 ⇒ managed externally; enforcement skips it
-                base_env={},
+                base_env=speaker_stream_env,
             ),
             # Claude Code agent — the in-container worker harness (worker): consumes the
             # dispatch from env, runs the governed turn over the mounted workspace, XADDs UnitEvents to

--- a/core/runtime/tests/test_profiles.py
+++ b/core/runtime/tests/test_profiles.py
@@ -54,6 +54,17 @@ def test_meeting_bot_uses_browser_image_from_env(monkeypatch):
     assert reg.get("meeting-bot").idle_timeout_sec == 0
 
 
+def test_meeting_bot_forwards_speaker_stream_tuning(monkeypatch):
+    monkeypatch.setenv("BOT_SPEAKER_MIN_AUDIO_SEC", "1")
+    monkeypatch.setenv("BOT_SPEAKER_CONFIRM_THRESHOLD", "1")
+    monkeypatch.delenv("BOT_SPEAKER_SUBMIT_INTERVAL_SEC", raising=False)
+    reg = default_registry()
+    assert reg.get("meeting-bot").base_env == {
+        "BOT_SPEAKER_MIN_AUDIO_SEC": "1",
+        "BOT_SPEAKER_CONFIRM_THRESHOLD": "1",
+    }
+
+
 def test_meeting_bot_env_is_a_valid_invocation():
     """The bot's whole config is delivered as VEXA_BOT_CONFIG — a JSON-encoded Invocation. Build the
     env the control plane would hand the profile and prove the payload conforms to invocation.v1."""

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -76,6 +76,11 @@ TRANSCRIPTION_SERVICE_TOKEN=
 # default POST /bots. Both default true.
 TRANSCRIBE_ENABLED=
 RECORDING_ENABLED=
+BOT_SPEAKER_MIN_AUDIO_SEC=
+BOT_SPEAKER_SUBMIT_INTERVAL_SEC=
+BOT_SPEAKER_CONFIRM_THRESHOLD=
+BOT_SPEAKER_MAX_BUFFER_SEC=
+BOT_SPEAKER_IDLE_TIMEOUT_SEC=
 # Self-hosted Jitsi hostnames (comma-separated, e.g. calls.example.org) recognized when parsing
 # pasted meeting links AND calendar (ICS) links. meet.jit.si and hosts naming "jitsi" are always
 # recognized; hosts with a "meet" label (meet.example.org, eu.meet.example.org) are recognized in

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -137,6 +137,13 @@ services:
       # is set EXPLICITLY (no suffix derivation); AGENT_IMAGE now matches the built control-plane tag.
       - AGENT_IMAGE=${AGENT_IMAGE:-vexaai/v012-agent-api:${IMAGE_TAG:-dev}}
       - AGENT_WORKER_IMAGE=${AGENT_WORKER_IMAGE:-vexaai/v012-agent-worker:${IMAGE_TAG:-dev}}
+      # Optional low-latency tuning for the Google Meet speaker-stream pipeline. Empty values keep
+      # the bot defaults; runtime forwards configured values to spawned bot containers.
+      - BOT_SPEAKER_MIN_AUDIO_SEC=${BOT_SPEAKER_MIN_AUDIO_SEC:-}
+      - BOT_SPEAKER_SUBMIT_INTERVAL_SEC=${BOT_SPEAKER_SUBMIT_INTERVAL_SEC:-}
+      - BOT_SPEAKER_CONFIRM_THRESHOLD=${BOT_SPEAKER_CONFIRM_THRESHOLD:-}
+      - BOT_SPEAKER_MAX_BUFFER_SEC=${BOT_SPEAKER_MAX_BUFFER_SEC:-}
+      - BOT_SPEAKER_IDLE_TIMEOUT_SEC=${BOT_SPEAKER_IDLE_TIMEOUT_SEC:-}
       - VEXA_AGENT_SRC_MOUNT=${VEXA_AGENT_SRC_MOUNT:-}
       - REDIS_URL=redis://redis:6379/0
       # The Runtime brokers model credentials into spawned agents. Subscription credentials may be

--- a/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
@@ -62,6 +62,16 @@ spec:
               value: {{ include "vexa.agentImage" . | quote }}
             - name: AGENT_WORKER_IMAGE
               value: {{ include "vexa.agentWorkerImage" . | quote }}
+            - name: BOT_SPEAKER_MIN_AUDIO_SEC
+              value: {{ .Values.runtime.speakerStream.minAudioSec | default "" | quote }}
+            - name: BOT_SPEAKER_SUBMIT_INTERVAL_SEC
+              value: {{ .Values.runtime.speakerStream.submitIntervalSec | default "" | quote }}
+            - name: BOT_SPEAKER_CONFIRM_THRESHOLD
+              value: {{ .Values.runtime.speakerStream.confirmThreshold | default "" | quote }}
+            - name: BOT_SPEAKER_MAX_BUFFER_SEC
+              value: {{ .Values.runtime.speakerStream.maxBufferSec | default "" | quote }}
+            - name: BOT_SPEAKER_IDLE_TIMEOUT_SEC
+              value: {{ .Values.runtime.speakerStream.idleTimeoutSec | default "" | quote }}
             - name: INTERNAL_API_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -186,6 +186,12 @@ runtime:
   agentImage: "vexaai/v012-agent-api:v012"
   agentWorkerImage: "vexaai/v012-agent-worker:v012"
   logLevel: "info"
+  speakerStream:
+    minAudioSec: ""
+    submitIntervalSec: ""
+    confirmThreshold: ""
+    maxBufferSec: ""
+    idleTimeoutSec: ""
   resources:
     requests: { cpu: 50m, memory: 256Mi }
     limits:   { cpu: 500m, memory: 768Mi }

--- a/deploy/lite/entrypoint.sh
+++ b/deploy/lite/entrypoint.sh
@@ -38,6 +38,14 @@ export DISPLAY="${DISPLAY:-:99}"
 export ADMIN_API_TOKEN="${ADMIN_API_TOKEN:-${ADMIN_TOKEN:-changeme}}"
 export INTERNAL_API_SECRET="${INTERNAL_API_SECRET:-lite-internal-secret}"
 
+# Optional Google Meet speaker-stream tuning. Empty values preserve bot defaults; the runtime
+# profile forwards configured values to every spawned bot process.
+export BOT_SPEAKER_MIN_AUDIO_SEC="${BOT_SPEAKER_MIN_AUDIO_SEC:-}"
+export BOT_SPEAKER_SUBMIT_INTERVAL_SEC="${BOT_SPEAKER_SUBMIT_INTERVAL_SEC:-}"
+export BOT_SPEAKER_CONFIRM_THRESHOLD="${BOT_SPEAKER_CONFIRM_THRESHOLD:-}"
+export BOT_SPEAKER_MAX_BUFFER_SEC="${BOT_SPEAKER_MAX_BUFFER_SEC:-}"
+export BOT_SPEAKER_IDLE_TIMEOUT_SEC="${BOT_SPEAKER_IDLE_TIMEOUT_SEC:-}"
+
 export TRANSCRIPTION_SERVICE_URL="${TRANSCRIPTION_SERVICE_URL:-}"
 export TRANSCRIPTION_SERVICE_TOKEN="${TRANSCRIPTION_SERVICE_TOKEN:-}"
 

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -19,6 +19,11 @@ are public.
 |---|---|---|
 | `TRANSCRIPTION_SERVICE_URL` | — | STT service **base URL** (the client appends `/v1/audio/transcriptions`), e.g. `http://<gpu-host>:8083`. Point it at the bundled service you deploy separately (`deploy/transcription`) or a hosted endpoint. Unset → bots join and record but produce no transcript. |
 | `TRANSCRIPTION_SERVICE_TOKEN` | — | STT auth token — must match the `API_TOKEN` of your `deploy/transcription` unit, or a token from `vexa.ai/account`. |
+| `BOT_SPEAKER_MIN_AUDIO_SEC` | `2` | Google Meet minimum audio window before submitting to STT. Lower values reduce first-transcript latency but increase request frequency. |
+| `BOT_SPEAKER_SUBMIT_INTERVAL_SEC` | `2` | Google Meet speaker-stream submission interval. |
+| `BOT_SPEAKER_CONFIRM_THRESHOLD` | `2` | Consecutive matching STT results required to confirm a segment. `1` lowers latency but reduces LocalAgreement protection against corrections. |
+| `BOT_SPEAKER_MAX_BUFFER_SEC` | `30` | Maximum buffered Google Meet audio before a forced submission. |
+| `BOT_SPEAKER_IDLE_TIMEOUT_SEC` | `15` | Flush/reset timeout after a speaker stops producing audio. |
 
 The STT service is the **GPU workload, deployed separately** from this stack — see
 [Deployment → Transcription](/deployment#transcription-the-separate-gpu-unit). The main stack


### PR DESCRIPTION
## What changed

Make the Google Meet speaker-stream latency controls available as normal deployment settings and pass them through the real bot-spawn path:

- `BOT_SPEAKER_MIN_AUDIO_SEC`
- `BOT_SPEAKER_SUBMIT_INTERVAL_SEC`
- `BOT_SPEAKER_CONFIRM_THRESHOLD`
- `BOT_SPEAKER_MAX_BUFFER_SEC`
- `BOT_SPEAKER_IDLE_TIMEOUT_SEC`

The values flow from Compose/Helm/Lite runtime configuration into spawned bot containers and then into `SpeakerStreamManager`. When unset, the existing code defaults remain unchanged.

Invalid values are rejected loudly per variable and fall back to the built-in default. The active values are logged without exposing secrets.

## Why

The speaker-stream module already had these tuning seams, but the composition root always passed no config. Self-hosters using fast local STT could not reduce first-transcript latency without modifying the image or source.

`BOT_SPEAKER_CONFIRM_THRESHOLD=1` is intentionally documented as a latency/quality tradeoff: it reduces LocalAgreement protection against corrections.

## Use case

Self-hosted deployments using a low-latency local STT service can tune the Meet lane without rebuilding the bot image. Deployments that do not set these variables retain the existing behavior exactly.

The PR contains only generic bot/runtime configuration and documentation. It does not depend on a private service, account, domain, model credential, or product-specific dashboard.

Fixes #535

## Validation

- `pnpm --filter @vexa/bot test` — full bot test suite passed.
- `pnpm --filter @vexa/bot build` — TypeScript and browser utility build passed.
- `uv run --project core/runtime pytest core/runtime/tests/test_profiles.py core/runtime/tests/test_config_contract.py -q` — 22 passed.
- `pnpm gate:config-contract` — deployment declarations, code reads, Compose, Helm, and Lite surfaces agree.
- Pre-push static gates passed.
