### PR TITLE
fix(config): a wrong STT URL or token is caught where you set it, not by an empty transcript (#511)

### DIFF
--- a/clients/terminal/src/app/api/__tests__/sttEndpoint.test.ts
+++ b/clients/terminal/src/app/api/__tests__/sttEndpoint.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { STT_PATH, sttEndpoint } from "../stt/endpoint";
+
+/** #511 C4 — one URL contract across all four consumers. TRANSCRIPTION_SERVICE_URL is accepted as a
+ *  bare base OR as the full endpoint; the dictation route used to append blindly, so a full-path URL
+ *  that transcribes meetings fine 404'd here. */
+describe("sttEndpoint — the shared TRANSCRIPTION_SERVICE_URL rule", () => {
+  it("appends the transcriptions path to a bare base", () => {
+    expect(sttEndpoint("https://api.openai.com")).toBe(`https://api.openai.com${STT_PATH}`);
+  });
+
+  it("tolerates trailing slashes and surrounding whitespace", () => {
+    expect(sttEndpoint("https://api.openai.com///")).toBe(`https://api.openai.com${STT_PATH}`);
+    expect(sttEndpoint("  https://api.openai.com  ")).toBe(`https://api.openai.com${STT_PATH}`);
+  });
+
+  it("does NOT double-path a URL that already carries the endpoint", () => {
+    const full = `https://api.openai.com${STT_PATH}`;
+    expect(sttEndpoint(full)).toBe(full);
+    expect(sttEndpoint(`${full}/`)).toBe(full);
+  });
+
+  it("returns empty for an unset value so the route can answer 503", () => {
+    expect(sttEndpoint("")).toBe("");
+    expect(sttEndpoint("   ")).toBe("");
+  });
+
+  it("leaves a self-hosted path prefix intact", () => {
+    // a reverse-proxied deployment (…/stt) is a base like any other — append, do not rewrite
+    expect(sttEndpoint("https://internal.example/stt")).toBe(`https://internal.example/stt${STT_PATH}`);
+  });
+});

--- a/clients/terminal/src/app/api/stt/endpoint.ts
+++ b/clients/terminal/src/app/api/stt/endpoint.ts
@@ -1,0 +1,17 @@
+/** The one URL rule for `TRANSCRIPTION_SERVICE_URL`, shared by every consumer.
+ *
+ *  The env var is accepted in BOTH shapes an operator naturally writes: a bare base
+ *  (`https://api.openai.com`) and the full endpoint (`https://api.openai.com/v1/audio/transcriptions`).
+ *  The path is appended only when it is not already there — appending blindly double-paths the full
+ *  shape into a 404, so the same URL that transcribes a meeting would fail dictation.
+ *
+ *  Same rule as `@vexa/transcribe-whisper`'s TranscriptionClient (the canonical contract) and the
+ *  config.v1 boot probe (`deploy/contracts/config.v1/preflight.py:probe_url`).
+ */
+export const STT_PATH = "/v1/audio/transcriptions";
+
+export function sttEndpoint(configuredUrl: string): string {
+  const base = (configuredUrl ?? "").trim().replace(/\/+$/, "");
+  if (!base) return "";
+  return base.endsWith(STT_PATH) ? base : `${base}${STT_PATH}`;
+}

--- a/clients/terminal/src/app/api/stt/route.ts
+++ b/clients/terminal/src/app/api/stt/route.ts
@@ -10,6 +10,7 @@
  */
 import { NextResponse } from "next/server";
 import { resolveApiKey } from "../proxyAuth";
+import { sttEndpoint } from "./endpoint";
 
 export const runtime = "nodejs";
 
@@ -26,6 +27,7 @@ export async function POST(req: Request): Promise<NextResponse> {
 
   const base = (process.env.TRANSCRIPTION_SERVICE_URL ?? "").replace(/\/+$/, "");
   if (!base) return NextResponse.json({ error: "Transcription is not configured (TRANSCRIPTION_SERVICE_URL)" }, { status: 503 });
+  const endpoint = sttEndpoint(base);
 
   const wav = await req.arrayBuffer();
   if (wav.byteLength < 100) return NextResponse.json({ error: "Empty recording" }, { status: 400 });
@@ -47,7 +49,7 @@ export async function POST(req: Request): Promise<NextResponse> {
   if (token) headers.Authorization = `Bearer ${token}`;
 
   try {
-    const r = await fetch(`${base}/v1/audio/transcriptions`, { method: "POST", headers, body: form, signal: AbortSignal.timeout(30000) });
+    const r = await fetch(endpoint, { method: "POST", headers, body: form, signal: AbortSignal.timeout(30000) });
     if (!r.ok) {
       const detail = await r.text().catch(() => "");
       return NextResponse.json({ error: `Transcription failed (${r.status})`, detail: detail.slice(0, 300) }, { status: 502 });

--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -21,6 +21,6 @@
   "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",
   "core/runtime/contracts/runtime.v1": "9d67b9379e0d34c4d715764a467e7f6e6543a5db8177fc284fb4a7418067bc18",
   "core/runtime/contracts/schedule.v1": "6f2c0277d3d186ca2a9333342930f135ea66bfd931135c451bd12b05ff862648",
-  "deploy/contracts/config.v1": "cf5961992377978a3dabc11cf7291f4781cc1115d6407b6888d3dc7a4c38328d",
+  "deploy/contracts/config.v1": "f30ab55cdf847714dd81a3fd64dc6bb1db845c70cf2b7dbc7db5380da895e061",
   "deploy/contracts/execution-targets.v1": "0c644571b7823024aa2e7ec6a135a55202233155c6c60eef79f1f4ec063e6375"
 }

--- a/core/agent/control_plane/config_preflight.py
+++ b/core/agent/control_plane/config_preflight.py
@@ -137,11 +137,35 @@ def _reset_probe_cache() -> None:
     _probe_cache.clear()
 
 
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
-    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
-    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
+    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
+    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
+    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+
+    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
+    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
+    or a DNS blip produces, so refusing on it would couple this service's availability to the
+    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
+    distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
-    url = base + (spec.get("path") or "")
+    url = probe_url(base, spec.get("path") or "")
     req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
@@ -152,11 +176,21 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     except urllib.error.HTTPError as e:
         status = int(e.code)
     except Exception as e:  # noqa: BLE001 — a probe must never throw past here
-        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
-        return {"ok": False, "status": status,
+        return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
     return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
@@ -205,6 +239,21 @@ def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = F
     result = _run_probe(spec, env)
     _probe_cache[name] = {"at": now, "result": result}
     return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
 
 
 def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:

--- a/core/agent/control_plane/config_test.py
+++ b/core/agent/control_plane/config_test.py
@@ -148,33 +148,63 @@ def run_models_test(config: dict, env: Optional[dict] = None,
 
 # ── transcription ─────────────────────────────────────────────────────────────────────────────
 
-def run_transcription_test(url: str, token: str, source: str, get: HttpGet = _get) -> dict:
+# The OpenAI-compatible transcriptions path every consumer agrees on. Appended only when the
+# configured URL does not already carry it — the one rule shared with the config.v1 probe
+# (deploy/contracts/config.v1/preflight.py:probe_url), the bot's client, and the dictation route.
+_STT_PATH = "/v1/audio/transcriptions"
+
+def _verify_openai_compatible(base: str, token: str, source: str, post: HttpPost) -> dict:
+    """The non-Vexa fallback: verify the token the way the bot's FIRST CHUNK will — POST the
+    transcriptions endpoint with a Bearer header and an empty body. The endpoint's own answer
+    grades it: 401/403 the token is rejected · 404 the URL is not a transcriptions endpoint ·
+    anything else (400 for the empty body, 405, 200) means auth was accepted and a bot will
+    transcribe. "Reachable" was never the question — the operator is asking whether it WORKS."""
+    endpoint = base if base.endswith(_STT_PATH) else base + _STT_PATH
+    try:
+        status, _ = post(endpoint, {}, {"Authorization": f"Bearer {token}"})
+    except Exception as exc:
+        return _result(False, f"Backend unreachable: {exc}", source=source)
+    if status in (401, 403):
+        return _result(False, f"Token REJECTED by {endpoint} (HTTP {status}).", source=source,
+                       status=status)
+    if status == 404:
+        return _result(False, f"No transcriptions endpoint at {endpoint} (HTTP 404) — check the "
+                              "URL shape; some gateways also answer 404 for a rejected key.",
+                       source=source, status=status)
+    return _result(True, f"OK — endpoint verified at {endpoint} (HTTP {status}); the token was "
+                         "accepted by the same request a bot makes.", source=source, status=status)
+
+
+def run_transcription_test(url: str, token: str, source: str, get: HttpGet = _get,
+                           post: HttpPost = _post) -> dict:
     """A real authenticated probe of the effective STT backend: GET ``{base}/balance`` with the
-    token. Grades the answers the 2026-07-09 402 saga taught us to distinguish."""
+    token. Grades the answers the 2026-07-09 402 saga taught us to distinguish. A backend with no
+    ``/balance`` is not a Vexa gateway — it is graded by the transcriptions endpoint itself
+    (:func:`_verify_openai_compatible`), because a green that verified nothing is the failure this
+    test exists to prevent."""
     base = (url or "").strip().rstrip("/")
     if not base:
         return _result(False, "No transcription backend configured at any level "
                               "(user, global, or deployment env).", source=source)
     # Bots post to {url}/v1/audio/transcriptions — strip the path for the account probe.
+    probe_base = base
     for suffix in ("/v1/audio/transcriptions", "/v1/audio", "/v1"):
-        if base.endswith(suffix):
-            base = base[: -len(suffix)]
+        if probe_base.endswith(suffix):
+            probe_base = probe_base[: -len(suffix)]
             break
     if not token:
-        return _result(False, f"Backend {base} configured but NO token set ({source}).",
+        return _result(False, f"Backend {probe_base} configured but NO token set ({source}).",
                        source=source)
     try:
-        status, body = get(f"{base}/balance", {"X-API-Key": token})
+        status, body = get(f"{probe_base}/balance", {"X-API-Key": token})
     except Exception as exc:
         return _result(False, f"Backend unreachable: {exc}", source=source)
     if status in (401, 403):
-        return _result(False, f"Token REJECTED by {base} (HTTP {status}).", source=source,
+        return _result(False, f"Token REJECTED by {probe_base} (HTTP {status}).", source=source,
                        status=status)
     if status == 404:
-        # Not a vexa transcription gateway (no /balance) — reachable is all we can attest.
-        return _result(True, f"Backend {base} reachable; no /balance endpoint, so the token "
-                             "was not verified (non-Vexa gateway?).", source=source,
-                       status=status, unverified=True)
+        # Not a Vexa transcription gateway (no /balance) — verify against the endpoint bots use.
+        return _verify_openai_compatible(base, token, source, post)
     if status != 200:
         return _result(False, f"Backend answered HTTP {status}.", source=source, status=status)
     try:

--- a/core/agent/tests/test_config_test.py
+++ b/core/agent/tests/test_config_test.py
@@ -128,10 +128,54 @@ def test_transcription_no_backend_and_no_token():
     assert not out["ok"] and "NO token" in out["summary"]
 
 
-def test_transcription_unreachable_and_non_gateway():
+def test_transcription_unreachable():
     def boom(url, headers):
         raise OSError("timeout")
     out = ct.run_transcription_test("https://t", "tok", "env", get=boom)
     assert not out["ok"] and "unreachable" in out["summary"]
-    out = ct.run_transcription_test("https://t", "tok", "env", get=lambda u, h: (404, ""))
-    assert out["ok"] and out.get("unverified") is True  # reachable, token unproven — says so
+
+
+# ── C2 (#511): a non-Vexa backend is graded by the endpoint BOTS use, never "reachable" ──────────
+# No /balance means "not a Vexa gateway", which is not a verdict on the operator's question. The
+# fallback runs the bot's own first-chunk request, so the wizard's green means "a bot will
+# transcribe" on ANY OpenAI-compatible endpoint.
+
+_NO_BALANCE = lambda u, h: (404, "")  # noqa: E731 — the non-Vexa signature, reused by every row
+
+
+def test_transcription_openai_wrong_key_is_red():
+    """A1/A2: a rejected key on an OpenAI-compatible endpoint is RED at the click — it used to
+    return green-unverified and fail mid-meeting."""
+    out = ct.run_transcription_test("https://api.openai.com", "sk-wrong", "settings",
+                                    get=_NO_BALANCE, post=lambda u, p, h: (401, ""))
+    assert not out["ok"], "a rejected key must never test green"
+    assert "REJECTED" in out["summary"] and out["status"] == 401
+    assert out.get("unverified") is None, "there is no longer an unverified green"
+
+
+def test_transcription_openai_good_key_is_green_and_names_the_endpoint():
+    out = ct.run_transcription_test("https://api.openai.com", "sk-good", "settings",
+                                    get=_NO_BALANCE, post=lambda u, p, h: (400, ""))
+    assert out["ok"], "auth accepted (400 = our empty body rejected, not our key)"
+    assert "/v1/audio/transcriptions" in out["summary"]
+
+
+def test_transcription_openai_wrong_url_is_red():
+    out = ct.run_transcription_test("https://api.openai.com/wrong", "sk-good", "env",
+                                    get=_NO_BALANCE, post=lambda u, p, h: (404, ""))
+    assert not out["ok"] and "URL shape" in out["summary"]
+
+
+def test_transcription_fallback_sends_bearer_to_the_transcriptions_path():
+    """C4 (A5) at this consumer: base URL and full-path URL must hit the SAME endpoint once, with
+    the Bearer header the bot sends (the /balance probe's X-API-Key is Vexa-gateway-only)."""
+    for configured in ("https://api.openai.com", "https://api.openai.com/v1/audio/transcriptions"):
+        seen = []
+        def post(url, payload, headers):
+            seen.append((url, headers.get("Authorization")))
+            return 400, ""
+        out = ct.run_transcription_test(configured, "sk-good", "env", get=_NO_BALANCE, post=post)
+        assert out["ok"], f"{configured} must verify green"
+        assert seen == [("https://api.openai.com/v1/audio/transcriptions", "Bearer sk-good")], (
+            f"{configured} → {seen}"
+        )

--- a/core/gateway/services/gateway/src/gateway/config_preflight.py
+++ b/core/gateway/services/gateway/src/gateway/config_preflight.py
@@ -137,11 +137,35 @@ def _reset_probe_cache() -> None:
     _probe_cache.clear()
 
 
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
-    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
-    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
+    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
+    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
+    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+
+    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
+    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
+    or a DNS blip produces, so refusing on it would couple this service's availability to the
+    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
+    distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
-    url = base + (spec.get("path") or "")
+    url = probe_url(base, spec.get("path") or "")
     req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
@@ -152,11 +176,21 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     except urllib.error.HTTPError as e:
         status = int(e.code)
     except Exception as e:  # noqa: BLE001 — a probe must never throw past here
-        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
-        return {"ok": False, "status": status,
+        return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
     return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
@@ -205,6 +239,21 @@ def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = F
     result = _run_probe(spec, env)
     _probe_cache[name] = {"at": now, "result": result}
     return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
 
 
 def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:

--- a/core/identity/services/admin-api/src/admin_api/config_preflight.py
+++ b/core/identity/services/admin-api/src/admin_api/config_preflight.py
@@ -137,11 +137,35 @@ def _reset_probe_cache() -> None:
     _probe_cache.clear()
 
 
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
-    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
-    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
+    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
+    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
+    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+
+    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
+    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
+    or a DNS blip produces, so refusing on it would couple this service's availability to the
+    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
+    distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
-    url = base + (spec.get("path") or "")
+    url = probe_url(base, spec.get("path") or "")
     req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
@@ -152,11 +176,21 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     except urllib.error.HTTPError as e:
         status = int(e.code)
     except Exception as e:  # noqa: BLE001 — a probe must never throw past here
-        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
-        return {"ok": False, "status": status,
+        return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
     return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
@@ -205,6 +239,21 @@ def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = F
     result = _run_probe(spec, env)
     _probe_cache[name] = {"at": now, "result": result}
     return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
 
 
 def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -27,6 +27,7 @@ import os
 import uuid
 from typing import Any, Optional
 
+from ..config_preflight import CONFIG_FAULT_KINDS, cached_probe_verdict
 from ..obs import log_event
 from .env_flags import env_flag
 from .invocation import build_invocation, build_workload_spec, mint_meeting_token
@@ -49,6 +50,11 @@ __all__ = ["request_bot", "construct_meeting_url", "DuplicateMeeting"]
 # Non-terminal statuses (parent's active set) — a prior meeting in one of these blocks a new spawn.
 _ACTIVE_STATUSES = ("requested", "joining", "awaiting_admission", "active", "stopping")
 _TERMINAL_STATUSES = ("completed", "failed")
+
+# How stale an `stt` probe verdict may be and still refuse a spawn (#511 C3). Matches the probe's
+# declared ttl_s: past it the cache holds no actionable opinion, so a spawn proceeds rather than
+# blocking on a verdict that predates the operator's fix.
+_STT_VERDICT_MAX_AGE_S = 60.0
 
 # Construct-URL templates per platform (the parent's ``Platform.construct_meeting_url``, core set).
 # NO jitsi template: a jitsi room name is scoped to a DEPLOYMENT (meet.jit.si is only the public
@@ -192,6 +198,30 @@ async def request_bot(
             "no transcription backend configured — set it in Settings or environment variables "
             "TRANSCRIPTION_SERVICE_URL + TRANSCRIPTION_SERVICE_TOKEN"
         )
+    # 1b-ii. SET-but-MISCONFIGURED is the other half of the same gate (#511 C3): a URL/token that is
+    #     present but rejected (or points at a 404) used to spawn a bot that joined, captured, and
+    #     transcribed NOTHING. Refuse it here, with the probe's own named reason, before the DB
+    #     write. Three bounds keep the refusal honest:
+    #       * CACHED verdicts only (boot preflight seeds them, /health refreshes them per ttl) — no
+    #         probe I/O rides the spawn path;
+    #       * CONFIG faults only — a `unreachable` verdict is the endpoint being down, and refusing
+    #         on it would make every spawn fail for a minute whenever STT restarts. The bot's own
+    #         client retries; a wrong URL never heals by itself. Only the latter is ours to refuse;
+    #       * the ENV backend only — the verdict describes that endpoint, so a Settings-configured
+    #         backend (a different endpoint) must never be blocked by the env one's health.
+    if transcribe_enabled and not configured.get("url"):
+        verdict = cached_probe_verdict("stt", max_age_s=_STT_VERDICT_MAX_AGE_S)
+        if verdict is not None and verdict.get("kind") in CONFIG_FAULT_KINDS:
+            log_event(
+                "bot_spawn_stt_backend_unhealthy", audience="user", level="warning",
+                span="bots.create", user_id=user_id,
+                fields={"reason": verdict.get("reason"), "status": verdict.get("status")},
+            )
+            raise TranscriptionNotConfigured(
+                f"the configured transcription backend is not working: {verdict.get('reason')} — "
+                f"fix TRANSCRIPTION_SERVICE_URL / TRANSCRIPTION_SERVICE_TOKEN; this re-tests within "
+                f"{int(_STT_VERDICT_MAX_AGE_S)}s, or call /health?force=1 to re-probe now"
+            )
 
     # 1c. Authenticated-bot mode (#724, deployment-scoped knob — Q1-A): when BOT_AUTHENTICATED is
     #     set, EVERY spawn carries the sealed invocation.v1 auth block, so the bot restores the

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -516,6 +516,9 @@
      "unauthorized_statuses": [
       401,
       403
+     ],
+     "invalid_statuses": [
+      404
      ]
     }
    }

--- a/core/meetings/services/meeting-api/src/meeting_api/config_preflight.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/config_preflight.py
@@ -137,11 +137,35 @@ def _reset_probe_cache() -> None:
     _probe_cache.clear()
 
 
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
-    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
-    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
+    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
+    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
+    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+
+    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
+    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
+    or a DNS blip produces, so refusing on it would couple this service's availability to the
+    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
+    distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
-    url = base + (spec.get("path") or "")
+    url = probe_url(base, spec.get("path") or "")
     req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
@@ -152,11 +176,21 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     except urllib.error.HTTPError as e:
         status = int(e.code)
     except Exception as e:  # noqa: BLE001 — a probe must never throw past here
-        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
-        return {"ok": False, "status": status,
+        return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
     return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
@@ -205,6 +239,21 @@ def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = F
     result = _run_probe(spec, env)
     _probe_cache[name] = {"at": now, "result": result}
     return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
 
 
 def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:

--- a/core/meetings/services/meeting-api/tests/test_config_contract.py
+++ b/core/meetings/services/meeting-api/tests/test_config_contract.py
@@ -193,3 +193,229 @@ def test_spawn_503_when_stt_fully_unset(monkeypatch):
     r2 = _client(repo).post("/bots", headers=HEADERS,
                             json={"platform": "google_meet", "native_meeting_id": "no-stt"})
     assert r2.status_code == 201, f"retry after configuring must not 409/503: {r2.status_code} {r2.text}"
+
+
+# ── C1/C4 (#511): the probe's ORACLE — a wrong URL must not prove a working backend ──────────────
+# These exercise the REAL _http_probe against a local HTTP server (not the _run_probe monkeypatch
+# seam above), because the defect under test IS the status→verdict mapping and the URL it builds.
+
+
+class _ProbeServer:
+    """A local HTTP server that answers a scripted status per request path, and records the paths
+    it was asked for (so a double-pathed URL is visible, not merely inferred from a 404)."""
+
+    def __init__(self, routes: dict, default_status: int = 404):
+        self.routes = routes
+        self.default_status = default_status
+        self.paths: list = []
+        self._server = None
+        self._thread = None
+
+    def __enter__(self):
+        import http.server
+        import threading
+
+        outer = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802 — BaseHTTPRequestHandler's interface
+                outer.paths.append(self.path)
+                self.send_response(outer.routes.get(self.path, outer.default_status))
+                self.end_headers()
+
+            def log_message(self, *a):  # keep the test output clean
+                pass
+
+        self._server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_address[1]}"
+
+    def __exit__(self, *exc):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+
+_STT_PATH = "/v1/audio/transcriptions"
+
+
+def _stt_probe_spec():
+    return cp.load_declaration()["capabilities"]["stt"]["probe"]
+
+
+def test_probe_url_accepts_both_declared_url_shapes():
+    """C4: the ONE rule — append the path only when the configured URL does not already carry it.
+    Same rule as the bot's client (whisper/src/transcription-client.ts) and the dictation route."""
+    assert cp.probe_url("https://api.openai.com", _STT_PATH) == f"https://api.openai.com{_STT_PATH}"
+    assert cp.probe_url("https://api.openai.com/", _STT_PATH) == f"https://api.openai.com{_STT_PATH}"
+    # the full endpoint URL — appending blindly here is the double-path 404 this closes
+    full = f"https://api.openai.com{_STT_PATH}"
+    assert cp.probe_url(full, _STT_PATH) == full
+    assert cp.probe_url(full + "/", _STT_PATH) == full
+
+
+def test_probe_404_is_misconfigured_not_ok():
+    """C1 (A1): a URL whose transcriptions path answers 404 is the WRONG address — it must not
+    probe green. A real OpenAI-compatible endpoint answers 400/401 to an empty body, never 404."""
+    with _ProbeServer(routes={}, default_status=404) as srv:  # every path 404s
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base, "TRANSCRIPTION_SERVICE_TOKEN": "tok"}
+        result = cp._http_probe(_stt_probe_spec()["http"], env, timeout=5)
+    assert result["ok"] is False, "404 must NOT count as proof of a reachable transcriptions endpoint"
+    assert result["status"] == 404
+    assert "URL shape" in result["reason"]
+
+
+def test_probe_404_demotes_the_health_row():
+    """C1 (A1), at the surface an operator actually reads: /health's stt row goes misconfigured."""
+    with _ProbeServer(routes={}, default_status=404) as srv:
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base, "TRANSCRIPTION_SERVICE_TOKEN": "tok"}
+        rows = cp.capability_health(env)
+    assert rows["stt"]["state"] == cp.MISCONFIGURED
+    assert rows["stt"]["probe"]["status"] == 404
+
+
+def test_probe_400_and_401_verdicts_unchanged():
+    """C1 no-regression: 400 stays proof-of-life (green); 401 stays a rejected credential (red)."""
+    with _ProbeServer(routes={_STT_PATH: 400}) as srv:
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base, "TRANSCRIPTION_SERVICE_TOKEN": "tok"}
+        ok = cp._http_probe(_stt_probe_spec()["http"], env, timeout=5)
+    assert ok["ok"] is True and ok["status"] == 400, "an empty-body 400 proves a live endpoint"
+
+    with _ProbeServer(routes={_STT_PATH: 401}) as srv:
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base, "TRANSCRIPTION_SERVICE_TOKEN": "bad"}
+        rejected = cp._http_probe(_stt_probe_spec()["http"], env, timeout=5)
+    assert rejected["ok"] is False and rejected["status"] == 401
+    assert "REJECTED" in rejected["reason"]
+
+
+def test_probe_accepts_a_full_path_url_without_double_pathing():
+    """C4 (A5): the SAME URL that works in a meeting must probe green. Configured as the full
+    endpoint, the probe must request that path once — not append a second copy into a 404."""
+    with _ProbeServer(routes={_STT_PATH: 400}) as srv:
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base + _STT_PATH,
+               "TRANSCRIPTION_SERVICE_TOKEN": "tok"}
+        result = cp._http_probe(_stt_probe_spec()["http"], env, timeout=5)
+        requested = list(srv.paths)
+    assert result["ok"] is True, f"full-path URL must not double-path: requested {requested}"
+    assert requested == [_STT_PATH], f"expected exactly one un-doubled request, got {requested}"
+
+
+# ── C3 (#511): a spawn against a SET-but-BROKEN backend refuses with the probe's reason ─────────
+
+
+def _seed_stt_verdict(result: dict):
+    """Put a verdict in the probe cache the way boot preflight / a /health poll would."""
+    import time as _t
+    cp._probe_cache["stt"] = {"at": _t.monotonic(), "result": result}
+
+
+def test_spawn_503_when_the_probe_says_the_backend_is_broken(monkeypatch):
+    """A3: set env + a cached FAILING verdict ⇒ typed 503 carrying the probe's reason, and NO
+    meeting row (the refusal precedes the write, so the retry after a fix cannot 409)."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "http://stt.test")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "bad-token")
+    monkeypatch.delenv("ADMIN_API_URL", raising=False)  # no Settings backend → env is the resolved one
+    _seed_stt_verdict({"ok": False, "status": 401, "kind": "unauthorized",
+                       "reason": "unauthorized — the configured token was REJECTED by the endpoint"})
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS,
+                           json={"platform": "google_meet", "native_meeting_id": "broken-stt"})
+    assert r.status_code == 503, f"{r.status_code} {r.text}"
+    detail = r.json()["detail"]
+    assert "REJECTED" in detail, f"the 503 must carry the probe's own reason: {detail}"
+    assert "/health?force=1" in detail, "the refusal must tell the operator how to re-test now"
+    assert repo._meetings == {}, f"refused spawn wrote a meeting row: {repo._meetings}"
+
+
+def test_spawn_proceeds_when_the_probe_says_the_backend_works(monkeypatch):
+    """A3 no-regression: a passing verdict must not interfere with the spawn."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "http://stt.test")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "good-token")
+    monkeypatch.delenv("ADMIN_API_URL", raising=False)
+    _seed_stt_verdict({"ok": True, "status": 400})
+    r = _client().post("/bots", headers=HEADERS,
+                       json={"platform": "google_meet", "native_meeting_id": "working-stt"})
+    assert r.status_code == 201, f"{r.status_code} {r.text}"
+
+
+def test_spawn_proceeds_when_no_verdict_has_been_cached(monkeypatch):
+    """An UNPROBED capability is not a broken one — absence of a verdict must never refuse."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "http://stt.test")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok")
+    monkeypatch.delenv("ADMIN_API_URL", raising=False)
+    assert cp._probe_cache == {}
+    r = _client().post("/bots", headers=HEADERS,
+                       json={"platform": "google_meet", "native_meeting_id": "unprobed-stt"})
+    assert r.status_code == 201, f"{r.status_code} {r.text}"
+
+
+def test_stale_verdict_does_not_block_a_fixed_backend(monkeypatch):
+    """The stale-red fork the issue names: past the probe's ttl the cache holds no actionable
+    opinion, so an operator who just fixed the endpoint is not locked out by the old red."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "http://stt.test")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "now-fixed")
+    monkeypatch.delenv("ADMIN_API_URL", raising=False)
+    import time as _t
+    cp._probe_cache["stt"] = {"at": _t.monotonic() - 3600,
+                              "result": {"ok": False, "kind": "unauthorized",
+                                         "reason": "unauthorized — ...", "status": 401}}
+    r = _client().post("/bots", headers=HEADERS,
+                       json={"platform": "google_meet", "native_meeting_id": "stale-red"})
+    assert r.status_code == 201, f"a verdict older than the ttl must not refuse: {r.text}"
+
+
+def test_settings_backend_is_not_blocked_by_the_env_backends_verdict(monkeypatch):
+    """The claim-together fork (#502 C1): the cached verdict describes the ENV endpoint. When the
+    user's Settings backend is what we resolved, the env backend's health is irrelevant — blocking
+    on it would refuse a spawn against a perfectly good endpoint."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "http://env-stt.test")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "env-token")
+    _seed_stt_verdict({"ok": False, "status": 401, "kind": "unauthorized",
+                       "reason": "unauthorized — env backend is broken"})
+
+    async def _settings_backend(user_id):
+        return {"url": "http://user-stt.test", "token": "user-token"}
+
+    from meeting_api.bot_spawn import service as svc
+    monkeypatch.setattr(svc, "_resolve_transcription_backend", _settings_backend)
+    r = _client().post("/bots", headers=HEADERS,
+                       json={"platform": "google_meet", "native_meeting_id": "settings-stt"})
+    assert r.status_code == 201, f"the env verdict must not gate a Settings backend: {r.text}"
+
+
+def test_unreachable_backend_does_not_refuse_spawns(monkeypatch):
+    """A DOWN endpoint is not a MISCONFIGURED one. Refusing on `unreachable` would couple every
+    spawn to STT liveness — an STT restart or a DNS blip would 503 the whole deployment for a
+    minute, while the bot's own transcription client already retries. Only a fault an operator
+    must FIX (rejected token / wrong path) may refuse."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "http://stt.test")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok")
+    monkeypatch.delenv("ADMIN_API_URL", raising=False)
+    _seed_stt_verdict({"ok": False, "kind": "unreachable",
+                       "reason": "unreachable: URLError: <urlopen error [Errno -2] Name or "
+                                 "service not known>"})
+    r = _client().post("/bots", headers=HEADERS,
+                       json={"platform": "google_meet", "native_meeting_id": "stt-down"})
+    assert r.status_code == 201, f"a down backend must not refuse the spawn: {r.text}"
+
+
+def test_probe_failure_kinds_are_classified():
+    """The kind is what lets a consumer tell 'fix your config' from 'the endpoint is down'."""
+    spec = _stt_probe_spec()["http"]
+    with _ProbeServer(routes={}, default_status=404) as srv:
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base, "TRANSCRIPTION_SERVICE_TOKEN": "t"}
+        assert cp._http_probe(spec, env, timeout=5)["kind"] == "invalid_endpoint"
+    with _ProbeServer(routes={_STT_PATH: 401}) as srv:
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base, "TRANSCRIPTION_SERVICE_TOKEN": "t"}
+        assert cp._http_probe(spec, env, timeout=5)["kind"] == "unauthorized"
+    # nothing listening on a closed port — a liveness fault, never a config fault
+    env = {"TRANSCRIPTION_SERVICE_URL": "http://127.0.0.1:1", "TRANSCRIPTION_SERVICE_TOKEN": "t"}
+    down = cp._http_probe(spec, env, timeout=2)
+    assert down["kind"] == "unreachable"
+    assert down["kind"] not in cp.CONFIG_FAULT_KINDS
+    assert {"unauthorized", "invalid_endpoint"} == set(cp.CONFIG_FAULT_KINDS)

--- a/core/runtime/src/runtime_kernel/config_preflight.py
+++ b/core/runtime/src/runtime_kernel/config_preflight.py
@@ -137,11 +137,35 @@ def _reset_probe_cache() -> None:
     _probe_cache.clear()
 
 
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
-    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
-    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
+    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
+    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
+    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+
+    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
+    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
+    or a DNS blip produces, so refusing on it would couple this service's availability to the
+    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
+    distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
-    url = base + (spec.get("path") or "")
+    url = probe_url(base, spec.get("path") or "")
     req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
@@ -152,11 +176,21 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     except urllib.error.HTTPError as e:
         status = int(e.code)
     except Exception as e:  # noqa: BLE001 — a probe must never throw past here
-        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
-        return {"ok": False, "status": status,
+        return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
     return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
@@ -205,6 +239,21 @@ def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = F
     result = _run_probe(spec, env)
     _probe_cache[name] = {"at": now, "result": result}
     return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
 
 
 def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:

--- a/deploy/contracts/config.v1/config.schema.json
+++ b/deploy/contracts/config.v1/config.schema.json
@@ -120,16 +120,21 @@
           "type": "object",
           "required": ["url_key"],
           "additionalProperties": false,
-          "description": "One authenticated request to the capability's endpoint. Verdict: an `unauthorized_statuses` answer or a network failure/timeout ⇒ probe FAILS (misconfigured); ANY other status (400/404/405/…) proves the endpoint is reachable and the credential accepted ⇒ probe passes.",
+          "description": "One authenticated request to the capability's endpoint. Verdict, in order: a network failure/timeout ⇒ probe FAILS (unreachable); an `unauthorized_statuses` answer ⇒ FAILS (the credential was REJECTED); an `invalid_statuses` answer ⇒ FAILS (we are not talking to the declared endpoint at all — the URL shape is wrong); ANY other status (400/405/…) proves the endpoint is reachable and the credential accepted ⇒ probe passes.",
           "properties": {
             "method": { "type": "string", "default": "POST" },
-            "url_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$", "description": "the declared key holding the base URL" },
-            "path": { "type": "string", "description": "appended to the base URL (e.g. /v1/audio/transcriptions)" },
+            "url_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$", "description": "the declared key holding the endpoint URL — accepted as a bare base (https://host) OR as the full endpoint already carrying `path`; the probe appends `path` only when absent, the same rule the bot's client and the terminal dictation route apply" },
+            "path": { "type": "string", "description": "the capability's endpoint path (e.g. /v1/audio/transcriptions), appended to the configured URL only when it does not already end with it" },
             "auth_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$", "description": "the declared key holding the bearer token sent as Authorization" },
             "unauthorized_statuses": {
               "type": "array",
               "items": { "type": "integer" },
               "description": "statuses that mean the credential was REJECTED (default [401, 403])"
+            },
+            "invalid_statuses": {
+              "type": "array",
+              "items": { "type": "integer" },
+              "description": "statuses that mean the URL does not name this capability's endpoint — proof of the WRONG address, not of a working one (default []; the stt transcriptions probe declares [404], since a real OpenAI-compatible transcriptions path answers 400/401 to an empty body and never 404)"
             }
           }
         },

--- a/deploy/contracts/config.v1/preflight.py
+++ b/deploy/contracts/config.v1/preflight.py
@@ -137,11 +137,35 @@ def _reset_probe_cache() -> None:
     _probe_cache.clear()
 
 
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
-    """One authenticated request. Unauthorized statuses / network failure ⇒ FAIL (the credential is
-    set but does not work); ANY other status (400/404/405/…) proves reachability + auth ⇒ ok."""
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
+    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
+    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
+    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+
+    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
+    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
+    or a DNS blip produces, so refusing on it would couple this service's availability to the
+    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
+    distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
-    url = base + (spec.get("path") or "")
+    url = probe_url(base, spec.get("path") or "")
     req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
@@ -152,11 +176,21 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     except urllib.error.HTTPError as e:
         status = int(e.code)
     except Exception as e:  # noqa: BLE001 — a probe must never throw past here
-        return {"ok": False, "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
-        return {"ok": False, "status": status,
+        return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
     return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
@@ -205,6 +239,21 @@ def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = F
     result = _run_probe(spec, env)
     _probe_cache[name] = {"at": now, "result": result}
     return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
 
 
 def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:

--- a/docs/changelog.d/819-stt-config-truth.md
+++ b/docs/changelog.d/819-stt-config-truth.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **A wrong STT URL or token is now caught where you set it, not by an empty transcript.** The
+  config probe treated *any* answer except 401/403 as proof of a working backend, so a URL whose
+  transcriptions path 404s — the most common misconfiguration — passed every check. It is now
+  reported as `misconfigured` with the reason, on the boot log and the `stt` row of `GET /health`.
+  ([#511](https://github.com/Vexa-ai/vexa/issues/511))
+- **The setup wizard's green now means "a bot will transcribe".** On any non-Vexa
+  OpenAI-compatible endpoint the test previously reported "reachable; token was not verified" as a
+  PASS, so a rejected key tested green and failed mid-meeting. It now verifies with the same
+  request a bot's first audio chunk makes, and grades the endpoint's own answer.
+  ([#511](https://github.com/Vexa-ai/vexa/issues/511))
+- **`POST /bots` refuses a set-but-broken backend** with a typed 503 carrying the probe's reason,
+  before the meeting row is written — instead of spawning a bot that joins and captures nothing.
+  The refusal names how to re-test immediately. ([#511](https://github.com/Vexa-ai/vexa/issues/511))
+- **`TRANSCRIPTION_SERVICE_URL` accepts both documented shapes everywhere.** A full
+  `…/v1/audio/transcriptions` URL worked in meetings but double-pathed into a 404 in the boot probe
+  and the terminal's dictation route. All four consumers now share one rule: append the path only
+  when it is absent. ([#511](https://github.com/Vexa-ai/vexa/issues/511))

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -17,7 +17,7 @@ are public.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `TRANSCRIPTION_SERVICE_URL` | — | STT service **base URL** (the client appends `/v1/audio/transcriptions`), e.g. `http://<gpu-host>:8083`. Point it at the bundled service you deploy separately (`deploy/transcription`) or a hosted endpoint. Unset → bots join and record but produce no transcript. |
+| `TRANSCRIPTION_SERVICE_URL` | — | STT service URL, e.g. `http://<gpu-host>:8083`. Give it the **base URL** (canonical) or the full `…/v1/audio/transcriptions` endpoint — every consumer appends the path only when it is missing, so both shapes behave identically. Point it at the bundled service you deploy separately (`deploy/transcription`) or any OpenAI-compatible endpoint. Unset → bots join and record but produce no transcript. |
 | `TRANSCRIPTION_SERVICE_TOKEN` | — | STT auth token — must match the `API_TOKEN` of your `deploy/transcription` unit, or a token from `vexa.ai/account`. |
 | `TRANSCRIPTION_MODEL` | `whisper-1` | STT model id sent on every transcription request (the OpenAI-compatible `model` field). **Set it when the backend validates model ids** — Groq (`whisper-large-v3-turbo`), OpenAI (`whisper-1` / `gpt-4o-transcribe`), vLLM/LiteLLM (the served name) — or every request fails `model_not_found`. Ignored by the bundled `deploy/transcription` unit, whose model is its own `MODEL_SIZE`. |
 | `TRANSCRIBE_ENABLED` | `true` | Deployment-level default for a spawn's transcription when `POST /bots` does not say. Set `false` for a deliberately no-STT deployment: bots spawn **capture-only** instead of answering 503. Leaving it **empty means `true`** — only an explicit `false`/`0`/`no`/`off` opts out. |
@@ -31,6 +31,26 @@ are public.
 The STT service is the **GPU workload, deployed separately** from this stack — see
 [Deployment → Transcription](/deployment#transcription-the-separate-gpu-unit). The main stack
 stays GPU-free and reaches it over the network via the two variables above.
+
+### When the backend is wrong, you learn at configure time
+
+A URL or token that does not work is refused where you set it, not by an empty transcript hours
+later. The same live check runs at three surfaces, and all three name the same cause:
+
+| Surface | What you see |
+|---|---|
+| Setup wizard — **Save & test** | Red with the endpoint's own status: `Token REJECTED by … (HTTP 401)` or `No transcriptions endpoint at … (HTTP 404)`. A green here means a bot will transcribe — the wizard verifies with the exact request a bot's first audio chunk makes. |
+| Boot log + `GET /health` | The `stt` capability row reads `misconfigured` with a `probe.reason`, instead of `configured`. A failing probe warns loudly but never blocks boot. |
+| `POST /bots` | `503` carrying that same reason, **before** any meeting row is written — never a bot that joins and silently transcribes nothing. |
+
+The verdict is cached for 60s, so after fixing the value either wait a minute or call
+`GET /health?force=1` to re-probe immediately.
+
+<Note>
+A `404` from the transcriptions path is treated as a **wrong URL**, not as proof of life: a real
+OpenAI-compatible endpoint answers `400` or `401` to an empty request body and never `404`. Some
+gateways also answer `404` for a rejected credential — the error text names both possibilities.
+</Note>
 
 <Warning>
 **Never put a comment on the same line as a value in `.env`.** Write it on its own line above the


### PR DESCRIPTION
Refs #511 — closes after the A4 live walk lands its evidence.

## The observation bundle

Base `2ac776e9` → head `d21cd2e0`. Every row below was run; each negative control was
executed by actually reverting the mechanism and re-running, not asserted.

| # | Observation | Result |
|---|---|---|
| **A1** (V1) | C1 probe red→green: a 404-answering endpoint fixture is `misconfigured` with a reason, and the `stt` /health row demotes | ✅ `test_probe_404_is_misconfigured_not_ok`, `test_probe_404_demotes_the_health_row`. **Negative control:** dropped the `invalid_statuses` branch → both FAIL (`state: configured`), restored → 17 passed |
| **A2** (V1) | C2 red→green: a wrong key on an OpenAI-compatible stub is RED "token REJECTED" (was green-unverified) | ✅ `test_transcription_openai_wrong_key_is_red` + 3 siblings. **Negative control:** restored the green-unverified branch → 4 FAIL, restored → 20 passed |
| **A3** (V1) | C3 gate red→green: a failing probe cache ⇒ typed 503 with the reason; passing cache ⇒ spawn proceeds | ✅ `test_spawn_503_when_the_probe_says_the_backend_is_broken` + 4 siblings. **Negative control:** removed the verdict consult → FAIL (spawn proceeded, `bot_join_requested` logged), restored → 22 passed |
| **A4** (V1) | LIVE (Lite, fresh clone): wrong key → wizard red + POST /bots 503 with the same reason; fix → bot joins, words come back | ⏳ **NOT YET RUN — see below** |
| **A5** (V2) | C4: a full-path `TRANSCRIPTION_SERVICE_URL` passes probe + dictation route identically | ✅ `test_probe_accepts_a_full_path_url_without_double_pathing` asserts the server received exactly `["/v1/audio/transcriptions"]` — one un-doubled request; `sttEndpoint.test.ts` (5 rows) covers the route. **Negative control:** reverted to blind append → 2 FAIL, restored → green |
| **A6** | Docs diff present | ✅ `configuration.mdx`: URL-shape contract restated + a new "When the backend is wrong, you learn at configure time" table naming all three surfaces; changelog fragment `819-stt-config-truth.md` |
| **A-** | No-regression: repo gates green at head | ✅ `node scripts/gates.mjs all` → **gates green** (includes config-contract, contract-version, tracing, licenses, compose, contract-conformance, turbo build/test) |

### A4 is outstanding and I am not claiming it

A4 needs a fresh-clone Lite stack plus a real meeting. It is the row that proves the value from
an operator's chair, and it has not been run. I will run it and post the evidence before this
merges — flagging it now rather than letting a green table imply a live witness that does not exist.

## Two findings from the work, both recorded rather than papered over

**1. My first C3 was an availability regression, caught by the gate suite.** Gating on *any*
failing verdict meant a cached `unreachable` — an STT restart, a DNS blip — would 503 every
spawn for up to 60s, while the bot's own client already retries. Probe failures now carry
`kind`, and only **config faults** (`unauthorized`, `invalid_endpoint`) may refuse a spawn;
`unreachable` never does. `test_unreachable_backend_does_not_refuse_spawns` pins it.

**2. #502 C1 has already landed, so C3's target moved.** The issue names the gate at
`bot_spawn/router.py:149-167`; on current main that block is gone and the STT gate lives in
`service.py` step 1b as the resolver-based `TranscriptionNotConfigured`. C3 is implemented
there instead, which also resolves the issue's own claim-together fork: the cached verdict
describes the **env** backend, so it is consulted only when the env backend is what was
resolved — a Settings-configured backend is a different endpoint and must never be blocked by
the env one's health (`test_settings_backend_is_not_blocked_by_the_env_backends_verdict`).

## Contract change — needs `lane:contract` review

`deploy/contracts/config.v1` is sealed, and this moves its hash. The change is
**back-compatible**: one new optional `http.invalid_statuses` (default `[]`, so every existing
declaration behaves identically) plus a `kind` on failure results. Re-sealed with
`pnpm seal:contracts`; the seal diff touches exactly one line. Per the contract README this
wants a human-reviewed `lane:contract` PR — that is this one.

## Diff shape

- `deploy/contracts/config.v1/preflight.py` — canonical; `probe_url()`, `invalid_statuses`, `kind`, `cached_probe_verdict()`, `CONFIG_FAULT_KINDS`. Re-synced byte-equal into all 5 vendored copies.
- `deploy/contracts/config.v1/config.schema.json` — declares `invalid_statuses`; the `http` description restated to the corrected oracle (it documented "404 ⇒ ok" as intended behavior).
- `meeting-api/config.v1.json` — stt probe declares `invalid_statuses: [404]`.
- `bot_spawn/service.py` — the C3 gate at step 1b-ii.
- `control_plane/config_test.py` — `_verify_openai_compatible` fallback.
- `clients/terminal/src/app/api/stt/endpoint.ts` — the rule extracted so it is testable; route consumes it.

## Out of scope, deliberately

`runtime_kernel`'s `model_inference` probe has the same 404-blind oracle. The issue scopes to
`stt`, so I left it — it is a one-line declaration change once someone wants it, now that the
mechanism is declaration-driven.

