### PR TITLE
ci(pr-value): lite-smoke leg — build the PR lite image, boot it, smoke the front doors (#581)

### DIFF
--- a/.github/workflows/pr-value.yml
+++ b/.github/workflows/pr-value.yml
@@ -99,3 +99,92 @@ jobs:
         run: |
           docker ps -a
           docker compose -p vexa-compose-gate -f deploy/compose/docker-compose.yml logs --no-color --tail 200 || true
+
+  # The LITE boot leg (#581). Lite builds and boots ONLY at release time, so three lite-only
+  # bugs (the Dockerfile.lite stale brick filter #576, the Makefile $IMG-orphaned-by-comment,
+  # the #585 stream-authz misconfig) each cost a full failed release pipeline (~35 min) to
+  # surface. This job closes that gap per PR: build deploy/lite/Dockerfile.lite from the PR's
+  # own tree, `make -C deploy/lite up` from that exact image, probe the front doors, then the
+  # concurrent-bots smoke (the #478 class + the #585 stream-authz guard).
+  #
+  # Scope: only when the lite bundle's inputs change — deploy/lite/** (Dockerfile + Makefile +
+  # launchers + supervisor conf) or core/** (the bot/service source the image bakes) or the
+  # workspace manifests. clients/terminal is deliberately OUT: the terminal has its own image
+  # leg, and a terminal-only PR should not pay a lite build. Job-level path scoping is a git
+  # diff against the merge ref's first parent (main) — no extra action, works identically for
+  # the dispatch backfill mode. Fail-open: if the diff cannot be computed, the leg runs.
+  #
+  # NO secrets (like value-fsm): base images and the vexaai/vexa-lite:buildcache registry cache
+  # are pulled anonymously — warm-cache runs land in single-digit minutes; a cold cache is the
+  # 45-min ceiling, never a wrong verdict.
+  lite-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr && format('refs/pull/{0}/merge', inputs.pr) || '' }}
+          fetch-depth: 2   # merge commit + both parents → HEAD^1 (main) is diffable
+      - name: Scope — does this PR touch the lite bundle?
+        id: scope
+        run: |
+          if files=$(git diff --name-only HEAD^1 HEAD 2>/dev/null); then
+            if echo "$files" | grep -qE '^(deploy/lite/|core/|package\.json$|pnpm-lock\.yaml$)'; then
+              echo "hit=1" >> "$GITHUB_OUTPUT"; echo "lite bundle inputs changed — running the leg"
+            else
+              echo "hit=0" >> "$GITHUB_OUTPUT"; echo "no lite bundle inputs changed — skipping"
+            fi
+          else
+            echo "hit=1" >> "$GITHUB_OUTPUT"; echo "could not diff — failing open, running the leg"
+          fi
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        if: steps.scope.outputs.hit == '1'
+      - uses: docker/setup-buildx-action@v3
+        if: steps.scope.outputs.hit == '1'
+      # Build the PR's OWN lite image (A3: the PR tree, anonymous pulls, no cache-to — read-only
+      # cache use). The tag is the Makefile's LOCAL_TAG: `make up` prefers a local vexa-lite:dev
+      # over the Hub image, so the stack below boots exactly what this PR would ship.
+      - name: Build deploy/lite/Dockerfile.lite from the PR tree
+        if: steps.scope.outputs.hit == '1'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/lite/Dockerfile.lite
+          load: true
+          tags: vexa-lite:dev
+          cache-from: type=registry,ref=vexaai/vexa-lite:buildcache
+      - name: Seed the lite .env
+        if: steps.scope.outputs.hit == '1'
+        run: printf 'ADMIN_TOKEN=ci-admin-token\nTRANSCRIPTION_SERVICE_URL=\nTRANSCRIPTION_SERVICE_TOKEN=\n' > .env
+      - name: Bring lite up from the PR-built image
+        if: steps.scope.outputs.hit == '1'
+        run: make -C deploy/lite up init-db
+      - name: Probe the front doors (make test exits non-zero on failure)
+        if: steps.scope.outputs.hit == '1'
+        run: |
+          for i in $(seq 1 10); do
+            make -C deploy/lite test && exit 0
+            echo "…front doors not all up yet (attempt $i/10)"; sleep 15
+          done
+          echo "::error ::lite front-door probes failed after 10 attempts"
+          exit 1
+      - name: Concurrent-bots smoke (the #478 class + the #585 stream-authz guard)
+        if: steps.scope.outputs.hit == '1'
+        run: ADMIN_TOKEN=ci-admin-token deploy/lite/tests/concurrent-bots.sh
+      - name: Present the lite-leg row (job summary)
+        if: always() && steps.scope.outputs.hit == '1'
+        run: |
+          {
+            echo "## pr-value/lite-smoke — the lite boot leg (#581)"
+            echo
+            echo "Built \`deploy/lite/Dockerfile.lite\` from this PR's tree, booted it via"
+            echo "\`make -C deploy/lite up\`, probed the front doors, ran the concurrent-bots smoke."
+            echo
+            echo "Verdict: **${{ job.status }}** — green means the lite image assembles and boots"
+            echo "from THIS tree. Real-Meet admission and audio→words remain release-bar legs."
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Lite state on failure
+        if: failure()
+        run: |
+          docker ps -a
+          docker logs vexa-lite --tail 300 || true

--- a/docs/changelog.d/581-lite-smoke-leg.md
+++ b/docs/changelog.d/581-lite-smoke-leg.md
@@ -1,0 +1,8 @@
+- **Per-PR lite boot smoke: lite-only breakage now fails the PR, not the release (#581).** A new
+  `lite-smoke` job in `pr-value` builds `deploy/lite/Dockerfile.lite` from the PR's own tree, boots
+  it with `make -C deploy/lite up`, probes the front doors, and runs the concurrent-bots smoke —
+  scoped to PRs that touch `deploy/lite/**` or `core/**`, with no secrets (anonymous pulls). Three
+  v0.12.2 release blockers were lite-only bugs this leg would have caught per-PR. A companion
+  `gate:lite-makefile` statically rejects the exact footgun class (a comment line inside a
+  `\`-continued recipe block in `deploy/lite/Makefile`, which once shipped `docker run` with an
+  empty image).

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -4,7 +4,8 @@
  * real as content lands — "an artifact exists only when gate-green" (P9).
  * Usage: node scripts/gates.mjs [readme|isolation|isolation-py|exports|graph|graph-py|schema|
  *                                contract-version|config-contract|python|stack|node|health|access|
- *                                tracing|replay|telemetry|eval|licenses|compose|execution-env|all]
+ *                                tracing|replay|telemetry|eval|licenses|compose|execution-env|
+ *                                lite-makefile|all]
  */
 import { readdirSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -983,7 +984,31 @@ function gateDbBudget() {
   return true;
 }
 
-const GATES = { readme: gateReadme, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
+// gate:lite-makefile (#581) — no comment line inside a `\`-continued recipe block in
+// deploy/lite/Makefile. A bare `#` recipe line without a trailing `\` ENDS the continuation, so
+// make runs the rest in a separate shell where the block's variables are lost (the empty-$IMG
+// class: `docker run … $IMG` with no image); with a trailing `\` the shell comment swallows the
+// continued line instead. Either way the block silently breaks — commentary belongs ABOVE the
+// recipe, in `##` doc lines. Green-on-empty if the Makefile is absent.
+function gateLiteMakefile() {
+  const f = join(ROOT, "deploy", "lite", "Makefile");
+  if (!existsSync(f)) { console.log("  ✓ gate:lite-makefile — no deploy/lite/Makefile (green-on-empty)"); return true; }
+  const lines = readFileSync(f, "utf8").split("\n");
+  const errs = [];
+  let cont = false;  // the previous RECIPE line ended with `\` — we are inside a continued block
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const recipe = line.startsWith("\t");
+    if (recipe && cont && line.trim().startsWith("#"))
+      errs.push(`deploy/lite/Makefile:${i + 1} — comment line inside a \`\\\`-continued recipe block (orphans the rest of the block's shell state; move it above the recipe as a \`##\` doc line)`);
+    cont = recipe && line.replace(/\s+$/, "").endsWith("\\");
+  }
+  if (errs.length) return fail(["lite-makefile (#581, the empty-$IMG class):", ...errs.map((e) => "   " + e)]);
+  console.log("  ✓ gate:lite-makefile — no comment lines inside continued recipe blocks (deploy/lite/Makefile)");
+  return true;
+}
+
+const GATES = { readme: gateReadme, "lite-makefile": gateLiteMakefile, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
 const which = process.argv[2] || "all";
 
 // `seal` (not a gate) — (re)freeze the current published contracts into contracts.seal.json.


### PR DESCRIPTION
Refs #581. From the autonomous session, with adversarial verification by a second agent (verdict: asks — the CI leg's own live run is the remaining anchor).

## The mechanism
`.github/workflows/pr-value.yml` — new `lite-smoke` job: git-diff path scope (`deploy/lite/**`, `core/**`, `package.json`, `pnpm-lock.yaml`; fail-open, fetch-depth-2 diff vs HEAD^1 — correct for both pull_request and dispatch backfill, no third-party paths-filter dep), buildx build of `deploy/lite/Dockerfile.lite` tagged `vexa-lite:dev` (the Makefile's LOCAL_TAG, so `make up` boots the PR image), anonymous read-only cache-from `vexaai/vexa-lite:buildcache`, `make -C deploy/lite up init-db`, 10x front-door probe retry, `ADMIN_TOKEN=ci-admin-token deploy/lite/tests/concurrent-bots.sh`, job summary + failure logs. **Zero secrets anywhere in the job** (A3).

`scripts/gates.mjs` — new `gate:lite-makefile` (in `all` + usage): fails on any comment line inside a `\`-continued recipe block of deploy/lite/Makefile (the empty-`$IMG` footgun class). Changelog via fragment `docs/changelog.d/581-lite-smoke-leg.md` — no hot files touched.

## Observation bundle (issue's numbering)
| Row | Status | Evidence |
|---|---|---|
| A1 lite-smoke job: build → `make up` from PR image → front doors → concurrent-bots | diff-covered, **pending witness** (live CI run) | wiring cross-checked against deploy/lite/Makefile (LOCAL_TAG, ENV_FILE, targets, script all verified real) |
| A2 negative control: reverting the empty-`$IMG` / stale-brick-filter fix goes RED at the right step | **pending witness in CI** | the `$IMG` class is covered NOW by gate:lite-makefile's demonstrated red; the stale-brick-filter class would red at Dockerfile.lite's `test -f dist/index.js` build assertion (unexercised locally — the multi-GB build is exactly the cost the issue moves into CI) |
| A3 PR's own tree, no secrets | **done** | checkout of merge ref like value-fsm; zero secrets refs; cache-from anonymous read-only |
| A4 bare-`#`-in-continued-block lint | **done** | green on clean tree → injected a bare `#` into the `up` recipe's continued block → `✗ deploy/lite/Makefile:164 — comment line inside a \`\\\`-continued recipe block … ❌ gates failed` exit 1 → reverted → green |

The adversarial verifier independently reran the gate red/green pair (red at Makefile:249 on injection, rc=1) and confirmed the check fires before the continuation-state update, so both comment variants are caught. `gates.mjs all` → 32 gates green including the new one.

## Why A2/A1's live leg is still pending — the honest part
**This PR's own diff does not match pr-value's path filter** (workflow + gates + fragment only), so the lite-smoke leg never self-ran on this branch. The real Actions run — one green run, and one red-on-revert (e.g. `workflow_dispatch` against a scratch PR touching `core/**` with the #576 fix reverted) — is the remaining anchor; a maintainer/dispatch run is needed to witness it. Until then "lite breakage now fails the PR" is asserted by construction, not observed. Hence Refs, not Closes.

## Findings / era drift
- Issue says "path-filtered … in pr-value.yml" — the workflow-level paths already include `deploy/lite/**` (line 29, added since the issue was written); what was missing was any lite JOB. Job-level scoping implemented as a git-diff step rather than a new third-party action.
- Design calls needing ruling: (1) clients/terminal is bundled into the lite image but excluded from the lite-smoke scope per the issue's floor — a terminal-only PR skips the leg; widen the grep if wanted. (2) The ~6–8 min claim holds only with a warm buildcache; a cold run can approach the 45-min timeout — the job does no cache-to (would need secrets, which A3 forbids). (3) gate:lite-makefile flags comments only inside continued blocks, not a `#…\` line that starts one — same family, trivially widened if wanted.
- Not checked: actionlint (not installed); any live GH Actions run.
