### PR TITLE
fix(bot): share orchestrator port doubles and fail loud on missing deps (#865)

### DIFF
--- a/core/meetings/services/bot/src/README.md
+++ b/core/meetings/services/bot/src/README.md
@@ -10,6 +10,7 @@ types; transports are adapters wired at the composition root.
 | `index.ts` | **composition root** — validates config, launches the browser, wires the REAL adapters, runs the orchestrator, exits. Speak acts are tee'd to a voice handler (orchestrator core untouched). The container entrypoint (`main`). |
 | `config.ts` | `invocation.v1` boot config — parse + ajv-validate `VEXA_BOT_CONFIG`, fail-fast (P14). Exports the typed `Invocation`. |
 | `ports.ts` | the port interfaces the core depends on: `JoinDriver · Pipeline · TranscriptSink · LifecycleSink · ActsSource · RecordingSink`. Pure (no transport types). |
+| `test-doubles.ts` | shared L2 port doubles (`noopAloneness`, `noopActs`, `noopPipeline`, …) — one export site for every orchestrator construction in tests. |
 | `orchestrator.ts` | the `lifecycle.v1` state machine (`createOrchestrator`) — joining → awaiting_admission → active → (completed \| failed). Depends only on ports. |
 | `contracts.ts` | TS mirrors of the published `lifecycle.v1 · acts.v1 · transcript.v1` schemas + the executable `canTransition` machine. |
 | `join-driver.ts` | **JoinDriver** — wraps `@vexa/join` `joinMeeting`/leave/removal (guest + authenticated); maps `JoinState`→`BotStatus`. |

--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -19,8 +19,9 @@ import { fileURLToPath } from 'node:url';
 import { createOrchestrator, CONTROL_PLANE_UNREACHABLE, CONTROL_PLANE_UNREACHABLE_EXIT } from './orchestrator.js';
 import { createLivePipeline } from './pipeline.js';
 import { canTransition, type BotStatus, type LifecycleEvent, type TranscriptSegment } from './contracts.js';
-import type { JoinDriver, JoinOutcome, Pipeline, LifecycleSink, ActsSource, AlonenessSource, TranscriptSink, PrimaryReachability } from './ports.js';
+import type { JoinDriver, JoinOutcome, LifecycleSink, TranscriptSink, PrimaryReachability } from './ports.js';
 import type { Invocation } from './config.js';
+import { noopAloneness, controlledAloneness, noopPipeline, noopActs } from './test-doubles.js';
 
 let failed = 0;
 const check = (name: string, cond: boolean, detail = '') => {
@@ -49,17 +50,6 @@ const recordingSink = (): LifecycleSink & { readonly events: LifecycleEvent[] } 
   const events: LifecycleEvent[] = [];
   return { events, async emit(e: LifecycleEvent) { events.push(e); } };
 };
-const noopPipeline = (): Pipeline & { started: boolean } => {
-  const p = { started: false, async start() { p.started = true; }, async stop() { p.started = false; } };
-  return p;
-};
-const noopActs = (ref?: (fire: (a: { action: 'leave' }) => void) => void): ActsSource => ({
-  subscribe(handler) { ref?.((a) => void handler(a)); return () => { /* */ }; },
-});
-const noopAloneness = (): AlonenessSource => ({ onAlone() { return () => { /* */ }; } });
-const controlledAloneness = (ref: (fire: () => void) => void, onStop?: () => void): AlonenessSource => ({
-  onAlone(callback) { ref(callback); return () => onStop?.(); },
-});
 const mockJoin = (outcome: JoinOutcome, onRemovalRef?: (fire: () => void) => void): JoinDriver => ({
   async join(report) { await report('awaiting_admission'); if (outcome === 'admitted') await report('active'); return outcome; },
   onRemoval(cb) { onRemovalRef?.(cb); return () => { /* */ }; },
@@ -421,6 +411,26 @@ async function main(): Promise<void> {
     const res = await runP;
     check('gate reachable: proceeded to completed', res.status === 'completed', JSON.stringify(res));
     check('gate reachable: secondary channel NEVER probed (fast path, zero added latency)', secondaryProbed === 0, `probed=${secondaryProbed}`);
+  }
+
+  // ── #865: missing required port fails loud with the port name (not a TypeError on .onAlone) ──
+  {
+    let threw: unknown;
+    try {
+      createOrchestrator(inv(), {
+        lifecycle: recordingSink(),
+        join: mockJoin('admitted'),
+        pipeline: noopPipeline(),
+        acts: noopActs(),
+        // deliberately omit aloneness
+      } as Parameters<typeof createOrchestrator>[1]);
+    } catch (e) {
+      threw = e;
+    }
+    const msg = threw instanceof Error ? threw.message : String(threw);
+    check('missing port: throws', threw instanceof Error, msg);
+    check('missing port: names the port', /required port 'aloneness' is missing/.test(msg), msg);
+    check('missing port: not a raw property TypeError', !/Cannot read properties of undefined/.test(msg), msg);
   }
 
   if (failed) { console.error(`\n❌ orchestrator (L2): ${failed} check(s) FAILED.`); process.exit(1); }

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -91,11 +91,23 @@ export interface RunOptions {
   maxActiveMs?: number;
 }
 
+/** Required ports — missing any of these used to surface as a raw TypeError deep in `run()`. */
+const REQUIRED_PORTS = ['lifecycle', 'join', 'pipeline', 'acts', 'aloneness'] as const;
+
+function assertRequiredPorts(deps: OrchestratorDeps): void {
+  for (const name of REQUIRED_PORTS) {
+    if (deps[name] == null) {
+      throw new Error(`orchestrator: required port '${name}' is missing`);
+    }
+  }
+}
+
 /**
  * Build the meeting orchestrator. Returns `run()` (drives the machine to a terminal state)
  * and `handle(act)` (the acts.v1 entrypoint the ActsSource adapter — or a test — feeds).
  */
 export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
+  assertRequiredPorts(deps);
   const base: { connection_id: string; container_id?: string } = {
     connection_id: inv.connectionId ?? '',
     ...(inv.container_name ? { container_id: inv.container_name } : {}),

--- a/core/meetings/services/bot/src/stress.test.ts
+++ b/core/meetings/services/bot/src/stress.test.ts
@@ -10,8 +10,9 @@
  */
 import { createOrchestrator } from './orchestrator.js';
 import { canTransition, type BotStatus, type LifecycleEvent } from './contracts.js';
-import type { JoinDriver, JoinOutcome, Pipeline, LifecycleSink, ActsSource, AlonenessSource } from './ports.js';
+import type { JoinDriver, JoinOutcome, Pipeline, LifecycleSink, ActsSource } from './ports.js';
 import type { Invocation } from './config.js';
+import { noopAloneness, noopPipeline, noopActs } from './test-doubles.js';
 
 let failed = 0;
 const check = (name: string, cond: boolean, detail = '') => {
@@ -29,14 +30,13 @@ const sink = (): LifecycleSink & { readonly events: LifecycleEvent[] } => {
   const events: LifecycleEvent[] = [];
   return { events, async emit(e: LifecycleEvent) { events.push(e); } };
 };
-const noopPipeline = (): Pipeline => ({ async start() { /* */ }, async stop() { /* */ } });
 // The orchestrator subscribes to acts AFTER it reaches active — so an acts source that fires on
 // subscribe delivers its acts during the active phase (when the handler is wired). `nLeaves` floods.
 const leavesOnSubscribe = (n: number): ActsSource => ({
   subscribe(handler) { for (let i = 0; i < n; i++) void handler({ action: 'leave' }); return () => { /* */ }; },
 });
-const noActs: ActsSource = { subscribe() { return () => { /* */ }; } };
-const noAloneness: AlonenessSource = { onAlone() { return () => { /* */ }; } };
+const noActs = noopActs();
+const noAloneness = noopAloneness();
 
 const terminals = (e: LifecycleEvent[]) => e.filter((x) => x.status === 'completed' || x.status === 'failed');
 const allLegal = (e: LifecycleEvent[]) =>

--- a/core/meetings/services/bot/src/stt-faults.test.ts
+++ b/core/meetings/services/bot/src/stt-faults.test.ts
@@ -15,7 +15,8 @@ import { createSttFaultReporter } from './stt-faults.js';
 import { createOrchestrator } from './orchestrator.js';
 import type { Invocation } from './config.js';
 import type { LifecycleEvent } from './contracts.js';
-import type { JoinDriver, Pipeline, ActsSource, LifecycleSink, AlonenessSource } from './ports.js';
+import type { JoinDriver, Pipeline, ActsSource, LifecycleSink } from './ports.js';
+import { noopAloneness } from './test-doubles.js';
 
 let failed = 0;
 const check = (name: string, cond: boolean, detail = ''): void => {
@@ -41,10 +42,7 @@ function fakes(events: LifecycleEvent[]) {
   };
   const pipeline: Pipeline = { async start() { /* */ }, async stop() { /* */ } };
   const acts: ActsSource = { subscribe() { return () => { /* */ }; } };
-  // A never-firing aloneness source: this suite is about STT-fault reporting, and the
-  // orchestrator subscribes to aloneness unconditionally, so every construction site owes it one.
-  const aloneness: AlonenessSource = { onAlone() { return () => { /* */ }; } };
-  return { lifecycle, join, pipeline, acts, aloneness };
+  return { lifecycle, join, pipeline, acts, aloneness: noopAloneness() };
 }
 
 async function main(): Promise<void> {

--- a/core/meetings/services/bot/src/test-doubles.ts
+++ b/core/meetings/services/bot/src/test-doubles.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared L2 port doubles for constructing an orchestrator in tests.
+ *
+ * `createOrchestrator` requires `aloneness` (and the other core ports) unconditionally.
+ * Keeping the noops in one place stops every new construction site from rediscovering that
+ * by crashing with `Cannot read properties of undefined (reading "onAlone")`.
+ */
+import type { Act } from './contracts.js';
+import type { ActsSource, AlonenessSource, Pipeline } from './ports.js';
+
+/** Never-firing aloneness source — the default for suites that are not about left_alone. */
+export const noopAloneness = (): AlonenessSource => ({
+  onAlone() {
+    return () => {
+      /* */
+    };
+  },
+});
+
+/** Aloneness source the test can fire (and optionally observe stop). */
+export const controlledAloneness = (
+  ref: (fire: () => void) => void,
+  onStop?: () => void,
+): AlonenessSource => ({
+  onAlone(callback) {
+    ref(callback);
+    return () => onStop?.();
+  },
+});
+
+/** Start/stop-tracking pipeline double. */
+export const noopPipeline = (): Pipeline & { started: boolean } => {
+  const p = {
+    started: false,
+    async start() {
+      p.started = true;
+    },
+    async stop() {
+      p.started = false;
+    },
+  };
+  return p;
+};
+
+/** Acts source; optional `ref` captures a fire(leave) handle for the test. */
+export const noopActs = (ref?: (fire: (a: Act) => void) => void): ActsSource => ({
+  subscribe(handler) {
+    ref?.((a) => void handler(a));
+    return () => {
+      /* */
+    };
+  },
+});

--- a/docs/changelog.d/865-aloneness-test-doubles.md
+++ b/docs/changelog.d/865-aloneness-test-doubles.md
@@ -1,0 +1,1 @@
+- **Bot test doubles: shared `noopAloneness` (+ siblings) and named missing-port errors (#865).** Pure L2 scaffolding — no user-facing behaviour change. Stops every new orchestrator construction site rediscovering the required `aloneness` seam by crashing with a raw TypeError.


### PR DESCRIPTION
## Summary
- Export shared L2 port doubles (`noopAloneness`, `noopActs`, `noopPipeline`, `controlledAloneness`) from `test-doubles.ts` so every orchestrator construction site stops rediscovering the required `aloneness` seam by crashing.
- `createOrchestrator` now fails loud with `orchestrator: required port '<name>' is missing` instead of a raw `TypeError` on `.onAlone`.
- `orchestrator.test.ts`, `stt-faults.test.ts`, and `stress.test.ts` import the shared doubles (no local redeclares).

Closes #865.

## Observation bundle (acceptance)

| # | Expected | Actual | Verdict |
|---|---|---|---|
| A1 | noopAloneness (+ sibling noops) exported from one place; no test file redeclares them | `src/test-doubles.ts` exports them; `rg` shows only `noopAloneness =` definition there; tests import | green |
| A2 | orchestrator.test.ts + stt-faults.test.ts use shared doubles and pass | both suites pass locally | green |
| A3 | missing required port → error naming the port, not TypeError | new checks: `required port 'aloneness' is missing` | green |
| A4 | gates | local bot suites + pre-push static gates green; full `gates.mjs all` runs in CI | green (desk) |

## Test plan
- [x] `pnpm exec tsx src/orchestrator.test.ts`
- [x] `pnpm exec tsx src/stt-faults.test.ts`
- [x] `pnpm exec tsx src/stress.test.ts`
- [ ] CI gates on this PR

## Notes
- Branched from `rc/0.12.16` (aloneness + stt-faults batch). Not on `main` yet.
- Desk check only — no meeting / infra required (issue human bar).
- Authorship: Ayush7614 only (no agent co-author trailers).