### PR TITLE
fix(meeting-api): reject native_meeting_id carrying URL/query chars at intake (#892)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -40,6 +40,15 @@ from .service import DuplicateMeeting, construct_meeting_url, request_bot
 #: 422 here rather than an asyncpg truncation 500 deep in the spawn path (#843).
 NATIVE_MEETING_ID_MAX_LEN = 255
 
+#: URL-structural characters that must never appear in a native_meeting_id. The id is
+#: interpolated into a URL PATH SEGMENT (`construct_meeting_url` — google_meet/teams) and reused
+#: as the DELETE path param and the dashboard lookup key, so any of these breaks that use (#892):
+#: a Teams passcode left on the id (`…982?p=X8hc…`) built `…/meetup-join/…982?p=X8hc…`
+#: (join_failure) and stored an unfindable `platform_specific_id`. No valid id across platforms
+#: carries them — Meet dash-codes (`abc-defg-hij`), Zoom digits, Teams `19:…@thread.v2` / bare
+#: short ids, and Jitsi rooms all exclude `? # & = /` and whitespace (see collector.meeting_link).
+NATIVE_MEETING_ID_URL_CHARS = "?#&=/"
+
 
 
 def _resolve_recording_enabled(value: Optional[object]) -> bool:
@@ -300,9 +309,11 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
         # in, while every other malformed field is refused at this boundary with a typed 422 (#843).
         # Applied after URL-derivation so a derived id is bounded too.
         #
-        # Length and control bytes ONLY. The id's SHAPE is deliberately not validated: ids that look
-        # wrong do join (a bare-numeric Teams id transcribed a real meeting in production), so a
-        # format rule would refuse working meetings while fixing nothing.
+        # Length and control bytes; plus the URL-structural chars below. The id's SEMANTIC shape is
+        # STILL not validated: ids that look wrong do join (a bare-numeric Teams id transcribed a
+        # real meeting in production), so a format rule would refuse working meetings. The one shape
+        # rule is that the id must be a bare, URL-safe token — it is embedded into a URL path segment
+        # and a lookup key, not carrying its own query string.
         if native_meeting_id:
             if len(native_meeting_id) > NATIVE_MEETING_ID_MAX_LEN:
                 raise HTTPException(
@@ -316,6 +327,19 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
                 raise HTTPException(
                     status_code=422,
                     detail="'native_meeting_id' contains control characters",
+                )
+            # URL-structural chars (#892). A passcode accidentally left on the id
+            # (`397421056486982?p=X8hc…`) is short and control-free, so it passed both guards above,
+            # then built a broken join URL and stored an unfindable id. Refuse at the door and name
+            # the fix. Whitespace beyond the control range (a literal space) is caught here too.
+            if any(ch in NATIVE_MEETING_ID_URL_CHARS or ch.isspace() for ch in native_meeting_id):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "'native_meeting_id' must be the bare meeting id and cannot contain URL "
+                        "characters ('?', '#', '&', '=', '/') or spaces — pass any passcode in "
+                        "'passcode' or supply the full 'meeting_url' instead"
+                    ),
                 )
         # Reject a platform the meeting-bot flow cannot invoke, up front (→ 422) and BEFORE any DB
         # write. Without this, a platform outside the sealed invocation.v1 enum but WITH a

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -614,15 +614,54 @@ def test_native_meeting_id_with_nul_byte_is_422_not_500(monkeypatch):
 
 
 def test_native_meeting_id_bounds_do_not_validate_SHAPE(monkeypatch):
-    """NEGATIVE CONTROL — the guard bounds length/bytes ONLY, never the id's shape.
+    """NEGATIVE CONTROL — the guard bounds length/bytes and URL-structural chars ONLY, never the
+    id's SEMANTIC shape.
 
     Production evidence: a bare-numeric Teams id (the dial-in kind) transcribed a real meeting
     (24368, 67 segments) while another of the SAME shape failed. Shape does not predict success,
-    so a format rule would refuse working meetings. These must all still spawn."""
+    so a format rule would refuse working meetings. The Teams thread-id form
+    (`19:…@thread.v2` — `: @ . _ -`) and Meet dash-codes must all still spawn; only URL-structural
+    chars are refused (see #892 test below)."""
     monkeypatch.setenv("ADMIN_TOKEN", "test-admin-token")
-    for odd_but_legal in ("474226440982", "abc-defg-hij", "x", "A" * 255, "id with spaces"):
+    for odd_but_legal in (
+        "474226440982", "abc-defg-hij", "x", "A" * 255,
+        "19:meeting_AbC-dEf_123@thread.v2",  # Teams thread id: `:@._-` must survive the #892 guard
+    ):
         repo = InMemoryMeetingRepo()
         r = _client(repo).post("/bots", headers=HEADERS, json={
             "platform": "google_meet", "native_meeting_id": odd_but_legal,
         })
         assert r.status_code == 201, f"{odd_but_legal!r} was refused: {r.status_code} {r.text}"
+
+
+def test_native_meeting_id_with_url_chars_is_422_not_join_failure(monkeypatch):
+    """#892: a `native_meeting_id` carrying URL-structural chars (a Teams passcode left on the id,
+    `397421056486982?p=X8hc…`) is short and control-free, so it passed the #843/#855 length+control
+    guards, then string-interpolated into `construct_meeting_url` to build a broken join URL
+    (`…/l/meetup-join/…982?p=X8hc…` → join_failure) and stored an unfindable `platform_specific_id`.
+    It must be refused HERE, typed 422, naming the fix, and write NO row."""
+    monkeypatch.setenv("ADMIN_TOKEN", "test-admin-token")
+    # The reproduced value from the issue, plus one per URL-structural class + a literal space.
+    for bad_id in (
+        "397421056486982?p=X8hcQVTnGNpGelJLSv",  # the reproduced Teams-passcode case
+        "abc?def", "abc&def", "abc=def", "abc/def", "abc#def", "abc def",
+    ):
+        repo = InMemoryMeetingRepo()
+        r = _client(repo).post("/bots", headers=HEADERS, json={
+            "platform": "teams", "native_meeting_id": bad_id,
+        })
+        assert r.status_code == 422, f"{bad_id!r} expected typed 422, got {r.status_code} {r.text}"
+        detail = r.json()["detail"]
+        assert "native_meeting_id" in detail and "passcode" in detail, (
+            f"the refusal must name the id and the fix, got: {detail}"
+        )
+        assert repo._meetings == {}, f"refused spawn wrote a meeting row: {repo._meetings}"
+
+    # POSITIVE CONTROL — the bare id + a separate passcode still spawns (the meeting-13564 pattern:
+    # pass the passcode in its own field, not glued onto the id).
+    repo = InMemoryMeetingRepo()
+    ok = _client(repo).post("/bots", headers=HEADERS, json={
+        "platform": "teams", "native_meeting_id": "397421056486982",
+        "passcode": "X8hcQVTnGNpGelJLSv",
+    })
+    assert ok.status_code == 201, f"bare id + separate passcode was refused: {ok.text}"

--- a/docs/changelog.d/892-native-id-url-chars.md
+++ b/docs/changelog.d/892-native-id-url-chars.md
@@ -1,0 +1,6 @@
+- **`POST /bots` rejects a `native_meeting_id` carrying URL characters (#892).** A meeting id
+  with `?`, `#`, `&`, `=`, `/`, or a space (e.g. a Teams passcode accidentally left on the id,
+  `397421056486982?p=…`) now returns a typed `422` at intake instead of building a broken join URL
+  and storing an unfindable record. Pass any passcode in the `passcode` field, or supply the full
+  `meeting_url`. Bare ids across platforms (Meet dash-codes, Zoom digits, Teams `19:…@thread.v2`)
+  are unaffected.


### PR DESCRIPTION
Closes #892

## What broke (point of introduction)
`POST /bots` accepted a `native_meeting_id` carrying URL-structural characters. The reproduced value from the issue — `397421056486982?p=X8hcQVTnGNpGelJLSv` (a Teams passcode accidentally glued onto the id) — is short and control-free, so it sailed past the #843/#855 length + control-byte guards. It was then string-interpolated by `construct_meeting_url` into `https://teams.microsoft.com/l/meetup-join/397421056486982?p=X8hcQVTnGNpGelJLSv` (broken join URL → `join_failure`) and stored as `platform_specific_id = "397421056486982?p=…"` (unfindable — the dashboard looks up the bare `397421056486982`).

## The fix
One new guard at the **#855 guard site** — `core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py`, immediately after the existing length + control-byte checks, so it runs **after** URL-derivation (a derived id is checked too):

```python
NATIVE_MEETING_ID_URL_CHARS = "?#&=/"
...
if any(ch in NATIVE_MEETING_ID_URL_CHARS or ch.isspace() for ch in native_meeting_id):
    raise HTTPException(status_code=422, detail=(
        "'native_meeting_id' must be the bare meeting id and cannot contain URL "
        "characters ('?', '#', '&', '=', '/') or spaces — pass any passcode in "
        "'passcode' or supply the full 'meeting_url' instead"))
```

**Char class rejected:** `?` `#` `&` `=` `/` and any whitespace (a literal space; tabs/newlines already fall to the control-byte check above).

**Why it won't over-reject.** These are exactly the URL delimiters that break the id when it is (a) interpolated into a URL **path segment** by `construct_meeting_url` (google_meet/teams), and (b) reused as the DELETE path param and the dashboard lookup key. No valid id across platforms carries them — verified against `collector/meeting_link.py`, the SSOT parser:
- **google_meet** — `abc-defg-hij` (`^[a-z]{3}-[a-z]{4}-[a-z]{3}$`): only `a-z` + `-`.
- **zoom** — 9–11 digits: only `0-9`.
- **teams** — `19:meeting_…@thread.v2` thread id (`: _ @ .`) or bare `/meet/<id>` short id (alphanumeric); the `?p=` passcode is a separate query, never part of the id.
- **jitsi** — room / `room@host` (`_JITSI_ROOM = ^[^/?#\s]+$` already excludes `/ ? #` and whitespace; carries an explicit `meeting_url`).

`- : @ . _` and alphanumerics are **not** rejected, so every real id shape still passes.

## Observation bundle (acceptance table)

| # | Observation | Evidence |
|---|---|---|
| 1 | URL/query chars → typed **422** at intake, no row written (negative control) | RED→GREEN unit test below. Each of `…982?p=X8hc…`, `abc?def`, `abc&def`, `abc=def`, `abc/def`, `abc#def`, `abc def` → 422; `repo._meetings == {}`. |
| 2 | Bare id + separate passcode still spawns (positive control — the meeting-13564 pattern) | `{"platform":"teams","native_meeting_id":"397421056486982","passcode":"X8hcQVTnGNpGelJLSv"}` → **201**. |
| 3 | No over-rejection of legit ids across platforms | Existing `test_native_meeting_id_bounds_do_not_validate_SHAPE` extended with `19:meeting_AbC-dEf_123@thread.v2` (Teams thread id: `:@._-`) → **201**; Meet dash-codes, numeric ids unchanged. |

### RED → GREEN (unit, no live meeting)
Pre-fix (guard reverted), the new test fails — the malformed id is **accepted 201** and builds the exact broken URL from the issue:
```
AssertionError: '397421056486982?p=X8hcQVTnGNpGelJLSv' expected typed 422, got 201
  constructed_meeting_url: https://teams.microsoft.com/l/meetup-join/397421056486982?p=X8hcQVTnGNpGelJLSv
```
Post-fix: `4 passed` (new #892 test + the SHAPE negative control + the two #843 guards).

### Suite + gates
- meeting-api suite: **823 passed, 5 skipped**.
- `node scripts/gates.mjs all`: **✅ gates green** (33 gates, incl. `gate:config-contract`, `gate:python`, `gate:contract-conformance`).

## Files
- `core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py` — the guard.
- `core/meetings/services/meeting-api/tests/test_bot_spawn.py` — new `test_native_meeting_id_with_url_chars_is_422_not_join_failure`; extended SHAPE negative control.
- `docs/changelog.d/892-native-id-url-chars.md` — changelog fragment.

Note: the dashboard's own parser strips the query today, so this only bit raw API/MCP callers — this guards them at the door. Ignore the spurious `merge-card` check.
