### PR TITLE
fix(bot-spawn,join): browser_session refuses typed at intake; unknown platforms refuse in the join layer (#816)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/__tests__/unknownPlatform.test.ts
+++ b/core/meetings/modules/join/src/__tests__/unknownPlatform.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #816 hardening — an unknown platform is REFUSED by the dispatch, never silently driven
+ * through the Google Meet join flow.
+ *
+ * The dispatch's else-branch used to BE the google_meet branch, so any platform string outside
+ * the known set ran Google Meet selectors against an arbitrary URL and failed minutes later with
+ * misattributed selector timeouts. Observed with `browser_session` (sealed in api.v1, absent from
+ * this layer) at the 0.12 prod cutover.
+ *
+ * Run: npx tsx core/meetings/modules/join/src/__tests__/unknownPlatform.test.ts
+ */
+
+import { joinMeeting } from '../index';
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail?: string) {
+  if (ok) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ''}`); failed++; }
+}
+
+// A page that fails LOUD if any join flow touches it — the refusal must precede all page use.
+const explodingPage: any = new Proxy({}, {
+  get: (_t, prop) => {
+    if (prop === 'then') return undefined; // not a thenable
+    return () => { throw new Error(`page.${String(prop)} was called — a join flow RAN`); };
+  },
+});
+
+async function main() {
+  try {
+    await joinMeeting(explodingPage, {
+      meetingUrl: 'http://irrelevant.example/x',
+      platform: 'browser_session' as any,
+    });
+    check('unknown platform is refused', false, 'joinMeeting resolved');
+  } catch (e: any) {
+    check('unknown platform is refused with a typed message, before any page interaction',
+      /Unsupported platform 'browser_session'/.test(e.message), e.message);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -119,10 +119,17 @@ export async function joinMeeting(page: Page, opts: JoinOptions): Promise<JoinRe
     admitted = await waitForJitsiMeetingAdmission(
       page, botConfig.automaticLeave!.waitingRoomTimeout, botConfig,
     );
-  } else {
+  } else if (platform === "google_meet") {
     await joinGoogleMeeting(page, opts.meetingUrl, botConfig.botName!, botConfig);
     admitted = await waitForGoogleMeetingAdmission(
       page, botConfig.automaticLeave!.waitingRoomTimeout, botConfig,
+    );
+  } else {
+    // Explicit refusal, never a fallthrough: an unknown platform used to silently run the GOOGLE
+    // MEET join flow against whatever URL it was handed — the wrong flow on the wrong site, failing
+    // minutes later with misattributed selector errors instead of naming the real problem here.
+    throw new Error(
+      `Unsupported platform '${platform}' — this join layer drives google_meet, teams, zoom, jitsi`,
     );
   }
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/invocation.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/invocation.py
@@ -50,6 +50,14 @@ _RUNTIME_SCHEMA = _load_schema(
 _INV_REGISTRY = Registry().with_resource(
     _INVOCATION_SCHEMA["$id"], Resource.from_contents(_INVOCATION_SCHEMA)
 )
+
+#: The platforms the MEETING-BOT spawn flow can actually invoke — the sealed invocation.v1
+#: Platform enum, read from the schema itself so this set can never drift from what
+#: ``build_invocation`` will accept. NB: api.v1's Platform enum is WIDER (it also seals
+#: ``browser_session``, whose runtime path is a distinct non-meeting workload — #816); the
+#: router refuses the difference with a typed 422 BEFORE any DB write, instead of writing a
+#: meeting row and then dying inside the schema validation with a 500 that orphans the row.
+SPAWNABLE_PLATFORMS = frozenset(_INVOCATION_SCHEMA["$defs"]["Platform"]["enum"])
 _RT_REGISTRY = Registry().with_resource(
     _RUNTIME_SCHEMA["$id"], Resource.from_contents(_RUNTIME_SCHEMA)
 )

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -32,6 +32,7 @@ from .ports import (
     SpawnFailed,
     TranscriptionNotConfigured,
 )
+from .invocation import SPAWNABLE_PLATFORMS
 from .service import DuplicateMeeting, construct_meeting_url, request_bot
 
 
@@ -246,6 +247,27 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
             raise HTTPException(
                 status_code=422,
                 detail="'platform' and 'native_meeting_id' (or 'meeting_url') are required",
+            )
+        # Reject a platform the meeting-bot flow cannot invoke, up front (→ 422) and BEFORE any DB
+        # write. Without this, a platform outside the sealed invocation.v1 enum but WITH a
+        # meeting_url (api.v1 seals more platforms than invocation.v1 — `browser_session`, #816)
+        # sailed past the constructibility guard below, wrote its `requested` meeting row, and then
+        # died inside build_invocation's schema validation: a 500, plus an ORPHANED active row that
+        # 409s the user's retry on the dedup guard. The refusal names the real state of the world.
+        if platform not in SPAWNABLE_PLATFORMS:
+            supported = ", ".join(sorted(SPAWNABLE_PLATFORMS))
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"platform '{platform}' cannot be spawned as a meeting bot — supported: "
+                    f"{supported}"
+                    + (
+                        ". browser_session is a provisioning workload, not a meeting bot; its "
+                        "0.12 runtime path is not yet restored (tracked in "
+                        "https://github.com/Vexa-ai/vexa/issues/816)"
+                        if platform == "browser_session" else ""
+                    )
+                ),
             )
         # Reject an unsupported platform up front (→ 422), instead of letting the spawn flow fail deep in
         # the invocation builder with an uncaught jsonschema error (→ 500): a meeting URL must be

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -467,3 +467,41 @@ def test_post_bots_explicit_native_id_unchanged_by_url(monkeypatch):
                                  "meeting_url": "https://meet.google.com/abc-defg-hij"})
     assert r.status_code == 201, r.text
     assert repo._meetings[1]["native_meeting_id"] == "xyz-explicit-id"
+
+
+# ── #816 hardening: a non-spawnable platform is refused typed, BEFORE any DB write ──────────────
+# api.v1 seals MORE platforms than invocation.v1 (`browser_session` — a provisioning workload, not
+# a meeting bot). With a meeting_url attached, such a request used to pass the constructibility
+# guard, WRITE its `requested` row, then die inside build_invocation's sealed-schema validation:
+# a 500 plus an orphaned active row that 409'd the user's retry on the dedup guard.
+
+
+def test_browser_session_with_url_is_422_and_writes_no_row(monkeypatch):
+    monkeypatch.setenv("ADMIN_TOKEN", "test-admin-token")
+    repo = InMemoryMeetingRepo()
+    r = _client(repo).post("/bots", headers=HEADERS, json={
+        "platform": "browser_session",
+        "native_meeting_id": "bs-deadbeef",
+        "meeting_url": "https://internal.example/browser-session",
+    })
+    assert r.status_code == 422, f"{r.status_code} {r.text}"
+    detail = r.json()["detail"]
+    assert "browser_session" in detail and "816" in detail, (
+        f"the refusal must name the tracked restoration, got: {detail}"
+    )
+    assert repo._meetings == {}, f"refused spawn wrote a meeting row: {repo._meetings}"
+
+    # And the retry is NOT poisoned: an ordinary meeting on the same repo still spawns.
+    ok = _client(repo).post("/bots", headers=HEADERS, json={
+        "platform": "google_meet", "native_meeting_id": "after-refusal",
+    })
+    assert ok.status_code == 201, ok.text
+
+
+def test_spawnable_platforms_is_the_sealed_invocation_enum():
+    """SSOT: the router's refusal set is READ from the sealed invocation.v1 schema, so it can
+    never drift from what build_invocation will actually accept."""
+    from meeting_api.bot_spawn.invocation import SPAWNABLE_PLATFORMS, _INVOCATION_SCHEMA
+
+    assert SPAWNABLE_PLATFORMS == frozenset(_INVOCATION_SCHEMA["$defs"]["Platform"]["enum"])
+    assert "browser_session" not in SPAWNABLE_PLATFORMS

--- a/docs/changelog.d/829-browser-session-typed-refusal.md
+++ b/docs/changelog.d/829-browser-session-typed-refusal.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Requesting a `browser_session` bot answers a typed 422 instead of a 500 that poisons the
+  retry.** api.v1 seals more platforms than the meeting-bot invocation contract carries; with a
+  `meeting_url` attached, such a request wrote its meeting row and then died inside schema
+  validation — a 500 plus an orphaned active row that made the user's retry 409. The refusal now
+  happens before any write, names the supported platforms, and points at the tracked
+  restoration ([#816](https://github.com/Vexa-ai/vexa/issues/816)).
+- **The join layer refuses an unknown platform instead of silently running the Google Meet
+  flow.** The dispatch's fallback branch WAS the Google Meet branch, so an unrecognized platform
+  drove Meet selectors against an arbitrary URL and failed minutes later with misattributed
+  selector errors. ([#816](https://github.com/Vexa-ai/vexa/issues/816))


### PR DESCRIPTION
Refs #816 — the **hardening slice only**; the capability restoration stays open on the issue (restore map posted there).

## The observation bundle

| # | Observation | Result |
|---|---|---|
| 1 | Red→green: `POST /bots {platform: browser_session, meeting_url: https://…}` ⇒ typed 422 naming the supported set + the tracked restoration, **no meeting row written**, and a subsequent ordinary spawn on the same account succeeds (retry not poisoned) | ✅ `test_browser_session_with_url_is_422_and_writes_no_row`. **Negative control:** removed the guard → the exact pre-fix failure reproduced: unhandled `ValidationError: 'browser_session' is not one of ['google_meet','zoom','teams','jitsi']` **after** the row write; restored → 32 passed |
| 2 | SSOT: the refusal set is read from the sealed invocation.v1 schema itself (`SPAWNABLE_PLATFORMS = frozenset(schema.$defs.Platform.enum)`) — it cannot drift from what `build_invocation` accepts | ✅ `test_spawnable_platforms_is_the_sealed_invocation_enum` |
| 3 | Join layer: an unknown platform throws a typed refusal **before any page interaction** — proven with a Proxy page that explodes on first property access; the old behavior ran the full Google Meet flow | ✅ `unknownPlatform.test.ts`, wired into the module test chain |
| 4 | No sealed bytes moved: neither api.v1 (browser_session stays sealed) nor invocation.v1 changed; `gates.mjs all` green including contract-version + contract-conformance | ✅ |

## What this deliberately does NOT do

It does not restore browser_session (runtime profile, gateway `/b/{token}` routes, per-user userdata prefix, noVNC path) — that is a 7-item restoration mapped on the issue, targeted at the next release. This PR only makes the current gap answer honestly: a typed 422 with a pointer, instead of a 500 that orphans a row and 409s every retry.
