### PR TITLE
fix(bot,meeting-api): a meeting degraded by STT reports WHY, instead of completing silently (#552 partial, #807 class)

### DIFF
--- a/core/meetings/services/bot/package.json
+++ b/core/meetings/services/bot/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && node build-browser-utils.mjs",
     "build:browser-utils": "node build-browser-utils.mjs",
     "start": "tsx src/index.ts",
-    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/telemetry-recorder.test.ts && tsx src/replay.test.ts && tsx src/zoom-speaker-wiring.test.ts && tsx mock/mock.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/telemetry-recorder.test.ts && tsx src/stt-faults.test.ts && tsx src/replay.test.ts && tsx src/zoom-speaker-wiring.test.ts && tsx mock/mock.test.ts",
     "replay": "tsx src/replay.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },

--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -33,6 +33,7 @@ import { createBrowserJoinDriver } from './join-driver.js';
 import { createBotPipeline, createLivePipeline, createTranscribe, serr, type BotPipeline } from './pipeline.js';
 import { createBotRecordingSink } from './recording.js';
 import { createCaptureSignalRecorder, wrapTranscribeWithTap, type CaptureSignalRecorder } from './telemetry.js';
+import { createSttFaultReporter } from './stt-faults.js';
 import { launchBrowser, startCaptureBridge, startRecording, createSpeakController, type BrowserSession, type SpeakController } from './capture-bridge.js';
 import { installSignalHandlers } from './signals.js';
 import type {
@@ -198,6 +199,9 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
       ? createCaptureSignalRecorder(inv)
       : null;
   if (signalRecorder) console.log(`[bot] capture-signal recording → ${signalRecorder.path}`);
+  // Counts STT failures across the meeting so the terminal lifecycle event can carry WHY a
+  // transcript is short or empty, instead of leaving it indistinguishable from a silent room.
+  const sttFaults = createSttFaultReporter();
   const speakerStreamConfig = speakerStreamConfigFromEnv(env);
   if (speakerStreamConfig) console.log(`[bot] speaker-stream tuning enabled: ${JSON.stringify(speakerStreamConfig)}`);
 
@@ -208,7 +212,9 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
       // When recording, tee every STT round-trip to <session>.stt.jsonl (the capture/STT/assembly bisect).
       transcribe: signalRecorder ? wrapTranscribeWithTap(createTranscribe(inv), signalRecorder.path) : undefined,
       config: speakerStreamConfig,
-      onError: (e) => console.error(`[bot] pipeline fault: ${String(e)}`),
+      // Every STT fault is counted and carried out on the terminal lifecycle event (see
+      // sttFaults). Logging it here as well keeps the raw line for anyone tailing the container.
+      onError: (e) => { sttFaults.record(e); console.error(`[bot] pipeline fault: ${String(e)}`); },
     });
     // Defer the page-side capture start to pipeline.start(): the orchestrator calls it AFTER
     // admission (orchestrator.ts:125), on the LIVE meeting page — where addInitScript has injected
@@ -271,6 +277,7 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
     acts,
     recording: recording as RecordingSink | undefined,
     reachability,
+    degraded: () => sttFaults.report(),
   });
 
   // Disposability (P7): a termination signal ends the active phase gracefully (leave → flush →

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -21,6 +21,7 @@ import {
   type LifecycleEvent,
   type Act,
   canTransition,
+  isTerminal,
 } from './contracts.js';
 import type {
   JoinDriver,
@@ -44,6 +45,15 @@ export interface OrchestratorDeps {
    *  treated as reachable (conservative: never abort on an un-probeable channel), so the gate
    *  never turns a missing probe into a join refusal. */
   reachability?: ControlPlaneProbe;
+  /** Optional — what DEGRADED the meeting without ending it (today: STT refusing every chunk).
+   *  Consulted once, when a TERMINAL event is built, and merged onto it. A meeting whose STT
+   *  backend was dead used to reach `completed` indistinguishable from a silent room: the faults
+   *  were typed and attributed all the way to the composition root and then died in a
+   *  console.error, so the emptiest possible transcript arrived with no reason attached (the #807
+   *  shape). Rides lifecycle.v1 exactly as `infra_fault` does — the contract is
+   *  additionalProperties:true, so this is additive.
+   *  Returns `undefined` when nothing degraded. MUST NOT throw. */
+  degraded?: () => Record<string, unknown> | undefined;
 }
 
 /** The dedicated non-zero exit code for a pre-join control-plane-unreachable abort (#530). On
@@ -97,7 +107,14 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
       throw new Error(`lifecycle.v1: illegal transition ${cur} → ${status}`);
     }
     cur = status;
-    await deps.lifecycle.emit({ ...base, status, ...extra });
+    // A terminal event is the LAST thing anyone hears from this bot — if the meeting was degraded,
+    // it says so here or the reason dies with the container. A reporter fault must never change the
+    // exit path (P18: report, but never at the cost of the report itself).
+    let degraded: Record<string, unknown> | undefined;
+    if (isTerminal(status) && deps.degraded) {
+      try { degraded = deps.degraded(); } catch { degraded = undefined; }
+    }
+    await deps.lifecycle.emit({ ...base, status, ...extra, ...(degraded ?? {}) });
   };
 
   // The load-bearing FIRST emit (#530). `cur` is already `joining` (the initial state), so this

--- a/core/meetings/services/bot/src/stt-faults.test.ts
+++ b/core/meetings/services/bot/src/stt-faults.test.ts
@@ -1,0 +1,132 @@
+/**
+ * A meeting degraded by STT says so on the way out. OFFLINE, no browser/redis/whisper.
+ *
+ * The defect this pins: the pipelines type and attribute every STT fault and hand it to
+ * `onError`, and the composition root logged it to a console that dies with the container — so a
+ * meeting whose backend refused every chunk reached `completed` indistinguishable from a silent
+ * room, which is exactly the zero-segment shape nobody could diagnose after the fact.
+ *
+ * Asserts the accumulator's contract AND the orchestrator wiring: the terminal lifecycle.v1 event
+ * carries the summary, non-terminal events never do, a fault storm collapses to one report, and
+ * neither a non-STT fault nor a throwing reporter can perturb the exit path.
+ * Run: npx tsx src/stt-faults.test.ts
+ */
+import { createSttFaultReporter } from './stt-faults.js';
+import { createOrchestrator } from './orchestrator.js';
+import type { Invocation } from './config.js';
+import type { LifecycleEvent } from './contracts.js';
+import type { JoinDriver, Pipeline, ActsSource, LifecycleSink } from './ports.js';
+
+let failed = 0;
+const check = (name: string, cond: boolean, detail = ''): void => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond ? '' : '  — ' + detail}`);
+  if (!cond) failed++;
+};
+
+/** A TranscriptionError as @vexa/transcribe-whisper throws it (structurally). */
+const sttError = (kind: string, status: number, detail: string) =>
+  Object.assign(new Error(`stt ${kind} (HTTP ${status}): ${detail}`), { source: 'stt', kind, status, detail, retryable: false });
+
+const inv = {
+  platform: 'google_meet', meetingUrl: 'https://meet.google.com/abc-defg-hij', botName: 'B',
+  connectionId: 'conn-stt-1', redisUrl: 'redis://unused:6379', nativeMeetingId: 'abc-defg-hij',
+} as Invocation;
+
+function fakes(events: LifecycleEvent[]) {
+  const lifecycle: LifecycleSink = { async emit(e) { events.push(e); } };
+  const join: JoinDriver = {
+    async join(report) { await report('awaiting_admission'); return 'admitted'; },
+    onRemoval() { return () => { /* */ }; },
+    async leave() { /* */ }, async withdraw() { /* */ },
+  };
+  const pipeline: Pipeline = { async start() { /* */ }, async stop() { /* */ } };
+  const acts: ActsSource = { subscribe() { return () => { /* */ }; } };
+  return { lifecycle, join, pipeline, acts };
+}
+
+async function main(): Promise<void> {
+  // ── 1) the accumulator: storm → ONE summary, counted per kind, backend's own words kept ──
+  {
+    const logs: string[] = [];
+    const r = createSttFaultReporter((m) => logs.push(m), () => new Date('2026-07-19T12:00:00Z'));
+    check('nothing degraded ⇒ nothing reported', r.report() === undefined);
+
+    for (let i = 0; i < 18; i++) r.record(sttError('payment_required', 402, 'Insufficient balance. Available: 0.00 minutes'));
+    r.record(sttError('unavailable', 503, 'upstream down'));
+
+    const rep = r.report() as any;
+    check('a degraded meeting reports', !!rep && !!rep.stt_fault);
+    check('18 faults collapse to ONE summary entry per kind', rep.stt_fault.kinds.length === 2,
+      JSON.stringify(rep.stt_fault.kinds.map((k: any) => k.kind)));
+    const pay = rep.stt_fault.kinds.find((k: any) => k.kind === 'payment_required');
+    check('the count carries the storm (18)', pay.count === 18, String(pay?.count));
+    check('the backend HTTP status is kept', pay.status === 402, String(pay?.status));
+    check("the backend's OWN detail is kept, not a paraphrase", /Insufficient balance/.test(pay.detail), pay?.detail);
+    check('total across kinds', rep.stt_fault.total === 19, String(rep.stt_fault.total));
+    check('kinds are ordered worst-first', rep.stt_fault.kinds[0].kind === 'payment_required');
+    check('a human-readable reason rides the field lifecycle.v1 already has',
+      /stt_degraded: payment_required×18/.test(rep.reason), rep.reason);
+    check('only the FIRST of a kind logs loudly (a storm must not flood the log)',
+      logs.length === 2, `${logs.length} lines`);
+    check('the loud line names the consequence', /transcription is failing/.test(logs[0]), logs[0]);
+  }
+
+  // ── 2) a non-STT fault is not an STT degradation ──
+  {
+    const r = createSttFaultReporter(() => { /* quiet */ });
+    r.record(new Error('some unrelated boom'));
+    r.record(null);
+    r.record(undefined);
+    check('a fault with no STT provenance is ignored (and null/undefined never throw)',
+      r.report() === undefined && r.total() === 0, String(r.total()));
+  }
+
+  // ── 3) the wiring: the TERMINAL event carries it; earlier events do not ──
+  {
+    const events: LifecycleEvent[] = [];
+    const r = createSttFaultReporter(() => { /* quiet */ });
+    const o = createOrchestrator(inv, { ...fakes(events), degraded: () => r.report() });
+    r.record(sttError('payment_required', 402, 'Insufficient balance'));
+    const run = o.run({ maxActiveMs: 50 });
+    const result = await run;
+
+    const terminal = events[events.length - 1] as any;
+    const nonTerminal = events.slice(0, -1) as any[];
+    check('the meeting still ends normally (reporting never changes the exit)',
+      result.status === 'completed' && result.exitCode === 0, JSON.stringify(result));
+    check('the TERMINAL event carries stt_fault', !!terminal.stt_fault,
+      JSON.stringify(Object.keys(terminal)));
+    check('it names the kind that broke the transcript',
+      terminal.stt_fault.kinds[0].kind === 'payment_required', JSON.stringify(terminal.stt_fault));
+    check('NO non-terminal event carries it (one report, at the end)',
+      nonTerminal.every((e) => !e.stt_fault), JSON.stringify(nonTerminal.map((e) => e.status)));
+  }
+
+  // ── 4) a clean meeting is unchanged — no field, no noise ──
+  {
+    const events: LifecycleEvent[] = [];
+    const r = createSttFaultReporter(() => { /* quiet */ });
+    const o = createOrchestrator(inv, { ...fakes(events), degraded: () => r.report() });
+    await o.run({ maxActiveMs: 50 });
+    check('a meeting with no STT fault emits NO stt_fault field',
+      events.every((e) => !(e as any).stt_fault), JSON.stringify(events.map((e) => e.status)));
+  }
+
+  // ── 5) a reporter that throws must not break the terminal emit ──
+  {
+    const events: LifecycleEvent[] = [];
+    const o = createOrchestrator(inv, {
+      ...fakes(events),
+      degraded: () => { throw new Error('reporter exploded'); },
+    });
+    const result = await o.run({ maxActiveMs: 50 });
+    check('a throwing reporter still lets the bot report its terminal state',
+      result.status === 'completed' && events.some((e) => e.status === 'completed'),
+      JSON.stringify(result));
+  }
+
+  if (failed) { console.error(`\n❌ stt-faults: ${failed} check(s) FAILED.`); process.exit(1); }
+  console.log('\n✅ stt-faults: a meeting degraded by STT carries WHY on its terminal lifecycle.v1 event — one summary per kind with the backend\'s own words, never on a non-terminal event, and never at the cost of the exit path.');
+}
+
+void main();

--- a/core/meetings/services/bot/src/stt-faults.ts
+++ b/core/meetings/services/bot/src/stt-faults.ts
@@ -1,0 +1,95 @@
+/**
+ * The STT degradation accumulator — what turns "the transcript is empty" into "the transcript is
+ * empty BECAUSE the backend refused, and here is its own answer".
+ *
+ * The faults are already typed and attributed by the time they reach the composition root
+ * (`TranscriptionError` from @vexa/transcribe-whisper: `kind`, `status`, `detail`, `retryable`),
+ * and the pipelines already hand every one of them to `onError`. What was missing is the last
+ * hop: the root logged them to a console nobody reads after the container exits, so a meeting
+ * whose STT backend was dead completed indistinguishable from a silent room — the #807 shape,
+ * and the reason the 2026-07-19 exhausted-token deployment produced zero transcripts in silence.
+ *
+ * This collapses a storm into ONE report. A dead backend faults on every chunk (18 in a 2-minute
+ * live run), so counting per kind and reporting once — on the terminal lifecycle event — is both
+ * the honest summary and the only shape that cannot flood the control plane.
+ */
+
+/** The structural shape of a @vexa/transcribe-whisper TranscriptionError, matched without
+ *  importing it: the accumulator must classify anything the pipeline hands it, including a
+ *  non-STT fault that happens to reach the same seam. */
+interface SttFaultLike {
+  source?: string;
+  kind?: string;
+  status?: number;
+  detail?: string;
+  message?: string;
+}
+
+/** One kind of STT failure, and how much of the meeting it ate. */
+export interface SttFaultSummary {
+  kind: string;                  // payment_required | unauthorized | unavailable | timeout | …
+  count: number;                 // how many chunks this kind refused
+  status?: number;               // the backend's HTTP status, when it had one
+  detail?: string;               // the backend's OWN words (truncated), never our paraphrase
+  first_at: string;              // ISO — when the degradation started
+}
+
+export interface SttFaultReporter {
+  /** Record one fault from a pipeline `onError`. Never throws. */
+  record(fault: unknown): void;
+  /** The lifecycle.v1 fragment to merge onto the terminal event, or undefined if nothing
+   *  degraded. Shaped for `OrchestratorDeps.degraded`. */
+  report(): Record<string, unknown> | undefined;
+  /** Total faults seen (all kinds) — the counter the periodic log line reads. */
+  total(): number;
+}
+
+const DETAIL_MAX = 300;
+
+/** True for a fault that came from the STT boundary (P5: the adapter stamps `source`). */
+function isSttFault(f: SttFaultLike): boolean {
+  return f?.source === 'stt' || typeof f?.kind === 'string';
+}
+
+export function createSttFaultReporter(
+  log: (m: string) => void = (m) => console.error(m),
+  now: () => Date = () => new Date(),
+): SttFaultReporter {
+  const byKind = new Map<string, SttFaultSummary>();
+  let total = 0;
+
+  return {
+    total: () => total,
+    record(fault: unknown): void {
+      try {
+        const f = (fault ?? {}) as SttFaultLike;
+        if (!isSttFault(f)) return;
+        total++;
+        const kind = f.kind ?? 'unknown';
+        const seen = byKind.get(kind);
+        if (seen) {
+          seen.count++;
+          return;
+        }
+        const detail = (f.detail ?? f.message ?? '').slice(0, DETAIL_MAX) || undefined;
+        byKind.set(kind, { kind, count: 1, status: f.status, detail, first_at: now().toISOString() });
+        // FIRST of a kind is loud — an operator watching logs should not wait for the terminal
+        // event to learn the backend is refusing. Repeats are silent (the count carries them).
+        log(`[bot] STT DEGRADED (${kind}${f.status ? ` HTTP ${f.status}` : ''}): ${detail ?? 'no detail'} — transcription is failing; this meeting will be short or empty`);
+      } catch { /* an accumulator must never break the path that reports to it */ }
+    },
+    report(): Record<string, unknown> | undefined {
+      if (byKind.size === 0) return undefined;
+      const faults = [...byKind.values()].sort((a, b) => b.count - a.count);
+      return {
+        stt_fault: {
+          kinds: faults,
+          total: faults.reduce((n, f) => n + f.count, 0),
+        },
+        // A one-line human summary on the field lifecycle.v1 already carries for free, so an
+        // operator reading a raw callback sees it without knowing the new field exists.
+        reason: `stt_degraded: ${faults.map((f) => `${f.kind}×${f.count}`).join(', ')}`,
+      };
+    },
+  };
+}

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
@@ -213,6 +213,9 @@ class MeetingRecord:
     bot_logs: Optional[List[str]] = None
     bot_logs_truncated: bool = False
     bot_resources: Optional[Dict[str, Any]] = None
+    #: What degraded the meeting without ending it — today the STT backend refusing chunks
+    #: (kinds + counts + the backend's own detail), reported by the bot on the terminal event.
+    stt_fault: Optional[Dict[str, Any]] = None
     # User intent (parent's `meeting.data.stop_requested`) — set by the DELETE/stop path, read
     # first by the exit classifier so a user stop is never mis-attributed as a failure.
     stop_requested: bool = False
@@ -249,6 +252,8 @@ class MeetingRecord:
             d["bot_resources"] = dict(self.bot_resources)
         if self.stop_requested:
             d["stop_requested"] = True
+        if self.stt_fault is not None:
+            d["stt_fault"] = dict(self.stt_fault)
         return d
 
 
@@ -435,6 +440,12 @@ class LifecycleSink:
                 rec.bot_logs, rec.bot_logs_truncated = _trim_bot_logs(list(event["bot_logs"]))
             if event.get("bot_resources"):
                 rec.bot_resources = dict(event["bot_resources"])
+            # WHY a transcript is short or empty. The bot counts STT failures across the meeting
+            # and reports them once, here — without it a meeting whose backend refused every chunk
+            # completes indistinguishable from a silent room (the zero-segment shape). Additive on
+            # lifecycle.v1 (additionalProperties: true), same as infra_fault.
+            if event.get("stt_fault"):
+                rec.stt_fault = dict(event["stt_fault"])
 
         rec.status = to
         rec.history.append(to)

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_diagnostics.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_diagnostics.py
@@ -197,3 +197,59 @@ def test_bot_logs_trimmed_oldest_first():
     assert len(kept) < len(lines)
     assert kept[-1] == lines[-1]  # newest survives
     assert kept[0] != lines[0]    # oldest dropped
+
+
+# ── the DEGRADED meeting: completed, but with no transcript and a reason why ────────────────────
+# A backend that refuses every chunk used to produce a meeting indistinguishable from a silent
+# room: the bot's faults were typed and attributed all the way to its composition root and then
+# died in a console.error. The bot now counts them and reports once on the terminal event; this
+# asserts the control plane PERSISTS that instead of accepting-and-dropping it (an additive field
+# on lifecycle.v1, which is additionalProperties: true).
+
+_STT_FAULT = {
+    "kinds": [
+        {"kind": "payment_required", "count": 18, "status": 402,
+         "detail": "Insufficient balance. Available: 0.00 minutes",
+         "first_at": "2026-07-19T12:00:00.000Z"},
+    ],
+    "total": 18,
+}
+
+
+def test_degraded_meeting_persists_why_the_transcript_is_empty():
+    terminal = {
+        "connection_id": "sess-uid", "status": "completed", "exit_code": 0,
+        "completion_reason": "stopped",
+        "reason": "stt_degraded: payment_required×18",
+        "stt_fault": _STT_FAULT,
+    }
+    # The degraded terminal event is still a CONFORMING lifecycle.v1 event (the field is additive).
+    conforms(terminal, "LifecycleEvent")
+
+    client, app, deliveries = _client()
+    final = _drive(client, JOINING, ACTIVE, terminal)[-1]
+
+    # It completes normally — a dead STT degrades the VALUE, it does not fail the meeting.
+    assert final["meeting_status"] == "completed"
+    assert final["completion_reason"] == "stopped"
+
+    # …and the meeting now says WHY it has no transcript, in the backend's own words.
+    persisted = final["data"]["stt_fault"]
+    assert persisted["total"] == 18
+    assert persisted["kinds"][0]["kind"] == "payment_required"
+    assert persisted["kinds"][0]["status"] == 402
+    assert "Insufficient balance" in persisted["kinds"][0]["detail"]
+
+    # The webhook carries the same attribution — an integrator sees it without polling.
+    status_hooks = [d for d in deliveries if d["event_type"] == "meeting.status_change"]
+    assert status_hooks[-1]["data"]["meeting"]["data"]["stt_fault"]["total"] == 18
+
+
+def test_healthy_meeting_carries_no_stt_fault():
+    """Negative control: the field appears ONLY when something actually degraded."""
+    client, app, deliveries = _client()
+    final = _drive(client, JOINING, ACTIVE, {
+        "connection_id": "sess-uid", "status": "completed", "exit_code": 0,
+        "completion_reason": "stopped",
+    })[-1]
+    assert "stt_fault" not in final["data"]

--- a/docs/changelog.d/552-stt-fault-surfacing.md
+++ b/docs/changelog.d/552-stt-fault-surfacing.md
@@ -1,0 +1,9 @@
+- **A meeting with no transcript now says why.** When the transcription backend refuses — an
+  exhausted token, a rejected key, an unreachable service — the bot counts the failures and
+  reports them once on its terminal `lifecycle.v1` event, and meeting-api persists them to
+  `meeting.data.stt_fault` and onto the `meeting.status_change` webhook. Previously those faults
+  were fully typed and attributed inside the bot and then died in a `console.error`, so a meeting
+  whose STT was dead completed indistinguishable from a silent room — the empty-transcript reports
+  that could never be diagnosed after the fact. The report carries the backend's own words
+  (`payment_required`, HTTP 402, "Insufficient balance…") and one count per kind, so a storm of
+  per-chunk failures becomes one honest summary rather than a flood.


### PR DESCRIPTION
Closes the bot half of the GAP row in `docs/test-scenarios/terminal-seams.md:147` (`stt_402_payment_required: surfaced_to_terminal — GAP: bot pipeline onError is console-only (index.ts) — dies before any carrier`). Related: #552, #807.

## The gap

The faults were never lost for lack of typing. `@vexa/transcribe-whisper` classifies every one (`payment_required` / `unauthorized` / `unavailable` / `timeout`, with the backend's own detail and the right retry semantics), and both pipelines hand them to `onError`. What was missing is the **last hop**: `bot/src/index.ts` logged them to a console that dies with the container.

So a meeting whose STT backend refused every chunk reached `completed` **indistinguishable from a silent room** — no reason in the DB, none on the webhook, nothing for a human to read afterwards. That is precisely why empty-transcript reports (the #807 class) could not be diagnosed after the fact. It is not hypothetical: the exhausted-token deployment in #832 produced 18 typed 402s in a 2-minute live run and completed clean and silent.

## The change

The bot accumulates STT faults **per kind** and reports once, on the **terminal** lifecycle event — the last thing anyone hears from a bot, and the only emit that is never an idempotent no-op at the receiver. A dead backend faults on every chunk, so counting and reporting once is both the honest summary and the only shape that cannot flood the control plane; the *first* fault of each kind still logs loudly for anyone tailing the container.

It rides `lifecycle.v1` as an additive field exactly as `infra_fault` already does (`additionalProperties: true` — **no schema edit, no seal change**). meeting-api ingests it into `meeting.data.stt_fault`, so it reaches the DB and the existing `meeting.status_change` webhook **without a new webhook event type**.

## Observation bundle

| # | Observation | Evidence |
|---|---|---|
| 1 | 18 faults of one kind collapse to ONE summary carrying the count | `stt-faults.test.ts` |
| 2 | The backend's own words survive (HTTP 402, "Insufficient balance. Available: 0.00 minutes") — not a paraphrase | same |
| 3 | Only the terminal event carries it; no non-terminal event does | same |
| 4 | A healthy meeting emits **no** field at all (negative control) | same |
| 5 | A non-STT fault is ignored; `null`/`undefined` never throw | same |
| 6 | A reporter that throws still lets the bot report its terminal state | same |
| 7 | meeting-api persists it to `data.stt_fault` **and** the status_change webhook | `test_degraded_meeting_persists_why_the_transcript_is_empty` |
| 8 | A healthy meeting persists no `stt_fault` key | `test_healthy_meeting_carries_no_stt_fault` |
| 9 | The degraded terminal event still conforms to sealed `lifecycle.v1` | `conforms(terminal, "LifecycleEvent")` in the same test |
| 10 | Suites | bot suite clean · gates green · meeting-api **770 pass** (the 31 `test_calendar_sync` failures are **pre-existing on main**, which has 768 pass) |

## Deliberately not changed

- **The `no_op` gate on same-status re-emits.** Reporting mid-meeting would have meant weakening `machine.py`'s idempotency, which is load-bearing; the terminal event carries the same information without touching it.
- **The terminal's live banner.** #552's UX half — "stream disconnected; reconnecting" naming the transport instead of the backend — is still open: the banner reads an SSE fed by the collector, not by lifecycle, so that leg needs a producer on the stream the SSE forwards. This PR makes the fault *durable and attributable*; it does not yet make it *live on screen*. The GAP row stays in-flight and I've left it that way rather than marking it green.