### PR TITLE
fix(hosted): restore Account API-key compatibility

### DIFF
--- a/docs/changelog.d/127-hosted-account-api.md
+++ b/docs/changelog.d/127-hosted-account-api.md
@@ -1,0 +1,1 @@
+Hosted Account and API-key management now consume the stock v0.12 Admin API’s email lookup, token metadata, and strict mint contracts. Structured validation failures render as actionable text, and token secrets remain visible only on successful creation.

--- a/services/dashboard/src/app/api/profile/keys/route.ts
+++ b/services/dashboard/src/app/api/profile/keys/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAuthenticatedUserEmail } from "@/lib/auth-utils";
+import { getAuthenticatedUserIdentity } from "@/lib/auth-utils";
 import {
   HostedAdminError,
   listHostedTokens,
   mintHostedToken,
-  resolveHostedUser,
   type HostedAdminConfig,
-  type HostedMintInput,
 } from "@/lib/hosted-account-admin";
 
 const getAdminConfig = () => {
@@ -64,14 +62,13 @@ export async function GET() {
     );
   }
 
-  const email = await getAuthenticatedUserEmail();
-  if (!email) {
+  const identity = await getAuthenticatedUserIdentity();
+  if (!identity) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
   try {
-    const user = await resolveHostedUser(config, email);
-    const keys = await listHostedTokens(config, user.id);
+    const keys = await listHostedTokens(config, identity.userId);
     return NextResponse.json({ keys });
   } catch (error) {
     return errorResponse(error);
@@ -95,15 +92,14 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const email = await getAuthenticatedUserEmail();
-  if (!email) {
+  const identity = await getAuthenticatedUserIdentity();
+  if (!identity) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
   try {
-    const body = await request.json() as HostedMintInput;
-    const user = await resolveHostedUser(config, email);
-    const data = await mintHostedToken(config, user.id, body);
+    const body: unknown = await request.json();
+    const data = await mintHostedToken(config, identity.userId, body);
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     return errorResponse(error);

--- a/services/dashboard/src/app/api/profile/keys/route.ts
+++ b/services/dashboard/src/app/api/profile/keys/route.ts
@@ -1,5 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAuthenticatedUserId } from "@/lib/auth-utils";
+import { getAuthenticatedUserEmail } from "@/lib/auth-utils";
+import {
+  HostedAdminError,
+  listHostedTokens,
+  mintHostedToken,
+  resolveHostedUser,
+  type HostedAdminConfig,
+  type HostedMintInput,
+} from "@/lib/hosted-account-admin";
 
 const getAdminConfig = () => {
   const VEXA_ADMIN_API_URL = process.env.VEXA_ADMIN_API_URL || "";
@@ -7,48 +15,66 @@ const getAdminConfig = () => {
   return { VEXA_ADMIN_API_URL, VEXA_ADMIN_API_KEY };
 };
 
+function adminConfig(): HostedAdminConfig | null {
+  const { VEXA_ADMIN_API_URL, VEXA_ADMIN_API_KEY } = getAdminConfig();
+  if (!VEXA_ADMIN_API_URL || !VEXA_ADMIN_API_KEY) return null;
+  return {
+    baseUrl: VEXA_ADMIN_API_URL,
+    adminKey: VEXA_ADMIN_API_KEY,
+  };
+}
+
+function errorResponse(error: unknown): NextResponse {
+  if (error instanceof HostedAdminError) {
+    return NextResponse.json(
+      {
+        error: {
+          code: error.code,
+          message: error.message,
+        },
+      },
+      { status: error.status }
+    );
+  }
+  return NextResponse.json(
+    {
+      error: {
+        code: "SERVICE_UNAVAILABLE",
+        message: "The Account service is temporarily unavailable.",
+      },
+    },
+    { status: 503 }
+  );
+}
+
 /**
  * GET /api/profile/keys — list user's API keys via admin API
  */
-export async function GET(request: NextRequest) {
-  const { VEXA_ADMIN_API_URL, VEXA_ADMIN_API_KEY } = getAdminConfig();
-
-  if (!VEXA_ADMIN_API_KEY) {
-    return NextResponse.json({ keys: [] });
+export async function GET() {
+  const config = adminConfig();
+  if (!config) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "NOT_CONFIGURED",
+          message: "The Account service is not configured.",
+        },
+      },
+      { status: 503 }
+    );
   }
 
-  // Resolve user from authenticated token instead of client-supplied userId
-  const userId = await getAuthenticatedUserId();
-  if (!userId) {
+  const email = await getAuthenticatedUserEmail();
+  if (!email) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
   try {
-    const response = await fetch(`${VEXA_ADMIN_API_URL}/admin/users/${userId}`, {
-      headers: { "X-Admin-API-Key": VEXA_ADMIN_API_KEY },
-      cache: "no-store",
-    });
-
-    if (!response.ok) {
-      return NextResponse.json({ keys: [] });
-    }
-
-    const userData = await response.json();
-    const keys = (userData.api_tokens || []).map(
-      (t: { id: number; token: string; scopes?: string[]; name?: string; created_at: string; last_used_at?: string; expires_at?: string }) => ({
-        id: String(t.id),
-        token: t.token,
-        scopes: t.scopes || [],
-        name: t.name || null,
-        created_at: t.created_at,
-        last_used_at: t.last_used_at || null,
-        expires_at: t.expires_at || null,
-      })
-    );
-
+    const user = await resolveHostedUser(config, email);
+    const keys = await listHostedTokens(config, user.id);
     return NextResponse.json({ keys });
-  } catch {
-    return NextResponse.json({ keys: [] });
+  } catch (error) {
+    return errorResponse(error);
   }
 }
 
@@ -56,54 +82,30 @@ export async function GET(request: NextRequest) {
  * POST /api/profile/keys — create a new API key via admin API
  */
 export async function POST(request: NextRequest) {
-  const { VEXA_ADMIN_API_URL, VEXA_ADMIN_API_KEY } = getAdminConfig();
-
-  if (!VEXA_ADMIN_API_KEY) {
-    return NextResponse.json({ error: "Admin API not configured" }, { status: 503 });
+  const config = adminConfig();
+  if (!config) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "NOT_CONFIGURED",
+          message: "The Account service is not configured.",
+        },
+      },
+      { status: 503 }
+    );
   }
 
-  // Resolve user from authenticated token instead of client-supplied userId
-  const userId = await getAuthenticatedUserId();
-  if (!userId) {
+  const email = await getAuthenticatedUserEmail();
+  if (!email) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
   try {
-    const body = await request.json();
-    const scopes = body.scopes || body.scope; // "bot,tx" or "bot" — accept both
-    const name = body.name;
-    const expiresIn = body.expires_in; // seconds until expiry
-
-    const params = new URLSearchParams();
-    if (scopes) params.set("scopes", scopes);
-    if (name) params.set("name", name);
-    if (expiresIn) params.set("expires_in", String(expiresIn));
-    const qs = params.toString();
-    const url = `${VEXA_ADMIN_API_URL}/admin/users/${userId}/tokens${qs ? `?${qs}` : ""}`;
-
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Admin-API-Key": VEXA_ADMIN_API_KEY,
-      },
-      body: JSON.stringify({}),
-    });
-
-    if (!response.ok) {
-      const errData = await response.json().catch(() => ({}));
-      return NextResponse.json(
-        { error: "Failed to create API key", ...errData },
-        { status: response.status }
-      );
-    }
-
-    const data = await response.json();
-    return NextResponse.json(data);
+    const body = await request.json() as HostedMintInput;
+    const user = await resolveHostedUser(config, email);
+    const data = await mintHostedToken(config, user.id, body);
+    return NextResponse.json(data, { status: 201 });
   } catch (error) {
-    return NextResponse.json(
-      { error: (error as Error).message },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 }

--- a/services/dashboard/src/app/profile/page.tsx
+++ b/services/dashboard/src/app/profile/page.tsx
@@ -10,6 +10,7 @@ import {
   Check,
   GitBranch,
   RefreshCw,
+  AlertCircle,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,10 @@ import { toast } from "sonner";
 import { useAuthStore } from "@/stores/auth-store";
 import { cn } from "@/lib/utils";
 import { withBasePath } from "@/lib/base-path";
+import {
+  profileApiErrorMessage,
+  tokenMetadataPreview,
+} from "@/lib/profile-api";
 
 // ==========================================
 // Types
@@ -36,7 +41,6 @@ interface APIKeyDisplay {
   id: string;
   name: string;
   scopes: KeyScope[];
-  token: string;
   masked_token: string;
   created_at: string;
   last_used_at: string | null;
@@ -54,12 +58,6 @@ const SCOPE_CONFIG: Record<KeyScope, { label: string; prefix: string; color: str
 // ==========================================
 // Helpers
 // ==========================================
-
-function inferScope(token: string): KeyScope {
-  if (token.startsWith("vxa_tx_")) return "tx";
-  if (token.startsWith("vxa_browser_")) return "browser";
-  return "bot";
-}
 
 function maskToken(token: string): string {
   if (token.length < 16) return token;
@@ -109,64 +107,71 @@ export default function ProfilePage() {
   // API Keys state
   const [apiKeys, setApiKeys] = useState<APIKeyDisplay[]>([]);
   const [isLoadingKeys, setIsLoadingKeys] = useState(true);
+  const [keysError, setKeysError] = useState<string | null>(null);
+  const [keysReload, setKeysReload] = useState(0);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
   const [newKeyScopes, setNewKeyScopes] = useState<Set<KeyScope>>(new Set(["bot", "tx", "browser"]));
   const [newKeyExpiry, setNewKeyExpiry] = useState<string>("");
   const [isCreatingKey, setIsCreatingKey] = useState(false);
   const [createdKeyToken, setCreatedKeyToken] = useState<string | null>(null);
-  const [copiedKeyId, setCopiedKeyId] = useState<string | null>(null);
 
 
   // Fetch API keys
   useEffect(() => {
     async function fetchKeys() {
-      if (!user?.id) return;
+      if (!user?.id) {
+        setIsLoadingKeys(false);
+        return;
+      }
+      setIsLoadingKeys(true);
+      setKeysError(null);
       try {
-        const response = await fetch(withBasePath(`/api/profile/keys?userId=${user.id}`));
+        const response = await fetch(withBasePath("/api/profile/keys"));
         if (!response.ok) {
-          // Graceful fallback — endpoint may not exist yet
-          setApiKeys([]);
-          return;
+          throw new Error(await profileApiErrorMessage(response));
         }
         const data = await response.json();
         setApiKeys(
-          (data.keys || []).map((k: { id: string; token: string; scopes?: string[]; name?: string; created_at: string; last_used_at?: string; expires_at?: string }) => ({
+          (data.keys || []).map((k: { id: string; scopes?: string[]; name?: string; created_at?: string; last_used_at?: string; expires_at?: string }) => ({
             id: k.id,
             name: k.name || "API Key",
-            scopes: k.scopes && k.scopes.length > 0 ? scopesFromApi(k.scopes) : [inferScope(k.token)],
-            token: k.token,
-            masked_token: maskToken(k.token),
-            created_at: k.created_at,
+            scopes: k.scopes && k.scopes.length > 0 ? scopesFromApi(k.scopes) : ["bot"],
+            masked_token: tokenMetadataPreview(k.scopes || []),
+            created_at: k.created_at || "",
             last_used_at: k.last_used_at || null,
             expires_at: k.expires_at || null,
           }))
         );
-      } catch {
+      } catch (error) {
         setApiKeys([]);
+        setKeysError(
+          error instanceof Error
+            ? error.message
+            : "The Account service is temporarily unavailable."
+        );
       } finally {
         setIsLoadingKeys(false);
       }
     }
     fetchKeys();
-  }, [user?.id]);
+  }, [user?.id, keysReload]);
 
 
   const handleCreateKey = async () => {
     setIsCreatingKey(true);
     try {
-      const scopes = Array.from(newKeyScopes).join(",");
+      const scopes = Array.from(newKeyScopes);
       const response = await fetch(withBasePath("/api/profile/keys"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: newKeyName,
           scopes,
-          userId: user?.id,
           ...(newKeyExpiry ? { expires_in: parseInt(newKeyExpiry) * 86400 } : {}),
         }),
       });
-      if (!response.ok) throw new Error("Failed to create key");
+      if (!response.ok) throw new Error(await profileApiErrorMessage(response));
       const data = await response.json();
       setCreatedKeyToken(data.token);
       // Add to list
@@ -176,7 +181,6 @@ export default function ProfilePage() {
           id: data.id || String(Date.now()),
           name: newKeyName || "API Key",
           scopes: data.scopes ? scopesFromApi(data.scopes) : Array.from(newKeyScopes),
-          token: data.token,
           masked_token: maskToken(data.token),
           created_at: new Date().toISOString(),
           last_used_at: null,
@@ -201,14 +205,6 @@ export default function ProfilePage() {
       toast.error("Failed to revoke key", { description: (error as Error).message });
     }
   };
-
-  const handleCopyKey = async (keyId: string, token: string) => {
-    await navigator.clipboard.writeText(token);
-    setCopiedKeyId(keyId);
-    setTimeout(() => setCopiedKeyId(null), 2000);
-    toast.success("Copied to clipboard");
-  };
-
 
   return (
     <div className="space-y-6">
@@ -273,6 +269,21 @@ export default function ProfilePage() {
               <div className="flex items-center justify-center py-8">
                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
               </div>
+            ) : keysError ? (
+              <div className="py-4 text-center space-y-3">
+                <div className="flex items-center justify-center gap-2 text-sm text-red-400">
+                  <AlertCircle className="h-4 w-4" />
+                  <span>{keysError}</span>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setKeysReload((value) => value + 1)}
+                >
+                  <RefreshCw className="h-3.5 w-3.5 mr-1" />
+                  Try again
+                </Button>
+              </div>
             ) : apiKeys.length === 0 ? (
               <p className="text-sm text-muted-foreground py-4 text-center">
                 No API keys yet. Create one to get started.
@@ -311,16 +322,6 @@ export default function ProfilePage() {
                       <span className="text-muted-foreground" title="Expires">
                         {key.expires_at ? `Exp ${formatExpiry(key.expires_at)}` : "No expiry"}
                       </span>
-                      <button
-                        onClick={() => handleCopyKey(key.id, key.token)}
-                        className="text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {copiedKeyId === key.id ? (
-                          <Check className="h-3.5 w-3.5 text-emerald-400" />
-                        ) : (
-                          <Copy className="h-3.5 w-3.5" />
-                        )}
-                      </button>
                       <button
                         onClick={() => handleRevokeKey(key.id)}
                         className="text-red-400 hover:text-red-300 transition-colors"

--- a/services/dashboard/src/lib/auth-utils.ts
+++ b/services/dashboard/src/lib/auth-utils.ts
@@ -1,96 +1,60 @@
 import { cookies } from "next/headers";
-import { getAuthCookieName, getUserInfoCookieName } from "@/lib/auth-cookies";
+import { getAuthCookieName } from "@/lib/auth-cookies";
+
+export interface AuthenticatedUserIdentity {
+  userId: number;
+  email: string;
+}
 
 /**
- * Resolve the authenticated user's ID from the configured auth cookie.
+ * Resolve the identity bound to the session's API key.
  *
- * Uses the auth cookie (an API key) to look up the owning user via the
- * Admin API's user-facing auth endpoint, which resolves token -> user.
- * Resolves through the configured admin /users/email/ endpoint when user-info is available.
- *
- * Returns the numeric user ID as a string, or null if unauthenticated.
+ * The gateway's /auth/me response is the sole identity source: the same token
+ * both authenticates the request and selects the user. No independently
+ * supplied profile cookie participates in this decision.
  */
-export async function getAuthenticatedUserId(): Promise<string | null> {
-  const VEXA_ADMIN_API_URL = process.env.VEXA_ADMIN_API_URL;
-  const VEXA_ADMIN_API_KEY = process.env.VEXA_ADMIN_API_KEY || "";
-
-  if (!VEXA_ADMIN_API_URL || !VEXA_ADMIN_API_KEY) return null;
+export async function getAuthenticatedUserIdentity(): Promise<AuthenticatedUserIdentity | null> {
+  const VEXA_API_URL = process.env.VEXA_API_URL;
+  if (!VEXA_API_URL) return null;
 
   const cookieStore = await cookies();
   const token = cookieStore.get(getAuthCookieName())?.value;
   if (!token) return null;
 
-  // Validate the token by calling the API gateway (same as /api/auth/me)
-  const VEXA_API_URL = process.env.VEXA_API_URL;
-  if (!VEXA_API_URL) return null;
-  const verifyRes = await fetch(`${VEXA_API_URL}/meetings`, {
-    headers: { "X-API-Key": token },
-  });
-  if (!verifyRes.ok) return null;
-
-  // Get the user's email from the SSO cookie, then resolve to a user ID
-  const userInfoStr = cookieStore.get(getUserInfoCookieName())?.value;
-  if (!userInfoStr) return null;
-
-  let email: string;
   try {
-    const userInfo = JSON.parse(userInfoStr);
-    email = userInfo.email;
-    if (!email) return null;
-  } catch {
-    return null;
-  }
-
-  // Look up user by email using the admin API key (server-side only)
-  try {
-    const res = await fetch(
-      `${VEXA_ADMIN_API_URL}/admin/users/email/${encodeURIComponent(email)}`,
+    const response = await fetch(
+      `${VEXA_API_URL.replace(/\/$/, "")}/auth/me`,
       {
-        headers: { "X-Admin-API-Key": VEXA_ADMIN_API_KEY },
+        headers: { "X-API-Key": token },
         cache: "no-store",
       }
     );
-    if (!res.ok) return null;
-    const user = await res.json();
-    return user.id != null ? String(user.id) : null;
+    if (!response.ok) return null;
+
+    const data = await response.json() as Record<string, unknown>;
+    const userId = data.user_id;
+    const email = data.email;
+    if (
+      typeof userId !== "number" ||
+      !Number.isSafeInteger(userId) ||
+      userId <= 0 ||
+      typeof email !== "string" ||
+      !email.trim()
+    ) {
+      return null;
+    }
+    return { userId, email: email.trim() };
   } catch {
     return null;
   }
 }
 
 /**
- * Return the email bound to the already-validated hosted session.
+ * Resolve the authenticated user's ID from the configured auth cookie.
  *
- * The cookie is only trusted after the API token succeeds against the gateway.
- * Account routes use this value to resolve/upsert through the stock Admin API's
- * supported email contract instead of inventing a user-by-id read.
+ * Returns the numeric user ID as a string, or null if unauthenticated.
  */
-export async function getAuthenticatedUserEmail(): Promise<string | null> {
-  const VEXA_API_URL = process.env.VEXA_API_URL;
-  if (!VEXA_API_URL) return null;
-
-  const cookieStore = await cookies();
-  const token = cookieStore.get(getAuthCookieName())?.value;
-  if (!token) return null;
-
-  try {
-    const verifyRes = await fetch(`${VEXA_API_URL}/meetings`, {
-      headers: { "X-API-Key": token },
-    });
-    if (!verifyRes.ok) return null;
-  } catch {
-    return null;
-  }
-
-  const userInfoStr = cookieStore.get(getUserInfoCookieName())?.value;
-  if (!userInfoStr) return null;
-
-  try {
-    const userInfo = JSON.parse(userInfoStr) as { email?: unknown };
-    return typeof userInfo.email === "string" && userInfo.email
-      ? userInfo.email
-      : null;
-  } catch {
-    return null;
-  }
+export async function getAuthenticatedUserId(): Promise<string | null> {
+  const identity = await getAuthenticatedUserIdentity();
+  return identity ? String(identity.userId) : null;
 }

--- a/services/dashboard/src/lib/auth-utils.ts
+++ b/services/dashboard/src/lib/auth-utils.ts
@@ -57,3 +57,40 @@ export async function getAuthenticatedUserId(): Promise<string | null> {
     return null;
   }
 }
+
+/**
+ * Return the email bound to the already-validated hosted session.
+ *
+ * The cookie is only trusted after the API token succeeds against the gateway.
+ * Account routes use this value to resolve/upsert through the stock Admin API's
+ * supported email contract instead of inventing a user-by-id read.
+ */
+export async function getAuthenticatedUserEmail(): Promise<string | null> {
+  const VEXA_API_URL = process.env.VEXA_API_URL;
+  if (!VEXA_API_URL) return null;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(getAuthCookieName())?.value;
+  if (!token) return null;
+
+  try {
+    const verifyRes = await fetch(`${VEXA_API_URL}/meetings`, {
+      headers: { "X-API-Key": token },
+    });
+    if (!verifyRes.ok) return null;
+  } catch {
+    return null;
+  }
+
+  const userInfoStr = cookieStore.get(getUserInfoCookieName())?.value;
+  if (!userInfoStr) return null;
+
+  try {
+    const userInfo = JSON.parse(userInfoStr) as { email?: unknown };
+    return typeof userInfo.email === "string" && userInfo.email
+      ? userInfo.email
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/services/dashboard/src/lib/hosted-account-admin.ts
+++ b/services/dashboard/src/lib/hosted-account-admin.ts
@@ -13,13 +13,6 @@ export interface HostedAdminConfig {
   fetcher?: typeof fetch;
 }
 
-export interface HostedUser {
-  id: number;
-  email: string;
-  name?: string | null;
-  max_concurrent_bots: number;
-}
-
 export interface HostedTokenMetadata {
   id: string;
   scopes: string[];
@@ -37,10 +30,9 @@ export interface HostedMintedToken {
 }
 
 export interface HostedMintInput {
-  scopes?: unknown;
-  scope?: unknown;
-  name?: unknown;
-  expires_in?: unknown;
+  scopes: string[];
+  name?: string;
+  expires_in?: number;
 }
 
 export class HostedAdminError extends Error {
@@ -176,29 +168,6 @@ async function adminRequest<T>(
   return { data: await response.json() as T, status: response.status };
 }
 
-export async function resolveHostedUser(
-  config: HostedAdminConfig,
-  email: string
-): Promise<HostedUser> {
-  try {
-    return (
-      await adminRequest<HostedUser>(
-        config,
-        `/admin/users/email/${encodeURIComponent(email)}`
-      )
-    ).data;
-  } catch (error) {
-    if (!(error instanceof HostedAdminError) || error.status !== 404) throw error;
-  }
-
-  return (
-    await adminRequest<HostedUser>(config, "/admin/users", {
-      method: "POST",
-      body: JSON.stringify({ email }),
-    })
-  ).data;
-}
-
 export async function listHostedTokens(
   config: HostedAdminConfig,
   userId: number
@@ -223,56 +192,60 @@ export async function listHostedTokens(
   }));
 }
 
-function normalizeScopes(input: HostedMintInput): string[] {
-  const raw = input.scopes ?? input.scope;
-  const values = Array.isArray(raw)
-    ? raw
-    : typeof raw === "string"
-      ? raw.split(",")
-      : [];
-  const scopes = values
-    .filter((value): value is string => typeof value === "string")
+function validationError(message: string): never {
+  throw new HostedAdminError(422, "VALIDATION_ERROR", message);
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return Boolean(input) && typeof input === "object" && !Array.isArray(input);
+}
+
+function normalizeScopes(raw: unknown): string[] {
+  if (!Array.isArray(raw) || raw.some((value) => typeof value !== "string")) {
+    validationError("Scopes must be an array of strings.");
+  }
+
+  const scopes = raw
     .map((value) => value.trim())
     .filter(Boolean);
 
   if (scopes.length === 0 || scopes.some((scope) => !VALID_SCOPES.has(scope))) {
-    throw new HostedAdminError(
-      422,
-      "VALIDATION_ERROR",
-      "Choose at least one valid API-key scope."
-    );
+    validationError("Choose at least one valid API-key scope.");
   }
   return [...new Set(scopes)];
 }
 
-export function supportedMintBody(input: HostedMintInput): {
-  scopes: string[];
-  name?: string;
-  expires_in?: number;
-} {
-  const body: {
-    scopes: string[];
-    name?: string;
-    expires_in?: number;
-  } = { scopes: normalizeScopes(input) };
+export function supportedMintBody(input: unknown): HostedMintInput {
+  if (!isRecord(input)) {
+    validationError("The API-key request must be a JSON object.");
+  }
 
-  if (typeof input.name === "string" && input.name.trim()) {
+  const supported = new Set(["scopes", "name", "expires_in"]);
+  const unknownFields = Object.keys(input).filter((key) => !supported.has(key));
+  if (unknownFields.length > 0) {
+    validationError(
+      `Unsupported API-key request field: ${unknownFields.sort().join(", ")}.`
+    );
+  }
+
+  const body: HostedMintInput = { scopes: normalizeScopes(input.scopes) };
+
+  if (input.name !== undefined) {
+    if (typeof input.name !== "string") {
+      validationError("Name must be a string.");
+    }
     body.name = input.name.trim();
   }
 
-  if (input.expires_in !== undefined && input.expires_in !== null) {
-    const expiresIn =
-      typeof input.expires_in === "number"
-        ? input.expires_in
-        : Number(input.expires_in);
-    if (!Number.isInteger(expiresIn) || expiresIn <= 0) {
-      throw new HostedAdminError(
-        422,
-        "VALIDATION_ERROR",
-        "Expiration must be a positive number of seconds."
-      );
+  if (input.expires_in !== undefined) {
+    if (
+      typeof input.expires_in !== "number" ||
+      !Number.isSafeInteger(input.expires_in) ||
+      input.expires_in <= 0
+    ) {
+      validationError("Expiration must be a positive integer of seconds.");
     }
-    body.expires_in = expiresIn;
+    body.expires_in = input.expires_in;
   }
 
   return body;
@@ -281,7 +254,7 @@ export function supportedMintBody(input: HostedMintInput): {
 export async function mintHostedToken(
   config: HostedAdminConfig,
   userId: number,
-  input: HostedMintInput
+  input: unknown
 ): Promise<HostedMintedToken> {
   return (
     await adminRequest<HostedMintedToken>(

--- a/services/dashboard/src/lib/hosted-account-admin.ts
+++ b/services/dashboard/src/lib/hosted-account-admin.ts
@@ -1,0 +1,296 @@
+/**
+ * Hosted Account adapter for the stock v0.12 Admin API.
+ *
+ * The server-side dashboard owns this translation boundary. Browser identity
+ * fields never cross it, and token secrets cross only on a successful mint.
+ */
+
+const VALID_SCOPES = new Set(["bot", "tx", "browser"]);
+
+export interface HostedAdminConfig {
+  baseUrl: string;
+  adminKey: string;
+  fetcher?: typeof fetch;
+}
+
+export interface HostedUser {
+  id: number;
+  email: string;
+  name?: string | null;
+  max_concurrent_bots: number;
+}
+
+export interface HostedTokenMetadata {
+  id: string;
+  scopes: string[];
+  name: string | null;
+  created_at: string | null;
+  last_used_at: string | null;
+  expires_at: string | null;
+}
+
+export interface HostedMintedToken {
+  id: number;
+  token: string;
+  user_id: number;
+  scopes: string[];
+}
+
+export interface HostedMintInput {
+  scopes?: unknown;
+  scope?: unknown;
+  name?: unknown;
+  expires_in?: unknown;
+}
+
+export class HostedAdminError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = "HostedAdminError";
+  }
+}
+
+function validationLocation(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const parts = value.filter(
+    (part): part is string | number =>
+      typeof part === "string" || typeof part === "number"
+  );
+  return parts.length > 0 ? parts.join(".") : null;
+}
+
+/**
+ * Render FastAPI's string or structured validation detail without coercing an
+ * object to "[object Object]". Deliberately ignores `input`, which may contain
+ * a credential or other user-supplied secret.
+ */
+export function formatFastApiDetail(detail: unknown): string {
+  if (typeof detail === "string" && detail.trim()) return detail.trim();
+
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map((item) => {
+        if (typeof item === "string") return item.trim();
+        if (!item || typeof item !== "object") return "";
+        const record = item as Record<string, unknown>;
+        const message =
+          typeof record.msg === "string"
+            ? record.msg
+            : typeof record.message === "string"
+              ? record.message
+              : "";
+        const location = validationLocation(record.loc);
+        return [location, message].filter(Boolean).join(": ");
+      })
+      .filter(Boolean);
+    if (messages.length > 0) return messages.join("; ");
+  }
+
+  if (detail && typeof detail === "object") {
+    const record = detail as Record<string, unknown>;
+    for (const key of ["detail", "message", "error"]) {
+      if (key in record) {
+        const nested = formatFastApiDetail(record[key]);
+        if (nested) return nested;
+      }
+    }
+  }
+
+  return "The Account service rejected the request.";
+}
+
+function errorCode(status: number): string {
+  if (status === 401) return "UNAUTHORIZED";
+  if (status === 403) return "FORBIDDEN";
+  if (status === 404) return "NOT_FOUND";
+  if (status === 409) return "CONFLICT";
+  if (status === 422) return "VALIDATION_ERROR";
+  if (status === 429) return "RATE_LIMITED";
+  if (status >= 500) return "SERVICE_UNAVAILABLE";
+  return "ADMIN_API_ERROR";
+}
+
+async function errorFromResponse(response: Response): Promise<HostedAdminError> {
+  let detail: unknown;
+  try {
+    const contentType = response.headers.get("content-type") || "";
+    detail = contentType.includes("json")
+      ? (await response.json() as { detail?: unknown; message?: unknown; error?: unknown })
+      : await response.text();
+  } catch {
+    detail = undefined;
+  }
+
+  const record =
+    detail && typeof detail === "object" && !Array.isArray(detail)
+      ? detail as Record<string, unknown>
+      : null;
+  const candidate = record?.detail ?? record?.message ?? record?.error ?? detail;
+  return new HostedAdminError(
+    response.status,
+    errorCode(response.status),
+    formatFastApiDetail(candidate)
+  );
+}
+
+function adminHeaders(adminKey: string): HeadersInit {
+  return {
+    "Content-Type": "application/json",
+    "X-Admin-API-Key": adminKey,
+  };
+}
+
+function endpoint(config: HostedAdminConfig, path: string): string {
+  return `${config.baseUrl.replace(/\/$/, "")}${path}`;
+}
+
+async function adminRequest<T>(
+  config: HostedAdminConfig,
+  path: string,
+  init: RequestInit = {}
+): Promise<{ data: T; status: number }> {
+  const fetcher = config.fetcher ?? fetch;
+  let response: Response;
+  try {
+    response = await fetcher(endpoint(config, path), {
+      ...init,
+      headers: {
+        ...adminHeaders(config.adminKey),
+        ...init.headers,
+      },
+      cache: "no-store",
+    });
+  } catch {
+    throw new HostedAdminError(
+      503,
+      "SERVICE_UNAVAILABLE",
+      "The Account service is temporarily unavailable."
+    );
+  }
+
+  if (!response.ok) throw await errorFromResponse(response);
+  return { data: await response.json() as T, status: response.status };
+}
+
+export async function resolveHostedUser(
+  config: HostedAdminConfig,
+  email: string
+): Promise<HostedUser> {
+  try {
+    return (
+      await adminRequest<HostedUser>(
+        config,
+        `/admin/users/email/${encodeURIComponent(email)}`
+      )
+    ).data;
+  } catch (error) {
+    if (!(error instanceof HostedAdminError) || error.status !== 404) throw error;
+  }
+
+  return (
+    await adminRequest<HostedUser>(config, "/admin/users", {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    })
+  ).data;
+}
+
+export async function listHostedTokens(
+  config: HostedAdminConfig,
+  userId: number
+): Promise<HostedTokenMetadata[]> {
+  const rows = (
+    await adminRequest<Array<Record<string, unknown>>>(
+      config,
+      `/admin/users/${userId}/tokens`
+    )
+  ).data;
+
+  return rows.map((row) => ({
+    id: String(row.id),
+    scopes: Array.isArray(row.scopes)
+      ? row.scopes.filter((scope): scope is string => typeof scope === "string")
+      : [],
+    name: typeof row.name === "string" ? row.name : null,
+    created_at: typeof row.created_at === "string" ? row.created_at : null,
+    last_used_at:
+      typeof row.last_used_at === "string" ? row.last_used_at : null,
+    expires_at: typeof row.expires_at === "string" ? row.expires_at : null,
+  }));
+}
+
+function normalizeScopes(input: HostedMintInput): string[] {
+  const raw = input.scopes ?? input.scope;
+  const values = Array.isArray(raw)
+    ? raw
+    : typeof raw === "string"
+      ? raw.split(",")
+      : [];
+  const scopes = values
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (scopes.length === 0 || scopes.some((scope) => !VALID_SCOPES.has(scope))) {
+    throw new HostedAdminError(
+      422,
+      "VALIDATION_ERROR",
+      "Choose at least one valid API-key scope."
+    );
+  }
+  return [...new Set(scopes)];
+}
+
+export function supportedMintBody(input: HostedMintInput): {
+  scopes: string[];
+  name?: string;
+  expires_in?: number;
+} {
+  const body: {
+    scopes: string[];
+    name?: string;
+    expires_in?: number;
+  } = { scopes: normalizeScopes(input) };
+
+  if (typeof input.name === "string" && input.name.trim()) {
+    body.name = input.name.trim();
+  }
+
+  if (input.expires_in !== undefined && input.expires_in !== null) {
+    const expiresIn =
+      typeof input.expires_in === "number"
+        ? input.expires_in
+        : Number(input.expires_in);
+    if (!Number.isInteger(expiresIn) || expiresIn <= 0) {
+      throw new HostedAdminError(
+        422,
+        "VALIDATION_ERROR",
+        "Expiration must be a positive number of seconds."
+      );
+    }
+    body.expires_in = expiresIn;
+  }
+
+  return body;
+}
+
+export async function mintHostedToken(
+  config: HostedAdminConfig,
+  userId: number,
+  input: HostedMintInput
+): Promise<HostedMintedToken> {
+  return (
+    await adminRequest<HostedMintedToken>(
+      config,
+      `/admin/users/${userId}/tokens`,
+      {
+        method: "POST",
+        body: JSON.stringify(supportedMintBody(input)),
+      }
+    )
+  ).data;
+}

--- a/services/dashboard/src/lib/profile-api.ts
+++ b/services/dashboard/src/lib/profile-api.ts
@@ -1,0 +1,62 @@
+export interface ProfileApiErrorBody {
+  error?: unknown;
+  detail?: unknown;
+  message?: unknown;
+}
+
+function renderDetail(detail: unknown): string | null {
+  if (typeof detail === "string" && detail.trim()) return detail.trim();
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map((item) => {
+        if (!item || typeof item !== "object") return null;
+        const record = item as Record<string, unknown>;
+        const location = Array.isArray(record.loc)
+          ? record.loc
+              .filter(
+                (part): part is string | number =>
+                  typeof part === "string" || typeof part === "number"
+              )
+              .join(".")
+          : "";
+        const message =
+          typeof record.msg === "string"
+            ? record.msg
+            : typeof record.message === "string"
+              ? record.message
+              : "";
+        return [location, message].filter(Boolean).join(": ") || null;
+      })
+      .filter((message): message is string => Boolean(message));
+    return messages.length > 0 ? messages.join("; ") : null;
+  }
+  if (detail && typeof detail === "object") {
+    const record = detail as Record<string, unknown>;
+    for (const key of ["message", "detail", "error"]) {
+      const nested = renderDetail(record[key]);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+export async function profileApiErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = await response.json() as ProfileApiErrorBody;
+    return (
+      renderDetail(body.error) ??
+      renderDetail(body.detail) ??
+      renderDetail(body.message) ??
+      `Account request failed (HTTP ${response.status}).`
+    );
+  } catch {
+    return `Account request failed (HTTP ${response.status}).`;
+  }
+}
+
+export function tokenMetadataPreview(scopes: string[]): string {
+  const primary = scopes.find((scope) =>
+    ["bot", "tx", "browser"].includes(scope)
+  );
+  return primary ? `vxa_${primary}_••••` : "Secret shown only once";
+}

--- a/services/dashboard/tests/test_auth_utils_identity.test.ts
+++ b/services/dashboard/tests/test_auth_utils_identity.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cookieGet = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ get: cookieGet })),
+}));
+
+import {
+  getAuthenticatedUserId,
+  getAuthenticatedUserIdentity,
+} from "@/lib/auth-utils";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("token-bound hosted identity", () => {
+  beforeEach(() => {
+    process.env.VEXA_API_URL = "http://stock-gateway.test";
+    cookieGet.mockReset();
+    cookieGet.mockImplementation((name: string) => {
+      if (name === "vexa-token") return { value: "token-owner-a" };
+      if (name === "vexa-user-info") {
+        return {
+          value: JSON.stringify({
+            email: "forged-owner-b@example.net",
+            id: 999,
+          }),
+        };
+      }
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete process.env.VEXA_API_URL;
+  });
+
+  it("uses only /auth/me identity when a stale user-info cookie names another user", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        calls.push({ url: String(input), init });
+        return jsonResponse({
+          user_id: 41,
+          email: "owner-a@example.com",
+          scopes: ["bot"],
+          max_concurrent: 3,
+        });
+      })
+    );
+
+    await expect(getAuthenticatedUserIdentity()).resolves.toEqual({
+      userId: 41,
+      email: "owner-a@example.com",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://stock-gateway.test/auth/me");
+    expect(calls[0].init?.headers).toEqual({
+      "X-API-Key": "token-owner-a",
+    });
+    expect(cookieGet).toHaveBeenCalledTimes(1);
+    expect(cookieGet).toHaveBeenCalledWith("vexa-token");
+    expect(JSON.stringify(calls)).not.toContain("forged-owner-b");
+  });
+
+  it("keeps existing user-ID consumers on the same token-bound identity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          user_id: 41,
+          email: "owner-a@example.com",
+          scopes: ["bot"],
+          max_concurrent: 3,
+        })
+      )
+    );
+
+    await expect(getAuthenticatedUserId()).resolves.toBe("41");
+    expect(cookieGet).toHaveBeenCalledTimes(1);
+    expect(cookieGet).not.toHaveBeenCalledWith("vexa-user-info");
+  });
+
+  it.each([
+    [{ user_id: "41", email: "owner-a@example.com" }],
+    [{ user_id: 41, email: "" }],
+    [{ user_id: -1, email: "owner-a@example.com" }],
+  ])("rejects malformed /auth/me identity %#", async (body) => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(body)));
+    await expect(getAuthenticatedUserIdentity()).resolves.toBeNull();
+  });
+});

--- a/services/dashboard/tests/test_hosted_account_admin_contract.test.ts
+++ b/services/dashboard/tests/test_hosted_account_admin_contract.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/lib/auth-utils", () => ({
-  getAuthenticatedUserEmail: vi.fn().mockResolvedValue("person@example.com"),
+  getAuthenticatedUserIdentity: vi.fn().mockResolvedValue({
+    userId: 41,
+    email: "person@example.com",
+  }),
   getAuthenticatedUserId: vi.fn().mockResolvedValue("41"),
 }));
 
@@ -30,21 +33,13 @@ describe("hosted Account adapter against the stock v0.12.18 Admin API contract",
     delete process.env.VEXA_ADMIN_API_KEY;
   });
 
-  it("resolves the authenticated email, then lists secret-free token metadata", async () => {
+  it("lists secret-free token metadata for the token-bound user ID", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
         const url = String(input);
         calls.push({ url, init });
-        if (url === `${ADMIN_URL}/admin/users/email/person%40example.com`) {
-          return jsonResponse({
-            id: 41,
-            email: "person@example.com",
-            name: "Person",
-            max_concurrent_bots: 3,
-          });
-        }
         if (url === `${ADMIN_URL}/admin/users/41/tokens`) {
           return jsonResponse([
             {
@@ -57,10 +52,6 @@ describe("hosted Account adapter against the stock v0.12.18 Admin API contract",
               expires_at: null,
             },
           ]);
-        }
-        // Exact stock behavior: user-by-id is not a route.
-        if (url === `${ADMIN_URL}/admin/users/41`) {
-          return jsonResponse({ detail: "Not Found" }, 404);
         }
         throw new Error(`unexpected request: ${url}`);
       })
@@ -82,69 +73,18 @@ describe("hosted Account adapter against the stock v0.12.18 Admin API contract",
       ],
     });
     expect(calls.map((call) => call.url)).toEqual([
-      `${ADMIN_URL}/admin/users/email/person%40example.com`,
       `${ADMIN_URL}/admin/users/41/tokens`,
     ]);
     expect(JSON.stringify(calls)).not.toContain("vxa_");
   });
 
-  it("upserts a newly authenticated account only after the supported email lookup returns 404", async () => {
+  it("mints with exactly the stock-supported JSON fields", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
         const url = String(input);
         calls.push({ url, init });
-        if (url === `${ADMIN_URL}/admin/users/email/person%40example.com`) {
-          return jsonResponse({ detail: "User not found" }, 404);
-        }
-        if (url === `${ADMIN_URL}/admin/users`) {
-          return jsonResponse(
-            {
-              id: 41,
-              email: "person@example.com",
-              name: null,
-              max_concurrent_bots: 3,
-            },
-            201
-          );
-        }
-        if (url === `${ADMIN_URL}/admin/users/41/tokens`) {
-          return jsonResponse([]);
-        }
-        throw new Error(`unexpected request: ${url}`);
-      })
-    );
-
-    const response = await GET();
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ keys: [] });
-    expect(calls.map((call) => call.url)).toEqual([
-      `${ADMIN_URL}/admin/users/email/person%40example.com`,
-      `${ADMIN_URL}/admin/users`,
-      `${ADMIN_URL}/admin/users/41/tokens`,
-    ]);
-    expect(JSON.parse(String(calls[1].init?.body))).toEqual({
-      email: "person@example.com",
-    });
-  });
-
-  it("mints with only stock-supported JSON fields and never forwards client identity", async () => {
-    const calls: Array<{ url: string; init?: RequestInit }> = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-        const url = String(input);
-        calls.push({ url, init });
-        if (url === `${ADMIN_URL}/admin/users/email/person%40example.com`) {
-          return jsonResponse({
-            id: 41,
-            email: "person@example.com",
-            name: "Person",
-            max_concurrent_bots: 3,
-          });
-        }
         if (url === `${ADMIN_URL}/admin/users/41/tokens`) {
           return jsonResponse(
             {
@@ -165,9 +105,7 @@ describe("hosted Account adapter against the stock v0.12.18 Admin API contract",
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: "attacker@example.net",
-          userId: "999",
-          scopes: "bot,tx",
+          scopes: ["bot", "tx"],
           name: "automation",
           expires_in: 3600,
         }),
@@ -181,29 +119,48 @@ describe("hosted Account adapter against the stock v0.12.18 Admin API contract",
       scopes: ["bot", "tx"],
     });
     expect(calls.map((call) => call.url)).toEqual([
-      `${ADMIN_URL}/admin/users/email/person%40example.com`,
       `${ADMIN_URL}/admin/users/41/tokens`,
     ]);
-    expect(JSON.parse(String(calls[1].init?.body))).toEqual({
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
       scopes: ["bot", "tx"],
       name: "automation",
       expires_in: 3600,
     });
   });
 
+  it.each([
+    ["email", { scopes: ["bot"], email: "attacker@example.net" }],
+    ["userId", { scopes: ["bot"], userId: "999" }],
+    ["scope alias", { scope: ["bot"] }],
+    ["string scopes", { scopes: "bot,tx" }],
+    ["non-string scope", { scopes: ["bot", 7] }],
+    ["non-string name", { scopes: ["bot"], name: 7 }],
+    ["string expiration", { scopes: ["bot"], expires_in: "3600" }],
+    ["non-positive expiration", { scopes: ["bot"], expires_in: 0 }],
+    ["unknown field", { scopes: ["bot"], unexpected: true }],
+  ])("rejects %s before any Admin request", async (_case, body) => {
+    const fetcher = vi.fn();
+    vi.stubGlobal("fetch", fetcher);
+
+    const response = await POST(
+      new NextRequest("http://dashboard.test/api/profile/keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toMatchObject({
+      error: { code: "VALIDATION_ERROR" },
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("preserves a structured FastAPI 422 as a typed actionable response", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (input: string | URL | Request) => {
-        const url = String(input);
-        if (url.includes("/admin/users/email/")) {
-          return jsonResponse({
-            id: 41,
-            email: "person@example.com",
-            name: "Person",
-            max_concurrent_bots: 3,
-          });
-        }
+      vi.fn(async () => {
         return jsonResponse(
           {
             detail: [
@@ -224,7 +181,7 @@ describe("hosted Account adapter against the stock v0.12.18 Admin API contract",
       new NextRequest("http://dashboard.test/api/profile/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ scopes: "bot", name: "automation" }),
+        body: JSON.stringify({ scopes: ["bot"], name: "automation" }),
       })
     );
 
@@ -246,16 +203,7 @@ describe("hosted Account adapter against the stock v0.12.18 Admin API contract",
     ];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (input: string | URL | Request) => {
-        const url = String(input);
-        if (url.includes("/admin/users/email/")) {
-          return jsonResponse({
-            id: 41,
-            email: "person@example.com",
-            name: "Person",
-            max_concurrent_bots: 3,
-          });
-        }
+      vi.fn(async () => {
         return jsonResponse(
           {
             id: 8,

--- a/services/dashboard/tests/test_hosted_account_admin_contract.test.ts
+++ b/services/dashboard/tests/test_hosted_account_admin_contract.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth-utils", () => ({
+  getAuthenticatedUserEmail: vi.fn().mockResolvedValue("person@example.com"),
+  getAuthenticatedUserId: vi.fn().mockResolvedValue("41"),
+}));
+
+import { GET, POST } from "@/app/api/profile/keys/route";
+
+const ADMIN_URL = "http://stock-admin.test";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("hosted Account adapter against the stock v0.12.18 Admin API contract", () => {
+  beforeEach(() => {
+    process.env.VEXA_ADMIN_API_URL = ADMIN_URL;
+    process.env.VEXA_ADMIN_API_KEY = "test-admin-key";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete process.env.VEXA_ADMIN_API_URL;
+    delete process.env.VEXA_ADMIN_API_KEY;
+  });
+
+  it("resolves the authenticated email, then lists secret-free token metadata", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, init });
+        if (url === `${ADMIN_URL}/admin/users/email/person%40example.com`) {
+          return jsonResponse({
+            id: 41,
+            email: "person@example.com",
+            name: "Person",
+            max_concurrent_bots: 3,
+          });
+        }
+        if (url === `${ADMIN_URL}/admin/users/41/tokens`) {
+          return jsonResponse([
+            {
+              id: 7,
+              user_id: 41,
+              scopes: ["bot", "tx"],
+              name: "automation",
+              created_at: "2026-07-24T08:00:00Z",
+              last_used_at: null,
+              expires_at: null,
+            },
+          ]);
+        }
+        // Exact stock behavior: user-by-id is not a route.
+        if (url === `${ADMIN_URL}/admin/users/41`) {
+          return jsonResponse({ detail: "Not Found" }, 404);
+        }
+        throw new Error(`unexpected request: ${url}`);
+      })
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      keys: [
+        {
+          id: "7",
+          scopes: ["bot", "tx"],
+          name: "automation",
+          created_at: "2026-07-24T08:00:00Z",
+          last_used_at: null,
+          expires_at: null,
+        },
+      ],
+    });
+    expect(calls.map((call) => call.url)).toEqual([
+      `${ADMIN_URL}/admin/users/email/person%40example.com`,
+      `${ADMIN_URL}/admin/users/41/tokens`,
+    ]);
+    expect(JSON.stringify(calls)).not.toContain("vxa_");
+  });
+
+  it("upserts a newly authenticated account only after the supported email lookup returns 404", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, init });
+        if (url === `${ADMIN_URL}/admin/users/email/person%40example.com`) {
+          return jsonResponse({ detail: "User not found" }, 404);
+        }
+        if (url === `${ADMIN_URL}/admin/users`) {
+          return jsonResponse(
+            {
+              id: 41,
+              email: "person@example.com",
+              name: null,
+              max_concurrent_bots: 3,
+            },
+            201
+          );
+        }
+        if (url === `${ADMIN_URL}/admin/users/41/tokens`) {
+          return jsonResponse([]);
+        }
+        throw new Error(`unexpected request: ${url}`);
+      })
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ keys: [] });
+    expect(calls.map((call) => call.url)).toEqual([
+      `${ADMIN_URL}/admin/users/email/person%40example.com`,
+      `${ADMIN_URL}/admin/users`,
+      `${ADMIN_URL}/admin/users/41/tokens`,
+    ]);
+    expect(JSON.parse(String(calls[1].init?.body))).toEqual({
+      email: "person@example.com",
+    });
+  });
+
+  it("mints with only stock-supported JSON fields and never forwards client identity", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, init });
+        if (url === `${ADMIN_URL}/admin/users/email/person%40example.com`) {
+          return jsonResponse({
+            id: 41,
+            email: "person@example.com",
+            name: "Person",
+            max_concurrent_bots: 3,
+          });
+        }
+        if (url === `${ADMIN_URL}/admin/users/41/tokens`) {
+          return jsonResponse(
+            {
+              id: 8,
+              token: "vxa_bot_one-time-secret",
+              user_id: 41,
+              scopes: ["bot", "tx"],
+            },
+            201
+          );
+        }
+        throw new Error(`unexpected request: ${url}`);
+      })
+    );
+
+    const response = await POST(
+      new NextRequest("http://dashboard.test/api/profile/keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "attacker@example.net",
+          userId: "999",
+          scopes: "bot,tx",
+          name: "automation",
+          expires_in: 3600,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      id: 8,
+      token: "vxa_bot_one-time-secret",
+      scopes: ["bot", "tx"],
+    });
+    expect(calls.map((call) => call.url)).toEqual([
+      `${ADMIN_URL}/admin/users/email/person%40example.com`,
+      `${ADMIN_URL}/admin/users/41/tokens`,
+    ]);
+    expect(JSON.parse(String(calls[1].init?.body))).toEqual({
+      scopes: ["bot", "tx"],
+      name: "automation",
+      expires_in: 3600,
+    });
+  });
+
+  it("preserves a structured FastAPI 422 as a typed actionable response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/admin/users/email/")) {
+          return jsonResponse({
+            id: 41,
+            email: "person@example.com",
+            name: "Person",
+            max_concurrent_bots: 3,
+          });
+        }
+        return jsonResponse(
+          {
+            detail: [
+              {
+                type: "extra_forbidden",
+                loc: ["body", "userId"],
+                msg: "Extra inputs are not permitted",
+                input: "999",
+              },
+            ],
+          },
+          422
+        );
+      })
+    );
+
+    const response = await POST(
+      new NextRequest("http://dashboard.test/api/profile/keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scopes: "bot", name: "automation" }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "body.userId: Extra inputs are not permitted",
+      },
+    });
+  });
+
+  it("does not log the one-time token returned by a successful mint", async () => {
+    const logSpies = [
+      vi.spyOn(console, "log").mockImplementation(() => undefined),
+      vi.spyOn(console, "info").mockImplementation(() => undefined),
+      vi.spyOn(console, "warn").mockImplementation(() => undefined),
+      vi.spyOn(console, "error").mockImplementation(() => undefined),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/admin/users/email/")) {
+          return jsonResponse({
+            id: 41,
+            email: "person@example.com",
+            name: "Person",
+            max_concurrent_bots: 3,
+          });
+        }
+        return jsonResponse(
+          {
+            id: 8,
+            token: "vxa_bot_one-time-secret",
+            user_id: 41,
+            scopes: ["bot"],
+          },
+          201
+        );
+      })
+    );
+
+    const response = await POST(
+      new NextRequest("http://dashboard.test/api/profile/keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scopes: ["bot"], name: "automation" }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect((await response.json()).token).toBe("vxa_bot_one-time-secret");
+    for (const spy of logSpies) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/services/dashboard/tests/test_profile_key_presenter.test.ts
+++ b/services/dashboard/tests/test_profile_key_presenter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  profileApiErrorMessage,
+  tokenMetadataPreview,
+} from "@/lib/profile-api";
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Profile API-key presenter", () => {
+  it("renders typed route errors as actionable text", async () => {
+    const response = jsonResponse(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "body.userId: Extra inputs are not permitted",
+        },
+      },
+      422
+    );
+
+    await expect(profileApiErrorMessage(response)).resolves.toBe(
+      "body.userId: Extra inputs are not permitted"
+    );
+  });
+
+  it("renders a raw FastAPI detail array without object coercion or input disclosure", async () => {
+    const response = jsonResponse(
+      {
+        detail: [
+          {
+            type: "extra_forbidden",
+            loc: ["body", "userId"],
+            msg: "Extra inputs are not permitted",
+            input: "secret-value-must-not-render",
+          },
+        ],
+      },
+      422
+    );
+
+    const message = await profileApiErrorMessage(response);
+    expect(message).toBe("body.userId: Extra inputs are not permitted");
+    expect(message).not.toContain("[object Object]");
+    expect(message).not.toContain("secret-value-must-not-render");
+  });
+
+  it("shows only a scope-derived placeholder for listed token metadata", () => {
+    expect(tokenMetadataPreview(["tx", "bot"])).toBe("vxa_tx_••••");
+    expect(tokenMetadataPreview([])).toBe("Secret shown only once");
+  });
+});


### PR DESCRIPTION
## Value

Restores the hosted Account/API-key client boundary against the stock v0.12.18 API contracts. No compatibility endpoint, dual request contract, or hosted behavior was added to OSS core.

Refs private delivery issue `Vexa-ai/vexa-platform#127` and customer incident #942. Neither issue closes from source merge; immutable image, isolated hosted witness, and production readback remain required.

## Exact source

- reviewed head: `48750747d88ec13c8c7a1df9866bd23cfaf097a5`
- merged commit: `67aeec3b2e3da7d02a29f11b86c63706930fc77a`
- reviewed and merged trees: byte-identical `19896e8beaaad83322ac3bd8ca4f4b262c7c05a7`
- base: `hosted/dashboard-version-truth` at `4f3ee7c32f20a9750ad7048e0dc016710e3355d8`

## Root cause and correction

The old hosted profile client called unsupported `GET /admin/users/{id}`, expected secrets in user/list responses, forwarded legacy identity/request shapes, and rendered structured errors as `[object Object]`.

The final correction:

- derives identity solely from stock gateway `GET /auth/me` using the session API token;
- never reads the independent user-info cookie for authorization;
- lists and mints only through stock `/admin/users/{user_id}/tokens`;
- accepts exactly `scopes: string[]`, optional string `name`, and optional positive integer `expires_in`;
- rejects identity fields, aliases, strings, wrong types, and unknown fields with typed 422 before Admin HTTP;
- treats listed keys as secret-free metadata; a newly minted secret is shown only once;
- renders structured FastAPI validation details as actionable text without leaking the `input` value.

No by-email lookup/upsert exists in Account operations. No Admin API/core, package manifest/lock, #937-owned file, image, stage, prod, or release record changed in this PR.

## Evidence

Expected-red on the base reproduced the stock incompatibility. After the first source draft, independent review additionally found and stopped an unbound cookie identity and a retained legacy request adapter before any image build.

Final exact-head evidence:

- token-A / forged-cookie-B identity negative: GREEN; cookie B is never read;
- canonical request plus nine fail-before-network shape/type negatives: GREEN;
- focused identity/stock-contract/presenter suite: **21/21**;
- full dashboard suite: **74/74**;
- generated version + TypeScript: GREEN;
- changed-file lint: zero errors;
- production Next build: GREEN, **59/59** static pages;
- `git diff --check`: GREEN.

## Remaining delivery gates

1. Build and read back one immutable `vexaai/dashboard` linux/amd64 digest from merged commit `67aeec3b…`.
2. Isolated hosted preview: real token-bound Account read, secret-free list, exactly one key mint/copy, metadata re-read, typed negative, and secret absent from logs.
3. Independently review the one-Deployment dashboard rollout and rollback/continuity receipt.
4. Roll production `Deployment/vexa-platform-dashboard` only, then reproduce #942 green and hold for fresh 404/422/log signatures.
