### PR TITLE
fix(spawn): a workload dead at start no longer yields POST /bots 201 (#718)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -24,6 +24,20 @@ from .ports import (
 )
 
 
+def _reason(resp) -> str:
+    """The kernel's error reason from a non-201 runtime.v1 response — its ``{detail}`` (the sealed
+    contract defines no error shape, so the API uses FastAPI's default), falling back to the raw body
+    text. Lets the meeting-api 502 name WHY the spawn failed (e.g. the absent image) instead of a bare
+    status code (#718)."""
+    try:
+        body = resp.json()
+        if isinstance(body, dict) and body.get("detail"):
+            return str(body["detail"])
+    except Exception:  # noqa: BLE001 — a non-JSON error body falls back to text
+        pass
+    return (getattr(resp, "text", "") or "").strip() or f"HTTP {resp.status_code}"
+
+
 def _iso_utc(dt) -> Optional[str]:
     """Serialize a datetime as an unambiguous UTC ISO-8601 string (``…Z``).
 
@@ -548,6 +562,39 @@ class SqlAlchemyMeetingRepo:
             await db.refresh(m)
             return _row_to_dict(m)
 
+    async def fail_meeting(self, *, meeting_id, reason, failure_stage="requested") -> Optional[dict]:
+        """Mark a meeting ``failed`` BY ID (no session needed) — the spawn-time failure path (#718).
+
+        A workload dead on arrival (kernel ``start_failed``) is refused BEFORE the ``MeetingSession``
+        exists, so the session-keyed ``update_meeting_status`` cannot reach the row; this fails it
+        directly, stamping the reason into ``data`` so ``GET /meetings`` and the terminal show WHY
+        instead of leaving a ``requested`` row for the 5-minute reaper to flip reason-less. Row-locked;
+        a missing row is a no-op."""
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            m = (
+                await db.execute(select(Meeting).where(Meeting.id == meeting_id).with_for_update())
+            ).scalars().first()
+            if m is None:
+                return None
+            m.status = "failed"
+            merged = dict(m.data) if isinstance(m.data, dict) else {}
+            merged["failure_stage"] = failure_stage
+            merged["failure_reason"] = reason
+            merged["completion_reason"] = "start_failed"
+            m.data = merged
+            flag_modified(m, "data")
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            if m.end_time is None:
+                m.end_time = now
+            await db.commit()
+            await db.refresh(m)
+            return _row_to_dict(m)
+
 
 class HttpRuntimeClient:
     """``RuntimeClient`` over the runtime.v1 HTTP kernel (``POST /workloads``). 429 → QuotaExceeded;
@@ -562,8 +609,19 @@ class HttpRuntimeClient:
         if resp.status_code == 429:
             raise QuotaExceeded("runtime kernel: owner quota exceeded")
         if resp.status_code != 201:
-            raise SpawnFailed(f"runtime kernel returned {resp.status_code}")
-        return resp.json()
+            # Carry the kernel's own reason (its {detail}) so the 502 the user sees NAMES the cause
+            # — e.g. "No such image: …" for an absent bot image (#718 C1 → C2).
+            raise SpawnFailed(f"runtime kernel returned {resp.status_code}: {_reason(resp)}")
+        body = resp.json()
+        # Belt-and-suspenders (#718 C2): even a 201 must be a workload that actually STARTED. A kernel
+        # that answers 201 with a dead body (state=stopped/destroyed, e.g. start_failed) is dead on
+        # arrival — refuse it here too, so the adapter never trusts any kernel version's optimism.
+        state = body.get("state")
+        if state in ("stopped", "destroyed"):
+            raise SpawnFailed(
+                f"workload dead on spawn: {body.get('stopReason') or state}"
+            )
+        return body
 
     async def delete_workload(self, workload_id: str) -> None:
         """Tear down a workload (``DELETE /workloads/{id}``) — teardown must be CONFIRMED.

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -201,6 +201,16 @@ class InMemoryMeetingRepo:
         row["bot_container_id"] = bot_container_id
         return dict(row)
 
+    async def fail_meeting(self, *, meeting_id, reason, failure_stage="requested") -> Optional[dict]:
+        row = self._meetings.get(meeting_id)
+        if row is None:
+            return None
+        row["status"] = "failed"
+        row["data"]["failure_stage"] = failure_stage
+        row["data"]["failure_reason"] = reason
+        row["data"]["completion_reason"] = "start_failed"
+        return dict(row)
+
     async def get_status_by_session(self, *, session_uid) -> Optional[str]:
         sess = next((s for s in self.sessions if s["session_uid"] == session_uid), None)
         if sess is None:
@@ -299,9 +309,15 @@ class FakeRuntimeClient:
     """A ``RuntimeClient`` that records the spec and returns a synthetic ``workloadId``."""
 
     def __init__(self, *, quota_exceeded: bool = False, fail: bool = False,
+                 dead_on_arrival: bool = False,
                  workloads: Optional[dict[str, dict]] = None):
         self._quota_exceeded = quota_exceeded
         self._fail = fail
+        # dead_on_arrival models a kernel that (against #718 C1) still answers 201 but with a workload
+        # that never started (state=stopped/start_failed). The HTTP adapter's body-state check (C2)
+        # must catch it, so the FAKE returns that shape verbatim rather than raising — the belt of the
+        # belt-and-suspenders defense the adapter owns.
+        self._dead_on_arrival = dead_on_arrival
         self.specs: list[dict] = []  # every spawned spec, for assertions
         self.deleted: list[str] = []  # workload ids torn down (ROB3 compensation), for assertions
         # Liveness map for the reconcile sweep: workload_id -> status dict ({"state": ...}). A workload
@@ -315,6 +331,8 @@ class FakeRuntimeClient:
             raise QuotaExceeded("owner quota exceeded")
         if self._fail:
             raise SpawnFailed("kernel could not start the workload")
+        if self._dead_on_arrival:
+            return {"workloadId": spec["workloadId"], "state": "stopped", "stopReason": "start_failed"}
         return {"workloadId": spec["workloadId"], "state": "starting"}
 
     async def delete_workload(self, workload_id: str) -> None:

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
@@ -108,6 +108,16 @@ class MeetingRepo(Protocol):
         """Record the kernel-assigned workload id/name on the meeting and return the updated row."""
         ...
 
+    async def fail_meeting(
+        self, *, meeting_id: int, reason: str, failure_stage: str = "requested"
+    ) -> Optional[dict]:
+        """Mark a meeting ``failed`` BY ID (no session_uid), stamping ``reason``/``failure_stage`` into
+        ``meeting.data`` — the spawn-time failure path (#718). A workload dead on arrival is refused
+        BEFORE the ``MeetingSession`` exists, so the session-keyed ``update_meeting_status`` cannot
+        reach the row; this fails it directly so no ``requested`` row lingers for the reaper to flip
+        reason-less. Returns the updated row (or ``None`` for an unknown id)."""
+        ...
+
     async def count_active_bots(self, *, user_id: int, exclude_meeting_id: Optional[int] = None) -> int:
         """Count the user's ACTIVE (non-terminal) bots for the max-bots quota (P3e).
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -398,16 +398,38 @@ async def request_bot(
     )
     try:
         result = await runtime.create_workload(spec)
+        # Defense in depth at the service/port seam (#718 C2): the adapter already refuses a dead
+        # spawn (non-201, or a 201 whose body is state=stopped/destroyed), but the service must not
+        # trust ANY port's optimism either — a returned non-live state is a spawn failure here too, so
+        # no code path proceeds to a 201 over a workload that never came up.
+        spawned_state = result.get("state")
+        if spawned_state in ("stopped", "destroyed"):
+            raise SpawnFailed(f"workload dead on spawn: {result.get('stopReason') or spawned_state}")
     except QuotaExceeded:
         log_event(
             "bot_spawn_quota_exceeded", audience="user", level="warning",
             span="bots.create", user_id=user_id, meeting_id=str(meeting_id),
         )
         raise
-    except SpawnFailed:
+    except SpawnFailed as e:
+        # No workload came up. Mark the just-inserted meeting row `failed` with the reason so no
+        # `requested` row lingers for the 5-minute reaper to flip reason-less (#718): the failure and
+        # its cause are on the row NOW, and POST /bots answers 502 with the same reason. The row is
+        # failed BY ID — the MeetingSession is not created until after a successful spawn, so the
+        # session-keyed update_meeting_status cannot reach it yet.
+        reason = str(e) or "bot workload failed to start"
+        try:
+            await repo.fail_meeting(meeting_id=meeting_id, reason=reason, failure_stage="requested")
+        except Exception as fail_err:  # noqa: BLE001 — failing the row is best-effort; never mask the spawn error
+            log_event(
+                "bot_spawn_fail_row_error", audience="system", level="error",
+                span="bots.create", user_id=user_id, meeting_id=str(meeting_id),
+                fields={"error": str(fail_err)},
+            )
         log_event(
             "bot_spawn_failed", audience="system", level="error",
             span="bots.create", user_id=user_id, meeting_id=str(meeting_id),
+            fields={"reason": reason},
         )
         raise
 

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -155,6 +155,45 @@ async def test_request_bot_quota_propagates(monkeypatch):
                           native_meeting_id="x", redis_url="r", token_secret=SECRET)
 
 
+# ── #718: a workload DEAD AT START is refused, the row is failed with the reason, no `requested` lingers
+async def test_request_bot_dead_on_arrival_fails_the_row(monkeypatch):
+    """C2: the kernel answers 201 but with a workload that never started (state=stopped/start_failed).
+    ``create_workload`` catches the dead body → ``SpawnFailed``; ``request_bot`` marks the meeting
+    row ``failed`` with the reason so NO ``requested`` row remains, and creates no session.
+
+    Negative control (the bug): before the fix the dead 201 sailed through, the row stayed
+    ``requested``, and the reaper flipped it reason-less 5 minutes later."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient(dead_on_arrival=True)
+    with pytest.raises(SpawnFailed) as ei:
+        await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                          native_meeting_id="dead", redis_url="r", token_secret=SECRET)
+    assert "start_failed" in str(ei.value)
+    # exactly one row, and it is FAILED with the reason — not a lingering `requested`.
+    rows = list(repo._meetings.values())
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["status"] == "failed"
+    assert row["data"]["completion_reason"] == "start_failed"
+    assert "start_failed" in row["data"]["failure_reason"]
+    assert repo.sessions == [], "no MeetingSession for a workload that never started"
+
+
+async def test_request_bot_spawnfailed_fails_the_row(monkeypatch):
+    """The same row-failing discipline on the runtime-error path (create_workload raises SpawnFailed,
+    e.g. a non-201 from the kernel): the row is failed, not left ``requested``."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient(fail=True)
+    with pytest.raises(SpawnFailed):
+        await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                          native_meeting_id="boom", redis_url="r", token_secret=SECRET)
+    assert list(repo._meetings.values())[0]["status"] == "failed"
+
+
 # ── route: POST /bots maps outcomes onto HTTP status ─────────────────────────────────────────────
 
 def _client(repo=None, runtime=None):
@@ -262,6 +301,22 @@ def test_post_bots_429_on_quota(monkeypatch):
     r = client.post("/bots", headers=HEADERS,
                     json={"platform": "google_meet", "native_meeting_id": "x"})
     assert r.status_code == 429
+
+
+def test_post_bots_502_when_workload_dead_on_arrival(monkeypatch):
+    """Route level (#718 A1): a workload dead at start → POST /bots is 502 naming the reason, and the
+    meeting row is ``failed`` (NOT a lingering ``requested`` that would 409 the user's retry)."""
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient(dead_on_arrival=True)
+    client = _client(repo, runtime)
+    r = client.post("/bots", headers=HEADERS,
+                    json={"platform": "google_meet", "native_meeting_id": "dead-201"})
+    assert r.status_code == 502, f"a dead-at-start spawn must not 201; got {r.status_code}"
+    assert "start_failed" in r.json()["detail"]
+    rows = list(repo._meetings.values())
+    assert len(rows) == 1 and rows[0]["status"] == "failed"
 
 
 def test_post_bots_401_without_identity(monkeypatch):

--- a/core/meetings/services/meeting-api/tests/test_robustness_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_robustness_seam.py
@@ -508,6 +508,57 @@ async def test_http_runtime_client_delete_404_raises_workload_unknown():
     assert ok.deleted == ["http://runtime:8090/workloads/mtg-2-d93eee39"]
 
 
+async def test_http_runtime_client_create_refuses_dead_workload():
+    """#718 C1/C2 at the production HTTP boundary: create_workload raises SpawnFailed when the kernel
+    answers a non-201 (carrying the kernel's reason) OR a 201 whose BODY is a dead workload
+    (state=stopped/start_failed). A live 201 (state=starting) returns the body cleanly."""
+    import pytest
+
+    from meeting_api.bot_spawn.adapters import HttpRuntimeClient
+    from meeting_api.bot_spawn.ports import SpawnFailed
+
+    class _Resp:
+        def __init__(self, status_code, body=None, text=""):
+            self.status_code = status_code
+            self._body = body if body is not None else {}
+            self.text = text
+
+        def json(self):
+            return self._body
+
+    class _StubHttp:
+        def __init__(self, resp):
+            self._resp = resp
+
+        async def post(self, url, json=None, timeout=None):
+            return self._resp
+
+    spec = {"workloadId": "mtg-1-abc", "profile": "meeting-bot", "env": {}}
+
+    # C1 path: the kernel's 502 (naming the absent image) → SpawnFailed carrying that reason.
+    dead502 = HttpRuntimeClient(
+        _StubHttp(_Resp(502, {"detail": "No such image: vexaai/vexa-bot:dev"})), "http://runtime:8090"
+    )
+    with pytest.raises(SpawnFailed) as ei502:
+        await dead502.create_workload(spec)
+    assert "No such image" in str(ei502.value)
+
+    # C2 belt: a 201 with a dead body (a kernel that still 201s) → SpawnFailed naming the stopReason.
+    dead201 = HttpRuntimeClient(
+        _StubHttp(_Resp(201, {"workloadId": "mtg-1-abc", "state": "stopped", "stopReason": "start_failed"})),
+        "http://runtime:8090",
+    )
+    with pytest.raises(SpawnFailed) as ei201:
+        await dead201.create_workload(spec)
+    assert "start_failed" in str(ei201.value)
+
+    # A live spawn (201 + running/starting) returns cleanly.
+    live = HttpRuntimeClient(
+        _StubHttp(_Resp(201, {"workloadId": "mtg-1-abc", "state": "starting"})), "http://runtime:8090"
+    )
+    assert (await live.create_workload(spec))["state"] == "starting"
+
+
 # ──────────────────────────────────────────────────────────────────────────────────────────────
 # (b3) CC5 — a workload that DIES before the bot reports drives the meeting to `failed` (no hang).
 # ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/core/runtime/src/runtime_kernel/__init__.py
+++ b/core/runtime/src/runtime_kernel/__init__.py
@@ -1,5 +1,5 @@
 """The runtime kernel — implements runtime.v1 (spawn/execute workloads through the lifecycle)."""
-from .kernel import Runtime, QuotaExceeded
+from .kernel import Runtime, QuotaExceeded, StartFailed
 from .models import WorkloadSpec, WorkloadStatus, RuntimeEvent, RuntimeState, StopReason, BackendKind
 from .profiles import Runnable, Profile, ProfileRegistry, default_registry
 from .process_backend import ProcessBackend
@@ -22,7 +22,7 @@ from .callbacks import (
 )
 
 __all__ = [
-    "Runtime", "QuotaExceeded",
+    "Runtime", "QuotaExceeded", "StartFailed",
     "Runnable", "Profile", "ProfileRegistry", "default_registry",
     "ProcessBackend", "DockerBackend", "K8sBackend",
     "WorkloadSpec", "WorkloadStatus", "RuntimeEvent",

--- a/core/runtime/src/runtime_kernel/api.py
+++ b/core/runtime/src/runtime_kernel/api.py
@@ -15,7 +15,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from .callbacks import CallbackQueue
-from .kernel import QuotaExceeded, Runtime
+from .kernel import QuotaExceeded, Runtime, StartFailed
 from .models import RuntimeEvent, StopReason, WorkloadSpec
 from .obs import TraceMiddleware, log_event
 from .scheduler import Scheduler
@@ -106,7 +106,9 @@ def create_app(
     def create(spec: WorkloadSpec):
         try:
             status = rt.create(spec)
-            # SYSTEM event: a workload was spawned for the calling control-plane request.
+            # SYSTEM event: a workload was spawned for the calling control-plane request. Only logged
+            # on the success path — a workload that failed to START raises StartFailed below, so
+            # `workload_spawned` never fires over a dead workload (#718).
             log_event(
                 "workload_spawned",
                 audience="system",
@@ -114,6 +116,19 @@ def create_app(
                 fields={"workload_id": spec.workloadId, "profile": spec.profile},
             )
             return dump(status)
+        except StartFailed as e:
+            # The backend could not start the workload (e.g. the image is absent). The kernel already
+            # recorded the honest stopped/start_failed status + emitted its event; answer a non-201
+            # that NAMES the cause (the existing {detail} error convention — no runtime.v1 shape is
+            # sealed for errors, same as the 429/400 branches below) so no caller reads a false 201.
+            log_event(
+                "workload_spawn_failed",
+                audience="system",
+                level="error",
+                span="workloads.create",
+                fields={"workload_id": spec.workloadId, "profile": spec.profile, "error": str(e)},
+            )
+            raise HTTPException(status_code=502, detail=str(e))
         except QuotaExceeded as e:
             log_event(
                 "workload_quota_exceeded",

--- a/core/runtime/src/runtime_kernel/kernel.py
+++ b/core/runtime/src/runtime_kernel/kernel.py
@@ -38,6 +38,20 @@ class QuotaExceeded(Exception):
         super().__init__(f"owner {owner!r} at quota cap ({cap})")
 
 
+class StartFailed(Exception):
+    """Raised by create() when the backend could not START the workload (e.g. the docker
+    image is absent → a 404 on container create). The honest ``stopped``/``start_failed``
+    record is persisted and its RuntimeEvent emitted BEFORE this raises, so ``GET /workloads``
+    and the callback stream still tell the truth; the raise carries the backend's own reason
+    text so the API answers a non-201 that NAMES the cause instead of a false ``spawned`` 201
+    over a workload that never came up."""
+
+    def __init__(self, workload_id: str, reason: str) -> None:
+        self.workload_id = workload_id
+        self.reason = reason
+        super().__init__(reason)
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -183,13 +197,17 @@ class Runtime:
             # never reaches the spawned pod and chart-set tuning is dead config (issue #771).
             effective_env = {**profile.base_env, **spec.env}
             self._handles[spec.workloadId] = self.backend.start(spec.workloadId, runnable, effective_env)
-        except Exception:
+        except Exception as exc:
+            # Record the honest terminal state (persist + emit) FIRST — GET /workloads and the
+            # callback stream must still see stopped/start_failed — THEN raise so the API answers a
+            # non-201 naming the cause. A caught-and-returned status here is a false "spawned" 201
+            # over a workload that never came up (#718): the create response must not read as success.
             status.state = RuntimeState.stopped
             status.stopReason = StopReason.start_failed
             status.stoppedAt = _now()
             self._persist(spec, status)
             self._emit(spec.workloadId, RuntimeState.stopped, stopReason=StopReason.start_failed)
-            return status
+            raise StartFailed(spec.workloadId, str(exc)) from exc
         status.state = RuntimeState.running
         status.startedAt = _now()
         status.ports = {}

--- a/core/runtime/tests/test_start_failed.py
+++ b/core/runtime/tests/test_start_failed.py
@@ -1,0 +1,100 @@
+"""#718 C1 — a workload that is DEAD AT START must not read as spawned.
+
+The docker backend raises loudly when the image is absent (``docker create … (404): No such
+image``). The kernel records the honest ``stopped``/``start_failed`` state (so ``GET /workloads``
+and the callback stream stay truthful) but must NOT answer the create as success: the kernel
+raises ``StartFailed`` and the HTTP API maps it to a 502 that NAMES the cause, logging
+``workload_spawn_failed`` instead of ``workload_spawned``.
+
+Negative control (the bug this fixes): before the fix, ``create()`` caught the start failure and
+RETURNED the stopped status, so ``POST /workloads`` answered 201 + ``workload_spawned`` over a
+workload that never came up.
+"""
+import json
+
+from fastapi.testclient import TestClient
+
+from runtime_kernel import Runtime, RuntimeState, StartFailed, StopReason, WorkloadSpec
+from runtime_kernel.api import create_app
+from runtime_kernel.backend import WorkloadHandle
+
+_MISSING_IMAGE_MSG = "docker create vexa-w1 failed (404): No such image: vexaai/vexa-bot:dev"
+
+
+class _DeadAtStartBackend:
+    """A backend whose ``start`` raises exactly as the docker backend does for an absent image."""
+
+    name = "docker"
+
+    def start(self, workload_id, runnable, env):
+        raise RuntimeError(_MISSING_IMAGE_MSG)
+
+    def exit_code(self, h):  # pragma: no cover — never reached (start raised)
+        return None
+
+    def terminate(self, h):  # pragma: no cover
+        pass
+
+    def kill(self, h):  # pragma: no cover
+        pass
+
+    def cleanup(self, h):  # pragma: no cover
+        pass
+
+    def find(self, workload_id):  # pragma: no cover
+        return None
+
+
+def test_create_raises_start_failed_but_records_the_honest_state():
+    """Kernel level: ``create`` RAISES ``StartFailed`` (carrying the backend reason), yet the
+    persisted record and the emitted event are the honest ``stopped``/``start_failed`` — the
+    truthful record is kept, the false success is refused."""
+    events = []
+    rt = Runtime(backend=_DeadAtStartBackend(), profiles={"bot": ["run"]}, on_event=events.append)
+
+    try:
+        rt.create(WorkloadSpec(workloadId="w1", profile="bot", env={}))
+        assert False, "expected StartFailed"
+    except StartFailed as e:
+        assert "No such image" in str(e)
+
+    # The record is honest — GET /workloads must still tell the truth.
+    rec = rt.store.get("w1")
+    assert rec.status.state is RuntimeState.stopped
+    assert rec.status.stopReason is StopReason.start_failed
+    # The lifecycle stream saw starting → stopped(start_failed), never running.
+    assert [e.state.value for e in events] == ["starting", "stopped"]
+    assert events[-1].stopReason is StopReason.start_failed
+
+
+def test_post_workloads_dead_at_start_is_502_not_a_false_201(capsys):
+    """API level (the point of introduction): ``POST /workloads`` for a dead-at-start workload is a
+    502 naming the missing image — NOT a bare 201 — and logs ``workload_spawn_failed``, never
+    ``workload_spawned``."""
+    app = create_app(Runtime(backend=_DeadAtStartBackend(), profiles={"bot": ["run"]}))
+    client = TestClient(app)
+
+    r = client.post("/workloads", json={"workloadId": "w1", "profile": "bot", "env": {}})
+
+    assert r.status_code == 502, f"a dead-at-start spawn must not 201; got {r.status_code}"
+    assert "No such image" in r.json()["detail"]
+
+    events = [json.loads(line)["event"] for line in capsys.readouterr().out.splitlines() if line.strip().startswith("{")]
+    assert "workload_spawn_failed" in events
+    assert "workload_spawned" not in events, "the success log must not fire over a dead workload"
+
+
+def test_post_workloads_healthy_spawn_still_201():
+    """Negative control the other way: a backend that starts cleanly still answers 201 + running —
+    the fix does not turn healthy spawns into 502s."""
+
+    class _OkBackend(_DeadAtStartBackend):
+        def start(self, workload_id, runnable, env):
+            return WorkloadHandle(id=workload_id, impl=workload_id)
+
+        def exit_code(self, h):
+            return None
+
+    app = create_app(Runtime(backend=_OkBackend(), profiles={"bot": ["run"]}))
+    r = TestClient(app).post("/workloads", json={"workloadId": "w1", "profile": "bot", "env": {}})
+    assert r.status_code == 201 and r.json()["state"] == "running"

--- a/deploy/compose/Makefile
+++ b/deploy/compose/Makefile
@@ -89,10 +89,20 @@ dev:
 	@$(MAKE) --no-print-directory _preflight
 	@[ -f .env ] || { echo "→ no .env found; seeding from .env.example"; cp .env.example .env; }
 	IMAGE_TAG=dev $(COMPOSE) up -d --build
-	IMAGE_TAG=dev $(COMPOSE) build agent-worker  # profiles:[build-only] keeps it out of `up`
-	@$(MAKE) --no-print-directory _bot_check
-	@$(MAKE) --no-print-directory _creds_check
-	@$(MAKE) --no-print-directory _access
+	@# Every remaining step must RUN and the target must exit non-zero naming EVERY gap. A failed
+	@# agent-worker build (a transient apt flake, #716) must NOT abort BEFORE the bot-image check —
+	@# that is exactly how a stack came up "healthy" but spawned dead bots with no signal (#718 C4).
+	@fail=""; \
+	 IMAGE_TAG=dev $(COMPOSE) build agent-worker || fail="$$fail agent-worker-build"; \
+	 $(MAKE) --no-print-directory _bot_check BOT_CHECK_STRICT=1 || fail="$$fail bot-image-missing"; \
+	 $(MAKE) --no-print-directory _creds_check; \
+	 $(MAKE) --no-print-directory _access; \
+	 if [ -n "$$fail" ]; then \
+	   echo ""; \
+	   echo "✗ make dev did not fully succeed —$$fail (see the messages above)."; \
+	   echo "  The stack is up, but spawned bots may fail to start until every item above is resolved."; \
+	   exit 1; \
+	 fi
 
 ## digest-audit — the #569 negative control: every vexaai/*:$IMAGE_TAG image on this host must
 ## carry a RepoDigest (= came from the registry). A locally-built image has NO RepoDigest, so a
@@ -149,6 +159,11 @@ bot:
 ## _bot_check — FAIL LOUD if the meeting bot image isn't built locally. The bot is built here, never
 ## pulled (the published vexaai/vexa-bot:dev is the old 0.10 line). Without this the failure was silent:
 ## bots sat in `requested` and the meeting was reaped to `completed`/0-segments. Now it is screamingly visible.
+##
+## BOT_CHECK_STRICT=1 turns the warning into a non-zero EXIT (used by `dev` — an aborted build must never
+## leave a stack that spawns dead bots with no signal, #718 C4). `up` calls it warn-only (the published
+## image is pulled elsewhere), so the shared default stays a warning. Check-and-instruct only — it prints
+## the `make bot` / `docker pull` line and NEVER forces a 3.6GB pull mid-`make dev`.
 _bot_check:
 	@_bi=$$(grep -E '^BROWSER_IMAGE=' .env 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$$//; s/[[:space:]]+$$//'); \
 	 if [ -n "$$_bi" ] && ! docker image inspect "$$_bi" >/dev/null 2>&1; then \
@@ -163,6 +178,7 @@ _bot_check:
 	   echo "      Bots will FAIL TO JOIN until the image exists."; \
 	   echo "═══════════════════════════════════════════════════════════"; \
 	   echo ""; \
+	   if [ -n "$(BOT_CHECK_STRICT)" ]; then exit 1; fi; \
 	 fi
 
 ## _creds_check — WARN (never fail) when .env leaves a capability unconfigured: empty STT creds mean

--- a/docs/changelog.d/718-dead-workload-201.md
+++ b/docs/changelog.d/718-dead-workload-201.md
@@ -1,0 +1,7 @@
+- **A bot that fails to start now surfaces the failure instead of a false success (#718).** When the
+  runtime cannot start a bot workload (e.g. the bot image is absent), `POST /bots` returns `502` with
+  the reason (the missing image is named) and the meeting is marked `failed` on the spot — no more a
+  `201` over a workload that never came up, followed by five silent minutes and a reason-less
+  `failed`. The runtime kernel answers the spawn honestly (non-201 + `workload_spawn_failed`), the
+  meeting-api refuses the dead spawn at both the runtime seam and the service, and `make dev` now
+  exits non-zero naming an unpulled bot image even when an earlier build step fails.


### PR DESCRIPTION
Closes #718

## The false 201, traced hop-by-hop

A bot workload dead at start (e.g. the bot image is absent) was converted into silence at every layer. The **point of introduction** is the runtime API answering the create as success over a workload that never came up:

1. **Runtime kernel** — `core/runtime/src/runtime_kernel/kernel.py`: `backend.start()` raised (docker create on the absent image, `docker_backend.py:262-263`), the kernel caught it, recorded `state=stopped, stopReason=start_failed`, and **`return`ed the status** (was `kernel.py:192`).
2. **Runtime API (← the false 201 is born here)** — `core/runtime/src/runtime_kernel/api.py:105-116`: `POST /workloads` is `status_code=201`, so returning that stopped status **answered 201 + logged `workload_spawned`** over a dead workload.
3. **meeting-api adapter** — `adapters.py` `HttpRuntimeClient.create_workload`: only checked `!= 201`, so the 201-with-`state:stopped` body sailed through; `request_bot` proceeded, the row stayed `requested`, and the reaper flipped it reason-less 5 minutes later.

### Reproduced without a live meeting (RED → GREEN)

Pre-fix, driven directly against the runtime API with a backend whose `start()` raises the docker missing-image error:

```
status_code = 201 <-- BUG: dead workload answered 201
body.state  = stopped / stopReason = start_failed
logged events = ['workload_spawned']
```

Pre-fix, driven through meeting-api `POST /bots` with a kernel that 201s a dead body: `bot_join_requested`, HTTP **201**, meeting row **`requested`**.

## The fix (defense in depth across the runtime seam)

- **C1 — runtime kernel + api.** `kernel.create()` persists the honest `stopped`/`start_failed` record **and emits its `RuntimeEvent` first** (so `GET /workloads` and the callback stream stay truthful), then raises `StartFailed` carrying the backend's reason. The API maps it to **502 naming the cause** and logs `workload_spawn_failed`, never `workload_spawned`, over a dead workload.
- **C2 — meeting-api adapter + service.** `HttpRuntimeClient.create_workload` carries the kernel's reason on a non-201 and refuses a 201 whose body is `state=stopped/destroyed`. `request_bot` refuses a non-live returned state at the service seam too (it trusts no port's optimism) and marks the meeting row **`failed` with the reason** (`fail_meeting`, by id — the `MeetingSession` doesn't exist yet), so **no `requested` row lingers**.
- **C4 — `make dev`.** A failed `agent-worker` build no longer aborts before the bot-image check; `make dev` runs every check and **exits non-zero naming an unpulled bot image** (`BOT_CHECK_STRICT=1`), while `up` keeps its warn-only behavior. Check-and-instruct only — never forces a 3.6 GB pull.

### Contract fork (signed)

runtime.v1 seals `WorkloadSpec`/`WorkloadStatus`/`RuntimeEvent` — **no error shape**. The existing API error branches (429 `QuotaExceeded`, 400 `ValueError`) already answer with FastAPI's default `{detail}` body, which is not sealed. **C1 resolves as the 502 path using that same `{detail}` convention → no contract touch, no unseal.** C2's body check is the belt-and-suspenders half of the seam (the adapter must not trust any kernel version's optimism). `gate:schema` + `gate:contract-version` (24 contracts) + `gate:contract-conformance` (api.v1) all green — nothing sealed moved.

## Observation bundle (acceptance table)

| # | Observation | Evidence |
|---|---|---|
| A1 | Dead-at-start spawn → 502 `SpawnFailed` naming the reason; no `requested` row remains | `test_post_bots_502_when_workload_dead_on_arrival` (route: 502 + row `failed`), `test_request_bot_dead_on_arrival_fails_the_row`, `test_http_runtime_client_create_refuses_dead_workload` (adapter: non-201 reason + 201-dead-body), `test_post_workloads_dead_at_start_is_502_not_a_false_201` (runtime API). RED shown above. |
| A2 | Workload `start_failed` → meeting `failed` with reason in <5s | The row is failed **synchronously** at spawn (`fail_meeting` stamps `failure_stage`/`failure_reason`/`completion_reason=start_failed`), not the 5-minute reaper. Post-legitimate-spawn deaths keep the existing `synthesize_terminal_for_dead_workload` path. |
| A3 | Terminal meeting view shows failed state + reason | The terminal already treats `failed` as a durable-terminal state carrying `failure_stage`/`completion_reason` (`useMeeting.ts:336`, `MeetingCanvasView.tsx:78`, `meeting.tsx:383`, `runtime.tsx:101`). The witnessed bug was upstream — the row never reached `failed`; it now does, with its reason, so the existing surface engages. Visual confirmation is the named live-validation leg. |
| A4 | `make dev` with agent-worker build failing exits non-zero naming the unpulled bot image | Validated: warn-only `_bot_check` exits 0 (models `up`); `BOT_CHECK_STRICT=1` exits 1; the `dev` accumulation with a failing build stub + missing image prints the instruction and exits non-zero naming **both** `agent-worker-build` and `bot-image-missing`. |
| A- | No-regression: touched lanes + gates green | runtime suite **159 passed / 1 skipped**; meeting-api suite **828 passed / 3 skipped**; `gate:python` **12 packages · pytest green**; every static gate green (schema, contract-version, config-contract, contract-conformance, test-isolation, isolation-py, exports, graph-py, licenses, arch-report, …). Pre-push static gates green. |

The `stack` gate (full compose build + stand-up) failed on a Docker **buildkit snapshot error** (`parent snapshot … does not exist`) at the image-build step — environmental (concurrent builds across parallel worktrees), unrelated to this diff; CI runs it clean.

## Live validation (the human part)

One operator on a mac compose install with the bot image deliberately removed sends a bot from the terminal and signs that the failure + reason were visible in the UI and the API response without reading a container log. Preferred signer: the originating reporter.

## Scope note

Delivers C1, C2, C4 (the point-of-introduction fix + `make dev` guard) and the row substrate the terminal's existing `failed` surface (A3) consumes. Ignore the spurious `merge-card` check.
