### PR TITLE
fix(bot/teams): a join redirected to login.microsoftonline.com fails fast with a typed reason, not an admission timeout (#915)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -146,5 +146,14 @@ export { AdmissionError } from "./shared/admission";
 export type { AdmissionOutcome } from "./shared/admission";
 export { AuthSessionError } from "./googlemeet/join";
 export { joinMicrosoftTeams, waitForTeamsMeetingAdmission, checkForTeamsAdmissionSilent, prepareForTeamsRecording, leaveMicrosoftTeams, startTeamsRemovalMonitor };
+// The Teams anonymous-join origin guard. A meetup-join redirected to the Microsoft sign-in host
+// terminates the join THERE with `TeamsJoinRedirectError` — deliberately not an AdmissionError, so
+// the orchestrator's join catch carries its `reasonCode` into the terminal event's reason text
+// instead of the sealed enum flattening it into a nameless admission timeout. See auth-redirect.ts.
+export {
+  TeamsJoinRedirectError, TEAMS_AUTH_REDIRECT, TEAMS_OFF_MEETING_ORIGIN,
+  isMicrosoftLoginUrl, isTeamsMeetingUrl,
+} from "./msteams/auth-redirect";
+export type { TeamsJoinRedirectReason } from "./msteams/auth-redirect";
 export { joinZoomMeeting, buildZoomWebClientUrl, waitForZoomMeetingAdmission, checkForZoomAdmissionSilent, leaveZoomMeeting, dismissZoomPopups, startZoomRemovalMonitor };
 export { joinJitsiMeeting, buildJitsiMeetingUrl, waitForJitsiMeetingAdmission, checkForJitsiAdmissionSilent, leaveJitsiMeeting, startJitsiRemovalMonitor };

--- a/core/meetings/modules/join/src/msteams/README.md
+++ b/core/meetings/modules/join/src/msteams/README.md
@@ -1,5 +1,7 @@
 # join/src/msteams — Microsoft Teams join flow
 
 Enter a Teams meeting (teams.microsoft.com / teams.live.com) and resolve admission.
-`join.ts`, `admission.ts` (roster/lobby oracle), `leave.ts`, `removal.ts`, `selectors.ts`.
+`join.ts`, `admission.ts` (roster/lobby oracle), `leave.ts`, `removal.ts`, `selectors.ts`,
+`auth-redirect.ts` (origin guard: a meetup-join bounced to the Microsoft sign-in host is a typed
+terminal, never an admission timeout).
 Imports host symbols from `../_host`, `playwright`, and Node builtins only.

--- a/core/meetings/modules/join/src/msteams/auth-redirect.test.ts
+++ b/core/meetings/modules/join/src/msteams/auth-redirect.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Regression guard for the Teams anonymous-join sign-in redirect (Vexa-ai/vexa#915).
+ *
+ * Prod v0.12.16, three bots inside an hour: the meetup-join navigation landed on
+ * `login.microsoftonline.com/common/oauth2/v2.0/authorize`, and the join flow then spent ~75s
+ * pantomiming a join against a sign-in page — "Continue button not found, continuing…",
+ * "Camera button not found", "Display name input not found", "Join button not found", and a
+ * mic-mute keystroke that "succeeded" — before the admission wait reported
+ * `Bot was not admitted into the Teams meeting within the timeout period`. A host-admission
+ * timeout for what was an authentication redirect: the host was never asked.
+ *
+ * Fix (at the point of introduction, join.ts + auth-redirect.ts): the join asserts it is on the
+ * meeting before it drives the pre-join, and a sign-in URL is a typed terminal
+ * (`TeamsJoinRedirectError`, reasonCode `teams_auth_redirect`) carrying the redacted URL.
+ *
+ * Fabricated-DOM/URL test in the same style as msteams/removal.test.ts — no browser, no live
+ * meeting. A VIRTUAL clock (Date.now + the mock page's waitForTimeout) makes the 45s pre-join
+ * wait free, so "how long would this have burned" is an assertable number.
+ *
+ * Run: npx tsx src/msteams/auth-redirect.test.ts
+ */
+
+import {
+  TeamsJoinRedirectError,
+  TEAMS_AUTH_REDIRECT,
+  TEAMS_OFF_MEETING_ORIGIN,
+  isMicrosoftLoginUrl,
+  isTeamsMeetingUrl,
+  redactUrl,
+} from './auth-redirect';
+import { joinMicrosoftTeams } from './join';
+
+// ── virtual clock: the join flow measures elapsed with Date.now() and sleeps with
+//    page.waitForTimeout(), so driving both from one counter runs 45s of waiting instantly.
+let vnow = 1_000_000;
+const realDateNow = Date.now;
+(Date as any).now = () => vnow;
+
+// ── log capture (the join layer logs single-line JSON through console.log) ──
+let captured: string[] = [];
+const realConsoleLog = console.log;
+function startCapture() {
+  captured = [];
+  console.log = (...a: any[]) => {
+    const s = a.map(String).join(' ');
+    try { captured.push(JSON.parse(s).msg ?? s); } catch { captured.push(s); }
+  };
+}
+function stopCapture(): string[] { console.log = realConsoleLog; return captured; }
+
+/**
+ * Minimal Playwright-Page stand-in. `url` is what page.url() reports (optionally a sequence:
+ * the Nth entry is returned from the Nth call onward, modelling a redirect that lands mid-wait).
+ * `visible` are substrings; a locator is visible when its selector contains one of them.
+ */
+function mockPage(url: string | string[], visible: string[] = []): any {
+  const urls = Array.isArray(url) ? url : [url];
+  let urlCalls = 0;
+  const node = (sel: string): any => ({
+    first: () => node(sel),
+    isVisible: async () => visible.some((v) => sel.includes(v)),
+    waitFor: async () => { throw new Error(`timeout waiting for ${sel}`); },
+    click: async () => { throw new Error(`no element for ${sel}`); },
+    fill: async () => { throw new Error(`no element for ${sel}`); },
+    getAttribute: async () => null,
+  });
+  return {
+    url: () => urls[Math.min(urlCalls++, urls.length - 1)],
+    goto: async () => {},
+    waitForTimeout: async (ms: number) => { vnow += ms; },
+    locator: node,
+    evaluate: async () => 'media warm-up success (tracks=0)',
+    keyboard: { press: async () => {} },
+    isClosed: () => false,
+  };
+}
+
+const BOT_CONFIG = { platform: 'teams', botName: 'Vexa Bot' } as any;
+
+/** The prod URL from #915 (query redacted here as it is in the log). */
+const LOGIN_URL =
+  'https://login.microsoftonline.com/common/oauth2/v2.0/authorize' +
+  '?client_id=5e3ce6c0-REDACTED&redirect_uri=https%3A%2F%2Fteams.microsoft.com%2Fv2%2Fauthv2' +
+  '&response_type=code&code_challenge_method=S256';
+
+const MEETUP_JOIN_URL =
+  'https://teams.microsoft.com/l/meetup-join/19%3ameeting_REDACTED%40thread.v2/0?context=%7b%7d';
+
+/** Drive joinMicrosoftTeams on a fabricated page; report what it threw and the virtual cost. */
+async function driveJoin(page: any, meetingUrl: string) {
+  const t0 = vnow;
+  startCapture();
+  let error: any = null;
+  try {
+    await joinMicrosoftTeams(page, meetingUrl, 'Vexa Bot', BOT_CONFIG);
+  } catch (e) { error = e; }
+  const logs = stopCapture();
+  return { error, elapsedMs: vnow - t0, logs };
+}
+
+let passed = 0, failed = 0;
+function check(name: string, actual: boolean, expected: boolean) {
+  if (actual === expected) { realConsoleLog(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { realConsoleLog(`  \x1b[31mFAIL\x1b[0m  ${name} (expected ${expected}, got ${actual})`); failed++; }
+}
+
+/** The five steps the flow used to run against a sign-in page. */
+const PANTOMIME = ['Step 3:', 'Step 4:', 'Step 5:', 'Step 6:', 'Step 6b:'];
+
+(async () => {
+  realConsoleLog('\n=== Teams anonymous join redirected to the Microsoft sign-in page (#915) ===');
+
+  // ── 1. URL classification (the point of introduction) ──────────────────────
+  check('prod OAuth authorize URL → isMicrosoftLoginUrl', isMicrosoftLoginUrl(LOGIN_URL), true);
+  for (const u of [
+    'https://login.microsoftonline.us/common/oauth2/v2.0/authorize',
+    'https://login.live.com/oauth20_authorize.srf',
+    'https://login.microsoft.com/common/',
+    'https://login.windows.net/common/oauth2/authorize',
+  ]) check(`sign-in host → isMicrosoftLoginUrl: ${new URL(u).hostname}`, isMicrosoftLoginUrl(u), true);
+
+  for (const u of [MEETUP_JOIN_URL, 'https://teams.live.com/meet/REDACTED', 'https://teams.cloud.microsoft/v2/']) {
+    check(`Teams host is NOT a sign-in host: ${new URL(u).hostname}`, isMicrosoftLoginUrl(u), false);
+    check(`Teams host → isTeamsMeetingUrl: ${new URL(u).hostname}`, isTeamsMeetingUrl(u), true);
+  }
+  check('garbage url → isMicrosoftLoginUrl = false', isMicrosoftLoginUrl('not a url'), false);
+
+  // The tenant/client ids and the meetup-join payload in redirect_uri are customer data; the
+  // reported URL keeps origin+path and drops the query.
+  check(
+    'reported URL drops the query string',
+    redactUrl(LOGIN_URL) === 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+    true,
+  );
+
+  // ── 2. The reported failure: sign-in redirect present at first URL read ────
+  {
+    const { error, elapsedMs, logs } = await driveJoin(mockPage(LOGIN_URL), MEETUP_JOIN_URL);
+    check(
+      'sign-in redirect → throws TeamsJoinRedirectError',
+      error instanceof TeamsJoinRedirectError, true,
+    );
+    check(
+      `typed reason is "${TEAMS_AUTH_REDIRECT}"`,
+      error?.reasonCode === TEAMS_AUTH_REDIRECT, true,
+    );
+    check(
+      'the reason text is NOT an admission/pre-join timeout',
+      /admission|pre-join readiness|timeout period/i.test(String(error?.message ?? '')), false,
+    );
+    check(
+      'the reason text names the sign-in page it landed on',
+      String(error?.message ?? '').includes('login.microsoftonline.com'), true,
+    );
+    check('the reason text carries no query string', String(error?.message ?? '').includes('client_id'), false);
+    // The RED cost was 45 700ms here (plus 30 000ms of admission polling after it).
+    check(`fails fast: ${elapsedMs}ms << 45000ms pre-join wait`, elapsedMs < 5000, true);
+    check(
+      'never logs the misleading "pre-join readiness" timeout',
+      logs.some((l) => l.includes('pre-join readiness')), false,
+    );
+    for (const step of PANTOMIME) {
+      check(`no pantomime against the sign-in page: ${step}`, logs.some((l) => l.startsWith(step)), false);
+    }
+  }
+
+  // ── 3. The redirect lands MID-WAIT (client-side nav after the pre-join wait began) ──
+  {
+    // Teams host for the first two reads, then bounced to sign-in.
+    const page = mockPage([MEETUP_JOIN_URL, MEETUP_JOIN_URL, LOGIN_URL]);
+    const { error, elapsedMs } = await driveJoin(page, MEETUP_JOIN_URL);
+    check(
+      'redirect during the pre-join wait → still typed teams_auth_redirect',
+      error instanceof TeamsJoinRedirectError && error.reasonCode === TEAMS_AUTH_REDIRECT, true,
+    );
+    check(`mid-wait redirect fails fast too: ${elapsedMs}ms`, elapsedMs < 5000, true);
+  }
+
+  // ── 4. Negative control: a real anonymous pre-join screen still joins ──────
+  {
+    const page = mockPage(MEETUP_JOIN_URL, ['Join now']);
+    const { error, logs } = await driveJoin(page, MEETUP_JOIN_URL);
+    check('healthy pre-join → no throw', error === null, true);
+    check('healthy pre-join → readiness reached', logs.some((l) => l.includes('pre-join controls are ready')), true);
+    check('healthy pre-join → the flow still runs its steps', logs.some((l) => l.startsWith('Step 6:')), true);
+  }
+
+  // ── 5. Negative control: a SLOW pre-join on the meeting host stays advisory ──
+  //     (no over-correction — a Teams page that is merely late is not a redirect)
+  {
+    const page = mockPage(MEETUP_JOIN_URL);
+    const { error, logs, elapsedMs } = await driveJoin(page, MEETUP_JOIN_URL);
+    check('slow pre-join ON the Teams host → no throw', error === null, true);
+    check(
+      'slow pre-join → the advisory readiness timeout still logs',
+      logs.some((l) => l.includes('pre-join readiness')), true,
+    );
+    check(`slow pre-join → the full wait is still spent: ${elapsedMs}ms`, elapsedMs > 45000, true);
+  }
+
+  // ── 6. Any other non-meeting origin is terminal too, and says which ────────
+  {
+    const page = mockPage('https://www.microsoft.com/en-us/microsoft-teams/download-app');
+    const { error } = await driveJoin(page, MEETUP_JOIN_URL);
+    check(
+      'non-Teams, non-sign-in origin → teams_off_meeting_origin',
+      error instanceof TeamsJoinRedirectError && error.reasonCode === TEAMS_OFF_MEETING_ORIGIN, true,
+    );
+  }
+
+  // ── 7. An embedder-supplied host we were POINTED at stays advisory ─────────
+  //     (a vanity/white-label Teams entry point is not a redirect — we are where we asked to be)
+  {
+    const vanity = 'https://meet.contoso.example/join/REDACTED';
+    const page = mockPage(vanity);
+    const { error } = await driveJoin(page, vanity);
+    check('still on the requested host → no throw', error === null, true);
+  }
+
+  (Date as any).now = realDateNow;
+  realConsoleLog(`\n  ${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+})();

--- a/core/meetings/modules/join/src/msteams/auth-redirect.ts
+++ b/core/meetings/modules/join/src/msteams/auth-redirect.ts
@@ -1,0 +1,145 @@
+/**
+ * The Teams anonymous-join origin guard.
+ *
+ * The bot joins Teams ANONYMOUSLY by design: it navigates a meetup-join link and
+ * expects the anonymous pre-join screen. Teams can instead bounce that navigation to
+ * the Microsoft OAuth sign-in host (`login.microsoftonline.com/common/oauth2/v2.0/authorize`),
+ * where no pre-join, no name input, no "Join now" and no meeting toolbar will EVER exist.
+ *
+ * That condition is detected HERE, at the navigation boundary, and named: a sign-in page is
+ * not a slow pre-join screen, and a bot on a sign-in page was never offered to a host for
+ * admission — so it must never be reported as an admission/pre-join timeout.
+ *
+ * Deliberately NOT an `AdmissionError`: the JoinDriver adapter maps an AdmissionError onto a
+ * bare `JoinOutcome`, and that branch of the orchestrator emits its terminal lifecycle event
+ * with a completion reason but NO reason text — the discriminator would die at the seam. A
+ * plain throw travels the orchestrator's join catch, which stamps `reason: String(e)` onto the
+ * terminal event, so `reasonCode` + the redacted URL reach `last_error` where triage reads them.
+ * Same no-seal-bump idiom as the bot's `control_plane_unreachable` tag: an existing
+ * `CompletionReason` (`join_failure`, transient) carrying a discriminating reason text.
+ */
+
+/** Machine-readable discriminator: the navigation landed on a Microsoft sign-in host. */
+export const TEAMS_AUTH_REDIRECT = "teams_auth_redirect";
+
+/** Machine-readable discriminator: the pre-join never rendered and the page is on neither the
+ *  requested host nor any Teams host — the flow is pointed at something that is not the meeting. */
+export const TEAMS_OFF_MEETING_ORIGIN = "teams_off_meeting_origin";
+
+export type TeamsJoinRedirectReason =
+  | typeof TEAMS_AUTH_REDIRECT
+  | typeof TEAMS_OFF_MEETING_ORIGIN;
+
+/** Microsoft identity-platform sign-in hosts. An anonymous meetup-join that lands on one of
+ *  these has been handed to OAuth, not to a meeting. */
+const MICROSOFT_LOGIN_HOSTS = [
+  "login.microsoftonline.com",
+  "login.microsoftonline.us",
+  "login.partner.microsoftonline.cn",
+  "login.microsoft.com",
+  "login.live.com",
+  "login.windows.net",
+  "login.microsoftonline.de",
+];
+
+/** Hosts that ARE the Teams web client (world-wide, GCC/DoD, and the cloud.microsoft rename). */
+const TEAMS_HOST_SUFFIXES = [
+  "teams.microsoft.com",
+  "teams.live.com",
+  "teams.microsoft.us",
+  "teams.cloud.microsoft",
+];
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/** True iff `url` is a Microsoft identity sign-in page. */
+export function isMicrosoftLoginUrl(url: string): boolean {
+  const host = hostOf(url);
+  if (!host) return false;
+  return MICROSOFT_LOGIN_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+}
+
+/** True iff `url` is served by the Teams web client. */
+export function isTeamsMeetingUrl(url: string): boolean {
+  const host = hostOf(url);
+  if (!host) return false;
+  return TEAMS_HOST_SUFFIXES.some((h) => host === h || host.endsWith(`.${h}`));
+}
+
+/** The hostname of the meeting link the join was asked to open (null when unparseable). */
+export function meetingOriginHost(meetingUrl: string): string | null {
+  return hostOf(meetingUrl);
+}
+
+/**
+ * `origin + pathname` — the whole diagnostic value with none of the customer data. The sign-in
+ * query string carries tenant/client identifiers and the full meetup-join payload in
+ * `redirect_uri`; logs and `last_error` are read by humans and shipped off-box, so the query is
+ * dropped rather than redacted field-by-field.
+ */
+export function redactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return "(unparseable url)";
+  }
+}
+
+/** The typed terminal for a Teams join that is not on the meeting. */
+export class TeamsJoinRedirectError extends Error {
+  readonly reasonCode: TeamsJoinRedirectReason;
+  /** The redacted page URL the join was standing on when it gave up. */
+  readonly observedUrl: string;
+  constructor(reasonCode: TeamsJoinRedirectReason, observedUrl: string, detail: string) {
+    super(`${reasonCode}: ${detail} (url=${observedUrl})`);
+    this.name = "TeamsJoinRedirectError";
+    this.reasonCode = reasonCode;
+    this.observedUrl = observedUrl;
+  }
+}
+
+/** Build the sign-in-redirect terminal for `currentUrl`. */
+export function authRedirectError(currentUrl: string): TeamsJoinRedirectError {
+  return new TeamsJoinRedirectError(
+    TEAMS_AUTH_REDIRECT,
+    redactUrl(currentUrl),
+    "the anonymous Teams join was redirected to the Microsoft sign-in page; this meeting link " +
+      "offered no anonymous pre-join, so the bot never reached the meeting and no host was " +
+      "ever asked to admit it",
+  );
+}
+
+/** Build the off-meeting-origin terminal for `currentUrl`. */
+export function offMeetingOriginError(currentUrl: string, requestedHost: string | null): TeamsJoinRedirectError {
+  return new TeamsJoinRedirectError(
+    TEAMS_OFF_MEETING_ORIGIN,
+    redactUrl(currentUrl),
+    "the Teams pre-join never rendered and the page is on neither the requested meeting host " +
+      `(${requestedHost ?? "unknown"}) nor any Teams host`,
+  );
+}
+
+/**
+ * The verdict for a page that is not showing a Teams pre-join.
+ *
+ * `null` = keep going (still on a Teams host, or still on the host we were pointed at — a slow
+ * pre-join is a legitimate reason to wait). Anything else is terminal and names why.
+ */
+export function classifyNonMeetingUrl(
+  currentUrl: string,
+  requestedHost: string | null,
+): TeamsJoinRedirectError | null {
+  if (isMicrosoftLoginUrl(currentUrl)) return authRedirectError(currentUrl);
+  if (isTeamsMeetingUrl(currentUrl)) return null;
+  const host = hostOf(currentUrl);
+  if (host && requestedHost && host === requestedHost) return null;
+  if (!host) return null;
+  return offMeetingOriginError(currentUrl, requestedHost);
+}

--- a/core/meetings/modules/join/src/msteams/join.ts
+++ b/core/meetings/modules/join/src/msteams/join.ts
@@ -14,6 +14,12 @@ import {
   teamsSpeakerDisableSelectors
 } from "./selectors";
 import { dismissTeamsAvConfirmModal, isTeamsAvConfirmModalVisible } from "./modals";
+import {
+  authRedirectError,
+  classifyNonMeetingUrl,
+  isMicrosoftLoginUrl,
+  meetingOriginHost,
+} from "./auth-redirect";
 
 // NOTE vs the monolith: the WebRTC remote-audio hook and the voice-agent
 // virtual-camera flow are RECORDING/HOST concerns and stay outside this brick.
@@ -41,13 +47,32 @@ async function warmUpTeamsMediaDevices(page: Page): Promise<void> {
   }
 }
 
-async function waitForTeamsPreJoinReadiness(page: Page, timeoutMs: number): Promise<boolean> {
+/**
+ * Wait for the anonymous pre-join screen.
+ *
+ * The loop watches the URL as well as the DOM: Teams can bounce the meetup-join to the Microsoft
+ * sign-in host at any point (it is a client-side navigation, so it happens mid-wait as readily as
+ * before the first tick). A sign-in page is terminal on sight — waiting out the timeout there
+ * buys nothing but a misleading "pre-join readiness" verdict on a page that has no pre-join.
+ *
+ * `requestedHost` is the host of the meeting link we were asked to open. A readiness timeout is
+ * terminal when the page ended up on neither that host nor a Teams host — there is no pre-join to
+ * be slow. Timing out ON one of those hosts stays advisory: a genuinely slow Teams pre-join is a
+ * thing, and the later steps still get their chance at it.
+ */
+async function waitForTeamsPreJoinReadiness(
+  page: Page,
+  timeoutMs: number,
+  requestedHost: string | null,
+): Promise<boolean> {
   const start = Date.now();
   let mediaWarmupAttempted = false;
   let continueClickAttempts = 0;
   let continueWithoutMediaClickAttempts = 0;
 
   while (Date.now() - start < timeoutMs) {
+    if (isMicrosoftLoginUrl(page.url())) throw authRedirectError(page.url());
+
     // v0.10.5 — "Continue without audio or video" confirmation modal.
     // Teams renders this BEFORE the prejoin name input when Chromium's
     // media-permission state is "denied". The modal is intermittent
@@ -126,6 +151,8 @@ async function waitForTeamsPreJoinReadiness(page: Page, timeoutMs: number): Prom
   }
 
   const finalUrl = page.url();
+  const offMeeting = classifyNonMeetingUrl(finalUrl, requestedHost);
+  if (offMeeting) throw offMeeting;
   log(`⚠️ Timed out waiting for Teams pre-join readiness after ${timeoutMs}ms (url=${finalUrl})`);
   return false;
 }
@@ -145,6 +172,12 @@ export async function joinMicrosoftTeams(
   await callJoiningCallback(botConfig);
   log("Joining callback sent successfully");
 
+  // Step 1b: the navigation landed somewhere. If that somewhere is the Microsoft sign-in host,
+  // stop here — every step below hunts for pre-join controls that a sign-in page does not have,
+  // and each one of them "succeeds" quietly by continuing.
+  if (isMicrosoftLoginUrl(page.url())) throw authRedirectError(page.url());
+  const requestedHost = meetingOriginHost(meetingUrl);
+
   log("Step 2: Looking for 'Continue on this browser' button...");
   try {
     const continueButton = page.locator(teamsContinueButtonSelectors[0]).first();
@@ -158,7 +191,7 @@ export async function joinMicrosoftTeams(
   }
 
   log("Step 2.5: Waiting for Teams pre-join controls...");
-  await waitForTeamsPreJoinReadiness(page, 45000);
+  await waitForTeamsPreJoinReadiness(page, 45000, requestedHost);
 
   // NOTE: Steps 3-5 configure the pre-join screen BEFORE clicking "Join now".
   // The pre-join screen shows camera toggle, name input, and audio settings.

--- a/core/meetings/services/bot/src/join-driver.test.ts
+++ b/core/meetings/services/bot/src/join-driver.test.ts
@@ -7,7 +7,7 @@
  *
  * Run: tsx src/join-driver.test.ts
  */
-import { AdmissionError, AuthSessionError } from '@vexa/join';
+import { AdmissionError, AuthSessionError, TeamsJoinRedirectError, TEAMS_AUTH_REDIRECT } from '@vexa/join';
 import { admissionOutcomeToJoinOutcome } from './join-driver.js';
 import type { JoinOutcome } from './ports.js';
 
@@ -45,6 +45,19 @@ const authMapped = admissionOutcomeToJoinOutcome(authErr.outcome);
 check('AuthSessionError.outcome maps to auth_missing', authMapped === 'auth_missing');
 check('a missing auth session is PERMANENT (not a retried join_failure)', PERMANENT_OUTCOMES.has(authMapped));
 check('auth failure does NOT map to the transient/retried classes', authMapped !== 'error' && authMapped !== 'timeout');
+
+// The Teams sign-in-redirect terminal (#915) takes the OTHER branch on purpose: it is NOT an
+// AdmissionError, so the driver re-raises it and the orchestrator's join catch stamps
+// `reason: String(e)` onto the terminal event — the sealed CompletionReason enum has no value for
+// "the anonymous join was handed to OAuth", so the discriminator has to ride the reason text.
+// Mapping it to a JoinOutcome would drop the message at this seam (that branch emits no reason).
+const teamsRedirect = new TeamsJoinRedirectError(
+  TEAMS_AUTH_REDIRECT, 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize', 'redirected',
+);
+check('TeamsJoinRedirectError is NOT an AdmissionError (driver re-raises → message survives)',
+  !(teamsRedirect instanceof AdmissionError));
+check('TeamsJoinRedirectError carries the typed reasonCode in its message',
+  teamsRedirect.message.startsWith(`${TEAMS_AUTH_REDIRECT}:`));
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -115,6 +115,11 @@ async function main(): Promise<void> {
     check('join-error: failed / exit 1', res.status === 'failed' && res.exitCode === 1);
     check('join-error: failure_stage=joining', last(lc.events).failure_stage === 'joining');
     check('join-error: completion_reason=join_failure', last(lc.events).completion_reason === 'join_failure');
+    // The thrown message is the ONLY channel a join-phase cause has to `last_error`: the sealed
+    // CompletionReason enum cannot name platform-specific causes, so a typed brick throw (e.g.
+    // @vexa/join's TeamsJoinRedirectError, #915) carries its discriminator in this text.
+    check('join-error: the thrown reason text reaches the terminal event',
+      String(last(lc.events).reason ?? '').includes('navigation failed'));
     check('join-error: no active emitted', !seq(lc.events).includes('active'));
     check('join-error: events conform', allConform(lc.events));
   }

--- a/docs/changelog.d/915-teams-login-redirect.md
+++ b/docs/changelog.d/915-teams-login-redirect.md
@@ -1,0 +1,8 @@
+- **Teams: a join redirected to the Microsoft sign-in page now fails fast and says so (#915).** When
+  an anonymous Teams join was bounced to `login.microsoftonline.com`, the bot spent ~75s hunting for
+  pre-join controls that a sign-in page does not have and then reported
+  `Bot was not admitted into the Teams meeting within the timeout period` — an admission timeout for
+  a meeting no host was ever asked to admit it to. The join now checks where the navigation actually
+  landed and terminates there with a typed reason, `teams_auth_redirect: … (url=…)`, carried into
+  `last_error`. Failures of this shape are legible in bot logs and the meeting record instead of
+  being bucketed as host behaviour. A pre-join that is merely slow on a Teams host is unchanged.


### PR DESCRIPTION
Closes #915

## What changed

An anonymous Teams join that Teams bounces to `login.microsoftonline.com` is now **detected at the
navigation boundary** and terminated there with its **own typed reason** — instead of being waited
out for ~75s and reported as an admission timeout.

- **Detection points** — `core/meetings/modules/join/src/msteams/join.ts:178` (immediately after the
  navigation + joining callback), `join.ts:74` (every tick of the pre-join wait — the redirect is a
  client-side nav and can land mid-wait), `join.ts:154` (the readiness timeout is terminal when the
  page is on neither the requested host nor a Teams host).
- **The classifier** — new brick-local `core/meetings/modules/join/src/msteams/auth-redirect.ts`:
  `isMicrosoftLoginUrl` / `isTeamsMeetingUrl` / `classifyNonMeetingUrl` + `TeamsJoinRedirectError`.
- **The typed reason** — `teams_auth_redirect: … (url=https://login.microsoftonline.com/common/oauth2/v2.0/authorize)`,
  sibling `teams_off_meeting_origin`. The URL is reported as **origin + path only**: the OAuth query
  carries tenant/client ids and the meetup-join payload in `redirect_uri`, and this string ships to
  logs and `last_error`.
- **No recovery/retry invented.** The issue prescribes none, explicitly records "whether a retry
  would succeed" as unchecked, and the bot joins anonymously by design — so the retry classification
  is unchanged (`join_failure`, transient, exactly what this failure got before). There is no
  credentialed-login flow here.

### Why the error is *not* an `AdmissionError`

The JoinDriver maps an `AdmissionError` onto a bare `JoinOutcome`, and that branch of the
orchestrator emits its terminal event with a completion reason but **no reason text** — the
discriminator would die at the seam. A plain throw travels the orchestrator's join catch, which
stamps `reason: String(e)`, so `teams_auth_redirect` + the URL reach `last_error`. The sealed
`CompletionReason` enum has no value for "the anonymous join was handed to OAuth", so this rides the
same existing-reason + discriminating-text idiom already used for `control_plane_unreachable`.
**No sealed contract, schema, seal, or retry-policy change.**

## Observation bundle

Reproduced with **no live meeting**: a fabricated-DOM/URL harness in the style of
`msteams/removal.test.ts`, with a virtual clock (`Date.now` + the mock page's `waitForTimeout`) so
the 45s pre-join wait is free and "how long would this have burned" is an assertable number.

### O1 — the issue's claims verified against `origin/rc/0.12.18` (RED)

Driving `joinMicrosoftTeams` on a page whose `url()` is the prod OAuth URL from the issue
(`npx tsx` probe, pre-fix tree) reproduces the reported log **verbatim**:

```
virtual elapsed inside joinMicrosoftTeams: 45700ms
threw: NO — resolved normally
  Step 2: Looking for 'Continue on this browser' button...
  ℹ️ Continue button not found, continuing...
  Step 2.5: Waiting for Teams pre-join controls...
  ⚠️ Timed out waiting for Teams pre-join readiness after 45000ms (url=https://login.microsoftonline.com/…)
  Step 3: Camera handling...           ℹ️ Camera button not found or already off
  Step 4: Trying to set display name…  ℹ️ Display name input not found, continuing...
  Step 5: …                            ℹ️ Speaker controls not visible; continuing with defaults.
  Step 6: Clicking 'Join now'…         ⚠️ Join button not found — bot may not be able to enter the meeting
  Step 6b: Muting mic...               ✅ Mic muted via Ctrl+Shift+M
  Step 7: Checking current state...
```

then `waitForTeamsMeetingAdmission` on the same page:

```
admission virtual elapsed: 30000ms
admission threw: Error: Bot was not admitted into the Teams meeting within the timeout period:
                 Bot failed to join the Teams meeting - no meeting indicators found after polling
```

**45 700 + 30 000 = 75 700 ms** and the exact `last_error` string from the issue. Every claim in the
issue body holds on the current tree — nothing stale. **Verdict: confirmed at the altitude claimed.**

### O2 — red → green on the committed test

`core/meetings/modules/join/src/msteams/auth-redirect.test.ts`, run against the **pre-fix** `join.ts`
(same test file, `git checkout -- src/msteams/join.ts`):

```
22 passed, 13 failed
  FAIL  sign-in redirect → throws TeamsJoinRedirectError (expected true, got false)
  FAIL  typed reason is "teams_auth_redirect" (expected true, got false)
  FAIL  the reason text names the sign-in page it landed on (expected true, got false)
  FAIL  fails fast: 45700ms << 45000ms pre-join wait (expected true, got false)
  FAIL  never logs the misleading "pre-join readiness" timeout (expected false, got true)
  FAIL  no pantomime against the sign-in page: Step 3: / Step 4: / Step 5: / Step 6: / Step 6b:
  FAIL  redirect during the pre-join wait → still typed teams_auth_redirect (expected true, got false)
  FAIL  mid-wait redirect fails fast too: 45700ms (expected true, got false)
  FAIL  non-Teams, non-sign-in origin → teams_off_meeting_origin (expected true, got false)
```

with the fix:

```
35 passed, 0 failed
  PASS  sign-in redirect → throws TeamsJoinRedirectError
  PASS  typed reason is "teams_auth_redirect"
  PASS  the reason text is NOT an admission/pre-join timeout
  PASS  the reason text names the sign-in page it landed on
  PASS  the reason text carries no query string
  PASS  fails fast: 500ms << 45000ms pre-join wait
  PASS  never logs the misleading "pre-join readiness" timeout
  PASS  no pantomime against the sign-in page: Step 3: … Step 6b:
  PASS  redirect during the pre-join wait → still typed teams_auth_redirect   (800ms)
```

### O3 — negative controls (no over-correction)

| control | result |
|---|---|
| healthy anonymous pre-join (`Join now` visible on `teams.microsoft.com`) | no throw; readiness reached; Steps 3–6 still run |
| pre-join that never renders **on the Teams host** | no throw; the advisory readiness-timeout line still logs; the full 45 700 ms is still spent (behaviour unchanged) |
| page still on the host the embedder pointed us at (vanity/white-label) | no throw |
| a non-Teams, non-sign-in origin | typed `teams_off_meeting_origin` |
| sign-in host table: `login.microsoftonline.{com,us}`, `login.microsoft.com`, `login.live.com`, `login.windows.net` | detected |
| Teams host table: `teams.microsoft.com`, `teams.live.com`, `teams.cloud.microsoft` | never mistaken for sign-in |
| unparseable URL | `false` — fails open, never a spurious terminal |

### O4 — the reporting seam

New assertions on the bot side prove the reason text actually survives to the lifecycle event:

```
✅ join-error: the thrown reason text reaches the terminal event            (orchestrator.test.ts)
PASS  TeamsJoinRedirectError is NOT an AdmissionError (driver re-raises → message survives)
PASS  TeamsJoinRedirectError carries the typed reasonCode in its message    (join-driver.test.ts)
```

### O5 — suites + gates

```
core/meetings/modules/join    npm test        → exit 0, 0 FAIL (incl. 35/35 new)
core/meetings/modules/join    check:isolation → ✅ 52 files, every import inside the package
core/meetings/services/bot    npm test        → exit 0, 0 FAIL
MOCK_BOT=1 BROWSER_IMAGE=mock-bot:dev node scripts/gates.mjs all → ✅ gates green
  (32 gates; compose-stress / compose-chaos opt-in → skip)
pnpm install --frozen-lockfile && pnpm -r build → clean
```

## What I did NOT check

- **No live Teams leg.** Nothing here was witnessed against a real Teams meeting — the redirect is
  intermittent (3 failures in an hour while a 4th meeting was healthy) and I cannot force it. **A
  live Teams witness remains outstanding** for (a) the URL already being `login.microsoftonline.com`
  at the moment we now read it (the probe asserts the classifier and the control flow, not
  Chromium's navigation timing), and (b) a healthy anonymous join being unaffected. The negative
  controls are fabricated DOM, not a real pre-join screen.
- **Why the redirect happens** is untouched — link type, tenant anonymous-join policy, the
  `[_getUserIdentifier] user missing` page fault. The issue's direction 3, deferred to #501.
- **Whether a retry would succeed** — unknown, so the retry classification is deliberately unchanged.
- **The SLO-breach re-bucketing** (up to 7/47 failures possibly mis-bucketed as "not a defect") is
  not redone here; this change is what makes the next one honest.
- The issue's direction 2 in its **general** form ("a pre-join readiness timeout should be terminal")
  is deliberately **not** taken: on a Teams host a timeout stays advisory, because there is no
  evidence that a slow-but-legitimate pre-join never recovers in the later steps, and making it
  terminal would be an unproven behaviour change. It IS terminal on every **off-meeting** origin,
  which is the observed failure.

## Files touched outside `msteams/**`

- `core/meetings/modules/join/src/index.ts` — export the new error/constants/predicates (front door).
- `core/meetings/modules/join/package.json` — register the new test in the suite.
- `core/meetings/services/bot/src/{orchestrator,join-driver}.test.ts` — **assertions only**, pinning
  the seam this fix depends on. **No bot production code changed.**
- `docs/changelog.d/915-teams-login-redirect.md` — fragment (the `docs-current` touch).

No files under `googlemeet/**` were touched.
