### PR TITLE
fix(meeting-api): reclaim degrades on Redis<6.2 (#636) + advisory-lock signature (#637) — v0.12.5 witness regressions

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -19,12 +19,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import secrets
 from datetime import datetime, timezone
 from typing import Optional
 
 from .ports import RedisBus, TranscriptStore
+
+log = logging.getLogger("meeting_api.collector.adapters")
 
 
 def _decode_claimed(resp) -> "list[tuple[str, dict]]":
@@ -998,6 +1001,7 @@ class RedisStreamBus:
 
     def __init__(self, client):
         self._client = client
+        self._reclaim_unsupported = False  # #636: log-once latch when the Redis lacks XAUTOCLAIM
 
     async def read_segments(self, *, group, consumer, stream, count=10):
         try:
@@ -1021,15 +1025,35 @@ class RedisStreamBus:
 
     async def reclaim_orphans(self, *, group, stream, consumer, min_idle_ms, count=10):
         """#636: XAUTOCLAIM idle (crashed-replica) entries from the group's PEL into ``consumer``.
-        Bounded (single call, ``count`` cap) — the returned cursor lets the next tick continue."""
+        Bounded (single call, ``count`` cap) — the returned cursor lets the next tick continue.
+
+        XAUTOCLAIM needs **Redis >= 6.2**. On an older server (e.g. Redis 6.0, which the Lite image
+        bundled — the #636 regression the v0.12.5 witness caught) the command is unknown; rather than
+        crash the segment-consumer loop every tick, degrade to a **no-op** (return no reclaimed
+        entries). The normal consume path (XREADGROUP) is unaffected; only cross-replica orphan
+        recovery is unavailable until Redis is upgraded. Logged once."""
+        from redis.exceptions import ResponseError
+
         try:
             await self._client.xgroup_create(name=stream, groupname=group, id="0", mkstream=True)
         except Exception:
             pass  # BUSYGROUP — group already exists
-        resp = await self._client.xautoclaim(
-            name=stream, groupname=group, consumername=consumer,
-            min_idle_time=min_idle_ms, start_id="0-0", count=count,
-        )
+        try:
+            resp = await self._client.xautoclaim(
+                name=stream, groupname=group, consumername=consumer,
+                min_idle_time=min_idle_ms, start_id="0-0", count=count,
+            )
+        except ResponseError as e:
+            msg = str(e).lower()
+            if "unknown command" in msg or "xautoclaim" in msg:
+                if not self._reclaim_unsupported:
+                    self._reclaim_unsupported = True
+                    log.warning(
+                        "XAUTOCLAIM unsupported on this Redis (needs >= 6.2) — #636 orphan reclaim "
+                        "disabled; normal segment consumption is unaffected. Upgrade Redis to re-enable."
+                    )
+                return []
+            raise
         return _decode_claimed(resp)
 
     async def ack(self, *, group, stream, message_ids):

--- a/core/meetings/services/meeting-api/src/meeting_api/sweeps/single_flight.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/sweeps/single_flight.py
@@ -8,12 +8,12 @@ replicas it doubled the outbound requests to third-party calendar providers ever
 
 Design choices (see the issue's "Along the way" forks):
 
-* **Disjoint keyspace.** The per-user spawn/plan locks use the single-arg
-  ``pg_advisory_xact_lock(:user_id)`` form on user-id ints (``bot_spawn/adapters.py``,
-  ``collector/adapters.py``). The sweep locks use the **two-arg** ``pg_try_advisory_lock(classid,
-  objid)`` form with a fixed ``SWEEP_LOCK_CLASSID`` namespace, so a ``crc32(loop_name)`` objid can
-  never collide with a user-id single-arg key (Postgres treats the one-arg and two-arg advisory-lock
-  spaces as disjoint).
+* **Disjoint keyspace.** The per-user spawn/plan locks use ``pg_advisory_xact_lock(:user_id)`` on
+  small user-id ints (``bot_spawn/adapters.py``, ``collector/adapters.py``). The sweep locks also use
+  the single-arg form, on a **64-bit key** = ``(SWEEP_LOCK_CLASSID << 32) | crc32(loop_name)`` — the
+  ``SWP\0`` namespace in the high 32 bits, so a sweep key can never collide with a small user-id key.
+  (The earlier two-arg ``(classid, objid)`` form was a trap: crc32 overflows signed int4 → asyncpg
+  binds it as bigint → ``pg_try_advisory_lock(int4, bigint)`` doesn't exist — the #637 witness bug.)
 * **Session-level, explicitly released.** ``pg_try_advisory_lock`` (not ``_xact_``) so the lock
   spans the whole tick and is released in a ``finally`` — and a replica that dies mid-tick drops the
   lock when its connection closes, so the other replica acquires it on the next tick (no starvation).
@@ -30,14 +30,21 @@ from typing import Awaitable, Callable, Optional, Protocol
 
 log = logging.getLogger("meeting_api.sweeps.single_flight")
 
-# Fixed "sweeps" namespace for the two-arg advisory-lock form. Any stable int works; the point is
-# that pairing it as the classid keeps every sweep key disjoint from the single-arg per-user locks.
-SWEEP_LOCK_CLASSID = 0x53575000  # "SWP\0"
+# Fixed "sweeps" namespace, folded into the HIGH 32 bits of a single 64-bit advisory key. Postgres's
+# TWO-arg pg_try_advisory_lock is (int4, int4); but crc32 can exceed signed int4, so asyncpg then
+# binds it as bigint → pg_try_advisory_lock(int4, bigint), a signature Postgres does NOT have — the
+# #637 regression caught at the v0.12.5 witness (`function pg_try_advisory_lock(integer, bigint) does
+# not exist`). The SINGLE-arg pg_try_advisory_lock(bigint) form has no such trap; packing the
+# namespace into the high 32 bits keeps every sweep key disjoint from the small per-user single-arg
+# locks (pg_advisory_xact_lock(:user_id), whose high 32 bits are 0).
+SWEEP_LOCK_CLASSID = 0x53575000  # "SWP\0" — < 2**31, so (CLASSID<<32)|crc32 is a positive signed int8
 
 
 def sweep_lock_key(loop_name: str) -> int:
-    """Stable per-loop objid = ``crc32(loop_name)`` (a small fixed set of name-hashes)."""
-    return binascii.crc32(loop_name.encode("utf-8"))
+    """Stable per-loop 64-bit advisory key: the SWEEP_LOCK_CLASSID namespace in the high 32 bits and
+    the ``crc32(loop_name)`` name-hash in the low 32 — always a positive signed int8 (Postgres
+    ``bigint``), disjoint from the small per-user single-arg locks."""
+    return (SWEEP_LOCK_CLASSID << 32) | binascii.crc32(loop_name.encode("utf-8"))
 
 
 class AdvisoryLock(Protocol):
@@ -74,7 +81,7 @@ async def run_single_flight(
 class PgAdvisoryLock:
     """``AdvisoryLock`` over a SQLAlchemy-async ``session_factory``.
 
-    ``try_lock`` opens a session, takes ``pg_try_advisory_lock(SWEEP_LOCK_CLASSID, key)`` on that
+    ``try_lock`` opens a session, takes ``pg_try_advisory_lock(cast(:key as bigint))`` on that
     connection, and — if acquired — HOLDS the session open so the session-scoped lock spans the tick.
     ``unlock`` releases the lock and closes the held session. ``unlock`` is best-effort: on shutdown
     the connection may already be closing, and a session-level lock releases on disconnect anyway.
@@ -92,8 +99,8 @@ class PgAdvisoryLock:
         try:
             got = (
                 await db.execute(
-                    text("SELECT pg_try_advisory_lock(:cls, :obj)").bindparams(
-                        bindparam("cls", SWEEP_LOCK_CLASSID), bindparam("obj", key)
+                    text("SELECT pg_try_advisory_lock(cast(:key as bigint))").bindparams(
+                        bindparam("key", key)
                     )
                 )
             ).scalar()
@@ -114,8 +121,8 @@ class PgAdvisoryLock:
             from sqlalchemy import bindparam, text
 
             await db.execute(
-                text("SELECT pg_advisory_unlock(:cls, :obj)").bindparams(
-                    bindparam("cls", SWEEP_LOCK_CLASSID), bindparam("obj", key)
+                text("SELECT pg_advisory_unlock(cast(:key as bigint))").bindparams(
+                    bindparam("key", key)
                 )
             )
         except Exception:

--- a/core/meetings/services/meeting-api/tests/test_reclaim_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_reclaim_seam.py
@@ -140,3 +140,56 @@ async def test_consumer_name_is_pod_derived():
     finally:
         del _os.environ["COLLECTOR_CONSUMER_NAME"]
         importlib.reload(ingest_mod)  # restore the default for other tests
+
+
+# ── #636 witness regression: reclaim degrades (never crashes the consumer) on a Redis without XAUTOCLAIM ──
+
+async def test_reclaim_orphans_degrades_when_xautoclaim_unsupported():
+    """On Redis < 6.2 the server has no ``XAUTOCLAIM`` and replies ``unknown command`` — the v0.12.5
+    Lite box bundled Redis 6.0.16, so ``reclaim_segments`` threw every segment-consumer tick and
+    transcription died. ``reclaim_orphans`` must now degrade to a **no-op** (return ``[]``), leaving
+    the normal ``XREADGROUP`` consume path untouched. This offline test uses fakeredis (which DOES
+    have XAUTOCLAIM), so it drives the adapter directly with a client that raises like Redis 6.0."""
+    from redis.exceptions import ResponseError
+
+    from meeting_api.collector.adapters import RedisStreamBus
+
+    class _Redis60:
+        async def xgroup_create(self, **kw):
+            return None
+
+        async def xautoclaim(self, **kw):
+            raise ResponseError("unknown command 'XAUTOCLAIM', with args beginning with: ...")
+
+    bus = RedisStreamBus(_Redis60())
+    out = await bus.reclaim_orphans(
+        group=CONSUMER_GROUP, stream=STREAM_NAME, consumer="collector-x", min_idle_ms=60000
+    )
+    assert out == [], "unsupported XAUTOCLAIM must degrade to no reclaimed entries, not raise"
+    assert bus._reclaim_unsupported is True, "the log-once latch must be set"
+    # a subsequent call keeps degrading (and, per the latch, does not re-log)
+    assert await bus.reclaim_orphans(
+        group=CONSUMER_GROUP, stream=STREAM_NAME, consumer="collector-x", min_idle_ms=1
+    ) == []
+
+
+async def test_reclaim_orphans_reraises_unrelated_response_error():
+    """Only 'unknown command' / XAUTOCLAIM ResponseErrors degrade — any OTHER ResponseError must
+    propagate (we don't want a real Redis fault silently swallowed as 'no orphans')."""
+    from redis.exceptions import ResponseError
+
+    from meeting_api.collector.adapters import RedisStreamBus
+
+    class _RedisBadReply:
+        async def xgroup_create(self, **kw):
+            return None
+
+        async def xautoclaim(self, **kw):
+            raise ResponseError("WRONGTYPE Operation against a key holding the wrong kind of value")
+
+    bus = RedisStreamBus(_RedisBadReply())
+    with pytest.raises(ResponseError):
+        await bus.reclaim_orphans(
+            group=CONSUMER_GROUP, stream=STREAM_NAME, consumer="c", min_idle_ms=1
+        )
+    assert bus._reclaim_unsupported is False, "an unrelated error must NOT flip the unsupported latch"

--- a/core/meetings/services/meeting-api/tests/test_single_flight.py
+++ b/core/meetings/services/meeting-api/tests/test_single_flight.py
@@ -7,13 +7,19 @@ ONE lock and one counter: the winner's body runs, the loser's does NOT (counter 
 the winner releases, a later tick by the loser DOES run (counter == 2). The negative control shows
 that calling the bodies directly (no guard) yields counter == 2 — the guard, not chance, halves it.
 
-Also asserts the disjoint-keyspace fork: the sweep lock key is the two-arg
-``(SWEEP_LOCK_CLASSID, crc32(loop_name))`` form, which cannot collide with the single-arg per-user
-``pg_advisory_xact_lock(:user_id)`` locks.
+Also asserts the disjoint-keyspace fork: the sweep lock key is a single 64-bit
+``(SWEEP_LOCK_CLASSID << 32) | crc32(loop_name)`` value taken via the **single-arg**
+``pg_try_advisory_lock(bigint)`` form — disjoint from the small per-user
+``pg_advisory_xact_lock(:user_id)`` locks. (The earlier two-arg ``(classid, objid)`` form was the
+#637 witness regression: crc32 overflowed signed int4 → bound as bigint → ``pg_try_advisory_lock(
+int4, bigint)`` doesn't exist.) The REAL SQL is now exercised too: a real-Postgres conformance test
+runs when ``MEETING_API_TEST_DATABASE_URL`` is set — the offline lane alone let that mismatch slip to
+the live witness.
 """
 from __future__ import annotations
 
 import asyncio
+import os
 
 import pytest
 
@@ -131,11 +137,93 @@ async def test_body_exception_releases_lock():
 
 
 def test_sweep_key_disjoint_from_user_locks():
-    """The two-arg (classid, objid) sweep key can't collide with single-arg per-user xact locks."""
-    # A fixed namespace classid pairs with every crc32(loop_name); the per-user locks are single-arg
-    # on user-id ints, a disjoint Postgres advisory-lock space.
+    """The 64-bit sweep key ((SWEEP_LOCK_CLASSID << 32) | crc32) can't collide with the small
+    per-user single-arg locks — the namespace lives in the high 32 bits, above any user-id."""
+    # Both use the single-arg pg_try/advisory_lock(bigint) space now; disjointness comes from the
+    # SWP\0 namespace in the high 32 bits (user-ids are small, high bits 0).
     assert isinstance(SWEEP_LOCK_CLASSID, int)
     keys = {name: sweep_lock_key(name) for name in
             ("db-writer", "webhook-drain", "stop-reconcile", "auto-join", "calendar-sync")}
     assert len(set(keys.values())) == len(keys), "each loop hashes to a distinct objid (no collision)"
     assert sweep_lock_key("calendar-sync") == sweep_lock_key("calendar-sync"), "stable per loop name"
+
+
+# ── #637 witness regression: the real advisory-lock contract (offline shape + real-PG conformance) ──
+
+INT8_MAX = 2**63 - 1
+
+
+def test_sweep_lock_key_is_valid_positive_int8():
+    """Every sweep key must be a POSITIVE signed int8 (Postgres ``bigint``). The old objid was
+    ``crc32(loop_name)`` alone — which overflows signed int4 for names whose hash exceeds 2**31, and
+    in the two-arg form bound as bigint → ``pg_try_advisory_lock(int4, bigint)`` (the witness bug).
+    Packing the namespace into the high 32 bits makes the key a well-formed bigint for every name."""
+    names = ["segment-consumer", "db-writer", "webhook-drain", "stop-reconcile", "auto-join",
+             "calendar-sync", "", "x" * 300, "é-loop-ÿ"]
+    keys = [sweep_lock_key(n) for n in names]
+    for n, k in zip(names, keys):
+        assert 0 < k <= INT8_MAX, f"sweep_lock_key({n!r}) = {k} is not a positive int8"
+        assert (k >> 32) == SWEEP_LOCK_CLASSID, f"{n!r}: namespace not in the high 32 bits"
+    assert len(set(keys)) == len(set(names)), "distinct loop names must map to distinct keys"
+
+
+async def test_pg_advisory_lock_issues_single_arg_bigint_sql():
+    """``PgAdvisoryLock`` must issue the SINGLE-arg ``pg_try_advisory_lock(cast(:key as bigint))`` —
+    NOT the two-arg ``(:cls, :obj)`` form that failed on real Postgres at the v0.12.5 witness.
+    Needs SQLAlchemy (the lock builds the statement with it); the offline lane lacks it, which is
+    part of why the two-arg form reached the live witness — so this runs wherever SQLAlchemy is."""
+    pytest.importorskip("sqlalchemy")
+    from meeting_api.sweeps.single_flight import PgAdvisoryLock
+
+    executed: list[str] = []
+
+    class _Result:
+        def scalar(self):
+            return True
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def execute(self, stmt, *a, **k):
+            executed.append(str(stmt))
+            return _Result()
+
+    lock = PgAdvisoryLock(lambda: _Session())
+    key = sweep_lock_key("calendar-sync")
+    assert await lock.try_lock(key) is True
+    await lock.unlock(key)
+    sql = " ".join(executed).lower()
+    assert "pg_try_advisory_lock(cast(:key as bigint))" in sql, f"not single-arg bigint: {sql}"
+    assert "pg_advisory_unlock(cast(:key as bigint))" in sql
+    assert ":cls" not in sql and ":obj" not in sql, "the two-arg (classid, objid) form must be gone"
+
+
+@pytest.mark.skipif(
+    not os.getenv("MEETING_API_TEST_DATABASE_URL"),
+    reason="real-Postgres conformance for the advisory lock; set MEETING_API_TEST_DATABASE_URL to run",
+)
+async def test_pg_advisory_lock_runs_on_real_postgres():
+    """Fake-conformance guard (the class the witness caught): run the ACTUAL advisory-lock SQL against
+    a REAL Postgres. ``FakeAdvisoryLock`` never executes it, so the ``(int4, bigint)`` mismatch was
+    invisible until a live meeting. Here ``try_lock`` executes the real ``pg_try_advisory_lock`` — the
+    witness bug would raise ``UndefinedFunctionError`` on this line — and contention/release behave."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from meeting_api.sweeps.single_flight import PgAdvisoryLock
+
+    engine = create_async_engine(os.environ["MEETING_API_TEST_DATABASE_URL"])
+    try:
+        sf = async_sessionmaker(engine, expire_on_commit=False)
+        holder, contender = PgAdvisoryLock(sf), PgAdvisoryLock(sf)
+        key = sweep_lock_key("calendar-sync")
+        assert await holder.try_lock(key) is True       # runs the real SQL (bug would raise here)
+        assert await contender.try_lock(key) is False    # contended: session-level lock is held
+        await holder.unlock(key)
+        assert await contender.try_lock(key) is True     # released -> now acquirable
+        await contender.unlock(key)
+    finally:
+        await engine.dispose()

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -55,6 +55,18 @@ count) alongside `pipeline.consumer_lag`, and degrades to `503` once it exceeds
 `PIPELINE_PENDING_ALARM` (default `100`) — a stuck batch is a reportable state, not a silent
 stall.
 
+<Warning>
+**Orphan reclaim requires Redis 6.2 or newer** — `XAUTOCLAIM` does not exist before it. On an
+older Redis the reclaim disables itself and logs once at startup; everything else (normal
+`XREADGROUP` consumption, per-pod identity, `pending_depth`) is unaffected. The cost is narrow but
+real: if a replica dies mid-batch, that batch stays pending instead of being drained by a peer, so
+run a single replica on Redis < 6.2 or upgrade Redis. Check yours with `redis-server --version`.
+
+This bites Vexa Lite in particular: its bundled Redis is **6.0.16**, so a Lite box never reclaims.
+Lite runs one meeting-api, so nothing is lost — but do not read the paragraph above as a guarantee
+that holds on every backing store.
+</Warning>
+
 ## In-cluster self-addressing
 
 Under Helm the meeting-api Service is release-qualified (`<release>-vexa-meeting-api`),


### PR DESCRIPTION
The **v0.12.5 release witness** caught two real regressions from the reliability batch — both were **green in CI**, both **crash-loop on real infrastructure**. This is the value-witness law working: fakes outran production.

## The bugs

**#636 — no transcription on Redis < 6.2.** `reclaim_orphans` called `XAUTOCLAIM` unconditionally (added in Redis 6.2), but the **Lite image bundles Redis 6.0.16**. Every segment-consumer tick raised `unknown command 'XAUTOCLAIM'` and the consumer died → segments never consumed → **no transcription.** The unit test used **fakeredis**, which *has* XAUTOCLAIM, so it passed.
→ Now degrades to a **no-op** (logged once) when XAUTOCLAIM is unsupported; the normal `XREADGROUP` consume path is untouched. Unrelated `ResponseError`s still propagate.

**#637 — sweeps crash on ALL real Postgres.** The guard used two-arg `pg_try_advisory_lock(classid, objid)`; `crc32(objid)` overflows signed int4, so asyncpg binds it as bigint → `pg_try_advisory_lock(int4, bigint)`, a signature Postgres doesn't have → `auto-join`/`calendar-sync`/`stop-reconcile` crashed every tick. The unit test used a **FakeAdvisoryLock**, so the real SQL was never run.
→ Now a single 64-bit key `((SWEEP_LOCK_CLASSID<<32)|crc32)` via the single-arg `pg_try_advisory_lock(bigint)` form.

## The gap this closes (so L5 isn't the safety net)

Both tests used **fakes more capable than the shipped backends**. Added guards that catch this class below the human witness:
- `test_reclaim_orphans_degrades_when_xautoclaim_unsupported` + an over-swallow control
- `test_sweep_lock_key_is_valid_positive_int8`, `test_pg_advisory_lock_issues_single_arg_bigint_sql`
- `test_pg_advisory_lock_runs_on_real_postgres` — **real-Postgres conformance**, runs when `MEETING_API_TEST_DATABASE_URL` is set (the fake never executed the SQL that broke)

## Verified

Full meeting-api suite green (685 passed). **Patched onto the v0.12.5 witness box and restarted meeting-api → 0 XAUTOCLAIM / advisory-lock errors, 0 tick-failures** (the crash-loop is gone).

Refs #636 #637 — blocks the v0.12.5 promote; re-cut as v0.12.6 after merge.
