### PR TITLE
fix(release-validate): un-break YAML — #675 conformance snippet as one-liner

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -225,12 +225,7 @@ jobs:
           # / AGENT_WORKER_COMMAND override — container backends set neither, so these are the defaults).
           PROFILES_JSON="$(docker run --rm --entrypoint "" \
             -e BROWSER_IMAGE="$BOT_REF" -e AGENT_IMAGE="vexaai/v012-agent-api:$VERSION" \
-            "$RUNTIME_REF" python -c '
-import json
-from runtime_kernel import default_registry
-from runtime_kernel.profiles import apply_command_overrides
-reg = apply_command_overrides(default_registry())
-print(json.dumps({n: reg.resolve(n).command for n in reg.names()}))')"
+            "$RUNTIME_REF" python -c 'import json; from runtime_kernel import default_registry; from runtime_kernel.profiles import apply_command_overrides; reg = apply_command_overrides(default_registry()); print(json.dumps({n: reg.resolve(n).command for n in reg.names()}))')"
           echo "profiles: $PROFILES_JSON"
           # Profile → the published image its command must resolve inside. Every profile MUST be mapped
           # here (need-style: a new, unmapped profile fails the gate rather than shipping unchecked).


### PR DESCRIPTION
PR #681's image-identity step embedded a multi-line `python -c` heredoc at column 1 inside a `run: |` block — YAML terminates the block scalar there (`could not find expected ':'` line 229). Since release-images **calls release-validate as a reusable workflow**, the parse failure blocked the entire v0.12.8 build: the tag push died as a 0-second failure and `workflow_dispatch` 422s.

Fix: the registry-dump snippet becomes a semicolon-chained one-liner (verified: YAML parses, `bash -n` clean, `ast.parse` clean). No behavioral change to the gate.

Unblocks the v0.12.8 candidate build. Part of the #675 batch follow-through.