### PR TITLE
feat(bots): authenticated session lifecycle — provisioning end-to-end + write-back on teardown (#724, #725)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Vexa open-core — top-level deploy entrypoint (Docker Compose)
 # =============================================================================
-.PHONY: all up dev down bot lite probe help
+.PHONY: all up dev down bot lite probe login help
 
 SURFACE ?= compose
 
@@ -12,6 +12,7 @@ help:
 	@echo "  make bot   build the meeting bot from source into vexa/vexa-bot:dev (dev path)"
 	@echo "  make lite  single-container Vexa Lite from the published image"
 	@echo "  make probe full-journey smoke probe of a RUNNING install (SURFACE=compose|lite|helm)"
+	@echo "  make login provision an authenticated-bot session (sign in once; uploads to userdata storage)"
 	@echo "  make down  stop the compose stack"
 
 all up:              ## full compose stack
@@ -28,6 +29,9 @@ bot:                 ## build the meeting bot from source → vexa/vexa-bot:dev 
 
 probe:               ## full-journey smoke probe (spawn→…→stop + log sweep) of a running install — see deploy/$(SURFACE)/probe.sh
 	@./deploy/$(SURFACE)/probe.sh
+
+login:               ## provision an authenticated-bot session — sign in once, persist it (docs: /authenticated-bots)
+	@pnpm --filter @vexa/remote-browser login
 
 down:                ## stop the compose stack
 	@$(MAKE) --no-print-directory -C deploy/compose down

--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -1012,6 +1012,33 @@
       ]
     },
     {
+      "unique-id": "userdata-blob",
+      "node-type": "data-asset",
+      "name": "userdata bucket (blob)",
+      "description": "authenticated-bot browser sessions (auth-essential profile subset): remote-browser's provisioning login uploads the signed-in session; the bot restores it before launch and writes the rotated session back on clean teardown",
+      "controls": {
+        "ownership": {
+          "description": "two writers by design: remote-browser=provisioning upload, bot=write-back on teardown",
+          "requirements": [
+            {
+              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+              "config": {
+                "writers": [
+                  "remote-browser",
+                  "bot"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "metadata": [
+        {
+          "stage": "session"
+        }
+      ]
+    },
+    {
       "unique-id": "runtime",
       "node-type": "service",
       "name": "runtime",
@@ -1259,7 +1286,8 @@
             "u-meetings",
             "bot-commands",
             "segments-table",
-            "recording-blob"
+            "recording-blob",
+            "userdata-blob"
           ]
         }
       }
@@ -1504,6 +1532,46 @@
           }
         }
       },
+      "metadata": [
+        {
+          "access": "write"
+        }
+      ]
+    },
+    {
+      "unique-id": "bot-userdata",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "bot"
+          },
+          "destination": {
+            "node": "userdata-blob"
+          }
+        }
+      },
+      "description": "restore session before launch (read) + write rotated session back on clean teardown (write)",
+      "protocol": "HTTPS",
+      "metadata": [
+        {
+          "access": "read-write"
+        }
+      ]
+    },
+    {
+      "unique-id": "remote-browser-userdata",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "remote-browser"
+          },
+          "destination": {
+            "node": "userdata-blob"
+          }
+        }
+      },
+      "description": "provisioning login uploads the confirmed signed-in session",
+      "protocol": "HTTPS",
       "metadata": [
         {
           "access": "write"

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "4b0364f10283dcb3d9878988a8e9319bfd27a38b15264e37f9532853294502ef"
+  "architecture.calm.json": "7d169e6108733171e6afc983886ffc1dbb076e3008ce5b1436c44b4fddc3f614"
 }

--- a/core/meetings/modules/remote-browser/package.json
+++ b/core/meetings/modules/remote-browser/package.json
@@ -1,18 +1,24 @@
 {
   "name": "@vexa/remote-browser",
   "version": "0.1.0",
-  "description": "Remote browser as container: persistent-context launch (VNC/CDP), browser-session persistence + retrieval (cookies/localStorage), and logged-in validation — so the join layer can join authenticated.",
+  "description": "Remote browser as container: persistent-context launch (VNC/CDP), browser-session persistence + retrieval (cookies/localStorage), and logged-in validation \u2014 so the join layer can join authenticated.",
   "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/auth.smoke.test.ts",
-    "check:isolation": "node scripts/check-isolation.js"
+    "test": "tsx src/auth.smoke.test.ts && tsx src/session-store.test.ts",
+    "check:isolation": "node scripts/check-isolation.js",
+    "login": "tsx src/provision-cli.ts"
   },
   "dependencies": {
     "playwright": "1.56.0",

--- a/core/meetings/modules/remote-browser/src/index.ts
+++ b/core/meetings/modules/remote-browser/src/index.ts
@@ -27,6 +27,7 @@ export {
   ensureBrowserDataDir,
   makeEphemeralProfileDir,
   removeProfileDir,
+  SessionSyncError,
 } from './session-store';
 export type { S3Config } from './session-store';
 

--- a/core/meetings/modules/remote-browser/src/provision-cli.ts
+++ b/core/meetings/modules/remote-browser/src/provision-cli.ts
@@ -1,0 +1,80 @@
+/**
+ * provision-cli — the operator entry point that creates an authenticated bot session
+ * (the `make login` / `pnpm --filter @vexa/remote-browser login` command, #724 C1).
+ *
+ * Flow: open the platform's sign-in page in the provisioning browser (headed locally, or
+ * via the module's VNC flow inside a container) → a human signs in → `provisionLogin`
+ * confirms with `validateLoggedIn` → the auth-essential subset of the profile is uploaded
+ * to the deployment's userdata prefix (`syncBrowserDataToS3`). Every bot spawned by a
+ * deployment configured with `BOT_AUTHENTICATED=true` then restores this session and
+ * joins signed-in.
+ *
+ * Env (the SAME names meeting-api's spawn knob reads, one vocabulary per deployment):
+ *   AUTH_PLATFORM            google | zoom | teams        (default: google)
+ *   BOT_USERDATA_S3_PATH     userdata prefix, e.g. userdata/bot-identity-1
+ *   BOT_S3_ENDPOINT          e.g. http://minio:9000
+ *   BOT_S3_BUCKET            e.g. vexa
+ *   BOT_S3_ACCESS_KEY / BOT_S3_SECRET_KEY   scoped userdata credentials — never admin creds
+ *   LOGIN_PROFILE_DIR        where the live profile is written (default: BROWSER_DATA_DIR)
+ *   LOGIN_TIMEOUT_MS         how long to wait for the human sign-in (default: 10 min)
+ *
+ * Exit codes: 0 = signed in AND (when S3 is configured) uploaded; 1 = login not confirmed
+ * (the userdata prefix is untouched) or the upload shipped nothing.
+ */
+import { provisionLogin } from './login';
+import { BROWSER_DATA_DIR, syncBrowserDataToS3, type S3Config } from './session-store';
+import type { AuthPlatform } from './types';
+
+const PLATFORMS: AuthPlatform[] = ['google', 'zoom', 'teams'];
+
+async function main(): Promise<number> {
+  const raw = (process.env.AUTH_PLATFORM || process.argv[2] || 'google').toLowerCase();
+  if (!PLATFORMS.includes(raw as AuthPlatform)) {
+    console.error(`[provision-login] unknown platform '${raw}' — expected one of: ${PLATFORMS.join(', ')}`);
+    return 1;
+  }
+  const platform = raw as AuthPlatform;
+  const profileDir = process.env.LOGIN_PROFILE_DIR || BROWSER_DATA_DIR;
+  const timeoutMs = Number(process.env.LOGIN_TIMEOUT_MS) > 0 ? Number(process.env.LOGIN_TIMEOUT_MS) : 600_000;
+
+  const s3: S3Config = {
+    userdataS3Path: process.env.BOT_USERDATA_S3_PATH || undefined,
+    s3Endpoint: process.env.BOT_S3_ENDPOINT || undefined,
+    s3Bucket: process.env.BOT_S3_BUCKET || undefined,
+    s3AccessKey: process.env.BOT_S3_ACCESS_KEY || undefined,
+    s3SecretKey: process.env.BOT_S3_SECRET_KEY || undefined,
+  };
+  const s3Configured = !!(s3.userdataS3Path && s3.s3Endpoint && s3.s3Bucket);
+
+  console.log(`[provision-login] platform=${platform} profileDir=${profileDir} ` +
+    (s3Configured ? `upload → s3://${s3.s3Bucket}/${s3.userdataS3Path}` : 'no S3 config — profile dir only'));
+
+  // The login gate: only a validateLoggedIn-confirmed session proceeds. An aborted /
+  // timed-out sign-in exits non-zero with the login verdict and touches NOTHING durable.
+  const status = await provisionLogin({ platform, profileDir, timeoutMs, keepOpenMs: 2000 });
+  if (!status.loggedIn) {
+    console.error(`[provision-login] FAILED — login not confirmed: ${status.detail}`);
+    return 1;
+  }
+
+  if (!s3Configured) {
+    console.log(`[provision-login] signed in; session lives in ${profileDir} (set BOT_USERDATA_S3_PATH ` +
+      `+ BOT_S3_ENDPOINT + BOT_S3_BUCKET to persist it to the deployment's userdata storage).`);
+    return 0;
+  }
+
+  const uploaded = syncBrowserDataToS3(s3, profileDir);
+  if (uploaded === 0) {
+    console.error('[provision-login] FAILED — signed in, but zero auth-essential items reached ' +
+      `s3://${s3.s3Bucket}/${s3.userdataS3Path} (see warnings above; check credentials/endpoint/aws CLI).`);
+    return 1;
+  }
+  console.log(`[provision-login] SUCCESS — ${uploaded} auth-essential items at ` +
+    `s3://${s3.s3Bucket}/${s3.userdataS3Path}/browser-data; authenticated bots will restore this session.`);
+  return 0;
+}
+
+main().then((code) => process.exit(code)).catch((e) => {
+  console.error(`[provision-login] FAILED — ${String(e)}`);
+  process.exit(1);
+});

--- a/core/meetings/modules/remote-browser/src/session-store.test.ts
+++ b/core/meetings/modules/remote-browser/src/session-store.test.ts
@@ -3,7 +3,7 @@
  *
  * A fake `aws` executable on PATH records every invocation to a log file, so the REAL
  * syncBrowserDataToS3 / syncBrowserDataFromS3 run end-to-end and the assertions read
- * what actually crossed the shell boundary. Covers the two contract-level behaviours:
+ * what actually crossed the process boundary. Covers the two contract-level behaviours:
  *
  *  1. WRITE-BACK SOURCE DIR (#725 C1) — syncBrowserDataToS3(config, dataDir) uploads
  *     from the LIVE per-bot ephemeral dir it is handed, symmetric with the restore half.
@@ -13,7 +13,6 @@
  *
  * Same shape as auth.smoke.test.ts (tsx + exit code, no assert lib).
  */
-import { execSync } from 'child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -82,10 +81,11 @@ check(count === 0, `all-failing uploads must report 0 items, got ${count}`);
 // ── 3. restore failure is a typed, attributed SessionSyncError (#724 C3) ────
 let restoreErr: unknown;
 try { syncBrowserDataFromS3(config, liveDir); } catch (e) { restoreErr = e; }
-check(restoreErr instanceof SessionSyncError, 'failing restore must throw SessionSyncError (typed, not a bare execSync death)');
+check(restoreErr instanceof SessionSyncError, 'failing restore must throw SessionSyncError (typed, not a bare exec death)');
 if (restoreErr instanceof SessionSyncError) {
   check(restoreErr.step === 'session-restore', `restore error must name the session-restore step, got '${restoreErr.step}'`);
-  check(restoreErr.message.includes('http://minio.test:9000'), 'restore error must name the endpoint');
+  const namedEndpoint = /\(endpoint (.+?), path /.exec(restoreErr.message)?.[1];
+  check(namedEndpoint === config.s3Endpoint, `restore error must name the exact endpoint, got '${namedEndpoint}'`);
 }
 
 // ── 3b. a missing aws CLI is named as such ──────────────────────────────────
@@ -111,5 +111,3 @@ if (fails.length) {
   process.exit(1);
 }
 console.log('session-store.test OK — write-back dataDir honored; restore fail-loud + typed; teardown warn-only.');
-// keep execSync imported reference honest (silences unused-import under strict configs)
-void execSync;

--- a/core/meetings/modules/remote-browser/src/session-store.test.ts
+++ b/core/meetings/modules/remote-browser/src/session-store.test.ts
@@ -1,0 +1,115 @@
+/**
+ * session-store.test — the S3 sync surface, offline (no real S3, no network).
+ *
+ * A fake `aws` executable on PATH records every invocation to a log file, so the REAL
+ * syncBrowserDataToS3 / syncBrowserDataFromS3 run end-to-end and the assertions read
+ * what actually crossed the shell boundary. Covers the two contract-level behaviours:
+ *
+ *  1. WRITE-BACK SOURCE DIR (#725 C1) — syncBrowserDataToS3(config, dataDir) uploads
+ *     from the LIVE per-bot ephemeral dir it is handed, symmetric with the restore half.
+ *  2. FAIL-LOUD RESTORE (#724 C3) — a failing download surfaces as a typed
+ *     SessionSyncError naming the session-restore step (and names a missing aws CLI),
+ *     never an unattributed process death; the upload half stays warn-only and reports 0.
+ *
+ * Same shape as auth.smoke.test.ts (tsx + exit code, no assert lib).
+ */
+import { execSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { syncBrowserDataToS3, syncBrowserDataFromS3, SessionSyncError, type S3Config } from './session-store';
+
+const fails: string[] = [];
+const check = (cond: boolean, msg: string) => { if (!cond) fails.push(msg); };
+
+const work = mkdtempSync(join(tmpdir(), 'session-store-test-'));
+const binDir = join(work, 'bin');
+const logFile = join(work, 'aws-calls.log');
+mkdirSync(binDir, { recursive: true });
+
+/** Install the fake `aws` on PATH. mode: 'ok' records + exits 0; 'fail' records + exits 1. */
+function installFakeAws(mode: 'ok' | 'fail'): void {
+  const script = `#!/bin/sh\necho "$@" >> "${logFile}"\n${mode === 'fail' ? 'exit 1' : 'exit 0'}\n`;
+  writeFileSync(join(binDir, 'aws'), script);
+  chmodSync(join(binDir, 'aws'), 0o755);
+}
+const realPath = process.env.PATH ?? '';
+const withFakePath = `${binDir}:${realPath}`;
+const calls = (): string[] => (existsSync(logFile) ? readFileSync(logFile, 'utf8').trim().split('\n').filter(Boolean) : []);
+const resetLog = (): void => { rmSync(logFile, { force: true }); };
+
+const config: S3Config = {
+  userdataS3Path: 'userdata/test-identity',
+  s3Endpoint: 'http://minio.test:9000',
+  s3Bucket: 'vexa-test',
+  s3AccessKey: 'k',
+  s3SecretKey: 's',
+};
+
+// A live-looking profile dir with an auth-essential subset present.
+const liveDir = mkdtempSync(join(tmpdir(), 'browser-data-'));
+mkdirSync(join(liveDir, 'Default', 'Local Storage'), { recursive: true });
+writeFileSync(join(liveDir, 'Default', 'Cookies'), 'rotated-cookie-bytes');
+writeFileSync(join(liveDir, 'Local State'), '{}');
+writeFileSync(join(liveDir, 'Default', 'Local Storage', 'x.ldb'), 'ls');
+
+// ── 1. write-back uploads from the dataDir it is handed (#725 C1) ───────────
+installFakeAws('ok');
+process.env.PATH = withFakePath;
+resetLog();
+const uploaded = syncBrowserDataToS3(config, liveDir);
+check(uploaded === 3, `write-back should upload the 3 present auth-essential items, got ${uploaded}`);
+const upCalls = calls();
+check(upCalls.length === 3, `expected 3 aws invocations, got ${upCalls.length}`);
+check(upCalls.every((c) => c.includes(liveDir)), 'every upload must read from the LIVE dataDir handed in (not BROWSER_DATA_DIR)');
+check(upCalls.some((c) => c.includes(`${liveDir}/Default/Cookies`)), 'the rotated Cookies file must be among the uploads');
+check(upCalls.every((c) => c.includes('s3://vexa-test/userdata/test-identity/browser-data')), 'uploads must target the userdata prefix');
+
+// ── 1b. incomplete config is a no-op (guest/anonymous path untouched) ───────
+resetLog();
+const noop = syncBrowserDataToS3({ userdataS3Path: 'x' }, liveDir);   // no endpoint/bucket
+check(noop === 0 && calls().length === 0, 'incomplete S3 config must be a no-op (0 uploads, no aws calls)');
+
+// ── 2. upload failures are warnings, never throws (teardown safety) ─────────
+installFakeAws('fail');
+resetLog();
+let threw = false;
+let count = -1;
+try { count = syncBrowserDataToS3(config, liveDir); } catch { threw = true; }
+check(!threw, 'write-back must NEVER throw on upload failure (teardown path)');
+check(count === 0, `all-failing uploads must report 0 items, got ${count}`);
+
+// ── 3. restore failure is a typed, attributed SessionSyncError (#724 C3) ────
+let restoreErr: unknown;
+try { syncBrowserDataFromS3(config, liveDir); } catch (e) { restoreErr = e; }
+check(restoreErr instanceof SessionSyncError, 'failing restore must throw SessionSyncError (typed, not a bare execSync death)');
+if (restoreErr instanceof SessionSyncError) {
+  check(restoreErr.step === 'session-restore', `restore error must name the session-restore step, got '${restoreErr.step}'`);
+  check(restoreErr.message.includes('http://minio.test:9000'), 'restore error must name the endpoint');
+}
+
+// ── 3b. a missing aws CLI is named as such ──────────────────────────────────
+process.env.PATH = join(work, 'empty-bin');   // no aws anywhere on PATH
+mkdirSync(process.env.PATH, { recursive: true });
+let missingErr: unknown;
+try { syncBrowserDataFromS3(config, liveDir); } catch (e) { missingErr = e; }
+check(missingErr instanceof SessionSyncError, 'missing aws CLI must still surface as SessionSyncError');
+check(String((missingErr as Error)?.message ?? '').includes('aws CLI not found'), 'missing aws CLI must be named in the error');
+process.env.PATH = realPath;
+
+// ── 3c. restore with incomplete config is a no-op (anonymous bots unaffected) ──
+let noopThrew = false;
+try { syncBrowserDataFromS3({}, liveDir); } catch { noopThrew = true; }
+check(!noopThrew, 'restore with no S3 config must be a no-op');
+
+// ── verdict ─────────────────────────────────────────────────────────────────
+rmSync(work, { recursive: true, force: true });
+rmSync(liveDir, { recursive: true, force: true });
+if (fails.length) {
+  console.error(`session-store.test FAILED (${fails.length}):`);
+  for (const f of fails) console.error(`  ✗ ${f}`);
+  process.exit(1);
+}
+console.log('session-store.test OK — write-back dataDir honored; restore fail-loud + typed; teardown warn-only.');
+// keep execSync imported reference honest (silences unused-import under strict configs)
+void execSync;

--- a/core/meetings/modules/remote-browser/src/session-store.ts
+++ b/core/meetings/modules/remote-browser/src/session-store.ts
@@ -12,7 +12,7 @@
  * session; these helpers just copy the auth-essential subset of it in/out of a
  * durable store. Cache/GPU/IndexedDB junk is excluded — ~200KB, not the full profile.
  */
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync, unlinkSync, mkdirSync, cpSync, mkdtempSync, rmSync, readdirSync, readlinkSync, statSync } from 'fs';
 import { join, dirname, basename } from 'path';
 
@@ -112,7 +112,7 @@ const AUTH_ESSENTIAL_DIRS = [
 /**
  * A typed, attributed S3-session-sync failure. The restore half THROWS this (an authenticated
  * bot whose session cannot be restored must fail loud with the step named — never die on an
- * unattributed execSync, never silently join signed-out); the save half only WARNS (teardown
+ * unattributed exec, never silently join signed-out); the save half only WARNS (teardown
  * must never hang or fail the exit on a flaky upload — the durable copy simply stays at the
  * last restore).
  */
@@ -127,7 +127,7 @@ export class SessionSyncError extends Error {
   }
 }
 
-/** Attribute an `aws` execSync failure: a missing CLI (shell 127 / ENOENT) is named as such —
+/** Attribute an `aws` exec failure: a missing CLI (ENOENT / 127) is named as such —
  *  the deployment's image must ship the aws CLI — anything else carries the exit status. */
 function describeAwsFailure(err: any): string {
   const status = err?.status ?? err?.code;
@@ -148,18 +148,18 @@ function getS3Env(config: S3Config): Record<string, string> {
 export function s3Sync(localDir: string, s3Path: string, config: S3Config, direction: 'up' | 'down', excludes: string[] = []): void {
   if (!config.userdataS3Path || !config.s3Endpoint || !config.s3Bucket) return;
   const s3Uri = `s3://${config.s3Bucket}/${s3Path}`;
-  const excludeArgs = excludes.map(e => `--exclude "${e}"`).join(' ');
-  const deleteArg = '';
   const [src, dst] = direction === 'down' ? [s3Uri, `${localDir}/`] : [`${localDir}/`, s3Uri];
   console.log(`[s3-sync] S3 sync ${direction}: ${src} → ${dst}`);
   try {
-    execSync(
-      `aws s3 sync "${src}" "${dst}" --endpoint-url "${config.s3Endpoint}" ${deleteArg} ${excludeArgs}`,
+    // argv-exec, never a shell — config values are arguments, they cannot inject.
+    execFileSync(
+      'aws',
+      ['s3', 'sync', src, dst, '--endpoint-url', config.s3Endpoint, ...excludes.flatMap(e => ['--exclude', e])],
       { env: getS3Env(config), stdio: 'inherit', timeout: 300000 }
     );
   } catch (err: any) {
     // Attributed, typed failure naming the sync step + target (#724 C3). The pre-guard shape —
-    // an unguarded execSync — killed the process before Chromium launched with nothing on the
+    // an unguarded exec — killed the process before Chromium launched with nothing on the
     // log naming the step (the #461 signature).
     throw new SessionSyncError(
       direction === 'down' ? 'session-restore' : 'session-save',
@@ -186,7 +186,7 @@ export function syncBrowserDataToS3(config: S3Config, dataDir: string = BROWSER_
   if (!config.userdataS3Path || !config.s3Endpoint || !config.s3Bucket) return 0;
   const s3Base = `s3://${config.s3Bucket}/${config.userdataS3Path}/browser-data`;
   const env = getS3Env(config);
-  const endpoint = `--endpoint-url "${config.s3Endpoint}"`;
+  const endpointArgs = ['--endpoint-url', config.s3Endpoint];
   let uploaded = 0;
 
   console.log(`[s3-sync] S3 save (auth-essential files only) from ${dataDir}...`);
@@ -195,7 +195,7 @@ export function syncBrowserDataToS3(config: S3Config, dataDir: string = BROWSER_
     const local = join(dataDir, file);
     if (!existsSync(local)) continue;
     try {
-      execSync(`aws s3 cp "${local}" "${s3Base}/${file}" ${endpoint}`, { env, stdio: 'pipe', timeout: 10000 });
+      execFileSync('aws', ['s3', 'cp', local, `${s3Base}/${file}`, ...endpointArgs], { env, stdio: 'pipe', timeout: 10000 });
       uploaded++;
     } catch (err: any) {
       console.log(`[s3-sync] Warning: failed to upload ${file}: ${describeAwsFailure(err)}`);
@@ -206,7 +206,7 @@ export function syncBrowserDataToS3(config: S3Config, dataDir: string = BROWSER_
     const local = join(dataDir, dir);
     if (!existsSync(local)) continue;
     try {
-      execSync(`aws s3 sync "${local}/" "${s3Base}/${dir}/" ${endpoint}`, { env, stdio: 'pipe', timeout: 10000 });
+      execFileSync('aws', ['s3', 'sync', `${local}/`, `${s3Base}/${dir}/`, ...endpointArgs], { env, stdio: 'pipe', timeout: 10000 });
       uploaded++;
     } catch (err: any) {
       console.log(`[s3-sync] Warning: failed to sync ${dir}: ${describeAwsFailure(err)}`);

--- a/core/meetings/modules/remote-browser/src/session-store.ts
+++ b/core/meetings/modules/remote-browser/src/session-store.ts
@@ -109,6 +109,34 @@ const AUTH_ESSENTIAL_DIRS = [
 
 // ── S3 backend (production) ───────────────────────────────────────────────
 
+/**
+ * A typed, attributed S3-session-sync failure. The restore half THROWS this (an authenticated
+ * bot whose session cannot be restored must fail loud with the step named — never die on an
+ * unattributed execSync, never silently join signed-out); the save half only WARNS (teardown
+ * must never hang or fail the exit on a flaky upload — the durable copy simply stays at the
+ * last restore).
+ */
+export class SessionSyncError extends Error {
+  constructor(
+    public readonly step: 'session-restore' | 'session-save',
+    detail: string,
+    public readonly cause?: unknown,
+  ) {
+    super(`[session-store] ${step} failed: ${detail}`);
+    this.name = 'SessionSyncError';
+  }
+}
+
+/** Attribute an `aws` execSync failure: a missing CLI (shell 127 / ENOENT) is named as such —
+ *  the deployment's image must ship the aws CLI — anything else carries the exit status. */
+function describeAwsFailure(err: any): string {
+  const status = err?.status ?? err?.code;
+  if (status === 127 || err?.code === 'ENOENT') {
+    return 'aws CLI not found on PATH — the bot image (or provisioning host) must ship it';
+  }
+  return `aws exited with ${String(status ?? 'unknown')}: ${String(err?.message ?? err)}`;
+}
+
 function getS3Env(config: S3Config): Record<string, string> {
   return {
     ...process.env as Record<string, string>,
@@ -124,48 +152,69 @@ export function s3Sync(localDir: string, s3Path: string, config: S3Config, direc
   const deleteArg = '';
   const [src, dst] = direction === 'down' ? [s3Uri, `${localDir}/`] : [`${localDir}/`, s3Uri];
   console.log(`[s3-sync] S3 sync ${direction}: ${src} → ${dst}`);
-  execSync(
-    `aws s3 sync "${src}" "${dst}" --endpoint-url "${config.s3Endpoint}" ${deleteArg} ${excludeArgs}`,
-    { env: getS3Env(config), stdio: 'inherit', timeout: 300000 }
-  );
+  try {
+    execSync(
+      `aws s3 sync "${src}" "${dst}" --endpoint-url "${config.s3Endpoint}" ${deleteArg} ${excludeArgs}`,
+      { env: getS3Env(config), stdio: 'inherit', timeout: 300000 }
+    );
+  } catch (err: any) {
+    // Attributed, typed failure naming the sync step + target (#724 C3). The pre-guard shape —
+    // an unguarded execSync — killed the process before Chromium launched with nothing on the
+    // log naming the step (the #461 signature).
+    throw new SessionSyncError(
+      direction === 'down' ? 'session-restore' : 'session-save',
+      `${describeAwsFailure(err)} (endpoint ${config.s3Endpoint}, path ${s3Path})`,
+      err,
+    );
+  }
 }
 
 export function syncBrowserDataFromS3(config: S3Config, dataDir: string = BROWSER_DATA_DIR): void {
   s3Sync(dataDir, `${config.userdataS3Path}/browser-data`, config, 'down', BROWSER_CACHE_EXCLUDES);
 }
 
-export function syncBrowserDataToS3(config: S3Config): void {
-  if (!config.userdataS3Path || !config.s3Endpoint || !config.s3Bucket) return;
+/**
+ * Upload the auth-essential subset of a LIVE profile dir to the durable S3 copy — the write-back
+ * half of restore→use→write-back (#725 C1). `dataDir` names the profile the browser actually ran
+ * on (a per-bot ephemeral `${BROWSER_DATA_DIR}-XXXXXX` dir — symmetric with
+ * `syncBrowserDataFromS3(config, dataDir)`). Per-item failures are attributed warnings, never a
+ * throw and never unbounded (each call carries its own timeout) — a flaky upload on teardown
+ * leaves the durable copy at the last restore, it never hangs the exit. Returns the number of
+ * items uploaded (0 ⇒ nothing durable changed — provisioning treats that as failure).
+ */
+export function syncBrowserDataToS3(config: S3Config, dataDir: string = BROWSER_DATA_DIR): number {
+  if (!config.userdataS3Path || !config.s3Endpoint || !config.s3Bucket) return 0;
   const s3Base = `s3://${config.s3Bucket}/${config.userdataS3Path}/browser-data`;
   const env = getS3Env(config);
   const endpoint = `--endpoint-url "${config.s3Endpoint}"`;
   let uploaded = 0;
 
-  console.log(`[s3-sync] S3 save (auth-essential files only)...`);
+  console.log(`[s3-sync] S3 save (auth-essential files only) from ${dataDir}...`);
 
   for (const file of AUTH_ESSENTIAL_FILES) {
-    const local = join(BROWSER_DATA_DIR, file);
+    const local = join(dataDir, file);
     if (!existsSync(local)) continue;
     try {
       execSync(`aws s3 cp "${local}" "${s3Base}/${file}" ${endpoint}`, { env, stdio: 'pipe', timeout: 10000 });
       uploaded++;
     } catch (err: any) {
-      console.log(`[s3-sync] Warning: failed to upload ${file}: ${err.message}`);
+      console.log(`[s3-sync] Warning: failed to upload ${file}: ${describeAwsFailure(err)}`);
     }
   }
 
   for (const dir of AUTH_ESSENTIAL_DIRS) {
-    const local = join(BROWSER_DATA_DIR, dir);
+    const local = join(dataDir, dir);
     if (!existsSync(local)) continue;
     try {
       execSync(`aws s3 sync "${local}/" "${s3Base}/${dir}/" ${endpoint}`, { env, stdio: 'pipe', timeout: 10000 });
       uploaded++;
     } catch (err: any) {
-      console.log(`[s3-sync] Warning: failed to sync ${dir}: ${err.message}`);
+      console.log(`[s3-sync] Warning: failed to sync ${dir}: ${describeAwsFailure(err)}`);
     }
   }
 
   console.log(`[s3-sync] Uploaded ${uploaded} auth-essential items`);
+  return uploaded;
 }
 
 // ── Local backend (desktop/dev, no S3 creds) ─────────────────────────────

--- a/core/meetings/services/bot/Dockerfile
+++ b/core/meetings/services/bot/Dockerfile
@@ -100,15 +100,21 @@ RUN cd /build && node core/meetings/services/bot/warm-hf-cache.mjs
 FROM vexa/meet-join-env:dev AS runtime
 
 # The bot's OWN runtime deps NOT in the meet-join env: PulseAudio (the speak/TTS
-# + capture audio chain) and fluxbox (a WM for the X11 session). The Playwright +
-# humanized-X11 stack (xvfb·xdotool·xclip·x11vnc·websockify) comes from the base.
+# + capture audio chain), fluxbox (a WM for the X11 session), and the aws CLI —
+# the authenticated-bot session store (@vexa/remote-browser session-store.ts)
+# shells out to `aws s3` to restore the signed-in profile before launch and write
+# it back on clean teardown; without the binary every authenticated spawn fails
+# at session-restore. The Playwright + humanized-X11 stack (xvfb·xdotool·xclip·
+# x11vnc·websockify) comes from the base.
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
        pulseaudio \
        fluxbox \
        socat \
-    && rm -rf /var/lib/apt/lists/*
+       awscli \
+    && rm -rf /var/lib/apt/lists/* \
+    && aws --version
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     DISPLAY=:99 \

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -27,6 +27,7 @@
 import {
   launchPersistentBrowser,
   syncBrowserDataFromS3,
+  syncBrowserDataToS3,
   cleanStaleLocks,
   getAuthenticatedBrowserArgs,
   makeEphemeralProfileDir,
@@ -97,14 +98,18 @@ export async function launchBrowser(inv: Invocation): Promise<BrowserSession> {
   // SingletonLock (#478: joining → failed <1s, "Opening in existing browser session").
   // Authenticated: restore the S3 userdata into this bot's dir before launch (index.ts:2313–2347).
   const dataDir = makeEphemeralProfileDir();
+  const s3Config = {
+    userdataS3Path: inv.userdataS3Path,
+    s3Endpoint: inv.s3Endpoint,
+    s3Bucket: inv.s3Bucket,
+    s3AccessKey: inv.s3AccessKey,
+    s3SecretKey: inv.s3SecretKey,
+  };
   if (inv.authenticated && inv.userdataS3Path) {
-    syncBrowserDataFromS3({
-      userdataS3Path: inv.userdataS3Path,
-      s3Endpoint: inv.s3Endpoint,
-      s3Bucket: inv.s3Bucket,
-      s3AccessKey: inv.s3AccessKey,
-      s3SecretKey: inv.s3SecretKey,
-    }, dataDir);
+    // Fail-loud restore: an unreachable/misconfigured store surfaces as a typed SessionSyncError
+    // naming the session-restore step (the composition root drives it to a clean terminal failed)
+    // — an authenticated bot never silently proceeds to join signed-out on a failed restore.
+    syncBrowserDataFromS3(s3Config, dataDir);
     cleanStaleLocks(dataDir);
   }
 
@@ -177,6 +182,18 @@ export async function launchBrowser(inv: Invocation): Promise<BrowserSession> {
     page,
     async close() {
       await context.close().catch(() => { /* best-effort */ });
+      // Write-back on clean teardown (#725): Google rotates session cookies during use, so the
+      // durable copy is refreshed from the LIVE profile dir after the context flushes — the next
+      // spawn restores the freshest state instead of a decaying snapshot. Clean teardown only:
+      // a SIGKILL never reaches close(), so a hard-killed meeting keeps the last durable copy.
+      // Failures are attributed warnings, bounded per upload — teardown never hangs on S3.
+      if (inv.authenticated && inv.userdataS3Path) {
+        try {
+          syncBrowserDataToS3(s3Config, dataDir);
+        } catch (e) {
+          console.error(`[bot] session write-back failed (durable copy stays at last restore): ${String(e)}`);
+        }
+      }
       removeProfileDir(dataDir);   // per-bot dir — leaking one per bot fills the disk in vexa-lite
     },
   };

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -67,6 +67,23 @@ class SqlAlchemyMeetingRepo:
             m = (await db.execute(stmt)).scalars().first()
             return _row_to_dict(m) if m else None
 
+    async def find_active_by_userdata(self, userdata_s3_path) -> Optional[dict]:
+        from sqlalchemy import select
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            stmt = (
+                select(Meeting)
+                .where(
+                    Meeting.status.in_(["requested", "joining", "awaiting_admission", "active", "stopping"]),
+                    Meeting.data["auth_userdata_path"].astext == userdata_s3_path,
+                )
+                .order_by(Meeting.created_at.desc())
+            )
+            m = (await db.execute(stmt)).scalars().first()
+            return _row_to_dict(m) if m else None
+
     async def find_latest(self, user_id, platform, native_meeting_id) -> Optional[dict]:
         from sqlalchemy import select
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -50,6 +50,15 @@ class InMemoryMeetingRepo:
                 return dict(m)
         return None
 
+    async def find_active_by_userdata(self, userdata_s3_path) -> Optional[dict]:
+        for m in self._meetings.values():
+            if (
+                m["status"] in _ACTIVE_STATUSES
+                and m.get("data", {}).get("auth_userdata_path") == userdata_s3_path
+            ):
+                return dict(m)
+        return None
+
     async def find_latest(self, user_id, platform, native_meeting_id) -> Optional[dict]:
         rows = [
             m for m in self._meetings.values()

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/invocation.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/invocation.py
@@ -142,6 +142,12 @@ def build_invocation(
     transcription_service_url: Optional[str] = None,
     transcription_service_token: Optional[str] = None,
     transcription_model: Optional[str] = None,
+    authenticated: Optional[bool] = None,
+    userdata_s3_path: Optional[str] = None,
+    s3_endpoint: Optional[str] = None,
+    s3_bucket: Optional[str] = None,
+    s3_access_key: Optional[str] = None,
+    s3_secret_key: Optional[str] = None,
 ) -> dict:
     """Assemble the bot's ``invocation.v1`` Invocation (the parent's ``BOT_CONFIG``).
 
@@ -171,6 +177,16 @@ def build_invocation(
         "meetingApiCallbackUrl": meeting_api_callback_url,
         "internalSecret": internal_secret,
         "automaticLeave": automatic_leave,
+        # Authenticated-bot mode (sealed invocation.v1 auth block): the bot restores the stored
+        # browser session from the userdata store before launch and joins signed-in. Deployment-
+        # scoped — set by the BOT_AUTHENTICATED knob in ``request_bot``; None-stripped otherwise
+        # so anonymous invocations carry no auth fields at all.
+        "authenticated": authenticated,
+        "userdataS3Path": userdata_s3_path,
+        "s3Endpoint": s3_endpoint,
+        "s3Bucket": s3_bucket,
+        "s3AccessKey": s3_access_key,
+        "s3SecretKey": s3_secret_key,
     }
     invocation = {k: v for k, v in invocation.items() if v is not None}
     conforms_invocation(invocation)

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
@@ -34,6 +34,16 @@ class MeetingRepo(Protocol):
         set; ``stopping`` is in-flight too — see ``_ACTIVE_STATUSES``)."""
         ...
 
+    async def find_active_by_userdata(self, userdata_s3_path: str) -> Optional[dict]:
+        """Any user's ACTIVE meeting whose spawn carried this ``userdata_s3_path``
+        (``meeting.data.auth_userdata_path``), or ``None``. The per-identity serialization
+        boundary for authenticated bots: one stored browser session = one Google identity =
+        one live cookie jar, so a second concurrent spawn against the same path is refused
+        (→ HTTP 409, ``AuthSessionBusy``) — running one identity from N containers/IPs at
+        once is both an account-risk signal and a write-back race. Cross-user by design:
+        the identity is deployment-scoped, not per-user."""
+        ...
+
     async def find_latest(self, user_id: int, platform: str, native_meeting_id: str) -> Optional[dict]:
         """The user's MOST-RECENT meeting for ``(platform, native_id)`` regardless of status, or
         ``None``. ``continue_meeting`` reuses this row when it is TERMINAL (completed/failed)."""
@@ -181,6 +191,31 @@ class MaxBotsExceeded(Exception):
         self.user_id = user_id
         self.cap = cap
         super().__init__(f"User has reached the maximum concurrent bot limit ({cap}).")
+
+
+class AuthSessionNotConfigured(Exception):
+    """``BOT_AUTHENTICATED=true`` without a complete userdata store config — HTTP 503.
+
+    Authenticated mode is a deployment property: the knob demands ``BOT_USERDATA_S3_PATH`` +
+    ``BOT_S3_ENDPOINT`` + ``BOT_S3_BUCKET`` (scoped credentials via ``BOT_S3_ACCESS_KEY`` /
+    ``BOT_S3_SECRET_KEY``). A spawn is refused loud BEFORE any DB write — never a bot that
+    silently joins anonymous when the operator configured signed-in."""
+
+
+class AuthSessionBusy(Exception):
+    """A second concurrent authenticated spawn against the SAME stored session — HTTP 409.
+
+    Names the conflicting meeting so the operator can wait for or stop it. One identity,
+    one writer: serializing spawns per ``userdata_s3_path`` protects both the account's
+    risk posture (one cookie jar live from one place) and write-back integrity."""
+
+    def __init__(self, conflicting_meeting_id: int, userdata_s3_path: str):
+        self.conflicting_meeting_id = conflicting_meeting_id
+        self.userdata_s3_path = userdata_s3_path
+        super().__init__(
+            f"authenticated session '{userdata_s3_path}' is in use by active meeting "
+            f"{conflicting_meeting_id} — one stored session runs one bot at a time"
+        )
 
 
 class SpawnFailed(Exception):

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -21,7 +21,16 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from .env_flags import env_flag
-from .ports import MaxBotsExceeded, MeetingRepo, QuotaExceeded, RuntimeClient, SpawnFailed, TranscriptionNotConfigured
+from .ports import (
+    AuthSessionBusy,
+    AuthSessionNotConfigured,
+    MaxBotsExceeded,
+    MeetingRepo,
+    QuotaExceeded,
+    RuntimeClient,
+    SpawnFailed,
+    TranscriptionNotConfigured,
+)
 from .service import DuplicateMeeting, construct_meeting_url, request_bot
 
 
@@ -234,6 +243,14 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
             )
         except TranscriptionNotConfigured as e:
             raise HTTPException(status_code=503, detail=str(e))
+        except AuthSessionNotConfigured as e:
+            # Deployment misconfiguration (BOT_AUTHENTICATED without a complete userdata store) —
+            # a service-side 503 like the transcription gate, never a silent anonymous join.
+            raise HTTPException(status_code=503, detail=str(e))
+        except AuthSessionBusy as e:
+            # One stored session, one live bot: the second concurrent authenticated spawn is
+            # refused naming the conflicting meeting (per-identity serialization, #725).
+            raise HTTPException(status_code=409, detail=str(e))
         except DuplicateMeeting as e:
             raise HTTPException(status_code=409, detail=str(e))
         except (MaxBotsExceeded, QuotaExceeded) as e:

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -28,8 +28,11 @@ import uuid
 from typing import Any, Optional
 
 from ..obs import log_event
+from .env_flags import env_flag
 from .invocation import build_invocation, build_workload_spec, mint_meeting_token
 from .ports import (
+    AuthSessionBusy,
+    AuthSessionNotConfigured,
     DuplicateMeeting,
     MaxBotsExceeded,
     MeetingRepo,
@@ -190,6 +193,33 @@ async def request_bot(
             "TRANSCRIPTION_SERVICE_URL + TRANSCRIPTION_SERVICE_TOKEN"
         )
 
+    # 1c. Authenticated-bot mode (#724, deployment-scoped knob — Q1-A): when BOT_AUTHENTICATED is
+    #     set, EVERY spawn carries the sealed invocation.v1 auth block, so the bot restores the
+    #     deployment's provisioned browser session (`make login`) and joins signed-in. Config is
+    #     gated loud BEFORE any DB write (the TranscriptionNotConfigured precedent) — a half-
+    #     configured knob must never spawn a bot that silently joins anonymous. Env vocabulary
+    #     matches the provisioning CLI: BOT_USERDATA_S3_PATH + BOT_S3_{ENDPOINT,BUCKET,ACCESS_KEY,
+    #     SECRET_KEY} (scoped userdata credentials — never the deployment's admin S3 creds; they
+    #     ride the invocation env into the bot container, so their blast radius must stay the
+    #     userdata prefix).
+    authenticated = env_flag("BOT_AUTHENTICATED", False)
+    auth_userdata_path: Optional[str] = None
+    auth_s3: dict[str, Optional[str]] = {}
+    if authenticated:
+        auth_userdata_path = os.getenv("BOT_USERDATA_S3_PATH") or None
+        auth_s3 = {
+            "s3_endpoint": os.getenv("BOT_S3_ENDPOINT") or None,
+            "s3_bucket": os.getenv("BOT_S3_BUCKET") or None,
+            "s3_access_key": os.getenv("BOT_S3_ACCESS_KEY") or None,
+            "s3_secret_key": os.getenv("BOT_S3_SECRET_KEY") or None,
+        }
+        if not (auth_userdata_path and auth_s3["s3_endpoint"] and auth_s3["s3_bucket"]):
+            raise AuthSessionNotConfigured(
+                "BOT_AUTHENTICATED is set but the userdata store is incomplete — set "
+                "BOT_USERDATA_S3_PATH + BOT_S3_ENDPOINT + BOT_S3_BUCKET (and scoped "
+                "BOT_S3_ACCESS_KEY/BOT_S3_SECRET_KEY); provision the session with `make login`"
+            )
+
     # 2c. continue_meeting (P3c): reuse a TERMINAL prior meeting row if asked. The reused row keeps
     #     its id (so its transcripts/recordings survive); a fresh session is appended below. This read
     #     stays a plain query — the reused-row path reopens an existing terminal row (no NEW active row
@@ -208,6 +238,22 @@ async def request_bot(
     #     real adapter serializes per-user with a pg advisory lock + a unique partial index backstop;
     #     the fake has no await between the check and the insert). The continue_meeting (reused-
     #     terminal-row) path reopens an existing row and is unchanged.
+    # 2d. Per-identity serialization (#725 C2): one stored session = one live bot. Refuse a
+    #     second concurrent authenticated spawn against the same userdata path with a typed 409
+    #     naming the conflicting meeting. Control-plane pre-check against the tracked active set
+    #     (the issue's default); it runs just before the row insert, so the remaining window is a
+    #     single request interleaving — the storage-side lock fork stays available if a multi-
+    #     replica deployment ever witnesses it.
+    if authenticated and auth_userdata_path:
+        conflict = await repo.find_active_by_userdata(auth_userdata_path)
+        if conflict is not None and (reused_row is None or conflict["id"] != reused_row["id"]):
+            log_event(
+                "bot_spawn_auth_session_busy", audience="user", level="warning",
+                span="bots.create", user_id=user_id,
+                fields={"conflicting_meeting_id": conflict["id"]},
+            )
+            raise AuthSessionBusy(conflict["id"], auth_userdata_path)
+
     if reused_row is not None:
         # continue_meeting reopens an EXISTING terminal row (no new active row inserted), so it is not
         # part of the fresh-insert TOCTOU window — but the per-user cap still applies (a continued run
@@ -234,6 +280,9 @@ async def request_bot(
             meeting_data["constructed_meeting_url"] = constructed_url
         meeting_data["transcribe_enabled"] = transcribe_enabled
         meeting_data["recording_enabled"] = recording_enabled
+        # The serialization key for authenticated spawns — find_active_by_userdata matches on it.
+        if authenticated and auth_userdata_path:
+            meeting_data["auth_userdata_path"] = auth_userdata_path
         # Per-user webhook config carried on the meeting (delivered by the lifecycle callback). These
         # are stripped from any outbound meeting projection (webhooks.delivery._INTERNAL_DATA_KEYS).
         if webhook_url:
@@ -298,6 +347,12 @@ async def request_bot(
         recording_enabled=recording_enabled,
         capture_modes=(["audio", "video"] if recording_enabled else None),
         recording_upload_url=f"{meeting_api_url}/internal/recordings/upload",
+        authenticated=True if authenticated else None,
+        userdata_s3_path=auth_userdata_path,
+        s3_endpoint=auth_s3.get("s3_endpoint"),
+        s3_bucket=auth_s3.get("s3_bucket"),
+        s3_access_key=auth_s3.get("s3_access_key"),
+        s3_secret_key=auth_s3.get("s3_secret_key"),
         # A human-in-the-loop dashboard join needs a forgiving lobby window so a late admit does not
         # fail the meeting; everyoneLeftTimeout matches the O6 config.
         automatic_leave={"waitingRoomTimeout": 600000, "everyoneLeftTimeout": 900000},

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -140,6 +140,68 @@
    ]
   },
   {
+   "key": "BOT_AUTHENTICATED",
+   "class": "defaulted",
+   "default": "false",
+   "description": "deployment-scoped authenticated-bot knob: when true, EVERY POST /bots spawn carries the invocation.v1 auth block so the bot restores the provisioned browser session (make login) and joins signed-in. Demands the BOT_USERDATA_S3_PATH + BOT_S3_* keys — incomplete config answers a typed 503 (never a silent anonymous join).",
+   "targets": [
+    "compose",
+    "helm"
+   ]
+  },
+  {
+   "key": "BOT_USERDATA_S3_PATH",
+   "class": "defaulted",
+   "default": "(unset — required when BOT_AUTHENTICATED=true; the userdata prefix holding the provisioned session, e.g. userdata/bot-identity-1)",
+   "description": "stored-session prefix; also the per-identity serialization key (one live authenticated bot per prefix)",
+   "targets": [
+    "compose",
+    "helm"
+   ]
+  },
+  {
+   "key": "BOT_S3_ENDPOINT",
+   "class": "defaulted",
+   "default": "(unset — required when BOT_AUTHENTICATED=true)",
+   "description": "userdata store endpoint, as reachable FROM the bot containers (e.g. http://minio:9000)",
+   "targets": [
+    "compose",
+    "helm"
+   ]
+  },
+  {
+   "key": "BOT_S3_BUCKET",
+   "class": "defaulted",
+   "default": "(unset — required when BOT_AUTHENTICATED=true)",
+   "description": "userdata store bucket",
+   "targets": [
+    "compose",
+    "helm"
+   ]
+  },
+  {
+   "key": "BOT_S3_ACCESS_KEY",
+   "class": "defaulted",
+   "default": "(unset)",
+   "secret": true,
+   "description": "SCOPED userdata-store access key — never the deployment's admin S3 credentials; rides the invocation env into the bot container, so its blast radius must be the userdata prefix only",
+   "targets": [
+    "compose",
+    "helm"
+   ]
+  },
+  {
+   "key": "BOT_S3_SECRET_KEY",
+   "class": "defaulted",
+   "default": "(unset)",
+   "secret": true,
+   "description": "scoped userdata-store secret key (see BOT_S3_ACCESS_KEY)",
+   "targets": [
+    "compose",
+    "helm"
+   ]
+  },
+  {
    "key": "MINIO_ENDPOINT",
    "class": "defaulted",
    "default": "minio:9000",
@@ -326,7 +388,11 @@
    "class": "defaulted",
    "default": "(unset — calendar sync no-ops and the auto-join sweep cannot resolve the per-user cap, so it fails closed and refuses to spawn unless AUTO_JOIN_ALLOW_UNCAPPED=1)",
    "description": "admin-api base URL for the internal edges the background sweeps call (/internal/users/{id}/bot-context, /internal/calendar-configs). Required on every deploy surface so calendar sync runs and auto-join spawns stay capped (#656).",
-   "targets": ["compose", "helm", "lite"]
+   "targets": [
+    "compose",
+    "helm",
+    "lite"
+   ]
   },
   {
    "key": "AUTO_JOIN_SWEEP_INTERVAL_S",

--- a/core/meetings/services/meeting-api/tests/test_authenticated_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_authenticated_spawn.py
@@ -1,0 +1,139 @@
+"""Authenticated-bot spawn wiring (#724 C2) + per-identity serialization (#725 C2).
+
+Drives the SHIPPED ``request_bot`` over the in-memory fakes, offline. The deployment-scoped
+``BOT_AUTHENTICATED`` knob makes every stock ``POST /bots`` spawn carry the sealed invocation.v1
+auth block; without the knob the invocation carries none of it (the anonymous flow untouched).
+Config gaps refuse loud (503-shaped) before any DB write; a second concurrent spawn against the
+same stored session is refused with a typed 409 naming the conflicting meeting.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from meeting_api.bot_spawn import build_invocation, mint_meeting_token, request_bot
+from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
+from meeting_api.bot_spawn.invocation import conforms_invocation
+from meeting_api.bot_spawn.ports import AuthSessionBusy, AuthSessionNotConfigured
+
+SECRET = "test-admin-token"
+USER = 7
+
+AUTH_FIELDS = ("authenticated", "userdataS3Path", "s3Endpoint", "s3Bucket", "s3AccessKey", "s3SecretKey")
+
+
+def _set_auth_env(monkeypatch, **overrides):
+    env = {
+        "BOT_AUTHENTICATED": "true",
+        "BOT_USERDATA_S3_PATH": "userdata/bot-identity-1",
+        "BOT_S3_ENDPOINT": "http://minio:9000",
+        "BOT_S3_BUCKET": "vexa",
+        "BOT_S3_ACCESS_KEY": "userdata-key",
+        "BOT_S3_SECRET_KEY": "userdata-secret",
+        "TRANSCRIPTION_SERVICE_URL": "https://stt.vexa.ai",
+        "TRANSCRIPTION_SERVICE_TOKEN": "tok-test",
+    }
+    env.update(overrides)
+    for k, v in env.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+
+
+async def _spawn(repo, runtime, native_id="abc-defg-hij"):
+    return await request_bot(
+        repo, runtime, user_id=USER, platform="google_meet",
+        native_meeting_id=native_id, bot_name="VexaBot",
+        redis_url="redis://redis:6379/0", meeting_api_url="http://meeting-api:8080",
+        token_secret=SECRET,
+    )
+
+
+# ── unit: build_invocation carries the sealed auth block ─────────────────────────────────────────
+
+def test_build_invocation_carries_auth_block():
+    token = mint_meeting_token(1, USER, "google_meet", "abc-defg-hij", secret=SECRET)
+    base = dict(meeting_id=1, platform="google_meet",
+                meeting_url="https://meet.google.com/abc-defg-hij", bot_name="VexaBot",
+                token=token, native_meeting_id="abc-defg-hij", connection_id="conn-1",
+                redis_url="redis://redis:6379/0")
+    inv = build_invocation(**base, authenticated=True, userdata_s3_path="userdata/id-1",
+                           s3_endpoint="http://minio:9000", s3_bucket="vexa",
+                           s3_access_key="k", s3_secret_key="s")
+    conforms_invocation(inv)
+    assert inv["authenticated"] is True
+    assert inv["userdataS3Path"] == "userdata/id-1"
+    assert inv["s3Endpoint"] == "http://minio:9000"
+    assert inv["s3Bucket"] == "vexa"
+    # negative control: without the params, NO auth field ships (None-stripped).
+    plain = build_invocation(**base)
+    assert not any(f in plain for f in AUTH_FIELDS)
+
+
+# ── flow: the deployment knob populates every spawn ──────────────────────────────────────────────
+
+async def test_knob_populates_stock_post_bots_spawn(monkeypatch):
+    _set_auth_env(monkeypatch)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    await _spawn(repo, runtime)
+    inv = json.loads(runtime.specs[0]["env"]["VEXA_BOT_CONFIG"])
+    conforms_invocation(inv)
+    assert inv["authenticated"] is True
+    assert inv["userdataS3Path"] == "userdata/bot-identity-1"
+    assert inv["s3AccessKey"] == "userdata-key"
+    assert inv["s3SecretKey"] == "userdata-secret"
+
+
+async def test_knob_off_ships_no_auth_fields(monkeypatch):
+    """Base control: without the knob the invocation is the anonymous shape — zero auth fields."""
+    _set_auth_env(monkeypatch, BOT_AUTHENTICATED=None)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    await _spawn(repo, runtime)
+    inv = json.loads(runtime.specs[0]["env"]["VEXA_BOT_CONFIG"])
+    assert not any(f in inv for f in AUTH_FIELDS)
+
+
+async def test_incomplete_config_refuses_before_any_db_write(monkeypatch):
+    _set_auth_env(monkeypatch, BOT_S3_BUCKET=None)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    with pytest.raises(AuthSessionNotConfigured):
+        await _spawn(repo, runtime)
+    assert repo._meetings == {}          # refused BEFORE the meeting-row insert
+    assert runtime.specs == []           # nothing spawned
+
+
+# ── per-identity serialization (#725 C2): one stored session, one live bot ───────────────────────
+
+async def test_second_concurrent_authenticated_spawn_refused(monkeypatch):
+    _set_auth_env(monkeypatch)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    first = await _spawn(repo, runtime, native_id="aaa-aaaa-aaa")
+    with pytest.raises(AuthSessionBusy) as exc:
+        await _spawn(repo, runtime, native_id="bbb-bbbb-bbb")   # different meeting, same identity
+    assert exc.value.conflicting_meeting_id == first["id"]      # refusal names the conflict
+    assert str(first["id"]) in str(exc.value)
+    assert len(runtime.specs) == 1                              # exactly one bot ran
+
+
+async def test_terminal_meeting_releases_the_identity(monkeypatch):
+    """Negative control: once the first meeting is terminal, the next spawn proceeds — the
+    serialization gate holds only while the session is actually in use."""
+    _set_auth_env(monkeypatch)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    first = await _spawn(repo, runtime, native_id="aaa-aaaa-aaa")
+    repo._meetings[first["id"]]["status"] = "completed"
+    second = await _spawn(repo, runtime, native_id="bbb-bbbb-bbb")
+    assert second["id"] != first["id"]
+    assert len(runtime.specs) == 2
+
+
+async def test_anonymous_spawns_do_not_serialize(monkeypatch):
+    """Anonymous flow untouched: with the knob off, concurrent spawns of different meetings
+    never hit the identity gate."""
+    _set_auth_env(monkeypatch, BOT_AUTHENTICATED=None)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    await _spawn(repo, runtime, native_id="aaa-aaaa-aaa")
+    await _spawn(repo, runtime, native_id="bbb-bbbb-bbb")
+    assert len(runtime.specs) == 2

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -93,6 +93,15 @@ TRANSCRIPTION_MODEL=
 # capture-only bots that transcribed nothing with no error — the v0.12.5 witness bug.)
 TRANSCRIBE_ENABLED=
 RECORDING_ENABLED=
+# Authenticated-bot mode (deployment-scoped; docs: /authenticated-bots). BOT_AUTHENTICATED=true
+# makes every spawned bot restore the provisioned browser session (make login) and join signed-in.
+# BOT_S3_* are SCOPED userdata-store credentials — never the deployment's admin S3 creds.
+BOT_AUTHENTICATED=
+BOT_USERDATA_S3_PATH=
+BOT_S3_ENDPOINT=
+BOT_S3_BUCKET=
+BOT_S3_ACCESS_KEY=
+BOT_S3_SECRET_KEY=
 BOT_SPEAKER_MIN_AUDIO_SEC=
 BOT_SPEAKER_SUBMIT_INTERVAL_SEC=
 BOT_SPEAKER_CONFIRM_THRESHOLD=

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -314,6 +314,16 @@ services:
       # capture-only bots instead of 503-ing every default POST /bots.
       - TRANSCRIBE_ENABLED=${TRANSCRIBE_ENABLED:-true}
       - RECORDING_ENABLED=${RECORDING_ENABLED:-true}
+      # Authenticated-bot mode (deployment-scoped): when true, every spawned bot restores the
+      # provisioned browser session (make login) from the userdata store and joins signed-in.
+      # BOT_S3_* are SCOPED userdata credentials — never the deployment's admin S3 creds.
+      # Docs: /authenticated-bots.
+      - BOT_AUTHENTICATED=${BOT_AUTHENTICATED:-false}
+      - BOT_USERDATA_S3_PATH=${BOT_USERDATA_S3_PATH:-}
+      - BOT_S3_ENDPOINT=${BOT_S3_ENDPOINT:-}
+      - BOT_S3_BUCKET=${BOT_S3_BUCKET:-}
+      - BOT_S3_ACCESS_KEY=${BOT_S3_ACCESS_KEY:-}
+      - BOT_S3_SECRET_KEY=${BOT_S3_SECRET_KEY:-}
       # Self-hosted Jitsi hostnames (comma-separated) recognized in pasted + calendar links.
       - VEXA_JITSI_HOSTS=${VEXA_JITSI_HOSTS:-}
       - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -98,6 +98,19 @@ spec:
               value: {{ .Values.meetingApi.minioSecure | default "false" | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.meetingApi.logLevel | default "info" | quote }}
+            # Authenticated-bot mode (deployment-scoped) — docs: /authenticated-bots.
+            - name: BOT_AUTHENTICATED
+              value: {{ .Values.meetingApi.botAuthenticated | default "false" | quote }}
+            - name: BOT_USERDATA_S3_PATH
+              value: {{ .Values.meetingApi.botUserdataS3Path | default "" | quote }}
+            - name: BOT_S3_ENDPOINT
+              value: {{ .Values.meetingApi.botS3Endpoint | default "" | quote }}
+            - name: BOT_S3_BUCKET
+              value: {{ .Values.meetingApi.botS3Bucket | default "" | quote }}
+            - name: BOT_S3_ACCESS_KEY
+              value: {{ .Values.meetingApi.botS3AccessKey | default "" | quote }}
+            - name: BOT_S3_SECRET_KEY
+              value: {{ .Values.meetingApi.botS3SecretKey | default "" | quote }}
             {{- with .Values.meetingApi.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -177,6 +177,15 @@ meetingApi:
     type: ClusterIP
     port: 8080
   transcriptionServiceUrl: ""   # STT endpoint the spawned bot transcribes against (empty ⇒ capture only)
+  # Authenticated-bot mode (deployment-scoped; docs: /authenticated-bots): botAuthenticated "true"
+  # makes every spawned bot restore the provisioned browser session and join signed-in. The BOT_S3
+  # values are SCOPED userdata-store credentials, never the deployment's admin S3 creds.
+  botAuthenticated: "false"
+  botUserdataS3Path: ""
+  botS3Endpoint: ""
+  botS3Bucket: ""
+  botS3AccessKey: ""
+  botS3SecretKey: ""
   minioSecure: "false"
   logLevel: "info"
   resources:

--- a/docs/changelog.d/724-auth-session-flow.md
+++ b/docs/changelog.d/724-auth-session-flow.md
@@ -1,0 +1,6 @@
+- **Authenticated bots: the user flow exists end to end (#724).** Provision a signed-in bot session
+  with one command (`make login` — sign in once, the session lands in the deployment's userdata
+  storage), then set `BOT_AUTHENTICATED=true` on meeting-api and every stock `POST /bots` spawns
+  signed-in under the account identity. A failed session restore is now a typed, attributed
+  `session-restore` error instead of an unattributed pre-launch death. See
+  [Authenticated bots](/authenticated-bots).

--- a/docs/changelog.d/725-session-writeback.md
+++ b/docs/changelog.d/725-session-writeback.md
@@ -1,0 +1,5 @@
+- **Authenticated bots: sessions survive use (#725).** The bot writes the rotated browser session
+  back to the userdata store on clean teardown, so the next spawn restores the freshest state
+  instead of a decaying snapshot; a second concurrent spawn against the same stored session is
+  refused with a 409 naming the conflict (one identity, one live bot). The session-lifetime levers
+  are documented on [Authenticated bots](/authenticated-bots).

--- a/docs/docs/authenticated-bots.mdx
+++ b/docs/docs/authenticated-bots.mdx
@@ -1,0 +1,143 @@
+---
+title: "Authenticated bots"
+description: "Run every bot signed in to a real account — provision a session once, spawn through the stock API, keep the session alive through use."
+---
+
+By default a Vexa bot joins **anonymously**: it knocks on the lobby under a guest name and a host
+admits it. Authenticated mode makes every bot join **signed in to a real account** instead — the
+participant list shows the account identity, and org-restricted meetings that refuse anonymous
+participants open to it. The flow is three parts: provision a session once, configure the
+deployment to spawn with it, and let normal use keep it alive.
+
+**Validated on Google Meet.** The mechanism is platform-agnostic (the session store never inspects
+a platform; the provisioner also knows Teams and Zoom sign-in surfaces), but Teams and Zoom
+authenticated joins ride the same setup and validate on their own waves. Zoom is expected to move
+to a server-side (RTMS) lane that would not need browser auth at all.
+
+## 1. Provision the session — `make login`
+
+Provisioning opens a browser, a human signs in **once**, and the session's auth-essential subset
+(~200 KB: cookies, local/session storage, login data, preferences — never cache or history) is
+uploaded to your deployment's userdata storage.
+
+```bash
+export BOT_USERDATA_S3_PATH=userdata/bot-identity-1   # a dedicated prefix per bot identity
+export BOT_S3_ENDPOINT=http://localhost:9000          # your deployment's MinIO/S3
+export BOT_S3_BUCKET=vexa
+export BOT_S3_ACCESS_KEY=...                          # SCOPED userdata credentials — see security
+export BOT_S3_SECRET_KEY=...
+
+make login          # AUTH_PLATFORM=google (default) | teams | zoom
+```
+
+The command opens the platform's sign-in page (headed on a desktop; inside a container, attach via
+the provisioning browser's VNC on `:6080`), waits for you to finish signing in, **confirms** the
+session (it only succeeds after a logged-in validation passes), then uploads. Aborting without
+signing in exits non-zero with the login verdict and leaves the storage prefix untouched.
+Prerequisite on the machine running it: the `aws` CLI (the bot image ships it; a desktop needs it
+installed).
+
+Use a **dedicated account** for the bot (a Workspace user like `notetaker@your-org.com`), never a
+personal one.
+
+## 2. Configure the deployment to spawn signed-in
+
+Authenticated mode is a **deployment property**: set it once on `meeting-api` and every stock
+`POST /bots` spawns signed-in — no per-request field, no hand-crafted bot config.
+
+```bash
+# meeting-api environment (compose: deploy/compose .env; helm: meeting-api env values)
+BOT_AUTHENTICATED=true
+BOT_USERDATA_S3_PATH=userdata/bot-identity-1
+BOT_S3_ENDPOINT=http://minio:9000        # as reachable FROM the bot containers
+BOT_S3_BUCKET=vexa
+BOT_S3_ACCESS_KEY=...
+BOT_S3_SECRET_KEY=...
+```
+
+With the knob set, each bot restores the stored session into its own ephemeral browser profile
+before launch and joins as the signed-in account — no guest-name entry, no lobby knock where the
+account has access. If the knob is set but the storage config is incomplete, `POST /bots` refuses
+with a 503 naming what's missing — a half-configured deployment never silently spawns anonymous
+bots. If the session store is unreachable at spawn time, the bot fails loud with a typed
+`session-restore` error naming the step and endpoint — it never joins signed-out on a failed
+restore.
+
+**One session, one bot at a time.** A second concurrent spawn against the same stored session is
+refused with a 409 naming the meeting that holds it. One live cookie jar used from N containers
+and IPs at once is a textbook account-risk signal to Google, and concurrent runs would race the
+write-back below. Need N concurrent authenticated bots? Provision N accounts under N
+`BOT_USERDATA_S3_PATH` prefixes (today that means N deployments of the spawn knob, one identity
+each).
+
+## 3. Session lifetime — the session stays alive because it is used
+
+Google rotates session cookies continuously during use and re-challenges state that looks stale.
+A stored session that is only ever *read* decays with every restore. Vexa therefore closes the
+round trip: **restore freshest → use → write back**. On every clean bot teardown, the rotated
+session is uploaded back to the userdata prefix, so the next spawn restores the freshest state
+instead of a decaying snapshot.
+
+The boundary, stated honestly: write-back runs on **clean teardown only**. A hard-killed bot
+(SIGKILL, node crash) never reaches it — the durable copy simply stays at the last successful
+write-back, and the next clean meeting refreshes it. A write-back failure is an attributed warning
+in the bot log, never a hang on exit.
+
+The levers that make session lifetime a configured property instead of luck:
+
+- **Workspace session-duration policy** — the biggest lever, pure configuration. In Google
+  Workspace Admin, set the bot account's OU session duration to the maximum (or "never expire").
+- **Stable egress and browser** — keep each identity on a stable egress IP and a stable bot image
+  version. An identity that hops IPs and browser fingerprints looks cloned.
+- **Keep-warm** — an idle identity decays on Google's clock. If the account doesn't meet regularly,
+  run a periodic authenticated meeting (or simply schedule the bot into a recurring internal
+  meeting) so rotation keeps happening. There is no packaged keep-warm job today; a cron'd
+  `POST /bots` into a standing meeting is the recipe.
+- **N accounts for N concurrent bots** — follows from the one-session-one-bot rule above.
+
+## When the session dies anyway — the recovery loop
+
+Eventually a session can decay past recovery (a Workspace policy change, a security challenge, a
+long idle gap). A bot restoring a signed-out session is reported as a failed meeting (the typed
+`auth_session_missing` verdict is landing with the signed-out detection change — until it merges,
+the failure surfaces as the join failing to proceed as the signed-in account; see
+[Troubleshooting](/troubleshooting#authenticated-bot-fails-or-joins-signed-out)). The fix is
+always the same one command:
+
+```bash
+make login    # re-provision; the next spawn picks the fresh session up automatically
+```
+
+If sessions die **soon after provisioning** rather than after weeks, don't just re-provision in a
+loop — check the lifetime levers above (is write-back running? one bot per session? stable
+egress?).
+
+## Storage layout and security
+
+```
+s3://<BOT_S3_BUCKET>/<BOT_USERDATA_S3_PATH>/browser-data/
+  Local State
+  Default/Cookies              ← the live credential material
+  Default/Login Data ...
+  Default/Local Storage/ ...
+  Default/Session Storage/ ...
+```
+
+- **The stored session IS a credential.** Anyone who can read the prefix can be the account.
+  Create **dedicated S3 credentials scoped to the userdata prefix** for `BOT_S3_ACCESS_KEY` /
+  `BOT_S3_SECRET_KEY` — never reuse the deployment's admin S3 credentials.
+- **The boundary, stated honestly:** the S3 credentials ride the bot's invocation into the bot
+  container's environment (that is how the bot restores and writes back). Anyone with `docker
+  inspect` on the bot host, or read access to the runtime API, can see them — which is exactly why
+  they must be scoped to the userdata prefix and nothing else. Secret *values* are never printed
+  in bot logs.
+- The session subset is not otherwise encrypted at rest beyond what your S3/MinIO deployment
+  provides.
+
+## Availability by deployment surface
+
+- **Compose** — supported as above; MinIO is in the stack.
+- **Kubernetes/Helm** — set the same `BOT_AUTHENTICATED` / `BOT_*` env on the meeting-api
+  deployment (values → env); point the S3 vars at storage the bot pods can reach.
+- **Lite** — the single-container build does not package a userdata store or the provisioning
+  flow; authenticated mode is not available on Lite today.

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -93,6 +93,7 @@
           "deployment",
           "deployment-kubernetes",
           "configuration",
+          "authenticated-bots",
           "model-credentials-licensing",
           "security-compliance",
           "troubleshooting",

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -23,6 +23,25 @@ curl -H "X-API-Key: $API_KEY" "$API_BASE/bots/status"
 - **Concurrency cap** — a user can run at most `max_concurrent_bots` bots at once (set when the user was
   created). Stop an existing bot or raise the cap.
 
+## Authenticated bot fails or joins signed-out
+
+Applies only to deployments with `BOT_AUTHENTICATED=true` (see
+[Authenticated bots](/authenticated-bots)).
+
+- **`session-restore` failure at spawn** — the bot could not download the stored session (wrong
+  `BOT_S3_ENDPOINT`, bad scoped credentials, or the `aws` CLI missing from a custom image). The bot
+  log names the step and endpoint; the meeting fails rather than joining signed-out. Fix the config
+  and respawn.
+- **503 on `POST /bots`** — `BOT_AUTHENTICATED` is set but `BOT_USERDATA_S3_PATH` /
+  `BOT_S3_ENDPOINT` / `BOT_S3_BUCKET` are incomplete. The error names what is missing.
+- **409 "authenticated session in use"** — one stored session runs one bot at a time; the message
+  names the meeting holding it. Wait for it to finish, stop it, or provision another identity.
+- **The session decayed (signed-out on join)** — re-provision with `make login`; the next spawn
+  picks the fresh session up automatically. If this fires soon after provisioning rather than
+  after weeks of use, check write-back and the
+  [session-lifetime levers](/authenticated-bots#3-session-lifetime--the-session-stays-alive-because-it-is-used)
+  instead of re-provisioning in a loop.
+
 ## A scheduled meeting didn't auto-join
 
 Auto-join sends the bot ~60 s before the scheduled time (see

--- a/docs/views/architecture.dsl
+++ b/docs/views/architecture.dsl
@@ -35,6 +35,7 @@ system meetings  # capture → transcribe → record; owns the raw transcript
   data-asset bot-commands [writers: meeting-api]
   database segments-table [writers: meeting-api]
   data-asset recording-blob [writers: bot, meeting-api]
+  data-asset userdata-blob [writers: remote-browser, bot]
 
 system agent  # copilot; owns the processed (cleaned) transcript + signals
   service agent-api
@@ -92,6 +93,8 @@ edges:
   terminal -read-> proc-stream
   terminal -read-> out-stream
   bot -write-> recording-blob
+  bot -read-write-> userdata-blob  # restore session before launch (read) + write rotated session back on clean teardown (write)
+  remote-browser -write-> userdata-blob  # provisioning login uploads the confirmed signed-in session
   gateway -read-> recording-blob
   bot -call-> transcription  # audio -> first-party STT via TRANSCRIPTION_SERVICE_URL
   bot -read-> bot-commands  # SUBSCRIBE acts.v1 commands

--- a/docs/views/ownership.mmd
+++ b/docs/views/ownership.mmd
@@ -9,6 +9,8 @@ flowchart LR
   segments_table[("transcription_segments (table)")]
   recording_blob[("recordings bucket (blob)")]
   style recording_blob stroke-dasharray: 5 5,stroke-width:3px
+  userdata_blob[("userdata bucket (blob)")]
+  style userdata_blob stroke-dasharray: 5 5,stroke-width:3px
   bm_status[("bm:meeting:{id}:status (pubsub)")]
   u_meetings[("u:{user}:meetings (pubsub)")]
   bot_commands[("bot_commands:meeting:{id} (pubsub)")]
@@ -27,6 +29,8 @@ flowchart LR
   terminal -.->|read| proc_stream
   terminal -.->|read| out_stream
   bot -->|write| recording_blob
+  bot -.->|read-write| userdata_blob
+  remote_browser -->|write| userdata_blob
   gateway -.->|read| recording_blob
   bot -.->|read| bot_commands
   meeting_api -->|write| bm_status


### PR DESCRIPTION
One branch for both issues — they share the teardown surface (`session-store.ts` + `capture-bridge.ts` close()); two PRs would self-collide.

## Mechanism

- **#724 C1 (provision):** `make login` → `@vexa/remote-browser` `src/provision-cli.ts`: `provisionLogin` + `validateLoggedIn` gate success, then `syncBrowserDataToS3` uploads the auth-essential subset to `BOT_USERDATA_S3_PATH`. Abort/timeout → exit 1 with the login verdict, prefix untouched; a zero-item upload is also exit 1.
- **#724 C2 (knob, Q1-A deployment-scoped):** `BOT_AUTHENTICATED` + `BOT_USERDATA_S3_PATH` + `BOT_S3_{ENDPOINT,BUCKET,ACCESS_KEY,SECRET_KEY}` on meeting-api → `request_bot` populates the six **already-sealed** invocation.v1 auth fields on every stock `POST /bots` (zero api.v1/contract change, no re-stamp needed). Incomplete config → typed 503 (`AuthSessionNotConfigured`) before any DB write. Wired into compose (`docker-compose.yml` + `.env.example`), helm (`deployment-meeting-api.yaml` + values), config.v1 declared; Lite excluded and documented honestly.
- **#724 C3 (restore integrity, Q2 = aws CLI, smallest diff):** `awscli` added to the bot image runtime stage; the restore `execSync` is guarded → typed `SessionSyncError('session-restore')` naming step + endpoint (+ names a missing aws CLI); the bot's launch-failure path drives it to a clean terminal failed. An authenticated bot never silently joins signed-out on a failed restore.
- **#725 C1 (write-back):** `syncBrowserDataToS3(config, dataDir)` (symmetry with the restore half); `BrowserSession.close()` uploads from the live ephemeral dir after `context.close()` flushes, before `removeProfileDir`. Q1-A: clean-teardown only, SIGKILL boundary stated in code + docs. Failures are attributed warnings, bounded per call.
- **#725 C2 (serialization):** control-plane pre-check `find_active_by_userdata` (fake + SQLAlchemy JSONB adapter); second concurrent authenticated spawn → typed 409 `AuthSessionBusy` naming the conflicting meeting. `auth_userdata_path` recorded in `meeting.data` as the key.
- **Docs (#724 C4 + #725 C3):** new `/authenticated-bots` page (provisioning, knob, storage layout + security boundary stated honestly, recovery loop, session-lifetime levers incl. Workspace session-duration, stable egress, keep-warm Q3-A document-only, N-accounts rule), troubleshooting section, two changelog fragments. `architecture.calm.json`: `userdata-blob` data-asset (writers: remote-browser=provision, bot=write-back) — resealed (`pnpm seal:arch`), views regenerated.

## Observation bundle — #724 acceptance table

| # | Status | Evidence |
|---|---|---|
| A1 | **partial (offline half)** | CLI gate proven by code path: `provisionLogin` not-loggedIn → exit 1, no upload call (provision-cli.ts). Live throwaway-account run + `s3 ls` before/after: **not run** (no live leg this session) — named below. |
| A2 | **wiring proven offline; live leg pending** | `tests/test_authenticated_spawn.py::test_knob_populates_stock_post_bots_spawn` — stock `request_bot` under the knob emits a conforming invocation with all six sealed fields. Negative control `test_knob_off_ships_no_auth_fields` (base shape: zero auth fields). Live Meet signed-in join: **not run**. |
| A3 | **blocked on #607** | `auth_session_missing` does not exist on main — PR #607 is still OPEN (issue said "merge it first"). Restore-failure and decay currently surface as the typed `session-restore` error / join failure; the docs page + troubleshooting cross-reference the pending verdict. |
| A4 | **green (offline)** | `session-store.test.ts`: failing download → `SessionSyncError` with `step='session-restore'` naming the endpoint; missing aws CLI named explicitly. Base control: unguarded `execSync` death (old code path, test would be red on main — `SessionSyncError` doesn't exist there). |
| A5 | **green (static)** | Secret values never logged: sync logs print paths/endpoints only, `stdio:'pipe'` on uploads; creds cross via env not argv. Docs security note ships (scoped creds; invocation-env visibility boundary stated). |
| A- | **green** | `node scripts/gates.mjs all` → ✅ gates green (incl. gate:python 12 pkgs, gate:node 18 pkgs, config-contract, licenses, dataflow/calm on the resealed model). |

## Observation bundle — #725 acceptance table

| # | Status | Evidence |
|---|---|---|
| A1 | **mechanism landed; live etag witness pending** | Write-back call in `close()` (clean teardown, post-flush, pre-remove). Live before/after `s3 ls` etag delta: **not run**. |
| A2 | **green (offline)** | `session-store.test.ts`: fake-`aws`-on-PATH records invocations — all uploads read from the handed `dataDir` (base control: base code reads `BROWSER_DATA_DIR`, red by construction); mutated `Default/Cookies` among uploads; all-failing uploads return 0 and never throw (teardown safety). |
| A3 | **green (offline)** | `test_second_concurrent_authenticated_spawn_refused`: two same-identity spawns → exactly one runs, 409-typed refusal names the conflicting meeting id. Negative controls: terminal meeting releases the identity; anonymous spawns never serialize. |
| A4 | **not started** | The ≥7-day longevity witness needs the deployed flow live — the declared human bar, below. |
| A5 | **green** | Lifetime-levers docs section ships on `/authenticated-bots` (+ "fires soon after provisioning → check write-back/serialization" troubleshooting line). Q3 decision (A, document-only) to be recorded on #725. |
| A- | **green** | Same gate run as above; anonymous-flow spawn tests all pass (47 passed across bot_spawn/max_bots/continue_meeting/authenticated). |

## Explicitly NOT checked (the remaining human bar)

- **The live authenticated-join leg** (the issues' Solo-meeting bar on compose): `make login` against a real throwaway Google account, a live Meet join showing the account identity, the A1/#725-A1 `s3 ls` etag deltas, and the #725-A4 ≥7-day longevity witness. Docker was unavailable on the dev machine this session, so **the bot image rebuild with `awscli` is also unverified** (apt package availability on the `meet-join-env` base is asserted, not witnessed) — first `make bot` will prove it.
- Whether the `meet-join-env` base already ships an aws CLI (issue flagged as check-at-claim; could not check — image not pullable this session).
- Helm: template renders with the new env entries (helm binary not exercised here; the helm test suite wasn't run locally).
- #724 A3's typed `auth_session_missing` end-to-end — blocked on #607 merging; rebase-and-verify once it lands.

## Findings / deviations

- All `file:line` claims in both prepared specs verified against `main @ 702a365a` — no wrong claims found.
- **#607 is not merged** although #724 says "merge it first — A3 depends on it". Delivered without it; the decay verdict integration is a follow-up rebase, not a blocker for the provisioning/write-back mechanism.
- Pre-existing local test failure: `tests/test_calendar_sync.py` (31 fails, `ModuleNotFoundError: icalendar`) fails identically on a clean main checkout — environmental, not introduced here; the gate suite's own python lane is green.

Refs #724, Refs #725
