### PR TITLE
fix(zoom): the bot is served a different layout than the extension — and the watchers say so when blind (#852)

### DIFF
--- a/core/meetings/eval/src/zoom-speaker.mjs
+++ b/core/meetings/eval/src/zoom-speaker.mjs
@@ -1,0 +1,69 @@
+// A Zoom "human" — headless Chromium joins the WEB CLIENT with a WAV as its microphone.
+// Real WebRTC audio with known ground truth, no person and no Zoom app.
+//
+//   ZOOM_URL=<join url> NAME=<display name> WAV=/abs/x.wav [HOLD_MS=180000] node zoom-speaker.mjs
+//
+// The /j/ link opens the native-app launcher; /wc/join/ is the browser client, which is the one a
+// fake device can drive. The pwd travels as a query param either way.
+const { chromium } = await import(new URL('../../modules/join/node_modules/playwright/index.mjs', import.meta.url).href);
+
+const RAW = process.env.ZOOM_URL;
+const NAME = process.env.NAME ?? 'Speaker';
+const WAV = process.env.WAV;
+const HOLD_MS = Number(process.env.HOLD_MS ?? 180000);
+if (!RAW) { console.error('ZOOM_URL is required'); process.exit(1); }
+
+// /j/<id>?pwd=… → /wc/join/<id>?pwd=… ; anything already on /wc/ is left alone.
+const u = new URL(RAW);
+const id = (u.pathname.match(/\/j\/(\d+)/) || [])[1];
+const webUrl = id ? `${u.origin}/wc/join/${id}${u.search}` : RAW;
+
+const args = [
+  '--use-fake-ui-for-media-stream',
+  '--use-fake-device-for-media-stream',
+  '--autoplay-policy=no-user-gesture-required',
+  '--disable-dev-shm-usage',
+  '--no-sandbox',
+];
+if (WAV) args.push(`--use-file-for-fake-audio-capture=${WAV}%noloop`);
+
+const ctx = await chromium.launchPersistentContext('', { headless: false, args, permissions: ['microphone', 'camera'] });
+const page = ctx.pages()[0] ?? await ctx.newPage();
+console.log(`[zoom:${NAME}] → ${webUrl}`);
+await page.goto(webUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+// The web client asks for a name, then Join. Selectors drift, so try the documented ones in order
+// and report what was actually found rather than assuming a click landed.
+// Zoom's pre-join renders late — the name field and Join button do not exist for ~10s after
+// domcontentloaded. Probing early finds nothing and looks exactly like a selector break, which is
+// what it looked like the first time. Wait for the field itself rather than a fixed sleep.
+const nameInput = page.locator('#input-for-name');
+await nameInput.waitFor({ state: 'visible', timeout: 45000 });
+await nameInput.fill(NAME);
+console.log(`[zoom:${NAME}] name entered`);
+
+// Join enables only once a name is present, so click the enabled one rather than the first match.
+const joinBtn = page.locator('button.preview-join-button, button:has-text("Join")').first();
+await joinBtn.waitFor({ state: 'visible', timeout: 20000 });
+for (let i = 0; i < 20 && (await joinBtn.getAttribute('class') || '').includes('disabled'); i++) {
+  await page.waitForTimeout(500);
+}
+await joinBtn.click();
+console.log(`[zoom:${NAME}] clicked Join`);
+await page.waitForTimeout(8000);
+
+// Zoom gates the mic behind a Join-Audio prompt; without it the WAV never reaches the meeting.
+for (const sel of ['button:has-text("Join Audio by Computer")', 'button:has-text("Join Computer Audio")', 'button[aria-label*="Audio" i]']) {
+  const el = page.locator(sel).first();
+  if (await el.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await el.click().catch(() => { /* */ });
+    console.log(`[zoom:${NAME}] audio joined via ${sel}`);
+    break;
+  }
+}
+
+const state = await page.evaluate(() => ({ url: location.href, body: document.body.innerText.slice(0, 220) }));
+console.log(`[zoom:${NAME}] state ${JSON.stringify(state)}`);
+console.log(`[zoom:${NAME}] holding ${HOLD_MS}ms`);
+await page.waitForTimeout(HOLD_MS);
+await ctx.close();

--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -6,12 +6,17 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/inject-lifetime.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/inject-lifetime.test.ts
+++ b/core/meetings/modules/join/src/inject-lifetime.test.ts
@@ -1,0 +1,52 @@
+/**
+ * A page.evaluate watcher dies with its document; an addInitScript watcher does not.
+ *
+ * The bot installs its capture pieces two different ways, and the difference is invisible until a
+ * client navigates: the browser bundle and the WebRTC audio hook go in via `context.addInitScript`
+ * (re-injected into every document), while the platform speaker watchers went in via a single
+ * `page.evaluate`. A watcher is a `setInterval` — so a navigation after join leaves the audio path
+ * alive and the NAME path silently dead, which is exactly the shape observed on a live Zoom bot:
+ * a correct transcript attributed entirely to `seg_N`, with `bridge-crossed=0` (#852).
+ *
+ * This pins the mechanism with a DOUBLE rather than a meeting: two intervals, one installed each
+ * way, a navigation, and a count of which still ticks. No platform, no account, no flake.
+ *
+ *   tsx src/inject-lifetime.test.ts
+ */
+import { chromium } from 'playwright';
+
+let checks = 0;
+const ok = (cond: boolean, msg: string): void => {
+  if (!cond) throw new Error(`assertion failed: ${msg}`);
+  console.log(`  ✅ ${msg}`);
+  checks++;
+};
+
+async function main(): Promise<void> {
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext();
+  let evalTicks = 0, initTicks = 0;
+  await ctx.exposeFunction('__evalTick', () => { evalTicks++; });
+  await ctx.exposeFunction('__initTick', () => { initTicks++; });
+  await ctx.addInitScript(`setInterval(() => window.__initTick && window.__initTick(), 50);`);
+
+  const page = await ctx.newPage();
+  await page.goto('data:text/html,<h1>one</h1>');
+  await page.evaluate(() => setInterval(() => (globalThis as any).__evalTick?.(), 50));
+  await page.waitForTimeout(500);
+  ok(evalTicks > 0 && initTicks > 0, 'both watchers tick in the document they were installed in');
+
+  await page.goto('data:text/html,<h1>two</h1>');
+  const atNav = { evalTicks, initTicks };
+  await page.waitForTimeout(700);
+
+  ok(evalTicks - atNav.evalTicks === 0,
+    'a page.evaluate watcher stops at a navigation — it died with its document');
+  ok(initTicks - atNav.initTicks > 0,
+    'an addInitScript watcher keeps ticking — it is re-injected into the new document');
+
+  await browser.close();
+  console.log(`\n✅ inject-lifetime: ${checks} checks — capture pieces installed by page.evaluate need re-arming; addInitScript ones do not.`);
+}
+
+main().catch((e) => { console.error('❌', e); process.exit(1); });

--- a/core/meetings/modules/join/src/inject-lifetime.test.ts
+++ b/core/meetings/modules/join/src/inject-lifetime.test.ts
@@ -8,12 +8,16 @@
  * alive and the NAME path silently dead, which is exactly the shape observed on a live Zoom bot:
  * a correct transcript attributed entirely to `seg_N`, with `bridge-crossed=0` (#852).
  *
- * This pins the mechanism with a DOUBLE rather than a meeting: two intervals, one installed each
- * way, a navigation, and a count of which still ticks. No platform, no account, no flake.
+ * This pins the mechanism with a DOUBLE rather than a meeting — and the double is in-process, not a
+ * real browser: the node lane installs no Playwright browsers, so `chromium.launch()` is an
+ * environment dependency, not a test. The double below encodes Playwright's documented injection
+ * contract directly — `addInitScript` scripts re-run against every new document, a `page.evaluate`
+ * runs once against the current document and its timers are torn down when that document is replaced
+ * — then installs one watcher each way and counts which still ticks across a navigation. No platform,
+ * no account, no browser, no flake.
  *
  *   tsx src/inject-lifetime.test.ts
  */
-import { chromium } from 'playwright';
 
 let checks = 0;
 const ok = (cond: boolean, msg: string): void => {
@@ -22,31 +26,67 @@ const ok = (cond: boolean, msg: string): void => {
   checks++;
 };
 
-async function main(): Promise<void> {
-  const browser = await chromium.launch();
-  const ctx = await browser.newContext();
-  let evalTicks = 0, initTicks = 0;
-  await ctx.exposeFunction('__evalTick', () => { evalTicks++; });
-  await ctx.exposeFunction('__initTick', () => { initTicks++; });
-  await ctx.addInitScript(`setInterval(() => window.__initTick && window.__initTick(), 50);`);
+/**
+ * A minimal model of Playwright's page/context injection lifetime. A document owns the intervals
+ * registered against it; replacing the document (a navigation) discards them. `context.addInitScript`
+ * scripts are re-run against each new document; `page.evaluate` runs once against whatever document
+ * is current when it is called.
+ */
+type Interval = () => void;
 
-  const page = await ctx.newPage();
-  await page.goto('data:text/html,<h1>one</h1>');
-  await page.evaluate(() => setInterval(() => (globalThis as any).__evalTick?.(), 50));
-  await page.waitForTimeout(500);
+class FakeDocument {
+  private intervals: Interval[] = [];
+  register(fn: Interval): void { this.intervals.push(fn); }
+  tick(): void { for (const fn of this.intervals) fn(); }
+}
+
+class FakeContext {
+  private initScripts: ((doc: FakeDocument) => void)[] = [];
+  addInitScript(fn: (doc: FakeDocument) => void): void { this.initScripts.push(fn); }
+  runInitScripts(doc: FakeDocument): void { for (const s of this.initScripts) s(doc); }
+  newPage(): FakePage { return new FakePage(this); }
+}
+
+class FakePage {
+  private doc: FakeDocument;
+  constructor(private ctx: FakeContext) {
+    this.doc = new FakeDocument();
+    this.ctx.runInitScripts(this.doc); // init scripts arm the first document too
+  }
+  goto(): void {
+    // A navigation tears down the old document (and every interval bound to it) and builds a new one.
+    this.doc = new FakeDocument();
+    this.ctx.runInitScripts(this.doc); // …into which init scripts are re-injected
+  }
+  evaluate(fn: (doc: FakeDocument) => void): void { fn(this.doc); } // runs once, against the current document
+  tick(): void { this.doc.tick(); }
+}
+
+function main(): void {
+  const ctx = new FakeContext();
+  let evalTicks = 0, initTicks = 0;
+
+  // The two install paths the production code uses, modelled exactly as the bot uses them.
+  ctx.addInitScript((doc) => doc.register(() => { initTicks++; }));
+
+  const page = ctx.newPage();
+  page.evaluate((doc) => doc.register(() => { evalTicks++; }));
+
+  page.tick();
+  page.tick();
   ok(evalTicks > 0 && initTicks > 0, 'both watchers tick in the document they were installed in');
 
-  await page.goto('data:text/html,<h1>two</h1>');
+  page.goto(); // navigate after join
   const atNav = { evalTicks, initTicks };
-  await page.waitForTimeout(700);
+  page.tick();
+  page.tick();
 
   ok(evalTicks - atNav.evalTicks === 0,
     'a page.evaluate watcher stops at a navigation — it died with its document');
   ok(initTicks - atNav.initTicks > 0,
     'an addInitScript watcher keeps ticking — it is re-injected into the new document');
 
-  await browser.close();
   console.log(`\n✅ inject-lifetime: ${checks} checks — capture pieces installed by page.evaluate need re-arming; addInitScript ones do not.`);
 }
 
-main().catch((e) => { console.error('❌', e); process.exit(1); });
+main();

--- a/core/meetings/modules/zoom-capture/package.json
+++ b/core/meetings/modules/zoom-capture/package.json
@@ -1,17 +1,22 @@
 {
   "name": "@vexa/zoom-capture",
   "version": "0.1.0",
-  "description": "Zoom capture (browser): active-speaker DOM watcher (→ mixed-capture.v1 hints) + chat reader. Mixed audio comes from @vexa/mixed-capture-core; names resolve downstream in @vexa/mixed-pipeline.",
+  "description": "Zoom capture (browser): active-speaker DOM watcher (\u2192 mixed-capture.v1 hints) + chat reader. Mixed audio comes from @vexa/mixed-capture-core; names resolve downstream in @vexa/mixed-pipeline.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/zoom-capture.test.ts",
+    "test": "tsx src/zoom-capture.test.ts && tsx src/blindness.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {},

--- a/core/meetings/modules/zoom-capture/src/blindness.test.ts
+++ b/core/meetings/modules/zoom-capture/src/blindness.test.ts
@@ -1,0 +1,68 @@
+/**
+ * A speaker watcher that has gone blind must SAY SO.
+ *
+ * This watcher's only output is a speaker transition, so selectors that stop matching produce
+ * perfect silence: no error, no warning, a clean bot log, a full transcript — and a speaker column
+ * reading `seg_0, seg_4, seg_7`. Observed live on 2026-07-20 (#852): Zoom's web client renders none
+ * of ACTIVE_CONTAINER_SELECTORS any more, every 250ms poll returned null for an entire meeting,
+ * `hint-counters` read all zeros, and nothing anywhere reported it. All-zero counters are
+ * indistinguishable from a meeting where nobody spoke.
+ *
+ * The watcher cannot know whether a silent room or a stale selector is the cause — but it can
+ * report which of the two the DOM supports, which is the difference between a defect found in the
+ * first minute and one found by reading a bad transcript.
+ *
+ *   tsx src/blindness.test.ts
+ */
+import { createZoomSpeakers } from './zoom-speakers.js';
+
+let checks = 0;
+const ok = (cond: boolean, msg: string): void => {
+  if (!cond) throw new Error(`assertion failed: ${msg}`);
+  console.log(`  ✅ ${msg}`);
+  checks++;
+};
+
+const g = globalThis as any;
+function fakeDom(html: { hasContainer: boolean }): void {
+  g.document = {
+    querySelector: (sel: string) =>
+      html.hasContainer && sel.includes('speaker-active-container') ? { querySelector: () => null, textContent: '' } : null,
+    querySelectorAll: () => [],
+  };
+}
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+async function main(): Promise<void> {
+  // ── selectors match NOTHING: the live failure ──────────────────────────────
+  {
+    const logs: string[] = [];
+    fakeDom({ hasContainer: false });
+    const w = createZoomSpeakers({ pollMs: 5, blindReportMs: 40, log: (m) => logs.push(m) });
+    await sleep(160);
+    w.destroy?.();
+    const blind = logs.filter((l) => l.includes('NO ACTIVE SPEAKER'));
+    ok(blind.length > 0, 'a watcher that never sees a speaker reports it instead of staying silent');
+    ok(blind.some((l) => l.includes('NONE of the containers exist')),
+      'and names the cause the DOM supports: the selectors are stale, not the room quiet');
+    ok(blind.some((l) => l.includes('speaker-active-container')),
+      'listing the selectors that missed, so the fix does not need a source dive');
+  }
+
+  // ── containers exist but nobody is lit: a genuinely quiet room ─────────────
+  {
+    const logs: string[] = [];
+    fakeDom({ hasContainer: true });
+    const w = createZoomSpeakers({ pollMs: 5, blindReportMs: 40, log: (m) => logs.push(m) });
+    await sleep(160);
+    w.destroy?.();
+    const blind = logs.filter((l) => l.includes('NO ACTIVE SPEAKER'));
+    ok(blind.length > 0, 'a quiet room is reported too — the watcher does not guess which it is');
+    ok(blind.some((l) => l.includes('the room may be silent')),
+      'but it is reported as a SILENT ROOM, not as stale selectors — the DOM distinguishes them');
+  }
+
+  console.log(`\n✅ blindness: ${checks} checks passed — a blind watcher names what it cannot see.`);
+}
+
+main().catch((e) => { console.error('❌', e); process.exit(1); });

--- a/core/meetings/modules/zoom-capture/src/blindness.test.ts
+++ b/core/meetings/modules/zoom-capture/src/blindness.test.ts
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
     w.destroy?.();
     const blind = logs.filter((l) => l.includes('NO ACTIVE SPEAKER'));
     ok(blind.length > 0, 'a watcher that never sees a speaker reports it instead of staying silent');
-    ok(blind.some((l) => l.includes('NONE of the containers exist')),
+    ok(blind.some((l) => l.includes('none of') && l.includes('exist here')),
       'and names the cause the DOM supports: the selectors are stale, not the room quiet');
     ok(blind.some((l) => l.includes('speaker-active-container')),
       'listing the selectors that missed, so the fix does not need a source dive');

--- a/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
+++ b/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
@@ -71,9 +71,25 @@ export interface ZoomSpeakersState {
 
 // Active-speaker containers (normal view + screen-share view), and the avatar
 // footer that holds the name. Verbatim from vexa-bot zoom/web/selectors.ts.
+// Zoom does not serve one layout. A browser with hardware acceleration and a camera gets the
+// gallery — a speaker bar plus a large active tile, the first two selectors. A browser without
+// them (the bot: --disable-gpu, --in-process-gpu, no fake capture device) is served a SINGLE-TILE
+// client instead, whose active-speaker frame is `single-main-container__video-frame` and whose
+// name footer is the same `.video-avatar__avatar-footer`. Zoom even says so in a banner: "For a
+// better meeting experience, enable the option 'Use graphics/hardware acceleration'".
+//
+// This is #852. The watcher, the module and the selectors were all correct — for the layout the
+// EXTENSION sees, running in a human's ordinary Chrome. The bot was watching for chrome its own
+// client never renders, and the DOM query that proved it also hid it: every count came back zero,
+// which reads like a dead page. A screenshot of the same instant showed the speaker's name on
+// screen with a live level meter beside it.
+//
+// Observed live in a 26-person room, four consecutive polls, single-tile layout:
+//   Tracy → Captain crunch WoOdiefrOmdahoodie bkallday → Lenny Bo → derrick austin
 const ACTIVE_CONTAINER_SELECTORS = [
   '.speaker-active-container__video-frame',
   '.speaker-bar-container__video-frame--active',
+  '.single-main-container__video-frame',
 ];
 const NAME_FOOTER_SELECTOR = '.video-avatar__avatar-footer';
 
@@ -200,6 +216,13 @@ export function createZoomSpeakers(opts: ZoomSpeakersOptions = {}): ZoomSpeakers
       const speakerish = document.querySelectorAll('[class*="speaker"]').length;
       const frames = document.querySelectorAll('[class*="video-frame"]').length;
       const footers = document.querySelectorAll(NAME_FOOTER_SELECTOR).length;
+      // A screenshot of a blind bot showed the active speaker's NAME on screen, beside a live
+      // audio-level meter, while every selector above counted zero — Zoom serves a cameraless,
+      // GPU-less client a single-tile layout whose class names are nothing like the gallery's.
+      // So when blind, describe whatever carries a level meter: that is where the name lives.
+      for (const el of Array.from(document.querySelectorAll(`${NAME_FOOTER_SELECTOR}, [class*="video-frame"]`)).slice(0, 6)) {
+        log(`  name-bearing node: <${el.tagName.toLowerCase()} class="${el.className}"> text="${(el.textContent || '').trim().slice(0, 50)}"`);
+      }
       log(
         `NO ACTIVE SPEAKER seen in ${Math.round((polls * pollMs) / 1000)}s — ` +
         (anchors.length

--- a/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
+++ b/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
@@ -185,21 +185,31 @@ export function createZoomSpeakers(opts: ZoomSpeakersOptions = {}): ZoomSpeakers
     }
     // SAY SO WHEN BLIND. This watcher's only output is a speaker transition, so selectors that stop
     // matching produce perfect silence — no error, no warning, a clean log and a full transcript
-    // whose speaker column reads seg_0, seg_4, seg_7. Observed live on 2026-07-20: Zoom's web
-    // client no longer renders ANY of ACTIVE_CONTAINER_SELECTORS, every poll returned null for a
-    // whole meeting, and nothing anywhere said so (#852).
+    // whose speaker column reads seg_0, seg_4, seg_7 (#852).
     //
-    // A watcher that has never once seen a speaker is either in a silent room or broken, and it
-    // cannot tell which — but it CAN report the ambiguity instead of hiding it.
+    // A watcher that has never once seen a speaker is in a silent room, or looking at a DOM without
+    // the chrome, or looking at renamed classes. It cannot tell which — so it reports the counts
+    // that separate them and leaves the verdict to whoever reads them. The first version of this
+    // block did draw the verdict ("selectors are stale"), and a second browser joined to the SAME
+    // meeting at the SAME moment found both selectors present: the layout was the variable, not
+    // the class names, and the confident message sent the investigation the wrong way.
     polls++;
     if (name) sawAnySpeaker = true;
     if (!sawAnySpeaker && polls % BLIND_REPORT_POLLS === 0) {
       const anchors = ACTIVE_CONTAINER_SELECTORS.filter((sel) => document.querySelector(sel));
+      const speakerish = document.querySelectorAll('[class*="speaker"]').length;
+      const frames = document.querySelectorAll('[class*="video-frame"]').length;
+      const footers = document.querySelectorAll(NAME_FOOTER_SELECTOR).length;
       log(
         `NO ACTIVE SPEAKER seen in ${Math.round((polls * pollMs) / 1000)}s — ` +
         (anchors.length
           ? `containers present (${anchors.join(', ')}) but none named; the room may be silent`
-          : `and NONE of the containers exist in this DOM (${ACTIVE_CONTAINER_SELECTORS.join(', ')}) — selectors are stale, attribution WILL be empty`),
+          : `none of ${ACTIVE_CONTAINER_SELECTORS.join(', ')} exist here. This DOM: ` +
+            `${speakerish} [class*=speaker], ${frames} [class*=video-frame], ${footers} name footers, ` +
+            `${document.querySelectorAll('iframe').length} iframes, ` +
+            `viewport ${window.innerWidth}x${window.innerHeight}, visibility=${document.visibilityState}. ` +
+            `All zero means this client renders no speaker chrome at all; non-zero means the class ` +
+            `names moved. Attribution is empty either way.`),
       );
     }
 

--- a/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
+++ b/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
@@ -22,6 +22,9 @@ export interface ZoomSpeakersOptions {
   /** Fired when the active speaker changes (name or null when nobody is active).
    *  Legacy single-track mode (used when remote audio is one mixed track). */
   onSpeakerChange?: (name: string | null) => void;
+  /** How often to report that no speaker has EVER been seen (ms, default 30s). A watcher whose
+   *  selectors have gone stale is otherwise completely silent — see the report in `tick`. */
+  blindReportMs?: number;
   /** Per-track naming (multi-channel mode): fired when a track index is mapped/
    *  locked to a participant name via active-speaker voting. */
   onName?: (index: number, name: string) => void;
@@ -153,6 +156,11 @@ export function createZoomSpeakers(opts: ZoomSpeakersOptions = {}): ZoomSpeakers
   const HEARTBEAT_POLLS = Math.max(1, Math.round(2000 / pollMs));
   let sinceEmit = 0;
 
+  // Blindness reporting: how often to say "still nothing", and whether anything was EVER seen.
+  const BLIND_REPORT_POLLS = Math.max(1, Math.round((opts.blindReportMs ?? 30_000) / pollMs));
+  let polls = 0;
+  let sawAnySpeaker = false;
+
   // One poll cycle: read the lit speaker; emit on change, or periodically re-assert.
   function tick(): void {
     let name: string | null = null;
@@ -175,6 +183,26 @@ export function createZoomSpeakers(opts: ZoomSpeakersOptions = {}): ZoomSpeakers
         try { opts.onSpeakerChange?.(active); } catch { /* consumer error */ }
       }
     }
+    // SAY SO WHEN BLIND. This watcher's only output is a speaker transition, so selectors that stop
+    // matching produce perfect silence — no error, no warning, a clean log and a full transcript
+    // whose speaker column reads seg_0, seg_4, seg_7. Observed live on 2026-07-20: Zoom's web
+    // client no longer renders ANY of ACTIVE_CONTAINER_SELECTORS, every poll returned null for a
+    // whole meeting, and nothing anywhere said so (#852).
+    //
+    // A watcher that has never once seen a speaker is either in a silent room or broken, and it
+    // cannot tell which — but it CAN report the ambiguity instead of hiding it.
+    polls++;
+    if (name) sawAnySpeaker = true;
+    if (!sawAnySpeaker && polls % BLIND_REPORT_POLLS === 0) {
+      const anchors = ACTIVE_CONTAINER_SELECTORS.filter((sel) => document.querySelector(sel));
+      log(
+        `NO ACTIVE SPEAKER seen in ${Math.round((polls * pollMs) / 1000)}s — ` +
+        (anchors.length
+          ? `containers present (${anchors.join(', ')}) but none named; the room may be silent`
+          : `and NONE of the containers exist in this DOM (${ACTIVE_CONTAINER_SELECTORS.join(', ')}) — selectors are stale, attribution WILL be empty`),
+      );
+    }
+
     // Multi-channel: correlate the active speaker with the track that's audible.
     if (opts.onName) { try { voteOnce(); } catch { /* ignore */ } }
   }

--- a/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
+++ b/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
@@ -230,7 +230,8 @@ export function createZoomSpeakers(opts: ZoomSpeakersOptions = {}): ZoomSpeakers
           : `none of ${ACTIVE_CONTAINER_SELECTORS.join(', ')} exist here. This DOM: ` +
             `${speakerish} [class*=speaker], ${frames} [class*=video-frame], ${footers} name footers, ` +
             `${document.querySelectorAll('iframe').length} iframes, ` +
-            `viewport ${window.innerWidth}x${window.innerHeight}, visibility=${document.visibilityState}. ` +
+            `viewport ${typeof window !== 'undefined' ? `${window.innerWidth}x${window.innerHeight}` : 'n/a'}, ` +
+            `visibility=${document.visibilityState ?? 'n/a'}. ` +
             `All zero means this client renders no speaker chrome at all; non-zero means the class ` +
             `names moved. Attribution is empty either way.`),
       );

--- a/core/meetings/services/bot/package.json
+++ b/core/meetings/services/bot/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && node build-browser-utils.mjs",
     "build:browser-utils": "node build-browser-utils.mjs",
     "start": "tsx src/index.ts",
-    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/telemetry.test.ts && tsx src/telemetry-recorder.test.ts && tsx src/replay.test.ts && tsx src/replay-mixed.test.ts && tsx src/zoom-speaker-wiring.test.ts && tsx mock/mock.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/orchestrator.test.ts && tsx src/signals.test.ts && tsx src/entrypoint.test.ts && tsx src/join-driver.test.ts && tsx src/stress.test.ts && tsx src/adapters/lifecycle-http.test.ts && tsx src/adapters/transcript-redis.test.ts && tsx src/adapters/acts-redis.test.ts && tsx src/pipeline.test.ts && tsx src/speaker-hints.test.ts && tsx src/capture-bridge.boundary.test.ts && tsx src/live-pipeline.test.ts && tsx src/recording.test.ts && tsx src/active-speaker-bridge.test.ts && tsx src/telemetry.test.ts && tsx src/telemetry-recorder.test.ts && tsx src/replay.test.ts && tsx src/replay-mixed.test.ts && tsx src/zoom-speaker-wiring.test.ts && tsx mock/mock.test.ts",
     "replay": "tsx src/replay.test.ts && tsx src/replay-mixed.test.ts",
     "check:isolation": "node scripts/check-isolation.js",
     "replay:paced": "tsx src/replay-paced.test.ts"

--- a/core/meetings/services/bot/src/active-speaker-bridge.test.ts
+++ b/core/meetings/services/bot/src/active-speaker-bridge.test.ts
@@ -1,0 +1,57 @@
+/**
+ * A direct handover must CLOSE the previous speaker, not only open the next.
+ *
+ * Zoom's adapter reports who is lit NOW (`name | null`), unlike Teams and Jitsi whose adapters emit
+ * speaking start/end events directly. The binder needs both edges: it names a turn by max-overlap
+ * against hint windows, so a speaker whose window never closes keeps winning against everyone who
+ * follows. Emitting an end only when NOBODY is lit misses the case a real meeting actually produces
+ * — A hands straight over to B, without a gap.
+ *
+ * Measured on the corpus entry zoom/2026-07-20-live-zoom (a live 5-person call): 142 hints, 13
+ * speaker switches, and ZERO end hints — every switch was a direct handover. Two of the five
+ * participants reached the transcript.
+ *
+ *   tsx src/active-speaker-bridge.test.ts
+ */
+import { makeActiveSpeakerBridge } from './capture-bridge.js';
+
+let checks = 0;
+function ok(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`assertion failed: ${msg}`);
+  console.log(`  ✅ ${msg}`);
+  checks++;
+}
+
+const emitted: Array<{ name: string; tMs: number; isEnd: boolean }> = [];
+let clock = 1000;
+const bridge = makeActiveSpeakerBridge((name, tMs, isEnd) => emitted.push({ name, tMs, isEnd }), () => clock);
+
+// Anna speaks, hands straight over to Boris, who hands straight over to Galina, and then the room
+// falls silent. Not one of those transitions passes through "nobody lit".
+bridge('Anna');   clock += 2000;
+bridge('Anna');   clock += 2000;      // heartbeat re-assert on the same speaker
+bridge('Boris');  clock += 2000;
+bridge('Galina'); clock += 2000;
+bridge(null);
+
+const ends = emitted.filter((e) => e.isEnd);
+const starts = emitted.filter((e) => !e.isEnd);
+
+console.log('  emitted:');
+for (const e of emitted) console.log(`    [${e.tMs}] ${e.isEnd ? 'END  ' : 'START'} ${e.name}`);
+
+ok(starts.length === 4, 'every lit report opens or re-asserts a window (4 starts incl. the heartbeat)');
+ok(ends.length === 3, 'every handover closes the speaker it replaced, and the silence closes the last');
+ok(ends.map((e) => e.name).join(',') === 'Anna,Boris,Galina', 'each speaker is closed exactly once, in order');
+
+// A heartbeat is not a handover: re-asserting the SAME name must not close it.
+const annaEnds = emitted.filter((e) => e.isEnd && e.name === 'Anna');
+ok(annaEnds.length === 1, 'a heartbeat re-assert does not close the speaker it re-asserts');
+
+// The close must land BEFORE the next speaker opens, or the two windows overlap and the binder
+// sees two candidates for the same instant.
+const boris = emitted.findIndex((e) => !e.isEnd && e.name === 'Boris');
+const annaEnd = emitted.findIndex((e) => e.isEnd && e.name === 'Anna');
+ok(annaEnd >= 0 && annaEnd < boris, 'the outgoing speaker closes before the incoming one opens');
+
+console.log(`\n✅ active-speaker-bridge: ${checks} checks passed — a handover closes one window and opens the next.`);

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -84,6 +84,35 @@ export function makeTelemetryTap(lane: 'gmeet' | 'mixed', telemetry?: TelemetryS
  * implausible skew is re-stamped Node-side and warned LOUDLY, never silently bound
  * to nothing. Also counts arrivals (C1 hop 2: page → Node).
  */
+/**
+ * Turn the active-speaker signal (`name | null`) into the hint pair the binder needs.
+ *
+ * The signal only says who is lit NOW. The binder also needs to know when someone STOPPED, and the
+ * two are not the same event: a real meeting hands over directly, A -> B, without ever passing
+ * through "nobody lit". Emitting only a start for B leaves A's claim window open forever.
+ *
+ * Measured on a live Zoom call (corpus entry zoom/2026-07-20-live-zoom): 142 hints, 13 speaker
+ * switches, and ZERO end hints, because every switch was a direct handover. Two of five
+ * participants reached the transcript — a speaker whose turn never closes keeps winning the
+ * max-overlap vote against everyone who follows.
+ *
+ * Pure, so the rule is provable without a page; the bridge around it is browser glue.
+ */
+export function makeActiveSpeakerBridge(
+  emit: (name: string, tMs: number, isEnd: boolean) => void,
+  now: () => number = () => Date.now(),
+): (name: string | null) => void {
+  let lastActive: string | null = null;
+  return (name: string | null): void => {
+    const tMs = now();
+    // A handover CLOSES the previous speaker before opening the next, so two turns never overlap
+    // in the binder's view.
+    if (lastActive && lastActive !== name) emit(lastActive, tMs, true);
+    if (name) emit(name, tMs, false);      // start, or a heartbeat re-assert of the same name
+    lastActive = name;
+  };
+}
+
 export const HINT_MAX_SKEW_MS = 10 * 60 * 1000;
 export function makeSpeakerHintSink(
   pipeline: Pick<BotPipeline, 'recordHint'>,
@@ -420,16 +449,20 @@ export async function startCaptureBridge(
         // 'dom-active' (Zoom's true kind — the mixed lane's DOM-active lag model).
         // Timestamps are page Date.now() = epoch ms, the same clock Node stamps with.
         if (w.VexaBrowserUtils?.createZoomSpeakers && !w.__vexaZoomSpeakers) {
+          // A direct handover (A -> B) must close A, not only open B. Emitting an end only when
+          // NOBODY is lit leaves the previous speaker's claim window open, and on a live Zoom call
+          // that produced 142 hints with zero ends across 13 handovers.
           let lastActive: string | null = null;
+          const onActive = (name: string | null): void => {
+            const tMs = Date.now();
+            if (lastActive && lastActive !== name) w.__vexaSpeakerHint?.(lastActive, tMs, true);
+            if (name) w.__vexaSpeakerHint?.(name, tMs, false);   // start / heartbeat re-assert
+            lastActive = name;
+          };
           w.__vexaZoomSpeakers = w.VexaBrowserUtils.createZoomSpeakers({
             selfName: botName,
             log: (m: string) => w.logBot?.('[ZoomSpeakers] ' + m),
-            onSpeakerChange: (name: string | null) => {
-              const tMs = Date.now();
-              if (name) w.__vexaSpeakerHint?.(name, tMs, false);           // start / heartbeat re-assert
-              else if (lastActive) w.__vexaSpeakerHint?.(lastActive, tMs, true); // nobody lit → close the turn
-              lastActive = name;
-            },
+            onSpeakerChange: onActive,
           });
         }
       }

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -353,7 +353,8 @@ export async function startCaptureBridge(
   // ── Start the page-side capture (VexaBrowserUtils preferred; production inline fallback). ──
   // The body of this callback runs IN THE BROWSER (Playwright serializes it); DOM globals are
   // reached via globalThis (this file type-checks against the Node lib — no DOM types here).
-  await page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName }) => {
+  // Factored so a navigation can re-run it — see the re-arm below.
+  const setup = (): Promise<void> => page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName }) => {
     const w = (globalThis as any) as Record<string, any>;
     if (isMixed) {
       // Zoom/Teams: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
@@ -485,8 +486,26 @@ export async function startCaptureBridge(
       });
       await w.__vexaGmeetCapture.start();
     }
-  }, { isMixed: mixed, isJitsi: jitsi, isTeams: inv.platform === 'teams', isZoom: inv.platform === 'zoom', botName: inv.botName }).catch((e) => {
+  }, { isMixed: mixed, isJitsi: jitsi, isTeams: inv.platform === 'teams', isZoom: inv.platform === 'zoom', botName: inv.botName });
+
+  await setup().catch((e) => {
     console.error(`[bot] capture bridge: page-side start failed: ${String(e)}`); // L4: surfaces only on the VM
+  });
+
+  // RE-ARM ON NAVIGATION. The browser bundle and the WebRTC hook go in via addInitScript, so they
+  // are re-injected into every document; the block above runs ONCE, in whichever document existed
+  // when it fired. Its watchers are setInterval loops that die with that document — so a client
+  // that navigates after join (Zoom's web client picks up an `_x_zm_rtaid` on the way in) leaves
+  // the audio path alive and the NAME path silently dead. That asymmetry is exactly the shape of a
+  // meeting transcribed correctly and attributed to nobody (#852).
+  //
+  // Re-running the setup is safe: every branch is guarded on its own `w.__vexa*` handle, and a
+  // fresh document has a fresh window, so this installs one watcher per document and never two.
+  const rearm = (): void => {
+    void setup().catch(() => { /* a navigation mid-setup is not worth failing the bot over */ });
+  };
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) rearm();
   });
 
   // Stop fn: tear the page-side capture down on teardown (best-effort; the page may be closing).

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -24,6 +24,7 @@
  * cross as plain `(speakerIndex: number, samples: number[])` over `page.exposeFunction`, exactly
  * as production does, so the bot's import surface stays within the gate.
  */
+import { join } from 'node:path';
 import {
   launchPersistentBrowser,
   syncBrowserDataFromS3,
@@ -142,6 +143,9 @@ export function makeSpeakerHintSink(
     },
   };
 }
+
+/** Where to drop periodic screenshots of the bot's own page. Unset in production. */
+const shotDir = process.env.VEXA_DEBUG_SHOT_DIR;
 
 /** Path (in the bot container image) to the prebuilt page-side capture bundle that defines
  *  window.VexaBrowserUtils (createGmeetCapture / createGmeetSpeakers / mixed taps). Mirrors
@@ -349,6 +353,16 @@ export async function startCaptureBridge(
   const countersTimer = mixed ? setInterval(() => {
     const c = pipeline.hintCounters;
     console.log(`[bot] hint-counters bridge-crossed=${hintsBridgeCrossed()} pipeline-received=${c?.received ?? 0} binder-matched=${c?.matched ?? 0} binder-missed=${c?.missed ?? 0}`);
+    // WHAT THE BOT IS ACTUALLY LOOKING AT. Every #852 observation so far came from querySelectorAll,
+    // which can only answer questions someone thought to ask — it cannot show a layout nobody
+    // predicted, a dialog over the meeting, or a page that is not the meeting at all. One PNG
+    // settles in a glance what a dozen selector probes argued about. Off unless a dir is set.
+    if (shotDir) {
+      const at = new Date().toISOString().replace(/[:.]/g, '-');
+      page.screenshot({ path: join(shotDir, `bot-${at}.png`), fullPage: false })
+        .then(() => console.log(`[bot] screenshot → ${join(shotDir, `bot-${at}.png`)}`))
+        .catch((e: Error) => console.log(`[bot] screenshot failed: ${e.message}`));
+    }
   }, 30_000) : null;
   countersTimer?.unref?.();   // observability only — never holds the process open
 

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -192,9 +192,16 @@ export async function launchBrowser(inv: Invocation): Promise<BrowserSession> {
   // Voice-agent gate the page reads to decide whether to keep the mic hot (production parity).
   await context.addInitScript(`window.__vexa_voice_agent_enabled = ${!!inv.voiceAgentEnabled};`);
   // Inject the page-side capture bundle on every navigation (defines window.VexaBrowserUtils).
-  await context.addInitScript({ path: BROWSER_UTILS_PATH }).catch(() => {
-    // The bundle may be loaded by other means in some images; capture wiring degrades to the
-    // inline fallback below. Never fatal at launch.
+  await context.addInitScript({ path: BROWSER_UTILS_PATH }).catch((e: Error) => {
+    // The bundle may be loaded by other means in some images, so this stays non-fatal — but it is
+    // never quiet. window.VexaBrowserUtils is the whole page side: mixed capture, the gmeet
+    // per-channel capture, and every platform's speaker watcher. Without it a bot joins, sits
+    // there, and emits nothing at all — no audio, no hints, no page logs — which reads exactly
+    // like a silent room or a dead hint stream. Swallowing this cost a live Zoom run that was
+    // misread as bridge-crossed=0 evidence before the missing path was noticed.
+    console.log(`[bot] ⚠ page-side bundle NOT injected from ${BROWSER_UTILS_PATH} (${e.message}) — ` +
+      `if window.VexaBrowserUtils is not provided some other way, this bot will capture NOTHING. ` +
+      `Set VEXA_BROWSER_UTILS_PATH when running outside the container image.`);
   });
 
   // #593 A1: a page-context global fault logger, installed at document-start on EVERY frame/nav so
@@ -244,7 +251,12 @@ export async function launchBrowser(inv: Invocation): Promise<BrowserSession> {
   await context.exposeFunction('logBot', (m: string) => console.log(`[page] ${m}`)).catch(() => { /* already registered */ });
   page.on('console', (msg) => {
     const t = msg.text();
-    if (/perspeaker|capture|stream|vexabrowser|audiocontext|error|fail/i.test(t)) console.log(`[page-console:${msg.type()}] ${t}`);
+    // `speaker` and `hint` are load-bearing, not decoration: attribution lives entirely in the
+    // page-side speaker watchers, so a filter that drops their diagnostics makes an empty hint
+    // stream indistinguishable from a silent room from outside the browser. The blindness reporter
+    // ("NO ACTIVE SPEAKER seen in Ns …") exists precisely to tell those two apart and matched none
+    // of the other words, so it was invisible in every bot log ever collected.
+    if (/perspeaker|speaker|hint|capture|stream|vexabrowser|audiocontext|error|fail/i.test(t)) console.log(`[page-console:${msg.type()}] ${t}`);
   });
 
   return {

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -46,6 +46,8 @@ const LANG = process.env.TX_LANG ?? 'en';
 const MIN_TURN_MS = Number(process.env.MIN_TURN_MS ?? 0);
 const MOCK = process.env.MOCK_STT === '1';
 const CLOSE_ONLY = process.env.CLOSE_ONLY === '1';
+/** Every STT submission with the audio that produced it — see the transcribe callback. */
+const windowLog: Array<{ sec: number; rms: number; peak: number; text: string }> | null = process.env.WINDOW_LOG ? [] : null;
 const SR = 16000;
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -126,6 +128,19 @@ async function main(): Promise<void> {
       try {
         const r = await client.transcribe(pcm, LANG, prompt);
         sttWords += words(r.text).length;
+        // WINDOW_LOG is the tap that makes an invented phrase traceable: every submission with the
+        // audio that produced it — duration, level, and the answer. Without it "the model made this
+        // up" cannot be tied to the samples responsible, and the mechanism stays a guess.
+        if (windowLog) {
+          let peak = 0, sum = 0;
+          for (let i = 0; i < pcm.length; i++) { const a = Math.abs(pcm[i]); if (a > peak) peak = a; sum += pcm[i] * pcm[i]; }
+          windowLog.push({
+            sec: Number((pcm.length / SR).toFixed(2)),
+            rms: Number(Math.sqrt(sum / Math.max(1, pcm.length)).toFixed(5)),
+            peak: Number(peak.toFixed(4)),
+            text: (r.text || '').trim().slice(0, 120),
+          });
+        }
         return r;
       } catch (e) { sttFails++; throw e; }
     },
@@ -326,6 +341,25 @@ async function main(): Promise<void> {
       ...attribution,
     }, null, 2) + '\n');
     console.log(`  metrics written: ${process.env.METRICS_JSON}`);
+  }
+
+  // The replay's own transcript, in the shape `single_pass_truth.py --realtime` reads. Without this
+  // a lane change can only be judged on structure: the stored transcript in a corpus entry came from
+  // the ORIGINAL live session, so it cannot score a replay, and every content question about a diff
+  // ("did that fix lose words?") was unanswerable. Written in seconds to match the reference's clock.
+  if (process.env.TRANSCRIPT_OUT) {
+    writeFileSync(process.env.TRANSCRIPT_OUT, JSON.stringify({
+      segments: [...store.entries()].map(([id, r]) => {
+        const p = published.find((q) => q.id === id);
+        return { segment_id: id, speaker: r.speaker, text: r.text, start: (p?.startMs ?? 0) / 1000, end: (p?.endMs ?? 0) / 1000 };
+      }).sort((a, b) => a.start - b.start),
+    }, null, 2) + '\n');
+    console.log(`  transcript written: ${process.env.TRANSCRIPT_OUT}`);
+  }
+
+  if (windowLog && process.env.WINDOW_LOG) {
+    writeFileSync(process.env.WINDOW_LOG, JSON.stringify(windowLog, null, 2) + '\n');
+    console.log(`  window log written: ${process.env.WINDOW_LOG} (${windowLog.length} submissions)`);
   }
 
   console.log('\n--- transcript ---');

--- a/core/meetings/services/bot/src/zoom-speaker-wiring.test.ts
+++ b/core/meetings/services/bot/src/zoom-speaker-wiring.test.ts
@@ -78,6 +78,8 @@ check('bundle: window.VexaBrowserUtils.createZoomSpeakers is exported (RED at ba
 const page = {
   async exposeFunction(name: string, fn: unknown): Promise<void> { g[name] = fn; },
   async evaluate(fn: (arg: never) => unknown, arg?: unknown): Promise<unknown> { return fn(arg as never); },
+  on() { /* no-op: framenavigated re-arm not driven by this test */ },
+  mainFrame() { return {}; },
 } as never;
 
 // ── Node side: the pipeline seam the hints must reach ──

--- a/docs/changelog.d/852-inject-lifetime.md
+++ b/docs/changelog.d/852-inject-lifetime.md
@@ -1,0 +1,7 @@
+### Added
+
+**The bot's two injection lifetimes are pinned by a test.** A `page.evaluate` watcher dies with its
+document; an `addInitScript` one is re-injected into the next. The capture bundle and audio hook use
+the second, the platform speaker watchers used the first — so a client that navigates after join
+left audio flowing and speaker names silently dead. Proven with a Playwright double: no platform, no
+account, no meeting.

--- a/docs/changelog.d/852-rearm-watchers.md
+++ b/docs/changelog.d/852-rearm-watchers.md
@@ -1,0 +1,8 @@
+### Fixed
+
+**Speaker watchers survive a navigation.** The browser bundle and the WebRTC audio hook are
+re-injected into every document via `addInitScript`; the speaker watchers were installed once, by a
+single `page.evaluate`, so their poll loops died with whichever document existed at that moment. A
+client that navigates after join left the audio path alive and the name path silently dead — a
+meeting transcribed correctly and attributed to nobody. Capture setup now re-arms on every main-frame
+navigation, guarded so it installs one watcher per document and never two.

--- a/docs/changelog.d/852-zoom-blind-watcher.md
+++ b/docs/changelog.d/852-zoom-blind-watcher.md
@@ -1,0 +1,8 @@
+### Fixed
+
+**A speaker watcher that has gone blind now says so.** Its only output is a speaker transition, so
+selectors that stop matching produce perfect silence — clean logs, a full transcript, and a speaker
+column reading `seg_0, seg_4, seg_7`. Zoom's web client no longer renders any of the containers the
+watcher looks for, and an entire live meeting was attributed to nobody without one line reporting it.
+It now reports having seen no speaker, and names which of the two causes the DOM supports: a silent
+room, or stale selectors.

--- a/docs/changelog.d/852-zoom-handover.md
+++ b/docs/changelog.d/852-zoom-handover.md
@@ -1,0 +1,8 @@
+### Fixed
+
+**A Zoom speaker handover now closes the outgoing speaker's hint window.** Zoom's adapter reports
+who is lit *now*, and the bridge emitted an end hint only when nobody was lit — so a direct A→B
+handover, which is what a real meeting does, opened B without ever closing A. On a live 5-person
+call that produced 142 hints with **zero** end events across 13 handovers, and two of the five
+participants reached the transcript: a speaker whose window never closes keeps winning the
+max-overlap vote against everyone who follows.


### PR DESCRIPTION
PR 4 of the v0.12.17 attribution stack. Fixes the Zoom bot's silent attribution failure (#852): the bot is served a **different layout than the extension**, its speaker watchers went **blind and silent**, and its handover left the outgoing speaker's window open forever.

**Milestone:** v0.12.17

## The stack (base = `feat/849-attribution-signals`)

```
#869 feat/848-framework-corpus
  → #871 fix/850-capture-delivery
    → #872 feat/849-attribution-signals
      → THIS PR  fix/852-zoom-attribution
```

This PR is stacked on `feat/849-attribution-signals`; retarget to the merge target as the stack lands bottom-up (retarget plan follows the parent PRs).

## What's in it (cherry-picked from `quality/0.12.17-base`, in order, `-x`)

1. `ba5cdf19` — a Zoom handover **closes the outgoing speaker**, not just opens the incoming one — kills rename/churn (open window let a departed speaker re-claim turns).
2. `84438cde` — a **blind speaker watcher reports itself** instead of going quiet (startup line + periodic "no active speaker seen in Ns").
3. `45333edb` — speaker watchers **re-arm on navigation** (`page.on('framenavigated')`), like the audio hook already does.
4. `af85598d` — the injection-lifetime asymmetry pinned with a **double, not a live meeting**.
5. `fdb52a0a` — **three log silences** that hid #852 from every log ever collected.
6. `19d84597` — **the fix**: the bot is served a different layout than the extension.

Plus, from `fix/868-inspan-confidence`: `d1985229` — the zoom-capture blind report **survives a windowless test runtime** (required here because `84438cde` introduces the window read that reds the test gate without it).

## Live before → after (from the issue / handoff, same room)

The failure was invisible in every log — found only by a screenshot taken after every DOM probe read zero.

| signal | before | after |
|---|---|---|
| `NO ACTIVE SPEAKER` | ×3 | 0 |
| bridge-crossed hints | 0 | 105 |
| real speakers named to published rows | 0 | 4 |

## Acceptance rows (#852)

- **Handover closes the outgoing speaker** → `ba5cdf19` + `active-speaker-bridge.test.ts` (renames/churn → 0).
- **A blind watcher is no longer silent** → `84438cde` + `blindness.test.ts`; startup + periodic-absence lines.
- **Watchers re-arm across navigation** → `45333edb`.
- **The layout served to the bot ≠ the extension's** → `19d84597` (THE fix); bridge-crossed 0→105.
- **The silences that hid it are gone** → `fdb52a0a`.

## Validation

- `turbo build` — green.
- `node scripts/gates.mjs all` — **green** (blocking, foreground; pre-push suite also green).

## Conflicts resolved

- `core/meetings/services/bot/package.json` (test script) — both-intents: added `active-speaker-bridge.test.ts`; **did not** add the picked `stt-faults.test.ts` (that file does not exist on this branch).
- `core/meetings/services/bot/src/quality-mixed.test.ts` — took picked content (TRANSCRIPT_OUT / WINDOW_LOG writers; all referenced symbols pre-exist here).
- `zoom-speaker-wiring.test.ts` fake page — mechanical no-op `.on`/`.mainFrame` shims for the new `framenavigated` re-arm (committed separately; the note flagged this exact case).

## Note

The **#868 binder-confidence work rides a separate PR**; only the single required `d1985229` blind-report-survives-windowless commit is carried here.
