### PR TITLE
fix(db-budget-gate): the pool scan counts production source — make the test filter express it (stacked on #703)

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -44,6 +44,12 @@ jobs:
       - run: pnpm gate:dataflow
       - run: pnpm gate:calm
       - run: pnpm gate:licenses
+      # Tests OF the gate scripts (the instruments the steps above trust). scripts/ is not a
+      # workspace package, so `pnpm test` — turbo run test — never reaches it: this step is the
+      # only lane these files run in. Kept here, beside the gates they cover, rather than in the
+      # node job, whose install/build cost buys them nothing.
+      - name: gate script tests
+        run: node --test scripts/*.test.mjs
 
   python:
     runs-on: ubuntu-latest

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -904,6 +904,22 @@ function gateDbSchema() {
 // not-yet-added ones, never gitignored paths. The .venv/site-packages trees gate:python materializes
 // under core/ match both patterns (numpy fixtures set pool_size=; sqlalchemy defines
 // create_async_engine) and must not enter the budget. --untracked keeps a brand-new .py in scope.
+//
+// Both scans count a service's PRODUCTION source only. A test's engine is a throwaway no deployment
+// runs: it holds zero production connections, so a pool literal in a test cannot under-state a budget
+// whose unit is Σ(helm replicas × pool ceiling), and counting one could only invent a red against a
+// service whose deployed pool is whatever its production source says. Excluding tests is therefore
+// the contract gateDbBudget() already states in its own error text ("no non-test source constructs a
+// DB engine there") — the two scans share one path test so they can never disagree on the population.
+//
+// A file is a test when it sits under a tests/ dir or its BASENAME starts with test_ — not merely
+// when "test_" occurs somewhere in the path, which would drop production files (latest_pool.py) out
+// of a production budget: the one direction this gate must never fail. pytest's other convention,
+// the *_test.py suffix, is deliberately NOT a rule: core/agent/control_plane/config_test.py is
+// production source (it implements the Settings → Models "Test" buttons), and excluding it would
+// under-count for real. Filename heuristics have counterexamples in this tree; both are checked.
+const _isTestPath = (p) => /(^|\/)tests?\//.test(p) || /(^|\/)test_[^/]*$/.test(p);
+
 function _dbHoldingServices() {
   let out;
   try {
@@ -911,26 +927,36 @@ function _dbHoldingServices() {
   } catch { return new Set(); }  // grep exit 1 = no matches
   const svcs = new Set();
   for (const path of out.split("\n")) {
-    if (!path || /(^|\/)tests?\//.test(path) || path.includes("test_")) continue;
+    if (!path || _isTestPath(path)) continue;
     const m = path.match(/\/services\/([^/]+)\//);
     if (m) svcs.add(m[1]);
   }
   return svcs;
 }
 
-function _explicitPool(service) {
-  // the largest explicit pool_size= / max_overflow= a service's code sets, or {} when it relies on
-  // the framework default (the "silent default" the issue names). Used to reject an under-stated budget.
+function _explicitPool() {
+  // the largest explicit pool_size= / max_overflow= a service's production code sets and where, or {}
+  // when every service relies on the framework default (the "silent default" #529 names). Used to
+  // reject an under-stated budget. `-n -o`, never `-h`: the path has to survive the scan both to be
+  // filtered on and to name the file in the error — a bare number is a verdict nobody can trace back
+  // to a line. `-o` also splits two literals on one source line (pool_size=…, max_overflow=…) into
+  // two records, so neither hides behind the other.
   let out = "";
   try {
-    out = execSync(`git grep --untracked -hoE '(pool_size|max_overflow) *= *[0-9]+' -- 'core/*.py' 2>/dev/null | grep -v test || true`, { cwd: ROOT }).toString();
+    out = execSync(`git grep --untracked -noE '(pool_size|max_overflow) *= *[0-9]+' -- 'core/*.py' 2>/dev/null || true`, { cwd: ROOT }).toString();
   } catch { out = ""; }
   const found = {};
   for (const line of out.split("\n")) {
-    const m = line.match(/(pool_size|max_overflow)\s*=\s*(\d+)/);
-    if (m) found[m[1]] = Math.max(found[m[1]] || 0, parseInt(m[2], 10));
+    // anchored to git grep's whole `path:lineno:match` record: -o makes the match the entire final
+    // field, so a path that happens to spell "pool_size=5" can never be parsed as the literal.
+    const m = line.match(/^(.+?):(\d+):(pool_size|max_overflow) *= *(\d+)$/);
+    if (!m) continue;
+    const [, path, lineno, key, val] = m;
+    if (_isTestPath(path)) continue;
+    const value = parseInt(val, 10);
+    if (!found[key] || value > found[key].value) found[key] = { value, where: `${path}:${lineno}` };
   }
-  return found;  // note: repo-wide (explicit overrides are rare); a match anywhere raises the floor
+  return found;  // repo-wide (explicit overrides are rare); a match anywhere raises the floor
 }
 
 function _helmReplicas(key) {
@@ -966,10 +992,10 @@ function gateDbBudget() {
   for (const [svc, cfg] of Object.entries(budget.services || {})) {
     const replicas = _helmReplicas(cfg.helm_key);
     if (replicas === null) { errs.push(`${svc}: could not read replicaCount for helm key '${cfg.helm_key}' in values.yaml`); continue; }
-    if (explicit.pool_size && explicit.pool_size > cfg.pool_size)
-      errs.push(`${svc}: code sets pool_size=${explicit.pool_size} but db-budget declares ${cfg.pool_size} (under-count)`);
-    if (explicit.max_overflow && explicit.max_overflow > cfg.max_overflow)
-      errs.push(`${svc}: code sets max_overflow=${explicit.max_overflow} but db-budget declares ${cfg.max_overflow} (under-count)`);
+    if (explicit.pool_size && explicit.pool_size.value > cfg.pool_size)
+      errs.push(`${svc}: code sets pool_size=${explicit.pool_size.value} (${explicit.pool_size.where}) but db-budget declares ${cfg.pool_size} (under-count)`);
+    if (explicit.max_overflow && explicit.max_overflow.value > cfg.max_overflow)
+      errs.push(`${svc}: code sets max_overflow=${explicit.max_overflow.value} (${explicit.max_overflow.where}) but db-budget declares ${cfg.max_overflow} (under-count)`);
     const ceiling = Number(cfg.pool_size || 0) + Number(cfg.max_overflow || 0);
     const conns = replicas * ceiling;
     total += conns;

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -1,0 +1,116 @@
+// Regression tests for gate:db-budget's two source scans in gates.mjs (#529, #702).
+// Run: node --test scripts/gates.test.mjs   (CI: the gates.yml `static` job runs scripts/*.test.mjs
+// directly — scripts/ is not a workspace package, so `pnpm test` never reaches these files)
+//
+// These plant real files in the checkout and run the real gate as a subprocess, deliberately: the
+// defect class here lives in the SHELL PIPELINE, not the parse. A scan that strips the filename
+// (`grep -h`) silently disarms every path-based filter downstream of it, and the bare numbers it
+// emits still parse perfectly — so a test that stubs the grep and feeds the parse a fixture would
+// stay green through exactly the bug it was written to catch. The planted file IS the input
+// population: `git grep --untracked` reads the working tree, so a file on disk is a real input.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// admin-api is declared in deploy/db-budget.json (pool_size 5 / max_overflow 10), so a literal
+// planted here is compared against a real ceiling. agent-api is a real service dir that is NOT
+// declared — a create_async_engine there is what a phantom-service error would be read from.
+const TEST_FILE = "core/identity/services/admin-api/tests/test_zz_planted_pool.py";
+const PROD_FILE = "core/identity/services/admin-api/src/admin_api/zz_planted_pool.py";
+const PHANTOM_TEST_FILE = "core/agent/services/agent-api/tests/test_zz_planted_engine.py";
+
+// two literals on ONE line, both far above every declared ceiling: if either is counted the gate
+// must red, and the pair also pins that neither hides behind the other.
+const POOL_LITERALS = "configure(url, pool_size=20, max_overflow=30)\n";
+
+// Plants a file, runs fn, and removes EVERYTHING it created — including any directory it had to
+// make. An empty leftover dir is invisible to `git status` (git tracks files) but very visible to
+// gate:readme, which reads the filesystem: a fixture that leaks one reds a sibling gate later, in
+// another run, with no trace of who dropped it. So remember the topmost ancestor that did not
+// already exist and prune from there.
+function withPlanted(relPath, body, fn) {
+  const abs = join(ROOT, relPath);
+  const dir = dirname(abs);
+  let prune = null;
+  for (let d = dir; !existsSync(d); d = dirname(d)) prune = d;
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(abs, body);
+  try {
+    return fn();
+  } finally {
+    rmSync(abs, { force: true });
+    if (prune) rmSync(prune, { recursive: true, force: true });
+  }
+}
+
+function runDbBudget() {
+  try {
+    return { green: true, out: execFileSync("node", ["scripts/gates.mjs", "db-budget"], { cwd: ROOT, encoding: "utf8" }) };
+  } catch (e) {
+    return { green: false, out: `${e.stdout || ""}${e.stderr || ""}` };
+  }
+}
+
+const rx = (s) => new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+
+// ── the population: production source counts, tests do not ──────────────────────────────────────
+
+test("vacuity control: the committed tree is green (a red here invalidates every row below)", () => {
+  const r = runDbBudget();
+  assert.equal(r.green, true, `the clean tree already reds — these fixtures prove nothing:\n${r.out}`);
+});
+
+test("a pool literal in a test file does NOT red the budget (a test holds no production connections)", () => {
+  const r = withPlanted(TEST_FILE, POOL_LITERALS, runDbBudget);
+  assert.equal(r.green, true, `a literal in ${TEST_FILE} red the connection budget:\n${r.out}`);
+});
+
+test("negative control: the SAME literal in production source DOES red the budget", () => {
+  const r = withPlanted(PROD_FILE, POOL_LITERALS, runDbBudget);
+  assert.equal(r.green, false, "the gate no longer catches an under-stated budget — the scan is inert");
+  assert.match(r.out, /pool_size=20/);
+  assert.match(r.out, /max_overflow=30/); // -o keeps the second literal on the line its own record
+});
+
+test("the under-count error names the file:line it read the literal from, not just a number", () => {
+  const r = withPlanted(PROD_FILE, POOL_LITERALS, runDbBudget);
+  assert.match(r.out, rx(`${PROD_FILE}:1`));
+});
+
+test("a path that spells a literal is not parsed as one (the match is the record's final field)", () => {
+  // The file must CONTAIN a real literal or git grep emits no record for it at all and the parse is
+  // never reached — the fixture has to produce `…/pool_size=99_zz.py:1:pool_size=3`. pool_size=3 is
+  // UNDER the declared 5, so this can only red if the parse reads the 99 out of the path.
+  const weird = "core/identity/services/admin-api/src/admin_api/pool_size=99_zz.py";
+  const r = withPlanted(weird, "configure(url, pool_size=3)\n", runDbBudget);
+  assert.equal(r.green, true, `the "99" in the path was parsed as a declared pool:\n${r.out}`);
+});
+
+// ── the population's edges: filename heuristics have counterexamples in this tree ───────────────
+
+test("a production file whose path merely CONTAINS test_ is still counted (latest_pool.py)", () => {
+  const prod = "core/identity/services/admin-api/src/admin_api/latest_pool_zz.py";
+  const r = withPlanted(prod, POOL_LITERALS, runDbBudget);
+  assert.equal(r.green, false, `"latest_pool_zz.py" was read as a test — a production pool literal
+    dropped out of the production budget, the one direction this gate must not fail:\n${r.out}`);
+});
+
+test("a production file using the *_test.py suffix is still counted (config_test.py's shape)", () => {
+  const prod = "core/identity/services/admin-api/src/admin_api/zz_config_test.py";
+  const r = withPlanted(prod, POOL_LITERALS, runDbBudget);
+  assert.equal(r.green, false, `"zz_config_test.py" was read as a test, but core/agent/control_plane/
+    config_test.py proves that suffix names production source in this tree:\n${r.out}`);
+});
+
+// ── the sibling scan reads the same population (shared _isTestPath) ─────────────────────────────
+
+test("a test-only create_async_engine does not invent a service in the budget", () => {
+  const r = withPlanted(PHANTOM_TEST_FILE, "engine = create_async_engine(FAKE_URL)\n", runDbBudget);
+  assert.equal(r.green, true, `a test fixture phantomed agent-api into the connection budget:\n${r.out}`);
+});


### PR DESCRIPTION
> **Stacked on #703** — base branch is `claude/quizzical-goldstine-9f853f` @ `50385418`, not `main`.
> #703 rewrites the same two lines; this is written on top of it and **must merge after it**
> (retarget to `main` once #703 lands). Sequenced rather than raced, per AGENTS.md: *"flag it on the
> issues and sequence the PRs (land one, rebase the other)."* The diff below is **this PR's own**
> (`50385418..75ef5665`); #703's commit is inherited, not re-proposed.
>
> **No issue number.** #702's correction comment says this was *"Filed separately"* — it never was
> (no such issue exists). Grounding is #702's body + its correction comment; happy to file one if
> the record wants a number.

## Value this PR delivers

> A contributor may write `configure(url, pool_size=20, max_overflow=30)` in a test without the
> connection budget reding their push. `gate:db-budget`'s verdict becomes a function of a service's
> **production** source — the only source that holds production connections — and when it does red,
> it names the `file:line` it read the literal from instead of asserting a bare number against a
> service that may set nothing.

## Where we are (honest)

`_explicitPool()` ends `… | grep -v test`, downstream of a `-h` scan. `-h` (with `-o`) strips the
filename, so the pipeline emits bare matches and `grep -v test` is matching "test" against text that
carries no path. It removes nothing. Reproduced on **this PR's base** (#703 @ `50385418`), planting
one file inside `tests/`:

```console
$ cat core/identity/services/admin-api/tests/_probe_test_fixture.py
configure(url, pool_size=20, max_overflow=30)
weird = "pool_size=99"

$ git grep --untracked -hoE '(pool_size|max_overflow) *= *[0-9]+' -- 'core/*.py' | grep -v test
pool_size=20
max_overflow=30
pool_size=99
```

All three survive `grep -v test`, from a file named `_probe_test_fixture.py` inside a `tests/` dir.
Fed to the gate, that is a false red naming a service that sets nothing:

```console
$ node scripts/gates.mjs db-budget          # base @ 50385418, literal planted in an admin-api TEST
  ✗ meeting-api: code sets pool_size=20 but db-budget declares 5 (under-count)
  ✗ meeting-api: code sets max_overflow=30 but db-budget declares 10 (under-count)
❌ gates failed
```

It does not fire on the committed tree today: `git grep --untracked -noE '(pool_size|max_overflow) *= *[0-9]+' -- 'core/*.py'`
is **empty** — no tracked file carries a numeric pool literal at all, in tests or in production
(#635 moved both services to `DB_POOL_SIZE`/`DB_MAX_OVERFLOW` env knobs). The exposure is latent, and
`tests/test_db_pool.py` is *already paying for it*: it routes its kwargs through variables
specifically to dodge this grep, and says so in a comment —

```python
# NB: pass the sizes via variables (not integer-literal kwargs) so the db-budget gate's repo-wide
# explicit-pool grep doesn't read a test's kwargs as a service's declared pool ceiling.
want_size, want_over = 7, 3
```

The gate's bug is bending tests around it today. That is a cost, not a hypothetical.

## The decision: tests are excluded

The budget's unit is Σ(helm replicas × pool ceiling) against `max_connections` — a **production**
connection count. A test's engine is a throwaway no deployment runs: it holds zero production
connections, so a pool literal in a test cannot under-state the budget, and counting one could only
invent a red against a service whose deployed pool is whatever its production source says.

This is not a new contract — it is the one `gateDbBudget()` already states in its own error text
(*"no non-test source constructs a DB engine there"*) and the population `_dbHoldingServices()`
already reads. Both scans now share one `_isTestPath`, so they cannot drift apart on what
"a service's code" means.

**Mechanism.** `-no`, never `-h`: the path has to survive the scan to be filtered on. The parse is
anchored to git grep's whole `path:lineno:match` record — `-o` makes the match the entire final
field, so a path spelling `pool_size=99` can never be read as the literal (the old first-match regex
reads the 99 and reds; row A4). `-o` is kept because it splits two literals on one source line into
two records; without it the second hides behind the first (row A2).

### The path test has counterexamples in this tree, in both directions

The sibling's `p.includes("test_")` was the obvious thing to reuse. It is wrong twice over, and this
tree proves both:

| Shape | `includes("test_")` | shipped rule | why it matters |
|---|---|---|---|
| `latest_pool.py` | **EXCLUDED** | counted | drops **production** source out of a production budget — the one direction this gate must never fail |
| `core/agent/control_plane/config_test.py` | counted | counted | pytest's `*_test.py` suffix is **not** a rule here: this file is production source (it implements the Settings → Models "Test" buttons) |

Shipped rule: under a `tests/` dir, **or** basename starts with `test_`. It **reclassifies 0 of 348**
tracked `core/**/*.py` files — it closes a hole rather than moving the line. Both counterexamples are
pinned by tests (A5, A6), because "simplifying" this back to a substring check is the obvious future
mistake.

## The observation bundle

No prepared issue exists, so the numbering is this PR's own. Anchors: base `50385418`, head
`75ef5665`, macOS 15 (Darwin 25.5.0), git 2.50.1, node 24.13.0 (CI: node 22). Every planted fixture
is created and removed by the test itself; the tree is left clean.

| # | Observation | Expected | Actual | Verdict |
|---|---|---|---|---|
| **A-** | vacuity control: clean committed tree | green | `✓ gate:db-budget — Σ 70/100 connections fits [admin-api 2×15=30, meeting-api 2×15=30, reserved 10]` | ✅ |
| **A1** | `pool_size=20, max_overflow=30` in a **test** file | green (was red) | green | ✅ |
| **A2** | the **same literal** in **production** source | **red**, naming both literals | red; `pool_size=20` **and** `max_overflow=30` both reported | ✅ |
| **A3** | the under-count error names its source | `file:line` present | `admin-api: code sets pool_size=20 (core/identity/services/admin-api/src/admin_api/zz_planted_pool.py:1) but db-budget declares 5` | ✅ |
| **A4** | record `…/pool_size=99_zz.py:1:pool_size=3` | reads **3**, green | reads 3 (old first-match regex reads **99** → false red) | ✅ |
| **A5** | `latest_pool_zz.py` (production, contains `test_`) | **red** — still counted | red | ✅ |
| **A6** | `zz_config_test.py` (production, `*_test.py`) | **red** — still counted | red | ✅ |
| **A7** | test-only `create_async_engine` under non-budget `agent-api` | green — no phantom | green | ✅ |
| **A8** | **composes with #703**: db-budget with 11 `.venv` trees + #702's actual numpy fixture on disk | green | green — `core/meetings/services/transcription/.venv/…/numpy/random/tests/test_direct.py` present, gate green | ✅ |
| **A9** | live witness: `node scripts/gates.mjs all` (the pre-push bar) | green | `✅ gates green` | ✅ |
| **A10** | the CI leg on **node 22** (this PR's own run) | `static` green, the new step runs | `static` ✅ 50s — step 19 *"gate script tests"* success, `# tests 19 / # pass 19 / # fail 0`; `gates` (the required check) ✅; `python` ✅; `node` ✅ | ✅ |
| **A11** | classification: `pr-value` must **not** fire on a non-runtime diff | not triggered | not triggered — `docs-current` ✅ (exempt, no surface touched) | ✅ |

**Discrimination — stated honestly.** Run against the unfixed scan (`git stash` the `gates.mjs`
hunk, same 8 test rows), **2 fail and 6 pass**:

- **Discriminating** (fail on base, pass on head): **A1**, **A3** — the fix's thesis.
- **Controls/guards** (pass on both, by design): **A-** (vacuity), **A2** (the gate must still bite —
  it *should* pass on both), **A4**/**A5**/**A6** (guards on the *new* design: the base's
  `_explicitPool` never consults a path at all, so these can only regress forward), **A7** (guards
  the shared-`_isTestPath` refactor of the sibling scan).

A4–A6 encode three near-misses hit while building this: the naive first-match parse on `-n` output,
the `latest_pool.py` hole, and the `*_test.py` trap.

## Why the test plants real files and shells out

The defect class here lives in the **shell pipeline**, not the parse: the bare numbers a `-h` scan
emits parse *perfectly*, so a test that stubs the grep and feeds the parse a fixture would stay green
through exactly the bug it was written to catch. The planted file **is** the input population —
`git grep --untracked` reads the working tree, so a file on disk is a real input. This is #702's own
planted-tree methodology (its A2 row), kept.

`withPlanted` prunes the topmost directory it creates. An empty leftover dir is invisible to
`git status` (git tracks files, not directories) but very visible to `gate:readme` — a leaking
fixture reds a **sibling gate**, in a later run, with no trace of who dropped it. This is not
theoretical: it happened while building this PR and cost a misdiagnosis.

## Wiring — and a gap it closes

`scripts/` is not a workspace package (`pnpm-workspace.yaml`), so `pnpm test` (`turbo run test`)
never reaches `scripts/*.test.mjs`. #702 named this: *"the one existing `scripts/*.test.mjs`
(`merge-card-gate.test.mjs`) is wired to no lane."* An unwired regression check is decoration, so the
`static` job now runs them, beside the gates they cover. `merge-card-gate.test.mjs` (11 passing tests,
in no lane at all until now) runs too — 19 tests total.

Deliberately **not** a `package.json` script: `package.json` is in `pr-value.yml`'s path filter and
`docs-current`'s `SURFACE_FILES`, so a `test:scripts` entry would drag a pure tooling change into a
full compose-stack value run. `.github/**` is not a surface, so this PR stays in the same
**non-runtime** class #702 argued for `scripts/**`.

## Deployments to validate (D12b)

**None**, on #702's argument unchanged: this touches no image, chart, compose file, migration, or
runtime path, and `scripts/**` + `.github/**` are outside `pr-value.yml`'s path filter — the repo
already classifies this diff non-runtime. The setup that matters is a developer workstation; A8's
provenance is stated above (11 `.venv` trees materialized by a real `gate:python` run on this
machine, not planted).

## Docs surface

None. `docs-current` exempts this PR (no `SURFACE_PREFIXES` path touched). No changelog fragment, per
the precedent of the two comparable tooling fixes: #703 (`scripts/gates.mjs` only) and `40694c6c`
(`deploy/helm/tests/test_template.sh` only) both shipped without one. Say the word if you want one.

## What I did NOT check

- **`_dbHoldingServices()`'s repo-wide phantom half is untouched** — still #702's A2 mechanism, still
  latent. A7 only pins that my shared-`_isTestPath` refactor did not regress it.
- **The "match anywhere raises the floor" coarseness is untouched.** A3 makes it *legible* (the error
  now shows a `meeting-api` verdict citing an `admin-api` file) but does not fix it. Whether the scan
  should be per-service is a separate argument.
- **I did not audit whether any third-party consumer parses `gate:db-budget`'s error string.** A3
  changes its shape.
- **`merge-card` is ❌ by design, not by defect** — it reports `missing state: value-signed`, the
  non-author value sign-off this PR is waiting on (Diff is already ✅). A9/A10 are *my own* witness;
  they are the bundle's first row, not its last.

## Findings filed alongside (not fixed here)

1. **`tests/test_db_pool.py`'s workaround comment becomes false when this lands** — it documents
   dodging a grep that now excludes tests deliberately. Kept out of this diff because `core/**`
   triggers `pr-value`'s full compose-stack run for a comment cleanup; sequenced separately.
2. **`docs/docs/governance/arch-compliance.mdx` is stale on `main`** — committed "299 dirs each carry
   a README" vs a live `307`; also 17→18 bricks, 13→14 packages, 81→82 nodes. `gateArchReport()` only
   runs `arch-report.mjs --check`, which asserts no gate is RED — never that the generated page still
   matches the tree, so the published law drifts silently. Verified not a local artifact: **0** of the
   dirs `walkDirs` visits lack a tracked file. Reverted from this branch, filed separately.

## Authorship

Mine, in full (D13) — no co-author trailers.
