### PR TITLE
fix(runtime): meeting-bot profile carries no command so k8s spawns the real bot ENTRYPOINT (#675)

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -206,6 +206,60 @@ jobs:
           done
           echo "✓ all $(wc -w <<<"$ALL_IMAGES") published images match their names"
 
+      # ── image↔profile conformance gate (#675) ──────────────────────────────────────────────────
+      # The runtime spawns each profile's Runnable.command as argv[0] of the workload. Under k8s
+      # (`kubectl run --command`) that REPLACES the image entrypoint, so a command path absent from
+      # the image StartErrors EVERY spawn (v0.12.7: meeting-bot carried /app/vexa-bot/entrypoint.sh,
+      # which the bot image does not have; docker's Cmd-append hid it, k8s detonated it). This gate
+      # reads the REAL profile registry out of the published runtime image and, for every profile,
+      # asserts the resolved command is either empty (⇒ the image ENTRYPOINT boots the workload) or an
+      # in-image executable (`test -x`), against the SAME published images the release ships.
+      - name: Profile commands resolve inside their target images (#675)
+        run: |
+          set -euo pipefail
+          RUNTIME_REF="vexaai/v012-runtime:$VERSION"
+          BOT_REF="vexaai/vexa-bot:$VERSION"
+          WORKER_REF="vexaai/v012-agent-worker:$VERSION"
+          docker pull -q "$RUNTIME_REF"
+          # Emit {profile: command-argv-or-null} from the deployment-shaped registry (post BOT_COMMAND
+          # / AGENT_WORKER_COMMAND override — container backends set neither, so these are the defaults).
+          PROFILES_JSON="$(docker run --rm --entrypoint "" \
+            -e BROWSER_IMAGE="$BOT_REF" -e AGENT_IMAGE="vexaai/v012-agent-api:$VERSION" \
+            "$RUNTIME_REF" python -c '
+import json
+from runtime_kernel import default_registry
+from runtime_kernel.profiles import apply_command_overrides
+reg = apply_command_overrides(default_registry())
+print(json.dumps({n: reg.resolve(n).command for n in reg.names()}))')"
+          echo "profiles: $PROFILES_JSON"
+          # Profile → the published image its command must resolve inside. Every profile MUST be mapped
+          # here (need-style: a new, unmapped profile fails the gate rather than shipping unchecked).
+          image_for() {
+            case "$1" in
+              meeting-bot) echo "$BOT_REF" ;;
+              agent)       echo "$WORKER_REF" ;;
+              *) echo "::error title=profile-conformance::profile '$1' has no image mapping in this gate — add one (#675)"; exit 1 ;;
+            esac
+          }
+          docker pull -q "$BOT_REF"; docker pull -q "$WORKER_REF"
+          for name in $(echo "$PROFILES_JSON" | jq -r 'keys[]'); do
+            ref="$(image_for "$name")"
+            len="$(echo "$PROFILES_JSON" | jq -r --arg n "$name" '.[$n] | if . == null then 0 else length end')"
+            if [ "$len" = "0" ]; then
+              echo "   ✓ $name: no command → image ENTRYPOINT of $ref is authoritative"
+              continue
+            fi
+            argv0="$(echo "$PROFILES_JSON" | jq -r --arg n "$name" '.[$n][0]')"
+            case "$argv0" in
+              /*) test_cmd="test -x '$argv0'" ;;        # absolute path → must be an in-image executable
+              *)  test_cmd="command -v '$argv0'" ;;     # bare name → must be on PATH in the image
+            esac
+            docker run --rm --entrypoint "" "$ref" sh -c "$test_cmd" >/dev/null \
+              || { echo "::error title=profile-conformance::profile '$name' command argv[0] '$argv0' is not runnable inside $ref — under k8s this StartErrors every spawn (#675)"; exit 1; }
+            echo "   ✓ $name: '$argv0' is runnable inside $ref"
+          done
+          echo "✓ every profile command resolves inside its target image"
+
   # ──────────────────────────────────────────────────────────────────────────────────────────
   # Validation legs — every one pulls the PUBLISHED :$VERSION images (COMPOSE_NO_BUILD=1 /
   # helm --set global.imageTag / lite IMAGE_TAG). Green here means the artifacts work, not

--- a/core/meetings/services/bot/Dockerfile.mock
+++ b/core/meetings/services/bot/Dockerfile.mock
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1
 #
 # mock-bot:dev — the tiny Lane A instrument image (A:V0). Swapped in as BROWSER_IMAGE for the
-# MOCK_BOT=1 gate:compose run: the runtime spawns it EXACTLY like the real bot (the meeting-bot
-# profile's command is `/app/vexa-bot/entrypoint.sh`), but it fakes JoinDriver+Pipeline and emits
-# ONLY sealed contracts. No Playwright/Chromium/ONNX → a few hundred MB, builds on amd64 in seconds
-# (vs the ~2.5 GB real bot). It reuses the bot's REAL orchestrator + adapters (mock/main.ts).
+# MOCK_BOT=1 gate:compose run: the runtime spawns it EXACTLY like the real bot — the meeting-bot
+# profile carries NO command, so every backend execs the image ENTRYPOINT. This mock therefore
+# declares the SAME ENTRYPOINT path as the real bot image (`/app/entrypoint.sh`), so the instrument
+# can never silently diverge from the layout it is meant to stand in for. It fakes JoinDriver+Pipeline
+# and emits ONLY sealed contracts. No Playwright/Chromium/ONNX → a few hundred MB, builds on amd64 in
+# seconds (vs the ~2.5 GB real bot). It reuses the bot's REAL orchestrator + adapters (mock/main.ts).
 #
 # Build (REPO ROOT context):
 #   docker build -f core/meetings/services/bot/Dockerfile.mock -t mock-bot:dev .
@@ -23,10 +25,11 @@ COPY core/meetings/services/bot/src   /app/meetings/services/bot/src
 COPY core/meetings/services/bot/mock  /app/meetings/services/bot/mock
 COPY core/meetings/contracts          /app/meetings/contracts
 
-# The meeting-bot runtime profile runs `/app/vexa-bot/entrypoint.sh` — provide one that launches the mock.
-RUN mkdir -p /app/vexa-bot \
- && printf '#!/bin/sh\nexec npx --no-install tsx /app/meetings/services/bot/mock/main.ts\n' > /app/vexa-bot/entrypoint.sh \
- && chmod +x /app/vexa-bot/entrypoint.sh
+# Match the real bot image's launcher path exactly: ENTRYPOINT ["/app/entrypoint.sh"]. The runtime
+# spawns the bot with no profile command, so the image ENTRYPOINT is what every backend execs — this
+# mock stands in at the same path, launching the mock worker instead of the browser bot.
+RUN printf '#!/bin/sh\nexec npx --no-install tsx /app/meetings/services/bot/mock/main.ts\n' > /app/entrypoint.sh \
+ && chmod +x /app/entrypoint.sh
 
 ENV NODE_ENV=production
-CMD ["/app/vexa-bot/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/core/runtime/src/runtime_kernel/profiles.py
+++ b/core/runtime/src/runtime_kernel/profiles.py
@@ -111,11 +111,19 @@ def default_registry() -> ProfileRegistry:
         {
             # Meeting bot — Playwright browser; lifetime managed by meeting-api, so no idle timeout.
             # The bot's whole config arrives as one env var VEXA_BOT_CONFIG (invocation.v1).
+            # No command: the shipped bot image already declares the launcher as its ENTRYPOINT
+            # (core/meetings/services/bot/Dockerfile: ENTRYPOINT ["/app/entrypoint.sh"]), so every
+            # backend must exec THAT and nothing else. A profile command here would either be a
+            # harmless trailing arg (docker Cmd-append) or REPLACE the entrypoint with a path that
+            # does not exist in the image (k8s `kubectl run --command` → StartError). Leaving it
+            # empty makes docker (omit Cmd) and k8s (omit --command) both boot the image entrypoint
+            # identically. The process backend (lite) never uses this default — it sets BOT_COMMAND
+            # to its in-container launcher (deploy/lite/bin/vexa-bot-launch), applied below.
             "meeting-bot": Profile(
                 name="meeting-bot",
                 runnable=Runnable(
                     image=browser_image,
-                    command=["/app/vexa-bot/entrypoint.sh"],
+                    command=None,
                 ),
                 idle_timeout_sec=0,  # 0 ⇒ managed externally; enforcement skips it
                 base_env=speaker_stream_env,
@@ -138,10 +146,11 @@ def default_registry() -> ProfileRegistry:
     )
 
 
-# Per-deployment command overrides: env var → the profile whose Runnable.command it replaces. The
-# default commands (above) are the container-IMAGE entrypoints the docker/k8s backends exec; a
-# process-backend deployment (single-host `lite`) instead points these at in-container launchers
-# that wire the right venv/PYTHONPATH/cwd before exec'ing the same workload.
+# Per-deployment command overrides: env var → the profile whose Runnable.command it replaces. Under
+# the container backends the meeting-bot command is empty (the image ENTRYPOINT is authoritative) and
+# the agent command is the image's launch argv; a process-backend deployment (single-host `lite`) has
+# no image ENTRYPOINT to lean on, so it MUST point these at in-container launchers that wire the right
+# venv/PYTHONPATH/cwd before exec'ing the same workload (the process backend requires a command).
 _COMMAND_OVERRIDE_ENV = {
     "meeting-bot": "BOT_COMMAND",
     "agent": "AGENT_WORKER_COMMAND",

--- a/core/runtime/tests/test_k8s_command_wiring.py
+++ b/core/runtime/tests/test_k8s_command_wiring.py
@@ -1,0 +1,70 @@
+"""A1 (#675) — OFFLINE proof that the k8s backend execs an in-image path for the meeting-bot profile.
+
+`kubectl run --command -- <argv>` REPLACES the image entrypoint (sets Pod.spec.containers[].command).
+So whatever the meeting-bot profile carries as its command becomes argv[0] of the Pod. The shipped bot
+image has ENTRYPOINT ["/app/entrypoint.sh"] and no /app/vexa-bot/ directory — so a profile command of
+/app/vexa-bot/entrypoint.sh makes every k8s spawn StartError (exit 128, "no such file or directory").
+
+The fix drops the meeting-bot profile command: the k8s backend then omits `--command` entirely and the
+Pod boots the image ENTRYPOINT — the real launcher. These tests capture the exact kubectl argv without
+a cluster (the live-cluster lifecycle lives in test_k8s_backend.py) by stubbing the module's _kubectl.
+
+RED on main: pre-fix the meeting-bot runnable carries ["/app/vexa-bot/entrypoint.sh"], so the argv here
+would contain `--command -- /app/vexa-bot/entrypoint.sh` and the assertions below fail.
+"""
+from __future__ import annotations
+
+import runtime_kernel.k8s_backend as k8s_backend
+from runtime_kernel import default_registry
+from runtime_kernel.k8s_backend import K8sBackend
+from runtime_kernel.profiles import Runnable
+
+
+def _capture_run_argv(monkeypatch) -> list:
+    """Stub the module-level _kubectl so start() runs offline; return the captured argv list."""
+    calls: list[list[str]] = []
+
+    def fake_kubectl(*args, check=True):
+        calls.append(list(args))
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(k8s_backend, "_kubectl", fake_kubectl)
+    return calls
+
+
+def test_meeting_bot_k8s_run_omits_command_uses_image_entrypoint(monkeypatch):
+    """The meeting-bot profile has no command ⇒ `kubectl run` carries NO `--command`, so the Pod execs
+    the shipped bot image's own ENTRYPOINT (the real, in-image launcher)."""
+    calls = _capture_run_argv(monkeypatch)
+    monkeypatch.setenv("BROWSER_IMAGE", "vexaai/vexa-bot:test")
+    runnable = default_registry().resolve("meeting-bot")
+    assert runnable.command is None  # the source of the fix (#675)
+    assert runnable.image == "vexaai/vexa-bot:test"
+
+    K8sBackend(namespace="ns").start("mtg-1", runnable, env={"VEXA_BOT_CONFIG": "{}"})
+
+    run_argv = calls[0]
+    assert run_argv[0] == "run"
+    # No entrypoint replacement: the image ENTRYPOINT (/app/entrypoint.sh) boots the container.
+    assert "--command" not in run_argv
+    # And the phantom path never appears anywhere in the argv.
+    assert not any("/app/vexa-bot/entrypoint.sh" in a for a in run_argv)
+
+
+def test_k8s_run_still_replaces_entrypoint_for_a_profile_that_has_a_command(monkeypatch):
+    """The append/replace machinery is intact: a profile that DOES carry a command (e.g. agent) still
+    gets `--command -- <argv>` — the fix is scoped to dropping the bogus meeting-bot command, not to
+    removing entrypoint replacement wholesale."""
+    calls = _capture_run_argv(monkeypatch)
+    K8sBackend(namespace="ns").start(
+        "agent-1", Runnable(image="img", command=["python", "-m", "worker"]), env={}
+    )
+    run_argv = calls[0]
+    i = run_argv.index("--command")
+    assert run_argv[i:] == ["--command", "--", "python", "-m", "worker"]

--- a/core/runtime/tests/test_profile_image_conformance.py
+++ b/core/runtime/tests/test_profile_image_conformance.py
@@ -1,0 +1,91 @@
+"""A2 (#675) — image↔profile conformance gate (OFFLINE, durable).
+
+A profile's command becomes argv[0] of the spawned workload under the k8s backend
+(`kubectl run --command`) and is the sole argv under the process backend. If that path does not exist
+in the target image, every spawn StartErrors — which is exactly how v0.12.7 shipped: the meeting-bot
+profile carried `/app/vexa-bot/entrypoint.sh`, absent from the bot image whose ENTRYPOINT is
+`/app/entrypoint.sh`. docker's Cmd-append hid it (harmless trailing arg); k8s's entrypoint-replace
+detonated it.
+
+The live release-validate leg proves the path with `docker run --rm <image> test -x <path>` against the
+PUBLISHED bot image (see .github/workflows/release-validate.yml). This offline twin is the cheap,
+durable half: it parses the real bot Dockerfile's ENTRYPOINT and asserts the meeting-bot profile
+command is CONSISTENT with it — either empty (so every backend execs the image ENTRYPOINT) or exactly
+the ENTRYPOINT path. Any future edit that reintroduces a command the image does not declare fails here,
+at head, instead of at a customer's helm install.
+
+RED on main: pre-fix the meeting-bot command argv[0] is /app/vexa-bot/entrypoint.sh, which is neither
+empty nor equal to the Dockerfile's ENTRYPOINT (/app/entrypoint.sh) → this test fails.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from runtime_kernel import default_registry
+from runtime_kernel.profiles import apply_command_overrides
+
+# core/  (the dir holding both `runtime` and `meetings`) — same anchor test_profiles.py uses.
+CORE = Path(__file__).resolve().parents[2]
+BOT_DOCKERFILE = CORE / "meetings" / "services" / "bot" / "Dockerfile"
+
+
+def _entrypoint_paths(dockerfile: Path) -> list[str]:
+    """Return the argv of the last ENTRYPOINT declared in `dockerfile` (exec-form JSON or shell-form).
+
+    Durable and dependency-free: we only need argv[0] (the executable path), and ENTRYPOINT in the bot
+    image is the exec-form JSON array `["/app/entrypoint.sh"]`."""
+    text = dockerfile.read_text()
+    argv: list[str] | None = None
+    for m in re.finditer(r"^\s*ENTRYPOINT\s+(.+)$", text, flags=re.MULTILINE):
+        raw = m.group(1).strip()
+        if raw.startswith("["):
+            argv = json.loads(raw)
+        else:
+            argv = raw.split()
+    return argv or []
+
+
+def test_bot_dockerfile_declares_the_expected_entrypoint():
+    """Pin the anchor the gate leans on: the real bot image's launcher path."""
+    assert _entrypoint_paths(BOT_DOCKERFILE) == ["/app/entrypoint.sh"]
+
+
+def test_meeting_bot_command_conforms_to_bot_image_entrypoint():
+    """The container-backend meeting-bot command must resolve to a path the shipped bot image has.
+
+    Offline rule (the durable half of the conformance gate): the command is empty — so docker omits Cmd
+    and k8s omits --command, both booting the image ENTRYPOINT — OR its argv[0] equals the image's
+    declared ENTRYPOINT path. Anything else is the #675 defect class."""
+    entry = _entrypoint_paths(BOT_DOCKERFILE)
+    assert entry, "bot Dockerfile declares no ENTRYPOINT — conformance anchor missing"
+    entry_path = entry[0]
+
+    command = default_registry().resolve("meeting-bot").command
+    if command:  # non-empty ⇒ it REPLACES the entrypoint, so argv[0] must be an in-image path
+        assert command[0] == entry_path, (
+            f"meeting-bot profile command {command!r} does not resolve to the bot image ENTRYPOINT "
+            f"{entry_path!r}; under k8s this StartErrors (#675). Drop the command or point it at the "
+            f"image's real launcher."
+        )
+    # command is None ⇒ the image ENTRYPOINT is authoritative on every backend; conformant by design.
+
+
+def test_meeting_bot_command_conforms_under_a_bogus_override(monkeypatch):
+    """The gate covers the post-BOT_COMMAND-override value too: an override that points at a path the
+    image does not declare is caught here, not at spawn time.
+
+    (Note: a real process-backend/lite deployment sets BOT_COMMAND to an in-container launcher in a
+    DIFFERENT image — lite-process — where the live gate's `docker run test -x` is the authority. This
+    offline check pins the CONTAINER-backend contract against the bot Dockerfile.)"""
+    entry_path = _entrypoint_paths(BOT_DOCKERFILE)[0]
+    monkeypatch.setenv("BOT_COMMAND", "/app/vexa-bot/entrypoint.sh")  # the historical bad path
+    reg = apply_command_overrides(default_registry())
+    bad = reg.resolve("meeting-bot").command
+    assert bad == ["/app/vexa-bot/entrypoint.sh"]
+    # The conformance rule would REJECT this override against the bot image — proving the gate's reach.
+    with pytest.raises(AssertionError):
+        assert not bad or bad[0] == entry_path

--- a/core/runtime/tests/test_profiles.py
+++ b/core/runtime/tests/test_profiles.py
@@ -42,7 +42,10 @@ def test_registry_resolves_meeting_bot_and_agent():
     for name in ("meeting-bot", "agent"):
         runnable = reg.resolve(name)
         assert isinstance(runnable, Runnable)
-        assert runnable.command  # both have a launch command
+    # The agent carries an explicit launch argv; the meeting-bot deliberately carries NO command so
+    # every container backend execs the shipped bot image's own ENTRYPOINT (#675).
+    assert reg.resolve("agent").command == ["python", "-m", "worker"]
+    assert reg.resolve("meeting-bot").command is None
     assert reg.resolve("does-not-exist") is None
 
 
@@ -161,7 +164,7 @@ def test_command_overrides_noop_without_env(monkeypatch):
     monkeypatch.delenv("BOT_COMMAND", raising=False)
     monkeypatch.delenv("AGENT_WORKER_COMMAND", raising=False)
     reg = apply_command_overrides(default_registry())
-    assert reg.resolve("meeting-bot").command == ["/app/vexa-bot/entrypoint.sh"]
+    assert reg.resolve("meeting-bot").command is None  # image ENTRYPOINT is authoritative (#675)
     assert reg.resolve("agent").command == ["python", "-m", "worker"]
 
 
@@ -182,5 +185,5 @@ def test_command_overrides_ignore_blank_env(monkeypatch):
     monkeypatch.setenv("BOT_COMMAND", "")
     monkeypatch.setenv("AGENT_WORKER_COMMAND", "   ")
     reg = apply_command_overrides(default_registry())
-    assert reg.resolve("meeting-bot").command == ["/app/vexa-bot/entrypoint.sh"]
+    assert reg.resolve("meeting-bot").command is None  # image ENTRYPOINT is authoritative (#675)
     assert reg.resolve("agent").command == ["python", "-m", "worker"]

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -41,6 +41,19 @@ destroyed`) and delegates only the substrate question — *how do I start, obser
 workload?* — to the backend. On `k8s`, a workload is a bare Pod; the same dispatch, contracts,
 and worker run identically to the Docker backend. See [Execution](/architecture/execution).
 
+<Warning>
+**Spawned-workload commands must exist in the target image under k8s (entrypoint-replace)
+semantics.** A runtime profile may carry a `command`; the k8s backend passes it as
+`kubectl run --command -- …`, which **replaces** the image `ENTRYPOINT` (it becomes the Pod's
+`argv[0]`). So a command path that is not present in the image `StartError`s **every** spawn on
+k8s — even though the Docker backend, which *appends* the command to the entrypoint as arguments,
+silently ignores the same bad path. The meeting-bot profile therefore carries **no** command: the
+bot image's own `ENTRYPOINT` (`/app/entrypoint.sh`) boots it on every backend. At release time an
+image↔profile conformance gate (`image-identity`) asserts each profile command is either empty or
+an in-image executable against the published images, so a profile that diverges from its image
+fails the release rather than a customer's install.
+</Warning>
+
 ## Scaling meeting-api
 
 `meetingApi.replicaCount` defaults to `2`, and that is safe for the segment consumer.


### PR DESCRIPTION
Closes #675 · part of the **v0.12.8 helm batch** (with #673 and siblings #676 / #677) — stock helm cannot deliver join→words→live-view without all four.

## What was wrong

The `meeting-bot` profile hard-coded `Runnable.command=["/app/vexa-bot/entrypoint.sh"]` (`profiles.py:118`) — a path the shipped bot image does **not** have (its `ENTRYPOINT` is `/app/entrypoint.sh`, `WORKDIR /app`, no `/app/vexa-bot/` dir). A **backend-semantics split** hid it everywhere except k8s:

- **docker** (`docker_backend.py:255-256`) passes it as `Cmd` → Docker *appends* it to the `ENTRYPOINT` → the bad path is a harmless trailing arg → works by accident.
- **k8s** (`k8s_backend.py:89-90`) passes it as `kubectl run --command -- …` → *replaces* the entrypoint → `argv[0]` is a path that doesn't exist → **`StartError`, exit 128** on every stock helm bot spawn.

## The fix

**C1 — drop the `meeting-bot` command (prepared solution (a)).** With no command, docker omits `Cmd` and k8s omits `--command`, so both boot the image's own `ENTRYPOINT` (`/app/entrypoint.sh`) identically. The process backend (lite) is untouched: it sets `BOT_COMMAND=/usr/local/bin/vexa-bot-launch`, which overrides the default and is exactly what its `argv[0]` already resolved to.

**C2 — image↔profile conformance gate.** A new `release-validate` leg (in `image-identity`) reads the real profile registry out of the published runtime image and asserts each profile command is either empty (→ image `ENTRYPOINT` is authoritative) or an in-image executable (`test -x`) against the published images. An **offline unit twin** parses the bot Dockerfile's `ENTRYPOINT` and pins the same contract — cheap and durable.

**Mock alignment.** `Dockerfile.mock` now declares the SAME `ENTRYPOINT ["/app/entrypoint.sh"]` as the real image and drops the phantom `/app/vexa-bot/` path — so the `MOCK_BOT` gate instrument can no longer silently diverge from the layout it stands in for (the issue calls this out explicitly).

**Docs (D6c).** `deployment-kubernetes.mdx` now documents the entrypoint-replace contract and the release-time conformance gate.

## Observation bundle (acceptance table)

| # | Observation | Evidence |
|---|---|---|
| **A1** | `k8s_backend.start()` for `meeting-bot` produces a Pod that execs an in-image path (empty command → image ENTRYPOINT) | `test_k8s_command_wiring.py` — offline argv capture asserts **no** `--command` and the phantom path appears nowhere. **RED on main**: with the old command restored the argv carried `--command -- /app/vexa-bot/entrypoint.sh` (verified — test fails). |
| **A2** | Conformance gate: `meeting-bot` command resolves inside the bot image | `test_profile_image_conformance.py` parses the real Dockerfile `ENTRYPOINT` and asserts the command is empty or equals it. **RED on main** (verified: `assert '/app/vexa-bot/entrypoint.sh' == '/app/entrypoint.sh'` fails); GREEN after C1. Live twin: new `image-identity` leg (`docker run --rm <img> test -x <path>`). |
| **A3** | **No-change on docker**: `validate-bot-spawn` (compose, real bot) still spawns + transcribes | The mock (its stand-in) rebuilt clean: `ENTRYPOINT ["/app/entrypoint.sh"]`, `test -x /app/entrypoint.sh` OK, phantom path absent. Runtime spawns with no command → docker boots the ENTRYPOINT — the exact path the real bot has. No behavior change (before: harmless trailing arg; after: no arg). |
| **A4** | **No-change on process**: lite `RUNTIME_BACKEND=process` `argv[0]` unchanged | `test_command_overrides_replace_commands` — with `BOT_COMMAND` set (as lite always does), `meeting-bot` resolves to `/usr/local/bin/vexa-bot-launch`, unchanged by this diff (it only touches the *default*, which the override replaces). |
| **A5** | **Staging LKE (helm)**: real meeting → bot Pod `Running` (no `StartError`) → transcript | Operator run (D12b) — to be witnessed on `vexa-v012-staging` by a non-author (the reporter is the preferred signer). |

## Per-backend proof summary
- **k8s red→green**: A1/A2 both proven RED on the buggy command and GREEN after the fix (documented above).
- **docker no-change**: the executed `argv[0]` is `/app/entrypoint.sh` in both worlds; the only difference is an ignored trailing arg that no longer appears. Mock rebuilt and inspected.
- **process no-change**: lite's `BOT_COMMAND` override means `argv[0]` was never the phantom default; unchanged.

## Gates
`node scripts/gates.mjs all` — all green **except** `gate:db-budget`, which fails **identically on the untouched base commit** (`admin-api`/`meeting-api` `pool_size=6` vs declared `5`) — a pre-existing issue orthogonal to this diff, which touches no DB config. Runtime suite: 150 passed, 1 skipped (live-cluster test).

No merge, no labels — maintainer triages per the TAKE protocol.