### PR TITLE
feat(bot): record-always at the capture boundary — captured-signal.v1 recorder, hint capture, STT tap, distiller (#830)

### DIFF
--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -13,7 +13,7 @@
   "core/gateway/contracts/ws.v1": "77ce41cb384600acaf34402f4daf8d04b32063c662831238ba7a2e4195e80287",
   "core/identity/contracts/identity.v1": "36902fe610115088c855e7af607c1d778dbd3ab75512d8c71c8bf78cf1767dc7",
   "core/meetings/contracts/acts.v1": "1eaa34d27c52b0eb987a278115a1966c058f615ca16e3391b00107a6779dec4f",
-  "core/meetings/contracts/captured-signal.v1": "78db9e8188a27ca88d3a07ad5a8d0ef458e63fa207538ae19429f86d59857332",
+  "core/meetings/contracts/captured-signal.v1": "6ab2c63f5164827d9735f51b0add4d30890972069f18b63d52255df33c36907d",
   "core/meetings/contracts/flagged-issue.v1": "4b868f57298131f8eec8246d86d57251f259927d8bfd7df5a0f6016a10f16211",
   "core/meetings/contracts/invocation.v1": "c7d7f6b95f11da595d0a9e27a429774cdefcc997831cbedff061ebcc2aafbbb8",
   "core/meetings/contracts/lifecycle.v1": "95392746da49c7c61ec81863e6b836af5acb879f979918753fc8fcf92583b820",

--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -15,7 +15,7 @@
   "core/meetings/contracts/acts.v1": "1eaa34d27c52b0eb987a278115a1966c058f615ca16e3391b00107a6779dec4f",
   "core/meetings/contracts/captured-signal.v1": "78db9e8188a27ca88d3a07ad5a8d0ef458e63fa207538ae19429f86d59857332",
   "core/meetings/contracts/flagged-issue.v1": "4b868f57298131f8eec8246d86d57251f259927d8bfd7df5a0f6016a10f16211",
-  "core/meetings/contracts/invocation.v1": "24ee452ac0ceb58f96422123a2139dc15d5bc1ce54c1a3f4aa45612d8ba77151",
+  "core/meetings/contracts/invocation.v1": "c7d7f6b95f11da595d0a9e27a429774cdefcc997831cbedff061ebcc2aafbbb8",
   "core/meetings/contracts/lifecycle.v1": "95392746da49c7c61ec81863e6b836af5acb879f979918753fc8fcf92583b820",
   "core/meetings/contracts/transcript.v1": "7d07d0fbac77f6562af64ae6c6286051e0e07763f427347d4e7b7735eaa0f9c8",
   "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",

--- a/core/meetings/contracts/captured-signal.v1/captured-signal.schema.json
+++ b/core/meetings/contracts/captured-signal.v1/captured-signal.schema.json
@@ -2,11 +2,24 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://vexa.ai/schemas/captured-signal.v1",
   "title": "captured-signal.v1",
-  "description": "The VERBATIM raw capture signal teed at the bot's capture bridge BEFORE the pipeline — the exact stream a live bug rides on, stored so it replays through the same pipeline OFFLINE (O-TEL-2). One session = a SessionHeader followed by N CapturedFrame records (JSONL-on-disk). Each frame mirrors the @vexa/capture-codec binary frame shape: pcm is base64 of the Float32 PCM bytes (little-endian), so a frame round-trips through the codec encode→decode→same.",
+  "description": "The VERBATIM raw capture signal teed at the bot's capture bridge BEFORE the pipeline — the exact stream a live bug rides on, stored so it replays through the same pipeline OFFLINE (O-TEL-2). One session = a SessionHeader followed by N records (JSONL-on-disk); a record is a CapturedFrame (audio) or a HintEvent (a `type`-tagged out-of-band speaker hint). Each frame mirrors the @vexa/capture-codec binary frame shape: pcm is base64 of the Float32 PCM bytes (little-endian), so a frame round-trips through the codec encode→decode→same.",
   "$defs": {
     "Lane": {
       "description": "Which pipeline lane the frame feeds — gmeet (per-channel, glow-named) or mixed (one stream, named from hints).",
       "enum": ["gmeet", "mixed"]
+    },
+    "HintEvent": {
+      "description": "One OUT-OF-BAND speaker hint as it crossed the capture bridge. The mixed lane (zoom/teams/jitsi) carries a single audio stream and names it from active-speaker hints that arrive on their OWN channel, independent of the audio frames — so a session that stored only CapturedFrames could never reproduce attribution offline. gmeet binds its glow name onto the frame itself and emits no HintEvent. `t` shares the audio frames' epoch-ms clock (the bridge's clock contract), which is what lets a replay re-window the hints against the same audio.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "t", "name"],
+      "properties": {
+        "type": { "const": "hint" },
+        "t": { "type": "number", "description": "hint epoch ms — the SAME clock domain as CapturedFrame.ts" },
+        "name": { "type": "string", "description": "the speaker the platform reports as active" },
+        "isEnd": { "type": "boolean", "description": "true when the hint marks the END of that speaker's turn" },
+        "lane": { "$ref": "#/$defs/Lane" }
+      }
     },
     "CapturedFrame": {
       "description": "One raw capture frame as it crossed the capture-bridge tap. ts is CAPTURE epoch ms (never restamped). speakerIndex is the channel id (999 = mixed, 1000 = the local mic). pcm carries the Float32 PCM bytes base64-encoded; pcm_len is the sample count.",

--- a/core/meetings/contracts/invocation.v1/invocation.schema.json
+++ b/core/meetings/contracts/invocation.v1/invocation.schema.json
@@ -40,6 +40,7 @@
         "transcriptionServiceToken": { "type": "string", "description": "SECRET; placeholder in goldens" },
         "transcriptionModel": { "type": ["string", "null"], "description": "stt model id sent as the OpenAI-compatible `model` form part; unset → whisper-1" },
         "recordingEnabled": { "type": "boolean" },
+        "captureSignalEnabled": { "type": "boolean", "description": "tee the raw captured-signal.v1 stream (audio frames + speaker events) to durable storage for offline replay (O-TEL-1); the transcript/recording paths are unaffected either way" },
         "captureModes": { "type": "array", "items": { "type": "string" } },
         "recordingUploadUrl": { "type": "string", "format": "uri", "description": "recording sink" },
         "automaticLeave": { "$ref": "#/$defs/AutomaticLeave" },

--- a/core/meetings/eval/src/distill.mjs
+++ b/core/meetings/eval/src/distill.mjs
@@ -50,26 +50,67 @@ if (header.type !== 'captured_signal_header') {
   console.error('distill: not a captured-signal.v1 session (bad header)');
   process.exit(2);
 }
-const frames = lines.slice(1).map((l) => JSON.parse(l));
+// A session is a header + records: audio CapturedFrames and `type:"hint"` HintEvents. The mixed
+// lane's attribution lives ENTIRELY in the hints, so a window must carry both or the distilled
+// fixture reproduces sound without speakers.
+const records = lines.slice(1).map((l) => JSON.parse(l));
+const isHint = (r) => r.type === 'hint';
+const timeOf = (r) => (isHint(r) ? r.t : r.ts);
 
 const from = (parseT(opt('from', undefined)) ?? -Infinity) - pad;
 const to = (parseT(opt('to', undefined)) ?? Infinity) + pad;
 
-let kept = frames.filter((f) => f.ts >= from && f.ts <= to);
-if (speaker) kept = kept.filter((f) => f.speakerName === speaker || f.hint === speaker);
-kept = kept.map((f, i) => ({ ...f, seq: i }));
+let kept = records.filter((r) => timeOf(r) >= from && timeOf(r) <= to);
+if (speaker) {
+  // gmeet names each frame (glow-bound), so a name filter selects frames directly. The mixed
+  // lane carries ONE stream nobody's name is on — there the speaker lives only in the hints, so
+  // select the TIME WINDOWS that speaker is hinted over and keep the audio inside them.
+  const named = kept.filter((r) => !isHint(r) && (r.speakerName === speaker || r.hint === speaker));
+  if (named.length) {
+    kept = kept.filter((r) => (isHint(r) ? r.name === speaker : named.includes(r)));
+  } else {
+    const windows = [];
+    let open = null;
+    for (const r of kept.filter(isHint).sort((a, b) => a.t - b.t)) {
+      if (r.name === speaker && !r.isEnd) { open = open ?? r.t; continue; }
+      if (open !== null && (r.isEnd ? r.name === speaker : r.name !== speaker)) {
+        windows.push([open, r.t]); open = null;
+      }
+    }
+    if (open !== null) windows.push([open, Infinity]);
+    if (!windows.length) {
+      console.error(`distill: no hint names "${speaker}" — cannot derive a window in the mixed lane`);
+      process.exit(1);
+    }
+    const inWin = (t) => windows.some(([a, b]) => t >= a - pad && t <= b + pad);
+    kept = kept.filter((r) => (isHint(r) ? r.name === speaker : inWin(r.ts)));
+    console.log(`  (mixed lane: "${speaker}" derived from ${windows.length} hint window(s))`);
+  }
+}
+// Re-seq the audio frames from 0; hints keep their own clock (they are matched by time, not order).
+let n = 0;
+kept = kept.map((r) => (isHint(r) ? r : { ...r, seq: n++ }));
 
-if (kept.length === 0) {
-  console.error('distill: window/filter matched ZERO frames — nothing written');
+const keptFrames = kept.filter((r) => !isHint(r));
+const keptHints = kept.filter(isHint);
+if (keptFrames.length === 0) {
+  console.error('distill: window/filter matched ZERO audio frames — nothing written');
   process.exit(1);
 }
 
-fs.writeFileSync(out, [JSON.stringify(header), ...kept.map((f) => JSON.stringify(f))].join('\n') + '\n', 'utf8');
+fs.writeFileSync(out, [JSON.stringify(header), ...kept.map((r) => JSON.stringify(r))].join('\n') + '\n', 'utf8');
 
-const names = [...new Set(kept.flatMap((f) => [f.speakerName, f.hint].filter(Boolean)))];
-const span = ((kept[kept.length - 1].ts - kept[0].ts) / 1000).toFixed(1);
-console.log(`distilled ${kept.length}/${frames.length} frames → ${out}`);
-console.log(`  span ${span}s (${new Date(kept[0].ts).toISOString()} → ${new Date(kept[kept.length - 1].ts).toISOString()})`);
+const names = [...new Set(kept.flatMap((r) => (isHint(r) ? [r.name] : [r.speakerName, r.hint])).filter(Boolean))];
+const t0 = timeOf(kept[0]);
+const t1 = timeOf(kept[kept.length - 1]);
+const span = ((t1 - t0) / 1000).toFixed(1);
+const totalFrames = records.filter((r) => !isHint(r)).length;
+const totalHints = records.filter(isHint).length;
+console.log(`distilled ${keptFrames.length}/${totalFrames} frames + ${keptHints.length}/${totalHints} hints → ${out}`);
+console.log(`  span ${span}s (${new Date(t0).toISOString()} → ${new Date(t1).toISOString()})`);
 console.log(`  speakers/hints: ${names.join(', ') || '(none)'}   lane=${header.lane ?? '?'} platform=${header.platform}`);
+if (header.lane === 'mixed' && keptHints.length === 0) {
+  console.log('  ⚠ mixed lane with NO hints in window — a replay of this fixture cannot attribute speakers');
+}
 console.log(`  replay offline:  (from meetings/services/bot)  REPLAY_FIXTURE=${out} npx tsx src/replay.test.ts`);
 console.log(`  replay live:     node eval/src/replay.mjs ${out}`);

--- a/core/meetings/eval/src/distill.mjs
+++ b/core/meetings/eval/src/distill.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// distill — cut a recorded captured-signal.v1 session down to a MINIMAL replay fixture.
+//
+// The failure→fixture step of the harvest loop: a live bug is observed on a recorded
+// session; distill the offending time window (± padding) into a small self-contained
+// fixture that replays through the exact pipeline offline (services/bot/src/replay.test.ts
+// consumes it verbatim; eval/src/replay.mjs re-sends it into a live desktop ingest).
+//
+//   node distill.mjs <session.jsonl> [--from <epoch-ms|ISO>] [--to <epoch-ms|ISO>]
+//                    [--speaker <name>] [--pad <ms>] [--out <fixture.jsonl>]
+//
+//   --from/--to   keep frames whose ts falls in [from, to] (default: whole session)
+//   --speaker     keep only frames named/hinted <name> (attribution repros)
+//   --pad         widen the window by <ms> both sides (default 2000 — context the
+//                 segmenter needs around the symptom)
+//   --out         output path (default: <session>.distilled.jsonl)
+//
+// Frames are re-seq'd from 0; ts values are NEVER restamped (the pipeline's segmentation
+// clock is the capture ts). Prints a summary (frames kept/dropped, speakers, span) so the
+// distilled fixture is a checkable claim, not a silent slice.
+import fs from 'node:fs';
+
+const args = process.argv.slice(2);
+const input = args.find((a) => !a.startsWith('--'));
+if (!input) {
+  console.error('usage: node distill.mjs <session.jsonl> [--from t] [--to t] [--speaker name] [--pad ms] [--out path]');
+  process.exit(2);
+}
+const opt = (name, dflt) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] !== undefined ? args[i + 1] : dflt;
+};
+const parseT = (v) => {
+  if (v === undefined) return undefined;
+  const n = Number(v);
+  if (Number.isFinite(n)) return n;
+  const d = Date.parse(v);
+  if (Number.isFinite(d)) return d;
+  console.error(`distill: cannot parse time "${v}" (epoch ms or ISO)`);
+  process.exit(2);
+};
+
+const pad = Number(opt('pad', '2000'));
+const speaker = opt('speaker', undefined);
+const out = opt('out', input.replace(/\.jsonl$/, '') + '.distilled.jsonl');
+
+const lines = fs.readFileSync(input, 'utf8').split('\n').filter(Boolean);
+const header = JSON.parse(lines[0]);
+if (header.type !== 'captured_signal_header') {
+  console.error('distill: not a captured-signal.v1 session (bad header)');
+  process.exit(2);
+}
+const frames = lines.slice(1).map((l) => JSON.parse(l));
+
+const from = (parseT(opt('from', undefined)) ?? -Infinity) - pad;
+const to = (parseT(opt('to', undefined)) ?? Infinity) + pad;
+
+let kept = frames.filter((f) => f.ts >= from && f.ts <= to);
+if (speaker) kept = kept.filter((f) => f.speakerName === speaker || f.hint === speaker);
+kept = kept.map((f, i) => ({ ...f, seq: i }));
+
+if (kept.length === 0) {
+  console.error('distill: window/filter matched ZERO frames — nothing written');
+  process.exit(1);
+}
+
+fs.writeFileSync(out, [JSON.stringify(header), ...kept.map((f) => JSON.stringify(f))].join('\n') + '\n', 'utf8');
+
+const names = [...new Set(kept.flatMap((f) => [f.speakerName, f.hint].filter(Boolean)))];
+const span = ((kept[kept.length - 1].ts - kept[0].ts) / 1000).toFixed(1);
+console.log(`distilled ${kept.length}/${frames.length} frames → ${out}`);
+console.log(`  span ${span}s (${new Date(kept[0].ts).toISOString()} → ${new Date(kept[kept.length - 1].ts).toISOString()})`);
+console.log(`  speakers/hints: ${names.join(', ') || '(none)'}   lane=${header.lane ?? '?'} platform=${header.platform}`);
+console.log(`  replay offline:  (from meetings/services/bot)  REPLAY_FIXTURE=${out} npx tsx src/replay.test.ts`);
+console.log(`  replay live:     node eval/src/replay.mjs ${out}`);

--- a/core/meetings/services/bot/package.json
+++ b/core/meetings/services/bot/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && node build-browser-utils.mjs",
     "build:browser-utils": "node build-browser-utils.mjs",
     "start": "tsx src/index.ts",
-    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/replay.test.ts && tsx src/zoom-speaker-wiring.test.ts && tsx mock/mock.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/telemetry-recorder.test.ts && tsx src/replay.test.ts && tsx src/zoom-speaker-wiring.test.ts && tsx mock/mock.test.ts",
     "replay": "tsx src/replay.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -88,6 +88,11 @@ export const HINT_MAX_SKEW_MS = 10 * 60 * 1000;
 export function makeSpeakerHintSink(
   pipeline: Pick<BotPipeline, 'recordHint'>,
   warn: (m: string) => void = (m) => console.warn(m),
+  /** O-TEL-1: the same sink the audio tap feeds. Mixed-lane hints arrive HERE, not on the audio
+   *  frames, so a session recorded without this tee stores audio that can never reproduce
+   *  attribution offline. Teed with the post-guard `t`, so the stored hint carries the clock the
+   *  pipeline actually saw. */
+  telemetry?: TelemetrySink,
 ): { sink: (name: string, tMs?: number, isEnd?: boolean) => void; crossed: () => number } {
   let crossed = 0;
   return {
@@ -99,6 +104,10 @@ export function makeSpeakerHintSink(
       if (skew > HINT_MAX_SKEW_MS) {
         warn(`[bot] hint-clock-skew: hint tMs=${t} is ${Math.round(skew / 1000)}s off the epoch audio clock — page emitted a non-epoch timestamp; re-stamping (name=${name})`);
         t = Date.now();
+      }
+      if (telemetry?.captureHint) {
+        try { telemetry.captureHint({ type: 'hint', t, name, isEnd, lane: 'mixed' }); }
+        catch { /* telemetry must not break capture */ }
       }
       pipeline.recordHint(name, t, isEnd);
     },
@@ -280,7 +289,7 @@ export async function startCaptureBridge(
   };
   // mixed lane "who is lit" hint (Zoom/Teams active-speaker → the namer's time window).
   // Epoch-clock-guarded + counted; see makeSpeakerHintSink for the clock contract.
-  const { sink: onSpeakerHint, crossed: hintsBridgeCrossed } = makeSpeakerHintSink(pipeline);
+  const { sink: onSpeakerHint, crossed: hintsBridgeCrossed } = makeSpeakerHintSink(pipeline, undefined, telemetry);
   // C1: the four hint hops on one periodic, cumulative counter line —
   // page-emitted lives in the page console ([TeamsSpeakers]/[JitsiSpeakers] logs);
   // bridge-crossed / pipeline-received / binder matched|missed are Node-side.

--- a/core/meetings/services/bot/src/config.ts
+++ b/core/meetings/services/bot/src/config.ts
@@ -70,6 +70,7 @@ export interface Invocation {
   transcriptionModel?: string | null;
   // ── recording ──
   recordingEnabled?: boolean;
+  captureSignalEnabled?: boolean;
   captureModes?: string[];
   recordingUploadUrl?: string;
   // ── lifecycle timeouts ──

--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -30,8 +30,9 @@ import { createHttpLifecycleSink } from './adapters/lifecycle-http.js';
 import { createRedisTranscriptSink, redisClientFrom } from './adapters/transcript-redis.js';
 import { createRedisActsSource, redisActsClientFrom } from './adapters/acts-redis.js';
 import { createBrowserJoinDriver } from './join-driver.js';
-import { createBotPipeline, createLivePipeline, serr, type BotPipeline } from './pipeline.js';
+import { createBotPipeline, createLivePipeline, createTranscribe, serr, type BotPipeline } from './pipeline.js';
 import { createBotRecordingSink } from './recording.js';
+import { createCaptureSignalRecorder, wrapTranscribeWithTap, type CaptureSignalRecorder } from './telemetry.js';
 import { launchBrowser, startCaptureBridge, startRecording, createSpeakController, type BrowserSession, type SpeakController } from './capture-bridge.js';
 import { installSignalHandlers } from './signals.js';
 import type {
@@ -189,13 +190,26 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
   let botPipeline: BotPipeline | null = null;
   let acts: ActsSource = liveActs;
   const recording = inv.recordingEnabled ? createBotRecordingSink({ inv, log: (m) => console.log(`[bot] ${m}`) }) : undefined;
+  // O-TEL-1: persist the raw captured-signal.v1 stream for offline replay. Off ⇒ the tap is a
+  // single undefined-check and the capture path is byte-for-byte unchanged. VEXA_CAPTURE_SIGNAL=1
+  // enables it without a control plane (the local hot-loop path).
+  const signalRecorder: CaptureSignalRecorder | null =
+    (inv.captureSignalEnabled ?? env.VEXA_CAPTURE_SIGNAL === '1')
+      ? createCaptureSignalRecorder(inv)
+      : null;
+  if (signalRecorder) console.log(`[bot] capture-signal recording → ${signalRecorder.path}`);
   const speakerStreamConfig = speakerStreamConfigFromEnv(env);
   if (speakerStreamConfig) console.log(`[bot] speaker-stream tuning enabled: ${JSON.stringify(speakerStreamConfig)}`);
 
   try {
     session = await launchBrowser(inv);                                   // L4 (O6/VM)
     join = createBrowserJoinDriver(session.page, inv);
-    botPipeline = createBotPipeline(inv, transcript, { config: speakerStreamConfig, onError: (e) => console.error(`[bot] pipeline fault: ${String(e)}`) });
+    botPipeline = createBotPipeline(inv, transcript, {
+      // When recording, tee every STT round-trip to <session>.stt.jsonl (the capture/STT/assembly bisect).
+      transcribe: signalRecorder ? wrapTranscribeWithTap(createTranscribe(inv), signalRecorder.path) : undefined,
+      config: speakerStreamConfig,
+      onError: (e) => console.error(`[bot] pipeline fault: ${String(e)}`),
+    });
     // Defer the page-side capture start to pipeline.start(): the orchestrator calls it AFTER
     // admission (orchestrator.ts:125), on the LIVE meeting page — where addInitScript has injected
     // window.VexaBrowserUtils and the participant <audio> elements exist. Starting it at launch ran
@@ -226,7 +240,7 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
     // each failure surfaces LOUD via onFault (console with a full-fidelity serr(e)) instead of
     // throwing into the orchestrator's leave-on-fail backstop (which would hang the bot up).
     pipeline = createLivePipeline({
-      startCapture: () => startCaptureBridge(sess.page, inv, bp, undefined, publishChat),   // on the live meeting page
+      startCapture: () => startCaptureBridge(sess.page, inv, bp, signalRecorder?.sink, publishChat),   // on the live meeting page
       startRecording: rec ? () => startRecording(sess.page, inv, rec) : undefined,          // MediaRecorder → recording.v1
       engine: bp,
       onFault: (stage, e) => {
@@ -275,6 +289,7 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
     // on a normal end; createLivePipeline.stop() is idempotent, and this also covers an early-exit
     // path that skipped the orchestrator's teardown. (#593)
     await pipeline.stop().catch(() => { /* best-effort */ });
+    await signalRecorder?.close().catch(() => { /* best-effort */ });
     if (session) await session.close().catch(() => { /* best-effort */ });
     // Quit the redis connections on teardown (best-effort — a quit failure must not change the
     // exit code; they may never have connected if redis was unreachable).

--- a/core/meetings/services/bot/src/ports.ts
+++ b/core/meetings/services/bot/src/ports.ts
@@ -108,6 +108,19 @@ export interface CapturedFrame {
   lane: 'gmeet' | 'mixed';          // which pipeline lane this frame feeds
 }
 
+/** One captured-signal.v1 OUT-OF-BAND speaker hint as it crosses the capture bridge. The mixed
+ *  lane carries ONE audio stream and names it from active-speaker hints delivered on their own
+ *  channel — so the hints are not on any CapturedFrame, and a session without them cannot
+ *  reproduce attribution offline. `t` shares the audio frames' epoch-ms clock. (gmeet binds its
+ *  glow name onto the frame itself and emits none.) */
+export interface HintEvent {
+  type: 'hint';
+  t: number;                        // hint epoch ms — SAME clock domain as CapturedFrame.ts
+  name: string;                     // who the platform reports as active
+  isEnd?: boolean;                  // marks the END of that speaker's turn
+  lane?: 'gmeet' | 'mixed';
+}
+
 /** TelemetrySink port — the OPTIONAL dual-sink the capture bridge tees raw frames into, BEFORE
  *  the pipeline. The real adapter persists captured-signal.v1 (file/store); when unset the tap is
  *  a single undefined-check (zero overhead — the proven O6 capture path is never altered). The
@@ -116,4 +129,8 @@ export interface TelemetrySink {
   /** Tee one raw capture frame. MUST NOT throw into the capture path (the bridge calls it
    *  fire-and-forget); the adapter swallows + logs its own faults. */
   captureFrame(frame: CapturedFrame): void;
+  /** Tee one out-of-band speaker hint. OPTIONAL so older sinks keep compiling; a recorder that
+   *  omits it stores a mixed-lane session that can never reproduce attribution. Same
+   *  fire-and-forget contract as captureFrame. */
+  captureHint?(hint: HintEvent): void;
 }

--- a/core/meetings/services/bot/src/replay.test.ts
+++ b/core/meetings/services/bot/src/replay.test.ts
@@ -32,7 +32,12 @@ import { createGmeetPipeline, type TranscriptSegment } from '@vexa/gmeet-pipelin
 import type { TranscriptionResult } from '@vexa/transcribe-whisper';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const FIXTURE = join(HERE, '..', '..', '..', 'eval', 'replay-fixture', 'session.captured-signal.jsonl');
+// REPLAY_FIXTURE points the harness at ANY recorded/distilled session (eval/src/distill.mjs) —
+// the universal checks (loads · deterministic · transcript.v1-valid) run on it; the golden's
+// Alice→Bob→Alice structure checks run only on the default fixture, whose shape they pin.
+const GOLDEN = join(HERE, '..', '..', '..', 'eval', 'replay-fixture', 'session.captured-signal.jsonl');
+const FIXTURE = process.env.REPLAY_FIXTURE ?? GOLDEN;
+const IS_GOLDEN = FIXTURE === GOLDEN;
 const TX_SCHEMA = join(HERE, '..', '..', '..', 'contracts', 'transcript.v1', 'transcript.schema.json');
 
 let failed = 0;
@@ -109,6 +114,13 @@ async function main(): Promise<void> {
     JSON.stringify(segs.map((s) => ({ speaker: s.speaker, speaker_key: s.speaker_key, text: s.text, start: s.start, end: s.end })));
   check('same input ⇒ same output (replay is deterministic)', norm(run1) === norm(run2),
     `\n      run1=${norm(run1)}\n      run2=${norm(run2)}`);
+
+  if (!IS_GOLDEN) {
+    if (failed) { console.error(`\n❌ replay (O-TEL-2, custom fixture): ${failed} check(s) FAILED.`); process.exit(1); }
+    console.log(`\n✅ replay (O-TEL-2): custom fixture ${FIXTURE} replays deterministically; every segment transcript.v1-valid.`);
+    console.log(run1.map((s) => `  ${s.speaker}  [${s.start.toFixed(2)}–${s.end.toFixed(2)}]  ${s.text}`).join('\n'));
+    return;
+  }
 
   // STRUCTURE: the captured signal alone drives the expected three-turn Alice → Bob → Alice shape.
   const speakers = run1.map((s) => s.speaker);

--- a/core/meetings/services/bot/src/replay.test.ts
+++ b/core/meetings/services/bot/src/replay.test.ts
@@ -61,7 +61,13 @@ function loadCapturedSignal(path: string): { header: CapHeader; frames: CapFrame
   const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
   const header = JSON.parse(lines[0]) as CapHeader;
   if (header.type !== 'captured_signal_header') throw new Error('not a captured-signal.v1 fixture (bad header)');
-  const frames = lines.slice(1).map((l) => JSON.parse(l) as CapFrame);
+  // A session interleaves audio frames with `type:"hint"` records (the mixed lane's attribution
+  // channel). This gmeet harness drives audio only; hints are surfaced so a mixed-lane session
+  // is never silently replayed as if it had no speakers.
+  const records = lines.slice(1).map((l) => JSON.parse(l) as CapFrame & { type?: string });
+  const frames = records.filter((r) => r.type !== 'hint');
+  const hints = records.length - frames.length;
+  if (hints) console.log(`  (session carries ${hints} out-of-band speaker hint(s))`);
   return { header, frames };
 }
 

--- a/core/meetings/services/bot/src/telemetry-recorder.test.ts
+++ b/core/meetings/services/bot/src/telemetry-recorder.test.ts
@@ -18,7 +18,7 @@ import { readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { makeTelemetryTap } from './capture-bridge.js';
+import { makeTelemetryTap, makeSpeakerHintSink } from './capture-bridge.js';
 import { createCaptureSignalRecorder, type SignalWriter } from './telemetry.js';
 import type { Invocation } from './config.js';
 
@@ -36,6 +36,7 @@ addFormats(ajv);
 ajv.addSchema(csSchema);
 const validateFrame: ValidateFunction = ajv.compile({ $ref: `${csSchema.$id}#/$defs/CapturedFrame` });
 const validateHeader: ValidateFunction = ajv.compile({ $ref: `${csSchema.$id}#/$defs/SessionHeader` });
+const validateHint: ValidateFunction = ajv.compile({ $ref: `${csSchema.$id}#/$defs/HintEvent` });
 
 const inv = {
   platform: 'google_meet', meetingUrl: 'https://meet.google.com/abc-defg-hij', botName: 'RecBot',
@@ -79,6 +80,47 @@ async function main(): Promise<void> {
       });
       check('stored pcm ≡ tapped pcm (Float32-bit-exact, replay-loadable)', exact);
       check('names alternate Alice/Bob as tapped', frames[0].speakerName === 'Alice' && frames[1].speakerName === 'Bob');
+    }
+
+    // ── 1b) MIXED lane: the out-of-band hints are recorded too ────────────────────────
+    // Live-witnessed gap: a mixed-lane session (jitsi/teams/zoom) carries ONE audio stream and
+    // names it from hints that arrive on their own channel — never on the audio frames. A
+    // recorder that taps only audio stores a session that replays sound with NO speakers.
+    // Drive the REAL hint sink (the closure the bridge exposes as __vexaSpeakerHint).
+    {
+      const rec = createCaptureSignalRecorder({ ...inv, platform: 'jitsi' } as Invocation, { dir: join(dir, 'mixed'), flushMs: 10 });
+      const tee = makeTelemetryTap('mixed', rec.sink);
+      const seen: Array<[string, number, boolean | undefined]> = [];
+      const { sink: hintSink } = makeSpeakerHintSink(
+        { recordHint: (n, t, e) => { seen.push([n, t, e]); } }, () => { /* quiet */ }, rec.sink,
+      );
+      // Hints ride the LIVE epoch clock: the bridge's skew guard re-stamps anything far from
+      // now (a page emitting performance.now() instead of epoch), so the fixture must be current.
+      const base = Date.now();
+      hintSink('Anna', base + 100);
+      for (let i = 0; i < 10; i++) tee(0, pcm(160, i), base + 200 + i * 100);
+      hintSink('Anna', base + 1300, true);
+      hintSink('Boris', base + 1400);
+      for (let i = 0; i < 10; i++) tee(0, pcm(160, i + 50), base + 1500 + i * 100);
+      await rec.close();
+
+      const recs = readFileSync(rec.path, 'utf8').split('\n').filter(Boolean).slice(1).map((l) => JSON.parse(l));
+      const hintRecs = recs.filter((r) => r.type === 'hint');
+      const frameRecs = recs.filter((r) => r.type !== 'hint');
+      check('mixed lane: hints reach the session file', hintRecs.length === 3, `n=${hintRecs.length}`);
+      check('every hint is captured-signal.v1-valid (ajv vs SSOT)',
+        hintRecs.every((h) => validateHint(h)), ajv.errorsText(validateHint.errors));
+      check('hints carry name + epoch t + isEnd',
+        hintRecs[0].name === 'Anna' && hintRecs[0].t === base + 100 &&
+        hintRecs[1].isEnd === true && hintRecs[2].name === 'Boris', JSON.stringify(hintRecs));
+      check('audio frames still recorded alongside hints', frameRecs.length === 20, `n=${frameRecs.length}`);
+      check('hints interleave with audio in arrival order',
+        recs[0].type === 'hint' && recs[1].type !== 'hint', recs.slice(0, 3).map((r) => r.type ?? 'frame').join(','));
+      check('the pipeline still receives every hint (tee never swallows)', seen.length === 3, `n=${seen.length}`);
+      // The stored hints must be enough to reconstruct who spoke when, offline.
+      const names = [...new Set(hintRecs.map((h) => h.name))].sort();
+      check('stored hints name both speakers (attribution is reproducible offline)',
+        names.join(',') === 'Anna,Boris', names.join(','));
     }
 
     // ── 2) zero-frame session: header-only file still written (attributable) ──

--- a/core/meetings/services/bot/src/telemetry-recorder.test.ts
+++ b/core/meetings/services/bot/src/telemetry-recorder.test.ts
@@ -1,0 +1,110 @@
+/**
+ * O-TEL-1b — the recorder adapter (telemetry.ts). OFFLINE, NO browser/redis/whisper.
+ *
+ * Drives the EXACT bridge tap (makeTelemetryTap) into the REAL recording sink
+ * (createCaptureSignalRecorder) and asserts the persisted session is replay-grade:
+ *   • the file opens with a captured-signal.v1 SessionHeader (ajv vs the SSOT schema);
+ *   • every frame line conforms + seq is monotone + arrival order is preserved across
+ *     buffered flushes;
+ *   • each stored pcm decodes back to the EXACT Float32 PCM the tap saw (the replay loader's
+ *     framePcm shape) — so replay.test.ts can consume a recorded session verbatim;
+ *   • a zero-frame session still leaves an attributable header-only file;
+ *   • a writer fault never throws into captureFrame, and close() is idempotent.
+ * Run: npx tsx src/telemetry-recorder.test.ts
+ */
+import Ajv2020, { type ValidateFunction } from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTelemetryTap } from './capture-bridge.js';
+import { createCaptureSignalRecorder, type SignalWriter } from './telemetry.js';
+import type { Invocation } from './config.js';
+
+let failed = 0;
+const check = (name: string, cond: boolean, detail = ''): void => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond ? '' : '  — ' + detail}`);
+  if (!cond) failed++;
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CS_SCHEMA = join(HERE, '..', '..', '..', 'contracts', 'captured-signal.v1', 'captured-signal.schema.json');
+const csSchema = JSON.parse(readFileSync(CS_SCHEMA, 'utf8'));
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(csSchema);
+const validateFrame: ValidateFunction = ajv.compile({ $ref: `${csSchema.$id}#/$defs/CapturedFrame` });
+const validateHeader: ValidateFunction = ajv.compile({ $ref: `${csSchema.$id}#/$defs/SessionHeader` });
+
+const inv = {
+  platform: 'google_meet', meetingUrl: 'https://meet.google.com/abc-defg-hij', botName: 'RecBot',
+  nativeMeetingId: 'abc-defg-hij', connectionId: 'conn-rec-1', redisUrl: 'redis://unused:6379',
+  language: 'en',
+} as Invocation;
+
+const pcm = (n: number, seed: number): Float32Array =>
+  Float32Array.from({ length: n }, (_, i) => ((((seed * 5 + i * 3) % 256) - 128) / 256));
+
+async function main(): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'cs-rec-'));
+  try {
+    // ── 1) tap → recorder → file: header + frames conform, order + pcm exact ──
+    {
+      const rec = createCaptureSignalRecorder(inv, { dir, flushMs: 10 });
+      const tee = makeTelemetryTap('gmeet', rec.sink);
+      const sent: Float32Array[] = [];
+      for (let i = 0; i < 50; i++) {
+        const p = pcm(160, i);
+        sent.push(p);
+        tee(i % 2, p, 1718000000000 + i * 100, i % 2 ? 'Bob' : 'Alice');
+      }
+      await rec.close();
+      await rec.close(); // idempotent
+
+      const lines = readFileSync(rec.path, 'utf8').split('\n').filter(Boolean);
+      const header = JSON.parse(lines[0]);
+      check('SessionHeader conforms (ajv vs SSOT)', !!validateHeader(header), ajv.errorsText(validateHeader.errors));
+      check('header carries platform/native/lane', header.platform === 'google_meet' && header.native_meeting_id === 'abc-defg-hij' && header.lane === 'gmeet', JSON.stringify(header));
+      const frames = lines.slice(1).map((l) => JSON.parse(l));
+      check('all 50 frames persisted', frames.length === 50, `n=${frames.length}`);
+      check('every frame conforms', frames.every((f) => validateFrame(f)), ajv.errorsText(validateFrame.errors));
+      check('seq monotone, arrival order preserved', frames.every((f, i) => f.seq === i), JSON.stringify(frames.map((f) => f.seq).slice(0, 5)));
+      const exact = frames.every((f, i) => {
+        const b = Buffer.from(f.pcm, 'base64');
+        const restored = new Float32Array(b.buffer, b.byteOffset, b.byteLength / 4);
+        return f.pcm_len === sent[i].length &&
+          Buffer.compare(Buffer.from(restored.buffer, restored.byteOffset, restored.byteLength),
+                         Buffer.from(sent[i].buffer, sent[i].byteOffset, sent[i].byteLength)) === 0;
+      });
+      check('stored pcm ≡ tapped pcm (Float32-bit-exact, replay-loadable)', exact);
+      check('names alternate Alice/Bob as tapped', frames[0].speakerName === 'Alice' && frames[1].speakerName === 'Bob');
+    }
+
+    // ── 2) zero-frame session: header-only file still written (attributable) ──
+    {
+      const rec = createCaptureSignalRecorder(inv, { dir: join(dir, 'empty') });
+      await rec.close();
+      const lines = readFileSync(rec.path, 'utf8').split('\n').filter(Boolean);
+      check('zero-frame session leaves a header-only file', lines.length === 1 && !!validateHeader(JSON.parse(lines[0])));
+    }
+
+    // ── 3) writer faults are swallowed — captureFrame never throws into capture ──
+    {
+      const bad: SignalWriter = { append: async () => { throw new Error('disk gone'); }, end: async () => { /* */ } };
+      const rec = createCaptureSignalRecorder(inv, { writer: bad, flushMs: 5, log: () => { /* quiet */ } });
+      const tee = makeTelemetryTap('gmeet', rec.sink);
+      let threw = false;
+      try { for (let i = 0; i < 100; i++) tee(0, pcm(16, i), i, 'Alice'); await rec.close(); }
+      catch { threw = true; }
+      check('a faulting writer never throws into the capture path', !threw);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  if (failed) { console.error(`\n❌ telemetry-recorder (O-TEL-1b): ${failed} check(s) FAILED.`); process.exit(1); }
+  console.log('\n✅ telemetry-recorder (O-TEL-1b): the recorder persists a replay-grade captured-signal.v1 session (header + ordered conformant frames, bit-exact pcm); zero-frame sessions stay attributable; writer faults never reach capture.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/core/meetings/services/bot/src/telemetry.ts
+++ b/core/meetings/services/bot/src/telemetry.ts
@@ -19,7 +19,7 @@ import { appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { isMixedLanePlatform, type Invocation } from './config.js';
 import { rmsOf } from './capture-bridge.js';
-import type { CapturedFrame, TelemetrySink } from './ports.js';
+import type { CapturedFrame, HintEvent, TelemetrySink } from './ports.js';
 
 /** Where a session's JSONL lines land. append() receives whole lines (newline-terminated). */
 export interface SignalWriter {
@@ -167,7 +167,20 @@ export function createCaptureSignalRecorder(inv: Invocation, opts: RecorderOptio
   const timer = writer ? setInterval(() => { void flush(); }, opts.flushMs ?? DEFAULT_FLUSH_MS) : null;
   timer?.unref?.();
 
+  let hints = 0;
   const sink: TelemetrySink = {
+    // The mixed lane's speaker hints arrive out-of-band; without them a replay of this session
+    // has audio but no way to attribute it (the gmeet lane binds its name onto the frame instead).
+    captureHint(hint: HintEvent): void {
+      if (!writer) return;
+      try {
+        const line = JSON.stringify(hint) + '\n';
+        buf.push(line);
+        bufBytes += line.length;
+        hints++;
+        if (bufBytes >= maxBuffer) void flush();
+      } catch { /* must never throw into capture */ }
+    },
     captureFrame(frame: CapturedFrame): void {
       if (!writer) return;
       try {
@@ -197,7 +210,7 @@ export function createCaptureSignalRecorder(inv: Invocation, opts: RecorderOptio
       try {
         await flush();
         await writer?.end();
-        log(`session written: ${path} (${seq} frames)`);
+        log(`session written: ${path} (${seq} frames, ${hints} hints)`);
       } catch (e) {
         log(`close failed: ${String(e)}`);
       }

--- a/core/meetings/services/bot/src/telemetry.ts
+++ b/core/meetings/services/bot/src/telemetry.ts
@@ -1,0 +1,206 @@
+/**
+ * O-TEL-1 recorder adapter — the real TelemetrySink behind the capture-bridge tap.
+ *
+ * Persists one captured-signal.v1 session as JSONL: a SessionHeader line, then every raw
+ * frame the bridge tees in, in arrival order. The output is byte-compatible with
+ * eval/replay-fixture/session.captured-signal.jsonl, so a recorded session replays through
+ * the EXACT pipeline offline (replay.test.ts / eval/src/replay.mjs — O-TEL-2).
+ *
+ * Contract with the capture path (ports.ts TelemetrySink): captureFrame is fire-and-forget
+ * and MUST NOT throw or block — frames are buffered in memory and flushed to the writer on
+ * a size/time threshold, and every writer fault is swallowed + logged. A crashed bot still
+ * leaves everything flushed so far on disk (crash sessions are the most valuable ones).
+ *
+ * The writer is a port: the local file writer here is the dev/self-host default; an S3
+ * chunked writer plugs in behind the same SignalWriter shape without touching the sink.
+ */
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { appendFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { isMixedLanePlatform, type Invocation } from './config.js';
+import { rmsOf } from './capture-bridge.js';
+import type { CapturedFrame, TelemetrySink } from './ports.js';
+
+/** Where a session's JSONL lines land. append() receives whole lines (newline-terminated). */
+export interface SignalWriter {
+  append(chunk: string): Promise<void>;
+  end(): Promise<void>;
+}
+
+/** Local-file SignalWriter — one JSONL file per session under `dir`. */
+export function fileSignalWriter(path: string): SignalWriter {
+  return {
+    append: (chunk) => appendFile(path, chunk, 'utf8'),
+    async end() { /* nothing to finalize for a plain file */ },
+  };
+}
+
+export interface CaptureSignalRecorder {
+  sink: TelemetrySink;
+  /** The session file path (file writer) or logical key. */
+  path: string;
+  /** Flush any buffered frames and stop the flush timer. Idempotent; never throws. */
+  close(): Promise<void>;
+}
+
+export interface RecorderOptions {
+  /** Directory for the session file (file writer). Created if absent. */
+  dir?: string;
+  /** Inject a writer (S3 adapter / test spy). Overrides `dir`. */
+  writer?: SignalWriter;
+  /** Flush cadence + buffer cap — tuned so a crash loses at most ~flushMs of signal. */
+  flushMs?: number;
+  maxBufferBytes?: number;
+  log?: (m: string) => void;
+  now?: () => number;
+}
+
+const DEFAULT_DIR = process.env.VEXA_CAPTURE_SIGNAL_DIR ?? '/tmp/captured-signal';
+const DEFAULT_FLUSH_MS = 2000;
+const DEFAULT_MAX_BUFFER = 1 << 20; // 1 MiB of pending JSONL
+
+/** Build the captured-signal.v1 SessionHeader for this invocation. */
+export function sessionHeader(inv: Invocation, startedAt: number): Record<string, unknown> {
+  const header: Record<string, unknown> = {
+    type: 'captured_signal_header',
+    v: 1,
+    platform: inv.platform,
+    native_meeting_id: inv.nativeMeetingId ?? inv.connectionId ?? 'session',
+    language: inv.language ?? null,
+    lane: isMixedLanePlatform(inv.platform) ? 'mixed' : 'gmeet',
+    sample_rate: 16000,
+    started_at: new Date(startedAt).toISOString(),
+  };
+  if (inv.connectionId) header.trace_id = inv.connectionId;
+  return header;
+}
+
+/** The minimal structural shape of the STT round-trip we tap (pipeline.ts Transcribe). */
+type TranscribeFn = (pcm: Float32Array, prompt?: string) => Promise<{
+  text: string; language: string; duration: number; segments: unknown[];
+}>;
+
+/**
+ * Wrap the real STT closure so every request/response (or typed fault) lands as one JSONL
+ * line next to the session file — the bisect layer between capture and assembly: a replay
+ * can distinguish audio-reached-STT-and-came-back-empty against audio-never-got-there.
+ * Same fire-and-forget discipline as the frame sink: a tap fault never disturbs STT.
+ */
+export function wrapTranscribeWithTap<T extends TranscribeFn>(
+  transcribe: T,
+  sessionPath: string,
+  log: (m: string) => void = (m) => console.log(`[bot] stt-tap: ${m}`),
+): T {
+  const path = sessionPath.replace(/\.captured-signal\.jsonl$/, '.stt.jsonl');
+  let faults = 0;
+  const write = (rec: Record<string, unknown>): void => {
+    appendFile(path, JSON.stringify(rec) + '\n', 'utf8')
+      .catch((e) => { if (faults++ < 5) log(`write failed: ${String(e)}`); });
+  };
+  const tapped = (async (pcm: Float32Array, prompt?: string) => {
+    const t0 = Date.now();
+    try {
+      const res = await transcribe(pcm, prompt);
+      write({ at: new Date(t0).toISOString(), ms: Date.now() - t0, pcm_len: pcm.length, prompt_len: prompt?.length ?? 0, ok: true, text: res.text, language: res.language, duration: res.duration, segments: res.segments.length });
+      return res;
+    } catch (e) {
+      const x = e as { kind?: string; status?: number; message?: string };
+      write({ at: new Date(t0).toISOString(), ms: Date.now() - t0, pcm_len: pcm.length, prompt_len: prompt?.length ?? 0, ok: false, kind: x?.kind ?? 'unknown', status: x?.status, error: x?.message });
+      throw e;
+    }
+  }) as T;
+  return tapped;
+}
+
+/**
+ * Create the recording TelemetrySink for one bot session. The header line is written
+ * synchronously at creation (boot-time, before capture starts); frames are buffered and
+ * flushed asynchronously so the capture path never waits on I/O.
+ */
+export function createCaptureSignalRecorder(inv: Invocation, opts: RecorderOptions = {}): CaptureSignalRecorder {
+  const log = opts.log ?? ((m: string) => console.log(`[bot] capture-signal: ${m}`));
+  const now = opts.now ?? Date.now;
+  const startedAt = now();
+  const dir = opts.dir ?? DEFAULT_DIR;
+  const name = `${inv.connectionId ?? inv.nativeMeetingId ?? 'session'}.captured-signal.jsonl`;
+  const path = join(dir, name);
+
+  const headerLine = JSON.stringify(sessionHeader(inv, startedAt)) + '\n';
+  let writer: SignalWriter | null = null;
+  let flushing: Promise<void> = Promise.resolve();
+  try {
+    if (opts.writer) {
+      writer = opts.writer;
+      // Chain the header into the flush sequence so it always precedes frame lines.
+      flushing = writer.append(headerLine).catch((e) => log(`header write failed: ${String(e)}`));
+    } else {
+      mkdirSync(dir, { recursive: true });
+      // Header lands synchronously so even a zero-frame session leaves an attributable file.
+      appendFileSync(path, headerLine, 'utf8');
+      writer = fileSignalWriter(path);
+    }
+  } catch (e) {
+    // A broken writer disables recording for the session — capture is never affected.
+    log(`disabled (writer init failed): ${String(e)}`);
+    writer = null;
+  }
+
+  let buf: string[] = [];
+  let bufBytes = 0;
+  let seq = 0;
+  let faults = 0;
+  const maxBuffer = opts.maxBufferBytes ?? DEFAULT_MAX_BUFFER;
+
+  const flush = (): Promise<void> => {
+    if (!writer || buf.length === 0) return flushing;
+    const chunk = buf.join('');
+    buf = [];
+    bufBytes = 0;
+    const w = writer;
+    // Serialize flushes so lines never interleave out of order.
+    flushing = flushing
+      .then(() => w.append(chunk))
+      .catch((e) => { if (faults++ < 5) log(`flush failed (frames dropped): ${String(e)}`); });
+    return flushing;
+  };
+
+  const timer = writer ? setInterval(() => { void flush(); }, opts.flushMs ?? DEFAULT_FLUSH_MS) : null;
+  timer?.unref?.();
+
+  const sink: TelemetrySink = {
+    captureFrame(frame: CapturedFrame): void {
+      if (!writer) return;
+      try {
+        // The bridge tap supplies seq/rms; derive them here if a caller doesn't (ports.ts).
+        const full = {
+          ...frame,
+          seq: frame.seq ?? seq,
+          rms: frame.rms ?? rmsOf(new Float32Array(Buffer.from(frame.pcm, 'base64').buffer)),
+        };
+        seq = full.seq + 1;
+        const line = JSON.stringify(full) + '\n';
+        buf.push(line);
+        bufBytes += line.length;
+        if (bufBytes >= maxBuffer) void flush();
+      } catch { /* must never throw into capture */ }
+    },
+  };
+
+  let closed = false;
+  return {
+    sink,
+    path,
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      if (timer) clearInterval(timer);
+      try {
+        await flush();
+        await writer?.end();
+        log(`session written: ${path} (${seq} frames)`);
+      } catch (e) {
+        log(`close failed: ${String(e)}`);
+      }
+    },
+  };
+}

--- a/docs/changelog.d/capture-signal-recorder.md
+++ b/docs/changelog.d/capture-signal-recorder.md
@@ -5,6 +5,9 @@
   STT round-trip beside it (`<session>.stt.jsonl`). A recorded session replays byte-for-byte
   through the exact transcription pipeline with no live meeting (`REPLAY_FIXTURE=<file> tsx
   src/replay.test.ts`), and `eval/src/distill.mjs` cuts a session down to a minimal fixture
-  around a reported symptom (time window / speaker). Off by default; when off, the capture
-  path is unchanged (a single branch). This is the diagnostic layer for zero-transcript and
-  misattribution reports: the failing meeting's input becomes a deterministic red test.
+  around a reported symptom (time window / speaker). A session stores both halves of the
+  signal: the audio frames and — for Zoom/Teams/Jitsi, whose single mixed stream is named from
+  active-speaker hints arriving on their own channel — those hints as `type: "hint"` records,
+  so a replay reproduces who spoke, not just what was heard. Off by default; when off, the
+  capture path is unchanged (a single branch). This is the diagnostic layer for zero-transcript
+  and misattribution reports: the failing meeting's input becomes a deterministic red test.

--- a/docs/changelog.d/capture-signal-recorder.md
+++ b/docs/changelog.d/capture-signal-recorder.md
@@ -1,0 +1,10 @@
+- **Record-always at the capture boundary: bots can now persist their raw
+  `captured-signal.v1` stream for offline replay.** With `captureSignalEnabled` in the
+  invocation (or `VEXA_CAPTURE_SIGNAL=1`), the bot tees every raw capture frame — per-channel
+  PCM audio plus the speaker events it was captured with — into a session JSONL, and logs each
+  STT round-trip beside it (`<session>.stt.jsonl`). A recorded session replays byte-for-byte
+  through the exact transcription pipeline with no live meeting (`REPLAY_FIXTURE=<file> tsx
+  src/replay.test.ts`), and `eval/src/distill.mjs` cuts a session down to a minimal fixture
+  around a reported symptom (time window / speaker). Off by default; when off, the capture
+  path is unchanged (a single branch). This is the diagnostic layer for zero-transcript and
+  misattribution reports: the failing meeting's input becomes a deterministic red test.


### PR DESCRIPTION
Closes #830.

## The observation bundle

Rows map to #830's acceptance table. Every offline row is a committed test; the live rows were witnessed on a real Jitsi meeting (mixed lane — the same lane as the Teams/Zoom attribution bugs) with two scripted Chromium speakers whose microphones are ground-truth WAVs.

| # | Evidence | Result |
|---|---|---|
| 1 | `tsx src/telemetry-recorder.test.ts` — 50 tapped frames → file; header + every frame ajv-valid vs the SSOT schema; seq monotone; stored PCM byte-compared Float32-exact against the tapped PCM | ✅ |
| 2 | same suite §1b — real `makeSpeakerHintSink` drives 3 hints + 20 frames: hints land as `type:"hint"`, ajv-valid, epoch-clocked, interleaved in arrival order, and the pipeline still receives all 3 | ✅ |
| 3 | same suite — zero-frame session leaves a header-only file; a writer that throws on every append never throws into `captureFrame` | ✅ |
| 4 | **live**: real bot (this branch's `dist`, published image, hosted STT) in a real meeting → `session written: … (216 frames, 78 hints)`, exit 0; harvested and replayed with `REPLAY_FIXTURE=… tsx src/replay.test.ts` → deterministic, every segment transcript.v1-valid | ✅ |
| 5 | **live**: `distill.mjs` full cut 216 frames + 78 hints; `--speaker Boris` → 115 frames + 58 hints from 2 hint-derived windows; `--speaker Anna` → 127 + 20; both replay green | ✅ |
| 6 | toggle off ⇒ tap is one truthiness check (`makeTelemetryTap` short-circuit, asserted in the pre-existing `telemetry.test.ts`); full bot suite + `node scripts/gates.mjs all` green | ✅ |
| 7 | **live**: `stt.jsonl` captured 18 round-trips with latency and typed faults | ✅ |

### What the live leg found (and this PR fixes)

The first live run recorded **162 frames of real audio and zero attribution** while the bot's own counters read `bridge-crossed=28`. In the mixed lane the speaker hints arrive on a *separate* bridge channel that the audio tap never sees, so a recorded Teams/Zoom/Jitsi session could reproduce the sound of a misattribution bug but never the misattribution — useless for exactly #797/#499/#539. The offline test had missed it because it fed hints *through* the tap, which the real lane never does. Fixed in 73af234b (`HintEvent` in captured-signal.v1, `captureHint` port, tee in `makeSpeakerHintSink`); re-run recorded 216 frames + **78 hints** whose timeline matches the scripted Anna→Boris turn-taking. gmeet was never affected (it binds the glow name onto the frame).

### Not covered
No successful live STT text: the test deployment's transcription token is exhausted and 402s every request (a separate finding — see the STT-preflight PR). The STT tap recorded those 402s, which demonstrates the capture-vs-STT bisect working but is not the happy path.

## The diff
`contracts.seal.json` reseal is additive (`captured-signal.v1` gains `HintEvent`; `invocation.v1` gains optional `captureSignalEnabled`) — lane:contract review.