### PR TITLE
lite: mute the bot mic by default so meeting audio can't feed back

### DIFF
--- a/deploy/lite/bin/setup-pulseaudio-sinks.sh
+++ b/deploy/lite/bin/setup-pulseaudio-sinks.sh
@@ -18,3 +18,12 @@ pactl load-module module-null-sink sink_name=tts_sink \
 pactl load-module module-remap-source master=tts_sink.monitor source_name=virtual_mic \
   source_properties=device.description="VirtualMicrophone" 2>/dev/null || true
 pactl set-default-source virtual_mic 2>/dev/null || true
+
+# Mute the speak path by default — the bot is a LISTENER unless actively speaking. tts_sink is
+# the default output, so Chromium renders ALL meeting audio into it, and its monitor feeds
+# virtual_mic (the bot's mic). Left hot, that loops the meeting audio straight back out the mic —
+# everyone hears themselves (the gmeet feedback echo; the per-meeting bot's entrypoint.sh already
+# mutes these, lite did not). The speak path (tts-playback.ts) unmutes both only for the duration
+# of a TTS utterance and re-mutes after, so on-demand speaking still works.
+pactl set-sink-mute tts_sink 1 2>/dev/null || true
+pactl set-source-mute virtual_mic 1 2>/dev/null || true

--- a/docs/changelog.d/819-lite-mic-feedback.md
+++ b/docs/changelog.d/819-lite-mic-feedback.md
@@ -1,0 +1,4 @@
+- **Lite: bots no longer echo in Google Meet (#819).** Vexa Lite left the bot's microphone path
+  (`tts_sink` / `virtual_mic`) unmuted by default, so meeting audio looped back and participants
+  heard themselves. Lite now mutes the mic by default like the per-meeting bot does; on-demand
+  speaking still unmutes for the utterance. See [Deployment](/deployment).


### PR DESCRIPTION
**Delivers issue:** #819 · Closes #819

Base `main` (a7f404ee, v0.12.14) · head 1573b025 · `deploy/lite/bin/setup-pulseaudio-sinks.sh` (+2) + changelog fragment.

Vexa Lite left the bot's mic path unmuted by default, so Google Meet audio looped back and every
participant heard themselves. This mirrors the two `pactl` mute lines the per-meeting bot already
runs in `entrypoint.sh`, so Lite behaves like the container bot: a silent listener that only unmutes
for on-demand TTS.

## Observation bundle (the record of the harnessed loop)

- **C1 — the loop, reproduced.** ran: a Lite bot into a live Google Meet with the stock
  `setup-pulseaudio-sinks.sh`. saw: every participant hears a doubled echo of their own voice the
  moment the bot joins. concluded: Lite's default output (`tts_sink`) is hot and its monitor
  (`virtual_mic`) is the bot mic, so Chromium's rendered meeting audio loops back into the call.
- **C2 — the sibling that's already correct.** ran: read `core/meetings/services/bot/entrypoint.sh`.
  saw: lines 35-36 mute `tts_sink` and `virtual_mic` at startup; per-meeting bots never echo.
  concluded: Lite's `setup-pulseaudio-sinks.sh:16-20` builds the same graph but omits those two lines
  — the fix is parity, not new behavior.
- **C3 — muting is safe for speak.** ran: read `core/meetings/services/bot/src/tts-playback.ts`.
  saw: it unmutes both only for the duration of a TTS utterance and re-mutes after. concluded:
  default-muted keeps on-demand speaking working; the bot is otherwise a silent listener.
- **C4 — fix verified live.** ran: `pactl set-sink-mute tts_sink 1 && pactl set-source-mute virtual_mic 1`
  inside the running Lite container, mid-call. saw: echo stops immediately, transcription continues.
  concluded: the two lines are necessary and sufficient.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 — no feedback loop on Lite | Meet call on Lite: **red** (stock) `pactl get-sink-mute tts_sink` → `no`, echo audible; **green** (this PR) `pactl get-sink-mute tts_sink` → `yes` and `get-source-mute virtual_mic` → `yes`, no echo. |
| A2 — negative control | revert the two lines on head → echo returns; confirms the lines are load-bearing. |
| A3 — speak path intact | trigger a TTS utterance → audible in-call; sinks return to muted after. |
| A4 — listener transcribes | segments continue to land during/after the call (no capture regression). |

> Honesty note (D12b): C1/C4 were witnessed on a v0.12.6-derived Lite image; the changed script is
> **identical on `main`**, so the defect and fix transfer verbatim. A fresh-clone `main` re-run on
> Lite is the validation ask below.

## Docs diff (D6c)

`docs/changelog.d/819-lite-mic-feedback.md` (user-visible fix). The script's own comment is updated
to state the mute-by-default invariant. No other page teaches Lite's PulseAudio graph.

## Security checks (required on the diff)

Shell-only; no new deps, no secrets, no external surface. `gitleaks` clean.

## Validation request

Any competent non-author on a fresh-clone **Lite** stack at head (a7f404ee + this PR): join a Google
Meet with a Lite bot, confirm no self-echo, confirm `pactl get-sink-mute tts_sink` = `yes`, then
confirm an on-demand TTS utterance is still audible. Deployment validated: **Lite** (`deploy/lite`).

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional): drafted with agent assistance; all claims code-grounded and re-verified by the author.
