### PR TITLE
feat(meeting-api): serve POST /meetings/{meeting_id}/transcribe, deferred transcription from the recording (#525)

### DIFF
--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -1670,6 +1670,42 @@
     }
    }
   },
+    {
+   "unique-id": "meeting-api-stt",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "transcription",
+      "interface": "stt-endpoint"
+     }
+    }
+   },
+   "description": "deferred transcription of a master recording (POST /meetings/{id}/transcribe, #525) via TRANSCRIPTION_SERVICE_URL",
+   "protocol": "HTTPS",
+   "metadata": [
+    {
+     "access": "call"
+    }
+   ],
+   "controls": {
+    "data-egress": {
+     "description": "STT is first-party and self-hostable; default destination is tenant-hosted, so audio need not leave the tenant",
+     "requirements": [
+      {
+       "requirement-url": "https://vexa.ai/calm/controls/no-egress.requirement.json",
+       "config": {
+        "dataClass": "audio",
+        "destination": "tenant-hosted",
+        "egressApproved": true
+       }
+      }
+     ]
+    }
+   }
+  },
   {
    "unique-id": "bot-commands-read",
    "relationship-type": {

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "847535bba56bcdb2e39284413bbbf53e9c4a0b23397e5787c4a2a23959799367"
+  "architecture.calm.json": "01a3f536775f9628a7a522055b0d2a52b9448eebf29d6b38ccd868a198b106ed"
 }

--- a/core/gateway/contracts/api.v1/KNOWN_GAPS.json
+++ b/core/gateway/contracts/api.v1/KNOWN_GAPS.json
@@ -25,12 +25,6 @@
       "issue": "https://github.com/Vexa-ai/vexa/issues/579"
     },
     {
-      "method": "POST",
-      "path": "/meetings/{meeting_id}/transcribe",
-      "reason": "No on-demand re-transcribe orchestration exists in the 0.12 core (transcription is a live-pipeline concern). Left unimplemented + recorded rather than faked.",
-      "issue": "https://github.com/Vexa-ai/vexa/issues/591"
-    },
-    {
       "method": "PUT",
       "path": "/bots/{platform}/{native_meeting_id}/avatar",
       "reason": "Bot-command channel (set avatar) — a live acts.v1 PUBLISH to an active bot, not meeting-api persistence. No downstream handler in the 0.12 carve (voice/media-agent carve, same family as /speak, /config).",

--- a/core/gateway/services/conformance/src/gateway_conformance/fake_meeting_api.py
+++ b/core/gateway/services/conformance/src/gateway_conformance/fake_meeting_api.py
@@ -197,6 +197,12 @@ def build_fake_downstream() -> FastAPI:
         # The real bot-manager returns the meeting it acted on.
         return _golden("MeetingResponse.example.json")
 
+    @app.post("/meetings/{meeting_id}/transcribe")
+    async def transcribe_meeting(meeting_id: int):
+        # Deferred transcription from the recording (#525) — the module's honest result shape
+        # (the sealed 200 schema is unconstrained).
+        return {"meeting_id": meeting_id, "segments_stored": 0, "language": None}
+
     # --- recordings (gateway forwards /recordings to meeting-api; no sealed api.v1 component) ---
     @app.get("/recordings")
     async def list_recordings():

--- a/core/gateway/services/conformance/src/gateway_conformance/gateway_app.py
+++ b/core/gateway/services/conformance/src/gateway_conformance/gateway_app.py
@@ -42,7 +42,8 @@ class _ConformanceDownstream:
     def __init__(self, client: httpx.AsyncClient):
         self._client = client
 
-    async def request(self, method, url, *, headers=None, params=None, content=None):
+    async def request(self, method, url, *, headers=None, params=None, content=None, timeout=None):
+        # timeout is accepted for port parity and ignored: the in-process ASGI hop has no wire.
         parts = urlsplit(url)
         path = parts.path or "/"
         if parts.query:

--- a/core/gateway/services/conformance/tests/test_gateway_seam.py
+++ b/core/gateway/services/conformance/tests/test_gateway_seam.py
@@ -66,7 +66,7 @@ class _RaisingDownstream:
     def __init__(self, exc: Exception):
         self._exc = exc
 
-    async def request(self, method, url, *, headers=None, params=None, content=None):
+    async def request(self, method, url, *, headers=None, params=None, content=None, timeout=None):
         raise self._exc
 
 
@@ -79,7 +79,7 @@ class _StatusDownstream:
         self._content = content
         self._content_type = content_type
 
-    async def request(self, method, url, *, headers=None, params=None, content=None):
+    async def request(self, method, url, *, headers=None, params=None, content=None, timeout=None):
         return httpx.Response(
             status_code=self._status,
             content=self._content,
@@ -94,7 +94,7 @@ class _CapturingDownstream:
     def __init__(self):
         self.seen_headers: dict | None = None
 
-    async def request(self, method, url, *, headers=None, params=None, content=None):
+    async def request(self, method, url, *, headers=None, params=None, content=None, timeout=None):
         self.seen_headers = dict(headers or {})
         return httpx.Response(status_code=200, content=b'{"ok": true}',
                               headers={"content-type": "application/json"})

--- a/core/gateway/services/gateway/src/gateway/adapters.py
+++ b/core/gateway/services/gateway/src/gateway/adapters.py
@@ -32,9 +32,12 @@ class HttpxDownstreamClient:
     def __init__(self, client):
         self._client = client
 
-    async def request(self, method, url, *, headers=None, params=None, content=None):
+    async def request(self, method, url, *, headers=None, params=None, content=None, timeout=None):
+        import httpx
+
         return await self._client.request(
-            method, url, headers=headers, params=params or None, content=content
+            method, url, headers=headers, params=params or None, content=content,
+            timeout=timeout if timeout is not None else httpx.USE_CLIENT_DEFAULT,
         )
 
     async def stream(self, method, url, *, headers=None, params=None, content=None):

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -407,6 +407,12 @@ def create_app(
     async def patch_planned_meeting(meeting_id: int, request: Request):
         return await _forward("PATCH", _meeting(f"/meetings/{meeting_id}"), request)
 
+    # Deferred transcription from the recording (#525): the sealed api.v1 route, forwarded to
+    # meeting-api's transcribe module (serve-fork ruling — what api.v1 seals, the stack serves).
+    @app.post("/meetings/{meeting_id}/transcribe")
+    async def transcribe_meeting(meeting_id: int, request: Request):
+        return await _forward("POST", _meeting(f"/meetings/{meeting_id}/transcribe"), request)
+
     @app.delete("/meetings/{meeting_id}", status_code=204)
     async def delete_planned_meeting(meeting_id: int, request: Request):
         return await _forward("DELETE", _meeting(f"/meetings/{meeting_id}"), request)

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -246,7 +246,9 @@ def create_app(
         return headers, None
 
     # --- the REST proxy: faithful carve of main.forward_request for client (non-admin) routes.
-    async def _forward(method: str, url: str, request: Request) -> Response:
+    async def _forward(
+        method: str, url: str, request: Request, *, timeout: Optional[float] = None,
+    ) -> Response:
         headers, error = await _authorize(method, request)
         if error is not None:
             return error
@@ -262,6 +264,7 @@ def create_app(
                 headers=headers,
                 params=dict(request.query_params) or None,
                 content=content,
+                timeout=timeout,
             )
         except httpx.TimeoutException:
             return Response(content=json.dumps({"detail": "upstream timeout"}),
@@ -408,10 +411,14 @@ def create_app(
         return await _forward("PATCH", _meeting(f"/meetings/{meeting_id}"), request)
 
     # Deferred transcription from the recording (#525): the sealed api.v1 route, forwarded to
-    # meeting-api's transcribe module (serve-fork ruling — what api.v1 seals, the stack serves).
+    # meeting-api's transcribe module (serve-fork ruling: what api.v1 seals, the stack serves).
+    # Synchronous by design (the client waits for its transcript), so the forward outlives the
+    # default 30s hop: master upload + STT + the deferred tier's bounded 503 backoff.
     @app.post("/meetings/{meeting_id}/transcribe")
     async def transcribe_meeting(meeting_id: int, request: Request):
-        return await _forward("POST", _meeting(f"/meetings/{meeting_id}/transcribe"), request)
+        return await _forward(
+            "POST", _meeting(f"/meetings/{meeting_id}/transcribe"), request, timeout=660.0,
+        )
 
     @app.delete("/meetings/{meeting_id}", status_code=204)
     async def delete_planned_meeting(meeting_id: int, request: Request):

--- a/core/gateway/services/gateway/src/gateway/ports.py
+++ b/core/gateway/services/gateway/src/gateway/ports.py
@@ -86,6 +86,7 @@ class DownstreamClient(Protocol):
         headers: Optional[dict] = None,
         params: Optional[dict] = None,
         content: Optional[bytes] = None,
+        timeout: Optional[float] = None,
     ) -> DownstreamResponse:
         ...
 

--- a/core/gateway/services/gateway/tests/conftest.py
+++ b/core/gateway/services/gateway/tests/conftest.py
@@ -78,9 +78,9 @@ class FakeDownstream:
         ]
         self.last: Optional[dict] = None
 
-    async def request(self, method, url, *, headers=None, params=None, content=None):
+    async def request(self, method, url, *, headers=None, params=None, content=None, timeout=None):
         self.last = {"method": method, "url": url, "headers": headers or {},
-                     "params": params, "content": content}
+                     "params": params, "content": content, "timeout": timeout}
         return _Resp(self.status_code, json.dumps(self._body).encode(),
                      {"content-type": self._content_type, **self._extra_headers})
 

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -228,6 +228,18 @@ def test_native_meeting_mutate_passes_downstream_404_verbatim():
     assert r.status_code == 404
 
 
+def test_transcribe_forwards_to_meeting_api():
+    """#525 C2: the sealed POST /meetings/{meeting_id}/transcribe forwards verbatim to meeting-api's
+    transcribe module. Negative control: before this route the gateway 404'd a sealed path (the
+    KNOWN_GAPS row this change removes)."""
+    client, downstream = _client()
+    r = client.post("/meetings/42/transcribe", headers=AUTH, json={"language": "en"})
+    assert r.status_code == 200
+    assert downstream.last["method"] == "POST"
+    assert downstream.last["url"].endswith("/meetings/42/transcribe")
+    assert "meeting-api" in downstream.last["url"]
+
+
 def test_native_share_alias_forwards_to_meetings_share_mint():
     """#579 C3: the 0.10 POST /transcripts/{platform}/{native}/share aliases to the moved mint at
     POST /meetings/{platform}/{native}/share."""

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -238,6 +238,10 @@ def test_transcribe_forwards_to_meeting_api():
     assert downstream.last["method"] == "POST"
     assert downstream.last["url"].endswith("/meetings/42/transcribe")
     assert "meeting-api" in downstream.last["url"]
+    # Synchronous by design: the forward must outlive the default 30s hop (upload + STT +
+    # the deferred tier's bounded 503 backoff), else the edge 504s exactly when the
+    # backpressure works and a retry then 409s against the stored transcript.
+    assert downstream.last["timeout"] == 660.0
 
 
 def test_native_share_alias_forwards_to_meetings_share_mint():

--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -169,6 +169,8 @@ def build_production_app():
         from .calendar_sync import read_stamp
         return await read_stamp(redis_client, user_id)
 
+    from .transcribe import HttpSttTranscriber
+
     app = create_app(
         transcript_store=transcript_store,
         redis=segment_bus,
@@ -176,6 +178,8 @@ def build_production_app():
         runtime=runtime_client,
         recording_repo=recording_repo,
         storage=storage,
+        # deferred transcribe (#525): the deployment's configured STT backend + #522 model
+        stt=HttpSttTranscriber.from_env(),
         token_secret=token_secret,
         # The user-stop route (DELETE /bots) publishes the bot's `leave` command on redis pub/sub.
         # redis.asyncio's client satisfies the CommandPublisher port directly (async publish()).

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -117,6 +117,9 @@ def create_app(
     # recordings ports
     recording_repo: Optional["_recordings.RecordingRepo"] = None,
     storage: Optional["_recordings.Storage"] = None,
+    # transcribe port (#525) — None builds the env-configured HTTP client (whose routes
+    # refuse with a typed 503 when TRANSCRIPTION_SERVICE_URL is unset)
+    stt: Optional["object"] = None,
     # lifecycle store
     meeting_store: Optional[MeetingStore] = None,
     token_secret: Optional[str] = None,
@@ -207,6 +210,15 @@ def create_app(
     if storage is None:
         storage = _recordings_fakes().InMemoryStorage()
     app.include_router(_recordings.build_router(recording_repo, storage, token_secret=token_secret))
+
+    # --- transcribe: POST /meetings/{id}/transcribe — deferred STT from the recording (#525) ---
+    from . import transcribe as _transcribe
+
+    if stt is None:
+        stt = _transcribe.HttpSttTranscriber.from_env()
+    app.include_router(_transcribe.build_router(
+        transcript_store, stt, _transcribe.master_audio_resolver(recording_repo, storage),
+    ))
 
     return app
 

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -117,8 +117,8 @@ def create_app(
     # recordings ports
     recording_repo: Optional["_recordings.RecordingRepo"] = None,
     storage: Optional["_recordings.Storage"] = None,
-    # transcribe port (#525) — None builds the env-configured HTTP client (whose routes
-    # refuse with a typed 503 when TRANSCRIPTION_SERVICE_URL is unset)
+    # transcribe port (#525) — None falls back to the in-memory fake like every other port;
+    # production passes HttpSttTranscriber.from_env() (see __main__.build_production_app)
     stt: Optional["object"] = None,
     # lifecycle store
     meeting_store: Optional[MeetingStore] = None,
@@ -215,7 +215,7 @@ def create_app(
     from . import transcribe as _transcribe
 
     if stt is None:
-        stt = _transcribe.HttpSttTranscriber.from_env()
+        stt = _transcribe_fakes().FakeSttTranscriber()
     app.include_router(_transcribe.build_router(
         transcript_store, stt, _transcribe.master_audio_resolver(recording_repo, storage),
     ))
@@ -662,6 +662,12 @@ def _bot_spawn_fakes():
 
 def _collector_fakes():
     from .collector import fakes
+
+    return fakes
+
+
+def _transcribe_fakes():
+    from .transcribe import fakes
 
     return fakes
 

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/README.md
@@ -1,0 +1,23 @@
+# transcribe: deferred transcription from the recording (#525)
+
+Serves the sealed `POST /meetings/{meeting_id}/transcribe`: a completed meeting with a master
+recording gains transcript rows on demand. Composes the recordings seam (finalize-on-read →
+master bytes) and the collector's durable-write seam (`upsert_segments`); the STT hop speaks the
+OpenAI-compatible `/v1/audio/transcriptions` contract on the deferred tier (503 + Retry-After
+looped, bounded). Language is normalized to ISO-639-1 at storage (#355 defect 3); every refusal
+is a typed `TranscribeFault` the router maps to an HTTP status: never a silent `[]`.
+
+## Front door
+- `build_router(store, stt, resolve_master)`: the mountable route (the unified app mounts it).
+- `transcribe_meeting(...)`: the flow core (callable directly in tests): owner-only,
+  terminal-status gate, Q2 conflict on a second run, per-process in-flight guard.
+- `TranscribeFault`: the typed refusal (`kind` + optional provider status/code).
+- `normalize_language`: provider language value → ISO-639-1 code (or None).
+- `adapters.HttpSttTranscriber`: the STT client (`from_env()`: `TRANSCRIPTION_SERVICE_URL` /
+  `TRANSCRIPTION_SERVICE_TOKEN` / #522's `TRANSCRIPTION_MODEL`, default `whisper-1`).
+- `adapters.master_audio_resolver(repo, storage)`: recordings seam → `MasterResolver` port.
+- `fakes.FakeSttTranscriber`: offline driver (app factory / conformance).
+
+## Tests
+`tests/test_transcribe_deferred.py`: the #355 regression floor (D-A2 fixtures verbatim) plus
+the ruled edges. Red-first: the file predates the module and is its contract.

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/__init__.py
@@ -1,0 +1,14 @@
+"""transcribe — deferred transcription from the recording (#525): the sealed
+``POST /meetings/{meeting_id}/transcribe`` served from the recordings + collector seams."""
+from .adapters import HttpSttTranscriber, master_audio_resolver
+from .router import build_router
+from .service import TranscribeFault, normalize_language, transcribe_meeting
+
+__all__ = [
+    "HttpSttTranscriber",
+    "TranscribeFault",
+    "build_router",
+    "master_audio_resolver",
+    "normalize_language",
+    "transcribe_meeting",
+]

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/__init__.py
@@ -1,4 +1,4 @@
-"""transcribe — deferred transcription from the recording (#525): the sealed
+"""transcribe, deferred transcription from the recording (#525): the sealed
 ``POST /meetings/{meeting_id}/transcribe`` served from the recordings + collector seams."""
 from .adapters import HttpSttTranscriber, master_audio_resolver
 from .router import build_router

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/adapters.py
@@ -1,7 +1,7 @@
 """Production adapters for the transcribe module (#525 C1).
 
 ``HttpSttTranscriber`` speaks the OpenAI-compatible ``POST /v1/audio/transcriptions``
-contract — the single ASR seam (#437 ruling) — against the deployment's configured
+contract, the single ASR seam (#437 ruling), against the deployment's configured
 backend (bundled unit or a remote provider like Groq). ``master_audio_resolver``
 composes the recordings seam (finalize-on-read, #768) into the byte-resolver port
 the service flow consumes.
@@ -36,7 +36,7 @@ def _provider_fault(resp: httpx.Response) -> TranscribeFault:
             message = err.get("message") or str(err)
         else:
             message = str(body.get("detail") or resp.text)
-    except Exception:  # noqa: BLE001 — a non-JSON error body still surfaces verbatim
+    except Exception:  # noqa: BLE001, a non-JSON error body still surfaces verbatim
         message = resp.text
     return TranscribeFault(
         "provider_rejected", message, status=resp.status_code, provider_code=code,
@@ -48,7 +48,7 @@ class HttpSttTranscriber:
 
     Sends the resolved model id + ``response_format=verbose_json`` +
     ``transcription_tier=deferred`` (#355 defects 1+2, the deferred capacity tier),
-    and loops on 503 honoring Retry-After — the bundled service fails fast when
+    and loops on 503 honoring Retry-After, the bundled service fails fast when
     busy, so a deferred caller waits its turn.
     """
 
@@ -78,7 +78,7 @@ class HttpSttTranscriber:
         )
 
     def _endpoint(self) -> str:
-        # Append-only-when-missing — the ONE url rule the TS client and
+        # Append-only-when-missing, the ONE url rule the TS client and
         # config_preflight already share; anything else double-paths into a 404.
         base = (self.base_url or "").rstrip("/")
         return base if base.endswith(_ENDPOINT_PATH) else base + _ENDPOINT_PATH
@@ -120,7 +120,7 @@ class HttpSttTranscriber:
 
         if resp.status_code == 503:
             raise TranscribeFault(
-                "unavailable", "transcription backend busy — retries exhausted", status=503,
+                "unavailable", "transcription backend busy, retries exhausted", status=503,
             )
         if resp.status_code >= 400:
             raise _provider_fault(resp)
@@ -138,7 +138,7 @@ def master_audio_resolver(repo, storage):
 
     Finalize-on-read over every recording of the meeting (a meeting can carry
     several); the first media file that finalizes to a master wins. None when
-    nothing finalizes — recording disabled, or nothing captured.
+    nothing finalizes, recording disabled, or nothing captured.
     """
     from ..recordings.service import finalize_master
 

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/adapters.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import httpx
 
+from ..config_preflight import probe_url
 from .service import TranscribeFault
 
 _ENDPOINT_PATH = "/v1/audio/transcriptions"
@@ -59,7 +60,7 @@ class HttpSttTranscriber:
         token: Optional[str] = None,
         model: str = "whisper-1",
         transport: Optional[httpx.AsyncBaseTransport] = None,
-        max_busy_retries: int = 60,
+        max_busy_retries: int = 20,
     ):
         self.base_url = base_url
         self.token = token
@@ -77,12 +78,6 @@ class HttpSttTranscriber:
             model=os.getenv("TRANSCRIPTION_MODEL") or "whisper-1",
         )
 
-    def _endpoint(self) -> str:
-        # Append-only-when-missing, the ONE url rule the TS client and
-        # config_preflight already share; anything else double-paths into a 404.
-        base = (self.base_url or "").rstrip("/")
-        return base if base.endswith(_ENDPOINT_PATH) else base + _ENDPOINT_PATH
-
     async def transcribe(self, audio: bytes, *, language: Optional[str] = None) -> dict:
         if not self.base_url:
             raise TranscribeFault(
@@ -91,27 +86,32 @@ class HttpSttTranscriber:
         data = {
             "model": self.model,
             "response_format": "verbose_json",
-            "transcription_tier": "deferred",
         }
         if language:
             data["language"] = language
         # ponytail: filename hint is master.wav regardless of container; thread the real
         # fmt through the resolver if a provider ever starts sniffing extensions.
         files = {"file": ("master.wav", audio, "audio/wav")}
-        headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        # The tier travels as the X-Transcription-Tier HEADER (the bundled service's alias),
+        # never a form field: a strict remote OpenAI-compatible provider 400s unknown
+        # multipart fields, and remote providers ignore unknown headers safely.
+        headers = {"X-Transcription-Tier": "deferred"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
 
+        endpoint = probe_url(self.base_url, _ENDPOINT_PATH)
         try:
             async with httpx.AsyncClient(
                 transport=self._transport, timeout=httpx.Timeout(600.0, connect=10.0),
             ) as client:
                 for attempt in range(self._max_busy_retries + 1):
-                    resp = await client.post(
-                        self._endpoint(), data=data, files=files, headers=headers,
-                    )
+                    resp = await client.post(endpoint, data=data, files=files, headers=headers)
                     if resp.status_code != 503 or attempt == self._max_busy_retries:
                         break
                     try:
-                        retry_after = float(resp.headers.get("Retry-After", "1"))
+                        # Sleep cap bounds the worst-case wait so the whole call stays inside
+                        # the gateway's per-route forward timeout.
+                        retry_after = min(float(resp.headers.get("Retry-After", "1")), 15.0)
                     except ValueError:
                         retry_after = 1.0
                     await asyncio.sleep(retry_after)
@@ -144,12 +144,17 @@ def master_audio_resolver(repo, storage):
 
     async def resolve(meeting_id: int) -> Optional[bytes]:
         for rec in await repo.get_recordings(meeting_id):
-            key = await finalize_master(
-                repo, storage, meeting_id=meeting_id, recording_id=rec.get("id"),
-                media_type="audio",
-            )
-            if key is not None:
-                return await storage.get(key)
+            try:
+                key = await finalize_master(
+                    repo, storage, meeting_id=meeting_id, recording_id=rec.get("id"),
+                    media_type="audio",
+                )
+                if key is not None:
+                    return await storage.get(key)
+            except Exception as e:  # noqa: BLE001, a storage fault must be typed, not a 500
+                raise TranscribeFault(
+                    "unavailable", f"recording storage read failed: {e}",
+                )
         return None
 
     return resolve

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/adapters.py
@@ -1,0 +1,155 @@
+"""Production adapters for the transcribe module (#525 C1).
+
+``HttpSttTranscriber`` speaks the OpenAI-compatible ``POST /v1/audio/transcriptions``
+contract — the single ASR seam (#437 ruling) — against the deployment's configured
+backend (bundled unit or a remote provider like Groq). ``master_audio_resolver``
+composes the recordings seam (finalize-on-read, #768) into the byte-resolver port
+the service flow consumes.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Optional
+
+import httpx
+
+from .service import TranscribeFault
+
+_ENDPOINT_PATH = "/v1/audio/transcriptions"
+
+
+def _provider_fault(resp: httpx.Response) -> TranscribeFault:
+    """An HTTP error response → a typed fault carrying the provider's own words.
+
+    Understands both the Groq/OpenAI error envelope ({"error": {message, code}})
+    and the bundled service's FastAPI shape ({"detail": ...}). The message travels
+    with the fault: an operator must see WHY, not 0.10's generic
+    "Transcription service error: 404" (#355 defect 1).
+    """
+    code: Optional[str] = None
+    try:
+        body = resp.json()
+        err = body.get("error")
+        if isinstance(err, dict):
+            code = err.get("code")
+            message = err.get("message") or str(err)
+        else:
+            message = str(body.get("detail") or resp.text)
+    except Exception:  # noqa: BLE001 — a non-JSON error body still surfaces verbatim
+        message = resp.text
+    return TranscribeFault(
+        "provider_rejected", message, status=resp.status_code, provider_code=code,
+    )
+
+
+class HttpSttTranscriber:
+    """The deferred-tier STT client over httpx.
+
+    Sends the resolved model id + ``response_format=verbose_json`` +
+    ``transcription_tier=deferred`` (#355 defects 1+2, the deferred capacity tier),
+    and loops on 503 honoring Retry-After — the bundled service fails fast when
+    busy, so a deferred caller waits its turn.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str],
+        *,
+        token: Optional[str] = None,
+        model: str = "whisper-1",
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+        max_busy_retries: int = 60,
+    ):
+        self.base_url = base_url
+        self.token = token
+        self.model = model
+        self._transport = transport
+        self._max_busy_retries = max_busy_retries
+
+    @classmethod
+    def from_env(cls) -> "HttpSttTranscriber":
+        """The deployment's configured backend: #522's TRANSCRIPTION_MODEL (default
+        whisper-1) against TRANSCRIPTION_SERVICE_URL/TOKEN."""
+        return cls(
+            os.getenv("TRANSCRIPTION_SERVICE_URL") or None,
+            token=os.getenv("TRANSCRIPTION_SERVICE_TOKEN") or None,
+            model=os.getenv("TRANSCRIPTION_MODEL") or "whisper-1",
+        )
+
+    def _endpoint(self) -> str:
+        # Append-only-when-missing — the ONE url rule the TS client and
+        # config_preflight already share; anything else double-paths into a 404.
+        base = (self.base_url or "").rstrip("/")
+        return base if base.endswith(_ENDPOINT_PATH) else base + _ENDPOINT_PATH
+
+    async def transcribe(self, audio: bytes, *, language: Optional[str] = None) -> dict:
+        if not self.base_url:
+            raise TranscribeFault(
+                "stt_unconfigured", "TRANSCRIPTION_SERVICE_URL is not set on this deployment",
+            )
+        data = {
+            "model": self.model,
+            "response_format": "verbose_json",
+            "transcription_tier": "deferred",
+        }
+        if language:
+            data["language"] = language
+        # ponytail: filename hint is master.wav regardless of container; thread the real
+        # fmt through the resolver if a provider ever starts sniffing extensions.
+        files = {"file": ("master.wav", audio, "audio/wav")}
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+
+        try:
+            async with httpx.AsyncClient(
+                transport=self._transport, timeout=httpx.Timeout(600.0, connect=10.0),
+            ) as client:
+                for attempt in range(self._max_busy_retries + 1):
+                    resp = await client.post(
+                        self._endpoint(), data=data, files=files, headers=headers,
+                    )
+                    if resp.status_code != 503 or attempt == self._max_busy_retries:
+                        break
+                    try:
+                        retry_after = float(resp.headers.get("Retry-After", "1"))
+                    except ValueError:
+                        retry_after = 1.0
+                    await asyncio.sleep(retry_after)
+        except httpx.HTTPError as e:
+            raise TranscribeFault("unavailable", f"transcription backend unreachable: {e}")
+
+        if resp.status_code == 503:
+            raise TranscribeFault(
+                "unavailable", "transcription backend busy — retries exhausted", status=503,
+            )
+        if resp.status_code >= 400:
+            raise _provider_fault(resp)
+        try:
+            return resp.json()
+        except ValueError:
+            raise TranscribeFault(
+                "provider_rejected", "transcription backend returned a non-JSON body",
+                status=resp.status_code,
+            )
+
+
+def master_audio_resolver(repo, storage):
+    """recordings seam → the service's byte-resolver port.
+
+    Finalize-on-read over every recording of the meeting (a meeting can carry
+    several); the first media file that finalizes to a master wins. None when
+    nothing finalizes — recording disabled, or nothing captured.
+    """
+    from ..recordings.service import finalize_master
+
+    async def resolve(meeting_id: int) -> Optional[bytes]:
+        for rec in await repo.get_recordings(meeting_id):
+            key = await finalize_master(
+                repo, storage, meeting_id=meeting_id, recording_id=rec.get("id"),
+                media_type="audio",
+            )
+            if key is not None:
+                return await storage.get(key)
+        return None
+
+    return resolve

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/fakes.py
@@ -1,0 +1,23 @@
+"""In-process fakes satisfying the transcribe ports: offline drivers for the app factory
+and the conformance harness (no STT service, no network), like every sibling module's fakes."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+class FakeSttTranscriber:
+    """A canned verbose_json responder. ``calls`` records (audio, language) per request;
+    set ``fault`` to raise a typed fault instead."""
+
+    def __init__(self, result: Optional[dict] = None, fault: Optional[Exception] = None):
+        self.result = result if result is not None else {
+            "text": "", "language": "en", "duration": 0.0, "segments": [],
+        }
+        self.fault = fault
+        self.calls: list[tuple[bytes, Optional[str]]] = []
+
+    async def transcribe(self, audio: bytes, *, language: Optional[str] = None) -> dict:
+        self.calls.append((audio, language))
+        if self.fault is not None:
+            raise self.fault
+        return self.result

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/ports.py
@@ -1,0 +1,14 @@
+"""Ports of the transcribe module: the typing.Protocol seams the service flow composes."""
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Optional, Protocol
+
+
+class SttTranscriber(Protocol):
+    """One audio buffer in, one parsed verbose_json dict out; typed TranscribeFault on failure."""
+
+    async def transcribe(self, audio: bytes, *, language: Optional[str] = None) -> dict: ...
+
+
+#: Resolve a meeting's finalized master audio to raw bytes (None: nothing to transcribe).
+MasterResolver = Callable[[int], Awaitable[Optional[bytes]]]

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/router.py
@@ -1,4 +1,4 @@
-"""POST /meetings/{meeting_id}/transcribe — the sealed api.v1 route (#525 C1).
+"""POST /meetings/{meeting_id}/transcribe, the sealed api.v1 route (#525 C1).
 
 The contract stops lying: the route either serves a transcript from a completed
 meeting's recording or refuses with a typed reason. Fault→HTTP mapping lives
@@ -14,8 +14,10 @@ from .service import TranscribeFault, transcribe_meeting
 
 _FAULT_STATUS = {
     "not_found": 404,
+    "not_completed": 409,         # still recording, a partial transcript would 409-block the full one
     "no_recording": 404,          # prepared: a reasoned 404, never a 500
     "already_transcribed": 409,   # Q2 ruling: refuse a second run, typed
+    "already_running": 409,       # concurrent duplicate, the first run is still transcribing
     "no_segments": 502,
     "provider_rejected": 502,
     "unavailable": 503,

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/router.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Body, Header, HTTPException
 
+from ..obs import log_event
 from .service import TranscribeFault, transcribe_meeting
 
 _FAULT_STATUS = {
@@ -48,16 +49,27 @@ def build_router(store, stt, resolve_master) -> APIRouter:
         user_id = _resolve_user_id(x_user_id)
         language = (body or {}).get("language")
         try:
-            return await transcribe_meeting(
+            result = await transcribe_meeting(
                 store=store, stt=stt, resolve_master=resolve_master,
                 user_id=user_id, meeting_id=meeting_id, language=language,
             )
         except TranscribeFault as fault:
+            log_event(
+                "deferred_transcribe_refused", audience="user", level="warning",
+                span="transcribe", user_id=user_id, meeting_id=str(meeting_id),
+                fields={"reason": fault.kind, "provider_code": fault.provider_code},
+            )
             detail = {"reason": fault.kind, "message": fault.detail}
             if fault.provider_code:
                 detail["provider_code"] = fault.provider_code
             raise HTTPException(
                 status_code=_FAULT_STATUS.get(fault.kind, 502), detail=detail,
             )
+        log_event(
+            "deferred_transcribed", audience="user", span="transcribe",
+            user_id=user_id, meeting_id=str(meeting_id),
+            fields={"segments_stored": result["segments_stored"], "language": result["language"]},
+        )
+        return result
 
     return router

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/router.py
@@ -1,0 +1,61 @@
+"""POST /meetings/{meeting_id}/transcribe — the sealed api.v1 route (#525 C1).
+
+The contract stops lying: the route either serves a transcript from a completed
+meeting's recording or refuses with a typed reason. Fault→HTTP mapping lives
+here; the flow itself is ``service.transcribe_meeting``.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Body, Header, HTTPException
+
+from .service import TranscribeFault, transcribe_meeting
+
+_FAULT_STATUS = {
+    "not_found": 404,
+    "no_recording": 404,          # prepared: a reasoned 404, never a 500
+    "already_transcribed": 409,   # Q2 ruling: refuse a second run, typed
+    "no_segments": 502,
+    "provider_rejected": 502,
+    "unavailable": 503,
+    "stt_unconfigured": 503,
+}
+
+
+def _resolve_user_id(x_user_id: Optional[str]) -> int:
+    if not x_user_id:
+        raise HTTPException(status_code=401, detail="Missing user identity")
+    try:
+        return int(x_user_id)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid user identity")
+
+
+def build_router(store, stt, resolve_master) -> APIRouter:
+    router = APIRouter()
+
+    @router.post("/meetings/{meeting_id}/transcribe")
+    async def transcribe(
+        meeting_id: int,
+        body: Optional[dict] = Body(default=None),
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        """api/meetings.mdx: transcribe a completed meeting recording. Optional body
+        ``{"language": "en"}`` forwards a language hint to the STT backend."""
+        user_id = _resolve_user_id(x_user_id)
+        language = (body or {}).get("language")
+        try:
+            return await transcribe_meeting(
+                store=store, stt=stt, resolve_master=resolve_master,
+                user_id=user_id, meeting_id=meeting_id, language=language,
+            )
+        except TranscribeFault as fault:
+            detail = {"reason": fault.kind, "message": fault.detail}
+            if fault.provider_code:
+                detail["provider_code"] = fault.provider_code
+            raise HTTPException(
+                status_code=_FAULT_STATUS.get(fault.kind, 502), detail=detail,
+            )
+
+    return router

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/service.py
@@ -1,0 +1,146 @@
+"""Deferred transcription from the recording (#525 C1) — the pure flow over ports.
+
+A completed meeting with a master recording gains transcript rows on demand:
+resolve the master via the recordings seam, POST it to the STT service, normalize
+the detected language to ISO-639-1 (#355 defect 3), store rows through the
+collector's durable-write seam. Every failure is a typed ``TranscribeFault`` —
+never a silent ``[]`` (#355 defects 1 and 2; P18).
+"""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+
+class TranscribeFault(Exception):
+    """A typed refusal/failure of the deferred-transcribe flow.
+
+    ``kind`` is the machine-readable reason the router maps to an HTTP status:
+    ``not_found`` · ``no_recording`` · ``already_transcribed`` · ``no_segments`` ·
+    ``provider_rejected`` · ``unavailable`` · ``stt_unconfigured``.
+    ``provider_code``/``status`` carry the upstream provider's error verbatim so an
+    operator sees WHY (0.10 collapsed a Groq model_not_found 404 into a generic 502).
+    """
+
+    def __init__(
+        self,
+        kind: str,
+        detail: str = "",
+        *,
+        status: Optional[int] = None,
+        provider_code: Optional[str] = None,
+    ):
+        super().__init__(f"{kind}: {detail}" if detail else kind)
+        self.kind = kind
+        self.detail = detail
+        self.status = status
+        self.provider_code = provider_code
+
+
+class SttTranscriber(Protocol):
+    async def transcribe(self, audio: bytes, *, language: Optional[str] = None) -> dict: ...
+
+
+# Whisper's own language inventory, inverted: full name (lowercased) → ISO-639-1 code.
+# Groq/OpenAI verbose_json name the language in full ("English"); the collector's
+# ``transcriptions.language`` column is String(10) and every consumer expects a code,
+# so normalization happens HERE, at storage time (#525 A3).
+_NAME_TO_ISO = {
+    "english": "en", "chinese": "zh", "german": "de", "spanish": "es", "russian": "ru",
+    "korean": "ko", "french": "fr", "japanese": "ja", "portuguese": "pt", "turkish": "tr",
+    "polish": "pl", "catalan": "ca", "dutch": "nl", "arabic": "ar", "swedish": "sv",
+    "italian": "it", "indonesian": "id", "hindi": "hi", "finnish": "fi", "vietnamese": "vi",
+    "hebrew": "he", "ukrainian": "uk", "greek": "el", "malay": "ms", "czech": "cs",
+    "romanian": "ro", "danish": "da", "hungarian": "hu", "tamil": "ta", "norwegian": "no",
+    "thai": "th", "urdu": "ur", "croatian": "hr", "bulgarian": "bg", "lithuanian": "lt",
+    "latin": "la", "maori": "mi", "malayalam": "ml", "welsh": "cy", "slovak": "sk",
+    "telugu": "te", "persian": "fa", "latvian": "lv", "bengali": "bn", "serbian": "sr",
+    "azerbaijani": "az", "slovenian": "sl", "kannada": "kn", "estonian": "et",
+    "macedonian": "mk", "breton": "br", "basque": "eu", "icelandic": "is", "armenian": "hy",
+    "nepali": "ne", "mongolian": "mn", "bosnian": "bs", "kazakh": "kk", "albanian": "sq",
+    "swahili": "sw", "galician": "gl", "marathi": "mr", "punjabi": "pa", "sinhala": "si",
+    "khmer": "km", "shona": "sn", "yoruba": "yo", "somali": "so", "afrikaans": "af",
+    "occitan": "oc", "georgian": "ka", "belarusian": "be", "tajik": "tg", "sindhi": "sd",
+    "gujarati": "gu", "amharic": "am", "yiddish": "yi", "lao": "lo", "uzbek": "uz",
+    "faroese": "fo", "haitian creole": "ht", "pashto": "ps", "turkmen": "tk",
+    "nynorsk": "nn", "maltese": "mt", "sanskrit": "sa", "luxembourgish": "lb",
+    "myanmar": "my", "tibetan": "bo", "tagalog": "tl", "malagasy": "mg", "assamese": "as",
+    "tatar": "tt", "hawaiian": "haw", "lingala": "ln", "hausa": "ha", "bashkir": "ba",
+    "javanese": "jw", "sundanese": "su", "cantonese": "yue",
+}
+
+
+def normalize_language(value: Optional[str]) -> Optional[str]:
+    """A provider language value → ISO-639-1 code, or None when it can't be one.
+
+    Codes pass through; full names map via the whisper inventory; anything else
+    stores as NULL — never a value the String(10) column and code-expecting
+    consumers can't hold (the 0.10 read path dropped every segment over exactly
+    this, #355 defect 3).
+    """
+    if not value:
+        return None
+    v = value.strip().lower()
+    if v in _NAME_TO_ISO:
+        return _NAME_TO_ISO[v]
+    if len(v) <= 3:  # already a code (whisper's own form, incl. "haw"/"yue")
+        return v
+    return None
+
+
+async def transcribe_meeting(
+    *,
+    store: Any,
+    stt: SttTranscriber,
+    resolve_master: Callable[[int], Awaitable[Optional[bytes]]],
+    user_id: int,
+    meeting_id: int,
+    language: Optional[str] = None,
+) -> dict:
+    """Transcribe a completed meeting's master recording into transcript rows.
+
+    Returns ``{"meeting_id", "segments_stored", "language"}``. Raises
+    ``TranscribeFault`` for every refusal — the router owns the HTTP mapping.
+    """
+    doc = await store.get_transcript_by_id(user_id, meeting_id)
+    if doc is None:
+        raise TranscribeFault("not_found", f"meeting {meeting_id} not found for this user")
+    if doc.get("segments"):
+        # Q2 ruling (2026-07-21): a meeting with transcript rows is refused, typed.
+        raise TranscribeFault(
+            "already_transcribed",
+            f"meeting {meeting_id} already has {len(doc['segments'])} transcript segments",
+        )
+
+    audio = await resolve_master(meeting_id)
+    if audio is None:
+        raise TranscribeFault(
+            "no_recording",
+            f"meeting {meeting_id} has no finalized master recording (recording disabled or empty)",
+        )
+
+    result = await stt.transcribe(audio, language=language)
+    if "segments" not in result:
+        # The ABSENT key means response_format=verbose_json was not honored (#355
+        # defect 2). A present-but-empty list is legitimate silence, not this fault.
+        raise TranscribeFault(
+            "no_segments",
+            "provider returned no segments[] — response_format=verbose_json not honored "
+            "by the transcription backend",
+        )
+
+    lang = normalize_language(result.get("language") or language)
+    segments = []
+    for i, seg in enumerate(result["segments"]):
+        if "start" not in seg or "end" not in seg or not str(seg.get("text", "")).strip():
+            continue  # provider hygiene: a row needs a span and words (0.10's own filter)
+        start = float(seg["start"])
+        segments.append({
+            "segment_id": f"deferred:{i}:{start:.3f}",  # the 0.10-observable id shape
+            "start": start,
+            "end": float(seg["end"]),
+            "text": seg["text"],
+            "language": lang,
+            "source": "deferred",
+        })
+    await store.upsert_segments(meeting_id, segments)
+    return {"meeting_id": meeting_id, "segments_stored": len(segments), "language": lang}

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/service.py
@@ -8,7 +8,9 @@ never a silent ``[]`` (#355 defects 1 and 2; P18).
 """
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Optional, Protocol
+from typing import Any, Awaitable, Callable, Optional
+
+from .ports import SttTranscriber
 
 
 class TranscribeFault(Exception):
@@ -35,10 +37,6 @@ class TranscribeFault(Exception):
         self.detail = detail
         self.status = status
         self.provider_code = provider_code
-
-
-class SttTranscriber(Protocol):
-    async def transcribe(self, audio: bytes, *, language: Optional[str] = None) -> dict: ...
 
 
 # Whisper's own language inventory, inverted: full name (lowercased) → ISO-639-1 code.

--- a/core/meetings/services/meeting-api/src/meeting_api/transcribe/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/transcribe/service.py
@@ -1,9 +1,9 @@
-"""Deferred transcription from the recording (#525 C1) — the pure flow over ports.
+"""Deferred transcription from the recording (#525 C1), the pure flow over ports.
 
 A completed meeting with a master recording gains transcript rows on demand:
 resolve the master via the recordings seam, POST it to the STT service, normalize
 the detected language to ISO-639-1 (#355 defect 3), store rows through the
-collector's durable-write seam. Every failure is a typed ``TranscribeFault`` —
+collector's durable-write seam. Every failure is a typed ``TranscribeFault``,
 never a silent ``[]`` (#355 defects 1 and 2; P18).
 """
 from __future__ import annotations
@@ -15,8 +15,9 @@ class TranscribeFault(Exception):
     """A typed refusal/failure of the deferred-transcribe flow.
 
     ``kind`` is the machine-readable reason the router maps to an HTTP status:
-    ``not_found`` · ``no_recording`` · ``already_transcribed`` · ``no_segments`` ·
-    ``provider_rejected`` · ``unavailable`` · ``stt_unconfigured``.
+    ``not_found`` · ``not_completed`` · ``no_recording`` · ``already_transcribed`` ·
+    ``already_running`` · ``no_segments`` · ``provider_rejected`` · ``unavailable`` ·
+    ``stt_unconfigured``.
     ``provider_code``/``status`` carry the upstream provider's error verbatim so an
     operator sees WHY (0.10 collapsed a Groq model_not_found 404 into a generic 502).
     """
@@ -73,7 +74,7 @@ def normalize_language(value: Optional[str]) -> Optional[str]:
     """A provider language value → ISO-639-1 code, or None when it can't be one.
 
     Codes pass through; full names map via the whisper inventory; anything else
-    stores as NULL — never a value the String(10) column and code-expecting
+    stores as NULL, never a value the String(10) column and code-expecting
     consumers can't hold (the 0.10 read path dropped every segment over exactly
     this, #355 defect 3).
     """
@@ -85,6 +86,16 @@ def normalize_language(value: Optional[str]) -> Optional[str]:
     if len(v) <= 3:  # already a code (whisper's own form, incl. "haw"/"yue")
         return v
     return None
+
+
+# ponytail: per-process in-flight guard, a second meeting-api replica can double-run;
+# move to a redis lock when meeting-api scales past one replica (docs already caveat that).
+_IN_FLIGHT: set[int] = set()
+
+# Statuses whose recording is final. Anything earlier (active/awaiting/...) would transcribe
+# a PARTIAL master (finalize-on-read is deliberately re-assemblable mid-recording, #768) and
+# then 409-block the full run forever via the Q2 conflict check.
+_TERMINAL_STATUSES = frozenset({"completed", "failed"})
 
 
 async def transcribe_meeting(
@@ -99,8 +110,23 @@ async def transcribe_meeting(
     """Transcribe a completed meeting's master recording into transcript rows.
 
     Returns ``{"meeting_id", "segments_stored", "language"}``. Raises
-    ``TranscribeFault`` for every refusal — the router owns the HTTP mapping.
+    ``TranscribeFault`` for every refusal, the router owns the HTTP mapping.
     """
+    # OWNER-only: transcription incurs STT cost, writes rows into the meeting, and consumes
+    # the single Q2-permitted run, owner-tier mutations, so the read-tier ACL that admits
+    # transcript-share viewers and workspace members is not enough. ``shared`` is the store's
+    # own owner test (user_id mismatch).
+    rows = await store.list_meetings(user_id, meeting_id=meeting_id, slim=True)
+    row = rows[0] if rows else None
+    if row is None or row.get("shared"):
+        raise TranscribeFault("not_found", f"meeting {meeting_id} not found for this user")
+    if row.get("status") not in _TERMINAL_STATUSES:
+        raise TranscribeFault(
+            "not_completed",
+            f"meeting {meeting_id} is {row.get('status')!r}, a transcript from a still-running "
+            "recording would be partial and would block the full run; retry after the meeting ends",
+        )
+
     doc = await store.get_transcript_by_id(user_id, meeting_id)
     if doc is None:
         raise TranscribeFault("not_found", f"meeting {meeting_id} not found for this user")
@@ -111,6 +137,30 @@ async def transcribe_meeting(
             f"meeting {meeting_id} already has {len(doc['segments'])} transcript segments",
         )
 
+    if meeting_id in _IN_FLIGHT:
+        # The Q2 check alone is check-then-act across a minutes-long STT await: a concurrent
+        # second run would double-spend the provider. Refuse it while the first is running.
+        raise TranscribeFault(
+            "already_running", f"a transcription of meeting {meeting_id} is already in progress",
+        )
+    _IN_FLIGHT.add(meeting_id)
+    try:
+        return await _transcribe_locked(
+            store=store, stt=stt, resolve_master=resolve_master,
+            meeting_id=meeting_id, language=language,
+        )
+    finally:
+        _IN_FLIGHT.discard(meeting_id)
+
+
+async def _transcribe_locked(
+    *,
+    store: Any,
+    stt: SttTranscriber,
+    resolve_master: Callable[[int], Awaitable[Optional[bytes]]],
+    meeting_id: int,
+    language: Optional[str],
+) -> dict:
     audio = await resolve_master(meeting_id)
     if audio is None:
         raise TranscribeFault(
@@ -124,7 +174,7 @@ async def transcribe_meeting(
         # defect 2). A present-but-empty list is legitimate silence, not this fault.
         raise TranscribeFault(
             "no_segments",
-            "provider returned no segments[] — response_format=verbose_json not honored "
+            "provider returned no segments[], response_format=verbose_json not honored "
             "by the transcription backend",
         )
 

--- a/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
+++ b/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
@@ -182,16 +182,19 @@ async def test_request_carries_model_verbose_json_and_deferred_tier():
     await run(store, mid, make_stt(handler), language="en")
 
     (req,) = seen
-    # Bare base URL gets the OpenAI-compatible path appended (append-only-when-missing,
-    # the one rule the TS client and config_preflight already share).
+    # Bare base URL gets the OpenAI-compatible path appended (probe_url, the one rule the
+    # TS client and config_preflight already share).
     assert req.url.path == "/v1/audio/transcriptions"
     assert req.headers.get("authorization") == "Bearer test-stt-token"
+    # The tier travels as a HEADER (bundled service's alias): a strict remote provider
+    # 400s unknown multipart fields but ignores unknown headers.
+    assert req.headers.get("x-transcription-tier") == "deferred"
 
     body = req.read()
     assert b'name="file"' in body
     assert b'name="model"\r\n\r\nwhisper-large-v3-turbo' in body      # defect-1 floor
     assert b'name="response_format"\r\n\r\nverbose_json' in body      # defect-2 floor
-    assert b'name="transcription_tier"\r\n\r\ndeferred' in body       # the deferred tier
+    assert b'name="transcription_tier"' not in body                   # never a form field
     assert b'name="language"\r\n\r\nen' in body                       # caller hint forwarded
 
 
@@ -226,6 +229,30 @@ async def test_absent_master_is_a_no_recording_fault_not_a_500():
     with pytest.raises(TranscribeFault) as ei:
         await run(store, mid, make_stt(lambda r: httpx.Response(500)), resolver=no_master)
     assert ei.value.kind == "no_recording"
+
+
+async def test_storage_read_failure_is_a_typed_unavailable_not_a_500():
+    from meeting_api.transcribe import master_audio_resolver
+
+    class OneRecordingRepo:
+        async def get_recordings(self, meeting_id):
+            return [{"id": 1, "media_files": [{"type": "audio"}]}]
+
+    class BrokenStorage:
+        async def exists(self, key):
+            raise RuntimeError("S3 unreachable")
+
+        async def get(self, key):
+            raise RuntimeError("S3 unreachable")
+
+        async def list(self, prefix):
+            raise RuntimeError("S3 unreachable")
+
+    resolver = master_audio_resolver(OneRecordingRepo(), BrokenStorage())
+    store, mid = seeded_store()
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(lambda r: httpx.Response(500)), resolver=resolver)
+    assert ei.value.kind == "unavailable"
 
 
 async def test_foreign_meeting_is_not_found():

--- a/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
+++ b/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
@@ -318,6 +318,37 @@ async def test_second_transcription_is_refused_as_conflict():
     assert ei.value.kind == "already_transcribed"
 
 
+# --- the sealed route itself: fault kinds mapped to HTTP statuses -----------------------
+
+def test_router_maps_faults_to_http_statuses():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from meeting_api.transcribe import build_router
+    from meeting_api.transcribe.fakes import FakeSttTranscriber
+
+    store, mid = seeded_store()
+    app = FastAPI()
+    app.include_router(build_router(
+        store, FakeSttTranscriber(result=VERBOSE_JSON_LANGUAGE_ENGLISH), resolve_master,
+    ))
+    client = TestClient(app)
+
+    assert client.post(f"/meetings/{mid}/transcribe").status_code == 401  # no identity
+
+    ok = client.post(f"/meetings/{mid}/transcribe", headers={"x-user-id": "7"})
+    assert ok.status_code == 200
+    assert ok.json() == {"meeting_id": mid, "segments_stored": 2, "language": "en"}
+
+    conflict = client.post(f"/meetings/{mid}/transcribe", headers={"x-user-id": "7"})
+    assert conflict.status_code == 409
+    assert conflict.json()["detail"]["reason"] == "already_transcribed"
+
+    missing = client.post("/meetings/999999/transcribe", headers={"x-user-id": "7"})
+    assert missing.status_code == 404
+    assert missing.json()["detail"]["reason"] == "not_found"
+
+
 # --- #522 semantics: the model id comes from the deployment, default whisper-1 ----------
 
 async def test_from_env_model_resolution(monkeypatch):

--- a/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
+++ b/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
@@ -1,0 +1,259 @@
+"""RED fixtures for #525 C1: deferred transcription from the recording (D-A2 lane).
+
+Hand-authored edge fixtures FROM the #355 report, as #525 mandates. Each pins one defect
+of the 0.10 implementation as a regression floor for the new ``meeting_api.transcribe``
+module:
+
+  * defect 1: a Groq-shaped ``model_not_found`` 404 body surfaces as a TYPED fault that
+    carries the provider's code and message, never a generic 502 or a silent empty;
+  * defect 2: a default-``json`` response WITHOUT ``segments[]`` (response_format not
+    honored) is loud, never "0 segments, speakers=[]" with a green status;
+  * defect 3: ``language: "English"`` is normalized to ISO-639-1 ``en`` at STORAGE time
+    (A3; the 0.10 read-side validator that crashed on it no longer exists).
+
+RED by construction: ``meeting_api.transcribe`` does not exist yet, so this file is the
+module's contract. Green = C1 implemented as prepared in #525 and ruled on 2026-07-21:
+serve fork; master audio via the recordings seam; STT call with the configured model +
+``response_format=verbose_json`` + ``transcription_tier=deferred`` (503 + Retry-After
+looped); rows through the collector's durable-write seam; second run refused as a
+conflict (Q2); meeting-api owns the route (Q4).
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+from meeting_api.transcribe import HttpSttTranscriber, TranscribeFault, transcribe_meeting
+
+# --- fixtures, verbatim from the #355 report --------------------------------------------
+
+# Defect 1: Groq's exact 404 body for the wrong model id ``large-v3-turbo`` (the correct
+# id is ``whisper-large-v3-turbo``). 0.10 collapsed this into HTTPException 502
+# "Transcription service error: 404" and the user saw a generic gateway error.
+GROQ_MODEL_NOT_FOUND = {
+    "error": {
+        "message": "The model `large-v3-turbo` does not exist or you do not have access to it.",
+        "type": "invalid_request_error",
+        "code": "model_not_found",
+    }
+}
+
+# Defect 2: with response_format omitted, Groq's /audio/transcriptions defaults to the
+# plain ``json`` format: a top-level text and NO segments key. 0.10 read
+# ``tx_result.get("segments", [])`` and silently stored nothing.
+DEFAULT_JSON_NO_SEGMENTS = {"text": "Deferred transcription of a real meeting."}
+
+# Defect 3: Groq names the language in full. 0.10 stored it verbatim; every deferred
+# segment then failed the read-side ISO validator and was dropped from the transcript.
+VERBOSE_JSON_LANGUAGE_ENGLISH = {
+    "text": " Hello everyone. Let's get started.",
+    "language": "English",
+    "duration": 8.2,
+    "segments": [
+        {
+            "id": 0, "seek": 0, "start": 0.0, "end": 3.4, "text": " Hello everyone.",
+            "tokens": [], "temperature": 0.0, "avg_logprob": -0.21,
+            "compression_ratio": 1.08, "no_speech_prob": 0.01,
+        },
+        {
+            "id": 1, "seek": 340, "start": 3.4, "end": 8.2, "text": " Let's get started.",
+            "tokens": [], "temperature": 0.0, "avg_logprob": -0.18,
+            "compression_ratio": 1.11, "no_speech_prob": 0.02,
+        },
+    ],
+}
+
+WAV = b"RIFF\x24\x00\x00\x00WAVEfmt "  # raw master bytes; content is opaque to the module
+
+
+# --- harness ----------------------------------------------------------------------------
+
+def make_stt(handler, model="whisper-large-v3-turbo"):
+    """The prod STT adapter over httpx.MockTransport (the house pattern for HTTP seams)."""
+    return HttpSttTranscriber(
+        base_url="http://stt.test",
+        token="test-stt-token",
+        model=model,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def seeded_store(**kw):
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(
+        user_id=7, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status="completed", **kw,
+    )
+    return store, mid
+
+
+async def resolve_master(meeting_id):
+    """The recordings-seam stub: a finalized master exists for the meeting."""
+    return WAV
+
+
+async def run(store, mid, stt, *, user_id=7, resolver=resolve_master, language=None):
+    return await transcribe_meeting(
+        store=store, stt=stt, resolve_master=resolver,
+        user_id=user_id, meeting_id=mid, language=language,
+    )
+
+
+# --- defect 1: provider rejection is a typed fault, carried loudly ----------------------
+
+async def test_groq_model_not_found_is_a_typed_fault_not_a_generic_502():
+    def handler(request):
+        return httpx.Response(404, json=GROQ_MODEL_NOT_FOUND)
+
+    store, mid = seeded_store()
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(handler, model="large-v3-turbo"))
+
+    fault = ei.value
+    assert fault.kind == "provider_rejected"
+    assert fault.status == 404
+    assert fault.provider_code == "model_not_found"
+    # The provider's own message travels with the fault: an operator must see WHY, not
+    # 0.10's "Transcription service error: 404".
+    assert "large-v3-turbo" in str(fault)
+
+    doc = await store.get_transcript_by_id(7, mid)
+    assert doc["segments"] == []  # nothing stored on a rejected run
+
+
+# --- defect 2: a segments-less body is loud, never a silent zero-row success ------------
+
+async def test_missing_segments_key_is_loud_not_a_silent_empty():
+    # NOTE: a genuine verbose_json ``"segments": []`` (silent audio) is NOT this fault;
+    # the defect is the ABSENT key, meaning response_format was not honored.
+    def handler(request):
+        return httpx.Response(200, json=DEFAULT_JSON_NO_SEGMENTS)
+
+    store, mid = seeded_store()
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(handler))
+
+    fault = ei.value
+    assert fault.kind == "no_segments"
+    assert "verbose_json" in str(fault)  # the fault names the response_format contract
+
+    doc = await store.get_transcript_by_id(7, mid)
+    assert doc["segments"] == []
+
+
+# --- defect 3: language normalized to ISO-639-1 at storage time (A3) --------------------
+
+async def test_language_english_is_normalized_to_iso_at_storage():
+    def handler(request):
+        return httpx.Response(200, json=VERBOSE_JSON_LANGUAGE_ENGLISH)
+
+    store, mid = seeded_store()
+    result = await run(store, mid, make_stt(handler))
+
+    assert result["meeting_id"] == mid
+    assert result["segments_stored"] == 2
+    assert result["language"] == "en"
+
+    doc = await store.get_transcript_by_id(7, mid)
+    segs = sorted(doc["segments"], key=lambda s: s["start"])
+    assert len(segs) == 2
+    assert [s["language"] for s in segs] == ["en", "en"]  # never "English" in a row
+    assert segs[0]["text"].strip() == "Hello everyone."
+    assert segs[1]["text"].strip() == "Let's get started."
+    assert (segs[0]["start"], segs[0]["end"]) == (0.0, 3.4)
+    assert (segs[1]["start"], segs[1]["end"]) == (3.4, 8.2)
+    # Distinct, truthy segment ids: the collector upsert drops id-less rows silently.
+    assert len({s["segment_id"] for s in segs}) == 2
+
+
+# --- the outbound request: the #355 root causes, pinned at the wire ---------------------
+
+async def test_request_carries_model_verbose_json_and_deferred_tier():
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, json=VERBOSE_JSON_LANGUAGE_ENGLISH)
+
+    store, mid = seeded_store()
+    await run(store, mid, make_stt(handler), language="en")
+
+    (req,) = seen
+    # Bare base URL gets the OpenAI-compatible path appended (append-only-when-missing,
+    # the one rule the TS client and config_preflight already share).
+    assert req.url.path == "/v1/audio/transcriptions"
+    assert req.headers.get("authorization") == "Bearer test-stt-token"
+
+    body = req.read()
+    assert b'name="file"' in body
+    assert b'name="model"\r\n\r\nwhisper-large-v3-turbo' in body      # defect-1 floor
+    assert b'name="response_format"\r\n\r\nverbose_json' in body      # defect-2 floor
+    assert b'name="transcription_tier"\r\n\r\ndeferred' in body       # the deferred tier
+    assert b'name="language"\r\n\r\nen' in body                       # caller hint forwarded
+
+
+# --- deferred tier backpressure: 503 + Retry-After is looped, not fatal -----------------
+
+async def test_busy_503_is_retried_per_retry_after():
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        if len(calls) == 1:
+            return httpx.Response(
+                503, headers={"Retry-After": "0"},
+                json={"detail": "Service busy handling maximum concurrent requests"},
+            )
+        return httpx.Response(200, json=VERBOSE_JSON_LANGUAGE_ENGLISH)
+
+    store, mid = seeded_store()
+    result = await run(store, mid, make_stt(handler))
+
+    assert len(calls) == 2
+    assert result["segments_stored"] == 2
+
+
+# --- prepared edges: absent master, ownership, and the Q2 conflict ruling ---------------
+
+async def test_absent_master_is_a_no_recording_fault_not_a_500():
+    async def no_master(meeting_id):
+        return None  # finalize_master's None: recording disabled or nothing to finalize
+
+    store, mid = seeded_store()
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(lambda r: httpx.Response(500)), resolver=no_master)
+    assert ei.value.kind == "no_recording"
+
+
+async def test_foreign_meeting_is_not_found():
+    store, mid = seeded_store()  # owned by user 7
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(lambda r: httpx.Response(500)), user_id=8)
+    assert ei.value.kind == "not_found"
+
+
+async def test_second_transcription_is_refused_as_conflict():
+    # Q2 ruling (2026-07-21): keep 0.10's refuse-second-run semantics, typed.
+    store, mid = seeded_store(segments=[
+        {"segment_id": "deferred:0:0.000", "start": 0.0, "end": 3.4,
+         "text": "Hello everyone.", "language": "en"},
+    ])
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(lambda r: httpx.Response(500)))
+    assert ei.value.kind == "already_transcribed"
+
+
+# --- #522 semantics: the model id comes from the deployment, default whisper-1 ----------
+
+async def test_from_env_model_resolution(monkeypatch):
+    monkeypatch.setenv("TRANSCRIPTION_MODEL", "whisper-large-v3-turbo")
+    stt = HttpSttTranscriber.from_env()
+    assert stt.model == "whisper-large-v3-turbo"
+    assert stt.base_url == "http://stt.test/transcribe"  # conftest's autouse STT env
+    assert stt.token == "test-stt-token"
+
+    monkeypatch.delenv("TRANSCRIPTION_MODEL")
+    assert HttpSttTranscriber.from_env().model == "whisper-1"

--- a/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
+++ b/core/meetings/services/meeting-api/tests/test_transcribe_deferred.py
@@ -235,6 +235,51 @@ async def test_foreign_meeting_is_not_found():
     assert ei.value.kind == "not_found"
 
 
+async def test_active_meeting_is_refused_not_partially_transcribed():
+    # finalize-on-read assembles a PARTIAL master mid-recording (#768); transcribing it would
+    # store a partial transcript that then 409-blocks the full run forever. Refuse, typed.
+    store, mid = seeded_store()
+    store._meetings[mid]["status"] = "active"
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(lambda r: httpx.Response(500)))
+    assert ei.value.kind == "not_completed"
+
+    doc = await store.get_transcript_by_id(7, mid)
+    assert doc["segments"] == []
+
+
+async def test_transcript_share_viewer_cannot_transcribe():
+    # Transcription is an OWNER-tier mutation (provider cost, rows written, the single Q2 run
+    # consumed); the read-tier ACL admits share viewers, the transcribe gate must not.
+    store, mid = seeded_store(data={"transcript_viewers": [9]})
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, make_stt(lambda r: httpx.Response(500)), user_id=9)
+    assert ei.value.kind == "not_found"
+
+
+async def test_concurrent_second_run_is_refused_while_first_transcribes():
+    import asyncio
+
+    release = asyncio.Event()
+
+    class SlowStt:
+        async def transcribe(self, audio, *, language=None):
+            await release.wait()
+            return VERBOSE_JSON_LANGUAGE_ENGLISH
+
+    store, mid = seeded_store()
+    first = asyncio.create_task(run(store, mid, SlowStt()))
+    await asyncio.sleep(0)  # let the first run enter the STT await
+
+    with pytest.raises(TranscribeFault) as ei:
+        await run(store, mid, SlowStt())
+    assert ei.value.kind == "already_running"
+
+    release.set()
+    result = await first
+    assert result["segments_stored"] == 2
+
+
 async def test_second_transcription_is_refused_as_conflict():
     # Q2 ruling (2026-07-21): keep 0.10's refuse-second-run semantics, typed.
     store, mid = seeded_store(segments=[

--- a/docs/changelog.d/525-deferred-transcribe.md
+++ b/docs/changelog.d/525-deferred-transcribe.md
@@ -1,0 +1,7 @@
+- **Transcribe a recording after the fact (#525).** `POST /meetings/{meeting_id}/transcribe` is
+  served again: a completed, recorded meeting gains a transcript on demand, on the STT service's
+  capacity-reserved deferred tier, with typed refusals (409 on a second run, provider errors
+  surfaced with the provider's own code and message, never a silent empty transcript) and the
+  detected language stored as ISO-639-1. The route was sealed in api.v1 but served by nothing on
+  0.12 deployments; the conformance gate now holds it to the contract. See
+  [Meetings API](/api/meetings#transcribe-a-recording).

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -118,7 +118,7 @@ native_meeting_id)` keying a 0.10 client uses is served by the 0.12 core:
 | `GET /recordings/{recording_id}/media/{media_file_id}/download` | **Aliased** to the `.../raw` master byte stream (Range-capable). |
 | `GET /bots/{platform}/{native_meeting_id}/chat` | **Restored, empty** — the owner boundary is real; the message list is always empty (0.12 does not persist in-meeting chat server-side; chat flows live over the WS `va:…:chat` channel). |
 | `POST /bots/{platform}/{native_meeting_id}/chat` | **Not implemented** — no bot-command (send) backend in the 0.12 core. |
-| `POST /meetings/{meeting_id}/transcribe` | **Served** — row-id keyed (no native-id form). See [Transcribe a recording](#transcribe-a-recording). |
+| `POST /meetings/{meeting_id}/transcribe` | **Served** (row-id keyed, no native-id form). See [Transcribe a recording](#transcribe-a-recording). |
 
 <Note>
 **What the seal enforces now.** Because the file hash pins the *document* and not the *running
@@ -150,12 +150,12 @@ curl -X POST "$API_BASE/meetings/42/transcribe" \
 The transcript is then readable at `GET /transcripts/by-id/{meeting_id}` as usual. Refusals are
 typed (`{"detail": {"reason": …, "message": …}}`):
 
-- `409 already_transcribed` — the meeting already has transcript rows; a second run is refused.
-- `404 no_recording` — no finalized master recording (recording disabled, or nothing captured).
-- `502 provider_rejected` / `no_segments` — the STT backend rejected the request or did not honor
+- `409 already_transcribed`: the meeting already has transcript rows; a second run is refused.
+- `404 no_recording`: no finalized master recording (recording disabled, or nothing captured).
+- `502 provider_rejected` / `no_segments`: the STT backend rejected the request or did not honor
   `verbose_json`; the body carries the provider's own code and message (e.g. Groq
   `model_not_found`), never a silent empty transcript.
-- `503 unavailable` / `stt_unconfigured` — backend busy past retries, or
+- `503 unavailable` / `stt_unconfigured`: backend busy past retries, or
   `TRANSCRIPTION_SERVICE_URL` unset on the deployment.
 
 The request runs on the STT service's **deferred tier** (capacity-reserved so live meetings keep

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -118,7 +118,7 @@ native_meeting_id)` keying a 0.10 client uses is served by the 0.12 core:
 | `GET /recordings/{recording_id}/media/{media_file_id}/download` | **Aliased** to the `.../raw` master byte stream (Range-capable). |
 | `GET /bots/{platform}/{native_meeting_id}/chat` | **Restored, empty** — the owner boundary is real; the message list is always empty (0.12 does not persist in-meeting chat server-side; chat flows live over the WS `va:…:chat` channel). |
 | `POST /bots/{platform}/{native_meeting_id}/chat` | **Not implemented** — no bot-command (send) backend in the 0.12 core. |
-| `POST /meetings/{meeting_id}/transcribe` | **Not implemented** — no on-demand re-transcribe backend in the 0.12 core. |
+| `POST /meetings/{meeting_id}/transcribe` | **Served** — row-id keyed (no native-id form). See [Transcribe a recording](#transcribe-a-recording). |
 
 <Note>
 **What the seal enforces now.** Because the file hash pins the *document* and not the *running
@@ -127,10 +127,39 @@ every `(path, method)` `api.v1` declares, the shipped gateway + meeting-api must
 the route must be recorded in the audited `core/gateway/contracts/api.v1/KNOWN_GAPS.json` ledger (with
 a reason + issue link), which the gate prints loudly on every run. A sealed endpoint renamed or dropped
 without a ledger entry fails CI. The frozen golden examples are also driven against the real responses,
-so a renamed response field (e.g. `running_bots` → `running`) fails too. The two **Not implemented**
-rows above and the share **response-shape** divergence are the current recorded gaps — a client can rely
+so a renamed response field (e.g. `running_bots` → `running`) fails too. The **Not implemented**
+row above and the share **response-shape** divergence are the current recorded gaps — a client can rely
 on the seal meaning "served, or explicitly listed as a gap", not merely "the schema file didn't change".
 </Note>
+
+## Transcribe a recording
+
+A completed meeting that was **recorded** but not transcribed (transcription off, or STT down
+mid-meeting) can be transcribed after the fact from its master recording:
+
+```bash POST /meetings/{meeting_id}/transcribe
+curl -X POST "$API_BASE/meetings/42/transcribe" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"language": "en"}'   # body optional; language is a hint to the STT backend
+```
+
+```json Response
+{ "meeting_id": 42, "segments_stored": 27, "language": "en" }
+```
+
+The transcript is then readable at `GET /transcripts/by-id/{meeting_id}` as usual. Refusals are
+typed (`{"detail": {"reason": …, "message": …}}`):
+
+- `409 already_transcribed` — the meeting already has transcript rows; a second run is refused.
+- `404 no_recording` — no finalized master recording (recording disabled, or nothing captured).
+- `502 provider_rejected` / `no_segments` — the STT backend rejected the request or did not honor
+  `verbose_json`; the body carries the provider's own code and message (e.g. Groq
+  `model_not_found`), never a silent empty transcript.
+- `503 unavailable` / `stt_unconfigured` — backend busy past retries, or
+  `TRANSCRIPTION_SERVICE_URL` unset on the deployment.
+
+The request runs on the STT service's **deferred tier** (capacity-reserved so live meetings keep
+priority) and the detected language is stored as an ISO-639-1 code on every segment.
 
 ## Auto-join
 

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -75,7 +75,7 @@ is the brick — faster-whisper / CTranslate2 behind an OpenAI-compatible `/v1/a
 Language is detected per transcription window and stamped on each segment; force a single language
 via the bot request's `language` (see [Send a bot](/how-to/send-a-bot)). After-the-fact
 transcription of a recording (`POST /meetings/{id}/transcribe`) runs on the service's **deferred
-tier**, which is capacity-reserved behind live meetings — on a busy deployment those requests are
+tier**, which is capacity-reserved behind live meetings: on a busy deployment those requests are
 answered `503` + `Retry-After` and the caller retries, so live transcription never starves.
 
 Stand it up wherever a GPU lives (the same host or a dedicated GPU box):

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -73,7 +73,10 @@ runs GPU-free and anywhere, and the STT service is its own deploy unit at
 ([`core/meetings/services/transcription`](https://github.com/Vexa-ai/vexa/tree/main/core/meetings/services/transcription)
 is the brick — faster-whisper / CTranslate2 behind an OpenAI-compatible `/v1/audio/transcriptions`).
 Language is detected per transcription window and stamped on each segment; force a single language
-via the bot request's `language` (see [Send a bot](/how-to/send-a-bot)).
+via the bot request's `language` (see [Send a bot](/how-to/send-a-bot)). After-the-fact
+transcription of a recording (`POST /meetings/{id}/transcribe`) runs on the service's **deferred
+tier**, which is capacity-reserved behind live meetings — on a busy deployment those requests are
+answered `503` + `Retry-After` and the caller retries, so live transcription never starves.
 
 Stand it up wherever a GPU lives (the same host or a dedicated GPU box):
 

--- a/docs/docs/how-to/recordings.mdx
+++ b/docs/docs/how-to/recordings.mdx
@@ -69,7 +69,7 @@ curl -X POST "$API_BASE/meetings/<meeting_id>/transcribe" -H "X-API-Key: $API_KE
 
 Then read it back as usual (`GET /transcripts/by-id/<meeting_id>`). A meeting that already has
 transcript rows is refused with a `409`; full request/response detail in
-[Meetings API — Transcribe a recording](/api/meetings#transcribe-a-recording).
+[Meetings API: Transcribe a recording](/api/meetings#transcribe-a-recording).
 
 ## Where it's stored
 

--- a/docs/docs/how-to/recordings.mdx
+++ b/docs/docs/how-to/recordings.mdx
@@ -57,6 +57,20 @@ curl -I -H "X-API-Key: $API_KEY" -H "Range: bytes=0-1023" \
 # Content-Range: bytes 0-1023/<total>
 ```
 
+## Get a transcript from a recording
+
+Recorded a meeting with transcription off (or STT was down mid-meeting)? Turn the recording into
+a transcript after the fact:
+
+```bash
+curl -X POST "$API_BASE/meetings/<meeting_id>/transcribe" -H "X-API-Key: $API_KEY"
+# → { "meeting_id": 42, "segments_stored": 27, "language": "en" }
+```
+
+Then read it back as usual (`GET /transcripts/by-id/<meeting_id>`). A meeting that already has
+transcript rows is refused with a `409`; full request/response detail in
+[Meetings API — Transcribe a recording](/api/meetings#transcribe-a-recording).
+
 ## Where it's stored
 
 Recordings live in the bucket configured by `MINIO_*` ([Configuration](/configuration#database-storage)).

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -106,6 +106,14 @@ The bot is capturing audio, but transcription isn't configured — or the bot wa
   normal, not a failure.
 - A stale bot key shows up as `native_resolve:{ok:false,kind:"unauthorized"}` on
   `GET /api/meeting/relay-health` rather than as silent dead air.
+- **If the meeting was recorded**, the transcript is recoverable:
+  `POST /meetings/{id}/transcribe` transcribes the master recording after the fact (see
+  [Meetings API](/api/meetings#transcribe-a-recording)).
+- **"0 segments" from a remote STT provider** (Groq and friends): on 0.10, a wrong model id or a
+  backend ignoring `response_format=verbose_json` made deferred transcription report success and
+  store an empty transcript. Since the deferred path returned in 0.12, both conditions are a loud
+  `502` carrying the provider's own error — an empty transcript can no longer mean that; it means
+  the audio was silent or the meeting produced no confirmed segments.
 
 ## What terminal errors look like — and where the technical details live
 

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -112,7 +112,7 @@ The bot is capturing audio, but transcription isn't configured — or the bot wa
 - **"0 segments" from a remote STT provider** (Groq and friends): on 0.10, a wrong model id or a
   backend ignoring `response_format=verbose_json` made deferred transcription report success and
   store an empty transcript. Since the deferred path returned in 0.12, both conditions are a loud
-  `502` carrying the provider's own error — an empty transcript can no longer mean that; it means
+  `502` carrying the provider's own error: an empty transcript can no longer mean that; it means
   the audio was silent or the meeting produced no confirmed segments.
 
 ## What terminal errors look like — and where the technical details live

--- a/docs/views/architecture.dsl
+++ b/docs/views/architecture.dsl
@@ -97,6 +97,7 @@ edges:
   remote-browser -write-> userdata-blob  # provisioning login uploads the confirmed signed-in session
   gateway -read-> recording-blob
   bot -call-> transcription  # audio -> first-party STT via TRANSCRIPTION_SERVICE_URL
+  meeting-api -call-> transcription  # deferred transcription of a master recording (POST /meetings/{id}/transcribe, #525) via TRANSCRIPTION_SERVICE_URL
   bot -read-> bot-commands  # SUBSCRIBE acts.v1 commands
   meeting-api -write-> bm-status  # PUBLISH status
   meeting-api -write-> u-meetings  # PUBLISH per-user status

--- a/docs/views/containers.mmd
+++ b/docs/views/containers.mmd
@@ -33,6 +33,7 @@ flowchart LR
   dashboard["dashboard (deprecated)"]
   meeting_api -->|"write"| segments_table
   bot -->|"HTTPS"| transcription
+  meeting_api -->|"HTTPS"| transcription
   meeting_api -->|"JDBC"| postgres
   meeting_api -->|"HTTPS"| minio
   meeting_api -->|"HTTPS"| runtime

--- a/docs/views/egress.mmd
+++ b/docs/views/egress.mmd
@@ -22,3 +22,5 @@ flowchart LR
   end
   transcription["transcription"]
   bot ==>|"audio -> tenant-hosted"| transcription
+  transcription["transcription"]
+  meeting_api ==>|"audio -> tenant-hosted"| transcription


### PR DESCRIPTION
# #525 observation bundle: deferred transcribe (serve fork)

**Branch:** `fix/525-deferred-transcribe` @ `1efcfe40` (waqaskhan137/vexa) · **Base:** `upstream/main` @ `bf13dc54` (v0.12.15)
**Author + first witness:** @waqaskhan137 (the live meetings below are my own run, per D8)
**Setup:** fresh clone, macOS arm64, Docker Desktop 29.6.1. Full compose via `make dev` (`IMAGE_TAG=dev`, all images built from the checkout; bot `vexa/vexa-bot:dev` via `make bot`). Env deltas from stock `.env`: `RECORDING_ENABLED=true`, `BROWSER_IMAGE=vexa/vexa-bot:dev`, and `TRANSCRIPTION_SERVICE_URL/TOKEN/MODEL` per leg (named per row).
**Groq provenance (batch rule):** my own Groq account (the key my production deployment uses), endpoint `https://api.groq.com/openai/v1/audio/transcriptions`, model `whisper-large-v3-turbo`.
**Live meetings (operator: me):** Google Meet `ktj-wibg-zrv` → meeting id 1 (2026-07-21 ~17:23Z, ~80s, recording on, `transcribe_enabled:false`) and `dqq-xnxt-hko` → meeting id 2 (~17:29Z, same shape). Bot stopped via `DELETE /bots/...`; both meetings reached `completed` with a chunked webm recording.

## Table findings (report-first, per AGENTS.md)

1. **A1's negative control expects the wrong status.** At base the sealed call answers **405 Method Not Allowed**, not 404, at BOTH the gateway and meeting-api: `POST /meetings/1/transcribe` matches the 2-segment native-keyed `PATCH/DELETE /meetings/{platform}/{native}` path shape that #579 added after this issue was prepared (platform=`1`, native=`transcribe`), so FastAPI answers 405/`allow: PATCH` instead of no-route 404. The row's substance (sealed route unserved at base) holds; the expected observable is 405. Evidence: `A1-neg-base-404.log` (meeting-api in-process), `A1-neg-base-gateway-404.log` (shipped gateway app in-process, valid key).
2. **The issue's collector anchor drifted:** `adapters.py:565-570` → `:681-724` on current main (already noted on the issue).
3. **Pre-existing, not fixed here: `config_preflight`'s STT probe false-negatives on Groq.** With a key that `GET /v1/models` accepts (200) and that live transcription uses successfully, the capability probe reports `misconfigured / unauthorized (403)`. Observed on Lite at head with the working A5 key; the probe's request shape (not this PR's adapter) is the suspect. Worth its own issue.
4. **Scope classification observation (correct behavior, recorded for operators):** the route inherits `/meetings` → scope `tx`, so a token minted without `tx` gets the gateway's 403 `Insufficient scope`; witnessed on Lite with a default-scope mint, green after re-minting `?scopes=tx,bot`.

## The rows

| Row | Verdict | Evidence file | What was observed |
|---|---|---|---|
| A1 | **GREEN** | `A1-bundled-run.log` | Head full compose, STT = bundled unit (`deploy/transcription` `docker-compose.cpu.yml`, `MODEL_SIZE=tiny`, CPU): `POST /meetings/2/transcribe` → `{"meeting_id":2,"segments_stored":23,"language":"en"}`; `GET /transcripts/by-id/2` returns the 23 rows. Negative control: base-sha call answers 405 (finding 1), route unserved; head serves it (`A1-head-route-serves.log`: typed `not_found` for an unknown meeting id, proving the route exists and refuses typed). |
| A2 | **GREEN** | `A2-A3-real-run.log` | Head clean image, STT = real Groq, model `whisper-large-v3-turbo`: `POST /meetings/1/transcribe` → 200 `{"segments_stored":6,"language":"en"}`. Negative controls, both shown RED first, same meeting (they refuse before storing): (1) `A2-neg1-wrong-model.log`: scratch env `TRANSCRIPTION_MODEL=large-v3-turbo` (the #355 defect id) → **502** `{"reason":"provider_rejected","provider_code":"model_not_found","message":"The model `large-v3-turbo` does not exist…"}`: Groq's verbatim body carried, loudly, not 0.10's generic 502; (2) `A2-neg2-no-verbose.log`: scratch in-container removal of the `response_format` field → **502** `{"reason":"no_segments",...}`: the silent-`[]` class is now loud. |
| A3 | **GREEN** | `A2-A3-real-run.log`, `A3-neg-bypass.log` | Real run: psql `select language, count(*) from transcriptions where meeting_id=1` → `en | 6`; `GET /transcripts/by-id/1` returns the rows (my own words from the call). Negative control shown RED first: scratch in-container bypass of `normalize_language` → 200 with `"language":"English"` and psql showing `English | 6` verbatim in the row (the 0.10 read-crash class, observed in a real DB row); scratch rows then deleted via psql and the clean image force-recreated before the real run. |
| A4 | **GREEN** | `A4-red-base.log`, `A4-green-head.log` | Post-#670 mechanism as re-ruled on the issue: at base with the route's `KNOWN_GAPS.json` row removed and no implementation, `test_every_sealed_api_v1_route_is_implemented_or_audited` goes RED naming exactly `[('POST', '/meetings/{meeting_id}/transcribe')]`; at head (row removed, route served by gateway + meeting-api) the same gate is GREEN. |
| A5 | **GREEN** | `A5-lite-run.log` | `vexa-lite:dev` built from head (`deploy/lite make build`), stock single-container run (`make up`), STT = real Groq: live Meet `aft-pzjg-xys` recorded (`transcribe_enabled:false`) → master finalized on read (`master.webm`) → `POST /meetings/1/transcribe` → 200 `{"segments_stored":4,"language":"en"}` → `GET /transcripts/by-id/1` returns the rows. This also answers the issue's stated unknown: stock Lite DOES produce a retrievable master. Bonus control: the published `vexaai/vexa-lite:v012` (released line) answers 405 on the route (`A5-neg-published-lite-405.log`). |
| A- | **GREEN** | `gates3.log` (scratchpad) | `node scripts/gates.mjs all` → "gates green" at head: meeting-api lane 814 passed/5 skipped (14 transcribe tests), gateway 91+1 xfail, conformance 84, plus the full repo gate suite. |
| Q2 (live) | **GREEN** | `Q2-conflict-live.log` | Second `POST /meetings/1/transcribe` after the real run → **409** `{"reason":"already_transcribed","message":"meeting 1 already has 6 transcript segments"}`. |

## Not checked (stated per P21)

- k8s/helm and hosted 0.10 (out of scope per the issue; Q3 is the ops lane).
- meeting-api at >1 replica (the in-flight guard is per-process; ponytail-marked, redis lock is the named upgrade path: the deployment docs already caveat multi-replica).
- Masters exceeding remote-provider per-file caps (#524's chunking question): both test meetings were ~1-2 min; the loud-typed-fault path for provider rejections is unit-tested but a real >cap master was not exercised.
- Platforms other than Google Meet for the recording flow (the recording path is platform-shared; only gmeet witnessed live).
- The bot's `left_alone` auto-stop (bot was stopped via the explicit user-stop `DELETE`; #866 tracks left_alone separately).

## The diff (8 commits, red-first)

- `2df8617f` **test(meeting-api)**: the RED fixtures, D-A2 payloads verbatim from #355 plus the ruled edges; the file predates the module and is its contract.
- `a70fc13d` **feat(meeting-api) C1**: `meeting_api.transcribe` (ports/service/router/adapters/fakes/README) composing the recordings finalize-on-read seam and the collector upsert seam; #522 model resolution; language to ISO-639-1 at storage; typed `TranscribeFault` for every refusal.
- `0483e2a8` **feat(gateway) C2+C3**: the sealed route forwarded beside the other row-id meeting routes; conformance fake registers it; the `KNOWN_GAPS.json` row retired so the reverse-conformance gate holds the route to the contract (post-#670 mechanism, as re-ruled on the issue).
- `7f7e670e` **docs D6c**: api/meetings.mdx reference entry (+ the native-id table row flips to Served), how-to/recordings "recording → transcript" step, deployment.mdx deferred-tier sentence, troubleshooting "0 segments" symptom row. Changelog fragment rides the later polish commit.
- `eca1dc00` / `7d7273d0` / `3065ce99` / `1efcfe40` **self-review round** (13-agent adversarial pass before any human review): terminal-status gate (an active meeting would have transcribed a PARTIAL master, #768 semantics, then 409-blocked the full run forever), owner-only authorization (the read-tier ACL admitted transcript-share viewers to an owner-tier mutation), per-process in-flight guard (concurrent duplicate would double-spend STT; redis lock is the named multi-replica upgrade), per-route 660s gateway forward timeout (the 30s default 504'd the sealed route exactly when its deferred backpressure engaged, with rows still landing and retries then 409ing), tier via `X-Transcription-Tier` header (strict remote providers 400 unknown multipart fields), `probe_url` reuse, typed storage faults, house conformance (obs events, README, fakes-backed `create_app` default with explicit production composition), P23 CALM edge (meeting-api → transcription) + reseal, changelog fragment.

Gates: `node scripts/gates.mjs all` green at head.

## Validation request (D9)

Per the issue: preferred signer **@Allevat-ORX** (the #355 reporter; the A2/A3 rows are exactly their Groq rig). Any competent non-author qualifies; needs one Groq key and curl. Raw evidence logs for every row are on my machine and attached on request; every command and verbatim response is quoted in the table above.

Closes #525.
