### PR TITLE
fix(meeting-api): POST /bots derives native_meeting_id from meeting_url or refuses typed 422 — no more orphan meetings (#792)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 import ipaddress
 import os
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from ..collector.meeting_link import parse_meeting_url
 from .env_flags import env_flag
 from .ports import (
     AuthSessionBusy,
@@ -157,6 +158,21 @@ def _resolve_max_concurrent(x_user_limits: Optional[str]) -> Optional[int]:
     return None
 
 
+def _passcode_from_url(meeting_url: str) -> Optional[str]:
+    """The passcode a meeting URL itself carries — zoom's ``?pwd=`` / teams' ``?p=`` query param.
+    Consulted only on the derive path (url-only body) and only when the body sent no explicit
+    ``passcode``; anything else returns None."""
+    try:
+        query = parse_qs(urlparse(meeting_url).query)
+    except Exception:
+        return None
+    for key in ("pwd", "p"):
+        values = query.get(key)
+        if values and values[0]:
+            return values[0]
+    return None
+
+
 def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
     """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` ports."""
     router = APIRouter()
@@ -196,6 +212,36 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
         # (zoom/jitsi) — validate at the point of entry (SSRF hygiene, 422 on violation).
         if meeting_url is not None:
             meeting_url = _validate_meeting_url(meeting_url)
+        passcode = body.get("passcode")
+        # api.v1 promise: a meeting_url provided WITHOUT native_meeting_id is parsed to extract
+        # platform, native_meeting_id, and passcode (collector.meeting_link — the same parser the
+        # planned-meeting routes use). An underivable URL is a typed 422, NEVER a persisted ''
+        # key: (platform, native_meeting_id) is the only user-facing address for stop/transcripts,
+        # so an empty id would be a 201 that creates a meeting no API call can reach again.
+        # Runs AFTER the SSRF validator (derivation never bypasses the URL guard) and only when
+        # the explicit id is absent — a supplied native_meeting_id is authoritative.
+        if not native_meeting_id and meeting_url:
+            derived = parse_meeting_url(meeting_url)
+            if derived is None:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "'native_meeting_id' is required: it could not be derived from "
+                        f"meeting_url '{meeting_url}' (unrecognized meeting link)"
+                    ),
+                )
+            derived_platform, native_meeting_id = derived
+            if platform and platform != derived_platform:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"platform '{platform}' disagrees with meeting_url "
+                        f"(which is a '{derived_platform}' link) — drop one or make them agree"
+                    ),
+                )
+            platform = derived_platform
+            if not passcode:
+                passcode = _passcode_from_url(meeting_url)
         if not platform or (not native_meeting_id and not meeting_url):
             raise HTTPException(
                 status_code=422,
@@ -225,7 +271,7 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
                 platform=platform,
                 native_meeting_id=native_meeting_id,
                 bot_name=body.get("bot_name"),
-                passcode=body.get("passcode"),
+                passcode=passcode,
                 meeting_url=meeting_url,
                 language=body.get("language"),
                 task=body.get("task"),

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -347,3 +347,123 @@ def test_post_bots_zoom_shares_meeting_url_guard(monkeypatch):
                        json={"platform": "zoom", "native_meeting_id": "123456",
                              "meeting_url": "https://192.168.1.10/j/123456"})
     assert r.status_code == 422, r.text
+
+
+# ── route: meeting_url-only bodies derive the addressing key, or refuse typed (#792) ─────────────
+#
+# api.v1's `meeting_url` description promises: "When provided without native_meeting_id, the URL is
+# parsed to extract platform, native_meeting_id, and passcode automatically." A url-only body must
+# therefore yield an ADDRESSABLE meeting (id derived via collector.meeting_link.parse_meeting_url)
+# or a typed 422 — never a 201 persisting native_meeting_id='' (the unaddressable orphan).
+
+def _spawn_env(monkeypatch):
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+
+
+def test_post_bots_url_only_derives_native_id(monkeypatch):
+    """Row 1: platform + meeting_url, no native id → 201 with the id derived from the URL."""
+    _spawn_env(monkeypatch)
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS,
+                           json={"platform": "google_meet",
+                                 "meeting_url": "https://meet.google.com/abc-defg-hij"})
+    assert r.status_code == 201, r.text
+    assert r.json()["native_meeting_id"] == "abc-defg-hij"
+    row = repo._meetings[1]
+    assert row["native_meeting_id"] == "abc-defg-hij"
+
+
+def test_post_bots_url_only_meeting_is_stop_addressable(monkeypatch):
+    """Row 2: a url-only spawn can be stopped via DELETE /bots/{platform}/{derived_id}."""
+    from fastapi import FastAPI
+
+    from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher, build_stop_router
+
+    _spawn_env(monkeypatch)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    app = FastAPI()
+    app.include_router(build_router(repo, runtime))
+    app.include_router(build_stop_router(repo, InMemoryCommandPublisher(), runtime))
+    client = TestClient(app)
+    assert client.post("/bots", headers=HEADERS,
+                       json={"platform": "google_meet",
+                             "meeting_url": "https://meet.google.com/abc-defg-hij"}).status_code == 201
+    r = client.delete("/bots/google_meet/abc-defg-hij", headers=HEADERS)
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "stopping"
+
+
+def test_post_bots_underivable_url_422_no_row(monkeypatch):
+    """Row 3: https URL that passes the SSRF guard but yields no id → typed 422, nothing persisted."""
+    _spawn_env(monkeypatch)
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS,
+                           json={"platform": "google_meet",
+                                 "meeting_url": "https://example.com/not-a-meet-link"})
+    assert r.status_code == 422, r.text
+    assert "native_meeting_id" in r.json()["detail"]
+    assert repo._meetings == {}  # never persist the '' orphan
+
+
+def test_post_bots_url_only_no_platform_derives_both(monkeypatch):
+    """Row 4: the report's literal body — meeting_url alone → platform AND id derived."""
+    _spawn_env(monkeypatch)
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS,
+                           json={"meeting_url": "https://meet.google.com/abc-defg-hij"})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["platform"] == "google_meet"
+    assert body["native_meeting_id"] == "abc-defg-hij"
+
+
+def test_post_bots_platform_url_mismatch_422(monkeypatch):
+    """Row 5: supplied platform disagrees with the URL-derived one → 422 naming both."""
+    _spawn_env(monkeypatch)
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS,
+                           json={"platform": "teams",
+                                 "meeting_url": "https://meet.google.com/abc-defg-hij"})
+    assert r.status_code == 422, r.text
+    detail = r.json()["detail"]
+    assert "teams" in detail and "google_meet" in detail
+    assert repo._meetings == {}
+
+
+def test_post_bots_url_only_jitsi_derives_room(monkeypatch):
+    """F2: jitsi derivation accepted — the room (+host scope) becomes the native id, URL rides along."""
+    _spawn_env(monkeypatch)
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS,
+                           json={"meeting_url": "https://meet.example.org/daily"})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["platform"] == "jitsi"
+    assert body["native_meeting_id"] == "daily@meet.example.org"
+
+
+def test_post_bots_url_only_derives_passcode(monkeypatch):
+    """F4: the contract sentence also promises passcode extraction — zoom ?pwd= rides into the
+    invocation when the body carries none."""
+    _spawn_env(monkeypatch)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    r = _client(repo, runtime).post("/bots", headers=HEADERS,
+                                    json={"meeting_url": "https://us02web.zoom.us/j/1234567890?pwd=sEcReT123"})
+    assert r.status_code == 201, r.text
+    assert r.json()["native_meeting_id"] == "1234567890"
+    inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
+    assert inv["passcode"] == "sEcReT123"
+
+
+def test_post_bots_explicit_native_id_unchanged_by_url(monkeypatch):
+    """Row 6 companion: an explicit native_meeting_id is NEVER overridden by the URL (derivation
+    only fills the gap; the valid 0.12 body is byte-identical)."""
+    _spawn_env(monkeypatch)
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS,
+                           json={"platform": "google_meet", "native_meeting_id": "xyz-explicit-id",
+                                 "meeting_url": "https://meet.google.com/abc-defg-hij"})
+    assert r.status_code == 201, r.text
+    assert repo._meetings[1]["native_meeting_id"] == "xyz-explicit-id"

--- a/docs/changelog.d/792-derive-native-id.md
+++ b/docs/changelog.d/792-derive-native-id.md
@@ -1,0 +1,8 @@
+- **`POST /bots` with only a `meeting_url` now derives the meeting id — no more orphan meetings
+  (#792).** A url-only body used to return 201 while persisting `native_meeting_id=''`, creating a
+  meeting (and a live bot) no `DELETE /bots/...` or `GET /transcripts/...` could ever address. The
+  API now honors what api.v1 always promised: the URL is parsed to extract `platform`,
+  `native_meeting_id`, and the passcode (Zoom `?pwd=` / Teams `?p=`); an unrecognizable URL is a
+  typed `422` naming the missing `native_meeting_id`, and a `platform` that disagrees with the URL
+  is a `422` too. Explicit `native_meeting_id` is never overridden. See
+  [Send a bot](/how-to/send-a-bot).

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -45,6 +45,20 @@ The only thing that changes between platforms is the `platform` value.
 
 `native_meeting_id` is the id **inside** the join URL (e.g. `abc-defg-hij` for Meet, the room name for
 Jitsi), not the whole URL.
+
+Have only the URL? Send `meeting_url` alone — the API parses it to extract `platform`,
+`native_meeting_id`, and (for Zoom/Teams links that embed one) the passcode:
+
+```bash
+curl -X POST "$API_BASE/bots" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"meeting_url":"https://meet.google.com/abc-defg-hij","bot_name":"Vexa"}'
+```
+
+A URL that isn't a recognizable meeting link is refused with a `422` naming the missing
+`native_meeting_id`; if you supply both `platform` and `meeting_url` and they disagree, that's a
+`422` too. An explicit `native_meeting_id` always wins — the URL never overrides it.
+
 Optional: `language` (ISO code) and `task` (`transcribe` default, or `translate`). Language works in
 two modes:
 


### PR DESCRIPTION
Refs #792. Implements the prepared mechanism exactly: derive-with-422-fallback at the router boundary (`bot_spawn/router.py`), composing the existing `collector/meeting_link.parse_meeting_url` — no contract edit; the code now honors the sealed api.v1 `meeting_url` description as written. F2 jitsi derivation accepted; F4 passcode taken (trivially available: `?pwd=`/`?p=` query params on the same URL); F3 per the maintainer ruling — one-shot ops cleanup documented below, not a reconciler rule.

## Observation bundle (issue #792's own numbering)

Red anchored at base `7cb43e93`, green at head `8ba07435`. Harness: `core/meetings/services/meeting-api` pytest (offline, `build_router` + `InMemoryMeetingRepo` + `FakeRuntimeClient`, `tests/test_bot_spawn.py`).

| Row | Test (tests/test_bot_spawn.py) | Red @ 7cb43e93 (raw) | Green @ 8ba07435 |
|---|---|---|---|
| 1 | `test_post_bots_url_only_derives_native_id` | 201, `assert '' == 'abc-defg-hij'` — response/row carried `native_meeting_id:""` | 201, response + persisted row `native_meeting_id='abc-defg-hij'` |
| 2 | `test_post_bots_url_only_meeting_is_stop_addressable` (build_router + build_stop_router over one repo) | DELETE cannot target — row keyed `''` (test red) | `DELETE /bots/google_meet/abc-defg-hij` → 200 `{"status":"stopping"}` |
| 3 | `test_post_bots_underivable_url_422_no_row` (`https://example.com/not-a-meet-link`, passes SSRF guard) | 201, orphan `''` row persisted | 422, detail names `native_meeting_id`; `repo._meetings == {}` |
| 4 | `test_post_bots_url_only_no_platform_derives_both` (the report's literal body) | 422 platform-required | 201, `platform='google_meet'` AND id derived |
| 5 | `test_post_bots_platform_url_mismatch_422` (`platform:'teams'` + gmeet URL) | 201 — persisted `{"platform":"teams","native_meeting_id":""}` (raw row in red run output) | 422 naming both `teams` and `google_meet`; nothing persisted |
| 6 | Negative control: `test_post_bots_201` (valid 0.12 body) + new `test_post_bots_explicit_native_id_unchanged_by_url` | green today | still green; explicit id never overridden by the URL |
| 7 | Negative control: SSRF guard block (`test_bot_spawn.py` jitsi/zoom 422 rows + hostname 201 control) | green today | still green — derivation runs after `_validate_meeting_url`, never bypasses it |
| 8 | Full meeting-api suite | green at base (in the gate env) | `node scripts/gates.mjs all` → all green incl. `gate:python — 12 package(s) · pytest green`; `tests/test_bot_spawn.py` 30 passed |
| 9 | F3 — existing `''`-keyed rows on hosted | count unknown (prod DB not queried, per PREPARE) | One-shot ops cleanup documented below; execution is the hosted ops lane, not this diff |

F2 evidence: `test_post_bots_url_only_jitsi_derives_room` — `https://meet.example.org/daily` → 201, `('jitsi','daily@meet.example.org')`, URL rides along (no reconstruct).
F4 evidence: `test_post_bots_url_only_derives_passcode` — zoom `?pwd=sEcReT123` lands in the invocation's `passcode` when the body carries none; an explicit body `passcode` wins.

## F3 one-shot cleanup (ops runbook, hosted lane)

After this fix no new `''` rows can be created. For rows already on hosted:

```sql
-- count first, record it in the attestation
SELECT count(*) FROM meetings WHERE native_meeting_id = '' AND status NOT IN ('completed','failed');
-- one-shot: terminalize the unaddressable orphans with an attributable reason
UPDATE meetings
   SET status = 'failed',
       completion_reason = 'ops_cleanup_792_unaddressable_empty_native_id',
       updated_at = now()
 WHERE native_meeting_id = '' AND status NOT IN ('completed','failed');
```

Delete any still-live bot workloads for those rows by their `bot_container_id` first (the row is only reapable by the sweep once the workload is gone).

## Not checked (explicit)

- The one-operator Lite-compose live run (row 1 + row 3 through the gateway hop) — the issue's declared human bar remains open; preferred signer is the originating reporter.
- Hosted prod count of orphan rows (row 9) — cleanup SQL provided, not executed.
- No live meeting was joined; all rows are the offline harness per the PREPARE's primary lane.
- Contract: `api.schema.json` untouched (IMPLEMENTED, not edited); `gate:contract-conformance` green with no re-stamp.

## Docs

- `docs/docs/how-to/send-a-bot.mdx` — url-only form documented as supported, with the 422 behaviors.
- `docs/changelog.d/792-derive-native-id.md` — per-PR fragment (docs-current touch).

Attestation: sha `8ba07435`, offline harness + full gate suite, long-lived checkout worktree (`vexa-792` from `origin/main@7cb43e93`), no env deltas beyond the tests' own monkeypatched vars.