### PR TITLE
fix(lite): pass STT + internal-secret env to [program:terminal] (#628)

### DIFF
--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -104,7 +104,7 @@ The repo-root `.env` (auto-seeded from `deploy/compose/.env` if present, else mi
 
 | Variable | Default | Description |
 |---|---|---|
-| `TRANSCRIPTION_SERVICE_URL` / `_TOKEN` | — | STT endpoint + key. Unset → bots capture, no transcript |
+| `TRANSCRIPTION_SERVICE_URL` / `_TOKEN` | — | STT endpoint + key, shared by the bot transcript pipeline and the terminal composer mic (dictation `/api/stt`). Unset → bots capture, no transcript; composer mic returns 503 "not configured" |
 | `ADMIN_TOKEN` | `changeme` | admin API token (the stack's shared admin secret) |
 | `IMAGE_TAG` | `latest` | the `vexaai/vexa-lite` tag to pull (a local `vexa-lite:dev` build wins) |
 

--- a/deploy/lite/supervisord.conf
+++ b/deploy/lite/supervisord.conf
@@ -220,7 +220,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
-environment=NODE_ENV="production",PORT="3001",HOST="0.0.0.0",AGENT_API_URL="http://localhost:8100",GATEWAY_URL="http://localhost:8056",VEXA_API_URL="http://localhost:8056",VEXA_ADMIN_API_URL="http://localhost:8001",VEXA_ADMIN_API_KEY="%(ENV_ADMIN_API_TOKEN)s",VEXA_API_KEY="%(ENV_VEXA_API_KEY)s",VEXA_BOT_API_KEY="%(ENV_VEXA_BOT_API_KEY)s",NEXTAUTH_URL="%(ENV_TERMINAL_PUBLIC_URL)s",NEXTAUTH_SECRET="%(ENV_NEXTAUTH_SECRET)s"
+environment=NODE_ENV="production",PORT="3001",HOST="0.0.0.0",AGENT_API_URL="http://localhost:8100",GATEWAY_URL="http://localhost:8056",VEXA_API_URL="http://localhost:8056",VEXA_ADMIN_API_URL="http://localhost:8001",VEXA_ADMIN_API_KEY="%(ENV_ADMIN_API_TOKEN)s",VEXA_INTERNAL_API_SECRET="%(ENV_INTERNAL_API_SECRET)s",VEXA_API_KEY="%(ENV_VEXA_API_KEY)s",VEXA_BOT_API_KEY="%(ENV_VEXA_BOT_API_KEY)s",TRANSCRIPTION_SERVICE_URL="%(ENV_TRANSCRIPTION_SERVICE_URL)s",TRANSCRIPTION_SERVICE_TOKEN="%(ENV_TRANSCRIPTION_SERVICE_TOKEN)s",NEXTAUTH_URL="%(ENV_TERMINAL_PUBLIC_URL)s",NEXTAUTH_SECRET="%(ENV_NEXTAUTH_SECRET)s"
 
 ; ─── process group ────────────────────────────────────────────────────────────────────────────────
 [group:vexa]

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -144,6 +144,12 @@ probe), not inferred from planning docs.
 - **`discord` ingest and `GET …/participants`**: **planned back in the 0.12.x line** with the
   next `api.v1` contract revision.
 
+## 0.12.x maintenance fixes
+
+- **Lite: terminal transcription env wired (#628).** In `deploy/lite`, the `[program:terminal]`
+  worker now receives the STT and internal-secret environment it needs, so speech-to-text works in
+  the single-container lite deploy. See [Deployment](/deployment).
+
 ## Versioning
 
 Vexa follows semantic-ish versioning at the `MAJOR.MINOR` line; breaking changes are called out in the


### PR DESCRIPTION
## Problem
On a lite deploy with transcription configured, the terminal **composer mic** (`/api/stt`) returned 503 "transcription not configured" even though the meeting transcription pipeline worked. The `[program:terminal]` supervisord block sets an explicit `environment=` list (which replaces inherited container env) and omitted `TRANSCRIPTION_SERVICE_URL` / `TRANSCRIPTION_SERVICE_TOKEN`, so `clients/terminal/src/app/api/stt/route.ts` read an empty `process.env.TRANSCRIPTION_SERVICE_URL`.

## Fix
Add `TRANSCRIPTION_SERVICE_URL` + `TRANSCRIPTION_SERVICE_TOKEN` to the terminal `environment=` list, mirroring the `[program:meeting-api]` block that already passes them.

**Why `%(ENV_...)s` is startup-safe when the vars are empty/unset:** both vars are *guaranteed set* on the lite container — `Dockerfile.lite` declares them as empty `ENV` defaults and `entrypoint.sh` re-exports them with `${VAR:-}` fallbacks. supervisord only hard-fails on `%(ENV_X)s` when `X` is truly *unset*; empty-but-set interpolates fine. An empty value produces a clean 503 at the route's `if (!base)` guard (correct "unconfigured" behavior), not a crash. When `LOCAL_STT=1` (#626), `make up` passes the bundled Whisper URL via docker `-e`, so the terminal now sees it too.

## Additional same-class var found
Diffing the terminal `environment=` list against `process.env.*` reads in `clients/terminal/src/app/api/` surfaced one more: **`VEXA_INTERNAL_API_SECRET`**, read by `auth/adminApi.ts` (auth-token validation) and admin routes, which return a 503 "not configured" when it's absent — and it was missing from the env list. Added as `%(ENV_INTERNAL_API_SECRET)s` (the container's shared internal secret, always set as a `Dockerfile.lite` ENV). Other unpassed reads (Google/Microsoft OAuth, cookie-name overrides, `VEXA_ADMIN_EMAILS`) are optional operator config with in-code defaults — left as-is.

## Docs
Updated the `deploy/lite/README.md` config table to note `TRANSCRIPTION_SERVICE_URL`/`_TOKEN` also power the terminal composer mic dictation.

## Verification
- `deploy/lite/supervisord.conf` parses (Python configparser); all three keys present in `[program:terminal]`.
- `node scripts/gates.mjs all` — green, incl. `gate:config-contract` (declarations ≡ deploy surfaces ≡ code reads). Only `db-budget` fails, a pre-existing false-positive (admin-api/meeting-api pool_size declaration mismatch) unrelated to this change.

Closes #628