### PR TITLE
fix(helm): wire VEXA_INTERNAL_API_SECRET into terminal Deployment (Closes #676)

### DIFF
--- a/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
@@ -71,6 +71,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "vexa.adminTokenSecretName" . }}
                   key: NEXTAUTH_SECRET
+            # Admin internal edge: internalRequest()/validateAuthToken() need this to claim the
+            # admin role + mint per-session keys on sign-in; without it the edge returns 503 and
+            # bootstrap-admin fails closed. Same secret+key every other service reads.
+            - name: VEXA_INTERNAL_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: INTERNAL_API_SECRET
             {{- if .Values.terminal.publicUrl }}
             # External origin (set when ingress/LB fronts the terminal) — cookie security + OAuth callbacks.
             - name: NEXTAUTH_URL

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -43,6 +43,10 @@ need 2 'name: MEETING_API_URL' "MEETING_API_URL set on gateway AND meeting-api"
 # #656: meeting-api MUST get ADMIN_API_URL or calendar sync no-ops and auto-join spawns uncapped.
 # It rides the gateway env too; assert >=2 (gateway + meeting-api).
 need 2 'name: ADMIN_API_URL'   "ADMIN_API_URL set on gateway AND meeting-api"
+# #676: terminal MUST get VEXA_INTERNAL_API_SECRET or the admin internal edge is dead
+# (bootstrap-admin claim + per-session key mint fail closed). Terminal is the lone consumer of
+# this env-var spelling (other services read the same secret key as INTERNAL_API_SECRET), so >=1.
+need 1 'name: VEXA_INTERNAL_API_SECRET' "terminal internal-edge secret"
 
 # auth unset (values-test) → the chart Secret must NOT carry the key; auth set → it must.
 if printf '%s\n' "$RENDER" | grep -qE '^  CLAUDE_CODE_OAUTH_TOKEN:'; then


### PR DESCRIPTION
Closes #676. Part of the **v0.12.8 helm batch** (siblings #673 / #675 / #677) — stock helm cannot deliver join→words→live-view until all four config-parity omissions are wired.

## Problem

The terminal's admin **internal edge** (`internalRequest`/`validateAuthToken`, `clients/terminal/src/app/api/auth/adminApi.ts`) hard-requires **both** `VEXA_ADMIN_API_URL` and `VEXA_INTERNAL_API_SECRET`. The helm terminal Deployment set the former but never the latter, so on **every stock install** the edge returned 503: `bootstrapAdminClaim` failed closed and per-session key mint / auth-token validation degraded silently (`[terminal-auth] bootstrap-admin claim failed (sign-in continues): Admin API internal edge is not configured …`). Witnessed live on the stock v0.12.7 LKE helm witness; fixed live by `kubectl set env`.

## Change (the ONE PR)

- **C1** — `deployment-terminal.yaml`: source `VEXA_INTERNAL_API_SECRET` from the chart secret key `INTERNAL_API_SECRET` via the same `secretKeyRef` idiom every other service (admin-api, gateway, meeting-api, runtime) already uses — and that the terminal already uses for `ADMIN_API_TOKEN`/`NEXTAUTH_SECRET`.
- **C2** — `test_template.sh`: add `need 1 'name: VEXA_INTERNAL_API_SECRET'` render row so the seam can't silently drop again. Terminal is the lone consumer of this env-var spelling (other services read the same secret key spelled `INTERNAL_API_SECRET`), so the count is >=1.

Config-contract: the terminal is a `clients/terminal` Next.js client, not a `core/` service — it has no `config.v1.json` and is **not** among the 5 config-contract-adopted services, so no contract declaration applies (confirmed: `gate:config-contract` stays green). Docs (`deployment-kubernetes.mdx`) list the terminal only as a component, not its env/auth, so no D6c doc change applies.

## Observation bundle

| # | Observation | Evidence |
|---|---|---|
| A1 | `helm template` terminal Deployment env carries `VEXA_INTERNAL_API_SECRET` via `secretKeyRef … key: INTERNAL_API_SECRET`; **before=0, after=1** occurrence chart-wide | render diff below |
| A2 | `test_template.sh` asserts the row; **RED (got 0)** with C1 reverted, **GREEN (1)** with C1 | negative control below |
| A3 | Staging LKE (helm) sign-in mints a working per-session key with no `bootstrap-admin claim failed` and no manual `kubectl set env` | **operator validation pending** (non-author signer) |

### A1 — render diff (terminal Deployment, before → after)
```
1153a1154,1161
>             - name: VEXA_INTERNAL_API_SECRET
>               valueFrom:
>                 secretKeyRef:
>                   name: vexa-vexa-secrets
>                   key: INTERNAL_API_SECRET
count 'name: VEXA_INTERNAL_API_SECRET':  before 0  →  after 1
```

### A2 — negative control
```
# template reverted (C1 absent):
  FAIL: terminal internal-edge secret — want >=1 got 0
gate:helm FAIL
# full change:
  OK: terminal internal-edge secret (1)
gate:helm PASS
```

## Gates
`node scripts/gates.mjs` → **✅ gates green** (all 32 gates, incl. `gate:config-contract`, `gate:db-budget`).

Do not merge / no labels — awaiting non-author live validation (A3) per the acceptance table.
