### PR TITLE
sec(deps): adm-zip >=0.6.0 via override — Dependabot high closed at the resolution layer (#773)

### DIFF
--- a/docs/changelog.d/773-adm-zip-override.md
+++ b/docs/changelog.d/773-adm-zip-override.md
@@ -1,0 +1,4 @@
+- **Security floor: adm-zip bumped to 0.6.0 via pnpm override (#773).** Closes Dependabot high
+  GHSA-xcpc-8h2w-3j85 (crafted-ZIP 4 GB allocation in adm-zip <0.6.0), which rode in through
+  onnxruntime-node's install-time unpack under `@vexa/mixed-pipeline`. Exposure was
+  postinstall-only, but the resolution layer now excludes the vulnerable range entirely.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss@<8.5.10: '>=8.5.10'
+  adm-zip@<0.6.0: '>=0.6.0'
 
 importers:
 
@@ -1693,9 +1694,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -4205,7 +4206,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -5427,13 +5428,13 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 
   onnxruntime-node@1.26.0:
     dependencies:
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       global-agent: 4.1.3
       onnxruntime-common: 1.26.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,6 @@ allowBuilds:
 # API-compatible. clients/terminal/package.json carries the same floor for its npm lockfile.
 overrides:
   "postcss@<8.5.10": ">=8.5.10"
+  # Security floor (GHSA-xcpc-8h2w-3j85): crafted-ZIP 4 GB allocation in adm-zip <0.6.0,
+  # reached only in onnxruntime-node's postinstall unpack of its own runtime archive.
+  "adm-zip@<0.6.0": ">=0.6.0"


### PR DESCRIPTION
Refs #773

## What
pnpm override `"adm-zip@<0.6.0": ">=0.6.0"` in `pnpm-workspace.yaml` (the repo's existing override idiom, alongside the postcss floor — note pnpm 11 ignores `pnpm.overrides` in package.json, so the workspace file is the only working location). Lockfile regenerated; changelog fragment `docs/changelog.d/773-adm-zip-override.md`.

## Observation bundle (issue #773 acceptance mapped)

**1. Alert 181 vulnerable range excluded (fixed path, not dismissal)**
- Advisory GHSA-xcpc-8h2w-3j85, `gh api .../dependabot/alerts/181`: vulnerable range `< 0.6.0`, first patched `0.6.0` (published on npm — `npm view adm-zip version` → `0.6.0`).
- Before: `pnpm why adm-zip` →
  ```
  adm-zip@0.5.17
  ├─┬ onnxruntime-node@1.24.3 └─┬ @huggingface/transformers@4.2.0 └── @vexa/mixed-pipeline@0.1.0
  └─┬ onnxruntime-node@1.26.0 └── @vexa/mixed-pipeline@0.1.0
  ```
- After: same chains, `adm-zip@0.6.0` — `Found 1 version of adm-zip`; lockfile carries `adm-zip@0.6.0` only. Alert closes automatically when Dependabot rescans the merged lock.

**2. mixed-pipeline suite green on the bumped lock**
- `pnpm install` clean; `pnpm rebuild -r onnxruntime-node` → both postinstalls (1.24.3, 1.26.0) `Done` unpacking with adm-zip 0.6.0.
- `pnpm --filter @vexa/mixed-pipeline test` → all 11 test files pass (confirm-loop golden through short-ui-switch smoke).

**3. gate:licenses unaffected + full gates**
- `node scripts/gates.mjs all` → `✅ gates green`; gate:licenses: 460 deps OSS-clean (adm-zip is MIT, Cat A).

**4. Release-notes line**
- Fragment `docs/changelog.d/773-adm-zip-override.md` — folded at the next release cut.

**Not checked**: no live-meeting leg — the change is resolution-layer only; runtime code paths are covered by the model-free mixed-pipeline goldens above.