### PR TITLE
fix(bot): non-admitted bot death carries its reason instead of reason:None (#926)

### DIFF
--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -57,7 +57,7 @@ function consoleLifecycleSink(): LifecycleSink {
  *  the orchestrator drives to a clean terminal `failed`(join_failure) instead of the root crashing. */
 function noBrowserJoinDriver(reason: string): JoinDriver {
   return {
-    async join() { console.error(`[bot] no browser session: ${reason}`); return 'error'; },
+    async join() { console.error(`[bot] no browser session: ${reason}`); return { outcome: 'error', reason: `no browser session: ${reason}` }; },
     onRemoval() { return () => { /* */ }; },
     async leave() { /* */ },
     async withdraw() { /* no browser — nothing to withdraw */ },

--- a/core/meetings/services/bot/src/join-driver.ts
+++ b/core/meetings/services/bot/src/join-driver.ts
@@ -15,7 +15,7 @@ import {
 } from '@vexa/join';
 import type { BotStatus } from './contracts.js';
 import type { Invocation } from './config.js';
-import type { JoinDriver, JoinOutcome } from './ports.js';
+import type { JoinDriver, JoinOutcome, JoinResult } from './ports.js';
 
 /**
  * Map @vexa/join's typed AdmissionError `outcome` → a JoinOutcome (G1).
@@ -59,7 +59,7 @@ function joinPlatform(p: string): JoinPlatform {
 export function createBrowserJoinDriver(page: Page, inv: Invocation): JoinDriver {
   const platform = joinPlatform(inv.platform);
   return {
-    async join(report): Promise<JoinOutcome> {
+    async join(report): Promise<JoinResult> {
       let r;
       try {
         r = await joinMeeting(page, {
@@ -73,14 +73,18 @@ export function createBrowserJoinDriver(page: Page, inv: Invocation): JoinDriver
         });
       } catch (e) {
         // A TYPED admission verdict (denial/lobby_timeout/join_failure) → map its outcome so the
-        // control plane records the truth, not a generic retried `join_failure` (G1). A genuinely
-        // unexpected throw (browser crash, navigation error) is NOT an AdmissionError → re-raise so
-        // the orchestrator classifies it as a transient join_failure.
-        if (e instanceof AdmissionError) return admissionOutcomeToJoinOutcome(e.outcome);
+        // control plane records the truth, not a generic retried `join_failure` (G1). CARRY the
+        // AdmissionError's own message as the reason text (#926) — that's the real Zoom cause
+        // ("auth_required: …", "host did not start …") the terminal lifecycle row would otherwise
+        // lose, leaving meeting-api to synthesize "reason: None". A genuinely unexpected throw
+        // (browser crash, navigation error) is NOT an AdmissionError → re-raise so the orchestrator
+        // classifies it as a transient join_failure (and stamps `reason: String(e)` itself).
+        if (e instanceof AdmissionError) return { outcome: admissionOutcomeToJoinOutcome(e.outcome), reason: e.message };
         throw e;
       }
-      if (r.admitted) { await report('active'); return 'admitted'; }
-      return (r.state === 'blocked' || r.state === 'needs_human_help') ? 'blocked' : 'rejected';
+      if (r.admitted) { await report('active'); return { outcome: 'admitted' }; }
+      const outcome: JoinOutcome = (r.state === 'blocked' || r.state === 'needs_human_help') ? 'blocked' : 'rejected';
+      return { outcome, reason: `join ended in state '${r.state}' without admission` };
     },
     onRemoval(cb) {
       if (platform === 'teams') return startTeamsRemovalMonitor(page, cb);

--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -142,6 +142,31 @@ async function main(): Promise<void> {
     check('timeout: completion_reason=awaiting_admission_timeout', last(lc.events).completion_reason === 'awaiting_admission_timeout');
   }
 
+  // ── #926: a non-admitted terminal ALWAYS carries a human `reason` text ──
+  // Prod signature: a Zoom bot exited code 1 with reason:None because the non-admitted branch
+  // emitted completion_reason but no `reason`, so meeting-api synthesized "Bot exited with code 1;
+  // reason: None". RED before the fix (reason was undefined); GREEN after.
+  {
+    // (a) driver carries its own cause (the AdmissionError message path) → it survives to the row.
+    const lc = recordingSink();
+    const carryingJoin: JoinDriver = {
+      async join(report) { await report('awaiting_admission'); return { outcome: 'auth_missing', reason: 'auth_required: meeting host restricted entry to authenticated Zoom users' }; },
+      onRemoval() { return () => { /* */ }; }, async leave() { /* */ }, async withdraw() { /* */ },
+    };
+    const res = await createOrchestrator(inv({ platform: 'zoom' }), { lifecycle: lc, join: carryingJoin, pipeline: noopPipeline(), acts: noopActs(), aloneness: noopAloneness() }).run();
+    const t = last(lc.events);
+    check('reasonless#926: exit 1', res.exitCode === 1);
+    check('reasonless#926: completion_reason=auth_session_missing', t.completion_reason === 'auth_session_missing');
+    check('reasonless#926: reason text is NON-NULL (carried from driver)', typeof t.reason === 'string' && t.reason.includes('auth_required'));
+    check('reasonless#926: events conform', allConform(lc.events));
+
+    // (b) bare enum (no driver message) → orchestrator STILL stamps a derived reason (never null).
+    const lc2 = recordingSink();
+    await createOrchestrator(inv(), { lifecycle: lc2, join: mockJoin('rejected'), pipeline: noopPipeline(), acts: noopActs(), aloneness: noopAloneness() }).run();
+    const t2 = last(lc2.events);
+    check('reasonless#926: bare enum still gets a non-null reason', typeof t2.reason === 'string' && t2.reason.length > 0);
+  }
+
   // ── pipeline.start throws → failed(active/...) ──
   {
     const lc = recordingSink();

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -26,6 +26,7 @@ import {
 import type {
   JoinDriver,
   JoinOutcome,
+  JoinResult,
   Pipeline,
   LifecycleSink,
   ActsSource,
@@ -74,6 +75,13 @@ export interface MeetingResult {
   exitCode: number;
   status: BotStatus;
   completionReason?: CompletionReason;
+}
+
+/** Normalize a driver's join return — a bare `JoinOutcome` or a `JoinResult` — into `{ outcome,
+ *  reason? }` so the orchestrator has ONE shape to reason about (and the reason text, when the
+ *  driver supplied one, survives to the terminal lifecycle row). */
+function normalizeJoin(r: JoinOutcome | JoinResult): JoinResult {
+  return typeof r === 'string' ? { outcome: r } : r;
 }
 
 /** Map a non-admitted join verdict to the terminal completion_reason. */
@@ -217,13 +225,14 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
     // join. `unsubscribe()` is called on every exit path (pre-active + active) below.
     const unsubscribe = deps.acts.subscribe(handle);
     let outcome: JoinOutcome;
+    let joinReason: string | undefined;
     try {
       // Race the (possibly long, lobby-blocked) join against a pre-active abort. A stop/SIGTERM in the
       // waiting room resolves `aborted` → we stop waiting, WITHDRAW the join request, and terminate —
       // rather than SIGKILLing a bot that is still asking to join (the waiting-room orphan). The race
       // yields a tagged result so the abort branch narrows cleanly (no symbol-vs-JoinOutcome union).
-      const raced = await Promise.race<{ aborted: false; outcome: JoinOutcome } | { aborted: true }>([
-        deps.join.join(report).then((o) => ({ aborted: false as const, outcome: o })),
+      const raced = await Promise.race<{ aborted: false; result: JoinResult } | { aborted: true }>([
+        deps.join.join(report).then((o) => ({ aborted: false as const, result: normalizeJoin(o) })),
         aborted.then(() => ({ aborted: true as const })),
       ]);
       if (raced.aborted) {
@@ -243,7 +252,8 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
         unsubscribe();
         return { exitCode: 0, status: 'failed', completionReason: 'stopped' };
       }
-      outcome = raced.outcome;
+      outcome = raced.result.outcome;
+      joinReason = raced.result.reason;
       await reportChain;   // flush in-flight reports before deciding admission
     } catch (e) {
       unsubscribe();
@@ -253,7 +263,13 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
     if (outcome !== 'admitted') {
       const reason = OUTCOME_FAIL[outcome];
       unsubscribe();
-      await emit('failed', { failure_stage: 'awaiting_admission', completion_reason: reason, exit_code: 1 });
+      // ALWAYS stamp a human `reason` text (#926). A non-admitted verdict carries a completion_reason
+      // enum, but the terminal row also needs the human cause or meeting-api synthesizes the
+      // uninformative "Bot exited with code 1; reason: None". Prefer the driver's own message
+      // (the AdmissionError text — e.g. the Zoom "auth_required" / "host not started" cause); fall
+      // back to a derived line so NO reasonless terminal can ever leave this branch.
+      const reasonText = joinReason ?? `join ended without admission: ${outcome} → ${reason}`;
+      await emit('failed', { failure_stage: 'awaiting_admission', completion_reason: reason, reason: reasonText, exit_code: 1 });
       return { exitCode: 1, status: 'failed', completionReason: reason };
     }
     if (cur !== 'active') await emit('active');   // the join driver may already have reported active

--- a/core/meetings/services/bot/src/ports.ts
+++ b/core/meetings/services/bot/src/ports.ts
@@ -19,12 +19,25 @@ import type { BotStatus, LifecycleEvent, Act, TranscriptSegment } from './contra
  *  platform's many failure modes translated into the bot's vocabulary). */
 export type JoinOutcome = 'admitted' | 'rejected' | 'timeout' | 'blocked' | 'auth_missing' | 'error';
 
+/** A join verdict that CARRIES its human reason text. A non-admitted platform failure is born with
+ *  a message (the @vexa/join AdmissionError text: "auth_required: …", "host did not start …") — but
+ *  the bare `JoinOutcome` enum throws that message away, so the orchestrator's terminal `failed`
+ *  used to arrive with `completion_reason` set and `reason` NULL, and meeting-api synthesized the
+ *  uninformative "Bot exited with code N; reason: None" (#926). A driver MAY return this instead of
+ *  a bare outcome to pass the real cause all the way to the lifecycle row. */
+export interface JoinResult {
+  outcome: JoinOutcome;
+  /** The human cause text (e.g. the AdmissionError message). Rides onto lifecycle.v1 `reason`. */
+  reason?: string;
+}
+
 /** Drives the platform join. The real adapter wraps @vexa/join.joinMeeting + admission
  *  watchers + the removal monitor over a @vexa/remote-browser page. */
 export interface JoinDriver {
   /** Join + await admission. `report` fires on each intermediate lifecycle state
-   *  (awaiting_admission / needs_help / active). Resolves with the verdict. */
-  join(report: (s: BotStatus) => void | Promise<void>): Promise<JoinOutcome>;
+   *  (awaiting_admission / needs_help / active). Resolves with the verdict — a bare `JoinOutcome`
+   *  or a `JoinResult` that also carries the failure's human reason text (#926). */
+  join(report: (s: BotStatus) => void | Promise<void>): Promise<JoinOutcome | JoinResult>;
   /** Watch for being removed from the meeting while active; returns a stop fn. */
   onRemoval(cb: () => void): () => void;
   /** Leave the meeting (best-effort; never throws fatally). */

--- a/docs/changelog.d/926-zoom-reasonless-exit.md
+++ b/docs/changelog.d/926-zoom-reasonless-exit.md
@@ -1,0 +1,9 @@
+- **A non-admitted bot death now carries its cause instead of `reason: None` (#926).** When the join
+  ended without admission — a Zoom `auth_required` / `host-not-started` wall, a denial, a lobby
+  timeout, or a browser that never launched — the bot emitted a terminal `failed` with the
+  `completion_reason` enum but **no human `reason` text**, so meeting-api synthesized the
+  uninformative `Bot exited with code 1; reason: None` (two Zoom users hit this back-to-back in prod).
+  The typed `AdmissionError` message is now carried through the join driver (`JoinResult.reason`) and
+  the orchestrator ALWAYS stamps a `reason` on the non-admitted terminal — falling back to a derived
+  line so no reasonless terminal can leave that branch. The fix is platform-agnostic: any bot death
+  through the non-admitted path now reaches the row with its cause attached.


### PR DESCRIPTION
Closes #926

## Diagnosis — where the reason is lost

`reason: None` in prod is not a lost stderr; it is a terminal `failed` that reached meeting-api **carrying `exit_code:1` but no `reason` text**. meeting-api then synthesizes the string verbatim at [`lifecycle/machine.py:432-435`](../blob/rc/0.12.18/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py#L432):

```python
if rec.error_details is None and (rec.exit_code is not None or rec.reason):
    rec.error_details = f"Bot exited with code {rec.exit_code}; reason: {rec.reason}"
```

So the callback WAS delivered — it just had `reason == None`. Tracing back, every terminal `failed` in the orchestrator stamps a `reason` text (join-catch `orchestrator.ts:250`, pipeline-fail `:270`, abort `:239`, control-plane `:187`) **except one**: the non-admitted branch.

**Point of introduction — two seams:**

1. `join-driver.ts:79` — a typed `AdmissionError` (the real Zoom cause: `auth_required`, `host-not-started`, denial) was mapped to a bare `JoinOutcome` enum, **discarding `e.message`**.
2. `orchestrator.ts:253-257` — the non-admitted branch emitted `completion_reason` but **no `reason` and no `error_details`**:
   ```ts
   await emit('failed', { failure_stage: 'awaiting_admission', completion_reason: reason, exit_code: 1 });
   ```

The Zoom ~12s signature fits exactly: browser launches, `joinZoomMeeting` throws an `AdmissionError` early (pre-join `auth_required` at `zoom/join.ts:144`, or a denial), join-driver maps it to `auth_missing`/`error`, orchestrator emits the reasonless `failed` → `reason: None`.

## The fix (generalizes past Zoom)

- `ports.ts` — widen `JoinDriver.join` to return `JoinOutcome | JoinResult` (`{ outcome, reason? }`), back-compatible with bare enums.
- `join-driver.ts` — carry the `AdmissionError.message` as `JoinResult.reason`; the returned blocked/rejected path gets a reason too.
- `orchestrator.ts` — normalize the join return and **ALWAYS stamp a `reason`** on the non-admitted terminal (driver message preferred, derived line as fallback). No reasonless terminal can leave that branch.
- `index.ts` — `noBrowserJoinDriver` carries its launch-failure reason too.

## Observation bundle

- **Red→green** (`orchestrator.test.ts`, new #926 block): with the reason stamp reverted, `reason text is NON-NULL (carried from driver)` and `bare enum still gets a non-null reason` FAIL (❌); with the fix both pass, terminal still conforms to lifecycle.v1.
- **Bot suite** (22 files incl. `mock/mock.test.ts` full lifecycle) — 0 failures.
- **Join module suite** — 0 failures.
- **Build** `pnpm -r build` — green.

## Not checked / caveat

- **No live Zoom repro** — a real Zoom meeting was unavailable; the Zoom-side cause is a ranked candidate (auth-required wall / denial), confirmed against the code path, not a live join.
- **`gate:compose` (mock full-lifecycle) did not run to green on this machine** — 4 attempts each failed in the compose **docker fixture bring-up** (`conftest.py:114`) with a *different* daemon error each time (gateway SIGTERM 143, `port 18090 already allocated`, `No such container`). The failures are environmental (local Docker daemon), before any bot-behavior assertion, and cannot be caused by this TS-only bot/join change. Please confirm `gate:compose` on CI's clean Docker.
