### PR TITLE
fix(mixed): a turn whose speaker the platform already named never publishes as seg_N (#868)

### DIFF
--- a/core/meetings/modules/mixed-pipeline/package.json
+++ b/core/meetings/modules/mixed-pipeline/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/draft-identity.test.ts && tsx src/hole-timebase.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts && tsx src/handover.smoke.test.ts",
+    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/draft-identity.test.ts && tsx src/hole-timebase.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts && tsx src/handover.smoke.test.ts && tsx src/tie-swamp.smoke.test.ts && tsx src/flicker-evict.smoke.test.ts && tsx src/sweep-adjudicate.smoke.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/mixed-pipeline/package.json
+++ b/core/meetings/modules/mixed-pipeline/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/draft-identity.test.ts && tsx src/hole-timebase.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts",
+    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/draft-identity.test.ts && tsx src/hole-timebase.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts && tsx src/handover.smoke.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -787,6 +787,10 @@ export class ChunkedTranscriber {
     if (r.source !== 'provisional-cluster-id') {
       this.binder.recordClusterVote(turn.clusterId, r.speakerName);
       turn.resolvedName = r.speakerName;
+    } else {
+      const d = this.binder.explainMatch(commit);
+      const b = d.best ? ` best=${d.best.name} support=${Math.round(d.best.supportMs)}ms cov=${d.best.coverage.toFixed(2)} conf=${d.best.confidence.toFixed(2)}` : '';
+      this.log(`[binder-reject] ${turn.clusterId} [${Math.round(turn.t0)},${Math.round(turn.t1)}] reason=${d.reject} candidates=${d.candidates} flickerSkipped=${d.flickerSkipped}${b}`);
     }
     return r.speakerName;
   }

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -210,6 +210,10 @@ interface UnresolvedTurn { clusterId: string; t0: number; t1: number; blockedNam
  *  heartbeat could be the tail of the same blip; two (~4s apart on the Zoom/Teams
  *  re-assert cadence) is a speaker who is still talking. */
 const REASSERT_UNBLOCK_COUNT = 2;
+/** How long after a held turn's end a blocked name's fresh hints still count as
+ *  testimony about it. Two heartbeats plus slack; past this, the room has moved
+ *  on and the hold stands. */
+const REASSERT_WINDOW_MS = 8000;
 
 function rms(s: Float32Array): number {
   if (s.length === 0) return 0;
@@ -370,17 +374,23 @@ export class ChunkedTranscriber {
     for (const u of this.unresolved) {
       const blocked = u.blockedNames ?? new Set<string>();
       const m = this.binder.matchWindow({ clusterId: u.clusterId, tStartMs: u.t0, tEndMs: u.t1 });
-      if (m && blocked.has(m.name) && name === m.name) {
-        // The held-back name is speaking AGAIN (this very hint is fresh testimony,
-        // not a re-read of the slice that got it blocked). A transient flip never
-        // re-asserts; a real speaker's heartbeat does — after enough, lift the block.
-        const seen = (u.reasserted ??= new Map()).get(m.name) ?? 0;
-        if (seen + 1 >= REASSERT_UNBLOCK_COUNT) {
-          blocked.delete(m.name);
-          this.log(`[ChunkedTranscriber] short-UI block lifted for "${m.name}" on ${u.clusterId} — re-asserted ×${seen + 1}`);
-        } else {
-          u.reasserted.set(m.name, seen + 1);
+      if (!isEnd && blocked.has(name) && tMs - u.t1 <= REASSERT_WINDOW_MS) {
+        // The held-back name is speaking AGAIN. The hold vetoed a window-match that
+        // had already passed every binder gate, on suspicion of a tile flip — and a
+        // transient flip never re-asserts, while a real speaker's heartbeat does.
+        // Fresh testimony is judged on ARRIVAL TIME (within a couple of heartbeats
+        // of the held turn's end), not on re-matching the past window, which a
+        // later hint can never do. At the threshold the suspicion is disproved:
+        // the original match stands — lift and claim.
+        const seen = ((u.reasserted ??= new Map()).get(name) ?? 0) + 1;
+        if (seen >= REASSERT_UNBLOCK_COUNT) {
+          blocked.delete(name);
+          this.log(`[ChunkedTranscriber] short-UI block lifted for "${name}" on ${u.clusterId} — re-asserted ×${seen}`);
+          this.claimTurn(u.clusterId, name);
+          matchedNow = true;
+          continue;
         }
+        u.reasserted.set(name, seen);
       }
       if (m && !blocked.has(m.name)) { this.claimTurn(u.clusterId, m.name); matchedNow = true; continue; }   // window-matched → repaint, drop
       if (u.t1 >= claimFrom && !blocked.has(name)) { this.claimTurn(u.clusterId, name); matchedNow = true; } // late-box gap → claim for this speaker

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -214,6 +214,13 @@ const REASSERT_UNBLOCK_COUNT = 2;
  *  testimony about it. Two heartbeats plus slack; past this, the room has moved
  *  on and the hold stands. */
 const REASSERT_WINDOW_MS = 8000;
+/** A held turn is adjudicated by the SWEEP once its re-assertion window has
+ *  passed: if the held-back name's total lit time around the turn reaches this,
+ *  it was a speaker (heartbeats total seconds), not a tile flip (one short
+ *  slice) — the vetoed match stands and the turn repaints. */
+const REAL_SPEAKER_LIT_MS = 2000;
+/** Audio-time cadence for the held-turn sweep. */
+const SWEEP_EVERY_MS = 1000;
 
 function rms(s: Float32Array): number {
   if (s.length === 0) return 0;
@@ -241,6 +248,7 @@ export class ChunkedTranscriber {
   private queue: Array<SegItem | 'tick'> = [];
   /** Timestamp of the freshest audio in the ring (the live edge). */
   private latestAudioMs = 0;
+  private lastSweepMs = 0;
   private pumping = false;
   private lastConfirmedText = '';
   /** Audio-time end of the last processed commit — used to detect the silence
@@ -329,6 +337,10 @@ export class ChunkedTranscriber {
     if (this.disposed) return;
     if (this.firstAudioMs === null) this.firstAudioMs = tsMs;
     this.latestAudioMs = Math.max(this.latestAudioMs, tsMs + (pcm.length / SAMPLE_RATE) * 1000);
+    if (this.latestAudioMs - this.lastSweepMs >= SWEEP_EVERY_MS) {
+      this.lastSweepMs = this.latestAudioMs;
+      this.sweepHeld(this.latestAudioMs);
+    }
     this.ring.push({ pcm, tMs: tsMs });
     this.ringMs += (pcm.length / SAMPLE_RATE) * 1000;
     while (this.ring.length > 0 && this.ringMs > RING_MS) {
@@ -400,6 +412,36 @@ export class ChunkedTranscriber {
     report();
   }
 
+  /** THE SWEEP (audio-clock driven, and once more at dispose): adjudicate every
+   *  held or unnamed turn whose re-assertion window has closed, against the
+   *  hints ALREADY recorded. A hold must not depend on a future hint — under
+   *  hint-leads-turn interleaving there is none — and it must not be a life
+   *  sentence: the binder match the hold vetoed either stands (the name shows
+   *  real lit time around the turn) or the turn stays provisional. */
+  private sweepHeld(nowMs: number): void {
+    if (this.unresolved.length === 0) return;
+    const still: UnresolvedTurn[] = [];
+    for (const u of this.unresolved) {
+      if (nowMs < u.t1 + REASSERT_WINDOW_MS) { still.push(u); continue; }
+      const m = this.binder.matchWindow({ clusterId: u.clusterId, tStartMs: u.t0, tEndMs: u.t1 });
+      if (!m) { still.push(u); continue; }
+      const blocked = u.blockedNames;
+      if (blocked?.has(m.name)) {
+        const lit = this.binder.litMsAround(m.name, u.t0 - REASSERT_WINDOW_MS, u.t1 + REASSERT_WINDOW_MS);
+        if (lit >= REAL_SPEAKER_LIT_MS) {
+          blocked.delete(m.name);
+          this.log(`[ChunkedTranscriber] sweep adjudicated ${u.clusterId} → "${m.name}" (lit ${Math.round(lit)}ms around the turn — a speaker, not a flip)`);
+          this.claimTurn(u.clusterId, m.name);
+          continue;
+        }
+        still.push(u);   // one short slice — the flip suspicion stands
+        continue;
+      }
+      this.claimTurn(u.clusterId, m.name);   // ordinary late window-match, no hold involved
+    }
+    this.unresolved = still;
+  }
+
   /** Late-box claim: repaint a provisional turn's published segments under `name`
    *  (the speaker whose box just lit). Same path as a binder rename. */
   private claimTurn(clusterId: string, name: string): void {
@@ -429,6 +471,9 @@ export class ChunkedTranscriber {
     while (this.pumping) await new Promise(r => setTimeout(r, 50));
     await this.pump(true);
     while (this.pumping) await new Promise(r => setTimeout(r, 50));
+    // Final adjudication: every held turn gets its sweep verdict from the full
+    // hint log before the session ends — a hold is never left undecided.
+    this.sweepHeld(Infinity);
     try { this.segmenter?.reset(); } catch { /* best effort */ }
   }
 

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -200,8 +200,16 @@ interface Turn {
 }
 /** A committed turn whose hint hasn't arrived yet (provisional segmentation id) —
  *  re-resolved when a later hint produces a window match. Segments live in
- *  clusterSegments, so only the window + key are kept here. */
-interface UnresolvedTurn { clusterId: string; t0: number; t1: number; blockedNames?: Set<string> }
+ *  clusterSegments, so only the window + key are kept here. `reasserted` counts
+ *  FRESH post-hold hints per blocked name: a transient tile flip never speaks
+ *  again, so a blocked name that keeps re-asserting was the real speaker and
+ *  earns its claim back (see recordHint). */
+interface UnresolvedTurn { clusterId: string; t0: number; t1: number; blockedNames?: Set<string>; reasserted?: Map<string, number> }
+
+/** Fresh hints of a held-back name needed to lift a short-UI-switch block. One
+ *  heartbeat could be the tail of the same blip; two (~4s apart on the Zoom/Teams
+ *  re-assert cadence) is a speaker who is still talking. */
+const REASSERT_UNBLOCK_COUNT = 2;
 
 function rms(s: Float32Array): number {
   if (s.length === 0) return 0;
@@ -362,6 +370,18 @@ export class ChunkedTranscriber {
     for (const u of this.unresolved) {
       const blocked = u.blockedNames ?? new Set<string>();
       const m = this.binder.matchWindow({ clusterId: u.clusterId, tStartMs: u.t0, tEndMs: u.t1 });
+      if (m && blocked.has(m.name) && name === m.name) {
+        // The held-back name is speaking AGAIN (this very hint is fresh testimony,
+        // not a re-read of the slice that got it blocked). A transient flip never
+        // re-asserts; a real speaker's heartbeat does — after enough, lift the block.
+        const seen = (u.reasserted ??= new Map()).get(m.name) ?? 0;
+        if (seen + 1 >= REASSERT_UNBLOCK_COUNT) {
+          blocked.delete(m.name);
+          this.log(`[ChunkedTranscriber] short-UI block lifted for "${m.name}" on ${u.clusterId} — re-asserted ×${seen + 1}`);
+        } else {
+          u.reasserted.set(m.name, seen + 1);
+        }
+      }
       if (m && !blocked.has(m.name)) { this.claimTurn(u.clusterId, m.name); matchedNow = true; continue; }   // window-matched → repaint, drop
       if (u.t1 >= claimFrom && !blocked.has(name)) { this.claimTurn(u.clusterId, name); matchedNow = true; } // late-box gap → claim for this speaker
       else still.push(u);

--- a/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
+++ b/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
@@ -242,7 +242,7 @@ export class ClusterNameBinder {
     const supportStart = commit.tStartMs - HINT_SUPPORT_SLACK_MS;
     const supportEnd = commit.tEndMs + HINT_SUPPORT_SLACK_MS;
     const commitDur = Math.max(1, commit.tEndMs - commit.tStartMs);
-    const agg = new Map<string, { ms: number; supportMs: number; lastStart: number }>();
+    const agg = new Map<string, { ms: number; supportMs: number; inSpanMs: number; lastStart: number }>();
 
     let flickerSkipped = 0;
     for (const log of this.turns.values()) {
@@ -261,8 +261,9 @@ export class ClusterNameBinder {
         if (o <= 0) continue;
         const support = Math.max(0, Math.min(turnEnd, supportEnd) - Math.max(turn.tStartMs, supportStart));
         if (support <= 0) continue;
-        const a = agg.get(turn.name) ?? { ms: 0, supportMs: 0, lastStart: -Infinity };
-        a.ms += o; a.supportMs += support; a.lastStart = Math.max(a.lastStart, turn.tStartMs);
+        const inSpan = Math.max(0, Math.min(turnEnd, commit.tEndMs) - Math.max(turn.tStartMs, commit.tStartMs));
+        const a = agg.get(turn.name) ?? { ms: 0, supportMs: 0, inSpanMs: 0, lastStart: -Infinity };
+        a.ms += o; a.supportMs += support; a.inSpanMs += inSpan; a.lastStart = Math.max(a.lastStart, turn.tStartMs);
         agg.set(turn.name, a);
       }
     }
@@ -271,17 +272,28 @@ export class ClusterNameBinder {
     // Most overlap-ms wins; on a near-tie (within RECENCY_TIE_MS) the MORE RECENT
     // hint wins — so a previous speaker's still-open turn can't out-vote the speaker
     // who actually just started.
-    let best: { name: string; ms: number; supportMs: number; lastStart: number } | null = null;
+    let best: { name: string; ms: number; supportMs: number; inSpanMs: number; lastStart: number } | null = null;
     let totalSupportMs = 0;
+    let totalInSpanMs = 0;
     for (const [name, a] of agg) {
       totalSupportMs += a.supportMs;
+      totalInSpanMs += a.inSpanMs;
       if (!best) { best = { name, ...a }; continue; }
       if (a.supportMs > best.supportMs + RECENCY_TIE_MS) best = { name, ...a };
       else if (a.supportMs >= best.supportMs - RECENCY_TIE_MS && a.lastStart > best.lastStart) best = { name, ...a };
     }
     if (!best) return { result: null, reject: 'no-hint-overlap', candidates: agg.size, flickerSkipped };
     const coverage = Math.min(1, best.supportMs / commitDur);
-    const confidence = totalSupportMs > 0 ? best.supportMs / totalSupportMs : 0;
+    // Confidence is CONTESTED-NESS INSIDE THE COMMIT SPAN. The ±support slack exists to
+    // absorb hint-lag jitter, not to give the neighbouring speaker's adjacent speech a
+    // vote: with sub-second diarizer turns, a handover commit fully covered by one name
+    // was still scoring conf<0.6 because the previous speaker's closed heartbeat slices
+    // sat inside the slack — 10 of 13 unnamed turns on the botsig9 red arm (#868). When
+    // no hint time falls inside the span at all (pure lag), the slack-window share is
+    // the only evidence there is, and judges as before.
+    const confidence = totalInSpanMs > 0
+      ? best.inSpanMs / totalInSpanMs
+      : (totalSupportMs > 0 ? best.supportMs / totalSupportMs : 0);
     const bestDiag = { name: best.name, supportMs: best.supportMs, coverage, confidence };
     const requiredSupport = Math.min(MIN_MATCH_SUPPORT_MS, commitDur * 0.8);
     if (best.supportMs < requiredSupport) return { result: null, reject: 'support', candidates: agg.size, flickerSkipped, best: bestDiag };

--- a/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
+++ b/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
@@ -248,13 +248,20 @@ export class ClusterNameBinder {
     for (const log of this.turns.values()) {
       for (const turn of log) {
         // FLICKER DEBOUNCE: a closed turn shorter than the window is a transient (noise
-        // burst / UI blip), never a real turn — skip it so it can't steal a segment.
+        // burst / UI blip) — but only when it carries NO in-span evidence. A short slice
+        // that intersects the commit span itself is testimony about who lit DURING the
+        // commit, and evicting it handed the window to the lagging neighbour (the sole
+        // remaining candidate) on the botsig9 red (#868). Out-of-span transients still
+        // can't steal a segment: in-span ranking + in-span confidence outvote them.
         if (turn.tEndMs !== undefined && turn.tEndMs - turn.tStartMs < FLICKER_MIN_MS) {
-          // Count only flickers that would otherwise have overlapped this window,
-          // so the diagnostic names what the debounce actually cost here.
           const fEnd = turn.tEndMs;
-          if (Math.min(fEnd, windowEnd) - Math.max(turn.tStartMs, windowStart) > 0) flickerSkipped++;
-          continue;
+          const inSpanHere = Math.min(fEnd, commit.tEndMs) - Math.max(turn.tStartMs, commit.tStartMs);
+          if (inSpanHere <= 0) {
+            // Count only flickers that would otherwise have overlapped this window,
+            // so the diagnostic names what the debounce actually cost here.
+            if (Math.min(fEnd, windowEnd) - Math.max(turn.tStartMs, windowStart) > 0) flickerSkipped++;
+            continue;
+          }
         }
         const turnEnd = turn.tEndMs ?? (turn.tStartMs + OPEN_TURN_GRACE_MS);
         const o = Math.max(0, Math.min(turnEnd, windowEnd) - Math.max(turn.tStartMs, windowStart));
@@ -275,12 +282,25 @@ export class ClusterNameBinder {
     let best: { name: string; ms: number; supportMs: number; inSpanMs: number; lastStart: number } | null = null;
     let totalSupportMs = 0;
     let totalInSpanMs = 0;
+    for (const [name, a] of agg) { totalSupportMs += a.supportMs; totalInSpanMs += a.inSpanMs; }
+    // Winner selection prefers IN-SPAN evidence: the name that actually lit during
+    // the commit beats the name whose support piled up in the ±slack (the lagging
+    // previous speaker's heartbeat slices — on the botsig9 red those were chosen as
+    // best with inSpanMs=0 and then rejected at confidence 0.00, #868). Only when
+    // NOBODY lit in-span (pure hint lag) does slack support choose, as before.
+    // The tie window must live on the metric's own scale: in-span durations are
+    // bounded by the commit (sub-second here), so the slack-scale RECENCY_TIE_MS
+    // would call EVERY comparison a tie and let recency — the neighbour's latest
+    // heartbeat — decide anyway (the pass-two regression). In-span ties are a
+    // fifth of the larger claim, floored at 50ms; recency still breaks real ties.
+    const inSpanRank = totalInSpanMs > 0;
     for (const [name, a] of agg) {
-      totalSupportMs += a.supportMs;
-      totalInSpanMs += a.inSpanMs;
       if (!best) { best = { name, ...a }; continue; }
-      if (a.supportMs > best.supportMs + RECENCY_TIE_MS) best = { name, ...a };
-      else if (a.supportMs >= best.supportMs - RECENCY_TIE_MS && a.lastStart > best.lastStart) best = { name, ...a };
+      const av = inSpanRank ? a.inSpanMs : a.supportMs;
+      const bv = inSpanRank ? best.inSpanMs : best.supportMs;
+      const tie = inSpanRank ? Math.max(50, 0.2 * Math.max(av, bv)) : RECENCY_TIE_MS;
+      if (av > bv + tie) best = { name, ...a };
+      else if (av >= bv - tie && a.lastStart > best.lastStart) best = { name, ...a };
     }
     if (!best) return { result: null, reject: 'no-hint-overlap', candidates: agg.size, flickerSkipped };
     const coverage = Math.min(1, best.supportMs / commitDur);

--- a/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
+++ b/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
@@ -122,6 +122,20 @@ export interface ResolveOptions {
   recordVote?: boolean;
 }
 
+/** Why a window-match returned null (or that it didn't) — per-commit, for the
+ *  attribution instruments (#849/#852). `no-hint-overlap` = no hint turn touched
+ *  the tolerance window at all; the gate reasons mean a candidate existed and a
+ *  specific threshold rejected it. */
+export interface MatchDiagnostics {
+  result: { name: string; confidence: number } | null;
+  reject?: 'no-hint-overlap' | 'support' | 'coverage' | 'confidence';
+  /** Distinct candidate names that overlapped the window. */
+  candidates: number;
+  /** Hint turns skipped by the flicker debounce while scanning this window. */
+  flickerSkipped: number;
+  best?: { name: string; supportMs: number; coverage: number; confidence: number };
+}
+
 interface HintTurn {
   name: string;
   /** Lag-corrected start (ms). */
@@ -210,7 +224,17 @@ export class ClusterNameBinder {
     return this.windowMatch(commit);
   }
 
+  /** windowMatch with its working shown: the same scan, but reporting WHICH gate
+   *  rejected the best candidate (or that none overlapped). Read-only. */
+  explainMatch(commit: CommitInfo): MatchDiagnostics {
+    return this.windowMatchDiag(commit);
+  }
+
   private windowMatch(commit: CommitInfo): { name: string; confidence: number } | null {
+    return this.windowMatchDiag(commit).result;
+  }
+
+  private windowMatchDiag(commit: CommitInfo): MatchDiagnostics {
     // Hints are already lag-corrected at insert, so the commit window only
     // needs tolerance slack.
     const windowStart = commit.tStartMs - this.matchToleranceMs;
@@ -220,11 +244,18 @@ export class ClusterNameBinder {
     const commitDur = Math.max(1, commit.tEndMs - commit.tStartMs);
     const agg = new Map<string, { ms: number; supportMs: number; lastStart: number }>();
 
+    let flickerSkipped = 0;
     for (const log of this.turns.values()) {
       for (const turn of log) {
         // FLICKER DEBOUNCE: a closed turn shorter than the window is a transient (noise
         // burst / UI blip), never a real turn — skip it so it can't steal a segment.
-        if (turn.tEndMs !== undefined && turn.tEndMs - turn.tStartMs < FLICKER_MIN_MS) continue;
+        if (turn.tEndMs !== undefined && turn.tEndMs - turn.tStartMs < FLICKER_MIN_MS) {
+          // Count only flickers that would otherwise have overlapped this window,
+          // so the diagnostic names what the debounce actually cost here.
+          const fEnd = turn.tEndMs;
+          if (Math.min(fEnd, windowEnd) - Math.max(turn.tStartMs, windowStart) > 0) flickerSkipped++;
+          continue;
+        }
         const turnEnd = turn.tEndMs ?? (turn.tStartMs + OPEN_TURN_GRACE_MS);
         const o = Math.max(0, Math.min(turnEnd, windowEnd) - Math.max(turn.tStartMs, windowStart));
         if (o <= 0) continue;
@@ -235,7 +266,7 @@ export class ClusterNameBinder {
         agg.set(turn.name, a);
       }
     }
-    if (agg.size === 0) return null;
+    if (agg.size === 0) return { result: null, reject: 'no-hint-overlap', candidates: 0, flickerSkipped };
 
     // Most overlap-ms wins; on a near-tie (within RECENCY_TIE_MS) the MORE RECENT
     // hint wins — so a previous speaker's still-open turn can't out-vote the speaker
@@ -248,14 +279,15 @@ export class ClusterNameBinder {
       if (a.supportMs > best.supportMs + RECENCY_TIE_MS) best = { name, ...a };
       else if (a.supportMs >= best.supportMs - RECENCY_TIE_MS && a.lastStart > best.lastStart) best = { name, ...a };
     }
-    if (!best) return null;
+    if (!best) return { result: null, reject: 'no-hint-overlap', candidates: agg.size, flickerSkipped };
     const coverage = Math.min(1, best.supportMs / commitDur);
     const confidence = totalSupportMs > 0 ? best.supportMs / totalSupportMs : 0;
+    const bestDiag = { name: best.name, supportMs: best.supportMs, coverage, confidence };
     const requiredSupport = Math.min(MIN_MATCH_SUPPORT_MS, commitDur * 0.8);
-    if (best.supportMs < requiredSupport) return null;
-    if (coverage < MIN_MATCH_COVERAGE) return null;
-    if (confidence < MIN_MATCH_CONFIDENCE) return null;
-    return { name: best.name, confidence: Math.min(coverage, confidence) };
+    if (best.supportMs < requiredSupport) return { result: null, reject: 'support', candidates: agg.size, flickerSkipped, best: bestDiag };
+    if (coverage < MIN_MATCH_COVERAGE) return { result: null, reject: 'coverage', candidates: agg.size, flickerSkipped, best: bestDiag };
+    if (confidence < MIN_MATCH_CONFIDENCE) return { result: null, reject: 'confidence', candidates: agg.size, flickerSkipped, best: bestDiag };
+    return { result: { name: best.name, confidence: Math.min(coverage, confidence) }, candidates: agg.size, flickerSkipped, best: bestDiag };
   }
 
   private clusterMajority(clusterId: string): { name: string; confidence: number } | null {

--- a/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
+++ b/core/meetings/modules/mixed-pipeline/src/cluster-name-binder.ts
@@ -359,6 +359,22 @@ export class ClusterNameBinder {
     }
   }
 
+  /** Total lit-time (ms) of `name` across all hint kinds within [fromMs, toMs].
+   *  Flicker-short slices count — this is raw testimony of the name's activity
+   *  around a window, and the CALLER thresholds it (a stale tile flip is one
+   *  short slice; a real speaker's heartbeats total seconds). */
+  litMsAround(name: string, fromMs: number, toMs: number): number {
+    let ms = 0;
+    for (const log of this.turns.values()) {
+      for (const turn of log) {
+        if (turn.name !== name) continue;
+        const end = turn.tEndMs ?? (turn.tStartMs + OPEN_TURN_GRACE_MS);
+        ms += Math.max(0, Math.min(end, toMs) - Math.max(turn.tStartMs, fromMs));
+      }
+    }
+    return ms;
+  }
+
   /** Diagnostics for telemetry. */
   stats(): { hintTurns: Record<string, number>; clustersWithVotes: number; resolvedClusters: number } {
     const hintTurns: Record<string, number> = {};

--- a/core/meetings/modules/mixed-pipeline/src/flicker-evict.smoke.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/flicker-evict.smoke.test.ts
@@ -1,0 +1,33 @@
+/**
+ * flicker-evict.smoke — the flicker debounce keeps a slice that carries IN-SPAN
+ * evidence, dropping only out-of-span transients. Pins the pass-two regression
+ * (#868): the debounce evicted ANY closed slice shorter than FLICKER_MIN_MS (1000ms)
+ * before ranking, so the true speaker's short sub-second slice DURING the commit was
+ * thrown away and the window handed to the lagging neighbour — the sole survivor.
+ *
+ * Scenario: a commit [10000,10800]. True speaker T lit an 800ms slice fully inside
+ * the span (shorter than FLICKER_MIN_MS). Neighbour N lit a 1350ms slice that ends
+ * before the span (in the ±slack, zero in-span).
+ *
+ * Pre-fix (4a48649a): T's 800ms slice < 1000ms → flicker-skipped → only N remains →
+ *   N carries no in-span → the turn resolves provisional (seg id).
+ * Post-fix (head):   T's slice intersects the span → kept → T out-ranks N → binds.
+ */
+import { ClusterNameBinder } from './index.js';
+
+const b = new ClusterNameBinder({});
+// T: dom-active [10000,10800] internal (lag 250) → an 800ms slice, entirely in-span,
+// shorter than the 1000ms flicker floor.
+b.recordHint({ name: 'T', tMs: 10250, kind: 'dom-active' });
+b.recordHint({ name: 'T', tMs: 11050, kind: 'dom-active', isEnd: true });
+// N: dom-active [8550,9900] internal → 1350ms, ends before the span (in the ±slack).
+b.recordHint({ name: 'N', tMs: 8800, kind: 'dom-active' });
+b.recordHint({ name: 'N', tMs: 10150, kind: 'dom-active', isEnd: true });
+
+const r = b.resolve({ clusterId: 'seg_9', tStartMs: 10000, tEndMs: 10800 });
+console.log(`flicker-evict commit → speaker=${r.speakerName} source=${r.source} conf=${r.confidence?.toFixed(3)}`);
+const ok = r.speakerName === 'T' && r.source === 'window-match';
+console.log(ok
+  ? '✅ PASS — the short in-span slice was kept; T bound instead of the out-of-span neighbour'
+  : `❌ PASS-two regression — the in-span slice was flicker-evicted and the turn went provisional (${r.speakerName})`);
+process.exit(ok ? 0 : 1);

--- a/core/meetings/modules/mixed-pipeline/src/handover.smoke.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/handover.smoke.test.ts
@@ -1,0 +1,39 @@
+/**
+ * handover.smoke — the confidence gate must judge the COMMIT SPAN, not the ±slack
+ * neighbourhood. Two speakers alternate on one dom-active stream (heartbeat
+ * re-assertions ~2s apart). At a handover, Ada lingers a beat while Ben takes over;
+ * the diarizer cuts a short commit that Ben covers in-span. Ben is the in-span
+ * winner AND holds the most support — yet the OLD confidence (a name's share of all
+ * hint time in the ±support slack) let Ada's lingering slice dilute Ben's share
+ * below the 0.6 gate, so the turn published provisional (seg_N) though the live UI
+ * named it Ben.
+ *
+ * Pre-fix (f4461a85): windowMatch rejects on `confidence` (0.559) → provisional.
+ * Post-fix (#868):     confidence is in-span contested-ness (0.643) → Ben binds.
+ *
+ * Anchored on the botsig9 real-STT red (#868): the ±slack neighbour vote is the
+ * point of introduction; the fix removes the slack's vote while keeping its jitter
+ * roles (admission, support, coverage).
+ */
+import { ClusterNameBinder } from './index.js';
+
+const b = new ClusterNameBinder({});
+// Ada speaks, heartbeating on dom-active every ~2s, then hands over — lingering a
+// beat into the handover before her box goes dark.
+b.recordHint({ name: 'Ada', tMs: 7000, kind: 'dom-active' });
+b.recordHint({ name: 'Ada', tMs: 9000, kind: 'dom-active' });   // heartbeat re-assertion
+b.recordHint({ name: 'Ada', tMs: 10800, kind: 'dom-active', isEnd: true }); // lingers into handover
+// Ben takes over and holds the floor across the commit.
+b.recordHint({ name: 'Ben', tMs: 10000, kind: 'dom-active' });
+b.recordHint({ name: 'Ben', tMs: 11000, kind: 'dom-active', isEnd: true });
+
+// The diarizer cuts a short (500ms) turn that Ben covers in-span, right after the
+// handover. Ada's lingering slice overlaps the ±slack but almost none of the span.
+const r = b.resolve({ clusterId: 'seg_42', tStartMs: 10300, tEndMs: 10800 });
+
+console.log(`handover commit → speaker=${r.speakerName} source=${r.source} conf=${r.confidence?.toFixed(3)}`);
+const ok = r.speakerName === 'Ben' && r.source === 'window-match';
+console.log(ok
+  ? '✅ PASS — in-span confidence bound the handover to Ben (not a provisional seg_N)'
+  : `❌ FAIL — the ±slack neighbour vote diluted Ben below the confidence gate; turn went provisional (${r.speakerName})`);
+process.exit(ok ? 0 : 1);

--- a/core/meetings/modules/mixed-pipeline/src/sweep-adjudicate.smoke.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/sweep-adjudicate.smoke.test.ts
@@ -1,0 +1,99 @@
+/**
+ * sweep-adjudicate.smoke — a held short-UI-switch turn is adjudicated from the
+ * ALREADY-recorded hint log by the sweep (audio-clock + once at dispose), never
+ * left provisional forever. Pins the pass-six fix (#868): under hint-leads-turn
+ * interleaving a hold could never see a FUTURE re-assertion, so a real speaker held
+ * on a sub-second alternation stayed seg_N for good. The sweep re-judges each held
+ * turn against recorded testimony: ≥2000ms lit around the turn ⇒ a speaker (claim);
+ * one short slice ⇒ a flip (hold stands).
+ *
+ * Two arms, each its own transcriber:
+ *  A. RICH: Boris is held after Alice, but Boris's DOM lit ~2.5s around the turn →
+ *     the sweep at dispose repaints it to Boris.  Pre-fix (23f6841b): no sweep → the
+ *     turn stays provisional, Boris never published.
+ *  B. LONE FLIP: Carol is held after Alice with a single ~0.5s blip → the sweep
+ *     leaves the hold standing (the steal class the hold exists for). Same on both.
+ */
+import { ChunkedTranscriber, type BoundarySource } from './index.js';
+import type { BoundaryEvent } from './pyannote-segmenter.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function runArm(
+  richArm: boolean,
+): Promise<{ published: string[]; renames: { from: string; to: string }[] }> {
+  let emit!: (ev: BoundaryEvent) => void;
+  let call = 0;
+  const published: string[] = [];
+  const renames: { from: string; to: string }[] = [];
+  const second = richArm ? 'Boris' : 'Carol';
+
+  const tc = await ChunkedTranscriber.create({
+    language: 'en',
+    transcribe: async () => {
+      call++;
+      const text = call === 1 ? 'alice opens the meeting here' : 'the very short second turn';
+      return {
+        text, language: 'en', language_probability: 0.99,
+        segments: [{ text, start: 0, end: call === 1 ? 4.0 : 1.6, no_speech_prob: 0.01, avg_logprob: -0.2, compression_ratio: 1.1 } as any],
+      };
+    },
+    publish: (speaker) => { published.push(speaker); },
+    publishPending: () => {},
+    clearPending: () => {},
+    rename: (from, to) => { renames.push({ from, to }); },
+    makeSegmenter: async (onBoundary): Promise<BoundarySource> => { emit = onBoundary; return { appendFrame: async () => {}, reset: () => {} }; },
+    log: () => {},
+  });
+
+  const frame = new Float32Array(1600).fill(0.05);
+  const feed = (from: number, to: number) => { for (let t = from; t < to; t += 100) tc.feedAudio(frame, t); };
+
+  // Turn 1 — Alice, a normal 4s turn: publishes as Alice (no prior speaker → no defer).
+  feed(1000, 5000);
+  tc.recordHint('Alice', 'dom-active', 1000);
+  emit({ tMs: 1000, kind: 'silence→speaker', confidence: 0.9 });
+  emit({ tMs: 5000, kind: 'speaker→silence', confidence: 0.9 });
+  await sleep(200);
+
+  // Turn 2 — a SHORT turn right after Alice, window-matching the second speaker →
+  // held provisional (short-UI-switch). Its DOM testimony differs by arm.
+  if (richArm) {
+    // Boris lit continuously ~2.5s around the turn — a real speaker's heartbeats.
+    tc.recordHint('Boris', 'dom-active', 5050);
+    feed(5200, 7000);
+    emit({ tMs: 5200, kind: 'silence→speaker', confidence: 0.9 });
+    emit({ tMs: 7000, kind: 'speaker→silence', confidence: 0.9 });
+    tc.recordHint('Boris', 'dom-active', 7550, true);   // close the ~2.5s Boris slice
+  } else {
+    // Carol lit a single ~0.5s blip — a transient tile flip.
+    tc.recordHint('Carol', 'dom-active', 5150);
+    feed(5200, 6000);
+    emit({ tMs: 5200, kind: 'silence→speaker', confidence: 0.9 });
+    emit({ tMs: 6000, kind: 'speaker→silence', confidence: 0.9 });
+    tc.recordHint('Carol', 'dom-active', 5650, true);   // close the 0.5s blip
+  }
+  await sleep(200);
+  // more audio so the audio-clock advances well past the re-assertion window
+  feed(7200, 16000);
+  await sleep(200);
+
+  await tc.dispose();   // sweep(∞) runs here
+  return { published, renames };
+}
+
+async function main() {
+  const rich = await runArm(true);
+  const flip = await runArm(false);
+  console.log('RICH  published=', JSON.stringify(rich.published), 'renames=', JSON.stringify(rich.renames));
+  console.log('FLIP  published=', JSON.stringify(flip.published), 'renames=', JSON.stringify(flip.renames));
+
+  const richRepainted = rich.renames.some((r) => r.to === 'Boris') || rich.published.includes('Boris');
+  const flipStayedHeld = !flip.renames.some((r) => r.to === 'Carol') && !flip.published.includes('Carol');
+  const ok = richRepainted && flipStayedHeld;
+  console.log(ok
+    ? '✅ PASS — the sweep repainted the rich-testimony hold to Boris; the lone flip stayed held'
+    : `❌ FAIL — richRepainted=${richRepainted} (want true), flipStayedHeld=${flipStayedHeld} (want true)`);
+  process.exit(ok ? 0 : 1);
+}
+main().catch((e) => { console.error('❌ FAIL —', e?.message || e); process.exit(1); });

--- a/core/meetings/modules/mixed-pipeline/src/tie-swamp.smoke.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/tie-swamp.smoke.test.ts
@@ -1,0 +1,33 @@
+/**
+ * tie-swamp.smoke — winner selection ranks by IN-SPAN evidence on its OWN scale.
+ * Pins the pass-two regression (#868): once selection ranked by in-span ms it reused
+ * RECENCY_TIE_MS (1000ms) as the tie band — but in-span slices are sub-second, so
+ * EVERY pair fell inside the band and the more-recent hint won on recency, handing
+ * the commit back to the lagging neighbour. The tie band now scales to the metric
+ * (a fifth of the larger claim, floor 50ms), so recency only breaks a genuine tie.
+ *
+ * Scenario: a commit [10000,11000]. True speaker T lit 500ms of the span; neighbour
+ * N lit only 200ms of it but started LATER (more recent). T is the larger in-span
+ * claim and must win.
+ *
+ * Pre-fix (4a48649a): |500−200|=300 < 1000 tie band → recency → N wins → conf 0.286
+ *   < gate → the turn resolves provisional (seg id).
+ * Post-fix (head):   tie band = max(50, 0.2·500)=100; 500 > 200+100 → T wins → binds.
+ */
+import { ClusterNameBinder } from './index.js';
+
+const b = new ClusterNameBinder({});
+// T: dom-active [9500,10500] internal (lag 250) → 500ms in the commit span.
+b.recordHint({ name: 'T', tMs: 9750, kind: 'dom-active' });
+b.recordHint({ name: 'T', tMs: 10750, kind: 'dom-active', isEnd: true });
+// N: dom-active [10800,11800] internal → 200ms in-span, but a MORE RECENT start.
+b.recordHint({ name: 'N', tMs: 11050, kind: 'dom-active' });
+b.recordHint({ name: 'N', tMs: 12050, kind: 'dom-active', isEnd: true });
+
+const r = b.resolve({ clusterId: 'seg_7', tStartMs: 10000, tEndMs: 11000 });
+console.log(`tie-swamp commit → speaker=${r.speakerName} source=${r.source} conf=${r.confidence?.toFixed(3)}`);
+const ok = r.speakerName === 'T' && r.source === 'window-match';
+console.log(ok
+  ? '✅ PASS — the larger in-span claim (T) won; recency did not swamp the sub-second tie'
+  : `❌ PASS-two regression — recency swamped the in-span tie and the neighbour took the commit (${r.speakerName})`);
+process.exit(ok ? 0 : 1);

--- a/core/meetings/services/bot/src/quality-mixed.test.ts
+++ b/core/meetings/services/bot/src/quality-mixed.test.ts
@@ -97,6 +97,8 @@ async function main(): Promise<void> {
   // pipeline's own outputs: a turn that never got a name, a hint that named nothing, a name that
   // could not make up its mind, and a speaker count that does not match the room.
   let hintMatched = 0, hintMissed = 0;
+  /** reason → count, from the lane's own [binder-reject] narration (last reject per resolve attempt). */
+  const binderRejects = new Map<string, number>();
   const renames: Array<{ from: string; to: string; n: number }> = [];
   const names = new Map<string, string[]>();
   const nameHistory = (id: string): string[] => {
@@ -184,7 +186,13 @@ async function main(): Promise<void> {
       if (!REAL_SEG) return Promise.resolve<BoundarySource>({ appendFrame: async () => { /* */ }, reset() { /* */ } });
       return PyannoteSegmenter.create({ inferIntervalMs: 500, onBoundary }) as unknown as Promise<BoundarySource>;
     },
-    log: () => { /* quiet */ },
+    // The lane narrates why each provisional turn stayed unnamed ([binder-reject] …);
+    // tally the reasons so the run ends with a per-gate count, not 27 anecdotes.
+    log: (msg: string) => {
+      const m = msg.match(/\[binder-reject\] .* reason=(\S+)/);
+      if (m) binderRejects.set(m[1], (binderRejects.get(m[1]) ?? 0) + 1);
+      if (process.env.BINDER_DIAG) console.log(msg);
+    },
   });
 
   type Ev = { t: number; frame?: Frame; hint?: Hint; cut?: Cut };
@@ -317,6 +325,10 @@ async function main(): Promise<void> {
     `(${(attribution.hintMissRate * 100).toFixed(1)}% — NOT an attribution failure, read ACCURACY below) · ` +
     `${renames.length} renames, ${churned} turns churned · speakers ${publishedSpeakers.size} published vs ${hintNames.size} substantively hinted` +
     (briefNames ? ` (+${briefNames} lit under ${SUBSTANTIVE_LIT_MS / 1000}s, not counted)` : ''));
+  if (binderRejects.size > 0) {
+    const tally = [...binderRejects.entries()].sort((a, b) => b[1] - a[1]).map(([k, n]) => `${k}=${n}`).join(' · ');
+    console.log(`  binder-reject ${tally}  (per resolve attempt; BINDER_DIAG=1 for per-turn lines)`);
+  }
 
   // ── Attribution ACCURACY — the truth-bearing oracle ─────────────────────────────────────────
   // The four signals above say whether a name was assigned. They cannot say whether it was RIGHT,

--- a/docs/changelog.d/868-inspan-confidence.md
+++ b/docs/changelog.d/868-inspan-confidence.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **mixed lane (Zoom/Teams/YouTube): a handover turn the UI already named no longer publishes
+  provisional when a neighbour's slack overlap dilutes the vote.** The window-match confidence gate
+  scored a name's share of *all* hint time in the ±support slack. With sub-second diarizer turns, a
+  handover commit fully covered by one speaker could still fail the 0.6 gate because the previous
+  speaker's lingering/heartbeat slices sat inside the slack and split the share. Confidence now
+  measures contested-ness *inside the commit span itself* — the slack keeps its jitter roles
+  (admission, support, coverage) and loses its vote; when no hint time falls in-span at all (pure
+  lag), the slack-window share judges as before. A committed regression test
+  (`handover.smoke.test.ts`) pins the handover scenario red on the parent, green on the fix.


### PR DESCRIPTION
Capstone of the v0.12.17 series: the #868 binder / attribution fix chain for the mixed pipeline.

## Evidence

The PR's acceptance evidence is the final **observation bundle** comment on #868:
https://github.com/Vexa-ai/vexa/issues/868#issuecomment-5033406024

Headline results (botsig9 real-STT arm, whisper-1 @ transcription.vexa.ai, 90/90 STT calls every run, bit-stable):
- **Provisional attribution 31.9% → 2.4%** of words (target ≤5%); seg_N rows 22 → 3.
- **Truth-oracle accuracy 0.947 → 1.000** (19/19, 0 wrong, 0 unnamed); recall/precision unchanged.
- **Four red→green regression tests**, each verified red on its pre-fix commit and green at head: `handover.smoke`, `tie-swamp.smoke`, `flicker-evict.smoke`, `sweep-adjudicate.smoke`.

## Mechanism (the designed present)

Confidence now judges contested-ness **inside the commit span**, not the ±slack neighbourhood — a lagging previous speaker's heartbeat slices keep their jitter role and lose their vote. Winner **selection** ranks in-span evidence on its own metric scale (ties by fifths, floored at 50ms) so the slack-scale tie window can't hand every comparison to recency. The flicker debounce evicts only out-of-span transients, so a still-lit speaker's in-span testimony survives. Finally **the sweep** adjudicates a held short-UI-switch turn from testimony already recorded (audio clock + dispose): `litMsAround ≥ 2s` around the turn = a real speaker (heartbeats); a single short slice = a flip, and the hold stands.

## The honest middle of the chain

This chain includes a regression that the validation loop caught: pass 2 (in-span *selection*, commit `4a48649a`, not picked here) pushed provisional % **up** to 36.2/38.7% before pass 3 (`364ebd7a`) corrected the tie scale down to 33.1% and drove binder rejects to 0. Kept in the record via the bundle; only the corrected commits are on this branch.

## Notes

- **CORPUS baseline** 0.947 → 1.000 is a deliberate improvement, pending a baseline `--update` (not touched here).
- Offline real-STT replay is the witness (issue's declared bar: desk); the live Zoom re-witness rides #852's leg.

## Stack / retarget

PR 7 of 7 in the v0.12.17 stack: #869 → #871 → #872 → #873 → #880. **Base = `feat/854-truth-oracle`**; retarget to `main` after the stack lands. Milestone **v0.12.17**.
