### PR TITLE
harden: bot callback horizon ~0.6s→7.5s + completed-meeting delivery marker (#806, #807)

### DIFF
--- a/core/meetings/services/bot/src/adapters/lifecycle-http.test.ts
+++ b/core/meetings/services/bot/src/adapters/lifecycle-http.test.ts
@@ -94,6 +94,20 @@ async function main(): Promise<void> {
     check('permanent-5xx: bounded to `retries` attempts', calls.length === 2, String(calls.length));
   }
 
+  // ── default horizon: 5 attempts × 500ms exponential base (≈7.5s) — a >1s meeting-api blip
+  //    must not lose the event (hosted 07-14→07-17: the old ~0.6s horizon dropped callbacks and
+  //    the reaper failed seated bots) ──
+  {
+    const calls: Recorded[] = [];
+    const sleeps: number[] = [];
+    const fetchImpl: FetchLike = async (url, init) => { calls.push({ url, ...init }); return { ok: false, status: 503 }; };
+    const sink = createHttpLifecycleSink({ callbackUrl: 'http://cb', fetchImpl, sleep: async (ms) => { sleeps.push(ms); } });
+    await sink.emit(EVENT);
+    check('default horizon: 5 attempts', calls.length === 5, String(calls.length));
+    check('default horizon: exponential from 500ms (500,1000,2000,4000)',
+      JSON.stringify(sleeps) === JSON.stringify([500, 1000, 2000, 4000]), JSON.stringify(sleeps));
+  }
+
   // ── #530 reachability gate: emitReachable reports channel reachability of the first emit ──
   const JOINING: LifecycleEvent = { connection_id: 'sess-uid', status: 'joining' };
 

--- a/core/meetings/services/bot/src/adapters/lifecycle-http.ts
+++ b/core/meetings/services/bot/src/adapters/lifecycle-http.ts
@@ -54,8 +54,11 @@ export function createHttpLifecycleSink(opts: HttpLifecycleSinkOptions): Lifecyc
     callbackUrl,
     internalSecret,
     fetchImpl = globalThis.fetch as unknown as FetchLike,
-    retries = 3,
-    backoffMs = 200,
+    // 5 × 500ms exponential ≈ 7.5s horizon. The old 3×200ms (~0.6s) horizon lost events across
+    // any >1s meeting-api blip; the reaper then attributed a failure to a bot that was seated and
+    // healthy (hosted 07-14→07-17: callback losses were the dominant "joining" failure class).
+    retries = 5,
+    backoffMs = 500,
     sleep = realSleep,
     reachRetries = 6,
     reachBackoffMs = 300,

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -197,6 +197,20 @@ class SqlAlchemyMeetingRepo:
                 merged["failure_stage"] = failure_stage
             for k, v in (data or {}).items():
                 merged[k] = v
+            if status in ("completed", "failed"):
+                # Delivery marker (#807): `completed` alone means "the bot exited cleanly" — it says
+                # nothing about whether a transcript exists. Persisting the segment count at the
+                # terminal transition makes completed-but-empty meetings (roughly half of hosted
+                # completions) queryable and alertable instead of indistinguishable from successes.
+                from sqlalchemy import func as _func
+
+                from ..sessions.models import Transcription
+
+                merged["segments_captured"] = (
+                    await db.execute(
+                        select(_func.count()).select_from(Transcription).where(Transcription.meeting_id == m.id)
+                    )
+                ).scalar() or 0
             m.data = merged
             flag_modified(m, "data")
             # Naive UTC into the naive time columns (tz-aware → asyncpg DataError, per set_bot_container).

--- a/docs/changelog.d/806-callback-horizon-delivery-marker.md
+++ b/docs/changelog.d/806-callback-horizon-delivery-marker.md
@@ -1,0 +1,7 @@
+- **Bot lifecycle callbacks survive meeting-api blips; completions carry a delivery marker (#806, #807).**
+  The bot's status-callback retry horizon grows from ~0.6s (3×200ms) to ~7.5s (5×500ms exponential) —
+  in hosted production a brief meeting-api disruption made seated, healthy bots unable to report
+  `joining`, and the reaper then failed their meetings; a longer horizon rides out such blips.
+  Separately, every terminal transition now stamps `meeting.data.segments_captured`, so a meeting
+  that "completed" without capturing any transcript is queryable and alertable instead of being
+  indistinguishable from a success.


### PR DESCRIPTION
Part of #806; closes the marker leg of #807.

## What

1. **Callback resilience (#806)**: the bot's lifecycle status-callback defaults grow from 3×200ms (~0.6s horizon) to 5×500ms exponential (~7.5s). Hosted evidence (07-14→17): callback losses during meeting-api blips were the **dominant** organic failure class — seated, healthy bots got failed by the reaper because ~0.6s wasn't enough to ride out a restart/probe blip. Default-horizon test asserts 5 attempts / 500-1000-2000-4000ms.
2. **Delivery marker (#807)**: `update_meeting_status` stamps `meeting.data.segments_captured` at every terminal transition — `completed` with zero segments (≈48% of hosted organic completions) becomes queryable and alertable. Hosted slo-check ([vexa-platform#70](https://github.com/Vexa-ai/vexa-platform/issues/70), deployed rev 84) consumes exactly this class of signal.

## Observation bundle

- Bot suite green incl. the new default-horizon case; `gates.mjs all` → ✅ green.
- Live PG16 check through the real `SqlAlchemyMeetingRepo`: 2 transcription rows → `segments_captured=2`, `end_time` stamped on completion.
- Hosted production (rev 83/84) currently: organic join success 80%, delivery 65% — the marker + hosted SLO gate turn tomorrow's numbers into an automatic page instead of a hand query.

Value sign-off: acting maintainer/product per owner delegation (see hosted incident 2026-07-19 record).