### PR TITLE
fix(meeting-api): answer /bots/status from the query, not from the whole account (#803)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -409,7 +409,8 @@ class SqlAlchemyTranscriptStore:
         # Session closed (transaction ended, connection returned to pool) BEFORE the Redis merge (#508).
         return await self._merge_live_segments(pg)
 
-    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None, list_view=False):
+    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
+                            member_workspaces=None, list_view=False, meeting_id=None, slim=False):
         from sqlalchemy import cast, func, select, union_all
         from sqlalchemy.dialects.postgresql import JSONB
 
@@ -441,7 +442,20 @@ class SqlAlchemyTranscriptStore:
             def _branch(cond):
                 s = select(Meeting.id).where(cond)
                 if status:
-                    s = s.where(Meeting.status == status)
+                    # A sequence selects a SET of statuses in SQL (`/bots/status` wants the five
+                    # non-terminal ones). Filtering here instead of in Python is the difference
+                    # between reading a caller's handful of live meetings and reading their entire
+                    # history — see the `slim=` note below (#803).
+                    s = s.where(
+                        Meeting.status.in_(tuple(status))
+                        if isinstance(status, (list, tuple, set, frozenset))
+                        else Meeting.status == status
+                    )
+                if meeting_id is not None:
+                    # Detail-by-id: constrain in SQL rather than enumerating the account and
+                    # filtering in Python. The access union still decides WHETHER the caller may
+                    # see it, so ownership/share semantics are unchanged.
+                    s = s.where(Meeting.id == meeting_id)
                 if platform:
                     s = s.where(Meeting.platform == platform)
                 if fetch_bound is not None:
@@ -495,9 +509,15 @@ class SqlAlchemyTranscriptStore:
                     "updated_at": m.updated_at.isoformat() if m.updated_at else None,
                     # #584: the LIST drops the heavy detail keys (speaker_events/bot_logs/recordings/… —
                     # the 4.6 MB / event-loop-wedge cause) but keeps the light metadata it renders
-                    # (title/docs/flags). Internal callers (get-by-id, /bots/status, calendar sync) get
-                    # full `data`, so the detail view and reconciliation are unchanged.
-                    "data": project_list_data(m.data) if list_view else (m.data if isinstance(m.data, dict) else {}),
+                    # (title/docs/flags).
+                    # #803: `slim` extends the SAME projection to a non-list caller that renders none
+                    # of the heavy keys either. `/bots/status` powers a running-bots badge, yet it
+                    # materialized every byte of `data` — 180 MB for one production account, 144 MB of
+                    # it `bot_logs` that no endpoint renders. Four concurrent polls demanded ~740 MB
+                    # transiently and OOM-killed the pod. Only callers that genuinely need full `data`
+                    # (the detail view, calendar sync, reconciliation) leave both flags off.
+                    "data": project_list_data(m.data) if (list_view or slim)
+                    else (m.data if isinstance(m.data, dict) else {}),
                 }
                 return row
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -236,8 +236,12 @@ def build_router(
         platform: Optional[str] = Query(default=None),
     ):
         user_id = _resolve_user_id(x_user_id)
-        meetings = await store.list_meetings(user_id, platform=platform)
-        running = [m for m in meetings if m.get("status") in _RUNNING_STATUSES]
+        # Filtered + projected IN SQL (#803). Reading the caller's whole history and filtering here
+        # meant a running-bots badge materialized every meeting they ever had, with full `data` —
+        # hundreds of MB for a heavy account, and an OOM under concurrent polls.
+        running = await store.list_meetings(
+            user_id, status=_RUNNING_STATUSES, platform=platform, slim=True,
+        )
         log_event(
             "bots_status", audience="user", span="bots.status",
             user_id=user_id, fields={"running": len(running)},
@@ -250,7 +254,9 @@ def build_router(
         })
 
     # --- GET /meetings/{meeting_id} → the single meeting (api.v1; the meeting-detail page fetches it).
-    # Reuses list_meetings + filters by id (owner-scoped, so a non-owner can't read another's meeting). ---
+    # Constrained by id IN SQL under the same access union, so a non-owner still cannot read another's
+    # meeting — but one row is read instead of the caller's entire history (#803). Full `data` is
+    # retained: this IS the detail view. ---
     @router.get("/meetings/{meeting_id}")
     async def get_meeting(
         request: Request,
@@ -258,7 +264,7 @@ def build_router(
         x_user_id: Optional[str] = Header(default=None),
     ):
         user_id = _resolve_user_id(x_user_id)
-        meetings = await store.list_meetings(user_id)
+        meetings = await store.list_meetings(user_id, meeting_id=meeting_id)
         meeting = next((m for m in meetings if m.get("id") == meeting_id), None)
         if meeting is None:
             return JSONResponse(status_code=404, content={"detail": "Meeting not found"})

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -172,7 +172,8 @@ class InMemoryTranscriptStore:
         )
         return await self._transcript_doc(mid) if authorized else None
 
-    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None, member_workspaces=None, list_view=False):
+    async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
+                            member_workspaces=None, list_view=False, meeting_id=None, slim=False):
         from .projection import DEFAULT_LIST_LIMIT, project_list_data
         mws = member_workspaces or set()
 
@@ -184,7 +185,10 @@ class InMemoryTranscriptStore:
         rows = [
             (mid, m) for mid, m in self._meetings.items()
             if accessible(m)
-            and (status is None or m["status"] == status)
+            and (status is None or (m["status"] in status
+                                    if isinstance(status, (list, tuple, set, frozenset))
+                                    else m["status"] == status))
+            and (meeting_id is None or mid == meeting_id)
             and (platform is None or m["platform"] == platform)
         ]
         # newest first (by created_at desc, then id desc as a stable tiebreak)
@@ -215,8 +219,9 @@ class InMemoryTranscriptStore:
                 "shared": m["user_id"] != user_id,
                 "created_at": m["created_at"],
                 "updated_at": m["updated_at"],
-                # #584: LIST drops heavy detail keys, keeps light metadata; internal callers get full data.
-                "data": project_list_data(m["data"]) if list_view else m["data"],
+                # #584 list_view / #803 slim: both drop the heavy detail keys and keep the light
+                # metadata. Only a caller that genuinely renders full `data` leaves both off.
+                "data": project_list_data(m["data"]) if (list_view or slim) else m["data"],
             }
             return row
 

--- a/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
+++ b/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
@@ -6,9 +6,11 @@ morning load (the 2026-07-15 hosted read outage). ``data`` is not part of the se
 ``MeetingResponse`` schema; the list now returns only the sealed scalar metadata, bounded by a
 default page size, and a caller fetches one meeting's ``data`` on demand (``GET /meetings/{id}``).
 
-The fix is gated on a ``list_view`` flag so the internal callers that REUSE ``list_meetings`` to
-enumerate a user's meetings (``GET /meetings/{id}`` filter, ``GET /bots/status``, calendar sync) are
-unchanged — full ``data``, no default cap. These tests pin both halves.
+The projection is gated per caller, on what that caller actually renders. ``list_view`` marks the
+paginated list endpoints; ``slim`` marks a non-list caller that renders none of the heavy keys either
+(``GET /bots/status`` — #803, where materializing full ``data`` for a running-bots badge cost 180 MB
+on one production account and OOM-killed the pod). Only a caller that genuinely needs every key —
+``GET /meetings/{id}``, calendar sync, reconciliation — leaves both off. These tests pin each half.
 
 Drives the SHIPPED meeting-api handlers over the in-memory fakes (TestClient, offline) and the store
 directly. The fake mirrors the real ``SqlAlchemyTranscriptStore`` (both share
@@ -143,3 +145,117 @@ async def test_internal_path_is_unbounded_and_keeps_data():
     rows = await store.list_meetings(USER)    # list_view=False (default) → plain list, no cap
     assert isinstance(rows, list) and len(rows) == DEFAULT_LIST_LIMIT + 10   # NOT capped to 50
     assert all("data" in r for r in rows)     # full data retained for internal reuse
+
+
+# ── #803 · /bots/status is filtered and projected IN THE STORE, not in the route ─────────────────
+# The running-bots badge used to read the caller's ENTIRE history with full `data` and filter in
+# Python. On a production account that is 4,896 meetings / 180 MB — 144 MB of it `bot_logs`, which
+# no endpoint renders. Four concurrent polls demanded ~740 MB transiently; the pod OOM-killed at
+# 1 Gi. Both halves of the fix are load-bearing: the status filter bounds the ROWS, the projection
+# bounds each row, and stuck non-terminal rows (98 in production) mean the filter alone is not a cap.
+
+
+_TERMINAL = ("completed", "failed")
+_RUNNING = ("requested", "joining", "awaiting_admission", "active", "stopping")
+
+
+def _seed_history(store, *, running=_RUNNING, terminal_count=40):
+    """A realistic account: a few live meetings buried in a long terminal history, every row heavy."""
+    for i in range(terminal_count):
+        store.seed_meeting(
+            user_id=USER, platform="google_meet", native_meeting_id=f"old-{i:04d}",
+            status=_TERMINAL[i % len(_TERMINAL)],
+            created_at=f"2026-06-01T{i // 60:02d}:{i % 60:02d}:00Z", data=dict(HEAVY_DATA),
+        )
+    for i, st in enumerate(running):
+        store.seed_meeting(
+            user_id=USER, platform="google_meet", native_meeting_id=f"live-{i}", status=st,
+            created_at=f"2026-06-20T00:{i:02d}:00Z", data=dict(HEAVY_DATA),
+        )
+
+
+def test_bots_status_returns_only_running_and_never_reads_terminal_history():
+    store = InMemoryTranscriptStore()
+    _seed_history(store)
+    r = _client(store).get("/bots/status", headers=HEADERS)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == len(_RUNNING)
+    assert {m["status"] for m in body["running"]} == set(_RUNNING)
+    assert all(m["native_meeting_id"].startswith("live-") for m in body["running"]), (
+        "a terminal meeting reached the running-bots badge"
+    )
+
+
+def test_bots_status_rows_carry_no_heavy_data():
+    """The badge renders a count and a status. Shipping `bot_logs`/`speaker_events` with it was pure
+    cost — the bytes are never rendered by any caller of this endpoint."""
+    store = InMemoryTranscriptStore()
+    _seed_history(store)
+    r = _client(store).get("/bots/status", headers=HEADERS)
+    for row in r.json()["running"]:
+        for heavy in HEAVY_KEYS:
+            assert heavy not in row["data"], f"/bots/status still ships heavy key {heavy!r}"
+        # the light metadata a caller may legitimately show survives
+        assert row["data"].get("title") == "Weekly sync"
+    assert len(r.content) < 20_000, f"/bots/status response too large: {len(r.content)} bytes"
+
+
+def test_bots_status_asks_the_store_for_the_filter_rather_than_filtering_after():
+    """The point of introduction: the ROUTE must not receive the terminal rows at all. Pinning the
+    store call is what keeps the filter from silently drifting back into Python, where it would
+    still produce a correct response while reading the whole account."""
+    store = InMemoryTranscriptStore()
+    _seed_history(store)
+    seen = {}
+    original = store.list_meetings
+
+    async def spy(user_id, **kw):
+        seen.update(kw)
+        rows = await original(user_id, **kw)
+        seen["returned"] = len(rows)
+        return rows
+
+    store.list_meetings = spy
+    r = _client(store).get("/bots/status", headers=HEADERS)
+    assert r.status_code == 200
+    assert set(seen.get("status") or ()) == set(_RUNNING), (
+        f"the status filter did not reach the store: {seen.get('status')!r}"
+    )
+    assert seen.get("slim") is True, "the projection did not reach the store"
+    assert seen["returned"] == len(_RUNNING), (
+        f"the store handed the route {seen['returned']} rows for {len(_RUNNING)} running bots — "
+        f"the terminal history is still being read"
+    )
+
+
+def test_get_meeting_by_id_is_constrained_in_the_store():
+    """Same defect, smaller blast radius: the detail route enumerated the whole account to find one
+    row. It must ask for the row — while still returning FULL data, and still refusing a non-owner."""
+    store = InMemoryTranscriptStore()
+    _seed_history(store)
+    mid = _seed_heavy(store, nid="detail-1")
+    seen = {}
+    original = store.list_meetings
+
+    async def spy(user_id, **kw):
+        seen.update(kw)
+        rows = await original(user_id, **kw)
+        seen["returned"] = len(rows)
+        return rows
+
+    store.list_meetings = spy
+    r = _client(store).get(f"/meetings/{mid}", headers=HEADERS)
+    assert r.status_code == 200
+    assert seen.get("meeting_id") == mid, "the id filter did not reach the store"
+    assert seen["returned"] == 1, f"the detail route read {seen['returned']} rows to return one"
+    # the detail view is exactly where full `data` still belongs
+    assert "speaker_events" in r.json()["data"] and "bot_logs" in r.json()["data"]
+
+
+def test_get_meeting_by_id_still_refuses_a_non_owner():
+    """No-regression on the security property: constraining by id must not bypass the access union."""
+    store = InMemoryTranscriptStore()
+    mid = _seed_heavy(store, nid="private-1")
+    r = _client(store).get(f"/meetings/{mid}", headers={"x-user-id": "999"})
+    assert r.status_code == 404, "a non-owner must not read another user's meeting"

--- a/docs/changelog.d/825-status-projection.md
+++ b/docs/changelog.d/825-status-projection.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **`GET /bots/status` no longer reads a caller's entire meeting history to answer a running-bots
+  badge.** It fetched every meeting the account ever had, with the full `data` JSONB, and filtered
+  in Python — 4,896 meetings / 180 MB on one production account, 144 MB of that `bot_logs` no
+  endpoint renders. Four concurrent polls demanded roughly 740 MB transiently and OOM-killed the
+  pod at the default 1 GiB limit. The status filter and the heavy-key projection now both happen in
+  the query. ([#803](https://github.com/Vexa-ai/vexa/issues/803))
+- **`GET /meetings/{id}` fetches the row instead of enumerating the account and filtering by id.**
+  Access rules are unchanged — the same ownership/share union decides visibility — and the detail
+  view still returns full `data`. ([#803](https://github.com/Vexa-ai/vexa/issues/803))


### PR DESCRIPTION
Part of #803 (the issue stays open — see "Not claimed" below).

## The observation bundle

All measurements below are **current-era** — taken live on today's pods (image `0.12.14-260719-hc12`), not from historical rows.

| # | Observation | Result |
|---|---|---|
| 1 | **Not a leak — peak memory.** 8-min RssAnon series on 3 identical pods: flat-to-declining baselines at wildly different plateaus (712 / 778 / 1344 MiB) with one +300 MiB step that never returned — per-request high-water marks, not a slope. Allocator-retention hypothesis falsified on linux/CPython 3.12: 4 concurrent parses of a 162 MB payload peaked 741 MB and returned to 187 MB after gc. | ✅ raw series in the issue comment |
| 2 | **The demand source.** `GET /bots/status` enumerates the caller's whole account with full `data`: 4,896 meetings / 180 MB for one live account, 144 MB of it `bot_logs` no endpoint renders. 4 concurrent polls hit one pod within 400 ms (trace ids logged). Deployed pod's code confirmed: `collector/app.py:233` filters in Python, `adapters.py:500` exempts this path from projection. | ✅ pod grep + DB size query |
| 3 | Red→green: `/bots/status` returns only running rows, projected — the store receives the status set and `slim=True`, and hands the route exactly the running rows, not the account | ✅ `test_bots_status_asks_the_store_for_the_filter_rather_than_filtering_after` + 2 siblings. **Negative control:** restored route-side filtering → store returned 46 rows for a 5-bot badge, heavy keys shipped — 3 tests FAIL; restored → green |
| 4 | `GET /meetings/{id}` reads ONE row (id constrained in SQL under the same access union), still returns full `data`, still 404s a non-owner | ✅ `test_get_meeting_by_id_is_constrained_in_the_store` + `test_get_meeting_by_id_still_refuses_a_non_owner` |
| 5 | No-regression: #584 list-view semantics untouched; full meeting-api suite; repo gates | ✅ 742 passed · `gates.mjs all` green |

## Point of introduction

The #584 outage fix built exactly the right mechanism (status/heavy-key projection) and then exempted "internal enumeration" callers — but `/bots/status` is a user-facing polling endpoint, not internal enumeration. That exemption is the defect; the fix extends the same projection to it via a `slim` flag and pushes the status filter into SQL (`status` now accepts a set). Callers that genuinely need every key (detail view, calendar sync, reconciliation) are unchanged.

**Not claimed:** that this settles the issue's "10–20 Mi/min" figure — that slope was never reproduced (likely a metrics-scrape smoothing artifact of the steps). A multi-hour post-deploy RSS series should confirm before the 2560Mi mitigation is lowered; proposed as the issue's closing observation.

