### PR TITLE
fix(merge-card): concurrency group scoped per trigger event — cross-event runs never cancel each other (#798)

### DIFF
--- a/.github/workflows/merge-card.yml
+++ b/.github/workflows/merge-card.yml
@@ -22,9 +22,11 @@ permissions:
   checks: read
   issues: read   # the acceptance row reads closing-issue bodies; unlisted scopes drop to none
 
-# a superseded run's verdict is worthless
+# a superseded run's verdict is worthless — but only within the SAME event
+# stream: a review-triggered run must never cancel (or be cancelled by) a
+# label/push-triggered one, or the survivor's stale verdict blocks the final mile (#798)
 concurrency:
-  group: merge-card-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  group: merge-card-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/changelog.d/798-merge-card-concurrency.md
+++ b/docs/changelog.d/798-merge-card-concurrency.md
@@ -1,0 +1,1 @@
+- merge-card: concurrency group scoped per trigger event — near-simultaneous approval + label events no longer cancel each other's runs, leaving a stale red required check on the final mile (#798)


### PR DESCRIPTION
## Bundle (issue's numbering)

- **A1** — the group key now includes `github.event_name`: a `pull_request_review`-triggered run and a `pull_request:labeled`-triggered run occupy different groups and can never cancel each other; within one event stream, superseded runs still cancel (the original intent preserved). Base-red witness: #621's final mile (approval + value-sign label < 2s apart → surviving check stuck red until a manual label cycle re-fired it).
- **A2** — negative control by construction: revert this diff and the group keys collide again (key is the only change).
- **A3** — carried to observation on the next organically-concurrent PR; named as the remaining leg, not claimed.

One-line mechanism + comment stating the designed present. Fragment: `docs/changelog.d/798-merge-card-concurrency.md`. Fork B (final-mile bot) explicitly not taken — stays on the roadmap item per the issue.

Refs #798