### PR TITLE
fix(lifecycle): await lobby withdrawal before teardown

### DIFF
--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -592,7 +592,7 @@
    "unique-id": "lifecycle.v1",
    "node-type": "contract",
    "name": "lifecycle.v1",
-   "description": "lifecycle.v1 — sealed/published contract (meetings)",
+   "description": "lifecycle.v1 — sealed/published bot-status contract, including durable lobby-withdrawal acknowledgement before runtime deletion (meetings)",
    "metadata": [
     {
      "path": "core/meetings/contracts/lifecycle.v1",

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "79bdb30d31ae5d36ee6078340d4ec8eabe2c767497d6c19e015437ecf0b1db4d"
+  "architecture.calm.json": "5782cd22ee82a0a526412b6d8de0e33b2c04089829c7642540ba29836a5368bd"
 }

--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -16,7 +16,7 @@
   "core/meetings/contracts/captured-signal.v1": "d811ef322aa50dcb95d879c3fab712902c0538eb49f94dc2b4e63964534cbf34",
   "core/meetings/contracts/flagged-issue.v1": "4b868f57298131f8eec8246d86d57251f259927d8bfd7df5a0f6016a10f16211",
   "core/meetings/contracts/invocation.v1": "c7d7f6b95f11da595d0a9e27a429774cdefcc997831cbedff061ebcc2aafbbb8",
-  "core/meetings/contracts/lifecycle.v1": "95392746da49c7c61ec81863e6b836af5acb879f979918753fc8fcf92583b820",
+  "core/meetings/contracts/lifecycle.v1": "5b4cbe39d6f1cd423d83afca6d8d7ee842bd889350474f8e997db756847f4768",
   "core/meetings/contracts/transcript.v1": "7d07d0fbac77f6562af64ae6c6286051e0e07763f427347d4e7b7735eaa0f9c8",
   "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",
   "core/runtime/contracts/runtime.v1": "9d67b9379e0d34c4d715764a467e7f6e6543a5db8177fc284fb4a7418067bc18",

--- a/core/meetings/contracts/lifecycle.v1/README.md
+++ b/core/meetings/contracts/lifecycle.v1/README.md
@@ -23,5 +23,9 @@ impl enforces it (lean: no separate harness, B8).
 ## Shape
 `LifecycleEvent` (`$defs`): `connection_id` + `status` always; state-dependent `reason · exit_code ·
 completion_reason · failure_stage · bot_logs · bot_resources · speaker_events` (terminal forensics).
+For a pre-active user Stop, the terminal carries `withdrawal`: a typed acknowledgement with the
+platform cancellation/page-close evidence and duration. The control plane persists that
+acknowledgement before it may delete the workload; absence of the acknowledgement takes the
+separately typed bounded-timeout path and is never reported as graceful success.
 
 No auth token (transport-layer), no tenancy fields (deferred). Goldens validated by `gate:schema`.

--- a/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.failed-withdrawn.json
+++ b/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.failed-withdrawn.json
@@ -1,0 +1,16 @@
+{
+  "connection_id": "sess-lobby-stop",
+  "container_id": "mtg-839-bot",
+  "status": "failed",
+  "failure_stage": "awaiting_admission",
+  "completion_reason": "stopped",
+  "reason": "stopped while awaiting admission (withdrew the join request)",
+  "exit_code": 0,
+  "withdrawal": {
+    "status": "completed",
+    "completed_at": "2026-07-24T08:45:00Z",
+    "duration_ms": 413,
+    "cancel_attempted": true,
+    "page_closed": true
+  }
+}

--- a/core/meetings/contracts/lifecycle.v1/lifecycle.schema.json
+++ b/core/meetings/contracts/lifecycle.v1/lifecycle.schema.json
@@ -15,6 +15,19 @@
       "description": "Furthest stage reached, for `failed` attribution.",
       "enum": ["requested", "joining", "awaiting_admission", "active"]
     },
+    "WithdrawalAcknowledgement": {
+      "description": "Durable proof that a pre-active Stop completed the platform withdrawal before workload deletion. Emitted only after the cancellation attempt and page close have finished; the control plane persists this object before invoking runtime deletion.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "completed_at", "duration_ms", "cancel_attempted", "page_closed"],
+      "properties": {
+        "status": { "const": "completed" },
+        "completed_at": { "type": "string", "format": "date-time" },
+        "duration_ms": { "type": "integer", "minimum": 0, "maximum": 10000 },
+        "cancel_attempted": { "type": "boolean" },
+        "page_closed": { "const": true }
+      }
+    },
     "LifecycleEvent": {
       "description": "One status report. connection_id + status always present; the rest are state-dependent (forensics on terminal states). LIBERAL ingestion (additionalProperties:true): the control plane validates the core shape but TOLERATES extra fields the real bot emits, matching main's pydantic ignore-extras — the carve's earlier additionalProperties:false rejected the bot's real callbacks.",
       "type": "object",
@@ -28,6 +41,7 @@
         "exit_code": { "type": "integer", "description": "terminal only" },
         "completion_reason": { "$ref": "#/$defs/CompletionReason" },
         "failure_stage": { "$ref": "#/$defs/FailureStage" },
+        "withdrawal": { "$ref": "#/$defs/WithdrawalAcknowledgement" },
         "bot_logs": { "type": "array", "items": { "type": "string" }, "description": "terminal: ring buffer of log lines" },
         "bot_resources": {
           "type": "object",

--- a/core/meetings/services/bot/src/README.md
+++ b/core/meetings/services/bot/src/README.md
@@ -11,9 +11,9 @@ types; transports are adapters wired at the composition root.
 | `config.ts` | `invocation.v1` boot config — parse + ajv-validate `VEXA_BOT_CONFIG`, fail-fast (P14). Exports the typed `Invocation`. |
 | `ports.ts` | the port interfaces the core depends on: `JoinDriver · Pipeline · TranscriptSink · LifecycleSink · ActsSource · RecordingSink`. Pure (no transport types). |
 | `test-doubles.ts` | shared L2 port doubles (`noopAloneness`, `noopActs`, `noopPipeline`, …) — one export site for every orchestrator construction in tests. |
-| `orchestrator.ts` | the `lifecycle.v1` state machine (`createOrchestrator`) — joining → awaiting_admission → active → (completed \| failed). Depends only on ports. |
+| `orchestrator.ts` | the `lifecycle.v1` state machine (`createOrchestrator`) — joining → awaiting_admission → active → (completed \| failed). A Stop while awaiting admission completes platform withdrawal and durably reports that acknowledgement before exit. Depends only on ports. |
 | `contracts.ts` | TS mirrors of the published `lifecycle.v1 · acts.v1 · transcript.v1` schemas + the executable `canTransition` machine. |
-| `join-driver.ts` | **JoinDriver** — wraps `@vexa/join` `joinMeeting`/leave/removal (guest + authenticated); maps `JoinState`→`BotStatus`. |
+| `join-driver.ts` | **JoinDriver** — wraps `@vexa/join` `joinMeeting`/leave/removal (guest + authenticated); maps `JoinState`→`BotStatus`; reports cancellation-attempt/page-close evidence for lobby withdrawal. |
 | `pipeline.ts` | **Pipeline** — `google_meet`→`@vexa/gmeet-pipeline` (per-channel, glow-named) · `zoom`/`teams`→`@vexa/mixed-pipeline`; STT via `@vexa/transcribe-whisper`; lane sink → bot `TranscriptSink.publish`. Exposes `feedAudio`. |
 | `recording.ts` | **RecordingSink** — `@vexa/recording` assembler (`buildRecordingMaster` on `is_final`/`close`) → upload (`RecordingService`). |
 | `capture-bridge.ts` | **L4-pending (O6)** — browser launch (+ S3 auth profile), page-side capture inject + PCM pump → `pipeline.feedAudio`, and the speak controller. Browser-resident; not unit-provable — validated on the VM. |

--- a/core/meetings/services/bot/src/adapters/lifecycle-http.test.ts
+++ b/core/meetings/services/bot/src/adapters/lifecycle-http.test.ts
@@ -94,6 +94,29 @@ async function main(): Promise<void> {
     check('permanent-5xx: bounded to `retries` attempts', calls.length === 2, String(calls.length));
   }
 
+  // ── #839 durable acknowledgement: only a 2xx earns "persisted" ──
+  {
+    let n = 0;
+    const fetchImpl: FetchLike = async () => {
+      n++;
+      return n === 2 ? { ok: true, status: 200 } : { ok: false, status: 503 };
+    };
+    const sink = createHttpLifecycleSink({
+      callbackUrl: 'http://cb', fetchImpl, retries: 2, sleep: noSleep,
+    });
+    const verdict = await sink.emitDurable!(EVENT);
+    check('durable: a later 2xx confirms persisted', verdict === 'persisted', verdict);
+    check('durable: confirmation used the bounded retry path', n === 2, String(n));
+  }
+  {
+    const fetchImpl: FetchLike = async () => { throw new Error('network down'); };
+    const sink = createHttpLifecycleSink({
+      callbackUrl: 'http://cb', fetchImpl, retries: 2, sleep: noSleep,
+    });
+    const verdict = await sink.emitDurable!(EVENT);
+    check('durable: no response remains unconfirmed', verdict === 'unconfirmed', verdict);
+  }
+
   // ── default horizon: 5 attempts × 500ms exponential base (≈7.5s) — a >1s meeting-api blip
   //    must not lose the event (hosted 07-14→07-17: the old ~0.6s horizon dropped callbacks and
   //    the reaper failed seated bots) ──

--- a/core/meetings/services/bot/src/adapters/lifecycle-http.ts
+++ b/core/meetings/services/bot/src/adapters/lifecycle-http.ts
@@ -90,6 +90,25 @@ export function createHttpLifecycleSink(opts: HttpLifecycleSinkOptions): Lifecyc
     );
   }
 
+  async function emitDurable(event: LifecycleEvent): Promise<'persisted' | 'unconfirmed'> {
+    const body = JSON.stringify(event);
+    let lastErr: string | undefined;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        const res = await fetchImpl(callbackUrl, { method: 'POST', headers, body });
+        if (res.ok) return 'persisted';
+        lastErr = `HTTP ${res.status}`;
+      } catch (e) {
+        lastErr = (e as Error)?.message ?? String(e);
+      }
+      if (attempt < attempts) await sleep(backoffMs * 2 ** (attempt - 1));
+    }
+    console.error(
+      `[bot] lifecycle.v1 durable ${event.status} POST unconfirmed after ${attempts} attempt(s): ${lastErr ?? 'unknown'}`,
+    );
+    return 'unconfirmed';
+  }
+
   // The reachability gate's first-emit probe (#530). Emits the (joining) event AND reports whether
   // the primary channel is REACHABLE. Any HTTP response — 2xx OR non-2xx — proves the channel is
   // up (P18) and returns `reachable` immediately (near-zero latency on the fast path). Only when
@@ -114,5 +133,5 @@ export function createHttpLifecycleSink(opts: HttpLifecycleSinkOptions): Lifecyc
     return 'unreachable';
   }
 
-  return { emit, emitReachable };
+  return { emit, emitDurable, emitReachable };
 }

--- a/core/meetings/services/bot/src/contracts.ts
+++ b/core/meetings/services/bot/src/contracts.ts
@@ -34,6 +34,14 @@ export type CompletionReason =
 
 export type FailureStage = 'requested' | 'joining' | 'awaiting_admission' | 'active';
 
+export interface WithdrawalAcknowledgement {
+  status: 'completed';
+  completed_at: string;
+  duration_ms: number;
+  cancel_attempted: boolean;
+  page_closed: true;
+}
+
 /** One lifecycle.v1 status report. `connection_id` + `status` always; the rest are
  *  state-dependent terminal forensics. Mirrors `#/$defs/LifecycleEvent`. */
 export interface LifecycleEvent {
@@ -44,6 +52,7 @@ export interface LifecycleEvent {
   exit_code?: number;
   completion_reason?: CompletionReason;
   failure_stage?: FailureStage;
+  withdrawal?: WithdrawalAcknowledgement;
   bot_logs?: string[];
   bot_resources?: { peak_memory_bytes?: number; cpu_usage_usec?: number; [k: string]: unknown };
   speaker_events?: unknown[];

--- a/core/meetings/services/bot/src/join-driver.test.ts
+++ b/core/meetings/services/bot/src/join-driver.test.ts
@@ -8,7 +8,7 @@
  * Run: tsx src/join-driver.test.ts
  */
 import { AdmissionError, AuthSessionError, TeamsJoinRedirectError, TEAMS_AUTH_REDIRECT } from '@vexa/join';
-import { admissionOutcomeToJoinOutcome } from './join-driver.js';
+import { admissionOutcomeToJoinOutcome, createBrowserJoinDriver } from './join-driver.js';
 import type { JoinOutcome } from './ports.js';
 
 let passed = 0, failed = 0;
@@ -58,6 +58,24 @@ check('TeamsJoinRedirectError is NOT an AdmissionError (driver re-raises → mes
   !(teamsRedirect instanceof AdmissionError));
 check('TeamsJoinRedirectError carries the typed reasonCode in its message',
   teamsRedirect.message.startsWith(`${TEAMS_AUTH_REDIRECT}:`));
+
+let pageClosed = false;
+const page = {
+  isClosed: () => pageClosed,
+  close: async () => { pageClosed = true; },
+};
+const driver = createBrowserJoinDriver(page as never, {
+  platform: 'google_meet',
+  meetingUrl: 'https://meet.google.com/abc-defg-hij',
+  botName: 'Vexa',
+  redisUrl: 'redis://redis:6379',
+  connectionId: 'sess-withdraw',
+  nativeMeetingId: 'abc-defg-hij',
+} as never);
+const withdrawal = await driver.withdraw('stopped');
+check('withdraw closes the pre-join page', pageClosed);
+check('withdraw returns evidence only after page close',
+  withdrawal?.cancelAttempted === true && withdrawal.pageClosed === true);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/core/meetings/services/bot/src/join-driver.ts
+++ b/core/meetings/services/bot/src/join-driver.ts
@@ -109,7 +109,9 @@ export function createBrowserJoinDriver(page: Page, inv: Invocation): JoinDriver
       //     (just "Asking to join…"), so closing the tab is the reliable way to abandon the request;
       //     it is also the universal fallback if the cancel click missed. Closing the page after the
       //     click is harmless (the click already fired).
+      let cancelAttempted = false;
       try {
+        cancelAttempted = true;
         if (platform === 'teams')      await leaveMicrosoftTeams(page, undefined, reason);
         else if (platform === 'zoom')  await leaveZoomMeeting(page, undefined, reason);
         else if (platform === 'jitsi') await leaveJitsiMeeting(page, undefined, reason);
@@ -118,6 +120,7 @@ export function createBrowserJoinDriver(page: Page, inv: Invocation): JoinDriver
       try {
         if (!page.isClosed()) await page.close({ runBeforeUnload: false });
       } catch { /* best-effort */ }
+      return { cancelAttempted, pageClosed: page.isClosed() };
     },
   };
 }

--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -73,7 +73,11 @@ const lobbyBlockingJoin = () => {
     async join(report) { await report('awaiting_admission'); return new Promise<JoinOutcome>(() => { /* never resolves */ }); },
     onRemoval() { return () => { /* */ }; },
     async leave() { calls.leave++; },
-    async withdraw(reason) { calls.withdraw++; calls.withdrawReason = reason; },
+    async withdraw(reason) {
+      calls.withdraw++;
+      calls.withdrawReason = reason;
+      return { cancelAttempted: true, pageClosed: true };
+    },
   };
   return { driver, calls };
 };
@@ -415,8 +419,34 @@ async function main(): Promise<void> {
     check('withdraw: reason forwarded to the withdraw', calls.withdrawReason === 'stopped', calls.withdrawReason);
     check('withdraw: reached awaiting_admission then terminated (no active)', seq(lc.events).includes('awaiting_admission') && !seq(lc.events).includes('active'), JSON.stringify(seq(lc.events)));
     check('withdraw: terminal failed(awaiting_admission / stopped), exit 0', res.status === 'failed' && res.exitCode === 0 && last(lc.events).failure_stage === 'awaiting_admission' && last(lc.events).completion_reason === 'stopped', JSON.stringify(last(lc.events)));
+    check('withdraw: terminal carries durable-order acknowledgement evidence',
+      last(lc.events).withdrawal?.status === 'completed'
+      && last(lc.events).withdrawal.page_closed === true
+      && last(lc.events).withdrawal.duration_ms <= 10_000,
+      JSON.stringify(last(lc.events).withdrawal));
     check('withdraw: sequence legal + conforms', allLegal(seq(lc.events)) && allConform(lc.events), ajv.errorsText(validateLifecycle.errors));
     check('withdraw: did NOT SIGKILL-orphan — the run resolved on its own (no watchdog needed)', true);
+  }
+
+  // A page close without a control-plane 2xx is not a durable acknowledgement. The bot reports a
+  // non-zero result and leaves the pending control-plane timer to persist the typed fallback.
+  {
+    const events: LifecycleEvent[] = [];
+    const lifecycle: LifecycleSink = {
+      async emit(e) { events.push(e); },
+      async emitDurable(e) { events.push(e); return 'unconfirmed'; },
+    };
+    const { driver } = lobbyBlockingJoin();
+    const o = createOrchestrator(inv(), {
+      lifecycle, join: driver, pipeline: noopPipeline(),
+      acts: noopActs(), aloneness: noopAloneness(),
+    });
+    const runP = o.run();
+    setTimeout(() => o.stop(), 5);
+    const res = await runP;
+    check('withdraw-unconfirmed: no false graceful-success exit',
+      res.exitCode === 1 && last(events).withdrawal?.status === 'completed',
+      JSON.stringify({ res, event: last(events) }));
   }
 
   // ── #889: a `leave` ACT delivered while BLOCKED in the lobby (awaiting_admission) → WITHDRAW ──

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -105,6 +105,7 @@ export interface RunOptions {
 
 export const DEFAULT_PIPELINE_STOP_TIMEOUT_MS = 9_000;
 export const PLATFORM_LEAVE_TIMEOUT_MS = 8_000;
+export const PRE_ACTIVE_WITHDRAW_TIMEOUT_MS = 8_000;
 
 /** Required ports — missing any of these used to surface as a raw TypeError deep in `run()`. */
 const REQUIRED_PORTS = ['lifecycle', 'join', 'pipeline', 'acts', 'aloneness'] as const;
@@ -161,7 +162,11 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
 
   let cur: BotStatus = 'joining';
 
-  const emit = async (status: BotStatus, extra: Partial<LifecycleEvent> = {}): Promise<void> => {
+  const emit = async (
+    status: BotStatus,
+    extra: Partial<LifecycleEvent> = {},
+    durable = false,
+  ): Promise<'persisted' | 'unconfirmed'> => {
     if (status !== cur && !canTransition(cur, status)) {
       throw new Error(`lifecycle.v1: illegal transition ${cur} → ${status}`);
     }
@@ -173,7 +178,10 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
     if (isTerminal(status) && deps.degraded) {
       try { degraded = deps.degraded(); } catch { degraded = undefined; }
     }
-    await deps.lifecycle.emit({ ...base, status, ...extra, ...(degraded ?? {}) });
+    const event = { ...base, status, ...extra, ...(degraded ?? {}) };
+    if (durable && deps.lifecycle.emitDurable) return deps.lifecycle.emitDurable(event);
+    await deps.lifecycle.emit(event);
+    return 'persisted';
   };
 
   // The load-bearing FIRST emit (#530). `cur` is already `joining` (the initial state), so this
@@ -249,7 +257,7 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
     // than silently dropping it.
     let reportChain: Promise<void> = Promise.resolve();
     const report = (s: BotStatus): Promise<void> => {
-      reportChain = reportChain.then(() => emit(s)).catch((e) => {
+      reportChain = reportChain.then(async () => { await emit(s); }).catch((e) => {
         console.error(`[bot] lifecycle report '${s}' rejected: ${String(e)}`);
       });
       return reportChain;
@@ -277,17 +285,59 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
         // request is dropped — bounded + best-effort (the platform withdraw itself caps its clicks;
         // the guaranteed fallback closes the page). The bot never reached active, so the terminal is
         // `failed` (stage = the pre-active stage it was stopped in), attributed to the user stop.
-        await Promise.race([
-          deps.join.withdraw('stopped').catch(() => { /* best-effort */ }),
-          new Promise<void>((resolve) => setTimeout(resolve, 8000)),
-        ]);
+        const withdrawStartedAt = Date.now();
+        let withdrawTimer: ReturnType<typeof setTimeout> | null = null;
+        const withdrawSettled = deps.join.withdraw('stopped').then(
+          (evidence) => ({ kind: 'finished' as const, evidence }),
+          (error: unknown) => ({ kind: 'fault' as const, error }),
+        );
+        const withdrawDeadline = new Promise<{ kind: 'timeout' }>((resolve) => {
+          withdrawTimer = setTimeout(
+            () => resolve({ kind: 'timeout' }),
+            PRE_ACTIVE_WITHDRAW_TIMEOUT_MS,
+          );
+        });
+        const withdrawal = await Promise.race([withdrawSettled, withdrawDeadline]);
+        if (withdrawTimer) clearTimeout(withdrawTimer);
+        const durationMs = Math.min(10_000, Math.max(0, Date.now() - withdrawStartedAt));
         const stage = cur === 'awaiting_admission' ? 'awaiting_admission' : 'joining';
+        if (
+          withdrawal.kind === 'finished'
+          && withdrawal.evidence?.pageClosed === true
+        ) {
+          const persisted = await emit('failed', {
+            failure_stage: stage,
+            completion_reason: 'stopped',
+            reason: 'stopped while awaiting admission (withdrew the join request)',
+            exit_code: 0,
+            withdrawal: {
+              status: 'completed',
+              completed_at: new Date().toISOString(),
+              duration_ms: durationMs,
+              cancel_attempted: withdrawal.evidence.cancelAttempted,
+              page_closed: true,
+            },
+          }, true);
+          unsubscribe();
+          return {
+            exitCode: persisted === 'persisted' ? 0 : 1,
+            status: 'failed',
+            completionReason: 'stopped',
+          };
+        }
+        const withdrawalFailure = withdrawal.kind === 'timeout'
+          ? `withdrawal did not finish within ${PRE_ACTIVE_WITHDRAW_TIMEOUT_MS}ms`
+          : `withdrawal did not confirm page close: ${
+              withdrawal.kind === 'fault' ? String(withdrawal.error) : 'page remained open'
+            }`;
         await emit('failed', {
-          failure_stage: stage, completion_reason: 'stopped',
-          reason: 'stopped while awaiting admission (withdrew the join request)', exit_code: 0,
+          failure_stage: stage,
+          completion_reason: 'stopped',
+          reason: `stopped while awaiting admission; ${withdrawalFailure}`,
+          exit_code: 1,
         });
         unsubscribe();
-        return { exitCode: 0, status: 'failed', completionReason: 'stopped' };
+        return { exitCode: 1, status: 'failed', completionReason: 'stopped' };
       }
       outcome = raced.result.outcome;
       joinReason = raced.result.reason;

--- a/core/meetings/services/bot/src/ports.ts
+++ b/core/meetings/services/bot/src/ports.ts
@@ -45,7 +45,12 @@ export interface JoinDriver {
   /** Withdraw a PENDING join request from the waiting room / pre-join screen (Bug 2): cancel the
    *  ask-to-join (Teams/Meet have a Cancel affordance) and, as a guaranteed drop, close the page so
    *  the request is abandoned even where no cancel button is reachable. Best-effort; never throws. */
-  withdraw(reason: string): Promise<void>;
+  withdraw(reason: string): Promise<WithdrawalEvidence | void>;
+}
+
+export interface WithdrawalEvidence {
+  cancelAttempted: boolean;
+  pageClosed: boolean;
 }
 
 /** The capture → lane → STT → transcript/recording engine. The orchestrator starts/stops
@@ -73,6 +78,10 @@ export type PrimaryReachability = 'reachable' | 'unreachable';
  *  adapter POSTs to meeting-api's callback; the L2 fake records the sequence to assert. */
 export interface LifecycleSink {
   emit(event: LifecycleEvent): Promise<void>;
+  /** A lifecycle callback whose HTTP 2xx is part of the value contract. Unlike ordinary best-effort
+   *  status reports, a pre-active withdrawal acknowledgement is not "completed" unless the control
+   *  plane confirmed it was durably accepted. */
+  emitDurable?(event: LifecycleEvent): Promise<'persisted' | 'unconfirmed'>;
   /** Emit the LOAD-BEARING first `joining` event AND report whether the primary control-plane
    *  channel is reachable — the reachability gate (#530, P18). Reachable ⇒ the orchestrator
    *  proceeds with ZERO added latency (the secondary channel is never probed). OPTIONAL: sinks

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import FastAPI, Request
@@ -233,8 +234,16 @@ def create_app(
     app.state.delivery_ledger = delivery_ledger
     # The lifecycle callback publishes each persisted FSM advance to bm:meeting:{id}:status so the
     # gateway /ws (which SUBSCRIBEs that channel) forwards a ws.v1 BotStatus frame to the dashboard.
-    _mount_lifecycle(app, sink, meeting_repo, webhook_sink, redis, transcript_finalizer,
-                     delivery_ledger)
+    _mount_lifecycle(
+        app,
+        sink,
+        meeting_repo,
+        webhook_sink,
+        redis,
+        transcript_finalizer,
+        delivery_ledger,
+        runtime,
+    )
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
     app.include_router(_bot_spawn.build_router(meeting_repo, runtime))
@@ -319,6 +328,7 @@ def _mount_lifecycle(
     redis: "object" = None,
     transcript_finalizer: "object" = None,
     delivery_ledger: "object" = None,
+    runtime: "object" = None,
 ) -> None:
     """Register the lifecycle.v1 callback route on the unified app (the lifecycle receiver's
     ``/bots/internal/callback/lifecycle`` handler, sharing the app's TraceMiddleware).
@@ -464,6 +474,59 @@ def _mount_lifecycle(
             except Exception as e:  # noqa: BLE001 — persistence is best-effort
                 log_event("lifecycle_persist_failed", audience="system", level="warning",
                           span="lifecycle.callback", fields={"error": str(e)})
+        # #839 PRE-ACTIVE WITHDRAWAL ORDERING. A bot may earn this acknowledgement only after its
+        # platform cancellation/page close completed. Persist the typed acknowledgement through an
+        # atomic pending→completed compare-and-set, then and only then ask runtime to delete the
+        # workload. The timeout path races on the same durable CAS; exactly one winner deletes.
+        withdrawal = body.get("withdrawal")
+        if (
+            isinstance(withdrawal, dict)
+            and withdrawal.get("status") == "completed"
+            and connection_id
+            and hasattr(meeting_repo, "finalize_withdrawal")
+        ):
+            try:
+                acknowledged_row = await meeting_repo.finalize_withdrawal(
+                    session_uid=connection_id,
+                    expected_status="pending",
+                    outcome={
+                        **withdrawal,
+                        "acknowledged_at": datetime.now(timezone.utc)
+                        .isoformat()
+                        .replace("+00:00", "Z"),
+                    },
+                )
+            except Exception as e:  # noqa: BLE001 — no persistence means no delete
+                acknowledged_row = None
+                log_event(
+                    "withdrawal_ack_persist_failed",
+                    audience="system",
+                    level="error",
+                    span="lifecycle.callback",
+                    fields={
+                        "meeting_id": meeting_row.get("id")
+                        if isinstance(meeting_row, dict) else None,
+                        "error": str(e),
+                    },
+                )
+            if isinstance(acknowledged_row, dict):
+                meeting_row = acknowledged_row
+                workload_id = acknowledged_row.get("bot_container_id")
+                if runtime is not None and workload_id:
+                    try:
+                        await runtime.delete_workload(workload_id)
+                    except Exception as e:  # noqa: BLE001 — ack stays durable; reconcile owns retry
+                        log_event(
+                            "withdrawal_ack_teardown_failed",
+                            audience="system",
+                            level="warning",
+                            span="lifecycle.callback",
+                            fields={
+                                "meeting_id": acknowledged_row.get("id"),
+                                "workload_id": workload_id,
+                                "error": str(e),
+                            },
+                        )
         # COMPLETION FINALIZATION — the moment the FSM lands on a terminal status, flush the
         # meeting's remaining live redis segments to the durable store (threshold 0: the mutable
         # tail included, no more updates are coming) and persist the processed doc into
@@ -576,7 +639,6 @@ def _mount_lifecycle(
             meeting_id = meeting_row.get("id")
             if meeting_id is not None:
                 import json as _json
-                from datetime import datetime, timezone
 
                 frame = {
                     "type": "meeting.status",

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -267,6 +267,38 @@ class SqlAlchemyMeetingRepo:
             # meeting.data (and the stop route gets a clean dict) without a second query.
             return _row_to_dict(m)
 
+    async def finalize_withdrawal(
+        self, *, session_uid, expected_status, outcome
+    ) -> Optional[dict]:
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from ..sessions.models import Meeting, MeetingSession
+
+        async with self._session_factory() as db:
+            sess = (
+                await db.execute(select(MeetingSession).where(MeetingSession.session_uid == session_uid))
+            ).scalars().first()
+            if sess is None:
+                return None
+            m = (
+                await db.execute(
+                    select(Meeting).where(Meeting.id == sess.meeting_id).with_for_update()
+                )
+            ).scalars().first()
+            if m is None:
+                return None
+            data = dict(m.data) if isinstance(m.data, dict) else {}
+            current = data.get("withdrawal")
+            if not isinstance(current, dict) or current.get("status") != expected_status:
+                return None
+            data["withdrawal"] = {**current, **dict(outcome)}
+            m.data = data
+            flag_modified(m, "data")
+            await db.commit()
+            await db.refresh(m)
+            return _row_to_dict(m)
+
     async def count_active_bots(self, *, user_id, exclude_meeting_id=None) -> int:
         from sqlalchemy import func, select
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -253,6 +253,19 @@ class InMemoryMeetingRepo:
             row["data"][k] = v
         return dict(row)
 
+    async def finalize_withdrawal(self, *, session_uid, expected_status, outcome) -> Optional[dict]:
+        sess = next((s for s in self.sessions if s["session_uid"] == session_uid), None)
+        if sess is None:
+            return None
+        row = self._meetings.get(sess["meeting_id"])
+        if row is None:
+            return None
+        current = row.get("data", {}).get("withdrawal")
+        if not isinstance(current, dict) or current.get("status") != expected_status:
+            return None
+        row["data"]["withdrawal"] = {**current, **dict(outcome)}
+        return dict(row)
+
     async def count_active_bots(self, *, user_id, exclude_meeting_id=None) -> int:
         return sum(
             1 for m in self._meetings.values()

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
@@ -154,6 +154,17 @@ class MeetingRepo(Protocol):
         in-process ``MeetingStore``."""
         ...
 
+    async def finalize_withdrawal(
+        self, *, session_uid: str, expected_status: str, outcome: dict
+    ) -> Optional[dict]:
+        """Atomically replace ``meeting.data.withdrawal`` only while its status matches
+        ``expected_status`` and return the updated meeting.
+
+        The bot acknowledgement and the bounded timeout race on this compare-and-set. Exactly one
+        winner persists its typed outcome before it is allowed to invoke runtime deletion; the
+        loser observes ``None`` and performs no teardown."""
+        ...
+
 
 @runtime_checkable
 class RuntimeClient(Protocol):

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/README.md
@@ -36,6 +36,13 @@ parent's FM-003 discipline). `active → joining` (and any re-open of a terminal
 - `stop.py` (P3b) — the user-stop path: `request_stop(record, publisher, meeting_id)` sets
   `stop_requested` + publishes the `bot_commands:meeting:{id}` `{action:"leave"}` command;
   `classify_user_stop` / `stop_event_for` resolve the bot's exit to an ATTRIBUTED terminal.
+- `stop_router.py` — the API Stop composition. For a bot that has reported
+  `awaiting_admission`, it persists `withdrawal.status=pending`, publishes `leave`, and waits for
+  the bot's typed cancellation/page-close acknowledgement. The callback atomically persists
+  `completed` before runtime deletion. A missing acknowledgement atomically becomes `timed_out`
+  before the bounded 24-second capacity fallback deletes the workload. `requested`/`joining`
+  retain direct teardown because those states do not prove the bot subscribed to the command
+  channel; active stops retain the normal recording-finalization path.
 - `retry.py` (P3d) — `JoinRetryController` + the transient/permanent taxonomy
   (`classify_retry` / `is_transient`): on a TRANSIENT join-failure schedule a fresh re-spawn (a new
   `meeting_session`) through the runtime scheduler with bounded exponential backoff; a PERMANENT

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/stop_router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/stop_router.py
@@ -17,7 +17,9 @@ injects the real ``redis_client.publish``.
 """
 from __future__ import annotations
 
+import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Protocol, runtime_checkable
 
 from fastapi import APIRouter, Header, HTTPException
@@ -61,6 +63,13 @@ def _resolve_user_id(x_user_id: Optional[str]) -> int:
 # workload down directly. An `active`/`needs_help` bot IS listening → trust the graceful leave (so it
 # finalizes its recording cleanly); the reconcile loop is the backstop if it never completes.
 _BOOTING_STATUSES = {"requested", "joining", "awaiting_admission"}
+# Only ``awaiting_admission`` proves both facts the graceful handshake requires: the bot subscribed
+# to acts before entering join(), and a host-visible knock may exist. ``requested``/``joining`` do
+# not confirm a listener; preserving their direct P22 delete prevents a Stop from being lost while
+# a bot continues booting into the meeting.
+_WITHDRAWAL_STATUSES = {"awaiting_admission"}
+WITHDRAWAL_SLA_SECONDS = 10
+WITHDRAWAL_TIMEOUT_SECONDS = 24
 
 # The sealed api.v1 `Platform` enum — the DELETE path param is typed as this enum in the contract, so an
 # unsupported platform is a VALIDATION error (422), not a missing-resource (404). Mirrors the POST /bots
@@ -120,12 +129,40 @@ def build_stop_router(repo: MeetingRepo, publisher: CommandPublisher, runtime=No
         # workload is torn down directly below, and the terminal is attributed to the stage it really
         # reached.
         sessions = await repo.list_sessions(meeting_id=meeting_id)
-        if sessions:
+        session_uid = sessions[-1] if sessions else None
+        withdrawal = None
+        if status in _WITHDRAWAL_STATUSES and session_uid:
+            requested_at = datetime.now(timezone.utc)
+            withdrawal = {
+                "status": "pending",
+                "requested_at": requested_at.isoformat().replace("+00:00", "Z"),
+                "deadline_at": (
+                    requested_at + timedelta(seconds=WITHDRAWAL_TIMEOUT_SECONDS)
+                ).isoformat().replace("+00:00", "Z"),
+                "sla_seconds": WITHDRAWAL_SLA_SECONDS,
+                "timeout_seconds": WITHDRAWAL_TIMEOUT_SECONDS,
+            }
+        if session_uid:
             await repo.update_meeting_status(
-                session_uid=sessions[-1],
+                session_uid=session_uid,
                 status=status if status in _BOOTING_STATUSES else "stopping",
-                data={"stop_requested": True},
+                data={
+                    "stop_requested": True,
+                    **({"withdrawal": withdrawal} if withdrawal is not None else {}),
+                },
             )
+        # The timeout is a capacity guarantee, not graceful success. Schedule it from the durable
+        # pending row before touching redis: even a command-bus outage still converges to the typed
+        # timeout outcome and a bounded delete. The deterministic oracle calls
+        # ``enforce_withdrawal_timeout`` directly with a fake time; it never proves ordering by sleep.
+        if withdrawal is not None and runtime is not None and bot_container_id:
+            task = asyncio.create_task(
+                _withdrawal_timeout_task(
+                    repo, runtime, session_uid, meeting_id, bot_container_id
+                ),
+                name=f"withdrawal-timeout-{meeting_id}",
+            )
+            task.add_done_callback(_consume_timeout_task)
         # Publish the leave command — an ACTIVE (listening) bot honours it, leaves, emits its terminal event.
         # #809: this is a GENUINELY Redis-dependent path (pub/sub is the only delivery). During a Redis
         # outage it must fail NARROWLY per-request (503, retryable) — not as an opaque 500 stack trace,
@@ -144,13 +181,18 @@ def build_stop_router(repo: MeetingRepo, publisher: CommandPublisher, runtime=No
                 detail="stop command bus (redis) unavailable; the stop is recorded and will "
                        "reconcile when redis returns — retry to re-issue the leave",
             ) from e
-        # GUARANTEE no orphan: a stop must not rely solely on a fire-and-forget command the bot may never
-        # receive. A BOOTING bot (status in _BOOTING_STATUSES) has likely not subscribed yet → directly
-        # tear its workload down (it has nothing to finalize). Best-effort: logged, never fails the stop.
-        if runtime is not None and bot_container_id and status in _BOOTING_STATUSES:
+        # P22 remains the guarantee for a consumer not yet confirmed listening. There cannot be a
+        # host-visible lobby knock in ``requested``; ``joining`` has not emitted the subscribed
+        # waiting-room status yet. Delete these directly so a lost pub/sub command cannot let a
+        # stopped bot proceed into the meeting.
+        if (
+            runtime is not None
+            and bot_container_id
+            and status in (_BOOTING_STATUSES - _WITHDRAWAL_STATUSES)
+        ):
             try:
                 await runtime.delete_workload(bot_container_id)
-            except Exception as e:  # noqa: BLE001 — teardown is best-effort; the reconcile loop backstops
+            except Exception as e:  # noqa: BLE001 — reconcile backstops and logs
                 _log_stop_teardown_failed(meeting_id, bot_container_id, e)
         return {
             "status": "stopping",
@@ -159,6 +201,66 @@ def build_stop_router(repo: MeetingRepo, publisher: CommandPublisher, runtime=No
         }
 
     return router
+
+
+async def enforce_withdrawal_timeout(
+    repo: MeetingRepo,
+    runtime: Any,
+    *,
+    session_uid: str,
+    meeting_id: Any,
+    workload_id: str,
+    timed_out_at: Optional[datetime] = None,
+) -> bool:
+    """Persist the typed timeout and then force-delete, exactly once.
+
+    Returns ``True`` only when this timeout won the durable compare-and-set. A completed bot
+    acknowledgement wins the same CAS first, so a late timer performs no second delete and can
+    never overwrite graceful-success evidence.
+    """
+    at = timed_out_at or datetime.now(timezone.utc)
+    row = await repo.finalize_withdrawal(
+        session_uid=session_uid,
+        expected_status="pending",
+        outcome={
+            "status": "timed_out",
+            "timed_out_at": at.isoformat().replace("+00:00", "Z"),
+            "reason": "withdrawal acknowledgement not persisted before the bounded deadline",
+        },
+    )
+    if row is None:
+        return False
+    try:
+        await runtime.delete_workload(workload_id)
+    except Exception as e:  # noqa: BLE001 — persisted timeout remains truthful; reconcile retries
+        _log_stop_teardown_failed(meeting_id, workload_id, e)
+    return True
+
+
+async def _withdrawal_timeout_task(
+    repo: MeetingRepo,
+    runtime: Any,
+    session_uid: str,
+    meeting_id: Any,
+    workload_id: str,
+) -> None:
+    await asyncio.sleep(WITHDRAWAL_TIMEOUT_SECONDS)
+    await enforce_withdrawal_timeout(
+        repo,
+        runtime,
+        session_uid=session_uid,
+        meeting_id=meeting_id,
+        workload_id=workload_id,
+    )
+
+
+def _consume_timeout_task(task: "asyncio.Task[None]") -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception as e:  # noqa: BLE001 — fail loud without an unhandled-task warning
+        _log_stop_teardown_failed("unknown", "unknown", e)
 
 
 def _log_stop_teardown_failed(meeting_id, workload_id, err) -> None:

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_cascade.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_cascade.py
@@ -142,10 +142,14 @@ def test_full_meeting_lifecycle_cascade():
     assert len(envelopes) == 3
 
 
-def test_stop_cascade_tears_down_a_booting_bot_no_orphan():
-    """Spawn → DELETE while the bot is still BOOTING (status `requested`): the stop route cascade marks
-    `stopping`, publishes the graceful leave AND directly tears the workload down (ORPH1/B1), so a
-    not-yet-subscribed bot can't orphan. Exercises bot_spawn → stop_router → runtime end to end."""
+def test_stop_cascade_waits_for_durable_withdrawal_before_workload_delete():
+    """Spawn → DELETE while the bot is still PRE-ACTIVE: publish leave and persist the withdrawal
+    request, but do not race the bot's platform cancellation with direct workload deletion.
+
+    The pre-#839 path fails this discriminator because the route calls ``delete_workload`` in the
+    same request, before any bot callback can durably acknowledge that the pending knock was
+    withdrawn.
+    """
     from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher
 
     repo = InMemoryMeetingRepo()
@@ -160,12 +164,204 @@ def test_stop_cascade_tears_down_a_booting_bot_no_orphan():
     assert r.status_code == 201, r.text
     workload_id = runtime.specs[0]["workloadId"]
 
-    # The meeting is `requested` (booting) — the bot has NOT subscribed to its leave channel yet.
+    session_uid = repo.sessions[0]["session_uid"]
+    for status in ("joining", "awaiting_admission"):
+        progressed = client.post("/bots/internal/callback/lifecycle", json={
+            "connection_id": session_uid, "container_id": workload_id, "status": status,
+        })
+        assert progressed.status_code == 200, progressed.text
+
+    # `awaiting_admission` proves the bot subscribed before entering the lobby and that the host-side
+    # knock may exist. This is the status that must handshake rather than delete immediately.
     d = client.delete("/bots/google_meet/stop-cascade", headers={"x-user-id": str(USER)})
     assert d.status_code == 200, d.text
     assert d.json()["status"] == "stopping"
 
     # Graceful path: the leave command was published…
     assert any("leave" in msg for _ch, msg in publisher.published), "leave command must be published"
-    # …AND the guarantee: a booting bot's workload is torn down directly → no orphan.
-    assert workload_id in runtime.deleted, "a booting bot's workload must be directly torn down (ORPH1/B1)"
+    # The workload remains until a durable withdrawal acknowledgement (or the typed bounded timeout)
+    # wins the outcome race. Direct deletion here abandons the host-visible knock.
+    assert workload_id not in runtime.deleted, (
+        "pre-active Stop must not delete the workload before withdrawal is durably acknowledged"
+    )
+    row = repo._meetings[1]
+    assert row["data"]["withdrawal"]["status"] == "pending"
+
+
+def test_pre_active_withdrawal_ack_is_persisted_before_exactly_one_delete():
+    """A2: the bot's typed acknowledgement wins the durable CAS before runtime teardown."""
+    from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher, enforce_withdrawal_timeout
+
+    order: list[str] = []
+
+    class OrderedRepo(InMemoryMeetingRepo):
+        async def finalize_withdrawal(self, **kwargs):
+            row = await super().finalize_withdrawal(**kwargs)
+            if row is not None:
+                order.append(f"persist:{kwargs['outcome']['status']}")
+            return row
+
+    class OrderedRuntime(FakeRuntimeClient):
+        async def delete_workload(self, workload_id):
+            order.append(f"delete:{workload_id}")
+            await super().delete_workload(workload_id)
+
+    repo = OrderedRepo()
+    runtime = OrderedRuntime()
+    client = TestClient(create_app(
+        meeting_repo=repo,
+        runtime=runtime,
+        command_publisher=InMemoryCommandPublisher(),
+        token_secret=SECRET,
+    ))
+    created = client.post(
+        "/bots",
+        headers={"x-user-id": str(USER)},
+        json={"platform": "google_meet", "native_meeting_id": "withdraw-order"},
+    )
+    assert created.status_code == 201, created.text
+    session_uid = repo.sessions[0]["session_uid"]
+    workload_id = runtime.specs[0]["workloadId"]
+    for status in ("joining", "awaiting_admission"):
+        r = client.post("/bots/internal/callback/lifecycle", json={
+            "connection_id": session_uid, "container_id": workload_id, "status": status,
+        })
+        assert r.status_code == 200, r.text
+
+    stopped = client.delete(
+        "/bots/google_meet/withdraw-order", headers={"x-user-id": str(USER)}
+    )
+    assert stopped.status_code == 200, stopped.text
+    assert runtime.deleted == []
+
+    ack = client.post("/bots/internal/callback/lifecycle", json={
+        "connection_id": session_uid,
+        "container_id": workload_id,
+        "status": "failed",
+        "failure_stage": "awaiting_admission",
+        "completion_reason": "stopped",
+        "reason": "stopped while awaiting admission (withdrew the join request)",
+        "exit_code": 0,
+        "withdrawal": {
+            "status": "completed",
+            "completed_at": "2026-07-24T08:45:00Z",
+            "duration_ms": 413,
+            "cancel_attempted": True,
+            "page_closed": True,
+        },
+    })
+    assert ack.status_code == 200, ack.text
+    assert order == [f"persist:completed", f"delete:{workload_id}"]
+    assert runtime.deleted == [workload_id]
+    durable = repo._meetings[1]["data"]["withdrawal"]
+    assert durable["status"] == "completed"
+    assert durable["page_closed"] is True
+    assert durable["duration_ms"] == 413
+    assert durable["acknowledged_at"].endswith("Z")
+
+    # A late timeout loses the same CAS and cannot overwrite success or delete twice.
+    won = asyncio.run(enforce_withdrawal_timeout(
+        repo,
+        runtime,
+        session_uid=session_uid,
+        meeting_id=1,
+        workload_id=workload_id,
+    ))
+    assert won is False
+    assert runtime.deleted == [workload_id]
+    assert repo._meetings[1]["data"]["withdrawal"]["status"] == "completed"
+
+
+def test_missing_ack_persists_typed_timeout_before_bounded_fallback_delete():
+    """A3: exercise the deadline action directly — deterministic clock, no sleep-based proof."""
+    from datetime import datetime, timezone
+
+    from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher, enforce_withdrawal_timeout
+
+    order: list[str] = []
+
+    class OrderedRepo(InMemoryMeetingRepo):
+        async def finalize_withdrawal(self, **kwargs):
+            row = await super().finalize_withdrawal(**kwargs)
+            if row is not None:
+                order.append(f"persist:{kwargs['outcome']['status']}")
+            return row
+
+    class OrderedRuntime(FakeRuntimeClient):
+        async def delete_workload(self, workload_id):
+            order.append(f"delete:{workload_id}")
+            await super().delete_workload(workload_id)
+
+    repo = OrderedRepo()
+    runtime = OrderedRuntime()
+    client = TestClient(create_app(
+        meeting_repo=repo,
+        runtime=runtime,
+        command_publisher=InMemoryCommandPublisher(),
+        token_secret=SECRET,
+    ))
+    created = client.post(
+        "/bots",
+        headers={"x-user-id": str(USER)},
+        json={"platform": "google_meet", "native_meeting_id": "withdraw-timeout"},
+    )
+    session_uid = repo.sessions[0]["session_uid"]
+    workload_id = runtime.specs[0]["workloadId"]
+    for status in ("joining", "awaiting_admission"):
+        progressed = client.post("/bots/internal/callback/lifecycle", json={
+            "connection_id": session_uid, "container_id": workload_id, "status": status,
+        })
+        assert progressed.status_code == 200, progressed.text
+    stopped = client.delete(
+        "/bots/google_meet/withdraw-timeout", headers={"x-user-id": str(USER)}
+    )
+    assert stopped.status_code == 200, stopped.text
+    assert runtime.deleted == []
+
+    won = asyncio.run(enforce_withdrawal_timeout(
+        repo,
+        runtime,
+        session_uid=session_uid,
+        meeting_id=1,
+        workload_id=workload_id,
+        timed_out_at=datetime(2026, 7, 24, 8, 45, 25, tzinfo=timezone.utc),
+    ))
+    assert won is True
+    assert order == [f"persist:timed_out", f"delete:{workload_id}"]
+    timeout = repo._meetings[1]["data"]["withdrawal"]
+    assert timeout["status"] == "timed_out"
+    assert timeout["timed_out_at"] == "2026-07-24T08:45:25Z"
+    assert "not persisted" in timeout["reason"]
+
+
+def test_active_stop_keeps_existing_leave_finalize_path():
+    """A4: an admitted bot gets no withdrawal carrier and no direct workload delete."""
+    from meeting_api.lifecycle.stop_router import InMemoryCommandPublisher
+
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient()
+    publisher = InMemoryCommandPublisher()
+    client = TestClient(create_app(
+        meeting_repo=repo, runtime=runtime, command_publisher=publisher, token_secret=SECRET,
+    ))
+    created = client.post(
+        "/bots",
+        headers={"x-user-id": str(USER)},
+        json={"platform": "google_meet", "native_meeting_id": "active-stop-control"},
+    )
+    session_uid = repo.sessions[0]["session_uid"]
+    workload_id = runtime.specs[0]["workloadId"]
+    for status in ("joining", "awaiting_admission", "active"):
+        r = client.post("/bots/internal/callback/lifecycle", json={
+            "connection_id": session_uid, "container_id": workload_id, "status": status,
+        })
+        assert r.status_code == 200, r.text
+
+    stopped = client.delete(
+        "/bots/google_meet/active-stop-control", headers={"x-user-id": str(USER)}
+    )
+    assert stopped.status_code == 200, stopped.text
+    assert runtime.deleted == []
+    assert "withdrawal" not in repo._meetings[1]["data"]
+    assert repo._meetings[1]["status"] == "stopping"
+    assert any("leave" in body for _channel, body in publisher.published)

--- a/docs/changelog.d/839-graceful-lobby-withdrawal.md
+++ b/docs/changelog.d/839-graceful-lobby-withdrawal.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Stopping a bot while it waits for meeting admission now cancels and closes the pending join,
+  persists typed withdrawal evidence, and only then removes its worker. Missing acknowledgements
+  take a distinct bounded-timeout fallback instead of appearing as graceful success. (#839)

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -261,6 +261,14 @@ curl -X PUT "$API_BASE/bots/google_meet/abc-defg-hij/config" \
 curl -X DELETE "$API_BASE/bots/google_meet/abc-defg-hij" -H "X-API-Key: $API_KEY"
 ```
 
+For a bot already waiting in the lobby, Stop is ordered as
+`leave command → cancel/page close → durable withdrawal acknowledgement → worker deletion`.
+The host-visible knock has a 10-second disappearance objective. A missing acknowledgement is
+persisted as `meeting.data.withdrawal.status: timed_out` before the capacity fallback deletes the
+worker within 25 seconds; it is not classified as graceful success. Stops before the bot confirms
+its command subscription use direct teardown, while admitted bots keep the normal leave and
+recording-finalization path.
+
 ```bash Running bots — GET /bots/status
 curl -H "X-API-Key: $API_KEY" "$API_BASE/bots/status"
 ```

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -125,6 +125,12 @@ of polling, subscribe over **WebSocket** — see the [Meetings API](/api/meeting
 curl -X DELETE "$API_BASE/bots/google_meet/abc-defg-hij" -H "X-API-Key: $API_KEY"
 ```
 
+If you stop a bot while it is waiting for admission, Vexa first cancels the pending join and closes
+the meeting page. It records that acknowledgement before removing the worker, so the host-visible
+knock should disappear within 10 seconds. If no acknowledgement arrives, Vexa records a
+`withdrawal.status: timed_out` diagnostic and force-removes the worker within 25 seconds; that
+fallback is not reported as a graceful withdrawal.
+
 <Note>
 Mid-call reconfiguration (`PUT …/config`, change language/task while the bot is in the call) rides
 the live bot-control plane and is **not yet wired in the v0.12 open-core stack** — it currently

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -19,7 +19,10 @@ curl -H "X-API-Key: $API_KEY" "$API_BASE/bots/status"
 - **Bad meeting id** — `native_meeting_id` is the id *inside* the join URL (e.g. `abc-defg-hij`), not the
   whole URL. Wrong platform value also fails: use `google_meet`, `zoom`, or `teams`.
 - **Waiting room / admission** — on Meet and Teams the bot may be parked in a lobby until a host admits
-  it. Admit it like any guest.
+  it. Admit it like any guest. If you stop it instead, the host-visible knock should disappear
+  within 10 seconds. A retained `meeting.data.withdrawal.status: timed_out` means Vexa did not
+  receive durable cancellation/page-close proof and used the bounded capacity fallback; inspect
+  the bot's terminal logs rather than treating that outcome as graceful success.
 - **Concurrency cap** — a user can run at most `max_concurrent_bots` bots at once (set when the user was
   created). Stop an existing bot or raise the cap.
 


### PR DESCRIPTION
## Value

Part of #839.

Stopping a bot that has reported `awaiting_admission` now preserves the host-visible lobby
withdrawal before worker teardown:

`leave → cancel/page close → durable lifecycle.v1 acknowledgement → delete_workload`

The normal success path has an 8-second bot-side bound, inside the issue's 10-second
host-visible objective. If no acknowledgement is durably accepted, the control plane persists
`withdrawal.status=timed_out` and force-deletes at 24 seconds, inside the issue's 25-second
capacity bound. That fallback is typed failure, never graceful success.

`requested` and `joining` retain direct P22 teardown because those states do not prove the bot
subscribed to the leave channel or created a host-visible knock. Active/admitted Stop retains its
existing leave and recording-finalization path.

This draft intentionally targets the frozen v0.12.19 candidate branch. It must rebase onto the
exact public v0.12.19 delivery ref before it can become a v0.12.20 candidate.

## Expected → Actual → Verdict

Expected on the exact base `efc684a8d88cdd30fd34a67f6a23b0c4f6c66347`: an
`awaiting_admission` Stop should leave the worker alive until withdrawal evidence is persisted.

Actual before the change: the deterministic lifecycle cascade immediately contained the workload
in `runtime.deleted`, before a bot callback could acknowledge cancellation/page close.

Verdict: genuine point-of-introduction red in `stop_router`; implemented the cross-process
handshake rather than delaying deletion with a sleep.

## Acceptance rows

| Row | Observation | Evidence on `42f87fbc7d4d82e487188fcc8b47b22cacda2cb1` |
|---|---|---|
| A1 | Direct pre-active delete red | Deterministic base run failed because `runtime.deleted` already contained the workload. |
| A2 | Completed withdrawal persists before exactly one delete | `test_pre_active_withdrawal_ack_is_persisted_before_exactly_one_delete`; observed `persist:completed` before `delete:<id>`; late timeout lost the CAS. |
| A3 | Missing acknowledgement is loud and bounded | `test_missing_ack_persists_typed_timeout_before_bounded_fallback_delete`; deterministic fake time, no sleep; observed `persist:timed_out` before delete; configured deadline 24s. |
| A4 | Active/admitted Stop unchanged | `test_active_stop_keeps_existing_leave_finalize_path`; no withdrawal carrier and no direct delete. Existing requested/joining no-orphan control remains green. |
| A5 | Host knock disappears within 10s and no post-Stop admission | **Pending**: exact two-browser Google Meet leg; no live meeting traffic was authorized for this implementation car. |
| A6 | Fresh non-author validation | **Pending** after immutable artifact; `@awen11123` is an opt-in validator, not assigned or claimed here. |

Additional local evidence:

- meeting-api focused lifecycle cascade: 5 passed
- full meeting-api: 846 passed, 5 skipped
- full bot package: green
- full Node gate: 18 packages build + test green
- lifecycle.v1 schema: 24 contracts conform; contract seal green
- dataflow and architecture report: green; architecture deliberately re-sealed
- pre-push static suite: 14/14 green
- root typecheck: green

The aggregate Python gate reached the unrelated transcription package and could not build NumPy
1.26 on this Python 3.13 host because `Python.h` is unavailable. The changed meeting-api package's
full suite is green; hosted CI remains authoritative for the aggregate.

## Contract and docs

- additive `lifecycle.v1.withdrawal` acknowledgement with a golden
- deliberate `contracts.seal.json` and architecture seal updates (`lane:contract`)
- API, send-a-bot, troubleshooting, component README, and changelog fragment updated

## Not claimed

- no live Google Meet validation
- no stage or production mutation
- no final v0.12.20 delivery or release claim
- no issue closure before exact tagged delivery and validation/credit receipt
