### PR TITLE
docs/tests: kill the merge-train tax (fragments + merge=union + fan-out) + edge-guard safe-config caveat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# .gitattributes — merge strategy per path.
+#
+# `merge=union` tells git, on a merge conflict in a file, to KEEP BOTH SIDES' added lines instead
+# of raising a conflict. It is correct ONLY for genuinely append-only content: lines are added, never
+# edited in place, and line ORDER carries no meaning. Applied to anything else it silently corrupts —
+# so this file is deliberately conservative. Every `merge=union` line says why it is safe; the long
+# comment block at the end says why the obvious candidates are NOT union-ized. (See issue #691.)
+
+# ── union-safe: per-PR changelog fragments ───────────────────────────────────────────────────────
+# Each release PR drops its own docs/changelog.d/<pr>-<slug>.md (the towncrier pattern, see that
+# dir's README). The primary anti-collision mechanism is one-file-per-PR — distinct new files never
+# conflict at all. union here is the safety net for the rare case two PRs add lines to the SAME
+# fragment file: fragments are unordered Markdown bullets that are never edited once written, so
+# keeping both sides' bullets is exactly the right resolution. Genuinely append-only ⇒ union-safe.
+docs/changelog.d/*.md merge=union
+
+# ── NOT union-safe — intentionally left to human resolution (do not add merge=union below) ────────
+#
+# deploy/helm/tests/test_template.sh — the gate:helm static-render proof. Its assertions are
+#   `need <count> <pattern> <label>`; adding a k8s resource means EDITING an existing count line
+#   (e.g. `need 7 '^kind: Deployment'` → `need 8`), not appending. Two PRs each bumping the same
+#   count is a true semantic conflict — union would keep BOTH `need 7` and `need 8`, a silently-wrong
+#   gate. A visible conflict is the correct outcome here. Keep two agents off it via AGENTS.md's
+#   fan-out rule (#691 C3); the long-term fix is deriving counts instead of asserting literals.
+#
+# docs/docs/changelog.mdx — prose, plus the `docs-reflects:` version stamp that gate:docs-version
+#   pins to Chart.yaml appVersion. Interleaved release bullets read wrong under union, and union near
+#   the stamp could duplicate it. Solved by the fragments above (C1), NOT by union — never union-ize.
+#
+# docs/docs/deployment-kubernetes.mdx — prose. Two PRs appending different sections would interleave
+#   into nonsense under union. Solved by the fan-out rule (C3), NOT by union — never union-ize.
+#
+# Structured config (deploy/helm/charts/vexa/Chart.yaml, **/config.v1.json, deploy/**/.env.example,
+#   package.json, security-insights.yml, license-exceptions.json, docker-compose*.yml, …) — JSON /
+#   YAML / KEY=VALUE. A changed value is an EDITED line, not an append, and union would produce
+#   duplicate keys or structurally invalid files. Never union-ize structured formats.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,20 @@ A prepared issue is a worked delivery spec — read it end to end before touchin
   didn't happen. The issue is the source of truth; Discord is the speed.
 - **One worktree per session** (`git worktree add ../vexa-<slug> -b <your-branch>`). Never two
   sessions on one tree; never adopt another session's uncommitted files — surface them.
+- **Never fan two parallel agents onto the same hot file — write your own file, or sequence.**
+  Parallel PRs that all append to one file's tail collide on the same last line even when the
+  additions don't interact — the v0.12.9 batch paid 5 manual conflict-resolution cycles to exactly
+  this. The three hot files and their remedy:
+  - **`docs/docs/changelog.mdx`** — do **not** edit it for a per-PR line. Drop a fragment at
+    `docs/changelog.d/<pr>-<slug>.md` (one file per PR → zero collisions; the release collector
+    folds them in, `docs-reflects` stamp intact). See
+    [`docs/changelog.d/README.md`](docs/changelog.d/README.md). That fragment is your `docs-current` touch.
+  - **`deploy/helm/tests/test_template.sh`** and **`docs/docs/deployment-kubernetes.mdx`** — no
+    fragment mechanism, and **not** `merge=union`-safe (the helm test's `need <count>` assertions are
+    *edited* when a resource count changes, not appended; the k8s page is prose). If two claimed
+    issues both touch one of these, **flag it on the issues and sequence the PRs** (land one, rebase
+    the other) rather than racing them into a conflict. This is the same "anything decided lands back
+    on the issue" rule applied before the collision.
 - **Read the chart first.** [`docs/views/architecture.dsl`](docs/views/architecture.dsl)
   (~1.4k tokens) is the generated whole-graph index: every node, edge, carrier, owner. For a
   slice: `pnpm arch:viz cluster:<domain>`. If your change adds/moves a module or alters a

--- a/docs/changelog.d/README.md
+++ b/docs/changelog.d/README.md
@@ -1,0 +1,45 @@
+# `docs/changelog.d/` — per-PR changelog fragments (the towncrier pattern)
+
+**Do not edit `docs/docs/changelog.mdx` directly for a per-PR entry.** Drop a *fragment* here
+instead. This exists to kill the merge-train tax: when N parallel PRs each append a line to the
+single tail of `changelog.mdx`, they collide on the same last line even though the additions never
+interact (the v0.12.9 batch paid 5 manual conflict-resolution cycles to exactly this). One file per
+PR means N PRs create N distinct files — git auto-merges them, zero conflicts.
+
+## Add a fragment (in your PR)
+
+Create **one file per PR**, named `<pr>-<slug>.md` — e.g. `692-fragments-collector.md`. (Don't know
+the PR number yet? Use the issue number, or rename on push. Any unique `<n>-<slug>.md` works; the
+collector orders by the leading number.)
+
+Its contents are the changelog entry exactly as it should read — one or more Markdown bullets, in
+the same voice as the existing `## 0.12.x maintenance fixes` bullets:
+
+```markdown
+- **Short subject: what changed and who feels it (#692).** One or two sentences of the user-visible
+  effect. Link the relevant docs page if there is one. See [Deployment](/deployment).
+```
+
+That fragment file **is** your PR's docs touch — it satisfies `docs-current` (D6c / ADR-0032) for a
+user-visible change on its own; you don't also need to edit `changelog.mdx`.
+
+Not every PR needs a fragment: repo-tooling / docs-only / test-only changes with no user-visible
+effect don't add a changelog line (they take `docs: none` or ride their own docs). Add a fragment
+only when a `:v012` user would want to read about the change.
+
+## What happens at release
+
+The release version-bump runs the collector once:
+
+```bash
+node scripts/changelog-collect.mjs            # fold pending fragments into changelog.mdx, remove them
+node scripts/changelog-collect.mjs --check    # preview only (exit 3 if fragments are pending)
+```
+
+It appends every pending fragment into the `## <MAJOR>.<MINOR>.x maintenance fixes` section of
+`docs/docs/changelog.mdx`, then deletes the consumed fragments so this directory returns to empty
+(just this README). It never touches the `docs-reflects:` stamp — the version-bump advances that
+separately so `gate:docs-version` stays green. See [`releases/README.md`](../../releases/README.md).
+
+Migrate nothing retroactively — the convention starts now; existing `changelog.mdx` sections stay
+as they are.

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -204,7 +204,9 @@ IP → one global bucket shared by all clients (one abuser throttles everyone). 
 | `GUARD_WS_ENABLED` | `false` | Opt-in `/ws` connect guard. In-memory per-process — does **not** share ban/rate state with the Redis-backed HTTP layer, and under `uvicorn --workers N>1` each worker keeps an independent WS ban set. |
 
 <Note>
-With `GUARD_ENABLE_REDIS=false` AND `uvicorn --workers N>1`, the HTTP rate-limit buckets and auto-bans are also per-process: the effective limit becomes `N × GUARD_RATE_LIMIT_RPM` and bans do not propagate across workers (the WS per-process ceiling above applies to the WS path independently).
+With `GUARD_ENABLE_REDIS=false` AND `uvicorn --workers N>1`, the HTTP rate-limit buckets and auto-bans are also per-process: the effective limit becomes `N × GUARD_RATE_LIMIT_RPM` and bans do not propagate across workers (the WS per-process ceiling above applies to the WS path independently). The same applies across multiple gateway **replicas** without Redis — each is its own process.
+
+**Safe configurations:** the shipped gateway runs a **single** uvicorn worker, so the default (`GUARD_ENABLE_REDIS=true`, one worker) enforces the limit globally. If you scale to multiple workers **or** replicas, keep `GUARD_ENABLE_REDIS=true` — Redis-backed state is what shares the buckets and bans across processes. `GUARD_ENABLE_REDIS=false` is only safe with a single worker **and** a single replica; if you must run without Redis at higher concurrency, divide `GUARD_RATE_LIMIT_RPM` by the process count to hold the aggregate cap (note this still will not propagate bans).
 </Note>
 
 The guard fails open (`fail_secure=false`): a guard-check bug or a redis outage returns the request to

--- a/releases/README.md
+++ b/releases/README.md
@@ -10,6 +10,22 @@ required-reviewer approval — a committed file cannot forge a human approval, s
 Publish and promote are **separate acts**; neither the moving tag `:v012` nor a published GitHub
 Release happens before the witness pass is signed.
 
+0. **Version-bump (before you tag)** — advance `appVersion` in
+   `deploy/helm/charts/vexa/Chart.yaml`, advance the matching `docs-reflects:` stamp (and the visible
+   line) in `docs/docs/changelog.mdx` so `gate:docs-version` stays green, and **assemble the changelog
+   fragments** that PRs dropped since the last release (the towncrier pattern —
+   [`docs/changelog.d/`](../docs/changelog.d/README.md)):
+
+   ```bash
+   node scripts/changelog-collect.mjs --check   # preview pending fragments (exit 3 if any pending)
+   node scripts/changelog-collect.mjs           # fold them into the ## <MAJOR>.<MINOR>.x section, remove them
+   ```
+
+   The collector appends each `docs/changelog.d/<pr>-<slug>.md` bullet into the current version
+   section and deletes the consumed fragments; it does **not** touch the `docs-reflects:` stamp (you
+   just advanced it). Commit the bumped `Chart.yaml` + assembled `changelog.mdx` + emptied
+   `changelog.d/` together, then tag.
+
 1. **Publish + validate** — push tag `vX.Y.Z`. `release-images` builds and publishes the versioned
    `:vX.Y.Z` images and runs `release-validate` with **`promote: false`** — the L4 legs prove the
    published bytes, but `:v012` does **not** move. The release candidate now exists to be witnessed.

--- a/scripts/changelog-collect.mjs
+++ b/scripts/changelog-collect.mjs
@@ -1,0 +1,102 @@
+// scripts/changelog-collect.mjs — assemble per-PR changelog fragments into the changelog at
+// release time (the towncrier pattern). Repo tooling only: pure Node stdlib, no product runtime,
+// no import from core/ or clients/ — it runs during the release version-bump, never in a service.
+//
+// WHY THIS EXISTS. Every user-visible PR used to append its line to the single tail of
+// docs/docs/changelog.mdx. N parallel PRs then collide on that one last line even though the
+// additions don't interact — the v0.12.9 batch (#678…#687) paid 5 manual conflict-resolution
+// cycles to exactly this. The fix: each PR drops its own file at docs/changelog.d/<pr>-<slug>.md
+// (N PRs → N distinct files → zero collisions; git never sees a shared edit). The release
+// version-bump runs this collector once to fold the pending fragments into the changelog under the
+// current version section, then removes the consumed fragments.
+//
+// The docs-reflects stamp (docs/docs/changelog.mdx:6-7) is NOT touched here — the release
+// version-bump owns advancing it (gate:docs-version pins it to Chart.yaml appVersion). This script
+// only inserts the accumulated fragment bullets into an existing version section.
+//
+// Usage:
+//   node scripts/changelog-collect.mjs                 assemble pending fragments, delete them
+//   node scripts/changelog-collect.mjs --check         preview only; mutate nothing
+//                                                       (exit 3 if fragments are pending — a CI signal)
+//   node scripts/changelog-collect.mjs --version X.Y.Z override the target version
+//   node scripts/changelog-collect.mjs --section "## …" override the exact section heading
+//
+// Default target version = Chart.yaml appVersion; default section = "## <MAJOR>.<MINOR>.x maintenance
+// fixes" (the changelog's existing home for per-PR point-release bullets).
+
+import { readFileSync, writeFileSync, readdirSync, rmSync, existsSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const FRAG_DIR = join(ROOT, "docs", "changelog.d");
+const CHANGELOG = join(ROOT, "docs", "docs", "changelog.mdx");
+const CHART = join(ROOT, "deploy", "helm", "charts", "vexa", "Chart.yaml");
+
+const argv = process.argv.slice(2);
+const flag = (name) => { const i = argv.indexOf(name); return i >= 0 ? argv[i + 1] : undefined; };
+const check = argv.includes("--check");
+
+function die(msg) { console.error(`changelog-collect: ${msg}`); process.exit(2); }
+
+// The version whose section receives the fragments.
+let version = flag("--version");
+if (!version) {
+  if (!existsSync(CHART)) die("Chart.yaml not found — pass --version X.Y.Z");
+  version = (readFileSync(CHART, "utf8").match(/^appVersion:\s*"?([^"\s]+)"?/m) || [])[1];
+  if (!version) die("could not read appVersion from Chart.yaml — pass --version X.Y.Z");
+}
+const [major, minor] = version.split(".");
+const section = flag("--section") || `## ${major}.${minor}.x maintenance fixes`;
+
+// Pending fragments: every *.md under docs/changelog.d/ except the README convention doc.
+// Sorted by numeric PR prefix (then name) so assembly order is deterministic and PR-ordered.
+const fragments = existsSync(FRAG_DIR)
+  ? readdirSync(FRAG_DIR)
+      .filter((f) => f.endsWith(".md") && f !== "README.md")
+      .sort((a, b) => (parseInt(a) || 0) - (parseInt(b) || 0) || a.localeCompare(b))
+  : [];
+
+if (fragments.length === 0) {
+  console.log("changelog-collect: no pending fragments in docs/changelog.d/ — nothing to assemble.");
+  process.exit(0);
+}
+
+const blocks = fragments.map((f) => ({
+  file: f,
+  body: readFileSync(join(FRAG_DIR, f), "utf8").replace(/\s+$/, ""),
+}));
+
+if (check) {
+  console.log(`changelog-collect --check: ${blocks.length} pending fragment(s) for section "${section}":`);
+  for (const b of blocks) console.log(`\n  ── ${b.file} ──\n${b.body.split("\n").map((l) => "  " + l).join("\n")}`);
+  console.log(`\n(preview only — nothing written; run without --check at release to assemble.)`);
+  process.exit(3); // nonzero: "fragments are pending", a usable CI/release-checklist signal
+}
+
+// Insert the fragment bodies at the END of the named section (append after its last line, just
+// before the next "## " level-2 heading or EOF). Everything else — including the docs-reflects
+// stamp — is preserved byte-for-byte.
+const lines = readFileSync(CHANGELOG, "utf8").split("\n");
+const start = lines.findIndex((l) => l.trim() === section);
+if (start < 0) {
+  die(`section heading not found in changelog.mdx: "${section}".\n` +
+      `   Create it (a deliberate act at a minor bump), or pass --section "## …".`);
+}
+let end = lines.length;
+for (let i = start + 1; i < lines.length; i++) {
+  if (/^## /.test(lines[i])) { end = i; break; }
+}
+// Trim trailing blank lines inside the section, then append each fragment as its own block.
+let insertAt = end;
+while (insertAt > start + 1 && lines[insertAt - 1].trim() === "") insertAt--;
+const additions = [];
+for (const b of blocks) { additions.push("", b.body); }
+lines.splice(insertAt, 0, ...additions);
+
+writeFileSync(CHANGELOG, lines.join("\n"));
+for (const b of blocks) rmSync(join(FRAG_DIR, b.file));
+
+console.log(`changelog-collect: assembled ${blocks.length} fragment(s) into "${section}" of docs/docs/changelog.mdx:`);
+for (const b of blocks) console.log(`  ✓ ${basename(b.file)} (removed)`);
+console.log(`  docs-reflects stamp untouched — advance it in the version-bump so gate:docs-version stays green.`);


### PR DESCRIPTION
Closes #691
Closes #568

Owner ruling: docs/config/scripts only, one PR, no release needed. Zero runtime surface.

---

## #691 — kill the shared-file merge-train tax

The v0.12.9 batch paid **5 manual conflict-resolution cycles**, all on the three append-heavy hot
files (`changelog.mdx`, `deploy/helm/tests/test_template.sh`, `deployment-kubernetes.mdx`). This PR
removes the tax at the mechanism level.

| # | Observation (from the issue's acceptance table) | Where it landed / evidence |
|---|---|---|
| **A1** | Two branches each add a `docs/changelog.d/<pr>-<slug>.md` fragment → `git merge` both with **no conflict**; the release collector assembles both into `changelog.mdx`, stamp intact | **C1.** New `docs/changelog.d/` (README = the convention) + `scripts/changelog-collect.mjs` (stdlib-only, no product runtime), wired into the release version-bump in `releases/README.md`. Validated in a sandbox: two distinct fragment files merged with **NO conflict** (negative control: two branches editing the same `changelog.mdx` tail → **CONFLICT**). Collector run folded 2 test fragments into the `## 0.12.x maintenance fixes` section, removed them, `docs-reflects` stamp untouched → `gate:docs-version` green. |
| **A2** | `.gitattributes` applies `merge=union` to declared union-safe files **and explicitly excludes** `test_template.sh` (with a comment saying why) | **C2.** New `.gitattributes`: `merge=union` **only** on `docs/changelog.d/*.md` (genuinely append-only, order-irrelevant bullets — the safety net for the fragments mechanism). `test_template.sh`, `changelog.mdx`, `deployment-kubernetes.mdx`, and structured config each **excluded with a per-line reason**. Validated: two branches appending to a union-marked file **auto-merged**; two branches bumping a `need <count>` line on the non-union test file **still CONFLICT** (proving we did *not* paper over the unsafe file). |
| **A3** | `AGENTS.md` "How you work the checkout" names the three hot files and the fragment/sequence remedy | **C3.** New bullet under "How you work the checkout": `changelog.mdx` → drop a fragment; `test_template.sh` / `deployment-kubernetes.mdx` → flag on the issue and **sequence** (not union-safe). |
| **A-** | No-regression: `gate:docs-version` stays green (stamp preserved); `gate:helm` assertions unchanged; product behavior untouched | `gate:docs-version` green (stamp still `0.12.9` == Chart.yaml appVersion). `test_template.sh` **not touched**. `gate:readme` green (new dir carries its README → 307 dirs). No runtime file changed. |

**Honesty note (per the issue's own analysis):** `deploy/helm/tests/test_template.sh` is deliberately
**not** `merge=union` — its `need <count>` assertions are *edited* (not appended) when a resource
count changes, so union would keep both a stale and a new count and silently corrupt the gate. It is
routed to the C3 fan-out rule, exactly as the issue instructs.

## #568 — edge-guard: `GUARD_ENABLE_REDIS=false` + `--workers N` degradation

Verified against `core/gateway/services/gateway/src/gateway/edge_guard.py`: `build_guard_config()`
sets `enable_redis=_env_bool("GUARD_ENABLE_REDIS", True)`; with it `false`, fastapi-guard keeps
rate-limit buckets and ban lists in **process memory**, so under `uvicorn --workers N` (or N
replicas) each process has its own — effective limit `N × GUARD_RATE_LIMIT_RPM`, bans don't
propagate. The shipped gateway (`__main__.py`) runs a **single** uvicorn worker, so the default is
safe.

**Finding:** the degradation sentence the issue asks for was **already added by PR #573** (comment on
the issue: "Fixed in #573") in `core/gateway/README.md`, `docs/docs/configuration.mdx`, and
`deploy/lite/supervisord.conf` — and it is accurate. The one part the issue's acceptance calls for
that was **missing** is *"state the safe configurations."* This PR adds exactly that to the existing
`<Note>` in `docs/docs/configuration.mdx` (the canonical operator knob page): default is safe;
multi-worker/replica needs `GUARD_ENABLE_REDIS=true`; without Redis run a single worker + single
replica (or divide `GUARD_RATE_LIMIT_RPM` by the process count to hold the aggregate — still won't
propagate bans).

## Deviations from the prepared solutions

- **#691 C2 union target.** The issue anticipated union targeting "remaining accumulate-only
  manifests" beyond the changelog. A survey of the actual collision surface found none that are
  genuinely append-only (the other hot files are count-based or prose; the other frequently-touched
  files are structured JSON/YAML/env, all union-unsafe). So union is applied to the one genuinely
  safe target — `docs/changelog.d/*.md` — as the documented safety net for C1, and every unsafe
  candidate is excluded with a reason. This matches the issue's "apply union only where a line, once
  written, is never edited" instruction honestly.
- **#568 already largely shipped.** Rather than duplicate the existing (correct) caveat, this PR adds
  only the missing "safe configurations" guidance. If the maintainer prefers, #568 could simply be
  closed as done-by-#573; the added safe-config paragraph is the marginal value.

## Gates

`node scripts/gates.mjs` — the pre-push static subset (readme, dataflow, isolation, exports, graph,
schema, contract-version, config-contract, licenses, execution-env, test-isolation,
contract-conformance) ran green on push. `gate:readme` (307 dirs) and `gate:docs-version` (stamp ==
appVersion) confirmed green on the changed tree. `docs-current` is satisfied by the docs diff itself.
