### PR TITLE
fix(bot): Stop while awaiting_admission leaves the lobby (#889)

### DIFF
--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -16,10 +16,10 @@ import addFormats from 'ajv-formats';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createOrchestrator, CONTROL_PLANE_UNREACHABLE, CONTROL_PLANE_UNREACHABLE_EXIT } from './orchestrator.js';
+import { createOrchestrator, CONTROL_PLANE_UNREACHABLE, CONTROL_PLANE_UNREACHABLE_EXIT, type MeetingResult } from './orchestrator.js';
 import { createLivePipeline } from './pipeline.js';
-import { canTransition, type BotStatus, type LifecycleEvent, type TranscriptSegment } from './contracts.js';
-import type { JoinDriver, JoinOutcome, LifecycleSink, TranscriptSink, PrimaryReachability } from './ports.js';
+import { canTransition, type Act, type BotStatus, type LifecycleEvent, type TranscriptSegment } from './contracts.js';
+import type { ActsSource, JoinDriver, JoinOutcome, LifecycleSink, TranscriptSink, PrimaryReachability } from './ports.js';
 import type { Invocation } from './config.js';
 import { noopAloneness, controlledAloneness, noopPipeline, noopActs } from './test-doubles.js';
 
@@ -280,6 +280,38 @@ async function main(): Promise<void> {
     check('withdraw: terminal failed(awaiting_admission / stopped), exit 0', res.status === 'failed' && res.exitCode === 0 && last(lc.events).failure_stage === 'awaiting_admission' && last(lc.events).completion_reason === 'stopped', JSON.stringify(last(lc.events)));
     check('withdraw: sequence legal + conforms', allLegal(seq(lc.events)) && allConform(lc.events), ajv.errorsText(validateLifecycle.errors));
     check('withdraw: did NOT SIGKILL-orphan — the run resolved on its own (no watchdog needed)', true);
+  }
+
+  // ── #889: a `leave` ACT delivered while BLOCKED in the lobby (awaiting_admission) → WITHDRAW ──
+  // The canonical user Stop is a `leave` command on the bot's command channel (meeting-api's stop.py
+  // publishes `bot_commands:meeting:{id}` `{action:leave}`). The orchestrator used to subscribe to
+  // acts only AFTER admission, so a `leave` arriving while the bot was still knocking in the lobby was
+  // never heard (redis pub/sub has no backlog) — and handle()'s `leave` routed to the ACTIVE-phase end
+  // (signalEnd), not the pre-active abort. Net: the bot kept "asking to join" after Stop (#889). This
+  // asserts (a) the acts subscription is live DURING the lobby and (b) a lobby `leave` withdraws.
+  {
+    const lc = recordingSink();
+    const { driver, calls } = lobbyBlockingJoin();
+    let fireLeave: (a: Act) => void = () => {};
+    let subscribed = false;
+    const acts: ActsSource = {
+      subscribe(handler) { subscribed = true; fireLeave = (a) => void handler(a); return () => { /* */ }; },
+    };
+    const o = createOrchestrator(inv(), { lifecycle: lc, join: driver, pipeline: noopPipeline(), acts, aloneness: noopAloneness() });
+    const runP = o.run();
+    await new Promise((r) => setTimeout(r, 10));   // let the machine reach awaiting_admission + subscribe
+    check('#889: acts subscribed DURING the lobby (before admission)', subscribed, `subscribed=${subscribed}`);
+    fireLeave({ action: 'leave' });
+    // Bound the wait: with the bug the run never resolves (the leave is dropped) — the sentinel proves it.
+    const res = await Promise.race<MeetingResult>([
+      runP,
+      new Promise<MeetingResult>((r) => setTimeout(() => r({ exitCode: -1, status: 'joining' as BotStatus }), 500)),
+    ]);
+    check('#889: lobby leave act → withdraw invoked exactly once', calls.withdraw === 1, `withdraw=${calls.withdraw}`);
+    check('#889: withdraw reason forwarded (stopped)', calls.withdrawReason === 'stopped', calls.withdrawReason);
+    check('#889: terminal failed(awaiting_admission / stopped), exit 0', res.status === 'failed' && res.exitCode === 0 && last(lc.events).failure_stage === 'awaiting_admission' && last(lc.events).completion_reason === 'stopped', JSON.stringify(res) + ' / ' + JSON.stringify(last(lc.events)));
+    check('#889: never reached active (withdrew from the lobby)', !seq(lc.events).includes('active'), JSON.stringify(seq(lc.events)));
+    check('#889: sequence legal + conforms', allLegal(seq(lc.events)) && allConform(lc.events), ajv.errorsText(validateLifecycle.errors));
   }
 
   // ── Bug 2 (invariant): stop() while ACTIVE still uses the existing active-leave path, NOT withdraw ──

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -154,10 +154,14 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
   let signalAbort: ((r: CompletionReason) => void) | null = null;
   const aborted = new Promise<CompletionReason>((res) => { signalAbort = res; });
 
-  // acts.v1 dispatch. `leave` ends the run; reconfigure + voice acts are handled by the
-  // live pipeline adapter (no-op for the machine; voice agent is DEFERRED this increment).
+  // acts.v1 dispatch. A `leave` command routes through `stop()` — the SAME phase-aware decision the
+  // SIGTERM seam uses — so a Stop is honored NO MATTER the phase it arrives in: ACTIVE ⇒ graceful
+  // leave; PRE-ACTIVE (still knocking in the lobby) ⇒ abort the join → WITHDRAW the ask-to-join
+  // request (#889). Routing `leave` straight to `signalEnd` used to only end the ACTIVE phase, so a
+  // lobby `leave` did nothing. reconfigure + voice acts are handled by the live pipeline adapter
+  // (no-op for the machine; voice agent is DEFERRED this increment).
   async function handle(act: Act): Promise<void> {
-    if (act.action === 'leave') signalEnd?.('stopped');
+    if (act.action === 'leave') stop('stopped');
   }
 
   async function run(opts: RunOptions = {}): Promise<MeetingResult> {
@@ -205,6 +209,13 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
       });
       return reportChain;
     };
+    // Subscribe to the command bus BEFORE the join race (#889). A user Stop is delivered as a `leave`
+    // command on the bot's channel; when it arrives while the bot is still knocking in the lobby, the
+    // orchestrator must ALREADY be listening (redis pub/sub has no backlog) — handle() then routes it
+    // through stop() → the pre-active abort race → withdraw. Subscribing only AFTER admission (the old
+    // placement) dropped every lobby-phase leave, so a Stop in the waiting room left the bot asking to
+    // join. `unsubscribe()` is called on every exit path (pre-active + active) below.
+    const unsubscribe = deps.acts.subscribe(handle);
     let outcome: JoinOutcome;
     try {
       // Race the (possibly long, lobby-blocked) join against a pre-active abort. A stop/SIGTERM in the
@@ -229,22 +240,25 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
           failure_stage: stage, completion_reason: 'stopped',
           reason: 'stopped while awaiting admission (withdrew the join request)', exit_code: 0,
         });
+        unsubscribe();
         return { exitCode: 0, status: 'failed', completionReason: 'stopped' };
       }
       outcome = raced.outcome;
       await reportChain;   // flush in-flight reports before deciding admission
     } catch (e) {
+      unsubscribe();
       await emit('failed', { failure_stage: 'joining', completion_reason: 'join_failure', reason: String(e), exit_code: 1 });
       return { exitCode: 1, status: 'failed', completionReason: 'join_failure' };
     }
     if (outcome !== 'admitted') {
       const reason = OUTCOME_FAIL[outcome];
+      unsubscribe();
       await emit('failed', { failure_stage: 'awaiting_admission', completion_reason: reason, exit_code: 1 });
       return { exitCode: 1, status: 'failed', completionReason: reason };
     }
     if (cur !== 'active') await emit('active');   // the join driver may already have reported active
 
-    // ── active: start the engine, wire removal + acts + the optional time cap ──
+    // ── active: start the engine, wire removal + aloneness + the optional time cap (acts already subscribed) ──
     try {
       await deps.pipeline.start();
     } catch (e) {
@@ -252,12 +266,12 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
       // strand a ghost participant. Best-effort; never masks the failure.
       deps.recording?.close(recordingKey);
       await deps.join.leave('pipeline_start_failed').catch(() => { /* best-effort */ });
+      unsubscribe();
       await emit('failed', { failure_stage: 'active', completion_reason: 'join_failure', reason: String(e), exit_code: 1 });
       return { exitCode: 1, status: 'failed', completionReason: 'join_failure' };
     }
     const stopRemoval = deps.join.onRemoval(() => signalEnd?.('evicted'));
     const stopAloneness = deps.aloneness.onAlone(() => signalEnd?.('left_alone'));
-    const unsubscribe = deps.acts.subscribe(handle);
     const cap = opts.maxActiveMs && opts.maxActiveMs > 0
       ? setTimeout(() => signalEnd?.('max_bot_time_exceeded'), opts.maxActiveMs)
       : null;

--- a/core/meetings/services/bot/src/stress.test.ts
+++ b/core/meetings/services/bot/src/stress.test.ts
@@ -9,7 +9,7 @@
  * Run: npx tsx src/stress.test.ts
  */
 import { createOrchestrator } from './orchestrator.js';
-import { canTransition, type BotStatus, type LifecycleEvent } from './contracts.js';
+import { canTransition, type Act, type BotStatus, type LifecycleEvent } from './contracts.js';
 import type { JoinDriver, JoinOutcome, Pipeline, LifecycleSink, ActsSource } from './ports.js';
 import type { Invocation } from './config.js';
 import { noopAloneness, noopPipeline, noopActs } from './test-doubles.js';
@@ -30,11 +30,14 @@ const sink = (): LifecycleSink & { readonly events: LifecycleEvent[] } => {
   const events: LifecycleEvent[] = [];
   return { events, async emit(e: LifecycleEvent) { events.push(e); } };
 };
-// The orchestrator subscribes to acts AFTER it reaches active — so an acts source that fires on
-// subscribe delivers its acts during the active phase (when the handler is wired). `nLeaves` floods.
-const leavesOnSubscribe = (n: number): ActsSource => ({
-  subscribe(handler) { for (let i = 0; i < n; i++) void handler({ action: 'leave' }); return () => { /* */ }; },
-});
+// The orchestrator subscribes to acts DURING the lobby now (before admission, #889), so acts can
+// arrive in ANY phase. This double CAPTURES the handler and lets the driver fire a flood at a chosen
+// phase (from inside join(), after it has reported the phase it wants to stress).
+const capturingActs = () => {
+  let handler: (a: Act) => void = () => { /* */ };
+  const acts: ActsSource = { subscribe(h) { handler = (a) => void h(a); return () => { /* */ }; } };
+  return { acts, flood: (n: number) => { for (let i = 0; i < n; i++) handler({ action: 'leave' }); } };
+};
 const noActs = noopActs();
 const noAloneness = noopAloneness();
 
@@ -45,26 +48,57 @@ const allLegal = (e: LifecycleEvent[]) =>
 async function main(): Promise<void> {
   console.log('\n=== bot orchestrator stress (shake) ===');
 
-  // ── (1) act flood: 200 concurrent `leave` acts → exactly ONE clean terminal ──
+  // ── (1) ACTIVE-phase act flood: 200 concurrent `leave` acts after admission → ONE clean completed ──
   {
     const lc = sink();
-    const o = createOrchestrator(inv(), {
-      lifecycle: lc, join: mockJoin('admitted'), pipeline: noopPipeline(), acts: leavesOnSubscribe(200), aloneness: noAloneness,
-    });
-    const res = await o.run();  // 200 leave acts flood in on subscribe (during active)
+    const { acts, flood } = capturingActs();
+    const join: JoinDriver = {
+      async join(report) { await report('awaiting_admission'); await report('active'); flood(200); return 'admitted' as JoinOutcome; },
+      onRemoval() { return () => { /* */ }; },
+      async leave() { /* */ },
+      async withdraw() { /* */ },
+    };
+    const o = createOrchestrator(inv(), { lifecycle: lc, join, pipeline: noopPipeline(), acts, aloneness: noAloneness });
+    const res = await o.run();  // 200 leave acts flood in during the active phase
     check('act-flood: completed(stopped)', res.status === 'completed' && res.completionReason === 'stopped');
     check('act-flood: EXACTLY one terminal (no double-terminal under 200 leaves)', terminals(lc.events).length === 1,
       `got ${terminals(lc.events).length}`);
     check('act-flood: every event legal', allLegal(lc.events));
   }
 
+  // ── (1b) LOBBY-phase act flood (#889): 200 `leave` acts while still knocking → ONE clean WITHDRAW ──
+  // The lobby `leave` (meeting-api's stop command) now aborts the join under load: the first leave
+  // withdraws (once — the abort resolver is one-shot), the other 199 are no-ops, and the bot terminates
+  // failed(awaiting_admission / stopped) with EXACTLY one terminal. No double-withdraw, no hang.
+  {
+    const lc = sink();
+    const { acts, flood } = capturingActs();
+    let withdrew = 0;
+    const lobbyJoin: JoinDriver = {
+      // Reach the lobby, flood, then block (the real lobby never resolves on its own) — the flood aborts it.
+      async join(report) { await report('awaiting_admission'); flood(200); return new Promise<JoinOutcome>(() => { /* never */ }); },
+      onRemoval() { return () => { /* */ }; },
+      async leave() { /* */ },
+      async withdraw() { withdrew++; },
+    };
+    const o = createOrchestrator(inv(), { lifecycle: lc, join: lobbyJoin, pipeline: noopPipeline(), acts, aloneness: noAloneness });
+    const res = await o.run();
+    check('lobby-flood: failed(stopped) via withdraw', res.status === 'failed' && res.completionReason === 'stopped');
+    check('lobby-flood: withdraw invoked EXACTLY once (200 leaves are idempotent)', withdrew === 1, `withdrew=${withdrew}`);
+    check('lobby-flood: exactly one terminal', terminals(lc.events).length === 1, `got ${terminals(lc.events).length}`);
+    check('lobby-flood: never reached active', !lc.events.some((e) => e.status === 'active'));
+    check('lobby-flood: every event legal', allLegal(lc.events));
+  }
+
   // ── (2) report flood: 500 rapid status reports serialise and still reach active → completed ──
   {
     const lc = sink();
+    const { acts, flood } = capturingActs();
     const floodJoin: JoinDriver = {
       async join(report) {
         for (let i = 0; i < 500; i++) void report('awaiting_admission');  // fire-and-forget flood
         await report('active');
+        flood(1);   // one leave AFTER active ends the run so we can assert it reached active + completed
         return 'admitted' as JoinOutcome;
       },
       onRemoval() { return () => { /* */ }; },
@@ -72,7 +106,7 @@ async function main(): Promise<void> {
       async withdraw() { /* */ },
     };
     const o = createOrchestrator(inv(), {
-      lifecycle: lc, join: floodJoin, pipeline: noopPipeline(), acts: leavesOnSubscribe(1), aloneness: noAloneness,
+      lifecycle: lc, join: floodJoin, pipeline: noopPipeline(), acts, aloneness: noAloneness,
     });
     const res = await o.run();
     check('report-flood: reached a clean completed', res.status === 'completed');
@@ -104,15 +138,6 @@ async function main(): Promise<void> {
     ? '\n✅ bot orchestrator stress: floods + failure-under-load stay legal, single-terminal, no ghost'
     : `\n❌ ${failed} stress check(s) failed`);
   if (failed > 0) process.exit(1);
-}
-
-function mockJoin(outcome: JoinOutcome): JoinDriver {
-  return {
-    async join(report) { await report('awaiting_admission'); if (outcome === 'admitted') await report('active'); return outcome; },
-    onRemoval() { return () => { /* */ }; },
-    async leave() { /* */ },
-    async withdraw() { /* */ },
-  };
 }
 
 void main();

--- a/docs/changelog.d/889-gmeet-stop-awaiting-admission.md
+++ b/docs/changelog.d/889-gmeet-stop-awaiting-admission.md
@@ -1,0 +1,8 @@
+- **Google Meet: Stop now leaves the lobby while the bot is still `awaiting_admission` (#889).** A
+  Stop issued while a bot was knocking in the waiting room (never admitted) did not withdraw it — the
+  bot kept showing as a pending "asking to join" attendee. The stop is delivered as a `leave` command
+  on the bot's channel, but the orchestrator subscribed to that channel only *after* admission, so a
+  lobby-phase `leave` was dropped (Redis pub/sub has no backlog) and `handle()` routed `leave` to the
+  active-phase end rather than the pre-active abort. The orchestrator now subscribes before the join
+  race and routes a `leave` through the same phase-aware stop path, so a Stop during
+  `awaiting_admission` cancels the join request and closes the lobby tab.


### PR DESCRIPTION
Closes #889

## What & why

A Stop issued while a Google Meet bot was still knocking in the waiting room (`awaiting_admission`, never admitted) did **not** withdraw it — the bot stayed a pending "asking to join" attendee in the meeting.

### Root cause (verified against the current tree — code has moved since the issue was filed)

The issue's line references (`join-driver.ts:94-114`, `orchestrator.ts:116-200/226/268`) predate a 0.12 refactor; the mechanism is the same and its two halves are now:

1. **The withdraw path is present and correct.** `orchestrator.stop()` (`orchestrator.ts:298-310`) is phase-aware: pre-active ⇒ `signalAbort` ⇒ `run()` races the lobby-blocked join against the abort and calls `deps.join.withdraw('stopped')`, which for gmeet clicks Cancel and **closes the lobby tab** (`join-driver.ts:97-117`). SIGTERM is wired to `stop()` (`index.ts:291` → `signals.ts`).

2. **But a `leave` command delivered in the lobby never reached the machine.** The canonical user Stop is a `leave` command on `bot_commands:meeting:{id}`, published by meeting-api's stop path (`lifecycle/stop.py:54-69`, `lifecycle/stop_router.py:129-146`). The orchestrator subscribed to that channel **only after admission** (old `orchestrator.ts:260`), and the redis subscriber establishes its SUBSCRIBE lazily on `.subscribe()` (`adapters/acts-redis.ts:57`) — redis pub/sub has no backlog, so a `leave` published while the bot was still in the lobby was dropped. And `handle()` routed `leave` straight to `signalEnd` (the **active-phase** end), not the pre-active abort. Net: a lobby `leave` did nothing.

The only backstop in the hosted flow was `stop_router.py`'s best-effort `runtime.delete_workload()` (SIGTERM) for booting statuses — not guaranteed (depends on `bot_container_id`, runtime wiring, and SIGTERM→node forwarding). When it didn't reach the pod, the bot kept knocking. **Pre-existing, not a v0.12.16 regression** (confirmed by the reporter).

### Fix — at the point of introduction (the orchestrator's acts consumption)

- **Subscribe to the command bus BEFORE the join race**, so a lobby `leave` is heard; `unsubscribe()` on every exit path.
- **Route `handle()`'s `leave` through the same phase-aware `stop()`** the SIGTERM seam uses: ACTIVE ⇒ graceful leave; PRE-ACTIVE ⇒ abort the join ⇒ withdraw.

No contract/schema/dependency changes. Files: `core/meetings/services/bot/src/orchestrator.ts` (+ `orchestrator.test.ts`, `stress.test.ts`).

## Observation bundle (raw evidence)

**L2 orchestrator unit test — RED before, GREEN after** (`orchestrator.test.ts`, new `#889` case: a `leave` act delivered while blocked in the lobby):

RED (source change reverted):
```
❌ #889: acts subscribed DURING the lobby (before admission)  — subscribed=false
❌ #889: lobby leave act → withdraw invoked exactly once  — withdraw=0
❌ #889: withdraw reason forwarded (stopped)  —
❌ #889: terminal failed(awaiting_admission / stopped), exit 0  — {"exitCode":-1,"status":"joining"} / last event = awaiting_admission (run hung; sentinel returned)
❌ orchestrator (L2): 4 check(s) FAILED.
```

GREEN (with fix):
```
✅ #889: acts subscribed DURING the lobby (before admission)
✅ #889: lobby leave act → withdraw invoked exactly once
✅ #889: withdraw reason forwarded (stopped)
✅ #889: terminal failed(awaiting_admission / stopped), exit 0
✅ #889: never reached active (withdrew from the lobby)
✅ #889: sequence legal + conforms
```

**Full bot suite green** (`npm test` in `core/meetings/services/bot`, exit 0) — including the reworked stress suite (the old `leavesOnSubscribe` premise "acts subscribe after active" is exactly what changed; it now fires floods at a chosen phase, and gains a lobby-flood case):
```
✅ act-flood: completed(stopped)                 (active-phase flood → one clean completed)
✅ lobby-flood: failed(stopped) via withdraw     (NEW: 200 lobby leaves → withdraw once)
✅ lobby-flood: withdraw invoked EXACTLY once (200 leaves are idempotent)
✅ report-flood: reached a clean completed / did reach active
✅ bot orchestrator stress: floods + failure-under-load stay legal, single-terminal, no ghost
```

**Gates:** `node scripts/gates.mjs all` — all green. `gate:compose` first hit the known buildkit snapshot-cache-corruption flake (`failed to prepare extraction snapshot … parent snapshot … does not exist`, aggravated by a concurrent full-gate run in a parallel worktree sharing the buildkit); after `docker builder prune -f` it re-ran green solo:
```
✓ gate:node — 18 package(s) · build + test green
✓ gate:compose — REAL compose stack proven bot-ready (health·auth·transcript·recording·control-plane)
```

## What I did NOT check (honesty)

- **No live gmeet leg.** Proven at L2 only (offline, every port faked). The live "bot in a real Meet lobby → hit Stop → bot leaves the lobby" witness is **still wanted before ship** — flagging, not claiming it. The withdraw mechanism itself (cancel-click + page-close) is unchanged and was already the SIGTERM path; what this PR changes is that the **acts `leave`** now also reaches it.
- I did not exercise the meeting-api → redis → bot wire end-to-end (a real `leave` command arriving over redis while the bot sits in the lobby); the fix is at the bot's consumption seam and is unit-proven there.
- I did not touch the `runtime.delete_workload()` backstop in `stop_router.py` — it remains as a secondary guarantee.

Ignore the spurious `merge-card` check.
