### PR TITLE
docs: Jitsi joins the platform lineup — README + docs site 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Open-source, self-hosted meeting bot & transcription API.**
 
-A bot joins your Google Meet, Microsoft Teams, and Zoom calls and streams speaker-attributed
+A bot joins your Google Meet, Microsoft Teams, Zoom, and Jitsi calls and streams speaker-attributed
 transcripts in real time through an API *you* host — then feeds sandboxed agents that build a
 Markdown knowledge base your team owns. Self-hosted, Apache-2.0, air-gap-ready.
 
@@ -29,7 +29,7 @@ your meetings become.
 
 No one else has all three:
 
-1. **Vexa is *in* the meeting.** A real bot joins Meet, Teams, and Zoom and streams
+1. **Vexa is *in* the meeting.** A real bot joins Meet, Teams, Zoom, and Jitsi and streams
    speaker-attributed transcripts live. That bot fleet is the genuinely hard part — every
    "chat with your docs" tool starts *after* a transcript exists. Vexa produces it.
 
@@ -336,7 +336,7 @@ Against the tools developers actually weigh for meeting capture:
 |---|:---:|:---:|:---:|
 | Self-hosted / own your data | ✅ | ❌ their cloud | ✅ |
 | Real-time transcript API | ✅ | ✅ | 🟡 build it |
-| Joins **Meet + Teams + Zoom** | ✅ | 🟡 varies | ❌ enormous effort |
+| Joins **Meet + Teams + Zoom + Jitsi** | ✅ | 🟡 varies | ❌ enormous effort |
 | Speaker attribution | ✅ | ✅ | 🟡 build it |
 | Knowledge as files you own | ✅ | ❌ | 🟡 build it |
 | Agents over your workspace | ✅ | ❌ | ❌ |
@@ -368,7 +368,7 @@ Companion** on the axes they structurally can't move:
 | Models | Vendor-hosted, fixed | **Bring your own** — local or hosted LLMs |
 | Commercial model | Rented, per-seat subscription | **Owned** — Apache-2.0, no per-seat tax |
 | Adaptable | Generic; no custom vocabulary; vendor roadmap queue | **Your engineers extend it directly** — domain vocabulary, underserved languages, custom workflows |
-| Meeting platforms | Teams-only / Zoom-only | **Meet + Teams + Zoom** |
+| Meeting platforms | Teams-only / Zoom-only | **Meet + Teams + Zoom + Jitsi** |
 | Data control | Transits the vendor's cloud | **Never leaves your perimeter** |
 | Extensibility | Closed black box | Open source, API-first |
 

--- a/docs/docs/comparison.mdx
+++ b/docs/docs/comparison.mdx
@@ -24,7 +24,7 @@ API for downstream systems, and speaker attribution limited to what mono device 
 personal tool, not an infrastructure layer.
 
 **DIY** (Whisper + your own headless-browser bot) — full control, and an enormous, permanently
-maintained effort: three platforms' join flows, admission handling, audio capture, streaming STT,
+maintained effort: four platforms' join flows, admission handling, audio capture, streaming STT,
 attribution, scaling.
 
 ## Vexa vs. the alternatives
@@ -33,7 +33,7 @@ attribution, scaling.
 |---|:---:|:---:|:---:|:---:|:---:|
 | Self-hosted / data stays in your perimeter | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Fully **air-gapped** (bundled self-hosted GPU STT unit) | ✅ | 🟡 BYO STT wiring | ❌ | 🟡 local models | 🟡 build it |
-| Bot joins **Meet + Teams + Zoom** | ✅ | ✅ | ✅ | ❌ device audio | 🟡 build ×3 |
+| Bot joins **Meet + Teams + Zoom + Jitsi** | ✅ | ✅ | ✅ | ❌ device audio | 🟡 build ×3 |
 | Real-time transcript API, speaker-attributed | ✅ | ✅ | ✅ | 🟡 app-local | 🟡 build it |
 | **Bring your own models** (STT + LLM endpoints) | ✅ | 🟡 STT providers | ❌ | ✅ | ✅ |
 | Kubernetes / OpenShift scale-out (Helm, a Pod per workload) | ✅ | 🟡 compose-first | n/a | ❌ | 🟡 build it |

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -8,7 +8,7 @@ description: "Sandboxed AI agents that grow corporate knowledge from your meetin
   Sandboxed agents that grow corporate knowledge from your meetings and docs.
 </div>
 
-Real-time transcripts from Google Meet, Zoom, and Teams (Whisper included), fed to agents that build knowledge as code — fully self-hosted.
+Real-time transcripts from Google Meet, Zoom, Teams, and Jitsi (Whisper included), fed to agents that build knowledge as code — fully self-hosted.
 
 <Note>
   **These docs cover Vexa 0.12.** The hosted [vexa.ai](https://vexa.ai) runs the 0.10 line today and will be updated to 0.12 soon — to try 0.12 now, [self-host it](#try-it) below.
@@ -40,7 +40,7 @@ them.
 <CardGroup cols={2}>
   <Card title="Meetings" icon="video" href="/core/meetings">
     Plan, capture, and share meetings — calendar sync, auto-joining bots, real-time transcripts from
-    Google Meet, Zoom, and Teams. Usable standalone as a meeting API.
+    Google Meet, Zoom, Teams, and Jitsi. Usable standalone as a meeting API.
   </Card>
   <Card title="Agents" icon="robot" href="/core/agents">
     Sandboxed, scalable agents over your workspace. Put them to work on any knowledge — with or without
@@ -67,7 +67,7 @@ them.
 
 ## What it does
 
-- **Captures meetings natively** — real-time transcripts from [Google Meet, Zoom, and Teams](/core/meetings), no plugins or recorders. **Whisper included**.
+- **Captures meetings natively** — real-time transcripts from [Google Meet, Zoom, Teams, and Jitsi](/core/meetings), no plugins or recorders. **Whisper included**.
 - **Meets you at your calendar** — [connect a secret ICS address](/how-to/calendar-sync) and upcoming meetings import automatically; the bot [auto-joins](/core/meetings#auto-join--scheduled-means-the-bot-comes) each one at start. [Plan a meeting](/how-to/plan-a-meeting) ahead and share its prep workspace with the people you're meeting.
 - **Turns knowledge into code** — meetings and emails become a living, Markdown [workspace](/concepts#workspace) that agents treat as their working directory.
 - **Runs agents safely** — every [agent](/core/agents) executes in an isolated, ephemeral [container](/concepts#container): no egress except through brokered tools, thousands in parallel, no lateral movement.


### PR DESCRIPTION
Jitsi Meet support landed (#543) and **v0.12.4's #597 made it handle real members-only lobbies**. The README's headline still said *"Meet + Teams + Zoom"* while the API docs already accept `jitsi` — this closes that gap.

Adds Jitsi to the four headline platform claims (intro line, 'what Vexa is', and both comparison tables) → **Meet + Teams + Zoom + Jitsi**. No other content change.

Docs-only front-page update; the platform is real (join adapter + capture + pipeline from #543, lobby admission solid as of #597).