### PR TITLE
fix(release): the witness batch is bounded by the last release that SHIPPED, not the last tag

### DIFF
--- a/releases/README.md
+++ b/releases/README.md
@@ -34,6 +34,18 @@ Release happens before the witness pass is signed.
    downgrade an over-marked user-visible entry to `by-proxy` (with its evidence) or walk it — either
    is a conscious decision, which is the point: **no value is silently skipped.**
 
+   **"Since the last release" means the last one that SHIPPED, not the last tag.** A tag is not a
+   release: a candidate can be tagged, published, fail its witness, and be abandoned. The baseline
+   is therefore the greatest lower tag carrying a `releases/<tag>/witness.json` — an abandoned
+   candidate has no receipt, so its PRs stay in the batch and are witnessed by the release that
+   actually delivers them. The generator logs the baseline it picked and any candidate it skipped.
+   (v0.12.5 was tagged, published, witness-failed, abandoned; v0.12.6's batch is therefore
+   `v0.12.4...v0.12.6` — the 15 PRs a `:v012` user actually receives — not the 2 since the tag.)
+   `RELEASE_PREV_TAG=vA.B.C` overrides the baseline; it is an escape hatch and is logged loudly.
+
+   The rule to hold onto: **the batch is what the promote hands users** — `(last shipped) → (this
+   version)`. If those diverge, the receipt is describing a release that isn't the one shipping.
+
 3. **Promote** — dispatch `release-validate` with `promote: true`. Two gates run first:
    - **`value-gate`** (guarantee 8) — every batch PR is `pr-value`-green on its head or `state: value-signed`.
    - **`witness-gate`** (guarantee 7) — `releases/vX.Y.Z/witness.json` is present, well-formed, version-matched.

--- a/scripts/release-witness-script.mjs
+++ b/scripts/release-witness-script.mjs
@@ -15,14 +15,27 @@
 // witnessed_by/at/deployment, and sets signed_off:true. release-witness-gate.mjs enforces that every
 // user-visible entry is witnessed and every backend entry names evidence (full-coverage gate).
 //
+// The batch is bounded by the last release that ACTUALLY SHIPPED — not the last tag that exists.
+// A tag is not a release: a candidate can be tagged, published, fail its witness, and be abandoned
+// (v0.12.5 was). Keying the baseline off tag existence lets an abandoned candidate's whole batch
+// fall through a hole — v0.12.4's receipt ends before it, v0.12.6's begins after it — so those PRs
+// reach users in the next promote with no entry in any manifest. `releases/<tag>/witness.json` is
+// the record of a release (releases/README.md: "the receipt is the record"), so the baseline is the
+// greatest lower tag that HAS one. An abandoned tag has no receipt and can never become a baseline.
+//
 // Usage: RELEASE_VERSION=vX.Y.Z GITHUB_REPOSITORY=owner/repo node scripts/release-witness-script.mjs
 //        [> releases/vX.Y.Z/witness.json]   (writes to stdout)
+//        RELEASE_PREV_TAG=vA.B.C  — override the baseline explicitly (escape hatch; logged loudly)
 
 import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
 
 const REPO = process.env.GITHUB_REPOSITORY;
 const VERSION = process.env.RELEASE_VERSION;
 if (!REPO || !VERSION) { console.error("release-witness-script: RELEASE_VERSION + GITHUB_REPOSITORY required"); process.exit(2); }
+
+const ROOT = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
+const hasReceipt = (tag) => existsSync(`${ROOT}/releases/${tag}/witness.json`);
 
 function ghRaw(p) { let e; for (let i = 0; i < 3; i++) { try { return execSync(`gh api "${p}"`, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }); } catch (x) { e = x; } } throw e; }
 const ghj = (p) => JSON.parse(ghRaw(p));
@@ -30,9 +43,27 @@ const ghj = (p) => JSON.parse(ghRaw(p));
 function parseVer(t) { const m = String(t).match(/^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/); return m ? { core: [+m[1], +m[2], +m[3]], pre: m[4] || null, raw: t } : null; }
 function cmpVer(a, b) { for (let i = 0; i < 3; i++) if (a.core[i] !== b.core[i]) return a.core[i] - b.core[i]; if (a.pre === b.pre) return 0; if (!a.pre) return 1; if (!b.pre) return -1; return a.pre < b.pre ? -1 : 1; }
 function prevTag() {
+  if (process.env.RELEASE_PREV_TAG) {
+    console.error(`release-witness-script: baseline OVERRIDDEN by RELEASE_PREV_TAG=${process.env.RELEASE_PREV_TAG}`);
+    return process.env.RELEASE_PREV_TAG;
+  }
   const cur = parseVer(VERSION), tags = [];
   for (let pg = 1; pg <= 10; pg++) { const b = ghj(`repos/${REPO}/tags?per_page=100&page=${pg}`); for (const t of b) { const p = parseVer(t.name); if (p && !p.pre) tags.push(p); } if (b.length < 100) break; }
-  const lower = tags.filter((t) => cmpVer(t, cur) < 0).sort(cmpVer); return lower.length ? lower[lower.length - 1].raw : null;
+  const lower = tags.filter((t) => cmpVer(t, cur) < 0).sort(cmpVer);
+  if (!lower.length) return null;
+  // Walk down from the nearest tag to the last one that SHIPPED (carries a receipt). Skipped tags
+  // are abandoned candidates: their PRs never reached users, so they belong in THIS batch — the
+  // batch is what the promote actually hands users, which is (last shipped) → (this version).
+  for (let i = lower.length - 1; i >= 0; i--) {
+    if (hasReceipt(lower[i].raw)) {
+      const skipped = lower.slice(i + 1).map((t) => t.raw);
+      if (skipped.length) console.error(`release-witness-script: baseline ${lower[i].raw} (last SHIPPED) — skipping abandoned candidate(s) ${skipped.join(", ")}: tagged but no releases/<tag>/witness.json, so their PRs ship with ${VERSION} and are batched here`);
+      return lower[i].raw;
+    }
+  }
+  // Bootstrap: no receipts exist yet (pre-ADR-0029 history). Fall back to the nearest tag.
+  console.error(`release-witness-script: no prior receipt under ${VERSION}; falling back to nearest tag ${lower[lower.length - 1].raw}`);
+  return lower[lower.length - 1].raw;
 }
 function batchPRs(prev) {
   const nums = new Set();


### PR DESCRIPTION
## The value

**Right now, promoting v0.12.6 would hand users 15 PRs while the witness gate evaluates 2.** This makes the receipt describe the release that is actually shipping.

`:v012` points at **0.12.4** (digest-confirmed). So a promote moves every user **0.12.4 → 0.12.6 = 15 PRs**. But `prevTag(v0.12.6)` resolved to **v0.12.5** — a candidate that was tagged, published, **failed its witness, and was abandoned** — so the generated manifest listed only #649 and #652.

#626 (LOCAL_STT), #636, #637, #584, #633, #638 and the rest would reach users with **no entry in any manifest**: v0.12.4's receipt ends before them, v0.12.6's begins after them, and no gate requires `releases/<prevTag>/witness.json` to exist. A tag alone launders a whole batch.

That is **guarantee 7 failing exactly the way the v0.12.1 incident failed it** — promoted on machinery green, witnessed by nobody. The incident that created the rule, recurring.

## The fix

A tag is not a release. `releases/README.md` already says **"the receipt is the record"**, so this uses what exists: the baseline is the greatest lower tag that **has** `releases/<tag>/witness.json`. An abandoned candidate has no receipt and **can never become a baseline** — the hole closes structurally, not by convention, and needs no separate "what shipped" bookkeeping.

The rule, stated in the README: **the batch is what the promote hands users** — `(last shipped) → (this version)`.

## Verified against the live API

```
before → generated_from: v0.12.5...v0.12.6    2 entries  [649, 652]
after  → generated_from: v0.12.4...v0.12.6   15 entries  (4 user-visible / 11 by-proxy)
```

And it now logs its reasoning instead of silently deciding:

```
baseline v0.12.4 (last SHIPPED) — skipping abandoned candidate(s) v0.12.5:
tagged but no releases/<tag>/witness.json, so their PRs ship with v0.12.6 and are batched here
```

`RELEASE_PREV_TAG` is added as an explicit escape hatch (logged loudly). The bootstrap path — no receipts anywhere below the version — falls back to the nearest tag, unchanged.

## Scope — what this does NOT fix

Found in the same audit, filed separately rather than smuggled in here. All three are proven, not theorised:

- **The gate never reads `visibility`** — it's decorative; the only discriminator is the string `witnessed === "by-proxy"`. Already exploited in the *shipped* v0.12.4 receipt (#606/#608/#609 are `user-visible` + `by-proxy`), and it's how #636's reclaim was downgraded and shipped a crash bug.
- **`deployment` is unvalidated free text.** The gate accepted `deployment: "my laptop, vibes only"` and exited 0.
- **The generator auto-names `test_reclaim_seam.py` as #649's by-proxy evidence** — the very fake whose superset-of-production behaviour hid the bug #649 fixes. The fix for "the fake hid the bug", certified by the fake.

## Testing note, stated plainly

`scripts/*.mjs` has **no test harness** in this repo, so this ships with the before/after run above as its evidence rather than a unit test. That's a real gap — these scripts are the release's control plane — but standing up a harness for them is its own change, not a rider on this one.