### PR TITLE
fix(msteams): wire speaker name hints to the transcriber — segments carry who spoke (#498)

### DIFF
--- a/core/meetings/modules/mixed-pipeline/package.json
+++ b/core/meetings/modules/mixed-pipeline/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts",
+    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -144,6 +144,12 @@ export interface ChunkedTranscriberCallbacks {
    *  degrades gracefully, but the host gets the fault to make it observable instead of
    *  a silent "no transcript". Receives the thrown value (e.g. a TranscriptionError). */
   onError?: (fault: unknown) => void;
+  /** Instantaneous per-hint outcome (the hint-hop instrument): 'matched' when the
+   *  hint names/claims a turn at the moment it arrives (or re-asserts the open
+   *  turn's already-resolved name); 'missed' when no turn overlaps it yet. A
+   *  'missed' hint is still recorded in the binder and may window-match a later
+   *  commit — this reports the hop's immediate fate, not the final binding. */
+  onHintOutcome?: (o: { name: string; kind: HintKind; tMs: number; outcome: 'matched' | 'missed' }) => void;
 }
 
 interface RingFrame { pcm: Float32Array; tMs: number }
@@ -322,6 +328,13 @@ export class ChunkedTranscriber {
   recordHint(name: string, kind: HintKind, tMs: number, isEnd = false): void {
     this.binder.recordHint({ name, tMs, kind, isEnd });
     if (!name) return;
+    // Hint-hop instrument: did this hint find a turn RIGHT NOW? Emitted once per
+    // start-hint at every exit below (end-hints close windows, they don't bind).
+    let matchedNow = false;
+    const report = (): void => {
+      if (isEnd || !this.cb.onHintOutcome) return;
+      this.cb.onHintOutcome({ name, kind, tMs, outcome: matchedNow ? 'matched' : 'missed' });
+    };
     // Faster attribution of an UNATTRIBUTED open turn: a just-arrived hint may now
     // name it — resolve immediately so its pending repaints under the right speaker
     // instead of showing seg_N until the next tick. STICKY: only while unattributed
@@ -331,7 +344,8 @@ export class ChunkedTranscriber {
     if (this.turn && !this.turn.resolvedName && (this.turn.pendingTail.length > 0 || this.turn.allConfirmed.length > 0)) {
       this.resolveName(this.turn);
     }
-    if (this.unresolved.length === 0) return;
+    if (this.turn?.resolvedName === name) matchedNow = true;   // named (now or already) the open turn
+    if (this.unresolved.length === 0) { report(); return; }
     // Two passes for turns that committed before their hint arrived:
     //  1. window-match — a hint whose lag-shifted window overlaps the turn names it
     //     (re-resolve casts the vote → onClusterRename repaints). Preferred.
@@ -344,11 +358,12 @@ export class ChunkedTranscriber {
     for (const u of this.unresolved) {
       const blocked = u.blockedNames ?? new Set<string>();
       const m = this.binder.matchWindow({ clusterId: u.clusterId, tStartMs: u.t0, tEndMs: u.t1 });
-      if (m && !blocked.has(m.name)) { this.claimTurn(u.clusterId, m.name); continue; }   // window-matched → repaint, drop
-      if (u.t1 >= claimFrom && !blocked.has(name)) this.claimTurn(u.clusterId, name);      // late-box gap → claim for this speaker
+      if (m && !blocked.has(m.name)) { this.claimTurn(u.clusterId, m.name); matchedNow = true; continue; }   // window-matched → repaint, drop
+      if (u.t1 >= claimFrom && !blocked.has(name)) { this.claimTurn(u.clusterId, name); matchedNow = true; } // late-box gap → claim for this speaker
       else still.push(u);
     }
     this.unresolved = still.slice(-MAX_UNRESOLVED);
+    report();
   }
 
   /** Late-box claim: repaint a provisional turn's published segments under `name`

--- a/core/meetings/modules/mixed-pipeline/src/hint-outcome.smoke.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/hint-outcome.smoke.test.ts
@@ -1,0 +1,59 @@
+/**
+ * hint-outcome.smoke — does the onHintOutcome instrument tell the truth?
+ * A hint that names the open turn reports 'matched'; a hint with no overlapping
+ * turn reports 'missed' (and is still recorded for later window matches).
+ * Injected segmenter + stub Whisper. No network, no model.
+ */
+import { ChunkedTranscriber, type BoundarySource } from './index.js';
+import type { BoundaryEvent } from './pyannote-segmenter.js';
+
+let emit!: (ev: BoundaryEvent) => void;
+const outcomes: { name: string; kind: string; outcome: string }[] = [];
+
+async function main() {
+  const tc = await ChunkedTranscriber.create({
+    language: 'en',
+    transcribe: async () => ({
+      text: 'hello world this is a test',
+      language: 'en',
+      language_probability: 0.99,
+      segments: [{ text: 'hello world this is a test', start: 0, end: 2, no_speech_prob: 0.01, avg_logprob: -0.2, compression_ratio: 1.1 } as any],
+    }),
+    publish: () => {}, publishPending: () => {}, clearPending: () => {}, rename: () => {},
+    makeSegmenter: async (onBoundary): Promise<BoundarySource> => {
+      emit = onBoundary;
+      return { appendFrame: async () => {}, reset: () => {} };
+    },
+    onHintOutcome: (o) => outcomes.push({ name: o.name, kind: o.kind, outcome: o.outcome }),
+    log: () => {},
+  });
+
+  // MISSED: a hint before any audio/turn exists — nothing can overlap it.
+  tc.recordHint('Nobody Yet', 'dom-outline', 500);
+
+  // 3s of audio; a turn opens and confirms; Alice's hint lands mid-turn → MATCHED.
+  const frame = new Float32Array(1600).fill(0.05);
+  for (let t = 60000; t < 63000; t += 100) tc.feedAudio(frame, t);
+  emit({ tMs: 60000, kind: 'silence→speaker', confidence: 0.9 });
+  await new Promise(r => setTimeout(r, 50));
+  emit({ tMs: 63000, kind: 'speaker→silence', confidence: 0.9 });
+  await new Promise(r => setTimeout(r, 100));
+  tc.recordHint('Alice', 'dom-outline', 61000);
+
+  // An end-hint emits NO outcome (it closes a window, it doesn't bind).
+  tc.recordHint('Alice', 'dom-outline', 63200, true);
+
+  await tc.dispose();
+
+  console.log(`outcomes = ${JSON.stringify(outcomes)}`);
+  const missedFirst = outcomes[0]?.name === 'Nobody Yet' && outcomes[0]?.outcome === 'missed';
+  const aliceMatched = outcomes.some(o => o.name === 'Alice' && o.outcome === 'matched');
+  const endSilent = outcomes.length === 2;
+  const ok = missedFirst && aliceMatched && endSilent;
+  console.log(ok
+    ? '✅ PASS — matched/missed report the hint hop truthfully; end-hints stay silent'
+    : `❌ FAIL — missedFirst=${missedFirst} aliceMatched=${aliceMatched} endSilent=${endSilent}`);
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((e) => { console.error('❌ FAIL —', e?.message || e); process.exit(1); });

--- a/core/meetings/services/bot/Dockerfile
+++ b/core/meetings/services/bot/Dockerfile
@@ -68,7 +68,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 # runs build-browser-utils.mjs, which esbuild-bundles these bricks' dist into
 # window.VexaBrowserUtils (the global capture-bridge.ts injects via addInitScript) —
 # so their dist/ must already exist when the bot build runs.
-RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" run build
+RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" run build
 
 # Build @vexa/bot and everything it depends on (the `...` selector pulls the deps;
 # pnpm runs them in topological order, each package's own `build` = tsc → dist/).

--- a/core/meetings/services/bot/build-browser-utils.mjs
+++ b/core/meetings/services/bot/build-browser-utils.mjs
@@ -53,6 +53,7 @@ const GMEET = moduleEntry('gmeet-capture');       // @vexa/gmeet-capture
 const MIXED = moduleEntry('mixed-capture-core');  // @vexa/mixed-capture-core
 const RECORD = moduleEntry('record-chunker');     // @vexa/record-chunker (MediaRecorder → recording.v1)
 const JITSI = moduleEntry('jitsi-capture');       // @vexa/jitsi-capture (dominant-speaker hints + chat)
+const TEAMS = moduleEntry('teams-capture');       // @vexa/teams-capture (voice-level-outline speaker hints)
 
 // In-memory entry: import the bricks and hang them on window.VexaBrowserUtils with
 // the EXACT names capture-bridge.ts reaches for. esbuild bundles the relative
@@ -78,6 +79,9 @@ import {
   createJitsiChat,
   sendJitsiChatMessage,
 } from ${JSON.stringify(JITSI)};
+import {
+  createTeamsSpeakers,
+} from ${JSON.stringify(TEAMS)};
 
 const VexaBrowserUtils = {
   // ── gmeet lane (per-participant capture + glow attribution) ──
@@ -96,6 +100,8 @@ const VexaBrowserUtils = {
   createJitsiSpeakers,       // capture-bridge.ts: w.VexaBrowserUtils.createJitsiSpeakers
   createJitsiChat,           // capture-bridge.ts: w.VexaBrowserUtils.createJitsiChat
   sendJitsiChatMessage,
+  // ── teams lane (voice-level "blue-square" outline → speaker hints) ──
+  createTeamsSpeakers,       // capture-bridge.ts: w.VexaBrowserUtils.createTeamsSpeakers
 };
 
 (globalThis).VexaBrowserUtils = VexaBrowserUtils;
@@ -141,4 +147,5 @@ console.log('  - createGmeetCapture / createGmeetSpeakers / createGmeetCaptureV1
 console.log('  - GmeetChannelBinder / createPcmCaptureNode');
 console.log('  - createMixedAudioCapture / installRemoteAudioHook');
 console.log('  - createJitsiSpeakers / createJitsiChat / sendJitsiChatMessage');
+console.log('  - createTeamsSpeakers');
 console.log('  - window.performLeaveAction');

--- a/core/meetings/services/bot/package.json
+++ b/core/meetings/services/bot/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && node build-browser-utils.mjs",
     "build:browser-utils": "node build-browser-utils.mjs",
     "start": "tsx src/index.ts",
-    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/replay.test.ts && tsx mock/mock.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/replay.test.ts && tsx mock/mock.test.ts",
     "replay": "tsx src/replay.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },

--- a/core/meetings/services/bot/src/capture-bridge.boundary.test.ts
+++ b/core/meetings/services/bot/src/capture-bridge.boundary.test.ts
@@ -1,0 +1,128 @@
+/**
+ * L3 boundary — Teams speaker hints cross the page→Node boundary (#498 C4).
+ *
+ * Launches the REAL bridge wiring end-to-end, no meeting and no display:
+ *   1. asserts the built browser bundle (dist/browser-utils.global.js) exposes
+ *      createTeamsSpeakers (the regression that shipped seg_N: the brick missing
+ *      from the bundle);
+ *   2. headless Chromium (the same launchPersistentBrowser the bot uses) loads a
+ *      static fixture page with a Teams-shaped DOM — a participant tile carrying
+ *      the voice-level-stream-outline signal — plus a 1:1-layout tile WITHOUT the
+ *      outline (the #481 two-party class: no signal ⇒ no hint, never a wrong one);
+ *   3. startCaptureBridge (the real function) wires the page; the fixture toggles
+ *      the vdi-frame-occlusion speaking signal; the test asserts the hints arrive
+ *      Node-side with the participant's NAME, epoch tMs, and start/end order.
+ *
+ * Where headless Chromium cannot launch (no playwright browser in the env) the test
+ * SKIPS LOUDLY with exit 0 — the same green-or-skip shape as gate:stack.
+ * Run: npx tsx src/capture-bridge.boundary.test.ts
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { launchPersistentBrowser, type BrowserContext } from '@vexa/remote-browser';
+import { startCaptureBridge } from './capture-bridge.js';
+import type { BotPipeline, HintCounters } from './pipeline.js';
+import type { Invocation } from './config.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BOT_DIR = join(HERE, '..');
+const BUNDLE = join(BOT_DIR, 'dist', 'browser-utils.global.js');
+
+let failed = 0;
+const check = (name: string, cond: boolean, detail = '') => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond ? '' : '  — ' + detail}`);
+  if (!cond) failed++;
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const FIXTURE = `<!doctype html><html><body>
+  <div data-tid="participant-tile" id="alice-tile">
+    <span title="Alice Fixture">Alice Fixture</span>
+    <div data-tid="voice-level-stream-outline" id="alice-outline"></div>
+  </div>
+  <!-- #481 two-party (1:1) layout class: the outline indicator never renders.
+       The watcher must emit NO hint for this tile (no signal ⇒ silence, not a guess). -->
+  <div data-tid="participant-tile" id="bob-tile">
+    <span title="Bob OneToOne">Bob OneToOne</span>
+  </div>
+</body></html>`;
+
+async function main(): Promise<void> {
+  // ── 1) the bundle carries the Teams brick (the shipped regression) ──
+  if (!existsSync(BUNDLE)) execSync('node build-browser-utils.mjs', { cwd: BOT_DIR, stdio: 'inherit' });
+  const bundleHasTeams = execSync(`grep -c createTeamsSpeakers ${JSON.stringify(BUNDLE)} || true`).toString().trim() !== '0';
+  check('browser bundle exposes createTeamsSpeakers', bundleHasTeams);
+
+  // ── 2) headless browser (green-or-skip where chromium is absent) ──
+  const dataDir = mkdtempSync(join(tmpdir(), 'vexa-boundary-'));
+  let context: BrowserContext;
+  let page;
+  try {
+    ({ context, page } = await launchPersistentBrowser({ dataDir, args: ['--no-sandbox', '--mute-audio'], headless: true }));
+  } catch (e) {
+    console.log(`  ⚠️ SKIP — headless Chromium unavailable in this environment: ${(e as Error).message?.split('\n')[0]}`);
+    process.exit(0);
+  }
+  try {
+    await context.addInitScript({ path: BUNDLE });
+    const pageLogs: string[] = [];
+    await context.exposeFunction('logBot', (m: string) => pageLogs.push(String(m)));
+
+    // The REAL bridge over a stub pipeline capturing what crosses the boundary.
+    const hints: { name: string; tMs: number; isEnd?: boolean }[] = [];
+    const hintCounters: HintCounters = { received: 0, matched: 0, missed: 0 };
+    const pipeline: BotPipeline = {
+      async start() { /* stub */ }, async stop() { /* stub */ },
+      feedAudio() { /* stub */ }, feedMixedAudio() { /* stub */ },
+      recordHint(name, tMs, isEnd) { hintCounters.received++; hints.push({ name, tMs, isEnd }); },
+      hintCounters,
+    };
+    const inv: Invocation = {
+      platform: 'teams', meetingUrl: 'https://teams.fixture.test/m', botName: 'Vexa',
+      redisUrl: 'redis://localhost:6379', transcribeEnabled: false,
+    };
+    await page.setContent(FIXTURE);
+    // setContent does not re-run context init scripts in this launch shape, so load the
+    // SAME prebuilt bundle into the fixture document directly (identical bytes to what
+    // addInitScript injects on a real navigation).
+    await page.addScriptTag({ path: BUNDLE });
+    // tsx transpiles this test with esbuild keepNames, whose `__name` helper leaks into
+    // page.evaluate-serialized functions; shim it page-side so the REAL bridge code
+    // (which ships helper-free via tsc) runs unmodified under the test runner.
+    await page.evaluate('globalThis.__name = globalThis.__name || ((t, v) => t);');
+    const stop = await startCaptureBridge(page, inv, pipeline);
+
+    // Fixture drives the speaking signal: occlusion class ON (start) → OFF (end).
+    await sleep(600);   // observer attach + initial silent state past the 200ms hysteresis
+    await page.evaluate(`document.getElementById('alice-outline').classList.add('vdi-frame-occlusion')`);
+    await sleep(900);   // 200ms hysteresis + 300ms debounce + margin
+    await page.evaluate(`document.getElementById('alice-outline').classList.remove('vdi-frame-occlusion')`);
+    await sleep(900);
+    await stop();
+
+    // ── 3) the assertions: hints crossed with name, epoch clock, order ──
+    check('page-side watcher started (hop 1 visible in page logs)', pageLogs.some((l) => l.includes('[TeamsSpeakers]')), JSON.stringify(pageLogs.slice(0, 3)));
+    const alice = hints.filter((h) => h.name === 'Alice Fixture');
+    check('speaker hints crossed the boundary for the outlined tile', alice.length >= 2, JSON.stringify(hints));
+    // The watcher reports the tile's initial silent state first (an END-shaped hint),
+    // then the scripted transitions: START on occlusion, END on its removal — in order.
+    const firstStart = alice.findIndex((h) => h.isEnd === false);
+    check('a START hint (isEnd=false) crossed for the speaking transition', firstStart >= 0, JSON.stringify(alice));
+    check('an END hint follows the START (transition order intact)', firstStart >= 0 && alice.slice(firstStart + 1).some((h) => h.isEnd === true), JSON.stringify(alice));
+    check('hint tMs is epoch ms (same clock domain as audio)', alice.every((h) => Math.abs(h.tMs - Date.now()) < 60_000), JSON.stringify(alice.map((h) => h.tMs)));
+    check('bot self-name and the signal-less 1:1 tile emit NO hints',
+      !hints.some((h) => h.name.includes('Vexa') || h.name === 'Bob OneToOne'), JSON.stringify(hints));
+    check('pipeline-received counter moved with the arrivals', hintCounters.received === hints.length && hintCounters.received > 0, JSON.stringify(hintCounters));
+  } finally {
+    await context.close().catch(() => { /* best-effort */ });
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+
+  console.log(failed === 0 ? '\n✅ capture-bridge boundary: all green' : `\n❌ capture-bridge boundary: ${failed} failure(s)`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error('❌ FAIL —', e?.stack || e); process.exit(1); });

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -72,6 +72,38 @@ export function makeTelemetryTap(lane: 'gmeet' | 'mixed', telemetry?: TelemetryS
   };
 }
 
+/**
+ * Build the mixed-lane speaker-hint sink — the EXACT closure the bridge exposes as
+ * `__vexaSpeakerHint`, factored out so it is offline-provable WITHOUT a Playwright page.
+ *
+ * CLOCK CONTRACT: hint tMs and audio tsMs entering the pipeline share ONE domain —
+ * epoch ms. The page-side watchers stamp Date.now() (epoch), so normally the value
+ * passes through untouched; a page that emits a non-epoch time (e.g. a relative
+ * performance.now()) would make every hint window miss every speech turn, so an
+ * implausible skew is re-stamped Node-side and warned LOUDLY, never silently bound
+ * to nothing. Also counts arrivals (C1 hop 2: page → Node).
+ */
+export const HINT_MAX_SKEW_MS = 10 * 60 * 1000;
+export function makeSpeakerHintSink(
+  pipeline: Pick<BotPipeline, 'recordHint'>,
+  warn: (m: string) => void = (m) => console.warn(m),
+): { sink: (name: string, tMs?: number, isEnd?: boolean) => void; crossed: () => number } {
+  let crossed = 0;
+  return {
+    crossed: () => crossed,
+    sink: (name: string, tMs?: number, isEnd?: boolean): void => {
+      crossed++;
+      let t = tMs ?? Date.now();
+      const skew = Math.abs(t - Date.now());
+      if (skew > HINT_MAX_SKEW_MS) {
+        warn(`[bot] hint-clock-skew: hint tMs=${t} is ${Math.round(skew / 1000)}s off the epoch audio clock — page emitted a non-epoch timestamp; re-stamping (name=${name})`);
+        t = Date.now();
+      }
+      pipeline.recordHint(name, t, isEnd);
+    },
+  };
+}
+
 /** Path (in the bot container image) to the prebuilt page-side capture bundle that defines
  *  window.VexaBrowserUtils (createGmeetCapture / createGmeetSpeakers / mixed taps). Mirrors
  *  production's browser-utils.global.js; injected via addInitScript so it is present on every
@@ -230,9 +262,16 @@ export async function startCaptureBridge(
     pipeline.feedAudio(channel, glowName, pcm, ts);
   };
   // mixed lane "who is lit" hint (Zoom/Teams active-speaker → the namer's time window).
-  const onSpeakerHint = (name: string, tMs?: number, isEnd?: boolean): void => {
-    pipeline.recordHint(name, tMs ?? Date.now(), isEnd);
-  };
+  // Epoch-clock-guarded + counted; see makeSpeakerHintSink for the clock contract.
+  const { sink: onSpeakerHint, crossed: hintsBridgeCrossed } = makeSpeakerHintSink(pipeline);
+  // C1: the four hint hops on one periodic, cumulative counter line —
+  // page-emitted lives in the page console ([TeamsSpeakers]/[JitsiSpeakers] logs);
+  // bridge-crossed / pipeline-received / binder matched|missed are Node-side.
+  const countersTimer = mixed ? setInterval(() => {
+    const c = pipeline.hintCounters;
+    console.log(`[bot] hint-counters bridge-crossed=${hintsBridgeCrossed()} pipeline-received=${c?.received ?? 0} binder-matched=${c?.matched ?? 0} binder-missed=${c?.missed ?? 0}`);
+  }, 30_000) : null;
+  countersTimer?.unref?.();   // observability only — never holds the process open
 
   await page.exposeFunction('__vexaPerSpeakerAudioData', onPerSpeakerAudio).catch((e: Error) => {
     if (!String(e.message).includes('already registered')) throw e;
@@ -247,7 +286,7 @@ export async function startCaptureBridge(
   // ── Start the page-side capture (VexaBrowserUtils preferred; production inline fallback). ──
   // The body of this callback runs IN THE BROWSER (Playwright serializes it); DOM globals are
   // reached via globalThis (this file type-checks against the Node lib — no DOM types here).
-  await page.evaluate(async ({ isMixed, isJitsi, botName }) => {
+  await page.evaluate(async ({ isMixed, isJitsi, isTeams, botName }) => {
     const w = (globalThis as any) as Record<string, any>;
     if (isMixed) {
       // Zoom/Teams: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
@@ -281,6 +320,21 @@ export async function startCaptureBridge(
       };
       setupMix();
       w.__vexaMixRescan = (globalThis as any).setInterval(setupMix, 2000); // pick up late-arriving tracks
+      if (isTeams) {
+        // Teams contributes the WHO signal the mixed audio can't carry: the voice-level
+        // "blue-square" outline watcher (@vexa/teams-capture — the SAME module the desktop
+        // extension runs) emits debounced speaking start/stop per participant; each crosses
+        // to the Node side as a speaker hint (epoch tMs) and the pipeline stamps the
+        // platform's 'dom-outline' kind at its wiring seam.
+        if (w.VexaBrowserUtils?.createTeamsSpeakers && !w.__vexaTeamsSpeakers) {
+          w.__vexaTeamsSpeakers = w.VexaBrowserUtils.createTeamsSpeakers({
+            selfName: botName,
+            log: (m: string) => w.logBot?.('[TeamsSpeakers] ' + m),
+            onSpeaking: (name: string, _id: string, isEnd: boolean, tMs: number) =>
+              w.__vexaSpeakerHint?.(name, tMs, isEnd),
+          });
+        }
+      }
       if (isJitsi) {
         // Jitsi contributes the WHO + chat signals the mixed audio can't carry:
         // dominant-speaker changes name the pyannote clusters ('dom-active' hints),
@@ -319,15 +373,17 @@ export async function startCaptureBridge(
       });
       await w.__vexaGmeetCapture.start();
     }
-  }, { isMixed: mixed, isJitsi: jitsi, botName: inv.botName }).catch((e) => {
+  }, { isMixed: mixed, isJitsi: jitsi, isTeams: inv.platform === 'teams', botName: inv.botName }).catch((e) => {
     console.error(`[bot] capture bridge: page-side start failed: ${String(e)}`); // L4: surfaces only on the VM
   });
 
   // Stop fn: tear the page-side capture down on teardown (best-effort; the page may be closing).
   return async () => {
+    if (countersTimer) clearInterval(countersTimer);
     await page.evaluate(() => {
       const w = (globalThis as any) as Record<string, any>;
       try { w.__vexaGmeetCapture?.stop?.(); } catch { /* best-effort */ }
+      try { w.__vexaTeamsSpeakers?.destroy?.(); w.__vexaTeamsSpeakers = null; } catch { /* best-effort */ }
       try { w.__vexaJitsiSpeakers?.destroy?.(); w.__vexaJitsiSpeakers = null; } catch { /* best-effort */ }
       try { w.__vexaJitsiChat?.destroy?.(); w.__vexaJitsiChat = null; } catch { /* best-effort */ }
       try { if (w.__vexaMixRescan) { (globalThis as any).clearInterval(w.__vexaMixRescan); w.__vexaMixRescan = null; } } catch { /* */ }

--- a/core/meetings/services/bot/src/pipeline.ts
+++ b/core/meetings/services/bot/src/pipeline.ts
@@ -27,15 +27,41 @@ import {
 import {
   ChunkedTranscriber,
   type ChunkSegment,
+  type ChunkedTranscriberCallbacks,
+  type HintKind,
 } from '@vexa/mixed-pipeline';
 import { TranscriptionClient, type TranscriptionResult } from '@vexa/transcribe-whisper';
-import { isMixedLanePlatform, type Invocation } from './config.js';
+import { isMixedLanePlatform, type Invocation, type Platform } from './config.js';
 import type { TranscriptSegment } from './contracts.js';
 import type { Pipeline, TranscriptSink } from './ports.js';
 
 /** stt.v1 round-trip — real adapter = TranscriptionClient.transcribe; L2/L3 = a mock. The
  *  lane bakes language/prompt at the call site, so the closure carries the configured language. */
 export type Transcribe = (pcm: Float32Array, prompt?: string) => Promise<TranscriptionResult>;
+
+/** Each platform's TRUE hint kind — the binder's lag correction is per-kind
+ *  (cluster-name-binder KIND_LAG_MS), so the label must survive the bot's wiring:
+ *  Teams' voice-level outline is 'dom-outline'; Zoom's active-speaker DOM poll and
+ *  jitsi's dominant-speaker signal ride 'dom-active'. Bound once at wiring time —
+ *  the page-side watcher and the transcriber never renegotiate it. */
+export function hintKindForPlatform(platform: Platform | string): HintKind {
+  return platform === 'teams' ? 'dom-outline' : 'dom-active';
+}
+
+/** Cumulative hint-hop counters (the C1 instrument): how many hints crossed into the
+ *  pipeline, and their instantaneous binder outcome. Printed on the bridge's periodic
+ *  counter line so a name lost between the page and the transcript names its hop. */
+export interface HintCounters {
+  received: number;
+  matched: number;
+  missed: number;
+}
+
+/** The mixed-lane transcriber seam — the REAL ChunkedTranscriber in production,
+ *  injectable so an offline test observes exactly what reaches the transcriber
+ *  (name, KIND, tMs) without the pyannote model load. */
+export type MixedTranscriber = Pick<ChunkedTranscriber, 'feedAudio' | 'recordHint' | 'dispose'>;
+export type MixedTranscriberFactory = (cb: ChunkedTranscriberCallbacks) => Promise<MixedTranscriber>;
 
 /** The Pipeline port extended with the capture entry the bridge pumps frames into. The
  *  orchestrator only sees start/stop; the capture bridge holds the BotPipeline to feedAudio. */
@@ -44,8 +70,13 @@ export interface BotPipeline extends Pipeline {
   feedAudio(channel: number, glowName: string | undefined, pcm: Float32Array, tsMs: number): void;
   /** One mixed (Zoom/Teams) capture.v1 frame: a single mixed PCM stream, named downstream. */
   feedMixedAudio(pcm: Float32Array, tsMs: number): void;
-  /** A mixed-lane "who is lit" hint (Zoom/Teams active-speaker), windowed by the namer. */
+  /** A mixed-lane "who is lit" hint (platform active-speaker), windowed by the namer.
+   *  CLOCK CONTRACT: tMs MUST be epoch ms — the same domain as feedMixedAudio's tsMs —
+   *  or no hint window can ever overlap a speech turn (the bridge guards this). The
+   *  platform's hint KIND is bound at wiring time (hintKindForPlatform), not per call. */
   recordHint(name: string, tMs: number, isEnd?: boolean): void;
+  /** Mixed lane only: the cumulative hint-hop counters (undefined on the gmeet lane). */
+  readonly hintCounters?: HintCounters;
 }
 
 /** The lane segments are the SEALED transcript.v1 view — structurally identical to the bot's
@@ -141,11 +172,14 @@ function createGmeetBotPipeline(
 function createMixedBotPipeline(
   transcribe: Transcribe,
   sink: TranscriptSink,
+  hintKind: HintKind,
   language?: string,
   onError?: (e: unknown) => void,
+  createTranscriber: MixedTranscriberFactory = (cb) => ChunkedTranscriber.create(cb),
 ): BotPipeline {
-  let transcriber: ChunkedTranscriber | null = null;
-  let creating: Promise<ChunkedTranscriber> | null = null;
+  let transcriber: MixedTranscriber | null = null;
+  let creating: Promise<MixedTranscriber> | null = null;
+  const hintCounters: HintCounters = { received: 0, matched: 0, missed: 0 };
 
   const publish = (speaker: string, segs: ChunkSegment[], completed: boolean): void => {
     for (const c of segs) {
@@ -155,10 +189,10 @@ function createMixedBotPipeline(
     }
   };
 
-  const ensure = (): Promise<ChunkedTranscriber> => {
+  const ensure = (): Promise<MixedTranscriber> => {
     if (transcriber) return Promise.resolve(transcriber);
     if (!creating) {
-      creating = ChunkedTranscriber.create({
+      creating = createTranscriber({
         transcribe,
         // ONE atomic bundle: newly-confirmed (persisted) + the surviving pending tail.
         publish: (speaker, confirmed, pending) => { publish(speaker, confirmed, true); publish(speaker, pending, false); },
@@ -167,6 +201,9 @@ function createMixedBotPipeline(
         rename: (_oldSpeaker, newSpeaker, segments) => publish(newSpeaker, segments, true),
         language,
         onError,
+        // C1 hop 4: the binder's instantaneous verdict per hint — a hint with no
+        // overlapping turn increments `missed` (loudly, on the periodic counter line).
+        onHintOutcome: (o) => { if (o.outcome === 'matched') hintCounters.matched++; else hintCounters.missed++; },
       }).then((t) => { transcriber = t; return t; })
         // #593: DON'T cache a rejected create promise. The mixed lane's create() loads the pyannote
         // model (from_pretrained) — if that rejects (empty HF cache, no egress), leaving `creating`
@@ -182,7 +219,9 @@ function createMixedBotPipeline(
     async stop() { if (transcriber) await transcriber.dispose(); },
     feedAudio() { /* not the mixed lane (mixed has no per-channel glow) */ },
     feedMixedAudio: (pcm, tsMs) => { transcriber?.feedAudio(pcm, tsMs); },
-    recordHint: (name, tMs, isEnd) => { transcriber?.recordHint(name, 'dom-active', tMs, isEnd); },
+    // C1 hop 3 + C2: count the arrival, forward under the platform's TRUE kind.
+    recordHint: (name, tMs, isEnd) => { hintCounters.received++; transcriber?.recordHint(name, hintKind, tMs, isEnd); },
+    hintCounters,
   };
 }
 
@@ -209,11 +248,21 @@ export function createTranscribe(inv: Invocation): Transcribe {
 export function createBotPipeline(
   inv: Invocation,
   sink: TranscriptSink,
-  opts: { transcribe?: Transcribe; config?: SpeakerStreamManagerConfig; onError?: (e: unknown) => void } = {},
+  opts: {
+    transcribe?: Transcribe;
+    config?: SpeakerStreamManagerConfig;
+    onError?: (e: unknown) => void;
+    /** Mixed-lane transcriber seam — the real ChunkedTranscriber unless a test injects
+     *  an observer (pins what actually reaches the transcriber: name, kind, tMs). */
+    createMixedTranscriber?: MixedTranscriberFactory;
+  } = {},
 ): BotPipeline {
   const transcribe = opts.transcribe ?? createTranscribe(inv);
   if (isMixedLanePlatform(inv.platform)) {
-    return createMixedBotPipeline(transcribe, sink, inv.language ?? undefined, opts.onError);
+    return createMixedBotPipeline(
+      transcribe, sink, hintKindForPlatform(inv.platform),
+      inv.language ?? undefined, opts.onError, opts.createMixedTranscriber,
+    );
   }
   return createGmeetBotPipeline(transcribe, sink, opts.config, opts.onError);
 }

--- a/core/meetings/services/bot/src/speaker-hints.test.ts
+++ b/core/meetings/services/bot/src/speaker-hints.test.ts
@@ -1,0 +1,191 @@
+/**
+ * L2/L3 — the mixed-lane speaker-hint wiring, OFFLINE (no browser, no pyannote, no whisper).
+ *
+ * Pins the seams #498 names:
+ *   • C2 kind fidelity: the platform's TRUE hint kind reaches the transcriber —
+ *     'dom-outline' for Teams, 'dom-active' for Zoom AND jitsi (observed via an
+ *     injected MixedTranscriberFactory at the exact recordHint seam);
+ *   • C1 counters: received advances per hint; matched/missed advance on the
+ *     transcriber's onHintOutcome; a hint with no overlapping turn counts missed;
+ *   • C3 clock guard: an implausibly-skewed (non-epoch) hint tMs is re-stamped to
+ *     epoch with a LOUD warning — never silently bound to nothing; epoch times and
+ *     the undefined-tMs fallback pass through;
+ *   • C5 host parity: one scripted timeline (audio + boundaries + hints) through the
+ *     desktop-style wiring (ChunkedTranscriber + 'dom-outline' directly — the
+ *     extension's shape, clients/extension/src/inpage.ts) and through the bot's
+ *     teams lane produces identical named segments.
+ * Run: npx tsx src/speaker-hints.test.ts
+ */
+import { ChunkedTranscriber, type BoundarySource, type ChunkSegment } from '@vexa/mixed-pipeline';
+import type { BoundaryEvent } from '@vexa/mixed-pipeline';
+import { createBotPipeline, hintKindForPlatform, type BotPipeline } from './pipeline.js';
+import { makeSpeakerHintSink } from './capture-bridge.js';
+import type { Invocation } from './config.js';
+import type { TranscriptSink } from './ports.js';
+import type { TranscriptSegment } from './contracts.js';
+
+let failed = 0;
+const check = (name: string, cond: boolean, detail = '') => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond ? '' : '  — ' + detail}`);
+  if (!cond) failed++;
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const inv = (platform: Invocation['platform']): Invocation => ({
+  platform, meetingUrl: 'https://example.test/m', botName: 'Vexa',
+  redisUrl: 'redis://localhost:6379', transcribeEnabled: false,
+});
+const nullSink: TranscriptSink = { async publish() { /* discard */ } };
+
+/** A spy transcriber factory — records exactly what the bot forwards. */
+function spyFactory() {
+  const hints: { name: string; kind: string; tMs: number; isEnd?: boolean }[] = [];
+  let cb: Parameters<NonNullable<Parameters<typeof createBotPipeline>[2]['createMixedTranscriber']>>[0] | null = null;
+  const factory = async (c: typeof cb & object) => {
+    cb = c;
+    return {
+      feedAudio() { /* not under test */ },
+      recordHint(name: string, kind: string, tMs: number, isEnd = false) { hints.push({ name, kind, tMs, isEnd }); },
+      async dispose() { /* nothing */ },
+    };
+  };
+  return { hints, factory: factory as NonNullable<Parameters<typeof createBotPipeline>[2]['createMixedTranscriber']>, getCb: () => cb };
+}
+
+async function main(): Promise<void> {
+  // ── C2: kind fidelity per platform at the transcriber seam ──
+  console.log('C2 — platform hint kind reaches the transcriber');
+  check("hintKindForPlatform('teams') == 'dom-outline'", hintKindForPlatform('teams') === 'dom-outline');
+  check("hintKindForPlatform('zoom') == 'dom-active'", hintKindForPlatform('zoom') === 'dom-active');
+  check("hintKindForPlatform('jitsi') == 'dom-active' (jitsi lane preserved)", hintKindForPlatform('jitsi') === 'dom-active');
+  for (const [platform, kind] of [['teams', 'dom-outline'], ['zoom', 'dom-active'], ['jitsi', 'dom-active']] as const) {
+    const spy = spyFactory();
+    const pipe = createBotPipeline(inv(platform), nullSink, { createMixedTranscriber: spy.factory });
+    await pipe.start();
+    pipe.recordHint('Alice', 1234567890123);
+    pipe.recordHint('Alice', 1234567891123, true);
+    await pipe.stop();
+    check(`${platform}: recordHint forwards kind='${kind}' with name+tMs+isEnd intact`,
+      spy.hints.length === 2 && spy.hints.every((h) => h.kind === kind)
+      && spy.hints[0].name === 'Alice' && spy.hints[0].tMs === 1234567890123 && spy.hints[0].isEnd === false
+      && spy.hints[1].isEnd === true,
+      JSON.stringify(spy.hints));
+  }
+
+  // ── C1: counters — received per hint; matched/missed via onHintOutcome ──
+  console.log('C1 — hint-hop counters');
+  {
+    const spy = spyFactory();
+    const pipe = createBotPipeline(inv('teams'), nullSink, { createMixedTranscriber: spy.factory });
+    await pipe.start();
+    pipe.recordHint('Alice', Date.now());
+    pipe.recordHint('Bob', Date.now());
+    check('received advances per pipeline-received hint', pipe.hintCounters?.received === 2, JSON.stringify(pipe.hintCounters));
+    const cb = spy.getCb()!;
+    cb.onHintOutcome?.({ name: 'Alice', kind: 'dom-outline', tMs: Date.now(), outcome: 'matched' });
+    cb.onHintOutcome?.({ name: 'Ghost', kind: 'dom-outline', tMs: Date.now(), outcome: 'missed' });
+    check('binder outcomes advance matched/missed', pipe.hintCounters?.matched === 1 && pipe.hintCounters?.missed === 1, JSON.stringify(pipe.hintCounters));
+    await pipe.stop();
+  }
+  {
+    // End-to-end missed: the REAL transcriber (injected segmenter, no model) — a hint
+    // with no overlapping turn increments `missed`, loudly countable.
+    const pipe = createBotPipeline(inv('teams'), nullSink, {
+      createMixedTranscriber: (cb) => ChunkedTranscriber.create({
+        ...cb,
+        makeSegmenter: async (): Promise<BoundarySource> => ({ appendFrame: async () => { /* scripted */ }, reset: () => { /* scripted */ } }),
+        log: () => { /* quiet */ },
+      }),
+    });
+    await pipe.start();
+    pipe.recordHint('Nobody Yet', Date.now());
+    check('real transcriber: hint with no overlapping turn → missed', pipe.hintCounters?.missed === 1 && pipe.hintCounters?.received === 1, JSON.stringify(pipe.hintCounters));
+    await pipe.stop();
+  }
+
+  // ── C3: the epoch clock guard at the bridge seam ──
+  console.log('C3 — hint/audio clock contract (epoch ms)');
+  {
+    const got: { name: string; tMs: number; isEnd?: boolean }[] = [];
+    const warns: string[] = [];
+    const target: Pick<BotPipeline, 'recordHint'> = { recordHint: (name, tMs, isEnd) => got.push({ name, tMs, isEnd }) };
+    const { sink, crossed } = makeSpeakerHintSink(target, (m) => warns.push(m));
+    const epoch = Date.now();
+    sink('Alice', epoch);                       // same clock domain — passes through untouched
+    sink('Bob', 12345);                         // performance.now()-shaped — implausible skew
+    sink('Carol', undefined, true);             // no page stamp — Node epoch fallback
+    check('bridge-crossed counter counts every arrival', crossed() === 3, String(crossed()));
+    check('epoch tMs passes through unchanged', got[0]?.tMs === epoch, String(got[0]?.tMs));
+    check('non-epoch tMs re-stamped to epoch (never silently binds nothing)',
+      got[1] !== undefined && Math.abs(got[1].tMs - Date.now()) < 5000, String(got[1]?.tMs));
+    check('the skew warns LOUDLY, typed', warns.length === 1 && /hint-clock-skew/.test(warns[0] ?? ''), JSON.stringify(warns));
+    check('undefined tMs falls back to Node epoch', got[2] !== undefined && Math.abs(got[2].tMs - Date.now()) < 5000 && got[2].isEnd === true, JSON.stringify(got[2]));
+  }
+
+  // ── C5: host parity — one timeline, desktop wiring vs bot wiring, identical output ──
+  console.log('C5 — desktop-vs-bot differential (same fixture, diffed segments)');
+  {
+    const stubTranscribe = async () => ({
+      text: 'hello from the fixture', language: 'en', duration: 2,
+      segments: [{ start: 0, end: 2, text: 'hello from the fixture' }],
+    });
+    interface Host { published: { speaker: string; text: string; completed: boolean }[]; feed(pcm: Float32Array, t: number): void; hint(name: string, t: number, isEnd?: boolean): void; boundary(ev: BoundaryEvent): void; stop(): Promise<void> }
+
+    // Desktop-style host: ChunkedTranscriber wired the way the extension wires it
+    // (direct recordHint with the platform kind — inpage.ts posts kind 'dom-outline').
+    const makeDesktopHost = async (): Promise<Host> => {
+      let emit!: (ev: BoundaryEvent) => void;
+      const published: Host['published'] = [];
+      const push = (speaker: string, segs: ChunkSegment[], completed: boolean) => { for (const s of segs) published.push({ speaker, text: s.text, completed }); };
+      const tc = await ChunkedTranscriber.create({
+        language: 'en', transcribe: stubTranscribe,
+        publish: (sp, confirmed, pending) => { push(sp, confirmed, true); push(sp, pending, false); },
+        publishPending: (sp, segs) => push(sp, segs, false),
+        clearPending: () => { /* fixture */ }, rename: (_o, n, segs) => push(n, segs, true),
+        makeSegmenter: async (onB): Promise<BoundarySource> => { emit = onB; return { appendFrame: async () => { /* scripted */ }, reset: () => { /* scripted */ } }; },
+        log: () => { /* quiet */ },
+      });
+      return { published, feed: (p, t) => tc.feedAudio(p, t), hint: (n, t, e) => tc.recordHint(n, 'dom-outline', t, e), boundary: (ev) => emit(ev), stop: () => tc.dispose() };
+    };
+
+    // Bot host: the REAL bot teams lane (createBotPipeline) with only the segmenter scripted.
+    const makeBotHost = async (): Promise<Host> => {
+      let emit!: (ev: BoundaryEvent) => void;
+      const published: Host['published'] = [];
+      const sink: TranscriptSink = { async publish(seg: TranscriptSegment) { published.push({ speaker: seg.speaker, text: seg.text, completed: !!seg.completed }); } };
+      const pipe = createBotPipeline(inv('teams'), sink, {
+        transcribe: stubTranscribe,
+        createMixedTranscriber: (cb) => ChunkedTranscriber.create({
+          ...cb, transcribe: stubTranscribe,
+          makeSegmenter: async (onB): Promise<BoundarySource> => { emit = onB; return { appendFrame: async () => { /* scripted */ }, reset: () => { /* scripted */ } }; },
+          log: () => { /* quiet */ },
+        }),
+      });
+      await pipe.start();
+      return { published, feed: (p, t) => pipe.feedMixedAudio(p, t), hint: (n, t, e) => pipe.recordHint(n, t, e), boundary: (ev) => emit(ev), stop: () => pipe.stop() };
+    };
+
+    // ONE scripted timeline through both hosts.
+    const drive = async (host: Host): Promise<string> => {
+      const frame = new Float32Array(1600).fill(0.05);   // 100ms @16k, above DROP_RMS
+      for (let t = 10000; t < 13000; t += 100) host.feed(frame, t);
+      host.boundary({ tMs: 10000, kind: 'silence→speaker', confidence: 0.9 });
+      await sleep(50);
+      host.hint('Alice Fixture', 11000);
+      host.boundary({ tMs: 13000, kind: 'speaker→silence', confidence: 0.9 });
+      await sleep(150);
+      await host.stop();
+      const confirmed = host.published.filter((p) => p.completed).map((p) => `${p.speaker}|${p.text}`).sort();
+      return JSON.stringify(confirmed);
+    };
+    const desktopOut = await drive(await makeDesktopHost());
+    const botOut = await drive(await makeBotHost());
+    check('desktop and bot wiring publish IDENTICAL named segments', desktopOut === botOut && desktopOut.includes('Alice Fixture'),
+      `desktop=${desktopOut} bot=${botOut}`);
+  }
+
+  console.log(failed === 0 ? '\n✅ speaker-hints: all green' : `\n❌ speaker-hints: ${failed} failure(s)`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error('❌ FAIL —', e?.stack || e); process.exit(1); });

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -37,7 +37,7 @@ COPY scripts ./scripts
 RUN --mount=type=cache,id=pnpm-store-lite,target=/pnpm/store \
     pnpm install --frozen-lockfile=false
 # Build the page-side capture bricks first (browser bundles, not bot deps), then @vexa/bot + deps.
-RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" run build
+RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" run build
 RUN pnpm --filter "@vexa/bot..." run build
 RUN test -f /build/core/meetings/services/bot/dist/index.js \
  && test -s /build/core/meetings/services/bot/dist/browser-utils.global.js

--- a/docs/changelog.d/498-teams-speaker-wiring.md
+++ b/docs/changelog.d/498-teams-speaker-wiring.md
@@ -1,0 +1,7 @@
+- **Teams bot speaker attribution: segments carry who spoke, not `seg_N` (#498).** The bot now
+  bundles the Teams voice-level-outline speaker watcher (`@vexa/teams-capture` — the same module
+  the desktop extension runs) into its browser bundle and wires it to the transcriber: hints cross
+  the page→Node boundary under Teams' true `dom-outline` kind (previously erased to Zoom's
+  `dom-active`), on one epoch-ms clock with a loud skew guard, and a periodic
+  `hint-counters` log line names the exact hop if a name ever goes missing again. A headless
+  boundary CI test pins the wiring so the regression cannot ship silently.


### PR DESCRIPTION
Refs #498 (not Closes — the live Teams leg / A6 remains the human bar).

## Observation bundle (acceptance table, the issue's numbering)

**Era-check first (finding):** the issue's re-prep comment is confirmed at head — the jitsi lane
already wires `__vexaSpeakerHint` (capture-bridge.ts jitsi branch), so "zero callers in the tree"
holds only FOR TEAMS, and the previously-hardcoded `'dom-active'` at the pipeline seam was
load-bearing-correct for jitsi. This diff preserves the jitsi kind (pinned by test).

### A1 — C1 seam counters (red→green + loud `missed`)
- `core/meetings/services/bot/src/speaker-hints.test.ts` (in the bot's `pnpm test` chain): `received` advances per pipeline-received hint; binder outcomes advance `matched`/`missed`; **end-to-end with the REAL `ChunkedTranscriber`** (injected segmenter, no model): a hint with no overlapping turn increments `missed`.
- New additive `onHintOutcome` callback on `ChunkedTranscriberCallbacks` (mixed-pipeline), pinned by `core/meetings/modules/mixed-pipeline/src/hint-outcome.smoke.test.ts` (in that package's test chain): pre-turn hint → `missed`; mid-turn hint → `matched`; end-hints emit no outcome.
- The four hops surface on one periodic line: `[bot] hint-counters bridge-crossed=… pipeline-received=… binder-matched=… binder-missed=…` (capture-bridge.ts, 30 s cadence, unref'd); hop 1 (page-emitted) is the page console's `[TeamsSpeakers]` log.
- **Negative control (shown RED):** removed `hintCounters.received++` → `❌ received advances per pipeline-received hint — {"received":0,…}` (2 failures), reverted → green.

### A2 — C2 kind fidelity (the shared-engine threading)
- `hintKindForPlatform` (pipeline.ts): teams → `'dom-outline'`, zoom → `'dom-active'`, **jitsi → `'dom-active'` (preserved)**; bound once at wiring time. Pinned at the exact transcriber seam via an injected `MixedTranscriberFactory` observing the real `recordHint(name, kind, tMs, isEnd)` call — all three platforms asserted.
- **Negative control (shown RED):** reverted to hardcoded `'dom-active'` → `❌ teams: recordHint forwards kind='dom-outline' … got "dom-active"`, reverted → green.

### A3 — C3 timebase contract
- Contract documented at the `recordHint` seam and in `makeSpeakerHintSink` (capture-bridge.ts, exported so it is offline-provable): hint `tMs` and audio `tsMs` are BOTH epoch ms. The Teams watcher stamps `Date.now()` page-side (msteams-speakers.ts `emit`) — the clocks agree by construction; the guard asserts it: skew >10 min → loud `[bot] hint-clock-skew` warning + Node-epoch re-stamp, never a silent miss.
- Test: epoch tMs passes through unchanged; `12345` (performance.now()-shaped) → re-stamped + typed warning; undefined → Node epoch fallback.
- **Negative control (shown RED):** guard disabled → `12345` passes through silently, `❌ the skew warns LOUDLY — []`; reverted → green.

### A4 — C4 wiring + boundary test
- `@vexa/teams-capture` added to the browser bundle (`build-browser-utils.mjs`) and the Dockerfile brick-build filter list; `startCaptureBridge`'s teams branch starts the watcher and forwards transitions to `__vexaSpeakerHint(name, tMs, isEnd)` — the SAME module + shape the desktop extension runs.
- `core/meetings/services/bot/src/capture-bridge.boundary.test.ts` (in the test chain): headless Chromium (the bot's own `launchPersistentBrowser`), the REAL built bundle + REAL `startCaptureBridge` over a fixture Teams DOM. Asserts: bundle exposes `createTeamsSpeakers`; page-side watcher starts (hop-1 logs); hints cross with the participant's NAME; START precedes END; tMs is epoch; the bot self-name and the **#481 1:1 no-outline tile** emit NO hints; the received counter moves. Green-or-skip (loud SKIP, exit 0) where headless Chromium is absent — same shape as gate:stack.
- **Negative control (shown RED):** page-side teams wiring disabled → zero arrivals, 5 failures; reverted → green.

### A5 — C5 host-parity differential
- `speaker-hints.test.ts` C5 block: ONE scripted timeline (audio frames + boundaries + a hint) through (a) desktop-style wiring — `ChunkedTranscriber` + direct `recordHint(name,'dom-outline',t)`, the extension's shape (`clients/extension/src/inpage.ts:159`) — and (b) the bot's real teams lane (`createBotPipeline`, only the segmenter scripted). Diff of published confirmed segments: **identical**, both naming `Alice Fixture`. GREEN after C2–C4 — per the issue, "green after C2–C4 land — either is informative"; it now guards the parity.

### A6 — LIVE Teams run: **NOT DONE — the remaining human bar.**
No live Teams meeting was run in this session. Everything above is offline/headless evidence; the value attestation (2 speakers, named segments, repaint observed, fsm.log + transcript) needs a live bot run on a Teams meeting, signed by a non-author. Lite compose is the reference setup.

### A7 — No-regression
- `node scripts/gates.mjs all` → **all green** at head of this branch (incl. gate:node = turbo build+test across 18 packages: bot chain with the two new tests, mixed-pipeline chain with the new smoke). BASELINE.md untouched (its Teams row is exactly what A6 will re-measure).

## NOT checked
- A6 live leg (above). No Docker image was built/run (gate:compose skipped — docker absent on this machine); the Dockerfile brick-list change is exercised only by the local equivalent (`pnpm --filter … run build` + bundle grep).
- Zoom live behavior (sibling #538); the zoom/jitsi kinds are pinned by unit test only.
- The boundary test self-skips where headless Chromium is missing — on this machine it RAN (all green).

## Findings / deviations
- Era-note confirmed (see top). Line anchors at head: kind hardcode was pipeline.ts:185, clock fallback capture-bridge.ts:234, exposeFunction :241 — as the re-prep comment said.
- `setContent` does not re-run `addInitScript` scripts in the bot's launch shape (playwright-extra persistent context) — the boundary test therefore injects the same bundle bytes via `addScriptTag`; on a real navigation the init-script path is the one production uses (unchanged).
- The watcher emits the tile's initial silent state as an END-shaped hint before the first START — real behavior, asserted as order (START before its END) rather than "first hint is START".
