### PR TITLE
fix(admin-api): honor JSON body scopes on token mint (#922)

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -12,17 +12,19 @@ exercises:
   email, plus webhook_url/secret/events from user.data; rejects expired tokens; bumps
   last_used_at; FAILS CLOSED when INTERNAL_API_SECRET is unset (503) and on a bad secret (403).
 
-  Token mint: scoped {bot,tx,browser}, optional multi-scope `?scopes=bot,tx`, optional expiry
-  `?expires_in=<sec>`; an invalid scope → 422.
+  Token mint: scoped {bot,tx,browser}. Scopes via JSON body `{"scopes":["bot","tx"]}` or
+  query `?scopes=bot,tx` / `?scope=bot` (body wins when present). Optional `name` /
+  `expires_in` in body or query; an invalid scope → 422. A JSON body with unknown fields
+  is refused (422) — never silently dropped (#922).
 """
 import hmac
 import os
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Response, Security, status
+from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request, Response, Security, status
 from fastapi.security import APIKeyHeader
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -94,6 +96,19 @@ class TokenResponse(BaseModel):
     scopes: List[str]
 
     model_config = {"from_attributes": True}
+
+
+class TokenCreate(BaseModel):
+    """Mint request body — scopes/name/expires_in may also arrive as query params (compat).
+
+    ``extra='forbid'`` so a caller who sends an unsupported field gets a loud 422 instead of
+    a silent drop that mints the wrong token (#922).
+    """
+    scopes: Optional[List[str]] = None
+    name: Optional[str] = None
+    expires_in: Optional[int] = Field(default=None, gt=0)
+
+    model_config = {"extra": "forbid"}
 
 
 class TokenInfo(BaseModel):
@@ -253,26 +268,40 @@ def create_app() -> FastAPI:
 
     @app.post("/admin/users/{user_id}/tokens", response_model=TokenResponse,
               status_code=status.HTTP_201_CREATED, dependencies=[Depends(verify_admin_token)])
-    async def create_token_for_user(user_id: int, scope: str = "bot",
-                                    scopes: Optional[str] = None,
-                                    name: Optional[str] = None,
-                                    expires_in: Optional[int] = None,
-                                    db: AsyncSession = Depends(get_db)):
+    async def create_token_for_user(
+        user_id: int,
+        body: TokenCreate = Body(default_factory=TokenCreate),
+        scope: str = Query("bot"),
+        scopes: Optional[str] = Query(None),
+        name: Optional[str] = Query(None),
+        expires_in: Optional[int] = Query(None),
+        db: AsyncSession = Depends(get_db),
+    ):
         user = await db.get(User, user_id)
         if not user:
             raise HTTPException(status.HTTP_404_NOT_FOUND, detail="User not found")
-        scope_list = ([s.strip() for s in scopes.split(",") if s.strip()]
-                      if scopes is not None else [scope])
+        # Body scopes win when present — a JSON mint must not silently fall through to ["bot"] (#922).
+        if body.scopes is not None:
+            scope_list = [s.strip() for s in body.scopes if s and s.strip()]
+        elif scopes is not None:
+            scope_list = [s.strip() for s in scopes.split(",") if s.strip()]
+        else:
+            scope_list = [scope]
+        if not scope_list:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                detail="scopes must not be empty")
         invalid = [s for s in scope_list if s not in VALID_SCOPES]
         if invalid:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY,
                                 detail=f"Invalid scope(s): {invalid}. Valid: {sorted(VALID_SCOPES)}")
+        token_name = body.name if body.name is not None else name
+        token_expires_in = body.expires_in if body.expires_in is not None else expires_in
         token_value = generate_prefixed_token(scope_list[0])
         expires_at = None
-        if expires_in is not None and expires_in > 0:
-            expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+        if token_expires_in is not None and token_expires_in > 0:
+            expires_at = datetime.utcnow() + timedelta(seconds=token_expires_in)
         tok = APIToken(token=token_value, user_id=user_id, scopes=scope_list,
-                       name=name, created_at=datetime.utcnow(), expires_at=expires_at)
+                       name=token_name, created_at=datetime.utcnow(), expires_at=expires_at)
         db.add(tok)
         await db.commit()
         await db.refresh(tok)

--- a/core/identity/services/admin-api/tests/test_stack_admin_api.py
+++ b/core/identity/services/admin-api/tests/test_stack_admin_api.py
@@ -186,6 +186,44 @@ def test_invalid_scope_422(client):
     assert "Invalid scope" in r.json()["detail"]
 
 
+def test_mint_scopes_from_json_body(client):
+    """#922: body ``{"scopes":["bot","tx"]}`` must be honored — not silently dropped to ["bot"]."""
+    user_id = client.post("/admin/users", headers=_admin(),
+                          json={"email": "body-scopes@vexa.ai"}).json()["id"]
+    r = client.post(
+        f"/admin/users/{user_id}/tokens",
+        headers=_admin(),
+        json={"scopes": ["bot", "tx"]},
+    )
+    assert r.status_code == 201, r.text
+    assert set(r.json()["scopes"]) == {"bot", "tx"}
+
+
+def test_mint_unknown_body_field_422(client):
+    """#922: an unsupported body field is refused (422), never silently dropped."""
+    user_id = client.post("/admin/users", headers=_admin(),
+                          json={"email": "body-extra@vexa.ai"}).json()["id"]
+    r = client.post(
+        f"/admin/users/{user_id}/tokens",
+        headers=_admin(),
+        json={"scopes": ["bot"], "not_a_field": True},
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_mint_body_scopes_win_over_query(client):
+    """When both body and query supply scopes, the body wins."""
+    user_id = client.post("/admin/users", headers=_admin(),
+                          json={"email": "body-wins@vexa.ai"}).json()["id"]
+    r = client.post(
+        f"/admin/users/{user_id}/tokens?scopes=bot",
+        headers=_admin(),
+        json={"scopes": ["bot", "tx"]},
+    )
+    assert r.status_code == 201, r.text
+    assert set(r.json()["scopes"]) == {"bot", "tx"}
+
+
 def test_admin_tier_auth_enforced(client):
     """The admin tier rejects a missing/wrong X-Admin-API-Key (403)."""
     r = client.post("/admin/users", json={"email": "f@vexa.ai"})           # no key

--- a/docs/changelog.d/922-token-scopes-body.md
+++ b/docs/changelog.d/922-token-scopes-body.md
@@ -1,0 +1,4 @@
+- **Admin token mint honors JSON `scopes` (and refuses unknown body fields) (#922).**
+  `POST /admin/users/{id}/tokens` with `{"scopes":["bot","tx"]}` now mints those scopes instead of
+  silently falling through to `["bot"]`. Query `?scopes=` / `?scope=` still work; unsupported body
+  fields return `422`. See [Authentication](/authentication).

--- a/docs/docs/authentication.mdx
+++ b/docs/docs/authentication.mdx
@@ -47,17 +47,22 @@ curl -X POST "$ADMIN/admin/users" \
   -d '{"email":"jane@acme.com","name":"Jane","max_concurrent_bots":2}'
 # → {"id":1,"email":"jane@acme.com","name":"Jane","max_concurrent_bots":2}
 
-# 2. mint a key for that user id
-curl -X POST "$ADMIN/admin/users/1/tokens?scopes=bot,tx" \
-  -H "X-Admin-API-Key: $ADMIN_TOKEN"
+# 2. mint a key for that user id (JSON body preferred)
+curl -X POST "$ADMIN/admin/users/1/tokens" \
+  -H "X-Admin-API-Key: $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d '{"scopes":["bot","tx"]}'
 # → {"id":7,"token":"vxa_bot_...","user_id":1,"scopes":["bot","tx"]}
+
+# query form still works: ?scopes=bot,tx or ?scope=bot
 ```
 
 The returned `token` is your `X-API-Key`. **It is shown once** — store it.
 
 ## Scopes
 
-A key carries one or more scopes. Pass `scope=<one>` or `scopes=<a>,<b>` when minting.
+A key carries one or more scopes. Pass them in the JSON body as `{"scopes":["bot","tx"]}`, or as
+query `scope=<one>` / `scopes=<a>,<b>`. The body wins when both are present. An unknown body field
+is refused with `422` — never silently dropped.
 
 | Scope | Grants |
 |---|---|


### PR DESCRIPTION
## Summary
- `POST /admin/users/{id}/tokens` with `{"scopes":["bot","tx"]}` was silently ignored and minted `["bot"]` — failure only showed up later as a confusing 403 on `/transcripts` / `/meetings`.
- Body now honors `scopes` / `name` / `expires_in` (body wins over query); unknown body fields → `422`; query `?scopes=` / `?scope=` still work.
- Docs + changelog fragment updated. Closes #922.

## Observation bundle

| # | Expected | Actual | Verdict |
|---|----------|--------|---------|
| 1 | Body `{"scopes":["bot","tx"]}` → mint scopes `{bot,tx}` | `test_mint_scopes_from_json_body` green | pass |
| 2 | Unknown body field → 422 (no silent drop) | `test_mint_unknown_body_field_422` green | pass |
| 3 | Body wins over query when both present | `test_mint_body_scopes_win_over_query` green | pass |
| 4 | Query `?scopes=bot,tx` still works (compat) | `test_golden_identity_flow` green | pass |
| 5 | Invalid scope still 422 | `test_invalid_scope_422` green | pass |

**Evidence:** `cd core/identity/services/admin-api && uv run pytest tests/test_stack_admin_api.py -k 'mint_scopes or mint_unknown or mint_body or invalid_scope or golden_identity' -q` → **5 passed** (testcontainers Postgres).

**Not checked:** live staging mint against a running admin-api (desk-checkable at the seam; suite covers the contract).

## Test plan
- [x] admin-api mint body/query/unknown-field tests green
- [ ] Maintainer desk-check: mint with JSON body on staging/compose admin-api