### PR TITLE
ci: authenticate frozen release descriptor validation

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -123,42 +123,19 @@ jobs:
           if [ "$BARE" != "$BASE" ]; then PRE=true; else PRE=false; fi
           { echo "version=$VERSION"; echo "prerelease=$PRE"; } >> "$GITHUB_OUTPUT"
           echo "✓ validating published set $VERSION (prerelease=$PRE)"
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Every published manifest resolves and carries required platforms
+      - uses: actions/checkout@v4
+      - name: Registry validator controls
+        run: node --test scripts/registry-candidate-validate.test.mjs
+      - name: Every frozen descriptor resolves through authenticated registry reads
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # `imagetools inspect` prints no Platform line for classic-driver (schema-v2)
-          # manifests even when the registry descriptor says linux/amd64 — the bot image
-          # is built on the classic driver by design, so read the registry descriptor
-          # instead; it is authoritative for both manifest shapes.
-          for img in $ALL_IMAGES; do
-            echo "== $img:$VERSION"
-            # NOTE: a `IMG=... cmd | python3` prefix binds the var only to the first
-            # pipeline command — python3 would KeyError. Export it instead.
-            export IMG="$img"
-            docker manifest inspect -v "$img:$VERSION" | python3 -c "
-          import os, sys, json
-          img = os.environ['IMG']
-          d = json.load(sys.stdin)
-          items = d if isinstance(d, list) else [d]
-          plats = {(m.get('Descriptor', {}).get('platform', {}).get('os'),
-                    m.get('Descriptor', {}).get('platform', {}).get('architecture'))
-                   for m in items}
-          required = {('linux', 'amd64')}
-          if img != 'vexaai/vexa-bot':
-            required.add(('linux', 'arm64'))
-          missing = required - plats
-          if missing:
-            print(f'missing platforms: {sorted(missing)}', file=sys.stderr)
-            sys.exit(1)
-          " || { echo "::error ::$img:$VERSION missing required platform manifest(s) — is the set published?"; exit 1; }
-          done
-          echo "✓ all $(wc -w <<<"$ALL_IMAGES") manifests present with required platforms"
+          node scripts/registry-candidate-validate.mjs \
+            --candidate-map "releases/$VERSION/candidate-images.json" \
+            --tag "$VERSION"
 
   # ──────────────────────────────────────────────────────────────────────────────────────────
   # Image-identity smoke — a dumb, loud assertion that every published image CONTAINS what its

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -133,9 +133,23 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
+          case "$VERSION" in
+            v0.12.18)
+              EXPECTED_MAP_SHA256=80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f
+              EXPECTED_TOP_DESCRIPTORS=10
+              EXPECTED_PLATFORM_IDENTITIES=19
+              ;;
+            *)
+              echo "::error ::$VERSION has no reviewed, packet-bound candidate-map identity"
+              exit 1
+              ;;
+          esac
           node scripts/registry-candidate-validate.mjs \
             --candidate-map "releases/$VERSION/candidate-images.json" \
-            --tag "$VERSION"
+            --tag "$VERSION" \
+            --expected-map-sha256 "$EXPECTED_MAP_SHA256" \
+            --expected-top-descriptors "$EXPECTED_TOP_DESCRIPTORS" \
+            --expected-platform-identities "$EXPECTED_PLATFORM_IDENTITIES"
 
   # ──────────────────────────────────────────────────────────────────────────────────────────
   # Image-identity smoke — a dumb, loud assertion that every published image CONTAINS what its

--- a/scripts/registry-candidate-validate.mjs
+++ b/scripts/registry-candidate-validate.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const ACCEPT = [
+  "application/vnd.oci.image.index.v1+json",
+  "application/vnd.docker.distribution.manifest.list.v2+json",
+  "application/vnd.oci.image.manifest.v1+json",
+  "application/vnd.docker.distribution.manifest.v2+json",
+].join(", ");
+
+export class RegistryValidationError extends Error {
+  constructor(kind, message, details = {}) {
+    super(message);
+    this.name = "RegistryValidationError";
+    this.kind = kind;
+    this.details = details;
+  }
+}
+
+function classifyStatus(status) {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 429) return "quota";
+  if (status >= 500) return "network";
+  return "registry";
+}
+
+async function request(fetchImpl, url, options, context) {
+  let response;
+  try {
+    response = await fetchImpl(url, options);
+  } catch (error) {
+    throw new RegistryValidationError(
+      "network",
+      `${context}: network request failed: ${error.message}`,
+      { cause: error.message },
+    );
+  }
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 500);
+    const kind = classifyStatus(response.status);
+    throw new RegistryValidationError(
+      kind,
+      `${context}: registry HTTP ${response.status}${body ? `: ${body}` : ""}`,
+      { status: response.status, body },
+    );
+  }
+  return response;
+}
+
+async function jsonResponse(response, context) {
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new RegistryValidationError(
+      "network",
+      `${context}: registry returned an invalid JSON response: ${error.message}`,
+      { cause: error.message },
+    );
+  }
+}
+
+function identity(condition, message, details = {}) {
+  if (!condition) {
+    throw new RegistryValidationError("identity", message, details);
+  }
+}
+
+function platformKey(platform) {
+  return `${platform?.os ?? ""}/${platform?.architecture ?? ""}`;
+}
+
+function isAttestation(descriptor) {
+  return descriptor.annotations?.["vnd.docker.reference.type"] === "attestation-manifest";
+}
+
+export function validateManifestIdentity({ repository, expected, topDigest, manifest, children }) {
+  identity(
+    topDigest === expected.digest,
+    `${repository}: top descriptor mismatch (expected ${expected.digest}, actual ${topDigest || "<missing>"})`,
+    { repository, expected: expected.digest, actual: topDigest || null, level: "top" },
+  );
+
+  const expectedPlatforms = expected.platform_manifests;
+  const descriptors = Array.isArray(manifest.manifests) ? manifest.manifests : null;
+
+  if (!descriptors) {
+    const keys = Object.keys(expectedPlatforms);
+    identity(
+      keys.length === 1,
+      `${repository}: single manifest cannot satisfy ${keys.length} expected platforms`,
+      { repository, expected_platforms: keys },
+    );
+    const key = keys[0];
+    const expectedPlatform = expectedPlatforms[key];
+    identity(
+      expectedPlatform.manifest_digest === topDigest,
+      `${repository} ${key}: manifest mismatch (expected ${expectedPlatform.manifest_digest}, actual ${topDigest})`,
+      { repository, platform: key, expected: expectedPlatform.manifest_digest, actual: topDigest },
+    );
+    identity(
+      manifest.config?.digest === expectedPlatform.config_digest,
+      `${repository} ${key}: config mismatch (expected ${expectedPlatform.config_digest}, actual ${manifest.config?.digest || "<missing>"})`,
+      {
+        repository,
+        platform: key,
+        expected: expectedPlatform.config_digest,
+        actual: manifest.config?.digest || null,
+      },
+    );
+    identity(!expected.attestations, `${repository}: candidate map forbids attestations on a single manifest`);
+    return { platforms: 1, attestations: 0 };
+  }
+
+  const platformDescriptors = new Map(
+    descriptors.filter((item) => !isAttestation(item)).map((item) => [platformKey(item.platform), item]),
+  );
+  const attestations = descriptors.filter(isAttestation);
+
+  identity(
+    platformDescriptors.size === Object.keys(expectedPlatforms).length,
+    `${repository}: platform descriptor count mismatch (expected ${Object.keys(expectedPlatforms).length}, actual ${platformDescriptors.size})`,
+    { repository, expected: Object.keys(expectedPlatforms).length, actual: platformDescriptors.size },
+  );
+
+  for (const [key, expectedPlatform] of Object.entries(expectedPlatforms)) {
+    const descriptor = platformDescriptors.get(key);
+    identity(descriptor, `${repository}: expected platform ${key} is absent`, { repository, platform: key });
+    identity(
+      descriptor.digest === expectedPlatform.manifest_digest,
+      `${repository} ${key}: manifest mismatch (expected ${expectedPlatform.manifest_digest}, actual ${descriptor.digest})`,
+      {
+        repository,
+        platform: key,
+        expected: expectedPlatform.manifest_digest,
+        actual: descriptor.digest,
+      },
+    );
+    const child = children.get(descriptor.digest);
+    identity(child, `${repository} ${key}: child manifest ${descriptor.digest} was not resolved`);
+    identity(
+      child.config?.digest === expectedPlatform.config_digest,
+      `${repository} ${key}: config mismatch (expected ${expectedPlatform.config_digest}, actual ${child.config?.digest || "<missing>"})`,
+      {
+        repository,
+        platform: key,
+        expected: expectedPlatform.config_digest,
+        actual: child.config?.digest || null,
+      },
+    );
+  }
+
+  if (expected.attestations) {
+    const referenced = new Set(
+      attestations.map((item) => item.annotations?.["vnd.docker.reference.digest"]).filter(Boolean),
+    );
+    for (const expectedPlatform of Object.values(expectedPlatforms)) {
+      identity(
+        referenced.has(expectedPlatform.manifest_digest),
+        `${repository}: attestation for ${expectedPlatform.manifest_digest} is absent`,
+        { repository, manifest_digest: expectedPlatform.manifest_digest },
+      );
+    }
+    identity(
+      attestations.length === Object.keys(expectedPlatforms).length,
+      `${repository}: attestation descriptor count mismatch (expected ${Object.keys(expectedPlatforms).length}, actual ${attestations.length})`,
+      { repository, expected: Object.keys(expectedPlatforms).length, actual: attestations.length },
+    );
+  } else {
+    identity(
+      attestations.length === 0,
+      `${repository}: candidate map forbids attestations, found ${attestations.length}`,
+      { repository, actual: attestations.length },
+    );
+  }
+
+  return { platforms: platformDescriptors.size, attestations: attestations.length };
+}
+
+async function bearerToken({ fetchImpl, authBase, service, repository, username, password }) {
+  const url = new URL("/token", authBase);
+  url.searchParams.set("service", service);
+  url.searchParams.set("scope", `repository:${repository}:pull`);
+  const response = await request(
+    fetchImpl,
+    url,
+    { headers: { authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}` } },
+    `${repository}: token exchange`,
+  );
+  const body = await jsonResponse(response, `${repository}: token exchange`);
+  if (!body.token && !body.access_token) {
+    throw new RegistryValidationError("auth", `${repository}: token exchange returned no bearer token`);
+  }
+  return body.token ?? body.access_token;
+}
+
+async function registryManifest({ fetchImpl, registryBase, repository, reference, token }) {
+  const url = new URL(`/v2/${repository}/manifests/${reference}`, registryBase);
+  const response = await request(
+    fetchImpl,
+    url,
+    { headers: { authorization: `Bearer ${token}`, accept: ACCEPT } },
+    `${repository}@${reference}: manifest read`,
+  );
+  return {
+    digest: response.headers.get("docker-content-digest"),
+    body: await jsonResponse(response, `${repository}@${reference}: manifest read`),
+  };
+}
+
+export async function validateCandidateMap({
+  candidateMap,
+  tag,
+  username,
+  password,
+  fetchImpl = fetch,
+  authBase = "https://auth.docker.io",
+  registryBase = "https://registry-1.docker.io",
+  service = "registry.docker.io",
+}) {
+  if (!username || !password) {
+    throw new RegistryValidationError("auth", "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are required");
+  }
+  identity(candidateMap.stable_tag === tag, `candidate map stable_tag ${candidateMap.stable_tag} does not match ${tag}`);
+
+  let topDescriptors = 0;
+  let platformIdentities = 0;
+  let attestationIdentities = 0;
+
+  for (const [fullRepository, expected] of Object.entries(candidateMap.images)) {
+    const repository = fullRepository.replace(/^docker\.io\//, "");
+    const token = await bearerToken({
+      fetchImpl,
+      authBase,
+      service,
+      repository,
+      username,
+      password,
+    });
+    const top = await registryManifest({
+      fetchImpl,
+      registryBase,
+      repository,
+      reference: tag,
+      token,
+    });
+    const children = new Map();
+    if (Array.isArray(top.body.manifests)) {
+      for (const descriptor of top.body.manifests.filter((item) => !isAttestation(item))) {
+        const child = await registryManifest({
+          fetchImpl,
+          registryBase,
+          repository,
+          reference: descriptor.digest,
+          token,
+        });
+        identity(
+          child.digest === descriptor.digest,
+          `${repository}: child response digest mismatch (expected ${descriptor.digest}, actual ${child.digest || "<missing>"})`,
+        );
+        children.set(descriptor.digest, child.body);
+      }
+    }
+    const counts = validateManifestIdentity({
+      repository,
+      expected,
+      topDigest: top.digest,
+      manifest: top.body,
+      children,
+    });
+    topDescriptors += 1;
+    platformIdentities += counts.platforms;
+    attestationIdentities += counts.attestations;
+    console.log(`✓ ${repository}:${tag} ${expected.digest}`);
+  }
+
+  return { topDescriptors, platformIdentities, attestationIdentities };
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (key === "--candidate-map") result.candidateMap = argv[++index];
+    else if (key === "--tag") result.tag = argv[++index];
+    else throw new Error(`unknown argument: ${key}`);
+  }
+  if (!result.candidateMap || !result.tag) {
+    throw new Error("usage: registry-candidate-validate.mjs --candidate-map <file> --tag <vX.Y.Z>");
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = await readFile(args.candidateMap);
+  const candidateMap = JSON.parse(raw);
+  const mapHash = createHash("sha256").update(raw).digest("hex");
+  const counts = await validateCandidateMap({
+    candidateMap,
+    tag: args.tag,
+    username: process.env.DOCKERHUB_USERNAME,
+    password: process.env.DOCKERHUB_TOKEN,
+  });
+  console.log(
+    `✓ authenticated candidate-map validation: ${counts.topDescriptors} top descriptors, ` +
+      `${counts.platformIdentities} platform manifest/config identities, ` +
+      `${counts.attestationIdentities} linked attestations; map sha256:${mapHash}`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    if (error instanceof RegistryValidationError) {
+      console.error(`registry-candidate-validate [${error.kind}]: ${error.message}`);
+      process.exitCode = error.kind === "identity" ? 4 : error.kind === "auth" ? 5 : error.kind === "quota" ? 6 : 7;
+    } else {
+      console.error(`registry-candidate-validate [internal]: ${error.stack || error.message}`);
+      process.exitCode = 2;
+    }
+  });
+}

--- a/scripts/registry-candidate-validate.mjs
+++ b/scripts/registry-candidate-validate.mjs
@@ -69,6 +69,16 @@ function identity(condition, message, details = {}) {
   }
 }
 
+export function verifyCandidateMapHash(raw, expectedHash) {
+  const actualHash = createHash("sha256").update(raw).digest("hex");
+  identity(
+    actualHash === expectedHash,
+    `candidate map hash mismatch (expected sha256:${expectedHash}, actual sha256:${actualHash})`,
+    { expected: `sha256:${expectedHash}`, actual: `sha256:${actualHash}`, level: "candidate-map" },
+  );
+  return actualHash;
+}
+
 function platformKey(platform) {
   return `${platform?.os ?? ""}/${platform?.architecture ?? ""}`;
 }
@@ -220,6 +230,8 @@ export async function validateCandidateMap({
   authBase = "https://auth.docker.io",
   registryBase = "https://registry-1.docker.io",
   service = "registry.docker.io",
+  expectedTopDescriptors,
+  expectedPlatformIdentities,
 }) {
   if (!username || !password) {
     throw new RegistryValidationError("auth", "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are required");
@@ -277,6 +289,21 @@ export async function validateCandidateMap({
     console.log(`✓ ${repository}:${tag} ${expected.digest}`);
   }
 
+  if (expectedTopDescriptors !== undefined) {
+    identity(
+      topDescriptors === expectedTopDescriptors,
+      `candidate population mismatch (expected ${expectedTopDescriptors} top descriptors, actual ${topDescriptors})`,
+      { expected: expectedTopDescriptors, actual: topDescriptors, level: "population" },
+    );
+  }
+  if (expectedPlatformIdentities !== undefined) {
+    identity(
+      platformIdentities === expectedPlatformIdentities,
+      `candidate population mismatch (expected ${expectedPlatformIdentities} platform identities, actual ${platformIdentities})`,
+      { expected: expectedPlatformIdentities, actual: platformIdentities, level: "population" },
+    );
+  }
+
   return { topDescriptors, platformIdentities, attestationIdentities };
 }
 
@@ -286,10 +313,22 @@ function parseArgs(argv) {
     const key = argv[index];
     if (key === "--candidate-map") result.candidateMap = argv[++index];
     else if (key === "--tag") result.tag = argv[++index];
+    else if (key === "--expected-map-sha256") result.expectedMapHash = argv[++index];
+    else if (key === "--expected-top-descriptors") result.expectedTopDescriptors = Number(argv[++index]);
+    else if (key === "--expected-platform-identities") result.expectedPlatformIdentities = Number(argv[++index]);
     else throw new Error(`unknown argument: ${key}`);
   }
-  if (!result.candidateMap || !result.tag) {
-    throw new Error("usage: registry-candidate-validate.mjs --candidate-map <file> --tag <vX.Y.Z>");
+  if (
+    !result.candidateMap ||
+    !result.tag ||
+    !/^[0-9a-f]{64}$/.test(result.expectedMapHash ?? "") ||
+    !Number.isInteger(result.expectedTopDescriptors) ||
+    !Number.isInteger(result.expectedPlatformIdentities)
+  ) {
+    throw new Error(
+      "usage: registry-candidate-validate.mjs --candidate-map <file> --tag <vX.Y.Z> " +
+        "--expected-map-sha256 <64-hex> --expected-top-descriptors <n> --expected-platform-identities <n>",
+    );
   }
   return result;
 }
@@ -297,13 +336,15 @@ function parseArgs(argv) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const raw = await readFile(args.candidateMap);
+  const mapHash = verifyCandidateMapHash(raw, args.expectedMapHash);
   const candidateMap = JSON.parse(raw);
-  const mapHash = createHash("sha256").update(raw).digest("hex");
   const counts = await validateCandidateMap({
     candidateMap,
     tag: args.tag,
     username: process.env.DOCKERHUB_USERNAME,
     password: process.env.DOCKERHUB_TOKEN,
+    expectedTopDescriptors: args.expectedTopDescriptors,
+    expectedPlatformIdentities: args.expectedPlatformIdentities,
   });
   console.log(
     `✓ authenticated candidate-map validation: ${counts.topDescriptors} top descriptors, ` +

--- a/scripts/registry-candidate-validate.test.mjs
+++ b/scripts/registry-candidate-validate.test.mjs
@@ -5,9 +5,22 @@ import {
   RegistryValidationError,
   validateCandidateMap,
   validateManifestIdentity,
+  verifyCandidateMapHash,
 } from "./registry-candidate-validate.mjs";
 
 const digest = (character) => `sha256:${character.repeat(64)}`;
+
+test("frozen map hash accepts exact bytes and rejects altered or truncated bytes", () => {
+  const raw = Buffer.from('{"images":{"vexaai/vexa-lite":{}}}\n');
+  const hash = "1887b0e9d312f64c21e46b0bf45d3cff9504fd9042a1a29463e14230d520add3";
+  assert.equal(verifyCandidateMapHash(raw, hash), hash);
+  for (const changed of [Buffer.from('{"images":{}}\n'), raw.subarray(0, raw.length - 2)]) {
+    assert.throws(
+      () => verifyCandidateMapHash(changed, hash),
+      (error) => error instanceof RegistryValidationError && error.kind === "identity",
+    );
+  }
+});
 
 function fixture() {
   const platform = digest("2");

--- a/scripts/registry-candidate-validate.test.mjs
+++ b/scripts/registry-candidate-validate.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RegistryValidationError,
+  validateCandidateMap,
+  validateManifestIdentity,
+} from "./registry-candidate-validate.mjs";
+
+const digest = (character) => `sha256:${character.repeat(64)}`;
+
+function fixture() {
+  const platform = digest("2");
+  const config = digest("3");
+  const attestation = digest("4");
+  return {
+    expected: {
+      digest: digest("1"),
+      platform_manifests: {
+        "linux/amd64": { manifest_digest: platform, config_digest: config },
+      },
+      attestations: true,
+    },
+    top: {
+      schemaVersion: 2,
+      manifests: [
+        { digest: platform, platform: { os: "linux", architecture: "amd64" } },
+        {
+          digest: attestation,
+          platform: { os: "unknown", architecture: "unknown" },
+          annotations: {
+            "vnd.docker.reference.type": "attestation-manifest",
+            "vnd.docker.reference.digest": platform,
+          },
+        },
+      ],
+    },
+    children: new Map([[platform, { schemaVersion: 2, config: { digest: config } }]]),
+  };
+}
+
+test("exact top, platform/config, and linked attestation identities pass", () => {
+  const value = fixture();
+  assert.deepEqual(
+    validateManifestIdentity({
+      repository: "vexaai/vexa-lite",
+      expected: value.expected,
+      topDigest: digest("1"),
+      manifest: value.top,
+      children: value.children,
+    }),
+    { platforms: 1, attestations: 1 },
+  );
+});
+
+test("altered Lite top identity is classified as identity mismatch", () => {
+  const value = fixture();
+  assert.throws(
+    () =>
+      validateManifestIdentity({
+        repository: "vexaai/vexa-lite",
+        expected: value.expected,
+        topDigest: digest("9"),
+        manifest: value.top,
+        children: value.children,
+      }),
+    (error) =>
+      error instanceof RegistryValidationError &&
+      error.kind === "identity" &&
+      error.message.includes(`expected ${digest("1")}, actual ${digest("9")}`),
+  );
+});
+
+function response(status, body, headers = {}) {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function oneImageMap() {
+  const value = fixture();
+  return {
+    stable_tag: "v0.12.18",
+    images: { "vexaai/vexa-lite": value.expected },
+  };
+}
+
+test("injected HTTP 429 is quota, never platform/identity", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(String(url));
+    if (calls.length === 1) return response(200, { token: "scoped-token" });
+    return response(429, { errors: [{ code: "TOOMANYREQUESTS" }] });
+  };
+  await assert.rejects(
+    validateCandidateMap({
+      candidateMap: oneImageMap(),
+      tag: "v0.12.18",
+      username: "user",
+      password: "token",
+      fetchImpl,
+    }),
+    (error) =>
+      error instanceof RegistryValidationError &&
+      error.kind === "quota" &&
+      !error.message.includes("platform"),
+  );
+});
+
+test("injected HTTP 401 is auth", async () => {
+  await assert.rejects(
+    validateCandidateMap({
+      candidateMap: oneImageMap(),
+      tag: "v0.12.18",
+      username: "user",
+      password: "bad",
+      fetchImpl: async () => response(401, { message: "unauthorized" }),
+    }),
+    (error) => error instanceof RegistryValidationError && error.kind === "auth",
+  );
+});
+
+test("injected network failure is network", async () => {
+  await assert.rejects(
+    validateCandidateMap({
+      candidateMap: oneImageMap(),
+      tag: "v0.12.18",
+      username: "user",
+      password: "token",
+      fetchImpl: async () => {
+        throw new Error("socket reset");
+      },
+    }),
+    (error) => error instanceof RegistryValidationError && error.kind === "network",
+  );
+});
+
+test("invalid registry JSON is a transport response failure, not identity", async () => {
+  let calls = 0;
+  await assert.rejects(
+    validateCandidateMap({
+      candidateMap: oneImageMap(),
+      tag: "v0.12.18",
+      username: "user",
+      password: "token",
+      fetchImpl: async () => {
+        calls += 1;
+        if (calls === 1) return response(200, { token: "scoped-token" });
+        return response(200, "not-json", { "content-type": "text/plain" });
+      },
+    }),
+    (error) =>
+      error instanceof RegistryValidationError &&
+      error.kind === "network" &&
+      !error.message.includes("identity"),
+  );
+});


### PR DESCRIPTION
Closes #947

## What you get

Release validation now reads Docker Hub through explicitly authenticated repository-scoped bearer tokens and compares the published aliases to the immutable release candidate map. Quota/auth/network failures remain registry failures; they can no longer be reported as a missing image platform.

## Observation bundle

Exact head: `3beaaa90380089e45cef6a7a26305c9f11d12045`
Base: `b6583279035dac8783f16a492fbca6ddb9612902`

| Row | Expected | Actual | Verdict |
|---|---|---|---|
| A1 | Frozen v0.12.18 aliases match 10 top descriptors and 19 platform manifest/config identities. | Real authenticated local Registry API read: 10/10 top, 19/19 platform/config, 18 linked attestations; map `sha256:80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f`. Lite `sha256:5d0b6f865afe726109bb326361b917a3d9f762d64abbeea0826744134162d051`. | GREEN |
| A2 | Injected 429 is quota, never platform/identity. | `node --test scripts/registry-candidate-validate.test.mjs`: quota control green. | GREEN |
| A3 | 401 and network/invalid JSON remain attributable transport failures. | Seven-test suite: auth, socket, and invalid-response controls green. | GREEN |
| A4 | Altered descriptor is identity mismatch with expected/actual. | Altered Lite top-digest control green. | GREEN |
| A5 | No artifact/environment mutation. | Diff is one read-only script, its tests, and the release-validate resolve call-site. No build, pull, registry write, moving tag, runtime input, hosted, stage, or prod code. | GREEN |

Commands:

```text
node --test scripts/registry-candidate-validate.test.mjs
node scripts/registry-candidate-validate.mjs --candidate-map releases/v0.12.18/candidate-images.json --tag v0.12.18
node scripts/gates.mjs {readme,dataflow,isolation,graph,licenses,health}
pre-push static gates (14/14)
```

Broad local `gates all` boundary: static gates and Node build/test were green. Unrelated host rows were not claimed green: DB rendering initially used Python 3.14 (green under CI-aligned 3.12); runtime real-container test found local `alpine:latest` absent; an overlapping worktree recreated the fixed `vexa-compose-gate` project during Compose. No image was pulled to mask those host conditions. Hosted CI is the clean-runner observation.

## Diff

- Exchange Docker Hub credentials for a repository-scoped bearer token per image.
- Read top and child manifests with explicit bearer auth; never pull image layers.
- Compare top digest, platform-manifest digest, config digest, and attestation linkage to `candidate-images.json`.
- Give identity/auth/quota/network failures distinct types and exit codes.
- Run deterministic controls before the live resolve row.

## Coverage

Desk-check/release-tooling only. Product Compose, Lite, k8s, and hosted behavior are not re-claimed here; immutable-source release run 30080642172 attempt 2 already carries those rows.

Docs: none — internal release machinery; issue + PR are the operator record.

## Review ask

Please review this exact head independently against #947 A1–A5. A later push invalidates the endorsement.