### PR TITLE
fix(meeting-api): single-flight background sweeps across replicas (#637)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -12,11 +12,15 @@ control-plane background loops alongside the HTTP app via the FastAPI lifespan:
     write) and drains the copilot's ``proc:meeting:{id}`` notes into ``meeting.data`` JSONB.
   * **webhook retry-drain** — one ``drain_retry_queue`` sweep per interval over the redis retry
     queue (failed ``meeting.status_change`` deliveries are retried with backoff).
-  * **scheduler tick** — fires due ``schedule.v1`` jobs (this also drives the join-retry re-spawns
-    that ``JoinRetryController`` schedules) on the tick interval.
 
 Each loop is a single-tick function the eval drives explicitly; here the entrypoint wraps it in the
 ``while True: tick; sleep`` poll the deployment uses. uvicorn-target: ``uvicorn meeting_api.__main__:app``.
+
+#637 — at ``meetingApi.replicaCount>1`` every replica starts these same loops, so each live tick body
+is wrapped in a per-loop Postgres advisory lock (``sweeps.single_flight``): the real work runs once per
+interval, not once per replica. ``segment-consumer`` is intentionally left unguarded (Redis competing
+consumer). The former ``scheduler-tick`` loop was dead code (``app.state.scheduler`` was never wired —
+the ``Scheduler`` in ``scheduling/`` is an eval-only engine) and has been removed.
 """
 from __future__ import annotations
 
@@ -182,7 +186,10 @@ def build_production_app():
         calendar_sync_status=_calendar_sync_status,
     )
 
-    _attach_background_loops(app, transcript_store, segment_bus, redis_client, meeting_repo, runtime_client)
+    _attach_background_loops(
+        app, transcript_store, segment_bus, redis_client, meeting_repo, runtime_client,
+        session_factory=session_factory,
+    )
     return app
 
 
@@ -195,9 +202,29 @@ def _minio_endpoint_url() -> str:
     return f"{scheme}://{endpoint}"
 
 
-def _attach_background_loops(app, transcript_store, segment_bus, redis_client, meeting_repo=None, runtime=None) -> None:
-    """Register the FastAPI lifespan that starts/stops the control-plane poll loops."""
+def _attach_background_loops(
+    app, transcript_store, segment_bus, redis_client, meeting_repo=None, runtime=None,
+    session_factory=None,
+) -> None:
+    """Register the FastAPI lifespan that starts/stops the control-plane poll loops.
+
+    #637 — single-flight sweeps: at ``replicaCount>1`` every replica runs these same loops, so each
+    live tick body is wrapped in a per-loop Postgres advisory lock (``_guarded``) — the real work runs
+    once per interval, not once per replica. With no ``session_factory`` (Lite / a store without PG)
+    the guard degrades to run-the-tick, so single-replica behavior is unchanged. ``segment-consumer``
+    is DELIBERATELY left unguarded — it is a Redis competing consumer (``XREADGROUP … ">"``) whose
+    single-delivery is already exact, and guarding it would needlessly serialize the replicas' reads.
+    """
     from .collector.ingest import RECLAIM_MIN_IDLE_MS, consume_segments, reclaim_segments
+    from .sweeps.single_flight import PgAdvisoryLock, run_single_flight, sweep_lock_key
+
+    # One shared advisory-lock backend across the guarded loops (each keyed by its own loop name).
+    # None when there is no Postgres session factory → the guard runs every tick (Lite single-replica).
+    sweep_lock = PgAdvisoryLock(session_factory) if session_factory is not None else None
+
+    async def _guarded(loop_name: str, body):
+        """Run ``body`` (a zero-arg coroutine fn) at most once per interval across replicas."""
+        return await run_single_flight(sweep_lock, sweep_lock_key(loop_name), body)
 
     seg_interval = float(os.getenv("SEGMENT_CONSUMER_INTERVAL", "0.5"))
     # #636: orphan-reclaim cadence — fold a bounded XAUTOCLAIM into the consumer loop every N ticks
@@ -206,7 +233,6 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
     # (RECLAIM_MIN_IDLE_MS) ensures a live peer's in-flight batch is never stolen.
     seg_reclaim_every = max(1, int(os.getenv("SEGMENT_RECLAIM_EVERY_N_TICKS", "120")))
     webhook_interval = float(os.getenv("WEBHOOK_DRAIN_INTERVAL", "5"))
-    scheduler_interval = float(os.getenv("SCHEDULER_TICK_INTERVAL", "1"))
     # The db-writer cadence — the parent's BACKGROUND_TASK_INTERVAL (10s); either env name works.
     db_writer_interval = float(
         os.getenv("DB_WRITER_INTERVAL_S", os.getenv("BACKGROUND_TASK_INTERVAL", "10"))
@@ -284,9 +310,13 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
 
         if not hasattr(transcript_store, "upsert_segments"):
             return  # a store without a durable sink (bare fake) — nothing to flush into
+
+        async def _tick():
+            await db_writer_tick(redis_client, transcript_store)
+
         while True:
             try:
-                await db_writer_tick(redis_client, transcript_store)
+                await _guarded("db-writer", _tick)  # #637: one flush per interval across replicas
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -308,29 +338,17 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
             async with httpx.AsyncClient(timeout=10.0, transport=build_pinned_transport()) as client:
                 return await client.post(url, content=body, headers=headers)
 
+        async def _tick():
+            await drain_retry_queue(redis_client, _transport)
+
         while True:
             try:
-                await drain_retry_queue(redis_client, _transport)
+                await _guarded("webhook-drain", _tick)  # #637: one drain sweep per interval
             except asyncio.CancelledError:
                 raise
             except Exception:
                 log.exception("webhook retry-drain tick failed")
             await asyncio.sleep(webhook_interval)
-
-    async def _scheduler_tick_loop() -> None:
-        # The scheduler fires due schedule.v1 jobs — including the join-retry re-spawns that
-        # JoinRetryController enqueues. The Scheduler instance lives on app.state when wired.
-        scheduler = getattr(app.state, "scheduler", None)
-        if scheduler is None:
-            return
-        while True:
-            try:
-                scheduler.tick()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                log.exception("scheduler tick failed")
-            await asyncio.sleep(scheduler_interval)
 
     async def _stop_reconcile_loop() -> None:
         # Complete meetings stuck in `stopping` past the grace window AND kill any orphan workload (CC6 /
@@ -364,17 +382,21 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
         # The general sweep (any stale non-terminal status whose bot is gone) subsumes the stale-
         # stopping sweep, but we keep the latter as the guaranteed orphan-kill backstop for `stopping`.
         has_general = hasattr(meeting_repo, "list_stale_nonterminal")
+
+        async def _tick():
+            if has_general:
+                await reconcile_stale_nonterminal_sweep(
+                    meeting_repo, runtime, _post_lifecycle,
+                    stop_grace=stop_grace, active_grace=active_grace, log=log,
+                    untracked_grace=untracked_grace,
+                )
+            await reconcile_stale_stopping_sweep(
+                meeting_repo, runtime, _post_lifecycle, stop_grace=stop_grace, log=log,
+            )
+
         while True:
             try:
-                if has_general:
-                    await reconcile_stale_nonterminal_sweep(
-                        meeting_repo, runtime, _post_lifecycle,
-                        stop_grace=stop_grace, active_grace=active_grace, log=log,
-                        untracked_grace=untracked_grace,
-                    )
-                await reconcile_stale_stopping_sweep(
-                    meeting_repo, runtime, _post_lifecycle, stop_grace=stop_grace, log=log,
-                )
+                await _guarded("stop-reconcile", _tick)  # #637: one reconcile pass per interval
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -427,17 +449,22 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
             except Exception:
                 pass  # best-effort, like the collector's publish
 
+        async def _tick():
+            await auto_join_tick(
+                meeting_repo, runtime,
+                fetch_bot_context=fetch_bot_context,
+                publish_status=publish_status,
+                lead_s=auto_join_lead, grace_s=auto_join_grace,
+                retry_backoff_s=auto_join_backoff,
+                token_secret=os.getenv("ADMIN_TOKEN") or None,
+                redis_url=os.getenv("REDIS_URL"),
+            )
+
         while True:
             try:
-                await auto_join_tick(
-                    meeting_repo, runtime,
-                    fetch_bot_context=fetch_bot_context,
-                    publish_status=publish_status,
-                    lead_s=auto_join_lead, grace_s=auto_join_grace,
-                    retry_backoff_s=auto_join_backoff,
-                    token_secret=os.getenv("ADMIN_TOKEN") or None,
-                    redis_url=os.getenv("REDIS_URL"),
-                )
+                # #637: one sweep per interval — the per-user spawn stays single-flighted by its own
+                # xact lock, but this also single-flights the doubled admin-api bot-context fetch.
+                await _guarded("auto-join", _tick)
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -467,16 +494,22 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
             return
         from .calendar_sync import fetch_configs, run_user_sync, store_stamp
 
+        async def _tick():
+            configs = await fetch_configs(admin_api_url, internal_secret)
+            for cfg in configs or []:
+                try:  # one bad feed never stalls the sweep
+                    stamp = await run_user_sync(transcript_store, cfg, publish=_cal_publish)
+                except Exception:
+                    log.exception("calendar sync failed for user %s", cfg.get("user_id"))
+                    continue
+                await store_stamp(redis_client, cfg["user_id"], stamp)
+
         while True:
             try:
-                configs = await fetch_configs(admin_api_url, internal_secret)
-                for cfg in configs or []:
-                    try:  # one bad feed never stalls the sweep
-                        stamp = await run_user_sync(transcript_store, cfg, publish=_cal_publish)
-                    except Exception:
-                        log.exception("calendar sync failed for user %s", cfg.get("user_id"))
-                        continue
-                    await store_stamp(redis_client, cfg["user_id"], stamp)
+                # #637 (load-bearing): the external ICS/Google fetch has no other dedup, so at
+                # replicaCount>1 it doubled outbound provider requests every interval. Single-flight
+                # it — the replica that loses the advisory lock skips the whole fetch this tick.
+                await _guarded("calendar-sync", _tick)
             except Exception:
                 log.exception("calendar sync tick failed")
             await asyncio.sleep(calendar_interval)
@@ -487,7 +520,6 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
             asyncio.create_task(_segment_consumer_loop(), name="segment-consumer"),
             asyncio.create_task(_db_writer_loop(), name="db-writer"),
             asyncio.create_task(_webhook_drain_loop(), name="webhook-drain"),
-            asyncio.create_task(_scheduler_tick_loop(), name="scheduler-tick"),
             asyncio.create_task(_stop_reconcile_loop(), name="stop-reconcile"),
             asyncio.create_task(_auto_join_loop(), name="auto-join"),
             asyncio.create_task(_calendar_sync_loop(), name="calendar-sync"),

--- a/core/meetings/services/meeting-api/src/meeting_api/sweeps/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/sweeps/README.md
@@ -1,0 +1,15 @@
+# meeting_api.sweeps — single-flight guard for background sweeps (#637)
+
+At `meetingApi.replicaCount > 1` every meeting-api replica starts the same background loops, so each
+sweep's real work runs once **per replica** instead of once per interval. This package makes that
+safety structural rather than accidental.
+
+`single_flight` wraps a sweep tick in a Postgres **session-level advisory lock** keyed by loop name
+(a fixed `classid` disjoint from the per-user `pg_advisory_xact_lock` keyspace): the replica that
+acquires the lock runs the tick, the others skip it that interval. A replica that dies mid-tick drops
+its session lock on disconnect, so the next interval is picked up elsewhere — no leader-election infra.
+
+The guard **degrades to run-the-tick** when no DB session factory is available (single-replica / Lite),
+so single-replica behaviour is unchanged. The `segment-consumer` loop is deliberately **not** wrapped —
+it is already single-delivery via the Redis consumer group, and wrapping it would serialize the
+replicas' stream reads.

--- a/core/meetings/services/meeting-api/src/meeting_api/sweeps/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/sweeps/__init__.py
@@ -1,0 +1,8 @@
+"""Cross-replica sweep coordination for the lifespan background loops.
+
+At ``meetingApi.replicaCount>1`` (the Helm/hosted default) every meeting-api process starts the
+SAME set of background loops. Without a guard each sweep's real work runs once *per replica* instead
+of once *per interval* — most sharply the ``calendar-sync`` external ICS fetch, which re-hits every
+user's third-party calendar provider on each replica. ``single_flight`` makes that structural: a
+per-loop Postgres advisory lock elects one runner per tick.
+"""

--- a/core/meetings/services/meeting-api/src/meeting_api/sweeps/single_flight.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/sweeps/single_flight.py
@@ -1,0 +1,124 @@
+"""Single-flight sweep guard (#637) — one runner per interval across meeting-api replicas.
+
+At ``replicaCount>1`` every replica's FastAPI lifespan starts the same background loops with no
+leader election. ``run_single_flight`` wraps a live tick body in a Postgres **session-level**
+advisory lock so exactly one replica runs the body each interval; the losers skip and sleep. The
+load-bearing case is ``calendar-sync`` — its external ICS/Google fetch has no other dedup, so at two
+replicas it doubled the outbound requests to third-party calendar providers every interval.
+
+Design choices (see the issue's "Along the way" forks):
+
+* **Disjoint keyspace.** The per-user spawn/plan locks use the single-arg
+  ``pg_advisory_xact_lock(:user_id)`` form on user-id ints (``bot_spawn/adapters.py``,
+  ``collector/adapters.py``). The sweep locks use the **two-arg** ``pg_try_advisory_lock(classid,
+  objid)`` form with a fixed ``SWEEP_LOCK_CLASSID`` namespace, so a ``crc32(loop_name)`` objid can
+  never collide with a user-id single-arg key (Postgres treats the one-arg and two-arg advisory-lock
+  spaces as disjoint).
+* **Session-level, explicitly released.** ``pg_try_advisory_lock`` (not ``_xact_``) so the lock
+  spans the whole tick and is released in a ``finally`` — and a replica that dies mid-tick drops the
+  lock when its connection closes, so the other replica acquires it on the next tick (no starvation).
+* **Degrade to run-the-tick.** When there is no DB session factory (Lite single-replica, or a store
+  without Postgres) the guard runs the body unconditionally — it never fails closed into skipping all
+  work. On a single replica the lock is always free, so every tick runs: single-replica behavior is
+  unchanged.
+"""
+from __future__ import annotations
+
+import binascii
+import logging
+from typing import Awaitable, Callable, Optional, Protocol
+
+log = logging.getLogger("meeting_api.sweeps.single_flight")
+
+# Fixed "sweeps" namespace for the two-arg advisory-lock form. Any stable int works; the point is
+# that pairing it as the classid keeps every sweep key disjoint from the single-arg per-user locks.
+SWEEP_LOCK_CLASSID = 0x53575000  # "SWP\0"
+
+
+def sweep_lock_key(loop_name: str) -> int:
+    """Stable per-loop objid = ``crc32(loop_name)`` (a small fixed set of name-hashes)."""
+    return binascii.crc32(loop_name.encode("utf-8"))
+
+
+class AdvisoryLock(Protocol):
+    """The lock backend the guard drives. Production = :class:`PgAdvisoryLock`; tests inject a fake."""
+
+    async def try_lock(self, key: int) -> bool: ...
+
+    async def unlock(self, key: int) -> None: ...
+
+
+async def run_single_flight(
+    lock: Optional[AdvisoryLock],
+    key: int,
+    body: Callable[[], Awaitable[None]],
+) -> bool:
+    """Run ``body()`` at most once per interval across replicas; return whether it ran.
+
+    * ``lock is None`` (no PG / Lite) → run ``body`` unconditionally and return ``True``.
+    * lock acquired → run ``body``, release in ``finally``, return ``True``.
+    * lock NOT acquired (another replica holds it this tick) → skip ``body``, return ``False``.
+    """
+    if lock is None:
+        await body()
+        return True
+    if not await lock.try_lock(key):
+        return False
+    try:
+        await body()
+        return True
+    finally:
+        await lock.unlock(key)
+
+
+class PgAdvisoryLock:
+    """``AdvisoryLock`` over a SQLAlchemy-async ``session_factory``.
+
+    ``try_lock`` opens a session, takes ``pg_try_advisory_lock(SWEEP_LOCK_CLASSID, key)`` on that
+    connection, and — if acquired — HOLDS the session open so the session-scoped lock spans the tick.
+    ``unlock`` releases the lock and closes the held session. ``unlock`` is best-effort: on shutdown
+    the connection may already be closing, and a session-level lock releases on disconnect anyway.
+    """
+
+    def __init__(self, session_factory):
+        self._session_factory = session_factory
+        self._held: dict[int, object] = {}  # key -> open AsyncSession holding the lock
+
+    async def try_lock(self, key: int) -> bool:
+        from sqlalchemy import bindparam, text
+
+        db = self._session_factory()
+        await db.__aenter__()
+        try:
+            got = (
+                await db.execute(
+                    text("SELECT pg_try_advisory_lock(:cls, :obj)").bindparams(
+                        bindparam("cls", SWEEP_LOCK_CLASSID), bindparam("obj", key)
+                    )
+                )
+            ).scalar()
+        except BaseException:
+            await db.__aexit__(None, None, None)
+            raise
+        if not got:
+            await db.__aexit__(None, None, None)
+            return False
+        self._held[key] = db
+        return True
+
+    async def unlock(self, key: int) -> None:
+        db = self._held.pop(key, None)
+        if db is None:
+            return
+        try:
+            from sqlalchemy import bindparam, text
+
+            await db.execute(
+                text("SELECT pg_advisory_unlock(:cls, :obj)").bindparams(
+                    bindparam("cls", SWEEP_LOCK_CLASSID), bindparam("obj", key)
+                )
+            )
+        except Exception:
+            log.debug("advisory unlock best-effort failed for key %s", key, exc_info=True)
+        finally:
+            await db.__aexit__(None, None, None)

--- a/core/meetings/services/meeting-api/tests/test_app.py
+++ b/core/meetings/services/meeting-api/tests/test_app.py
@@ -79,3 +79,36 @@ def test_lifecycle_callback_on_unified_app():
     client = TestClient(create_app())
     r = client.post("/bots/internal/callback/lifecycle", json=event)
     assert r.status_code in (200, 409), r.text  # accepted, or a legal-transition rejection
+
+
+async def test_boot_loop_set_excludes_dead_scheduler_tick(caplog):
+    """#637 A2 (offline): the boot loop-name set does NOT contain the dead ``scheduler-tick`` loop.
+
+    Drive the real ``_attach_background_loops`` lifespan (over fakes) and read the boot line
+    (``meeting-api background loops started: [...]``, ``__main__``) — the started set must list the six
+    live loops and no longer name ``scheduler-tick`` (V2: the dead loop is gone).
+    """
+    import logging
+
+    import fakeredis.aioredis
+
+    from meeting_api.__main__ import _attach_background_loops
+    from meeting_api.collector.adapters import RedisStreamBus
+    from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+    app = create_app()
+    store = InMemoryTranscriptStore()
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    bus = RedisStreamBus(redis)
+    # meeting_repo/runtime/session_factory left None → guarded loops degrade cleanly (Lite shape).
+    _attach_background_loops(app, store, bus, redis, meeting_repo=None, runtime=None)
+
+    with caplog.at_level(logging.INFO, logger="meeting_api.entrypoint"):
+        async with app.router.lifespan_context(app):
+            pass  # the boot line is logged at lifespan enter, before the loops do any work
+
+    line = next(m for m in caplog.messages if "background loops started" in m)
+    assert "scheduler-tick" not in line, "the dead scheduler-tick loop must be gone from the boot set"
+    for live in ("segment-consumer", "db-writer", "webhook-drain",
+                 "stop-reconcile", "auto-join", "calendar-sync"):
+        assert live in line, f"{live} must still be a started loop"

--- a/core/meetings/services/meeting-api/tests/test_single_flight.py
+++ b/core/meetings/services/meeting-api/tests/test_single_flight.py
@@ -1,0 +1,141 @@
+"""Single-flight sweep guard (#637, A3) — offline unit lane for the cross-replica lock mechanism.
+
+The real ``pg_try_advisory_lock`` behavior is proven in the compose/helm leg (A1); the offline suite
+has no Postgres, so this lane drives the guard's contract with a hand-authored ``FakeAdvisoryLock``
+(a dict-backed ``try_lock(key)->bool`` / ``unlock(key)``). Two concurrent guarded coroutines share
+ONE lock and one counter: the winner's body runs, the loser's does NOT (counter == 1, not 2); after
+the winner releases, a later tick by the loser DOES run (counter == 2). The negative control shows
+that calling the bodies directly (no guard) yields counter == 2 — the guard, not chance, halves it.
+
+Also asserts the disjoint-keyspace fork: the sweep lock key is the two-arg
+``(SWEEP_LOCK_CLASSID, crc32(loop_name))`` form, which cannot collide with the single-arg per-user
+``pg_advisory_xact_lock(:user_id)`` locks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from meeting_api.sweeps.single_flight import (
+    SWEEP_LOCK_CLASSID,
+    run_single_flight,
+    sweep_lock_key,
+)
+
+
+class FakeAdvisoryLock:
+    """Dict-backed stand-in for a session-level Postgres advisory lock.
+
+    ``try_lock`` returns ``True`` only if no one currently holds ``key`` (mirroring
+    ``pg_try_advisory_lock`` — non-blocking, immediate ``false`` when contended). An ``await
+    asyncio.sleep(0)`` yields the event loop so a second coroutine can interleave, reproducing the
+    two-replicas-contend-the-same-tick race without a real DB.
+    """
+
+    def __init__(self):
+        self.held: set[int] = set()
+        self.try_calls: list[int] = []
+
+    async def try_lock(self, key: int) -> bool:
+        self.try_calls.append(key)
+        await asyncio.sleep(0)  # yield: let the other guarded coroutine reach its own try_lock
+        if key in self.held:
+            return False
+        self.held.add(key)
+        return True
+
+    async def unlock(self, key: int) -> None:
+        self.held.discard(key)
+
+
+KEY = sweep_lock_key("calendar-sync")
+
+
+async def test_loser_body_does_not_run_under_contention():
+    """Two guarded coroutines, one lock, one counter → exactly one body runs (counter == 1)."""
+    lock = FakeAdvisoryLock()
+    counter = {"n": 0}
+    ran: list[bool] = []
+
+    async def body():
+        # Hold across a yield so the second coroutine's try_lock definitely lands while held.
+        await asyncio.sleep(0)
+        counter["n"] += 1
+
+    async def guarded():
+        ran.append(await run_single_flight(lock, KEY, body))
+
+    await asyncio.gather(guarded(), guarded())
+
+    assert counter["n"] == 1, "the loser's body must NOT run — single-flight, not once-per-replica"
+    assert sorted(ran) == [False, True], "exactly one guarded call ran the body; the other skipped"
+    assert lock.held == set(), "the winner released the lock in its finally"
+
+
+async def test_loser_runs_on_a_later_uncontended_tick():
+    """After the winner releases, a later tick by the (former) loser DOES run — no permanent skip."""
+    lock = FakeAdvisoryLock()
+    counter = {"n": 0}
+
+    async def body():
+        await asyncio.sleep(0)  # hold the lock across a yield so the contended tick truly contends
+        counter["n"] += 1
+
+    # Tick 1: contended → one body runs.
+    await asyncio.gather(
+        run_single_flight(lock, KEY, body),
+        run_single_flight(lock, KEY, body),
+    )
+    assert counter["n"] == 1
+
+    # Tick 2: uncontended (lock free) → the body runs again (the guard is not a one-shot latch).
+    ran = await run_single_flight(lock, KEY, body)
+    assert ran is True
+    assert counter["n"] == 2
+
+
+async def test_negative_control_no_guard_both_bodies_run():
+    """RED analogue: call the bodies directly (guard removed) → counter == 2 (both replicas ran)."""
+    counter = {"n": 0}
+
+    async def body():
+        await asyncio.sleep(0)
+        counter["n"] += 1
+
+    await asyncio.gather(body(), body())
+    assert counter["n"] == 2, "without the guard both replicas' bodies run — this is the doubled work"
+
+
+async def test_none_lock_degrades_to_run_the_tick():
+    """Lite / no PG (session_factory is None → lock is None): the guard runs the body, never skips."""
+    counter = {"n": 0}
+
+    async def body():
+        counter["n"] += 1
+
+    ran = await run_single_flight(None, KEY, body)
+    assert ran is True and counter["n"] == 1
+
+
+async def test_body_exception_releases_lock():
+    """A body that raises still releases the lock (finally) so the next tick can acquire it."""
+    lock = FakeAdvisoryLock()
+
+    async def boom():
+        raise RuntimeError("tick blew up")
+
+    with pytest.raises(RuntimeError):
+        await run_single_flight(lock, KEY, boom)
+    assert lock.held == set(), "the lock is released even when the body raises"
+
+
+def test_sweep_key_disjoint_from_user_locks():
+    """The two-arg (classid, objid) sweep key can't collide with single-arg per-user xact locks."""
+    # A fixed namespace classid pairs with every crc32(loop_name); the per-user locks are single-arg
+    # on user-id ints, a disjoint Postgres advisory-lock space.
+    assert isinstance(SWEEP_LOCK_CLASSID, int)
+    keys = {name: sweep_lock_key(name) for name in
+            ("db-writer", "webhook-drain", "stop-reconcile", "auto-join", "calendar-sync")}
+    assert len(set(keys.values())) == len(keys), "each loop hashes to a distinct objid (no collision)"
+    assert sweep_lock_key("calendar-sync") == sweep_lock_key("calendar-sync"), "stable per loop name"

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -133,6 +133,18 @@ write is rejected, check that the dispatch's trigger is `message`/`scheduled` (w
 - Wipe and restart from clean: `make down` (or `docker compose -p vexa-v012 down -v` to drop the
   postgres + minio volumes too), then `make all`.
 
+## Scaling meeting-api to more than one replica
+
+Running `meetingApi.replicaCount > 1` (the Helm chart default is `2`) is **safe**. Every replica
+starts the same background sweeps, but each sweep's real work is **single-flighted** by a Postgres
+session-level advisory lock (one per loop): the replica that acquires the lock runs the tick, the
+others skip it that interval. So a sweep's real work — notably the `calendar-sync` external ICS
+fetch — runs **once per interval across the cluster, not once per replica**. Sweep intervals
+(`CALENDAR_SYNC_INTERVAL_S`, etc.) are therefore per-cluster, not per-replica. A replica that dies
+mid-tick drops its lock on disconnect, so the next interval is picked up by another replica — no
+leader-election setup required. On a single replica the lock is always free, so behaviour is
+unchanged. Note that `scheduler-tick` is not a production loop and is no longer started.
+
 ## Still stuck?
 
 Open an issue or ask on the [GitHub repo](https://github.com/Vexa-ai/vexa). Include the failing request,


### PR DESCRIPTION
Closes #637.

Every meeting-api replica started all background sweeps with no leader election — at `replicaCount: 2` each sweep ran twice (calendar-sync doubling external ICS fetches per user). The safety was accidental (per-loop idempotency), not structural. Plus `scheduler-tick` was dead code (`app.state.scheduler` is never set).

- new `meeting_api/sweeps/single_flight.py`: wrap each live tick in a session-level `pg_try_advisory_lock` (disjoint classid) → one runner per interval across replicas; degrades to run-the-tick with no DB session (Lite/single-replica); `segment-consumer` left as a competing consumer
- delete the dead `scheduler-tick` loop + `_scheduler_tick_loop`

**Verified:** meeting-api 667 passed incl. `test_single_flight.py` (loser-skips) + boot-loop-set excludes scheduler-tick.
