### PR TITLE
fix(api.v1): restore native-id-keyed routes for 0.10 client continuity (#579)

### DIFF
--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -344,6 +344,16 @@ def create_app(
     async def accept_transcript_share(request: Request):
         return await _forward("POST", _meeting("/transcripts/share/accept"), request)
 
+    # native-keyed share MINT alias (#579 C3): the 0.10 api.v1 share path. The mint MOVED to
+    # POST /meetings/{platform}/{native}/share in 0.12; alias the old transcripts path to it so a
+    # 0.10 client no longer 404s. NOTE (signed): the 0.12 mint returns the capability-token share
+    # shape ({id, token, mode, expires_at}), NOT the sealed TranscriptShareResponse public-URL shape
+    # ({share_id, url, expires_at, expires_in_seconds}) — the public-URL-share backend is gone; only
+    # the capability-token share exists. See the PR's "signed gaps" section.
+    @app.post("/transcripts/{platform}/{native_meeting_id}/share")
+    async def mint_transcript_share_alias(platform: str, native_meeting_id: str, request: Request):
+        return await _forward("POST", _meeting(f"/meetings/{platform}/{native_meeting_id}/share"), request)
+
     @app.get("/transcripts/{platform}/{native_meeting_id}")
     async def transcript(platform: str, native_meeting_id: str, request: Request):
         return await _forward("GET", _meeting(f"/transcripts/{platform}/{native_meeting_id}"), request)
@@ -365,6 +375,15 @@ def create_app(
     # The master byte stream the recording player loads (the master metadata's raw_url points here).
     @app.get("/recordings/{recording_id}/media/{media_file_id}/raw")
     async def get_recording_media_raw(recording_id: int, media_file_id: int, request: Request):
+        return await _forward(
+            "GET", _meeting(f"/recordings/{recording_id}/media/{media_file_id}/raw"), request
+        )
+
+    # native download alias (#579 C3): the sealed api.v1 media-download path a 0.10 client calls.
+    # 0.12 renamed the media byte route to .../raw (finalize-on-read master stream); alias .../download
+    # to it so recording playback no longer 404s. Forwarded verbatim (Range headers preserved).
+    @app.get("/recordings/{recording_id}/media/{media_file_id}/download")
+    async def get_recording_media_download(recording_id: int, media_file_id: int, request: Request):
         return await _forward(
             "GET", _meeting(f"/recordings/{recording_id}/media/{media_file_id}/raw"), request
         )
@@ -409,6 +428,26 @@ def create_app(
         return await _forward(
             "PUT", _meeting(f"/meetings/{platform}/{native_meeting_id}/intent"), request
         )
+
+    # native-keyed mutate (#579 C1): the sealed api.v1 PATCH/DELETE a 0.10 client (incl. the shipped
+    # dashboard) calls by (platform, native_meeting_id). Thin passthrough — meeting-api resolves
+    # (platform, native) → the caller's newest OWNED row and forwards to the same row-id handler
+    # (unknown/unowned native → 404, FSM-owned row → 409). Additive: the by-ROW-id int routes above
+    # are unchanged; these 2-segment paths never shadow them (FastAPI matches on segment count).
+    @app.patch("/meetings/{platform}/{native_meeting_id}")
+    async def patch_native_meeting(platform: str, native_meeting_id: str, request: Request):
+        return await _forward("PATCH", _meeting(f"/meetings/{platform}/{native_meeting_id}"), request)
+
+    @app.delete("/meetings/{platform}/{native_meeting_id}")
+    async def delete_native_meeting(platform: str, native_meeting_id: str, request: Request):
+        return await _forward("DELETE", _meeting(f"/meetings/{platform}/{native_meeting_id}"), request)
+
+    # native-keyed chat READ (#579 C3): the sealed api.v1 GET the 0.10 dashboard's chat panel calls.
+    # Thin passthrough to meeting-api's honest empty-list restore (0.12 does not persist in-meeting
+    # chat server-side). The POST (send) half is a SIGNED GAP — no bot-command backend in 0.12.
+    @app.get("/bots/{platform}/{native_meeting_id}/chat")
+    async def read_meeting_chat(platform: str, native_meeting_id: str, request: Request):
+        return await _forward("GET", _meeting(f"/bots/{platform}/{native_meeting_id}/chat"), request)
 
     # ---- user self-serve webhook config (main.py:1080 set_user_webhook_proxy) ----
     # Identity OWNS the config (user.data JSONB via admin-api); the gateway is the public edge for

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -203,6 +203,60 @@ def test_planned_meeting_routes_forward_to_meeting_api():
     assert downstream.last["url"].endswith("/meetings/42")
 
 
+def test_native_meeting_mutate_forwards_to_meeting_api():
+    """#579 C1: native-keyed PATCH/DELETE /meetings/{platform}/{native} forward verbatim to
+    meeting-api (which resolves native → owned row). Negative control: on v0.12.2 there was no
+    2-segment route → 404 at the gateway. The 1-segment row-id routes are unchanged (above)."""
+    client, downstream = _client()
+    r = client.patch("/meetings/google_meet/abc-defg-hij", headers=AUTH, json={"title": "renamed"})
+    assert r.status_code == 200
+    assert downstream.last["method"] == "PATCH"
+    assert downstream.last["url"].endswith("/meetings/google_meet/abc-defg-hij")
+    assert "meeting-api" in downstream.last["url"]
+
+    client.delete("/meetings/google_meet/abc-defg-hij", headers=AUTH)
+    assert downstream.last["method"] == "DELETE"
+    assert downstream.last["url"].endswith("/meetings/google_meet/abc-defg-hij")
+
+
+def test_native_meeting_mutate_passes_downstream_404_verbatim():
+    """An unknown/unowned native id → meeting-api 404; the gateway returns it verbatim (not a
+    gateway-minted 404 for a missing route)."""
+    downstream = FakeDownstream(status_code=404, body={"detail": "Meeting not found"})
+    client, _ = _client(downstream=downstream)
+    r = client.patch("/meetings/google_meet/nope", headers=AUTH, json={"title": "x"})
+    assert r.status_code == 404
+
+
+def test_native_share_alias_forwards_to_meetings_share_mint():
+    """#579 C3: the 0.10 POST /transcripts/{platform}/{native}/share aliases to the moved mint at
+    POST /meetings/{platform}/{native}/share."""
+    client, downstream = _client()
+    r = client.post("/transcripts/google_meet/abc-defg-hij/share", headers=AUTH, json={})
+    assert r.status_code == 200
+    assert downstream.last["method"] == "POST"
+    assert downstream.last["url"].endswith("/meetings/google_meet/abc-defg-hij/share")
+    assert "meeting-api" in downstream.last["url"]
+
+
+def test_native_chat_read_forwards_to_meeting_api():
+    """#579 C3: GET /bots/{platform}/{native}/chat forwards to meeting-api's honest chat-read."""
+    client, downstream = _client()
+    r = client.get("/bots/google_meet/abc-defg-hij/chat", headers=AUTH)
+    assert r.status_code == 200
+    assert downstream.last["method"] == "GET"
+    assert downstream.last["url"].endswith("/bots/google_meet/abc-defg-hij/chat")
+
+
+def test_recording_download_alias_forwards_to_raw():
+    """#579 C3: GET /recordings/{id}/media/{mid}/download aliases to the .../raw byte route."""
+    client, downstream = _client()
+    r = client.get("/recordings/5/media/9/download", headers=AUTH)
+    assert r.status_code == 200
+    assert downstream.last["method"] == "GET"
+    assert downstream.last["url"].endswith("/recordings/5/media/9/raw")
+
+
 def test_planned_meeting_routes_require_api_key():
     client, downstream = _client()
     assert client.post("/meetings", json={"title": "x"}).status_code == 401

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -242,7 +242,12 @@ def build_router(
             "bots_status", audience="user", span="bots.status",
             user_id=user_id, fields={"running": len(running)},
         )
-        return JSONResponse(content={"running": running, "count": len(running)})
+        # `running_bots` is the sealed api.v1 field (golden BotStatusResponse.example.json) a 0.10
+        # client reads for the bot-running badge; `running`/`count` are the 0.12 names. All three are
+        # emitted (additive back-compat, #579 C2) — the same list under both keys.
+        return JSONResponse(content={
+            "running": running, "running_bots": running, "count": len(running),
+        })
 
     # --- GET /meetings/{meeting_id} → the single meeting (api.v1; the meeting-detail page fetches it).
     # Reuses list_meetings + filters by id (owner-scoped, so a non-owner can't read another's meeting). ---
@@ -356,17 +361,22 @@ def build_router(
     # workspace / auto_join). Owner-scoped; refused (409) once the row advanced into the bot FSM —
     # the FSM is never fought. `scheduled_at: null` clears the time (status flips to `idle`);
     # `meeting_url: null` detaches the link (row becomes link-less). ---
-    @router.patch("/meetings/{meeting_id}")
-    async def patch_planned_meeting(
-        meeting_id: int,
-        request: Request,
-        x_user_id: Optional[str] = Header(default=None),
-    ):
-        user_id = _resolve_user_id(x_user_id)
-        try:
-            payload = await request.json()
-        except Exception:
-            raise HTTPException(status_code=422, detail="invalid JSON body")
+    # --- native-id → owned ROW resolver (#579 C1). Resolve (platform, native) to the caller's
+    # NEWEST OWNED row, exactly the rule the native transcript/authorize paths use (list_meetings is
+    # created_at-desc). OWNER-scoped: `shared` rows (a workspace/transcript-share grant) are excluded
+    # so a viewer can never mutate/delete someone else's meeting via the native path. None → 404. ---
+    async def _resolve_owned_native(user_id: int, platform: str, native_meeting_id: str):
+        meetings = await store.list_meetings(user_id, platform=platform)
+        for m in meetings:  # newest-first
+            if (not m.get("shared")
+                    and m.get("platform") == platform
+                    and m.get("native_meeting_id") == native_meeting_id):
+                return m.get("id")
+        return None
+
+    # --- the ROW-id PATCH/DELETE bodies, factored out so the native-keyed aliases (#579 C1) forward
+    # to the SAME owner-scoped, FSM-refusing logic once they have resolved (platform, native) → row. ---
+    async def _apply_meeting_patch(user_id: int, meeting_id: int, payload) -> dict:
         if not isinstance(payload, dict):
             raise HTTPException(status_code=422, detail="body must be an object")
 
@@ -427,16 +437,9 @@ def build_router(
             native_id=row.get("native_meeting_id"), status=row.get("status"),
             when=(row.get("data") or {}).get("scheduled_at"), log_event=log_event,
         )
-        return JSONResponse(content=row)
+        return row
 
-    # --- DELETE /meetings/{meeting_id} → delete a PLANNED row (intent status only; an FSM row is
-    # never deletable from here). Owner-scoped, ROW-id addressed. ---
-    @router.delete("/meetings/{meeting_id}", status_code=204)
-    async def delete_planned_meeting(
-        meeting_id: int,
-        x_user_id: Optional[str] = Header(default=None),
-    ):
-        user_id = _resolve_user_id(x_user_id)
+    async def _apply_meeting_delete(user_id: int, meeting_id: int) -> None:
         result = await store.delete_planned_meeting(user_id, meeting_id)
         if result is None:
             raise HTTPException(status_code=404, detail="Meeting not found")
@@ -452,7 +455,99 @@ def build_router(
             redis, user_id=user_id, meeting_id=meeting_id, native_id=None,
             status="deleted", when=None, log_event=log_event,
         )
+
+    @router.patch("/meetings/{meeting_id}")
+    async def patch_planned_meeting(
+        meeting_id: int,
+        request: Request,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=422, detail="invalid JSON body")
+        row = await _apply_meeting_patch(user_id, meeting_id, payload)
+        return JSONResponse(content=row)
+
+    # --- DELETE /meetings/{meeting_id} → delete a PLANNED row (intent status only; an FSM row is
+    # never deletable from here). Owner-scoped, ROW-id addressed. ---
+    @router.delete("/meetings/{meeting_id}", status_code=204)
+    async def delete_planned_meeting(
+        meeting_id: int,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        await _apply_meeting_delete(user_id, meeting_id)
         return Response(status_code=204)
+
+    # --- native-keyed PATCH/DELETE /meetings/{platform}/{native_meeting_id} (#579 C1) — the sealed
+    # api.v1 mutate routes a 0.10 client (incl. the shipped dashboard) calls. Resolve (platform,
+    # native) → the caller's newest OWNED row, then forward to the SAME row-id logic above (which
+    # refuses an FSM-owned row with 409). Unknown/unowned native → 404. Additive: the int routes are
+    # unchanged. DELETE returns 200 + a small body (the sealed native-delete response), NOT the 204
+    # the row-id route returns. ---
+    @router.patch("/meetings/{platform}/{native_meeting_id}")
+    async def patch_native_meeting(
+        platform: str,
+        native_meeting_id: str,
+        request: Request,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=422, detail="invalid JSON body")
+        meeting_id = await _resolve_owned_native(user_id, platform, native_meeting_id)
+        if meeting_id is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Meeting not found for platform {platform} and ID {native_meeting_id}",
+            )
+        row = await _apply_meeting_patch(user_id, meeting_id, payload)
+        return JSONResponse(content=row)
+
+    @router.delete("/meetings/{platform}/{native_meeting_id}")
+    async def delete_native_meeting(
+        platform: str,
+        native_meeting_id: str,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        meeting_id = await _resolve_owned_native(user_id, platform, native_meeting_id)
+        if meeting_id is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Meeting not found for platform {platform} and ID {native_meeting_id}",
+            )
+        await _apply_meeting_delete(user_id, meeting_id)
+        return JSONResponse(content={
+            "status": "deleted", "id": meeting_id,
+            "platform": platform, "native_meeting_id": native_meeting_id,
+        })
+
+    # --- GET /bots/{platform}/{native_meeting_id}/chat (#579 C3, sealed api.v1 ChatMessagesResponse).
+    # Thin HONEST restore: the route + owner boundary are real (unowned/unknown native → 404), but
+    # 0.12 does not PERSIST in-meeting chat server-side (chat frames flow live over the va:…:chat WS
+    # channel and are not stored), so the captured-message list is always empty until a chat-capture
+    # backend lands. The response conforms to the sealed shape; the empty list is the truthful state,
+    # not a fabricated one. The POST (send) half is a SIGNED GAP — see the PR (no bot-command backend
+    # in the 0.12 core). ---
+    @router.get("/bots/{platform}/{native_meeting_id}/chat")
+    async def read_meeting_chat(
+        platform: str,
+        native_meeting_id: str,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        meeting_id = await _resolve_owned_native(user_id, platform, native_meeting_id)
+        if meeting_id is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Meeting not found for platform {platform} and ID {native_meeting_id}",
+            )
+        return JSONResponse(content={"messages": []})
 
     # --- POST /meetings/{platform}/{native_meeting_id}/workspace → BIND the meeting to a shared workspace
     # (meetings.data.workspace_id). Owner-scoped. Members of that workspace can then subscribe to this

--- a/core/meetings/services/meeting-api/tests/test_native_id_api_v1.py
+++ b/core/meetings/services/meeting-api/tests/test_native_id_api_v1.py
@@ -1,0 +1,144 @@
+"""#579 — native-id-keyed api.v1 continuity on the meeting-api collector.
+
+A 0.10 api.v1 client (incl. the shipped 0.10 dashboard) addresses meetings by
+``(platform, native_meeting_id)``. 0.12 re-keyed the mutate routes to numeric row-id, so those
+native paths 404'd. These tests drive the SHIPPED collector handlers (offline, in-memory fake)
+proving the restored native-keyed surface:
+
+  * PATCH /meetings/{platform}/{native} — resolves native → newest OWNED row → 200 (rename);
+    unknown native → 404; FSM-owned row → 409; a shared (non-owned) row → 404 (never mutable).
+  * DELETE /meetings/{platform}/{native} — 200 + row gone; unknown → 404.
+  * GET /bots/status — carries BOTH `running` and `running_bots` (sealed golden field), same list.
+  * GET /bots/{platform}/{native}/chat — owner boundary real (unowned → 404); honest empty list.
+
+Negative control for the acceptance table: the same requests on current v0.12.2 (no native route)
+return 404 — these tests are the green half of that red→green pair.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+USER = 7
+H = {"x-user-id": str(USER)}
+URL = "https://meet.google.com/abc-defg-hij"
+PLAT, NATIVE = "google_meet", "abc-defg-hij"
+
+
+class _CaptureRedis:
+    def __init__(self):
+        self.published: list[tuple[str, str]] = []
+
+    async def publish(self, channel, data):
+        self.published.append((channel, data))
+
+
+def _client():
+    store = InMemoryTranscriptStore()
+    return TestClient(create_app(store, redis=_CaptureRedis())), store
+
+
+# ---- C1: native PATCH ---------------------------------------------------------------
+
+def test_native_patch_renames_owned_meeting_200():
+    client, _store = _client()
+    # a planned meeting created from a link carries (platform, native)
+    client.post("/meetings", json={"title": "old", "meeting_url": URL}, headers=H)
+    r = client.patch(f"/meetings/{PLAT}/{NATIVE}", json={"title": "new"}, headers=H)
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["title"] == "new"
+
+
+def test_native_patch_resolves_to_newest_row():
+    """Several rows on the SAME native link → the native path addresses the NEWEST (spawn-dedup rule)."""
+    client, store = _client()
+    store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=NATIVE, status="idle",
+                       created_at="2026-01-01T00:00:00Z")
+    newest = store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=NATIVE, status="idle",
+                                created_at="2026-06-01T00:00:00Z")
+    r = client.patch(f"/meetings/{PLAT}/{NATIVE}", json={"title": "hit-newest"}, headers=H)
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == newest
+
+
+def test_native_patch_unknown_native_404():
+    client, _store = _client()
+    r = client.patch(f"/meetings/{PLAT}/nope-nope-nope", json={"title": "x"}, headers=H)
+    assert r.status_code == 404
+
+
+def test_native_patch_fsm_row_409():
+    client, store = _client()
+    store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=NATIVE, status="active")
+    r = client.patch(f"/meetings/{PLAT}/{NATIVE}", json={"title": "nope"}, headers=H)
+    assert r.status_code == 409
+
+
+def test_native_patch_shared_row_not_owned_404():
+    """A row owned by another user but visible to the caller via a workspace share is NEVER mutable
+    through the native path — owner-scoped resolution excludes `shared` rows."""
+    client, store = _client()
+    store.seed_meeting(user_id=999, platform=PLAT, native_meeting_id=NATIVE, status="idle",
+                       data={"workspace_id": "ws-1"})
+    r = client.patch(f"/meetings/{PLAT}/{NATIVE}", json={"title": "steal"},
+                     headers={"x-user-id": str(USER), "x-user-workspaces": "ws-1"})
+    assert r.status_code == 404
+
+
+# ---- C1: native DELETE --------------------------------------------------------------
+
+def test_native_delete_owned_meeting_200_and_gone():
+    client, store = _client()
+    mid = client.post("/meetings", json={"title": "x", "meeting_url": URL}, headers=H).json()["id"]
+    r = client.delete(f"/meetings/{PLAT}/{NATIVE}", headers=H)
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == mid
+    assert mid not in store._meetings
+
+
+def test_native_delete_unknown_native_404():
+    client, _store = _client()
+    assert client.delete(f"/meetings/{PLAT}/{NATIVE}", headers=H).status_code == 404
+
+
+# ---- row-id routes still work (no regression) ---------------------------------------
+
+def test_row_id_patch_still_200():
+    client, _store = _client()
+    mid = client.post("/meetings", json={"title": "x"}, headers=H).json()["id"]
+    assert client.patch(f"/meetings/{mid}", json={"title": "y"}, headers=H).status_code == 200
+
+
+def test_row_id_delete_still_204():
+    client, _store = _client()
+    mid = client.post("/meetings", json={"title": "x"}, headers=H).json()["id"]
+    assert client.delete(f"/meetings/{mid}", headers=H).status_code == 204
+
+
+# ---- C2: /bots/status running_bots back-compat --------------------------------------
+
+def test_bots_status_carries_running_and_running_bots():
+    client, store = _client()
+    store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=NATIVE, status="active")
+    body = client.get("/bots/status", headers=H).json()
+    assert "running" in body and "running_bots" in body
+    assert body["running_bots"] == body["running"]
+    assert len(body["running_bots"]) == 1
+    assert body["count"] == 1
+
+
+# ---- C3: native chat READ (honest empty; owner boundary real) -----------------------
+
+def test_chat_read_owned_returns_empty_messages():
+    client, store = _client()
+    store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=NATIVE, status="active")
+    r = client.get(f"/bots/{PLAT}/{NATIVE}/chat", headers=H)
+    assert r.status_code == 200, r.text
+    assert r.json() == {"messages": []}
+
+
+def test_chat_read_unowned_404():
+    client, _store = _client()
+    assert client.get(f"/bots/{PLAT}/{NATIVE}/chat", headers=H).status_code == 404

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -97,6 +97,29 @@ curl -X DELETE "$API_BASE/meetings/12345" -H "X-API-Key: $API_KEY"
 
 Both answer `404` for a record you don't own and `409` once the bot lifecycle owns the record.
 
+The same edit/delete is also reachable **by native key** — `PATCH`/`DELETE
+/meetings/{platform}/{native_meeting_id}` — which resolves `(platform, native_meeting_id)` to your
+newest owned row and applies the same rules (`404` unknown/unowned, `409` once FSM-owned). Use it
+when you address meetings by their join-link identity rather than the record id; `DELETE` answers
+`200` on this path (the by-record-id `DELETE` answers `204`).
+
+## api.v1 native-id support (per route)
+
+`api.v1` is sealed as a **file hash** (`contracts.seal.json`), which pins the schema document, not
+the running implementation. This table states, per route, whether the `(platform,
+native_meeting_id)` keying a 0.10 client uses is served by the 0.12 core:
+
+| Route | Native-id keying in 0.12 |
+|---|---|
+| `PATCH /meetings/{platform}/{native_meeting_id}` | **Yes** — resolves to your newest owned row. |
+| `DELETE /meetings/{platform}/{native_meeting_id}` | **Yes** — `200` on success (by-id path is `204`). |
+| `GET /bots/status` | **Yes** — body carries both `running_bots` (0.10) and `running`/`count` (0.12). |
+| `POST /transcripts/{platform}/{native_meeting_id}/share` | **Aliased** to the moved `POST /meetings/{platform}/{native_meeting_id}/share` mint. The response is the capability-token share (`{id, token, mode, expires_at}`), not the 0.10 public-URL `TranscriptShareResponse` — the public-URL-share backend is not in the 0.12 core. |
+| `GET /recordings/{recording_id}/media/{media_file_id}/download` | **Aliased** to the `.../raw` master byte stream (Range-capable). |
+| `GET /bots/{platform}/{native_meeting_id}/chat` | **Restored, empty** — the owner boundary is real; the message list is always empty (0.12 does not persist in-meeting chat server-side; chat flows live over the WS `va:…:chat` channel). |
+| `POST /bots/{platform}/{native_meeting_id}/chat` | **Not implemented** — no bot-command (send) backend in the 0.12 core. |
+| `POST /meetings/{meeting_id}/transcribe` | **Not implemented** — no on-demand re-transcribe backend in the 0.12 core. |
+
 ## Auto-join
 
 A `scheduled` meeting **with a link** is joined automatically: a background sweep sends the bot


### PR DESCRIPTION
Closes #579. Companion/enabler for #591 (the reverse `contract ⊆ impl` conformance gate is the follow-up, built on top of this branch).

Restores the sealed native-id `api.v1` surface a 0.10 client (incl. `vexaai/dashboard:0.10.6.x`) calls, so rename/delete/share/chat/download stop 404ing against a 0.12 core and the bot-running badge reads truthfully. **All changes are additive** — no existing 0.12 route removed or altered.

## Observation bundle (#579 acceptance table)

| # | Observation | Evidence (green) | Negative control |
|---|---|---|---|
| A1 | `PATCH /meetings/{platform}/{native}` renames → 200 | `test_native_patch_renames_owned_meeting_200`, gateway `test_native_meeting_mutate_forwards_to_meeting_api` | no 2-seg route on v0.12.2 → 404 |
| A2 | `DELETE /meetings/{platform}/{native}` → 200; row gone | `test_native_delete_owned_meeting_200_and_gone` | v0.12.2 → 404 |
| A3 | `/bots/status` body has `running_bots` == `running` | `test_bots_status_carries_running_and_running_bots` | v0.12.2 → key absent |
| A- | No-regression: gateway + meeting-api lanes + repo gates green | full suites + `node scripts/gates.mjs all` (below) | — |

Extra coverage: newest-row resolution (`test_native_patch_resolves_to_newest_row`), owner-scoping (a workspace-shared row is **not** mutable via native path → 404), FSM row → 409, unknown native → 404, row-id routes unchanged (204 delete / 200 patch), downstream-404 passed verbatim, share + download + chat aliases forward correctly.

## The 6 sealed rows (#591 table): restored vs signed-gap

| Row | Status |
|---|---|
| `PATCH,DELETE /meetings/{platform}/{native}` | **Restored** (real — native→newest-owned-row → row-id logic) |
| `GET /bots/status` `running_bots` | **Restored** (additive field, same list) |
| `POST /transcripts/{platform}/{native}/share` | **Restored path** (aliased to the moved `/meetings/.../share` mint) — see signed gap on **shape** |
| `GET /recordings/{id}/media/{mid}/download` | **Restored** (aliased to `.../raw`, Range-capable) |
| `POST,GET /bots/{platform}/{native}/chat` | **GET restored honest-empty**; **POST is a signed gap** |
| `POST /meetings/{meeting_id}/transcribe` | **Signed gap** |

## Signed gaps (backend capability genuinely absent in the 0.12 core — not faked)

1. **`POST /bots/{platform}/{native}/chat` (send).** 0.12 has no bot-command (send-to-meeting) backend — the same class as `/speak` and `/config`, which also lack a downstream handler. Chat frames flow live over the WS `va:…:chat` channel but there is no REST send. Registering a 200 that does nothing would fake the capability, so the send half is left unimplemented and documented.
2. **`POST /meetings/{meeting_id}/transcribe` (re-transcribe).** No on-demand re-transcribe orchestration exists in the 0.12 core (transcription is a live-pipeline concern). Left unimplemented + documented.
3. **Share response *shape*.** The 0.10 sealed `TranscriptShareResponse` (`{share_id, url, expires_at, expires_in_seconds}`) is a **public-URL** share; the 0.12 `/meetings/.../share` mint returns a **capability-token** share (`{id, token, mode, expires_at}`). The public-URL-share backend is not in the 0.12 core. The path is aliased (no more 404) but the response shape diverges; the reverse-conformance gate (#591) will have to treat this as a re-version-or-restore decision, not a silent pass.
4. **`GET /bots/{platform}/{native}/chat` returns an empty list always** — the owner boundary (404 unowned) is real, but 0.12 does not persist in-meeting chat server-side, so the message list is honestly empty until a capture backend lands.

## Docs (D6c)

`docs/docs/api/meetings.mdx` gains a per-route **"api.v1 native-id support"** table stating exactly what the seal (a file hash) guarantees vs. what the implementation serves, including the aliases and the two signed gaps.

## Gates + tests

- `node scripts/gates.mjs all` → **✅ gates green** (incl. `gate:contract-conformance`, `gate:python` 12 pkgs, `gate:db-budget` Σ70/100 — no false-positive).
- meeting-api suite: 735 passed / 5 skipped (12 new in `test_native_id_api_v1.py`).
- gateway suite: 90 passed / 1 xfailed (5 new forwarding tests in `test_proxy.py`).
- gateway conformance suite: 79 passed.

## Live-witness note

Witnessed at the offline seam (TestClient over the shipped `create_app` factories) — native PATCH→200/DELETE→200, unknown→404, owner-scoping→404, `/bots/status` dual-field, chat/share/download aliases. The issue's declared human bar (0.10 dashboard image against a 0.12 gateway, an operator renaming/deleting a meeting) is a **helm/hosted** run left for the non-author validator — the preferred signer is the original reporter.

Not merging; no labels.