### PR TITLE
fix(lite): an empty env flag must not silently disable transcription (#650) + unbreak `make up` (#651) — v0.12.5 witness regressions

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
@@ -70,10 +70,16 @@ def due_rows(rows: list[dict], *, now: datetime,
 
 def _production_transcribe_gate() -> Optional[str]:
     """Mirror POST /bots' CC4 fail-loud STT gate: when transcription resolves ON (env default) but
-    the ``stt`` capability is not configured, refuse the auto-spawn with the reason string."""
-    from ..config_preflight import CONFIGURED, capability_state, missing_capability_keys
+    the ``stt`` capability is not configured, refuse the auto-spawn with the reason string.
 
-    if os.getenv("TRANSCRIBE_ENABLED", "true").lower() != "true":
+    Read through ``env_flag`` for the same reason as router.py: with a bare ``os.getenv`` a
+    set-but-empty ``TRANSCRIBE_ENABLED=`` made ``"" != "true"`` true, so this gate returned None and
+    refused nothing — the empty value both disabled transcription AND disarmed the alarm meant to
+    catch it. That double failure is why the v0.12.5 witness saw silence with no error."""
+    from ..config_preflight import CONFIGURED, capability_state, missing_capability_keys
+    from .env_flags import env_flag
+
+    if not env_flag("TRANSCRIBE_ENABLED", True):
         return None
     state = capability_state("stt")
     if state != CONFIGURED:

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/env_flags.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/env_flags.py
@@ -1,0 +1,50 @@
+"""Boolean env flags that survive a set-but-empty value.
+
+``os.getenv("TRANSCRIBE_ENABLED", "true")`` only falls back to the default when the key is
+ABSENT. An env-file line with no value — ``TRANSCRIBE_ENABLED=``, which ``.env.example`` ships and
+``docker run --env-file`` passes through verbatim — resolves to ``""``, and ``"" == "true"`` is
+False. The default silently inverts.
+
+That is not academic: it is the v0.12.5 release-witness failure. Lite's ``make up`` runs
+``docker run --env-file $(ENV_FILE)`` and does not ``-e``-override these keys, so every Lite
+self-host seeded from ``.env.example`` spawned capture-only bots — a bot that joins, behaves
+normally, and transcribes nothing, with no error anywhere. Compose is accidentally immune because
+``${TRANSCRIBE_ENABLED:-true}`` treats empty as unset; Lite has no such rescue.
+
+config.v1 (``when_unconfigured``) states the contract these flags must keep: *bots must opt out
+explicitly* to spawn capture-only. An empty string is not an explicit opt-out, and neither is a
+typo — so only a recognized false value opts out. Anything unrecognized keeps the default and warns
+rather than silently disabling the product's core value.
+"""
+
+import logging
+import os
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+_TRUE = ("true", "1", "yes", "on")
+_FALSE = ("false", "0", "no", "off")
+
+
+def env_flag(name: str, default: bool = True, raw: Optional[str] = None) -> bool:
+    """Resolve ``name`` as a boolean, treating unset and set-but-empty alike.
+
+    ``raw`` is an injection seam for tests; production passes ``None`` and reads the environment.
+    Vocabulary matches the request-body parsers in ``router.py`` so ``TRANSCRIBE_ENABLED=1`` and
+    ``transcribe_enabled: "1"`` cannot disagree.
+    """
+    value = os.getenv(name) if raw is None else raw
+    if value is None or not value.strip():
+        return default
+    v = value.strip().lower()
+    if v in _TRUE:
+        return True
+    if v in _FALSE:
+        return False
+    log.warning(
+        "%s=%r is not a recognized boolean (%s / %s) — keeping the default %s. "
+        "An unrecognized value is not an explicit opt-out.",
+        name, value, "/".join(_TRUE), "/".join(_FALSE), default,
+    )
+    return default

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from .env_flags import env_flag
 from .ports import MaxBotsExceeded, MeetingRepo, QuotaExceeded, RuntimeClient, SpawnFailed, TranscriptionNotConfigured
 from .service import DuplicateMeeting, construct_meeting_url, request_bot
 
@@ -28,9 +29,12 @@ def _resolve_recording_enabled(value: Optional[object]) -> bool:
     """Recording default: an explicit request value wins; else the ``RECORDING_ENABLED`` env
     (default ``true``), so a dashboard bot records by default. The request value is type-validated —
     a bool is honored, a string is parsed (``"true"``/``"false"`` etc.), and any other type is a 422
-    (NOT silently ``bool()``-coerced, which would turn the string ``"false"`` into ``True``)."""
+    (NOT silently ``bool()``-coerced, which would turn the string ``"false"`` into ``True``).
+
+    The env is read through ``env_flag``, so a set-but-empty ``RECORDING_ENABLED=`` keeps the
+    default instead of resolving False (see env_flags — the v0.12.5 witness bug)."""
     if value is None:
-        return os.getenv("RECORDING_ENABLED", "true").lower() == "true"
+        return env_flag("RECORDING_ENABLED", True)
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -45,9 +49,12 @@ def _resolve_recording_enabled(value: Optional[object]) -> bool:
 def _resolve_transcribe_enabled(value: Optional[object]) -> bool:
     """Transcription default: an explicit request value wins; else the ``TRANSCRIBE_ENABLED`` env
     (default ``true``). Type-validated like ``recording_enabled`` (CC3) — a bare ``bool(...)`` turned the
-    JSON string ``"false"`` into ``True``, silently ENABLING transcription a caller asked to disable."""
+    JSON string ``"false"`` into ``True``, silently ENABLING transcription a caller asked to disable.
+
+    The env is read through ``env_flag``: a set-but-empty ``TRANSCRIBE_ENABLED=`` kept the default
+    OFF and shipped capture-only bots to every Lite self-host (the v0.12.5 witness bug)."""
     if value is None:
-        return os.getenv("TRANSCRIBE_ENABLED", "true").lower() == "true"
+        return env_flag("TRANSCRIBE_ENABLED", True)
     if isinstance(value, bool):
         return value
     if isinstance(value, str):

--- a/core/meetings/services/meeting-api/tests/test_env_flags.py
+++ b/core/meetings/services/meeting-api/tests/test_env_flags.py
@@ -1,0 +1,135 @@
+"""env_flags — a SET-BUT-EMPTY boolean env must not invert its default.
+
+The v0.12.5 release witness: a bot joined a real Google Meet, behaved normally, and transcribed
+nothing, with no error. Cause: ``.env.example`` ships ``TRANSCRIBE_ENABLED=`` and Lite's ``make up``
+runs ``docker run --env-file``, which passes the key through SET and EMPTY. ``os.getenv(k, "true")``
+only defaults when the key is ABSENT, so it returned ``""`` — and ``"" == "true"`` is False. The
+default inverted, the bot spawned capture-only, and the fail-loud STT gate (which tested the same
+expression) also read empty as an explicit opt-out and refused nothing.
+
+Every rung below L5 missed it because no test ever set the env to empty — the fakes and the unit
+tests only ever exercised the REQUEST value. These are that missing rung.
+"""
+from __future__ import annotations
+
+import pytest
+
+from meeting_api.bot_spawn.env_flags import env_flag
+
+
+class TestEmptyIsNotOptOut:
+    """The witness bug, pinned. `raw` is the injection seam; env parity is covered below."""
+
+    @pytest.mark.parametrize("raw", ["", " ", "\t", "\n", "   "])
+    def test_set_but_empty_keeps_default_true(self, raw):
+        assert env_flag("ANY", True, raw=raw) is True
+
+    @pytest.mark.parametrize("raw", ["", " ", "\t"])
+    def test_set_but_empty_keeps_default_false(self, raw):
+        assert env_flag("ANY", False, raw=raw) is False
+
+    def test_unset_keeps_default(self, monkeypatch):
+        monkeypatch.delenv("VEXA_TEST_FLAG", raising=False)
+        assert env_flag("VEXA_TEST_FLAG", True) is True
+        assert env_flag("VEXA_TEST_FLAG", False) is False
+
+    def test_empty_env_reads_as_default_not_false(self, monkeypatch):
+        """The exact production shape: `docker run --env-file` with `TRANSCRIBE_ENABLED=`."""
+        monkeypatch.setenv("TRANSCRIBE_ENABLED", "")
+        assert env_flag("TRANSCRIBE_ENABLED", True) is True
+
+    def test_the_old_expression_would_have_failed_this(self, monkeypatch):
+        """Negative control: pin the defect so a revert to `os.getenv(k, "true")` re-reddens.
+
+        If this ever passes, the empty-string hole is back.
+        """
+        import os
+
+        monkeypatch.setenv("TRANSCRIBE_ENABLED", "")
+        old_result = os.getenv("TRANSCRIBE_ENABLED", "true").lower() == "true"
+        assert old_result is False, "the old expression is what shipped the bug"
+        assert env_flag("TRANSCRIBE_ENABLED", True) is not old_result
+
+
+class TestVocabulary:
+    @pytest.mark.parametrize("raw", ["true", "TRUE", "True", " true ", "1", "yes", "on", "ON"])
+    def test_truthy(self, raw):
+        assert env_flag("ANY", False, raw=raw) is True
+
+    @pytest.mark.parametrize("raw", ["false", "FALSE", "False", " false ", "0", "no", "off"])
+    def test_falsey(self, raw):
+        assert env_flag("ANY", True, raw=raw) is False
+
+    @pytest.mark.parametrize("raw", ["maybe", "tru", "enabled", "#", "null"])
+    def test_unrecognized_keeps_default_and_never_silently_opts_out(self, raw):
+        """config.v1: opt-out must be EXPLICIT. A typo is not an opt-out — it must not disable
+        transcription, which is exactly the silent-failure class this module exists to kill."""
+        assert env_flag("ANY", True, raw=raw) is True
+        assert env_flag("ANY", False, raw=raw) is False
+
+    def test_unrecognized_warns(self, caplog):
+        with caplog.at_level("WARNING"):
+            env_flag("TRANSCRIBE_ENABLED", True, raw="maybe")
+        assert "not a recognized boolean" in caplog.text
+        assert "TRANSCRIBE_ENABLED" in caplog.text
+
+
+class TestSpawnFlagCallSites:
+    """The three shipped readers resolve ON when the env is empty — end of the witness bug."""
+
+    @pytest.mark.parametrize("key", ["TRANSCRIBE_ENABLED", "RECORDING_ENABLED"])
+    def test_router_resolvers_default_on_when_env_empty(self, monkeypatch, key):
+        from meeting_api.bot_spawn.router import (
+            _resolve_recording_enabled,
+            _resolve_transcribe_enabled,
+        )
+
+        monkeypatch.setenv(key, "")
+        resolve = (
+            _resolve_transcribe_enabled if key == "TRANSCRIBE_ENABLED" else _resolve_recording_enabled
+        )
+        assert resolve(None) is True, f"{key}= (empty) must not disable the spawn default"
+
+    @pytest.mark.parametrize("key", ["TRANSCRIBE_ENABLED", "RECORDING_ENABLED"])
+    def test_explicit_false_env_still_opts_out(self, monkeypatch, key):
+        from meeting_api.bot_spawn.router import (
+            _resolve_recording_enabled,
+            _resolve_transcribe_enabled,
+        )
+
+        monkeypatch.setenv(key, "false")
+        resolve = (
+            _resolve_transcribe_enabled if key == "TRANSCRIBE_ENABLED" else _resolve_recording_enabled
+        )
+        assert resolve(None) is False, "an explicit opt-out must still work"
+
+    def test_request_value_still_wins_over_env(self, monkeypatch):
+        from meeting_api.bot_spawn.router import _resolve_transcribe_enabled
+
+        monkeypatch.setenv("TRANSCRIBE_ENABLED", "false")
+        assert _resolve_transcribe_enabled(True) is True
+        monkeypatch.setenv("TRANSCRIBE_ENABLED", "true")
+        assert _resolve_transcribe_enabled(False) is False
+
+    def test_empty_env_no_longer_disarms_the_fail_loud_stt_gate(self, monkeypatch):
+        """The second half of the witness bug: `"" != "true"` made the gate return None, so the
+        503 designed to catch an unconfigured STT never fired. Empty must now reach the gate."""
+        from meeting_api.bot_spawn import auto_join
+
+        monkeypatch.setenv("TRANSCRIBE_ENABLED", "")
+        monkeypatch.setattr(auto_join, "__name__", auto_join.__name__)
+
+        called = {"n": 0}
+
+        def _fake_state(_cap):
+            called["n"] += 1
+            return "unset"
+
+        import meeting_api.config_preflight as cp
+
+        monkeypatch.setattr(cp, "capability_state", _fake_state)
+        monkeypatch.setattr(cp, "missing_capability_keys", lambda _c: ["TRANSCRIPTION_SERVICE_URL"])
+
+        reason = auto_join._production_transcribe_gate()
+        assert called["n"] == 1, "empty env must NOT short-circuit the gate"
+        assert reason is not None and "STT not configured" in reason

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -5,13 +5,21 @@
 # =============================================================================
 
 # --- project + host ports ----------------------------------------------------
+# NOTE: keep comments on their OWN line, never trailing a value. This file is consumed by
+# `docker run --env-file` (deploy/lite), whose parser does NOT strip an inline comment — it becomes
+# part of the value. A trailing comment here once made Lite's `docker run` word-split a bare `#`
+# into the image slot ("docker: invalid reference format"), and shipped commented-out ports as
+# literal values.
 COMPOSE_PROJECT_NAME=vexa-v012
-API_GATEWAY_HOST_PORT=18056      # API gateway (all docs/SDK calls target this)
-ADMIN_API_PORT=18057             # admin-api (mint API keys)
+# API gateway (all docs/SDK calls target this)
+API_GATEWAY_HOST_PORT=18056
+# admin-api (mint API keys)
+ADMIN_API_PORT=18057
 MEETING_API_PORT=18080
 RUNTIME_API_PORT=18090
 AGENT_API_PORT=18100
-TERMINAL_PORT=13000              # the terminal workbench UI → http://localhost:13000
+# the terminal workbench UI → http://localhost:13000
+TERMINAL_PORT=13000
 POSTGRES_HOST_PORT=5458
 MINIO_HOST_PORT=9000
 MINIO_CONSOLE_HOST_PORT=9001
@@ -41,7 +49,8 @@ MINIO_ENDPOINT=minio:9000
 MINIO_SECURE=false
 
 # --- stack secrets (CHANGE for any non-local deploy) -------------------------
-ADMIN_TOKEN=dev-admin-token                         # admin-api auth; `make all` mints your API key with this
+# admin-api auth; `make all` mints your API key with this
+ADMIN_TOKEN=dev-admin-token
 INTERNAL_API_SECRET=vexa-internal-secret
 VEXA_DISPATCH_SIGNING_KEY=dev-dispatch-signing-key
 NEXTAUTH_SECRET=dev-nextauth-secret
@@ -56,7 +65,8 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=
-MICROSOFT_TENANT_ID=common                          # "common" = work/school + personal; or an org tenant id
+# "common" = work/school + personal; or an org tenant id
+MICROSOFT_TENANT_ID=common
 
 # Google Analytics 4 (terminal web usage). Set to your measurement id (G-XXXXXXXXXX) to turn on
 # frontend analytics — page views + an `api_request` event per web-client API call. Baked into the
@@ -73,7 +83,9 @@ TRANSCRIPTION_SERVICE_URL=
 TRANSCRIPTION_SERVICE_TOKEN=
 # Deployment-level defaults for a spawn's flags when the request does not say (config.v1 `defaulted`).
 # TRANSCRIBE_ENABLED=false makes a no-STT deployment spawn capture-only bots instead of 503-ing every
-# default POST /bots. Both default true.
+# default POST /bots. Both default true — and LEFT EMPTY BELOW STILL MEANS true: only an explicit
+# false/0/no/off opts out. (Empty used to resolve False on the `--env-file` path, silently shipping
+# capture-only bots that transcribed nothing with no error — the v0.12.5 witness bug.)
 TRANSCRIBE_ENABLED=
 RECORDING_ENABLED=
 BOT_SPEAKER_MIN_AUDIO_SEC=

--- a/deploy/lite/Makefile
+++ b/deploy/lite/Makefile
@@ -99,13 +99,25 @@ preflight:
 ## point HOST_CLAUDE_CREDENTIALS at the IN-CONTAINER path — in LITE the process backend reads the
 ## file directly. (Compose is the opposite: there the var is a docker-HOST path the compose file
 ## mounts. Don't copy the semantics across.)
+##
+## `envv` strips an INLINE COMMENT and trailing space from a .env value. `.env.example` once shipped
+## `ADMIN_TOKEN=dev-admin-token   # admin-api auth…`; a bare `cut -d= -f2-` kept the comment, and the
+## unquoted `-e ADMIN_API_TOKEN=$ADMIN_TK` then word-split it so a lone `#` landed in the IMAGE slot
+## — `docker: invalid reference format`, the v0.12.5 witness's finding #3. Values interpolated into
+## `docker run` are QUOTED for the same reason. `$$CLAUDE_MOUNT` is the deliberate exception: it
+## carries multiple argv words and MUST stay unquoted — do not "fix" it.
+##
+## Note this recipe does NOT `-e` the spawn-default flags (TRANSCRIBE_ENABLED/RECORDING_ENABLED);
+## they ride `--env-file`, where an empty value must keep the default. That is enforced in code
+## (bot_spawn/env_flags.py), not here — compose's `${VAR:-true}` has no `--env-file` equivalent.
 up: preflight
 	@set -e; \
 	docker network inspect $(NETWORK) >/dev/null 2>&1 || docker network create $(NETWORK) >/dev/null; \
-	ADMIN_TK=$$(grep -E '^ADMIN_TOKEN=' $(ENV_FILE) 2>/dev/null | cut -d= -f2-); ADMIN_TK=$${ADMIN_TK:-changeme}; \
-	TX_URL=$$(grep -E '^TRANSCRIPTION_SERVICE_URL=' $(ENV_FILE) 2>/dev/null | cut -d= -f2-); \
-	TX_TOKEN=$$(grep -E '^TRANSCRIPTION_SERVICE_TOKEN=' $(ENV_FILE) 2>/dev/null | cut -d= -f2-); \
-	IMAGE_TAG=$$(grep -E '^IMAGE_TAG=' $(ENV_FILE) 2>/dev/null | cut -d= -f2-); IMAGE_TAG=$${IMAGE_TAG:-v012}; \
+	envv() { grep -E "^$$1=" $(ENV_FILE) 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$$//; s/[[:space:]]+$$//'; }; \
+	ADMIN_TK=$$(envv ADMIN_TOKEN); ADMIN_TK=$${ADMIN_TK:-changeme}; \
+	TX_URL=$$(envv TRANSCRIPTION_SERVICE_URL); \
+	TX_TOKEN=$$(envv TRANSCRIPTION_SERVICE_TOKEN); \
+	IMAGE_TAG=$$(envv IMAGE_TAG); IMAGE_TAG=$${IMAGE_TAG:-v012}; \
 	IMG=$$(docker image inspect $(LOCAL_TAG) >/dev/null 2>&1 && echo $(LOCAL_TAG) || echo $(DOCKERHUB_USER)/$(IMAGE_NAME):$$IMAGE_TAG); \
 	CLAUDE_CREDS="$$HOME/.claude/.credentials.json"; \
 	if [ -f "$$CLAUDE_CREDS" ]; then \
@@ -155,14 +167,14 @@ up: preflight
 		--env-file $(ENV_FILE) \
 		-p $(HOST_GATEWAY_PORT):8056 -p $(HOST_TERMINAL_PORT):3001 -p $(HOST_AGENT_PORT):8100 \
 		-e DB_HOST=$(PG_CONTAINER) -e DB_PORT=5432 -e DB_NAME=vexa -e DB_USER=postgres -e DB_PASSWORD=postgres \
-		-e ADMIN_API_TOKEN=$$ADMIN_TK -e ADMIN_TOKEN=$$ADMIN_TK \
-		-e TRANSCRIPTION_SERVICE_URL=$$TX_URL -e TRANSCRIPTION_SERVICE_TOKEN=$$TX_TOKEN \
+		-e ADMIN_API_TOKEN="$$ADMIN_TK" -e ADMIN_TOKEN="$$ADMIN_TK" \
+		-e TRANSCRIPTION_SERVICE_URL="$$TX_URL" -e TRANSCRIPTION_SERVICE_TOKEN="$$TX_TOKEN" \
 		-e MINIO_ENDPOINT=$(MINIO_CONTAINER):9000 -e MINIO_ACCESS_KEY=$(MINIO_ACCESS_KEY) \
 		-e MINIO_SECRET_KEY=$(MINIO_SECRET_KEY) -e MINIO_BUCKET=$(MINIO_BUCKET) -e MINIO_SECURE=false \
 		-e VEXA_PUBLIC_API_URL=http://localhost:$(HOST_GATEWAY_PORT) \
 		-e TERMINAL_PUBLIC_URL=http://localhost:$(HOST_TERMINAL_PORT) \
 		$$CLAUDE_MOUNT \
-		$$IMG > /dev/null; \
+		"$$IMG" > /dev/null; \
 	echo "  Waiting for the gateway (up to 3 min)..."; \
 	for i in $$(seq 1 36); do curl -sf -o /dev/null http://localhost:$(HOST_GATEWAY_PORT)/health 2>/dev/null && break; sleep 5; done; \
 	echo "  ✓ Vexa Lite running"

--- a/deploy/lite/tests/test_env_file_hygiene.py
+++ b/deploy/lite/tests/test_env_file_hygiene.py
@@ -1,0 +1,96 @@
+"""`.env.example` must be a VALID `docker run --env-file`, and Lite's `up` must not splat it.
+
+Two shipped defects, both found by the v0.12.5 release witness and neither caught by any rung below
+it:
+
+1. `docker run --env-file` does NOT strip an inline comment — `FOO=bar  # why` yields the literal
+   value `"bar  # why"`. `.env.example` carried five such lines, so a Lite box booted with
+   commented-out ports as values.
+2. Lite's `up` recipe read `ADMIN_TOKEN` with `cut -d= -f2-` (comment included) and interpolated it
+   UNQUOTED into `docker run -e ADMIN_API_TOKEN=$ADMIN_TK`. /bin/sh word-split it, a bare `#` landed
+   in the image slot, and `make -C deploy/lite up` died with `docker: invalid reference format`.
+   That is what forced the witness box to be hand-built, which is what exposed defect (1) of
+   env_flags and cost the release a cycle.
+"""
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+ENV_EXAMPLE = ROOT / "deploy" / "compose" / ".env.example"
+LITE_MAKEFILE = ROOT / "deploy" / "lite" / "Makefile"
+
+# KEY=value followed by whitespace then a `#`. Docker keeps the comment as part of the value.
+INLINE_COMMENT = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(?!\s*$).*?\s+#")
+
+
+def _env_lines(path: Path):
+    for i, line in enumerate(path.read_text().splitlines(), 1):
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        yield i, line
+
+
+def test_env_example_has_no_inline_comments():
+    offenders = [
+        f"{ENV_EXAMPLE.name}:{i}: {line}"
+        for i, line in _env_lines(ENV_EXAMPLE)
+        if INLINE_COMMENT.match(line)
+    ]
+    assert not offenders, (
+        "docker's --env-file parser keeps an inline comment as part of the value. "
+        "Put the comment on its own line above the key.\n" + "\n".join(offenders)
+    )
+
+
+def test_env_example_values_round_trip_through_a_shell_word_split():
+    """Every value must survive unquoted expansion as a single argv word.
+
+    This is the actual failure: `-e K=$V` under /bin/sh. If a value word-splits, extra argv words
+    reach `docker run` and the first bare one is taken as the IMAGE.
+    """
+    bad = []
+    for i, line in _env_lines(ENV_EXAMPLE):
+        key, _, value = line.partition("=")
+        if not value:
+            continue
+        words = shlex.split(f"K={value}", posix=True) if "'" not in value and '"' not in value else ["ok"]
+        if len(words) > 1:
+            bad.append(f"{ENV_EXAMPLE.name}:{i}: {key} splits into {len(words)} argv words: {words}")
+    assert not bad, "\n".join(bad)
+
+
+def test_lite_up_strips_inline_comments_and_quotes_interpolations():
+    mk = LITE_MAKEFILE.read_text()
+    assert "envv()" in mk, "the `up` recipe must read .env through the comment-stripping `envv` helper"
+    assert "s/[[:space:]]+#.*$$//" in mk, "`envv` must strip inline comments"
+    for var in ("$$ADMIN_TK", "$$TX_URL", "$$TX_TOKEN", "$$IMG"):
+        assert f'"{var}"' in mk, f"{var} must be QUOTED where it reaches docker run (word-split → bad image ref)"
+    # CLAUDE_MOUNT is the deliberate exception: it carries multiple argv words.
+    assert '"$$CLAUDE_MOUNT"' not in mk, "CLAUDE_MOUNT must stay unquoted — it is multiple argv words by design"
+
+
+@pytest.mark.skipif(not (ROOT / "deploy" / "compose" / ".env.example").exists(), reason="no env example")
+def test_admin_token_from_env_example_yields_one_argv_word():
+    """End-to-end repro of the shipped bug, in the shell make actually uses.
+
+    Before the fix this produced argv `[... , '#', 'admin-api', ...]` and `docker: invalid
+    reference format`.
+    """
+    script = r"""
+        envv() { grep -E "^$1=" "$2" | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//'; }
+        ADMIN_TK=$(envv ADMIN_TOKEN "$3")
+        n=0; for w in -e ADMIN_API_TOKEN="$ADMIN_TK" IMAGE; do n=$((n+1)); done
+        echo $n
+    """
+    out = subprocess.run(
+        ["/bin/sh", "-c", script, "sh", "ADMIN_TOKEN", str(ENV_EXAMPLE), str(ENV_EXAMPLE)],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert out == "3", f"expected argv [-e, ADMIN_API_TOKEN=…, IMAGE] = 3 words, got {out}"

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -19,6 +19,8 @@ are public.
 |---|---|---|
 | `TRANSCRIPTION_SERVICE_URL` | — | STT service **base URL** (the client appends `/v1/audio/transcriptions`), e.g. `http://<gpu-host>:8083`. Point it at the bundled service you deploy separately (`deploy/transcription`) or a hosted endpoint. Unset → bots join and record but produce no transcript. |
 | `TRANSCRIPTION_SERVICE_TOKEN` | — | STT auth token — must match the `API_TOKEN` of your `deploy/transcription` unit, or a token from `vexa.ai/account`. |
+| `TRANSCRIBE_ENABLED` | `true` | Deployment-level default for a spawn's transcription when `POST /bots` does not say. Set `false` for a deliberately no-STT deployment: bots spawn **capture-only** instead of answering 503. Leaving it **empty means `true`** — only an explicit `false`/`0`/`no`/`off` opts out. |
+| `RECORDING_ENABLED` | `true` | Deployment-level default for a spawn's recording when `POST /bots` does not say. Same empty-means-default rule as above. |
 | `BOT_SPEAKER_MIN_AUDIO_SEC` | `2` | Google Meet minimum audio window before submitting to STT. Lower values reduce first-transcript latency but increase request frequency. |
 | `BOT_SPEAKER_SUBMIT_INTERVAL_SEC` | `2` | Google Meet speaker-stream submission interval. |
 | `BOT_SPEAKER_CONFIRM_THRESHOLD` | `2` | Consecutive matching STT results required to confirm a segment. `1` lowers latency but reduces LocalAgreement protection against corrections. |
@@ -28,6 +30,13 @@ are public.
 The STT service is the **GPU workload, deployed separately** from this stack — see
 [Deployment → Transcription](/deployment#transcription-the-separate-gpu-unit). The main stack
 stays GPU-free and reaches it over the network via the two variables above.
+
+<Warning>
+**Never put a comment on the same line as a value in `.env`.** Write it on its own line above the
+key. Compose tolerates a trailing `# comment`, but `docker run --env-file` (which Vexa Lite uses)
+does **not** strip it — the comment becomes part of the value, so `TERMINAL_PORT=13000  # the UI`
+sets the port to the literal string `13000  # the UI`.
+</Warning>
 
 ## Secrets & identity
 

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -70,8 +70,17 @@ usual causes:
 
 ## Bot joins but there's no transcript
 
-The bot is capturing audio, but transcription isn't configured.
+The bot is capturing audio, but transcription isn't configured — or the bot was spawned
+**capture-only**, which looks identical from the outside.
 
+- **First, check whether the bot was spawned capture-only.** `GET /bots` (or `GET /meetings/{id}`)
+  reports the resolved flag: `data.transcribe_enabled: false` means the bot was never asked to
+  transcribe, so no STT request was ever made and no error will appear anywhere. If it is `false`
+  and you did not intend that, an explicit `{"transcribe_enabled": true}` on `POST /bots` overrides
+  the deployment default and confirms the diagnosis in one call.
+- Confirm `TRANSCRIBE_ENABLED` is not set to a false value in your `.env`. An **empty**
+  `TRANSCRIBE_ENABLED=` means `true` (the default) — but a trailing comment on that line does not:
+  `docker run --env-file` keeps the comment as part of the value. Keep comments on their own line.
 - Confirm `TRANSCRIPTION_SERVICE_URL` and `TRANSCRIPTION_SERVICE_TOKEN` are set (see
   [Configuration](/configuration#transcription-stt)). Unset → audio is recorded, no text is produced.
 - Segments arrive draft-first (`completed: false`) then confirmed (`completed: true`) — a short delay is


### PR DESCRIPTION
Closes #650. Closes #651.

## The value

**A Lite self-host currently transcribes nothing, and never says why.** Both defects are in the published `vexaai/vexa-lite:v0.12.5` artifact (the running container's `router.py` is md5-identical to the pristine image), and every self-host seeded from the shipped `.env.example` is exposed. This is the product's core value silently not happening — the strongest possible reason to fix before v0.12.6.

Live-witnessed: a bot joined a real Google Meet, was admitted, behaved normally, transcribed nothing, and raised **no error anywhere**. It blocked the release and was initially misdiagnosed as a phantom audio-capture bug.

## What was actually wrong

**#650 — an empty value is not an opt-out.** `os.getenv(k, "true")` only defaults when the key is *absent*. `.env.example:77` ships `TRANSCRIBE_ENABLED=`; Lite's `up` runs `docker run --env-file`, which passes it **set and empty**; `"" == "true"` is False, so the default inverts and the bot spawns capture-only. Compose is *accidentally* immune (`${VAR:-true}` covers empty) — which is exactly why compose-run witnesses passed and this shipped. `RECORDING_ENABLED` has the identical defect.

**The same expression guarded the alarm.** `auto_join.py:76` used `!= "true"`, so empty **both** disabled transcription **and** disarmed the fail-loud 503 designed to catch an unconfigured STT. `config.v1.json:410` states the contract this broke: *bots must opt out **explicitly***. An empty string isn't explicit; neither is a typo.

**#651 — `make -C deploy/lite up` → `docker: invalid reference format`.** `.env.example:44` had a trailing `# comment`; `--env-file` keeps it in the value; the recipe's unquoted `-e ADMIN_API_TOKEN=$ADMIN_TK` let `/bin/sh` word-split a bare `#` into the image slot. This is the *upstream* cause — it forced the witness box to be hand-built, which is how #650 stayed hidden. (It doesn't reproduce in zsh, which doesn't word-split unquoted expansions — likely why it passed review.)

## Proof

Capture was never broken. The failed bot's own log:

```
[PerSpeaker] stream 1 AUDIO seen=270 emitted=200 max=0.742
[PerSpeaker] capture started with 3 stream(s)
```

Controlled experiment — same box, same image, same whisper, only the flag differs:

| spawn | whisper requests | segments |
|---|---|---|
| `transcribe_enabled: false` (empty-env default) | 0 | 0 |
| `transcribe_enabled: true` (explicit override) | 60+ | **11**, correct speaker attribution |

`make up` bug reproduced under `/bin/sh`: `argv[8]=[#]` → `docker: invalid reference format`.

## The fix

- New `bot_spawn/env_flags.py`: unset and set-but-empty resolve alike; only an explicit `false/0/no/off` opts out; an unrecognized value keeps the default **and warns**. Vocabulary matches the request-body parsers so env and request can't disagree.
- All three readers go through it (`_resolve_transcribe_enabled`, `_resolve_recording_enabled`, `_production_transcribe_gate`).
- `deploy/lite/Makefile`: `envv` strips inline comments; interpolated values are quoted. `$$CLAUDE_MOUNT` stays unquoted **by design** (multiple argv words) and is annotated so nobody "fixes" it.
- `.env.example`: comments moved to their own lines; the empty-means-`true` rule stated where operators read it.
- Docs: both flags documented for the first time (`configuration.mdx`), plus the real diagnostic path in `troubleshooting.mdx` (`data.transcribe_enabled: false` is how a user tells capture-only from broken) and a warning about inline comments in `.env`.

## The rung below L5 that didn't exist

Every automated rung passed because **no test ever set these vars to empty** — the units only exercised the *request* value, and the one guard that would have fired tested the same broken expression.

42 new tests, both suites **negative-controlled** — they fail on the pre-fix tree:
- pre-fix `router.py`/`auto_join.py`: 3 fail, including the gate test asserting `0 == 1` (it was never called).
- pre-fix `.env.example`: `ADMIN_TOKEN splits into 12 argv words: ['K=dev-admin-token', '#', 'admin-api', ...]`.
- `test_the_old_expression_would_have_failed_this` pins the defect itself, so a revert re-reddens.

meeting-api suite green (690 passed). The 31 `test_calendar_sync` failures are a pre-existing local `icalendar` gap — identical on pristine `main` with this branch stashed, and `gate:python` is green.