### PR TITLE
release: package.json 0.12.10 — the third preflight version stamp (+README §0 names it)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",

--- a/releases/README.md
+++ b/releases/README.md
@@ -10,10 +10,11 @@ required-reviewer approval — a committed file cannot forge a human approval, s
 Publish and promote are **separate acts**; neither the moving tag `:v012` nor a published GitHub
 Release happens before the witness pass is signed.
 
-0. **Version-bump (before you tag)** — advance `appVersion` in
-   `deploy/helm/charts/vexa/Chart.yaml`, advance the matching `docs-reflects:` stamp (and the visible
-   line) in `docs/docs/changelog.mdx` so `gate:docs-version` stays green, and **assemble the changelog
-   fragments** that PRs dropped since the last release (the towncrier pattern —
+0. **Version-bump (before you tag)** — advance **all three version stamps** `release-images`
+   preflight cross-checks: `version` in the root `package.json`, `appVersion` in
+   `deploy/helm/charts/vexa/Chart.yaml`, and the matching `docs-reflects:` stamp (and the visible
+   line) in `docs/docs/changelog.mdx` so `gate:docs-version` stays green. Then **assemble the
+   changelog fragments** that PRs dropped since the last release (the towncrier pattern —
    [`docs/changelog.d/`](../docs/changelog.d/README.md)):
 
    ```bash


### PR DESCRIPTION
The v0.12.10 tag run failed preflight: `tag v0.12.10 vs package.json version 0.12.9`. release-images preflight cross-checks THREE stamps (tag · Chart.yaml appVersion · root package.json version); #707 advanced two because releases/README.md §0 only named two — the checklist lied by omission.

- root `package.json` version → 0.12.10
- releases/README.md §0 now names all three stamps (fix at the point of introduction — the checklist, not just the instance)

Dead tag deleted (preflight failed before any publish). After this lands: re-tag `v0.12.10` on the new head.