### PR TITLE
docs: clarify contributor-rights choice

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,9 @@
 <!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
      must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->
 
+> **Select exactly one.** GitHub checkboxes are not radio buttons; selecting zero or multiple
+> choices fails the required `contribution-rights` check.
+
 - [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
   under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
   <!-- rights:independent -->

--- a/CONTRIBUTOR_RIGHTS.md
+++ b/CONTRIBUTOR_RIGHTS.md
@@ -59,6 +59,11 @@ revenue, procurement, or permission to use the organization's name or marks.
 
 ## Fixing a DCO failure
 
+On a published branch, prefer the failed DCO check's author-only remediation message when it is
+available. It adds the original author's certification in a new commit without rewriting shared
+history. Copy that message exactly; never use a maintainer override. An agent may prepare the
+remediation only after the named author explicitly approves it.
+
 For the latest commit:
 
 ```bash

--- a/scripts/contribution-rights-gate.mjs
+++ b/scripts/contribution-rights-gate.mjs
@@ -7,11 +7,27 @@ const RIGHTS = ["independent", "corporate", "uncertain"];
 const DECISION_MARKER = "<!-- vexa-contribution-rights-decision:v1 -->";
 
 function selectedRights(body = "") {
-  return RIGHTS.filter((right) => {
-    const marker = `<!-- rights:${right} -->`;
-    const line = body.split("\n").find((candidate) => candidate.includes(marker)) || "";
-    return /^\s*-\s*\[[xX]\]/.test(line);
-  });
+  const lines = body.split("\n");
+  const selected = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const checkbox = lines[index].match(/^[ \t]*-[ \t]*\[([ xX])\]/);
+    if (!checkbox) continue;
+
+    const item = [lines[index]];
+    while (index + 1 < lines.length && /^[ \t]+\S/.test(lines[index + 1])) {
+      index += 1;
+      item.push(lines[index]);
+    }
+
+    if (checkbox[1].toLowerCase() !== "x") continue;
+    const itemBody = item.join("\n");
+    for (const right of RIGHTS) {
+      if (itemBody.includes(`<!-- rights:${right} -->`)) selected.push(right);
+    }
+  }
+
+  return selected;
 }
 
 function field(body, name) {

--- a/scripts/contribution-rights-gate.test.mjs
+++ b/scripts/contribution-rights-gate.test.mjs
@@ -8,9 +8,13 @@ const oldSha = "b".repeat(40);
 const config = { effectiveAfterPullRequest: 100, verifiers: ["rights-verifier"] };
 const body = (selected) => `
 ## Contribution rights
-- [${selected === "independent" ? "x" : " "}] I own this contribution. <!-- rights:independent -->
-- [${selected === "corporate" ? "x" : " "}] An employer or client owns or controls it. <!-- rights:corporate -->
-- [${selected === "uncertain" ? "x" : " "}] I am unsure. <!-- rights:uncertain -->
+- [${selected === "independent" ? "x" : " "}] I own this contribution.
+  This description wraps like the production pull-request template.
+  <!-- rights:independent -->
+- [${selected === "corporate" ? "x" : " "}] An employer or client owns or controls it.
+  <!-- rights:corporate -->
+- [${selected === "uncertain" ? "x" : " "}] I am unsure.
+  <!-- rights:uncertain -->
 `;
 const pr = (overrides = {}) => ({ number: 101, body: body("independent"), head: { sha }, ...overrides });
 const decision = ({ type = "verified", head = sha, login = "rights-verifier", receipt = "VCR-2026-0001", created = 1 } = {}) => ({
@@ -44,6 +48,11 @@ test("independent path passes without a CLA", () => {
   const verdict = evaluatePullRequest(pr(), [], config);
   assert.equal(verdict.ok, true);
   assert.match(verdict.summary, /separately required DCO/);
+});
+
+test("accepts a marker on the checkbox line for backwards compatibility", () => {
+  const inline = "- [x] I own this contribution. <!-- rights:independent -->";
+  assert.equal(evaluatePullRequest(pr({ body: inline }), [], config).ok, true);
 });
 
 test("uncertain path opens review and blocks merge", () => {


### PR DESCRIPTION
**Canary for:** #1007 (does not close it)

## Contribution rights

> **Select exactly one.** GitHub checkboxes are not radio buttons; selecting zero or multiple
> choices fails the required `contribution-rights` check.

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it <!-- rights:independent -->
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or <!-- rights:corporate -->
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Observation bundle

- **Expected negative control:** the independent declaration makes `contribution-rights` pass,
  while the intentionally unsigned initial commit makes `DCO` fail. No remediation has occurred.
- **Local evidence:** the one-file diff is clean; the contributor-rights harness passes 18/18;
  the 14 pre-push static gates pass after installing the locked workspace dependencies.

## Acceptance floor

| Row | Evidence |
|---|---|
| Individual declaration | Pending live `contribution-rights` Check Run |
| Missing DCO sign-off | Pending live DCO failure |
| Agent remediation | Deliberately not performed in this phase |

## Docs diff

Makes the exactly-one constraint visible in the pull-request template instead of hiding it only
inside an HTML comment.

## Security checks

No executable code or workflow permissions change. GitHub CI is the authoritative full-suite run.

## Validation request

The maintainer witnesses the expected rights-green/DCO-red split before authorizing remediation.
This draft must not merge in its initial unsigned state.

## Authorship

Sole author: Dmitry Grankin. No agent co-author trailers.
Tooling disclosure: Codex prepared the one-file diff and canary mechanics under explicit human
rights selection and publication approval.
