### PR TITLE
fix(bot): point the fake camera at a decodable y4m — kills Meet's permanent "Camera not found" toast

### DIFF
--- a/core/meetings/modules/join/scripts/debug-join.ts
+++ b/core/meetings/modules/join/scripts/debug-join.ts
@@ -14,7 +14,21 @@
  */
 import { chromium } from "playwright-extra";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
+import { existsSync, writeFileSync } from "fs";
 import { joinMeeting, startDebugView, leaveGoogleMeet, leaveMicrosoftTeams, leaveZoomMeeting, getJoinBrowserArgs } from "../src/index";
+
+// The fake camera must point at a DECODABLE y4m — /dev/null registers a camera Chromium can
+// never read frames from, and Google Meet shows a permanent "Camera not found" toast over the
+// meeting stage (#998). The bot image generates this file in its entrypoint (ffmpeg); the debug
+// image carries no ffmpeg, so write the one black 640x360 yuv420p frame directly.
+const BLANK_CAM = "/tmp/blank-camera.y4m";
+if (!existsSync(BLANK_CAM)) {
+  const w = 640, h = 360;
+  const header = Buffer.from(`YUV4MPEG2 W${w} H${h} F30:1 Ip A1:1 C420jpeg\nFRAME\n`, "ascii");
+  const luma = Buffer.alloc(w * h, 0);
+  const chroma = Buffer.alloc((w * h) / 2, 128);
+  writeFileSync(BLANK_CAM, Buffer.concat([header, luma, chroma]));
+}
 
 
 if (process.platform !== "linux" || !process.env.DISPLAY) {
@@ -56,7 +70,7 @@ if (!isMeetUrl && !isTeamsUrl && !isZoomUrl) {
       "--no-sandbox", "--disable-setuid-sandbox", "--disable-blink-features=AutomationControlled",
       "--disable-infobars", "--disable-gpu", "--disable-features=IsolateOrigins,site-per-process",
       "--disable-site-isolation-trials", "--in-process-gpu", "--use-fake-ui-for-media-stream",
-      "--use-file-for-fake-video-capture=/dev/null", "--disable-features=VizDisplayCompositor",
+      "--use-file-for-fake-video-capture=/tmp/blank-camera.y4m", "--disable-features=VizDisplayCompositor",
       "--password-store=basic", "--remote-debugging-port=9222",
     ];
     const ctx = await chromium.launchPersistentContext(AUTH_PROFILE, {

--- a/core/meetings/modules/join/src/__tests__/localePin.test.ts
+++ b/core/meetings/modules/join/src/__tests__/localePin.test.ts
@@ -19,6 +19,19 @@ console.log("\n=== 1. Default pin: en-US ===");
   assert(args.includes("--accept-lang=en-US,en"), "getJoinBrowserArgs() carries --accept-lang=en-US,en by default");
 }
 
+console.log("\n=== 1b. Fake camera source is decodable, not /dev/null (#998) ===");
+{
+  const args = getJoinBrowserArgs();
+  assert(
+    args.includes("--use-file-for-fake-video-capture=/tmp/blank-camera.y4m"),
+    "getJoinBrowserArgs() points the fake camera at the entrypoint-generated blank y4m"
+  );
+  assert(
+    !args.some((a) => a.includes("--use-file-for-fake-video-capture=/dev/null")),
+    "getJoinBrowserArgs() must NOT point the fake camera at /dev/null (undecodable — permanent 'Camera not found' toast on Meet)"
+  );
+}
+
 console.log("\n=== 2. Negative control: the knob really drives it (A2) ===");
 {
   process.env.BOT_UI_LOCALE = "hu-HU";

--- a/core/meetings/modules/join/src/browser-args.ts
+++ b/core/meetings/modules/join/src/browser-args.ts
@@ -64,7 +64,12 @@ export const JOIN_BROWSER_ARGS: readonly string[] = [
   // Start AudioContexts in 'running', not 'suspended' — the capture taps remote participant audio
   // via createMediaStreamSource; without this the worklet never fires and no PCM flows. (L4.)
   "--autoplay-policy=no-user-gesture-required",
-  "--use-file-for-fake-video-capture=/dev/null",
+  // Must point at a real, decodable y4m — /dev/null registers a camera Chromium can't decode,
+  // so Google Meet shows a permanent "Camera not found" toast over the meeting stage (#998).
+  // The entrypoint generates this file. Do NOT switch to --use-fake-device-for-media-stream:
+  // that also fakes the microphone, displacing the tts_sink→virtual_mic PulseAudio chain the
+  // speak path depends on.
+  "--use-file-for-fake-video-capture=/tmp/blank-camera.y4m",
   "--disable-blink-features=AutomationControlled",
   "--disable-features=VizDisplayCompositor",
   "--disable-site-isolation-trials",

--- a/core/meetings/modules/remote-browser/src/args.ts
+++ b/core/meetings/modules/remote-browser/src/args.ts
@@ -38,7 +38,10 @@ export function getAuthenticatedBrowserArgs(): string[] {
     '--disable-site-isolation-trials',
     '--in-process-gpu',
     '--use-fake-ui-for-media-stream',
-    '--use-file-for-fake-video-capture=/dev/null',
+    // Must point at a real, decodable y4m — /dev/null registers a camera Chromium can't decode,
+    // so Google Meet shows a permanent "Camera not found" toast over the meeting stage (#998).
+    // The entrypoint generates this file.
+    '--use-file-for-fake-video-capture=/tmp/blank-camera.y4m',
     '--disable-features=VizDisplayCompositor',
     '--password-store=basic',
   ];

--- a/core/meetings/modules/remote-browser/src/auth.smoke.test.ts
+++ b/core/meetings/modules/remote-browser/src/auth.smoke.test.ts
@@ -39,6 +39,14 @@ check(authArgs.includes('--disable-blink-features=AutomationControlled'),
 check(!authArgs.includes('--incognito'),
   'authenticated args must NOT be incognito (wipes stored cookies)');
 check(authArgs.includes('--no-sandbox'), 'authenticated args must include --no-sandbox (container)');
+check(
+  authArgs.includes('--use-file-for-fake-video-capture=/tmp/blank-camera.y4m'),
+  'authenticated args must point the fake camera at the entrypoint-generated blank y4m (#998)'
+);
+check(
+  !authArgs.some((a) => a.includes('--use-file-for-fake-video-capture=/dev/null')),
+  'authenticated args must NOT point the fake camera at /dev/null (undecodable — permanent "Camera not found" toast on Meet)'
+);
 
 const sessionArgs = getBrowserSessionArgs();
 for (const bad of FORBIDDEN) {

--- a/core/meetings/services/bot/entrypoint.sh
+++ b/core/meetings/services/bot/entrypoint.sh
@@ -35,6 +35,16 @@ pactl set-default-source virtual_mic 2>/dev/null || true
 pactl set-sink-mute tts_sink 1 2>/dev/null || true
 pactl set-source-mute virtual_mic 1 2>/dev/null || true
 
+# A DECODABLE fake camera. --use-file-for-fake-video-capture must point at a real y4m;
+# /dev/null makes Chromium register a camera it cannot decode, so Google Meet shows a permanent
+# "Camera not found" toast over the meeting stage. One black frame is enough: the bot turns its
+# camera off at join, so this is never published.
+BLANK_CAM=/tmp/blank-camera.y4m
+if [ ! -s "$BLANK_CAM" ]; then
+  ffmpeg -y -loglevel error -f lavfi -i color=c=black:s=640x360:d=1 -pix_fmt yuv420p \
+    -frames:v 1 "$BLANK_CAM" || echo "[entrypoint] WARNING: blank camera source not generated"
+fi
+
 # Run the worker from its package dir so the schema path (src→../../../contracts)
 # and the pnpm-linked workspace deps resolve. Always emit start + exit breadcrumbs
 # so an instant crash is never silent in container stdout.

--- a/docs/changelog.d/998-fake-camera-decodable.md
+++ b/docs/changelog.d/998-fake-camera-decodable.md
@@ -1,0 +1,6 @@
+- **The fake camera source is now a decodable y4m, not `/dev/null` (#998).** Both launch-arg lists
+  pointed `--use-file-for-fake-video-capture` at `/dev/null`, which Chromium registers as a camera
+  it cannot decode — Google Meet showed a permanent "Camera not found / Make sure your camera is
+  plugged in" toast bottom-center over the meeting stage for the whole call, overlapping shared
+  screen content. The bot entrypoint now generates a one-frame black `blank-camera.y4m` before the
+  worker starts, and both flag sites point at it instead.


### PR DESCRIPTION
Fixes #998.

### What

`--use-file-for-fake-video-capture=/dev/null` registers a fake camera Chromium can never decode frames from, so Google Meet shows a permanent **"Camera not found / Make sure your camera is plugged in"** toast bottom-center over the meeting stage — for the whole call (observed still up 11 minutes in), overlapping shared-screen content. All three flag sites are fixed:

- `join/src/browser-args.ts` and `remote-browser/src/args.ts` now point at `/tmp/blank-camera.y4m`, generated as a one-frame black 640×360 y4m by the bot `entrypoint.sh` via the `ffmpeg` already in the image. The bot turns its camera off at join, so the frame is never published — it only has to *exist and decode*.
- `join/scripts/debug-join.ts` (the hot debug container, which has no ffmpeg) writes the same frame directly with Node `fs`. This is load-bearing, not cosmetic: the debug runner also consumes `getJoinBrowserArgs()`, which now expects the file.

### Why not `--use-fake-device-for-media-stream`

It also fakes the microphone, which would displace the `tts_sink` → `virtual_mic` PulseAudio chain the speak path depends on. Keeping the file-based flag changes nothing about audio.

### Evidence

- **Red→green pair:** new assertions in `localePin.test.ts` and `auth.smoke.test.ts` — the arg lists must carry the y4m path and must NOT carry `/dev/null` (no existing test covered this flag). `modules/join` suite: 12 passed; `modules/remote-browser` suite: both files pass.
- **The generated y4m decodes:** verified with the image's own ffmpeg — `ffprobe` reports `rawvideo, 640x360, yuv420p`, and a full `ffmpeg -i … -f null -` decode pass is error-free. Both the entrypoint (ffmpeg) and debug (Node-written) variants checked.
- **Validated live** on a self-hosted compose deployment at `v0.12.18` + this patch: the toast is gone from join onward on a real Meet call (confirmed via periodic captures of the bot's X display). Before the patch the toast was present on every Meet join.
- Changelog fragment included (`docs/changelog.d/998-fake-camera-decodable.md`).

Happy to have a non-author validate per the delivery loop — reproduction is one Meet join with any bot, looking at the bot's display (or a stage screenshot) for the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
