### PR TITLE
fix(helm): set MEETING_API_URL on meeting-api deployment (#634)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -77,7 +77,7 @@
    "key": "MEETING_API_URL",
    "class": "defaulted",
    "default": "http://meeting-api:8080",
-   "description": "this service's own base URL as the spawned bot must reach it (lifecycle.v1 callback + transcript socket); compose/helm rely on the default service DNS name, lite overrides to localhost",
+   "description": "this service's own base URL as the spawned bot must reach it (lifecycle.v1 callback + transcript socket); compose relies on the default service DNS name, helm sets it explicitly to the release-qualified Service DNS, lite overrides to localhost",
    "targets": [
     "lite"
    ]

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -59,6 +59,8 @@ spec:
               value: {{ include "vexa.redisUrl" . | quote }}
             - name: RUNTIME_API_URL
               value: "http://{{ include "vexa.componentName" (list . "runtime") }}:{{ .Values.runtime.service.port }}"
+            - name: MEETING_API_URL
+              value: "http://{{ include "vexa.componentName" (list . "meeting-api") }}:{{ .Values.meetingApi.service.port }}"
             - name: INTERNAL_API_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -39,6 +39,7 @@ need 1 'serviceAccountName: vexa-vexa-runtime' "runtime SA bound"
 # must stay green, the env ref is optional:true).
 need 1 'key: CLAUDE_CODE_OAUTH_TOKEN' "agent-api CLAUDE_CODE_OAUTH_TOKEN secret ref"
 need 2 'key: ANTHROPIC_AUTH_TOKEN'    "ANTHROPIC_AUTH_TOKEN secret refs (agent-api + runtime)"
+need 2 'name: MEETING_API_URL' "MEETING_API_URL set on gateway AND meeting-api"
 
 # auth unset (values-test) → the chart Secret must NOT carry the key; auth set → it must.
 if printf '%s\n' "$RENDER" | grep -qE '^  CLAUDE_CODE_OAUTH_TOKEN:'; then

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -55,6 +55,15 @@ count) alongside `pipeline.consumer_lag`, and degrades to `503` once it exceeds
 `PIPELINE_PENDING_ALARM` (default `100`) — a stuck batch is a reportable state, not a silent
 stall.
 
+## In-cluster self-addressing
+
+Under Helm the meeting-api Service is release-qualified (`<release>-vexa-meeting-api`),
+not the bare `meeting-api` that the Compose stack uses. So the chart sets `MEETING_API_URL`
+explicitly on the meeting-api deployment to `http://<release>-vexa-meeting-api:8080` — the
+address a spawned bot calls back on for its lifecycle callback and recording upload. Left
+unset it would fall back to the compose-only default `http://meeting-api:8080`, which does
+not resolve in-cluster.
+
 ## Honest status
 
 The k8s backend **lifecycle and the workspace mount are implemented** (the workspace store


### PR DESCRIPTION
Closes #634.

The helm chart never set `MEETING_API_URL` on the meeting-api deployment, so bot-spawn fell back to the compose-only `http://meeting-api:8080` — which doesn't resolve under Helm (the Service is release-qualified, e.g. `vexa-vexa-meeting-api`). Every bot's lifecycle callback + recording upload targeted an unresolvable host.

- add the env entry to `deployment-meeting-api.yaml` (mirrors the gateway, via `vexa.componentName` + `meetingApi.service.port`)
- correct the false `config.v1.json` description (the default holds for compose only)
- `gate:helm` assertion `need 2 'name: MEETING_API_URL'` (gateway **and** meeting-api)

**Verified:** `helm template … | grep -c 'name: MEETING_API_URL'` = 2; `test_template.sh` + `helm lint` pass; meeting-api suite green.
