### PR TITLE
fix(gateway): preserve Content-Range/Accept-Ranges on proxied 206 (#633)

### DIFF
--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -286,7 +286,22 @@ def create_app(
             media_type = resp_headers.get("content-type", "application/json")
         except Exception:
             pass
-        return Response(content=resp.content, status_code=resp.status_code, media_type=media_type)
+        # Preserve the END-TO-END headers a media/range response needs. The buffered proxy
+        # otherwise returns a 206 with no Content-Range, which browsers treat as a protocol
+        # violation and abort — breaking recording playback (<audio>/<video> Range streaming).
+        # Length/encoding headers are intentionally NOT copied: Starlette recomputes
+        # Content-Length from the (already httpx-decoded) body; a stale one would corrupt it.
+        passthrough = {
+            k: resp_headers[k]
+            for k in ("content-range", "accept-ranges", "content-disposition")
+            if k in resp_headers
+        }
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            media_type=media_type,
+            headers=passthrough,
+        )
 
     def _meeting(path: str) -> str:
         return f"{meeting_api_url}{path}"

--- a/core/gateway/services/gateway/tests/conftest.py
+++ b/core/gateway/services/gateway/tests/conftest.py
@@ -64,10 +64,13 @@ class FakeDownstream:
 
     def __init__(self, status_code: int = 200, body: Optional[dict] = None,
                  content_type: str = "application/json",
-                 stream_chunks: Optional[list] = None):
+                 stream_chunks: Optional[list] = None,
+                 extra_headers: Optional[dict] = None):
         self.status_code = status_code
         self._body = body if body is not None else {"ok": True}
         self._content_type = content_type
+        # extra downstream response headers (e.g. Content-Range/Accept-Ranges on a 206)
+        self._extra_headers = extra_headers or {}
         # canned SSE frames for the streaming (agent chat) path
         self._stream_chunks = stream_chunks if stream_chunks is not None else [
             b'data: {"type":"token","text":"hi"}\n\n',
@@ -79,7 +82,7 @@ class FakeDownstream:
         self.last = {"method": method, "url": url, "headers": headers or {},
                      "params": params, "content": content}
         return _Resp(self.status_code, json.dumps(self._body).encode(),
-                     {"content-type": self._content_type})
+                     {"content-type": self._content_type, **self._extra_headers})
 
     async def stream(self, method, url, *, headers=None, params=None, content=None):
         self.last = {"method": method, "url": url, "headers": headers or {},

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -89,6 +89,30 @@ def test_authed_request_passes_body_and_status_verbatim():
     assert r.json() == {"id": 99, "platform": "google_meet"}
 
 
+def test_range_response_preserves_content_range_headers():
+    """A 206 from a recording /raw byte stream must keep its Content-Range/Accept-Ranges on the way
+    out. Without them the response is a malformed 206 and browsers abort <audio>/<video> playback
+    (the 0.12 recording-playback "Preparing audio…" hang). Regression guard for the buffered proxy
+    dropping end-to-end response headers."""
+    downstream = FakeDownstream(
+        status_code=206,
+        content_type="audio/webm",
+        extra_headers={
+            "content-range": "bytes 500-999/722448",
+            "accept-ranges": "bytes",
+        },
+    )
+    client, _ = _client(downstream=downstream)
+    r = client.get(
+        "/recordings/369743266808/media/827161823280/raw?type=audio",
+        headers={**AUTH, "range": "bytes=500-999"},
+    )
+    assert r.status_code == 206
+    assert r.headers["content-range"] == "bytes 500-999/722448"
+    assert r.headers["accept-ranges"] == "bytes"
+    assert r.headers["content-type"].startswith("audio/webm")
+
+
 def test_rate_limit_returns_429_past_the_per_user_cap():
     """WS-6: with a per-user limiter injected, requests up to the bucket pass (verbatim), the next is
     throttled with 429 + Retry-After — closing the unlimited-requests-on-a-valid-key DoS gap."""

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -267,7 +267,9 @@ curl -H "X-API-Key: $API_KEY" "$API_BASE/recordings/42/master?type=audio"
 ```
 
 The master metadata returns a `raw_url` pointing at the byte stream
-`GET /recordings/{recording_id}/media/{media_file_id}/raw`, which the player loads.
+`GET /recordings/{recording_id}/media/{media_file_id}/raw`, which the player loads. The `/raw` endpoint
+honours a `Range` header and returns `206 Partial Content` with `Content-Range` and `Accept-Ranges` —
+these are preserved **through the gateway**, not only on a direct hit, so browser playback and seeking work.
 
 ---
 

--- a/docs/docs/how-to/recordings.mdx
+++ b/docs/docs/how-to/recordings.mdx
@@ -5,8 +5,9 @@ description: "List recordings and stream the audio — from your own object stor
 
 <Note>
 Recording retrieval is **API-only today** — the terminal has no built-in player yet. The endpoints below
-are live and covered by service tests; the full live loop (in-meeting capture → object storage →
-playback) has not been validated end-to-end. See the [capability truth table](/roadmap/status#capability-truth-table).
+are live and covered by service tests. Browser playback and seeking work **through the gateway**: a `Range`
+request returns a `206 Partial Content` with its `Content-Range` and `Accept-Ranges` headers intact.
+See the [capability truth table](/roadmap/status#capability-truth-table).
 </Note>
 
 Alongside the diarized transcript, each meeting's **audio recording** is uploaded to object storage — on a
@@ -40,6 +41,20 @@ The response carries a `raw_url` of the form
 ```bash
 curl -H "X-API-Key: $API_KEY" \
   "$API_BASE/recordings/42/media/<media_file_id>/raw" -o meeting-42.audio
+```
+
+### Range requests (playback and seek)
+
+The `/raw` endpoint honours HTTP `Range` — a partial request returns `206 Partial Content` carrying
+`Content-Range` and `Accept-Ranges: bytes`, **preserved through the gateway** front door. This is what
+lets a browser `<audio>`/`<video>` element stream and seek the recording instead of aborting the fetch:
+
+```bash
+curl -I -H "X-API-Key: $API_KEY" -H "Range: bytes=0-1023" \
+  "$API_BASE/recordings/42/media/<media_file_id>/raw?type=audio"
+# HTTP/1.1 206 Partial Content
+# Accept-Ranges: bytes
+# Content-Range: bytes 0-1023/<total>
 ```
 
 ## Where it's stored


### PR DESCRIPTION
Closes #633.

The gateway's buffered proxy rebuilt responses from body+status+media_type only, dropping `Content-Range`/`Accept-Ranges` on a proxied **206** — a protocol violation browsers abort, so recording seek/playback broke through the front door. (Same fix already running in our hosted fork.)

- pass through `content-range`/`accept-ranges`/`content-disposition`; do **not** copy `content-length`/`content-encoding` (Starlette recomputes length)
- `FakeDownstream` gains `extra_headers`; new red→green 206-passthrough test in `test_proxy.py`

**Verified:** `uv run pytest tests/test_proxy.py` → 85 passed; the A1 discriminating row is covered. (A2/A3 are negative-controls; live seek is the human bar.)
