### PR TITLE
fix(recordings): per-chunk durable upload + finalize-on-read — confirmed uploads retrievable (#509, #491, #412)

### DIFF
--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -316,13 +316,25 @@ export async function startCaptureBridge(
  * The MediaRecorder loop lives in @vexa/record-chunker (bundled into window.VexaBrowserUtils, like
  * the capture bricks). It records the meeting's combined audio mix, base64-encodes each timeslice,
  * and hands it to `onChunk`. We bridge those chunks over the Playwright boundary to `recording.chunk`
- * using the SAME key the orchestrator closes with (`platform/native`), so the assembler groups them
- * and the final chunk (on stop) assembles the master. Started post-admission (on the live meeting
- * page, where the participant <audio> elements exist), exactly like the capture bridge.
+ * using the SAME key the orchestrator closes with (`platform/native`); the sink uploads each chunk to
+ * meeting-api the moment it arrives (#491/#412 — every finished part is durable before the meeting
+ * ends), and the master is assembled server-side on read. The trailing empty is_final chunk (on
+ * stop) is the COMPLETED signal. Started post-admission (on the live meeting page, where the
+ * participant <audio> elements exist), exactly like the capture bridge.
  */
 export async function startRecording(page: Page, inv: Invocation, recording: BotRecordingSink): Promise<() => Promise<void>> {
   const key = `${inv.platform}/${inv.nativeMeetingId ?? inv.connectionId ?? 'session'}`;
-  // Node-side: decode one base64 recording.v1 chunk → the assembler. mimeType→master format.
+  // Recording part interval (ms): the MediaRecorder timeslice = the durable-upload granularity.
+  // Env-overridable (VEXA_RECORDING_TIMESLICE_MS) so a live multi-part run can shrink it to land
+  // ≥2 parts in a short meeting (#509 A5); default 15000 (production parity). Each timeslice is a
+  // chunk uploaded the moment it is produced (recording.ts sink), so a SIGKILL leaves every
+  // finished part durable (#412). Invalid / non-positive values fall back to the default.
+  const timesliceMs = ((): number => {
+    const raw = process.env.VEXA_RECORDING_TIMESLICE_MS;
+    const n = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : 15000;
+  })();
+  // Node-side: decode one base64 recording.v1 chunk → the per-chunk upload sink. mimeType→format.
   await page.exposeFunction('__vexaRecordingChunk', (base64: string, chunkSeq: number, isFinal: boolean, mimeType: string): void => {
     const bytes = base64 ? new Uint8Array(Buffer.from(base64, 'base64')) : new Uint8Array(0);
     const format: RecordingMasterFormat = /wav/i.test(mimeType) ? 'wav' : 'webm';
@@ -330,11 +342,11 @@ export async function startRecording(page: Page, inv: Invocation, recording: Bot
   }).catch((e: Error) => { if (!String(e.message).includes('already registered')) throw e; });
 
   // Page-side: start the generic recording tap (finds + combines the page audio elements).
-  await page.evaluate(async () => {
+  await page.evaluate(async (timesliceMs) => {
     const w = (globalThis as any) as Record<string, any>;
     if (w.VexaBrowserUtils?.createRecordingTap && !w.__vexaRecordingTap) {
       w.__vexaRecordingTap = w.VexaBrowserUtils.createRecordingTap({
-        timesliceMs: 15000,
+        timesliceMs,
         onChunk: async (c: { base64: string; chunkSeq: number; isFinal: boolean; mimeType: string }) => {
           try { await w.__vexaRecordingChunk(c.base64, c.chunkSeq, c.isFinal, c.mimeType); return true; }
           catch { return false; }
@@ -342,7 +354,7 @@ export async function startRecording(page: Page, inv: Invocation, recording: Bot
       });
       await w.__vexaRecordingTap.start();
     }
-  }).catch((e) => { console.error(`[bot] recording bridge: page-side start failed: ${String(e)}`); });
+  }, timesliceMs).catch((e) => { console.error(`[bot] recording bridge: page-side start failed: ${String(e)}`); });
 
   // Stop fn: stop the recorder so it flushes the final (isFinal) chunk → master assembly.
   return async () => {

--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -12,7 +12,7 @@
  * ├─ INCREMENT 2b wires the browser join + capture + recording (THIS file):
  * │    • JoinDriver     → @vexa/join.joinMeeting over a @vexa/remote-browser page               ✅ WIRED (L4)
  * │    • Pipeline       → capture bridge → @vexa/{gmeet,mixed}-pipeline → @vexa/transcribe-whisper ✅ WIRED (L4 capture · L2/L3 lane)
- * │    • RecordingSink  → @vexa/recording assembler → upload to inv.recordingUploadUrl          ✅ WIRED (L4 upload · L2/L3 assembler)
+ * │    • RecordingSink  → per-chunk upload to inv.recordingUploadUrl (master assembled server-side) ✅ WIRED (L4 upload · L3 sink)
  * │    • Speak          → acts.v1 `speak`/`speak_stop` → meeting-UI mic + VM TTS chain          ✅ WIRED (L4)
  * └─ The browser/capture/recording-upload/speak legs are BROWSER- or VM-resident → L4-gated
  *    (proven by the O6 VM run, not unit tests). The lane + assembler cores are L2/L3-proven.

--- a/core/meetings/services/bot/src/recording.test.ts
+++ b/core/meetings/services/bot/src/recording.test.ts
@@ -1,20 +1,25 @@
 /**
- * L3 — recording sink (recording.v1 accumulate → assemble master). OFFLINE, NO disk/HTTP.
+ * L3 — recording sink (recording.v1 PER-CHUNK durable upload). OFFLINE, NO disk (HTTP only to a
+ * localhost capture server for the wire arm).
  *
- * Drives the REAL @vexa/recording assembler through the bot's `createBotRecordingSink` with an
- * injected `onMaster` (so we assert the assembled master WITHOUT a meeting-api receiver), and
- * asserts:
- *   • chunks accumulate per key; the empty is_final chunk assembles + emits the master;
- *   • close(key) is the ROBUST trigger — it assembles even when the trailing is_final chunk
- *     never arrives (the live Stop race that loses the last MediaRecorder chunk);
- *   • the assembled master is the byte-concat / RIFF-merge the recording.v1 codec defines
- *     (webm byte-concat; wav header-stripped PCM merge), with the right key/format/chunk count;
- *   • out-of-order seqs are sorted at assembly.
+ * #491/#412: the 0.12 bot accumulated the whole recording in Node memory and uploaded ONE master at
+ * graceful close — a SIGKILL lost everything. This sink uploads EACH timeslice immediately. This
+ * test is the P22/#224-class regression pin that absence lacked. It asserts:
+ *   • each chunk() uploads IMMEDIATELY (before any close), in seq order, with bytes forwarded;
+ *   • a simulated mid-meeting kill (close never called, no final) leaves every finished part
+ *     ALREADY durable — no all-or-nothing loss (V2/#412);
+ *   • the empty is_final chunk is FORWARDED (the COMPLETED signal), never dropped;
+ *   • close() with no prior final sends EXACTLY ONE empty is_final fallback (the live Stop race),
+ *     and fires at most once; a never-fed session's close is a no-op;
+ *   • over the real RecordingService HTTP wire, session_uid == inv.connectionId on every chunk,
+ *     seq monotone, only the last is_final (the split/404-guard contract).
  * Run: npx tsx src/recording.test.ts
  */
-import { createBotRecordingSink } from './recording.js';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { createBotRecordingSink, type ChunkUploader } from './recording.js';
 import type { Invocation } from './config.js';
-import type { RecordingMaster } from '@vexa/recording';
+import type { RecordingMasterFormat } from '@vexa/recording';
 
 let failed = 0;
 const check = (name: string, cond: boolean, detail = '') => {
@@ -24,82 +29,144 @@ const check = (name: string, cond: boolean, detail = '') => {
 
 const inv = (over: Partial<Invocation> = {}): Invocation => ({
   platform: 'google_meet', meetingUrl: 'https://meet.google.com/abc-defg-hij', botName: 'Vexa',
-  redisUrl: 'redis://localhost:6379', recordingEnabled: true, ...over,
+  redisUrl: 'redis://localhost:6379', recordingEnabled: true, connectionId: 'conn-xyz', ...over,
 });
 
-/** Build a canonical 44-byte-header WAV chunk wrapping `data` (mirrors the recording codec's
- *  expected per-chunk RIFF shape — fmt: PCM, mono, 16kHz, 16bps). */
-const FMT = Buffer.from([0x01, 0x00, 0x01, 0x00, 0x80, 0x3e, 0x00, 0x00, 0x00, 0x7d, 0x00, 0x00, 0x02, 0x00, 0x10, 0x00]);
-function wavChunk(data: Buffer): Buffer {
-  const h = Buffer.alloc(44);
-  h.write('RIFF', 0, 'ascii'); h.writeUInt32LE(36 + data.length, 4); h.write('WAVE', 8, 'ascii');
-  h.write('fmt ', 12, 'ascii'); h.writeUInt32LE(16, 16); FMT.copy(h, 20);
-  h.write('data', 36, 'ascii'); h.writeUInt32LE(data.length, 40);
-  return Buffer.concat([h, data]);
+/** A record of one delivered chunk (what the injected uploader saw). */
+interface Seen { seq: number; isFinal: boolean; format: string; len: number }
+function fakeUploader(): { seen: Seen[]; upload: ChunkUploader } {
+  const seen: Seen[] = [];
+  const upload: ChunkUploader = (seq, isFinal, format, bytes) => {
+    seen.push({ seq, isFinal, format, len: bytes.length });
+  };
+  return { seen, upload };
 }
+/** Drain the sink's internal upload queue (microtasks) — a macrotask tick runs after all of them. */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 
 async function main(): Promise<void> {
-  // ── 1) webm: accumulate chunks, empty is_final assembles the master (byte-concat) ──
+  // ── 1) each timeslice uploads IMMEDIATELY, in seq order, bytes forwarded ─────────────────────
   {
-    const masters: RecordingMaster[] = [];
-    const sink = createBotRecordingSink({ inv: inv(), onMaster: (m) => masters.push(m) });
-    const c0 = Buffer.from([0x1a, 0x45, 0xdf, 0xa3]); // self-describing chunk 0
-    const c1 = Buffer.from([0xa3, 0x01, 0x02]);       // cluster-only
-    sink.chunk('google_meet/m1', 0, false, 'webm', c0);
-    sink.chunk('google_meet/m1', 1, false, 'webm', c1);
-    sink.chunk('google_meet/m1', 2, true, 'webm', new Uint8Array(0)); // empty final = COMPLETED signal
-
-    check('is_final: exactly one master emitted', masters.length === 1, String(masters.length));
-    check('is_final: master keyed by the session key', masters[0]?.key === 'google_meet/m1', masters[0]?.key);
-    check('is_final: master format = webm', masters[0]?.format === 'webm', masters[0]?.format);
-    check('is_final: chunk count = 2 non-empty', masters[0]?.chunks === 2, String(masters[0]?.chunks));
-    check('is_final: webm master == byte-concat(c0,c1)', !!masters[0] && Buffer.from(masters[0].bytes).equals(Buffer.concat([c0, c1])),
-      masters[0] ? Buffer.from(masters[0].bytes).toString('hex') : 'no master');
+    const { seen, upload } = fakeUploader();
+    const sink = createBotRecordingSink({ inv: inv(), uploadChunk: upload });
+    sink.chunk('google_meet/m1', 0, false, 'webm', new Uint8Array([1, 2, 3]));
+    sink.chunk('google_meet/m1', 1, false, 'webm', new Uint8Array([4, 5]));
+    sink.chunk('google_meet/m1', 2, false, 'webm', new Uint8Array([6]));
+    await flush();
+    check('per-chunk: 3 chunks → 3 immediate uploads BEFORE any close', seen.length === 3, String(seen.length));
+    check('per-chunk: none accumulated as a whole-recording master', seen.every((s) => s.len <= 3), JSON.stringify(seen));
+    check('per-chunk: all non-final', seen.every((s) => !s.isFinal), JSON.stringify(seen));
+    check('per-chunk: seq order 0,1,2', seen.map((s) => s.seq).join(',') === '0,1,2', seen.map((s) => s.seq).join(','));
+    check('per-chunk: bytes forwarded verbatim (3,2,1)', seen.map((s) => s.len).join(',') === '3,2,1', seen.map((s) => s.len).join(','));
   }
 
-  // ── 2) close(key) assembles even without an is_final chunk (the robust trigger) ──
+  // ── 2) kill-before-close: no close, no final → the N finished parts are ALREADY durable (#412) ──
   {
-    const masters: RecordingMaster[] = [];
-    const sink = createBotRecordingSink({ inv: inv(), onMaster: (m) => masters.push(m) });
-    const a = Buffer.from([0x11, 0x22, 0x33, 0x44]);
-    const b = Buffer.from([0x55, 0x66]);
-    sink.chunk('google_meet/m2', 0, false, 'wav', wavChunk(a));
-    sink.chunk('google_meet/m2', 1, false, 'wav', wavChunk(b));
-    check('close: nothing assembled before close', masters.length === 0, String(masters.length));
-    sink.close('google_meet/m2');   // host-side close (the WS dropped) — robust assembly trigger
-    check('close: master assembled on close (no is_final needed)', masters.length === 1, String(masters.length));
-    check('close: wav master payload == concat of stripped PCM (a,b)',
-      !!masters[0] && Buffer.from(masters[0].bytes).subarray(44).equals(Buffer.concat([a, b])),
-      masters[0] ? Buffer.from(masters[0].bytes).subarray(44).toString('hex') : 'no master');
-    check('close: wav master chunk count = 2', masters[0]?.chunks === 2, String(masters[0]?.chunks));
+    const { seen, upload } = fakeUploader();
+    const sink = createBotRecordingSink({ inv: inv(), uploadChunk: upload });
+    for (let i = 0; i < 4; i++) sink.chunk('google_meet/m2', i, false, 'webm', new Uint8Array([i]));
+    await flush();
+    // simulate SIGKILL: close() is NEVER called — nothing was buffered waiting for it.
+    check('crash: N=4 parts durable before any close (no all-or-nothing loss)', seen.length === 4, String(seen.length));
+    check('crash: no final signal sent (recording stays in_progress; finalize-on-read still serves it)',
+      seen.every((s) => !s.isFinal), JSON.stringify(seen));
   }
 
-  // ── 3) out-of-order seqs are sorted at assembly ──
+  // ── 3) the empty is_final chunk is FORWARDED (COMPLETED signal), not dropped ─────────────────
   {
-    const masters: RecordingMaster[] = [];
-    const sink = createBotRecordingSink({ inv: inv(), onMaster: (m) => masters.push(m) });
-    const c0 = Buffer.from([0xaa]);
-    const c1 = Buffer.from([0xbb]);
-    const c2 = Buffer.from([0xcc]);
-    sink.chunk('google_meet/m3', 2, false, 'webm', c2);   // arrive out of order
-    sink.chunk('google_meet/m3', 0, false, 'webm', c0);
-    sink.chunk('google_meet/m3', 1, false, 'webm', c1);
-    sink.close('google_meet/m3');
-    check('order: webm master == byte-concat in SEQ order (c0,c1,c2)',
-      !!masters[0] && Buffer.from(masters[0].bytes).equals(Buffer.concat([c0, c1, c2])),
-      masters[0] ? Buffer.from(masters[0].bytes).toString('hex') : 'no master');
+    const { seen, upload } = fakeUploader();
+    const sink = createBotRecordingSink({ inv: inv(), uploadChunk: upload });
+    sink.chunk('google_meet/m3', 0, false, 'webm', new Uint8Array([9, 9]));
+    sink.chunk('google_meet/m3', 1, true, 'webm', new Uint8Array(0)); // empty final = COMPLETED signal
+    await flush();
+    check('final: empty is_final forwarded (not dropped)', seen.length === 2, String(seen.length));
+    const fin = seen[seen.length - 1];
+    check('final: last upload is isFinal=true, 0 bytes', !!fin && fin.isFinal && fin.len === 0, JSON.stringify(fin));
   }
 
-  // ── 4) close on an empty/never-fed session is a no-op (no spurious master) ──
+  // ── 4) close() with no prior final → EXACTLY ONE empty is_final fallback (live Stop race) ────
   {
-    const masters: RecordingMaster[] = [];
-    const sink = createBotRecordingSink({ inv: inv(), onMaster: (m) => masters.push(m) });
+    const { seen, upload } = fakeUploader();
+    const sink = createBotRecordingSink({ inv: inv(), uploadChunk: upload });
+    sink.chunk('google_meet/m4', 0, false, 'webm', new Uint8Array([1]));
+    sink.chunk('google_meet/m4', 1, false, 'webm', new Uint8Array([2]));
+    sink.close('google_meet/m4');   // host-side close (the WS dropped) — synthesize the final signal
+    await flush();
+    check('fallback: 2 data uploads + 1 synthesized final', seen.length === 3, String(seen.length));
+    const fin = seen[2];
+    check('fallback: final is isFinal=true, 0 bytes, seq after the last part (2)',
+      !!fin && fin.isFinal && fin.len === 0 && fin.seq === 2, JSON.stringify(fin));
+    sink.close('google_meet/m4');   // idempotent
+    await flush();
+    check('fallback: fires at most once (second close is a no-op)',
+      seen.filter((s) => s.isFinal).length === 1, String(seen.filter((s) => s.isFinal).length));
+  }
+
+  // ── 5) close() AFTER a real final → no extra fallback (no double final) ──────────────────────
+  {
+    const { seen, upload } = fakeUploader();
+    const sink = createBotRecordingSink({ inv: inv(), uploadChunk: upload });
+    sink.chunk('google_meet/m5', 0, false, 'webm', new Uint8Array([1]));
+    sink.chunk('google_meet/m5', 1, true, 'webm', new Uint8Array(0));
+    sink.close('google_meet/m5');
+    await flush();
+    check('no-double-final: a real final was sent → close adds nothing',
+      seen.filter((s) => s.isFinal).length === 1 && seen.length === 2, JSON.stringify(seen));
+  }
+
+  // ── 6) close() on a never-fed session is a no-op (no phantom recording) ──────────────────────
+  {
+    const { seen, upload } = fakeUploader();
+    const sink = createBotRecordingSink({ inv: inv(), uploadChunk: upload });
     sink.close('google_meet/never');
-    check('empty session: close is a no-op (no master)', masters.length === 0, String(masters.length));
+    await flush();
+    check('empty session: close is a no-op (no upload)', seen.length === 0, String(seen.length));
+  }
+
+  // ── 7) the DEFAULT uploader on the real RecordingService HTTP wire: session_uid == connectionId ──
+  {
+    interface Wire { session_uid?: string; chunk_seq?: number; is_final?: boolean; format?: string; size?: number }
+    const wire: Wire[] = [];
+    const server = http.createServer((req, res) => {
+      const parts: Buffer[] = [];
+      req.on('data', (d: Buffer) => parts.push(d));
+      req.on('end', () => {
+        const text = Buffer.concat(parts).toString('latin1');
+        const m = text.match(/name="metadata"[\s\S]*?\r\n\r\n(\{[\s\S]*?\})\r\n/);
+        let meta: Record<string, unknown> = {};
+        if (m) { try { meta = JSON.parse(m[1]); } catch { /* ignore */ } }
+        wire.push({
+          session_uid: meta.session_uid as string, chunk_seq: meta.chunk_seq as number,
+          is_final: meta.is_final as boolean, format: meta.format as string,
+          size: meta.file_size_bytes as number,
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/internal/recordings/upload`;
+
+    const sink = createBotRecordingSink({
+      inv: inv({ connectionId: 'conn-xyz', meeting_id: 42, recordingUploadUrl: url, internalSecret: 's' }),
+    });
+    sink.chunk('google_meet/w', 0, false, 'webm', new Uint8Array([1, 2, 3, 4]));
+    sink.chunk('google_meet/w', 1, false, 'webm', new Uint8Array([5, 6]));
+    sink.chunk('google_meet/w', 2, true, 'webm', new Uint8Array(0));
+    for (let i = 0; i < 100 && wire.length < 3; i++) await new Promise((r) => setTimeout(r, 10));
+    await new Promise<void>((r) => server.close(() => r()));
+
+    check('wire: 3 chunks POSTed to meeting-api', wire.length === 3, String(wire.length));
+    check('wire: session_uid == inv.connectionId on EVERY chunk (never nativeMeetingId/master key)',
+      wire.length === 3 && wire.every((w) => w.session_uid === 'conn-xyz'),
+      JSON.stringify(wire.map((w) => w.session_uid)));
+    check('wire: seq order 0,1,2', wire.map((w) => w.chunk_seq).join(',') === '0,1,2', wire.map((w) => w.chunk_seq).join(','));
+    check('wire: only the LAST chunk is_final', wire.map((w) => w.is_final).join(',') === 'false,false,true',
+      wire.map((w) => w.is_final).join(','));
   }
 
   if (failed) { console.error(`\n❌ recording (L3): ${failed} check(s) FAILED.`); process.exit(1); }
-  console.log('\n✅ recording (L3): recording.v1 chunks accumulate → buildRecordingMaster on is_final OR close; webm byte-concat + wav RIFF-merge, seq-ordered (real assembler · injected onMaster · no disk/HTTP).');
+  console.log('\n✅ recording (L3): each recording.v1 timeslice uploads immediately (seq-ordered, session_uid==connectionId); a mid-meeting kill leaves every finished part durable; the empty is_final signal is forwarded; close() synthesizes the final signal at most once (injected uploader + real RecordingService HTTP wire · no whole-recording buffering).');
 }
 
 void main();

--- a/core/meetings/services/bot/src/recording.ts
+++ b/core/meetings/services/bot/src/recording.ts
@@ -1,80 +1,110 @@
 /**
- * RecordingSink adapter (2b) — the recording.v1 finalize + upload path, behind the
+ * RecordingSink adapter (2b) — the recording.v1 PER-CHUNK durable upload path, behind the
  * orchestrator's RecordingSink port (`close(key)`).
  *
- * recording.v1 has TWO halves (both in @vexa/recording): ACQUIRE (the browser MediaRecorder
- * tap → chunks) and DELIVER (chunk-upload over HTTP to meeting-api). The ACQUIRE side is
- * browser-resident and L4-gated (it lives in capture-bridge.ts); THIS file is the DELIVER +
- * finalize core:
- *   - chunk(seq, isFinal, format, bytes) accumulates recording.v1 chunks (createRecordingAssembler);
- *   - the empty is_final chunk OR close(key) triggers buildRecordingMaster → onMaster;
- *   - onMaster uploads the assembled master to inv.recordingUploadUrl via RecordingService.
+ * recording.v1 has TWO halves (both in @vexa/recording): ACQUIRE (the browser MediaRecorder tap →
+ * timeslice chunks, capture-bridge.ts `startRecording`) and DELIVER (this file). #491/#412: the 0.12
+ * bot ACCUMULATED every chunk in Node memory (createRecordingAssembler) and uploaded ONE master at
+ * graceful close — so a SIGKILL/OOM mid-meeting lost the WHOLE recording (V2/#412), and a multi-hour
+ * master rode one 30s-timeout POST that fails permanently on a slow link. This sink instead uploads
+ * EACH timeslice the moment it is produced via RecordingService.uploadChunk (retry+backoff), so a
+ * crash leaves every FINISHED part durable in object storage; the master is assembled SERVER-SIDE on
+ * the first GET /recordings/{id}/master or …/raw (meeting-api finalize-on-read). No meeting-length
+ * blob ever sits in Node memory or rides one long POST.
  *
- * The orchestrator only ever calls close(key) (graceful teardown) — the robust assembly trigger,
- * since the live Stop race routinely loses the trailing MediaRecorder chunk (the WS closes before
- * it flushes). is_final is the prompt-path optimization. (See @vexa/recording's assembler doc.)
+ * Contract that must hold (or the recording 404s / splits / never completes):
+ *   • session_uid == inv.connectionId — the eager-created MeetingSession the server resolves the
+ *     upload against (bot_spawn). NOT nativeMeetingId / a master key (the old uploadMaster fallbacks
+ *     would 404 SessionNotFound or fold into the wrong recording).
+ *   • the empty is_final chunk is the COMPLETED signal — forward it (do NOT drop it).
+ *   • close(key) is the final-signal FALLBACK: the live Stop race routinely drops the trailing
+ *     is_final MediaRecorder chunk (the WS closes before it flushes), so on close we POST one empty
+ *     is_final upload IF none was sent — the server then flips the recording to COMPLETED. Fires once.
+ *   • uploads are serialized on an internal promise queue so parts land in seq order; a chunk that
+ *     fails permanently is logged-and-skipped — the master assembles from the parts that DID arrive.
  *
- * The assembler itself is PURE (in-memory, callback-only) → L2/L3-testable without disk/socket
- * (recording.test.ts). The upload leg is L4-gated (needs a live meeting-api receiver).
+ * L4-gated: the full page→Node→HTTP loss path is proven only by a live compose run. The SINK half
+ * (per-chunk upload, correct seq/isFinal/session_uid, the close fallback) is offline-provable
+ * (recording.test.ts) — the P22/#224-class regression pin the 0.12 in-memory bot lacked. The
+ * assembler stays in @vexa/recording (the desktop composition root still uses it) — only the cloud
+ * bot's wiring changes.
  */
-import {
-  createRecordingAssembler,
-  RecordingService,
-  type RecordingMaster,
-  type RecordingMasterFormat,
-} from '@vexa/recording';
+import { RecordingService, type RecordingMasterFormat } from '@vexa/recording';
 import type { Invocation } from './config.js';
 import type { RecordingSink } from './ports.js';
 
-/** The RecordingSink extended with the chunk ingress the capture bridge's MediaRecorder tap
- *  pumps into. The orchestrator only sees close(key); the bridge holds the BotRecordingSink to
- *  feed chunks as they arrive from the page-side recorder. */
+/** The RecordingSink extended with the chunk ingress the capture bridge's MediaRecorder tap pumps
+ *  into. The orchestrator only sees close(key); the bridge holds the BotRecordingSink to feed chunks
+ *  as they arrive from the page-side recorder. */
 export interface BotRecordingSink extends RecordingSink {
   /** One recording.v1 chunk for `key`: monotonic seq, the COMPLETED-signal flag, format, bytes. */
   chunk(key: string, seq: number, isFinal: boolean, format: RecordingMasterFormat, bytes: Uint8Array): void;
 }
 
+/** Deliver ONE recording.v1 chunk. The default uploads to inv.recordingUploadUrl via
+ *  RecordingService.uploadChunk; tests inject a fake to assert per-chunk delivery without HTTP. */
+export type ChunkUploader = (
+  seq: number, isFinal: boolean, format: RecordingMasterFormat, bytes: Uint8Array,
+) => void | Promise<void>;
+
 export interface RecordingSinkOptions {
   inv: Invocation;
-  /** Override the master handler (tests inject this to assert the assembled master without HTTP).
-   *  Default = upload to inv.recordingUploadUrl via RecordingService. */
-  onMaster?: (master: RecordingMaster) => void | Promise<void>;
+  /** Override the chunk uploader (tests inject this to assert per-chunk upload without a live
+   *  receiver). Default = HTTP upload to inv.recordingUploadUrl via RecordingService.uploadChunk. */
+  uploadChunk?: ChunkUploader;
   log?: (msg: string) => void;
 }
 
-/** Upload an assembled master to meeting-api. The 0.11 RecordingService.upload() POSTs the
- *  finalized file to the internal upload endpoint (multipart, retry/backoff). We write the master
- *  bytes through writeBlob (it owns the temp file) then upload to inv.recordingUploadUrl. Best-
- *  effort: an upload failure is logged, never thrown (the orchestrator's teardown must not hang). */
-async function uploadMaster(inv: Invocation, master: RecordingMaster, log: (m: string) => void): Promise<void> {
+/** The default chunk uploader: POST each chunk to meeting-api's internal upload endpoint via the
+ *  shipped RecordingService.uploadChunk (multipart, retry+backoff, structured chunk-loss logging).
+ *  session_uid is inv.connectionId — the server resolves the eager-created MeetingSession by it. */
+function defaultChunkUploader(inv: Invocation, log: (m: string) => void): ChunkUploader {
   const url = inv.recordingUploadUrl;
-  if (!url) { log(`recording: no recordingUploadUrl — master (${master.bytes.length}B, ${master.chunks} chunks) NOT uploaded`); return; }
-  try {
-    const meetingId = inv.meeting_id ?? 0;
-    const sessionUid = inv.connectionId ?? inv.nativeMeetingId ?? master.key;
-    const svc = new RecordingService(meetingId, sessionUid);
-    await svc.writeBlob(Buffer.from(master.bytes), master.format);
-    await svc.upload(url, inv.internalSecret ?? '');
-    await svc.cleanup().catch(() => { /* best-effort */ });
-    log(`recording: uploaded master ${master.key} (${master.bytes.length}B, ${master.chunks} chunks, ${master.format})`);
-  } catch (e) {
-    log(`recording: upload FAILED for ${master.key}: ${String(e)}`);
-  }
+  const meetingId = inv.meeting_id ?? 0;
+  const sessionUid = inv.connectionId ?? '';
+  const token = inv.internalSecret ?? '';
+  const svc = new RecordingService(meetingId, sessionUid);
+  return async (seq, isFinal, format, bytes) => {
+    if (!url) {
+      log(`recording: no recordingUploadUrl — chunk ${seq} (${bytes.length}B, isFinal=${isFinal}) NOT uploaded`);
+      return;
+    }
+    await svc.uploadChunk(url, token, Buffer.from(bytes), seq, isFinal, format);
+  };
 }
 
 /**
- * Build the recording sink. Accumulates chunks per key; on the is_final chunk OR close(key)
- * assembles the master and hands it to onMaster (default: upload to meeting-api).
+ * Build the recording sink. Each chunk(...) uploads immediately (serialized in seq order); close(key)
+ * sends the empty is_final fallback exactly once if the tap never delivered its own final chunk.
  */
 export function createBotRecordingSink(opts: RecordingSinkOptions): BotRecordingSink {
   const log = opts.log ?? (() => { /* silent by default */ });
-  const onMaster = opts.onMaster ?? ((master: RecordingMaster) => void uploadMaster(opts.inv, master, log));
-  const assembler = createRecordingAssembler({
-    onMaster: (master) => { void onMaster(master); },
-    log,
-  });
+  const upload = opts.uploadChunk ?? defaultChunkUploader(opts.inv, log);
+
+  let queue: Promise<void> = Promise.resolve();       // serialize uploads → parts land in seq order
+  let anyChunk = false;                                // did the tap ever deliver a chunk?
+  let finalSent = false;                               // has an is_final chunk been sent? (fallback guard)
+  let maxSeq = -1;                                     // highest seq seen → the fallback's seq
+  let lastFormat: RecordingMasterFormat = 'webm';      // format for the empty-final fallback
+
+  const enqueue = (seq: number, isFinal: boolean, format: RecordingMasterFormat, bytes: Uint8Array): void => {
+    anyChunk = true;
+    if (isFinal) finalSent = true;
+    if (seq > maxSeq) maxSeq = seq;
+    lastFormat = format;
+    queue = queue
+      .then(() => upload(seq, isFinal, format, bytes))
+      .catch((e) => { log(`recording: chunk ${seq} (isFinal=${isFinal}) upload failed — continuing: ${String(e)}`); });
+  };
+
   return {
-    chunk: (key, seq, isFinal, format, bytes) => assembler.chunk(key, seq, isFinal, format, bytes),
-    close: (key) => assembler.close(key),
+    chunk: (_key, seq, isFinal, format, bytes) => { enqueue(seq, isFinal, format, bytes); },
+    close: (_key) => {
+      // Final-signal FALLBACK: if the live Stop race dropped the trailing is_final chunk, send one
+      // empty is_final so the server flips the recording COMPLETED. No-op for a never-fed session
+      // (no phantom recording), and at most once (a real is_final already set finalSent).
+      if (!anyChunk || finalSent) return;
+      enqueue(maxSeq + 1, true, lastFormat, new Uint8Array(0));
+    },
   };
 }

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/jsonb.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/jsonb.py
@@ -85,7 +85,14 @@ def apply_chunk_to_recording(
         or prior_sp.endswith("/audio/master.wav")
         or prior_is_final
     )
-    new_storage_path = prior_sp if master_finalized else storage_path
+    # #491 — the empty is_final "signal" chunk (file_size == 0) is a zero-byte COMPLETED marker, NOT
+    # playable bytes. It must NEVER become media_files.storage_path: when a prior data chunk of this
+    # type exists, keep pointing at THAT (the master is assembled from all chunks on read). Before this
+    # guard an empty-final fold set storage_path to the zero-byte signal object, and GET .../raw
+    # (which trusted is_final as "storage_path is playable") served 0 bytes for a confirmed upload.
+    empty_signal = file_size == 0 and prior_same_type is not None
+    keep_prior_path = master_finalized or empty_signal
+    new_storage_path = prior_sp if keep_prior_path else storage_path
     new_is_final = True if master_finalized else is_final
 
     media_files.append({

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/router.py
@@ -255,7 +255,14 @@ def build_router(
         )
         if mf is None:
             raise HTTPException(status_code=404, detail="No such media file")
-        if not mf.get("is_final"):
+        # Finalize-on-read: serve the ASSEMBLED master, never a raw part or the empty final-signal
+        # chunk. #491 — the old guard (`if not mf.is_final`) trusted the media-file's is_final flag as
+        # "storage_path is playable"; but after an empty-final fold storage_path names the zero-byte
+        # signal chunk (0 bytes served) or, with the jsonb fix, the LAST data part (#412: last-part-
+        # only). is_final must stop doubling as "playable" — the ONLY playable object is master.<fmt>,
+        # so finalize (idempotent) unless storage_path already IS the master key, then re-read.
+        storage_path = mf.get("storage_path") or ""
+        if not storage_path.rsplit("/", 1)[-1].startswith("master."):
             await finalize_master(
                 repo, storage, meeting_id=rec["meeting_id"], recording_id=recording_id,
                 media_type=mf.get("type", type),

--- a/core/meetings/services/meeting-api/tests/test_recordings.py
+++ b/core/meetings/services/meeting-api/tests/test_recordings.py
@@ -11,9 +11,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 from meeting_api.bot_spawn import mint_meeting_token
+from meeting_api.recording_codec import build_recording_master
 from meeting_api.recordings import build_router, finalize_master, upload_chunk
 from meeting_api.recordings.fakes import InMemoryRecordingRepo, InMemoryStorage
-from meeting_api.recordings.jsonb import chunk_storage_key
+from meeting_api.recordings.jsonb import apply_chunk_to_recording, chunk_storage_key
 
 SECRET = "test-admin-token"
 USER = 7
@@ -31,10 +32,36 @@ def _wav(n_data: int = 4) -> bytes:
     return struct.pack("<4sI4s", b"RIFF", riff_len, b"WAVE") + fmt + chunk
 
 
+# A deterministic COUNTING-PATTERN wav part (#509): part k's PCM is the byte value k repeated
+# n_data times, so the assembled master's PCM is arithmetic — any dropped / duplicated /
+# overwritten / reordered part is a byte-count or pattern mismatch, every byte accounted for.
+_PART_PCM_LEN = 8
+
+
+def _counting_wav(byte_val: int, n_data: int = _PART_PCM_LEN) -> bytes:
+    import struct
+
+    data = bytes([byte_val % 256]) * n_data
+    fmt = struct.pack("<4sIHHIIHH", b"fmt ", 16, 1, 1, 16000, 32000, 2, 16)
+    chunk = struct.pack("<4sI", b"data", len(data)) + data
+    riff_len = 4 + len(fmt) + len(chunk)
+    return struct.pack("<4sI4s", b"RIFF", riff_len, b"WAVE") + fmt + chunk
+
+
 def _seeded():
     repo = InMemoryRecordingRepo()
     repo.seed(meeting_id=MEETING_ID, user_id=USER, session_uid=SESSION_UID)
     return repo, InMemoryStorage()
+
+
+def _client_for(repo, storage):
+    """A TestClient over the SAME repo+storage a test already uploaded chunks into (so the user read
+    path GET /recordings -> /master -> /raw sees what upload_chunk wrote)."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(build_router(repo, storage, token_secret=SECRET))
+    return TestClient(app)
 
 
 # ── flow: upload folds chunks into JSONB; finalize builds the master ─────────────────────────────
@@ -226,3 +253,163 @@ async def test_concurrent_chunk_uploads_do_not_lose_updates():
     assert len(bot_recs) == 1, f"exactly one recording for the session, got {len(bot_recs)}"
     mf = next(m for m in bot_recs[0]["media_files"] if m["type"] == "audio")
     assert mf["chunk_count"] == 3, f"all 3 chunks must be folded (no lost update), got {mf['chunk_count']}"
+
+
+# ── #509 C2: retrieval serves the assembled master, never the empty final-signal chunk ────────────
+# V1/#491 — a confirmed multi-chunk upload downloads BYTE-COMPLETE via /master and /raw.
+# V2/#412 — every uploaded part is kept; a crashed (no-final) recording still retrieves its parts.
+
+_HDRS = {"x-user-id": str(USER)}
+
+
+def _first_audio(rec: dict) -> dict:
+    return next(m for m in rec["media_files"] if m["type"] == "audio")
+
+
+async def test_multichunk_plus_empty_final_raw_serves_master_not_signal_chunk():
+    """A2 (V1/#491): N counting-pattern data chunks + an empty is_final signal, all folded, then
+    GET .../media/{id}/raw serves the ASSEMBLED master BYTE-COMPLETE — never the zero-byte signal
+    chunk. RED at base: /raw trusted the media-file is_final flag and served storage_path (the
+    0-byte final chunk) directly."""
+    repo, storage = _seeded()
+    n = 5
+    parts = [_counting_wav(k) for k in range(n)]
+    for k, part in enumerate(parts):
+        await upload_chunk(
+            repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+            data=part, media_type="audio", media_format="wav", chunk_seq=k, is_final=False,
+        )
+    # The empty is_final "signal" chunk — a zero-byte COMPLETED marker, NOT playable bytes.
+    receipt = await upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=b"", media_type="audio", media_format="wav", chunk_seq=n, is_final=True,
+    )
+    assert receipt["status"] == "completed"
+
+    client = _client_for(repo, storage)
+    listed = client.get("/recordings", headers=_HDRS)
+    assert listed.status_code == 200, listed.text
+    recs = listed.json()["recordings"]
+    assert len(recs) == 1
+    rec = recs[0]
+    rid, mf = rec["id"], _first_audio(rec)
+    # A3 defence-in-depth: the LISTED pointer must never be the zero-byte final-signal chunk.
+    assert not mf["storage_path"].endswith(f"/audio/{n:06d}.wav"), mf["storage_path"]
+
+    # Hit /raw DIRECTLY (no prior /master) — finalize-on-read must assemble + serve the master.
+    raw = client.get(f"/recordings/{rid}/media/{mf['id']}/raw?type=audio", headers=_HDRS)
+    assert raw.status_code == 200, raw.text
+    oracle = build_recording_master(parts, "wav")
+    assert raw.content == oracle, "raw must byte-equal the codec master oracle"
+    # Independent arithmetic oracle: the PCM payload is exactly each part's counting bytes, in order.
+    assert raw.content[44:] == b"".join(bytes([k]) * _PART_PCM_LEN for k in range(n))
+    assert len(raw.content) > 44, "must not be the zero-byte signal chunk"
+
+
+async def test_multichunk_full_read_path_master_then_raw_byte_complete():
+    """A2 (V1/#491) full player path: GET /recordings -> /recordings/{id} -> /master -> /raw, each
+    step succeeds and the bytes are the complete assembled master."""
+    repo, storage = _seeded()
+    n = 4
+    parts = [_counting_wav(k) for k in range(n)]
+    for k, part in enumerate(parts):
+        await upload_chunk(
+            repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+            data=part, media_type="audio", media_format="wav", chunk_seq=k, is_final=False,
+        )
+    await upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=b"", media_type="audio", media_format="wav", chunk_seq=n, is_final=True,
+    )
+    client = _client_for(repo, storage)
+    rec = client.get("/recordings", headers=_HDRS).json()["recordings"][0]
+    rid = rec["id"]
+    detail = client.get(f"/recordings/{rid}", headers=_HDRS)
+    assert detail.status_code == 200, detail.text
+
+    master = client.get(f"/recordings/{rid}/master?type=audio", headers=_HDRS)
+    assert master.status_code == 200, master.text
+    body = master.json()
+    assert body["storage_path"].endswith("/audio/master.wav"), body["storage_path"]
+    assert body["raw_url"], body
+
+    raw = client.get(body["raw_url"], headers=_HDRS)
+    assert raw.status_code == 200, raw.text
+    assert raw.content == build_recording_master(parts, "wav")
+
+
+async def test_crash_no_final_master_serves_uploaded_parts():
+    """A1 (V2/#412) offline: a bot killed after part 3 (NO is_final) leaves parts 0-2 durable; the
+    recording stays in_progress but /raw finalizes-on-read to EXACTLY those 3 parts concatenated —
+    nothing lost, no all-or-nothing. Download must NOT require status==completed."""
+    repo, storage = _seeded()
+    parts = [_counting_wav(k) for k in range(3)]
+    rid = None
+    for k, part in enumerate(parts):
+        r = await upload_chunk(
+            repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+            data=part, media_type="audio", media_format="wav", chunk_seq=k, is_final=False,
+        )
+        rid = r["recording_id"]
+    # No final chunk (SIGKILL) — status stays IN_PROGRESS.
+    recs = await repo.get_recordings(MEETING_ID)
+    rec = next(r for r in recs if r["id"] == rid)
+    assert rec["status"] == "in_progress"
+
+    client = _client_for(repo, storage)
+    listed = client.get("/recordings", headers=_HDRS).json()["recordings"][0]
+    mf = _first_audio(listed)
+    raw = client.get(f"/recordings/{rid}/media/{mf['id']}/raw?type=audio", headers=_HDRS)
+    assert raw.status_code == 200, raw.text
+    assert raw.content == build_recording_master(parts, "wav")
+    assert raw.content[44:] == b"".join(bytes([k]) * _PART_PCM_LEN for k in range(3))
+
+
+def test_empty_final_fold_never_points_storage_at_signal_chunk():
+    """A3 (unit): folding an empty is_final chunk keeps storage_path on the prior DATA chunk, never
+    the zero-byte signal object, and still flips the recording to completed. Reverting the jsonb hunk
+    makes storage_path the empty chunk key -> red."""
+    data_key = chunk_storage_key(
+        user_id=USER, recording_id=123, session_uid=SESSION_UID,
+        media_type="audio", media_format="wav", chunk_seq=0,
+    )
+    rec, _ = apply_chunk_to_recording(
+        None, recording_id=123, meeting_id=MEETING_ID, user_id=USER, session_uid=SESSION_UID,
+        media_type="audio", media_format="wav", storage_path=data_key, file_size=100,
+        chunk_seq=0, is_final=False, duration_seconds=None, sample_rate=None,
+    )
+    signal_key = chunk_storage_key(
+        user_id=USER, recording_id=123, session_uid=SESSION_UID,
+        media_type="audio", media_format="wav", chunk_seq=1,
+    )
+    rec2, transitioned = apply_chunk_to_recording(
+        rec, recording_id=123, meeting_id=MEETING_ID, user_id=USER, session_uid=SESSION_UID,
+        media_type="audio", media_format="wav", storage_path=signal_key, file_size=0,
+        chunk_seq=1, is_final=True, duration_seconds=None, sample_rate=None,
+    )
+    mf = next(m for m in rec2["media_files"] if m["type"] == "audio")
+    assert mf["storage_path"] == data_key, "kept the data chunk, not the zero-byte signal object"
+    assert mf["storage_path"] != signal_key
+    assert rec2["status"] == "completed", "empty final still completes the recording"
+    assert transitioned is True
+
+
+async def test_single_final_chunk_downloads_byte_complete():
+    """A4 (no-regression): today's single-master-equivalent writer (ONE is_final chunk carrying
+    data) still lists, masters, and /raw-downloads byte-complete."""
+    repo, storage = _seeded()
+    part = _counting_wav(9, n_data=16)
+    r = await upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=part, media_type="audio", media_format="wav", chunk_seq=0, is_final=True,
+    )
+    assert r["status"] == "completed"
+    rid = r["recording_id"]
+
+    client = _client_for(repo, storage)
+    rec = client.get("/recordings", headers=_HDRS).json()["recordings"][0]
+    mf = _first_audio(rec)
+    raw = client.get(f"/recordings/{rid}/media/{mf['id']}/raw?type=audio", headers=_HDRS)
+    assert raw.status_code == 200, raw.text
+    assert raw.content == build_recording_master([part], "wav")
+    assert raw.content[44:] == bytes([9]) * 16


### PR DESCRIPTION
Closes #509. Addresses #491 (retrieval) and #412 (crash durability).

## Why this matters

Two paying-user reports, both hosted, both about the same promise: **the audio you recorded is the audio you can get back.**

- **#491** — bot logs show successful uploads (201s), the meeting shows `has_recording: true`, but `/recordings` doesn't return the files: `/raw` serves the empty final-signal chunk (0 bytes). A confirmed upload is unretrievable.
- **#412** — a ~3h meeting's older audio parts are missing/overwritten ("only the last audio file remains") because the whole recording was held in Node memory and one master uploaded at graceful close — a crash loses everything.

## Value delivered

> **V1 (#491):** A recording the API confirmed uploaded — 201s in the bot log, listed by `GET /recordings` — downloads **byte-complete** through `GET /recordings/{id}/master` and `…/media/{id}/raw`.

> **V2 (#412):** A long, multi-part meeting keeps every audio part: everything the bot uploaded before a crash or the end of the meeting is retrievable, and no part is overwritten or silently replaced by the last one.

## The three seams

**C2 — meeting-api retrieval (load-bearing, fully offline-provable)**
- `recordings/router.py` `get_recording_media_raw`: stop trusting the media-file `is_final` flag as "storage_path is playable". Always **finalize-on-read** into the assembled master unless `storage_path` already IS a `master.<fmt>` key, then re-read. After an empty-final fold, `storage_path` named the zero-byte signal object → `/raw` served 0 bytes (#491).
- `recordings/jsonb.py` `apply_chunk_to_recording`: never let `media_files.storage_path` name an empty signal chunk — when `file_size == 0` and a prior media-file of this type exists, keep the prior `storage_path` (the master is assembled from all chunks on read).

**C1 — bot per-chunk durability (sink half offline-provable; full loss path live-only)**
- `bot/src/recording.ts` `createBotRecordingSink`: stop accumulating into `createRecordingAssembler` + uploading one master at close. Each MediaRecorder timeslice uploads **immediately** via `RecordingService.uploadChunk` (already shipped with retry/backoff — zero production callers before this), serialized in seq order; a permanently-failed chunk is logged-and-skipped. `session_uid == inv.connectionId` (the eager-created MeetingSession the server resolves against — never `nativeMeetingId`/a master key). The empty `is_final` chunk is forwarded (COMPLETED signal); `close(key)` is the final-signal **fallback** (one empty `is_final` if the live Stop race dropped the tap's own final, fired at most once). A SIGKILL now leaves every finished part durable; the master is assembled server-side.
- `bot/src/capture-bridge.ts` `startRecording`: the MediaRecorder timeslice is env-overridable via `VEXA_RECORDING_TIMESLICE_MS` (default `15000`) — the knob a live multi-part run uses.

The `@vexa/recording` assembler stays (the desktop composition root still uses it); only the cloud bot's wiring changes.

## Acceptance table

| # | Observation | Negative control | Status |
|---|---|---|---|
| **A2 (V1/#491)** | N counting-pattern chunks + empty `is_final`, all folded → `GET /recordings` → `/master` → `/media/{id}/raw` **byte-equals** `build_recording_master(chunks)` **and** the arithmetic PCM oracle | at base `/raw` after the final serves the **0-byte** signal chunk → **RED** | ✅ offline, red→green |
| **A1 (V2/#412)** | crashed 3-of-5, **no** `is_final` → recording stays `in_progress` yet `/raw` finalizes-on-read to **exactly** parts 1-3 concatenated | (sink half) `recording.test.ts`: N parts durable before any close, no all-or-nothing | ✅ offline |
| **A3** | after an empty-final fold, `storage_path` never names the signal chunk; `/raw` never serves a non-master part | revert the jsonb/router hunk → **RED** | ✅ offline, red→green |
| **A4** | no-regression: a single `is_final` chunk still lists / masters / `/raw`-downloads byte-complete | — | ✅ offline |
| **wire** | over the real `RecordingService` HTTP wire, `session_uid == inv.connectionId` on every chunk, seq monotone, only the last `is_final` | — | ✅ offline (localhost) |
| **A5 (LIVE)** | Lite compose: real meeting, small timeslice, ≥2 parts land, bot container `docker kill`ed mid-meeting → the audio up to the kill downloads and plays | — | ⏳ **deferred, live-only** |

### Test results

meeting-api lane (`uv run --frozen pytest -q`): **639 passed, 2 skipped**.
bot lane (`npm test`): all files green, exit 0 — including `recording.test.ts` (rewritten for the per-chunk path) and `init-segment.test.ts`.
recording-module lane (`npm test`): green (goldens + init-segment intact). Bot `tsc --noEmit`: clean.

## Honest scope / deferred

- **C1's full page→Node→HTTP loss path is proven ONLY by a live Lite-compose run (A5).** The offline arm proves the sink half (per-chunk delivery, seq/isFinal, session_uid, the close fallback); it can pass while a live loss point remains.
- A crashed (no-final) recording stays `status=in_progress` — the `recording.completed` webhook won't fire — but finalize-on-read still serves it. **Download does not require `status==completed`.**
- **Deferred (not in this PR):** C3 compose-gate multi-chunk probe (`deploy/compose/tests/stack_test.py`, live/docker); the docs.vexa.ai mdx pages (how-to / api ref / configuration knob + retention statement / status truth-table / changelog); deleting the now-unused `audio-pipeline.ts` / `UnifiedRecordingPipeline`.
- Hosted #491/#412 500s are out of scope for this table — they close at the owner-gated engine cutover, whose published acceptance case is exactly this retrieval.
