### PR TITLE
fix(meeting-api): slim the meetings list — drop heavy data keys + default page size (#584)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -385,11 +385,12 @@ class SqlAlchemyTranscriptStore:
         # Session closed (transaction ended, connection returned to pool) BEFORE the Redis merge (#508).
         return await self._merge_live_segments(pg)
 
-    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None):
+    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None, list_view=False):
         from sqlalchemy import cast, func, or_, select
         from sqlalchemy.dialects.postgresql import JSONB
 
         from .models import Meeting
+        from .projection import DEFAULT_LIST_LIMIT, project_list_data
 
         async with self._session_factory() as db:
             # ACCESS = owner OR transcript-share viewer OR member of the bound workspace. Shared meetings
@@ -406,13 +407,29 @@ class SqlAlchemyTranscriptStore:
             if platform:
                 stmt = stmt.where(Meeting.platform == platform)
             stmt = stmt.order_by(Meeting.created_at.desc())
-            if limit:
-                stmt = stmt.limit(limit)
-            if offset:
-                stmt = stmt.offset(offset)
-            rows = (await db.execute(stmt)).scalars().all()
-            return [
-                {
+            if list_view:
+                # #584: the paginated, slim list-view path (GET /bots, GET /meetings). Bound the response
+                # with a default page size (an explicit `limit` still wins) and over-fetch one row past
+                # the page to compute `has_more` without a second COUNT query.
+                effective_limit = limit if limit is not None else DEFAULT_LIST_LIMIT
+                if offset:
+                    stmt = stmt.offset(offset)
+                stmt = stmt.limit(effective_limit + 1)
+                rows = (await db.execute(stmt)).scalars().all()
+                has_more = len(rows) > effective_limit
+                rows = rows[:effective_limit]
+            else:
+                # Internal enumeration (get-by-id filter, /bots/status, calendar sync): unchanged —
+                # explicit `limit` only, NO default cap, full `data` retained below.
+                if limit:
+                    stmt = stmt.limit(limit)
+                if offset:
+                    stmt = stmt.offset(offset)
+                rows = (await db.execute(stmt)).scalars().all()
+                has_more = False
+
+            def _row(m):
+                row = {
                     "id": m.id,
                     "user_id": m.user_id,
                     "platform": m.platform,
@@ -423,13 +440,19 @@ class SqlAlchemyTranscriptStore:
                     "bot_container_id": m.bot_container_id,
                     "start_time": m.start_time.isoformat() if m.start_time else None,
                     "end_time": m.end_time.isoformat() if m.end_time else None,
-                    "data": m.data if isinstance(m.data, dict) else {},
                     "shared": m.user_id != user_id,   # surfaced via a share/membership, not owned by the caller
                     "created_at": m.created_at.isoformat() if m.created_at else None,
                     "updated_at": m.updated_at.isoformat() if m.updated_at else None,
+                    # #584: the LIST drops the heavy detail keys (speaker_events/bot_logs/recordings/… —
+                    # the 4.6 MB / event-loop-wedge cause) but keeps the light metadata it renders
+                    # (title/docs/flags). Internal callers (get-by-id, /bots/status, calendar sync) get
+                    # full `data`, so the detail view and reconciliation are unchanged.
+                    "data": project_list_data(m.data) if list_view else (m.data if isinstance(m.data, dict) else {}),
                 }
-                for m in rows
-            ]
+                return row
+
+            result = [_row(m) for m in rows]
+            return (result, has_more) if list_view else result
 
     async def authorize_subscribe(self, user_id, platform, native_meeting_id, member_workspaces=None) -> Optional[int]:
         """Authorize a live-transcript subscribe → the meeting ROW id, or None. TWO branches:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -189,9 +189,9 @@ def build_router(
     ):
         user_id = _resolve_user_id(x_user_id)
         member_workspaces = {w.strip() for w in (x_user_workspaces or "").split(",") if w.strip()}
-        meetings = await store.list_meetings(
+        meetings, _has_more = await store.list_meetings(
             user_id, status=status, platform=platform, limit=limit, offset=offset,
-            member_workspaces=member_workspaces,
+            member_workspaces=member_workspaces, list_view=True,
         )
         log_event(
             "meetings_listed",
@@ -214,14 +214,15 @@ def build_router(
         platform: Optional[str] = Query(default=None),
     ):
         user_id = _resolve_user_id(x_user_id)
-        meetings = await store.list_meetings(
-            user_id, status=status, platform=platform, limit=limit, offset=offset
+        meetings, has_more = await store.list_meetings(
+            user_id, status=status, platform=platform, limit=limit, offset=offset,
+            list_view=True,
         )
         log_event(
             "bots_listed", audience="user", span="bots.list",
             user_id=user_id, fields={"count": len(meetings)},
         )
-        return JSONResponse(content={"meetings": meetings, "has_more": False})
+        return JSONResponse(content={"meetings": meetings, "has_more": has_more})
 
     # --- GET /bots/status → the caller's currently-running bots (api/meetings.mdx "Running bots").
     # Running == any non-terminal FSM status (requested·joining·awaiting_admission·active·stopping);

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -172,7 +172,8 @@ class InMemoryTranscriptStore:
         )
         return await self._transcript_doc(mid) if authorized else None
 
-    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None):
+    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None, list_view=False):
+        from .projection import DEFAULT_LIST_LIMIT, project_list_data
         mws = member_workspaces or set()
 
         def accessible(m):
@@ -190,10 +191,18 @@ class InMemoryTranscriptStore:
         rows.sort(key=lambda kv: (kv[1]["created_at"], kv[0]), reverse=True)
         if offset:
             rows = rows[offset:]
-        if limit:
-            rows = rows[:limit]
-        return [
-            {
+        if list_view:
+            # #584: mirror the real store — default page size + over-fetch-by-1 for honest has_more.
+            effective_limit = limit if limit is not None else DEFAULT_LIST_LIMIT
+            has_more = len(rows) > effective_limit
+            rows = rows[:effective_limit]
+        else:
+            if limit:
+                rows = rows[:limit]
+            has_more = False
+
+        def _row(mid, m):
+            row = {
                 "id": mid,
                 "user_id": m["user_id"],
                 "platform": m["platform"],
@@ -203,13 +212,16 @@ class InMemoryTranscriptStore:
                 "bot_container_id": m.get("bot_container_id"),
                 "start_time": m["start_time"],
                 "end_time": m["end_time"],
-                "data": m["data"],
                 "shared": m["user_id"] != user_id,
                 "created_at": m["created_at"],
                 "updated_at": m["updated_at"],
+                # #584: LIST drops heavy detail keys, keeps light metadata; internal callers get full data.
+                "data": project_list_data(m["data"]) if list_view else m["data"],
             }
-            for mid, m in rows
-        ]
+            return row
+
+        result = [_row(mid, m) for mid, m in rows]
+        return (result, has_more) if list_view else result
 
     async def authorize_subscribe(self, user_id, platform, native_meeting_id, member_workspaces=None) -> Optional[int]:
         mid = self._find(user_id, platform, native_meeting_id)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
@@ -1,0 +1,54 @@
+"""List-view shaping for the meetings list (#584).
+
+The meetings-list endpoints (``GET /bots``, ``GET /meetings``) return a row PER meeting. Each row used
+to embed that meeting's full ``data`` JSONB — transcripts, speaker events, logs, recordings. On a real
+583-meeting account the list response was 4.6 MB, and serializing it on the meeting-api event loop
+under morning load wedged the loop and caused a ~1.5 h hosted read outage (2026-07-15).
+
+We cannot drop ``data`` from the list wholesale — the list genuinely renders a few LIGHT keys from it
+(a meeting's ``title``, connected ``docs``, ``scheduled_at``, the recording/transcribe flags). So the
+list keeps those light keys and drops only the heavy detail keys — the ones that made the response
+multi-MB and that the list never renders. Full ``data`` (every key) still ships on the detail path
+(``GET /meetings/{id}`` and the transcript endpoint).
+
+This module holds the two things the real store (``adapters.py``) and the in-memory fake (``fakes.py``)
+must share so they can never diverge: the set of heavy keys dropped from a list row, and the default
+page size that bounds an otherwise-unbounded list.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Heavy per-meeting ``data`` keys the list NEVER renders — dropped from list rows. Everything else
+# (title, docs, scheduled_at, workspace_id, constructed_meeting_url, recording/transcribe flags, …)
+# rides along, because the list DOES render some of it. Full ``data`` stays on ``GET /meetings/{id}``.
+# Measured weight on the outage account (sum across meetings / max in one): speaker_events 155 MB /
+# 3.2 MB, bot_logs 78 MB, recordings 13 MB, status_transition 6 MB, last_error 2 MB / 2 MB,
+# chat_messages 796 KB. Dropping these removes ~99% of the list's bytes.
+LIST_OMIT_KEYS = frozenset({
+    "speaker_events",
+    "bot_logs",
+    "recordings",
+    "status_transition",
+    "chat_messages",
+    "error_details",
+    "last_error",
+})
+
+# Default page size applied on the list-view path when a caller passes no ``limit`` — turns an
+# unbounded full-table response (the outage's proximate trigger) into a bounded page. An explicit
+# ``limit`` still wins. Internal callers that reuse ``list_meetings`` to enumerate ALL of a user's
+# meetings (get-by-id filter, /bots/status, calendar sync) do NOT take the list-view path and are
+# never capped.
+DEFAULT_LIST_LIMIT = 50
+
+
+def project_list_data(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return ``data`` with the heavy :data:`LIST_OMIT_KEYS` dropped; every light key kept.
+
+    Pure and non-mutating (builds a new dict), so the caller's stored ``data`` is untouched and the
+    detail view still sees every key. A non-dict ``data`` projects to ``{}``.
+    """
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if k not in LIST_OMIT_KEYS}

--- a/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
+++ b/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
@@ -1,0 +1,145 @@
+"""#584 — the meetings list omits per-row ``data`` and is bounded by a default page size.
+
+The list endpoints (``GET /bots``, ``GET /meetings``) used to embed each meeting's full ``data``
+JSONB per row — 4.6 MB on a real 583-meeting account — which wedged the meeting-api event loop under
+morning load (the 2026-07-15 hosted read outage). ``data`` is not part of the sealed api.v1
+``MeetingResponse`` schema; the list now returns only the sealed scalar metadata, bounded by a
+default page size, and a caller fetches one meeting's ``data`` on demand (``GET /meetings/{id}``).
+
+The fix is gated on a ``list_view`` flag so the internal callers that REUSE ``list_meetings`` to
+enumerate a user's meetings (``GET /meetings/{id}`` filter, ``GET /bots/status``, calendar sync) are
+unchanged — full ``data``, no default cap. These tests pin both halves.
+
+Drives the SHIPPED meeting-api handlers over the in-memory fakes (TestClient, offline) and the store
+directly. The fake mirrors the real ``SqlAlchemyTranscriptStore`` (both share
+``collector/projection.py``), so the list-shape behaviour proven here is the shipped behaviour.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meeting_api import create_app
+from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+from meeting_api.collector.projection import DEFAULT_LIST_LIMIT
+from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher
+
+USER = 7
+HEADERS = {"x-user-id": str(USER)}
+
+# A meeting whose ``data`` carries the heavy detail keys the list must never ship (the outage cause),
+# plus the light ``constructed_meeting_url`` the list promotes to a top-level scalar.
+HEAVY_DATA = {
+    # light keys the LIST renders — must survive the projection
+    "constructed_meeting_url": "https://meet.google.com/abc-defg-hij",
+    "title": "Weekly sync",
+    "docs": [{"workspace": "u", "path": "notes.md"}],
+    # heavy detail keys the LIST must never ship (the outage cause)
+    "speaker_events": [{"i": i, "t": "x" * 64} for i in range(2000)],   # the ~3 MB-class key
+    "bot_logs": ["log-line " * 8] * 2000,
+    "recordings": [{"id": "r1", "url": "s3://…"}],
+    "status_transition": [{"to": "active"}],
+    "chat_messages": [{"m": "hi"}],
+    "last_error": {"trace": "x" * 5000},
+}
+
+HEAVY_KEYS = ("speaker_events", "bot_logs", "recordings", "status_transition",
+              "chat_messages", "error_details", "last_error")
+
+
+def _client(store):
+    return TestClient(create_app(
+        transcript_store=store,
+        meeting_repo=InMemoryMeetingRepo(),
+        runtime=FakeRuntimeClient(),
+        command_publisher=InMemoryCommandPublisher(),
+    ))
+
+
+def _seed_heavy(store, nid="abc-defg-hij"):
+    return store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id=nid, status="active",
+        constructed_meeting_url="https://meet.google.com/abc-defg-hij", data=dict(HEAVY_DATA),
+    )
+
+
+def _seed_n(store, n):
+    for i in range(n):
+        store.seed_meeting(
+            user_id=USER, platform="google_meet", native_meeting_id=f"m-{i:04d}", status="active",
+            created_at=f"2026-06-20T{i // 60:02d}:{i % 60:02d}:00Z", data=dict(HEAVY_DATA),
+        )
+
+
+# ── C1 · the LIST omits `data` (route-level, both endpoints) ───────────────────────────────────────
+
+@pytest.mark.parametrize("path", ["/bots", "/meetings"])
+def test_list_row_drops_heavy_data_keeps_light(path):
+    store = InMemoryTranscriptStore()
+    _seed_heavy(store)
+    r = _client(store).get(path, headers=HEADERS)
+    assert r.status_code == 200
+    (row,) = r.json()["meetings"]
+    # #584: the heavy detail keys (the 4.6 MB / event-loop-wedge cause) are gone from the list row…
+    for heavy in HEAVY_KEYS:
+        assert heavy not in row["data"], f"list row still ships heavy key {heavy!r}"
+    # …but the light metadata the list actually renders survives.
+    assert row["data"].get("title") == "Weekly sync"
+    assert row["data"].get("docs") == [{"workspace": "u", "path": "notes.md"}]
+    assert row["constructed_meeting_url"] == "https://meet.google.com/abc-defg-hij"
+    assert row["status"] == "active" and row["native_meeting_id"] == "abc-defg-hij"
+    # the whole list response is a few KB, not the multi-MB the stored data would make.
+    assert len(r.content) < 20_000, f"list response too large: {len(r.content)} bytes"
+
+
+def test_get_meeting_by_id_still_returns_full_data():
+    """A3 — the detail path (GET /meetings/{id}) reuses list_meetings on the INTERNAL path, so it
+    still returns the full `data`; only the LIST drops it."""
+    store = InMemoryTranscriptStore()
+    mid = _seed_heavy(store)
+    c = _client(store)
+    # list row: heavy keys dropped
+    list_row = c.get("/bots", headers=HEADERS).json()["meetings"][0]
+    assert "speaker_events" not in list_row["data"] and "recordings" not in list_row["data"]
+    # detail row (GET /meetings/{id}, internal path): full data, heavy keys present
+    detail = c.get(f"/meetings/{mid}", headers=HEADERS)
+    assert detail.status_code == 200
+    body = detail.json()
+    assert "data" in body and "speaker_events" in body["data"] and "recordings" in body["data"]
+
+
+# ── C2 · default page size + honest has_more ───────────────────────────────────────────────────────
+
+def test_bots_has_more_reflects_more_not_hardcoded_false():
+    store = InMemoryTranscriptStore()
+    _seed_n(store, 2)
+    c = _client(store)
+    # one-per-page over two meetings → there IS more (was hardcoded `false` before #584)
+    r1 = c.get("/bots", headers=HEADERS, params={"limit": 1})
+    assert r1.status_code == 200 and len(r1.json()["meetings"]) == 1
+    assert r1.json()["has_more"] is True
+    # the whole (small) set on one page → no more
+    r2 = c.get("/bots", headers=HEADERS, params={"limit": 100})
+    assert r2.json()["has_more"] is False
+
+
+async def test_list_view_applies_default_limit_and_has_more():
+    """The store's list-view path caps an unbounded request at DEFAULT_LIST_LIMIT and reports more."""
+    store = InMemoryTranscriptStore()
+    _seed_n(store, DEFAULT_LIST_LIMIT + 10)   # 60
+    rows, has_more = await store.list_meetings(USER, list_view=True)   # no explicit limit
+    assert len(rows) == DEFAULT_LIST_LIMIT and has_more is True
+    # an explicit limit still wins and its has_more is honest
+    rows2, more2 = await store.list_meetings(USER, list_view=True, limit=100)
+    assert len(rows2) == DEFAULT_LIST_LIMIT + 10 and more2 is False
+
+
+# ── the internal path is UNCHANGED — no default cap, full data (protects get-by-id / status / sync) ─
+
+async def test_internal_path_is_unbounded_and_keeps_data():
+    store = InMemoryTranscriptStore()
+    _seed_n(store, DEFAULT_LIST_LIMIT + 10)   # 60
+    rows = await store.list_meetings(USER)    # list_view=False (default) → plain list, no cap
+    assert isinstance(rows, list) and len(rows) == DEFAULT_LIST_LIMIT + 10   # NOT capped to 50
+    assert all("data" in r for r in rows)     # full data retained for internal reuse

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -237,6 +237,17 @@ curl -H "X-API-Key: $API_KEY" "$API_BASE/meetings"
 curl -H "X-API-Key: $API_KEY" "$API_BASE/meetings/12345"
 ```
 
+### List rows are slim; detail is full
+
+The two list endpoints — `GET /bots` and `GET /meetings` — return **lightweight rows**. Each row keeps
+its light metadata (id, status, times, `title`, connected docs) but **omits the heavy `data` detail
+keys**: `speaker_events`, `bot_logs`, `recordings`, `status_transition`, `chat_messages`,
+`error_details`, and `last_error`. Fetch a meeting's full `data` from `GET /meetings/{meeting_id}` — the
+detail endpoint is unaffected and still returns every key.
+
+The list is also **paged**: with no `limit`, a default page size of `50` applies (pass `limit`/`offset`
+to page explicitly). `GET /bots` returns `has_more: true` when more rows remain past the current page.
+
 ## Speaker-attributed transcripts
 
 Each segment is **diarized** — attributed to a speaker (a bound display name, or a provisional label


### PR DESCRIPTION
## What & why

`GET /bots` and `GET /meetings` embed each meeting's full `data` JSONB **per row** — `speaker_events`, `bot_logs`, `recordings`, `status_transition`, `last_error`, … On a real 583-meeting account the list response is **4.6 MB**, and serializing it on the meeting-api event loop under morning load wedged the loop → the **2026-07-15 hosted read outage** (~1.5 h, ~100% read failure on `/meetings` + `/transcripts`). Restart + pool bump didn't hold (loop-bound, not pool-bound); it was mitigated by scaling meeting-api to 2 replicas. This is the durable cure.

## The fix

- **`collector/projection.py`** (new) — shared by the real `SqlAlchemyTranscriptStore` and the in-memory fake so they can't diverge:
  - `project_list_data()` drops the heavy detail keys from a list row and **keeps the light metadata the list actually renders** (`title`, `docs`, `constructed_meeting_url`, the recording/transcribe flags…).
  - `DEFAULT_LIST_LIMIT = 50` bounds an otherwise-unbounded response.
- **List path** (`GET /bots`, `GET /meetings`): default page size + **honest `has_more`** via over-fetch-by-1 (was hardcoded `false`).
- **Gated on a `list_view` flag** so the internal callers that reuse `list_meetings` — `GET /meetings/{id}` (detail filter), `GET /bots/status`, calendar sync — keep **full `data`** and stay **unbounded**. No older-meeting truncation, detail view unchanged.

The sealed `api.v1 MeetingResponse` schema has **no `data` field** — the list was shipping it as an off-contract extra; this moves the list toward the seal while keeping the light keys the UI needs.

> Note: dropping `data` from the list *entirely* isn't possible — the list renders `data.title` (planned meetings) and `data.docs` (connected docs); two existing tests depend on it. So the fix drops only the heavy keys (~99% of the bytes).

## Acceptance (`tests/test_slim_meetings_list.py`, red→green)

| # | Observation | Negative control (RED at base) |
|---|---|---|
| A1 | list row drops the heavy keys, keeps `title`/`docs`; whole response < 20 KB for a heavy meeting | base: heavy keys present, multi-MB |
| A2 | `GET /bots?limit=1` over 2 meetings → `has_more: true`; default caps at 50, `has_more` honest | base: `has_more` hardcoded `false` |
| A3 | `GET /meetings/{id}` still returns full `data` (detail unaffected) | — |
| — | internal path unbounded + keeps `data` (get-by-id / status / calendar-sync unaffected) | — |

Full meeting-api suite green (`uv run pytest` → 666 passed). 5 of the 6 new tests fail on base source (discriminating).

Closes #584
