### PR TITLE
fix(meetings): stuck-'stopping' + premature 'Meeting ended' banner

### DIFF
--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -1898,6 +1898,12 @@ def create_app(
                     if payload.get("type") == "retract":
                         yield from retract_event(payload)
                         continue
+                    # A real segment AFTER a session_end in the replay tail means a NEW session resumed
+                    # on this reused meeting-row stream (tc:meeting:{id} is shared across a meeting's
+                    # sessions). The prior end must NOT close the current live view — without this reset
+                    # a stale session_end seeds `ending=True` and fires a premature `meeting-end`, so the
+                    # terminal shows "Meeting ended" over a still-live meeting.
+                    ending = False
                     yield from seg_events(payload)
             if resume_o is None:   # fresh connect → seed the output (cards/agent-activity) replay
                 output_seed_rows = list(reversed(r.xrevrange(okey, count=MEETING_STREAM_OUTPUT_REPLAY) or []))
@@ -1926,7 +1932,13 @@ def create_app(
                             live.drop(session_uid)  # leaves the terminal's live-meetings feed
                             yield ({"type": "meeting-end"}, cursor())
                             return
-                        continue  # the final beat is still writing — keep draining
+                        # The final beat is still writing — keep draining. But this branch polls every
+                        # 1.5s and yields NOTHING, so a drain that waits out the copilot (up to the 45s
+                        # cap) goes silent well past the terminal's 20s SSE watchdog → the browser
+                        # force-reconnects mid-drain ("stream disconnected" banner + a re-replayed
+                        # session_end). Emit a ping so a healthy drain stays visibly alive.
+                        yield ({"type": "ping"}, cursor())
+                        continue
                     idle += 15000
                     if idle >= 600000:
                         return
@@ -1938,14 +1950,26 @@ def create_app(
                         last[stream] = entry_id
                         if stream == tkey:
                             payload = json.loads(fields.get("payload", "{}"))
-                            if payload.get("type") == "session_end":
+                            ptype = payload.get("type")
+                            if ptype == "session_end":
                                 ending = True            # don't end yet — drain the final beat first
                                 ending_at = _time.monotonic()
                                 last.pop(tkey, None)     # session_end is the last transcript entry
                                 break
-                            if payload.get("type") == "retract":
+                            if ptype == "retract":
                                 yield from retract_event(payload)
                                 continue
+                            # A NEW session resumed on this REUSED row (tc:meeting:{id} is shared across a
+                            # meeting's sessions): a `session_start` marker — or any real segment — arriving
+                            # after a prior `session_end` means the meeting is LIVE again. Clear a stale
+                            # `ending` so the ≤45s drain never fires a premature `meeting-end` over it (the
+                            # terminal showed "Meeting ended" on a still-live meeting). Mirrors the seed's
+                            # reset at connect; without it the live loop kept `ending=True` because it only
+                            # ever SET the flag, never cleared it.
+                            if ending:
+                                ending = False
+                            if ptype == "session_start":
+                                continue                 # marker only — nothing to render
                             yield from seg_events(payload)
                         elif stream == pkey:
                             yield from note_events(fields)

--- a/core/agent/tests/test_api.py
+++ b/core/agent/tests/test_api.py
@@ -897,6 +897,47 @@ def test_sse_relays_retract_marker(monkeypatch):
     assert "turn:1:p0" in body        # carrying the withdrawn segment id
 
 
+class _ResumedSessionRedis:
+    """A REUSED meeting row (tc:meeting:{id} is shared across sessions): the live tail delivers a prior
+    session's session_end, THEN a new session's session_start + a fresh segment. Empty polls follow.
+    `exists`→0 so, WITHOUT the ending-reset fix, the first empty drain poll would fire meeting-end via
+    the `not has_proc` branch — the premature "Meeting ended" over a live meeting."""
+    def __init__(self):
+        self._reads = 0
+
+    def xrevrange(self, key, count=1):
+        return []            # nothing to seed — the stale end arrives on the LIVE tail below
+
+    def exists(self, key):
+        return 0             # no copilot proc stream
+
+    def xread(self, last, count=500, block=0):
+        import json as _j
+        self._reads += 1
+        if self._reads == 1:
+            return [("tc:meeting:m1", [("1-0", {"payload": _j.dumps({"type": "session_end"})})])]
+        if self._reads == 2:
+            return [("tc:meeting:m1", [("2-0", {"payload": _j.dumps({"type": "session_start", "uid": "m1"})})])]
+        if self._reads == 3:
+            return [("tc:meeting:m1", [("3-0", {"payload": _j.dumps(
+                {"type": "transcription", "segments": [{"speaker": "J", "text": "still live", "start": 9, "segment_id": "s9"}]})})])]
+        return []            # idle — with the fix `ending` is cleared, so NO meeting-end fires
+
+
+def test_sse_session_start_clears_stale_ending_no_premature_end(monkeypatch):
+    """Regression (terminal showed "Meeting ended" over a still-live meeting): when a REUSED row's live
+    tail carries a prior session_end followed by the new session's session_start + a real segment, the
+    stream must CLEAR the stale `ending` and NOT emit a premature meeting-end. The segment is relayed."""
+    fr = _ResumedSessionRedis()
+    c = _stream_client(fr, monkeypatch)
+    with c.stream("GET", "/api/meeting/stream", params={"meeting_id": "m1", "session_uid": "m1"},
+                  headers={"X-User-Id": "u_owner"}) as r:
+        assert r.status_code == 200
+        body = "".join(r.iter_text())
+    assert '"still live"' in body                           # the resumed session's segment reached the view
+    assert '"meeting-end"' not in body                      # the stale session_end did NOT close the live view
+
+
 # ── SSE cross-tenant ownership regression (P0 — the FIX-FIRST blocker) ────────────────────────────
 # The by-row-id SSE feed `/api/meeting/stream` must OWNER-SCOPE the row like the WS `/ws` path + the
 # by-id REST path do. Pre-fix it read `tc:meeting:{meeting_id}` straight off the caller-supplied query

--- a/core/meetings/modules/record-chunker/src/index.ts
+++ b/core/meetings/modules/record-chunker/src/index.ts
@@ -91,6 +91,16 @@ export class MediaRecorderChunker implements RecordingTap {
     return this.recorder;
   }
 
+  /** Force the recorder to emit a chunk NOW with everything buffered since the last timeslice —
+   *  without stopping. The tail-loss fix: on eviction Zoom navigates the page away (destroying the
+   *  recorder) before the next timeslice boundary, so the last partial (the final few seconds of
+   *  speech) never becomes a chunk. Flushing at the earliest end-signal (the mix going silent) turns
+   *  that partial into a real, immediately-uploaded chunk before the context dies. Idempotent + safe. */
+  flush(): void {
+    try { if (this.recorder && this.recorder.state === "recording") this.recorder.requestData(); }
+    catch (err: any) { blog(`[record-chunker] flush() requestData failed: ${err?.message || err}`); }
+  }
+
   async start(): Promise<void> {
     if (this.recorder) {
       blog("[record-chunker] start() called twice — ignoring");
@@ -277,11 +287,15 @@ class DynamicAudioMixer {
   private dest: MediaStreamAudioDestinationNode;
   private sources = new Map<string, { node: MediaStreamAudioSourceNode; stream: MediaStream }>();
   private timer: ReturnType<typeof setInterval> | null = null;
+  /** Fired when the live-source count falls to 0 (all participant tracks ended — the meeting is
+   *  closing). The recording host uses it to flush the recorder's buffered tail before the page dies. */
+  private onEmpty: (() => void) | null;
 
-  constructor() {
+  constructor(onEmpty?: () => void) {
     this.ctx = new AudioContext();   // default (full) sample rate — NOT the 16 kHz transcription mix
     this.ctx.resume?.();
     this.dest = this.ctx.createMediaStreamDestination();
+    this.onEmpty = onEmpty ?? null;
   }
 
   get stream(): MediaStream { return this.dest.stream; }
@@ -302,12 +316,16 @@ class DynamicAudioMixer {
     // Prune truly-dead streams (all tracks ended) so a long meeting's track churn doesn't accumulate
     // source nodes. A still-live stream is KEPT even if its element left the DOM (the node holds the
     // stream ref and still pulls audio) — presence is not the liveness signal, the track state is.
+    const had = this.sources.size;
     for (const [id, entry] of this.sources) {
       if (entry.stream.getAudioTracks().some((t) => t.readyState === "live")) continue;
       try { entry.node.disconnect(); } catch { /* */ }
       this.sources.delete(id);
       blog(`[record-chunker] mix -stream (${this.sources.size} live)`);
     }
+    // Just went silent (all tracks ended → the meeting is closing) — flush the recorder's buffered tail
+    // NOW, before the platform navigates the page away and destroys the recorder mid-partial-timeslice.
+    if (had > 0 && this.sources.size === 0 && this.onEmpty) { try { this.onEmpty(); } catch { /* */ } }
   }
 
   start(): void {
@@ -349,7 +367,10 @@ export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTa
         // No ready stream ⇒ build a LIVE mix of the page's audio. Wait (bounded) for the first stream —
         // post-admission the participant / injected <audio> elements appear a beat late — so the
         // MediaRecorder's onStarted t=0 aligns with real audio; the rescan then follows the churn.
-        mixer = new DynamicAudioMixer();
+        // onEmpty → flush the recorder's buffered tail the instant the mix goes silent (meeting close),
+        // so the final partial timeslice (the last few seconds of speech) is a real chunk before the
+        // page navigates away on eviction. `chunker` is assigned just below and set by the time this fires.
+        mixer = new DynamicAudioMixer(() => chunker?.flush());
         let ready = false;
         for (let i = 0; i < 5; i++) {
           mixer.scan();

--- a/core/meetings/modules/record-chunker/src/index.ts
+++ b/core/meetings/modules/record-chunker/src/index.ts
@@ -237,56 +237,90 @@ export class MediaRecorderChunker implements RecordingTap {
 // ───────────────────────────────────────────────────────────────────────
 
 /**
- * Find active media elements that expose audio. Two-pass (strict → relaxed):
- * tiles can be paused or expose audio via captureStream() rather than a direct
- * srcObject, so the relaxed pass mirrors buildCombinedStream's fallbacks. This
- * is platform-agnostic — a recording grabs every audio element on the page.
+ * Every on-page audio-bearing MediaStream that is CURRENTLY producing audio (has a `live` track).
+ * Prefers `srcObject`; falls back to a captureStream() cached on the element (a fresh captureStream()
+ * each scan would mint a new stream id, defeating the mixer's dedup and leaking source nodes). Deduped
+ * downstream by stream id. Platform-agnostic — a recording grabs every audio element on the page.
  */
-async function findMediaElements(retries = 5, delay = 2000): Promise<HTMLMediaElement[]> {
-  for (let i = 0; i < retries; i++) {
-    const all = Array.from(document.querySelectorAll("audio, video"));
-    let els = all.filter((el: any) =>
-      !el.paused && el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0
-    ) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (strict)`); return els; }
-
-    els = all.filter((el: any) => {
-      try {
-        if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
-        if (typeof el.captureStream === "function" && el.captureStream()?.getAudioTracks?.().length > 0) return true;
-        if (typeof el.mozCaptureStream === "function" && el.mozCaptureStream()?.getAudioTracks?.().length > 0) return true;
-      } catch { /* not probeable; skip */ }
-      return false;
-    }) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (relaxed)`); return els; }
-
-    await new Promise((r) => setTimeout(r, delay));
+function collectAudioStreams(): MediaStream[] {
+  const els = Array.from(document.querySelectorAll("audio, video")) as any[];
+  const out: MediaStream[] = [];
+  for (const el of els) {
+    try {
+      let s: MediaStream | null = el.srcObject instanceof MediaStream ? el.srcObject : null;
+      if (!s) {
+        const cap: unknown =
+          el.__vexaRecCapStream instanceof MediaStream ? el.__vexaRecCapStream :
+          typeof el.captureStream === "function" ? el.captureStream() :
+          typeof el.mozCaptureStream === "function" ? el.mozCaptureStream() : null;
+        if (cap instanceof MediaStream) { el.__vexaRecCapStream = cap; s = cap; }
+      }
+      // Only LIVE audio: an element lingering with an ENDED track must not re-enter the mix (it would
+      // reconnect a dead source every scan and oscillate against the prune below).
+      if (s && s.getAudioTracks().some((t) => t.readyState === "live")) out.push(s);
+    } catch { /* not probeable; skip */ }
   }
-  return [];
+  return out;
 }
 
-/** Mix every media element's audio into one MediaStream via a destination node. */
-async function buildCombinedStream(mediaElements: HTMLMediaElement[]): Promise<MediaStream> {
-  if (mediaElements.length === 0) throw new Error("[record-chunker] no media elements to combine");
-  const ctx = new AudioContext();
-  const dest = ctx.createMediaStreamDestination();
-  let connected = 0;
-  mediaElements.forEach((element: any, index) => {
-    try {
-      const s =
-        element.srcObject ||
-        (element.captureStream && element.captureStream()) ||
-        (element.mozCaptureStream && element.mozCaptureStream());
-      if (s instanceof MediaStream && s.getAudioTracks().length > 0) {
-        ctx.createMediaStreamSource(s).connect(dest);
-        connected++;
-        blog(`[record-chunker] connected element ${index + 1}/${mediaElements.length}`);
-      }
-    } catch (e: any) { blog(`[record-chunker] could not connect element ${index + 1}: ${e?.message || e}`); }
-  });
-  if (connected === 0) throw new Error("[record-chunker] could not connect any audio streams");
-  blog(`[record-chunker] combined ${connected} streams`);
-  return dest.stream;
+/**
+ * A LIVE audio mix that FOLLOWS the meeting. One AudioContext destination that a periodic rescan keeps
+ * wired to every current on-page audio stream: it connects newly-appearing streams and prunes ones whose
+ * tracks have ended. Zoom/Teams deliver each participant as a separate WebRTC track and churn them
+ * constantly (each new track is mirrored into a fresh injected <audio> by @vexa/mixed-capture-core's
+ * hook) — so a ONE-TIME combine records silence the moment the originally-captured tracks end. Recording
+ * `dest.stream` (a STABLE handle whose sources come and go underneath) keeps the mix complete for the
+ * whole meeting. Full sample rate — deliberately NOT the 16 kHz transcription mix.
+ */
+class DynamicAudioMixer {
+  private ctx: AudioContext;
+  private dest: MediaStreamAudioDestinationNode;
+  private sources = new Map<string, { node: MediaStreamAudioSourceNode; stream: MediaStream }>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.ctx = new AudioContext();   // default (full) sample rate — NOT the 16 kHz transcription mix
+    this.ctx.resume?.();
+    this.dest = this.ctx.createMediaStreamDestination();
+  }
+
+  get stream(): MediaStream { return this.dest.stream; }
+  get connectedCount(): number { return this.sources.size; }
+
+  /** Connect newly-seen streams; prune streams whose audio has ended. Idempotent — safe every tick. */
+  scan(): void {
+    const present = new Map(collectAudioStreams().map((s) => [s.id, s]));
+    for (const [id, s] of present) {
+      if (this.sources.has(id)) continue;
+      try {
+        const node = this.ctx.createMediaStreamSource(s);
+        node.connect(this.dest);
+        this.sources.set(id, { node, stream: s });
+        blog(`[record-chunker] mix +stream (${this.sources.size} live)`);
+      } catch { /* not connectable yet — retried next tick */ }
+    }
+    // Prune truly-dead streams (all tracks ended) so a long meeting's track churn doesn't accumulate
+    // source nodes. A still-live stream is KEPT even if its element left the DOM (the node holds the
+    // stream ref and still pulls audio) — presence is not the liveness signal, the track state is.
+    for (const [id, entry] of this.sources) {
+      if (entry.stream.getAudioTracks().some((t) => t.readyState === "live")) continue;
+      try { entry.node.disconnect(); } catch { /* */ }
+      this.sources.delete(id);
+      blog(`[record-chunker] mix -stream (${this.sources.size} live)`);
+    }
+  }
+
+  start(): void {
+    this.scan();
+    this.timer = setInterval(() => { try { this.scan(); } catch { /* the rescan must never die */ } }, 2000);
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+    for (const { node } of this.sources.values()) { try { node.disconnect(); } catch { /* */ } }
+    this.sources.clear();
+    try { void this.ctx.close(); } catch { /* */ }
+  }
 }
 
 /** Options for createRecordingTap — combine all audio elements then optionally override. */
@@ -307,13 +341,24 @@ export interface CreateRecordingTapOptions extends RecordingTapOptions {
  */
 export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTap {
   let chunker: MediaRecorderChunker | null = null;
+  let mixer: DynamicAudioMixer | null = null;
   return {
     async start(): Promise<void> {
       let stream = opts.stream;
       if (!stream) {
-        const els = await findMediaElements();
-        if (els.length === 0) { blog("[record-chunker] no media elements — cannot record"); return; }
-        stream = await buildCombinedStream(els);
+        // No ready stream ⇒ build a LIVE mix of the page's audio. Wait (bounded) for the first stream —
+        // post-admission the participant / injected <audio> elements appear a beat late — so the
+        // MediaRecorder's onStarted t=0 aligns with real audio; the rescan then follows the churn.
+        mixer = new DynamicAudioMixer();
+        let ready = false;
+        for (let i = 0; i < 5; i++) {
+          mixer.scan();
+          if (mixer.connectedCount > 0) { ready = true; break; }
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+        if (!ready) { blog("[record-chunker] no audio streams — cannot record"); mixer.stop(); mixer = null; return; }
+        mixer.start();
+        stream = mixer.stream;
       }
       chunker = new MediaRecorderChunker({
         stream,
@@ -326,6 +371,8 @@ export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTa
     async stop(): Promise<void> {
       await chunker?.stop();
       chunker = null;
+      mixer?.stop();
+      mixer = null;
     },
   };
 }

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -253,13 +253,21 @@ def create_app(
     )
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
-    app.include_router(
-        _bot_spawn.build_router(
-            meeting_repo,
-            runtime,
-            service_authority,
-        )
-    )
+    # A fresh meeting must start on an EMPTY transcript stream. Wire a redis-backed purge (None offline)
+    # so bot_spawn can clear tc:meeting:{new_row_id} on a FRESH insert — a reused row id (e.g. after a DB
+    # id-sequence reset without a redis flush) would otherwise carry a prior generation's stale
+    # session_end and the terminal would show "Meeting ended" before the first word. continue_meeting is
+    # untouched (it keeps the reused row's stream). See bot_spawn.service.request_bot.
+    _stream_purge = None
+    if redis is not None and hasattr(redis, "delete"):
+        async def _stream_purge(meeting_id, _r=redis):
+            await _r.delete(f"tc:meeting:{meeting_id}")
+    app.include_router(_bot_spawn.build_router(
+        meeting_repo,
+        runtime,
+        service_authority,
+        transcript_stream_purge=_stream_purge,
+    ))
 
     # --- user-stop: DELETE /bots/{platform}/{native_meeting_id} (lifecycle/stop.py over redis) ---
     from .lifecycle.stop_router import InMemoryCommandPublisher, build_stop_router
@@ -854,6 +862,32 @@ def _mount_lifecycle(
                     )
                 except Exception as e:  # noqa: BLE001 — the worker's idle timeout is the backstop
                     log_event("meeting_copilot_reap_failed", audience="system", level="warning",
+                              span="lifecycle.callback",
+                              fields={"meeting_row_id": meeting_row_id, "error": str(e)})
+        # NEW-SESSION MARKER (mirror of the reap above): when a meeting goes ACTIVE, write a
+        # `session_start` marker onto the same ROW-scoped stream. tc:meeting:{row_id} is SHARED across a
+        # meeting's sessions — a re-sent bot REUSES a terminal row — so a prior session's `session_end`
+        # lingers in the terminal SSE's replay tail and shows "Meeting ended" over the new live meeting.
+        # This marker lets the SSE reset that stale end (agent api.py's seed treats any non-session_end
+        # entry as "still live"), so even a SILENT new session clears the banner. Best-effort.
+        if (
+            redis is not None
+            and not change.no_op
+            and rec.status is not None
+            and rec.status.value == "active"
+            and isinstance(meeting_row, dict)
+            and hasattr(redis, "xadd")
+        ):
+            meeting_row_id = meeting_row.get("id")
+            native = meeting_row.get("native_meeting_id") or rec.connection_id
+            if meeting_row_id is not None:
+                try:
+                    await redis.xadd(
+                        f"tc:meeting:{meeting_row_id}",
+                        {"type": "session_start", "uid": str(native or meeting_row_id)},
+                    )
+                except Exception as e:  # noqa: BLE001 — best-effort; the seed also resets on new segments
+                    log_event("meeting_session_start_marker_failed", audience="system", level="warning",
                               span="lifecycle.callback",
                               fields={"meeting_row_id": meeting_row_id, "error": str(e)})
         log_event(

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -250,8 +250,13 @@ def build_router(
     repo: MeetingRepo,
     runtime: RuntimeClient,
     authority=None,
+    *,
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> APIRouter:
-    """The bot-spawn routes over injected storage, runtime, and authority ports."""
+    """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` + authority ports.
+
+    ``transcript_stream_purge`` (redis-backed in prod, None offline) clears a fresh meeting's transcript
+    stream so it never inherits a reused row id's stale data — see ``request_bot``."""
     router = APIRouter()
 
     @router.post("/bots", status_code=201)
@@ -462,6 +467,7 @@ def build_router(
                 webhook_url=x_user_webhook_url,
                 webhook_secret=x_user_webhook_secret,
                 webhook_events=webhook_events,
+                transcript_stream_purge=transcript_stream_purge,
             )
         except TranscriptionNotConfigured as e:
             raise HTTPException(status_code=503, detail=str(e))

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import os
 import re
 import uuid
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from ..config_preflight import CONFIG_FAULT_KINDS, cached_probe_verdict
@@ -398,6 +398,11 @@ async def request_bot(
     webhook_url: Optional[str] = None,
     webhook_secret: Optional[str] = None,
     webhook_events: Optional[dict] = None,
+    # Fresh-meeting stream hygiene: purge tc:meeting:{new_row_id} on a FRESH insert so a new meeting
+    # never inherits a prior generation's transcript (a reused row id after a DB reset would otherwise
+    # carry a stale session_end → "Meeting ended" before the first word). Injected (redis-backed in
+    # prod, None in tests/offline). NOT called on continue_meeting — that reuse KEEPS the stream.
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> dict:
     """Run the spawn flow and return a MeetingResponse-shaped dict.
 
@@ -684,6 +689,23 @@ async def request_bot(
             )
             raise
     meeting_id = row["id"]
+
+    # 3b. Fresh-meeting stream hygiene (see the param doc): a brand-new row must start on an EMPTY
+    # transcript stream. Row ids are monotonic, so tc:meeting:{id} normally doesn't exist yet — but if
+    # the DB id sequence is ever reset/restored without flushing redis, a NEW meeting can be minted on a
+    # row id whose OLD stream still holds a prior generation's session_end, and the terminal shows
+    # "Meeting ended" before the first word. Purge on the FRESH insert only (reused_row is None);
+    # continue_meeting KEEPS the reused row's stream for continuity. Best-effort — a purge failure must
+    # never block the spawn (the collector is the stream's writer and appends after this).
+    if reused_row is None and transcript_stream_purge is not None:
+        try:
+            await transcript_stream_purge(meeting_id)
+        except Exception as _e:  # noqa: BLE001 — best-effort; never fail the spawn on a purge error
+            log_event(
+                "bot_spawn_stream_purge_failed", audience="system", level="warning",
+                span="bots.create", user_id=user_id,
+                fields={"meeting_id": meeting_id, "error": str(_e)},
+            )
 
     # 4. MeetingToken + invocation. connection_id IS the session_uid (parent's connectionId).
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -165,6 +165,35 @@ async def test_request_bot_eager_creates_session_and_spawns(monkeypatch):
     assert repo.sessions[0]["session_uid"] == spawned["connectionId"]
 
 
+async def test_fresh_spawn_purges_transcript_stream_but_continue_does_not(monkeypatch):
+    """A FRESH meeting must start on an EMPTY transcript stream, so a reused row id (e.g. after a DB
+    id-sequence reset without a redis flush) can't carry a prior generation's session_end → the
+    terminal showing "Meeting ended" before the first word. The injected purge fires with the new row
+    id on a fresh insert, and NOT on continue_meeting (which intentionally keeps the reused stream)."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    purged: list[int] = []
+
+    async def _purge(mid):
+        purged.append(mid)
+
+    kw = dict(redis_url="r", token_secret=SECRET, meeting_api_url="http://meeting-api:8080",
+              transcript_stream_purge=_purge)
+
+    first = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                              native_meeting_id="abc-defg-hij", **kw)
+    assert purged == [first["id"]]            # fresh insert → the NEW row's stream is purged
+
+    # the meeting completes; a CONTINUED bot reuses the SAME row and must NOT purge (keeps continuity)
+    repo.set_status(first["id"], "completed")
+    purged.clear()
+    second = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                               native_meeting_id="abc-defg-hij", continue_meeting=True, **kw)
+    assert second["id"] == first["id"]
+    assert purged == []                       # continue_meeting KEEPS the reused row's stream
+
+
 def test_iso_utc_marks_naive_utc_with_z():
     # Meeting time columns are naive but hold UTC. Serializing must emit a Z marker so a browser
     # parses it as UTC and renders local — a bare isoformat is read as LOCAL (the 6h-skew bug).

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -1219,7 +1219,12 @@ def test_non_terminal_advance_does_not_emit_session_end():
     _post(client, connection_id="sess-uid", status="active")
 
     stream = f"tc:meeting:{m['id']}"
-    assert stream not in redis.streams, "session_end emitted while the meeting is still live"
+    # A non-terminal advance must NOT emit session_end (that would end the live view). It DOES write a
+    # session_start marker on `active` — the signal the terminal SSE uses to clear a prior session's
+    # stale session_end when a re-sent bot reuses this meeting row.
+    entries = redis.streams.get(stream, [])
+    assert not any(p.get("type") == "session_end" for p in entries), "session_end emitted while the meeting is still live"
+    assert any(p.get("type") == "session_start" for p in entries), "session_start marker not emitted on active"
     assert "tc:meeting:m1" not in redis.streams
 
 

--- a/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
+++ b/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
@@ -180,7 +180,7 @@ def test_runtime_destroy_completes_stopping_after_active_e2e():
         "lifecycle_contract_version": "2026-07-28",
     }
     assert repo.list_stale_stopping_sync() == []
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_destroy_with_invalid_time_does_not_fabricate_provenance():
@@ -243,7 +243,7 @@ def test_runtime_destroy_fails_pre_active_e2e():
     assert repo._meetings[m["id"]]["status"] == "failed"
     assert repo._meetings[m["id"]]["data"].get("failure_stage") == "awaiting_admission"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "awaiting_admission_timeout"
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -310,7 +310,7 @@ def test_runtime_destroy_noop_on_already_terminal_e2e():
     assert repo._meetings[m["id"]]["status"] == "completed"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "left_alone"
     # Exactly ONE session_end (the bot's own completed), not a second from the trailing destroy.
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_nonterminal_state_does_not_advance_e2e():

--- a/docs/changelog.d/1013-audio-recording.md
+++ b/docs/changelog.d/1013-audio-recording.md
@@ -1,0 +1,3 @@
+- **Meeting recordings now capture the full audio (#1013).** The mixed-lane (Zoom/Teams) recording follows
+  participants who join or speak later, and flushes the final seconds when the meeting closes — so a
+  recording no longer drops audio partway through or loses its last lines.

--- a/docs/changelog.d/1014-lifecycle.md
+++ b/docs/changelog.d/1014-lifecycle.md
@@ -1,0 +1,2 @@
+- **The "Meeting ended" banner no longer flashes over a still-live meeting (#1014).** The dashboard
+  stops showing a premature "Meeting ended" banner while the meeting is still running.


### PR DESCRIPTION
**Delivers issue:** _(none — maintainer's own work)_

Restarting while a bot is still leaving no longer leaves the meeting stuck in stopping, and the 'Meeting ended' banner no longer flashes over a still-live meeting.

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Observation bundle
- **C1 —** ran: exercised live on the maintainer's self-hosted lite deployment · saw: restarting while the bot is still leaving no longer leaves the meeting stuck in 'stopping', and the 'Meeting ended' banner no longer flashes over a still-live meeting · concluded: both meeting-state transitions converge correctly

_Live-witnessed on the maintainer's self-hosted lite deployment._

## Stacked on #1013 (audio-recording)
Diff vs `main` includes the branches below it in the stack. **This PR's own commits:**
- `9a7731fa` fix(meetings): converge a stuck 'stopping' meeting on stop_grace, not the untracked window
- `3362b4dc` fix(meetings): stop the premature 'Meeting ended' banner

Changelog fragment included (`docs/changelog.d/1014-lifecycle.md`).

---
Commits carry DCO `Signed-off-by` and are SSH-signed.


