### PR TITLE
gov: your own worktree BEFORE your first edit — trespass tells + remedies (AGENTS.md, D14b)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,21 @@ A prepared issue is a worked delivery spec — read it end to end before touchin
 - **Discord is the working channel** — blockers, steering, quick questions live there while you
   work. One rule keeps the record honest: **anything decided lands back on the issue**, or it
   didn't happen. The issue is the source of truth; Discord is the speed.
-- **One worktree per session** (`git worktree add ../vexa-<slug> -b <your-branch>`). Never two
-  sessions on one tree; never adopt another session's uncommitted files — surface them.
+- **Your own worktree BEFORE your first edit — always.** A session's opening move on any work
+  that will touch files is `git worktree add ../vexa-<slug> -b <your-branch>`; only then edit.
+  You do not own `main`, the primary checkout, or any tree you did not create this session —
+  even when the change "belongs on" a branch that lives there. Two tells that you are about to
+  trespass, and the remedy for each:
+  - `git worktree add` says the branch is **"already used by worktree …"** — that tree is
+    another session's checkout, not an invitation. Branch FROM that ref into a fresh worktree
+    of your own (`git worktree add ../vexa-<slug> -b <your-branch> <their-branch>`) and build
+    on it there; coordinate the eventual merge on the issue, never in their tree.
+  - `git status` in a tree you're about to edit shows **uncommitted files you didn't write** —
+    stop, surface them, move to your own worktree. Never adopt, commit, or clean another
+    session's uncommitted state.
+  One worktree per session, one session per worktree — no exceptions for "just one file",
+  docs, or governance edits (this rule was added from a session that edited another agent's
+  checkout after seeing the first tell).
 - **Never fan two parallel agents onto the same hot file — write your own file, or sequence.**
   Parallel PRs that all append to one file's tail collide on the same last line even when the
   additions don't interact — the v0.12.9 batch paid 5 manual conflict-resolution cycles to exactly

--- a/docs/changelog.d/gov-worktree-first.md
+++ b/docs/changelog.d/gov-worktree-first.md
@@ -1,0 +1,5 @@
+- **Governance: a session's own worktree comes before its first edit.** The actor contract
+  (AGENTS.md) now spells out the two trespass tells — `git worktree add` answering "already
+  used by worktree" and uncommitted files you didn't write — and the remedy for each: branch
+  from the ref into a fresh worktree of your own, never edit `main`, the primary checkout, or
+  another session's tree. D14b ties the claim lease to that own-worktree rule.

--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -404,8 +404,11 @@ make-illegal-states-unrepresentable (Wlaschin). · *Gate:* a label bot enforces 
 `ready` is the maintainer stamp. **[TO BUILD: label bot]**
 
 **D14b — A claim is a heartbeat lease, not ownership.** Anyone claims a `ready` item — no
-permission needed. A checkout is a **4-hour lease**; a **heartbeat** (a short "here's what's going
-on" update) renews it for another 4 hours. No heartbeat → the lease expires and the item returns
+permission needed. A checkout is a **4-hour lease** on a *worktree of your own*, created before
+your first edit — never `main`, never another session's checkout; building on someone else's
+branch means branching from the ref into a fresh worktree, not editing their tree (the actor
+contract's worktree rule, AGENTS.md). A **heartbeat** (a short "here's what's going
+on" update) renews the lease for another 4 hours. No heartbeat → the lease expires and the item returns
 to `ready`, claimable by anyone; the prior holder may reclaim with a fresh heartbeat. Work is
 never hoarded and flow never stalls on an absent contributor — and the heartbeats become the front
 of the PR's observation bundle, the loop's narration written as it happens. · *Source:* TTL leases


### PR DESCRIPTION
Incident-derived, docs-only.

**What happened:** a session extended another session's branch by editing that branch's existing worktree — *after* `git worktree add` had already answered `fatal: '<branch>' is already used by worktree at …`, which is precisely the tell that the tree belongs to someone else. The old rule ("One worktree per session … never adopt another session's uncommitted files") was true but easy to read as advice about *files*, not about *whose checkout you are standing in*, and it said nothing about what to do when the branch you need is already checked out elsewhere.

**The change:**
- `AGENTS.md` — the worktree bullet becomes the session's **opening move**: create your own worktree before your first edit; you never own `main`, the primary checkout, or any tree you did not create this session. Both trespass tells are named with their remedy: *"already used by worktree"* ⇒ branch FROM that ref into a fresh worktree of your own (`git worktree add ../vexa-<slug> -b <your-branch> <their-branch>`), coordinate the merge on the issue; *foreign uncommitted files in `git status`* ⇒ stop, surface, move. No exceptions for "just one file", docs, or governance edits.
- `delivery.mdx` **D14b** — the claim lease now explicitly names *a worktree of your own, created before your first edit*, pointing at the actor contract's rule.

Worth landing promptly: `AGENTS.md` is read at the start of every session, so the rule only binds sessions that start after it merges.

This PR was itself authored in a fresh worktree branched from `main`. Docs gates green; changelog fragment at `docs/changelog.d/gov-worktree-first.md`.