### PR TITLE
feat(gmeet): every segment carries the STT-detected window language (#523)

### DIFF
--- a/core/meetings/modules/gmeet-pipeline/src/gmeet-pipeline.ts
+++ b/core/meetings/modules/gmeet-pipeline/src/gmeet-pipeline.ts
@@ -59,23 +59,30 @@ export function createGmeetPipeline(opts: GmeetPipelineOptions): GmeetPipeline {
   // Emit the SEALED transcript.v1 shape (snake_case, segment_id + completed, source
   // in the contract's enum) — the pipeline IS the transcript.v1 producer, so its
   // output conforms to meetings/contracts/transcript.v1 (pinned by the replay golden).
-  const segOf = (speakerName: string, key: string, text: string, startMs: number, endMs: number, completed: boolean): TranscriptSegment => {
+  const segOf = (speakerName: string, key: string, text: string, startMs: number, endMs: number, completed: boolean, lang?: string): TranscriptSegment => {
     const named = speakerName !== UNKNOWN;
     return {
       segment_id: `${key}:${Math.round(startMs)}`,
       speaker: speakerName, speaker_key: key, text,
       start: startMs / 1000, end: endMs / 1000, completed, words: [],
+      language: lang ?? null,
       source: named ? 'glow-bound' : 'provisional-cluster-id',
       confidence: named ? 1 : 0,
     };
   };
+
+  // The window's language off the stt.v1 result: the per-call detection in auto mode, or the
+  // invocation-forced code (baked into the transcribe closure, echoed back by the service).
+  // 'unknown' is the client's no-detection sentinel, not an ISO code — NULL stays honest.
+  const langOf = (l: string | undefined): string | undefined =>
+    l && l !== 'unknown' ? l : undefined;
 
   mgr.onSegmentReady = (speakerId, _name, audio) => {
     const p = (async () => {
       try {
         const r = await opts.transcribe(audio, mgr.getLastConfirmedText(speakerId) || undefined);
         const segs = r?.segments;
-        mgr.handleTranscriptionResult(speakerId, (r?.text || '').trim(), segs?.[segs.length - 1]?.end, segs);
+        mgr.handleTranscriptionResult(speakerId, (r?.text || '').trim(), segs?.[segs.length - 1]?.end, segs, langOf(r?.language));
       } catch (e) {
         opts.onError?.(e);                          // P18: report the fault, don't swallow it…
         mgr.handleTranscriptionResult(speakerId, '');   // …but still free the turn (graceful degrade)
@@ -85,12 +92,12 @@ export function createGmeetPipeline(opts: GmeetPipelineOptions): GmeetPipeline {
     void p.finally(() => inflight.delete(p));
   };
 
-  mgr.onSegmentConfirmed = (speakerId, speakerName, text, startMs, endMs) => {
+  mgr.onSegmentConfirmed = (speakerId, speakerName, text, startMs, endMs, _segmentId, lang) => {
     if (!text.trim()) return;
-    opts.sink.segment(segOf(speakerName, speakerId, text, startMs, endMs, true));
+    opts.sink.segment(segOf(speakerName, speakerId, text, startMs, endMs, true, lang));
   };
-  mgr.onSegmentPending = (speakerId, speakerName, text, startMs) => {
-    opts.sink.draft?.({ ...segOf(speakerName, speakerId, text, startMs, startMs, false), confidence: 0 });
+  mgr.onSegmentPending = (speakerId, speakerName, text, startMs, lang) => {
+    opts.sink.draft?.({ ...segOf(speakerName, speakerId, text, startMs, startMs, false, lang), confidence: 0 });
   };
 
   const settle = async () => { while (inflight.size) await Promise.all([...inflight]); };

--- a/core/meetings/modules/gmeet-pipeline/src/pipeline-conformance.test.ts
+++ b/core/meetings/modules/gmeet-pipeline/src/pipeline-conformance.test.ts
@@ -76,6 +76,13 @@ async function run() {
   check("sealed snake_case shape: segment_id + speaker_key strings",
     segments.every((s) => typeof s.segment_id === "string" && typeof s.speaker_key === "string"));
 
+  // The fixture-range rule (P8 / D-A2): `language` is nullable in the schema, so schema
+  // conformance alone never discriminates on it — this golden REQUIRES the populated case.
+  // The stub STT detects "en" per window; every emitted segment must carry that detection.
+  check("every segment carries the STT-detected window language (\"en\", not null/undefined)",
+    segments.every((s) => s.language === "en"),
+    JSON.stringify(segments.map((s) => [s.speaker, s.language])));
+
   if (failed) { console.error(`\n❌ pipeline-conformance: ${failed} checks FAILED.`); process.exit(1); }
   console.log(`\n✅ pipeline-conformance: gmeet pipeline emits SEALED transcript.v1 offline — names carried, source/confidence correct, every segment schema-valid.`);
 }

--- a/core/meetings/modules/gmeet-pipeline/src/speaker-streams.ts
+++ b/core/meetings/modules/gmeet-pipeline/src/speaker-streams.ts
@@ -58,6 +58,10 @@ interface SpeakerBuffer {
    *  finalized (re-emitted confirmed under the same id) or the buffer fully resets.
    *  A turn-close uses it to FINALIZE the draft so it never lingers as completed:false. */
   pendingDraftText: string;
+  /** STT-detected (or invocation-forced, echoed by the service) language of the most recently
+   *  accepted transcription result — stamped on every segment this buffer emits. Undefined until
+   *  the first accepted result: undetected stays honest (never defaulted to 'en' here). */
+  lastLanguage?: string;
   /** windowStartMs the outstanding pending draft was published under — its segment id.
    *  Finalizing re-emits the confirmed under THIS exact start so the consumer's
    *  upsert-by-id replaces the pending row (rather than appending a new id and
@@ -111,13 +115,13 @@ export class SpeakerStreamManager {
   onSegmentReady: ((speakerId: string, speakerName: string, audioBuffer: Float32Array) => void) | null = null;
 
   /** Called when a segment is confirmed and should be published. */
-  onSegmentConfirmed: ((speakerId: string, speakerName: string, transcript: string, bufferStartMs: number, bufferEndMs: number, segmentId: string) => void) | null = null;
+  onSegmentConfirmed: ((speakerId: string, speakerName: string, transcript: string, bufferStartMs: number, bufferEndMs: number, segmentId: string, language?: string) => void) | null = null;
 
   /** Called with the UNCONFIRMED forming tail after each submission (the "pending"
    *  draft) — parity with ChunkedTranscriber's publishPending, so the multistream
    *  (gmeet per-participant) path shows a live forming tail like the mixed path,
    *  not just confirmed text. Empty string ⇒ clear the speaker's draft. */
-  onSegmentPending: ((speakerId: string, speakerName: string, text: string, bufferStartMs: number) => void) | null = null;
+  onSegmentPending: ((speakerId: string, speakerName: string, text: string, bufferStartMs: number, language?: string) => void) | null = null;
 
   constructor(config?: SpeakerStreamManagerConfig) {
     this.minAudioDuration = config?.minAudioDuration ?? 2;
@@ -233,7 +237,7 @@ export class SpeakerStreamManager {
    *          draft for a rejected result — its text describes audio this
    *          buffer no longer owns.
    */
-  handleTranscriptionResult(speakerId: string, transcript: string, segmentEndSec?: number, segments?: WhisperSegment[]): boolean {
+  handleTranscriptionResult(speakerId: string, transcript: string, segmentEndSec?: number, segments?: WhisperSegment[], language?: string): boolean {
     const buffer = this.buffers.get(speakerId);
     if (!buffer) return false;
 
@@ -247,6 +251,10 @@ export class SpeakerStreamManager {
     if (submitGen !== undefined && submitGen < buffer.generation) {
       return false;
     }
+
+    // The window's language (STT-detected, or the forced code the service echoes back). Stamped
+    // now — before any emit path below — so the very confirm this result triggers carries it.
+    if (language) buffer.lastLanguage = language;
 
     // Segmentation closed this buffer while this request was in flight: the
     // text covers the pre-trim window (may include the next segment's audio).
@@ -347,7 +355,7 @@ export class SpeakerStreamManager {
               continue;
             }
             const segmentId = `${buffer.speakerId}:${buffer.sequenceNumber}`;
-            this.onSegmentConfirmed(buffer.speakerId, buffer.speakerName, seg.text.trim(), buffer.windowStartMs, segEndMs, segmentId);
+            this.onSegmentConfirmed(buffer.speakerId, buffer.speakerName, seg.text.trim(), buffer.windowStartMs, segEndMs, segmentId, buffer.lastLanguage);
             buffer.sequenceNumber++;
             buffer.lastConfirmedText = seg.text.trim();
           }
@@ -380,7 +388,7 @@ export class SpeakerStreamManager {
       // instead of leaving a dangling completed:false.
       buffer.pendingDraftText = trimmed;
       buffer.pendingDraftStartMs = buffer.windowStartMs;
-      this.onSegmentPending(buffer.speakerId, buffer.speakerName, trimmed, buffer.windowStartMs);
+      this.onSegmentPending(buffer.speakerId, buffer.speakerName, trimmed, buffer.windowStartMs, buffer.lastLanguage);
     }
     return true;
   }
@@ -536,7 +544,7 @@ export class SpeakerStreamManager {
       const endMs = buffer.totalSamples > 0
         ? buffer.windowStartMs + (buffer.totalSamples / this.sampleRate) * 1000
         : startMs;
-      this.onSegmentConfirmed(buffer.speakerId, buffer.speakerName, text, startMs, endMs, `${buffer.speakerId}:${buffer.sequenceNumber}`);
+      this.onSegmentConfirmed(buffer.speakerId, buffer.speakerName, text, startMs, endMs, `${buffer.speakerId}:${buffer.sequenceNumber}`, buffer.lastLanguage);
       buffer.sequenceNumber++;
       buffer.lastConfirmedText = text;
     } else if (this.onSegmentPending) {
@@ -674,7 +682,7 @@ export class SpeakerStreamManager {
       ? buffer.windowStartMs + (buffer.totalSamples / this.sampleRate) * 1000
       : Date.now();
     const segmentId = `${buffer.speakerId}:${buffer.sequenceNumber}`;
-    this.onSegmentConfirmed(buffer.speakerId, buffer.speakerName, text, buffer.windowStartMs, endMs, segmentId);
+    this.onSegmentConfirmed(buffer.speakerId, buffer.speakerName, text, buffer.windowStartMs, endMs, segmentId, buffer.lastLanguage);
     buffer.sequenceNumber++;
     buffer.lastConfirmedText = text;
     // This confirmed segment supersedes the outstanding pending draft. If it went out under a

--- a/docs/changelog.d/523-meet-segment-language.md
+++ b/docs/changelog.d/523-meet-segment-language.md
@@ -1,0 +1,6 @@
+- **Google Meet segments now carry a real `language` (#523).** The Meet lane stamps the
+  STT-detected (or forced) language of each transcription window onto its segments, so
+  `GET /transcripts/...` labels Meet segments the same way Zoom/Teams always did — mixed-language
+  meetings read truthfully instead of `null`. The language contract (auto vs forced mode,
+  window-level granularity) is now documented in [Send a bot](/how-to/send-a-bot) and the
+  [Meetings API](/api/meetings#send-a-bot-to-a-meeting).

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -195,7 +195,13 @@ the secret address.
 <ParamField body="platform" type="string" required>`google_meet` · `zoom` · `teams`</ParamField>
 <ParamField body="native_meeting_id" type="string" required>The meeting id from the join URL (e.g. `abc-defg-hij`).</ParamField>
 <ParamField body="bot_name" type="string">Display name the bot uses in the call. Defaults to `Vexa`.</ParamField>
-<ParamField body="language" type="string">ISO code (e.g. `en`); omit to auto-detect.</ParamField>
+<ParamField body="language" type="string">ISO code (e.g. `en`). **Omitted** = auto mode: each STT
+window's language is detected independently and stamped on its segments' `language` field. **Set** =
+forced mode: every STT call is pinned to this code and every segment carries it. Granularity is the
+transcription window (a few seconds of one speaker's audio), not word-level; in auto mode a
+low-confidence detection on the Zoom/Teams (mixed-audio) lane discards the window rather than
+guessing. Undetermined windows yield `language: null`. (0.10's `allowed_languages` is not part of
+the 0.12 API.)</ParamField>
 <ParamField body="task" type="string">`transcribe` (default) or `translate`.</ParamField>
 
 ```bash POST /bots

--- a/docs/docs/comparison.mdx
+++ b/docs/docs/comparison.mdx
@@ -35,6 +35,7 @@ attribution, scaling.
 | Fully **air-gapped** (bundled self-hosted GPU STT unit) | ✅ | 🟡 BYO STT wiring | ❌ | 🟡 local models | 🟡 build it |
 | Bot joins **Meet + Teams + Zoom + Jitsi** | ✅ | ✅ | ✅ | ❌ device audio | 🟡 build ×3 |
 | Real-time transcript API, speaker-attributed | ✅ | ✅ | ✅ | 🟡 app-local | 🟡 build it |
+| 99+ languages: auto-detect or forced, per-window segment labels | ✅ | 🟡 provider-dependent | ✅ | 🟡 model-dependent | 🟡 build it |
 | **Bring your own models** (STT + LLM endpoints) | ✅ | 🟡 STT providers | ❌ | ✅ | ✅ |
 | Kubernetes / OpenShift scale-out (Helm, a Pod per workload) | ✅ | 🟡 compose-first | n/a | ❌ | 🟡 build it |
 | Knowledge layer: transcripts → git Markdown workspace + sandboxed agents | ✅ | ❌ | ❌ | 🟡 app notes | ❌ |

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -72,6 +72,8 @@ runs GPU-free and anywhere, and the STT service is its own deploy unit at
 [`deploy/transcription`](https://github.com/Vexa-ai/vexa/tree/main/deploy/transcription)
 ([`core/meetings/services/transcription`](https://github.com/Vexa-ai/vexa/tree/main/core/meetings/services/transcription)
 is the brick — faster-whisper / CTranslate2 behind an OpenAI-compatible `/v1/audio/transcriptions`).
+Language is detected per transcription window and stamped on each segment; force a single language
+via the bot request's `language` (see [Send a bot](/how-to/send-a-bot)).
 
 Stand it up wherever a GPU lives (the same host or a dedicated GPU box):
 

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -45,7 +45,16 @@ The only thing that changes between platforms is the `platform` value.
 
 `native_meeting_id` is the id **inside** the join URL (e.g. `abc-defg-hij` for Meet, the room name for
 Jitsi), not the whole URL.
-Optional: `language` (ISO code, omit to auto-detect) and `task` (`transcribe` default, or `translate`).
+Optional: `language` (ISO code) and `task` (`transcribe` default, or `translate`). Language works in
+two modes:
+
+- **Auto (omit `language`)** — the STT unit detects the language of each transcription window
+  independently, and every segment carries the detected code in its `language` field.
+- **Forced (`language: "es"`)** — every STT call is pinned to that language; every segment carries it.
+
+Detection is **per window** (one STT call, a few seconds of one speaker's audio), not per word:
+code-switching *within* a window takes the window's language; switching between utterances lands on
+the segment boundary. A window whose language could not be determined has `language: null`.
 
 On Meet and Teams the bot may wait in the lobby until a host admits it; a Jitsi room with the
 lobby enabled behaves the same way.
@@ -82,14 +91,16 @@ of polling, subscribe over **WebSocket** — see the [Meetings API](/api/meeting
 ## 3. Manage and stop
 
 ```bash
-# switch to live Spanish translation mid-call
-curl -X PUT "$API_BASE/bots/google_meet/abc-defg-hij/config" \
-  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
-  -d '{"language":"es","task":"translate"}'
-
 # stop the bot / leave the call
 curl -X DELETE "$API_BASE/bots/google_meet/abc-defg-hij" -H "X-API-Key: $API_KEY"
 ```
+
+<Note>
+Mid-call reconfiguration (`PUT …/config`, change language/task while the bot is in the call) rides
+the live bot-control plane and is **not yet wired in the v0.12 open-core stack** — it currently
+returns `404`. Set `language` and `task` on the `POST /bots` spawn. See the
+[Meetings API](/api/meetings#manage-the-bot).
+</Note>
 
 The audio **recording** lands in your object storage — retrieve it via `GET /recordings`
 ([Meetings API](/api/meetings#recordings)).


### PR DESCRIPTION
Refs #523. From the autonomous session, with adversarial verification by a second agent (verdict: sound diff, live-leg asks).

## The mechanism
`speaker-streams.ts` — `SpeakerBuffer.lastLanguage`; `handleTranscriptionResult` gains a `language` param, stamped at result-accept **before any emit path**; all 3 `onSegmentConfirmed` sites + the pending-draft publish carry it (trailing optional params, backward-compatible). `gmeet-pipeline.ts` — call site passes `r.language` (`'unknown'` sentinel → undefined, NULL stays honest, no `'en'` default); `segOf` gains `language: lang ?? null`. Forced mode rides the existing client fallback `data.language || language` (transcription-client.ts:274), so `forced || detected` holds without new plumbing. Bot mapper (services/bot/src/pipeline.ts:70) and collector (ingest.py:95) already pass through — no change; live-wire `'en'` filler (ingest.py:129) kept per the issue's open maintainer ruling. No contract edit — `language` is already nullable in sealed transcript.v1.

Docs surface (all four pages named by D6c moved): send-a-bot.mdx (two language modes + mid-call translate example replaced with the not-yet-wired 404 Note), api/meetings.mdx (language ParamField mode semantics), comparison.mdx (language capability row), deployment.mdx (per-window detection one-liner). Changelog via fragment `docs/changelog.d/523-meet-segment-language.md` — no hot files touched.

## Observation bundle (issue's numbering)
| Row | Status | Evidence |
|---|---|---|
| A1 live Meet auto (Lite) | **pending witness** | mechanism + replay-golden red→green cover the code leg; the live `GET /transcripts` leg needs a Lite rig meeting |
| A2 forced `es` | **pending witness** | plumbing verified in code (forced code baked into transcribe closure, echoed via `result.language`, same stamp path); live leg pending |
| A3 mixed-lane no-regression | **pending witness** (live corroboration) | covered at unit altitude: chunked-transcriber.ts untouched, mixed-pipeline suite green |
| A4 docs move with the diff | **done** (validator docs-story attestation pending) | all four pages in the diff; fragment as docs-current touch |
| A- no-regression CI | **done** | gmeet-pipeline, @vexa/bot, mixed-pipeline suites + `gates.mjs all` green at head |

Red→green (A4/A-, replay golden, pipeline-conformance):
- RED on base: `❌ every segment carries the STT-detected window language ("en", not null/undefined) — [["Alice",null],["Bob",null],["Speaker",null]]`
- GREEN at head: `✅ every segment carries the STT-detected window language ("en", not null/undefined)`

The adversarial verifier independently reverted gmeet-pipeline.ts + speaker-streams.ts to main and reproduced the red, confirming the new conformance check is a true discriminator.

## Findings / era drift (vs issue sha 0080471a)
- speaker-streams.ts lines shifted (#617 silence-gate landed): `handleTranscriptionResult` now :236, confirm callbacks :114/:350; three confirm emit sites exist, all stamped.
- A4's mid-call-config truth marker at api/meetings.mdx already exists on main (~:261); send-a-bot.mdx still promised the dead mid-call translate behavior — fixed there.
- ingest.py filler is at :129 not :108 (kept per the issue's open ruling).
- Design call for ruling: the `'unknown'` sentinel from transcription-client is mapped to NULL at the lane, not stamped; the mixed lane would stamp `'unknown'` in the same case (pre-existing, untouched).
- `task:translate` example removed via the Note rather than documenting translate semantics — no maintainer ruling recorded on the issue.
- Prob-gate port from mixed lane to gmeet was NOT done (optional extra value per the issue).

## Honest asks
1. A1/A2/A3 live legs need a Lite rig run (meeting ids, response excerpts, base+head shas) — the offline golden alone does not satisfy the table; hence Refs, not Closes.
2. A4 needs the validator's docs-story attestation per D6c.
3. Optional hardening (verifier's note): the conformance check covers only completed segments; the pending-draft stamp path (speaker-streams.ts:391) is exercised but not asserted.
