### PR TITLE
docs(governance): the two loops — debugging discipline, flake discipline, human placement (Closes #688)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ A prepared issue is a worked delivery spec — read it end to end before touchin
   external semantics (live exec · overlay · spawn probe, seconds–minutes) *before* you package it
   through the release pipeline; never cut a build to find out whether the code works, never rerun a
   deterministic red as a "flake", and rehearse the demo path end-to-end before the human walks it.
-  See [the two loops](https://docs.vexa.ai/governance/delivery#the-two-loops).
+  See [the two loops](docs/docs/governance/delivery.mdx) (§7 in this tree — the law at YOUR
+  checkout's revision; the published copy is at
+  [docs.vexa.ai/governance/delivery#the-two-loops](https://docs.vexa.ai/governance/delivery#the-two-loops)).
 - **Gates green before push:** `node scripts/gates.mjs all` (also runs on pre-push). Green is
   necessary, never sufficient — prove user-facing behavior at the altitude of the claim (P19):
   a live leg for live behavior, not just unit green.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,11 @@ A prepared issue is a worked delivery spec — read it end to end before touchin
   an unexpected result is a finding, never something to paper over. Unfinished scaffolding you
   were always meant to complete is NOT "unexpected" — finish it; stop only on genuine
   contradiction.
+- **Debug ≠ deliver — the two loops.** Prove a diff on the hottest loop that carries the real
+  external semantics (live exec · overlay · spawn probe, seconds–minutes) *before* you package it
+  through the release pipeline; never cut a build to find out whether the code works, never rerun a
+  deterministic red as a "flake", and rehearse the demo path end-to-end before the human walks it.
+  See [the two loops](https://docs.vexa.ai/governance/delivery#the-two-loops).
 - **Gates green before push:** `node scripts/gates.mjs all` (also runs on pre-push). Green is
   necessary, never sufficient — prove user-facing behavior at the altitude of the claim (P19):
   a live leg for live behavior, not just unit green.

--- a/docs/adr/0033-the-two-loops-debug-flake-human.md
+++ b/docs/adr/0033-the-two-loops-debug-flake-human.md
@@ -1,0 +1,87 @@
+# ADR 0033 — The two loops: debug ≠ deliver, flake is earned, the human appears twice (D-L cluster)
+
+**Status:** accepted · 2026-07-16 · enforces **D1** (a rule that isn't enforced is a comment) and
+records the **`D-L`** principle cluster (D-L0–D-L4) added to the delivery constitution · arms:
+[#689](https://github.com/Vexa-ai/vexa/issues/689),
+[#690](https://github.com/Vexa-ai/vexa/issues/690),
+[#691](https://github.com/Vexa-ai/vexa/issues/691) · from the **v0.12.9 release retrospective**
+(2026-07-16)
+
+## Context
+
+v0.12.9 burned ~12h of wall time where ~6h was achievable, and shipped six bugs that CI missed and
+only the live witness caught. The retrospective traced almost every lost hour to one root cause:
+**the release pipeline was used as a debugger.** Fixes were serially found and each packaged through
+a full PR → gates → tag → build cycle (~40 min/iter) to discover whether the *next* layer worked —
+instead of being proven on a hot loop that carries the real external semantics (seconds–minutes/iter)
+and only *then* packaged.
+
+The D-book codified PREPARE (§6) and PROOF (§8, was §7) but was thin on the DELIVER arc's *inner
+mechanics* — how an agent actually drives a diff to the point where it is provable. Four concrete
+failures anchor the gap, all from the v0.12.9 batch on `origin/main`:
+
+- **Pipeline-as-debugger tax.** v0.12.8 was cut after four serially-found helm fixes with no
+  assembled-system probe, and the 5th bug was in the new code. PR #684 emitted `containers: [{name}]`
+  in every `kubectl run --overrides`, which merges the containers list *by replacement* — wiping the
+  generated image/env/command, so the API server rejected every Pod (`spec.containers[0].image:
+  Required value`) and every spawn died in ~0.3 s, forcing a full re-cut to v0.12.9. The eventual hot
+  loop (a ConfigMap overlay of the runtime env + a dead-URL spawn probe) proved the whole chain in
+  ~10 minutes — the thing four ~40-min pipeline iterations never touched.
+- **Serial onion-peeling.** The helm chain was peeled one bug at a time (#656 → #675/#681 →
+  #677/#680 → #676/#679 → #684), ~3h a single 20-min full-journey probe + one all-component log
+  sweep would have inventoried at once.
+- **Un-earned flake.** The `gate:helm` `printf | grep -q` under `set -euo pipefail` SIGPIPE-raced to
+  exit 141 *exactly on a match* — deterministic on ubuntu runners once `$RENDER_AUTH` outgrew the
+  pipe buffer. It "failed the v0.12.9 preflight twice" and was rerun as a flake — two full builds
+  burned — before the code was read (#686).
+- **Human misplacement.** ~8 owner round-trips were spent on dead tunnels, stale browser sessions,
+  and a cold-start whisper model — a demo path the agent had not rehearsed end-to-end.
+
+## Decision
+
+Add a Part I principle cluster **`D-L` (the loops)** as **§7 "The two loops — debug before you
+package"** (between §6 The issue and the renumbered §8 Proof), and a matching Part II operating
+module **"Debugging — the hot loop"** immediately before the Validation ladder — Validation is
+machine-first *proof*; the module is how a provable diff is *produced*. Five principles:
+
+- **D-L0 — Two loops: debug ≠ deliver.** The release pipeline is a *packaging* loop; a hypothesis
+  drops to the hottest loop that carries the real external semantics; ceremony packages proven diffs
+  only.
+- **D-L1 — Debug exit criterion:** a green end-to-end probe of the *assembled* system on the target
+  surface — never "N green unit fixes".
+- **D-L2 — Parallel failure inventory before fixing:** the full-journey probe matrix + one
+  all-component log sweep, before the first fix.
+- **D-L3 — Flake discipline:** "flake" claims nondeterminism and must be earned — one unexplained
+  failure buys one rerun, an identical second demands reading the code; tool answers are
+  cross-checked.
+- **D-L4 — Human placement:** the human appears exactly twice (final witness; sign/approve), the
+  agent self-serves everything else and rehearses the demo path end-to-end before the human walks it.
+
+The DELIVER arc label in the Loop diagram gains `D-L` (`5. DELIVER (D-A · D6b · D-A2 · D-L)`). The
+`D-L3` rule is reinforced in the TAKE protocol's honesty rules; the `D-L4` rehearsal obligation is
+reinforced at choke point 2. AGENTS.md "How you work the checkout" links the section.
+
+## Consequences
+
+- **The next release cannot legally use the packaging pipeline to answer "does this code work?"**,
+  cannot call a deterministic failure a flake, and cannot burn owner round-trips on an un-rehearsed
+  demo — each rule now named in the constitution and mapped to an arm rather than living as prose
+  that rots (D1).
+- **The arms carry the machinery (D1).** #689 (a pre-tag real-spawn leg on k3s) and #690 (`make
+  probe` — the standing full-journey hot loop per surface) are the mechanical gates for D-L0–D-L2 and
+  the D-L4 rehearsal; #686's here-string regression test (`deploy/helm/tests/test_template.sh`) is
+  the durable D-L3 guard; #691 removes the shared-file merge-train tax the same batch paid. Until the
+  OPEN arms land, their enforcement-map rows read **TO BUILD**, honestly.
+- **Not covered (honest):** the one-rerun flake discipline and the hot-loop *choice* stay
+  behavioral — no machine forces an agent to overlay instead of rebuild; the arms make the hot loop
+  cheap and standing, not mandatory. That residue is the same shape as every human-judgment gate in
+  the book.
+- **Renumbering:** inserting §7 shifts Proof → §8, People → §9, Release and closure → §10, How this
+  document changes → §11; no cross-reference used section numbers (principles cite each other by ID
+  and by named anchor), so only the visible heading numbers moved.
+
+## Enforcement map
+
+`docs/docs/governance/delivery.mdx`: five new rows — D-L0/D-L1 (**TO BUILD**, #689/#690),
+D-L2 (**TO BUILD**, #690), D-L3 (**have** #686 regression test / **TO BUILD** rerun rule), and
+D-L4 (**have** choke point 2 / **TO BUILD** #690 rehearsal probe).

--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -49,7 +49,8 @@ one arc, and each arc has a gate.
                     │  4. CLAIM     (D14b)          │  heartbeat lease: 4h, renew or release
                     └───────────────┬───────────────┘
                     ┌───────────────▼───────────────┐
-                    │  5. DELIVER (D-A · D6b · D-A2)│  human + agent in the harnessed loop
+                    │  5. DELIVER (D-A · D6b · D-A2 │  human + agent: debug the hot loop,
+                    │     · D-L the two loops)      │  package only the proven diff
                     └───────────────┬───────────────┘
                                     │  a PR: value bundle + diff
                     ┌───────────────▼───────────────┐
@@ -243,7 +244,75 @@ is a constitution finding that feeds back into `ARCHITECTURE.md`. · *Source:* f
 systemic cause (Toyota); the two books talk to each other. · *Gate:* "Principle check" section on
 fix-requests.
 
-## 7. Proof — PRs and validation
+<a id="the-two-loops"></a>
+
+## 7. The two loops — debug before you package
+
+The DELIVER arc (Loop box 5) runs **two** loops, not one, and confusing them is the most expensive
+mistake we make. v0.12.9 proved the bill: ~6 of ~12 wall-clock hours went to driving fixes through
+the release pipeline to discover whether the *next* layer worked — the pipeline used as a debugger.
+This cluster (`D-L`) makes the split law, gives debugging an exit criterion and a parallel-inventory
+discipline, earns the word "flake", and fixes the human to two moments. Its enforcement arms are
+issues #689, #690, #691; this section is the law they enforce.
+
+**D-L0 — Two loops: debug ≠ deliver.** The release pipeline (PR → gates → tag → build, ~40 min/iter)
+is a *packaging* loop; it must never be used to answer *"does this code work?"*. A hypothesis drops
+to the **hottest loop that carries the real external semantics** — live staging exec, a ConfigMap
+overlay of the runtime env, a spawn probe against a dead URL — where an iteration costs seconds to
+minutes, not a build; ceremony packages *proven* diffs only. · *Source:* the fast inner loop vs. the
+slow outer loop (Humble–Farley); a build is a packaging step, not an experiment. · *Evidence:*
+v0.12.8 was cut after four serially-found helm fixes with no assembled-system probe, and the 5th bug
+was in the new code — PR #684 emitted `containers: [{name}]` in every `kubectl run --overrides`,
+which merges the containers list *by replacement* and wiped the generated image/env/command, so the
+API server rejected every Pod (`spec.containers[0].image: Required value`) and every spawn died in
+~0.3 s, forcing a full re-cut to v0.12.9; the eventual hot loop (ConfigMap overlay + dead-URL spawn
+probe) proved the whole chain in ~10 minutes. · *Gate:* #690 (`make probe` — the standing hot loop)
++ #689 (the pre-tag real-spawn leg, so the packaging loop never *has* to be the debugger).
+**[TO BUILD: #689, #690]**
+
+**D-L1 — Debug exit criterion: a green end-to-end probe of the assembled system on the target
+surface.** You leave debug when the **assembled chain** runs green on the surface that carries the
+bug — never on "N green unit fixes". The last component compiling is not the exit; the whole journey
+running on the real surface is. A unit green claims only its unit (P19/D12): four green helm fixes
+never touched the spawn path that was actually broken. · *Source:* prove at the altitude of the
+claim (P19) applied to the debug loop's exit. · *Gate:* #690 / #689 — the assembled-system probe
+*is* the exit criterion, machine-run. **[TO BUILD: #689, #690]**
+
+**D-L2 — Parallel failure inventory before fixing.** On a suspect surface, run the **full-journey
+probe matrix** (spawn · schedule · boot · join · transcribe · live-view · stop) and sweep **all**
+component logs **once, before touching a fix** — inventory the whole failure set at once, never peel
+one bug at a time. Serial onion-peeling pays the outer-loop tax per layer. · *Source:* see the whole
+line, not one station (Toyota jidoka); log-sweep-before-fix. · *Evidence:* the v0.12.9 helm chain was
+peeled one bug at a time (#656 → #675/#681 → #677/#680 → #676/#679 → #684), ~3h a single 20-min
+full-journey probe + one all-component log sweep would have inventoried at once. · *Gate:* #690 —
+the probe matrix as standing infrastructure. **[TO BUILD: #690]**
+
+**D-L3 — Flake discipline: "flake" is a claim of nondeterminism, and must be earned.** Calling a
+failure a *flake* asserts the code is correct and the run was noise — a claim, not a shrug. One
+unexplained failure buys **exactly one** rerun; an **identical second failure forbids further reruns
+and demands reading the code**. Tool answers (gh CLI state, cached reads, a green that "usually
+passes") are cross-checked against a second source before you act on them. · *Source:* Heisenbug
+discipline; a flaky-test claim is a hypothesis to reproduce or refute, never assume. · *Evidence:*
+the `gate:helm` `printf | grep -q` under `set -euo pipefail` SIGPIPE-raced to exit 141 *exactly on a
+match* — **deterministic** on ubuntu runners once `$RENDER_AUTH` outgrew the pipe buffer; it "failed
+the v0.12.9 preflight twice" and was rerun as a flake, two full builds burned, before the code was
+read (#686). · *Gate:* a durable regression test on the fixed gate (here-strings not pipes,
+`deploy/helm/tests/test_template.sh`, #686) + this rule in the [TAKE protocol](#take-protocol).
+**have** (#686) / **[TO BUILD: rerun-discipline check]**
+
+**D-L4 — Human placement: the human appears exactly twice.** The final **witness pass** and the
+**sign / approve** gates — and nothing else. Everything before is **agent-self-served** — the agent
+drives its own browser session, raw-protocol clients, synthetic and dead-URL meetings, in-bot
+screenshots — and **rehearses the demo path end-to-end minutes before the human walks it**. A human
+asked to admit a bot and handed a dead tunnel, a stale session, or a cold-start model is a scarce
+oracle spent on the agent's un-run homework. · *Source:* the human is the scarce oracle (D9); the
+[two choke points](#the-two-choke-points) already name the two moments — D-L4 adds the rehearsal
+obligation. · *Evidence:* ~8 owner round-trips in v0.12.9 on dead tunnels, stale browser sessions,
+and a cold whisper model — a demo path the agent had not rehearsed. · *Gate:* #690 (the
+agent-runnable probe *is* the rehearsal) + [choke point 2](#the-two-choke-points).
+**have** (choke point 2 named) / **[TO BUILD: #690 rehearsal probe]**
+
+## 8. Proof — PRs and validation
 
 **D8 — Issue = PR, one to one; a PR carries two artifacts — the value bundle and the diff.** The
 bundle answers *"is the value real?"* (D9/D10); the diff answers *"is it correct and safe?"*
@@ -313,7 +382,7 @@ evidence. · *Gate:* prepared-issue template requires the deployments-to-validat
 the attestation names its setup + build provenance; the bundle checker flags rows with no named
 deployment.
 
-## 8. People
+## 9. People
 
 **D13 — Humans author; tools assist. Disclosure welcome, co-authorship never.** What ships carries
 a human name and a human's full responsibility — the sole author is the human, and responsibility
@@ -341,7 +410,7 @@ of the PR's observation bundle, the loop's narration written as it happens. · *
 `claimed` + expiry, watches heartbeats, auto-releases on a miss — all on the issue timeline.
 **[TO BUILD: lease bot]**
 
-### 8b. The tags — the state machine's alphabet
+### 9b. The tags — the state machine's alphabet
 
 Five orthogonal dimensions; a tag is a claim, and the bots keep every claim true. **Exactly one
 `state:`, exactly one `kind:` on prepared work, any number of `area:`, `P0` only when
@@ -360,7 +429,7 @@ maintainer-only on a passing template check; `claimed` only with a live lease; a
 its issue is `value-signed` + security green; `incoming` >3 days alarms; `needs-info` quiet 14
 days → proposed `declined: stale`; every closed-without-merge issue carries one `declined:` reason.
 
-## 9. Release and closure
+## 10. Release and closure
 
 **D15 — Release closes the loop, fast.** A maintainer batches a few value-signed PRs, runs the
 release machinery (image set, gates, VM-validated) and the closing security bundle, ships, and the
@@ -387,7 +456,7 @@ declines rather than letting items age. **[TO BUILD: stale proposer]**
 
 ---
 
-## 10. How this document changes
+## 11. How this document changes
 
 Like the architecture book: propose the change, record the decision as an ADR under
 [`docs/adr/`](https://github.com/Vexa-ai/vexa/tree/main/docs/adr) (process decisions live beside build decisions), and update the [enforcement map](#enforcement-map). A
@@ -640,8 +709,50 @@ hearing about it is an unclosed loop.
 The floor is a floor: never move it mid-review, never demand past it. Every finding carries
 `file:line` and a concrete failure scenario. A human-red is never bounced back as "try
 again" — fully elaborate the failure on instruments first, then request the next human
-attempt. An invalidation ("row A3 is red") is a first-class, credited result. If TAKE reveals
+attempt. **A red is not a flake until earned** (D-L3): one unexplained failure buys exactly one
+rerun, an identical second demands reading the code — never rerun a deterministic red into green.
+An invalidation ("row A3 is red") is a first-class, credited result. If TAKE reveals
 the issue itself was wrong, saying so publicly IS the deliverable (D11).
+
+## Debugging — the hot loop
+
+[Validation](#validation) is machine-first *proof*; this module is how a provable diff is
+*produced*. It operates the `D-L` cluster ([§7](#the-two-loops)): the packaging pipeline is never the
+debugger, and a hypothesis is tested on the hottest loop that carries the real external semantics.
+
+**Pick the hottest loop that carries the real semantics (`D-L0`).** Rank the loops by iteration cost
+and by how much external truth each carries; drop the hypothesis to the *hottest one that still
+exercises the real failure*:
+
+| Loop | Iter cost | Carries | Use it to |
+|---|---|---|---|
+| unit / golden | seconds | one seam, mocked edges | localize a seam bug you can already name |
+| **assembled hot loop** — live exec · ConfigMap overlay · spawn probe | seconds–minutes | the real chain on the real surface | **answer "does this work?"** — this is the debug loop |
+| release pipeline — PR → gates → tag → build | ~40 min | the packaged artifact | package a *proven* diff — never to discover one |
+
+If you find yourself cutting a build to learn whether the next layer works, you are debugging in the
+wrong loop — stop and build the overlay / probe that carries the same semantics in minutes.
+
+**Inventory in parallel, before the first fix (`D-L2`).** On a suspect surface, run the full-journey
+probe matrix — spawn · schedule · boot · join · transcribe · live-view · stop — and sweep **every**
+component's logs **once**, before touching a fix. Write the whole failure set down, then fix. Serial
+onion-peeling pays the outer-loop tax per layer (v0.12.9's helm chain: ~3h of one-bug-at-a-time a
+single 20-min sweep would have inventoried).
+
+**Leave debug only on the assembled-system green (`D-L1`).** The exit is a green end-to-end probe of
+the *assembled* system on the surface that has the bug — not the last component compiling. A unit
+green claims only its unit (P19/D12).
+
+**Earn the word "flake" (`D-L3`).** A failure is not a flake until you have earned the claim. One
+unexplained failure → **exactly one** rerun; an identical second failure → **stop rerunning, read the
+code**. Cross-check tool answers (CLI state, cached reads) against a second source before acting. A
+deterministic failure rerun as a flake burns builds and hides the bug (v0.12.9's SIGPIPE gate, #686).
+
+**Rehearse before the human (`D-L4`).** The human appears exactly twice — the witness pass and the
+sign/approve gates. Everything else the agent self-serves (own browser session, raw-protocol clients,
+synthetic and dead-URL meetings, in-bot screenshots), and the agent **runs the demo path end-to-end
+minutes before the human walks it** (`make probe` is the rehearsal, #690). A human handed a dead
+tunnel or a cold model is a wasted oracle.
 
 ## Validation
 
@@ -801,7 +912,9 @@ author (us). The maintainer rules on the card in minutes; they never re-derive e
 
 **Choke point 2 — the release witness pass, one per release.** The batch's user-visible value,
 walked once, live, on the release candidate (the witness script; ship bar above). The human
-acts where machines cannot — admission, and seeing the assembled product deliver.
+acts where machines cannot — admission, and seeing the assembled product deliver. The agent
+**rehearses the whole path end-to-end minutes before** — every tunnel, session, and model warm — so
+the human meets a working demo, not the agent's un-run homework (D-L4).
 
 ## Asking the human
 
@@ -893,6 +1006,10 @@ silence is released, never punished · every decline names its reopen condition 
 | D6c docs ride the change; docs declare their release; docs story human-validated | `docs-current` (product-surface PR updates docs/ or declares `docs: none`) · `gate:docs-version` (docs stamp == appVersion) · attestation covers the docs story | **have** (CI: `docs-current-gate` + `gate:docs-version`, [ADR-0032](https://github.com/Vexa-ai/vexa/blob/main/docs/adr/0032-docs-currency-gates.md)) / **TO BUILD** (content-accuracy stays human) |
 | D12b deployment named + setup provenance | "deployments to validate" required before `ready`; attestation names setup + build provenance | **have** (templates) / **TO BUILD** (bundle checker flags rows with no named deployment) |
 | D7 principle check on fixes | fix-request template section | **have** (prepared-issue template) |
+| D-L0/D-L1 debug ≠ deliver + assembled-probe exit criterion | the standing hot loop (`make probe`) + a pre-tag real-spawn leg, so the packaging pipeline is never the debugger | **TO BUILD** (#689 real-spawn leg · #690 `make probe`; [ADR-0033](https://github.com/Vexa-ai/vexa/blob/main/docs/adr/0033-the-two-loops-debug-flake-human.md)) |
+| D-L2 parallel failure inventory before fixing | full-journey probe matrix + one all-component log sweep, as standing infrastructure | **TO BUILD** (#690 probe matrix) |
+| D-L3 "flake" is earned | durable regression test on the fixed gate + the one-rerun rule in TAKE | **have** (#686 `deploy/helm/tests/test_template.sh`) / **TO BUILD** (rerun-discipline in the checks bot) |
+| D-L4 human placement — exactly twice + rehearsal | agent-rehearsable probe is the rehearsal; choke point 2 names the witness moment | **have** (choke point 2 named) / **TO BUILD** (#690 agent-rehearsable probe) |
 | D8 bundle + diff | PR template requires the observation bundle | **have** (`.github/pull_request_template.md`) |
 | D-S security lanes | contributor security status + maintainer bundle | **TO BUILD** (status) / **have** (maintainer practice) |
 | D9 value-signed, corroborated | `gate:value-signed` checks non-author + channel consistency (merge-time) · **release-time:** `value-gate` requires every batch PR pr-value-green/value-signed | **have** (CI: `merge-card-gate` merge-time, `release-value-gate` release-time; [ADR-0029](https://github.com/Vexa-ai/vexa/blob/main/docs/adr/0029-release-witness-and-value-gates-enforced.md)/[ADR-0030](https://github.com/Vexa-ai/vexa/blob/main/docs/adr/0030-merge-card-value-and-diff-gate.md)) |

--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -454,6 +454,19 @@ failure state we refuse. · *Source:* explicit disposition; stop starting, start
 · *Gate:* every closed-without-merge issue carries a `declined:` reason; intake/stale bots propose
 declines rather than letting items age. **[TO BUILD: stale proposer]**
 
+**D18 — Every release session ends in a retrospective; abandonment doubly so.** A release session
+— whether it promoted or abandoned its candidate — closes with a retro stage covering three axes:
+**loop efficiency** (where wall-time went; which hypotheses ran the packaging loop instead of the
+hot loop — D-L0), **delivery hardening** (what shipped-or-nearly-shipped that the machine missed,
+and which gate would have caught it), and **architecture quality** (what class of gap the batch
+exposed — not the instances, the class). Findings leave the chat as *prepared issues* before the
+session closes; a reflection that stays in the transcript is a reflection lost. An **abandoned
+candidate is not an embarrassment to skip past — it is the highest-yield retro input we have**
+(v0.12.5–v0.12.8 each carried a lesson no green run could teach). · *Source:* the v0.12.9
+retrospective — six shipped bugs, two release-infra bugs, and the D-L cluster itself all came out
+of one retro stage. · *Gate:* the CTO handover template carries the three retro axes; a release
+event in the planning log links its retro issues. **[TO BUILD: handover template section]**
+
 ---
 
 ## 11. How this document changes


### PR DESCRIPTION
Closes #688 — amends the delivery constitution with the **`D-L` (the two loops)** principle cluster from the v0.12.9 release retrospective. Docs + ADR only; no product code.

## What lands

- **C1 — the two-loops section (`docs/docs/governance/delivery.mdx`).**
  - New **Part I §7 "The two loops — debug before you package"** (D-L0–D-L4), inserted between §6 The issue and the renumbered §8 Proof, with a renumber-proof `<a id="the-two-loops">` anchor.
  - Renumbered downward: Proof → **§8**, People → **§9** (9b tags), Release and closure → **§10**, How this document changes → **§11**. No cross-reference used section numbers (principles cite each other by ID / named anchor), so only the visible heading numbers moved.
  - New **Part II operating module "Debugging — the hot loop"** immediately before the Validation ladder (Validation is machine-first *proof*; the module is how a provable diff is *produced*).
  - **Loop diagram** DELIVER-arc label now reads `5. DELIVER (D-A · D6b · D-A2 · D-L)`.
  - D-L3 reinforced in the **TAKE** protocol honesty rules; D-L4 rehearsal obligation reinforced at **choke point 2** — so the enforcement-map gate citations are true.
- **C2 — `AGENTS.md`.** "How you work the checkout" carries a new bullet linking `https://docs.vexa.ai/governance/delivery#the-two-loops`.
- **C3 — ADR + enforcement map.** `docs/adr/0033-the-two-loops-debug-flake-human.md` records the amendment (context = v0.12.9 retro; arms = #689/#690/#691). Five new enforcement-map rows for D-L0–D-L4, each carrying its gate + honest status.

## The five laws

- **D-L0** Two loops: debug ≠ deliver — the release pipeline is a *packaging* loop; a hypothesis drops to the hottest loop carrying the real external semantics; ceremony packages proven diffs only.
- **D-L1** Debug exit criterion: a green end-to-end probe of the **assembled** system on the target surface — never N green unit fixes.
- **D-L2** Parallel failure inventory before fixing: full-journey probe matrix + one all-component log sweep, before the first fix.
- **D-L3** Flake discipline: "flake" claims nondeterminism and must be earned — one unexplained failure buys one rerun; an identical second demands reading the code.
- **D-L4** Human placement: the human appears exactly twice (final witness; sign/approve); the agent self-serves everything else and rehearses the demo path before the human walks it.

## Acceptance mapping (from #688)

| # | Observation | Where |
|---|---|---|
| **A1** | D-book renders the `D-L` cluster (D-L0–D-L4) as a Part I §7 + a Part II "Debugging — the hot loop" module before "Validation"; the Loop diagram's DELIVER arc names `D-L` | `delivery.mdx` §7 (Part I), "Debugging — the hot loop" (Part II), diagram box 5 |
| **A2** | AGENTS.md "How you work the checkout" carries a link whose anchor resolves to the new section | `AGENTS.md` → `#the-two-loops` (explicit `<a id>`, renumber-proof) |
| **A3** | `docs/adr/0033-*.md` exists and the enforcement map lists D-L0–D-L4 each with a gate + status citing #689/#690/#686 | `docs/adr/0033-the-two-loops-debug-flake-human.md` + 5 enforcement-map rows |
| **A-** | No-regression: docs site builds; `gate:docs-version` unaffected; no dead links introduced | `docs-reflects` untouched; `node scripts/gates.mjs` green (incl. `gate:docs-version — docs reflect v0.12.9`) |

## Evidence (v0.12.9 retrospective, verified on `origin/main`)

- **#684** (MERGED) — `containers: [{name}]` in `kubectl run --overrides` merged by replacement, wiped image/env/command → every spawn died ~0.3 s → full re-cut to v0.12.9. The pipeline-as-debugger tax (D-L0/D-L1).
- **#686** (MERGED) — `gate:helm` `printf | grep -q` under `set -euo pipefail` SIGPIPE-raced to exit 141 *deterministically*, "failed preflight twice", reran as a flake → the durable here-string regression test (`deploy/helm/tests/test_template.sh`) is the D-L3 guard.
- **#673/#675/#678/#681** — the serially-peeled helm chain (D-L2).
- **#689 / #690 / #691** (OPEN) — the enforcement arms; their map rows read **TO BUILD** honestly until they land.
- `releases/v0.12.9/witness.json` — the batch receipt.

## Notes for the ready-stamp

- Placement follows #688's primary proposal (§7 numeric, renumber downward). The alternative (`## 6b.` under §6) is available if the maintainer prefers — the anchor `#the-two-loops` and every internal cross-ref are number-independent either way.
- Governance/docs-only PR: `docs-current` is exempt (not a product surface); `gate:docs-version` carries no change (I did not touch the `docs-reflects` stamp).

No merge, no labels — leaving triage per TAKE.
