### PR TITLE
release: v0.12.4 version bump

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.3"
+appVersion: "0.12.4"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
Bumps `package.json` version + Chart.yaml `appVersion` 0.12.3 → 0.12.4 so the `v0.12.4` tag passes release-images preflight (tag == package.json == appVersion).

**Release payload (already merged to main):**
- Reliability batch: #601(#495 gateway auth pool), #602(#508 txn scope), #603(#528 redis hardening), #604(#519 webhook idempotency), #605(#526 config-contract), #606(#527 pipeline liveness), #610(#529 db-budget gate), #611(#509 recordings per-chunk), #612(schema seal)
- Bot/join: #599(#593 Teams self-evict), #597(#592 jitsi lobby), #608(x11 fail-fast), #609(speaker-stream tuning)

Once this lands, tag `v0.12.4` → release-images (build+publish) → release-validate (legs + promote :v012) → release-attest.