### PR TITLE
fix(gmeet): leave click's browser-context fallbacks were dead — ':has-text()' fed to querySelector; one canonical in-page clicker + a gate lane that sees the class (#542)

### DIFF
--- a/core/meetings/modules/join/README.md
+++ b/core/meetings/modules/join/README.md
@@ -17,9 +17,18 @@ builtins, so the package is provably standalone).
 
 ## Depends on
 `playwright` (the `Page`/automation) + Node builtins only. `playwright-extra` +
-`puppeteer-extra-plugin-stealth` are used by the debug harness (`scripts/`). Verified by
-`pnpm --filter @vexa/join check:isolation` (gate:isolation, P2). CommonJS by design — see
-`tsconfig.json`; ESM consumers import it via Node interop.
+`puppeteer-extra-plugin-stealth` are used by the debug harness (`scripts/`); `jsdom` is
+test-only (real CSS engine for the no-browser fixtures + the selector-validity gate).
+Verified by `pnpm --filter @vexa/join check:isolation` (gate:isolation, P2). CommonJS by
+design — see `tsconfig.json`; ESM consumers import it via Node interop.
+
+## Selector conventions
+Selector validity is **per execution context**, not per engine: Playwright engines
+(`text=`, `:has-text()`) exist only on the locator side; anything shipped into
+`page.evaluate` runs through `document.querySelector` and must be **plain CSS**. Declare
+browser-context arrays in `browserContextSelectorArrays` (per-platform `selectors.ts`) so
+`src/shared/selector-validity.test.ts` CSS-parses them; text-labelled buttons are
+`{ text: … }` matcher fields, matched in-page against `textContent`.
 
 ## Prove it
 - `pnpm --filter @vexa/join build` · `pnpm --filter @vexa/join test` (L1/L2 admission oracle — DOM fixtures, no browser)

--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "jsdom": "^29.1.1",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
   }

--- a/core/meetings/modules/join/src/googlemeet/leave.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/leave.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Browser-context leave click — execution-context regression guard (#542).
+ *
+ * The leave click runs INSIDE the page via page.evaluate + document.querySelector,
+ * which understands plain CSS only. The pre-#542 array fed it Playwright-only
+ * `:has-text()` entries: querySelector threw SyntaxError on every one, the
+ * throws were caught-and-skipped, and every confirmation-dialog fallback
+ * ("Leave meeting", "Just leave the meeting", dialog-scoped Leave/End) was
+ * silently dead — the bot could not click a leave-confirmation dialog, and each
+ * leave attempt spammed N invalid-selector errors that read like join failures
+ * (#432). Red control on the pre-fix tree: the same dialog fixture returned
+ * false with 10/20 selectors throwing.
+ *
+ * This test drives googleLeaveBrowserClick — the EXACT function both consumers
+ * serialize into the page — against jsdom fixtures (a real CSS engine, no
+ * browser): the confirmation dialog is clickable, priorities hold, and no
+ * selector error fires.
+ *
+ * Run: npx tsx src/googlemeet/leave.test.ts
+ */
+
+import { JSDOM } from 'jsdom';
+import { googleLeaveBrowserClick } from './leave';
+import { googleLeaveButtonMatchers } from './selectors';
+
+let passed = 0, failed = 0;
+function check(name: string, actual: unknown, expected: unknown) {
+  if (actual === expected) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name} (expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)})`); failed++; }
+}
+
+/**
+ * Mount a jsdom document as the click routine's browser context. jsdom has no
+ * layout, so every element gets a real box; visibility then keys on computed
+ * style (display/visibility/opacity), exactly like a rendered page.
+ * Returns the collected logBot lines and a `clicked` recorder.
+ */
+function mountDom(html: string) {
+  const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`);
+  dom.window.Element.prototype.getBoundingClientRect = function () {
+    return { width: 120, height: 40, top: 0, left: 0, right: 120, bottom: 40, x: 0, y: 0, toJSON() {} } as any;
+  };
+  (dom.window.HTMLElement.prototype as any).scrollIntoView = function () {};
+  const logs: string[] = [];
+  (dom.window as any).logBot = (m: string) => logs.push(m);
+  const clicked: string[] = [];
+  for (const el of Array.from(dom.window.document.querySelectorAll('button, [role="button"], input'))) {
+    el.addEventListener('click', () => clicked.push(el.getAttribute('data-fixture-id') || el.outerHTML));
+  }
+  (globalThis as any).window = dom.window;
+  (globalThis as any).document = dom.window.document;
+  (globalThis as any).getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+  return { dom, logs, clicked };
+}
+
+const selectorErrors = (logs: string[]) => logs.filter((l) => l.includes('selector failed in browser context'));
+
+(async () => {
+  console.log('\n=== the mechanism (#542): Playwright-only selectors are invalid in browser context ===');
+
+  // Negative control — the exact selector shape the pre-fix array shipped
+  // throws in a real CSS engine. This is what killed every dialog fallback,
+  // and it proves this fixture's engine genuinely rejects Playwright syntax
+  // (so the zero-selector-error assertions below mean something).
+  {
+    const { dom } = mountDom('<button>Leave meeting</button>');
+    let threw = false;
+    try { dom.window.document.querySelector('button:has-text("Leave meeting")'); }
+    catch { threw = true; }
+    check('querySelector(`button:has-text("…")`) throws SyntaxError (the dead-selector mechanism)', threw, true);
+  }
+
+  console.log('\n=== A1: leave-confirmation dialog is clickable through the browser-context path ===');
+
+  // The dialog fixture: ONLY a confirmation dialog — no toolbar leave button.
+  // Pre-#542 red: leave returned false here (every matching selector was
+  // Playwright-only). Includes the dialog's Close X to pin priority: the
+  // confirmation button must win over generic close/cancel.
+  {
+    const { logs, clicked } = mountDom(`
+      <div role="dialog" aria-label="Leave the meeting?">
+        <h2>Leave the meeting?</h2>
+        <button aria-label="Close" data-fixture-id="close-x"></button>
+        <button data-fixture-id="just-leave"><span>Just leave the meeting</span></button>
+      </div>`);
+    const result = await googleLeaveBrowserClick(googleLeaveButtonMatchers);
+    check('dialog-only fixture → leave returns true', result, true);
+    check('the confirmation button was clicked (not the Close X)', clicked.join(','), 'just-leave');
+    check('zero selector errors in browser context', selectorErrors(logs).length, 0);
+    // NB: attributed to the "Just leave the meeting" matcher — "Leave meeting"
+    // is NOT a substring of "Just leave THE meeting", under these semantics or
+    // Playwright's `:has-text()` alike.
+    check(
+      'click is attributed in the logs',
+      logs.includes('[leave] clicked leave button via text~"Just leave the meeting"'),
+      true,
+    );
+  }
+
+  console.log('\n=== A3 guards: primary path, visibility, and the no-button case ===');
+
+  // In-call fixture — the primary aria-label button wins first, before any
+  // text matching (unchanged behavior of the shipped path).
+  {
+    const { logs, clicked } = mountDom(`
+      <div role="toolbar">
+        <button aria-label="Chat with everyone" data-fixture-id="chat"></button>
+        <button aria-label="Leave call" data-fixture-id="leave-call"></button>
+      </div>`);
+    const result = await googleLeaveBrowserClick(googleLeaveButtonMatchers);
+    check('in-call fixture → leave returns true', result, true);
+    check('the primary Leave call button was clicked', clicked.join(','), 'leave-call');
+    check(
+      'attributed to the primary CSS matcher',
+      logs.some((l) => l === '[leave] clicked leave button via button[aria-label="Leave call"]'),
+      true,
+    );
+  }
+
+  // Visibility guard — a display:none confirmation button must not be clicked.
+  {
+    const { clicked } = mountDom(`
+      <div role="dialog">
+        <button style="display: none" data-fixture-id="hidden"><span>Just leave the meeting</span></button>
+      </div>`);
+    const result = await googleLeaveBrowserClick(googleLeaveButtonMatchers);
+    check('hidden confirmation button → leave returns false', result, false);
+    check('nothing was clicked', clicked.length, 0);
+  }
+
+  // No leave affordance at all → false, loudly.
+  {
+    const { logs, clicked } = mountDom('<div>Meeting chrome, no leave anywhere</div>');
+    const result = await googleLeaveBrowserClick(googleLeaveButtonMatchers);
+    check('no leave affordance → leave returns false', result, false);
+    check('nothing was clicked', clicked.length, 0);
+    check('zero selector errors in browser context', selectorErrors(logs).length, 0);
+    check(
+      'the no-match outcome is logged',
+      logs.includes('[leave] no visible leave button matched any matcher'),
+      true,
+    );
+  }
+
+  console.log(`\n=== summary: ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/core/meetings/modules/join/src/googlemeet/leave.ts
+++ b/core/meetings/modules/join/src/googlemeet/leave.ts
@@ -2,8 +2,66 @@ import { Page } from "playwright";
 import { log, callLeaveCallback } from "../_host";
 import { logJSON } from "../_host";
 import { BotConfig } from "../_host";
-import { googleLeaveSelectors } from "./selectors";
+import { googleLeaveButtonMatchers, BrowserContextButtonMatcher } from "./selectors";
 import { stopGoogleRecording } from "../_host";
+
+// The leave click that runs INSIDE the page (shipped through page.evaluate by
+// both consumers below — ONE canonical routine, so the injected hook and the
+// direct leave can never drift, and the no-browser fixture test drives exactly
+// the function production serializes into the browser).
+//
+// Self-contained by contract: it is serialized into the browser context, where
+// module scope does not exist — DOM globals and its argument only.
+// document.querySelector understands plain CSS (no Playwright engines), so
+// text-labelled buttons are expressed as `text` fields and matched here by
+// whitespace-normalized, case-insensitive substring of textContent — the
+// semantics `:has-text()` applies in Playwright contexts. Matchers are tried
+// in order; the first visible match is clicked.
+export async function googleLeaveBrowserClick(
+  matchers: BrowserContextButtonMatcher[],
+): Promise<boolean> {
+  // Serialization contract: esbuild-family compilers (tsx — the debug harness
+  // lane) emit nested function expressions wrapped in a `__name` helper that
+  // does not exist inside the page. Define an identity fallback BEFORE any
+  // nested function is created, so the serialized source is self-contained
+  // under every compiler (tsc emits none of this; the line is then inert).
+  (globalThis as any).__name = (globalThis as any).__name || ((f: unknown) => f);
+  const blog = (m: string) => { try { (window as any).logBot?.(m); } catch { /* logging is best-effort */ } };
+  const normalize = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
+  const isVisible = (el: Element) => {
+    const rect = el.getBoundingClientRect();
+    const cs = getComputedStyle(el as HTMLElement);
+    return rect.width > 0 && rect.height > 0
+      && cs.display !== "none" && cs.visibility !== "hidden" && cs.opacity !== "0";
+  };
+  for (const matcher of matchers) {
+    const scope = matcher.css ?? 'button, [role="button"]';
+    let candidates: Element[];
+    try {
+      candidates = Array.from(document.querySelectorAll(scope));
+    } catch (e: any) {
+      // The selector-validity gate CSS-parses every declared browser-context
+      // entry, so this only fires on drift — loudly, never silently.
+      blog(`[leave] selector failed in browser context: ${scope} — ${e?.message}`);
+      continue;
+    }
+    const needle = matcher.text === undefined ? null : normalize(matcher.text);
+    const button = candidates.find(
+      (el) => (needle === null || normalize(el.textContent || "").includes(needle)) && isVisible(el),
+    ) as HTMLElement | undefined;
+    if (!button) continue;
+    button.scrollIntoView({ behavior: "smooth", block: "center" });
+    await new Promise((r) => setTimeout(r, 300));
+    button.click();
+    await new Promise((r) => setTimeout(r, 800));
+    const via = [matcher.css, matcher.text === undefined ? undefined : `text~"${matcher.text}"`]
+      .filter(Boolean).join(" ");
+    blog(`[leave] clicked leave button via ${via}`);
+    return true;
+  }
+  blog("[leave] no visible leave button matched any matcher");
+  return false;
+}
 
 // Prepare for recording by exposing necessary functions
 export async function prepareForRecording(page: Page, botConfig: BotConfig): Promise<void> {
@@ -15,83 +73,35 @@ export async function prepareForRecording(page: Page, botConfig: BotConfig): Pro
   // Expose bot config for callback functions
   await page.exposeFunction("getBotConfig", (): BotConfig => botConfig);
 
-  // Ensure leave function is available even before admission
-  await page.evaluate((selectorsData) => {
+  // Node-side binding backing the browser-context leave hook: it drives the
+  // same canonical googleLeaveBrowserClick through page.evaluate, so the hook
+  // needs no in-page copy of the click logic. The binding survives
+  // navigations; the hook below is re-armed per document like before.
+  await page.exposeFunction("__vexaGoogleLeaveClick", async (): Promise<boolean> => {
+    try {
+      return Boolean(await page.evaluate(googleLeaveBrowserClick, googleLeaveButtonMatchers));
+    } catch (err: any) {
+      log(`[performLeaveAction] browser leave click failed: ${err?.message}`);
+      return false;
+    }
+  });
+
+  // Ensure leave function is available even before admission. The leave
+  // callback to meeting-api is sent from the Node side (leaveGoogleMeet), not
+  // from this hook.
+  await page.evaluate(() => {
     if (typeof (window as any).performLeaveAction !== "function") {
       (window as any).performLeaveAction = async () => {
         try {
-          // Call leave callback first to notify meeting-api
-          (window as any).logBot?.("🔥 Calling leave callback before attempting to leave...");
-          try {
-            const botConfig = (window as any).getBotConfig?.();
-            if (botConfig) {
-              // We need to call the callback from Node.js context, not browser context
-              // This will be handled by the Node.js side when leaveGoogleMeet is called
-              (window as any).logBot?.("📡 Leave callback will be sent from Node.js context");
-            }
-          } catch (callbackError: any) {
-            (window as any).logBot?.(`⚠️ Warning: Could not prepare leave callback: ${callbackError.message}`);
-          }
-
-          // Use directly injected selectors (stateless approach)
-          const leaveSelectors = selectorsData.googleLeaveSelectors || [];
-
-          (window as any).logBot?.("🔍 Starting stateless Google Meet leave button detection...");
-          (window as any).logBot?.(`📋 Will try ${leaveSelectors.length} selectors until one works`);
-          
-          // Try each selector until one works (stateless iteration)
-          for (let i = 0; i < leaveSelectors.length; i++) {
-            const selector = leaveSelectors[i];
-            try {
-              (window as any).logBot?.(`🔍 [${i + 1}/${leaveSelectors.length}] Trying selector: ${selector}`);
-              
-              const button = document.querySelector(selector) as HTMLElement;
-              if (button) {
-                // Check if button is visible and clickable
-                const rect = button.getBoundingClientRect();
-                const computedStyle = getComputedStyle(button);
-                const isVisible = rect.width > 0 && rect.height > 0 && 
-                                computedStyle.display !== 'none' && 
-                                computedStyle.visibility !== 'hidden' &&
-                                computedStyle.opacity !== '0';
-                
-                if (isVisible) {
-                  const ariaLabel = button.getAttribute('aria-label');
-                  const textContent = button.textContent?.trim();
-                  
-                  (window as any).logBot?.(`✅ Found clickable button: aria-label="${ariaLabel}", text="${textContent}"`);
-                  
-                  // Scroll into view and click
-                  button.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                  await new Promise((resolve) => setTimeout(resolve, 500));
-                  
-                  (window as any).logBot?.(`🖱️ Clicking Google Meet button...`);
-                  button.click();
-                  await new Promise((resolve) => setTimeout(resolve, 1000));
-                  
-                  (window as any).logBot?.(`✅ Successfully clicked button with selector: ${selector}`);
-                  return true;
-                } else {
-                  (window as any).logBot?.(`ℹ️ Button found but not visible for selector: ${selector}`);
-                }
-              } else {
-                (window as any).logBot?.(`ℹ️ No button found for selector: ${selector}`);
-              }
-            } catch (e: any) {
-              (window as any).logBot?.(`❌ Error with selector ${selector}: ${e.message}`);
-              continue;
-            }
-          }
-          
-          (window as any).logBot?.("❌ No working leave/cancel button found - tried all selectors");
-          return false;
+          (window as any).logBot?.("🔥 Leave requested from browser context — clicking the leave path...");
+          return await (window as any).__vexaGoogleLeaveClick();
         } catch (err: any) {
-          (window as any).logBot?.(`Error during Google Meet leave attempt: ${err.message}`);
+          (window as any).logBot?.(`Error during Google Meet leave attempt: ${err?.message}`);
           return false;
         }
       };
     }
-  }, { googleLeaveSelectors });
+  });
 }
 
 // --- ADDED: Exported function to trigger leave from Node.js ---
@@ -148,30 +158,9 @@ export async function leaveGoogleMeet(page: Page | null, botConfig?: BotConfig, 
   }
 
   try {
-    // Inline the leave-click (self-contained): try each leave selector and click the first visible
-    // match. Self-contained so it never depends on a separately-injected window.performLeaveAction.
-    const result = await page.evaluate(async (selectors: string[]) => {
-      const blog = (m: string) => { try { (window as any).logBot?.(m); } catch { /* */ } };
-      for (const selector of selectors) {
-        try {
-          const button = document.querySelector(selector) as HTMLElement | null;
-          if (!button) continue;
-          const rect = button.getBoundingClientRect();
-          const cs = getComputedStyle(button);
-          const visible = rect.width > 0 && rect.height > 0
-            && cs.display !== "none" && cs.visibility !== "hidden" && cs.opacity !== "0";
-          if (!visible) continue;
-          button.scrollIntoView({ behavior: "smooth", block: "center" });
-          await new Promise((r) => setTimeout(r, 300));
-          button.click();
-          await new Promise((r) => setTimeout(r, 800));
-          blog(`[leave] clicked leave button via ${selector}`);
-          return true;
-        } catch { /* try the next selector */ }
-      }
-      blog("[leave] no visible leave button matched any selector");
-      return false;
-    }, googleLeaveSelectors);
+    // Ship the canonical leave click into the page directly (self-contained:
+    // never depends on the separately-injected window.performLeaveAction).
+    const result = await page.evaluate(googleLeaveBrowserClick, googleLeaveButtonMatchers);
     logJSON({
       level: "info",
       msg: "[leaveGoogleMeet] Browser leave action complete",
@@ -179,14 +168,14 @@ export async function leaveGoogleMeet(page: Page | null, botConfig?: BotConfig, 
       leave_reason: reason,
     });
     // Contract: this function is typed Promise<boolean>. page.evaluate can return
-    // undefined (e.g. a black/captcha page where performLeaveAction never resolves a
+    // undefined (e.g. a black/captcha page where the click routine never resolves a
     // value), which otherwise propagates as `result: undefined` to callers that treat
     // it as a tri-state. Coerce to match the declared boolean (and the log above).
     return Boolean(result);
   } catch (error: any) {
     logJSON({
       level: "error",
-      msg: "[leaveGoogleMeet] Error calling performLeaveAction in browser",
+      msg: "[leaveGoogleMeet] Error calling the browser leave click",
       error_message: error?.message,
       error_name: error?.name,
       leave_reason: reason,

--- a/core/meetings/modules/join/src/googlemeet/selectors.ts
+++ b/core/meetings/modules/join/src/googlemeet/selectors.ts
@@ -8,6 +8,15 @@
 // by the detectors' try/catch loops (dead selectors). All `text*="foo"`
 // entries were replaced with the unquoted substring form on 2026-07-04;
 // src/shared/selector-validity.test.ts now gates every selector array.
+//
+// EXECUTION-CONTEXT SEMANTICS: Playwright engines (`text=`, `:has-text()`)
+// exist ONLY on the Playwright side (page.locator). Anything shipped into
+// page.evaluate runs through document.querySelector, which understands plain
+// CSS and nothing else — a Playwright-only entry there throws SyntaxError on
+// every call. Arrays consumed in browser context are declared in
+// browserContextSelectorArrays (bottom of this file); the validity gate
+// CSS-parses each declared entry, and text-labelled buttons are expressed as
+// `{ text: … }` matcher fields, matched in-page against textContent.
 
 export const googleInitialAdmissionIndicators: string[] = [
   // DOM fallback selectors — only indicators that do NOT appear in the lobby.
@@ -207,43 +216,6 @@ export const googleParticipantContainerSelectors: string[] = [
   '[jsname="BOHaEe"]' // Google Meet meeting container
 ];
 
-// Leave button selectors (used in browser context via page.evaluate)
-export const googlePrimaryLeaveButtonSelectors: string[] = [
-  // Primary Google Meet leave button
-  'button[aria-label="Leave call"]',
-  
-  // Alternative leave button patterns
-  'button[aria-label*="Leave"]',
-  'button[aria-label*="leave"]',
-  'button[aria-label*="End meeting"]',
-  'button[aria-label*="end meeting"]',
-  'button[aria-label*="Hang up"]',
-  'button[aria-label*="hang up"]',
-  
-  // Toolbar-based selectors
-  '[role="toolbar"] button[aria-label*="Leave"]'
-];
-
-export const googleSecondaryLeaveButtonSelectors: string[] = [
-  // Confirmation dialog leave buttons
-  'button:has-text("Leave meeting")',
-  'button:has-text("Just leave the meeting")',
-  'button:has-text("Leave")',
-  'button:has-text("End meeting")',
-  'button:has-text("Hang up")',
-  'button:has-text("End call")',
-  'button:has-text("Leave call")',
-  
-  // Dialog-specific selectors
-  '[role="dialog"] button:has-text("Leave")',
-  '[role="dialog"] button:has-text("End meeting")',
-  '[role="alertdialog"] button:has-text("Leave")',
-  
-  // Generic confirmation patterns
-  'button[aria-label*="confirm"]:has-text("Leave")',
-  'button[aria-label*="confirm"]:has-text("End")'
-];
-
 // Google Meet name selectors for participant identification
 export const googleNameSelectors: string[] = [
   // Google Meet specific name selectors
@@ -363,41 +335,54 @@ export const googleParticipantIdSelectors: string[] = [
   '[jsinstance]'
 ];
 
-// Google Meet comprehensive leave selectors (stateless - covers all scenarios)
-export const googleLeaveSelectors: string[] = [
-  // WORKING SELECTORS FIRST - Google Meet primary leave button
-  'button[aria-label="Leave call"]', // ✅ Primary Google Meet leave button
-  
+// Browser-context button matcher: `css` scopes candidates via
+// document.querySelectorAll (plain CSS ONLY — this shape is consumed inside
+// page.evaluate, where Playwright engines like `:has-text()` do not exist);
+// `text` filters those candidates by whitespace-normalized, case-insensitive
+// substring of textContent (the semantics `:has-text()` applies in Playwright
+// contexts). At least one field must be present; `css` alone means "first
+// visible match", `text` alone scopes to any button-like element.
+export type BrowserContextButtonMatcher = { css?: string; text?: string };
+
+// Google Meet comprehensive leave matchers (stateless - covers all scenarios).
+// BROWSER CONTEXT: consumed inside page.evaluate via document.querySelector —
+// declared in browserContextSelectorArrays below, so the validity gate
+// CSS-parses every `css` field. Tried in order; first visible match wins.
+export const googleLeaveButtonMatchers: BrowserContextButtonMatcher[] = [
+  // Primary Google Meet leave button
+  { css: 'button[aria-label="Leave call"]' },
+
   // Alternative leave patterns
-  'button[aria-label*="Leave"]',
-  'button[aria-label*="leave"]',
-  '[role="toolbar"] button[aria-label*="Leave"]',
-  
+  { css: 'button[aria-label*="Leave"]' },
+  { css: 'button[aria-label*="leave"]' },
+  { css: '[role="toolbar"] button[aria-label*="Leave"]' },
+
   // End meeting alternatives
-  'button[aria-label*="End meeting"]',
-  'button:has-text("End meeting")',
-  'button[aria-label*="Hang up"]',
-  'button:has-text("Hang up")',
-  
+  { css: 'button[aria-label*="End meeting"]' },
+  { text: 'End meeting' },
+  { text: 'End call' },
+  { css: 'button[aria-label*="Hang up"]' },
+  { text: 'Hang up' },
+
   // Confirmation dialog buttons (secondary)
-  'button:has-text("Leave meeting")',
-  'button:has-text("Just leave the meeting")',
-  'button:has-text("Leave")',
-  
+  { text: 'Leave meeting' },
+  { text: 'Just leave the meeting' },
+  { text: 'Leave' },
+
   // Dialog-specific patterns
-  '[role="dialog"] button:has-text("Leave")',
-  '[role="dialog"] button:has-text("End meeting")',
-  '[role="alertdialog"] button:has-text("Leave")',
-  
+  { css: '[role="dialog"] button', text: 'Leave' },
+  { css: '[role="dialog"] button', text: 'End meeting' },
+  { css: '[role="alertdialog"] button', text: 'Leave' },
+
   // Generic close/cancel patterns
-  'button:has-text("Close")',
-  'button[aria-label="Close"]',
-  'button:has-text("Cancel")',
-  'button[aria-label="Cancel"]',
-  
+  { text: 'Close' },
+  { css: 'button[aria-label="Close"]' },
+  { text: 'Cancel' },
+  { css: 'button[aria-label="Cancel"]' },
+
   // Fallback patterns
-  'input[type="button"][value="Leave"]',
-  'input[type="submit"][value="Leave"]'
+  { css: 'input[type="button"][value="Leave"]' },
+  { css: 'input[type="submit"][value="Leave"]' }
 ];
 
 // Google Meet people/participant panel selectors
@@ -422,4 +407,13 @@ export const googlePeopleButtonSelectors: string[] = [
   'button[data-tooltip*="participants"]',
   'button[data-tooltip*="Participants"]'
 ];
+
+// EXECUTION-CONTEXT DECLARATION — consumed by src/shared/selector-validity.test.ts.
+// Arrays named here ship into page.evaluate and run through
+// document.querySelector, so the gate additionally CSS-parses them: a
+// Playwright parse alone would let `:has-text()` — invalid in that context —
+// ship green as a dead selector. Entries may be plain CSS strings or
+// BrowserContextButtonMatcher objects (`css` field parsed as CSS; `text`
+// fields are raw strings, not selectors).
+export const browserContextSelectorArrays: string[] = ['googleLeaveButtonMatchers'];
 

--- a/core/meetings/modules/join/src/shared/selector-validity.test.ts
+++ b/core/meetings/modules/join/src/shared/selector-validity.test.ts
@@ -1,6 +1,6 @@
 /**
  * Selector-validity gate — every selector array in this module must parse as a
- * VALID Playwright selector.
+ * VALID selector FOR THE EXECUTION CONTEXT it runs in.
  *
  * WHY: the detector loops (admission / rejection / waiting / removal) wrap each
  * page.locator(sel).isVisible() in try/catch-continue. An INVALID selector
@@ -10,22 +10,36 @@
  * selector strings as opaque keys and stay green. This gate makes that class
  * of bug fail loudly — no browser needed.
  *
- * HOW: playwright-core's server-side `Selectors.parseSelector` performs the
- * exact parse + engine validation the live locator path runs before touching
- * the page. playwright-core is resolved THROUGH the declared `playwright`
- * dependency, so validation always happens against the engine version this
- * module actually ships with (its exports map hides lib/server/selectors.js,
- * hence the two-step package.json resolution + direct file require).
+ * Validity is PER EXECUTION CONTEXT, not per engine (#542): `:has-text()`
+ * parses fine as a Playwright selector yet throws SyntaxError in
+ * document.querySelector, so a browser-context array full of it ships green
+ * under a Playwright-only parse while every entry is dead. Hence two lanes:
  *
- * SCOPE: exported arrays whose name ends in `Selectors` or `Indicators` are
- * Playwright locator selectors. `*Texts` / `*ClassNames` exports are raw
- * strings consumed inside page.evaluate() / textContent matching — NOT
- * locator selectors — and are excluded on purpose.
+ * LANE 1 — Playwright (locator) arrays. HOW: playwright-core's server-side
+ * `Selectors.parseSelector` performs the exact parse + engine validation the
+ * live locator path runs before touching the page. playwright-core is resolved
+ * THROUGH the declared `playwright` dependency, so validation always happens
+ * against the engine version this module actually ships with (its exports map
+ * hides lib/server/selectors.js, hence the two-step package.json resolution +
+ * direct file require). SCOPE: exported arrays whose name ends in `Selectors`
+ * or `Indicators`. `*Texts` / `*ClassNames` exports are raw strings consumed
+ * inside page.evaluate() / textContent matching — NOT locator selectors — and
+ * are excluded on purpose.
+ *
+ * LANE 2 — browser-context arrays. Each platform's selectors.ts DECLARES the
+ * arrays it ships into page.evaluate in a `browserContextSelectorArrays`
+ * export (names, not values — the declaration travels with the arrays it
+ * covers). Those run through document.querySelector, so every entry — a plain
+ * CSS string or the `css` field of a `{ css?, text? }` button matcher — must
+ * additionally parse as REAL CSS, validated here with jsdom's querySelector (a
+ * real CSS engine, no browser needed). `text` fields are raw strings matched
+ * against textContent in-page, never parsed as selectors.
  *
  * Run: npx tsx src/shared/selector-validity.test.ts
  */
 
 import * as path from 'path';
+import { JSDOM } from 'jsdom';
 import * as googlemeet from '../googlemeet/selectors';
 import * as msteams from '../msteams/selectors';
 import * as zoom from '../zoom/selectors';
@@ -75,8 +89,105 @@ if (arrays < 10 || checked < 100) {
   );
 }
 
+// --- LANE 2: browser-context arrays must be plain CSS (document.querySelector) ---
+
+const cssProbe = new JSDOM('<!doctype html><html><body></body></html>').window.document;
+
+// jsdom's selector engine compiles lazily: with no candidate elements for a
+// selector's indexable parts (tag/attribute/class/id), querySelector returns
+// null WITHOUT parsing the pseudo-classes — an invalid entry would pass. So
+// seed the probe with elements carrying every tag/attribute/class/id the
+// selector mentions before querying; then a parse is guaranteed.
+const cssError = (sel: string): string | null => {
+  let m: RegExpExecArray | null;
+  const tags = new Set(['div']);
+  const tagRe = /(?:^|[\s>+~,(])([a-zA-Z][a-zA-Z0-9-]*)/g;
+  while ((m = tagRe.exec(sel))) tags.add(m[1].toLowerCase());
+  const attrs: Array<[string, string]> = [];
+  const attrRe = /\[\s*([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*(?:[*^$|~]?=\s*("([^"]*)"|'([^']*)'|([^\]\s]+)))?\s*\]/g;
+  while ((m = attrRe.exec(sel))) attrs.push([m[1], m[3] ?? m[4] ?? m[5] ?? 'probe']);
+  const classes: string[] = [];
+  const classRe = /\.([a-zA-Z_-][a-zA-Z0-9_-]*)/g;
+  while ((m = classRe.exec(sel))) classes.push(m[1]);
+  const idRe = /#([a-zA-Z_-][a-zA-Z0-9_-]*)/.exec(sel);
+  const host = cssProbe.createElement('div');
+  for (const t of tags) {
+    let el: Element;
+    try { el = cssProbe.createElement(t); } catch { continue; }
+    for (const [a, v] of attrs) { try { el.setAttribute(a, v); } catch { /* unseedable attr name */ } }
+    if (classes.length) el.setAttribute('class', classes.join(' '));
+    if (idRe) el.setAttribute('id', idRe[1]);
+    host.appendChild(el);
+  }
+  cssProbe.body.appendChild(host);
+  try { cssProbe.querySelector(sel); return null; }
+  catch (e: any) { return String(e?.message || e).split('\n')[0]; }
+  finally { host.remove(); }
+};
+
+let cssArrays = 0;
+let cssChecked = 0;
+
+for (const [modName, mod] of Object.entries(modules)) {
+  const declared = (mod as Record<string, unknown>).browserContextSelectorArrays;
+  if (declared === undefined) continue;
+  for (const arrayName of declared as string[]) {
+    const value = (mod as Record<string, unknown>)[arrayName];
+    if (!Array.isArray(value)) {
+      // A stale declaration would silently shrink the gate's coverage — red it.
+      invalid++;
+      console.log(
+        `  \x1b[31mINVALID\x1b[0m ${modName}.browserContextSelectorArrays names ` +
+        `'${arrayName}', but no such array is exported (stale declaration)`,
+      );
+      continue;
+    }
+    cssArrays++;
+    for (const entry of value as Array<string | { css?: string; text?: string }>) {
+      const css = typeof entry === 'string' ? entry : entry?.css;
+      const text = typeof entry === 'string' ? undefined : entry?.text;
+      if (css === undefined && text === undefined) {
+        invalid++;
+        console.log(`  \x1b[31mINVALID\x1b[0m ${modName}.${arrayName} :: empty matcher (no css, no text)`);
+        continue;
+      }
+      if (css === undefined) continue; // pure text matcher — raw string, not a selector
+      cssChecked++;
+      const err = cssError(css);
+      if (err !== null) {
+        invalid++;
+        console.log(
+          `  \x1b[31mINVALID(css)\x1b[0m ${modName}.${arrayName} :: ${css}\n` +
+          `          browser-context array, but not valid CSS: ${err}`,
+        );
+      }
+    }
+  }
+}
+
+// Negative control: the CSS lane must actually reject Playwright-only syntax —
+// if this probe ever passes, the lane has gone blind and the gate is broken.
+if (cssError('button:has-text("probe")') === null) {
+  gateBroken = true;
+  console.log(
+    '  \x1b[31mFAIL\x1b[0m css-lane self-check: `:has-text()` was accepted as CSS — ' +
+    'the browser-context lane no longer rejects Playwright-only syntax',
+  );
+}
+
+// Self-check: at least one browser-context array must be declared and carry
+// CSS entries (the leave matchers) — a deleted declaration must not pass green.
+if (cssArrays < 1 || cssChecked < 10) {
+  gateBroken = true;
+  console.log(
+    `  \x1b[31mFAIL\x1b[0m css-lane self-check: only ${cssArrays} declared arrays / ` +
+    `${cssChecked} css entries — did browserContextSelectorArrays disappear?`,
+  );
+}
+
 console.log(
-  `\n=== selector-validity: ${checked} selectors in ${arrays} arrays — ` +
-  `${checked - invalid} valid, ${invalid} invalid ===`,
+  `\n=== selector-validity: ${checked} playwright selectors in ${arrays} arrays + ` +
+  `${cssChecked} css entries in ${cssArrays} browser-context arrays — ` +
+  `${invalid} invalid ===`,
 );
 process.exit(invalid > 0 || gateBroken ? 1 : 0);

--- a/core/meetings/services/bot/src/join-driver.ts
+++ b/core/meetings/services/bot/src/join-driver.ts
@@ -96,7 +96,7 @@ export function createBrowserJoinDriver(page: Page, inv: Invocation): JoinDriver
       // best-effort:
       //  1. Click the platform's cancel/leave affordance. The stateless leave-click helpers already
       //     include the waiting-room selectors: Teams' teamsLeaveSelectors carry the "Cancel" buttons
-      //     "(for awaiting admission/waiting room)", and googleLeaveSelectors include Cancel/Close. On
+      //     "(for awaiting admission/waiting room)", and googleLeaveButtonMatchers include Cancel/Close. On
       //     Zoom the web client shows no reliable pre-admit cancel, so step 2 is the withdraw there.
       //  2. GUARANTEED DROP: close the page. Google Meet's lobby often exposes no clickable Cancel
       //     (just "Asking to join…"), so closing the tab is the reliable way to abandon the request;

--- a/docs/changelog.d/542-leave-selector-fallbacks.md
+++ b/docs/changelog.d/542-leave-selector-fallbacks.md
@@ -1,0 +1,8 @@
+- **Google Meet leave: confirmation-dialog fallbacks work again, and the error spam is gone (#542).**
+  The browser-context leave click fed Playwright-only `:has-text()` selectors to
+  `document.querySelector`, so every dialog-confirmation fallback ("Leave meeting", "Just leave
+  the meeting", dialog-scoped Leave/End) was silently dead, and each leave attempt logged a burst
+  of `not a valid selector` errors that read like join failures (#432). Leave buttons are now
+  matched in-page with plain CSS plus real text matching, and the selector-validity gate
+  CSS-parses every array declared browser-context, so this class of dead selector fails CI
+  loudly instead of shipping green.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.43
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       tsx:
         specifier: ^4.19.0
         version: 4.22.4


### PR DESCRIPTION
Delivers #542 (W2, good-first). `Refs #542` not `Closes` — the live-leave leg stays open per the acceptance table.

## Mechanism
`googleLeaveSelectors` → `googleLeaveButtonMatchers` (`{css|text}` fork, priority order preserved); one canonical `googleLeaveBrowserClick` shipped via `page.evaluate` by both consumers (direct + injected hook); dead selector arrays removed; **selector-validity gate gains LANE 2**: declared browser-context arrays CSS-parsed via jsdom, with a baked-in `:has-text()` negative control so the class can never go blind again.

## Observation bundle (issue's numbering)
| Row | Status | Evidence |
|---|---|---|
| A1 dialog-fallback works | **desk red→green** | base: fixture → `false`, 10/20 selectors threw; head: clicked, 0 selector errors — verified in REAL Chromium, both paths (`direct → clicked: just-leave`, `injected-hook → clicked: just-leave`) |
| A2 gate sees the class | **desk red→green** | base gate: `356 valid, 0 invalid` (blind); planted `:has-text()` → `INVALID(css)… exit 1` |
| A3 suites+gates | **green** (live leave pending) | join suite `10·14·6·12·11·6·6 passed, 0 failed`; new `leave.test.ts` 14/14; `gates.mjs all` ✅ (one environmental rerun, stale gate container, cleaned) |
| live leave | **pending witness** | operator smoke on Lite/compose + non-author validation |

## Finds beyond the prep (recorded)
- **Real mechanism bug invisible to in-process tests:** tsx/esbuild wraps nested functions in `__name`, breaking `page.evaluate` serialization — caught by the live-Chromium probe, fixed with an identity shim.
- `googleSecondaryLeaveButtonSelectors` was also dead — removed. Google's injected `performLeaveAction` has no in-tree caller (kept per prep).
- msteams/zoom/jitsi leave paths share the pattern — follow-up candidate, not smuggled into this diff.