### PR TITLE
fix(recordings): master is re-assemblable — mid-meeting reads can't freeze it, chunk listing paginates to exhaustion (#768 #769)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/adapters.py
@@ -48,8 +48,29 @@ class S3Storage:
         await self._run(self._c().put_object, Bucket=self._bucket, Key=key, Body=data, ContentType=content_type)
 
     async def list(self, prefix: str) -> list[str]:
-        resp = await self._run(self._c().list_objects_v2, Bucket=self._bucket, Prefix=prefix)
-        return sorted(o["Key"] for o in resp.get("Contents", []))
+        # S3 (and every S3-compatible backend) caps a single list_objects_v2 response at 1000 keys and
+        # signals more via IsTruncated + NextContinuationToken (#769). Loop to exhaustion — a single
+        # unpaginated call silently drops every chunk past the first page, so a >1000-chunk recording
+        # would assemble a master from only its first 1000 objects.
+        keys: list[str] = []
+        token: Optional[str] = None
+        while True:
+            kw = {"Bucket": self._bucket, "Prefix": prefix}
+            if token is not None:
+                kw["ContinuationToken"] = token
+            resp = await self._run(self._c().list_objects_v2, **kw)
+            keys.extend(o["Key"] for o in resp.get("Contents", []))
+            if not resp.get("IsTruncated"):
+                break
+            token = resp.get("NextContinuationToken")
+            if not token:
+                # Truncated but no continuation token — the backend contract is broken; stop rather
+                # than loop forever, but do NOT swallow it silently.
+                raise RuntimeError(
+                    f"list_objects_v2 reported IsTruncated with no NextContinuationToken "
+                    f"(prefix={prefix!r}); chunk listing may be incomplete"
+                )
+        return sorted(keys)
 
     async def get(self, key: str) -> bytes:
         obj = await self._run(self._c().get_object, Bucket=self._bucket, Key=key)

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/router.py
@@ -255,24 +255,23 @@ def build_router(
         )
         if mf is None:
             raise HTTPException(status_code=404, detail="No such media file")
-        # Finalize-on-read: serve the ASSEMBLED master, never a raw part or the empty final-signal
-        # chunk. #491 — the old guard (`if not mf.is_final`) trusted the media-file's is_final flag as
-        # "storage_path is playable"; but after an empty-final fold storage_path names the zero-byte
-        # signal chunk (0 bytes served) or, with the jsonb fix, the LAST data part (#412: last-part-
-        # only). is_final must stop doubling as "playable" — the ONLY playable object is master.<fmt>,
-        # so finalize (idempotent) unless storage_path already IS the master key, then re-read.
-        storage_path = mf.get("storage_path") or ""
-        if not storage_path.rsplit("/", 1)[-1].startswith("master."):
-            await finalize_master(
-                repo, storage, meeting_id=rec["meeting_id"], recording_id=recording_id,
-                media_type=mf.get("type", type),
-            )
-            recs = await repo.list_meeting_recordings(user_id)
-            rec = next((r for r in recs if r.get("id") == recording_id), rec)
-            mf = next(
-                (m for m in (rec or {}).get("media_files", []) if str(m.get("id")) == str(media_file_id)),
-                mf,
-            )
+        # Finalize-on-read, ALWAYS: serve the ASSEMBLED master, never a raw part or the empty
+        # final-signal chunk. The ONLY playable object is master.<fmt>. finalize_master is
+        # re-assemblable and idempotent (#768) — it rebuilds only when new chunks arrived since the
+        # master was last assembled — so calling it unconditionally reflects late chunks and makes a
+        # mid-recording read impossible to freeze at the retrieval boundary too. (A prior guard that
+        # skipped finalize once storage_path already named the master key was the second freeze door:
+        # after a mid-meeting /master it never re-assembled, serving the stale partial forever.)
+        await finalize_master(
+            repo, storage, meeting_id=rec["meeting_id"], recording_id=recording_id,
+            media_type=mf.get("type", type),
+        )
+        recs = await repo.list_meeting_recordings(user_id)
+        rec = next((r for r in recs if r.get("id") == recording_id), rec)
+        mf = next(
+            (m for m in (rec or {}).get("media_files", []) if str(m.get("id")) == str(media_file_id)),
+            mf,
+        )
         storage_path = mf.get("storage_path")
         if not storage_path:
             raise HTTPException(status_code=404, detail="Media file has no storage path")

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/service.py
@@ -134,9 +134,16 @@ async def finalize_master(
     recording_id: int,
     media_type: str = "audio",
 ) -> Optional[str]:
-    """Build + upload the master for a recording media-file and stamp the JSONB. Idempotent: if the
-    master already exists in storage it is reused. Returns the master storage key, or ``None`` when
-    there is nothing to finalize.
+    """Build + upload the master for a recording media-file and stamp the JSONB. Returns the master
+    storage key, or ``None`` when there is nothing to finalize.
+
+    RE-ASSEMBLABLE, not write-once (#768). Existence is the WRONG freshness signal: a read while the
+    meeting is still recording must not permanently freeze the master. The master is (re)built when
+    it is absent OR when the number of chunk objects under the recording's prefix differs from the
+    count the current master already represents (``assembled_chunk_count``). So a mid-recording read
+    assembles a partial, and every later read that finds new chunks rebuilds — which also repairs a
+    master frozen by a pre-fix stack on its next read. The freeze is impossible to reintroduce
+    silently: the assembled-chunk-count is recorded and compared, and a rebuild-on-growth is logged.
     """
     recordings = await repo.get_recordings(meeting_id)
     rec = next((r for r in recordings if r.get("id") == recording_id), None)
@@ -149,11 +156,41 @@ async def finalize_master(
     media_format = mf.get("format", "wav")
     master_key = master_storage_key(mf["storage_path"], media_format)
 
-    if not await storage.exists(master_key):
-        # Gather the chunk objects under the recording's prefix (excluding any prior master).
-        prefix = mf["storage_path"].rsplit("/", 1)[0]
-        keys = [k for k in await storage.list(prefix) if not k.rsplit("/", 1)[-1].startswith("master.")]
-        chunks = [await storage.get(k) for k in sorted(keys)]
+    # Gather the chunk objects under the recording's prefix (excluding any prior master).
+    prefix = mf["storage_path"].rsplit("/", 1)[0]
+    keys = sorted(
+        k for k in await storage.list(prefix) if not k.rsplit("/", 1)[-1].startswith("master.")
+    )
+    listed_count = len(keys)
+    assembled_count = mf.get("assembled_chunk_count")
+
+    # Loud guard (#769): the number of chunks we're about to assemble vs what the JSONB fold counted.
+    # A mismatch means chunks were dropped from the listing (truncation) or the fold — surface it.
+    jsonb_count = mf.get("chunk_count")
+    if jsonb_count is not None and listed_count != jsonb_count:
+        log_event(
+            "recording_chunk_count_mismatch", audience="operator", span="recordings.finalize",
+            meeting_id=str(meeting_id),
+            fields={"recording_id": recording_id, "media_type": media_type,
+                    "listed_count": listed_count, "jsonb_chunk_count": jsonb_count},
+        )
+
+    master_exists = await storage.exists(master_key)
+    # Rebuild only when there ARE chunks to assemble (listed_count > 0) and either no master exists yet
+    # or the chunk count changed since the master was last assembled. With zero chunk objects we never
+    # rebuild — an existing master is served as-is rather than assembled from nothing.
+    rebuild = listed_count > 0 and ((not master_exists) or assembled_count != listed_count)
+    if rebuild:
+        if master_exists and assembled_count is not None and listed_count > assembled_count:
+            # A prior (partial) master is being superseded by chunks that arrived after it — the exact
+            # #768 unfreeze. Log it so a re-freeze regression is noisy rather than silent.
+            log_event(
+                "recording_master_reassembled", audience="operator", span="recordings.finalize",
+                meeting_id=str(meeting_id),
+                fields={"recording_id": recording_id, "media_type": media_type,
+                        "prior_assembled_count": assembled_count, "new_count": listed_count},
+            )
+        chunks = [await storage.get(k) for k in keys]
         master_bytes = build_recording_master(chunks, media_format)
         await storage.upload(master_key, master_bytes, content_type=_content_type(media_format))
 
@@ -169,6 +206,7 @@ async def finalize_master(
             return recs, None
         m["storage_path"] = master_key
         m["is_final"] = True
+        m["assembled_chunk_count"] = listed_count
         m["finalized_at"] = _now_iso()
         m["finalized_by"] = "recording_finalizer.master"
         existing_pb = r.get("playback_url") or {}

--- a/core/meetings/services/meeting-api/tests/test_recordings.py
+++ b/core/meetings/services/meeting-api/tests/test_recordings.py
@@ -413,3 +413,130 @@ async def test_single_final_chunk_downloads_byte_complete():
     assert raw.status_code == 200, raw.text
     assert raw.content == build_recording_master([part], "wav")
     assert raw.content[44:] == bytes([9]) * 16
+
+
+# ── #768: a mid-recording read must NOT freeze the master (finalize is re-assemblable) ────────────
+
+
+async def test_finalize_after_midread_reassembles_all_chunks():
+    """#768 (the exact prod scenario): a GET /master while the meeting is STILL recording must not
+    permanently freeze the master. Two chunks land; a mid-recording finalize assembles a 2-chunk
+    partial master; three more chunks arrive and the recording completes; the next finalize must
+    REBUILD the master to contain ALL five chunks. RED on base: finalize short-circuits on
+    ``storage.exists(master_key)`` and never rebuilds → the served master stays the 2-chunk partial
+    (in prod: a 4h meeting frozen at 49s, 6.6% of the audio)."""
+    repo, storage = _seeded()
+    early = [_counting_wav(k) for k in range(2)]
+    rid = None
+    for k, part in enumerate(early):
+        r = await upload_chunk(
+            repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+            data=part, media_type="audio", media_format="wav", chunk_seq=k, is_final=False,
+        )
+        rid = r["recording_id"]
+    # Mid-recording read: assemble a PARTIAL master (the prod "check on the recording" gesture).
+    mid_key = await finalize_master(repo, storage, meeting_id=MEETING_ID, recording_id=rid)
+    assert storage.blobs[mid_key] == build_recording_master(early, "wav"), "partial master = 2 chunks"
+
+    # More chunks arrive AFTER the read, then the meeting ends (empty is_final signal).
+    late = [_counting_wav(k) for k in range(2, 5)]
+    for k, part in enumerate(late, start=2):
+        await upload_chunk(
+            repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+            data=part, media_type="audio", media_format="wav", chunk_seq=k, is_final=False,
+        )
+    await upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=b"", media_type="audio", media_format="wav", chunk_seq=5, is_final=True,
+    )
+
+    # The finalize on completion must REASSEMBLE all five chunks — not serve the frozen partial.
+    final_key = await finalize_master(repo, storage, meeting_id=MEETING_ID, recording_id=rid)
+    all_parts = early + late
+    assert storage.blobs[final_key] == build_recording_master(all_parts, "wav"), (
+        "the completed master must contain ALL chunks, not the mid-read partial"
+    )
+    # Independent arithmetic oracle: the PCM is each part's counting bytes, in order, none dropped.
+    assert storage.blobs[final_key][44:] == b"".join(bytes([k]) * _PART_PCM_LEN for k in range(5))
+
+
+async def test_master_route_reflects_late_chunks_after_midread():
+    """#768 at the route altitude: GET /master mid-recording, then more chunks + completion, then
+    GET .../raw serves the byte-complete master. RED on base: the first /master freezes it."""
+    repo, storage = _seeded()
+    early = [_counting_wav(k) for k in range(2)]
+    rid = None
+    for k, part in enumerate(early):
+        r = await upload_chunk(
+            repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+            data=part, media_type="audio", media_format="wav", chunk_seq=k, is_final=False,
+        )
+        rid = r["recording_id"]
+    client = _client_for(repo, storage)
+    # Mid-recording read via the route (this is what froze prod).
+    assert client.get(f"/recordings/{rid}/master?type=audio", headers=_HDRS).status_code == 200
+    late = [_counting_wav(k) for k in range(2, 5)]
+    for k, part in enumerate(late, start=2):
+        await upload_chunk(
+            repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+            data=part, media_type="audio", media_format="wav", chunk_seq=k, is_final=False,
+        )
+    await upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=b"", media_type="audio", media_format="wav", chunk_seq=5, is_final=True,
+    )
+    rec = client.get("/recordings", headers=_HDRS).json()["recordings"][0]
+    mf = _first_audio(rec)
+    raw = client.get(f"/recordings/{rid}/media/{mf['id']}/raw?type=audio", headers=_HDRS)
+    assert raw.status_code == 200, raw.text
+    assert raw.content == build_recording_master(early + late, "wav")
+
+
+# ── #769: chunk listing must paginate past the S3 1000-key cap ────────────────────────────────────
+
+
+class _PagedS3Client:
+    """A stub boto3 S3 client whose ``list_objects_v2`` paginates at ``PAGE`` keys — mirroring the
+    real S3/S3-compatible 1000-key response cap — signalling more via ``IsTruncated`` +
+    ``NextContinuationToken`` (an opaque offset here)."""
+
+    PAGE = 1000
+
+    def __init__(self, keys):
+        self._keys = sorted(keys)
+
+    def list_objects_v2(self, Bucket, Prefix, ContinuationToken=None, **kw):
+        matched = [k for k in self._keys if k.startswith(Prefix)]
+        start = int(ContinuationToken) if ContinuationToken else 0
+        page = matched[start : start + self.PAGE]
+        resp = {"Contents": [{"Key": k} for k in page]}
+        nxt = start + self.PAGE
+        if nxt < len(matched):
+            resp["IsTruncated"] = True
+            resp["NextContinuationToken"] = str(nxt)
+        else:
+            resp["IsTruncated"] = False
+        return resp
+
+
+async def test_s3_storage_list_paginates_past_1000_keys():
+    """#769: a single ``list_objects_v2`` caps at 1000 keys and signals more via IsTruncated /
+    NextContinuationToken. ``S3Storage.list`` must loop to exhaustion. RED on base: the single
+    unpaginated call returns only the first 1000 of 1500 keys, silently dropping 500 chunks."""
+    from meeting_api.recordings.adapters import S3Storage
+
+    prefix = "recordings/7/42/sess/audio/"
+    keys = [f"{prefix}{i:06d}.wav" for i in range(1500)]
+
+    class _Stub(S3Storage):
+        def __init__(self, client):
+            super().__init__(bucket="b")
+            self._stub = client
+
+        def _c(self):
+            return self._stub
+
+    storage = _Stub(_PagedS3Client(keys))
+    listed = await storage.list(prefix)
+    assert len(listed) == 1500, f"expected all 1500 keys across pages, got {len(listed)}"
+    assert listed == sorted(keys)

--- a/docs/changelog.d/768-recordings-freeze.md
+++ b/docs/changelog.d/768-recordings-freeze.md
@@ -1,0 +1,5 @@
+- **Recordings: opening a recording mid-meeting no longer freezes it (#768).** Master assembly is now
+  re-assemblable instead of write-once — a `GET /recordings/{id}/master` while the meeting is still
+  recording serves the audio captured so far without permanently freezing the file, and every later
+  read that finds new chunks rebuilds the master (repairing already-frozen recordings on their next
+  read). The assembled-chunk-count is recorded and compared so the freeze cannot silently return.

--- a/docs/changelog.d/769-chunk-pagination.md
+++ b/docs/changelog.d/769-chunk-pagination.md
@@ -1,0 +1,4 @@
+- **Recordings: long recordings over ~1000 chunks are assembled in full (#769).** The chunk listing
+  now paginates `list_objects_v2` to exhaustion (looping on `IsTruncated`/`NextContinuationToken`)
+  instead of reading only the first 1000-key page, so a master built from a very long meeting no
+  longer silently drops everything past the first page. A chunk-count mismatch is logged loudly.


### PR DESCRIPTION
Production P0 from #768 + #769 (one seam: recordings assembly correctness). Refs #768, Refs #769 — live legs stay open on the issues.

## The mechanism
**#768 — two freeze doors closed, not one.** (1) `finalize_master` no longer treats existence as freshness: the master rebuilds whenever the chunk-object count under the prefix differs from the recorded `assembled_chunk_count` — mid-recording reads assemble an honest partial, later reads rebuild with the new chunks, and **a master frozen by a pre-fix stack self-repairs on its next read** (the reporter's 4h/6.6% meeting: all 955 stranded chunks are still in storage — one GET after deploy rebuilds it). (2) The second door the issue didn't name: `/raw` skipped finalize entirely once `storage_path` named the master key — fixed; `/raw` always re-finalizes.
**#769 —** `S3Storage.list` loops `IsTruncated`/`NextContinuationToken` to exhaustion; truncated-without-token raises instead of silently shortening; plus the loud `recording_chunk_count_mismatch` operator event when listed ≠ folded counts.

## Observation bundle (the issues' Reproduce sections, offline)
| Scenario | Status | Evidence |
|---|---|---|
| #768 steps 1–5: read mid-recording, chunks keep arriving, final master = ALL chunks | **desk red→green** | `test_finalize_after_midread_reassembles_all_chunks` (service altitude) + `test_master_route_reflects_late_chunks_after_midread` (HTTP altitude): RED on base with the byte-diff showing the 2-chunk partial vs 5-chunk full; green with fix, byte-equality + PCM oracle |
| frozen-master self-repair | **desk** | same tests: mid-read persists a real partial, completion finalize rebuilds on count growth |
| #769 >1000 chunks | **desk red→green** | `test_s3_storage_list_paginates_past_1000_keys`: 1500 keys / 2 pages — base got 1000, fix gets 1500 |
| no regression | **green** | meeting-api suite **753 passed**; recording-relevant gates green (compose real-stack, contract-conformance). One unrelated environmental red on this host: `test_docker_backend_real_container_lifecycle` — stuck `vexa-rt-dockertest` container (409 removal-in-progress), untouched subsystem, reproduces without this diff |
| live re-read of the reporter's frozen prod master | **pending witness** | the deploy itself is the rig — one GET, compare duration |

## Recorded design choice
Persist-with-rebuild over finalize-only-in-terminal-state: `/raw` streams from object storage (no temp-body path), the existing crash-partial test requires in-progress `/raw` to serve assembled parts, and rebuild-on-growth is what repairs pre-fix frozen masters. Freshness = monotonic chunk count, not meeting status — also correct for crash-without-final recordings. Adjacent benign find recorded on the issue thread: the JSONB fold drops `assembled_chunk_count` on later chunks — errs safe (forces rebuild), noted for the future.

From the production-P0 sitting; opus implementation, fable verification.