### PR TITLE
fix(mcp): sessioned GET /mcp starts SSE via ASGI passthrough (#921)

### DIFF
--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -3,7 +3,9 @@
 Port of 0.10.6 ``services/mcp/main.py`` reduced to the tools whose REST routes EXIST on
 the v0.12 public API (the gateway — ``core/gateway/services/gateway/src/gateway/app.py``).
 Every tool is a thin FastAPI route; ``FastApiMCP`` derives the MCP tool surface from them
-and mounts the streamable-HTTP MCP transport at ``/mcp``.
+and mounts the streamable-HTTP MCP transport at ``/mcp``. The mount uses an ASGI
+passthrough so a sessioned ``GET /mcp`` can start its SSE response immediately
+(#921) — fastapi-mcp's buffered adapter never completes for an open EventSource.
 
 Auth: the caller's credential (``Authorization: Bearer <key>`` / raw ``Authorization`` /
 ``X-API-Key``) is treated as the Vexa API key and forwarded to the gateway as ``X-API-Key``
@@ -27,6 +29,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from .link_parser import ParseMeetingLinkResponse, parse_meeting_url
 from .prompts import PROMPTS, get_prompt_result
+from .streamable_http import install_streaming_http_transport
 
 _DEFAULT_GATEWAY_URL = "http://gateway:8000"
 
@@ -339,5 +342,8 @@ def create_app(
         return get_prompt_result(name, arguments)
 
     mcp.mount_http()
+    # fastapi-mcp 0.4 buffers the ASGI response; a sessioned GET is an open SSE
+    # stream and never completes that buffer — install a passthrough (#921).
+    install_streaming_http_transport(mcp)
     app.state.mcp = mcp
     return app

--- a/core/meetings/services/mcp/src/vexa_mcp/streamable_http.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/streamable_http.py
@@ -1,0 +1,68 @@
+"""ASGI passthrough for the MCP streamable-HTTP mount (#921).
+
+``fastapi-mcp`` 0.4.x's ``FastApiHttpSessionManager.handle_fastapi_request`` captures
+the upstream ASGI ``send`` into an in-memory buffer and only returns a FastAPI
+``Response`` after ``handle_request`` completes. That works for short JSON answers
+(initialize, sessionless 400) but deadlocks a sessioned ``GET /mcp``: the MCP SDK
+builds an open ``EventSourceResponse`` that never finishes, so headers never leave
+the buffer — uvicorn never sees ``http.response.start``, and sse-starlette's keep-alive
+ping never fires.
+
+Fix at the point of introduction: relay the real ASGI ``send`` so the stream can
+start immediately. We keep ``FastApiMCP`` for tool derivation; only the HTTP
+request adapter is replaced.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException, Request, Response
+from fastapi_mcp.transport.http import FastApiHttpSessionManager
+from starlette.types import Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+class _ASGIPassthroughResponse(Response):
+    """A Response whose body is the ASGI app itself (not a buffered byte string)."""
+
+    def __init__(self, asgi_call: Any, scope: Scope, receive: Receive) -> None:
+        # status/headers are owned by the upstream ASGI callable — placeholders only.
+        super().__init__(content=b"", status_code=200)
+        self._asgi_call = asgi_call
+        self._scope = scope
+        self._receive = receive
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Use Starlette's real ``send`` so ``http.response.start`` reaches the server.
+        await self._asgi_call(self._scope, self._receive, send)
+
+
+async def handle_fastapi_request_streaming(
+    transport: FastApiHttpSessionManager, request: Request
+) -> Response:
+    """Drop-in replacement for ``FastApiHttpSessionManager.handle_fastapi_request``."""
+    await transport._ensure_session_manager_started()
+    if not transport._session_manager:
+        raise HTTPException(status_code=500, detail="Session manager not initialized")
+
+    logger.debug("Handling MCP streamable-HTTP (ASGI passthrough): %s %s",
+                 request.method, request.url.path)
+    return _ASGIPassthroughResponse(
+        transport._session_manager.handle_request,
+        request.scope,
+        request.receive,
+    )
+
+
+def install_streaming_http_transport(mcp: Any) -> None:
+    """Patch the mounted FastApiMCP HTTP transport so sessioned GET SSE can start (#921)."""
+    http_transport = getattr(mcp, "_http_transport", None)
+    if http_transport is None:
+        raise RuntimeError("FastApiMCP has no _http_transport — call mount_http() first")
+
+    async def _handle(request: Request) -> Response:
+        return await handle_fastapi_request_streaming(http_transport, request)
+
+    http_transport.handle_fastapi_request = _handle  # type: ignore[method-assign]

--- a/core/meetings/services/mcp/tests/test_mcp_sessioned_sse.py
+++ b/core/meetings/services/mcp/tests/test_mcp_sessioned_sse.py
@@ -1,0 +1,185 @@
+"""#921 — sessioned GET /mcp must start the SSE response (headers + keep-alive ping).
+
+Asserts at the ASGI ``send`` boundary (the same altitude as the original measurement:
+uvicorn logs at ``http.response.start``). httpx's ASGI transport does not reliably
+surface headers for a never-finishing EventSourceResponse, so we drive the app as
+ASGI and capture ``send`` messages directly.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Dict, List
+
+import httpx
+import pytest
+
+from vexa_mcp import create_app
+
+JsonHeaders = Dict[str, str]
+
+
+@pytest.fixture
+def app():
+    return create_app(
+        "http://gateway.test",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+    )
+
+
+async def _asgi_exchange(
+    app,
+    method: str,
+    path: str,
+    headers: JsonHeaders,
+    body: bytes = b"",
+    *,
+    hold_seconds: float = 0.3,
+) -> List[dict]:
+    """Run one HTTP exchange; for long-lived streams, hold then disconnect."""
+    messages: List[dict] = []
+    body_sent = False
+    disconnect = asyncio.Event()
+
+    async def receive() -> dict:
+        nonlocal body_sent
+        if not body_sent:
+            body_sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        await disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict) -> None:
+        messages.append(message)
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "root_path": "",
+        "scheme": "http",
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+        "client": ("127.0.0.1", 1),
+        "server": ("test", 80),
+    }
+    task = asyncio.create_task(app(scope, receive, send))
+    try:
+        await asyncio.sleep(hold_seconds)
+        if task.done():
+            await task
+            return messages
+        disconnect.set()
+        try:
+            await asyncio.wait_for(task, timeout=2.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        return messages
+    finally:
+        if not task.done():
+            disconnect.set()
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+
+def _header_map(start_msg: dict) -> Dict[str, str]:
+    return {k.decode().lower(): v.decode() for k, v in start_msg.get("headers", [])}
+
+
+def _first_start(messages: List[dict]) -> dict:
+    for m in messages:
+        if m["type"] == "http.response.start":
+            return m
+    raise AssertionError(f"no http.response.start in {messages!r}")
+
+
+async def _handshake(app) -> str:
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0"},
+            },
+        }
+    ).encode()
+    msgs = await _asgi_exchange(
+        app,
+        "POST",
+        "/mcp",
+        {
+            "content-type": "application/json",
+            "accept": "application/json, text/event-stream",
+        },
+        body,
+    )
+    start = _first_start(msgs)
+    assert start["status"] == 200
+    sid = _header_map(start).get("mcp-session-id")
+    assert sid, start
+    await _asgi_exchange(
+        app,
+        "POST",
+        "/mcp",
+        {
+            "content-type": "application/json",
+            "accept": "application/json, text/event-stream",
+            "mcp-session-id": sid,
+        },
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}).encode(),
+    )
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_sessionless_get_still_400(app):
+    """Negative control: sessionless GET still returns MCP's own 400 promptly (#920)."""
+    msgs = await _asgi_exchange(app, "GET", "/mcp", {"accept": "text/event-stream"})
+    start = _first_start(msgs)
+    assert start["status"] == 400
+
+
+@pytest.mark.asyncio
+async def test_sessioned_get_starts_sse_headers_promptly(app):
+    """A valid mcp-session-id GET must emit status + text/event-stream before any push."""
+    sid = await _handshake(app)
+    msgs = await _asgi_exchange(
+        app,
+        "GET",
+        "/mcp",
+        {"accept": "text/event-stream", "mcp-session-id": sid},
+        hold_seconds=0.5,
+    )
+    start = _first_start(msgs)
+    assert start["status"] == 200
+    headers = _header_map(start)
+    assert "text/event-stream" in headers.get("content-type", "")
+    assert headers.get("mcp-session-id") == sid
+
+
+@pytest.mark.asyncio
+async def test_sessioned_get_idle_ping(app):
+    """sse-starlette keep-alive comment must appear on an idle sessioned stream (~15s)."""
+    sid = await _handshake(app)
+    msgs = await _asgi_exchange(
+        app,
+        "GET",
+        "/mcp",
+        {"accept": "text/event-stream", "mcp-session-id": sid},
+        hold_seconds=16.0,
+    )
+    start = _first_start(msgs)
+    assert start["status"] == 200
+    bodies = [m.get("body", b"") for m in msgs if m["type"] == "http.response.body"]
+    joined = b"".join(bodies)
+    assert b"ping" in joined.lower(), f"expected keep-alive ping in {bodies!r}"

--- a/docs/changelog.d/921-mcp-sessioned-sse.md
+++ b/docs/changelog.d/921-mcp-sessioned-sse.md
@@ -1,0 +1,5 @@
+- **MCP sessioned GET /mcp starts its SSE stream (#921).** A `GET /mcp` with a valid
+  `mcp-session-id` now emits `text/event-stream` headers promptly (and sse-starlette's
+  keep-alive ping on an idle stream). fastapi-mcp's buffered HTTP adapter had swallowed
+  the open SSE response so the server→client channel never opened. Sessionless GET still
+  returns MCP's own 400.


### PR DESCRIPTION
## Summary
- A `GET /mcp` with a **valid** `mcp-session-id` never started a response (no status/headers/body; no uvicorn access line; no sse-starlette 15s ping). Identical direct-to-mcp and via gateway — point of introduction is the MCP service, not the gateway (#920).
- Root cause: `fastapi-mcp` 0.4's `FastApiHttpSessionManager` buffers the full ASGI response and only returns after `handle_request` completes. A sessioned GET is an open `EventSourceResponse`, so that never happens and `http.response.start` never reaches uvicorn.
- Fix: after `mcp.mount_http()`, install an ASGI passthrough that relays the real `send`. Sessionless GET still returns MCP's own 400. Closes #921.

## Observation bundle

| # | Expected | Actual | Verdict |
|---|----------|--------|---------|
| 1 | Sessioned GET emits `200` + `content-type: text/event-stream` promptly | Raw ASGI `send` captured `http.response.start` within 0.5s; `test_sessioned_get_starts_sse_headers_promptly` green | pass |
| 2 | Idle stream emits sse-starlette keep-alive ping (~15s) | Body `: ping - <ts>` at ~15s; `test_sessioned_get_idle_ping` green | pass |
| 3 | Sessionless GET still MCP's own 400 (negative control / #920) | `test_sessionless_get_still_400` green | pass |
| 4 | Tool surface unchanged | `tests/test_mcp_surface.py` green | pass |

**Evidence:**
```text
cd core/meetings/services/mcp && PYTHONPATH=src uv run pytest \
  tests/test_mcp_sessioned_sse.py tests/test_mcp_surface.py -q
# → 11 passed in ~18s
```

**Red (before fix):** same handshake → sessioned GET → `TimeoutError` at 5s with no `http.response.start`.

**Not checked:** live compose stack push of a server→client MCP message over the SSE leg (acceptance sketch row 3). Headers + idle ping prove the stream opens; a live push can be signed on compose if wanted.

## Test plan
- [x] In-process ASGI: sessioned headers, idle ping, sessionless 400
- [ ] Optional compose: handshake → sessioned GET via gateway and direct `:8010`