### PR TITLE
fix(mixed-capture): capture delivers the audio it hears — 65% -> 99.9% duty on a continuous source (#850)

### DIFF
--- a/core/meetings/eval/src/capture-bench.mjs
+++ b/core/meetings/eval/src/capture-bench.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// capture-bench — reproduce capture loss with no meeting, no bot, and no human.
+//
+// A 65% capture duty cycle has two candidate mechanisms that leave IDENTICAL evidence in a
+// recording, because both simply omit a frame:
+//
+//   the silence gate      mixed-audio.ts refuses a 256ms buffer whose peak is <= 0.005
+//   the ScriptProcessor   its callback runs on the MAIN THREAD and is skipped when the page is busy
+//                         (documented in gmeet-capture/src/pcm-capture.ts, the module written to
+//                          replace it — the bot's mixed lane is the last path still on it)
+//
+// Nothing recorded can separate them: a buffer the processor never delivered was never peak-tested
+// either. So drive the REAL capture module in a REAL browser over a SYNTHETIC source whose silence
+// structure and main-thread load are ours to set, and read the counters it now keeps against the
+// AudioContext's own clock.
+//
+//   node src/capture-bench.mjs [--sec 20]
+//
+// Arms: continuous tone (no silence to gate) · speech-like with digital-silence pauses (what WebRTC
+// silence suppression produces) · continuous tone under main-thread load. The first isolates the
+// processor, the second the gate, the third says whether load alone can produce the observed loss.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const HERE = path.dirname(new URL(import.meta.url).pathname);
+// eval is deliberately NOT a workspace member, so its deps are resolved by path — the same way it
+// imports the capture bricks. Playwright belongs to @vexa/join, the only package that drives a browser.
+const { chromium } = await import(new URL('../../modules/join/node_modules/playwright/index.mjs', import.meta.url).href);
+const BUNDLE = path.join(HERE, '..', '..', 'services', 'bot', 'dist', 'browser-utils.global.js');
+
+const SEC = Number(process.argv[process.argv.indexOf('--sec') + 1] || 20);
+
+/** Runs inside the page: build a live MediaStream, capture it, report the counters. */
+async function runArm(page, { silence, load, sec }) {
+  return page.evaluate(async ({ silence, load, sec }) => {
+    const SR = 16000;
+    const ctx = new AudioContext({ sampleRate: SR });
+    await ctx.resume();
+    const osc = ctx.createOscillator();
+    osc.frequency.value = 220;
+    const gain = ctx.createGain();
+    const dest = ctx.createMediaStreamDestination();
+    osc.connect(gain).connect(dest);
+
+    // Speech-like: 1.2s of tone, 0.6s of DIGITAL silence (gain exactly 0, which is what a codec's
+    // silence suppression yields — not a noise floor). Continuous: gain pinned at speech level.
+    const t0 = ctx.currentTime + 0.05;
+    if (silence) {
+      for (let t = 0, i = 0; t < sec + 2; t += 1.8, i++) {
+        gain.gain.setValueAtTime(0.3, t0 + t);
+        gain.gain.setValueAtTime(0.0, t0 + t + 1.2);
+      }
+    } else {
+      gain.gain.setValueAtTime(0.3, t0);
+    }
+    osc.start();
+
+    let frames = 0;
+    const cap = await window.VexaBrowserUtils.createMixedAudioCapture(
+      dest.stream, () => { frames++; }, { sampleRate: SR, replay: false, log: () => { /* quiet */ } },
+    );
+
+    // Main-thread load: block the event loop in bursts, which is what a live meeting client plus a
+    // software-rendered page does to a ScriptProcessor callback.
+    let loader = null;
+    if (load) loader = setInterval(() => { const end = Date.now() + 180; while (Date.now() < end) { /* block */ } }, 220);
+
+    await new Promise((r) => setTimeout(r, sec * 1000));
+    if (loader) clearInterval(loader);
+    const s = cap.stats();
+    cap.stop();
+    try { osc.stop(); ctx.close(); } catch { /* */ }
+    return { ...s, framesDelivered: frames };
+  }, { silence, load, sec });
+}
+
+const browser = await chromium.launch({
+  args: ['--autoplay-policy=no-user-gesture-required', '--mute-audio'],
+});
+const page = await browser.newPage();
+await page.setContent('<!doctype html><title>capture-bench</title><body></body>');
+await page.addScriptTag({ content: readFileSync(BUNDLE, 'utf8') });
+
+const ARMS = [
+  { name: 'continuous tone, idle page', silence: false, load: false },
+  { name: 'speech-like + digital silence, idle page', silence: true, load: false },
+  { name: 'continuous tone, main thread BUSY', silence: false, load: true },
+  { name: 'speech-like + silence, main thread BUSY', silence: true, load: true },
+];
+
+console.log(`capture-bench — ${SEC}s per arm, real createMixedAudioCapture in real chromium\n`);
+console.log('arm'.padEnd(42) + 'duty   gated  processor-deficit');
+for (const arm of ARMS) {
+  const s = await runArm(page, { ...arm, sec: SEC });
+  const duty = s.renderedSec > 0 ? s.deliveredSec / s.renderedSec : 0;
+  console.log(
+    arm.name.padEnd(42) +
+    `${(duty * 100).toFixed(1)}%`.padEnd(7) +
+    `${s.gatedSec.toFixed(1)}s`.padEnd(7) +
+    `${s.processorDeficitSec.toFixed(1)}s   ` +
+    `(seen ${s.seen}, emitted ${s.emitted}, rendered ${s.renderedSec.toFixed(1)}s)`);
+}
+await browser.close();
+
+console.log(`
+Reading it: 'duty' is what the SESSION RECORDING would show — buffers that reached the callback over
+the audio the graph rendered. 'gated' and 'processor-deficit' split that loss into the two
+mechanisms, which no recording can do on its own.`);

--- a/core/meetings/eval/src/extension-loop.mjs
+++ b/core/meetings/eval/src/extension-loop.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// extension-loop — the EXTERNAL loop, driven without a human.
+//
+// The framework's external loop is `clients/extension` → `services/desktop`: a real browser tab, the
+// real capture path, the real lane at production config, real STT. It was treated as the half that
+// needs a person because a person normally clicks it. Nothing about the loop requires that — the
+// extension auto-starts on a recognised tab, so a driver can open the tab, let it run, stop it, and
+// hand the recorded tape straight to the offline scorers.
+//
+// What this does NOT replace: a human's judgement of whether a transcript FEELS right, and any
+// meeting whose other participants are people. It replaces the mechanical part — press play, wait,
+// collect — which is the part that was rate-limiting the loop.
+//
+//   node src/extension-loop.mjs --url <page> [--sec 120] [--profile <dir>]
+//
+// Requires the desktop running (VEXA_RECORD_TAPE set) and a profile whose chrome.storage.local
+// carries the extension's apiKey + endpoint config.
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const { chromium } = await import(new URL('../../modules/join/node_modules/playwright/index.mjs', import.meta.url).href);
+
+const HERE = path.dirname(new URL(import.meta.url).pathname);
+const EXT = path.join(HERE, '..', '..', '..', '..', 'clients', 'extension', 'dist');
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i < 0 ? d : process.argv[i + 1]; };
+
+const URL_ = arg('url');
+const SEC = Number(arg('sec', 120));
+const PROFILE = arg('profile', path.join(process.env.TMPDIR || '/tmp', 'vexa-ext-loop-profile'));
+const TAPES = process.env.VEXA_RECORD_TAPE;
+
+if (!URL_) { console.error('usage: extension-loop.mjs --url <page> [--sec 120] [--profile <dir>]'); process.exit(1); }
+if (!existsSync(EXT)) { console.error(`extension not built: ${EXT} (npm run build in clients/extension)`); process.exit(1); }
+
+const newestTape = () => {
+  if (!TAPES || !existsSync(TAPES)) return null;
+  const files = readdirSync(TAPES).filter((f) => f.endsWith('.jsonl')).map((f) => ({ f, t: statSync(path.join(TAPES, f)).mtimeMs }));
+  return files.sort((a, b) => b.t - a.t)[0]?.f ?? null;
+};
+const before = newestTape();
+
+const ctx = await chromium.launchPersistentContext(PROFILE, {
+  // Extensions need a real browser context, and MV3 service workers need the new headless.
+  headless: false,
+  args: [
+    `--disable-extensions-except=${EXT}`,
+    `--load-extension=${EXT}`,
+    '--autoplay-policy=no-user-gesture-required',
+    '--mute-audio',
+  ],
+});
+
+// The service worker is the extension: waiting for it is how we know the load actually took, rather
+// than discovering later that the tape is empty because nothing was ever listening.
+let sw = ctx.serviceWorkers()[0];
+if (!sw) sw = await ctx.waitForEvent('serviceworker', { timeout: 30_000 });
+const extId = new URL(sw.url()).host;
+console.log(`extension loaded: ${extId}`);
+
+// Extension storage is keyed by extension id, and a freshly side-loaded copy gets a new one — so a
+// profile a human configured by hand does not carry over to a driven run. Seed it instead of
+// requiring one: the `desktop` preset already points at the desktop's own ingest and gateway.
+const API_KEY = arg('api-key', process.env.VEXA_API_KEY || 'local-desktop');
+await sw.evaluate(async (k) => {
+  const cur = await chrome.storage.local.get(['apiKey']);
+  if (!cur.apiKey) await chrome.storage.local.set({ apiKey: k, deployment: 'desktop', autoStart: true });
+}, API_KEY);
+
+const cfg = await sw.evaluate(() => chrome.storage.local.get(['apiKey', 'deployment', 'gatewayUrl', 'autoStart']));
+console.log(`  config: apiKey ${cfg.apiKey ? 'set' : 'MISSING'} · deployment ${cfg.deployment ?? '(default)'} · gateway ${cfg.gatewayUrl ?? '(preset)'} · autoStart ${cfg.autoStart !== false}`);
+
+const page = await ctx.newPage();
+await page.goto(URL_, { waitUntil: 'domcontentloaded' });
+// A tab that never plays is a tab with no audio to capture, and a MUTED element produces none
+// either — the silence gate then drops every buffer and the tape is empty. Browser-level
+// --mute-audio silences the speakers without touching what tab capture taps.
+await page.evaluate(async () => {
+  for (const v of document.querySelectorAll('video,audio')) { v.muted = false; v.volume = 1; try { await v.play?.(); } catch { /* */ } }
+});
+
+console.log(`capturing ${URL_} for ${SEC}s …`);
+const started = Date.now();
+let last = '';
+while ((Date.now() - started) / 1000 < SEC) {
+  await new Promise((r) => setTimeout(r, 5000));
+  const st = await sw.evaluate(() => new Promise((r) => { try { chrome.runtime.sendMessage({ type: 'STATUS' }, (x) => r(x || {})); } catch { r({}); } }))
+    .catch(() => ({}));
+  const tape = newestTape();
+  const size = tape && tape !== before ? (statSync(path.join(TAPES, tape)).size / 1e6).toFixed(1) : '0.0';
+  const line = `  t+${Math.round((Date.now() - started) / 1000)}s status=${st.status ?? '?'} tape=${size}MB${st.error ? ' err=' + st.error : ''}`;
+  console.log(line); last = line;
+}
+
+await sw.evaluate(() => chrome.runtime.sendMessage({ type: 'STOP' })).catch(() => { /* best effort */ });
+await new Promise((r) => setTimeout(r, 2000));
+await ctx.close();
+
+const after = newestTape();
+console.log(`\ntape: ${after && after !== before ? path.join(TAPES, after) : 'NO NEW TAPE — capture never reached the desktop'}`);
+if (after && after !== before) {
+  console.log(`  ${(statSync(path.join(TAPES, after)).size / 1e6).toFixed(1)} MB`);
+  console.log(`\nnext: node src/promote-fixture.mjs ${path.join(TAPES, after)} --slug <slug> --platform <p>`);
+}

--- a/core/meetings/eval/src/score-fixture.mjs
+++ b/core/meetings/eval/src/score-fixture.mjs
@@ -34,7 +34,19 @@ const named = argv.filter((a) => !a.startsWith('--'));
 // Tolerances are per-metric because the metrics are not the same KIND of number: a duty cycle
 // recomputed from the same bytes is exact, a word count is exact, but a wall-clock-derived p50 can
 // wobble by a rounding step. Nothing here is loose enough to hide a real regression.
-const TOL = { dutyCycle: 0.001, recall: 0.001, precision: 0.001, retention: 0.001, coverage: 0.02, segP50Sec: 0.05 };
+// A lane run over a tape fixture drives the REAL segmenter alongside an async pump, so the
+// interleaving — and with it the number of resubmissions — varies run to run. Measured over five
+// consecutive runs of identical code on youtube/2026-07-20-continuous-speech: coverage 0.905-0.906,
+// holes 6/6/6/6/6, published words 2746-2750, but STT call count 429-440. Structure is stable;
+// call-count-derived figures are not, so they are toleranced from that spread rather than pretended
+// exact. Anything the corpus is meant to CATCH — a duplicate identity, a lost turn — moves far
+// further than this (reverting 4c030cd8 moves storeDupes 0 → 11).
+const TOL = {
+  dutyCycle: 0.001, recall: 0.001, precision: 0.001,       // recomputed from stored bytes — exact
+  retention: 0.001, coverage: 0.01, segP50Sec: 0.25,
+  sttCalls: 15, sttWords: 250, publishCalls: 5, uniqueSegmentIds: 5,
+  storeRows: 5, segments: 5, segUnder1s: 8, publishedWords: 25,
+};
 const DEFAULT_TOL = 0;
 // Where a metric has a direction, say so — it turns "changed" into "better" or "worse" in the
 // report. Metrics with no entry are directionless: any movement is reported as a difference.
@@ -129,7 +141,9 @@ for (const { id, dir } of entries()) {
       console.log(`  lane      skipped — ${manifest.lane} lane has its own harness (quality.test.ts)`);
     } else {
       lane = laneMetrics(sessionPath);
-      console.log(`  lane      ${lane.storeRows} store rows (${lane.storeDupes} dup texts) · retention ${lane.retention} · coverage ${lane.coverage} · ${lane.holesOver2s} holes >2s`);
+      console.log(`  lane      ${lane.storeRows} store rows (${lane.storeDupes} dup texts) · ${lane.publishedWords} words · ` +
+        `coverage ${lane.coverage} · ${lane.holesOver2s} holes >2s` +
+        (lane.retention === undefined ? '' : ` · retention ${lane.retention}`));
     }
   }
 

--- a/core/meetings/modules/mixed-capture-core/src/index.ts
+++ b/core/meetings/modules/mixed-capture-core/src/index.ts
@@ -8,5 +8,5 @@
  * concern — see `@vexa/record-chunker` (createRecordingTap), not here.
  */
 export { createMixedAudioCapture } from './mixed-audio.js';
-export type { MixedAudioCapture, MixedAudioOptions } from './mixed-audio.js';
+export type { MixedAudioCapture, MixedAudioOptions, MixedAudioStats } from './mixed-audio.js';
 export { installRemoteAudioHook } from './webrtc-audio-hook.js';

--- a/core/meetings/modules/mixed-capture-core/src/mixed-audio.ts
+++ b/core/meetings/modules/mixed-capture-core/src/mixed-audio.ts
@@ -19,9 +19,32 @@
  * available to the bot — same contract as the other capture bricks.
  */
 
+/** Delivery accounting — see `stats()`. Every number is seconds of audio except the counts. */
+export interface MixedAudioStats {
+  /** Buffers the ScriptProcessor handed us. */
+  seen: number;
+  /** Buffers that passed the silence gate. */
+  emitted: number;
+  /** `seen` as audio time — what capture actually received. */
+  deliveredSec: number;
+  /** The AudioContext's own elapsed time — what the graph rendered. */
+  renderedSec: number;
+  /** `renderedSec - deliveredSec`: audio that existed and never reached the callback. */
+  processorDeficitSec: number;
+  /** `seen - emitted` as audio time: audio the gate refused. */
+  gatedSec: number;
+}
+
 export interface MixedAudioCapture {
   /** Stop re-play + capture and release resources. */
   stop(): void;
+  /**
+   * Where the audio went. A frame missing downstream was either never delivered by the
+   * ScriptProcessor or refused by the silence gate, and the two have entirely different fixes —
+   * so they are counted separately against the context clock, which is the only local witness to
+   * how much audio existed. Without this split a missing 256 ms is unattributable.
+   */
+  stats(): MixedAudioStats;
 }
 
 export interface MixedAudioOptions {
@@ -33,6 +56,12 @@ export interface MixedAudioOptions {
   replay?: boolean;
   log?: (msg: string) => void;
 }
+
+/** ScriptProcessor buffer size — 4096 @ 16 kHz = 256 ms per frame. */
+const BUFFER_SAMPLES = 4096;
+/** Log the delivery split every this many buffers (100 ≈ 25 s of audio). */
+const REPORT_EVERY = 100;
+
 
 export async function createMixedAudioCapture(
   stream: MediaStream,
@@ -46,12 +75,38 @@ export async function createMixedAudioCapture(
   // ── CAPTURE — 16 kHz context + ScriptProcessor (no worklet module → no CSP) ────
   const ctx = new AudioContext({ sampleRate: SR });
   const source = ctx.createMediaStreamSource(stream);
-  const proc = ctx.createScriptProcessor(4096, 1, 1);
+  const proc = ctx.createScriptProcessor(BUFFER_SAMPLES, 1, 1);
+
+  // Samples, not buffer counts: the engine chooses the buffer length, so counting what actually
+  // arrived is the only figure that stays true if it ever chooses differently.
+  let seen = 0, emitted = 0, deliveredSamples = 0, gatedSamples = 0, ctxStart = -1;
+  const stats = (): MixedAudioStats => {
+    const deliveredSec = deliveredSamples / SR;
+    const renderedSec = ctxStart < 0 ? 0 : ctx.currentTime - ctxStart;
+    return {
+      seen, emitted, deliveredSec, renderedSec,
+      processorDeficitSec: Math.max(0, renderedSec - deliveredSec),
+      gatedSec: gatedSamples / SR,
+    };
+  };
+
   proc.onaudioprocess = (e: AudioProcessingEvent) => {
     const input = e.inputBuffer.getChannelData(0);
+    // The context clock at the FIRST buffer is the zero, less that buffer's own span: everything
+    // before it is graph startup, not loss.
+    if (ctxStart < 0) ctxStart = ctx.currentTime - input.length / SR;
+    seen++;
+    deliveredSamples += input.length;
     let maxVal = 0;
     for (let i = 0; i < input.length; i++) { const a = Math.abs(input[i]); if (a > maxVal) maxVal = a; }
-    if (maxVal > SILENCE) onPcm(new Float32Array(input));   // copy — the buffer is reused
+    if (maxVal > SILENCE) { emitted++; onPcm(new Float32Array(input)); }   // copy — the buffer is reused
+    else gatedSamples += input.length;
+    if (seen % REPORT_EVERY === 0) {
+      const s = stats();
+      log(`capture: seen=${s.seen} emitted=${s.emitted} · delivered ${s.deliveredSec.toFixed(1)}s of ` +
+        `${s.renderedSec.toFixed(1)}s rendered · processor deficit ${s.processorDeficitSec.toFixed(1)}s · ` +
+        `gated ${s.gatedSec.toFixed(1)}s`);
+    }
   };
   source.connect(proc);
   proc.connect(ctx.destination);                           // pull the processor (outputs silence)
@@ -79,5 +134,6 @@ export async function createMixedAudioCapture(
       try { cloned?.stop(); } catch { /* */ }
       try { ctx.close(); } catch { /* */ }
     },
+    stats,
   };
 }

--- a/core/meetings/modules/mixed-capture-core/src/mixed-audio.ts
+++ b/core/meetings/modules/mixed-capture-core/src/mixed-audio.ts
@@ -50,7 +50,20 @@ export interface MixedAudioCapture {
 export interface MixedAudioOptions {
   /** PCM target rate (Hz). Default 16000. */
   sampleRate?: number;
-  /** Skip near-silent frames below this peak amplitude. Default 0.005. */
+  /**
+   * Skip frames whose peak amplitude is at or below this. **Default 0 — nothing is skipped.**
+   *
+   * Dropping a frame does not drop audio, it drops TIME, and everything downstream reconstructs
+   * meaning from timestamps: the segmenter splices speech onto speech across the hole and reads it
+   * as a speaker change, turn boundaries land where no audio was delivered, and the hint binder
+   * matches names against a clock that has drifted. Measured on a real bot renderer, this gate
+   * discarded 85s of a 128s session while the ScriptProcessor delivered every buffer it was given —
+   * so the gate was the entire capture deficit.
+   *
+   * The cost it was paying for is already paid downstream, twice: the pipeline refuses to submit a
+   * span below DROP_RMS, and drops whatever comes back through the post-Whisper acoustic gates.
+   * Silence never reached STT because of this; it reached it because of those.
+   */
   silenceThreshold?: number;
   /** Re-play the stream to the speakers (un-mute the captured tab). Default true. */
   replay?: boolean;
@@ -69,7 +82,7 @@ export async function createMixedAudioCapture(
   opts: MixedAudioOptions = {},
 ): Promise<MixedAudioCapture> {
   const SR = opts.sampleRate ?? 16000;
-  const SILENCE = opts.silenceThreshold ?? 0.005;
+  const SILENCE = opts.silenceThreshold ?? 0;
   const log = opts.log ?? (() => { /* silent */ });
 
   // ── CAPTURE — 16 kHz context + ScriptProcessor (no worklet module → no CSP) ────
@@ -99,7 +112,10 @@ export async function createMixedAudioCapture(
     deliveredSamples += input.length;
     let maxVal = 0;
     for (let i = 0; i < input.length; i++) { const a = Math.abs(input[i]); if (a > maxVal) maxVal = a; }
-    if (maxVal > SILENCE) { emitted++; onPcm(new Float32Array(input)); }   // copy — the buffer is reused
+    // A NON-POSITIVE threshold disables gating outright, digital silence included. Testing
+    // `maxVal > 0` would still drop an all-zero buffer — and an all-zero buffer is precisely what a
+    // codec's silence suppression emits, so that is the case a threshold of zero must let through.
+    if (SILENCE <= 0 || maxVal > SILENCE) { emitted++; onPcm(new Float32Array(input)); }   // copy — the buffer is reused
     else gatedSamples += input.length;
     if (seen % REPORT_EVERY === 0) {
       const s = stats();

--- a/core/meetings/modules/mixed-capture-core/src/mixed-capture-core.test.ts
+++ b/core/meetings/modules/mixed-capture-core/src/mixed-capture-core.test.ts
@@ -80,6 +80,21 @@ const fire = (samples: Float32Array) => {
   check('stop() closes the capture context', closed.length === before + 1);
 }
 
+// ── the default lets EVERYTHING through, digital silence included ─────────────
+// Dropping a frame drops TIME, and a codec's silence suppression emits exactly-zero buffers — so
+// the case a disabled gate most needs to pass is the one a naive `maxVal > 0` would still refuse.
+{
+  const pcms: Float32Array[] = [];
+  const cap = await createMixedAudioCapture(new FakeMediaStream() as any, (pcm) => pcms.push(pcm), { sampleRate: 16000, replay: false });
+  ctxClock = 0;
+  fire(new Float32Array(8));               // digital silence — what DTX sends
+  fire(new Float32Array(8).fill(0.0005));  // near-silence, under the old 0.005 gate
+  fire(new Float32Array(8).fill(0.5));     // speech
+  check('by default nothing is gated — silence keeps the timeline intact', pcms.length === 3);
+  check('and the gate reports nothing refused', cap.stats().gatedSec === 0);
+  cap.stop();
+}
+
 // ── delivery accounting: the two losses must be told apart ────────────────────
 // A frame missing downstream was either refused by the gate or never handed over by the
 // ScriptProcessor, and the fixes are unrelated (drop the gate vs move to an AudioWorklet). The

--- a/core/meetings/modules/mixed-capture-core/src/mixed-capture-core.test.ts
+++ b/core/meetings/modules/mixed-capture-core/src/mixed-capture-core.test.ts
@@ -18,9 +18,14 @@ const g = globalThis as any;
 let lastProc: any = null;            // the most-recently-created ScriptProcessor
 const closed: any[] = [];            // contexts that got .close()
 
+// The context clock, driven by the test. In a browser it advances with rendering; here advancing
+// it independently of `fire()` is exactly how a starved ScriptProcessor is modelled.
+let ctxClock = 0;
+
 class FakeAudioContext {
   sampleRate: number;
   destination = { _id: 'dest' };
+  get currentTime() { return ctxClock; }
   constructor(opts?: { sampleRate?: number }) { this.sampleRate = opts?.sampleRate ?? 48000; }
   createMediaStreamSource() { return { connect() {} }; }
   createScriptProcessor() {
@@ -73,6 +78,38 @@ const fire = (samples: Float32Array) => {
   const before = closed.length;
   cap.stop();
   check('stop() closes the capture context', closed.length === before + 1);
+}
+
+// ── delivery accounting: the two losses must be told apart ────────────────────
+// A frame missing downstream was either refused by the gate or never handed over by the
+// ScriptProcessor, and the fixes are unrelated (drop the gate vs move to an AudioWorklet). The
+// context clock is the only local witness to how much audio existed, so stats() measures both
+// against it — which is what makes a capture deficit attributable at all.
+{
+  const SR = 16000, BUF = 4096, FRAME = BUF / SR;
+  ctxClock = 0;
+  const cap = await createMixedAudioCapture(new FakeMediaStream() as any, () => { /* */ },
+    { sampleRate: SR, silenceThreshold: 0.005, replay: false });
+
+  // Ten buffers rendered, ten delivered, three of them silent: the gate is the whole deficit.
+  for (let i = 0; i < 10; i++) { ctxClock += FRAME; fire(new Float32Array(BUF).fill(i < 3 ? 0.001 : 0.5)); }
+  let s = cap.stats();
+  check('seen counts every buffer the processor delivered', s.seen === 10);
+  check('emitted counts only what passed the gate', s.emitted === 7);
+  check('gated time is the silent buffers', Math.abs(s.gatedSec - 3 * FRAME) < 1e-6);
+  check('no processor deficit when every rendered buffer arrives', s.processorDeficitSec < 1e-6);
+
+  // Now the context renders five buffers' worth of time while one buffer arrives — the signature
+  // of a ScriptProcessor starved on the main thread. The gate must not be blamed for it.
+  ctxClock += 5 * FRAME;
+  fire(new Float32Array(BUF).fill(0.5));
+  s = cap.stats();
+  check('processor deficit appears when rendered time outruns delivered buffers',
+    Math.abs(s.processorDeficitSec - 4 * FRAME) < 1e-6);
+  check('gated time is unchanged by a processor deficit', Math.abs(s.gatedSec - 3 * FRAME) < 1e-6);
+  check('delivered time counts real samples, not an assumed buffer size',
+    Math.abs(s.deliveredSec - 11 * FRAME) < 1e-6);
+  cap.stop();
 }
 
 // ── installRemoteAudioHook contract: no RTCPeerConnection → no-op false ─────────

--- a/core/meetings/modules/mixed-pipeline/package.json
+++ b/core/meetings/modules/mixed-pipeline/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/draft-identity.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts",
+    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/draft-identity.test.ts && tsx src/hole-timebase.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -153,6 +153,10 @@ export interface ChunkedTranscriberCallbacks {
 }
 
 interface RingFrame { pcm: Float32Array; tMs: number }
+
+/** One contiguous run inside a cut: where it sits in the compressed audio, and the wall instant it
+ *  came from. A cut over a gapless span has exactly one; each hole adds another. */
+interface CutSpan { fromSample: number; wallStartMs: number; samples: number }
 /** Segmentation lifecycle items on the serialized queue: a boundary opens a turn
  *  (speech start / speaker change) or closes the open one (speaker change / end). */
 type SegItem =
@@ -444,10 +448,19 @@ export class ChunkedTranscriber {
     void this.pump();
   }
 
-  /** Exact retroactive cut from the ring (frames are contiguous per source;
-   *  partial frames at the edges are sliced by sample offset). */
-  private cut(t0: number, t1: number): Float32Array {
+  /**
+   * Exact retroactive cut from the ring, with the layout needed to read its timestamps back.
+   *
+   * A span may contain HOLES — instants no frame ever covered, because capture dropped a buffer,
+   * gated a silence, or the source renegotiated. The cut concatenates only what exists, so the
+   * audio handed to STT is SHORTER than the span it covers and its internal clock is not the wall
+   * clock. Zero-filling the holes would restore that equality at the price of inviting the model to
+   * hallucinate over manufactured silence, so the audio stays compressed and `spans` records which
+   * wall instant each run of it came from. Partial frames at the edges are sliced by sample offset.
+   */
+  private cut(t0: number, t1: number): { pcm: Float32Array; spans: CutSpan[] } {
     const parts: Float32Array[] = [];
+    const spans: CutSpan[] = [];
     let total = 0;
     for (const f of this.ring) {
       const fStart = f.tMs;
@@ -456,12 +469,47 @@ export class ChunkedTranscriber {
       if (fStart >= t1) break;
       const from = Math.max(0, Math.round(((t0 - fStart) / 1000) * SAMPLE_RATE));
       const to = Math.min(f.pcm.length, Math.round(((t1 - fStart) / 1000) * SAMPLE_RATE));
-      if (to > from) { parts.push(f.pcm.subarray(from, to)); total += to - from; }
+      if (to <= from) continue;
+      const wallStartMs = fStart + (from / SAMPLE_RATE) * 1000;
+      const prev = spans[spans.length - 1];
+      // Frames that abut in wall time are ONE run; a jump opens a new one. Measuring against the
+      // previous run's end is what makes a hole a hole rather than a per-frame accounting artefact.
+      if (prev && Math.abs(wallStartMs - (prev.wallStartMs + (prev.samples / SAMPLE_RATE) * 1000)) < 1) {
+        prev.samples += to - from;
+      } else {
+        spans.push({ fromSample: total, wallStartMs, samples: to - from });
+      }
+      parts.push(f.pcm.subarray(from, to));
+      total += to - from;
     }
     const out = new Float32Array(total);
     let off = 0;
     for (const p of parts) { out.set(p, off); off += p.length; }
-    return out;
+    return { pcm: out, spans };
+  }
+
+  /**
+   * Compressed audio time (seconds into a cut) → wall time (ms).
+   *
+   * Without it every word after a hole is stamped early by the accumulated hole and the error
+   * compounds across the turn: turns open and close against the wrong instants, and the hint binder
+   * matches names against a clock that has drifted away from the meeting's.
+   */
+  private wallTimeAt(spans: CutSpan[], sec: number, fallbackMs: number, edge: 'start' | 'end' = 'start'): number {
+    if (!spans.length) return fallbackMs + Math.max(0, sec) * 1000;
+    const raw = Math.round(Math.max(0, sec) * SAMPLE_RATE);
+    // A time landing exactly on a run boundary is ambiguous, and the two edges resolve it opposite
+    // ways: a START opens the next run, an END closes the previous one. Resolving an end from the
+    // last sample it covers is what stops a sentence being stretched across the hole that follows it.
+    const sample = edge === 'end' ? Math.max(0, raw - 1) : raw;
+    for (const s of spans) {
+      if (sample < s.fromSample + s.samples) {
+        const off = Math.max(0, sample - s.fromSample) + (edge === 'end' ? 1 : 0);
+        return s.wallStartMs + (off / SAMPLE_RATE) * 1000;
+      }
+    }
+    const last = spans[spans.length - 1];
+    return last.wallStartMs + (last.samples / SAMPLE_RATE) * 1000;
   }
 
   // ── Serialized pipeline ────────────────────────────────────────
@@ -543,7 +591,13 @@ export class ChunkedTranscriber {
    *  confirmation is LocalAgreement-2 (the bot's word-prefix stability); on
    *  close everything confirms. */
   private async submitTurn(turn: Turn, closing: boolean): Promise<void> {
-    const spanStart = turn.confirmedUpToMs;
+    // Never ask for audio the ring has already evicted. `cut` can only return what it still holds,
+    // so a span reaching further back yields RECENT audio under an OLD start time — the whole turn
+    // then lands at the wrong instant. Clamping to the oldest surviving frame keeps the claim and
+    // the samples the same age; audio older than the ring is gone and pretending otherwise is worse
+    // than admitting it.
+    const oldestRingMs = this.ring.length ? this.ring[0].tMs : turn.confirmedUpToMs;
+    const spanStart = Math.max(turn.confirmedUpToMs, oldestRingMs);
     // Open turns read to the LIVE AUDIO EDGE, not the last commit — pending
     // tracks speech in near-real-time and stability builds at tick cadence.
     // The trailing un-committed second may belong to the next speaker; the
@@ -563,7 +617,7 @@ export class ChunkedTranscriber {
     if (!closing && spanEnd - turn.lastSubmitEndMs < 500) return;
     turn.lastSubmitEndMs = spanEnd;
 
-    const pcm = this.cut(spanStart, spanEnd);
+    const { pcm, spans } = this.cut(spanStart, spanEnd);
     if (pcm.length < SAMPLE_RATE * 0.2 || rms(pcm) < DROP_RMS) {
       if (closing) await this.closeOut(turn);
       return;
@@ -583,11 +637,13 @@ export class ChunkedTranscriber {
       return;
     }
 
-    // Map whisper segments (relative to spanStart) to audio time.
+    // Map whisper segments from the CUT's timebase to wall time. Whisper describes the audio it was
+    // handed, which is the span minus its holes — so the two clocks agree only when the span was
+    // gapless, and `spans` is what carries the difference.
     const lang = this.cb.language || result!.language || 'en';
     const mapped = gated.map((ws) => {
-      const startMs = spanStart + (ws.start || 0) * 1000;
-      const rawEndMs = spanStart + (ws.end || 0) * 1000;
+      const startMs = this.wallTimeAt(spans, ws.start || 0, spanStart);
+      const rawEndMs = this.wallTimeAt(spans, ws.end || 0, spanStart, 'end');
       const endMs = Math.min(publishEnd, rawEndMs || publishEnd) || publishEnd;
       return {
         text: ws.text.trim(),

--- a/core/meetings/modules/mixed-pipeline/src/hole-timebase.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/hole-timebase.test.ts
@@ -1,0 +1,109 @@
+/**
+ * A transcript timestamp must be WALL time, even when the audio behind it has holes.
+ *
+ * `cut(t0,t1)` concatenates only the frames that exist, so a span containing a hole yields audio
+ * SHORTER than the span it claims to cover. Whisper then reports its segment times relative to that
+ * compressed audio, and mapping them as `spanStart + ws.start*1000` silently treats compressed time
+ * as wall time: every word after a hole is stamped early by the accumulated hole, and the error
+ * accumulates across a turn.
+ *
+ * This is not hypothetical and it is not a capture bug — capture always has SOME holes (a dropped
+ * buffer, a renegotiation, a gated silence). On the corpus entry `jitsi/2026-07-20-capture-gaps`,
+ * 108 of 183 recorded segmenter cuts land at a wall time where no audio was ever delivered.
+ * Consequences are downstream and expensive: turns open and close against the wrong instants, and
+ * the hint binder matches speaker names to a clock that has drifted, so attribution decays too.
+ *
+ * The fix keeps the audio compressed — sending Whisper a zero-filled hole invites it to hallucinate
+ * over the silence and costs STT time for nothing — and instead carries the cut's span layout, so
+ * compressed time maps back through the holes to the wall clock it came from.
+ *
+ *   tsx src/hole-timebase.test.ts
+ */
+import { ChunkedTranscriber, type BoundarySource } from './chunked-transcriber.js';
+import type { BoundaryEvent } from './pyannote-segmenter.js';
+import type { TranscriptionResult } from '@vexa/transcribe-whisper';
+
+const SR = 16000;
+let checks = 0;
+function ok(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`assertion failed: ${msg}`);
+  console.log(`  ✅ ${msg}`);
+  checks++;
+}
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+const seg = (text: string, start: number, end: number): any =>
+  ({ text, start, end, no_speech_prob: 0, avg_logprob: -0.1, compression_ratio: 1.0 });
+const result = (segs: any[]): TranscriptionResult =>
+  ({ text: segs.map((s) => s.text).join(' '), language: 'en', language_probability: 0.99, segments: segs } as any);
+
+// The session under test: speech, a 3s hole where no frame ever arrived, then speech again.
+//   wall 0–2000ms   audio   ─┐
+//   wall 2000–5000ms HOLE    │ cut(0,7000) returns 4s of audio for a 7s span
+//   wall 5000–7000ms audio  ─┘
+const HOLE_START_MS = 2000, HOLE_END_MS = 5000, SPAN_END_MS = 7000;
+
+async function main(): Promise<void> {
+  const published: Array<{ text: string; startMs: number; endMs: number }> = [];
+  let emit!: (ev: BoundaryEvent) => void;
+  let submittedSamples = 0;
+
+  // Whisper sees 4 seconds of audio and describes it in ITS OWN timebase: the second sentence
+  // begins at 2s into the audio it was handed — which is wall 5000ms, not wall 2000ms.
+  const SCRIPT = [
+    result([seg('before the hole', 0, 2), seg('after the hole', 2, 4)]),
+    result([seg('before the hole', 0, 2), seg('after the hole', 2, 4)]),
+    result([seg('before the hole', 0, 2), seg('after the hole', 2, 4)]),
+  ];
+  let i = 0;
+
+  const tc = await ChunkedTranscriber.create({
+    language: 'en',
+    transcribe: async (pcm: Float32Array) => { submittedSamples = pcm.length; return SCRIPT[Math.min(i++, SCRIPT.length - 1)]; },
+    publish: (_s, confirmed) => { for (const c of confirmed) published.push({ text: c.text, startMs: c.startMs, endMs: c.endMs }); },
+    publishPending: () => { /* drafts are not the oracle here */ },
+    clearPending: () => { /* */ },
+    rename: () => { /* */ },
+    makeSegmenter: (onBoundary) => { emit = onBoundary; return Promise.resolve<BoundarySource>({ appendFrame: async () => { /* */ }, reset() { /* */ } }); },
+    log: () => { /* */ },
+  });
+
+  emit({ kind: 'silence→speaker', tMs: 0, confidence: 0.9 });
+  // Two 1s frames before the hole…
+  for (let k = 0; k < 2; k++) { const a = new Float32Array(SR); a.fill(0.2); tc.feedAudio(a, k * 1000); await sleep(400); }
+  // …nothing at all across the hole — this is a hole, not silence: no frame ever arrived…
+  await sleep(400);
+  // …then two more 1s frames after it.
+  for (let k = 0; k < 2; k++) { const a = new Float32Array(SR); a.fill(0.2); tc.feedAudio(a, HOLE_END_MS + k * 1000); await sleep(400); }
+  emit({ kind: 'speaker→silence', tMs: SPAN_END_MS, confidence: 0.9 });
+  await tc.dispose();
+
+  console.log(`  submitted ${(submittedSamples / SR).toFixed(1)}s of audio for a ${(SPAN_END_MS / 1000).toFixed(1)}s span`);
+  for (const p of published) console.log(`    [${p.startMs}-${p.endMs}] ${JSON.stringify(p.text)}`);
+
+  ok(published.length > 0, 'the turn published something');
+  ok(submittedSamples <= SR * 4.5,
+    'the hole is NOT zero-filled — Whisper still receives only the audio that exists');
+
+  const after = published.find((p) => p.text.includes('after the hole'));
+  ok(!!after, 'the sentence after the hole was published');
+
+  // THE invariant: no published segment may start inside a window where no audio ever arrived.
+  for (const p of published) {
+    ok(!(p.startMs >= HOLE_START_MS && p.startMs < HOLE_END_MS),
+      `${JSON.stringify(p.text)} starts at ${p.startMs}ms — outside the hole ${HOLE_START_MS}-${HOLE_END_MS}ms`);
+  }
+
+  // …and specifically, the post-hole sentence lands after the hole, not shifted back into it.
+  ok(after!.startMs >= HOLE_END_MS - 250,
+    `the post-hole sentence starts at ${after!.startMs}ms, at or after the hole ends (${HOLE_END_MS}ms)`);
+
+  // The mirror invariant: the sentence BEFORE the hole must not be stretched across it either.
+  // Both edges land on the same run boundary and they resolve to opposite sides of it.
+  const before = published.find((p) => p.text.includes('before the hole'));
+  ok(!!before && before.endMs <= HOLE_START_MS + 250,
+    `the pre-hole sentence ends at ${before?.endMs}ms, at or before the hole opens (${HOLE_START_MS}ms)`);
+
+  console.log(`\n✅ hole-timebase: ${checks} checks passed — compressed audio time maps back to the wall clock it came from.`);
+}
+
+main().catch((e) => { console.error('❌', e); process.exit(1); });

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -270,19 +270,31 @@ export async function startCaptureBridge(
   const tee = makeTelemetryTap(lane, telemetry);
 
   // ── Node-side frame sink: one capture.v1 frame crossing the Playwright boundary. ──
-  // The page serializes PCM as a plain number[] (Array.from(Float32Array)); we restore the
-  // Float32Array and stamp the capture time if the page didn't supply one (production stamps
-  // Date.now() on the Node side — index.ts:1598–1605).
-  const onPerSpeakerAudio = (speakerIndex: number, samples: number[], tsMs?: number): void => {
-    const pcm = new Float32Array(samples);
+  // PCM crosses as base64, not as a number[]. A 4096-sample frame is 16.0 KB raw; JSON-encoding it
+  // as decimal numbers costs 80.8 KB — 5.05x — because every sample becomes a ~20-character string.
+  // At 4 frames a second that is 1.2 GB per hour per bot, and it is pure serialization: base64 of
+  // the same bytes is 21.3 KB, so the hop drops to 0.3 GB/hour for identical samples. The number[]
+  // form is still accepted, because a page from an older bundle can be mid-session.
+  const decodePcm = (samples: number[] | string): Float32Array => {
+    if (typeof samples !== 'string') return new Float32Array(samples);
+    const buf = Buffer.from(samples, 'base64');
+    // Copy rather than view: Buffer.from may hand back a slice of a pooled ArrayBuffer, whose
+    // byteOffset is not guaranteed 4-byte aligned for a Float32Array view.
+    const out = new Float32Array(buf.byteLength / 4);
+    Buffer.from(out.buffer).set(buf);
+    return out;
+  };
+
+  const onPerSpeakerAudio = (speakerIndex: number, samples: number[] | string, tsMs?: number): void => {
+    const pcm = decodePcm(samples);
     const ts = tsMs ?? Date.now();
     tee(speakerIndex, pcm, ts);                                 // O-TEL-1: tap BEFORE the pipeline
     if (mixed) pipeline.feedMixedAudio(pcm, ts);
     else pipeline.feedAudio(speakerIndex, undefined, pcm, ts); // glow name is bound page-side in the v1 producer; channel index here
   };
   // gmeet: the v1 producer stamps the glow name page-side; this named variant carries it through.
-  const onNamedAudio = (channel: number, glowName: string | undefined, samples: number[], tsMs?: number): void => {
-    const pcm = new Float32Array(samples);
+  const onNamedAudio = (channel: number, glowName: string | undefined, samples: number[] | string, tsMs?: number): void => {
+    const pcm = decodePcm(samples);
     const ts = tsMs ?? Date.now();
     tee(channel, pcm, ts, glowName);                            // O-TEL-1: tap BEFORE the pipeline
     pipeline.feedAudio(channel, glowName, pcm, ts);
@@ -319,6 +331,18 @@ export async function startCaptureBridge(
       // track into w.__vexaCapturedRemoteAudioStreams. Combine them into ONE live stream (an
       // AudioContext destination), keep connecting late-arriving tracks via a rescan (a participant
       // who speaks later), and feed that single mix to the mixed lane (pyannote re-separates speakers).
+      // Float32 PCM -> base64, chunked. String.fromCharCode.apply over a 16 KB frame exceeds the
+      // argument limit and throws, so the bytes are walked in slices; this runs 4x a second, so it
+      // stays a tight loop rather than a spread.
+      w.__vexaB64 = (pcm: Float32Array): string => {
+        const bytes = new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+        let bin = '';
+        for (let i = 0; i < bytes.length; i += 0x8000) {
+          bin += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + 0x8000)) as unknown as number[]);
+        }
+        return btoa(bin);
+      };
+
       const setupMix = (): void => {
         const streams = (w.__vexaCapturedRemoteAudioStreams || []) as Array<{ id: string }>;
         if (!streams.length) return;
@@ -344,7 +368,8 @@ export async function startCaptureBridge(
           // The gmeet lane has always logged its seen/emitted counters; this lane never did.
           Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(
             w.__vexaMixDest.stream,
-            (pcm: Float32Array) => w.__vexaPerSpeakerAudioData(0, Array.from(pcm)),
+            // base64, not Array.from: a decimal number[] is 5x the raw bytes over this hop.
+            (pcm: Float32Array) => w.__vexaPerSpeakerAudioData(0, w.__vexaB64(pcm)),
             { log: (m: string) => w.logBot?.('[mixed] ' + m) },
           ))
             .then((cap: any) => { w.__vexaMixedCapture = cap; return cap?.start?.(); })

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -338,7 +338,15 @@ export async function startCaptureBridge(
         }
         if (!w.__vexaMixedCapture && w.__vexaMixSeen.size && w.VexaBrowserUtils?.createMixedAudioCapture) {
           w.__vexaMixedCapture = true; // guard re-entry while the async create resolves
-          Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(w.__vexaMixDest.stream, (pcm: Float32Array) => w.__vexaPerSpeakerAudioData(0, Array.from(pcm))))
+          // `log` is not decoration here: capture reports how much audio the graph rendered against
+          // how much reached the callback and how much the silence gate refused. Without that split
+          // a missing 256 ms is unattributable — which is how a 35% capture deficit ran unnoticed.
+          // The gmeet lane has always logged its seen/emitted counters; this lane never did.
+          Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(
+            w.__vexaMixDest.stream,
+            (pcm: Float32Array) => w.__vexaPerSpeakerAudioData(0, Array.from(pcm)),
+            { log: (m: string) => w.logBot?.('[mixed] ' + m) },
+          ))
             .then((cap: any) => { w.__vexaMixedCapture = cap; return cap?.start?.(); })
             .then(() => w.logBot?.('[mixed] capture started over ' + w.__vexaMixSeen.size + ' stream(s)'))
             .catch((e: any) => { w.__vexaMixedCapture = null; w.logBot?.('[mixed] capture start failed: ' + String(e)); });

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -176,6 +176,11 @@ async function main(): Promise<void> {
       tc.recordHint(ev.hint.name, 'dom-active', ev.hint.t, ev.hint.isEnd);
     } else if (ev.frame) {
       tc.feedAudio(framePcm(ev.frame), ev.frame.ts);
+      // Yield between frames. feedAudio is synchronous, so a tight loop feeds the WHOLE session
+      // before the lane's async pump runs once — audio is evicted from the 120s ring before anything
+      // reads it, and the run scores the leftovers rather than the session. Yielding lets the pump
+      // interleave; the replay is still far faster than real time.
+      await sleep(0);
     }
   }
   // Closing the last turn is the harness standing in for the meeting ending — true for either cut
@@ -230,7 +235,12 @@ async function main(): Promise<void> {
       sttCalls, sttWords, sttFails,
       publishCalls: published.length, uniqueSegmentIds: byId.size,
       storeRows: storeRows.length, storeDupes,
-      retention: Number((txWords / Math.max(1, sttWords)).toFixed(3)),
+      publishedWords: txWords,
+      // Retention is only a LOSS metric against real STT. The mock invents fresh tokens per call,
+      // so every LocalAgreement resubmission of the same audio inflates the denominator with words
+      // that were never new — retention then measures resubmission overlap and calls it loss. It is
+      // recorded only when the words on both sides came from the same answer to the same audio.
+      ...(MOCK ? {} : { retention: Number((txWords / Math.max(1, sttWords)).toFixed(3)) }),
       coverage: Number((covered / wallSec).toFixed(3)),
       segments: published.length,
       segP50Sec: Number((durs[Math.floor(durs.length / 2)] ?? 0).toFixed(2)),

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -246,6 +246,14 @@ async function main(): Promise<void> {
       segP50Sec: Number((durs[Math.floor(durs.length / 2)] ?? 0).toFixed(2)),
       segUnder1s: durs.filter((d) => d < 1).length,
       holesOver2s: holes.length,
+      // The COST of LocalAgreement: a turn re-sends its whole unconfirmed span every pass, so the
+      // same audio is transcribed once per pass until it confirms. Two numbers say whether that is
+      // the designed price or a runaway — the ratio of audio sent to distinct audio covered, and the
+      // longest span any single submission reached. The tail is what a user feels as latency: on a
+      // live desktop session the p50 was 3 passes / 5.3s but the tail hit 11 passes / 35.0s, and a
+      // 35s window costs seconds of STT before a word can appear.
+      resendRatio: Number((submitSecs.reduce((a, b) => a + b, 0) / Math.max(1, covered)).toFixed(2)),
+      maxSubmitSec: Number(Math.max(0, ...submitSecs).toFixed(1)),
     }, null, 2) + '\n');
     console.log(`  metrics written: ${process.env.METRICS_JSON}`);
   }

--- a/docs/changelog.d/850-capture-bench.md
+++ b/docs/changelog.d/850-capture-bench.md
@@ -1,0 +1,7 @@
+### Added
+
+**Capture loss is reproducible with no meeting, no bot and no human.** `eval/src/capture-bench.mjs`
+drives the real `createMixedAudioCapture` in a real browser over a synthetic source whose silence
+structure and main-thread load are set by the bench, and reads the delivery counters. It settles
+which of the two mechanisms — the silence gate or the main-thread ScriptProcessor — actually omits
+audio, which no session recording can do on its own.

--- a/docs/changelog.d/850-capture-delivery-accounting.md
+++ b/docs/changelog.d/850-capture-delivery-accounting.md
@@ -1,0 +1,7 @@
+### Added
+
+**Mixed capture reports where the audio went.** The capture node now counts what the audio graph
+rendered against what the ScriptProcessor delivered and what the silence gate refused, and logs the
+split. A frame missing downstream was previously unattributable on this lane — the gmeet lane has
+always had its seen/emitted counters, the mixed lane had none, which is how a 35% capture deficit
+ran unnoticed on jitsi/zoom/teams bots.

--- a/docs/changelog.d/850-gate-off-green.md
+++ b/docs/changelog.d/850-gate-off-green.md
@@ -1,0 +1,5 @@
+### Fixed
+
+**Bot capture delivers the whole timeline again** — 65.0% → 99.9% duty cycle on the same chain, with
+the silence gate off. The segmenter stops firing spurious cuts (8.7× fewer, sub-second turns nearly
+gone) and every word gets a real speaker name instead of 16.7% landing under a provisional id.

--- a/docs/changelog.d/850-hole-timebase.md
+++ b/docs/changelog.d/850-hole-timebase.md
@@ -1,0 +1,12 @@
+### Fixed
+
+**A transcript timestamp is wall time, even when the audio behind it has holes.** The mixed lane
+concatenates only the frames that exist, so a span containing a hole yields audio shorter than the
+span it covers; Whisper's segment times were then read as if that compressed audio were the wall
+clock, stamping every word after a hole early by the accumulated hole. The cut now carries its span
+layout and maps back through it. The audio stays compressed — zero-filling a hole only invites the
+model to hallucinate over manufactured silence.
+
+A span is also no longer allowed to reach behind the audio ring: `cut` can only return what it still
+holds, so an over-long span returned recent audio under an old start time and put a whole turn at
+the wrong instant.

--- a/docs/changelog.d/850-pcm-wire.md
+++ b/docs/changelog.d/850-pcm-wire.md
@@ -1,0 +1,7 @@
+### Fixed
+
+**PCM crosses the bot's page→node hop as base64, not as a JSON number array.** A 4096-sample frame
+is 16.0 KB raw; encoding it as decimal numbers cost 80.8 KB — 5.05× — because every sample became a
+~20-character string. At four frames a second that is 1.2 GB per hour per bot of pure serialization
+overhead, which the silence-gate fix would otherwise have made continuous. Base64 of the same bytes
+is 21.3 KB, so the hop drops to 0.3 GB/hour, bit-exact.

--- a/docs/changelog.d/850-resend-cost.md
+++ b/docs/changelog.d/850-resend-cost.md
@@ -1,0 +1,6 @@
+### Added
+
+**The lane reports what LocalAgreement costs.** A turn re-sends its whole unconfirmed span on every
+pass, so the same audio is transcribed once per pass until it confirms. `resendRatio` (audio sent ÷
+distinct audio covered) and `maxSubmitSec` (the longest single submission) now ride in every corpus
+entry, because that tail is what a user feels as latency.

--- a/docs/changelog.d/850-silence-gate-off.md
+++ b/docs/changelog.d/850-silence-gate-off.md
@@ -1,0 +1,7 @@
+### Fixed
+
+**Mixed capture no longer discards time.** The peak-amplitude silence gate is off by default: a
+dropped frame does not drop audio, it drops the timeline everything downstream reconstructs meaning
+from. Measured on a real bot renderer, that gate accounted for the entire capture deficit while the
+ScriptProcessor delivered every buffer it was given. The cost it was paying for is already paid
+twice downstream, before Whisper and after it.


### PR DESCRIPTION
## PR 2 of the v0.12.17 delivery series — capture delivery (#850)

**Stacked on #869** (`feat/848-framework-corpus`, the eval-harness/corpus PR). Base is
`feat/848-framework-corpus` because A2/A3/A4 are scored by the corpus scorer that lands in #869.
**Retarget to `main` once #869 merges.**

Closes #850.

### The value

> A bot in a conference meeting receives the audio that is actually spoken — the mixed-capture
> chain now delivers **99.9%** of a continuous source (was **65.0%**), so the transcript is no
> longer shredded by holes the pipeline never created. Pays on jitsi + teams + zoom (shared path).

The losing hop was named by measurement, not inferred: a **silence gate on by default** in the
mixed-capture chain was discarding time on a continuous source. Turning it off is the fix
(`2c9b4b62`); the accounting instrument (`d12659ec`), the hole-tolerant timebase (`113b782f`),
and the base64 PCM wire (`7b8aef41`) are the supporting mechanism.

### Acceptance bundle (mapped to #850)

| # | Observation | Evidence |
|---|---|---|
| **A1** | Mechanism NAMED by measurement, not inferred — losing hop identified before the fix | `d12659ec` capture-accounting instrument (seen/emitted/deficit/gated counters) + `736a31f0` headless capture-bench that refutes the leading suspect. The named hop: silence gate on-by-default. |
| **A2** | Duty cycle **≥95%** on a continuous source (red: 65.0%) | **RED:** jitsi corpus entry `2026-07-20-capture-gaps` — duty cycle **0.650**, 199 gaps / 115.1s. **GREEN:** `37d8ec23` headless arm, corpus `jitsi/2026-07-20-gate-off` — **0.999**, 9 gaps / 1.9s, measured with no human. Live cross-check: handoff's live Zoom botsig4 duty **100.0%**. |
| **A3** | STT windows shift to p50 ≥2s, <1s ≤10%, filler drops | gate-off arm: inter-cut p50 0.41s → **1.47s**, cuts <1s 142 → 10, provisional words 16.7% → **0.0%**. Resend cost now a fixture too (`df03a1e6`: resendRatio/maxSubmitSec). |
| **A4** | The 65.0% fixture stays as permanent red; a later regression re-fails it | `2026-07-20-capture-gaps` retained in `core/meetings/eval/CORPUS.md` as the permanent red; the gate-off entry is its red→green pair. |
| **A-** | Negative control: extension path unchanged; gmeet per-channel untouched | Extension capture path and gmeet per-channel capture not touched by these commits. |

### Corpus entries (the red and the green)
- RED — `core/meetings/eval/CORPUS.md` → `jitsi/2026-07-20-capture-gaps` (65.0% duty, continuous YouTube source)
- GREEN — `core/meetings/eval/CORPUS.md` → `jitsi/2026-07-20-gate-off` (99.9%, `37d8ec23`, headless/no-human arm)
- Live product-surface cross-check — `zoom/2026-07-20-live-zoom` (duty 1.001, zero gaps >100ms in 269s)

### Commits (cherry-picked `-x` from `quality/0.12.17-base`, in order)
`d12659ec` → `113b782f` → `736a31f0` → `df03a1e6` → `2c9b4b62` → `37d8ec23` → `7b8aef41`.
`c0684af5` (instrument-defect rules) was SKIPPED — already carried by #869 as `e6c2852b`.

### Conflicts resolved
- `core/meetings/services/bot/src/quality-mixed.test.ts` (df03a1e6): kept the #850 content
  (`resendRatio` + `maxSubmitSec`; both `submitSecs`/`covered` exist here) and dropped the
  incidental `...attribution` spread — that came from `88424778` (#849 speaker-attribution,
  **not** in this pick list). No #850 semantics lost.
- `core/meetings/eval/CORPUS.md` (37d8ec23): both branches insert a corpus entry before
  `## The contract`; kept both — #869's `zoom/2026-07-20-live-zoom` and #850's
  `jitsi/2026-07-20-gate-off`.

### Validation
- `pnpm turbo build` — 17/17 successful.
- `node scripts/gates.mjs all` — **all green** (compose gate green after clearing a stale
  local container; a Docker-daemon race, not code).
- Leak check: `@vexa/zoom-capture` window ReferenceError from `84438cde` is **NOT present** —
  that commit was outside the pick list and did not leak.

### Changelog
7 fragments already ride the picked commits (`docs/changelog.d/850-*.md`) — the #850 story is
fully told; no extra fragment added.
