### PR TITLE
docs: hosted runs Vexa 0.12 for meetings/transcription; agents remain self-hosted (#954)

### DIFF
--- a/docs/changelog.d/954-hosted-012-start-here.md
+++ b/docs/changelog.d/954-hosted-012-start-here.md
@@ -1,0 +1,4 @@
+- **Start here: hosted now runs Vexa 0.12 for meeting bots and transcription (#954).** The Overview
+  page no longer says hosted [vexa.ai](https://vexa.ai) is on the 0.10 line. It states the current
+  boundary: hosted runs 0.12 for meeting bots and transcription but does not include the agent
+  runtime — agents and the full stack require [self-hosting](/deployment).

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -11,7 +11,7 @@ description: "Sandboxed AI agents that grow corporate knowledge from your meetin
 Real-time transcripts from Google Meet, Zoom, Teams, and Jitsi (Whisper included), fed to agents that build knowledge as code — fully self-hosted.
 
 <Note>
-  **These docs cover Vexa 0.12.** The hosted [vexa.ai](https://vexa.ai) runs the 0.10 line today and will be updated to 0.12 soon — to try 0.12 now, [self-host it](#try-it) below.
+  **These docs cover Vexa 0.12.** The hosted [vexa.ai](https://vexa.ai) runs Vexa 0.12 for meeting bots and transcription today — it does not currently include the agent runtime. To run agents and the full stack, [self-host it](#try-it) below.
 </Note>
 
 Vexa tightens the loop every organization runs on: **sense → think → act**. Meetings and docs are
@@ -86,7 +86,7 @@ The API comes up at `http://localhost:18056` (gateway) and the terminal web
 workbench at `http://localhost:13000`. Full options — air-gapped, bring-your-own
 inference — in [Deployment](/deployment).
 
-**Prefer to look before you build?** Hosted [vexa.ai](https://vexa.ai) runs the 0.10 line today; it moves to 0.12 soon. These docs describe the 0.12 stack you self-host above.
+**Prefer to look before you build?** Hosted [vexa.ai](https://vexa.ai) runs Vexa 0.12 for meeting bots and transcription today — agents aren't part of the hosted service yet. These docs describe the full 0.12 stack, agents included, that you self-host above.
 
 ## Why Vexa
 


### PR DESCRIPTION
Closes #954

## What

The Start here / Overview page (`docs/docs/index.mdx`) still said hosted vexa.ai runs the 0.10 line and would move to 0.12 "soon". Hosted is now on the 0.12 meeting/transcription product but does **not** offer the agent runtime. Two sentences updated (the `<Note>` at the top and the "Prefer to look before you build?" line); a changelog fragment added. Docs-only — no code, API, environment, release, or capability change.

## Observation bundle (acceptance table, issue numbering)

| Row | Expected (Green) | Actual | Verdict |
|---|---|---|---|
| A1 version truth | Start page says hosted meeting/transcription runs 0.12 | Both sentences now read "runs Vexa 0.12 for meeting bots and transcription today" | ✅ |
| A2 capability boundary | adjacent copy explicitly says agents require self-hosting | Note: "it does not currently include the agent runtime. To run agents and the full stack, [self-host it] below." | ✅ |
| A3 no regression | self-host link remains the path for agents and full stack | `[self-host it](#try-it)` preserved; both lines route agents/full-stack to self-host | ✅ |
| A4 consistency | targeted docs search finds no stale hosted-0.10 sentence | `grep "0.10 line\|moves to 0.12 soon\|updated to 0.12 soon" docs/docs/index.mdx` → no matches | ✅ |

Remaining `0.10` references in the tree are legitimate historical/compat context (changelog migration notes, bot-image compat warnings, deprecated dashboard) — not the hosted-version claim.

## Checks

- `node scripts/gates.mjs docs-version` → green (docs reflect v0.12.18, matches Chart.yaml).
- `node scripts/changelog-collect.mjs --check` → fragment `954-hosted-012-start-here.md` recognized.
