### PR TITLE
fix(compose): first-run 'make all' — expand ${IMAGE_TAG} in BROWSER_IMAGE before the spawn-image pull (#812)

### DIFF
--- a/deploy/compose/Makefile
+++ b/deploy/compose/Makefile
@@ -71,10 +71,11 @@ up:
 	@$(MAKE) --no-print-directory _preflight
 	@[ -f .env ] || { echo "→ no .env found; seeding from .env.example"; cp .env.example .env; }
 	$(COMPOSE) pull
-	@_tag=$$(grep -E '^IMAGE_TAG=' .env | cut -d= -f2- | tr -d '[:space:]'); _tag=$${_tag:-v012}; \
+	@_tag=$$(grep -E '^IMAGE_TAG=' .env | head -1 | cut -d= -f2- | tr -d '[:space:]'); _tag=$${_tag:-v012}; \
 	 echo "→ pulling spawn-time images (agent-worker is a build-only compose profile pull skips)"; \
 	 docker pull "vexaai/v012-agent-worker:$$_tag"; \
 	 _bi=$$(grep -E '^BROWSER_IMAGE=' .env | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$$//; s/[[:space:]]+$$//'); \
+	 _bi=$$(printf '%s' "$$_bi" | sed "s/\$${IMAGE_TAG}/$$_tag/; s/\$$IMAGE_TAG/$$_tag/"); \
 	 case "$$_bi" in vexaai/*) docker pull "$$_bi";; esac
 	$(COMPOSE) up -d --no-build
 	@$(MAKE) --no-print-directory _bot_check

--- a/docs/changelog.d/812-first-run-browser-image.md
+++ b/docs/changelog.d/812-first-run-browser-image.md
@@ -1,0 +1,5 @@
+- **Cold first-run no longer dies on `invalid reference format` (#812).** Stock `.env.example` ships
+  `BROWSER_IMAGE=vexaai/vexa-bot:${IMAGE_TAG}` — docker-compose expands it, but `make all`'s
+  spawn-image pull read the literal string and handed `docker pull` an invalid reference, breaking
+  every fresh install at the last step. The pull now resolves `${IMAGE_TAG}` (and hardens the tag
+  read against duplicate lines); a genuinely custom literal `BROWSER_IMAGE` still pulls verbatim.


### PR DESCRIPTION
Closes #812.

## The defect

Stock `.env.example` ships `BROWSER_IMAGE=vexaai/vexa-bot:${IMAGE_TAG}`. Compose expands that in yml context, but `make all`'s spawn-image pull reads it with grep/cut and hands the **literal** to `docker pull` → `invalid reference format` → **every cold first-run fails at the final step**. Found by the v0.12.14 witness provisioning (a fresh Ubuntu 24.04 host).

## The fix

Substitute `${IMAGE_TAG}`/`$IMAGE_TAG` with the already-computed `_tag` before pulling; harden `_tag` with `head -1` (duplicate IMAGE_TAG lines concatenated before). Custom literal `BROWSER_IMAGE` values pass through untouched.

## Observation bundle (acceptance table of #812)

1. **Fresh-host validation on the original repro machine**: stock parameterized `.env` + `IMAGE_TAG=v0.12.14` → resolves `vexaai/vexa-bot:v0.12.14` and the **real `docker pull` succeeds** (previously: invalid reference format at this exact step).
2. Default case pipe-tested: no IMAGE_TAG pin → `vexaai/vexa-bot:v012`.
3. **Negative control**: `BROWSER_IMAGE=vexaai/vexa-bot:custom-literal` → pulled verbatim, untouched.
4. `make -n up` confirms the rendered shell is exactly the pipe-tested logic.

Origin: v0.12.14 witness pass → #812 → this PR.