### PR TITLE
feat(join): define unsigned Zoom browser product contract (#938)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts && tsx src/inject-lifetime.test.ts",
+    "test": "tsx src/browser-product.test.ts && tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts && tsx src/inject-lifetime.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/browser-product.test.ts && tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts && tsx src/inject-lifetime.test.ts",
+    "test": "tsx src/browser-product.test.ts && tsx src/browser-product-custody.test.ts && tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts && tsx src/inject-lifetime.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/__fixtures__/README.md
+++ b/core/meetings/modules/join/src/__fixtures__/README.md
@@ -1,0 +1,18 @@
+# Join contract fixtures
+
+Offline acceptance fixtures for contracts owned by `@vexa/join`. They describe
+decisions the join boundary must make before an embedder launches a browser;
+they are not captured pages, browser binaries, or final-image evidence.
+
+`browser-product.contract.v1.json` records the #938 prepared fork: unsigned
+stock Zoom selects Playwright 1.61.1 with Firefox 151 revision 1532 and a fresh
+ephemeral profile, while authenticated Zoom and non-Zoom platforms retain the
+existing Chromium lane. Its artifact paths, notice requirements, native-image
+matrix, and Chrome-for-Testing exclusions come from the public P17 decision
+packet on #938; the arm64 source-image digest is explicitly research
+provenance, not proof for another architecture.
+
+Ownership stays in this package. Change the fixture, `browser-product.ts`, and
+`browser-product.test.ts` together. Runtime wiring, image assembly, licence
+files, and SBOM emission remain owned by their respective service/deployment
+boundaries and require their own evidence.

--- a/core/meetings/modules/join/src/__fixtures__/browser-product.contract.v1.json
+++ b/core/meetings/modules/join/src/__fixtures__/browser-product.contract.v1.json
@@ -1,0 +1,129 @@
+{
+  "schema": "zoom-browser-product-contract.v1",
+  "unsignedZoomStockBrowser": {
+    "driver": {
+      "package": "playwright",
+      "version": "1.61.1"
+    },
+    "browser": {
+      "engine": "firefox",
+      "version": "151.0",
+      "playwrightRevision": "1532",
+      "artifactPath": "/ms-playwright/firefox-1532"
+    },
+    "profilePolicy": "fresh_ephemeral",
+    "stockEvidenceEligible": true
+  },
+  "selectionMatrix": [
+    {
+      "case": "unsigned_zoom_stock",
+      "input": {
+        "platform": "zoom",
+        "authenticated": false
+      },
+      "expected": {
+        "engine": "firefox",
+        "runtime": "unsigned_zoom_stock",
+        "profilePolicy": "fresh_ephemeral",
+        "stockEvidenceEligible": true
+      }
+    },
+    {
+      "case": "authenticated_zoom",
+      "input": {
+        "platform": "zoom",
+        "authenticated": true
+      },
+      "expected": {
+        "engine": "chromium",
+        "runtime": "existing",
+        "profilePolicy": "authenticated_persistent",
+        "stockEvidenceEligible": false
+      }
+    },
+    {
+      "case": "google_meet",
+      "input": {
+        "platform": "google_meet",
+        "authenticated": false
+      },
+      "expected": {
+        "engine": "chromium",
+        "runtime": "existing",
+        "profilePolicy": "existing",
+        "stockEvidenceEligible": false
+      }
+    },
+    {
+      "case": "teams",
+      "input": {
+        "platform": "teams",
+        "authenticated": false
+      },
+      "expected": {
+        "engine": "chromium",
+        "runtime": "existing",
+        "profilePolicy": "existing",
+        "stockEvidenceEligible": false
+      }
+    },
+    {
+      "case": "jitsi",
+      "input": {
+        "platform": "jitsi",
+        "authenticated": false
+      },
+      "expected": {
+        "engine": "chromium",
+        "runtime": "existing",
+        "profilePolicy": "existing",
+        "stockEvidenceEligible": false
+      }
+    },
+    {
+      "case": "operator_override",
+      "input": {
+        "platform": "zoom",
+        "authenticated": false,
+        "executablePath": "/operator/browser"
+      },
+      "expected": {
+        "engine": "operator",
+        "runtime": "operator_override",
+        "profilePolicy": "fresh_ephemeral",
+        "stockEvidenceEligible": false,
+        "executablePath": "/operator/browser"
+      }
+    }
+  ],
+  "artifactCustody": {
+    "copyOnly": "/ms-playwright/firefox-1532",
+    "researchArm64SourceImage": "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e",
+    "requiredNativeEvidence": [
+      "bot_linux_amd64",
+      "lite_linux_amd64",
+      "lite_linux_arm64"
+    ],
+    "requiredNotices": [
+      "MPL-2.0",
+      "firefox_embedded_third_party_inventory"
+    ],
+    "requiredNestedComponents": [
+      "liblgpllibs.so"
+    ],
+    "forbiddenArtifacts": [
+      {
+        "product": "chrome-for-testing",
+        "version": "149.0.7827.55",
+        "playwrightRevision": "1228",
+        "path": "/ms-playwright/chromium-1228"
+      },
+      {
+        "product": "chrome-headless-shell-for-testing",
+        "version": "149.0.7827.55",
+        "playwrightRevision": "1228",
+        "path": "/ms-playwright/chromium_headless_shell-1228"
+      }
+    ]
+  }
+}

--- a/core/meetings/modules/join/src/browser-product-custody.test.ts
+++ b/core/meetings/modules/join/src/browser-product-custody.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #938 P2 — the static browser artifact contract must fail closed when its
+ * selected Firefox identity, copy-only path, CfT exclusions, or provenance
+ * contradict each other.
+ *
+ * Run:
+ *   pnpm --filter @vexa/join exec tsx src/browser-product-custody.test.ts
+ */
+
+import assert from "assert/strict";
+import contractFixture from "./__fixtures__/browser-product.contract.v1.json";
+import * as browserProduct from "./browser-product";
+
+type MutableContract = typeof contractFixture;
+type ContractValidator = (value: unknown) => MutableContract;
+
+const validate = (
+  browserProduct as typeof browserProduct & {
+    validateBrowserProductContract?: ContractValidator;
+  }
+).validateBrowserProductContract;
+
+assert.equal(
+  typeof validate,
+  "function",
+  "CUSTODY_VALIDATOR_RED: browser-product has no fail-closed artifact contract validator",
+);
+
+const validateContract = validate as ContractValidator;
+
+function mutated(change: (contract: MutableContract) => void): MutableContract {
+  const copy = structuredClone(contractFixture);
+  change(copy);
+  return copy;
+}
+
+function rejects(label: string, change: (contract: MutableContract) => void): void {
+  assert.throws(
+    () => validateContract(mutated(change)),
+    /BROWSER_PRODUCT_CONTRACT_INVALID:/,
+    label,
+  );
+}
+
+assert.doesNotThrow(
+  () => validateContract(structuredClone(contractFixture)),
+  "prepared Firefox contract is valid",
+);
+
+rejects("copyOnly must equal the selected Firefox artifact path", (contract) => {
+  contract.artifactCustody.copyOnly = "/ms-playwright/chromium-1228";
+});
+
+const forbiddenFields = [
+  ["product", "firefox"],
+  ["version", "151.0"],
+  ["playwrightRevision", "1532"],
+  ["path", "/ms-playwright/firefox-1532"],
+] as const;
+
+for (const index of [0, 1] as const) {
+  for (const [field, replacement] of forbiddenFields) {
+    rejects(`forbidden artifact ${index} binds ${field}`, (contract) => {
+      contract.artifactCustody.forbiddenArtifacts[index][field] = replacement;
+    });
+  }
+}
+
+rejects("arm64 source-image provenance binds the researched digest", (contract) => {
+  contract.artifactCustody.researchArm64SourceImage =
+    "mcr.microsoft.com/playwright@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+});
+
+console.log(
+  "CUSTODY_GREEN: copyOnly, full CfT exclusions, and source-image provenance fail closed",
+);

--- a/core/meetings/modules/join/src/browser-product.test.ts
+++ b/core/meetings/modules/join/src/browser-product.test.ts
@@ -9,6 +9,7 @@
 import assert from "assert/strict";
 import { readFileSync } from "fs";
 import { join } from "path";
+import * as publicApi from "./index";
 
 type Contract = {
   schema: string;
@@ -112,18 +113,19 @@ async function main(): Promise<void> {
     "FIXTURE_GREEN: selection, Firefox custody, no-CfT, and official-test-page contracts are coherent",
   );
 
-  let browserProduct: {
+  assert.equal(
+    typeof (publicApi as Record<string, unknown>).selectBrowserProduct,
+    "function",
+    "PUBLIC_API_RED: @vexa/join does not export selectBrowserProduct from its governed front door",
+  );
+  const browserProduct = publicApi as typeof publicApi & {
     selectBrowserProduct: (input: Record<string, unknown>) => Record<string, unknown>;
   };
-  try {
-    const modulePath = "./browser-product";
-    browserProduct = await import(modulePath);
-  } catch (error) {
-    throw new Error(
-      "BROWSER_PRODUCT_RED: @vexa/join has no native browser/profile selection seam",
-      { cause: error },
-    );
-  }
+  assert.deepEqual(
+    browserProduct.browserProductContract,
+    contract,
+    "public front door exports the validated browser-product contract",
+  );
 
   for (const row of contract.selectionMatrix) {
     assert.deepEqual(

--- a/core/meetings/modules/join/src/browser-product.test.ts
+++ b/core/meetings/modules/join/src/browser-product.test.ts
@@ -1,0 +1,140 @@
+/**
+ * #938 browser-product contract — the decision is explicit before any browser
+ * is launched or a live meeting is contacted.
+ *
+ * Run:
+ *   pnpm --filter @vexa/join exec tsx src/browser-product.test.ts
+ */
+
+import assert from "assert/strict";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+type Contract = {
+  schema: string;
+  unsignedZoomStockBrowser: {
+    driver: { package: string; version: string };
+    browser: {
+      engine: string;
+      version: string;
+      playwrightRevision: string;
+      artifactPath: string;
+    };
+    profilePolicy: string;
+    stockEvidenceEligible: boolean;
+  };
+  selectionMatrix: Array<{
+    case: string;
+    input: Record<string, unknown>;
+    expected: Record<string, unknown>;
+  }>;
+  artifactCustody: {
+    copyOnly: string;
+    requiredNativeEvidence: string[];
+    requiredNotices: string[];
+    requiredNestedComponents: string[];
+    forbiddenArtifacts: Array<{
+      product: string;
+      playwrightRevision: string;
+      path: string;
+    }>;
+  };
+};
+
+type OfficialTestPage = {
+  schema: string;
+  url: string;
+  purpose: string;
+  participantTraffic: string;
+  profilePolicy: string;
+  doesNotProve: string[];
+};
+
+function readFixture<T>(...segments: string[]): T {
+  return JSON.parse(readFileSync(join(__dirname, ...segments), "utf8")) as T;
+}
+
+async function main(): Promise<void> {
+  const contract = readFixture<Contract>(
+    "__fixtures__",
+    "browser-product.contract.v1.json",
+  );
+  const officialPage = readFixture<OfficialTestPage>(
+    "zoom",
+    "__fixtures__",
+    "official-test-page.v1.json",
+  );
+
+  assert.equal(contract.schema, "zoom-browser-product-contract.v1");
+  assert.deepEqual(contract.unsignedZoomStockBrowser, {
+    driver: { package: "playwright", version: "1.61.1" },
+    browser: {
+      engine: "firefox",
+      version: "151.0",
+      playwrightRevision: "1532",
+      artifactPath: "/ms-playwright/firefox-1532",
+    },
+    profilePolicy: "fresh_ephemeral",
+    stockEvidenceEligible: true,
+  });
+  assert.deepEqual(contract.artifactCustody.requiredNativeEvidence, [
+    "bot_linux_amd64",
+    "lite_linux_amd64",
+    "lite_linux_arm64",
+  ]);
+  assert(contract.artifactCustody.requiredNotices.includes("MPL-2.0"));
+  assert(contract.artifactCustody.requiredNestedComponents.includes("liblgpllibs.so"));
+  assert.deepEqual(
+    contract.artifactCustody.forbiddenArtifacts.map(({ playwrightRevision, path }) => ({
+      playwrightRevision,
+      path,
+    })),
+    [
+      {
+        playwrightRevision: "1228",
+        path: "/ms-playwright/chromium-1228",
+      },
+      {
+        playwrightRevision: "1228",
+        path: "/ms-playwright/chromium_headless_shell-1228",
+      },
+    ],
+  );
+
+  assert.equal(officialPage.schema, "zoom-official-test-page.v1");
+  assert.equal(officialPage.url, "https://zoom.us/test");
+  assert.equal(officialPage.purpose, "native_stock_image_negative_control");
+  assert.equal(officialPage.participantTraffic, "forbidden");
+  assert.equal(officialPage.profilePolicy, "fresh_ephemeral");
+  assert(officialPage.doesNotProve.includes("protected_room_admission"));
+
+  console.log(
+    "FIXTURE_GREEN: selection, Firefox custody, no-CfT, and official-test-page contracts are coherent",
+  );
+
+  let browserProduct: {
+    selectBrowserProduct: (input: Record<string, unknown>) => Record<string, unknown>;
+  };
+  try {
+    const modulePath = "./browser-product";
+    browserProduct = await import(modulePath);
+  } catch (error) {
+    throw new Error(
+      "BROWSER_PRODUCT_RED: @vexa/join has no native browser/profile selection seam",
+      { cause: error },
+    );
+  }
+
+  for (const row of contract.selectionMatrix) {
+    assert.deepEqual(
+      browserProduct.selectBrowserProduct(row.input),
+      row.expected,
+      row.case,
+    );
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/core/meetings/modules/join/src/browser-product.ts
+++ b/core/meetings/modules/join/src/browser-product.ts
@@ -1,0 +1,59 @@
+import contract from "./__fixtures__/browser-product.contract.v1.json";
+
+export type JoinPlatform = "google_meet" | "teams" | "zoom" | "jitsi";
+export type BrowserEngine = "chromium" | "firefox" | "operator";
+export type BrowserRuntime = "existing" | "unsigned_zoom_stock" | "operator_override";
+export type BrowserProfilePolicy =
+  | "existing"
+  | "fresh_ephemeral"
+  | "authenticated_persistent";
+
+export interface BrowserProductInput {
+  platform: JoinPlatform;
+  authenticated?: boolean;
+  executablePath?: string;
+}
+
+export interface BrowserProductSelection {
+  engine: BrowserEngine;
+  runtime: BrowserRuntime;
+  profilePolicy: BrowserProfilePolicy;
+  stockEvidenceEligible: boolean;
+  executablePath?: string;
+}
+
+export const browserProductContract = contract;
+
+export function selectBrowserProduct(
+  input: BrowserProductInput,
+): BrowserProductSelection {
+  if (input.executablePath) {
+    return {
+      engine: "operator",
+      runtime: "operator_override",
+      profilePolicy: input.authenticated
+        ? "authenticated_persistent"
+        : "fresh_ephemeral",
+      stockEvidenceEligible: false,
+      executablePath: input.executablePath,
+    };
+  }
+
+  if (input.platform === "zoom" && !input.authenticated) {
+    return {
+      engine: "firefox",
+      runtime: "unsigned_zoom_stock",
+      profilePolicy: "fresh_ephemeral",
+      stockEvidenceEligible: true,
+    };
+  }
+
+  return {
+    engine: "chromium",
+    runtime: "existing",
+    profilePolicy: input.authenticated
+      ? "authenticated_persistent"
+      : "existing",
+    stockEvidenceEligible: false,
+  };
+}

--- a/core/meetings/modules/join/src/browser-product.ts
+++ b/core/meetings/modules/join/src/browser-product.ts
@@ -22,7 +22,100 @@ export interface BrowserProductSelection {
   executablePath?: string;
 }
 
-export const browserProductContract = contract;
+export interface BrowserProductContract {
+  schema: "zoom-browser-product-contract.v1";
+  unsignedZoomStockBrowser: {
+    driver: { package: "playwright"; version: "1.61.1" };
+    browser: {
+      engine: "firefox";
+      version: "151.0";
+      playwrightRevision: "1532";
+      artifactPath: "/ms-playwright/firefox-1532";
+    };
+    profilePolicy: "fresh_ephemeral";
+    stockEvidenceEligible: true;
+  };
+  selectionMatrix: Array<{
+    case: string;
+    input: BrowserProductInput;
+    expected: BrowserProductSelection;
+  }>;
+  artifactCustody: {
+    copyOnly: "/ms-playwright/firefox-1532";
+    researchArm64SourceImage: string;
+    requiredNativeEvidence: string[];
+    requiredNotices: string[];
+    requiredNestedComponents: string[];
+    forbiddenArtifacts: Array<{
+      product: string;
+      version: string;
+      playwrightRevision: string;
+      path: string;
+    }>;
+  };
+}
+
+const RESEARCH_ARM64_SOURCE_IMAGE =
+  "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e";
+
+const FORBIDDEN_CFT_ARTIFACTS = [
+  {
+    product: "chrome-for-testing",
+    version: "149.0.7827.55",
+    playwrightRevision: "1228",
+    path: "/ms-playwright/chromium-1228",
+  },
+  {
+    product: "chrome-headless-shell-for-testing",
+    version: "149.0.7827.55",
+    playwrightRevision: "1228",
+    path: "/ms-playwright/chromium_headless_shell-1228",
+  },
+] as const;
+
+function invalidContract(reason: string): never {
+  throw new Error(`BROWSER_PRODUCT_CONTRACT_INVALID: ${reason}`);
+}
+
+export function validateBrowserProductContract(
+  value: unknown,
+): BrowserProductContract {
+  const candidate = value as Partial<BrowserProductContract>;
+  const selected = candidate.unsignedZoomStockBrowser;
+  const custody = candidate.artifactCustody;
+
+  if (candidate.schema !== "zoom-browser-product-contract.v1") {
+    invalidContract("schema must be zoom-browser-product-contract.v1");
+  }
+  if (
+    selected?.driver?.package !== "playwright" ||
+    selected.driver.version !== "1.61.1" ||
+    selected.browser?.engine !== "firefox" ||
+    selected.browser.version !== "151.0" ||
+    selected.browser.playwrightRevision !== "1532" ||
+    selected.browser.artifactPath !== "/ms-playwright/firefox-1532" ||
+    selected.profilePolicy !== "fresh_ephemeral" ||
+    selected.stockEvidenceEligible !== true
+  ) {
+    invalidContract("unsigned Zoom stock identity must be Playwright 1.61.1 / Firefox 151 rev 1532");
+  }
+  if (custody?.copyOnly !== selected.browser.artifactPath) {
+    invalidContract("artifactCustody.copyOnly must equal the selected Firefox artifact path");
+  }
+  if (custody.researchArm64SourceImage !== RESEARCH_ARM64_SOURCE_IMAGE) {
+    invalidContract("research arm64 source-image provenance does not match the prepared digest");
+  }
+  if (
+    JSON.stringify(custody.forbiddenArtifacts) !==
+    JSON.stringify(FORBIDDEN_CFT_ARTIFACTS)
+  ) {
+    invalidContract("forbidden artifacts must bind both complete CfT 149/rev 1228 tuples");
+  }
+
+  return value as BrowserProductContract;
+}
+
+export const browserProductContract = validateBrowserProductContract(contract);
 
 export function selectBrowserProduct(
   input: BrowserProductInput,

--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -32,6 +32,16 @@ export { startDebugView, setHooks };
 // Canonical browser launch args — the vexa-bot service and the debug harness both
 // build on this ONE set (browser-args.ts), so join↔bot flags never drift.
 export { JOIN_BROWSER_ARGS, getJoinBrowserArgs };
+export { browserProductContract, selectBrowserProduct } from "./browser-product";
+export type {
+  BrowserEngine,
+  BrowserProductContract,
+  BrowserProductInput,
+  BrowserProductSelection,
+  BrowserProfilePolicy,
+  BrowserRuntime,
+  JoinPlatform,
+} from "./browser-product";
 
 export type Platform = "google_meet" | "teams" | "zoom" | "jitsi";
 

--- a/core/meetings/modules/join/src/zoom/__fixtures__/README.md
+++ b/core/meetings/modules/join/src/zoom/__fixtures__/README.md
@@ -1,0 +1,17 @@
+# Zoom offline fixtures
+
+Offline metadata fixtures owned by the Zoom join implementation in
+`@vexa/join`. They define deterministic negative controls without storing
+meeting content or contacting Zoom during tests.
+
+`official-test-page.v1.json` names Zoom's public `https://zoom.us/test` page and
+the page/capability/cleanup observations required later from a native stock
+image. It contains no fetched HTML, credentials, meeting identifier, passcode,
+participant data, or screenshot. The fixture forbids participant traffic and
+cannot prove protected-room admission, CAPTCHA bypass, or universal unsigned
+Zoom support.
+
+Update this fixture with its package-local test. A real page observation must
+record its source SHA, image digest, architecture, fresh-profile custody, and
+cleanup separately; it must never be folded into this static fixture as if it
+were current runtime evidence.

--- a/core/meetings/modules/join/src/zoom/__fixtures__/official-test-page.v1.json
+++ b/core/meetings/modules/join/src/zoom/__fixtures__/official-test-page.v1.json
@@ -1,0 +1,21 @@
+{
+  "schema": "zoom-official-test-page.v1",
+  "url": "https://zoom.us/test",
+  "purpose": "native_stock_image_negative_control",
+  "expectedPage": {
+    "title": "Join a Test Meeting | Zoom",
+    "mediaDevices": true
+  },
+  "participantTraffic": "forbidden",
+  "profilePolicy": "fresh_ephemeral",
+  "cleanup": {
+    "context": "closed",
+    "profileDirectory": "removed",
+    "browserProcess": "absent"
+  },
+  "doesNotProve": [
+    "protected_room_admission",
+    "captcha_bypass",
+    "universal_unsigned_zoom_admission"
+  ]
+}


### PR DESCRIPTION
Refs #938

## What changed

This bounded source slice makes the unsigned-Zoom browser decision explicit inside `@vexa/join`, before any browser is launched:

- unsigned stock Zoom → Firefox lane, fresh ephemeral profile, stock-evidence eligible;
- authenticated Zoom and Meet/Teams/Jitsi → existing Chromium lane;
- operator executable override → explicit, never stock-evidence eligible;
- the selector and validated custody contract are exported through the governed `@vexa/join` front door;
- the fail-closed custody validator binds Playwright 1.61.1 + Firefox 151 rev 1532, `copyOnly`, the exact arm64 source-image provenance digest, and both complete forbidden CfT rev 1228 tuples;
- an offline `https://zoom.us/test` fixture defines the later native-image negative control while forbidding participant traffic and protected-admission claims.

This PR does **not** wire Firefox into a service or image.

## Exact provisional custody

- base branch: `codex/01219-final-assembly`
- base commit: `72ecb679761fc49668b8d48d54062868832ac1c9`
- review head: `2235a2c8cc61409c613b6c4f21f26bbd5203d9fb`
- review tree: `5e4ae0e7b5c20dbe618a633bf3923914b1256773`
- superseded review head: `26914ea8219f9c00b6a5df4715faaf3d00c21748` (P1/P2 findings repaired by the current head)
- superseded standalone observation: `588c689682f2b5cfefa123970c07f7791389cebe` (failed P12 directory README gate; historical parent only)

This is a provisional development lineage, not a delivered-base claim. Composition remains blocked on the public delivered v0.12.19 rebase, collision recheck, and invalidated-gate rerun.

## Exact nine-file base→head manifest

1. `core/meetings/modules/join/package.json`
2. `core/meetings/modules/join/src/__fixtures__/README.md`
3. `core/meetings/modules/join/src/__fixtures__/browser-product.contract.v1.json`
4. `core/meetings/modules/join/src/browser-product-custody.test.ts`
5. `core/meetings/modules/join/src/browser-product.test.ts`
6. `core/meetings/modules/join/src/browser-product.ts`
7. `core/meetings/modules/join/src/index.ts`
8. `core/meetings/modules/join/src/zoom/__fixtures__/README.md`
9. `core/meetings/modules/join/src/zoom/__fixtures__/official-test-page.v1.json`

The P1/P2 repair commit is confined to five files: `package.json`, `browser-product-custody.test.ts`, `browser-product.test.ts`, `browser-product.ts`, and `index.ts` under `core/meetings/modules/join`.

## RED → GREEN

Initial selector RED at the base:

```
FIXTURE_GREEN: selection, Firefox custody, no-CfT, and official-test-page contracts are coherent
BROWSER_PRODUCT_RED: @vexa/join has no native browser/profile selection seam
```

Review P1 RED at `26914ea8…`:

```
PUBLIC_API_RED: @vexa/join does not export selectBrowserProduct from its governed front door
actual: undefined; expected: function
```

Review P2 RED at `26914ea8…`:

```
CUSTODY_VALIDATOR_RED: browser-product has no fail-closed artifact contract validator
actual: undefined; expected: function
```

GREEN at `2235a2c8…` / `5e4ae0e7…`:

- public selector/fixture matrix: exit 0
- custody mutations (`copyOnly`, every field of both forbidden CfT tuples, source-image digest): exit 0
- compiled `dist/index` front-door probe: exit 0
- `pnpm --filter @vexa/join build`: exit 0
- `pnpm --filter @vexa/join check:isolation`: exit 0, 58 files
- `node scripts/gates.mjs readme`: exit 0, 313 directories
- `git diff --check`: exit 0
- pre-push: all 14 static gates green

## Fresh non-author review

Verdict for exact head `2235a2c8…` / tree `5e4ae0e7…`: **CLEAN — no findings.** The reviewer verified the governed source and compiled front door, every P2 custody mutation control, selector behavior, and the five-file/nine-file scope boundaries. Receipt: https://github.com/Vexa-ai/vexa/pull/957#issuecomment-5071144553

PR #923 owns the shared packaging/licence seams. This PR does not enter `THIRD_PARTY_LICENSES.md`, Lite Dockerfile, gates, SBOM, or `image-licenses.json`.

## Explicitly unclaimed

No browser launch, network request, native image, Firefox binary custody, licence/SBOM implementation, protected-room admission, CAPTCHA bypass, universal Zoom support, shared bot/config/deployment change, stage/prod mutation, or final composition.

## Accidental aggregate-run custody

A previously started aggregate command is excluded from all proof. Its newly created Compose containers were brought down without `-v`; all three named project volumes remain. A pre-existing exited Redis metadata ghost `dcfe28d7…` remains uninspectable and out of scope; it must not be touched. No stage or prod environment was involved.