### PR TITLE
fix(runtime): kernel merges Profile.base_env into the spawn env — chart-set BOT_SPEAKER_* tuning reaches the bot (#771)

### DIFF
--- a/core/runtime/src/runtime_kernel/kernel.py
+++ b/core/runtime/src/runtime_kernel/kernel.py
@@ -159,9 +159,10 @@ class Runtime:
         if existing is not None and existing.state in (RuntimeState.starting, RuntimeState.running):
             return existing
 
-        runnable = self.profiles.resolve(spec.profile)
-        if runnable is None:
+        profile = self.profiles.get(spec.profile)
+        if profile is None:
             raise ValueError(f"unknown profile: {spec.profile!r}")
+        runnable = profile.runnable
 
         # Quota check (O-RT-2): reject the N+1th active workload for this owner.
         if self.owner_quota is not None:
@@ -176,7 +177,12 @@ class Runtime:
         self._persist(spec, status)
         self._emit(spec.workloadId, RuntimeState.starting)
         try:
-            self._handles[spec.workloadId] = self.backend.start(spec.workloadId, runnable, spec.env)
+            # The profile's base_env is the deployment-wide floor (e.g. meeting-bot's BOT_SPEAKER_*
+            # tuning, rendered onto the runtime pod by the chart); the per-workload spec.env is
+            # layered on top so an explicit spec value always wins. Without this merge the base_env
+            # never reaches the spawned pod and chart-set tuning is dead config (issue #771).
+            effective_env = {**profile.base_env, **spec.env}
+            self._handles[spec.workloadId] = self.backend.start(spec.workloadId, runnable, effective_env)
         except Exception:
             status.state = RuntimeState.stopped
             status.stopReason = StopReason.start_failed

--- a/core/runtime/tests/test_lifecycle.py
+++ b/core/runtime/tests/test_lifecycle.py
@@ -72,10 +72,12 @@ class _FakeBackend:
 
     def __init__(self) -> None:
         self.starts: list[str] = []
+        self.envs: dict[str, dict[str, str]] = {}
         self.exit_codes: dict[str, int | None] = {}
 
     def start(self, workload_id, runnable, env):
         self.starts.append(workload_id)
+        self.envs[workload_id] = dict(env)
         self.exit_codes[workload_id] = None
         return WorkloadHandle(id=workload_id, impl=workload_id)
 
@@ -125,6 +127,31 @@ def test_create_respawns_after_self_exit():
     respawned = rt.create(WorkloadSpec(workloadId="w1", profile="test", env={}))
     assert respawned.state is RuntimeState.running
     assert be.starts == ["w1", "w1"]                    # exit-reflection let the re-create spawn
+
+
+def test_profile_base_env_reaches_the_spawn_env():
+    """A profile's base_env (e.g. meeting-bot's BOT_SPEAKER_* tuning rendered onto the runtime pod)
+    must be merged into the spawned workload's env, with the per-workload spec.env layered on top
+    (spec wins). Without the merge the chart's tuning never reaches the bot pod (issue #771)."""
+    from runtime_kernel.profiles import Profile, ProfileRegistry, Runnable
+
+    reg = ProfileRegistry({
+        "meeting-bot": Profile(
+            name="meeting-bot",
+            runnable=Runnable(image="bot:img", command=None),
+            base_env={"BOT_SPEAKER_MIN_AUDIO_SEC": "1.5", "BOT_SPEAKER_MAX_BUFFER_SEC": "8"},
+        )
+    })
+    be = _FakeBackend()
+    rt = Runtime(backend=be, profiles=reg)
+    rt.create(WorkloadSpec(
+        workloadId="w1", profile="meeting-bot",
+        env={"VEXA_BOT_CONFIG": "{}", "BOT_SPEAKER_MAX_BUFFER_SEC": "12"},
+    ))
+    spawned = be.envs["w1"]
+    assert spawned["BOT_SPEAKER_MIN_AUDIO_SEC"] == "1.5"   # base_env floor reaches the pod
+    assert spawned["VEXA_BOT_CONFIG"] == "{}"              # spec.env preserved
+    assert spawned["BOT_SPEAKER_MAX_BUFFER_SEC"] == "12"   # spec.env wins over base_env
 
 
 def test_create_touches_across_a_runtime_restart():

--- a/docs/changelog.d/771-bot-speaker-env.md
+++ b/docs/changelog.d/771-bot-speaker-env.md
@@ -1,0 +1,6 @@
+- **Speaker-stream tuning now reaches spawned bots (#771).** `runtime.speakerStream.*`
+  (`BOT_SPEAKER_MIN_AUDIO_SEC`, `BOT_SPEAKER_SUBMIT_INTERVAL_SEC`, `BOT_SPEAKER_CONFIRM_THRESHOLD`,
+  `BOT_SPEAKER_MAX_BUFFER_SEC`, `BOT_SPEAKER_IDLE_TIMEOUT_SEC`) rendered onto the runtime pod are
+  now merged into each spawned bot workload's environment, so the accuracy/latency knobs actually
+  take effect on k8s and docker-backed deployments instead of rendering as dead config. See
+  [Configuration](/configuration).


### PR DESCRIPTION
Fixes the production defect in #771 at its actual point of introduction — which the hop-by-hop trace showed is NOT where the report suggested.

## The trace (all four hops, current main)
1. chart → runtime pod env: **works** (all 5 vars, `deployment-runtime.yaml:65-74`)
2. runtime env → profile passthrough: **works, complete** (all 5, `profiles.py:99-129`, landed with #609/`fc5c7c7e`)
3. **kernel → backend spawn env: BROKEN — the defect.** `create()` resolved only the `Runnable` and passed `spec.env` alone to `backend.start`; `Profile.base_env` had **zero read sites** — the docstring promised a merge that was never implemented. All three backends faithfully set what they receive; the drop was purely at the kernel.
4. bot reads `BOT_SPEAKER_*` from its own process env: **works** (`config.ts:139-168` → pipeline, also #609)

So the report's suggested fix (thread values into `BOT_CONFIG`) was one layer off — the bridge existed and was never applied. **12-line kernel fix**: `effective_env = {**profile.base_env, **spec.env}` (spec wins).

## Bundle
| Row | Status | Evidence |
|---|---|---|
| env reaches the spawn | **desk red→green** | new `test_profile_base_env_reaches_the_spawn_env`: RED on base (`KeyError: 'BOT_SPEAKER_MIN_AUDIO_SEC'`), green with fix; asserts floor arrives + spec.env preserved + spec.env overrides |
| no regression | **green** | runtime suite **156 passed**; bot suite green incl. its own env-read test; `gates.mjs all` green (config-contract 182 keys ≡ surfaces ≡ reads) |
| live behavioral witness (fragment sizes/segment caps on k8s) | **pending witness** | the reporter's cluster is the natural rig — this hop-fix is provable offline, the behavior change is theirs to see |

Compose and lite were never affected (they pass env to the bot directly). Refs #771 — the live row stays open. From the production-P0 sitting; opus implementation, fable verification.