### PR TITLE
fix(msteams): leave fallbacks were dead — ':has-text()' through querySelector; canonical clicker hoisted to shared, gate covers the Teams array (#759)

### DIFF
--- a/core/meetings/modules/join/README.md
+++ b/core/meetings/modules/join/README.md
@@ -28,7 +28,10 @@ Selector validity is **per execution context**, not per engine: Playwright engin
 `page.evaluate` runs through `document.querySelector` and must be **plain CSS**. Declare
 browser-context arrays in `browserContextSelectorArrays` (per-platform `selectors.ts`) so
 `src/shared/selector-validity.test.ts` CSS-parses them; text-labelled buttons are
-`{ text: … }` matcher fields, matched in-page against `textContent`.
+`{ text: … }` matcher fields, matched in-page against `textContent`. The one canonical
+in-page leave clicker (`src/shared/leave-click.ts`, `leaveBrowserClick`) is shared across
+platforms — Google Meet and MS Teams both serialize it through `page.evaluate` — so the
+walker cannot drift between the injected hook and the direct leave.
 
 ## Prove it
 - `pnpm --filter @vexa/join build` · `pnpm --filter @vexa/join test` (L1/L2 admission oracle — DOM fixtures, no browser)

--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/googlemeet/leave.ts
+++ b/core/meetings/modules/join/src/googlemeet/leave.ts
@@ -2,66 +2,15 @@ import { Page } from "playwright";
 import { log, callLeaveCallback } from "../_host";
 import { logJSON } from "../_host";
 import { BotConfig } from "../_host";
-import { googleLeaveButtonMatchers, BrowserContextButtonMatcher } from "./selectors";
+import { googleLeaveButtonMatchers } from "./selectors";
 import { stopGoogleRecording } from "../_host";
 
-// The leave click that runs INSIDE the page (shipped through page.evaluate by
-// both consumers below — ONE canonical routine, so the injected hook and the
-// direct leave can never drift, and the no-browser fixture test drives exactly
-// the function production serializes into the browser).
-//
-// Self-contained by contract: it is serialized into the browser context, where
-// module scope does not exist — DOM globals and its argument only.
-// document.querySelector understands plain CSS (no Playwright engines), so
-// text-labelled buttons are expressed as `text` fields and matched here by
-// whitespace-normalized, case-insensitive substring of textContent — the
-// semantics `:has-text()` applies in Playwright contexts. Matchers are tried
-// in order; the first visible match is clicked.
-export async function googleLeaveBrowserClick(
-  matchers: BrowserContextButtonMatcher[],
-): Promise<boolean> {
-  // Serialization contract: esbuild-family compilers (tsx — the debug harness
-  // lane) emit nested function expressions wrapped in a `__name` helper that
-  // does not exist inside the page. Define an identity fallback BEFORE any
-  // nested function is created, so the serialized source is self-contained
-  // under every compiler (tsc emits none of this; the line is then inert).
-  (globalThis as any).__name = (globalThis as any).__name || ((f: unknown) => f);
-  const blog = (m: string) => { try { (window as any).logBot?.(m); } catch { /* logging is best-effort */ } };
-  const normalize = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
-  const isVisible = (el: Element) => {
-    const rect = el.getBoundingClientRect();
-    const cs = getComputedStyle(el as HTMLElement);
-    return rect.width > 0 && rect.height > 0
-      && cs.display !== "none" && cs.visibility !== "hidden" && cs.opacity !== "0";
-  };
-  for (const matcher of matchers) {
-    const scope = matcher.css ?? 'button, [role="button"]';
-    let candidates: Element[];
-    try {
-      candidates = Array.from(document.querySelectorAll(scope));
-    } catch (e: any) {
-      // The selector-validity gate CSS-parses every declared browser-context
-      // entry, so this only fires on drift — loudly, never silently.
-      blog(`[leave] selector failed in browser context: ${scope} — ${e?.message}`);
-      continue;
-    }
-    const needle = matcher.text === undefined ? null : normalize(matcher.text);
-    const button = candidates.find(
-      (el) => (needle === null || normalize(el.textContent || "").includes(needle)) && isVisible(el),
-    ) as HTMLElement | undefined;
-    if (!button) continue;
-    button.scrollIntoView({ behavior: "smooth", block: "center" });
-    await new Promise((r) => setTimeout(r, 300));
-    button.click();
-    await new Promise((r) => setTimeout(r, 800));
-    const via = [matcher.css, matcher.text === undefined ? undefined : `text~"${matcher.text}"`]
-      .filter(Boolean).join(" ");
-    blog(`[leave] clicked leave button via ${via}`);
-    return true;
-  }
-  blog("[leave] no visible leave button matched any matcher");
-  return false;
-}
+// The canonical in-page leave click is shared across platforms
+// (../shared/leave-click). Re-exported under the Google-scoped name this
+// module's consumers and fixture test already use; page.evaluate serializes
+// this exact function, so the no-browser fixture drives what production ships.
+import { leaveBrowserClick as googleLeaveBrowserClick } from "../shared/leave-click";
+export { googleLeaveBrowserClick };
 
 // Prepare for recording by exposing necessary functions
 export async function prepareForRecording(page: Page, botConfig: BotConfig): Promise<void> {

--- a/core/meetings/modules/join/src/googlemeet/selectors.ts
+++ b/core/meetings/modules/join/src/googlemeet/selectors.ts
@@ -335,14 +335,11 @@ export const googleParticipantIdSelectors: string[] = [
   '[jsinstance]'
 ];
 
-// Browser-context button matcher: `css` scopes candidates via
-// document.querySelectorAll (plain CSS ONLY — this shape is consumed inside
-// page.evaluate, where Playwright engines like `:has-text()` do not exist);
-// `text` filters those candidates by whitespace-normalized, case-insensitive
-// substring of textContent (the semantics `:has-text()` applies in Playwright
-// contexts). At least one field must be present; `css` alone means "first
-// visible match", `text` alone scopes to any button-like element.
-export type BrowserContextButtonMatcher = { css?: string; text?: string };
+// Browser-context button matcher — the canonical shape lives in
+// ../shared/leave-click (shared with msteams); imported for local use below
+// and re-exported so this module's existing importers keep their reference.
+import type { BrowserContextButtonMatcher } from "../shared/leave-click";
+export type { BrowserContextButtonMatcher };
 
 // Google Meet comprehensive leave matchers (stateless - covers all scenarios).
 // BROWSER CONTEXT: consumed inside page.evaluate via document.querySelector —

--- a/core/meetings/modules/join/src/msteams/leave.test.ts
+++ b/core/meetings/modules/join/src/msteams/leave.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Browser-context leave click — execution-context regression guard (#759,
+ * the MS Teams instance of #542's class).
+ *
+ * The leave click runs INSIDE the page via page.evaluate + document.querySelector,
+ * which understands plain CSS only. The pre-#759 array (teamsLeaveSelectors) fed
+ * it Playwright-only `:has-text()` entries: querySelector threw SyntaxError on
+ * every one, the throws were caught-and-skipped, and every text-labelled
+ * fallback — all three confirmation-dialog entries included — was silently dead.
+ * The bot could not click a leave-confirmation dialog, and each leave attempt
+ * spammed 10 invalid-selector errors that read like a root cause (#432/#432's
+ * Teams sibling). Red control on the pre-fix tree: the same dialog fixture
+ * returned false with 10/25 selectors throwing.
+ *
+ * This test drives leaveBrowserClick — the EXACT shared function both consumers
+ * serialize into the page — against jsdom fixtures (a real CSS engine, no
+ * browser): the confirmation dialog is clickable, priorities hold, and no
+ * selector error fires.
+ *
+ * Run: npx tsx src/msteams/leave.test.ts
+ */
+
+import { JSDOM } from 'jsdom';
+import { leaveBrowserClick } from '../shared/leave-click';
+import { teamsLeaveButtonMatchers } from './selectors';
+
+let passed = 0, failed = 0;
+function check(name: string, actual: unknown, expected: unknown) {
+  if (actual === expected) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name} (expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)})`); failed++; }
+}
+
+/**
+ * Mount a jsdom document as the click routine's browser context. jsdom has no
+ * layout, so every element gets a real box; visibility then keys on computed
+ * style (display/visibility/opacity), exactly like a rendered page.
+ * Returns the collected logBot lines and a `clicked` recorder.
+ */
+function mountDom(html: string) {
+  const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`);
+  dom.window.Element.prototype.getBoundingClientRect = function () {
+    return { width: 120, height: 40, top: 0, left: 0, right: 120, bottom: 40, x: 0, y: 0, toJSON() {} } as any;
+  };
+  (dom.window.HTMLElement.prototype as any).scrollIntoView = function () {};
+  const logs: string[] = [];
+  (dom.window as any).logBot = (m: string) => logs.push(m);
+  const clicked: string[] = [];
+  for (const el of Array.from(dom.window.document.querySelectorAll('button, [role="button"], input'))) {
+    el.addEventListener('click', () => clicked.push(el.getAttribute('data-fixture-id') || el.outerHTML));
+  }
+  (globalThis as any).window = dom.window;
+  (globalThis as any).document = dom.window.document;
+  (globalThis as any).getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+  return { dom, logs, clicked };
+}
+
+const selectorErrors = (logs: string[]) => logs.filter((l) => l.includes('selector failed in browser context'));
+
+(async () => {
+  console.log('\n=== the mechanism (#759): Playwright-only selectors are invalid in browser context ===');
+
+  // Negative control — the exact selector shape the pre-fix array shipped
+  // throws in a real CSS engine. This is what killed every dialog fallback,
+  // and it proves this fixture's engine genuinely rejects Playwright syntax
+  // (so the zero-selector-error assertions below mean something).
+  {
+    const { dom } = mountDom('<button>Leave</button>');
+    let threw = false;
+    try { dom.window.document.querySelector('button:has-text("Leave")'); }
+    catch { threw = true; }
+    check('querySelector(`button:has-text("…")`) throws SyntaxError (the dead-selector mechanism)', threw, true);
+  }
+
+  console.log('\n=== A1: leave-confirmation dialog is clickable through the browser-context path ===');
+
+  // The dialog fixture: ONLY a confirmation dialog with a text-labelled Leave
+  // button (no aria-label, no id) — no toolbar hangup button. Pre-#759 red:
+  // leave returned false here (every matching selector was Playwright-only).
+  // Includes the dialog's Close X to pin priority: the confirmation button must
+  // win over generic close/cancel.
+  {
+    const { logs, clicked } = mountDom(`
+      <div role="dialog" aria-label="Leave the meeting?">
+        <h2>Leave the meeting?</h2>
+        <button aria-label="Close" data-fixture-id="close-x"></button>
+        <button data-fixture-id="dialog-leave"><span>Leave</span></button>
+      </div>`);
+    const result = await leaveBrowserClick(teamsLeaveButtonMatchers);
+    check('dialog-only fixture → leave returns true', result, true);
+    check('the confirmation Leave button was clicked (not the Close X)', clicked.join(','), 'dialog-leave');
+    check('zero selector errors in browser context', selectorErrors(logs).length, 0);
+    // Attributed to the bare `{ text: 'Leave' }` matcher, which precedes the
+    // dialog-scoped one in priority order and matches the same button.
+    check(
+      'click is attributed in the logs',
+      logs.some((l) => l === '[leave] clicked leave button via text~"Leave"'),
+      true,
+    );
+  }
+
+  // "End meeting" confirmation dialog — a second text-labelled dialog button
+  // that was Playwright-only pre-fix.
+  {
+    const { logs, clicked } = mountDom(`
+      <div role="dialog">
+        <button data-fixture-id="end-meeting"><span>End meeting</span></button>
+      </div>`);
+    const result = await leaveBrowserClick(teamsLeaveButtonMatchers);
+    check('End-meeting dialog fixture → leave returns true', result, true);
+    check('the End meeting button was clicked', clicked.join(','), 'end-meeting');
+    check('zero selector errors in browser context', selectorErrors(logs).length, 0);
+  }
+
+  console.log('\n=== A3 guards: primary path, visibility, and the no-button case ===');
+
+  // In-call fixture — the primary #hangup-button wins first, before any text
+  // matching (unchanged behavior of the shipped Node/fast path's fallback).
+  {
+    const { logs, clicked } = mountDom(`
+      <div role="toolbar">
+        <button aria-label="Chat" data-fixture-id="chat"></button>
+        <button id="hangup-button" data-fixture-id="hangup"></button>
+      </div>`);
+    const result = await leaveBrowserClick(teamsLeaveButtonMatchers);
+    check('in-call fixture → leave returns true', result, true);
+    check('the primary hangup button was clicked', clicked.join(','), 'hangup');
+    check(
+      'attributed to the primary CSS matcher',
+      logs.some((l) => l === '[leave] clicked leave button via button[id="hangup-button"]'),
+      true,
+    );
+  }
+
+  // Visibility guard — a display:none confirmation button must not be clicked.
+  {
+    const { clicked } = mountDom(`
+      <div role="dialog">
+        <button style="display: none" data-fixture-id="hidden"><span>Leave</span></button>
+      </div>`);
+    const result = await leaveBrowserClick(teamsLeaveButtonMatchers);
+    check('hidden confirmation button → leave returns false', result, false);
+    check('nothing was clicked', clicked.length, 0);
+  }
+
+  // No leave affordance at all → false, loudly.
+  {
+    const { logs, clicked } = mountDom('<div>Meeting chrome, no leave anywhere</div>');
+    const result = await leaveBrowserClick(teamsLeaveButtonMatchers);
+    check('no leave affordance → leave returns false', result, false);
+    check('nothing was clicked', clicked.length, 0);
+    check('zero selector errors in browser context', selectorErrors(logs).length, 0);
+    check(
+      'the no-match outcome is logged',
+      logs.includes('[leave] no visible leave button matched any matcher'),
+      true,
+    );
+  }
+
+  console.log(`\n=== summary: ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/core/meetings/modules/join/src/msteams/leave.ts
+++ b/core/meetings/modules/join/src/msteams/leave.ts
@@ -2,7 +2,8 @@ import { Page } from "playwright";
 import { log, callLeaveCallback } from "../_host";
 import { logJSON } from "../_host";
 import { BotConfig } from "../_host";
-import { teamsLeaveSelectors, teamsPrimaryHangupButtonSelector } from "./selectors";
+import { teamsLeaveButtonMatchers, teamsPrimaryHangupButtonSelector } from "./selectors";
+import { leaveBrowserClick } from "../shared/leave-click";
 import { stopTeamsRecording } from "../_host";
 
 // Prepare for recording by exposing necessary functions
@@ -15,84 +16,34 @@ export async function prepareForRecording(page: Page, botConfig: BotConfig): Pro
   // Expose bot config for callback functions
   await page.exposeFunction("getBotConfig", (): BotConfig => botConfig);
 
-  // Ensure leave function is available even before admission
-  await page.evaluate((selectorsData) => {
+  // Node-side binding backing the browser-context leave hook: it drives the
+  // shared canonical leaveBrowserClick through page.evaluate, so the hook needs
+  // no in-page copy of the click logic and cannot drift from the direct path.
+  await page.exposeFunction("__vexaTeamsLeaveClick", async (): Promise<boolean> => {
+    try {
+      return Boolean(await page.evaluate(leaveBrowserClick, teamsLeaveButtonMatchers));
+    } catch (err: any) {
+      log(`[performLeaveAction] browser leave click failed: ${err?.message}`);
+      return false;
+    }
+  });
+
+  // Ensure leave function is available even before admission. The leave
+  // callback to the host is sent from the Node side (leaveMicrosoftTeams), not
+  // from this hook.
+  await page.evaluate(() => {
     if (typeof (window as any).performLeaveAction !== "function") {
       (window as any).performLeaveAction = async () => {
         try {
-          // Call leave callback first to notify the host
-          (window as any).logBot?.("🔥 Calling leave callback before attempting to leave...");
-          try {
-            const botConfig = (window as any).getBotConfig?.();
-            if (botConfig) {
-              // We need to call the callback from Node.js context, not browser context
-              // This will be handled by the Node.js side when leaveMicrosoftTeams is called
-              (window as any).logBot?.("📡 Leave callback will be sent from Node.js context");
-            }
-          } catch (callbackError: any) {
-            (window as any).logBot?.(`⚠️ Warning: Could not prepare leave callback: ${callbackError.message}`);
-          }
-
-          // Use directly injected selectors (stateless approach)
-          const leaveSelectors = selectorsData.teamsLeaveSelectors || [];
-
-          (window as any).logBot?.("🔍 Starting stateless Teams leave button detection...");
-          (window as any).logBot?.(`📋 Will try ${leaveSelectors.length} selectors until one works`);
-
-          // Try each selector until one works (stateless iteration)
-          for (let i = 0; i < leaveSelectors.length; i++) {
-            const selector = leaveSelectors[i];
-            try {
-              (window as any).logBot?.(`🔍 [${i + 1}/${leaveSelectors.length}] Trying selector: ${selector}`);
-
-              const button = document.querySelector(selector) as HTMLElement;
-              if (button) {
-                // Check if button is visible and clickable
-                const rect = button.getBoundingClientRect();
-                const computedStyle = getComputedStyle(button);
-                const isVisible = rect.width > 0 && rect.height > 0 &&
-                                computedStyle.display !== 'none' &&
-                                computedStyle.visibility !== 'hidden' &&
-                                computedStyle.opacity !== '0';
-
-                if (isVisible) {
-                  const ariaLabel = button.getAttribute('aria-label');
-                  const dataTid = button.getAttribute('data-tid');
-                  const textContent = button.textContent?.trim();
-
-                  (window as any).logBot?.(`✅ Found clickable button: aria-label="${ariaLabel}", data-tid="${dataTid}", text="${textContent}"`);
-
-                  // Scroll into view and click
-                  button.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                  await new Promise((resolve) => setTimeout(resolve, 500));
-
-                  (window as any).logBot?.(`🖱️ Clicking Teams button...`);
-                  button.click();
-                  await new Promise((resolve) => setTimeout(resolve, 1000));
-
-                  (window as any).logBot?.(`✅ Successfully clicked button with selector: ${selector}`);
-                  return true;
-                } else {
-                  (window as any).logBot?.(`ℹ️ Button found but not visible for selector: ${selector}`);
-                }
-              } else {
-                (window as any).logBot?.(`ℹ️ No button found for selector: ${selector}`);
-              }
-            } catch (e: any) {
-              (window as any).logBot?.(`❌ Error with selector ${selector}: ${e.message}`);
-              continue;
-            }
-          }
-
-          (window as any).logBot?.("❌ No working leave/cancel button found - tried all selectors");
-          return false;
+          (window as any).logBot?.("🔥 Leave requested from browser context — clicking the leave path...");
+          return await (window as any).__vexaTeamsLeaveClick();
         } catch (err: any) {
-          (window as any).logBot?.(`Error during Teams leave attempt: ${err.message}`);
+          (window as any).logBot?.(`Error during Teams leave attempt: ${err?.message}`);
           return false;
         }
       };
     }
-  }, { teamsLeaveSelectors });
+  });
 }
 
 // --- ADDED: Exported function to trigger leave from Node.js ---

--- a/core/meetings/modules/join/src/msteams/selectors.ts
+++ b/core/meetings/modules/join/src/msteams/selectors.ts
@@ -11,6 +11,10 @@
 // entries were replaced with the unquoted substring form on 2026-07-04;
 // src/shared/selector-validity.test.ts now gates every selector array.
 
+// Browser-context button matcher (shared shape) — see ../shared/leave-click.
+import type { BrowserContextButtonMatcher } from "../shared/leave-click";
+export type { BrowserContextButtonMatcher };
+
 export const teamsInitialAdmissionIndicators: string[] = [
   // Most reliable indicators: Leave buttons that actually exist in Teams meetings
   'button[id="hangup-button"]',
@@ -221,50 +225,66 @@ export const teamsNameInputSelectors: string[] = [
 // Primary hangup button selector (most reliable)
 export const teamsPrimaryHangupButtonSelector = '#hangup-button';
 
-// Teams comprehensive leave selectors (stateless - covers all scenarios)
-export const teamsLeaveSelectors: string[] = [
+// Teams comprehensive leave matchers (stateless — covers all scenarios).
+// BROWSER CONTEXT: consumed inside page.evaluate via document.querySelector —
+// declared in browserContextSelectorArrays below, so the validity gate
+// CSS-parses every `css` field. Tried in order; first visible match wins.
+// Text-labelled buttons (Teams confirmation dialogs name their buttons by
+// textContent, not aria-label) are `text` matchers — the `:has-text()`
+// semantics, expressed for a plain-CSS engine. Priority order is preserved
+// from the working `#hangup-button` first down to generic close/cancel, so a
+// confirmation Leave/End cannot be outranked by a stray Close.
+export const teamsLeaveButtonMatchers: BrowserContextButtonMatcher[] = [
   // WORKING SELECTORS FIRST - confirmed from logs
-  'button[id="hangup-button"]', // ✅ CONFIRMED WORKING - successfully clicked in logs
+  { css: 'button[id="hangup-button"]' }, // ✅ CONFIRMED WORKING - successfully clicked in logs
 
   // Teams-specific leave/hangup buttons
-  'button[data-tid="hangup-main-btn"]',
+  { css: 'button[data-tid="hangup-main-btn"]' },
 
   // Cancel buttons (for awaiting admission/waiting room)
-  'button[aria-label="Cancel"]',
-  'button:has-text("Cancel")',
+  { css: 'button[aria-label="Cancel"]' },
+  { text: 'Cancel' },
 
   // Leave buttons (for active meetings)
-  'button[aria-label="Leave"]',
-  'button:has-text("Leave")',
+  { css: 'button[aria-label="Leave"]' },
+  { text: 'Leave' },
 
   // More specific leave patterns
-  'button[aria-label*="Leave"]',
-  'button[aria-label*="leave"]',
-  '[role="toolbar"] button[aria-label*="Leave"]',
+  { css: 'button[aria-label*="Leave"]' },
+  { css: 'button[aria-label*="leave"]' },
+  { css: '[role="toolbar"] button[aria-label*="Leave"]' },
 
   // End meeting alternatives
-  'button[aria-label*="End meeting"]',
-  'button:has-text("End meeting")',
-  'button[aria-label*="Hang up"]',
-  'button:has-text("Hang up")',
+  { css: 'button[aria-label*="End meeting"]' },
+  { text: 'End meeting' },
+  { css: 'button[aria-label*="Hang up"]' },
+  { text: 'Hang up' },
 
   // Close/dismiss alternatives
-  'button:has-text("Close")',
-  'button[aria-label="Close"]',
-  'button:has-text("Dismiss")',
-  'button[aria-label="Dismiss"]',
+  { text: 'Close' },
+  { css: 'button[aria-label="Close"]' },
+  { text: 'Dismiss' },
+  { css: 'button[aria-label="Dismiss"]' },
 
   // Generic cancel patterns
-  'button[aria-label*="Cancel"]',
-  'button[data-tid*="cancel"]',
-  '[role="button"]:has-text("Cancel")',
+  { css: 'button[aria-label*="Cancel"]' },
+  { css: 'button[data-tid*="cancel"]' },
+  { css: '[role="button"]', text: 'Cancel' },
 
   // Confirmation dialog buttons
-  '[role="dialog"] button:has-text("Leave")',
-  '[role="dialog"] button:has-text("End meeting")',
-  '[role="alertdialog"] button:has-text("Leave")',
+  { css: '[role="dialog"] button', text: 'Leave' },
+  { css: '[role="dialog"] button', text: 'End meeting' },
+  { css: '[role="alertdialog"] button', text: 'Leave' },
 
   // Fallback patterns
-  'input[type="button"][value="Cancel"]',
-  'input[type="submit"][value="Cancel"]'
+  { css: 'input[type="button"][value="Cancel"]' },
+  { css: 'input[type="submit"][value="Cancel"]' }
 ];
+
+// EXECUTION-CONTEXT DECLARATION — consumed by src/shared/selector-validity.test.ts.
+// teamsLeaveButtonMatchers ships into page.evaluate and runs through
+// document.querySelector, so the gate's LANE 2 additionally CSS-parses every
+// `css` field: a Playwright-only `:has-text()` — invalid in that context —
+// would otherwise ship green as a dead selector. `text` fields are raw strings
+// matched against textContent in-page, never parsed as selectors.
+export const browserContextSelectorArrays: string[] = ['teamsLeaveButtonMatchers'];

--- a/core/meetings/modules/join/src/shared/leave-click.ts
+++ b/core/meetings/modules/join/src/shared/leave-click.ts
@@ -1,0 +1,67 @@
+// A leave-button matcher for the BROWSER context. `css` is a plain-CSS scope
+// (evaluated with document.querySelector inside page.evaluate, where Playwright
+// engines like `:has-text()` do not exist); `text` filters those candidates by
+// whitespace-normalized, case-insensitive substring of textContent (the
+// semantics `:has-text()` applies in Playwright contexts). At least one field
+// must be present; `css` alone means "first visible match", `text` alone scopes
+// to any button-like element.
+export type BrowserContextButtonMatcher = { css?: string; text?: string };
+
+// The leave click that runs INSIDE the page (shipped through page.evaluate by
+// every platform's consumers — ONE canonical routine, shared across googlemeet
+// and msteams, so an injected hook and a direct leave can never drift, and each
+// platform's no-browser fixture test drives exactly the function production
+// serializes into the browser).
+//
+// Self-contained by contract: it is serialized into the browser context, where
+// module scope does not exist — DOM globals and its argument only.
+// document.querySelector understands plain CSS (no Playwright engines), so
+// text-labelled buttons are expressed as `text` fields and matched here by
+// whitespace-normalized, case-insensitive substring of textContent — the
+// semantics `:has-text()` applies in Playwright contexts. Matchers are tried
+// in order; the first visible match is clicked.
+export async function leaveBrowserClick(
+  matchers: BrowserContextButtonMatcher[],
+): Promise<boolean> {
+  // Serialization contract: esbuild-family compilers (tsx — the debug harness
+  // lane) emit nested function expressions wrapped in a `__name` helper that
+  // does not exist inside the page. Define an identity fallback BEFORE any
+  // nested function is created, so the serialized source is self-contained
+  // under every compiler (tsc emits none of this; the line is then inert).
+  (globalThis as any).__name = (globalThis as any).__name || ((f: unknown) => f);
+  const blog = (m: string) => { try { (window as any).logBot?.(m); } catch { /* logging is best-effort */ } };
+  const normalize = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
+  const isVisible = (el: Element) => {
+    const rect = el.getBoundingClientRect();
+    const cs = getComputedStyle(el as HTMLElement);
+    return rect.width > 0 && rect.height > 0
+      && cs.display !== "none" && cs.visibility !== "hidden" && cs.opacity !== "0";
+  };
+  for (const matcher of matchers) {
+    const scope = matcher.css ?? 'button, [role="button"]';
+    let candidates: Element[];
+    try {
+      candidates = Array.from(document.querySelectorAll(scope));
+    } catch (e: any) {
+      // The selector-validity gate CSS-parses every declared browser-context
+      // entry, so this only fires on drift — loudly, never silently.
+      blog(`[leave] selector failed in browser context: ${scope} — ${e?.message}`);
+      continue;
+    }
+    const needle = matcher.text === undefined ? null : normalize(matcher.text);
+    const button = candidates.find(
+      (el) => (needle === null || normalize(el.textContent || "").includes(needle)) && isVisible(el),
+    ) as HTMLElement | undefined;
+    if (!button) continue;
+    button.scrollIntoView({ behavior: "smooth", block: "center" });
+    await new Promise((r) => setTimeout(r, 300));
+    button.click();
+    await new Promise((r) => setTimeout(r, 800));
+    const via = [matcher.css, matcher.text === undefined ? undefined : `text~"${matcher.text}"`]
+      .filter(Boolean).join(" ");
+    blog(`[leave] clicked leave button via ${via}`);
+    return true;
+  }
+  blog("[leave] no visible leave button matched any matcher");
+  return false;
+}

--- a/core/meetings/services/bot/src/join-driver.ts
+++ b/core/meetings/services/bot/src/join-driver.ts
@@ -95,7 +95,7 @@ export function createBrowserJoinDriver(page: Page, inv: Invocation): JoinDriver
       // Bug 2 — cancel a PENDING join from the waiting room / pre-join screen. Two-step, both
       // best-effort:
       //  1. Click the platform's cancel/leave affordance. The stateless leave-click helpers already
-      //     include the waiting-room selectors: Teams' teamsLeaveSelectors carry the "Cancel" buttons
+      //     include the waiting-room selectors: Teams' teamsLeaveButtonMatchers carry the "Cancel" buttons
       //     "(for awaiting admission/waiting room)", and googleLeaveButtonMatchers include Cancel/Close. On
       //     Zoom the web client shows no reliable pre-admit cancel, so step 2 is the withdraw there.
       //  2. GUARANTEED DROP: close the page. Google Meet's lobby often exposes no clickable Cancel

--- a/docs/changelog.d/759-teams-leave-selector-fallbacks.md
+++ b/docs/changelog.d/759-teams-leave-selector-fallbacks.md
@@ -1,0 +1,8 @@
+- **Teams bot leave — dead browser-context fallbacks revived (#759).** The Microsoft Teams
+  leave path ran its fallback list through the browser's `document.querySelector`, but 10 of the
+  25 entries were Playwright-only `:has-text()` locators — invalid CSS that threw on every call,
+  so every text-labelled button (all three leave-confirmation dialog buttons included) was
+  silently un-clickable and each leave attempt logged 10 "not a valid selector" errors. The array
+  is now a `{ css | text }` matcher list driven by the same shared in-page clicker as Google Meet
+  (#542), and it joins the selector-validity gate's browser-context lane so the class fails loudly
+  for Teams too.


### PR DESCRIPTION
Delivers #759 — the MS Teams instance of #542's class, applied via PR #758's established recipe. Refs #759 (live-leave leg stays open, same as #542).

## Mechanism
`teamsLeaveSelectors` → `teamsLeaveButtonMatchers` (`{css|text}` split, **all 25 entries preserved in priority order** — the 10 dead `:has-text()` ones converted, none dropped without live proof); the canonical in-page clicker is **hoisted to `src/shared/leave-click.ts`** so Meet and Teams share one walker (Google's surface unchanged via re-exports, its tests untouched); Teams array declared into the selector gate's LANE 2.

## Bundle
| Row | Status | Evidence |
|---|---|---|
| A1 dialog fallbacks work | **desk red→green** | base: `leave clicked=false, invalid-selector throws=9/25` (jsdom; Chromium counts 10 — lazy-vs-eager parse, engine artifact noted); head: new jsdom suite **17/17**, confirmation button beats Close X |
| A2 gate sees Teams | **desk red→green** | `2 browser-context arrays, 32 css entries — 0 invalid`; planted `:has-text()` → `1 invalid`, exit 1 |
| A3 no-regression | **desk green, live pending** | join suites green, `gates.mjs all` ✅ (one TS re-export scoping bug caught by the gate's first run, fixed) |
| class extinct repo-wide | **audited** | zoom: `:has-text()` only in Playwright context (valid); jitsi: none — Teams was the last instance |

From the production sitting; opus implementation, fable verification.