### PR TITLE
docs(governance): value definition leads the prepared-issue body

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-prepared-issue.md
+++ b/.github/ISSUE_TEMPLATE/3-prepared-issue.md
@@ -7,14 +7,14 @@ labels: ["state: prepared"]
 <!-- The body IS the delivery constitution applied (docs/docs/governance/delivery.mdx D5/D6/D10).
      A maintainer stamps `state: ready` only when every section below holds. -->
 
-### Why this matters
-<!-- Dry, factual business stakes: what a user loses, what depends on it, what was observed and where. No drama. -->
-
 ### Value this issue delivers
 > <!-- ONE sentence a human can witness: the smallest holistic thing someone recognizes as "this delivers value to me".
      D5b: if this ONE code change delivers several values (one root cause, several reports), state EACH value as its
      own sentence here — and give each its own acceptance row + preferred validator below. Never bundle values that
      need different code changes; record those as a `same-setup` note instead. -->
+
+### Why this matters
+<!-- Dry, factual business stakes: what a user loses, what depends on it, what was observed and where. No drama. -->
 
 ### Where we are (honest)
 <!-- Current-code facts, file:line where known. Old reports contribute symptoms only. -->

--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -567,9 +567,10 @@ State it before writing the body:
    starves token validation under load — valid API keys mass-401"); for probes, the question
    being measured; for features, the capability. Never an aspirational state-sentence
    ("The API answers while…") — the title states what is wrong, not the world after the fix.
-2. **Why this matters** — dry, factual stakes: what a user loses, what depends on it, what was
+2. **Value this issue delivers** — one witnessable sentence per value (D5/D5b), FIRST: the
+   reader decides whether to care before anything else, so the value leads the body.
+3. **Why this matters** — dry, factual stakes: what a user loses, what depends on it, what was
    observed and where (D3).
-3. **Value this issue delivers** — one witnessable sentence per value (D5/D5b).
 4. **Where we are (honest)** — current-code facts, `file:line` for every claim. Unknowns stated
    as unknowns. **The era note is mandatory when the report predates the current tree:** state
    the report's version/era vs today's code explicitly — an old-era report means we are


### PR DESCRIPTION
Owner ruling at the v0.12.9 finalization: the value sentence is the first thing a reader sees in a prepared issue — it currently sits mid-body. Reorders `.github/ISSUE_TEMPLATE/3-prepared-issue.md` (Value → Why → Where we are) and the D-book PREPARE Step 4 numbering to match. Docs+template only, no release.