### PR TITLE
fix(gmeet): locate the lobby CTA without knowing the UI language (#846)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/googlemeet/join-cta.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/join-cta.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Google Meet lobby primary-CTA location — the #846 gap and its guard rails.
+ *
+ * THE BUG (#846, prod meetings 24337 / 24339 on v0.12.15, then 3 more on
+ * v0.12.16): the bot reached the Meet lobby, exhausted the full 60s join-button
+ * budget and exited code 1 with 0 segments —
+ * "Could not locate join button by any locale-agnostic or English selector".
+ * The selector list's only locale-agnostic entry is
+ * `button[jsname]:not([aria-label]):has(span)`, so it can see a lobby ONLY when
+ * the CTA carries no accessible label. A non-English lobby whose CTA IS
+ * aria-labelled matches nothing in the list: the English literals lose on the
+ * language, the structural entry loses on `:not([aria-label])`. Production
+ * agrees the structural entries are inert — 7/7 successful joins on 2026-07-20
+ * matched the English literal `//button[.//span[text()="Ask to join"]]`.
+ *
+ * WHAT THIS FILE PINS
+ *   1. The gap is real: the shipped selector list locates NOTHING on a lobby
+ *      whose CTA is aria-labelled and non-English (and nothing on the variant
+ *      whose CTA carries no jsname either — the other way the entry can miss).
+ *   2. `findLobbyPrimaryCta` closes it locale-agnostically, and picks the CTA —
+ *      not the mic/camera toggles, not the 3-dot menu, not the secondary
+ *      joining options.
+ *   3. It REFUSES to resolve anything when more than one button qualifies, so
+ *      over-inclusion can only ever produce a diagnosable timeout, never a
+ *      click on the wrong control (the #600 failure class: a catch-all selector
+ *      that matches too much is its own bug).
+ *   4. Ordered resolution: the selector list is honoured top-down, so a broad
+ *      structural entry can never beat a precise English one on the same DOM.
+ *   5. A total miss records the observed URL / html.lang / navigator.language
+ *      and the candidate labels into the thrown message, which is what reaches
+ *      `meeting.data.last_error` (#846 A4).
+ *
+ * FIXTURE HONESTY (#857): the lobby DOMs below are FABRICATED, not captured.
+ * They are built to be consistent with the production evidence — every selector
+ * in the shipped list misses — and they run through jsdom's real CSS engine and
+ * real XPath, not a hand-rolled matcher. They prove the LOCATION LOGIC against
+ * a real DOM implementation; they cannot prove Google's lobby has this exact
+ * shape. Capturing the real lobby subtree is #857's job, and when it lands the
+ * fixtures here should be replaced by it.
+ *
+ * No browser, no live meeting, no Google.
+ *
+ * Run: npx tsx src/googlemeet/join-cta.test.ts
+ */
+
+import { JSDOM } from 'jsdom';
+import {
+  googleJoinButtonSelectors,
+  googleLobbyIconGlyphSelectors,
+  googleLobbyCtaMaxLabelChars,
+} from './selectors';
+import {
+  findLobbyPrimaryCta,
+  waitForAnySelector,
+  waitForLobbyCta,
+  STRUCTURAL_CTA_ORIGIN,
+} from './join';
+
+let passed = 0, failed = 0;
+function assert(cond: boolean, msg: string): void {
+  if (cond) { passed++; console.log(`  \x1b[32mPASS\x1b[0m  ${msg}`); }
+  else { failed++; console.log(`  \x1b[31mFAIL\x1b[0m  ${msg}`); }
+}
+
+// ── Lobby fixtures ──────────────────────────────────────────────────────────
+// Chrome shared by every variant: the icon affordances a lobby always renders.
+// Each is icon-bearing, which is the locale-independent fact the scan keys on.
+const LOBBY_ICON_CHROME = `
+  <div jscontroller="mdEjVc" class="controls">
+    <button jsname="hw0c9" aria-label="MIC_LABEL" data-is-muted="false">
+      <i class="google-material-icons" aria-hidden="true">mic</i>
+    </button>
+    <button jsname="psRWwc" aria-label="CAM_LABEL">
+      <i class="google-material-icons" aria-hidden="true">videocam</i>
+    </button>
+    <button jsname="NakZHc" aria-label="MORE_LABEL">
+      <i class="google-material-icons" aria-hidden="true">more_vert</i>
+    </button>
+  </div>`;
+
+// Secondary joining options: icon + text. Real buttons, real labels, never the
+// admission CTA. They carry an aria-label so the shipped structural selector
+// (`:not([aria-label])`) misses them too — matching the production fact that
+// the whole list came back empty.
+const LOBBY_SECONDARY_OPTIONS = (phone: string, cast: string) => `
+  <div class="other-joining-options">
+    <button jsname="zTPKAe" aria-label="${phone}">
+      <i class="google-material-icons" aria-hidden="true">phone</i><span>${phone}</span>
+    </button>
+    <button jsname="A9Sbfc" aria-label="${cast}">
+      <i class="google-material-icons" aria-hidden="true">cast</i><span>${cast}</span>
+    </button>
+  </div>`;
+
+function lobby(opts: {
+  lang: string;
+  ctaText: string;
+  ctaAriaLabel?: string;
+  ctaJsname?: string;
+  micLabel: string;
+  camLabel: string;
+  moreLabel: string;
+  phoneLabel: string;
+  castLabel: string;
+  extra?: string;
+}): string {
+  const aria = opts.ctaAriaLabel === undefined ? '' : ` aria-label="${opts.ctaAriaLabel}"`;
+  const jsname = opts.ctaJsname === undefined ? '' : ` jsname="${opts.ctaJsname}"`;
+  return `<!doctype html><html lang="${opts.lang}"><body>
+  <div jscontroller="dyDNGc" class="lobby">
+    <input jsname="YPqjbf" type="text" aria-label="name" value="">
+    ${LOBBY_ICON_CHROME
+      .replace('MIC_LABEL', opts.micLabel)
+      .replace('CAM_LABEL', opts.camLabel)
+      .replace('MORE_LABEL', opts.moreLabel)}
+    <div jscontroller="soHxf" class="cta-row">
+      <button${jsname}${aria} class="UywwFc-LgbsSe" data-cta="1">
+        <div class="UywwFc-Bz112c"></div><span jsname="V67aGc">${opts.ctaText}</span>
+      </button>
+    </div>
+    ${LOBBY_SECONDARY_OPTIONS(opts.phoneLabel, opts.castLabel)}
+    ${opts.extra || ''}
+  </div>
+</body></html>`;
+}
+
+const HU = {
+  lang: 'hu',
+  ctaText: 'Kérvényezés a csatlakozásra',
+  micLabel: 'Mikrofon kikapcsolása',
+  camLabel: 'Kamera kikapcsolása',
+  moreLabel: 'További beállítások',
+  phoneLabel: 'Csatlakozás telefonnal',
+  castLabel: 'Értekezlet átküldése',
+};
+const EN = {
+  lang: 'en',
+  ctaText: 'Ask to join',
+  micLabel: 'Turn off microphone',
+  camLabel: 'Turn off camera',
+  moreLabel: 'More options',
+  phoneLabel: 'Join and use a phone for audio',
+  castLabel: 'Cast this meeting',
+};
+
+// #846 variant: Hungarian lobby, CTA carries BOTH jsname and an accessible label.
+const HU_LABELLED_CTA = lobby({ ...HU, ctaAriaLabel: HU.ctaText, ctaJsname: 'Qx7uuf' });
+// The other way the shipped entry misses: CTA with an accessible label and no jsname.
+const HU_NO_JSNAME_CTA = lobby({ ...HU, ctaAriaLabel: HU.ctaText });
+// Negative control: today's happy path — English lobby, unlabelled CTA.
+const EN_PLAIN_CTA = lobby({ ...EN, ctaJsname: 'Qx7uuf' });
+// The shape production actually wins on (7/7 joins on 2026-07-20 matched the
+// English literal, never the structural entry): English lobby, aria-labelled CTA.
+const EN_LABELLED_CTA = lobby({ ...EN, ctaAriaLabel: EN.ctaText, ctaJsname: 'Qx7uuf' });
+// Over-match guard: a second text-only button in the same lobby.
+const HU_AMBIGUOUS = lobby({
+  ...HU, ctaAriaLabel: HU.ctaText, ctaJsname: 'Qx7uuf',
+  extra: '<div class="dlg"><button jsname="Pw3Ldc">Mégse</button></div>',
+});
+// Prose button: long text is not a CTA label.
+const HU_PROSE_ONLY = lobby({
+  ...HU, ctaText: 'x', ctaAriaLabel: HU.ctaText, ctaJsname: 'Qx7uuf',
+  extra: '',
+}).replace(
+  '<span jsname="V67aGc">x</span>',
+  '<span jsname="V67aGc">A csatlakozáshoz fogadd el a felvételkészítésre vonatkozó feltételeket</span>',
+);
+
+// ── jsdom harness ───────────────────────────────────────────────────────────
+// The scan reads `document` (it must, to survive serialization into
+// page.evaluate), so the document under test is installed as the global. Layout
+// is stubbed because jsdom does not lay out: every element is 120x40 unless it
+// opts out with data-offscreen, which reproduces the invisible-button case.
+function mount(html: string): Document {
+  const dom = new JSDOM(html);
+  const El = dom.window.Element as any;
+  El.prototype.getBoundingClientRect = function () {
+    const off = this.getAttribute && this.getAttribute('data-offscreen') !== null;
+    const w = off ? 0 : 120, h = off ? 0 : 40;
+    return { width: w, height: h, top: 0, left: 0, right: w, bottom: h, x: 0, y: 0, toJSON() { return {}; } };
+  };
+  (globalThis as any).document = dom.window.document;
+  return dom.window.document;
+}
+
+const SCAN_OPTS = {
+  iconGlyphSelector: googleLobbyIconGlyphSelectors.join(', '),
+  maxLabelChars: googleLobbyCtaMaxLabelChars,
+};
+const scan = (html: string) => { mount(html); return findLobbyPrimaryCta(SCAN_OPTS); };
+
+/**
+ * Evaluate one SHIPPED selector against a real DOM. Playwright's engines are
+ * emulated exactly where jsdom has no equivalent:
+ *   `//…`            → document.evaluate (jsdom implements XPath natively)
+ *   `:has-text("x")` → substring, case-insensitive, whitespace-normalized
+ *   everything else  → jsdom's real CSS engine (`:has()`, `:not()` included)
+ */
+function selectorMatches(doc: Document, selector: string): Element[] {
+  if (selector.startsWith('//')) {
+    const r = doc.evaluate(selector, doc, null, 7 /* ORDERED_NODE_SNAPSHOT_TYPE */, null);
+    const out: Element[] = [];
+    for (let i = 0; i < r.snapshotLength; i++) out.push(r.snapshotItem(i) as Element);
+    return out;
+  }
+  const m = /^(.*):has-text\("(.+)"\)$/.exec(selector);
+  if (m) {
+    const needle = m[2].toLowerCase();
+    return Array.from(doc.querySelectorAll(m[1] || '*')).filter((el) =>
+      (el.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase().includes(needle));
+  }
+  return Array.from(doc.querySelectorAll(selector));
+}
+
+/** What the SHIPPED selector list alone resolves on this DOM, in list order. */
+function resolveBySelectorsOnly(html: string): { el: Element | null; selector: string | null } {
+  const doc = mount(html);
+  for (const sel of googleJoinButtonSelectors) {
+    const hits = selectorMatches(doc, sel);
+    if (hits.length > 0) return { el: hits[0], selector: sel };
+  }
+  return { el: null, selector: null };
+}
+
+const isCta = (el: Element | null) => el !== null && el.getAttribute('data-cta') === '1';
+
+(async () => {
+  console.log('\n=== 1. The #846 gap — the shipped selector list is blind to an aria-labelled non-English CTA ===');
+  {
+    const hu = resolveBySelectorsOnly(HU_LABELLED_CTA);
+    assert(hu.el === null,
+      'hu lobby, aria-labelled CTA: NO selector in googleJoinButtonSelectors matches (this is the reported failure)');
+
+    const huNoJsname = resolveBySelectorsOnly(HU_NO_JSNAME_CTA);
+    assert(huNoJsname.el === null,
+      'hu lobby, CTA without jsname: NO selector matches either (the other way the structural entry misses)');
+
+    // The English literal is what production actually wins on — pin it, so a
+    // future edit cannot quietly remove the only entry that works today.
+    const en = resolveBySelectorsOnly(EN_PLAIN_CTA);
+    assert(isCta(en.el), `en lobby: selector list still resolves the CTA (via ${en.selector})`);
+
+    const enLabelled = resolveBySelectorsOnly(EN_LABELLED_CTA);
+    assert(isCta(enLabelled.el) && enLabelled.selector === '//button[.//span[text()="Ask to join"]]',
+      'en lobby, aria-labelled CTA: resolved by the English literal — the entry production wins on 7/7');
+  }
+
+  console.log('\n=== 2. findLobbyPrimaryCta closes it — locale-agnostically, on the CTA itself ===');
+  {
+    const hu = scan(HU_LABELLED_CTA);
+    assert(isCta(hu.el), 'hu lobby, aria-labelled CTA: the scan resolves the CTA (red→green for #846 A1)');
+    assert(hu.labels.length === 1 && hu.labels[0] === HU.ctaText,
+      `exactly one candidate, and it is the CTA label ("${hu.labels[0]}")`);
+
+    const huNoJsname = scan(HU_NO_JSNAME_CTA);
+    assert(isCta(huNoJsname.el), 'hu lobby, CTA without jsname: the scan resolves it too (no attribute dependency)');
+
+    const en = scan(EN_PLAIN_CTA);
+    assert(isCta(en.el), 'en lobby: the scan agrees with the English selector — same element (A3 negative control)');
+
+    const enLabelled = scan(EN_LABELLED_CTA);
+    assert(isCta(enLabelled.el), 'en lobby, aria-labelled CTA: the scan lands on the same element the literal does');
+  }
+
+  console.log('\n=== 3. Over-match guards — what the scan must NOT pick ===');
+  {
+    const hu = scan(HU_LABELLED_CTA);
+    assert(!hu.labels.some((t) => [HU.micLabel, HU.camLabel, HU.moreLabel].includes(t)),
+      'mic / camera / 3-dot menu are never candidates (icon-only, in any language)');
+    assert(!hu.labels.some((t) => [HU.phoneLabel, HU.castLabel].includes(t)),
+      'secondary joining options are never candidates (icon + text, in any language)');
+
+    const ambiguous = scan(HU_AMBIGUOUS);
+    assert(ambiguous.el === null,
+      'two text-only buttons → resolves NOTHING (refuses to guess; cannot click the wrong control)');
+    assert(ambiguous.labels.length === 2 && ambiguous.labels.includes('Mégse'),
+      `ambiguity is reported, not swallowed: [${ambiguous.labels.join(' | ')}]`);
+
+    const prose = scan(HU_PROSE_ONLY);
+    assert(prose.el === null, 'a long prose button is not a CTA label (over maxLabelChars)');
+
+    // An icon button whose glyph renders as bare ligature text (no <i>/<svg> to
+    // key on) must not read as a labelled button. Underscored ligatures are
+    // filtered outright; a single-word one survives the filter and is caught by
+    // the uniqueness rule instead. Either way it never gets clicked.
+    const ligature = scan(lobby({
+      ...HU, ctaAriaLabel: HU.ctaText, ctaJsname: 'Qx7uuf',
+      extra: '<button jsname="Zz1" aria-label="Feliratok">closed_caption</button>',
+    }));
+    assert(isCta(ligature.el) && !ligature.labels.includes('closed_caption'),
+      'an underscored material ligature is filtered out; the CTA is still resolved');
+
+    const bareLigature = scan(lobby({
+      ...HU, ctaAriaLabel: HU.ctaText, ctaJsname: 'Qx7uuf',
+      extra: '<button jsname="Zz1" aria-label="Mikrofon">mic</button>',
+    }));
+    assert(bareLigature.el === null && bareLigature.labels.includes('mic'),
+      'a single-word ligature becomes a second candidate → the pick is refused, not guessed');
+
+    const offscreen = scan(lobby({ ...HU, ctaAriaLabel: HU.ctaText, ctaJsname: 'Qx7uuf' })
+      .replace('data-cta="1"', 'data-cta="1" data-offscreen'));
+    assert(offscreen.el === null, 'a zero-size (not rendered) CTA is not resolved — visibility still gates the pick');
+
+    const disabled = scan(lobby({ ...HU, ctaAriaLabel: HU.ctaText, ctaJsname: 'Qx7uuf' })
+      .replace('data-cta="1"', 'data-cta="1" disabled'));
+    assert(disabled.el === null, 'a disabled CTA is not resolved');
+
+    const iconsOnly = scan(`<!doctype html><html lang="hu"><body>${
+      LOBBY_ICON_CHROME.replace('MIC_LABEL', HU.micLabel).replace('CAM_LABEL', HU.camLabel).replace('MORE_LABEL', HU.moreLabel)
+    }</body></html>`);
+    assert(iconsOnly.el === null && iconsOnly.labels.length === 0,
+      'a lobby of icon buttons only → no candidates at all (the scan is not a catch-all)');
+  }
+
+  console.log('\n=== 4. Ordered resolution — the selector list is honoured top-down ===');
+  {
+    // Both the structural entry and the English literal are "visible" here. The
+    // resolver must return the EARLIER one deterministically; the previous
+    // parallel race made this a coin flip, which is how a broad entry can beat a
+    // precise one (#600's failure class).
+    const both = [googleJoinButtonSelectors[0], '//button[.//span[text()="Ask to join"]]'];
+    const hit = await waitForAnySelector(mockPage({ visible: both }) as any, googleJoinButtonSelectors, 5000, 'join button');
+    assert(hit.selector === googleJoinButtonSelectors[0],
+      `earlier selector wins when several match ("${hit.selector}")`);
+
+    // And a later entry still wins when it is the only match.
+    const late = await waitForAnySelector(
+      mockPage({ visible: ['button:has-text("Join now")'] }) as any, googleJoinButtonSelectors, 5000, 'join button');
+    assert(late.selector === 'button:has-text("Join now")', 'a later-only match is still resolved');
+
+    // The selector list is checked BEFORE the scan on every poll, so the scan
+    // cannot overrule a lobby the list can name.
+    const listWins = await waitForLobbyCta(
+      mockPage({ visible: ['button:has-text("Ask to join")'], scanLabels: ['Ask to join'], scanHits: true }) as any,
+      googleJoinButtonSelectors, 5000, 'join button');
+    assert(listWins.selector === 'button:has-text("Ask to join")',
+      'the structural scan never overrules a selector the list can name');
+  }
+
+  console.log('\n=== 5. A total miss is diagnosable from last_error alone (#846 A4) ===');
+  {
+    let message = '';
+    try {
+      await waitForLobbyCta(
+        mockPage({ visible: [], scanLabels: ['Kérvényezés a csatlakozásra', 'Mégse'], lang: 'hu', nav: 'hu-HU' }) as any,
+        googleJoinButtonSelectors, 900, 'join button');
+    } catch (e: any) { message = String(e?.message || e); }
+
+    assert(/^Could not locate join button by any locale-agnostic or English selector after 900ms/.test(message),
+      'the historical error prefix is preserved verbatim (prod monitoring greps it)');
+    assert(/html\.lang=hu/.test(message) && /navigator\.language=hu-HU/.test(message),
+      'the observed UI locale is recorded in the error');
+    assert(/url=https:\/\/meet\.google\.com\//.test(message), 'the observed URL is recorded in the error');
+    assert(/Mégse/.test(message) && /Kérvényezés/.test(message),
+      'the visible text-button labels are recorded — the next occurrence is a one-look diagnosis');
+    console.log(`    last_error.reason would read: ${message}`);
+  }
+
+  console.log(`\n=== summary: ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+})();
+
+// ── Minimal Playwright-Page stand-in ────────────────────────────────────────
+// Only the surface the resolvers touch: ordered locator visibility, the
+// structural scan handle, the failure screenshot and the locale probe.
+function mockPage(m: {
+  visible: string[]; scanLabels?: string[]; scanHits?: boolean; lang?: string; nav?: string;
+}) {
+  const el = { __element: true };
+  return {
+    url: () => 'https://meet.google.com/abc-defg-hij',
+    locator: (sel: string) => ({
+      first: () => ({
+        isVisible: async () => m.visible.includes(sel),
+        elementHandle: async () => (m.visible.includes(sel) ? el : null),
+      }),
+    }),
+    waitForTimeout: async (_ms: number) => { await new Promise((r) => setTimeout(r, 1)); },
+    screenshot: async (_o: any) => {},
+    evaluate: async (_fn: any) => ({ lang: m.lang || 'en', nav: m.nav || 'en-US' }),
+    evaluateHandle: async (_fn: any, _opts: any) => ({
+      getProperty: async (k: string) => ({
+        jsonValue: async () => (k === 'labels' ? (m.scanLabels || []) : null),
+        asElement: () => (k === 'el' && m.scanHits ? el : null),
+      }),
+      dispose: async () => {},
+    }),
+  };
+}

--- a/core/meetings/modules/join/src/googlemeet/join.ts
+++ b/core/meetings/modules/join/src/googlemeet/join.ts
@@ -7,7 +7,9 @@ import {
   googleMicrophoneButtonSelectors,
   googleCameraButtonSelectors,
   googleAuthJoinCtaSelectors,
-  googleSignedOutLobbyProbeSelectors
+  googleSignedOutLobbyProbeSelectors,
+  googleLobbyIconGlyphSelectors,
+  googleLobbyCtaMaxLabelChars
 } from "./selectors";
 import { HumanizedInteractor, MOCAP_LIBRARY } from "./humanized";
 import { AdmissionError } from "../shared/admission";
@@ -47,12 +49,165 @@ export function resolveUiInteractionMode(botConfig: BotConfig): "humanized" | "s
   return botConfig.platform === "google_meet" ? "humanized" : "synthetic";
 }
 
+/** Poll cadence for the ordered selector resolvers. */
+const SELECTOR_POLL_MS = 300;
+/** The structural CTA scan runs every Nth poll — it is a full-document walk. */
+const CTA_SCAN_EVERY_POLLS = 5;
+/** The scan only starts once the lobby SPA has had time to finish rendering:
+ *  a half-built lobby can momentarily expose exactly one text button that is
+ *  not the CTA, and the scan's whole safety argument is uniqueness. */
+const CTA_SCAN_GRACE_MS = 8000;
+/** Reported in place of a selector string when the structural scan wins. */
+export const STRUCTURAL_CTA_ORIGIN = "structural:lobby-primary-cta";
+
+/** Result of the browser-context lobby scan. `el` is non-null ONLY when exactly
+ *  one candidate passed — see findLobbyPrimaryCta. `labels` is every candidate's
+ *  visible text, kept for the failure diagnostic. */
+export interface LobbyCtaScan { el: Element | null; labels: string[] }
+export interface LobbyCtaScanOptions { iconGlyphSelector: string; maxLabelChars: number }
+
 /**
- * Wait for the FIRST of an ordered selector list to appear (locale-agnostic
- * selectors first, English text fallbacks last). Returns the matched handle and
- * the selector that won. On total failure: screenshot + LOUD throw with the full
- * list tried (no-fallbacks.md — a missing control fails with a logged reason +
- * screenshot, never a silent skip).
+ * Locale-agnostic primary-CTA scan for the Google Meet lobby.
+ *
+ * RUNS IN BROWSER CONTEXT (page.evaluateHandle serializes this function's
+ * source), so it is self-contained by construction: it closes over nothing,
+ * reads only its argument and `document`, and uses plain CSS. That also makes it
+ * directly executable against a jsdom document, which is how join-cta.test.ts
+ * pins it against a real DOM rather than a mock.
+ *
+ * The discriminator is positive and structural, never textual: the lobby's
+ * primary CTA is the one visible, enabled <button> that carries a real text
+ * label and no icon glyph. Everything else in the lobby is an icon affordance
+ * (mic / camera / 3-dot menu) or pairs an icon with its text ("cast this
+ * meeting", "use a phone for audio"), so `iconGlyphSelector` removes them
+ * without knowing a single word of the UI language.
+ *
+ * WHY IT CANNOT MIS-CLICK: it returns an element ONLY when exactly one button in
+ * the document passes. A second text-labelled button — a consent dialog, a
+ * "cancel", an unrecognized icon rendering as ligature text — makes the result
+ * ambiguous, and an ambiguous result resolves nothing and clicks nothing. The
+ * caller then fails loud with every candidate label recorded. Over-inclusion
+ * degrades to a diagnosable timeout; it never degrades to the wrong control.
+ */
+export function findLobbyPrimaryCta(opts: LobbyCtaScanOptions): LobbyCtaScan {
+  const labels: string[] = [];
+  const candidates: Element[] = [];
+  const buttons = document.querySelectorAll("button");
+  for (let i = 0; i < buttons.length; i++) {
+    const btn = buttons[i] as HTMLButtonElement;
+    if (btn.disabled || btn.getAttribute("aria-disabled") === "true") continue;
+    if (btn.closest("[hidden]") !== null) continue;
+    const rect = btn.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    const style = btn.ownerDocument.defaultView.getComputedStyle(btn);
+    if (style.visibility === "hidden" || style.display === "none" || style.opacity === "0") continue;
+    // Icon affordance, in any language.
+    if (btn.querySelector(opts.iconGlyphSelector) !== null) continue;
+    const text = (btn.textContent || "").replace(/\s+/g, " ").trim();
+    if (text.length === 0 || text.length > opts.maxLabelChars) continue;
+    // A Material ligature that escaped the icon filter ("mic_off", "more_vert")
+    // is not a label: no natural-language CTA contains an underscore.
+    if (text.indexOf("_") >= 0) continue;
+    // Must contain an actual letter — a glyph/number-only button is not a CTA.
+    if (!/\p{L}/u.test(text)) continue;
+    labels.push(text);
+    candidates.push(btn);
+  }
+  return { el: candidates.length === 1 ? candidates[0] : null, labels: labels };
+}
+
+/** Run findLobbyPrimaryCta in the page and lift the winner into an ElementHandle. */
+async function scanLobbyPrimaryCta(
+  page: Page
+): Promise<{ handle: ElementHandle<Element> | null; labels: string[] }> {
+  const opts: LobbyCtaScanOptions = {
+    iconGlyphSelector: googleLobbyIconGlyphSelectors.join(", "),
+    maxLabelChars: googleLobbyCtaMaxLabelChars,
+  };
+  let scan: any = null;
+  try {
+    scan = await page.evaluateHandle(findLobbyPrimaryCta, opts);
+    const labels = (await (await scan.getProperty("labels")).jsonValue()) as string[];
+    const handle = (await scan.getProperty("el")).asElement();
+    return { handle: (handle as ElementHandle<Element>) || null, labels: labels || [] };
+  } catch {
+    return { handle: null, labels: [] };
+  } finally {
+    if (scan) { try { await scan.dispose(); } catch { /* best-effort */ } }
+  }
+}
+
+/**
+ * First VISIBLE selector in list order, or null. Order is authoritative: the
+ * whole list is re-checked top-down on every poll, so the locale-agnostic entry
+ * can never be beaten to the punch by a broader English fallback (or the
+ * reverse). A per-selector parse/detach rejection never denies the rest their
+ * turn.
+ */
+async function firstVisibleSelector(
+  page: Page,
+  selectors: string[]
+): Promise<{ handle: ElementHandle<Element>; selector: string } | null> {
+  for (const sel of selectors) {
+    try {
+      const loc = page.locator(sel).first();
+      if (!(await loc.isVisible())) continue;
+      const handle = await loc.elementHandle({ timeout: 2000 });
+      if (handle) return { handle: handle as ElementHandle<Element>, selector: sel };
+    } catch { /* invalid selector or detached node — the next entry still gets its chance */ }
+  }
+  return null;
+}
+
+/**
+ * Observed page context for a selector miss. Recorded INTO the thrown error so
+ * the failure is diagnosable from `meeting.data.last_error` alone — the pods
+ * that saw the lobby are long gone by the time anyone reads it (#846 A4).
+ */
+async function observedPageContext(page: Page): Promise<string> {
+  let url = "?";
+  try { url = page.url(); } catch { /* best-effort */ }
+  try {
+    const ctx: any = await page.evaluate(() => ({
+      lang: document.documentElement.getAttribute("lang") || "",
+      nav: navigator.language || "",
+    }));
+    return `url=${url} html.lang=${ctx.lang || "?"} navigator.language=${ctx.nav || "?"}`;
+  } catch {
+    return `url=${url} html.lang=? navigator.language=?`;
+  }
+}
+
+/**
+ * Screenshot + compose the LOUD failure message for a total selector miss
+ * (no-fallbacks.md — a missing control fails with a logged reason + screenshot,
+ * never a silent skip). The message keeps its historical prefix verbatim (prod
+ * monitoring greps it) and appends the observed locale/URL, plus the visible
+ * text-button labels when a structural scan ran — the one datum that turns the
+ * next occurrence into a one-look diagnosis.
+ */
+export async function describeSelectorMiss(
+  page: Page,
+  selectors: string[],
+  timeoutMs: number,
+  label: string,
+  candidateLabels: string[] | null
+): Promise<string> {
+  const shot = `/app/storage/screenshots/bot-checkpoint-${label.replace(/[^a-z0-9]+/gi, "-")}-not-found.png`;
+  try { await page.screenshot({ path: shot, fullPage: true }); } catch { /* best-effort */ }
+  log(`📸 Screenshot: ${label} not found by any of ${selectors.length} selectors (tried: ${selectors.join(" | ")})`);
+  const context = await observedPageContext(page);
+  const seen = candidateLabels === null
+    ? ""
+    : `; visible text buttons: ${candidateLabels.length === 0 ? "(none)" : candidateLabels.map((t) => `"${t}"`).join(" | ")}`;
+  return `Could not locate ${label} by any locale-agnostic or English selector after ${timeoutMs}ms (${context}${seen})`;
+}
+
+/**
+ * Wait for the FIRST of an ordered selector list to become visible
+ * (locale-agnostic selectors first, English text fallbacks last). Returns the
+ * matched handle and the selector that won. On total failure: screenshot + LOUD
+ * throw carrying the observed locale/URL.
  */
 export async function waitForAnySelector(
   page: Page,
@@ -60,36 +215,60 @@ export async function waitForAnySelector(
   timeoutMs: number,
   label: string
 ): Promise<{ handle: ElementHandle<Element>; selector: string }> {
-  // First selector to MATCH wins; a per-selector timeout/parse rejection must
-  // NOT abort the others (so the locale-agnostic + English fallbacks all get a
-  // fair chance). We resolve on first success and only fail once every selector
-  // has settled without a match.
-  const winner = await new Promise<{ handle: ElementHandle<Element>; selector: string } | null>((resolve) => {
-    let pending = selectors.length;
-    let settled = false;
-    if (pending === 0) { resolve(null); return; }
-    for (const sel of selectors) {
-      page
-        .waitForSelector(sel, { timeout: timeoutMs, state: "visible" })
-        .then((el) => {
-          if (!settled && el) { settled = true; resolve({ handle: el as ElementHandle<Element>, selector: sel }); }
-          else if (--pending === 0 && !settled) { settled = true; resolve(null); }
-        })
-        .catch(() => {
-          if (--pending === 0 && !settled) { settled = true; resolve(null); }
-        });
+  const started = Date.now();
+  do {
+    const hit = await firstVisibleSelector(page, selectors);
+    if (hit) {
+      log(`Located ${label} via selector: ${hit.selector}`);
+      return hit;
     }
-  });
+    await page.waitForTimeout(SELECTOR_POLL_MS);
+  } while (Date.now() - started < timeoutMs);
 
-  if (winner) {
-    log(`Located ${label} via selector: ${winner.selector}`);
-    return winner;
-  }
+  throw new Error(await describeSelectorMiss(page, selectors, timeoutMs, label, null));
+}
 
-  const shot = `/app/storage/screenshots/bot-checkpoint-${label.replace(/[^a-z0-9]+/gi, "-")}-not-found.png`;
-  try { await page.screenshot({ path: shot, fullPage: true }); } catch { /* best-effort */ }
-  log(`📸 Screenshot: ${label} not found by any of ${selectors.length} selectors (tried: ${selectors.join(" | ")})`);
-  throw new Error(`Could not locate ${label} by any locale-agnostic or English selector after ${timeoutMs}ms`);
+/**
+ * Resolve the Meet lobby's primary admission CTA: the ordered selector list
+ * first, then — once the lobby has settled — the locale-agnostic structural scan
+ * (findLobbyPrimaryCta) as the backstop for a lobby the selector list cannot
+ * express, i.e. a non-English CTA that carries an accessible label (#846).
+ *
+ * The selector list is re-checked BEFORE the scan on every poll, so a lobby any
+ * selector can name is still resolved by that selector and the scan never gets
+ * to overrule it. Both share the one budget; neither shortens the other.
+ */
+export async function waitForLobbyCta(
+  page: Page,
+  selectors: string[],
+  timeoutMs: number,
+  label: string
+): Promise<{ handle: ElementHandle<Element>; selector: string }> {
+  const started = Date.now();
+  const graceMs = Math.min(CTA_SCAN_GRACE_MS, Math.floor(timeoutMs / 3));
+  let polls = 0;
+  // null until the scan has actually run: "(none)" must mean "the lobby showed
+  // no text-labelled button", never "the scan never got to look".
+  let lastLabels: string[] | null = null;
+  do {
+    const hit = await firstVisibleSelector(page, selectors);
+    if (hit) {
+      log(`Located ${label} via selector: ${hit.selector}`);
+      return hit;
+    }
+    if (Date.now() - started >= graceMs && polls % CTA_SCAN_EVERY_POLLS === 0) {
+      const scan = await scanLobbyPrimaryCta(page);
+      lastLabels = scan.labels;
+      if (scan.handle) {
+        log(`Located ${label} via ${STRUCTURAL_CTA_ORIGIN} (label: "${scan.labels[0]}")`);
+        return { handle: scan.handle, selector: STRUCTURAL_CTA_ORIGIN };
+      }
+    }
+    polls++;
+    await page.waitForTimeout(SELECTOR_POLL_MS);
+  } while (Date.now() - started < timeoutMs);
+
+  throw new Error(await describeSelectorMiss(page, selectors, timeoutMs, label, lastLabels));
 }
 
 export async function joinGoogleMeeting(
@@ -194,10 +373,11 @@ export async function joinGoogleMeeting(
     // Authenticated lobby: one primary CTA — "Join now" (standard join),
     // "Switch here" (same account already in the call) or "Ask to join"
     // (host approval required) — or any localized equivalent. The CTA is
-    // located structurally (googleAuthJoinCtaSelectors, locale-agnostic first),
-    // so the branch works on non-English lobbies; waitForAnySelector fails
-    // LOUD (screenshot + selector list) if no CTA appears.
-    const { handle: ctaHandle, selector: ctaSelector } = await waitForAnySelector(
+    // located structurally (googleAuthJoinCtaSelectors, locale-agnostic first,
+    // then findLobbyPrimaryCta), so the branch works on non-English lobbies;
+    // waitForLobbyCta fails LOUD (screenshot + selector list + observed locale)
+    // if no CTA appears.
+    const { handle: ctaHandle, selector: ctaSelector } = await waitForLobbyCta(
       page,
       googleAuthJoinCtaSelectors,
       30000,
@@ -253,7 +433,7 @@ export async function joinGoogleMeeting(
       log("Camera already off or not found.");
     }
 
-    const { handle: joinHandle } = await waitForAnySelector(
+    const { handle: joinHandle } = await waitForLobbyCta(
       page,
       googleJoinButtonSelectors,
       60000,

--- a/core/meetings/modules/join/src/googlemeet/selectors.ts
+++ b/core/meetings/modules/join/src/googlemeet/selectors.ts
@@ -270,28 +270,57 @@ export const googleRemovalIndicators: string[] = [
 
 // Google Meet UI interaction selectors.
 //
-// Locale-agnostic FIRST (structure / jsname / role), then English text as a
-// fallback. The English-literal `text()="Ask to join"` / has-text locators only
-// match an English UI, so a Hungarian (or any non-English) Meet lobby never
-// found the join button — the bot sat in the lobby until manual_leave
-// (prod ids 13951 13952 14018 14153). The primary admission CTA in the Meet
-// lobby is the last/right-most jsname-tagged <button> in the lobby controls;
-// it carries a jsname and is the only enabled <button> with non-icon text.
+// ORDER IS AUTHORITATIVE: join.ts resolves these lists top-down on every poll,
+// so an earlier entry always beats a later one on the same DOM.
+//
+// The first entry is the locale-agnostic one; the English literals follow. The
+// `text()="Ask to join"` / has-text locators only match an English UI, so a
+// Hungarian (or any non-English) Meet lobby cannot be joined by them alone
+// (prod ids 13951 13952 14018 14153).
+//
+// COVERAGE LIMIT — read before adding to this list: the structural entry can
+// only see a lobby whose CTA carries NO accessible label. `:not([aria-label])`
+// is load-bearing (the lobby's aria-labelled 3-dot menu is otherwise a
+// `button[jsname]` with a span, and the humanized click lands on the menu), but
+// it also blinds this list to a lobby whose CTA IS aria-labelled — which is the
+// shape reported in #846 (prod meetings 24337, 24339: the full list exhausted
+// its 60s budget). Attribute presence cannot express "the button with a real
+// text label", so that case is closed in join.ts by `findLobbyPrimaryCta` — a
+// structural scan that discriminates on non-icon label text and refuses to
+// click unless exactly one candidate exists. Widen there, not here.
 export const googleJoinButtonSelectors: string[] = [
-  // Locale-agnostic: a real <button> carrying Google's jsname token whose label
-  // text is non-empty (excludes icon-only mic/camera toggles which have no text
-  // node). Matches "Ask to join"/"Join now"/localized equivalents alike.
+  // Locale-agnostic: a real <button> carrying Google's jsname token, a text span
+  // and no accessible label. Matches "Ask to join"/"Join now"/localized alike.
   'button[jsname]:not([aria-label]):has(span)',
-  // NB: must exclude [aria-label] — the lobby 3-dot "more options" menu is also a
-  // div[jscontroller] button[jsname] with a span; without this filter it matched
-  // FIRST and the humanized click landed on the menu, never "Ask to join".
-  'div[jscontroller] button[jsname]:not([aria-label]):has(span)',
   // English fallbacks (kept for resilience on English UIs).
   '//button[.//span[text()="Ask to join"]]',
   'button:has-text("Ask to join")',
   'button:has-text("Join now")',
   'button:has-text("Join")'
 ];
+
+// Icon-glyph descendants of a lobby <button>. A button containing any of these
+// is an icon affordance (mic / camera / 3-dot menu / "cast this meeting" /
+// "use a phone for audio"), never the primary admission CTA — Meet renders that
+// one as text only. Consumed by `findLobbyPrimaryCta` in join.ts, which runs in
+// BROWSER CONTEXT through document.querySelector, so every entry must be plain
+// CSS (declared in browserContextSelectorArrays below; the validity gate
+// CSS-parses it). Material icons carry their glyph name as a TEXT node
+// ("mic_off", "more_vert"), so excluding these elements is what keeps an
+// icon-only button from reading as a text-labelled one.
+export const googleLobbyIconGlyphSelectors: string[] = [
+  'i',
+  'svg',
+  'img',
+  '[class*="material-icons"]',
+  '[class*="material-symbols"]',
+  '[data-icon-name]'
+];
+
+// A primary CTA label is a couple of words in any language ("Ask to join",
+// "Kérvényezés a csatlakozásra", "参加をリクエスト"). Anything longer is prose —
+// a disclosure/consent paragraph rendered as a button — and is not a CTA.
+export const googleLobbyCtaMaxLabelChars = 48;
 
 export const googleCameraButtonSelectors: string[] = [
   '[aria-label*="Turn off camera"]',
@@ -322,14 +351,12 @@ export const googleNameInputSelectors: string[] = [
 ];
 
 // Authenticated-lobby primary CTA — "Join now" / "Switch here" / "Ask to join"
-// or any localized equivalent. Locale-agnostic structural selectors FIRST
-// (the English-literal failure class of ids 13951/13952/14018/14153 above):
-// the CTA is the jsname-tagged <button> with a text span and no aria-label,
-// which excludes the icon-only mic/camera toggles and the aria-labelled
-// 3-dot menu. English text kept as last-resort fallbacks only.
+// or any localized equivalent. Same shape and same coverage limit as
+// googleJoinButtonSelectors above: the locale-agnostic entry is first, the
+// English text is a fallback, and an aria-labelled CTA on a non-English lobby
+// is reached by join.ts's `findLobbyPrimaryCta` scan rather than by this list.
 export const googleAuthJoinCtaSelectors: string[] = [
   'button[jsname]:not([aria-label]):has(span)',
-  'div[jscontroller] button[jsname]:not([aria-label]):has(span)',
   // English fallbacks.
   'button:has-text("Join now")',
   'button:has-text("Switch here")',
@@ -441,5 +468,8 @@ export const googlePeopleButtonSelectors: string[] = [
 // ship green as a dead selector. Entries may be plain CSS strings or
 // BrowserContextButtonMatcher objects (`css` field parsed as CSS; `text`
 // fields are raw strings, not selectors).
-export const browserContextSelectorArrays: string[] = ['googleLeaveButtonMatchers'];
+export const browserContextSelectorArrays: string[] = [
+  'googleLeaveButtonMatchers',
+  'googleLobbyIconGlyphSelectors',
+];
 

--- a/core/meetings/modules/join/src/googlemeet/session.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/session.test.ts
@@ -51,13 +51,28 @@ function mockPage(visible: string[]) {
     waitForTimeout: async () => {},
     fill: async () => {},
     mouse: { move: async () => {} },
+    url: () => 'https://meet.google.com/abc-defg-hij',
+    // The lobby-CTA resolvers read the observed locale for the failure
+    // diagnostic and run the structural scan through evaluateHandle; neither
+    // resolves anything on this fixture, which is driven purely by `visible`.
+    evaluate: async () => ({ lang: 'en', nav: 'en-US' }),
+    evaluateHandle: async () => ({
+      getProperty: async (k: string) => ({
+        jsonValue: async () => (k === 'labels' ? [] : null),
+        asElement: () => null,
+      }),
+      dispose: async () => {},
+    }),
     waitForSelector: (sel: string, _opts?: any) =>
       visible.includes(sel)
         ? Promise.resolve(handle(sel))
         : Promise.reject(new Error(`mock: ${sel} not on page`)),
     $: async (sel: string) => (visible.includes(sel) ? handle(sel) : null),
     locator: (sel: string) => ({
-      first: () => ({ isVisible: async () => visible.includes(sel) }),
+      first: () => ({
+        isVisible: async () => visible.includes(sel),
+        elementHandle: async () => (visible.includes(sel) ? handle(sel) : null),
+      }),
     }),
   };
   return page;

--- a/docs/changelog.d/846-gmeet-lobby-cta-locale-agnostic.md
+++ b/docs/changelog.d/846-gmeet-lobby-cta-locale-agnostic.md
@@ -1,0 +1,9 @@
+- **Google Meet: the bot joins a lobby in any UI language (#846).** A Meet lobby served in a
+  non-English language whose join button carries an accessibility label matched none of the bot's
+  join selectors, so the bot sat on the lobby for the full 60s budget and exited with zero
+  transcript segments. The lobby's primary button is now also located structurally — the one
+  visible, enabled button with a real text label and no icon — which needs no knowledge of the UI
+  language. The scan resolves nothing unless exactly one button qualifies, so it can never click
+  the wrong control. When the button genuinely cannot be found, the failure now records the
+  observed URL, page language and visible button labels, so the reason reaches you in the meeting's
+  error instead of only in the bot's logs.


### PR DESCRIPTION
Closes #846

## What was wrong

A Google Meet lobby served in a **non-English language whose primary button carries an accessible label** matches **no entry** in `googleJoinButtonSelectors`:

| entry | why it misses that lobby |
|---|---|
| `button[jsname]:not([aria-label]):has(span)` | `:not([aria-label])` excludes an aria-labelled CTA |
| `div[jscontroller] button[jsname]:not([aria-label]):has(span)` | strict subset of the above — same exclusion |
| `//button[.//span[text()="Ask to join"]]` | English literal |
| `button:has-text("Ask to join" / "Join now" / "Join")` | English literals |

The bot burned the full 60s budget and exited code 1 with 0 segments — prod meetings 24337 / 24339 on v0.12.15, 3 more on v0.12.16. The issue's own evidence agrees the structural entries are inert: 7/7 successful joins on 2026-07-20 matched the English literal, the structural pair matched zero.

This is the **point of introduction**: the locator expresses "the CTA" as *absence of an attribute*, which is not a property of a CTA.

## The fix

`findLobbyPrimaryCta` (join.ts) — a positive, structural, locale-agnostic discriminator: **the one visible, enabled `<button>` carrying a real text label and no icon glyph.** Everything else in a Meet lobby is an icon affordance (mic / camera / 3-dot menu) or pairs an icon with its text ("cast this meeting", "use a phone for audio"), so `googleLobbyIconGlyphSelectors` removes them without knowing a word of the UI language. It requires neither `jsname` nor the absence of `aria-label`, so it also covers the second way the shipped entry can miss (a CTA with no `jsname`).

**Why it cannot mis-click** — the #600 lesson (a generic `[role=alert]` catch-all causing false evictions) is taken seriously:

1. It **resolves only when exactly one button in the document qualifies.** A second text-labelled button (consent dialog, "cancel", an unrecognized icon rendering as ligature text) makes the result ambiguous, and an ambiguous result clicks nothing and fails loud with every candidate label recorded. **Over-inclusion degrades to a diagnosable timeout, never to the wrong control.**
2. It is a **backstop, not a competitor**: the whole selector list is re-checked *before* the scan on every poll, so any lobby a selector can name is resolved by that selector.
3. Layered filters: disabled / `aria-disabled` / `[hidden]` / zero-size / `visibility:hidden` / `display:none` / `opacity:0` are out; label must be ≤48 chars (prose buttons out), must contain a letter, must not contain `_` (Material ligatures like `mic_off`, `more_vert` out).
4. It only runs after an 8s grace, so a half-rendered lobby cannot momentarily present a single non-CTA text button.

Two supporting changes in the same seam:

- **Selector resolution is ordered, not raced.** `waitForAnySelector` used to fire all entries in parallel and take whichever `waitForSelector` resolved first — the file's documented "locale-agnostic FIRST, English fallback" priority was decorative, and a broad entry could beat a precise one nondeterministically. It now re-checks the list top-down each poll, so order is authoritative.
- **A total miss is diagnosable from the DB alone (A4).** The thrown message keeps its historical prefix verbatim (prod monitoring greps it) and appends the observed URL, `html.lang`, `navigator.language` and the visible text-button labels. This is what lands in `meeting.data.last_error`:

```
Could not locate join button by any locale-agnostic or English selector after 60000ms
(url=https://meet.google.com/abc-defg-hij html.lang=hu navigator.language=hu-HU;
 visible text buttons: "Kérvényezés a csatlakozásra" | "Mégse")
```

The redundant `div[jscontroller]`-scoped entry is deleted from both join arrays.

## Observation bundle

`src/googlemeet/join-cta.test.ts` — 26 rows, jsdom's **real** CSS engine (`:has()`, `:not()`) and **real** XPath, no browser, no live meeting.

### RED — pre-fix tree, shipped selectors against the reported lobby shape

```
googleJoinButtonSelectors (6 entries):
  0 match  button[jsname]:not([aria-label]):has(span)
  0 match  div[jscontroller] button[jsname]:not([aria-label]):has(span)
  0 match  //button[.//span[text()="Ask to join"]]
  0 match  button:has-text("Ask to join")
  0 match  button:has-text("Join now")
  0 match  button:has-text("Join")
  => NOT LOCATED (60s budget exhausted, exit 1)

googleAuthJoinCtaSelectors (5 entries):  0/5  => NOT LOCATED
```

The test file itself fails to load on the pre-fix tree (`findLobbyPrimaryCta` / `waitForLobbyCta` do not exist).

### GREEN — post-fix, 26/26

| # | acceptance | observation |
|---|---|---|
| A1 | failing variant → CTA located | `hu lobby, aria-labelled CTA: the scan resolves the CTA` · `…CTA without jsname: the scan resolves it too` |
| A2 | a running test pins it | `join-cta.test.ts` wired into `@vexa/join`'s `npm test`; section 1 permanently pins that the selector list alone is blind to this lobby |
| A3 | negative control | `en lobby: selector list still resolves the CTA` · `en lobby, aria-labelled CTA: resolved by the English literal — the entry production wins on 7/7` · `the scan lands on the same element the literal does` |
| A4 | `last_error` records locale/URL | prefix preserved verbatim · `html.lang=hu` · `navigator.language=hu-HU` · `url=…` · candidate labels |
| — | over-match guards | mic/camera/3-dot never candidates · secondary joining options never candidates · two text buttons → **resolves nothing** · prose button rejected · underscored ligature filtered · bare ligature → refuse, not guess · zero-size CTA rejected · disabled CTA rejected · icon-only lobby → zero candidates |
| — | ordering | earlier selector wins when several match · later-only match still resolved · the scan never overrules a selector the list can name |

### Suites

- `@vexa/join` — all 15 suites green, incl. `selector-validity` (298 Playwright selectors / 39 arrays + 38 CSS entries / 3 browser-context arrays, 0 invalid — the new `googleLobbyIconGlyphSelectors` is declared in `browserContextSelectorArrays` so the CSS lane parses it), `humanized` 29/29, `session` 13/13.
- `@vexa/bot` — green.
- `MOCK_BOT=1 BROWSER_IMAGE=mock-bot:dev node scripts/gates.mjs all` — **✅ gates green** (32 gates; compose-stress/chaos opt-in→skip).

## Fixture honesty (#857 applies to this PR too)

**The lobby DOMs in the test are fabricated, not captured.** They are built to be consistent with the production evidence (every shipped selector misses) and are exercised through a real DOM implementation rather than a hand-rolled matcher — so they prove the *location logic*, not that Google's lobby has this exact shape. That limitation is stated at the top of the file. When #857 lands a real captured lobby subtree, these fixtures should be replaced by it, and A2 of #857 can then be checked against this change.

## Still owed — flag for the maintainer

- **A live Google Meet join witness remains.** I proved the diff offline (fabricated-DOM + gates); I have not run a bot into a live Meet lobby, and I certainly have not run one into a *non-English* lobby, which is the case this fixes. The English path is the one at risk of regression (ordered resolution + the new poll loop replace `page.waitForSelector`), so a normal English join is the first thing to witness.
- **#856 remains the primary fix.** This is defence-in-depth: once the browser's UI locale is pinned, the English literals are correct by construction. This change is what keeps that true if the pin is ever overridden or ignored.

## Surprise worth recording

The comment block in `selectors.ts` claims "locale-agnostic FIRST … then English text as a fallback", but `waitForAnySelector` raced every entry in parallel and returned whichever `waitForSelector` settled first — **the documented priority was not implemented.** That means a broad structural entry could beat a precise English one nondeterministically, which is exactly the hazard that made a wider structural selector unsafe to add. Ordered resolution had to land before the fix could be made safely.

## Files touched

- `core/meetings/modules/join/src/googlemeet/join.ts` — ordered resolver, `findLobbyPrimaryCta`, `waitForLobbyCta`, failure diagnostics
- `core/meetings/modules/join/src/googlemeet/selectors.ts` — dropped the duplicate entry, documented the coverage limit, added `googleLobbyIconGlyphSelectors` / `googleLobbyCtaMaxLabelChars`
- `core/meetings/modules/join/src/googlemeet/join-cta.test.ts` — new
- `core/meetings/modules/join/src/googlemeet/session.test.ts` — its Page stand-in gained `url` / `evaluate` / `evaluateHandle` / `locator().first().elementHandle()`, the surface the ordered resolver touches
- `core/meetings/modules/join/package.json` — test script wires the new suite in
- `docs/changelog.d/846-gmeet-lobby-cta-locale-agnostic.md` — fragment (no `changelog.mdx` edit; no helm/k8s hot files touched)

Ignore the spurious `merge-card` check.
