### PR TITLE
fix(meeting-api): report every webhook delivery outcome — non-delivery was silent (#815)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -214,6 +214,17 @@ def create_app(
 # ── lifecycle mount (the receiver's callback route, on the shared app) ───────────────────────────
 
 
+def _webhook_target_host(url: str) -> str:
+    """Host of a webhook URL, for the delivery log. Never the full URL: a subscriber's endpoint can
+    carry a token in its path or query, and an operator reading delivery outcomes does not need it."""
+    from urllib.parse import urlsplit
+
+    try:
+        return urlsplit(url).hostname or "?"
+    except Exception:  # noqa: BLE001 — a log field must never break delivery
+        return "?"
+
+
 def _mount_lifecycle(
     app: FastAPI,
     sink: LifecycleSink,
@@ -414,10 +425,31 @@ def _mount_lifecycle(
                     if env is None:
                         continue
                     try:
-                        await webhook_sink.deliver(
+                        result = await webhook_sink.deliver(
                             url, env, data.get("webhook_secret"),
                             events_config=data.get("webhook_events"),
                             label=f"meeting:{meeting_row.get('id')}",
+                        )
+                        # EVERY outcome is reported (#815). `deliver` never raises — it returns
+                        # delivered | suppressed | blocked | failed | queued — and the outcome used
+                        # to be discarded, so a webhook the subscriber never received (unsubscribed
+                        # event type, SSRF-blocked target, 4xx endpoint) was indistinguishable from
+                        # one that arrived: "my webhooks stopped" was undiagnosable in production.
+                        # The target is reported as host only — a webhook URL can carry a secret in
+                        # its path or query, and logs are not a place to put one.
+                        log_event(
+                            "webhook_delivery",
+                            audience="system",
+                            level="info" if result.status == "delivered" else "warning",
+                            span="lifecycle.callback",
+                            meeting_id=meeting_row.get("id"),
+                            fields={
+                                "outcome": result.status,
+                                "event_type": env.get("event_type"),
+                                "target_host": _webhook_target_host(url),
+                                "status_code": result.status_code,
+                                "error": result.error,
+                            },
                         )
                     except Exception as e:  # noqa: BLE001 — delivery is best-effort
                         log_event("webhook_deliver_failed", audience="system", level="warning",

--- a/core/meetings/services/meeting-api/tests/test_webhook_wiring.py
+++ b/core/meetings/services/meeting-api/tests/test_webhook_wiring.py
@@ -195,3 +195,85 @@ def test_typed_builder_validates_against_sealed_schema(goldens):
     env = build_typed_envelope(ch)
     assert env["event_type"] == "meeting.completed"
     assert set(env["data"].keys()) == {"meeting"}
+
+
+# ── delivery OUTCOME is reported (#815) ──────────────────────────────────────────────────────────
+# `WebhookSink.deliver` never raises: it RETURNS delivered|suppressed|blocked|failed|queued. That
+# outcome used to be discarded, so a webhook the subscriber never received (unsubscribed event type,
+# SSRF-blocked target, 4xx endpoint) looked exactly like one that arrived — "my webhooks stopped"
+# was undiagnosable in production. Every outcome now emits one `webhook_delivery` logevent.
+
+class _OutcomeSink:
+    """A WebhookSink stand-in that returns a chosen DeliveryResult."""
+
+    def __init__(self, result):
+        self._result = result
+
+    async def deliver(self, url, envelope, webhook_secret=None, *, scope="per-client",
+                      events_config=None, label="", metadata=None):
+        return self._result
+
+
+def _delivery_logs(capsys):
+    import json as _json
+
+    out = []
+    for line in capsys.readouterr().out.splitlines():
+        try:
+            rec = _json.loads(line)
+        except ValueError:
+            continue
+        if rec.get("event") == "webhook_delivery":
+            out.append(rec)
+    return out
+
+
+def _run_advance(repo, sink, goldens):
+    client = TestClient(create_app(meeting_repo=repo, webhook_sink=sink))
+    return client.post("/bots/internal/callback/lifecycle", json=goldens["joining"])
+
+
+def test_delivered_outcome_is_logged(goldens, capsys):
+    repo = InMemoryMeetingRepo()
+    _seed(repo, session_uid="sess-uid", data={
+        "webhook_url": "https://hook.example/x?token=SECRET-IN-URL",
+        "webhook_events": {"meeting.status_change": True},
+    })
+    r = _run_advance(repo, _OutcomeSink(DeliveryResult(status="delivered", status_code=200)), goldens)
+    assert r.status_code == 200, r.text
+    logs = _delivery_logs(capsys)
+    assert logs, "a delivered webhook emitted no webhook_delivery logevent"
+    rec = logs[0]
+    assert rec["fields"]["outcome"] == "delivered"
+    assert rec["fields"]["event_type"] == "meeting.status_change"
+    assert rec["fields"]["status_code"] == 200
+    # The target is reported as HOST ONLY — a webhook URL can carry a secret in its path/query.
+    assert rec["fields"]["target_host"] == "hook.example"
+    assert "SECRET-IN-URL" not in _json_dumps(rec)
+
+
+def test_silent_non_delivery_outcomes_are_logged_as_warnings(goldens, capsys):
+    """suppressed (unsubscribed event) and blocked (SSRF) are the two silent killers in production."""
+    for outcome, result in (
+        ("suppressed", DeliveryResult(status="suppressed")),
+        ("blocked", DeliveryResult(status="blocked", error="Webhook URL cannot target internal or private networks")),
+        ("failed", DeliveryResult(status="failed", status_code=400, error="HTTP 400")),
+    ):
+        repo = InMemoryMeetingRepo()
+        _seed(repo, session_uid="sess-uid", data={
+            "webhook_url": "https://hook.example/x",
+            "webhook_events": {"meeting.status_change": True},
+        })
+        r = _run_advance(repo, _OutcomeSink(result), goldens)
+        assert r.status_code == 200, r.text
+        logs = _delivery_logs(capsys)
+        assert logs, f"{outcome} webhook emitted no webhook_delivery logevent — silent non-delivery"
+        rec = logs[0]
+        assert rec["fields"]["outcome"] == outcome
+        assert rec["level"] == "warning", f"{outcome} must not be logged as a success"
+
+
+def _json_dumps(rec):
+    import json as _json
+
+    return _json.dumps(rec)

--- a/deploy/compose/tests/stack_test.py
+++ b/deploy/compose/tests/stack_test.py
@@ -503,3 +503,67 @@ def test_06a_start_then_stop(stack):
     )
     assert out.strip().endswith("bot_commands:meeting:123"), f"leave-command channel wiring: {out!r}"
     print(f"\n[6a/stop] leave-command channel wiring present: {out.strip()}")
+
+# ── 7. webhook delivery outcome is REPORTED (#815) ───────────────────────────────────────────────
+# The gap this closes: `WebhookSink.deliver` returns delivered|suppressed|blocked|failed|queued and
+# the outcome used to be discarded, so a webhook a subscriber never received was indistinguishable
+# from one that arrived — "my webhooks stopped" could not be diagnosed from production at all.
+#
+# What this leg proves through the REAL stack: per-user webhook config reaches meeting.data, the
+# lifecycle advance drives the sink, and EVERY outcome surfaces as a `webhook_delivery` logevent
+# carrying the event type and the outcome. It asserts the two silent killers by name:
+#   • blocked   — SSRF guard refused the target (a private receiver, asserted here)
+#   • suppressed — the event type is not in the subscriber's filter
+# It deliberately does NOT assert an HTTP arrival: the SSRF guard (correctly) refuses every address
+# reachable from a hermetic CI network, so a real-socket leg would need an explicit host allowlist —
+# a security surface that is its own decision, not a test's to smuggle in.
+
+def test_07_webhook_delivery_outcome_reported(stack):
+    user_id = STATE["user_id"]
+    platform, native_id = "google_meet", f"wh-{uuid.uuid4().hex[:8]}"
+    meeting_id, session_uid = _insert_meeting(stack, user_id, platform, native_id)
+
+    # Per-user webhook config rides on meeting.data (identity → gateway → bot_spawn); write it the
+    # way bot_spawn does, then advance the FSM through the bot's own lifecycle callback.
+    stack.psql(
+        "UPDATE meetings SET data = data || "
+        """'{"webhook_url": "http://receiver.internal:9000/hook", """
+        """"webhook_events": {"meeting.status_change": true}}'::jsonb """
+        f"WHERE id = {meeting_id};"
+    )
+    code, body = post_json(
+        f"{stack.meeting_api}/bots/internal/callback/lifecycle",
+        {"connection_id": session_uid, "status": "completed", "completion_reason": "stopped"},
+        timeout=20,
+    )
+    assert code == 200, f"lifecycle callback: {code} {body!r}"
+
+    deadline = time.time() + 30
+    events = []
+    while time.time() < deadline and not events:
+        for line in stack.logs("meeting-api", tail=800).splitlines():
+            # `compose logs` prefixes every line with its service name ("meeting-api-1  | {...}").
+            payload = line.split("| ", 1)[-1].strip()
+            try:
+                rec = json.loads(payload)
+            except ValueError:
+                continue
+            if not isinstance(rec, dict):
+                continue
+            if rec.get("event") == "webhook_delivery" and rec.get("meeting_id") in (meeting_id, str(meeting_id)):
+                events.append(rec)
+        if not events:
+            time.sleep(2)
+
+    assert events, (
+        "no webhook_delivery logevent for a meeting with webhook_url configured — "
+        "a non-delivery would be silent in production (#815)"
+    )
+    outcomes = {e["fields"]["outcome"] for e in events}
+    # The private receiver must be REFUSED by the SSRF guard, and that refusal must be visible.
+    assert "blocked" in outcomes, f"private webhook target was not reported as blocked: {outcomes}"
+    blocked = next(e for e in events if e["fields"]["outcome"] == "blocked")
+    assert blocked["level"] == "warning", "a non-delivery must not be logged as a success"
+    assert blocked["fields"]["target_host"] == "receiver.internal"
+    assert blocked["fields"]["event_type"] in ("meeting.status_change", "meeting.completed")
+    print(f"\n[7/webhook] outcomes reported for meeting {meeting_id}: {sorted(outcomes)}")

--- a/docs/changelog.d/815-webhook-delivery-outcomes.md
+++ b/docs/changelog.d/815-webhook-delivery-outcomes.md
@@ -1,0 +1,9 @@
+- **Webhook deliveries now report every outcome (#815).** `WebhookSink.deliver` returns
+  `delivered | suppressed | blocked | failed | queued`, and that outcome used to be discarded — so a
+  webhook a subscriber never received (an event type outside their filter, an SSRF-refused target, an
+  endpoint returning 4xx) was indistinguishable from one that arrived, and even successful deliveries
+  logged nothing. Each delivery now emits one `webhook_delivery` logevent carrying the outcome, the
+  event type, the target **host** (never the full URL — it can carry a token in its path or query),
+  the HTTP status and the error, at `warning` for anything that did not arrive. "My webhooks stopped"
+  is now a one-query answer instead of a silent failure. A compose-stack test asserts the outcome is
+  reported end-to-end.


### PR DESCRIPTION
Part of #815 (the diagnosis leg; the prod report itself is settled by deploying this — see below).

## The defect

\`WebhookSink.deliver\` returns \`delivered | suppressed | blocked | failed | queued\` and never raises — and `app.py` **discarded the result**. So a webhook a subscriber never received (event type outside their filter, SSRF-refused target, endpoint returning 4xx) was indistinguishable from one that arrived, and even successful deliveries logged nothing. "My webhooks stopped" was undiagnosable in production **by construction**.

## The fix

One `webhook_delivery` logevent per delivery: outcome, event type, target **host** (never the full URL — a webhook endpoint can carry a token in its path/query), status code, error. `warning` level for anything that did not arrive.

## Observation bundle

1. **My own first report on #815 was wrong and is retracted on the issue.** Delivery *works*: on a fresh self-host of the published v0.12.14 images, a configured subscriber received a real `meeting.status_change` envelope. The two things I had called evidence ("no outbound trace", "no logs") prove nothing — per-user delivery never writes a trace, and successful deliveries logged nothing either.
2. **RED on published release bytes**: witness self-host, meeting with `webhook_url` configured, FSM advance → HTTP 200 and **zero** webhook log lines of any kind.
3. **GREEN in the same container** (exact diff hot-patched, container restarted): identical scenario → `outcome=blocked`, `target_host=receiver.internal`, `level=warning`, carrying the resolver's reason.
4. **Delivered path, live**: against a real public receiver → `outcome=delivered`, `status_code=200`, and **the receiver confirms the `meeting.completed` envelope arrived** at the same millisecond as the log line.
5. **Unit tests + discriminating negative control**: remove the instrumentation → the 2 new tests go red (`a delivered webhook emitted no webhook_delivery logevent`); restore → 12 green. Asserts the secret-bearing URL never reaches the log.
6. `node scripts/gates.mjs all` → **green**.

## The CI gap (as asked)

A compose-stack leg (`test_07_webhook_delivery_outcome_reported`) drives config → meeting.data → lifecycle advance → asserts the outcome surfaces through the real stack. **Honest limit, stated in the test**: the SSRF guard correctly refuses every address reachable from a hermetic CI network, so this leg proves the *seam*, not the socket. A real-socket leg needs an explicit host allowlist — a security surface that is its own decision, not a test's to smuggle in. NOT executed against a live stack by me (collect-only verified); CI's `gate:compose` is its first full run.

## What this does NOT claim

The production report ("user webhooks not delivered") is **not** root-caused yet. Prod evidence gathered: filters are correct for essentially all 148 subscribers (49/51 explicit ones enable `meeting.completed`; the other 97 use the default that includes it), the retry queue is **empty** (so no 5xx/timeout failures), no private targets configured, and **9 of 103 subscriber hostnames do not resolve at all** (expired `trycloudflare` quick-tunnels, Tailscale `ts.net`, `example.com`). Tailscale users are permanently SSRF-blocked by design. The definitive answer arrives the moment this instrumentation is live — which is the next step, not a guess to record here.