### PR TITLE
fix(meetings): pre-active teardown attributes the reason from the status (#598)

### DIFF
--- a/core/meetings/contracts/lifecycle.v1/README.md
+++ b/core/meetings/contracts/lifecycle.v1/README.md
@@ -12,7 +12,11 @@ active             → completed · failed
 completed          ∅   (terminal)
 failed             ∅   (terminal)
 ```
-`completed` carries a `completion_reason`; `failed` carries a `failure_stage`. The machine-checked
+`completed` carries a `completion_reason`; `failed` carries a `failure_stage`. Pre-active teardown
+attribution (the control plane's reconcile path, when the workload dies before the bot reports
+`active`): `awaiting_admission` → `awaiting_admission_timeout` (reaped while waiting in the lobby —
+the room never admitted the bot), `requested`/`joining` → `join_failure` (died before it could
+join). The machine-checked
 `canTransition` lives in the **runtime/bot implementation** (Stage 2) — the contract documents it; the
 impl enforces it (lean: no separate harness, B8).
 

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
@@ -377,6 +377,17 @@ _PRE_ACTIVE_STATUSES = frozenset({"requested", "joining", "awaiting_admission"})
 _WAS_ACTIVE_STATUSES = frozenset({"stopping", "active", "needs_help"})
 
 
+def _pre_active_completion_reason(status: Optional[str]) -> str:
+    """Attribute a pre-active teardown to the stage the bot died in: a bot whose workload is torn
+    down while it sits in the waiting room (``awaiting_admission``) was never admitted →
+    ``awaiting_admission_timeout``; any earlier pre-active stage (``requested``/``joining``) died
+    before it could join → ``join_failure``. Keyed on ``awaiting_admission`` EXPLICITLY: an
+    escalation state like ``needs_help`` is not an admission wait and must never earn the
+    admission-timeout reason. Both values are TRANSIENT (see ``retry.py``), so attribution never
+    changes the retry class."""
+    return "awaiting_admission_timeout" if status == "awaiting_admission" else "join_failure"
+
+
 async def synthesize_terminal_for_dead_workload(
     repo: Any,
     workload_id: Optional[str],
@@ -424,8 +435,12 @@ async def synthesize_terminal_for_dead_workload(
             "connection_id": info["session_uid"],
             "status": "failed",
             "failure_stage": status,                    # the stage the bot died IN (requested/joining/…)
-            "completion_reason": "join_failure",        # workload died before the bot could join/report
-            "reason": f"workload {state} before the bot reported (never started)",
+            "completion_reason": _pre_active_completion_reason(status),
+            "reason": (
+                f"workload {state} while awaiting admission (never admitted)"
+                if status == "awaiting_admission"
+                else f"workload {state} before the bot reported (never started)"
+            ),
         }
     elif status in _WAS_ACTIVE_STATUSES:
         # It reached the meeting and its workload is now runtime-confirmed gone with no terminal callback

--- a/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
+++ b/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
@@ -158,7 +158,9 @@ def test_runtime_destroy_completes_stopping_after_active_e2e():
 def test_runtime_destroy_fails_pre_active_e2e():
     """PRE-ACTIVE → failed, end to end. A meeting stuck ``awaiting_admission`` (bot killed in the waiting
     room before it could report ``active``) whose workload the runtime confirms ``destroyed`` reaches
-    ``failed`` (attributed to the stage it died in), and still reaps the copilot."""
+    ``failed`` attributed to the stage it died in — ``failure_stage=awaiting_admission`` AND
+    ``completion_reason=awaiting_admission_timeout`` (the room never admitted the bot; NOT the generic
+    ``join_failure``) — and still reaps the copilot."""
     async def scenario():
         repo = _ReaperRepo()
         m = await _seed(repo)  # requested → callbacks walk it to awaiting_admission
@@ -174,7 +176,50 @@ def test_runtime_destroy_fails_pre_active_e2e():
     repo, redis, m = asyncio.run(scenario())
     assert repo._meetings[m["id"]]["status"] == "failed"
     assert repo._meetings[m["id"]]["data"].get("failure_stage") == "awaiting_admission"
+    assert repo._meetings[m["id"]]["data"].get("completion_reason") == "awaiting_admission_timeout"
     assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+
+
+@pytest.mark.parametrize(
+    "callbacks,stage",
+    [
+        (("joining",), "joining"),   # bot reported joining, died before admission/active
+        ((), "requested"),           # workload destroyed before the bot reported anything
+    ],
+)
+def test_runtime_destroy_pre_active_before_admission_is_join_failure_e2e(callbacks, stage):
+    """DISCRIMINATOR: a pre-active bot destroyed BEFORE it reached the waiting room (``requested`` /
+    ``joining``) is a genuine join failure — ``completion_reason=join_failure``, never
+    ``awaiting_admission_timeout`` (only a bot that WAS awaiting admission earns that reason)."""
+    async def scenario():
+        repo = _ReaperRepo()
+        m = await _seed(repo)
+        redis = _StreamRedis()
+        app = create_app(meeting_repo=repo, redis=redis)
+        async with _asgi(app) as c:
+            for st in callbacks:
+                assert (await c.post(LIFECYCLE, json={"connection_id": "sess-uid", "status": st})).status_code == 200
+            rc = await c.post(RUNTIME, json={"workloadId": "wl-1", "state": "destroyed"})
+            assert rc.status_code == 200, rc.text
+        return repo, redis, m
+
+    repo, redis, m = asyncio.run(scenario())
+    assert repo._meetings[m["id"]]["status"] == "failed"
+    assert repo._meetings[m["id"]]["data"].get("failure_stage") == stage
+    assert repo._meetings[m["id"]]["data"].get("completion_reason") == "join_failure"
+
+
+def test_pre_active_attribution_is_retry_neutral():
+    """RETRY PARITY (the "no behavior change" guard): both pre-active teardown reasons are TRANSIENT,
+    so status-accurate attribution never flips a destroy-path bot's retry class."""
+    from meeting_api.lifecycle.machine import CompletionReason
+    from meeting_api.lifecycle.retry import RetryClass, classify_retry
+
+    assert (
+        classify_retry(CompletionReason.AWAITING_ADMISSION_TIMEOUT)
+        is classify_retry(CompletionReason.JOIN_FAILURE)
+        is RetryClass.TRANSIENT
+    )
 
 
 def test_runtime_destroy_noop_on_already_terminal_e2e():

--- a/docs/changelog.d/598-teardown-attribution.md
+++ b/docs/changelog.d/598-teardown-attribution.md
@@ -1,0 +1,5 @@
+- **Pre-active teardown attribution: lobby waits are no longer filed as join errors (#598).** A bot
+  whose workload is torn down while it sits in `awaiting_admission` now terminates with
+  `completion_reason: awaiting_admission_timeout` ("the room never admitted the bot") instead of the
+  generic `join_failure`; bots destroyed at `requested`/`joining` keep `join_failure`. Both reasons
+  stay transient→retry, so only the label — what operators see on the meeting terminal — changes.


### PR DESCRIPTION
Refs #598. From the autonomous session, with adversarial verification by a second agent — **verdict: sound** (one process ask, recorded on the issue).

## The mechanism
`reconcile.py` — pure helper `_pre_active_completion_reason` (keyed on `awaiting_admission` explicitly, per open question 2: `needs_help` can never earn the timeout reason), used at the destroy-path stamping site (was hardcoded `"join_failure"`); free-text reason tailored ("never admitted" vs "never started"). Fork choice: **3(b)** — the sweep path (reconcile.py:~304) still stamps `left_alone` for pre-active reaps; unification flips the retry class permanent→transient and needs the maintainer ruling (recorded on the issue per the fork's own instruction).

Docs: lifecycle.v1 README gains the pre-active teardown attribution semantics (the README had no completion-reason semantics table at all, contrary to the issue's docs-surface wording — added). Changelog via fragment `docs/changelog.d/598-teardown-attribution.md` — no hot files touched.

## Observation bundle (issue's numbering)
| Row | Status | Evidence |
|---|---|---|
| A1 destroy path: `awaiting_admission` → `awaiting_admission_timeout` | **done** | red on base (fix stashed): `E - awaiting_admission_timeout / E + join_failure … 1 failed, 2 passed`; green after fix through the real `/runtime/callback` ASGI path |
| A2 discriminator: `joining` AND `requested` → `join_failure` | **done** | new parametrized e2e; verifier confirmed a naive rename-all fix reds both cases — exactly the table's negative control |
| A3 sweep path → timeout reason | **not taken by design** | conditional on fork 3(a) — pending maintainer ruling (open question 1) |
| A4 retry parity (both TRANSIENT) | **done** | explicit parity test against the real retry.py enum |
| A- lanes + gates | **done** | `gates.mjs all` exit 0; affected lanes 28 passed; full meeting-api suite green except pre-existing env-only calendar_sync reds (missing `icalendar` locally — identical red with the diff stashed) |

The adversarial verifier independently reverted the helper call back to the hardcoded reason (A1 red) and applied a naive always-timeout fix (A2 red) — both tests are real discriminators — and reran `gates.mjs all` green including the real compose gate.

## Findings / era drift
- Third stamping site the issue did not list: `_escalate_untracked_zombie` (stamps `left_alone` for pre-active untracked-zombie escalations) — same divergence family as the sweep; should ride the same ruling/follow-up.
- Minor line drift (`join_failure` at reconcile.py:427 vs claimed :426; retry.py one line off) — all claims substantively verified.
- Optional live Jitsi lobby run (issue names it optional; floor is the deterministic harness) — not run; hence Refs, not Closes, with A3 unruled.
- Tooling note: two spurious `gate:compose` reds were caused by a parallel worktree holding the fixed compose project name `vexa-compose-gate` — possible follow-up: per-worktree project names.
