### PR TITLE
fix(gmeet): a host denial beats a captcha element — the bot stops looping 'staying for solve' (#840)

### DIFF
--- a/core/meetings/modules/join/src/googlemeet/admission.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/admission.test.ts
@@ -22,47 +22,113 @@
  *    transcriptions. `hasConsentPrompt` detects it and
  *    `checkForGoogleAdmissionIndicators` suppresses the admitted signal.
  *
+ * 4. #840 denial-vs-captcha (FIXED): Google Meet loads reCAPTCHA Enterprise
+ *    INVISIBLY on every join (a background scoring frame), so a `/recaptcha/`
+ *    frame sits on the HOST DENIAL screen too. The old detector read frame-URL
+ *    presence as "a captcha is on screen" and suppressed the denial forever —
+ *    prod meeting 24348 looped `"reCAPTCHA present alongside rejection
+ *    indicator … staying for solve"` every 2s and never left `awaiting_admission`.
+ *    Now: explicit host-denial copy wins over any captcha, only a VISIBLE
+ *    challenge-sized widget counts as a challenge, and the stay-for-solve wager
+ *    expires (CAPTCHA_SOLVE_GRACE_MS).
+ *
  * This test feeds the detectors a fabricated DOM for each scenario (no browser,
  * no live meeting, no Google).
  *
  * Run: npx tsx src/googlemeet/admission.test.ts
  */
 
-import {
+// Namespace import on purpose: this file must also RUN against the pre-#840
+// module (which has no CAPTCHA_SOLVE_GRACE_MS) to demonstrate red→green.
+import * as admission from './admission';
+import { AdmissionError } from '../shared/admission';
+import { resetEscalation } from '../shared/escalation';
+const {
   checkForGoogleRejection,
   checkForWaitingRoomIndicators,
   checkForGoogleAdmissionIndicators,
   hasConsentPrompt,
-} from './admission';
+  waitForGoogleMeetingAdmission,
+} = admission;
+const GRACE_MS: number = (admission as any).CAPTCHA_SOLVE_GRACE_MS ?? 120_000;
 
 /**
  * Minimal Playwright-Page stand-in. `visible` = the selectors that resolve
- * isVisible()===true on this page; `recaptcha` = whether a /recaptcha/ frame is
- * present; `participantLabels` = aria-labels returned for [data-participant-id]
- * tiles (drives countRealParticipantTiles). Matches exactly the surface the
- * admission detectors use.
+ * isVisible()===true on this page; `captcha` = the reCAPTCHA shape on the page;
+ * `participantLabels` = aria-labels returned for [data-participant-id] tiles
+ * (drives countRealParticipantTiles). Matches exactly the surface the admission
+ * detectors use.
+ *
+ *   false        — no reCAPTCHA anywhere.
+ *   'invisible'  — reCAPTCHA Enterprise's background scoring frame: a
+ *                  `/recaptcha/` FRAME exists, its iframe element is
+ *                  display:none (isVisible false, no box). This is what sits on
+ *                  a real Google Meet page — including the denial screen (#840).
+ *   'live'       — an actual challenge: a visible, challenge-sized iframe
+ *                  (bframe, 400x580) a human/agent can solve.
  */
-function mockPage(visible: string[], recaptcha = false, participantLabels: string[] = []): any {
+type CaptchaMode = false | 'invisible' | 'live';
+const RECAPTCHA_IFRAME = 'iframe[src*="recaptcha"]';
+
+function mockPage(visible: string[], captcha: CaptchaMode = false, participantLabels: string[] = []): any {
+  const captchaIframes: { visible: boolean; box: { x: number; y: number; width: number; height: number } | null }[] =
+    captcha === 'live' ? [{ visible: true, box: { x: 300, y: 120, width: 400, height: 580 } }]
+      : captcha === 'invisible' ? [{ visible: false, box: null }]
+        : [];
+  const iframeEl = (i: number) => ({
+    isVisible: async () => !!captchaIframes[i]?.visible,
+    boundingBox: async () => captchaIframes[i]?.box ?? null,
+    getAttribute: async () => null,
+  });
   return {
-    locator: (sel: string) => ({
-      first: () => ({
-        isVisible: async () => visible.includes(sel),
-        getAttribute: async () => null,
-      }),
-      count: async () => (visible.includes(sel) ? 1 : 0),
-      evaluateAll: async () => participantLabels,
-    }),
+    locator: (sel: string) => sel === RECAPTCHA_IFRAME
+      ? {
+        first: () => iframeEl(0),
+        nth: (i: number) => iframeEl(i),
+        count: async () => captchaIframes.length,
+        evaluateAll: async () => [],
+      }
+      : {
+        first: () => ({
+          isVisible: async () => visible.includes(sel),
+          getAttribute: async () => null,
+        }),
+        count: async () => (visible.includes(sel) ? 1 : 0),
+        evaluateAll: async () => participantLabels,
+      },
     mouse: { move: async () => {} },
-    frames: () => (recaptcha
-      ? [{ url: () => 'https://www.google.com/recaptcha/enterprise/anchor?ar=1' }]
+    url: () => 'https://meet.google.com/abc-defg-hij',
+    screenshot: async () => {},
+    waitForTimeout: async (_ms: number) => {},
+    frames: () => (captcha
+      ? [{ url: () => 'https://meet.google.com/' }, { url: () => 'https://www.google.com/recaptcha/enterprise/anchor?ar=1' }]
       : [{ url: () => 'https://meet.google.com/' }]),
   };
 }
 
 let passed = 0, failed = 0;
-async function check(name: string, actual: boolean, expected: boolean) {
+async function check(name: string, actual: boolean, expected: boolean, detail?: string) {
   if (actual === expected) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
-  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name} (expected ${expected}, got ${actual})`); failed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name} (expected ${expected}, got ${detail ?? actual})`); failed++; }
+}
+
+/**
+ * Outcome of a shipped admission wait, with a WATCHDOG: if no verdict lands within
+ * `watchdogMs` the wait is still polling — which is exactly the #840 failure mode
+ * (`awaiting_admission` forever), so it must read as a distinct, failing outcome.
+ */
+async function outcomeOf(run: Promise<unknown>, watchdogMs = 10_000): Promise<string> {
+  const watchdog = new Promise<string>(resolve => {
+    const t = setTimeout(() => resolve('NO-VERDICT (still polling after watchdog)'), watchdogMs);
+    (t as any).unref?.();
+  });
+  return Promise.race([
+    run.then(
+      () => 'resolved',
+      (e: any) => (e instanceof AdmissionError ? `AdmissionError:${e.outcome}` : `Error:${e.message}`),
+    ),
+    watchdog,
+  ]);
 }
 
 (async () => {
@@ -85,8 +151,8 @@ async function check(name: string, actual: boolean, expected: boolean) {
   );
 
   // 2. REMAINING #444 CONFLATION — a Google ERROR/BLOCK page's "Try again"
-  //    affordance (no host-denial text, no reCAPTCHA) is still classified as a
-  //    denial. #471 narrowed the conflation but did not close it; flip this to
+  //    affordance (no host-denial text, no live challenge) is still classified as
+  //    a denial. #471 narrowed the conflation but did not close it; flip this to
   //    `false` when a block/error-vs-denial distinction lands.
   await check(
     'CONFLATION (#444, still open): Google error/block page ("Try again") → reported as DENIAL (the remaining bug)',
@@ -101,11 +167,12 @@ async function check(name: string, actual: boolean, expected: boolean) {
     true,
   );
 
-  // 4. GUARD — reCAPTCHA present alongside an error affordance: treated as
-  //    bot-detection, NOT a denial (keeps the bot on the page for a human solve).
+  // 4. GUARD — a LIVE reCAPTCHA challenge alongside an AMBIGUOUS error affordance:
+  //    treated as bot-detection, NOT a denial (keeps the bot on the page for a
+  //    human solve). NEGATIVE CONTROL (a) for #840 — must never regress.
   await check(
-    'reCAPTCHA + "Try again" → NOT a denial (bot-detection guard works)',
-    await checkForGoogleRejection(mockPage(['button:has-text("Try again")'], /*recaptcha*/ true)),
+    'NEG-CTRL (a): live reCAPTCHA + "Try again", no denial copy → NOT a denial (stay-for-solve preserved)',
+    await checkForGoogleRejection(mockPage(['button:has-text("Try again")'], 'live')),
     false,
   );
 
@@ -116,9 +183,118 @@ async function check(name: string, actual: boolean, expected: boolean) {
     false,
   );
 
+  console.log('\n=== #840 — host denial vs. reCAPTCHA (prod meeting 24348) ===');
+
+  // 6. THE #840 BUG — the exact prod page: host denial copy ("denied your
+  //    request") on a page that ALSO carries Meet's invisible reCAPTCHA
+  //    Enterprise scoring frame. Pre-fix this returned false forever (the 2s
+  //    "staying for solve" loop, meeting stuck awaiting_admission).
+  await check(
+    '#840 host denial + invisible reCAPTCHA scoring frame → REJECTED (explicit denial wins)',
+    await checkForGoogleRejection(mockPage(['text=denied your request'], 'invisible')),
+    true,
+  );
+
+  // 6b. Same rule against a LIVE challenge: solving a captcha cannot undo a host's
+  //     "no", so explicit denial copy still wins.
+  await check(
+    '#840 host denial + LIVE reCAPTCHA challenge → REJECTED (explicit denial still wins)',
+    await checkForGoogleRejection(mockPage(['text=denied your request'], 'live')),
+    true,
+  );
+
+  // 6c. Other explicit denial copy, same page shape.
+  await check(
+    '#840 "weren’t allowed to join" + invisible reCAPTCHA → REJECTED',
+    await checkForGoogleRejection(mockPage(['text=weren’t allowed to join'], 'invisible')),
+    true,
+  );
+
+  // 6c-bis. Order-independence: the denial screen also carries the generic "Try again"
+  //     affordance. The explicit-denial pass runs first, so the verdict does not depend
+  //     on where each selector sits in googleRejectionIndicators.
+  await check(
+    '#840 denial copy + "Try again" + live challenge → REJECTED (explicit pass runs first)',
+    await checkForGoogleRejection(
+      mockPage(['text=denied your request', 'button:has-text("Try again")'], 'live'),
+    ),
+    true,
+  );
+
+  // 6d. NEGATIVE CONTROL (b) — a plain denial with no captcha at all still rejects.
+  await check(
+    'NEG-CTRL (b): host denial, no reCAPTCHA anywhere → REJECTED',
+    await checkForGoogleRejection(mockPage(['text=denied your request'])),
+    true,
+  );
+
+  // 7. The detector no longer reads Meet's INVISIBLE scoring frame as a challenge:
+  //    an ambiguous affordance next to it is not a solvable captcha, so the bot
+  //    concludes instead of waiting for a solve that can never happen.
+  await check(
+    '#840 invisible scoring frame is NOT a challenge ("Try again" concludes, no stay-for-solve)',
+    await checkForGoogleRejection(mockPage(['button:has-text("Try again")'], 'invisible')),
+    true,
+  );
+
+  console.log('\n=== #840 — the stay-for-solve wager is BOUNDED ===');
+
+  // 8. A live challenge suppresses the ambiguous indicator only within the grace
+  //    window; past it the bot concludes terminal instead of polling forever.
+  const boundedPage = mockPage(['button:has-text("Try again")'], 'live');
+  const t0 = 1_000_000;
+  await check(
+    `bound: t+0s — live challenge suppresses (stay for solve)`,
+    await checkForGoogleRejection(boundedPage, t0),
+    false,
+  );
+  await check(
+    `bound: t+${Math.round(GRACE_MS / 2000)}s (inside grace) — still staying for solve`,
+    await checkForGoogleRejection(boundedPage, t0 + GRACE_MS / 2),
+    false,
+  );
+  await check(
+    `bound: t+${Math.round(GRACE_MS / 1000) + 1}s (past grace) — concludes TERMINAL, never loops forever`,
+    await checkForGoogleRejection(boundedPage, t0 + GRACE_MS + 1_000),
+    true,
+  );
+
+  // 8b. The clock is per-page and restarts after the page stops showing the
+  //     indicator — a later, independent challenge gets its full grace.
+  const freshPage = mockPage(['button:has-text("Try again")'], 'live');
+  await check(
+    'bound: a different page starts its own grace window (no shared clock)',
+    await checkForGoogleRejection(freshPage, t0 + GRACE_MS * 10),
+    false,
+  );
+
+  console.log('\n=== #840 — the SHIPPED wait concludes TERMINAL on the prod page shape ===');
+
+  // 9. Altitude of the claim: not just the detector, the shipped
+  //    waitForGoogleMeetingAdmission. Meeting 24348's page — stale lobby text +
+  //    "denied your request" + Meet's invisible reCAPTCHA frame — must throw the TYPED
+  //    AdmissionError("denial"), which the JoinDriver maps to `rejected` →
+  //    `awaiting_admission_rejected` (PERMANENT, no re-knock). Pre-fix it never threw:
+  //    the poll looped to the 10-minute timeout, so the meeting sat `awaiting_admission`.
+  //    The watchdog below is the "loops forever" detector — a verdict must arrive.
+  {
+    resetEscalation();
+    const deniedPage = mockPage(
+      ['text=Asking to be let in', 'text=denied your request'],
+      'invisible',
+    );
+    const got = await outcomeOf(waitForGoogleMeetingAdmission(deniedPage, 20_000, {} as any));
+    check(
+      "#840 shipped waitForGoogleMeetingAdmission(denial + invisible captcha) → AdmissionError('denial')",
+      got === "AdmissionError:denial",
+      true,
+      got,
+    );
+  }
+
   console.log('\n=== Gemini "take notes" consent gate (#454 / issue #429) ===');
 
-  // 6. Detector fires on the consent prompt copy.
+  // 9. Detector fires on the consent prompt copy.
   await check(
     'consent prompt visible → hasConsentPrompt = true',
     await hasConsentPrompt(mockPage(['text=take notes for me'])),
@@ -130,7 +306,7 @@ async function check(name: string, actual: boolean, expected: boolean) {
     false,
   );
 
-  // 7. THE #429 BUG — meeting controls (real participant tiles) visible BEHIND
+  // 10. THE #429 BUG — meeting controls (real participant tiles) visible BEHIND
   //    the consent dialog must NOT read as admitted; the bot is not truly in the
   //    call until a human accepts/declines.
   await check(
@@ -141,7 +317,7 @@ async function check(name: string, actual: boolean, expected: boolean) {
     false,
   );
 
-  // 8. CONTROL — same participant tiles without the consent prompt → admitted.
+  // 11. CONTROL — same participant tiles without the consent prompt → admitted.
   await check(
     'participant tiles, no consent prompt → admitted (control)',
     await checkForGoogleAdmissionIndicators(mockPage([], false, ['John Doe'])),

--- a/core/meetings/modules/join/src/googlemeet/admission.ts
+++ b/core/meetings/modules/join/src/googlemeet/admission.ts
@@ -13,55 +13,146 @@ import {
 // teams) throws the SAME typed error the JoinDriver maps, without one platform depending on another.
 import { AdmissionError } from "../shared/admission";
 
-// Detect an active reCAPTCHA (enterprise) challenge. Google renders it in iframes whose
-// URL contains "/recaptcha/"; it can sit on the same screen as error affordances
-// ("Try again", "Go back") that otherwise read exactly like an admin rejection. Used to
-// keep the bot ON the page (instead of quitting) so the challenge can be solved by a
-// human over VNC or an agent over CDP — after which the normal admission poll proceeds
-// into the meeting.
+// A LIVE reCAPTCHA challenge is a VISIBLE, challenge-sized `iframe[src*="recaptcha"]` —
+// the "I'm not a robot" anchor or the opened bframe. Frame-URL presence is NOT a
+// challenge: Google Meet loads reCAPTCHA Enterprise INVISIBLY on every normal join (a
+// background bot-scoring frame whose iframe is display:none), so a `/recaptcha/` frame
+// exists on clean joins and on host-denial screens alike. A live challenge keeps the bot
+// ON the page (instead of quitting) so it can be solved by a human over VNC or an agent
+// over CDP — after which the normal admission poll proceeds into the meeting.
+const CAPTCHA_MIN_WIDTH = 120;
+const CAPTCHA_MIN_HEIGHT = 40;
 export async function hasRecaptchaChallenge(page: Page): Promise<boolean> {
   try {
-    for (const frame of page.frames()) {
-      if ((frame.url() || "").includes("/recaptcha/")) return true;
+    const frames = page.frames().filter(f => (f.url() || "").includes("/recaptcha/"));
+    if (frames.length === 0) return false;
+    const iframes = page.locator('iframe[src*="recaptcha"]');
+    const count = await iframes.count().catch(() => 0);
+    for (let i = 0; i < count; i++) {
+      const el = iframes.nth(i);
+      if (!(await el.isVisible().catch(() => false))) continue;
+      // Size guard: a scoring/telemetry stub can be a 1x1 or 0x0 visible node; a real
+      // challenge widget is at least checkbox-sized. Unmeasurable box → keep the
+      // conservative "stay for solve" reading (the stay is now bounded, see below).
+      const box = typeof (el as any).boundingBox === "function"
+        ? await (el as any).boundingBox().catch(() => null)
+        : null;
+      if (!box) return true;
+      if (box.width >= CAPTCHA_MIN_WIDTH && box.height >= CAPTCHA_MIN_HEIGHT) return true;
     }
-    const iframe = page.locator('iframe[src*="recaptcha"]').first();
-    return await iframe.isVisible().catch(() => false);
+    return false;
   } catch {
     return false;
   }
 }
 
-// Function to check if bot has been rejected from the meeting
-export async function checkForGoogleRejection(page: Page): Promise<boolean> {
+// EXPLICIT host-denial copy. `googleRejectionIndicators` mixes two very different things:
+// unambiguous "the host said no" text, and generic error affordances ("Try again",
+// "Go back", "Access denied") that also render on Google's bot-block / invalid-state
+// pages. Only the second kind may ever be re-read as bot-detection; an explicit denial is
+// the host's answer and no captcha on the page can overturn it.
+const EXPLICIT_HOST_DENIAL_COPY = [
+  "denied your request",
+  "request to join was denied",
+  "you were denied",
+  "weren't allowed to join",
+  "weren’t allowed to join",
+  "not allowed to join",
+  "not admitted",
+  "ask to join again",
+];
+export function isExplicitDenialIndicator(selector: string): boolean {
+  const s = (selector || "").toLowerCase();
+  return EXPLICIT_HOST_DENIAL_COPY.some(copy => s.includes(copy));
+}
+
+// Bound on the stay-for-solve path. Suppressing a rejection indicator because a captcha
+// is on screen is a WAGER that a human/agent will solve it; the wager must expire, or the
+// bot polls until the admission timeout and the meeting never reaches a terminal state.
+export const CAPTCHA_SOLVE_GRACE_MS = 120_000;
+// First moment we suppressed a rejection indicator for this page. Per-page (WeakMap) so a
+// bot's pages never share the clock and nothing leaks after the page is gone.
+const captchaSuppressionSince = new WeakMap<object, number>();
+
+export type GoogleRejectionReason = "host_denial" | "error_page" | "captcha_unsolved";
+export type GoogleRejectionVerdict = {
+  rejected: boolean;
+  reason: GoogleRejectionReason | null;
+  selector: string | null;
+};
+
+/**
+ * Classify the page into a rejection verdict. The discrimination rule, in order:
+ *
+ *  1. EXPLICIT host-denial copy visible → REJECTED (`host_denial`), whatever else is on
+ *     the page. A reCAPTCHA element cannot overturn a host's "no" (#840).
+ *  2. Ambiguous error affordance + LIVE captcha challenge → not rejected, stay for solve,
+ *     but only within CAPTCHA_SOLVE_GRACE_MS of the first suppression.
+ *  3. Grace expired → REJECTED (`captcha_unsolved`): terminal beats hanging.
+ *  4. Ambiguous error affordance, no live challenge → REJECTED (`error_page`) — the
+ *     pre-existing #444 conflation, unchanged by this fix.
+ */
+export async function classifyGoogleRejection(
+  page: Page,
+  now: number = Date.now(),
+): Promise<GoogleRejectionVerdict> {
+  const isVisible = async (selector: string): Promise<boolean> => {
+    try {
+      return await (await page.locator(selector).first()).isVisible();
+    } catch {
+      return false;
+    }
+  };
   try {
-    // Check for rejection indicators
+    // PASS 1 — explicit host denials, scanned BEFORE anything ambiguous so the verdict
+    // does not depend on the order of googleRejectionIndicators.
     for (const selector of googleRejectionIndicators) {
+      if (!isExplicitDenialIndicator(selector)) continue;
+      if (!(await isVisible(selector))) continue;
+      captchaSuppressionSince.delete(page as unknown as object);
+      log(`🚨 Google Meet admission rejection detected: explicit host denial "${selector}" (wins over any reCAPTCHA element on the page)`);
+      return { rejected: true, reason: "host_denial", selector };
+    }
+
+    // PASS 2 — ambiguous error affordances; these, and only these, may be re-read as
+    // bot-detection while a live challenge is on screen.
+    for (const selector of googleRejectionIndicators) {
+      if (isExplicitDenialIndicator(selector)) continue;
       try {
-        const element = await page.locator(selector).first();
-        if (await element.isVisible()) {
-          // A reCAPTCHA challenge renders the same error affordances ("Try again",
-          // "Go back") as an admin rejection. If a captcha is on screen, this is Google
-          // bot-detection, NOT a host denial — classifying it as a rejection makes the
-          // bot quit before the captcha can be solved. Stay instead; the admission poll
-          // keeps running so a solve (human via VNC / agent via CDP) leads straight into
-          // admission.
-          if (await hasRecaptchaChallenge(page)) {
-            log(`🤖 reCAPTCHA present alongside rejection indicator "${selector}" — treating as bot-detection, NOT admin rejection. Staying for manual/agent solve.`);
-            return false;
+        if (!(await isVisible(selector))) continue;
+
+        if (await hasRecaptchaChallenge(page)) {
+          const since = captchaSuppressionSince.get(page as unknown as object) ?? now;
+          captchaSuppressionSince.set(page as unknown as object, since);
+          const waited = now - since;
+          if (waited < CAPTCHA_SOLVE_GRACE_MS) {
+            log(`🤖 Live reCAPTCHA challenge alongside ambiguous indicator "${selector}" — treating as bot-detection, NOT admin rejection. Staying for manual/agent solve (${Math.round(waited / 1000)}s/${Math.round(CAPTCHA_SOLVE_GRACE_MS / 1000)}s).`);
+            return { rejected: false, reason: null, selector };
           }
-          log(`🚨 Google Meet admission rejection detected: Found rejection indicator "${selector}"`);
-          return true;
+          captchaSuppressionSince.delete(page as unknown as object);
+          log(`⏱️ reCAPTCHA stay-for-solve bound exceeded (${Math.round(waited / 1000)}s > ${Math.round(CAPTCHA_SOLVE_GRACE_MS / 1000)}s) with "${selector}" still on screen — concluding terminal instead of polling forever.`);
+          return { rejected: true, reason: "captcha_unsolved", selector };
         }
+
+        captchaSuppressionSince.delete(page as unknown as object);
+        log(`🚨 Google Meet admission rejection detected: Found rejection indicator "${selector}"`);
+        return { rejected: true, reason: "error_page", selector };
       } catch (e) {
         // Continue checking other selectors
         continue;
       }
     }
-    return false;
+    captchaSuppressionSince.delete(page as unknown as object);
+    return { rejected: false, reason: null, selector: null };
   } catch (error: any) {
     log(`Error checking for Google Meet rejection: ${error.message}`);
-    return false;
+    return { rejected: false, reason: null, selector: null };
   }
+}
+
+// Function to check if bot has been rejected from the meeting
+export async function checkForGoogleRejection(page: Page, now: number = Date.now()): Promise<boolean> {
+  return (await classifyGoogleRejection(page, now)).rejected;
 }
 
 // Helper function to check for any visible and enabled admission indicators
@@ -233,11 +324,20 @@ export async function hasConsentPrompt(page: Page): Promise<boolean> {
   return false;
 }
 
+// Terminal admission verdicts carry an honest reason: a host denial says so, and an
+// unsolved captcha says THAT — both map to AdmissionError("denial") (PERMANENT, no
+// re-knock), which the JoinDriver records as `awaiting_admission_rejected`.
+const REJECTION_MESSAGE: Record<GoogleRejectionReason, string> = {
+  host_denial: "Bot admission was rejected by meeting admin",
+  error_page: "Bot admission was rejected by meeting admin",
+  captcha_unsolved: `Bot faced a reCAPTCHA challenge that went unsolved for ${Math.round(CAPTCHA_SOLVE_GRACE_MS / 1000)}s alongside a rejection screen`,
+};
+
 async function throwIfGoogleAdmissionRejected(page: Page, context: string): Promise<void> {
-  const isRejected = await checkForGoogleRejection(page);
-  if (isRejected) {
-    log(`🚨 Bot was rejected from the Google Meet meeting by admin (${context})`);
-    throw new AdmissionError("denial", "Bot admission was rejected by meeting admin");
+  const verdict = await classifyGoogleRejection(page);
+  if (verdict.rejected) {
+    log(`🚨 Bot admission concluded terminal for the Google Meet meeting (${verdict.reason}, ${context})`);
+    throw new AdmissionError("denial", REJECTION_MESSAGE[verdict.reason!]);
   }
 }
 
@@ -377,19 +477,13 @@ export async function waitForGoogleMeetingAdmission(
       const effectiveTimeout2 = () => timeout + getEscalationExtensionMs();
       while (Date.now() - startTime < effectiveTimeout2()) {
         // #444 — the `blocked` state is wired (callBlockedCallback), but NOT emitted yet.
-        // hasRecaptchaChallenge() is too loose to drive it: Google Meet loads reCAPTCHA
-        // Enterprise INVISIBLY on every normal join (a background bot-scoring frame), so
-        // matching a "/recaptcha/" frame url false-fires on clean joins — verified live
-        // 2026-06-12 (humanized, residential): blocked->awaiting->admitted, no real challenge.
-        // The real block detector (VISIBLE challenge / blank block page) needs a run that
-        // actually reproduces a block (datacenter egress arm) to build without false positives.
+        // hasRecaptchaChallenge() detects a VISIBLE, challenge-sized widget, which is the
+        // narrow half of the signal; the blank block page half needs a run that actually
+        // reproduces a block (datacenter egress arm) before it can drive `blocked` without
+        // false positives.
 
         // Rejection check first
-        const isRejected = await checkForGoogleRejection(page);
-        if (isRejected) {
-          log("🚨 Bot was rejected from the Google Meet meeting by admin (polling mode)");
-          throw new AdmissionError("denial", "Bot admission was rejected by meeting admin");
-        }
+        await throwIfGoogleAdmissionRejected(page, "polling mode");
 
         // Admission indicators — if meeting controls are visible, bot is admitted
         // regardless of any residual lobby-like elements in the DOM
@@ -459,10 +553,7 @@ export async function waitForGoogleMeetingAdmission(
 
     // Before concluding failure, check for rejection one last time
     log("No admission indicators after timeout - checking rejection one last time...");
-    const finalRejected = await checkForGoogleRejection(page);
-    if (finalRejected) {
-      throw new AdmissionError("denial", "Bot admission was rejected by meeting admin");
-    }
+    await throwIfGoogleAdmissionRejected(page, "final check");
 
     // Distinguish lobby-timeout from join-failure by checking waiting-room state
     const lobbyStillVisible = await checkForWaitingRoomIndicators(page);

--- a/docs/changelog.d/840-gmeet-denial-vs-captcha.md
+++ b/docs/changelog.d/840-gmeet-denial-vs-captcha.md
@@ -1,0 +1,8 @@
+- **Google Meet: a host denial now ends the meeting instead of hanging forever (#840).** Meet loads
+  reCAPTCHA Enterprise invisibly on every join, so a background captcha frame sat on the denial
+  screen too — the bot read it as bot-detection, logged "staying for manual/agent solve" every two
+  seconds, and the meeting stayed `awaiting_admission` until the 10-minute lobby timeout (which is
+  retried, so a host who said no could be knocked on again). An explicit denial ("denied your
+  request", "weren't allowed to join", …) now wins over any captcha on the page, only a *visible*
+  challenge widget counts as a real captcha, and the stay-for-solve wait is bounded at two minutes.
+  A denied bot reports `failed / awaiting_admission_rejected` — permanent, no re-knock.


### PR DESCRIPTION
Closes #840

## What was wrong (verified against the tree)

`admission.ts` had a guard that suppressed a rejection indicator whenever
`hasRecaptchaChallenge(page)` was true — and that detector returned true for **any frame
whose URL contains `/recaptcha/`**. The tree already carried the live measurement that
kills this premise (admission.ts, the #444 note in the polling loop, verified live
2026-06-12): *Google Meet loads reCAPTCHA Enterprise **INVISIBLY** on every normal join —
a background bot-scoring frame*. So the frame is on the denial screen too. That answers
the issue's open question: **fork (b)** — the detector was too loose; nothing about the
denial page is captcha-ish, Meet's ambient scoring frame is simply always there.

The guard therefore swallowed the real denial (`text=denied your request`), returned
`false`, and the poll kept going — the 2s "staying for manual/agent solve" loop, meeting
stuck `awaiting_admission`.

## The discrimination rule now implemented

1. **Explicit host-denial copy wins over any captcha** — "denied your request", "request
   to join was denied", "you were denied", "weren't allowed to join", "not allowed to
   join", "not admitted", "Ask to join again". Scanned in its **own first pass**, so the
   verdict does not depend on where a selector sits in `googleRejectionIndicators`.
2. **Only ambiguous error affordances** ("Try again", "Go back", "Retry", …) may still be
   re-read as bot-detection — and only next to a **LIVE** challenge: a *visible*,
   challenge-sized (`>=120x40`) `iframe[src*="recaptcha"]`. A `/recaptcha/` frame with no
   visible widget is Meet's scoring frame, never a solvable challenge.
3. **The stay-for-solve wager expires** — `CAPTCHA_SOLVE_GRACE_MS = 120_000`, tracked
   per-page (WeakMap). Past the bound the bot concludes terminal rather than polling on.
   Staying forever is never the right answer.

`classifyGoogleRejection()` returns a typed verdict (`host_denial` / `error_page` /
`captcha_unsolved`) so the throw carries an honest reason; all three rejection call sites
in `waitForGoogleMeetingAdmission` now route through `throwIfGoogleAdmissionRejected`,
which throws `AdmissionError("denial")` → JoinDriver `rejected` →
`awaiting_admission_rejected` (**PERMANENT**, no re-knock). That mapping lives in
`core/meetings/services/bot/src/{join-driver,orchestrator}.ts` and needed **no change** —
it was correct all along; Meet just never reached it.

Scope: `googlemeet/admission.ts` + `googlemeet/admission.test.ts` only (`join.ts`,
`selectors.ts`, `msteams/**` are being edited by concurrent issues — untouched here; the
explicit-vs-ambiguous split is expressed inside `admission.ts` precisely so `selectors.ts`
did not have to move).

## Observation bundle

All rows are fabricated-DOM, **no live meeting, no browser, no Google**
(`core/meetings/modules/join/src/googlemeet/admission.test.ts`). The mock models three
captcha shapes: `false`, `'invisible'` (a `/recaptcha/` **frame** whose iframe element is
`display:none` — the real prod page), `'live'` (a visible 400x580 challenge).

| # | Acceptance item | Observation |
|---|---|---|
| 1 | Measured: what `hasRecaptchaChallenge` matched on a denial page | **fork (b)** — frame-URL presence. Grounded in this file's own live-run note (Meet's invisible Enterprise scoring frame, verified live 2026-06-12), not re-measured live here — see *Not checked* below. |
| 2 | Real denial throws `denial` even with a captcha element present | **RED→GREEN** (below), unit + shipped-function level |
| 3 | Negative control: a GENUINE captcha still takes stay-for-solve | **GREEN, passes before and after** — it is a true control |
| 4 | Stay-for-solve is BOUNDED | **RED→GREEN** at t+121s |

### RED (pre-fix source, same test file — namespace import lets it run against both)

```
FAIL  #840 host denial + invisible reCAPTCHA scoring frame → REJECTED   (expected true, got false)
FAIL  #840 host denial + LIVE reCAPTCHA challenge → REJECTED            (expected true, got false)
FAIL  #840 "weren’t allowed to join" + invisible reCAPTCHA → REJECTED   (expected true, got false)
FAIL  #840 denial copy + "Try again" + live challenge → REJECTED        (expected true, got false)
FAIL  #840 invisible scoring frame is NOT a challenge                   (expected true, got false)
FAIL  bound: t+121s (past grace) — concludes TERMINAL                   (expected true, got false)
PASS  NEG-CTRL (a): live reCAPTCHA + "Try again", no denial copy → NOT a denial
PASS  NEG-CTRL (b): host denial, no reCAPTCHA anywhere → REJECTED
```

**RED at the altitude of the claim** — the SHIPPED `waitForGoogleMeetingAdmission` driven
over the prod page shape (stale lobby text + "denied your request" + invisible captcha
frame), pre-fix source, `waitingRoomTimeout=20_000`:

```
RED-RESULT: AdmissionError:lobby_timeout after 320002ms
"Staying for manual/agent solve" log lines: 25,141,371
```

Never a denial: it burned the full timeout **plus the 5-minute escalation extension** and
then reported `lobby_timeout` → `awaiting_admission_timeout` → **TRANSIENT** → the control
plane may re-knock on a host who said no. That is exactly the compounding damage the issue
describes, reproduced with no live meeting.

### GREEN (this branch)

```
=== Google Meet rejection detector — #471 fix + remaining #444 conflation ===
  PASS  #471 waiting screen ("Return to home screen", no denial text) → NOT a denial (fixed)
  PASS  #471 "Return to home screen" → recognized as waiting-room indicator
  PASS  CONFLATION (#444, still open): Google error/block page ("Try again") → reported as DENIAL
  PASS  genuine host denial ("denied your request") → rejection (correct)
  PASS  NEG-CTRL (a): live reCAPTCHA + "Try again", no denial copy → NOT a denial (stay-for-solve preserved)
  PASS  clean waiting-room (no rejection text) → not a rejection (correct)
=== #840 — host denial vs. reCAPTCHA (prod meeting 24348) ===
  PASS  #840 host denial + invisible reCAPTCHA scoring frame → REJECTED (explicit denial wins)
  PASS  #840 host denial + LIVE reCAPTCHA challenge → REJECTED (explicit denial still wins)
  PASS  #840 "weren’t allowed to join" + invisible reCAPTCHA → REJECTED
  PASS  #840 denial copy + "Try again" + live challenge → REJECTED (explicit pass runs first)
  PASS  NEG-CTRL (b): host denial, no reCAPTCHA anywhere → REJECTED
  PASS  #840 invisible scoring frame is NOT a challenge ("Try again" concludes, no stay-for-solve)
=== #840 — the stay-for-solve wager is BOUNDED ===
  PASS  bound: t+0s — live challenge suppresses (stay for solve)
  PASS  bound: t+60s (inside grace) — still staying for solve
  PASS  bound: t+121s (past grace) — concludes TERMINAL, never loops forever
  PASS  bound: a different page starts its own grace window (no shared clock)
=== #840 — the SHIPPED wait concludes TERMINAL on the prod page shape ===
  PASS  #840 shipped waitForGoogleMeetingAdmission(denial + invisible captcha) → AdmissionError('denial')
=== Gemini "take notes" consent gate (#454 / issue #429) ===
  PASS  consent prompt visible → hasConsentPrompt = true
  PASS  no consent prompt → hasConsentPrompt = false
  PASS  consent prompt + participant tiles → admission SUPPRESSED (no false ACTIVE)
  PASS  participant tiles, no consent prompt → admitted (control)
=== summary: 21 passed, 0 failed ===
```

The whole run takes **0.4s** post-fix vs. **320s with no denial** pre-fix — the terminal
verdict now lands on the first poll.

### Suites and gates

```
pnpm install --frozen-lockfile && pnpm -r build     → clean
core/meetings/modules/join   pnpm test              → exit 0 (all platform suites)
core/meetings/services/bot   pnpm test              → exit 0
npx tsc --noEmit -p core/meetings/modules/join      → clean
MOCK_BOT=1 BROWSER_IMAGE=mock-bot:dev node scripts/gates.mjs all → ✅ gates green (32 gates;
  compose-stress / compose-chaos skip as opt-in)
```

### Not checked (stated plainly)

- **No live Google Meet host-denial run.** The issue's live-witness row remains open: a
  human must deny a bot from a real Meet lobby and confirm the meeting lands
  `failed / awaiting_admission_rejected` (not `awaiting_admission`) within seconds. I am
  flagging it, not claiming it.
- **Acceptance item 1 was not re-measured on a live denial page** (no page HTML/screenshot
  captured by me). The fork-(b) conclusion rests on the in-tree live measurement from
  2026-06-12 quoted above. If a live capture ever shows a *visible* challenge widget on a
  denial screen, rule 1 still carries the fix — the explicit denial wins regardless.
- The #444 conflation (generic "Try again" on a Google block page reported as `denial`) is
  **unchanged and still open**; its regression row is kept, documenting the present.
- `docs/changelog.d/840-gmeet-denial-vs-captcha.md` is the docs touch (no hot-file edits).
