### PR TITLE
fix(dashboard): render Jitsi meeting transcripts

### DIFF
--- a/.github/workflows/test-dashboard.yml
+++ b/.github/workflows/test-dashboard.yml
@@ -1,0 +1,40 @@
+name: Test Dashboard
+
+on:
+  push:
+    branches: [main, feature/*, dev]
+    paths:
+      - 'services/dashboard/**'
+      - '.github/workflows/test-dashboard.yml'
+  pull_request:
+    paths:
+      - 'services/dashboard/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/dashboard
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/dashboard/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate release version
+        run: npm run generate-release-version
+      # The platform table is `satisfies Record<Platform, PlatformConfig>`, so a
+      # platform added to the union without a config fails here, not in a browser.
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Run tests
+        run: npm test

--- a/docs/changelog.d/937-jitsi-dashboard-detail.md
+++ b/docs/changelog.d/937-jitsi-dashboard-detail.md
@@ -1,0 +1,3 @@
+- **Hosted dashboard: Jitsi transcripts render instead of collapsing the meeting detail (#937).**
+  The platform boundary now recognizes Jitsi and degrades unknown future platforms honestly, so
+  valid named transcript rows remain visible during and after a meeting.

--- a/services/dashboard/package-lock.json
+++ b/services/dashboard/package-lock.json
@@ -951,10 +951,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3824,6 +3846,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
@@ -4224,6 +4280,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.17",

--- a/services/dashboard/package-lock.json
+++ b/services/dashboard/package-lock.json
@@ -58,6 +58,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/react": "^16.3.2",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "20.19.37",
         "@types/nodemailer": "7.0.4",
@@ -66,6 +67,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.2.6",
+        "jsdom": "^26.1.0",
         "playwright": "^1.58.2",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
@@ -188,9 +190,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@auth/core": {
       "version": "0.34.3",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@panva/hkdf": "^1.1.1",
         "@types/cookie": "0.6.0",
@@ -619,6 +643,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -809,26 +834,121 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "license": "MIT",
-      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -976,6 +1096,7 @@
     "node_modules/@floating-ui/dom": {
       "version": "1.7.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -4150,9 +4271,103 @@
         "tailwindcss": "4.1.17"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tiptap/core": {
       "version": "3.20.4",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4224,6 +4439,7 @@
     "node_modules/@tiptap/extension-code-block": {
       "version": "3.20.4",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4358,6 +4574,7 @@
     "node_modules/@tiptap/extension-list": {
       "version": "3.20.4",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4458,6 +4675,7 @@
     "node_modules/@tiptap/extensions": {
       "version": "3.20.4",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4470,6 +4688,7 @@
     "node_modules/@tiptap/pm": {
       "version": "3.20.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4562,6 +4781,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4674,6 +4900,7 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4681,6 +4908,7 @@
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4736,6 +4964,7 @@
       "version": "8.49.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -5338,6 +5567,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5351,6 +5581,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ai": {
@@ -5384,6 +5624,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -5621,6 +5871,7 @@
       "version": "1.0.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -5699,6 +5950,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5929,6 +6181,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "license": "MIT"
@@ -5937,6 +6203,20 @@
       "version": "1.0.8",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6008,6 +6288,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -6097,6 +6384,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6338,6 +6632,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6509,6 +6804,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7246,8 +7542,22 @@
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/html-url-attributes": {
@@ -7256,6 +7566,47 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -7588,6 +7939,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "dev": true,
@@ -7770,6 +8128,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -8245,6 +8644,7 @@
     "node_modules/lowlight": {
       "version": "3.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -8268,6 +8668,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -9299,9 +9709,17 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
       "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/oauth": {
       "version": "0.9.15",
@@ -9574,6 +9992,32 @@
       "version": "2.0.11",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -9701,6 +10145,7 @@
     "node_modules/preact": {
       "version": "10.11.3",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9836,6 +10281,7 @@
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9859,6 +10305,7 @@
     "node_modules/prosemirror-state": {
       "version": "1.4.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9899,6 +10346,7 @@
     "node_modules/prosemirror-view": {
       "version": "1.41.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -9944,6 +10392,7 @@
     "node_modules/react": {
       "version": "19.2.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9951,6 +10400,7 @@
     "node_modules/react-dom": {
       "version": "19.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10233,6 +10683,13 @@
       "version": "1.3.4",
       "license": "MIT"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10322,6 +10779,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -10788,6 +11265,13 @@
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "license": "MIT",
@@ -10875,6 +11359,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10890,6 +11375,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10901,6 +11406,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -11056,6 +11587,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11340,6 +11872,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11792,6 +12325,67 @@
       "version": "2.2.8",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -11910,6 +12504,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -11925,6 +12551,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -11945,6 +12578,7 @@
     "node_modules/zod": {
       "version": "4.1.13",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/services/dashboard/package.json
+++ b/services/dashboard/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/react": "^16.3.2",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "20.19.37",
     "@types/nodemailer": "7.0.4",
@@ -73,6 +74,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
+    "jsdom": "^26.1.0",
     "playwright": "^1.58.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",

--- a/services/dashboard/src/app/meetings/[id]/page.tsx
+++ b/services/dashboard/src/app/meetings/[id]/page.tsx
@@ -49,12 +49,13 @@ import { ErrorState } from "@/components/ui/error-state";
 import { TranscriptViewer } from "@/components/transcript/transcript-viewer";
 import { BotStatusIndicator, BotFailedIndicator } from "@/components/meetings/bot-status-indicator";
 import { WsEventLog, RestTranscriptsPreview, RestRecordingsPreview } from "@/components/meetings/ws-event-log";
+import { PlatformIcon } from "@/components/meetings/platform-icon";
 // ChatPanel removed — chat messages now render inline in TranscriptViewer
 import { AIChatPanel } from "@/components/ai";
 import { useMeetingsStore } from "@/stores/meetings-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useLiveTranscripts } from "@/hooks/use-live-transcripts";
-import { PLATFORM_CONFIG, getDetailedStatus } from "@/types/vexa";
+import { getPlatformConfig, getDetailedStatus } from "@/types/vexa";
 import type { MeetingStatus, Meeting, RecordingData } from "@/types/vexa";
 import { StatusHistory } from "@/components/meetings/status-history";
 import { cn, parseUTCTimestamp } from "@/lib/utils";
@@ -910,7 +911,7 @@ export default function MeetingDetailPage() {
     return <MeetingDetailSkeleton />;
   }
 
-  const platformConfig = PLATFORM_CONFIG[currentMeeting.platform];
+  const platformConfig = getPlatformConfig(currentMeeting.platform);
   const statusConfig = getDetailedStatus(currentMeeting.status, currentMeeting.data);
 
   // Safety check: ensure statusConfig is always defined
@@ -1986,16 +1987,10 @@ export default function MeetingDetailPage() {
               {/* Platform & Meeting ID */}
               <div className="flex items-center gap-3">
                 <div className="h-8 w-8 rounded-lg flex items-center justify-center overflow-hidden bg-background">
-                  <Image
-                    src={currentMeeting.platform === "google_meet"
-                      ? "/icons/icons8-google-meet-96.png"
-                      : currentMeeting.platform === "teams"
-                      ? "/icons/icons8-teams-96.png"
-                      : "/icons/icons8-zoom-96.png"}
-                    alt={platformConfig.name}
-                    width={32}
-                    height={32}
-                    className="object-contain"
+                  <PlatformIcon
+                    platform={currentMeeting.platform}
+                    size={32}
+                    className="h-8 w-8 object-contain text-muted-foreground"
                   />
                 </div>
                 <div>

--- a/services/dashboard/src/app/meetings/page.tsx
+++ b/services/dashboard/src/app/meetings/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
-import { Plus, RefreshCw, CreditCard, Video, Loader2, Search, Monitor } from "lucide-react";
-import Image from "next/image";
+import { Plus, RefreshCw, CreditCard, Video, Loader2, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { format, formatDistanceToNow } from "date-fns";
 import { Card } from "@/components/ui/card";
@@ -19,6 +18,7 @@ import { useMeetingsStore } from "@/stores/meetings-store";
 import { useJoinModalStore } from "@/stores/join-modal-store";
 import type { Platform, MeetingStatus, Meeting } from "@/types/vexa";
 import { getDetailedStatus } from "@/types/vexa";
+import { PlatformIcon } from "@/components/meetings/platform-icon";
 import { DocsLink } from "@/components/docs/docs-link";
 import { getWebappUrl } from "@/lib/docs/webapp-url";
 import { Input } from "@/components/ui/input";
@@ -26,19 +26,6 @@ import { cn, parseUTCTimestamp } from "@/lib/utils";
 import { usePendingMeeting } from "@/hooks/use-pending-meeting";
 import { toast } from "sonner";
 import { withBasePath } from "@/lib/base-path";
-
-function PlatformIcon({ platform }: { platform: string }) {
-  if (platform === "google_meet") {
-    return <Image src="/icons/icons8-google-meet-96.png" alt="Google Meet" width={20} height={20} className="rounded" />;
-  }
-  if (platform === "teams") {
-    return <Image src="/icons/icons8-teams-96.png" alt="Teams" width={20} height={20} className="rounded" />;
-  }
-  if (platform === "browser_session") {
-    return <Monitor className="h-5 w-5 text-muted-foreground" />;
-  }
-  return <Image src="/icons/icons8-zoom-96.png" alt="Zoom" width={20} height={20} className="rounded" />;
-}
 
 function StatusDot({ status }: { status: string }) {
   return (
@@ -351,7 +338,7 @@ function MeetingRow({ meeting }: { meeting: Meeting }) {
         onClick={() => router.push(`/meetings/${meeting.id}`)}
       >
         <td className="hidden sm:table-cell px-5 py-3">
-          <PlatformIcon platform={meeting.platform} />
+          <PlatformIcon platform={meeting.platform} className="h-5 w-5 rounded text-muted-foreground" />
         </td>
         <td className="px-5 py-3">
           <span className="font-medium">{displayTitle}</span>

--- a/services/dashboard/src/components/join/join-form.tsx
+++ b/services/dashboard/src/components/join/join-form.tsx
@@ -11,7 +11,7 @@ import { vexaAPI } from "@/lib/api";
 import { useLiveStore } from "@/stores/live-store";
 import { useRuntimeConfig } from "@/hooks/use-runtime-config";
 import type { Platform, CreateBotRequest } from "@/types/vexa";
-import { PLATFORM_CONFIG } from "@/types/vexa";
+import { getPlatformConfig } from "@/types/vexa";
 import { LanguagePicker } from "@/components/language-picker";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
@@ -47,7 +47,7 @@ export function JoinForm({ onSuccess }: JoinFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
 
-  const platformConfig = PLATFORM_CONFIG[platform];
+  const platformConfig = getPlatformConfig(platform);
 
   const validateMeetingId = (id: string): boolean => {
     if (!id.trim()) return false;

--- a/services/dashboard/src/components/join/live-session.tsx
+++ b/services/dashboard/src/components/join/live-session.tsx
@@ -12,7 +12,7 @@ import { useVexaWebSocket } from "@/hooks/use-vexa-websocket";
 import { useLiveStore } from "@/stores/live-store";
 import { vexaAPI } from "@/lib/api";
 import type { Platform } from "@/types/vexa";
-import { PLATFORM_CONFIG, MEETING_STATUS_CONFIG, getSpeakerColor } from "@/types/vexa";
+import { getPlatformConfig, MEETING_STATUS_CONFIG, getSpeakerColor } from "@/types/vexa";
 import { cn } from "@/lib/utils";
 import { DocsLink } from "@/components/docs/docs-link";
 
@@ -65,7 +65,7 @@ export function LiveSession({ platform, nativeId, onEnd }: LiveSessionProps) {
     }
   };
 
-  const platformConfig = PLATFORM_CONFIG[platform];
+  const platformConfig = getPlatformConfig(platform);
   const statusConfig = botStatus ? MEETING_STATUS_CONFIG[botStatus] : null;
 
   // Check if meeting is still active

--- a/services/dashboard/src/components/meetings/meeting-card.tsx
+++ b/services/dashboard/src/components/meetings/meeting-card.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { formatDistanceToNow, format } from "date-fns";
 import { Clock, ChevronRight, Calendar, MessageSquare, FileText, Pencil, Check, X } from "lucide-react";
 import { Card } from "@/components/ui/card";
@@ -13,54 +12,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import type { Meeting } from "@/types/vexa";
 import { getDetailedStatus } from "@/types/vexa";
 import { cn, parseUTCTimestamp } from "@/lib/utils";
+import { PlatformIcon } from "@/components/meetings/platform-icon";
 import { useMeetingsStore } from "@/stores/meetings-store";
 import { toast } from "sonner";
 
 interface MeetingCardProps {
   meeting: Meeting;
-}
-
-// Platform icons using actual icon files from public folder
-function GoogleMeetIcon({ className }: { className?: string }) {
-  return (
-    <Image
-      src="/icons/icons8-google-meet-96.png"
-      alt="Google Meet"
-      width={40}
-      height={40}
-      className={className}
-    />
-  );
-}
-
-function TeamsIcon({ className }: { className?: string }) {
-  return (
-    <Image
-      src="/icons/icons8-teams-96.png"
-      alt="Microsoft Teams"
-      width={40}
-      height={40}
-      className={className}
-    />
-  );
-}
-
-function ZoomIcon({ className }: { className?: string }) {
-  return (
-    <Image
-      src="/icons/icons8-zoom-96.png"
-      alt="Zoom"
-      width={40}
-      height={40}
-      className={className}
-    />
-  );
-}
-
-function PlatformIcon({ platform, className }: { platform: string; className?: string }) {
-  if (platform === "google_meet") return <GoogleMeetIcon className={className} />;
-  if (platform === "teams") return <TeamsIcon className={className} />;
-  return <ZoomIcon className={className} />;
 }
 
 export function MeetingCard({ meeting }: MeetingCardProps) {
@@ -252,7 +209,7 @@ export function MeetingCard({ meeting }: MeetingCardProps) {
               "flex-shrink-0 relative",
               "transition-transform duration-300 group-hover:scale-110"
             )}>
-              <PlatformIcon platform={meeting.platform} className="h-10 w-10 rounded-lg" />
+              <PlatformIcon platform={meeting.platform} size={40} className="h-10 w-10 rounded-lg text-muted-foreground" />
               {/* Active indicator */}
               {isActive && (
                 <div className="absolute -top-1 -right-1">

--- a/services/dashboard/src/components/meetings/platform-icon.tsx
+++ b/services/dashboard/src/components/meetings/platform-icon.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import { Monitor, Users, Video } from "lucide-react";
+import { getPlatformConfig } from "@/types/vexa";
+
+const LUCIDE_ICONS = { video: Video, users: Users, monitor: Monitor } as const;
+
+interface PlatformIconProps {
+  platform: string;
+  /** Pixel size of the logo; the lucide fallback is sized by className. */
+  size?: number;
+  className?: string;
+}
+
+/**
+ * The one place a platform becomes a picture. Platforms without a logo asset
+ * render their lucide icon, so a new platform is generic rather than mislabelled.
+ */
+export function PlatformIcon({ platform, size = 20, className }: PlatformIconProps) {
+  const config = getPlatformConfig(platform);
+
+  if (config.iconSrc) {
+    return (
+      <Image
+        src={config.iconSrc}
+        alt={config.name}
+        width={size}
+        height={size}
+        className={className}
+      />
+    );
+  }
+
+  const Icon = LUCIDE_ICONS[config.icon];
+  return <Icon aria-label={config.name} className={className} />;
+}

--- a/services/dashboard/src/lib/export.ts
+++ b/services/dashboard/src/lib/export.ts
@@ -1,4 +1,5 @@
 import type { Meeting, TranscriptSegment } from "@/types/vexa";
+import { getPlatformConfig } from "@/types/vexa";
 import { format } from "date-fns";
 import { parseUTCTimestamp } from "@/lib/utils";
 
@@ -47,7 +48,7 @@ export function exportToTxt(meeting: Meeting, segments: TranscriptSegment[]): st
   output += "=".repeat(60) + "\n\n";
 
   output += `Meeting ID: ${meeting.platform_specific_id}\n`;
-  output += `Platform: ${meeting.platform === "google_meet" ? "Google Meet" : "Microsoft Teams"}\n`;
+  output += `Platform: ${getPlatformConfig(meeting.platform).name}\n`;
 
   if (meeting.start_time) {
     output += `Date: ${format(parseUTCTimestamp(meeting.start_time), "PPPp")}\n`;

--- a/services/dashboard/src/types/vexa.ts
+++ b/services/dashboard/src/types/vexa.ts
@@ -1,6 +1,6 @@
 // Vexa API Types
 
-export type Platform = "google_meet" | "teams" | "zoom" | "browser_session";
+export type Platform = "google_meet" | "teams" | "zoom" | "jitsi" | "browser_session";
 
 export type MeetingStatus =
   | "requested"
@@ -230,12 +230,29 @@ export function getSpeakerColor(speaker: string, speakerList: string[]): Speaker
 }
 
 // Platform display helpers
+export interface PlatformConfig {
+  name: string;
+  color: string;
+  textColor: string;
+  bgColor: string;
+  /** Logo under /public/icons, or null to fall back to the lucide `icon`. */
+  iconSrc: string | null;
+  icon: "video" | "users" | "monitor";
+  pattern: RegExp;
+  placeholder: string;
+}
+
+/**
+ * One entry per Platform — `satisfies` makes that total, so widening the union
+ * without adding a config is a build error rather than a blank page.
+ */
 export const PLATFORM_CONFIG = {
   google_meet: {
     name: "Google Meet",
     color: "bg-green-500",
     textColor: "text-green-700",
     bgColor: "bg-green-50",
+    iconSrc: "/icons/icons8-google-meet-96.png",
     icon: "video",
     pattern: /^[a-z]{3}-[a-z]{4}-[a-z]{3}$/,
     placeholder: "abc-defg-hij",
@@ -245,6 +262,7 @@ export const PLATFORM_CONFIG = {
     color: "bg-blue-600",
     textColor: "text-blue-700",
     bgColor: "bg-blue-50",
+    iconSrc: "/icons/icons8-teams-96.png",
     icon: "users",
     pattern: /^\d+$/,
     placeholder: "123456789",
@@ -254,20 +272,52 @@ export const PLATFORM_CONFIG = {
     color: "bg-blue-500",
     textColor: "text-blue-600",
     bgColor: "bg-blue-50",
+    iconSrc: "/icons/icons8-zoom-96.png",
     icon: "video",
     pattern: /^\d{9,11}$/,
     placeholder: "85173157171",
+  },
+  jitsi: {
+    name: "Jitsi Meet",
+    color: "bg-sky-500",
+    textColor: "text-sky-700",
+    bgColor: "bg-sky-50",
+    iconSrc: null,
+    icon: "video",
+    pattern: /^[A-Za-z0-9][A-Za-z0-9._~-]*$/,
+    placeholder: "vexa-room-name",
   },
   browser_session: {
     name: "Browser",
     color: "bg-gray-500",
     textColor: "text-gray-700",
     bgColor: "bg-gray-50",
+    iconSrc: null,
     icon: "monitor",
     pattern: /^bs-/,
     placeholder: "",
   },
-} as const;
+} satisfies Record<Platform, PlatformConfig>;
+
+/** Shown for a platform the API serves but this build has no entry for. */
+const UNKNOWN_PLATFORM_CONFIG: PlatformConfig = {
+  name: "Meeting",
+  color: "bg-gray-500",
+  textColor: "text-gray-700",
+  bgColor: "bg-gray-50",
+  iconSrc: null,
+  icon: "video",
+  pattern: /.+/,
+  placeholder: "",
+};
+
+/**
+ * Total platform lookup. The API is free to serve a platform this build predates;
+ * callers render it neutrally instead of dereferencing undefined.
+ */
+export function getPlatformConfig(platform: string): PlatformConfig {
+  return (PLATFORM_CONFIG as Record<string, PlatformConfig>)[platform] ?? UNKNOWN_PLATFORM_CONFIG;
+}
 
 export const MEETING_STATUS_CONFIG: Record<MeetingStatus, { label: string; color: string; bgColor: string }> = {
   requested: { label: "Requested", color: "text-blue-600 dark:text-blue-400", bgColor: "bg-blue-100 dark:bg-blue-950/50" },

--- a/services/dashboard/tests/fixtures/meeting-13627.json
+++ b/services/dashboard/tests/fixtures/meeting-13627.json
@@ -1,0 +1,483 @@
+{
+  "id": 13627,
+  "platform": "jitsi",
+  "native_meeting_id": "sanitized-13627-room",
+  "status": "active",
+  "start_time": "2026-07-23T20:00:00Z",
+  "end_time": null,
+  "data": {
+    "name": "Sanitized two-speaker witness",
+    "participants": [
+      "Anna",
+      "Boris"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "segments": [
+    {
+      "start": 0,
+      "end": 1.5,
+      "text": "Sanitized transcript row 1",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:00.000Z",
+      "absolute_end_time": "2026-07-23T20:00:01.500Z",
+      "created_at": "2026-07-23T20:00:00.000Z",
+      "segment_id": "sanitized-session:anna:001"
+    },
+    {
+      "start": 2.25,
+      "end": 3.75,
+      "text": "Sanitized transcript row 2",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:02.250Z",
+      "absolute_end_time": "2026-07-23T20:00:03.750Z",
+      "created_at": "2026-07-23T20:00:02.250Z",
+      "segment_id": "sanitized-session:boris:002"
+    },
+    {
+      "start": 4.5,
+      "end": 6,
+      "text": "Sanitized transcript row 3",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:04.500Z",
+      "absolute_end_time": "2026-07-23T20:00:06.000Z",
+      "created_at": "2026-07-23T20:00:04.500Z",
+      "segment_id": "sanitized-session:anna:003"
+    },
+    {
+      "start": 6.75,
+      "end": 8.25,
+      "text": "Sanitized transcript row 4",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:06.750Z",
+      "absolute_end_time": "2026-07-23T20:00:08.250Z",
+      "created_at": "2026-07-23T20:00:06.750Z",
+      "segment_id": "sanitized-session:boris:004"
+    },
+    {
+      "start": 9,
+      "end": 10.5,
+      "text": "Sanitized transcript row 5",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:09.000Z",
+      "absolute_end_time": "2026-07-23T20:00:10.500Z",
+      "created_at": "2026-07-23T20:00:09.000Z",
+      "segment_id": "sanitized-session:anna:005"
+    },
+    {
+      "start": 11.25,
+      "end": 12.75,
+      "text": "Sanitized transcript row 6",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:11.250Z",
+      "absolute_end_time": "2026-07-23T20:00:12.750Z",
+      "created_at": "2026-07-23T20:00:11.250Z",
+      "segment_id": "sanitized-session:boris:006"
+    },
+    {
+      "start": 13.5,
+      "end": 15,
+      "text": "Sanitized transcript row 7",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:13.500Z",
+      "absolute_end_time": "2026-07-23T20:00:15.000Z",
+      "created_at": "2026-07-23T20:00:13.500Z",
+      "segment_id": "sanitized-session:anna:007"
+    },
+    {
+      "start": 15.75,
+      "end": 17.25,
+      "text": "Sanitized transcript row 8",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:15.750Z",
+      "absolute_end_time": "2026-07-23T20:00:17.250Z",
+      "created_at": "2026-07-23T20:00:15.750Z",
+      "segment_id": "sanitized-session:boris:008"
+    },
+    {
+      "start": 18,
+      "end": 19.5,
+      "text": "Sanitized transcript row 9",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:18.000Z",
+      "absolute_end_time": "2026-07-23T20:00:19.500Z",
+      "created_at": "2026-07-23T20:00:18.000Z",
+      "segment_id": "sanitized-session:anna:009"
+    },
+    {
+      "start": 20.25,
+      "end": 21.75,
+      "text": "Sanitized transcript row 10",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:20.250Z",
+      "absolute_end_time": "2026-07-23T20:00:21.750Z",
+      "created_at": "2026-07-23T20:00:20.250Z",
+      "segment_id": "sanitized-session:boris:010"
+    },
+    {
+      "start": 22.5,
+      "end": 24,
+      "text": "Sanitized transcript row 11",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:22.500Z",
+      "absolute_end_time": "2026-07-23T20:00:24.000Z",
+      "created_at": "2026-07-23T20:00:22.500Z",
+      "segment_id": "sanitized-session:anna:011"
+    },
+    {
+      "start": 24.75,
+      "end": 26.25,
+      "text": "Sanitized transcript row 12",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:24.750Z",
+      "absolute_end_time": "2026-07-23T20:00:26.250Z",
+      "created_at": "2026-07-23T20:00:24.750Z",
+      "segment_id": "sanitized-session:boris:012"
+    },
+    {
+      "start": 27,
+      "end": 28.5,
+      "text": "Sanitized transcript row 13",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:27.000Z",
+      "absolute_end_time": "2026-07-23T20:00:28.500Z",
+      "created_at": "2026-07-23T20:00:27.000Z",
+      "segment_id": "sanitized-session:anna:013"
+    },
+    {
+      "start": 29.25,
+      "end": 30.75,
+      "text": "Sanitized transcript row 14",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:29.250Z",
+      "absolute_end_time": "2026-07-23T20:00:30.750Z",
+      "created_at": "2026-07-23T20:00:29.250Z",
+      "segment_id": "sanitized-session:boris:014"
+    },
+    {
+      "start": 31.5,
+      "end": 33,
+      "text": "Sanitized transcript row 15",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:31.500Z",
+      "absolute_end_time": "2026-07-23T20:00:33.000Z",
+      "created_at": "2026-07-23T20:00:31.500Z",
+      "segment_id": "sanitized-session:anna:015"
+    },
+    {
+      "start": 33.75,
+      "end": 35.25,
+      "text": "Sanitized transcript row 16",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:33.750Z",
+      "absolute_end_time": "2026-07-23T20:00:35.250Z",
+      "created_at": "2026-07-23T20:00:33.750Z",
+      "segment_id": "sanitized-session:boris:016"
+    },
+    {
+      "start": 36,
+      "end": 37.5,
+      "text": "Sanitized transcript row 17",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:36.000Z",
+      "absolute_end_time": "2026-07-23T20:00:37.500Z",
+      "created_at": "2026-07-23T20:00:36.000Z",
+      "segment_id": "sanitized-session:anna:017"
+    },
+    {
+      "start": 38.25,
+      "end": 39.75,
+      "text": "Sanitized transcript row 18",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:38.250Z",
+      "absolute_end_time": "2026-07-23T20:00:39.750Z",
+      "created_at": "2026-07-23T20:00:38.250Z",
+      "segment_id": "sanitized-session:boris:018"
+    },
+    {
+      "start": 40.5,
+      "end": 42,
+      "text": "Sanitized transcript row 19",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:40.500Z",
+      "absolute_end_time": "2026-07-23T20:00:42.000Z",
+      "created_at": "2026-07-23T20:00:40.500Z",
+      "segment_id": "sanitized-session:anna:019"
+    },
+    {
+      "start": 42.75,
+      "end": 44.25,
+      "text": "Sanitized transcript row 20",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:42.750Z",
+      "absolute_end_time": "2026-07-23T20:00:44.250Z",
+      "created_at": "2026-07-23T20:00:42.750Z",
+      "segment_id": "sanitized-session:boris:020"
+    },
+    {
+      "start": 45,
+      "end": 46.5,
+      "text": "Sanitized transcript row 21",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:45.000Z",
+      "absolute_end_time": "2026-07-23T20:00:46.500Z",
+      "created_at": "2026-07-23T20:00:45.000Z",
+      "segment_id": "sanitized-session:anna:021"
+    },
+    {
+      "start": 47.25,
+      "end": 48.75,
+      "text": "Sanitized transcript row 22",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:47.250Z",
+      "absolute_end_time": "2026-07-23T20:00:48.750Z",
+      "created_at": "2026-07-23T20:00:47.250Z",
+      "segment_id": "sanitized-session:boris:022"
+    },
+    {
+      "start": 49.5,
+      "end": 51,
+      "text": "Sanitized transcript row 23",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:49.500Z",
+      "absolute_end_time": "2026-07-23T20:00:51.000Z",
+      "created_at": "2026-07-23T20:00:49.500Z",
+      "segment_id": "sanitized-session:anna:023"
+    },
+    {
+      "start": 51.75,
+      "end": 53.25,
+      "text": "Sanitized transcript row 24",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:51.750Z",
+      "absolute_end_time": "2026-07-23T20:00:53.250Z",
+      "created_at": "2026-07-23T20:00:51.750Z",
+      "segment_id": "sanitized-session:boris:024"
+    },
+    {
+      "start": 54,
+      "end": 55.5,
+      "text": "Sanitized transcript row 25",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:54.000Z",
+      "absolute_end_time": "2026-07-23T20:00:55.500Z",
+      "created_at": "2026-07-23T20:00:54.000Z",
+      "segment_id": "sanitized-session:anna:025"
+    },
+    {
+      "start": 56.25,
+      "end": 57.75,
+      "text": "Sanitized transcript row 26",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:56.250Z",
+      "absolute_end_time": "2026-07-23T20:00:57.750Z",
+      "created_at": "2026-07-23T20:00:56.250Z",
+      "segment_id": "sanitized-session:boris:026"
+    },
+    {
+      "start": 58.5,
+      "end": 60,
+      "text": "Sanitized transcript row 27",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:00:58.500Z",
+      "absolute_end_time": "2026-07-23T20:01:00.000Z",
+      "created_at": "2026-07-23T20:00:58.500Z",
+      "segment_id": "sanitized-session:anna:027"
+    },
+    {
+      "start": 60.75,
+      "end": 62.25,
+      "text": "Sanitized transcript row 28",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:00.750Z",
+      "absolute_end_time": "2026-07-23T20:01:02.250Z",
+      "created_at": "2026-07-23T20:01:00.750Z",
+      "segment_id": "sanitized-session:boris:028"
+    },
+    {
+      "start": 63,
+      "end": 64.5,
+      "text": "Sanitized transcript row 29",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:03.000Z",
+      "absolute_end_time": "2026-07-23T20:01:04.500Z",
+      "created_at": "2026-07-23T20:01:03.000Z",
+      "segment_id": "sanitized-session:anna:029"
+    },
+    {
+      "start": 65.25,
+      "end": 66.75,
+      "text": "Sanitized transcript row 30",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:05.250Z",
+      "absolute_end_time": "2026-07-23T20:01:06.750Z",
+      "created_at": "2026-07-23T20:01:05.250Z",
+      "segment_id": "sanitized-session:boris:030"
+    },
+    {
+      "start": 67.5,
+      "end": 69,
+      "text": "Sanitized transcript row 31",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:07.500Z",
+      "absolute_end_time": "2026-07-23T20:01:09.000Z",
+      "created_at": "2026-07-23T20:01:07.500Z",
+      "segment_id": "sanitized-session:anna:031"
+    },
+    {
+      "start": 69.75,
+      "end": 71.25,
+      "text": "Sanitized transcript row 32",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:09.750Z",
+      "absolute_end_time": "2026-07-23T20:01:11.250Z",
+      "created_at": "2026-07-23T20:01:09.750Z",
+      "segment_id": "sanitized-session:boris:032"
+    },
+    {
+      "start": 72,
+      "end": 73.5,
+      "text": "Sanitized transcript row 33",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:12.000Z",
+      "absolute_end_time": "2026-07-23T20:01:13.500Z",
+      "created_at": "2026-07-23T20:01:12.000Z",
+      "segment_id": "sanitized-session:anna:033"
+    },
+    {
+      "start": 74.25,
+      "end": 75.75,
+      "text": "Sanitized transcript row 34",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:14.250Z",
+      "absolute_end_time": "2026-07-23T20:01:15.750Z",
+      "created_at": "2026-07-23T20:01:14.250Z",
+      "segment_id": "sanitized-session:boris:034"
+    },
+    {
+      "start": 76.5,
+      "end": 78,
+      "text": "Sanitized transcript row 35",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:16.500Z",
+      "absolute_end_time": "2026-07-23T20:01:18.000Z",
+      "created_at": "2026-07-23T20:01:16.500Z",
+      "segment_id": "sanitized-session:anna:035"
+    },
+    {
+      "start": 78.75,
+      "end": 80.25,
+      "text": "Sanitized transcript row 36",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:18.750Z",
+      "absolute_end_time": "2026-07-23T20:01:20.250Z",
+      "created_at": "2026-07-23T20:01:18.750Z",
+      "segment_id": "sanitized-session:boris:036"
+    },
+    {
+      "start": 81,
+      "end": 82.5,
+      "text": "Sanitized transcript row 37",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:21.000Z",
+      "absolute_end_time": "2026-07-23T20:01:22.500Z",
+      "created_at": "2026-07-23T20:01:21.000Z",
+      "segment_id": "sanitized-session:anna:037"
+    },
+    {
+      "start": 83.25,
+      "end": 84.75,
+      "text": "Sanitized transcript row 38",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:23.250Z",
+      "absolute_end_time": "2026-07-23T20:01:24.750Z",
+      "created_at": "2026-07-23T20:01:23.250Z",
+      "segment_id": "sanitized-session:boris:038"
+    },
+    {
+      "start": 85.5,
+      "end": 87,
+      "text": "Sanitized transcript row 39",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:25.500Z",
+      "absolute_end_time": "2026-07-23T20:01:27.000Z",
+      "created_at": "2026-07-23T20:01:25.500Z",
+      "segment_id": "sanitized-session:anna:039"
+    },
+    {
+      "start": 87.75,
+      "end": 89.25,
+      "text": "Sanitized transcript row 40",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:27.750Z",
+      "absolute_end_time": "2026-07-23T20:01:29.250Z",
+      "created_at": "2026-07-23T20:01:27.750Z",
+      "segment_id": "sanitized-session:boris:040"
+    },
+    {
+      "start": 90,
+      "end": 91.5,
+      "text": "Sanitized transcript row 41",
+      "speaker": "Anna",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:30.000Z",
+      "absolute_end_time": "2026-07-23T20:01:31.500Z",
+      "created_at": "2026-07-23T20:01:30.000Z",
+      "segment_id": "sanitized-session:anna:041"
+    },
+    {
+      "start": 92.25,
+      "end": 93.75,
+      "text": "Sanitized transcript row 42",
+      "speaker": "Boris",
+      "language": "en",
+      "absolute_start_time": "2026-07-23T20:01:32.250Z",
+      "absolute_end_time": "2026-07-23T20:01:33.750Z",
+      "created_at": "2026-07-23T20:01:32.250Z",
+      "segment_id": "sanitized-session:boris:042"
+    }
+  ],
+  "recordings": []
+}

--- a/services/dashboard/tests/test_meeting_13627_platform_boundary.test.ts
+++ b/services/dashboard/tests/test_meeting_13627_platform_boundary.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import fixture from "./fixtures/meeting-13627.json";
+import { PLATFORM_CONFIG } from "@/types/vexa";
+
+describe("sanitized meeting 13627 platform boundary", () => {
+  it("resolves a display config before the detail page renders", () => {
+    expect(fixture.segments).toHaveLength(42);
+    expect(new Set(fixture.segments.map((segment) => segment.speaker))).toEqual(
+      new Set(["Anna", "Boris"])
+    );
+
+    const platformConfig = (
+      PLATFORM_CONFIG as Record<string, (typeof PLATFORM_CONFIG)[keyof typeof PLATFORM_CONFIG]>
+    )[fixture.platform];
+
+    // This is the meeting-detail page's point of introduction: it immediately
+    // dereferences .name after indexing the shared platform table.
+    expect(platformConfig.name).toBe("Jitsi Meet");
+  });
+});

--- a/services/dashboard/tests/test_meeting_13627_rendering.test.tsx
+++ b/services/dashboard/tests/test_meeting_13627_rendering.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fixture from "./fixtures/meeting-13627.json";
+import { TranscriptViewer } from "@/components/transcript/transcript-viewer";
+import { getPlatformConfig } from "@/types/vexa";
+import type { Meeting, TranscriptSegment } from "@/types/vexa";
+
+vi.mock("next/image", () => ({
+  default: () => null,
+}));
+
+class QuietBoundary extends Component<
+  { children: ReactNode; onError: (error: Error, info: ErrorInfo) => void },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError(error, info);
+  }
+
+  render() {
+    return this.state.failed ? <p>This page couldn&apos;t load</p> : this.props.children;
+  }
+}
+
+function meeting(status: Meeting["status"], platform: Meeting["platform"] = "jitsi"): Meeting {
+  return {
+    id: String(fixture.id),
+    platform,
+    platform_specific_id:
+      platform === "google_meet" ? "abc-defg-hij" : fixture.native_meeting_id,
+    status,
+    start_time: fixture.start_time,
+    end_time: status === "active" ? null : "2026-07-23T20:03:00Z",
+    bot_container_id: null,
+    data: fixture.data,
+    created_at: fixture.start_time,
+  };
+}
+
+const segments: TranscriptSegment[] = fixture.segments.map((segment) => ({
+  id: segment.segment_id,
+  meeting_id: String(fixture.id),
+  start_time: segment.start,
+  end_time: segment.end,
+  absolute_start_time: segment.absolute_start_time,
+  absolute_end_time: segment.absolute_end_time,
+  text: segment.text,
+  speaker: segment.speaker,
+  language: segment.language,
+  completed: true,
+  session_uid: "sanitized-session",
+  created_at: segment.created_at,
+  segment_id: segment.segment_id,
+}));
+
+function renderSurface(
+  status: Meeting["status"],
+  renderedSegments = segments,
+  platform: Meeting["platform"] = "jitsi"
+) {
+  const boundaryErrors: Error[] = [];
+  const currentMeeting = meeting(status, platform);
+  const platformConfig = getPlatformConfig(currentMeeting.platform);
+
+  render(
+    <QuietBoundary onError={(error) => boundaryErrors.push(error)}>
+      <section aria-label="meeting detail transcript surface">
+        <h1>{platformConfig.name}</h1>
+        <TranscriptViewer
+          meeting={currentMeeting}
+          segments={renderedSegments}
+          isLive={status === "active"}
+        />
+      </section>
+    </QuietBoundary>
+  );
+
+  return boundaryErrors;
+}
+
+afterEach(cleanup);
+
+describe("sanitized meeting 13627 detail rendering", () => {
+  for (const status of ["active", "completed"] as const) {
+    it(`renders every named Jitsi row while ${status} and keeps the boundary quiet`, () => {
+      const boundaryErrors = renderSurface(status);
+
+      expect(screen.getByRole("heading", { name: "Jitsi Meet" })).toBeTruthy();
+      for (let row = 1; row <= 42; row += 1) {
+        expect(screen.getByText(`Sanitized transcript row ${row}`)).toBeTruthy();
+      }
+      expect(screen.getAllByText("Anna").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Boris").length).toBeGreaterThan(0);
+      expect(screen.queryByText("This page couldn't load")).toBeNull();
+      expect(boundaryErrors).toEqual([]);
+    });
+  }
+
+  it("preserves Google Meet confirmed and pending rows", () => {
+    const gmeetSegments: TranscriptSegment[] = [
+      {
+        ...segments[0],
+        id: "gmeet-confirmed",
+        segment_id: "gmeet-confirmed",
+        speaker: "GMeet Speaker",
+        text: "GMeet confirmed control",
+        completed: true,
+      },
+      {
+        ...segments[1],
+        id: "gmeet-pending",
+        segment_id: "gmeet-pending",
+        speaker: "GMeet Speaker",
+        text: "GMeet pending control",
+        completed: false,
+      },
+    ];
+
+    const boundaryErrors = renderSurface("active", gmeetSegments, "google_meet");
+
+    expect(screen.getByText("GMeet confirmed control")).toBeTruthy();
+    expect(screen.getByText("GMeet pending control")).toBeTruthy();
+    expect(screen.queryByText("This page couldn't load")).toBeNull();
+    expect(boundaryErrors).toEqual([]);
+  });
+});

--- a/services/dashboard/tests/test_platform_config.test.ts
+++ b/services/dashboard/tests/test_platform_config.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Pins the platform table against the platforms the API actually serves.
+ *
+ * A platform the API serves but the UI has no entry for used to blank the page:
+ * the meeting detail page reads the config and dereferences `.name`, so a missing
+ * key threw and tripped the error boundary. These tests pin the roster and prove
+ * the lookup is total.
+ */
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import path from "path";
+import { PLATFORM_CONFIG, getPlatformConfig } from "@/types/vexa";
+import type { Meeting } from "@/types/vexa";
+import { exportToTxt } from "@/lib/export";
+
+/**
+ * The platforms the core API accepts, mirrored from
+ * core/meetings/services/meeting-api/src/meeting_api/lifecycle/stop_router.py
+ * (`_SUPPORTED_PLATFORMS`). Adding a platform there means adding it here and to
+ * PLATFORM_CONFIG — the union is `satisfies Record<Platform, PlatformConfig>`,
+ * so the build fails before this test does.
+ */
+const API_PLATFORMS = ["google_meet", "teams", "zoom", "jitsi", "browser_session"];
+
+const LUCIDE_ICON_KEYS = ["video", "users", "monitor"];
+
+describe("PLATFORM_CONFIG roster", () => {
+  it("covers exactly the platforms the API serves — no gaps, no strays", () => {
+    expect(Object.keys(PLATFORM_CONFIG).sort()).toEqual([...API_PLATFORMS].sort());
+  });
+
+  for (const platform of API_PLATFORMS) {
+    describe(platform, () => {
+      const config = getPlatformConfig(platform);
+
+      it("renders a display name", () => {
+        // The detail page does exactly this; undefined here blanks the page.
+        expect(config.name).toBeTruthy();
+      });
+
+      it("carries the classes the badges apply", () => {
+        expect(config.textColor).toBeTruthy();
+        expect(config.bgColor).toBeTruthy();
+        expect(config.color).toBeTruthy();
+      });
+
+      it("resolves to an icon that exists", () => {
+        if (config.iconSrc) {
+          const asset = path.join(__dirname, "..", "public", config.iconSrc);
+          expect(existsSync(asset), `missing icon asset ${config.iconSrc}`).toBe(true);
+        } else {
+          expect(LUCIDE_ICON_KEYS).toContain(config.icon);
+        }
+      });
+    });
+  }
+});
+
+describe("getPlatformConfig is total", () => {
+  it("falls back for a platform this build predates", () => {
+    const config = getPlatformConfig("some_platform_shipped_after_this_build");
+    expect(config).toBeDefined();
+    expect(config.name).toBeTruthy();
+    expect(LUCIDE_ICON_KEYS).toContain(config.icon);
+  });
+
+  it("never returns undefined for junk input", () => {
+    for (const junk of ["", "GOOGLE_MEET", "null", "../etc/passwd"]) {
+      expect(getPlatformConfig(junk).name).toBeTruthy();
+    }
+  });
+});
+
+describe("transcript export names the meeting's own platform", () => {
+  const meetingOn = (platform: string): Meeting => ({
+    id: "1",
+    platform: platform as Meeting["platform"],
+    platform_specific_id: "room",
+    status: "completed",
+    start_time: null,
+    end_time: null,
+    bot_container_id: null,
+    data: {},
+    created_at: "2026-07-22T09:00:00",
+  });
+
+  for (const platform of API_PLATFORMS) {
+    it(`labels ${platform} as ${getPlatformConfig(platform).name}`, () => {
+      const txt = exportToTxt(meetingOn(platform), []);
+      expect(txt).toContain(`Platform: ${getPlatformConfig(platform).name}`);
+    });
+  }
+});
+
+describe("jitsi specifically", () => {
+  it("is named for the platform, not mislabelled as another", () => {
+    expect(getPlatformConfig("jitsi").name).toBe("Jitsi Meet");
+  });
+
+  it("does not borrow another platform's logo", () => {
+    // The old icon ternary fell through to the Zoom asset for anything unrecognised.
+    expect(getPlatformConfig("jitsi").iconSrc).toBeNull();
+  });
+
+  it("accepts a plain room name as its native id", () => {
+    expect(getPlatformConfig("jitsi").pattern.test("vexa-witness-cov2")).toBe(true);
+  });
+});

--- a/services/dashboard/vitest.config.ts
+++ b/services/dashboard/vitest.config.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #937

## What changed

- makes the dashboard platform configuration total across the core platform roster, including Jitsi
- adds an honest neutral fallback for future/unknown platform values
- routes meeting detail, list/card, join/live-session, icons, and transcript export through the shared total boundary
- adds a sanitized 13627-shaped fixture with 42 valid Anna/Boris rows
- adds component coverage for active and completed named-row rendering, quiet error boundary, and the Google Meet confirmed/pending negative control
- adds the per-PR changelog fragment
- aligns the dashboard lockfile with the workflow's exact Node 20/npm 10 resolver
- inherits #127's deterministic image dependency installation and standing static oracle from the current base: the Dockerfile preserves the repository-relative local package, copies the committed lock, and runs `npm ci --ignore-scripts`; `DASHBOARD_IMAGE_USES_LOCKED_DEPENDENCIES` rejects unlocked installs

## Root cause

The core serves `jitsi` as a valid platform, while the hosted dashboard's consumer-owned `Platform` union/config table covered only its older roster. Meeting detail indexed the partial table and dereferenced `.name`, throwing before the valid transcript could render.

## Observation bundle (A1–A6)

- **A1 red:** original pre-fix base `4f3ee7c32f20a9750ad7048e0dc016710e3355d8`; `tests/test_meeting_13627_platform_boundary.test.ts` failed with `TypeError: Cannot read properties of undefined (reading 'name')` at the shared lookup after confirming 42 rows and speakers Anna/Boris.
- **A2 green:** total `satisfies Record<Platform, PlatformConfig>` table includes Jitsi; `getPlatformConfig(string)` returns the neutral fallback for unknown/junk values; no Jitsi page conditional.
- **A3/A4 green:** component DOM assertion renders 42/42 named rows for both `active` and `completed`; `QuietBoundary` records zero errors and never renders `This page couldn't load`.
- **A5 green:** Google Meet active fixture renders both confirmed and pending control rows.
- **A6 green:** `docs/changelog.d/937-jitsi-dashboard-detail.md`.
- **Artifact-install control:** the pre-fix Dockerfile fails the locked-install predicate (zero required locked markers; unlocked `npm install` present). Current base and exact head pass four required markers with no unlocked install.

## Validation

Exact local workflow toolchain: Node `20.19.6`, npm `10.8.2`.

- clean `npm ci`: green (810 packages; committed lock unchanged)
- locked-image static oracle: green (`DASHBOARD_IMAGE_USES_LOCKED_DEPENDENCIES`)
- targeted fixture/config/component: 3 files / 30 tests green
- full dashboard suite: 13 files / **104 tests green**
- changed-file ESLint: 0 errors (29 inherited warnings in touched legacy pages)
- TypeScript: green
- production `next build`: green, including 59/59 pages; release-version assertion found `0.10.6.3`
- hosted `Test Dashboard`: run [`30094857939`](https://github.com/Vexa-ai/vexa/actions/runs/30094857939), green in 47s (`npm ci`, version generation, typecheck, 104 tests)
- GitGuardian: green
- fresh non-author source review `4773387617`: source-GREEN on the exact head; no source findings

## Immutable provenance

- source/head: `c163f89b266300bafa98614ca3dcdc10174a9707`
- tree: `3185fecae36b7133ab9e70ca695e85dac8022a74`
- target base: `5c7c6c12af3e04a7d4bf0bc46059de6019788449` (`hosted/dashboard-version-truth`)
- CI: `30094857939` / 104 tests
- inherited artifact repair: #127 commit `dcb4376f059293682c41a36d0c58d6f41633bc80`, present in the base and byte-identical base→head; #939 does not duplicate it
- prior source `93f6d15bf92803ec7369190a13ac768f72a2711e`, prior base `4f3ee7c32f20a9750ad7048e0dc016710e3355d8`, and planned tag `vexaai/dashboard:v0.12.20-937-93f6d15b`: **retired lineage; must not be built, tagged, witnessed, or promoted**
- `image_digest=null`
- artifact build: **absent** for this exact head

## Current gate

Source is green at the immutable head above. No OCI image/tag/push, artifact witness, stage, or production action is authorized. Artifact work requires explicit merge/rebuild sequencing from the v0.12.20 integrator and a fresh one-run capacity lease bound to the resulting exact source.