### PR TITLE
fix(merge-card): non-terminal value-fsm is pending, not failure — wait for a verdict (Closes #655)

### DIFF
--- a/docs/adr/0030-merge-card-value-and-diff-gate.md
+++ b/docs/adr/0030-merge-card-value-and-diff-gate.md
@@ -25,6 +25,13 @@ value and the diff are accepted:**
 - **Value accepted** — for a runtime PR (pr-value's path filter), `value-fsm` is GREEN on the head
   sha **and** the PR carries `state: value-signed` (the D9 sign-off). A red value-fsm is never
   waived by the label. Non-runtime PRs (no pr-value leg): `state: value-signed` alone.
+  - **Non-terminal value-fsm ⇒ pending, not failure.** The `labeled` event that fires the card
+    also re-triggers `value-fsm`, so its newest run on head is frequently still `queued`/
+    `in_progress` (`conclusion === null`) when the card evaluates. The card treats that as
+    **pending** and **waits** for a terminal verdict (bounded poll) rather than reading an
+    in-flight run as failure — the #655 race, which red-carded correctly-approved PRs and forced a
+    manual rerun. A value-fsm that never reaches terminal `success` within the wait budget stays
+    not-mergeable (the label cannot waive it; success must be positively observed).
 - **Diff accepted** — a GitHub review **approval from a non-author** whose `commit_id` is the
   current head sha (a new push dismisses a stale approval — re-review required).
 

--- a/scripts/merge-card-gate.mjs
+++ b/scripts/merge-card-gate.mjs
@@ -3,7 +3,11 @@
 //
 //   • VALUE accepted  — the observation bundle is real. Runtime PRs: `value-fsm` (pr-value L3)
 //     GREEN on the head sha AND `state: value-signed` (the D9 human sign-off). Non-runtime PRs
-//     (no pr-value leg): `state: value-signed` alone.
+//     (no pr-value leg): `state: value-signed` alone. Because `labeled` also re-triggers value-fsm,
+//     its newest run on head is often still non-terminal when the card fires: the card WAITS for a
+//     terminal verdict (success/failure) rather than reading an in-flight run as failure (#655). A
+//     value-fsm that never settles within the wait budget stays not-mergeable — a label can never
+//     waive value-fsm; success must be positively observed.
 //   • DIFF accepted   — the code was reviewed. Either the PR author is a MAINTAINER (holds the
 //     commit bit — a maintainer reviewing their own work is allowed; the mandatory-review rule is
 //     the quality gate for CONTRIBUTOR PRs), OR a GitHub review APPROVAL from a NON-AUTHOR whose
@@ -18,9 +22,11 @@
 // Exit 0 = every named PR's card is satisfied; 1 = one or more not; 2 = usage/nothing to check.
 
 import { execSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 const REPO = process.env.GITHUB_REPOSITORY;
-if (!REPO) { console.error("merge-card-gate: GITHUB_REPOSITORY required"); process.exit(2); }
+const IS_MAIN = import.meta.url === pathToFileURL(process.argv[1] || "").href;
+if (IS_MAIN && !REPO) { console.error("merge-card-gate: GITHUB_REPOSITORY required"); process.exit(2); }
 
 const RUNTIME_PREFIXES = ["core/", "clients/terminal/", "deploy/compose/", "deploy/lite/", "libs/"];
 const RUNTIME_FILES = ["package.json", "pnpm-lock.yaml"];
@@ -56,12 +62,55 @@ function touchesRuntime(num) {
   return false;
 }
 
-function valueFsmVerdict(sha) {
-  const runs = (ghj(`repos/${REPO}/commits/${sha}/check-runs?per_page=100`).check_runs || [])
-    .filter((r) => r.name === "value-fsm");
-  if (!runs.length) return "absent";
-  runs.sort((a, b) => new Date(b.started_at || 0) - new Date(a.started_at || 0));
-  return runs[0].conclusion === "success" ? "success" : "failure";
+// value-fsm is a live sibling check: `labeled` (which triggers merge-card) also re-triggers
+// value-fsm, so the head sha's newest value-fsm run is frequently still `queued`/`in_progress`
+// when merge-card evaluates. A non-terminal run has `conclusion === null` — it is NOT a failure,
+// it simply has no verdict yet. Collapsing it into "failure" (the old bug) red-cards a PR whose
+// value-fsm is on its way to green. The verdict is therefore FOUR-state:
+//
+//   "absent"   — no value-fsm run on this sha at all
+//   "pending"  — newest run exists but is non-terminal (queued|in_progress; conclusion === null)
+//   "success"  — newest run completed with conclusion "success"
+//   "failure"  — newest run completed with any other conclusion (failure|cancelled|timed_out|…)
+//
+// Pure over a raw check-runs array so it is unit-testable against fixtures.
+export function verdictFromRuns(runs) {
+  const vf = (runs || []).filter((r) => r.name === "value-fsm");
+  if (!vf.length) return "absent";
+  vf.sort((a, b) => new Date(b.started_at || 0) - new Date(a.started_at || 0));
+  const top = vf[0];
+  if (top.status && top.status !== "completed") return "pending"; // queued | in_progress
+  if (top.conclusion == null) return "pending";                   // completed-but-verdictless: treat as not-yet-terminal
+  return top.conclusion === "success" ? "success" : "failure";
+}
+
+function readValueFsmRuns(sha) {
+  return ghj(`repos/${REPO}/commits/${sha}/check-runs?per_page=100`).check_runs || [];
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Wait for value-fsm to reach a TERMINAL verdict on `sha` instead of sampling it once mid-run.
+// Polls the newest run's verdict; on "pending" it backs off and re-reads, up to `attempts` reads
+// within the job budget. Removes the race entirely: a value-fsm still running when the card fires
+// is waited out to its real success/failure. If it never settles within the budget the verdict
+// stays "pending" (or "absent") and the caller red-cards it LOUDLY — a non-terminal check is never
+// silently accepted, so the invariant holds: success must be positively observed, a label cannot
+// waive it. Injected read/sleep make it unit-testable without the network or real clock.
+export async function waitForTerminalValueFsm(
+  sha,
+  { read = readValueFsmRuns, wait = sleep, attempts = 20, delayMs = 15000 } = {},
+) {
+  let verdict = "absent";
+  for (let i = 0; i < attempts; i++) {
+    verdict = verdictFromRuns(read(sha));
+    // "absent" and "pending" are both non-terminal: `labeled` also re-triggers value-fsm, so on a
+    // runtime PR the run may not have registered (absent) or may still be running (pending) when
+    // the card fires. Only success/failure are settled reads.
+    if (verdict === "success" || verdict === "failure") return verdict;
+    if (i < attempts - 1) await wait(delayMs);
+  }
+  return verdict; // still absent/pending after the budget — caller treats non-success as not-mergeable
 }
 
 // Is the PR author a MAINTAINER — i.e. holds the commit bit (push access to this repo)? A
@@ -95,20 +144,25 @@ function diffAccepted(pr) {
   return { ok: false };
 }
 
-function card(num) {
+async function card(num) {
   const pr = ghj(`repos/${REPO}/pulls/${num}`);
   if (pr.draft) return { num, ok: true, skip: "draft" };
   const labels = (pr.labels || []).map((l) => l.name);
   const signed = labels.includes("state: value-signed");
   const head = pr.head?.sha;
   const runtime = touchesRuntime(num);
-  const vf = head ? valueFsmVerdict(head) : "absent";
+  // Only a runtime PR has a value-fsm leg, and only then do we pay the wait. A non-terminal
+  // value-fsm is waited out to its real verdict rather than sampled once mid-run (the #655 race).
+  const vf = runtime && head ? await waitForTerminalValueFsm(head) : "absent";
 
   // VALUE
   let valueOk = false, valueWhy;
   if (!signed) valueWhy = "missing `state: value-signed` (the value sign-off)";
-  else if (runtime && vf !== "success") valueWhy = `value-signed but value-fsm is ${vf} on head — value-fsm must be green (a label cannot waive it)`;
-  else { valueOk = true; valueWhy = runtime ? "value-fsm green + value-signed" : "non-runtime + value-signed"; }
+  else if (runtime && vf === "success") { valueOk = true; valueWhy = "value-fsm green + value-signed"; }
+  else if (runtime && (vf === "pending" || vf === "absent"))
+    valueWhy = `value-signed but value-fsm did not reach a terminal verdict on head within the wait budget (still ${vf}) — value-fsm must be green (a label cannot waive it)`;
+  else if (runtime) valueWhy = `value-signed but value-fsm is ${vf} on head — value-fsm must be green (a label cannot waive it)`;
+  else { valueOk = true; valueWhy = "non-runtime + value-signed"; }
 
   // DIFF
   const d = diffAccepted(pr);
@@ -144,23 +198,25 @@ function renderCard(c) {
   ].join("\n");
 }
 
-const nums = prNumbers();
-if (!nums.length) { console.error("merge-card-gate: no PR number resolved from PR_NUMBERS / MERGE_GROUP_REF"); process.exit(2); }
+async function main() {
+  const nums = prNumbers();
+  if (!nums.length) { console.error("merge-card-gate: no PR number resolved from PR_NUMBERS / MERGE_GROUP_REF"); process.exit(2); }
 
-let failed = 0;
-const cards = [];
-for (const num of nums) {
-  let c;
-  try { c = card(num); }
-  catch (e) { console.error(`::error ::merge-card #${num} — could not evaluate: ${e.message}`); failed++; continue; }
-  cards.push(c);
-  console.log(renderCard(c));
-  console.log("");
-  if (!c.skip && !c.ok) failed++;
+  let failed = 0;
+  for (const num of nums) {
+    let c;
+    try { c = await card(num); }
+    catch (e) { console.error(`::error ::merge-card #${num} — could not evaluate: ${e.message}`); failed++; continue; }
+    console.log(renderCard(c));
+    console.log("");
+    if (!c.skip && !c.ok) failed++;
+  }
+
+  if (failed) {
+    console.error(`::error ::merge-card — ${failed} PR(s) not mergeable: value AND diff must both be accepted (choke point 1).`);
+    process.exit(1);
+  }
+  console.log(`✓ merge-card — value + diff accepted for: ${nums.map((n) => "#" + n).join(", ")}`);
 }
 
-if (failed) {
-  console.error(`::error ::merge-card — ${failed} PR(s) not mergeable: value AND diff must both be accepted (choke point 1).`);
-  process.exit(1);
-}
-console.log(`✓ merge-card — value + diff accepted for: ${nums.map((n) => "#" + n).join(", ")}`);
+if (IS_MAIN) main();

--- a/scripts/merge-card-gate.test.mjs
+++ b/scripts/merge-card-gate.test.mjs
@@ -1,0 +1,97 @@
+// Unit tests for the value-fsm verdict + wait logic in merge-card-gate.mjs (issue #655).
+// Run: node --test scripts/merge-card-gate.test.mjs
+//
+// The regression: a non-terminal value-fsm run (queued|in_progress, conclusion === null) on the
+// head sha was collapsed to "failure", red-carding a PR whose value-fsm was on its way to green.
+// The fix makes the verdict four-state and WAITS for a terminal read before red-carding.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { verdictFromRuns, waitForTerminalValueFsm } from "./merge-card-gate.mjs";
+
+const run = (o) => ({ name: "value-fsm", started_at: "2026-07-16T20:07:14Z", ...o });
+
+// ── verdictFromRuns — pure, fixture-driven ──────────────────────────────────────────────────────
+
+test("in_progress run (conclusion null) → pending, NOT failure (the #655 bug)", () => {
+  assert.equal(verdictFromRuns([run({ status: "in_progress", conclusion: null })]), "pending");
+});
+
+test("queued run → pending", () => {
+  assert.equal(verdictFromRuns([run({ status: "queued", conclusion: null })]), "pending");
+});
+
+test("completed + success → success", () => {
+  assert.equal(verdictFromRuns([run({ status: "completed", conclusion: "success" })]), "success");
+});
+
+test("completed + failure → failure", () => {
+  assert.equal(verdictFromRuns([run({ status: "completed", conclusion: "failure" })]), "failure");
+});
+
+test("completed + cancelled → failure (terminal non-success red-cards)", () => {
+  assert.equal(verdictFromRuns([run({ status: "completed", conclusion: "cancelled" })]), "failure");
+});
+
+test("no value-fsm run → absent", () => {
+  assert.equal(verdictFromRuns([{ name: "gates", status: "completed", conclusion: "success" }]), "absent");
+});
+
+test("newest run wins: a fresh in_progress re-run supersedes an old success → pending", () => {
+  assert.equal(
+    verdictFromRuns([
+      run({ started_at: "2026-07-16T19:00:00Z", status: "completed", conclusion: "success" }),
+      run({ started_at: "2026-07-16T20:07:14Z", status: "in_progress", conclusion: null }),
+    ]),
+    "pending",
+  );
+});
+
+// ── waitForTerminalValueFsm — injected read/sleep, no network or real clock ──────────────────────
+
+test("A1: in_progress → wait → success (poll settles to the real verdict)", async () => {
+  const seq = [
+    [run({ status: "in_progress", conclusion: null })],
+    [run({ status: "in_progress", conclusion: null })],
+    [run({ status: "completed", conclusion: "success" })],
+  ];
+  let i = 0, sleeps = 0;
+  const verdict = await waitForTerminalValueFsm("sha", {
+    read: () => seq[Math.min(i++, seq.length - 1)],
+    wait: async () => { sleeps++; },
+    attempts: 5, delayMs: 0,
+  });
+  assert.equal(verdict, "success");
+  assert.equal(sleeps, 2, "backed off twice before the terminal read");
+});
+
+test("A3: terminal failure fails immediately, no wasted polling", async () => {
+  let reads = 0;
+  const verdict = await waitForTerminalValueFsm("sha", {
+    read: () => { reads++; return [run({ status: "completed", conclusion: "failure" })]; },
+    wait: async () => { throw new Error("should not sleep on a terminal read"); },
+    attempts: 5, delayMs: 0,
+  });
+  assert.equal(verdict, "failure");
+  assert.equal(reads, 1);
+});
+
+test("missing run: never registers → stays pending/absent, fails loudly (not silently green)", async () => {
+  const verdict = await waitForTerminalValueFsm("sha", {
+    read: () => [], // value-fsm never appears
+    wait: async () => {},
+    attempts: 3, delayMs: 0,
+  });
+  assert.notEqual(verdict, "success"); // the invariant: success must be positively observed
+  assert.equal(verdict, "absent");
+});
+
+test("stuck in_progress → timeout → pending (caller red-cards, not green)", async () => {
+  const verdict = await waitForTerminalValueFsm("sha", {
+    read: () => [run({ status: "in_progress", conclusion: null })],
+    wait: async () => {},
+    attempts: 4, delayMs: 0,
+  });
+  assert.equal(verdict, "pending");
+  assert.notEqual(verdict, "success");
+});


### PR DESCRIPTION
Closes #655.

## What was wrong

`labeled` fires `merge-card` **and** re-triggers `value-fsm`. So when the card evaluates, the newest `value-fsm` run on the head sha is frequently still `queued`/`in_progress` (`conclusion === null`). `valueFsmVerdict()` did `runs[0].conclusion === "success" ? "success" : "failure"` — collapsing that non-terminal run into **failure**, red-carding a PR whose value-fsm was on its way to green. Every `value-signed` PR (incl. release bumps) needed a manual `gh run rerun`, and the audit trail recorded a falsehood ("value-fsm is failure on head" while it was in progress). Hit deterministically on #649, #652, #654.

## The fix (prepared solution A + B)

State machine for the value-fsm verdict on the head sha:

```
read newest value-fsm run on head
  status queued|in_progress (conclusion null) ─► pending ─┐
  no value-fsm run at all                      ─► absent ─┤  poll/backoff, bounded budget
  completed + success                          ─► success ◄┘ (terminal — return)
  completed + anything else                    ─► failure   (terminal — return)

card VALUE (runtime PR, value-signed):
  success            ─► ✅  value-fsm green + value-signed
  failure            ─► ❌  value-fsm is failure on head (terminal)
  pending | absent   ─► ❌  did not reach a terminal verdict within the wait budget (fails LOUDLY)
```

- `verdictFromRuns(runs)` — pure, four-state, exported for unit tests.
- `waitForTerminalValueFsm(sha, {read, wait, attempts, delayMs})` — polls until a terminal read within a bounded budget (default 20 × 15s, inside the 10-min job). Injected `read`/`wait` make it testable without network or real clock.
- **Invariant preserved:** a run that never settles stays `pending`/`absent` and the card red-cards it — success must be positively observed, a label can never waive value-fsm. Missing/stuck value-fsm fails loudly, never silently green.
- Module `main()` guarded behind `import.meta.url` so tests import the seams without executing the gate.
- Docs surface: ADR-0030 + the script header comment now state that a non-terminal value-fsm yields **pending**, not failure.

`.github/workflows/merge-card.yml:12` trigger left as-is: inverting the dependency (value-fsm → merge-card via `workflow_run`, fork **C**) is the durable end state and is filed as a follow-up, not needed for A+B.

## Tests + gates

- `node --test scripts/merge-card-gate.test.mjs` — **11/11 pass**. Covers: `in_progress`→pending (the #655 bug, was "failure"); `queued`→pending; completed `success`/`failure`/`cancelled`; newest-run-wins with a fresh in_progress re-run superseding an old success; A1 `in_progress`→wait→success; A3 terminal failure fails fast (no wasted poll); missing run → timeout → absent (not success); stuck in_progress → timeout → pending. (No prior harness existed for `scripts/*.mjs`; this adds a minimal `node:test` one.)
- `node scripts/gates.mjs` — **all green** (32 gates).

## Along the way

`scripts/release-value-gate.mjs:111` has the identical `? "success" : "failure"` shape, but it runs at release time over a settled merged commit — a non-terminal value-fsm there is genuinely "not releasable", so it is left as-is (noted, not changed).

## Note — the irony

This PR touches `scripts/` only (non-runtime), so it has no `value-fsm` leg and won't hit the race itself. But **any** `value-signed` PR opened before this merges still can. When this PR is signed, expect the card to need **one final manual rerun** — the last one. After it lands, `value-signed` PRs clear without a hand rerun.
