### PR TITLE
fix(meeting-api): reclaim a crashed replica's orphaned segment batch (#636)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -196,9 +196,14 @@ def _minio_endpoint_url() -> str:
 
 def _attach_background_loops(app, transcript_store, segment_bus, redis_client, meeting_repo=None, runtime=None) -> None:
     """Register the FastAPI lifespan that starts/stops the control-plane poll loops."""
-    from .collector.ingest import consume_segments
+    from .collector.ingest import RECLAIM_MIN_IDLE_MS, consume_segments, reclaim_segments
 
     seg_interval = float(os.getenv("SEGMENT_CONSUMER_INTERVAL", "0.5"))
+    # #636: orphan-reclaim cadence — fold a bounded XAUTOCLAIM into the consumer loop every N ticks
+    # (default 120 ⇒ ~60s at the 0.5s tick), so a crashed replica's un-acked batch is picked up by a
+    # survivor without a dedicated loop (no second /health heartbeat to maintain). The min-idle gate
+    # (RECLAIM_MIN_IDLE_MS) ensures a live peer's in-flight batch is never stolen.
+    seg_reclaim_every = max(1, int(os.getenv("SEGMENT_RECLAIM_EVERY_N_TICKS", "120")))
     webhook_interval = float(os.getenv("WEBHOOK_DRAIN_INTERVAL", "5"))
     scheduler_interval = float(os.getenv("SCHEDULER_TICK_INTERVAL", "1"))
     # The db-writer cadence — the parent's BACKGROUND_TASK_INTERVAL (10s); either env name works.
@@ -241,12 +246,25 @@ def _attach_background_loops(app, transcript_store, segment_bus, redis_client, m
     app.state.pipeline_group = _SEG_GROUP
     app.state.pipeline_tick_stale_s = float(os.getenv("PIPELINE_TICK_STALE_S", "120"))
     app.state.pipeline_lag_alarm = int(os.getenv("PIPELINE_LAG_ALARM", "500"))
+    # #636: group PEL depth (delivered-but-un-acked) alarm. Steady state acks within a tick, so a
+    # SUSTAINED total above this threshold is an orphaned batch (a crashed replica's un-reclaimed
+    # PEL) → /health degrades + 503. Default headroom over one in-flight batch (count=10 default).
+    app.state.pipeline_pending_alarm = int(os.getenv("PIPELINE_PENDING_ALARM", "100"))
 
     async def _segment_consumer_loop() -> None:
         # Drain the transcription_segments stream → persist + publish tc:…:mutable.
+        tick_n = 0
         while True:
             try:
                 await consume_segments(transcript_store, segment_bus)
+                # #636: every N ticks, reclaim any ORPHANED (crashed-replica) un-acked batch idle
+                # past RECLAIM_MIN_IDLE_MS and drain it through the same ingest→ack path. Bounded to
+                # one XAUTOCLAIM per pass (its cursor continues next time) — never a hang surface.
+                tick_n += 1
+                if tick_n % seg_reclaim_every == 0:
+                    await reclaim_segments(
+                        transcript_store, segment_bus, min_idle_ms=RECLAIM_MIN_IDLE_MS
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -41,22 +41,41 @@ from .lifecycle.machine import LifecycleSink, MeetingStore
 from .obs import TraceMiddleware
 
 
-async def _pipeline_health(app) -> "tuple[dict, bool]":
-    """#527: derive pipeline liveness from the per-loop heartbeats + collector-group lag, and decide
-    whether to DEGRADE. A loop hung inside an await stops stamping, so its tick_age_s climbs past
-    PIPELINE_TICK_STALE_S even while the process and the live-WS path look healthy — exactly the
-    2026-04-26 silent hang. Returns ``({loops, consumer_lag}, degraded)``.
+def _xpending_total(summary) -> "Optional[int]":
+    """Total DELIVERED-but-un-acked count for the group from an XPENDING SUMMARY reply (#636).
+    redis-py returns a dict ``{'pending': N, 'min', 'max', 'consumers'}``; the raw protocol reply is
+    a list ``[N, min, max, consumers]``. Returns the integer total, or None when unrecognizable."""
+    if isinstance(summary, dict):
+        v = summary.get("pending")
+        return int(v) if isinstance(v, int) else None
+    if isinstance(summary, (list, tuple)) and summary:
+        try:
+            return int(summary[0])
+        except (TypeError, ValueError):
+            return None
+    return None
 
-    The probe MUST NOT itself hang (that would defeat the point): the XINFO call is bounded by a 2s
-    wait_for and any failure degrades to ``consumer_lag: "unavailable"`` rather than blocking."""
+
+async def _pipeline_health(app) -> "tuple[dict, bool]":
+    """#527/#636: derive pipeline liveness from the per-loop heartbeats + collector-group lag +
+    pending-entry (PEL) depth, and decide whether to DEGRADE. A loop hung inside an await stops
+    stamping, so its tick_age_s climbs past PIPELINE_TICK_STALE_S even while the process and the
+    live-WS path look healthy — the 2026-04-26 silent hang. A crashed replica's delivered-but-un-acked
+    batch is NOT lag (it was delivered) and NOT a stale heartbeat on the survivor, so #636 surfaces it
+    as ``pending_depth``. Returns ``({loops, consumer_lag, pending_depth}, degraded)``.
+
+    The probe MUST NOT itself hang (that would defeat the point): the XINFO/XPENDING calls are each
+    bounded by a 2s wait_for and any failure degrades that field to ``"unavailable"`` — never blocks."""
     st = app.state
     now = time.monotonic()
     stale_s = getattr(st, "pipeline_tick_stale_s", 120.0)
     lag_alarm = getattr(st, "pipeline_lag_alarm", 500)
+    pending_alarm = getattr(st, "pipeline_pending_alarm", 100)
     loops = {name: round(now - ts, 1) for name, ts in (st.pipeline_ticks or {}).items()}
     degraded = any(age > stale_s for age in loops.values())
 
     lag = None
+    pending_depth = None
     redis = getattr(st, "pipeline_redis", None)
     if redis is not None:
         try:
@@ -69,9 +88,22 @@ async def _pipeline_health(app) -> "tuple[dict, bool]":
                     break
         except Exception:
             lag = "unavailable"  # a dead/absent group is itself a signal, never a hang
+        # #636: PEL depth — a bounded XPENDING SUMMARY. A delivered-but-un-acked orphan is invisible
+        # to lag; a SUSTAINED non-zero total is the orphan signal (steady state acks within a tick).
+        try:
+            summary = await asyncio.wait_for(
+                redis.xpending(st.pipeline_stream, st.pipeline_group), timeout=2.0
+            )
+            pending_depth = _xpending_total(summary)
+            if pending_depth is None:
+                pending_depth = "unavailable"
+        except Exception:
+            pending_depth = "unavailable"  # never block the probe on a pending read
     if isinstance(lag, int) and lag > lag_alarm:
         degraded = True
-    return {"loops": loops, "consumer_lag": lag}, degraded
+    if isinstance(pending_depth, int) and pending_depth > pending_alarm:
+        degraded = True
+    return {"loops": loops, "consumer_lag": lag, "pending_depth": pending_depth}, degraded
 
 
 def create_app(

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -27,6 +27,27 @@ from typing import Optional
 from .ports import RedisBus, TranscriptStore
 
 
+def _decode_claimed(resp) -> "list[tuple[str, dict]]":
+    """Normalize an XAUTOCLAIM response to ``[(message_id, fields), ...]`` (#636).
+
+    redis-py returns ``[cursor, claimed]`` (older) or ``[cursor, claimed, deleted]`` (Redis 7+),
+    where ``claimed`` is ``[(id, {field: value}), ...]``. Ids/keys/values are decoded from bytes so
+    the drained fields match ``read_segments``' shape (``ingest`` reads ``fields['payload']``)."""
+    if not resp or len(resp) < 2:
+        return []
+    claimed = resp[1] or []
+    out: list[tuple[str, dict]] = []
+    for message_id, fields in claimed:
+        mid = message_id.decode() if isinstance(message_id, bytes) else message_id
+        decoded = {
+            (k.decode() if isinstance(k, bytes) else k):
+            (v.decode() if isinstance(v, bytes) else v)
+            for k, v in (fields or {}).items()
+        }
+        out.append((mid, decoded))
+    return out
+
+
 def _sha(s: str) -> str:
     return hashlib.sha256(s.encode()).hexdigest()
 
@@ -974,6 +995,19 @@ class RedisStreamBus:
                 }
                 out.append((mid, decoded))
         return out
+
+    async def reclaim_orphans(self, *, group, stream, consumer, min_idle_ms, count=10):
+        """#636: XAUTOCLAIM idle (crashed-replica) entries from the group's PEL into ``consumer``.
+        Bounded (single call, ``count`` cap) — the returned cursor lets the next tick continue."""
+        try:
+            await self._client.xgroup_create(name=stream, groupname=group, id="0", mkstream=True)
+        except Exception:
+            pass  # BUSYGROUP — group already exists
+        resp = await self._client.xautoclaim(
+            name=stream, groupname=group, consumername=consumer,
+            min_idle_time=min_idle_ms, start_id="0-0", count=count,
+        )
+        return _decode_claimed(resp)
 
     async def ack(self, *, group, stream, message_ids):
         if message_ids:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -542,6 +542,20 @@ class FakeRedisBus:
                 out.append((mid, decoded))
         return out
 
+    async def reclaim_orphans(self, *, group, stream, consumer, min_idle_ms, count=10):
+        """#636: mirror of ``RedisStreamBus.reclaim_orphans`` over ``fakeredis.aioredis`` (which
+        supports XAUTOCLAIM ≥ 2.21). Reclaims idle delivered-but-un-acked entries into ``consumer``."""
+        from .adapters import _decode_claimed
+        try:
+            await self._client.xgroup_create(name=stream, groupname=group, id="0", mkstream=True)
+        except Exception:
+            pass
+        resp = await self._client.xautoclaim(
+            name=stream, groupname=group, consumername=consumer,
+            min_idle_time=min_idle_ms, start_id="0-0", count=count,
+        )
+        return _decode_claimed(resp)
+
     async def ack(self, *, group, stream, message_ids):
         if message_ids:
             await self._client.xack(stream, group, *message_ids)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ingest.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ingest.py
@@ -21,6 +21,8 @@ The ``:mutable`` payload mirrors the bot's live publisher
 from __future__ import annotations
 
 import json
+import os
+import socket
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -29,7 +31,16 @@ from .ports import RedisBus, TranscriptStore
 # Stream / consumer-group defaults (parent ``collector/config.py``).
 STREAM_NAME = "transcription_segments"
 CONSUMER_GROUP = "collector_group"
-CONSUMER_NAME = "collector-main"
+# #636: the consumer name must be UNIQUE per replica, else every meeting-api pod joins the group
+# under one identity and a crashed pod's delivered-but-un-acked batch is orphaned forever (no peer
+# can distinguish — or reclaim — it). Derive it from pod identity: in k8s the pod name IS the
+# hostname, so ``collector-<hostname>`` is distinct per replica; keep ``COLLECTOR_CONSUMER_NAME`` as
+# an explicit override (and to pin a deterministic name in single-process tests).
+CONSUMER_NAME = os.environ.get("COLLECTOR_CONSUMER_NAME") or f"collector-{socket.gethostname()}"
+# #636: how long a delivered-but-un-acked entry must sit idle before another replica may reclaim it.
+# The gate is what keeps reclaim from STEALING a live peer's in-flight batch (which is pending only
+# for the sub-second between XREADGROUP and XACK) — only a genuinely orphaned batch idles past this.
+RECLAIM_MIN_IDLE_MS = int(os.environ.get("COLLECTOR_RECLAIM_MIN_IDLE_MS", "60000"))
 
 
 def _mutable_channel(meeting_id: int) -> str:
@@ -261,6 +272,40 @@ async def consume_segments(
     total = 0
     acked: list[str] = []
     for message_id, fields in batch:
+        total += await ingest(store, redis, fields)
+        acked.append(message_id)
+    if acked:
+        await redis.ack(group=group, stream=stream, message_ids=acked)
+    return total
+
+
+async def reclaim_segments(
+    store: TranscriptStore,
+    redis: RedisBus,
+    *,
+    stream: str = STREAM_NAME,
+    group: str = CONSUMER_GROUP,
+    consumer: str = CONSUMER_NAME,
+    min_idle_ms: int = RECLAIM_MIN_IDLE_MS,
+    count: int = 10,
+) -> int:
+    """#636: reclaim ORPHANED entries — a crashed replica's delivered-but-un-acked batch that sits
+    in its PEL with no surviving owner — and drain them through the SAME ``ingest`` → ``ack`` path
+    ``consume_segments`` uses, so at-least-once delivery holds across replicas.
+
+    One bounded ``XAUTOCLAIM`` per call (``min_idle_ms`` gated). The gate is load-bearing: an entry
+    that a LIVE peer merely holds in-flight (pending for the sub-second between its XREADGROUP and
+    XACK) idles far less than ``min_idle_ms`` and is therefore NEVER stolen — only a genuinely
+    orphaned batch (idle past the threshold) is reclaimed. A single call with a bounded ``count`` is
+    sufficient: XAUTOCLAIM returns a continuation cursor and the NEXT tick continues from it, so this
+    never loops-to-exhaustion inside one tick (which would reintroduce a hang surface). Returns the
+    total segments persisted from the reclaimed batch."""
+    reclaimed = await redis.reclaim_orphans(
+        group=group, stream=stream, consumer=consumer, min_idle_ms=min_idle_ms, count=count
+    )
+    total = 0
+    acked: list[str] = []
+    for message_id, fields in reclaimed:
         total += await ingest(store, redis, fields)
         acked.append(message_id)
     if acked:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -221,6 +221,16 @@ class RedisBus(Protocol):
     ) -> list[tuple[str, dict]]:
         ...
 
+    async def reclaim_orphans(
+        self, *, group: str, stream: str, consumer: str, min_idle_ms: int, count: int = 10
+    ) -> list[tuple[str, dict]]:
+        """#636: reclaim DELIVERED-but-un-acked entries idle longer than ``min_idle_ms`` from ANY
+        consumer's PEL into ``consumer`` (XAUTOCLAIM) → ``[(message_id, fields), ...]``. A crashed
+        replica's orphaned batch is otherwise never re-delivered; this is the seam a surviving
+        replica uses to pick it up. One bounded call per tick (XAUTOCLAIM returns a continuation
+        cursor; the next tick continues) — never loops-to-exhaustion inside one call."""
+        ...
+
     async def ack(self, *, group: str, stream: str, message_ids: list[str]) -> None: ...
 
     async def publish(self, channel: str, data: str) -> Any: ...

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -359,6 +359,34 @@
    "default": "3600",
    "description": "#527: acked transcription_segments entries older than this are trimmed; an unread (un-acked) entry is NEVER trimmed regardless of age (the 2026-04-26 data-loss guard)",
    "targets": []
+  },
+  {
+   "key": "COLLECTOR_CONSUMER_NAME",
+   "class": "defaulted",
+   "default": "",
+   "description": "#636: per-replica Redis consumer name for the segment group; empty → derived as collector-<hostname> (pod identity) so a crashed replica's pending batch is attributable + reclaimable",
+   "targets": []
+  },
+  {
+   "key": "COLLECTOR_RECLAIM_MIN_IDLE_MS",
+   "class": "defaulted",
+   "default": "60000",
+   "description": "#636: min idle (ms) before a replica reclaims another replica's un-acked segment batch via XAUTOCLAIM, so a live peer's in-flight batch is never stolen",
+   "targets": []
+  },
+  {
+   "key": "SEGMENT_RECLAIM_EVERY_N_TICKS",
+   "class": "defaulted",
+   "default": "120",
+   "description": "#636: run the orphan-reclaim scan every N segment-consumer ticks",
+   "targets": []
+  },
+  {
+   "key": "PIPELINE_PENDING_ALARM",
+   "class": "defaulted",
+   "default": "100",
+   "description": "#636: /health degrades to 503 when the segment group's pending-entry (PEL) depth exceeds this — a stuck/orphaned batch is a reportable state (P18)",
+   "targets": []
   }
  ],
  "capabilities": {

--- a/core/meetings/services/meeting-api/tests/test_collector_health.py
+++ b/core/meetings/services/meeting-api/tests/test_collector_health.py
@@ -26,3 +26,63 @@ def test_health_needs_no_user_identity():
     """Health must be reachable WITHOUT an x-user-id — it is not a client route."""
     client = TestClient(_app())
     assert client.get("/health").status_code == 200
+
+
+# ──────────────────────────────────────────────────────────────────────────────────────────────
+# #636 · C2/A4 — the UNIFIED meeting-api /health surfaces the collector-group PEL depth, so a
+# crashed replica's orphaned (delivered-but-un-acked) batch is a reportable state, not a silent
+# stall. Drives meeting_api.create_app (the app that carries the #527 `pipeline` section), with the
+# pipeline redis wired to a fake exposing xinfo_groups + a bounded XPENDING summary.
+# ──────────────────────────────────────────────────────────────────────────────────────────────
+
+
+class _PendingRedis:
+    """A pipeline-redis fake: xinfo_groups (lag) + xpending SUMMARY (delivered-but-un-acked total)."""
+
+    def __init__(self, *, pending, lag=0):
+        self._pending, self._lag = pending, lag
+
+    async def xinfo_groups(self, stream):
+        return [{"name": "collector_group", "lag": self._lag}]
+
+    async def xpending(self, stream, group):
+        return {"pending": self._pending, "min": "1-0", "max": "9-0", "consumers": []}
+
+
+def _unified_health(*, pending, lag=0, pending_alarm=0):
+    import time
+
+    from meeting_api import create_app as create_unified_app
+
+    app = create_unified_app()
+    app.state.pipeline_ticks = {"segment-consumer": time.monotonic(), "db-writer": time.monotonic()}
+    app.state.pipeline_redis = _PendingRedis(pending=pending, lag=lag)
+    app.state.pipeline_stream = "transcription_segments"
+    app.state.pipeline_group = "collector_group"
+    app.state.pipeline_tick_stale_s = 120.0
+    app.state.pipeline_lag_alarm = 500
+    app.state.pipeline_pending_alarm = pending_alarm
+    return TestClient(app).get("/health")
+
+
+def test_pending_depth_degrades():
+    """Orphan present: the group PEL total is N=5 above the alarm → /health reports
+    ``pipeline.pending_depth == 5``, ``status: degraded``, HTTP 503.
+
+    RED on head: /health has only ``consumer_lag`` (= 0 for a delivered-but-un-acked orphan), so it
+    stays ``ok`` / 200 and the stall is invisible."""
+    r = _unified_health(pending=5, pending_alarm=0)
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["pipeline"]["pending_depth"] == 5
+
+
+def test_pending_depth_zero_is_ok():
+    """No orphan: PEL total 0 (steady state — entries ack within a tick) → ``pending_depth == 0``,
+    ``status: ok``, 200."""
+    r = _unified_health(pending=0, pending_alarm=0)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["pipeline"]["pending_depth"] == 0

--- a/core/meetings/services/meeting-api/tests/test_reclaim_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_reclaim_seam.py
@@ -1,0 +1,142 @@
+"""#636 · C1/A1+A2 — a surviving replica reclaims a crashed replica's orphaned segment batch.
+
+Every meeting-api replica USED to join the collector group under one hard-coded name
+(``collector-main``) and there was no ``XAUTOCLAIM`` anywhere, so a replica that crashed AFTER
+``XREADGROUP`` delivered a batch but BEFORE ``XACK`` left those entries in its PEL forever — no peer
+could distinguish, let alone reclaim, them. #636 gives each replica a pod-derived identity
+(``collector-<hostname>`` / ``COLLECTOR_CONSUMER_NAME``) and adds ``reclaim_segments`` — a bounded,
+``min_idle_ms``-gated ``XAUTOCLAIM`` that drains the orphan through the SAME ingest→ack path.
+
+Driven against ``fakeredis.aioredis`` (xautoclaim ≥ 2.21) — no real redis. Same lane as
+``test_robustness_seam.py`` / ``test_stream_retention.py``.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+from fakeredis import aioredis as fake_aioredis  # noqa: E402
+
+from meeting_api.collector.fakes import FakeRedisBus, InMemoryTranscriptStore  # noqa: E402
+from meeting_api.collector.ingest import (  # noqa: E402
+    CONSUMER_GROUP,
+    STREAM_NAME,
+    reclaim_segments,
+)
+
+
+async def _crashed_consumer_pel(n: int):
+    """The ``crashed_consumer_pel`` fixture: consumer ``collector-dead`` XREADGROUPs a batch of ``n``
+    one-segment messages and NEVER acks — so ``n`` entries land un-acked in its PEL, exactly the
+    state a replica leaves when it dies between delivery and ack. Returns (client, bus, store, ids)."""
+    client = fake_aioredis.FakeRedis(decode_responses=True)
+    bus = FakeRedisBus(client)
+    store = InMemoryTranscriptStore()
+    seg_ids: list[str] = []
+    for i in range(1, n + 1):
+        sid = f"seg-{i}"
+        seg_ids.append(sid)
+        await bus.xadd(STREAM_NAME, {
+            "type": "transcript", "meeting_id": 1,
+            "segments": [{
+                "segment_id": sid, "start": float(i), "end": float(i) + 1.0,
+                "text": f"t{i}", "completed": True,
+            }],
+        })
+    dead = await bus.read_segments(
+        group=CONSUMER_GROUP, consumer="collector-dead", stream=STREAM_NAME, count=n
+    )
+    assert len(dead) == n, "the dead consumer must hold the whole batch in its PEL"
+    return client, bus, store, seg_ids
+
+
+def _pending_count(pending) -> int:
+    if isinstance(pending, dict):
+        return int(pending.get("pending") or 0)
+    return int(pending[0]) if pending else 0
+
+
+async def test_survivor_reclaims_crashed_batch():
+    """A1 (discriminating). N=5 entries un-acked in ``collector-dead``'s PEL. The survivor's plain
+    ``XREADGROUP >`` sees NOTHING (the orphan is not lag — it was already delivered). Only the reclaim
+    tick picks it up: all 5 segment_ids land in the store and the group PEL drains to 0.
+
+    RED on head code (no ``reclaim_orphans``/``XAUTOCLAIM``, shared consumer name): the survivor's
+    ``>`` read returns nothing, the store stays empty, and XPENDING stays 5 forever."""
+    client, bus, store, seg_ids = await _crashed_consumer_pel(5)
+
+    # the orphan is NOT undelivered lag: a fresh new-only read by the survivor returns nothing.
+    fresh = await bus.read_segments(
+        group=CONSUMER_GROUP, consumer="collector-live", stream=STREAM_NAME
+    )
+    assert fresh == [], "the orphaned batch is delivered-but-un-acked, invisible to a '>' read"
+
+    reclaimed = await reclaim_segments(
+        store, bus, consumer="collector-live", min_idle_ms=0
+    )
+
+    assert reclaimed == 5, "the survivor reclaims + persists all 5 orphaned segments"
+    persisted = sorted(store._meetings.get(1, {}).get("segments", {}).keys())
+    assert persisted == seg_ids, f"all segment_ids must land in the store: {persisted}"
+    pending = await client.xpending(STREAM_NAME, CONSUMER_GROUP)
+    assert _pending_count(pending) == 0, "the group PEL must drain to 0 after reclaim+ack"
+    await client.aclose()
+
+
+async def test_reclaim_respects_min_idle():
+    """A2 (min-idle guard). An entry pending only ~0 ms — the shape of a LIVE peer's in-flight batch,
+    delivered and about to ack — must NOT be reclaimed when ``min_idle_ms=60000``. The gate is what
+    stops a survivor from STEALING a healthy peer's work.
+
+    Negative control (inline): with the gate OFF (``min_idle_ms=0``) the SAME batch IS reclaimed and
+    re-drained through the sink — the duplicate processing the guard exists to prevent (call-count on
+    the store sink proves it)."""
+    client, bus, store, _ = await _crashed_consumer_pel(3)
+
+    calls = {"n": 0}
+    orig_append = store.append_segment
+
+    async def _counting_append(meeting_id, segment):
+        calls["n"] += 1
+        return await orig_append(meeting_id, segment)
+
+    store.append_segment = _counting_append  # type: ignore[assignment]
+
+    # GREEN: the 60s gate leaves a 0ms-idle (live in-flight) batch untouched — no reclaim, no sink call.
+    reclaimed = await reclaim_segments(
+        store, bus, consumer="collector-live", min_idle_ms=60000
+    )
+    assert reclaimed == 0, "a live peer's in-flight (0ms-idle) batch must never be reclaimed"
+    assert calls["n"] == 0, "the sink must not be touched when the min-idle gate holds"
+
+    # NEGATIVE CONTROL: gate off → the same batch is stolen and reprocessed (the double-process).
+    stolen = await reclaim_segments(
+        store, bus, consumer="collector-live", min_idle_ms=0
+    )
+    assert stolen == 3, "with the gate off the batch IS reclaimed (proves the gate suppressed it)"
+    assert calls["n"] == 3, "the stolen batch is re-drained through the sink — the duplicate"
+    await client.aclose()
+
+
+async def test_consumer_name_is_pod_derived():
+    """The consumer identity is per-replica, not the old shared ``collector-main``. An explicit
+    ``COLLECTOR_CONSUMER_NAME`` override wins; otherwise it is ``collector-<hostname>``."""
+    import importlib
+
+    # `meeting_api.collector.__init__` re-exports the `ingest` function, shadowing the submodule for
+    # attribute access — use importlib to get the real module object (as test_robustness_seam does).
+    ingest_mod = importlib.import_module("meeting_api.collector.ingest")
+
+    assert ingest_mod.CONSUMER_NAME != "collector-main"
+    assert ingest_mod.CONSUMER_NAME.startswith("collector-")
+
+    import os as _os
+    _os.environ["COLLECTOR_CONSUMER_NAME"] = "collector-pod-xyz"
+    try:
+        reloaded = importlib.reload(ingest_mod)
+        assert reloaded.CONSUMER_NAME == "collector-pod-xyz"
+    finally:
+        del _os.environ["COLLECTOR_CONSUMER_NAME"]
+        importlib.reload(ingest_mod)  # restore the default for other tests

--- a/core/meetings/services/meeting-api/tests/test_stream_retention.py
+++ b/core/meetings/services/meeting-api/tests/test_stream_retention.py
@@ -71,3 +71,33 @@ async def test_no_group_does_not_blind_trim():
     # no consumer group created → the trim must NOT drop entries it can't prove are consumed
     await _trim_segments_stream(r, RETENTION_S, NOW_MS)
     assert len(await _ids(r)) == 3
+
+
+async def test_reclaimed_orphan_lets_trim_advance():
+    """#636 · A3 (trim unblocks). A crashed replica's un-acked (orphaned) entry pins the trim floor
+    via XPENDING oldest-pending (``db_writer._trim_segments_stream``), so the stream grows without
+    bound around it — the quiet second consequence of the orphan. After a survivor reclaims + acks it,
+    the floor un-pins and the aged entries trim away.
+
+    Negative control (inline): with the orphan LEFT un-reclaimed, the trim cannot advance — XLEN
+    stays at N across the tick (unbounded growth). RED on head, where no reclaim path exists."""
+    from meeting_api.collector.fakes import FakeRedisBus, InMemoryTranscriptStore
+    from meeting_api.collector.ingest import reclaim_segments
+
+    r = fake_aioredis.FakeRedis(decode_responses=True)
+    ids = await _seed(r, 5)  # 5 aged entries; group created at 0
+    # a dead consumer delivers all 5 and never acks → all 5 pending; the oldest pins the trim floor.
+    msgs = await r.xreadgroup(CONSUMER_GROUP, "collector-dead", {STREAM_NAME: ">"}, count=5)
+    assert len(msgs[0][1]) == 5
+
+    # CONTROL: the un-reclaimed orphan pins the floor — nothing is trimmed even though all are aged.
+    await _trim_segments_stream(r, RETENTION_S, NOW_MS)
+    assert len(await _ids(r)) == 5, "an un-reclaimed pending entry pins the trim floor (unbounded)"
+
+    # a survivor reclaims + acks the orphan, then the aged entries trim away (floor un-pinned).
+    bus = FakeRedisBus(r)
+    store = InMemoryTranscriptStore()
+    await reclaim_segments(store, bus, consumer="collector-live", min_idle_ms=0)
+    await _trim_segments_stream(r, RETENTION_S, NOW_MS)
+    assert len(await _ids(r)) == 0, "after reclaim+ack the trim advances past the (now consumed) floor"
+    assert ids  # (seeded)

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -41,6 +41,20 @@ destroyed`) and delegates only the substrate question — *how do I start, obser
 workload?* — to the backend. On `k8s`, a workload is a bare Pod; the same dispatch, contracts,
 and worker run identically to the Docker backend. See [Execution](/architecture/execution).
 
+## Scaling meeting-api
+
+`meetingApi.replicaCount` defaults to `2`, and that is safe for the segment consumer.
+Each replica now joins the `transcription_segments` consumer group under a **per-pod
+identity** (`collector-<hostname>`, overridable with `COLLECTOR_CONSUMER_NAME`), and a
+surviving replica periodically `XAUTOCLAIM`s a crashed replica's un-acked segment batch and
+drains it through the normal persist path — so no transcript segments are orphaned when a
+pod dies mid-batch. The reclaim only fires once a batch has idled past
+`COLLECTOR_RECLAIM_MIN_IDLE_MS` (default `60000`), so a live peer's in-flight batch is never
+stolen. `/health` exposes `pipeline.pending_depth` (the group's delivered-but-un-acked
+count) alongside `pipeline.consumer_lag`, and degrades to `503` once it exceeds
+`PIPELINE_PENDING_ALARM` (default `100`) — a stuck batch is a reportable state, not a silent
+stall.
+
 ## Honest status
 
 The k8s backend **lifecycle and the workspace mount are implemented** (the workspace store


### PR DESCRIPTION
Closes #636.

The segment consumer joined the group as the pod-shared `collector-main` with no `XAUTOCLAIM`, so a replica that crashed mid-batch left its un-acked segments orphaned in the PEL forever (live at `replicaCount: 2`) — and the orphan pinned the stream-trim floor, growing the stream unboundedly. Successor of the 20-lost-meetings incident class.

- per-replica consumer name (`COLLECTOR_CONSUMER_NAME` or `collector-<hostname>`)
- `reclaim_orphans()` on the RedisBus port via `XAUTOCLAIM` (min-idle-gated so a live peer's batch isn't stolen); mirrored in the fake
- PEL depth on `/health` → degrade+503 (P18); 4 new env keys declared in `config.v1.json`

**Verified:** meeting-api 666 passed incl. all 6 acceptance tests (reclaim / min-idle guard / trim-unblocks / health). Follow-up recommended: D6c docs (consumer-group contract + ops scaling note) before the live close.
