### PR TITLE
ci: preserve exact manifest identity when promoting aliases

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -865,6 +865,7 @@ jobs:
           node scripts/registry-candidate-validate.mjs \
             --candidate-map "releases/$VERSION/candidate-images.json" \
             --tag v012 \
+            --expected-map-stable-tag "$VERSION" \
             --expected-map-sha256 "$EXPECTED_MAP_SHA256" \
             --expected-top-descriptors 10 \
             --expected-platform-identities 19

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: false
         type: boolean
+      promote_repository:
+        description: "Alias all frozen repositories, or one exact owner/name repair target"
+        required: false
+        default: all
+        type: string
       validation_leg:
         description: "Validation scope: all, or compose for an isolated harness rerun"
         required: false
@@ -71,6 +76,23 @@ on:
         required: false
         default: false
         type: boolean
+      promote_repository:
+        description: "Alias scope"
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - vexaai/v012-admin-api
+          - vexaai/v012-runtime
+          - vexaai/v012-agent-worker
+          - vexaai/v012-agent-api
+          - vexaai/v012-meeting-api
+          - vexaai/v012-gateway
+          - vexaai/v012-mcp
+          - vexaai/v012-terminal
+          - vexaai/vexa-bot
+          - vexaai/vexa-lite
       validation_leg:
         description: "Validation scope"
         required: false
@@ -786,29 +808,50 @@ jobs:
     env:
       VERSION: ${{ needs.resolve.outputs.version }}
       PROMOTE_LATEST: ${{ inputs.promote_latest == true }}
+      PROMOTE_REPOSITORY: ${{ inputs.promote_repository }}
+      EXPECTED_MAP_SHA256: 80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f
     steps:
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Promote :v012 (and :latest only when explicitly requested)
+      - uses: actions/checkout@v4
+      - name: Manifest-preserving promotion and exact readback
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
           move() {
-            local dst="$1:$2" src="$1:$VERSION"
-            case "$dst" in
+            local image="$1" target="$2"
+            case "$image:$target" in
               vexaai/vexa-bot:dev|vexaai/vexa-bot:latest|*:dev)
-                echo "::error ::constitutional guard: refusing to move $dst (vexa-bot:{dev,latest} belong to the 0.10 line; :dev is never moved by release CI)"
+                echo "::error ::constitutional guard: refusing to move $image:$target (vexa-bot:{dev,latest} belong to the 0.10 line; :dev is never moved by release CI)"
                 exit 1;;
             esac
-            echo "→ $dst ⇐ $src"
-            docker buildx imagetools create -t "$dst" "$src"
+            local unchanged=()
+            if [ "$target" = "v012" ] && [ "$PROMOTE_LATEST" != "true" ]; then
+              unchanged=(--assert-unchanged-tag latest)
+            fi
+            node scripts/registry-manifest-alias.mjs \
+              --candidate-map "releases/$VERSION/candidate-images.json" \
+              --expected-map-sha256 "$EXPECTED_MAP_SHA256" \
+              --repository "$image" \
+              --source-tag "$VERSION" \
+              --target-tag "$target" \
+              "${unchanged[@]}"
           }
-          for img in $ALL_IMAGES; do
+
+          if [ "$PROMOTE_REPOSITORY" = "all" ]; then
+            images="$ALL_IMAGES"
+          elif grep -Fxq "$PROMOTE_REPOSITORY" < <(tr ' ' '\n' <<<"$ALL_IMAGES"); then
+            images="$PROMOTE_REPOSITORY"
+          else
+            echo "::error ::$PROMOTE_REPOSITORY is not a frozen release repository"
+            exit 1
+          fi
+
+          for img in $images; do
             move "$img" v012
           done
           if [ "$PROMOTE_LATEST" = "true" ]; then
-            for img in $ALL_IMAGES; do
+            for img in $images; do
               if [ "$img" = "vexaai/vexa-bot" ]; then
                 echo "· skipping vexaai/vexa-bot:latest (constitutional guard — 0.10 line)"
                 continue
@@ -818,3 +861,10 @@ jobs:
           else
             echo "· :latest untouched (promote_latest not requested)"
           fi
+
+          node scripts/registry-candidate-validate.mjs \
+            --candidate-map "releases/$VERSION/candidate-images.json" \
+            --tag v012 \
+            --expected-map-sha256 "$EXPECTED_MAP_SHA256" \
+            --expected-top-descriptors 10 \
+            --expected-platform-identities 19

--- a/docs/changelog.d/951-manifest-preserving-release-alias.md
+++ b/docs/changelog.d/951-manifest-preserving-release-alias.md
@@ -1,0 +1,5 @@
+Release promotion now assigns moving image aliases by copying the authenticated
+registry manifest bytes and media type exactly, then reads back all frozen
+descriptors. Single-platform images can no longer be silently wrapped in a new
+index, and `:latest` is checked as an unchanged negative control unless its
+promotion was explicitly requested.

--- a/scripts/registry-candidate-validate.mjs
+++ b/scripts/registry-candidate-validate.mjs
@@ -377,6 +377,7 @@ export async function aliasManifest({
 export async function validateCandidateMap({
   candidateMap,
   tag,
+  expectedStableTag = tag,
   username,
   password,
   fetchImpl = fetch,
@@ -389,7 +390,10 @@ export async function validateCandidateMap({
   if (!username || !password) {
     throw new RegistryValidationError("auth", "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are required");
   }
-  identity(candidateMap.stable_tag === tag, `candidate map stable_tag ${candidateMap.stable_tag} does not match ${tag}`);
+  identity(
+    candidateMap.stable_tag === expectedStableTag,
+    `candidate map stable_tag ${candidateMap.stable_tag} does not match frozen source ${expectedStableTag}`,
+  );
 
   let topDescriptors = 0;
   let platformIdentities = 0;
@@ -466,6 +470,7 @@ function parseArgs(argv) {
     const key = argv[index];
     if (key === "--candidate-map") result.candidateMap = argv[++index];
     else if (key === "--tag") result.tag = argv[++index];
+    else if (key === "--expected-map-stable-tag") result.expectedStableTag = argv[++index];
     else if (key === "--expected-map-sha256") result.expectedMapHash = argv[++index];
     else if (key === "--expected-top-descriptors") result.expectedTopDescriptors = Number(argv[++index]);
     else if (key === "--expected-platform-identities") result.expectedPlatformIdentities = Number(argv[++index]);
@@ -494,6 +499,7 @@ async function main() {
   const counts = await validateCandidateMap({
     candidateMap,
     tag: args.tag,
+    expectedStableTag: args.expectedStableTag ?? args.tag,
     username: process.env.DOCKERHUB_USERNAME,
     password: process.env.DOCKERHUB_TOKEN,
     expectedTopDescriptors: args.expectedTopDescriptors,

--- a/scripts/registry-candidate-validate.mjs
+++ b/scripts/registry-candidate-validate.mjs
@@ -190,10 +190,18 @@ export function validateManifestIdentity({ repository, expected, topDigest, mani
   return { platforms: platformDescriptors.size, attestations: attestations.length };
 }
 
-async function bearerToken({ fetchImpl, authBase, service, repository, username, password }) {
+async function bearerToken({
+  fetchImpl,
+  authBase,
+  service,
+  repository,
+  username,
+  password,
+  actions = "pull",
+}) {
   const url = new URL("/token", authBase);
   url.searchParams.set("service", service);
-  url.searchParams.set("scope", `repository:${repository}:pull`);
+  url.searchParams.set("scope", `repository:${repository}:${actions}`);
   const response = await request(
     fetchImpl,
     url,
@@ -218,6 +226,151 @@ async function registryManifest({ fetchImpl, registryBase, repository, reference
   return {
     digest: response.headers.get("docker-content-digest"),
     body: await jsonResponse(response, `${repository}@${reference}: manifest read`),
+  };
+}
+
+async function rawRegistryManifest({ fetchImpl, registryBase, repository, reference, token }) {
+  const url = new URL(`/v2/${repository}/manifests/${reference}`, registryBase);
+  const response = await request(
+    fetchImpl,
+    url,
+    { headers: { authorization: `Bearer ${token}`, accept: ACCEPT } },
+    `${repository}@${reference}: manifest read`,
+  );
+  return {
+    digest: response.headers.get("docker-content-digest"),
+    mediaType: response.headers.get("content-type")?.split(";")[0],
+    bytes: Buffer.from(await response.arrayBuffer()),
+  };
+}
+
+async function putRegistryManifest({
+  fetchImpl,
+  registryBase,
+  repository,
+  reference,
+  token,
+  mediaType,
+  bytes,
+}) {
+  const url = new URL(`/v2/${repository}/manifests/${reference}`, registryBase);
+  const response = await request(
+    fetchImpl,
+    url,
+    {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": mediaType,
+        "content-length": String(bytes.length),
+      },
+      body: bytes,
+    },
+    `${repository}:${reference}: manifest alias write`,
+  );
+  return response.headers.get("docker-content-digest");
+}
+
+export async function aliasManifest({
+  repository,
+  sourceReference,
+  targetReference,
+  expectedDigest,
+  unchangedReference,
+  username,
+  password,
+  fetchImpl = fetch,
+  authBase = "https://auth.docker.io",
+  registryBase = "https://registry-1.docker.io",
+  service = "registry.docker.io",
+}) {
+  if (!username || !password) {
+    throw new RegistryValidationError("auth", "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are required");
+  }
+  identity(repository && !repository.startsWith("docker.io/"), "repository must be in owner/name form");
+  identity(sourceReference && targetReference, "source and target references are required");
+
+  const token = await bearerToken({
+    fetchImpl,
+    authBase,
+    service,
+    repository,
+    username,
+    password,
+    actions: "pull,push",
+  });
+  const source = await rawRegistryManifest({
+    fetchImpl,
+    registryBase,
+    repository,
+    reference: sourceReference,
+    token,
+  });
+  identity(
+    source.digest === expectedDigest,
+    `${repository}:${sourceReference}: source top descriptor mismatch (expected ${expectedDigest}, actual ${source.digest || "<missing>"})`,
+  );
+  identity(source.mediaType && ACCEPT.includes(source.mediaType), `${repository}:${sourceReference}: unsupported media type ${source.mediaType || "<missing>"}`);
+
+  let unchanged;
+  if (unchangedReference) {
+    unchanged = await rawRegistryManifest({
+      fetchImpl,
+      registryBase,
+      repository,
+      reference: unchangedReference,
+      token,
+    });
+  }
+
+  const writtenDigest = await putRegistryManifest({
+    fetchImpl,
+    registryBase,
+    repository,
+    reference: targetReference,
+    token,
+    mediaType: source.mediaType,
+    bytes: source.bytes,
+  });
+  identity(
+    writtenDigest === expectedDigest,
+    `${repository}:${targetReference}: alias write digest mismatch (expected ${expectedDigest}, actual ${writtenDigest || "<missing>"})`,
+  );
+
+  const target = await rawRegistryManifest({
+    fetchImpl,
+    registryBase,
+    repository,
+    reference: targetReference,
+    token,
+  });
+  identity(
+    target.digest === expectedDigest,
+    `${repository}:${targetReference}: alias readback mismatch (expected ${expectedDigest}, actual ${target.digest || "<missing>"})`,
+  );
+  identity(
+    target.mediaType === source.mediaType && target.bytes.equals(source.bytes),
+    `${repository}:${targetReference}: alias readback bytes or media type differ from ${sourceReference}`,
+  );
+
+  if (unchangedReference) {
+    const readback = await rawRegistryManifest({
+      fetchImpl,
+      registryBase,
+      repository,
+      reference: unchangedReference,
+      token,
+    });
+    identity(
+      readback.digest === unchanged.digest,
+      `${repository}:${unchangedReference}: negative-control descriptor moved (before ${unchanged.digest}, after ${readback.digest || "<missing>"})`,
+    );
+  }
+
+  return {
+    sourceDigest: source.digest,
+    targetDigest: target.digest,
+    unchangedDigest: unchanged?.digest,
   };
 }
 

--- a/scripts/registry-candidate-validate.test.mjs
+++ b/scripts/registry-candidate-validate.test.mjs
@@ -147,6 +147,52 @@ test("injected HTTP 429 is quota, never platform/identity", async () => {
   );
 });
 
+test("moving alias readback uses the frozen source tag without weakening map identity", async () => {
+  const value = fixture();
+  const fetchImpl = async (url) => {
+    if (String(url).includes("/token")) return response(200, { token: "scoped-token" });
+    const childDigest = value.expected.platform_manifests["linux/amd64"].manifest_digest;
+    if (String(url).endsWith(childDigest)) {
+      return response(200, value.children.get(childDigest), {
+        "docker-content-digest": childDigest,
+      });
+    }
+    return response(200, value.top, {
+      "docker-content-digest": value.expected.digest,
+    });
+  };
+  const counts = await validateCandidateMap({
+    candidateMap: oneImageMap(),
+    tag: "v012",
+    expectedStableTag: "v0.12.18",
+    username: "user",
+    password: "token",
+    fetchImpl,
+  });
+  assert.deepEqual(counts, {
+    topDescriptors: 1,
+    platformIdentities: 1,
+    attestationIdentities: 1,
+  });
+
+  await assert.rejects(
+    validateCandidateMap({
+      candidateMap: oneImageMap(),
+      tag: "v012",
+      expectedStableTag: "v0.12.19",
+      username: "user",
+      password: "token",
+      fetchImpl: async () => {
+        throw new Error("must stop before network");
+      },
+    }),
+    (error) =>
+      error instanceof RegistryValidationError &&
+      error.kind === "identity" &&
+      error.message.includes("does not match frozen source v0.12.19"),
+  );
+});
+
 test("injected HTTP 401 is auth", async () => {
   await assert.rejects(
     validateCandidateMap({

--- a/scripts/registry-candidate-validate.test.mjs
+++ b/scripts/registry-candidate-validate.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
+  aliasManifest,
   RegistryValidationError,
   validateCandidateMap,
   validateManifestIdentity,
@@ -9,6 +12,7 @@ import {
 } from "./registry-candidate-validate.mjs";
 
 const digest = (character) => `sha256:${character.repeat(64)}`;
+const sha256 = (bytes) => `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 
 test("frozen map hash accepts exact bytes and rejects altered or truncated bytes", () => {
   const raw = Buffer.from('{"images":{"vexaai/vexa-lite":{}}}\n');
@@ -20,6 +24,26 @@ test("frozen map hash accepts exact bytes and rejects altered or truncated bytes
       (error) => error instanceof RegistryValidationError && error.kind === "identity",
     );
   }
+});
+
+test("v0.12.18 frozen map pins exactly 10 top and 19 platform identities", async () => {
+  const raw = await readFile(new URL("../releases/v0.12.18/candidate-images.json", import.meta.url));
+  assert.equal(
+    verifyCandidateMapHash(
+      raw,
+      "80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f",
+    ),
+    "80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f",
+  );
+  const map = JSON.parse(raw);
+  assert.equal(Object.keys(map.images).length, 10);
+  assert.equal(
+    Object.values(map.images).reduce(
+      (count, image) => count + Object.keys(image.platform_manifests).length,
+      0,
+    ),
+    19,
+  );
 });
 
 function fixture() {
@@ -85,7 +109,9 @@ test("altered Lite top identity is classified as identity mismatch", () => {
 });
 
 function response(status, body, headers = {}) {
-  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+  const payload =
+    typeof body === "string" || Buffer.isBuffer(body) ? body : JSON.stringify(body);
+  return new Response(payload, {
     status,
     headers: { "content-type": "application/json", ...headers },
   });
@@ -167,5 +193,188 @@ test("invalid registry JSON is a transport response failure, not identity", asyn
       error instanceof RegistryValidationError &&
       error.kind === "network" &&
       !error.message.includes("identity"),
+  );
+});
+
+test("single-manifest alias writes the exact source bytes and preserves its top digest", async () => {
+  const sourceBytes = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      config: { digest: digest("3") },
+      layers: [],
+    }),
+  );
+  const sourceDigest = sha256(sourceBytes);
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+    if (String(url).startsWith("https://auth.example/token")) {
+      return response(200, { token: "push-token" });
+    }
+    const reference = decodeURIComponent(String(url).split("/manifests/")[1]);
+    if (options.method === "PUT") {
+      assert.equal(reference, "v012");
+      assert.equal(options.headers["content-type"], "application/vnd.oci.image.manifest.v1+json");
+      assert.deepEqual(Buffer.from(options.body), sourceBytes);
+      return response(201, "", { "docker-content-digest": sourceDigest });
+    }
+    if (reference === "latest") {
+      return response(200, sourceBytes, {
+        "content-type": "application/vnd.oci.image.manifest.v1+json",
+        "docker-content-digest": digest("9"),
+      });
+    }
+    return response(200, sourceBytes, {
+      "content-type": "application/vnd.oci.image.manifest.v1+json",
+      "docker-content-digest": sourceDigest,
+    });
+  };
+
+  const result = await aliasManifest({
+    repository: "vexaai/vexa-bot",
+    sourceReference: "v0.12.18",
+    targetReference: "v012",
+    expectedDigest: sourceDigest,
+    unchangedReference: "latest",
+    username: "user",
+    password: "token",
+    fetchImpl,
+    authBase: "https://auth.example",
+    registryBase: "https://registry.example",
+    service: "registry.example",
+  });
+
+  assert.deepEqual(result, {
+    sourceDigest,
+    targetDigest: sourceDigest,
+    unchangedDigest: digest("9"),
+  });
+  const tokenUrl = new URL(calls[0].url);
+  assert.equal(tokenUrl.searchParams.get("scope"), "repository:vexaai/vexa-bot:pull,push");
+});
+
+test("red control: an imagetools-style index wrapper changes a single-manifest top digest", () => {
+  const manifestBytes = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      config: { digest: digest("3") },
+      layers: [],
+    }),
+  );
+  const manifestDigest = sha256(manifestBytes);
+  const wrappedBytes = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.index.v1+json",
+      manifests: [
+        {
+          mediaType: "application/vnd.oci.image.manifest.v1+json",
+          digest: manifestDigest,
+          size: manifestBytes.length,
+        },
+      ],
+    }),
+  );
+  const wrappedDigest = sha256(wrappedBytes);
+
+  assert.notEqual(wrappedDigest, manifestDigest);
+  assert.throws(
+    () =>
+      validateManifestIdentity({
+        repository: "vexaai/vexa-bot",
+        expected: {
+          digest: manifestDigest,
+          platform_manifests: {
+            "linux/amd64": {
+              manifest_digest: manifestDigest,
+              config_digest: digest("3"),
+            },
+          },
+          attestations: false,
+        },
+        topDigest: wrappedDigest,
+        manifest: JSON.parse(wrappedBytes),
+        children: new Map(),
+      }),
+    (error) =>
+      error instanceof RegistryValidationError &&
+      error.kind === "identity" &&
+      error.message.includes("top descriptor mismatch"),
+  );
+});
+
+test("alias readback digest rewrite is an identity failure", async () => {
+  const bytes = Buffer.from('{"schemaVersion":2}');
+  let reads = 0;
+  await assert.rejects(
+    aliasManifest({
+      repository: "vexaai/vexa-bot",
+      sourceReference: "v0.12.18",
+      targetReference: "v012",
+      expectedDigest: digest("1"),
+      username: "user",
+      password: "token",
+      fetchImpl: async (url, options = {}) => {
+        if (String(url).includes("/token")) return response(200, { token: "push-token" });
+        if (options.method === "PUT") {
+          return response(201, "", { "docker-content-digest": digest("1") });
+        }
+        reads += 1;
+        return response(200, bytes, {
+          "content-type": "application/vnd.oci.image.manifest.v1+json",
+          "docker-content-digest": reads === 1 ? digest("1") : digest("4"),
+        });
+      },
+      authBase: "https://auth.example",
+      registryBase: "https://registry.example",
+      service: "registry.example",
+    }),
+    (error) =>
+      error instanceof RegistryValidationError &&
+      error.kind === "identity" &&
+      error.message.includes("alias readback"),
+  );
+});
+
+test("aliasing cannot move the unchanged latest negative control", async () => {
+  const bytes = Buffer.from('{"schemaVersion":2}');
+  let latestReads = 0;
+  await assert.rejects(
+    aliasManifest({
+      repository: "vexaai/vexa-bot",
+      sourceReference: "v0.12.18",
+      targetReference: "v012",
+      expectedDigest: digest("1"),
+      unchangedReference: "latest",
+      username: "user",
+      password: "token",
+      fetchImpl: async (url, options = {}) => {
+        if (String(url).includes("/token")) return response(200, { token: "push-token" });
+        const reference = decodeURIComponent(String(url).split("/manifests/")[1]);
+        if (options.method === "PUT") {
+          return response(201, "", { "docker-content-digest": digest("1") });
+        }
+        if (reference === "latest") {
+          latestReads += 1;
+          return response(200, bytes, {
+            "content-type": "application/vnd.oci.image.manifest.v1+json",
+            "docker-content-digest": latestReads === 1 ? digest("8") : digest("7"),
+          });
+        }
+        return response(200, bytes, {
+          "content-type": "application/vnd.oci.image.manifest.v1+json",
+          "docker-content-digest": digest("1"),
+        });
+      },
+      authBase: "https://auth.example",
+      registryBase: "https://registry.example",
+      service: "registry.example",
+    }),
+    (error) =>
+      error instanceof RegistryValidationError &&
+      error.kind === "identity" &&
+      error.message.includes("negative-control descriptor moved"),
   );
 });

--- a/scripts/registry-manifest-alias.mjs
+++ b/scripts/registry-manifest-alias.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+import {
+  aliasManifest,
+  RegistryValidationError,
+  verifyCandidateMapHash,
+} from "./registry-candidate-validate.mjs";
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (key === "--candidate-map") result.candidateMap = argv[++index];
+    else if (key === "--expected-map-sha256") result.expectedMapHash = argv[++index];
+    else if (key === "--repository") result.repository = argv[++index];
+    else if (key === "--source-tag") result.sourceTag = argv[++index];
+    else if (key === "--target-tag") result.targetTag = argv[++index];
+    else if (key === "--assert-unchanged-tag") result.unchangedTag = argv[++index];
+    else throw new Error(`unknown argument: ${key}`);
+  }
+  if (
+    !result.candidateMap ||
+    !/^[0-9a-f]{64}$/.test(result.expectedMapHash ?? "") ||
+    !result.repository ||
+    !result.sourceTag ||
+    !result.targetTag
+  ) {
+    throw new Error(
+      "usage: registry-manifest-alias.mjs --candidate-map <file> " +
+        "--expected-map-sha256 <64-hex> --repository <owner/name> " +
+        "--source-tag <tag> --target-tag <tag> [--assert-unchanged-tag <tag>]",
+    );
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = await readFile(args.candidateMap);
+  verifyCandidateMapHash(raw, args.expectedMapHash);
+  const candidateMap = JSON.parse(raw);
+  const expected = candidateMap.images[args.repository];
+  if (!expected) {
+    throw new RegistryValidationError(
+      "identity",
+      `${args.repository}: repository is not present in the frozen candidate map`,
+    );
+  }
+  if (candidateMap.stable_tag !== args.sourceTag) {
+    throw new RegistryValidationError(
+      "identity",
+      `candidate map stable_tag ${candidateMap.stable_tag} does not match source ${args.sourceTag}`,
+    );
+  }
+
+  const receipt = await aliasManifest({
+    repository: args.repository,
+    sourceReference: args.sourceTag,
+    targetReference: args.targetTag,
+    expectedDigest: expected.digest,
+    unchangedReference: args.unchangedTag,
+    username: process.env.DOCKERHUB_USERNAME,
+    password: process.env.DOCKERHUB_TOKEN,
+  });
+  console.log(
+    `✓ exact manifest alias ${args.repository}:${args.targetTag} = ${receipt.targetDigest}` +
+      (args.unchangedTag
+        ? `; ${args.unchangedTag} unchanged at ${receipt.unchangedDigest}`
+        : ""),
+  );
+}
+
+main().catch((error) => {
+  if (error instanceof RegistryValidationError) {
+    console.error(`registry-manifest-alias [${error.kind}]: ${error.message}`);
+    process.exitCode =
+      error.kind === "identity" ? 4 : error.kind === "auth" ? 5 : error.kind === "quota" ? 6 : 7;
+  } else {
+    console.error(`registry-manifest-alias [internal]: ${error.stack || error.message}`);
+    process.exitCode = 2;
+  }
+});


### PR DESCRIPTION
**Delivers issue:** #951

## Observation bundle (the record of the harnessed loop)

- **C1 — single-manifest point of introduction:** expected an alias operation to preserve the source top descriptor; the fixture models the observed `imagetools` behavior and sees an OCI manifest wrapped in a new OCI index, changing its top digest. This reproduces run 30090194354's Bot `a7f8… → 43ec…` red without touching Docker Hub.
- **C2 — authenticated manifest alias:** expected a scoped `pull,push` token, exact source bytes/media type PUT, and exact response/readback digest; the fixture sees byte-for-byte equality and the unchanged source top digest.
- **C3 — exact release population:** expected the immutable candidate map to remain sha256:80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f with 10 top descriptors and 19 platform manifest/config identities; the real-map control sees exactly 10/19. The post-promotion workflow reads that entire population and linked attestations from `:v012`.
- **C4 — negative/error controls:** injected 401, 429, network, alias digest rewrite, and moved `:latest` are separately classified; the Bot-only repair selector leaves the other nine aliases unselected.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 — reproduce single-manifest retag red | `red control: an imagetools-style index wrapper changes a single-manifest top digest` GREEN as a negative control; it proves wrapper digest ≠ source digest and the candidate validator rejects it as `identity`. Historical live anchor: run 30090194354 job 89473145412. |
| A2 — preserve exact manifest | `single-manifest alias writes the exact source bytes and preserves its top digest` GREEN; asserts scoped `repository:vexaai/vexa-bot:pull,push`, exact request bytes/media type, PUT digest, and GET readback bytes/digest. |
| A3 — typed failures | 401=`auth`, 429=`quota`, network=`network`, rewritten alias=`identity`; all GREEN in the 12-test control suite. |
| A4 — frozen population | Real candidate-map raw hash and exact 10-top/19-platform counts GREEN; promotion finishes with authenticated full-map `:v012` readback including linked attestations. |
| A5 — no collateral alias movement | `promote_repository=vexaai/vexa-bot` selects only Bot; `latest` is snapshotted before PUT and must be identical after. A moved negative control fails as `identity`. No build, Git tag, hosted, stage, or prod operation exists in this diff. |

## Docs diff (D6c)

`docs/changelog.d/951-manifest-preserving-release-alias.md` records the operator-visible release-tooling contract: exact manifest copy, readback, and unchanged `:latest` negative control. No product/runtime documentation changes because this is release tooling only.

## Security checks (required on the diff)

- `node --test scripts/registry-candidate-validate.test.mjs` — 12/12 GREEN.
- Pre-push static gate suite — GREEN, including isolation, schema, contract, licences, execution environment, and contract conformance.
- Focused `gate:node`, `gate:docs-version`, and `gate:licenses` — GREEN.
- `git diff --check` and JS syntax checks — GREEN.
- Full local suite also ran. Unrelated baseline reds: existing `schema.seal.json` lambda-spacing drift; transcription Python/health lane; compose readiness raced a removed stale container. The exact `vexa-compose-gate` project was torn down without `-v`; no named volume was removed. Hosted CI is the closing authority.

## Validation request

A fresh non-author should review exact head `a554eb81f350be68efa1825aee5fc65d88dc65f5` and corroborate:

1. source manifest bytes/media type are the exact PUT payload;
2. scoped Registry API auth and typed faults are correct;
3. repair dispatch with `promote_repository=vexaai/vexa-bot`, `promote=true`, `promote_latest=false` can touch only Bot `:v012`;
4. post-write readback proves exact 10 top + 19 platform/config identities and linked attestations, with `:latest` unchanged.

Deployment validated: fixture/local release harness only at this head. No image, Lite, Compose, k8s, hosted, stage, or prod deployment is claimed or required for this byte-orthogonal tooling change. The real registry mutation remains gated until merge and protected environment approval.

## Authorship

Sole author: Dmitry Grankin. No agent co-author trailers (D13).
Tooling disclosure: Codex assisted with implementation and evidence collection; authorship and responsibility remain with the submitter.