### PR TITLE
feat(deploy): make probe — standing full-journey smoke probe per surface (#690)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # =============================================================================
 # Vexa open-core — top-level deploy entrypoint (Docker Compose)
 # =============================================================================
-.PHONY: all up dev down bot lite help
+.PHONY: all up dev down bot lite probe help
+
+SURFACE ?= compose
 
 help:
 	@echo "Vexa deploy:"
@@ -9,6 +11,7 @@ help:
 	@echo "  make dev   full stack built from THIS checkout, tagged :dev (contributors)"
 	@echo "  make bot   build the meeting bot from source into vexa/vexa-bot:dev (dev path)"
 	@echo "  make lite  single-container Vexa Lite from the published image"
+	@echo "  make probe full-journey smoke probe of a RUNNING install (SURFACE=compose|lite|helm)"
 	@echo "  make down  stop the compose stack"
 
 all up:              ## full compose stack
@@ -22,6 +25,9 @@ dev:                 ## full stack built from this checkout (:dev tags — never
 
 bot:                 ## build the meeting bot from source → vexa/vexa-bot:dev (dev path; install pulls the published bot)
 	@$(MAKE) --no-print-directory -C deploy/compose bot
+
+probe:               ## full-journey smoke probe (spawn→…→stop + log sweep) of a running install — see deploy/$(SURFACE)/probe.sh
+	@./deploy/$(SURFACE)/probe.sh
 
 down:                ## stop the compose stack
 	@$(MAKE) --no-print-directory -C deploy/compose down

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -35,3 +35,16 @@ docker compose -f deploy/compose/docker-compose.yml down -v
 `.env.example` documents every variable (faithful to the 0.11 `deploy/compose` names: `DB_*`,
 `REDIS_URL`, `ADMIN_TOKEN`, `INTERNAL_API_SECRET`, `MINIO_*`, `BROWSER_IMAGE`/`AGENT_IMAGE`,
 `DOCKER_GID`, `*_HOST_PORT`).
+
+## Smoke probe — "is this install actually working?"
+
+```bash
+make probe                       # from the repo root (compose is the default surface)
+```
+
+Drives the ONE full journey through the gateway front door — spawn → schedule → boot → join →
+transcribe → live-view → stop — then sweeps every component's logs once. Each stage prints
+Expected / Actual / Verdict; a red stage names where the journey broke and fails the command.
+With the mock bot as `BROWSER_IMAGE` (`mock-bot:dev`) the journey is a deterministic green,
+transcript included; with the real bot it drives a dead synthetic meeting to a truthful named
+`join_failure`. See `deploy/compose/probe.sh` (a wrapper over `scripts/probe/journey.sh`).

--- a/deploy/compose/probe.sh
+++ b/deploy/compose/probe.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy/compose/probe.sh — `make probe SURFACE=compose` (the fast default).
+#
+# The compose surface's wrapper around the shared full-journey probe
+# (scripts/probe/journey.sh): resolves the gateway front door + admin-api from
+# .env, mints a scoped API key (bin/provision-token — idempotent), picks the
+# mode from the stack's BROWSER_IMAGE (mock-bot → the deterministic green
+# journey; anything else → the truthful dead-URL journey), and wires the
+# all-component `docker compose logs` sweep.
+#
+# Overrides: GATEWAY_URL · VEXA_API_KEY · ADMIN_TOKEN · PROBE_MODE · PROBE_* (see journey.sh)
+# =============================================================================
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$HERE"
+
+envv() { grep -E "^$1=" .env 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//'; }
+
+GW_PORT="$(envv API_GATEWAY_HOST_PORT)"; GW_PORT="${GW_PORT:-18056}"
+ADMIN_PORT="$(envv ADMIN_API_PORT)";     ADMIN_PORT="${ADMIN_PORT:-18057}"
+PROJECT="${COMPOSE_PROJECT:-$(envv COMPOSE_PROJECT_NAME)}"; PROJECT="${PROJECT:-vexa-v012}"
+GATEWAY_URL="${GATEWAY_URL:-http://127.0.0.1:$GW_PORT}"
+
+if [ -z "${VEXA_API_KEY:-}" ]; then
+  ADMIN_TOKEN="${ADMIN_TOKEN:-$(envv ADMIN_TOKEN)}"
+  : "${ADMIN_TOKEN:?no VEXA_API_KEY given and no ADMIN_TOKEN in env/.env to mint one with}"
+  VEXA_API_KEY="$(ADMIN_TOKEN="$ADMIN_TOKEN" ADMIN_API_URL="http://127.0.0.1:$ADMIN_PORT" \
+    EMAIL=probe@vexa.ai SCOPES=bot,tx ./bin/provision-token)"
+fi
+
+if [ -z "${PROBE_MODE:-}" ]; then
+  BROWSER_IMAGE="${BROWSER_IMAGE:-$(envv BROWSER_IMAGE)}"
+  case "$BROWSER_IMAGE" in *mock*) PROBE_MODE=mock;; *) PROBE_MODE=real;; esac
+fi
+
+# The one-shot all-component sweep: every service's tail together, plus any bot containers
+# the runtime spawned (vexa-mtg-…) — the parallel failure inventory, gathered ONCE.
+PROBE_SWEEP_CMD="
+docker compose -p '$PROJECT' -f '$HERE/docker-compose.yml' logs --tail=40 2>&1;
+echo '--- spawned bot containers (vexa-mtg-*) ---';
+docker ps -a --filter name=vexa-mtg --format '{{.Names}}  {{.Status}}  {{.Image}}' | head -10;
+for c in \$(docker ps -aq --filter name=vexa-mtg | head -3); do
+  echo \"--- \$c (tail 30) ---\"; docker logs --tail 30 \"\$c\" 2>&1;
+done"
+
+export GATEWAY_URL VEXA_API_KEY PROBE_MODE PROBE_SWEEP_CMD
+exec "$ROOT/scripts/probe/journey.sh"

--- a/deploy/compose/probe.sh
+++ b/deploy/compose/probe.sh
@@ -16,7 +16,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/../.." && pwd)"
 cd "$HERE"
 
-envv() { grep -E "^$1=" .env 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//'; }
+envv() { grep -E "^$1=" .env 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//' || true; }
 
 GW_PORT="$(envv API_GATEWAY_HOST_PORT)"; GW_PORT="${GW_PORT:-18056}"
 ADMIN_PORT="$(envv ADMIN_API_PORT)";     ADMIN_PORT="${ADMIN_PORT:-18057}"

--- a/deploy/compose/tests/probe_wiring_test.py
+++ b/deploy/compose/tests/probe_wiring_test.py
@@ -1,0 +1,57 @@
+"""The `make probe` wiring proof (offline — no stack, no docker).
+
+`make probe SURFACE=<lite|compose|helm>` is the standing hot-loop entry point: the
+full-journey smoke (spawn→schedule→boot→join→transcribe→live-view→stop + one-shot log
+sweep) an agent or operator drops a hypothesis into. These assertions pin the WIRING —
+the entry point exists per surface, delegates like `make all`/`make lite` do, and every
+per-surface script is a well-formed executable — so the journey itself (proved live,
+per surface) can never silently lose its front door.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SURFACES = ("compose", "lite", "helm")
+
+
+def test_root_makefile_has_probe_target():
+    makefile = (ROOT / "Makefile").read_text()
+    assert re.search(r"^probe:", makefile, re.M), "root Makefile: no `probe` target"
+    assert "deploy/$(SURFACE)/probe.sh" in makefile, "probe target must delegate per surface"
+    assert re.search(r"^SURFACE \?= compose$", makefile, re.M), "compose is the fast default surface"
+    assert "make probe" in makefile, "`make help` must list probe"
+
+
+def test_per_surface_probe_scripts_exist_and_parse():
+    for surface in SURFACES:
+        script = ROOT / "deploy" / surface / "probe.sh"
+        assert script.is_file(), f"deploy/{surface}/probe.sh missing"
+        assert script.stat().st_mode & 0o111, f"deploy/{surface}/probe.sh not executable"
+        subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_shared_journey_core_exists_and_parses():
+    journey = ROOT / "scripts" / "probe" / "journey.sh"
+    assert journey.is_file() and journey.stat().st_mode & 0o111
+    subprocess.run(["bash", "-n", str(journey)], check=True)
+    # every wrapper funnels into the ONE shared journey (one contract, per-surface fan-out)
+    for surface in SURFACES:
+        text = (ROOT / "deploy" / surface / "probe.sh").read_text()
+        assert "scripts/probe/journey.sh" in text, f"deploy/{surface}/probe.sh must run the shared journey"
+    # the WS listener reuses THIS suite's stdlib client (_ws.py) — no new client invented
+    ws_tail = ROOT / "scripts" / "probe" / "ws_tail.py"
+    assert ws_tail.is_file()
+    assert "from _ws import WS" in ws_tail.read_text()
+
+
+def test_probe_requires_gateway_and_key():
+    """journey.sh fails FAST (exit 1, named missing env) rather than probing nothing."""
+    r = subprocess.run(
+        ["bash", str(ROOT / "scripts" / "probe" / "journey.sh")],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    assert r.returncode != 0
+    assert "GATEWAY_URL" in (r.stderr + r.stdout)

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -71,3 +71,14 @@ Docker to build the images. It proves the control plane stands up and `/health` 
 
 This is a composition layer — it owns no service code and consumes none of the `*.v1` schemas
 directly (each service vendors its own). It mirrors the [`deploy/compose`](../compose/) env contract.
+
+## Smoke probe — "is this install actually working?"
+
+```bash
+make probe SURFACE=helm          # from the repo root; port-forwards if GATEWAY_URL is unset
+GATEWAY_URL=http://<node>:<nodePort> make probe SURFACE=helm   # drive a NodePort directly
+```
+
+The full-journey smoke (spawn → schedule → boot → join → transcribe → live-view → stop) plus a
+one-shot `kubectl logs` sweep of every deployment. Mints its API key through the release secret's
+`ADMIN_API_TOKEN` unless `VEXA_API_KEY` is given. See `deploy/helm/probe.sh`.

--- a/deploy/helm/probe.sh
+++ b/deploy/helm/probe.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy/helm/probe.sh — `make probe SURFACE=helm` (k3s / LKE).
+#
+# The helm surface's wrapper around the shared full-journey probe
+# (scripts/probe/journey.sh). Two front-door strategies:
+#   • GATEWAY_URL set (a NodePort / ingress / LB) → drive it directly — the
+#     same path the release-validate k3s leg exercises.
+#   • GATEWAY_URL unset → kubectl port-forward the gateway (and admin-api, to
+#     mint a key) for the probe's lifetime.
+# ADMIN_TOKEN falls back to the release secret's ADMIN_API_TOKEN.
+#
+# Overrides: NAMESPACE (vexa) · RELEASE (vexa) · GATEWAY_URL · VEXA_API_KEY ·
+#            ADMIN_TOKEN · PROBE_MODE · PROBE_* (see journey.sh)
+# =============================================================================
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+NS="${NAMESPACE:-vexa}"
+RELEASE="${RELEASE:-vexa}"
+GW_SVC="$RELEASE-gateway"
+ADMIN_SVC="$RELEASE-admin-api"
+PF_PIDS=()
+cleanup() { for p in "${PF_PIDS[@]:-}"; do [ -n "$p" ] && kill "$p" 2>/dev/null; done; }
+trap cleanup EXIT
+
+kubectl get ns "$NS" >/dev/null
+
+pf() { # svc local_port → port-forward in background, wait until the local port answers TCP
+  local svc="$1" lport="$2" rport
+  rport="$(kubectl -n "$NS" get svc "$svc" -o jsonpath='{.spec.ports[0].port}')"
+  kubectl -n "$NS" port-forward "svc/$svc" "$lport:$rport" >/dev/null 2>&1 &
+  PF_PIDS+=($!)
+  for i in $(seq 1 20); do
+    (exec 3<>"/dev/tcp/127.0.0.1/$lport") 2>/dev/null && { exec 3>&- 3<&-; return 0; }
+    sleep 1
+  done
+  echo "probe: port-forward svc/$svc never answered on :$lport" >&2; return 1
+}
+
+if [ -z "${GATEWAY_URL:-}" ]; then
+  pf "$GW_SVC" 18856
+  GATEWAY_URL="http://127.0.0.1:18856"
+fi
+
+if [ -z "${VEXA_API_KEY:-}" ]; then
+  if [ -z "${ADMIN_TOKEN:-}" ]; then
+    ADMIN_TOKEN="$(kubectl -n "$NS" get secret "$RELEASE-secrets" \
+      -o jsonpath='{.data.ADMIN_API_TOKEN}' 2>/dev/null | base64 -d || true)"
+  fi
+  : "${ADMIN_TOKEN:?no VEXA_API_KEY given and no ADMIN_TOKEN (env or $RELEASE-secrets) to mint one with}"
+  pf "$ADMIN_SVC" 18857
+  VEXA_API_KEY="$(ADMIN_TOKEN="$ADMIN_TOKEN" ADMIN_API_URL="http://127.0.0.1:18857" \
+    EMAIL=probe@vexa.ai SCOPES=bot,tx "$ROOT/deploy/compose/bin/provision-token")"
+fi
+
+# The one-shot all-component sweep: every deployment's tail + the pod/event state — the
+# whole install's failure set in one kubectl read.
+PROBE_SWEEP_CMD="
+kubectl -n '$NS' get pods -o wide 2>&1;
+for d in \$(kubectl -n '$NS' get deploy -o name); do
+  echo \"--- \$d (tail 40) ---\"; kubectl -n '$NS' logs \"\$d\" --all-containers --tail=40 2>&1;
+done;
+echo '--- recent events ---';
+kubectl -n '$NS' get events --sort-by=.lastTimestamp 2>&1 | tail -20"
+
+PROBE_MODE="${PROBE_MODE:-real}"
+export GATEWAY_URL VEXA_API_KEY PROBE_MODE PROBE_SWEEP_CMD
+"$ROOT/scripts/probe/journey.sh"

--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -142,3 +142,14 @@ Outgrow lite? Switch to [compose](../compose/README.md) — same images, same co
 | Shared X11 display | bots share one Xvfb (`:99`) — best for one browser session at a time |
 | Ephemeral redis | internal redis is in-container; mount `/var/lib/redis` for persistence |
 | Agent ↔ gateway | the agent control plane is reached directly on `:8100` (gateway-fronting is roadmap) |
+
+## Smoke probe — "is this install actually working?"
+
+```bash
+make probe SURFACE=lite          # from the repo root, against a running `make lite`
+```
+
+The full-journey smoke (spawn → schedule → boot → join → transcribe → live-view → stop + a
+one-shot log sweep of the container and every bot workload log), driven through the published
+gateway. Lite runs the real bot, so the dead-URL journey's truthful terminal is a NAMED
+failure — never a fake green. See `deploy/lite/probe.sh`.

--- a/deploy/lite/probe.sh
+++ b/deploy/lite/probe.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy/lite/probe.sh — `make probe SURFACE=lite` (the most divergent path).
+#
+# The Lite surface's wrapper around the shared full-journey probe
+# (scripts/probe/journey.sh): mints a scoped API key through the admin-api
+# INSIDE the vexa-lite container (its port moved between images — autodetect,
+# like the release smoke does), then drives the journey through the published
+# gateway front door. Lite runs the REAL bot as an in-container process, so the
+# mode is `real`: a dead synthetic meeting → a truthful named terminal.
+#
+# Overrides: GATEWAY_URL · VEXA_API_KEY · ADMIN_TOKEN · APP_CONTAINER · PROBE_* (see journey.sh)
+# =============================================================================
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+APP="${APP_CONTAINER:-vexa-lite}"
+GW_PORT="${HOST_GATEWAY_PORT:-8056}"
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:$GW_PORT}"
+ADMIN_TOKEN="${ADMIN_TOKEN:-changeme}"
+
+X() { docker exec "$APP" "$@"; }
+
+if [ -z "${VEXA_API_KEY:-}" ]; then
+  # admin-api port moved between images (8057 → 8001) — autodetect, don't assume.
+  ADMIN_PORT=""
+  for p in 8001 8057; do
+    code="$(X curl -s -m 3 -o /dev/null -w '%{http_code}' "http://localhost:$p/admin/users" \
+            -H "X-Admin-API-Key: $ADMIN_TOKEN" 2>/dev/null || true)"
+    case "$code" in 2*|4*) ADMIN_PORT="$p"; break;; esac
+  done
+  [ -n "$ADMIN_PORT" ] || { echo "probe: admin-api not reachable on 8001/8057 inside $APP" >&2; exit 1; }
+  ADMIN="http://localhost:$ADMIN_PORT"
+  uid="$(X curl -s "$ADMIN/admin/users/email/probe@vexa.ai" -H "X-Admin-API-Key: $ADMIN_TOKEN" \
+         | sed -n 's/.*"id":\([0-9]*\).*/\1/p')"
+  if [ -z "$uid" ]; then
+    uid="$(X curl -s -X POST "$ADMIN/admin/users" -H "X-Admin-API-Key: $ADMIN_TOKEN" \
+           -H 'Content-Type: application/json' \
+           -d '{"email":"probe@vexa.ai","name":"Probe","max_concurrent_bots":3}' \
+           | sed -n 's/.*"id":\([0-9]*\).*/\1/p')"
+  fi
+  [ -n "$uid" ] || { echo "probe: could not create/find the probe user" >&2; exit 1; }
+  VEXA_API_KEY="$(X curl -s -X POST "$ADMIN/admin/users/$uid/tokens?scopes=bot,tx" \
+                  -H "X-Admin-API-Key: $ADMIN_TOKEN" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  [ -n "$VEXA_API_KEY" ] || { echo "probe: could not mint a bot,tx token" >&2; exit 1; }
+fi
+
+# The one-shot all-component sweep: the single container's supervised services + every
+# spawned bot workload's log — the whole Lite failure set in one read.
+PROBE_SWEEP_CMD="
+echo '--- $APP (tail 60) ---'; docker logs --tail 60 '$APP' 2>&1;
+echo '--- bot workload logs (/tmp/vexa-workloads) ---';
+docker exec '$APP' bash -c 'for f in /tmp/vexa-workloads/*.log; do
+  [ -e \"\$f\" ] || { echo \"(no workload logs)\"; break; };
+  echo \"--- \$f (tail 25) ---\"; tail -25 \"\$f\"; done' 2>&1"
+
+PROBE_MODE="${PROBE_MODE:-real}"
+export GATEWAY_URL VEXA_API_KEY PROBE_MODE PROBE_SWEEP_CMD
+exec "$ROOT/scripts/probe/journey.sh"

--- a/docs/changelog.d/690-make-probe.md
+++ b/docs/changelog.d/690-make-probe.md
@@ -1,0 +1,7 @@
+- **`make probe` — the standing full-journey smoke probe, per surface (#690).** One command per
+  install surface (`make probe`, `SURFACE=compose|lite|helm`) drives the whole journey through the
+  gateway front door — spawn → schedule → boot → join → transcribe → live-view → stop — then sweeps
+  every component's logs once. Each stage prints Expected / Actual / Verdict and a red stage names
+  where the journey broke, so an operator (or an agent mid-debug) gets a truthful install verdict
+  in minutes with zero humans. See [Kubernetes deployment](/deployment-kubernetes) and the
+  `deploy/*/probe.sh` wrappers.

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -34,6 +34,22 @@ helm install vexa deploy/helm/charts/vexa -f deploy/helm/charts/vexa/values.yaml
 `values-staging.yaml` and `values-test.yaml` show environment overlays. Chart tests
 (`helm lint` + template tests) live under `deploy/helm/tests/`.
 
+### Is this install actually working? — `make probe SURFACE=helm`
+
+The standing full-journey smoke probe drives spawn → schedule → boot → join → transcribe →
+live-view → stop through the gateway front door, then sweeps every deployment's logs once. Each
+stage prints Expected / Actual / Verdict; a red stage names where the journey broke and fails the
+command, so you get a truthful install verdict in minutes with no meeting and no humans.
+
+```bash
+make probe SURFACE=helm                                        # port-forwards gateway + admin-api
+GATEWAY_URL=http://<node>:<nodePort> make probe SURFACE=helm   # or drive a NodePort directly
+```
+
+It mints its API key from the release secret's `ADMIN_API_TOKEN` (or pass `VEXA_API_KEY`). The
+same journey runs on the other surfaces: `make probe` (compose, the fast default) and
+`make probe SURFACE=lite`.
+
 ## The runtime on Kubernetes
 
 The runtime kernel owns one `runtime.v1` lifecycle (`starting → running → stopping → stopped →

--- a/scripts/probe/README.md
+++ b/scripts/probe/README.md
@@ -1,0 +1,40 @@
+# scripts/probe — the standing full-journey smoke probe (`make probe`)
+
+The hot-loop entry point an agent or operator drops a debugging hypothesis into: ONE
+journey driven entirely through a surface's gateway front door — **spawn → schedule →
+boot → join → transcribe → live-view → stop** — followed by a one-shot all-component
+log sweep (the parallel failure inventory). Each stage prints Expected / Actual /
+Verdict; any red fails the command (exit 1) after the sweep still runs. No real
+meeting, no audio, no human: minutes to a truthful verdict.
+
+## Entry points
+
+```bash
+make probe                    # compose (the fast default)
+make probe SURFACE=lite
+make probe SURFACE=helm
+```
+
+The root `Makefile` delegates to `deploy/<surface>/probe.sh`, exactly as `make all` /
+`make lite` delegate bring-up. Each wrapper resolves its surface's gateway URL, mints
+a `bot,tx` API key (compose: `bin/provision-token` · lite: the in-container admin-api
+· helm: the release secret + `kubectl port-forward`), defines the surface's log-sweep
+command, and runs the ONE shared journey here.
+
+## Files
+
+| File | Role |
+|---|---|
+| `journey.sh` | the shared journey: stages S0–S8, the one contract all surfaces fan into |
+| `ws_tail.py` | live `/ws` feed listener started BEFORE spawn (reuses `deploy/compose/tests/_ws.py` — no new WS client) |
+
+## Modes
+
+- **mock** (`BROWSER_IMAGE` = `mock-bot:dev`, compose) — `bot_name=mock:normal` +
+  `mock:immediate-stop`: a deterministic green full journey, transcript segments and
+  the DELETE-driven stop included.
+- **real** (default) — the real bot at a dead synthetic meeting URL: the truthful
+  terminal is a NAMED failure (`join_failure`), never a fake green. A stack whose
+  spawn is broken goes red at **S3 boot** (the row never leaves `requested`).
+
+Wiring is pinned offline by `deploy/compose/tests/probe_wiring_test.py`.

--- a/scripts/probe/journey.sh
+++ b/scripts/probe/journey.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/probe/journey.sh — the standing full-journey smoke probe (`make probe`).
+#
+# ONE journey, driven entirely through the surface's gateway front door:
+#   spawn → schedule → boot → join → transcribe → live-view → stop
+# followed by a ONE-SHOT all-component log sweep (the parallel failure
+# inventory). Every stage prints Expected / Actual / Verdict; any RED fails the
+# command (exit 1) — the sweep still runs, so a red probe ships its failure
+# inventory in the same output. No real meeting, no audio, no human: the
+# journey reaches a bounded, truthful terminal state in minutes.
+#
+# Modes (PROBE_MODE):
+#   mock — bot_name=mock:<scenario> against a stack whose BROWSER_IMAGE is the
+#          mock bot (mock-bot:dev): a deterministic green full journey,
+#          transcript segments included.
+#   real — the real bot at a dead synthetic meeting URL: the journey's truthful
+#          terminal is a NAMED failure (join_failure) — never a fake green.
+#
+# Journey stages chain (a red stage skips the rest of the chain); the surface
+# probes S5 (WS feed) · S6 (SSE live-view) · S7 (stop route) and the S8 sweep
+# run whenever the gateway is up, so ONE red run still ships the whole
+# failure inventory.
+#
+# env (set by the per-surface wrapper — deploy/{compose,lite,helm}/probe.sh):
+#   GATEWAY_URL           (required) the surface's gateway front door
+#   VEXA_API_KEY          (required) a bot,tx-scoped API key
+#   PROBE_MODE            mock | real                    (default real)
+#   PROBE_SWEEP_CMD       the surface's all-component log-sweep shell command
+#   PROBE_BOOT_TIMEOUT    seconds for the bot to leave `requested`  (default 180)
+#   PROBE_SETTLE_TIMEOUT  seconds to reach a terminal state (default mock 120 / real 300)
+#   PLATFORM              meeting platform               (default google_meet)
+# =============================================================================
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${GATEWAY_URL:?set GATEWAY_URL (the gateway front door of the surface)}"
+: "${VEXA_API_KEY:?set VEXA_API_KEY (a bot,tx-scoped API key)}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+MODE="${PROBE_MODE:-real}"
+PLATFORM="${PLATFORM:-google_meet}"
+BOOT_TIMEOUT="${PROBE_BOOT_TIMEOUT:-180}"
+if [ "$MODE" = mock ]; then SETTLE_TIMEOUT="${PROBE_SETTLE_TIMEOUT:-120}"; else SETTLE_TIMEOUT="${PROBE_SETTLE_TIMEOUT:-300}"; fi
+NATIVE="${PROBE_NATIVE_ID:-aaa-prb$(date +%s | tail -c 5)-bot}"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vexa-probe.XXXXXX")"
+WS_PID=""
+trap '[ -n "$WS_PID" ] && kill "$WS_PID" 2>/dev/null; rm -rf "$WORK"' EXIT
+
+# ── stage bookkeeping ────────────────────────────────────────────────────────
+FAIL=0            # any red anywhere → exit 1
+JOURNEY=1         # the S1→S4 chain: a red link skips the rest of the chain
+SUMMARY=()
+stage()    { printf '\n━━ %s ━━\n' "$1"; }
+expected() { printf '   Expected: %s\n' "$1"; }
+actual()   { printf '   Actual:   %s\n' "$1"; }
+green()    { printf '   Verdict:  GREEN\n'; SUMMARY+=("GREEN  $1"); }
+red()      { printf '   Verdict:  RED — %s\n' "$2"; SUMMARY+=("RED    $1 — $2"); FAIL=1; }
+skipped()  { SUMMARY+=("SKIP   $1 — upstream red"); printf '\n━━ %s ━━\n   Verdict:  SKIPPED (upstream red)\n' "$1"; }
+
+# ── HTTP helpers ─────────────────────────────────────────────────────────────
+CODE=""; BODY=""
+api() { # method path [json-body] → sets CODE + BODY
+  local m="$1" p="$2" d="${3:-}" out
+  if [ -n "$d" ]; then
+    out="$(curl -sS -m 20 -X "$m" "$GATEWAY_URL$p" -H "X-API-Key: $VEXA_API_KEY" \
+           -H 'Content-Type: application/json' -d "$d" -w '\n%{http_code}' 2>&1)"
+  else
+    out="$(curl -sS -m 20 -X "$m" "$GATEWAY_URL$p" -H "X-API-Key: $VEXA_API_KEY" -w '\n%{http_code}' 2>&1)"
+  fi
+  CODE="$(printf '%s' "$out" | tail -1)"
+  BODY="$(printf '%s' "$out" | sed '$d')"
+}
+
+# meeting row for a native id → "status|id|session_uid|completion_reason|failure_stage" (or empty)
+row() {
+  api GET /meetings
+  printf '%s' "$BODY" | NATIVE="$1" python3 -c '
+import json, os, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+ms = d.get("meetings", d if isinstance(d, list) else [])
+m = next((m for m in ms if m.get("native_meeting_id") == os.environ["NATIVE"]), None)
+if m:
+    data = m.get("data") or {}
+    print("|".join(str(x if x is not None else "") for x in (
+        m.get("status"), m.get("id"), m.get("session_uid"),
+        data.get("completion_reason"), data.get("failure_stage"))))
+' 2>/dev/null
+}
+
+# wait until the row's status matches the regex; echoes the final row. Args: native regex timeout
+wait_status() {
+  local native="$1" re="$2" timeout="$3" deadline r st
+  deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    r="$(row "$native")"; st="${r%%|*}"
+    if [ -n "$st" ] && printf '%s' "$st" | grep -qE "$re"; then echo "$r"; return 0; fi
+    [ "$(date +%s)" -ge "$deadline" ] && { echo "$r"; return 1; }
+    sleep 3
+  done
+}
+
+TERMINAL='^(completed|failed)$'
+
+echo "═══ vexa full-journey probe · mode=$MODE · gateway=$GATEWAY_URL · meeting=$PLATFORM/$NATIVE ═══"
+
+# ── S0 · ready — the bot route answers, not just routes ──────────────────────
+stage "S0 ready"
+expected "GET /health 200 and authed GET /meetings non-5xx (meeting-api ready behind the gateway)"
+READY=""
+hc=""
+for i in $(seq 1 24); do
+  hc="$(curl -s -m 5 -o /dev/null -w '%{http_code}' "$GATEWAY_URL/health" || true)"
+  api GET /meetings
+  case "$hc:$CODE" in 200:2*|200:4*) READY=1; break;; esac
+  sleep 5
+done
+actual "/health → ${hc:-none} · GET /meetings → ${CODE:-none}"
+if [ -n "$READY" ]; then green "S0 ready"; else red "S0 ready" "gateway/meeting-api never became ready (120s)"; JOURNEY=0; fi
+
+# ── the live-view listener: subscribe /ws BEFORE spawning, so live frames are caught ──
+WS_LOG="$WORK/ws.jsonl"
+if [ -n "$READY" ]; then
+  python3 "$HERE/ws_tail.py" "$GATEWAY_URL" "$VEXA_API_KEY" "$PLATFORM" "$NATIVE" \
+    "$(( SETTLE_TIMEOUT + 30 ))" "$WS_LOG" >/dev/null 2>&1 &
+  WS_PID=$!
+fi
+
+# ── S1 · spawn ───────────────────────────────────────────────────────────────
+if [ "$JOURNEY" = 1 ]; then
+  stage "S1 spawn"
+  if [ "$MODE" = mock ]; then BOT_NAME="mock:normal"; else BOT_NAME="probe"; fi
+  # transcribe_enabled=false: the probe carries no audio, and a default spawn is (correctly)
+  # refused 503 by the STT-config gate on stacks with no transcription creds. The mock bot
+  # emits its transcript segments regardless, so the transcribe stage still proves the dataflow.
+  expected "POST /bots ($BOT_NAME) → 201 + a meeting row id"
+  api POST /bots "{\"platform\":\"$PLATFORM\",\"native_meeting_id\":\"$NATIVE\",\"bot_name\":\"$BOT_NAME\",\"transcribe_enabled\":false}"
+  actual "→ $CODE $(printf '%s' "$BODY" | head -c 200)"
+  case "$CODE" in
+    201|200) green "S1 spawn";;
+    *) red "S1 spawn" "POST /bots → $CODE (bot never requested)"; JOURNEY=0;;
+  esac
+else skipped "S1 spawn"; fi
+
+# ── S2 · schedule ────────────────────────────────────────────────────────────
+if [ "$JOURNEY" = 1 ]; then
+  stage "S2 schedule"
+  expected "the meeting row appears in GET /meetings (status=requested counts) within 20s"
+  R="$(wait_status "$NATIVE" '.' 20)" || true
+  actual "row: ${R:-<absent>}"
+  if [ -n "$R" ]; then green "S2 schedule"; else red "S2 schedule" "meeting row never appeared"; JOURNEY=0; fi
+else skipped "S2 schedule"; fi
+
+# ── S3 · boot — the discriminator: a broken spawn parks the row at `requested` ───────────────
+if [ "$JOURNEY" = 1 ]; then
+  stage "S3 boot"
+  expected "status leaves 'requested' (bot booted + first lifecycle callback) ≤ ${BOOT_TIMEOUT}s"
+  if R="$(wait_status "$NATIVE" '^(joining|awaiting_admission|active|stopping|completed|failed)$' "$BOOT_TIMEOUT")"; then
+    actual "row: $R"
+    green "S3 boot"
+  else
+    actual "row: ${R:-<absent>} — stuck at spawn/Running: the runtime never booted a bot that called back"
+    red "S3 boot" "bot never left 'requested' in ${BOOT_TIMEOUT}s (spawn/Running stage — runtime/image/boot)"
+    JOURNEY=0
+  fi
+else skipped "S3 boot"; fi
+
+# ── S4 · join ────────────────────────────────────────────────────────────────
+if [ "$JOURNEY" = 1 ]; then
+  stage "S4 join"
+  if [ "$MODE" = mock ]; then
+    expected "mock:normal → admitted → active → self-ends → completed ≤ ${SETTLE_TIMEOUT}s"
+    if R="$(wait_status "$NATIVE" '^completed$' "$SETTLE_TIMEOUT")"; then
+      actual "row: $R"; green "S4 join"
+    else
+      actual "row: ${R:-<absent>}"; red "S4 join" "mock journey did not reach completed in ${SETTLE_TIMEOUT}s"; JOURNEY=0
+    fi
+  else
+    expected "dead meeting URL → a TRUTHFUL named terminal (failed + completion_reason/failure_stage) ≤ ${SETTLE_TIMEOUT}s"
+    if R="$(wait_status "$NATIVE" "$TERMINAL" "$SETTLE_TIMEOUT")"; then
+      IFS='|' read -r st _id _sess reason fstage <<<"$R"
+      actual "terminal: $st (reason=${reason:-<none>} stage=${fstage:-<none>})"
+      if [ "$st" = failed ] && [ -z "$reason" ]; then
+        red "S4 join" "failed with NO attributable reason (P18: failures must name themselves)"
+      else
+        green "S4 join"
+      fi
+    else
+      actual "row: ${R:-<absent>} — no terminal in ${SETTLE_TIMEOUT}s"
+      red "S4 join" "dead-URL journey never reached a truthful terminal (status=${R%%|*})"
+    fi
+  fi
+else skipped "S4 join"; fi
+
+# ── S5 · transcribe — the WS subscribe feed (live frames caught since pre-spawn) ─────────────
+if [ -n "$READY" ]; then
+  stage "S5 transcribe"
+  if [ "$MODE" = mock ]; then
+    expected "WS /ws subscribe acked AND ≥1 transcript reaches the client (live frame or durable GET /transcripts)"
+  else
+    expected "WS /ws subscribe acked (no meeting was joined, so 0 segments is the truthful count)"
+  fi
+  ACK=""
+  for i in $(seq 1 10); do
+    grep -q '"type": *"subscribed"' "$WS_LOG" 2>/dev/null && { ACK=1; break; }; sleep 2
+  done
+  FRAMES="$(grep -c '"type": *"transcript"' "$WS_LOG" 2>/dev/null || true)"; FRAMES="${FRAMES:-0}"
+  api GET "/transcripts/$PLATFORM/$NATIVE"
+  SEGS="$(printf '%s' "$BODY" | python3 -c 'import json,sys
+try: print(len(json.load(sys.stdin).get("segments") or []))
+except Exception: print(0)' 2>/dev/null)"
+  actual "ws ack=${ACK:-no} · live transcript frames=$FRAMES · durable segments=${SEGS:-0} (GET /transcripts → $CODE)"
+  if [ -z "$ACK" ]; then
+    red "S5 transcribe" "WS /ws subscribe never acked"
+  elif [ "$MODE" = mock ] && [ "${FRAMES:-0}" -eq 0 ] && [ "${SEGS:-0}" -eq 0 ]; then
+    red "S5 transcribe" "mock emitted segments but none reached the WS client or the durable transcript"
+  else
+    green "S5 transcribe"
+  fi
+else skipped "S5 transcribe"; fi
+
+# ── S6 · live-view — the SSE feed fetch ──────────────────────────────────────
+if [ -n "$READY" ]; then
+  stage "S6 live-view"
+  expected "GET /agent/meeting/stream (SSE) → 200 text/event-stream for the probe's own meeting"
+  R="$(row "$NATIVE")"; IFS='|' read -r _st MID _SESS _r _f <<<"$R"
+  SESS="${_SESS:-$NATIVE}"
+  HDRS="$WORK/sse.hdrs"
+  curl -s -N -m 6 -D "$HDRS" -o "$WORK/sse.body" \
+    -H "X-API-Key: $VEXA_API_KEY" \
+    "$GATEWAY_URL/agent/meeting/stream?meeting_id=${MID:-0}&session_uid=$SESS" || true
+  SSE_STATUS="$(head -1 "$HDRS" 2>/dev/null | tr -d '\r')"
+  SSE_CT="$(grep -i '^content-type:' "$HDRS" 2>/dev/null | head -1 | tr -d '\r')"
+  actual "${SSE_STATUS:-<no response>} · ${SSE_CT:-<no content-type>}"
+  if printf '%s' "$SSE_STATUS" | grep -q ' 200' && printf '%s' "$SSE_CT" | grep -qi 'text/event-stream'; then
+    green "S6 live-view"
+  else
+    red "S6 live-view" "SSE feed did not answer 200 text/event-stream"
+  fi
+else skipped "S6 live-view"; fi
+
+# ── S7 · stop ────────────────────────────────────────────────────────────────
+if [ -n "$READY" ]; then
+  stage "S7 stop"
+  if [ "$MODE" = mock ]; then
+    # mock:normal self-ends, so the stop leg gets its OWN bot: immediate-stop runs until the
+    # backend drives the leave — exactly the DELETE /bots path a user exercises.
+    STOP_NATIVE="aaa-prb$(date +%s | tail -c 5)-stp"
+    expected "spawn mock:immediate-stop → active, then DELETE /bots → terminal"
+    api POST /bots "{\"platform\":\"$PLATFORM\",\"native_meeting_id\":\"$STOP_NATIVE\",\"bot_name\":\"mock:immediate-stop\",\"transcribe_enabled\":false}"
+    SPAWN_CODE="$CODE"
+    R="$(wait_status "$STOP_NATIVE" '^(active|awaiting_admission)$' 90)" || true
+    api DELETE "/bots/$PLATFORM/$STOP_NATIVE"
+    DEL_CODE="$CODE"
+    if R2="$(wait_status "$STOP_NATIVE" "$TERMINAL" 60)"; then STOPPED=1; else STOPPED=""; fi
+    actual "spawn→$SPAWN_CODE · pre-stop row: ${R:-<absent>} · DELETE→$DEL_CODE · post-stop row: ${R2:-<absent>}"
+    if [ -n "$STOPPED" ] && case "$DEL_CODE" in 2*) true;; *) false;; esac; then
+      green "S7 stop"
+    else
+      red "S7 stop" "DELETE /bots did not drive the bot to a terminal state"
+    fi
+  else
+    R="$(row "$NATIVE")"; ST="${R%%|*}"
+    if [ -n "$ST" ] && ! printf '%s' "$ST" | grep -qE "$TERMINAL"; then
+      expected "DELETE /bots on the still-running bot → 2xx and a terminal state ≤ 90s"
+      api DELETE "/bots/$PLATFORM/$NATIVE"; DEL_CODE="$CODE"
+      if R2="$(wait_status "$NATIVE" "$TERMINAL" 90)"; then STOPPED=1; else STOPPED=""; fi
+      actual "DELETE→$DEL_CODE · post-stop row: ${R2:-<absent>}"
+      if [ -n "$STOPPED" ] && case "$DEL_CODE" in 2*) true;; *) false;; esac; then
+        green "S7 stop"; else red "S7 stop" "DELETE /bots did not drive the bot to a terminal state"; fi
+    else
+      expected "bot already terminal (${ST:-absent}) — the stop route still ANSWERS (non-5xx)"
+      api DELETE "/bots/$PLATFORM/$NATIVE"
+      actual "DELETE → $CODE"
+      case "$CODE" in 2*|4*) green "S7 stop";; *) red "S7 stop" "DELETE /bots → ${CODE:-none} (route dead)";; esac
+    fi
+  fi
+else skipped "S7 stop"; fi
+
+if [ -n "$WS_PID" ]; then kill "$WS_PID" 2>/dev/null; wait "$WS_PID" 2>/dev/null; WS_PID=""; fi
+
+# ── S8 · log sweep — every component's logs, ONCE, together (the parallel inventory) ─────────
+stage "S8 log sweep"
+if [ -n "${PROBE_SWEEP_CMD:-}" ]; then
+  bash -c "$PROBE_SWEEP_CMD" || true
+  SUMMARY+=("DONE   S8 log sweep")
+else
+  echo "   (no PROBE_SWEEP_CMD set by the surface wrapper — sweep skipped)"
+  SUMMARY+=("SKIP   S8 log sweep — no sweep command")
+fi
+
+# ── verdict ──────────────────────────────────────────────────────────────────
+printf '\n═══ PROBE %s · mode=%s · %s/%s ═══\n' "$([ "$FAIL" = 0 ] && echo PASS || echo FAIL)" "$MODE" "$PLATFORM" "$NATIVE"
+for line in "${SUMMARY[@]}"; do printf '  %s\n' "$line"; done
+exit "$FAIL"

--- a/scripts/probe/ws_tail.py
+++ b/scripts/probe/ws_tail.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""ws_tail.py — subscribe to the gateway ``/ws`` feed and record every frame as JSONL.
+
+The probe's live-transcript listener: it REUSES the stdlib WebSocket client the compose
+stack proof already carries (``deploy/compose/tests/_ws.py``) — the probe invents no new
+client. ``journey.sh`` starts it BEFORE spawning the bot, so live transcript frames are
+caught the moment the collector fans them out, and greps the JSONL afterwards.
+
+usage: ws_tail.py <gateway_url> <api_key> <platform> <native_id> <seconds> <out_file>
+
+Writes one JSON object per line (the ``subscribed`` ack first, then each frame).
+Exits 0 iff the subscribe ack arrived.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve()
+sys.path.insert(0, str(HERE.parents[2] / "deploy" / "compose" / "tests"))
+from _ws import WS  # noqa: E402 — the reused stdlib WS client
+
+gateway, api_key, platform, native_id, seconds, out_file = sys.argv[1:7]
+ws_url = gateway.replace("http://", "ws://").replace("https://", "wss://").rstrip("/")
+
+acked = False
+with open(out_file, "w") as out:
+    try:
+        ws = WS(f"{ws_url}/ws?api_key={api_key}", timeout=15)
+    except Exception as e:  # noqa: BLE001 — the probe reads this line as the failure evidence
+        out.write(json.dumps({"type": "probe-error", "error": str(e)}) + "\n")
+        sys.exit(1)
+    ws.send_text(json.dumps({"action": "subscribe",
+                             "meetings": [{"platform": platform, "native_id": native_id}]}))
+    deadline = time.time() + float(seconds)
+    while time.time() < deadline:
+        try:
+            raw = ws.recv_text(timeout=min(5.0, max(0.5, deadline - time.time())))
+        except TimeoutError:
+            continue
+        except Exception:  # noqa: BLE001 — closed by peer / handshake torn down → stop tailing
+            break
+        try:
+            frame = json.loads(raw)
+        except ValueError:
+            frame = {"type": "raw", "raw": raw[:500]}
+        out.write(json.dumps(frame) + "\n")
+        out.flush()
+        if frame.get("type") == "subscribed":
+            acked = True
+    ws.close()
+sys.exit(0 if acked else 1)


### PR DESCRIPTION
Refs #690. From the autonomous session, with adversarial verification by a second agent — and this one is a small showcase of why: **the verifier found a real bug in the probe, and commit c81ec089 fixes it** (details below).

## The mechanism
One shared full-journey probe, three thin surface wrappers:
- `scripts/probe/journey.sh` — S0 ready → S1 spawn → S2 schedule → S3 boot → S4 join → S5 transcribe/WS → S6 live-view/SSE → S7 stop → S8 one-shot log sweep; per-stage Expected/Actual/Verdict; exit 1 on any red (sweep still runs); mock|real modes. `scripts/probe/ws_tail.py` reuses `deploy/compose/tests/_ws.py` (no new WS client).
- `deploy/compose/probe.sh` / `deploy/lite/probe.sh` / `deploy/helm/probe.sh` — per-surface env/port/key resolution + surface-appropriate log sweep (compose+`vexa-mtg-*`; `vexa-lite`+workload logs; kubectl per-deployment).
- `Makefile` — `make probe` (SURFACE ?= compose) + help line. `deploy/compose/tests/probe_wiring_test.py` — offline wiring proof inside every stack-test/gate:compose session. Docs: three deploy READMEs + deployment-kubernetes.mdx "Is this install actually working?" sections; changelog fragment `docs/changelog.d/690-make-probe.md`.

## The bug verification caught (c81ec089)
The adversarial verifier ran `make probe` in a fresh tree without `deploy/compose/.env`: **exit 2, zero output** — `set -euo pipefail` + a failing `grep` inside `envv()` killed the wrapper before any message, despite defaults existing for every value. That silently-unnamed death contradicted the probe's own "truthful, named failure" contract. Fixed with `|| true` in `envv` so defaults apply and failures are named. Verification catching a real bug before a human hit it is the system working as designed.

## Observation bundle (issue's numbering)
| Row | Status | Evidence |
|---|---|---|
| A1 `make probe SURFACE=compose` full journey + sweep, minutes, zero humans | **done (live witness)** | `═══ PROBE PASS · mode=real · google_meet/aaa-prb3191-bot ═══ / GREEN S0…S7 / DONE S8` against the running vexa-v012 stack (~4 min, real vexa/vexa-bot:dev spawned, terminal exit(1) with named join_meeting_error swept in S8). Negative control red on base: `make: *** No rule to make target 'probe'.` Note: this run was REAL mode; a mock-BROWSER_IMAGE green-with-transcript run is pending witness on a MOCK_BOT=1 stack |
| A2 broken-spawn stack → RED at spawn/Running | design-covered, **pending witness** | S3 reds exactly when the row never leaves `requested`; not run against v0.12.8 images this session |
| A3 lite + helm truthful verdicts | **pending witness** | wrappers delivered, syntax/wiring-proven (lite key-mint byte-compatible with the release-validated concurrent-bots.sh path; helm needs a k3s/LKE install) |
| A- no regression; no runtime dep in shipped images | **done** | Makefile targets untouched (additive), operator-side scripts only, full `gates.mjs all` green; wiring pytest `4 passed in 0.04s` |

The verifier independently ran the live PASS (S0–S7 + sweep, exit 0), the gates, and the wiring pytest — and confirmed the wiring tests honestly self-scope to wiring, not journey behavior.

## Findings / era drift
- **Hold-on-ready:** #690 is `state: prepared` with a 2026-07-17 maintainer comment "Hold on ready … stamp follows re-grounding." Built to the prepared floor; this PR should not merge before the ready-stamp lands.
- Stale comment (not spec): mock_scenarios_test.py `_stop_bot` docstring claims DELETE /bots isn't wired — it is (`lifecycle/stop_router.py:77`); S7 uses the real route.
- Hot-file awareness: deployment-kubernetes.mdx gained a subsection (named as the issue's docs surface) — sequence against any sibling PR (e.g. #689) touching the same page.
- Design call needing ruling: in real mode S5 asserts only the WS subscribe ack (0 segments is the truthful count for a never-joined meeting); full transcript-dataflow assertion lives in mock mode.
- Genuine product trail surfaced by the sweep, possibly its own issue: bot retried lifecycle callback → HTTP 422 lifecycle.v1 schema violation when `error_message` is a dict (8h-old container log).
- Live-run residue on the dev stack: probe@vexa.ai user + token, 1 exited vexa-mtg-4 container, 2 terminal meeting rows — nothing running.

## Honest asks
1. A2 (broken-spawn RED) and A3 (lite + helm runs) still need witnessing — the issue's close condition names them; hence Refs, not Closes.
2. Minor open nit from the verifier: `deploy/lite/probe.sh:24` comment is history-flavored ("port moved between images") — restate as designed-present ("admin-api port varies by image; autodetect"). Happy to fold into review.
