### PR TITLE
feat(helm): topologySpreadConstraints (global + per-component, own-selector injected) · agent-api Recreate on RWO workspace PVC (#770 #774)

### DIFF
--- a/deploy/helm/charts/vexa/README.md
+++ b/deploy/helm/charts/vexa/README.md
@@ -29,6 +29,38 @@ ingress) and the values table. Key knobs: `global.imageTag`, `runtime.backend`
 (`k8s`|`docker`|`process`), `secrets.*` (or `secrets.existingSecretName`), `postgres/redis/minio.enabled`,
 `pgbouncer.enabled`, `ingress.*`.
 
+## Spreading replicas across nodes
+
+`replicaCount > 1` alone buys rolling-update safety, not availability — the scheduler may place
+every replica on one node, so losing that node takes the whole component down. Add pod topology
+spread to force replicas apart. `global.topologySpreadConstraints` applies to **every** component
+(gateway · admin-api · meeting-api · runtime · agent-api · terminal); when a constraint omits
+`labelSelector`, the chart injects **that component's own pod selector**, so one block means
+"spread each component's own replicas":
+
+```yaml
+global:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway   # best-effort — small/single-node clusters still schedule
+```
+
+Override per component with `<component>.topologySpreadConstraints` (same shape, wins over the
+global default for that component only):
+
+```yaml
+gateway:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+```
+
+Provide your own `labelSelector` in a constraint to opt out of the automatic injection. Empty
+default (the shipped value) renders nothing — single-node / k3s installs are unaffected. Use
+`ScheduleAnyway`, not `DoNotSchedule`, unless you can guarantee enough nodes, or pods stay Pending.
+
 ## Validate (no cluster)
 
 ```bash

--- a/deploy/helm/charts/vexa/templates/_helpers.tpl
+++ b/deploy/helm/charts/vexa/templates/_helpers.tpl
@@ -134,6 +134,40 @@ vexaai/vexa-bot:v012
 {{- end -}}
 {{- end -}}
 
+{{/*
+vexa.topologySpreadConstraints — render pod topology spread constraints for a component.
+
+Call:  include "vexa.topologySpreadConstraints" (list $root $componentValues "component-name")
+  - $root           = the template root context (.)
+  - $componentValues = that component's values map (e.g. .Values.gateway)
+  - "component-name" = the value of its app.kubernetes.io/component label (e.g. "gateway")
+
+Per-component `.topologySpreadConstraints` wins over `global.topologySpreadConstraints`
+(same override shape as replicaCount/resources). Each constraint that omits `labelSelector`
+gets the component's OWN pod selector injected — name + instance + component — so the default
+meaning is "spread THIS component's replicas across the topology", which is the part users get
+wrong when they hand-write it. A constraint that carries its own labelSelector is rendered
+verbatim. Renders NOTHING when neither global nor per-component constraints are set (empty
+default is byte-identical to a chart without the field).
+*/}}
+{{- define "vexa.topologySpreadConstraints" -}}
+{{- $root := index . 0 -}}
+{{- $componentValues := index . 1 -}}
+{{- $component := index . 2 -}}
+{{- $constraints := $componentValues.topologySpreadConstraints | default $root.Values.global.topologySpreadConstraints -}}
+{{- if $constraints -}}
+{{- $selector := dict "matchLabels" (dict "app.kubernetes.io/name" (include "vexa.name" $root) "app.kubernetes.io/instance" $root.Release.Name "app.kubernetes.io/component" $component) -}}
+topologySpreadConstraints:
+{{- range $constraints }}
+{{- if hasKey . "labelSelector" }}
+  -{{ toYaml . | nindent 4 }}
+{{- else }}
+  -{{ toYaml (merge (deepCopy .) (dict "labelSelector" $selector)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
 {{- define "vexa.deploymentStrategy" -}}
 {{/*
 v0.10.5.3 Pack H — zero-downtime rolling update.

--- a/deploy/helm/charts/vexa/templates/deployment-admin-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-admin-api.yaml
@@ -102,4 +102,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "vexa.topologySpreadConstraints" (list . .Values.adminApi "admin-api")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
@@ -7,7 +7,18 @@ metadata:
     {{- include "vexa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.agentApi.replicaCount }}
+  {{- if eq (.Values.agentApi.workspaces.accessMode | default "ReadWriteOnce") "ReadWriteMany" }}
   {{- include "vexa.deploymentStrategy" . | nindent 2 }}
+  {{- else }}
+  # agent-api mounts the single agent-workspaces PVC. A ReadWriteOnce volume cannot be held by two
+  # pods at once, so the shared zero-downtime RollingUpdate (maxSurge:1) would deadlock on a
+  # Multi-Attach error — the new pod can't mount until the old one releases, and maxUnavailable:0
+  # forbids the old one from leaving first. Recreate tears the old pod down before the new one
+  # starts. A ReadWriteMany workspace (multi-worker dispatch) lifts the constraint and takes the
+  # shared rolling strategy instead.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "vexa.selectorLabels" . | nindent 6 }}
@@ -163,5 +174,8 @@ spec:
       {{- with .Values.global.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (include "vexa.topologySpreadConstraints" (list . .Values.agentApi "agent-api")) }}
+      {{- . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
@@ -118,4 +118,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "vexa.topologySpreadConstraints" (list . .Values.gateway "gateway")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -134,4 +134,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "vexa.topologySpreadConstraints" (list . .Values.meetingApi "meeting-api")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
@@ -165,4 +165,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "vexa.topologySpreadConstraints" (list . .Values.runtime "runtime")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
@@ -121,4 +121,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "vexa.topologySpreadConstraints" (list . .Values.terminal "terminal")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -19,6 +19,19 @@ global:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Pod topology spread — applied to EVERY component Deployment (gateway, admin-api, meeting-api,
+  # runtime, agent-api, terminal). Empty by default → nothing rendered (single-node / k3s installs
+  # keep working unchanged). Each constraint you add here is stamped onto every component; when a
+  # constraint omits `labelSelector`, the chart injects THAT component's own pod selector
+  # (name + instance + component), so the constraint means "spread this component's replicas". A
+  # per-component `<component>.topologySpreadConstraints` overrides this global default for that one
+  # component. Use ScheduleAnyway (not DoNotSchedule) so a full/small cluster still schedules.
+  # Example — spread each component's replicas one-per-node, best-effort:
+  #   topologySpreadConstraints:
+  #     - maxSkew: 1
+  #       topologyKey: kubernetes.io/hostname
+  #       whenUnsatisfiable: ScheduleAnyway
+  topologySpreadConstraints: []
   podSecurityContext: {}
   # Hardened defaults: block privilege escalation, drop all caps. Images run non-root via their
   # Dockerfile USER. Override per-component only if a workload genuinely needs a cap back.
@@ -116,6 +129,12 @@ gateway:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: 500m, memory: 512Mi }
   extraEnv: []
+  # Per-component override of global.topologySpreadConstraints (same shape). Omit `labelSelector`
+  # and the gateway's own pod selector is injected — spread gateway replicas across nodes:
+  #   topologySpreadConstraints:
+  #     - maxSkew: 1
+  #       topologyKey: kubernetes.io/hostname
+  #       whenUnsatisfiable: ScheduleAnyway
 
 # Identity / tokens (compose: admin-api → :8001).
 adminApi:
@@ -164,6 +183,9 @@ meetingApi:
     requests: { cpu: 200m, memory: 512Mi }
     limits:   { cpu: 1000m, memory: 1Gi }
   extraEnv: []
+  # Per-component override of global.topologySpreadConstraints (same shape). Omit `labelSelector`
+  # and the meeting-api's own pod selector is injected. See global.topologySpreadConstraints.
+  # topologySpreadConstraints: []
 
 # Runtime kernel — spawns bot + agent-worker workloads (compose: runtime → :8090).
 runtime:
@@ -195,6 +217,11 @@ runtime:
   resources:
     requests: { cpu: 50m, memory: 256Mi }
     limits:   { cpu: 500m, memory: 768Mi }
+  # Per-component override of global.topologySpreadConstraints (same shape). Applies to the runtime
+  # Deployment's OWN pods (not the bot/agent Pods it spawns — those carry runtime.tolerations/
+  # nodeSelector via the RUNTIME_K8S_* env below). Omit `labelSelector` and the runtime's own pod
+  # selector is injected. See global.topologySpreadConstraints.
+  # topologySpreadConstraints: []
   # Scheduling for the Pods the runtime SPAWNS (backend=k8s). A `kubectl run` bot/agent Pod is NOT a
   # child of the runtime Deployment, so it does NOT inherit global.nodeSelector/global.tolerations —
   # on an all-tainted pool (dedicated / spot / GPU node pools) every spawn strands Pending and the

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -91,4 +91,77 @@ else
   echo "  FAIL: runtime RUNTIME_K8S_NODE_SELECTOR missing the global.nodeSelector JSON"; fail=1
 fi
 
+# #770: pod topology spread. Empty default (values-test sets nothing) must render NOTHING — the
+# field is optional, so a no-spread chart is byte-identical to a chart without it (single-node /
+# k3s installs keep working). This is the red→green control direction: nothing here, everything
+# once a constraint is set.
+if grep -qE 'topologySpreadConstraints:' <<< "$RENDER"; then
+  echo "  FAIL: topologySpreadConstraints rendered with empty default (should render nothing)"; fail=1
+else
+  echo "  OK: no topologySpreadConstraints when unset (empty default renders nothing)"
+fi
+# A global constraint must land on EVERY component Deployment with THAT component's own selector
+# injected (labelSelector omitted by the user → chart fills it). 6 Deployments carry the field
+# (gateway, admin-api, meeting-api, runtime, agent-api, terminal), each with its own component
+# label under matchLabels.
+RENDER_TSC="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set-json 'global.topologySpreadConstraints=[{"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]')"
+tsc_count="$(grep -cE '^      topologySpreadConstraints:' <<< "$RENDER_TSC" || true)"
+if [ "$tsc_count" -ge 6 ]; then
+  echo "  OK: global topologySpreadConstraints on all 6 component Deployments ($tsc_count)"
+else
+  echo "  FAIL: global topologySpreadConstraints — want >=6 Deployments got $tsc_count"; fail=1
+fi
+# Each component's OWN selector injected — assert the gateway and meeting-api component labels both
+# appear inside an injected topology-spread matchLabels (they'd be absent if the selector weren't
+# component-specific).
+for comp in gateway meeting-api runtime; do
+  if grep -A6 'topologySpreadConstraints:' <<< "$RENDER_TSC" | grep -qE "app.kubernetes.io/component: ${comp}\$"; then
+    echo "  OK: topology spread injects ${comp}'s own selector"
+  else
+    echo "  FAIL: topology spread missing injected selector for ${comp}"; fail=1
+  fi
+done
+# Per-component override wins over the global default: gateway asks for a zone key, meeting-api
+# keeps the global hostname key.
+RENDER_TSC_OV="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set-json 'global.topologySpreadConstraints=[{"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]' \
+  --set-json 'gateway.topologySpreadConstraints=[{"maxSkew":2,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"DoNotSchedule"}]')"
+gw_block="$(awk '/deployment-gateway.yaml/{f=1} f&&/topologySpreadConstraints:/{p=1} p{print} /^---/{if(p)exit}' <<< "$RENDER_TSC_OV")"
+if grep -q 'topology.kubernetes.io/zone' <<< "$gw_block" && grep -q 'maxSkew: 2' <<< "$gw_block"; then
+  echo "  OK: per-component topologySpreadConstraints override wins on gateway"
+else
+  echo "  FAIL: gateway per-component topologySpreadConstraints override did not win"; fail=1
+fi
+
+# #774: agent-api mounts the single ReadWriteOnce agent-workspaces PVC, so it MUST opt out of the
+# shared zero-downtime RollingUpdate (maxSurge:1 deadlocks on Multi-Attach against an RWO volume)
+# and render Recreate — same deliberate opt-out redis already carries. Assert the agent-api block
+# specifically renders type: Recreate.
+agent_strategy="$(awk '/deployment-agent-api.yaml/{f=1} f&&/^spec:/{p=1} p{print} p&&/selector:/{exit}' <<< "$RENDER")"
+if grep -q 'type: Recreate' <<< "$agent_strategy"; then
+  echo "  OK: agent-api renders Recreate (RWO workspace PVC — no Multi-Attach deadlock)"
+else
+  echo "  FAIL: agent-api did not render type: Recreate under default RWO workspace"; fail=1
+fi
+# The other API/UI Deployments keep the shared zero-downtime RollingUpdate — redis + agent-api are
+# the only two single-PVC opt-outs, so exactly 5 RollingUpdate blocks remain (gateway, admin-api,
+# meeting-api, runtime, terminal).
+roll_count="$(grep -cE '^    type: RollingUpdate' <<< "$RENDER" || true)"
+if [ "$roll_count" -eq 5 ]; then
+  echo "  OK: 5 non-PVC Deployments keep RollingUpdate (agent-api + redis excepted)"
+else
+  echo "  FAIL: expected 5 RollingUpdate Deployments, got $roll_count"; fail=1
+fi
+# A ReadWriteMany workspace lifts the single-mount constraint → agent-api takes the shared rolling
+# strategy back (conditional is on accessMode, not hardcoded).
+RENDER_RWX="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set agentApi.workspaces.accessMode=ReadWriteMany)"
+agent_rwx="$(awk '/deployment-agent-api.yaml/{f=1} f&&/^spec:/{p=1} p{print} p&&/selector:/{exit}' <<< "$RENDER_RWX")"
+if grep -q 'type: RollingUpdate' <<< "$agent_rwx"; then
+  echo "  OK: agent-api takes RollingUpdate when workspace is ReadWriteMany"
+else
+  echo "  FAIL: agent-api did not take RollingUpdate under ReadWriteMany workspace"; fail=1
+fi
+
 [ "$fail" -eq 0 ] && { echo "gate:helm PASS"; exit 0; } || { echo "gate:helm FAIL"; exit 1; }

--- a/docs/changelog.d/770-topology-spread.md
+++ b/docs/changelog.d/770-topology-spread.md
@@ -1,0 +1,6 @@
+- **Helm: spread replicas across nodes with `topologySpreadConstraints` (#770).** `replicaCount > 1`
+  no longer means "all on one node" — set `global.topologySpreadConstraints` (applied to every
+  component) or a per-component `<component>.topologySpreadConstraints` override, and the chart
+  injects that component's own pod selector when you omit `labelSelector`, so a single block spreads
+  each component's own replicas. Empty by default (single-node / k3s installs are unaffected). See
+  the chart README's "Spreading replicas across nodes".

--- a/docs/changelog.d/774-agent-api-recreate.md
+++ b/docs/changelog.d/774-agent-api-recreate.md
@@ -1,0 +1,5 @@
+- **Helm: agent-api no longer deadlocks on upgrade (#774).** agent-api mounts the single
+  `agent-workspaces` PVC, whose default access mode is `ReadWriteOnce`; the shared zero-downtime
+  RollingUpdate (`maxSurge:1`) made any pod-spec-changing `helm upgrade` stall on a Multi-Attach
+  error. agent-api now renders `strategy: Recreate` under an RWO workspace (the same opt-out redis
+  already carries), and keeps RollingUpdate when the workspace is `ReadWriteMany`.


### PR DESCRIPTION
Production availability pair from the prod review — Refs #770, Refs #774 (shared files: agent-api template + test_template.sh, hence one branch; the commit body delineates).

## #770 — spread constraints
`global.topologySpreadConstraints: []` applied to all six component Deployments; `<component>.topologySpreadConstraints` override wins (the chart's existing resources/replicaCount precedence pattern). The helper injects **that component's own selector** (name+instance+component) when a constraint omits `labelSelector` — the exact thing `global.affinity`'s single-map could never express; a user-supplied selector passes verbatim. README section with the working hostname/maxSkew:1 example.

## #774 — agent-api upgrade deadlock
Conditional strategy: **`Recreate` when the workspace PVC is RWO** (the default, the Multi-Attach deadlock case) — same deliberate opt-out redis documents; **RollingUpdate restored automatically under `ReadWriteMany`** (an operator who moves to RWX regains zero-downtime rollout without hand-editing).

## Bundle
| Row | Status | Evidence |
|---|---|---|
| empty default = no change | **byte-identical control** | `helm template` diff-identical to pre-change HEAD |
| global constraint on all 6 + own selector injected | **desk** | helm test rows: `OK: global … on all 6`, selector rows for gateway/meeting-api/runtime |
| per-component override wins | **desk** | gateway zone/maxSkew:2 while meeting-api keeps global |
| agent-api Recreate (RWO) / RollingUpdate (RWX) / 5 others unchanged | **desk** | strategy test rows all OK |
| suites | **green** | `gate:helm PASS`, `helm lint` 0 failed, `gates.mjs all` exit 0 |
| the reporter's cluster actually spreads | **pending witness** | needs their values + a drain — the natural post-deploy check |

Hot-file note: `test_template.sh` edits are **append-only**, no `need <count>` assertion touched (optional fields + one strategy value change ≠ resource-count change). redis/pgbouncer deliberately excluded from topology wiring (single-replica; redis has its own podAntiAffinity). From the production sitting; opus implementation, fable verification.