### PR TITLE
fix(config): an exhausted STT token probes RED — the preflight transcribes real audio (#511 follow-up)

### DIFF
--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -21,6 +21,6 @@
   "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",
   "core/runtime/contracts/runtime.v1": "9d67b9379e0d34c4d715764a467e7f6e6543a5db8177fc284fb4a7418067bc18",
   "core/runtime/contracts/schedule.v1": "6f2c0277d3d186ca2a9333342930f135ea66bfd931135c451bd12b05ff862648",
-  "deploy/contracts/config.v1": "f30ab55cdf847714dd81a3fd64dc6bb1db845c70cf2b7dbc7db5380da895e061",
+  "deploy/contracts/config.v1": "b8c5c1f6344858eddd6509dcbf0a459a3df73866b467011a774245fb3c9ecb17",
   "deploy/contracts/execution-targets.v1": "0c644571b7823024aa2e7ec6a135a55202233155c6c60eef79f1f4ec063e6375"
 }

--- a/core/agent/control_plane/config_preflight.py
+++ b/core/agent/control_plane/config_preflight.py
@@ -149,24 +149,85 @@ def probe_url(base: str, path: str) -> str:
     return base if base.endswith(path) else base + path
 
 
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     """One authenticated request against the configured endpoint.
 
     The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
-    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
-    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
-    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
-    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
 
-    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
-    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
-    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
-    or a DNS blip produces, so refusing on it would couple this service's availability to the
-    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
-    distinction."""
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
     url = probe_url(base, spec.get("path") or "")
-    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
         req.add_header("Authorization", f"Bearer {token}")
@@ -181,6 +242,11 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
         return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
     if status in (spec.get("invalid_statuses") or []):
         return {"ok": False, "status": status, "kind": "invalid_endpoint",
                 "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
@@ -190,7 +256,7 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
 
 #: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
 #: value), as opposed to the endpoint merely being down. A request path may refuse on these.
-CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:

--- a/core/agent/control_plane/config_test.py
+++ b/core/agent/control_plane/config_test.py
@@ -32,10 +32,14 @@ KEYCHAIN_REFRESH = ('security find-generic-password -s "Claude Code-credentials"
                     "> ~/.claude/.credentials.json")
 
 _TIMEOUT = 8.0
+# The audio round-trip probe transcribes a real ~1s clip — give the model time to answer.
+_STT_PROBE_TIMEOUT = 20.0
 
 # (status, body_text) — injectable for tests; None body on network failure.
 HttpPost = Callable[[str, dict, dict], tuple[int, str]]
 HttpGet = Callable[[str, dict], tuple[int, str]]
+# (endpoint, token) → (status, body_text) for the STT audio round-trip — injectable for tests.
+TranscribeProbe = Callable[[str, str], tuple[int, str]]
 
 
 def _post(url: str, payload: dict, headers: dict) -> tuple[int, str]:
@@ -153,40 +157,78 @@ def run_models_test(config: dict, env: Optional[dict] = None,
 # (deploy/contracts/config.v1/preflight.py:probe_url), the bot's client, and the dictation route.
 _STT_PATH = "/v1/audio/transcriptions"
 
-def _verify_openai_compatible(base: str, token: str, source: str, post: HttpPost) -> dict:
-    """The non-Vexa fallback: verify the token the way the bot's FIRST CHUNK will — POST the
-    transcriptions endpoint with a Bearer header and an empty body. The endpoint's own answer
-    grades it: 401/403 the token is rejected · 404 the URL is not a transcriptions endpoint ·
-    anything else (400 for the empty body, 405, 200) means auth was accepted and a bot will
-    transcribe. "Reachable" was never the question — the operator is asking whether it WORKS."""
-    endpoint = base if base.endswith(_STT_PATH) else base + _STT_PATH
+def _transcribe_probe(endpoint: str, token: str) -> tuple:
+    """POST the shared audio probe body — the same request the boot preflight makes."""
+    from control_plane.config_preflight import audio_probe_body
+
+    content_type, body = audio_probe_body()
+    req = urllib.request.Request(
+        endpoint, data=body, method="POST",
+        headers={"Content-Type": content_type, "Authorization": f"Bearer {token}"})
     try:
-        status, _ = post(endpoint, {}, {"Authorization": f"Bearer {token}"})
+        with urllib.request.urlopen(req, timeout=_STT_PROBE_TIMEOUT) as r:
+            return r.status, r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+
+
+def _verify_transcribes(base: str, token: str, source: str, probe: TranscribeProbe,
+                        account: str = "") -> dict:
+    """Grade the backend by the ONE question the operator is actually asking: will a bot get a
+    transcript out of this? Answered by sending real audio — the same request a bot's first chunk
+    makes, and the same body the boot preflight sends.
+
+    An EMPTY body cannot answer it: a metered backend answers an empty POST the same way whether
+    the credential is funded or worthless, which is how a token that 402s every segment of every
+    meeting used to test green here. Nor can the account's balance answer it — a billing-exempt
+    account reports 0.0 minutes and transcribes perfectly, so a balance threshold condemns the
+    working credential and clears nothing. Sending audio makes the verdict independent of whose
+    token it is, so no account identity is named anywhere in this codebase."""
+    endpoint = base if base.endswith(_STT_PATH) else base + _STT_PATH
+    who = f" ({account})" if account else ""
+    try:
+        status, body = probe(endpoint, token)
     except Exception as exc:
         return _result(False, f"Backend unreachable: {exc}", source=source)
     if status in (401, 403):
         return _result(False, f"Token REJECTED by {endpoint} (HTTP {status}).", source=source,
                        status=status)
+    if status == 402:
+        detail = (body or "").strip()[:160]
+        return _result(False, f"Token is valid{who} but cannot pay for transcription (HTTP 402) — "
+                              f"every segment will fail and meetings will complete with NO "
+                              f"transcript. Top up the account or use a token that can transcribe."
+                              + (f" Backend said: {detail}" if detail else ""),
+                       source=source, status=status, account=account or None)
     if status == 404:
         return _result(False, f"No transcriptions endpoint at {endpoint} (HTTP 404) — check the "
                               "URL shape; some gateways also answer 404 for a rejected key.",
                        source=source, status=status)
-    return _result(True, f"OK — endpoint verified at {endpoint} (HTTP {status}); the token was "
-                         "accepted by the same request a bot makes.", source=source, status=status)
+    if status >= 500:
+        return _result(False, f"Backend error at {endpoint} (HTTP {status}).", source=source,
+                       status=status)
+    return _result(True, f"OK — {endpoint} transcribed the probe clip{who} (HTTP {status}).",
+                   source=source, status=status, account=account or None)
 
 
 def run_transcription_test(url: str, token: str, source: str, get: HttpGet = _get,
-                           post: HttpPost = _post) -> dict:
-    """A real authenticated probe of the effective STT backend: GET ``{base}/balance`` with the
-    token. Grades the answers the 2026-07-09 402 saga taught us to distinguish. A backend with no
-    ``/balance`` is not a Vexa gateway — it is graded by the transcriptions endpoint itself
-    (:func:`_verify_openai_compatible`), because a green that verified nothing is the failure this
-    test exists to prevent."""
+                           probe: TranscribeProbe = _transcribe_probe) -> dict:
+    """A real round-trip test of the effective STT backend: transcribe a ~1s probe clip with the
+    configured token — the same request (and the same probe body) a bot's first chunk and the boot
+    preflight make, so the wizard can never green what the deployment refuses.
+
+    The endpoint's own answer is the verdict. Neither of the two indirect oracles survives contact
+    with reality: an empty-body POST is answered identically for a funded and a worthless
+    credential, and ``balance_minutes`` reads 0.0 for a billing-exempt account that transcribes
+    perfectly — the 2026-07-19 recurrence was exactly a zero-balance token probing green while a
+    zero-balance *exempt* token did the actual work. Sending audio asks the real question and keeps
+    every account identity out of this codebase. ``/balance`` is still consulted first, but only to
+    NAME the account in the verdict (a courtesy, never the oracle)."""
     base = (url or "").strip().rstrip("/")
     if not base:
         return _result(False, "No transcription backend configured at any level "
                               "(user, global, or deployment env).", source=source)
-    # Bots post to {url}/v1/audio/transcriptions — strip the path for the account probe.
+    # Bots post to {url}/v1/audio/transcriptions — strip the path for the account lookup.
     probe_base = base
     for suffix in ("/v1/audio/transcriptions", "/v1/audio", "/v1"):
         if probe_base.endswith(suffix):
@@ -195,31 +237,14 @@ def run_transcription_test(url: str, token: str, source: str, get: HttpGet = _ge
     if not token:
         return _result(False, f"Backend {probe_base} configured but NO token set ({source}).",
                        source=source)
+    account = ""
     try:
         status, body = get(f"{probe_base}/balance", {"X-API-Key": token})
-    except Exception as exc:
-        return _result(False, f"Backend unreachable: {exc}", source=source)
-    if status in (401, 403):
-        return _result(False, f"Token REJECTED by {probe_base} (HTTP {status}).", source=source,
-                       status=status)
-    if status == 404:
-        # Not a Vexa transcription gateway (no /balance) — verify against the endpoint bots use.
-        return _verify_openai_compatible(base, token, source, post)
-    if status != 200:
-        return _result(False, f"Backend answered HTTP {status}.", source=source, status=status)
-    try:
-        acct = json.loads(body)
-    except ValueError:
-        acct = {}
-    email = acct.get("email") or "?"
-    balance = acct.get("balance_minutes")
-    if email == "internal@vexa.ai":
-        return _result(True, f"OK — internal service token at {base} (billing-exempt).",
-                       source=source, account=email)
-    if isinstance(balance, (int, float)) and balance <= 0:
-        return _result(False, f"Token valid ({email}) but balance is {balance:g} minutes — "
-                              "every segment will fail 402 payment_required. Top up or switch "
-                              "the token.", source=source, account=email, balance=balance)
-    return _result(True, f"OK — {email}, {balance:g} minutes remaining." if isinstance(
-        balance, (int, float)) else f"OK — {email}.", source=source, account=email,
-        balance=balance)
+        if status == 200:
+            try:
+                account = (json.loads(body) or {}).get("email") or ""
+            except ValueError:
+                account = ""
+    except Exception:
+        pass  # no /balance ⇒ not a Vexa gateway; the round-trip below is the oracle either way
+    return _verify_transcribes(base, token, source, probe, account)

--- a/core/agent/tests/test_config_test.py
+++ b/core/agent/tests/test_config_test.py
@@ -89,35 +89,58 @@ def _balance(email, minutes):
     return 200, json.dumps({"email": email, "balance_minutes": minutes})
 
 
-def test_transcription_internal_token_billing_exempt():
-    out = ct.run_transcription_test("https://transcription.vexa.ai", "tok", "env",
-                                    get=lambda u, h: _balance("internal@vexa.ai", 0.0))
-    assert out["ok"] and "billing-exempt" in out["summary"]
+# The 2026-07-19 recurrence, as a permanent pair: two tokens, both reporting balance 0.0 —
+# one exhausted (every request 402s), one billing-exempt (transcribes fine). NO balance
+# threshold and NO account name can tell them apart; only the endpoint's answer to real audio
+# can. Neither row names any specific account: identity must never be the oracle.
 
-
-def test_transcription_zero_balance_external_fails_loud():
-    out = ct.run_transcription_test("https://transcription.vexa.ai", "tok", "settings",
-                                    get=lambda u, h: _balance("someone@gmail.com", 0.0))
+def test_transcription_exhausted_token_fails_loud_despite_valid_auth():
+    out = ct.run_transcription_test(
+        "https://transcription.vexa.ai", "tok", "settings",
+        get=lambda u, h: _balance("someone@gmail.com", 0.0),
+        probe=lambda e, t: (402, '{"detail":"Insufficient balance"}'))
     assert not out["ok"] and "402" in out["summary"] and out["source"] == "settings"
+    assert "NO transcript" in out["summary"], "the verdict must name the consequence"
+
+
+def test_transcription_zero_balance_but_transcribing_token_is_green():
+    """A billing-exempt account reports 0.0 minutes and transcribes perfectly — the round-trip
+    must green it where a balance threshold would condemn it."""
+    out = ct.run_transcription_test(
+        "https://transcription.vexa.ai", "tok", "env",
+        get=lambda u, h: _balance("svc-account@example.com", 0.0),
+        probe=lambda e, t: (200, '{"text":"probe"}'))
+    assert out["ok"], "zero balance alone must never fail a token that transcribes"
+    assert "svc-account@example.com" in out["summary"]
 
 
 def test_transcription_funded_external_ok():
-    out = ct.run_transcription_test("https://transcription.vexa.ai", "tok", "env",
-                                    get=lambda u, h: _balance("someone@gmail.com", 42.5))
-    assert out["ok"] and "42.5" in out["summary"]
+    out = ct.run_transcription_test(
+        "https://transcription.vexa.ai", "tok", "env",
+        get=lambda u, h: _balance("someone@gmail.com", 42.5),
+        probe=lambda e, t: (200, '{"text":"probe"}'))
+    assert out["ok"] and "someone@gmail.com" in out["summary"]
 
 
 def test_transcription_rejected_token():
-    out = ct.run_transcription_test("https://x", "bad", "env", get=lambda u, h: (403, ""))
+    out = ct.run_transcription_test("https://x", "bad", "env", get=lambda u, h: (403, ""),
+                                    probe=lambda e, t: (403, ""))
     assert not out["ok"] and "REJECTED" in out["summary"]
+
+
+def test_transcription_backend_5xx_is_red():
+    out = ct.run_transcription_test("https://t", "tok", "env", get=lambda u, h: (404, ""),
+                                    probe=lambda e, t: (503, ""))
+    assert not out["ok"] and "503" in out["summary"]
 
 
 def test_transcription_strips_v1_path_for_balance_probe():
     seen = []
     def get(url, headers):
         seen.append(url)
-        return _balance("internal@vexa.ai", 0.0)
-    ct.run_transcription_test("https://t.vexa.ai/v1/audio/transcriptions", "tok", "env", get=get)
+        return _balance("someone@example.com", 5.0)
+    ct.run_transcription_test("https://t.vexa.ai/v1/audio/transcriptions", "tok", "env", get=get,
+                              probe=lambda e, t: (200, "{}"))
     assert seen == ["https://t.vexa.ai/balance"]
 
 
@@ -129,16 +152,27 @@ def test_transcription_no_backend_and_no_token():
 
 
 def test_transcription_unreachable():
-    def boom(url, headers):
+    def boom(endpoint, token):
         raise OSError("timeout")
-    out = ct.run_transcription_test("https://t", "tok", "env", get=boom)
+    out = ct.run_transcription_test("https://t", "tok", "env", get=lambda u, h: (404, ""),
+                                    probe=boom)
     assert not out["ok"] and "unreachable" in out["summary"]
+
+
+def test_transcription_balance_failure_never_blocks_the_verdict():
+    """/balance is a courtesy account lookup, never the oracle — a gateway without it (or one
+    that errors) must not stop the round-trip from grading the backend."""
+    def boom(url, headers):
+        raise OSError("no /balance here")
+    out = ct.run_transcription_test("https://t", "tok", "env", get=boom,
+                                    probe=lambda e, t: (200, "{}"))
+    assert out["ok"]
 
 
 # ── C2 (#511): a non-Vexa backend is graded by the endpoint BOTS use, never "reachable" ──────────
 # No /balance means "not a Vexa gateway", which is not a verdict on the operator's question. The
-# fallback runs the bot's own first-chunk request, so the wizard's green means "a bot will
-# transcribe" on ANY OpenAI-compatible endpoint.
+# round-trip runs the bot's own first-chunk request (same probe body as the boot preflight), so
+# the wizard's green means "a bot will transcribe" on ANY OpenAI-compatible endpoint.
 
 _NO_BALANCE = lambda u, h: (404, "")  # noqa: E731 — the non-Vexa signature, reused by every row
 
@@ -147,7 +181,7 @@ def test_transcription_openai_wrong_key_is_red():
     """A1/A2: a rejected key on an OpenAI-compatible endpoint is RED at the click — it used to
     return green-unverified and fail mid-meeting."""
     out = ct.run_transcription_test("https://api.openai.com", "sk-wrong", "settings",
-                                    get=_NO_BALANCE, post=lambda u, p, h: (401, ""))
+                                    get=_NO_BALANCE, probe=lambda e, t: (401, ""))
     assert not out["ok"], "a rejected key must never test green"
     assert "REJECTED" in out["summary"] and out["status"] == 401
     assert out.get("unverified") is None, "there is no longer an unverified green"
@@ -155,27 +189,27 @@ def test_transcription_openai_wrong_key_is_red():
 
 def test_transcription_openai_good_key_is_green_and_names_the_endpoint():
     out = ct.run_transcription_test("https://api.openai.com", "sk-good", "settings",
-                                    get=_NO_BALANCE, post=lambda u, p, h: (400, ""))
-    assert out["ok"], "auth accepted (400 = our empty body rejected, not our key)"
+                                    get=_NO_BALANCE, probe=lambda e, t: (200, '{"text":""}'))
+    assert out["ok"]
     assert "/v1/audio/transcriptions" in out["summary"]
 
 
 def test_transcription_openai_wrong_url_is_red():
     out = ct.run_transcription_test("https://api.openai.com/wrong", "sk-good", "env",
-                                    get=_NO_BALANCE, post=lambda u, p, h: (404, ""))
+                                    get=_NO_BALANCE, probe=lambda e, t: (404, ""))
     assert not out["ok"] and "URL shape" in out["summary"]
 
 
-def test_transcription_fallback_sends_bearer_to_the_transcriptions_path():
-    """C4 (A5) at this consumer: base URL and full-path URL must hit the SAME endpoint once, with
-    the Bearer header the bot sends (the /balance probe's X-API-Key is Vexa-gateway-only)."""
+def test_transcription_probe_hits_the_transcriptions_path_once():
+    """C4 (A5) at this consumer: base URL and full-path URL must hit the SAME endpoint once with
+    the configured token (the /balance lookup's X-API-Key is Vexa-gateway-only)."""
     for configured in ("https://api.openai.com", "https://api.openai.com/v1/audio/transcriptions"):
         seen = []
-        def post(url, payload, headers):
-            seen.append((url, headers.get("Authorization")))
-            return 400, ""
-        out = ct.run_transcription_test(configured, "sk-good", "env", get=_NO_BALANCE, post=post)
+        def probe(endpoint, token):
+            seen.append((endpoint, token))
+            return 200, "{}"
+        out = ct.run_transcription_test(configured, "sk-good", "env", get=_NO_BALANCE, probe=probe)
         assert out["ok"], f"{configured} must verify green"
-        assert seen == [("https://api.openai.com/v1/audio/transcriptions", "Bearer sk-good")], (
+        assert seen == [("https://api.openai.com/v1/audio/transcriptions", "sk-good")], (
             f"{configured} → {seen}"
         )

--- a/core/gateway/services/gateway/src/gateway/config_preflight.py
+++ b/core/gateway/services/gateway/src/gateway/config_preflight.py
@@ -149,24 +149,85 @@ def probe_url(base: str, path: str) -> str:
     return base if base.endswith(path) else base + path
 
 
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     """One authenticated request against the configured endpoint.
 
     The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
-    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
-    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
-    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
-    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
 
-    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
-    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
-    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
-    or a DNS blip produces, so refusing on it would couple this service's availability to the
-    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
-    distinction."""
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
     url = probe_url(base, spec.get("path") or "")
-    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
         req.add_header("Authorization", f"Bearer {token}")
@@ -181,6 +242,11 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
         return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
     if status in (spec.get("invalid_statuses") or []):
         return {"ok": False, "status": status, "kind": "invalid_endpoint",
                 "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
@@ -190,7 +256,7 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
 
 #: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
 #: value), as opposed to the endpoint merely being down. A request path may refuse on these.
-CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:

--- a/core/identity/services/admin-api/src/admin_api/config_preflight.py
+++ b/core/identity/services/admin-api/src/admin_api/config_preflight.py
@@ -149,24 +149,85 @@ def probe_url(base: str, path: str) -> str:
     return base if base.endswith(path) else base + path
 
 
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     """One authenticated request against the configured endpoint.
 
     The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
-    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
-    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
-    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
-    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
 
-    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
-    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
-    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
-    or a DNS blip produces, so refusing on it would couple this service's availability to the
-    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
-    distinction."""
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
     url = probe_url(base, spec.get("path") or "")
-    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
         req.add_header("Authorization", f"Bearer {token}")
@@ -181,6 +242,11 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
         return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
     if status in (spec.get("invalid_statuses") or []):
         return {"ok": False, "status": status, "kind": "invalid_endpoint",
                 "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
@@ -190,7 +256,7 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
 
 #: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
 #: value), as opposed to the endpoint merely being down. A request path may refuse on these.
-CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -506,8 +506,8 @@
    "when_unconfigured": "POST /bots with transcribe_enabled=true answers a typed 503 naming the unset key(s) — bots must opt out explicitly (transcribe_enabled=false / TRANSCRIBE_ENABLED=false) to spawn capture-only",
    "probe": {
     "kind": "http",
-    "timeout_s": 2,
-    "ttl_s": 60,
+    "timeout_s": 15,
+    "ttl_s": 900,
     "http": {
      "method": "POST",
      "url_key": "TRANSCRIPTION_SERVICE_URL",
@@ -519,6 +519,10 @@
      ],
      "invalid_statuses": [
       404
+     ],
+     "payload": "audio",
+     "exhausted_statuses": [
+      402
      ]
     }
    }

--- a/core/meetings/services/meeting-api/src/meeting_api/config_preflight.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/config_preflight.py
@@ -149,24 +149,85 @@ def probe_url(base: str, path: str) -> str:
     return base if base.endswith(path) else base + path
 
 
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     """One authenticated request against the configured endpoint.
 
     The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
-    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
-    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
-    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
-    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
 
-    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
-    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
-    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
-    or a DNS blip produces, so refusing on it would couple this service's availability to the
-    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
-    distinction."""
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
     url = probe_url(base, spec.get("path") or "")
-    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
         req.add_header("Authorization", f"Bearer {token}")
@@ -181,6 +242,11 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
         return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
     if status in (spec.get("invalid_statuses") or []):
         return {"ok": False, "status": status, "kind": "invalid_endpoint",
                 "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
@@ -190,7 +256,7 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
 
 #: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
 #: value), as opposed to the endpoint merely being down. A request path may refuse on these.
-CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:

--- a/core/meetings/services/meeting-api/tests/test_config_contract.py
+++ b/core/meetings/services/meeting-api/tests/test_config_contract.py
@@ -418,4 +418,59 @@ def test_probe_failure_kinds_are_classified():
     down = cp._http_probe(spec, env, timeout=2)
     assert down["kind"] == "unreachable"
     assert down["kind"] not in cp.CONFIG_FAULT_KINDS
-    assert {"unauthorized", "invalid_endpoint"} == set(cp.CONFIG_FAULT_KINDS)
+    assert {"unauthorized", "invalid_endpoint", "exhausted"} == set(cp.CONFIG_FAULT_KINDS)
+
+
+def test_probe_402_is_exhausted_config_fault():
+    """The 2026-07-19 recurrence: a token that AUTHENTICATES but 402s every transcription probed
+    green (the old empty-body probe could never even elicit the 402). The declared
+    exhausted_statuses turn it into a refusable CONFIG fault with the consequence in the reason."""
+    spec = _stt_probe_spec()["http"]
+    with _ProbeServer(routes={_STT_PATH: 402}) as srv:
+        env = {"TRANSCRIPTION_SERVICE_URL": srv.base, "TRANSCRIPTION_SERVICE_TOKEN": "t"}
+        result = cp._http_probe(spec, env, timeout=5)
+    assert result["ok"] is False and result["kind"] == "exhausted"
+    assert result["kind"] in cp.CONFIG_FAULT_KINDS, "spawn must refuse on an exhausted token"
+    assert "no transcript" in result["reason"].lower()
+
+
+def test_probe_sends_real_audio_so_a_metered_backend_can_price_it():
+    """The declaration says payload: audio — assert the request BODY actually carries a WAV in
+    multipart form-data. An empty POST is answered 400/422 for funded and worthless credentials
+    alike, which is exactly how the exhausted token used to probe green."""
+    spec = _stt_probe_spec()["http"]
+    assert spec.get("payload") == "audio", "stt must declare the audio round-trip"
+    assert 402 in (spec.get("exhausted_statuses") or []), "stt must declare 402 as exhausted"
+    bodies: list = []
+
+    import http.server
+    import threading
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            bodies.append(self.rfile.read(int(self.headers.get("Content-Length") or 0)))
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *a):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        env = {"TRANSCRIPTION_SERVICE_URL": f"http://127.0.0.1:{server.server_address[1]}",
+               "TRANSCRIPTION_SERVICE_TOKEN": "t"}
+        assert cp._http_probe(spec, env, timeout=10)["ok"] is True
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert len(bodies) == 1 and b"RIFF" in bodies[0] and b"probe.wav" in bodies[0]
+
+
+def test_probe_declares_a_long_ttl_because_the_round_trip_is_metered():
+    probe = _stt_probe_spec()
+    assert float(probe.get("ttl_s") or 0) >= 600, (
+        "the audio probe COSTS a fraction of a minute per run — /health must not re-bill it "
+        "every 60s")

--- a/core/runtime/src/runtime_kernel/config_preflight.py
+++ b/core/runtime/src/runtime_kernel/config_preflight.py
@@ -149,24 +149,85 @@ def probe_url(base: str, path: str) -> str:
     return base if base.endswith(path) else base + path
 
 
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     """One authenticated request against the configured endpoint.
 
     The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
-    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
-    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
-    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
-    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
 
-    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
-    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
-    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
-    or a DNS blip produces, so refusing on it would couple this service's availability to the
-    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
-    distinction."""
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
     url = probe_url(base, spec.get("path") or "")
-    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
         req.add_header("Authorization", f"Bearer {token}")
@@ -181,6 +242,11 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
         return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
     if status in (spec.get("invalid_statuses") or []):
         return {"ok": False, "status": status, "kind": "invalid_endpoint",
                 "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
@@ -190,7 +256,7 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
 
 #: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
 #: value), as opposed to the endpoint merely being down. A request path may refuse on these.
-CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -305,7 +305,8 @@ services:
       # main (meeting-api ADMIN_TOKEN = admin-api ADMIN_API_TOKEN). __main__ passes token_secret=ADMIN_TOKEN.
       - ADMIN_TOKEN=${ADMIN_TOKEN:-changeme}
       # STT the spawned bot transcribes with — bot_spawn threads these into the invocation (registry
-      # `stt` resource; the funded internal@vexa.ai token). Unset → bot joins+captures but no transcript.
+      # `stt` resource; a token that can actually transcribe — the boot probe + wizard Test verify
+      # it with real audio). Unset → bot joins+captures but no transcript.
       # MODEL is the id validating backends require (Groq/vLLM); unset → whisper-1.
       - TRANSCRIPTION_SERVICE_URL=${TRANSCRIPTION_SERVICE_URL:-}
       - TRANSCRIPTION_SERVICE_TOKEN=${TRANSCRIPTION_SERVICE_TOKEN:-}

--- a/deploy/contracts/config.v1/config.schema.json
+++ b/deploy/contracts/config.v1/config.schema.json
@@ -120,7 +120,7 @@
           "type": "object",
           "required": ["url_key"],
           "additionalProperties": false,
-          "description": "One authenticated request to the capability's endpoint. Verdict, in order: a network failure/timeout ⇒ probe FAILS (unreachable); an `unauthorized_statuses` answer ⇒ FAILS (the credential was REJECTED); an `invalid_statuses` answer ⇒ FAILS (we are not talking to the declared endpoint at all — the URL shape is wrong); ANY other status (400/405/…) proves the endpoint is reachable and the credential accepted ⇒ probe passes.",
+          "description": "One authenticated request to the capability's endpoint. Verdict, in order: a network failure/timeout ⇒ probe FAILS (unreachable); an `unauthorized_statuses` answer ⇒ FAILS (the credential was REJECTED); an `exhausted_statuses` answer ⇒ FAILS (the credential is authentic but cannot buy the work); an `invalid_statuses` answer ⇒ FAILS (we are not talking to the declared endpoint at all — the URL shape is wrong); ANY other status (400/405/…) proves the endpoint is reachable and the credential accepted ⇒ probe passes.",
           "properties": {
             "method": { "type": "string", "default": "POST" },
             "url_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$", "description": "the declared key holding the endpoint URL — accepted as a bare base (https://host) OR as the full endpoint already carrying `path`; the probe appends `path` only when absent, the same rule the bot's client and the terminal dictation route apply" },
@@ -135,6 +135,19 @@
               "type": "array",
               "items": { "type": "integer" },
               "description": "statuses that mean the URL does not name this capability's endpoint — proof of the WRONG address, not of a working one (default []; the stt transcriptions probe declares [404], since a real OpenAI-compatible transcriptions path answers 400/401 to an empty body and never 404)"
+            },
+            "exhausted_statuses": {
+              "type": "array",
+              "items": { "type": "integer" },
+              "description": "statuses that mean the credential AUTHENTICATED but cannot pay for the work — a metered backend's 402 (default []; the stt probe declares [402]). Distinct from unauthorized: nothing is wrong with the token, it simply buys nothing, so every request fails while every reachability check passes. Only meaningful with `payload: \"audio\"` — an endpoint cannot price a body it never received."
+            },
+            "payload": {
+              "enum": ["audio"],
+              "description": "send a REAL request body instead of an empty POST. `audio` posts a ~1s WAV as multipart/form-data — the same shape a bot's first chunk makes — because an empty body cannot distinguish a funded credential from a worthless one: a metered backend answers both alike. It also makes the verdict independent of WHOSE token it is (a billing-exempt account and a funded one both answer 200), so no account identity is encoded anywhere. The request is METERED — declare a long `ttl_s`."
+            },
+            "payload_model": {
+              "type": "string",
+              "description": "the `model` form field sent with `payload: \"audio\"` (default whisper-1); backends that validate model ids need their served name"
             }
           }
         },

--- a/deploy/contracts/config.v1/preflight.py
+++ b/deploy/contracts/config.v1/preflight.py
@@ -149,24 +149,85 @@ def probe_url(base: str, path: str) -> str:
     return base if base.endswith(path) else base + path
 
 
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
 def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     """One authenticated request against the configured endpoint.
 
     The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
-    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``invalid_statuses`` (404 for an
-    OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is wrong — a real
-    transcriptions endpoint answers 400/401 to an empty body, never 404, so 404 proves we are not
-    talking to one. Any OTHER status (400/405/…) proves reachability + accepted auth ⇒ ok.
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
 
-    A failure carries ``kind`` because the two classes are NOT interchangeable to a consumer:
-    ``unauthorized``/``invalid_endpoint`` are CONFIGURATION faults, true until an operator edits a
-    value, so a request path may refuse on them; ``unreachable`` is a LIVENESS fault that a restart
-    or a DNS blip produces, so refusing on it would couple this service's availability to the
-    endpoint's. Both demote the /health row identically — only actors that REFUSE need the
-    distinction."""
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
     base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
     url = probe_url(base, spec.get("path") or "")
-    req = urllib.request.Request(url, data=b"", method=(spec.get("method") or "POST"))
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
     token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
     if token:
         req.add_header("Authorization", f"Bearer {token}")
@@ -181,6 +242,11 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
     if status in (spec.get("unauthorized_statuses") or [401, 403]):
         return {"ok": False, "status": status, "kind": "unauthorized",
                 "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
     if status in (spec.get("invalid_statuses") or []):
         return {"ok": False, "status": status, "kind": "invalid_endpoint",
                 "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
@@ -190,7 +256,7 @@ def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
 
 #: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
 #: value), as opposed to the endpoint merely being down. A request path may refuse on these.
-CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint"})
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
 
 
 def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:

--- a/deploy/execution-targets.example.json
+++ b/deploy/execution-targets.example.json
@@ -38,8 +38,8 @@
       "endpoint": "https://transcription.vexa.ai",
       "secret_ref": "vexa-secrets:prod/transcription.enc.env#TRANSCRIPTION_SERVICE_TOKEN",
       "env": ["TRANSCRIPTION_SERVICE_URL", "TRANSCRIPTION_SERVICE_TOKEN"],
-      "validate": "GET https://transcription.vexa.ai/balance with the token → require HTTP 200 AND balance_minutes > 0. STT tokens are PER-USER (the response carries the account email + balance). Preflight EVERY live run; it caught the 0-balance + the 403 wrong-key-type before any audio.",
-      "notes": "the bot's STT at transcription.vexa.ai (OpenAI-compatible /v1/audio/transcriptions; /balance·/purchase·/admin/user-tokens). prod/transcription.enc.env#TRANSCRIPTION_SERVICE_TOKEN = internal@vexa.ai's reusable token. CURRENT BALANCE = 0 min → /purchase (or auto-topup) before a live transcript (Learning #28)."
+      "validate": "POST a ~1s WAV to /v1/audio/transcriptions with the token (the config.v1 audio probe / the wizard Test do exactly this) → require HTTP 200. NEVER grade by /balance: balance_minutes is 0.0 BOTH for an exhausted token (every request 402s) and for a billing-exempt service account (transcribes fine) — the 2026-07-19 recurrence was a green balance-style check over a token that 402'd every segment. /balance only NAMES the account.",
+      "notes": "the bot's STT at transcription.vexa.ai (OpenAI-compatible /v1/audio/transcriptions; /balance·/purchase·/admin/user-tokens). The deployment token comes from the secret_ref above — per-account; which account (and whether it is billing-exempt) is the secret store's knowledge, never this file's."
     },
     {
       "name": "minio",

--- a/docs/changelog.d/stt-402-roundtrip.md
+++ b/docs/changelog.d/stt-402-roundtrip.md
@@ -1,0 +1,9 @@
+- **An exhausted STT token is now caught where you set it — by transcribing real audio, not by
+  guessing from balances or account names.** The config preflight's STT probe posts a ~1s WAV
+  (the same request a bot's first chunk makes); a metered backend that answers 402 becomes a
+  typed `exhausted` configuration fault that demotes `/health`, refuses bot spawns, and names
+  the consequence ("meetings will complete with no transcript"). The old empty-body probe
+  could never elicit the 402 and greened the dead token. The wizard's Test button now runs the
+  same round-trip and no longer consults `balance_minutes` — which reads 0.0 both for an
+  exhausted token and for a billing-exempt service account that transcribes perfectly — and no
+  account identity is hardcoded anywhere. The probe is metered, so it caches for 15 minutes.


### PR DESCRIPTION
Stacked on `fix/511-stt-preflight` (#511). Retarget to `main` once that lands.

## Why this is not already covered by #511

#511 regrades 404 → `invalid_endpoint`, but **402 still falls into the `ok: True` bucket**, so the failure below survives it. Live-witnessed on a deployment today: a token that authenticates everywhere and 402s every transcription, with every machine check green and the meeting completing with zero segments (the #807 shape).

**The probe cannot see the fault, structurally.** It POSTs an *empty body*; a metered backend answers that identically whether the credential is funded or worthless. Measured on the live service with the real dead token:

```
OLD empty-body probe -> {'ok': True,  'status': 422}          # greens the dead token
NEW audio round-trip -> {'ok': False, 'status': 402, 'kind': 'exhausted'}
```

**And no balance threshold can see it either.** `balance_minutes` reads **0.0** both for the exhausted token *and* for a billing-exempt service account that transcribes perfectly — which is why the one balance-aware check in the repo (the wizard) had to hardcode the exempt account's email to avoid condemning the working credential. That hardcode is an internal account name living in an OSS repo, and it is the reason the check could never be generalised.

## The change

Ask the real question: `payload: "audio"` posts a ~1s WAV — the same request shape a bot's first chunk makes — and declared `exhausted_statuses: [402]` grade the answer as a typed `exhausted` **config** fault (member of `CONFIG_FAULT_KINDS`, so bot spawn refuses and `/health` demotes, with the consequence in the reason). The wizard's Test runs the identical round-trip via a shared `audio_probe_body`; `/balance` survives only to *name* the account. No account identity is encoded anywhere — which account a deployment's token belongs to is the secret store's knowledge, via the existing `secret_ref`.

## Observation bundle

| # | Observation | Evidence |
|---|---|---|
| 1 | Exhausted token: old probe green, new probe red-402 | live 2×2 above, real service |
| 2 | Negative control — zero-balance **exempt** token still green | live: `{'ok': True, 'status': 200}` |
| 3 | 402 → `kind: exhausted` ∈ `CONFIG_FAULT_KINDS` (spawn refuses, /health demotes) | `test_probe_402_is_exhausted_config_fault` (real local HTTP server) |
| 4 | The probe body actually carries a WAV in multipart | `test_probe_sends_real_audio_so_a_metered_backend_can_price_it` (asserts `RIFF` + `probe.wav` in the received body) |
| 5 | Wizard: exhausted red / zero-balance-but-transcribing green — the pair no balance rule can pass | `test_transcription_exhausted_token_fails_loud_despite_valid_auth`, `test_transcription_zero_balance_but_transcribing_token_is_green` |
| 6 | Metered probe does not run hot | `test_probe_declares_a_long_ttl_because_the_round_trip_is_metered` (ttl 60s → 900s) |
| 7 | **Live deployment**: patched preflight into a running meeting-api with the dead token → boot log `config.v1 capability stt: MISCONFIGURED — the token is VALID but cannot pay…`; `/health` stt row `state: misconfigured`, `kind: exhausted`, `status: 402` | witnessed on the test box |
| 8 | Suites | agent config-test **22 pass**, meeting-api config-contract **27 pass**, `gates.mjs all` green |

`internal@vexa.ai` is removed from `config_test.py`, both test fixtures, the compose comment, and `execution-targets.example.json` — whose note additionally claimed the exempt token needed topping up before a live transcript, the exact misreading that put a meterable throwaway token on a test box.

Contract reseal is additive (optional `payload` / `payload_model` / `exhausted_statuses` on the http probe) — lane:contract review.