### PR TITLE
Integrate #923 with complete image-license and Lite SBOM coverage

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,13 +2,35 @@
 
 `gate:licenses` (ADR-0004, `scripts/gates.mjs`) scans the resolved **npm** dependency
 tree (`pnpm licenses list --json`) and the Python tree grows into `pip-licenses`. Neither
-sees **non-dependency artifacts baked into the images** — most notably model weights
-pulled from a model hub at build time. This file is the packaging-side complement: every
-such artifact is recorded here with its license, and mirrored into the per-release SPDX
-SBOM (`scripts/sbom.mjs`).
+sees **non-dependency artifacts baked into the images** — model weights pulled from a model
+hub, or a service binary built from source at image-build time. This file is the
+packaging-side complement: every such artifact is recorded here with its license, mirrored
+into the per-release SPDX SBOM (`scripts/sbom.mjs`), and — for baked binaries and pinned
+container images — audited by **`gate:image-licenses`** against
+[`image-licenses.json`](image-licenses.json) (#653).
 
 The verbatim upstream license for each entry lives under [`licenses/`](licenses/) and is
 copied into the image next to the artifact it covers, so the notice travels with the bytes.
+
+## Baked service binaries
+
+| Artifact | Version | License | Source | Baked into | In-image path |
+| --- | --- | --- | --- | --- | --- |
+| `valkey` | `8.1.9` | BSD-3-Clause | [github.com/valkey-io/valkey](https://github.com/valkey-io/valkey) | `vexaai/vexa-lite` | `/usr/local/bin/valkey-server`, `/usr/local/share/valkey/LICENSE` |
+
+**`valkey`** — the internal cache / stream store (bus, scheduler, per-dispatch streams). Lite
+builds `valkey-server` + `valkey-cli` from the pinned git tag in the `valkey-builder` stage of
+[`deploy/lite/Dockerfile.lite`](deploy/lite/Dockerfile.lite) (glibc-matched to the final image;
+an alpine/musl binary can't run there) and copies them onto `PATH`. Valkey is the Linux
+Foundation's BSD-3-Clause fork of Redis 7.2.4 — it has `XAUTOCLAIM` (parity with compose/helm)
+and keeps Lite off both jammy apt's stale Redis 6.0.16 and source-available Redis ≥7.4
+(RSALv2/SSPLv1). compose and helm pin `valkey/valkey:8-alpine` (operator-pulled, recorded in
+[`image-licenses.json`](image-licenses.json)). Full text:
+[`licenses/valkey-8.1.9.COPYING.txt`](licenses/valkey-8.1.9.COPYING.txt).
+
+> BSD-3-Clause is a Category-A (permissive) license under ADR-0004; baking it requires no
+> exception, only that the notice be preserved — which this file and the in-image
+> `/usr/local/share/valkey/LICENSE` satisfy.
 
 ## Baked model weights
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -12,6 +12,11 @@ container images — audited by **`gate:image-licenses`** against
 The verbatim upstream license for each entry lives under [`licenses/`](licenses/) and is
 copied into the image next to the artifact it covers, so the notice travels with the bytes.
 
+The SPDX also inventories every package name in the Lite Dockerfile's final-stage `apt install`.
+That is a source-level inventory: Docker source does not resolve Ubuntu package versions or
+package licences, so those fields are emitted as `NOASSERTION` until an image-level scanner
+enriches them. Builder-stage packages that do not cross into the final image are excluded.
+
 ## Baked service binaries
 
 | Artifact | Version | License | Source | Baked into | In-image path |

--- a/core/identity/services/admin-api/tests/conftest.py
+++ b/core/identity/services/admin-api/tests/conftest.py
@@ -40,13 +40,19 @@ def pg_async_url(pg_url):
 
 @pytest.fixture(scope="session")
 def redis_client():
-    """Ephemeral Redis → a connected redis-py client. Session-scoped."""
+    """Ephemeral Valkey → a connected redis-py client. Session-scoped.
+
+    Valkey (BSD-3 fork of Redis 7.2.4) is the engine we ship on every surface (#653); the eval runs
+    against it, not stock Redis, so the stack it witnesses matches what users deploy. RedisContainer
+    waits via a redis-py TCP PING (RESP), not an in-container `redis-cli`, so the Valkey image — which
+    ships `valkey-cli`, not `redis-cli` — is a clean drop-in.
+    """
     if not _docker_ok():
         pytest.skip("docker daemon not available")
     import redis as redis_lib
     from testcontainers.redis import RedisContainer
 
-    with RedisContainer("redis:7-alpine") as rc:
+    with RedisContainer("valkey/valkey:8-alpine") as rc:
         host = rc.get_container_host_ip()
         port = int(rc.get_exposed_port(6379))
         client = redis_lib.Redis(host=host, port=port, decode_responses=True)

--- a/core/identity/services/admin-api/tests/test_stack_redis.py
+++ b/core/identity/services/admin-api/tests/test_stack_redis.py
@@ -1,9 +1,10 @@
-"""O-STACK-2 — Redis backing-stack eval (testcontainers-redis).
+"""O-STACK-2 — Valkey backing-stack eval (testcontainers).
 
-Exercises each usage class from `services/redis.md` against an ephemeral Redis, asserting the
-REAL patterns work end-to-end:
+Runs against an ephemeral **Valkey** (the engine every surface ships, #653), asserting the REAL
+usage patterns work end-to-end on the store we deploy:
 
   Stream     XADD → XREADGROUP → XACK   — transcription_segments (consumer group collector_group)
+  Reclaim    XAUTOCLAIM                 — orphan-drain on the same stream (the #636 command; absent on Redis < 6.2)
   Pub/Sub    PUBLISH → SUBSCRIBE        — tc:meeting:*, bot_commands:meeting:*, meeting:*:status
   List queue LPUSH → BRPOP              — webhook_retry_queue
   Sorted set ZADD → ZRANGEBYSCORE       — speaker_events:{session_uid} (scheduler/score-ordered)
@@ -54,6 +55,28 @@ def test_stream_xadd_xreadgroup_xack(redis_client):
     # XACK — message acknowledged, pending drains.
     acked = r.xack(STREAM, GROUP, got_id)
     assert acked == 1
+    assert r.xpending(STREAM, GROUP)["pending"] == 0
+
+
+def test_stream_xautoclaim_reclaims_orphans(redis_client):
+    """The orphan-reclaim path (#636): XAUTOCLAIM must exist and drain a pending entry from a dead
+    consumer to a survivor. This is the exact command jammy's Redis 6.0.16 lacked — asserting it
+    against the shipped Valkey engine is what makes the eval witness the store users run (#653)."""
+    r = redis_client
+    r.delete(STREAM)
+    r.xgroup_create(STREAM, GROUP, id="0", mkstream=True)
+    msg_id = r.xadd(STREAM, {"payload": json.dumps({"uid": "orphan"})})
+
+    # "dead" consumer reads the message but never acks — it stays pending, owned by the dead consumer.
+    r.xreadgroup(GROUP, "consumer-dead", {STREAM: ">"}, count=10)
+    assert r.xpending(STREAM, GROUP)["pending"] == 1
+
+    # XAUTOCLAIM (min-idle 0) transfers the orphan to the survivor — the reclaim the collector runs.
+    cursor, claimed, _deleted = r.xautoclaim(STREAM, GROUP, "consumer-survivor", min_idle_time=0, start_id="0")
+    assert any(cid == msg_id for cid, _fields in claimed), "XAUTOCLAIM did not reclaim the orphaned entry"
+
+    # The survivor now owns it; ack drains the group to empty.
+    assert r.xack(STREAM, GROUP, msg_id) == 1
     assert r.xpending(STREAM, GROUP)["pending"] == 0
 
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 # deploy — the v0.12 container composition (Compose)
 
 Brings up the whole v0.12 control plane as one ordered, health-gated stack: the infra
-(`postgres:17` · `redis:7` · `minio` + `minio-init`) and the four long-running Python
+(`postgres:17` · `valkey:8` · `minio` + `minio-init`) and the four long-running Python
 services — **admin-api · runtime · agent-api · meeting-api · gateway** — each building its own
 slim `uv` image, plus the dev hot-reload overlay and the dashboard overlay. This is the
 *composition* layer (it owns no service code); it also owns the **`execution-targets.v1`**
@@ -13,7 +13,7 @@ resolves against in planning, before execution (ADR-0020).
 | Direction | Neighbour | Via | What crosses |
 |---|---|---|---|
 | spawns-over | the 4 core services + dashboard | `<service>/Dockerfile` build + `python -m <pkg>` | container images, env wiring, ordered health-gated bring-up |
-| spawns-over | infra | `redis:7-alpine` · `postgres:17-alpine` · `minio` + `minio/mc` | the backing stores every service `depends_on: service_healthy` |
+| spawns-over | infra | `valkey/valkey:8-alpine` · `postgres:17-alpine` · `minio` + `minio/mc` | the backing stores every service `depends_on: service_healthy` |
 | spawns-over | bot | `runtime` → `/var/run/docker.sock`, `BROWSER_IMAGE=vexaai/vexa-bot:v012` | on-demand per-meeting bot container (published image, never built here) |
 | produces | `scripts/gates.mjs` (`gate:execution-env`) + planning preflight | `execution-targets.v1` JSON (`deploy/execution-targets.json`, gitignored) | the resolved targets[]/resources[] registry; `secret_ref` references only (P14) |
 | calls | host secret store | `secret_ref: vexa-secrets:<path>` / `env:<NAME>` | references to credentials — never inline secret values |

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -1,7 +1,7 @@
 # deploy/compose — the v0.12 control-plane stack (P4)
 
 `docker-compose.yml` brings up the v0.12 control plane: the infra (`postgres:17-alpine`,
-`redis:7-alpine`, `minio` + `minio-init`) and the long-running services below, each building its own
+`valkey/valkey:8-alpine`, `minio` + `minio-init`) and the long-running services below, each building its own
 slim image from `<service>/Dockerfile`:
 
 | service      | build context                          | host port | entrypoint                         |

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -1,6 +1,6 @@
 name: vexa-v012
 # v0.12 control plane (P4). The carved analog of deploy/compose/docker-compose.yml (0.11):
-# postgres:17 + redis:7 + minio + minio-init infra, then the four long-running Python services —
+# postgres:17 + valkey:8 + minio + minio-init infra, then the four long-running Python services —
 # admin-api · runtime · meeting-api · gateway — each building its own slim uv-based image.
 # Improvement over 0.11: EVERY service carries a healthcheck and depends_on waits on
 # `condition: service_healthy` so the bring-up is ordered + observable.
@@ -11,10 +11,13 @@ name: vexa-v012
 services:
   # ─── Infrastructure ───────────────────────────────────────────────────────────────────────────
   redis:
-    image: redis:7-alpine
-    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
+    # Valkey (Linux Foundation BSD-3 fork of Redis 7.2.4): parity with the Lite witness surface
+    # and off source-available Redis ≥7.4 (RSALv2/SSPLv1). Wire-compatible (RESP) — the service
+    # name, REDIS_URL, and every consumer stay put; only the engine changes (#653).
+    image: valkey/valkey:8-alpine
+    command: ["valkey-server", "--appendonly", "yes", "--appendfsync", "everysec"]
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -2,7 +2,7 @@
 
 The `helm` target of the lite/compose/helm trio: the full v0.12 stack as a Kubernetes release —
 the control plane **gateway · admin-api · meeting-api · runtime · agent-api**, the **terminal** web
-UI, and infra (`postgres:17` · `redis:7` · `minio` + a `minio-init` bucket Job). The **terminal** is
+UI, and infra (`postgres:17` · `valkey:8` · `minio` + a `minio-init` bucket Job). The **terminal** is
 the human front door (Next.js; proxies `/ws` → gateway and REST/login → agent-api/admin-api
 server-side); the gateway stays the API front door for programmatic use. The difference from compose
 is the **spawn substrate**: on k8s the `runtime` launches the bot and agent-worker as **Pods** (via

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -367,7 +367,10 @@ postgres:
 
 redis:
   enabled: true
-  image: redis:7-alpine
+  # Valkey (BSD-3 fork of Redis 7.2.4) — engine parity with Lite/compose and off source-available
+  # Redis ≥7.4. Wire-compatible (RESP): the `redis.*` keys, redisConfig.url, and the durability
+  # helper are unchanged so existing values overrides keep working; only the engine swaps (#653).
+  image: valkey/valkey:8-alpine
   service:
     port: 6379
   persistence:

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -61,21 +61,56 @@ COPY clients/terminal/ ./
 RUN npm run build && npm prune --omit=dev
 
 # -----------------------------------------------------------------------------
+# Stage 2c: valkey-builder — build valkey-server + valkey-cli from source on the SAME jammy glibc
+# as the final stage. Valkey (Linux Foundation BSD-3 fork of Redis 7.2.4) gives XAUTOCLAIM parity
+# with compose/helm and keeps Lite off BOTH ends of the #653 gap: jammy apt's stale redis 6.0.16
+# (no XAUTOCLAIM — the v0.12.5 witness root) AND source-available Redis ≥7.4 (RSALv2/SSPLv1). Built
+# from the pinned git tag, so: no external apt-repo trust (the issue verified redis's apt license
+# metadata is wrong), and no glibc mismatch — an alpine/musl binary can't run on this glibc base.
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS valkey-builder
+ARG VALKEY_VERSION=8.1.9
+# Pinned SHA-256 of the tag tarball (supply-chain, production-grade R16): the build verifies the bytes,
+# not just the version. `sha256sum -c` fails LOUD on any mismatch — a tampered or drifted tarball stops
+# the build rather than baking silently. Update this hash in lockstep whenever VALKEY_VERSION changes.
+ARG VALKEY_SHA256=f7e927534aaeb3a5f4410375c3e6f2f0c1b9257db8bc573e68f9e2dbb11344f4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL "https://github.com/valkey-io/valkey/archive/refs/tags/${VALKEY_VERSION}.tar.gz" -o /tmp/valkey.tar.gz \
+ && echo "${VALKEY_SHA256}  /tmp/valkey.tar.gz" | sha256sum -c - \
+ && mkdir -p /tmp/valkey && tar -xzf /tmp/valkey.tar.gz -C /tmp/valkey --strip-components=1 \
+ && make -C /tmp/valkey -j"$(nproc)" BUILD_TLS=no \
+ && make -C /tmp/valkey install PREFIX=/opt/valkey \
+ && cp /tmp/valkey/COPYING /valkey-COPYING \
+ && /opt/valkey/bin/valkey-server --version \
+ && /opt/valkey/bin/valkey-cli --version
+
+# -----------------------------------------------------------------------------
 # Stage 3: final — assemble the all-in-one runtime image on the same Playwright base.
 # -----------------------------------------------------------------------------
 FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final
 ENV DEBIAN_FRONTEND=noninteractive
 
-# System stack: Python (the 5 services) · supervisor · redis · X11/audio (Xvfb/fluxbox/pulse) ·
+# System stack: Python (the 5 services) · supervisor · X11/audio (Xvfb/fluxbox/pulse) ·
 # noVNC (browser view) · postgres client (pg_isready) · git (agent governance ops).
+# The cache/stream store is Valkey, copied from valkey-builder below — NOT jammy apt's redis-server
+# (6.0.16, no XAUTOCLAIM, the #653 parity gap).
 RUN apt-get update && apt-get install -y --no-install-recommends \
       python3 python3-pip python3-venv python3-dev build-essential \
-      supervisor redis-server postgresql-client \
+      supervisor postgresql-client \
       xvfb fluxbox x11vnc novnc python3-websockify \
       pulseaudio xdotool xclip socat ffmpeg libsndfile1 \
       curl git ca-certificates \
  && usermod -aG pulse-access root 2>/dev/null || true \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Valkey 8.1.9 (BSD-3) — the internal cache/stream store, glibc-matched from valkey-builder. Ships
+# valkey-server + valkey-cli on PATH (supervisord runs valkey-server; healthchecks use valkey-cli),
+# with the license notice traveling next to the bytes (THIRD_PARTY_LICENSES.md, per-release SBOM).
+COPY --from=valkey-builder /opt/valkey/bin/valkey-server /opt/valkey/bin/valkey-cli /usr/local/bin/
+COPY --from=valkey-builder /valkey-COPYING /usr/local/share/valkey/LICENSE
+RUN valkey-server --version && command -v valkey-cli
 
 # uv (the per-service venvs are resolved from each service's own pyproject + uv.lock).
 RUN pip3 install --no-cache-dir uv==0.9.22

--- a/deploy/lite/supervisord.conf
+++ b/deploy/lite/supervisord.conf
@@ -32,9 +32,11 @@ serverurl=unix:///var/run/supervisor.sock
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
-; ─── Internal Redis (bus + scheduler + per-dispatch streams) ─────────────────────────────────────
+; ─── Internal Valkey (bus + scheduler + per-dispatch streams) ────────────────────────────────────
+; Valkey (BSD-3 fork of Redis 7.2.4) — same RESP wire protocol and config flags as redis-server; the
+; REDIS_* env and every consumer are unchanged (#653). Program name stays `redis` (the bus's identity).
 [program:redis]
-command=/usr/bin/redis-server --bind 127.0.0.1 --port 6379 --dir /var/lib/redis --appendonly yes --appendfsync everysec --protected-mode yes
+command=/usr/local/bin/valkey-server --bind 127.0.0.1 --port 6379 --dir /var/lib/redis --appendonly yes --appendfsync everysec --protected-mode yes
 autostart=true
 autorestart=true
 priority=5

--- a/docs/changelog.d/653-redis-to-valkey.md
+++ b/docs/changelog.d/653-redis-to-valkey.md
@@ -1,0 +1,11 @@
+- **Every deploy surface now runs Valkey 8.1.9 instead of Redis (#653).** Vexa Lite, Docker
+  Compose, and Helm all use [Valkey](https://valkey.io) — the Linux Foundation's BSD-3 fork of
+  Redis 7.2.4 — for the bus, scheduler, and per-dispatch streams. This gives every surface (Lite
+  included) `XAUTOCLAIM` orphan-reclaim parity, and moves off source-available Redis ≥7.4
+  (RSALv2/SSPLv1). The store is wire-compatible (RESP): `REDIS_URL` and every `redis.*` config key
+  are unchanged, so existing overrides keep working. See [Deployment](/deployment).
+- **Two new license/parity gates close the class the audit exposed (#653).** `gate:image-licenses`
+  audits container-image pins and image-baked binaries (which `gate:licenses` never saw), and
+  `gate:runtime-parity` asserts every surface's engine version supports the RESP commands the code
+  actually calls — the rung that catches a backing store shipped without a capability the code
+  assumes.

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -15,7 +15,7 @@ deploys the same control plane as the Compose stack, with the runtime pointed at
 | gateway · admin-api · meeting-api · agent-api · runtime | Deployments (RollingUpdate, `maxUnavailable: 0`) |
 | terminal (web workbench) | Deployment + ingress |
 | postgres | StatefulSet (or point values at your managed DB) |
-| redis · minio | Deployments (+ minio init Job) |
+| redis (Valkey) · minio | Deployments (+ minio init Job) |
 | DB migrations | Job |
 | pgbouncer | optional connection pooling |
 | dashboard (deprecated 0.10 UI) | optional Deployment + Service, **off by default** |
@@ -164,18 +164,21 @@ actually exist — dead `collector-<oldhash>` names are expected to disappear wi
 TTL. For k8s you can eliminate the churn at the source by pinning a stable per-replica identity via
 `COLLECTOR_CONSUMER_NAME` (e.g. a StatefulSet ordinal) so a restart re-uses the same consumer.
 
-<Warning>
-**Orphan reclaim requires Redis 6.2 or newer** — `XAUTOCLAIM` does not exist before it. On an
-older Redis the reclaim disables itself and logs once at startup; everything else (normal
-`XREADGROUP` consumption, per-pod identity, `pending_depth`) is unaffected. The cost is narrow but
-real: if a replica dies mid-batch, that batch stays pending instead of being drained by a peer, so
-run a single replica on Redis < 6.2 or upgrade Redis. Check yours with `redis-server --version`.
+<Note>
+**Every surface now ships Valkey 8.x**, which has `XAUTOCLAIM` — so orphan reclaim is active
+everywhere Vexa ships, including Vexa Lite (compose, helm, and Lite all run Valkey, the Linux
+Foundation BSD-3 fork of Redis 7.2.4; see [the changelog](/changelog) and #653). Reclaim, per-pod
+identity, and ghost-consumer pruning all work on the shipped stack. Check yours with
+`valkey-server --version`.
 
-This bites Vexa Lite in particular: its bundled Redis is **6.0.16**, so a Lite box never reclaims.
-Lite runs one meeting-api, so nothing is lost — but do not read the paragraph above as a guarantee
-that holds on every backing store. Ghost-consumer pruning degrades the same way: if the backing
-Redis rejects `XINFO CONSUMERS`, the prune logs once and no-ops, leaving the consume path untouched.
-</Warning>
+The degradation path below still exists as a safety net for a *bring-your-own* backing store older
+than the floor: on a Redis/Valkey without `XAUTOCLAIM` the reclaim disables itself and logs once at
+startup; everything else (normal `XREADGROUP` consumption, `pending_depth`) is unaffected. The cost
+is narrow but real — if a replica dies mid-batch on such a store, that batch stays pending instead of
+being drained by a peer, so run a single replica or move to a store with `XAUTOCLAIM` (Redis ≥ 6.2 /
+Valkey ≥ 7.2). Ghost-consumer pruning degrades the same way: if the backing store rejects `XINFO
+CONSUMERS`, the prune logs once and no-ops, leaving the consume path untouched.
+</Note>
 
 ## In-cluster self-addressing
 

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -46,7 +46,7 @@ terminal web workbench at `http://localhost:13000`.
 | **runtime** | spawns bot + agent **containers** on demand (via the Docker socket) |
 | **agent-api** | the [agent control plane](/api/agent) — dispatch, chat, routines, events |
 | **terminal** (`:13000`) | the web workbench — proxies `/ws` → gateway and REST/login → agent-api/admin-api |
-| redis · postgres · **minio** | bus + scheduler · metadata · object storage (recordings + workspaces) |
+| redis (Valkey) · postgres · **minio** | bus + scheduler · metadata · object storage (recordings + workspaces) |
 
 The **bot is not a long-running service** — the [runtime](/core/runtime) spawns a browser container per
 meeting (`BROWSER_IMAGE`) and an agent container per dispatch (`AGENT_IMAGE`), then reaps them. The

--- a/image-licenses.json
+++ b/image-licenses.json
@@ -1,0 +1,44 @@
+{
+  "_comment": "Packaging-side licence manifest (P17 / ADR-0004, #653), the complement to license-exceptions.json. gate:licenses scans the npm/py DEPENDENCY tree; it is blind to what our IMAGES ship. This file declares the two surfaces it cannot see, and gate:image-licenses (scripts/gates.mjs) audits them: `images` = third-party container images our deploy surfaces pin (user-pulled sidecars — an undeclared pin fails; a non-permissive one needs a logged `reason`); `bundled` = components baked INTO a published vexaai/* image (redistribution — Cat A or Cat-B-with-reason only, Cat X always fails). `name` matches an image ref with its :tag stripped. System apt tools baked by Dockerfile.lite (ffmpeg, x11vnc, pulseaudio, …) are mere-aggregation in a container and out of scope here — the per-release SPDX SBOM (scripts/sbom.mjs) inventories them.",
+  "images": [
+    {
+      "name": "valkey/valkey",
+      "license": "BSD-3-Clause",
+      "disposition": "sidecar",
+      "note": "compose + helm cache/stream store (#653). BSD-3 permissive; parity with the Lite source-build."
+    },
+    {
+      "name": "postgres",
+      "license": "PostgreSQL",
+      "disposition": "sidecar",
+      "note": "Primary datastore. The PostgreSQL Licence is an OSI-approved permissive (BSD/MIT-style) licence."
+    },
+    {
+      "name": "edoburu/pgbouncer",
+      "license": "MIT",
+      "disposition": "sidecar",
+      "note": "Connection pooler. Wrapper image is MIT; PgBouncer itself is ISC — both Category A."
+    },
+    {
+      "name": "minio/minio",
+      "license": "AGPL-3.0-or-later",
+      "disposition": "sidecar",
+      "reason": "Object store the operator pulls DIRECTLY from MinIO's official registry — it is not redistributed inside any vexaai/* artifact, so no AGPL source-offer obligation attaches to Vexa's Apache-2.0 images; the obligation rests with the upstream image the operator runs. A deliberate, reviewed sidecar allowance (ADR-0004). Not a bundled component."
+    },
+    {
+      "name": "minio/mc",
+      "license": "AGPL-3.0-or-later",
+      "disposition": "sidecar",
+      "reason": "MinIO client, used only by the compose/helm bucket-init Job. Same disposition as minio/minio: operator-pulled, never redistributed inside a vexaai/* artifact (ADR-0004)."
+    }
+  ],
+  "bundled": [
+    {
+      "name": "valkey",
+      "license": "BSD-3-Clause",
+      "artifact": "vexaai/vexa-lite",
+      "how": "source-build from the pinned git tag 8.1.9 (deploy/lite/Dockerfile.lite valkey-builder stage); valkey-server + valkey-cli copied into the final image, COPYING preserved at /usr/local/share/valkey/LICENSE",
+      "reason": "XAUTOCLAIM parity with compose/helm and off BOTH jammy apt's stale Redis 6.0.16 (no XAUTOCLAIM) and source-available Redis ≥7.4 (RSALv2/SSPLv1). BSD-3 is Category A — clean to redistribute (#653)."
+    }
+  ]
+}

--- a/image-licenses.json
+++ b/image-licenses.json
@@ -1,6 +1,12 @@
 {
-  "_comment": "Packaging-side licence manifest (P17 / ADR-0004, #653), the complement to license-exceptions.json. gate:licenses scans the npm/py DEPENDENCY tree; it is blind to what our IMAGES ship. This file declares the two surfaces it cannot see, and gate:image-licenses (scripts/gates.mjs) audits them: `images` = third-party container images our deploy surfaces pin (user-pulled sidecars — an undeclared pin fails; a non-permissive one needs a logged `reason`); `bundled` = components baked INTO a published vexaai/* image (redistribution — Cat A or Cat-B-with-reason only, Cat X always fails). `name` matches an image ref with its :tag stripped. System apt tools baked by Dockerfile.lite (ffmpeg, x11vnc, pulseaudio, …) are mere-aggregation in a container and out of scope here — the per-release SPDX SBOM (scripts/sbom.mjs) inventories them.",
+  "_comment": "Packaging-side licence manifest (P17 / ADR-0004, #653), the complement to license-exceptions.json. gate:licenses scans the npm/py DEPENDENCY tree; it is blind to what our IMAGES ship. This file declares the two surfaces it cannot see, and gate:image-licenses (scripts/gates.mjs) audits them: `images` = third-party container images pinned by deploy-owned compose, Helm, or Lite Dockerfile FROM surfaces (an undeclared pin fails; a non-permissive one needs a logged `reason`); `bundled` = components baked INTO a published vexaai/* image (redistribution — Cat A or Cat-B-with-reason only, Cat X always fails). `name` matches an image ref with its :tag stripped. The per-release SPDX SBOM inventories every package name installed by the Lite final stage; because Docker source cannot resolve Ubuntu package versions or licences, those fields stay NOASSERTION until an image-level scanner enriches them.",
   "images": [
+    {
+      "name": "mcr.microsoft.com/playwright",
+      "license": "Apache-2.0",
+      "disposition": "base-image",
+      "note": "Pinned base and builder image for Vexa Lite. Playwright is Apache-2.0; Ubuntu package names installed in the final stage are separately inventoried in the SPDX with unresolved fields stated as NOASSERTION."
+    },
     {
       "name": "valkey/valkey",
       "license": "BSD-3-Clause",

--- a/licenses/valkey-8.1.9.COPYING.txt
+++ b/licenses/valkey-8.1.9.COPYING.txt
@@ -1,0 +1,32 @@
+# License 1
+
+SPDX-License-Identifier: BSD-3-Clause
+
+BSD 3-Clause License
+
+Copyright (c) 2024-present, Valkey contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# License 2
+
+BSD 3-Clause License
+
+Copyright (c) 2006-2020, Redis Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Redis nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "gate:stack": "node scripts/gates.mjs stack",
     "gate:node": "node scripts/gates.mjs node",
     "gate:licenses": "node scripts/gates.mjs licenses",
+    "gate:image-licenses": "node scripts/gates.mjs image-licenses",
+    "gate:runtime-parity": "node scripts/gates.mjs runtime-parity",
     "gate:calm": "npx -y @finos/calm-cli@1.47.1 validate -p calm/patterns/meeting-intelligence.pattern.json -a architecture.calm.json",
     "gates": "node scripts/gates.mjs all",
     "observe": "node core/meetings/eval/src/observe.mjs",

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -365,34 +365,188 @@ function gateEvalBaseline() {
 // built-in licence index (no added dependency to vet — itself a P17 win). Cat A (permissive) passes;
 // Cat B (LGPL/MPL/EPL) must be listed in license-exceptions.json; Cat X (GPL/AGPL/SSPL/BSL/…) and
 // any unclassified licence fail the build. B is checked before X so LGPL never trips the GPL match.
+// FINOS licence classifier (ADR-0004), shared by gate:licenses (npm/py deps) and gate:image-licenses
+// (baked apt packages + pinned container images). B is tested before X so LGPL never trips the GPL
+// match. Cat X is where Redis ≥7.4's RSALv2/SSPLv1 lands — the exact class #653 keeps out of our images.
+const LICENSE_A = [/^MIT/, /^Apache-2\.0/i, /^BSD\b/, /^BSD-/, /^ISC/, /^0BSD/, /^Unlicense/, /^CC0-/, /^CC-BY-/, /^Python-2\.0/, /^PostgreSQL$/i, /^BlueOak/, /^Zlib/i, /^MIT-0/, /^WTFPL/i, /^SIL OPEN FONT LICENSE/i, /OR CC0-1\.0/];
+const LICENSE_B = [/LGPL/i, /^MPL/i, /^EPL/i];                                    // weak copyleft — needs a logged exception
+const LICENSE_X = [/(^|[^L])GPL/i, /AGPL/i, /SSPL/i, /\bBSL\b/i, /Business Source/i, /Elastic-/i, /Commons.?Clause/i, /Proprietary/i, /UNLICENSED/, /\bRSALv?\d/i, /Redis Source Available/i];
+// → "A" (permissive, passes) | "B" (weak-copyleft, needs a logged exception) | "X" (forbidden) | "?" (unclassified)
+function classifyLicense(lic) {
+  if (LICENSE_A.some((re) => re.test(lic))) return "A";
+  if (LICENSE_B.some((re) => re.test(lic))) return "B";
+  if (LICENSE_X.some((re) => re.test(lic))) return "X";
+  return "?";
+}
+
 function gateLicenses() {
   let raw;
   try { raw = execSync("pnpm licenses list --json", { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString(); }
   catch (e) { raw = (e.stdout || "").toString(); }
   if (!raw.trim()) { console.log("  ✓ gate:licenses — no resolved deps yet (green-on-empty)"); return true; }
   let data; try { data = JSON.parse(raw); } catch { return fail(["`pnpm licenses list --json` returned non-JSON — run `pnpm install` first"]); }
-  const A = [/^MIT/, /^Apache-2\.0/i, /^BSD\b/, /^BSD-/, /^ISC/, /^0BSD/, /^Unlicense/, /^CC0-/, /^CC-BY-/, /^Python-2\.0/, /^BlueOak/, /^Zlib/i, /^MIT-0/, /^WTFPL/i, /^SIL OPEN FONT LICENSE/i, /OR CC0-1\.0/];
-  const B = [/LGPL/i, /^MPL/i, /^EPL/i];                                          // weak copyleft — needs a logged exception
-  const X = [/(^|[^L])GPL/i, /AGPL/i, /SSPL/i, /\bBSL\b/i, /Business Source/i, /Elastic-/i, /Commons.?Clause/i, /Proprietary/i, /UNLICENSED/];
   const exFile = join(ROOT, "license-exceptions.json");
   const exceptions = existsSync(exFile) ? (JSON.parse(readFileSync(exFile, "utf8")).categoryB || []) : [];
   const excepted = (name) => exceptions.some((e) => name === e.package || name.startsWith(e.package));
   const bad = [], flagged = [];
   for (const [lic, pkgs] of Object.entries(data)) {
     const names = pkgs.map((p) => p.name);
-    if (A.some((re) => re.test(lic))) continue;
-    if (B.some((re) => re.test(lic))) {
+    const cat = classifyLicense(lic);
+    if (cat === "A") continue;
+    if (cat === "B") {
       const unlisted = names.filter((n) => !excepted(n));
       if (unlisted.length) bad.push(`Cat-B ${lic} needs an entry in license-exceptions.json: ${unlisted.join(", ")}`);
       else flagged.push(`${lic} (${names.join(", ")})`);
       continue;
     }
-    if (X.some((re) => re.test(lic))) { bad.push(`FORBIDDEN (Cat X) ${lic}: ${names.join(", ")} — replace this dependency`); continue; }
+    if (cat === "X") { bad.push(`FORBIDDEN (Cat X) ${lic}: ${names.join(", ")} — replace this dependency`); continue; }
     bad.push(`unclassified licence "${lic}": ${names.join(", ")} — classify it in scripts/gates.mjs or replace the dep`);
   }
   if (bad.length) return fail(bad);
   const total = Object.values(data).reduce((n, p) => n + p.length, 0);
   console.log(`  ✓ gate:licenses — ${total} deps OSS-clean (Cat A${flagged.length ? `; ${flagged.length} Cat-B by exception: ${flagged.join("; ")}` : ""})`);
+  return true;
+}
+
+// gate:image-licenses (P17, #653) — the packaging-side complement to gate:licenses. That gate scans the
+// npm/py DEPENDENCY tree; it is blind to two license surfaces the project actually ships, the class the
+// #653 audit exposed — "the thing we ship is not the thing the gate checks":
+//   (1) third-party container images our deploy surfaces PIN (compose/helm `image:` refs) — user-pulled
+//       sidecars. Each is DECLARED in image-licenses.json; an undeclared pin fails (the "green gate ships
+//       an un-audited component" hole); a non-permissive licence (e.g. a source-available Redis ≥7.4
+//       RSALv2/SSPL, or AGPL MinIO) requires a logged `reason`, so it is a reviewed decision, never silent.
+//   (2) components BAKED INTO a published vexaai/* image (`bundled`) — redistribution, so strict: Cat A
+//       (or Cat-B with a reason); Cat X always fails. This is the rung that keeps source-available Redis
+//       out of the Apache-2.0 Lite image. Plus a concrete guard: Lite must not `apt install redis-server`
+//       (jammy's 6.0.16 — the parity trap #653 moved off of; use the Valkey source-build).
+// System apt tools (ffmpeg/x11vnc/pulseaudio …) are mere-aggregation in a container image, not code we
+// link or redistribute as our own — out of scope here, tracked by the SBOM, not license-gated.
+function gateImageLicenses() {
+  const manFile = join(ROOT, "image-licenses.json");
+  if (!existsSync(manFile)) { console.log("  ✓ gate:image-licenses — no manifest yet (green-on-empty)"); return true; }
+  const man = JSON.parse(readFileSync(manFile, "utf8"));
+  const declaredImages = new Map((man.images || []).map((e) => [e.name, e]));
+  const bad = [], flagged = [];
+
+  // (1) third-party `image:` pins in compose + helm values AND helm templates (a literal `image:` in a
+  //     template — e.g. the minio-init Job — is a real pin the gate must see; `{{ … }}` refs are skipped
+  //     below). Skip our own vexaai/* images — those are built here, not third-party redistributables.
+  const chartDir = join(ROOT, "deploy", "helm", "charts", "vexa");
+  const tplDir = join(chartDir, "templates");
+  const deployFiles = [
+    join(ROOT, "deploy", "compose", "docker-compose.yml"),
+    ...(existsSync(chartDir) ? readdirSync(chartDir).filter((f) => /^values.*\.yaml$/.test(f)).map((f) => join(chartDir, f)) : []),
+    ...(existsSync(tplDir) ? readdirSync(tplDir).filter((f) => /\.ya?ml$/.test(f)).map((f) => join(tplDir, f)) : []),
+  ].filter(existsSync);
+  const foundImages = new Map();   // name → ref (first sighting)
+  for (const f of deployFiles)
+    // same-line values only ([ \t]*, never \s* which would cross a newline into a structured
+    // `image:\n  repository:` block — those are first-party app images, correctly skipped). The value
+    // may carry `${VAR:-default}` interpolation ⇒ capture the whole token (no `{}` exclusion) and resolve.
+    for (const m of readFileSync(f, "utf8").matchAll(/^[ \t]*image:[ \t]*["']?([^\s"']+)/gm)) {
+      let ref = m[1];
+      if (ref.includes("{{")) continue;                                          // helm template expression
+      ref = ref.replace(/\$\{[^:}]*:-([^}]+)\}/g, "$1");                         // ${VAR:-default} → the default image
+      if (ref.includes("$")) continue;                                          // unresolved ${VAR} → env-only, unauditable
+      if (ref.startsWith("vexaai/")) continue;                                   // first-party (built here)
+      const name = ref.replace(/@sha256:.*$/, "").replace(/:[^/:]+$/, "");       // strip digest / :tag, keep registry/name
+      if (!foundImages.has(name)) foundImages.set(name, ref);
+    }
+  for (const [name, ref] of foundImages) {
+    const e = declaredImages.get(name);
+    if (!e) { bad.push(`undeclared pinned image "${ref}" — add it to image-licenses.json (images[]) with its SPDX licence`); continue; }
+    const cat = classifyLicense(e.license);
+    if (cat === "?") bad.push(`image "${name}": unclassified licence "${e.license}" — classify it or replace the image`);
+    else if (cat === "A") { /* clean */ }
+    else if (!e.reason) bad.push(`image "${name}" is ${e.license} (Cat ${cat}) but has no \`reason\` — a non-permissive pinned image must carry a logged rationale (why it's acceptable / not redistributed)`);
+    else flagged.push(`${name} (${e.license}, Cat ${cat}: ${e.reason.slice(0, 48)}…)`);
+  }
+
+  // (2) bundled components baked into a published image — strict (redistribution).
+  for (const e of (man.bundled || [])) {
+    const cat = classifyLicense(e.license);
+    if (cat === "X") bad.push(`FORBIDDEN (Cat X) bundled "${e.name}": ${e.license} — a source-available/non-OSS component cannot ship inside ${e.artifact || "a vexaai/* image"} (#653)`);
+    else if (cat === "?") bad.push(`bundled "${e.name}": unclassified licence "${e.license}" — classify it`);
+    else if (cat === "B" && !e.reason) bad.push(`bundled "${e.name}" is Cat-B (${e.license}) with no \`reason\``);
+    else if (cat !== "A") flagged.push(`bundled ${e.name} (${e.license})`);
+  }
+
+  // (3) concrete #653 guard — the Lite parity trap: apt-installed redis-server (jammy 6.0.16, no XAUTOCLAIM).
+  const lite = join(ROOT, "deploy", "lite", "Dockerfile.lite");
+  // `[^&]*?` scopes the match to the install statement's package list (it terminates at the first `&&`),
+  // so a comment MENTIONING redis-server later in the file never trips the guard — only a real package does.
+  // `apt(?:-get)?` covers both the `apt-get install` and the bare `apt install` forms.
+  if (existsSync(lite) && /\bapt(?:-get)? install\b[^&]*?\bredis-server\b/.test(readFileSync(lite, "utf8")))
+    bad.push("Lite bakes `apt install redis-server` (jammy 6.0.16 — no XAUTOCLAIM, the #653 parity trap). Use the Valkey source-build stage (BSD-3, XAUTOCLAIM) instead.");
+
+  if (bad.length) return fail(bad);
+  console.log(`  ✓ gate:image-licenses — ${foundImages.size} pinned image(s) + ${(man.bundled || []).length} bundled component(s) declared & audited${flagged.length ? ` (${flagged.length} non-A by logged reason: ${flagged.join("; ")})` : ""}`);
+  return true;
+}
+
+// gate:runtime-parity (P17, #653 · catches the #636/#637 class) — asserts the cache/stream commands
+// the CODE calls are supported by the engine version EVERY deploy surface pins. #636 shipped because
+// Lite's jammy apt redis (6.0.16) lacks XAUTOCLAIM while the collector calls it: code assumed a backend
+// capability the shipped backend lacked. This gate closes that rung with no human in the loop.
+//   used commands  ← grep core/** for `.<cmd>(` against the floor table below
+//   surface version← compose/helm `image:` pins + Lite (apt redis-server ⇒ jammy 6.0; else ARG VALKEY_VERSION)
+//   assert         ← every surface's redis-equivalent command era ≥ the highest used command's floor
+// Floors are the Redis version each command shipped in (Valkey ≥7.2 implements the whole surface we use).
+const COMMAND_FLOORS = {                                                          // command → [major, minor] introduced
+  xadd: [5, 0], xreadgroup: [5, 0], xack: [5, 0], xpending: [5, 0], xtrim: [5, 0], xlen: [5, 0],
+  xclaim: [5, 0], xread: [5, 0], xrange: [5, 0], xinfo: [5, 0], xautoclaim: [6, 2],   // XAUTOCLAIM is the load-bearing floor (#636)
+  zadd: [1, 2], zrange: [1, 2], zrangebyscore: [1, 2], zrem: [1, 2],
+  lpush: [1, 0], rpush: [1, 0], brpop: [2, 0], blpop: [2, 0], sadd: [1, 0], smembers: [1, 0],
+  publish: [2, 0], subscribe: [2, 0], hset: [2, 0], setex: [2, 0], expire: [1, 0],
+};
+const verNum = ([maj, min]) => maj * 100 + min;
+const verStr = (n) => `${Math.floor(n / 100)}.${n % 100}`;                        // 602 → "6.2" (major.minor encoding)
+// the Redis command-set version a pinned surface supports. Valkey ≥7.2 forked Redis 7.2.4 and carries
+// the full command surface we use (incl XAUTOCLAIM) → treat as Redis 7.4-equivalent; stock Redis → itself.
+function redisCommandEra(engine, ver) {
+  if (engine === "valkey") return verNum(ver[0] > 7 || (ver[0] === 7 && ver[1] >= 2) ? [7, 4] : ver);
+  return verNum(ver);
+}
+const parseTag = (tag) => { const p = tag.replace(/-alpine$/, "").split("."); return [parseInt(p[0], 10) || 0, parseInt(p[1], 10) || 0]; };
+function gateRuntimeParity() {
+  const compose = join(ROOT, "deploy", "compose", "docker-compose.yml");
+  const values = join(ROOT, "deploy", "helm", "charts", "vexa", "values.yaml");
+  const lite = join(ROOT, "deploy", "lite", "Dockerfile.lite");
+  if (![compose, values, lite].some(existsSync)) { console.log("  ✓ gate:runtime-parity — no deploy surfaces yet (green-on-empty)"); return true; }
+
+  // used commands: grep the Python core for `.<cmd>(` against the floor table
+  const used = new Set();
+  try {
+    const hits = execSync(`grep -rhoiE "\\.(${Object.keys(COMMAND_FLOORS).join("|")})\\(" core --include="*.py"`, { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString();
+    for (const m of hits.matchAll(/\.([a-z]+)\(/gi)) if (COMMAND_FLOORS[m[1].toLowerCase()]) used.add(m[1].toLowerCase());
+  } catch { /* grep exit 1 = no matches: no commands used, gate is vacuously green below */ }
+  if (!used.size) { console.log("  ✓ gate:runtime-parity — no cache/stream commands called by core yet (green-on-empty)"); return true; }
+  const floorCmd = [...used].reduce((a, c) => verNum(COMMAND_FLOORS[c]) > verNum(COMMAND_FLOORS[a]) ? c : a);
+  const floor = verNum(COMMAND_FLOORS[floorCmd]);
+
+  // each surface's pinned engine + version
+  const surfaces = [];
+  const imgOf = (file, label) => {
+    if (!existsSync(file)) return;
+    const m = readFileSync(file, "utf8").match(/image:\s*["']?(valkey\/valkey|redis):([\w.-]+)/);
+    if (m) surfaces.push({ label, engine: m[1] === "redis" ? "redis" : "valkey", ver: parseTag(m[2]), ref: `${m[1]}:${m[2]}` });
+  };
+  imgOf(compose, "compose");
+  imgOf(values, "helm");
+  if (existsSync(lite)) {
+    const txt = readFileSync(lite, "utf8");
+    if (/\bapt(?:-get)? install\b[^&]*?\bredis-server\b/.test(txt)) surfaces.push({ label: "lite", engine: "redis", ver: [6, 0], ref: "apt redis-server (jammy 6.0.16)" });
+    else { const a = txt.match(/ARG VALKEY_VERSION=([\d.]+)/); if (a) { const p = a[1].split("."); surfaces.push({ label: "lite", engine: "valkey", ver: [parseInt(p[0], 10), parseInt(p[1], 10) || 0], ref: `valkey ${a[1]} (source build)` }); } }
+  }
+  if (!surfaces.length) return fail(["gate:runtime-parity — no cache engine pin found on any deploy surface (compose/helm image: or Lite ARG VALKEY_VERSION)"]);
+
+  const bad = [];
+  for (const s of surfaces) {
+    const era = redisCommandEra(s.engine, s.ver);
+    if (era < floor) bad.push(`${s.label} pins ${s.ref} (Redis-command era ${verStr(era)}) but core calls ${floorCmd.toUpperCase()} (needs ≥ ${verStr(floor)}) — the #636 class: code assumes a backend capability this surface lacks`);
+  }
+  if (bad.length) return fail(bad);
+  console.log(`  ✓ gate:runtime-parity — ${surfaces.length} surface(s) [${surfaces.map((s) => s.label).join(", ")}] support all ${used.size} used command(s); floor ${floorCmd.toUpperCase()} needs ≥ ${verStr(floor)}`);
   return true;
 }
 
@@ -1034,7 +1188,7 @@ function gateLiteMakefile() {
   return true;
 }
 
-const GATES = { readme: gateReadme, "lite-makefile": gateLiteMakefile, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
+const GATES = { readme: gateReadme, "lite-makefile": gateLiteMakefile, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, "image-licenses": gateImageLicenses, "runtime-parity": gateRuntimeParity, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance };
 const which = process.argv[2] || "all";
 
 // `seal` (not a gate) — (re)freeze the current published contracts into contracts.seal.json.

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -428,33 +428,77 @@ function gateImageLicenses() {
   const declaredImages = new Map((man.images || []).map((e) => [e.name, e]));
   const bad = [], flagged = [];
 
-  // (1) third-party `image:` pins in compose + helm values AND helm templates (a literal `image:` in a
-  //     template — e.g. the minio-init Job — is a real pin the gate must see; `{{ … }}` refs are skipped
-  //     below). Skip our own vexaai/* images — those are built here, not third-party redistributables.
+  // (1) third-party image pins across the deploy-owned forms:
+  //     • scalar `image: ref` in compose, Helm values, and Helm templates;
+  //     • structured Helm `image: { repository, tag }` blocks;
+  //     • every `FROM ref` in the Lite Dockerfile (including builder stages whose bytes feed final).
+  //     Skip our own vexaai/* / vexa/* images — those are built here, not third-party inputs.
   const chartDir = join(ROOT, "deploy", "helm", "charts", "vexa");
   const tplDir = join(chartDir, "templates");
+  const helmValueFiles = existsSync(chartDir)
+    ? readdirSync(chartDir).filter((f) => /^values.*\.yaml$/.test(f)).map((f) => join(chartDir, f))
+    : [];
   const deployFiles = [
     join(ROOT, "deploy", "compose", "docker-compose.yml"),
-    ...(existsSync(chartDir) ? readdirSync(chartDir).filter((f) => /^values.*\.yaml$/.test(f)).map((f) => join(chartDir, f)) : []),
+    ...helmValueFiles,
     ...(existsSync(tplDir) ? readdirSync(tplDir).filter((f) => /\.ya?ml$/.test(f)).map((f) => join(tplDir, f)) : []),
   ].filter(existsSync);
-  const foundImages = new Map();   // name → ref (first sighting)
+  const foundImages = new Map();   // name → { ref, source } (first sighting)
+  const recordImage = (rawRef, source) => {
+    let ref = rawRef.replace(/^["']|["']$/g, "");
+    if (ref.includes("{{")) return;                                          // helm template expression
+    ref = ref.replace(/\$\{[^:}]*:-([^}]+)\}/g, "$1");                       // ${VAR:-default} → default image
+    if (ref.includes("$")) return;                                           // unresolved variable → no auditable pin
+    if (ref.startsWith("vexaai/") || ref.startsWith("vexa/")) return;         // first-party
+    const name = ref.replace(/@sha256:.*$/, "").replace(/:[^/:]+$/, "");     // strip digest / :tag
+    if (!name || (!ref.includes("/") && !ref.includes(":"))) return;         // Docker stage alias / invalid ref
+    if (!foundImages.has(name)) foundImages.set(name, { ref, source });
+  };
+
   for (const f of deployFiles)
     // same-line values only ([ \t]*, never \s* which would cross a newline into a structured
-    // `image:\n  repository:` block — those are first-party app images, correctly skipped). The value
-    // may carry `${VAR:-default}` interpolation ⇒ capture the whole token (no `{}` exclusion) and resolve.
+    // `image:\n  repository:` block — that shape is enumerated separately below). The value may carry
+    // `${VAR:-default}` interpolation ⇒ capture the whole token (no `{}` exclusion) and resolve.
     for (const m of readFileSync(f, "utf8").matchAll(/^[ \t]*image:[ \t]*["']?([^\s"']+)/gm)) {
-      let ref = m[1];
-      if (ref.includes("{{")) continue;                                          // helm template expression
-      ref = ref.replace(/\$\{[^:}]*:-([^}]+)\}/g, "$1");                         // ${VAR:-default} → the default image
-      if (ref.includes("$")) continue;                                          // unresolved ${VAR} → env-only, unauditable
-      if (ref.startsWith("vexaai/")) continue;                                   // first-party (built here)
-      const name = ref.replace(/@sha256:.*$/, "").replace(/:[^/:]+$/, "");       // strip digest / :tag, keep registry/name
-      if (!foundImages.has(name)) foundImages.set(name, ref);
+      recordImage(m[1], rel(f));
     }
-  for (const [name, ref] of foundImages) {
+
+  // Helm's established structured values shape:
+  //   image:
+  //     repository: minio/minio
+  //     tag: latest
+  // Use indentation to bind repository+tag to the same image block.
+  for (const f of helmValueFiles) {
+    const lines = readFileSync(f, "utf8").split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const image = lines[i].match(/^([ \t]*)image:[ \t]*(?:#.*)?$/);
+      if (!image) continue;
+      const baseIndent = image[1].length;
+      let repository;
+      let tag;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (!lines[j].trim() || lines[j].trimStart().startsWith("#")) continue;
+        const indent = (lines[j].match(/^[ \t]*/) || [""])[0].length;
+        if (indent <= baseIndent) break;
+        const repoMatch = lines[j].match(/^[ \t]*repository:[ \t]*["']?([^\s"']+)/);
+        const tagMatch = lines[j].match(/^[ \t]*tag:[ \t]*["']?([^\s"']+)/);
+        if (repoMatch) repository = repoMatch[1];
+        if (tagMatch) tag = tagMatch[1];
+      }
+      if (repository && tag) recordImage(`${repository}:${tag}`, rel(f));
+    }
+  }
+
+  const liteDockerfile = join(ROOT, "deploy", "lite", "Dockerfile.lite");
+  if (existsSync(liteDockerfile)) {
+    for (const m of readFileSync(liteDockerfile, "utf8").matchAll(
+      /^FROM[ \t]+(?:--platform=\S+[ \t]+)?(\S+)/gmi,
+    )) recordImage(m[1], rel(liteDockerfile));
+  }
+
+  for (const [name, { ref, source }] of foundImages) {
     const e = declaredImages.get(name);
-    if (!e) { bad.push(`undeclared pinned image "${ref}" — add it to image-licenses.json (images[]) with its SPDX licence`); continue; }
+    if (!e) { bad.push(`undeclared pinned image "${ref}" in ${source} — add it to image-licenses.json (images[]) with its SPDX licence`); continue; }
     const cat = classifyLicense(e.license);
     if (cat === "?") bad.push(`image "${name}": unclassified licence "${e.license}" — classify it or replace the image`);
     else if (cat === "A") { /* clean */ }

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -12,7 +12,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, readFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -113,4 +113,108 @@ test("a production file using the *_test.py suffix is still counted (config_test
 test("a test-only create_async_engine does not invent a service in the budget", () => {
   const r = withPlanted(PHANTOM_TEST_FILE, "engine = create_async_engine(FAKE_URL)\n", runDbBudget);
   assert.equal(r.green, true, `a test fixture phantomed agent-api into the connection budget:\n${r.out}`);
+});
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+// #653 — gate:image-licenses and gate:runtime-parity. Same plant-and-run-the-real-gate discipline: a
+// gate that never reds on the input it was written to catch is theatre. These edit a tracked deploy
+// file in place, run the real gate as a subprocess, and restore — so each RED is the actual pipeline
+// firing, not a stubbed parse. Every fixture is paired with the vacuity control that the clean tree
+// is green (a red there would invalidate the fixture below it).
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+
+function runGate(name) {
+  try { return { green: true, out: execFileSync("node", ["scripts/gates.mjs", name], { cwd: ROOT, encoding: "utf8" }) }; }
+  catch (e) { return { green: false, out: `${e.stdout || ""}${e.stderr || ""}` }; }
+}
+// Temporarily replace `find`→`repl` in a tracked file, run fn, always restore the exact original bytes.
+function withEdited(relPath, find, repl, fn) {
+  const abs = join(ROOT, relPath);
+  const orig = readFileSync(abs, "utf8");
+  const edited = orig.replace(find, repl);
+  assert.notEqual(edited, orig, `fixture setup: pattern not found in ${relPath} — the test would prove nothing`);
+  writeFileSync(abs, edited);
+  try { return fn(); } finally { writeFileSync(abs, orig); }
+}
+
+const COMPOSE = "deploy/compose/docker-compose.yml";
+const VALUES = "deploy/helm/charts/vexa/values.yaml";
+const LITE = "deploy/lite/Dockerfile.lite";
+const IMG_MANIFEST = "image-licenses.json";
+
+// ── gate:runtime-parity ─────────────────────────────────────────────────────────────────────────
+
+test("runtime-parity vacuity: the committed tree (all surfaces on Valkey 8) is green", () => {
+  const r = runGate("runtime-parity");
+  assert.equal(r.green, true, `the clean tree already reds — the fixtures below prove nothing:\n${r.out}`);
+});
+
+test("runtime-parity RED (#636): Lite reverting to apt redis-server (jammy 6.0.16) reds against XAUTOCLAIM", () => {
+  const r = withEdited(LITE, "supervisor postgresql-client", "supervisor redis-server postgresql-client",
+    () => runGate("runtime-parity"));
+  assert.equal(r.green, false, "a surface pinned below XAUTOCLAIM's floor no longer reds — the #636 rung is inert");
+  assert.match(r.out, /lite/);
+  assert.match(r.out, /XAUTOCLAIM/);
+});
+
+test("runtime-parity RED (#637 class): a compose pin below a used command's floor reds", () => {
+  const r = withEdited(COMPOSE, "image: valkey/valkey:8-alpine", "image: redis:6.0-alpine",
+    () => runGate("runtime-parity"));
+  assert.equal(r.green, false, "a compose engine pinned below the used-command floor no longer reds");
+  assert.match(r.out, /compose/);
+  assert.match(r.out, /6\.0/);
+});
+
+// ── gate:image-licenses ─────────────────────────────────────────────────────────────────────────
+
+test("image-licenses vacuity: the committed tree (Valkey everywhere) is green", () => {
+  const r = runGate("image-licenses");
+  assert.equal(r.green, true, `the clean tree already reds — the fixtures below prove nothing:\n${r.out}`);
+});
+
+test("image-licenses RED: an undeclared pinned image (a stray redis:7.4) reds", () => {
+  // redis:7.4 is exactly the source-available (RSALv2/SSPL) engine #653 keeps out; undeclared ⇒ loud red.
+  const r = withEdited(COMPOSE, "image: valkey/valkey:8-alpine", "image: redis:7.4-alpine",
+    () => runGate("image-licenses"));
+  assert.equal(r.green, false, "an undeclared image pin sailed through — the 'green gate ships an un-audited component' hole is back");
+  assert.match(r.out, /undeclared pinned image/);
+  assert.match(r.out, /redis:7\.4/);
+});
+
+test("image-licenses RED: the Lite apt redis-server parity trap reds", () => {
+  const r = withEdited(LITE, "supervisor postgresql-client", "supervisor redis-server postgresql-client",
+    () => runGate("image-licenses"));
+  assert.equal(r.green, false, "the Lite apt redis-server guard is inert");
+  assert.match(r.out, /redis-server/);
+});
+
+test("image-licenses RED: a bundled component under a source-available licence (SSPL) is FORBIDDEN", () => {
+  // The strict redistribution path: anything baked into a vexaai/* image must be Cat A (or B-with-reason).
+  const inject = '"bundled": [\n    {\n      "name": "redis",\n      "license": "SSPLv1",\n      "artifact": "vexaai/vexa-lite",\n      "reason": "test fixture"\n    },';
+  const r = withEdited(IMG_MANIFEST, '"bundled": [', inject, () => runGate("image-licenses"));
+  assert.equal(r.green, false, "a source-available bundled component was not forbidden — the redistribution guard is inert");
+  assert.match(r.out, /FORBIDDEN \(Cat X\)/);
+  assert.match(r.out, /redis/);
+});
+
+const MINIO_JOB = "deploy/helm/charts/vexa/templates/job-minio-init.yaml";
+
+test("image-licenses RED: an undeclared image pinned in a helm TEMPLATE (not just values) reds", () => {
+  // The gate must read helm templates, not only compose + values — a literal `image:` in a template
+  // is a real pin. An undeclared one must red, else the 'green gate ships an un-audited component' hole.
+  const r = withEdited(MINIO_JOB, "image: minio/mc:latest", "image: somevendor/unaudited:1.2",
+    () => runGate("image-licenses"));
+  assert.equal(r.green, false, "an undeclared image in a helm template sailed through — the gate never read templates");
+  assert.match(r.out, /undeclared pinned image/);
+  assert.match(r.out, /somevendor\/unaudited/);
+});
+
+test("runtime-parity RED: the bare `apt install` form (not just apt-get) is caught too", () => {
+  // A contributor who writes `apt install redis-server` (no -get) must not bypass the #636 guard.
+  const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final";
+  const r = withEdited(LITE, "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final", inject,
+    () => runGate("runtime-parity"));
+  assert.equal(r.green, false, "`apt install redis-server` (no -get) bypassed the parity guard");
+  assert.match(r.out, /lite/);
+  assert.match(r.out, /XAUTOCLAIM/);
 });

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -209,6 +209,30 @@ test("image-licenses RED: an undeclared image pinned in a helm TEMPLATE (not jus
   assert.match(r.out, /somevendor\/unaudited/);
 });
 
+test("image-licenses RED: an undeclared structured Helm repository/tag pin reds", () => {
+  const injected = [
+    "reviewProbe:",
+    "  image:",
+    "    repository: somevendor/unaudited",
+    "    tag: 1.2",
+    "",
+    "minio:",
+  ].join("\n");
+  const r = withEdited(VALUES, "minio:\n", injected, () => runGate("image-licenses"));
+  assert.equal(r.green, false, "a structured Helm repository/tag image pin sailed through");
+  assert.match(r.out, /undeclared pinned image/);
+  assert.match(r.out, /somevendor\/unaudited:1\.2/);
+});
+
+test("image-licenses RED: an undeclared Dockerfile FROM pin reds", () => {
+  const base = "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS bot-builder";
+  const injected = `FROM somevendor/unaudited:1.2 AS review-probe\n${base}`;
+  const r = withEdited(LITE, base, injected, () => runGate("image-licenses"));
+  assert.equal(r.green, false, "an undeclared Dockerfile FROM image pin sailed through");
+  assert.match(r.out, /undeclared pinned image/);
+  assert.match(r.out, /somevendor\/unaudited:1\.2/);
+});
+
 test("runtime-parity RED: the bare `apt install` form (not just apt-get) is caught too", () => {
   // A contributor who writes `apt install redis-server` (no -get) must not bypass the #636 guard.
   const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final";

--- a/scripts/sbom.mjs
+++ b/scripts/sbom.mjs
@@ -159,6 +159,20 @@ const BAKED_MODEL = {
   comment: "Baked into vexaai/vexa-bot + vexaai/vexa-lite at /opt/hf-cache; loaded offline by the mixed (Zoom/Teams) diarization lane. Notice: /opt/hf-cache/LICENSE.pyannote-segmentation-3.0 + repo THIRD_PARTY_LICENSES.md.",
 };
 
+// Valkey — the cache/stream engine BAKED into vexaai/vexa-lite (source-build, Dockerfile.lite
+// valkey-builder). Like the model, it is bytes CONTAINED in the published image, not a source
+// dependency, so gate:licenses never sees it — gate:image-licenses (bundled[]) audits it and this
+// records it in the SBOM. BSD-3 (Category A), clean to redistribute (#653).
+const BAKED_VALKEY = {
+  eco: "github", name: "valkey", version: "8.1.9",
+  licenseDeclared: "BSD-3-Clause", licenseConcluded: "BSD-3-Clause",
+  copyrightText: "Copyright (c) 2024-present, Valkey contributors",
+  downloadLocation: "https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz",
+  purl: "pkg:github/valkey-io/valkey@8.1.9",
+  supplier: "Organization: Valkey (Linux Foundation)",
+  comment: "Source-built (BUILD_TLS=no) into vexaai/vexa-lite; valkey-server + valkey-cli at /usr/local/bin, notice at /usr/local/share/valkey/LICENSE. compose/helm pin valkey/valkey:8-alpine (user-pulled, in image-licenses.json). #653.",
+};
+
 // ── assemble the SPDX 2.3 document ──────────────────────────────────────────────
 function pkgObject(p, id) {
   const externalRefs = p.purl ? [{ referenceCategory: "PACKAGE-MANAGER", referenceType: "purl", referenceLocator: p.purl }] : [];
@@ -201,6 +215,10 @@ const modelId = spdxId("Package", "hf", "pyannote-segmentation-3.0");
 packages.push(pkgObject(BAKED_MODEL, modelId));
 relationships.push({ spdxElementId: ROOT_ID, relatedSpdxElement: modelId, relationshipType: "CONTAINS" });
 
+const valkeyId = spdxId("Package", "github", "valkey", "8.1.9");
+packages.push(pkgObject(BAKED_VALKEY, valkeyId));
+relationships.push({ spdxElementId: ROOT_ID, relatedSpdxElement: valkeyId, relationshipType: "CONTAINS" });
+
 for (const d of deps) {
   const id = spdxId("Package", d.eco, d.name, d.version);
   packages.push(pkgObject(d, id));
@@ -216,7 +234,7 @@ const doc = {
   creationInfo: {
     created: CREATED,
     creators: ["Tool: vexa-sbom (scripts/sbom.mjs)", "Organization: Vexa"],
-    comment: `Coverage: npm deps=${npm.length} (declared licences via pnpm), pip deps=${pip.length} (inventory only, licence=NOASSERTION — pip-licenses owed per ADR-0009), baked model weights=1 (fully specified). Non-dependency baked artifacts (model weights) sit outside gate:licenses; see THIRD_PARTY_LICENSES.md.`,
+    comment: `Coverage: npm deps=${npm.length} (declared licences via pnpm), pip deps=${pip.length} (inventory only, licence=NOASSERTION — pip-licenses owed per ADR-0009), baked artifacts=2 (pyannote model weights + Valkey engine, fully specified). Non-dependency baked artifacts sit outside gate:licenses (audited by gate:image-licenses); see THIRD_PARTY_LICENSES.md.`,
   },
   packages,
   relationships,

--- a/scripts/sbom.mjs
+++ b/scripts/sbom.mjs
@@ -6,7 +6,7 @@
  * `gate:licenses` (scripts/gates.mjs) PROVES the npm tree is licence-clean but
  * emits no artifact, and it never sees non-dependency bytes baked into the images
  * (model weights). This script is the emit side + the packaging complement: it
- * inventories three sources into one SPDX document —
+ * inventories four sources into one SPDX document —
  *
  *   1. npm deps   — `pnpm licenses list --json` (the same index gate:licenses uses):
  *                   name · version · declared licence, one SPDX package per version.
@@ -14,14 +14,17 @@
  *                   no licence field, so pip packages ship licenceDeclared=NOASSERTION
  *                   (Python licence resolution via pip-licenses is owed per ADR-0009);
  *                   the INVENTORY is still complete and CI-runnable with no install.
- *   3. baked model — onnx-community/pyannote-segmentation-3.0 (MIT), baked into
+ *   3. Lite apt   — every package name installed in Dockerfile.lite's final stage.
+ *                   Docker source does not resolve Ubuntu versions or licences, so
+ *                   those fields are explicitly NOASSERTION pending image scanning.
+ *   4. baked model — onnx-community/pyannote-segmentation-3.0 (MIT), baked into
  *                   vexaai/vexa-bot + vexaai/vexa-lite at /opt/hf-cache. Fully
  *                   specified (licence + copyright + download location). Mirrors
  *                   THIRD_PARTY_LICENSES.md; the piece gate:licenses cannot see.
  *
  * The npm and pip sources are best-effort: a missing pnpm index or absent uv.locks
  * degrade to a WARNING on stderr, never a hard failure — the document always emits
- * with at least the repo + the baked model (green-on-empty, like the gates).
+ * with at least the repo + the baked model and Valkey (green-on-empty, like the gates).
  *
  * Usage:
  *   node scripts/sbom.mjs --version v0.12.3 [--output sbom.spdx.json]
@@ -29,7 +32,7 @@
  * Run from the repo root (like scripts/gates.mjs).
  */
 import { readFileSync, existsSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { execSync } from "node:child_process";
 
 const ROOT = process.cwd();
@@ -148,7 +151,46 @@ function pipPackages() {
   return [...byKey.values()];
 }
 
-// ── source 3: the baked model weights (the piece gate:licenses cannot see) ───────
+// ── source 3: Lite final-stage apt packages ───────────────────────────────────
+// Docker source gives us the exact declared package NAMES but not the resolved Ubuntu
+// versions or their package-level licences. Inventory the names honestly and leave those
+// fields NOASSERTION; an image scanner may enrich them after the image exists.
+function liteAptPackages() {
+  const dockerfile = process.env.SBOM_LITE_DOCKERFILE
+    ? resolve(process.env.SBOM_LITE_DOCKERFILE)
+    : join(ROOT, "deploy", "lite", "Dockerfile.lite");
+  if (!existsSync(dockerfile)) return [];
+  const text = readFileSync(dockerfile, "utf8");
+  const finalStart = text.match(/^FROM\s+\S+(?:\s+AS\s+final)\s*$/mi);
+  if (!finalStart || finalStart.index === undefined) {
+    warn("Dockerfile.lite has no named final stage — Lite apt inventory is empty");
+    return [];
+  }
+  const afterFinal = text.slice(finalStart.index + finalStart[0].length);
+  const nextStage = afterFinal.search(/^FROM\s+/mi);
+  const finalStage = (nextStage >= 0 ? afterFinal.slice(0, nextStage) : afterFinal)
+    .replace(/\\\r?\n/g, " ");
+  const names = new Set();
+  for (const match of finalStage.matchAll(/\bapt(?:-get)?\s+install\b([^&;\n]+)/gi)) {
+    for (const token of match[1].trim().split(/\s+/)) {
+      if (!token || token.startsWith("-") || token.includes("$")) continue;
+      const name = token.replace(/^["']|["']$/g, "").split("=")[0];
+      if (/^[a-z0-9][a-z0-9+.-]*$/i.test(name)) names.add(name);
+    }
+  }
+  return [...names].sort().map((name) => ({
+    eco: "deb",
+    name,
+    version: "NOASSERTION",
+    licenseDeclared: "NOASSERTION",
+    licenseConcluded: "NOASSERTION",
+    copyrightText: "NOASSERTION",
+    supplier: "Organization: Ubuntu",
+    comment: "Declared by deploy/lite/Dockerfile.lite final-stage apt install; version and package licence require enrichment from the built image.",
+  }));
+}
+
+// ── source 4: the baked model weights (the piece gate:licenses cannot see) ───────
 const BAKED_MODEL = {
   eco: "huggingface", name: "onnx-community/pyannote-segmentation-3.0", version: "main",
   licenseDeclared: "MIT", licenseConcluded: "MIT",
@@ -194,6 +236,7 @@ function pkgObject(p, id) {
 
 const npm = npmPackages();
 const pip = pipPackages();
+const liteApt = liteAptPackages();
 const deps = [...npm, ...pip].sort((a, b) => (a.eco + a.name + a.version).localeCompare(b.eco + b.name + b.version));
 
 const ROOT_ID = "SPDXRef-Package-vexa";
@@ -219,6 +262,12 @@ const valkeyId = spdxId("Package", "github", "valkey", "8.1.9");
 packages.push(pkgObject(BAKED_VALKEY, valkeyId));
 relationships.push({ spdxElementId: ROOT_ID, relatedSpdxElement: valkeyId, relationshipType: "CONTAINS" });
 
+for (const apt of liteApt) {
+  const id = spdxId("Package", apt.eco, apt.name, apt.version);
+  packages.push(pkgObject(apt, id));
+  relationships.push({ spdxElementId: ROOT_ID, relatedSpdxElement: id, relationshipType: "CONTAINS" });
+}
+
 for (const d of deps) {
   const id = spdxId("Package", d.eco, d.name, d.version);
   packages.push(pkgObject(d, id));
@@ -234,7 +283,7 @@ const doc = {
   creationInfo: {
     created: CREATED,
     creators: ["Tool: vexa-sbom (scripts/sbom.mjs)", "Organization: Vexa"],
-    comment: `Coverage: npm deps=${npm.length} (declared licences via pnpm), pip deps=${pip.length} (inventory only, licence=NOASSERTION — pip-licenses owed per ADR-0009), baked artifacts=2 (pyannote model weights + Valkey engine, fully specified). Non-dependency baked artifacts sit outside gate:licenses (audited by gate:image-licenses); see THIRD_PARTY_LICENSES.md.`,
+    comment: `Coverage: npm deps=${npm.length} (declared licences via pnpm), pip deps=${pip.length} (inventory only, licence=NOASSERTION — pip-licenses owed per ADR-0009), Lite final-stage apt packages=${liteApt.length} (source-declared names; version/licence=NOASSERTION pending image enrichment), baked artifacts=2 (pyannote model weights + Valkey engine, fully specified). Non-dependency baked artifacts sit outside gate:licenses (audited by gate:image-licenses); see THIRD_PARTY_LICENSES.md.`,
   },
   packages,
   relationships,
@@ -243,7 +292,7 @@ const doc = {
 const json = JSON.stringify(doc, null, 2) + "\n";
 if (OUTPUT) {
   writeFileSync(OUTPUT, json);
-  console.error(`[sbom] wrote ${OUTPUT} — ${packages.length} packages (root + model + ${deps.length} deps: ${npm.length} npm, ${pip.length} pip)`);
+  console.error(`[sbom] wrote ${OUTPUT} — ${packages.length} packages (root + 2 baked + ${liteApt.length} Lite apt + ${deps.length} deps: ${npm.length} npm, ${pip.length} pip)`);
 } else {
   process.stdout.write(json);
 }

--- a/scripts/sbom.test.mjs
+++ b/scripts/sbom.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const LITE = join(ROOT, "deploy", "lite", "Dockerfile.lite");
+
+function emitSbom(liteDockerfile) {
+  const scratch = mkdtempSync(join(tmpdir(), "vexa-sbom-test-"));
+  const output = join(scratch, "sbom.spdx.json");
+  const env = { ...process.env, SBOM_CREATED: "2026-07-24T00:00:00.000Z" };
+  if (liteDockerfile) {
+    const fixture = join(scratch, "Dockerfile.lite");
+    writeFileSync(fixture, liteDockerfile);
+    env.SBOM_LITE_DOCKERFILE = fixture;
+  }
+  try {
+    execFileSync(
+      "node",
+      ["scripts/sbom.mjs", "--version", "test", "--output", output],
+      {
+        cwd: ROOT,
+        env,
+        stdio: "pipe",
+      },
+    );
+    return JSON.parse(readFileSync(output, "utf8"));
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+function packageNamed(doc, name) {
+  return doc.packages.find((entry) => entry.name === name);
+}
+
+test("Lite final-stage apt packages are represented in the emitted SPDX", () => {
+  const doc = emitSbom();
+  for (const name of ["ffmpeg", "x11vnc", "pulseaudio", "postgresql-client"]) {
+    const pkg = packageNamed(doc, name);
+    assert(pkg, `${name} is installed in the Lite final image but absent from the SPDX`);
+    assert.equal(pkg.licenseDeclared, "NOASSERTION");
+    assert(doc.relationships.some(
+      (edge) => edge.relatedSpdxElement === pkg.SPDXID && edge.relationshipType === "CONTAINS",
+    ));
+  }
+});
+
+test("a newly declared Lite final-stage apt package is automatically inventoried", () => {
+  const marker = "supervisor postgresql-client";
+  const original = readFileSync(LITE, "utf8");
+  const edited = original.replace(marker, `${marker} review-apt-probe`);
+  assert.notEqual(edited, original, "fixture setup did not alter Dockerfile.lite");
+  const doc = emitSbom(edited);
+  assert(packageNamed(doc, "review-apt-probe"));
+});


### PR DESCRIPTION
Closes #653.

Integrates the exact contributed head of PR #923 (`d1702d870798d2417f20c69cfccab724ac5068d3`) and adds the two maintainer-owned source repairs required by exact-head review.

## Custody and source receipt

- `source_disposition: absorb_with_receipt`
- Credit: @a-tokyo authored the Valkey migration, runtime-parity/image-license gates, license inventory, and associated delivery work in PR #923.
- The contributor commit is preserved unchanged in this branch's ancestry: `d1702d87` → maintainer merge `1015fb90` → repair `3c9a0251`.
- PR #923 stays open until this integration PR actually delivers the value.
- No contributor action is requested. The repair and integration are maintainer-owned.

## Maintainer repairs

1. `gate:image-licenses` now enumerates all supported deploy-owned pin forms: scalar Compose/Helm `image:` values, structured Helm `repository` + `tag` values, Helm template literals, and every Lite Dockerfile `FROM`, including builder stages. Each new shape has a deterministic negative control.
2. The SPDX generator now inventories all 21 package names introduced by Lite's final-stage `apt install`, including `ffmpeg`, `x11vnc`, `pulseaudio`, and `postgresql-client`. Because Docker source does not resolve Ubuntu package versions or package-level licenses, those fields are truthfully `NOASSERTION` pending built-image enrichment. Builder-only apt packages are excluded.

The inherited trailing whitespace in `licenses/valkey-8.1.9.COPYING.txt` was not touched because neither bounded source repair edits that file.

## Observation bundle

Expected → Actual → Verdict:

- Structured Helm pin must red when undeclared → planted `somevendor/unaudited:1.2` was initially missed, then named by `gate:image-licenses` after repair → GREEN.
- Lite Dockerfile `FROM` must red when undeclared → planted `somevendor/unaudited:1.2` was initially missed, then named with its source file after repair → GREEN.
- Lite final-stage apt inventory must contain the four named packages and future declarations → all four were initially absent; after repair the SPDX contains all four plus an automatically planted `review-apt-probe` → GREEN.
- Focused negative controls → `node --test scripts/gates.test.mjs scripts/sbom.test.mjs` twice consecutively: 21/21 each run → GREEN.
- Full script/release tests → `node --test scripts/*.test.mjs release/*.test.mjs`: 77/77 → GREEN.
- `node scripts/gates.mjs image-licenses` → 6 pinned images + 1 bundled component audited → GREEN.
- `node scripts/gates.mjs runtime-parity` → 3 surfaces, 22 used commands, XAUTOCLAIM floor satisfied → GREEN.
- `node scripts/gates.mjs licenses` → 460 dependencies OSS-clean, 2 logged Cat-B exceptions → GREEN.
- Deterministic SPDX emit → 633 packages: root + 2 baked + 21 Lite apt + 609 dependency packages; the four named apt packages present with `NOASSERTION` license fields → GREEN.
- Pre-push static suite → all 14 checks GREEN.
- Additional static checks run locally (architecture/dataflow/contracts/config/licenses/runtime parity) were GREEN. `gate:db-schema` alone remains red on untouched current-main formatter drift (`default=lambda: {}` versus the sealed `default=lambda : {}`); this integration neither introduces nor reseals that unrelated drift.

Not checked by design: Docker builds/runs, browser, live meetings, stage, production, or Zoom.