### PR TITLE
fix(bot): latch mixed-lane remote-audio ready on mix destination (#866)

### DIFF
--- a/core/meetings/services/bot/src/capture-bridge.boundary.test.ts
+++ b/core/meetings/services/bot/src/capture-bridge.boundary.test.ts
@@ -93,15 +93,32 @@ async function main(): Promise<void> {
     // page.evaluate-serialized functions; shim it page-side so the REAL bridge code
     // (which ships helper-free via tsc) runs unmodified under the test runner.
     await page.evaluate('globalThis.__name = globalThis.__name || ((t, v) => t);');
-    const stop = await startCaptureBridge(page, inv, pipeline);
+    let readyCalls = 0;
+    let unavailableCalls = 0;
+    const activity = {
+      ready() { readyCalls++; },
+      unavailable() { unavailableCalls++; },
+      observeRemoteEnergy() { /* unused — empty-room latch must not need energy */ },
+      snapshot() { return { available: readyCalls > 0 }; },
+    };
+    const stop = await startCaptureBridge(page, inv, pipeline, undefined, undefined, activity);
+
+    // #866 — mixed lane (Teams here) must latch ready when the mix destination exists, even with
+    // ZERO remote audio frames. Waiting on the first gated PCM frame made empty-room left_alone
+    // unreachable on Zoom/Teams/Jitsi.
+    await sleep(200);
+    check('mixed lane latches remote-audio ready without any PCM frames (#866)', readyCalls === 1,
+      `readyCalls=${readyCalls}`);
 
     // Fixture drives the speaking signal: occlusion class ON (start) → OFF (end).
-    await sleep(600);   // observer attach + initial silent state past the 200ms hysteresis
+    await sleep(400);   // observer attach + initial silent state past the 200ms hysteresis
     await page.evaluate(`document.getElementById('alice-outline').classList.add('vdi-frame-occlusion')`);
     await sleep(900);   // 200ms hysteresis + 300ms debounce + margin
     await page.evaluate(`document.getElementById('alice-outline').classList.remove('vdi-frame-occlusion')`);
     await sleep(900);
     await stop();
+    check('teardown reports unavailable (fail-closed; no spurious alone after stop) (#866 A4)',
+      unavailableCalls >= 1, `unavailableCalls=${unavailableCalls}`);
 
     // ── 3) the assertions: hints crossed with name, epoch clock, order ──
     check('page-side watcher started (hop 1 visible in page logs)', pageLogs.some((l) => l.includes('[TeamsSpeakers]')), JSON.stringify(pageLogs.slice(0, 3)));

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -330,19 +330,30 @@ export async function startCaptureBridge(
   await page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName }) => {
     const w = (globalThis as any) as Record<string, any>;
     if (isMixed) {
-      // Zoom/Teams: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
+      // Zoom/Teams/Jitsi: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
       // track into w.__vexaCapturedRemoteAudioStreams. Combine them into ONE live stream (an
       // AudioContext destination), keep connecting late-arriving tracks via a rescan (a participant
       // who speaks later), and feed that single mix to the mixed lane (pyannote re-separates speakers).
+      //
+      // Readiness (#866): `left_alone` fails closed until capture reports ready. Ready means
+      // "the mix destination exists — capture is attached and could hear", NOT "a gated PCM frame
+      // has arrived". An empty room (no remote tracks yet, nobody ever speaks) must still latch
+      // ready so the silence window can fire; waiting on the first frame made that headline case
+      // unreachable on every mixed-lane platform.
       const setupMix = (): void => {
-        const streams = (w.__vexaCapturedRemoteAudioStreams || []) as Array<{ id: string }>;
-        if (!streams.length) return;
         if (!w.__vexaMixCtx) {
           w.__vexaMixCtx = new (globalThis as any).AudioContext({ sampleRate: 16000 });
           w.__vexaMixCtx.resume?.();
           w.__vexaMixDest = w.__vexaMixCtx.createMediaStreamDestination();
           w.__vexaMixSeen = new Set();
+          if (!w.__vexaRemoteAudioReadyLatched) {
+            w.__vexaRemoteAudioReadyLatched = true;
+            void w.__vexaRemoteAudioReady?.();
+            w.logBot?.('[mixed] remote-audio ready (mix destination attached)');
+          }
         }
+        const streams = (w.__vexaCapturedRemoteAudioStreams || []) as Array<{ id: string }>;
+        if (!streams.length) return;
         for (const s of streams) {
           if (!s || w.__vexaMixSeen.has(s.id)) continue;
           try {
@@ -355,8 +366,7 @@ export async function startCaptureBridge(
           w.__vexaMixedCapture = true; // guard re-entry while the async create resolves
           Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(w.__vexaMixDest.stream, (pcm: Float32Array) => w.__vexaPerSpeakerAudioData(0, Array.from(pcm))))
             .then((cap: any) => { w.__vexaMixedCapture = cap; return cap?.start?.(); })
-            .then(async () => {
-              await w.__vexaRemoteAudioReady?.();
+            .then(() => {
               w.logBot?.('[mixed] capture started over ' + w.__vexaMixSeen.size + ' stream(s)');
             })
             .catch((e: any) => { w.__vexaMixedCapture = null; w.logBot?.('[mixed] capture start failed: ' + String(e)); });

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -340,17 +340,34 @@ export async function startCaptureBridge(
       // has arrived". An empty room (no remote tracks yet, nobody ever speaks) must still latch
       // ready so the silence window can fire; waiting on the first frame made that headline case
       // unreachable on every mixed-lane platform.
-      const setupMix = (): void => {
-        if (!w.__vexaMixCtx) {
-          w.__vexaMixCtx = new (globalThis as any).AudioContext({ sampleRate: 16000 });
-          w.__vexaMixCtx.resume?.();
-          w.__vexaMixDest = w.__vexaMixCtx.createMediaStreamDestination();
-          w.__vexaMixSeen = new Set();
-          if (!w.__vexaRemoteAudioReadyLatched) {
-            w.__vexaRemoteAudioReadyLatched = true;
-            void w.__vexaRemoteAudioReady?.();
-            w.logBot?.('[mixed] remote-audio ready (mix destination attached)');
+      //
+      // AudioContext construction is best-effort and MUST NOT abort the rest of this block: the
+      // Zoom/Teams/Jitsi WHO watchers install below and are independent of the mix graph. An
+      // in-process L3 shim (zoom-speaker-wiring) has no real AudioContext — throwing here used
+      // to skip createZoomSpeakers entirely and zero the boundary arrivals.
+      const ensureMixDestination = (): boolean => {
+        if (w.__vexaMixDest) return true;
+        try {
+          if (!w.__vexaMixCtx) {
+            const AC = (globalThis as any).AudioContext || (globalThis as any).webkitAudioContext;
+            if (typeof AC !== 'function') throw new Error('AudioContext unavailable');
+            w.__vexaMixCtx = new AC({ sampleRate: 16000 });
+            w.__vexaMixCtx.resume?.();
           }
+          w.__vexaMixDest = w.__vexaMixCtx.createMediaStreamDestination();
+          w.__vexaMixSeen = w.__vexaMixSeen ?? new Set();
+          return true;
+        } catch (e) {
+          w.logBot?.('[mixed] mix destination unavailable: ' + String(e));
+          return false;
+        }
+      };
+      const setupMix = (): void => {
+        if (!ensureMixDestination()) return;
+        if (!w.__vexaRemoteAudioReadyLatched) {
+          w.__vexaRemoteAudioReadyLatched = true;
+          void w.__vexaRemoteAudioReady?.();
+          w.logBot?.('[mixed] remote-audio ready (mix destination attached)');
         }
         const streams = (w.__vexaCapturedRemoteAudioStreams || []) as Array<{ id: string }>;
         if (!streams.length) return;

--- a/docs/changelog.d/866-mixed-lane-aloneness-ready.md
+++ b/docs/changelog.d/866-mixed-lane-aloneness-ready.md
@@ -1,0 +1,1 @@
+- **Empty-room `left_alone` on Zoom/Teams/Jitsi (#866).** Mixed-lane capture now reports remote-audio ready when the mix destination is attached — not when the first gated PCM frame arrives — so a bot alone from the start can leave after the silence window on every platform. See [Send a bot](/how-to/send-a-bot#when-the-bot-leaves-on-its-own).

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -130,8 +130,9 @@ join. Re-authenticate the browser profile and retry.
 
 An active bot leaves after it receives no remote microphone audio for **10 minutes** and the meeting
 finishes as `completed(left_alone)`. The same rule covers an empty room and a room containing only silent
-notetakers: it listens to the remote-audio signal and does not identify participants by name. Bot-generated
-speech is not part of that signal.
+notetakers — on **Google Meet, Zoom, Microsoft Teams, and Jitsi** alike: it listens to the remote-audio
+signal (capture attached and able to hear, not "someone has already spoken") and does not identify
+participants by name. Bot-generated speech is not part of that signal.
 
 Set a per-meeting window with `automatic_leave.max_time_left_alone` (milliseconds):
 


### PR DESCRIPTION
## Summary
- Mixed-lane (Zoom / Teams / Jitsi) now latches remote-audio **ready** when the mix `MediaStreamDestination` is created — i.e. capture is attached and *could* hear — instead of waiting for the first gated PCM frame.
- That unblocks the empty-room / alone-from-start case: previously no remote speech ⇒ no frame ⇒ never `available` ⇒ `left_alone` never fired (bot burned to the 4h cap).
- Docs (`send-a-bot.mdx`) state the silence auto-leave rule for **all four platforms**; changelog fragment added.

Closes #866.

## Observation bundle (acceptance)

| # | Expected | Actual | Verdict |
|---|---|---|---|
| A1 | Zoom empty-room → `left_alone` after window | **Not yet live-witnessed** — needs solo empty Zoom join | pending live |
| A2 | Same for Teams + Jitsi | **Not yet live-witnessed** | pending live |
| A3 | Google Meet unchanged | gmeet path still latches after `createGmeetCapture.start()` (untouched) | green (code review) |
| A4 | Tear-down / never attached fails closed | Boundary test: `unavailable()` on stop; aloneness suite keeps fail-closed | green (desk) |
| A5 | `send-a-bot.mdx` accurate for every platform | Explicit Meet/Zoom/Teams/Jitsi wording; no caveat | green |

### Desk / offline evidence (done)
- `capture-bridge.boundary.test.ts` (Teams fixture, **zero PCM frames**): `mixed lane latches remote-audio ready without any PCM frames (#866)` ✅
- Same test: teardown calls `unavailable` (#866 A4) ✅
- `aloneness.test.ts` full suite ✅ (silence / reset / fail-closed / exactly-once)

## Test plan
- [x] Offline boundary + aloneness suites
- [ ] Solo empty-room Zoom → `left_alone` (A1)
- [ ] Solo empty-room Teams + Jitsi (A2)
- [ ] Meet regression smoke (A3)
- [ ] CI gates

## Notes
- Branched from `rc/0.12.16` (depends on #545 / #485 already in that rc).
- Live legs are the issue's human bar — please hold merge until A1/A2 are witnessed (or a maintainer co-witnesses).
- Authorship: Ayush7614 only (no agent co-author trailers).