### PR TITLE
fix(lite-smoke): bounded wait for internal admin-api — the leg's first real firing raced the boot

### DIFF
--- a/deploy/lite/probe.sh
+++ b/deploy/lite/probe.sh
@@ -25,10 +25,13 @@ X() { docker exec "$APP" "$@"; }
 if [ -z "${VEXA_API_KEY:-}" ]; then
   # admin-api port moved between images (8057 → 8001) — autodetect, don't assume.
   ADMIN_PORT=""
-  for p in 8001 8057; do
-    code="$(X curl -s -m 3 -o /dev/null -w '%{http_code}' "http://localhost:$p/admin/users" \
-            -H "X-Admin-API-Key: $ADMIN_TOKEN" 2>/dev/null || true)"
-    case "$code" in 2*|4*) ADMIN_PORT="$p"; break;; esac
+  for attempt in $(seq 1 24); do
+    for p in 8001 8057; do
+      code="$(X curl -s -m 3 -o /dev/null -w '%{http_code}' "http://localhost:$p/admin/users" \
+              -H "X-Admin-API-Key: $ADMIN_TOKEN" 2>/dev/null || true)"
+      case "$code" in 2*|4*) ADMIN_PORT="$p"; break 2;; esac
+    done
+    sleep 5   # admin-api is internal — no front-door probe waits for it, so this one must
   done
   [ -n "$ADMIN_PORT" ] || { echo "probe: admin-api not reachable on 8001/8057 inside $APP" >&2; exit 1; }
   ADMIN="http://localhost:$ADMIN_PORT"

--- a/deploy/lite/tests/concurrent-bots.sh
+++ b/deploy/lite/tests/concurrent-bots.sh
@@ -40,10 +40,13 @@ post_status() { # state description
 
 # ── admin-api port moved between images (8057 → 8001); autodetect, don't assume ──
 ADMIN_PORT=""
-for p in 8001 8057; do
-  code=$(X curl -s -m 3 -o /dev/null -w "%{http_code}" "http://localhost:$p/admin/users" \
-         -H "X-Admin-API-Key: ${ADMIN_TOKEN:-changeme}" 2>/dev/null || true)
-  case "$code" in 2*|4*) ADMIN_PORT=$p; break;; esac
+for attempt in $(seq 1 24); do
+  for p in 8001 8057; do
+    code=$(X curl -s -m 3 -o /dev/null -w "%{http_code}" "http://localhost:$p/admin/users" \
+           -H "X-Admin-API-Key: ${ADMIN_TOKEN:-changeme}" 2>/dev/null || true)
+    case "$code" in 2*|4*) ADMIN_PORT=$p; break 2;; esac
+  done
+  sleep 5   # admin-api is internal — no front-door probe waits for it, so this one must
 done
 [ -n "$ADMIN_PORT" ] || die "admin-api not reachable on 8001/8057 inside $APP"
 ADMIN="http://localhost:$ADMIN_PORT"


### PR DESCRIPTION
PR #778's `lite-smoke` red diagnosed: the workflow retries the FRONT doors (10×15s) but `concurrent-bots.sh` (and `deploy/lite/probe.sh`, same pattern) probed the internal admin-api exactly once with two 3s curls — a boot race on a cold runner, not an image defect (the published v0.12.11 image boots admin-api fine on the live witness VM, evidence in the release thread). Fix: the same bounded patience the front doors get — 24×5s retry around the port autodetect, truthful named failure after. Syntax-checked; behavior on an already-up stack is identical (first attempt succeeds immediately). Unblocks #778 → the v0.12.12 tag.