### PR TITLE
fix(release-validate): honesty valve renders per-leg scope, never a claim it can't measure

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -484,13 +484,23 @@ jobs:
         run: |
           set -euo pipefail
           m() { [ "$1" = "success" ] && echo "✅" || echo "❌ ($1)"; }
+          # Scoped renderer (the honesty valve's neutral rendering): a leg renders ONLY its own
+          # measured scope, never a stronger sentence.  success → "<scope> ✓";  a leg that did not
+          # run at all (skipped/empty) → "— not exercised", never ✓;  any other result → "❌ (state)".
+          s() {
+            case "$1" in
+              success)    printf '%s ✓' "$2" ;;
+              skipped|"") printf '— not exercised' ;;
+              *)          printf '❌ (%s)' "$1" ;;
+            esac
+          }
           {
             echo "## The guarantee — $VERSION ([this run]($RUN_URL))"
             echo
             echo "| # | Guarantee | Proof in this run |"
             echo "|---|---|---|"
             echo "| 1 | Every artifact users pull is the artifact we proved | $(m "$R_RESOLVE") manifests resolve; every leg pulls published bytes only |"
-            echo "| 2 | Works end-to-end on every documented install path | compose $(m "$R_COMPOSE") · FSM $(m "$R_MOCKFSM") · lite $(m "$R_LITE") · helm $(m "$R_HELM") |"
+            echo "| 2 | Every documented install path stands up and is exercised to its leg's scope (NOT full end-to-end — real audio→words is row 3) | compose $(s "$R_COMPOSE" "installs + API/data-plane wiring, synthetic transcript; real bot in row 5") · FSM $(s "$R_MOCKFSM" "meeting-lifecycle FSM via mock bot, no real browser/STT") · lite $(s "$R_LITE" "front doors + ≥2 concurrent real-bot spawn, no meeting/STT assertion") · helm $(s "$R_HELM" "installs + healthy, bot/meeting/STT not exercised") |"
             echo "| 3 | Real audio → correct, speaker-attributed words | ⚠️ NOT machine-proven in this run — witness-pass only until the wav→words leg (#560) ships |"
             echo "| 4 | A fresh machine with nothing on it succeeds | ⚠️ fresh-VM leg runs outside this workflow — attach its evidence to the notes or state unclaimed |"
             echo "| 5 | Nothing that worked before broke | v010-compat $(m "$R_V010") · bot-spawn $(m "$R_BOTSPAWN") |"


### PR DESCRIPTION
Closes #657

## The overclaim (C1 · option A)

`release-validate.yml`'s guarantee table (the block the comment calls **"the honesty valve"**, `:455`) renders row 2 — *"Works end-to-end on every documented install path"* — with cells driven by `m()` (`:486`), which maps `success`→`✅` and everything else→`❌ (state)`. It has **no install-scoped rendering**. So `R_HELM` — a leg that only runs `helm install` + `curl /health` + all-pods-Running (`values-test.yaml:7`: *"Does NOT exercise live bot/agent spawn."*) — printed a bare `✅` against an *end-to-end* sentence. The valve named "honesty" was failing open: a stronger claim than the evidence.

This matters for **v0.12.6** whose notes carry #634 (helm-only) and #636 (provable only on helm), while #656 means helm auto-join is in fact broken — the notes asserted helm works end-to-end for a release whose helm-specific behavior nothing executed.

## The fix

Added a **scoped renderer `s()`** next to `m()`:
- `success` → `"<scope> ✓"` — the leg's own measured scope, never a stronger sentence
- `skipped`/empty (leg did not run) → `"— not exercised"`, **never ✓** (acceptance A2)
- anything else → `"❌ (state)"`

Row 2's guarantee sentence changed from unconditional *"Works end-to-end…"* to *"Every documented install path stands up and is exercised to its leg's scope (NOT full end-to-end — real audio→words is row 3)"*, and each cell now states what its leg measures.

## Whole-table audit (per the issue's instruction, not just helm)

I traced every row-2 leg to its actual test body:

| Cell | What the leg runs | Was | Now |
|---|---|---|---|
| **helm** | `helm install` + `/health` + pods Running (`:427`-`:444`); no bot/meeting/STT | `helm ✅` | `helm installs + healthy, bot/meeting/STT not exercised ✓` |
| **compose** | `stack-test` always-on subset — health/auth/**transcript dataflow via XADD of a golden segment**/recording/continue-meeting/max-bots. Real bot spawn is `COMPOSE_BOT=1` → the **separate** `validate-bot-spawn` leg (row 5), NOT this one | `compose ✅` | `compose installs + API/data-plane wiring, synthetic transcript; real bot in row 5 ✓` |
| **FSM** | `MOCK_BOT` scenarios — meeting-lifecycle FSM driven by a mock bot; no real browser/Meet/STT | `FSM ✅` | `FSM meeting-lifecycle FSM via mock bot, no real browser/STT ✓` |
| **lite** | front-door probes + `concurrent-bots.sh` (≥2 real bots reach `joining`, browsers survive the window, per-bot profile dirs); no meeting/STT assertion | `lite ✅` | `lite front doors + ≥2 concurrent real-bot spawn, no meeting/STT assertion ✓` |

Other rows were already leg-scoped and keep `m()`: row 1 (manifests resolve), row 5 (v010-compat, bot-spawn — the *real* bot leg), row 6 (image-identity). Rows 3/4 already carry honest `⚠️` hedges; rows 7-10 are enforced/self-referential. No other row overstated its leg.

## Acceptance table (issue #657)

- **A1** — Rendered notes: helm cell states install/health scope, not "Works end-to-end ✓". ✓ (see render below)
- **A2** — An unmeasured leg renders `—`/"not exercised", never `✓`. ✓ (`s()` `skipped`/empty branch)
- **A-** — No-regression: change is a pure notes-render YAML edit; no gate exercises this workflow.

## Early validation — rendered locally by extracting the render logic

All legs green (the v0.12.6 helm-install-only shape):
```
| 2 | Every documented install path stands up and is exercised to its leg's scope (NOT full end-to-end — real audio→words is row 3) | compose installs + API/data-plane wiring, synthetic transcript; real bot in row 5 ✓ · FSM meeting-lifecycle FSM via mock bot, no real browser/STT ✓ · lite front doors + ≥2 concurrent real-bot spawn, no meeting/STT assertion ✓ · helm installs + healthy, bot/meeting/STT not exercised ✓ |
```
helm leg skipped (did not run):
```
… · helm — not exercised |
```
helm leg failed:
```
… · helm ❌ (failure) |
```

## Verification

- `actionlint`: not installed on this host; **YAML parses clean** (`python3 -c "yaml.safe_load(...)"`).
- Render logic extracted and exercised across success / skipped / failure (above).
- Gates: `node scripts/gates.mjs` — only `gate:compose` red, and that is an **environmental** failure (its `stack-test` stands up the real docker compose stack locally; `vexa-compose-gate-gateway-1` exited 143 / SIGTERM). It is unrelated to this diff, which touches only the release-notes render text in the workflow — no gate reads that file.

## Follow-up (issue's option B, not in this PR)
Add a real helm e2e leg (bot spawn + meeting on k8s, replicas ≥ 2) and gate a strong claim on *that* — the durable fix and the only thing that would have caught #656.