### PR TITLE
fix(runtime): spawned k8s Pods inherit the runtime's scheduling constraints (#673)

### DIFF
--- a/core/runtime/src/runtime_kernel/config.v1.json
+++ b/core/runtime/src/runtime_kernel/config.v1.json
@@ -90,6 +90,24 @@
    "targets": []
   },
   {
+   "key": "RUNTIME_K8S_TOLERATIONS",
+   "class": "defaulted",
+   "default": "(chart's global.tolerations, JSON — the runtime's own tolerations)",
+   "description": "k8s backend: JSON array of toleration objects stamped onto every SPAWNED Pod's spec so a bare `kubectl run` bot/agent Pod (not a Deployment child) tolerates the same taints the runtime does — else it strands Pending forever on an all-tainted pool (#673). Empty [] ⇒ no tolerations; malformed JSON is fatal at spawn (a silently dropped constraint is the bug)",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
+   "key": "RUNTIME_K8S_NODE_SELECTOR",
+   "class": "defaulted",
+   "default": "(chart's global.nodeSelector, JSON — the runtime's own nodeSelector)",
+   "description": "k8s backend: JSON object of node-label selectors stamped onto every SPAWNED Pod's spec so a bare `kubectl run` bot/agent Pod schedules onto the same pool the runtime does. Empty {} ⇒ no selector; malformed JSON is fatal at spawn (#673)",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
    "key": "BROWSER_IMAGE",
    "class": "capability",
    "capability": "bot_spawn",

--- a/core/runtime/src/runtime_kernel/k8s_backend.py
+++ b/core/runtime/src/runtime_kernel/k8s_backend.py
@@ -16,6 +16,43 @@ from .profiles import Runnable
 MANAGED_LABEL = "runtime.managed"
 WORKLOAD_ID_LABEL = "runtime.workload_id"
 
+# The runtime's OWN scheduling constraints, serialized as JSON by the chart from
+# global.tolerations / global.nodeSelector (see deployment-runtime.yaml). A spawned workload is a bare
+# `kubectl run` Pod — NOT a Deployment child — so it inherits none of the runtime Deployment's
+# scheduling directives; on an all-tainted pool it sits Pending forever and the meeting silently fails.
+# These knobs let the spawn override carry the runtime's own constraints so the Pod schedules wherever
+# the runtime itself is allowed to run.
+TOLERATIONS_ENV = "RUNTIME_K8S_TOLERATIONS"      # JSON array of toleration objects
+NODE_SELECTOR_ENV = "RUNTIME_K8S_NODE_SELECTOR"  # JSON object of node-label selectors
+
+
+def _scheduling_json(env: dict[str, str], key: str, expected: type) -> Optional[object]:
+    """Parse one scheduling knob (``key``) from ``env`` as JSON of ``expected`` shape. Unset or empty
+    (the chart's default ``[]`` / ``{}`` serialize to ``"[]"`` / ``"{}"``) ⇒ None (no constraint,
+    today's behaviour). Malformed JSON or a wrong shape is FATAL (raise) — a scheduling constraint
+    silently dropped is exactly the bug this fixes (a stranded Pending Pod, a silent meeting failure),
+    so it must fail loud at spawn, never fail open like the workspace mount set."""
+    raw = env.get(key)
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return None
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError(f"{key} is not valid JSON: {exc}") from exc
+    if not isinstance(value, expected):
+        raise ValueError(
+            f"{key} must be a JSON {expected.__name__}, got {type(value).__name__}: {raw!r}"
+        )
+    return value or None                                 # empty [] / {} ⇒ treat as unset
+
+
+def _runtime_scheduling_env() -> dict[str, str]:
+    """The runtime's own scheduling knobs from its PROCESS env (set by the chart on the runtime
+    Deployment). Overlaid onto the per-workload spawn env for ``pod_overrides`` — spec.env cannot
+    carry these: it is built per-workload by different producers (meeting-api for a bot, agent-api for
+    an agent worker), whereas the scheduling constraints are a property of the runtime/backend."""
+    return {k: os.environ[k] for k in (TOLERATIONS_ENV, NODE_SELECTOR_ENV) if os.environ.get(k)}
+
 
 def _kubectl(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     r = subprocess.run(["kubectl", *args], capture_output=True, text=True)
@@ -36,22 +73,37 @@ def _stop_grace_sec() -> int:
 
 
 def pod_overrides(env: dict[str, str], *, container_name: str) -> Optional[dict]:
-    """The ``kubectl run --overrides`` spec that mounts the workspace store into the worker Pod — the k8s
-    twin of the docker backend's ``Binds``, from the SAME env. The store PVC (``VEXA_WORKSPACE_MOUNT_SOURCE``
-    = the claim name on k8s) is bound at the store root (``VEXA_WORKSPACE_MOUNT_TARGET``), exposing the WHOLE
-    active mount set (WP-A1.1) — every in-store workspace lives under the root. Returns None when no store
-    is configured (no override needed). Pure/env-driven → unit-tested offline (no kubectl)."""
+    """The ``kubectl run --overrides`` spec for a spawned Pod, built from the SAME env. It carries two
+    independent seams:
+
+      * the workspace store mount set (WP-A1.1): the store PVC (``VEXA_WORKSPACE_MOUNT_SOURCE`` = the
+        claim name on k8s) exposes every in-store workspace via per-mount subPath volumeMounts;
+      * the runtime's scheduling constraints (``RUNTIME_K8S_TOLERATIONS`` / ``RUNTIME_K8S_NODE_SELECTOR``)
+        so the bare ``kubectl run`` Pod — which inherits none of the runtime Deployment's scheduling —
+        lands where the runtime itself is allowed to run instead of stranding Pending on a tainted pool.
+
+    The spec is built whenever EITHER seam is present; returns None only when neither is (no override
+    needed). Building it for scheduling alone is load-bearing: a plain meeting bot has no workspace PVC,
+    so a volumes-only early return would silently drop its tolerations and re-create the bug. Pure/
+    env-driven → unit-tested offline (no kubectl)."""
     pvc = env.get("VEXA_WORKSPACE_MOUNT_SOURCE")
     root = env.get("VEXA_WORKSPACE_MOUNT_TARGET")
     volumes, volume_mounts = k8s_volume_mounts(env, pvc_name=pvc or "", store_target=root or "")
-    if not volumes:
+    tolerations = _scheduling_json(env, TOLERATIONS_ENV, list)
+    node_selector = _scheduling_json(env, NODE_SELECTOR_ENV, dict)
+    if not volumes and not tolerations and not node_selector:
         return None
-    return {
-        "spec": {
-            "containers": [{"name": container_name, "volumeMounts": volume_mounts}],
-            "volumes": volumes,
-        }
-    }
+    container: dict = {"name": container_name}
+    if volume_mounts:
+        container["volumeMounts"] = volume_mounts
+    spec: dict = {"containers": [container]}
+    if volumes:
+        spec["volumes"] = volumes
+    if tolerations:
+        spec["tolerations"] = tolerations
+    if node_selector:
+        spec["nodeSelector"] = node_selector
+    return {"spec": spec}
 
 
 class K8sBackend:
@@ -80,10 +132,12 @@ class K8sBackend:
         ]
         for k, v in env.items():
             args += [f"--env={k}={v}"]
-        # Workspace mount set (WP-A1.1): the store PVC is bound at the store root via --overrides,
-        # exposing every active workspace (they live under the root). The container name kubectl uses
-        # for a `run` Pod is the Pod name, so the volumeMount targets that container.
-        overrides = pod_overrides(env, container_name=name)
+        # The --overrides spec carries the workspace mount set (WP-A1.1: the store PVC bound per-mount,
+        # container name = Pod name for a `run` Pod) AND the runtime's own scheduling constraints. The
+        # latter live in the runtime's PROCESS env (the chart sets them on the runtime Deployment), not
+        # in the per-workload spec.env, so overlay them here; the workload's own --env (above) is left
+        # untouched — scheduling shapes the Pod, it is not container config.
+        overrides = pod_overrides({**env, **_runtime_scheduling_env()}, container_name=name)
         if overrides:
             args += ["--overrides", json.dumps(overrides)]
         if runnable.command:

--- a/core/runtime/tests/test_mounts.py
+++ b/core/runtime/tests/test_mounts.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from runtime_kernel.mounts import MountBind, k8s_volume_mounts, mount_set, workspace_binds
 from runtime_kernel.docker_backend import DockerBackend  # for the docker bind-string shape
 from runtime_kernel.k8s_backend import pod_overrides
@@ -163,6 +165,90 @@ def test_k8s_pod_overrides_carry_the_per_mount_spec():
 
 def test_k8s_pod_overrides_none_when_no_store_configured():
     assert pod_overrides({}, container_name="x") is None
+
+
+# ── k8s: scheduling constraints merged into the spawn override (#673) ──────────
+# A spawned Pod is a bare `kubectl run` Pod — NOT a Deployment child — so it inherits none of the
+# runtime Deployment's nodeSelector/tolerations. Without these it strands Pending forever on an
+# all-tainted pool and the meeting silently fails. RUNTIME_K8S_TOLERATIONS / RUNTIME_K8S_NODE_SELECTOR
+# (JSON, from the chart's global.*) let the override carry the runtime's own constraints.
+
+_TOL = [{"key": "vexa.ai/pool", "operator": "Equal", "value": "main", "effect": "NoSchedule"}]
+_SEL = {"vexa.ai/pool": "main"}
+
+
+def _sched_env(*, tolerations=None, node_selector=None, **kw):
+    e = _env(**kw) if kw else {}
+    if tolerations is not None:
+        e["RUNTIME_K8S_TOLERATIONS"] = json.dumps(tolerations)
+    if node_selector is not None:
+        e["RUNTIME_K8S_NODE_SELECTOR"] = json.dumps(node_selector)
+    return e
+
+
+def test_k8s_pod_overrides_tolerations_only_no_pvc_builds_a_valid_spec():
+    """The load-bearing case: a plain meeting bot has NO workspace PVC, yet its spawn override MUST
+    still carry tolerations — a volumes-only early return would silently drop them and re-create #673.
+    Negative control: the pre-#673 pod_overrides returned None here (no store ⇒ no override at all)."""
+    ov = pod_overrides(_sched_env(tolerations=_TOL, node_selector=_SEL), container_name="vexa-mtg-6")
+    assert ov is not None                                  # NOT None — the pre-#673 bug returned None
+    spec = ov["spec"]
+    assert spec["tolerations"] == _TOL
+    assert spec["nodeSelector"] == _SEL
+    assert "volumes" not in spec                           # no PVC ⇒ no volumes, but scheduling stands
+    assert spec["containers"] == [{"name": "vexa-mtg-6"}]  # no volumeMounts when no store
+
+
+def test_k8s_pod_overrides_merges_pvc_and_scheduling():
+    """An agent worker with a workspace PVC: the override carries BOTH the per-mount volumeMounts AND
+    the scheduling constraints — the two seams coexist."""
+    ov = pod_overrides(
+        _sched_env(tolerations=_TOL, node_selector=_SEL, source="vexa-agent-workspaces"),
+        container_name="vexa-worker-u1",
+    )
+    spec = ov["spec"]
+    assert spec["volumes"][0]["persistentVolumeClaim"]["claimName"] == "vexa-agent-workspaces"
+    assert spec["containers"][0]["volumeMounts"] == [
+        {"name": "workspace-store", "mountPath": "/workspaces/u1", "subPath": "u1", "readOnly": False}
+    ]
+    assert spec["tolerations"] == _TOL
+    assert spec["nodeSelector"] == _SEL
+
+
+def test_k8s_pod_overrides_empty_scheduling_is_unchanged_from_today():
+    """The chart's DEFAULT deployment serializes global.tolerations=[] / global.nodeSelector={} to the
+    strings "[]" / "{}". These are treated as unset — no scheduling appears, and a no-store spawn still
+    returns None — so an untainted cluster sees exactly today's behaviour (no regression)."""
+    assert pod_overrides({"RUNTIME_K8S_TOLERATIONS": "[]", "RUNTIME_K8S_NODE_SELECTOR": "{}"},
+                         container_name="x") is None
+    ov = pod_overrides(_sched_env(tolerations=[], node_selector={}, source="vexa-agent-workspaces"),
+                       container_name="vexa-worker-u1")
+    assert "tolerations" not in ov["spec"] and "nodeSelector" not in ov["spec"]
+    assert ov["spec"]["volumes"]                           # volumes-only spec, exactly as before #673
+
+
+def test_k8s_pod_overrides_malformed_scheduling_json_fails_loud():
+    """Malformed scheduling JSON is FATAL (raise), not fail-open like the workspace mount set: a
+    silently dropped toleration is precisely the stranded-Pod / silent-meeting-failure bug."""
+    with pytest.raises(ValueError, match="RUNTIME_K8S_TOLERATIONS"):
+        pod_overrides({"RUNTIME_K8S_TOLERATIONS": "{not json"}, container_name="x")
+    # wrong shape (object where an array is required) is caught too
+    with pytest.raises(ValueError, match="RUNTIME_K8S_NODE_SELECTOR"):
+        pod_overrides({"RUNTIME_K8S_NODE_SELECTOR": "[1,2]"}, container_name="x")
+
+
+def test_k8s_start_overlays_runtime_process_scheduling_env(monkeypatch):
+    """start() overlays the runtime's OWN process env (RUNTIME_K8S_* set by the chart on the runtime
+    Deployment) onto the spawn override — spec.env, built per-workload by meeting-api/agent-api, cannot
+    carry these. Proven via _runtime_scheduling_env without a cluster."""
+    from runtime_kernel.k8s_backend import _runtime_scheduling_env
+    monkeypatch.setenv("RUNTIME_K8S_TOLERATIONS", json.dumps(_TOL))
+    monkeypatch.setenv("RUNTIME_K8S_NODE_SELECTOR", json.dumps(_SEL))
+    overlay = _runtime_scheduling_env()
+    # the workload's own spec.env has no scheduling; the overlay supplies it → the override carries it
+    ov = pod_overrides({**_env(source="vexa-agent-workspaces"), **overlay}, container_name="w")
+    assert ov["spec"]["tolerations"] == _TOL
+    assert ov["spec"]["nodeSelector"] == _SEL
 
 
 # ── process: shares the host FS — no binds, but N-mount aware (parity) ────────

--- a/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
@@ -105,6 +105,19 @@ spec:
               value: {{ .Values.models.anthropicHaikuModel | default "" | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.runtime.logLevel | default "info" | quote }}
+            {{- if eq .Values.runtime.backend "k8s" }}
+            # Scheduling parity for SPAWNED Pods (#673). A `kubectl run` bot/agent Pod is not a child of
+            # this Deployment, so it inherits none of the nodeSelector/tolerations applied below at the
+            # pod spec (:143-154). Hand the runtime its OWN scheduling constraints as JSON so the spawn
+            # backend can stamp them onto every spawned Pod — otherwise, on an all-tainted pool (dedicated
+            # / spot / GPU node pools), every spawn strands Pending and the meeting silently fails.
+            # Defaults to the runtime's own constraints (global.*); override per-runtime for a distinct
+            # spawn pool (e.g. GPU bots).
+            - name: RUNTIME_K8S_TOLERATIONS
+              value: {{ .Values.runtime.tolerations | default .Values.global.tolerations | toJson | quote }}
+            - name: RUNTIME_K8S_NODE_SELECTOR
+              value: {{ .Values.runtime.nodeSelector | default .Values.global.nodeSelector | toJson | quote }}
+            {{- end }}
             {{- with .Values.runtime.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -195,6 +195,16 @@ runtime:
   resources:
     requests: { cpu: 50m, memory: 256Mi }
     limits:   { cpu: 500m, memory: 768Mi }
+  # Scheduling for the Pods the runtime SPAWNS (backend=k8s). A `kubectl run` bot/agent Pod is NOT a
+  # child of the runtime Deployment, so it does NOT inherit global.nodeSelector/global.tolerations —
+  # on an all-tainted pool (dedicated / spot / GPU node pools) every spawn strands Pending and the
+  # meeting silently fails (#673). By DEFAULT (leave these unset) spawned Pods inherit the runtime's
+  # own constraints — global.tolerations / global.nodeSelector — so they schedule wherever the runtime
+  # itself can, with zero operator action. Set these ONLY to send spawned workloads to a DIFFERENT
+  # pool than the kernel (e.g. GPU bots): they are passed to the backend as RUNTIME_K8S_TOLERATIONS /
+  # RUNTIME_K8S_NODE_SELECTOR (JSON) and stamped onto every spawned Pod's spec.
+  # tolerations: []            # override global.tolerations for spawned Pods (list of toleration objects)
+  # nodeSelector: {}           # override global.nodeSelector for spawned Pods (node-label map)
   extraEnv: []
 
 # Agent control plane — /invocations dispatch + /api/chat SSE (compose: agent-api → :8100).

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -43,6 +43,11 @@ need 2 'name: MEETING_API_URL' "MEETING_API_URL set on gateway AND meeting-api"
 # #656: meeting-api MUST get ADMIN_API_URL or calendar sync no-ops and auto-join spawns uncapped.
 # It rides the gateway env too; assert >=2 (gateway + meeting-api).
 need 2 'name: ADMIN_API_URL'   "ADMIN_API_URL set on gateway AND meeting-api"
+# #673: the runtime (backend=k8s) MUST carry its own scheduling constraints as env, or every SPAWNED
+# bot/agent Pod (a bare `kubectl run` Pod, not a Deployment child) strands Pending on an all-tainted
+# pool and the meeting silently fails. Durable seam-guard so a refactor can't drop it again.
+need 1 'name: RUNTIME_K8S_TOLERATIONS'   "runtime carries spawn-Pod tolerations env"
+need 1 'name: RUNTIME_K8S_NODE_SELECTOR' "runtime carries spawn-Pod nodeSelector env"
 
 # auth unset (values-test) → the chart Secret must NOT carry the key; auth set → it must.
 if printf '%s\n' "$RENDER" | grep -qE '^  CLAUDE_CODE_OAUTH_TOKEN:'; then
@@ -56,6 +61,26 @@ if printf '%s\n' "$RENDER_AUTH" | grep -qE '^  CLAUDE_CODE_OAUTH_TOKEN: "sk-test
   echo "  OK: CLAUDE_CODE_OAUTH_TOKEN lands in the Secret when set"
 else
   echo "  FAIL: CLAUDE_CODE_OAUTH_TOKEN missing from the Secret when set"; fail=1
+fi
+
+# #673: with global scheduling set, the runtime env must carry the SERIALIZED JSON values (not just
+# the keys) — proof the seam actually threads global.tolerations/nodeSelector to the spawn backend.
+RENDER_SCHED="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set-json 'global.tolerations=[{"key":"vexa.ai/pool","operator":"Equal","value":"main","effect":"NoSchedule"}]' \
+  --set-json 'global.nodeSelector={"vexa.ai/pool":"main"}')"
+# toJson sorts keys, so the toleration serializes as effect,key,operator,value — assert the
+# distinctive tokens are present on the value line (order-independent), not the empty "[]".
+tol_line="$(printf '%s\n' "$RENDER_SCHED" | grep -A1 'name: RUNTIME_K8S_TOLERATIONS' | grep 'value:')"
+if printf '%s\n' "$tol_line" | grep -q 'NoSchedule' && printf '%s\n' "$tol_line" | grep -q 'vexa.ai/pool'; then
+  echo "  OK: runtime RUNTIME_K8S_TOLERATIONS carries global.tolerations JSON"
+else
+  echo "  FAIL: runtime RUNTIME_K8S_TOLERATIONS missing the global.tolerations JSON"; fail=1
+fi
+sel_line="$(printf '%s\n' "$RENDER_SCHED" | grep -A1 'name: RUNTIME_K8S_NODE_SELECTOR' | grep 'value:')"
+if printf '%s\n' "$sel_line" | grep -q 'vexa.ai/pool' && printf '%s\n' "$sel_line" | grep -q 'main'; then
+  echo "  OK: runtime RUNTIME_K8S_NODE_SELECTOR carries global.nodeSelector JSON"
+else
+  echo "  FAIL: runtime RUNTIME_K8S_NODE_SELECTOR missing the global.nodeSelector JSON"; fail=1
 fi
 
 [ "$fail" -eq 0 ] && { echo "gate:helm PASS"; exit 0; } || { echo "gate:helm FAIL"; exit 1; }

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -41,6 +41,42 @@ destroyed`) and delegates only the substrate question — *how do I start, obser
 workload?* — to the backend. On `k8s`, a workload is a bare Pod; the same dispatch, contracts,
 and worker run identically to the Docker backend. See [Execution](/architecture/execution).
 
+### Scheduling spawned Pods on a tainted / dedicated pool
+
+A spawned bot or agent Pod is created with `kubectl run` — it is **not** a child of the runtime
+Deployment, so it does **not** inherit `global.nodeSelector` / `global.tolerations`. On a cluster
+whose nodes are all tainted (the standard pool-segregation pattern — dedicated, spot/temp, or GPU
+node pools), a spawned Pod with no tolerations sits `Pending` forever (`untolerated taint(s)`) and
+the meeting silently fails while the runtime itself — a Deployment that *does* apply those
+constraints — looks healthy.
+
+The chart closes this by handing the runtime its **own** scheduling constraints as env, which the
+spawn backend stamps onto every Pod it creates:
+
+| Env on the runtime | Chart source | Applied to |
+|---|---|---|
+| `RUNTIME_K8S_TOLERATIONS` | `runtime.tolerations` ⟶ defaults to `global.tolerations` | every spawned Pod's `spec.tolerations` |
+| `RUNTIME_K8S_NODE_SELECTOR` | `runtime.nodeSelector` ⟶ defaults to `global.nodeSelector` | every spawned Pod's `spec.nodeSelector` |
+
+By default a spawned Pod schedules **wherever the runtime itself can** — set `global.tolerations`
+/ `global.nodeSelector` for your pool and both the runtime and everything it spawns land there, with
+no extra action:
+
+```yaml
+global:
+  tolerations:
+    - key: vexa.ai/pool
+      operator: Equal
+      value: main
+      effect: NoSchedule
+  nodeSelector:
+    vexa.ai/pool: main
+```
+
+Set `runtime.tolerations` / `runtime.nodeSelector` only to send spawned workloads to a **different**
+pool than the kernel (e.g. GPU bots). Both values are serialized to JSON; malformed JSON fails the
+spawn loudly rather than dropping the constraint (a dropped constraint is the stranded-Pod bug).
+
 ## Scaling meeting-api
 
 `meetingApi.replicaCount` defaults to `2`, and that is safe for the segment consumer.


### PR DESCRIPTION
Closes #673. Part of the **v0.12.8 helm batch**.

## Problem
The k8s spawn backend runs every workload (meeting bot, agent, worker) as a bare `kubectl run` Pod — **not** a child of the runtime Deployment, so it inherits none of `global.nodeSelector` / `global.tolerations`. On an all-tainted cluster (dedicated / spot / GPU node pools) every spawn strands `Pending` forever (`untolerated taint(s)`) and the meeting silently fails, while the runtime Deployment itself schedules fine and looks healthy. Witnessed live on LKE during the v0.12.7 release witness.

## The diff
- **C1 — `core/runtime/src/runtime_kernel/k8s_backend.py`**: `pod_overrides()` merges `RUNTIME_K8S_TOLERATIONS` (JSON array) / `RUNTIME_K8S_NODE_SELECTOR` (JSON object) into the `--overrides` spec, and now builds the spec whenever **either** volumes **or** scheduling constraints are present. The prior volumes-only early return (`return None` when no store PVC) dropped tolerations on any spawn without a workspace PVC — a plain meeting bot — re-creating the exact bug. Malformed JSON fails **loud** at spawn (a silently dropped constraint is the defect); empty `[]` / `{}` (the chart default) is treated as unset → today's behaviour on an untainted cluster is unchanged. `start()` overlays the runtime's own process env, since the per-workload `spec.env` (built by meeting-api / agent-api) cannot carry these.
- **C2 — `deploy/helm/charts/vexa/templates/deployment-runtime.yaml`**: the runtime Deployment (`backend=k8s`) is handed its own scheduling constraints as env, `.Values.runtime.tolerations | default .Values.global.tolerations | toJson` (same for nodeSelector). By default a spawned Pod schedules **wherever the runtime itself can**; `runtime.tolerations` / `runtime.nodeSelector` is an escape hatch for a distinct spawn pool (e.g. GPU bots). Documented in `values.yaml`.
- **Config-contract**: both keys declared in `core/runtime/src/runtime_kernel/config.v1.json` (targets: `helm`). `gate:config-contract` enforces declaration ≡ deploy surface ≡ code read.
- **Docs**: `docs/docs/deployment-kubernetes.mdx` — new "Scheduling spawned Pods on a tainted / dedicated pool" section.

## Observation bundle

| # | Observation | Evidence |
|---|---|---|
| **A1** | `pod_overrides` unit tests: tolerations-only no-PVC builds a valid spec (not `None`); PVC+scheduling merge; empty `[]`/`{}` unchanged from today; malformed JSON fails loud; `start()` overlays runtime process env | `core/runtime/tests/test_mounts.py` — 6 new tests. **RED** (pre-C1): 4 fail (`DID NOT RAISE` / tolerations-only returned `None` / helper missing). **GREEN**: `19 passed`; full runtime suite `150 passed, 1 skipped`. |
| **A2** | `helm template` runtime env contains `RUNTIME_K8S_TOLERATIONS` + `RUNTIME_K8S_NODE_SELECTOR` carrying the `global.*` JSON | `deploy/helm/tests/test_template.sh` seam-guard + value-flow assertion → `gate:helm PASS`. **Negative control**: render at HEAD before C2 = **0** occurrences; post-C2 = **2**. |
| **A3** | Staging LKE (all nodes `vexa.ai/pool:NoSchedule`): spawn bot **and** agent → both reach `Running` | **Deferred to the named validator** (needs the live tainted LKE cluster). |
| **A-** | No-regression: runtime unit lane + helm render/lint + repo gates green | `node scripts/gates.mjs` → **✅ gates green** (32 gates incl. config-contract, python, helm); `helm lint` clean. |

A3 is the live LKE witness from the issue's "How this issue closes" — an operator sets `global.tolerations`/`global.nodeSelector` for the pool, runs a real meeting, and confirms the spawned bot goes `Pending → Running` on the tainted pool with no manual untaint, then an agent does the same. The reporter (@DmitriyG228) is the preferred signer.

Do not merge pending value validation.