### PR TITLE
harness: least-privilege env for the model subprocess (scrub REDIS_URL + dispatch token)

### DIFF
--- a/core/agent/llm/claude_code.py
+++ b/core/agent/llm/claude_code.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Iterable, Iterator, Optional
 
 from llm.errors import looks_like_auth_failure, preflight_provider_guard
-from llm.ports import HarnessExec, scrubbed_git_env
+from llm.ports import HarnessExec, harness_subprocess_env
 
 
 def _short(content: object, n: int = 80) -> str:
@@ -134,10 +134,13 @@ def build_argv(
 
 
 def _exec_subprocess(argv: list[str], cwd: str) -> Iterator[str]:
-    # scrubbed_git_env: the harness runs git inside the workspace; a hook-exported GIT_DIR would
-    # re-point those ops (and the workspace's own repo discovery) at the hook's repo.
+    # harness_subprocess_env: the model's Bash tool runs INSIDE this subprocess, so it must not inherit
+    # the worker's data-plane secrets — ``REDIS_URL`` (which would let Bash reach the shared redis and
+    # read/write another tenant's tc:meeting:* / unit:*:in streams, crossing the tenancy boundary the
+    # mounts enforce on the filesystem) nor the minted per-dispatch bearer token. It also drops the
+    # git repo-discovery redirects (a hook-exported GIT_DIR would re-point the workspace's git ops).
     proc = subprocess.Popen(argv, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
-                            env=scrubbed_git_env())
+                            env=harness_subprocess_env())
     assert proc.stdout is not None
     try:
         yield from proc.stdout

--- a/core/agent/llm/ports.py
+++ b/core/agent/llm/ports.py
@@ -38,9 +38,28 @@ _GIT_REPO_DISCOVERY_VARS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
 
 def scrubbed_git_env() -> dict[str, str]:
     """``os.environ`` minus every git repo-discovery redirect — cwd-based discovery, always.
-    Used for the local ``_git`` AND for launching harness CLIs (they shell out to git in the
-    workspace and would inherit the same poisoned discovery)."""
+    Used for the local ``_git`` (the worker's OWN commits) AND as the base for launching harness CLIs
+    (they shell out to git in the workspace and would inherit the same poisoned discovery)."""
     return {k: v for k, v in os.environ.items() if k not in _GIT_REPO_DISCOVERY_VARS}
+
+
+# Host DATA-PLANE secrets the worker PROCESS legitimately holds — it drives redis (the serve loop, the
+# meeting/processed streams) and carries the minted per-dispatch token — but that the UNTRUSTED model
+# subprocess must NEVER inherit. A harness CLI exposes a Bash tool to the model; with ``REDIS_URL`` in its
+# environment that Bash reaches the SHARED redis and can read/write ANOTHER tenant's ``tc:meeting:*`` /
+# ``unit:*:in`` keys — filesystem tenancy is mount-enforced, the data plane is not. The per-dispatch
+# identity token is a bearer secret the subprocess has no use for. The model DOES need its MODEL
+# credentials (ANTHROPIC_*/VEXA_LLM_*/CLAUDE_CODE_OAUTH_TOKEN) to talk to the provider, so those are
+# deliberately absent here — this is the tight denylist of vars the model has no legitimate reason to hold.
+_HARNESS_SUBPROCESS_DENY_VARS = ("REDIS_URL", "VEXA_AGENT_IDENTITY_TOKEN")
+
+
+def harness_subprocess_env() -> dict[str, str]:
+    """The env for launching an UNTRUSTED model-driven harness subprocess: ``scrubbed_git_env()`` further
+    stripped of the host data-plane secrets in ``_HARNESS_SUBPROCESS_DENY_VARS``. Use this — never a raw
+    ``os.environ`` / ``scrubbed_git_env`` — to spawn a harness CLI: its Bash tool would otherwise inherit
+    the worker's own ``REDIS_URL`` and cross the data-plane tenancy boundary the mounts enforce on disk."""
+    return {k: v for k, v in scrubbed_git_env().items() if k not in _HARNESS_SUBPROCESS_DENY_VARS}
 
 
 # A raw process runner: given an argv + a cwd, yield the process's stdout lines. Injected into CLI

--- a/core/agent/tests/test_llm_claude_code.py
+++ b/core/agent/tests/test_llm_claude_code.py
@@ -12,6 +12,7 @@ import yaml
 
 from llm import run_harness_turn
 from llm.claude_code import ClaudeCodeHarness, build_argv, parse_stream_json
+from llm.ports import harness_subprocess_env
 
 
 def _git(d: Path, *a: str) -> None:
@@ -117,6 +118,52 @@ def test_build_argv_core_flags_and_session_model():
     assert "--allowedTools" in argv and "Read" in argv
     assert "--resume" in argv and "s1" in argv
     assert "--model" in argv and "m1" in argv
+
+
+# ── the untrusted-subprocess env scrub (data-plane tenancy) ──────────────────
+# The model-driven harness CLI exposes a Bash tool. It must NOT inherit the worker's REDIS_URL (which
+# reaches the SHARED redis — another tenant's tc:meeting:* / unit:*:in) nor the minted per-dispatch
+# bearer token. Filesystem tenancy is mount-enforced; the data plane is enforced HERE, at the launch env.
+
+def test_harness_subprocess_env_strips_data_plane_secrets(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://the-shared-bus:6379/0")
+    monkeypatch.setenv("VEXA_AGENT_IDENTITY_TOKEN", "minted.bearer.jwt")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-model-cred")   # the subprocess DOES need its model cred
+    monkeypatch.setenv("GIT_DIR", "/hook/.git")                # git-discovery scrub still composes
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = harness_subprocess_env()
+    assert "REDIS_URL" not in env, "REDIS_URL must not reach the model's Bash (cross-tenant redis reach)"
+    assert "VEXA_AGENT_IDENTITY_TOKEN" not in env, "the per-dispatch bearer token must not leak in"
+    assert "GIT_DIR" not in env, "the git repo-discovery scrub still composes"
+    assert env["ANTHROPIC_API_KEY"] == "sk-model-cred", "model credentials must survive"
+    assert env["PATH"] == "/usr/bin", "benign vars pass through untouched"
+
+
+def test_exec_subprocess_launches_with_scrubbed_env(monkeypatch):
+    """The DEFAULT runner (real launch path) must pass the scrubbed env to the actual subprocess —
+    negative control: before the fix REDIS_URL/token WOULD ride ``scrubbed_git_env`` into the child."""
+    from llm import claude_code
+
+    monkeypatch.setenv("REDIS_URL", "redis://the-shared-bus:6379/0")
+    monkeypatch.setenv("VEXA_AGENT_IDENTITY_TOKEN", "minted.bearer.jwt")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-model-cred")
+    captured: dict = {}
+
+    class _FakeProc:
+        stdout = iter(())
+
+        def wait(self):
+            return 0
+
+    def _fake_popen(argv, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _FakeProc()
+
+    monkeypatch.setattr(claude_code.subprocess, "Popen", _fake_popen)
+    list(claude_code._exec_subprocess(["claude", "-p", "hi"], "/tmp"))
+    assert "REDIS_URL" not in captured["env"]
+    assert "VEXA_AGENT_IDENTITY_TOKEN" not in captured["env"]
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-model-cred"  # model cred still delivered
 
 
 # ── run_harness_turn: conformant + free-zone writes both commit ──────────────


### PR DESCRIPTION
## Least-privilege environment for the model harness subprocess

**Hardening (defense-in-depth).** The in-container `claude` harness subprocess — which runs an untrusted model turn with the `Bash` tool enabled — was launched inheriting the worker's full process environment (`scrubbed_git_env()` strips only `GIT_*`). It only needs its model credentials and working tree; it does not need the worker's host-side infrastructure variables. This change launches it with the minimum it needs.

### What changed
- `core/agent/llm/ports.py` — new `harness_subprocess_env()` = `scrubbed_git_env()` minus a small denylist of host-side infrastructure variables (`REDIS_URL`, `VEXA_AGENT_IDENTITY_TOKEN`), mirroring the module's existing `GIT_*` denylist pattern.
- `core/agent/llm/claude_code.py` — `_exec_subprocess` now launches the harness with `harness_subprocess_env()`.
- Model credentials (`ANTHROPIC_*` / `VEXA_LLM_*` / `CLAUDE_CODE_OAUTH_TOKEN`) are **deliberately retained** — the subprocess reaches the provider itself. The tool-less `claude_cli.py` path (`--allowedTools ""`) has no execution surface and is unchanged.

### Why it matters
Filesystem tenancy between workers is already strongly enforced (one bind per mount, store subpaths, `:ro` — `core/runtime/src/runtime_kernel/mounts.py`). This closes the analogous gap on the process-environment side so the harness child runs with least privilege rather than the worker's full ambient environment — narrowing what a compromised or prompt-injected turn can reach. The upstream mitigation for prompt-injection itself (the instruction/content boundary) is tracked separately in the terminal UX design work (`clients/terminal/docs/UX-FLOWS.md`, L17) and is not duplicated here.

### Validation
- `core/agent/tests/test_llm_claude_code.py` — added two tests: the pure-function scrub, and the real `Popen` launch-path environment. Negative control shown red (on base the harness launch env carries the denied variables; the new symbol does not exist).
- `17 passed` on the touched test file; `121 passed` across the `core/agent` llm/worker/config lanes, including the tests that stamp and read `VEXA_AGENT_IDENTITY_TOKEN` elsewhere.
- No architecture / contract / schema change -> no seal touch. Full `node scripts/gates.mjs all` not run in the worktree — run as a pre-merge step.

### Deferred (follow-up, not this PR)
- Verifying the per-dispatch identity token at the meeting-api / runtime edges (`verify_dispatch_token` exists but has no production callers today). Env-scrub is the self-contained, highest-leverage first step; edge verification is the larger follow-up.

### Notes
- No-regression: touched lanes green at head.
- Live two-tenant end-to-end validation on a Lite + meetings deployment is left for operator sign-off (not reproducible in the worktree).
