### PR TITLE
fix(join): Zoom/Teams admission verdicts are typed — permanent failures stop being retried (#806)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/googlemeet/admission.ts
+++ b/core/meetings/modules/join/src/googlemeet/admission.ts
@@ -366,7 +366,7 @@ export async function waitForGoogleMeetingAdmission(
       const finalWaitingCheck = await checkForWaitingRoomIndicators(page);
       
       if (finalWaitingCheck) {
-        throw new Error("Bot is still in the Google Meet waiting room after timeout - not admitted to the meeting");
+        throw new AdmissionError("lobby_timeout", "Bot is still in the Google Meet waiting room after timeout - not admitted to the meeting");
       }
     } else {
       // Not in waiting room and not admitted yet: actively poll during the timeout

--- a/core/meetings/modules/join/src/msteams/admission.test.ts
+++ b/core/meetings/modules/join/src/msteams/admission.test.ts
@@ -1,0 +1,103 @@
+/**
+ * #806 — Teams admission verdicts are TYPED (AdmissionError), not plain Errors.
+ *
+ * Teams had TWO layers of the same defect: (1) every denial/timeout threw a bare Error (the
+ * denial message was byte-identical to the Google Meet path that throws a typed one), and
+ * (2) even a typed throw would have been FLATTENED by the function's outer catch, which
+ * re-wraps everything into `new Error("Bot was not admitted … ${message}")`. Either layer
+ * alone turns a PERMANENT host denial into a transient `join_failure` the control plane
+ * re-spawns 3× on the user's quota.
+ *
+ * Drives the SHIPPED waitForTeamsMeetingAdmission over a fabricated locator-only Page (the
+ * Teams checks are all selector-visibility reads — same no-browser pattern as the jitsi and
+ * zoom admission tests). Escalation note: cases conclude before any checkEscalation threshold
+ * (see zoom/admission.test.ts) so the 5-minute escalation extension never latches.
+ *
+ * Run: npx tsx src/msteams/admission.test.ts
+ */
+
+import { waitForTeamsMeetingAdmission } from "./admission";
+import { AdmissionError } from "../shared/admission";
+import { resetEscalation } from "../shared/escalation";
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail?: string) {
+  if (ok) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ""}`); failed++; }
+}
+
+/** A page whose world is a set of currently-visible selectors, mutable mid-test. */
+function makePage(isVisible: (sel: string) => boolean): any {
+  const locator = (sel: string): any => ({
+    first: () => locator(sel),
+    isVisible: async () => isVisible(sel),
+    click: async () => {},
+    count: async () => 0,
+  });
+  return {
+    locator,
+    getByRole: (_role: string, _opts?: any) => locator(`role:${_role}`),
+    waitForTimeout: async (_ms: number) => {},
+    evaluate: async (fn: any, arg?: any) => {
+      (globalThis as any).document = { body: { innerText: "" } };
+      try { return fn(arg); } finally { delete (globalThis as any).document; }
+    },
+  };
+}
+
+const LOBBY = "Someone will let you in shortly";
+const DENIED = "Sorry, but you were denied";
+
+async function outcomeOf(run: Promise<unknown>): Promise<string> {
+  try { await run; return "resolved"; }
+  catch (e: any) { return e instanceof AdmissionError ? `AdmissionError:${e.outcome}` : `Error:${e.message}`; }
+}
+
+async function main() {
+  const cfg: any = {};
+
+  console.log("\n=== host denial → typed PERMANENT denial (survives the outer catch) ===");
+  {
+    resetEscalation();
+    // Start in the lobby; after a few polls the lobby disappears and the denial text renders —
+    // the shipped flow then runs checkForTeamsRejection and must throw the TYPED verdict.
+    let polls = 0;
+    const page = makePage((sel) => {
+      const denied = polls > 6;
+      if (sel.includes(LOBBY)) { polls++; return !denied; }
+      if (sel.includes(DENIED)) return denied;
+      return false;
+    });
+    const got = await outcomeOf(waitForTeamsMeetingAdmission(page, 60_000, cfg));
+    check("denial → AdmissionError('denial') — permanent, never re-spawned",
+      got === "AdmissionError:denial", got);
+  }
+
+  console.log("\n=== lobby forever → typed TRANSIENT lobby_timeout ===");
+  {
+    resetEscalation();
+    // timeout=0: the admission poll loop is never entered; the final still-in-lobby check must
+    // throw the typed timeout, not the old plain Error the outer catch then re-wrapped.
+    const page = makePage((sel) => sel.includes(LOBBY));
+    const got = await outcomeOf(waitForTeamsMeetingAdmission(page, 0, cfg));
+    check("lobby timeout → AdmissionError('lobby_timeout') — the legit retry stays a retry",
+      got === "AdmissionError:lobby_timeout", got);
+  }
+
+  console.log("\n=== an UNTYPED failure still reads as a plain Error (no over-typing) ===");
+  {
+    resetEscalation();
+    // Nothing visible at all: no lobby, no denial, no admission indicators. That is genuinely
+    // indeterminate — it must NOT be dressed up as a typed admission verdict.
+    const page = makePage(() => false);
+    const got = await outcomeOf(waitForTeamsMeetingAdmission(page, 0, cfg));
+    check("indeterminate state stays a plain Error (transient join_failure at the driver)",
+      got.startsWith("Error:"), got);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/core/meetings/modules/join/src/msteams/admission.ts
+++ b/core/meetings/modules/join/src/msteams/admission.ts
@@ -1,3 +1,4 @@
+import { AdmissionError } from "../shared/admission";
 import { Page } from "playwright";
 import { log, callAwaitingAdmissionCallback } from "../_host";
 import { BotConfig } from "../_host";
@@ -208,7 +209,7 @@ export async function waitForTeamsMeetingAdmission(
           const isRejected = await checkForTeamsRejection(page);
           if (isRejected) {
             log("🚨 Bot was rejected from the Teams meeting by admin");
-            throw new Error("Bot admission was rejected by meeting admin");
+            throw new AdmissionError("denial", "Bot admission was rejected by meeting admin");
           }
 
           // Check for admission indicators since waiting room disappeared and no rejection found
@@ -254,7 +255,7 @@ export async function waitForTeamsMeetingAdmission(
       const finalWaitingCheck = finalLobbyTextVisible || finalJoinNowButtonVisible;
 
       if (finalWaitingCheck) {
-        throw new Error("Bot is still in the Teams waiting room after timeout - not admitted to the meeting");
+        throw new AdmissionError("lobby_timeout", "Bot is still in the Teams waiting room after timeout - not admitted to the meeting");
       }
     }
 
@@ -301,7 +302,7 @@ export async function waitForTeamsMeetingAdmission(
         const isRejected = await checkForTeamsRejection(page);
         if (isRejected) {
           log("🚨 Bot was rejected from the Teams meeting by admin");
-          throw new Error("Bot admission was rejected by meeting admin");
+          throw new AdmissionError("denial", "Bot admission was rejected by meeting admin");
         }
 
         // Check for admission
@@ -339,13 +340,13 @@ export async function waitForTeamsMeetingAdmission(
               }
               const rejectedNow = await checkForTeamsRejection(page);
               if (rejectedNow) {
-                throw new Error("Bot admission was rejected by meeting admin");
+                throw new AdmissionError("denial", "Bot admission was rejected by meeting admin");
               }
             }
             await page.waitForTimeout(2000);
             log(`Still in Teams waiting room... ${Math.round((Date.now() - lobbyStart) / 1000)}s elapsed`);
           }
-          throw new Error("Bot is still in the Teams waiting room after timeout");
+          throw new AdmissionError("lobby_timeout", "Bot is still in the Teams waiting room after timeout");
         }
 
         log(`Polling for admission... ${Math.round((Date.now() - pollStart) / 1000)}s elapsed`);
@@ -371,6 +372,10 @@ export async function waitForTeamsMeetingAdmission(
     }
 
   } catch (error: any) {
+    // Re-throw typed admission verdicts unchanged (same idiom as googlemeet/admission.ts): the
+    // driver inspects `outcome` with `instanceof`, and wrapping here is exactly what used to
+    // flatten a Teams denial into a transient, retried `join_failure`.
+    if (error instanceof AdmissionError) throw error;
     throw new Error(
       `Bot was not admitted into the Teams meeting within the timeout period: ${error.message}`
     );

--- a/core/meetings/modules/join/src/zoom/admission.test.ts
+++ b/core/meetings/modules/join/src/zoom/admission.test.ts
@@ -1,0 +1,94 @@
+/**
+ * #806 — Zoom admission verdicts are TYPED (AdmissionError), not plain Errors.
+ *
+ * Every Zoom admission failure used to throw a bare Error, so the driver's `instanceof
+ * AdmissionError` check missed it and the orchestrator blanket-mapped it to a TRANSIENT
+ * `join_failure` — the retry classifier then RE-SPAWNED bots against meetings that had
+ * DENIED them (a host rejection re-knocked 3×; the RTMS anti-bot wall was retried into
+ * the same wall), burning user quota on permanent verdicts.
+ *
+ * Drives the SHIPPED waitForZoomMeetingAdmission over a fabricated Page whose `evaluate`
+ * runs the probe fns in-node against a fake `document` (same no-browser pattern as
+ * jitsi/admission.test.ts).
+ *
+ * Run: npx tsx src/zoom/admission.test.ts
+ */
+
+import { waitForZoomMeetingAdmission } from "./admission";
+import { AdmissionError } from "../shared/admission";
+import { resetEscalation } from "../shared/escalation";
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail?: string) {
+  if (ok) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ""}`); failed++; }
+}
+
+/** A page whose DOM is just body text: evaluate() runs the probe in-node, locators see nothing. */
+function makePage(bodyText: () => string): any {
+  const locator = (sel: string): any => ({
+    first: () => locator(sel),
+    isVisible: async () => false,
+    click: async () => {},
+    count: async () => 0,
+  });
+  return {
+    evaluate: async (fn: any, arg?: any) => {
+      (globalThis as any).document = { body: { innerText: bodyText() } };
+      try { return fn(arg); } finally { delete (globalThis as any).document; }
+    },
+    locator,
+    waitForTimeout: async (_ms: number) => {},
+  };
+}
+
+async function outcomeOf(run: Promise<unknown>): Promise<string> {
+  try { await run; return "resolved"; }
+  catch (e: any) { return e instanceof AdmissionError ? `AdmissionError:${e.outcome}` : `Error:${e.message}`; }
+}
+
+async function main() {
+  const cfg: any = {};
+
+  // NB on escalation: once checkEscalation fires (elapsed > 80% of timeout, or >10s of unknown
+  // state), the module latches a 5-MINUTE timeout extension — with a no-op waitForTimeout that
+  // turns the poll into a minutes-long busy spin. Each case below is shaped to conclude before
+  // any escalation threshold: the timeout case uses timeoutMs=0 (the poll loop is never entered),
+  // and the rejection flips on the second iteration (~4s of logical unknown time, under the 10s
+  // bar). resetEscalation() between cases keeps the latch from leaking across them.
+
+  console.log("\n=== admission never granted → typed TRANSIENT lobby_timeout ===");
+  {
+    resetEscalation();
+    const page = makePage(() => "");
+    const got = await outcomeOf(waitForZoomMeetingAdmission(page, 0, cfg));
+    check("timeout → AdmissionError('lobby_timeout') — the legit retry case stays a retry",
+      got === "AdmissionError:lobby_timeout", got);
+  }
+
+  console.log("\n=== RTMS anti-bot wall (pre-poll) → typed PERMANENT denial ===");
+  {
+    resetEscalation();
+    const page = makePage(() => "Automated bots aren't allowed. This meeting must use Zoom RTMS.");
+    const got = await outcomeOf(waitForZoomMeetingAdmission(page, 4000, cfg));
+    check("anti-bot wall → AdmissionError('denial'), never a retried join_failure",
+      got === "AdmissionError:denial", got);
+  }
+
+  console.log("\n=== host rejection during the poll → typed PERMANENT denial ===");
+  {
+    resetEscalation();
+    // First evaluate calls see a neutral page (no wall, not admitted), then the removal text lands.
+    let polled = 0;
+    const page = makePage(() => (polled++ < 3 ? "" : "You have been removed from the meeting"));
+    const got = await outcomeOf(waitForZoomMeetingAdmission(page, 30_000, cfg));
+    check("host rejection → AdmissionError('denial') — a re-knock cannot succeed",
+      got === "AdmissionError:denial", got);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/core/meetings/modules/join/src/zoom/admission.ts
+++ b/core/meetings/modules/join/src/zoom/admission.ts
@@ -1,3 +1,4 @@
+import { AdmissionError } from '../shared/admission';
 import { Page } from "playwright";
 import { log, callAwaitingAdmissionCallback, callBlockedCallback } from "../_host";
 import { BotConfig } from "../_host";
@@ -177,7 +178,10 @@ export async function waitForZoomMeetingAdmission(
     if (wall) {
       log(`[Zoom Web] 🚫 Anti-bot wall detected (matched: "${wall}") — this meeting requires Zoom RTMS; bots cannot join via the web client. Failing fast.`);
       await callBlockedCallback(botConfig, 'zoom_requires_rtms', { matched: wall, phase: 'pre_admission_poll' });
-      throw new Error('[Zoom Web] zoom_requires_rtms: meeting/account blocks automated browser joins and requires Zoom RTMS (Realtime Media Streams); route to the RTMS path');
+      // PERMANENT platform verdict: Zoom itself refuses browser bots here — a re-spawn hits the
+      // same wall. `denial` is the closest sealed outcome (a distinct `blocked` CompletionReason
+      // needs lane:contract — see join-driver.ts).
+      throw new AdmissionError('denial', '[Zoom Web] zoom_requires_rtms: meeting/account blocks automated browser joins and requires Zoom RTMS (Realtime Media Streams); route to the RTMS path');
     }
   }
 
@@ -203,7 +207,7 @@ export async function waitForZoomMeetingAdmission(
 
     if (await isRejectedOrEnded(page)) {
       log('[Zoom Web] Bot was rejected or meeting ended during admission wait');
-      throw new Error('Bot was rejected from the Zoom meeting or meeting ended');
+      throw new AdmissionError('denial', 'Bot was rejected from the Zoom meeting or meeting ended');
     }
 
     // Anti-bot wall can also appear a beat after Join (the reCAPTCHA frame and
@@ -213,7 +217,7 @@ export async function waitForZoomMeetingAdmission(
     if (wall) {
       log(`[Zoom Web] 🚫 Anti-bot wall detected during poll (matched: "${wall}") — requires Zoom RTMS. Failing fast.`);
       await callBlockedCallback(botConfig, 'zoom_requires_rtms', { matched: wall, phase: 'admission_poll' });
-      throw new Error('[Zoom Web] zoom_requires_rtms: meeting/account blocks automated browser joins and requires Zoom RTMS (Realtime Media Streams); route to the RTMS path');
+      throw new AdmissionError('denial', '[Zoom Web] zoom_requires_rtms: meeting/account blocks automated browser joins and requires Zoom RTMS (Realtime Media Streams); route to the RTMS path');
     }
 
     if (await isAdmitted(page)) {
@@ -240,7 +244,7 @@ export async function waitForZoomMeetingAdmission(
     log(`[Zoom Web] Still waiting for admission... ${elapsed}s elapsed`);
   }
 
-  throw new Error(`[Zoom Web] Bot not admitted within ${effectiveTimeout()}ms timeout`);
+  throw new AdmissionError('lobby_timeout', `[Zoom Web] Bot not admitted within ${effectiveTimeout()}ms timeout`);
 }
 
 export async function checkForZoomAdmissionSilent(page: Page): Promise<boolean> {

--- a/core/meetings/modules/join/src/zoom/join.ts
+++ b/core/meetings/modules/join/src/zoom/join.ts
@@ -1,3 +1,4 @@
+import { AdmissionError } from '../shared/admission';
 import { Page } from "playwright";
 import { log, callJoiningCallback } from "../_host";
 import { BotConfig } from "../_host";
@@ -137,7 +138,10 @@ export async function joinZoomMeeting(
     }).catch(() => false);
     if (authRequired && !authenticated) {
       log('[Zoom Web] Sign-in page detected — meeting requires authenticated users');
-      throw new Error('[Zoom Web] auth_required: meeting host has restricted entry to authenticated Zoom users; bot cannot join without a Zoom account session');
+      // PERMANENT: the host restricted entry to signed-in users and this bot has no session — a
+      // re-spawn joins just as signed-out. Same sealed outcome the authenticated-mode dead-profile
+      // path uses; the retry classifier already treats it as no-retry.
+      throw new AdmissionError('auth_session_missing', '[Zoom Web] auth_required: meeting host has restricted entry to authenticated Zoom users; bot cannot join without a Zoom account session');
     }
     if (authRequired && authenticated) {
       log('[Zoom Web] Authenticated mode: sign-in text present, proceeding (the persistent context should already carry a Zoom session)');

--- a/docs/changelog.d/827-typed-admission-verdicts.md
+++ b/docs/changelog.d/827-typed-admission-verdicts.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Zoom and Teams admission verdicts are now typed, so permanent failures are no longer
+  retried on your quota.** Both platforms threw plain errors for every admission failure, which
+  the control plane classified as transient `join_failure` and re-spawned up to 3× — a Zoom host
+  denial re-knocked on the same host, the Zoom RTMS anti-bot wall was retried into the same wall,
+  and a meeting restricted to signed-in users was rejoined just as signed-out. They now throw the
+  same typed `AdmissionError` Google Meet and Jitsi already use: denials and auth walls are
+  permanent (no retry), lobby timeouts stay transient (still retried). Teams additionally had an
+  outer catch that re-wrapped *any* error — including a typed one — into a plain string; typed
+  verdicts now pass through it. Failure reasons land in `completion_reason`
+  (`awaiting_admission_rejected` / `awaiting_admission_timeout` / `auth_session_missing`), making
+  these modes measurable per platform for the first time.
+  ([#806](https://github.com/Vexa-ai/vexa/issues/806))


### PR DESCRIPTION
Refs #806 — this is the era-independent half (see the era-correction comment on the issue): the code defect that misclassifies Zoom/Teams admission failures and burns retries on permanent verdicts. The `join_failure_code` taxonomy field stays open on the issue.

## The observation bundle

| # | Observation | Result |
|---|---|---|
| 1 | **Code fact (era-independent):** `AdmissionOutcome` existed (`shared/admission.ts:15`) and the driver mapping was correct (`join-driver.ts:33`) — but Zoom/Teams threw bare Errors at every terminal site, so all their admission failures blanket-mapped to TRANSIENT `join_failure` and `retry.py` re-spawned them | anchored at `zoom/admission.ts`, `zoom/join.ts:140`, `msteams/admission.ts` (pre-fix) |
| 2 | **The Teams flattener:** the outer catch re-wrapped every throw — even a typed one — into a plain Error. Found during this work; fixing the throw sites alone would have changed nothing on Teams | red→green in row 4 |
| 3 | Zoom red→green: RTMS wall → `denial`; host rejection mid-poll → `denial`; timeout → `lobby_timeout` — driving the SHIPPED `waitForZoomMeetingAdmission` over a fabricated page | ✅ `zoom/admission.test.ts` (3 cases). **Negative control:** reverted the typed rejection → FAIL (`Error:Bot was rejected…`), restored → green |
| 4 | Teams red→green: denial → `denial` **through the outer catch**; lobby timeout → `lobby_timeout`; genuinely indeterminate state STAYS a plain Error (no over-typing) | ✅ `msteams/admission.test.ts` (3 cases). **Negative control:** restored the flattener → denial and timeout both FAIL flattened, restored → green |
| 5 | No-regression: full join-module suite (107 PASS incl. the existing gmeet/jitsi typed cases) · build green · `gates.mjs all` green | ✅ |

## Retry-class consequences (the user-visible value)

| Mode | Before | After |
|---|---|---|
| Zoom host denial | `join_failure` → re-knock 3× | `awaiting_admission_rejected`, no retry |
| Zoom RTMS anti-bot wall | retried into the same wall | `awaiting_admission_rejected`, no retry |
| Zoom signed-in-users-only | rejoined signed-out 3× | `auth_session_missing`, no retry |
| Teams host denial | `join_failure` → re-spawn 3× | `awaiting_admission_rejected`, no retry |
| Zoom/Teams lobby timeout | retried (correct, by accident) | `awaiting_admission_timeout`, retried (correct, on purpose) |

These land in `completion_reason`, so the modes become measurable per platform — the first half of #806's taxonomy ask.

## Test-harness note (honest)

The admission waits couple to the escalation module: once `checkEscalation` fires, a 5-minute timeout extension latches, which with a no-op `waitForTimeout` turns the poll into a minutes-long busy spin. Each test case is shaped to conclude before any threshold (timeout cases use `timeoutMs=0` so the poll loop is never entered; rejections flip on the second iteration), with `resetEscalation()` between cases. The zoom auth-wall throw (`zoom/join.ts`) is typed but not unit-driven — its flow needs a full join; it is compile-checked and will be witnessed in the release walk.

Live leg: not yet run. A real Zoom/Teams denial needs a human host to deny the bot — batched into the v0.12.15 witness walk rather than claimed here.
