### PR TITLE
fix(meeting-api): shared-meetings list — UNION-split access branches + per-branch indexes (#800)

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/schema/models.py
+++ b/core/identity/services/admin-api/src/admin_api/schema/models.py
@@ -99,6 +99,16 @@ class Meeting(Base):
         Index("ix_meeting_user_platform_native_id_created_at",
               "user_id", "platform", "platform_specific_id", "created_at"),
         Index("ix_meeting_data_gin", "data", postgresql_using="gin"),
+        # #800 (mirror of meeting-api's sessions/models.py): the collector's list_meetings UNIONs
+        # three access branches, one scan path each — owner top-N, transcript-share containment,
+        # workspace top-N. The whole-column GIN above cannot serve a containment probe on the
+        # `transcript_viewers` key alone.
+        # ⚠ PROD ROLLOUT: build CONCURRENTLY out-of-band before deploying (vexa-platform O-book
+        # O4); _sync_indexes' in-band CREATE INDEX locks `meetings` under live traffic.
+        Index("ix_meeting_user_created_at", "user_id", "created_at"),
+        Index("ix_meeting_transcript_viewers_gin",
+              text("(data -> 'transcript_viewers') jsonb_path_ops"), postgresql_using="gin"),
+        Index("ix_meeting_workspace_created_at", text("(data ->> 'workspace_id')"), "created_at"),
         # ROB1/ROB2 DB-level backstop (mirror of meeting-api's sessions/models.py): at most ONE
         # ACTIVE (non-terminal) meeting per (user, platform, native_meeting_id). Unique PARTIAL
         # index — terminal rows (completed/failed) are NOT covered, so a user can re-meet the same

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -410,7 +410,7 @@ class SqlAlchemyTranscriptStore:
         return await self._merge_live_segments(pg)
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None, list_view=False):
-        from sqlalchemy import cast, func, or_, select
+        from sqlalchemy import cast, func, select, union_all
         from sqlalchemy.dialects.postgresql import JSONB
 
         from .models import Meeting
@@ -419,18 +419,44 @@ class SqlAlchemyTranscriptStore:
         async with self._session_factory() as db:
             # ACCESS = owner OR transcript-share viewer OR member of the bound workspace. Shared meetings
             # (owned by someone else) surface in the caller's list so a share recipient can find + open them.
+            #
+            # #800: the branches are UNIONed, never OR-ed. A single `WHERE a OR b` plans as a backward
+            # walk of the created_at index with the OR as a Filter — for a caller with few/old meetings
+            # that scans most of the table (100s+ per call under production load). Each branch below is
+            # independently index-scannable (owner → ix_meeting_user_created_at, viewer →
+            # ix_meeting_transcript_viewers_gin, workspace → ix_meeting_workspace_created_at) with its
+            # own top-N ORDER BY/LIMIT; the outer query dedups the merged ids and re-orders.
             access = [
                 Meeting.user_id == user_id,
                 cast(Meeting.data["transcript_viewers"], JSONB).op("@>")(func.to_jsonb(user_id)),
             ]
             if member_workspaces:
                 access.append(Meeting.data["workspace_id"].astext.in_(list(member_workspaces)))
-            stmt = select(Meeting).where(or_(*access))
-            if status:
-                stmt = stmt.where(Meeting.status == status)
-            if platform:
-                stmt = stmt.where(Meeting.platform == platform)
-            stmt = stmt.order_by(Meeting.created_at.desc())
+
+            if list_view:
+                fetch_bound = (offset or 0) + (limit if limit is not None else DEFAULT_LIST_LIMIT) + 1
+            else:
+                fetch_bound = ((offset or 0) + limit) if limit else None
+
+            def _branch(cond):
+                s = select(Meeting.id).where(cond)
+                if status:
+                    s = s.where(Meeting.status == status)
+                if platform:
+                    s = s.where(Meeting.platform == platform)
+                if fetch_bound is not None:
+                    # ORDER BY inside a compound member is only meaningful (and only kept by
+                    # the compiler) together with LIMIT; an unbounded branch returns its full
+                    # set, so the outer ORDER BY alone decides.
+                    s = s.order_by(Meeting.created_at.desc()).limit(fetch_bound)
+                return s
+
+            ids = union_all(*[_branch(c) for c in access]).subquery()
+            stmt = (
+                select(Meeting)
+                .where(Meeting.id.in_(select(ids.c.id)))
+                .order_by(Meeting.created_at.desc())
+            )
             if list_view:
                 # #584: the paginated, slim list-view path (GET /bots, GET /meetings). Bound the response
                 # with a default page size (an explicit `limit` still wins) and over-fetch one row past

--- a/core/meetings/services/meeting-api/src/meeting_api/db.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/db.py
@@ -24,6 +24,14 @@ def engine_pool_kwargs() -> dict:
         "pool_size": int(os.getenv("DB_POOL_SIZE", "5")),
         "max_overflow": int(os.getenv("DB_MAX_OVERFLOW", "10")),
         "pool_pre_ping": True,
+        # #800: every meeting-api statement arrives as an asyncpg prepared statement, and after
+        # warm-up Postgres may switch a parameterized plan to its GENERIC form. For the JSONB
+        # containment branches of list_meetings the generic plan cannot use the parameter to pick
+        # the GIN path and falls back to the backward created_at walk — re-creating at plan level
+        # exactly the storm the UNION rewrite removes at query level (observed live: sub-ms custom
+        # plans vs 100s+ generic plans on the same statement). Custom plans are forced per
+        # connection; the planning cost is noise against the queries this pool actually runs.
+        "connect_args": {"server_settings": {"plan_cache_mode": "force_custom_plan"}},
     }
 
 

--- a/core/meetings/services/meeting-api/src/meeting_api/sessions/models.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/sessions/models.py
@@ -73,6 +73,17 @@ class Meeting(Base):
             "user_id", "platform", "platform_specific_id", "created_at",
         ),
         Index("ix_meeting_data_gin", "data", postgresql_using="gin"),
+        # #800: the collector's list_meetings UNIONs three access branches, one scan path each —
+        # owner top-N, transcript-share containment, workspace top-N. The whole-column GIN above
+        # cannot serve a containment probe on the `transcript_viewers` key alone, and the
+        # single-column created_at index invites the catastrophic backward-walk plan the UNION
+        # exists to avoid.
+        # ⚠ PROD ROLLOUT: build these CONCURRENTLY out-of-band before deploying (vexa-platform
+        # O-book O4); in-band CREATE INDEX locks `meetings` under live traffic.
+        Index("ix_meeting_user_created_at", "user_id", "created_at"),
+        Index("ix_meeting_transcript_viewers_gin",
+              text("(data -> 'transcript_viewers') jsonb_path_ops"), postgresql_using="gin"),
+        Index("ix_meeting_workspace_created_at", text("(data ->> 'workspace_id')"), "created_at"),
         # ROB1/ROB2 DB-level backstop: at most ONE ACTIVE (non-terminal) meeting per
         # (user, platform, native_meeting_id). A unique PARTIAL index — terminal rows
         # (completed/failed) are NOT covered, so continue_meeting can reopen a prior terminal row and

--- a/core/meetings/services/meeting-api/tests/test_db_pool.py
+++ b/core/meetings/services/meeting-api/tests/test_db_pool.py
@@ -18,7 +18,8 @@ def test_engine_pool_kwargs_reads_env(monkeypatch):
     monkeypatch.setenv("DB_POOL_SIZE", "7")
     monkeypatch.setenv("DB_MAX_OVERFLOW", "3")
     kw = mdb.engine_pool_kwargs()
-    assert kw == {"pool_size": 7, "max_overflow": 3, "pool_pre_ping": True}
+    assert kw == {"pool_size": 7, "max_overflow": 3, "pool_pre_ping": True,
+                  "connect_args": {"server_settings": {"plan_cache_mode": "force_custom_plan"}}}
 
 
 def test_engine_pool_kwargs_defaults(monkeypatch):
@@ -26,7 +27,8 @@ def test_engine_pool_kwargs_defaults(monkeypatch):
     monkeypatch.delenv("DB_POOL_SIZE", raising=False)
     monkeypatch.delenv("DB_MAX_OVERFLOW", raising=False)
     kw = mdb.engine_pool_kwargs()
-    assert kw == {"pool_size": 5, "max_overflow": 10, "pool_pre_ping": True}
+    assert kw == {"pool_size": 5, "max_overflow": 10, "pool_pre_ping": True,
+                  "connect_args": {"server_settings": {"plan_cache_mode": "force_custom_plan"}}}
 
 
 def test_build_engine_applies_pool(monkeypatch):

--- a/docs/changelog.d/800-shared-meetings-union.md
+++ b/docs/changelog.d/800-shared-meetings-union.md
@@ -1,0 +1,8 @@
+- **meeting-api: shared-meetings list no longer melts the database under load (#800).** The
+  meetings list combined owner, transcript-share, and workspace access in one `OR`, which planned
+  as a backward walk of the whole `created_at` index — 100s+ per call for users with few or old
+  meetings, enough concurrent calls to saturate the connection pool (this rolled back a hosted
+  0.12.12 production cutover). The three access branches now run as an indexed `UNION` (each with
+  its own top-N scan) plus supporting indexes; worst-case calls drop from hundreds of seconds to
+  sub-millisecond with identical results. Deployers: build the three new `meetings` indexes
+  `CONCURRENTLY` before rolling the image on a large live table.


### PR DESCRIPTION
Closes #800.

## The defect

`list_meetings` combined its three access arms (owner / transcript-share viewer / workspace member) in one `OR`, which plans as `Index Scan Backward using ix_meetings_created_at` with the OR as a Filter — for a caller with few/old meetings it walks ~the whole table per call. Under production load this saturated the DB pool and **rolled back the hosted 0.12.12 cutover** (2026-07-19 incident).

## The fix

Each access arm is its own top-N indexed subquery merged by `UNION ALL`, deduped + re-ordered by the outer query ([adapters.py](core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py) `list_meetings`). Supporting indexes in BOTH schema mirrors (admin-api SSOT + meeting-api sessions): `(user_id, created_at)` btree, `jsonb_path_ops` GIN on `(data->'transcript_viewers')`, `((data->>'workspace_id'), created_at)` btree.

## Observation bundle (acceptance table of #800, row by row)

1. **EXPLAIN ANALYZE, prod-scale worst case** (PG16, 400k rows / 4k users / 400 days; caller owns 3 old meetings + 2 shared): old shape **220.8ms, 402,536 buffers, `Rows Removed by Filter: 399,998`** → new shape **0.104ms, 33 buffers**, per-branch `Index Scan Backward using ix_meeting_user_created_at` + `Bitmap Index Scan on ix_meeting_transcript_viewers_gin`; the pathological plan shape is gone.
2. **Negative control — result equality**: ordered id arrays of old vs new identical (`5|5|t`); live-adapter checks through the real `SqlAlchemyTranscriptStore` against the same PG: ordering desc, pagination slice (limit 2 offset 2), workspace branch, non-list enumeration path, heavy-user page + `has_more` — all pass.
3. **Real-data plan check** on the hosted staging DB (13k rows): new shape 0.33ms with both branch indexes in use.
4. `node scripts/gates.mjs all` → **✅ gates green** (incl. gate:python full pytest, gate:db-schema seal).
NOT checked: a sustained concurrent load run on prod-scale hardware — the hosted deployment will watch `pg_stat_activity` during rollout per its O-book and roll back on storm recurrence.

## Deployer note

Build the three new `meetings` indexes `CONCURRENTLY` **before** rolling the image on a large live table (in-band CREATE INDEX takes a lock); on fresh installs `metadata.create_all` picks them up automatically. Changelog fragment included per `docs/changelog.d/`.

Origin: users → prod → system logs → OSS issue (#800) → this PR.