### PR TITLE
fix(meetings): a bot waiting in the lobby is liveness-gated, not reaped on silence (#862)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -257,12 +257,24 @@ def _attach_background_loops(
     stop_interval = float(os.getenv("STOP_RECONCILE_INTERVAL_S", "15"))
     # GENERAL reconcile: ANY non-terminal status whose bot is gone (its row quiet past the grace) is
     # converged to a terminal state through the same lifecycle callback. `stopping` uses stop_grace
-    # (a stop was requested); `active`/etc. use `active_grace`. The active-reap is ADDITIONALLY gated on
-    # runtime WORKLOAD liveness (reconcile.py `_bot_workload_gone`): a meeting whose bot workload is still
+    # (a stop was requested); `active`/etc. use `active_grace`. The reap is ADDITIONALLY gated on
+    # runtime WORKLOAD liveness (reconcile.py `_probe_bot_workload`): a meeting whose bot workload is still
     # alive is NEVER reaped, even past the grace — so a quiet-but-live (silent) bot is safe regardless of
     # this window. With that gate in place, 300s is a SANE default again (the 86400 env stopgap, which
     # only worked because it disabled the time-based reap entirely, is no longer needed).
     active_grace = float(os.getenv("RECONCILE_ACTIVE_GRACE_S", "300"))
+    # A bot that has NOT yet reached the meeting gets its OWN, longer window (#862). The control plane
+    # hands every spawn a lobby budget (`waitingRoomTimeout`) and the bot reports `awaiting_admission`
+    # exactly ONCE before polling silently for the rest of it — so a HEALTHY bot waiting to be let in
+    # is indistinguishable from a dead one for the whole wait, and OUR patience has to outlast the
+    # deadline WE issued. Hence a floor DERIVED from that budget (+60s of headroom for the bot's own
+    # terminal callback to land) rather than a second number free to drift under it. The liveness
+    # gate is the primary defence; this is the belt for an inconclusive probe.
+    from .lifecycle.reconcile import default_preactive_grace
+
+    preactive_grace = float(
+        os.getenv("RECONCILE_PREACTIVE_GRACE_S", str(default_preactive_grace()))
+    )
     # Bounded untracked escalation (the zombie-loop fix): a meeting whose workload stays UNTRACKED
     # (runtime 404) CONTINUOUSLY past this window — no runtime re-adoption, no bot callback — is
     # presumed lost (runtime restart on the process backend / external removal) and advanced to
@@ -410,7 +422,7 @@ def _attach_background_loops(
                 await reconcile_stale_nonterminal_sweep(
                     meeting_repo, runtime, _post_lifecycle,
                     stop_grace=stop_grace, active_grace=active_grace, log=log,
-                    untracked_grace=untracked_grace,
+                    preactive_grace=preactive_grace, untracked_grace=untracked_grace,
                 )
             await reconcile_stale_stopping_sweep(
                 meeting_repo, runtime, _post_lifecycle, stop_grace=stop_grace, log=log,

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -21,6 +21,7 @@ from .ports import (
     QuotaExceeded,
     SpawnFailed,
     WorkloadUnknown,
+    reconcile_grace_for_status,
 )
 
 
@@ -320,7 +321,7 @@ class SqlAlchemyMeetingRepo:
         return [(mid, sid, bcid) for mid, (sid, bcid) in out.items()]
 
     async def list_stale_nonterminal(
-        self, *, stop_grace: float, active_grace: float
+        self, *, stop_grace: float, active_grace: float, preactive_grace: Optional[float] = None
     ) -> list[tuple[int, str, str, Optional[str], bool]]:
         """Meetings stuck in ANY non-terminal status whose row has gone quiet past its grace window —
         a bot that exited (or vanished) without ever sending its terminal lifecycle callback leaves the
@@ -329,8 +330,10 @@ class SqlAlchemyMeetingRepo:
         CANDIDATE signal only — the sweep additionally gates the active-reap on runtime workload
         liveness (see ``reconcile.py``), because a silent-but-live bot stops bumping ``updated_at``.
 
-        Per-row window: ``stopping`` uses ``stop_grace`` (a stop was requested — clear it fast),
-        everything else uses ``active_grace`` (a longer idle so a momentarily-quiet live bot is not
+        Per-row window: ``stopping`` uses ``stop_grace`` (a stop was requested — clear it fast), a
+        PRE-ACTIVE row (`requested`/`joining`/`awaiting_admission` — the bot has not reached the
+        meeting yet, and holds the lobby budget the control plane handed it) uses ``preactive_grace``,
+        everything else ``active_grace`` (a longer idle so a momentarily-quiet live bot is not
         reaped). Returns ``[(meeting_id, status, session_uid, bot_container_id, stop_requested), …]`` with
         the LATEST session_uid per meeting (mirrors ``list_stale_stopping``)."""
         from datetime import datetime, timezone
@@ -358,7 +361,7 @@ class SqlAlchemyMeetingRepo:
             if mid in out or upd is None or not sid:
                 continue
             u = upd if upd.tzinfo else upd.replace(tzinfo=timezone.utc)
-            grace = stop_grace if status == "stopping" else active_grace
+            grace = reconcile_grace_for_status(status, stop_grace, active_grace, preactive_grace)
             if (now - u).total_seconds() >= grace:
                 stop_req = bool(isinstance(data, dict) and data.get("stop_requested"))
                 out[mid] = (status, sid, bcid, stop_req)

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -24,6 +24,7 @@ from .ports import (
     QuotaExceeded,
     SpawnFailed,
     WorkloadUnknown,
+    reconcile_grace_for_status,
 )
 
 _ACTIVE_STATUSES = ("requested", "joining", "awaiting_admission", "active")
@@ -262,12 +263,13 @@ class InMemoryMeetingRepo:
         )
 
     async def list_stale_nonterminal(
-        self, *, stop_grace: float, active_grace: float
+        self, *, stop_grace: float, active_grace: float, preactive_grace: Optional[float] = None
     ) -> list:
         """In-memory mirror of the SQL adapter's general reconcile query. A row is stale once its age
-        (now - ``updated_at``) passes its per-status grace (``stopping`` → stop_grace, else
-        active_grace). Rows carry a static created/updated timestamp, so a test sets ``updated_at`` (or
-        leaves it in the past) to mark a row stale; a row whose ``updated_at`` is recent is NOT listed."""
+        (now - ``updated_at``) passes its per-status grace (``reconcile_grace_for_status`` — the SAME
+        policy the SQL adapter reads, so the two listings cannot drift). Rows carry a static created/
+        updated timestamp, so a test sets ``updated_at`` (or leaves it in the past) to mark a row
+        stale; a row whose ``updated_at`` is recent is NOT listed."""
         from datetime import datetime, timezone
 
         non_terminal = {
@@ -292,7 +294,9 @@ class InMemoryMeetingRepo:
                 continue
             if u.tzinfo is None:
                 u = u.replace(tzinfo=timezone.utc)
-            grace = stop_grace if row["status"] == "stopping" else active_grace
+            grace = reconcile_grace_for_status(
+                row["status"], stop_grace, active_grace, preactive_grace
+            )
             if (now - u).total_seconds() < grace:
                 continue
             stop_req = bool(row.get("data", {}).get("stop_requested"))

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
@@ -260,3 +260,29 @@ class DuplicateMeeting(Exception):
     Raised by ``MeetingRepo.create_meeting_guarded`` (the atomic dedup) — either because the in-txn
     dedup query found an active row, or because the unique partial index on active rows rejected the
     concurrent insert (the DB-level backstop). Re-exported from ``service`` for the router's mapping."""
+
+
+# Statuses in which the bot has NOT yet reached the meeting. Their row goes quiet by DESIGN — a bot
+# parked in a waiting room reports `awaiting_admission` once and then polls silently for the whole
+# lobby budget the control plane handed it — so they carry their OWN (longer) reconcile window.
+PRE_ACTIVE_MEETING_STATUSES = frozenset({"requested", "joining", "awaiting_admission"})
+
+
+def reconcile_grace_for_status(
+    status: Optional[str],
+    stop_grace: float,
+    active_grace: float,
+    preactive_grace: Optional[float] = None,
+) -> float:
+    """The reconcile window a stale row is measured against — the ONE definition both the SQL adapter
+    and the in-memory fake read, so the two listings can never drift.
+
+      * ``stopping``   → ``stop_grace``      (a stop was requested: clear it fast)
+      * PRE-ACTIVE     → ``preactive_grace`` (must OUTLAST the lobby budget we issued — #862)
+      * everything else→ ``active_grace``    (a bot-present row: a longer idle before we look)
+    """
+    if status == "stopping":
+        return stop_grace
+    if status in PRE_ACTIVE_MEETING_STATUSES:
+        return active_grace if preactive_grace is None else preactive_grace
+    return active_grace

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -45,7 +45,15 @@ from .ports import (
 
 # Re-exported here (defined in ports.py to avoid an adapters→service circular import) so callers that
 # already do ``from .service import DuplicateMeeting`` (the router) keep working.
-__all__ = ["request_bot", "construct_meeting_url", "DuplicateMeeting"]
+__all__ = ["request_bot", "construct_meeting_url", "DuplicateMeeting", "LOBBY_BUDGET_MS"]
+
+# The waiting-room budget the control plane ISSUES to every bot it spawns (``automatic_leave
+# .waitingRoomTimeout``): how long the bot may sit in a lobby, silently polling, before it gives up
+# and reports its own ``awaiting_admission_timeout``. It is a DEADLINE WE WROTE, so every window the
+# control plane measures a not-yet-admitted bot against must outlast it — the reconcile sweep derives
+# its pre-active grace from this constant (``lifecycle.reconcile.default_preactive_grace``) rather
+# than carrying a second, independently-drifting number (#862).
+LOBBY_BUDGET_MS = 600_000
 
 # Non-terminal statuses (parent's active set) — a prior meeting in one of these blocks a new spawn.
 _ACTIVE_STATUSES = ("requested", "joining", "awaiting_admission", "active", "stopping")
@@ -387,7 +395,7 @@ async def request_bot(
         # Explicit caller windows win; otherwise omit everyoneLeftTimeout so the bot's
         # silence-window module default applies (the lobby window stays forgiving for
         # human-in-the-loop dashboard joins).
-        automatic_leave=automatic_leave or {"waitingRoomTimeout": 600_000},
+        automatic_leave=automatic_leave or {"waitingRoomTimeout": LOBBY_BUDGET_MS},
     )
 
     # 5. Spawn over runtime.v1.

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -366,6 +366,13 @@
    "targets": []
   },
   {
+   "key": "RECONCILE_PREACTIVE_GRACE_S",
+   "class": "defaulted",
+   "default": "660",
+   "description": "grace (s) before a meeting whose bot has NOT yet reached the room (requested/joining/awaiting_admission) is reconciled — derived from the lobby budget the spawn issues (waitingRoomTimeout 600s) plus headroom, so the control plane is never less patient than the deadline it handed the bot (#862)",
+   "targets": []
+  },
+  {
    "key": "MEETING_UNTRACKED_GRACE_SEC",
    "class": "defaulted",
    "default": "600",

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
@@ -99,11 +99,17 @@ async def reconcile_stale_stopping_sweep(
 # (the bot WAS live) reconcile to `completed`.
 _PRE_ACTIVE_NONTERMINAL = frozenset({"requested", "joining", "awaiting_admission", "needs_help"})
 
-# Statuses where a BOT IS (or was) IN THE MEETING and may be legitimately quiet — silence (no segments)
-# does NOT mean the bot is gone, so the active-reap on these is gated on POSITIVE evidence the bot's
-# workload is no longer alive (runtime liveness), NOT on `updated_at`/segment staleness. `stopping` is
-# EXCLUDED: a stop was requested, so it reaps on its short grace regardless (its bot SHOULD be leaving).
-_LIVE_NONTERMINAL = frozenset({"active", "needs_help"})
+# Statuses where a BOT MAY BE ALIVE and legitimately QUIET — either in the meeting (`active`/
+# `needs_help`) or on its way in (`requested`/`joining`/`awaiting_admission`). Silence does NOT mean
+# the bot is gone: an ACTIVE bot stops bumping `updated_at` through a silent room, and a bot parked in
+# a waiting room reports `awaiting_admission` ONCE and then polls for up to the lobby budget the
+# control plane itself handed it (``bot_spawn.service.LOBBY_BUDGET_MS``) — there is no heartbeat on
+# either path. So the reap on ALL of these is gated on POSITIVE evidence the bot's workload is no
+# longer alive (runtime liveness), NOT on `updated_at`/segment staleness. `stopping` is EXCLUDED: a
+# stop was requested, so it reaps on its short grace regardless (its bot SHOULD be leaving).
+_LIVENESS_GATED = frozenset(
+    {"requested", "joining", "awaiting_admission", "needs_help", "active"}
+)
 
 # runtime.v1 workload states that mean the bot is STILL ALIVE in the meeting (the workload exists and is
 # not torn down). A TRACKED workload in any other state is positive evidence the bot exited. A 404
@@ -113,8 +119,10 @@ _ALIVE_WORKLOAD_STATES = frozenset({"starting", "running", "stopping"})
 
 async def _probe_bot_workload(
     runtime: Optional[Any], bot_container_id: Optional[str], *, log: Any
-) -> str:
-    """Liveness probe for the active-reap gate. Returns:
+) -> tuple[str, Optional[dict]]:
+    """Liveness probe for the reap gate. Returns ``(verdict, workload_info)`` — the info is the
+    kernel's own answer, carried back so a reap can ATTRIBUTE itself to real evidence instead of
+    manufacturing a reason. Verdicts:
 
       * ``"gone"``      — POSITIVE evidence the bot exited: the kernel TRACKS the workload and
                           reports a terminal state (stopped/destroyed…, with an exit code).
@@ -126,15 +134,48 @@ async def _probe_bot_workload(
                           safe toward keeping a possibly-live meeting.
     """
     if runtime is None or not bot_container_id or not hasattr(runtime, "get_workload"):
-        return "unknown"
+        return "unknown", None
     try:
         info = await runtime.get_workload(bot_container_id)
     except Exception:  # noqa: BLE001 — probe is best-effort; unknown ⇒ do NOT reap
         log.warning("nonterminal-reconcile: get_workload(%s) failed; not reaping", bot_container_id)
-        return "unknown"
+        return "unknown", None
     if info is None:  # 404 — the kernel does not KNOW; never mistake amnesia for evidence
-        return "untracked"
-    return "alive" if info.get("state") in _ALIVE_WORKLOAD_STATES else "gone"
+        return "untracked", None
+    if info.get("state") in _ALIVE_WORKLOAD_STATES:
+        return "alive", info
+    return "gone", info
+
+
+def _workload_evidence(bot_container_id: Optional[str], info: Optional[dict]) -> str:
+    """The probe's answer, rendered for the terminal transition's ``reason``. This is what replaces
+    the manufactured "bot gone while {status}": a reader learns WHAT the kernel reported (state,
+    exit code, stop reason) — or, honestly, that there was nothing to ask about."""
+    if not bot_container_id:
+        return "no workload recorded for this meeting"
+    if not info:
+        return f"workload {bot_container_id}: no runtime evidence (probe inconclusive)"
+    parts = [f"workload {bot_container_id} state={info.get('state') or 'unknown'}"]
+    code = info.get("exitCode", info.get("exit_code"))
+    if code is not None:
+        parts.append(f"exitCode={code}")
+    stop_reason = info.get("stopReason") or info.get("stop_reason")
+    if stop_reason:
+        parts.append(f"stopReason={stop_reason}")
+    return " ".join(parts)
+
+
+def default_preactive_grace() -> float:
+    """The pre-active reap floor, DERIVED from the lobby budget the control plane itself issues.
+
+    A not-yet-admitted bot holds a deadline WE wrote (``bot_spawn.service.LOBBY_BUDGET_MS``, the
+    spawn's ``waitingRoomTimeout``); the window we then measure it against must outlast that deadline,
+    or the control plane kills bots that are still inside the budget it granted them (#862). Deriving
+    the floor — the budget plus a minute of headroom for the bot's own terminal callback to land —
+    keeps the two in lockstep: shorten the budget and the floor follows."""
+    from ..bot_spawn.service import LOBBY_BUDGET_MS
+
+    return LOBBY_BUDGET_MS / 1000.0 + 60.0
 
 
 # ── bounded untracked escalation (the zombie-loop fix) ───────────────────────────────────────────
@@ -172,20 +213,28 @@ async def _escalate_untracked_zombie(
     *,
     grace: float,
     log: Any,
+    stop_requested: bool = False,
 ) -> bool:
     """Advance a continuously-untracked meeting to ``failed`` — through the bot's OWN lifecycle
     callback, with the evidence note as the transition's reason. WARN, not error: this is the
-    system converging on its declared policy, not a fresh surprise."""
+    system converging on its declared policy, not a fresh surprise.
+
+    A PRE-ACTIVE row is attributed to the stage it was lost in (``_pre_active_completion_reason``),
+    so a bot that never reached the meeting stays RE-SPAWNABLE (#862 — ``left_alone`` is
+    ``_PERMANENT`` in ``retry.py``, and using it here cancelled the legitimate retry)."""
     reason = (
         f"workload {bot_container_id} untracked for >{int(grace)}s; presumed lost — "
         "runtime restart or external removal"
     )
-    stage = status if status in ("requested", "joining", "awaiting_admission") else "active"
+    pre_active = status in _PRE_ACTIVE_STATUSES
+    stage = status if pre_active else "active"
     body = {
         "connection_id": session_uid,
         "status": "failed",
         "failure_stage": stage,
-        "completion_reason": "left_alone",
+        "completion_reason": (
+            _pre_active_completion_reason(status, stop_requested) if pre_active else "left_alone"
+        ),
         "reason": reason,
     }
     log.warning(
@@ -210,6 +259,7 @@ async def reconcile_stale_nonterminal_sweep(
     stop_grace: float,
     active_grace: float,
     log: Any,
+    preactive_grace: Optional[float] = None,
     untracked_grace: float = 600.0,
     untracked_since: Optional[dict] = None,
 ) -> int:
@@ -223,16 +273,21 @@ async def reconcile_stale_nonterminal_sweep(
       * `requested` / `joining` / `awaiting_admission` / `needs_help` (never reached `active`) → `failed`,
         attributed to the stage it died in.
 
-    Two grace windows (env-configurable): ``stop_grace`` for `stopping` (a stop was requested — clear it
-    fast), ``active_grace`` for everything else (a longer idle so a momentarily-quiet live bot is not
-    reaped). Best-effort per meeting — never raises. Idempotent: an already-terminal row is not listed by
+    THREE grace windows (env-configurable): ``stop_grace`` for `stopping` (a stop was requested — clear
+    it fast), ``preactive_grace`` for a bot that has not reached the meeting yet (it holds a lobby
+    budget from the control plane — our patience must OUTLAST the deadline we issued, #862), and
+    ``active_grace`` for everything else (a longer idle so a momentarily-quiet live bot is not reaped).
+    Best-effort per meeting — never raises. Idempotent: an already-terminal row is not listed by
     ``list_stale_nonterminal``, and a redelivered terminal is an idempotent 200 no-op at the callback.
 
     Returns the number of meetings reconciled."""
     if repo is None or not hasattr(repo, "list_stale_nonterminal"):
         return 0
     try:
-        stale = await repo.list_stale_nonterminal(stop_grace=stop_grace, active_grace=active_grace)
+        stale = await repo.list_stale_nonterminal(
+            stop_grace=stop_grace, active_grace=active_grace,
+            preactive_grace=active_grace if preactive_grace is None else preactive_grace,
+        )
     except Exception:
         log.exception("nonterminal-reconcile: list_stale_nonterminal failed")
         return 0
@@ -241,15 +296,20 @@ async def reconcile_stale_nonterminal_sweep(
     seen_untracked: set = set()
     now = time.monotonic()
     for meeting_id, status, session_uid, bot_container_id, stop_requested in stale:
-        # LIVENESS GATE (the correctness fix): for a status where a bot is in the meeting and may be
-        # legitimately QUIET (`active`/`needs_help`), `updated_at` staleness is NOT evidence the bot
-        # is gone — segments stop bumping it during silence. Only POSITIVE evidence ("gone": the
-        # kernel TRACKS the workload and reports it terminal) reaps. A 404 ("untracked") is NOT
-        # evidence — a recreated runtime forgets live bots (the orphaned-live-bot incident advanced
-        # a live, capturing meeting to `completed` on exactly that 404). `stopping` is exempt (a
-        # stop was requested → it converges on its grace, gated on a CONFIRMED teardown below).
-        if status in _LIVE_NONTERMINAL and bot_container_id:
-            probe = await _probe_bot_workload(runtime, bot_container_id, log=log)
+        probe, probe_info = "unknown", None
+        # LIVENESS GATE (the correctness fix): for a status where a bot may be alive and legitimately
+        # QUIET — in the meeting (`active`/`needs_help`) or on its way in (`requested`/`joining`/
+        # `awaiting_admission`) — `updated_at` staleness is NOT evidence the bot is gone. Segments
+        # stop bumping it through a silent room, and a lobby bot emits `awaiting_admission` ONCE and
+        # then polls silently for the whole budget we handed it (#862: the sweep force-deleted
+        # HEALTHY bots that were still waiting to be let in, at 300s of a 600s wait). Only POSITIVE
+        # evidence ("gone": the kernel TRACKS the workload and reports it terminal) reaps. A 404
+        # ("untracked") is NOT evidence — a recreated runtime forgets live bots (the orphaned-live-bot
+        # incident advanced a live, capturing meeting to `completed` on exactly that 404). `stopping`
+        # is exempt (a stop was requested → it converges on its grace, gated on a CONFIRMED teardown
+        # below).
+        if status in _LIVENESS_GATED and bot_container_id:
+            probe, probe_info = await _probe_bot_workload(runtime, bot_container_id, log=log)
             if probe == "untracked":
                 _log_workload_untracked(meeting_id, status, bot_container_id)
                 log.error(
@@ -265,7 +325,7 @@ async def reconcile_stale_nonterminal_sweep(
                     tracker, meeting_id, seen_untracked, grace=untracked_grace, now=now
                 ) and await _escalate_untracked_zombie(
                     meeting_id, status, session_uid, bot_container_id, post_lifecycle,
-                    tracker, grace=untracked_grace, log=log,
+                    tracker, grace=untracked_grace, log=log, stop_requested=stop_requested,
                 ):
                     reconciled += 1
                 continue
@@ -290,7 +350,7 @@ async def reconcile_stale_nonterminal_sweep(
                 tracker, meeting_id, seen_untracked, grace=untracked_grace, now=now
             ) and await _escalate_untracked_zombie(
                 meeting_id, status, session_uid, bot_container_id, post_lifecycle,
-                tracker, grace=untracked_grace, log=log,
+                tracker, grace=untracked_grace, log=log, stop_requested=stop_requested,
             ):
                 reconciled += 1
             continue
@@ -301,8 +361,18 @@ async def reconcile_stale_nonterminal_sweep(
             if stop_requested:
                 body["data"] = {"stop_requested": True}
         else:
-            body["completion_reason"] = "left_alone"
-            body["reason"] = f"bot gone while {status}; reconciled to failed (never reached active)"
+            # ATTRIBUTE, never manufacture (#862). The reason is DERIVED from the stage the bot
+            # died in, and the note carries the probe's own answer (workload state, exit code) —
+            # the only things this sweep actually knows. A default of `left_alone` would be a claim
+            # with no evidence behind it (the sweep issued the delete itself), and `left_alone` is
+            # `_PERMANENT` in ``retry.py``, so it would also cancel the legitimate re-spawn.
+            body["completion_reason"] = _pre_active_completion_reason(status, stop_requested)
+            body["reason"] = (
+                f"{_workload_evidence(bot_container_id, probe_info)}; "
+                f"reconciled to failed at {status} (never reached active)"
+            )
+            if stop_requested:
+                body["data"] = {"stop_requested": True}
         try:
             result = await post_lifecycle(body)
             reconciled += 1

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -608,16 +608,18 @@ def _set_updated_now(repo: InMemoryMeetingRepo, meeting_id: int) -> None:
     repo._meetings[meeting_id]["updated_at"] = datetime.now(timezone.utc).isoformat()
 
 
-def _run_general_sweep(client: TestClient, repo: InMemoryMeetingRepo, *, stop_grace=45.0, active_grace=300.0):
+def _run_general_sweep(client: TestClient, repo: InMemoryMeetingRepo, *, stop_grace=45.0,
+                       active_grace=300.0, preactive_grace=None):
     """Run ONE general sweep exactly as the loop does, posting through the live callback."""
     import logging
 
     async def _post(body: dict):
         return client.post(ENDPOINT, json=body).status_code
 
+    extra = {} if preactive_grace is None else {"preactive_grace": preactive_grace}
     return asyncio.run(reconcile_stale_nonterminal_sweep(
         repo, None, _post, stop_grace=stop_grace, active_grace=active_grace,
-        log=logging.getLogger("test.reconcile"),
+        log=logging.getLogger("test.reconcile"), **extra,
     ))
 
 
@@ -701,16 +703,18 @@ def test_general_reconcile_noop_on_terminal_rows():
 from meeting_api.bot_spawn.fakes import FakeRuntimeClient  # noqa: E402
 
 
-def _run_general_sweep_rt(client, repo, runtime, *, stop_grace=45.0, active_grace=300.0):
+def _run_general_sweep_rt(client, repo, runtime, *, stop_grace=45.0, active_grace=300.0,
+                          preactive_grace=None):
     """Run ONE general sweep with a real RuntimeClient injected (so the liveness gate is exercised)."""
     import logging
 
     async def _post(body: dict):
         return client.post(ENDPOINT, json=body).status_code
 
+    extra = {} if preactive_grace is None else {"preactive_grace": preactive_grace}
     return asyncio.run(reconcile_stale_nonterminal_sweep(
         repo, runtime, _post, stop_grace=stop_grace, active_grace=active_grace,
-        log=logging.getLogger("test.reconcile"),
+        log=logging.getLogger("test.reconcile"), **extra,
     ))
 
 
@@ -1326,3 +1330,268 @@ def test_status_change_envelope_log_is_bounded_under_sustained_callbacks():
     # ring semantics: the LAST advance is still the most recent captured envelope
     last = app.state.status_change_webhooks[-1]["data"]["meeting"]["connection_id"]
     assert last == f"leak-sess-{overshoot - 1}"
+
+
+# ╔══════════════════════════════════════════════════════════════════════════════════════════════╗
+# ║ #862 — a bot LEGITIMATELY WAITING IN THE LOBBY must outlive the control plane's sweep           ║
+# ╚══════════════════════════════════════════════════════════════════════════════════════════════╝
+# The control plane hands every gmeet bot a 600s lobby budget (`bot_spawn/service.py`
+# `waitingRoomTimeout`), and a lobby bot emits `awaiting_admission` ONCE then polls silently — there
+# is no heartbeat, so `updated_at` stops moving for the whole wait. The sweep reaped at 300s. Because
+# the liveness gate covered only `active`/`needs_help`, a pre-active row skipped the probe entirely
+# and was force-deleted with a MANUFACTURED `left_alone` (`_PERMANENT` in retry.py → the legitimate
+# re-spawn was cancelled too). Both halves are fixed here: pre-active statuses are liveness-gated,
+# and a genuinely-dead pre-active workload is attributed from the stage + the probe's own evidence.
+
+def _set_updated_age(repo: InMemoryMeetingRepo, meeting_id: int, seconds: float) -> None:
+    """Age a row's ``updated_at`` by exactly ``seconds`` (the sweep's grace is measured off it)."""
+    from datetime import datetime, timedelta, timezone
+    repo._meetings[meeting_id]["updated_at"] = (
+        datetime.now(timezone.utc) - timedelta(seconds=seconds)
+    ).isoformat()
+
+
+def _terminal_reason(repo: InMemoryMeetingRepo, meeting_id: int) -> str:
+    """The `reason` string the terminal transition actually recorded (the trail entry)."""
+    trail = repo._meetings[meeting_id]["data"].get("status_transition", [])
+    return next((t.get("reason") or "" for t in reversed(trail) if t.get("reason")), "")
+
+
+def test_live_lobby_bot_is_not_reaped_past_the_active_grace():
+    """A3 — THE HEADLINE. A bot sitting in the Meet waiting room reports `awaiting_admission` once,
+    then polls silently for up to its 600s budget. Its row goes quiet; its WORKLOAD IS ALIVE. The
+    sweep must SKIP it, so the bot resolves its own admission (admitted, or an honest
+    `awaiting_admission_timeout` at 600s) — never a force-delete at 300s of legitimate quiet."""
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="awaiting_admission")   # updated_at far in the past — past any grace
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-lobby"
+    runtime = FakeRuntimeClient(
+        workloads={"wl-lobby": {"workloadId": "wl-lobby", "state": "running"}}
+    )
+    client = TestClient(create_app(meeting_repo=repo))
+
+    n = _run_general_sweep_rt(client, repo, runtime)
+    assert n == 0, "a LIVE lobby bot must never be reaped on updated_at staleness alone"
+    assert repo._meetings[m["id"]]["status"] == "awaiting_admission"
+    assert runtime.deleted == [], "the live workload must NOT be torn down"
+
+
+@pytest.mark.parametrize("status", ["requested", "joining", "awaiting_admission"])
+def test_every_pre_active_status_is_liveness_gated(status):
+    """The gate covers the whole pre-active span, not just the lobby: `requested` (spawned, not yet
+    reported) and `joining` (driving the join UI) are equally quiet-but-live states."""
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status=status)
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-pre"
+    runtime = FakeRuntimeClient(
+        workloads={"wl-pre": {"workloadId": "wl-pre", "state": "starting"}}
+    )
+    client = TestClient(create_app(meeting_repo=repo))
+
+    assert _run_general_sweep_rt(client, repo, runtime) == 0
+    assert repo._meetings[m["id"]]["status"] == status
+    assert runtime.deleted == []
+
+
+def test_dead_lobby_workload_is_attributed_to_the_admission_wait_with_evidence():
+    """A1 — when the probe says the workload is GENUINELY gone, the reason is DERIVED from the stage
+    (`awaiting_admission` → `awaiting_admission_timeout`) and carries the probe's own evidence
+    (workload state + exit code). No more manufactured `left_alone`/"bot gone while …", which was
+    written with zero liveness evidence AND is `_PERMANENT` — it cancelled the legitimate re-spawn."""
+    from meeting_api.lifecycle.machine import CompletionReason
+    from meeting_api.lifecycle.retry import RetryClass, classify_retry
+
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="awaiting_admission")
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-dead"
+    runtime = FakeRuntimeClient(
+        workloads={"wl-dead": {"workloadId": "wl-dead", "state": "exited", "exitCode": 137}}
+    )
+    client = TestClient(create_app(meeting_repo=repo))
+
+    n = _run_general_sweep_rt(client, repo, runtime)
+    assert n == 1
+    row = repo._meetings[m["id"]]
+    assert row["status"] == "failed"
+    reason_code = row["data"].get("completion_reason")
+    assert reason_code == "awaiting_admission_timeout", (
+        f"a never-admitted bot cannot have been 'left alone'; got {reason_code!r}"
+    )
+    # the row is RETRY-ELIGIBLE again (left_alone is _PERMANENT; this reason is TRANSIENT)
+    assert classify_retry(CompletionReason(reason_code)) is RetryClass.TRANSIENT
+    note = _terminal_reason(repo, m["id"])
+    assert "exited" in note and "137" in note, f"reason must carry the probe evidence: {note!r}"
+    assert "bot gone" not in note, f"the manufactured phrase must be gone: {note!r}"
+    assert "wl-dead" in runtime.deleted, "a confirmed-dead workload is still torn down"
+
+
+def test_dead_joining_workload_is_attributed_to_join_failure():
+    """The earlier pre-active stages never reached the waiting room → `join_failure` (also
+    TRANSIENT), not the admission-timeout reason and not `left_alone`."""
+    from meeting_api.lifecycle.machine import CompletionReason
+    from meeting_api.lifecycle.retry import RetryClass, classify_retry
+
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="joining")
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-crash"
+    runtime = FakeRuntimeClient(
+        workloads={"wl-crash": {"workloadId": "wl-crash", "state": "crashed", "exitCode": 1}}
+    )
+    client = TestClient(create_app(meeting_repo=repo))
+
+    assert _run_general_sweep_rt(client, repo, runtime) == 1
+    row = repo._meetings[m["id"]]
+    assert row["status"] == "failed"
+    assert row["data"].get("completion_reason") == "join_failure"
+    assert row["data"].get("failure_stage") == "joining"
+    assert classify_retry(CompletionReason("join_failure")) is RetryClass.TRANSIENT
+    assert "crashed" in _terminal_reason(repo, m["id"])
+
+
+def test_user_stopped_pre_active_reap_is_never_retried():
+    """`stop_requested` still overrides the stage attribution (#807): a deliberate cancellation
+    seals as the PERMANENT `stopped`, so the re-spawn machinery never spends the user's quota
+    re-joining a meeting they walked away from."""
+    from meeting_api.lifecycle.machine import CompletionReason
+    from meeting_api.lifecycle.retry import RetryClass, classify_retry
+
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="awaiting_admission")
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-stopped"
+    repo._meetings[m["id"]]["data"]["stop_requested"] = True
+    runtime = FakeRuntimeClient(
+        workloads={"wl-stopped": {"workloadId": "wl-stopped", "state": "destroyed"}}
+    )
+    client = TestClient(create_app(meeting_repo=repo))
+
+    assert _run_general_sweep_rt(client, repo, runtime) == 1
+    row = repo._meetings[m["id"]]
+    assert row["status"] == "failed"
+    assert row["data"].get("completion_reason") == "stopped"
+    assert classify_retry(CompletionReason("stopped")) is RetryClass.PERMANENT
+
+
+# ── negative controls: the behaviours this change must NOT disturb ───────────────────────────────
+
+def test_active_liveness_gate_behaviour_is_unchanged():
+    """NEGATIVE CONTROL. The `active` gate keeps both of its halves: a live workload is skipped, a
+    runtime-confirmed terminal workload still completes with `left_alone` (the bot WAS in the
+    meeting — there, `left_alone` is the honest reason, not a manufactured one)."""
+    repo = InMemoryMeetingRepo()
+    live = _seed(repo, status="active", session_uid="sess-live")
+    repo._meetings[live["id"]]["bot_container_id"] = "wl-a-live"
+    client = TestClient(create_app(meeting_repo=repo))
+    runtime = FakeRuntimeClient(
+        workloads={"wl-a-live": {"workloadId": "wl-a-live", "state": "running"}}
+    )
+    assert _run_general_sweep_rt(client, repo, runtime) == 0
+    assert repo._meetings[live["id"]]["status"] == "active"
+
+    repo2 = InMemoryMeetingRepo()
+    dead = _seed(repo2, status="active", session_uid="sess-dead")
+    repo2._meetings[dead["id"]]["bot_container_id"] = "wl-a-dead"
+    client2 = TestClient(create_app(meeting_repo=repo2))
+    runtime2 = FakeRuntimeClient(
+        workloads={"wl-a-dead": {"workloadId": "wl-a-dead", "state": "stopped"}}
+    )
+    assert _run_general_sweep_rt(client2, repo2, runtime2) == 1
+    assert repo2._meetings[dead["id"]]["status"] == "completed"
+    assert repo2._meetings[dead["id"]]["data"].get("completion_reason") == "left_alone"
+
+
+def test_stopping_row_still_reaps_on_its_short_grace():
+    """NEGATIVE CONTROL. `stopping` stays EXEMPT from the liveness gate — a stop was requested, so
+    the row converges on its short grace even while the workload still reports alive."""
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="stopping")
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-stop"
+    repo._meetings[m["id"]]["data"]["stop_requested"] = True
+    _set_updated_age(repo, m["id"], 60)          # past stop_grace (45), inside active_grace (300)
+    runtime = FakeRuntimeClient(
+        workloads={"wl-stop": {"workloadId": "wl-stop", "state": "running"}}
+    )
+    client = TestClient(create_app(meeting_repo=repo))
+
+    assert _run_general_sweep_rt(client, repo, runtime) == 1
+    assert repo._meetings[m["id"]]["status"] == "completed"
+    assert "wl-stop" in runtime.deleted
+
+
+def test_pre_active_row_with_no_workload_at_all_still_reconciles():
+    """NEGATIVE CONTROL (no row leaks forever). A pre-active row with NO recorded workload has
+    nothing that could be alive — the gate does not apply, so it still converges on the time window,
+    with a note that says so instead of claiming a bot went missing. (`joining`, not `requested`:
+    the FSM's only legal first edge is `<new>` → `joining`, so a never-reported row's convergence
+    rides the runtime-destroy force path, not this callback — unchanged by #862.)"""
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="joining")
+    runtime = FakeRuntimeClient(workloads={})
+    client = TestClient(create_app(meeting_repo=repo))
+
+    assert _run_general_sweep_rt(client, repo, runtime) == 1
+    row = repo._meetings[m["id"]]
+    assert row["status"] == "failed"
+    assert row["data"].get("completion_reason") == "join_failure"
+    assert "no workload recorded" in _terminal_reason(repo, m["id"])
+
+
+def test_pre_active_untracked_workload_still_escalates_on_the_bounded_window():
+    """NEGATIVE CONTROL (no row leaks forever, part 2). Now that pre-active rows are probed, a
+    runtime 404 lands them on the SAME bounded untracked escalation as `active`: no reap on the
+    404 itself (amnesia is not evidence), and convergence to `failed` once the window elapses —
+    with the stage-derived reason, so the re-spawn is still allowed."""
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="awaiting_admission")
+    repo._meetings[m["id"]]["bot_container_id"] = "wl-404"
+    runtime = FakeRuntimeClient(workloads={})
+    client = TestClient(create_app(meeting_repo=repo))
+    tracker: dict = {}
+
+    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=0.0) == 0
+    assert repo._meetings[m["id"]]["status"] == "awaiting_admission"   # window opened only
+    assert runtime.deleted == []
+
+    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=0.0) == 1
+    row = repo._meetings[m["id"]]
+    assert row["status"] == "failed"
+    assert row["data"].get("completion_reason") == "awaiting_admission_timeout"
+    assert "presumed lost" in _terminal_reason(repo, m["id"])
+
+
+# ── the constant itself: 300s for a bot-present row, and a PRE-ACTIVE floor above the 600s budget ──
+
+def test_active_grace_boundary_is_exactly_the_configured_window():
+    """The 325s prod signature decomposes to `active_grace(300) + time-to-lobby + sweep phase`.
+    Pin the constant: 299s quiet is NOT listed, 301s IS."""
+    for age, expect in ((299, 0), (301, 1)):
+        repo = InMemoryMeetingRepo()
+        m = _seed(repo, status="active")
+        _set_updated_age(repo, m["id"], age)
+        client = TestClient(create_app(meeting_repo=repo))
+        assert _run_general_sweep(client, repo) == expect, f"age={age}s"
+
+
+def test_pre_active_grace_floor_outlives_the_lobby_budget_we_issue():
+    """F4 — the control plane's patience can never be shorter than the deadline it issues. A lobby
+    bot holds a 600s budget, so a pre-active row is not even LISTED before the pre-active floor
+    (660s) elapses — belt to the liveness gate's braces, for the case where the probe is
+    inconclusive."""
+    for age, expect in ((301, 0), (661, 1)):
+        repo = InMemoryMeetingRepo()
+        m = _seed(repo, status="awaiting_admission")
+        _set_updated_age(repo, m["id"], age)
+        client = TestClient(create_app(meeting_repo=repo))
+        n = _run_general_sweep(client, repo, preactive_grace=660.0)
+        assert n == expect, f"age={age}s → {n} (expected {expect})"
+
+
+def test_default_pre_active_grace_is_derived_from_the_issued_lobby_budget():
+    """The floor is DERIVED, not a second magic number: it is the very ``waitingRoomTimeout`` the
+    spawn hands the bot, plus headroom. If someone shortens the budget the floor follows; if
+    someone lengthens it, this anchor fails loudly rather than re-opening #862."""
+    from meeting_api.bot_spawn.service import LOBBY_BUDGET_MS
+    from meeting_api.lifecycle.reconcile import default_preactive_grace
+
+    assert LOBBY_BUDGET_MS == 600_000
+    assert default_preactive_grace() == 660.0
+    assert default_preactive_grace() > LOBBY_BUDGET_MS / 1000.0

--- a/docs/changelog.d/862-lobby-bot-reap.md
+++ b/docs/changelog.d/862-lobby-bot-reap.md
@@ -1,0 +1,11 @@
+- **A bot waiting in a Google Meet lobby is no longer killed at 5 minutes (#862).** The bot is handed
+  a 10-minute waiting-room budget, but it reports `awaiting_admission` once and then waits silently —
+  so the reconcile sweep, which only checked whether the workload was alive for bots already *in* the
+  meeting, force-deleted healthy bots at 300s of legitimate quiet, seconds before hosts who admit at
+  4–5 minutes let them in. The liveness check now covers the whole pre-admission span, and the sweep's
+  patience for a not-yet-admitted bot is derived from the budget it issued, so it can never be shorter.
+- **A bot that never reached the meeting now reports why, and is retried (#862).** When the runtime
+  confirms a pre-admission workload really is gone, the meeting is attributed to the stage it died in
+  (`awaiting_admission_timeout` / `join_failure`) with the runtime's own evidence — workload state and
+  exit code — instead of the catch-all `left_alone`. `left_alone` counts as a normal ending, so it also
+  suppressed the automatic re-join; these reasons are retryable, and the re-spawn happens again.


### PR DESCRIPTION
Closes #862

The premise inverted in [the diagnosis](https://github.com/Vexa-ai/vexa/issues/862): the bots were **alive**, and our own reconcile sweep force-killed them. This PR stops that, and stops the manufactured label that suppressed their re-spawn.

## What was wrong (verified at `file:line` on `rc/0.12.18`)

`bot_spawn/service.py` hands every spawn `waitingRoomTimeout: 600_000`. A gmeet lobby bot emits `awaiting_admission` **once** and then polls silently — there is no heartbeat, so `updated_at` stops moving for the whole wait. The sweep reaped at `RECONCILE_ACTIVE_GRACE_S=300` because the liveness gate covered only `active`/`needs_help` (`reconcile.py:106,251`); a pre-active row **skipped the probe entirely** and fell straight into an unconditional `_teardown_verdict` (`kubectl delete --grace-period=0 --force`). Then `reconcile.py:304-305` wrote `completion_reason="left_alone"` + `"bot gone while {status}"` with zero liveness evidence — and `LEFT_ALONE` is `_PERMANENT` in `retry.py:52` while `AWAITING_ADMISSION_TIMEOUT` is retryable (`retry.py:39`), so the mislabel **also cancelled the legitimate re-join**.

## What this changes

- **F1 — the liveness gate covers the whole pre-admission span.** `_LIVE_NONTERMINAL` → `_LIVENESS_GATED = {requested, joining, awaiting_admission, needs_help, active}`. A live pre-active workload is **skipped**, so the bot resolves its own admission at its own budget. `stopping` stays excluded by design (a stop was requested; it reaps on its short grace).
- **F2 — attribute, never manufacture.** When the probe returns positive evidence the workload is gone, the reason comes from the existing `_pre_active_completion_reason(status, stop_requested)` (`awaiting_admission_timeout` / `join_failure`, or `stopped` when the user cancelled), and the transition's `reason` carries the probe's own answer (`workload wl-x state=exited exitCode=137`) instead of the words "bot gone". Same treatment applied to the bounded-untracked escalation, which had the identical `left_alone` default for pre-active rows. **This restores the retry path** (both new reasons are `_TRANSIENT`).
- **F4 — `RECONCILE_PREACTIVE_GRACE_S` (default 660), derived, not invented.** `bot_spawn.service.LOBBY_BUDGET_MS` is now a named constant and `lifecycle.reconcile.default_preactive_grace()` returns `LOBBY_BUDGET_MS/1000 + 60`. The control plane's patience for a not-yet-admitted bot cannot fall under the deadline it just issued — shorten the budget and the floor follows. Declared `defaulted` with `targets: []` (no deploy surface; helm/compose untouched).
- The grace-window policy is one function (`ports.reconcile_grace_for_status`) read by **both** the SQL adapter and the in-memory fake, so the two listings cannot drift.

## F3 — deferred, and here is the evidence for deferring

F3 (graceful stop-then-destroy so the death is observable and the lobby knock is withdrawn) was assessed and **is not included** — because F1 removes its premise from this path. After F1 the sweep's reap paths are:

| path | can it force-kill a LIVE workload? |
|---|---|
| liveness-gated + probe `alive`/`unknown` | no — skipped |
| liveness-gated + probe `untracked` (404) | no — nothing deleted; bounded escalation only |
| liveness-gated + probe `gone` | no — the workload is **already terminal**; `kernel.stop` would return immediately (`kernel.py:246-247`) |
| pre-active with no `bot_container_id` | no — nothing to kill |
| `stopping` past its short grace | **yes** — but that is ADR-0024's orphan-kill backstop, on a row where the user asked the bot to leave |

So the only remaining consumer of a graceful stop is the `stopping` orphan-kill, which is not #862. It is also not free: `kernel.stop` blocks synchronously for up to `RUNTIME_STOP_GRACE_SEC` (30s) inside a 15s sweep tick, and `stop_workload` is not on the `RuntimeClient` port. **Scoped follow-up:** add `stop_workload` to the port (`POST /workloads/{id}/stop`), use it before `destroy` on the `stopping` backstop only, bound it (the bot's own `signals.ts` handles SIGTERM → graceful leave, and with #913 that withdraws the lobby knock), and prove it on the compose stack. I did **not** land a half version of it.

## Observation bundle

Every row is offline — no live meeting, no docker: `meeting-api/tests/test_lifecycle_seam.py` + `bot_spawn/fakes.py` `FakeRuntimeClient(workloads=…, .deleted)`.

| # (issue) | observation | evidence |
|---|---|---|
| **A3** | a bot in the lobby with a **live** workload is not reaped | `test_live_lobby_bot_is_not_reaped_past_the_active_grace` — **RED on base** (below), green after |
| A3+ | the gate covers `requested`/`joining`/`awaiting_admission` | `test_every_pre_active_status_is_liveness_gated[3 params]` |
| **A1** | a genuinely-dead lobby workload produces a **typed** reason naming the cause, with the runtime's evidence, and is **retry-eligible** | `test_dead_lobby_workload_is_attributed_to_the_admission_wait_with_evidence` (asserts `awaiting_admission_timeout`, `exited`+`137` in the reason, `"bot gone" not in reason`, `classify_retry(...) is TRANSIENT`) |
| A1 | the earlier stages earn `join_failure`, not the admission reason | `test_dead_joining_workload_is_attributed_to_join_failure` |
| A1 | a user-cancelled pre-active row stays PERMANENT (`stopped`) — #807 preserved | `test_user_stopped_pre_active_reap_is_never_retried` |
| **A4** | a bot legitimately waiting the full budget is not flagged — it is not even listed before the derived floor | `test_pre_active_grace_floor_outlives_the_lobby_budget_we_issue` (301s ⇒ not listed, 661s ⇒ listed) |
| A4 | the floor is derived from the issued budget, not a second magic number | `test_default_pre_active_grace_is_derived_from_the_issued_lobby_budget` |
| — | the 325s constant pinned: 299s ⇒ not listed, 301s ⇒ listed | `test_active_grace_boundary_is_exactly_the_configured_window` |
| NC1 | `active` gate behaviour unchanged (live skipped; terminal workload still completes with `left_alone`) | `test_active_liveness_gate_behaviour_is_unchanged` + the 5 pre-existing gate tests, all still green |
| NC2 | `stopping` still reaps on its short grace even with a live workload | `test_stopping_row_still_reaps_on_its_short_grace` |
| NC3 | a genuinely-gone pre-active row still reconciles — no row leaks forever | `test_dead_lobby_workload_…`, `test_pre_active_row_with_no_workload_at_all_still_reconciles` |
| NC4 | a pre-active 404 lands on the same **bounded** untracked escalation (no reap on amnesia, convergence at the window) | `test_pre_active_untracked_workload_still_escalates_on_the_bounded_window` |

**A5 (two spawns <1s apart) is not addressed and, per the diagnosis, is not implicated** — workload ids are per-session unique (`service.py`), so the docker-409 path is unreachable across siblings; the pair simply crossed 300s together.

### The RED, on the base tree

```
$ uv run pytest tests/test_lifecycle_seam.py -q -k "live_lobby_bot_is_not_reaped"
F
        n = _run_general_sweep_rt(client, repo, runtime)
>       assert n == 0, "a LIVE lobby bot must never be reaped on updated_at staleness alone"
E       AssertionError: a LIVE lobby bot must never be reaped on updated_at staleness alone
E       assert 1 == 0
----------------------------- Captured stdout call -----------------------------
{"event":"meeting_lifecycle_advanced","span":"lifecycle.callback","meeting_id":"sess-uid","fields":{"meeting_status":"failed"}}
1 failed, 109 deselected
```

The whole new section on the base tree: **11 failed, 4 passed** — the 4 passers are exactly the negative controls (`active` gate, `stopping` short grace, the 300s boundary), which is what makes them controls.

### After

```
$ uv run pytest tests/ -q          # meeting-api
842 passed, 5 skipped

$ MOCK_BOT=1 BROWSER_IMAGE=mock-bot:dev node scripts/gates.mjs all
✅ gates green      (32 gates, incl. config-contract: 192 declared keys ≡ deploy surfaces ≡ code reads)
```

## What I did NOT check — the remaining validator leg

**No live confirmation.** Everything above is offline. The live leg someone else must witness: spawn a gmeet bot into a meeting whose host does **not** admit it immediately, and observe that (a) it is still `awaiting_admission` past 300s — the row is untouched at the old reap point — and (b) it either gets **admitted at 4–5 minutes and captures normally** (the 24386 shape), or reports an honest `awaiting_admission_timeout` at its own 600s budget. I also did not pull kubelet/eviction records, and I did not re-measure the prod signature rate after this change.

One note for that run: the sweep's own DELETE is what fires `kernel.destroy` → the inline runtime callback → `synthesize_terminal_for_dead_workload` (`reconcile.py:445-455`). Both writers now agree on the reason, where before line 451 wrote `awaiting_admission_timeout` and line 305 wrote `left_alone` for the same event — so the "two buckets" in the prod decomposition should collapse into one honest label.
