### PR TITLE
release: v0.12.7 version bump

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.6"
+appVersion: "0.12.7"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -3,10 +3,10 @@ title: "Changelog & migration"
 description: "Release notes and what changes between major versions."
 ---
 
-{/* docs-reflects: 0.12.6 — the released version these docs describe. CI (gate:docs-version) keeps
+{/* docs-reflects: 0.12.7 — the released version these docs describe. CI (gate:docs-version) keeps
     this equal to Chart.yaml appVersion; the release version-bump updates it. */}
 
-> 📌 **These docs reflect Vexa `v0.12.6`** — the latest released control-plane. Older self-hosts
+> 📌 **These docs reflect Vexa `v0.12.7`** — the latest released control-plane. Older self-hosts
 > should read against their pinned version.
 
 The authoritative, per-release changelog is on **GitHub Releases**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
Bumps package.json + Chart.yaml appVersion + docs-reflects to **0.12.7**.

Re-cut of the never-promoted v0.12.6 candidate (no committed witness.json → not a shipped baseline) plus the 11 production-facing fixes merged since it: #546 #578 #579 #591 #628 #655 #656 #657 #659 #660 and witness-baseline #658.

Per the two-phase release flow (releases/README.md), the promote batch baseline is the last *shipped* release with a receipt (v0.12.4), so the v0.12.7 witness will cover the full `v0.12.4...v0.12.7` set a `:v012` user actually receives on promote — v0.12.6's 15 PRs + these 11.

Gates: gate:docs-version + gate:contract-version green locally.

Next: tag v0.12.7 → release-images publishes candidate (promote:false) → witness on lite+compose+helm → owner-gated promote.