### PR TITLE
fix(lite): pin service venvs to Python 3.12 so admin-api boots (#927)

### DIFF
--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -90,29 +90,33 @@ RUN mkdir -p /var/log/supervisor /var/lib/redis /var/run/redis /workspaces
 
 # ── Python venvs — one per service (avoids cross-service dependency-pin conflicts). Each mirrors
 #    that service's Dockerfile (uv sync --frozen + the production-only ASGI/DB extras). ────────────
+#    `--python 3.12` pins the interpreter to match every compose image's `FROM python:3.12-slim`.
+#    The jammy base ships only system python3.10 (< requires-python >=3.11), so an unpinned
+#    `uv venv` would auto-download the newest managed CPython (3.14) — whose stack fails at boot
+#    (SQLAlchemy's psycopg dialect import). Pinning keeps Lite on the same interpreter as compose/helm.
 # admin-api
 COPY core/identity/services/admin-api/pyproject.toml core/identity/services/admin-api/uv.lock /tmp/admin/
-RUN cd /tmp/admin && uv venv /opt/venvs/admin \
+RUN cd /tmp/admin && uv venv --python 3.12 /opt/venvs/admin \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/admin uv sync --frozen --no-install-project \
  && uv pip install --python /opt/venvs/admin/bin/python "uvicorn[standard]==0.34.0" "sqlalchemy[asyncio]==2.0.36" "asyncpg==0.30.0"
 # runtime
 COPY core/runtime/pyproject.toml core/runtime/uv.lock /tmp/runtime/
-RUN cd /tmp/runtime && uv venv /opt/venvs/runtime \
+RUN cd /tmp/runtime && uv venv --python 3.12 /opt/venvs/runtime \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/runtime uv sync --frozen --no-install-project --no-dev \
  && uv pip install --python /opt/venvs/runtime/bin/python "uvicorn[standard]==0.34.0"
 # meeting-api
 COPY core/meetings/services/meeting-api/pyproject.toml core/meetings/services/meeting-api/uv.lock /tmp/meeting/
-RUN cd /tmp/meeting && uv venv /opt/venvs/meeting \
+RUN cd /tmp/meeting && uv venv --python 3.12 /opt/venvs/meeting \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/meeting uv sync --frozen --no-install-project \
  && uv pip install --python /opt/venvs/meeting/bin/python "uvicorn[standard]==0.34.0" "sqlalchemy[asyncio]==2.0.36" "asyncpg==0.30.0" "boto3==1.35.0"
 # gateway
 COPY core/gateway/services/gateway/pyproject.toml core/gateway/services/gateway/uv.lock /tmp/gateway/
-RUN cd /tmp/gateway && uv venv /opt/venvs/gateway \
+RUN cd /tmp/gateway && uv venv --python 3.12 /opt/venvs/gateway \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/gateway uv sync --frozen --no-install-project \
  && uv pip install --python /opt/venvs/gateway/bin/python "uvicorn[standard]==0.34.0" "redis==5.2.1"
 # agent (control-plane group ⇒ fastapi/uvicorn; base deps cover the worker too)
 COPY core/agent/pyproject.toml core/agent/uv.lock /tmp/agent/
-RUN cd /tmp/agent && uv venv /opt/venvs/agent \
+RUN cd /tmp/agent && uv venv --python 3.12 /opt/venvs/agent \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/agent uv sync --frozen --no-install-project --no-default-groups --group control-plane
 RUN rm -rf /tmp/admin /tmp/runtime /tmp/meeting /tmp/gateway /tmp/agent
 

--- a/docs/changelog.d/927-lite-python-pin.md
+++ b/docs/changelog.d/927-lite-python-pin.md
@@ -1,0 +1,10 @@
+- **Vexa Lite pins its service interpreters to Python 3.12, so admin-api boots again (#927).** The
+  single-container Lite image builds each service venv with `uv venv` on a Playwright/jammy base
+  whose only system Python is 3.10 — below `requires-python >=3.11`. An unpinned `uv venv` therefore
+  auto-downloaded the newest managed CPython (3.14), on which the frozen async-Postgres stack fails
+  (asyncpg's C extension will not build under 3.14; SQLAlchemy's psycopg dialect import crashes at
+  startup), so `admin-api` entered a supervisor FATAL loop and API-key provisioning silently no-oped
+  — the gateway then answered every request with `Authentication temporarily unavailable`. All five
+  Lite venvs (admin-api, runtime, meeting-api, gateway, agent) now pass `--python 3.12`, matching the
+  `FROM python:3.12-slim` every compose image (and helm, which ships those images) already pinned.
+  Compose and helm never shared the exposure.


### PR DESCRIPTION
Closes #927

## Where Python 3.14 enters

Vexa **Lite** builds one venv per service in `deploy/lite/Dockerfile.lite` with `uv venv` on the
`mcr.microsoft.com/playwright:v1.56.0-jammy` base. Jammy's only system Python is **3.10**, which is
below every service's `requires-python >=3.11`. With no interpreter satisfying the constraint and
`--python` unset, `uv venv` **auto-downloads the newest managed CPython — 3.14** — the interpreter
the crash log names (`/opt/venvs/admin/lib/python3.14/...`).

On 3.14 the frozen async-Postgres stack does not stand up: `asyncpg==0.30.0`'s C extension fails to
build under 3.14 (the `uv sync --frozen` step itself errors), and SQLAlchemy's psycopg dialect
import blows up at boot — so `admin-api` enters a supervisor FATAL loop, key provisioning silently
no-ops, and the gateway answers `Authentication temporarily unavailable`.

## The fork I chose — and why

**Pin the interpreter, not the driver.** Every compose service image already pins `FROM
python:3.12-slim` (admin-api, runtime, meeting-api, gateway, agent), and helm ships those same
images. Lite was the *only* surface that let uv float to a newer Python. The fix restores parity:
all five Lite `uv venv` calls now pass `--python 3.12`.

Rejected the issue's suggested "upgrade psycopg2 to 2.9.11+" fork: the admin-api dependency set is
`psycopg[binary]` (psycopg3) + `asyncpg` — there is no psycopg2 to bump, and the true defect is
`asyncpg` not building on 3.14, not a psycopg2 version. Bumping a phantom dep would leave the
interpreter drift (the point of introduction) unfixed. No new dependency is added, so FINOS Cat A
is untouched.

## Do compose / helm share the exposure?

**No.** All five compose images pin `FROM python:3.12-slim`; helm deploys those images. The drift is
Lite-only. Fix keeps Lite on the same interpreter compose/helm already use.

## Observation bundle — red → green

Reproduced offline with a minimal jammy layer mirroring Lite's admin-api venv build (`pyproject.toml`
+ `uv.lock` unchanged), `uv==0.9.22` (the pinned version).

**RED (pre-fix, unpinned `uv venv`):**
```
#10 Downloading cpython-3.14.2-linux-aarch64-gnu
#10 Using CPython 3.14.2
#10 Creating virtual environment at: /opt/venvs/admin
#10 uv sync --frozen  ├─▶ The build backend returned an error
#10   creating build/lib.linux-aarch64-cpython-314/asyncpg   (C-extension build FAILS)
```
Build aborts at `uv sync --frozen`; admin-api can never boot — exactly issue #927.

**GREEN (post-fix, `uv venv --python 3.12`):**
```
#10 Downloading cpython-3.12.12-linux-aarch64-gnu
#10 Using CPython 3.12.12
#10 uv venv --python 3.12 && uv sync --frozen && uv pip install sqlalchemy asyncpg
#10 DONE 7.5s
#11 Python 3.12.12
#13 naming to docker.io/library/repro927-green   (image builds clean)
```
Interpreter pinned to 3.12; `uv sync --frozen` succeeds (asyncpg builds); admin-api's async-Postgres
stack installs, matching the working compose image.

## Gates

`node scripts/gates.mjs all` (MOCK_BOT=1 BROWSER_IMAGE=mock-bot:dev): the Lite-relevant
`gate:lite-makefile` is green, along with readme, docs-version, dataflow, isolation(-py),
exports, graph(-py), schema, contract-version, config-contract, db-schema, db-budget.

## What I did NOT check

- Did **not** build the full ~3.6 GB Lite image end-to-end (Playwright + npm + all five venvs);
  reproduced the failing/fixed layer in isolation (the admin-api venv is where the crash lives).
- Did **not** boot admin-api against a live Postgres and mint a real key; the RED→GREEN turns on the
  interpreter selection + `uv sync --frozen` build, which is the crash's point of introduction.
- `gate:python` / heavier `uv run pytest` gates could not run in this sandbox — `uv run` is killed
  (SIGTERM/exit 144, no network for interpreter/testcontainers). Unrelated to this diff, which only
  touches `deploy/lite/Dockerfile.lite` and a changelog fragment; those gates run pytest over
  `core/` packages this change does not touch.
