### PR TITLE
release: v0.12.10 version-bump — fragments assembled, credits, docs-reflects advanced

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.9"
+appVersion: "0.12.10"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/docs/changelog.d/614-webhook-retry-durable.md
+++ b/docs/changelog.d/614-webhook-retry-durable.md
@@ -1,1 +1,0 @@
-- **Webhooks: crash-safe retry drain (#520).** The retry drain now uses a Redis reliable-queue, so failed webhook deliveries survive a storage outage and are still delivered after recovery instead of being lost.

--- a/docs/changelog.d/619-silence-hallucinations.md
+++ b/docs/changelog.d/619-silence-hallucinations.md
@@ -1,1 +1,0 @@
-- **Google Meet: stop silence hallucinations (#617).** Added ja/tr phrase lists plus a near-silent submit gate, so near-silent audio windows are no longer sent to Whisper — killing the phantom phrases Whisper emits for near-silence.

--- a/docs/changelog.d/623-hallucination-harvester.md
+++ b/docs/changelog.d/623-hallucination-harvester.md
@@ -1,1 +1,0 @@
-- **Google Meet: empirical hallucination harvester (#617 follow-up).** A single script that harvests hallucination phrase-lists empirically across every Whisper language — groundwork for the broader silence-hallucination work (#622).

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -3,10 +3,10 @@ title: "Changelog & migration"
 description: "Release notes and what changes between major versions."
 ---
 
-{/* docs-reflects: 0.12.9 — the released version these docs describe. CI (gate:docs-version) keeps
+{/* docs-reflects: 0.12.10 — the released version these docs describe. CI (gate:docs-version) keeps
     this equal to Chart.yaml appVersion; the release version-bump updates it. */}
 
-> 📌 **These docs reflect Vexa `v0.12.9`** — the latest released control-plane. Older self-hosts
+> 📌 **These docs reflect Vexa `v0.12.10`** — the latest released control-plane. Older self-hosts
 > should read against their pinned version.
 
 The authoritative, per-release changelog is on **GitHub Releases**:
@@ -155,6 +155,16 @@ probe), not inferred from planning docs.
 - **Lite: terminal transcription env wired (#628).** In `deploy/lite`, the `[program:terminal]`
   worker now receives the STT and internal-secret environment it needs, so speech-to-text works in
   the single-container lite deploy. See [Deployment](/deployment).
+
+- **Webhooks: crash-safe retry drain (#520).** The retry drain now uses a Redis reliable-queue, so failed webhook deliveries survive a storage outage and are still delivered after recovery instead of being lost.
+
+- **Google Meet: stop silence hallucinations (#617).** Added ja/tr phrase lists plus a near-silent submit gate, so near-silent audio windows are no longer sent to Whisper — killing the phantom phrases Whisper emits for near-silence.
+
+- **Google Meet: empirical hallucination harvester (#617 follow-up).** A single script that harvests hallucination phrase-lists empirically across every Whisper language — groundwork for the broader silence-hallucination work (#622).
+- **Credits (v0.12.10).** @waqaskhan137 — the orphan-process-group diagnosis (#486) and the
+  transcription-model findings whose regression rows now live in #522/#525; @m-tauqueer — driving
+  the leave-when-alone value (#270) whose spec is now #545. Superseded PRs are credited on their
+  threads; findings are contributions.
 
 ## Versioning
 


### PR DESCRIPTION
Version-bump for the v0.12.10 cut per the two-phase release flow (releases/README.md §0):

- `deploy/helm/charts/vexa/Chart.yaml` appVersion 0.12.9 → 0.12.10
- `docs/docs/changelog.mdx` docs-reflects stamp + visible line advanced; three fragments assembled into **## 0.12.x maintenance fixes** (#520 durable webhook retry · #617 silence-hallucination gate · harvester); `docs/changelog.d/` emptied
- **Credits (v0.12.10)** section added — @waqaskhan137 (#486 diagnosis; #522/#525 regression rows), @m-tauqueer (#270 → #545)

Batch since v0.12.9: #703 (#702 db-budget gate), #619 (#617), #623, #614 (#520), #615 (SBOM + bake VERIFY). After this lands: tag `v0.12.10` → publish+validate (promote:false) → witness pass → human-gated promote dispatch.

Non-runtime PR (helm chart metadata + docs); `docs-current` rides the changelog.mdx touch; gate:docs-version green locally.