### PR TITLE
ci(release): #583 residual — page-brick list single-sourced (gate:page-bricks) + guarded make release-retag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Vexa open-core — top-level deploy entrypoint (Docker Compose)
 # =============================================================================
-.PHONY: all up dev down bot lite probe login help
+.PHONY: all up dev down bot lite probe login release-retag help
 
 SURFACE ?= compose
 
@@ -35,3 +35,6 @@ login:               ## provision an authenticated-bot session — sign in once,
 
 down:                ## stop the compose stack
 	@$(MAKE) --no-print-directory -C deploy/compose down
+
+release-retag:       ## move an existing release tag to origin/main's head, guarded (VERSION=… EXPECT=<sha> [CONFIRM=1]) — see scripts/release-retag.sh
+	@./scripts/release-retag.sh

--- a/core/meetings/services/bot/Dockerfile
+++ b/core/meetings/services/bot/Dockerfile
@@ -67,8 +67,9 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 # `@vexa/bot...` selector below does NOT pull them. The bot's own `build` script
 # runs build-browser-utils.mjs, which esbuild-bundles these bricks' dist into
 # window.VexaBrowserUtils (the global capture-bridge.ts injects via addInitScript) —
-# so their dist/ must already exist when the bot build runs.
-RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" --filter "@vexa/zoom-capture" run build
+# so their dist/ must already exist when the bot build runs. The brick list is read from
+# page-bricks.list — the single source of truth shared with Dockerfile.lite (gate:page-bricks).
+RUN pnpm $(grep -vE '^(#|$)' core/meetings/services/bot/page-bricks.list | sed 's/^/--filter /') run build
 
 # Build @vexa/bot and everything it depends on (the `...` selector pulls the deps;
 # pnpm runs them in topological order, each package's own `build` = tsc → dist/).

--- a/core/meetings/services/bot/page-bricks.list
+++ b/core/meetings/services/bot/page-bricks.list
@@ -1,0 +1,12 @@
+# Page-side capture bricks — browser bundles, NOT bot node deps (gate:isolation), so the
+# `@vexa/bot...` selector never pulls them; they must be built BEFORE the bot build emits
+# window.VexaBrowserUtils. The ONE source of truth for that pre-build list: both image builds
+# (core/meetings/services/bot/Dockerfile and deploy/lite/Dockerfile.lite) read this file, and
+# gate:page-bricks holds the copies to it (#583, the #576 rot class). One package name per line.
+@vexa/capture-codec
+@vexa/gmeet-capture
+@vexa/mixed-capture-core
+@vexa/record-chunker
+@vexa/jitsi-capture
+@vexa/teams-capture
+@vexa/zoom-capture

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -37,7 +37,8 @@ COPY scripts ./scripts
 RUN --mount=type=cache,id=pnpm-store-lite,target=/pnpm/store \
     pnpm install --frozen-lockfile=false
 # Build the page-side capture bricks first (browser bundles, not bot deps), then @vexa/bot + deps.
-RUN pnpm --filter "@vexa/capture-codec" --filter "@vexa/gmeet-capture" --filter "@vexa/mixed-capture-core" --filter "@vexa/record-chunker" --filter "@vexa/jitsi-capture" --filter "@vexa/teams-capture" --filter "@vexa/zoom-capture" run build
+# The brick list comes from the shared page-bricks.list (single source of truth; gate:page-bricks).
+RUN pnpm $(grep -vE '^(#|$)' core/meetings/services/bot/page-bricks.list | sed 's/^/--filter /') run build
 RUN pnpm --filter "@vexa/bot..." run build
 RUN test -f /build/core/meetings/services/bot/dist/index.js \
  && test -s /build/core/meetings/services/bot/dist/browser-utils.global.js

--- a/docs/changelog.d/583-release-mechanics-residual.md
+++ b/docs/changelog.d/583-release-mechanics-residual.md
@@ -1,0 +1,7 @@
+- **Release mechanics hardening (residual of #583)** — the page-side capture-brick build list now
+  lives once, in `core/meetings/services/bot/page-bricks.list`; both image builds (the bot
+  Dockerfile and `deploy/lite/Dockerfile.lite`) read it at build time and the new
+  `gate:page-bricks` fails any reintroduced inline copy (the #576 rot class). Re-tagging a release
+  is now scripted and guarded: `make release-retag VERSION=… EXPECT=<sha>` verifies the expected
+  fix is on `origin/main` before moving the tag (dry-run by default, `CONFIRM=1` to act, then
+  watches the tag build).

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -5,7 +5,7 @@
  * Usage: node scripts/gates.mjs [readme|isolation|isolation-py|exports|graph|graph-py|schema|
  *                                contract-version|config-contract|python|stack|node|health|access|
  *                                tracing|replay|telemetry|eval|licenses|compose|execution-env|
- *                                lite-makefile|all]
+ *                                lite-makefile|page-bricks|all]
  */
 import { readdirSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -1034,7 +1034,43 @@ function gateLiteMakefile() {
   return true;
 }
 
-const GATES = { readme: gateReadme, "lite-makefile": gateLiteMakefile, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
+// gate:page-bricks (#583, the #576 rot class) — the page-side capture-brick build list lives ONCE,
+// in core/meetings/services/bot/page-bricks.list; both image builds (the bot Dockerfile and
+// deploy/lite/Dockerfile.lite) read it at build time. The gate holds the seam: every listed brick
+// is a real workspace package with a build script, both Dockerfiles reference the list, and
+// neither reintroduces an inline `--filter` copy of a listed brick. Green-on-empty if the list
+// is absent.
+function gatePageBricks() {
+  const listFile = join(ROOT, "core", "meetings", "services", "bot", "page-bricks.list");
+  if (!existsSync(listFile)) { console.log("  ✓ gate:page-bricks — no page-bricks.list (green-on-empty)"); return true; }
+  const bricks = readFileSync(listFile, "utf8").split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("#"));
+  const errs = [];
+  if (!bricks.length) errs.push("page-bricks.list exists but lists no packages");
+  const pkgNames = new Map(packageDirs().map((d) => {
+    try { return [JSON.parse(readFileSync(join(d, "package.json"), "utf8")).name, d]; } catch { return [null, d]; }
+  }));
+  for (const b of bricks) {
+    const dir = pkgNames.get(b);
+    if (!dir) { errs.push(`${b} is listed but no workspace package has that name`); continue; }
+    let pkg; try { pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")); } catch { pkg = {}; }
+    if (!pkg.scripts?.build) errs.push(`${b} (${rel(dir)}) has no build script — the Dockerfile pre-build would no-op`);
+  }
+  for (const df of ["core/meetings/services/bot/Dockerfile", "deploy/lite/Dockerfile.lite"]) {
+    const p = join(ROOT, ...df.split("/"));
+    if (!existsSync(p)) continue;
+    const text = readFileSync(p, "utf8");
+    if (!text.includes("page-bricks.list"))
+      errs.push(`${df} does not read page-bricks.list — the brick pre-build list has forked from the single source`);
+    for (const b of bricks)
+      if (new RegExp(`--filter\\s+"?${b.replace("/", "\\/")}"?(?!\\.)`).test(text))
+        errs.push(`${df} inlines --filter ${b} — brick filters belong in page-bricks.list only`);
+  }
+  if (errs.length) return fail(["page-bricks (#583, the #576 rot class):", ...errs.map((e) => "   " + e)]);
+  console.log(`  ✓ gate:page-bricks — ${bricks.length} bricks single-sourced in page-bricks.list; both Dockerfiles read it, no inline copies`);
+  return true;
+}
+
+const GATES = { readme: gateReadme, "lite-makefile": gateLiteMakefile, "page-bricks": gatePageBricks, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
 const which = process.argv[2] || "all";
 
 // `seal` (not a gate) — (re)freeze the current published contracts into contracts.seal.json.

--- a/scripts/release-retag.sh
+++ b/scripts/release-retag.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# release-retag (#583 item 3) — the scripted, guarded re-tag.
+#
+# A failed release run gets fixed on main and the SAME version tag must move to main's new
+# head. v0.12.2 did this by hand 3× under pressure, each with an ad-hoc "grep the fix on
+# main's head before moving the tag" check. This script is that operator ritual, mechanized:
+#
+#   make release-retag VERSION=v0.12.14 EXPECT=<sha-of-the-fix>            # dry-run: plan only
+#   make release-retag VERSION=v0.12.14 EXPECT=<sha-of-the-fix> CONFIRM=1  # act + watch
+#
+# Guards, in order:
+#   1. VERSION must be an existing tag (a retag moves a tag; minting a new one is `git tag` +
+#      release-images.yml's own preflight, not this script).
+#   2. EXPECT is REQUIRED and must be an ancestor of (or equal to) origin/main's head — the
+#      machine form of "the fix is actually on what I'm about to tag". No EXPECT, no retag.
+#   3. Dry-run by default: prints old → new tag targets and the exact commands. CONFIRM=1 pushes.
+# After the push it watches the release-images run for the tag (gh CLI, best-effort).
+set -euo pipefail
+
+VERSION="${VERSION:-}"; EXPECT="${EXPECT:-}"; CONFIRM="${CONFIRM:-}"; REMOTE="${REMOTE:-origin}"
+[ -n "$VERSION" ] || { echo "ERROR: VERSION=vX.Y.Z[-suffix] is required"; exit 1; }
+[ -n "$EXPECT" ]  || { echo "ERROR: EXPECT=<commit that must be on main's head> is required — the guard is the point"; exit 1; }
+
+echo "Fetching $REMOTE (tags + main)…"
+git fetch --quiet "$REMOTE" main "+refs/tags/$VERSION:refs/tags/$VERSION" 2>/dev/null || git fetch --quiet "$REMOTE" main
+
+OLD=$(git rev-parse -q --verify "refs/tags/$VERSION^{commit}" || true)
+[ -n "$OLD" ] || { echo "ERROR: tag $VERSION does not exist — retag moves an existing tag; mint new tags via the normal release path"; exit 1; }
+
+HEAD_MAIN=$(git rev-parse "$REMOTE/main")
+EXPECT_SHA=$(git rev-parse -q --verify "$EXPECT^{commit}" || true)
+[ -n "$EXPECT_SHA" ] || { echo "ERROR: EXPECT ($EXPECT) is not a commit in this repo"; exit 1; }
+git merge-base --is-ancestor "$EXPECT_SHA" "$HEAD_MAIN" \
+  || { echo "ERROR: expected commit $EXPECT_SHA is NOT on $REMOTE/main ($HEAD_MAIN) — the fix you are retagging for has not landed; refusing"; exit 1; }
+
+echo ""
+echo "Retag plan for $VERSION:"
+echo "  old tag target : $OLD  ($(git log -1 --format=%s "$OLD"))"
+echo "  new tag target : $HEAD_MAIN  ($(git log -1 --format=%s "$HEAD_MAIN"))"
+echo "  guard          : $EXPECT_SHA is an ancestor of $REMOTE/main ✓"
+if [ "$OLD" = "$HEAD_MAIN" ]; then echo "  NOTE: tag already points at $REMOTE/main's head — nothing to move"; exit 0; fi
+
+if [ -z "$CONFIRM" ]; then
+  echo ""
+  echo "DRY-RUN (pass CONFIRM=1 to execute):"
+  echo "  git push $REMOTE :refs/tags/$VERSION"
+  echo "  git tag -f $VERSION $HEAD_MAIN && git push $REMOTE refs/tags/$VERSION"
+  exit 0
+fi
+
+echo ""
+echo "Moving $VERSION → $HEAD_MAIN…"
+git push "$REMOTE" ":refs/tags/$VERSION"
+git tag -f "$VERSION" "$HEAD_MAIN"
+git push "$REMOTE" "refs/tags/$VERSION"
+echo "  ✓ tag moved"
+
+if command -v gh >/dev/null 2>&1; then
+  echo "Waiting for the release-images run on $VERSION…"
+  for i in $(seq 1 12); do
+    RUN_ID=$(gh run list --workflow release-images.yml --branch "$VERSION" --limit 1 --json databaseId,createdAt \
+      -q '.[0].databaseId' 2>/dev/null || true)
+    [ -n "$RUN_ID" ] && break; sleep 10
+  done
+  if [ -n "${RUN_ID:-}" ]; then gh run watch "$RUN_ID" --exit-status; else
+    echo "  (no run appeared within 2 min — watch manually: gh run list --workflow release-images.yml)"; fi
+else
+  echo "  gh CLI not found — watch the tag build manually in Actions."
+fi


### PR DESCRIPTION
Delivers the **residual scope of #583** as re-scoped by the era-check on the issue (items 1 + the two comment-adds are already on main via #551/#554, #590, #686 and are not re-claimed here). Claim comment: https://github.com/Vexa-ai/vexa/issues/583#issuecomment-5013156533

## What ships

**Item 2 residual — one source of truth for the page-brick build list (the #576 rot class).**
The identical 7-package `--filter` chain lived verbatim in `core/meetings/services/bot/Dockerfile:71` and `deploy/lite/Dockerfile.lite:40`. It now lives once in `core/meetings/services/bot/page-bricks.list` (inside the `COPY core` both stages already do); both `RUN` lines derive their filters from it at build time. The new **`gate:page-bricks`** (scripts/gates.mjs, in `all` and pre-push) holds the seam: every listed brick must be a real workspace package with a `build` script, both Dockerfiles must read the list, and any reintroduced inline `--filter <brick>` goes red by name. Green-on-empty if the list is absent.

**Item 3 — scripted, guarded re-tag.**
`make release-retag VERSION=vX.Y.Z EXPECT=<sha> [CONFIRM=1]` (scripts/release-retag.sh): refuses unless the tag already exists AND `EXPECT` is an ancestor of `origin/main`'s head (the machine form of the v0.12.2 hand-ritual's "grep the fix on head first"). Dry-run by default — prints old→new tag targets and the exact commands; `CONFIRM=1` deletes+re-pushes the tag and then watches the tag's release-images run via `gh run watch --exit-status`.

## Observation bundle (issue numbering; expected → actual)

| Row | Expected | Actual (witnessed this session) |
|---|---|---|
| 2a | constructed argv ≡ the old inline chain | `echo` of the substituted `RUN` (both `zsh` and `sh`) prints the byte-identical 7-filter `pnpm … run build` command |
| 2b | the derived command drives the real workspace | ran the exact substituted command against the workspace: all 7 bricks `tsc` → `Done` |
| 2c | gate green on the shipped tree | `node scripts/gates.mjs page-bricks` → `✓ 7 bricks single-sourced …` |
| 2d | **negative control**: reintroduce an inline `--filter "@vexa/zoom-capture"` in Dockerfile.lite → red | gate exits 1: `deploy/lite/Dockerfile.lite inlines --filter @vexa/zoom-capture — brick filters belong in page-bricks.list only` |
| 3a | missing `EXPECT` → refuse | `make release-retag VERSION=v0.12.12` → `ERROR: EXPECT=… is required — the guard is the point`, exit ≠ 0 |
| 3b | **negative control**: `EXPECT` not on `origin/main` → refuse | dangling commit `226297b4` → `ERROR: expected commit … is NOT on origin/main … refusing`, exit ≠ 0 |
| 3c | nonexistent tag → refuse | `VERSION=v9.9.9` → `ERROR: tag v9.9.9 does not exist — retag moves an existing tag…`, exit ≠ 0 |
| 3d | valid dry-run plans, never pushes | `VERSION=v0.12.12 EXPECT=e53fbc75` → prints old/new targets + the two commands, exits 0, no remote mutation (verified: no push commands executed) |
| — | full suite + unit tests green | `node scripts/gates.mjs all` green in the worktree; `gates.test.mjs` 8/8, `merge-card-gate.test.mjs` 15/15 |

**Not checked here (honesty row):** a full local Docker build of either image (Docker daemon unavailable on the dev host) — this PR's own `pr-value/lite-smoke` leg builds `deploy/lite/Dockerfile.lite` from this tree (the path filter hits on `deploy/lite/**` + `core/**`), which is the live in-image leg for the edited `RUN` line; the bot Dockerfile's identical line is exercised at the release bar as before. `CONFIRM=1` retag path was NOT executed against the real repo (it moves a published tag); its guard/plan logic is fully exercised above and the act path is three git commands printed verbatim by the dry-run.

Docs surface: changelog fragment at `docs/changelog.d/583-release-mechanics-residual.md`.

Closes nothing on its own — #583 disposition (re-scope bookkeeping) stays with the maintainer per the era-check.
