### PR TITLE
feat(licenses): govern Firefox artifact custody (#938)

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -17,6 +17,33 @@ That is a source-level inventory: Docker source does not resolve Ubuntu package 
 package licences, so those fields are emitted as `NOASSERTION` until an image-level scanner
 enriches them. Builder-stage packages that do not cross into the final image are excluded.
 
+## Selected copy-only browser payload
+
+The unsigned-Zoom browser candidate is the unmodified Firefox payload matched to Playwright
+`1.61.1`: Firefox `151.0`, Playwright revision `1532`, artifact path
+`/ms-playwright/firefox-1532`. The packaging authority is
+[`image-licenses.json`](image-licenses.json), which binds:
+
+- the researched Linux/arm64 source image digest and Firefox BuildID;
+- the Firefox 151 source-retrieval directory required for MPL executable-form distribution;
+- `copyOnly` to the matched Firefox artifact path;
+- the embedded MPL/third-party inventory at
+  `omni.ja!/chrome/toolkit/content/global/license.html` by byte count and SHA-256;
+- the separately shipped, dynamically loaded `liblgpllibs.so` by path and SHA-256; and
+- both complete Chrome-for-Testing `149.0.7827.55` / revision `1228` tuples as forbidden
+  artifacts.
+
+Firefox is MPL-2.0. The named `liblgpllibs.so` child is LGPL-2.1-or-later and remains an
+unmodified, separate dynamic library rather than being statically linked into Vexa. These are
+Category-B dispositions under P17: their reasons and isolation facts live beside the artifact
+identity in `image-licenses.json`, and `gate:image-licenses` fails closed if they drift. The
+per-release SPDX represents the containment honestly as Vexa `CONTAINS` Firefox and Firefox
+`CONTAINS` `liblgpllibs.so`.
+
+This source inventory does **not** prove that a final native image contains the selected bytes
+or notices, nor that a browser launches or joins a meeting. Those remain later native-image and
+live acceptance rows.
+
 ## Baked service binaries
 
 | Artifact | Version | License | Source | Baked into | In-image path |

--- a/image-licenses.json
+++ b/image-licenses.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Packaging-side licence manifest (P17 / ADR-0004, #653), the complement to license-exceptions.json. gate:licenses scans the npm/py DEPENDENCY tree; it is blind to what our IMAGES ship. This file declares the two surfaces it cannot see, and gate:image-licenses (scripts/gates.mjs) audits them: `images` = third-party container images pinned by deploy-owned compose, Helm, or Lite Dockerfile FROM surfaces (an undeclared pin fails; a non-permissive one needs a logged `reason`); `bundled` = components baked INTO a published vexaai/* image (redistribution — Cat A or Cat-B-with-reason only, Cat X always fails). `name` matches an image ref with its :tag stripped. The per-release SPDX SBOM inventories every package name installed by the Lite final stage; because Docker source cannot resolve Ubuntu package versions or licences, those fields stay NOASSERTION until an image-level scanner enriches them.",
+  "_comment": "Packaging-side licence manifest (P17 / ADR-0004, #653), the complement to license-exceptions.json. gate:licenses scans the npm/py DEPENDENCY tree; it is blind to what our IMAGES ship. This file declares the surfaces it cannot see, and gate:image-licenses (scripts/gates.mjs) audits them: `images` = third-party container images pinned by deploy-owned compose, Helm, or Lite Dockerfile FROM surfaces; `bundled` = components baked INTO a published vexaai/* image; `browserArtifacts` = the selected copy-only browser payload, its provenance/notices/nested weak-copyleft components, and exact forbidden browser payloads. `name` matches an image ref with its :tag stripped. The per-release SPDX SBOM inventories every package name installed by the Lite final stage; because Docker source cannot resolve Ubuntu package versions or licences, those fields stay NOASSERTION until an image-level scanner enriches them.",
   "images": [
     {
       "name": "mcr.microsoft.com/playwright",
@@ -45,6 +45,63 @@
       "artifact": "vexaai/vexa-lite",
       "how": "source-build from the pinned git tag 8.1.9 (deploy/lite/Dockerfile.lite valkey-builder stage); valkey-server + valkey-cli copied into the final image, COPYING preserved at /usr/local/share/valkey/LICENSE",
       "reason": "XAUTOCLAIM parity with compose/helm and off BOTH jammy apt's stale Redis 6.0.16 (no XAUTOCLAIM) and source-available Redis ≥7.4 (RSALv2/SSPLv1). BSD-3 is Category A — clean to redistribute (#653)."
+    }
+  ],
+  "browserArtifacts": [
+    {
+      "name": "firefox",
+      "version": "151.0",
+      "playwrightRevision": "1532",
+      "artifactPath": "/ms-playwright/firefox-1532",
+      "copyOnly": "/ms-playwright/firefox-1532",
+      "driver": {
+        "name": "playwright",
+        "version": "1.61.1",
+        "license": "Apache-2.0"
+      },
+      "sourceImage": "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e",
+      "sourceRetrieval": "https://archive.mozilla.org/pub/firefox/releases/151.0/source/",
+      "sourceArchitecture": "linux/arm64",
+      "researchBuildId": "20260611122632",
+      "license": "MPL-2.0",
+      "reason": "Firefox is copied unmodified as a separately identifiable browser payload. MPL-2.0 applies to the Firefox files, not to Vexa source; the source-retrieval and embedded notice references travel with the payload.",
+      "requiredNotices": [
+        {
+          "name": "MPL-2.0",
+          "path": "omni.ja!/chrome/toolkit/content/global/license.html"
+        },
+        {
+          "name": "firefox_embedded_third_party_inventory",
+          "path": "omni.ja!/chrome/toolkit/content/global/license.html",
+          "bytes": 308060,
+          "sha256": "276c0a63176234c8aa3108e415a9e336c590ecf600bc24af7d6809d5af75436e"
+        }
+      ],
+      "nestedComponents": [
+        {
+          "name": "liblgpllibs.so",
+          "path": "/ms-playwright/firefox-1532/firefox/liblgpllibs.so",
+          "sha256": "e09a057e89519b24f1dd8c26b29df9175c3233b86d8102ad9e13c2e9041acc66",
+          "license": "LGPL-2.1-or-later",
+          "linkage": "separate-dynamic-library",
+          "modified": false,
+          "reason": "Unmodified, separately shipped and dynamically loaded Firefox runtime library; never statically linked into Vexa. Category-B redistribution remains confined to this named component."
+        }
+      ],
+      "forbiddenArtifacts": [
+        {
+          "product": "chrome-for-testing",
+          "version": "149.0.7827.55",
+          "playwrightRevision": "1228",
+          "path": "/ms-playwright/chromium-1228"
+        },
+        {
+          "product": "chrome-headless-shell-for-testing",
+          "version": "149.0.7827.55",
+          "playwrightRevision": "1228",
+          "path": "/ms-playwright/chromium_headless_shell-1228"
+        }
+      ]
     }
   ]
 }

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -10,6 +10,13 @@ Each file here is copied into the image next to the artifact it covers (e.g.
 [`THIRD_PARTY_LICENSES.md`](../THIRD_PARTY_LICENSES.md) manifest and the per-release SPDX
 SBOM ([`scripts/sbom.mjs`](../scripts/sbom.mjs)).
 
+Firefox is the exception to the standalone-file shape: its MPL text and complete third-party
+inventory already travel inside the selected browser payload at
+`omni.ja!/chrome/toolkit/content/global/license.html`. The packaging authority records that
+embedded file's exact size and SHA-256 in
+[`image-licenses.json`](../image-licenses.json); duplicating an extracted copy here would create
+a second, drift-prone notice source.
+
 | File | Artifact | Licence |
 | --- | --- | --- |
 | `onnx-community-pyannote-segmentation-3.0.LICENSE.txt` | `onnx-community/pyannote-segmentation-3.0` (mixed-lane diarization weights) | MIT |

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -520,6 +520,9 @@ function gateImageLicenses() {
   // separately loaded weak-copyleft components, and the artifacts that must not cross into the image.
   const browserArtifacts = man.browserArtifacts || [];
   const firefox = browserArtifacts.find((entry) => entry.name === "firefox");
+  if (browserArtifacts.length !== 1 || browserArtifacts[0]?.name !== "firefox") {
+    bad.push("browser artifact authority must contain exactly one selected Firefox record");
+  }
   const expectedFirefoxSource =
     "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e";
   const expectedNotices = [

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -515,7 +515,114 @@ function gateImageLicenses() {
     else if (cat !== "A") flagged.push(`bundled ${e.name} (${e.license})`);
   }
 
-  // (3) concrete #653 guard — the Lite parity trap: apt-installed redis-server (jammy 6.0.16, no XAUTOCLAIM).
+  // (3) selected browser payloads. These are copy-only artifacts whose driver licence does not cover
+  // the browser bytes. Bind the exact browser identity, source provenance, travelling notices,
+  // separately loaded weak-copyleft components, and the artifacts that must not cross into the image.
+  const browserArtifacts = man.browserArtifacts || [];
+  const firefox = browserArtifacts.find((entry) => entry.name === "firefox");
+  const expectedFirefoxSource =
+    "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e";
+  const expectedNotices = [
+    {
+      name: "MPL-2.0",
+      path: "omni.ja!/chrome/toolkit/content/global/license.html",
+    },
+    {
+      name: "firefox_embedded_third_party_inventory",
+      path: "omni.ja!/chrome/toolkit/content/global/license.html",
+      bytes: 308060,
+      sha256: "276c0a63176234c8aa3108e415a9e336c590ecf600bc24af7d6809d5af75436e",
+    },
+  ];
+  const expectedNested = [
+    {
+      name: "liblgpllibs.so",
+      path: "/ms-playwright/firefox-1532/firefox/liblgpllibs.so",
+      sha256: "e09a057e89519b24f1dd8c26b29df9175c3233b86d8102ad9e13c2e9041acc66",
+      license: "LGPL-2.1-or-later",
+      linkage: "separate-dynamic-library",
+      modified: false,
+    },
+  ];
+  const expectedForbidden = [
+    {
+      product: "chrome-for-testing",
+      version: "149.0.7827.55",
+      playwrightRevision: "1228",
+      path: "/ms-playwright/chromium-1228",
+    },
+    {
+      product: "chrome-headless-shell-for-testing",
+      version: "149.0.7827.55",
+      playwrightRevision: "1228",
+      path: "/ms-playwright/chromium_headless_shell-1228",
+    },
+  ];
+
+  if (!firefox) {
+    bad.push('browser artifact authority is missing selected "firefox"');
+  } else {
+    if (
+      firefox.version !== "151.0" ||
+      firefox.playwrightRevision !== "1532" ||
+      firefox.artifactPath !== "/ms-playwright/firefox-1532" ||
+      firefox.copyOnly !== firefox.artifactPath ||
+      firefox.driver?.name !== "playwright" ||
+      firefox.driver?.version !== "1.61.1" ||
+      firefox.driver?.license !== "Apache-2.0"
+    ) {
+      bad.push(
+        `Firefox copyOnly identity must be Playwright 1.61.1 / Firefox 151 rev1532 at /ms-playwright/firefox-1532; got copyOnly=${firefox.copyOnly || "<missing>"}`,
+      );
+    }
+    if (
+      firefox.sourceImage !== expectedFirefoxSource ||
+      firefox.sourceRetrieval !== "https://archive.mozilla.org/pub/firefox/releases/151.0/source/" ||
+      firefox.sourceArchitecture !== "linux/arm64" ||
+      firefox.researchBuildId !== "20260611122632"
+    ) {
+      bad.push("Firefox source-image provenance must match the prepared arm64 digest and BuildID");
+    }
+
+    const firefoxCat = classifyLicense(firefox.license || "");
+    if (firefoxCat !== "B" || !firefox.reason) {
+      bad.push(`Firefox MPL custody must be a reasoned Cat-B disposition; got ${firefox.license || "<missing>"}`);
+    }
+    if (JSON.stringify(firefox.requiredNotices) !== JSON.stringify(expectedNotices)) {
+      bad.push("Firefox required notice identity must bind MPL-2.0 and the exact embedded third-party inventory");
+    }
+
+    const nestedComparable = (firefox.nestedComponents || []).map(
+      ({ name, path, sha256, license, linkage, modified }) =>
+        ({ name, path, sha256, license, linkage, modified }),
+    );
+    if (JSON.stringify(nestedComparable) !== JSON.stringify(expectedNested)) {
+      bad.push("Firefox nested Cat-B inventory must bind the unmodified separate liblgpllibs.so identity");
+    }
+    for (const component of firefox.nestedComponents || []) {
+      const cat = classifyLicense(component.license || "");
+      if (
+        cat !== "B" ||
+        !component.reason ||
+        component.linkage !== "separate-dynamic-library" ||
+        component.modified !== false
+      ) {
+        bad.push(
+          `nested Firefox component "${component.name || "<missing>"}" (${component.license || "<missing>"}) must carry a reasoned, unmodified, separate-dynamic-library Cat-B disposition`,
+        );
+      }
+    }
+
+    if (JSON.stringify(firefox.forbiddenArtifacts) !== JSON.stringify(expectedForbidden)) {
+      bad.push("Firefox forbidden CfT inventory must bind both complete Chrome-for-Testing 149/rev1228 tuples");
+    }
+    const forbiddenPaths = new Set(expectedForbidden.map((entry) => entry.path));
+    if (forbiddenPaths.has(firefox.copyOnly)) {
+      bad.push(`Firefox copyOnly selects forbidden CfT artifact ${firefox.copyOnly}`);
+    }
+  }
+
+  // (4) concrete #653 guard — the Lite parity trap: apt-installed redis-server (jammy 6.0.16, no XAUTOCLAIM).
   const lite = join(ROOT, "deploy", "lite", "Dockerfile.lite");
   // `[^&]*?` scopes the match to the install statement's package list (it terminates at the first `&&`),
   // so a comment MENTIONING redis-server later in the file never trips the guard — only a real package does.
@@ -524,7 +631,7 @@ function gateImageLicenses() {
     bad.push("Lite bakes `apt install redis-server` (jammy 6.0.16 — no XAUTOCLAIM, the #653 parity trap). Use the Valkey source-build stage (BSD-3, XAUTOCLAIM) instead.");
 
   if (bad.length) return fail(bad);
-  console.log(`  ✓ gate:image-licenses — ${foundImages.size} pinned image(s) + ${(man.bundled || []).length} bundled component(s) declared & audited${flagged.length ? ` (${flagged.length} non-A by logged reason: ${flagged.join("; ")})` : ""}`);
+  console.log(`  ✓ gate:image-licenses — ${foundImages.size} pinned image(s) + ${(man.bundled || []).length} bundled component(s) + ${browserArtifacts.length} browser artifact(s) declared & audited${flagged.length ? ` (${flagged.length} non-A by logged reason: ${flagged.join("; ")})` : ""}`);
   return true;
 }
 

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -205,6 +205,29 @@ test("image-licenses audits the declared Firefox artifact authority", () => {
   );
 });
 
+test("image-licenses RED: an extra top-level CfT 1228 browser authority is rejected", () => {
+  const extraChromium = `"browserArtifacts": [
+    {
+      "name": "chromium",
+      "version": "149.0.7827.55",
+      "playwrightRevision": "1228",
+      "artifactPath": "/ms-playwright/chromium-1228",
+      "copyOnly": "/ms-playwright/chromium-1228"
+    },`;
+  const r = withEdited(
+    IMG_MANIFEST,
+    '"browserArtifacts": [',
+    extraChromium,
+    () => runGate("image-licenses"),
+  );
+  assert.equal(
+    r.green,
+    false,
+    "an extra top-level CfT 1228 browser authority false-greened",
+  );
+  assert.match(r.out, /exactly one.*Firefox/i);
+});
+
 test("image-licenses RED: Firefox source-image provenance drift is rejected", () => {
   const original =
     "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e";

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -172,6 +172,95 @@ test("image-licenses vacuity: the committed tree (Valkey everywhere) is green", 
   assert.equal(r.green, true, `the clean tree already reds — the fixtures below prove nothing:\n${r.out}`);
 });
 
+test("image-licenses declares the prepared Firefox copy-only custody contract", () => {
+  const manifest = JSON.parse(readFileSync(join(ROOT, IMG_MANIFEST), "utf8"));
+  const firefox = manifest.browserArtifacts?.find((entry) => entry.name === "firefox");
+  assert(firefox, "FIREFOX_CUSTODY_RED: image-licenses.json has no Firefox artifact authority");
+  assert.deepEqual(
+    {
+      version: firefox.version,
+      playwrightRevision: firefox.playwrightRevision,
+      artifactPath: firefox.artifactPath,
+      sourceImage: firefox.sourceImage,
+      sourceRetrieval: firefox.sourceRetrieval,
+    },
+    {
+      version: "151.0",
+      playwrightRevision: "1532",
+      artifactPath: "/ms-playwright/firefox-1532",
+      sourceImage:
+        "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e",
+      sourceRetrieval: "https://archive.mozilla.org/pub/firefox/releases/151.0/source/",
+    },
+  );
+});
+
+test("image-licenses audits the declared Firefox artifact authority", () => {
+  const r = runGate("image-licenses");
+  assert.equal(r.green, true, `the prepared Firefox custody contract is invalid:\n${r.out}`);
+  assert.match(
+    r.out,
+    /1 browser artifact/,
+    "FIREFOX_GATE_RED: gate:image-licenses ignores browserArtifacts",
+  );
+});
+
+test("image-licenses RED: Firefox source-image provenance drift is rejected", () => {
+  const original =
+    "mcr.microsoft.com/playwright@sha256:7b86926fff94374389e8e1f4fdc5c76d050d4a06a7886bb537bf412b20e2b71e";
+  const drifted =
+    "mcr.microsoft.com/playwright@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const r = withEdited(IMG_MANIFEST, original, drifted, () => runGate("image-licenses"));
+  assert.equal(r.green, false, "Firefox source-image provenance drift false-greened");
+  assert.match(r.out, /source-image provenance/i);
+});
+
+test("image-licenses RED: copyOnly cannot select a forbidden CfT 1228 path", () => {
+  const r = withEdited(
+    IMG_MANIFEST,
+    '"copyOnly": "/ms-playwright/firefox-1532"',
+    '"copyOnly": "/ms-playwright/chromium-1228"',
+    () => runGate("image-licenses"),
+  );
+  assert.equal(r.green, false, "a forbidden CfT 1228 copyOnly path false-greened");
+  assert.match(r.out, /copyOnly/i);
+  assert.match(r.out, /chromium-1228/);
+});
+
+test("image-licenses RED: both complete forbidden CfT tuples are pinned", () => {
+  const r = withEdited(
+    IMG_MANIFEST,
+    '"playwrightRevision": "1228",\n          "path": "/ms-playwright/chromium_headless_shell-1228"',
+    '"playwrightRevision": "1532",\n          "path": "/ms-playwright/firefox-1532"',
+    () => runGate("image-licenses"),
+  );
+  assert.equal(r.green, false, "forbidden CfT tuple drift false-greened");
+  assert.match(r.out, /forbidden.*CfT/i);
+});
+
+test("image-licenses RED: Firefox embedded notice identity is fail-closed", () => {
+  const r = withEdited(
+    IMG_MANIFEST,
+    "276c0a63176234c8aa3108e415a9e336c590ecf600bc24af7d6809d5af75436e",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    () => runGate("image-licenses"),
+  );
+  assert.equal(r.green, false, "Firefox embedded notice hash drift false-greened");
+  assert.match(r.out, /notice/i);
+});
+
+test("image-licenses RED: nested LGPL library needs an isolated Cat-B disposition", () => {
+  const r = withEdited(
+    IMG_MANIFEST,
+    '"linkage": "separate-dynamic-library"',
+    '"linkage": "static"',
+    () => runGate("image-licenses"),
+  );
+  assert.equal(r.green, false, "a statically linked LGPL browser component false-greened");
+  assert.match(r.out, /Cat-B|LGPL/);
+  assert.match(r.out, /liblgpllibs\.so/);
+});
+
 test("image-licenses RED: an undeclared pinned image (a stray redis:7.4) reds", () => {
   // redis:7.4 is exactly the source-available (RSALv2/SSPL) engine #653 keeps out; undeclared ⇒ loud red.
   const r = withEdited(COMPOSE, "image: valkey/valkey:8-alpine", "image: redis:7.4-alpine",

--- a/scripts/sbom.mjs
+++ b/scripts/sbom.mjs
@@ -6,7 +6,7 @@
  * `gate:licenses` (scripts/gates.mjs) PROVES the npm tree is licence-clean but
  * emits no artifact, and it never sees non-dependency bytes baked into the images
  * (model weights). This script is the emit side + the packaging complement: it
- * inventories four sources into one SPDX document —
+ * inventories five sources into one SPDX document —
  *
  *   1. npm deps   — `pnpm licenses list --json` (the same index gate:licenses uses):
  *                   name · version · declared licence, one SPDX package per version.
@@ -21,6 +21,10 @@
  *                   vexaai/vexa-bot + vexaai/vexa-lite at /opt/hf-cache. Fully
  *                   specified (licence + copyright + download location). Mirrors
  *                   THIRD_PARTY_LICENSES.md; the piece gate:licenses cannot see.
+ *   5. browser payload — the copy-only Firefox artifact declared by
+ *                   image-licenses.json, plus its separately loaded LGPL child.
+ *                   The relationship graph records root CONTAINS Firefox and
+ *                   Firefox CONTAINS each nested component.
  *
  * The npm and pip sources are best-effort: a missing pnpm index or absent uv.locks
  * degrade to a WARNING on stderr, never a hard failure — the document always emits
@@ -215,6 +219,51 @@ const BAKED_VALKEY = {
   comment: "Source-built (BUILD_TLS=no) into vexaai/vexa-lite; valkey-server + valkey-cli at /usr/local/bin, notice at /usr/local/share/valkey/LICENSE. compose/helm pin valkey/valkey:8-alpine (user-pulled, in image-licenses.json). #653.",
 };
 
+// Browser payloads are governed by image-licenses.json because Playwright's Apache licence covers
+// the driver, not the browser bytes it downloads. gate:image-licenses validates the exact identity,
+// provenance, travelling notices, Cat-B isolation, and forbidden artifacts before this emitter
+// turns the same authority into SPDX packages and nested CONTAINS relationships.
+function browserArtifactPackages() {
+  const manifestPath = join(ROOT, "image-licenses.json");
+  if (!existsSync(manifestPath)) return [];
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  return (manifest.browserArtifacts || []).map((browser) => ({
+    package: {
+      eco: "generic",
+      name: browser.name,
+      version: browser.version,
+      licenseDeclared: browser.license,
+      licenseConcluded: browser.license,
+      copyrightText: "NOASSERTION",
+      downloadLocation: browser.sourceRetrieval || "NOASSERTION",
+      purl: `pkg:generic/${browser.name}@${browser.version}`,
+      supplier: browser.name === "firefox" ? "Organization: Mozilla" : undefined,
+      comment: [
+        `Copy-only artifact ${browser.artifactPath} from ${browser.sourceImage}.`,
+        `Playwright revision ${browser.playwrightRevision}; research BuildID ${browser.researchBuildId}.`,
+        `Required notices: ${(browser.requiredNotices || []).map((notice) => notice.path).join(", ")}.`,
+        "Final native-image identity remains a separate release proof.",
+      ].join(" "),
+    },
+    nested: (browser.nestedComponents || []).map((component) => ({
+      eco: "generic",
+      name: component.name,
+      version: browser.version,
+      licenseDeclared: component.license,
+      licenseConcluded: component.license,
+      copyrightText: "NOASSERTION",
+      downloadLocation: "NOASSERTION",
+      purl: `pkg:generic/${browser.name}-${component.name}@${browser.version}`,
+      supplier: browser.name === "firefox" ? "Organization: Mozilla" : undefined,
+      comment: [
+        `${component.path}; sha256:${component.sha256}.`,
+        `Linkage=${component.linkage}; modified=${component.modified}.`,
+        component.reason,
+      ].join(" "),
+    })),
+  }));
+}
+
 // ── assemble the SPDX 2.3 document ──────────────────────────────────────────────
 function pkgObject(p, id) {
   const externalRefs = p.purl ? [{ referenceCategory: "PACKAGE-MANAGER", referenceType: "purl", referenceLocator: p.purl }] : [];
@@ -237,6 +286,7 @@ function pkgObject(p, id) {
 const npm = npmPackages();
 const pip = pipPackages();
 const liteApt = liteAptPackages();
+const browserArtifacts = browserArtifactPackages();
 const deps = [...npm, ...pip].sort((a, b) => (a.eco + a.name + a.version).localeCompare(b.eco + b.name + b.version));
 
 const ROOT_ID = "SPDXRef-Package-vexa";
@@ -262,6 +312,36 @@ const valkeyId = spdxId("Package", "github", "valkey", "8.1.9");
 packages.push(pkgObject(BAKED_VALKEY, valkeyId));
 relationships.push({ spdxElementId: ROOT_ID, relatedSpdxElement: valkeyId, relationshipType: "CONTAINS" });
 
+for (const browser of browserArtifacts) {
+  const browserId = spdxId(
+    "Package",
+    browser.package.eco,
+    browser.package.name,
+    browser.package.version,
+  );
+  packages.push(pkgObject(browser.package, browserId));
+  relationships.push({
+    spdxElementId: ROOT_ID,
+    relatedSpdxElement: browserId,
+    relationshipType: "CONTAINS",
+  });
+  for (const component of browser.nested) {
+    const componentId = spdxId(
+      "Package",
+      component.eco,
+      browser.package.name,
+      component.name,
+      component.version,
+    );
+    packages.push(pkgObject(component, componentId));
+    relationships.push({
+      spdxElementId: browserId,
+      relatedSpdxElement: componentId,
+      relationshipType: "CONTAINS",
+    });
+  }
+}
+
 for (const apt of liteApt) {
   const id = spdxId("Package", apt.eco, apt.name, apt.version);
   packages.push(pkgObject(apt, id));
@@ -283,7 +363,7 @@ const doc = {
   creationInfo: {
     created: CREATED,
     creators: ["Tool: vexa-sbom (scripts/sbom.mjs)", "Organization: Vexa"],
-    comment: `Coverage: npm deps=${npm.length} (declared licences via pnpm), pip deps=${pip.length} (inventory only, licence=NOASSERTION — pip-licenses owed per ADR-0009), Lite final-stage apt packages=${liteApt.length} (source-declared names; version/licence=NOASSERTION pending image enrichment), baked artifacts=2 (pyannote model weights + Valkey engine, fully specified). Non-dependency baked artifacts sit outside gate:licenses (audited by gate:image-licenses); see THIRD_PARTY_LICENSES.md.`,
+    comment: `Coverage: npm deps=${npm.length} (declared licences via pnpm), pip deps=${pip.length} (inventory only, licence=NOASSERTION — pip-licenses owed per ADR-0009), Lite final-stage apt packages=${liteApt.length} (source-declared names; version/licence=NOASSERTION pending image enrichment), baked artifacts=2 (pyannote model weights + Valkey engine, fully specified), browser artifacts=${browserArtifacts.length} (${browserArtifacts.reduce((count, browser) => count + browser.nested.length, 0)} nested components). Non-dependency baked/browser artifacts sit outside gate:licenses (audited by gate:image-licenses); see THIRD_PARTY_LICENSES.md.`,
   },
   packages,
   relationships,
@@ -292,7 +372,7 @@ const doc = {
 const json = JSON.stringify(doc, null, 2) + "\n";
 if (OUTPUT) {
   writeFileSync(OUTPUT, json);
-  console.error(`[sbom] wrote ${OUTPUT} — ${packages.length} packages (root + 2 baked + ${liteApt.length} Lite apt + ${deps.length} deps: ${npm.length} npm, ${pip.length} pip)`);
+  console.error(`[sbom] wrote ${OUTPUT} — ${packages.length} packages (root + 2 baked + ${browserArtifacts.length} browser + ${browserArtifacts.reduce((count, browser) => count + browser.nested.length, 0)} browser-nested + ${liteApt.length} Lite apt + ${deps.length} deps: ${npm.length} npm, ${pip.length} pip)`);
 } else {
   process.stdout.write(json);
 }

--- a/scripts/sbom.test.mjs
+++ b/scripts/sbom.test.mjs
@@ -58,3 +58,28 @@ test("a newly declared Lite final-stage apt package is automatically inventoried
   const doc = emitSbom(edited);
   assert(packageNamed(doc, "review-apt-probe"));
 });
+
+test("Firefox and its isolated LGPL library are nested in the emitted SPDX", () => {
+  const doc = emitSbom();
+  const firefox = packageNamed(doc, "firefox");
+  assert(firefox, "FIREFOX_SBOM_RED: Firefox is absent from the emitted SPDX");
+  assert.equal(firefox.versionInfo, "151.0");
+  assert.equal(firefox.licenseDeclared, "MPL-2.0");
+
+  const lgpl = packageNamed(doc, "liblgpllibs.so");
+  assert(lgpl, "FIREFOX_SBOM_RED: liblgpllibs.so is absent from the emitted SPDX");
+  assert.equal(lgpl.licenseDeclared, "LGPL-2.1-or-later");
+
+  assert(doc.relationships.some(
+    (edge) =>
+      edge.spdxElementId === "SPDXRef-Package-vexa" &&
+      edge.relatedSpdxElement === firefox.SPDXID &&
+      edge.relationshipType === "CONTAINS",
+  ), "root package does not CONTAIN Firefox");
+  assert(doc.relationships.some(
+    (edge) =>
+      edge.spdxElementId === firefox.SPDXID &&
+      edge.relatedSpdxElement === lgpl.SPDXID &&
+      edge.relationshipType === "CONTAINS",
+  ), "Firefox does not CONTAIN liblgpllibs.so");
+});


### PR DESCRIPTION
Part of #938. This is the bounded shared Firefox/license source slice; it is intentionally separate from PR #957 pending an explicit composition decision.

## Immutable scope

- Base: `d7ed2bb8e0fd00d4f0b2915afae06044a8b90547` / tree `e784e72328deb1aee03e9c6a0a7df33dc9188724`
- Head: `bc5a473352dc009da5f5e3fa20d817cdcdaa94f3` / tree `2433064c505186f230dccbba35b7b0b7701c14d0`
- Seven files only: `THIRD_PARTY_LICENSES.md`, `image-licenses.json`, `licenses/README.md`, `scripts/gates.mjs`, `scripts/gates.test.mjs`, `scripts/sbom.mjs`, `scripts/sbom.test.mjs`

## Expected

The landed PR #961 image-license authority should fail closed unless it binds the selected Playwright 1.61.1 / Firefox 151 rev1532 copy-only artifact, arm64 provenance and source retrieval, embedded MPL/third-party notice identity, isolated LGPL child, both forbidden CfT 149/rev1228 tuples, and nested SPDX containment—without disturbing the existing Valkey or Lite apt inventory.

## Actual

RED at the prepared introduction point:

- initial custody contract: `FIREFOX_CUSTODY_RED: image-licenses.json has no Firefox artifact authority`
- after adding only the authority, the focused suite exposed seven false-greens: gate ignored browser artifacts; source-digest drift; forbidden copyOnly; forbidden tuple drift; notice hash drift; static LGPL linkage; and Firefox absent from the SBOM.

GREEN:

- focused Firefox/CfT/LGPL/SBOM suite: 8/8
- full `scripts/gates.test.mjs` + `scripts/sbom.test.mjs`: 29/29
- source-only `node --test scripts/*.test.mjs release/*.test.mjs`: 85/85
- `gate:image-licenses`: 6 pinned + 1 bundled + 1 browser artifact
- `gate:licenses`: 460 dependencies; existing two Cat-B exceptions preserved
- `gate:readme`: 311 directories
- generated SPDX: 635 packages, including root `CONTAINS` Firefox and Firefox `CONTAINS` `liblgpllibs.so`
- staged/delivered `git diff --check`: clean
- pre-push static set: all 14 green

## Verdict

The source contract now binds Firefox identity/provenance/notices, rejects CfT 1228 custody, carries the MPL/LGPL Cat-B disposition, and emits nested SPDX `CONTAINS` relationships. Existing Valkey and Lite apt inventory remain intact.

This PR does **not** claim a native image contains these bytes/notices, a browser launches, or Zoom join/leave behavior works. No browser runtime, Docker/image build, network/live meeting, stage, or prod action was performed.

## Custody and credit

This builds on the image-license/SBOM authority delivered through PR #961 and #653. Preserve @a-tokyo's contributor custody and credit through PR #923/#653/PR #961 under the recorded `absorb_with_receipt` disposition.