### PR TITLE
governance(D-L4): the witness walks a DELIVERED deployment — enforced at the receipt

### DIFF
--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -308,9 +308,12 @@ asked to admit a bot and handed a dead tunnel, a stale session, or a cold-start 
 oracle spent on the agent's un-run homework. · *Source:* the human is the scarce oracle (D9); the
 [two choke points](#the-two-choke-points) already name the two moments — D-L4 adds the rehearsal
 obligation. · *Evidence:* ~8 owner round-trips in v0.12.9 on dead tunnels, stale browser sessions,
-and a cold whisper model — a demo path the agent had not rehearsed. · *Gate:* #690 (the
-agent-runnable probe *is* the rehearsal) + [choke point 2](#the-two-choke-points).
-**have** (choke point 2 named) / **[TO BUILD: #690 rehearsal probe]**
+and a cold whisper model — a demo path the agent had not rehearsed. · *Gate:* the witness receipt
+structurally requires the **delivered deployment record** (`witness_deployment: {url,
+provisioned_by, prevalidated[]}` — `release-witness-gate` refuses a receipt without it: the human
+receives a running URL, never a setup recipe) + #690 (the agent-runnable probe *is* the rehearsal)
++ [choke point 2](#the-two-choke-points).
+**have** (receipt-level delivered-deployment gate; choke point 2 named) / **[TO BUILD: #690 rehearsal probe]**
 
 ## 8. Proof — PRs and validation
 

--- a/releases/README.md
+++ b/releases/README.md
@@ -31,10 +31,14 @@ Release happens before the witness pass is signed.
    `:vX.Y.Z` images and runs `release-validate` with **`promote: false`** — the L4 legs prove the
    published bytes, but `:v012` does **not** move. The release candidate now exists to be witnessed.
 
-2. **Witness** — on a fresh self-host of the **published** `:vX.Y.Z` images, admit a bot to a real
-   meeting, walk every user-visible batch value once, and record what you saw. **Generate the
-   witness script FROM THE BATCH** — it lists every PR so no value is missed — then resolve each
-   entry and commit to `main`:
+2. **Witness** — the human walks a **DELIVERED deployment** (D-L4): the agent provisions a fresh
+   self-host of the **published** `:vX.Y.Z` images, pre-validates it autonomously (health, UI,
+   auth path, STT readiness), and hands the human a **running UI URL — never a setup recipe**.
+   The delivered deployment is recorded in the receipt (`witness_deployment: {url,
+   provisioned_by, prevalidated[]}`) and the witness gate refuses a receipt without it. The human
+   then admits a bot to a real meeting, walks every user-visible batch value once, and records
+   what they saw. **Generate the witness script FROM THE BATCH** — it lists every PR so no value
+   is missed — then resolve each entry and commit to `main`:
 
    ```bash
    mkdir -p releases/vX.Y.Z
@@ -91,6 +95,8 @@ Release happens before the witness pass is signed.
   "witnessed_by": "who ran the pass",
   "witnessed_at": "YYYY-MM-DD",
   "deployment": "compose | lite | helm",
+  "witness_deployment": { "url": "http://<host>:3000", "provisioned_by": "agent (throwaway VM <id>)",
+    "prevalidated": ["gateway /health 200", "terminal UI 200", "debug login ok", "STT ready"] },
   "values": [
     { "pr": "599", "title": "MS Teams self-evict fix", "visibility": "user-visible",
       "platform": "ms-teams", "witnessed": true,

--- a/scripts/release-witness-gate.mjs
+++ b/scripts/release-witness-gate.mjs
@@ -52,6 +52,19 @@ export function validateReceipt(r, version) {
   checkDigestFields("deployment", r.deployment, errs);
   checkDigestFields("witness_deployment", r.witness_deployment, errs);
 
+  // D-L4, enforced at the receipt: the human walks a DELIVERED deployment — provisioned,
+  // pre-validated, and instrumented by the agent — never a setup recipe. A receipt with no
+  // delivered-deployment record means the human was handed homework, not a URL.
+  const wd = r.witness_deployment;
+  if (!wd || typeof wd !== "object") {
+    errs.push("witness_deployment is missing — the witness walks a DELIVERED deployment: record {url, provisioned_by, prevalidated[]} (D-L4: the human receives a URL, never a setup recipe)");
+  } else {
+    if (!nonEmpty(wd.url)) errs.push("witness_deployment.url is empty — the UI URL the human actually walked");
+    if (!nonEmpty(wd.provisioned_by)) errs.push("witness_deployment.provisioned_by is empty — who/what stood the deployment up");
+    if (!Array.isArray(wd.prevalidated) || wd.prevalidated.length === 0 || !wd.prevalidated.every(nonEmpty))
+      errs.push("witness_deployment.prevalidated is empty — name the autonomous checks that passed before handover (health, UI, auth, STT)");
+  }
+
   let coverage = null;
   if (!Array.isArray(r.values) || r.values.length === 0) {
     errs.push("values is empty — the receipt must account for every batch PR (regenerate with release-witness-script.mjs)");

--- a/scripts/release-witness-gate.test.mjs
+++ b/scripts/release-witness-gate.test.mjs
@@ -24,6 +24,9 @@ const receipt = (o) => ({
   witnessed_by: "Test Witness", witnessed_at: "2026-07-17",
   deployment: `lite (image index sha256:${FULL_A} (linux/amd64 image sha256:${FULL_B}))`,
   values: [{ pr: "1", title: "backend value", visibility: "backend", witnessed: "by-proxy", evidence: "scripts/x.test.mjs" }],
+  // D-L4 (#709): the witness walks a DELIVERED deployment — the record is required, so the
+  // all-green fixture carries one; the D-L4 tests below mutate it away.
+  witness_deployment: { url: "http://test:3001", provisioned_by: "agent (test VM)", prevalidated: ["gateway /health 200"] },
   signed_off: true,
   ...o,
 });
@@ -72,6 +75,25 @@ test("GREEN: full 64-hex digests (index + platform image) pass clean", () => {
 test("GREEN: a receipt with no sha256: anywhere (the v0.12.4/v0.12.9 shape) passes untouched", () => {
   const { errs } = validateReceipt(receipt({ deployment: "lite (throwaway Linode VM, LOCAL_STT=1)" }), V);
   assert.deepEqual(errs, []);
+});
+
+// ── D-L4 (#709): the witness walks a DELIVERED deployment — RED without the record ──────────────
+
+const dl4Errs = (r) => validateReceipt(r, V).errs.filter((e) => /witness_deployment/.test(e) && !/truncated/.test(e));
+
+test("RED (D-L4): no witness_deployment at all — the human was handed homework, not a URL", () => {
+  const errs = dl4Errs(receipt({ witness_deployment: undefined }));
+  assert.equal(errs.length, 1);
+  assert.match(errs[0], /witness_deployment is missing/);
+  assert.match(errs[0], /never a setup recipe/);
+});
+
+test("RED (D-L4): empty url / provisioned_by / prevalidated each flag by name", () => {
+  const errs = dl4Errs(receipt({ witness_deployment: { url: "", provisioned_by: "", prevalidated: [] } }));
+  assert.equal(errs.length, 3);
+  assert.match(errs[0], /witness_deployment\.url is empty/);
+  assert.match(errs[1], /witness_deployment\.provisioned_by is empty/);
+  assert.match(errs[2], /witness_deployment\.prevalidated is empty/);
 });
 
 // ── CLI: exit codes against the COMMITTED v0.12.10 receipt (temp-dir spawn, no network) ─────────

--- a/scripts/release-witness-script.mjs
+++ b/scripts/release-witness-script.mjs
@@ -148,6 +148,9 @@ const receipt = {
   // deployment field pins WHICH BYTES were witnessed (#713). The hint below ships in the emitted
   // skeleton so the operator is asked for the full values at fill time.
   deployment: "<compose|lite|helm> (…, image index sha256:<64-hex> (linux/<arch> image sha256:<64-hex>))",
+  // D-L4: the witness walks a DELIVERED deployment — the agent provisions, pre-validates,
+  // and records it here. The gate refuses a receipt without it.
+  witness_deployment: { url: "", provisioned_by: "", prevalidated: [] },
   values,
   signed_off: false,
 };


### PR DESCRIPTION
The D-L4 gap, closed structurally: the law said 'agent-self-served' but releases/README §2 told the HUMAN to self-host, and nothing machine-checked that a witness deployment was ever delivered — the rule lived in chat.

- **releases/README.md §2**: the agent provisions + pre-validates the published images and hands the human a running UI URL — never a setup recipe; schema example gains `witness_deployment`.
- **scripts/release-witness-script.mjs**: generator emits the `witness_deployment: {url, provisioned_by, prevalidated[]}` skeleton so it can't be silently omitted.
- **scripts/release-witness-gate.mjs**: refuses a receipt without a filled record (negative control run: the staged v0.12.10 receipt reds on exactly this; positive control: complete receipt passes with pre-existing checks intact).
- **delivery.mdx D-L4**: Gate line upgraded from '[TO BUILD]'-only to name the receipt-level enforcement.

First enforced release: v0.12.10 (its receipt is being assembled with the delivered-VM record now).