### PR TITLE
fix(terminal): error truth at every surface — presentError seam + WS-gated bot controls (#533, #674)

### DIFF
--- a/clients/terminal/src/surfaces/README.md
+++ b/clients/terminal/src/surfaces/README.md
@@ -12,3 +12,12 @@ RECENT ACTIVITY feed (email-attributed, clickable files), the "new updates" nav 
 (`updatesBadge.ts` + the Workbench poll), doc auto-reload + one-click **Changes** diff, README
 auto-pin on shared connect, and the Share/invite dialog (single-rank). The end-to-end model is in
 **[`docs/docs/core/workspaces.mdx`](../../../../docs/docs/core/workspaces.mdx)**.
+
+**Error presentation is part of the surface contract** — surfaces render `presentError(e)`
+(`apiClient.ts`), never `e.message`: the headline is user vocabulary ("Couldn't reach the Vexa
+server…", the backend's own prose reason verbatim when it sent one), while the untranslated
+plumbing string stays on the operator channels (the returned `detail` and a `console.warn`). The
+raw idiom `e instanceof Error ? e.message : String(e)` is banned from surface files by
+`__tests__/errorPresentation.guard.test.ts`. State-bearing controls (the meeting header's
+Stop/Send bot) additionally follow the live ws.v1 connection (`useLiveMeetingsConnection`):
+disconnected → indeterminate/disabled, never an actionable control derived from a stale snapshot.

--- a/clients/terminal/src/surfaces/__tests__/errorPresentation.guard.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/errorPresentation.guard.test.ts
@@ -1,0 +1,26 @@
+/** Grep-guard (issue #533 C3): no surface renders the raw error idiom
+ *  `e instanceof Error ? e.message : String(e)` — surfaces render `presentError(e)`, never
+ *  `e.message`. This is the terminal twin of #508's C2 pattern: the 46th site cannot land
+ *  silently. The one legal home for raw plumbing is the presenter itself (apiClient.ts).
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SURFACES_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+// The raw idiom in any spelling of the binding: `x instanceof Error ? x.message : String(x)`.
+const RAW_IDIOM = /(\w+) instanceof Error \? \1\.message : String\(\1\)/;
+
+describe("error presentation guard", () => {
+  it("no surface file contains the raw error-render idiom", () => {
+    const offenders: string[] = [];
+    for (const f of readdirSync(SURFACES_DIR)) {
+      if (!/\.(ts|tsx)$/.test(f)) continue;
+      const src = readFileSync(join(SURFACES_DIR, f), "utf8");
+      const m = src.match(RAW_IDIOM);
+      if (m) offenders.push(`${f}: ${m[0]}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/clients/terminal/src/surfaces/__tests__/liveMeetings.store.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/liveMeetings.store.test.tsx
@@ -140,6 +140,31 @@ describe("liveMeetings store", () => {
     expect(snapshotCalls.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("(e) exposes WS connected-ness: open → true, close → false (stale rows are never silently 'live truth'), reopen → true + re-snapshot", async () => {
+    const { mod, hook } = await startStore();
+    const conn = renderHook(() => mod.useLiveMeetingsConnection());
+    await waitFor(() => expect(conn.result.current).toBe(true));
+
+    // Drive the WS down while an active-looking row is seeded — the store must EXPOSE the drop.
+    await act(async () => {
+      FakeWebSocket.last!.onclose?.();
+    });
+    await waitFor(() => expect(conn.result.current).toBe(false));
+    // the rows themselves are still served (last snapshot) — but marked as not-live-truth
+    expect(hook.result.current.length).toBe(1);
+
+    // Reconnect restores connected AND re-snapshots (repairs any missed frame).
+    const before = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/api/meetings")).length;
+    await act(async () => {
+      FakeWebSocket.last!.onopen?.();
+    });
+    await waitFor(() => expect(conn.result.current).toBe(true));
+    await waitFor(() => {
+      const now = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/api/meetings")).length;
+      expect(now).toBeGreaterThan(before);
+    });
+  });
+
   it("(d) a 'deleted' frame REMOVES the row (a retired plan never masquerades as Recorded)", async () => {
     const { hook } = await startStore();
     expect(hook.result.current.length).toBe(1);

--- a/clients/terminal/src/surfaces/__tests__/meetingActions.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/meetingActions.test.tsx
@@ -93,20 +93,55 @@ describe("actionsFor — each action fires the correct endpoint+body", () => {
     expect(init.method).toBe("DELETE");
   });
 
-  it("active→Stop reports network failures instead of throwing", async () => {
+  it("active→Stop reports network failures instead of throwing — as user truth, raw on the console", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const onFailure = vi.fn();
     fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
 
     await expect(actionsFor(row("active")).find((a) => a.id === "stop")!.run(onFailure)).resolves.toBeUndefined();
 
+    // UI channel: the presented truth, never the fetch engine's message.
     expect(onFailure).toHaveBeenCalledWith({
       actionId: "stop",
       actionLabel: "Stop",
       native: NATIVE,
-      message: "Failed to fetch",
+      message: "Couldn't reach the Vexa server — check that the stack is running.",
     });
+    // Operator channel: the raw plumbing stays on the console (P18).
     expect(warn).toHaveBeenCalledWith("meeting action failed", expect.objectContaining({ actionId: "stop", message: "Failed to fetch" }));
+  });
+
+  it("a 404 on Stop yields the HUMAN no-longer-active message + a reconciling re-snapshot — never the raw JSON body (issue #674)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const onFailure = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: false, status: 404, statusText: "Not Found", url: `/api/bots/google_meet/${NATIVE}`,
+      json: async () => ({ detail: "No active meeting found for this bot in google_meet with ID abc-defg-hij" }),
+    } as unknown as Response);
+
+    await actionsFor(row("active")).find((a) => a.id === "stop")!.run(onFailure);
+
+    const { message } = onFailure.mock.calls[0][0];
+    expect(message).toBe("This meeting is no longer active — refreshing the list.");
+    expect(message).not.toContain("404");
+    expect(message).not.toContain("{");
+    // reconcile: the finally-path re-snapshot was requested so the control self-corrects
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/api/meetings"))).toBe(true);
+    // the raw upstream detail is preserved on the operator channel
+    expect(warn).toHaveBeenCalledWith("meeting action failed", expect.objectContaining({ message: expect.stringContaining("No active meeting found") }));
+  });
+
+  it("a 409 on Send maps to the human already-has-a-bot line", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const onFailure = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: false, status: 409, statusText: "Conflict", url: "/api/bots",
+      json: async () => ({ detail: "An active or requested meeting already exists" }),
+    } as unknown as Response);
+
+    await actionsFor(row("idle")).find((a) => a.id === "send")!.run(onFailure);
+
+    expect(onFailure.mock.calls[0][0].message).toBe("That meeting already has a bot.");
   });
 
   it("idle→Schedule PUTs intent:scheduled with an ISO `at`", () => {

--- a/clients/terminal/src/surfaces/__tests__/meetingHeaderControls.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/meetingHeaderControls.test.tsx
@@ -1,0 +1,55 @@
+/** Behavioral test for the meeting-header bot control's WS gating (issue #674 C1).
+ *
+ *  The header state and the control's enabled-ness are a pure function of (row status,
+ *  WS-connected): connected+active → Live + enabled "Stop bot"; disconnected → indeterminate
+ *  ("Reconnecting…") + DISABLED control — a stale-live snapshot can never present an actionable
+ *  "Stop bot"; no active meeting → the send/resend control.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { BotControls, meetingHeaderState } from "../meeting";
+import type { MeetingMock } from "../meetingModel";
+
+const NATIVE = "abc-defg-hij";
+
+function row(live_status: string, status: "live" | "past" = live_status === "active" ? "live" : "past"): MeetingMock {
+  return {
+    id: NATIVE, native_id: NATIVE, title: "Google Meet · " + NATIVE, when: "now",
+    status, live_status, platform: "Google Meet", has_recording: false,
+    docs: [], participants: [], mentioned: [], actions: [], transcript: [], insights: [],
+  } as MeetingMock;
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({}) }) as Response) as unknown as typeof fetch;
+});
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+describe("meetingHeaderState — pure (row, connected) → header", () => {
+  it("connected + live row → live", () => expect(meetingHeaderState(row("active"), true)).toBe("live"));
+  it("DISCONNECTED + live row → reconnecting (never a stale Live)", () => expect(meetingHeaderState(row("active"), false)).toBe("reconnecting"));
+  it("terminal row → recap (either way)", () => {
+    expect(meetingHeaderState(row("completed"), true)).toBe("recap");
+    expect(meetingHeaderState(row("completed"), false)).toBe("recap");
+  });
+  it("unresolved row → connecting", () => expect(meetingHeaderState(undefined, true)).toBe("connecting"));
+});
+
+describe("BotControls — enabled-ness follows WS connectivity", () => {
+  it("connected + active → 'Stop bot' enabled", () => {
+    render(<BotControls m={row("active")} connected={true} />);
+    const btn = screen.getByRole("button", { name: "Stop bot" });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+  it("disconnected + (stale) active → 'Stop bot' DISABLED with the reconnect hint", () => {
+    render(<BotControls m={row("active")} connected={false} />);
+    const btn = screen.getByRole("button", { name: "Stop bot" });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+    expect(btn.getAttribute("title")).toMatch(/reconnecting/i);
+  });
+  it("no active meeting (terminal row) → the send-again control, not Stop", () => {
+    render(<BotControls m={row("completed")} connected={true} />);
+    expect(screen.queryByRole("button", { name: "Stop bot" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Send bot again" })).toBeTruthy();
+  });
+});

--- a/clients/terminal/src/surfaces/__tests__/presentError.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/presentError.test.ts
@@ -1,0 +1,101 @@
+/** The presenter seam (issue #533): `presentError` maps a typed `ApiError`'s STRUCTURED fields to
+ *  user vocabulary; the untranslated plumbing string is always preserved on `detail` and echoed to
+ *  the console (P18's observable channel). The fixture range is the C1 inventory: one hand-authored
+ *  `ApiError` per failure class, each pinned to the user-truth headline it must show.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiError, presentError } from "../apiClient";
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+// C1 fixtures — the failure range, sanitized (localhost only, no real keys).
+const FIX = {
+  network: new ApiError(0, "Failed to fetch", "/api/user/calendar"),
+  gatewayDown: new ApiError(502, "upstream unreachable: ConnectError", "/api/vexa/user/calendar"),
+  upstreamTimeout: new ApiError(504, "upstream timeout", "/api/meetings"),
+  auth: new ApiError(401, "Invalid API key", "/api/tokens"),
+  scope: new ApiError(403, "Forbidden", "/api/admin/settings/models"),
+  validation422Json: new ApiError(422, '{"field":"ics_url","msg":"invalid url"}', "/api/user/calendar"),
+  rateLimit: new ApiError(429, "Bot concurrency limit reached", "/api/bots"),
+  // A typed backend detail that SHOULD pass through verbatim (the STT 503 —
+  // meeting-api bot_spawn/router.py: TranscriptionNotConfigured → 503 detail=str(e)).
+  typed503: new ApiError(503, "Transcription is not configured: set TRANSCRIPTION_SERVICE_URL or ask your operator", "/api/bots"),
+  emptyDetail: new ApiError(500, "", "/api/meetings"),
+};
+
+describe("presentError — ApiError → user truth (fixture range)", () => {
+  it("network (status 0) → couldn't reach the server", () => {
+    expect(presentError(FIX.network).headline).toBe("Couldn't reach the Vexa server — check that the stack is running.");
+  });
+  it("gateway-down 502 → backend-unreachable truth, NOT the plumbing string", () => {
+    const p = presentError(FIX.gatewayDown);
+    expect(p.headline).toBe("The Vexa server can't reach a backend service right now.");
+    expect(p.headline).not.toContain("502");
+    expect(p.headline).not.toContain("ConnectError");
+    expect(p.headline).not.toContain("/api/");
+  });
+  it("upstream-timeout 504 → same backend-unreachable truth", () => {
+    expect(presentError(FIX.upstreamTimeout).headline).toBe("The Vexa server can't reach a backend service right now.");
+  });
+  it("auth 401 → key rejected, sign in again", () => {
+    expect(presentError(FIX.auth).headline).toBe("Your API key was rejected — sign in again.");
+  });
+  it("scope 403 → no access", () => {
+    expect(presentError(FIX.scope).headline).toBe("Your key doesn't have access to this.");
+  });
+  it("validation 422 with a JSON payload detail → generic (payloads are operator-only)", () => {
+    const p = presentError(FIX.validation422Json);
+    expect(p.headline).toBe("The request failed (422).");
+    expect(p.headline).not.toContain("{");
+  });
+  it("rate-limit 429 → rate limit truth", () => {
+    expect(presentError(FIX.rateLimit).headline).toBe("Rate limit hit — try again in a moment.");
+  });
+  it("A3: a typed backend 503 detail passes through VERBATIM — never genericized", () => {
+    expect(presentError(FIX.typed503).headline).toBe(FIX.typed503.detail);
+  });
+  it("non-JSON body (empty detail) → generic with the status", () => {
+    expect(presentError(FIX.emptyDetail).headline).toBe("The request failed (500).");
+  });
+});
+
+describe("presentError — loudness no-regression (A4, P18)", () => {
+  it("the plumbing string is preserved intact on `detail` for every fixture", () => {
+    for (const e of Object.values(FIX)) {
+      expect(presentError(e).detail).toBe(e.message);
+    }
+  });
+  it("the console channel carries the full plumbing string", () => {
+    presentError(FIX.gatewayDown);
+    expect(console.warn).toHaveBeenCalledWith("api failure", FIX.gatewayDown.message);
+  });
+  it("presentation never mutates the error: ApiError.status/detail/url/message unchanged", () => {
+    const e = FIX.gatewayDown;
+    presentError(e);
+    expect(e.status).toBe(502);
+    expect(e.detail).toBe("upstream unreachable: ConnectError");
+    expect(e.url).toBe("/api/vexa/user/calendar");
+    expect(e.message).toBe("/api/vexa/user/calendar → 502: upstream unreachable: ConnectError");
+  });
+});
+
+describe("presentError — non-ApiError failures", () => {
+  it("a fetch()-level TypeError reads as the network truth", () => {
+    expect(presentError(new TypeError("Failed to fetch")).headline).toBe("Couldn't reach the Vexa server — check that the stack is running.");
+  });
+  it("a prose Error message (a client edge's own user-facing reason) passes through", () => {
+    expect(presentError(new Error("That doesn't look like a valid ICS address.")).headline).toBe("That doesn't look like a valid ICS address.");
+  });
+  it("a payload-shaped Error message → generic", () => {
+    const p = presentError(new Error('{"detail":"boom"}'));
+    expect(p.headline).toBe("Something went wrong — details are in the browser console.");
+    expect(p.detail).toBe('{"detail":"boom"}');
+  });
+  it("a non-Error throw → generic, stringified on detail", () => {
+    const p = presentError("boom");
+    expect(p.headline).toBe("Something went wrong — details are in the browser console.");
+    expect(p.detail).toBe("boom");
+  });
+});

--- a/clients/terminal/src/surfaces/apiClient.ts
+++ b/clients/terminal/src/surfaces/apiClient.ts
@@ -19,6 +19,54 @@ export class ApiError extends Error {
   }
 }
 
+/** What a surface renders for a failure: the user-truth headline + the full plumbing string.
+ *  `headline` is user vocabulary; `detail` is the untranslated fault (ApiError.message / the raw
+ *  error text) for the operator channel — a `title=` affordance and the browser console. */
+export interface PresentedError { headline: string; detail: string }
+
+const NETWORK_HEADLINE = "Couldn't reach the Vexa server — check that the stack is running.";
+const GENERIC_HEADLINE = "Something went wrong — details are in the browser console.";
+
+// A fetch()-level network failure surfaces as one of these engine-specific messages.
+const NETWORK_MESSAGE = /failed to fetch|networkerror|load failed|network request failed/i;
+
+/** Is a backend `detail` a human sentence we can show verbatim (the backend's own user-facing
+ *  reason), rather than a serialized payload? Deliberately conservative: prose has a space and
+ *  doesn't open like JSON/markup. */
+function isProse(detail: string): boolean {
+  const t = detail.trim();
+  return t.length > 0 && t.length <= 300 && !/^[{[<]/.test(t) && t.includes(" ");
+}
+
+/** The presenter seam (issue #533): every terminal surface renders `presentError(e).headline`,
+ *  never `e.message`. Maps the STRUCTURED fields of an `ApiError` to user vocabulary; the typed
+ *  plumbing is preserved intact on the returned `detail` AND echoed to the console (P18's
+ *  observable channel keeps the full string — presentation never mutates the error). */
+export function presentError(e: unknown): PresentedError {
+  if (e instanceof ApiError) {
+    const detail = e.message;
+    console.warn("api failure", detail);
+    if (e.status === 0) return { headline: NETWORK_HEADLINE, detail };
+    if (e.status === 502 || e.status === 504) return { headline: "The Vexa server can't reach a backend service right now.", detail };
+    if (e.status === 401) return { headline: "Your API key was rejected — sign in again.", detail };
+    if (e.status === 403) return { headline: "Your key doesn't have access to this.", detail };
+    if (e.status === 429) return { headline: "Rate limit hit — try again in a moment.", detail };
+    // Remaining 4xx/5xx: a prose `detail` is the backend's own user-facing reason — pass it
+    // through VERBATIM (e.g. a typed transcription 503). A payload-shaped detail stays operator-only.
+    if (isProse(e.detail)) return { headline: e.detail.trim(), detail };
+    return { headline: `The request failed (${e.status}).`, detail };
+  }
+  if (e instanceof Error) {
+    const detail = e.message || String(e);
+    console.warn("api failure", detail);
+    if (NETWORK_MESSAGE.test(detail)) return { headline: NETWORK_HEADLINE, detail };
+    return isProse(detail) ? { headline: detail.trim(), detail } : { headline: GENERIC_HEADLINE, detail };
+  }
+  const detail = String(e);
+  console.warn("api failure", detail);
+  return { headline: GENERIC_HEADLINE, detail };
+}
+
 /** GET/POST… JSON, loud on failure. status 0 = the request never completed (network/DNS/abort). */
 export async function getJson<T = unknown>(url: string, init?: RequestInit): Promise<T> {
   const method = (init?.method || "GET").toUpperCase();

--- a/clients/terminal/src/surfaces/liveMeetings.ts
+++ b/clients/terminal/src/surfaces/liveMeetings.ts
@@ -129,6 +129,7 @@ function formatTranscriptTime(start?: number | null): string {
 const LIVE_STATUSES = new Set(["active", "joining", "requested", "awaiting_admission", "needs_help", "stopping"]);
 
 let meetings: MeetingMock[] = [];
+let wsConnected = false;   // the live meeting.status stream's connection state — part of the store's external state
 const subs = new Set<() => void>();
 let started = false;
 let wsUnsub: (() => void) | null = null;
@@ -259,6 +260,13 @@ function ensureStarted() {
   void snapshot();                          // initial snapshot on mount
   wsUnsub = onMeetingStatus(applyFrame);    // then live status deltas over the gateway WS
   connUnsub = onGatewayWSConnected((ok) => {
+    // Propagate connected-ness into the store's external state: consumers (the meeting header's
+    // bot controls) must know when the rows are a possibly-stale snapshot rather than live truth
+    // (issue #674) — a disconnected store never silently serves stale rows as current.
+    if (wsConnected !== ok) {
+      wsConnected = ok;
+      subs.forEach((f) => f());
+    }
     if (ok) void snapshot();
   });
 }
@@ -311,6 +319,18 @@ export function liveMeetingsNow(): MeetingMock[] {
  *  list reflects the new status immediately, even before the echoing WS frame lands. */
 export function refreshMeetings(): void {
   void snapshot();
+}
+
+/** Subscribe a component to the live `meeting.status` stream's CONNECTION state. `false` means the
+ *  rows are the last snapshot, not live truth — state-bearing controls (Stop bot …) must degrade
+ *  to indeterminate/disabled until it is `true` again (ws.v1 is the authoritative state channel). */
+export function useLiveMeetingsConnection(): boolean {
+  ensureStarted();
+  return useSyncExternalStore(
+    (cb) => { subs.add(cb); return () => subs.delete(cb); },
+    () => wsConnected,
+    () => false,
+  );
 }
 
 /** Subscribe a component to the meetings feed (live + past). */

--- a/clients/terminal/src/surfaces/meeting.tsx
+++ b/clients/terminal/src/surfaces/meeting.tsx
@@ -11,7 +11,8 @@ import { Icon } from "../ui-kit";
 import { ContextMenu, copyText } from "../ui-kit/ContextMenu";
 import { MEETING_CANVAS_CONTENT_INSET, MeetingCanvasView } from "../canvas/MeetingCanvasView";
 import { type MeetingMock } from "./meetingModel";
-import { useLiveMeetings, liveMeetingsNow, refreshMeetings } from "./liveMeetings";
+import { ApiError, presentError } from "./apiClient";
+import { useLiveMeetings, useLiveMeetingsConnection, liveMeetingsNow, refreshMeetings } from "./liveMeetings";
 import { usePreviewPinTab } from "./previewPinTab";
 import { parseMeetingInput } from "./meetingId";
 import { getJitsiHosts } from "./jitsiHosts";
@@ -55,7 +56,7 @@ function ShareSessionButton({ platform, native }: { platform: string; native: st
         params.set("invite", inv.token);
       }
       setLink(`${window.location.origin}/?${params.toString()}`);
-    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    } catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
   const fieldStyle = { fontSize: 12, padding: "4px 6px", background: "var(--panel)", border: "1px solid var(--line)", borderRadius: 6, color: "var(--t1)" } as const;
@@ -278,27 +279,37 @@ type MeetingActionFailure = { actionId: string; actionLabel: string; native: str
 type MeetingActionFailureHandler = (failure: MeetingActionFailure) => void;
 type RowAction = { id: string; label: string; tone: "accent" | "live" | "muted"; run: (onFailure?: MeetingActionFailureHandler) => Promise<void> | void };
 
-function failureMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  if (typeof error === "string" && error.trim()) return error.trim();
-  return "Request failed";
+/** A non-ok action response as a STRUCTURED failure (status + backend detail), never a raw body. */
+async function readFailure(r: Response): Promise<ApiError> {
+  let detail = "";
+  try {
+    const b = (await r.json()) as { detail?: unknown; error?: unknown };
+    const d = b?.detail ?? b?.error;
+    detail = typeof d === "string" ? d : d != null ? JSON.stringify(d).slice(0, 200) : "";
+  } catch { /* body wasn't JSON — the status alone is the signal */ }
+  return new ApiError(r.status, detail, r.url);
 }
 
-async function readFailure(r: Response): Promise<string> {
-  const detail = (await r.text().catch(() => "")).trim().replace(/\s+/g, " ");
-  const status = `${r.status}${r.statusText ? ` ${r.statusText}` : ""}`;
-  if (!detail) return status;
-  return `${status}: ${detail.slice(0, 180)}`;
+/** User-truth message for a failed bot/row action (issue #674): a `404` means the backend no
+ *  longer has this meeting — the list re-snapshot (runMeetingAction's `finally`) reconciles the
+ *  control, so say that; a `409` is the duplicate/already case. Everything else goes through the
+ *  presenter seam. Exported (additive) so the action test pins the vocabulary. */
+export function presentMeetingActionFailure(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 404) return "This meeting is no longer active — refreshing the list.";
+    if (error.status === 409) return "That meeting already has a bot.";
+  }
+  return presentError(error).headline;
 }
 
 async function runMeetingAction(action: Omit<MeetingActionFailure, "message">, request: Promise<Response>, onFailure?: MeetingActionFailureHandler): Promise<void> {
   try {
     const r = await request;
-    if (!r.ok) throw new Error(await readFailure(r));
+    if (!r.ok) throw await readFailure(r);
   } catch (error) {
-    const message = failureMessage(error);
-    console.warn("meeting action failed", { ...action, message });
-    onFailure?.({ ...action, message });
+    // Operator channel keeps the full plumbing (P18); the UI channel gets the presented truth.
+    console.warn("meeting action failed", { ...action, message: String(error instanceof Error ? error.message : error) });
+    onFailure?.({ ...action, message: presentMeetingActionFailure(error) });
   } finally {
     refreshMeetings();
   }
@@ -527,7 +538,7 @@ function CalendarSyncButton({ variant = "icon" }: { variant?: "icon" | "row" }) 
   const syncNow = async () => {
     setSyncing(true); setErr(null);
     try { setStamp(await syncCalendarNow()); refreshMeetings(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setSyncing(false); }
   };
   // the row skin needs the connected-state up front (it hides once connected)
@@ -551,7 +562,7 @@ function CalendarSyncButton({ variant = "icon" }: { variant?: "icon" | "row" }) 
       if (body.ics_url) await syncNow();              // paste → an ANSWER, not a silent wait
       if (body.ics_url === null) setStamp(null);
     }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
   if (variant === "row" && cfg?.ics_url_set) return null;   // connected → manage via the header icon
@@ -658,13 +669,12 @@ function MeetingsList() {
         refreshMeetings(); setTimeout(refreshMeetings, 2000); setTimeout(refreshMeetings, 6000);
       } else {
         // Surface the REAL reason, not a generic "bad link" (the cap/dup/auth cases are common).
-        const detail = (await r.text().catch(() => "")).replace(/\s+/g, " ").slice(0, 160);
         setSent("err");
         setErrMsg(
           r.status === 429 ? "You're at your meeting limit — stop one first."
             : r.status === 409 ? "That meeting already has a bot."
               : r.status === 401 ? "Not signed in — sign in and retry."
-                : `Couldn't send (${r.status})${detail ? `: ${detail}` : ""}`,
+                : presentError(await readFailure(r)).headline,
         );
       }
     } catch { setSent("err"); setErrMsg("Couldn't reach the server."); }
@@ -745,18 +755,25 @@ function ModelChips() {
  *  is in the call, Re-send once it stopped/completed/failed. Reuses the row-action map verbatim
  *  (same endpoints, same status vocabulary) — only bot actions surface here; row management
  *  (schedule/cancel/delete) stays in the sidebar menu. */
-function BotControls({ m }: { m: MeetingMock }) {
+export function BotControls({ m, connected = true }: { m: MeetingMock; connected?: boolean }) {
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const acts = actionsFor(m).filter((a) => a.id === "stop" || a.id === "resend" || a.id === "send");
   if (acts.length === 0) return null;
+  // The control's enabled-ness is a pure function of (row status, WS-connected): while the live
+  // `meeting.status` stream is down the row may be a stale snapshot, so a state-bearing control
+  // degrades to indeterminate/disabled — never an actionable "Stop bot" for a meeting the backend
+  // may no longer have (issue #674).
+  const disabled = busy || !connected;
   return (
     <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flex: "none" }}>
       {acts.map((a) => {
         const danger = a.tone === "live";
         return (
-          <button key={a.id} disabled={busy}
+          <button key={a.id} disabled={disabled}
+            title={!connected ? "Live connection lost — reconnecting…" : undefined}
             onClick={() => {
+              if (disabled) return;
               setErr(null); setBusy(true);
               void Promise.resolve(a.run((f) => setErr(f.message))).finally(() => setBusy(false));
             }}
@@ -764,7 +781,7 @@ function BotControls({ m }: { m: MeetingMock }) {
               border: `1px solid ${danger ? "var(--danger)" : "var(--line2)"}`,
               color: danger ? "var(--danger)" : "var(--accent)",
               borderRadius: 7, padding: "4px 11px", fontSize: 12, fontWeight: 600,
-              cursor: busy ? "default" : "pointer", opacity: busy ? 0.6 : 1 }}>
+              cursor: disabled ? "default" : "pointer", opacity: disabled ? 0.6 : 1 }}>
             {a.id === "stop" ? "Stop bot" : "Send bot again"}
           </button>
         );
@@ -774,33 +791,45 @@ function BotControls({ m }: { m: MeetingMock }) {
   );
 }
 
+/** Header state as a pure function of (row, WS-connected) — the badge and the bot controls both
+ *  derive from it, so a stale-live snapshot can never present as Live while the authoritative
+ *  `meeting.status` stream is down (issue #674). Exported for the behavioral test. */
+export function meetingHeaderState(m: MeetingMock | undefined, connected: boolean): "live" | "reconnecting" | "recap" | "connecting" {
+  if (!m) return "connecting";
+  if (m.status !== "live") return "recap";
+  return connected ? "live" : "reconnecting";
+}
+
 function MeetingTab({ params }: TabProps) {
   const liveList = useLiveMeetings();
+  const connected = useLiveMeetingsConnection();
   const requestedMeetingId = params.meetingId as string;
   // ONE resolver, shared with the canvas body (useMeeting.resolveMeeting): the real meetings list is the
   // only source of truth — a mock never shadows a real id, and a real id never falls back to a mock. While
   // the async list is still loading the row is simply not-yet-resolved; we render the canvas bound to the
   // id with a neutral header (never a wrong/mock meeting), so the header can't disagree with the body.
   const m = liveList.find((x) => x.id === requestedMeetingId || x.native_id === requestedMeetingId);
-  const live = m?.status === "live";
+  const header = meetingHeaderState(m, connected);
 
   return (
     <div style={{ width: "100%", height: "100%", minHeight: 0, display: "flex", flexDirection: "column", padding: "16px 0 24px", boxSizing: "border-box" }}>
       <header style={{ flex: "none", marginBottom: 16, padding: `0 ${MEETING_CANVAS_CONTENT_INSET}px`, boxSizing: "border-box" }}>
         <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 13, minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 9, minWidth: 0 }}>
-            {live
+            {header === "live"
               ? <span style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "var(--green)", fontWeight: 600, letterSpacing: ".04em", fontSize: 11, textTransform: "uppercase", flex: "none" }}><span style={{ width: 7, height: 7, borderRadius: "50%", background: "var(--green)", boxShadow: "0 0 0 3px var(--greenbg)" }} />Live</span>
-              : m
-                ? <span style={{ display: "inline-flex", alignItems: "center", color: "var(--violet)", background: "var(--violetbg)", fontWeight: 600, letterSpacing: ".06em", fontSize: 10.5, textTransform: "uppercase", borderRadius: 999, padding: "2px 9px", flex: "none" }}>Recap</span>
-                : <span style={{ fontSize: 11, color: "var(--t3)", fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase", flex: "none" }}>Connecting…</span>}
+              : header === "reconnecting"
+                ? <span style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "var(--accent)", fontWeight: 600, letterSpacing: ".04em", fontSize: 11, textTransform: "uppercase", flex: "none" }} title="Live connection lost — the last known state may be stale"><span style={{ width: 7, height: 7, borderRadius: "50%", background: "var(--accent)", boxShadow: "0 0 0 3px var(--accentbg)" }} />Reconnecting…</span>
+                : header === "recap"
+                  ? <span style={{ display: "inline-flex", alignItems: "center", color: "var(--violet)", background: "var(--violetbg)", fontWeight: 600, letterSpacing: ".06em", fontSize: 10.5, textTransform: "uppercase", borderRadius: 999, padding: "2px 9px", flex: "none" }}>Recap</span>
+                  : <span style={{ fontSize: 11, color: "var(--t3)", fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase", flex: "none" }}>Connecting…</span>}
             <span style={{ width: 3, height: 3, borderRadius: "50%", background: "var(--t3)", flex: "none" }} />
             <span style={{ color: "var(--t1)", fontWeight: 550, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{m ? (m.title_custom ?? (m.native_id ?? m.title).replace(/^Google Meet · /, "")) : "Meeting"}</span>
             {m && <span style={{ color: "var(--t3)", flex: "none", fontSize: 12 }}>{m.platform}</span>}
             {m && <span style={{ color: "var(--t3)", flex: "none" }}>{m.participants.length} in the room</span>}
           </div>
           <div style={{ flex: 1 }} />
-          {m && <BotControls m={m} />}
+          {m && <BotControls m={m} connected={connected} />}
           {m?.native_id && <ShareSessionButton platform={platformSlug(m.platform)} native={m.native_id} />}
           <ModelChips />
         </div>

--- a/clients/terminal/src/surfaces/meetingPrep.tsx
+++ b/clients/terminal/src/surfaces/meetingPrep.tsx
@@ -18,6 +18,7 @@ import { DateTimePicker } from "../ui-kit/DateTimePicker";
 import { copyText } from "../ui-kit/ContextMenu";
 import { useLiveMeetings, refreshMeetings } from "./liveMeetings";
 import type { MeetingMock } from "./meetingModel";
+import { presentError } from "./apiClient";
 import { createPlannedMeeting, updatePlannedMeeting, deletePlannedMeeting } from "./plannedApi";
 import { createSharedWorkspace, listSharedMemberships, listWorkspaceTree, mintInvite, readWorkspaceFile, type Membership } from "./workspaceApi";
 import { findBriefNote, isExampleNote } from "./briefNote";
@@ -227,7 +228,7 @@ function MeetingPrepTab({ params }: TabProps) {
       if (!id) return;
       await updatePlannedMeeting(id, body); refreshMeetings();
     }
-    catch (e) { if (mounted.current) setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { if (mounted.current) setErr(presentError(e).headline); }
     finally { if (mounted.current) setBusy(false); }
   };
 
@@ -242,7 +243,7 @@ function MeetingPrepTab({ params }: TabProps) {
       });
       if (!r.ok) throw new Error((await r.text().catch(() => "")).slice(0, 180) || `${r.status}`);
       refreshMeetings();
-    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    } catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -252,7 +253,7 @@ function MeetingPrepTab({ params }: TabProps) {
     try {
       const inv = await mintInvite({ workspace_id: m.workspace_id, role: "contributor", mode: "open", expires_in_sec: 7 * 86400, max_uses: 50 });
       setInviteLink(`${window.location.origin}/?invite=${inv.token}`);
-    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    } catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -276,7 +277,7 @@ function MeetingPrepTab({ params }: TabProps) {
       window.dispatchEvent(new CustomEvent(ASK_CHAT_EVENT, {
         detail: { prompt: `I just created the shared workspace "${ws.workspace_id}" for the meeting "${m.title_custom || title || headline}" — it is brand-new (empty) and exists so the other participants and I can collaborate on this meeting and its series. Scaffold it now: write its README as the team brief (audience = everyone in the room, so keep my private context out unless I confirm it), set up whatever structure the series needs, and interview me for what you can't know from my records.${carry} Write early and keep updating as we talk — the README renders live on the meeting page.` },
       }));
-    } catch (e) { if (mounted.current) setErr(e instanceof Error ? e.message : String(e)); }
+    } catch (e) { if (mounted.current) setErr(presentError(e).headline); }
     finally { if (mounted.current) setBusy(false); }
   };
 
@@ -298,7 +299,7 @@ function MeetingPrepTab({ params }: TabProps) {
       window.dispatchEvent(new CustomEvent(ASK_CHAT_EVENT, {
         detail: { prompt: `Interview me to build the brief for "${name}" — ask what you can't know from my records (who's in the room, what I want out of it, what the notetaker should listen for), research the attendees in my knowledge and public sources, then write the brief as this meeting's note in my own workspace (no shared workspace) so it can be reused across this meeting's series.${key} Write the note EARLY and keep updating it as we talk — it renders live on the meeting page.` },
       }));
-    } catch (e) { if (mounted.current) setErr(e instanceof Error ? e.message : String(e)); }
+    } catch (e) { if (mounted.current) setErr(presentError(e).headline); }
     finally { if (mounted.current) setBusy(false); }
   };
 
@@ -308,7 +309,7 @@ function MeetingPrepTab({ params }: TabProps) {
     if (typeof window !== "undefined" && !window.confirm("Delete this planned meeting?")) return;
     setBusy(true);
     try { await deletePlannedMeeting(m.id); refreshMeetings(); layout.closeTab(`prep:${m.id}`); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 

--- a/clients/terminal/src/surfaces/meetingsOnboarding.tsx
+++ b/clients/terminal/src/surfaces/meetingsOnboarding.tsx
@@ -18,6 +18,7 @@ import { LayoutServiceId } from "../workbench/layout";
 import { Icon } from "../ui-kit";
 import { parseMeetingInput } from "./meetingId";
 import { getJitsiHosts } from "./jitsiHosts";
+import { presentError } from "./apiClient";
 import { refreshMeetings } from "./liveMeetings";
 import { getCalendarConfig, setCalendarConfig, syncCalendarNow, type CalendarSyncStamp } from "./plannedApi";
 import { prepDraftTabDescriptor } from "./meetingPrep";
@@ -72,13 +73,13 @@ function ConnectCalendarModal({ onClose, onConnected }: { onClose: () => void; o
       // paste → an ANSWER, not a silent wait (same rule as the sidebar connect)
       let stamp: CalendarSyncStamp = {};
       try { stamp = await syncCalendarNow(); } catch (e) {
-        stamp = { last_error: e instanceof Error ? e.message : String(e) };
+        stamp = { last_error: presentError(e).detail };  // data stays raw (telemetry) — UI renders the presented stamp
       }
       refreshMeetings();
       setDone(connectOutcome(stamp));
       onConnected();
     } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e));
+      setErr(presentError(e).headline);
     } finally {
       setBusy(false);
     }

--- a/clients/terminal/src/surfaces/plannedApi.ts
+++ b/clients/terminal/src/surfaces/plannedApi.ts
@@ -6,10 +6,18 @@
  *  (link-less plans have no native id to address). The calendar config (`/api/user/calendar`)
  *  lives in the identity domain — the ICS URL is a secret, so reads come back MASKED. */
 
+import { ApiError } from "./apiClient";
+
 async function jsonOrThrow<T>(r: Response): Promise<T> {
   if (!r.ok) {
-    const detail = (await r.text().catch(() => "")).replace(/\s+/g, " ").slice(0, 200);
-    throw new Error(detail || `${r.status} ${r.statusText}`);
+    // Structured failure (P18): carry status + detail so the presenter maps it to user truth.
+    let detail = "";
+    try {
+      const b = (await r.json()) as { detail?: unknown; error?: unknown };
+      const d = b?.detail ?? b?.error;
+      detail = typeof d === "string" ? d : d != null ? JSON.stringify(d).slice(0, 200) : "";
+    } catch { /* body wasn't JSON — the status alone is the signal */ }
+    throw new ApiError(r.status, detail, r.url);
   }
   return r.status === 204 ? (undefined as T) : ((await r.json()) as T);
 }

--- a/clients/terminal/src/surfaces/routines.tsx
+++ b/clients/terminal/src/surfaces/routines.tsx
@@ -12,6 +12,7 @@ import { usePreviewPinTab } from "./previewPinTab";
 // Data-access lives in its own SoC module (scoped to the authed user — no client subject, P20),
 // proven in isolation by routinesApi.test.ts.
 import { listRoutines, deleteRoutine, setRoutineEnabled, type Routine } from "./routinesApi";
+import { presentError } from "./apiClient";
 
 const BOARD: TabDescriptor = { id: "board:routines", title: "Routines", kind: "routines", params: {}, context: null };
 
@@ -36,10 +37,10 @@ function RoutinesBoard() {
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [editing, setEditing] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);  // fail-loud (P18): a load/mutation error is shown, never swallowed
-  useEffect(() => { void listRoutines().then((rs) => { setRoutines(rs); setError(null); }).catch((e: unknown) => setError(e instanceof Error ? e.message : String(e))); }, []);
+  useEffect(() => { void listRoutines().then((rs) => { setRoutines(rs); setError(null); }).catch((e: unknown) => setError(presentError(e).headline)); }, []);
   const del = async (id: string) => {
     try { await deleteRoutine(id); setRoutines((rs) => rs.filter((r) => r.id !== id)); }
-    catch (e: unknown) { setError(e instanceof Error ? e.message : String(e)); }
+    catch (e: unknown) { setError(presentError(e).headline); }
   };
   const toggle = async (routine: Routine) => {
     const nextEnabled = !routine.enabled;
@@ -47,7 +48,7 @@ function RoutinesBoard() {
     try {
       await setRoutineEnabled(routine.name, nextEnabled);  // throws on a backend error (fail-loud)
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(presentError(e).headline);
       setRoutines((rs) => rs.map((r) => (r.id === routine.id && r.enabled === nextEnabled ? { ...r, enabled: routine.enabled } : r)));
     }
   };

--- a/clients/terminal/src/surfaces/settings.tsx
+++ b/clients/terminal/src/surfaces/settings.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { registerTab } from "../contributions";
 import { Icon } from "../ui-kit";
 import { GitHubTokenCard, TokensPanel } from "./tokens";
+import { presentError } from "./apiClient";
 import { getCalendarConfig, setCalendarConfig, getCalendarSyncStatus, syncCalendarNow, type CalendarConfig, type CalendarSyncStamp } from "./plannedApi";
 import { getModelPrefs, setModelPrefs, getTranscriptionPrefs, setTranscriptionPrefs, getGlobalSetting, setGlobalSetting, testModels, testTranscription, type ConfigTestResult } from "./settingsApi";
 
@@ -34,7 +35,7 @@ function CalendarSection() {
   const [err, setErr] = useState<string | null>(null);
 
   const refresh = () => {
-    getCalendarConfig().then((c) => { setCfg(c); setErr(null); }).catch((e: unknown) => setErr(e instanceof Error ? e.message : String(e)));
+    getCalendarConfig().then((c) => { setCfg(c); setErr(null); }).catch((e: unknown) => setErr(presentError(e).headline));
     getCalendarSyncStatus().then(setStamp).catch(() => undefined);
   };
   useEffect(refresh, []);
@@ -42,13 +43,13 @@ function CalendarSection() {
   const save = async (body: { ics_url?: string | null; auto_join?: boolean }) => {
     setBusy(true); setErr(null);
     try { setCfg(await setCalendarConfig(body)); setUrl(""); refresh(); }
-    catch (e: unknown) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e: unknown) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
   const syncNow = async () => {
     setSyncing(true); setErr(null);
     try { setStamp(await syncCalendarNow()); }
-    catch (e: unknown) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e: unknown) { setErr(presentError(e).headline); }
     finally { setSyncing(false); }
   };
 
@@ -110,7 +111,7 @@ function ConfigForm({ fields, load, save, note }: {
   useEffect(() => {
     let on = true;
     load().then((v) => { if (on) { setValues(v); setInitial(v); } })
-      .catch((e: unknown) => on && setErr(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => on && setErr(presentError(e).headline));
     return () => { on = false; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -124,7 +125,7 @@ function ConfigForm({ fields, load, save, note }: {
       if ((values[f.key] ?? "") !== (initial[f.key] ?? "")) update[f.key] = values[f.key] ?? "";
     }
     try { const v = await save(update); setValues(v); setInitial(v); setSaved(true); }
-    catch (e: unknown) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e: unknown) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -170,7 +171,7 @@ function TestRow({ label, run }: { label: string; run: () => Promise<ConfigTestR
   const doTest = async () => {
     setBusy(true); setErr(null); setRes(null);
     try { setRes(await run()); }
-    catch (e: unknown) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e: unknown) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
   const provenance = res ? [res.mode, res.source && `via ${res.source}`].filter(Boolean).join(" · ") : "";

--- a/clients/terminal/src/surfaces/settingsApi.ts
+++ b/clients/terminal/src/surfaces/settingsApi.ts
@@ -2,6 +2,7 @@
  *  gateway (`/api/user/models`, `/api/user/transcription` — admin-api behind it, secrets masked
  *  on every read-back). The GLOBAL defaults ride the admin-gated terminal route
  *  (`/api/admin/settings/{key}` — 404 for non-admins, indistinguishable from absent). */
+import { ApiError } from "./apiClient";
 
 export type ModelPrefs = {
   mode?: "subscription" | "custom" | null;
@@ -23,9 +24,10 @@ export type GlobalSetting = Record<string, string>;
 
 async function jsonOrThrow(res: Response) {
   if (!res.ok) {
-    let detail = `${res.status}`;
-    try { detail = ((await res.json()) as { detail?: string; error?: string }).detail || detail; } catch { /* body not json */ }
-    throw new Error(detail);
+    // Structured failure (P18): carry status + detail so the presenter maps it to user truth.
+    let detail = "";
+    try { detail = ((await res.json()) as { detail?: string; error?: string }).detail || ""; } catch { /* body not json */ }
+    throw new ApiError(res.status, detail, res.url);
   }
   return res.json();
 }

--- a/clients/terminal/src/surfaces/tokens.tsx
+++ b/clients/terminal/src/surfaces/tokens.tsx
@@ -11,6 +11,7 @@ import { Icon } from "../ui-kit";
 import { copyText } from "../ui-kit/ContextMenu";
 import { listTokens, createToken, revokeToken, TOKEN_SCOPES, type TokenInfo, type TokenScope, type MintedToken } from "./tokensApi";
 import { getGitToken, setGitToken, type SavedGitToken } from "./workspaceApi";
+import { presentError } from "./apiClient";
 
 const EXPIRIES: Array<{ label: string; seconds?: number }> = [
   { label: "never expires" },
@@ -94,7 +95,7 @@ function CreateTokenForm({ onCreated }: { onCreated: (t: MintedToken) => void })
       setName("");
       onCreated(minted);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : String(e));  // fail-loud (P18)
+      setError(presentError(e).headline);  // fail-loud (P18)
     } finally {
       setBusy(false);
     }
@@ -134,7 +135,7 @@ export function GitHubTokenCard() {
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(() => {
-    void getGitToken().then((s) => { setState(s); setError(null); }).catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+    void getGitToken().then((s) => { setState(s); setError(null); }).catch((e: unknown) => setError(presentError(e).headline));
   }, []);
   useEffect(() => refresh(), [refresh]);
 
@@ -142,13 +143,13 @@ export function GitHubTokenCard() {
     if (!value.trim() || busy) return;
     setBusy(true); setError(null);
     try { const s = await setGitToken(value.trim()); setState(s); setValue(""); setEditing(false); }
-    catch (e: unknown) { setError(e instanceof Error ? e.message : String(e)); }
+    catch (e: unknown) { setError(presentError(e).headline); }
     finally { setBusy(false); }
   };
   const clear = async () => {
     setBusy(true); setError(null);
     try { const s = await setGitToken(null); setState(s); setValue(""); setEditing(false); }
-    catch (e: unknown) { setError(e instanceof Error ? e.message : String(e)); }
+    catch (e: unknown) { setError(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -192,13 +193,13 @@ export function TokensPanel() {
   const [error, setError] = useState<string | null>(null);  // fail-loud (P18)
 
   const refresh = useCallback(() => {
-    void listTokens().then((t) => { setTokens(t); setError(null); }).catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+    void listTokens().then((t) => { setTokens(t); setError(null); }).catch((e: unknown) => setError(presentError(e).headline));
   }, []);
   useEffect(() => refresh(), [refresh]);
 
   const onCreated = (t: MintedToken) => { setMinted(t); refresh(); };
   const onRevoke = (id: number) => {
-    void revokeToken(id).then(refresh).catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+    void revokeToken(id).then(refresh).catch((e: unknown) => setError(presentError(e).headline));
   };
 
   return (

--- a/clients/terminal/src/surfaces/workspace.tsx
+++ b/clients/terminal/src/surfaces/workspace.tsx
@@ -17,6 +17,7 @@ import { MdxDoc } from "../ui-kit/MdxDoc";
 // proven in isolation by workspaceApi.test.ts.
 import { readWorkspaceFile, listWorkspaceTree, readWorkspaceGit, readWorkspaceGitDiff, readAttachedWorkspaces, renameWorkspace, publishWorkspace, readActiveSet, activateWorkspace, deactivateWorkspace, createWorkspace, mintInvite, listSharedMemberships, setSharedActive, shareEnableWorkspace, unshareWorkspace, archiveWorkspace, deleteWorkspace, type GitState, type GitCommit, type AttachedWorkspaces, type PublishResult, type ActiveMount, type Membership } from "./workspaceApi";
 import { manageTabDescriptor } from "./workspaceManage";
+import { presentError } from "./apiClient";
 const base = (p: string) => p.split("/").pop() ?? p;
 // `slug` (Lane A) opens a file from a SHARED workspace the user is a member of; omitted → own workspace.
 // The tab id includes the slug so the same path in two workspaces gets distinct tabs.
@@ -190,7 +191,7 @@ function MountSection({ mount }: { mount: ActiveMount }) {
     if (!open) return;
     const load = () => void listWorkspaceTree({ hidden: false, slug: mount.slug })
       .then((t) => { setTree((prev) => (JSON.stringify(prev) === JSON.stringify(t) ? prev : t)); setError(null); })
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => setError(presentError(e).headline));
     load();
     const id = setInterval(() => { if (!document.hidden) load(); }, 8000);
     window.addEventListener("focus", load);
@@ -292,7 +293,7 @@ export function FilesList() {  // exported for the surface test
             const t = await listWorkspaceTree({ hidden: false, slug: home.slug });
             setTree((prev) => (JSON.stringify(prev) === JSON.stringify(t) ? prev : t));
             setError(null);
-          } catch (e: unknown) { setError(e instanceof Error ? e.message : String(e)); }
+          } catch (e: unknown) { setError(presentError(e).headline); }
         } else { setTree([]); setError(null); }
         // fetch each extra mount's full tree so the search index spans every active workspace
         const entries = await Promise.all(mounts.map(async (m) => {
@@ -301,7 +302,7 @@ export function FilesList() {  // exported for the surface test
         }));
         setMountTrees(Object.fromEntries(entries));
       })
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => setError(presentError(e).headline));
     load();
     const id = setInterval(() => { if (!document.hidden) load(); }, 5000);
     window.addEventListener("focus", load);
@@ -485,7 +486,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
   const [rowMenu, setRowMenu] = useState<{ slug: string; display: string; x: number; y: number } | null>(null);  // per-row … menu (archive/delete)
   const [showArchived, setShowArchived] = useState(false);  // the collapsed 'Archived' group
   const load = () => {
-    void readAttachedWorkspaces().then((v) => { setView(v); setErr(null); }).catch((e: unknown) => setErr(e instanceof Error ? e.message : String(e)));
+    void readAttachedWorkspaces().then((v) => { setView(v); setErr(null); }).catch((e: unknown) => setErr(presentError(e).headline));
     void readActiveSet().then((s) => setActiveSet(s.active)).catch(() => { /* active-set is additive UI; a failure just leaves the toggles at the baseline */ });
     void listSharedMemberships().then(setSharedMemberships).catch(() => { /* shared list is additive; ignore */ });
   };
@@ -502,7 +503,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
   const toggleActive = async (slug: string, mounted: boolean) => {
     setBusy(true); setErr(null);
     try { if (mounted) { await deactivateWorkspace(slug); } else { await activateWorkspace({ slug }); } load(); onSwapped(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -510,7 +511,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
   const doAttach = async (repo: string, ref?: string, token?: string) => {
     setBusy(true); setErr(null);
     try { await activateWorkspace({ repo, ref, token }); load(); onSwapped(); setForm(null); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -520,7 +521,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
   const doNewWorkspace = async () => {
     setBusy(true); setErr(null);
     try { await createWorkspace(); load(); onSwapped(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -531,14 +532,14 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
   const doPublish = async (f: { name: string; priv: boolean; token: string; remoteUrl?: string }) => {
     setBusy(true); setErr(null);
     try { setPublished(await publishWorkspace(f.name.trim(), f.priv, f.token.trim(), f.remoteUrl)); setPubForm(null); load(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
   const doRename = async (slug: string, name: string) => {
     setBusy(true); setErr(null);
     try { setView(await renameWorkspace(slug, name.trim())); setRenaming(null); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); setRenaming(null); }
+    catch (e) { setErr(presentError(e).headline); setRenaming(null); }
     finally { setBusy(false); }
   };
 
@@ -547,7 +548,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
     if (typeof window !== "undefined" && !window.confirm(`Stop sharing "${workspaceId}"? Other members will lose access; it becomes a private workspace of yours.`)) return;
     setBusy(true); setErr(null);
     try { await unshareWorkspace(workspaceId); load(); onSwapped(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -555,7 +556,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
   const doArchive = async (slug: string, archived: boolean) => {
     setBusy(true); setErr(null);
     try { await archiveWorkspace(slug, archived); load(); onSwapped(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
   // Delete one of your workspaces — irreversible (hard confirm).
@@ -563,7 +564,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
     if (typeof window !== "undefined" && !window.confirm(`Delete "${display}"? This permanently removes the workspace and all its data.`)) return;
     setBusy(true); setErr(null);
     try { await deleteWorkspace(slug); load(); onSwapped(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -571,7 +572,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
   const toggleShared = async (workspaceId: string, active: boolean) => {
     setBusy(true); setErr(null);
     try { await setSharedActive(workspaceId, active); load(); onSwapped(); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -583,7 +584,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
       const { workspace_id } = await shareEnableWorkspace(slug);
       load(); onSwapped();
       setShare({ wsId: workspace_id, role: "contributor", mode: "open", emails: "", ttlDays: 7, link: null });
-    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    } catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -599,7 +600,7 @@ export function WorkspaceSwitcher({ onSwapped }: { onSwapped: () => void }) {  /
       });
       const link = `${window.location.origin}/?invite=${encodeURIComponent(minted.token)}`;
       setShare({ ...s, link });
-    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    } catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -861,7 +862,7 @@ function GitSection() {
               .flatMap(({ m, g }) => g.commits.map((c) => ({ ...c, slug: m.slug, ws: m.name || m.slug }))),
         ].sort((a, b) => (b.ts ?? 0) - (a.ts ?? 0)).slice(0, 12);
         setFeed(merged);
-      } catch (e: unknown) { setGitError(e instanceof Error ? e.message : String(e)); }
+      } catch (e: unknown) { setGitError(presentError(e).headline); }
     };
     void load();
     const id = setInterval(() => void load(), 5000);  // reflect commits as they land, across workspaces
@@ -1059,7 +1060,7 @@ function DocTab({ id, params }: TabProps) {
         const d = await readWorkspaceGitDiff({ sha: c.sha, slug, path });
         setDiff(d.diff || "(no textual changes)");
       })
-      .catch((e: unknown) => setDiff(`⚠ ${e instanceof Error ? e.message : String(e)}`));
+      .catch((e: unknown) => setDiff(`⚠ ${presentError(e).headline}`));
   };
   const show = (p: string) => layout.retargetTab(id, docTab(p, slug));
   const navigate: DocNavigate = (detail) => {

--- a/clients/terminal/src/surfaces/workspaceManage.tsx
+++ b/clients/terminal/src/surfaces/workspaceManage.tsx
@@ -18,6 +18,7 @@ import { Icon, Checkbox } from "../ui-kit";
 import { Modal } from "../ui-kit/Modal";
 import { ContextMenu, copyText } from "../ui-kit/ContextMenu";
 import { MdxDoc } from "../ui-kit/MdxDoc";
+import { presentError } from "./apiClient";
 import { DocMetaContext } from "../ui-kit/docLinks";
 import {
   readAttachedWorkspaces, readActiveSet, listSharedMemberships, renameWorkspace,
@@ -77,7 +78,7 @@ function WorkspaceManagePanel({ id, params }: TabProps) {
   const run = async (fn: () => Promise<unknown>, ok?: string) => {
     setBusy(true); setErr(null); setNote(null);
     try { await fn(); if (ok) setNote(ok); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
 
@@ -192,7 +193,7 @@ function ReadmeBody({ slug }: { slug: string }) {
     setText(undefined); setError(null);
     const load = () => void readWorkspaceFile("README.md", { slug })
       .then((c) => { if (live) { setText(c); setError(null); } })
-      .catch((e: unknown) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+      .catch((e: unknown) => { if (live) setError(presentError(e).headline); });
     load();
     const iv = setInterval(() => { if (!document.hidden) load(); }, 8000);
     window.addEventListener("focus", load);
@@ -295,7 +296,7 @@ function PurposeSection({ slug }: { slug: string }) {
   const save = async () => {
     setBusy(true); setErr(null);
     try { const p = await writeWorkspacePurpose(draft, { slug }); setPurpose(p); setDraft(p); setEditing(false); }
-    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
   return (

--- a/core/gateway/contracts/ws.v1/README.md
+++ b/core/gateway/contracts/ws.v1/README.md
@@ -39,6 +39,11 @@ SDKs, and any client build against.
 | `meetings/services/meeting-api` (+ collector) | publishes the data shapes to the redis channels above |
 | any client | subscribe + consume the type-tagged stream |
 
+`meeting.status` is the **authoritative state channel** for a client's bot/meeting-state
+controls: while this stream is not connected, a client MUST degrade state-bearing controls
+(Stop/Send bot) to indeterminate/disabled — a cached REST snapshot is display-only, never a
+basis for an actionable control.
+
 ## Re-verify / re-seal
 Shapes are pinned by main's gate test. To re-verify: `node gateway/contracts/ws.v1/validate.mjs`
 (goldens ≡ `$defs`). A deliberate main change → update the schema/goldens + `pnpm seal:contracts`

--- a/docs/changelog.d/533-terminal-error-presenter.md
+++ b/docs/changelog.d/533-terminal-error-presenter.md
@@ -1,0 +1,7 @@
+- **Terminal errors now speak user truth (#533).** Every error a terminal surface shows states
+  what happened in the user's vocabulary ("Couldn't reach the Vexa server — check that the stack
+  is running.", "Your API key was rejected — sign in again.", or the backend's own reason
+  verbatim) instead of transport plumbing like `/api/... → 502: upstream unreachable:
+  ConnectError`. The full technical string is preserved on the browser console for operators. A
+  new presenter seam (`presentError` beside `ApiError`) plus a grep-guard test keep the 46 former
+  raw render sites — and any future one — honest.

--- a/docs/changelog.d/674-ws-gated-bot-controls.md
+++ b/docs/changelog.d/674-ws-gated-bot-controls.md
@@ -1,0 +1,6 @@
+- **Meeting-header bot controls follow the live WebSocket, never a stale snapshot (#674).** When
+  the `meeting.status` stream is disconnected the header shows "Reconnecting…" and Stop/Send bot
+  are disabled — a stale-live row can no longer offer an actionable "Stop bot" for a meeting the
+  backend no longer has. A stop that races reality (404/409) now shows a human message ("This
+  meeting is no longer active — refreshing the list.") and reconciles the control, instead of a
+  raw JSON toast.

--- a/docs/docs/architecture/meeting-status-ws.md
+++ b/docs/docs/architecture/meeting-status-ws.md
@@ -9,6 +9,12 @@ the source of truth**; leave the bot lifecycle FSM untouched.
 
 This doc is grounded in the real 0.12 code; every claim cites `file:line`.
 
+**Client contract:** the `meeting.status` stream is the **single source of truth** for any
+client's bot/meeting-state controls. A client MUST degrade state-bearing controls (Stop bot,
+Send bot…) to an indeterminate/disabled state while the stream is not connected — a cached
+REST snapshot is display-only, never a basis for an actionable control (the terminal implements
+this via `useLiveMeetingsConnection()` gating the meeting-header `BotControls`).
+
 ---
 
 ## 0. Grounding — what exists today

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -88,6 +88,16 @@ The bot is capturing audio, but transcription isn't configured — or the bot wa
 - A stale bot key shows up as `native_resolve:{ok:false,kind:"unauthorized"}` on
   `GET /api/meeting/relay-health` rather than as silent dead air.
 
+## What terminal errors look like — and where the technical details live
+
+Terminal error surfaces speak user vocabulary ("Couldn't reach the Vexa server — check that the
+stack is running.", "Your API key was rejected — sign in again.", or the backend's own reason when
+it sent one). The full technical string — proxied URL, HTTP status, backend exception detail, e.g.
+`/api/vexa/user/calendar → 502: upstream unreachable: ConnectError` — is never lost: it is written
+verbatim to the **browser console** (`api failure …` / `meeting action failed …` warnings) on every
+presented error. Support and self-hosters debug from the console line; the on-screen headline tells
+the user which layer to suspect.
+
 ## Authentication failures
 
 | Symptom | Cause | Fix |

--- a/docs/test-scenarios/terminal-seams.md
+++ b/docs/test-scenarios/terminal-seams.md
@@ -195,4 +195,30 @@ deferred to an L4 eval with a frozen transcript fixture.
   expected:
     deterministic_half: turn_streams_and_commits_doc_at_expected_path
     judge_half: doc_is_correct_sourced_summary
+
+# ── Error presentation + control gating (issue #533 / #674 rows) ──────────────
+- id: terminal-error-presentation-user-truth
+  status: green
+  seam: "ApiError {status,detail,url} -> presentError -> surface alert regions (8 surface files)"
+  module_probe: clients/terminal/src/surfaces/__tests__/presentError.test.ts  # fixture range: network 0, 502/504, 401, 403, 422-json, 429, typed 503 prose (verbatim pass-through), empty detail
+  seam_probe: clients/terminal/src/surfaces/__tests__/errorPresentation.guard.test.ts  # grep-guard: no surface renders the raw `e instanceof Error ? e.message : String(e)` idiom
+  expected:
+    headline: user_vocabulary_never_transport_plumbing   # no url/status/exception-name in the rendered line
+    typed_backend_detail: passes_through_verbatim        # a prose 4xx/5xx detail is the backend's own user-facing reason
+    plumbing: preserved_on_detail_and_console            # P18's observable channel keeps the full string; the error object is never mutated
+  note: >
+    The presenter seam lives beside ApiError (apiClient.ts). Surfaces render presentError(e),
+    never e.message; the grep-guard makes the 46th raw site impossible to land silently.
+
+- id: terminal-header-botcontrol-follows-ws
+  status: green
+  seam: "ws.v1 meeting.status connectivity -> liveMeetings store (useLiveMeetingsConnection) -> meeting header BotControls"
+  module_probe: clients/terminal/src/surfaces/__tests__/liveMeetings.store.test.tsx  # (e) open->true, close->false, reopen->true + re-snapshot
+  seam_probe: clients/terminal/src/surfaces/__tests__/meetingHeaderControls.test.tsx  # header state pure fn + disabled "Stop bot" while disconnected
+  expected:
+    connected_active: stop_enabled
+    disconnected: indeterminate_disabled_reconnecting    # a stale-live snapshot can never present an actionable "Stop bot"
+    action_404: human_message_plus_reconciling_resnapshot  # never the raw JSON body (meetingActions.test.tsx)
+    action_409: human_already_has_bot_line
+
 ```


### PR DESCRIPTION
Refs #533, Refs #674. From the autonomous session, with adversarial verification by a second agent (verdict: asks — see below).

## ⚠️ #552 is NOT delivered by this PR
The witnessed #552 surface ("Stream error: Meeting stream disconnected" / eternal "Waiting for transcript") lives in `clients/terminal/src/canvas/MeetingHealthBanner.tsx` + meetingHealth — **untouched by this diff** (canvas/ has zero changes). The blocker is structural, confirmed at head: the bot's transcription fault dies in the console (`core/meetings/services/bot/src/index.ts:177` wires `onError` to console.error only); transcript.v1 has no error/fault message type; lifecycle.v1 carries `error_details` only on terminal events; the meeting record exposes no fault field over `GET /meetings`. The terminal structurally cannot name the STT fault — fixing the mislabel client-side would be dressing up a transport message (the issue's own P21 warning). Required: a cross-service fault-propagation mechanism (bot → lifecycle/meeting-api fault field → ws.v1/REST → terminal), i.e. lane:contract work outside this terminal-seam branch. The terminal render side is now ready for it. Recommend splitting #552 into the propagation issue + a thin terminal render leg. **#552 stays open.**

## The mechanism (#533 + #674)
- `apiClient.ts` — `presentError` presenter seam beside `ApiError`: status arms, verbatim prose-detail pass-through, plumbing preserved on `.detail` + console (P18). ApiError fields never mutated.
- All raw `e.message` render sites across 7 surface files → `presentError(e).headline`; `plannedApi`/`settingsApi` now throw structured `ApiError` at the point of introduction.
- `meeting.tsx` — `readFailure` → structured ApiError; 404 → human message + reconciling re-snapshot, 409 → human line; `BotControls` exported + WS-gated (disabled, "Reconnecting" title); `meetingHeaderState` pure fn; header Live→Reconnecting badge when disconnected. `liveMeetings.ts` — `wsConnected` in store + `useLiveMeetingsConnection()` selector.
- New tests: presentError fixture range (C1), grep-guard banning the raw idiom from surfaces, meetingHeaderControls, store connection exposure, meetingActions. Docs: surfaces README contract line, terminal-seams rows, troubleshooting block, ws.v1 README client-contract clause (prose only — seal intact, 12 goldens conform), 2 changelog fragments. No hot files touched.

## Observation bundle (issues' own numbering)
| Row | Status | Evidence |
|---|---|---|
| #533 A1 inventory red→green | **done** (with deviation, see asks) | base (src stashed, new tests kept): `Test Files 5 failed (5) / Tests 28 failed \| 19 passed (47)`; head: `52 passed (52) / 390 passed (390)` |
| #533 A2 live Lite leg (gateway down → headlines) | **pending witness** | needs a running Lite deployment |
| #533 A3 typed 503 verbatim | **done** | unit test: prose detail passes verbatim |
| #533 A4 no-mutation + console plumbing | **done** | explicit test asserts ApiError fields unchanged + console channel |
| #533 A- | **done** | 390 green, gates green (exit 0, 32 gates ✓; one transient compose-gate red was a stale container on this host, identical rerun green), guard green at head / red at base |
| #674 A1 connection exposure | **done** | `useLiveMeetingsConnection` + `meetingHeaderState` tests; red at base |
| #674 A2 disabled controls while disconnected | **done** | store test drives onclose → false; BotControls disabled render test; red at base |
| #674 A3 stale-action truth (404/409) | **done** | human message + reconcile / human line; red at base |
| #674 A- + live helm leg | lane/gates **done**; live WS-drop witness **pending** | gatewayWS.golden.test.ts untouched/green |

The adversarial verifier independently reverted the WS gating (`busy || !connected` → `busy`) and reproduced a red in meetingHeaderControls.test.tsx — the tests are real discriminators.

## Findings / era drift
- Raw-idiom count is 46 across 8 files at this tree, not 45 (meeting.tsx has 3 sites: :58, :530, :554); `readFailure` at meeting.tsx:287-292; the STT 503 anchor moved to `bot_spawn/router.py:234-236` (src/ layout landed). #674 anchors all current at 9e8ebd47.
- Deviation (#533 C1): instead of per-surface render snapshots for all 8 files, coverage is presenter fixture units + the grep-guard (mechanically holds all 8 files) + component tests for the meeting surface — same acceptance substance, less snapshot brittleness. Flag if literal alert-region snapshots are wanted.
- Open maintainer question #1 on #533 resolved as prepared: console + `title=` where the surface already had one; no collapsible details built.

## Honest asks (from the adversarial verifier)
1. Live legs unevidenced: #533 A2 (Lite, gateway down, base-vs-head screenshots + console capture) and #674's helm WS-drop witness must land in the bundle before merge.
2. `BotControls` defaults `connected = true` (meeting.tsx:758); MeetingTab passes it, but no test renders MeetingTab against the store — dropping the prop later silently restores the stale-actionable bug. Ask: false-safe default / required prop, or a MeetingTab-level test.
3. Surfaces README says surfaces "never" render `e.message`, but chat.tsx (:278,:293,:622) still uses a variant idiom that evades the guard regex — chat was outside #533's 8 files; soften the claim, widen the guard, or file the follow-up.
