### PR TITLE
release: v0.12.5 version bump

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.4"
+appVersion: "0.12.5"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -3,10 +3,10 @@ title: "Changelog & migration"
 description: "Release notes and what changes between major versions."
 ---
 
-{/* docs-reflects: 0.12.4 — the released version these docs describe. CI (gate:docs-version) keeps
+{/* docs-reflects: 0.12.5 — the released version these docs describe. CI (gate:docs-version) keeps
     this equal to Chart.yaml appVersion; the release version-bump updates it. */}
 
-> 📌 **These docs reflect Vexa `v0.12.4`** — the latest released control-plane. Older self-hosts
+> 📌 **These docs reflect Vexa `v0.12.5`** — the latest released control-plane. Older self-hosts
 > should read against their pinned version.
 
 The authoritative, per-release changelog is on **GitHub Releases**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
Bumps `package.json` version + `Chart.yaml` appVersion **0.12.4 → 0.12.5** so the `v0.12.5` tag passes the `release-images` preflight (tag == package.json == appVersion). No behavior change.

**The v0.12.5 batch** (value-signed merges since v0.12.4):

_Prod-reliability (the vexa-platform request):_
- #584 slim `/meetings` list — **the 2026-07-15 outage cure**
- #635 `DB_POOL_*` wired · #636 XAUTOCLAIM orphan reclaim · #637 single-flight sweeps
- #638 terminal token cap+prune · #634 helm `MEETING_API_URL` · #633 gateway 206 `Content-Range`
- #647 merge-card maintainer self-review

_Prior merges since v0.12.4:_ #624 (merge-card enforce), #626 (LOCAL_STT), #629 (witness script), #631/#632 (docs-currency, Jitsi docs).

After this merges: tag `v0.12.5` → `release-images` builds+publishes the `:0.12.5` candidate → witness → owner-approved promote of `:v012`.
