### PR TITLE
chart: probe timeoutSeconds=5 across app services — 1s default probe-kills busy-but-healthy async workers (#802)

### DIFF
--- a/deploy/helm/charts/vexa/templates/deployment-admin-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-admin-api.yaml
@@ -76,18 +76,21 @@ spec:
               port: http
             periodSeconds: 5
             failureThreshold: 40
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 20
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.adminApi.resources | nindent 12 }}
       {{- with .Values.global.nodeSelector }}

--- a/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
@@ -145,18 +145,21 @@ spec:
               port: http
             periodSeconds: 5
             failureThreshold: 40
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 20
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.agentApi.resources | nindent 12 }}
       volumes:

--- a/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
@@ -92,18 +92,21 @@ spec:
               port: http
             periodSeconds: 5
             failureThreshold: 40
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 20
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
       {{- with .Values.global.nodeSelector }}

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -129,12 +129,14 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 10
             failureThreshold: 3
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 45
             periodSeconds: 20
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.meetingApi.resources | nindent 12 }}
       {{- with .Values.global.nodeSelector }}

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -122,6 +122,7 @@ spec:
               port: http
             periodSeconds: 5
             failureThreshold: 40
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health

--- a/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
@@ -132,18 +132,21 @@ spec:
               port: http
             periodSeconds: 5
             failureThreshold: 40
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 20
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.runtime.resources | nindent 12 }}
       {{- if eq .Values.runtime.backend "docker" }}

--- a/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
@@ -95,18 +95,21 @@ spec:
               port: http
             periodSeconds: 5
             failureThreshold: 40
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: http
             initialDelaySeconds: 30
             periodSeconds: 20
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.terminal.resources | nindent 12 }}
       {{- with .Values.global.nodeSelector }}

--- a/docs/changelog.d/802-probe-timeouts.md
+++ b/docs/changelog.d/802-probe-timeouts.md
@@ -1,0 +1,6 @@
+- **helm chart: probe timeouts raised to 5s across app services (#802).** Liveness/readiness/startup
+  probes previously inherited Kubernetes' 1-second default `timeoutSeconds`; on a busy single-event-loop
+  service a healthy pod can hold `/health` past 1s, and the liveness kill turned load into a restart
+  storm (observed in hosted production on meeting-api: pods serving 200s probe-killed every ~10 min).
+  All HTTP-probed app deployments (meeting-api, gateway, admin-api, runtime, agent-api, terminal) now
+  declare `timeoutSeconds: 5`.


### PR DESCRIPTION
Closes #802.

## The defect

Every HTTP-probed app deployment left `timeoutSeconds` at Kubernetes' 1-second default. A single-event-loop async worker can hold `/health` past 1s while entirely healthy — under a normal polling burst the kubelet kills a pod that is serving 200s. Observed in hosted production (v0.12.12, rev 83): meeting-api pods probe-killed every ~10 minutes with zero DB pressure and low CPU; kubelet events `Readiness probe failed: context deadline exceeded` while final log lines were all 200s.

## The fix

`timeoutSeconds: 5` on liveness/readiness/startup probes of meeting-api, gateway, admin-api, runtime, agent-api, terminal (18 probe blocks rendered). redis/minio/pgbouncer (C services) unchanged.

## Observation bundle

1. **Live witness**: the same change applied to hosted prod (kubectl patch, then re-vendored fork chart `36db696f`) stopped the kill loop immediately — meeting-api restarts went from ~1 per 10 min per pod to 0 over the subsequent soak.
2. `helm template` renders clean; 18 probe blocks carry `timeoutSeconds: 5`.
3. Negative control: probe periods/thresholds/paths untouched — only the deadline changed.

Origin: users → prod → system logs → OSS issue #802 → this PR.