### PR TITLE
fix(gmeet): dropped submit ticks catch up, and the first window submits when ready (#851)

### DIFF
--- a/core/meetings/modules/gmeet-pipeline/src/speaker-streams.ts
+++ b/core/meetings/modules/gmeet-pipeline/src/speaker-streams.ts
@@ -33,6 +33,13 @@ interface SpeakerBuffer {
   /** Word-level prefix confirmation: words from previous Whisper submission */
   lastWords: string[];
   inFlight: boolean;
+  /** A submit tick fired while a request was in flight and could not run: the submission is
+   *  OWED. Set by trySubmit when it bails on the inFlight guard; consumed by
+   *  handleTranscriptionResult, which re-fires trySubmit the moment inFlight clears (rather than
+   *  waiting a full submitInterval for the next tick). Without this, at production STT — where a
+   *  round-trip exceeds submitInterval — every tick that lands mid-flight is dropped with no
+   *  catch-up and the effective cadence degrades to a multiple of the interval. */
+  owedSubmit: boolean;
   /** Wall-clock time (ms) when the current unconfirmed window started */
   windowStartMs: number;
   /** Wall-clock time (ms) when the buffer first started (for segment timing) */
@@ -147,6 +154,7 @@ export class SpeakerStreamManager {
       confirmCount: 0,
       lastWords: [],
       inFlight: false,
+      owedSubmit: false,
       windowStartMs: now,
       bufferStartMs: now,
       sequenceNumber: 0,
@@ -242,6 +250,19 @@ export class SpeakerStreamManager {
     if (!buffer) return false;
 
     buffer.inFlight = false;
+
+    // Catch-up for the tick(s) dropped while this request was in flight (fix a, #851). A submit
+    // tick that landed mid-flight set owedSubmit rather than being lost; now that inFlight is
+    // clear, re-run trySubmit so the owed window submits at the STT round-trip rather than waiting
+    // a full submitInterval for the next tick. Consumed here (owed reset) so it fires ONCE per
+    // response — no unconditional re-fire, no busy loop: trySubmit re-checks every condition
+    // (unconfirmed ≥ minAudioDuration, not inFlight), and the next mid-flight tick re-owes it.
+    // Deferred to a microtask so it runs AFTER this handler's confirm/reset logic settles, and
+    // regardless of which return path below executes. In the fast regime (STT « submitInterval) a
+    // tick never lands mid-flight, so owedSubmit is never set and this is inert — no regression.
+    const catchUp = buffer.owedSubmit;
+    buffer.owedSubmit = false;
+    if (catchUp) queueMicrotask(() => { void this.trySubmit(speakerId); });
 
     // Discard stale responses: if the buffer was reset (generation bumped)
     // while a Whisper request was in flight, this response is for audio that
@@ -564,7 +585,12 @@ export class SpeakerStreamManager {
 
   private async trySubmit(speakerId: string): Promise<void> {
     const buffer = this.buffers.get(speakerId);
-    if (!buffer || buffer.inFlight) return;
+    if (!buffer) return;
+    // A request is in flight: this tick cannot submit. Record that a submission is OWED so
+    // handleTranscriptionResult re-fires the moment inFlight clears, instead of dropping the tick
+    // and waiting a full submitInterval for the next one (the catch-up the fast regime never
+    // needs but the production regime — STT round-trip > submitInterval — critically does).
+    if (buffer.inFlight) { buffer.owedSubmit = true; return; }
 
     const unconfirmedSec = this.unconfirmedSamples(buffer) / this.sampleRate;
     const totalSec = buffer.totalSamples / this.sampleRate;
@@ -828,6 +854,7 @@ export class SpeakerStreamManager {
     buffer.confirmCount = 0;
     buffer.lastWords = [];
     buffer.inFlight = false;
+    buffer.owedSubmit = false;
     buffer.windowStartMs = Date.now();
     buffer.bufferStartMs = Date.now();
     buffer.lastAudioTimestamp = Date.now();

--- a/core/meetings/modules/gmeet-pipeline/src/speaker-streams.ts
+++ b/core/meetings/modules/gmeet-pipeline/src/speaker-streams.ts
@@ -40,6 +40,12 @@ interface SpeakerBuffer {
    *  round-trip exceeds submitInterval — every tick that lands mid-flight is dropped with no
    *  catch-up and the effective cadence degrades to a multiple of the interval. */
   owedSubmit: boolean;
+  /** The turn's FIRST submission has gone out. Until then feedAudio submits immediately once
+   *  minAudioDuration of audio has accrued, rather than waiting for the next submitInterval tick
+   *  (first-submit fast path, fix b, #851) — the tick phase alone cost up to a full interval
+   *  before any text could form. Set in submitBuffer, reset on fullReset; subsequent submissions
+   *  stay on the tick + catch-up cadence. */
+  firstSubmitDone: boolean;
   /** Wall-clock time (ms) when the current unconfirmed window started */
   windowStartMs: number;
   /** Wall-clock time (ms) when the buffer first started (for segment timing) */
@@ -155,6 +161,7 @@ export class SpeakerStreamManager {
       lastWords: [],
       inFlight: false,
       owedSubmit: false,
+      firstSubmitDone: false,
       windowStartMs: now,
       bufferStartMs: now,
       sequenceNumber: 0,
@@ -228,6 +235,18 @@ export class SpeakerStreamManager {
     buffer.totalSamples += audioData.length;
     buffer.lastAudioTimestamp = Date.now();
     buffer.idleSubmitted = false;
+
+    // First-submit fast path (fix b, #851): the turn's first submission otherwise waits for the
+    // next submitInterval tick — up to a full interval of dead air before any text can form, on
+    // top of the STT round-trip. Once minAudioDuration of audio has accrued for a turn that has
+    // never submitted (and nothing is in flight), submit NOW rather than at the tick phase.
+    // Scoped to the first submission: subsequent windows stay on the tick + catch-up cadence.
+    // submitBuffer keeps the RMS silence gate authoritative — a near-silent first window is still
+    // skipped there and never reaches Whisper.
+    if (!buffer.firstSubmitDone && !buffer.inFlight
+        && this.unconfirmedSamples(buffer) >= this.minAudioDuration * this.sampleRate) {
+      void this.submitBuffer(buffer);
+    }
   }
 
   /**
@@ -676,6 +695,7 @@ export class SpeakerStreamManager {
     }
 
     buffer.inFlight = true;
+    buffer.firstSubmitDone = true;
     this.submitGeneration.set(buffer.speakerId, buffer.generation);
 
     try {
@@ -855,6 +875,7 @@ export class SpeakerStreamManager {
     buffer.lastWords = [];
     buffer.inFlight = false;
     buffer.owedSubmit = false;
+    buffer.firstSubmitDone = false;
     buffer.windowStartMs = Date.now();
     buffer.bufferStartMs = Date.now();
     buffer.lastAudioTimestamp = Date.now();

--- a/docs/changelog.d/851-gmeet-cadence.md
+++ b/docs/changelog.d/851-gmeet-cadence.md
@@ -1,0 +1,11 @@
+### Fixed
+- **gmeet: a speaker's words appear sooner and arrive more steadily (#851).** Two cadence defects in
+  the per-speaker assembly loop are fixed. A submit tick that fired while an STT request was in flight
+  used to be dropped with no catch-up, so the owed window waited a full submit interval — at
+  production STT (round-trip longer than the interval) nearly every other tick dropped and the update
+  rhythm beat irregularly; the dropped tick is now recorded and the submission fires the moment the
+  in-flight response lands. And a turn's first window used to wait for the next tick even after enough
+  audio had accrued, adding up to a full interval of dead air before any text; it now submits as soon
+  as it is ready. Measured on the paced replay harness (gmeet golden, production config): pipeline
+  overhead p95 drops from 3953ms to 2007ms, and at a real 2.1s STT round-trip time-to-first-text falls
+  from a projected ~8.15s to a measured 6.20s (first draft 4.10s).


### PR DESCRIPTION
Closes part of #851 (defects a + b; defect c held for a separate verdict).

## What
Two cadence defects in the gmeet per-speaker assembly loop (`speaker-streams.ts`):

- **(a) Dropped submit ticks, no catch-up.** A submit tick landing while an STT request was in flight was dropped entirely; the owed window waited a full `submitInterval`. At production STT (round-trip > interval) nearly every other tick dropped, degrading cadence to a multiple of the interval and beating irregularly. Fix: record the dropped tick as `owedSubmit`; when `handleTranscriptionResult` clears `inFlight`, consume the flag once and re-run `trySubmit` via a microtask. Inert in the fast regime (a tick never lands mid-flight there).
- **(b) No first-submit fast path.** A turn's first window waited for the next tick even after `minAudioDuration` had accrued. Fix: `feedAudio` submits immediately once enough audio has accrued for a turn that has never submitted (and nothing is in flight), scoped via `firstSubmitDone`; the RMS silence gate stays authoritative.

## Value witnessed — `replay-paced` (gmeet golden, production config `2/2/2`)
| STT regime | RED | after (a) | after (a)+(b) |
|---|---|---|---|
| 250ms (fast) | 3953ms | 3953ms (no regression) | **2007ms** overhead p95 |
| 2500ms (drop regime) | 6206ms | **2258ms** | — |

Decisive A4 at **MOCK_STT_MS=2100** (real round-trip), prod config, (a)+(b):
- time-to-first-**confirmed**-text: **6.20s** ×2 (was ~8.15s projected)
- time-to-first-**draft** (what the terminal first renders): **4.10s** ×2

Full bundle (red baseline, three attributions with file:line + probe evidence, controls): https://github.com/Vexa-ai/vexa/issues/851#issuecomment-5034658361

## Open decision (on the issue, for the owner)
**A4 ≤5s confirmed-text requires lowering `confirmThreshold` (2→1) or `minAudioDuration` — a product lever, not a defect fix.** The residual 4.2s at 2.1s STT is `2×STT` from `confirmThreshold=2`. Draft text lands at 4.10s, **under** the 5s bar if "first text" means what the user first sees. **Defect (c) per-sub-segment fanout is measured but held for a separate verdict.**

## Controls (green)
`confirm-loop.golden` · `close-tail` · `count-channelswitch` 1..500 · `pipeline-conformance` · `silence-gate` · bot `replay`/`replay-mixed` · `node scripts/gates.mjs all` green on this base.

Milestone v0.12.17. Draft — base `fix/868-attribution-chain` (stacked).
