### PR TITLE
docs: truthful value claims — Teams/Zoom speaker bullets corrected to wiring-only + fragment rule (witness retro)

### DIFF
--- a/docs/changelog.d/README.md
+++ b/docs/changelog.d/README.md
@@ -43,3 +43,12 @@ separately so `gate:docs-version` stays green. See [`releases/README.md`](../../
 
 Migrate nothing retroactively — the convention starts now; existing `changelog.mdx` sections stay
 as they are.
+
+## The fragment states what the WITNESS can see — not what the wiring promises
+
+A fragment's bullet is release-notes truth. If your PR `Refs` its issue (instead of `Closes`)
+because a live acceptance leg remains open, the fragment must claim the **mechanism you proved**
+("hints now reach the transcriber"), never the **end value still awaiting its human bar**
+("segments carry who spoke"). The v0.12.14 witness pass caught exactly this: two fragments
+advertised live speaker attribution, the walk showed `seg_N` — and the release notes on `main`
+had to be corrected after the fact. The bundle was honest; the headline wasn't. Match them.

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -290,7 +290,11 @@ probe), not inferred from planning docs.
   error. agent-api now renders `strategy: Recreate` under an RWO workspace (the same opt-out redis
   already carries), and keeps RollingUpdate when the workspace is `ReadWriteMany`.
 
-- **Teams bot speaker attribution: segments carry who spoke, not `seg_N` (#498).** The bot now
+- **Teams bot speaker attribution: the hint pipeline now reaches the transcriber (#498 — wiring
+  only; live attribution NOT yet delivered).** ⚠ The v0.12.14 witness pass (2026-07-19) observed a
+  live 2-speaker Teams meeting still publishing every segment as `seg_N` — the hints cross, the
+  name resolution does not complete. #498 remains open; the end-to-end value lands in a later
+  release. What this change DID deliver: the bot now
   bundles the Teams voice-level-outline speaker watcher (`@vexa/teams-capture` — the same module
   the desktop extension runs) into its browser bundle and wires it to the transcriber: hints cross
   the page→Node boundary under Teams' true `dom-outline` kind (previously erased to Zoom's
@@ -308,7 +312,10 @@ probe), not inferred from planning docs.
   secondary channel is never probed). Operators can now tell "broken node" from "broken join" in one
   `kubectl describe`. See [Kubernetes deployment](/deployment-kubernetes) and [Troubleshooting](/troubleshooting).
 
-- **Zoom transcripts now name who spoke (#538).** The Zoom active-speaker watcher
+- **Zoom speaker hints: watcher wired into the capture bundle (#538 — wiring only; live
+  attribution NOT yet delivered).** ⚠ The v0.12.14 witness pass observed live Zoom segments still
+  publishing as `seg_N`; #538 remains open. What this change DID deliver: the Zoom active-speaker
+  watcher
   (`createZoomSpeakers`) is wired into the bot's page-side capture bundle: active-speaker
   transitions cross to the name binder as `dom-active` hints, so Zoom bot segments carry the
   real participant's name instead of `seg_N` placeholders — the same attribution Google Meet


### PR DESCRIPTION
Retro action from the failed v0.12.14 witness pass.

## What happened

PRs #787/#789 merged **honestly at the bundle level** (`Refs` not `Closes`, live leg explicitly reserved, thorough wiring evidence with negative controls) — but their **titles and changelog fragments claimed the end value** ('segments carry who spoke'). The witness walk falsified that value live (all segments `seg_N` on both platforms; Meet control resolves real names). Release notes on main advertised value the product doesn't deliver.

## The fix

1. Both bullets corrected in place: they now state the delivered mechanism, carry the witness result inline (⚠ live attribution NOT yet delivered, #498/#538 open), and stop claiming attribution.
2. `docs/changelog.d/README.md` gains the rule: **a Refs-PR fragment claims the proven mechanism, never the value still awaiting its human bar.** The headline must match the bundle.

## Observation bundle

- Witness evidence: witness-stack DB, meetings 2 (Teams, 40/40 segments `seg_N`) and 5 (Zoom, 15/15 `seg_N`); control meeting 1 (Meet) resolves 'Dmitriy Grankin'. Recorded on #498/#538.
- Negative control: the #530 bullet between them (bundle-backed, closed issue) untouched.

Non-runtime docs change.