### PR TITLE
gov: enforce low-friction contributor rights at PR intake

### DIFF
--- a/.github/contribution-rights.json
+++ b/.github/contribution-rights.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "effectiveAfterPullRequest": "__BOOTSTRAP_PR__",
+  "verifiers": [
+    "DmitriyG228"
+  ]
+}

--- a/.github/contribution-rights.json
+++ b/.github/contribution-rights.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "effectiveAfterPullRequest": "__BOOTSTRAP_PR__",
+  "effectiveAfterPullRequest": 1008,
   "verifiers": [
     "DmitriyG228"
   ]

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,23 @@
 
 **Delivers issue:** #
 
+## Contribution rights
+<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
+     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->
+
+- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
+  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
+  <!-- rights:independent -->
+- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
+  may control this contribution. I am requesting Vexa's private corporate-authorization process.
+  <!-- rights:corporate -->
+- [ ] **Unsure:** I need a private rights review before merge.
+  <!-- rights:uncertain -->
+
+Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
+independent path means no individual CLA is required. Corporate and unsure paths do not stop
+technical review, but they do block merge until resolved.
+
 ## Observation bundle (the record of your harnessed loop)
 <!-- One entry per component: what you ran, what you saw with your own eyes, what it told you
      about the next step. Your claim heartbeats are the natural front of this. A component that

--- a/.github/workflows/contribution-rights.yml
+++ b/.github/workflows/contribution-rights.yml
@@ -1,0 +1,40 @@
+name: contribution-rights-driver
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+  issue_comment:
+    types: [created, edited, deleted]
+  merge_group:
+  check_run:
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  checks: write
+
+concurrency:
+  group: contribution-rights-${{ github.event.pull_request.number || github.event.issue.number || github.event.merge_group.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    if: >-
+      ${{
+        (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
+        (github.event_name != 'check_run' || (github.event.check_run.name == 'DCO' && github.event.check_run.app.slug == 'dco'))
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      # pull_request_target is safe here: only trusted default-branch code is checked out,
+      # contributor code is never executed, and the token is limited to publishing this check.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Evaluate and publish the head-bound rights check
+        run: node scripts/contribution-rights-gate.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,16 @@ A prepared issue is a worked delivery spec — read it end to end before touchin
 
 ## How you work the checkout
 
+- **Contribution rights are a human decision; automate the mechanics.** Before the first commit,
+  read [`CONTRIBUTOR_RIGHTS.md`](CONTRIBUTOR_RIGHTS.md) and ask the human to choose independent,
+  employer/client-controlled, or unsure. Never choose or tick the PR declaration for them. After
+  the human explicitly chooses the independent or corporate path, inspect repository-local
+  `user.name` and `user.email`, surface any mismatch, and create every commit with
+  `git commit --signoff`. Never change global identity, insert another person's sign-off, enable
+  third-party remediation, or use a maintainer override. Diagnose missing/mismatched commits by
+  SHA. Before an amend/rebase/force-push, show the exact rewrite and obtain explicit approval;
+  prefer the DCO App's individual remediation commit on a shared branch.
+
 - **Discord is the working channel** — blockers, steering, quick questions live there while you
   work. One rule keeps the record honest: **anything decided lands back on the issue**, or it
   didn't happen. The issue is the source of truth; Discord is the speed.

--- a/CLA/README.md
+++ b/CLA/README.md
@@ -1,0 +1,13 @@
+# Corporate contribution authorization
+
+Do not commit executed agreements or personal information here. A contributor selects the
+corporate path in the pull-request template and emails [dmitry@vexa.ai](mailto:dmitry@vexa.ai)
+with the PR URL and the rights holder's legal/IP contact. Vexa then supplies the current
+counsel-approved corporate agreement or contribution-specific authorization through the private
+return channel.
+
+The public repository records only an opaque `VCR-YYYY-NNNN` receipt bound to the exact PR and
+head SHA. Agreement text is published here only after licensed counsel approves the exact version
+and SHA-256; until then, no repository draft is represented as an executable agreement.
+
+See [`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md) for the complete policy and verifier format.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,11 @@ never on whether you show up — but showing up makes everything smoother.
 
 Working with an agent, or in a checkout? Start at [`AGENTS.md`](AGENTS.md) — intake, the
 one-call roadmap fetch, claiming, and the session rules. Security reports: [`SECURITY.md`](SECURITY.md).
+
+## Rights and DCO — one choice, then automatic
+
+Every new pull request selects exactly one rights path: independent, employer/client-controlled,
+or unsure. Independent contributors sign each commit under DCO 1.1 and do **not** sign an
+individual CLA. Corporate or uncertain contributions enter private rights review while technical
+review continues; only merge waits. Read [`CONTRIBUTOR_RIGHTS.md`](CONTRIBUTOR_RIGHTS.md) for the
+exact choices, `git commit --signoff` workflow, safe remediation commands, and corporate process.

--- a/CONTRIBUTOR_RIGHTS.md
+++ b/CONTRIBUTOR_RIGHTS.md
@@ -1,0 +1,133 @@
+# Contributor rights
+
+Vexa accepts contributions under Apache-2.0 while preserving a reviewable record that the person
+or organization supplying each contribution had the right to do so. The normal individual path is
+one declaration in the pull request plus the standard Developer Certificate of Origin (DCO) on
+each commit. An individual CLA is not required on that path.
+
+This policy applies to pull requests opened after the activation pull request recorded in
+`.github/contribution-rights.json`. Earlier merged work is not rewritten or retroactively declared
+non-compliant. Concrete ownership concerns in earlier work are reviewed individually.
+
+## Choose one path when opening a pull request
+
+### Independent
+
+Choose **Independent** when you created the contribution, or otherwise have the right to submit
+it under Apache-2.0, and no employer, client, or other organization owns or controls it. Employment
+or a corporate email address alone does not force the corporate path.
+
+Sign every commit under [DCO 1.1](https://developercertificate.org/) by using:
+
+```bash
+git commit --signoff
+```
+
+The sign-off is a legal certification, not a cryptographic signature. It must use the name and
+email of the commit author. Vexa's required DCO App check validates every commit separately. A
+second required `dco-no-override` check rejects the app's write-user override and any unknown
+success result.
+
+### Employer/client authorization required
+
+Choose this path when the contribution is assigned work, was prepared using controlled employer
+or client assets, is sponsored for upstream submission, or may otherwise be owned or controlled
+by another legal entity. Continue to sign your own commits under the DCO; Vexa will privately send
+the rights holder the current approved corporate agreement or a contribution-specific
+authorization. Technical review may continue while that happens, but merge waits.
+
+Start the private process by emailing [dmitry@vexa.ai](mailto:dmitry@vexa.ai) with the pull-request
+URL and the rights holder's legal/IP contact. Do not attach executed agreements, signatures,
+addresses, employment documents, or private correspondence to a public issue or pull request.
+
+### Unsure
+
+Choose **Unsure** as early as possible. Technical review may continue. Vexa will help determine
+whether the independent or corporate path applies, without asking you to draft legal language.
+
+## What the automated gate proves
+
+The `contribution-rights` check requires exactly one declaration. The corporate path passes only
+after a designated verifier records an opaque private-register receipt against the exact pull
+request number and current head SHA. A later push invalidates the verification. A verifier can
+also place an independent declaration into rights review when concrete facts contradict it.
+
+The executed agreement and personal information remain in the private register. Public checks show
+only an opaque receipt identifier and verification state. A corporate authorization is evidence of
+contribution rights; it is not evidence of a customer, deployment, partnership, endorsement,
+revenue, procurement, or permission to use the organization's name or marks.
+
+## Fixing a DCO failure
+
+For the latest commit:
+
+```bash
+git commit --amend --no-edit --signoff
+git push --force-with-lease
+```
+
+For several commits on a branch only you use:
+
+```bash
+git rebase --signoff <merge-base>
+git push --force-with-lease
+```
+
+If other people use the branch, do not rewrite it without their agreement. The DCO App's individual
+remediation-commit flow is enabled so the original author can add a retrospective certification
+without a third party signing for them. Vexa does not enable third-party remediation and a
+maintainer will never manufacture another person's sign-off.
+
+## Agent-assisted contributions
+
+An agent may explain this policy, inspect commits, use `--signoff` after the human has explicitly
+chosen a rights path, and prepare a repair. It must not choose the legal path, certify rights,
+change global Git identity, add another person's sign-off, or rewrite/push history without the
+human's explicit approval. The desired experience is one conscious legal choice and no Git
+ceremony.
+
+## Previously merged contributions
+
+Missing DCO evidence does not by itself prove that an Apache-2.0 contribution is unlicensed.
+Historical review is risk-based:
+
+- small contributions with no ownership signal are recorded without outreach;
+- significant or ambiguous individual contributions may receive a separate retrospective DCO
+  attestation from the original contributor;
+- employer-owned or corporate-directed work requires a corporate authorization covering named
+  pull requests or commit SHAs; and
+- material work that cannot be cleared is replaced or removed, unless licensed counsel documents
+  a different disposition.
+
+Vexa never rewrites history merely to insert a sign-off and never signs for a contributor.
+
+## Administration
+
+The designated verifier compares the proposed public decision with the private register before
+posting it. A verified record must identify the legal entity, authorized signer, contributor and
+GitHub identity, covered repository and contribution, agreement version and SHA-256, effective
+dates, limitations, private document location, and the current PR head SHA.
+
+Public verifier decision format:
+
+```text
+<!-- vexa-contribution-rights-decision:v1 -->
+Decision: verified
+Receipt: VCR-YYYY-NNNN
+PR: #NNN
+Head: <40-character commit SHA>
+```
+
+`Decision: review` opens a persistent hold. `Decision: cleared` closes that hold for an independent
+contribution at the named head. Only identities listed in `.github/contribution-rights.json` are
+accepted, and all decisions are re-evaluated in the merge queue.
+
+Before activating the gate, repository administrators must:
+
+1. install the maintained [DCO App](https://github.com/apps/dco) and require both `DCO` and
+   `dco-no-override` checks;
+2. enable GitHub's compulsory sign-off for web-based commits;
+3. replace `__BOOTSTRAP_PR__` with this policy PR's number;
+4. require the `contribution-rights` check, with the ruleset bypass list set to none; and
+5. verify the private register, retention rule, return channel, and exact corporate agreement hash
+   with licensed counsel.

--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Honest state of the **0.12** line (mirrors the [status page](https://docs.vexa.a
 - **Contributing** — [how delivery works](docs/docs/governance/delivery.mdx): prepared issues
   with acceptance tables that *guarantee* merge, and human validation credited as a first-class
   contribution (one page, law and how-to together).
+- **Contributor rights** — [one rights choice plus DCO](CONTRIBUTOR_RIGHTS.md) for individuals;
+  private, head-bound authorization when an employer or client owns the work.
 - **Issues & PRs** — welcome. See [`SECURITY.md`](SECURITY.md) to report vulnerabilities.
 
 Vexa is built in the open. If you self-host it, extend it, or run it air-gapped somewhere interesting,

--- a/docs/adr/0034-contributor-rights-gate.md
+++ b/docs/adr/0034-contributor-rights-gate.md
@@ -1,0 +1,38 @@
+# ADR-0034 — Contributor rights are declared at intake and corporate evidence is head-bound
+
+**Status:** proposed
+
+## Context
+
+Apache-2.0 supplies inbound contribution terms, but a pull request can still leave ambiguity about
+whether an individual or an employer controls the submitted work. Requiring every individual to
+sign a CLA would add disproportionate friction. A generic maintainer label is not sufficient
+corporate evidence because it can survive later pushes and does not identify a private receipt.
+
+## Decision
+
+New pull requests choose exactly one of three paths: independent, employer/client-controlled, or
+unsure. Independent contributors use DCO 1.1 per commit and no individual CLA. Corporate work uses
+the same individual DCO plus a private corporate agreement or narrow authorization. The public
+gate accepts only a designated verifier's opaque receipt decision naming the PR and exact head SHA.
+A push invalidates that verification. Rights review can proceed alongside technical review; merge
+is the only blocked transition.
+
+The maintained DCO App owns DCO identity/trailer verification. Vexa does not reproduce that logic
+with a regular expression and does not allow third parties or maintainers to sign for an author.
+Because the hosted app exposes a write-user override that cannot be disabled in repository
+configuration, a second required `dco-no-override` check accepts only the app's ordinary verified
+success and fails closed on manual overrides or unknown success messages. The local rights gate
+otherwise owns only path selection, review state, and head-bound corporate receipts.
+
+The policy is prospective at the bootstrap PR number. Historical work is risk-triaged and never
+rewritten merely to add sign-offs.
+
+## Consequences
+
+- The ordinary contributor makes one explicit legal choice and uses standard Git sign-off.
+- Corporate authorization becomes attributable, private, and invalidated by code changes.
+- DCO App installation, required-check configuration, a private register, and licensed-counsel
+  approval of the corporate instrument remain activation prerequisites outside the repository.
+- A bootstrap PR can prove the deterministic machinery locally; a post-merge canary PR is required
+  to witness GitHub event, Check Runs, DCO App, and branch-protection behavior end to end.

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -117,7 +117,8 @@
           "governance/index",
           "governance/architecture",
           "governance/arch-compliance",
-          "governance/delivery"
+          "governance/delivery",
+          "governance/contributor-rights"
         ]
       }
     ]

--- a/docs/docs/governance/contributor-rights.mdx
+++ b/docs/docs/governance/contributor-rights.mdx
@@ -1,0 +1,41 @@
+---
+title: "Contributor rights"
+description: "Vexa's low-friction DCO path for individuals and head-bound authorization path for employer-owned contributions."
+---
+
+Vexa uses one conscious rights choice at pull-request intake and automates the remaining mechanics.
+The canonical policy and operational commands live in
+[`CONTRIBUTOR_RIGHTS.md`](https://github.com/Vexa-ai/vexa/blob/main/CONTRIBUTOR_RIGHTS.md).
+
+| Path | Contributor action | Merge evidence |
+|---|---|---|
+| Independent | Select the declaration and sign each commit with `git commit --signoff` | Declaration plus the required DCO check; no individual CLA |
+| Employer/client-controlled | Select the corporate path and provide a legal/IP contact privately | Individual DCO plus a private authorization receipt bound to the current PR head |
+| Unsure | Select unsure as early as possible | Rights review resolves the path before merge |
+
+Technical review may continue during rights review. A later push invalidates a corporate
+verification, and only a designated verifier can bind a private receipt to the new head. Executed
+agreements, signatures, addresses, and employment information never belong in public PR comments.
+
+## Agent-assisted flow
+
+Agents automate Git, not legal judgment. They ask the human to choose the path, check the
+repository-local Git identity, use `--signoff` after authorization, identify failing commits by
+SHA, and prepare safe remediation. They never select the declaration, sign for another person, or
+rewrite/push history without explicit approval.
+
+For the latest unsigned commit:
+
+```bash
+git commit --amend --no-edit --signoff
+git push --force-with-lease
+```
+
+Shared branches use the DCO App's individual remediation flow rather than third-party sign-off.
+
+## Historical work
+
+The gate is prospective. Earlier contributions are triaged by concrete risk instead of rewritten
+or subjected to a blanket CLA campaign. Significant ambiguous work may receive a retrospective
+attestation; corporate-directed work receives a contribution-specific corporate authorization;
+material work that cannot be cleared is replaced or removed.

--- a/docs/docs/governance/index.mdx
+++ b/docs/docs/governance/index.mdx
@@ -62,6 +62,10 @@ contributor's work — a PRD whose acceptance table is a merge promise.
   [the enforcement map](/governance/delivery#enforcement-map).
 - **The actor contract: visibility.** No gate checks the expect→verdict loop — the human
   reading the ledger *is* the gate.
+- **[Contributor rights](/governance/contributor-rights): declaration + DCO + attributable
+  corporate authorization.** Individuals make one conscious choice and encounter no CLA;
+  employer-controlled work waits for a private receipt bound to the current PR head.
+
 
 ## How the law itself changes
 

--- a/scripts/contribution-rights-gate.mjs
+++ b/scripts/contribution-rights-gate.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const RIGHTS = ["independent", "corporate", "uncertain"];
+const DECISION_MARKER = "<!-- vexa-contribution-rights-decision:v1 -->";
+
+function selectedRights(body = "") {
+  return RIGHTS.filter((right) => {
+    const marker = `<!-- rights:${right} -->`;
+    const line = body.split("\n").find((candidate) => candidate.includes(marker)) || "";
+    return /^\s*-\s*\[[xX]\]/.test(line);
+  });
+}
+
+function field(body, name) {
+  const pattern = `^\\s*(?:[-*]\\s*)?${name}:\\s*\\x60?([^\\n\\x60]+)\\x60?\\s*$`;
+  const match = body.match(new RegExp(pattern, "im"));
+  return match?.[1]?.trim();
+}
+
+function parseDecision(comment, config, pr) {
+  const body = comment?.body || "";
+  const login = comment?.user?.login?.toLowerCase();
+  if (!body.includes(DECISION_MARKER) || !config.verifiers.map((v) => v.toLowerCase()).includes(login)) {
+    return null;
+  }
+
+  const decision = field(body, "Decision")?.toLowerCase();
+  const prNumber = field(body, "PR")?.replace(/^#/, "");
+  const head = field(body, "Head")?.toLowerCase();
+  const receipt = field(body, "Receipt");
+  if (!["review", "cleared", "verified"].includes(decision) || Number(prNumber) !== pr.number) return null;
+  if (!/^[0-9a-f]{40}$/.test(head || "")) return null;
+  if (decision === "verified" && !/^VCR-[0-9]{4}-[0-9]{4,}$/.test(receipt || "")) return null;
+
+  return {
+    decision,
+    head,
+    receipt,
+    login: comment.user.login,
+    order: Number(comment.id || 0) || Date.parse(comment.created_at || comment.updated_at || 0),
+  };
+}
+
+export function evaluatePullRequest(pr, comments, config) {
+  if (!Number.isInteger(config.effectiveAfterPullRequest)) {
+    return {
+      ok: false,
+      title: "Contributor-rights gate is not activated",
+      summary: "Set .github/contribution-rights.json effectiveAfterPullRequest to the bootstrap PR number before merge.",
+    };
+  }
+
+  if (pr.number <= config.effectiveAfterPullRequest) {
+    return {
+      ok: true,
+      title: "Grandfathered pull request",
+      summary: `PR #${pr.number} predates contributor-rights enforcement after PR #${config.effectiveAfterPullRequest}.`,
+    };
+  }
+
+  const selected = selectedRights(pr.body || "");
+  if (selected.length !== 1) {
+    return {
+      ok: false,
+      title: "Select exactly one contribution-rights path",
+      summary: `Found ${selected.length} selected paths. Edit the Contribution rights section of the PR description and select exactly one.`,
+    };
+  }
+
+  const decisions = comments
+    .map((comment) => parseDecision(comment, config, pr))
+    .filter(Boolean)
+    .sort((a, b) => a.order - b.order);
+  const latestReview = [...decisions].reverse().find((decision) => decision.decision === "review");
+  const currentHeadDecisions = decisions.filter((decision) => decision.head === pr.head.sha.toLowerCase());
+  const latestCurrent = currentHeadDecisions.at(-1);
+  const unresolvedReview = latestReview && (!latestCurrent || latestCurrent.order <= latestReview.order || latestCurrent.decision === "review");
+
+  if (selected[0] === "uncertain") {
+    return {
+      ok: false,
+      title: "Rights review requested",
+      summary: "Technical review may continue, but merge is blocked. Vexa will help determine whether the independent or corporate path applies.",
+    };
+  }
+
+  if (selected[0] === "independent") {
+    if (unresolvedReview) {
+      return {
+        ok: false,
+        title: "Rights review is unresolved",
+        summary: "A designated verifier opened a rights review. A current-head cleared decision is required before merge.",
+      };
+    }
+    return {
+      ok: true,
+      title: "Independent contribution path is complete",
+      summary: "The contributor selected the independent path. The separately required DCO check validates per-commit sign-offs.",
+    };
+  }
+
+  if (latestCurrent?.decision === "verified" && !unresolvedReview) {
+    return {
+      ok: true,
+      title: "Corporate contribution authorization verified",
+      summary: `Receipt ${latestCurrent.receipt} was verified by @${latestCurrent.login} for PR #${pr.number} at head ${pr.head.sha}.`,
+    };
+  }
+
+  const staleVerification = [...decisions].reverse().find((decision) => decision.decision === "verified");
+  return {
+    ok: false,
+    title: staleVerification ? "Corporate authorization must be re-bound to the current head" : "Corporate authorization is pending",
+    summary: staleVerification
+      ? `The latest verified receipt covers ${staleVerification.head}, not current head ${pr.head.sha}.`
+      : "Technical review may continue, but merge requires a designated verifier's current-head receipt decision.",
+  };
+}
+
+async function requestJson(url, token, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+  if (!response.ok) throw new Error(`GitHub API ${response.status} for ${url}: ${await response.text()}`);
+  return response.status === 204 ? null : response.json();
+}
+
+async function pullRequestsForEvent(event, apiBase, token) {
+  if (event.pull_request) return [event.pull_request];
+  if (event.issue?.pull_request) {
+    return [await requestJson(`${apiBase}/repos/${event.repository.full_name}/pulls/${event.issue.number}`, token)];
+  }
+  if (event.merge_group?.head_ref) {
+    const match = event.merge_group.head_ref.match(/(?:^|\/)gh-readonly-queue\/.+\/pr-(\d+)-/);
+    if (!match) throw new Error(`Unrecognized merge-group head ref: ${event.merge_group.head_ref}`);
+    return [await requestJson(`${apiBase}/repos/${event.repository.full_name}/pulls/${Number(match[1])}`, token)];
+  }
+  return [];
+}
+
+async function commentsForPullRequest(event, pr, apiBase, token) {
+  const comments = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const batch = await requestJson(
+      `${apiBase}/repos/${event.repository.full_name}/issues/${pr.number}/comments?per_page=100&page=${page}`,
+      token,
+    );
+    comments.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return comments;
+}
+
+async function createCheck(event, headSha, { name, ok, title, summary }, apiBase, token) {
+  await requestJson(`${apiBase}/repos/${event.repository.full_name}/check-runs`, token, {
+    method: "POST",
+    body: JSON.stringify({
+      name,
+      head_sha: headSha,
+      status: "completed",
+      conclusion: ok ? "success" : "failure",
+      output: { title, summary: summary.slice(0, 65000) },
+    }),
+  });
+  return ok;
+}
+
+async function publishRightsCheck(event, headSha, results, apiBase, token) {
+  const ok = results.every((result) => result.verdict.ok);
+  const summary = results
+    .map(({ pr, verdict }) => `### PR #${pr.number}: ${verdict.title}\n\n${verdict.summary}`)
+    .join("\n\n");
+  return createCheck(event, headSha, {
+    name: "contribution-rights",
+    ok,
+    title: ok ? "Contribution rights complete" : "Contribution rights action required",
+    summary,
+  }, apiBase, token);
+}
+
+async function publishDcoPolicyCheck(event, apiBase, token) {
+  const dco = event.check_run;
+  const ordinarySuccess = dco.conclusion === "success" && dco.output?.summary?.trim() === "All commits are signed off!";
+  return createCheck(event, dco.head_sha, {
+    name: "dco-no-override",
+    ok: ordinarySuccess,
+    title: ordinarySuccess ? "DCO completed without override" : "DCO result is not an ordinary verified success",
+    summary: ordinarySuccess
+      ? "The maintained DCO App verified every applicable commit."
+      : "Vexa does not accept manual DCO overrides or unknown success messages. The original author must complete DCO remediation and rerun the DCO check.",
+  }, apiBase, token);
+}
+
+export async function run({ event, config, token, apiBase = "https://api.github.com" }) {
+  if (event.check_run?.name === "DCO" && event.check_run?.app?.slug === "dco") {
+    return publishDcoPolicyCheck(event, apiBase, token);
+  }
+  const pullRequests = await pullRequestsForEvent(event, apiBase, token);
+  if (!pullRequests.length) return true;
+  const results = [];
+  for (const pr of pullRequests) {
+    const comments = await commentsForPullRequest(event, pr, apiBase, token);
+    results.push({ pr, verdict: evaluatePullRequest(pr, comments, config) });
+  }
+  const headSha = event.merge_group?.head_sha || pullRequests[0].head.sha;
+  return publishRightsCheck(event, headSha, results, apiBase, token);
+}
+
+async function main() {
+  const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+  const config = JSON.parse(readFileSync(process.env.CONTRIBUTION_RIGHTS_CONFIG || ".github/contribution-rights.json", "utf8"));
+  const ok = await run({ event, config, token: process.env.GITHUB_TOKEN });
+  if (!ok) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/contribution-rights-gate.test.mjs
+++ b/scripts/contribution-rights-gate.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluatePullRequest, run } from "./contribution-rights-gate.mjs";
+
+const sha = "a".repeat(40);
+const oldSha = "b".repeat(40);
+const config = { effectiveAfterPullRequest: 100, verifiers: ["rights-verifier"] };
+const body = (selected) => `
+## Contribution rights
+- [${selected === "independent" ? "x" : " "}] I own this contribution. <!-- rights:independent -->
+- [${selected === "corporate" ? "x" : " "}] An employer or client owns or controls it. <!-- rights:corporate -->
+- [${selected === "uncertain" ? "x" : " "}] I am unsure. <!-- rights:uncertain -->
+`;
+const pr = (overrides = {}) => ({ number: 101, body: body("independent"), head: { sha }, ...overrides });
+const decision = ({ type = "verified", head = sha, login = "rights-verifier", receipt = "VCR-2026-0001", created = 1 } = {}) => ({
+  id: created,
+  created_at: new Date(created * 1000).toISOString(),
+  user: { login },
+  body: `<!-- vexa-contribution-rights-decision:v1 -->
+Decision: ${type}
+Receipt: ${receipt}
+PR: #101
+Head: ${head}`,
+});
+
+test("grandfathers PRs at or before activation", () => {
+  assert.equal(evaluatePullRequest(pr({ number: 100, body: "" }), [], config).ok, true);
+});
+
+test("fails closed while the bootstrap PR number is unset", () => {
+  const verdict = evaluatePullRequest(pr(), [], { ...config, effectiveAfterPullRequest: "__BOOTSTRAP_PR__" });
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.title, /not activated/);
+});
+
+test("requires exactly one declaration", () => {
+  assert.equal(evaluatePullRequest(pr({ body: body("none") }), [], config).ok, false);
+  const multiple = `${body("independent")}`.replace("[ ] An employer", "[x] An employer");
+  assert.equal(evaluatePullRequest(pr({ body: multiple }), [], config).ok, false);
+});
+
+test("independent path passes without a CLA", () => {
+  const verdict = evaluatePullRequest(pr(), [], config);
+  assert.equal(verdict.ok, true);
+  assert.match(verdict.summary, /separately required DCO/);
+});
+
+test("uncertain path opens review and blocks merge", () => {
+  assert.equal(evaluatePullRequest(pr({ body: body("uncertain") }), [], config).ok, false);
+});
+
+test("corporate path requires a designated current-head receipt", () => {
+  const corporate = pr({ body: body("corporate") });
+  assert.equal(evaluatePullRequest(corporate, [], config).ok, false);
+  assert.equal(evaluatePullRequest(corporate, [decision({ login: "outsider" })], config).ok, false);
+  assert.equal(evaluatePullRequest(corporate, [decision({ head: oldSha })], config).ok, false);
+  assert.equal(evaluatePullRequest(corporate, [decision()], config).ok, true);
+});
+
+test("verifier identity is case-insensitive but receipt format is strict", () => {
+  const corporate = pr({ body: body("corporate") });
+  assert.equal(evaluatePullRequest(corporate, [decision({ login: "RIGHTS-VERIFIER" })], config).ok, true);
+  assert.equal(evaluatePullRequest(corporate, [decision({ receipt: "sony-email" })], config).ok, false);
+});
+
+test("a decision for another PR cannot authorize this PR", () => {
+  const wrongPr = decision();
+  wrongPr.body = wrongPr.body.replace("PR: #101", "PR: #999");
+  assert.equal(evaluatePullRequest(pr({ body: body("corporate") }), [wrongPr], config).ok, false);
+});
+
+test("a new push invalidates corporate verification", () => {
+  const verdict = evaluatePullRequest(
+    pr({ body: body("corporate"), head: { sha: oldSha } }),
+    [decision({ head: sha })],
+    config,
+  );
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.title, /re-bound/);
+});
+
+test("a review hold blocks an independent declaration until current-head clearance", () => {
+  const review = decision({ type: "review", created: 1 });
+  assert.equal(evaluatePullRequest(pr(), [review], config).ok, false);
+  const cleared = decision({ type: "cleared", receipt: "", created: 2 });
+  assert.equal(evaluatePullRequest(pr(), [review, cleared], config).ok, true);
+  assert.equal(evaluatePullRequest(pr({ head: { sha: oldSha } }), [review, cleared], config).ok, false);
+});
+
+test("a review posted after corporate verification re-blocks merge", () => {
+  const verified = decision({ created: 1 });
+  const review = decision({ type: "review", created: 2 });
+  assert.equal(evaluatePullRequest(pr({ body: body("corporate") }), [verified, review], config).ok, false);
+});
+
+test("verification after review resolves the corporate path at the same head", () => {
+  const review = decision({ type: "review", created: 1 });
+  const verified = decision({ created: 2 });
+  assert.equal(evaluatePullRequest(pr({ body: body("corporate") }), [review, verified], config).ok, true);
+});
+
+test("markdown text cannot spoof an unchecked declaration marker", () => {
+  const spoofed = `${body("none")}\nThe text [x] appears elsewhere <!-- rights:independent -->`;
+  assert.equal(evaluatePullRequest(pr({ body: spoofed }), [], config).ok, false);
+});
+
+test("pull-request event publishes the result against the PR head", async () => {
+  const event = { repository: { full_name: "Vexa-ai/vexa" }, pull_request: pr() };
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    const payload = url.includes("/comments") ? [] : {};
+    return { ok: true, status: options.method === "POST" ? 201 : 200, json: async () => payload, text: async () => "" };
+  };
+  try {
+    assert.equal(await run({ event, config, token: "test", apiBase: "https://example.test" }), true);
+    const publish = calls.find((call) => call.url.endsWith("/check-runs"));
+    assert.equal(JSON.parse(publish.options.body).head_sha, sha);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("issue-comment event re-evaluates the current PR head", async () => {
+  const event = {
+    repository: { full_name: "Vexa-ai/vexa" },
+    issue: { number: 101, pull_request: { url: "https://example.test/pr/101" } },
+  };
+  const corporate = pr({ body: body("corporate") });
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    let payload = {};
+    if (url.endsWith("/pulls/101")) payload = corporate;
+    else if (url.includes("/issues/101/comments")) payload = [decision()];
+    return { ok: true, status: options.method === "POST" ? 201 : 200, json: async () => payload, text: async () => "" };
+  };
+  try {
+    assert.equal(await run({ event, config, token: "test", apiBase: "https://example.test" }), true);
+    const publish = calls.find((call) => call.url.endsWith("/check-runs"));
+    assert.equal(JSON.parse(publish.options.body).conclusion, "success");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ordinary DCO App success produces the no-override success check", async () => {
+  const event = {
+    repository: { full_name: "Vexa-ai/vexa" },
+    check_run: { name: "DCO", app: { slug: "dco" }, head_sha: sha, conclusion: "success", output: { summary: "All commits are signed off!" } },
+  };
+  const originalFetch = globalThis.fetch;
+  let published;
+  globalThis.fetch = async (_url, options = {}) => {
+    published = JSON.parse(options.body);
+    return { ok: true, status: 201, json: async () => ({}), text: async () => "" };
+  };
+  try {
+    assert.equal(await run({ event, config, token: "test", apiBase: "https://example.test" }), true);
+    assert.equal(published.name, "dco-no-override");
+    assert.equal(published.conclusion, "success");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("DCO App manual override is rejected", async () => {
+  const event = {
+    repository: { full_name: "Vexa-ai/vexa" },
+    check_run: { name: "DCO", app: { slug: "dco" }, head_sha: sha, conclusion: "success", output: { summary: "Commit sign-off was manually approved." } },
+  };
+  const originalFetch = globalThis.fetch;
+  let published;
+  globalThis.fetch = async (_url, options = {}) => {
+    published = JSON.parse(options.body);
+    return { ok: true, status: 201, json: async () => ({}), text: async () => "" };
+  };
+  try {
+    assert.equal(await run({ event, config, token: "test", apiBase: "https://example.test" }), false);
+    assert.equal(published.name, "dco-no-override");
+    assert.equal(published.conclusion, "failure");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("merge-group run resolves its PR from the queue ref and publishes on the group head", async () => {
+  const groupSha = "c".repeat(40);
+  const event = {
+    repository: { full_name: "Vexa-ai/vexa" },
+    merge_group: { head_sha: groupSha, head_ref: "refs/heads/gh-readonly-queue/main/pr-101-abcdef" },
+  };
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    let payload = {};
+    if (url.endsWith("/pulls/101")) payload = pr();
+    else if (url.includes("/issues/101/comments")) payload = [];
+    return { ok: true, status: options.method === "POST" ? 201 : 200, json: async () => payload, text: async () => "" };
+  };
+  try {
+    assert.equal(await run({ event, config, token: "test", apiBase: "https://example.test" }), true);
+    const publish = calls.find((call) => call.url.endsWith("/check-runs"));
+    assert.equal(JSON.parse(publish.options.body).head_sha, groupSha);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
**Delivers issue:** #1007

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## Observation bundle

- **C1 — contributor-rights gate:** ran the zero-dependency event harness at base
  `1f6898cf486a0f57ee0544e5e7bd6382f9612a6f`; saw 18/18 rights scenarios pass; concluded the
  independent, review, corporate receipt, stale-head, no-override and merge-group state machine is
  deterministic. Full live GitHub integration remains the declared post-merge canary.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 | Independent green; missing/multiple declaration red |
| A2 | Unsure red without blocking technical review |
| A3 | Exact designated current-head receipt green; outsider/malformed/wrong-PR/stale red |
| A4 | Synthetic later push invalidates the old receipt |
| A5 | Review/clear/verify ordering and stale-clear controls pass |
| A6 | Ordinary DCO success green; manual override red |
| A7 | PR, issue-comment and merge-group event fixtures publish on the intended SHA |
| A- | Rights harness 18/18; `gate:readme` green; `gate:node` 18 package builds/tests green. The broad script suite is 77/79 with two unrelated SBOM/`pnpm list` failures; full `gates all` remains red in unrelated baseline/environment lanes and is not claimed. |

## Docs diff

Adds the canonical contributor-rights policy, contributor/agent how-to, corporate private-return
boundary, governance page/navigation and ADR. No unapproved CCLA text or executed agreement is
published.

## Security checks

- Fork code is never checked out or executed under `pull_request_target`.
- Checkout is pinned to an immutable action SHA and the trusted default branch.
- Token scope is metadata read plus Check Runs write; contributor-controlled text is not emitted.
- Corporate receipts are opaque, verifier-allowlisted, PR-bound and head-bound.
- DCO third-party remediation is disabled and manual override is independently rejected.
- Staged-diff credential-pattern scan found no credential material; `git diff --cached --check` is clean.

## Validation request

A non-author maintainer reviews the `pull_request_target` boundary and witnesses the post-merge
canary against Vexa's real DCO App, ruleset and merge queue. Product deployments are out of scope.

## Authorship

Sole author: Dmitry Grankin. No agent co-author trailers.
Tooling disclosure: Codex assisted with research, implementation and deterministic testing.
