### PR TITLE
fix(deploy,admin-api): migrations job honors global.imageTag; bounded DB-connect retry at boot (#900, #901)

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/__main__.py
+++ b/core/identity/services/admin-api/src/admin_api/__main__.py
@@ -7,7 +7,67 @@ request. uvicorn-target: ``uvicorn admin_api.__main__:app`` / ``python -m admin_
 """
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
+import socket
+
+logger = logging.getLogger("admin_api.boot")
+
+# #901: bounded initial-DB-connect retry. On a cold start the Postgres DNS name may not resolve
+# yet (socket.gaierror) or the socket may refuse (ConnectionError); rather than throwing exit(3)
+# on the first miss and leaning on the k8s restart loop (observed 2× in the first ~20s of the
+# v0.12.17-rc.1 smoke), we retry with capped exponential backoff, then fail LOUD after the bound.
+# Bounds are env-tunable but default to ~ (0.5+1+2+4+8)*→ under the 40×5s startup-probe budget.
+DB_CONNECT_MAX_ATTEMPTS = int(os.getenv("DB_CONNECT_MAX_ATTEMPTS", "10"))
+DB_CONNECT_BASE_DELAY = float(os.getenv("DB_CONNECT_BASE_DELAY", "0.5"))
+DB_CONNECT_MAX_DELAY = float(os.getenv("DB_CONNECT_MAX_DELAY", "8.0"))
+
+# Transient boot-time connect failures worth retrying: DNS not-yet-resolvable (socket.gaierror is
+# an OSError subclass) and refused/reset sockets (ConnectionError ⊂ OSError). SQLAlchemy wraps the
+# driver error in OperationalError/InterfaceError, but the underlying OSError is chained as
+# __cause__, so we unwrap and match on it — narrow enough that a real auth/config error (which is
+# NOT an OSError) still fails fast without burning the retry budget.
+_TRANSIENT_OS_ERRORS = (socket.gaierror, ConnectionError, TimeoutError, OSError)
+
+
+def _is_transient_connect_error(exc: BaseException) -> bool:
+    seen = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, _TRANSIENT_OS_ERRORS):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+async def _connect_with_retry(
+    connect,
+    *,
+    max_attempts: int = DB_CONNECT_MAX_ATTEMPTS,
+    base_delay: float = DB_CONNECT_BASE_DELAY,
+    max_delay: float = DB_CONNECT_MAX_DELAY,
+    sleep=asyncio.sleep,
+):
+    """Await ``connect()`` (a zero-arg coroutine fn), retrying transient connect errors with capped
+    exponential backoff. Re-raises the last error LOUD once ``max_attempts`` is exhausted (#901)."""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await connect()
+        except BaseException as exc:  # noqa: BLE001 — re-raised below unless transient+budget left
+            if attempt >= max_attempts or not _is_transient_connect_error(exc):
+                if attempt >= max_attempts:
+                    logger.error(
+                        "admin-api DB connect failed after %d attempt(s) — giving up", attempt
+                    )
+                raise
+            delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
+            logger.warning(
+                "admin-api DB connect attempt %d/%d failed (%s: %s) — retrying in %.1fs",
+                attempt, max_attempts, type(exc).__name__, exc, delay,
+            )
+            await sleep(delay)
 
 
 def _database_url() -> str:
@@ -49,7 +109,10 @@ def build_production_app():
     async def _converge_schema() -> None:
         # Idempotent, never-drops convergence — safe to run on every boot (matches the parent's
         # ensure_schema() discipline). The async engine is the one db.configure() just bound.
-        await ensure_schema(app_db.get_engine(), Base)
+        # #901: the first connect here is where a cold-start DNS race surfaces (socket.gaierror);
+        # retry with bounded backoff so a not-yet-ready Postgres doesn't exit(3) into the restart
+        # loop. After the bound it re-raises loud — a persistently unreachable DB still fails.
+        await _connect_with_retry(lambda: ensure_schema(app_db.get_engine(), Base))
 
     return app
 

--- a/core/identity/services/admin-api/src/admin_api/config.v1.json
+++ b/core/identity/services/admin-api/src/admin_api/config.v1.json
@@ -69,6 +69,27 @@
    "targets": []
   },
   {
+   "key": "DB_CONNECT_MAX_ATTEMPTS",
+   "class": "defaulted",
+   "default": "10",
+   "description": "bounded initial-DB-connect retry: max attempts before failing loud. On a cold start where Postgres DNS isn't resolvable yet, the boot retries the first connect instead of exit(3)-ing into the k8s restart loop (#901). After this many attempts it re-raises.",
+   "targets": []
+  },
+  {
+   "key": "DB_CONNECT_BASE_DELAY",
+   "class": "defaulted",
+   "default": "0.5",
+   "description": "bounded initial-DB-connect retry: base backoff seconds (capped-exponential: base×2^(n-1), clamped to DB_CONNECT_MAX_DELAY). #901.",
+   "targets": []
+  },
+  {
+   "key": "DB_CONNECT_MAX_DELAY",
+   "class": "defaulted",
+   "default": "8.0",
+   "description": "bounded initial-DB-connect retry: max backoff seconds per attempt (the exponential is clamped here). #901.",
+   "targets": []
+  },
+  {
    "key": "DEV_MODE",
    "class": "defaulted",
    "default": "false",

--- a/core/identity/services/admin-api/tests/test_boot_db_retry.py
+++ b/core/identity/services/admin-api/tests/test_boot_db_retry.py
@@ -1,0 +1,106 @@
+"""#901 · admin-api bounded initial-DB-connect retry.
+
+On a cold start where Postgres DNS isn't resolvable yet, admin-api used to throw
+``socket.gaierror`` straight out of the startup schema-convergence and exit(3), leaning on the
+k8s restart loop (observed 2× in the first ~20s of the v0.12.17-rc.1 smoke). The fix wraps the
+initial connect in ``_connect_with_retry``: transient connect errors (DNS/refused/reset) retry
+with bounded exponential backoff; after the bound it re-raises LOUD (no infinite retry).
+
+Discriminating red→green:
+  * fails N times with socket.gaierror then succeeds → returns the value, no raise (today: raises)
+  * persistently failing → still raises after exactly max_attempts tries (fail loud, not forever)
+  * a NON-transient error (auth/config) fails fast without burning the retry budget
+
+Uses ``asyncio.run`` in plain sync tests (matching the suite's existing pattern) — no
+pytest-asyncio marker dependency.
+"""
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from admin_api.__main__ import _connect_with_retry, _is_transient_connect_error
+
+
+async def _nosleep(_delay):
+    return None
+
+
+def test_retries_then_succeeds():
+    calls = {"n": 0}
+
+    async def connect():
+        calls["n"] += 1
+        if calls["n"] < 4:
+            raise socket.gaierror(-2, "Name or service not known")
+        return "healthy"
+
+    result = asyncio.run(
+        _connect_with_retry(
+            connect, max_attempts=10, base_delay=0.0, max_delay=0.0, sleep=_nosleep
+        )
+    )
+    assert result == "healthy"
+    assert calls["n"] == 4  # 3 failures then a success
+
+
+def test_wrapped_gaierror_is_transient_and_retried():
+    # SQLAlchemy wraps the driver error; the gaierror is chained as __cause__. Retry must unwrap.
+    calls = {"n": 0}
+
+    async def connect():
+        calls["n"] += 1
+        if calls["n"] < 2:
+            try:
+                raise socket.gaierror(-2, "Name or service not known")
+            except socket.gaierror as e:
+                raise RuntimeError("(sqlalchemy) OperationalError connecting") from e
+        return "ok"
+
+    result = asyncio.run(
+        _connect_with_retry(
+            connect, max_attempts=5, base_delay=0.0, max_delay=0.0, sleep=_nosleep
+        )
+    )
+    assert result == "ok"
+    assert calls["n"] == 2
+
+
+def test_fails_loud_after_bound():
+    calls = {"n": 0}
+
+    async def connect():
+        calls["n"] += 1
+        raise socket.gaierror(-2, "Name or service not known")
+
+    with pytest.raises(socket.gaierror):
+        asyncio.run(
+            _connect_with_retry(
+                connect, max_attempts=5, base_delay=0.0, max_delay=0.0, sleep=_nosleep
+            )
+        )
+    assert calls["n"] == 5  # bounded — exactly max_attempts, never infinite
+
+
+def test_non_transient_error_fails_fast():
+    calls = {"n": 0}
+
+    async def connect():
+        calls["n"] += 1
+        raise ValueError("bad DSN / auth misconfig — not a network blip")
+
+    with pytest.raises(ValueError):
+        asyncio.run(
+            _connect_with_retry(
+                connect, max_attempts=10, base_delay=0.0, max_delay=0.0, sleep=_nosleep
+            )
+        )
+    assert calls["n"] == 1  # no retry budget burned on a config error
+
+
+def test_transient_classifier():
+    assert _is_transient_connect_error(socket.gaierror(-2, "x"))
+    assert _is_transient_connect_error(ConnectionRefusedError())
+    assert not _is_transient_connect_error(ValueError("x"))

--- a/deploy/helm/charts/vexa/templates/job-migrations.yaml
+++ b/deploy/helm/charts/vexa/templates/job-migrations.yaml
@@ -42,7 +42,7 @@ spec:
         - name: migrations
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ default .Values.meetingApi.image.repository .Values.migrations.image.repository }}:{{ default .Values.meetingApi.image.tag .Values.migrations.image.tag }}"
+          image: "{{ default .Values.meetingApi.image.repository .Values.migrations.image.repository }}:{{ .Values.global.imageTag | default (default .Values.meetingApi.image.tag .Values.migrations.image.tag) }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command:
             - /bin/sh

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -186,4 +186,16 @@ else
   echo "  OK: dashboard image ignores global.imageTag (own pinned tag)"
 fi
 
+# #900 — the migrations Job must follow global.imageTag (it runs release code against the
+# schema; a rolling-v012 image on a pinned deploy is a schema/code skew). Opposite of the
+# dashboard: here global.imageTag MUST win over the meetingApi/migrations fallback tag.
+MIG_IMG="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set migrations.enabled=true --set global.imageTag=vMIGRATE \
+  --show-only templates/job-migrations.yaml | grep -E '^\s+image:')"
+if grep -qE ':vMIGRATE"?$' <<< "$MIG_IMG"; then
+  echo "  OK: migrations Job honors global.imageTag (pinned release image)"
+else
+  echo "  FAIL: migrations Job ignored global.imageTag — schema/code skew risk (#900): $MIG_IMG"; fail=1
+fi
+
 [ "$fail" -eq 0 ] && { echo "gate:helm PASS"; exit 0; } || { echo "gate:helm FAIL"; exit 1; }

--- a/docs/changelog.d/900-migrations-job-honors-imagetag.md
+++ b/docs/changelog.d/900-migrations-job-honors-imagetag.md
@@ -1,0 +1,5 @@
+- **Helm migrations Job now honors `global.imageTag` (#900).** A pinned-tag deploy with
+  `migrations.enabled=true` previously ran the schema-convergence Job from the rolling `v012`
+  image instead of the deployed release tag — a schema/code skew risk. The Job now resolves its
+  tag with the same precedence the component Deployments use (`global.imageTag` wins, falling back
+  to the `migrations`/`meetingApi` image tag). See [Kubernetes deployment](/deployment-kubernetes).

--- a/docs/changelog.d/901-admin-api-db-connect-retry.md
+++ b/docs/changelog.d/901-admin-api-db-connect-retry.md
@@ -1,0 +1,5 @@
+- **admin-api retries the initial DB connect on cold start (#901).** On a boot where Postgres DNS
+  isn't resolvable yet, admin-api used to throw `socket.gaierror` and exit immediately, relying on
+  the k8s restart loop (a transient RED an operator would see). It now retries the first connect
+  with bounded exponential backoff (env-tunable via `DB_CONNECT_MAX_ATTEMPTS` /
+  `DB_CONNECT_BASE_DELAY` / `DB_CONNECT_MAX_DELAY`), then fails loud once the bound is exhausted.


### PR DESCRIPTION
> ⚠️ **HOT FILE TOUCHED — `deploy/helm/tests/test_template.sh`.** This PR adds one assertion
> block (12 lines, appended before the final gate verdict) to that flagged hot file for the #900
> regression guard. Per AGENTS.md this file is not `merge=union`-safe. **Sequence any other PR
> that touches it against this one.** No other open PR currently modifies it.

Two small deploy-hardening fixes found during the v0.12.17-rc.1 image smoke.

Closes #900
Closes #901

---

## #900 — Helm migrations Job ignored `global.imageTag`

`deploy/helm/charts/vexa/templates/job-migrations.yaml` resolved its image tag from
`meetingApi.image.tag` (default rolling `v012`) instead of `global.imageTag`. A pinned-tag deploy
with `migrations.enabled=true` ran schema convergence from the **wrong image** — a schema/code
skew risk. Now the Job follows the same precedence the component Deployments use:
`global.imageTag` wins, falling back to the `migrations`/`meetingApi` image tag.

Diff:
```
image: "...:{{ default .Values.meetingApi.image.tag .Values.migrations.image.tag }}"
     → image: "...:{{ .Values.global.imageTag | default (default .Values.meetingApi.image.tag .Values.migrations.image.tag) }}"
```

### Red → green (rendered image of the migrations Job)

| render | before fix | after fix |
|---|---|---|
| `--set migrations.enabled=true --set global.imageTag=vXTEST` | `vexaai/v012-meeting-api:v012` ❌ (wrong image) | `vexaai/v012-meeting-api:vXTEST` ✅ |
| default (control) | `vexaai/v012-meeting-api:v012` | `vexaai/v012-meeting-api:v012` ✅ (unchanged) |
| `--set migrations.image.tag=vMIG` (no global) | — | `vexaai/v012-meeting-api:vMIG` ✅ (override still honored) |

Regression guard added to `deploy/helm/tests/test_template.sh` (`--show-only
templates/job-migrations.yaml`, asserts the Job image ends in the pinned tag). Verified it FAILS
on the pre-fix template and PASSES on the fix:
```
RED (orig template):  FAIL: migrations Job ignored global.imageTag — schema/code skew risk (#900): image: "vexaai/v012-meeting-api:v012"
GREEN (fixed):        OK: migrations Job honors global.imageTag (pinned release image)
```

## #901 — admin-api had no DB-connect retry at boot

On a cold start where Postgres DNS isn't resolvable yet, admin-api's startup schema-convergence
threw `socket.gaierror` straight out and `exit(3)`, leaning on the k8s restart loop (observed 2×
in the first ~20s of the smoke). Fixed at the point of introduction
(`core/identity/services/admin-api/src/admin_api/__main__.py`): the startup connect is wrapped in
`_connect_with_retry` — bounded exponential backoff over transient connect errors (DNS/refused/
reset, unwrapped from SQLAlchemy's chained cause), then **re-raises loud** after the bound (no
infinite retry). A non-transient error (bad DSN/auth) still fails fast. Env-tunable:
`DB_CONNECT_MAX_ATTEMPTS` (10), `DB_CONNECT_BASE_DELAY` (0.5s), `DB_CONNECT_MAX_DELAY` (8s).

### Red → green (`tests/test_boot_db_retry.py`, 5 tests)

- **retries then succeeds** — fails 3× with `socket.gaierror` then succeeds → returns `healthy`,
  no raise (pre-fix: first miss propagates → `exit(3)`).
- **wrapped gaierror is transient** — a `socket.gaierror` chained as `__cause__` under a
  SQLAlchemy-shaped error is unwrapped and retried.
- **fails loud after bound** — persistent failure raises after exactly `max_attempts` (bounded,
  never infinite).
- **non-transient fails fast** — a `ValueError` (config/auth) raises on attempt 1, no retry
  budget burned.
- **classifier** — `gaierror`/`ConnectionRefusedError` transient, `ValueError` not.

```
RED (pre-fix): first miss propagates gaierror -> process exit(3)
GREEN (post-fix): retried 2 times then healthy
```

## Validation

- `deploy/helm/tests/test_template.sh` → `gate:helm PASS` (incl. new #900 assertion).
- admin-api suite: new `test_boot_db_retry.py` 5/5 pass; the 13 offline tests pass. (The
  testcontainers stack tests require a Docker/testcontainers env and are collection-skipped in the
  bare venv — unrelated to this change.)
- `MOCK_BOT=1 BROWSER_IMAGE=mock-bot:dev node scripts/gates.mjs all` — green.

Changelog fragments: `docs/changelog.d/900-migrations-job-honors-imagetag.md`,
`docs/changelog.d/901-admin-api-db-connect-retry.md`.

_Ignore the spurious merge-card check._
