### PR TITLE
dashboard: show one Vexa release in the version badge

### DIFF
--- a/services/dashboard/Dockerfile
+++ b/services/dashboard/Dockerfile
@@ -1,19 +1,19 @@
 # Build stage
 FROM node:20-alpine AS builder
 
-WORKDIR /app
+WORKDIR /workspace/services/dashboard
 
 # Copy transcript-rendering built package
-COPY packages/transcript-rendering/package.json /transcript-rendering/package.json
-COPY packages/transcript-rendering/dist/ /transcript-rendering/dist/
+COPY packages/transcript-rendering/package.json /workspace/packages/transcript-rendering/package.json
+COPY packages/transcript-rendering/dist/ /workspace/packages/transcript-rendering/dist/
 
-# Install dependencies (package.json only — no lockfile, to avoid path mismatch after sed)
-COPY services/dashboard/package.json ./
-RUN sed -i 's|"@vexaai/transcript-rendering": "file:../../packages/transcript-rendering"|"@vexaai/transcript-rendering": "file:/transcript-rendering"|' package.json && \
-    npm install --ignore-scripts
+# Install the exact dependency graph committed with the dashboard. The package
+# is copied to the same relative location expected by the manifests.
+COPY services/dashboard/package.json services/dashboard/package-lock.json ./
+RUN npm ci --ignore-scripts
 # Ensure transcript-rendering is physically copied (not symlinked)
 RUN rm -rf node_modules/@vexaai/transcript-rendering && \
-    cp -r /transcript-rendering node_modules/@vexaai/transcript-rendering
+    cp -r /workspace/packages/transcript-rendering node_modules/@vexaai/transcript-rendering
 
 # Copy source code
 COPY services/dashboard/src ./src
@@ -51,9 +51,9 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder /workspace/services/dashboard/public ./public
+COPY --from=builder --chown=nextjs:nodejs /workspace/services/dashboard/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /workspace/services/dashboard/.next/static ./.next/static
 COPY --chown=nextjs:nodejs services/dashboard/docker-entrypoint.sh ./docker-entrypoint.sh
 
 USER nextjs

--- a/services/dashboard/src/components/version-chip.tsx
+++ b/services/dashboard/src/components/version-chip.tsx
@@ -1,14 +1,10 @@
 /**
- * <VersionChip /> — small, discoverable label disclosing what version this
- * dashboard fronts. Two identities, both truthful:
- *   - the PLATFORM release it pairs with (runtime-configured via
- *     PLATFORM_VERSION → /api/config → `platformVersion` prop); and
- *   - its own UI build (build-time truth from release-version.generated.json).
+ * <VersionChip /> — small, discoverable label for the Vexa product version
+ * this dashboard fronts. Hosted deployments provide that identity at runtime
+ * through PLATFORM_VERSION → /api/config → `platformVersion`.
  *
- * When `platformVersion` is provided (hosted deploys where the UI build fronts
- * a newer platform), the chip shows "v0.12.16 · UI 0.10.6.3" — platform
- * prominent, UI build as provenance. When it is absent (OSS self-host where
- * UI == release), the chip falls back to the UI build alone, unchanged.
+ * When `platformVersion` is absent, the chip falls back to the build-time
+ * release identity used by OSS self-hosted deployments.
  *
  * Mirror of services/webapp's component, intentionally kept simple so it
  * can stay in sync without sharing a package.
@@ -32,7 +28,7 @@ export function VersionChip({
   /** Runtime platform release this build fronts. null → UI-build-only. */
   platformVersion?: string | null;
 }) {
-  const url = releaseUrl(RELEASE.version);
+  const url = releaseUrl(platformVersion || RELEASE.version);
   const { label, title } = versionChipText({
     uiVersion: RELEASE.version,
     releaseDate: RELEASE.releaseDate,

--- a/services/dashboard/src/lib/version-chip-label.ts
+++ b/services/dashboard/src/lib/version-chip-label.ts
@@ -1,13 +1,12 @@
 /**
  * Pure label/title builder for <VersionChip /> — kept free of React and of the
- * build-time release-version.generated.json import so its two-identity honesty
- * (hosted #72) is unit testable without a DOM or a generated file.
+ * build-time release-version.generated.json import so the hosted product
+ * release identity is unit testable without a DOM or a generated file.
  *
  * When `platformVersion` is provided (hosted deploys where a UI build fronts a
- * newer platform release), the chip shows the platform version PROMINENT with
- * the UI build as provenance ("v0.12.16 · UI 0.10.6.3"). When it is absent
- * (OSS self-host where UI == release), it falls back to the UI build alone,
- * unchanged from prior behavior.
+ * platform release), the chip presents that product version alone. When it is
+ * absent (OSS self-host where UI == release), it falls back to the build-time
+ * release identity.
  */
 
 export type Variant = "full" | "compact" | "minimal";
@@ -31,17 +30,14 @@ export function versionChipText({
 
   let label: string;
   if (platform) {
-    // Platform release prominent; UI build carried as provenance.
     switch (variant) {
       case "full":
-        label = `Running ${platform} · UI ${uiVersion} · updated ${releaseDate}`;
+        label = `Running ${platform}`;
         break;
       case "compact":
-        label = `${platform} · UI ${uiVersion} · ${releaseDate}`;
-        break;
       case "minimal":
       default:
-        label = `${platform} · UI ${uiVersion}`;
+        label = platform;
     }
   } else {
     switch (variant) {
@@ -58,7 +54,7 @@ export function versionChipText({
   }
 
   const title = platform
-    ? `Vexa platform ${platform} · dashboard UI build ${uiVersion} (released ${releaseDate}) · click for UI release notes`
+    ? `Vexa ${platform} · click for release notes`
     : `Vexa ${uiVersion} · released ${releaseDate} · click for release notes`;
 
   return { label, title };

--- a/services/dashboard/tests/test_version_chip_text.test.ts
+++ b/services/dashboard/tests/test_version_chip_text.test.ts
@@ -1,10 +1,8 @@
 /**
- * Unit tests for the version chip's two-identity label builder (hosted #72).
+ * Unit tests for the version chip's product release label builder.
  *
- * The chip must be HONEST: when a platform release is configured at runtime it
- * shows the platform version PROMINENT with the UI build as provenance; when it
- * is absent (OSS self-host where UI == release) it falls back to the UI build
- * alone, unchanged from prior behavior.
+ * A hosted deployment presents one product version. Without runtime platform
+ * configuration, OSS self-hosted deployments use the build-time identity.
  */
 import { describe, it, expect } from "vitest";
 import { versionChipText, withVPrefix } from "@/lib/version-chip-label";
@@ -13,15 +11,14 @@ const UI = "0.10.6.3";
 const DATE = "2025-01-01";
 
 describe("versionChipText — platform configured", () => {
-  it("minimal shows platform prominent, UI as provenance", () => {
+  it("minimal shows only the platform release", () => {
     const { label } = versionChipText({
       uiVersion: UI,
       releaseDate: DATE,
       platformVersion: "v0.12.16-rc.4",
     });
-    expect(label).toBe("v0.12.16-rc.4 · UI 0.10.6.3");
-    expect(label).toContain("v0.12.16");
-    expect(label).toContain("0.10.6.3");
+    expect(label).toBe("v0.12.16-rc.4");
+    expect(label).not.toContain(UI);
   });
 
   it("adds a v-prefix when the platform version lacks one", () => {
@@ -30,22 +27,22 @@ describe("versionChipText — platform configured", () => {
       releaseDate: DATE,
       platformVersion: "0.12.16",
     });
-    expect(label).toBe("v0.12.16 · UI 0.10.6.3");
+    expect(label).toBe("v0.12.16");
   });
 
-  it("full and compact variants keep both identities", () => {
+  it("full and compact variants keep one product identity", () => {
     expect(
       versionChipText({ uiVersion: UI, releaseDate: DATE, platformVersion: "v0.12.16", variant: "full" }).label
-    ).toBe("Running v0.12.16 · UI 0.10.6.3 · updated 2025-01-01");
+    ).toBe("Running v0.12.16");
     expect(
       versionChipText({ uiVersion: UI, releaseDate: DATE, platformVersion: "v0.12.16", variant: "compact" }).label
-    ).toBe("v0.12.16 · UI 0.10.6.3 · 2025-01-01");
+    ).toBe("v0.12.16");
   });
 
-  it("title names both platform and UI build", () => {
+  it("title points to the platform release without exposing the UI build", () => {
     const { title } = versionChipText({ uiVersion: UI, releaseDate: DATE, platformVersion: "v0.12.16" });
-    expect(title).toContain("platform v0.12.16");
-    expect(title).toContain("UI build 0.10.6.3");
+    expect(title).toBe("Vexa v0.12.16 · click for release notes");
+    expect(title).not.toContain(UI);
   });
 });
 


### PR DESCRIPTION
## Outcome

Hosted dashboard badges present the deployed Vexa product release only (`v0.12.18`). The dashboard build number remains image/deployment provenance and is no longer exposed as a second product identity. The badge now links to the platform release tag.

The image build also consumes the committed `package-lock.json`; the unlocked install failed to reproduce the dashboard build while preparing this rollout.

## Evidence

- Dashboard tests: 53/53 passed
- ESLint: changed files clean
- Next.js production build: passed
- Docker `linux/amd64` build + release-version assertion: passed
- Image: `vexaai/dashboard:0.10.6.3.15-260723-platformonly`
- Digest: `sha256:b84337d7e4a351b0539010767e9473ca35295e8845c0170725b0c1276da9e7e9`
- Stage Helm revision 65: all 10 deployments ready; dashboard 1/1, zero restarts
- Stage `/api/config`: `platformVersion=0.12.18`
- Compiled image contains neither `UI 0.10.6.3` nor `click for UI release notes`

## Not checked

An authenticated post-rollout screenshot still needs a signed-in browser session; the unauthenticated stage front door redirects to the hosted sign-in flow.