### PR TITLE
fix(transcript): retract stale drafts + never lose a turn's tail

### DIFF
--- a/clients/terminal/src/app/App.tsx
+++ b/clients/terminal/src/app/App.tsx
@@ -34,6 +34,15 @@ function InviteGate({ children }: { children: ReactNode }) {
   const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
   const invite = params.get("invite");
   const tshare = params.get("tshare");
+  const meeting = params.get("meeting");   // ?meeting=<platform>/<native> deep-link → open that meeting
+
+  // A `?meeting=` deep-link: stash the ref for the workbench first-view resolver, then clean the URL
+  // (reload so the stash is in place before the grid mounts) — unless an invite/tshare owns the reload.
+  useEffect(() => {
+    if (!meeting) return;
+    try { localStorage.setItem("vexa.openMeetingRef", meeting); } catch { /* locked-down storage */ }
+    if (!invite && !tshare) window.location.replace(window.location.pathname);
+  }, [meeting, invite, tshare]);
 
   // Transcript share redeems silently (no consent surface). Clean the URL after — unless an invite is also
   // present, in which case the invite flow owns the reload.

--- a/clients/terminal/src/app/api/config/README.md
+++ b/clients/terminal/src/app/api/config/README.md
@@ -1,0 +1,12 @@
+# `/api/config` — runtime deployment config
+
+`GET /api/config` → `{ defaultBotName: string | null }`, read from the container env **at request
+time** (`dynamic = "force-dynamic"`).
+
+Next.js inlines `NEXT_PUBLIC_*` at build time, so a per-deployment default baked into the image
+can't change without a rebuild. This route exposes the values the browser needs at **runtime**, so a
+plain compose env var takes effect on restart — no rebuild.
+
+- **`DEFAULT_BOT_NAME`** — the meeting bot's display name the terminal sends when joining. The client
+  caches this via [`surfaces/defaultBotName.ts`](../../../surfaces/defaultBotName.ts); precedence is
+  the runtime value → `NEXT_PUBLIC_DEFAULT_BOT_NAME` (build-time) → `"Vexa"`.

--- a/clients/terminal/src/app/api/config/route.ts
+++ b/clients/terminal/src/app/api/config/route.ts
@@ -1,0 +1,17 @@
+/** Runtime deployment config for the browser — read at REQUEST time, not build time.
+ *
+ *  Next.js inlines `NEXT_PUBLIC_*` at build, so a per-deployment default baked into the image can't
+ *  be changed without a rebuild. This endpoint exposes the values the terminal reads at runtime from
+ *  the container env, so a plain compose var (no rebuild) takes effect. Currently: `DEFAULT_BOT_NAME`
+ *  — the meeting bot's display name the terminal sends on join (see surfaces/defaultBotName.ts).
+ */
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic"; // never cache — reflect the live container env per request
+
+export async function GET() {
+  return NextResponse.json(
+    { defaultBotName: process.env.DEFAULT_BOT_NAME?.trim() || null },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/clients/terminal/src/canvas/MeetingCanvasView.tsx
+++ b/clients/terminal/src/canvas/MeetingCanvasView.tsx
@@ -1,5 +1,7 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useService } from "../platform";
+import { LayoutServiceId } from "../workbench/layout";
 import { CanvasActionsProvider, useActions, OPEN_ENTITY_EVENT } from "./actions";
 import { MeetingHealthBanner } from "./MeetingHealthBanner";
 import { LiveTranscriptEngine, type EngineActions, type EngineEntity, type EngineSignal } from "./LiveTranscriptEngine";
@@ -69,6 +71,14 @@ function ProcessedTranscript() {
 
 function MeetingCanvasBody({ meetingId }: { meetingId?: string }) {
   const { meeting, transcript } = useMeeting();
+  const layout = useService(LayoutServiceId);
+  // Name the tab from the loaded meeting — a meeting opened by `?meeting=<id>` before the list loaded
+  // opens as the generic "Meeting"; once the title arrives, rename the tab to match the list/prep views.
+  useEffect(() => {
+    if (meetingId && meeting.title && meeting.title !== "Meeting") {
+      layout.setTitle(`meeting:${meetingId}`, meeting.title.split(" — ")[0]);
+    }
+  }, [layout, meetingId, meeting.title]);
   const live = meeting.live === true;
   const hasNotes = (transcript.notes?.length ?? 0) > 0;
   // Durable truth wins over a stale list `live` flag ([N8] — the row can stay stuck on a live

--- a/clients/terminal/src/canvas/actions.ts
+++ b/clients/terminal/src/canvas/actions.ts
@@ -61,6 +61,10 @@ export const ASK_CHAT_EVENT = "vexa:terminal:ask-chat";
 // workbench resolves it to a file and opens the doc (revealing the center if in chat-only mode).
 export const OPEN_ENTITY_EVENT = "vexa:terminal:open-entity";
 
+// A `vexa-meeting:<platform>/<native>` link in a meeting note dispatches this; the workbench resolves
+// the native id → the meeting row and opens its canvas (transcript + recording). Detail: { ref }.
+export const OPEN_MEETING_EVENT = "vexa:terminal:open-meeting";
+
 // ASCII sentinel prefixed to the onboarding grounding (robust against bundler/linter normalization). The
 // agent ignores the bracketed tag; the chat uses it to recognize an onboarding turn (filter a pure
 // kickoff, compact the grounding off a real reply, keep it out of the session title).

--- a/clients/terminal/src/surfaces/__tests__/defaultBotName.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/defaultBotName.test.ts
@@ -1,20 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { defaultBotName } from '../defaultBotName';
+import { defaultBotName, loadDefaultBotName, __resetDefaultBotNameCache } from '../defaultBotName';
 
 describe('defaultBotName', () => {
   beforeEach(() => {
+    __resetDefaultBotNameCache();
     delete process.env.NEXT_PUBLIC_DEFAULT_BOT_NAME;
   });
 
   afterEach(() => {
+    __resetDefaultBotNameCache();
     delete process.env.NEXT_PUBLIC_DEFAULT_BOT_NAME;
   });
 
-  it('returns "Vexa" when env is unset', () => {
+  it('returns "Vexa" when nothing is set', () => {
     expect(defaultBotName()).toBe('Vexa');
   });
 
-  it('reads env at call time', () => {
+  it('falls back to NEXT_PUBLIC_DEFAULT_BOT_NAME (build-time) at call time', () => {
     expect(defaultBotName()).toBe('Vexa');
     process.env.NEXT_PUBLIC_DEFAULT_BOT_NAME = 'MyBot';
     expect(defaultBotName()).toBe('MyBot');
@@ -22,8 +24,34 @@ describe('defaultBotName', () => {
     expect(defaultBotName()).toBe('Vexa');
   });
 
-  it('trims whitespace', () => {
+  it('trims whitespace on the build-time fallback', () => {
     process.env.NEXT_PUBLIC_DEFAULT_BOT_NAME = '  Assistant  ';
     expect(defaultBotName()).toBe('Assistant');
+  });
+
+  it('prefers the runtime DEFAULT_BOT_NAME (via /api/config) over the build-time fallback', async () => {
+    process.env.NEXT_PUBLIC_DEFAULT_BOT_NAME = 'BuildTimeBot';
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      ok: true,
+      json: async () => ({ defaultBotName: '  Runtime Bot  ' }),
+    })) as unknown as typeof fetch;
+    try {
+      await loadDefaultBotName();
+      expect(defaultBotName()).toBe('Runtime Bot'); // runtime wins + trimmed
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it('keeps the fallback when /api/config has no name', async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => ({ ok: true, json: async () => ({ defaultBotName: null }) })) as unknown as typeof fetch;
+    try {
+      await loadDefaultBotName();
+      expect(defaultBotName()).toBe('Vexa');
+    } finally {
+      globalThis.fetch = orig;
+    }
   });
 });

--- a/clients/terminal/src/surfaces/defaultBotName.ts
+++ b/clients/terminal/src/surfaces/defaultBotName.ts
@@ -1,12 +1,43 @@
-/** Default bot name shown in the terminal surfaces.
+/** Default bot name the terminal sends to the API when joining meetings.
  *
- *  NEXT_PUBLIC_DEFAULT_BOT_NAME sets the meeting bot name the terminal sends to the API
- *  when joining meetings. In client-bundled code Next.js inlines NEXT_PUBLIC_* at build time,
- *  so the knob takes effect per deployment build — which matches this feature's intent
- *  (a per-deployment default), and the call-time function keeps tests correct.
+ *  RUNTIME (no rebuild): the deployment sets `DEFAULT_BOT_NAME` in the container env; the terminal's
+ *  `/api/config` route exposes it, and we cache it here. This is the wiring that lets a plain compose
+ *  var take effect on restart — Next.js inlines `NEXT_PUBLIC_*` at BUILD time, so it can't.
  *
- *  Read via a function (not a module constant) so tests that set the env after load observe it.
+ *  Precedence (call-time): the cached runtime `DEFAULT_BOT_NAME` → `NEXT_PUBLIC_DEFAULT_BOT_NAME`
+ *  (build-time fallback) → `"Vexa"`. `defaultBotName()` stays SYNC so every join call site is
+ *  unchanged; `loadDefaultBotName()` warms the cache (fired at module load in the browser) so the
+ *  value is ready before the first join.
  */
-export function defaultBotName(): string {
-  return process.env.NEXT_PUBLIC_DEFAULT_BOT_NAME?.trim() || "Vexa";
+let cached: string | null = null;
+let inflight: Promise<void> | null = null;
+
+/** Warm the runtime cache from `/api/config`. Idempotent, browser-only, best-effort (a failure just
+ *  leaves the fallbacks in place). Returns a promise so a caller may await it before a join. */
+export function loadDefaultBotName(): Promise<void> {
+  if (cached !== null) return Promise.resolve();
+  if (inflight) return inflight;
+  if (typeof fetch !== "function") return Promise.resolve();
+  inflight = fetch("/api/config", { cache: "no-store" })
+    .then((r) => (r.ok ? r.json() : null))
+    .then((cfg: { defaultBotName?: string | null } | null) => {
+      const name = (cfg?.defaultBotName ?? "").trim();
+      if (name) cached = name;
+    })
+    .catch(() => { /* best-effort — the fallbacks below still apply */ })
+    .finally(() => { inflight = null; });
+  return inflight;
 }
+
+export function defaultBotName(): string {
+  return cached || process.env.NEXT_PUBLIC_DEFAULT_BOT_NAME?.trim() || "Vexa";
+}
+
+/** Test-only: clear the module cache so a spec can drive the runtime path deterministically. */
+export function __resetDefaultBotNameCache(): void {
+  cached = null;
+  inflight = null;
+}
+
+// Warm as early as possible in the browser so the value is ready before the first join.
+if (typeof window !== "undefined") void loadDefaultBotName();

--- a/clients/terminal/src/surfaces/meetingLive.ts
+++ b/clients/terminal/src/surfaces/meetingLive.ts
@@ -120,7 +120,7 @@ function connect(e: Entry, meetingId: string, sessionUid: string): void {
   e.es = es;
   es.onopen = () => { e.state.connected = true; e.state.lastEventAt = Date.now(); armWatchdog(); emit(); };
   es.onmessage = (m) => {
-    let ev: { type?: string; speaker?: string; text?: string; t?: number; tsMs?: number; id?: string; completed?: boolean; card?: LiveCard; note?: LiveNote; error?: LiveModelError | string; message?: string; status?: number };
+    let ev: { type?: string; speaker?: string; text?: string; t?: number; tsMs?: number; id?: string; completed?: boolean; card?: LiveCard; note?: LiveNote; error?: LiveModelError | string; message?: string; status?: number; segment_ids?: string[] };
     try { ev = JSON.parse(m.data); } catch {
       addIssue({ kind: "parse", message: "Could not parse meeting stream event" });
       emit();
@@ -159,6 +159,14 @@ function connect(e: Entry, meetingId: string, sessionUid: string): void {
       const next: LiveNote = { id: ev.note.id, speaker: ev.note.speaker, chapter: ev.note.chapter, text: ev.note.text, t: ev.note.t, tsMs: absMs(ev.note.t), pass: ev.note.pass, frozen: ev.note.frozen };
       const i = s.notes.findIndex((x) => x.id === next.id);
       if (i >= 0) s.notes[i] = next; else s.notes.push(next);
+    }
+    else if (ev.type === "retract" && Array.isArray(ev.segment_ids) && ev.segment_ids.length) {
+      // The producer withdrew superseded/over-extended pending drafts (the mixed lane's full-replace
+      // tail). Our egress is append-only + we upsert by id, so a retract is the ONLY way a draft leaves
+      // the view — drop the named ids so a stale "unattached"/duplicated line disappears in place.
+      const drop = new Set(ev.segment_ids);
+      const kept = s.transcript.filter((x) => !x.id || !drop.has(x.id));
+      if (kept.length !== s.transcript.length) s.transcript = kept; else return; // nothing here → don't churn
     }
     else if (ev.type === "message-delta" && ev.text) s.note = ev.text;
     else if (ev.type === "stream-error") addIssue({ kind: "stream", message: ev.message || "Meeting stream error", status: ev.status });

--- a/clients/terminal/src/surfaces/today.tsx
+++ b/clients/terminal/src/surfaces/today.tsx
@@ -90,7 +90,8 @@ export function agendaWindow(groups: MeetingGroup[], now: Date = new Date(), wee
 export interface PastEntry { run: MeetingMock; group: MeetingGroup }
 export interface PastDay { key: string; date: Date; entries: PastEntry[] }
 
-const PAST_CAP = 8;
+const PAST_CAP = 8;       // initial past-meetings shown
+const PAST_MORE = 20;     // how many more each "Show more" reveals
 
 /** The past feed: each meeting's newest finished run, newest first, day-grouped. */
 export function pastFeed(groups: MeetingGroup[], cap: number = PAST_CAP): PastDay[] {
@@ -280,10 +281,13 @@ function TodayView() {
   const reviewedIds = useReviewed();
   const ownTree = useOwnWorkspaceTree();
   const [weekOffset, setWeekOffset] = useState(0);
+  const [pastCap, setPastCap] = useState(PAST_CAP);
   const now = new Date();
   const groups = groupMeetings(meetings);
   const days = agendaWindow(groups, now, weekOffset);
-  const past = pastFeed(groups);
+  const past = pastFeed(groups, pastCap);
+  // Total past meetings eligible for the feed (same predicate pastFeed slices by) — drives "Show more".
+  const pastTotal = groups.filter((g) => g.pastRuns[0] && (g.pastRuns[0].has_recording || g.pastRuns[0].start_time)).length;
   const todayKey = dayKey(now);
   const empty = meetings.length === 0;
   const pager = { background: "none", border: "1px solid var(--line)", color: "var(--t2)", borderRadius: 6,
@@ -327,6 +331,14 @@ function TodayView() {
             {day.entries.map((e) => <PastRow key={e.run.id} e={e} reviewedIds={reviewedIds} />)}
           </div>
         ))}
+
+        {pastCap < pastTotal && (
+          <button onClick={() => setPastCap((c) => c + PAST_MORE)}
+            style={{ background: "none", border: "1px solid var(--line)", color: "var(--t2)", borderRadius: 8,
+              padding: "7px 14px", cursor: "pointer", fontSize: 12.5, marginTop: 14 }}>
+            Show more ({pastTotal - pastCap} older)
+          </button>
+        )}
 
         {!empty && (
           <div style={{ fontSize: 11.5, color: "var(--t3)", margin: "24px 2px 10px", lineHeight: 1.5 }}>

--- a/clients/terminal/src/surfaces/workspace.tsx
+++ b/clients/terminal/src/surfaces/workspace.tsx
@@ -9,7 +9,7 @@ import { registerList, registerTab, type TabProps } from "../contributions";
 import { meetingsOnly } from "../app/mode";
 import { Icon, Checkbox } from "../ui-kit";
 import { Modal } from "../ui-kit/Modal";
-import { OPEN_ENTITY_EVENT } from "../canvas/actions";
+import { OPEN_ENTITY_EVENT, OPEN_MEETING_EVENT } from "../canvas/actions";
 import { ENTITY_CHIP, DEFAULT_ENTITY_CHIP, DocMetaContext, DocNavContext, resolveDocRef, type DocNavigate } from "../ui-kit/docLinks";
 import { ContextMenu, copyText } from "../ui-kit/ContextMenu";
 import { MdxDoc } from "../ui-kit/MdxDoc";
@@ -33,15 +33,28 @@ function parseEntity(text: string): { fm: [string, string][]; body: string } {
   return { fm, body: m[2] };
 }
 function wikilinks(text: string, navigate?: DocNavigate | null): ReactNode[] {
-  // Frontmatter [[wikilinks]] are clickable: navigate the doc pane in place when it provides
-  // a navigator (Obsidian-style), else fall back to the OPEN_ENTITY_EVENT tab path.
+  // Frontmatter [[wikilinks]] AND markdown [text](href) links are clickable (Obsidian-style): a
+  // wikilink / internal path navigates the doc pane (or opens a tab); a `?meeting=<id>` href opens the
+  // meeting canvas; http(s) opens externally. Lets a meeting note carry its recording links in metadata.
   const open = (wikilink: string) => navigate
     ? navigate({ wikilink })
     : window.dispatchEvent(new CustomEvent(OPEN_ENTITY_EVENT, { detail: { wikilink } }));
-  return text.split(/(\[\[[^\]]+\]\])/).map((part, i) => part.startsWith("[[")
-    ? <span key={i} onClick={() => open(part.slice(2, -2))}
-        style={{ color: "var(--blue)", cursor: "pointer" }}>{part}</span>
-    : <span key={i}>{part}</span>);
+  return text.split(/(\[\[[^\]]+\]\]|\[[^\]]+\]\([^)]+\))/).map((part, i) => {
+    if (part.startsWith("[[")) return <span key={i} onClick={() => open(part.slice(2, -2))}
+      style={{ color: "var(--blue)", cursor: "pointer" }}>{part}</span>;
+    const md = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+    if (md) {
+      const [, label, href] = md;
+      const meeting = href.match(/[?&]meeting=([^&#]+)/);
+      if (meeting) return <span key={i} role="link" style={{ color: "var(--blue)", cursor: "pointer" }}
+        onClick={() => window.dispatchEvent(new CustomEvent(OPEN_MEETING_EVENT, { detail: { ref: decodeURIComponent(meeting[1]) } }))}>{label}</span>;
+      if (/^https?:/i.test(href)) return <a key={i} href={href} target="_blank" rel="noreferrer noopener"
+        style={{ color: "var(--blue)" }}>{label}</a>;
+      return <span key={i} role="link" style={{ color: "var(--blue)", cursor: "pointer" }}
+        onClick={() => window.dispatchEvent(new CustomEvent(OPEN_ENTITY_EVENT, { detail: { path: href } }))}>{label}</span>;
+    }
+    return <span key={i}>{part}</span>;
+  });
 }
 
 // [[Title]] / relative-path resolution lives in ui-kit/docLinks (resolveDocRef) — shared

--- a/clients/terminal/src/ui-kit/MdxDoc.tsx
+++ b/clients/terminal/src/ui-kit/MdxDoc.tsx
@@ -21,6 +21,7 @@ import {
   Card, CardGroup, DocMetaContext, DocNavContext, ENTITY_CHIP, DEFAULT_ENTITY_CHIP, InternalLink,
   Wikilink, isInternalHref, type DocNavigate,
 } from "./docLinks";
+import { OPEN_MEETING_EVENT } from "../canvas/actions";
 
 // Link/wikilink resolution + the entity chips live in ./docLinks (ONE resolver shared with
 // the plain-Markdown fallback and the workbench event handler). Re-exported for existing
@@ -99,6 +100,14 @@ const htmlComponents = {
   h1: h(1), h2: h(2), h3: h(3), h4: h(4),
   p: ({ children }: { children?: ReactNode }) => <p style={{ margin: "0 0 8px", lineHeight: 1.6 }}>{children}</p>,
   a: ({ href, children }: { href?: string; children?: ReactNode }) => {
+    // Meeting deep-link (`?meeting=<id>`, relative or absolute) → open the meeting canvas (transcript +
+    // recording) in-app, no reload. The same URL also cold-opens the meeting via App.tsx (portable).
+    const mref = href?.match(/[?&]meeting=([^&#]+)/);
+    if (mref) {
+      const ref = decodeURIComponent(mref[1]);
+      return <span role="link" onClick={() => window.dispatchEvent(new CustomEvent(OPEN_MEETING_EVENT, { detail: { ref } }))}
+        style={{ color: "var(--blue)", textDecoration: "underline", cursor: "pointer" }}>{children}</span>;
+    }
     // Workspace-internal link (no scheme, not an anchor) → navigate the doc pane in place
     // (or open a tab outside a doc pane), same path the Wikilink chip uses. Relative hrefs
     // resolve against the linking doc's directory. External links open a browser tab.

--- a/clients/terminal/src/workbench/Workbench.tsx
+++ b/clients/terminal/src/workbench/Workbench.tsx
@@ -4,7 +4,7 @@
  *  CENTER: dockview TABS — a "tab" host resolves each panel by params.kind via the tab registry.
  *  RIGHT (resizable/collapsible): the persistent workspace chat, grounded by the active center tab.
  *  Reuses the Phase-C ⌘K palette + keybindings; the kernel's services do the rest. */
-import { useEffect, useRef, useState, useSyncExternalStore, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type CSSProperties } from "react";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 import { DockviewReact, type DockviewApi, type DockviewReadyEvent, type IDockviewPanelProps, type IDockviewPanelHeaderProps, themeAbyss } from "dockview-react";
@@ -26,7 +26,7 @@ import { Chat } from "../surfaces/chat";
 import { resolveDocRef } from "../ui-kit/docLinks";
 import { liveMeetingsNow } from "../surfaces/liveMeetings";
 import { firstViewPlan } from "./firstView";
-import { OPEN_ENTITY_EVENT } from "../canvas/actions";
+import { OPEN_ENTITY_EVENT, OPEN_MEETING_EVENT } from "../canvas/actions";
 import { useTheme } from "../app/theme";
 import { meetingsOnly } from "../app/mode";
 
@@ -300,7 +300,7 @@ export function Workbench() {
     if (meetOnly || layout.store.getState().activeList !== "sessions") return;
     try {
       if (localStorage.getItem("vexa.openWorkspace")) layout.setActiveList("files");
-      else if (localStorage.getItem("vexa.openMeeting")) layout.setActiveList("meetings");
+      else if (localStorage.getItem("vexa.openMeeting") || localStorage.getItem("vexa.openMeetingRef")) layout.setActiveList("meetings");
     } catch { /* noop — a locked-down localStorage just means no early reveal */ }
     // once, on mount (a fresh page load after the redeem reload) — deps intentionally empty
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -323,6 +323,27 @@ export function Workbench() {
     return () => window.removeEventListener(OPEN_ENTITY_EVENT, onOpenEntity);
   }, [layout]);
 
+  // A `?meeting=<platform>/<native>` deep-link (clicked in a meeting note, or the cold-load URL) →
+  // resolve the native id to its meeting row and open the canvas (transcript + recording).
+  const openMeetingByRef = useCallback((mid: string) => {
+    // `?meeting=<id>` deep-link — the meeting ROW id. Open its canvas directly (the same tab a click
+    // in the meetings list opens); the canvas fetches its transcript/recording by that id.
+    const id = mid.trim();
+    if (!id) return;
+    const m = liveMeetingsNow().find((x) => String(x.id) === id);
+    if (layout.store.getState().activeList === "sessions") layout.setActiveList("meetings");
+    layout.openTab({ id: `meeting:${id}`, title: m ? m.title.split(" — ")[0] : "Meeting", kind: "meeting", params: { meetingId: id } });
+  }, [layout]);
+
+  useEffect(() => {
+    const onOpenMeeting = (e: Event) => {
+      const ref = (e as CustomEvent<{ ref?: string }>).detail?.ref;
+      if (ref) openMeetingByRef(ref);
+    };
+    window.addEventListener(OPEN_MEETING_EVENT, onOpenMeeting);
+    return () => window.removeEventListener(OPEN_MEETING_EVENT, onOpenMeeting);
+  }, [openMeetingByRef]);
+
   // detach the dockview api on unmount (navigation/HMR dispose it) so the layout
   // service never operates on a disposed grid.
   const apiRef = useRef<DockviewApi | null>(null);
@@ -339,6 +360,12 @@ export function Workbench() {
   // gets ONLY the explicit shared-meeting arm (they clicked a share link) — never a surprise re-pin.
   const firstViewDone = useRef(false);
   const resolveFirstView = async (fresh: boolean) => {
+    // A `?meeting=<platform>/<native>` deep-link (App.tsx stashed the ref) — open that meeting's canvas
+    // directly. Explicit navigation wins over the plan below.
+    try {
+      const mref = localStorage.getItem("vexa.openMeetingRef");
+      if (mref) { localStorage.removeItem("vexa.openMeetingRef"); openMeetingByRef(mref); return; }
+    } catch { /* noop */ }
     // an explicit shared meeting from a ?tshare= link (InviteRedeemer stashed it before the reload)
     let sharedMeetingId: string | null = null;
     try { sharedMeetingId = localStorage.getItem("vexa.openMeeting"); if (sharedMeetingId) localStorage.removeItem("vexa.openMeeting"); } catch { /* noop */ }

--- a/clients/terminal/src/workbench/layout.ts
+++ b/clients/terminal/src/workbench/layout.ts
@@ -57,6 +57,9 @@ export interface LayoutService {
   setActiveTab(tab: ActiveTab | null): void;
   /** switch which chat session the right rail shows (Sessions list / New chat) */
   setActiveSession(id: string): void;
+  /** Rename an already-open tab by its logical id (no-op if it isn't open). Lets a canvas set its
+   *  real title once its data loads — e.g. a meeting opened by `?meeting=<id>` before the list loaded. */
+  setTitle(id: string, title: string): void;
   setActiveList(id: string): void;
   toggleLeft(): void;
   toggleRight(): void;
@@ -148,6 +151,7 @@ export function createLayoutService(defaultList: string): LayoutService {
     setContext(ctx) { store.set((st) => ({ ...st, context: ctx })); },
     setActiveTab(tab) { store.set((st) => ({ ...st, activeTab: tab })); },
     setActiveSession(id) { store.set((st) => ({ ...st, activeSession: id })); writeLS(LS_SESSION, id); },
+    setTitle(id, title) { const p = api?.getPanel(id); if (p && title) p.api.setTitle(title); },
     goBack() {
       const snap = hist.pop();
       if (!snap || !api) return false;

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -675,6 +675,7 @@ def _meeting_grounding(
         "title": str(m.get("title") or "").strip() or str(native),
         "platform": platform,
         "native": str(native),
+        "meeting_id": str(m.get("meeting_id") or native),   # the ROW id — the meeting's stable ?meeting= link
     }
 
     if phase == "prep":

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -1888,6 +1888,12 @@ def create_app(
                         ending_at = _time.monotonic()
                         last.pop(tkey, None)
                         continue
+                    # A real segment AFTER a session_end in the replay tail means a NEW session resumed
+                    # on this reused meeting-row stream (tc:meeting:{id} is shared across a meeting's
+                    # sessions). The prior end must NOT close the current live view — without this reset
+                    # a stale session_end seeds `ending=True` and fires a premature `meeting-end`, so the
+                    # terminal shows "Meeting ended" over a still-live meeting.
+                    ending = False
                     yield from seg_events(payload)
             if resume_o is None:   # fresh connect → seed the output (cards/agent-activity) replay
                 output_seed_rows = list(reversed(r.xrevrange(okey, count=MEETING_STREAM_OUTPUT_REPLAY) or []))
@@ -1916,7 +1922,13 @@ def create_app(
                             live.drop(session_uid)  # leaves the terminal's live-meetings feed
                             yield ({"type": "meeting-end"}, cursor())
                             return
-                        continue  # the final beat is still writing — keep draining
+                        # The final beat is still writing — keep draining. But this branch polls every
+                        # 1.5s and yields NOTHING, so a drain that waits out the copilot (up to the 45s
+                        # cap) goes silent well past the terminal's 20s SSE watchdog → the browser
+                        # force-reconnects mid-drain ("stream disconnected" banner + a re-replayed
+                        # session_end). Emit a ping so a healthy drain stays visibly alive.
+                        yield ({"type": "ping"}, cursor())
+                        continue
                     idle += 15000
                     if idle >= 600000:
                         return
@@ -1928,11 +1940,23 @@ def create_app(
                         last[stream] = entry_id
                         if stream == tkey:
                             payload = json.loads(fields.get("payload", "{}"))
-                            if payload.get("type") == "session_end":
+                            ptype = payload.get("type")
+                            if ptype == "session_end":
                                 ending = True            # don't end yet — drain the final beat first
                                 ending_at = _time.monotonic()
                                 last.pop(tkey, None)     # session_end is the last transcript entry
                                 break
+                            # A NEW session resumed on this REUSED row (tc:meeting:{id} is shared across a
+                            # meeting's sessions): a `session_start` marker — or any real segment — arriving
+                            # after a prior `session_end` means the meeting is LIVE again. Clear a stale
+                            # `ending` so the ≤45s drain never fires a premature `meeting-end` over it (the
+                            # terminal showed "Meeting ended" on a still-live meeting). Mirrors the seed's
+                            # reset at connect; without it the live loop kept `ending=True` because it only
+                            # ever SET the flag, never cleared it.
+                            if ending:
+                                ending = False
+                            if ptype == "session_start":
+                                continue                 # marker only — nothing to render
                             yield from seg_events(payload)
                         elif stream == pkey:
                             yield from note_events(fields)

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -1865,6 +1865,13 @@ def create_app(
                             "completed": seg.get("completed", True),
                             "id": seg.get("segment_id")}, cursor())
 
+            def retract_event(payload):
+                """A `retract` marker (the collector withdrew superseded/over-extended pending drafts) →
+                a `retract` SSE event so the terminal drops those segment ids from the live view."""
+                ids = payload.get("segment_ids") or []
+                if ids:
+                    yield ({"type": "retract", "segment_ids": ids}, cursor())
+
             def note_events(entry_fields):
                 """One proc-stream entry → the SAME `note` SSE event the out-stream used to carry
                 (meetingLive.ts upserts by note.id). The `view_end` marker flips completion instead."""
@@ -1888,6 +1895,9 @@ def create_app(
                         ending = True
                         ending_at = _time.monotonic()
                         last.pop(tkey, None)
+                        continue
+                    if payload.get("type") == "retract":
+                        yield from retract_event(payload)
                         continue
                     # A real segment AFTER a session_end in the replay tail means a NEW session resumed
                     # on this reused meeting-row stream (tc:meeting:{id} is shared across a meeting's
@@ -1958,6 +1968,9 @@ def create_app(
                                 ending = False
                             if ptype == "session_start":
                                 continue                 # marker only — nothing to render
+                            if ptype == "retract":
+                                yield from retract_event(payload)
+                                continue
                             yield from seg_events(payload)
                         elif stream == pkey:
                             yield from note_events(fields)

--- a/core/agent/control_plane/meeting_steering.py
+++ b/core/agent/control_plane/meeting_steering.py
@@ -81,7 +81,12 @@ DEFAULT_TEMPLATES: dict[str, str] = {
     "post": (
         "The meeting \"{title}\" ({platform}/{native}) has ended{failed}. Its {source} is below — "
         "answer from it. Default moves: recap what was decided, extract action items with owners, "
-        "and draft follow-ups on request. Don't paste the transcript back verbatim.\n\n"
+        "and draft follow-ups on request. Don't paste the transcript back verbatim. When you write or "
+        "update this meeting's note under kg/entities/meeting/, add a markdown link to THIS session's "
+        "recording & transcript to the note's YAML frontmatter `recording:` field — "
+        "`recording: [▶ Recording & transcript](/?meeting={meeting_id})`. If you are CONTINUING an existing "
+        "note (an earlier session of this same meeting), KEEP the earlier links in that field and ADD this "
+        "one after them — a meeting can have several recorded sessions.\n\n"
         "<transcript>\n{transcript}\n</transcript>\n\n"
     ),
     # Ambient terminal-state digest (context bundle): one steering sentence AFTER the

--- a/core/agent/tests/test_api.py
+++ b/core/agent/tests/test_api.py
@@ -865,6 +865,38 @@ def test_sse_fresh_connect_seeds_and_tails(monkeypatch):
     assert fr.xread_last["tc:meeting:m1"] == "$"            # then tails live from now
 
 
+class _RetractRedis:
+    """The live tail delivers a segment then a `retract` marker (the collector withdrew a superseded
+    draft). The SSE must relay the marker as a `retract` event so the terminal drops that id."""
+    def __init__(self):
+        self._reads = 0
+
+    def xrevrange(self, key, count=1):
+        return []
+
+    def xread(self, last, count=500, block=0):
+        import json as _j
+        self._reads += 1
+        if self._reads == 1:
+            return [("tc:meeting:m1", [("1-0", {"payload": _j.dumps(
+                {"type": "transcription", "segments": [{"speaker": "A", "text": "hi", "start": 1, "segment_id": "turn:1:p0"}]})})])]
+        if self._reads == 2:
+            return [("tc:meeting:m1", [("2-0", {"payload": _j.dumps({"type": "retract", "segment_ids": ["turn:1:p0"]})})])]
+        return []
+
+
+def test_sse_relays_retract_marker(monkeypatch):
+    """A `retract` marker on tc:meeting relays to the client as a `retract` SSE event carrying the ids."""
+    fr = _RetractRedis()
+    c = _stream_client(fr, monkeypatch)
+    with c.stream("GET", "/api/meeting/stream", params={"meeting_id": "m1", "session_uid": "m1"},
+                  headers={"X-User-Id": "u_owner"}) as r:
+        assert r.status_code == 200
+        body = "".join(r.iter_text())
+    assert '"retract"' in body        # the marker became a retract SSE event
+    assert "turn:1:p0" in body        # carrying the withdrawn segment id
+
+
 class _ResumedSessionRedis:
     """A REUSED meeting row (tc:meeting:{id} is shared across sessions): the live tail delivers a prior
     session's session_end, THEN a new session's session_start + a fresh segment. Empty polls follow.

--- a/core/agent/tests/test_api.py
+++ b/core/agent/tests/test_api.py
@@ -865,6 +865,47 @@ def test_sse_fresh_connect_seeds_and_tails(monkeypatch):
     assert fr.xread_last["tc:meeting:m1"] == "$"            # then tails live from now
 
 
+class _ResumedSessionRedis:
+    """A REUSED meeting row (tc:meeting:{id} is shared across sessions): the live tail delivers a prior
+    session's session_end, THEN a new session's session_start + a fresh segment. Empty polls follow.
+    `exists`→0 so, WITHOUT the ending-reset fix, the first empty drain poll would fire meeting-end via
+    the `not has_proc` branch — the premature "Meeting ended" over a live meeting."""
+    def __init__(self):
+        self._reads = 0
+
+    def xrevrange(self, key, count=1):
+        return []            # nothing to seed — the stale end arrives on the LIVE tail below
+
+    def exists(self, key):
+        return 0             # no copilot proc stream
+
+    def xread(self, last, count=500, block=0):
+        import json as _j
+        self._reads += 1
+        if self._reads == 1:
+            return [("tc:meeting:m1", [("1-0", {"payload": _j.dumps({"type": "session_end"})})])]
+        if self._reads == 2:
+            return [("tc:meeting:m1", [("2-0", {"payload": _j.dumps({"type": "session_start", "uid": "m1"})})])]
+        if self._reads == 3:
+            return [("tc:meeting:m1", [("3-0", {"payload": _j.dumps(
+                {"type": "transcription", "segments": [{"speaker": "J", "text": "still live", "start": 9, "segment_id": "s9"}]})})])]
+        return []            # idle — with the fix `ending` is cleared, so NO meeting-end fires
+
+
+def test_sse_session_start_clears_stale_ending_no_premature_end(monkeypatch):
+    """Regression (terminal showed "Meeting ended" over a still-live meeting): when a REUSED row's live
+    tail carries a prior session_end followed by the new session's session_start + a real segment, the
+    stream must CLEAR the stale `ending` and NOT emit a premature meeting-end. The segment is relayed."""
+    fr = _ResumedSessionRedis()
+    c = _stream_client(fr, monkeypatch)
+    with c.stream("GET", "/api/meeting/stream", params={"meeting_id": "m1", "session_uid": "m1"},
+                  headers={"X-User-Id": "u_owner"}) as r:
+        assert r.status_code == 200
+        body = "".join(r.iter_text())
+    assert '"still live"' in body                           # the resumed session's segment reached the view
+    assert '"meeting-end"' not in body                      # the stale session_end did NOT close the live view
+
+
 # ── SSE cross-tenant ownership regression (P0 — the FIX-FIRST blocker) ────────────────────────────
 # The by-row-id SSE feed `/api/meeting/stream` must OWNER-SCOPE the row like the WS `/ws` path + the
 # by-id REST path do. Pre-fix it read `tc:meeting:{meeting_id}` straight off the caller-supplied query

--- a/core/agent/workspace-seeds/default/CLAUDE.md
+++ b/core/agent/workspace-seeds/default/CLAUDE.md
@@ -28,6 +28,11 @@ to record, research, or restructure knowledge, you **write it into this repo** a
 
   You may add more frontmatter fields (role, company, tags, etc.) and a markdown body below the
   second `---`. Cross-reference other entities with `[[wikilinks]]` using their title.
+- **Meeting notes** (`kg/entities/meeting/*`) carry a `recording:` frontmatter field holding a markdown
+  link to each recorded session's recording & transcript:
+  `recording: [▶ Recording & transcript](/?meeting=<meeting_id>)` (the meeting's row id). A meeting can
+  have several sessions — when you continue a note for a later session, KEEP the earlier links and ADD
+  this session's after them. The client renders the frontmatter markdown link and opens the canvas from it.
 
 **Reference entities as `[[Title]]` everywhere — chat replies included.** The client renders
 `[[wikilinks]]` as clickable entity chips and workspace file paths (backticked or as markdown

--- a/core/meetings/modules/join/Dockerfile.env
+++ b/core/meetings/modules/join/Dockerfile.env
@@ -10,7 +10,7 @@
 #   - the live lens: x11vnc + novnc + websockify
 #
 # Build:  docker build -f Dockerfile.env -t vexa/meet-join-env:dev .
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy
+FROM mcr.microsoft.com/playwright:v1.56.0-noble
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       xvfb x11vnc websockify novnc xdotool xclip \

--- a/core/meetings/modules/mixed-pipeline/package.json
+++ b/core/meetings/modules/mixed-pipeline/package.json
@@ -1,17 +1,22 @@
 {
   "name": "@vexa/mixed-pipeline",
   "version": "0.1.0",
-  "description": "The mixed lane: one mixed audio stream → pyannote segmenter (cut-only, the only ONNX) + shared buffer/whisper + hints namer → transcript segments. Names from time-windowed hints; no diarization/clustering.",
+  "description": "The mixed lane: one mixed audio stream \u2192 pyannote segmenter (cut-only, the only ONNX) + shared buffer/whisper + hints namer \u2192 transcript segments. Names from time-windowed hints; no diarization/clustering.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts",
+    "test": "tsx src/confirm-loop.golden.test.ts && tsx src/pending-stability.test.ts && tsx src/naming.smoke.test.ts && tsx src/claim.smoke.test.ts && tsx src/priority.smoke.test.ts && tsx src/concurrency.smoke.test.ts && tsx src/flicker.smoke.test.ts && tsx src/hint-evidence.smoke.test.ts && tsx src/hint-outcome.smoke.test.ts && tsx src/ending-context.smoke.test.ts && tsx src/short-ui-switch.smoke.test.ts && tsx src/never-lose-tail.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -672,10 +672,20 @@ export class ChunkedTranscriber {
     // The whole turn span is adjudicated once closed — later commits
     // (overlap duplicates) must not re-transcribe any of it.
     this.confirmedHighWaterMs = Math.max(this.confirmedHighWaterMs, turn.t1, turn.confirmedUpToMs);
-    if (turn.seq === 0 && turn.allConfirmed.length === 0 && turn.pendingTail.length > 0) {
-      // Closing pass produced nothing but drafts existed — never lose a turn.
+    if (turn.pendingTail.length > 0) {
+      // NEVER LOSE A TURN. The closing pass yielded nothing new, but drafts are still pending —
+      // live-edge speech past the last committed boundary. Promote them to CONFIRMED before the
+      // clearPending below retracts them; otherwise that speech is DELETED from the live view AND
+      // the durable store (the pending-retract path). This covers the seq>0 case (a turn that
+      // already confirmed earlier segments and closed with a dangling tail via one of submitTurn's
+      // yielded-nothing early returns) — the previous guard only rescued a never-confirmed turn,
+      // so a confirmed-then-dangling turn silently lost its trailing words. Continue the segment
+      // numbering from turn.seq so the promoted ids never collide with turn:${id}:0..seq-1.
       const name = this.resolveName(turn);
-      const promoted = turn.pendingTail.map((s, i) => ({ ...s, segmentId: `turn:${turn.turnId}:${i}` }));
+      const promoted = turn.pendingTail.map((s, i) => ({ ...s, segmentId: `turn:${turn.turnId}:${turn.seq + i}` }));
+      turn.seq += promoted.length;
+      // publish(confirmed, []) republishes these as completed AND reconciles pending→[], so the
+      // matching turn:${id}:p* drafts are retracted in the same breath (text moves p*→confirmed).
       this.cb.publish(name, promoted, []);
       this.rememberPublishedSpeaker(name, promoted[promoted.length - 1]?.endMs);
       turn.allConfirmed.push(...promoted);
@@ -688,6 +698,7 @@ export class ChunkedTranscriber {
       // PUBLISHED, or the next turn re-transcribes the promoted audio and
       // the same sentence appears under two turns.
       this.confirmedHighWaterMs = Math.max(this.confirmedHighWaterMs, promoted[promoted.length - 1].endMs);
+      turn.pendingTail = [];
       this.log(`[ChunkedTranscriber] turn ${turn.turnId}: promoted ${promoted.length} draft segment(s) on close`);
     }
     if (turn.pendingName) this.cb.clearPending(turn.pendingName);

--- a/core/meetings/modules/mixed-pipeline/src/never-lose-tail.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/never-lose-tail.test.ts
@@ -1,0 +1,71 @@
+/**
+ * never-lose-tail — regression guard for the retract feature deleting live speech.
+ *
+ * A turn that CONFIRMS early segments (reaching seq>0) and then closes with a still-pending
+ * draft tail — via a closing pass that yields nothing (empty/gated STT result) — must PROMOTE
+ * that tail to confirmed, never retract it with no replacement. Before the fix, the "never lose
+ * a turn" promotion only covered a never-confirmed turn (seq===0), so a confirmed-then-dangling
+ * turn silently lost its trailing words (deleted from the live view AND the durable store).
+ *
+ *   tsx src/never-lose-tail.test.ts
+ */
+import { ChunkedTranscriber, type BoundarySource } from './chunked-transcriber.js';
+import type { BoundaryEvent } from './pyannote-segmenter.js';
+import type { TranscriptionResult } from '@vexa/transcribe-whisper';
+
+const SR = 16000;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let failed = 0;
+const check = (name: string, cond: boolean, detail = ''): void => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond ? '' : '  — ' + detail}`);
+  if (!cond) failed++;
+};
+
+const seg = (text: string, start: number, end: number): any =>
+  ({ text, start, end, no_speech_prob: 0, avg_logprob: -0.1, compression_ratio: 1.0 });
+const result = (segs: any[]): TranscriptionResult =>
+  ({ text: segs.map((s) => s.text).join(' '), language: 'en', language_probability: 0.99, segments: segs } as any);
+
+const confirmed: { id: string; text: string }[] = [];
+let emit!: (ev: BoundaryEvent) => void;
+let i = 0;
+// submit 1-3 build "alpha" (confirms via LocalAgreement-3) + a forming "beta ..." tail (pending);
+// the close pass yields NOTHING (empty segments) — so without promotion, "beta" is retracted + lost.
+const script: TranscriptionResult[] = [
+  result([seg('alpha', 0, 1.0)]),
+  result([seg('alpha', 0, 1.0), seg('beta', 1.0, 1.6)]),
+  result([seg('alpha', 0, 1.0), seg('beta forming', 1.0, 2.0)]),
+  result([]), // close → yields nothing → closeOut with a dangling pending tail
+];
+
+const tc = await ChunkedTranscriber.create({
+  language: 'en',
+  transcribe: async () => { const r = script[Math.min(i, script.length - 1)]; i++; return r; },
+  publish: (_s, segs) => { for (const c of segs) confirmed.push({ id: c.segmentId, text: c.text }); },
+  publishPending: () => {},
+  clearPending: () => {},
+  rename: () => {},
+  makeSegmenter: (onBoundary) => { emit = onBoundary; return Promise.resolve<BoundarySource>({ appendFrame: async () => {}, reset() {} }); },
+  log: () => {},
+});
+
+const feed = (fromSec: number, durSec: number): void => {
+  const a = new Float32Array(Math.round(SR * durSec)); a.fill(0.1); tc.feedAudio(a, fromSec * 1000);
+};
+emit({ kind: 'silence→speaker', tMs: 0, confidence: 0.9 });
+feed(0, 3); await sleep(1200);   // submit 1
+feed(3, 3); await sleep(1200);   // submit 2
+feed(6, 3); await sleep(1200);   // submit 3 → confirm "alpha", tail "beta forming" pending
+emit({ kind: 'speaker→silence', tMs: 9000, confidence: 0.9 });   // close → yields-nothing pass
+await sleep(150);
+await tc.dispose();
+
+const texts = confirmed.map((c) => c.text);
+const ids = confirmed.map((c) => c.id);
+check('early segment confirmed (turn reached seq>0)', texts.includes('alpha'), JSON.stringify(texts));
+check('dangling pending tail is PROMOTED on close, not lost', texts.some((t) => t.includes('beta')), JSON.stringify(texts));
+check('promoted id continues the seq (no collision with the confirmed segment)',
+  new Set(ids).size === ids.length && ids.every((id) => /^turn:\d+:\d+$/.test(id)), JSON.stringify(ids));
+
+if (failed) { console.error(`\n❌ never-lose-tail: ${failed} check(s) FAILED.`); process.exit(1); }
+console.log('\n✅ never-lose-tail: a confirmed-then-dangling turn promotes its tail instead of deleting it.');

--- a/core/meetings/modules/record-chunker/src/index.ts
+++ b/core/meetings/modules/record-chunker/src/index.ts
@@ -91,6 +91,16 @@ export class MediaRecorderChunker implements RecordingTap {
     return this.recorder;
   }
 
+  /** Force the recorder to emit a chunk NOW with everything buffered since the last timeslice —
+   *  without stopping. The tail-loss fix: on eviction Zoom navigates the page away (destroying the
+   *  recorder) before the next timeslice boundary, so the last partial (the final few seconds of
+   *  speech) never becomes a chunk. Flushing at the earliest end-signal (the mix going silent) turns
+   *  that partial into a real, immediately-uploaded chunk before the context dies. Idempotent + safe. */
+  flush(): void {
+    try { if (this.recorder && this.recorder.state === "recording") this.recorder.requestData(); }
+    catch (err: any) { blog(`[record-chunker] flush() requestData failed: ${err?.message || err}`); }
+  }
+
   async start(): Promise<void> {
     if (this.recorder) {
       blog("[record-chunker] start() called twice — ignoring");
@@ -277,11 +287,15 @@ class DynamicAudioMixer {
   private dest: MediaStreamAudioDestinationNode;
   private sources = new Map<string, { node: MediaStreamAudioSourceNode; stream: MediaStream }>();
   private timer: ReturnType<typeof setInterval> | null = null;
+  /** Fired when the live-source count falls to 0 (all participant tracks ended — the meeting is
+   *  closing). The recording host uses it to flush the recorder's buffered tail before the page dies. */
+  private onEmpty: (() => void) | null;
 
-  constructor() {
+  constructor(onEmpty?: () => void) {
     this.ctx = new AudioContext();   // default (full) sample rate — NOT the 16 kHz transcription mix
     this.ctx.resume?.();
     this.dest = this.ctx.createMediaStreamDestination();
+    this.onEmpty = onEmpty ?? null;
   }
 
   get stream(): MediaStream { return this.dest.stream; }
@@ -302,12 +316,16 @@ class DynamicAudioMixer {
     // Prune truly-dead streams (all tracks ended) so a long meeting's track churn doesn't accumulate
     // source nodes. A still-live stream is KEPT even if its element left the DOM (the node holds the
     // stream ref and still pulls audio) — presence is not the liveness signal, the track state is.
+    const had = this.sources.size;
     for (const [id, entry] of this.sources) {
       if (entry.stream.getAudioTracks().some((t) => t.readyState === "live")) continue;
       try { entry.node.disconnect(); } catch { /* */ }
       this.sources.delete(id);
       blog(`[record-chunker] mix -stream (${this.sources.size} live)`);
     }
+    // Just went silent (all tracks ended → the meeting is closing) — flush the recorder's buffered tail
+    // NOW, before the platform navigates the page away and destroys the recorder mid-partial-timeslice.
+    if (had > 0 && this.sources.size === 0 && this.onEmpty) { try { this.onEmpty(); } catch { /* */ } }
   }
 
   start(): void {
@@ -349,7 +367,10 @@ export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTa
         // No ready stream ⇒ build a LIVE mix of the page's audio. Wait (bounded) for the first stream —
         // post-admission the participant / injected <audio> elements appear a beat late — so the
         // MediaRecorder's onStarted t=0 aligns with real audio; the rescan then follows the churn.
-        mixer = new DynamicAudioMixer();
+        // onEmpty → flush the recorder's buffered tail the instant the mix goes silent (meeting close),
+        // so the final partial timeslice (the last few seconds of speech) is a real chunk before the
+        // page navigates away on eviction. `chunker` is assigned just below and set by the time this fires.
+        mixer = new DynamicAudioMixer(() => chunker?.flush());
         let ready = false;
         for (let i = 0; i < 5; i++) {
           mixer.scan();

--- a/core/meetings/modules/record-chunker/src/index.ts
+++ b/core/meetings/modules/record-chunker/src/index.ts
@@ -237,56 +237,90 @@ export class MediaRecorderChunker implements RecordingTap {
 // ───────────────────────────────────────────────────────────────────────
 
 /**
- * Find active media elements that expose audio. Two-pass (strict → relaxed):
- * tiles can be paused or expose audio via captureStream() rather than a direct
- * srcObject, so the relaxed pass mirrors buildCombinedStream's fallbacks. This
- * is platform-agnostic — a recording grabs every audio element on the page.
+ * Every on-page audio-bearing MediaStream that is CURRENTLY producing audio (has a `live` track).
+ * Prefers `srcObject`; falls back to a captureStream() cached on the element (a fresh captureStream()
+ * each scan would mint a new stream id, defeating the mixer's dedup and leaking source nodes). Deduped
+ * downstream by stream id. Platform-agnostic — a recording grabs every audio element on the page.
  */
-async function findMediaElements(retries = 5, delay = 2000): Promise<HTMLMediaElement[]> {
-  for (let i = 0; i < retries; i++) {
-    const all = Array.from(document.querySelectorAll("audio, video"));
-    let els = all.filter((el: any) =>
-      !el.paused && el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0
-    ) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (strict)`); return els; }
-
-    els = all.filter((el: any) => {
-      try {
-        if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
-        if (typeof el.captureStream === "function" && el.captureStream()?.getAudioTracks?.().length > 0) return true;
-        if (typeof el.mozCaptureStream === "function" && el.mozCaptureStream()?.getAudioTracks?.().length > 0) return true;
-      } catch { /* not probeable; skip */ }
-      return false;
-    }) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (relaxed)`); return els; }
-
-    await new Promise((r) => setTimeout(r, delay));
+function collectAudioStreams(): MediaStream[] {
+  const els = Array.from(document.querySelectorAll("audio, video")) as any[];
+  const out: MediaStream[] = [];
+  for (const el of els) {
+    try {
+      let s: MediaStream | null = el.srcObject instanceof MediaStream ? el.srcObject : null;
+      if (!s) {
+        const cap: unknown =
+          el.__vexaRecCapStream instanceof MediaStream ? el.__vexaRecCapStream :
+          typeof el.captureStream === "function" ? el.captureStream() :
+          typeof el.mozCaptureStream === "function" ? el.mozCaptureStream() : null;
+        if (cap instanceof MediaStream) { el.__vexaRecCapStream = cap; s = cap; }
+      }
+      // Only LIVE audio: an element lingering with an ENDED track must not re-enter the mix (it would
+      // reconnect a dead source every scan and oscillate against the prune below).
+      if (s && s.getAudioTracks().some((t) => t.readyState === "live")) out.push(s);
+    } catch { /* not probeable; skip */ }
   }
-  return [];
+  return out;
 }
 
-/** Mix every media element's audio into one MediaStream via a destination node. */
-async function buildCombinedStream(mediaElements: HTMLMediaElement[]): Promise<MediaStream> {
-  if (mediaElements.length === 0) throw new Error("[record-chunker] no media elements to combine");
-  const ctx = new AudioContext();
-  const dest = ctx.createMediaStreamDestination();
-  let connected = 0;
-  mediaElements.forEach((element: any, index) => {
-    try {
-      const s =
-        element.srcObject ||
-        (element.captureStream && element.captureStream()) ||
-        (element.mozCaptureStream && element.mozCaptureStream());
-      if (s instanceof MediaStream && s.getAudioTracks().length > 0) {
-        ctx.createMediaStreamSource(s).connect(dest);
-        connected++;
-        blog(`[record-chunker] connected element ${index + 1}/${mediaElements.length}`);
-      }
-    } catch (e: any) { blog(`[record-chunker] could not connect element ${index + 1}: ${e?.message || e}`); }
-  });
-  if (connected === 0) throw new Error("[record-chunker] could not connect any audio streams");
-  blog(`[record-chunker] combined ${connected} streams`);
-  return dest.stream;
+/**
+ * A LIVE audio mix that FOLLOWS the meeting. One AudioContext destination that a periodic rescan keeps
+ * wired to every current on-page audio stream: it connects newly-appearing streams and prunes ones whose
+ * tracks have ended. Zoom/Teams deliver each participant as a separate WebRTC track and churn them
+ * constantly (each new track is mirrored into a fresh injected <audio> by @vexa/mixed-capture-core's
+ * hook) — so a ONE-TIME combine records silence the moment the originally-captured tracks end. Recording
+ * `dest.stream` (a STABLE handle whose sources come and go underneath) keeps the mix complete for the
+ * whole meeting. Full sample rate — deliberately NOT the 16 kHz transcription mix.
+ */
+class DynamicAudioMixer {
+  private ctx: AudioContext;
+  private dest: MediaStreamAudioDestinationNode;
+  private sources = new Map<string, { node: MediaStreamAudioSourceNode; stream: MediaStream }>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.ctx = new AudioContext();   // default (full) sample rate — NOT the 16 kHz transcription mix
+    this.ctx.resume?.();
+    this.dest = this.ctx.createMediaStreamDestination();
+  }
+
+  get stream(): MediaStream { return this.dest.stream; }
+  get connectedCount(): number { return this.sources.size; }
+
+  /** Connect newly-seen streams; prune streams whose audio has ended. Idempotent — safe every tick. */
+  scan(): void {
+    const present = new Map(collectAudioStreams().map((s) => [s.id, s]));
+    for (const [id, s] of present) {
+      if (this.sources.has(id)) continue;
+      try {
+        const node = this.ctx.createMediaStreamSource(s);
+        node.connect(this.dest);
+        this.sources.set(id, { node, stream: s });
+        blog(`[record-chunker] mix +stream (${this.sources.size} live)`);
+      } catch { /* not connectable yet — retried next tick */ }
+    }
+    // Prune truly-dead streams (all tracks ended) so a long meeting's track churn doesn't accumulate
+    // source nodes. A still-live stream is KEPT even if its element left the DOM (the node holds the
+    // stream ref and still pulls audio) — presence is not the liveness signal, the track state is.
+    for (const [id, entry] of this.sources) {
+      if (entry.stream.getAudioTracks().some((t) => t.readyState === "live")) continue;
+      try { entry.node.disconnect(); } catch { /* */ }
+      this.sources.delete(id);
+      blog(`[record-chunker] mix -stream (${this.sources.size} live)`);
+    }
+  }
+
+  start(): void {
+    this.scan();
+    this.timer = setInterval(() => { try { this.scan(); } catch { /* the rescan must never die */ } }, 2000);
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+    for (const { node } of this.sources.values()) { try { node.disconnect(); } catch { /* */ } }
+    this.sources.clear();
+    try { void this.ctx.close(); } catch { /* */ }
+  }
 }
 
 /** Options for createRecordingTap — combine all audio elements then optionally override. */
@@ -307,13 +341,24 @@ export interface CreateRecordingTapOptions extends RecordingTapOptions {
  */
 export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTap {
   let chunker: MediaRecorderChunker | null = null;
+  let mixer: DynamicAudioMixer | null = null;
   return {
     async start(): Promise<void> {
       let stream = opts.stream;
       if (!stream) {
-        const els = await findMediaElements();
-        if (els.length === 0) { blog("[record-chunker] no media elements — cannot record"); return; }
-        stream = await buildCombinedStream(els);
+        // No ready stream ⇒ build a LIVE mix of the page's audio. Wait (bounded) for the first stream —
+        // post-admission the participant / injected <audio> elements appear a beat late — so the
+        // MediaRecorder's onStarted t=0 aligns with real audio; the rescan then follows the churn.
+        mixer = new DynamicAudioMixer();
+        let ready = false;
+        for (let i = 0; i < 5; i++) {
+          mixer.scan();
+          if (mixer.connectedCount > 0) { ready = true; break; }
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+        if (!ready) { blog("[record-chunker] no audio streams — cannot record"); mixer.stop(); mixer = null; return; }
+        mixer.start();
+        stream = mixer.stream;
       }
       chunker = new MediaRecorderChunker({
         stream,
@@ -326,6 +371,8 @@ export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTa
     async stop(): Promise<void> {
       await chunker?.stop();
       chunker = null;
+      mixer?.stop();
+      mixer = null;
     },
   };
 }

--- a/core/meetings/services/bot/src/adapters/transcript-redis.ts
+++ b/core/meetings/services/bot/src/adapters/transcript-redis.ts
@@ -64,7 +64,20 @@ export function createRedisTranscriptSink(opts: RedisTranscriptSinkOptions): Tra
     await client.publish(channel, msg);
   }
 
-  return { publish };
+  /** Withdraw previously-published segments by id (a superseded/over-extended pending draft). Rides the
+   *  SAME durable stream as `publish` so it's ordered with the segments it retracts — the collector
+   *  deletes those rows and forwards a `retract` marker; the mutable channel carries it live too. */
+  async function retract(segmentIds: string[]): Promise<void> {
+    if (segmentIds.length === 0) return;
+    const payload = JSON.stringify({
+      type: 'transcript_retract', meeting_id: meetingId, native_meeting_id: nativeMeetingId, segment_ids: segmentIds,
+    });
+    await client.xAdd(TRANSCRIPTION_STREAM, '*', { payload });
+    const msg = JSON.stringify({ type: 'transcript_retract', meeting: { id: meetingId }, segment_ids: segmentIds });
+    await client.publish(channel, msg);
+  }
+
+  return { publish, retract };
 }
 
 /** A live transcript client that also exposes connect/quit so the composition root can

--- a/core/meetings/services/bot/src/pipeline.test.ts
+++ b/core/meetings/services/bot/src/pipeline.test.ts
@@ -39,10 +39,12 @@ addFormats(ajv);
 ajv.addSchema(txSchema);
 const validateSeg: ValidateFunction = ajv.compile({ $ref: `${txSchema.$id}#/$defs/TranscriptSegment` });
 
-/** A capturing bot-port TranscriptSink — records every published segment (confirmed + drafts). */
-function captureSink(): TranscriptSink & { readonly published: TranscriptSegment[] } {
+/** A capturing bot-port TranscriptSink — records every published segment (confirmed + drafts) and
+ *  every retracted id (the pending-tail withdrawal path). */
+function captureSink(): TranscriptSink & { readonly published: TranscriptSegment[]; readonly retracted: string[] } {
   const published: TranscriptSegment[] = [];
-  return { published, async publish(seg) { published.push(seg); } };
+  const retracted: string[] = [];
+  return { published, retracted, async publish(seg) { published.push(seg); }, async retract(ids) { retracted.push(...ids); } };
 }
 
 const baseInv = (over: Partial<Invocation> = {}): Invocation => ({
@@ -196,6 +198,41 @@ async function main(): Promise<void> {
         !!s.absolute_start_time &&
         Math.abs(new Date(s.absolute_start_time).getTime() / 1000 - (s.start ?? 0)) < 1),
       JSON.stringify(sink.published.map((s) => ({ id: s.segment_id, abs: s.absolute_start_time, start: s.start }))));
+  }
+
+  // ── 6) MIXED LANE pending RETRACTION (transcript de-dup): the mixed lane republishes its pending
+  //     tail as a FULL-REPLACE block. The bot's egress is append-only + the terminal upserts by id, so a
+  //     draft id that DROPS OUT of the block (confirmed under a new seq id, tail shrank, turn closed) must
+  //     be RETRACTED or it lingers as a stale "unattached" duplicate (and an over-read past the turn
+  //     boundary re-appears when the next turn transcribes the same audio). Assert the diff → retract. ──
+  {
+    const sink = captureSink();
+    let cb: ChunkedTranscriberCallbacks | null = null;
+    const factory = async (c: ChunkedTranscriberCallbacks) => {
+      cb = c;
+      return { feedAudio() { /* stub */ }, recordHint() { /* stub */ }, async dispose() { /* stub */ } };
+    };
+    const pipe = createBotPipeline(baseInv({ platform: 'zoom' }), sink, { createMixedTranscriber: factory });
+    await pipe.start();
+    const seg = (id: string, s: number, e: number) => ({ text: 't', startMs: s, endMs: e, language: 'en', segmentId: id });
+
+    // Open turn: two pending drafts published (nothing departed yet).
+    cb!.publishPending('Speaker', [seg('turn:1:p0', 1000, 2000), seg('turn:1:p1', 2000, 3000)]);
+    // A confirm lands: the leading draft confirms under a NEW seq id and the tail SHRINKS to one — the
+    // dropped draft (turn:1:p1) must be retracted, the surviving draft (turn:1:p0) must NOT.
+    cb!.publish('Speaker', [seg('turn:1:0', 1000, 2000)], [seg('turn:1:p0', 2000, 2500)]);
+    // Turn closes: pending emptied → the last surviving draft is retracted; only confirmed seq ids remain.
+    cb!.clearPending();
+    await sleep(20);
+
+    check('retraction: a draft that dropped out of the pending block was retracted (turn:1:p1)',
+      sink.retracted.includes('turn:1:p1'), JSON.stringify(sink.retracted));
+    check('retraction: the surviving-then-closed draft was retracted on close (turn:1:p0)',
+      sink.retracted.includes('turn:1:p0'), JSON.stringify(sink.retracted));
+    check('retraction: a CONFIRMED seq segment is NEVER retracted (durable content survives)',
+      !sink.retracted.includes('turn:1:0'), JSON.stringify(sink.retracted));
+    check('retraction: the confirmed segment WAS published (real content kept)',
+      sink.published.some((s) => s.segment_id === 'turn:1:0' && s.completed), JSON.stringify(sink.published.map((s) => s.segment_id)));
   }
 
   if (failed) { console.error(`\n❌ pipeline (L3): ${failed} check(s) FAILED.`); process.exit(1); }

--- a/core/meetings/services/bot/src/pipeline.ts
+++ b/core/meetings/services/bot/src/pipeline.ts
@@ -201,15 +201,38 @@ function createMixedBotPipeline(
     }
   };
 
+  // The mixed lane's pending tail is a FULL-REPLACE block: the ChunkedTranscriber republishes the whole
+  // surviving tail each pass, shrinking it as segments confirm (under NEW `turn:N:{seq}` ids) and emptying
+  // it when the turn closes. The bot's egress is an append-only stream the terminal upserts by id, so a
+  // pending id that DROPS OUT of the block is never removed → it lingers as a stale "unattached" draft
+  // (and an over-read past the turn boundary re-appears when the next turn transcribes the same audio).
+  // Diff the pending id set each pass and RETRACT the departed ids so the terminal + durable store drop
+  // them, leaving only the clean confirmed segments. One turn is open at a time (the pump serializes), so
+  // a single set tracks the whole lane.
+  let pendingIds = new Set<string>();
+  const reconcilePending = (pending: ChunkSegment[]): void => {
+    const next = new Set(pending.map((c) => c.segmentId));
+    const retracted: string[] = [];
+    for (const id of pendingIds) if (!next.has(id)) retracted.push(id);
+    pendingIds = next;
+    if (retracted.length > 0 && sink.retract) {
+      void sink.retract(retracted).catch((e) => {
+        (onError ?? ((err) => console.error(`[bot] pipeline(mixed): retract rejected: ${String(err)}`)))(e);
+      });
+    }
+  };
+
   const ensure = (): Promise<MixedTranscriber> => {
     if (transcriber) return Promise.resolve(transcriber);
     if (!creating) {
       creating = createTranscriber({
         transcribe,
-        // ONE atomic bundle: newly-confirmed (persisted) + the surviving pending tail.
-        publish: (speaker, confirmed, pending) => { publish(speaker, confirmed, true); publish(speaker, pending, false); },
-        publishPending: (speaker, segments) => publish(speaker, segments, false),
-        clearPending: () => { /* the bot's transcript.v1 egress is append-only; drafts self-replace by id */ },
+        // ONE atomic bundle: newly-confirmed (persisted) + the surviving pending tail. Reconcile the
+        // pending block FIRST so a draft that just confirmed (or dropped out) is retracted, not orphaned.
+        publish: (speaker, confirmed, pending) => { publish(speaker, confirmed, true); reconcilePending(pending); publish(speaker, pending, false); },
+        publishPending: (speaker, segments) => { reconcilePending(segments); publish(speaker, segments, false); },
+        // The turn's pending is gone (moved to another name / tail emptied / turn closed) → retract it.
+        clearPending: () => { reconcilePending([]); },
         rename: (_oldSpeaker, newSpeaker, segments) => publish(newSpeaker, segments, true),
         language,
         onError,

--- a/core/meetings/services/bot/src/ports.ts
+++ b/core/meetings/services/bot/src/ports.ts
@@ -60,6 +60,12 @@ export interface Pipeline {
  *  adapter publishes them to the redis stream / bus consumed by the collector. */
 export interface TranscriptSink {
   publish(segment: TranscriptSegment): Promise<void>;
+  /** Withdraw previously-published segments by id. The mixed lane republishes its pending tail as a
+   *  FULL-REPLACE block; when an id drops out of that block (confirmed under a new id, tail shrank, or
+   *  turn closed) it must be actively retracted, because the collector's stream is append-only and the
+   *  terminal upserts by id — without this a stale pending draft lingers as a duplicate. Optional so
+   *  lanes/adapters that don't produce retractable drafts (or test fakes) need not implement it. */
+  retract?(segmentIds: string[]): Promise<void>;
 }
 
 /** The reachability verdict of the FIRST (load-bearing) lifecycle emit (#530). `reachable` iff

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -253,13 +253,21 @@ def create_app(
     )
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
-    app.include_router(
-        _bot_spawn.build_router(
-            meeting_repo,
-            runtime,
-            service_authority,
-        )
-    )
+    # A fresh meeting must start on an EMPTY transcript stream. Wire a redis-backed purge (None offline)
+    # so bot_spawn can clear tc:meeting:{new_row_id} on a FRESH insert — a reused row id (e.g. after a DB
+    # id-sequence reset without a redis flush) would otherwise carry a prior generation's stale
+    # session_end and the terminal would show "Meeting ended" before the first word. continue_meeting is
+    # untouched (it keeps the reused row's stream). See bot_spawn.service.request_bot.
+    _stream_purge = None
+    if redis is not None and hasattr(redis, "delete"):
+        async def _stream_purge(meeting_id, _r=redis):
+            await _r.delete(f"tc:meeting:{meeting_id}")
+    app.include_router(_bot_spawn.build_router(
+        meeting_repo,
+        runtime,
+        service_authority,
+        transcript_stream_purge=_stream_purge,
+    ))
 
     # --- user-stop: DELETE /bots/{platform}/{native_meeting_id} (lifecycle/stop.py over redis) ---
     from .lifecycle.stop_router import InMemoryCommandPublisher, build_stop_router
@@ -834,6 +842,32 @@ def _mount_lifecycle(
                     )
                 except Exception as e:  # noqa: BLE001 — the worker's idle timeout is the backstop
                     log_event("meeting_copilot_reap_failed", audience="system", level="warning",
+                              span="lifecycle.callback",
+                              fields={"meeting_row_id": meeting_row_id, "error": str(e)})
+        # NEW-SESSION MARKER (mirror of the reap above): when a meeting goes ACTIVE, write a
+        # `session_start` marker onto the same ROW-scoped stream. tc:meeting:{row_id} is SHARED across a
+        # meeting's sessions — a re-sent bot REUSES a terminal row — so a prior session's `session_end`
+        # lingers in the terminal SSE's replay tail and shows "Meeting ended" over the new live meeting.
+        # This marker lets the SSE reset that stale end (agent api.py's seed treats any non-session_end
+        # entry as "still live"), so even a SILENT new session clears the banner. Best-effort.
+        if (
+            redis is not None
+            and not change.no_op
+            and rec.status is not None
+            and rec.status.value == "active"
+            and isinstance(meeting_row, dict)
+            and hasattr(redis, "xadd")
+        ):
+            meeting_row_id = meeting_row.get("id")
+            native = meeting_row.get("native_meeting_id") or rec.connection_id
+            if meeting_row_id is not None:
+                try:
+                    await redis.xadd(
+                        f"tc:meeting:{meeting_row_id}",
+                        {"type": "session_start", "uid": str(native or meeting_row_id)},
+                    )
+                except Exception as e:  # noqa: BLE001 — best-effort; the seed also resets on new segments
+                    log_event("meeting_session_start_marker_failed", audience="system", level="warning",
                               span="lifecycle.callback",
                               fields={"meeting_row_id": meeting_row_id, "error": str(e)})
         log_event(

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -237,8 +237,13 @@ def build_router(
     repo: MeetingRepo,
     runtime: RuntimeClient,
     authority=None,
+    *,
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> APIRouter:
-    """The bot-spawn routes over injected storage, runtime, and authority ports."""
+    """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` + authority ports.
+
+    ``transcript_stream_purge`` (redis-backed in prod, None offline) clears a fresh meeting's transcript
+    stream so it never inherits a reused row id's stale data — see ``request_bot``."""
     router = APIRouter()
 
     @router.post("/bots", status_code=201)
@@ -411,6 +416,7 @@ def build_router(
                 webhook_url=x_user_webhook_url,
                 webhook_secret=x_user_webhook_secret,
                 webhook_events=webhook_events,
+                transcript_stream_purge=transcript_stream_purge,
             )
         except TranscriptionNotConfigured as e:
             raise HTTPException(status_code=503, detail=str(e))

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import os
 import uuid
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from ..config_preflight import CONFIG_FAULT_KINDS, cached_probe_verdict
 from ..obs import log_event
@@ -172,6 +172,11 @@ async def request_bot(
     webhook_url: Optional[str] = None,
     webhook_secret: Optional[str] = None,
     webhook_events: Optional[dict] = None,
+    # Fresh-meeting stream hygiene: purge tc:meeting:{new_row_id} on a FRESH insert so a new meeting
+    # never inherits a prior generation's transcript (a reused row id after a DB reset would otherwise
+    # carry a stale session_end → "Meeting ended" before the first word). Injected (redis-backed in
+    # prod, None in tests/offline). NOT called on continue_meeting — that reuse KEEPS the stream.
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> dict:
     """Run the spawn flow and return a MeetingResponse-shaped dict.
 
@@ -419,6 +424,23 @@ async def request_bot(
             )
             raise
     meeting_id = row["id"]
+
+    # 3b. Fresh-meeting stream hygiene (see the param doc): a brand-new row must start on an EMPTY
+    # transcript stream. Row ids are monotonic, so tc:meeting:{id} normally doesn't exist yet — but if
+    # the DB id sequence is ever reset/restored without flushing redis, a NEW meeting can be minted on a
+    # row id whose OLD stream still holds a prior generation's session_end, and the terminal shows
+    # "Meeting ended" before the first word. Purge on the FRESH insert only (reused_row is None);
+    # continue_meeting KEEPS the reused row's stream for continuity. Best-effort — a purge failure must
+    # never block the spawn (the collector is the stream's writer and appends after this).
+    if reused_row is None and transcript_stream_purge is not None:
+        try:
+            await transcript_stream_purge(meeting_id)
+        except Exception as _e:  # noqa: BLE001 — best-effort; never fail the spawn on a purge error
+            log_event(
+                "bot_spawn_stream_purge_failed", audience="system", level="warning",
+                span="bots.create", user_id=user_id,
+                fields={"meeting_id": meeting_id, "error": str(_e)},
+            )
 
     # 4. MeetingToken + invocation. connection_id IS the session_uid (parent's connectionId).
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -692,6 +692,31 @@ class SqlAlchemyTranscriptStore:
             pipe.expire(hash_key, ttl)
             await pipe.execute()
 
+    async def delete_segments(self, meeting_id, segment_ids) -> None:
+        # Retraction: withdraw superseded/over-extended pending drafts by segment id. Two legs mirror the
+        # append path — HDEL the live hash so an UN-flushed draft never reaches Postgres, and DELETE any
+        # rows the db-writer already flushed. Keyed on (meeting_id, segment_id). Idempotent.
+        ids = [str(s) for s in (segment_ids or []) if s]
+        if not ids:
+            return
+        # Leg 1: drop from the redis flush hash (before the db-writer persists an un-flushed draft).
+        if self._redis is not None:
+            from .db_writer import segments_hash_key
+            try:
+                await self._redis.hdel(segments_hash_key(meeting_id), *ids)
+            except Exception:  # noqa: BLE001 — best-effort; the DB delete is the durable backstop
+                pass
+        # Leg 2: delete any already-flushed rows.
+        from sqlalchemy import bindparam
+        from sqlalchemy import text as sql_text
+
+        stmt = sql_text(
+            "DELETE FROM transcriptions WHERE meeting_id = :mid AND segment_id IN :sids"
+        ).bindparams(bindparam("sids", expanding=True))
+        async with self._session_factory() as db:
+            await db.execute(stmt, {"mid": int(meeting_id), "sids": ids})
+            await db.commit()
+
     async def upsert_segments(self, meeting_id, segments) -> None:
         """The db-writer's durable sink — UPSERT a batch of flushed segments into ``transcriptions``
         on the segment identity ``(meeting_id, segment_id)`` (the partial unique index

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -496,6 +496,19 @@ class InMemoryTranscriptStore:
             return
         self._row_or_placeholder(meeting_id)["segments"][segment["segment_id"]] = segment
 
+    async def delete_segments(self, meeting_id, segment_ids) -> None:
+        ids = [str(s) for s in (segment_ids or []) if s]
+        if not ids:
+            return
+        if self._redis is not None:
+            from .db_writer import segments_hash_key
+
+            await self._redis.hdel(segments_hash_key(meeting_id), *ids)
+            return
+        segs = self._row_or_placeholder(meeting_id)["segments"]
+        for sid in ids:
+            segs.pop(sid, None)
+
     async def upsert_segments(self, meeting_id, segments) -> None:
         """The db-writer's durable sink (the dict stands in for the ``transcriptions`` table):
         upsert by ``segment_id`` — idempotent, a re-flush updates in place."""

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ingest.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ingest.py
@@ -190,6 +190,32 @@ async def ingest(store: TranscriptStore, redis: RedisBus, message: dict) -> int:
             except Exception as e:  # noqa: BLE001 — best-effort; never abort the batch
                 _log_publish_failure(meeting_id, e)
         return 0
+    if msg_type == "transcript_retract":
+        # The bot withdraws superseded/over-extended pending drafts (the mixed lane's full-replace tail).
+        # Delete them from the durable store AND append a `retract` marker to the row-scoped stream so the
+        # copilot worker + terminal SSE drop them live (mirrors the session_end marker path above).
+        mid_raw = data.get("meeting_id")
+        try:
+            meeting_id = int(mid_raw) if mid_raw is not None else None
+        except (TypeError, ValueError):
+            meeting_id = None
+        seg_ids = data.get("segment_ids")
+        if meeting_id is None or not isinstance(seg_ids, list) or not seg_ids:
+            return 0
+        ids = [str(s) for s in seg_ids if s]
+        try:
+            await store.delete_segments(meeting_id, ids)
+        except Exception as e:  # noqa: BLE001 — best-effort; never abort the batch on a retract
+            _log_publish_failure(meeting_id, e)
+        try:
+            await redis.xadd(_transcript_stream(meeting_id), {"type": "retract", "segment_ids": ids})
+            await redis.publish(
+                _mutable_channel(meeting_id),
+                json.dumps({"type": "transcript_retract", "meeting": {"id": meeting_id}, "segment_ids": ids}),
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort live fan-out
+            _log_publish_failure(meeting_id, e)
+        return 0
     if msg_type not in ("transcription", "transcript"):
         # session_start / speaker events are out of scope for this segment unit.
         return 0

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -103,6 +103,12 @@ class TranscriptStore(Protocol):
         persistence)."""
         ...
 
+    async def delete_segments(self, meeting_id: int, segment_ids: list) -> None:
+        """Withdraw retracted drafts by ``segment_id``: drop them from the live segments hash (before an
+        un-flushed draft reaches Postgres) AND delete any already-flushed rows. Idempotent — a missing id
+        is a no-op. The mixed lane's full-replace pending tail leaves stale drafts otherwise."""
+        ...
+
     async def connect_doc(
         self, user_id: int, platform: str, native_meeting_id: str, doc: dict
     ) -> Optional[list[dict]]:

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
@@ -347,11 +347,18 @@ async def reconcile_stale_nonterminal_sweep(
             runtime, bot_container_id, meeting_id=meeting_id, log=log
         )
         if verdict != "confirmed":
+            # A `stopping` row = a stop was EXPLICITLY requested; the bot is meant to be leaving. Once
+            # its workload is untracked (the runtime has nothing left to tear down), converge it on the
+            # SHORT stop_grace, not the long untracked window. This is the restart-mid-leave case: on the
+            # process backend the bot dies WITH the runtime, so without this a `stopping` row sits
+            # untracked for the full untracked_grace (10 min default) — and the in-process window resets
+            # on every restart, so a redeploy burst can keep it stuck ~indefinitely (the observed bug).
+            esc_grace = stop_grace if status == "stopping" else untracked_grace
             if verdict == "untracked" and _untracked_window_elapsed(
-                tracker, meeting_id, seen_untracked, grace=untracked_grace, now=now
+                tracker, meeting_id, seen_untracked, grace=esc_grace, now=now
             ) and await _escalate_untracked_zombie(
                 meeting_id, status, session_uid, bot_container_id, post_lifecycle,
-                tracker, grace=untracked_grace, log=log, stop_requested=stop_requested,
+                tracker, grace=esc_grace, log=log, stop_requested=stop_requested,
             ):
                 reconciled += 1
             continue

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -119,6 +119,35 @@ async def test_request_bot_eager_creates_session_and_spawns(monkeypatch):
     assert repo.sessions[0]["session_uid"] == spawned["connectionId"]
 
 
+async def test_fresh_spawn_purges_transcript_stream_but_continue_does_not(monkeypatch):
+    """A FRESH meeting must start on an EMPTY transcript stream, so a reused row id (e.g. after a DB
+    id-sequence reset without a redis flush) can't carry a prior generation's session_end → the
+    terminal showing "Meeting ended" before the first word. The injected purge fires with the new row
+    id on a fresh insert, and NOT on continue_meeting (which intentionally keeps the reused stream)."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    purged: list[int] = []
+
+    async def _purge(mid):
+        purged.append(mid)
+
+    kw = dict(redis_url="r", token_secret=SECRET, meeting_api_url="http://meeting-api:8080",
+              transcript_stream_purge=_purge)
+
+    first = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                              native_meeting_id="abc-defg-hij", **kw)
+    assert purged == [first["id"]]            # fresh insert → the NEW row's stream is purged
+
+    # the meeting completes; a CONTINUED bot reuses the SAME row and must NOT purge (keeps continuity)
+    repo.set_status(first["id"], "completed")
+    purged.clear()
+    second = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                               native_meeting_id="abc-defg-hij", continue_meeting=True, **kw)
+    assert second["id"] == first["id"]
+    assert purged == []                       # continue_meeting KEEPS the reused row's stream
+
+
 def test_iso_utc_marks_naive_utc_with_z():
     # Meeting time columns are naive but hold UTC. Serializing must emit a Z marker so a browser
     # parses it as UTC and renders local — a bare isoformat is read as LOCAL (the 6h-skew bug).

--- a/core/meetings/services/meeting-api/tests/test_ingest.py
+++ b/core/meetings/services/meeting-api/tests/test_ingest.py
@@ -45,6 +45,32 @@ def _message(meeting_id: int, segments: list[dict]) -> dict:
     })}
 
 
+def _retract_message(meeting_id: int, segment_ids: list) -> dict:
+    """A decoded ``transcript_retract`` stream message (the bot withdrawing superseded drafts)."""
+    return {"payload": json.dumps({
+        "type": "transcript_retract", "meeting_id": str(meeting_id), "segment_ids": segment_ids,
+    })}
+
+
+async def test_ingest_retract_deletes_drafts_and_publishes(store, bus):
+    # A turn: one confirmed segment + one still-pending draft.
+    await ingest(store, bus, _message(1, [
+        {"segment_id": "turn:1:0", "start": 1.0, "end": 2.0, "text": "keep me", "language": "en",
+         "speaker": "Alice", "completed": True},
+        {"segment_id": "turn:1:p0", "start": 2.0, "end": 3.0, "text": "stale draft", "language": "en",
+         "speaker": "Speaker", "completed": False},
+    ]))
+    # The draft is superseded/over-extended → the bot retracts it.
+    n = await ingest(store, bus, _retract_message(1, ["turn:1:p0"]))
+    assert n == 0  # a retract persists no segments
+    texts = [s["text"] for s in (await store.get_transcript(7, "google_meet", "abc-defg-hij"))["segments"]]
+    assert "keep me" in texts        # the confirmed segment survives
+    assert "stale draft" not in texts  # the retracted draft is gone from the durable store
+    # a live retract was published on the mutable channel so the terminal drops it in place
+    retracts = [json.loads(raw) for _ch, raw in bus.published if json.loads(raw).get("type") == "transcript_retract"]
+    assert retracts and retracts[0]["segment_ids"] == ["turn:1:p0"]
+
+
 async def test_ingest_persists_and_is_readable(store, bus):
     n = await ingest(store, bus, _message(1, [
         {"segment_id": "ch-0:1:a", "start": 1.0, "end": 2.5, "text": "Hello", "language": "en",

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -951,10 +951,12 @@ def test_continuous_untracked_past_window_escalates_once_with_evidence():
     assert repo._meetings[m["id"]]["status"] == "failed"
 
 
-def test_stopping_untracked_past_window_escalates_too():
+def test_stopping_untracked_past_window_escalates_on_stop_grace():
     """The `stopping` zombie (user pressed Stop, then the runtime restarted on the process backend):
-    the teardown stays unconfirmable (404) forever — past the window it converges to `failed`
-    instead of retrying the dead DELETE every sweep for eternity."""
+    the teardown stays unconfirmable (404) forever. A stop was EXPLICITLY requested, so it converges
+    on the SHORT stop_grace — NOT the long untracked window — instead of sitting stuck for 10 min (or,
+    across a redeploy burst that keeps resetting the in-process window, ~forever). The restart-mid-
+    leave stuck-meeting fix."""
     repo = InMemoryMeetingRepo()
     m = _seed(repo, status="stopping")
     repo._meetings[m["id"]]["bot_container_id"] = "wl-gone"
@@ -963,10 +965,12 @@ def test_stopping_untracked_past_window_escalates_too():
     client = TestClient(create_app(meeting_repo=repo))
     tracker: dict = {}
 
-    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=0.0) == 0
+    # untracked_grace stays LONG (a live *active* bot keeps its full patience); a `stopping` row
+    # converges on stop_grace regardless — proving it's the short window driving the escalation.
+    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=600.0, stop_grace=0.0) == 0
     assert repo._meetings[m["id"]]["status"] == "stopping"  # window opened
 
-    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=0.0) == 1
+    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=600.0, stop_grace=0.0) == 1
     assert repo._meetings[m["id"]]["status"] == "failed"
     assert runtime.deleted == []
 

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -1215,7 +1215,12 @@ def test_non_terminal_advance_does_not_emit_session_end():
     _post(client, connection_id="sess-uid", status="active")
 
     stream = f"tc:meeting:{m['id']}"
-    assert stream not in redis.streams, "session_end emitted while the meeting is still live"
+    # A non-terminal advance must NOT emit session_end (that would end the live view). It DOES write a
+    # session_start marker on `active` — the signal the terminal SSE uses to clear a prior session's
+    # stale session_end when a re-sent bot reuses this meeting row.
+    entries = redis.streams.get(stream, [])
+    assert not any(p.get("type") == "session_end" for p in entries), "session_end emitted while the meeting is still live"
+    assert any(p.get("type") == "session_start" for p in entries), "session_start marker not emitted on active"
     assert "tc:meeting:m1" not in redis.streams
 
 

--- a/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
+++ b/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
@@ -180,7 +180,7 @@ def test_runtime_destroy_completes_stopping_after_active_e2e():
         "lifecycle_contract_version": "2026-07-28",
     }
     assert repo.list_stale_stopping_sync() == []
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_destroy_with_invalid_time_does_not_fabricate_provenance():
@@ -243,7 +243,7 @@ def test_runtime_destroy_fails_pre_active_e2e():
     assert repo._meetings[m["id"]]["status"] == "failed"
     assert repo._meetings[m["id"]]["data"].get("failure_stage") == "awaiting_admission"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "awaiting_admission_timeout"
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -310,7 +310,7 @@ def test_runtime_destroy_noop_on_already_terminal_e2e():
     assert repo._meetings[m["id"]]["status"] == "completed"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "left_alone"
     # Exactly ONE session_end (the bot's own completed), not a second from the trailing destroy.
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_nonterminal_state_does_not_advance_e2e():

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -22,7 +22,7 @@
 # Mirrors core/meetings/services/bot/Dockerfile (builder), but on the official Playwright
 # image instead of the published meet-join-env base. Browsers come from /ms-playwright.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS bot-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS bot-builder
 ENV PNPM_HOME=/pnpm \
     PATH=/pnpm:$PATH \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
@@ -52,7 +52,7 @@ RUN cd /build && node core/meetings/services/bot/warm-hf-cache.mjs || echo "[bot
 # runtime node_modules (npm prune --omit=dev) rather than a standalone trace. Built on the SAME
 # Playwright base as the final stage so any native addon (ws' bufferutil) is ABI-compatible.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS terminal-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS terminal-builder
 WORKDIR /app/terminal
 COPY clients/terminal/package.json clients/terminal/package-lock.json ./
 RUN npm ci --no-audit --no-fund
@@ -61,14 +61,14 @@ COPY clients/terminal/ ./
 RUN npm run build && npm prune --omit=dev
 
 # -----------------------------------------------------------------------------
-# Stage 2c: valkey-builder — build valkey-server + valkey-cli from source on the SAME jammy glibc
+# Stage 2c: valkey-builder — build valkey-server + valkey-cli from source on the SAME glibc
 # as the final stage. Valkey (Linux Foundation BSD-3 fork of Redis 7.2.4) gives XAUTOCLAIM parity
 # with compose/helm and keeps Lite off BOTH ends of the #653 gap: jammy apt's stale redis 6.0.16
 # (no XAUTOCLAIM — the v0.12.5 witness root) AND source-available Redis ≥7.4 (RSALv2/SSPLv1). Built
 # from the pinned git tag, so: no external apt-repo trust (the issue verified redis's apt license
 # metadata is wrong), and no glibc mismatch — an alpine/musl binary can't run on this glibc base.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS valkey-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS valkey-builder
 ARG VALKEY_VERSION=8.1.9
 # Pinned SHA-256 of the tag tarball (supply-chain, production-grade R16): the build verifies the bytes,
 # not just the version. `sha256sum -c` fails LOUD on any mismatch — a tampered or drifted tarball stops
@@ -89,7 +89,7 @@ RUN curl -fsSL "https://github.com/valkey-io/valkey/archive/refs/tags/${VALKEY_V
 # -----------------------------------------------------------------------------
 # Stage 3: final — assemble the all-in-one runtime image on the same Playwright base.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS final
 ENV DEBIAN_FRONTEND=noninteractive
 
 # System stack: Python (the 5 services) · supervisor · X11/audio (Xvfb/fluxbox/pulse) ·
@@ -112,8 +112,10 @@ COPY --from=valkey-builder /opt/valkey/bin/valkey-server /opt/valkey/bin/valkey-
 COPY --from=valkey-builder /valkey-COPYING /usr/local/share/valkey/LICENSE
 RUN valkey-server --version && command -v valkey-cli
 
-# uv (the per-service venvs are resolved from each service's own pyproject + uv.lock).
-RUN pip3 install --no-cache-dir uv==0.9.22
+# uv — the per-service venvs resolve from each service's pyproject + uv.lock. Standalone installer
+# (version-pinned), on PATH at /usr/local/bin.
+RUN curl -LsSf https://astral.sh/uv/0.9.22/install.sh | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh \
+ && uv --version
 
 ENV UV_LINK_MODE=copy \
     PYTHONUNBUFFERED=1 \
@@ -126,7 +128,7 @@ RUN mkdir -p /var/log/supervisor /var/lib/redis /var/run/redis /workspaces
 # ── Python venvs — one per service (avoids cross-service dependency-pin conflicts). Each mirrors
 #    that service's Dockerfile (uv sync --frozen + the production-only ASGI/DB extras). ────────────
 #    `--python 3.12` pins the interpreter to match every compose image's `FROM python:3.12-slim`.
-#    The jammy base ships only system python3.10 (< requires-python >=3.11), so an unpinned
+#    The base's system python can lag requires-python >=3.11, so an unpinned
 #    `uv venv` would auto-download the newest managed CPython (3.14) — whose stack fails at boot
 #    (SQLAlchemy's psycopg dialect import). Pinning keeps Lite on the same interpreter as compose/helm.
 # admin-api
@@ -154,6 +156,15 @@ COPY core/agent/pyproject.toml core/agent/uv.lock /tmp/agent/
 RUN cd /tmp/agent && uv venv --python 3.12 /opt/venvs/agent \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/agent uv sync --frozen --no-install-project --no-default-groups --group control-plane
 RUN rm -rf /tmp/admin /tmp/runtime /tmp/meeting /tmp/gateway /tmp/agent
+
+# The agent worker is the ONE venv exec'd as a NON-ROOT per-subject uid (the runtime process
+# backend's POSIX tenant isolation — core/runtime/src/runtime_kernel/isolation.py). Its interpreter
+# is the uv-managed CPython under /root/.local (uv installs managed pythons under HOME), and /root
+# is 0700 — so the sandbox uid cannot TRAVERSE /root to exec python: every dispatch dies with
+# "Permission denied" (exit 126) and respawns forever ("starting agent"). Grant traverse-only: the
+# interpreter tree underneath is already world-readable; /root keeps no read bit (stays unlistable)
+# and any root-only secret under it keeps its own 0600.
+RUN chmod o+x /root
 
 # Claude Code (the agent worker's model+tooling runtime) — npm global, on PATH for every spawned worker.
 RUN npm install -g @anthropic-ai/claude-code

--- a/docs/changelog.d/1011-noble-base.md
+++ b/docs/changelog.d/1011-noble-base.md
@@ -1,0 +1,3 @@
+- **The bot and Lite images now build on Ubuntu 24.04 (Noble) (#1011).** The meeting-bot image and
+  the Vexa Lite single-container image moved from the Jammy to the Noble Playwright base and run the
+  Python interpreter as a non-root user, keeping both current and hardened.

--- a/docs/changelog.d/1012-bot-name.md
+++ b/docs/changelog.d/1012-bot-name.md
@@ -1,0 +1,2 @@
+- **Set a default bot name for your deployment (#1012).** A new config lets you choose the display name the
+  bot joins meetings with, instead of the built-in default.

--- a/docs/changelog.d/1013-audio-recording.md
+++ b/docs/changelog.d/1013-audio-recording.md
@@ -1,0 +1,3 @@
+- **Meeting recordings now capture the full audio (#1013).** The mixed-lane (Zoom/Teams) recording follows
+  participants who join or speak later, and flushes the final seconds when the meeting closes — so a
+  recording no longer drops audio partway through or loses its last lines.

--- a/docs/changelog.d/1014-lifecycle.md
+++ b/docs/changelog.d/1014-lifecycle.md
@@ -1,0 +1,2 @@
+- **Two meeting-state fixes (#1014).** Restarting while a bot is still leaving no longer leaves the meeting
+  stuck in "stopping", and the "Meeting ended" banner no longer flashes over a still-live meeting.

--- a/docs/changelog.d/1017-transcript-dedup.md
+++ b/docs/changelog.d/1017-transcript-dedup.md
@@ -1,0 +1,2 @@
+- **Cleaner live transcripts (#1017).** Superseded or over-extended draft lines are now withdrawn instead of
+  lingering as stale "temp" text, and a turn's trailing words are no longer dropped when it closes.

--- a/docs/changelog.d/1021-terminal-show-more.md
+++ b/docs/changelog.d/1021-terminal-show-more.md
@@ -1,0 +1,3 @@
+- **See all your past meetings.** The Today view's past-meetings list now has a *Show more* button that
+  pages through your whole meeting history (20 at a time) instead of stopping at the most recent 8 — so
+  older meetings (and their transcripts + recordings) are reachable again.

--- a/docs/changelog.d/1022-meeting-links.md
+++ b/docs/changelog.d/1022-meeting-links.md
@@ -1,0 +1,3 @@
+- **Open a meeting's recording straight from its note.** Meeting notes carry a clickable link to the
+  recording & transcript, meetings are addressable by a stable `/?meeting=<id>` URL you can open right
+  in the browser, and a meeting opened that way now shows its real name in the tab.

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -225,7 +225,7 @@ test("image-licenses RED: an undeclared structured Helm repository/tag pin reds"
 });
 
 test("image-licenses RED: an undeclared Dockerfile FROM pin reds", () => {
-  const base = "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS bot-builder";
+  const base = "FROM mcr.microsoft.com/playwright:v1.56.0-noble AS bot-builder";
   const injected = `FROM somevendor/unaudited:1.2 AS review-probe\n${base}`;
   const r = withEdited(LITE, base, injected, () => runGate("image-licenses"));
   assert.equal(r.green, false, "an undeclared Dockerfile FROM image pin sailed through");
@@ -235,8 +235,8 @@ test("image-licenses RED: an undeclared Dockerfile FROM pin reds", () => {
 
 test("runtime-parity RED: the bare `apt install` form (not just apt-get) is caught too", () => {
   // A contributor who writes `apt install redis-server` (no -get) must not bypass the #636 guard.
-  const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final";
-  const r = withEdited(LITE, "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final", inject,
+  const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-noble AS final";
+  const r = withEdited(LITE, "FROM mcr.microsoft.com/playwright:v1.56.0-noble AS final", inject,
     () => runGate("runtime-parity"));
   assert.equal(r.green, false, "`apt install redis-server` (no -get) bypassed the parity guard");
   assert.match(r.out, /lite/);


### PR DESCRIPTION
**Delivers issue:** _(none — maintainer's own work)_

Superseded/over-extended draft lines are withdrawn instead of lingering as stale temp text, and a turn's trailing words are no longer dropped on close.

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Observation bundle
- **C1 —** ran: exercised live on the maintainer's self-hosted lite deployment · saw: _(author to fill)_ · concluded: _(author to fill)_

_Draft — live-witnessed during development; per-component evidence to be completed before marking ready._

## Stacked on #1016 (recording-player)
Diff vs `main` includes the branches below it in the stack. **This PR's own commits:**
- `b42eb85f` docs(changelog): transcript-dedup fragment
- `ac8fac72` fix(transcript): promote a confirmed turn's dangling draft tail on close (never lose speech)
- `a562b6de` fix(transcript): retract superseded pending drafts (dedup + overlap)

Changelog fragment included (`docs/changelog.d/0000-transcript-dedup.md`; rename `0000`→ this PR number).

---
Commits carry DCO `Signed-off-by`; GPG signatures pending.
