### PR TITLE
lite: LOCAL_STT=1 — bundled CPU tiny whisper for transcripts with no token/GPU

### DIFF
--- a/deploy/lite/Makefile
+++ b/deploy/lite/Makefile
@@ -4,7 +4,7 @@
 # `make lite` (from repo root) → this Makefile's `all`: provisions PostgreSQL + MinIO sidecar
 # containers, pulls/builds the all-in-one image, runs it on the host network with the process
 # backend, and verifies the front doors. The app image is lean; postgres/minio stay external.
-.PHONY: all up down init-db test env preflight build push build-and-push set-latest set-dev setup-builder help
+.PHONY: all up down init-db test env preflight build push build-and-push set-latest set-dev setup-builder help stt-smoke
 
 # --- Paths ---
 ROOT       := $(shell git rev-parse --show-toplevel)
@@ -37,6 +37,19 @@ HOST_AGENT_PORT     ?= 8100
 MINIO_ACCESS_KEY ?= vexa-access-key
 MINIO_SECRET_KEY ?= vexa-secret-key
 MINIO_BUCKET     ?= vexa
+
+# --- Local CPU STT (LOCAL_STT=1) ---------------------------------------------------------------
+# Transcription in Vexa is always an external OpenAI-compatible /v1/audio/transcriptions service.
+# For a self-host (or a witness box) with NO hosted token and NO GPU, `make up LOCAL_STT=1` runs a
+# bundled faster-whisper CPU server on the tiny model and auto-wires TRANSCRIPTION_SERVICE_URL to
+# it — transcripts work out of the box, slower but real. The client sends model=whisper-1 (the
+# OpenAI id); faster-whisper-server accepts it and serves WHISPER_MODEL. Override for a bigger
+# model (WHISPER_MODEL=Systran/faster-whisper-small.en) or a GPU image.
+LOCAL_STT        ?=
+WHISPER_CONTAINER ?= vexa-lite-whisper
+WHISPER_IMAGE    ?= fedirz/faster-whisper-server:latest-cpu
+WHISPER_MODEL    ?= Systran/faster-whisper-tiny.en
+HOST_STT_PORT    ?= 8083
 
 define set_tag
 	@echo "Setting '$(1)' → $(2)..."
@@ -122,6 +135,20 @@ up: preflight
 		docker run --rm --network $(NETWORK) --entrypoint sh minio/mc:latest -c \
 			"mc alias set vexa http://$(MINIO_CONTAINER):9000 $(MINIO_ACCESS_KEY) $(MINIO_SECRET_KEY) && mc mb --ignore-existing vexa/$(MINIO_BUCKET)" >/dev/null 2>&1 || true; \
 	fi; echo "  ✓ MinIO ready"; \
+	if [ -n "$(LOCAL_STT)" ]; then \
+		echo "Starting local CPU STT ($(WHISPER_CONTAINER), $(WHISPER_MODEL))..."; \
+		if ! docker ps -q -f name=$(WHISPER_CONTAINER) | grep -q .; then \
+			docker rm -f $(WHISPER_CONTAINER) 2>/dev/null || true; \
+			docker run -d --name $(WHISPER_CONTAINER) --network $(NETWORK) --restart unless-stopped \
+				-e WHISPER__MODEL=$(WHISPER_MODEL) -e WHISPER__INFERENCE_DEVICE=cpu -e WHISPER__TTL=-1 \
+				-p $(HOST_STT_PORT):8000 \
+				$(WHISPER_IMAGE) > /dev/null; \
+		fi; \
+		echo "  Waiting for the STT model to load (up to 3 min)..."; \
+		for i in $$(seq 1 36); do curl -sf -o /dev/null http://localhost:$(HOST_STT_PORT)/health 2>/dev/null && break; sleep 5; done; \
+		TX_URL=http://$(WHISPER_CONTAINER):8000; TX_TOKEN=; \
+		echo "  ✓ local STT ready — routing transcription to $$TX_URL (model $(WHISPER_MODEL))"; \
+	fi; \
 	echo "Starting Vexa Lite ($$IMG)..."; \
 	docker rm -f $(APP_CONTAINER) 2>/dev/null || true; \
 	docker run -d --name $(APP_CONTAINER) --shm-size=2g --network $(NETWORK) --restart unless-stopped \
@@ -155,9 +182,31 @@ test:
 ## down — stop + remove app + sidecars + network (volumes persist; `docker volume rm vexa-lite-pgdata vexa-lite-miniodata` to wipe).
 down:
 	@echo "Stopping Vexa Lite..."
-	@docker rm -f $(APP_CONTAINER) $(PG_CONTAINER) $(MINIO_CONTAINER) 2>/dev/null || true
+	@docker rm -f $(APP_CONTAINER) $(PG_CONTAINER) $(MINIO_CONTAINER) $(WHISPER_CONTAINER) 2>/dev/null || true
 	@docker network rm $(NETWORK) 2>/dev/null || true
 	@echo "  ✓ Stopped (data volumes kept)"
+
+## stt-smoke — prove the local STT actually transcribes: synthesize speech, POST it as the client
+## does (model=whisper-1, verbose_json), and assert non-empty text. The machine check that the
+## witness box will transcribe BEFORE a human is asked to speak (validation ladder: machine first).
+## Requires LOCAL_STT to be up (HOST_STT_PORT published). Uses containers for espeak/ffmpeg — no
+## host tools needed.
+stt-smoke:
+	@set -e; \
+	echo "Synthesizing test speech + transcribing via local STT (:$(HOST_STT_PORT), model=whisper-1)..."; \
+	docker run --rm -v /tmp:/out --entrypoint sh $(WHISPER_IMAGE) -c 'exit 0' 2>/dev/null || true; \
+	TMP=$$(mktemp -d); \
+	docker run --rm -v $$TMP:/out debian:stable-slim sh -c \
+		'apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq espeak-ng ffmpeg >/dev/null 2>&1 && \
+		 espeak-ng "the quick brown fox jumps over the lazy dog" -w /tmp/s.wav 2>/dev/null && \
+		 ffmpeg -y -i /tmp/s.wav -ar 16000 -ac 1 /out/speech.wav >/dev/null 2>&1'; \
+	OUT=$$(curl -s --max-time 90 http://localhost:$(HOST_STT_PORT)/v1/audio/transcriptions \
+		-F file=@$$TMP/speech.wav -F model=whisper-1 -F response_format=verbose_json); \
+	rm -rf $$TMP; \
+	echo "  STT response: $$OUT" | head -c 300; echo; \
+	echo "$$OUT" | grep -qiE 'quick brown fox|lazy dog' \
+		&& echo "  ✓ local STT transcribes (model=whisper-1 → words)" \
+		|| { echo "  ✗ local STT returned no expected words — check $(WHISPER_CONTAINER) logs"; exit 1; }
 
 # ── Image build / publish ──────────────────────────────────────────────────────────────────────────
 build: preflight

--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -27,6 +27,25 @@ host network, and probes the front doors. Set `TRANSCRIPTION_SERVICE_URL` /
 `TRANSCRIPTION_SERVICE_TOKEN` in the repo-root `.env` for transcripts (get a token at
 `vexa.ai/account`, or self-host the transcription service on a GPU).
 
+### Transcripts with no token and no GPU — `LOCAL_STT=1`
+
+```bash
+make -C deploy/lite up LOCAL_STT=1
+```
+
+Runs a bundled **faster-whisper CPU server on the tiny model** (`vexa-lite-whisper`) on the same
+network and **auto-wires `TRANSCRIPTION_SERVICE_URL`** to it — real transcripts out of the box,
+slower than a GPU but zero setup. This is also how a **witness / human-eval box** always comes up
+with transcription ready. Verify it end-to-end (synthesize speech → transcribe):
+
+```bash
+make -C deploy/lite stt-smoke        # ✓ local STT transcribes (model=whisper-1 → words)
+```
+
+Override the model or image for more accuracy: `WHISPER_MODEL=Systran/faster-whisper-small.en`, or
+a GPU image via `WHISPER_IMAGE=...`. (The client sends `model=whisper-1`, the OpenAI id;
+faster-whisper-server accepts it and serves `WHISPER_MODEL`.)
+
 After it finishes:
 
 - **Terminal:** `http://YOUR_IP:3001` (the agent-domain browser-CLI workbench)
@@ -88,6 +107,10 @@ The repo-root `.env` (auto-seeded from `deploy/compose/.env` if present, else mi
 | `TRANSCRIPTION_SERVICE_URL` / `_TOKEN` | — | STT endpoint + key. Unset → bots capture, no transcript |
 | `ADMIN_TOKEN` | `changeme` | admin API token (the stack's shared admin secret) |
 | `IMAGE_TAG` | `latest` | the `vexaai/vexa-lite` tag to pull (a local `vexa-lite:dev` build wins) |
+
+`make` variables (not `.env`) for the bundled local STT: `LOCAL_STT=1` (off by default),
+`WHISPER_MODEL` (`Systran/faster-whisper-tiny.en`), `WHISPER_IMAGE`, `HOST_STT_PORT` (`8083`). When
+`LOCAL_STT=1`, the bundled server overrides `TRANSCRIPTION_SERVICE_URL` for you.
 
 Agent inference is BYO — point the runtime at your endpoint via `ANTHROPIC_*` / `VEXA_AGENT_MODEL`
 in `.env`; the runtime brokers credentials into spawned workers (nothing leaves the network).


### PR DESCRIPTION
## Why
Transcription in Vexa is **always** an external OpenAI-compatible `/v1/audio/transcriptions` service. So a self-host — or a **witness / human-eval box** — with no hosted token and no GPU comes up capturing audio but producing **no transcript**. We hit exactly this bringing up a v0.12.4 witness box (`no transcription backend configured`). A human-eval setup should have transcription **always**.

## What
- **`make -C deploy/lite up LOCAL_STT=1`** runs a bundled **faster-whisper CPU server on the tiny model** (`vexa-lite-whisper`) on the lite network and **auto-wires `TRANSCRIPTION_SERVICE_URL`** to it. Real transcripts, zero setup, slower than a GPU. Override `WHISPER_MODEL` / `WHISPER_IMAGE` / `HOST_STT_PORT`.
- **`make -C deploy/lite stt-smoke`** — synthesize speech → POST it exactly as the client does (`model=whisper-1`, `verbose_json`) → assert words. The **machine-first** check that a box transcribes *before* a human is asked to speak (the validation ladder).
- `down` tears the whisper container down too; README documents both.

## Verified
On a live box: `model=whisper-1` (Vexa's client [hardcodes it](core/meetings/modules/whisper/src/transcription-client.ts)) is accepted by faster-whisper-server and served with the tiny model; `stt-smoke` green end-to-end (*"the quick brown fox…"* → words). `make -n up LOCAL_STT=1` and `make -n stt-smoke` parse.

## Follow-up
Filing an issue to make the STT model id **configurable** (client hardcodes `whisper-1`) so self-hosters can point straight at `tiny`/`small` without relying on the server aliasing the OpenAI name.