### PR TITLE
fix(meeting-api): bound the in-process webhook-envelope capture — the RSS climb's actual source (#803)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from typing import Optional
 
 from fastapi import FastAPI, Request
@@ -39,6 +40,15 @@ from .collector.app import build_router as _build_collector_router
 from .collector.ports import RedisBus, TranscriptStore
 from .lifecycle.machine import LifecycleSink, MeetingStore
 from .obs import TraceMiddleware
+
+#: In-process capture of the last N emitted webhook envelopes — an eval/introspection seam, never a
+#: durable store (the DB meeting row is the durable record; the WebhookSink is the delivery path).
+#: BOUNDED because it lives on the production app and every bot lifecycle callback appends one
+#: envelope that embeds the meeting's ``data`` projection; an unbounded list grew RSS monotonically
+#: under production callback traffic while idle staging (no callbacks) stayed flat (#803). A ring
+#: buffer keeps the recent-envelope semantics every reader relies on (``[-1]``, ``len``, iteration)
+#: while capping retention.
+_ENVELOPE_LOG_CAP = 256
 
 
 def _xpending_total(summary) -> "Optional[int]":
@@ -280,8 +290,8 @@ def _mount_lifecycle(
             "updated_at": _iso(row.get("updated_at")),
         }
 
-    app.state.status_change_webhooks = []
-    app.state.typed_webhooks = []
+    app.state.status_change_webhooks = deque(maxlen=_ENVELOPE_LOG_CAP)
+    app.state.typed_webhooks = deque(maxlen=_ENVELOPE_LOG_CAP)
 
     async def _apply_lifecycle_event(
         body: dict,

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/receiver.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/receiver.py
@@ -12,6 +12,7 @@ the record store is in-memory (`MeetingStore`).
 from __future__ import annotations
 
 import json
+from collections import deque
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -23,6 +24,11 @@ from referencing import Registry, Resource
 from .machine import IllegalTransition, LifecycleSink, MeetingStore, TransitionSource
 from .webhook import build_status_change_envelope, build_typed_envelope
 from ..obs import TraceMiddleware, log_event
+
+#: See ``meeting_api.app._ENVELOPE_LOG_CAP`` — the same bounded eval/introspection seam applies to
+#: the standalone lifecycle receiver: an append-only list grew RSS under production callback traffic
+#: (#803). Bounded ring buffer, recent-envelope semantics preserved.
+_ENVELOPE_LOG_CAP = 256
 
 
 def _load_lifecycle_schema() -> dict:
@@ -68,8 +74,8 @@ def create_app(
     sink = LifecycleSink(store=store if store is not None else MeetingStore())
     app.state.sink = sink
     app.state.store = sink.store
-    app.state.status_change_webhooks = []  # every emitted status_change envelope, for the eval
-    app.state.typed_webhooks = []  # every emitted TYPED envelope (started/completed/failed)
+    app.state.status_change_webhooks = deque(maxlen=_ENVELOPE_LOG_CAP)  # recent status_change envelopes, for the eval
+    app.state.typed_webhooks = deque(maxlen=_ENVELOPE_LOG_CAP)  # recent TYPED envelopes (started/completed/failed)
     # Bind the upstream gateway's X-Trace-Id for each request so this hop's structured logs
     # (logevent.v1) correlate with the gateway's on the same trace_id.
     app.add_middleware(TraceMiddleware)

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -1292,3 +1292,37 @@ def test_user_stop_of_a_live_bot_still_completes():
     row = _stop_then_destroy("active")
     assert row["status"] == "completed"
     assert row["data"].get("completion_reason") == "stopped"
+
+
+# ── #803: the in-process envelope capture is BOUNDED (RSS-leak regression guard) ─────────────────
+def test_status_change_envelope_log_is_bounded_under_sustained_callbacks():
+    """The in-process ``app.state.status_change_webhooks`` capture is an eval/introspection seam that
+    lives on the PRODUCTION app; every bot lifecycle callback appends one envelope embedding the
+    meeting projection. Left unbounded it grew RSS monotonically under production callback traffic
+    (#803) — invisible to idle staging (no callbacks) and to single-endpoint hammering (never hits
+    this path). It must be a bounded ring buffer.
+
+    BUG (pre-fix): the capture was ``[]`` — its length equalled the number of advances forever.
+    Expected: after cap+N genuine advances the capture holds at most the cap, and it holds the most
+    RECENT envelopes (ring semantics every reader relies on)."""
+    from meeting_api.app import _ENVELOPE_LOG_CAP
+
+    repo = InMemoryMeetingRepo()
+    app = create_app(meeting_repo=repo)
+    client = TestClient(app)
+
+    overshoot = _ENVELOPE_LOG_CAP + 50
+    for i in range(overshoot):
+        uid = f"leak-sess-{i}"
+        _seed(repo, status="requested", session_uid=uid)
+        r = client.post(ENDPOINT, json={"connection_id": uid, "status": "joining"})
+        assert r.status_code == 200, r.text
+
+    cap = _ENVELOPE_LOG_CAP
+    assert len(app.state.status_change_webhooks) == cap, (
+        f"envelope capture unbounded: {overshoot} advances retained "
+        f"{len(app.state.status_change_webhooks)} envelopes (expected cap {cap})"
+    )
+    # ring semantics: the LAST advance is still the most recent captured envelope
+    last = app.state.status_change_webhooks[-1]["data"]["meeting"]["connection_id"]
+    assert last == f"leak-sess-{overshoot - 1}"

--- a/docs/changelog.d/803-meeting-api-envelope-log-bound.md
+++ b/docs/changelog.d/803-meeting-api-envelope-log-bound.md
@@ -1,0 +1,7 @@
+- **meeting-api RSS no longer climbs under production callback traffic (#803).** The in-process
+  webhook-envelope capture (`app.state.status_change_webhooks` / `typed_webhooks`) — an eval seam
+  that lived on the production app — was an unbounded list: every bot lifecycle callback appended an
+  envelope embedding the meeting projection, so RSS grew monotonically under real callback traffic
+  while idle staging (no callbacks) stayed flat. It is now a bounded ring buffer, capping retention
+  while preserving the recent-envelope semantics the eval relies on. Operators on the inherited 1Gi
+  limit no longer see the slow OOM cycle from this source.


### PR DESCRIPTION
Part of #803 — a **second, distinct** point of introduction from #825, and the one that matches the reported profile (a monotonic ~10–20 Mi/min slope, flat on idle staging, invisible to single-endpoint hammering).

## The finding

`app.state.status_change_webhooks` and `app.state.typed_webhooks` are an eval/introspection capture seam that lives on the **production** app — created in `create_app` (`meeting_api/app.py`) and in the standalone lifecycle receiver (`meeting_api/lifecycle/receiver.py`). They were plain lists, read **only** by tests (`test_lifecycle_*.py`); the source comment literally says "for the eval."

Every bot lifecycle callback (`POST /bots/internal/callback/lifecycle`) that drives a real FSM advance appends one `webhook.v1` envelope — and each envelope **embeds the meeting projection** (`data` / `clean_meeting_data(data)`, the same fat JSONB #825 flagged). A meeting emits ~5+ advances (requested → joining → awaiting_admission → active → completed). Nothing ever drains or trims the lists.

**Why it matched the profile exactly:**
- **Grows under the production mix** — real bots transitioning generate a steady stream of lifecycle callbacks; each append retains an envelope forever.
- **Flat on idle staging** — no bots, no callbacks, no appends.
- **Not reproduced by endpoint hammering** — `/meetings`, `/transcripts/{platform}/{code}`, `/bots/status`, `/recordings` never hit the lifecycle callback path, so no amount of read-polling grows these lists. This is why the earlier targeted hammering (single-endpoint, and even the read mix) came up empty.

This is complementary to #825 (which bounded the `/bots/status` **peak**); this bounds the **slope**.

## The fix — at the point of introduction

The capture becomes a bounded `deque(maxlen=256)` ring buffer in both factories. It preserves the recent-envelope semantics every existing reader relies on (`[-1]`, `len(...)`, iteration) — so all eval assertions are unchanged — while capping retention. Worst-case steady state is now ~256 envelopes per buffer instead of unbounded.

## The observation bundle

| # | Observation | Result |
|---|---|---|
| 1 | **Point of introduction identified.** Append-only `app.state.status_change_webhooks` / `typed_webhooks` on the production app; read only by tests; one envelope embedding the meeting projection per lifecycle advance, never trimmed. `app.py:283-284/360/414`, `receiver.py:71-72/124-127` (pre-fix). | ✅ code-grounded |
| 2 | **Red→green.** New guard `test_status_change_envelope_log_is_bounded_under_sustained_callbacks`: cap+50 genuine advances. **RED** on the plain list — retained all 306 (`FAILED … retained 306 (expected cap 256)`). **GREEN** with the deque — exactly 256, and `[-1]` is still the most recent advance. | ✅ demonstrated both states |
| 3 | **No regression to the eval seam.** Full meeting-api suite. | ✅ **814 passed, 5 skipped** |
| 4 | **Repo gates.** | ✅ `node scripts/gates.mjs all` → **gates green** |

**Not claimed:** a live multi-hour post-deploy RSS series (acceptance leg 1) — I have no prod/live access. The remaining closing observation for #803 stays a post-deploy soak confirming the slope is gone before the 2560Mi mitigation is lowered toward 1Gi. What this PR delivers is the reproduced-offline mechanism and its bound.

Closes #803