### PR TITLE
fix(terminal): cap and prune login-minted API tokens (#638)

### DIFF
--- a/clients/terminal/README.md
+++ b/clients/terminal/README.md
@@ -55,6 +55,13 @@ routes call admin-api with the server's `VEXA_ADMIN_API_KEY` (admin tier, like t
 scope every operation to the user resolved from the httpOnly auth cookies — a `user_id` from the
 client is never accepted. The minted token value is returned once, at creation.
 
+Separately, every OAuth **or** email **login** mints its own API token named `terminal-login`
+(distinct from the self-serve tokens above). These login tokens are **capped per user** — after each
+sign-in the terminal prunes a user's oldest `terminal-login` tokens beyond `VEXA_TERMINAL_LOGIN_TOKEN_CAP`
+(default `3`), so repeated sign-ins (including an OAuth redirect loop) leave a bounded set of live
+tokens rather than one new token per sign-in. The prune only ever touches `terminal-login`-named
+tokens; **self-serve tokens you created above are never pruned by login.**
+
 ## Isolated evaluation
 
 No test suite yet (`tests/` absent). Standalone build + typecheck:

--- a/clients/terminal/src/app/api/auth/__tests__/findOrCreateUserToken.test.ts
+++ b/clients/terminal/src/app/api/auth/__tests__/findOrCreateUserToken.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { findOrCreateUserToken } from "../adminApi";
+
+/**
+ * D-A2 fixture — a deterministic in-memory fake admin-api behind `fetch`.
+ *
+ * (a) deterministic producer: holds a `userId -> tokens[]` map, serves GET /tokens from it,
+ *     appends on POST .../tokens, removes on DELETE /tokens/{id}, and records every call.
+ * (b) captured live output: response shapes are the real admin-api ones quoted from
+ *     core/identity/services/admin-api/src/admin_api/app/main.py —
+ *     TokenResponse {id, token, user_id, scopes, name} on mint, TokenInfo[] (NO `token`) on list,
+ *     204 on delete.
+ * (c) hand-authored edges are the individual `it()` cases below.
+ */
+
+interface FakeTokenInfo {
+  id: number;
+  user_id: number;
+  scopes: string[];
+  name: string | null;
+  created_at: string;
+}
+
+interface Recorded {
+  method: string;
+  path: string;
+}
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+class FakeAdminApi {
+  users = new Map<string, { id: number; email: string }>();
+  tokens = new Map<number, FakeTokenInfo[]>();
+  calls: Recorded[] = [];
+  private nextUserId = 100;
+  private nextTokenId = 1000;
+  private clock = 0;
+  // when set to a token id, the first DELETE of that id 404s (concurrent-delete edge)
+  revoke404For: number | null = null;
+
+  seedUser(email: string): { id: number; email: string } {
+    const u = { id: this.nextUserId++, email };
+    this.users.set(email.toLowerCase(), u);
+    this.tokens.set(u.id, []);
+    return u;
+  }
+
+  seedToken(userId: number, name: string | null): FakeTokenInfo {
+    const tok: FakeTokenInfo = {
+      id: this.nextTokenId++,
+      user_id: userId,
+      scopes: ["bot", "tx", "browser"],
+      name,
+      created_at: new Date(Date.UTC(2026, 0, 1, 0, 0, this.clock++)).toISOString(),
+    };
+    this.tokens.get(userId)!.push(tok);
+    return tok;
+  }
+
+  liveTokens(userId: number): FakeTokenInfo[] {
+    return this.tokens.get(userId) ?? [];
+  }
+
+  countRevokes(): number {
+    return this.calls.filter((c) => c.method === "DELETE").length;
+  }
+
+  fetch = async (url: string, init?: RequestInit): Promise<Response> => {
+    const u = new URL(url);
+    const method = (init?.method || "GET").toUpperCase();
+    const path = u.pathname;
+    this.calls.push({ method, path });
+
+    // GET /admin/users/email/{email}
+    let m = path.match(/^\/admin\/users\/email\/(.+)$/);
+    if (m && method === "GET") {
+      const email = decodeURIComponent(m[1]).toLowerCase();
+      const user = this.users.get(email);
+      return user ? jsonRes(user) : new Response("", { status: 404 });
+    }
+
+    // POST /admin/users
+    if (path === "/admin/users" && method === "POST") {
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const user = this.seedUser(body.email);
+      return jsonRes(user);
+    }
+
+    // POST /admin/users/{id}/tokens  (mint)
+    m = path.match(/^\/admin\/users\/([^/]+)\/tokens$/);
+    if (m && method === "POST") {
+      const userId = Number(m[1]);
+      const name = u.searchParams.get("name");
+      const scopes = (u.searchParams.get("scopes") || "").split(",").filter(Boolean);
+      const tok = this.seedToken(userId, name);
+      tok.scopes = scopes.length ? scopes : tok.scopes;
+      // TokenResponse — the ONLY place the secret crosses
+      return jsonRes({ ...tok, token: `secret-${tok.id}` });
+    }
+
+    // GET /admin/users/{id}/tokens  (list — metadata only, NEVER the secret)
+    if (m && method === "GET") {
+      const userId = Number(m[1]);
+      const list = this.liveTokens(userId).map(({ id, user_id, scopes, name, created_at }) => ({
+        id,
+        user_id,
+        scopes,
+        name,
+        created_at,
+      }));
+      return jsonRes(list);
+    }
+
+    // DELETE /admin/tokens/{id}
+    m = path.match(/^\/admin\/tokens\/([^/]+)$/);
+    if (m && method === "DELETE") {
+      const tokenId = Number(m[1]);
+      if (this.revoke404For === tokenId) {
+        this.revoke404For = null;
+        return new Response("", { status: 404 });
+      }
+      for (const [uid, list] of this.tokens) {
+        const idx = list.findIndex((t) => t.id === tokenId);
+        if (idx >= 0) {
+          list.splice(idx, 1);
+          this.tokens.set(uid, list);
+          break;
+        }
+      }
+      return new Response("", { status: 204 });
+    }
+
+    return new Response("not found", { status: 404 });
+  };
+}
+
+let fake: FakeAdminApi;
+
+beforeEach(() => {
+  fake = new FakeAdminApi();
+  vi.stubGlobal("fetch", vi.fn(fake.fetch));
+  process.env.VEXA_ADMIN_API_URL = "http://admin.test";
+  process.env.VEXA_ADMIN_API_KEY = "test-admin-key";
+  // allowlist configured → the bootstrap-admin internal call short-circuits (no /internal hit)
+  process.env.VEXA_ADMIN_EMAILS = "owner@vexa.ai";
+  process.env.VEXA_TERMINAL_LOGIN_TOKEN_CAP = "3";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.VEXA_ADMIN_API_URL;
+  delete process.env.VEXA_ADMIN_API_KEY;
+  delete process.env.VEXA_ADMIN_EMAILS;
+  delete process.env.VEXA_TERMINAL_LOGIN_TOKEN_CAP;
+});
+
+describe("findOrCreateUserToken — bounded login-token minting (#638)", () => {
+  it("A1: K=6 sign-ins for one user stay bounded at cap N=3 (oldest login tokens pruned)", async () => {
+    const user = fake.seedUser("loop@vexa.ai");
+
+    for (let i = 0; i < 6; i++) {
+      const r = await findOrCreateUserToken("loop@vexa.ai");
+      expect(r.ok).toBe(true);
+    }
+
+    const live = fake.liveTokens(user.id);
+    // THE VALUE: final live-token count is bounded to the cap, not one-per-sign-in.
+    expect(live.length).toBe(3);
+    // all survivors are the login-named tokens (nothing else existed to prune)
+    expect(live.every((t) => t.name === "terminal-login")).toBe(true);
+
+    // recorder shows exactly 3 revokes (calls 4,5,6 each prune one overflow token)
+    expect(fake.countRevokes()).toBe(3);
+    // the survivors are the 3 NEWEST login tokens (oldest pruned first)
+    const surviving = live.map((t) => t.id).sort((a, b) => a - b);
+    expect(surviving).toEqual([1003, 1004, 1005]);
+  });
+
+  it("A2: N-1 login tokens + one self-serve token → mint once, revoke 0, self-serve untouched", async () => {
+    const user = fake.seedUser("dev@vexa.ai");
+    fake.seedToken(user.id, "terminal-login"); // id 1000
+    fake.seedToken(user.id, "terminal-login"); // id 1001
+    const selfServe = fake.seedToken(user.id, "my-ci-key"); // id 1002
+
+    const r = await findOrCreateUserToken("dev@vexa.ai");
+    expect(r.ok).toBe(true);
+
+    // exactly one mint this sign-in
+    const mintCalls = fake.calls.filter((c) => c.method === "POST" && /\/tokens$/.test(c.path));
+    expect(mintCalls.length).toBe(1);
+
+    // 2 existing login + 1 new = 3 = cap → nothing to prune
+    expect(fake.countRevokes()).toBe(0);
+
+    const live = fake.liveTokens(user.id);
+    // self-serve token still present and untouched
+    const stillThere = live.find((t) => t.id === selfServe.id);
+    expect(stillThere).toBeDefined();
+    expect(stillThere!.name).toBe("my-ci-key");
+    // 3 login tokens + 1 self-serve = 4 live
+    expect(live.length).toBe(4);
+    expect(live.filter((t) => t.name === "terminal-login").length).toBe(3);
+  });
+
+  it("A2b: a self-serve token is NEVER pruned even when login tokens are well over cap", async () => {
+    const user = fake.seedUser("busy@vexa.ai");
+    for (let i = 0; i < 5; i++) fake.seedToken(user.id, "terminal-login"); // ids 1000..1004
+    const selfServe = fake.seedToken(user.id, "my-ci-key"); // id 1005
+
+    const r = await findOrCreateUserToken("busy@vexa.ai");
+    expect(r.ok).toBe(true);
+
+    const live = fake.liveTokens(user.id);
+    // 5 existing + 1 new = 6 login tokens, cap 3 → 3 pruned
+    expect(fake.countRevokes()).toBe(3);
+    expect(live.filter((t) => t.name === "terminal-login").length).toBe(3);
+    // self-serve survives untouched regardless of overflow
+    expect(live.find((t) => t.id === selfServe.id)?.name).toBe("my-ci-key");
+  });
+
+  it("edge: a 404 mid-prune is swallowed and the sign-in still succeeds", async () => {
+    const user = fake.seedUser("racy@vexa.ai");
+    for (let i = 0; i < 4; i++) fake.seedToken(user.id, "terminal-login"); // ids 1000..1003
+    // the oldest overflow token 404s when revoked (deleted concurrently)
+    fake.revoke404For = 1000;
+
+    const r = await findOrCreateUserToken("racy@vexa.ai");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.token).toMatch(/^secret-/);
+
+    // 5 login tokens, cap 3 → 2 overflow revoke attempts; one 404s but is swallowed
+    expect(fake.countRevokes()).toBe(2);
+  });
+
+  it("edge: a fresh user with zero tokens mints exactly once and prunes nothing", async () => {
+    const r = await findOrCreateUserToken("new@vexa.ai");
+    expect(r.ok).toBe(true);
+    expect(fake.countRevokes()).toBe(0);
+
+    const created = fake.users.get("new@vexa.ai");
+    expect(created).toBeDefined();
+    expect(fake.liveTokens(created!.id).length).toBe(1);
+  });
+
+  it("mints with the terminal-login name and bot,tx,browser scopes", async () => {
+    await findOrCreateUserToken("scoped@vexa.ai");
+    const created = fake.users.get("scoped@vexa.ai")!;
+    const tok = fake.liveTokens(created.id)[0];
+    expect(tok.name).toBe("terminal-login");
+    expect(tok.scopes).toEqual(["bot", "tx", "browser"]);
+  });
+});

--- a/clients/terminal/src/app/api/auth/adminApi.ts
+++ b/clients/terminal/src/app/api/auth/adminApi.ts
@@ -238,6 +238,57 @@ async function provisionUserWorkspace(token: string): Promise<void> {
   }
 }
 
+/** The stable marker on login-minted tokens — this is the ONLY set the login cap prunes.
+ *  Self-serve tokens (minted via /api/tokens with a user-chosen name) carry a different name
+ *  and are NEVER touched by the prune below. */
+export const TERMINAL_LOGIN_TOKEN_NAME = "terminal-login";
+
+/** How many `terminal-login` tokens a single user may keep. A cap, not a purge: a user's few
+ *  genuine devices survive while a sign-in loop cannot exceed N. Configurable, default 3. */
+export function terminalLoginTokenCap(): number {
+  const raw = parseInt(process.env.VEXA_TERMINAL_LOGIN_TOKEN_CAP || "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 3;
+}
+
+/** BEST-EFFORT: after a login mint, bound the user's `terminal-login` tokens to the newest N.
+ *  Lists the user's tokens, keeps only those named `terminal-login`, sorts oldest→newest, and
+ *  revokes everything beyond the newest cap. NEVER touches differently-named (self-serve) tokens.
+ *  Every failure (list error, a 404 on a concurrently-deleted token) is logged and swallowed — a
+ *  prune problem must never turn a successful sign-in into a failure (mirrors bootstrapAdminClaim /
+ *  provisionUserWorkspace above). */
+async function pruneLoginTokens(userId: string | number): Promise<void> {
+  try {
+    const listed = await listUserTokens(userId);
+    if (!listed.ok || !listed.data) {
+      console.warn(`[terminal-auth] login-token prune skipped (list failed): ${listed.error}`);
+      return;
+    }
+    const cap = terminalLoginTokenCap();
+    const loginTokens = listed.data
+      .filter((t) => t.name === TERMINAL_LOGIN_TOKEN_NAME)
+      // oldest first: prefer created_at, fall back to numeric id
+      .sort((a, b) => {
+        const ta = a.created_at ? Date.parse(a.created_at) : NaN;
+        const tb = b.created_at ? Date.parse(b.created_at) : NaN;
+        if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) return ta - tb;
+        return Number(a.id) - Number(b.id);
+      });
+
+    const overflow = loginTokens.slice(0, Math.max(0, loginTokens.length - cap));
+    for (const tok of overflow) {
+      const revoked = await revokeToken(tok.id);
+      if (!revoked.ok) {
+        console.warn(`[terminal-auth] login-token prune: revoke of token ${tok.id} failed (swallowed): ${revoked.error}`);
+      }
+    }
+    if (overflow.length) {
+      console.info(`[terminal-auth] login-token prune: user ${userId} over cap ${cap}, revoked ${overflow.length} oldest login token(s)`);
+    }
+  } catch (err) {
+    console.warn("[terminal-auth] login-token prune failed (sign-in continues):", (err as Error).message);
+  }
+}
+
 /** Find the user by email, creating them if they don't exist, then mint an APIToken.
  *  Returns the user + token, or an error with an HTTP-ish status for the caller to surface. */
 export async function findOrCreateUserToken(
@@ -260,10 +311,15 @@ export async function findOrCreateUserToken(
     return { ok: false, status: found.status || 503, error: found.error || "Failed to look up user" };
   }
 
-  const minted = await createUserToken(user.id);
+  // Mint the login token with a stable `terminal-login` name so it is distinguishable from
+  // user-created self-serve tokens and can be bounded (find-or-create used to mint unconditionally
+  // with no name and no cap → one live token per sign-in, forever).
+  const minted = await mintUserToken(user.id, { scopes: ["bot", "tx", "browser"], name: TERMINAL_LOGIN_TOKEN_NAME });
   if (!minted.ok || !minted.data?.token) {
     return { ok: false, status: minted.status || 500, error: minted.error || "Failed to mint API token" };
   }
+  // Bound the user's login tokens to the newest N (best-effort; never blocks sign-in).
+  await pruneLoginTokens(user.id);
   // First-run bootstrap: on a fresh instance the FIRST successful sign-in claims the admin role
   // (no-op everywhere else — admin exists, or an allowlist runs the instance). Covers both the
   // direct email login and the OAuth signIn callback, which both land here.

--- a/docs/docs/authentication.mdx
+++ b/docs/docs/authentication.mdx
@@ -78,6 +78,20 @@ curl -X DELETE "$ADMIN/admin/tokens/7" -H "X-Admin-API-Key: $ADMIN_TOKEN"   # �
 
 Set an expiry at mint time with `expires_in=<seconds>`; expired keys are rejected automatically.
 
+### Login-minted tokens (`terminal-login`)
+
+When a user signs in through the terminal (OAuth or email login), the terminal mints an API token
+named **`terminal-login`** to populate the auth cookie. These are **bounded per user**: after each
+sign-in the terminal keeps only the newest `VEXA_TERMINAL_LOGIN_TOKEN_CAP` (default `3`) and revokes
+the older ones. So when you audit a user's tokens —
+
+```bash
+curl "$ADMIN/admin/users/1/tokens" -H "X-Admin-API-Key: $ADMIN_TOKEN"
+```
+
+— the `terminal-login`-named entries are login sessions (capped, not unbounded), while any
+differently-named entries are self-serve keys the user minted and are never pruned by login.
+
 ## What can go wrong
 
 | Status | `detail` | Meaning |


### PR DESCRIPTION
Closes #638.

`findOrCreateUserToken` minted a fresh API token on **every** sign-in and never revoked old ones (the name lied — it never "finds"). Under an auth loop this floods an account with live tokens (hosted precedent: 1,888 phantom tokens / 101 users in 3 days).

Reusing a live token is impossible — the list endpoint never returns a token's secret (only mint does) — so this **caps + prunes**: login tokens are named `terminal-login`, capped at the newest N (`VEXA_TERMINAL_LOGIN_TOKEN_CAP`, default 3), older ones revoked; self-serve tokens (any other name) are never touched. Client-only; the affordances already exist.

**Verified:** `npm test` (vitest) → 363 passed incl. the new A1/A2 cap+prune + self-serve-guard tests.
