### PR TITLE
fix(runtime): process backend reaps the whole process group on teardown (Closes #546)

### DIFF
--- a/core/runtime/README.md
+++ b/core/runtime/README.md
@@ -41,6 +41,10 @@ uv run pytest -q
   named-volume stores; `:ro` roles enforced); k8s = per-mount `subPath`+`readOnly` volumeMounts; process
   (lite) = per-subject uid + per-shared-workspace gids, 0700 tiers, default-deny sweep. A worker's
   filesystem contains ONLY its dispatch's mounts; no opt-out.
+- ✅ delivered — group-scoped teardown on the process backend: each workload leads its own process
+  group (`start_new_session=True`), and every ending path (observed self-exit, kill, cleanup, stop)
+  signals the whole group — a self-exiting or stopped bot never strands its child tree. Declared
+  limitation: descendants that detach into their own process group are out of the group signal's reach.
 - ✅ delivered — durable `RuntimeEvent` callback delivery (enqueue + retry-until-ack)
 - ✅ delivered — store port (InMemory / Redis) so workloads survive a process restart
 - ✅ delivered — `schedule.v1` Scheduler: `scheduler:jobs` sorted set, `tick()` every 5s, HTTP dispatch, exponential-backoff retry, cron re-arm, idempotency, orphan recovery

--- a/core/runtime/src/runtime_kernel/process_backend.py
+++ b/core/runtime/src/runtime_kernel/process_backend.py
@@ -5,11 +5,21 @@ Output capture: each workload's stdout+stderr goes to a per-workload log file un
 ``PROCESS_LOG_DIR`` (default ``<tempdir>/vexa-workloads``) — the process analog of ``docker logs``.
 A workload that exits nonzero gets its log tail surfaced at ERROR level through the runtime's own
 logs the first time the exit is observed, so a crashed worker (e.g. an ImportError at startup) is
-diagnosable from the runtime service logs instead of vanishing into /dev/null."""
+diagnosable from the runtime service logs instead of vanishing into /dev/null.
+
+Group-scoped teardown: each workload is spawned as its own process-group leader
+(``start_new_session=True`` → leader pid == pgid). Every path that ends a workload — an observed
+self-exit, ``kill``/``cleanup``, and the kernel's stop sequence — signals the whole *group*
+(``os.killpg``), so a workload's children (e.g. the bot's Chromium tree) are reaped with it instead
+of being reparented to PID 1 and stranded on the shared host. Declared limitation: descendants that
+detach into their OWN process group (the join module's debug-view x11vnc/websockify, spawned
+``detached: true``) are out of any group signal's reach — a container/host restart still clears
+those."""
 from __future__ import annotations
 
 import logging
 import os
+import signal
 import subprocess
 import tempfile
 from typing import Optional
@@ -38,6 +48,25 @@ def _tail(path: str, limit: int = _TAIL_BYTES) -> str:
             return f.read().decode("utf-8", errors="replace").strip()
     except OSError:
         return ""
+
+
+def _signal_group(pgid: int, sig: int) -> bool:
+    """Signal a whole process group by its pgid, which for our workloads equals the leader pid
+    (spawned ``start_new_session=True``, so the leader IS the group leader — pid == pgid, and stays
+    the pgid even after the leader dies, as long as any group member lives). Returns True if the
+    signal was delivered, False if the group is already gone (``ProcessLookupError`` = the common,
+    well-behaved case: every member already exited — nothing to reap). A non-root runtime that
+    cannot reach a per-subject-uid group degrades LOUDLY (the module's stated convention) and never
+    crashes the caller."""
+    try:
+        os.killpg(pgid, sig)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError as e:
+        log.error("workload group %d: cannot signal (%s) — orphans may survive (non-root runtime?)",
+                  pgid, e)
+        return False
 
 
 class ProcessBackend:
@@ -101,14 +130,28 @@ class ProcessBackend:
         finally:
             if out_fh is not None:
                 out_fh.close()  # the child holds its own fd; ours would only leak
-        self._capture[workload_id] = {"log_path": log_path, "reported": False}
+        self._capture[workload_id] = {"log_path": log_path, "reported": False, "reaped": False}
         return WorkloadHandle(id=workload_id, impl=proc)
 
     def exit_code(self, h: WorkloadHandle) -> Optional[int]:
         code = h._impl.poll()  # type: ignore[attr-defined]
-        if code is not None and code != 0:
-            self._report_failure(h.id, code)
+        if code is not None:
+            # A workload that ended — for ANY reason, clean or not — reaps its group on first
+            # observation (P22: teardown is guaranteed at the boundary, not hoped for). The leader
+            # is gone, so its children are already orphaned; SIGKILL the group with no grace. The
+            # one-shot guard mirrors the failure-report pattern: exit_code is polled repeatedly.
+            self._reap_group_once(h)
+            if code != 0:
+                self._report_failure(h.id, code)
         return code
+
+    def _reap_group_once(self, h: WorkloadHandle) -> None:
+        """Sweep the workload's process group exactly once, on first observation of its exit."""
+        state = self._capture.get(h.id)
+        if state is None or state["reaped"]:
+            return
+        state["reaped"] = True
+        _signal_group(h._impl.pid, signal.SIGKILL)  # type: ignore[attr-defined]
 
     def _report_failure(self, workload_id: str, code: int) -> None:
         """Log the failed workload's output tail — once per workload (exit_code is polled)."""
@@ -130,14 +173,19 @@ class ProcessBackend:
             state["reported"] = True
 
     def terminate(self, h: WorkloadHandle) -> None:
+        # Leader-only SIGTERM (fork B1): the bot's graceful-leave contract runs on the leader's
+        # SIGTERM handler; a group-wide SIGTERM would also hit Chromium mid-leave. The group sweep
+        # rides the observed exit (exit_code) and the kill() escalation, so children never survive.
         if h._impl.poll() is None:  # type: ignore[attr-defined]
             self._suppress_report(h.id)
             h._impl.terminate()  # type: ignore[attr-defined]
 
     def kill(self, h: WorkloadHandle) -> None:
-        if h._impl.poll() is None:  # type: ignore[attr-defined]
-            self._suppress_report(h.id)
-            h._impl.kill()  # type: ignore[attr-defined]
+        # Force path: SIGKILL the whole group, not just the leader — this is what reaps a child tree
+        # the leader would otherwise strand (the grace-expiry escalation of kernel.stop, and
+        # cleanup). The leader is a member of its own group, so this covers it too.
+        self._suppress_report(h.id)
+        _signal_group(h._impl.pid, signal.SIGKILL)  # type: ignore[attr-defined]
 
     def cleanup(self, h: WorkloadHandle) -> None:
         self.kill(h)

--- a/core/runtime/tests/test_process_backend.py
+++ b/core/runtime/tests/test_process_backend.py
@@ -13,6 +13,7 @@ import logging
 import os
 import sys
 import tempfile
+import time
 
 import pytest
 
@@ -22,6 +23,32 @@ from runtime_kernel.profiles import Runnable
 
 def _py(code: str) -> Runnable:
     return Runnable(command=[sys.executable, "-c", code])
+
+
+def _sh(script: str) -> Runnable:
+    return Runnable(command=["sh", "-c", script])
+
+
+def _alive(pid: int) -> bool:
+    """True while `pid` exists (signal 0 probes without delivering)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just not ours to signal
+
+
+def _wait_dead(pids, timeout: float = 5.0) -> None:
+    """Poll until every pid is gone (a SIGKILL'd child is reaped asynchronously)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline and any(_alive(p) for p in pids):
+        time.sleep(0.02)
+
+
+def _read_pids(*paths) -> list[int]:
+    return [int(p.read_text().strip()) for p in paths]
 
 
 def _start_and_wait(backend: ProcessBackend, workload_id: str, runnable: Runnable):
@@ -112,6 +139,80 @@ def test_unwritable_log_dir_falls_back_to_devnull(monkeypatch, tmp_path, caplog)
     assert any("cannot capture output" in r.getMessage() for r in caplog.records)
     errors = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert len(errors) == 1 and "not captured" in errors[0].getMessage()
+
+
+# ── group-scoped teardown (#546) ────────────────────────────────────────────────────────────────
+# Each workload is spawned as its own process-group leader (start_new_session=True). Every path that
+# ends a workload must reap the whole GROUP, not just the leader — otherwise a self-exiting or stopped
+# bot orphans every child it spawned onto the shared Lite host. These fixtures are #486's verbatim,
+# with pid capture so any survivor is arithmetic (RED on base a6ef9e23, GREEN after the fix).
+
+def test_self_exit_reaps_whole_group(monkeypatch, tmp_path, caplog):
+    """A1 (V1) — a workload that exits on its own leaves NO children. The leader forks two long
+    sleeps and exits 1; once exit_code() first observes the exit (plus cleanup), both captured child
+    pids are dead. On base (leader-only signal) both sleeps survive — RED."""
+    monkeypatch.setenv("PROCESS_LOG_DIR", str(tmp_path))
+    f1, f2 = tmp_path / "c1.pid", tmp_path / "c2.pid"
+    backend = ProcessBackend()
+    h = backend.start(
+        "w-orphan",
+        _sh(f"sleep 600 & echo $! > {f1}; sleep 600 & echo $! > {f2}; exit 1"),
+        {},
+    )
+    h._impl.wait(timeout=10)                     # leader gone; children reparented to PID 1
+    while not (f1.exists() and f2.exists()):
+        time.sleep(0.01)
+    child_pids = _read_pids(f1, f2)
+    assert all(_alive(p) for p in child_pids)    # precondition: children outlived the leader
+
+    with caplog.at_level(logging.ERROR, logger="runtime_kernel.process"):
+        assert backend.exit_code(h) == 1         # first observation triggers the group sweep
+    backend.cleanup(h)
+
+    _wait_dead(child_pids)
+    assert not any(_alive(p) for p in child_pids), f"orphaned children survived: {child_pids}"
+
+
+def test_stop_path_reaps_whole_group(monkeypatch, tmp_path):
+    """A2 (V2) — the kernel.stop() shape (terminate → grace → kill) tears down the whole tree, not
+    just the leader. The leader waits on its children (never self-exits), so only a group signal can
+    end them. On base (leader-only terminate/kill) both sleeps survive — RED."""
+    monkeypatch.setenv("PROCESS_LOG_DIR", str(tmp_path))
+    f1, f2 = tmp_path / "s1.pid", tmp_path / "s2.pid"
+    backend = ProcessBackend()
+    h = backend.start(
+        "w-stopgrp",
+        _sh(f"sleep 600 & echo $! > {f1}; sleep 600 & echo $! > {f2}; wait"),
+        {},
+    )
+    while not (f1.exists() and f2.exists()):
+        time.sleep(0.01)
+    child_pids = _read_pids(f1, f2)
+    assert all(_alive(p) for p in child_pids)
+
+    # mirror kernel.stop(): graceful terminate, brief grace, then force kill()
+    backend.terminate(h)
+    deadline = time.time() + 1.0
+    while backend.exit_code(h) is None and time.time() < deadline:
+        time.sleep(0.02)
+    if backend.exit_code(h) is None:
+        backend.kill(h)
+    backend.cleanup(h)
+
+    _wait_dead(child_pids)
+    assert not any(_alive(p) for p in child_pids), f"children survived stop: {child_pids}"
+
+
+def test_childless_workload_reap_is_silent(monkeypatch, tmp_path, caplog):
+    """Edge: a workload with no children (the common, well-behaved case). The group sweep finds an
+    empty/gone group (ProcessLookupError) and stays silent — no error log, no crash."""
+    monkeypatch.setenv("PROCESS_LOG_DIR", str(tmp_path))
+    backend = ProcessBackend()
+    h = _start_and_wait(backend, "w-lonely", _py("import sys; sys.exit(0)"))
+    with caplog.at_level(logging.ERROR, logger="runtime_kernel.process"):
+        assert backend.exit_code(h) == 0
+        backend.cleanup(h)
+    assert not [r for r in caplog.records if r.levelno == logging.ERROR]
 
 
 def test_workload_env_still_layered_over_process_env(monkeypatch, tmp_path):

--- a/docs/docs/core/runtime.mdx
+++ b/docs/docs/core/runtime.mdx
@@ -42,7 +42,11 @@ workload?) to a pluggable **Backend** with a five-method port: `start` · `exit_
 `kill` · `cleanup`. The same control plane and the same `unit.v1` dispatch drive every backend; only
 the implementation behind that port differs:
 
-- **Process** — agents and bots are spawned as **child processes**, no Docker socket required.
+- **Process** — agents and bots are spawned as **child processes**, no Docker socket required. Each
+  workload leads its own process group, and the backend owns that group: an observed exit or a stop
+  reaps every descendant, so a self-exiting or stopped bot never strands its child tree (e.g.
+  Chromium) on the shared host. Declared limitation — descendants that detach into their own process
+  group (the debug-view x11vnc/websockify) are out of the group signal's reach.
 - **Docker** — each workload is its own container via the Docker socket. This is what the open core
   ships, brought up with **Docker Compose** (`make all`).
 - **Kubernetes** — the same workload model scheduled as a **Pod** across a cluster.

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -126,6 +126,21 @@ The [runtime](/core/runtime) spawns bot and agent containers via the Docker sock
   the published `vexaai/vexa-bot:dev` is the old 0.10 line and is incompatible. `AGENT_IMAGE` is built by
   `make all` — confirm it resolves and `IMAGE_TAG` matches what you built.
 
+## Leftover chrome/node processes after a bot ends (Lite)
+
+On **Lite** every bot and agent runs as a child process inside one shared container (the
+[process backend](/core/runtime)). If a meeting ends and you still see stray `chrome`/`node`
+processes, check inside the container:
+
+```bash
+ps -eo pid,ppid,etime,comm   # PPID 1 = orphaned (reparented to init)
+```
+
+As of this release the backend reaps each workload's whole process group when it exits or is
+stopped, so no strays should remain — a descendant that detached into its own process group
+(the debug-view x11vnc/websockify) is the one declared exception. On older Lite images the
+workaround is a container restart.
+
 ## Agent write was rejected
 
 A streamed turn can end with a `rejected` frame carrying `violations`. This is governance, not a bug:


### PR DESCRIPTION
Closes #546.

## What / why
Lite runs every bot and agent as a child process in one shared container (`RUNTIME_BACKEND=process`). Each workload is spawned as its own process-group leader (`start_new_session=True` → leader pid == pgid), but nothing ever signalled the **group** — a self-exiting or stopped bot orphaned every child it spawned (the bot's Chromium/node tree) onto the shared host, reparented to PID 1 and invisible to the runtime's accounting.

Fix lives at the one seam — `core/runtime/src/runtime_kernel/process_backend.py`. `kernel.py`, `docker_backend.py`, `k8s_backend.py` are **untouched** (container/pod semantics already tear down the whole tree; A− guard).

- `_signal_group(pgid, sig)`: `os.killpg` on the dead-or-live leader's pid==pgid. `ProcessLookupError` = group already gone → silent success (the common well-behaved case). `PermissionError` (non-root runtime) degrades loudly, never crashes the poll.
- `exit_code()`: first observation of **any** exit (clean or not) sweeps the group once (one-shot guard mirroring the failure-report pattern) — **V1 self-exit**, and via `kernel.stop()`'s polling also the graceful-**stop** path.
- `kill()` / `cleanup()`: SIGKILL the whole group (the grace-expiry escalation of `kernel.stop`).
- `terminate()`: stays **leader-only SIGTERM** (fork **B1**) — preserves the bot's graceful-leave contract (`orchestrator.ts:200`); the group sweep rides the observed exit + `kill()`.

## Acceptance table → evidence
| Row | Evidence |
|---|---|
| **A1 (V1 self-exit)** | `test_self_exit_reaps_whole_group`: #486 fixture `sh -c 'sleep 600 & sleep 600 & exit 1'` with pid capture; after `exit_code()`+`cleanup()` both children dead. |
| **A2 (V2 stop)** | `test_stop_path_reaps_whole_group`: `sh -c 'sleep 600 & sleep 600 & wait'` driven through terminate→grace→kill (the `kernel.stop()` shape); whole group dead. |
| **A3 (control)** | Both A1+A2 run **RED against base** `origin/main` backend (test-only swap): `children survived stop: [19812, 19814]`; **GREEN** on head. Childless-edge test passes on both (correctly not a discriminator). |
| **A−** | Full runtime lane green at head: `test_process_backend.py` (11), `test_lifecycle.py`, `test_docker_backend.py`, `test_k8s_backend.py` → 18 passed, 1 skipped. |

Live legs A4/A5 (Lite Meet bot) are the operator/non-author validation legs per the issue — not run here; the module-lane contract fix (A1–A3) is shipped.

## Docs (D6c)
`docs/docs/core/runtime.mdx`, `core/runtime/README.md`, `docs/docs/troubleshooting.mdx` — whole-tree teardown guarantee + declared limitation (detached-into-own-group grandchildren, e.g. debug-view x11vnc/websockify, out of reach).

## Gates
`node scripts/gates.mjs all` — all green **except** `gate:db-budget` (admin-api/meeting-api `pool_size` 6-vs-5), a **pre-existing** failure unrelated to this diff (touches only the process backend, its tests, and docs; nothing DB-related).