### PR TITLE
fix(helm): agent-api VEXA_MEETING_API_URL so live-SSE owner-lookup resolves (Closes #677)

### DIFF
--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -309,9 +309,11 @@
       "key": "VEXA_MEETING_API_URL",
       "class": "defaulted",
       "default": "http://meeting-api:8080",
-      "description": "meeting-api base URL \u2014 agent-api owner-scopes the live SSE feed (GET /api/meeting/stream) by hitting GET /meetings/{id} on it before opening the redis transcript stream (P0 cross-tenant leak fix, SSE sibling of the by-id ownership check)",
+      "description": "meeting-api base URL \u2014 agent-api owner-scopes the live SSE feed (GET /api/meeting/stream) by hitting GET /meetings/{id} on it before opening the redis transcript stream (P0 cross-tenant leak fix, SSE sibling of the by-id ownership check). compose relies on the default service DNS name, helm sets it explicitly to the release-qualified Service DNS (unset it fails closed \u2192 403 for the owner, #677), lite overrides to localhost",
       "targets": [
-        "compose"
+        "compose",
+        "helm",
+        "lite"
       ]
     },
     {

--- a/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
@@ -44,6 +44,12 @@ spec:
               value: "http://{{ include "vexa.componentName" (list . "agent-api") }}:{{ .Values.agentApi.service.port }}"
             - name: VEXA_GATEWAY_URL
               value: "http://{{ include "vexa.componentName" (list . "gateway") }}:{{ .Values.gateway.service.port }}"
+            # Owner-scopes the live SSE feed (GET /api/meeting/stream): agent-api hits GET /meetings/{id}
+            # on meeting-api to verify the caller owns the row before opening the redis transcript stream
+            # (P0 cross-tenant guard, fail-closed). The compose-only default http://meeting-api:8080 does
+            # not resolve in-cluster, so set the release-qualified Service DNS (#677, sibling of #634).
+            - name: VEXA_MEETING_API_URL
+              value: "http://{{ include "vexa.componentName" (list . "meeting-api") }}:{{ .Values.meetingApi.service.port }}"
             - name: VEXA_AGENT_PROFILE
               value: "agent"
             - name: VEXA_WORKSPACES_DIR

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -40,6 +40,10 @@ need 1 'serviceAccountName: vexa-vexa-runtime' "runtime SA bound"
 need 1 'key: CLAUDE_CODE_OAUTH_TOKEN' "agent-api CLAUDE_CODE_OAUTH_TOKEN secret ref"
 need 2 'key: ANTHROPIC_AUTH_TOKEN'    "ANTHROPIC_AUTH_TOKEN secret refs (agent-api + runtime)"
 need 2 'name: MEETING_API_URL' "MEETING_API_URL set on gateway AND meeting-api"
+# #677: agent-api MUST get VEXA_MEETING_API_URL or its live-SSE owner-lookup calls the compose-only
+# http://meeting-api:8080 (unresolvable in-cluster) → fail-closed 403 for the meeting's own owner.
+# Only agent-api carries the VEXA_-prefixed spelling, so assert exactly 1.
+need 1 'name: VEXA_MEETING_API_URL' "agent-api meeting-api URL (owner-scope)"
 # #656: meeting-api MUST get ADMIN_API_URL or calendar sync no-ops and auto-join spawns uncapped.
 # It rides the gateway env too; assert >=2 (gateway + meeting-api).
 need 2 'name: ADMIN_API_URL'   "ADMIN_API_URL set on gateway AND meeting-api"

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -92,6 +92,13 @@ address a spawned bot calls back on for its lifecycle callback and recording upl
 unset it would fall back to the compose-only default `http://meeting-api:8080`, which does
 not resolve in-cluster.
 
+The chart sets the same address as `VEXA_MEETING_API_URL` on the **agent-api** deployment.
+Before opening a live-transcript SSE stream (`GET /api/meeting/stream`), agent-api verifies the
+caller owns the meeting by calling `GET /meetings/{id}` on meeting-api, and **fails closed** — an
+unreachable meeting-api returns `403 "not authorized for this meeting"` for the meeting's own
+owner. Left unset it would fall back to the compose-only `http://meeting-api:8080`, so the owner
+sees a permanent "Reconnecting to live stream…" instead of streaming words.
+
 The chart likewise sets `ADMIN_API_URL` on the meeting-api deployment to
 `http://<release>-vexa-admin-api:8001` (mirroring Compose's `ADMIN_API_URL=http://admin-api:8001`).
 This is **required** for two background loops: calendar sync (discovering each user's connected


### PR DESCRIPTION
Closes #677. Part of the **v0.12.8 helm batch** (cf. #673, #675, #676) — the same-class family of compose-only hostnames unset on helm.

## What & why

agent-api's live-meeting SSE stream (`GET /api/meeting/stream`) is a **P0 cross-tenant guard**: before opening any redis transcript stream it verifies the caller **owns** the meeting row by calling meeting-api (`_http_meeting_owner_lookup`, `api.py:880-903`), and **fails closed** — any error, including an unreachable meeting-api, returns `None` → `403 "not authorized for this meeting"` (`api.py:1819-1822`). The fail-closed is correct and stays.

The bug is the **URL**. `AgentApiSettings.meeting_api_url` defaults to the **compose** service name `http://meeting-api:8080` (`config.py:101`), overridable only by `VEXA_MEETING_API_URL`. The agent-api Deployment set its sibling URLs (`VEXA_RUNTIME_API_URL`, `VEXA_AGENT_API_SELF_URL`, `VEXA_GATEWAY_URL`) via the `componentName` idiom but **omitted `VEXA_MEETING_API_URL`** — so on helm the owner-lookup targets an unresolvable hostname → fail-closed → **403 for the meeting's own owner, on every stock helm install** (permanent "Reconnecting to live stream…"). Exact sibling of **#634** (meeting-api side).

## The diff (4 files)

- **`deployment-agent-api.yaml`** — set `VEXA_MEETING_API_URL` to the release-qualified Service DNS (`http://{{ include "vexa.componentName" (list . "meeting-api") }}:{{ .Values.meetingApi.service.port }}`), copying the #634/#656 idiom next to the sibling URLs.
- **`config.v1.json`** — `VEXA_MEETING_API_URL` `targets` → `["compose","helm","lite"]`. All three surfaces plumb it (compose `docker-compose.yml:218`, lite `supervisord.conf:168`, helm now); the declaration previously listed only `compose`. Description records the helm/lite plumbing.
- **`test_template.sh`** — `need 1 'name: VEXA_MEETING_API_URL'` on agent-api (only agent-api carries the `VEXA_`-prefixed spelling → exactly 1).
- **`deployment-kubernetes.mdx`** — document the agent-api owner-scope URL in the "In-cluster self-addressing" section (D6c), alongside #634's `MEETING_API_URL` entry.

## Acceptance table

| # | Observation | Evidence |
|---|---|---|
| **A1** | `helm template` agent-api env carries `VEXA_MEETING_API_URL` = `http://<release>-vexa-meeting-api:<port>` | render → `- name: VEXA_MEETING_API_URL` / `value: "http://vexa-vexa-meeting-api:8080"`; full-render count 1 |
| **A1 neg** | chart at head → agent-api has RUNTIME/SELF/GATEWAY URLs but **no** meeting-api URL | before: `grep -c name: VEXA_MEETING_API_URL` = **0** |
| **A2** | `test_template.sh` asserts `name: VEXA_MEETING_API_URL` present on agent-api | `OK: agent-api meeting-api URL (owner-scope) (1)` → `gate:helm PASS` |
| **A2 neg** | pre-C1 → row RED | stashed C1, ran test → `FAIL: agent-api meeting-api URL (owner-scope) — want >=1 got 0` → `gate:helm FAIL` |
| **A3** | Staging LKE (helm): owner opens live view → words stream (200 SSE, no 403) | **owner-witness on LKE `vexa-v012-staging` pending** — needs the deployed batch; not witnessed in this PR |
| **A-** | fail-closed cross-tenant guard still refuses a foreign row (403) | `api.py:1819-1822` unchanged |

## Same-class audit (agent-api `*_url` compose-hostname defaults)

Grepped `core/agent/shared/config.py` for every `*_url` default carrying a compose-style hostname and checked each is template-set or safe-when-empty:

| field | default | on helm | verdict |
|---|---|---|---|
| `runtime_api_url` | `http://runtime-api:8090` | set (`VEXA_RUNTIME_API_URL`, release-qualified) | safe |
| `agent_api_self_url` | `http://agent-api:8100` | set (`VEXA_AGENT_API_SELF_URL`) | safe |
| `redis_url` | `redis://redis:6379/0` | set (`VEXA_REDIS_URL` via `vexa.redisUrl`) | safe |
| `meeting_api_url` | `http://meeting-api:8080` | **was unset → this fix** | fixed |
| `admin_api_url` | `""` (empty) | not set | **safe-by-design**: empty = in-memory membership index (Lane M "shared with me" degraded, git files stay authoritative); no unresolvable-hostname fail-closed. Deliberately compose-only. Noted, not fixed. |
| `workspace_store_url` | `s3://vexa-workspaces` | not set (in-code dial, `targets: []`) | different class (bucket URL, not a service hostname) |

**Conclusion:** `meeting_api_url` is the only same-class gap; all other compose-hostname `*_url` defaults are already template-set, and `admin_api_url` degrades gracefully when empty rather than failing closed.

## Gates

`node scripts/gates.mjs all` → **✅ gates green** (incl. `gate:config-contract` — declarations ≡ deploy surfaces ≡ code reads; `gate:schema`/`gate:contract-version`; `gate:compose` real stack bot-ready).