### PR TITLE
fix(zoom): rank in-meeting DOM evidence above the lobby-text probe in isAdmitted()

### DIFF
--- a/core/meetings/modules/join/src/zoom/admission.test.ts
+++ b/core/meetings/modules/join/src/zoom/admission.test.ts
@@ -14,7 +14,7 @@
  * Run: npx tsx src/zoom/admission.test.ts
  */
 
-import { waitForZoomMeetingAdmission } from "./admission";
+import { waitForZoomMeetingAdmission, checkForZoomAdmissionSilent } from "./admission";
 import { AdmissionError } from "../shared/admission";
 import { resetEscalation } from "../shared/escalation";
 
@@ -25,8 +25,19 @@ function check(name: string, ok: boolean, detail?: string) {
   else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ""}`); failed++; }
 }
 
-/** A page whose DOM is just body text: evaluate() runs the probe in-node, locators see nothing. */
-function makePage(bodyText: () => string): any {
+/**
+ * A page whose DOM is body text plus a declared set of present selectors.
+ *
+ * `locator().isVisible()` always returns false — which is not a limitation but
+ * the single most important property of this harness: it reproduces Zoom's
+ * auto-hidden footer toolbar, the state in which every visibility probe lies
+ * about a bot that is genuinely in the meeting.
+ *
+ * `present` lists selectors for which `document.querySelector` returns an
+ * element. Exact-string matching is enough here because isAdmitted() queries
+ * the selector constants verbatim.
+ */
+function makePage(bodyText: () => string, present: string[] = []): any {
   const locator = (sel: string): any => ({
     first: () => locator(sel),
     isVisible: async () => false,
@@ -35,7 +46,11 @@ function makePage(bodyText: () => string): any {
   });
   return {
     evaluate: async (fn: any, arg?: any) => {
-      (globalThis as any).document = { body: { innerText: bodyText() } };
+      (globalThis as any).document = {
+        body: { innerText: bodyText() },
+        querySelector: (sel: string) => (present.includes(sel) ? ({} as any) : null),
+        querySelectorAll: (sel: string) => (present.includes(sel) ? [{} as any] : []),
+      };
       try { return fn(arg); } finally { delete (globalThis as any).document; }
     },
     locator,
@@ -85,6 +100,53 @@ async function main() {
     const got = await outcomeOf(waitForZoomMeetingAdmission(page, 30_000, cfg));
     check("host rejection → AdmissionError('denial') — a re-knock cannot succeed",
       got === "AdmissionError:denial", got);
+  }
+
+  // ---- checkForZoomAdmissionSilent: the post-ACTIVE verification ------------
+  //
+  // Its caller leaves the meeting when this returns false, so a wrong `false`
+  // costs the whole recording. All three cases run with every locator invisible
+  // (auto-hidden footer) — the state that made the old ordering fail.
+
+  console.log("\n=== admitted, footer auto-hidden, generic lobby substring on screen ===");
+  {
+    // The regression. Bot IS in the meeting: a footer control is in the DOM. The
+    // toolbar has auto-hidden so isVisible() is false everywhere, and an
+    // in-meeting toast contains 'Please wait' — a zoomWaitingRoomTexts entry.
+    // Old ordering: text probe ran first, returned false, caller left the call.
+    const page = makePage(
+      () => "Please wait while we connect your audio",
+      ["#wc-footer", ".meeting-app"],
+    );
+    const got = await checkForZoomAdmissionSilent(page);
+    check("footer marker present outranks a generic lobby substring — bot stays in the meeting",
+      got === true, `got ${got}`);
+  }
+
+  console.log("\n=== genuinely in the waiting room → still not admitted ===");
+  {
+    // No footer controls exist in the lobby. `.meeting-app` IS present, because
+    // Zoom renders the waiting room inside it — so the lobby text must still
+    // veto the weak fallback (meeting_id=36, 2026-04-26).
+    const page = makePage(
+      () => "Host has joined. We've let them know you're here",
+      [".meeting-app"],
+    );
+    const got = await checkForZoomAdmissionSilent(page);
+    check("lobby copy + .meeting-app but no footer → NOT admitted (no regression of #36)",
+      got === false, `got ${got}`);
+  }
+
+  console.log("\n=== pre-join form on screen → never admitted ===");
+  {
+    // Pre-join is the one case that outranks footer evidence (meeting_id=31).
+    const page = makePage(
+      () => "Enter Meeting Info",
+      ["#wc-footer", "#input-for-name"],
+    );
+    const got = await checkForZoomAdmissionSilent(page);
+    check("pre-join form vetoes footer markers → NOT admitted (no regression of #31)",
+      got === false, `got ${got}`);
   }
 
   console.log(`\n${passed} passed, ${failed} failed`);

--- a/core/meetings/modules/join/src/zoom/admission.ts
+++ b/core/meetings/modules/join/src/zoom/admission.ts
@@ -5,6 +5,7 @@ import { BotConfig } from "../_host";
 import { checkEscalation, triggerEscalation, getEscalationExtensionMs } from "../shared/escalation";
 import {
   zoomLeaveButtonSelector,
+  zoomInMeetingMarkers,
   zoomMeetingAppSelector,
   zoomWaitingRoomTexts,
   zoomRemovalTexts,
@@ -47,28 +48,40 @@ async function detectZoomBotBlock(page: Page): Promise<string | null> {
 
 /**
  * Check if the bot is confirmed inside the meeting.
- * Primary:   Leave button visible (footer is showing). Strong positive —
- *            this control never renders in the waiting room.
- * Fallback1: .meeting-app container present (footer may be auto-hidden).
- * Fallback2: live <audio> elements AND no pre-join-page indicators —
- *            Zoom Web preloads audio streams on the pre-join page itself
- *            (local mic preview), so audio presence alone is NOT enough.
- *            Require the pre-join name input AND join button to be absent.
- *            (Observed 2026-04-26 meeting_id=31: bot was at
- *            "Enter Meeting Info"/passcode-entry screen with 3 live audio
- *            elements; an earlier audio-only fallback falsely reported
- *            admitted, status=active appeared on the dashboard while the
- *            bot was actually still pre-join.)
  *
- * IMPORTANT — waiting-room exclusion runs before BOTH fallbacks:
- * Zoom renders the waiting room INSIDE `.meeting-app` (so fallback 1
- * fires false-positive there), and the bot's mic-preview audio stays live
- * across the pre-join → waiting-room transition while pre-join DOM
- * indicators are already gone (so fallback 2 fires false-positive too).
- * Without the exclusion, the bot reports admitted and the dashboard skips
- * the `awaiting_admission` state entirely. Observed 2026-04-26
- * meeting_id=36: screenshot showed "Host has joined. We've let them know
- * you're here." while the bot reported admitted=true.
+ * Signal order, strongest first:
+ *   1. Leave button VISIBLE — footer is showing. Never renders in the lobby.
+ *   2. Any in-meeting footer marker PRESENT in the DOM (zoomInMeetingMarkers),
+ *      with no pre-join form. Presence, not visibility: Zoom's footer toolbar
+ *      auto-hides after a few seconds without pointer movement, which makes
+ *      every isVisible() probe lie about a bot that is genuinely in the call.
+ *   3. Lobby text — only consulted once 1 and 2 have found nothing. It then
+ *      vetoes the weak fallback below.
+ *   4. Weak fallback: `.meeting-app` shell, no lobby copy, no pre-join form.
+ *
+ * WHY 2 OUTRANKS 3. zoomWaitingRoomTexts contains substrings as generic as
+ * 'Please wait' and 'waiting room'. Zoom renders those in-meeting too
+ * (connecting-audio toasts, host-control notices) and can leave lobby copy in
+ * the DOM after admission. Previously the text probe ran BEFORE both fallbacks,
+ * so a bot admitted seconds earlier — footer already auto-hidden — returned
+ * "not admitted" and its caller left the meeting. Footer markers never render
+ * in the lobby, so they are safe to rank above a fuzzy text match.
+ *
+ * WHY 3 STILL VETOES 4. Zoom renders the waiting room INSIDE `.meeting-app`,
+ * so the container alone reports admitted while the bot is still in the lobby,
+ * and the dashboard skips `awaiting_admission` entirely. Observed 2026-04-26
+ * meeting_id=36: screenshot showed "Host has joined. We've let them know you're
+ * here." while the bot reported admitted=true. `.meeting-app` therefore stays a
+ * WEAK signal and is deliberately excluded from zoomInMeetingMarkers.
+ *
+ * The pre-join guard is retained throughout: observed 2026-04-26 meeting_id=31,
+ * bot at the "Enter Meeting Info"/passcode screen while an earlier audio-only
+ * fallback reported admitted.
+ *
+ * The former live-<audio>/srcObject fallback is REMOVED: modern Zoom Web routes
+ * audio through the Web Audio API and no longer creates <audio> elements with
+ * srcObject (#318), so that branch could never return true. It read as a third
+ * layer of protection while contributing nothing.
  */
 async function isAdmitted(page: Page): Promise<boolean> {
   try {
@@ -77,40 +90,48 @@ async function isAdmitted(page: Page): Promise<boolean> {
     const leaveBtn = page.locator(zoomLeaveButtonSelector).first();
     if (await leaveBtn.isVisible({ timeout: 500 })) return true;
 
-    // Before the weaker fallbacks, rule out the waiting room. The
-    // waiting-room text is the most reliable disambiguator — it appears
-    // ONLY in the waiting room.
-    const inWaitingRoom = await page.evaluate((texts: string[]) => {
+    // Everything below in ONE page.evaluate, so all signals read a single
+    // consistent DOM snapshot instead of racing Zoom's UI transitions.
+    const state = await page.evaluate((cfg: { inMeeting: string[]; waiting: string[]; meetingApp: string }) => {
+      const present = cfg.inMeeting.filter(s => {
+        try { return !!document.querySelector(s); } catch { return false; }
+      });
       const bodyText = document.body?.innerText || '';
-      return texts.some(t => bodyText.includes(t));
-    }, zoomWaitingRoomTexts).catch(() => false);
-    if (inWaitingRoom) return false;
-
-    // Fallback 1: footer may be auto-hidden — check for the meeting app shell
-    const meetingApp = page.locator(zoomMeetingAppSelector).first();
-    if (await meetingApp.isVisible({ timeout: 500 })) return true;
-
-    // Fallback 2: live <audio> elements AND no pre-join indicators.
-    // Distinguishes "in meeting, audio routing" from "pre-join page with
-    // mic preview audio".
-    const state = await page.evaluate(() => {
-      const liveAudioCount = Array.from(document.querySelectorAll('audio'))
-        .filter((el: any) =>
-          !el.paused &&
-          el.srcObject instanceof MediaStream &&
-          el.srcObject.getAudioTracks().length > 0 &&
-          el.srcObject.getAudioTracks()[0].readyState === 'live')
-        .length;
+      const waitingHit = cfg.waiting.find(t => bodyText.includes(t)) || null;
       const preJoinPresent = !!(
         document.querySelector('#input-for-name') ||
         document.querySelector('button.preview-join-button') ||
         document.querySelector('input[placeholder*="passcode" i], input[placeholder*="password" i]')
       );
-      const bodyText = (document.body?.innerText || '').toLowerCase();
-      const preJoinTextHints = ['enter meeting info', 'meeting passcode'].some(t => bodyText.includes(t));
-      return { liveAudioCount, preJoinPresent, preJoinTextHints };
-    }).catch(() => ({ liveAudioCount: 0, preJoinPresent: true, preJoinTextHints: true }));
-    return state.liveAudioCount > 0 && !state.preJoinPresent && !state.preJoinTextHints;
+      const meetingAppPresent = !!document.querySelector(cfg.meetingApp);
+      return { present, waitingHit, preJoinPresent, meetingAppPresent };
+    }, { inMeeting: zoomInMeetingMarkers, waiting: zoomWaitingRoomTexts, meetingApp: zoomMeetingAppSelector })
+      .catch(() => ({ present: [] as string[], waitingHit: null as string | null, preJoinPresent: true, meetingAppPresent: false }));
+
+    // Hard DOM evidence of the in-meeting footer OUTRANKS the text probe.
+    //
+    // Previously the innerText match returned false BEFORE these markers were
+    // consulted, and zoomWaitingRoomTexts contains substrings as generic as
+    // 'Please wait' and 'waiting room' which Zoom also renders in-meeting
+    // (connecting-audio toasts, host-control notices) and can leave in the DOM
+    // after admission. Combined with the footer toolbar auto-hiding — which
+    // defeats the isVisible() probe above — a bot that had just been admitted
+    // returned "not admitted" and left the call.
+    //
+    // The pre-join form is the one exception: if the name/passcode form is on
+    // screen we are demonstrably not in the meeting, whatever else matched.
+    if (state.present.length > 0 && !state.preJoinPresent) return true;
+
+    // No footer evidence — now the lobby text is meaningful, and must veto the
+    // weak fallback below. Zoom renders the waiting room INSIDE `.meeting-app`,
+    // so without this the container alone would report admitted while still in
+    // the lobby (observed 2026-04-26 meeting_id=36).
+    if (state.waitingHit) return false;
+
+    // Weak fallback: meeting shell, no lobby copy, no pre-join form.
+    if (state.meetingAppPresent && !state.preJoinPresent) return true;
+
+    return false;
   } catch {
     return false;
   }
@@ -249,12 +270,17 @@ export async function waitForZoomMeetingAdmission(
 
 export async function checkForZoomAdmissionSilent(page: Page): Promise<boolean> {
   if (!page) return false;
-  // Retry up to 3 times with 1s delay — Zoom UI may briefly hide elements
-  // during popup dismissals, tooltips, or layout transitions after admission.
-  for (let attempt = 0; attempt < 3; attempt++) {
+  // Retry with a wider window — the lobby -> in-call DOM swap can take longer
+  // than the old 2s budget allowed. This check only ever gates a decision to
+  // LEAVE a meeting we believe we are in, so being slow to conclude "not
+  // admitted" is far cheaper than being wrong: a real ejection persists and is
+  // caught on a later attempt, while a premature false reads to the user as the
+  // bot abandoning a live call seconds after being let in.
+  const ATTEMPTS = 6;
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
     if (await isAdmitted(page)) return true;
-    if (attempt < 2) {
-      await page.waitForTimeout(1000);
+    if (attempt < ATTEMPTS - 1) {
+      await page.waitForTimeout(1500);
     }
   }
   return false;

--- a/core/meetings/modules/join/src/zoom/selectors.ts
+++ b/core/meetings/modules/join/src/zoom/selectors.ts
@@ -36,6 +36,30 @@ export const zoomLeaveButtonSelector = 'button[aria-label="Leave"]';
 // The meeting app container
 export const zoomMeetingAppSelector = '.meeting-app';
 
+// In-meeting footer markers, matched on DOM PRESENCE rather than visibility.
+//
+// Zoom's footer toolbar auto-hides after a few seconds without pointer movement,
+// so isVisible() on any footer control returns false for a bot that is very much
+// inside the meeting. Presence survives the auto-hide; visibility does not.
+//
+// These are admission concerns, not recording concerns: they answer "am I in the
+// meeting", which is exactly what isAdmitted() needs and what the auto-hide breaks.
+//
+// Deliberately broad and redundant — Zoom ships unannounced DOM changes and A/B
+// tests them, so no single selector can be trusted. Any one match is sufficient.
+// None of these render in the waiting room or on the pre-join page.
+export const zoomInMeetingMarkers = [
+  'button[aria-label="Leave"]',
+  'button[aria-label*="Leave"]',
+  '.footer__leave-btn',
+  'button.join-audio-container__btn',
+  'button.send-video-container__btn',
+  'button[aria-label*="participants list"]',
+  'button[aria-label*="chat panel"]',
+  '#wc-footer',
+  '.footer-button-base__button',
+];
+
 // ---- Host-not-started / invalid meeting ----
 // When host hasn't started: title="Error - Zoom", text="This meeting link is invalid (3,001)"
 export const zoomInvalidMeetingText = 'This meeting link is invalid';


### PR DESCRIPTION
# fix(zoom): rank in-meeting DOM evidence above the lobby-text probe in `isAdmitted()`

Fixes #966.

An admitted Zoom Web bot could conclude it was **not** in the meeting and leave ~3 seconds after the host clicked Admit — `admission_false_positive`, zero segments, no recording. This is the Zoom instance of the family already fixed for Google Meet (#377, #166) and Teams (#171, #600).

## What was wrong

`isAdmitted()` ran the `zoomWaitingRoomTexts` innerText probe **before** both DOM fallbacks. That list contains bare `'Please wait'` and `'waiting room'`, which Zoom also renders in-meeting (connecting-audio toasts, host-control notices) and can leave in the DOM after admission.

Meanwhile the two footer signals that should have overruled it were matched with `isVisible()` — and Zoom's footer toolbar **auto-hides** a few seconds after admission. So the only checks that could prove "we are in the meeting" were the ones auto-hide breaks, and a fuzzy text match got the last word.

Separately, the fourth fallback (live `<audio>` with `srcObject instanceof MediaStream`) is dead on modern Zoom Web, which uses the Web Audio API — this repo's **#318**. It made admission detection look four-deep when it was effectively two-deep.

## What this changes

- **`selectors.ts`** — adds `zoomInMeetingMarkers`: footer controls matched on **presence**, not visibility. Deliberately broad and redundant, since Zoom ships unannounced DOM changes and A/B tests them; any one match is sufficient. `.meeting-app` is **deliberately excluded** — Zoom renders the waiting room inside it.
- **`admission.ts`** — single `page.evaluate` snapshot, then: footer markers (presence, and no pre-join form) → admitted; else lobby text → not admitted; else `.meeting-app` without lobby copy or pre-join form → admitted. Removes the dead `<audio>`/`srcObject` branch.
- **`admission.ts`** — widens `checkForZoomAdmissionSilent` from 3 attempts/2s to 6/~7.5s. This check only ever gates a decision to **leave** a meeting we believe we are in, so being slow to conclude "not admitted" is much cheaper than being wrong: a real ejection persists and is caught on a later attempt, whereas a premature `false` reads to the user as the bot abandoning a live call.
- **`admission.test.ts`** — extends `makePage()` with a declared set of present selectors, and adds three cases against the shipped `checkForZoomAdmissionSilent`.

## Invariants deliberately preserved

Two earlier bugs are the reason the original ordering existed. Both are covered by new tests so this fix cannot silently undo them:

- **meeting_id=36** — Zoom renders the waiting room inside `.meeting-app`, so the container alone must not report admitted. Lobby text still vetoes that weak fallback.
- **meeting_id=31** — bot at the "Enter Meeting Info"/passcode screen. The pre-join form outranks everything, including footer markers.

## Test evidence

`npx tsx src/zoom/admission.test.ts`

Against current `main`, the new case fails and the guards hold:

```
PASS  timeout → AdmissionError('lobby_timeout')
PASS  anti-bot wall → AdmissionError('denial')
PASS  host rejection → AdmissionError('denial')
FAIL  footer marker present outranks a generic lobby substring — got false
PASS  lobby copy + .meeting-app but no footer → NOT admitted (no regression of #36)
PASS  pre-join form vetoes footer markers → NOT admitted (no regression of #31)
5 passed, 1 failed
```

After this change:

```
6 passed, 0 failed
```

The failing case reproduces the reported incident exactly: every locator invisible (auto-hidden toolbar), a footer control present in the DOM, and `'Please wait'` on screen from an in-meeting toast.

## Note on the harness

`makePage()` already returned `isVisible: () => false` for every locator — it *is* the auto-hidden-toolbar state — but its fake `document` exposed only `body.innerText`. With no `querySelector`, it could not distinguish "footer absent" from "footer present but hidden", which is the whole bug. Adding a declared present-selector set is a small step toward what **#857** asks for.

## Verification status

The fix has been running in production on a self-hosted deployment since 2026-07-24, where the identical defect exists in the pre-0.12 layout (`services/vexa-bot/core/src/platforms/zoom/web/admission.ts`). The bot now logs `✅ Bot verified to be in meeting after ACTIVE callback` at the point it previously left, and completed a subsequent 48-minute Zoom meeting with 115 transcript segments across two speakers.

I have **not** been able to run this against a live Zoom meeting on the 0.12 tree itself — the port is a faithful translation of a fix verified on 0.10.6.3.14, plus the unit tests above. Worth a maintainer smoke-test on a real waiting-room meeting before release.
