### PR TITLE
fix(bot): Teams removal monitor no longer evicts on a benign alert (#600)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/msteams/removal.test.ts
+++ b/core/meetings/modules/join/src/msteams/removal.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression guard for the Teams removal-monitor false-positive
+ * (Vexa-ai/vexa#600).
+ *
+ * A legitimately-joined-and-admitted Teams bot was evicted ~1.5s after
+ * admission because checkForTeamsRemoval() returned true on the FIRST visible
+ * `teamsRemovalIndicators` selector, and that list contained generic
+ * role/class patterns — `[role="alert"]`, `[role="alertdialog"]`,
+ * `.error-message`, `.connection-error`, `.meeting-error`. `[role="alert"]`
+ * matches ANY Teams alert region (mute toasts, captions, network blips, the
+ * post-join AV-confirmation modal), none of which mean the bot was removed.
+ * A benign transient alert therefore tripped a false removal → self-leave →
+ * `completed(evicted)`, no transcript.
+ *
+ * Fix (at the point of introduction, selectors.ts): the removal indicators are
+ * now the removal/"meeting ended" TEXT signals only — no generic role/class
+ * catch-alls.
+ *
+ * Fabricated-DOM test in the same style as msteams/modals.test.ts — no
+ * browser, no live meeting.
+ *
+ * Run: npx tsx src/msteams/removal.test.ts
+ */
+
+import { checkForTeamsRemoval } from './removal';
+import { teamsRemovalIndicators } from './selectors';
+
+/**
+ * Minimal Playwright-Page stand-in. `visible` = the selectors that resolve
+ * isVisible()===true. checkForTeamsRemoval iterates teamsRemovalIndicators and
+ * calls page.locator(sel).first().isVisible() on each.
+ */
+function mockPage(visible: string[]): any {
+  return {
+    locator: (sel: string) => ({
+      first: () => ({
+        isVisible: async () => visible.includes(sel),
+      }),
+    }),
+  };
+}
+
+let passed = 0, failed = 0;
+function check(name: string, actual: boolean, expected: boolean) {
+  if (actual === expected) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name} (expected ${expected}, got ${actual})`); failed++; }
+}
+
+// Generic patterns that must NOT be treated as removal signals.
+const GENERIC_ALERTS = [
+  '[role="alert"]',
+  '[role="alertdialog"]',
+  '.error-message',
+  '.connection-error',
+  '.meeting-error',
+];
+
+(async () => {
+  console.log('\n=== Teams removal-monitor false-positive (#600) ===');
+
+  // 1. Benign transient alert region on screen (the reported failure: a
+  //    `[role="alert"]` toast / AV-confirm modal ~1.5s after admission) must
+  //    NOT be classified as a removal.
+  check(
+    'benign [role="alert"] visible → checkForTeamsRemoval = false',
+    await checkForTeamsRemoval(mockPage(['[role="alert"]'])),
+    false,
+  );
+
+  // 2. None of the generic role/class catch-alls may live in the indicator
+  //    list at all — this is the point-of-introduction guard.
+  for (const g of GENERIC_ALERTS) {
+    check(
+      `generic selector NOT in teamsRemovalIndicators: ${g}`,
+      teamsRemovalIndicators.includes(g),
+      false,
+    );
+  }
+
+  // 3. A real removal message still trips detection (no over-correction).
+  check(
+    'real "removed from this meeting" text → checkForTeamsRemoval = true',
+    await checkForTeamsRemoval(mockPage(['text=You\'ve been removed from this meeting'])),
+    true,
+  );
+  check(
+    'real "Meeting ended" text → checkForTeamsRemoval = true',
+    await checkForTeamsRemoval(mockPage(['text=Meeting ended'])),
+    true,
+  );
+
+  // 4. Nothing visible → not removed.
+  check(
+    'nothing visible → checkForTeamsRemoval = false',
+    await checkForTeamsRemoval(mockPage([])),
+    false,
+  );
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+})();

--- a/core/meetings/modules/join/src/msteams/selectors.ts
+++ b/core/meetings/modules/join/src/msteams/selectors.ts
@@ -111,14 +111,16 @@ export const teamsRemovalIndicators: string[] = [
   'text="Connection lost"',
   'text=Connection lost',
   'text="Unable to connect"',
-  'text=Unable to connect',
+  'text=Unable to connect'
 
-  // Generic error patterns
-  '[role="alert"]',
-  '[role="alertdialog"]',
-  '.error-message',
-  '.connection-error',
-  '.meeting-error'
+  // NOTE (#600): no generic role/class catch-alls here. `[role="alert"]`,
+  // `[role="alertdialog"]`, `.error-message`, `.connection-error` and
+  // `.meeting-error` match ANY Teams alert region — mute toasts, captions,
+  // network blips, the post-join AV-confirmation modal — none of which mean the
+  // bot was removed. A benign transient alert ~1.5s after admission tripped a
+  // false removal → self-leave → `completed(evicted)`, no transcript. The
+  // removal signal is the removal/"meeting ended" TEXT above, which is
+  // trustworthy; keep this list text-only.
 ];
 
 // Teams UI interaction selectors

--- a/docs/changelog.d/600-teams-removal-alert-false-positive.md
+++ b/docs/changelog.d/600-teams-removal-alert-false-positive.md
@@ -1,0 +1,5 @@
+- **Teams: a benign alert no longer evicts a just-joined bot (#600).** The Teams removal monitor
+  matched a generic `[role="alert"]` (plus `[role="alertdialog"]`, `.error-message`,
+  `.connection-error`, `.meeting-error`), so a transient toast or the post-join AV-confirmation modal
+  could trip a false removal ~1.5s after admission and self-leave with `completed(evicted)` and no
+  transcript. The removal signal is now the removal/"meeting ended" text only.


### PR DESCRIPTION
Closes #600.

## What & why (point of introduction)

A legitimately joined-and-admitted Teams bot was evicted ~1.5s after admission — `completed(evicted)`, no transcript. `checkForTeamsRemoval()` (`core/meetings/modules/join/src/msteams/removal.ts`) returns `true` on the **first** visible `teamsRemovalIndicators` selector, and that list carried generic role/class catch-alls in `msteams/selectors.ts`:

```
[role="alert"]  [role="alertdialog"]  .error-message  .connection-error  .meeting-error
```

`[role="alert"]` matches **any** Teams alert region — mute toasts, captions, network blips, the post-join AV-confirmation modal — none of which mean the bot was removed. A benign transient alert therefore tripped a false removal → `signalEnd('evicted')` → `leaveMicrosoftTeams`.

**Fix at the point of introduction (`selectors.ts`):** `teamsRemovalIndicators` is now the removal/"meeting ended" **text** signals only; the five generic patterns are gone. `removal.ts` is unchanged — the producer of the bad signal was the indicator list, not the checker.

## The diff
- `msteams/selectors.ts` — drop the 5 generic role/class entries from `teamsRemovalIndicators`; add a `#600` note pinning the list text-only.
- `msteams/removal.test.ts` — new fabricated-DOM regression test (no browser, no live meeting), same style as `msteams/modals.test.ts`.
- `package.json` — wire `removal.test.ts` into the join module `test` script.
- `docs/changelog.d/600-teams-removal-alert-false-positive.md` — changelog fragment (docs-current touch).

## Observation bundle

**Acceptance (issue's own asks):** a visible `[role="alert"]` that is NOT a removal message must NOT trip `checkForTeamsRemoval`; real removal text still must.

RED (before the selector edit) — `npx tsx src/msteams/removal.test.ts`:
```
🚨 Teams removal detected: Found removal indicator "[role="alert"]"
FAIL  benign [role="alert"] visible → checkForTeamsRemoval = false (expected false, got true)
FAIL  generic selector NOT in teamsRemovalIndicators: [role="alert"] ... (×5 generic entries)
PASS  real "removed from this meeting" text → true
PASS  real "Meeting ended" text → true
PASS  nothing visible → false
3 passed, 6 failed
```

GREEN (after the edit):
```
PASS  benign [role="alert"] visible → checkForTeamsRemoval = false
PASS  generic selector NOT in teamsRemovalIndicators: [role="alert"] / [role="alertdialog"] / .error-message / .connection-error / .meeting-error
PASS  real "removed from this meeting" text → checkForTeamsRemoval = true
PASS  real "Meeting ended" text → checkForTeamsRemoval = true
PASS  nothing visible → checkForTeamsRemoval = false
9 passed, 0 failed
```

**Full offline suite / build / gates:**
- `pnpm install --frozen-lockfile` clean; join module `tsc` build clean.
- Join module `npm test` — all suites green (incl. new `removal.test.ts`).
- `node scripts/gates.mjs all` — ✅ gates green (incl. `gate:node`, `gate:compose`).

## Not witnessed — live Teams regression still wanted
This is proven offline only. The issue's declared human bar is a **real Teams join that is NOT falsely evicted** ~1.5s after admission. I could not run a live Teams meeting. **A live Teams witness is still wanted before ship** — flagging, not claiming it. Preferred validator: the reporter (owner-authored `msteams/*`), on a fresh join, watching for absence of `🚨 Teams removal detected` + `completed(evicted)` in the seconds after admission.

Note: ignore the spurious `merge-card` check.
