### PR TITLE
feat(meetings): freeze service provenance for trustworthy billing

### DIFF
--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -592,7 +592,7 @@
    "unique-id": "lifecycle.v1",
    "node-type": "contract",
    "name": "lifecycle.v1",
-   "description": "lifecycle.v1 — sealed/published contract (meetings)",
+   "description": "lifecycle.v1 — sealed/published bot status with producer-observed transition time (meetings)",
    "metadata": [
     {
      "path": "core/meetings/contracts/lifecycle.v1",
@@ -616,7 +616,7 @@
    "unique-id": "webhook.v1",
    "node-type": "contract",
    "name": "webhook.v1",
-   "description": "webhook.v1 — sealed/published contract (meetings)",
+   "description": "webhook.v1 — sealed/published delivery including privacy-safe terminal service provenance (meetings)",
    "metadata": [
     {
      "path": "core/meetings/contracts/webhook.v1",

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "79bdb30d31ae5d36ee6078340d4ec8eabe2c767497d6c19e015437ecf0b1db4d"
+  "architecture.calm.json": "237d0bbe42665e9e14b44ee3ecfb1d4a2f117e14535f91c3f7a2700017b8d6a9"
 }

--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -690,12 +690,30 @@ def create_app() -> FastAPI:
         # The effective transcription backend (user pref > platform setting) — bot_spawn overrides
         # its env-derived TRANSCRIPTION_SERVICE_URL/TOKEN with this when present. The token crosses
         # ONLY this internal hop.
-        transcription = _resolve_effective(
-            data.get("transcription_prefs") or {},
-            await _platform_setting("transcription", db),
-            _TRANSCRIPTION_FIELDS,
-        )
+        user_transcription = data.get("transcription_prefs") or {}
+        platform_transcription = await _platform_setting("transcription", db)
+        if user_transcription.get("url"):
+            # Selecting a customer endpoint changes the credential owner too. Never fill a
+            # missing customer token/model from the platform record: that would disclose a Vexa
+            # provider credential to an arbitrary customer-controlled host.
+            transcription = {
+                key: user_transcription[key]
+                for key in _TRANSCRIPTION_FIELDS
+                if user_transcription.get(key) not in (None, "")
+            }
+        else:
+            transcription = _resolve_effective(
+                user_transcription,
+                platform_transcription,
+                _TRANSCRIPTION_FIELDS,
+            )
         if transcription:
+            # Ownership follows the URL that will actually serve this spawn. This non-secret
+            # discriminator crosses only the internal bot-context edge; the URL/token remain
+            # internal and never enter the public completion provenance.
+            transcription["provider"] = (
+                "customer" if user_transcription.get("url") else "vexa"
+            )
             resp["transcription"] = transcription
         return resp
 

--- a/core/identity/services/admin-api/tests/test_model_settings.py
+++ b/core/identity/services/admin-api/tests/test_model_settings.py
@@ -130,13 +130,20 @@ def test_bot_context_carries_effective_transcription(client):
     client.put("/internal/settings/transcription", headers=_internal(),
                json={"url": "https://stt-global.example.com", "token": "tok-global"})
     r = client.get(f"/internal/users/{uid}/bot-context", headers=_internal())
-    assert r.json()["transcription"] == {"url": "https://stt-global.example.com", "token": "tok-global"}
+    assert r.json()["transcription"] == {
+        "url": "https://stt-global.example.com",
+        "token": "tok-global",
+        "provider": "vexa",
+    }
 
     client.put("/user/transcription", headers={"X-API-Key": tok},
                json={"url": "https://stt-mine.example.com"})
     r = client.get(f"/internal/users/{uid}/bot-context", headers=_internal())
-    # user url wins; global token still fills the gap (field-by-field)
-    assert r.json()["transcription"] == {"url": "https://stt-mine.example.com", "token": "tok-global"}
+    # A customer URL never inherits the platform credential.
+    assert r.json()["transcription"] == {
+        "url": "https://stt-mine.example.com",
+        "provider": "customer",
+    }
 
     # masked user-facing read-back
     cfg = client.get("/user/transcription", headers={"X-API-Key": tok}).json()

--- a/core/meetings/contracts/lifecycle.v1/README.md
+++ b/core/meetings/contracts/lifecycle.v1/README.md
@@ -21,7 +21,17 @@ join). The machine-checked
 impl enforces it (lean: no separate harness, B8).
 
 ## Shape
-`LifecycleEvent` (`$defs`): `connection_id` + `status` always; state-dependent `reason · exit_code ·
-completion_reason · failure_stage · bot_logs · bot_resources · speaker_events` (terminal forensics).
+`LifecycleEvent` (`$defs`): `connection_id` + `status` always; the shipping producer also stamps
+`timestamp`, the UTC time it observed the transition, before transport retries. That producer time
+is the lifecycle fact used for admitted-to-departed runtime; callback receipt time is never a
+service-duration clock. State-dependent fields are `reason · exit_code · completion_reason ·
+failure_stage · bot_logs · bot_resources · speaker_events` (terminal forensics).
+
+At the terminal boundary, meeting-api freezes a privacy-safe `service_provenance` projection:
+admission/departure times, bot outcome, transcription provider (`vexa · customer · none`),
+transcription outcome, and contract version. Provider ownership is selected when the bot is
+created; it is never reconstructed later from a URL or current user setting. Endpoint URLs,
+credentials, and tokens never enter the projection. A legacy meeting without frozen provider
+ownership remains unresolved for downstream billing.
 
 No auth token (transport-layer), no tenancy fields (deferred). Goldens validated by `gate:schema`.

--- a/core/meetings/contracts/lifecycle.v1/README.md
+++ b/core/meetings/contracts/lifecycle.v1/README.md
@@ -32,6 +32,8 @@ admission/departure times, bot outcome, transcription provider (`vexa · custome
 transcription outcome, and contract version. Provider ownership is selected when the bot is
 created; it is never reconstructed later from a URL or current user setting. Endpoint URLs,
 credentials, and tokens never enter the projection. A legacy meeting without frozen provider
-ownership remains unresolved for downstream billing.
+ownership remains unresolved for downstream billing. An admitted mixed-version session whose
+lifecycle event lacks a producer timestamp is likewise unresolved: receiver time remains useful
+for operations, but retry latency makes it invalid for rating.
 
 No auth token (transport-layer), no tenancy fields (deferred). Goldens validated by `gate:schema`.

--- a/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.active.json
+++ b/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.active.json
@@ -1,4 +1,5 @@
 {
   "connection_id": "sess-uid",
-  "status": "active"
+  "status": "active",
+  "timestamp": "2026-07-28T10:05:00.000Z"
 }

--- a/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.completed-stopped.json
+++ b/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.completed-stopped.json
@@ -1,6 +1,7 @@
 {
   "connection_id": "sess-uid",
   "status": "completed",
+  "timestamp": "2026-07-28T10:30:00.000Z",
   "exit_code": 0,
   "completion_reason": "stopped",
   "bot_logs": ["[JOIN-STATE] admitted", "[ACT] leave received"]

--- a/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.failed-join.json
+++ b/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.failed-join.json
@@ -1,6 +1,7 @@
 {
   "connection_id": "sess-uid",
   "status": "failed",
+  "timestamp": "2026-07-28T10:10:00.000Z",
   "exit_code": 1,
   "failure_stage": "awaiting_admission",
   "completion_reason": "awaiting_admission_rejected",

--- a/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.joining.json
+++ b/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.joining.json
@@ -1,5 +1,6 @@
 {
   "connection_id": "sess-uid",
   "container_id": "mtg-abc123-bot",
-  "status": "joining"
+  "status": "joining",
+  "timestamp": "2026-07-28T10:00:00.000Z"
 }

--- a/core/meetings/contracts/webhook.v1/README.md
+++ b/core/meetings/contracts/webhook.v1/README.md
@@ -25,6 +25,10 @@ this shape.
   (`event_type` is part of the identity).
 - **Retention.** Retain seen `event_id`s ≥ 48h (the retry schedule tops out at 24h, `retry.py`, plus
   slack) to dedupe a late redelivery.
+- **Completion carries frozen service facts.** `meeting.completed.data.meeting.service_provenance`
+  states admitted/departed time, bot outcome, transcription provider/outcome, and lifecycle
+  contract version. It contains no endpoint URL, token, credential, meeting title, or transcript.
+  Absence means provenance is unresolved; consumers must not infer it from legacy intent flags.
 
 ## Shapes (`$defs`)
 - **`Envelope`** — `event_id · event_type · api_version · created_at · data`. The body POSTed is

--- a/core/meetings/contracts/webhook.v1/golden/Envelope.meeting-completed.json
+++ b/core/meetings/contracts/webhook.v1/golden/Envelope.meeting-completed.json
@@ -13,6 +13,14 @@
       "status": "completed",
       "completion_reason": "stopped",
       "failure_stage": null,
+      "service_provenance": {
+        "bot_admitted_at": "2026-06-18T10:00:00.000Z",
+        "bot_departed_at": "2026-06-18T10:42:00.000Z",
+        "bot_outcome": "served",
+        "transcription_provider": "customer",
+        "transcription_outcome": "served",
+        "lifecycle_contract_version": "2026-07-28"
+      },
       "start_time": "2026-06-18T10:00:00.000Z",
       "end_time": "2026-06-18T10:42:00.000Z",
       "data": { "name": "Weekly sync" },

--- a/core/meetings/services/bot/src/contracts.ts
+++ b/core/meetings/services/bot/src/contracts.ts
@@ -40,6 +40,9 @@ export interface LifecycleEvent {
   connection_id: string;
   container_id?: string;
   status: BotStatus;
+  /** Time the producer observed this lifecycle transition. Callback receipt time is not an
+   *  admission/departure clock: delivery may be delayed or retried. */
+  timestamp?: string;
   reason?: string;
   exit_code?: number;
   completion_reason?: CompletionReason;

--- a/core/meetings/services/bot/src/orchestrator.test.ts
+++ b/core/meetings/services/bot/src/orchestrator.test.ts
@@ -97,6 +97,35 @@ async function main(): Promise<void> {
     check('happy: pipeline started then stopped', pipe.started === false);
   }
 
+  // ── producer-owned event time: admission/runtime billing survives callback delay ──
+  {
+    const lc = recordingSink();
+    const timestamps = [
+      '2026-07-28T10:00:00.000Z',
+      '2026-07-28T10:00:05.000Z',
+      '2026-07-28T10:00:10.000Z',
+      '2026-07-28T10:25:10.000Z',
+    ];
+    let index = 0;
+    let fireLeave: (a: { action: 'leave' }) => void = () => {};
+    const o = createOrchestrator(inv(), {
+      lifecycle: lc,
+      join: mockJoin('admitted'),
+      pipeline: noopPipeline(),
+      acts: noopActs((f) => { fireLeave = f; }),
+      aloneness: noopAloneness(),
+      now: () => timestamps[index++],
+    });
+    const runP = o.run();
+    setTimeout(() => fireLeave({ action: 'leave' }), 5);
+    await runP;
+    check(
+      'event-time: every lifecycle transition carries its producer timestamp exactly once',
+      JSON.stringify(lc.events.map((event) => event.timestamp)) === JSON.stringify(timestamps),
+      JSON.stringify(lc.events),
+    );
+  }
+
   // ── leave via the orchestrator.handle entrypoint (the acts adapter / test surface) ──
   {
     const lc = recordingSink();

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -57,6 +57,9 @@ export interface OrchestratorDeps {
    *  additionalProperties:true, so this is additive.
    *  Returns `undefined` when nothing degraded. MUST NOT throw. */
   degraded?: () => Record<string, unknown> | undefined;
+  /** Producer clock for lifecycle facts. Injected by tests; each logical event is stamped once
+   *  before the lifecycle adapter performs any HTTP retry. */
+  now?: () => string;
 }
 
 /** The dedicated non-zero exit code for a pre-join control-plane-unreachable abort (#530). On
@@ -123,6 +126,7 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
   const recordingKey = `${inv.platform}/${inv.nativeMeetingId ?? inv.connectionId ?? 'session'}`;
 
   let cur: BotStatus = 'joining';
+  const eventTime = (): string => deps.now?.() ?? new Date().toISOString();
 
   const emit = async (status: BotStatus, extra: Partial<LifecycleEvent> = {}): Promise<void> => {
     if (status !== cur && !canTransition(cur, status)) {
@@ -136,14 +140,25 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
     if (isTerminal(status) && deps.degraded) {
       try { degraded = deps.degraded(); } catch { degraded = undefined; }
     }
-    await deps.lifecycle.emit({ ...base, status, ...extra, ...(degraded ?? {}) });
+    await deps.lifecycle.emit({
+      ...base,
+      status,
+      timestamp: extra.timestamp ?? eventTime(),
+      ...extra,
+      ...(degraded ?? {}),
+    });
   };
 
   // The load-bearing FIRST emit (#530). `cur` is already `joining` (the initial state), so this
   // needs no transition guard. When the sink can report reachability we consult it; otherwise the
   // event is emitted normally and treated as reachable (self-host / test sinks have no gate).
   const emitJoining = async (extra: Partial<LifecycleEvent>): Promise<boolean> => {
-    const ev: LifecycleEvent = { ...base, status: 'joining', ...extra };
+    const ev: LifecycleEvent = {
+      ...base,
+      status: 'joining',
+      timestamp: extra.timestamp ?? eventTime(),
+      ...extra,
+    };
     if (deps.lifecycle.emitReachable) return (await deps.lifecycle.emitReachable(ev)) === 'reachable';
     await deps.lifecycle.emit(ev);
     return true;
@@ -195,6 +210,7 @@ export function createOrchestrator(inv: Invocation, deps: OrchestratorDeps) {
         await deps.lifecycle.emit({
           ...base,
           status: 'failed',
+          timestamp: eventTime(),
           failure_stage: 'requested',
           completion_reason: 'join_failure',
           infra_fault: CONTROL_PLANE_UNREACHABLE,

--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -138,8 +138,8 @@ def build_production_app():
     # the next db-writer tick happens to run`).
     from .collector.db_writer import finalize_meeting
 
-    async def _transcript_finalizer(meeting_id: int) -> None:
-        await finalize_meeting(redis_client, transcript_store, meeting_id)
+    async def _transcript_finalizer(meeting_id: int) -> int:
+        return await finalize_meeting(redis_client, transcript_store, meeting_id)
 
     # Calendar-sync user edges (GET/POST /user/calendar/sync): the SAME one-user pass the
     # background sweep runs, on demand — paste-a-feed gets an immediate result instead of a

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -338,6 +338,7 @@ def _mount_lifecycle(
     import jsonschema
 
     from .lifecycle.machine import IllegalTransition, TransitionSource
+    from .lifecycle.provenance import build_service_provenance
     from .lifecycle.receiver import conforms
     from .lifecycle.webhook import build_status_change_envelope, build_typed_envelope
     from .obs import log_event
@@ -360,6 +361,7 @@ def _mount_lifecycle(
             "status": row.get("status"),
             "completion_reason": data.get("completion_reason"),
             "failure_stage": data.get("failure_stage"),
+            "service_provenance": data.get("service_provenance"),
             "start_time": _iso(row.get("start_time")),
             "end_time": _iso(row.get("end_time")),
             "data": clean_meeting_data(data),
@@ -412,13 +414,19 @@ def _mount_lifecycle(
             existing = sink.store.get(connection_id)
             if existing is None or existing.status is None:
                 try:
-                    persisted = await meeting_repo.get_status_by_session(session_uid=connection_id)
+                    persisted = await meeting_repo.get_lifecycle_state_by_session(
+                        session_uid=connection_id
+                    )
                 except Exception as e:  # noqa: BLE001 — rehydration is best-effort
                     persisted = None
                     log_event("lifecycle_rehydrate_failed", audience="system", level="warning",
                               span="lifecycle.callback", fields={"error": str(e)})
                 if persisted:
-                    sink.store.rehydrate(connection_id, persisted)
+                    sink.store.rehydrate(
+                        connection_id,
+                        persisted.get("status"),
+                        persisted.get("data"),
+                    )
         try:
             change = sink.apply_change(
                 body,
@@ -471,20 +479,85 @@ def _mount_lifecycle(
         # This guarantees a completed meeting's transcript is durable even if the periodic
         # db-writer never gets another tick (crash/restart right after completion). Best-effort:
         # the periodic loop retries anything this misses; never fail the bot's callback.
-        if (
-            transcript_finalizer is not None
-            and not change.no_op
+        terminal_advanced = (
+            not change.no_op
             and rec.status is not None
             and rec.status.value in ("completed", "failed")
             and isinstance(meeting_row, dict)
             and meeting_row.get("id") is not None
+        )
+        if (
+            transcript_finalizer is not None
+            and terminal_advanced
         ):
+            terminal_meeting_id = meeting_row["id"]
             try:
-                await transcript_finalizer(meeting_row["id"])
+                finalized_segments = await transcript_finalizer(terminal_meeting_id)
+                if isinstance(finalized_segments, int) and finalized_segments >= 0:
+                    rec_data = rec.data
+                    rec_data["segments_captured"] = finalized_segments
+                    updated_row = await meeting_repo.update_meeting_status(
+                        session_uid=rec.connection_id,
+                        status=rec.status.value,
+                        completion_reason=(
+                            rec.completion_reason.value if rec.completion_reason else None
+                        ),
+                        failure_stage=rec.failure_stage.value if rec.failure_stage else None,
+                        data=rec_data,
+                    )
+                    if isinstance(updated_row, dict):
+                        meeting_row = updated_row
             except Exception as e:  # noqa: BLE001 — the db-writer loop is the retry path
+                rec_data = rec.data
+                rec_data["transcript_finalize_failed"] = True
+                try:
+                    updated_row = await meeting_repo.update_meeting_status(
+                        session_uid=rec.connection_id,
+                        status=rec.status.value,
+                        completion_reason=(
+                            rec.completion_reason.value if rec.completion_reason else None
+                        ),
+                        failure_stage=rec.failure_stage.value if rec.failure_stage else None,
+                        data=rec_data,
+                    )
+                    if isinstance(updated_row, dict):
+                        meeting_row = updated_row
+                except Exception:  # noqa: BLE001 — original finalization failure is the signal
+                    pass
                 log_event("transcript_finalize_failed", audience="system", level="warning",
                           span="lifecycle.callback",
-                          fields={"meeting_id": meeting_row.get("id"), "error": str(e)})
+                          fields={"meeting_id": terminal_meeting_id, "error": str(e)})
+        if terminal_advanced and isinstance(meeting_row, dict):
+            data = dict(meeting_row.get("data") or {})
+            provenance = build_service_provenance({**meeting_row, "data": data})
+            if provenance is not None:
+                data["service_provenance"] = provenance
+                # The event projection can truthfully carry the producer facts even if this
+                # best-effort persistence attempt fails, matching the callback's established
+                # availability contract. The next reconciliation pass owns that exception.
+                projection_row = {**meeting_row, "data": data}
+                try:
+                    updated_row = await meeting_repo.update_meeting_status(
+                        session_uid=rec.connection_id,
+                        status=rec.status.value,
+                        completion_reason=(
+                            rec.completion_reason.value if rec.completion_reason else None
+                        ),
+                        failure_stage=rec.failure_stage.value if rec.failure_stage else None,
+                        data=data,
+                    )
+                    meeting_row = (
+                        updated_row if isinstance(updated_row, dict) else projection_row
+                    )
+                except Exception as e:  # noqa: BLE001 — callback availability is pre-existing
+                    meeting_row = projection_row
+                    log_event(
+                        "service_provenance_persist_failed",
+                        audience="system",
+                        level="warning",
+                        span="lifecycle.callback",
+                        fields={"meeting_id": meeting_row.get("id"), "error": str(e)},
+                    )
         # Build the TYPED event the transition maps to (meeting.started on active,
         # meeting.completed with the post-meeting envelope on completion, bot.failed on terminal
         # failure) — additive alongside meeting.status_change, never instead of it. Built AFTER the

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -130,7 +130,7 @@ class SqlAlchemyMeetingRepo:
             m = (await db.execute(stmt)).scalars().first()
             return _row_to_dict(m) if m else None
 
-    async def reopen_meeting(self, *, meeting_id) -> dict:
+    async def reopen_meeting(self, *, meeting_id, data_patch=None) -> dict:
         from sqlalchemy import select
         from sqlalchemy.orm.attributes import flag_modified
 
@@ -146,6 +146,11 @@ class SqlAlchemyMeetingRepo:
             data = dict(m.data) if isinstance(m.data, dict) else {}
             for k in ("completion_reason", "failure_stage"):
                 data.pop(k, None)
+            for key, value in (data_patch or {}).items():
+                if value is None:
+                    data.pop(key, None)
+                else:
+                    data[key] = value
             m.data = data
             flag_modified(m, "data")
             # updated_at is set server-side by the column's onupdate=func.now() (main's pattern);
@@ -169,6 +174,26 @@ class SqlAlchemyMeetingRepo:
                 await db.execute(select(Meeting.status).where(Meeting.id == sess.meeting_id))
             ).scalars().first()
             return status
+
+    async def get_lifecycle_state_by_session(self, *, session_uid) -> Optional[dict]:
+        from sqlalchemy import select
+
+        from ..sessions.models import Meeting, MeetingSession
+
+        async with self._session_factory() as db:
+            row = (
+                await db.execute(
+                    select(Meeting.status, Meeting.data)
+                    .join(MeetingSession, MeetingSession.meeting_id == Meeting.id)
+                    .where(MeetingSession.session_uid == session_uid)
+                )
+            ).first()
+            if row is None:
+                return None
+            return {
+                "status": row.status,
+                "data": dict(row.data) if isinstance(row.data, dict) else {},
+            }
 
     async def find_by_container(self, *, bot_container_id) -> Optional[dict]:
         """The meeting + latest session for a workload id — used by the runtime callback (CC5) to drive a

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -180,7 +180,7 @@ class InMemoryMeetingRepo:
             else:
                 m["data"][k] = v
 
-    async def reopen_meeting(self, *, meeting_id) -> dict:
+    async def reopen_meeting(self, *, meeting_id, data_patch=None) -> dict:
         row = self._meetings[meeting_id]
         row["status"] = "requested"
         row["end_time"] = None
@@ -188,6 +188,11 @@ class InMemoryMeetingRepo:
         # Clear the prior terminal attribution but KEEP the row + its transcripts/recordings.
         for k in ("completion_reason", "failure_stage"):
             row["data"].pop(k, None)
+        for key, value in (data_patch or {}).items():
+            if value is None:
+                row["data"].pop(key, None)
+            else:
+                row["data"][key] = value
         self.reopened.append(meeting_id)
         return dict(row)
 
@@ -218,6 +223,18 @@ class InMemoryMeetingRepo:
             return None
         row = self._meetings.get(sess["meeting_id"])
         return row["status"] if row else None
+
+    async def get_lifecycle_state_by_session(self, *, session_uid) -> Optional[dict]:
+        sess = next((s for s in self.sessions if s["session_uid"] == session_uid), None)
+        if sess is None:
+            return None
+        row = self._meetings.get(sess["meeting_id"])
+        if row is None:
+            return None
+        return {
+            "status": row["status"],
+            "data": dict(row.get("data") or {}),
+        }
 
     async def find_by_container(self, *, bot_container_id) -> Optional[dict]:
         row = next(

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
@@ -87,10 +87,12 @@ class MeetingRepo(Protocol):
         ``create_meeting`` pre-check sequence on the fresh-insert path."""
         ...
 
-    async def reopen_meeting(self, *, meeting_id: int) -> dict:
+    async def reopen_meeting(
+        self, *, meeting_id: int, data_patch: Optional[dict] = None
+    ) -> dict:
         """Reset a TERMINAL meeting row back to ``requested`` for a continued run (``continue_meeting``):
         clear the prior terminal attribution, keep the row id (so transcripts/recordings keyed by it
-        survive). Returns the updated row."""
+        survive), and freeze the new session's service-selection facts. Returns the updated row."""
         ...
 
     async def create_session(self, *, meeting_id: int, session_uid: str) -> None:
@@ -133,6 +135,15 @@ class MeetingRepo(Protocol):
         FSM after a meeting-api restart (LIFECYCLE-409): the in-memory store is non-durable, so the
         callback reconciles a fresh/empty record against the DB's real status BEFORE applying the
         bot's event (else a terminal event on an empty store creates a status=None record and 409s)."""
+        ...
+
+    async def get_lifecycle_state_by_session(self, *, session_uid: str) -> Optional[dict]:
+        """Return the persisted lifecycle state needed to restore the FSM after restart.
+
+        Shape: ``{"status": str, "data": dict}``. The transition trail is part of the durable
+        lifecycle fact: restoring only the current status would erase the producer-observed
+        admission time when the terminal callback arrives after a process restart.
+        """
         ...
 
     async def update_meeting_status(

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -194,6 +194,7 @@ async def request_bot(
     transcription_service_token = os.getenv("TRANSCRIPTION_SERVICE_TOKEN") or None
     transcription_model = os.getenv("TRANSCRIPTION_MODEL") or None
     configured = await _resolve_transcription_backend(user_id)
+    transcription_provider: Optional[str] = "none" if not transcribe_enabled else None
     if configured.get("url"):
         transcription_service_url = configured["url"]
         # A configured backend's token replaces the env token even when empty — the env token
@@ -202,6 +203,14 @@ async def request_bot(
         # backend carries its own (unset → the client's whisper-1 default).
         transcription_service_token = configured.get("token") or None
         transcription_model = configured.get("model") or None
+        configured_provider = configured.get("provider")
+        if configured_provider in ("vexa", "customer"):
+            transcription_provider = configured_provider
+    elif transcribe_enabled and transcription_service_url:
+        # The process-level backend is operated by this Vexa deployment. A Settings response,
+        # however, is not inferred from its URL: mixed-version identity may return a customer URL
+        # without provenance, and guessing there could turn an unknown service into a Vexa charge.
+        transcription_provider = "vexa"
     if transcribe_enabled and not transcription_service_url:
         raise TranscriptionNotConfigured(
             "no transcription backend configured — set it in Settings or environment variables "
@@ -312,13 +321,22 @@ async def request_bot(
                     fields={"active": active, "cap": max_concurrent},
                 )
                 raise MaxBotsExceeded(user_id, max_concurrent)
-        row = await repo.reopen_meeting(meeting_id=reused_row["id"])
+        row = await repo.reopen_meeting(
+            meeting_id=reused_row["id"],
+            data_patch={
+                "transcribe_enabled": transcribe_enabled,
+                "recording_enabled": recording_enabled,
+                "transcription_provider": transcription_provider,
+            },
+        )
     else:
         meeting_data: dict[str, Any] = {}
         if constructed_url:
             meeting_data["constructed_meeting_url"] = constructed_url
         meeting_data["transcribe_enabled"] = transcribe_enabled
         meeting_data["recording_enabled"] = recording_enabled
+        if transcription_provider is not None:
+            meeting_data["transcription_provider"] = transcription_provider
         # The serialization key for authenticated spawns — find_active_by_userdata matches on it.
         if authenticated and auth_userdata_path:
             meeting_data["auth_userdata_path"] = auth_userdata_path

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -204,7 +204,7 @@ async def request_bot(
         transcription_service_token = configured.get("token") or None
         transcription_model = configured.get("model") or None
         configured_provider = configured.get("provider")
-        if configured_provider in ("vexa", "customer"):
+        if transcribe_enabled and configured_provider in ("vexa", "customer"):
             transcription_provider = configured_provider
     elif transcribe_enabled and transcription_service_url:
         # The process-level backend is operated by this Vexa deployment. A Settings response,

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
@@ -273,7 +273,12 @@ class MeetingStore:
             self._records[connection_id] = rec
         return rec
 
-    def rehydrate(self, connection_id: str, persisted_status: Optional[str]) -> MeetingRecord:
+    def rehydrate(
+        self,
+        connection_id: str,
+        persisted_status: Optional[str],
+        persisted_data: Optional[Dict[str, Any]] = None,
+    ) -> MeetingRecord:
         """Seed (or reconcile) the in-memory record from the DB's CURRENT meeting status.
 
         The store is in-memory, so a fresh process starts empty; seeding the record's status from the
@@ -290,6 +295,12 @@ class MeetingStore:
             seeded = bot_status_from_persisted(persisted_status)
             if seeded is not None:
                 rec.status = seeded
+            if isinstance(persisted_data, dict):
+                trail = persisted_data.get("status_transition")
+                if isinstance(trail, list):
+                    rec.status_transition = [
+                        dict(entry) for entry in trail if isinstance(entry, dict)
+                    ]
         return rec
 
     def __len__(self) -> int:  # pragma: no cover - trivial
@@ -455,7 +466,11 @@ class LifecycleSink:
         entry: Dict[str, Any] = {
             "from": frm.value if frm is not None else None,
             "to": to.value,
-            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            # The producer observed admission/departure. Callback receipt time may be delayed by
+            # retries, so it cannot be the billing clock. Legacy events without event time retain
+            # the server fallback but will not satisfy the provenance contract used for billing.
+            "timestamp": event.get("timestamp")
+            or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "source": transition_source.value,
         }
         if rec.reason is not None and to in _TERMINAL:

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
@@ -463,14 +463,16 @@ class LifecycleSink:
         rec.last_transition_source = transition_source
 
         # Append the status_transition[] trail entry (parent's update_meeting_status entry).
+        producer_timestamp = event.get("timestamp")
         entry: Dict[str, Any] = {
             "from": frm.value if frm is not None else None,
             "to": to.value,
             # The producer observed admission/departure. Callback receipt time may be delayed by
             # retries, so it cannot be the billing clock. Legacy events without event time retain
             # the server fallback but will not satisfy the provenance contract used for billing.
-            "timestamp": event.get("timestamp")
+            "timestamp": producer_timestamp
             or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "timestamp_source": "producer" if producer_timestamp else "receiver",
             "source": transition_source.value,
         }
         if rec.reason is not None and to in _TERMINAL:

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/provenance.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/provenance.py
@@ -1,0 +1,66 @@
+"""Privacy-safe service facts derived at the meeting lifecycle boundary."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+LIFECYCLE_CONTRACT_VERSION = "2026-07-28"
+_PROVIDERS = frozenset({"vexa", "customer", "none"})
+
+
+def _transition_time(transitions: list[dict], status: str) -> Optional[str]:
+    for transition in reversed(transitions):
+        if transition.get("to") == status and isinstance(transition.get("timestamp"), str):
+            return transition["timestamp"]
+    return None
+
+
+def build_service_provenance(meeting: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return facts sufficient to rate delivered service, or ``None`` for legacy custody.
+
+    Provider ownership is frozen at spawn. It is deliberately never reconstructed from a URL,
+    token, current user setting, or the old ``transcribe_enabled`` intent flag. A meeting without
+    that frozen discriminator predates this contract and remains unresolved downstream.
+    """
+    data = meeting.get("data") if isinstance(meeting.get("data"), dict) else {}
+    provider = data.get("transcription_provider")
+    if provider not in _PROVIDERS:
+        return None
+
+    transitions = data.get("status_transition")
+    if not isinstance(transitions, list):
+        transitions = []
+    transitions = [item for item in transitions if isinstance(item, dict)]
+
+    admitted_at = _transition_time(transitions, "active")
+    terminal_status = meeting.get("status")
+    departed_at = (
+        _transition_time(transitions, terminal_status)
+        if terminal_status in ("completed", "failed")
+        else None
+    )
+    if admitted_at is None:
+        bot_outcome = "never_admitted"
+        departed_at = None
+    elif terminal_status == "failed":
+        bot_outcome = "failed"
+    else:
+        bot_outcome = "served"
+
+    if provider == "none":
+        transcription_outcome = "disabled"
+    elif data.get("stt_fault") or data.get("transcript_finalize_failed"):
+        transcription_outcome = "failed"
+    elif int(data.get("segments_captured") or 0) > 0:
+        transcription_outcome = "served"
+    else:
+        transcription_outcome = "no_output"
+
+    return {
+        "bot_admitted_at": admitted_at,
+        "bot_departed_at": departed_at,
+        "bot_outcome": bot_outcome,
+        "transcription_provider": provider,
+        "transcription_outcome": transcription_outcome,
+        "lifecycle_contract_version": LIFECYCLE_CONTRACT_VERSION,
+    }

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/provenance.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/provenance.py
@@ -8,11 +8,26 @@ LIFECYCLE_CONTRACT_VERSION = "2026-07-28"
 _PROVIDERS = frozenset({"vexa", "customer", "none"})
 
 
-def _transition_time(transitions: list[dict], status: str) -> Optional[str]:
+def _latest_session(transitions: list[dict]) -> list[dict]:
+    """Return only the last bot run carried by a continued meeting row."""
+    for index in range(len(transitions) - 1, -1, -1):
+        if transitions[index].get("to") == "joining":
+            return transitions[index:]
+    return transitions
+
+
+def _transition(transitions: list[dict], status: str) -> Optional[dict]:
     for transition in reversed(transitions):
-        if transition.get("to") == status and isinstance(transition.get("timestamp"), str):
-            return transition["timestamp"]
+        if transition.get("to") == status:
+            return transition
     return None
+
+
+def _producer_time(transition: Optional[dict]) -> Optional[str]:
+    if not transition or transition.get("timestamp_source") != "producer":
+        return None
+    timestamp = transition.get("timestamp")
+    return timestamp if isinstance(timestamp, str) else None
 
 
 def build_service_provenance(meeting: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -30,18 +45,26 @@ def build_service_provenance(meeting: Dict[str, Any]) -> Optional[Dict[str, Any]
     transitions = data.get("status_transition")
     if not isinstance(transitions, list):
         transitions = []
-    transitions = [item for item in transitions if isinstance(item, dict)]
+    transitions = _latest_session(
+        [item for item in transitions if isinstance(item, dict)],
+    )
 
-    admitted_at = _transition_time(transitions, "active")
+    admitted_transition = _transition(transitions, "active")
+    admitted_at = _producer_time(admitted_transition)
     terminal_status = meeting.get("status")
-    departed_at = (
-        _transition_time(transitions, terminal_status)
+    terminal_transition = (
+        _transition(transitions, terminal_status)
         if terminal_status in ("completed", "failed")
         else None
     )
-    if admitted_at is None:
+    departed_at = _producer_time(terminal_transition)
+    if admitted_transition is None:
         bot_outcome = "never_admitted"
         departed_at = None
+    elif admitted_at is None or departed_at is None:
+        # A mixed-version bot can omit producer time. Receiver time is operationally useful but
+        # retry latency makes it unfit for rating, so an admitted legacy session stays unresolved.
+        return None
     elif terminal_status == "failed":
         bot_outcome = "failed"
     else:

--- a/core/meetings/services/meeting-api/src/meeting_api/webhooks/delivery.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/webhooks/delivery.py
@@ -36,6 +36,9 @@ _INTERNAL_DATA_KEYS = frozenset({
     "webhook_delivery", "webhook_deliveries", "webhook_secret", "webhook_secrets",
     "webhook_events", "webhook_url", "outbound_events",
     "bot_container_id", "container_name",
+    # Internal rating input. Consumers receive only the privacy-safe, frozen
+    # `service_provenance` projection assembled at terminal finalization.
+    "transcription_provider",
 })
 
 

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -433,6 +433,29 @@ async def test_request_bot_disabled_transcription_freezes_none_provider(monkeypa
     assert row["data"]["transcription_provider"] == "none"
 
 
+async def test_request_bot_disabled_transcription_ignores_configured_provider(monkeypatch):
+    from meeting_api.bot_spawn import service as spawn_service
+
+    async def fake_resolve(_user_id):
+        return {"url": "https://stt-mine.example.com", "provider": "customer"}
+
+    monkeypatch.setattr(spawn_service, "_resolve_transcription_backend", fake_resolve)
+    repo = InMemoryMeetingRepo()
+    await request_bot(
+        repo,
+        FakeRuntimeClient(),
+        user_id=USER,
+        platform="google_meet",
+        native_meeting_id="disabled-configured-tx",
+        transcribe_enabled=False,
+        redis_url="redis://redis:6379/0",
+        token_secret=SECRET,
+    )
+
+    row = next(iter(repo._meetings.values()))
+    assert row["data"]["transcription_provider"] == "none"
+
+
 async def test_request_bot_does_not_guess_provider_for_legacy_settings_response(monkeypatch):
     """A mixed-version identity response may have a URL but no provenance.
 

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -347,7 +347,7 @@ def test_post_bots_transcribe_with_settings_stt_passes(monkeypatch):
     monkeypatch.setenv("ADMIN_TOKEN", SECRET)
 
     async def fake_resolve(user_id):
-        return {"url": "https://stt-settings.example.com"}
+        return {"url": "https://stt-settings.example.com", "provider": "customer"}
 
     monkeypatch.setattr(spawn_service, "_resolve_transcription_backend", fake_resolve)
 
@@ -358,6 +358,8 @@ def test_post_bots_transcribe_with_settings_stt_passes(monkeypatch):
     assert r.status_code == 201, r.text
     inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
     assert inv["transcriptionServiceUrl"] == "https://stt-settings.example.com"
+    row = next(iter(repo._meetings.values()))
+    assert row["data"]["transcription_provider"] == "customer"
 
 
 # ── Settings → transcription backend: the configured STT (user pref > platform) beats the env ────
@@ -373,7 +375,7 @@ async def test_request_bot_configured_transcription_backend_overrides_env(monkey
 
     async def fake_resolve(user_id):
         assert user_id == USER
-        return {"url": "https://stt-mine.example.com"}
+        return {"url": "https://stt-mine.example.com", "provider": "customer"}
 
     monkeypatch.setenv("TRANSCRIPTION_MODEL", "env-model")
 
@@ -387,6 +389,8 @@ async def test_request_bot_configured_transcription_backend_overrides_env(monkey
     assert inv["transcriptionServiceUrl"] == "https://stt-mine.example.com"
     assert "transcriptionServiceToken" not in inv  # env token does NOT leak to the custom backend
     assert "transcriptionModel" not in inv  # env model names the ENV backend's model — same rule
+    row = next(iter(repo._meetings.values()))
+    assert row["data"]["transcription_provider"] == "customer"
 
 
 async def test_request_bot_env_transcription_stays_without_settings(monkeypatch):
@@ -404,6 +408,99 @@ async def test_request_bot_env_transcription_stays_without_settings(monkeypatch)
     inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
     assert inv["transcriptionServiceUrl"] == "https://stt-env.vexa.ai"
     assert inv["transcriptionServiceToken"] == "tok-env"
+    row = next(iter(repo._meetings.values()))
+    assert row["data"]["transcription_provider"] == "vexa"
+
+
+async def test_request_bot_disabled_transcription_freezes_none_provider(monkeypatch):
+    monkeypatch.delenv("TRANSCRIPTION_SERVICE_URL", raising=False)
+    monkeypatch.delenv("TRANSCRIPTION_SERVICE_TOKEN", raising=False)
+    monkeypatch.delenv("ADMIN_API_URL", raising=False)
+
+    repo = InMemoryMeetingRepo()
+    await request_bot(
+        repo,
+        FakeRuntimeClient(),
+        user_id=USER,
+        platform="google_meet",
+        native_meeting_id="disabled-tx",
+        transcribe_enabled=False,
+        redis_url="redis://redis:6379/0",
+        token_secret=SECRET,
+    )
+
+    row = next(iter(repo._meetings.values()))
+    assert row["data"]["transcription_provider"] == "none"
+
+
+async def test_request_bot_does_not_guess_provider_for_legacy_settings_response(monkeypatch):
+    """A mixed-version identity response may have a URL but no provenance.
+
+    The spawn may proceed for compatibility, but billing provenance must remain unresolved:
+    inferring from the URL would turn an unknown customer endpoint into a Vexa charge.
+    """
+    from meeting_api.bot_spawn import service as spawn_service
+
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt-env.vexa.ai")
+
+    async def fake_resolve(user_id):
+        return {"url": "https://legacy-settings.example.com"}
+
+    monkeypatch.setattr(spawn_service, "_resolve_transcription_backend", fake_resolve)
+    repo = InMemoryMeetingRepo()
+    await request_bot(
+        repo,
+        FakeRuntimeClient(),
+        user_id=USER,
+        platform="google_meet",
+        native_meeting_id="legacy-provider",
+        redis_url="redis://redis:6379/0",
+        token_secret=SECRET,
+    )
+
+    row = next(iter(repo._meetings.values()))
+    assert "transcription_provider" not in row["data"]
+
+
+async def test_continue_meeting_refreezes_provider_for_the_new_session(monkeypatch):
+    from meeting_api.bot_spawn import service as spawn_service
+
+    selected = {"provider": "customer"}
+
+    async def fake_resolve(_user_id):
+        return {
+            "url": "https://configured.example.com",
+            "provider": selected["provider"],
+        }
+
+    monkeypatch.setattr(spawn_service, "_resolve_transcription_backend", fake_resolve)
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient()
+    first = await request_bot(
+        repo,
+        runtime,
+        user_id=USER,
+        platform="google_meet",
+        native_meeting_id="continued-provider",
+        redis_url="redis://redis:6379/0",
+        token_secret=SECRET,
+    )
+    assert repo._meetings[first["id"]]["data"]["transcription_provider"] == "customer"
+
+    repo.set_status(first["id"], "completed")
+    selected["provider"] = "vexa"
+    await request_bot(
+        repo,
+        runtime,
+        user_id=USER,
+        platform="google_meet",
+        native_meeting_id="continued-provider",
+        continue_meeting=True,
+        redis_url="redis://redis:6379/0",
+        token_secret=SECRET,
+    )
+
+    assert repo._meetings[first["id"]]["data"]["transcription_provider"] == "vexa"
 
 
 async def test_request_bot_env_transcription_model_rides_invocation(monkeypatch):

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_diagnostics.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_diagnostics.py
@@ -126,7 +126,8 @@ def test_terminal_cause_attribution(row):
     assert len(trail) == len(prefix) + 2  # joining + prefix + terminal
     assert trail[0] == {
         "from": None, "to": "joining",
-        "timestamp": trail[0]["timestamp"], "source": "bot_callback",
+        "timestamp": trail[0]["timestamp"], "timestamp_source": "receiver",
+        "source": "bot_callback",
     }
     last = trail[-1]
     assert last["to"] == terminal_status

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_durable.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_durable.py
@@ -93,10 +93,10 @@ def test_rehydration_preserves_admission_timestamp_for_runtime_billing(goldens):
         admitted,
         {
             "from": "active",
-                "to": "completed",
-                "timestamp": "2026-07-28T10:25:10.000Z",
-                "timestamp_source": "producer",
-                "source": "bot_callback",
+            "to": "completed",
+            "timestamp": "2026-07-28T10:25:10.000Z",
+            "timestamp_source": "producer",
+            "source": "bot_callback",
             "completion_reason": "stopped",
         },
     ]

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_durable.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_durable.py
@@ -75,6 +75,7 @@ def test_rehydration_preserves_admission_timestamp_for_runtime_billing(goldens):
         "from": "awaiting_admission",
         "to": "active",
         "timestamp": "2026-07-28T10:00:10.000Z",
+        "timestamp_source": "producer",
         "source": "bot_callback",
     }
     repo._meetings[m["id"]]["data"]["status_transition"] = [admitted]
@@ -92,9 +93,10 @@ def test_rehydration_preserves_admission_timestamp_for_runtime_billing(goldens):
         admitted,
         {
             "from": "active",
-            "to": "completed",
-            "timestamp": "2026-07-28T10:25:10.000Z",
-            "source": "bot_callback",
+                "to": "completed",
+                "timestamp": "2026-07-28T10:25:10.000Z",
+                "timestamp_source": "producer",
+                "source": "bot_callback",
             "completion_reason": "stopped",
         },
     ]

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_durable.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_durable.py
@@ -67,6 +67,39 @@ def test_rehydration_terminal_after_restart_is_200(goldens):
     assert asyncio.run(repo.get_status_by_session(session_uid="sess-uid")) == "completed"
 
 
+def test_rehydration_preserves_admission_timestamp_for_runtime_billing(goldens):
+    """A restart between admission and departure must not erase the admitted transition."""
+    repo = InMemoryMeetingRepo()
+    m = _seed_active_meeting(repo)
+    admitted = {
+        "from": "awaiting_admission",
+        "to": "active",
+        "timestamp": "2026-07-28T10:00:10.000Z",
+        "source": "bot_callback",
+    }
+    repo._meetings[m["id"]]["data"]["status_transition"] = [admitted]
+    client = TestClient(create_app(meeting_repo=repo))
+    terminal = {
+        **goldens["completed-stopped"],
+        "timestamp": "2026-07-28T10:25:10.000Z",
+    }
+
+    response = client.post(ENDPOINT, json=terminal)
+
+    assert response.status_code == 200, response.text
+    trail = repo._meetings[m["id"]]["data"]["status_transition"]
+    assert trail == [
+        admitted,
+        {
+            "from": "active",
+            "to": "completed",
+            "timestamp": "2026-07-28T10:25:10.000Z",
+            "source": "bot_callback",
+            "completion_reason": "stopped",
+        },
+    ]
+
+
 def test_rehydration_emits_status_change_and_no_409(goldens):
     """The rehydrated advance still emits the meeting.status_change webhook envelope (the finalize
     signal that never fired while stuck at 409)."""

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_fixtures.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_fixtures.py
@@ -58,6 +58,17 @@ def test_fixture_normal():
     assert {e["source"] for e in rec.status_transition} == {"bot_callback"}
 
 
+def test_fixture_uses_producer_timestamp_for_transition_fact():
+    sink = LifecycleSink(store=MeetingStore())
+    emitted_at = "2026-07-28T10:00:10.000Z"
+
+    rec = sink.apply(
+        {"connection_id": "sess-time", "status": "joining", "timestamp": emitted_at}
+    )
+
+    assert rec.status_transition[-1]["timestamp"] == emitted_at
+
+
 # ── 2. start-then-immediate-user-stop ────────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("stop_at", ["joining", "awaiting_admission"])

--- a/core/meetings/services/meeting-api/tests/test_service_provenance.py
+++ b/core/meetings/services/meeting-api/tests/test_service_provenance.py
@@ -1,0 +1,100 @@
+"""Producer-owned service facts for the hosted billing boundary (#984)."""
+
+from meeting_api.lifecycle.provenance import build_service_provenance
+
+
+def meeting(
+    *,
+    provider="vexa",
+    segments=2,
+    transitions=None,
+    stt_fault=None,
+):
+    data = {
+        "transcribe_enabled": provider != "none",
+        "transcription_provider": provider,
+        "segments_captured": segments,
+        "status_transition": transitions
+        or [
+            {"to": "joining", "timestamp": "2026-07-28T10:00:00Z"},
+            {"to": "active", "timestamp": "2026-07-28T10:05:00Z"},
+            {"to": "completed", "timestamp": "2026-07-28T10:30:00Z"},
+        ],
+        # Seed secrets in the producer record: no value may cross the public fact block.
+        "transcription_service_url": "https://secret.example.test/v1/audio",
+        "transcription_service_token": "do-not-serialize",
+    }
+    if stt_fault is not None:
+        data["stt_fault"] = stt_fault
+    return {"status": transitions[-1]["to"] if transitions else "completed", "data": data}
+
+
+def test_vexa_service_uses_admitted_to_departed_runtime_and_observed_output():
+    assert build_service_provenance(meeting()) == {
+        "bot_admitted_at": "2026-07-28T10:05:00Z",
+        "bot_departed_at": "2026-07-28T10:30:00Z",
+        "bot_outcome": "served",
+        "transcription_provider": "vexa",
+        "transcription_outcome": "served",
+        "lifecycle_contract_version": "2026-07-28",
+    }
+
+
+def test_customer_endpoint_is_distinct_and_never_leaks_configuration():
+    provenance = build_service_provenance(meeting(provider="customer"))
+
+    assert provenance["transcription_provider"] == "customer"
+    serialized = repr(provenance)
+    assert "secret.example.test" not in serialized
+    assert "do-not-serialize" not in serialized
+
+
+def test_never_admitted_is_explicit_and_has_no_runtime():
+    transitions = [
+        {"to": "joining", "timestamp": "2026-07-28T10:00:00Z"},
+        {"to": "awaiting_admission", "timestamp": "2026-07-28T10:01:00Z"},
+        {"to": "failed", "timestamp": "2026-07-28T10:10:00Z"},
+    ]
+
+    provenance = build_service_provenance(
+        meeting(provider="vexa", segments=0, transitions=transitions),
+    )
+
+    assert provenance["bot_outcome"] == "never_admitted"
+    assert provenance["bot_admitted_at"] is None
+    assert provenance["bot_departed_at"] is None
+    assert provenance["transcription_outcome"] == "no_output"
+
+
+def test_disabled_and_failed_transcription_are_not_reported_as_served():
+    disabled = build_service_provenance(meeting(provider="none", segments=0))
+    failed = build_service_provenance(
+        meeting(provider="vexa", segments=0, stt_fault={"total": 2}),
+    )
+
+    assert disabled["transcription_outcome"] == "disabled"
+    assert failed["transcription_outcome"] == "failed"
+
+
+def test_legacy_meeting_without_frozen_provider_stays_unresolved():
+    legacy = meeting()
+    del legacy["data"]["transcription_provider"]
+
+    assert build_service_provenance(legacy) is None
+
+
+def test_continued_meeting_uses_latest_session_runtime_not_prior_cycle():
+    continued = meeting(
+        transitions=[
+            {"to": "active", "timestamp": "2026-07-28T09:00:00Z"},
+            {"to": "completed", "timestamp": "2026-07-28T09:30:00Z"},
+            {"to": "joining", "timestamp": "2026-07-28T10:00:00Z"},
+            {"to": "active", "timestamp": "2026-07-28T10:05:00Z"},
+            {"to": "completed", "timestamp": "2026-07-28T10:20:00Z"},
+        ],
+    )
+
+    provenance = build_service_provenance(continued)
+
+    assert provenance["bot_admitted_at"] == "2026-07-28T10:05:00Z"
+    assert provenance["bot_departed_at"] == "2026-07-28T10:20:00Z"

--- a/core/meetings/services/meeting-api/tests/test_service_provenance.py
+++ b/core/meetings/services/meeting-api/tests/test_service_provenance.py
@@ -16,9 +16,9 @@ def meeting(
         "segments_captured": segments,
         "status_transition": transitions
         or [
-            {"to": "joining", "timestamp": "2026-07-28T10:00:00Z"},
-            {"to": "active", "timestamp": "2026-07-28T10:05:00Z"},
-            {"to": "completed", "timestamp": "2026-07-28T10:30:00Z"},
+            {"to": "joining", "timestamp": "2026-07-28T10:00:00Z", "timestamp_source": "producer"},
+            {"to": "active", "timestamp": "2026-07-28T10:05:00Z", "timestamp_source": "producer"},
+            {"to": "completed", "timestamp": "2026-07-28T10:30:00Z", "timestamp_source": "producer"},
         ],
         # Seed secrets in the producer record: no value may cross the public fact block.
         "transcription_service_url": "https://secret.example.test/v1/audio",
@@ -51,9 +51,9 @@ def test_customer_endpoint_is_distinct_and_never_leaks_configuration():
 
 def test_never_admitted_is_explicit_and_has_no_runtime():
     transitions = [
-        {"to": "joining", "timestamp": "2026-07-28T10:00:00Z"},
-        {"to": "awaiting_admission", "timestamp": "2026-07-28T10:01:00Z"},
-        {"to": "failed", "timestamp": "2026-07-28T10:10:00Z"},
+        {"to": "joining", "timestamp": "2026-07-28T10:00:00Z", "timestamp_source": "producer"},
+        {"to": "awaiting_admission", "timestamp": "2026-07-28T10:01:00Z", "timestamp_source": "producer"},
+        {"to": "failed", "timestamp": "2026-07-28T10:10:00Z", "timestamp_source": "producer"},
     ]
 
     provenance = build_service_provenance(
@@ -83,14 +83,22 @@ def test_legacy_meeting_without_frozen_provider_stays_unresolved():
     assert build_service_provenance(legacy) is None
 
 
+def test_admitted_legacy_session_without_producer_timestamps_stays_unresolved():
+    legacy = meeting()
+    for transition in legacy["data"]["status_transition"]:
+        transition["timestamp_source"] = "receiver"
+
+    assert build_service_provenance(legacy) is None
+
+
 def test_continued_meeting_uses_latest_session_runtime_not_prior_cycle():
     continued = meeting(
         transitions=[
-            {"to": "active", "timestamp": "2026-07-28T09:00:00Z"},
-            {"to": "completed", "timestamp": "2026-07-28T09:30:00Z"},
-            {"to": "joining", "timestamp": "2026-07-28T10:00:00Z"},
-            {"to": "active", "timestamp": "2026-07-28T10:05:00Z"},
-            {"to": "completed", "timestamp": "2026-07-28T10:20:00Z"},
+            {"to": "active", "timestamp": "2026-07-28T09:00:00Z", "timestamp_source": "producer"},
+            {"to": "completed", "timestamp": "2026-07-28T09:30:00Z", "timestamp_source": "producer"},
+            {"to": "joining", "timestamp": "2026-07-28T10:00:00Z", "timestamp_source": "producer"},
+            {"to": "active", "timestamp": "2026-07-28T10:05:00Z", "timestamp_source": "producer"},
+            {"to": "completed", "timestamp": "2026-07-28T10:20:00Z", "timestamp_source": "producer"},
         ],
     )
 
@@ -98,3 +106,21 @@ def test_continued_meeting_uses_latest_session_runtime_not_prior_cycle():
 
     assert provenance["bot_admitted_at"] == "2026-07-28T10:05:00Z"
     assert provenance["bot_departed_at"] == "2026-07-28T10:20:00Z"
+
+
+def test_continued_meeting_never_admitted_does_not_reuse_prior_runtime():
+    continued = meeting(
+        segments=0,
+        transitions=[
+            {"to": "active", "timestamp": "2026-07-28T09:00:00Z", "timestamp_source": "producer"},
+            {"to": "completed", "timestamp": "2026-07-28T09:30:00Z", "timestamp_source": "producer"},
+            {"to": "joining", "timestamp": "2026-07-28T10:00:00Z", "timestamp_source": "producer"},
+            {"to": "failed", "timestamp": "2026-07-28T10:02:00Z", "timestamp_source": "producer"},
+        ],
+    )
+
+    provenance = build_service_provenance(continued)
+
+    assert provenance["bot_outcome"] == "never_admitted"
+    assert provenance["bot_admitted_at"] is None
+    assert provenance["bot_departed_at"] is None

--- a/core/meetings/services/meeting-api/tests/test_webhook_wiring.py
+++ b/core/meetings/services/meeting-api/tests/test_webhook_wiring.py
@@ -148,6 +148,84 @@ def test_meeting_completed_emitted_with_post_meeting_envelope(goldens):
     assert "webhook_url" not in m["data"]
 
 
+def test_meeting_completed_exposes_frozen_privacy_safe_service_provenance():
+    repo, sink = InMemoryMeetingRepo(), _CaptureSink()
+    seeded = _seed(repo, session_uid="sess-uid", data={
+        "webhook_url": "https://hook.example/x",
+        "webhook_events": dict(_ALL_EVENTS),
+        "transcribe_enabled": True,
+        "transcription_provider": "customer",
+    })
+
+    async def finalizer(meeting_id):
+        assert meeting_id == seeded["id"]
+        return 3
+
+    client = TestClient(
+        create_app(
+            meeting_repo=repo,
+            webhook_sink=sink,
+            transcript_finalizer=finalizer,
+        )
+    )
+    for event in (
+        {"connection_id": "sess-uid", "status": "joining",
+         "timestamp": "2026-07-28T10:00:00.000Z"},
+        {"connection_id": "sess-uid", "status": "active",
+         "timestamp": "2026-07-28T10:05:00.000Z"},
+        {"connection_id": "sess-uid", "status": "completed",
+         "completion_reason": "stopped", "timestamp": "2026-07-28T10:30:00.000Z"},
+    ):
+        _post(client, event)
+
+    completed = sink.calls[-1]["envelope"]["data"]["meeting"]
+    assert completed["service_provenance"] == {
+        "bot_admitted_at": "2026-07-28T10:05:00.000Z",
+        "bot_departed_at": "2026-07-28T10:30:00.000Z",
+        "bot_outcome": "served",
+        "transcription_provider": "customer",
+        "transcription_outcome": "served",
+        "lifecycle_contract_version": "2026-07-28",
+    }
+    assert "transcription_provider" not in completed["data"]
+    assert "transcription_service_url" not in repr(completed)
+    assert repo._meetings[seeded["id"]]["data"]["segments_captured"] == 3
+
+
+def test_finalization_failure_never_claims_vexa_transcription_was_served():
+    repo, sink = InMemoryMeetingRepo(), _CaptureSink()
+    _seed(repo, session_uid="sess-uid", data={
+        "webhook_url": "https://hook.example/x",
+        "webhook_events": dict(_ALL_EVENTS),
+        "transcribe_enabled": True,
+        "transcription_provider": "vexa",
+    })
+
+    async def failed_finalizer(_meeting_id):
+        raise RuntimeError("durable transcript unavailable")
+
+    client = TestClient(
+        create_app(
+            meeting_repo=repo,
+            webhook_sink=sink,
+            transcript_finalizer=failed_finalizer,
+        )
+    )
+    for event in (
+        {"connection_id": "sess-uid", "status": "joining",
+         "timestamp": "2026-07-28T10:00:00.000Z"},
+        {"connection_id": "sess-uid", "status": "active",
+         "timestamp": "2026-07-28T10:05:00.000Z"},
+        {"connection_id": "sess-uid", "status": "completed",
+         "completion_reason": "stopped", "timestamp": "2026-07-28T10:30:00.000Z"},
+    ):
+        _post(client, event)
+
+    provenance = sink.calls[-1]["envelope"]["data"]["meeting"]["service_provenance"]
+    assert provenance["transcription_provider"] == "vexa"
+    assert provenance["transcription_outcome"] == "failed"
+
+
 def test_bot_failed_emitted_on_terminal_failure(goldens):
     client, sink = _wired_client()
     _post(client, goldens["joining"])

--- a/docs/changelog.d/984-service-provenance.md
+++ b/docs/changelog.d/984-service-provenance.md
@@ -1,0 +1,4 @@
+- **Meeting completion now reports the service that actually ran (#984).** Lifecycle events carry
+  producer-observed transition times, and completed meetings expose privacy-safe bot runtime and
+  transcription-provider outcomes so hosted billing can distinguish Vexa transcription from a
+  customer endpoint without inspecting configuration or credentials.

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -244,7 +244,7 @@ wall-clock time or delayed webhook receipt time. A bot that never reached `activ
 URL, hostname, token, credential, meeting title, or transcript.
 
 If a legacy or mixed-version run lacks provider ownership or producer timestamps, the block is
-absent. Consumers must treat that as unresolved provenance; do not reconstruct it from
+`null` or absent. Consumers must treat that as unresolved provenance; do not reconstruct it from
 `transcribe_enabled`, current user settings, endpoint URLs, or meeting start/end time.
 
 ## Get the transcript

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -221,6 +221,32 @@ With transcription requested (the default) and STT unconfigured, the spawn is **
 `{"transcribe_enabled": false}` (or `TRANSCRIBE_ENABLED=false` for the deployment). See
 [Configuration](/configuration#transcription-stt) and [Troubleshooting](/troubleshooting#bot-joins-but-theres-no-transcript).
 
+### Completion service provenance
+
+The signed `meeting.completed` webhook includes
+`data.meeting.service_provenance` when the meeting has complete producer-owned lifecycle facts:
+
+```json
+{
+  "bot_admitted_at": "2026-07-28T10:05:00.000Z",
+  "bot_departed_at": "2026-07-28T10:30:00.000Z",
+  "bot_outcome": "served",
+  "transcription_provider": "customer",
+  "transcription_outcome": "served",
+  "lifecycle_contract_version": "2026-07-28"
+}
+```
+
+`transcription_provider` is frozen when that bot is created: `vexa`, `customer`, or `none`.
+`bot_admitted_at` and `bot_departed_at` are the bot-observed lifecycle transitions, not meeting
+wall-clock time or delayed webhook receipt time. A bot that never reached `active` reports
+`bot_outcome: "never_admitted"` with both timestamps absent. The block never contains an endpoint
+URL, hostname, token, credential, meeting title, or transcript.
+
+If a legacy or mixed-version run lacks provider ownership or producer timestamps, the block is
+absent. Consumers must treat that as unresolved provenance; do not reconstruct it from
+`transcribe_enabled`, current user settings, endpoint URLs, or meeting start/end time.
+
 ## Get the transcript
 
 ```bash GET /transcripts/{platform}/{native_meeting_id}


### PR DESCRIPTION
## Outcome

Freeze privacy-safe, producer-owned meeting service facts so the hosted platform can rate bot runtime, capture-only transcription, Vexa transcription, and failure paths without guessing from mutable customer settings.

Part of #984 and the hosted trustworthy-billing train. This PR owns only the OSS lifecycle contract; it does **not** implement platform rating, Stripe delivery, ledger authority, deployment, or live billing acceptance.

## Exact source

- base: `d7ed2bb8e0fd00d4f0b2915afae06044a8b90547`
- head: `86914a52fccc913f97a17aed53fd6019128906fd`
- tree: `025443fb17d0819e338b00a1b5801217eaa67b53`

## What changes

- lifecycle events carry one producer timestamp; durable state rehydrates without losing the admission boundary;
- receiver fallback times are marked and admitted mixed-version sessions remain unresolved for billing;
- bot spawn freezes `transcription_provider` as `vexa`, `customer`, or `none`, including configured-but-disabled transcription;
- terminal meeting provenance records the latest session's admitted/departed times, bot outcome, transcription provider/outcome, and contract version;
- legacy payloads with no frozen provider remain unresolved instead of being guessed;
- continued meetings never reuse a prior session's runtime when the latest bot was never admitted;
- transcript finalization completes before terminal provenance is emitted, so finalization failure cannot be labelled `served`;
- customer transcription URLs no longer inherit Vexa's platform transcription token/model;
- signed `meeting.completed` goldens expose the privacy-safe provenance and omit endpoint URLs/credentials;
- the public Meetings API documents the fact block, privacy boundary, and null/absent unresolved state.

## Acceptance evidence

| Row | Expected | Actual | Verdict |
|---|---|---|---|
| P1 | admitted/departed facts originate at lifecycle transitions and survive meeting-api restart | timestamped lifecycle goldens; durable rehydration regression green | GREEN |
| P2 | actual provider is frozen at spawn, never inferred later | Vexa/customer/none, configured-disabled, and mixed-version unresolved tests green | GREEN |
| P3 | never-admitted and failed/no-output/served outcomes are distinguishable per latest session | provenance derivation, continued-never-admitted, and webhook wiring negatives green | GREEN |
| P4 | missing producer clocks never become billable receipt-time runtime | receiver-source negative remains unresolved | GREEN |
| P5 | no customer endpoint URL, credential, or Vexa token crosses the webhook/customer-provider seam | identity regression + webhook golden green | GREEN |
| P6 | terminal envelope carries the versioned contract | schema, contract-version and golden conformance green | GREEN |
| P7 | real repository shapes remain healthy | meeting-api 858 passed/5 skipped; admin-api 59 passed; bot suite/build green; full Python gate 12 packages green; Node gate 18 packages build+test green | GREEN |
| P8 | runnable composition accepts the source contracts | isolated Compose gate green with local mock-bot; hosted value-fsm 23 passed/8 skipped | GREEN at mock-composition altitude |

Focused post-review regression: `72 passed`; durable focused follow-up: `10 passed`. Additional gates green: readme, dataflow/seal, isolation, exports, graph, schema, config-contract, licenses (460 dependencies), execution-env, test-isolation, contract-conformance, stack, health, access, tracing, replay, telemetry, runtime parity and image licenses.

## Review history

Fresh non-author source review accepted `578c7d07…`; final documentation review accepted `86914a52…`. Review receipts are bound to their exact commits in this PR. No concrete source blocker remains.

## Honest boundary

Not checked here: a delivered real-platform meeting, hosted platform consumption, Stripe TEST, stage, production, or customer money. Capture-only rating must remain blocked until the platform consumer lands and the end-to-end stage witness observes the resulting customer line item. Compose used a local/hosted test-only mock bot and disposable project namespaces.