### PR TITLE
fix(db-budget-gate): scan the committed tree — a numpy fixture in a gitignored .venv was reding the connection budget (#702)

### DIFF
--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -899,10 +899,14 @@ function gateDbSchema() {
 // service that constructs a Postgres engine must be in deploy/db-budget.json; Σ(helm replicas ×
 // per-service pool ceiling) + reserved must fit max_connections; and no service's code may set a
 // pool_size/max_overflow HIGHER than its declared ceiling (so the budget can't silently under-count).
+// Both scans below read the COMMITTED tree via `git grep --untracked` — tracked files plus new
+// not-yet-added ones, never gitignored paths. The .venv/site-packages trees gate:python materializes
+// under core/ match both patterns (numpy fixtures set pool_size=; sqlalchemy defines
+// create_async_engine) and must not enter the budget. --untracked keeps a brand-new .py in scope.
 function _dbHoldingServices() {
   let out;
   try {
-    out = execSync("grep -rl --include='*.py' create_async_engine core", { cwd: ROOT }).toString();
+    out = execSync("git grep --untracked -l create_async_engine -- 'core/*.py'", { cwd: ROOT }).toString();
   } catch { return new Set(); }  // grep exit 1 = no matches
   const svcs = new Set();
   for (const path of out.split("\n")) {
@@ -918,7 +922,7 @@ function _explicitPool(service) {
   // the framework default (the "silent default" the issue names). Used to reject an under-stated budget.
   let out = "";
   try {
-    out = execSync(`grep -rhoE --include='*.py' '(pool_size|max_overflow) *= *[0-9]+' core 2>/dev/null | grep -v test || true`, { cwd: ROOT }).toString();
+    out = execSync(`git grep --untracked -hoE '(pool_size|max_overflow) *= *[0-9]+' -- 'core/*.py' 2>/dev/null | grep -v test || true`, { cwd: ROOT }).toString();
   } catch { out = ""; }
   const found = {};
   for (const line of out.split("\n")) {


### PR DESCRIPTION
**Delivers issue:** #702

Both of `gate:db-budget`'s source scans ran `grep -r … core` over the **working directory**, so the
`.venv` trees `gate:python` materializes were part of the population. Both now scan the **committed
tree** via `git grep --untracked … -- 'core/*.py'`. 5 insertions, 2 deletions, one file.

## Observation bundle (the record of your harnessed loop)

- **C1 — `scripts/gates.mjs`, the two source scans.**
  **Ran:** reproduced the report on a poisoned tree before touching the fix (the hot loop — a shell exit
  code, seconds, no build). **Saw:** the reported red *plus a second error the report didn't mention* —
  `'agent-api' constructs a Postgres engine but is absent from db-budget.json`. **Concluded:** the report's
  claim that *"the same repo-wide grep pattern appears only in `_explicitPool()`"* is wrong;
  `_dbHoldingServices()` (`:905`) has the same defect — SQLAlchemy *defines* `create_async_engine`, and the
  path regex at `:910` reads the service name out of the **venv's own path**. Fixing only the reported scan
  would have left the gate poisoned. Both scans are in the diff.

- **C1 — instrument divergence, caught mid-bundle.**
  **Ran:** a "vacuity control" to confirm the real venvs actually carry the poison. **Saw:** my greps
  returned **empty** against a tree the gate was reding on — a contradiction, not a detail. **Concluded:**
  in this shell `grep` is a **function → ugrep 7.5.0**, which **skips hidden directories by default**, so it
  never entered `.venv/`; the gate's `execSync` runs under `/bin/sh`, where `grep` is `/usr/bin/grep`
  (**BSD grep 2.6.0-FreeBSD**), which descends. Two greps, same tree, opposite answers — and the convenient
  answer was the wrong one. Every count below is from the gate's actual instrument (`/usr/bin/grep`) or
  `git grep`. This is plausibly the same trap behind the report's misattribution.

- **C1 — the root cause is not what the report (or my first issue draft) said.**
  **Ran:** `/usr/bin/grep -rnoE` with filenames restored — the `-h` the gate uses strips them, which is why
  nobody could see the source. **Saw:**
  ```
  admin-api/.venv/…/sqlalchemy/testing/engines.py:390:  max_overflow = 0
  admin-api/.venv/…/sqlalchemy/engine/create.py:382:    max_overflow=10
  admin-api/.venv/…/sqlalchemy/engine/create.py:441:    pool_size=5
  transcription/.venv/…/numpy/random/tests/test_direct.py:137:  pool_size=6   ← the only one that reds
  ```
  **Concluded:** the gate errors on `explicit > declared`, so SQLAlchemy's own `5`/`10` — *exactly* the
  declared budget — **never red it**. The reported `pool_size=6` is a **numpy test fixture**, in the
  **transcription** service's venv, a service that holds no database at all. Issue body corrected + an
  auditable [correction comment](https://github.com/Vexa-ai/vexa/issues/702#issuecomment-5001901014) posted.
  This **strengthens** the fix: no hand-maintained `--exclude-dir` list would have anticipated numpy.

- **C1 — a co-cause, deliberately left alone.**
  **Ran:** traced why a file literally named `test_direct.py` survived `_explicitPool()`'s `| grep -v test`.
  **Saw:** the pipeline emits bare matches (`pool_size=6`) because of `-h` — there is no path for
  `grep -v test` to match. **Concluded:** the filter is **dead code** and a co-cause of the exact symptom.
  **Not in this diff:** making it live changes *which files count* toward a production budget — its own
  argument, not a rider on a PR whose thesis is "the gate reads the committed tree". Verified not firing
  (no tracked file carries a numeric pool literal; `test_db_pool.py` uses `pool_size=want_size`, a variable
  the regex misses). Latent trap, filed separately.

- **C1 — self-inflicted, reported.** My planted `.venv` paths collided with the **real** venvs from an
  earlier full run, clobbering two genuine `sqlalchemy/engine/create.py` files. Removed both venvs;
  `gate:python` rebuilt them (`✓ 12 package(s) · pytest green` in A5 run 1 confirms the repair). Gitignored
  artifacts, no tracked file touched — but it happened, so it's here.

## Acceptance floor

Base `85e12d1f` · head `50385418` · macOS 15 (Darwin 25.5.0), long-lived worktree, venvs as built by a real
`gate:python` run. Every row run locally; `gates` CI at head is the A- anchor.

*Anchor note:* rows were first run at `38613009`; the head was then amended to correct a **wrong claim in
the code comment itself** (it repeated the SQLAlchemy misattribution). The amend is comment-only — the
executable lines are byte-identical (`git show <sha>:scripts/gates.mjs | grep -vE '^\s*//' | shasum` →
`e78bdfb9…` at **both** shas). Rather than assert carry-over, the discriminating rows were **re-run** at
`50385418`: A5 red half `base_exit=1` (`pool_size=6`), green half `head_exit=0`, A3 `A3_exit=1`.

| Row | Evidence |
|---|---|
| **A1** | Planted gitignored `.venv` with `pool_size=99`/`max_overflow=99`. **Base RED** (`base_exit=1`): `admin-api: code sets pool_size=99 but db-budget declares 5 (under-count)` + the `max_overflow` twin + both for `meeting-api`. **Head GREEN** (`head_exit=0`) on the *same tree*: `✓ Σ 70/100 connections fits`. Control: `git check-ignore -v` → `.gitignore:4:.venv/` — the planted tree really is ignored. |
| **A2** | Same planted tree, `.venv` under `core/agent/services/agent-api/` defining `create_async_engine`. **Base RED:** `'agent-api' constructs a Postgres engine but is absent from db-budget.json`. **Head GREEN.** Honest scope: this row proves a **mechanism**, not a live failure — all 16 real site-packages `create_async_engine` hits sit under `admin-api/.venv/…` → resolve to `admin-api`, already declared → no phantom fires today. The latency is thin: `transcription/` already has a venv and is a service dir. |
| **A3** | Negative control for A1 — the gate still catches a **real** under-count. `pool_size=999` appended to tracked `core/identity/services/admin-api/src/admin_api/__init__.py` → **head RED** (`A3_exit=1`): `code sets pool_size=999 but db-budget declares 5`. Reverted. A1's green is not green-on-empty. |
| **A4** | `--untracked` proven. `pool_size=77` in a never-`git add`ed `core/identity/services/admin-api/tmp_probe_702.py` → **head RED** (`A4_exit=1`). Control: `git check-ignore` exits 1 (**not** ignored) and `git status --porcelain` shows `??` — without that the row proves nothing. Plain `git grep` would have left the pre-push gate blind to exactly the file being committed; this is why `--untracked` is not optional. Removed. |
| **A5** | **The reported sequence, real venvs, no planting.** Base against the real post-`gate:python` tree → **RED with the reporter's exact literal**: `admin-api: code sets pool_size=6 but db-budget declares 5 (under-count)` (`base_vs_real_venv_exit=1`). Head: `node scripts/gates.mjs all` **twice in a row** → both green (`run1_exit=0`, `run2_exit=0`), `✓ gate:db-budget` and `✓ gate:python — 12 package(s) · pytest green` in both. Vacuity control: the poison is confirmed still present in the tree the green runs saw (`numpy/random/tests/test_direct.py:137` → `pool_size=6`, `git check-ignore` → IGNORED). |
| **A-** | No-regression. Full suite at head: **all 31 gates green**, twice. db-budget's accounting output **unchanged**: `Σ 70/100 connections fits [admin-api 2×15=30, meeting-api 2×15=30, reserved 10]` — identical to base on a clean tree, i.e. the fix changes the gate's *input population*, never its arithmetic. `git grep --untracked -hoE '(pool_size|max_overflow) *= *[0-9]+' -- 'core/*.py'` → empty, confirming no committed pool literal exists and the green is correct rather than accidental. CI `gates` at head sha. |

## Docs diff (D6c)

**`docs: none`, argued.** The gate's *rule* does not move: same accounting
(`Σ (replicas × (pool_size + max_overflow)) + reserved ≤ max_connections`), same `deploy/db-budget.json`,
same arithmetic (A-). Only the **population it reads** is corrected from "every `.py` on disk" to "the
committed tree". The one docs surface naming the budget — `docs/docs/configuration.mdx:60-65`, the
`DB_POOL_SIZE`/`DB_MAX_OVERFLOW` note — describes that accounting and those defaults, all untouched.

**No changelog fragment:** per `docs/changelog.d/README.md`, repo-tooling with no user-visible effect takes
no line — a `:v012` user's deployment is unaffected (`scripts/**` is outside `pr-value.yml`'s path filter,
i.e. the repo already classifies this **non-runtime**). The durable note lands where it cannot rot: a
comment at the two scans naming the `.venv`/`site-packages` input class (P9 — *"a rule in a README rots"*).

## Security checks (required on the diff)

- **Dependency / licence (P17):** no dependency change — `package.json` and `pnpm-lock.yaml` untouched;
  `git grep` is a git builtin, not a new dep. `✓ gate:licenses — 460 deps OSS-clean` at head (unchanged).
- **Secrets:** no secret, token, or credential in the diff; nothing is logged that wasn't before. The gate's
  output strings are unchanged.
- **SAST / injection surface — the one thing worth a reviewer's eye:** both changed lines build a shell
  command string for `execSync`. **No interpolation was added or removed** — the pattern and pathspec are
  string literals, exactly as before; the only variable in scope (`service`) was unused before and remains
  unused. Attack surface is therefore identical to base. The pathspec is single-quoted (`'core/*.py'`) so
  the shell cannot expand it — git must receive the glob to apply its own `*`-crosses-`/` semantics.
- **Blast radius:** developer/CI tooling only. Cannot reach an image, chart, compose file, migration, or any
  runtime path.

## Validation request

**Desk check — ~2 minutes, zero humans beyond the validator, no meeting, no deployment** (D12: never more
humans than the observation requires; this observation is a shell exit code).

**Who:** any competent non-author with a checkout. **Noting honestly:** D9 requires a non-author, and the
reporter is the author here — so the reporter-preferred-signer convention **cannot** apply to this one; the
value signature must come from someone else. **Deployment validated (D12b):** none, argued above — the
setup that matters is a developer workstation, provenance stated at the top of the acceptance floor.

**What they'll watch:** plant a `.venv` under `core/` holding a `.py` with `pool_size=99`, run
`node scripts/gates.mjs db-budget` at base (red) and at head (green), then append `pool_size=999` to a
tracked `.py` and confirm head still reds. The last step is the one that matters — it distinguishes "the
gate was fixed" from "the gate was blinded".

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): written with Claude Code.
