### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Vexa
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2FVexa-ai%2Fvexa.svg)](https://mcptoplist.com/server/glama%2FVexa-ai%2Fvexa)
+
 **Open-source, self-hosted meeting bot & transcription API.**
 
 A bot joins your Google Meet, Microsoft Teams, Zoom, and Jitsi calls and streams speaker-attributed


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **Vexa** is currently ranked **#59**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2FVexa-ai%2Fvexa.svg)](https://mcptoplist.com/server/glama%2FVexa-ai%2Fvexa)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Vexa!
