### PR TITLE
fix(runtime): scheduling-only pod overrides must not replace the containers list

### DIFF
--- a/core/runtime/src/runtime_kernel/k8s_backend.py
+++ b/core/runtime/src/runtime_kernel/k8s_backend.py
@@ -93,10 +93,14 @@ def pod_overrides(env: dict[str, str], *, container_name: str) -> Optional[dict]
     node_selector = _scheduling_json(env, NODE_SELECTOR_ENV, dict)
     if not volumes and not tolerations and not node_selector:
         return None
-    container: dict = {"name": container_name}
+    # ``kubectl run --overrides`` merges the containers LIST by replacement (json-merge, not
+    # strategic), so a containers entry here wipes the generated container — image, env, command —
+    # and the API server rejects the Pod (`spec.containers[0].image: Required value`), killing the
+    # spawn instantly. Emit ``containers`` ONLY when volumeMounts force it (the workspace-store
+    # seam); pod-level fields (tolerations/nodeSelector) merge fine without touching the list.
+    spec: dict = {}
     if volume_mounts:
-        container["volumeMounts"] = volume_mounts
-    spec: dict = {"containers": [container]}
+        spec["containers"] = [{"name": container_name, "volumeMounts": volume_mounts}]
     if volumes:
         spec["volumes"] = volumes
     if tolerations:

--- a/core/runtime/tests/test_mounts.py
+++ b/core/runtime/tests/test_mounts.py
@@ -196,7 +196,11 @@ def test_k8s_pod_overrides_tolerations_only_no_pvc_builds_a_valid_spec():
     assert spec["tolerations"] == _TOL
     assert spec["nodeSelector"] == _SEL
     assert "volumes" not in spec                           # no PVC ⇒ no volumes, but scheduling stands
-    assert spec["containers"] == [{"name": "vexa-mtg-6"}]  # no volumeMounts when no store
+    # LOAD-BEARING (witnessed live, v0.12.8 staging): `kubectl run --overrides` merges the containers
+    # LIST by replacement, so ANY containers entry here wipes the generated container's image/env/command
+    # and the API server rejects the Pod (`spec.containers[0].image: Required value`) — the spawn dies in
+    # <1s. Scheduling-only overrides must NOT touch the containers list.
+    assert "containers" not in spec
 
 
 def test_k8s_pod_overrides_merges_pvc_and_scheduling():


### PR DESCRIPTION
**Found by the v0.12.8 stock helm witness — the exact class this witness exists for.**

#678 emits `containers: [{name}]` in every override. `kubectl run --overrides` merges the containers **list by replacement** (json-merge, not strategic), wiping the generated container's image/env/command → API server rejects the Pod (`spec.containers[0].image: Required value`) → every spawn dies in <1 s, meeting stuck `requested`, no pod ever exists.

Live evidence (staging, stock v0.12.8): workload `mtg-18-03262323` starting→stopped in 0.3 s; server dry-run inside the runtime pod reproduces the rejection with the containers key and passes without it (image survives, tolerations + nodeSelector applied).

Fix: emit `containers` only when volumeMounts force it (the workspace-store seam, pre-existing shape); scheduling stays at pod level. Red→green: `test_k8s_pod_overrides_scheduling_without_store` now asserts `containers` absent (old code fails it). Runtime suite 155 passed.

Requires re-cut (runtime image changed): v0.12.9.