### PR TITLE
fix(join): pin bot browser UI locale (#856) + demote #917 CTA scan to diagnostic-only

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/__tests__/localePin.test.ts
+++ b/core/meetings/modules/join/src/__tests__/localePin.test.ts
@@ -1,0 +1,48 @@
+// #856 — the browser UI locale is a PINNED input, not an uncontrolled one.
+// Pure unit checks, no browser: the launch flags carry --lang / --accept-lang for
+// the resolved BOT_UI_LOCALE knob, and the constructed Meet URL carries ?hl=.
+import { getJoinBrowserArgs, getLocaleBrowserArgs, resolveBotUiLocale } from "../browser-args";
+import { withPinnedMeetLocale } from "../googlemeet/join";
+
+let passed = 0, failed = 0;
+function assert(cond: boolean, msg: string): void {
+  if (cond) { passed++; console.log(`  \x1b[32mPASS\x1b[0m  ${msg}`); }
+  else { failed++; console.log(`  \x1b[31mFAIL\x1b[0m  ${msg}`); }
+}
+
+console.log("\n=== 1. Default pin: en-US ===");
+{
+  delete process.env.BOT_UI_LOCALE;
+  assert(resolveBotUiLocale() === "en-US", "resolveBotUiLocale() defaults to en-US when the knob is unset");
+  const args = getJoinBrowserArgs();
+  assert(args.includes("--lang=en-US"), "getJoinBrowserArgs() carries --lang=en-US by default");
+  assert(args.includes("--accept-lang=en-US,en"), "getJoinBrowserArgs() carries --accept-lang=en-US,en by default");
+}
+
+console.log("\n=== 2. Negative control: the knob really drives it (A2) ===");
+{
+  process.env.BOT_UI_LOCALE = "hu-HU";
+  assert(resolveBotUiLocale() === "hu-HU", "BOT_UI_LOCALE=hu-HU is honoured");
+  const args = getLocaleBrowserArgs();
+  assert(args.includes("--lang=hu-HU"), "--lang follows the knob (hu-HU) — the pin is not a no-op");
+  assert(args.includes("--accept-lang=hu-HU,hu"), "--accept-lang follows the knob (hu-HU,hu)");
+  delete process.env.BOT_UI_LOCALE;
+}
+
+console.log("\n=== 3. ?hl= on the constructed Meet URL (BOT_AUTHENTICATED lever) ===");
+{
+  const url = withPinnedMeetLocale("https://meet.google.com/abc-defg-hij", "en-US");
+  assert(/[?&]hl=en(&|$)/.test(url), `?hl=en appended (bare language subtag): ${url}`);
+
+  const hu = withPinnedMeetLocale("https://meet.google.com/abc-defg-hij", "hu-HU");
+  assert(/[?&]hl=hu(&|$)/.test(hu), `?hl follows the pinned locale: ${hu}`);
+
+  const preset = withPinnedMeetLocale("https://meet.google.com/abc-defg-hij?hl=fr", "en-US");
+  assert(/hl=fr/.test(preset) && !/hl=en/.test(preset), "an explicit caller hl= is preserved, never overridden");
+
+  const bad = withPinnedMeetLocale("not a url", "en-US");
+  assert(bad === "not a url", "a malformed URL is returned unchanged (no throw)");
+}
+
+console.log(`\n=== summary: ${passed} passed, ${failed} failed ===`);
+process.exit(failed > 0 ? 1 : 0);

--- a/core/meetings/modules/join/src/browser-args.ts
+++ b/core/meetings/modules/join/src/browser-args.ts
@@ -17,7 +17,33 @@
  * Google's bot-detection layer and directly cause the "You can't join this meeting"
  * interstitial on datacenter egress IPs. Meet uses valid TLS; init-scripts inject via
  * CDP (unaffected by CSP). --disable-blink-features=AutomationControlled replaces them.
+ *
+ * #856 (2026-07-23): the browser UI locale is now PINNED. We never used to tell
+ * the browser what language to be, so Google Meet localised from Accept-Language
+ * or IP geolocation and served non-English lobbies on EU/other egress — the root
+ * cause of the join-button-not-found class (#846). `--lang` / `--accept-lang`
+ * pin Chrome's own UI + Accept-Language header; the Playwright context `locale`
+ * (remote-browser/browser.ts) pins navigator.language. The pinned value is a
+ * deployment knob — BOT_UI_LOCALE, default en-US — so a deployment that genuinely
+ * wants another UI language can set it. This is what makes the English lobby
+ * selectors correct BY CONSTRUCTION rather than lucky.
  */
+
+/** The pinned browser UI locale (#856). Deployment knob; default en-US. */
+export function resolveBotUiLocale(): string {
+  const v = (process.env.BOT_UI_LOCALE || "").trim();
+  return v.length > 0 ? v : "en-US";
+}
+
+/** `--lang` / `--accept-lang` flags for the pinned UI locale (#856). Kept out of
+ *  the static array below because they resolve an env knob at call time. */
+export function getLocaleBrowserArgs(): string[] {
+  const locale = resolveBotUiLocale();
+  const primaryLang = locale.split("-")[0];
+  const acceptLang = primaryLang && primaryLang !== locale ? `${locale},${primaryLang}` : locale;
+  return [`--lang=${locale}`, `--accept-lang=${acceptLang}`];
+}
+
 export const JOIN_BROWSER_ARGS: readonly string[] = [
   "--incognito",
   "--no-sandbox",
@@ -44,7 +70,9 @@ export const JOIN_BROWSER_ARGS: readonly string[] = [
   "--disable-site-isolation-trials",
 ];
 
-/** The canonical join launch args, as a fresh mutable array per call. */
+/** The canonical join launch args, as a fresh mutable array per call. Includes
+ *  the pinned-locale flags (#856) so every launch path — production bot and the
+ *  debug harness — is byte-identical and speaks the same UI language. */
 export function getJoinBrowserArgs(): string[] {
-  return [...JOIN_BROWSER_ARGS];
+  return [...JOIN_BROWSER_ARGS, ...getLocaleBrowserArgs()];
 }

--- a/core/meetings/modules/join/src/googlemeet/humanized/humanized.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/humanized/humanized.test.ts
@@ -150,19 +150,22 @@ console.log("\nTest 4: X11Input command emission (dryRun)");
       path.join(__dirname, "..", "selectors.ts"),
       "utf-8"
     );
-    // (a) join button: a locale-agnostic structural selector precedes the
-    // English text selector, so a Hungarian "Kérvényezés a csatlakozásra"
-    // button (no English text) still matches by jsname/structure.
+    // (a) join button: #856 reorder — the EXACT English text selector precedes the
+    // broad structural entry, which is retained LAST as a locale-agnostic backstop.
+    // Ordered resolution makes list position authoritative, and with the UI locale
+    // pinned the English text is correct by construction; the broad entry must only
+    // win when nothing exact matches (it can otherwise pick a wrong jsname+span
+    // button early in DOM order). Match the selector *literals* in the array, not
+    // the prose comment (which mentions both).
     const joinBlock = selectorsSrc.slice(
-      selectorsSrc.indexOf("googleJoinButtonSelectors"),
-      selectorsSrc.indexOf("googleCameraButtonSelectors")
+      selectorsSrc.indexOf("export const googleJoinButtonSelectors"),
+      selectorsSrc.indexOf("googleLobbyIconGlyphSelectors")
     );
-    const joinJsnameIdx = joinBlock.indexOf("button[jsname]");
-    // Match the English *selector literals* (not the prose comment, which also
-    // mentions the English text).
+    const joinStructuralIdx = joinBlock.indexOf("'button[jsname]:not([aria-label]):has(span)'");
     const joinEnglishIdx = joinBlock.indexOf("has-text(\"Ask to join\")");
-    assert(joinJsnameIdx >= 0, "join selectors include a locale-agnostic jsname/structure selector");
-    assert(joinJsnameIdx < joinEnglishIdx, "locale-agnostic join selector precedes the English-text fallback");
+    assert(joinStructuralIdx >= 0, "join selectors retain the locale-agnostic structural backstop");
+    assert(joinEnglishIdx >= 0 && joinEnglishIdx < joinStructuralIdx,
+      "exact English-text join selector precedes the broad structural backstop (#856 order)");
 
     // (b) name field: structural input selector precedes the English aria-label.
     const nameBlock = selectorsSrc.slice(
@@ -195,9 +198,13 @@ console.log("\nTest 4: X11Input command emission (dryRun)");
       text: "",
       children: [],
     };
-    const firstJoinSel = googleJoinButtonSelectors[0];
+    // #856: the join list now leads with EXACT English text, so the Hungarian
+    // button is caught by the structural BACKSTOP (last entry), not [0]. That
+    // backstop is diagnostic-only in prod, but it must still structurally match a
+    // localized CTA — the property this row pins.
+    const structuralJoinSel = googleJoinButtonSelectors[googleJoinButtonSelectors.length - 1];
     const firstNameSel = googleNameInputSelectors[0];
-    assert(matchesSelector(huJoinBtn, firstJoinSel), `hu join button matches locale-agnostic selector '${firstJoinSel}'`);
+    assert(matchesSelector(huJoinBtn, structuralJoinSel), `hu join button matches the structural backstop '${structuralJoinSel}'`);
     assert(matchesSelector(huNameInput, firstNameSel), `hu name input matches locale-agnostic selector '${firstNameSel}'`);
     // Negative control: the English-text selector must NOT match the hu button.
     assert(!matchesSelector(huJoinBtn, 'button:has-text("Ask to join")'), "English-text selector does NOT match the hu join button (the regression)");

--- a/core/meetings/modules/join/src/googlemeet/join-cta.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/join-cta.test.ts
@@ -245,10 +245,10 @@ const isCta = (el: Element | null) => el !== null && el.getAttribute('data-cta')
       'en lobby, aria-labelled CTA: resolved by the English literal — the entry production wins on 7/7');
   }
 
-  console.log('\n=== 2. findLobbyPrimaryCta closes it — locale-agnostically, on the CTA itself ===');
+  console.log('\n=== 2. findLobbyPrimaryCta unit — the pure scan still discriminates (diagnostic-only in prod, #856) ===');
   {
     const hu = scan(HU_LABELLED_CTA);
-    assert(isCta(hu.el), 'hu lobby, aria-labelled CTA: the scan resolves the CTA (red→green for #846 A1)');
+    assert(isCta(hu.el), 'hu lobby, aria-labelled CTA: the scan uniquely identifies the CTA element (pure function)');
     assert(hu.labels.length === 1 && hu.labels[0] === HU.ctaText,
       `exactly one candidate, and it is the CTA label ("${hu.labels[0]}")`);
 
@@ -312,32 +312,56 @@ const isCta = (el: Element | null) => el !== null && el.getAttribute('data-cta')
       'a lobby of icon buttons only → no candidates at all (the scan is not a catch-all)');
   }
 
-  console.log('\n=== 4. Ordered resolution — the selector list is honoured top-down ===');
+  console.log('\n=== 4. Ordered resolution — EXACT text wins over the broad structural entry ===');
   {
-    // Both the structural entry and the English literal are "visible" here. The
-    // resolver must return the EARLIER one deterministically; the previous
-    // parallel race made this a coin flip, which is how a broad entry can beat a
-    // precise one (#600's failure class).
-    const both = [googleJoinButtonSelectors[0], '//button[.//span[text()="Ask to join"]]'];
+    const exactSelector = '//button[.//span[text()="Ask to join"]]';
+    const broadSelector = 'button[jsname]:not([aria-label]):has(span)';
+    // #856 ordering: the exact text selector is FIRST in googleJoinButtonSelectors
+    // and the broad structural entry is LAST. When both are visible, ordered
+    // resolution must return the EXACT one — the pin makes the English text
+    // correct by construction, and the broad entry (which can match a wrong
+    // jsname+span button early in DOM order) must only win when nothing exact does.
+    assert(googleJoinButtonSelectors[0] === exactSelector,
+      'the exact "Ask to join" selector is FIRST in the list (#856 reorder)');
+    assert(googleJoinButtonSelectors[googleJoinButtonSelectors.length - 1] === broadSelector,
+      'the broad structural entry is LAST in the list (#856 reorder)');
+
+    const both = [exactSelector, broadSelector];
     const hit = await waitForAnySelector(mockPage({ visible: both }) as any, googleJoinButtonSelectors, 5000, 'join button');
-    assert(hit.selector === googleJoinButtonSelectors[0],
-      `earlier selector wins when several match ("${hit.selector}")`);
+    assert(hit.selector === exactSelector,
+      `exact text beats the broad structural entry when both match ("${hit.selector}")`);
 
-    // And a later entry still wins when it is the only match.
-    const late = await waitForAnySelector(
-      mockPage({ visible: ['button:has-text("Join now")'] }) as any, googleJoinButtonSelectors, 5000, 'join button');
-    assert(late.selector === 'button:has-text("Join now")', 'a later-only match is still resolved');
+    // The broad entry still wins when it is the ONLY match (last-resort backstop).
+    const broadOnly = await waitForAnySelector(
+      mockPage({ visible: [broadSelector] }) as any, googleJoinButtonSelectors, 5000, 'join button');
+    assert(broadOnly.selector === broadSelector, 'the broad structural entry is still resolved when it is the only match');
+  }
 
-    // The selector list is checked BEFORE the scan on every poll, so the scan
-    // cannot overrule a lobby the list can name.
+  console.log('\n=== 5. The structural scan is DIAGNOSTIC-ONLY — it never returns/clicks a CTA (#856 owner ruling) ===');
+  {
+    // The selector list names this lobby → resolved by the selector, not the scan.
     const listWins = await waitForLobbyCta(
       mockPage({ visible: ['button:has-text("Ask to join")'], scanLabels: ['Ask to join'], scanHits: true }) as any,
       googleJoinButtonSelectors, 5000, 'join button');
-    assert(listWins.selector === 'button:has-text("Ask to join")',
-      'the structural scan never overrules a selector the list can name');
+    assert(listWins.selector === 'button:has-text("Ask to join")' && listWins.selector !== STRUCTURAL_CTA_ORIGIN,
+      'a lobby the list can name is resolved by the selector, never by the scan');
+
+    // The selector list MISSES but the scan WOULD uniquely resolve a button. Under
+    // #917 this returned the scan's handle; demoted, waitForLobbyCta must NOT
+    // return it — it runs the budget out and throws, recording the scan's labels.
+    let message = '';
+    let returned: any = null;
+    try {
+      returned = await waitForLobbyCta(
+        mockPage({ visible: [], scanLabels: ['Kérvényezés a csatlakozásra'], scanHits: true, lang: 'hu', nav: 'hu-HU' }) as any,
+        googleJoinButtonSelectors, 900, 'join button');
+    } catch (e: any) { message = String(e?.message || e); }
+    assert(returned === null, 'a unique scan hit is NOT returned as the CTA (diagnostic-only; the scan cannot click)');
+    assert(/Could not locate join button/.test(message) && /Kérvényezés/.test(message),
+      'the scan candidate label is recorded in the loud miss (evidence for a future re-promotion)');
   }
 
-  console.log('\n=== 5. A total miss is diagnosable from last_error alone (#846 A4) ===');
+  console.log('\n=== 6. A total miss is diagnosable from last_error alone (#846 A4) ===');
   {
     let message = '';
     try {

--- a/core/meetings/modules/join/src/googlemeet/join.ts
+++ b/core/meetings/modules/join/src/googlemeet/join.ts
@@ -13,6 +13,7 @@ import {
 } from "./selectors";
 import { HumanizedInteractor, MOCAP_LIBRARY } from "./humanized";
 import { AdmissionError } from "../shared/admission";
+import { resolveBotUiLocale } from "../browser-args";
 
 /** Thrown when authenticated mode detects a signed-out browser profile. Extends AdmissionError so
  *  the JoinDriver's single `instanceof` catch maps the typed `auth_session_missing` outcome to a
@@ -57,7 +58,11 @@ const CTA_SCAN_EVERY_POLLS = 5;
  *  a half-built lobby can momentarily expose exactly one text button that is
  *  not the CTA, and the scan's whole safety argument is uniqueness. */
 const CTA_SCAN_GRACE_MS = 8000;
-/** Reported in place of a selector string when the structural scan wins. */
+/** Origin tag for the structural scan. DIAGNOSTIC-ONLY: the scan never clicks or
+ *  returns a handle to the join flow (owner ruling on #856/#917). It is retained
+ *  purely to (a) record candidate labels for the failure diagnostic and (b) emit
+ *  a telemetry line when it WOULD have uniquely resolved a lobby the selectors
+ *  could not — the evidence a future re-promotion would need. */
 export const STRUCTURAL_CTA_ORIGIN = "structural:lobby-primary-cta";
 
 /** Result of the browser-context lobby scan. `el` is non-null ONLY when exactly
@@ -229,14 +234,23 @@ export async function waitForAnySelector(
 }
 
 /**
- * Resolve the Meet lobby's primary admission CTA: the ordered selector list
- * first, then — once the lobby has settled — the locale-agnostic structural scan
- * (findLobbyPrimaryCta) as the backstop for a lobby the selector list cannot
- * express, i.e. a non-English CTA that carries an accessible label (#846).
+ * Resolve the Meet lobby's primary admission CTA by the ordered selector list.
  *
- * The selector list is re-checked BEFORE the scan on every poll, so a lobby any
- * selector can name is still resolved by that selector and the scan never gets
- * to overrule it. Both share the one budget; neither shortens the other.
+ * The structural scan (findLobbyPrimaryCta) still runs on its cadence, but it is
+ * DIAGNOSTIC-ONLY (owner ruling on #856/#917): it NEVER returns a handle and the
+ * join flow never clicks its element. Two reasons it was demoted from backstop to
+ * diagnostic: (1) its uniqueness guard protects against ambiguity but not against
+ * a unique-but-WRONG button, and it was only ever proven on fabricated jsdom
+ * fixtures; (2) the real fix for the non-English lobby is #856 — the browser UI
+ * locale is now pinned, so Meet renders English by construction and the exact
+ * selectors above resolve it deterministically.
+ *
+ * What the scan is kept for: (a) its candidate labels feed the failure diagnostic
+ * (so a total miss still records every visible text button), and (b) when it WOULD
+ * have uniquely resolved a lobby that the selector list could not, it logs a
+ * telemetry line — that is the only evidence a future re-promotion could stand on
+ * (does a real non-English lobby exist where the scan uniquely wins?). It does not
+ * shorten or lengthen the selector budget.
  */
 export async function waitForLobbyCta(
   page: Page,
@@ -259,9 +273,14 @@ export async function waitForLobbyCta(
     if (Date.now() - started >= graceMs && polls % CTA_SCAN_EVERY_POLLS === 0) {
       const scan = await scanLobbyPrimaryCta(page);
       lastLabels = scan.labels;
+      // Diagnostic-only: the scan is NOT allowed to resolve the CTA. If it would
+      // have uniquely picked a button the selector list has not matched this poll,
+      // record that as telemetry — prod evidence for whether a real non-English
+      // lobby exists where re-promoting the scan would help. We do NOT click it,
+      // and we dispose the handle so nothing downstream can.
       if (scan.handle) {
-        log(`Located ${label} via ${STRUCTURAL_CTA_ORIGIN} (label: "${scan.labels[0]}")`);
-        return { handle: scan.handle, selector: STRUCTURAL_CTA_ORIGIN };
+        log(`structural scan candidate (diagnostic-only): "${scan.labels[0]}"`);
+        try { await scan.handle.dispose(); } catch { /* best-effort */ }
       }
     }
     polls++;
@@ -271,13 +290,34 @@ export async function waitForLobbyCta(
   throw new Error(await describeSelectorMiss(page, selectors, timeoutMs, label, lastLabels));
 }
 
+/**
+ * Append `?hl=<lang>` to the Meet URL so the lobby renders in the pinned UI
+ * language (#856). This is the lever that matters specifically on the
+ * BOT_AUTHENTICATED path: a signed-in Google account's own language preference
+ * otherwise wins over the browser's --lang/context locale. `hl` takes the bare
+ * language subtag (en-US → en). An existing `hl` on the caller's URL is
+ * preserved (never overridden). A malformed URL is returned unchanged.
+ */
+export function withPinnedMeetLocale(meetingUrl: string, locale: string): string {
+  const hl = (locale.split("-")[0] || locale).trim();
+  if (!hl) return meetingUrl;
+  try {
+    const u = new URL(meetingUrl);
+    if (!u.searchParams.has("hl")) u.searchParams.set("hl", hl);
+    return u.toString();
+  } catch {
+    return meetingUrl;
+  }
+}
+
 export async function joinGoogleMeeting(
   page: Page,
   meetingUrl: string,
   botName: string,
   botConfig: BotConfig
 ): Promise<void> {
-  await page.goto(meetingUrl, { waitUntil: "domcontentloaded" });
+  const navUrl = withPinnedMeetLocale(meetingUrl, resolveBotUiLocale());
+  await page.goto(navUrl, { waitUntil: "domcontentloaded" });
   await page.bringToFront();
 
   // Take screenshot after navigation
@@ -291,6 +331,11 @@ export async function joinGoogleMeeting(
 
   // Brief wait for page elements to settle (networkidle already ensures page loaded)
   await page.waitForTimeout(1000);
+
+  // Record the resolved UI locale on the SUCCESS path too (#856): the locale used
+  // to be invisible until a failure. observedPageContext reads navigator.language
+  // and <html lang> — with the pin in place these should read en-US / en.
+  log(`Lobby locale (#856): ${await observedPageContext(page)}`);
 
   // --- Humanized input layer (defeats Google Meet input-authenticity detection) ---
   const uiMode = resolveUiInteractionMode(botConfig);
@@ -373,10 +418,10 @@ export async function joinGoogleMeeting(
     // Authenticated lobby: one primary CTA — "Join now" (standard join),
     // "Switch here" (same account already in the call) or "Ask to join"
     // (host approval required) — or any localized equivalent. The CTA is
-    // located structurally (googleAuthJoinCtaSelectors, locale-agnostic first,
-    // then findLobbyPrimaryCta), so the branch works on non-English lobbies;
-    // waitForLobbyCta fails LOUD (screenshot + selector list + observed locale)
-    // if no CTA appears.
+    // located by the ordered selector list (googleAuthJoinCtaSelectors, exact
+    // text first now the UI locale is pinned — #856). The structural scan runs
+    // diagnostic-only and never clicks; waitForLobbyCta fails LOUD (screenshot +
+    // selector list + observed locale) if no CTA appears.
     const { handle: ctaHandle, selector: ctaSelector } = await waitForLobbyCta(
       page,
       googleAuthJoinCtaSelectors,

--- a/core/meetings/modules/join/src/googlemeet/selectors.ts
+++ b/core/meetings/modules/join/src/googlemeet/selectors.ts
@@ -282,21 +282,31 @@ export const googleRemovalIndicators: string[] = [
 // only see a lobby whose CTA carries NO accessible label. `:not([aria-label])`
 // is load-bearing (the lobby's aria-labelled 3-dot menu is otherwise a
 // `button[jsname]` with a span, and the humanized click lands on the menu), but
-// it also blinds this list to a lobby whose CTA IS aria-labelled — which is the
-// shape reported in #846 (prod meetings 24337, 24339: the full list exhausted
-// its 60s budget). Attribute presence cannot express "the button with a real
-// text label", so that case is closed in join.ts by `findLobbyPrimaryCta` — a
-// structural scan that discriminates on non-icon label text and refuses to
-// click unless exactly one candidate exists. Widen there, not here.
+// it also blinds this list to a lobby whose CTA IS aria-labelled. That shape is
+// NOT closed by widening this list; the real fix is #856 — the browser's UI
+// locale is now pinned (`--lang=en-US`, context `locale`), so Meet renders the
+// English lobby by construction and the exact-text entries below are correct,
+// not lucky. `findLobbyPrimaryCta` in join.ts still scans, but only as a
+// diagnostic (it never clicks) — see its docs.
+//
+// ORDERING IS AUTHORITATIVE: `waitForAnySelector` resolves this list top-down on
+// every poll (ordered, not raced), so list position decides which control wins.
+// The EXACT text selectors come FIRST and the broad structural
+// `button[jsname]:not([aria-label]):has(span)` entry comes LAST — deliberately
+// inverting #917's ordering. With the locale pinned, the exact English match is
+// the right control; the broad entry can match a wrong jsname+span button that
+// happens to sit earlier in DOM order, so it must only win when nothing exact
+// does. Do NOT move the structural entry up, and do NOT delete it (it is the
+// last-resort locale-agnostic backstop).
 export const googleJoinButtonSelectors: string[] = [
-  // Locale-agnostic: a real <button> carrying Google's jsname token, a text span
-  // and no accessible label. Matches "Ask to join"/"Join now"/localized alike.
-  'button[jsname]:not([aria-label]):has(span)',
-  // English fallbacks (kept for resilience on English UIs).
+  // Exact text FIRST — correct by construction now the UI locale is pinned (#856).
   '//button[.//span[text()="Ask to join"]]',
   'button:has-text("Ask to join")',
   'button:has-text("Join now")',
-  'button:has-text("Join")'
+  'button:has-text("Join")',
+  // Broad structural backstop LAST: a real <button> with Google's jsname token, a
+  // text span and no accessible label. Only wins if no exact selector matches.
+  'button[jsname]:not([aria-label]):has(span)'
 ];
 
 // Icon-glyph descendants of a lobby <button>. A button containing any of these
@@ -350,17 +360,20 @@ export const googleNameInputSelectors: string[] = [
   'input[placeholder*="Name"]'
 ];
 
-// Authenticated-lobby primary CTA — "Join now" / "Switch here" / "Ask to join"
-// or any localized equivalent. Same shape and same coverage limit as
-// googleJoinButtonSelectors above: the locale-agnostic entry is first, the
-// English text is a fallback, and an aria-labelled CTA on a non-English lobby
-// is reached by join.ts's `findLobbyPrimaryCta` scan rather than by this list.
+// Authenticated-lobby primary CTA — "Join now" / "Switch here" / "Ask to join".
+// Same ordering rule as googleJoinButtonSelectors above: ordered resolution makes
+// list position authoritative, so the EXACT text selectors come FIRST and the
+// broad structural `button[jsname]:not([aria-label]):has(span)` entry comes LAST.
+// With the UI locale pinned (#856) the English text is correct by construction;
+// the broad entry is only the last-resort backstop and must not beat an exact
+// match. `findLobbyPrimaryCta` scans here too, diagnostic-only (never clicks).
 export const googleAuthJoinCtaSelectors: string[] = [
-  'button[jsname]:not([aria-label]):has(span)',
-  // English fallbacks.
+  // Exact text FIRST.
   'button:has-text("Join now")',
   'button:has-text("Switch here")',
-  'button:has-text("Ask to join")'
+  'button:has-text("Ask to join")',
+  // Broad structural backstop LAST.
+  'button[jsname]:not([aria-label]):has(span)'
 ];
 
 // Signed-out guard probe (authenticated mode): a guest lobby renders a name

--- a/core/meetings/modules/join/src/googlemeet/session.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/session.test.ts
@@ -118,7 +118,14 @@ function check(name: string, ok: boolean, detail = '') {
 
   console.log('\n=== #757 — detection is structural: non-English lobby fixtures ===');
   console.log(`  (structural CTA selectors: ${CTA_STRUCTURAL.length}, structural probe selectors: ${PROBE_STRUCTURAL.length})`);
-  check('the CTA array leads with structural selectors', CTA_STRUCTURAL.length > 0 && !isEnglishLiteral(googleAuthJoinCtaSelectors[0]));
+  // #856 reorder: exact English text leads (correct by construction once the UI
+  // locale is pinned); the structural backstop is retained but LAST. The array
+  // must still CONTAIN a structural selector so signed-out detection never fails
+  // open on a lobby whose CTA the English literals miss.
+  check('the CTA array retains a structural backstop, placed LAST (#856 order)',
+    CTA_STRUCTURAL.length > 0
+    && isEnglishLiteral(googleAuthJoinCtaSelectors[0])
+    && !isEnglishLiteral(googleAuthJoinCtaSelectors[googleAuthJoinCtaSelectors.length - 1]));
   check('the probe array leads with structural selectors', PROBE_STRUCTURAL.length > 0 && !isEnglishLiteral(googleSignedOutLobbyProbeSelectors[0]));
 
   // 3. Signed-out NON-ENGLISH lobby: every English-literal selector misses;

--- a/core/meetings/modules/remote-browser/src/browser.ts
+++ b/core/meetings/modules/remote-browser/src/browser.ts
@@ -17,17 +17,23 @@ export interface LaunchPersistentOptions {
   args: string[];
   /** Headed by default (Xvfb under VNC); pass true only for headless contexts. */
   headless?: boolean;
+  /** Pinned UI locale (#856) — sets navigator.language / Accept-Language on the
+   *  context. Defaults to BOT_UI_LOCALE (env), else en-US. Keeps the page-level
+   *  locale byte-identical to the --lang launch flag the caller passes in args. */
+  locale?: string;
 }
 
 export async function launchPersistentBrowser(
   opts: LaunchPersistentOptions,
 ): Promise<{ context: BrowserContext; page: Page }> {
   const dataDir = opts.dataDir ?? BROWSER_DATA_DIR;
+  const locale = opts.locale ?? ((process.env.BOT_UI_LOCALE || '').trim() || 'en-US');
   const context = await chromium.launchPersistentContext(dataDir, {
     headless: opts.headless ?? false,
     ignoreDefaultArgs: ['--enable-automation'],
     args: opts.args,
     viewport: null,
+    locale,
   });
   const pages = context.pages();
   const page = pages.length > 0 ? pages[0] : await context.newPage();

--- a/docs/changelog.d/856-locale-pin.md
+++ b/docs/changelog.d/856-locale-pin.md
@@ -1,0 +1,10 @@
+- **Pin the bot browser's UI locale so Google Meet renders English by construction (#856).** The
+  bot never told its browser what language to be, so Meet localised from `Accept-Language` or IP
+  geolocation and served non-English lobbies on EU/other egress — the root cause of the
+  join-button-not-found class (#846). The browser now launches with `--lang` / `--accept-lang`, a
+  Playwright context `locale`, and `?hl=` on the Meet URL, all driven by a `BOT_UI_LOCALE` knob
+  (default `en-US`). The resolved locale (`navigator.language`, `<html lang>`) is now logged at
+  lobby time and recorded in `last_error` on failure, so it is never invisible again. The #917
+  structural CTA scan is demoted to diagnostic-only (it records candidate labels and telemetry but
+  never clicks), and the lobby selector lists now put exact-text entries first with the broad
+  structural entry last as a locale-agnostic backstop.


### PR DESCRIPTION
Closes #856. Refs #846, #917.

## Owner ruling this implements

PR #917 (merged) added the structural CTA scan (`findLobbyPrimaryCta`) and ordered selector resolution. Critical review found: (1) the scan's uniqueness guard protects against ambiguity but **not** against a unique-but-wrong button, and it is proven only on fabricated jsdom fixtures; (2) ordered resolution now *guarantees* the broad `button[jsname]:not([aria-label]):has(span)` entry (first in both lists under #917) beats the exact English text on every poll, so a wrong jsname+span button early in DOM order would be deterministically clicked on English lobbies; (3) the real root cause is **#856** — the browser UI locale is an uncontrolled input.

The owner ruled: **demote the scan to diagnostic-only, reorder exact-text selectors first, and implement #856's locale pin as the real fix.** This PR does all three.

## What changed

**A. Reorder (`selectors.ts`)** — `googleJoinButtonSelectors` and `googleAuthJoinCtaSelectors` now put EXACT text selectors FIRST and the broad structural entry LAST (deliberately inverting #917). Ordered resolution makes list position authoritative; with the locale pinned the English text is correct by construction, and the broad entry only wins as a last-resort backstop. The structural entry is retained, not deleted.

**B. Demote the scan (`join.ts`)** — `waitForLobbyCta` still runs `scanLobbyPrimaryCta` on its cadence but NEVER returns/clicks its element. It is used only to (a) record candidate labels for the failure diagnostic and (b) log `structural scan candidate (diagnostic-only): "<label>"` when it would have uniquely resolved a lobby the selectors could not — the prod telemetry a future re-promotion would need. `findLobbyPrimaryCta` stays exported. `STRUCTURAL_CTA_ORIGIN` + function docs updated to diagnostic-only.

**C. #856 locale pin (the root fix)** behind a `BOT_UI_LOCALE` knob (default `en-US`):
1. `--lang=<locale>` and `--accept-lang=<locale>,<lang>` in `browser-args.ts` (`getLocaleBrowserArgs`, folded into `getJoinBrowserArgs` so prod and the debug harness stay byte-identical).
2. **Playwright context `locale`** — added in `core/meetings/modules/remote-browser/src/browser.ts` (`launchPersistentBrowser`, the one true `chromium.launchPersistentContext` call; both the bot and VNC-login paths flow through it). Defaults to `BOT_UI_LOCALE` env, else `en-US`.
3. `?hl=<lang>` on the constructed Meet URL (`withPinnedMeetLocale` in `join.ts`) — the lever that matters on the `BOT_AUTHENTICATED` path, where the signed-in account's language pref otherwise wins. An explicit caller `hl=` is preserved.
4. **Observability** — the resolved locale (`navigator.language`, `<html lang>`) is now logged at lobby time on the SUCCESS path (`observedPageContext`), in addition to the existing failure/`last_error` capture.

**D. Tests** — `join-cta.test.ts`: the rows that asserted the scan returns/clicks now assert it is diagnostic-only (a unique scan hit on a selector-miss is NOT returned; `waitForLobbyCta` runs the budget out and throws, recording the scan's labels); the ordering row is flipped to the new exact-first order; the pure `findLobbyPrimaryCta` unit rows and all over-match guards are kept. New `__tests__/localePin.test.ts` pins `--lang`/`--accept-lang`, the `BOT_UI_LOCALE` knob (incl. `hu-HU` negative control), and `?hl=`. `session.test.ts` + `humanized.test.ts` ordering assertions updated to the #856 order.

## Observation bundle

| # | Acceptance (issue #856) | Evidence |
|---|---|---|
| A1 | pinned en-US → English lobby, join succeeds | **offline**: `localePin.test.ts` §1 (`--lang=en-US`, `--accept-lang=en-US,en`, `?hl=en`); live English witness still OWED (see below) |
| A2 | negative control: `BOT_UI_LOCALE=hu-HU` → Hungarian | `localePin.test.ts` §2 — the knob drives `--lang=hu-HU` / `--accept-lang=hu-HU,hu` / `?hl=hu`; proves the pin is not a no-op |
| A3 | log + `last_error` record `navigator.language` + `<html lang>` | success-path `Lobby locale (#856): …` log added; `join-cta.test.ts` §6 asserts `html.lang`/`navigator.language` in the miss error |
| A4 | normal English join unchanged | join suite green; ordered resolution resolves the exact English selector first |
| A5 | non-English STT unaffected by UI pin | **NOT verified here** — UI locale and STT `language`/`task` are separate axes (`invocation.v1`); no code couples them, but I did not run a live non-English meeting |

Suites: `@vexa/join` all suites green (incl. `join-cta` 30/30, `selector-validity`, `humanized`, `session`), `@vexa/bot` green, `@vexa/remote-browser` green. `MOCK_BOT=1 BROWSER_IMAGE=mock-bot:dev node scripts/gates.mjs all` — **✅ gates green**.

## Still owed — a live witness

I proved the diff offline (unit + gates). **No bot has been run into a live Google Meet lobby** — not English, not non-English. A1 (English join, no regression from the reorder + locale pin) and A2 (the Hungarian negative control, the discriminating row) both need the live loop. Flagging per the two-loops rule; I am not claiming live behavior.

Ignore the spurious `merge-card` check.
