### PR TITLE
release: fold #765's fragment — v0.12.11 batch completion

### DIFF
--- a/docs/changelog.d/531-sealed-auth-refs.md
+++ b/docs/changelog.d/531-sealed-auth-refs.md
@@ -1,9 +1,0 @@
-- **Sealed `api.v1` contract: security references now resolve (#531, closes #62).** All 61
-  secured operations in the sealed OpenAPI document referenced `APIKeyHeader` — a scheme the
-  document never defines — so Swagger UI's Authorize dialog could not attach the key and
-  spec-driven client generators emitted clients that never sent `X-API-Key`. The per-operation
-  references now point at the document's own defined schemes: `ApiKeyAuth` (`X-API-Key`) on the
-  56 client operations, `AdminApiKeyAuth` (`X-Admin-API-Key`) on the 5 `/admin/{path}`
-  operations — the headers the running gateway and admin-api already honor. `gate:schema`'s
-  `validate.mjs` now pins referential integrity (every referenced scheme must be defined, first
-  offenders named), so a re-capture can never re-import the bug.

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -249,6 +249,16 @@ probe), not inferred from planning docs.
   vX.Y.Z --verify-tag --latest --notes-file <notes>`; the guard's retract-to-draft re-check now
   lives under the act it guards. An operator ships a release end-to-end from the runbook alone.
 
+- **Sealed `api.v1` contract: security references now resolve (#531, closes #62).** All 61
+  secured operations in the sealed OpenAPI document referenced `APIKeyHeader` — a scheme the
+  document never defines — so Swagger UI's Authorize dialog could not attach the key and
+  spec-driven client generators emitted clients that never sent `X-API-Key`. The per-operation
+  references now point at the document's own defined schemes: `ApiKeyAuth` (`X-API-Key`) on the
+  56 client operations, `AdminApiKeyAuth` (`X-Admin-API-Key`) on the 5 `/admin/{path}`
+  operations — the headers the running gateway and admin-api already honor. `gate:schema`'s
+  `validate.mjs` now pins referential integrity (every referenced scheme must be defined, first
+  offenders named), so a re-capture can never re-import the bug.
+
 ## Versioning
 
 Vexa follows semantic-ish versioning at the `MAJOR.MINOR` line; breaking changes are called out in the


### PR DESCRIPTION
Final step-0 completion: `changelog-collect.mjs` folds `531-sealed-auth-refs.md` (rode #765 into the extended batch). Tag `v0.12.11` cuts from this merge commit. Batch = 14 PRs since v0.12.10.