### PR TITLE
fix(lifecycle): a bot that was never admitted is not a completed meeting (#807)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -145,7 +145,11 @@ class SqlAlchemyMeetingRepo:
     async def find_by_container(self, *, bot_container_id) -> Optional[dict]:
         """The meeting + latest session for a workload id — used by the runtime callback (CC5) to drive a
         synthetic ``failed`` for a workload that died before the bot reported. ``{meeting_id, status,
-        session_uid}`` or ``None``."""
+        session_uid, stop_requested}`` or ``None``.
+
+        ``stop_requested`` carries the user's intent so the synthetic terminal can tell a bot the USER
+        abandoned from one that timed out on its own — the two earn different completion reasons, and
+        only the latter may be retried."""
         from sqlalchemy import select
 
         from ..sessions.models import Meeting, MeetingSession
@@ -153,12 +157,14 @@ class SqlAlchemyMeetingRepo:
         async with self._session_factory() as db:
             row = (
                 await db.execute(
-                    select(Meeting.id, Meeting.status).where(Meeting.bot_container_id == bot_container_id)
+                    select(Meeting.id, Meeting.status, Meeting.data).where(
+                        Meeting.bot_container_id == bot_container_id
+                    )
                 )
             ).first()
             if row is None:
                 return None
-            mid, status = row
+            mid, status, data = row
             sid = (
                 await db.execute(
                     select(MeetingSession.session_uid)
@@ -166,7 +172,12 @@ class SqlAlchemyMeetingRepo:
                     .order_by(MeetingSession.id.desc())
                 )
             ).scalars().first()
-            return {"meeting_id": mid, "status": status, "session_uid": sid}
+            return {
+                "meeting_id": mid,
+                "status": status,
+                "session_uid": sid,
+                "stop_requested": bool((data or {}).get("stop_requested")),
+            }
 
     async def update_meeting_status(
         self, *, session_uid, status, completion_reason=None, failure_stage=None, data=None

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -217,7 +217,12 @@ class InMemoryMeetingRepo:
         sid = next(
             (s["session_uid"] for s in reversed(self.sessions) if s["meeting_id"] == row["id"]), None
         )
-        return {"meeting_id": row["id"], "status": row["status"], "session_uid": sid}
+        return {
+            "meeting_id": row["id"],
+            "status": row["status"],
+            "session_uid": sid,
+            "stop_requested": bool((row.get("data") or {}).get("stop_requested")),
+        }
 
     async def update_meeting_status(
         self, *, session_uid, status, completion_reason=None, failure_stage=None, data=None

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
@@ -106,7 +106,10 @@ _TERMINAL = frozenset({BotStatus.COMPLETED, BotStatus.FAILED})
 #   * `requested` → None (the FSM's pre-`joining` entry — the bot's first event must still be
 #     `joining`, and None→JOINING is the only legal first edge).
 #   * `stopping` → ACTIVE: `stopping` is the user-stop in-flight state (not a BotStatus); treating it
-#     as ACTIVE keeps active/stopping → completed a LEGAL transition (the bot's terminal lands).
+#     as ACTIVE keeps active/stopping → completed a LEGAL transition (the bot's terminal lands). This
+#     is sound because the stop path writes `stopping` ONLY over a status in which the bot reached the
+#     meeting — stopping a PRE-ACTIVE bot preserves its real stage, so this mapping can never launder
+#     a never-admitted bot into ACTIVE (#807).
 # Anything unrecognized maps to None (safe: forces the genuine-illegality check after reconciliation).
 _PERSISTED_STATUS_TO_BOTSTATUS: Dict[str, Optional[BotStatus]] = {
     "requested": None,

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
@@ -370,21 +370,29 @@ TERMINAL_WORKLOAD_STATES = frozenset({"destroyed", "failed", "exited", "crashed"
 # unambiguously.
 _PRE_ACTIVE_STATUSES = frozenset({"requested", "joining", "awaiting_admission"})
 # Meeting statuses where a bot WAS (or is being) live in the meeting — a `stopping` row is a user-stop
-# in flight (the bot was active before the stop), and `active`/`needs_help` mean the bot reported live.
+# in flight, and `active`/`needs_help` mean the bot reported live. `stopping` belongs here because the
+# stop path writes it ONLY over a status the bot reached the meeting in; a stop against a pre-active
+# bot leaves that stage in place instead (``stop_router``), so this set never has to guess.
 # A runtime-confirmed TERMINAL workload for one of these is real terminal evidence the run is over → the
 # meeting completes (it reached active, so `completed`, not `failed`). See
 # ``synthesize_terminal_for_dead_workload``.
 _WAS_ACTIVE_STATUSES = frozenset({"stopping", "active", "needs_help"})
 
 
-def _pre_active_completion_reason(status: Optional[str]) -> str:
+def _pre_active_completion_reason(status: Optional[str], stop_requested: bool = False) -> str:
     """Attribute a pre-active teardown to the stage the bot died in: a bot whose workload is torn
     down while it sits in the waiting room (``awaiting_admission``) was never admitted →
     ``awaiting_admission_timeout``; any earlier pre-active stage (``requested``/``joining``) died
     before it could join → ``join_failure``. Keyed on ``awaiting_admission`` EXPLICITLY: an
     escalation state like ``needs_help`` is not an admission wait and must never earn the
-    admission-timeout reason. Both values are TRANSIENT (see ``retry.py``), so attribution never
-    changes the retry class."""
+    admission-timeout reason. Both values are TRANSIENT (see ``retry.py``).
+
+    ``stop_requested`` overrides both: the workload died because the USER stopped it, so the run
+    ended for a reason no re-spawn can improve on. ``stopped`` is the sealed user-terminal reason
+    and is PERMANENT, which is what keeps a deliberate cancellation from being re-spawned three
+    times (#807 — the stage still lands in ``failure_stage``, so no attribution is lost)."""
+    if stop_requested:
+        return "stopped"
     return "awaiting_admission_timeout" if status == "awaiting_admission" else "join_failure"
 
 
@@ -430,18 +438,23 @@ async def synthesize_terminal_for_dead_workload(
     if not info or not info.get("session_uid"):
         return False
     status = info.get("status")
+    stop_requested = bool(info.get("stop_requested"))
     if status in _PRE_ACTIVE_STATUSES:
         body = {
             "connection_id": info["session_uid"],
             "status": "failed",
             "failure_stage": status,                    # the stage the bot died IN (requested/joining/…)
-            "completion_reason": _pre_active_completion_reason(status),
+            "completion_reason": _pre_active_completion_reason(status, stop_requested),
             "reason": (
-                f"workload {state} while awaiting admission (never admitted)"
+                f"stopped by the user at {status} (never admitted)"
+                if stop_requested
+                else f"workload {state} while awaiting admission (never admitted)"
                 if status == "awaiting_admission"
                 else f"workload {state} before the bot reported (never started)"
             ),
         }
+        if stop_requested:
+            body["data"] = {"stop_requested": True}
     elif status in _WAS_ACTIVE_STATUSES:
         # It reached the meeting and its workload is now runtime-confirmed gone with no terminal callback
         # of its own — complete it (it WAS active). `completion_reason=stopped` when the stop was in

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/stop_router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/stop_router.py
@@ -96,15 +96,35 @@ def build_stop_router(repo: MeetingRepo, publisher: CommandPublisher, runtime=No
         meeting = await repo.find_active(user_id, platform, native_meeting_id)
         if not meeting:
             raise HTTPException(status_code=404, detail="No active meeting for this bot")
+        # The stop trigger is ONE-SHOT. Redelivering DELETE must not re-publish a leave command or
+        # re-tear-down a workload, so the guard is the user-intent flag itself rather than a status
+        # side-effect: `stop_requested` is set by the first stop and is true regardless of which
+        # status the meeting was stopped at. (Reading it off the status cannot work — the SQL
+        # adapter's active set contains `stopping`, so a second DELETE still FINDS the row.)
+        if (meeting.get("data") or {}).get("stop_requested"):
+            raise HTTPException(status_code=404, detail="No active meeting for this bot")
         meeting_id = meeting["id"]
         status = meeting.get("status")
         bot_container_id = meeting.get("bot_container_id")
-        # Mark stop-requested + move to 'stopping' (mirrors main's DELETE), keyed by the latest session
-        # so the exit classifier reads the user-intent signal. Best-effort: an unknown session no-ops.
+        # Mark stop-requested, keyed by the latest session so the exit classifier reads the user-intent
+        # signal. Best-effort: an unknown session no-ops.
+        #
+        # `stopping` is written ONLY over a status where the bot actually reached the meeting. It means
+        # "a live bot is being asked to leave", and the whole terminal chain reads it that way:
+        # `reconcile._WAS_ACTIVE_STATUSES` completes it, and `machine._PERSISTED_STATUS_TO_BOTSTATUS`
+        # rehydrates it as ACTIVE. Writing it over a PRE-ACTIVE status (a bot still in the waiting room)
+        # destroyed the only record of the stage the bot died in, and every downstream reader then
+        # concluded the bot had been live — so a bot that was never admitted was persisted as
+        # `completed` with zero transcript, via an `awaiting_admission → completed` edge the state
+        # machine does not even consider legal (#807). A pre-active bot has nothing to leave: its
+        # workload is torn down directly below, and the terminal is attributed to the stage it really
+        # reached.
         sessions = await repo.list_sessions(meeting_id=meeting_id)
         if sessions:
             await repo.update_meeting_status(
-                session_uid=sessions[-1], status="stopping", data={"stop_requested": True},
+                session_uid=sessions[-1],
+                status=status if status in _BOOTING_STATUSES else "stopping",
+                data={"stop_requested": True},
             )
         # Publish the leave command — an ACTIVE (listening) bot honours it, leaves, emits its terminal event.
         await publisher.publish(

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -1208,3 +1208,87 @@ def test_idempotent_terminal_replay_does_not_double_reap():
     stream = f"tc:meeting:{m['id']}"
     markers = [p for p in redis.streams.get(stream, []) if p.get("type") == "session_end"]
     assert len(markers) == 1, f"double reap on idempotent replay: {markers}"
+
+
+# ── #807: the FULL user-stop chain for a bot that never reached the meeting ──────────────────────
+# The unit rows above seed a pre-active status DIRECTLY, so they always passed — the defect lived in
+# the hop they skip. Going through DELETE /bots is what exposed it: the stop wrote `stopping` over
+# `awaiting_admission`, `_WAS_ACTIVE_STATUSES` then read that as "the bot was live", and the meeting
+# was persisted `completed` with zero transcript — over an `awaiting_admission → completed` edge
+# LEGAL_TRANSITIONS does not contain. In prod this was 49% of all zero-segment `completed` meetings.
+
+
+def _stop_then_destroy(status: str):
+    """Seed a meeting AT `status`, stop it through the real DELETE route, then post the runtime's
+    destroy callback to the REAL ``POST /runtime/callback`` route. Returns the final row.
+
+    Driving the shipped route matters here: it applies the terminal in-process with
+    ``force_terminal_on_destroy=True``, which is what lets the edge land from a stale/entry FSM
+    state. The lower-level ``_consume_runtime_terminal`` helper above posts the plain lifecycle
+    callback instead, so it cannot advance a `requested` row — a property of the harness, not of
+    the product."""
+    from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher
+
+    repo, pub = _ReconcileRepo(), InMemoryCommandPublisher()
+    m = _seed(repo, status=status)
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-stopped"
+    client = TestClient(create_app(meeting_repo=repo, command_publisher=pub))
+
+    r = client.delete("/bots/google_meet/m1", headers={"x-user-id": "1"})
+    assert r.status_code == 200, r.text
+    rc = client.post("/runtime/callback", json={"workloadId": "wl-stopped", "state": "destroyed"})
+    assert rc.status_code == 200, rc.text
+    return repo._meetings[m["id"]]
+
+
+def test_user_stop_of_a_never_admitted_bot_is_failed_not_completed():
+    """A bot the user abandoned in the waiting room produced NOTHING. Reporting it `completed` is a
+    silent value failure — the system claiming success for a run with no transcript."""
+    row = _stop_then_destroy("awaiting_admission")
+    assert row["status"] == "failed", (
+        "a bot that was never admitted must not be reported as a completed meeting"
+    )
+    assert row["data"].get("failure_stage") == "awaiting_admission", (
+        "the stage the bot actually died in must survive the stop"
+    )
+
+
+def test_user_stop_before_admission_is_never_retried():
+    """The reason must be the USER-terminal one. `awaiting_admission_timeout` is TRANSIENT
+    (retry.py), so attributing a deliberate cancellation to it would re-spawn the bot three times
+    against a meeting the user already walked away from — spending their quota to do it."""
+    from meeting_api.lifecycle.retry import RetryClass, classify_retry
+    from meeting_api.lifecycle.machine import CompletionReason
+
+    for stage in ("requested", "joining", "awaiting_admission"):
+        row = _stop_then_destroy(stage)
+        reason = row["data"].get("completion_reason")
+        assert reason == "stopped", f"{stage}: expected the user-terminal reason, got {reason!r}"
+        assert classify_retry(CompletionReason(reason)) is RetryClass.PERMANENT
+        assert row["data"].get("stop_requested") is True
+
+
+def test_a_timed_out_admission_is_still_transient_and_still_retried():
+    """No-regression: without a user stop, an admission wait that dies on its own keeps the
+    TRANSIENT reason — the retry behaviour this fix must not disturb."""
+    from meeting_api.lifecycle.retry import RetryClass, classify_retry
+    from meeting_api.lifecycle.machine import CompletionReason
+
+    repo = _ReconcileRepo()
+    m = _seed(repo, status="awaiting_admission")
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-timeout"
+    client = TestClient(create_app(meeting_repo=repo))
+
+    assert _consume_runtime_terminal(client, repo, "wl-timeout", "destroyed") is True
+    row = repo._meetings[m["id"]]
+    assert row["status"] == "failed"
+    assert row["data"].get("completion_reason") == "awaiting_admission_timeout"
+    assert classify_retry(CompletionReason("awaiting_admission_timeout")) is RetryClass.TRANSIENT
+
+
+def test_user_stop_of_a_live_bot_still_completes():
+    """No-regression, the other side of the same fork: a bot that DID reach the meeting and is then
+    stopped completes with `stopped` — it delivered a real (possibly partial) meeting."""
+    row = _stop_then_destroy("active")
+    assert row["status"] == "completed"
+    assert row["data"].get("completion_reason") == "stopped"

--- a/core/meetings/services/meeting-api/tests/test_stop_route.py
+++ b/core/meetings/services/meeting-api/tests/test_stop_route.py
@@ -17,12 +17,21 @@ from meeting_api.bot_spawn.fakes import InMemoryMeetingRepo
 from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher
 
 
-def _seed_active(repo, *, user_id, platform, native):
+def _seed(repo, *, user_id, platform, native, status="active"):
+    """Seed a meeting AT a given lifecycle status. The status is load-bearing for the stop path:
+    `stopping` may only be written over a status in which the bot reached the meeting (#807)."""
     m = asyncio.run(
         repo.create_meeting(user_id=user_id, platform=platform, native_meeting_id=native, data={})
     )
-    asyncio.run(repo.create_session(meeting_id=m["id"], session_uid=f"sess-{m['id']}"))
+    sid = f"sess-{m['id']}"
+    asyncio.run(repo.create_session(meeting_id=m["id"], session_uid=sid))
+    if status != "requested":
+        asyncio.run(repo.update_meeting_status(session_uid=sid, status=status))
     return m
+
+
+def _seed_active(repo, *, user_id, platform, native):
+    return _seed(repo, user_id=user_id, platform=platform, native=native, status="active")
 
 
 def test_delete_bots_stops_active_meeting():
@@ -48,6 +57,43 @@ def test_delete_bots_stops_active_meeting():
     assert latest["data"].get("stop_requested") is True
 
 
+# ── #807: stopping a bot that never reached the meeting must not claim it was live ───────────────
+
+
+def test_stopping_a_pre_active_bot_preserves_the_stage_it_died_in():
+    """The producer half of the never-admitted-but-`completed` bug. Writing `stopping` over
+    `awaiting_admission` destroyed the only record of the stage, and every downstream reader then
+    concluded the bot had been live. The stage must survive the stop; the user-intent signal rides
+    in `data` where it always did."""
+    for stage in ("requested", "joining", "awaiting_admission"):
+        repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+        app = create_app(meeting_repo=repo, command_publisher=pub)
+        _seed(repo, user_id=7, platform="google_meet", native=f"m-{stage}", status=stage)
+
+        r = TestClient(app).delete(f"/bots/google_meet/m-{stage}", headers={"x-user-id": "7"})
+        assert r.status_code == 200, r.text
+
+        latest = asyncio.run(repo.find_latest(7, "google_meet", f"m-{stage}"))
+        assert latest["status"] == stage, (
+            f"a stop at {stage} must not overwrite the stage with 'stopping' — that is the evidence "
+            f"the terminal classifier needs to tell 'never admitted' from 'was live'"
+        )
+        assert latest["data"].get("stop_requested") is True, "user intent must still be recorded"
+
+
+def test_stop_still_moves_a_live_bot_to_stopping():
+    """No-regression: for a bot that DID reach the meeting, `stopping` is exactly right."""
+    for stage in ("active",):
+        repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+        app = create_app(meeting_repo=repo, command_publisher=pub)
+        _seed(repo, user_id=7, platform="google_meet", native=f"live-{stage}", status=stage)
+
+        r = TestClient(app).delete(f"/bots/google_meet/live-{stage}", headers={"x-user-id": "7"})
+        assert r.status_code == 200, r.text
+        latest = asyncio.run(repo.find_latest(7, "google_meet", f"live-{stage}"))
+        assert latest["status"] == "stopping"
+
+
 def test_delete_bots_404_when_no_active_meeting():
     repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
     r = TestClient(create_app(meeting_repo=repo, command_publisher=pub)).delete(
@@ -62,3 +108,23 @@ def test_delete_bots_401_without_identity():
         create_app(meeting_repo=InMemoryMeetingRepo(), command_publisher=InMemoryCommandPublisher())
     ).delete("/bots/google_meet/m1")
     assert r.status_code == 401
+
+
+def test_second_delete_never_re_stops_a_pre_active_bot():
+    """The stop trigger is one-shot for EVERY stage. Preserving the pre-active stage means the row
+    is still findable by `find_active` afterwards, so the guard has to be the user-intent flag —
+    otherwise a redelivered DELETE would publish a second leave command and tear the workload down
+    again. (The SQL adapter's active set contains `stopping` too, so this was already reachable in
+    production for a live bot; the fake's narrower set hid it.)"""
+    for stage in ("requested", "awaiting_admission", "active"):
+        repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+        app = create_app(meeting_repo=repo, command_publisher=pub)
+        _seed(repo, user_id=7, platform="google_meet", native=f"once-{stage}", status=stage)
+
+        first = TestClient(app).delete(f"/bots/google_meet/once-{stage}", headers={"x-user-id": "7"})
+        assert first.status_code == 200, first.text
+        published = len(pub.published)
+
+        second = TestClient(app).delete(f"/bots/google_meet/once-{stage}", headers={"x-user-id": "7"})
+        assert second.status_code == 404, f"{stage}: a redelivered stop must not re-trigger"
+        assert len(pub.published) == published, f"{stage}: second DELETE re-published a leave command"

--- a/docs/changelog.d/824-admission-truth.md
+++ b/docs/changelog.d/824-admission-truth.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **A bot that never got into the meeting is no longer reported as a completed meeting.** Stopping
+  a bot still sitting in the waiting room overwrote the stage it had reached, so the terminal
+  classifier concluded the bot had been live and persisted the run as `completed` with zero
+  transcript — a failure the system reported as success. The stage now survives the stop, and such
+  a run ends `failed` with `failure_stage` naming where it actually died. Reproduced on the deployed 0.12.14 build
+  (meeting 24336's own transition log records the illegal edge); the prior-era share of this
+  shape was ~49% of zero-segment completions.
+  ([#807](https://github.com/Vexa-ai/vexa/issues/807))
+- **Cancelling a bot before it is admitted no longer re-spawns it three times.** The terminal
+  reason for a user stop is now the user-terminal `stopped` (permanent) rather than
+  `awaiting_admission_timeout` (transient), so a meeting the user deliberately walked away from is
+  not retried on their quota. An admission wait that times out on its own is unchanged and still
+  retried. ([#807](https://github.com/Vexa-ai/vexa/issues/807))
+- **A redelivered `DELETE /bots/…` no longer publishes a second leave command.** The stop trigger
+  is one-shot, guarded on the recorded user intent instead of a status side-effect — the previous
+  guard held only against the in-memory test double, never against the real database.
+  ([#807](https://github.com/Vexa-ai/vexa/issues/807))


### PR DESCRIPTION
Refs #807 (cause A of the zero-segment audit — the issue stays open for causes B/C/D).

## The observation bundle

| # | Observation | Result |
|---|---|---|
| 1 | **Current-era repro on the deployed build.** Meeting 24336 (created 2026-07-19 12:18Z, meeting-api `0.12.14-260719-hc12`, post-cutover marker present) — its own `status_transition` log records `joining → awaiting_admission` (bot_callback) then `awaiting_admission → completed` (runtime_destroy, "stopped"), **0 transcript segments**. The defect line was read out of the running pod: `stop_router.py:107` writes `stopping` unconditionally. | ✅ raw row + pod grep in the issue comment |
| 2 | Full-chain red→green: seed at `awaiting_admission` → real `DELETE /bots` → real `POST /runtime/callback` destroy ⇒ `failed` + `failure_stage=awaiting_admission` (was: `completed`) | ✅ `test_user_stop_of_a_never_admitted_bot_is_failed_not_completed`. **Negative control:** restored the unconditional `stopping` write → FAILS (`completed` again), restored → green |
| 3 | Retry class: user stop pre-admission ⇒ `stopped` (PERMANENT, no re-spawn); an admission wait dying on its own ⇒ `awaiting_admission_timeout` (TRANSIENT, still retried) | ✅ `test_user_stop_before_admission_is_never_retried` + `test_a_timed_out_admission_is_still_transient_and_still_retried` |
| 4 | One-shot stop: a redelivered DELETE is 404 and publishes NO second leave command, at every stage | ✅ `test_second_delete_never_re_stops_a_pre_active_bot` |
| 5 | No-regression: live-bot stop still completes with `stopped`; the reaper-loop fix intact | ✅ `test_user_stop_of_a_live_bot_still_completes` + full lifecycle suite |
| 6 | Repo gates | ✅ `node scripts/gates.mjs all` green |

**Era note (honest bounds):** the "49% of zero-segment completions" that motivated the issue was measured over prior-era hosted-compat rows. The mechanism is proven on the current build (row 1); the current-era *share* is TBD after a week of post-cutover data. This PR fixes the mechanism and claims nothing about the share.

## The diff, briefly

Producer fix in `stop_router.py`: `stopping` is written only over a status where the bot reached the meeting; a pre-active stop preserves the real stage (+ `stop_requested`). `reconcile.py` distinguishes user-stop from timeout via `stop_requested` (now exposed by `find_by_container` in both the SQL adapter and the fake). The one-shot guard moved from a status side-effect (which only held against the fake — the SQL adapter's active set contains `stopping`) to the recorded user intent. The two comments that asserted the false premise ("a stopping row means the bot was active") now state the invariant the fix guarantees.

Also surfaced, filed separately: prod rows carry no producer-version stamp, which is what let prior-era data masquerade as current — see the provenance issue.
