### PR TITLE
build: noble base image for the bot (lite + full)

### DIFF
--- a/core/meetings/modules/join/Dockerfile.env
+++ b/core/meetings/modules/join/Dockerfile.env
@@ -10,7 +10,7 @@
 #   - the live lens: x11vnc + novnc + websockify
 #
 # Build:  docker build -f Dockerfile.env -t vexa/meet-join-env:dev .
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy
+FROM mcr.microsoft.com/playwright:v1.56.0-noble
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       xvfb x11vnc websockify novnc xdotool xclip \

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -22,7 +22,7 @@
 # Mirrors core/meetings/services/bot/Dockerfile (builder), but on the official Playwright
 # image instead of the published meet-join-env base. Browsers come from /ms-playwright.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS bot-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS bot-builder
 ENV PNPM_HOME=/pnpm \
     PATH=/pnpm:$PATH \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
@@ -52,7 +52,7 @@ RUN cd /build && node core/meetings/services/bot/warm-hf-cache.mjs || echo "[bot
 # runtime node_modules (npm prune --omit=dev) rather than a standalone trace. Built on the SAME
 # Playwright base as the final stage so any native addon (ws' bufferutil) is ABI-compatible.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS terminal-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS terminal-builder
 WORKDIR /app/terminal
 COPY clients/terminal/package.json clients/terminal/package-lock.json ./
 RUN npm ci --no-audit --no-fund
@@ -61,14 +61,14 @@ COPY clients/terminal/ ./
 RUN npm run build && npm prune --omit=dev
 
 # -----------------------------------------------------------------------------
-# Stage 2c: valkey-builder — build valkey-server + valkey-cli from source on the SAME jammy glibc
+# Stage 2c: valkey-builder — build valkey-server + valkey-cli from source on the SAME glibc
 # as the final stage. Valkey (Linux Foundation BSD-3 fork of Redis 7.2.4) gives XAUTOCLAIM parity
 # with compose/helm and keeps Lite off BOTH ends of the #653 gap: jammy apt's stale redis 6.0.16
 # (no XAUTOCLAIM — the v0.12.5 witness root) AND source-available Redis ≥7.4 (RSALv2/SSPLv1). Built
 # from the pinned git tag, so: no external apt-repo trust (the issue verified redis's apt license
 # metadata is wrong), and no glibc mismatch — an alpine/musl binary can't run on this glibc base.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS valkey-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS valkey-builder
 ARG VALKEY_VERSION=8.1.9
 # Pinned SHA-256 of the tag tarball (supply-chain, production-grade R16): the build verifies the bytes,
 # not just the version. `sha256sum -c` fails LOUD on any mismatch — a tampered or drifted tarball stops
@@ -89,7 +89,7 @@ RUN curl -fsSL "https://github.com/valkey-io/valkey/archive/refs/tags/${VALKEY_V
 # -----------------------------------------------------------------------------
 # Stage 3: final — assemble the all-in-one runtime image on the same Playwright base.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS final
 ENV DEBIAN_FRONTEND=noninteractive
 
 # System stack: Python (the 5 services) · supervisor · X11/audio (Xvfb/fluxbox/pulse) ·
@@ -112,8 +112,10 @@ COPY --from=valkey-builder /opt/valkey/bin/valkey-server /opt/valkey/bin/valkey-
 COPY --from=valkey-builder /valkey-COPYING /usr/local/share/valkey/LICENSE
 RUN valkey-server --version && command -v valkey-cli
 
-# uv (the per-service venvs are resolved from each service's own pyproject + uv.lock).
-RUN pip3 install --no-cache-dir uv==0.9.22
+# uv — the per-service venvs resolve from each service's pyproject + uv.lock. Standalone installer
+# (version-pinned), on PATH at /usr/local/bin.
+RUN curl -LsSf https://astral.sh/uv/0.9.22/install.sh | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh \
+ && uv --version
 
 ENV UV_LINK_MODE=copy \
     PYTHONUNBUFFERED=1 \
@@ -126,7 +128,7 @@ RUN mkdir -p /var/log/supervisor /var/lib/redis /var/run/redis /workspaces
 # ── Python venvs — one per service (avoids cross-service dependency-pin conflicts). Each mirrors
 #    that service's Dockerfile (uv sync --frozen + the production-only ASGI/DB extras). ────────────
 #    `--python 3.12` pins the interpreter to match every compose image's `FROM python:3.12-slim`.
-#    The jammy base ships only system python3.10 (< requires-python >=3.11), so an unpinned
+#    The base's system python can lag requires-python >=3.11, so an unpinned
 #    `uv venv` would auto-download the newest managed CPython (3.14) — whose stack fails at boot
 #    (SQLAlchemy's psycopg dialect import). Pinning keeps Lite on the same interpreter as compose/helm.
 # admin-api
@@ -154,6 +156,15 @@ COPY core/agent/pyproject.toml core/agent/uv.lock /tmp/agent/
 RUN cd /tmp/agent && uv venv --python 3.12 /opt/venvs/agent \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/agent uv sync --frozen --no-install-project --no-default-groups --group control-plane
 RUN rm -rf /tmp/admin /tmp/runtime /tmp/meeting /tmp/gateway /tmp/agent
+
+# The agent worker is the ONE venv exec'd as a NON-ROOT per-subject uid (the runtime process
+# backend's POSIX tenant isolation — core/runtime/src/runtime_kernel/isolation.py). Its interpreter
+# is the uv-managed CPython under /root/.local (uv installs managed pythons under HOME), and /root
+# is 0700 — so the sandbox uid cannot TRAVERSE /root to exec python: every dispatch dies with
+# "Permission denied" (exit 126) and respawns forever ("starting agent"). Grant traverse-only: the
+# interpreter tree underneath is already world-readable; /root keeps no read bit (stays unlistable)
+# and any root-only secret under it keeps its own 0600.
+RUN chmod o+x /root
 
 # Claude Code (the agent worker's model+tooling runtime) — npm global, on PATH for every spawned worker.
 RUN npm install -g @anthropic-ai/claude-code

--- a/docs/changelog.d/1011-noble-base.md
+++ b/docs/changelog.d/1011-noble-base.md
@@ -1,0 +1,3 @@
+- **The bot and Lite images now build on Ubuntu 24.04 (Noble) (#1011).** The meeting-bot image and
+  the Vexa Lite single-container image moved from the Jammy to the Noble Playwright base and run the
+  Python interpreter as a non-root user, keeping both current and hardened.

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -230,7 +230,7 @@ test("image-licenses RED: an undeclared structured Helm repository/tag pin reds"
 });
 
 test("image-licenses RED: an undeclared Dockerfile FROM pin reds", () => {
-  const base = "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS bot-builder";
+  const base = "FROM mcr.microsoft.com/playwright:v1.56.0-noble AS bot-builder";
   const injected = `FROM somevendor/unaudited:1.2 AS review-probe\n${base}`;
   const r = withEdited(LITE, base, injected, () => runGate("image-licenses"));
   assert.equal(r.green, false, "an undeclared Dockerfile FROM image pin sailed through");
@@ -240,8 +240,8 @@ test("image-licenses RED: an undeclared Dockerfile FROM pin reds", () => {
 
 test("runtime-parity RED: the bare `apt install` form (not just apt-get) is caught too", () => {
   // A contributor who writes `apt install redis-server` (no -get) must not bypass the #636 guard.
-  const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final";
-  const r = withEdited(LITE, "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final", inject,
+  const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-noble AS final";
+  const r = withEdited(LITE, "FROM mcr.microsoft.com/playwright:v1.56.0-noble AS final", inject,
     () => runGate("runtime-parity"));
   assert.equal(r.green, false, "`apt install redis-server` (no -get) bypassed the parity guard");
   assert.match(r.out, /lite/);


### PR DESCRIPTION
**Delivers issue:** _(none — maintainer's own work)_

Switch the bot's base image (Vexa Lite's `Dockerfile.lite` all stages, and the full bot's `meet-join-env` base) to `mcr.microsoft.com/playwright:v1.56.0-noble` — one base for lite and full. Also folds in the non-root `chmod o+x /root` fix (the agent worker's uv-managed Python lives under `/root`).

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## Observation bundle
- **C1 —** ran: lite + full bot image build on noble · saw: both lite and full bot images build on noble; the bot (in lite) joins meetings and operates normally · concluded: noble base works for lite and full.

_Live-witnessed on the maintainer's self-hosted lite deployment._

_Changelog fragment included (`docs/changelog.d/1011-noble-base.md`). Bottom of a stacked series; the rest build on this branch._

---
Commits carry DCO `Signed-off-by` and are SSH-signed.


