### PR TITLE
feat(meetings): add opt-in service-authority contract

### DIFF
--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -76,6 +76,12 @@
    ]
   },
   {
+   "unique-id": "service-authority-system",
+   "node-type": "system",
+   "name": "service authority",
+   "description": "optional operator-owned admission and active-service authority; absent in stock OSS and never owns billing policy inside core"
+  },
+  {
    "unique-id": "agent-api",
    "node-type": "service",
    "name": "agent-api",
@@ -200,7 +206,7 @@
    "unique-id": "meeting-api",
    "node-type": "service",
    "name": "meeting-api",
-   "description": "collector + bot-spawn + recordings + sessions (the hub)",
+   "description": "collector + bot-spawn + recordings + sessions (the hub); optionally asks an external service authority before spawn and at one-minute active boundaries",
    "metadata": [
     {
      "path": "core/meetings/services/meeting-api"
@@ -209,6 +215,18 @@
    "interfaces": [
     {
      "unique-id": "meeting-api-rest",
+     "type": "api"
+    }
+   ]
+  },
+  {
+   "unique-id": "service-authority",
+   "node-type": "service",
+   "name": "external service authority",
+   "description": "optional operator-provided service-authority.v1 endpoint; decides only allow/deny and remains outside the self-hosted core",
+   "interfaces": [
+    {
+     "unique-id": "service-authority-rest",
      "type": "api"
     }
    ]
@@ -596,6 +614,18 @@
    "metadata": [
     {
      "path": "core/meetings/contracts/lifecycle.v1",
+     "domain": "meetings"
+    }
+   ]
+  },
+  {
+   "unique-id": "service-authority.v1",
+   "node-type": "contract",
+   "name": "service-authority.v1",
+   "description": "service-authority.v1 — sealed opt-in admission and active-service decision contract without hosted billing data",
+   "metadata": [
+    {
+     "path": "core/meetings/contracts/service-authority.v1",
      "domain": "meetings"
     }
    ]
@@ -1288,6 +1318,7 @@
       "flagged-issue.v1",
       "invocation.v1",
       "lifecycle.v1",
+      "service-authority.v1",
       "transcript.v1",
       "webhook.v1",
       "transcription",
@@ -1300,6 +1331,17 @@
       "segments-table",
       "recording-blob",
       "userdata-blob"
+     ]
+    }
+   }
+  },
+  {
+   "unique-id": "service-authority-composed",
+   "relationship-type": {
+    "composed-of": {
+     "container": "service-authority-system",
+     "nodes": [
+      "service-authority"
      ]
     }
    }
@@ -1818,6 +1860,22 @@
     }
    },
    "description": "POST /workloads spawn bot",
+   "protocol": "HTTPS"
+  },
+  {
+   "unique-id": "ma-service-authority",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "meeting-api"
+     },
+     "destination": {
+      "node": "service-authority",
+      "interface": "service-authority-rest"
+     }
+    }
+   },
+   "description": "optional signed service-authority.v1 admit/continue decision; unset is explicit OSS allow-all, configured failure is closed",
    "protocol": "HTTPS"
   },
   {

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "237d0bbe42665e9e14b44ee3ecfb1d4a2f117e14535f91c3f7a2700017b8d6a9"
+  "architecture.calm.json": "314d9c77288ea766fcca6ed5b99e0cab7a354597865e08aacfc7b107f7da9a18"
 }

--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -17,6 +17,7 @@
   "core/meetings/contracts/flagged-issue.v1": "4b868f57298131f8eec8246d86d57251f259927d8bfd7df5a0f6016a10f16211",
   "core/meetings/contracts/invocation.v1": "c7d7f6b95f11da595d0a9e27a429774cdefcc997831cbedff061ebcc2aafbbb8",
   "core/meetings/contracts/lifecycle.v1": "95392746da49c7c61ec81863e6b836af5acb879f979918753fc8fcf92583b820",
+  "core/meetings/contracts/service-authority.v1": "cbcb1662424e180faebc9170896cc270985d8510b50f51ae1e9b32bc2e6050e6",
   "core/meetings/contracts/transcript.v1": "7d07d0fbac77f6562af64ae6c6286051e0e07763f427347d4e7b7735eaa0f9c8",
   "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",
   "core/runtime/contracts/runtime.v1": "9d67b9379e0d34c4d715764a467e7f6e6543a5db8177fc284fb4a7418067bc18",

--- a/core/meetings/contracts/README.md
+++ b/core/meetings/contracts/README.md
@@ -1,5 +1,6 @@
 # contracts — published by `meetings`
 
-Language-neutral contracts this domain owns (transcript · lifecycle · acts · invocation). Consumers
-reference them across the boundary (the legitimate seam); a domain may depend on another domain's
-`contracts/` but never its `services/`/`modules/`. `gate:schema` validates goldens ≡ schema.
+Language-neutral contracts this domain owns (transcript · lifecycle · acts · invocation ·
+service-authority). Consumers reference them across the boundary (the legitimate seam); a domain
+may depend on another domain's `contracts/` but never its `services/`/`modules/`. `gate:schema`
+validates goldens ≡ schema.

--- a/core/meetings/contracts/service-authority.v1/README.md
+++ b/core/meetings/contracts/service-authority.v1/README.md
@@ -1,0 +1,20 @@
+# service-authority.v1
+
+The generic, policy-free request/decision contract used by meeting-api before
+admitting a bot and at each one-minute active-service boundary.
+
+The request carries only authoritative service facts. The decision carries an
+opaque reason and optional stop scope. Payment providers, customer records,
+prices, balances, endpoint URLs, credentials, and hosted plan vocabulary are
+deliberately absent.
+
+Requests are serialized once and signed over
+`<X-Webhook-Timestamp>.<exact-body-bytes>` with HMAC-SHA256. The response echoes
+`request_id` and `service_identity`; the consumer rejects cross-bound or stale
+responses. Contextual invariants apply across the two schema shapes: an
+admission decision cannot carry `stop_scope`, while a denied continuation must
+carry `stop_scope: "billable_service"`. A response that violates either rule is
+unavailable, never an advisory denial that leaves paid work running.
+
+`service-authority.schema.json` is sealed by `contracts.seal.json`. Goldens are
+the wire specification and are validated by `validate.mjs`.

--- a/core/meetings/contracts/service-authority.v1/golden/Decision.allow.json
+++ b/core/meetings/contracts/service-authority.v1/golden/Decision.allow.json
@@ -1,0 +1,10 @@
+{
+  "authority_version": "service-authority.v1",
+  "decision_id": "decision-allow-41",
+  "request_id": "meeting-session-41:admit",
+  "service_identity": "meeting-session-41",
+  "allow": true,
+  "reason": "allowed",
+  "decided_at": "2026-07-29T08:00:00Z",
+  "stop_scope": null
+}

--- a/core/meetings/contracts/service-authority.v1/golden/Decision.stop.json
+++ b/core/meetings/contracts/service-authority.v1/golden/Decision.stop.json
@@ -1,0 +1,10 @@
+{
+  "authority_version": "service-authority.v1",
+  "decision_id": "decision-stop-41",
+  "request_id": "meeting-session-41:continue:2026-07-29T08:01:00+00:00",
+  "service_identity": "meeting-session-41",
+  "allow": false,
+  "reason": "opaque_limit",
+  "decided_at": "2026-07-29T08:01:00Z",
+  "stop_scope": "billable_service"
+}

--- a/core/meetings/contracts/service-authority.v1/golden/README.md
+++ b/core/meetings/contracts/service-authority.v1/golden/README.md
@@ -1,0 +1,8 @@
+# Goldens
+
+Committed request and decision vectors for `service-authority.v1`. The prefix
+before the first dot names the `$defs` shape validated by `validate.mjs`.
+
+Cross-shape invariants are enforced by the consumer because JSON Schema cannot
+bind a standalone Decision golden to its Request: admission has no stop scope;
+a denied continuation stops `billable_service`.

--- a/core/meetings/contracts/service-authority.v1/golden/Request.admit.json
+++ b/core/meetings/contracts/service-authority.v1/golden/Request.admit.json
@@ -1,0 +1,10 @@
+{
+  "user_id": 41,
+  "action": "admit",
+  "request_id": "meeting-session-41:admit",
+  "service_identity": "meeting-session-41",
+  "service_mode": "bot",
+  "transcription_provider": "customer",
+  "lifecycle_contract_version": "2026-07-28",
+  "active_concurrency": 0
+}

--- a/core/meetings/contracts/service-authority.v1/golden/Request.continue.json
+++ b/core/meetings/contracts/service-authority.v1/golden/Request.continue.json
@@ -1,0 +1,12 @@
+{
+  "user_id": 41,
+  "action": "continue",
+  "request_id": "meeting-session-41:continue:2026-07-29T08:01:00+00:00",
+  "service_identity": "meeting-session-41",
+  "service_mode": "bot",
+  "transcription_provider": "vexa",
+  "lifecycle_contract_version": "2026-07-28",
+  "active_concurrency": 1,
+  "admitted_at": "2026-07-29T08:00:00+00:00",
+  "boundary_at": "2026-07-29T08:01:00+00:00"
+}

--- a/core/meetings/contracts/service-authority.v1/service-authority.schema.json
+++ b/core/meetings/contracts/service-authority.v1/service-authority.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vexa.ai/contracts/meetings/service-authority.v1/service-authority.schema.json",
+  "title": "Vexa service authority v1",
+  "$defs": {
+    "Request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "user_id",
+        "action",
+        "request_id",
+        "service_identity",
+        "service_mode",
+        "transcription_provider",
+        "lifecycle_contract_version",
+        "active_concurrency"
+      ],
+      "properties": {
+        "user_id": { "type": "integer", "minimum": 1 },
+        "action": { "enum": ["admit", "continue"] },
+        "request_id": { "type": "string", "minLength": 1 },
+        "service_identity": { "type": "string", "minLength": 1 },
+        "service_mode": { "const": "bot" },
+        "transcription_provider": {
+          "enum": ["vexa", "customer", "none"]
+        },
+        "lifecycle_contract_version": { "const": "2026-07-28" },
+        "active_concurrency": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "admitted_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "boundary_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "action": { "const": "admit" } },
+            "required": ["action"]
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                { "required": ["admitted_at"] },
+                { "required": ["boundary_at"] }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "action": { "const": "continue" } },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["admitted_at", "boundary_at"]
+          }
+        }
+      ]
+    },
+    "Decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_version",
+        "decision_id",
+        "request_id",
+        "service_identity",
+        "allow",
+        "reason",
+        "decided_at"
+      ],
+      "properties": {
+        "authority_version": { "const": "service-authority.v1" },
+        "decision_id": { "type": "string", "minLength": 1 },
+        "request_id": { "type": "string", "minLength": 1 },
+        "service_identity": { "type": "string", "minLength": 1 },
+        "allow": { "type": "boolean" },
+        "reason": { "type": "string", "minLength": 1 },
+        "decided_at": { "type": "string", "format": "date-time" },
+        "stop_scope": {
+          "type": ["string", "null"],
+          "enum": ["billable_service", null]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "allow": { "const": true } },
+            "required": ["allow"]
+          },
+          "then": {
+            "properties": { "stop_scope": { "type": "null" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/core/meetings/contracts/service-authority.v1/validate.mjs
+++ b/core/meetings/contracts/service-authority.v1/validate.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(
+  readFileSync(join(HERE, "service-authority.schema.json"), "utf8"),
+);
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(schema);
+
+let failed = 0;
+const dir = join(HERE, "golden");
+const files = readdirSync(dir).filter((name) => name.endsWith(".json"));
+for (const file of files) {
+  const shape = file.split(".")[0];
+  const validate = ajv.compile({
+    $ref: `${schema.$id}#/$defs/${shape}`,
+  });
+  const value = JSON.parse(readFileSync(join(dir, file), "utf8"));
+  if (validate(value)) {
+    console.log(`  ✓ ${file} ≡ ${shape}`);
+  } else {
+    console.error(
+      `  ✗ ${file} (${shape}): ${ajv.errorsText(validate.errors)}`,
+    );
+    failed += 1;
+  }
+}
+console.log(
+  failed
+    ? `service-authority.v1: ${failed} golden(s) FAILED`
+    : `service-authority.v1: ${files.length} goldens conform`,
+);
+process.exit(failed ? 1 : 0);

--- a/core/meetings/services/meeting-api/README.md
+++ b/core/meetings/services/meeting-api/README.md
@@ -21,6 +21,7 @@ and stays in their ecosystem (FastAPI + redis + DB).
 | spawns-over | runtime kernel | `runtime.v1` (`RuntimeClient.create_workload`) | the meeting-bot workload (carries the `invocation.v1` BOT_CONFIG + MeetingToken) |
 | consumes | meeting-bot | `POST /bots/internal/callback/lifecycle` | `lifecycle.v1` `LifecycleEvent` → FSM advance + DB persist |
 | consumes | runtime kernel | `POST /runtime/callback` | workload state/terminal ACK (CC5 synthetic `failed`) |
+| calls (optional) | operator service authority | `service-authority.v1` over signed HTTP | allow/deny before spawn and at each one-minute active-service boundary; no hosted billing data |
 | consumes | transcription worker | redis stream `transcription_segments` | raw `transcript.v1` segments → DB |
 | publishes | api-gateway `/ws` | redis channel `tc:meeting:{id}:mutable` | the live mutable transcript bundle |
 | publishes | api-gateway `/ws` | redis channel `bm:meeting:{id}:status` | ws.v1 `meeting.status` (BotStatus) on each FSM advance |
@@ -30,7 +31,7 @@ and stays in their ecosystem (FastAPI + redis + DB).
 
 **Owns:** `core/meetings/contracts/lifecycle.v1` · `core/meetings/contracts/transcript.v1` ·
 `core/meetings/contracts/webhook.v1` · `core/meetings/contracts/invocation.v1` ·
-`core/meetings/contracts/acts.v1`.
+`core/meetings/contracts/acts.v1` · `core/meetings/contracts/service-authority.v1`.
 **Consumes:** `core/runtime/contracts/runtime.v1` (spawn the bot workload) and api.v1
 (`MeetingListResponse` / `TranscriptionResponse` response shapes). All sealed in `contracts.seal.json`.
 
@@ -53,5 +54,7 @@ Levels: **L1** contract conformance (`test_contract_conformance`, `collector_con
 - ✅ delivered — collector: `transcription_segments` → DB, publish `tc:meeting:{id}:mutable` + `bm:meeting:{id}:status`
 - ✅ delivered — `GET /meetings` (live + past per user) · `GET /transcripts` · `POST /ws/authorize-subscribe`
 - ✅ delivered — `webhook.v1` `meeting.status_change` signed per-user delivery
+- ✅ delivered — opt-in `service-authority.v1` admission and active-service boundary; unset is
+  explicit self-hosted allow-all, configured failure is closed
 - 🟡 partial — production composition root wiring real adapters (DB/redis/MinIO) is P3; ports are in place
 - ⬜ planned — `GET /meetings` is the source the terminal meetings list (live+past) will read via agent-api

--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -102,6 +102,9 @@ def build_production_app():
 
     runtime_http = httpx.AsyncClient(timeout=30.0)
     runtime_client = HttpRuntimeClient(runtime_http, runtime_api_url)
+    from .service_authority import build_service_authority_from_env
+
+    service_authority = build_service_authority_from_env()
 
     recording_repo = SqlAlchemyRecordingRepo(session_factory)
     storage = S3Storage(
@@ -181,6 +184,7 @@ def build_production_app():
         redis=segment_bus,
         meeting_repo=meeting_repo,
         runtime=runtime_client,
+        service_authority=service_authority,
         recording_repo=recording_repo,
         storage=storage,
         token_secret=token_secret,
@@ -196,6 +200,7 @@ def build_production_app():
 
     _attach_background_loops(
         app, transcript_store, segment_bus, redis_client, meeting_repo, runtime_client,
+        service_authority=service_authority,
         session_factory=session_factory,
     )
     return app
@@ -212,7 +217,7 @@ def _minio_endpoint_url() -> str:
 
 def _attach_background_loops(
     app, transcript_store, segment_bus, redis_client, meeting_repo=None, runtime=None,
-    session_factory=None,
+    service_authority=None, session_factory=None,
 ) -> None:
     """Register the FastAPI lifespan that starts/stops the control-plane poll loops.
 
@@ -280,6 +285,9 @@ def _attach_background_loops(
     # presumed lost (runtime restart on the process backend / external removal) and advanced to
     # `failed` with the evidence note, instead of retrying an error + dead DELETE every sweep forever.
     untracked_grace = float(os.getenv("MEETING_UNTRACKED_GRACE_SEC", "600"))
+    service_authority_interval = float(
+        os.getenv("SERVICE_AUTHORITY_SWEEP_INTERVAL_S", "15")
+    )
 
     # #527: per-loop liveness heartbeats. A loop hung inside an await stops stamping, so /health can
     # SEE a dead consumer that would otherwise look alive (live WS keeps flowing on a SEPARATE path —
@@ -437,6 +445,41 @@ def _attach_background_loops(
                 log.exception("stop-reconcile tick failed")
             await asyncio.sleep(stop_interval)
 
+    async def _service_authority_loop() -> None:
+        if (
+            service_authority is None
+            or not getattr(service_authority, "configured", False)
+            or meeting_repo is None
+            or runtime is None
+        ):
+            return
+        from .service_authority import run_service_authority_sweep
+
+        async def _tick():
+            observation = await run_service_authority_sweep(
+                meeting_repo,
+                runtime,
+                service_authority,
+            )
+            if observation.faults:
+                log.warning(
+                    "service-authority sweep faults=%s decisions=%s "
+                    "teardowns_confirmed=%s",
+                    observation.faults,
+                    observation.decisions,
+                    observation.teardowns_confirmed,
+                )
+
+        while True:
+            try:
+                await _guarded("service-authority", _tick)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("service-authority sweep failed")
+            ticks["service-authority"] = _time.monotonic()
+            await asyncio.sleep(service_authority_interval)
+
     # Auto-join: "scheduled" means the bot joins. The sweep spawns a bot for every scheduled row
     # whose data.scheduled_at arrived (lead window) and whose auto_join toggle is on, through the
     # SAME request_bot flow POST /bots runs — the claim/upgrade branch makes it idempotent. The
@@ -492,6 +535,7 @@ def _attach_background_loops(
         async def _tick():
             await auto_join_tick(
                 meeting_repo, runtime,
+                authority=service_authority,
                 fetch_bot_context=fetch_bot_context,
                 publish_status=publish_status,
                 lead_s=auto_join_lead, grace_s=auto_join_grace,
@@ -562,6 +606,10 @@ def _attach_background_loops(
             asyncio.create_task(_db_writer_loop(), name="db-writer"),
             asyncio.create_task(_webhook_drain_loop(), name="webhook-drain"),
             asyncio.create_task(_stop_reconcile_loop(), name="stop-reconcile"),
+            asyncio.create_task(
+                _service_authority_loop(),
+                name="service-authority",
+            ),
             asyncio.create_task(_auto_join_loop(), name="auto-join"),
             asyncio.create_task(_calendar_sync_loop(), name="calendar-sync"),
         ]

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -157,6 +157,7 @@ def create_app(
     # bot_spawn ports
     meeting_repo: Optional["_bot_spawn.MeetingRepo"] = None,
     runtime: Optional["_bot_spawn.RuntimeClient"] = None,
+    service_authority: Optional["object"] = None,
     # recordings ports
     recording_repo: Optional["_recordings.RecordingRepo"] = None,
     storage: Optional["_recordings.Storage"] = None,
@@ -218,6 +219,11 @@ def create_app(
         meeting_repo = _bot_spawn_fakes().InMemoryMeetingRepo()
     if runtime is None:
         runtime = _bot_spawn_fakes().FakeRuntimeClient()
+    if service_authority is None:
+        from .service_authority import AllowAllServiceAuthority
+
+        service_authority = AllowAllServiceAuthority()
+    app.state.service_authority = service_authority
 
     # --- lifecycle: bot lifecycle callbacks + FSM (lifecycle.v1), PERSISTED to the meeting row ---
     sink = LifecycleSink(store=meeting_store if meeting_store is not None else MeetingStore())
@@ -237,7 +243,13 @@ def create_app(
                      delivery_ledger)
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
-    app.include_router(_bot_spawn.build_router(meeting_repo, runtime))
+    app.include_router(
+        _bot_spawn.build_router(
+            meeting_repo,
+            runtime,
+            service_authority,
+        )
+    )
 
     # --- user-stop: DELETE /bots/{platform}/{native_meeting_id} (lifecycle/stop.py over redis) ---
     from .lifecycle.stop_router import InMemoryCommandPublisher, build_stop_router

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/README.md
@@ -18,6 +18,8 @@ eager-creates the `MeetingSession` keyed by the bot's `connectionId`.
 
 ## The flow (P2 core + P3 control-plane)
 construct the meeting URL → dedup (409 on a CONCURRENT active prior) → **max-bots pre-check (429)**
+→ mint a per-run service identity → **optional service-authority admission before any row/runtime
+effect (403 deny, 503 unavailable)**
 → **continue_meeting (reuse a TERMINAL prior row)** or insert a fresh `Meeting` row (status
 `requested`) → mint the MeetingToken + build the `invocation.v1` invocation → spawn the `runtime.v1`
 `WorkloadSpec` (`profile="meeting-bot"`; the invocation rides as the one `BOT_CONFIG` env var) →
@@ -50,3 +52,20 @@ Join-retry re-spawns and `continue_meeting` sessions count against the same cap.
 
 Tests: `../../../tests/test_bot_spawn.py` · `test_continue_meeting.py` · `test_max_bots.py`.
 Join-retry (P3d) lives in the `lifecycle` brick: `lifecycle/retry.py` + `test_join_retry.py`.
+
+### Optional external service authority
+
+`VEXA_SERVICE_AUTHORITY_CONFIG` enables the sealed, policy-free
+`service-authority.v1` seam. The request contains authoritative user/service identity, service
+mode, frozen transcription provider, concurrency, and lifecycle timing—never an email, payment
+provider ID, price, balance, transcription URL, or credential. The exact JSON bytes are signed
+with `VEXA_SERVICE_AUTHORITY_SECRET`.
+
+The admitted decision is frozen in `meeting.data.service_authority`. A meeting-api-owned sweep
+asks again at every admitted-time + N-minute boundary. An enforced stop is persisted before the
+runtime teardown and converges after restart; repeated sweeps never apply the same decision twice.
+Observe-only sessions are never later reinterpreted as enforced sessions.
+
+No config means explicit stock OSS allow-all. Once configured, unavailable, malformed, stale, or
+cross-bound decisions fail closed. `mode=observe` records the authority response but cannot satisfy
+a hosted hard-spend-cap claim.

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -556,6 +556,233 @@ class SqlAlchemyMeetingRepo:
             flag_modified(meeting, "data")
             await db.commit()
 
+    async def list_service_authority_sessions(self) -> list[dict]:
+        """Active admitted sessions carrying the frozen generic authority identity."""
+        from sqlalchemy import select
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            rows = (
+                await db.execute(
+                    select(Meeting).where(
+                        Meeting.status.in_(("active", "needs_help")),
+                    )
+                )
+            ).scalars().all()
+            return [
+                _row_to_dict(row)
+                for row in rows
+                if isinstance(row.data, dict)
+                and isinstance(row.data.get("service_authority"), dict)
+                and row.data["service_authority"].get("mode")
+                in ("enforce", "observe")
+            ]
+
+    async def record_service_authority_decision(
+        self,
+        *,
+        meeting_id,
+        request,
+        decision,
+    ) -> bool:
+        """Persist one request-bound boundary decision under a row lock."""
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            row = (
+                await db.execute(
+                    select(Meeting)
+                    .where(Meeting.id == meeting_id)
+                    .with_for_update()
+                )
+            ).scalars().first()
+            if row is None:
+                return False
+            data = dict(row.data) if isinstance(row.data, dict) else {}
+            metadata = data.get("service_authority")
+            if (
+                not isinstance(metadata, dict)
+                or metadata.get("service_identity")
+                != request.service_identity
+            ):
+                return False
+            metadata = dict(metadata)
+            boundary = request.boundary_at.isoformat()
+            prior_boundary = metadata.get("last_boundary_at")
+            if prior_boundary == boundary:
+                if metadata.get("last_decision_id") != decision.decision_id:
+                    raise ValueError(
+                        "service-authority boundary decision conflicts"
+                    )
+                return False
+            if prior_boundary:
+                prior = datetime.fromisoformat(
+                    prior_boundary.replace("Z", "+00:00")
+                )
+                if prior >= request.boundary_at:
+                    return False
+            metadata.update(decision.to_record())
+            metadata["last_boundary_at"] = boundary
+            metadata["last_decision_id"] = decision.decision_id
+            if (
+                decision.enforced
+                and not decision.allow
+                and decision.stop_scope == "billable_service"
+            ):
+                metadata["teardown_confirmed"] = False
+                data["stop_requested"] = True
+                row.status = "stopping"
+            data["service_authority"] = metadata
+            row.data = data
+            flag_modified(row, "data")
+            await db.commit()
+            return True
+
+    async def list_service_authority_teardowns(self) -> list[dict]:
+        """Durable stop intents that still lack a confirmed runtime teardown."""
+        from sqlalchemy import select
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            rows = (
+                await db.execute(
+                    select(Meeting).where(
+                        Meeting.status.in_((
+                            "active",
+                            "needs_help",
+                            "stopping",
+                        )),
+                    )
+                )
+            ).scalars().all()
+            out = []
+            for row in rows:
+                data = row.data if isinstance(row.data, dict) else {}
+                metadata = data.get("service_authority")
+                if (
+                    isinstance(metadata, dict)
+                    and metadata.get("enforced") is True
+                    and metadata.get("allow") is False
+                    and metadata.get("stop_scope")
+                    == "billable_service"
+                    and metadata.get("teardown_confirmed") is not True
+                ):
+                    out.append({
+                        "id": row.id,
+                        "bot_container_id": row.bot_container_id,
+                        "decision_id": metadata.get("decision_id"),
+                    })
+            return out
+
+    async def claim_service_authority_teardown(
+        self,
+        *,
+        meeting_id,
+        claim_id,
+        claimed_at,
+        lease_seconds,
+    ) -> Optional[dict]:
+        """Lease one stop intent under a row lock so replicas cannot race it."""
+        from datetime import timezone
+
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            row = (
+                await db.execute(
+                    select(Meeting)
+                    .where(Meeting.id == meeting_id)
+                    .with_for_update()
+                )
+            ).scalars().first()
+            if row is None:
+                return None
+            data = dict(row.data) if isinstance(row.data, dict) else {}
+            metadata = data.get("service_authority")
+            if (
+                not isinstance(metadata, dict)
+                or metadata.get("enforced") is not True
+                or metadata.get("allow") is not False
+                or metadata.get("stop_scope") != "billable_service"
+                or metadata.get("teardown_confirmed") is True
+            ):
+                return None
+            metadata = dict(metadata)
+            prior_claim = metadata.get("teardown_claim_id")
+            prior_at = metadata.get("teardown_claimed_at")
+            if prior_claim and prior_at:
+                try:
+                    prior_time = datetime.fromisoformat(
+                        prior_at.replace("Z", "+00:00"),
+                    ).astimezone(timezone.utc)
+                except (TypeError, ValueError):
+                    return None
+                if (
+                    claimed_at.astimezone(timezone.utc) - prior_time
+                ).total_seconds() < lease_seconds:
+                    return None
+            metadata["teardown_claim_id"] = claim_id
+            metadata["teardown_claimed_at"] = claimed_at.isoformat()
+            data["service_authority"] = metadata
+            row.data = data
+            flag_modified(row, "data")
+            await db.commit()
+            return {
+                "id": row.id,
+                "bot_container_id": row.bot_container_id,
+                "decision_id": metadata.get("decision_id"),
+                "claim_id": claim_id,
+            }
+
+    async def confirm_service_authority_teardown(
+        self,
+        *,
+        meeting_id,
+        decision_id,
+        claim_id,
+    ) -> bool:
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            row = (
+                await db.execute(
+                    select(Meeting)
+                    .where(Meeting.id == meeting_id)
+                    .with_for_update()
+                )
+            ).scalars().first()
+            if row is None:
+                return False
+            data = dict(row.data) if isinstance(row.data, dict) else {}
+            metadata = data.get("service_authority")
+            if (
+                not isinstance(metadata, dict)
+                or metadata.get("decision_id") != decision_id
+                or metadata.get("teardown_claim_id") != claim_id
+                or metadata.get("teardown_confirmed") is True
+            ):
+                return False
+            metadata = dict(metadata)
+            metadata["teardown_confirmed"] = True
+            metadata["teardown_claim_id"] = None
+            metadata["teardown_claimed_at"] = None
+            data["service_authority"] = metadata
+            row.data = data
+            flag_modified(row, "data")
+            await db.commit()
+            return True
+
     async def create_session(self, *, meeting_id, session_uid) -> None:
         async with self._session_factory() as db:
             db.add(new_session(meeting_id, session_uid))

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
@@ -26,6 +26,10 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable, Optional
 
 from ..obs import log_event
+from ..service_authority import (
+    ServiceAuthorityDenied,
+    ServiceAuthorityUnavailable,
+)
 from .ports import MaxBotsExceeded, QuotaExceeded, SpawnFailed
 from .service import DuplicateMeeting, request_bot
 
@@ -92,6 +96,7 @@ async def auto_join_tick(
     repo,
     runtime,
     *,
+    authority=None,
     fetch_bot_context: Optional[Callable[[int], Awaitable[Optional[dict]]]] = None,
     publish_status: Optional[Callable[..., Awaitable[None]]] = None,
     transcribe_gate: Optional[Callable[[], Optional[str]]] = None,
@@ -182,6 +187,7 @@ async def auto_join_tick(
         try:
             await request_bot(
                 repo, runtime,
+                authority=authority,
                 user_id=user_id,
                 platform=row["platform"],
                 native_meeting_id=row["native_meeting_id"],
@@ -199,6 +205,15 @@ async def auto_join_tick(
             continue
         except (MaxBotsExceeded, QuotaExceeded) as e:
             await _stamp_error(row, str(e) or "bot concurrency limit reached")
+            continue
+        except ServiceAuthorityDenied as e:
+            await _stamp_error(
+                row,
+                f"service not allowed ({e.reason}; decision {e.decision_id})",
+            )
+            continue
+        except ServiceAuthorityUnavailable:
+            await _stamp_error(row, "service authority unavailable")
             continue
         except SpawnFailed as e:
             await _stamp_error(row, str(e) or "bot workload failed to start")

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -501,8 +501,8 @@ class FakeRuntimeClient:
 
     async def delete_workload(self, workload_id: str) -> None:
         # Mirrors the HTTP adapter: an id the kernel doesn't track raises WorkloadUnknown (404).
-        # The service-authority sweep treats absence as an already-converged stop; other callers
-        # may still distinguish the response at their own boundary.
+        # Absence is NOT evidence the underlying workload stopped; every caller must preserve that
+        # distinction until it has a positive destroyed/teardown observation.
         if self._workloads is not None and workload_id not in self._workloads:
             raise WorkloadUnknown(workload_id)
         # Record the teardown so the partial-spawn test asserts the orphaned workload was torn down.

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -279,6 +279,149 @@ class InMemoryMeetingRepo:
             and m["id"] != exclude_meeting_id
         )
 
+    async def list_service_authority_sessions(self) -> list[dict]:
+        """Active rows carrying a per-run authority identity."""
+        return [
+            dict(m)
+            for m in self._meetings.values()
+            if m["status"] in ("active", "needs_help")
+            and isinstance(m.get("data", {}).get("service_authority"), dict)
+            and m["data"]["service_authority"].get("mode")
+            in ("enforce", "observe")
+        ]
+
+    async def record_service_authority_decision(
+        self,
+        *,
+        meeting_id,
+        request,
+        decision,
+    ) -> bool:
+        row = self._meetings.get(meeting_id)
+        if row is None:
+            return False
+        metadata = row.get("data", {}).get("service_authority")
+        if (
+            not isinstance(metadata, dict)
+            or metadata.get("service_identity")
+            != request.service_identity
+        ):
+            return False
+        boundary = request.boundary_at.isoformat()
+        if metadata.get("last_boundary_at") == boundary:
+            if metadata.get("last_decision_id") != decision.decision_id:
+                raise ValueError(
+                    "service-authority boundary decision conflicts"
+                )
+            return False
+        if metadata.get("last_boundary_at"):
+            from datetime import datetime
+
+            previous = datetime.fromisoformat(
+                metadata["last_boundary_at"].replace("Z", "+00:00")
+            )
+            if previous >= request.boundary_at:
+                return False
+        metadata.update(decision.to_record())
+        metadata["last_boundary_at"] = boundary
+        metadata["last_decision_id"] = decision.decision_id
+        if (
+            decision.enforced
+            and not decision.allow
+            and decision.stop_scope == "billable_service"
+        ):
+            metadata["teardown_confirmed"] = False
+            row["data"]["stop_requested"] = True
+            row["status"] = "stopping"
+        return True
+
+    async def list_service_authority_teardowns(self) -> list[dict]:
+        out = []
+        for row in self._meetings.values():
+            metadata = row.get("data", {}).get("service_authority")
+            if (
+                isinstance(metadata, dict)
+                and metadata.get("enforced") is True
+                and metadata.get("allow") is False
+                and metadata.get("stop_scope") == "billable_service"
+                and metadata.get("teardown_confirmed") is not True
+            ):
+                out.append({
+                    "id": row["id"],
+                    "bot_container_id": row.get("bot_container_id"),
+                    "decision_id": metadata.get("decision_id"),
+                })
+        return out
+
+    async def claim_service_authority_teardown(
+        self,
+        *,
+        meeting_id,
+        claim_id,
+        claimed_at,
+        lease_seconds,
+    ) -> Optional[dict]:
+        from datetime import datetime, timezone
+
+        row = self._meetings.get(meeting_id)
+        metadata = (
+            row.get("data", {}).get("service_authority")
+            if row is not None
+            else None
+        )
+        if (
+            not isinstance(metadata, dict)
+            or metadata.get("enforced") is not True
+            or metadata.get("allow") is not False
+            or metadata.get("stop_scope") != "billable_service"
+            or metadata.get("teardown_confirmed") is True
+        ):
+            return None
+        prior_claim = metadata.get("teardown_claim_id")
+        prior_at = metadata.get("teardown_claimed_at")
+        if prior_claim and prior_at:
+            try:
+                prior_time = datetime.fromisoformat(
+                    prior_at.replace("Z", "+00:00"),
+                ).astimezone(timezone.utc)
+            except (TypeError, ValueError):
+                return None
+            if (claimed_at - prior_time).total_seconds() < lease_seconds:
+                return None
+        metadata["teardown_claim_id"] = claim_id
+        metadata["teardown_claimed_at"] = claimed_at.isoformat()
+        return {
+            "id": row["id"],
+            "bot_container_id": row.get("bot_container_id"),
+            "decision_id": metadata.get("decision_id"),
+            "claim_id": claim_id,
+        }
+
+    async def confirm_service_authority_teardown(
+        self,
+        *,
+        meeting_id,
+        decision_id,
+        claim_id,
+    ) -> bool:
+        row = self._meetings.get(meeting_id)
+        metadata = (
+            row.get("data", {}).get("service_authority")
+            if row is not None
+            else None
+        )
+        if (
+            not isinstance(metadata, dict)
+            or metadata.get("decision_id") != decision_id
+            or metadata.get("teardown_claim_id") != claim_id
+            or metadata.get("teardown_confirmed") is True
+        ):
+            return False
+        metadata["teardown_confirmed"] = True
+        metadata["teardown_claim_id"] = None
+        metadata["teardown_claimed_at"] = None
+        return True
+
     async def list_stale_nonterminal(
         self, *, stop_grace: float, active_grace: float, preactive_grace: Optional[float] = None
     ) -> list:
@@ -357,8 +500,9 @@ class FakeRuntimeClient:
         return {"workloadId": spec["workloadId"], "state": "starting"}
 
     async def delete_workload(self, workload_id: str) -> None:
-        # Mirrors the HTTP adapter: an id the kernel doesn't track raises WorkloadUnknown (404) —
-        # termination UNCONFIRMED. With the default (no map) every teardown is tracked + confirmed.
+        # Mirrors the HTTP adapter: an id the kernel doesn't track raises WorkloadUnknown (404).
+        # The service-authority sweep treats absence as an already-converged stop; other callers
+        # may still distinguish the response at their own boundary.
         if self._workloads is not None and workload_id not in self._workloads:
             raise WorkloadUnknown(workload_id)
         # Record the teardown so the partial-spawn test asserts the orphaned workload was torn down.

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
@@ -129,6 +129,45 @@ class MeetingRepo(Protocol):
         ``continue_meeting`` reopen not double-count the row it is about to reuse."""
         ...
 
+    async def list_service_authority_sessions(self) -> list[dict]:
+        """Active admitted rows carrying a frozen service-authority identity."""
+        ...
+
+    async def record_service_authority_decision(
+        self,
+        *,
+        meeting_id: int,
+        request: Any,
+        decision: Any,
+    ) -> bool:
+        """Append the next monotonic boundary decision; return whether it was new."""
+        ...
+
+    async def list_service_authority_teardowns(self) -> list[dict]:
+        """Denied stop intents whose runtime teardown is not yet confirmed."""
+        ...
+
+    async def claim_service_authority_teardown(
+        self,
+        *,
+        meeting_id: int,
+        claim_id: str,
+        claimed_at: Any,
+        lease_seconds: float,
+    ) -> Optional[dict]:
+        """Lease one pending teardown under storage serialization."""
+        ...
+
+    async def confirm_service_authority_teardown(
+        self,
+        *,
+        meeting_id: int,
+        decision_id: str,
+        claim_id: str,
+    ) -> bool:
+        """Mark one matching stop intent confirmed; replay returns false."""
+        ...
+
     async def get_status_by_session(self, *, session_uid: str) -> Optional[str]:
         """Resolve ``session_uid`` (== the bot's ``connectionId``) → the meeting's CURRENT persisted
         status string, or ``None`` for an unknown session. Used to REHYDRATE the in-memory lifecycle

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -21,6 +21,10 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from ..collector.meeting_link import parse_meeting_url
+from ..service_authority import (
+    ServiceAuthorityDenied,
+    ServiceAuthorityUnavailable,
+)
 from .env_flags import env_flag
 from .ports import (
     AuthSessionBusy,
@@ -229,8 +233,12 @@ def _passcode_from_url(meeting_url: str) -> Optional[str]:
     return None
 
 
-def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
-    """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` ports."""
+def build_router(
+    repo: MeetingRepo,
+    runtime: RuntimeClient,
+    authority=None,
+) -> APIRouter:
+    """The bot-spawn routes over injected storage, runtime, and authority ports."""
     router = APIRouter()
 
     @router.post("/bots", status_code=201)
@@ -382,6 +390,7 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
             meeting = await request_bot(
                 repo,
                 runtime,
+                authority=authority,
                 user_id=user_id,
                 platform=platform,
                 native_meeting_id=native_meeting_id,
@@ -413,6 +422,23 @@ def build_router(repo: MeetingRepo, runtime: RuntimeClient) -> APIRouter:
             # One stored session, one live bot: the second concurrent authenticated spawn is
             # refused naming the conflicting meeting (per-identity serialization, #725).
             raise HTTPException(status_code=409, detail=str(e))
+        except ServiceAuthorityDenied as e:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "service_not_allowed",
+                    "reason": e.reason,
+                    "decision_id": e.decision_id,
+                },
+            )
+        except ServiceAuthorityUnavailable:
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "code": "service_authority_unavailable",
+                    "reason": "service_authority_unavailable",
+                },
+            )
         except DuplicateMeeting as e:
             raise HTTPException(status_code=409, detail=str(e))
         except (MaxBotsExceeded, QuotaExceeded) as e:

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -29,6 +29,12 @@ from typing import Any, Optional
 
 from ..config_preflight import CONFIG_FAULT_KINDS, cached_probe_verdict
 from ..obs import log_event
+from ..service_authority import (
+    AllowAllServiceAuthority,
+    ServiceAuthorityDenied,
+    ServiceAuthorityRequest,
+    ServiceAuthorityUnavailable,
+)
 from .env_flags import env_flag
 from .invocation import build_invocation, build_workload_spec, mint_meeting_token
 from .ports import (
@@ -142,6 +148,7 @@ async def request_bot(
     repo: MeetingRepo,
     runtime: RuntimeClient,
     *,
+    authority=None,
     user_id: int,
     platform: str,
     native_meeting_id: str,
@@ -177,6 +184,7 @@ async def request_bot(
     ``<= 0`` means the quota is DEPLETED (every spawn rejected) — 0 is never "unlimited"; ``None``
     means no cap was provided, so no pre-check.
     """
+    authority = authority or AllowAllServiceAuthority()
     # 1. URL.
     constructed_url = meeting_url or construct_meeting_url(platform, native_meeting_id)
 
@@ -302,6 +310,51 @@ async def request_bot(
             )
             raise AuthSessionBusy(conflict["id"], auth_userdata_path)
 
+    # The service identity exists before any meeting row or workload. It is a
+    # per-run identity (not the database row id): continued runs reuse a
+    # meeting row but remain distinct delivered services and distinct billing
+    # settlements. The admitted decision is frozen into meeting.data and
+    # therefore travels with the terminal meeting projection.
+    connection_id = str(uuid.uuid4())
+    service_identity = f"meeting-session:{connection_id}"
+    active_concurrency = await repo.count_active_bots(
+        user_id=user_id,
+        exclude_meeting_id=(
+            reused_row["id"] if reused_row is not None else None
+        ),
+    )
+    if transcription_provider is None and authority.configured:
+        raise ServiceAuthorityUnavailable(
+            "configured service authority requires resolved service provenance"
+        )
+    authority_request = ServiceAuthorityRequest.admit(
+        user_id=user_id,
+        request_id=f"{service_identity}:admit",
+        service_identity=service_identity,
+        transcription_provider=transcription_provider or "none",
+        active_concurrency=active_concurrency,
+    )
+    authority_decision = await authority.decide(authority_request)
+    if (
+        authority_decision.enforced
+        and not authority_decision.allow
+    ):
+        raise ServiceAuthorityDenied(
+            authority_decision.reason,
+            authority_decision.decision_id,
+        )
+    authority_record = {
+        **authority_decision.to_record(),
+        "mode": authority.mode,
+        "service_mode": "bot",
+        "transcription_provider": authority_request.transcription_provider,
+        "lifecycle_contract_version":
+            authority_request.lifecycle_contract_version,
+        "last_boundary_at": None,
+        "last_decision_id": authority_decision.decision_id,
+        "teardown_confirmed": False,
+    }
+
     if reused_row is not None:
         # continue_meeting reopens an EXISTING terminal row (no new active row inserted), so it is not
         # part of the fresh-insert TOCTOU window — but the per-user cap still applies (a continued run
@@ -327,6 +380,7 @@ async def request_bot(
                 "transcribe_enabled": transcribe_enabled,
                 "recording_enabled": recording_enabled,
                 "transcription_provider": transcription_provider,
+                "service_authority": authority_record,
             },
         )
     else:
@@ -337,6 +391,7 @@ async def request_bot(
         meeting_data["recording_enabled"] = recording_enabled
         if transcription_provider is not None:
             meeting_data["transcription_provider"] = transcription_provider
+        meeting_data["service_authority"] = authority_record
         # The serialization key for authenticated spawns — find_active_by_userdata matches on it.
         if authenticated and auth_userdata_path:
             meeting_data["auth_userdata_path"] = auth_userdata_path
@@ -366,7 +421,6 @@ async def request_bot(
     meeting_id = row["id"]
 
     # 4. MeetingToken + invocation. connection_id IS the session_uid (parent's connectionId).
-    connection_id = str(uuid.uuid4())
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")
     meeting_api_url = meeting_api_url or os.getenv("MEETING_API_URL", "http://meeting-api:8080")
     internal_secret = internal_secret if internal_secret is not None else os.getenv(

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -380,6 +380,36 @@
    "targets": []
   },
   {
+   "key": "VEXA_SERVICE_AUTHORITY_CONFIG",
+   "class": "defaulted",
+   "default": "(unset — explicit allow-all OSS behavior)",
+   "description": "JSON service-authority.v1 adapter config: credential-free endpoint URL, contract_version, timeout_ms, response_max_age_seconds, failure_policy=closed, and mode=enforce|observe. When set, unavailable or malformed authority decisions fail closed.",
+   "targets": [
+    "compose",
+    "helm",
+    "lite"
+   ]
+  },
+  {
+   "key": "VEXA_SERVICE_AUTHORITY_SECRET",
+   "class": "defaulted",
+   "default": "(unset — required when VEXA_SERVICE_AUTHORITY_CONFIG is set)",
+   "secret": true,
+   "description": "shared HMAC secret for exact-byte timestamped service-authority requests",
+   "targets": [
+    "compose",
+    "helm",
+    "lite"
+   ]
+  },
+  {
+   "key": "SERVICE_AUTHORITY_SWEEP_INTERVAL_S",
+   "class": "defaulted",
+   "default": "15",
+   "description": "poll cadence for due one-minute active-service decisions; boundary timestamps remain admitted_at + N minutes regardless of polling cadence",
+   "targets": []
+  },
+  {
    "key": "HOST",
    "class": "defaulted",
    "default": "0.0.0.0",

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/README.md
@@ -1,0 +1,13 @@
+# service_authority
+
+The meeting-api-owned, policy-free seam for asking an independently deployed
+authority whether one bot session may be admitted or continue through a
+one-minute service boundary.
+
+Public surface: `meeting_api.service_authority`.
+
+The module may depend on Python's standard library, `httpx`, the published
+`service-authority.v1` wire contract, and injected meeting/runtime ports. It
+must not know about payment providers, prices, balances, customer records, or
+hosted plan policy. With no authority configured it uses the explicit
+allow-all adapter, preserving the OSS self-hosted behavior.

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/__init__.py
@@ -1,0 +1,38 @@
+"""Public front door for the generic service-authority seam."""
+from .adapters import (
+    AllowAllServiceAuthority,
+    HttpServiceAuthority,
+    ServiceAuthorityConfig,
+    build_service_authority_from_env,
+)
+from .models import (
+    AUTHORITY_VERSION,
+    LIFECYCLE_CONTRACT_VERSION,
+    ServiceAuthorityDecision,
+    ServiceAuthorityRequest,
+)
+from .ports import (
+    ServiceAuthority,
+    ServiceAuthorityDenied,
+    ServiceAuthorityUnavailable,
+)
+from .sweep import (
+    ServiceAuthoritySweepObservation,
+    run_service_authority_sweep,
+)
+
+__all__ = [
+    "AUTHORITY_VERSION",
+    "LIFECYCLE_CONTRACT_VERSION",
+    "AllowAllServiceAuthority",
+    "HttpServiceAuthority",
+    "ServiceAuthority",
+    "ServiceAuthorityConfig",
+    "ServiceAuthorityDecision",
+    "ServiceAuthorityDenied",
+    "ServiceAuthorityRequest",
+    "ServiceAuthoritySweepObservation",
+    "ServiceAuthorityUnavailable",
+    "build_service_authority_from_env",
+    "run_service_authority_sweep",
+]

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/adapters.py
@@ -1,0 +1,252 @@
+"""Allow-all and signed HTTP adapters for service-authority.v1."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+import json
+import os
+import time
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Mapping, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from .models import (
+    AUTHORITY_VERSION,
+    ServiceAuthorityDecision,
+    ServiceAuthorityRequest,
+)
+from .ports import ServiceAuthorityUnavailable
+
+
+def _safe_url(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("service-authority URL is required")
+    try:
+        parsed = urlparse(value)
+        host = parsed.hostname
+    except ValueError as exc:
+        raise ValueError("service-authority URL is invalid") from exc
+    if (
+        not host
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError(
+            "service-authority URL must be a credential-free endpoint URL"
+        )
+    if parsed.scheme == "https":
+        return value
+    if parsed.scheme != "http":
+        raise ValueError("service-authority URL must use https")
+    lowered = host.lower()
+    loopback = lowered == "localhost"
+    try:
+        loopback = loopback or ipaddress.ip_address(lowered).is_loopback
+    except ValueError:
+        pass
+    in_cluster = (
+        "." not in lowered
+        or lowered.endswith(".svc")
+        or lowered.endswith(".svc.cluster.local")
+    )
+    if not (loopback or in_cluster):
+        raise ValueError(
+            "plain HTTP service-authority URL must be loopback or in-cluster"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class ServiceAuthorityConfig:
+    url: str
+    secret: str
+    timeout_seconds: float
+    response_max_age_seconds: float
+    mode: str
+    contract_version: str = AUTHORITY_VERSION
+    failure_policy: str = "closed"
+
+    def __post_init__(self) -> None:
+        _safe_url(self.url)
+        if not isinstance(self.secret, str) or not self.secret.strip():
+            raise ValueError("service-authority secret is required")
+        if self.contract_version != AUTHORITY_VERSION:
+            raise ValueError("unsupported service-authority contract_version")
+        if self.failure_policy != "closed":
+            raise ValueError(
+                "service-authority failure_policy must be closed"
+            )
+        if self.mode not in ("enforce", "observe"):
+            raise ValueError(
+                "service-authority mode must be enforce or observe"
+            )
+        if (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, (int, float))
+            or not (0 < self.timeout_seconds <= 30)
+        ):
+            raise ValueError(
+                "service-authority timeout must be within 0..30 seconds"
+            )
+        if (
+            isinstance(self.response_max_age_seconds, bool)
+            or not isinstance(self.response_max_age_seconds, (int, float))
+            or not (0 < self.response_max_age_seconds <= 300)
+        ):
+            raise ValueError(
+                "service-authority response age must be within 0..300 seconds"
+            )
+
+
+class AllowAllServiceAuthority:
+    """Explicit OSS default: no external authority is configured."""
+
+    configured = False
+    mode = "unconfigured"
+
+    async def decide(
+        self,
+        request: ServiceAuthorityRequest,
+    ) -> ServiceAuthorityDecision:
+        identity = hashlib.sha256(request.to_json_bytes()).hexdigest()
+        return ServiceAuthorityDecision(
+            authority_version=AUTHORITY_VERSION,
+            decision_id=f"service-authority:unconfigured:{identity}",
+            request_id=request.request_id,
+            service_identity=request.service_identity,
+            allow=True,
+            reason="unconfigured",
+            decided_at=datetime.now(timezone.utc),
+            enforced=False,
+        )
+
+
+class HttpServiceAuthority:
+    """Timestamp-sign exact request bytes and parse a request-bound decision."""
+
+    configured = True
+
+    def __init__(
+        self,
+        config: ServiceAuthorityConfig,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self.config = config
+        self.mode = config.mode
+        self._client = client
+
+    async def decide(
+        self,
+        request: ServiceAuthorityRequest,
+    ) -> ServiceAuthorityDecision:
+        body = request.to_json_bytes()
+        timestamp = str(int(time.time()))
+        digest = hmac.new(
+            self.config.secret.encode("utf-8"),
+            timestamp.encode("ascii") + b"." + body,
+            hashlib.sha256,
+        ).hexdigest()
+        headers = {
+            "Authorization": f"Bearer {self.config.secret}",
+            "Content-Type": "application/json",
+            "X-Webhook-Signature": f"sha256={digest}",
+            "X-Webhook-Timestamp": timestamp,
+        }
+        try:
+            if self._client is None:
+                async with httpx.AsyncClient(
+                    timeout=self.config.timeout_seconds,
+                ) as client:
+                    response = await client.post(
+                        self.config.url,
+                        content=body,
+                        headers=headers,
+                    )
+            else:
+                response = await self._client.post(
+                    self.config.url,
+                    content=body,
+                    headers=headers,
+                    timeout=self.config.timeout_seconds,
+                )
+            if response.status_code < 200 or response.status_code >= 300:
+                raise ValueError(
+                    f"authority returned HTTP {response.status_code}"
+                )
+            decision = ServiceAuthorityDecision.from_wire(
+                response.json(),
+                request=request,
+                now=datetime.now(timezone.utc),
+                max_age_seconds=self.config.response_max_age_seconds,
+                enforced=self.config.mode == "enforce",
+            )
+            return decision
+        except ServiceAuthorityUnavailable:
+            raise
+        except Exception as exc:
+            raise ServiceAuthorityUnavailable(
+                "configured service authority is unavailable"
+            ) from exc
+
+
+def build_service_authority_from_env(
+    env: Optional[Mapping[str, str]] = None,
+) -> AllowAllServiceAuthority | HttpServiceAuthority:
+    values = os.environ if env is None else env
+    raw = (values.get("VEXA_SERVICE_AUTHORITY_CONFIG") or "").strip()
+    if not raw:
+        return AllowAllServiceAuthority()
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            "VEXA_SERVICE_AUTHORITY_CONFIG must be valid JSON"
+        ) from exc
+    if not isinstance(body, dict):
+        raise ValueError(
+            "VEXA_SERVICE_AUTHORITY_CONFIG must be a JSON object"
+        )
+    allowed = {
+        "url",
+        "contract_version",
+        "timeout_ms",
+        "response_max_age_seconds",
+        "failure_policy",
+        "mode",
+    }
+    if set(body) - allowed:
+        raise ValueError(
+            "VEXA_SERVICE_AUTHORITY_CONFIG contains unknown fields"
+        )
+    secret = (values.get("VEXA_SERVICE_AUTHORITY_SECRET") or "").strip()
+    timeout_ms = body.get("timeout_ms", 2_000)
+    if (
+        isinstance(timeout_ms, bool)
+        or not isinstance(timeout_ms, (int, float))
+    ):
+        raise ValueError(
+            "service-authority timeout_ms must be numeric"
+        )
+    config = ServiceAuthorityConfig(
+        url=body.get("url"),
+        secret=secret,
+        timeout_seconds=timeout_ms / 1_000,
+        response_max_age_seconds=body.get(
+            "response_max_age_seconds",
+            30,
+        ),
+        mode=body.get("mode", "enforce"),
+        contract_version=body.get(
+            "contract_version",
+            AUTHORITY_VERSION,
+        ),
+        failure_policy=body.get("failure_policy", "closed"),
+    )
+    return HttpServiceAuthority(config)

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/models.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/models.py
@@ -1,0 +1,276 @@
+"""Language-neutral service-authority.v1 values at the Python boundary."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping, Optional
+
+
+AUTHORITY_VERSION = "service-authority.v1"
+LIFECYCLE_CONTRACT_VERSION = "2026-07-28"
+Action = Literal["admit", "continue"]
+TranscriptionProvider = Literal["vexa", "customer", "none"]
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("service-authority timestamps must include a timezone")
+    return value.astimezone(timezone.utc)
+
+
+def _wire_time(value: datetime) -> str:
+    return _utc(value).isoformat()
+
+
+def parse_time(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be an ISO timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO timestamp") from exc
+    return _utc(parsed)
+
+
+@dataclass(frozen=True)
+class ServiceAuthorityRequest:
+    user_id: int
+    action: Action
+    request_id: str
+    service_identity: str
+    service_mode: Literal["bot"]
+    transcription_provider: TranscriptionProvider
+    lifecycle_contract_version: str
+    active_concurrency: int
+    admitted_at: Optional[datetime] = None
+    boundary_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.user_id, bool)
+            or not isinstance(self.user_id, int)
+            or self.user_id <= 0
+        ):
+            raise ValueError("user_id must be a positive integer")
+        if self.action not in ("admit", "continue"):
+            raise ValueError("unsupported service-authority action")
+        if (
+            not isinstance(self.request_id, str)
+            or not self.request_id.strip()
+            or not isinstance(self.service_identity, str)
+            or not self.service_identity.strip()
+        ):
+            raise ValueError("service-authority request identity is required")
+        if self.service_mode != "bot":
+            raise ValueError("unsupported service mode")
+        if self.transcription_provider not in ("vexa", "customer", "none"):
+            raise ValueError("unsupported transcription provider")
+        if self.lifecycle_contract_version != LIFECYCLE_CONTRACT_VERSION:
+            raise ValueError("unsupported lifecycle contract version")
+        if (
+            isinstance(self.active_concurrency, bool)
+            or not isinstance(self.active_concurrency, int)
+            or self.active_concurrency < 0
+        ):
+            raise ValueError("active_concurrency must be a non-negative integer")
+        if self.action == "admit" and (
+            self.admitted_at is not None or self.boundary_at is not None
+        ):
+            raise ValueError("admission cannot carry active-service timestamps")
+        if self.action == "continue" and (
+            self.admitted_at is None or self.boundary_at is None
+        ):
+            raise ValueError("continuation requires admitted_at and boundary_at")
+        if self.admitted_at is not None:
+            _utc(self.admitted_at)
+        if self.boundary_at is not None:
+            _utc(self.boundary_at)
+        if (
+            self.admitted_at is not None
+            and self.boundary_at is not None
+            and self.boundary_at < self.admitted_at
+        ):
+            raise ValueError("service boundary precedes admission")
+
+    @classmethod
+    def admit(
+        cls,
+        *,
+        user_id: int,
+        request_id: str,
+        service_identity: str,
+        transcription_provider: TranscriptionProvider,
+        active_concurrency: int,
+    ) -> "ServiceAuthorityRequest":
+        return cls(
+            user_id=user_id,
+            action="admit",
+            request_id=request_id,
+            service_identity=service_identity,
+            service_mode="bot",
+            transcription_provider=transcription_provider,
+            lifecycle_contract_version=LIFECYCLE_CONTRACT_VERSION,
+            active_concurrency=active_concurrency,
+        )
+
+    @classmethod
+    def continuation(
+        cls,
+        *,
+        user_id: int,
+        request_id: str,
+        service_identity: str,
+        transcription_provider: TranscriptionProvider,
+        active_concurrency: int,
+        admitted_at: datetime,
+        boundary_at: datetime,
+    ) -> "ServiceAuthorityRequest":
+        return cls(
+            user_id=user_id,
+            action="continue",
+            request_id=request_id,
+            service_identity=service_identity,
+            service_mode="bot",
+            transcription_provider=transcription_provider,
+            lifecycle_contract_version=LIFECYCLE_CONTRACT_VERSION,
+            active_concurrency=active_concurrency,
+            admitted_at=admitted_at,
+            boundary_at=boundary_at,
+        )
+
+    def to_wire(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "user_id": self.user_id,
+            "action": self.action,
+            "request_id": self.request_id,
+            "service_identity": self.service_identity,
+            "service_mode": self.service_mode,
+            "transcription_provider": self.transcription_provider,
+            "lifecycle_contract_version": self.lifecycle_contract_version,
+            "active_concurrency": self.active_concurrency,
+        }
+        if self.action == "continue":
+            body["admitted_at"] = _wire_time(self.admitted_at)  # type: ignore[arg-type]
+            body["boundary_at"] = _wire_time(self.boundary_at)  # type: ignore[arg-type]
+        return body
+
+    def to_json_bytes(self) -> bytes:
+        return json.dumps(
+            self.to_wire(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+
+_DECISION_KEYS = frozenset({
+    "authority_version",
+    "decision_id",
+    "request_id",
+    "service_identity",
+    "allow",
+    "reason",
+    "decided_at",
+    "stop_scope",
+})
+
+
+@dataclass(frozen=True)
+class ServiceAuthorityDecision:
+    authority_version: str
+    decision_id: str
+    request_id: str
+    service_identity: str
+    allow: bool
+    reason: str
+    decided_at: datetime
+    stop_scope: Optional[Literal["billable_service"]] = None
+    enforced: bool = True
+
+    def __post_init__(self) -> None:
+        if self.authority_version != AUTHORITY_VERSION:
+            raise ValueError("unsupported service-authority response version")
+        identity_fields = (
+            self.decision_id,
+            self.request_id,
+            self.service_identity,
+            self.reason,
+        )
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in identity_fields
+        ):
+            raise ValueError("service-authority decision identity is incomplete")
+        if not isinstance(self.allow, bool):
+            raise ValueError("service-authority allow must be boolean")
+        if self.stop_scope not in (None, "billable_service"):
+            raise ValueError("unsupported service-authority stop scope")
+        if self.allow and self.stop_scope is not None:
+            raise ValueError("an allowed decision cannot carry a stop scope")
+        _utc(self.decided_at)
+
+    @classmethod
+    def from_wire(
+        cls,
+        value: Any,
+        *,
+        request: ServiceAuthorityRequest,
+        now: datetime,
+        max_age_seconds: float,
+        enforced: bool = True,
+    ) -> "ServiceAuthorityDecision":
+        if not isinstance(value, Mapping):
+            raise ValueError("service-authority response must be an object")
+        if set(value) - _DECISION_KEYS:
+            raise ValueError("service-authority response contains unknown fields")
+        required = _DECISION_KEYS - {"stop_scope"}
+        if any(key not in value for key in required):
+            raise ValueError("service-authority response is incomplete")
+        decided_at = parse_time(value["decided_at"], "decided_at")
+        observed = _utc(now)
+        if abs((observed - decided_at).total_seconds()) > max_age_seconds:
+            raise ValueError("service-authority response is stale")
+        decision = cls(
+            authority_version=value["authority_version"],
+            decision_id=value["decision_id"],
+            request_id=value["request_id"],
+            service_identity=value["service_identity"],
+            allow=value["allow"],
+            reason=value["reason"],
+            decided_at=decided_at,
+            stop_scope=value.get("stop_scope"),
+            enforced=enforced,
+        )
+        if (
+            decision.request_id != request.request_id
+            or decision.service_identity != request.service_identity
+        ):
+            raise ValueError(
+                "service-authority response is bound to another request"
+            )
+        if request.action == "admit" and decision.stop_scope is not None:
+            raise ValueError(
+                "an admission decision cannot carry a stop scope"
+            )
+        if (
+            request.action == "continue"
+            and not decision.allow
+            and decision.stop_scope != "billable_service"
+        ):
+            raise ValueError(
+                "a denied continuation must stop billable service"
+            )
+        return decision
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "authority_version": self.authority_version,
+            "decision_id": self.decision_id,
+            "request_id": self.request_id,
+            "service_identity": self.service_identity,
+            "allow": self.allow,
+            "reason": self.reason,
+            "decided_at": _wire_time(self.decided_at),
+            "stop_scope": self.stop_scope,
+            "enforced": self.enforced,
+        }

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/ports.py
@@ -1,0 +1,31 @@
+"""In-process ports consumed by the service-authority application logic."""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .models import ServiceAuthorityDecision, ServiceAuthorityRequest
+
+
+@runtime_checkable
+class ServiceAuthority(Protocol):
+    configured: bool
+    mode: str
+
+    async def decide(
+        self,
+        request: ServiceAuthorityRequest,
+    ) -> ServiceAuthorityDecision:
+        ...
+
+
+class ServiceAuthorityDenied(Exception):
+    """A configured authority returned an enforced deny."""
+
+    def __init__(self, reason: str, decision_id: str) -> None:
+        self.reason = reason
+        self.decision_id = decision_id
+        super().__init__(reason)
+
+
+class ServiceAuthorityUnavailable(Exception):
+    """A configured authority could not return a trustworthy decision."""

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/sweep.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/sweep.py
@@ -1,0 +1,191 @@
+"""Durable one-minute continuation decisions and teardown application."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+from uuid import uuid4
+
+from ..bot_spawn.ports import WorkloadUnknown
+from .models import (
+    AUTHORITY_VERSION,
+    ServiceAuthorityDecision,
+    ServiceAuthorityRequest,
+    parse_time,
+)
+from .ports import ServiceAuthority, ServiceAuthorityUnavailable
+
+
+@dataclass(frozen=True)
+class ServiceAuthoritySweepObservation:
+    decisions: int = 0
+    teardowns_confirmed: int = 0
+    faults: int = 0
+
+
+def _admitted_at(row: dict[str, Any]) -> Optional[datetime]:
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    transitions = data.get("status_transition")
+    if not isinstance(transitions, list):
+        return None
+    for item in reversed(transitions):
+        if (
+            isinstance(item, dict)
+            and item.get("to") == "active"
+            and item.get("timestamp_source") == "producer"
+        ):
+            try:
+                return parse_time(item.get("timestamp"), "bot admission")
+            except ValueError:
+                return None
+    return None
+
+
+def _unavailable_decision(
+    request: ServiceAuthorityRequest,
+    now: datetime,
+) -> ServiceAuthorityDecision:
+    digest = hashlib.sha256(request.to_json_bytes()).hexdigest()
+    return ServiceAuthorityDecision(
+        authority_version=AUTHORITY_VERSION,
+        decision_id=f"service-authority:unavailable:{digest}",
+        request_id=request.request_id,
+        service_identity=request.service_identity,
+        allow=False,
+        reason="service_authority_unavailable",
+        decided_at=now,
+        stop_scope="billable_service",
+    )
+
+
+async def run_service_authority_sweep(
+    repo,
+    runtime,
+    authority: ServiceAuthority,
+    *,
+    now: Optional[datetime] = None,
+) -> ServiceAuthoritySweepObservation:
+    """Process every due minute in order, then converge pending stops.
+
+    The repository persists a response before the external teardown. A crash
+    before the teardown therefore leaves a visible pending intent that the next
+    sweep resumes; a confirmed teardown is never invoked again.
+    """
+    if not authority.configured:
+        return ServiceAuthoritySweepObservation()
+    observed_at = (now or datetime.now(timezone.utc)).astimezone(
+        timezone.utc
+    )
+    decisions = 0
+    teardowns = 0
+    faults = 0
+
+    sessions = await repo.list_service_authority_sessions()
+    for row in sessions:
+        metadata = (
+            row.get("data", {}).get("service_authority")
+            if isinstance(row.get("data"), dict)
+            else None
+        )
+        if not isinstance(metadata, dict):
+            continue
+        # The admission mode is frozen with the delivered service.  Unconfigured
+        # OSS sessions never become externally controlled merely because a
+        # later deployment enables an authority, and an observe→enforce rollout
+        # cannot retroactively turn an observed session into a hard-cap claim.
+        if metadata.get("mode") != authority.mode:
+            faults += 1
+            continue
+        admitted_at = _admitted_at(row)
+        if admitted_at is None:
+            faults += 1
+            continue
+        last_raw = metadata.get("last_boundary_at")
+        try:
+            last_boundary = (
+                parse_time(last_raw, "last service boundary")
+                if last_raw
+                else admitted_at
+            )
+        except ValueError:
+            faults += 1
+            continue
+        boundary = last_boundary + timedelta(minutes=1)
+        while boundary <= observed_at:
+            service_identity = metadata.get("service_identity")
+            provider = metadata.get("transcription_provider")
+            if (
+                not isinstance(service_identity, str)
+                or provider not in ("vexa", "customer", "none")
+            ):
+                faults += 1
+                break
+            request_id = (
+                f"{service_identity}:continue:"
+                f"{boundary.isoformat()}"
+            )
+            active = await repo.count_active_bots(
+                user_id=row["user_id"],
+            )
+            request = ServiceAuthorityRequest.continuation(
+                user_id=row["user_id"],
+                request_id=request_id,
+                service_identity=service_identity,
+                transcription_provider=provider,
+                active_concurrency=active,
+                admitted_at=admitted_at,
+                boundary_at=boundary,
+            )
+            try:
+                decision = await authority.decide(request)
+            except ServiceAuthorityUnavailable:
+                decision = _unavailable_decision(request, observed_at)
+                faults += 1
+            recorded = await repo.record_service_authority_decision(
+                meeting_id=row["id"],
+                request=request,
+                decision=decision,
+            )
+            if recorded:
+                decisions += 1
+            if decision.enforced and not decision.allow:
+                break
+            boundary += timedelta(minutes=1)
+
+    for pending in await repo.list_service_authority_teardowns():
+        claim = await repo.claim_service_authority_teardown(
+            meeting_id=pending["id"],
+            claim_id=f"service-authority-teardown:{uuid4()}",
+            claimed_at=observed_at,
+            lease_seconds=60,
+        )
+        if claim is None:
+            continue
+        workload_id = claim.get("bot_container_id")
+        if not workload_id:
+            faults += 1
+            continue
+        try:
+            await runtime.delete_workload(workload_id)
+        except WorkloadUnknown:
+            # The requested workload is already absent.  This is the desired
+            # terminal runtime state, so converge the durable stop intent
+            # instead of retrying an impossible deletion forever.
+            pass
+        except Exception:
+            faults += 1
+            continue
+        confirmed = await repo.confirm_service_authority_teardown(
+            meeting_id=claim["id"],
+            decision_id=claim["decision_id"],
+            claim_id=claim["claim_id"],
+        )
+        if confirmed:
+            teardowns += 1
+
+    return ServiceAuthoritySweepObservation(
+        decisions=decisions,
+        teardowns_confirmed=teardowns,
+        faults=faults,
+    )

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/sweep.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/sweep.py
@@ -169,10 +169,12 @@ async def run_service_authority_sweep(
         try:
             await runtime.delete_workload(workload_id)
         except WorkloadUnknown:
-            # The requested workload is already absent.  This is the desired
-            # terminal runtime state, so converge the durable stop intent
-            # instead of retrying an impossible deletion forever.
-            pass
+            # Runtime 404 means UNTRACKED, not destroyed: a recreated runtime
+            # can forget a still-live external workload.  Keep the durable stop
+            # pending so re-adoption or another positive teardown can confirm
+            # it after the claim lease expires.
+            faults += 1
+            continue
         except Exception:
             faults += 1
             continue

--- a/core/meetings/services/meeting-api/tests/test_service_authority.py
+++ b/core/meetings/services/meeting-api/tests/test_service_authority.py
@@ -455,7 +455,7 @@ async def test_active_boundary_deny_tears_down_once_and_restart_replays_none() -
 
 
 @pytest.mark.asyncio
-async def test_active_boundary_absent_workload_converges_stop_once() -> None:
+async def test_active_boundary_untracked_workload_stays_pending_then_recovers() -> None:
     authority = RecordingAuthority(
         continuation=_decision(
             allow=False,
@@ -484,16 +484,51 @@ async def test_active_boundary_absent_workload_converges_stop_once() -> None:
         authority,
         now=ADMITTED_AT + timedelta(minutes=1, seconds=1),
     )
+    pending_after_untracked = dict(
+        row["data"]["service_authority"],
+    )
     replay = await run_service_authority_sweep(
         repo,
         runtime,
         authority,
         now=ADMITTED_AT + timedelta(minutes=1, seconds=20),
     )
+    pending_after_replay = dict(row["data"]["service_authority"])
+    runtime._workloads[row["bot_container_id"]] = {
+        "workloadId": row["bot_container_id"],
+        "state": "running",
+    }
+    recovered = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=2, seconds=2),
+    )
+    inert = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=2, seconds=20),
+    )
 
     assert observed.decisions == 1
-    assert observed.teardowns_confirmed == 1
+    assert observed.teardowns_confirmed == 0
+    assert observed.faults == 1
+    assert pending_after_untracked["teardown_confirmed"] is False
+    assert pending_after_untracked["teardown_claim_id"]
     assert replay.decisions == 0
+    assert replay.teardowns_confirmed == 0
+    assert pending_after_replay["teardown_confirmed"] is False
+    assert (
+        pending_after_replay["teardown_claim_id"]
+        == pending_after_untracked["teardown_claim_id"]
+    )
+    assert recovered.decisions == 0
+    assert recovered.teardowns_confirmed == 1
+    assert recovered.faults == 0
+    assert inert.decisions == 0
+    assert inert.teardowns_confirmed == 0
+    assert len(runtime.deleted) == 1
     assert row["data"]["service_authority"]["teardown_confirmed"] is True
 
 

--- a/core/meetings/services/meeting-api/tests/test_service_authority.py
+++ b/core/meetings/services/meeting-api/tests/test_service_authority.py
@@ -1,0 +1,767 @@
+"""Acceptance oracle for the opt-in generic service-authority seam (#988).
+
+The fixture owns no hosted policy.  It proves only that meeting-api asks a
+versioned authority before effects, preserves the decision identity, and
+applies a continuation stop exactly once at a one-minute boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from meeting_api import create_app
+from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
+from meeting_api.bot_spawn.service import request_bot
+from meeting_api.service_authority import (
+    AllowAllServiceAuthority,
+    HttpServiceAuthority,
+    ServiceAuthorityConfig,
+    ServiceAuthorityDecision,
+    ServiceAuthorityDenied,
+    ServiceAuthorityRequest,
+    ServiceAuthorityUnavailable,
+    build_service_authority_from_env,
+    run_service_authority_sweep,
+)
+from meeting_api.webhooks.delivery import clean_meeting_data
+
+
+UTC = timezone.utc
+ADMITTED_AT = datetime(2026, 7, 29, 8, 0, tzinfo=UTC)
+
+
+class RecordingAuthority:
+    configured = True
+    mode = "enforce"
+
+    def __init__(
+        self,
+        *,
+        admit: ServiceAuthorityDecision | Exception | None = None,
+        continuation: ServiceAuthorityDecision | Exception | None = None,
+        mode: str = "enforce",
+    ) -> None:
+        self.mode = mode
+        self.admit = admit or _decision(allow=True, action="admit")
+        self.continuation = continuation or _decision(
+            allow=True,
+            action="continue",
+        )
+        self.requests: list[ServiceAuthorityRequest] = []
+
+    async def decide(
+        self,
+        request: ServiceAuthorityRequest,
+    ) -> ServiceAuthorityDecision:
+        self.requests.append(request)
+        result = self.admit if request.action == "admit" else self.continuation
+        if isinstance(result, Exception):
+            raise result
+        return replace(
+            result,
+            request_id=request.request_id,
+            service_identity=request.service_identity,
+            enforced=self.mode == "enforce",
+        )
+
+
+def _decision(
+    *,
+    allow: bool,
+    action: str,
+    reason: str = "allowed",
+    decision_id: str | None = None,
+    stop_scope: str | None = None,
+) -> ServiceAuthorityDecision:
+    return ServiceAuthorityDecision(
+        authority_version="service-authority.v1",
+        decision_id=decision_id or f"decision-{action}-{reason}",
+        request_id="fixture-request",
+        service_identity="fixture-service",
+        allow=allow,
+        reason=reason,
+        decided_at=datetime.now(UTC),
+        stop_scope=stop_scope,
+    )
+
+
+async def _spawn(
+    authority,
+    *,
+    repo: InMemoryMeetingRepo | None = None,
+    runtime: FakeRuntimeClient | None = None,
+):
+    repo = repo or InMemoryMeetingRepo()
+    runtime = runtime or FakeRuntimeClient()
+    result = await request_bot(
+        repo,
+        runtime,
+        authority=authority,
+        user_id=41,
+        platform="google_meet",
+        native_meeting_id="authority-fixture",
+        transcribe_enabled=False,
+        recording_enabled=False,
+        token_secret="fixture-token-secret",
+    )
+    return repo, runtime, result
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_allow_all_preserves_stock_spawn() -> None:
+    repo, runtime, result = await _spawn(AllowAllServiceAuthority())
+
+    assert result["status"] == "requested"
+    assert len(repo._meetings) == 1
+    assert len(runtime.specs) == 1
+    authority = repo._meetings[result["id"]]["data"]["service_authority"]
+    assert authority["authority_version"] == "service-authority.v1"
+    assert authority["mode"] == "unconfigured"
+
+    row = repo._meetings[result["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+    configured_later = RecordingAuthority(
+        continuation=_decision(
+            allow=False,
+            action="continue",
+            reason="opaque_limit",
+            stop_scope="billable_service",
+        ),
+    )
+    observation = await run_service_authority_sweep(
+        repo,
+        runtime,
+        configured_later,
+        now=ADMITTED_AT + timedelta(minutes=1, seconds=1),
+    )
+    assert observation.decisions == 0
+    assert configured_later.requests == []
+    assert runtime.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_frozen_service_identity_survives_privacy_safe_completion_projection() -> None:
+    authority = RecordingAuthority()
+    repo, _runtime, meeting = await _spawn(authority)
+    stored = repo._meetings[meeting["id"]]["data"]
+
+    projected = clean_meeting_data(stored)
+
+    assert projected["service_authority"]["service_identity"].startswith(
+        "meeting-session:",
+    )
+    assert projected["service_authority"]["decision_id"].startswith(
+        "decision-admit-",
+    )
+    serialized = json.dumps(projected)
+    assert "fixture-authority-secret" not in serialized
+    assert "transcription_service_url" not in serialized
+    assert "transcription_service_token" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_deny_happens_before_any_meeting_or_runtime_effect() -> None:
+    authority = RecordingAuthority(
+        admit=_decision(
+            allow=False,
+            action="admit",
+            reason="opaque_limit",
+            decision_id="decision-deny-41",
+        ),
+    )
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient()
+
+    with pytest.raises(ServiceAuthorityDenied) as caught:
+        await _spawn(authority, repo=repo, runtime=runtime)
+
+    assert caught.value.reason == "opaque_limit"
+    assert caught.value.decision_id == "decision-deny-41"
+    assert repo._meetings == {}
+    assert runtime.specs == []
+
+    outbound = authority.requests[0].to_wire()
+    assert set(outbound) == {
+        "user_id",
+        "action",
+        "request_id",
+        "service_identity",
+        "service_mode",
+        "transcription_provider",
+        "lifecycle_contract_version",
+        "active_concurrency",
+    }
+    forbidden = {
+        "email",
+        "stripe_customer_id",
+        "price",
+        "balance",
+        "transcription_url",
+        "credential",
+        "secret",
+    }
+    assert forbidden.isdisjoint(outbound)
+
+
+@pytest.mark.asyncio
+async def test_configured_unavailable_fails_before_effects() -> None:
+    authority = RecordingAuthority(
+        admit=ServiceAuthorityUnavailable("fixture authority unavailable"),
+    )
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient()
+
+    with pytest.raises(ServiceAuthorityUnavailable):
+        await _spawn(authority, repo=repo, runtime=runtime)
+
+    assert repo._meetings == {}
+    assert runtime.specs == []
+
+
+def test_http_deny_is_typed_and_preserves_opaque_identity() -> None:
+    authority = RecordingAuthority(
+        admit=_decision(
+            allow=False,
+            action="admit",
+            reason="opaque_limit",
+            decision_id="decision-http-deny-41",
+        ),
+    )
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient()
+    client = TestClient(create_app(
+        meeting_repo=repo,
+        runtime=runtime,
+        service_authority=authority,
+        token_secret="fixture-token-secret",
+    ))
+
+    response = client.post(
+        "/bots",
+        headers={"x-user-id": "41"},
+        json={
+            "platform": "google_meet",
+            "native_meeting_id": "authority-http-deny",
+            "transcribe_enabled": False,
+            "recording_enabled": False,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": {
+            "code": "service_not_allowed",
+            "reason": "opaque_limit",
+            "decision_id": "decision-http-deny-41",
+        },
+    }
+    assert repo._meetings == {}
+    assert runtime.specs == []
+
+
+@pytest.mark.asyncio
+async def test_http_adapter_signs_exact_bytes_and_binds_fresh_response() -> None:
+    secret = "fixture-authority-secret"
+    captured: list[bytes] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        body = await request.aread()
+        captured.append(body)
+        timestamp = request.headers["x-webhook-timestamp"]
+        expected = hmac.new(
+            secret.encode(),
+            timestamp.encode() + b"." + body,
+            hashlib.sha256,
+        ).hexdigest()
+        assert request.headers["x-webhook-signature"] == f"sha256={expected}"
+        payload = json.loads(body)
+        return httpx.Response(
+            200,
+            json={
+                "authority_version": "service-authority.v1",
+                "decision_id": "decision-http-1",
+                "request_id": payload["request_id"],
+                "service_identity": payload["service_identity"],
+                "allow": True,
+                "reason": "allowed",
+                "decided_at": datetime.now(UTC).isoformat(),
+                "stop_scope": None,
+            },
+        )
+
+    config = ServiceAuthorityConfig(
+        url="http://service-authority:3000/api/internal/service-authority",
+        secret=secret,
+        timeout_seconds=2,
+        response_max_age_seconds=30,
+        mode="enforce",
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        authority = HttpServiceAuthority(config, client=client)
+        request = ServiceAuthorityRequest.admit(
+            user_id=41,
+            request_id="request-http-1",
+            service_identity="meeting-session-http-1",
+            transcription_provider="customer",
+            active_concurrency=0,
+        )
+        result = await authority.decide(request)
+
+    assert result.allow is True
+    assert result.request_id == request.request_id
+    assert result.service_identity == request.service_identity
+    assert captured == [request.to_json_bytes()]
+
+
+@pytest.mark.asyncio
+async def test_http_adapter_rejects_stale_or_cross_bound_response() -> None:
+    request = ServiceAuthorityRequest.admit(
+        user_id=41,
+        request_id="request-http-2",
+        service_identity="meeting-session-http-2",
+        transcription_provider="none",
+        active_concurrency=0,
+    )
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "authority_version": "service-authority.v1",
+                "decision_id": "decision-stale",
+                "request_id": "another-request",
+                "service_identity": request.service_identity,
+                "allow": True,
+                "reason": "allowed",
+                "decided_at": (
+                    datetime.now(UTC) - timedelta(minutes=5)
+                ).isoformat(),
+            },
+        )
+
+    config = ServiceAuthorityConfig(
+        url="http://service-authority:3000/api/internal/service-authority",
+        secret="fixture-secret",
+        timeout_seconds=2,
+        response_max_age_seconds=30,
+        mode="enforce",
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        with pytest.raises(ServiceAuthorityUnavailable):
+            await HttpServiceAuthority(config, client=client).decide(request)
+
+
+@pytest.mark.asyncio
+async def test_http_adapter_rejects_denied_continuation_without_stop_scope() -> None:
+    request = ServiceAuthorityRequest.continuation(
+        user_id=41,
+        request_id="request-http-stop",
+        service_identity="meeting-session-http-stop",
+        transcription_provider="none",
+        active_concurrency=1,
+        admitted_at=ADMITTED_AT,
+        boundary_at=ADMITTED_AT + timedelta(minutes=1),
+    )
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "authority_version": "service-authority.v1",
+                "decision_id": "decision-missing-stop",
+                "request_id": request.request_id,
+                "service_identity": request.service_identity,
+                "allow": False,
+                "reason": "opaque_limit",
+                "decided_at": datetime.now(UTC).isoformat(),
+            },
+        )
+
+    config = ServiceAuthorityConfig(
+        url="http://service-authority:3000/api/internal/service-authority",
+        secret="fixture-secret",
+        timeout_seconds=2,
+        response_max_age_seconds=30,
+        mode="enforce",
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        with pytest.raises(ServiceAuthorityUnavailable):
+            await HttpServiceAuthority(config, client=client).decide(request)
+
+
+@pytest.mark.asyncio
+async def test_active_boundary_deny_tears_down_once_and_restart_replays_none() -> None:
+    authority = RecordingAuthority(
+        continuation=_decision(
+            allow=False,
+            action="continue",
+            reason="opaque_limit",
+            decision_id="decision-stop-41",
+            stop_scope="billable_service",
+        ),
+    )
+    repo, runtime, meeting = await _spawn(authority)
+    row = repo._meetings[meeting["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+
+    observed = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=1, seconds=1),
+    )
+    replay = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=1, seconds=20),
+    )
+
+    assert observed.decisions == 1
+    assert observed.teardowns_confirmed == 1
+    assert replay.decisions == 0
+    assert replay.teardowns_confirmed == 0
+    assert len(runtime.deleted) == 1
+    persisted = row["data"]["service_authority"]
+    assert persisted["last_decision_id"] == "decision-stop-41"
+    assert persisted["last_boundary_at"] == (
+        ADMITTED_AT + timedelta(minutes=1)
+    ).isoformat()
+    assert persisted["teardown_confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_active_boundary_absent_workload_converges_stop_once() -> None:
+    authority = RecordingAuthority(
+        continuation=_decision(
+            allow=False,
+            action="continue",
+            reason="opaque_limit",
+            decision_id="decision-stop-absent",
+            stop_scope="billable_service",
+        ),
+    )
+    runtime = FakeRuntimeClient(workloads={})
+    repo, _runtime, meeting = await _spawn(
+        authority,
+        runtime=runtime,
+    )
+    row = repo._meetings[meeting["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+
+    observed = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=1, seconds=1),
+    )
+    replay = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=1, seconds=20),
+    )
+
+    assert observed.decisions == 1
+    assert observed.teardowns_confirmed == 1
+    assert replay.decisions == 0
+    assert row["data"]["service_authority"]["teardown_confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_active_boundary_unavailable_fails_closed_and_stops() -> None:
+    authority = RecordingAuthority(
+        continuation=ServiceAuthorityUnavailable("fixture outage"),
+    )
+    repo, runtime, meeting = await _spawn(authority)
+    row = repo._meetings[meeting["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+
+    observed = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=1, seconds=1),
+    )
+
+    persisted = row["data"]["service_authority"]
+    assert observed.decisions == 1
+    assert observed.teardowns_confirmed == 1
+    assert observed.faults == 1
+    assert persisted["reason"] == "service_authority_unavailable"
+    assert persisted["stop_scope"] == "billable_service"
+    assert persisted["teardown_confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_two_sweep_workers_apply_one_claimed_teardown() -> None:
+    class SlowRuntime(FakeRuntimeClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def delete_workload(self, workload_id: str) -> None:
+            self.entered.set()
+            await self.release.wait()
+            await super().delete_workload(workload_id)
+
+    authority = RecordingAuthority(
+        continuation=_decision(
+            allow=False,
+            action="continue",
+            reason="opaque_limit",
+            decision_id="decision-concurrent-stop",
+            stop_scope="billable_service",
+        ),
+    )
+    runtime = SlowRuntime()
+    repo, _runtime, meeting = await _spawn(authority, runtime=runtime)
+    row = repo._meetings[meeting["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+    observed_at = ADMITTED_AT + timedelta(minutes=1, seconds=1)
+
+    first_task = asyncio.create_task(run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=observed_at,
+    ))
+    await runtime.entered.wait()
+    second = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=observed_at,
+    )
+    runtime.release.set()
+    first = await first_task
+
+    assert first.teardowns_confirmed == 1
+    assert second.teardowns_confirmed == 0
+    assert runtime.deleted == [row["bot_container_id"]]
+    assert row["data"]["service_authority"]["teardown_confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_expired_teardown_claim_recovers_after_worker_crash() -> None:
+    authority = RecordingAuthority(
+        continuation=_decision(
+            allow=False,
+            action="continue",
+            reason="opaque_limit",
+            decision_id="decision-crash-stop",
+            stop_scope="billable_service",
+        ),
+    )
+    repo, runtime, meeting = await _spawn(authority)
+    row = repo._meetings[meeting["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+    first_boundary = ADMITTED_AT + timedelta(minutes=1)
+    decision = replace(
+        authority.continuation,
+        request_id=f"{row['data']['service_authority']['service_identity']}"
+        f":continue:{first_boundary.isoformat()}",
+        service_identity=row["data"]["service_authority"]["service_identity"],
+    )
+    request = ServiceAuthorityRequest.continuation(
+        user_id=row["user_id"],
+        request_id=decision.request_id,
+        service_identity=decision.service_identity,
+        transcription_provider="none",
+        active_concurrency=1,
+        admitted_at=ADMITTED_AT,
+        boundary_at=first_boundary,
+    )
+    assert await repo.record_service_authority_decision(
+        meeting_id=row["id"],
+        request=request,
+        decision=decision,
+    )
+    crashed_claim = await repo.claim_service_authority_teardown(
+        meeting_id=row["id"],
+        claim_id="crashed-worker",
+        claimed_at=first_boundary,
+        lease_seconds=60,
+    )
+    assert crashed_claim is not None
+
+    recovered = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=first_boundary + timedelta(seconds=61),
+    )
+
+    assert recovered.teardowns_confirmed == 1
+    assert runtime.deleted == [row["bot_container_id"]]
+    assert row["data"]["service_authority"]["teardown_confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_observe_only_denial_never_claims_or_applies_hard_stop() -> None:
+    authority = RecordingAuthority(
+        mode="observe",
+        continuation=_decision(
+            allow=False,
+            action="continue",
+            reason="opaque_limit",
+            decision_id="decision-observe-only",
+            stop_scope="billable_service",
+        ),
+    )
+    repo, runtime, meeting = await _spawn(authority)
+    row = repo._meetings[meeting["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+
+    observed = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=1, seconds=1),
+    )
+
+    persisted = row["data"]["service_authority"]
+    assert observed.decisions == 1
+    assert observed.teardowns_confirmed == 0
+    assert persisted["enforced"] is False
+    assert persisted["teardown_confirmed"] is False
+    assert row["status"] == "active"
+    assert runtime.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_sweep_catches_up_every_boundary_and_restart_skips_none() -> None:
+    authority = RecordingAuthority()
+    repo, runtime, meeting = await _spawn(authority)
+    row = repo._meetings[meeting["id"]]
+    row["status"] = "active"
+    row["data"]["status_transition"] = [{
+        "to": "active",
+        "timestamp": ADMITTED_AT.isoformat(),
+        "timestamp_source": "producer",
+    }]
+
+    first = await run_service_authority_sweep(
+        repo,
+        runtime,
+        authority,
+        now=ADMITTED_AT + timedelta(minutes=3, seconds=1),
+    )
+    restarted_authority = RecordingAuthority()
+    second = await run_service_authority_sweep(
+        repo,
+        runtime,
+        restarted_authority,
+        now=ADMITTED_AT + timedelta(minutes=4, seconds=1),
+    )
+
+    assert first.decisions == 3
+    assert second.decisions == 1
+    boundaries = [
+        request.boundary_at
+        for request in authority.requests
+        if request.action == "continue"
+    ] + [
+        request.boundary_at
+        for request in restarted_authority.requests
+        if request.action == "continue"
+    ]
+    assert boundaries == [
+        ADMITTED_AT + timedelta(minutes=minute)
+        for minute in (1, 2, 3, 4)
+    ]
+    assert runtime.deleted == []
+
+
+def test_config_is_explicit_and_fail_closed_when_enabled() -> None:
+    assert isinstance(
+        build_service_authority_from_env({}),
+        AllowAllServiceAuthority,
+    )
+
+    with pytest.raises(ValueError, match="secret"):
+        build_service_authority_from_env({
+            "VEXA_SERVICE_AUTHORITY_CONFIG": json.dumps({
+                "url": "https://authority.example.test/check",
+                "contract_version": "service-authority.v1",
+                "timeout_ms": 2_000,
+                "response_max_age_seconds": 30,
+                "failure_policy": "closed",
+                "mode": "enforce",
+            }),
+        })
+
+    with pytest.raises(ValueError, match="failure_policy"):
+        build_service_authority_from_env({
+            "VEXA_SERVICE_AUTHORITY_CONFIG": json.dumps({
+                "url": "https://authority.example.test/check",
+                "contract_version": "service-authority.v1",
+                "timeout_ms": 2_000,
+                "response_max_age_seconds": 30,
+                "failure_policy": "open",
+                "mode": "enforce",
+            }),
+            "VEXA_SERVICE_AUTHORITY_SECRET": "fixture-secret",
+        })
+
+    with pytest.raises(ValueError, match="URL"):
+        build_service_authority_from_env({
+            "VEXA_SERVICE_AUTHORITY_CONFIG": json.dumps({
+                "contract_version": "service-authority.v1",
+                "timeout_ms": 2_000,
+                "response_max_age_seconds": 30,
+                "failure_policy": "closed",
+                "mode": "enforce",
+            }),
+            "VEXA_SERVICE_AUTHORITY_SECRET": "fixture-secret",
+        })

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -104,6 +104,12 @@ BOT_S3_ENDPOINT=
 BOT_S3_BUCKET=
 BOT_S3_ACCESS_KEY=
 BOT_S3_SECRET_KEY=
+# Optional generic service authority. Unset preserves the stock OSS allow-all behavior. When set,
+# CONFIG is one compact JSON object with url/contract_version/timeout_ms/
+# response_max_age_seconds/failure_policy=closed/mode=enforce|observe. SECRET signs exact request
+# bytes; keep it out of source and shell history in real deployments.
+VEXA_SERVICE_AUTHORITY_CONFIG=
+VEXA_SERVICE_AUTHORITY_SECRET=
 BOT_ALONE_SILENCE_WINDOW_MS=
 BOT_SPEAKER_MIN_AUDIO_SEC=
 BOT_SPEAKER_SUBMIT_INTERVAL_SEC=

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -330,6 +330,9 @@ services:
       - BOT_S3_BUCKET=${BOT_S3_BUCKET:-}
       - BOT_S3_ACCESS_KEY=${BOT_S3_ACCESS_KEY:-}
       - BOT_S3_SECRET_KEY=${BOT_S3_SECRET_KEY:-}
+      # Optional operator-owned service-authority.v1 boundary. Empty is explicit OSS allow-all.
+      - VEXA_SERVICE_AUTHORITY_CONFIG=${VEXA_SERVICE_AUTHORITY_CONFIG:-}
+      - VEXA_SERVICE_AUTHORITY_SECRET=${VEXA_SERVICE_AUTHORITY_SECRET:-}
       # Self-hosted Jitsi hostnames (comma-separated) recognized in pasted + calendar links.
       - VEXA_JITSI_HOSTS=${VEXA_JITSI_HOSTS:-}
       - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}

--- a/deploy/compose/tests/service-authority.overlay.yml
+++ b/deploy/compose/tests/service-authority.overlay.yml
@@ -1,0 +1,27 @@
+services:
+  authority-fixture:
+    image: vexaai/v012-meeting-api:${IMAGE_TAG:-dev}
+    entrypoint: ["python", "/fixture/service_authority_fixture.py"]
+    environment:
+      - AUTHORITY_SECRET=compose-service-authority-fixture-secret
+    volumes:
+      - ./tests/service_authority_fixture.py:/fixture/service_authority_fixture.py:ro
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9880/health').status==200 else 1)"
+      interval: 2s
+      timeout: 2s
+      retries: 15
+    networks: [vexa]
+
+  meeting-api:
+    environment:
+      - VEXA_SERVICE_AUTHORITY_CONFIG={"url":"http://authority-fixture:9880/v1/service-authority","contract_version":"service-authority.v1","timeout_ms":2000,"response_max_age_seconds":30,"failure_policy":"closed","mode":"enforce"}
+      - VEXA_SERVICE_AUTHORITY_SECRET=compose-service-authority-fixture-secret
+      - SERVICE_AUTHORITY_SWEEP_INTERVAL_S=1
+    depends_on:
+      authority-fixture:
+        condition: service_healthy

--- a/deploy/compose/tests/service_authority_fixture.py
+++ b/deploy/compose/tests/service_authority_fixture.py
@@ -1,0 +1,146 @@
+"""Bounded service-authority.v1 fixture for the Compose acceptance oracle.
+
+This is a generic contract peer, not a hosted billing policy or Stripe double.
+It validates the exact-body HMAC, allows admission, and denies the first active
+continuation so the stock meeting-api can prove its durable one-minute stop.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+HOST = "0.0.0.0"
+PORT = 9880
+SECRET = os.environ.get(
+    "AUTHORITY_SECRET",
+    "compose-service-authority-fixture-secret",
+)
+MAX_REQUEST_AGE_SECONDS = 30
+
+_lock = threading.Lock()
+_observations: dict[str, Any] = {
+    "admit": 0,
+    "continue": 0,
+    "signature_failures": 0,
+    "request_ids": [],
+    "service_identities": [],
+    "decision_ids": [],
+    "request_keys": [],
+}
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "service-authority-fixture"
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        """Keep the fixture quiet: request bodies carry service identities."""
+
+    def _reply(self, status: int, value: Any) -> None:
+        body = _json_bytes(value)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib HTTP hook
+        if self.path == "/health":
+            self._reply(200, {"status": "ok"})
+            return
+        if self.path == "/observations":
+            with _lock:
+                snapshot = json.loads(json.dumps(_observations))
+            self._reply(200, snapshot)
+            return
+        self._reply(404, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib HTTP hook
+        if self.path != "/v1/service-authority":
+            self._reply(404, {"error": "not_found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            timestamp = self.headers.get("X-Webhook-Timestamp", "")
+            supplied = self.headers.get("X-Webhook-Signature", "")
+            bearer = self.headers.get("Authorization", "")
+            expected = hmac.new(
+                SECRET.encode("utf-8"),
+                timestamp.encode("ascii") + b"." + body,
+                hashlib.sha256,
+            ).hexdigest()
+            fresh = abs(time.time() - int(timestamp)) <= MAX_REQUEST_AGE_SECONDS
+            authenticated = (
+                bearer == f"Bearer {SECRET}"
+                and fresh
+                and hmac.compare_digest(supplied, f"sha256={expected}")
+            )
+        except (TypeError, ValueError, UnicodeError):
+            authenticated = False
+        if not authenticated:
+            with _lock:
+                _observations["signature_failures"] += 1
+            self._reply(401, {"error": "invalid_signature"})
+            return
+
+        try:
+            request = json.loads(body)
+            action = request["action"]
+            request_id = request["request_id"]
+            service_identity = request["service_identity"]
+            if action not in ("admit", "continue"):
+                raise ValueError("unsupported action")
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            self._reply(400, {"error": "invalid_request"})
+            return
+
+        allow = action == "admit"
+        decision_id = (
+            "compose-authority:"
+            + hashlib.sha256(
+                f"{action}:{request_id}".encode("utf-8"),
+            ).hexdigest()
+        )
+        with _lock:
+            _observations[action] += 1
+            _observations["request_ids"].append(request_id)
+            _observations["service_identities"].append(service_identity)
+            _observations["decision_ids"].append(decision_id)
+            _observations["request_keys"].append(sorted(request))
+
+        response = {
+            "authority_version": "service-authority.v1",
+            "decision_id": decision_id,
+            "request_id": request_id,
+            "service_identity": service_identity,
+            "allow": allow,
+            "reason": (
+                "compose_fixture_allow"
+                if allow
+                else "compose_fixture_limit"
+            ),
+            "decided_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if not allow:
+            response["stop_scope"] = "billable_service"
+        self._reply(200, response)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer((HOST, PORT), Handler).serve_forever()

--- a/deploy/compose/tests/service_authority_test.py
+++ b/deploy/compose/tests/service_authority_test.py
@@ -1,0 +1,178 @@
+"""L3 product-boundary oracle for service-authority.v1 (#988 A5).
+
+Opt in with SERVICE_AUTHORITY_COMPOSE=1 and the companion Compose overlay.  The
+test keeps a real mock bot active for one service minute, observes the persisted
+deny/lease, and proves that the real runtime teardown converges exactly once.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+
+import pytest
+
+from conftest import http, post_json, requires_docker
+from stack_test import _create_user
+
+
+pytestmark = requires_docker
+authority_only = pytest.mark.skipif(
+    os.getenv("SERVICE_AUTHORITY_COMPOSE") != "1",
+    reason=(
+        "service-authority Compose oracle is opt-in "
+        "(set SERVICE_AUTHORITY_COMPOSE=1 and COMPOSE_EXTRA_FILES)"
+    ),
+)
+
+REQUEST_KEYS = {
+    "user_id",
+    "action",
+    "request_id",
+    "service_identity",
+    "service_mode",
+    "transcription_provider",
+    "lifecycle_contract_version",
+    "active_concurrency",
+}
+CONTINUATION_KEYS = REQUEST_KEYS | {"admitted_at", "boundary_at"}
+
+
+def _meeting(stack, user_id: int, native_id: str) -> dict | None:
+    raw = stack.psql(
+        "SELECT json_build_object("
+        "'id', id, 'status', status, 'bot_container_id', bot_container_id, "
+        "'data', data)::text "
+        "FROM meetings "
+        f"WHERE user_id={user_id} "
+        f"AND platform_specific_id='{native_id}' "
+        "ORDER BY id DESC LIMIT 1;"
+    )
+    return json.loads(raw) if raw else None
+
+
+def _wait_for(predicate, *, timeout: float, poll: float = 1.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(poll)
+    raise AssertionError(f"condition not met within {timeout}s; last={last!r}")
+
+
+def _fixture_observations(stack) -> dict:
+    raw = stack.exec(
+        "meeting-api",
+        "python",
+        "-c",
+        (
+            "import urllib.request;"
+            "print(urllib.request.urlopen("
+            "'http://authority-fixture:9880/observations'"
+            ").read().decode())"
+        ),
+    )
+    return json.loads(raw)
+
+
+@authority_only
+def test_active_service_boundary_stops_once_and_replay_is_inert(stack) -> None:
+    user_id = _create_user(stack, max_bots=5)
+    native_id = f"authority-{uuid.uuid4().hex[:8]}"
+    code, created = post_json(
+        f"{stack.meeting_api}/bots",
+        {
+            "platform": "google_meet",
+            "native_meeting_id": native_id,
+            "bot_name": "mock:immediate-stop",
+            "transcribe_enabled": False,
+            "recording_enabled": False,
+        },
+        headers={"x-user-id": str(user_id), "x-user-limits": "5"},
+    )
+    assert code == 201, f"authority-backed POST /bots → {code} {created}"
+
+    active = _wait_for(
+        lambda: (
+            row
+            if (row := _meeting(stack, user_id, native_id))
+            and row["status"] == "active"
+            else None
+        ),
+        timeout=45,
+    )
+    authority = active["data"]["service_authority"]
+    service_identity = authority["service_identity"]
+    admission_decision = authority["decision_id"]
+    workload_id = active["bot_container_id"]
+    assert authority["mode"] == "enforce"
+    assert authority["allow"] is True
+    assert authority["reason"] == "compose_fixture_allow"
+    assert service_identity.startswith("meeting-session:")
+    assert workload_id
+    assert http("GET", f"{stack.runtime}/workloads/{workload_id}")[0] == 200
+
+    stopped = _wait_for(
+        lambda: (
+            row
+            if (row := _meeting(stack, user_id, native_id))
+            and row["data"]["service_authority"].get(
+                "teardown_confirmed",
+            )
+            is True
+            else None
+        ),
+        timeout=95,
+    )
+    final_authority = stopped["data"]["service_authority"]
+    stop_decision = final_authority["decision_id"]
+    boundary = final_authority["last_boundary_at"]
+    assert stop_decision != admission_decision
+    assert final_authority["allow"] is False
+    assert final_authority["reason"] == "compose_fixture_limit"
+    assert final_authority["stop_scope"] == "billable_service"
+    assert final_authority["service_identity"] == service_identity
+    assert stopped["data"]["stop_requested"] is True
+    runtime_code, runtime_status = http(
+        "GET",
+        f"{stack.runtime}/workloads/{workload_id}",
+    )
+    # runtime.v1 retains an authoritative terminal tombstone; 404 means
+    # "untracked", not "successfully destroyed".
+    assert runtime_code == 200
+    assert runtime_status["state"] == "destroyed"
+
+    observations = _fixture_observations(stack)
+    assert observations["signature_failures"] == 0
+    assert observations["admit"] == 1
+    assert observations["continue"] == 1
+    assert observations["service_identities"] == [
+        service_identity,
+        service_identity,
+    ]
+    assert set(observations["request_keys"][0]) == REQUEST_KEYS
+    assert set(observations["request_keys"][1]) == CONTINUATION_KEYS
+
+    # Wait beyond another sweep tick. A terminal/stopping stop with a confirmed
+    # lease is not reconsidered, so neither the provider effect nor teardown is
+    # repeated.
+    time.sleep(3)
+    replay = _meeting(stack, user_id, native_id)
+    replay_observations = _fixture_observations(stack)
+    assert replay["data"]["service_authority"]["decision_id"] == stop_decision
+    assert replay["data"]["service_authority"]["last_boundary_at"] == boundary
+    assert replay["data"]["service_authority"]["teardown_confirmed"] is True
+    assert replay_observations["admit"] == 1
+    assert replay_observations["continue"] == 1
+
+    print(
+        "\n[service-authority/A5] "
+        f"meeting={stopped['id']} "
+        f"service_identity={service_identity} "
+        f"decision={stop_decision} "
+        f"boundary={boundary} "
+        "runtime=destroyed replay=unchanged"
+    )

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -86,6 +86,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "vexa.adminTokenSecretName" . }}
                   key: TRANSCRIPTION_SERVICE_TOKEN
+            - name: VEXA_SERVICE_AUTHORITY_CONFIG
+              value: {{ .Values.meetingApi.serviceAuthorityConfig | default "" | quote }}
+            - name: VEXA_SERVICE_AUTHORITY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: VEXA_SERVICE_AUTHORITY_SECRET
+                  optional: true
             {{- if .Values.minio.enabled }}
             - name: MINIO_ENDPOINT
               value: "{{ include "vexa.componentName" (list . "minio") }}:{{ .Values.minio.service.port }}"

--- a/deploy/helm/charts/vexa/templates/secret.yaml
+++ b/deploy/helm/charts/vexa/templates/secret.yaml
@@ -10,6 +10,7 @@ stringData:
   ADMIN_API_TOKEN: {{ .Values.secrets.adminApiToken | quote }}
   INTERNAL_API_SECRET: {{ .Values.secrets.internalApiSecret | default "vexa-internal-secret" | quote }}
   TRANSCRIPTION_SERVICE_TOKEN: {{ .Values.secrets.transcriptionServiceToken | quote }}
+  VEXA_SERVICE_AUTHORITY_SECRET: {{ .Values.secrets.serviceAuthoritySecret | quote }}
   VEXA_DISPATCH_SIGNING_KEY: {{ .Values.secrets.dispatchSigningKey | default "dev-dispatch-signing-key" | quote }}
   NEXTAUTH_SECRET: {{ .Values.secrets.nextauthSecret | default "dev-nextauth-secret" | quote }}
   {{- if .Values.secrets.botApiKey }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -43,13 +43,14 @@ global:
 # ---------- Shared secrets ----------
 # Recommended: override via --set-file / external secret tooling, or point existingSecretName at a
 # Secret carrying these keys: ADMIN_API_TOKEN, INTERNAL_API_SECRET, TRANSCRIPTION_SERVICE_TOKEN,
-# VEXA_DISPATCH_SIGNING_KEY, VEXA_BOT_API_KEY, ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN,
-# ANTHROPIC_BASE_URL, CLAUDE_CODE_OAUTH_TOKEN.
+# VEXA_SERVICE_AUTHORITY_SECRET, VEXA_DISPATCH_SIGNING_KEY, VEXA_BOT_API_KEY, ANTHROPIC_API_KEY,
+# ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL, CLAUDE_CODE_OAUTH_TOKEN.
 secrets:
   existingSecretName: ""
   adminApiToken: "CHANGE_ME"        # admin-api auth + MeetingToken signing (== meeting-api ADMIN_TOKEN)
   internalApiSecret: ""             # gateway↔admin-api↔meeting-api internal calls (default vexa-internal-secret)
   transcriptionServiceToken: ""     # funded STT token threaded into spawned bots
+  serviceAuthoritySecret: ""        # exact-byte HMAC secret; required only when meetingApi.serviceAuthorityConfig is set
   dispatchSigningKey: ""            # agent-api signs per-dispatch tokens (default dev key; k8s prod → set this)
   botApiKey: ""                     # agent-api → gateway "add bot from URL" key (optional)
   nextauthSecret: ""                # terminal next-auth session signing (default dev key; set in prod)
@@ -178,6 +179,10 @@ meetingApi:
     port: 8080
   defaultBotName: ""        # server-side fallback when POST /bots omits bot_name
   transcriptionServiceUrl: ""   # STT endpoint the spawned bot transcribes against (empty ⇒ capture only)
+  # Optional service-authority.v1 adapter JSON. Empty preserves stock OSS allow-all. A configured
+  # authority must use failure_policy=closed and mode=enforce|observe; the secret lives under
+  # secrets.serviceAuthoritySecret or the existing Secret key VEXA_SERVICE_AUTHORITY_SECRET.
+  serviceAuthorityConfig: ""
   # Authenticated-bot mode (deployment-scoped; docs: /authenticated-bots): botAuthenticated "true"
   # makes every spawned bot restore the provisioned browser session and join signed-in. The BOT_S3
   # values are SCOPED userdata-store credentials, never the deployment's admin S3 creds.

--- a/deploy/lite/entrypoint.sh
+++ b/deploy/lite/entrypoint.sh
@@ -53,6 +53,11 @@ export TRANSCRIPTION_SERVICE_TOKEN="${TRANSCRIPTION_SERVICE_TOKEN:-}"
 # STT model id for validating backends (Groq/vLLM); empty → whisper-1.
 export TRANSCRIPTION_MODEL="${TRANSCRIPTION_MODEL:-}"
 
+# Optional operator-owned service-authority.v1 boundary. The config stays credential-free; the
+# signing secret remains a separate inherited environment value and is never printed below.
+export VEXA_SERVICE_AUTHORITY_CONFIG="${VEXA_SERVICE_AUTHORITY_CONFIG:-}"
+export VEXA_SERVICE_AUTHORITY_SECRET="${VEXA_SERVICE_AUTHORITY_SECRET:-}"
+
 export MINIO_ENDPOINT="${MINIO_ENDPOINT:-}"
 export MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-}"
 export MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-}"

--- a/docs/changelog.d/988-service-authority.md
+++ b/docs/changelog.d/988-service-authority.md
@@ -1,0 +1,4 @@
+- **Self-hosted deployments can opt into an external service authority without importing hosted
+  billing policy (#988).** Meeting-api can now ask a signed, versioned authority before bot spawn
+  and at each one-minute active-service boundary; stock OSS remains explicit allow-all when the
+  integration is unset. See [Configuration](/configuration#optional-service-authority).

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -60,6 +60,29 @@ does **not** strip it — the comment becomes part of the value, so `TERMINAL_PO
 sets the port to the literal string `13000  # the UI`.
 </Warning>
 
+## Optional service authority
+
+Stock self-hosted Vexa has no external service authority and continues to admit bots exactly as
+before. Operators who need an independently owned admission/active-service policy can opt into the
+sealed `service-authority.v1` boundary:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `VEXA_SERVICE_AUTHORITY_CONFIG` | — | Compact JSON containing a credential-free `url`, `contract_version: "service-authority.v1"`, `timeout_ms`, `response_max_age_seconds`, `failure_policy: "closed"`, and `mode: "enforce"` or `"observe"`. HTTPS is required except for loopback/in-cluster HTTP. |
+| `VEXA_SERVICE_AUTHORITY_SECRET` | — | HMAC-SHA256 secret for the exact timestamped request bytes. Required only when the config is set; keep it in the deployment secret store. |
+| `SERVICE_AUTHORITY_SWEEP_INTERVAL_S` | `15` | Poll cadence for discovering due active-service boundaries. Decisions remain anchored to admitted time plus whole minutes, so changing the poll cadence does not change the billable boundary. |
+
+The request contains service identity, authoritative user ID, service mode, frozen transcription
+provider, concurrency, and lifecycle timestamps. It deliberately contains no email, customer or
+payment-provider identifier, price, balance, transcription endpoint URL, or credential. A
+configured authority that is unavailable, malformed, stale, or bound to another request fails
+closed before a new bot is spawned. During active service, its stop intent is committed before
+runtime teardown and resumed after restart.
+
+`mode: "observe"` records decisions without refusing or stopping service. It is useful for rollout,
+but it is not evidence that a hard service control is enforced. A session admitted in one mode is
+never reinterpreted under another mode after a deployment change.
+
 ## Secrets & identity
 
 | Variable | Default | Purpose |

--- a/docs/views/architecture.dsl
+++ b/docs/views/architecture.dsl
@@ -24,6 +24,7 @@ system meetings  # capture → transcribe → record; owns the raw transcript
   contract flagged-issue.v1
   contract invocation.v1
   contract lifecycle.v1
+  contract service-authority.v1
   contract transcript.v1
   contract webhook.v1
   service transcription
@@ -75,6 +76,9 @@ system deploy  # deployment + execution-target registry
   contract execution-targets.v1
   contract config.v1
 
+system service-authority-system  # optional operator-owned admission and active-service authority; absent in stock OSS and never owns billing policy inside core
+  service service-authority
+
 system platform  # shared infra backing the services
   service redis
   database postgres
@@ -105,6 +109,7 @@ edges:
   meeting-api -write-> postgres
   meeting-api -write-> minio
   meeting-api -req-> runtime  # POST /workloads spawn bot
+  meeting-api -req-> service-authority  # optional signed service-authority.v1 admit/continue decision; unset is explicit OSS allow-all, configured failure is closed
   agent-api -read-> segments-stream  # XREADGROUP agent_copilot (proactive watcher)
   agent-api -req-> runtime  # POST /workloads spawn agent-worker
   agent-api -read-> out-stream  # SSE relay (/api/chat, /api/meeting/stream)

--- a/docs/views/containers.mmd
+++ b/docs/views/containers.mmd
@@ -22,6 +22,9 @@ flowchart LR
   subgraph runtime_system["runtime"]
     runtime["runtime"]
   end
+  subgraph service_authority_system["service authority"]
+    service_authority["external service authority"]
+  end
   subgraph platform["platform"]
     redis["redis"]
     postgres["postgres"]
@@ -36,6 +39,7 @@ flowchart LR
   meeting_api -->|"JDBC"| postgres
   meeting_api -->|"HTTPS"| minio
   meeting_api -->|"HTTPS"| runtime
+  meeting_api -->|"HTTPS"| service_authority
   agent_api -->|"HTTPS"| runtime
   mcp -->|"HTTPS"| gateway
   gateway -->|"HTTPS"| meeting_api

--- a/docs/views/egress.mmd
+++ b/docs/views/egress.mmd
@@ -8,6 +8,7 @@ flowchart LR
     bot["bot"]
     desktop["desktop"]
     meeting_api["meeting-api"]
+    service_authority["external service authority"]
     mcp["mcp"]
     slim["slim"]
     extension["extension"]


### PR DESCRIPTION
## Customer outcome

A hosted authority can now stop further billable bot service at an admitted session's producer-owned one-minute boundary. Stock self-hosted Vexa remains explicit allow-all when no authority is configured.

This is the OSS mechanism car for #988. It does **not** claim hosted #163 composition, Stripe TEST, stage, or customer-visible Account acceptance.

## Exact candidate

- commit: `f69cefdd60cad2598246e057afd1f8f46c61da9e`
- tree: `cdd1f4da06af9b5ba701354708bb959ba47c229f`
- base: `1f6898cf486a0f57ee0544e5e7bd6382f9612a6f`

## Mechanism

- Versioned, privacy-minimal `service-authority.v1` request/decision contract.
- Exact-body timestamped HMAC HTTP adapter; boot validation; configured-unavailable fail-closed; explicit unconfigured allow-all; explicit non-enforcing observe mode.
- Pre-effect admission check with per-run `meeting-session:*` identity frozen into meeting data.
- Meeting-api-owned one-minute continuation sweep derived from producer `active` time.
- Postgres row-locked teardown lease persists the decision before runtime deletion, converges crashes, and prevents replica double-application.
- Compose, Helm, and Lite configuration surfaces plus architecture/config/contract seals.
- Reusable L3 Compose fixture/oracle using the stock `mock:immediate-stop` bot.

## Expected / Actual / Verdict

**Expected:** one admitted synthetic bot remains active until the first service minute; one signed continuation denial is committed; one runtime teardown is confirmed; replay does not create a second decision or teardown.

**Actual:** Compose oracle printed `meeting=1`, a single `meeting-session:*` identity, one `compose-authority:*` decision at the exact producer minute boundary, `runtime=destroyed`, `replay=unchanged`; `1 passed in 94.25s`. The first oracle attempt correctly exposed that runtime retains a `destroyed` tombstone (HTTP 200), so the final assertion uses the sealed runtime truth rather than incorrectly expecting 404/untracked.

**Verdict:** OSS mechanism/source value is GREEN at L3. Hosted product value remains OPEN until #163 implements the same wire shape and the joint stage web witness is green.

## Acceptance evidence

| Row | Evidence |
|---|---|
| A1 unset | unit: unconfigured allow-all preserves one row/workload and later config does not seize that session |
| A2 allow | signed HTTP test + L3 admission produces exactly one active workload; response request/service identity bound |
| A3 deny | typed HTTP 403 with opaque reason/decision before zero DB/runtime effects |
| A4 unavailable/malformed/stale | configured authority fails before spawn; active unavailable persists a closed stop decision |
| A5 active boundary/replay | real Compose meeting-api + Postgres + runtime + mock bot: one producer minute, one lease, `destroyed`, replay unchanged |
| A6 privacy | exact key-set assertions; no email, provider/customer ID, price, balance, URL, credential or secret on wire/log receipt |
| A7 hosted composition | **pending** platform correction and stage joint witness; intentionally not claimed here |

## Validation

- focused service-authority: `16 passed`
- focused meeting-api slice: `120 passed`
- full meeting-api: `868 passed, 5 skipped`
- complete repository gates under supported Python 3.12: all green (`gate:python` 12 packages; node 18 packages; health 7; real Compose stack; DB schema 68 columns; schema 25 contracts)
- pre-push static gates: all 14 green; config `199 keys / 8 capabilities`; architecture `87 nodes / 59 edges`; contracts `25`
- L3 value oracle exact source: `1 passed in 94.25s`

## Security / exclusions

No Stripe/provider credential, hosted billing policy, customer data, stage, production, or financial mutation. The fixture secret and identity are disposable test-only values. The Compose harness cleaned its unique projects, workloads, networks, and volumes.

Refs #988