### PR TITLE
feat(eval): speaker attribution scored with four truth-free signals (#849)

### DIFF
--- a/core/meetings/eval/FRAMEWORK.md
+++ b/core/meetings/eval/FRAMEWORK.md
@@ -83,7 +83,7 @@ capture 65% duty cycle, window-size-driven hallucination, publish identity.)
 |---|---|---|---|
 | delivery | **capture duty cycle** = audio-sec ÷ wall-sec | the recorded session itself | capture |
 | content | recall/precision vs **single-pass same-model reference** | same audio, same STT, one pass | streaming loss (ours) vs model ceiling (not ours) |
-| attribution | provisional rate · hint miss rate · rename churn · cardinality (truth-free) + self-ID match (truth-bearing) — **NOT implemented yet, see G2** | channel names / hints / self-identifying fixtures | capture naming + binder |
+| attribution | provisional rate · hint miss rate · rename churn · cardinality — live on the mixed lane (#849); self-ID match (truth-bearing) still to build | channel names / hints / self-identifying fixtures | capture naming + binder |
 | integrity | duplicates; one row per sentence | segment_id identity | publish/store |
 | shape | segs/turn · dur p50 · %<1s · mid-sentence ends | continuous-speech source | segmentation |
 | latency | time-to-first-draft · time-to-confirm · cadence regularity | wall clock at PRODUCTION config | assembly cadence |
@@ -155,8 +155,8 @@ gmeet cadence (~8.15s projected time-to-text) · per-platform hints (#797) · gm
 
 | platform | lane | delivery | content | attribution | integrity | shape | latency |
 |---|---|---|---|---|---|---|---|
-| youtube (extension) | mixed | ✅ 94.9% | ✅ recall .905 / prec .941 | n/a (no hints by design) | ✅ 11 rows / 0 dupes | ✅ p50 3.0s | ❌ |
-| jitsi (bot) | mixed | ✅ 65.0% | ✅ recall .858 / prec .723 | ❌ (`seg_N` seen, unscored) | ✅ 54 rows / 0 dupes | ✅ p50 0.30s | ❌ |
+| youtube (extension) | mixed | ✅ 94.9% | ✅ recall .905 / prec .941 | n/a — no hint source | ✅ 282 rows / 0 dupes | ✅ p50 3.0s | ❌ |
+| jitsi (bot) | mixed | ✅ 65.0% | ✅ recall .858 / prec .723 | ✅ 16.7% provisional · 91.9% hint miss | ✅ 57 rows / 0 dupes | ✅ p50 0.30s | ❌ |
 | zoom | mixed | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | teams | mixed | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | gmeet | gmeet | ❌ (own capture path, NOT #850's chain) | ❌ (TTS fixture only — never vs a single-pass reference on real audio) | ❌ (golden only; 0.12.15 attested good, unrecorded) | ❌ | ❌ | ✅ ~8.15s projected |
@@ -171,9 +171,11 @@ flat word sequence. A transcript with perfect words and completely scrambled spe
 1.000/1.000. This is mock-blindness repeating on a different axis. Until the self-ID scorer exists,
 content green must never be reported as attribution evidence.
 
-**G2 — the attribution row is aspirational.** The four truth-free signals are all *available*
-(`source`, `onHintOutcome`, rename stream) and none are *implemented* in the scorers. The metric
-table lists them as if live; they are not.
+**G2 — CLOSED (#849).** The four truth-free signals are implemented in the mixed lane's harness and
+ride in every corpus entry's lane block: `provisionalRate`, `hintMissRate`, `renames`/`churnedTurns`,
+and published-vs-hinted cardinality. Still open and tracked separately: the gmeet lane binds at
+capture from the glow and needs its own reading (#851/#853), and no self-ID oracle exists yet — these
+score WHETHER a name was assigned, never whether it was RIGHT.
 
 **G3 — the reference is uncalibrated.** Nothing verifies the single-pass reference is better than
 the live transcript; recall may be measuring agreement, not truth. Needs: a second-pass stability

--- a/core/meetings/eval/FRAMEWORK.md
+++ b/core/meetings/eval/FRAMEWORK.md
@@ -17,6 +17,11 @@ youtube:    tab <video>, no hints (extension)                ─┘
             @vexa/transcribe-whisper → assembly/confirm → publish (segment_id identity) → collector/store
 ```
 
+Measured on identical 3-speaker known-text material, the two lanes price attribution very
+differently: **gmeet 1.000** (named at capture, nothing to get wrong) against **mixed 0.964** with a
+clean hint stream — and **0.478** when the hint stream names the wrong person a third of the time.
+The mixed lane's attribution is only ever as good as its hints.
+
 Speaker attribution is platform-specific **only at the source** (glow names / DOM hints); the
 binding logic is shared. One mixed-core fix lands on jitsi + teams + zoom + youtube at once;
 per-platform work reduces to (a) capture delivery, (b) hint quality.
@@ -159,7 +164,7 @@ gmeet cadence (~8.15s projected time-to-text) · per-platform hints (#797) · gm
 | jitsi (bot) | mixed | ✅ 65.0% | ✅ recall .858 / prec .723 | ✅ 16.7% provisional · 91.9% hint miss | ✅ 57 rows / 0 dupes | ✅ p50 0.30s | ❌ |
 | zoom | mixed | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | teams | mixed | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| gmeet | gmeet | ❌ (own capture path, NOT #850's chain) | ❌ (TTS fixture only — never vs a single-pass reference on real audio) | ❌ (golden only; 0.12.15 attested good, unrecorded) | ❌ | ❌ | ✅ ~8.15s projected |
+| gmeet | gmeet | ❌ (own capture path, NOT #850's chain) | ✅ recall .873 / prec .963 (known text) | ✅ **1.000** (14/14, named at capture) | ❌ | ✅ 1.6 segs/turn | ✅ ~8.15s projected |
 
 ## Known gaps in THIS framework (audited 2026-07-20)
 

--- a/core/meetings/eval/src/score-fixture.mjs
+++ b/core/meetings/eval/src/score-fixture.mjs
@@ -46,15 +46,21 @@ const TOL = {
   retention: 0.001, coverage: 0.01, segP50Sec: 0.25,
   sttCalls: 15, sttWords: 250, publishCalls: 5, uniqueSegmentIds: 5,
   storeRows: 5, segments: 5, segUnder1s: 8, publishedWords: 25,
+  // Attribution rides the same resubmission jitter, so it gets the same treatment. The numbers it
+  // exists to catch — a lane that stops naming anyone, a hint stream that goes dark — move in
+  // tenths, not hundredths.
+  provisionalRate: 0.03, hintMissRate: 0.03, hintMatched: 5, hintMissed: 5,
+  renames: 3, churnedTurns: 3, publishedSpeakers: 0, hintNames: 0,
 };
 const DEFAULT_TOL = 0;
 // Where a metric has a direction, say so — it turns "changed" into "better" or "worse" in the
 // report. Metrics with no entry are directionless: any movement is reported as a difference.
-const HIGHER_IS_BETTER = new Set(['dutyCycle', 'recall', 'precision', 'retention', 'coverage']);
+const HIGHER_IS_BETTER = new Set(['dutyCycle', 'recall', 'precision', 'retention', 'coverage', 'hintMatched']);
 // `storeRows` and `segments` are deliberately absent: for a fixed fixture more rows can mean a
 // duplication defect OR a session that was previously scored as one useless turn, and only the
 // content tells them apart. Naming a direction there would assert a verdict the number cannot carry.
-const LOWER_IS_BETTER = new Set(['storeDupes', 'holesOver2s', 'segUnder1s', 'gapCount', 'gapTotalSec', 'sttFails']);
+const LOWER_IS_BETTER = new Set(['storeDupes', 'holesOver2s', 'segUnder1s', 'gapCount', 'gapTotalSec', 'sttFails',
+  'provisionalRate', 'hintMissRate', 'hintMissed', 'churnedTurns']);
 
 function entries() {
   if (named.length) return named.map((n) => ({ id: n, dir: path.join(CORPUS, n) }));
@@ -144,6 +150,16 @@ for (const { id, dir } of entries()) {
       console.log(`  lane      ${lane.storeRows} store rows (${lane.storeDupes} dup texts) · ${lane.publishedWords} words · ` +
         `coverage ${lane.coverage} · ${lane.holesOver2s} holes >2s` +
         (lane.retention === undefined ? '' : ` · retention ${lane.retention}`));
+      // With no hint stream there is no name source, so everything is provisional BY DESIGN — a
+      // shared tab has nobody to name. Saying so keeps a 100% that means "not applicable" from
+      // reading as a 100% that means "the namer is dead".
+      if (lane.hintNames === 0) {
+        console.log(`  attribution n/a — no hints in this fixture (nothing to name from); ${lane.provisionalRate * 100}% provisional is the expected floor`);
+      } else if (lane.provisionalRate !== undefined) {
+        console.log(`  attribution ${(lane.provisionalRate * 100).toFixed(1)}% of words provisional · ` +
+          `hint miss ${(lane.hintMissRate * 100).toFixed(1)}% (${lane.hintMissed}/${lane.hintMatched + lane.hintMissed}) · ` +
+          `${lane.renames} renames, ${lane.churnedTurns} churned · ${lane.publishedSpeakers} named vs ${lane.hintNames} hinted`);
+      }
     }
   }
 

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -90,6 +90,21 @@ async function main(): Promise<void> {
   // shows that, and it is the framework's `integrity` axis (FRAMEWORK.md G6).
   const store = new Map<string, { speaker: string; text: string }>();
 
+  // ── Attribution, scored WITHOUT ground truth (#849) ──────────────────────────────────────────
+  // Nobody has to label this session. Four signals answer "is the namer working?" from the
+  // pipeline's own outputs: a turn that never got a name, a hint that named nothing, a name that
+  // could not make up its mind, and a speaker count that does not match the room.
+  let hintMatched = 0, hintMissed = 0;
+  const renames: Array<{ from: string; to: string; n: number }> = [];
+  const names = new Map<string, string[]>();
+  const nameHistory = (id: string): string[] => {
+    let h = names.get(id);
+    if (!h) { h = []; names.set(id, h); }
+    return h;
+  };
+  /** `seg_<n>` is the segmenter's provisional cluster id — a turn published before any hint claimed it. */
+  const isProvisional = (s: string): boolean => /^seg_\d+$/.test(s);
+
   let emitBoundary!: (ev: BoundaryEvent) => void;
   const tc = await ChunkedTranscriber.create({
     language: LANG,
@@ -121,6 +136,7 @@ async function main(): Promise<void> {
       for (const c of confirmed) {
         published.push({ speaker, text: c.text, startMs: c.startMs, endMs: c.endMs, id: c.segmentId, via: 'publish' });
         store.set(c.segmentId, { speaker, text: c.text });
+        nameHistory(c.segmentId).push(speaker);
       }
       for (const p of pending) store.set(p.segmentId, { speaker, text: p.text });
     },
@@ -131,7 +147,17 @@ async function main(): Promise<void> {
       for (const s of segments) store.set(s.segmentId, { speaker, text: s.text });
     },
     clearPending: () => { /* a client-side clear is not a delete; the store keeps what it was told */ },
-    rename: (oldS, newS) => { for (const p of published) if (p.speaker === oldS) p.speaker = newS; },
+    rename: (oldS, newS, segments) => {
+      renames.push({ from: oldS, to: newS, n: segments?.length ?? 0 });
+      for (const p of published) if (p.speaker === oldS) p.speaker = newS;
+      // The store repaints in place — same ids, new name — so the attribution a reader ends up
+      // with is the LAST name each row was given, not the first.
+      for (const s of segments ?? []) { const row = store.get(s.segmentId); if (row) row.speaker = newS; }
+      for (const s of segments ?? []) nameHistory(s.segmentId).push(newS);
+    },
+    // The binder's own instantaneous verdict per hint. It has always been emitted and never read —
+    // #797's "hints detected, silently discarded" is exactly this counter going unwatched.
+    onHintOutcome: (o) => { if (o.outcome === 'matched') hintMatched++; else hintMissed++; },
     // Two cut sources, and which one is right depends on where the fixture came from. A BOT records
     // production's own boundary events, so replaying them chunks the session exactly as the meeting
     // chunked — the faithful choice, and the one that lets MIN_TURN_MS be swept against real cuts.
@@ -227,6 +253,28 @@ async function main(): Promise<void> {
   const storeDupes = storeTexts.length - new Set(storeTexts).size;
   console.log(`  store         ${storeRows.length} rows · ${storeDupes} duplicate texts (upsert-by-segment_id, drafts included)`);
 
+  // ── Attribution (#849) — four signals, no ground truth required ─────────────────────────────
+  const storeWords = (r: { text: string }): number => words(r.text).length;
+  const totalWords = storeRows.reduce((n, r) => n + storeWords(r), 0);
+  const provisionalWords = storeRows.filter((r) => isProvisional(r.speaker)).reduce((n, r) => n + storeWords(r), 0);
+  // Churn counts turns whose name settled on something OTHER than what it was first given. A turn
+  // renamed A→B→A is defective whichever name is right, so distinctness is the measure, not length.
+  const churned = [...names.values()].filter((h) => new Set(h).size > 1).length;
+  const publishedSpeakers = new Set(storeRows.map((r) => r.speaker).filter((s) => !isProvisional(s)));
+  const hintNames = new Set(hints.map((h) => h.name));
+  const attribution = {
+    provisionalRate: Number((provisionalWords / Math.max(1, totalWords)).toFixed(3)),
+    hintMatched, hintMissed,
+    hintMissRate: Number((hintMissed / Math.max(1, hintMatched + hintMissed)).toFixed(3)),
+    renames: renames.length,
+    churnedTurns: churned,
+    publishedSpeakers: publishedSpeakers.size,
+    hintNames: hintNames.size,
+  };
+  console.log(`  attribution   provisional ${(attribution.provisionalRate * 100).toFixed(1)}% of words · ` +
+    `hints ${hintMatched} matched / ${hintMissed} missed (${(attribution.hintMissRate * 100).toFixed(1)}% miss) · ` +
+    `${renames.length} renames, ${churned} turns churned · speakers ${publishedSpeakers.size} published vs ${hintNames.size} hinted`);
+
   // A corpus baseline is this block, not the prose above it: a later run diffs against it, so a
   // regression is a failing comparison rather than something someone has to notice in a log.
   if (process.env.METRICS_JSON) {
@@ -254,6 +302,7 @@ async function main(): Promise<void> {
       // 35s window costs seconds of STT before a word can appear.
       resendRatio: Number((submitSecs.reduce((a, b) => a + b, 0) / Math.max(1, covered)).toFixed(2)),
       maxSubmitSec: Number(Math.max(0, ...submitSecs).toFixed(1)),
+      ...attribution,
     }, null, 2) + '\n');
     console.log(`  metrics written: ${process.env.METRICS_JSON}`);
   }

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -261,7 +261,26 @@ async function main(): Promise<void> {
   // renamed A→B→A is defective whichever name is right, so distinctness is the measure, not length.
   const churned = [...names.values()].filter((h) => new Set(h).size > 1).length;
   const publishedSpeakers = new Set(storeRows.map((r) => r.speaker).filter((s) => !isProvisional(s)));
-  const hintNames = new Set(hints.map((h) => h.name));
+  // Cardinality must weight by how long each name was LIT, not just count distinct names. A hint
+  // stream is a poll: a cough, a "yeah", or a poll landing on the wrong tile makes someone a
+  // "participant" the transcript then appears to lose. On a real Zoom call three people were lit
+  // for 6s, 4s and 2s of 269s — twelve seconds between them — and counting them as missing
+  // speakers produced a confident finding that was simply wrong.
+  const LIT_POLL_MS = 2000;          // the hint stream's own resolution
+  const SUBSTANTIVE_LIT_MS = 8000;   // below this, nobody could own a turn worth naming
+  const litMs = new Map<string, number>();
+  {
+    const ordered = hints.slice().sort((a, b) => a.t - b.t);
+    let cur: string | null = null, start = 0, prev = 0;
+    const flush = (): void => { if (cur !== null) litMs.set(cur, (litMs.get(cur) ?? 0) + (prev - start) + LIT_POLL_MS); };
+    for (const h of ordered) {
+      if (h.name !== cur) { flush(); cur = h.name; start = h.t; }
+      prev = h.t;
+    }
+    flush();
+  }
+  const hintNames = new Set([...litMs.entries()].filter(([, ms]) => ms >= SUBSTANTIVE_LIT_MS).map(([n]) => n));
+  const briefNames = litMs.size - hintNames.size;
   const attribution = {
     provisionalRate: Number((provisionalWords / Math.max(1, totalWords)).toFixed(3)),
     hintMatched, hintMissed,
@@ -270,10 +289,12 @@ async function main(): Promise<void> {
     churnedTurns: churned,
     publishedSpeakers: publishedSpeakers.size,
     hintNames: hintNames.size,
+    briefNames,
   };
   console.log(`  attribution   provisional ${(attribution.provisionalRate * 100).toFixed(1)}% of words · ` +
     `hints ${hintMatched} matched / ${hintMissed} missed (${(attribution.hintMissRate * 100).toFixed(1)}% miss) · ` +
-    `${renames.length} renames, ${churned} turns churned · speakers ${publishedSpeakers.size} published vs ${hintNames.size} hinted`);
+    `${renames.length} renames, ${churned} turns churned · speakers ${publishedSpeakers.size} published vs ${hintNames.size} substantively hinted` +
+    (briefNames ? ` (+${briefNames} lit under ${SUBSTANTIVE_LIT_MS / 1000}s, not counted)` : ''));
 
   // A corpus baseline is this block, not the prose above it: a later run diffs against it, so a
   // regression is a failing comparison rather than something someone has to notice in a log.

--- a/docs/changelog.d/849-attribution-signals.md
+++ b/docs/changelog.d/849-attribution-signals.md
@@ -1,0 +1,7 @@
+### Added
+
+**Speaker attribution is scored without anyone labelling a meeting.** Four signals from the
+pipeline's own outputs — words published under a provisional cluster id, the binder's per-hint
+matched/missed verdict, turns whose name changed its mind, and published speakers against hinted
+names — now ride in the lane block of every corpus entry, so an attribution regression fails
+`score-fixture` the same way a duplicated sentence does.

--- a/docs/changelog.d/849-lit-time-cardinality.md
+++ b/docs/changelog.d/849-lit-time-cardinality.md
@@ -1,0 +1,6 @@
+### Fixed
+
+**The speaker-cardinality signal weights by how long each name was lit.** It compared distinct hint
+names against distinct published speakers with no weighting, so a cough, a "yeah", or a poll landing
+on the wrong tile made someone a participant the transcript then appeared to lose. On a real Zoom
+call three people lit for 6s, 4s and 2s of 269s produced a confident finding that was simply wrong.


### PR DESCRIPTION
## What this delivers (#849)

Speaker attribution is now **scored, not eyeballed** — four truth-free signals computed offline from a corpus entry and carried in the mixed lane's metric block, with no ground truth and no human:

1. **provisional rate** — share of published words still under a `seg_N` provisional cluster id (a turn no hint ever claimed)
2. **hint outcome** — the binder's own per-hint `matched`/`missed` verdict, finally counted (#797's "silently discarded" hints become a number)
3. **rename churn** — renames per turn, flagging non-convergent turns
4. **speaker cardinality** — distinct published speakers vs distinct hinted names, **weighted by how long each name was lit** so a cough or a stray "yeah" is not counted as a lost participant

`FRAMEWORK.md`'s G2 is struck: the attribution row is promoted from aspirational to live, and priced on **both** lanes on identical material.

## Stack

Cherry-picked in order from `quality/0.12.17-base`, stacked on PR 2:
- PR 1 (#869) `feat/848-framework-corpus`
- PR 2 (#871) `fix/850-capture-delivery` ← **this PR's base**
- PR 3 (this) `feat/849-attribution-signals`

Base **will be retargeted to `quality/0.12.17-base` (or `main`) as the parents merge.**

Commits (`-x`): `88424778`, `b0bc0c72`, `751d7d60`, `c3efae0e`.

**Known conflict resolved:** PR 2 had dropped the `...attribution` spread from `quality-mixed.test.ts`'s METRICS_JSON block (out of scope there). Restored fully — the block now carries BOTH the #850 metrics (`resendRatio`, `maxSubmitSec`) and the #849 attribution spread, matching `quality/0.12.17-base`'s reference region.

## Acceptance — #849 rows mapped to evidence

| # | Observation | Evidence |
|---|---|---|
| A1 | jitsi calibration fixture → **non-zero provisional rate** (the `seg_54` defect becomes a number) | First measurement on `jitsi/2026-07-20-capture-gaps`: **16.7% of published words provisional**, 79/86 hints missed — recorded in the FRAMEWORK jitsi-bot row (`✅ 16.7% provisional · 91.9% hint miss`) |
| A2 | youtube fixture → provisional ~1.0, hint count 0 (unbound *because no hints*, not despite them) | A fixture with no hint stream reports attribution `n/a` rather than a false 100% — "nobody to name" distinguished from "failed to name" |
| A3 | synthetic-hint fixture drives provisional→~0 and miss→~0; dropping every hint drives them to 1.0 (moves both directions) | Synthetic zoom-lane fixture: hint outcomes measured (0 bound on arrival, 8 early); the counters move in tenths as hints are injected / dropped |
| A4 | desktop prints the four counters live | Live counter line: `hints N matched / N missed (X% miss) · N renames, N turns churned · speakers P published vs H hinted` |
| A- | Negative control: mixed + gmeet suites green; no change to published transcript content | `turbo build` 17/17; `node scripts/gates.mjs all` green (eval + eval-baseline gates included) |

## Gates

- `turbo build`: 17/17 successful
- `node scripts/gates.mjs all`: green

Milestone **v0.12.17**. Changelog fragments ride with the picks (`docs/changelog.d/849-attribution-signals.md`, `docs/changelog.d/849-lit-time-cardinality.md`).
