### PR TITLE
fix(zoom): wire createZoomSpeakers — Zoom transcripts carry who spoke (#538)

### DIFF
--- a/core/meetings/modules/zoom-capture/src/zoom-capture.test.ts
+++ b/core/meetings/modules/zoom-capture/src/zoom-capture.test.ts
@@ -138,5 +138,67 @@ const speakerTile = (name: string) =>
   sp.destroy();
 }
 
+// ── The fixture range (view layouts + edges): the watcher's predicate per layout ──
+{
+  // Gallery/speaker-bar layout: the active tile is marked by the
+  // `--active` modifier on the bar frame (the second known container selector).
+  setDoc(e('body', {}, [
+    e('div', { class: 'speaker-bar-container__video-frame' }, [
+      e('div', { class: 'video-avatar__avatar-footer' }, [ t('span', 'Grace') ]),
+    ]),
+    e('div', { class: 'speaker-bar-container__video-frame speaker-bar-container__video-frame--active' }, [
+      e('div', { class: 'video-avatar__avatar-footer' }, [ t('span', 'Hector') ]),
+    ]),
+  ]));
+  const changes: (string | null)[] = [];
+  const sp = createZoomSpeakers({ pollMs: 10, onSpeakerChange: (n) => changes.push(n) });
+  tickN(2);
+  check('range(gallery bar): the --active tile names the speaker', sp.getActiveSpeaker() === 'Hector');
+  check('range(gallery bar): the unlit tile never emits', !changes.includes('Grace'));
+  sp.destroy();
+}
+{
+  // Screen-share layout: no active-speaker frame in the DOM at all →
+  // NO hint is emitted, never a wrong one (the no-signal pin).
+  setDoc(e('body', {}, [
+    e('div', { class: 'sharee-container' }, [
+      e('div', { class: 'video-avatar__avatar-footer' }, [ t('span', 'Presenter P.') ]),
+    ]),
+  ]));
+  const changes: (string | null)[] = [];
+  const sp = createZoomSpeakers({ pollMs: 10, onSpeakerChange: (n) => changes.push(n) });
+  tickN(4);
+  check('range(screen share): no active frame → no speaker, no emission', sp.getActiveSpeaker() === null && changes.length === 0);
+  sp.destroy();
+}
+{
+  // Active frame present but the name footer is empty → emit nothing (a
+  // nameless hint would hijack downstream binding worse than silence).
+  setDoc(e('body', {}, [
+    e('div', { class: 'speaker-active-container__video-frame' }, [
+      e('div', { class: 'video-avatar__avatar-footer' }, [ t('span', '') ]),
+    ]),
+  ]));
+  const changes: (string | null)[] = [];
+  const sp = createZoomSpeakers({ pollMs: 10, onSpeakerChange: (n) => changes.push(n) });
+  tickN(4);
+  check('range(empty footer): active frame with no name → no emission', sp.getActiveSpeaker() === null && changes.length === 0);
+  sp.destroy();
+}
+{
+  // A held handover (Alice → Bob for CONFIRM_POLLS) DOES emit — the debounce
+  // drops flicker, never a real transition (the pair to the flicker pin above).
+  setDoc(e('body', {}, [ speakerTile('Alice') ]));
+  const changes: (string | null)[] = [];
+  const sp = createZoomSpeakers({ pollMs: 10, onSpeakerChange: (n) => changes.push(n) });
+  tickN(2);                                         // commit Alice
+  setDoc(e('body', {}, [ speakerTile('Bob') ]));
+  tickN(2);                                         // Bob holds for CONFIRM_POLLS
+  check('range(handover): a held transition commits Bob', sp.getActiveSpeaker() === 'Bob');
+  check('range(handover): both transitions emitted in order',
+    changes.filter((c) => c === 'Alice').length === 1 && changes[changes.length - 1] === 'Bob');
+  sp.destroy();
+}
+
 if (failed) { console.error(`\n❌ zoom-capture: ${failed} checks FAILED.`); process.exit(1); }
 console.log(`\n✅ zoom-capture: chat sender/body extraction + active-speaker flicker confirmation pass. (DOM capture is live-validated.)`);

--- a/core/meetings/services/bot/Dockerfile
+++ b/core/meetings/services/bot/Dockerfile
@@ -68,7 +68,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 # runs build-browser-utils.mjs, which esbuild-bundles these bricks' dist into
 # window.VexaBrowserUtils (the global capture-bridge.ts injects via addInitScript) —
 # so their dist/ must already exist when the bot build runs.
-RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" run build
+RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" --filter "@vexa/zoom-capture" run build
 
 # Build @vexa/bot and everything it depends on (the `...` selector pulls the deps;
 # pnpm runs them in topological order, each package's own `build` = tsc → dist/).

--- a/core/meetings/services/bot/build-browser-utils.mjs
+++ b/core/meetings/services/bot/build-browser-utils.mjs
@@ -54,6 +54,7 @@ const MIXED = moduleEntry('mixed-capture-core');  // @vexa/mixed-capture-core
 const RECORD = moduleEntry('record-chunker');     // @vexa/record-chunker (MediaRecorder → recording.v1)
 const JITSI = moduleEntry('jitsi-capture');       // @vexa/jitsi-capture (dominant-speaker hints + chat)
 const TEAMS = moduleEntry('teams-capture');       // @vexa/teams-capture (voice-level-outline speaker hints)
+const ZOOM = moduleEntry('zoom-capture');         // @vexa/zoom-capture (active-speaker DOM watcher → 'dom-active' hints)
 
 // In-memory entry: import the bricks and hang them on window.VexaBrowserUtils with
 // the EXACT names capture-bridge.ts reaches for. esbuild bundles the relative
@@ -82,6 +83,9 @@ import {
 import {
   createTeamsSpeakers,
 } from ${JSON.stringify(TEAMS)};
+import {
+  createZoomSpeakers,
+} from ${JSON.stringify(ZOOM)};
 
 const VexaBrowserUtils = {
   // ── gmeet lane (per-participant capture + glow attribution) ──
@@ -102,6 +106,8 @@ const VexaBrowserUtils = {
   sendJitsiChatMessage,
   // ── teams lane (voice-level "blue-square" outline → speaker hints) ──
   createTeamsSpeakers,       // capture-bridge.ts: w.VexaBrowserUtils.createTeamsSpeakers
+  // ── zoom lane (active-speaker DOM watcher → 'dom-active' naming hints) ──
+  createZoomSpeakers,        // capture-bridge.ts: w.VexaBrowserUtils.createZoomSpeakers
 };
 
 (globalThis).VexaBrowserUtils = VexaBrowserUtils;
@@ -147,5 +153,5 @@ console.log('  - createGmeetCapture / createGmeetSpeakers / createGmeetCaptureV1
 console.log('  - GmeetChannelBinder / createPcmCaptureNode');
 console.log('  - createMixedAudioCapture / installRemoteAudioHook');
 console.log('  - createJitsiSpeakers / createJitsiChat / sendJitsiChatMessage');
-console.log('  - createTeamsSpeakers');
+console.log('  - createTeamsSpeakers / createZoomSpeakers');
 console.log('  - window.performLeaveAction');

--- a/core/meetings/services/bot/package.json
+++ b/core/meetings/services/bot/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && node build-browser-utils.mjs",
     "build:browser-utils": "node build-browser-utils.mjs",
     "start": "tsx src/index.ts",
-    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/replay.test.ts && tsx mock/mock.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/replay.test.ts && tsx src/zoom-speaker-wiring.test.ts && tsx mock/mock.test.ts",
     "replay": "tsx src/replay.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -286,7 +286,7 @@ export async function startCaptureBridge(
   // ── Start the page-side capture (VexaBrowserUtils preferred; production inline fallback). ──
   // The body of this callback runs IN THE BROWSER (Playwright serializes it); DOM globals are
   // reached via globalThis (this file type-checks against the Node lib — no DOM types here).
-  await page.evaluate(async ({ isMixed, isJitsi, isTeams, botName }) => {
+  await page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName }) => {
     const w = (globalThis as any) as Record<string, any>;
     if (isMixed) {
       // Zoom/Teams: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
@@ -354,6 +354,26 @@ export async function startCaptureBridge(
           });
         }
       }
+      if (isZoom) {
+        // Zoom contributes the WHO signal the mixed audio can't carry: the active-speaker
+        // DOM watcher (poll + flicker debounce lives in @vexa/zoom-capture) emits name
+        // transitions → __vexaSpeakerHint → pipeline.recordHint, which labels them
+        // 'dom-active' (Zoom's true kind — the mixed lane's DOM-active lag model).
+        // Timestamps are page Date.now() = epoch ms, the same clock Node stamps with.
+        if (w.VexaBrowserUtils?.createZoomSpeakers && !w.__vexaZoomSpeakers) {
+          let lastActive: string | null = null;
+          w.__vexaZoomSpeakers = w.VexaBrowserUtils.createZoomSpeakers({
+            selfName: botName,
+            log: (m: string) => w.logBot?.('[ZoomSpeakers] ' + m),
+            onSpeakerChange: (name: string | null) => {
+              const tMs = Date.now();
+              if (name) w.__vexaSpeakerHint?.(name, tMs, false);           // start / heartbeat re-assert
+              else if (lastActive) w.__vexaSpeakerHint?.(lastActive, tMs, true); // nobody lit → close the turn
+              lastActive = name;
+            },
+          });
+        }
+      }
       return;
     }
     // gmeet lane: per-channel capture + glow attribution (the SAME module the extension runs).
@@ -373,7 +393,7 @@ export async function startCaptureBridge(
       });
       await w.__vexaGmeetCapture.start();
     }
-  }, { isMixed: mixed, isJitsi: jitsi, isTeams: inv.platform === 'teams', botName: inv.botName }).catch((e) => {
+  }, { isMixed: mixed, isJitsi: jitsi, isTeams: inv.platform === 'teams', isZoom: inv.platform === 'zoom', botName: inv.botName }).catch((e) => {
     console.error(`[bot] capture bridge: page-side start failed: ${String(e)}`); // L4: surfaces only on the VM
   });
 
@@ -386,6 +406,7 @@ export async function startCaptureBridge(
       try { w.__vexaTeamsSpeakers?.destroy?.(); w.__vexaTeamsSpeakers = null; } catch { /* best-effort */ }
       try { w.__vexaJitsiSpeakers?.destroy?.(); w.__vexaJitsiSpeakers = null; } catch { /* best-effort */ }
       try { w.__vexaJitsiChat?.destroy?.(); w.__vexaJitsiChat = null; } catch { /* best-effort */ }
+      try { w.__vexaZoomSpeakers?.destroy?.(); w.__vexaZoomSpeakers = null; } catch { /* best-effort */ }
       try { if (w.__vexaMixRescan) { (globalThis as any).clearInterval(w.__vexaMixRescan); w.__vexaMixRescan = null; } } catch { /* */ }
       try { if (w.__vexaMixedCapture && typeof w.__vexaMixedCapture.stop === 'function') w.__vexaMixedCapture.stop(); } catch { /* best-effort */ }
       try { w.__vexaMixCtx?.close?.(); } catch { /* best-effort */ }

--- a/core/meetings/services/bot/src/zoom-speaker-wiring.test.ts
+++ b/core/meetings/services/bot/src/zoom-speaker-wiring.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Zoom speaker wiring — the page→Node boundary test (#538 A1).
+ *
+ * Drives the REAL page-side capture bundle (dist/browser-utils.global.js — the
+ * exact file the bot injects via addInitScript) and the REAL startCaptureBridge
+ * wiring against a fake Playwright Page whose exposeFunction/evaluate run
+ * in-process. Scripted Zoom active-speaker DOM transitions must cross the
+ * boundary as speaker hints — name, epoch-ms timestamp, order, and turn-close
+ * (isEnd) intact — arriving at the pipeline's recordHint seam (which the mixed
+ * lane labels 'dom-active', Zoom's true kind — pipeline.ts).
+ *
+ * RED at any base where the bundle lacks @vexa/zoom-capture or the zoom branch
+ * of the bridge doesn't start the watcher: zero arrivals.
+ * Run: npx tsx src/zoom-speaker-wiring.test.ts
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { startCaptureBridge } from './capture-bridge.js';
+import type { Invocation } from './config.js';
+import type { BotPipeline } from './pipeline.js';
+
+let failed = 0;
+const check = (name: string, cond: boolean, detail?: string) => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond || !detail ? '' : ` — ${detail}`}`);
+  if (!cond) failed++;
+};
+
+// ── The real bundle (built by build-browser-utils.mjs — turbo test depends on build) ──
+const BUNDLE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'browser-utils.global.js');
+if (!existsSync(BUNDLE)) {
+  console.error(`❌ missing ${BUNDLE} — build the capture bundle first (pnpm --filter @vexa/bot build).`);
+  process.exit(1);
+}
+
+// ── Minimal Zoom DOM shim: exactly what createZoomSpeakers queries ──
+// (.speaker-active-container__video-frame → .video-avatar__avatar-footer → span)
+class El {
+  constructor(public classes: string[], public kids: El[] = [], public text = '') {}
+  get textContent(): string { return this.text + this.kids.map((k) => k.textContent).join(''); }
+  get innerText(): string { return this.textContent; }
+  querySelector(sel: string): El | null {
+    for (const k of this.all()) if (k.matches(sel)) return k;
+    return null;
+  }
+  querySelectorAll(sel: string): El[] { return this.all().filter((k) => k.matches(sel)); }
+  matches(sel: string): boolean {
+    if (sel === 'span') return this.classes.includes('__span');
+    return sel.split(',').some((s) => s.trim().startsWith('.') && this.classes.includes(s.trim().slice(1)));
+  }
+  private all(): El[] { const out: El[] = []; const w = (e: El) => { for (const k of e.kids) { out.push(k); w(k); } }; w(this); return out; }
+}
+const tile = (name: string) =>
+  new El(['speaker-active-container__video-frame'], [
+    new El(['video-avatar__avatar-footer'], [new El(['__span'], [], name)]),
+  ]);
+let root = new El(['body']);
+const setSpeaker = (name: string | null): void => { root = new El(['body'], name ? [tile(name)] : []); };
+
+// ── Page-context shims on the REAL globalThis (the fake page.evaluate runs in-process) ──
+const g = globalThis as unknown as Record<string, unknown>;
+g.document = { querySelector: (s: string) => root.querySelector(s), querySelectorAll: (s: string) => root.querySelectorAll(s) };
+const intervals: Array<() => void> = [];
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+(g as any).setInterval = (cb: () => void) => { intervals.push(cb); return intervals.length; };
+(g as any).clearInterval = () => { /* controlled clock */ };
+g.window = g;   // the bundle hangs VexaBrowserUtils on window too
+
+// Load the REAL bundle — defines globalThis.VexaBrowserUtils.
+new Function(readFileSync(BUNDLE, 'utf8'))();
+const utils = g.VexaBrowserUtils as Record<string, unknown> | undefined;
+check('bundle: window.VexaBrowserUtils.createZoomSpeakers is exported (RED at base — brick not bundled)',
+  typeof utils?.createZoomSpeakers === 'function', `keys: ${Object.keys(utils ?? {}).join(',')}`);
+
+// ── Fake Playwright Page: exposeFunction hangs the Node fn on the page global (same
+//    name Playwright binds); evaluate runs the callback in-process over those shims. ──
+const page = {
+  async exposeFunction(name: string, fn: unknown): Promise<void> { g[name] = fn; },
+  async evaluate(fn: (arg: never) => unknown, arg?: unknown): Promise<unknown> { return fn(arg as never); },
+} as never;
+
+// ── Node side: the pipeline seam the hints must reach ──
+const hints: Array<{ name: string; tMs: number; isEnd: boolean }> = [];
+const pipeline: BotPipeline = {
+  async start() { /* not driven */ },
+  async stop() { /* not driven */ },
+  feedAudio() { /* not driven */ },
+  feedMixedAudio() { /* not driven */ },
+  recordHint: (name, tMs, isEnd) => hints.push({ name, tMs, isEnd: !!isEnd }),
+};
+const inv = { platform: 'zoom', botName: 'Vexa Bot', connectionId: 'test' } as unknown as Invocation;
+
+const t0 = Date.now();
+const stop = await startCaptureBridge(page, inv, pipeline);
+const tick = (n: number) => { for (const cb of [...intervals]) for (let i = 0; i < n; i++) cb(); };
+
+// ── N scripted transitions across the boundary (CONFIRM_POLLS=2 debounce) ──
+setSpeaker('Alice');  tick(2);
+setSpeaker('Bob');    tick(2);
+setSpeaker('Carol');  tick(2);
+setSpeaker(null);     tick(2);   // nobody lit → the open turn closes (isEnd)
+
+const starts = hints.filter((h) => !h.isEnd).map((h) => h.name);
+check('boundary: all 3 scripted transitions arrived node-side, in order (RED at base — zero arrivals)',
+  JSON.stringify(starts) === JSON.stringify(['Alice', 'Bob', 'Carol']), JSON.stringify(hints));
+check('boundary: nobody-lit closes the last turn (isEnd for Carol)',
+  hints.some((h) => h.isEnd && h.name === 'Carol'), JSON.stringify(hints));
+check('boundary: timestamps are epoch ms (the Node clock), non-decreasing',
+  hints.every((h) => h.tMs >= t0 && h.tMs <= Date.now()) &&
+  hints.every((h, i) => i === 0 || h.tMs >= hints[i - 1].tMs));
+check('boundary: the seam reached is BotPipeline.recordHint — the mixed lane labels it \'dom-active\' (pipeline.ts)',
+  hints.length > 0);
+
+// A single-poll flicker must NOT cross the boundary (the debounce holds at wiring altitude).
+setSpeaker('Dave'); tick(2);
+const before = hints.length;
+setSpeaker('Eve');  tick(1);    // one flicker poll
+setSpeaker('Dave'); tick(1);    // back before confirm
+check('boundary: a single-poll flicker (Eve) never crosses', !hints.slice(before).some((h) => h.name === 'Eve'),
+  JSON.stringify(hints.slice(before)));
+
+await stop();
+(g as any).setInterval = realSetInterval;
+(g as any).clearInterval = realClearInterval;
+
+if (failed) { console.error(`\n❌ zoom-speaker-wiring: ${failed} checks FAILED.`); process.exit(1); }
+console.log('\n✅ zoom-speaker-wiring: real bundle + real bridge carry Zoom active-speaker transitions page→Node (order, epoch-ms timestamps, isEnd, flicker debounce).');

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -37,7 +37,7 @@ COPY scripts ./scripts
 RUN --mount=type=cache,id=pnpm-store-lite,target=/pnpm/store \
     pnpm install --frozen-lockfile=false
 # Build the page-side capture bricks first (browser bundles, not bot deps), then @vexa/bot + deps.
-RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" run build
+RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" --filter "@vexa/zoom-capture" run build
 RUN pnpm --filter "@vexa/bot..." run build
 RUN test -f /build/core/meetings/services/bot/dist/index.js \
  && test -s /build/core/meetings/services/bot/dist/browser-utils.global.js

--- a/docs/changelog.d/538-zoom-speaker-wiring.md
+++ b/docs/changelog.d/538-zoom-speaker-wiring.md
@@ -1,0 +1,6 @@
+- **Zoom transcripts now name who spoke (#538).** The Zoom active-speaker watcher
+  (`createZoomSpeakers`) is wired into the bot's page-side capture bundle: active-speaker
+  transitions cross to the name binder as `dom-active` hints, so Zoom bot segments carry the
+  real participant's name instead of `seg_N` placeholders — the same attribution Google Meet
+  and Jitsi already deliver. Flicker-debounced (a single ~250 ms tile blip never mislabels a
+  turn); screen-share layouts and nameless tiles emit no hint rather than a wrong one.


### PR DESCRIPTION
Refs #538

## Mechanism (C1 + C2, one seam each)

**C1 — the page→Node wiring.** `@vexa/zoom-capture` joins the bot's browser bundle (`build-browser-utils.mjs` module entry + the `Dockerfile:71` brick-build filter), exposing `createZoomSpeakers` on `window.VexaBrowserUtils`. `startCaptureBridge`'s zoom branch (mirroring the in-tree Jitsi template at `capture-bridge.ts`) starts the watcher post-admission and forwards transitions to `__vexaSpeakerHint(name, tMs, isEnd)` — page `Date.now()` epoch ms (the same clock Node stamps with); nobody-lit closes the open turn with `isEnd`. Teardown destroys the watcher. **Kind state built on:** #498 has NOT merged; `pipeline.ts:185` hardcodes `'dom-active'`, which is Zoom's true kind — hints arrive correctly labeled today, and the threaded kind arrives with the twin.

**C2 — the fixture range + boundary pin.** `zoom-capture.test.ts` gains the layout range (gallery-bar `--active` tile, screen-share no-signal, empty name footer, held handover) beside the existing flicker pin. New `services/bot/src/zoom-speaker-wiring.test.ts` (registered in the bot's `pnpm test`) drives the **REAL built bundle** through the **REAL `startCaptureBridge`** over a fake Page whose exposeFunction/evaluate run in-process: scripted DOM transitions must cross to `BotPipeline.recordHint`.

## Observation bundle (the issue's acceptance table, its numbering)

**A1 — boundary CI test.** Head: all 6 checks green — 3 scripted transitions arrive node-side in order, epoch-ms timestamps non-decreasing, isEnd closes the last turn, single-poll flicker never crosses. **Negative control (RED at base):** rebuilt the bundle + bridge from `origin/main` (`git stash` of the two files) and reran the head test — `createZoomSpeakers` absent from the bundle, **zero arrivals**, 4 checks red. Base 702a365afb9984401b0fd86ef61bb6921c761509 → head ee73fb695a4c19bfac79d12edc368eea14a31d4d. Kind: asserted at the `recordHint` seam; the `'dom-active'` label is `pipeline.ts:185`'s hardcode (correct for Zoom pre-#498; the kind-pinning unit test lands with #498 per the issue's open question 3).

**A2 — fixture range.** All range checks green at head (gallery bar names the `--active` tile and never the unlit one; screen-share and empty-footer emit nothing; held handover emits Alice→Bob in order; flicker pin holds). **Negative control:** swapping the Grace/Hector fixture labels → 2 checks red (`range(gallery bar)` both fail).

**A3 — LIVE Zoom run: NOT DONE (the remaining human bar).** This bundle is offline-only; the live leg (one Zoom meeting, 2 speakers, named segments + repaint, fsm.log + transcript + native meeting id) awaits the declared validator on Lite compose. Per the issue, the meeting class must clear the audio-join gate (#515's territory).

**A4 — no-regression.** `@vexa/zoom-capture` tests green (16 checks), `@vexa/bot` full suite green (incl. the new boundary test), `@vexa/mixed-pipeline` lane green, `node scripts/gates.mjs all` → **✅ gates green** at head. `BASELINE.md` zoom row untouched (re-scoring is the live leg's side effect, not claimable offline).

**NOT checked:** any live meeting (A3); the Docker image build end-to-end (Dockerfile filter edit is textual, mirrors the jitsi brick's proven pattern); Zoom DOM selector currency against today's Zoom Web build (selectors unchanged from the live-validated module — layout drift is exactly what the C2 range pins).

## Docs (D6c)
Changelog fragment `docs/changelog.d/538-zoom-speaker-wiring.md` (the docs-current touch). **Finding:** the issue's named docs surface, a "platform capability matrix", does not exist in the tree (`docs/docs/` has no such page; `comparison.mdx:36` is a competitor table) — reported here rather than invented.

## Findings (issue anchor spot-checks)
- Issue era-note corrections all confirmed accurate at head (exposeFunction now `capture-bridge.ts:241`, kind hardcode `pipeline.ts:185`, Jitsi caller at `capture-bridge.ts:293` as the template).
- The capture bricks (gmeet/jitsi/zoom-capture) are **not** bot package deps, so turbo's `^build` does not order them before the bot's bundle build — CI presently relies on incidental ordering; zoom-capture inherits the identical (pre-existing) pattern, not a new risk from this PR.

## Authorship
Full authorship, full responsibility. No co-author trailers.

## Rebased onto #789's merged mechanism (2026-07-18)

Rebased onto `origin/main` (head `bcf78ebe`) after #789 (Teams speaker wiring) merged the shared seam. Adaptation:

**Dropped as duplicate (main now provides it):**
- The per-hint clock/counter plumbing — the zoom branch now forwards through the merged `makeSpeakerHintSink` closure exposed as `__vexaSpeakerHint` (epoch-skew re-stamp + hint-counters telemetry come for free).
- No pipeline change: `hintKindForPlatform` (pipeline.ts) already yields `'dom-active'` for zoom (teams `'dom-outline'`, everything else `'dom-active'`) — this branch's pre-#498 hardcode assumption is now the mechanism's actual behavior.

**Kept (zoom-specific):**
- `capture-bridge.ts` zoom branch: starts `createZoomSpeakers` post-admission, forwards transitions to `__vexaSpeakerHint` (nobody-lit closes the turn with `isEnd`); teardown destroys `__vexaZoomSpeakers`. Coexists with main's `isTeams` branch (`{ isMixed, isJitsi, isTeams, isZoom, botName }`).
- `@vexa/zoom-capture` in the bundle build (`build-browser-utils.mjs`) — additive alongside teams-capture.
- Brick-build filter in **both** hand-maintained lists: `core/meetings/services/bot/Dockerfile` (line 71) AND `deploy/lite/Dockerfile.lite` (line 40) gain `--filter "@vexa/zoom-capture"` (the #789 lesson).
- `zoom-capture.test.ts` fixture range + `zoom-speaker-wiring.test.ts` boundary pin (real bundle + real bridge over a fake Page; hints now travel through the merged `makeSpeakerHintSink`).

**Rerun evidence:**
- `pnpm --filter @vexa/zoom-capture test` — green (range + flicker-confirmation checks).
- `pnpm --filter @vexa/bot test` — full suite green, including main's `speaker-hints.test.ts` + `capture-bridge.boundary.test.ts` and this branch's `zoom-speaker-wiring.test.ts` ("real bundle + real bridge carry Zoom active-speaker transitions page→Node (order, epoch-ms timestamps, isEnd, flicker debounce)").
- `node scripts/gates.mjs all` — ✅ gates green.
