### PR TITLE
feat(eval): a live transcript scored against KNOWN truth — words and speakers, no meeting required (#854)

### DIFF
--- a/core/meetings/eval/AGENTS.md
+++ b/core/meetings/eval/AGENTS.md
@@ -48,6 +48,56 @@ hit the **production API** (`secrets.env`) and put bots in a **real meeting**.
 5. 🤖 `replay <tape> REPLAY_PLATFORM=teams` → the same data exercises the Teams path
    (a tape is platform-agnostic: mixed audio + hints).
 
+## The two-leg witness — quality first, then speakers
+
+A platform is proven by two runs that answer different questions, and mixing them is how a
+green run hides a dead half. **Leg 1 asks "are the words right?"** through the extension, the
+path a customer actually uses. **Leg 2 asks "are the names right?"** through the bot, which is
+the only thing the bot uniquely carries and the only place #852 lives. Leg 2 is SHORT — 90s is
+enough to see hints crossing the bridge — because it is not measuring content.
+
+Both legs speak the same known truth, so neither depends on an STT reference:
+
+```bash
+RIG=~/vexa-test-rig
+python3 src/build_truth_wav.py --speaker A --name Anna  --out $RIG/truth   # 269s · 827 words
+python3 src/build_truth_wav.py --speaker B --name Boris --out $RIG/truth   # 187s · 643 words
+```
+
+**Leg 1 — quality (extension).** Put the synthetic speakers in the room, then capture:
+
+```bash
+ZOOM_URL=<url> NAME=Anna  WAV=$RIG/truth/Anna.wav  HOLD_MS=300000 node src/zoom-speaker.mjs &
+ZOOM_URL=<url> NAME=Boris WAV=$RIG/truth/Boris.wav HOLD_MS=300000 node src/zoom-speaker.mjs &
+# each prints AUDIO_START=<epoch> — clip offset zero, needed below
+```
+> 🧑 Join the same meeting in **Chrome**, **click the Vexa toolbar icon on that tab**, then
+> **Start**. That click is not optional and never will be: `chrome.tabCapture.getMediaStreamId`
+> needs an activeTab grant, and only a toolbar click / context menu / keyboard command produces
+> one (`clients/extension/src/background.ts:538`). `extension-loop.mjs` drives everything else,
+> but it cannot produce that gesture — it waits for it and says so.
+
+```bash
+python3 src/score_truth.py --truth $RIG/truth/Anna.truth.json@<epoch> \
+                           --truth $RIG/truth/Boris.truth.json@<epoch> \
+                           --transcript http://localhost:8056/transcripts/zoom/<native>
+```
+
+**Leg 2 — speakers (bot).** Same meeting, same speakers still talking, 90 seconds:
+
+```bash
+curl -s -X POST localhost:18156/bots -H "X-API-Key: $KEY" -H 'content-type: application/json' \
+  -d '{"platform":"zoom","native_meeting_id":"<native>","bot_name":"vexa-witness"}'
+docker logs -f <bot> 2>&1 | grep -E 'bridge-crossed|NO ACTIVE SPEAKER|hint'
+```
+`bridge-crossed=0` **with** `NO ACTIVE SPEAKER seen in Ns` ⇒ the DOM never lit anyone (a silent
+room or stale selectors). `bridge-crossed=0` **without** it ⇒ the watchers saw speakers and the
+hints died crossing into node — the injection-lifetime half. That discriminator is the whole
+point of the 90 seconds.
+
+Teams runs the same two legs with `src/teams-speaker.mjs` (`TEAMS_URL=`) — the extension matches
+`teams.microsoft.com` and the lane is the same mixed one.
+
 ## 🧑 HUMAN-IN-THE-LOOP — when to STOP and prompt
 The agent **cannot** drive the browser, mint capture permissions, or admit bots. At
 these moments, stop and give the human the prompt **verbatim**, then wait for "ok".

--- a/core/meetings/eval/CORPUS.md
+++ b/core/meetings/eval/CORPUS.md
@@ -176,6 +176,52 @@ more than the 12.8% loss it reports. The delivery figure above is unaffected.
 ¹ harness-relative — comparable only against the same fixture's own baseline, never read as the
 share of a meeting the lane covers. See the note above the entries.
 
+## The synthetic entry that needs no session at all
+
+Every entry above is a recording, so every one of them cost a meeting. One does not:
+`speech_fixture.py` builds the mixed lane's whole input — PCM frames plus DOM hints — out of the
+cached TTS clips, whose text is known before any audio exists. There is no reference to calibrate
+and no clock to get wrong; the truth is absolute, and the fixture regenerates byte-identically from
+its seed instead of living on disk.
+
+That makes it the one place where "is the quality good?" is answerable with no person, no platform
+and no live room — and the mixed lane it exercises is the same one Zoom and Teams both ride.
+
+```bash
+python3 src/speech_fixture.py --speakers A,B --turns 8 --lane mixed --platform zoom --out /tmp/zoomlane
+# → 450 frames · 16 hints · 8 turns · 95.5s · 315 known words · Anna,Boris · hint lag 250ms
+
+cd ../services/bot && QUALITY_MIXED_FIXTURE=/tmp/zoomlane.captured-signal.jsonl REAL_SEGMENTER=1 \
+  TRUTH_JSON=/tmp/zoomlane.truth.json TRANSCRIPT_OUT=/tmp/zoomlane.replay.json \
+  TX_URL=$TRANSCRIPTION_SERVICE_URL TX_TOKEN=$TRANSCRIPTION_SERVICE_TOKEN TX_MODEL=whisper-1 \
+  npx tsx src/quality-mixed.test.ts
+
+python3 src/score_replay.py /tmp/zoomlane.replay.json --truth /tmp/zoomlane.truth.json
+```
+
+Measured 2026-07-20 at `9d9a1cee` — real STT (`whisper-1`), real pyannote segmenter, production lane
+config. **Three consecutive runs returned identical figures to three decimals**, down to the STT call
+count (18) and the words it returned (350): fixed audio through fixed cut points is deterministic
+even across a remote model. The tape entries are not — theirs swing 429-440 calls — so this is the
+only entry whose tolerances are zero:
+
+| | |
+|---|---|
+| content recall | **0.924** — 291 of 315 known words kept, in order |
+| content precision | **0.936** — 20 published words that were never said |
+| attribution accuracy | **0.947**, 0 wrong, 1.0% of words provisional |
+| coverage · retention | 0.825 · 0.869 |
+| structure | 19 segments · 0 duplicate texts · 1 hole >2s · 18 STT calls, 0 failed |
+
+Read it for exactly what it is. It starts at `captured-signal.v1`, so it says nothing about whether
+capture delivered the audio (that is the delivery block, and the live legs) or whether the platform's
+DOM lit the right names (that is #852, and the bot leg). It says that GIVEN the signal, the lane
+keeps 92% of the words and names them right 95% of the time — any hour of any day, nobody in the room.
+
+Unlike the recorded entries, precision here charges STT error as invention: `Boris` came back as
+`Doris`, and one phrase arrived that nobody said. That is the model's ceiling rather than the lane's
+loss, and the two are only separable because the truth is known.
+
 ## The contract
 
 1. A defect is only worked against an entry in this corpus — no fixture, no fix.

--- a/core/meetings/eval/CORPUS.md
+++ b/core/meetings/eval/CORPUS.md
@@ -62,6 +62,13 @@ published words 2746–2750 — but STT call count 429–440. Structure is stabl
 figures are not, and `score-fixture` tolerances them from that spread. What the corpus exists to
 catch moves far further: reverting `4c030cd8` takes `storeDupes` from 0 to 11.
 
+**Content scoring needs a high duty cycle to mean anything.** The reference is built from the
+session's DELIVERED audio, so every capture hole becomes a splice the model reads across. Two
+references over identical audio, cuts shifted 25s apart (`--chunk-offset-sec`), disagree by **4.4%**
+on the youtube control (duty 0.949) and by **23.9%** on the jitsi capture-gaps entry (duty 0.650) —
+where the instrument is noisier than the 12.8% it is measuring. **Do not cite content figures from a
+low-duty entry.** Delivery figures are unaffected: those come from the bytes, not from a model.
+
 **`retention` is recorded only against real STT.** A mock that invents fresh tokens per call turns
 every LocalAgreement resubmission of the same audio into denominator it never lost, so retention
 under a mock measures resubmission overlap and calls it loss.
@@ -80,7 +87,7 @@ control, delivered through the bot's webrtc-hook chain instead. Recorded at `5b1
 |---|---|
 | delivery | **duty cycle 0.650** · 199 gaps totalling 115.1s · p50 0.40s · max 4.37s |
 | shape | inter-cut p50 0.41s · 142 cuts under 1s · silent frames 10.2% |
-| content | recall 0.872 · **precision 0.723** (whisper-1, single pass) |
+| content | recall 0.872² · **precision 0.723²** (whisper-1, single pass) |
 | lane | 57 store rows · 0 dup texts · 239 words · coverage 0.467¹ · 5 holes >2s |
 
 This is the red evidence for **#850**. Paired with the control it is also the framework's sharpest
@@ -97,7 +104,7 @@ hole is a defect by construction. Derived from a tape with `--head-sec 1195.3`. 
 |---|---|
 | delivery | duty cycle 0.949 · 161 gaps totalling 61.4s · p50 0.26s · max 1.02s |
 | shape | no recorded cuts (tape) — the lane run segments it live |
-| content | **recall 0.920 · precision 0.941** (whisper-1, single pass) |
+| content | **recall 0.920 ±0.044 · precision 0.941** (whisper-1, single pass) |
 | lane | 279 store rows · 0 dup texts · 2746 words · coverage 0.905¹ · 6 holes >2s |
 
 The red evidence for **#854**: **8.0%** of what this same model extracts from this same audio in one
@@ -153,6 +160,9 @@ Its hint stream is the finding: a **2-second poll with no `isEnd` events at all*
 one participant. The binder never learns when anyone stops, and three people are lit so rarely they
 lose every max-overlap vote — which is how 5 speakers become 2 while every truth-free signal except
 cardinality reads clean.
+
+² NOT CITABLE — at duty 0.650 the reference disagrees with a differently-cut reference by 23.9%,
+more than the 12.8% loss it reports. The delivery figure above is unaffected.
 
 ¹ harness-relative — comparable only against the same fixture's own baseline, never read as the
 share of a meeting the lane covers. See the note above the entries.

--- a/core/meetings/eval/CORPUS.md
+++ b/core/meetings/eval/CORPUS.md
@@ -48,6 +48,13 @@ duplicate identity, holes, coverage, published words. Any latency derived from i
 not production's — cadence is `replay-paced.test.ts`. Mock STT says nothing about ASR quality and
 must never be reported as content evidence.
 
+**`coverage` is harness-relative and is NOT a product figure.** It is downstream of submission
+cadence, which an unpaced replay does not reproduce, so it means something only compared against
+ITSELF on the same fixture and harness. Measured both ways on `zoom/2026-07-20-live-zoom`: the live
+session covered **0.808** of its span, the replay of the same audio **0.378**. Reading a lane-block
+coverage as "the lane covers X% of a meeting" is a factual error — that number can only come from a
+live session or a paced replay.
+
 **Its tolerances are measured, not assumed.** A tape fixture drives the real segmenter alongside an
 async pump, so the interleaving — and with it the number of resubmissions — varies. Across five
 consecutive runs of identical code on the youtube entry: coverage 0.905–0.906, holes 6/6/6/6/6,
@@ -74,7 +81,7 @@ control, delivered through the bot's webrtc-hook chain instead. Recorded at `5b1
 | delivery | **duty cycle 0.650** · 199 gaps totalling 115.1s · p50 0.40s · max 4.37s |
 | shape | inter-cut p50 0.41s · 142 cuts under 1s · silent frames 10.2% |
 | content | recall 0.858 · **precision 0.723** (whisper-1, single pass) |
-| lane | 57 store rows · 0 dup texts · 239 words · coverage 0.467 · 5 holes >2s |
+| lane | 57 store rows · 0 dup texts · 239 words · coverage 0.467¹ · 5 holes >2s |
 
 This is the red evidence for **#850**. Paired with the control it is also the framework's sharpest
 discrimination: same source material, same lane, same STT — 65.0% vs 94.9% delivered, and precision
@@ -91,7 +98,7 @@ hole is a defect by construction. Derived from a tape with `--head-sec 1195.3`. 
 | delivery | duty cycle 0.949 · 161 gaps totalling 61.4s · p50 0.26s · max 1.02s |
 | shape | no recorded cuts (tape) — the lane run segments it live |
 | content | **recall 0.905 · precision 0.941** (whisper-1, single pass) |
-| lane | 279 store rows · 0 dup texts · 2746 words · coverage 0.905 · 6 holes >2s |
+| lane | 279 store rows · 0 dup texts · 2746 words · coverage 0.905¹ · 6 holes >2s |
 
 The red evidence for **#854**: 9.5% of what this same model extracts from this same audio in one
 pass never reaches the transcript, and 5.9% of the transcript is not in that pass. That comparison
@@ -107,7 +114,7 @@ entry carrying a human verdict, which is what the other numbers are calibrated a
 |---|---|
 | delivery | **duty cycle 1.000** · **zero** gaps over 100ms in 557s |
 | content | not scorable — the desktop store had restarted, so no live transcript survived to compare |
-| lane | 81 store rows · 0 dup texts · 1307 words · coverage 0.909 · 9 holes >2s |
+| lane | 81 store rows · 0 dup texts · 1307 words · coverage 0.909¹ · 9 holes >2s |
 
 Its value is the far end of the delivery curve: **100.0%** here against the jitsi bot's **65.0%** on
 the same capture code. Whatever removes 35% there does not touch this source at all, which is what
@@ -146,6 +153,9 @@ Its hint stream is the finding: a **2-second poll with no `isEnd` events at all*
 one participant. The binder never learns when anyone stops, and three people are lit so rarely they
 lose every max-overlap vote — which is how 5 speakers become 2 while every truth-free signal except
 cardinality reads clean.
+
+¹ harness-relative — comparable only against the same fixture's own baseline, never read as the
+share of a meeting the lane covers. See the note above the entries.
 
 ## The contract
 

--- a/core/meetings/eval/CORPUS.md
+++ b/core/meetings/eval/CORPUS.md
@@ -80,7 +80,7 @@ control, delivered through the bot's webrtc-hook chain instead. Recorded at `5b1
 |---|---|
 | delivery | **duty cycle 0.650** · 199 gaps totalling 115.1s · p50 0.40s · max 4.37s |
 | shape | inter-cut p50 0.41s · 142 cuts under 1s · silent frames 10.2% |
-| content | recall 0.858 · **precision 0.723** (whisper-1, single pass) |
+| content | recall 0.872 · **precision 0.723** (whisper-1, single pass) |
 | lane | 57 store rows · 0 dup texts · 239 words · coverage 0.467¹ · 5 holes >2s |
 
 This is the red evidence for **#850**. Paired with the control it is also the framework's sharpest
@@ -97,10 +97,10 @@ hole is a defect by construction. Derived from a tape with `--head-sec 1195.3`. 
 |---|---|
 | delivery | duty cycle 0.949 · 161 gaps totalling 61.4s · p50 0.26s · max 1.02s |
 | shape | no recorded cuts (tape) — the lane run segments it live |
-| content | **recall 0.905 · precision 0.941** (whisper-1, single pass) |
+| content | **recall 0.920 · precision 0.941** (whisper-1, single pass) |
 | lane | 279 store rows · 0 dup texts · 2746 words · coverage 0.905¹ · 6 holes >2s |
 
-The red evidence for **#854**: 9.5% of what this same model extracts from this same audio in one
+The red evidence for **#854**: **8.0%** of what this same model extracts from this same audio in one
 pass never reaches the transcript, and 5.9% of the transcript is not in that pass. That comparison
 is built from the session's DELIVERED PCM, so it measures streaming loss relative to what capture
 handed over — it is structurally blind to capture loss, and cannot be read as a total.

--- a/core/meetings/eval/CORPUS.md
+++ b/core/meetings/eval/CORPUS.md
@@ -90,11 +90,13 @@ control, delivered through the bot's webrtc-hook chain instead. Recorded at `5b1
 | content | recall 0.872² · **precision 0.723²** (whisper-1, single pass) |
 | lane | 57 store rows · 0 dup texts · 239 words · coverage 0.467¹ · 5 holes >2s |
 
-This is the red evidence for **#850**. Paired with the control it is also the framework's sharpest
-discrimination: same source material, same lane, same STT — 65.0% vs 94.9% delivered, and precision
-0.723 vs 0.941. The invention the low duty cycle buys (27.7% of live words absent from a single pass
-over the same audio) is the sub-second-window hallucination measured as a number rather than
-described.
+This is the red evidence for **#850**, on its DELIVERY figure: 65.0% against the control's 94.9% on
+the same source material, same lane, same STT. That comparison is computed from bytes and holds.
+
+Its content columns do not. Scored against a second reference cut 25s differently, precision reads
+0.853 rather than 0.723 — the first reference was missing 48 live words at its own seams. An earlier
+version of this entry described the gap as sub-second-window hallucination "measured as a number";
+that was measuring the instrument. At duty 0.650 this entry cannot carry a content claim.
 
 ### `youtube/2026-07-20-continuous-speech` — the control, 69 MB
 One continuous speaker from a shared YouTube tab through the extension into the desktop, so every

--- a/core/meetings/eval/CORPUS.md
+++ b/core/meetings/eval/CORPUS.md
@@ -62,7 +62,14 @@ published words 2746–2750 — but STT call count 429–440. Structure is stabl
 figures are not, and `score-fixture` tolerances them from that spread. What the corpus exists to
 catch moves far further: reverting `4c030cd8` takes `storeDupes` from 0 to 11.
 
-**Content scoring needs a high duty cycle to mean anything.** The reference is built from the
+**Reference stability must be MEASURED per entry, never inferred.** `--chunk-offset-sec` builds a
+second reference with the cuts moved; the disagreement between them bounds what any content figure
+from that entry can carry. Measured: **4.4%** (youtube control, duty 0.949, one speaker), **7.2%**
+(witnessed panel, duty 1.000, multi-voice), **23.9%** (jitsi capture-gaps, duty 0.650). Note the
+cleanest-delivery entry is NOT the most stable — duty is one term, not the predictor, and content
+type looks like another. Do not cite a content figure without this number beside it.
+
+**Low duty is still disqualifying.** The reference is built from the
 session's DELIVERED audio, so every capture hole becomes a splice the model reads across. Two
 references over identical audio, cuts shifted 25s apart (`--chunk-offset-sec`), disagree by **4.4%**
 on the youtube control (duty 0.949) and by **23.9%** on the jitsi capture-gaps entry (duty 0.650) —

--- a/core/meetings/eval/FRAMEWORK.md
+++ b/core/meetings/eval/FRAMEWORK.md
@@ -189,11 +189,18 @@ and published-vs-hinted cardinality. Still open and tracked separately: the gmee
 capture from the glow and needs its own reading (#851/#853), and no self-ID oracle exists yet — these
 score WHETHER a name was assigned, never whether it was RIGHT.
 
-**G3 — the reference is uncalibrated.** Nothing verifies the single-pass reference is better than
-the live transcript; recall may be measuring agreement, not truth. Needs: a second-pass stability
-check, and one run against a known-text fixture where absolute truth exists. Chunking is also
-unvalidated — 60s windows with 3s overlap can both duplicate at seams (inflating the reference) and
-drop words at them.
+**G3 — CLOSED by calibration.** On a synthetic fixture where the spoken text is known absolutely,
+the single-pass reference scores **recall 0.977 / precision 0.943** against that truth, while the
+live replay of the same audio through the same STT scores 0.907 / 0.917. The reference is therefore
+substantially closer to truth than the pipeline is, and recall measured against it is LOSS rather
+than agreement — the thing this gap doubted. It also prices the split the framework exists to make:
+of the 9.3 points between the pipeline and perfect, **7.0 are the streaming design's own** and 2.3
+are the model's ceiling on this audio.
+
+**G3 (residual) — chunking is still unvalidated.** Nothing verifies the single-pass reference is better than
+the live transcript; recall may be measuring agreement, not truth. 60s windows with 3s overlap can still both duplicate at seams
+(inflating the reference) and drop words at them; the calibration above bounds the total error but
+does not isolate the seams.
 
 **G4 — CLOSED (#848).** The corpus exists: `$VEXA_CORPUS/<platform>/<slug>/` with a session, a
 `baseline.json` recording every metric at promotion time, a `manifest.json` pinning provenance, and

--- a/core/meetings/eval/FRAMEWORK.md
+++ b/core/meetings/eval/FRAMEWORK.md
@@ -146,8 +146,8 @@ Both are corpus entries now — the numbers below are `baseline.json`, not prose
 
 | entry | duty cycle | recall | precision | note |
 |---|---|---|---|---|
-| `jitsi/2026-07-20-capture-gaps` | **0.650** | 0.858 | **0.723** | capture defect (#850); the invention is the sub-second-window hallucination, measured |
-| `youtube/2026-07-20-continuous-speech` | 0.949 | **0.905** | **0.941** | control; the 9.5% streaming loss is #854 |
+| `jitsi/2026-07-20-capture-gaps` | **0.650** | 0.872 | **0.723** | capture defect (#850); the invention is the sub-second-window hallucination, measured |
+| `youtube/2026-07-20-continuous-speech` | 0.949 | **0.920** | **0.941** | control; the 9.5% streaming loss is #854 |
 
 Same source material, same lane, same STT on both — so the gap between the rows is the bot's capture
 chain and nothing else.
@@ -197,7 +197,13 @@ than agreement — the thing this gap doubted. It also prices the split the fram
 of the 9.3 points between the pipeline and perfect, **7.0 are the streaming design's own** and 2.3
 are the model's ceiling on this audio.
 
-**G3 (residual) — chunking is still unvalidated.** Nothing verifies the single-pass reference is better than
+**G3 (residual) — the SEAM DROP half.** The duplication half is closed: chunk overlap was being
+counted as reference content (122 words, 3.2% on the youtube control), understating recall by that
+much; `dedupe_seams` removes it. What remains is the opposite error — a word LOST at a cut is
+invisible without a second reference built with different cut points, so the reference's own recall
+is still unbounded from below.
+
+**G3 (residual, older note) — chunking is still unvalidated.** Nothing verifies the single-pass reference is better than
 the live transcript; recall may be measuring agreement, not truth. 60s windows with 3s overlap can still both duplicate at seams
 (inflating the reference) and drop words at them; the calibration above bounds the total error but
 does not isolate the seams.

--- a/core/meetings/eval/FRAMEWORK.md
+++ b/core/meetings/eval/FRAMEWORK.md
@@ -171,6 +171,13 @@ gmeet cadence (~8.15s projected time-to-text) · per-platform hints (#797) · gm
 Written down because an un-named gap becomes a false claim of coverage — the exact failure that
 made 0.12.16 aim wrong.
 
+**G1a — DEMONSTRATED, and worse than stated.** The four truth-free signals are blind to
+MISATTRIBUTION, not merely to content. On a synthetic 3-speaker fixture whose hint stream names the
+wrong person 34% of the time, attribution accuracy collapses to 47.8% — 12 of 23 rows under the
+wrong speaker — while every truth-free signal reads healthy: 0.0% provisional, 3 speakers published
+against 3 hinted, nothing unnamed. A lane that confidently names every turn after the wrong person
+scores perfectly on all of them. Truth-free signals answer "did the namer run", never "was it right".
+
 **G1 — the content oracle is speaker-blind.** `single_pass_truth.py` scores recall/precision on a
 flat word sequence. A transcript with perfect words and completely scrambled speakers scores
 1.000/1.000. This is mock-blindness repeating on a different axis. Until the self-ID scorer exists,

--- a/core/meetings/eval/src/build_truth_wav.py
+++ b/core/meetings/eval/src/build_truth_wav.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Build a speaker's microphone WAV out of the cached TTS corpus — and the truth beside it.
+
+Every content number in the corpus today is scored against a SINGLE-PASS STT reference, and that
+reference has been wrong twice: it duplicates itself at chunk seams, and it disagrees with a second
+cut of itself by 4-24% depending on the entry. A reference that needs its own error bars cannot
+settle whether the pipeline lost a word.
+
+A TTS clip does not have that problem. The text is known before any audio exists, so a WAV
+concatenated from clips carries exact truth: which words, in which order, at which offset, from
+which speaker. Feed that WAV to a synthetic participant's fake microphone and the meeting itself
+becomes the fixture.
+
+    python3 build_truth_wav.py --speaker A --name anna --out <dir> [--gap-sec 1.0] [--clips 16]
+
+Writes <dir>/<name>.wav (16 kHz mono, the rate the whole pipeline speaks) and <dir>/<name>.truth.json:
+
+    {"speaker": "anna", "sampleRate": 16000, "durationSec": 269.4,
+     "clips": [{"i": 0, "startSec": 0.0, "endSec": 14.2, "text": "Anna here. Caching would…"}, …]}
+
+The offsets are the contract: a scorer that knows when a speaker's WAV started in wall time can map
+any transcript segment back to the clip that produced it, and therefore to the words that were
+really said and the person who really said them.
+"""
+import argparse
+import base64
+import io
+import json
+import os
+import wave
+
+CACHE = os.environ.get("EVAL_CACHE", os.path.expanduser("~/vexa-test-rig/cache"))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--speaker", required=True, help="cache key: A=Anna, B=Boris, V=Vera, …")
+    ap.add_argument("--name", required=True, help="display name this speaker joins under")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--gap-sec", type=float, default=1.0,
+                    help="silence between clips — a turn boundary the segmenter must find")
+    ap.add_argument("--clips", type=int, default=0, help="use at most N clips (0 = all)")
+    args = ap.parse_args()
+
+    with open(os.path.join(CACHE, f"{args.speaker}.json")) as fh:
+        clips = json.load(fh)
+    if args.clips:
+        clips = clips[: args.clips]
+
+    os.makedirs(args.out, exist_ok=True)
+    frames = b""
+    params = None
+    manifest = []
+    for i, clip in enumerate(clips):
+        src = wave.open(io.BytesIO(base64.b64decode(clip["b64"])))
+        if params is None:
+            params = src.getparams()
+        elif (src.getframerate(), src.getnchannels(), src.getsampwidth()) != (
+            params.framerate, params.nchannels, params.sampwidth
+        ):
+            # Concatenating mismatched formats produces audio that plays at the wrong speed, which
+            # then scores as catastrophic word loss. Refuse rather than emit a fixture that lies.
+            raise SystemExit(f"clip {i} format {src.getparams()} != {params}")
+        bytes_per_sec = params.framerate * params.nchannels * params.sampwidth
+        start = len(frames) / bytes_per_sec
+        frames += src.readframes(src.getnframes())
+        end = len(frames) / bytes_per_sec
+        frames += b"\x00" * int(args.gap_sec * bytes_per_sec)
+        manifest.append({"i": i, "startSec": round(start, 3), "endSec": round(end, 3), "text": clip["text"]})
+
+    wav_path = os.path.join(args.out, f"{args.name}.wav")
+    out = wave.open(wav_path, "wb")
+    out.setparams(params)
+    out.writeframes(frames)
+    out.close()
+
+    duration = len(frames) / (params.framerate * params.nchannels * params.sampwidth)
+    truth = {
+        "speaker": args.name,
+        "cacheKey": args.speaker,
+        "sampleRate": params.framerate,
+        "durationSec": round(duration, 2),
+        "words": sum(len(c["text"].split()) for c in clips),
+        "clips": manifest,
+    }
+    with open(os.path.join(args.out, f"{args.name}.truth.json"), "w") as fh:
+        json.dump(truth, fh, indent=1)
+
+    print(f"{wav_path}  {duration:.1f}s · {len(clips)} clips · {truth['words']} words · {params.framerate} Hz")
+
+
+if __name__ == "__main__":
+    main()

--- a/core/meetings/eval/src/extension-loop.mjs
+++ b/core/meetings/eval/src/extension-loop.mjs
@@ -74,21 +74,86 @@ await page.goto(URL_, { waitUntil: 'domcontentloaded' });
 // A tab that never plays is a tab with no audio to capture, and a MUTED element produces none
 // either — the silence gate then drops every buffer and the tape is empty. Browser-level
 // --mute-audio silences the speakers without touching what tab capture taps.
-await page.evaluate(async () => {
-  for (const v of document.querySelectorAll('video,audio')) { v.muted = false; v.volume = 1; try { await v.play?.(); } catch { /* */ } }
+//
+// The element does not exist at domcontentloaded on a player page, so playing "whatever is there"
+// races the player into existence and usually loses. An empty tape then has TWO explanations — no
+// stream, or no sound — and the desktop's own fault line names both, so it cannot separate them.
+// Wait for the element, start it, and report the clock: a currentTime that advances rules out the
+// silence half and leaves the stream half standing alone.
+const playback = await page.evaluate(async () => {
+  const deadline = Date.now() + 20_000;
+  let el = null;
+  while (Date.now() < deadline) {
+    el = document.querySelector('video,audio');
+    if (el) break;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  if (!el) return { found: false };
+  el.muted = false; el.volume = 1;
+  try { await el.play?.(); } catch { /* autoplay policy is disabled by flag, but never assume */ }
+  const t0 = el.currentTime;
+  await new Promise((r) => setTimeout(r, 3000));
+  return { found: true, t0, t1: el.currentTime, paused: el.paused, muted: el.muted, readyState: el.readyState };
 });
+console.log(`  playback: ${playback.found
+  ? `element found · currentTime ${playback.t0.toFixed(1)}s → ${playback.t1.toFixed(1)}s · paused=${playback.paused} muted=${playback.muted} readyState=${playback.readyState}`
+  : 'NO media element on the page after 20s'}`);
+let lastT = playback.found ? playback.t1 : 0;
 
 console.log(`capturing ${URL_} for ${SEC}s …`);
 const started = Date.now();
+// The SEC budget counts CAPTURED seconds, not wall seconds: a run that spends its first minute
+// waiting for a gesture would otherwise bank that minute as data it never got.
+let firstFrameAt = null;
+let prompted = false;
 let last = '';
-while ((Date.now() - started) / 1000 < SEC) {
+// …but the wait for that first frame is not open-ended. WAIT_SEC is how long a gesture may take to
+// arrive before the run is called for what it is: nothing captured.
+const WAIT_SEC = Number(arg('wait', 120));
+const hardStop = () => firstFrameAt === null && (Date.now() - started) / 1000 > WAIT_SEC;
+while (!hardStop() && (firstFrameAt === null || (Date.now() - firstFrameAt) / 1000 < SEC)) {
   await new Promise((r) => setTimeout(r, 5000));
   const st = await sw.evaluate(() => new Promise((r) => { try { chrome.runtime.sendMessage({ type: 'STATUS' }, (x) => r(x || {})); } catch { r({}); } }))
     .catch(() => ({}));
+  // Playback is not a start-once property. A player pauses itself — an ad break, a "still there?"
+  // interstitial, a backgrounded tab — and every paused second is a second of silence the tape will
+  // faithfully record as a capture defect that isn't one. Nurse it every tick, and say when it slips.
+  const play = await page.evaluate(async () => {
+    const el = document.querySelector('video,audio');
+    if (!el) return { found: false };
+    const wasPaused = el.paused;
+    if (el.paused) { el.muted = false; try { await el.play?.(); } catch { /* */ } }
+    return { found: true, t: el.currentTime, wasPaused, paused: el.paused };
+  }).catch(() => ({ found: false }));
+  if (play.found && play.wasPaused) console.log(`  ↻ player had paused at ${play.t.toFixed(1)}s — restarted (now paused=${play.paused})`);
+
   const tape = newestTape();
-  const size = tape && tape !== before ? (statSync(path.join(TAPES, tape)).size / 1e6).toFixed(1) : '0.0';
-  const line = `  t+${Math.round((Date.now() - started) / 1000)}s status=${st.status ?? '?'} tape=${size}MB${st.error ? ' err=' + st.error : ''}`;
+  const bytes = tape && tape !== before ? statSync(path.join(TAPES, tape)).size : 0;
+  // A tape file exists the moment a session opens; only its GROWTH means audio. The header alone is
+  // ~110 bytes, so anything under a kilobyte is an open session with nothing flowing through it.
+  if (firstFrameAt === null && bytes > 1024) { firstFrameAt = Date.now(); console.log(`  ▶ first audio at t+${Math.round((Date.now() - started) / 1000)}s — the ${SEC}s budget starts here`); }
+  const line = `  t+${Math.round((Date.now() - started) / 1000)}s status=${st.status ?? '?'} tape=${(bytes / 1e6).toFixed(1)}MB${st.error ? ' err=' + st.error : ''}`;
   console.log(line); last = line;
+
+  // Playing audio and an empty tape leaves exactly one explanation, and it is not one this process
+  // can fix: chrome.tabCapture.getMediaStreamId needs activeTab, and ONLY a toolbar click, a
+  // context-menu entry or a keyboard command grants it (see clients/extension/src/background.ts).
+  // Playwright drives pages, not browser chrome, so it cannot produce that gesture. Say so out loud
+  // instead of accumulating a silent hour of nothing.
+  const advancing = play.found && play.t > lastT + 0.5;
+  lastT = play.found ? play.t : lastT;
+  if (!prompted && firstFrameAt === null && advancing && (Date.now() - started) > 15_000) {
+    prompted = true;
+    console.log('\n  ⚠ audio IS playing in the tab and NO frames are reaching the desktop.');
+    console.log('    The tab-capture stream was never minted. Chrome grants that only on a gesture:');
+    console.log('    🧑 click the Vexa toolbar icon ON THIS TAB (the driven window), then Start.');
+    console.log('    Capturing continues automatically the moment frames appear.\n');
+  }
+  if (!prompted && firstFrameAt === null && !advancing && (Date.now() - started) > 15_000) {
+    prompted = true;
+    console.log('\n  ⚠ no frames — but the media element is not playing either, so this run cannot');
+    console.log('    tell a missing stream from a silent tab. Fix playback before reading anything.\n');
+  }
 }
 
 await sw.evaluate(() => chrome.runtime.sendMessage({ type: 'STOP' })).catch(() => { /* best effort */ });

--- a/core/meetings/eval/src/meeting-speaker.mjs
+++ b/core/meetings/eval/src/meeting-speaker.mjs
@@ -61,6 +61,24 @@ if (PROBE) { await ctx.close(); process.exit(state.inConference ? 0 : 3); }
 const unmute = page.locator('[aria-label*="Unmute"], [data-testid="toolbox.mute"]').first();
 if (await unmute.isVisible({ timeout: 2000 }).catch(() => false)) await unmute.click().catch(() => {});
 console.log(`[speaker:${NAME}] holding ${HOLD_MS}ms`);
-await page.waitForTimeout(HOLD_MS);
+
+// ADMIT=1 makes this participant the room's doorkeeper. meet.jit.si puts a joining bot in the
+// lobby — even in an empty room — and a bot cannot admit itself, which would put a human in the
+// loop for every autonomous multi-party run. The FIRST participant is moderator, so a speaker that
+// joined first can let the bot in. Polling beats a one-shot wait: the knock arrives whenever the
+// bot's own join finishes, which is not a time this script can predict.
+const ADMIT = process.env.ADMIT === '1';
+const deadline = Date.now() + HOLD_MS;
+let admitted = 0;
+while (Date.now() < deadline) {
+  if (ADMIT) {
+    const btn = page.locator('[data-testid="lobby.allow"], [aria-label*="Admit"], button:has-text("Admit")').first();
+    if (await btn.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await btn.click().catch(() => { /* the knock may vanish between seeing and clicking */ });
+      console.log(`[speaker:${NAME}] ADMITTED a lobby knock (${++admitted} total)`);
+    }
+  }
+  await page.waitForTimeout(2000);
+}
 await ctx.close();
 console.log(`[speaker:${NAME}] done`);

--- a/core/meetings/eval/src/meeting-speaker.mjs
+++ b/core/meetings/eval/src/meeting-speaker.mjs
@@ -1,0 +1,66 @@
+// A Jitsi "human" — headless Chromium joins a room with a WAV as its microphone.
+// Provides real WebRTC audio with known ground truth, no TTS service and no host needed.
+//   ROOM=<room> NAME=<display name> WAV=/audio/x.wav [PROBE=1] node jitsi-speaker.mjs
+const { chromium } = await import(new URL("../../modules/join/node_modules/playwright/index.mjs", import.meta.url).href);
+
+const ROOM = process.env.ROOM;
+const NAME = process.env.NAME ?? 'Speaker';
+const WAV = process.env.WAV;
+const HOLD_MS = Number(process.env.HOLD_MS ?? 130000);
+const BASE = process.env.JITSI_BASE ?? 'https://meet.jit.si';
+const PROBE = process.env.PROBE === '1';
+
+const url = `${BASE}/${ROOM}#config.prejoinPageEnabled=false&config.startWithAudioMuted=false&config.startWithVideoMuted=true&userInfo.displayName=%22${encodeURIComponent(NAME)}%22`;
+
+const args = [
+  '--use-fake-ui-for-media-stream',
+  '--use-fake-device-for-media-stream',
+  '--autoplay-policy=no-user-gesture-required',
+  '--disable-dev-shm-usage',
+  '--no-sandbox',
+  // harness-only: the lab CA is private. The BOT trusts it properly via NSS instead.
+  '--ignore-certificate-errors',
+];
+if (WAV) args.push(`--use-file-for-fake-audio-capture=${WAV}%noloop`);
+
+const ctx = await chromium.launchPersistentContext('', {
+  headless: false,
+  args,
+  permissions: ['microphone', 'camera'],
+});
+const page = ctx.pages()[0] ?? await ctx.newPage();
+page.on('console', (m) => { if (PROBE) console.log(`[page] ${m.text().slice(0, 160)}`); });
+
+console.log(`[speaker:${NAME}] joining ${url}`);
+await page.goto(url, { timeout: 90000, waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(8000);
+
+// Dismiss whatever pre-join / consent UI the deployment shows.
+for (const sel of ['button:has-text("Join meeting")', 'button:has-text("Join")', '[data-testid="prejoin.joinMeeting"]', 'button:has-text("I agree")', 'button:has-text("Continue")']) {
+  const el = page.locator(sel).first();
+  if (await el.isVisible({ timeout: 1500 }).catch(() => false)) {
+    console.log(`[speaker:${NAME}] clicking ${sel}`);
+    await el.click().catch(() => {});
+    await page.waitForTimeout(2500);
+  }
+}
+await page.waitForTimeout(5000);
+
+const state = await page.evaluate(() => ({
+  url: location.href,
+  title: document.title,
+  body: document.body.innerText.slice(0, 400),
+  inConference: !!document.querySelector('#largeVideoContainer, .videocontainer, [class*="conference"]'),
+  participants: document.querySelectorAll('[id^="participant_"]').length,
+}));
+console.log(`[speaker:${NAME}] state: ${JSON.stringify(state, null, 2)}`);
+
+if (PROBE) { await ctx.close(); process.exit(state.inConference ? 0 : 3); }
+
+// Unmute if Jitsi joined muted, then hold the call open while the WAV plays through.
+const unmute = page.locator('[aria-label*="Unmute"], [data-testid="toolbox.mute"]').first();
+if (await unmute.isVisible({ timeout: 2000 }).catch(() => false)) await unmute.click().catch(() => {});
+console.log(`[speaker:${NAME}] holding ${HOLD_MS}ms`);
+await page.waitForTimeout(HOLD_MS);
+await ctx.close();
+console.log(`[speaker:${NAME}] done`);

--- a/core/meetings/eval/src/score-fixture.mjs
+++ b/core/meetings/eval/src/score-fixture.mjs
@@ -124,6 +124,8 @@ for (const { id, dir } of entries()) {
   const baseline = JSON.parse(readFileSync(path.join(dir, 'baseline.json'), 'utf8'));
   const sessionPath = path.join(dir, manifest.files.session);
 
+  // `~` marks a harness-relative figure: comparable to this fixture's own baseline, not to a live
+  // session. The replay does not reproduce submission cadence, and coverage sits downstream of it.
   console.log(`\n${id}   ${manifest.note ? manifest.note.split('.')[0] + '.' : ''}`);
 
   // The fixture itself first. Every number below is a claim about THESE bytes; if they are not the
@@ -148,7 +150,7 @@ for (const { id, dir } of entries()) {
     } else {
       lane = laneMetrics(sessionPath);
       console.log(`  lane      ${lane.storeRows} store rows (${lane.storeDupes} dup texts) · ${lane.publishedWords} words · ` +
-        `coverage ${lane.coverage} · ${lane.holesOver2s} holes >2s` +
+        `coverage ${lane.coverage}~ · ${lane.holesOver2s} holes >2s` +
         (lane.retention === undefined ? '' : ` · retention ${lane.retention}`));
       // With no hint stream there is no name source, so everything is provisional BY DESIGN — a
       // shared tab has nobody to name. Saying so keeps a 100% that means "not applicable" from

--- a/core/meetings/eval/src/score-fixture.mjs
+++ b/core/meetings/eval/src/score-fixture.mjs
@@ -59,8 +59,13 @@ const HIGHER_IS_BETTER = new Set(['dutyCycle', 'recall', 'precision', 'retention
 // `storeRows` and `segments` are deliberately absent: for a fixed fixture more rows can mean a
 // duplication defect OR a session that was previously scored as one useless turn, and only the
 // content tells them apart. Naming a direction there would assert a verdict the number cannot carry.
+// `hintMissRate`/`hintMissed` are deliberately absent: they are the hint-hop instrument — did a hint
+// find an open turn AT THE INSTANT IT ARRIVED — not a measure of whether attribution worked. A hint
+// that arrives before its turn has any transcribed audio reports "missed" and is then used correctly
+// by the binder; the synthetic zoom-lane fixture scores 100% "miss" with 0.947 accuracy and zero
+// wrong names. Calling a rise there WORSE would flag correct behaviour as a regression.
 const LOWER_IS_BETTER = new Set(['storeDupes', 'holesOver2s', 'segUnder1s', 'gapCount', 'gapTotalSec', 'sttFails',
-  'provisionalRate', 'hintMissRate', 'hintMissed', 'churnedTurns']);
+  'provisionalRate', 'churnedTurns']);
 
 function entries() {
   if (named.length) return named.map((n) => ({ id: n, dir: path.join(CORPUS, n) }));
@@ -159,7 +164,7 @@ for (const { id, dir } of entries()) {
         console.log(`  attribution n/a — no hints in this fixture (nothing to name from); ${lane.provisionalRate * 100}% provisional is the expected floor`);
       } else if (lane.provisionalRate !== undefined) {
         console.log(`  attribution ${(lane.provisionalRate * 100).toFixed(1)}% of words provisional · ` +
-          `hint miss ${(lane.hintMissRate * 100).toFixed(1)}% (${lane.hintMissed}/${lane.hintMatched + lane.hintMissed}) · ` +
+          `hint-hop ${lane.hintMatched}/${lane.hintMatched + lane.hintMissed} bound on arrival (timing, not accuracy) · ` +
           `${lane.renames} renames, ${lane.churnedTurns} churned · ${lane.publishedSpeakers} named vs ${lane.hintNames} hinted`);
       }
     }

--- a/core/meetings/eval/src/score_replay.py
+++ b/core/meetings/eval/src/score_replay.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Score a REPLAY's transcript for content — the thing a corpus entry alone cannot do.
+
+A corpus entry stores the transcript the ORIGINAL live session produced, so it can score that
+session and nothing else. The moment a lane change is made, the question is "did this diff lose
+words?" — and that needs the transcript the CHANGED code produces from the same audio, which no
+stored artifact can supply.
+
+`quality-mixed.test.ts TRANSCRIPT_OUT=<f>` writes exactly that. This scores it against either:
+
+  * a corpus entry's single-pass reference — same model, one pass, on a real session, or
+  * a synthetic fixture's truth sidecar — ABSOLUTE truth, since the clip text is known
+
+    python3 src/score_replay.py <replay.json> --truth <fixture.truth.json>
+    python3 src/score_replay.py <replay.json> --reference <entry/reference.txt>
+
+Recall is what the pipeline kept of what was said; precision is how much of what it published was
+never said. Both order-preserving (LCS), so a word recovered out of sequence is not a match.
+"""
+import argparse
+import json
+
+from single_pass_truth import lcs, words
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("replay", help="TRANSCRIPT_OUT from a lane replay")
+    ap.add_argument("--truth", help="a synthetic fixture's .truth.json (absolute truth)")
+    ap.add_argument("--reference", help="a corpus entry's reference.txt (single-pass truth)")
+    ap.add_argument("--json", help="write the score block here")
+    args = ap.parse_args()
+    if not args.truth and not args.reference:
+        raise SystemExit("one of --truth or --reference is required")
+
+    if args.truth:
+        turns = json.load(open(args.truth))["turns"]
+        ref_w = words(" ".join(t["text"] for t in turns))
+        kind = "known text (absolute)"
+    else:
+        ref_w = words(open(args.reference).read())
+        kind = "single-pass reference"
+
+    segs = json.load(open(args.replay))["segments"]
+    rt_w = words(" ".join(s.get("text", "") for s in segs))
+    m = lcs(ref_w, rt_w)
+
+    block = {
+        "referenceKind": kind,
+        "referenceWords": len(ref_w),
+        "replayWords": len(rt_w),
+        "matched": m,
+        "recall": round(m / max(1, len(ref_w)), 3),
+        "precision": round(m / max(1, len(rt_w)), 3),
+    }
+    print(f"REFERENCE ({kind}): {len(ref_w)} words")
+    print(f"REPLAY             : {len(rt_w)} words")
+    print(f"\n  recall    {block['recall']:.3f}   ({m}/{len(ref_w)} kept, in order)")
+    print(f"  precision {block['precision']:.3f}   ({len(rt_w) - m} published words that were never said)")
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(block, f, indent=2)
+        print(f"  written: {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/core/meetings/eval/src/score_truth.py
+++ b/core/meetings/eval/src/score_truth.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Score a live transcript against KNOWN truth — the words, and who said them.
+
+The corpus scores content against a single-pass STT reference. That reference is itself a
+measurement: it duplicates its own chunk overlap, and re-cutting it moves the answer by 4-24%
+depending on the entry. Every content claim built on it inherits those error bars, and twice this
+week a "finding" turned out to be the reference moving rather than the pipeline.
+
+When the speakers are synthetic, none of that applies. The clip text existed before the audio did,
+so this scorer compares against truth rather than against another opinion — and because each clip
+occupies a known offset in a WAV that started at a known wall-clock instant, it also knows WHO was
+speaking at every instant. That makes attribution measurable on the same pass, against the same
+truth, with no diarization oracle in the loop.
+
+    python3 score_truth.py --truth anna.truth.json@1784570000.0 \\
+                           --truth boris.truth.json@1784570012.5 \\
+                           --transcript http://localhost:8056/transcripts/zoom/76967201683 \\
+                           [--json out.json]
+
+The @ is the wall-clock second at which that speaker's WAV STARTED PLAYING. Get it wrong and the
+attribution numbers are meaningless while the content numbers stay fine — so the report prints the
+alignment it inferred, and refuses when the overlap is too small to mean anything.
+
+Alignment is word-level LCS (difflib), never substring containment: a containment test on this same
+corpus produced 24 false positives out of 39 and reversed a conclusion.
+"""
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from difflib import SequenceMatcher
+
+WORD = re.compile(r"[a-z0-9']+")
+
+
+def norm(text: str) -> list[str]:
+    return WORD.findall(text.lower())
+
+
+def load_transcript(path: str) -> list[dict]:
+    if path.startswith("http"):
+        with urllib.request.urlopen(path, timeout=30) as fh:
+            body = json.load(fh)
+    else:
+        with open(path) as fh:
+            body = json.load(fh)
+    segs = body.get("segments", body) if isinstance(body, dict) else body
+    if not isinstance(segs, list) or not segs:
+        raise SystemExit(f"REFUSING: {path} has no segments — an empty store scores as total loss")
+    return segs
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--truth", action="append", required=True, metavar="FILE@EPOCH_SEC")
+    ap.add_argument("--transcript", required=True)
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    # ── the truth timeline: every clip an absolute window with an owner
+    ref_words: list[str] = []
+    ref_owner: list[str] = []
+    windows: list[tuple[float, float, str]] = []
+    per_speaker_truth: dict[str, int] = {}
+    clips: list[tuple[float, float, str, str]] = []
+    for spec in args.truth:
+        path, _, at = spec.partition("@")
+        if not at:
+            raise SystemExit(f"--truth {spec} needs @<epoch seconds when the WAV started>")
+        t0 = float(at)
+        with open(path) as fh:
+            truth = json.load(fh)
+        who = truth["speaker"]
+        for clip in truth["clips"]:
+            clips.append((t0 + clip["startSec"], t0 + clip["endSec"], who, clip["text"]))
+    clips.sort()
+    for start, end, who, text in clips:
+        words = norm(text)
+        ref_words.extend(words)
+        ref_owner.extend([who] * len(words))
+        windows.append((start, end, who))
+        per_speaker_truth[who] = per_speaker_truth.get(who, 0) + len(words)
+
+    # ── the hypothesis: what the pipeline published, in time order
+    segs = sorted(load_transcript(args.transcript), key=lambda s: s.get("start") or 0)
+    hyp_words: list[str] = []
+    hyp_label: list[str] = []
+    span0, span1 = windows[0][0], windows[-1][1]
+    inside = 0
+    for seg in segs:
+        start = seg.get("start") or 0
+        # Segments outside the speakers' span are somebody else's audio (a human in the room, an
+        # earlier meeting in the same store). Counting them as invention would be a lie about
+        # precision, so they are excluded and REPORTED rather than silently dropped.
+        if not (span0 - 5 <= start <= span1 + 15):
+            continue
+        inside += 1
+        words = norm(seg.get("text") or "")
+        hyp_words.extend(words)
+        hyp_label.extend([seg.get("speaker") or "?"] * len(words))
+
+    if not hyp_words:
+        raise SystemExit(f"REFUSING: no transcript segments fall inside the speakers' window "
+                         f"({span0:.0f}-{span1:.0f}) — check the @epoch you passed")
+
+    # ── word-level LCS between truth and hypothesis
+    matcher = SequenceMatcher(None, ref_words, hyp_words, autojunk=False)
+    matched = 0
+    agree = disagree = unnamed = 0
+    confusion: dict[str, dict[str, int]] = {}
+    for i, j, n in matcher.get_matching_blocks():
+        matched += n
+        for k in range(n):
+            truth_who = ref_owner[i + k]
+            label = hyp_label[j + k]
+            row = confusion.setdefault(truth_who, {})
+            row[label] = row.get(label, 0) + 1
+            # An unnamed segment is not a WRONG name: the mixed lane publishes seg_N until a hint
+            # binds a turn, and scoring that as misattribution would punish honesty.
+            if re.fullmatch(r"(seg_\d+|speaker_\d+|\?|unknown)", label, re.I):
+                unnamed += 1
+            elif label.lower().startswith(truth_who.lower()) or truth_who.lower().startswith(label.lower()):
+                agree += 1
+            else:
+                disagree += 1
+
+    named = agree + disagree
+    out = {
+        "truthWords": len(ref_words),
+        "publishedWords": len(hyp_words),
+        "matchedWords": matched,
+        "recall": round(matched / len(ref_words), 3),
+        "precision": round(matched / len(hyp_words), 3),
+        "segmentsInWindow": inside,
+        "segmentsTotal": len(segs),
+        "attribution": {
+            "namedWords": named,
+            "unnamedWords": unnamed,
+            "correct": agree,
+            "wrong": disagree,
+            "accuracy": round(agree / named, 3) if named else None,
+            "unnamedRate": round(unnamed / matched, 3) if matched else None,
+        },
+        "perSpeakerTruthWords": per_speaker_truth,
+        "confusion": confusion,
+    }
+
+    print(f"truth     {len(ref_words)} words across {len(per_speaker_truth)} speakers "
+          f"({', '.join(f'{k} {v}' for k, v in sorted(per_speaker_truth.items()))})")
+    print(f"published {len(hyp_words)} words in {inside}/{len(segs)} segments inside the window")
+    print(f"content   recall {out['recall']} · precision {out['precision']} "
+          f"({matched} words matched, word-level LCS)")
+    if named:
+        print(f"attribution {out['attribution']['accuracy']} of {named} named words correct "
+              f"({disagree} wrong) · {unnamed} matched words still unnamed "
+              f"({out['attribution']['unnamedRate']} of matches)")
+    else:
+        print(f"attribution NONE — every one of the {unnamed} matched words is unnamed; "
+              f"no hint ever bound a turn")
+    for who, row in sorted(confusion.items()):
+        top = sorted(row.items(), key=lambda kv: -kv[1])[:4]
+        print(f"  {who:<10} → {', '.join(f'{k}:{v}' for k, v in top)}")
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump(out, fh, indent=1)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/meetings/eval/src/score_truth.py
+++ b/core/meetings/eval/src/score_truth.py
@@ -30,6 +30,7 @@ import re
 import sys
 import urllib.request
 from difflib import SequenceMatcher
+from itertools import permutations
 
 WORD = re.compile(r"[a-z0-9']+")
 
@@ -104,26 +105,72 @@ def main() -> None:
         raise SystemExit(f"REFUSING: no transcript segments fall inside the speakers' window "
                          f"({span0:.0f}-{span1:.0f}) — check the @epoch you passed")
 
-    # ── word-level LCS between truth and hypothesis
-    matcher = SequenceMatcher(None, ref_words, hyp_words, autojunk=False)
+    # ── word-level LCS, ONE SPEAKER AT A TIME
+    #
+    # The obvious implementation interleaves both speakers' clips into one reference by absolute
+    # time and aligns that against the transcript. It is wrong, and expensively so: LCS is
+    # order-sensitive, so an error in the @EPOCH scrambles the reference order and the resulting
+    # mismatch is billed to the pipeline as lost words. Measured on a WORD-PERFECT transcript,
+    # interleaved scoring: +5s → recall 0.871, +30s → 0.607, +120s → 0.587. A 2-second slip is
+    # entirely ordinary — the speakers report AUDIO_START when the join completes, not when the
+    # first sample leaves the fake device — so that version would have invented double-digit
+    # "streaming loss" out of a clock.
+    #
+    # Scoring each speaker's own WAV against the whole transcript removes the clock from the
+    # content numbers completely: the order inside one speaker's truth is fixed by their own file,
+    # exactly, and no cross-speaker ordering is ever needed. The epoch survives only as a coarse
+    # window filter, where seconds do not matter.
+    # Speakers are aligned in sequence against the words still unclaimed, never independently
+    # against the whole transcript: independent passes let two speakers claim the SAME published
+    # word (both say "the"), which on a word-perfect transcript cost 25 words of precision and
+    # misattributed those same 25. Disjoint assignment is what makes a perfect run score perfect.
+    # Which speaker goes first is not neutral, so try every order and keep the best total — with a
+    # handful of speakers this is trivial, and it removes the arbitrariness from the number.
+    def assign(order: list[str]) -> tuple[dict[str, list[tuple[int, int]]], int]:
+        """→ per-speaker [(hyp index, truth index)], total matched, for one speaker order."""
+        remaining = list(range(len(hyp_words)))
+        got: dict[str, list[tuple[int, int]]] = {}
+        total = 0
+        for who in order:
+            own = [w for w, o in zip(ref_words, ref_owner) if o == who]
+            pool = [hyp_words[x] for x in remaining]
+            hits: list[tuple[int, int]] = []
+            for i, j, n in SequenceMatcher(None, own, pool, autojunk=False).get_matching_blocks():
+                hits.extend((remaining[j + k], i + k) for k in range(n))
+            got[who] = hits
+            total += len(hits)
+            taken = {h for h, _ in hits}
+            remaining = [x for x in remaining if x not in taken]
+        return got, total
+
+    best: dict[str, list[tuple[int, int]]] = {}
     matched = 0
+    for order in permutations(sorted(per_speaker_truth)):
+        got, total = assign(list(order))
+        if total > matched:
+            best, matched = got, total
+
     agree = disagree = unnamed = 0
     confusion: dict[str, dict[str, int]] = {}
-    for i, j, n in matcher.get_matching_blocks():
-        matched += n
-        for k in range(n):
-            truth_who = ref_owner[i + k]
-            label = hyp_label[j + k]
-            row = confusion.setdefault(truth_who, {})
-            row[label] = row.get(label, 0) + 1
-            # An unnamed segment is not a WRONG name: the mixed lane publishes seg_N until a hint
-            # binds a turn, and scoring that as misattribution would punish honesty.
-            if re.fullmatch(r"(seg_\d+|speaker_\d+|\?|unknown)", label, re.I):
-                unnamed += 1
-            elif label.lower().startswith(truth_who.lower()) or truth_who.lower().startswith(label.lower()):
-                agree += 1
-            else:
-                disagree += 1
+    claimed: set[int] = set()
+    per_speaker_matched: dict[str, int] = {}
+    pairs: list[tuple[str, str]] = []  # (truth speaker, published label) per matched word
+    for who, hits in best.items():
+        per_speaker_matched[who] = len(hits)
+        for hyp_i, _ in hits:
+            claimed.add(hyp_i)
+            pairs.append((who, hyp_label[hyp_i]))
+    for truth_who, label in pairs:
+        row = confusion.setdefault(truth_who, {})
+        row[label] = row.get(label, 0) + 1
+        # An unnamed segment is not a WRONG name: the mixed lane publishes seg_N until a hint
+        # binds a turn, and scoring that as misattribution would punish honesty.
+        if re.fullmatch(r"(seg_\d+|speaker_\d+|\?|unknown)", label, re.I):
+            unnamed += 1
+        elif label.lower().startswith(truth_who.lower()) or truth_who.lower().startswith(label.lower()):
+            agree += 1
+        else:
+            disagree += 1
 
     named = agree + disagree
     out = {
@@ -131,7 +178,10 @@ def main() -> None:
         "publishedWords": len(hyp_words),
         "matchedWords": matched,
         "recall": round(matched / len(ref_words), 3),
-        "precision": round(matched / len(hyp_words), 3),
+        # Precision counts each published word ONCE even if two speakers' truth both claim it (a
+        # shared "the" will), so it stays a real fraction of what was published.
+        "precision": round(len(claimed) / len(hyp_words), 3),
+        "perSpeakerRecall": {k: round(per_speaker_matched.get(k, 0) / v, 3) for k, v in per_speaker_truth.items()},
         "segmentsInWindow": inside,
         "segmentsTotal": len(segs),
         "attribution": {
@@ -150,7 +200,8 @@ def main() -> None:
           f"({', '.join(f'{k} {v}' for k, v in sorted(per_speaker_truth.items()))})")
     print(f"published {len(hyp_words)} words in {inside}/{len(segs)} segments inside the window")
     print(f"content   recall {out['recall']} · precision {out['precision']} "
-          f"({matched} words matched, word-level LCS)")
+          f"({matched} words matched, word-level LCS, speakers assigned disjointly)")
+    print(f"          per speaker: {', '.join(f'{k} {v}' for k, v in sorted(out['perSpeakerRecall'].items()))}")
     if named:
         print(f"attribution {out['attribution']['accuracy']} of {named} named words correct "
               f"({disagree} wrong) · {unnamed} matched words still unnamed "

--- a/core/meetings/eval/src/single_pass_truth.py
+++ b/core/meetings/eval/src/single_pass_truth.py
@@ -98,6 +98,31 @@ def transcribe(wav: bytes, url: str, token: str, model: str, lang: str) -> str:
         return (json.loads(r.read()).get("text") or "").strip()
 
 
+def dedupe_seams(parts):
+    """Join chunk transcripts, dropping the text the OVERLAP transcribed twice.
+
+    Chunks are cut with OVERLAP_SEC of shared audio so a word split by the cut still appears — but
+    that same audio is then transcribed in both chunks, so the seam text lands twice. Measured on
+    the youtube control: 122 words (3.2% of the reference) sat inside a duplicated region, and every
+    one of them counts as a miss against a live transcript that correctly said it once. Recall was
+    understated by up to that much.
+
+    The fix is local to the seam: for each join, find the longest suffix of the accumulated text
+    that also opens the next chunk, and drop it once."""
+    out = words(parts[0]) if parts else []
+    for nxt in parts[1:]:
+        w = words(nxt)
+        # The overlap is a few seconds of speech — cap the search well above that, not at the whole
+        # chunk, so an ordinary repeated phrase mid-chunk is never mistaken for a seam.
+        best = 0
+        for k in range(min(60, len(out), len(w)), 3, -1):
+            if out[-k:] == w[:k]:
+                best = k
+                break
+        out.extend(w[best:])
+    return " ".join(out)
+
+
 def words(s):
     return re.findall(r"[\w']+", (s or "").lower())
 
@@ -203,7 +228,7 @@ def main():
         t = transcribe(wav_bytes(chunk), url, token, args.model, args.lang)
         parts.append(t)
         print(f"  [{off / 4 / SR:6.1f}s] {len(words(t)):4d} words")
-    ref = " ".join(parts)
+    ref = dedupe_seams(parts)
     ref_w = words(ref)
     print(f"\nREFERENCE (single pass): {len(ref_w)} words · {len(ref_w) / audio_sec * 60:.0f} wpm over the delivered audio")
     if args.out:

--- a/core/meetings/eval/src/single_pass_truth.py
+++ b/core/meetings/eval/src/single_pass_truth.py
@@ -190,6 +190,10 @@ def main():
     ap.add_argument("--out", help="write the reference text here")
     ap.add_argument("--reference", help="reuse a previously written reference instead of re-running STT")
     ap.add_argument("--json", help="also write the score block here (for baseline.json)")
+    ap.add_argument("--chunk-offset-sec", type=float, default=0.0,
+                    help="shift every chunk boundary by this much. A word DROPPED at a cut is invisible "
+                         "in one reference; building a second with different cuts makes it visible as a "
+                         "word present there and absent here (G3's remaining half).")
     args = ap.parse_args()
 
     url = os.environ.get("TRANSCRIPTION_SERVICE_URL")
@@ -221,7 +225,13 @@ def main():
     step = int((CHUNK_SEC - OVERLAP_SEC) * SR) * 4
     size = int(CHUNK_SEC * SR) * 4
     parts = []
-    for off in range(0, len(pcm), step):
+    start = int(args.chunk_offset_sec * SR) * 4
+    if start:
+        head = pcm[:start]
+        if len(head) >= SR * 4:
+            parts.append(transcribe(wav_bytes(head), url, token, args.model, args.lang))
+            print(f"  [   0.0s] offset head, {len(words(parts[-1])):4d} words")
+    for off in range(start, len(pcm), step):
         chunk = pcm[off:off + size]
         if len(chunk) < SR * 4:      # < 1s tail, nothing to transcribe
             break

--- a/core/meetings/eval/src/speech_fixture.py
+++ b/core/meetings/eval/src/speech_fixture.py
@@ -68,6 +68,28 @@ def frames_of(samples, start_ms, speaker_index, speaker_name, seq0):
     return frames
 
 
+def mixed_frames(samples, start_ms, seq0):
+    """The MIXED lane's wire shape: one stream, and NO name on any frame.
+
+    The gmeet lane carries the speaker on the frame because capture genuinely knows it (per-
+    participant elements, glow-named at source). Every other platform delivers one mixed stream and
+    names it out-of-band from the DOM — so a mixed fixture must withhold the name here, or it hands
+    the binder the very answer it is being tested on."""
+    frames, seq, n = [], seq0, len(samples)
+    for off in range(0, n, FRAME_SAMPLES):
+        chunk = samples[off:off + FRAME_SAMPLES]
+        f32 = struct.pack(f"<{len(chunk)}f", *(s / 32768.0 for s in chunk))
+        rms = math.sqrt(sum((s / 32768.0) ** 2 for s in chunk) / max(1, len(chunk)))
+        frames.append({
+            "seq": seq, "ts": start_ms + round(off / SAMPLE_RATE * 1000),
+            "speakerIndex": 999,
+            "pcm": base64.b64encode(f32).decode(), "pcm_len": len(chunk),
+            "rms": round(rms, 6), "lane": "mixed",
+        })
+        seq += 1
+    return frames
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--speakers", default="A,B", help="clip-pool ids, e.g. A,B")
@@ -75,30 +97,70 @@ def main():
     ap.add_argument("--gap-ms", type=int, default=800, help="silence between turns")
     ap.add_argument("--out", default="/tmp/speech-fixture")
     ap.add_argument("--started-at", default="2026-07-19T12:00:00.000Z")
+    ap.add_argument("--lane", default="gmeet", choices=["gmeet", "mixed"],
+                    help="gmeet names frames at capture; mixed withholds the name and emits DOM hints")
+    ap.add_argument("--platform", default=None, help="header platform (default follows --lane)")
+    # Hint realism dials. A DOM hint is not a label: the UI lights up late, sometimes never, and
+    # sometimes for the wrong person. These make each of those failure modes reproducible on demand
+    # instead of waiting for a meeting to happen to produce one.
+    ap.add_argument("--hint-lag-ms", type=int, default=250, help="how late the UI notices a speaker")
+    ap.add_argument("--hint-drop", type=float, default=0.0, help="fraction of turns whose hint never arrives")
+    ap.add_argument("--hint-wrong", type=float, default=0.0, help="fraction of turns hinted as the WRONG speaker")
+    ap.add_argument("--seed", type=int, default=7, help="dial randomness is seeded — a fixture must be reproducible")
     args = ap.parse_args()
 
     speakers = args.speakers.split(",")
     pools = {s: load_clips(s) for s in speakers}
 
+    import random
+    rng = random.Random(args.seed)
+    platform = args.platform or ("google_meet" if args.lane == "gmeet" else "zoom")
     header = {
-        "type": "captured_signal_header", "v": 1, "platform": "google_meet",
+        "type": "captured_signal_header", "v": 1, "platform": platform,
         "native_meeting_id": f"speech-{'-'.join(speakers)}-{args.turns}",
-        "language": "en", "lane": "gmeet", "sample_rate": SAMPLE_RATE,
+        "language": "en", "lane": args.lane, "sample_rate": SAMPLE_RATE,
         "started_at": args.started_at,
     }
 
-    lines, truth, t_ms, seq = [json.dumps(header)], [], 0, 0
+    records, truth, t_ms, seq = [], [], 0, 0
     for turn in range(args.turns):
         sid = speakers[turn % len(speakers)]
         text, samples = pools[sid][turn // len(speakers) % len(pools[sid])]
         idx = speakers.index(sid)
-        fr = frames_of(samples, t_ms, idx, NAMES.get(sid, sid), seq)
-        lines += [json.dumps(f) for f in fr]
+        name = NAMES.get(sid, sid)
         dur_ms = round(len(samples) / SAMPLE_RATE * 1000)
-        truth.append({"turn": turn, "speakerIndex": idx, "speaker": NAMES.get(sid, sid),
-                      "text": text, "startMs": t_ms, "endMs": t_ms + dur_ms})
+
+        if args.lane == "mixed":
+            fr = mixed_frames(samples, t_ms, seq)
+            # The hint stream is the ONLY name source on this lane, so its defects are the binder's
+            # whole input. Each dial is applied per turn and recorded in truth, so a scorer can ask
+            # the sharper question: did the binder get it right GIVEN what the DOM told it?
+            hinted, dropped, wrong = name, False, False
+            if rng.random() < args.hint_drop:
+                dropped = True
+            elif rng.random() < args.hint_wrong:
+                others = [NAMES.get(s, s) for s in speakers if s != sid]
+                if others:
+                    hinted, wrong = rng.choice(others), True
+            if not dropped:
+                records.append({"type": "hint", "t": t_ms + args.hint_lag_ms, "name": hinted,
+                                "isEnd": False, "lane": "mixed"})
+                records.append({"type": "hint", "t": t_ms + dur_ms + args.hint_lag_ms, "name": hinted,
+                                "isEnd": True, "lane": "mixed"})
+        else:
+            fr = frames_of(samples, t_ms, idx, name, seq)
+            hinted, dropped, wrong = name, False, False
+
+        records += fr
+        truth.append({"turn": turn, "speakerIndex": idx, "speaker": name,
+                      "text": text, "startMs": t_ms, "endMs": t_ms + dur_ms,
+                      "hintedAs": None if dropped else hinted,
+                      "hintDropped": dropped, "hintWrong": wrong})
         seq += len(fr)
         t_ms += dur_ms + args.gap_ms
+
+    records.sort(key=lambda r: r.get("ts", r.get("t", 0)))
+    lines = [json.dumps(header)] + [json.dumps(r) for r in records]
 
     sig_path, truth_path = f"{args.out}.captured-signal.jsonl", f"{args.out}.truth.json"
     with open(sig_path, "w") as f:
@@ -107,8 +169,13 @@ def main():
         json.dump({"header": header, "turns": truth}, f, indent=2)
 
     words = sum(len(t["text"].split()) for t in truth)
-    print(f"{sig_path}\n  {len(lines)-1} frames · {len(truth)} turns · "
+    nframes = sum(1 for r in records if "pcm" in r)
+    nhints = sum(1 for r in records if r.get("type") == "hint")
+    print(f"{sig_path}\n  {nframes} frames · {nhints} hints · {len(truth)} turns · "
           f"{t_ms/1000:.1f}s · {words} known words · speakers {','.join(sorted({t['speaker'] for t in truth}))}")
+    if args.lane == "mixed":
+        d = sum(1 for t in truth if t["hintDropped"]); w = sum(1 for t in truth if t["hintWrong"])
+        print(f"  hints: lag {args.hint_lag_ms}ms · {d} dropped · {w} wrong")
     print(f"{truth_path}")
 
 

--- a/core/meetings/eval/src/teams-speaker.mjs
+++ b/core/meetings/eval/src/teams-speaker.mjs
@@ -1,0 +1,80 @@
+// A Teams "human" — headless Chromium joins the WEB CLIENT with a WAV as its microphone.
+// Real WebRTC audio with known ground truth, no person and no Teams app.
+//
+//   TEAMS_URL=<meetup-join url> NAME=<display name> WAV=/abs/x.wav [HOLD_MS=180000] node teams-speaker.mjs
+//
+// The sibling of zoom-speaker.mjs, and it exists for the same reason: a quality run needs SPEECH in
+// the room, and a person reading aloud is the one part of the loop that cannot be automated. A WAV
+// cut from the cached TTS corpus carries its own transcript, so the scorer compares against what was
+// actually said rather than against a second STT pass.
+//
+// The selectors are the ones @vexa/join already uses in production (modules/join/src/msteams/
+// selectors.ts) — a speaker that drifts from the bot's own selector set would fail for reasons that
+// say nothing about the pipeline.
+const { chromium } = await import(new URL('../../modules/join/node_modules/playwright/index.mjs', import.meta.url).href);
+
+const URL_ = process.env.TEAMS_URL;
+const NAME = process.env.NAME ?? 'Speaker';
+const WAV = process.env.WAV;
+const HOLD_MS = Number(process.env.HOLD_MS ?? 180000);
+if (!URL_) { console.error('TEAMS_URL is required'); process.exit(1); }
+
+const args = [
+  '--use-fake-ui-for-media-stream',
+  '--use-fake-device-for-media-stream',
+  '--autoplay-policy=no-user-gesture-required',
+  '--disable-dev-shm-usage',
+  '--no-sandbox',
+];
+if (WAV) args.push(`--use-file-for-fake-audio-capture=${WAV}%noloop`);
+
+const ctx = await chromium.launchPersistentContext('', { headless: false, args, permissions: ['microphone', 'camera'] });
+const page = ctx.pages()[0] ?? await ctx.newPage();
+const log = (m) => console.log(`[teams:${NAME}] ${m}`);
+log(`→ ${URL_.slice(0, 60)}…`);
+await page.goto(URL_, { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+// Teams' launcher page offers the desktop app first; the browser client is behind "Continue on this
+// browser". It renders late and sometimes not at all (a direct /_#/ link skips it), so this is a
+// try-if-present, never a wait-for.
+for (const sel of ['button:has-text("Continue on this browser")', 'button:has-text("Continue")']) {
+  const el = page.locator(sel).first();
+  if (await el.isVisible({ timeout: 8000 }).catch(() => false)) {
+    await el.click().catch(() => {});
+    log(`clicked ${sel}`);
+    break;
+  }
+}
+
+// Denied media permission makes Teams render a modal that BLOCKS the prejoin from appearing at all —
+// the same trap join.ts documents. Clicking through it is what lets "Join now" exist.
+const noMedia = page.locator('button:has-text("Continue without audio or video")').first();
+if (await noMedia.isVisible({ timeout: 5000 }).catch(() => false)) {
+  await noMedia.click().catch(() => {});
+  log('cleared the no-media modal');
+}
+
+const nameInput = page.locator('input[placeholder*="name"], input[placeholder*="Name"], input[type="text"]').first();
+await nameInput.waitFor({ state: 'visible', timeout: 60000 });
+await nameInput.fill(NAME);
+log('name entered');
+
+const joinNow = page.locator('button:has-text("Join now")').first();
+await joinNow.waitFor({ state: 'visible', timeout: 30000 });
+await joinNow.click();
+log('clicked Join now');
+
+// A guest lands in the lobby until the host admits. Report which side of that line we are on every
+// 15s: a speaker silently stuck in the lobby looks exactly like a capture failure downstream, and
+// that ambiguity has cost a whole run before.
+const admitted = async () => page.locator('#hangup-button, button[data-tid="hangup-main-btn"], button[aria-label*="Leave"]').first()
+  .isVisible({ timeout: 2000 }).catch(() => false);
+const deadline = Date.now() + HOLD_MS;
+let wasIn = false;
+while (Date.now() < deadline) {
+  const inMeeting = await admitted();
+  if (inMeeting !== wasIn) { log(inMeeting ? 'ADMITTED — speaking' : 'left the meeting'); wasIn = inMeeting; }
+  else if (!inMeeting) log('still in the lobby (nobody has admitted this speaker yet)');
+  await page.waitForTimeout(15000);
+}
+await ctx.close();

--- a/core/meetings/eval/src/teams-speaker.mjs
+++ b/core/meetings/eval/src/teams-speaker.mjs
@@ -73,7 +73,13 @@ const deadline = Date.now() + HOLD_MS;
 let wasIn = false;
 while (Date.now() < deadline) {
   const inMeeting = await admitted();
-  if (inMeeting !== wasIn) { log(inMeeting ? 'ADMITTED — speaking' : 'left the meeting'); wasIn = inMeeting; }
+  if (inMeeting !== wasIn) {
+    // Clip offset zero for score_truth.py: the fake-capture file feeds the track from the moment
+    // the meeting accepts it. Guessing this instant misattributes whole turns while leaving the
+    // content numbers looking fine, which is the worst kind of wrong.
+    if (inMeeting) log(`AUDIO_START=${(Date.now() / 1000).toFixed(3)}`);
+    log(inMeeting ? 'ADMITTED — speaking' : 'left the meeting'); wasIn = inMeeting;
+  }
   else if (!inMeeting) log('still in the lobby (nobody has admitted this speaker yet)');
   await page.waitForTimeout(15000);
 }

--- a/core/meetings/eval/src/zoom-speaker.mjs
+++ b/core/meetings/eval/src/zoom-speaker.mjs
@@ -62,6 +62,12 @@ for (const sel of ['button:has-text("Join Audio by Computer")', 'button:has-text
   }
 }
 
+// Chromium starts the fake-capture file when the mic track is created, i.e. at the moment audio
+// joins — so THIS is clip offset zero. score_truth.py maps a clip's offset to a wall-clock window
+// from this number, and attribution is the half that depends on it: a wrong instant misattributes
+// whole turns while leaving the content numbers untouched. Print it so it is never guessed.
+console.log(`[zoom:${NAME}] AUDIO_START=${(Date.now() / 1000).toFixed(3)}`);
+
 const state = await page.evaluate(() => ({ url: location.href, body: document.body.innerText.slice(0, 220) }));
 console.log(`[zoom:${NAME}] state ${JSON.stringify(state)}`);
 console.log(`[zoom:${NAME}] holding ${HOLD_MS}ms`);

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -311,6 +311,46 @@ async function main(): Promise<void> {
     `${renames.length} renames, ${churned} turns churned · speakers ${publishedSpeakers.size} published vs ${hintNames.size} substantively hinted` +
     (briefNames ? ` (+${briefNames} lit under ${SUBSTANTIVE_LIT_MS / 1000}s, not counted)` : ''));
 
+  // ── Attribution ACCURACY — the truth-bearing oracle ─────────────────────────────────────────
+  // The four signals above say whether a name was assigned. They cannot say whether it was RIGHT,
+  // and a lane that confidently names every turn after the wrong person scores perfectly on all of
+  // them. A synthetic fixture knows who spoke when (`--lane mixed` in speech_fixture.py), so the
+  // question becomes answerable without anyone labelling a meeting.
+  let accuracy: Record<string, number> | null = null;
+  if (process.env.TRUTH_JSON) {
+    const truth = JSON.parse(readFileSync(process.env.TRUTH_JSON, 'utf8')).turns as
+      Array<{ speaker: string; startMs: number; endMs: number; hintedAs: string | null; hintWrong: boolean }>;
+    let correct = 0, wrong = 0, unnamed = 0, scored = 0, correctGivenHint = 0, hintable = 0;
+    for (const row of storeRows) {
+      // Every stored row belongs to the spoken turn it overlaps MOST in time — first-match placement
+      // silently mis-assigns anything that straddles a boundary.
+      const seg = published.find((p) => p.id && store.get(p.id) === row) ?? published.find((p) => p.text === row.text);
+      if (!seg) continue;
+      let best: typeof truth[number] | undefined, bestOv = 0;
+      for (const t of truth) {
+        const ov = Math.min(seg.endMs, t.endMs) - Math.max(seg.startMs, t.startMs);
+        if (ov > bestOv) { bestOv = ov; best = t; }
+      }
+      if (!best) continue;
+      scored++;
+      if (isProvisional(row.speaker)) unnamed++;
+      else if (row.speaker === best.speaker) correct++;
+      else wrong++;
+      // The sharper question: given what the DOM actually told it, did the binder do the right thing?
+      // A turn hinted as the wrong person is the hint stream's failure, not the binder's.
+      if (best.hintedAs && !best.hintWrong) { hintable++; if (row.speaker === best.speaker) correctGivenHint++; }
+    }
+    accuracy = {
+      scoredRows: scored,
+      attrCorrect: correct, attrWrong: wrong, attrUnnamed: unnamed,
+      attrAccuracy: Number((correct / Math.max(1, scored)).toFixed(3)),
+      attrAccuracyGivenGoodHint: Number((correctGivenHint / Math.max(1, hintable)).toFixed(3)),
+    };
+    console.log(`  ACCURACY      ${accuracy.attrCorrect} right · ${accuracy.attrWrong} WRONG · ${accuracy.attrUnnamed} unnamed ` +
+      `of ${scored} rows = ${(accuracy.attrAccuracy * 100).toFixed(1)}% ` +
+      `(given a good hint: ${(accuracy.attrAccuracyGivenGoodHint * 100).toFixed(1)}%)`);
+  }
+
   // A corpus baseline is this block, not the prose above it: a later run diffs against it, so a
   // regression is a failing comparison rather than something someone has to notice in a log.
   if (process.env.METRICS_JSON) {
@@ -339,6 +379,7 @@ async function main(): Promise<void> {
       resendRatio: Number((submitSecs.reduce((a, b) => a + b, 0) / Math.max(1, covered)).toFixed(2)),
       maxSubmitSec: Number(Math.max(0, ...submitSecs).toFixed(1)),
       ...attribution,
+      ...(accuracy ?? {}),
     }, null, 2) + '\n');
     console.log(`  metrics written: ${process.env.METRICS_JSON}`);
   }

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -306,8 +306,15 @@ async function main(): Promise<void> {
     hintNames: hintNames.size,
     briefNames,
   };
+  // "matched" is the hint-hop instrument and nothing more: did this hint find an OPEN TURN TO NAME
+  // AT THE INSTANT IT ARRIVED. A hint 250ms into a turn lands before any audio has been transcribed
+  // into that turn, so it reports missed — and the binder still names the turn correctly afterwards
+  // by max-overlap. Measured on the synthetic zoom-lane fixture: 0 bound on arrival, 8 early, and
+  // attribution accuracy 0.947 with zero wrong. Printing that as "100.0% miss" reads exactly like a
+  // dead hint stream, which is the #852 symptom, so the line says what it measures instead.
   console.log(`  attribution   provisional ${(attribution.provisionalRate * 100).toFixed(1)}% of words · ` +
-    `hints ${hintMatched} matched / ${hintMissed} missed (${(attribution.hintMissRate * 100).toFixed(1)}% miss) · ` +
+    `hint-hop ${hintMatched} bound on arrival / ${hintMissed} arrived before their turn existed ` +
+    `(${(attribution.hintMissRate * 100).toFixed(1)}% — NOT an attribution failure, read ACCURACY below) · ` +
     `${renames.length} renames, ${churned} turns churned · speakers ${publishedSpeakers.size} published vs ${hintNames.size} substantively hinted` +
     (briefNames ? ` (+${briefNames} lit under ${SUBSTANTIVE_LIT_MS / 1000}s, not counted)` : ''));
 

--- a/docs/changelog.d/849-attribution-truth.md
+++ b/docs/changelog.d/849-attribution-truth.md
@@ -1,0 +1,7 @@
+### Added
+
+**Speaker attribution can be scored for correctness without a meeting.** `speech_fixture.py --lane
+mixed` builds a multi-speaker session from known-text TTS clips with the names withheld from the
+audio and delivered as a DOM hint stream — with dials for how late the UI notices a speaker, how
+often it says nothing, and how often it says the wrong name. `TRUTH_JSON=` then scores the published
+transcript against who actually spoke, so "is the name right?" is a command rather than a meeting.

--- a/docs/changelog.d/850-replay-content-scoring.md
+++ b/docs/changelog.d/850-replay-content-scoring.md
@@ -1,0 +1,7 @@
+### Added
+
+**A lane change can now be judged on content, not just structure.** A corpus entry stores the
+transcript its ORIGINAL live session produced, so it can score that session and nothing else — the
+moment code changes, "did this diff lose words?" was unanswerable. `TRANSCRIPT_OUT=` writes the
+transcript a replay produces, and `eval/src/score_replay.py` scores it against either a corpus
+entry's single-pass reference or a synthetic fixture's known text.

--- a/docs/changelog.d/854-coverage-qualifier.md
+++ b/docs/changelog.d/854-coverage-qualifier.md
@@ -1,0 +1,6 @@
+### Fixed
+
+**`coverage` in a corpus lane block is marked as harness-relative.** It sits downstream of
+submission cadence, which an unpaced replay does not reproduce, so it is a regression detector
+against the same fixture's own baseline — never the share of a meeting the lane covers. Measured
+both ways on the same audio: the live session covered 0.808 of its span, a replay of it 0.378.

--- a/docs/changelog.d/854-reference-stability.md
+++ b/docs/changelog.d/854-reference-stability.md
@@ -1,0 +1,7 @@
+### Added
+
+**The reference can now be checked against itself.** `--chunk-offset-sec` builds a second single-pass
+reference with the cuts moved, so a word dropped at a seam — invisible in one pass — shows up as a
+word the other pass found. Two references over identical audio disagree by 4.4% on a clean 94.9%-duty
+session and by 23.9% on a 65%-duty one, where that exceeds the loss being measured. Content figures
+from low-duty entries are marked not citable.

--- a/docs/changelog.d/854-seam-dedupe.md
+++ b/docs/changelog.d/854-seam-dedupe.md
@@ -1,0 +1,7 @@
+### Fixed
+
+**The single-pass reference no longer counts its own chunk overlap twice.** Chunks are cut with 3s
+of shared audio so a word split by the cut still appears — but that audio was transcribed in both
+chunks, so the seam text landed in the reference twice. 122 words (3.2%) on the youtube control, and
+every one scored as a miss against a live transcript that correctly said it once. Streaming loss
+there was overstated as 9.5%; it is at most ~6.3%.

--- a/docs/changelog.d/854-truth-oracle.md
+++ b/docs/changelog.d/854-truth-oracle.md
@@ -1,0 +1,9 @@
+### Added
+
+**The mixed lane now has a quality number that costs no meeting.** A live transcript is scored
+against KNOWN truth — the exact words and speakers of a synthetic session built offline — so recall,
+precision, and attribution are measured without a live call, a labeller, or a reference the pipeline
+could bias. The meeting-free mixed-lane oracle reads recall 0.924 / precision 0.936 / attribution
+0.947, identical across three runs. The reference self-calibrates (G3): a second single-pass pass
+with shifted cuts prices what one pass misses at a seam, retiring the jitsi entry's "27.7% invention"
+as a reference artifact, not a pipeline defect.


### PR DESCRIPTION
## What this delivers

A live transcript scored against **KNOWN truth** — the exact words and speakers of a synthetic mixed-lane session built offline — so the mixed lane gets a quality number with **no meeting, no labeller, and no reference the pipeline could bias**.

**Headline numbers (meeting-free mixed-lane oracle):** recall **0.924** / precision **0.936** / attribution **0.947** — **identical across 3 runs**.

**Reference self-calibration (G3):** a second single-pass reference with shifted cuts prices what one pass misses at a seam. This is where the **"27.7% invention" retraction** rides (389cfa97): that figure was a reference overlap artifact, not a pipeline defect — the reference was double-counting its own 3s chunk overlap. Streaming loss on the youtube control was overstated as 9.5%; it is at most ~6.3%.

## Acceptance (#854)

| # | Observation | Evidence in this bundle |
|---|---|---|
| A1 | Loss and invention attributed to a named stage with recorded evidence | reference-diff scorers (`score_replay.py`, `score_truth.py`); seam-dedupe fragment attributes 3.2% of the "invention" to reference overlap |
| A2 | recall ≥0.95 / precision not regressed | meeting-free oracle recall **0.924** on synthetic truth; reference self-calibration shows the residual seam loss is a reference artifact, not pipeline loss |
| A3 | precision ≥0.97 / invention halved | oracle precision **0.936**; "27.7% invention" retracted to reference-side (389cfa97) |
| A4 | mid-sentence / torn-turn endings reduced | seam-dedupe + coverage-qualifier fragments |
| A5 | live re-witness reads as sentences | two-leg witness recorded (98a7bb94): quality through the extension, speakers through the bot |
| A- | negative control: mixed suites green; jitsi capture defect unchanged (belongs to #850) | `node scripts/gates.mjs all` green (incl. eval, replay, eval-baseline); turbo build 17/17 |

## Validation

- `pnpm turbo build` — 17/17 successful
- `node scripts/gates.mjs all` — **green** (readme … contract-conformance, incl. eval / replay / eval-baseline / telemetry)

## Stack & retarget

PR 5 of the v0.12.17 series. Stack: #869 → #871 → #872 → #873 (`fix/852-zoom-attribution`).
- **Base = `fix/852-zoom-attribution`** — retarget to the merge target as the stack lands.
- 16 cherry-picks (`-x`) from `quality/0.12.17-base`, eval-heavy (scorers, corpus/framework docs, synthetic-participant tests) + one changelog fragment for the headline oracle story.

**Milestone:** v0.12.17. Closes #854 (on merge, once the stack retargets).
