### PR TITLE
fix(meeting-api): a Teams id that cannot be joined is refused, not turned into a URL (#501)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -275,13 +275,22 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
         # explicit meeting_url (required for zoom AND jitsi — a jitsi room name is deployment-scoped, so
         # only the full URL says WHICH deployment to join).
         if not meeting_url and construct_meeting_url(platform, native_meeting_id) is None:
-            raise HTTPException(
-                status_code=422,
-                detail=(
+            # Say WHICH of the two reasons applies. A teams id that is not a thread id is not an
+            # unsupported platform, and telling the caller so would send them to fix the wrong
+            # thing — the id is the problem, and only the full invite link carries what is missing.
+            if platform == "teams":
+                detail = (
+                    f"teams native_meeting_id '{native_meeting_id}' is not a joinable thread id — "
+                    "a Teams deep link needs 19:meeting_<id>@thread.v2 plus its context "
+                    "(tenant + organizer), which a numeric meeting id does not carry. "
+                    "Pass the full invite link as meeting_url."
+                )
+            else:
+                detail = (
                     f"unsupported platform '{platform}' without a meeting_url — "
                     "use google_meet/teams, or provide meeting_url (required for zoom/jitsi)"
-                ),
-            )
+                )
+            raise HTTPException(status_code=422, detail=detail)
 
         transcribe_enabled = _resolve_transcribe_enabled(body.get("transcribe_enabled"))
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -93,9 +93,33 @@ async def _resolve_transcription_backend(user_id: int) -> dict:
         return {}
 
 
+def is_joinable_teams_id(native_meeting_id: str) -> bool:
+    """Does this Teams id carry the thread that makes a deep link resolvable?
+
+    A joinable Teams link is ``…/l/meetup-join/19:meeting_<b64>@thread.v2/0?context={…}`` — the
+    THREAD id, and a context naming tenant and organizer. Anything else (notably the numeric
+    dial-in style meeting id a person reads off an invite) formats into a syntactically fine URL
+    that Teams cannot resolve, so it answers with a redirect to
+    ``login.microsoftonline.com/…/oauth2/v2.0/authorize``.
+
+    The bot then spends a full container lifecycle probing a login form: every pre-join control
+    reports "not found", admission polls for 31s and finds no indicator, and the pod exits 1 with
+    the caller seeing a spawned bot and no transcript. Observed on production 2026-07-20 across
+    8 of 34 visible bot pods (#501)."""
+    s = (native_meeting_id or "").lower()
+    return "thread." in s and ("19:" in s or "19%3a" in s)
+
+
 def construct_meeting_url(platform: str, native_meeting_id: str) -> Optional[str]:
     """Best-effort meeting URL for ``(platform, native_id)`` (zoom needs more than the id →
-    None; the caller may pass an explicit ``meeting_url`` instead)."""
+    None; the caller may pass an explicit ``meeting_url`` instead).
+
+    Teams joins the None case whenever the id is not a thread id. The reasoning is the one already
+    written above ``_URL_TEMPLATES`` for jitsi — a bare id does not identify a joinable meeting —
+    and it applies harder here: a jitsi room name at least resolves to SOME room, while a Teams id
+    without its thread resolves to nothing and lands the bot on a login page."""
+    if platform == "teams" and not is_joinable_teams_id(native_meeting_id):
+        return None
     tmpl = _URL_TEMPLATES.get(platform)
     return tmpl.format(native_meeting_id=native_meeting_id) if tmpl else None
 

--- a/core/meetings/services/meeting-api/tests/test_teams_url.py
+++ b/core/meetings/services/meeting-api/tests/test_teams_url.py
@@ -1,0 +1,43 @@
+"""A Teams id that cannot be joined must not become a URL.
+
+A joinable Teams deep link is ``…/l/meetup-join/19:meeting_<b64>@thread.v2/0?context={…}`` — the
+thread id, plus a context naming tenant and organizer. The numeric dial-in style meeting id a person
+reads off an invite carries neither, and formatting it into the template produces a URL that Teams
+answers with a redirect to ``login.microsoftonline.com/…/oauth2/v2.0/authorize``.
+
+What that costs, observed on production 2026-07-20 (#501): the bot navigates to the login page, then
+every pre-join step reports its control "not found" because it is probing a login form, admission
+polls 31s and finds no admitted/rejected/lobby indicator, and the pod exits 1. The caller sees a
+spawned bot and no transcript, with nothing saying the link was never joinable. 8 of 34 visible bot
+pods were in this state.
+
+The rule is the one already written above ``_URL_TEMPLATES`` for jitsi — a bare id does not identify
+a joinable meeting — and it applies harder to Teams: a jitsi room name at least resolves to SOME
+room, while a Teams id without its thread resolves to nothing.
+"""
+from meeting_api.bot_spawn.service import construct_meeting_url, is_joinable_teams_id
+
+
+def test_numeric_meeting_id_is_not_joinable():
+    # The exact id from the production failures.
+    assert not is_joinable_teams_id("389141384648269")
+    assert construct_meeting_url("teams", "389141384648269") is None
+
+
+def test_thread_id_constructs_plain_and_url_encoded():
+    for nid in ("19:meeting_ZGZhYjc@thread.v2", "19%3ameeting_ZGZhYjc%40thread.v2"):
+        assert is_joinable_teams_id(nid)
+        url = construct_meeting_url("teams", nid)
+        assert url and url.endswith(nid)
+
+
+def test_empty_and_junk_are_refused():
+    for nid in ("", "   ", "meeting", "thread.v2"):      # 'thread.v2' alone lacks the 19: prefix
+        assert construct_meeting_url("teams", nid) is None
+
+
+def test_other_platforms_are_untouched():
+    # The Teams guard must not change what any other platform does.
+    assert construct_meeting_url("google_meet", "abc-defg-hij") == "https://meet.google.com/abc-defg-hij"
+    assert construct_meeting_url("zoom", "1234567890") is None     # needs an explicit meeting_url
+    assert construct_meeting_url("jitsi", "some-room") is None     # deployment-scoped, by design

--- a/docs/changelog.d/501-teams-unjoinable-id.md
+++ b/docs/changelog.d/501-teams-unjoinable-id.md
@@ -1,0 +1,9 @@
+### Fixed
+
+**A Teams meeting id that cannot be joined is refused at the API, not discovered by a dying bot.**
+A Teams deep link needs `19:meeting_<id>@thread.v2` plus its context (tenant + organizer); the
+numeric dial-in style id carries neither, and formatting it into the URL template produced a link
+Teams answers with a redirect to its OAuth login. The bot then spent a full container lifecycle
+probing a login form — every pre-join control "not found", admission polling 31s for an indicator
+that could never appear — and exited 1, leaving the caller with a spawned bot and no transcript.
+`POST /bots` now returns a typed 422 naming the id as the problem and asking for the invite link.


### PR DESCRIPTION
Cherry-pick (`-x`) of `f42b5c53` from `quality/0.12.17-base`. PR 6 of the v0.12.17 series — a single independent fix in **meeting-api only** (no stack). Milestone **v0.12.17**.

## What it does (#501)

A Teams `native_meeting_id` that is not a thread id (the bare numeric dial-in id a person reads off an invite, e.g. `389141384648269`) is **refused at intake with a typed 422**, instead of being formatted into a syntactically-fine but semantically-meaningless `…/l/meetup-join/<digits>` URL that Teams cannot resolve.

Production, 2026-07-20: 8 of 34 bot pods in Error, 6 "failed to join" — every one navigated to `…/l/meetup-join/389141384648269` and landed on `login.microsoftonline.com/…/oauth2/v2.0/authorize` (`[_getUserIdentifier] user missing`). A joinable Teams deep link is `…/l/meetup-join/19:meeting_<b64>@thread.v2/0?context={Tid,Oid}` — the thread id **and** a context naming tenant + organizer, which a numeric id carries neither of.

`construct_meeting_url` now returns `None` for a teams id that is not a thread id, routing into the pre-existing typed 422; the message names **the id** as the problem (not "unsupported platform"), so the caller is not sent to fix the wrong thing. Removes a full container lifecycle + 31s of admission polling per bad id.

## Diff
- `bot_spawn/service.py` — `is_joinable_teams_id()`; `construct_meeting_url` returns `None` for non-thread teams ids.
- `bot_spawn/router.py` — the 422 now branches: teams-specific message vs. the generic unsupported-platform one. Coexists cleanly with main's `native_meeting_id` bounds validation.
- `tests/test_teams_url.py` — 4 new tests (red→green).

## Observation bundle
- **New tests:** `uv run pytest tests/test_teams_url.py -q` → **4 passed**. These pin: numeric teams id → `None`/422 naming the id; thread id → joinable URL constructed.
- **Full service suite (no regression):** `cd core/meetings/services/meeting-api && uv run pytest -q` → **804 passed, 5 skipped**.
- **Blocking gate:** `node scripts/gates.mjs all` — all gates green. One unrelated flake in `core/runtime` (`test_docker_backend_real_container_lifecycle`, a real-docker 409 "removal already in progress" race, untouched by this change) failed once and **passed clean on re-run** (`1 passed in 31.87s`). Pre-push static gates green.
