### PR TITLE
feat(bot): fail-fast control-plane reachability gate — infra faults exit 3 with named channels, never an opaque crashloop (#530)

### DIFF
--- a/core/meetings/services/bot/README.md
+++ b/core/meetings/services/bot/README.md
@@ -22,6 +22,24 @@ composition root (`src/index.ts`).
 | produces | meeting-api | HTTP POST → `inv.recordingUploadUrl` | assembled recording master (multipart) |
 | consumes | gateway (commands) | redis pub/sub `bot_commands:meeting:{id}` | `acts.v1` commands (e.g. `speak` / `speak_stop`) |
 
+### Pre-join reachability gate (#530)
+
+Before any meeting navigation, the orchestrator makes the FIRST `joining` emit **load-bearing**
+(`orchestrator.ts` → `emitJoining`): the HTTP sink's `emitReachable` reports whether the meeting-api
+callback answered at all (any HTTP status = reachable; only an all-attempts network failure — the
+fresh-node CNI-lag signature — is `unreachable`). Reachable ⇒ the join proceeds with **zero added
+latency** (the secondary channel is never probed). Unreachable ⇒ it probes the secondary channel
+(redis PING); **either channel up ⇒ proceed** (the bot can still report), **both down ⇒ refuse to
+join** and terminate fast with a typed, attributed outcome instead of an opaque crashloop.
+
+**Exit codes** (the terminal signal on k8s, where each bot is a bare Pod, `--restart=Never`):
+
+| Code | Meaning |
+|---|---|
+| `0` | clean terminal (`completed`, or a user `stop` withdraw) |
+| `1` | join / runtime failure (`join_failure`, `validation_error`, admission rejected/timeout) |
+| `3` | **control plane unreachable** — both the meeting-api callback and redis were unreachable at boot; the bot refused to join (`failed`, `failure_stage: requested`, `infra_fault: control_plane_unreachable`). Distinguishes a **broken node** from a **broken join** in one `kubectl describe`. |
+
 ## Contracts
 
 **Owns:** none — the bot is a worker that implements published meetings contracts.
@@ -34,8 +52,10 @@ in `src/contracts.ts` and validated against the sealed registry goldens (`contra
 ## Isolated evaluation
 
 Unit/integration: `pnpm test` (chained `tsx` runs — no build step). Levels:
-**L1** config ajv goldens · **L2** orchestrator `lifecycle.v1` state machine (fake ports) ·
-**L3** transport adapters (lifecycle-http · transcript-redis · acts-redis), pipeline lane, recording
+**L1** config ajv goldens · **L2** orchestrator `lifecycle.v1` state machine (fake ports) — incl. the
+#530 reachability gate (both-channels-down ⇒ no join, exit 3, `control_plane_unreachable`; either-channel
+up ⇒ proceed) · **L3** transport adapters (lifecycle-http `emitReachable` reachability verdict ·
+transcript-redis · acts-redis), pipeline lane, recording
 assembler, replay tape. **L4** (browser/capture/speak/upload legs) runs via the standalone harness in
 [`eval/`](./eval): `make -C eval run MEETING=<id>` drives a live Meet with synthetic speakers and an
 autonomous PASS/FAIL verdict (`make -C eval verify` for the offline oracle self-test).

--- a/core/meetings/services/bot/src/adapters/lifecycle-http.test.ts
+++ b/core/meetings/services/bot/src/adapters/lifecycle-http.test.ts
@@ -94,8 +94,56 @@ async function main(): Promise<void> {
     check('permanent-5xx: bounded to `retries` attempts', calls.length === 2, String(calls.length));
   }
 
+  // ── #530 reachability gate: emitReachable reports channel reachability of the first emit ──
+  const JOINING: LifecycleEvent = { connection_id: 'sess-uid', status: 'joining' };
+
+  // healthy 200 → reachable on the FIRST attempt (fast path: near-zero added latency)
+  {
+    const calls: Recorded[] = [];
+    const fetchImpl: FetchLike = async (url, init) => { calls.push({ url, ...init }); return { ok: true, status: 200 }; };
+    const sink = createHttpLifecycleSink({ callbackUrl: 'http://cb', fetchImpl, sleep: noSleep });
+    const verdict = await sink.emitReachable!(JOINING);
+    check('reach-healthy: verdict=reachable', verdict === 'reachable', verdict);
+    check('reach-healthy: single attempt (fast path, no retries)', calls.length === 1, String(calls.length));
+    check('reach-healthy: posted the joining event verbatim', calls[0]?.body === JSON.stringify(JOINING), calls[0]?.body);
+  }
+
+  // 503 (control plane UP-but-broken) → reachable (either-channel rule guards over-blocking)
+  {
+    const calls: Recorded[] = [];
+    const fetchImpl: FetchLike = async (url, init) => { calls.push({ url, ...init }); return { ok: false, status: 503 }; };
+    const sink = createHttpLifecycleSink({ callbackUrl: 'http://cb', fetchImpl, sleep: noSleep });
+    const verdict = await sink.emitReachable!(JOINING);
+    check('reach-503: verdict=reachable (host answered → channel is up)', verdict === 'reachable', verdict);
+    check('reach-503: returns on the first response (no needless retries)', calls.length === 1, String(calls.length));
+  }
+
+  // all-attempts network error (CNI-lag signature) → unreachable, bounded to reachRetries
+  {
+    const calls: Recorded[] = [];
+    const sleeps: number[] = [];
+    const fetchImpl: FetchLike = async (url, init) => { calls.push({ url, ...init }); throw new Error('ECONNREFUSED'); };
+    const sink = createHttpLifecycleSink({ callbackUrl: 'http://cb', fetchImpl, reachRetries: 4, reachBackoffMs: 100, sleep: async (ms) => { sleeps.push(ms); } });
+    let threw = false;
+    let verdict: string | undefined;
+    try { verdict = await sink.emitReachable!(JOINING); } catch { threw = true; }
+    check('reach-down: did NOT throw (never crashes the bot)', threw === false);
+    check('reach-down: verdict=unreachable', verdict === 'unreachable', String(verdict));
+    check('reach-down: bounded to reachRetries attempts', calls.length === 4, String(calls.length));
+    check('reach-down: bounded exponential backoff (100,200,400)', JSON.stringify(sleeps) === JSON.stringify([100, 200, 400]), JSON.stringify(sleeps));
+  }
+
+  // transient: network error then 200 → reachable (rides out a brief programming window)
+  {
+    let n = 0;
+    const fetchImpl: FetchLike = async () => { n++; if (n === 1) throw new Error('EAI_AGAIN'); return { ok: true, status: 200 }; };
+    const sink = createHttpLifecycleSink({ callbackUrl: 'http://cb', fetchImpl, reachRetries: 4, reachBackoffMs: 10, sleep: noSleep });
+    const verdict = await sink.emitReachable!(JOINING);
+    check('reach-transient: verdict=reachable after one retry', verdict === 'reachable' && n === 2, `${verdict}/${n}`);
+  }
+
   if (failed) { console.error(`\n❌ lifecycle-http (L3): ${failed} check(s) FAILED.`); process.exit(1); }
-  console.log('\n✅ lifecycle-http (L3): POSTs the lifecycle.v1 event verbatim with x-internal-secret, retries with bounded backoff, and never throws out of emit.');
+  console.log('\n✅ lifecycle-http (L3): POSTs the lifecycle.v1 event verbatim with x-internal-secret, retries with bounded backoff, never throws out of emit, and emitReachable reports primary-channel reachability for the #530 gate.');
 }
 
 void main();

--- a/core/meetings/services/bot/src/adapters/lifecycle-http.ts
+++ b/core/meetings/services/bot/src/adapters/lifecycle-http.ts
@@ -15,7 +15,7 @@
  * seated bot or mask the terminal exit.)
  */
 import type { LifecycleEvent } from '../contracts.js';
-import type { LifecycleSink } from '../ports.js';
+import type { LifecycleSink, PrimaryReachability } from '../ports.js';
 
 /** The minimal fetch shape we depend on (a subset of the WHATWG `fetch`), so the test can
  *  inject a fake without pulling in DOM/undici types. */
@@ -37,6 +37,12 @@ export interface HttpLifecycleSinkOptions {
   backoffMs?: number;
   /** Sleep impl (injected so the test runs instantly). Default real setTimeout. */
   sleep?: (ms: number) => Promise<void>;
+  /** Max attempts for the REACHABILITY probe (`emitReachable`, #530) — a longer bounded budget
+   *  than a normal emit so it rides out transient CNI-programming lag, but capped WELL under the
+   *  meeting-api `requested` grace. Default 6 (with `reachBackoffMs` 300 ⇒ ≤ ~9.3s total). */
+  reachRetries?: number;
+  /** Base backoff (ms) for the reachability probe; doubles each retry. Default 300ms. */
+  reachBackoffMs?: number;
 }
 
 const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -51,12 +57,15 @@ export function createHttpLifecycleSink(opts: HttpLifecycleSinkOptions): Lifecyc
     retries = 3,
     backoffMs = 200,
     sleep = realSleep,
+    reachRetries = 6,
+    reachBackoffMs = 300,
   } = opts;
 
   const headers: Record<string, string> = { 'content-type': 'application/json' };
   if (internalSecret) headers['x-internal-secret'] = internalSecret;
 
   const attempts = Math.max(1, retries);
+  const reachAttempts = Math.max(1, reachRetries);
 
   async function emit(event: LifecycleEvent): Promise<void> {
     const body = JSON.stringify(event);
@@ -78,5 +87,29 @@ export function createHttpLifecycleSink(opts: HttpLifecycleSinkOptions): Lifecyc
     );
   }
 
-  return { emit };
+  // The reachability gate's first-emit probe (#530). Emits the (joining) event AND reports whether
+  // the primary channel is REACHABLE. Any HTTP response — 2xx OR non-2xx — proves the channel is
+  // up (P18) and returns `reachable` immediately (near-zero latency on the fast path). Only when
+  // EVERY attempt fails at the network layer (no response — the CNI-lag signature) is it
+  // `unreachable`. Never throws (P14).
+  async function emitReachable(event: LifecycleEvent): Promise<PrimaryReachability> {
+    const body = JSON.stringify(event);
+    let lastErr: string | undefined;
+    for (let attempt = 1; attempt <= reachAttempts; attempt++) {
+      try {
+        // A response of ANY status means the callback host answered → the channel is up.
+        await fetchImpl(callbackUrl, { method: 'POST', headers, body });
+        return 'reachable';
+      } catch (e) {
+        lastErr = (e as Error)?.message ?? String(e);
+      }
+      if (attempt < reachAttempts) await sleep(reachBackoffMs * 2 ** (attempt - 1));
+    }
+    console.error(
+      `[bot] lifecycle.v1 ${event.status} reachability probe: primary channel UNREACHABLE after ${reachAttempts} attempt(s): ${lastErr ?? 'unknown'}`,
+    );
+    return 'unreachable';
+  }
+
+  return { emit, emitReachable };
 }

--- a/core/meetings/services/bot/src/contracts.ts
+++ b/core/meetings/services/bot/src/contracts.ts
@@ -46,6 +46,14 @@ export interface LifecycleEvent {
   bot_logs?: string[];
   bot_resources?: { peak_memory_bytes?: number; cpu_usage_usec?: number; [k: string]: unknown };
   speaker_events?: unknown[];
+  /** Machine-readable infra-fault tag on a pre-join control-plane-unreachable abort (#530).
+   *  Additive field: lifecycle.v1 ingests liberally (additionalProperties:true), so this rides
+   *  the SEALED contract WITHOUT a schema/seal bump — it carries the attribution the sealed
+   *  CompletionReason enum does not (see orchestrator.ts CONTROL_PLANE_UNREACHABLE). */
+  infra_fault?: string;
+  /** The control-plane channels found unreachable when `infra_fault` is set (e.g. the
+   *  meeting-api callback and/or redis). Additive; same liberal-ingestion rationale. */
+  unreachable_channels?: string[];
 }
 
 /** The legal transitions — the machine the bot MUST obey (lifecycle.v1/README.md). */

--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -22,6 +22,7 @@
  * terminal `failed` (join_failure) rather than crashing the root — same disposability as the
  * lazy redis connect.
  */
+import { createClient } from 'redis';
 import { loadInvocation, InvocationError, speakerStreamConfigFromEnv, type Invocation } from './config.js';
 import type { Act, LifecycleEvent } from './contracts.js';
 import { createOrchestrator } from './orchestrator.js';
@@ -123,6 +124,26 @@ function voiceHandler(speak: SpeakController): (act: Act) => Promise<void> {
   };
 }
 
+/**
+ * Probe the SECONDARY control-plane channel (redis) for the reachability gate (#530). A fresh,
+ * short-lived connection with a bounded connect timeout and NO reconnection — a single yes/no on
+ * whether redis answers a PING. Never throws: any fault resolves to `false` (unreachable). Uses a
+ * throwaway client (not the lazy transcript/acts clients) so the probe can't disturb their state.
+ */
+async function pingRedis(redisUrl: string, timeoutMs = 3000): Promise<boolean> {
+  const client = createClient({ url: redisUrl, socket: { connectTimeout: timeoutMs, reconnectStrategy: false } });
+  client.on('error', () => { /* swallow — the probe's verdict is the return value, not a throw */ });
+  try {
+    await client.connect();
+    const pong = await client.ping();
+    return pong === 'PONG';
+  } catch {
+    return false;
+  } finally {
+    await client.disconnect().catch(() => { /* best-effort */ });
+  }
+}
+
 export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number> {
   // ── validate config (P14: fail fast) ──
   let inv: Invocation;
@@ -222,12 +243,20 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
     acts = liveActs;
   }
 
+  // Reachability gate (#530): only meaningful under a control plane (a callback URL is set). When
+  // present, the orchestrator makes the first `joining` emit load-bearing and, if the callback is
+  // unreachable, probes redis before refusing to join. Self-host (no callback) has no gate.
+  const reachability = inv.meetingApiCallbackUrl
+    ? { probeSecondary: () => pingRedis(inv.redisUrl) }
+    : undefined;
+
   const orchestrator = createOrchestrator(inv, {
     lifecycle,
     join,
     pipeline,
     acts,
     recording: recording as RecordingSink | undefined,
+    reachability,
   });
 
   // Disposability (P7): a termination signal ends the active phase gracefully (leave → flush →

--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -16,10 +16,10 @@ import addFormats from 'ajv-formats';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createOrchestrator } from './orchestrator.js';
+import { createOrchestrator, CONTROL_PLANE_UNREACHABLE, CONTROL_PLANE_UNREACHABLE_EXIT } from './orchestrator.js';
 import { createLivePipeline } from './pipeline.js';
 import { canTransition, type BotStatus, type LifecycleEvent, type TranscriptSegment } from './contracts.js';
-import type { JoinDriver, JoinOutcome, Pipeline, LifecycleSink, ActsSource, TranscriptSink } from './ports.js';
+import type { JoinDriver, JoinOutcome, Pipeline, LifecycleSink, ActsSource, TranscriptSink, PrimaryReachability } from './ports.js';
 import type { Invocation } from './config.js';
 
 let failed = 0;
@@ -318,6 +318,83 @@ async function main(): Promise<void> {
     check('#593: leave NEVER called with pipeline_start_failed', !leaveReasons.includes('pipeline_start_failed'), leaveReasons.join(','));
     check('#593: ended cleanly via the leave act → completed(stopped)', res.status === 'completed' && last(lc.events).completion_reason === 'stopped', JSON.stringify(last(lc.events)));
     check('#593: both subsystem faults surfaced loud (capture + engine)', faults.includes('capture-start') && faults.includes('engine-start'), faults.join(','));
+  }
+
+  // ── #530 reachability gate: BOTH channels down → refuse to join, exit 3, typed terminal ──
+  // The FIRST `joining` emit is load-bearing. A sink whose emitReachable reports `unreachable` +
+  // a secondary probe that reports redis down ⇒ the bot must NOT navigate to the meeting; it
+  // terminates failed(requested) with the control_plane_unreachable attribution and exit 3.
+  // RED AT BASE: before the gate, run() ignores reachability and proceeds to join.join().
+  {
+    const events: LifecycleEvent[] = [];
+    const gateSink: LifecycleSink = {
+      async emit(e) { events.push(e); },
+      async emitReachable(e) { events.push(e); return 'unreachable' as PrimaryReachability; },
+    };
+    let joinCalls = 0;
+    const spyJoin: JoinDriver = {
+      async join(report) { joinCalls++; await report('awaiting_admission'); await report('active'); return 'admitted'; },
+      onRemoval() { return () => {}; }, async leave() {}, async withdraw() {},
+    };
+    const res = await createOrchestrator(inv(), {
+      lifecycle: gateSink, join: spyJoin, pipeline: noopPipeline(), acts: noopActs(),
+      reachability: { async probeSecondary() { return false; } },
+    }).run();
+    check('gate both-down: NO join attempted (refused before meeting navigation)', joinCalls === 0, `joinCalls=${joinCalls}`);
+    check('gate both-down: exit code 3 (dedicated infra signal)', res.exitCode === CONTROL_PLANE_UNREACHABLE_EXIT, String(res.exitCode));
+    check('gate both-down: terminal failed', res.status === 'failed');
+    check('gate both-down: failure_stage=requested (distinct from a real join failure)', last(events).failure_stage === 'requested', JSON.stringify(last(events)));
+    check('gate both-down: infra_fault=control_plane_unreachable', last(events).infra_fault === CONTROL_PLANE_UNREACHABLE, JSON.stringify(last(events)));
+    check('gate both-down: unreachable_channels names both deps', JSON.stringify(last(events).unreachable_channels) === JSON.stringify(['meeting_api_callback', 'redis']), JSON.stringify(last(events).unreachable_channels));
+    check('gate both-down: reason text carries the discriminator', (last(events).reason ?? '').startsWith(CONTROL_PLANE_UNREACHABLE), last(events).reason);
+    check('gate both-down: exit_code on the event = 3', last(events).exit_code === CONTROL_PLANE_UNREACHABLE_EXIT, String(last(events).exit_code));
+    check('gate both-down: terminal event still conforms to lifecycle.v1', allConform(events), ajv.errorsText(validateLifecycle.errors));
+    check('gate both-down: never reached active', !seq(events).includes('active'), JSON.stringify(seq(events)));
+  }
+
+  // ── #530 gate: primary DOWN but SECONDARY up → proceed (either-channel rule) ──
+  {
+    const events: LifecycleEvent[] = [];
+    const gateSink: LifecycleSink = {
+      async emit(e) { events.push(e); },
+      async emitReachable(e) { events.push(e); return 'unreachable' as PrimaryReachability; },
+    };
+    let joinCalls = 0;
+    const spyJoin: JoinDriver = {
+      async join(report) { joinCalls++; await report('awaiting_admission'); await report('active'); return 'admitted'; },
+      onRemoval() { return () => {}; }, async leave() {}, async withdraw() {},
+    };
+    let fireLeave: (a: { action: 'leave' }) => void = () => {};
+    const o = createOrchestrator(inv(), {
+      lifecycle: gateSink, join: spyJoin, pipeline: noopPipeline(), acts: noopActs((f) => { fireLeave = f; }),
+      reachability: { async probeSecondary() { return true; } },   // redis up
+    });
+    const runP = o.run();
+    setTimeout(() => fireLeave({ action: 'leave' }), 5);
+    const res = await runP;
+    check('gate either-channel: join PROCEEDED (secondary up ⇒ can still report)', joinCalls === 1, `joinCalls=${joinCalls}`);
+    check('gate either-channel: completed(stopped), not an infra abort', res.status === 'completed' && res.exitCode === 0, JSON.stringify(res));
+    check('gate either-channel: no infra_fault emitted', !events.some((e) => e.infra_fault), JSON.stringify(seq(events)));
+  }
+
+  // ── #530 gate: primary REACHABLE (e.g. a 503 mapped to reachable) → proceed, ZERO extra probe ──
+  {
+    const events: LifecycleEvent[] = [];
+    let secondaryProbed = 0;
+    const gateSink: LifecycleSink = {
+      async emit(e) { events.push(e); },
+      async emitReachable(e) { events.push(e); return 'reachable' as PrimaryReachability; },
+    };
+    let fireLeave: (a: { action: 'leave' }) => void = () => {};
+    const o = createOrchestrator(inv(), {
+      lifecycle: gateSink, join: mockJoin('admitted'), pipeline: noopPipeline(), acts: noopActs((f) => { fireLeave = f; }),
+      reachability: { async probeSecondary() { secondaryProbed++; return false; } },
+    });
+    const runP = o.run();
+    setTimeout(() => fireLeave({ action: 'leave' }), 5);
+    const res = await runP;
+    check('gate reachable: proceeded to completed', res.status === 'completed', JSON.stringify(res));
+    check('gate reachable: secondary channel NEVER probed (fast path, zero added latency)', secondaryProbed === 0, `probed=${secondaryProbed}`);
   }
 
   if (failed) { console.error(`\n❌ orchestrator (L2): ${failed} check(s) FAILED.`); process.exit(1); }

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -29,6 +29,7 @@ import type {
   LifecycleSink,
   ActsSource,
   RecordingSink,
+  ControlPlaneProbe,
 } from './ports.js';
 
 export interface OrchestratorDeps {
@@ -38,7 +39,24 @@ export interface OrchestratorDeps {
   acts: ActsSource;
   /** Optional — recording is gated by invocation.recordingEnabled; the core only closes it. */
   recording?: RecordingSink;
+  /** Optional (#530) — the SECONDARY control-plane channel probe (redis), consulted only when
+   *  the first `joining` emit is unreachable on the primary channel. ABSENT ⇒ the secondary is
+   *  treated as reachable (conservative: never abort on an un-probeable channel), so the gate
+   *  never turns a missing probe into a join refusal. */
+  reachability?: ControlPlaneProbe;
 }
+
+/** The dedicated non-zero exit code for a pre-join control-plane-unreachable abort (#530). On
+ *  k8s each bot is a bare Pod (`--restart=Never`, `k8s_backend.py`) — the terminal exit code IS
+ *  the attributable signal an operator reads in one `kubectl describe`, distinct from a real
+ *  join failure (exit 1). */
+export const CONTROL_PLANE_UNREACHABLE_EXIT = 3;
+
+/** The infra-fault tag / reason-text discriminator for the control-plane-unreachable terminal
+ *  (#530). NOT a lifecycle.v1 CompletionReason — the sealed enum stays untouched; attribution
+ *  rides `failure_stage:"requested"` + `infra_fault` + this text + exit 3 (the C2 fork-4
+ *  no-seal-bump path: existing reason + liberal reason-text, LifecycleEvent additionalProperties:true). */
+export const CONTROL_PLANE_UNREACHABLE = 'control_plane_unreachable';
 
 export interface MeetingResult {
   exitCode: number;
@@ -81,6 +99,16 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
     await deps.lifecycle.emit({ ...base, status, ...extra });
   };
 
+  // The load-bearing FIRST emit (#530). `cur` is already `joining` (the initial state), so this
+  // needs no transition guard. When the sink can report reachability we consult it; otherwise the
+  // event is emitted normally and treated as reachable (self-host / test sinks have no gate).
+  const emitJoining = async (extra: Partial<LifecycleEvent>): Promise<boolean> => {
+    const ev: LifecycleEvent = { ...base, status: 'joining', ...extra };
+    if (deps.lifecycle.emitReachable) return (await deps.lifecycle.emitReachable(ev)) === 'reachable';
+    await deps.lifecycle.emit(ev);
+    return true;
+  };
+
   // The end signal: a `leave` act, host removal, or a timeout all resolve the active phase.
   let signalEnd: ((r: CompletionReason) => void) | null = null;
   const ended = new Promise<CompletionReason>((res) => { signalEnd = res; });
@@ -101,7 +129,38 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
   }
 
   async function run(opts: RunOptions = {}): Promise<MeetingResult> {
-    await emit('joining', base.container_id ? { container_id: base.container_id } : {});
+    // ── reachability gate (#530, P18) — the FIRST lifecycle emit is LOAD-BEARING ──
+    // The `joining` event must be sent regardless; we consult its delivery verdict. Reachable ⇒
+    // ZERO added latency (the secondary channel is never probed). Primary unreachable ⇒ probe the
+    // secondary (redis); BOTH down ⇒ refuse to join BEFORE any meeting navigation and terminate
+    // with the dedicated infra signal — rather than proceeding toward a human meeting the bot can
+    // never report about (the 2026-07-09 fresh-node signature: opaque join_failure / stuck-requested).
+    const joiningExtra: Partial<LifecycleEvent> = base.container_id ? { container_id: base.container_id } : {};
+    const primaryReachable = await emitJoining(joiningExtra);
+    if (!primaryReachable) {
+      // Either-channel rule: EITHER channel up ⇒ the bot can still report ⇒ proceed. Absent probe
+      // ⇒ treated as reachable (never abort on an un-probeable channel).
+      const secondaryReachable = deps.reachability ? await deps.reachability.probeSecondary() : true;
+      if (!secondaryReachable) {
+        // BOTH control-plane channels unreachable → refuse to join. Attempt the terminal on
+        // whichever channel answers (likely none — that is fine; on k8s the pod exit code carries
+        // it). Use the raw sink (never-throw) and mark `cur` terminal ourselves; the emit here is
+        // best-effort and must not mask the exit.
+        const unreachable = ['meeting_api_callback', 'redis'];
+        cur = 'failed';
+        await deps.lifecycle.emit({
+          ...base,
+          status: 'failed',
+          failure_stage: 'requested',
+          completion_reason: 'join_failure',
+          infra_fault: CONTROL_PLANE_UNREACHABLE,
+          unreachable_channels: unreachable,
+          reason: `${CONTROL_PLANE_UNREACHABLE}: control plane unreachable at boot (${unreachable.join(', ')}); refused to join`,
+          exit_code: CONTROL_PLANE_UNREACHABLE_EXIT,
+        }).catch(() => { /* the channel that would carry this is the one that is down */ });
+        return { exitCode: CONTROL_PLANE_UNREACHABLE_EXIT, status: 'failed', completionReason: 'join_failure' };
+      }
+    }
 
     // ── join → admission ──
     // Serialize the driver's intermediate reports so lifecycle.v1 events POST in order even

--- a/core/meetings/services/bot/src/ports.ts
+++ b/core/meetings/services/bot/src/ports.ts
@@ -49,10 +49,32 @@ export interface TranscriptSink {
   publish(segment: TranscriptSegment): Promise<void>;
 }
 
+/** The reachability verdict of the FIRST (load-bearing) lifecycle emit (#530). `reachable` iff
+ *  the primary control-plane channel answered AT ALL — a 2xx OR a non-2xx HTTP response both
+ *  prove the channel is up (P18's "can I reach my dependency?" answered yes); only when EVERY
+ *  attempt fails at the network layer (no response — the CNI-programming-lag signature) is it
+ *  `unreachable`. */
+export type PrimaryReachability = 'reachable' | 'unreachable';
+
 /** lifecycle.v1 egress — the orchestrator emits one status report per transition. The real
  *  adapter POSTs to meeting-api's callback; the L2 fake records the sequence to assert. */
 export interface LifecycleSink {
   emit(event: LifecycleEvent): Promise<void>;
+  /** Emit the LOAD-BEARING first `joining` event AND report whether the primary control-plane
+   *  channel is reachable — the reachability gate (#530, P18). Reachable ⇒ the orchestrator
+   *  proceeds with ZERO added latency (the secondary channel is never probed). OPTIONAL: sinks
+   *  that don't implement it (the console/self-host sink, most test fakes) are treated as always
+   *  reachable — no gate, so nothing that lacks a control plane is ever blocked from joining. */
+  emitReachable?(event: LifecycleEvent): Promise<PrimaryReachability>;
+}
+
+/** The SECONDARY control-plane channel probe (#530) — consulted ONLY when the first `joining`
+ *  emit is `unreachable` on the primary channel. The live adapter PINGs redis; `true` iff up.
+ *  Either-channel-up ⇒ the bot can still report ⇒ proceed; BOTH down ⇒ refuse to join. */
+export interface ControlPlaneProbe {
+  /** Probe the secondary channel (redis). Returns `true` iff reachable. MUST NOT throw — a probe
+   *  fault resolves to `false` (unreachable) at the adapter. */
+  probeSecondary(): Promise<boolean>;
 }
 
 /** acts.v1 ingress — the control plane's command bus. The real adapter subscribes to the

--- a/docs/changelog.d/530-reachability-gate.md
+++ b/docs/changelog.d/530-reachability-gate.md
@@ -1,0 +1,9 @@
+- **Bots fail fast when the control plane is unreachable, instead of an opaque crashloop (#530).** On a
+  freshly autoscaled k8s node whose network hasn't converged, a bot's first callback to meeting-api can
+  be unreachable. The bot now makes its first `joining` lifecycle emit load-bearing: if the meeting-api
+  callback is unreachable it probes redis, and only if BOTH control-plane channels are down does it
+  refuse to join — terminating in under a few seconds with a dedicated exit code (3) and an attributed
+  terminal (`failure_stage: requested`, `infra_fault: control_plane_unreachable`) rather than a generic
+  `join_failure` or a stuck-`requested` meeting. A reachable control plane adds zero latency (the
+  secondary channel is never probed). Operators can now tell "broken node" from "broken join" in one
+  `kubectl describe`. See [Kubernetes deployment](/deployment-kubernetes) and [Troubleshooting](/troubleshooting).

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -106,6 +106,34 @@ an in-image executable against the published images, so a profile that diverges 
 fails the release rather than a customer's install.
 </Warning>
 
+### Autoscaling and bot bursts — the fresh-node reachability gate
+
+Because every bot is its own bare Pod, a burst of meeting requests can push the cluster autoscaler to
+add nodes, and bots get scheduled onto them the moment they report `Ready`. But a brand-new node's
+network can take up to a few minutes to fully converge *after* `Ready` — the CNI/NetworkPolicy
+programming, kube-proxy, and DNS warmup all lag node readiness. A bot scheduled into that window can
+find its control plane (its meeting-api callback URL and redis) unreachable on its first outbound hop.
+
+The bot handles this with a **pre-join reachability gate**: it makes its first `joining` lifecycle
+emit load-bearing. If the meeting-api callback is reachable (any HTTP response), it joins immediately —
+zero added latency. If not, it probes redis; **if either channel is up it proceeds** (it can still
+report), and **only if both are down does it refuse to join**, terminating fast (< a few seconds) with:
+
+- **Pod exit code `3`** — the attributable terminal signal (`kubectl describe pod <bot>` →
+  `Last State: Terminated, Exit Code: 3`). Distinct from a real join failure (exit `1`).
+- a `failed` lifecycle event carrying `failure_stage: requested` and `infra_fault:
+  control_plane_unreachable` on whichever channel recovers (often none — the exit code is the signal).
+
+This converts an opaque CrashLoop / stuck-`requested` meeting into a fast, attributed failure an
+operator can read in one `kubectl describe`. See
+[Troubleshooting → exit code 3](/troubleshooting).
+
+**What stays cluster-side (not solved by the gate):** the node-readiness window itself. Consider
+pre-pulling the bot image onto new nodes (a cold pull can itself take minutes and mask the network
+window), and treat node `Ready` as insufficient for scheduling network-dependent work — the gate
+fails fast and, on k8s, the exit lets the operator (or an autoscaler policy) reschedule onto a warmed
+node.
+
 ## Scaling meeting-api
 
 `meetingApi.replicaCount` defaults to `2`, and that is safe for the segment consumer.

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -98,6 +98,25 @@ verbatim to the **browser console** (`api failure …` / `meeting action failed 
 presented error. Support and self-hosters debug from the console line; the on-screen headline tells
 the user which layer to suspect.
 
+## A bot on a fresh k8s node fails instantly with exit code 3 (`control_plane_unreachable`)
+
+On Kubernetes each bot is a bare Pod, and a freshly autoscaled node's network can take up to a few
+minutes to converge *after* the node reports `Ready`. A bot scheduled into that window may find its
+control plane (the meeting-api callback **and** redis) unreachable. Rather than crashloop opaquely or
+report a misleading `join_failure`, the bot now **fails fast**: it refuses to join and exits with a
+dedicated code.
+
+| Signal | Where to read it | Meaning |
+|---|---|---|
+| Pod exit code `3` | `kubectl describe pod <bot>` → `Last State: Terminated, Exit Code: 3` | control plane unreachable at boot — the bot never navigated to the meeting |
+| `infra_fault: control_plane_unreachable`, `failure_stage: requested` | meeting API / dashboard (if any callback channel recovered) or the pod logs | distinguishes a **broken node** from a **broken join** (a real join failure is exit `1`, `failure_stage: joining`/`awaiting_admission`/`active`) |
+
+**What to check on the node:** is the CNI fully programmed? can a canary pod on that node reach the
+meeting-api Service and redis? Deleting the pod to force a reschedule (onto a warmed node, or the same
+node after its window passes) is the manual remedy. The bot's exit is fast (< a few seconds) and the
+retry budget on the first emit (≤ ~15s) already rides out brief transient programming lag. See
+[Kubernetes deployment → autoscaling and bot bursts](/deployment-kubernetes).
+
 ## Authentication failures
 
 | Symptom | Cause | Fix |


### PR DESCRIPTION
Delivers the buildable half of #530 (C2/V2: the gate the issue orders 'either way'); the attribution half (C1/V1 — the 06:08 CrashLoop evidence + induced-netpol reproduction) stays open on the issue. Refs #530.

## Mechanism
Before any join, the bot proves it can reach its control plane: the first lifecycle emit's delivery verdict is load-bearing (bounded ≤~9.3s retry budget; any HTTP status = reachable — a 503 proceeds), redis PING as the secondary, either-channel rule. Both down ⇒ NO join attempt, terminal `failed` at `failure_stage:requested` with `infra_fault:"control_plane_unreachable"` + `unreachable_channels` + **exit code 3** — the operator's distinguisher from a real join failure (exit 1, later stages). Reachable fast path: zero added latency, secondary never probed.

## Deliberate design: NO sealed-contract change (fork-4, ratified rationale)
A new `CompletionReason` would leave `gate:contract-version` red AND — the load-bearing find — **break meeting-api ingestion**, which parses the reason via strict enum (`ValueError` on unknown). The extras ride `LifecycleEvent`'s `additionalProperties:true`. All 33 gates green including contract-version.

## Bundle
| Row | Status | Evidence |
|---|---|---|
| both-down ⇒ no join, exit 3, typed attribution | **desk red→green** | L2: base-sim RED (`joinCalls===0` ❌, exit 1; at true base the bot proceeds toward `active` and hangs — the incident signature); head GREEN all assertions |
| either-channel proceeds · reachable fast-path untouched | **desk** | L2 cases green; secondary-never-probed asserted |
| delivery-verdict semantics (healthy/503/down/transient) | **desk** | 4 L3 fixtures: 1-attempt fast path, 503=reachable, bounded 4-attempt backoff, transient recovery |
| suites | **green** | bot 320 checks 0❌; meeting-api 753 passed unchanged; `gates.mjs all` 33/33 |
| live k8s row (fresh-node witness) | **pending** | needs the reporter's cluster — pairs with the attribution half |

Validator note recorded on-issue: meeting-api derives `failure_stage` server-side (FM-003) and ignores the bot's — in the both-down case nothing arrives anyway; the operator signal is pod exit 3. From the production sitting; opus implementation, fable verification.