### PR TITLE
release: v0.12.14 version bump + changelog assembly

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.13"
+appVersion: "0.12.14"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/docs/changelog.d/773-adm-zip-override.md
+++ b/docs/changelog.d/773-adm-zip-override.md
@@ -1,4 +1,0 @@
-- **Security floor: adm-zip bumped to 0.6.0 via pnpm override (#773).** Closes Dependabot high
-  GHSA-xcpc-8h2w-3j85 (crafted-ZIP 4 GB allocation in adm-zip <0.6.0), which rode in through
-  onnxruntime-node's install-time unpack under `@vexa/mixed-pipeline`. Exposure was
-  postinstall-only, but the resolution layer now excludes the vulnerable range entirely.

--- a/docs/changelog.d/792-derive-native-id.md
+++ b/docs/changelog.d/792-derive-native-id.md
@@ -1,8 +1,0 @@
-- **`POST /bots` with only a `meeting_url` now derives the meeting id — no more orphan meetings
-  (#792).** A url-only body used to return 201 while persisting `native_meeting_id=''`, creating a
-  meeting (and a live bot) no `DELETE /bots/...` or `GET /transcripts/...` could ever address. The
-  API now honors what api.v1 always promised: the URL is parsed to extract `platform`,
-  `native_meeting_id`, and the passcode (Zoom `?pwd=` / Teams `?p=`); an unrecognizable URL is a
-  typed `422` naming the missing `native_meeting_id`, and a `platform` that disagrees with the URL
-  is a `422` too. Explicit `native_meeting_id` is never overridden. See
-  [Send a bot](/how-to/send-a-bot).

--- a/docs/changelog.d/798-merge-card-concurrency.md
+++ b/docs/changelog.d/798-merge-card-concurrency.md
@@ -1,1 +1,0 @@
-- merge-card: concurrency group scoped per trigger event — near-simultaneous approval + label events no longer cancel each other's runs, leaving a stale red required check on the final mile (#798)

--- a/docs/changelog.d/800-shared-meetings-union.md
+++ b/docs/changelog.d/800-shared-meetings-union.md
@@ -1,8 +1,0 @@
-- **meeting-api: shared-meetings list no longer melts the database under load (#800).** The
-  meetings list combined owner, transcript-share, and workspace access in one `OR`, which planned
-  as a backward walk of the whole `created_at` index — 100s+ per call for users with few or old
-  meetings, enough concurrent calls to saturate the connection pool (this rolled back a hosted
-  0.12.12 production cutover). The three access branches now run as an indexed `UNION` (each with
-  its own top-N scan) plus supporting indexes; worst-case calls drop from hundreds of seconds to
-  sub-millisecond with identical results. Deployers: build the three new `meetings` indexes
-  `CONCURRENTLY` before rolling the image on a large live table.

--- a/docs/changelog.d/802-probe-timeouts.md
+++ b/docs/changelog.d/802-probe-timeouts.md
@@ -1,6 +1,0 @@
-- **helm chart: probe timeouts raised to 5s across app services (#802).** Liveness/readiness/startup
-  probes previously inherited Kubernetes' 1-second default `timeoutSeconds`; on a busy single-event-loop
-  service a healthy pod can hold `/health` past 1s, and the liveness kill turned load into a restart
-  storm (observed in hosted production on meeting-api: pods serving 200s probe-killed every ~10 min).
-  All HTTP-probed app deployments (meeting-api, gateway, admin-api, runtime, agent-api, terminal) now
-  declare `timeoutSeconds: 5`.

--- a/docs/changelog.d/806-callback-horizon-delivery-marker.md
+++ b/docs/changelog.d/806-callback-horizon-delivery-marker.md
@@ -1,7 +1,0 @@
-- **Bot lifecycle callbacks survive meeting-api blips; completions carry a delivery marker (#806, #807).**
-  The bot's status-callback retry horizon grows from ~0.6s (3×200ms) to ~7.5s (5×500ms exponential) —
-  in hosted production a brief meeting-api disruption made seated, healthy bots unable to report
-  `joining`, and the reaper then failed their meetings; a longer horizon rides out such blips.
-  Separately, every terminal transition now stamps `meeting.data.segments_captured`, so a meeting
-  that "completed" without capturing any transcript is queryable and alertable instead of being
-  indistinguishable from a success.

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -3,10 +3,10 @@ title: "Changelog & migration"
 description: "Release notes and what changes between major versions."
 ---
 
-{/* docs-reflects: 0.12.13 — the released version these docs describe. CI (gate:docs-version) keeps
+{/* docs-reflects: 0.12.14 — the released version these docs describe. CI (gate:docs-version) keeps
     this equal to Chart.yaml appVersion; the release version-bump updates it. */}
 
-> 📌 **These docs reflect Vexa `v0.12.13`** — the latest released control-plane. Older self-hosts
+> 📌 **These docs reflect Vexa `v0.12.14`** — the latest released control-plane. Older self-hosts
 > should read against their pinned version.
 
 The authoritative, per-release changelog is on **GitHub Releases**:
@@ -362,6 +362,46 @@ probe), not inferred from planning docs.
   for Teams too.
 
 - **Governance: four D-book amendments from the v0.12.12 retro (#785).** TAKE verdicts now name the head sha they examined (a later push makes the endorsement historical); one rule governs sealed-contract re-stamps (a back-compatible re-seal may ride a `lane:contract` PR whose merge is the ruling, breaking changes get an issue-recorded ruling first); the closure mechanism gains mechanism-vs-tree verification over open prepared issues (catching deliveries no link sweep sees); and the incoming-report template now requires the deployed version / verified tag. See [Delivery](/governance/delivery).
+
+- **Security floor: adm-zip bumped to 0.6.0 via pnpm override (#773).** Closes Dependabot high
+  GHSA-xcpc-8h2w-3j85 (crafted-ZIP 4 GB allocation in adm-zip <0.6.0), which rode in through
+  onnxruntime-node's install-time unpack under `@vexa/mixed-pipeline`. Exposure was
+  postinstall-only, but the resolution layer now excludes the vulnerable range entirely.
+
+- **`POST /bots` with only a `meeting_url` now derives the meeting id — no more orphan meetings
+  (#792).** A url-only body used to return 201 while persisting `native_meeting_id=''`, creating a
+  meeting (and a live bot) no `DELETE /bots/...` or `GET /transcripts/...` could ever address. The
+  API now honors what api.v1 always promised: the URL is parsed to extract `platform`,
+  `native_meeting_id`, and the passcode (Zoom `?pwd=` / Teams `?p=`); an unrecognizable URL is a
+  typed `422` naming the missing `native_meeting_id`, and a `platform` that disagrees with the URL
+  is a `422` too. Explicit `native_meeting_id` is never overridden. See
+  [Send a bot](/how-to/send-a-bot).
+
+- merge-card: concurrency group scoped per trigger event — near-simultaneous approval + label events no longer cancel each other's runs, leaving a stale red required check on the final mile (#798)
+
+- **meeting-api: shared-meetings list no longer melts the database under load (#800).** The
+  meetings list combined owner, transcript-share, and workspace access in one `OR`, which planned
+  as a backward walk of the whole `created_at` index — 100s+ per call for users with few or old
+  meetings, enough concurrent calls to saturate the connection pool (this rolled back a hosted
+  0.12.12 production cutover). The three access branches now run as an indexed `UNION` (each with
+  its own top-N scan) plus supporting indexes; worst-case calls drop from hundreds of seconds to
+  sub-millisecond with identical results. Deployers: build the three new `meetings` indexes
+  `CONCURRENTLY` before rolling the image on a large live table.
+
+- **helm chart: probe timeouts raised to 5s across app services (#802).** Liveness/readiness/startup
+  probes previously inherited Kubernetes' 1-second default `timeoutSeconds`; on a busy single-event-loop
+  service a healthy pod can hold `/health` past 1s, and the liveness kill turned load into a restart
+  storm (observed in hosted production on meeting-api: pods serving 200s probe-killed every ~10 min).
+  All HTTP-probed app deployments (meeting-api, gateway, admin-api, runtime, agent-api, terminal) now
+  declare `timeoutSeconds: 5`.
+
+- **Bot lifecycle callbacks survive meeting-api blips; completions carry a delivery marker (#806, #807).**
+  The bot's status-callback retry horizon grows from ~0.6s (3×200ms) to ~7.5s (5×500ms exponential) —
+  in hosted production a brief meeting-api disruption made seated, healthy bots unable to report
+  `joining`, and the reaper then failed their meetings; a longer horizon rides out such blips.
+  Separately, every terminal transition now stamps `meeting.data.segments_captured`, so a meeting
+  that "completed" without capturing any transcript is queryable and alertable instead of being
+  indistinguishable from a success.
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
Release-cut housekeeping for v0.12.14 (the batch: #801 shared-meetings UNION query fix, #804 probe timeouts, #808 callback horizon + delivery marker).

- All three version stamps advanced (package.json, Chart.yaml appVersion, docs-reflects + visible line).
- `changelog-collect.mjs` folded the pending fragments; `changelog.d/` emptied.
- `gate:docs-version` green.

Non-runtime; tag `v0.12.14` follows the merge commit.