### PR TITLE
test(admin-api): inline the pool literals — the budget gate excludes tests by contract (#702)

### DIFF
--- a/core/identity/services/admin-api/tests/test_db_pool.py
+++ b/core/identity/services/admin-api/tests/test_db_pool.py
@@ -16,13 +16,10 @@ FAKE_URL = "postgresql+asyncpg://u:p@localhost:5432/vexa"
 
 
 def test_configure_applies_pool_size_and_max_overflow():
-    # NB: pass the sizes via variables (not integer-literal kwargs) so the db-budget gate's repo-wide
-    # explicit-pool grep doesn't read a test's kwargs as a service's declared pool ceiling.
-    want_size, want_over = 7, 3
-    app_db.configure(FAKE_URL, pool_size=want_size, max_overflow=want_over)
+    app_db.configure(FAKE_URL, pool_size=7, max_overflow=3)
     engine = app_db.get_engine()
-    assert engine.pool.size() == want_size
-    assert engine.pool._max_overflow == want_over
+    assert engine.pool.size() == 7
+    assert engine.pool._max_overflow == 3
 
 
 def test_configure_defaults_to_framework_pool_when_unset():


### PR DESCRIPTION
## What

`test_configure_applies_pool_size_and_max_overflow` routed its kwargs through `want_size`/`want_over`
variables purely to dodge the db-budget gate's repo-wide pool scan, and carried an NB comment saying so:

```python
# NB: pass the sizes via variables (not integer-literal kwargs) so the db-budget gate's repo-wide
# explicit-pool grep doesn't read a test's kwargs as a service's declared pool ceiling.
want_size, want_over = 7, 3
```

75ef5665 makes excluding tests the gate's **stated contract** (`_isTestPath`: a `tests/` dir, or a
`test_` basename). The dodge has no premise left, and its comment now describes a gate that no longer
exists — which AGENTS.md forbids: *"Source states the designed present, not its history."*

This inlines the literals and deletes the comment. Three lines. The kwargs are also the thing under
test, so the indirection was costing the test's directness for the benefit of a grep.

## ⚠️ Stacking — read before merging

```
#703       claude/quizzical-goldstine-9f853f  → main                          OPEN
follow-up  claude/vigilant-knuth-7b9a2c       → (no PR yet — needs one)       PUSHED
this PR    claude/nifty-merkle-0ae685         → claude/vigilant-knuth-7b9a2c
```

**On main today this commit reds `gate:db-budget`** — verified, see row 2 below. It is only mergeable
behind the #702 pair. The follow-up branch still needs its own PR opened; this PR is based on it so the
diff above is my three lines and not a duplicate of the gate fix.

## Observation bundle

Measured with a `.venv` present under `core/` (the #702 shape) unless noted. `deploy/db-budget.json`
declares admin-api `pool_size: 5`; the test asks for 7 — so 7 > 5 is the discriminating literal
(`max_overflow=3` is under the declared 10 and never reds).

| # | Setup | Expected | Actual | ✓ |
|---|---|---|---|---|
| 1 | Baseline: variables workaround, pre-#702 gate | green | `✓ Σ 70/100` | ✓ |
| 2 | **Literals, pre-#702 gate** (control — is the workaround load-bearing?) | **RED** | `✗ admin-api: code sets pool_size=7 but db-budget declares 5 (under-count)` + same vs **meeting-api, which sets nothing** — the repo-wide attribution the NB comment was written against | ✓ |
| 3 | **Literals, #702 gate** (the point of this PR) | **green** | `✓ gate:db-budget — Σ 70/100 connections fits [admin-api 2×15=30, meeting-api 2×15=30, reserved 10]` | ✓ |
| 4 | `pytest tests/test_db_pool.py` | 3 pass | `3 passed` — assertions pin 7/3 directly | ✓ |
| 5 | `node --test scripts/gates.test.mjs` (gate keeps its teeth) | 8/8 | `tests 8 · pass 8 · fail 0`, incl. *"negative control: the SAME literal in production source DOES red the budget"* | ✓ |
| 6 | `node scripts/gates.mjs all` | green | all 27 gates green (incl. `gate:python`, real `gate:compose`) | ✓ |

Rows 2→3 are the red→green pair: same three lines of Python, gate fix the only variable.

**Not checked:** no live/deployed leg — this is a test-only diff with no runtime surface; `configure()`
itself is unchanged. Row 3 was also reproduced with no venv present (same green).

## This file is now a live fixture

`gates.test.mjs` proves the "a pool literal in a test file does NOT red the budget" row against a
*planted* temp file. This leaves a **real** test literal in the committed tree, so a regression that
re-widens the scan reds `db-budget` on every run, not only under the planted fixture.

## Docs

`docs: none` — test-only, no user-visible effect. Per [`docs/changelog.d/README.md`](docs/changelog.d/README.md):
*"test-only changes with no user-visible effect don't add a changelog line."* The label is required
because `docs-current`'s `SURFACE_PREFIXES` matches `core/` by raw prefix, with no test carve-out.

## CI cost

Touches `core/**`, which is in `pr-value.yml`'s path filter → this triggers the full compose-stack
`value-fsm` run. Deliberately kept out of the gate-fix diff for exactly that reason.
