### PR TITLE
docs: align hosted 0.12 product truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Markdown knowledge base your team owns. Self-hosted, Apache-2.0, air-gap-ready.
 [![Self-hosted](https://img.shields.io/badge/deploy-self--hosted-success.svg)](#-quickstart)
 [![Discord](https://img.shields.io/badge/chat-Discord-5865F2.svg)](https://discord.gg/Ga9duGkVz9)
 
-**[vexa.ai](https://vexa.ai)** still runs the 0.10.6.13 line — it will host **0.12**.
+**[vexa.ai](https://vexa.ai)** runs Vexa 0.12 for meeting bots and transcription.
+Sandboxed knowledge agents are self-hosted only — [self-host Vexa](#-quickstart) to run the full stack.
 
 </div>
 

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -11,7 +11,7 @@ description: "Sandboxed AI agents that grow corporate knowledge from your meetin
 Real-time transcripts from Google Meet, Zoom, Teams, and Jitsi (Whisper included), fed to agents that build knowledge as code — fully self-hosted.
 
 <Note>
-  **These docs cover Vexa 0.12.** The hosted [vexa.ai](https://vexa.ai) runs Vexa 0.12 for meeting bots and transcription today — it does not currently include the agent runtime. To run agents and the full stack, [self-host it](#try-it) below.
+  **These docs cover Vexa 0.12.** Hosted [vexa.ai](https://vexa.ai) runs the 0.12 meeting and transcription experience. Sandboxed knowledge agents are currently self-hosted only — [self-host Vexa](#try-it) to run the full meetings → agents stack.
 </Note>
 
 Vexa tightens the loop every organization runs on: **sense → think → act**. Meetings and docs are


### PR DESCRIPTION
Part of #959

## Expected
Public entry points say hosted Vexa runs the 0.12 meeting/transcription experience, while sandboxed knowledge agents and the full meetings → agents stack require self-hosting. No current copy says hosted is still 0.10 or waiting for 0.12.

## Actual
- `docs/docs/index.mdx` now uses the prepared hosted/self-host split and preserves the `#try-it` self-host link.
- `README.md`, discovered as the directly coupled stale copy, now states hosted 0.12 meetings/transcription and links the self-host quickstart for agents/full stack.
- Current-doc stale-copy search is empty; the historical 0.10 changelog receipt remains unchanged.

## Acceptance evidence
- A1 hosted/self-host split: exact two-file diff at `d111639d31d2f2635e5bc8e2e058f9f0933c8145`.
- A2 stale current claims: zero matches for hosted 0.10 / waiting-for-0.12 patterns across `docs/docs` and root README, excluding historical changelog.
- A3 valid MDX/links: `@mdx-js/mdx` 3.1.1 compiled `docs/docs/index.mdx`; existing `#try-it` and `#-quickstart` targets verified.
- A4 gates: pre-push static 14/14 green; full CI-static parity gates green; gate-script tests 64/64. Local system Python 3.9 reproduced the known unchanged `ast.unparse` spacing false red for DB schema; supported Python 3.14 passed 68/68 sealed columns. `git diff --check` green.
- A5 mutation boundary: source/docs only. No product image, docs deployment, hosted environment, stage, or production mutation.

## Verdict
Prepared docs truth is represented consistently at both current public entry points. Fresh non-author review is requested before promotion from draft.