### PR TITLE
feat(deploy): the deprecated 0.10 dashboard gets a bounded, off-by-default home (#813)

### DIFF
--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -1,2263 +1,2305 @@
 {
-  "$schema": "https://calm.finos.org/release/1.0/meta/calm.json",
-  "metadata": [
+ "$schema": "https://calm.finos.org/release/1.0/meta/calm.json",
+ "metadata": [
+  {
+   "vexa": {
+    "purpose": "SSOT architecture model: module/service/contract inventory AND the runtime data plane (carriers, ownership, flows, egress boundary). gate:dataflow enforces model<->disk completeness, single-writer + render-only ownership, and a reality diff against code; gate:calm validates it against the FINOS meeting-intelligence pattern.",
+    "principle": "P23 — one writer per data carrier; readers never re-derive a producer's data; the model covers every module/service/contract (no drift)."
+   }
+  }
+ ],
+ "nodes": [
+  {
+   "unique-id": "meetings",
+   "node-type": "system",
+   "name": "meetings",
+   "description": "capture → transcribe → record; owns the raw transcript",
+   "metadata": [
     {
-      "vexa": {
-        "purpose": "SSOT architecture model: module/service/contract inventory AND the runtime data plane (carriers, ownership, flows, egress boundary). gate:dataflow enforces model<->disk completeness, single-writer + render-only ownership, and a reality diff against code; gate:calm validates it against the FINOS meeting-intelligence pattern.",
-        "principle": "P23 \u2014 one writer per data carrier; readers never re-derive a producer's data; the model covers every module/service/contract (no drift)."
-      }
+     "path": "core/meetings"
     }
-  ],
-  "nodes": [
-    {
-      "unique-id": "meetings",
-      "node-type": "system",
-      "name": "meetings",
-      "description": "capture \u2192 transcribe \u2192 record; owns the raw transcript",
-      "metadata": [
-        {
-          "path": "core/meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "agent",
-      "node-type": "system",
-      "name": "agent",
-      "description": "copilot; owns the processed (cleaned) transcript + signals",
-      "metadata": [
-        {
-          "path": "core/agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "gateway-system",
-      "node-type": "system",
-      "name": "gateway",
-      "description": "the one public edge (api.v1, ws.v1)",
-      "metadata": [
-        {
-          "path": "core/gateway"
-        }
-      ]
-    },
-    {
-      "unique-id": "identity",
-      "node-type": "system",
-      "name": "identity",
-      "description": "access + audit; owns the durable DB",
-      "metadata": [
-        {
-          "path": "core/identity"
-        }
-      ]
-    },
-    {
-      "unique-id": "runtime-system",
-      "node-type": "system",
-      "name": "runtime",
-      "description": "workload spawn (bot/agent containers)",
-      "metadata": [
-        {
-          "path": "core/runtime"
-        }
-      ]
-    },
-    {
-      "unique-id": "deploy",
-      "node-type": "system",
-      "name": "deploy",
-      "description": "deployment + execution-target registry",
-      "metadata": [
-        {
-          "path": "deploy"
-        }
-      ]
-    },
-    {
-      "unique-id": "agent-api",
-      "node-type": "service",
-      "name": "agent-api",
-      "description": "unit control-plane; dispatch -> runtime spawn; meeting copilot",
-      "metadata": [
-        {
-          "path": "core/agent/services/agent-api"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "agent-api-rest",
-          "type": "api"
-        }
-      ]
-    },
-    {
-      "unique-id": "conformance",
-      "node-type": "service",
-      "name": "conformance",
-      "description": "conformance \u2014 service in gateway",
-      "metadata": [
-        {
-          "path": "core/gateway/services/conformance"
-        }
-      ]
-    },
-    {
-      "unique-id": "gateway",
-      "node-type": "service",
-      "name": "gateway",
-      "description": "edge: auth (scopes) + REST routing + WS fan-out",
-      "metadata": [
-        {
-          "path": "core/gateway/services/gateway"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "gateway-rest",
-          "type": "api"
-        },
-        {
-          "unique-id": "gateway-ws",
-          "type": "websocket"
-        }
-      ]
-    },
-    {
-      "unique-id": "admin-api",
-      "node-type": "service",
-      "name": "admin-api",
-      "description": "identity: token mint/validate, users, webhooks",
-      "metadata": [
-        {
-          "path": "core/identity/services/admin-api"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "admin-api-rest",
-          "type": "api"
-        }
-      ]
-    },
-    {
-      "unique-id": "bot",
-      "node-type": "service",
-      "name": "bot",
-      "description": "spawned-per-meeting worker: join -> capture -> STT -> transcript.v1",
-      "metadata": [
-        {
-          "path": "core/meetings/services/bot"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "bot-commands-sub",
-          "type": "consumer"
-        }
-      ]
-    },
-    {
-      "unique-id": "transcription",
-      "node-type": "service",
-      "name": "transcription",
-      "description": "transcription \u2014 STT service (faster-whisper / CTranslate2, OpenAI-compatible /v1/audio/transcriptions). The GPU workload, deployed separately from the main stack; the bot streams audio windows to it and receives segments. Does not write any redis carrier (the bot XADDs segments).",
-      "metadata": [
-        {
-          "path": "core/meetings/services/transcription"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "stt-endpoint",
-          "type": "api"
-        }
-      ]
-    },
-    {
-      "unique-id": "desktop",
-      "node-type": "service",
-      "name": "desktop",
-      "description": "all-in-one dev host: bot+collector+gateway in one process",
-      "metadata": [
-        {
-          "path": "core/meetings/services/desktop"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "desktop-rest",
-          "type": "api"
-        },
-        {
-          "unique-id": "desktop-ingest-ws",
-          "type": "websocket"
-        }
-      ]
-    },
-    {
-      "unique-id": "meeting-api",
-      "node-type": "service",
-      "name": "meeting-api",
-      "description": "collector + bot-spawn + recordings + sessions (the hub)",
-      "metadata": [
-        {
-          "path": "core/meetings/services/meeting-api"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "meeting-api-rest",
-          "type": "api"
-        }
-      ]
-    },
-    {
-      "unique-id": "mcp",
-      "node-type": "service",
-      "name": "mcp",
-      "description": "MCP tools + prompts over the public API (stateless FastAPI, /mcp mount)",
-      "metadata": [
-        {
-          "path": "core/meetings/services/mcp"
-        }
-      ],
-      "interfaces": [
-        {
-          "unique-id": "mcp-http",
-          "type": "api"
-        }
-      ]
-    },
-    {
-      "unique-id": "buffer",
-      "node-type": "module",
-      "name": "buffer",
-      "description": "buffer \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/buffer"
-        }
-      ]
-    },
-    {
-      "unique-id": "capture-codec",
-      "node-type": "module",
-      "name": "capture-codec",
-      "description": "capture-codec \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/capture-codec"
-        }
-      ]
-    },
-    {
-      "unique-id": "gmeet-capture",
-      "node-type": "module",
-      "name": "gmeet-capture",
-      "description": "gmeet-capture \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/gmeet-capture"
-        }
-      ]
-    },
-    {
-      "unique-id": "gmeet-pipeline",
-      "node-type": "module",
-      "name": "gmeet-pipeline",
-      "description": "gmeet-pipeline \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/gmeet-pipeline"
-        }
-      ]
-    },
-    {
-      "unique-id": "jitsi-capture",
-      "node-type": "module",
-      "name": "jitsi-capture",
-      "description": "jitsi-capture \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/jitsi-capture"
-        }
-      ]
-    },
-    {
-      "unique-id": "join",
-      "node-type": "module",
-      "name": "join",
-      "description": "join \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/join"
-        }
-      ]
-    },
-    {
-      "unique-id": "mixed-capture-core",
-      "node-type": "module",
-      "name": "mixed-capture-core",
-      "description": "mixed-capture-core \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/mixed-capture-core"
-        }
-      ]
-    },
-    {
-      "unique-id": "mixed-pipeline",
-      "node-type": "module",
-      "name": "mixed-pipeline",
-      "description": "mixed-pipeline \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/mixed-pipeline"
-        }
-      ]
-    },
-    {
-      "unique-id": "record-chunker",
-      "node-type": "module",
-      "name": "record-chunker",
-      "description": "record-chunker \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/record-chunker"
-        }
-      ]
-    },
-    {
-      "unique-id": "recording",
-      "node-type": "module",
-      "name": "recording",
-      "description": "recording \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/recording"
-        }
-      ]
-    },
-    {
-      "unique-id": "remote-browser",
-      "node-type": "module",
-      "name": "remote-browser",
-      "description": "remote-browser \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/remote-browser"
-        }
-      ]
-    },
-    {
-      "unique-id": "teams-capture",
-      "node-type": "module",
-      "name": "teams-capture",
-      "description": "teams-capture \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/teams-capture"
-        }
-      ]
-    },
-    {
-      "unique-id": "whisper",
-      "node-type": "module",
-      "name": "whisper",
-      "description": "whisper \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/whisper"
-        }
-      ]
-    },
-    {
-      "unique-id": "zoom-capture",
-      "node-type": "module",
-      "name": "zoom-capture",
-      "description": "zoom-capture \u2014 atomic module in meetings",
-      "metadata": [
-        {
-          "path": "core/meetings/modules/zoom-capture"
-        }
-      ]
-    },
-    {
-      "unique-id": "event.v1",
-      "node-type": "contract",
-      "name": "event.v1",
-      "description": "event.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/event.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "invoke.v1",
-      "node-type": "contract",
-      "name": "invoke.v1",
-      "description": "invoke.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/invoke.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "proactive-card.v1",
-      "node-type": "contract",
-      "name": "proactive-card.v1",
-      "description": "proactive-card.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/proactive-card.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "routine.v1",
-      "node-type": "contract",
-      "name": "routine.v1",
-      "description": "routine.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/routine.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "task.v1",
-      "node-type": "contract",
-      "name": "task.v1",
-      "description": "task.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/task.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "tool.v1",
-      "node-type": "contract",
-      "name": "tool.v1",
-      "description": "tool.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/tool.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "unit.v1",
-      "node-type": "contract",
-      "name": "unit.v1",
-      "description": "unit.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/unit.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "processed-notes.v1",
-      "node-type": "contract",
-      "name": "processed-notes.v1",
-      "description": "processed-notes.v1 \u2014 sealed/published contract (agent): the proc:meeting:{row_id} cleaned-notes stream + view_end terminal marker (agent-worker \u2192 meeting-api db-writer / agent-api SSE; ADR-0027)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/processed-notes.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "workspace.v1",
-      "node-type": "contract",
-      "name": "workspace.v1",
-      "description": "workspace.v1 \u2014 sealed/published contract (agent)",
-      "metadata": [
-        {
-          "path": "core/agent/contracts/workspace.v1",
-          "domain": "agent"
-        }
-      ]
-    },
-    {
-      "unique-id": "api.v1",
-      "node-type": "contract",
-      "name": "api.v1",
-      "description": "api.v1 \u2014 sealed/published contract (gateway)",
-      "metadata": [
-        {
-          "path": "core/gateway/contracts/api.v1",
-          "domain": "gateway"
-        }
-      ]
-    },
-    {
-      "unique-id": "logevent.v1",
-      "node-type": "contract",
-      "name": "logevent.v1",
-      "description": "logevent.v1 \u2014 sealed/published contract (gateway)",
-      "metadata": [
-        {
-          "path": "core/gateway/contracts/logevent.v1",
-          "domain": "gateway"
-        }
-      ]
-    },
-    {
-      "unique-id": "ws.v1",
-      "node-type": "contract",
-      "name": "ws.v1",
-      "description": "ws.v1 \u2014 sealed/published contract (gateway)",
-      "metadata": [
-        {
-          "path": "core/gateway/contracts/ws.v1",
-          "domain": "gateway"
-        }
-      ]
-    },
-    {
-      "unique-id": "identity.v1",
-      "node-type": "contract",
-      "name": "identity.v1",
-      "description": "identity.v1 \u2014 sealed/published contract (identity)",
-      "metadata": [
-        {
-          "path": "core/identity/contracts/identity.v1",
-          "domain": "identity"
-        }
-      ]
-    },
-    {
-      "unique-id": "acts.v1",
-      "node-type": "contract",
-      "name": "acts.v1",
-      "description": "acts.v1 \u2014 sealed/published contract (meetings)",
-      "metadata": [
-        {
-          "path": "core/meetings/contracts/acts.v1",
-          "domain": "meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "captured-signal.v1",
-      "node-type": "contract",
-      "name": "captured-signal.v1",
-      "description": "captured-signal.v1 \u2014 sealed/published contract (meetings)",
-      "metadata": [
-        {
-          "path": "core/meetings/contracts/captured-signal.v1",
-          "domain": "meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "flagged-issue.v1",
-      "node-type": "contract",
-      "name": "flagged-issue.v1",
-      "description": "flagged-issue.v1 \u2014 sealed/published contract (meetings)",
-      "metadata": [
-        {
-          "path": "core/meetings/contracts/flagged-issue.v1",
-          "domain": "meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "invocation.v1",
-      "node-type": "contract",
-      "name": "invocation.v1",
-      "description": "invocation.v1 \u2014 sealed/published contract (meetings)",
-      "metadata": [
-        {
-          "path": "core/meetings/contracts/invocation.v1",
-          "domain": "meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "lifecycle.v1",
-      "node-type": "contract",
-      "name": "lifecycle.v1",
-      "description": "lifecycle.v1 \u2014 sealed/published contract (meetings)",
-      "metadata": [
-        {
-          "path": "core/meetings/contracts/lifecycle.v1",
-          "domain": "meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "transcript.v1",
-      "node-type": "contract",
-      "name": "transcript.v1",
-      "description": "transcript.v1 \u2014 sealed/published contract (meetings)",
-      "metadata": [
-        {
-          "path": "core/meetings/contracts/transcript.v1",
-          "domain": "meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "webhook.v1",
-      "node-type": "contract",
-      "name": "webhook.v1",
-      "description": "webhook.v1 \u2014 sealed/published contract (meetings)",
-      "metadata": [
-        {
-          "path": "core/meetings/contracts/webhook.v1",
-          "domain": "meetings"
-        }
-      ]
-    },
-    {
-      "unique-id": "runtime.v1",
-      "node-type": "contract",
-      "name": "runtime.v1",
-      "description": "runtime.v1 \u2014 sealed/published contract (runtime)",
-      "metadata": [
-        {
-          "path": "core/runtime/contracts/runtime.v1",
-          "domain": "runtime"
-        }
-      ]
-    },
-    {
-      "unique-id": "schedule.v1",
-      "node-type": "contract",
-      "name": "schedule.v1",
-      "description": "schedule.v1 \u2014 sealed/published contract (runtime)",
-      "metadata": [
-        {
-          "path": "core/runtime/contracts/schedule.v1",
-          "domain": "runtime"
-        }
-      ]
-    },
-    {
-      "unique-id": "execution-targets.v1",
-      "node-type": "contract",
-      "name": "execution-targets.v1",
-      "description": "execution-targets.v1 \u2014 sealed/published contract (deploy)",
-      "metadata": [
-        {
-          "path": "deploy/contracts/execution-targets.v1",
-          "domain": "deploy"
-        }
-      ]
-    },
-    {
-      "unique-id": "config.v1",
-      "node-type": "contract",
-      "name": "config.v1",
-      "description": "config.v1 \u2014 sealed/published contract (deploy): per-service deployment-config declaration (required-explicit / defaulted / capability tri-state + live probes), preflight + gate:config-contract (ADR-0026)",
-      "metadata": [
-        {
-          "path": "deploy/contracts/config.v1",
-          "domain": "deploy"
-        }
-      ]
-    },
-    {
-      "unique-id": "slim",
-      "node-type": "webclient",
-      "name": "slim",
-      "description": "slim \u2014 client",
-      "metadata": [
-        {
-          "path": "clients/slim"
-        }
-      ]
-    },
-    {
-      "unique-id": "extension",
-      "node-type": "webclient",
-      "name": "extension",
-      "description": "extension \u2014 client",
-      "metadata": [
-        {
-          "path": "clients/extension"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal",
-      "node-type": "webclient",
-      "name": "terminal",
-      "description": "terminal \u2014 client",
-      "metadata": [
-        {
-          "path": "clients/terminal"
-        }
-      ],
-      "controls": {
-        "render-only": {
-          "description": "A reader must not re-derive a producer's data. The terminal renders raw|processed; it must NOT contain a transcript-shaping transform (e.g. clustering).",
-          "requirements": [
-            {
-              "requirement-url": "vexa/controls/render-only",
-              "config": {
-                "forbidden-symbols": [
-                  "buildMeetingNotes"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "segments-stream",
-      "node-type": "data-asset",
-      "name": "transcription_segments (stream)",
-      "description": "durable raw segment feed (transcript.v1); bot XADDs, collector XREADGROUPs",
-      "controls": {
-        "ownership": {
-          "description": "single writer",
-          "requirements": [
-            {
-              "requirement-url": "vexa/controls/single-writer",
-              "config": {
-                "writers": [
-                  "bot"
-                ],
-                "match": "transcription_segments",
-                "op": "xadd"
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "contract": "transcript.v1"
-        },
-        {
-          "stage": "raw"
-        }
-      ]
-    },
-    {
-      "unique-id": "tc-mutable",
-      "node-type": "data-asset",
-      "name": "tc:meeting:{id}:mutable (pubsub)",
-      "description": "change-only transcript deltas the gateway + agent-api subscribe to",
-      "controls": {
-        "ownership": {
-          "description": "shared \u2014 review (P23 prefers one writer)",
-          "requirements": [
-            {
-              "requirement-url": "vexa/controls/single-writer",
-              "config": {
-                "writers": [
-                  "bot",
-                  "meeting-api"
-                ],
-                "match": "tc:meeting:.*:mutable",
-                "op": "publish"
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "contract": "transcript.v1"
-        },
-        {
-          "stage": "raw"
-        }
-      ]
-    },
-    {
-      "unique-id": "tc-stream",
-      "node-type": "data-asset",
-      "name": "tc:meeting:{id} (stream)",
-      "description": "native per-meeting transcript stream the agent worker + terminal SSE read; the collector (meetings) is the single writer (P23)",
-      "controls": {
-        "ownership": {
-          "description": "single writer",
-          "requirements": [
-            {
-              "requirement-url": "vexa/controls/single-writer",
-              "config": {
-                "writers": [
-                  "meeting-api"
-                ],
-                "match": "tc:meeting:[^:]*$",
-                "op": "xadd"
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "contract": "transcript.v1"
-        },
-        {
-          "stage": "raw"
-        }
-      ]
-    },
-    {
-      "unique-id": "proc-stream",
-      "node-type": "data-asset",
-      "name": "proc:meeting:{id} (stream)",
-      "description": "cleaned 1:1 processed transcript, keyed by segment_id, + the view_end terminal marker (processed-notes.v1, ADR-0027); agent-worker is the writer; read by meeting-api's db-writer (durable data.processed.views) and agent-api's live SSE",
-      "controls": {
-        "ownership": {
-          "description": "single writer (P23)",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "agent-worker"
-                ],
-                "match": "proc:meeting:",
-                "op": "xadd"
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "contract": "transcript.v1"
-        },
-        {
-          "stage": "cleaned"
-        }
-      ]
-    },
-    {
-      "unique-id": "out-stream",
-      "node-type": "data-asset",
-      "name": "unit:{id}:out (stream)",
-      "description": "worker output stream (cards / agent activity / message deltas \u2014 notes moved to proc-stream per ADR-0027); agent-api relays as SSE",
-      "controls": {
-        "ownership": {
-          "description": "single writer (P23)",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "agent-worker"
-                ],
-                "match": "unit:.*:out",
-                "op": "xadd"
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "contract": "proactive-card.v1"
-        },
-        {
-          "stage": "cards"
-        }
-      ]
-    },
-    {
-      "unique-id": "segments-table",
-      "node-type": "database",
-      "name": "transcription_segments (table)",
-      "description": "persisted raw transcript rows",
-      "controls": {
-        "ownership": {
-          "description": "single writer",
-          "requirements": [
-            {
-              "requirement-url": "vexa/controls/single-writer",
-              "config": {
-                "writers": [
-                  "meeting-api"
-                ],
-                "match": "transcription_segments",
-                "op": "db-write"
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "contract": "transcript.v1"
-        },
-        {
-          "stage": "raw"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-app",
-      "node-type": "module",
-      "name": "terminal/app",
-      "description": "Next.js routes + SSE proxy (terminal)",
-      "metadata": [
-        {
-          "path": "clients/terminal/src/app"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-canvas",
-      "node-type": "module",
-      "name": "terminal/canvas",
-      "description": "render engine: kit, runtime, useMeeting, notes (terminal)",
-      "metadata": [
-        {
-          "path": "clients/terminal/src/canvas"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-contributions",
-      "node-type": "module",
-      "name": "terminal/contributions",
-      "description": "contributed surfaces/commands (terminal)",
-      "metadata": [
-        {
-          "path": "clients/terminal/src/contributions"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-platform",
-      "node-type": "module",
-      "name": "terminal/platform",
-      "description": "platform adapters (terminal)",
-      "metadata": [
-        {
-          "path": "clients/terminal/src/platform"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-surfaces",
-      "node-type": "module",
-      "name": "terminal/surfaces",
-      "description": "state stores + surfaces (meetingLive, chat, gatewayWS) (terminal)",
-      "metadata": [
-        {
-          "path": "clients/terminal/src/surfaces"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-ui-kit",
-      "node-type": "module",
-      "name": "terminal/ui-kit",
-      "description": "shared UI primitives (terminal)",
-      "metadata": [
-        {
-          "path": "clients/terminal/src/ui-kit"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-workbench",
-      "node-type": "module",
-      "name": "terminal/workbench",
-      "description": "dockview workbench shell (terminal)",
-      "metadata": [
-        {
-          "path": "clients/terminal/src/workbench"
-        }
-      ]
-    },
-    {
-      "unique-id": "recording-blob",
-      "node-type": "data-asset",
-      "name": "recordings bucket (blob)",
-      "description": "chunked meeting recordings: bot uploads chunks (record-chunker), meeting-api PUTs the stitched master",
-      "controls": {
-        "ownership": {
-          "description": "two writers by design: bot=chunks, meeting-api=master",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "bot",
-                  "meeting-api"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "stage": "audio"
-        }
-      ]
-    },
-    {
-      "unique-id": "userdata-blob",
-      "node-type": "data-asset",
-      "name": "userdata bucket (blob)",
-      "description": "authenticated-bot browser sessions (auth-essential profile subset): remote-browser's provisioning login uploads the signed-in session; the bot restores it before launch and writes the rotated session back on clean teardown",
-      "controls": {
-        "ownership": {
-          "description": "two writers by design: remote-browser=provisioning upload, bot=write-back on teardown",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "remote-browser",
-                  "bot"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "metadata": [
-        {
-          "stage": "session"
-        }
-      ]
-    },
-    {
-      "unique-id": "runtime",
-      "node-type": "service",
-      "name": "runtime",
-      "description": "runtime.v1 kernel: POST /workloads spawns containers (docker/k8s/process)",
-      "interfaces": [
-        {
-          "unique-id": "runtime-rest",
-          "type": "api"
-        }
-      ],
-      "metadata": [
-        {
-          "path": "core/runtime/src"
-        }
-      ]
-    },
-    {
-      "unique-id": "agent-worker",
-      "node-type": "service",
-      "name": "agent-worker",
-      "description": "spawned claude-in-container worker; one dispatch turn / meeting copilot",
-      "metadata": [
-        {
-          "path": "core/agent/worker"
-        }
-      ]
-    },
-    {
-      "unique-id": "platform",
-      "node-type": "system",
-      "name": "platform",
-      "description": "shared infra backing the services"
-    },
-    {
-      "unique-id": "redis",
-      "node-type": "service",
-      "name": "redis",
-      "description": "stream + pub/sub broker for the live + durable transcript planes"
-    },
-    {
-      "unique-id": "postgres",
-      "node-type": "database",
-      "name": "postgres",
-      "description": "durable relational store"
-    },
-    {
-      "unique-id": "minio",
-      "node-type": "service",
-      "name": "minio",
-      "description": "S3-compatible object store for recordings"
-    },
-    {
-      "unique-id": "bm-status",
-      "node-type": "data-asset",
-      "name": "bm:meeting:{id}:status (pubsub)",
-      "description": "bot/meeting status pub/sub; gateway fans out",
-      "controls": {
-        "ownership": {
-          "description": "single writer (P23)",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "meeting-api"
-                ],
-                "match": "bm:meeting:.*:status",
-                "op": "publish"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "u-meetings",
-      "node-type": "data-asset",
-      "name": "u:{user}:meetings (pubsub)",
-      "description": "per-user meeting-status pub/sub; gateway auto-subscribes",
-      "controls": {
-        "ownership": {
-          "description": "single writer (P23)",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "meeting-api"
-                ],
-                "match": "u:.*:meetings",
-                "op": "publish"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "bot-commands",
-      "node-type": "data-asset",
-      "name": "bot_commands:meeting:{id} (pubsub)",
-      "description": "acts.v1 commands (leave/speak) to the bot",
-      "controls": {
-        "ownership": {
-          "description": "single writer (P23)",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "meeting-api"
-                ],
-                "match": "bot_commands:",
-                "op": "publish"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "unit-in",
-      "node-type": "data-asset",
-      "name": "unit:{id}:in (stream)",
-      "description": "interactive input stream for warm chat units; agent-worker reads. NO in-repo writer in this carve (input arrives via the hosted control plane)"
-    },
-    {
-      "unique-id": "va-chat",
-      "node-type": "data-asset",
-      "name": "va:meeting:{id}:chat (pubsub)",
-      "description": "in-meeting chat pub/sub; gateway fans out. NO in-repo writer in this carve"
-    },
-    {
-      "unique-id": "identity-db",
-      "node-type": "data-asset",
-      "name": "identity (users/api_tokens)",
-      "description": "users + scoped API tokens",
-      "controls": {
-        "ownership": {
-          "description": "single writer (P23)",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
-              "config": {
-                "writers": [
-                  "admin-api"
-                ]
-              }
-            }
-          ]
-        }
-      }
+   ]
+  },
+  {
+   "unique-id": "agent",
+   "node-type": "system",
+   "name": "agent",
+   "description": "copilot; owns the processed (cleaned) transcript + signals",
+   "metadata": [
+    {
+     "path": "core/agent"
     }
-  ],
-  "relationships": [
+   ]
+  },
+  {
+   "unique-id": "gateway-system",
+   "node-type": "system",
+   "name": "gateway",
+   "description": "the one public edge (api.v1, ws.v1)",
+   "metadata": [
     {
-      "unique-id": "agent-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "agent",
-          "nodes": [
-            "agent-api",
-            "event.v1",
-            "invoke.v1",
-            "proactive-card.v1",
-            "routine.v1",
-            "task.v1",
-            "tool.v1",
-            "unit.v1",
-            "processed-notes.v1",
-            "workspace.v1",
-            "agent-worker",
-            "out-stream",
-            "unit-in",
-            "proc-stream",
-            "va-chat"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "gateway-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "gateway-system",
-          "nodes": [
-            "conformance",
-            "gateway",
-            "api.v1",
-            "logevent.v1",
-            "ws.v1"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "identity-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "identity",
-          "nodes": [
-            "admin-api",
-            "identity.v1",
-            "identity-db"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "meetings-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "meetings",
-          "nodes": [
-            "bot",
-            "desktop",
-            "meeting-api",
-            "mcp",
-            "buffer",
-            "capture-codec",
-            "gmeet-capture",
-            "gmeet-pipeline",
-            "jitsi-capture",
-            "join",
-            "mixed-capture-core",
-            "mixed-pipeline",
-            "record-chunker",
-            "recording",
-            "remote-browser",
-            "teams-capture",
-            "whisper",
-            "zoom-capture",
-            "acts.v1",
-            "captured-signal.v1",
-            "flagged-issue.v1",
-            "invocation.v1",
-            "lifecycle.v1",
-            "transcript.v1",
-            "webhook.v1",
-            "transcription",
-            "segments-stream",
-            "tc-stream",
-            "tc-mutable",
-            "bm-status",
-            "u-meetings",
-            "bot-commands",
-            "segments-table",
-            "recording-blob",
-            "userdata-blob"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "runtime-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "runtime-system",
-          "nodes": [
-            "runtime.v1",
-            "schedule.v1",
-            "runtime"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "bot-writes-segments-stream",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "bot"
-          },
-          "destination": {
-            "node": "segments-stream"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "bot-publishes-mutable",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "bot"
-          },
-          "destination": {
-            "node": "tc-mutable"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "collector-reads-segments",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "segments-stream"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "collector-publishes-mutable",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "tc-mutable"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "collector-writes-table",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "segments-table"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "collector-writes-tc",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "tc-stream"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "agent-reads-tc",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-api"
-          },
-          "destination": {
-            "node": "tc-stream"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "gateway-reads-mutable",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "tc-mutable"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-reads-tc",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "terminal"
-          },
-          "destination": {
-            "node": "tc-stream"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-reads-processed",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "terminal"
-          },
-          "destination": {
-            "node": "proc-stream"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-reads-out",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "terminal"
-          },
-          "destination": {
-            "node": "out-stream"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "terminal-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "terminal",
-          "nodes": [
-            "terminal-app",
-            "terminal-canvas",
-            "terminal-contributions",
-            "terminal-platform",
-            "terminal-surfaces",
-            "terminal-ui-kit",
-            "terminal-workbench"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "bot-writes-recording",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "bot"
-          },
-          "destination": {
-            "node": "recording-blob"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "bot-userdata",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "bot"
-          },
-          "destination": {
-            "node": "userdata-blob"
-          }
-        }
-      },
-      "description": "restore session before launch (read) + write rotated session back on clean teardown (write)",
-      "protocol": "HTTPS",
-      "metadata": [
-        {
-          "access": "read-write"
-        }
-      ]
-    },
-    {
-      "unique-id": "remote-browser-userdata",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "remote-browser"
-          },
-          "destination": {
-            "node": "userdata-blob"
-          }
-        }
-      },
-      "description": "provisioning login uploads the confirmed signed-in session",
-      "protocol": "HTTPS",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "gateway-reads-recording",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "recording-blob"
-          }
-        }
-      },
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "platform-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "platform",
-          "nodes": [
-            "redis",
-            "postgres",
-            "minio"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "workers-deployed",
-      "description": "bot + agent-worker are runtime.v1 workloads",
-      "relationship-type": {
-        "deployed-in": {
-          "container": "runtime",
-          "nodes": [
-            "bot",
-            "agent-worker"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "bot-stt",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "bot"
-          },
-          "destination": {
-            "node": "transcription",
-            "interface": "stt-endpoint"
-          }
-        }
-      },
-      "description": "audio -> first-party STT via TRANSCRIPTION_SERVICE_URL",
-      "protocol": "HTTPS",
-      "metadata": [
-        {
-          "access": "call"
-        }
-      ],
-      "controls": {
-        "data-egress": {
-          "description": "STT is first-party and self-hostable; default destination is tenant-hosted, so audio need not leave the tenant",
-          "requirements": [
-            {
-              "requirement-url": "https://vexa.ai/calm/controls/no-egress.requirement.json",
-              "config": {
-                "dataClass": "audio",
-                "destination": "tenant-hosted",
-                "egressApproved": true
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "bot-commands-read",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "bot"
-          },
-          "destination": {
-            "node": "bot-commands"
-          }
-        }
-      },
-      "description": "SUBSCRIBE acts.v1 commands",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "ma-status",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "bm-status"
-          }
-        }
-      },
-      "description": "PUBLISH status",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "ma-umeetings",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "u-meetings"
-          }
-        }
-      },
-      "description": "PUBLISH per-user status",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "ma-commands",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "bot-commands"
-          }
-        }
-      },
-      "description": "PUBLISH leave/speak",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "ma-recording",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "recording-blob"
-          }
-        }
-      },
-      "description": "S3 PUT stitched master",
-      "protocol": "HTTPS",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "ma-pg",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "postgres"
-          }
-        }
-      },
-      "protocol": "JDBC",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "ma-minio",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "minio"
-          }
-        }
-      },
-      "protocol": "HTTPS",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "ma-runtime",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "meeting-api"
-          },
-          "destination": {
-            "node": "runtime",
-            "interface": "runtime-rest"
-          }
-        }
-      },
-      "description": "POST /workloads spawn bot",
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "aa-watch",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-api"
-          },
-          "destination": {
-            "node": "segments-stream"
-          }
-        }
-      },
-      "description": "XREADGROUP agent_copilot (proactive watcher)",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "aa-runtime",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-api"
-          },
-          "destination": {
-            "node": "runtime",
-            "interface": "runtime-rest"
-          }
-        }
-      },
-      "description": "POST /workloads spawn agent-worker",
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "aa-unitout",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-api"
-          },
-          "destination": {
-            "node": "out-stream"
-          }
-        }
-      },
-      "description": "SSE relay (/api/chat, /api/meeting/stream)",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "aw-tcnative",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-worker"
-          },
-          "destination": {
-            "node": "tc-stream"
-          }
-        }
-      },
-      "description": "copilot tails transcript",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "aw-unitout",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-worker"
-          },
-          "destination": {
-            "node": "out-stream"
-          }
-        }
-      },
-      "description": "XADD cards/notes/deltas",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "aw-proc",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-worker"
-          },
-          "destination": {
-            "node": "proc-stream"
-          }
-        }
-      },
-      "description": "XADD cleaned 1:1 notes",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "aw-unitin",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "agent-worker"
-          },
-          "destination": {
-            "node": "unit-in"
-          }
-        }
-      },
-      "description": "chat path XREADs interactive input",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "mcp-gw",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "mcp"
-          },
-          "destination": {
-            "node": "gateway",
-            "interface": "gateway-rest"
-          }
-        }
-      },
-      "description": "every MCP tool forwards the caller's X-API-Key to the public REST surface",
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "gw-ma",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "meeting-api",
-            "interface": "meeting-api-rest"
-          }
-        }
-      },
-      "description": "proxy /bots /transcripts /meetings /recordings",
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "gw-aa",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "agent-api",
-            "interface": "agent-api-rest"
-          }
-        }
-      },
-      "description": "proxy /agent/*",
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "gw-admin",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "admin-api",
-            "interface": "admin-api-rest"
-          }
-        }
-      },
-      "description": "POST /internal/validate (authz oracle)",
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "gw-status",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "bm-status"
-          }
-        }
-      },
-      "description": "WS fan-out",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "gw-umeetings",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "u-meetings"
-          }
-        }
-      },
-      "description": "WS auto-subscribe",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "gw-chat",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "gateway"
-          },
-          "destination": {
-            "node": "va-chat"
-          }
-        }
-      },
-      "description": "WS fan-out",
-      "metadata": [
-        {
-          "access": "read"
-        }
-      ]
-    },
-    {
-      "unique-id": "admin-db",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "admin-api"
-          },
-          "destination": {
-            "node": "identity-db"
-          }
-        }
-      },
-      "protocol": "JDBC",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "admin-pg",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "admin-api"
-          },
-          "destination": {
-            "node": "postgres"
-          }
-        }
-      },
-      "protocol": "JDBC",
-      "metadata": [
-        {
-          "access": "write"
-        }
-      ]
-    },
-    {
-      "unique-id": "term-gw-rest",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "terminal"
-          },
-          "destination": {
-            "node": "gateway",
-            "interface": "gateway-rest"
-          }
-        }
-      },
-      "description": "all REST via gateway",
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "term-gw-ws",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "terminal"
-          },
-          "destination": {
-            "node": "gateway",
-            "interface": "gateway-ws"
-          }
-        }
-      },
-      "description": "live WS via gateway",
-      "protocol": "WebSocket"
-    },
-    {
-      "unique-id": "slim-gw",
-      "description": "Python client; REST via gateway",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "slim"
-          },
-          "destination": {
-            "node": "gateway",
-            "interface": "gateway-rest"
-          }
-        }
-      },
-      "protocol": "HTTPS"
-    },
-    {
-      "unique-id": "deploy-composed",
-      "relationship-type": {
-        "composed-of": {
-          "container": "deploy",
-          "nodes": [
-            "execution-targets.v1",
-            "config.v1"
-          ]
-        }
-      }
-    },
-    {
-      "unique-id": "extension-gw",
-      "description": "browser extension client; live WS via gateway",
-      "relationship-type": {
-        "connects": {
-          "source": {
-            "node": "extension"
-          },
-          "destination": {
-            "node": "gateway",
-            "interface": "gateway-ws"
-          }
-        }
-      },
-      "protocol": "WebSocket"
-    },
-    {
-      "unique-id": "stack-deployed",
-      "description": "the long-running services ship as the deploy/compose stack (transcription has its own deploy unit)",
-      "relationship-type": {
-        "deployed-in": {
-          "container": "deploy",
-          "nodes": [
-            "gateway",
-            "meeting-api",
-            "agent-api",
-            "admin-api",
-            "runtime",
-            "redis",
-            "postgres",
-            "minio",
-            "transcription"
-          ]
-        }
-      }
+     "path": "core/gateway"
     }
-  ],
-  "flows": [
+   ]
+  },
+  {
+   "unique-id": "identity",
+   "node-type": "system",
+   "name": "identity",
+   "description": "access + audit; owns the durable DB",
+   "metadata": [
     {
-      "unique-id": "live-transcript-flow",
-      "name": "live transcript",
-      "description": "raw -> durable collector -> native stream -> copilot clean -> render. One render engine; terminal never re-derives.",
-      "transitions": [
-        {
-          "relationship-unique-id": "bot-writes-segments-stream",
-          "sequence-number": 1,
-          "description": "bot XADDs raw ASR segments"
-        },
-        {
-          "relationship-unique-id": "collector-reads-segments",
-          "sequence-number": 2,
-          "description": "collector consumes (XREADGROUP collector_group)"
-        },
-        {
-          "relationship-unique-id": "collector-writes-tc",
-          "sequence-number": 3,
-          "description": "collector writes the native stream (single writer, P23)"
-        },
-        {
-          "relationship-unique-id": "aw-tcnative",
-          "sequence-number": 4,
-          "description": "copilot tails the native stream"
-        },
-        {
-          "relationship-unique-id": "aw-proc",
-          "sequence-number": 5,
-          "description": "copilot writes cleaned 1:1 transcript"
-        },
-        {
-          "relationship-unique-id": "terminal-reads-processed",
-          "sequence-number": 6,
-          "description": "one engine renders raw|processed; no re-derivation"
-        }
-      ]
+     "path": "core/identity"
+    }
+   ]
+  },
+  {
+   "unique-id": "runtime-system",
+   "node-type": "system",
+   "name": "runtime",
+   "description": "workload spawn (bot/agent containers)",
+   "metadata": [
+    {
+     "path": "core/runtime"
+    }
+   ]
+  },
+  {
+   "unique-id": "deploy",
+   "node-type": "system",
+   "name": "deploy",
+   "description": "deployment + execution-target registry",
+   "metadata": [
+    {
+     "path": "deploy"
+    }
+   ]
+  },
+  {
+   "unique-id": "agent-api",
+   "node-type": "service",
+   "name": "agent-api",
+   "description": "unit control-plane; dispatch -> runtime spawn; meeting copilot",
+   "metadata": [
+    {
+     "path": "core/agent/services/agent-api"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "agent-api-rest",
+     "type": "api"
+    }
+   ]
+  },
+  {
+   "unique-id": "conformance",
+   "node-type": "service",
+   "name": "conformance",
+   "description": "conformance — service in gateway",
+   "metadata": [
+    {
+     "path": "core/gateway/services/conformance"
+    }
+   ]
+  },
+  {
+   "unique-id": "gateway",
+   "node-type": "service",
+   "name": "gateway",
+   "description": "edge: auth (scopes) + REST routing + WS fan-out",
+   "metadata": [
+    {
+     "path": "core/gateway/services/gateway"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "gateway-rest",
+     "type": "api"
     },
     {
-      "unique-id": "dispatch-flow",
-      "name": "agent dispatch",
-      "description": "a trigger spawns an isolated agent-worker via the runtime kernel; output streams back to the client.",
-      "transitions": [
-        {
-          "relationship-unique-id": "aa-runtime",
-          "sequence-number": 1,
-          "description": "agent-api POST /workloads"
-        },
-        {
-          "relationship-unique-id": "workers-deployed",
-          "sequence-number": 2,
-          "description": "runtime spawns agent-worker container"
-        },
-        {
-          "relationship-unique-id": "aw-unitout",
-          "sequence-number": 3,
-          "description": "worker XADDs output"
-        },
-        {
-          "relationship-unique-id": "aa-unitout",
-          "sequence-number": 4,
-          "description": "agent-api relays as SSE"
-        }
-      ]
+     "unique-id": "gateway-ws",
+     "type": "websocket"
     }
-  ]
+   ]
+  },
+  {
+   "unique-id": "admin-api",
+   "node-type": "service",
+   "name": "admin-api",
+   "description": "identity: token mint/validate, users, webhooks",
+   "metadata": [
+    {
+     "path": "core/identity/services/admin-api"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "admin-api-rest",
+     "type": "api"
+    }
+   ]
+  },
+  {
+   "unique-id": "bot",
+   "node-type": "service",
+   "name": "bot",
+   "description": "spawned-per-meeting worker: join -> capture -> STT -> transcript.v1",
+   "metadata": [
+    {
+     "path": "core/meetings/services/bot"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "bot-commands-sub",
+     "type": "consumer"
+    }
+   ]
+  },
+  {
+   "unique-id": "transcription",
+   "node-type": "service",
+   "name": "transcription",
+   "description": "transcription — STT service (faster-whisper / CTranslate2, OpenAI-compatible /v1/audio/transcriptions). The GPU workload, deployed separately from the main stack; the bot streams audio windows to it and receives segments. Does not write any redis carrier (the bot XADDs segments).",
+   "metadata": [
+    {
+     "path": "core/meetings/services/transcription"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "stt-endpoint",
+     "type": "api"
+    }
+   ]
+  },
+  {
+   "unique-id": "desktop",
+   "node-type": "service",
+   "name": "desktop",
+   "description": "all-in-one dev host: bot+collector+gateway in one process",
+   "metadata": [
+    {
+     "path": "core/meetings/services/desktop"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "desktop-rest",
+     "type": "api"
+    },
+    {
+     "unique-id": "desktop-ingest-ws",
+     "type": "websocket"
+    }
+   ]
+  },
+  {
+   "unique-id": "meeting-api",
+   "node-type": "service",
+   "name": "meeting-api",
+   "description": "collector + bot-spawn + recordings + sessions (the hub)",
+   "metadata": [
+    {
+     "path": "core/meetings/services/meeting-api"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "meeting-api-rest",
+     "type": "api"
+    }
+   ]
+  },
+  {
+   "unique-id": "mcp",
+   "node-type": "service",
+   "name": "mcp",
+   "description": "MCP tools + prompts over the public API (stateless FastAPI, /mcp mount)",
+   "metadata": [
+    {
+     "path": "core/meetings/services/mcp"
+    }
+   ],
+   "interfaces": [
+    {
+     "unique-id": "mcp-http",
+     "type": "api"
+    }
+   ]
+  },
+  {
+   "unique-id": "buffer",
+   "node-type": "module",
+   "name": "buffer",
+   "description": "buffer — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/buffer"
+    }
+   ]
+  },
+  {
+   "unique-id": "capture-codec",
+   "node-type": "module",
+   "name": "capture-codec",
+   "description": "capture-codec — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/capture-codec"
+    }
+   ]
+  },
+  {
+   "unique-id": "gmeet-capture",
+   "node-type": "module",
+   "name": "gmeet-capture",
+   "description": "gmeet-capture — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/gmeet-capture"
+    }
+   ]
+  },
+  {
+   "unique-id": "gmeet-pipeline",
+   "node-type": "module",
+   "name": "gmeet-pipeline",
+   "description": "gmeet-pipeline — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/gmeet-pipeline"
+    }
+   ]
+  },
+  {
+   "unique-id": "jitsi-capture",
+   "node-type": "module",
+   "name": "jitsi-capture",
+   "description": "jitsi-capture — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/jitsi-capture"
+    }
+   ]
+  },
+  {
+   "unique-id": "join",
+   "node-type": "module",
+   "name": "join",
+   "description": "join — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/join"
+    }
+   ]
+  },
+  {
+   "unique-id": "mixed-capture-core",
+   "node-type": "module",
+   "name": "mixed-capture-core",
+   "description": "mixed-capture-core — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/mixed-capture-core"
+    }
+   ]
+  },
+  {
+   "unique-id": "mixed-pipeline",
+   "node-type": "module",
+   "name": "mixed-pipeline",
+   "description": "mixed-pipeline — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/mixed-pipeline"
+    }
+   ]
+  },
+  {
+   "unique-id": "record-chunker",
+   "node-type": "module",
+   "name": "record-chunker",
+   "description": "record-chunker — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/record-chunker"
+    }
+   ]
+  },
+  {
+   "unique-id": "recording",
+   "node-type": "module",
+   "name": "recording",
+   "description": "recording — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/recording"
+    }
+   ]
+  },
+  {
+   "unique-id": "remote-browser",
+   "node-type": "module",
+   "name": "remote-browser",
+   "description": "remote-browser — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/remote-browser"
+    }
+   ]
+  },
+  {
+   "unique-id": "teams-capture",
+   "node-type": "module",
+   "name": "teams-capture",
+   "description": "teams-capture — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/teams-capture"
+    }
+   ]
+  },
+  {
+   "unique-id": "whisper",
+   "node-type": "module",
+   "name": "whisper",
+   "description": "whisper — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/whisper"
+    }
+   ]
+  },
+  {
+   "unique-id": "zoom-capture",
+   "node-type": "module",
+   "name": "zoom-capture",
+   "description": "zoom-capture — atomic module in meetings",
+   "metadata": [
+    {
+     "path": "core/meetings/modules/zoom-capture"
+    }
+   ]
+  },
+  {
+   "unique-id": "event.v1",
+   "node-type": "contract",
+   "name": "event.v1",
+   "description": "event.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/event.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "invoke.v1",
+   "node-type": "contract",
+   "name": "invoke.v1",
+   "description": "invoke.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/invoke.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "proactive-card.v1",
+   "node-type": "contract",
+   "name": "proactive-card.v1",
+   "description": "proactive-card.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/proactive-card.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "routine.v1",
+   "node-type": "contract",
+   "name": "routine.v1",
+   "description": "routine.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/routine.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "task.v1",
+   "node-type": "contract",
+   "name": "task.v1",
+   "description": "task.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/task.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "tool.v1",
+   "node-type": "contract",
+   "name": "tool.v1",
+   "description": "tool.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/tool.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "unit.v1",
+   "node-type": "contract",
+   "name": "unit.v1",
+   "description": "unit.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/unit.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "processed-notes.v1",
+   "node-type": "contract",
+   "name": "processed-notes.v1",
+   "description": "processed-notes.v1 — sealed/published contract (agent): the proc:meeting:{row_id} cleaned-notes stream + view_end terminal marker (agent-worker → meeting-api db-writer / agent-api SSE; ADR-0027)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/processed-notes.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "workspace.v1",
+   "node-type": "contract",
+   "name": "workspace.v1",
+   "description": "workspace.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/workspace.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
+   "unique-id": "api.v1",
+   "node-type": "contract",
+   "name": "api.v1",
+   "description": "api.v1 — sealed/published contract (gateway)",
+   "metadata": [
+    {
+     "path": "core/gateway/contracts/api.v1",
+     "domain": "gateway"
+    }
+   ]
+  },
+  {
+   "unique-id": "logevent.v1",
+   "node-type": "contract",
+   "name": "logevent.v1",
+   "description": "logevent.v1 — sealed/published contract (gateway)",
+   "metadata": [
+    {
+     "path": "core/gateway/contracts/logevent.v1",
+     "domain": "gateway"
+    }
+   ]
+  },
+  {
+   "unique-id": "ws.v1",
+   "node-type": "contract",
+   "name": "ws.v1",
+   "description": "ws.v1 — sealed/published contract (gateway)",
+   "metadata": [
+    {
+     "path": "core/gateway/contracts/ws.v1",
+     "domain": "gateway"
+    }
+   ]
+  },
+  {
+   "unique-id": "identity.v1",
+   "node-type": "contract",
+   "name": "identity.v1",
+   "description": "identity.v1 — sealed/published contract (identity)",
+   "metadata": [
+    {
+     "path": "core/identity/contracts/identity.v1",
+     "domain": "identity"
+    }
+   ]
+  },
+  {
+   "unique-id": "acts.v1",
+   "node-type": "contract",
+   "name": "acts.v1",
+   "description": "acts.v1 — sealed/published contract (meetings)",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/acts.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "captured-signal.v1",
+   "node-type": "contract",
+   "name": "captured-signal.v1",
+   "description": "captured-signal.v1 — sealed/published contract (meetings)",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/captured-signal.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "flagged-issue.v1",
+   "node-type": "contract",
+   "name": "flagged-issue.v1",
+   "description": "flagged-issue.v1 — sealed/published contract (meetings)",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/flagged-issue.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "invocation.v1",
+   "node-type": "contract",
+   "name": "invocation.v1",
+   "description": "invocation.v1 — sealed/published contract (meetings)",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/invocation.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "lifecycle.v1",
+   "node-type": "contract",
+   "name": "lifecycle.v1",
+   "description": "lifecycle.v1 — sealed/published contract (meetings)",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/lifecycle.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "transcript.v1",
+   "node-type": "contract",
+   "name": "transcript.v1",
+   "description": "transcript.v1 — sealed/published contract (meetings)",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/transcript.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "webhook.v1",
+   "node-type": "contract",
+   "name": "webhook.v1",
+   "description": "webhook.v1 — sealed/published contract (meetings)",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/webhook.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "runtime.v1",
+   "node-type": "contract",
+   "name": "runtime.v1",
+   "description": "runtime.v1 — sealed/published contract (runtime)",
+   "metadata": [
+    {
+     "path": "core/runtime/contracts/runtime.v1",
+     "domain": "runtime"
+    }
+   ]
+  },
+  {
+   "unique-id": "schedule.v1",
+   "node-type": "contract",
+   "name": "schedule.v1",
+   "description": "schedule.v1 — sealed/published contract (runtime)",
+   "metadata": [
+    {
+     "path": "core/runtime/contracts/schedule.v1",
+     "domain": "runtime"
+    }
+   ]
+  },
+  {
+   "unique-id": "execution-targets.v1",
+   "node-type": "contract",
+   "name": "execution-targets.v1",
+   "description": "execution-targets.v1 — sealed/published contract (deploy)",
+   "metadata": [
+    {
+     "path": "deploy/contracts/execution-targets.v1",
+     "domain": "deploy"
+    }
+   ]
+  },
+  {
+   "unique-id": "config.v1",
+   "node-type": "contract",
+   "name": "config.v1",
+   "description": "config.v1 — sealed/published contract (deploy): per-service deployment-config declaration (required-explicit / defaulted / capability tri-state + live probes), preflight + gate:config-contract (ADR-0026)",
+   "metadata": [
+    {
+     "path": "deploy/contracts/config.v1",
+     "domain": "deploy"
+    }
+   ]
+  },
+  {
+   "unique-id": "slim",
+   "node-type": "webclient",
+   "name": "slim",
+   "description": "slim — client",
+   "metadata": [
+    {
+     "path": "clients/slim"
+    }
+   ]
+  },
+  {
+   "unique-id": "extension",
+   "node-type": "webclient",
+   "name": "extension",
+   "description": "extension — client",
+   "metadata": [
+    {
+     "path": "clients/extension"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal",
+   "node-type": "webclient",
+   "name": "terminal",
+   "description": "terminal — client",
+   "metadata": [
+    {
+     "path": "clients/terminal"
+    }
+   ],
+   "controls": {
+    "render-only": {
+     "description": "A reader must not re-derive a producer's data. The terminal renders raw|processed; it must NOT contain a transcript-shaping transform (e.g. clustering).",
+     "requirements": [
+      {
+       "requirement-url": "vexa/controls/render-only",
+       "config": {
+        "forbidden-symbols": [
+         "buildMeetingNotes"
+        ]
+       }
+      }
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "segments-stream",
+   "node-type": "data-asset",
+   "name": "transcription_segments (stream)",
+   "description": "durable raw segment feed (transcript.v1); bot XADDs, collector XREADGROUPs",
+   "controls": {
+    "ownership": {
+     "description": "single writer",
+     "requirements": [
+      {
+       "requirement-url": "vexa/controls/single-writer",
+       "config": {
+        "writers": [
+         "bot"
+        ],
+        "match": "transcription_segments",
+        "op": "xadd"
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "contract": "transcript.v1"
+    },
+    {
+     "stage": "raw"
+    }
+   ]
+  },
+  {
+   "unique-id": "tc-mutable",
+   "node-type": "data-asset",
+   "name": "tc:meeting:{id}:mutable (pubsub)",
+   "description": "change-only transcript deltas the gateway + agent-api subscribe to",
+   "controls": {
+    "ownership": {
+     "description": "shared — review (P23 prefers one writer)",
+     "requirements": [
+      {
+       "requirement-url": "vexa/controls/single-writer",
+       "config": {
+        "writers": [
+         "bot",
+         "meeting-api"
+        ],
+        "match": "tc:meeting:.*:mutable",
+        "op": "publish"
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "contract": "transcript.v1"
+    },
+    {
+     "stage": "raw"
+    }
+   ]
+  },
+  {
+   "unique-id": "tc-stream",
+   "node-type": "data-asset",
+   "name": "tc:meeting:{id} (stream)",
+   "description": "native per-meeting transcript stream the agent worker + terminal SSE read; the collector (meetings) is the single writer (P23)",
+   "controls": {
+    "ownership": {
+     "description": "single writer",
+     "requirements": [
+      {
+       "requirement-url": "vexa/controls/single-writer",
+       "config": {
+        "writers": [
+         "meeting-api"
+        ],
+        "match": "tc:meeting:[^:]*$",
+        "op": "xadd"
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "contract": "transcript.v1"
+    },
+    {
+     "stage": "raw"
+    }
+   ]
+  },
+  {
+   "unique-id": "proc-stream",
+   "node-type": "data-asset",
+   "name": "proc:meeting:{id} (stream)",
+   "description": "cleaned 1:1 processed transcript, keyed by segment_id, + the view_end terminal marker (processed-notes.v1, ADR-0027); agent-worker is the writer; read by meeting-api's db-writer (durable data.processed.views) and agent-api's live SSE",
+   "controls": {
+    "ownership": {
+     "description": "single writer (P23)",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "agent-worker"
+        ],
+        "match": "proc:meeting:",
+        "op": "xadd"
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "contract": "transcript.v1"
+    },
+    {
+     "stage": "cleaned"
+    }
+   ]
+  },
+  {
+   "unique-id": "out-stream",
+   "node-type": "data-asset",
+   "name": "unit:{id}:out (stream)",
+   "description": "worker output stream (cards / agent activity / message deltas — notes moved to proc-stream per ADR-0027); agent-api relays as SSE",
+   "controls": {
+    "ownership": {
+     "description": "single writer (P23)",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "agent-worker"
+        ],
+        "match": "unit:.*:out",
+        "op": "xadd"
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "contract": "proactive-card.v1"
+    },
+    {
+     "stage": "cards"
+    }
+   ]
+  },
+  {
+   "unique-id": "segments-table",
+   "node-type": "database",
+   "name": "transcription_segments (table)",
+   "description": "persisted raw transcript rows",
+   "controls": {
+    "ownership": {
+     "description": "single writer",
+     "requirements": [
+      {
+       "requirement-url": "vexa/controls/single-writer",
+       "config": {
+        "writers": [
+         "meeting-api"
+        ],
+        "match": "transcription_segments",
+        "op": "db-write"
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "contract": "transcript.v1"
+    },
+    {
+     "stage": "raw"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-app",
+   "node-type": "module",
+   "name": "terminal/app",
+   "description": "Next.js routes + SSE proxy (terminal)",
+   "metadata": [
+    {
+     "path": "clients/terminal/src/app"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-canvas",
+   "node-type": "module",
+   "name": "terminal/canvas",
+   "description": "render engine: kit, runtime, useMeeting, notes (terminal)",
+   "metadata": [
+    {
+     "path": "clients/terminal/src/canvas"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-contributions",
+   "node-type": "module",
+   "name": "terminal/contributions",
+   "description": "contributed surfaces/commands (terminal)",
+   "metadata": [
+    {
+     "path": "clients/terminal/src/contributions"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-platform",
+   "node-type": "module",
+   "name": "terminal/platform",
+   "description": "platform adapters (terminal)",
+   "metadata": [
+    {
+     "path": "clients/terminal/src/platform"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-surfaces",
+   "node-type": "module",
+   "name": "terminal/surfaces",
+   "description": "state stores + surfaces (meetingLive, chat, gatewayWS) (terminal)",
+   "metadata": [
+    {
+     "path": "clients/terminal/src/surfaces"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-ui-kit",
+   "node-type": "module",
+   "name": "terminal/ui-kit",
+   "description": "shared UI primitives (terminal)",
+   "metadata": [
+    {
+     "path": "clients/terminal/src/ui-kit"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-workbench",
+   "node-type": "module",
+   "name": "terminal/workbench",
+   "description": "dockview workbench shell (terminal)",
+   "metadata": [
+    {
+     "path": "clients/terminal/src/workbench"
+    }
+   ]
+  },
+  {
+   "unique-id": "recording-blob",
+   "node-type": "data-asset",
+   "name": "recordings bucket (blob)",
+   "description": "chunked meeting recordings: bot uploads chunks (record-chunker), meeting-api PUTs the stitched master",
+   "controls": {
+    "ownership": {
+     "description": "two writers by design: bot=chunks, meeting-api=master",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "bot",
+         "meeting-api"
+        ]
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "stage": "audio"
+    }
+   ]
+  },
+  {
+   "unique-id": "userdata-blob",
+   "node-type": "data-asset",
+   "name": "userdata bucket (blob)",
+   "description": "authenticated-bot browser sessions (auth-essential profile subset): remote-browser's provisioning login uploads the signed-in session; the bot restores it before launch and writes the rotated session back on clean teardown",
+   "controls": {
+    "ownership": {
+     "description": "two writers by design: remote-browser=provisioning upload, bot=write-back on teardown",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "remote-browser",
+         "bot"
+        ]
+       }
+      }
+     ]
+    }
+   },
+   "metadata": [
+    {
+     "stage": "session"
+    }
+   ]
+  },
+  {
+   "unique-id": "runtime",
+   "node-type": "service",
+   "name": "runtime",
+   "description": "runtime.v1 kernel: POST /workloads spawns containers (docker/k8s/process)",
+   "interfaces": [
+    {
+     "unique-id": "runtime-rest",
+     "type": "api"
+    }
+   ],
+   "metadata": [
+    {
+     "path": "core/runtime/src"
+    }
+   ]
+  },
+  {
+   "unique-id": "agent-worker",
+   "node-type": "service",
+   "name": "agent-worker",
+   "description": "spawned claude-in-container worker; one dispatch turn / meeting copilot",
+   "metadata": [
+    {
+     "path": "core/agent/worker"
+    }
+   ]
+  },
+  {
+   "unique-id": "platform",
+   "node-type": "system",
+   "name": "platform",
+   "description": "shared infra backing the services"
+  },
+  {
+   "unique-id": "redis",
+   "node-type": "service",
+   "name": "redis",
+   "description": "stream + pub/sub broker for the live + durable transcript planes"
+  },
+  {
+   "unique-id": "postgres",
+   "node-type": "database",
+   "name": "postgres",
+   "description": "durable relational store"
+  },
+  {
+   "unique-id": "minio",
+   "node-type": "service",
+   "name": "minio",
+   "description": "S3-compatible object store for recordings"
+  },
+  {
+   "unique-id": "bm-status",
+   "node-type": "data-asset",
+   "name": "bm:meeting:{id}:status (pubsub)",
+   "description": "bot/meeting status pub/sub; gateway fans out",
+   "controls": {
+    "ownership": {
+     "description": "single writer (P23)",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "meeting-api"
+        ],
+        "match": "bm:meeting:.*:status",
+        "op": "publish"
+       }
+      }
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "u-meetings",
+   "node-type": "data-asset",
+   "name": "u:{user}:meetings (pubsub)",
+   "description": "per-user meeting-status pub/sub; gateway auto-subscribes",
+   "controls": {
+    "ownership": {
+     "description": "single writer (P23)",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "meeting-api"
+        ],
+        "match": "u:.*:meetings",
+        "op": "publish"
+       }
+      }
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "bot-commands",
+   "node-type": "data-asset",
+   "name": "bot_commands:meeting:{id} (pubsub)",
+   "description": "acts.v1 commands (leave/speak) to the bot",
+   "controls": {
+    "ownership": {
+     "description": "single writer (P23)",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "meeting-api"
+        ],
+        "match": "bot_commands:",
+        "op": "publish"
+       }
+      }
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "unit-in",
+   "node-type": "data-asset",
+   "name": "unit:{id}:in (stream)",
+   "description": "interactive input stream for warm chat units; agent-worker reads. NO in-repo writer in this carve (input arrives via the hosted control plane)"
+  },
+  {
+   "unique-id": "va-chat",
+   "node-type": "data-asset",
+   "name": "va:meeting:{id}:chat (pubsub)",
+   "description": "in-meeting chat pub/sub; gateway fans out. NO in-repo writer in this carve"
+  },
+  {
+   "unique-id": "identity-db",
+   "node-type": "data-asset",
+   "name": "identity (users/api_tokens)",
+   "description": "users + scoped API tokens",
+   "controls": {
+    "ownership": {
+     "description": "single writer (P23)",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/single-writer.requirement.json",
+       "config": {
+        "writers": [
+         "admin-api"
+        ]
+       }
+      }
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "dashboard",
+   "node-type": "webclient",
+   "name": "dashboard (deprecated)",
+   "description": "dashboard — DEPRECATED 0.10 web client, shipped as an off-by-default compose/helm option while still load-bearing (#813): the multi-user UI hosted production runs against the 0.12 core via the gateway's hosted-compat surface. External pinned image (vexaai/dashboard), not built from this tree; versions on its own tag, never global.imageTag. Deprecation exit: deleted when the terminal covers the authenticated-session/browser-session flows.",
+   "metadata": [
+    {
+     "path": "deploy/compose",
+     "external-image": "vexaai/dashboard"
+    }
+   ]
+  }
+ ],
+ "relationships": [
+  {
+   "unique-id": "agent-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "agent",
+     "nodes": [
+      "agent-api",
+      "event.v1",
+      "invoke.v1",
+      "proactive-card.v1",
+      "routine.v1",
+      "task.v1",
+      "tool.v1",
+      "unit.v1",
+      "processed-notes.v1",
+      "workspace.v1",
+      "agent-worker",
+      "out-stream",
+      "unit-in",
+      "proc-stream",
+      "va-chat"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "gateway-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "gateway-system",
+     "nodes": [
+      "conformance",
+      "gateway",
+      "api.v1",
+      "logevent.v1",
+      "ws.v1"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "identity-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "identity",
+     "nodes": [
+      "admin-api",
+      "identity.v1",
+      "identity-db"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "meetings-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "meetings",
+     "nodes": [
+      "bot",
+      "desktop",
+      "meeting-api",
+      "mcp",
+      "buffer",
+      "capture-codec",
+      "gmeet-capture",
+      "gmeet-pipeline",
+      "jitsi-capture",
+      "join",
+      "mixed-capture-core",
+      "mixed-pipeline",
+      "record-chunker",
+      "recording",
+      "remote-browser",
+      "teams-capture",
+      "whisper",
+      "zoom-capture",
+      "acts.v1",
+      "captured-signal.v1",
+      "flagged-issue.v1",
+      "invocation.v1",
+      "lifecycle.v1",
+      "transcript.v1",
+      "webhook.v1",
+      "transcription",
+      "segments-stream",
+      "tc-stream",
+      "tc-mutable",
+      "bm-status",
+      "u-meetings",
+      "bot-commands",
+      "segments-table",
+      "recording-blob",
+      "userdata-blob"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "runtime-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "runtime-system",
+     "nodes": [
+      "runtime.v1",
+      "schedule.v1",
+      "runtime"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "bot-writes-segments-stream",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "bot"
+     },
+     "destination": {
+      "node": "segments-stream"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "bot-publishes-mutable",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "bot"
+     },
+     "destination": {
+      "node": "tc-mutable"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "collector-reads-segments",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "segments-stream"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "collector-publishes-mutable",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "tc-mutable"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "collector-writes-table",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "segments-table"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "collector-writes-tc",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "tc-stream"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "agent-reads-tc",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-api"
+     },
+     "destination": {
+      "node": "tc-stream"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "gateway-reads-mutable",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "tc-mutable"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-reads-tc",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "terminal"
+     },
+     "destination": {
+      "node": "tc-stream"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-reads-processed",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "terminal"
+     },
+     "destination": {
+      "node": "proc-stream"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-reads-out",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "terminal"
+     },
+     "destination": {
+      "node": "out-stream"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "terminal-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "terminal",
+     "nodes": [
+      "terminal-app",
+      "terminal-canvas",
+      "terminal-contributions",
+      "terminal-platform",
+      "terminal-surfaces",
+      "terminal-ui-kit",
+      "terminal-workbench"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "bot-writes-recording",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "bot"
+     },
+     "destination": {
+      "node": "recording-blob"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "bot-userdata",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "bot"
+     },
+     "destination": {
+      "node": "userdata-blob"
+     }
+    }
+   },
+   "description": "restore session before launch (read) + write rotated session back on clean teardown (write)",
+   "protocol": "HTTPS",
+   "metadata": [
+    {
+     "access": "read-write"
+    }
+   ]
+  },
+  {
+   "unique-id": "remote-browser-userdata",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "remote-browser"
+     },
+     "destination": {
+      "node": "userdata-blob"
+     }
+    }
+   },
+   "description": "provisioning login uploads the confirmed signed-in session",
+   "protocol": "HTTPS",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "gateway-reads-recording",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "recording-blob"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "platform-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "platform",
+     "nodes": [
+      "redis",
+      "postgres",
+      "minio"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "workers-deployed",
+   "description": "bot + agent-worker are runtime.v1 workloads",
+   "relationship-type": {
+    "deployed-in": {
+     "container": "runtime",
+     "nodes": [
+      "bot",
+      "agent-worker"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "bot-stt",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "bot"
+     },
+     "destination": {
+      "node": "transcription",
+      "interface": "stt-endpoint"
+     }
+    }
+   },
+   "description": "audio -> first-party STT via TRANSCRIPTION_SERVICE_URL",
+   "protocol": "HTTPS",
+   "metadata": [
+    {
+     "access": "call"
+    }
+   ],
+   "controls": {
+    "data-egress": {
+     "description": "STT is first-party and self-hostable; default destination is tenant-hosted, so audio need not leave the tenant",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/no-egress.requirement.json",
+       "config": {
+        "dataClass": "audio",
+        "destination": "tenant-hosted",
+        "egressApproved": true
+       }
+      }
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "bot-commands-read",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "bot"
+     },
+     "destination": {
+      "node": "bot-commands"
+     }
+    }
+   },
+   "description": "SUBSCRIBE acts.v1 commands",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "ma-status",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "bm-status"
+     }
+    }
+   },
+   "description": "PUBLISH status",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "ma-umeetings",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "u-meetings"
+     }
+    }
+   },
+   "description": "PUBLISH per-user status",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "ma-commands",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "bot-commands"
+     }
+    }
+   },
+   "description": "PUBLISH leave/speak",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "ma-recording",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "recording-blob"
+     }
+    }
+   },
+   "description": "S3 PUT stitched master",
+   "protocol": "HTTPS",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "ma-pg",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "postgres"
+     }
+    }
+   },
+   "protocol": "JDBC",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "ma-minio",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "minio"
+     }
+    }
+   },
+   "protocol": "HTTPS",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "ma-runtime",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "runtime",
+      "interface": "runtime-rest"
+     }
+    }
+   },
+   "description": "POST /workloads spawn bot",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "aa-watch",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-api"
+     },
+     "destination": {
+      "node": "segments-stream"
+     }
+    }
+   },
+   "description": "XREADGROUP agent_copilot (proactive watcher)",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "aa-runtime",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-api"
+     },
+     "destination": {
+      "node": "runtime",
+      "interface": "runtime-rest"
+     }
+    }
+   },
+   "description": "POST /workloads spawn agent-worker",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "aa-unitout",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-api"
+     },
+     "destination": {
+      "node": "out-stream"
+     }
+    }
+   },
+   "description": "SSE relay (/api/chat, /api/meeting/stream)",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "aw-tcnative",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-worker"
+     },
+     "destination": {
+      "node": "tc-stream"
+     }
+    }
+   },
+   "description": "copilot tails transcript",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "aw-unitout",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-worker"
+     },
+     "destination": {
+      "node": "out-stream"
+     }
+    }
+   },
+   "description": "XADD cards/notes/deltas",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "aw-proc",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-worker"
+     },
+     "destination": {
+      "node": "proc-stream"
+     }
+    }
+   },
+   "description": "XADD cleaned 1:1 notes",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "aw-unitin",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "agent-worker"
+     },
+     "destination": {
+      "node": "unit-in"
+     }
+    }
+   },
+   "description": "chat path XREADs interactive input",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "mcp-gw",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "mcp"
+     },
+     "destination": {
+      "node": "gateway",
+      "interface": "gateway-rest"
+     }
+    }
+   },
+   "description": "every MCP tool forwards the caller's X-API-Key to the public REST surface",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "gw-ma",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "meeting-api",
+      "interface": "meeting-api-rest"
+     }
+    }
+   },
+   "description": "proxy /bots /transcripts /meetings /recordings",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "gw-aa",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "agent-api",
+      "interface": "agent-api-rest"
+     }
+    }
+   },
+   "description": "proxy /agent/*",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "gw-admin",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "admin-api",
+      "interface": "admin-api-rest"
+     }
+    }
+   },
+   "description": "POST /internal/validate (authz oracle)",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "gw-status",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "bm-status"
+     }
+    }
+   },
+   "description": "WS fan-out",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "gw-umeetings",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "u-meetings"
+     }
+    }
+   },
+   "description": "WS auto-subscribe",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "gw-chat",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "gateway"
+     },
+     "destination": {
+      "node": "va-chat"
+     }
+    }
+   },
+   "description": "WS fan-out",
+   "metadata": [
+    {
+     "access": "read"
+    }
+   ]
+  },
+  {
+   "unique-id": "admin-db",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "admin-api"
+     },
+     "destination": {
+      "node": "identity-db"
+     }
+    }
+   },
+   "protocol": "JDBC",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "admin-pg",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "admin-api"
+     },
+     "destination": {
+      "node": "postgres"
+     }
+    }
+   },
+   "protocol": "JDBC",
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "term-gw-rest",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "terminal"
+     },
+     "destination": {
+      "node": "gateway",
+      "interface": "gateway-rest"
+     }
+    }
+   },
+   "description": "all REST via gateway",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "term-gw-ws",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "terminal"
+     },
+     "destination": {
+      "node": "gateway",
+      "interface": "gateway-ws"
+     }
+    }
+   },
+   "description": "live WS via gateway",
+   "protocol": "WebSocket"
+  },
+  {
+   "unique-id": "dash-gw-rest",
+   "description": "dashboard → gateway REST (hosted-compat aliases; the hosted-proven wiring)",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "dashboard"
+     },
+     "destination": {
+      "node": "gateway",
+      "interface": "gateway-rest"
+     }
+    }
+   }
+  },
+  {
+   "unique-id": "dash-gw-ws",
+   "description": "dashboard → gateway /ws (live transcript view)",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "dashboard"
+     },
+     "destination": {
+      "node": "gateway",
+      "interface": "gateway-ws"
+     }
+    }
+   }
+  },
+  {
+   "unique-id": "slim-gw",
+   "description": "Python client; REST via gateway",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "slim"
+     },
+     "destination": {
+      "node": "gateway",
+      "interface": "gateway-rest"
+     }
+    }
+   },
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "deploy-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "deploy",
+     "nodes": [
+      "execution-targets.v1",
+      "config.v1"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "extension-gw",
+   "description": "browser extension client; live WS via gateway",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "extension"
+     },
+     "destination": {
+      "node": "gateway",
+      "interface": "gateway-ws"
+     }
+    }
+   },
+   "protocol": "WebSocket"
+  },
+  {
+   "unique-id": "stack-deployed",
+   "description": "the long-running services ship as the deploy/compose stack (transcription has its own deploy unit)",
+   "relationship-type": {
+    "deployed-in": {
+     "container": "deploy",
+     "nodes": [
+      "gateway",
+      "meeting-api",
+      "agent-api",
+      "admin-api",
+      "runtime",
+      "redis",
+      "postgres",
+      "minio",
+      "transcription"
+     ]
+    }
+   }
+  }
+ ],
+ "flows": [
+  {
+   "unique-id": "live-transcript-flow",
+   "name": "live transcript",
+   "description": "raw -> durable collector -> native stream -> copilot clean -> render. One render engine; terminal never re-derives.",
+   "transitions": [
+    {
+     "relationship-unique-id": "bot-writes-segments-stream",
+     "sequence-number": 1,
+     "description": "bot XADDs raw ASR segments"
+    },
+    {
+     "relationship-unique-id": "collector-reads-segments",
+     "sequence-number": 2,
+     "description": "collector consumes (XREADGROUP collector_group)"
+    },
+    {
+     "relationship-unique-id": "collector-writes-tc",
+     "sequence-number": 3,
+     "description": "collector writes the native stream (single writer, P23)"
+    },
+    {
+     "relationship-unique-id": "aw-tcnative",
+     "sequence-number": 4,
+     "description": "copilot tails the native stream"
+    },
+    {
+     "relationship-unique-id": "aw-proc",
+     "sequence-number": 5,
+     "description": "copilot writes cleaned 1:1 transcript"
+    },
+    {
+     "relationship-unique-id": "terminal-reads-processed",
+     "sequence-number": 6,
+     "description": "one engine renders raw|processed; no re-derivation"
+    }
+   ]
+  },
+  {
+   "unique-id": "dispatch-flow",
+   "name": "agent dispatch",
+   "description": "a trigger spawns an isolated agent-worker via the runtime kernel; output streams back to the client.",
+   "transitions": [
+    {
+     "relationship-unique-id": "aa-runtime",
+     "sequence-number": 1,
+     "description": "agent-api POST /workloads"
+    },
+    {
+     "relationship-unique-id": "workers-deployed",
+     "sequence-number": 2,
+     "description": "runtime spawns agent-worker container"
+    },
+    {
+     "relationship-unique-id": "aw-unitout",
+     "sequence-number": 3,
+     "description": "worker XADDs output"
+    },
+    {
+     "relationship-unique-id": "aa-unitout",
+     "sequence-number": 4,
+     "description": "agent-api relays as SSE"
+    }
+   ]
+  }
+ ]
 }

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "7d169e6108733171e6afc983886ffc1dbb076e3008ce5b1436c44b4fddc3f614"
+  "architecture.calm.json": "847535bba56bcdb2e39284413bbbf53e9c4a0b23397e5787c4a2a23959799367"
 }

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -206,3 +206,12 @@ VEXA_MEETING_API_URL=http://meeting-api:8080
 #GUARD_TRUSTED_PROXIES=          # comma-separated trusted proxy IPs (enables X-Forwarded-For resolution)
 #GUARD_BLOCKED_COUNTRIES=
 #GUARD_BLOCK_CLOUD_PROVIDERS=
+
+# --- Deprecated 0.10 dashboard (opt-in: docker compose --profile dashboard up -d) — #813 ---
+# Pinned external image + host port; public URLs only matter behind a domain/reverse-proxy.
+# DASHBOARD_IMAGE=vexaai/dashboard:0.10.6.3.14
+# DASHBOARD_PORT=13001
+# DASHBOARD_URL=http://localhost:13001
+# DASHBOARD_PUBLIC_API_URL=http://localhost:18056
+# DASHBOARD_PUBLIC_WS_URL=ws://localhost:18056/ws
+# DASHBOARD_ALLOW_REGISTRATIONS=true

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -509,6 +509,49 @@ services:
     networks: [vexa]
     restart: unless-stopped
 
+  # DEPRECATED — the 0.10 dashboard, kept as an OFF-BY-DEFAULT profile while it is still
+  # load-bearing (#813). It is the multi-user web UI hosted production runs against the 0.12 core
+  # (the wiring below is the hosted-proven one), and some flows (authenticated-session lifecycle,
+  # browser-session provisioning) are only walkable through it today. The Terminal is the
+  # first-class UI; this ships pinned so the UI users see belongs to a release again instead of
+  # floating outside all of them. Start it explicitly:
+  #     docker compose --profile dashboard up -d
+  # Deprecation exit: when the Terminal covers the flows above, this block is deleted, not ported.
+  dashboard:
+    profiles: ["dashboard"]
+    image: ${DASHBOARD_IMAGE:-vexaai/dashboard:0.10.6.3.14}
+    ports:
+      - "127.0.0.1:${DASHBOARD_PORT:-13001}:3000"
+    environment:
+      # Core wiring — identical shape to hosted production (vexa-platform chart), pointed at the
+      # compose service DNS. The dashboard talks to the gateway's hosted-compat surface.
+      - VEXA_API_URL=http://gateway:8000
+      - VEXA_ADMIN_API_URL=http://admin-api:8001
+      - VEXA_ADMIN_API_KEY=${ADMIN_TOKEN:-changeme}
+      - VEXA_PUBLIC_API_URL=${DASHBOARD_PUBLIC_API_URL:-http://localhost:18056}
+      - NEXT_PUBLIC_VEXA_WS_URL=${DASHBOARD_PUBLIC_WS_URL:-ws://localhost:18056/ws}
+      # Auth/session — self-hosted defaults: local registration on, no hosted-mode redirects.
+      - NEXTAUTH_URL=${DASHBOARD_URL:-http://localhost:13001}
+      - NEXT_PUBLIC_APP_URL=${DASHBOARD_URL:-http://localhost:13001}
+      - NEXT_PUBLIC_BASE_URL=${DASHBOARD_URL:-http://localhost:13001}
+      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-dev-nextauth-secret}
+      - JWT_SECRET=${NEXTAUTH_SECRET:-dev-nextauth-secret}
+      - ALLOW_REGISTRATIONS=${DASHBOARD_ALLOW_REGISTRATIONS:-true}
+      - NEXT_PUBLIC_HOSTED_MODE=false
+      - DEFAULT_BOT_NAME=${DEFAULT_BOT_NAME:-Vexa}
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    init: true
+    depends_on:
+      gateway:
+        condition: service_healthy
+    networks: [vexa]
+    restart: unless-stopped
+
 volumes:
   redis-data:
   postgres-data:

--- a/deploy/helm/charts/vexa/templates/deployment-dashboard.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-dashboard.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.dashboard.enabled }}
+# DEPRECATED — the 0.10 dashboard, OFF by default (#813). It is the multi-user web UI hosted
+# production still runs against the 0.12 core; some flows (authenticated-session lifecycle,
+# browser-session provisioning) are only walkable through it today, so it ships pinned as an
+# opt-in component until the Terminal covers them. Wiring mirrors the hosted-proven shape.
+# Deprecation exit: delete this template (and its service/values block), never port it forward.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vexa.componentName" (list . "dashboard") }}
+  labels:
+    {{- include "vexa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.dashboard.replicaCount }}
+  {{- include "vexa.deploymentStrategy" . | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "vexa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dashboard
+  template:
+    metadata:
+      labels:
+        {{- include "vexa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: dashboard
+      annotations:
+        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dashboard
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          # NB: deliberately NOT prefixed by global.imageTag — the dashboard is a deprecated
+          # external image on its own pinned tag, not part of the release image set.
+          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: VEXA_API_URL
+              value: "http://{{ include "vexa.componentName" (list . "gateway") }}:{{ .Values.gateway.service.port }}"
+            - name: VEXA_ADMIN_API_URL
+              value: "http://{{ include "vexa.componentName" (list . "admin-api") }}:{{ .Values.adminApi.service.port }}"
+            - name: VEXA_ADMIN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: ADMIN_API_TOKEN
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: NEXTAUTH_SECRET
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: NEXTAUTH_SECRET
+            - name: ALLOW_REGISTRATIONS
+              value: {{ .Values.dashboard.allowRegistrations | quote }}
+            - name: NEXT_PUBLIC_HOSTED_MODE
+              value: "false"
+            {{- if .Values.dashboard.publicUrl }}
+            - name: NEXTAUTH_URL
+              value: {{ .Values.dashboard.publicUrl | quote }}
+            - name: NEXT_PUBLIC_APP_URL
+              value: {{ .Values.dashboard.publicUrl | quote }}
+            - name: NEXT_PUBLIC_BASE_URL
+              value: {{ .Values.dashboard.publicUrl | quote }}
+            {{- end }}
+            {{- if .Values.dashboard.publicApiUrl }}
+            - name: VEXA_PUBLIC_API_URL
+              value: {{ .Values.dashboard.publicApiUrl | quote }}
+            - name: NEXT_PUBLIC_VEXA_WS_URL
+              value: {{ .Values.dashboard.publicWsUrl | default (printf "%s/ws" (.Values.dashboard.publicApiUrl | replace "https://" "wss://" | replace "http://" "ws://")) | quote }}
+            {{- end }}
+            {{- with .Values.dashboard.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 5
+            failureThreshold: 40
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.dashboard.resources | nindent 12 }}
+      {{- with .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/charts/vexa/templates/service-dashboard.yaml
+++ b/deploy/helm/charts/vexa/templates/service-dashboard.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vexa.componentName" (list . "dashboard") }}
+  labels:
+    {{- include "vexa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.dashboard.service.port }}
+      targetPort: http
+      {{- if .Values.dashboard.service.nodePort }}
+      nodePort: {{ .Values.dashboard.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "vexa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+{{- end }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -289,6 +289,33 @@ terminal:
   #     value: "..."
   extraEnv: []
 
+# DEPRECATED, OFF BY DEFAULT — the 0.10 dashboard as an opt-in component (#813). Hosted production
+# still runs this UI against the 0.12 core, and the authenticated-session / browser-session flows
+# are only walkable through it today; shipping it pinned here puts the UI users actually see back
+# on a release cadence. NOT covered by global.imageTag — it versions on its own pinned tag.
+# Deprecation exit: when the Terminal covers those flows, this block and its templates are deleted.
+dashboard:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: vexaai/dashboard
+    tag: 0.10.6.3.14
+  service:
+    type: ClusterIP
+    port: 3000
+    nodePort: ""
+  # External origin once an ingress/LB fronts the dashboard (NEXTAUTH_URL + public app URLs).
+  publicUrl: ""
+  # Public gateway origin as the BROWSER reaches it (NEXT_PUBLIC_* + websocket URL); empty for
+  # cluster-internal / port-forward access. publicWsUrl overrides the derived wss:// value.
+  publicApiUrl: ""
+  publicWsUrl: ""
+  allowRegistrations: true
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: 500m, memory: 1Gi }
+  extraEnv: []
+
 # Optional idempotent schema-sync Job (meeting-api owns init_db). Off by default; the services
 # create their schema on boot. Enable for an explicit pre-upgrade migration gate.
 migrations:

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -164,4 +164,26 @@ else
   echo "  FAIL: agent-api did not take RollingUpdate under ReadWriteMany workspace"; fail=1
 fi
 
+# #813 — the deprecated dashboard is a strictly OPT-IN component: absent from the default render
+# (the counts above must never silently grow by it), present with its Deployment + Service when
+# enabled, and pinned to its OWN tag (never global.imageTag — it is not part of the release set).
+if grep -q 'app.kubernetes.io/component: dashboard' <<< "$RENDER"; then
+  echo "  FAIL: dashboard rendered in the DEFAULT (disabled) state"; fail=1
+else
+  echo "  OK: dashboard absent by default (deprecated, opt-in only)"
+fi
+RENDER_DASH="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set dashboard.enabled=true --set global.imageTag=vSHOULD-NOT-APPLY)"
+dash_count="$(grep -c 'app.kubernetes.io/component: dashboard' <<< "$RENDER_DASH" || true)"
+if [ "$dash_count" -ge 3 ]; then
+  echo "  OK: dashboard.enabled=true renders its Deployment + Service ($dash_count)"
+else
+  echo "  FAIL: dashboard.enabled=true rendered $dash_count component labels (want >=3)"; fail=1
+fi
+if grep -q 'image: "vexaai/dashboard:vSHOULD-NOT-APPLY"' <<< "$RENDER_DASH"; then
+  echo "  FAIL: dashboard image followed global.imageTag — it must stay on its own pinned tag"; fail=1
+else
+  echo "  OK: dashboard image ignores global.imageTag (own pinned tag)"
+fi
+
 [ "$fail" -eq 0 ] && { echo "gate:helm PASS"; exit 0; } || { echo "gate:helm FAIL"; exit 1; }

--- a/docs/changelog.d/828-dashboard-profile.md
+++ b/docs/changelog.d/828-dashboard-profile.md
@@ -1,0 +1,11 @@
+### Added
+
+- **The deprecated 0.10 dashboard is back in the stack as an off-by-default option** — a
+  `dashboard` compose profile (`docker compose --profile dashboard up -d`, port 13001) and a
+  `dashboard.enabled` helm value, both wiring the pinned external image
+  `vexaai/dashboard:0.10.6.3.14` to the gateway's hosted-compat surface exactly as hosted
+  production runs it. It stays deprecated and versions on its own pinned tag (never
+  `global.imageTag`); it ships because it is still load-bearing — the authenticated-session
+  flows are only walkable through it today — and the UI users actually see should belong to a
+  release. Deletion, not porting, is the deprecation exit.
+  ([#813](https://github.com/Vexa-ai/vexa/issues/813))

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -18,6 +18,7 @@ deploys the same control plane as the Compose stack, with the runtime pointed at
 | redis · minio | Deployments (+ minio init Job) |
 | DB migrations | Job |
 | pgbouncer | optional connection pooling |
+| dashboard (deprecated 0.10 UI) | optional Deployment + Service, **off by default** |
 | RBAC for the k8s spawn backend | Role/RoleBinding scoped to Pod create/watch/delete |
 
 Hardened defaults throughout: containers run non-root with all capabilities dropped,
@@ -200,6 +201,25 @@ cap for every scheduled-meeting spawn). With `ADMIN_API_URL` unset, calendar syn
 auto-join sweep cannot resolve the per-user cap. The meeting-api then **fails closed and refuses to
 spawn** rather than spawn uncapped; set `AUTO_JOIN_ALLOW_UNCAPPED=1` only if you deliberately want
 uncapped auto-join spawns on a self-host.
+
+## The deprecated dashboard (optional)
+
+The 0.10 dashboard — the multi-user web UI that predates the Terminal — ships as an
+**off-by-default** component while it is still load-bearing: hosted production runs it against
+the 0.12 core, and the authenticated-session flows are only walkable through it today. Enable it
+explicitly:
+
+```bash
+helm upgrade --install vexa deploy/helm/charts/vexa -n vexa \
+  --set dashboard.enabled=true \
+  --set dashboard.publicUrl=https://dashboard.example.com \
+  --set dashboard.publicApiUrl=https://api.example.com
+```
+
+It runs the pinned external image `vexaai/dashboard` on its own tag — `global.imageTag` does
+not apply to it — and talks to the gateway's hosted-compat surface. It is **deprecated**: when
+the Terminal covers its remaining flows, the component is deleted, not ported. On Compose the
+same option is `docker compose --profile dashboard up -d` (port 13001).
 
 ## Honest status
 

--- a/docs/views/architecture.dsl
+++ b/docs/views/architecture.dsl
@@ -123,6 +123,8 @@ edges:
   admin-api -write-> postgres
   terminal -req-> gateway  # all REST via gateway
   terminal -req-> gateway  # live WS via gateway
+  dashboard -req-> gateway  # dashboard → gateway REST (hosted-compat aliases; the hosted-proven wiring)
+  dashboard -req-> gateway  # dashboard → gateway /ws (live transcript view)
   slim -req-> gateway  # Python client; REST via gateway
   extension -req-> gateway  # browser extension client; live WS via gateway
   bot, agent-worker deployed-in runtime

--- a/docs/views/containers.mmd
+++ b/docs/views/containers.mmd
@@ -30,6 +30,7 @@ flowchart LR
   slim["slim"]
   extension["extension"]
   terminal["terminal"]
+  dashboard["dashboard (deprecated)"]
   meeting_api -->|"write"| segments_table
   bot -->|"HTTPS"| transcription
   meeting_api -->|"JDBC"| postgres
@@ -43,5 +44,7 @@ flowchart LR
   admin_api -->|"JDBC"| postgres
   terminal -->|"HTTPS"| gateway
   terminal -->|"WebSocket"| gateway
+  dashboard -->|""| gateway
+  dashboard -->|""| gateway
   slim -->|"HTTPS"| gateway
   extension -->|"WebSocket"| gateway

--- a/docs/views/egress.mmd
+++ b/docs/views/egress.mmd
@@ -18,6 +18,7 @@ flowchart LR
     redis["redis"]
     postgres["postgres"]
     minio["minio"]
+    dashboard["dashboard (deprecated)"]
   end
   transcription["transcription"]
   bot ==>|"audio -> tenant-hosted"| transcription


### PR DESCRIPTION
Closes #813 — fork (b) from the issue, per the owner rulings on it: the dashboard stays **deprecated** but gets a **bounded, properly-managed home**, as a maintained external image on a pinned tag (reviving 0.10 source into the monorepo would make the deprecated UI permanent; a pin makes it removable).

## The observation bundle

| # | Observation | Result |
|---|---|---|
| 1 | Compose: default `docker compose config --services` does NOT include `dashboard`; `--profile dashboard` adds it, rendering the hosted-proven env shape (`VEXA_API_URL=http://gateway:8000`, …) | ✅ both renders captured |
| 2 | Helm: default template renders **0** dashboard resources (7 Deployments unchanged); `dashboard.enabled=true` renders Deployment + Service; the image **ignores `global.imageTag`** (pinned own tag) | ✅ three new rows in `deploy/helm/tests/test_template.sh` — `gate:helm PASS` |
| 3 | Live leg: `vexaai/dashboard:0.10.6.3.14` pulled and booted (amd64 under emulation) with exactly the compose block's env shape → **HTTP 200**. Also witnessed: the image *requires* `VEXA_API_URL` and fails loud without it — the compose block provides everything it demands | ✅ boot log + curl |
| 4 | Wiring provenance: env shape read from the RUNNING hosted production Deployment (`vexa-platform-dashboard`, kubectl) — not reconstructed from memory | ✅ |
| 5 | P23: `architecture.calm.json` gains the dashboard node + gateway REST/WS edges, re-sealed (`pnpm seal:arch`), generated views refreshed | ✅ seal diff in this PR |
| 6 | Docs: `deployment-kubernetes.mdx` component table + a "deprecated dashboard (optional)" section carrying the enable command AND the deprecation exit (delete, never port); `.env.example` block; changelog fragment | ✅ |
| 7 | Repo gates | ✅ `gates.mjs all` green |

## Hot-file note (AGENTS.md)

This PR edits both named hot files (`deploy/helm/tests/test_template.sh`, `docs/docs/deployment-kubernetes.mdx`). No other open PR touches them; if one appears before merge, sequence this one per the front-door rule.

## Deprecation contract (the SoC the owner asked for)

- OFF by default on both surfaces; enabling is an explicit operator act.
- Pinned external image; `global.imageTag` deliberately does not apply — the dashboard is not part of the release image set, so a release retag can never silently roll it.
- Exit is **deletion**: when the Terminal covers the authenticated-session/browser-session flows, the compose block, chart component, and CALM node are removed. Stated in the chart values, the compose comment, the template header, and the docs.

## Not claimed

An end-to-end login-and-spawn walk through the dashboard against a full compose stack — that is the v0.12.15 witness territory (it is also the surface #790's authenticated-session flow will be walked on).
