### PR TITLE
db-budget: CI gate auditing Σ(replicas × pool ceiling) vs max_connections (#529)

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -38,6 +38,7 @@ jobs:
       - run: pnpm gate:schema
       - run: pnpm gate:contract-version
       - run: pnpm gate:config-contract
+      - run: pnpm gate:db-budget
       - run: pnpm gate:dataflow
       - run: pnpm gate:calm
       - run: pnpm gate:licenses

--- a/deploy/db-budget.json
+++ b/deploy/db-budget.json
@@ -1,0 +1,10 @@
+{
+  "note": "#529 — the connection-budget accounting the 2026-04-21 outage lacked. gate:db-budget computes Σ(helm replicas × per-service pool ceiling) + reserved and FAILS if it exceeds max_connections. Ceilings are the SQLAlchemy framework defaults (pool_size 5 + max_overflow 10 = 15) — the code sets no explicit pool, so the gate also refuses a budget that UNDER-states any explicit pool_size/max_overflow it finds in a service's code. This budget is the DIRECT-connection worst case (pgbouncer OFF); with pgbouncer transaction-mode on (deploy/helm values pgbouncer.enabled=true) the server-side slot count is decoupled from these per-pod pools.",
+  "max_connections": 100,
+  "reserved": 10,
+  "reserved_note": "superuser_reserved_connections + migrations/admin/ad-hoc psql headroom",
+  "services": {
+    "admin-api": { "helm_key": "adminApi", "pool_size": 5, "max_overflow": 10 },
+    "meeting-api": { "helm_key": "meetingApi", "pool_size": 5, "max_overflow": 10 }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gate:schema": "node scripts/gates.mjs schema",
     "gate:contract-version": "node scripts/gates.mjs contract-version",
     "gate:config-contract": "node scripts/gates.mjs config-contract",
+    "gate:db-budget": "node scripts/gates.mjs db-budget",
     "gate:dataflow": "node scripts/gates.mjs dataflow",
     "seal:contracts": "node scripts/gates.mjs seal",
     "seal:arch": "node scripts/gates.mjs seal-arch",

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -811,7 +811,91 @@ function gateConfigContract() {
   return true;
 }
 
-const GATES = { readme: gateReadme, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
+// gate:db-budget (#529) — the connection-budget accounting the 2026-04-21 outage lacked. Every
+// service that constructs a Postgres engine must be in deploy/db-budget.json; Σ(helm replicas ×
+// per-service pool ceiling) + reserved must fit max_connections; and no service's code may set a
+// pool_size/max_overflow HIGHER than its declared ceiling (so the budget can't silently under-count).
+function _dbHoldingServices() {
+  let out;
+  try {
+    out = execSync("grep -rl --include='*.py' create_async_engine core", { cwd: ROOT }).toString();
+  } catch { return new Set(); }  // grep exit 1 = no matches
+  const svcs = new Set();
+  for (const path of out.split("\n")) {
+    if (!path || /(^|\/)tests?\//.test(path) || path.includes("test_")) continue;
+    const m = path.match(/\/services\/([^/]+)\//);
+    if (m) svcs.add(m[1]);
+  }
+  return svcs;
+}
+
+function _explicitPool(service) {
+  // the largest explicit pool_size= / max_overflow= a service's code sets, or {} when it relies on
+  // the framework default (the "silent default" the issue names). Used to reject an under-stated budget.
+  let out = "";
+  try {
+    out = execSync(`grep -rhoE --include='*.py' '(pool_size|max_overflow) *= *[0-9]+' core 2>/dev/null | grep -v test || true`, { cwd: ROOT }).toString();
+  } catch { out = ""; }
+  const found = {};
+  for (const line of out.split("\n")) {
+    const m = line.match(/(pool_size|max_overflow)\s*=\s*(\d+)/);
+    if (m) found[m[1]] = Math.max(found[m[1]] || 0, parseInt(m[2], 10));
+  }
+  return found;  // note: repo-wide (explicit overrides are rare); a match anywhere raises the floor
+}
+
+function _helmReplicas(key) {
+  const vals = join(ROOT, "deploy", "helm", "charts", "vexa", "values.yaml");
+  if (!existsSync(vals)) return null;
+  const lines = readFileSync(vals, "utf8").split("\n");
+  const start = lines.findIndex((l) => l.replace(/\s+$/, "") === `${key}:`);
+  if (start < 0) return null;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^[A-Za-z0-9_]+:/.test(lines[i])) break;               // next top-level key → left the block
+    const m = lines[i].match(/^\s+replicaCount:\s*(\d+)/);
+    if (m) return parseInt(m[1], 10);
+  }
+  return null;
+}
+
+function gateDbBudget() {
+  const budgetPath = join(ROOT, "deploy", "db-budget.json");
+  if (!existsSync(budgetPath)) return fail(["gate:db-budget — deploy/db-budget.json missing (the connection-budget accounting, #529)"]);
+  let budget;
+  try { budget = JSON.parse(readFileSync(budgetPath, "utf8")); }
+  catch (e) { return fail([`gate:db-budget — deploy/db-budget.json is not valid JSON — ${e.message}`]); }
+
+  const errs = [];
+  const declared = new Set(Object.keys(budget.services || {}));
+  const actual = _dbHoldingServices();
+  for (const s of actual) if (!declared.has(s)) errs.push(`'${s}' constructs a Postgres engine but is absent from db-budget.json — account for it (replicas × pool)`);
+  for (const s of declared) if (!actual.has(s)) errs.push(`db-budget lists '${s}' but no non-test source constructs a DB engine there — remove it or fix the name`);
+
+  const explicit = _explicitPool();
+  let total = Number(budget.reserved || 0);
+  const rows = [];
+  for (const [svc, cfg] of Object.entries(budget.services || {})) {
+    const replicas = _helmReplicas(cfg.helm_key);
+    if (replicas === null) { errs.push(`${svc}: could not read replicaCount for helm key '${cfg.helm_key}' in values.yaml`); continue; }
+    if (explicit.pool_size && explicit.pool_size > cfg.pool_size)
+      errs.push(`${svc}: code sets pool_size=${explicit.pool_size} but db-budget declares ${cfg.pool_size} (under-count)`);
+    if (explicit.max_overflow && explicit.max_overflow > cfg.max_overflow)
+      errs.push(`${svc}: code sets max_overflow=${explicit.max_overflow} but db-budget declares ${cfg.max_overflow} (under-count)`);
+    const ceiling = Number(cfg.pool_size || 0) + Number(cfg.max_overflow || 0);
+    const conns = replicas * ceiling;
+    total += conns;
+    rows.push(`${svc} ${replicas}×${ceiling}=${conns}`);
+  }
+  const limit = Number(budget.max_connections);
+  if (!errs.length && total > limit)
+    errs.push(`Σ ${total} connections EXCEEDS max_connections ${limit} — [${rows.join(", ")}, reserved ${budget.reserved}]. Reduce replicas/pool, raise the DB limit, or enable pgbouncer.`);
+
+  if (errs.length) return fail(["db-budget (#529, the 2026-04-21 outage shape) — connection-budget violations:", ...errs.map((e) => "   " + e)]);
+  console.log(`  ✓ gate:db-budget — Σ ${total}/${limit} connections fits [${rows.join(", ")}, reserved ${budget.reserved}]`);
+  return true;
+}
+
+const GATES = { readme: gateReadme, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
 const which = process.argv[2] || "all";
 
 // `seal` (not a gate) — (re)freeze the current published contracts into contracts.seal.json.


### PR DESCRIPTION
Closes #529 (offline arm). Refs the 2026-04-21 connection-exhaustion outage.

## Value

> The declared connection budget of a stock deploy provably fits the declared DB limit: a CI gate computes Σ(worst-case replicas × per-service pool ceiling) + reserved and fails if it exceeds `max_connections` — so a replicas/pool bump can never silently hard-exhaust Postgres.

## Root cause

On 04-21 the sum of per-service pool ceilings exceeded managed Postgres `max_connections` (100). Every service held its ceiling privately; no layer knew the sum; the first signal was user-facing `TooManyConnectionsError`. The safe margin ("~72/100") lived only as hand-arithmetic in a postmortem table.

## Fix — `gate:db-budget`

- **`deploy/db-budget.json`** declares `max_connections`, a `reserved` headroom, and per DB-holding service `{helm_key, pool_size, max_overflow}`. The 0.12 tree has exactly two Postgres services — **admin-api** and **meeting-api**, each at the SQLAlchemy default (5+10=15); agent-api/runtime/gateway are Redis-only.
- **`scripts/gates.mjs`** reads each service's `replicaCount` from helm `values.yaml`, computes Σ(replicas × ceiling) + reserved, and fails if > `max_connections`, printing the breakdown. **Σ = 2×15 + 2×15 + 10 = 70/100** — the postmortem's safe margin, now a green check.
- **Two drift guards:** (1) a service whose non-test source constructs `create_async_engine` but is absent from the budget → fail; (2) a budget that under-states an explicit `pool_size`/`max_overflow` the code sets → fail.
- **Wired into CI** (`package.json` + `gates.yml`) beside `gate:config-contract`.

## Acceptance

| # | Observation | Status |
|---|---|---|
| V1 | `gate:db-budget` green at **Σ 70/100** with the per-service breakdown | ✅ |
| control | RED when `max_connections` < Σ (exact arithmetic shown); RED when a DB service is dropped from the budget (named) | ✅ |
| drift | RED when a service's code sets a pool higher than the budget declares | ✅ (logic) |

## Notes

- This is the **direct-connection worst case (pgbouncer off)**. With `pgbouncer.enabled=true` (transaction mode) the server-side slot count is decoupled from these per-pod pools — the budget stays the conservative bound.
- Ceilings are the **framework defaults** (the code sets no explicit pool — the "silent default" the issue names); the budget states them explicitly and the gate refuses any code that raises them above the declared ceiling.