### PR TITLE
fix(zoom): accurate per-participant speaker attribution

### DIFF
--- a/clients/terminal/src/app/App.tsx
+++ b/clients/terminal/src/app/App.tsx
@@ -34,6 +34,15 @@ function InviteGate({ children }: { children: ReactNode }) {
   const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
   const invite = params.get("invite");
   const tshare = params.get("tshare");
+  const meeting = params.get("meeting");   // ?meeting=<platform>/<native> deep-link → open that meeting
+
+  // A `?meeting=` deep-link: stash the ref for the workbench first-view resolver, then clean the URL
+  // (reload so the stash is in place before the grid mounts) — unless an invite/tshare owns the reload.
+  useEffect(() => {
+    if (!meeting) return;
+    try { localStorage.setItem("vexa.openMeetingRef", meeting); } catch { /* locked-down storage */ }
+    if (!invite && !tshare) window.location.replace(window.location.pathname);
+  }, [meeting, invite, tshare]);
 
   // Transcript share redeems silently (no consent surface). Clean the URL after — unless an invite is also
   // present, in which case the invite flow owns the reload.

--- a/clients/terminal/src/canvas/MeetingCanvasView.tsx
+++ b/clients/terminal/src/canvas/MeetingCanvasView.tsx
@@ -1,5 +1,7 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useService } from "../platform";
+import { LayoutServiceId } from "../workbench/layout";
 import { CanvasActionsProvider, useActions, OPEN_ENTITY_EVENT } from "./actions";
 import { MeetingHealthBanner } from "./MeetingHealthBanner";
 import { LiveTranscriptEngine, type EngineActions, type EngineEntity, type EngineSignal } from "./LiveTranscriptEngine";
@@ -69,6 +71,14 @@ function ProcessedTranscript() {
 
 function MeetingCanvasBody({ meetingId }: { meetingId?: string }) {
   const { meeting, transcript } = useMeeting();
+  const layout = useService(LayoutServiceId);
+  // Name the tab from the loaded meeting — a meeting opened by `?meeting=<id>` before the list loaded
+  // opens as the generic "Meeting"; once the title arrives, rename the tab to match the list/prep views.
+  useEffect(() => {
+    if (meetingId && meeting.title && meeting.title !== "Meeting") {
+      layout.setTitle(`meeting:${meetingId}`, meeting.title.split(" — ")[0]);
+    }
+  }, [layout, meetingId, meeting.title]);
   const live = meeting.live === true;
   const hasNotes = (transcript.notes?.length ?? 0) > 0;
   // Durable truth wins over a stale list `live` flag ([N8] — the row can stay stuck on a live

--- a/clients/terminal/src/canvas/actions.ts
+++ b/clients/terminal/src/canvas/actions.ts
@@ -61,6 +61,10 @@ export const ASK_CHAT_EVENT = "vexa:terminal:ask-chat";
 // workbench resolves it to a file and opens the doc (revealing the center if in chat-only mode).
 export const OPEN_ENTITY_EVENT = "vexa:terminal:open-entity";
 
+// A `vexa-meeting:<platform>/<native>` link in a meeting note dispatches this; the workbench resolves
+// the native id → the meeting row and opens its canvas (transcript + recording). Detail: { ref }.
+export const OPEN_MEETING_EVENT = "vexa:terminal:open-meeting";
+
 // ASCII sentinel prefixed to the onboarding grounding (robust against bundler/linter normalization). The
 // agent ignores the bracketed tag; the chat uses it to recognize an onboarding turn (filter a pure
 // kickoff, compact the grounding off a real reply, keep it out of the session title).

--- a/clients/terminal/src/surfaces/today.tsx
+++ b/clients/terminal/src/surfaces/today.tsx
@@ -90,7 +90,8 @@ export function agendaWindow(groups: MeetingGroup[], now: Date = new Date(), wee
 export interface PastEntry { run: MeetingMock; group: MeetingGroup }
 export interface PastDay { key: string; date: Date; entries: PastEntry[] }
 
-const PAST_CAP = 8;
+const PAST_CAP = 8;       // initial past-meetings shown
+const PAST_MORE = 20;     // how many more each "Show more" reveals
 
 /** The past feed: each meeting's newest finished run, newest first, day-grouped. */
 export function pastFeed(groups: MeetingGroup[], cap: number = PAST_CAP): PastDay[] {
@@ -280,10 +281,13 @@ function TodayView() {
   const reviewedIds = useReviewed();
   const ownTree = useOwnWorkspaceTree();
   const [weekOffset, setWeekOffset] = useState(0);
+  const [pastCap, setPastCap] = useState(PAST_CAP);
   const now = new Date();
   const groups = groupMeetings(meetings);
   const days = agendaWindow(groups, now, weekOffset);
-  const past = pastFeed(groups);
+  const past = pastFeed(groups, pastCap);
+  // Total past meetings eligible for the feed (same predicate pastFeed slices by) — drives "Show more".
+  const pastTotal = groups.filter((g) => g.pastRuns[0] && (g.pastRuns[0].has_recording || g.pastRuns[0].start_time)).length;
   const todayKey = dayKey(now);
   const empty = meetings.length === 0;
   const pager = { background: "none", border: "1px solid var(--line)", color: "var(--t2)", borderRadius: 6,
@@ -327,6 +331,14 @@ function TodayView() {
             {day.entries.map((e) => <PastRow key={e.run.id} e={e} reviewedIds={reviewedIds} />)}
           </div>
         ))}
+
+        {pastCap < pastTotal && (
+          <button onClick={() => setPastCap((c) => c + PAST_MORE)}
+            style={{ background: "none", border: "1px solid var(--line)", color: "var(--t2)", borderRadius: 8,
+              padding: "7px 14px", cursor: "pointer", fontSize: 12.5, marginTop: 14 }}>
+            Show more ({pastTotal - pastCap} older)
+          </button>
+        )}
 
         {!empty && (
           <div style={{ fontSize: 11.5, color: "var(--t3)", margin: "24px 2px 10px", lineHeight: 1.5 }}>

--- a/clients/terminal/src/surfaces/workspace.tsx
+++ b/clients/terminal/src/surfaces/workspace.tsx
@@ -9,7 +9,7 @@ import { registerList, registerTab, type TabProps } from "../contributions";
 import { meetingsOnly } from "../app/mode";
 import { Icon, Checkbox } from "../ui-kit";
 import { Modal } from "../ui-kit/Modal";
-import { OPEN_ENTITY_EVENT } from "../canvas/actions";
+import { OPEN_ENTITY_EVENT, OPEN_MEETING_EVENT } from "../canvas/actions";
 import { ENTITY_CHIP, DEFAULT_ENTITY_CHIP, DocMetaContext, DocNavContext, resolveDocRef, type DocNavigate } from "../ui-kit/docLinks";
 import { ContextMenu, copyText } from "../ui-kit/ContextMenu";
 import { MdxDoc } from "../ui-kit/MdxDoc";
@@ -33,15 +33,28 @@ function parseEntity(text: string): { fm: [string, string][]; body: string } {
   return { fm, body: m[2] };
 }
 function wikilinks(text: string, navigate?: DocNavigate | null): ReactNode[] {
-  // Frontmatter [[wikilinks]] are clickable: navigate the doc pane in place when it provides
-  // a navigator (Obsidian-style), else fall back to the OPEN_ENTITY_EVENT tab path.
+  // Frontmatter [[wikilinks]] AND markdown [text](href) links are clickable (Obsidian-style): a
+  // wikilink / internal path navigates the doc pane (or opens a tab); a `?meeting=<id>` href opens the
+  // meeting canvas; http(s) opens externally. Lets a meeting note carry its recording links in metadata.
   const open = (wikilink: string) => navigate
     ? navigate({ wikilink })
     : window.dispatchEvent(new CustomEvent(OPEN_ENTITY_EVENT, { detail: { wikilink } }));
-  return text.split(/(\[\[[^\]]+\]\])/).map((part, i) => part.startsWith("[[")
-    ? <span key={i} onClick={() => open(part.slice(2, -2))}
-        style={{ color: "var(--blue)", cursor: "pointer" }}>{part}</span>
-    : <span key={i}>{part}</span>);
+  return text.split(/(\[\[[^\]]+\]\]|\[[^\]]+\]\([^)]+\))/).map((part, i) => {
+    if (part.startsWith("[[")) return <span key={i} onClick={() => open(part.slice(2, -2))}
+      style={{ color: "var(--blue)", cursor: "pointer" }}>{part}</span>;
+    const md = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+    if (md) {
+      const [, label, href] = md;
+      const meeting = href.match(/[?&]meeting=([^&#]+)/);
+      if (meeting) return <span key={i} role="link" style={{ color: "var(--blue)", cursor: "pointer" }}
+        onClick={() => window.dispatchEvent(new CustomEvent(OPEN_MEETING_EVENT, { detail: { ref: decodeURIComponent(meeting[1]) } }))}>{label}</span>;
+      if (/^https?:/i.test(href)) return <a key={i} href={href} target="_blank" rel="noreferrer noopener"
+        style={{ color: "var(--blue)" }}>{label}</a>;
+      return <span key={i} role="link" style={{ color: "var(--blue)", cursor: "pointer" }}
+        onClick={() => window.dispatchEvent(new CustomEvent(OPEN_ENTITY_EVENT, { detail: { path: href } }))}>{label}</span>;
+    }
+    return <span key={i}>{part}</span>;
+  });
 }
 
 // [[Title]] / relative-path resolution lives in ui-kit/docLinks (resolveDocRef) — shared

--- a/clients/terminal/src/ui-kit/MdxDoc.tsx
+++ b/clients/terminal/src/ui-kit/MdxDoc.tsx
@@ -21,6 +21,7 @@ import {
   Card, CardGroup, DocMetaContext, DocNavContext, ENTITY_CHIP, DEFAULT_ENTITY_CHIP, InternalLink,
   Wikilink, isInternalHref, type DocNavigate,
 } from "./docLinks";
+import { OPEN_MEETING_EVENT } from "../canvas/actions";
 
 // Link/wikilink resolution + the entity chips live in ./docLinks (ONE resolver shared with
 // the plain-Markdown fallback and the workbench event handler). Re-exported for existing
@@ -99,6 +100,14 @@ const htmlComponents = {
   h1: h(1), h2: h(2), h3: h(3), h4: h(4),
   p: ({ children }: { children?: ReactNode }) => <p style={{ margin: "0 0 8px", lineHeight: 1.6 }}>{children}</p>,
   a: ({ href, children }: { href?: string; children?: ReactNode }) => {
+    // Meeting deep-link (`?meeting=<id>`, relative or absolute) → open the meeting canvas (transcript +
+    // recording) in-app, no reload. The same URL also cold-opens the meeting via App.tsx (portable).
+    const mref = href?.match(/[?&]meeting=([^&#]+)/);
+    if (mref) {
+      const ref = decodeURIComponent(mref[1]);
+      return <span role="link" onClick={() => window.dispatchEvent(new CustomEvent(OPEN_MEETING_EVENT, { detail: { ref } }))}
+        style={{ color: "var(--blue)", textDecoration: "underline", cursor: "pointer" }}>{children}</span>;
+    }
     // Workspace-internal link (no scheme, not an anchor) → navigate the doc pane in place
     // (or open a tab outside a doc pane), same path the Wikilink chip uses. Relative hrefs
     // resolve against the linking doc's directory. External links open a browser tab.

--- a/clients/terminal/src/workbench/Workbench.tsx
+++ b/clients/terminal/src/workbench/Workbench.tsx
@@ -4,7 +4,7 @@
  *  CENTER: dockview TABS — a "tab" host resolves each panel by params.kind via the tab registry.
  *  RIGHT (resizable/collapsible): the persistent workspace chat, grounded by the active center tab.
  *  Reuses the Phase-C ⌘K palette + keybindings; the kernel's services do the rest. */
-import { useEffect, useRef, useState, useSyncExternalStore, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type CSSProperties } from "react";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 import { DockviewReact, type DockviewApi, type DockviewReadyEvent, type IDockviewPanelProps, type IDockviewPanelHeaderProps, themeAbyss } from "dockview-react";
@@ -27,7 +27,7 @@ import { resolveDocRef } from "../ui-kit/docLinks";
 import { liveMeetingsNow } from "../surfaces/liveMeetings";
 import { firstViewPlan } from "./firstView";
 import { isOwnedPath, meetingIdFromPath, meetingPath } from "../app/meetingRoute";
-import { OPEN_ENTITY_EVENT } from "../canvas/actions";
+import { OPEN_ENTITY_EVENT, OPEN_MEETING_EVENT } from "../canvas/actions";
 import { useTheme } from "../app/theme";
 import { meetingsOnly } from "../app/mode";
 
@@ -301,7 +301,7 @@ export function Workbench() {
     if (meetOnly || layout.store.getState().activeList !== "sessions") return;
     try {
       if (localStorage.getItem("vexa.openWorkspace")) layout.setActiveList("files");
-      else if (localStorage.getItem("vexa.openMeeting")) layout.setActiveList("meetings");
+      else if (localStorage.getItem("vexa.openMeeting") || localStorage.getItem("vexa.openMeetingRef")) layout.setActiveList("meetings");
     } catch { /* noop — a locked-down localStorage just means no early reveal */ }
     // once, on mount (a fresh page load after the redeem reload) — deps intentionally empty
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -323,6 +323,27 @@ export function Workbench() {
     window.addEventListener(OPEN_ENTITY_EVENT, onOpenEntity);
     return () => window.removeEventListener(OPEN_ENTITY_EVENT, onOpenEntity);
   }, [layout]);
+
+  // A `?meeting=<platform>/<native>` deep-link (clicked in a meeting note, or the cold-load URL) →
+  // resolve the native id to its meeting row and open the canvas (transcript + recording).
+  const openMeetingByRef = useCallback((mid: string) => {
+    // `?meeting=<id>` deep-link — the meeting ROW id. Open its canvas directly (the same tab a click
+    // in the meetings list opens); the canvas fetches its transcript/recording by that id.
+    const id = mid.trim();
+    if (!id) return;
+    const m = liveMeetingsNow().find((x) => String(x.id) === id);
+    if (layout.store.getState().activeList === "sessions") layout.setActiveList("meetings");
+    layout.openTab({ id: `meeting:${id}`, title: m ? m.title.split(" — ")[0] : "Meeting", kind: "meeting", params: { meetingId: id } });
+  }, [layout]);
+
+  useEffect(() => {
+    const onOpenMeeting = (e: Event) => {
+      const ref = (e as CustomEvent<{ ref?: string }>).detail?.ref;
+      if (ref) openMeetingByRef(ref);
+    };
+    window.addEventListener(OPEN_MEETING_EVENT, onOpenMeeting);
+    return () => window.removeEventListener(OPEN_MEETING_EVENT, onOpenMeeting);
+  }, [openMeetingByRef]);
 
   // detach the dockview api on unmount (navigation/HMR dispose it) so the layout
   // service never operates on a disposed grid.
@@ -363,6 +384,12 @@ export function Workbench() {
   }, [activeTab]);
 
   const resolveFirstView = async (fresh: boolean) => {
+    // A `?meeting=<platform>/<native>` deep-link (App.tsx stashed the ref) — open that meeting's canvas
+    // directly. Explicit navigation wins over the plan below.
+    try {
+      const mref = localStorage.getItem("vexa.openMeetingRef");
+      if (mref) { localStorage.removeItem("vexa.openMeetingRef"); openMeetingByRef(mref); return; }
+    } catch { /* noop */ }
     // an explicit shared meeting from a ?tshare= link (InviteRedeemer stashed it before the reload)
     let sharedMeetingId: string | null = null;
     try { sharedMeetingId = localStorage.getItem("vexa.openMeeting"); if (sharedMeetingId) localStorage.removeItem("vexa.openMeeting"); } catch { /* noop */ }

--- a/clients/terminal/src/workbench/layout.ts
+++ b/clients/terminal/src/workbench/layout.ts
@@ -57,6 +57,9 @@ export interface LayoutService {
   setActiveTab(tab: ActiveTab | null): void;
   /** switch which chat session the right rail shows (Sessions list / New chat) */
   setActiveSession(id: string): void;
+  /** Rename an already-open tab by its logical id (no-op if it isn't open). Lets a canvas set its
+   *  real title once its data loads — e.g. a meeting opened by `?meeting=<id>` before the list loaded. */
+  setTitle(id: string, title: string): void;
   setActiveList(id: string): void;
   toggleLeft(): void;
   toggleRight(): void;
@@ -148,6 +151,7 @@ export function createLayoutService(defaultList: string): LayoutService {
     setContext(ctx) { store.set((st) => ({ ...st, context: ctx })); },
     setActiveTab(tab) { store.set((st) => ({ ...st, activeTab: tab })); },
     setActiveSession(id) { store.set((st) => ({ ...st, activeSession: id })); writeLS(LS_SESSION, id); },
+    setTitle(id, title) { const p = api?.getPanel(id); if (p && title) p.api.setTitle(title); },
     goBack() {
       const snap = hist.pop();
       if (!snap || !api) return false;

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -1898,6 +1898,12 @@ def create_app(
                     if payload.get("type") == "retract":
                         yield from retract_event(payload)
                         continue
+                    # A real segment AFTER a session_end in the replay tail means a NEW session resumed
+                    # on this reused meeting-row stream (tc:meeting:{id} is shared across a meeting's
+                    # sessions). The prior end must NOT close the current live view — without this reset
+                    # a stale session_end seeds `ending=True` and fires a premature `meeting-end`, so the
+                    # terminal shows "Meeting ended" over a still-live meeting.
+                    ending = False
                     yield from seg_events(payload)
             if resume_o is None:   # fresh connect → seed the output (cards/agent-activity) replay
                 output_seed_rows = list(reversed(r.xrevrange(okey, count=MEETING_STREAM_OUTPUT_REPLAY) or []))
@@ -1926,7 +1932,13 @@ def create_app(
                             live.drop(session_uid)  # leaves the terminal's live-meetings feed
                             yield ({"type": "meeting-end"}, cursor())
                             return
-                        continue  # the final beat is still writing — keep draining
+                        # The final beat is still writing — keep draining. But this branch polls every
+                        # 1.5s and yields NOTHING, so a drain that waits out the copilot (up to the 45s
+                        # cap) goes silent well past the terminal's 20s SSE watchdog → the browser
+                        # force-reconnects mid-drain ("stream disconnected" banner + a re-replayed
+                        # session_end). Emit a ping so a healthy drain stays visibly alive.
+                        yield ({"type": "ping"}, cursor())
+                        continue
                     idle += 15000
                     if idle >= 600000:
                         return
@@ -1938,14 +1950,26 @@ def create_app(
                         last[stream] = entry_id
                         if stream == tkey:
                             payload = json.loads(fields.get("payload", "{}"))
-                            if payload.get("type") == "session_end":
+                            ptype = payload.get("type")
+                            if ptype == "session_end":
                                 ending = True            # don't end yet — drain the final beat first
                                 ending_at = _time.monotonic()
                                 last.pop(tkey, None)     # session_end is the last transcript entry
                                 break
-                            if payload.get("type") == "retract":
+                            if ptype == "retract":
                                 yield from retract_event(payload)
                                 continue
+                            # A NEW session resumed on this REUSED row (tc:meeting:{id} is shared across a
+                            # meeting's sessions): a `session_start` marker — or any real segment — arriving
+                            # after a prior `session_end` means the meeting is LIVE again. Clear a stale
+                            # `ending` so the ≤45s drain never fires a premature `meeting-end` over it (the
+                            # terminal showed "Meeting ended" on a still-live meeting). Mirrors the seed's
+                            # reset at connect; without it the live loop kept `ending=True` because it only
+                            # ever SET the flag, never cleared it.
+                            if ending:
+                                ending = False
+                            if ptype == "session_start":
+                                continue                 # marker only — nothing to render
                             yield from seg_events(payload)
                         elif stream == pkey:
                             yield from note_events(fields)

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -675,6 +675,7 @@ def _meeting_grounding(
         "title": str(m.get("title") or "").strip() or str(native),
         "platform": platform,
         "native": str(native),
+        "meeting_id": str(m.get("meeting_id") or native),   # the ROW id — the meeting's stable ?meeting= link
     }
 
     if phase == "prep":

--- a/core/agent/control_plane/meeting_steering.py
+++ b/core/agent/control_plane/meeting_steering.py
@@ -81,7 +81,12 @@ DEFAULT_TEMPLATES: dict[str, str] = {
     "post": (
         "The meeting \"{title}\" ({platform}/{native}) has ended{failed}. Its {source} is below — "
         "answer from it. Default moves: recap what was decided, extract action items with owners, "
-        "and draft follow-ups on request. Don't paste the transcript back verbatim.\n\n"
+        "and draft follow-ups on request. Don't paste the transcript back verbatim. When you write or "
+        "update this meeting's note under kg/entities/meeting/, add a markdown link to THIS session's "
+        "recording & transcript to the note's YAML frontmatter `recording:` field — "
+        "`recording: [▶ Recording & transcript](/?meeting={meeting_id})`. If you are CONTINUING an existing "
+        "note (an earlier session of this same meeting), KEEP the earlier links in that field and ADD this "
+        "one after them — a meeting can have several recorded sessions.\n\n"
         "<transcript>\n{transcript}\n</transcript>\n\n"
     ),
     # Ambient terminal-state digest (context bundle): one steering sentence AFTER the

--- a/core/agent/tests/test_api.py
+++ b/core/agent/tests/test_api.py
@@ -897,6 +897,47 @@ def test_sse_relays_retract_marker(monkeypatch):
     assert "turn:1:p0" in body        # carrying the withdrawn segment id
 
 
+class _ResumedSessionRedis:
+    """A REUSED meeting row (tc:meeting:{id} is shared across sessions): the live tail delivers a prior
+    session's session_end, THEN a new session's session_start + a fresh segment. Empty polls follow.
+    `exists`→0 so, WITHOUT the ending-reset fix, the first empty drain poll would fire meeting-end via
+    the `not has_proc` branch — the premature "Meeting ended" over a live meeting."""
+    def __init__(self):
+        self._reads = 0
+
+    def xrevrange(self, key, count=1):
+        return []            # nothing to seed — the stale end arrives on the LIVE tail below
+
+    def exists(self, key):
+        return 0             # no copilot proc stream
+
+    def xread(self, last, count=500, block=0):
+        import json as _j
+        self._reads += 1
+        if self._reads == 1:
+            return [("tc:meeting:m1", [("1-0", {"payload": _j.dumps({"type": "session_end"})})])]
+        if self._reads == 2:
+            return [("tc:meeting:m1", [("2-0", {"payload": _j.dumps({"type": "session_start", "uid": "m1"})})])]
+        if self._reads == 3:
+            return [("tc:meeting:m1", [("3-0", {"payload": _j.dumps(
+                {"type": "transcription", "segments": [{"speaker": "J", "text": "still live", "start": 9, "segment_id": "s9"}]})})])]
+        return []            # idle — with the fix `ending` is cleared, so NO meeting-end fires
+
+
+def test_sse_session_start_clears_stale_ending_no_premature_end(monkeypatch):
+    """Regression (terminal showed "Meeting ended" over a still-live meeting): when a REUSED row's live
+    tail carries a prior session_end followed by the new session's session_start + a real segment, the
+    stream must CLEAR the stale `ending` and NOT emit a premature meeting-end. The segment is relayed."""
+    fr = _ResumedSessionRedis()
+    c = _stream_client(fr, monkeypatch)
+    with c.stream("GET", "/api/meeting/stream", params={"meeting_id": "m1", "session_uid": "m1"},
+                  headers={"X-User-Id": "u_owner"}) as r:
+        assert r.status_code == 200
+        body = "".join(r.iter_text())
+    assert '"still live"' in body                           # the resumed session's segment reached the view
+    assert '"meeting-end"' not in body                      # the stale session_end did NOT close the live view
+
+
 # ── SSE cross-tenant ownership regression (P0 — the FIX-FIRST blocker) ────────────────────────────
 # The by-row-id SSE feed `/api/meeting/stream` must OWNER-SCOPE the row like the WS `/ws` path + the
 # by-id REST path do. Pre-fix it read `tc:meeting:{meeting_id}` straight off the caller-supplied query

--- a/core/agent/workspace-seeds/default/CLAUDE.md
+++ b/core/agent/workspace-seeds/default/CLAUDE.md
@@ -28,6 +28,11 @@ to record, research, or restructure knowledge, you **write it into this repo** a
 
   You may add more frontmatter fields (role, company, tags, etc.) and a markdown body below the
   second `---`. Cross-reference other entities with `[[wikilinks]]` using their title.
+- **Meeting notes** (`kg/entities/meeting/*`) carry a `recording:` frontmatter field holding a markdown
+  link to each recorded session's recording & transcript:
+  `recording: [▶ Recording & transcript](/?meeting=<meeting_id>)` (the meeting's row id). A meeting can
+  have several sessions — when you continue a note for a later session, KEEP the earlier links and ADD
+  this session's after them. The client renders the frontmatter markdown link and opens the canvas from it.
 
 **Reference entities as `[[Title]]` everywhere — chat replies included.** The client renders
 `[[wikilinks]]` as clickable entity chips and workspace file paths (backticked or as markdown

--- a/core/meetings/modules/join/Dockerfile.env
+++ b/core/meetings/modules/join/Dockerfile.env
@@ -10,7 +10,7 @@
 #   - the live lens: x11vnc + novnc + websockify
 #
 # Build:  docker build -f Dockerfile.env -t vexa/meet-join-env:dev .
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy
+FROM mcr.microsoft.com/playwright:v1.56.0-noble
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       xvfb x11vnc websockify novnc xdotool xclip \

--- a/core/meetings/modules/join/src/googlemeet/admission.ts
+++ b/core/meetings/modules/join/src/googlemeet/admission.ts
@@ -6,7 +6,8 @@ import {
   googleInitialAdmissionIndicators,
   googleWaitingRoomIndicators,
   googleRejectionIndicators,
-  googleConsentPromptIndicators
+  googleConsentPromptIndicators,
+  geminiNotesJoinNowSelectors
 } from "./selectors";
 
 // AdmissionError + AdmissionOutcome moved to ../shared/admission so every platform (jitsi/zoom/
@@ -213,14 +214,21 @@ export async function checkForGoogleAdmissionIndicators(page: Page): Promise<boo
     return false;
   }
 
-  // 1b. NEGATIVE GUARD: a Gemini "take notes" consent prompt is a pre-admission
-  // consent gate. Meeting controls can be visible behind it, but the bot is not
-  // truly participating until a human accepts/declines — reporting admitted here
-  // yields "status active, 0 transcriptions" (Vexa-ai/vexa#429). Suppress admission.
+  // 1b. The "Gemini is taking notes" dialog. Confirmed live (screenshot): it reads "Gemini is
+  // taking notes" with "Leave" / "Join now" — a JOIN NOTICE that AI notetaking is active in the
+  // meeting, NOT a consent-to-record gate. Clicking "Join now" is how any participant enters (a
+  // human does exactly this); it does not enable Gemini or consent on anyone's behalf. So proceed
+  // by clicking "Join now". Only if the dialog is present but has no "Join now" (a genuinely
+  // different consent gate) do we hold as not-admitted so a human can look.
   const consentPending = await hasConsentPrompt(page);
   if (consentPending) {
-    log(`⚠️ Gemini consent prompt visible — suppressing admission (consent pending; bot not truly in the call)`);
-    return false;
+    if (await acknowledgeGeminiNotesPrompt(page)) {
+      log(`✅ "Gemini is taking notes" notice — clicked "Join now" to enter the meeting`);
+      // Fall through to the admission checks below; the dialog is dismissed.
+    } else {
+      log(`⚠️ Consent prompt visible with no "Join now" — suppressing admission (bot not truly in the call)`);
+      return false;
+    }
   }
 
   // Wake the UI before probing. Google Meet auto-hides the in-call toolbar
@@ -305,16 +313,35 @@ export async function checkForWaitingRoomIndicators(page: Page): Promise<boolean
   return false;
 }
 
-// Detect Google's Gemini "take notes for me" in-call consent prompt — a consent
-// gate where the bot isn't truly participating until a human accepts/declines
-// (Vexa-ai/vexa#429). Mirrors checkForWaitingRoomIndicators: a pre-admission
-// state that suppresses the "admitted" signal. Consent must be a human decision,
-// so callers escalate to needs_human_help rather than auto-clicking it.
+// Detect Google's "Gemini is taking notes" dialog — a pre-admission notice that reads as "admitted"
+// behind it (meeting controls visible) but leaves the bot NOT truly in the call (status active, 0
+// transcriptions) until it is acknowledged. Mirrors checkForWaitingRoomIndicators. The caller
+// acknowledges it with acknowledgeGeminiNotesPrompt (clicks "Join now"); only a variant with no
+// "Join now" holds as not-admitted for a human to look.
 export async function hasConsentPrompt(page: Page): Promise<boolean> {
   for (const selector of googleConsentPromptIndicators) {
     try {
       const element = await page.locator(selector).first();
       if (await element.isVisible()) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+// Acknowledge the "Gemini is taking notes" dialog by clicking its "Join now" affirmative so the bot
+// enters the meeting (a human clicks exactly this). Scoped to the dialog so it never hits the pre-join
+// lobby "Join now", and it targets ONLY "Join now" — never "Leave", which would drop the bot. Returns
+// true if it clicked (dialog handled), false if no "Join now" is present (a different gate → hold).
+export async function acknowledgeGeminiNotesPrompt(page: Page): Promise<boolean> {
+  for (const selector of geminiNotesJoinNowSelectors) {
+    try {
+      const btn = page.locator(selector).first();
+      if (await btn.isVisible({ timeout: 0 })) {
+        await btn.click();
         return true;
       }
     } catch {
@@ -380,15 +407,16 @@ export async function waitForGoogleMeetingAdmission(
       return true;
     }
 
-    // Consent gate: if Google's Gemini "take notes" consent prompt is present,
-    // the bot is held behind a human decision (accept/decline) — not admitted.
-    // Do NOT auto-click it; consent is the user's choice (Vexa-ai/vexa#429).
-    // Summon a human via needs_human_help and keep polling, so admission
-    // proceeds once consent is granted (mirrors the reCAPTCHA "stay for human
-    // solve" handling).
+    // "Gemini is taking notes" notice (see §1b in checkForGoogleAdmissionIndicators): acknowledge it
+    // by clicking "Join now" so the bot enters — a join notice, not a consent-to-record gate, so we do
+    // NOT wait for a human. Only a variant with no "Join now" is a real gate that needs a human.
     if (await hasConsentPrompt(page)) {
-      log("🧑‍⚖️ Gemini consent prompt detected — bot is behind a consent gate (not admitted). Escalating to needs_human_help; not auto-consenting.");
-      await triggerEscalation(botConfig, "consent_required");
+      if (await acknowledgeGeminiNotesPrompt(page)) {
+        log("✅ \"Gemini is taking notes\" notice — clicked \"Join now\"; re-checking admission");
+      } else {
+        log("🧑‍⚖️ Consent prompt with no \"Join now\" — escalating to needs_human_help (not auto-consenting).");
+        await triggerEscalation(botConfig, "consent_required");
+      }
     }
 
     log("Bot not yet admitted - checking for Google Meet waiting room indicators...");

--- a/core/meetings/modules/join/src/googlemeet/selectors.ts
+++ b/core/meetings/modules/join/src/googlemeet/selectors.ts
@@ -83,6 +83,19 @@ export const googleConsentPromptIndicators: string[] = [
   '[role="alertdialog"]:has-text("taking notes")',
 ];
 
+// The affirmative on the "Gemini is taking notes" dialog. Confirmed live (screenshot): the dialog
+// reads "Gemini is taking notes" with two actions — "Leave" (exit) and "Join now" (proceed into the
+// meeting). It is a JOIN NOTICE that AI notetaking is active in the call, NOT a consent-to-record
+// gate the bot must decide on someone's behalf — clicking "Join now" is how any participant enters,
+// exactly what a human does. Scoped to the dialog (has-text "taking notes"/"Gemini") so it never
+// matches the pre-join lobby "Join now". NEVER target "Leave" — that would drop the bot from the call.
+export const geminiNotesJoinNowSelectors: string[] = [
+  '[role="dialog"]:has-text("taking notes") :is(button, [role="button"]):has-text("Join now")',
+  '[role="alertdialog"]:has-text("taking notes") :is(button, [role="button"]):has-text("Join now")',
+  '[role="dialog"]:has-text("Gemini") :is(button, [role="button"]):has-text("Join now")',
+  '[role="alertdialog"]:has-text("Gemini") :is(button, [role="button"]):has-text("Join now")',
+];
+
 export const googleRejectionIndicators: string[] = [
   // Waiting-room denial patterns. Google Meet can leave some lobby text in
   // the DOM after a host rejects the bot, so these must be checked before

--- a/core/meetings/modules/mixed-capture-core/src/mixed-audio.ts
+++ b/core/meetings/modules/mixed-capture-core/src/mixed-audio.ts
@@ -36,7 +36,7 @@ export interface MixedAudioOptions {
 
 export async function createMixedAudioCapture(
   stream: MediaStream,
-  onPcm: (pcm: Float32Array) => void,
+  onPcm: (pcm: Float32Array, tsMs?: number) => void,
   opts: MixedAudioOptions = {},
 ): Promise<MixedAudioCapture> {
   const SR = opts.sampleRate ?? 16000;
@@ -47,11 +47,21 @@ export async function createMixedAudioCapture(
   const ctx = new AudioContext({ sampleRate: SR });
   const source = ctx.createMediaStreamSource(stream);
   const proc = ctx.createScriptProcessor(4096, 1, 1);
+  // Accumulated-audio-time clock: stamp each frame with the wall-clock of the AUDIO it holds
+  // (anchor + samples-so-far / rate), NOT Date.now() at callback time. The ScriptProcessor fires a
+  // buffer-length (~256ms) AFTER the audio was captured, and that latency + event-loop jitter is
+  // exactly what pushed frames out of the speaker-hint binder's match window (misattribution). Count
+  // ALL processed samples — silent frames included — so the clock never drifts from real time. It's
+  // the same page clock the active-speaker hints carry, so the binder can align them.
+  const startMs = Date.now();
+  let processedSamples = 0;
   proc.onaudioprocess = (e: AudioProcessingEvent) => {
     const input = e.inputBuffer.getChannelData(0);
+    const tsMs = startMs + (processedSamples / SR) * 1000;   // wall-clock of this frame's first sample
+    processedSamples += input.length;
     let maxVal = 0;
     for (let i = 0; i < input.length; i++) { const a = Math.abs(input[i]); if (a > maxVal) maxVal = a; }
-    if (maxVal > SILENCE) onPcm(new Float32Array(input));   // copy — the buffer is reused
+    if (maxVal > SILENCE) onPcm(new Float32Array(input), tsMs);   // copy — the buffer is reused
   };
   source.connect(proc);
   proc.connect(ctx.destination);                           // pull the processor (outputs silence)

--- a/core/meetings/modules/record-chunker/src/index.ts
+++ b/core/meetings/modules/record-chunker/src/index.ts
@@ -91,6 +91,16 @@ export class MediaRecorderChunker implements RecordingTap {
     return this.recorder;
   }
 
+  /** Force the recorder to emit a chunk NOW with everything buffered since the last timeslice —
+   *  without stopping. The tail-loss fix: on eviction Zoom navigates the page away (destroying the
+   *  recorder) before the next timeslice boundary, so the last partial (the final few seconds of
+   *  speech) never becomes a chunk. Flushing at the earliest end-signal (the mix going silent) turns
+   *  that partial into a real, immediately-uploaded chunk before the context dies. Idempotent + safe. */
+  flush(): void {
+    try { if (this.recorder && this.recorder.state === "recording") this.recorder.requestData(); }
+    catch (err: any) { blog(`[record-chunker] flush() requestData failed: ${err?.message || err}`); }
+  }
+
   async start(): Promise<void> {
     if (this.recorder) {
       blog("[record-chunker] start() called twice — ignoring");
@@ -277,11 +287,15 @@ class DynamicAudioMixer {
   private dest: MediaStreamAudioDestinationNode;
   private sources = new Map<string, { node: MediaStreamAudioSourceNode; stream: MediaStream }>();
   private timer: ReturnType<typeof setInterval> | null = null;
+  /** Fired when the live-source count falls to 0 (all participant tracks ended — the meeting is
+   *  closing). The recording host uses it to flush the recorder's buffered tail before the page dies. */
+  private onEmpty: (() => void) | null;
 
-  constructor() {
+  constructor(onEmpty?: () => void) {
     this.ctx = new AudioContext();   // default (full) sample rate — NOT the 16 kHz transcription mix
     this.ctx.resume?.();
     this.dest = this.ctx.createMediaStreamDestination();
+    this.onEmpty = onEmpty ?? null;
   }
 
   get stream(): MediaStream { return this.dest.stream; }
@@ -302,12 +316,16 @@ class DynamicAudioMixer {
     // Prune truly-dead streams (all tracks ended) so a long meeting's track churn doesn't accumulate
     // source nodes. A still-live stream is KEPT even if its element left the DOM (the node holds the
     // stream ref and still pulls audio) — presence is not the liveness signal, the track state is.
+    const had = this.sources.size;
     for (const [id, entry] of this.sources) {
       if (entry.stream.getAudioTracks().some((t) => t.readyState === "live")) continue;
       try { entry.node.disconnect(); } catch { /* */ }
       this.sources.delete(id);
       blog(`[record-chunker] mix -stream (${this.sources.size} live)`);
     }
+    // Just went silent (all tracks ended → the meeting is closing) — flush the recorder's buffered tail
+    // NOW, before the platform navigates the page away and destroys the recorder mid-partial-timeslice.
+    if (had > 0 && this.sources.size === 0 && this.onEmpty) { try { this.onEmpty(); } catch { /* */ } }
   }
 
   start(): void {
@@ -349,7 +367,10 @@ export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTa
         // No ready stream ⇒ build a LIVE mix of the page's audio. Wait (bounded) for the first stream —
         // post-admission the participant / injected <audio> elements appear a beat late — so the
         // MediaRecorder's onStarted t=0 aligns with real audio; the rescan then follows the churn.
-        mixer = new DynamicAudioMixer();
+        // onEmpty → flush the recorder's buffered tail the instant the mix goes silent (meeting close),
+        // so the final partial timeslice (the last few seconds of speech) is a real chunk before the
+        // page navigates away on eviction. `chunker` is assigned just below and set by the time this fires.
+        mixer = new DynamicAudioMixer(() => chunker?.flush());
         let ready = false;
         for (let i = 0; i < 5; i++) {
           mixer.scan();

--- a/core/meetings/modules/record-chunker/src/index.ts
+++ b/core/meetings/modules/record-chunker/src/index.ts
@@ -237,56 +237,90 @@ export class MediaRecorderChunker implements RecordingTap {
 // ───────────────────────────────────────────────────────────────────────
 
 /**
- * Find active media elements that expose audio. Two-pass (strict → relaxed):
- * tiles can be paused or expose audio via captureStream() rather than a direct
- * srcObject, so the relaxed pass mirrors buildCombinedStream's fallbacks. This
- * is platform-agnostic — a recording grabs every audio element on the page.
+ * Every on-page audio-bearing MediaStream that is CURRENTLY producing audio (has a `live` track).
+ * Prefers `srcObject`; falls back to a captureStream() cached on the element (a fresh captureStream()
+ * each scan would mint a new stream id, defeating the mixer's dedup and leaking source nodes). Deduped
+ * downstream by stream id. Platform-agnostic — a recording grabs every audio element on the page.
  */
-async function findMediaElements(retries = 5, delay = 2000): Promise<HTMLMediaElement[]> {
-  for (let i = 0; i < retries; i++) {
-    const all = Array.from(document.querySelectorAll("audio, video"));
-    let els = all.filter((el: any) =>
-      !el.paused && el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0
-    ) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (strict)`); return els; }
-
-    els = all.filter((el: any) => {
-      try {
-        if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
-        if (typeof el.captureStream === "function" && el.captureStream()?.getAudioTracks?.().length > 0) return true;
-        if (typeof el.mozCaptureStream === "function" && el.mozCaptureStream()?.getAudioTracks?.().length > 0) return true;
-      } catch { /* not probeable; skip */ }
-      return false;
-    }) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (relaxed)`); return els; }
-
-    await new Promise((r) => setTimeout(r, delay));
+function collectAudioStreams(): MediaStream[] {
+  const els = Array.from(document.querySelectorAll("audio, video")) as any[];
+  const out: MediaStream[] = [];
+  for (const el of els) {
+    try {
+      let s: MediaStream | null = el.srcObject instanceof MediaStream ? el.srcObject : null;
+      if (!s) {
+        const cap: unknown =
+          el.__vexaRecCapStream instanceof MediaStream ? el.__vexaRecCapStream :
+          typeof el.captureStream === "function" ? el.captureStream() :
+          typeof el.mozCaptureStream === "function" ? el.mozCaptureStream() : null;
+        if (cap instanceof MediaStream) { el.__vexaRecCapStream = cap; s = cap; }
+      }
+      // Only LIVE audio: an element lingering with an ENDED track must not re-enter the mix (it would
+      // reconnect a dead source every scan and oscillate against the prune below).
+      if (s && s.getAudioTracks().some((t) => t.readyState === "live")) out.push(s);
+    } catch { /* not probeable; skip */ }
   }
-  return [];
+  return out;
 }
 
-/** Mix every media element's audio into one MediaStream via a destination node. */
-async function buildCombinedStream(mediaElements: HTMLMediaElement[]): Promise<MediaStream> {
-  if (mediaElements.length === 0) throw new Error("[record-chunker] no media elements to combine");
-  const ctx = new AudioContext();
-  const dest = ctx.createMediaStreamDestination();
-  let connected = 0;
-  mediaElements.forEach((element: any, index) => {
-    try {
-      const s =
-        element.srcObject ||
-        (element.captureStream && element.captureStream()) ||
-        (element.mozCaptureStream && element.mozCaptureStream());
-      if (s instanceof MediaStream && s.getAudioTracks().length > 0) {
-        ctx.createMediaStreamSource(s).connect(dest);
-        connected++;
-        blog(`[record-chunker] connected element ${index + 1}/${mediaElements.length}`);
-      }
-    } catch (e: any) { blog(`[record-chunker] could not connect element ${index + 1}: ${e?.message || e}`); }
-  });
-  if (connected === 0) throw new Error("[record-chunker] could not connect any audio streams");
-  blog(`[record-chunker] combined ${connected} streams`);
-  return dest.stream;
+/**
+ * A LIVE audio mix that FOLLOWS the meeting. One AudioContext destination that a periodic rescan keeps
+ * wired to every current on-page audio stream: it connects newly-appearing streams and prunes ones whose
+ * tracks have ended. Zoom/Teams deliver each participant as a separate WebRTC track and churn them
+ * constantly (each new track is mirrored into a fresh injected <audio> by @vexa/mixed-capture-core's
+ * hook) — so a ONE-TIME combine records silence the moment the originally-captured tracks end. Recording
+ * `dest.stream` (a STABLE handle whose sources come and go underneath) keeps the mix complete for the
+ * whole meeting. Full sample rate — deliberately NOT the 16 kHz transcription mix.
+ */
+class DynamicAudioMixer {
+  private ctx: AudioContext;
+  private dest: MediaStreamAudioDestinationNode;
+  private sources = new Map<string, { node: MediaStreamAudioSourceNode; stream: MediaStream }>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.ctx = new AudioContext();   // default (full) sample rate — NOT the 16 kHz transcription mix
+    this.ctx.resume?.();
+    this.dest = this.ctx.createMediaStreamDestination();
+  }
+
+  get stream(): MediaStream { return this.dest.stream; }
+  get connectedCount(): number { return this.sources.size; }
+
+  /** Connect newly-seen streams; prune streams whose audio has ended. Idempotent — safe every tick. */
+  scan(): void {
+    const present = new Map(collectAudioStreams().map((s) => [s.id, s]));
+    for (const [id, s] of present) {
+      if (this.sources.has(id)) continue;
+      try {
+        const node = this.ctx.createMediaStreamSource(s);
+        node.connect(this.dest);
+        this.sources.set(id, { node, stream: s });
+        blog(`[record-chunker] mix +stream (${this.sources.size} live)`);
+      } catch { /* not connectable yet — retried next tick */ }
+    }
+    // Prune truly-dead streams (all tracks ended) so a long meeting's track churn doesn't accumulate
+    // source nodes. A still-live stream is KEPT even if its element left the DOM (the node holds the
+    // stream ref and still pulls audio) — presence is not the liveness signal, the track state is.
+    for (const [id, entry] of this.sources) {
+      if (entry.stream.getAudioTracks().some((t) => t.readyState === "live")) continue;
+      try { entry.node.disconnect(); } catch { /* */ }
+      this.sources.delete(id);
+      blog(`[record-chunker] mix -stream (${this.sources.size} live)`);
+    }
+  }
+
+  start(): void {
+    this.scan();
+    this.timer = setInterval(() => { try { this.scan(); } catch { /* the rescan must never die */ } }, 2000);
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+    for (const { node } of this.sources.values()) { try { node.disconnect(); } catch { /* */ } }
+    this.sources.clear();
+    try { void this.ctx.close(); } catch { /* */ }
+  }
 }
 
 /** Options for createRecordingTap — combine all audio elements then optionally override. */
@@ -307,13 +341,24 @@ export interface CreateRecordingTapOptions extends RecordingTapOptions {
  */
 export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTap {
   let chunker: MediaRecorderChunker | null = null;
+  let mixer: DynamicAudioMixer | null = null;
   return {
     async start(): Promise<void> {
       let stream = opts.stream;
       if (!stream) {
-        const els = await findMediaElements();
-        if (els.length === 0) { blog("[record-chunker] no media elements — cannot record"); return; }
-        stream = await buildCombinedStream(els);
+        // No ready stream ⇒ build a LIVE mix of the page's audio. Wait (bounded) for the first stream —
+        // post-admission the participant / injected <audio> elements appear a beat late — so the
+        // MediaRecorder's onStarted t=0 aligns with real audio; the rescan then follows the churn.
+        mixer = new DynamicAudioMixer();
+        let ready = false;
+        for (let i = 0; i < 5; i++) {
+          mixer.scan();
+          if (mixer.connectedCount > 0) { ready = true; break; }
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+        if (!ready) { blog("[record-chunker] no audio streams — cannot record"); mixer.stop(); mixer = null; return; }
+        mixer.start();
+        stream = mixer.stream;
       }
       chunker = new MediaRecorderChunker({
         stream,
@@ -326,6 +371,8 @@ export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTa
     async stop(): Promise<void> {
       await chunker?.stop();
       chunker = null;
+      mixer?.stop();
+      mixer = null;
     },
   };
 }

--- a/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
+++ b/core/meetings/modules/zoom-capture/src/zoom-speakers.ts
@@ -71,6 +71,15 @@ export interface ZoomSpeakersState {
 const ACTIVE_CONTAINER_SELECTORS = [
   '.speaker-active-container__video-frame',
   '.speaker-bar-container__video-frame--active',
+  // Speaker/main view: Zoom renders exactly one large tile that follows the
+  // dominant (actively-speaking) participant — the footer name flips as the turn
+  // passes. The wrapper prefix drifts across client builds and view states
+  // (single-suspension-container, single-main-container, … — both observed live
+  // within ONE meeting), so match the family by the stable "-container__video-frame"
+  // leaf scoped to the "single-" prefix rather than pinning one name. The old
+  // speaker-active-/speaker-bar- classes above are gone from the DOM; the
+  // .video-avatar__avatar-footer name node is a descendant, so nameFromContainer reads it.
+  '[class*="single-"][class*="-container__video-frame"]',
 ];
 const NAME_FOOTER_SELECTOR = '.video-avatar__avatar-footer';
 
@@ -153,10 +162,23 @@ export function createZoomSpeakers(opts: ZoomSpeakersOptions = {}): ZoomSpeakers
   const HEARTBEAT_POLLS = Math.max(1, Math.round(2000 / pollMs));
   let sinceEmit = 0;
 
+  // DIAGNOSTIC (#speaker-split): the active-speaker selectors (.speaker-active-container__…)
+  // are the Zoom web-client classes; if Zoom drifts them, readActiveSpeaker() returns null
+  // forever and every segment lands as "Speaker". When we go a sustained stretch with NO
+  // active speaker, dump getState() forensics (per-selector present/name + every name-footer
+  // tile's ancestor classes + "speaking"-hint tokens) so the real lit-tile marker is visible
+  // in the bot log. Rate-limited so it prints ~once/6s. Remove with the fix.
+  let _diagNullPolls = 0;
+  const _DIAG_EVERY = Math.max(1, Math.round(6000 / pollMs));
+  function _diagDump(): void {
+    try { log('[DIAG] no active speaker — ' + JSON.stringify(getState())); } catch { /* never throw */ }
+  }
+
   // One poll cycle: read the lit speaker; emit on change, or periodically re-assert.
   function tick(): void {
     let name: string | null = null;
     try { name = readActiveSpeaker(); } catch { /* DOM in flux */ return; }
+    if (!name && !active) { if (++_diagNullPolls % _DIAG_EVERY === 0) _diagDump(); } else { _diagNullPolls = 0; }
     if (name !== active) {
       // A change must hold for CONFIRM_POLLS consecutive reads before we commit it,
       // so a single flicker poll can't emit a hint (and can't hijack attribution).

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -813,49 +813,95 @@ export async function startCaptureBridge(
       //     seen live (streams ≈ participants → safe to flip to per-track; streams ≫ participants → slots).
       if (isPerTrack) {
       // ── The track→name resolver ──────────────────────────────────────────────────────────────
-      // Names an anonymous WebRTC track by correlating per-track energy with the active-speaker
-      // signal: when EXACTLY ONE track is producing sound AND EXACTLY ONE participant is lit as the
-      // active speaker, that track IS that participant — and once that pairing holds continuously for
-      // SETTLE_MS (filtering the DOM indicator's lag at speaker transitions) the channel is LOCKED to
-      // the name for the track's life (a track never legitimately changes speaker). This is gmeet's
-      // "exactly-one-lit ⇒ name" moved to the track level. dom-active platforms (Zoom/Jitsi) light one
-      // speaker at a time (exclusive); Teams' voice-outline can light several (additive) — either way
-      // a bind only happens during a clean single-speaker moment.
+      // Zoom's remote audio is STABLE per participant: verified live that each speaker gets their OWN
+      // WebRTC stream (a permanent channel here), appearing when they first become active and never
+      // remapped or reused — 5 streams for 5 speakers, ch=3/ch=4 arriving only when the 4th/5th person
+      // first spoke. The unreliable part is the NAME: Zoom's active-speaker DOM is a sticky dominant-
+      // speaker spotlight (worse under screen-share) that lags/holds the wrong person. So the resolver's
+      // whole job is to attach each stable channel to the right name and DEFEND it against the flaky DOM:
+      //   • VOTE: every clean moment (this channel is the loudest hot one + exactly one speaker lit) casts
+      //     one channel<->name vote. The binding is the argmax — so a wrong early sample is a single vote
+      //     that the true speaker outweighs. SELF-CORRECTING: no bad first bind can lock in for the meeting.
+      //   • MARGIN hysteresis: a new leader must beat the current binding by MARGIN votes to flip, so the
+      //     sticky DOM's stray votes can't churn an established name (holds "Scott" while Zoom shows Justin).
+      //   • 1:1 BY IDENTITY: a name is another active channel's identity — the DOM can't paste "Justin"
+      //     onto Scott's channel even if it over-votes it there. It frees up only when its owner goes
+      //     long-idle (IDLE_RELEASE_MS) — so leave-then-rejoin-under-a-new-stream works. Exception: two
+      //     genuinely same-named people each earn the name with HIGH-PURITY votes → both are named (a
+      //     mixed minority — contamination — does not qualify).
+      // Floor: a channel still needs the DOM to name it correctly at least sometimes; a speaker Zoom never
+      // lights (e.g. throughout a screen-share) stays unknown — separated, but unnamed.
       if (!w.__vexaTrackNamer) {
         w.__vexaTrackNamer = {
           mode: (isTeams ? 'additive' : 'exclusive') as 'additive' | 'exclusive',
-          speaking: new Map<string, number>(),   // active-speaker name → since (ms)
-          hot: new Map<number, number>(),         // channel → last-energetic (ms)
-          names: new Map<number, string>(),       // channel → bound name (LOCKED once set)
-          cand: null as ({ ch: number; name: string; since: number } | null),
-          HOT_MS: 600, SETTLE_MS: 500,
+          speaking: new Map<string, number>(),                 // active-speaker name → since (ms)
+          hot: new Map<number, { ts: number; e: number }>(),   // channel → last-energetic {ts, peak}
+          votes: new Map<number, Map<string, number>>(),       // channel → name → co-occurrence tally
+          names: new Map<number, string>(),                    // channel → committed name (= argmax vote)
+          HOT_MS: 600, MARGIN: 3, IDLE_RELEASE_MS: 8000, PURITY: 0.7,
           onSpeak(name: string | null, tMs: number, isEnd: boolean): void {
             if (!name) return;
             if (isEnd) { this.speaking.delete(name); return; }
             if (this.mode === 'exclusive') { this.speaking.clear(); this.speaking.set(name, tMs); }
             else if (!this.speaking.has(name)) this.speaking.set(name, tMs);
           },
-          markHot(ch: number, ts: number): void { this.hot.set(ch, ts); },
+          markHot(ch: number, ts: number, e: number): void { this.hot.set(ch, { ts, e }); },
           resolve(ch: number, ts: number): string | undefined {
-            // A binding forms — or REBINDS — when a channel is the sole hot track while a single
-            // participant is lit, sustained for SETTLE_MS. It is NOT a lifetime lock: a stable
-            // per-participant stream (Zoom/Jitsi) never satisfies the gate for a DIFFERENT name so
-            // its binding never changes, but a remapped active-speaker SLOT (possible on Teams) that
-            // starts carrying a new speaker rebinds — and the per-channel lane rotates the turn on the
-            // name change. Between clean moments the last binding persists (returned every frame).
-            let hotCount = 0;
-            for (const t of this.hot.values()) if (ts - t < this.HOT_MS) hotCount++;
+            // VOTE whenever THIS channel is the loudest hot one while exactly one speaker is lit — a clean
+            // channel<->name co-occurrence. The binding is the argmax vote (rederive below), so a wrong
+            // early sample (the sticky DOM naming Justin during Scott's turn) is just ONE vote and gets
+            // outweighed as the true speaker accumulates — self-correcting, no permanent early lock-in.
+            let loud = -1, loudE = -1;
+            for (const [c, h] of this.hot) { if (ts - h.ts < this.HOT_MS && h.e > loudE) { loudE = h.e; loud = c; } }
             const active = Array.from(this.speaking.keys()) as string[];
-            if (hotCount === 1 && active.length === 1) {
-              const name = active[0];
-              if (this.cand && this.cand.ch === ch && this.cand.name === name) {
-                if (ts - this.cand.since >= this.SETTLE_MS && this.names.get(ch) !== name) {
-                  this.names.set(ch, name); this.cand = null;
-                  w.logBot?.('[pertrack] bound ch=' + ch + ' → ' + name);
-                }
-              } else { this.cand = { ch, name, since: ts }; }
-            } else if (this.cand && this.cand.ch === ch) { this.cand = null; }
-            return this.names.get(ch);   // the persisted binding (undefined until the first bind)
+            if (loud === ch && active.length === 1) {
+              const n = active[0];
+              let v = this.votes.get(ch); if (!v) { v = new Map(); this.votes.set(ch, v); }
+              v.set(n, (v.get(n) || 0) + 1);
+              this.rederive(ch, ts);
+            }
+            return this.names.get(ch);   // committed binding (undefined until the first confident bind)
+          },
+          rederive(ch: number, ts: number): void {
+            const v = this.votes.get(ch); if (!v) return;
+            let total = 0; for (const c of v.values()) total += c;
+            // A name is AVAILABLE to this channel if no OTHER active channel holds it (1:1 BY IDENTITY:
+            // a name is another stream's identity no matter how many stray sticky-DOM votes it collected
+            // here — raw-count 1:1 would let Scott's channel STEAL "Justin" when the sticky DOM over-votes
+            // it, which must not happen). The ONE exception: this channel's votes for the name are
+            // high-PURITY — it overwhelmingly IS this channel's own identity — which distinguishes a
+            // genuine SECOND same-named speaker (two "John Smith": pure votes on each → co-hold both)
+            // from contamination (a mixed minority on someone else's channel → stays blocked). A name
+            // also frees up once its owner goes long-idle (IDLE_RELEASE_MS — a leave / reconnect).
+            const available = (name: string): boolean => {
+              let activeOwner = false;
+              for (const [c, n] of this.names) {
+                if (n !== name || c === ch) continue;
+                const h = this.hot.get(c);
+                if (h && ts - h.ts <= this.IDLE_RELEASE_MS) { activeOwner = true; break; }
+              }
+              if (!activeOwner) return true;
+              const vn = v.get(name) || 0;
+              return vn >= this.PURITY * total && vn >= this.MARGIN;
+            };
+            // Best AVAILABLE name = argmax vote among names this channel may hold.
+            let best = '', bestN = -1;
+            for (const [n, c] of v) if (c > bestN && available(n)) { bestN = c; best = n; }
+            if (best === '') return;
+            const cur = this.names.get(ch);
+            if (best === cur) return;
+            const curN = cur ? (v.get(cur) || 0) : -1;
+            // Hysteresis: a new leader must beat the current binding by MARGIN before it flips — so a few
+            // stray sticky-DOM votes can't churn an established name, but real evidence still corrects it.
+            if (bestN < curN + this.MARGIN) return;
+            // Release only IDLE owners of the name (a leave/reconnect); keep active co-holders (duplicates).
+            for (const [c, n] of this.names) {
+              if (n !== best || c === ch) continue;
+              const h = this.hot.get(c);
+              if (!h || ts - h.ts > this.IDLE_RELEASE_MS) this.names.delete(c);
+            }
+            this.names.set(ch, best);
+            w.logBot?.('[pertrack] bound ch=' + ch + ' → ' + best + ' (' + bestN + ' votes)');
           },
         };
       }
@@ -894,7 +940,7 @@ export async function startCaptureBridge(
               let maxVal = 0;
               for (let i = 0; i < input.length; i++) { const a = Math.abs(input[i]); if (a > maxVal) maxVal = a; }
               if (maxVal <= SILENCE) return;                   // gate silence (as the mix path did)
-              w.__vexaTrackNamer.markHot(ch, ts);
+              w.__vexaTrackNamer.markHot(ch, ts, maxVal);      // peak energy → the dominant-slot ranking
               const name = w.__vexaTrackNamer.resolve(ch, ts);
               const arr = Array.from(input);                   // copy — the input buffer is reused
               if (name) w.__vexaNamedAudioData(ch, name, arr, ts);

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -37,7 +37,7 @@ import {
 } from '@vexa/remote-browser';
 import { getJoinBrowserArgs } from '@vexa/join';
 import type { RecordingMasterFormat } from '@vexa/recording';
-import { isMixedLanePlatform, type Invocation } from './config.js';
+import { isMixedLanePlatform, isPerTrackLanePlatform, type Invocation } from './config.js';
 import type { BotPipeline } from './pipeline.js';
 import type { BotRecordingSink } from './recording.js';
 import type { TelemetrySink } from './ports.js';
@@ -696,6 +696,8 @@ export async function startCaptureBridge(
   activity?: RemoteAudioActivityTap,
 ): Promise<() => Promise<void>> {
   const mixed = isMixedLanePlatform(inv.platform);
+  const perTrack = isPerTrackLanePlatform(inv.platform);   // Zoom: per-track through the per-channel lane
+  const useMix = mixed && !perTrack;                        // Teams/Jitsi: the pyannote mixed lane
   const jitsi = inv.platform === 'jitsi';
   const lane: 'gmeet' | 'mixed' = mixed ? 'mixed' : 'gmeet';
 
@@ -716,8 +718,12 @@ export async function startCaptureBridge(
     const ts = tsMs ?? Date.now();
     observeRemoteAudio(pcm);
     tee(speakerIndex, pcm, ts);                                 // O-TEL-1: tap BEFORE the pipeline
-    if (mixed) pipeline.feedMixedAudio(pcm, ts);
-    else pipeline.feedAudio(speakerIndex, undefined, pcm, ts); // glow name is bound page-side in the v1 producer; channel index here
+    // Teams/Jitsi (useMix): one combined stream → the pyannote mixed lane. Zoom + gmeet: per-channel —
+    // an unbound track (name not yet resolved) arrives with no name → the per-channel lane opens the
+    // turn UNKNOWN and upgrades it the moment the resolver binds (gmeet-pipeline onset-adopt); the
+    // named path is __vexaNamedAudioData.
+    if (useMix) pipeline.feedMixedAudio(pcm, ts);
+    else pipeline.feedAudio(speakerIndex, undefined, pcm, ts);
   };
   // gmeet: the v1 producer stamps the glow name page-side; this named variant carries it through.
   const onNamedAudio = (channel: number, glowName: string | undefined, samples: number[], tsMs?: number): void => {
@@ -756,7 +762,9 @@ export async function startCaptureBridge(
   // C1: the four hint hops on one periodic, cumulative counter line —
   // page-emitted lives in the page console ([TeamsSpeakers]/[JitsiSpeakers] logs);
   // bridge-crossed / pipeline-received / binder matched|missed are Node-side.
-  const countersTimer = mixed ? setInterval(() => {
+  // Only the pyannote mixed lane exposes hintCounters (the binder's hop tally). The per-channel
+  // lane names tracks page-side (the resolver), so there is no binder to count — skip the line.
+  const countersTimer = pipeline.hintCounters ? setInterval(() => {
     const c = pipeline.hintCounters;
     console.log(`[bot] hint-counters bridge-crossed=${hintsBridgeCrossed()} pipeline-received=${c?.received ?? 0} binder-matched=${c?.matched ?? 0} binder-missed=${c?.missed ?? 0} teams-captions=${captionsBridgeCrossed()} csrc-crossed=${csrcBridgeCrossed()} observations=${obsBridgeCrossed()}`);
   }, 30_000) : null;
@@ -788,18 +796,146 @@ export async function startCaptureBridge(
   // ── Start the page-side capture (VexaBrowserUtils preferred; production inline fallback). ──
   // The body of this callback runs IN THE BROWSER (Playwright serializes it); DOM globals are
   // reached via globalThis (this file type-checks against the Node lib — no DOM types here).
-  await page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName, mainAudioGraceMs, mainAudioSilenceMs, mainAudioEnergyRms }) => {
+  await page.evaluate(async ({ isMixed, isPerTrack, isJitsi, isTeams, isZoom, botName, mainAudioGraceMs, mainAudioSilenceMs, mainAudioEnergyRms }) => {
     const w = (globalThis as any) as Record<string, any>;
     if (isMixed) {
-      // Zoom/Teams: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
-      // track into w.__vexaCapturedRemoteAudioStreams. Combine them into ONE live stream (an
-      // AudioContext destination), keep connecting late-arriving tracks via a rescan (a participant
-      // who speaks later), and feed that single mix to the mixed lane (pyannote re-separates speakers).
-      // Teams delivers the COMPLETE meeting audio as a single server-side mix whose track id is prefixed
-      // "mainAudio" — witnessed live: the standard web client receives exactly ONE audio receiver. The
-      // bot is ALSO handed a redundant track (e.g. a dominant-speaker copy) whose audio is already inside
-      // that mix; combining both double-feeds every word to the transcriber → repeated words. So on Teams
-      // mix ONLY the mainAudio track. Jitsi keeps combining all tracks (its topology isn't witnessed).
+      // Zoom/Teams/Jitsi ride the WebRTC hook (installRemoteAudioHook, installed pre-nav), which mirrors
+      // each remote participant's audio track into w.__vexaCapturedRemoteAudioStreams AND into a hidden
+      // <audio data-vexa-injected> element (that latter copy is what the recorder taps — untouched by
+      // either path below). Two transcription topologies split here:
+      //   • PER-TRACK (Zoom — confirmed live: multi-stream, stable per-participant, 0 teardowns): capture
+      //     EACH track on its OWN channel and name it from the active-speaker hints, through the SAME
+      //     per-channel, name-at-onset engine Google Meet uses. A track = one speaker (ground truth), so
+      //     overlap is separated by the tracks themselves.
+      //   • MIXED (Teams/Jitsi — per-track topology NOT yet witnessed; Teams may use remapped active-
+      //     speaker SLOTS): combine every track into ONE stream and let @vexa/mixed-pipeline (pyannote)
+      //     re-separate speakers, named by time-windowed hints. Kept until each platform's streams are
+      //     seen live (streams ≈ participants → safe to flip to per-track; streams ≫ participants → slots).
+      if (isPerTrack) {
+      // ── The track→name resolver ──────────────────────────────────────────────────────────────
+      // Names an anonymous WebRTC track by correlating per-track energy with the active-speaker
+      // signal: when EXACTLY ONE track is producing sound AND EXACTLY ONE participant is lit as the
+      // active speaker, that track IS that participant — and once that pairing holds continuously for
+      // SETTLE_MS (filtering the DOM indicator's lag at speaker transitions) the channel is LOCKED to
+      // the name for the track's life (a track never legitimately changes speaker). This is gmeet's
+      // "exactly-one-lit ⇒ name" moved to the track level. dom-active platforms (Zoom/Jitsi) light one
+      // speaker at a time (exclusive); Teams' voice-outline can light several (additive) — either way
+      // a bind only happens during a clean single-speaker moment.
+      if (!w.__vexaTrackNamer) {
+        w.__vexaTrackNamer = {
+          mode: (isTeams ? 'additive' : 'exclusive') as 'additive' | 'exclusive',
+          speaking: new Map<string, number>(),   // active-speaker name → since (ms)
+          hot: new Map<number, number>(),         // channel → last-energetic (ms)
+          names: new Map<number, string>(),       // channel → bound name (LOCKED once set)
+          cand: null as ({ ch: number; name: string; since: number } | null),
+          HOT_MS: 600, SETTLE_MS: 500,
+          onSpeak(name: string | null, tMs: number, isEnd: boolean): void {
+            if (!name) return;
+            if (isEnd) { this.speaking.delete(name); return; }
+            if (this.mode === 'exclusive') { this.speaking.clear(); this.speaking.set(name, tMs); }
+            else if (!this.speaking.has(name)) this.speaking.set(name, tMs);
+          },
+          markHot(ch: number, ts: number): void { this.hot.set(ch, ts); },
+          resolve(ch: number, ts: number): string | undefined {
+            // A binding forms — or REBINDS — when a channel is the sole hot track while a single
+            // participant is lit, sustained for SETTLE_MS. It is NOT a lifetime lock: a stable
+            // per-participant stream (Zoom/Jitsi) never satisfies the gate for a DIFFERENT name so
+            // its binding never changes, but a remapped active-speaker SLOT (possible on Teams) that
+            // starts carrying a new speaker rebinds — and the per-channel lane rotates the turn on the
+            // name change. Between clean moments the last binding persists (returned every frame).
+            let hotCount = 0;
+            for (const t of this.hot.values()) if (ts - t < this.HOT_MS) hotCount++;
+            const active = Array.from(this.speaking.keys()) as string[];
+            if (hotCount === 1 && active.length === 1) {
+              const name = active[0];
+              if (this.cand && this.cand.ch === ch && this.cand.name === name) {
+                if (ts - this.cand.since >= this.SETTLE_MS && this.names.get(ch) !== name) {
+                  this.names.set(ch, name); this.cand = null;
+                  w.logBot?.('[pertrack] bound ch=' + ch + ' → ' + name);
+                }
+              } else { this.cand = { ch, name, since: ts }; }
+            } else if (this.cand && this.cand.ch === ch) { this.cand = null; }
+            return this.names.get(ch);   // the persisted binding (undefined until the first bind)
+          },
+        };
+      }
+
+      // ── Per-track capture: one 16 kHz PCM tap per remote track, each on its own stable channel ──
+      // ONE shared AudioContext hosts every track's tap (Chromium hard-caps concurrent AudioContexts
+      // at 6 — a per-track context would drop the 7th+ participant in a large meeting). Each track gets
+      // its own ScriptProcessor on that context; the bot page is headless with no UI to stutter, so the
+      // many-node cost that retired ScriptProcessor on the user's busy meeting page does not apply here.
+      // The accumulated-audio-time clock (anchor + samples/rate, the SAME the mix path proved) stamps
+      // every frame on the page clock = the hints' clock, so the resolver can correlate energy with the
+      // active-speaker signal and the per-channel lane times turns correctly.
+      const setupPerTrack = (): void => {
+        const streams = (w.__vexaCapturedRemoteAudioStreams || []) as Array<{ id: string }>;
+        if (!streams.length) return;
+        if (!w.__vexaTrackCtx) {
+          w.__vexaTrackCtx = new (globalThis as any).AudioContext({ sampleRate: 16000 });
+          w.__vexaTrackCtx.resume?.();
+          w.__vexaTrackCaps = new Map();
+          w.__vexaTrackNextCh = 0;
+        }
+        const ctx = w.__vexaTrackCtx;
+        const SR = 16000, SILENCE = 0.005;
+        for (const s of streams) {
+          if (!s || w.__vexaTrackCaps.has(s.id)) continue;
+          const ch: number = w.__vexaTrackNextCh++;
+          try {
+            const src = ctx.createMediaStreamSource(s);
+            const proc = ctx.createScriptProcessor(4096, 1, 1);
+            const startMs = Date.now();
+            let processed = 0;
+            proc.onaudioprocess = (e: any): void => {
+              const input = e.inputBuffer.getChannelData(0) as Float32Array;
+              const ts = startMs + (processed / SR) * 1000;   // wall-clock of this frame's first sample
+              processed += input.length;                       // count ALL samples (silent too) → no drift
+              let maxVal = 0;
+              for (let i = 0; i < input.length; i++) { const a = Math.abs(input[i]); if (a > maxVal) maxVal = a; }
+              if (maxVal <= SILENCE) return;                   // gate silence (as the mix path did)
+              w.__vexaTrackNamer.markHot(ch, ts);
+              const name = w.__vexaTrackNamer.resolve(ch, ts);
+              const arr = Array.from(input);                   // copy — the input buffer is reused
+              if (name) w.__vexaNamedAudioData(ch, name, arr, ts);
+              else w.__vexaPerSpeakerAudioData(ch, arr, ts);
+            };
+            src.connect(proc);
+            proc.connect(ctx.destination);                     // pull the processor (it outputs silence)
+            w.__vexaTrackCaps.set(s.id, { ch, src, proc });
+            w.logBot?.('[pertrack] capturing ch=' + ch + ' (' + w.__vexaTrackCaps.size + ' track(s))');
+            w.__vexaRemoteAudioReady?.();
+          } catch (e: any) { w.logBot?.('[pertrack] track setup failed ch=' + ch + ': ' + String(e)); }
+        }
+      };
+      setupPerTrack();
+      w.__vexaMixRescan = (globalThis as any).setInterval(setupPerTrack, 2000); // pick up late-joining tracks
+      // Zoom's active-speaker DOM watcher — the WHO signal the resolver correlates with per-track energy
+      // (also teed to __vexaSpeakerHint for telemetry; the pipeline's recordHint is a no-op on this lane).
+      if (isZoom && w.VexaBrowserUtils?.createZoomSpeakers && !w.__vexaZoomSpeakers) {
+        let lastActive: string | null = null;
+        w.__vexaZoomSpeakers = w.VexaBrowserUtils.createZoomSpeakers({
+          selfName: botName,
+          log: (m: string) => w.logBot?.('[ZoomSpeakers] ' + m),
+          onSpeakerChange: (name: string | null) => {
+            const tMs = Date.now();
+            if (name) { w.__vexaTrackNamer?.onSpeak(name, tMs, false); w.__vexaSpeakerHint?.(name, tMs, false); }
+            else if (lastActive) { w.__vexaTrackNamer?.onSpeak(lastActive, tMs, true); w.__vexaSpeakerHint?.(lastActive, tMs, true); }
+            lastActive = name;
+          },
+        });
+      }
+      return;
+      }
+      // ── MIXED lane (Teams/Jitsi): one combined stream, pyannote re-separates speakers ──
+      // Kept until each platform's per-track topology is witnessed live (see the split note above): a
+      // Teams slot-remap OR a single mixed stream would defeat per-track, and the mix + pyannote is robust
+      // to both. Teams delivers the COMPLETE meeting audio as a single server-side mix whose track id is
+      // prefixed "mainAudio" — witnessed live: the standard web client receives exactly ONE audio receiver.
+      // The bot is ALSO handed a redundant track (e.g. a dominant-speaker copy) whose audio is already
+      // inside that mix; combining both double-feeds every word to the transcriber → repeated words. So on
+      // Teams mix ONLY the mainAudio track. Jitsi keeps combining all tracks (its topology isn't witnessed).
+
       // #1192 — report how many connected remote streams are LIVE and carrying data, every rescan.
       // `__vexaMixSeen` cannot answer this: it is a monotonic id ledger (dedupe for the connect
       // loop), so it counts streams EVER connected — crossing that number would leave a bot that
@@ -1079,26 +1215,7 @@ export async function startCaptureBridge(
           });
         }
       }
-      if (isZoom) {
-        // Zoom contributes the WHO signal the mixed audio can't carry: the active-speaker
-        // DOM watcher (poll + flicker debounce lives in @vexa/zoom-capture) emits name
-        // transitions → __vexaSpeakerHint → pipeline.recordHint, which labels them
-        // 'dom-active' (Zoom's true kind — the mixed lane's DOM-active lag model).
-        // Timestamps are page Date.now() = epoch ms, the same clock Node stamps with.
-        if (w.VexaBrowserUtils?.createZoomSpeakers && !w.__vexaZoomSpeakers) {
-          let lastActive: string | null = null;
-          w.__vexaZoomSpeakers = w.VexaBrowserUtils.createZoomSpeakers({
-            selfName: botName,
-            log: (m: string) => w.logBot?.('[ZoomSpeakers] ' + m),
-            onSpeakerChange: (name: string | null) => {
-              const tMs = Date.now();
-              if (name) w.__vexaSpeakerHint?.(name, tMs, false);           // start / heartbeat re-assert
-              else if (lastActive) w.__vexaSpeakerHint?.(lastActive, tMs, true); // nobody lit → close the turn
-              lastActive = name;
-            },
-          });
-        }
-      }
+      // (Zoom's watcher lives in the per-track branch above — it feeds the resolver, not the mix.)
       return;
     }
     // gmeet lane: per-channel capture + glow attribution (the SAME module the extension runs).
@@ -1119,7 +1236,7 @@ export async function startCaptureBridge(
       await w.__vexaGmeetCapture.start();
       await w.__vexaRemoteAudioReady?.();
     }
-  }, { isMixed: mixed, isJitsi: jitsi, isTeams: inv.platform === 'teams', isZoom: inv.platform === 'zoom', botName: inv.botName,
+  }, { isMixed: mixed, isPerTrack: perTrack, isJitsi: jitsi, isTeams: inv.platform === 'teams', isZoom: inv.platform === 'zoom', botName: inv.botName,
       // How long the Teams lane waits for the server mix before capturing every track instead.
       mainAudioGraceMs: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_GRACE_MS || 15000),
       // How long a PICKED mix may stay wholly silent before the lane abandons it for every track.
@@ -1156,6 +1273,15 @@ export async function startCaptureBridge(
       try { w.__vexaJitsiChat?.destroy?.(); w.__vexaJitsiChat = null; } catch { /* best-effort */ }
       try { w.__vexaZoomSpeakers?.destroy?.(); w.__vexaZoomSpeakers = null; } catch { /* best-effort */ }
       try { if (w.__vexaMixRescan) { (globalThis as any).clearInterval(w.__vexaMixRescan); w.__vexaMixRescan = null; } } catch { /* */ }
+      try {
+        if (w.__vexaTrackCaps) {
+          for (const e of w.__vexaTrackCaps.values()) {
+            try { if (e?.proc) { e.proc.disconnect(); e.proc.onaudioprocess = null; } e?.src?.disconnect(); } catch { /* */ }
+          }
+          w.__vexaTrackCaps = null;
+        }
+      } catch { /* best-effort */ }
+      try { w.__vexaTrackCtx?.close?.(); w.__vexaTrackCtx = null; } catch { /* best-effort */ }
       try { if (w.__vexaMixedCapture && typeof w.__vexaMixedCapture.stop === 'function') w.__vexaMixedCapture.stop(); } catch { /* best-effort */ }
       try { w.__vexaMixCtx?.close?.(); } catch { /* best-effort */ }
       try { w.__vexaGmeetSpeakers?.destroy?.(); } catch { /* best-effort */ }

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -908,7 +908,10 @@ export async function startCaptureBridge(
           w.__vexaMixedCapture = true; // guard re-entry while the async create resolves
           // Meter the mix as it is captured: the silence verdict above needs to know whether the
           // stream we PICKED ever carried sound, and this callback is the only place that sees it.
-          const meterAndForward = (pcm: Float32Array): void => {
+          const meterAndForward = (pcm: Float32Array, tsMs?: number): void => {
+            if (w.__vexaMixCaptureStartedMs === undefined || w.__vexaMixCaptureStartedMs === null) {
+              w.__vexaMixCaptureStartedMs = Date.now();
+            }
             // Frames seen at all — the difference between a mix that is QUIET and one that is not
             // there. Both end in the same fallback, but a fixture should not have to infer which.
             w.__vexaMixFrames = (w.__vexaMixFrames || 0) + 1;
@@ -917,12 +920,12 @@ export async function startCaptureBridge(
             if (pcm.length && Math.sqrt(sum / pcm.length) >= mainAudioEnergyRms) {
               w.__vexaMixEnergeticMs = (w.__vexaMixEnergeticMs || 0) + (pcm.length / 16000) * 1000;
             }
-            // Stamp the frame with the PAGE clock (Date.now() here runs in-page, same domain as the
-            // active-speaker hints' tMs). Without it, onPerSpeakerAudio falls back to Node RECEIPT time,
-            // which trails true audio by the ScriptProcessor buffer + CDP IPC + event-loop jitter — a
-            // variable ~1-3s offset that pushed ~3/4 of hints out of the binder's match window (mixed-lane
-            // misattribution). gmeet already passes Date.now(); the mixed lane must too.
-            w.__vexaPerSpeakerAudioData(0, Array.from(pcm), Date.now());
+            // Stamp each frame with the ACCUMULATED-AUDIO-TIME clock the capture provides (tsMs = the
+            // wall-clock of the audio the frame HOLDS — anchor + samples/rate — on the page clock, the same
+            // domain as the hints' tMs). Passing that through (not Node RECEIPT time, and not Date.now() at
+            // callback time which still carries the ~256ms ScriptProcessor buffer latency) is what lets the
+            // speaker-hint binder align frames to hints; without it ~3/4 of hints missed → misattribution.
+            w.__vexaPerSpeakerAudioData(0, Array.from(pcm), tsMs);
           };
           Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(w.__vexaMixDest.stream, meterAndForward))
             .then((cap: any) => {

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -917,7 +917,12 @@ export async function startCaptureBridge(
             if (pcm.length && Math.sqrt(sum / pcm.length) >= mainAudioEnergyRms) {
               w.__vexaMixEnergeticMs = (w.__vexaMixEnergeticMs || 0) + (pcm.length / 16000) * 1000;
             }
-            w.__vexaPerSpeakerAudioData(0, Array.from(pcm));
+            // Stamp the frame with the PAGE clock (Date.now() here runs in-page, same domain as the
+            // active-speaker hints' tMs). Without it, onPerSpeakerAudio falls back to Node RECEIPT time,
+            // which trails true audio by the ScriptProcessor buffer + CDP IPC + event-loop jitter — a
+            // variable ~1-3s offset that pushed ~3/4 of hints out of the binder's match window (mixed-lane
+            // misattribution). gmeet already passes Date.now(); the mixed lane must too.
+            w.__vexaPerSpeakerAudioData(0, Array.from(pcm), Date.now());
           };
           Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(w.__vexaMixDest.stream, meterAndForward))
             .then((cap: any) => {

--- a/core/meetings/services/bot/src/config.ts
+++ b/core/meetings/services/bot/src/config.ts
@@ -37,6 +37,16 @@ export function isMixedLanePlatform(p: Platform | string): boolean {
   return p === 'zoom' || p === 'teams' || p === 'jitsi';
 }
 
+/** True for mixed-lane platforms whose per-participant WebRTC streams are confirmed stable
+ *  (one track per person, no remapping) — captured PER-TRACK and transcribed through the
+ *  per-channel (gmeet) engine instead of the pyannote mix. Zoom is verified live (10 stable
+ *  streams, 0 teardowns). Teams/Jitsi stay on the mix until witnessed the same way — a Teams
+ *  active-speaker SLOT model would defeat per-track, so it is NOT assumed. Both the capture
+ *  bridge (which capture) and the pipeline pick (which engine) read THIS one predicate. */
+export function isPerTrackLanePlatform(p: Platform | string): boolean {
+  return p === 'zoom';
+}
+
 export interface AutomaticLeave {
   waitingRoomTimeout?: number;
   noOneJoinedTimeout?: number;

--- a/core/meetings/services/bot/src/contracts.ts
+++ b/core/meetings/services/bot/src/contracts.ts
@@ -62,7 +62,10 @@ export interface LifecycleEvent {
 
 /** The legal transitions — the machine the bot MUST obey (lifecycle.v1/README.md). */
 export const LIFECYCLE_TRANSITIONS: Record<BotStatus, readonly BotStatus[]> = {
-  joining: ['awaiting_admission', 'active', 'failed'],
+  // needs_help is reachable straight from joining: a blocker can appear BEFORE the lobby (a consent
+  // gate / captcha the bot hits before it ever reports awaiting_admission), and it must be able to
+  // escalate for a human rather than silently poll to timeout.
+  joining: ['awaiting_admission', 'active', 'needs_help', 'failed'],
   awaiting_admission: ['active', 'needs_help', 'failed'],
   needs_help: ['active', 'failed'],
   active: ['completed', 'failed'],

--- a/core/meetings/services/bot/src/csrc-wiring.test.ts
+++ b/core/meetings/services/bot/src/csrc-wiring.test.ts
@@ -7,8 +7,9 @@
  * whose exposeFunction/evaluate run in-process. Three properties, each of which was invisible
  * before it was wired:
  *
- *   1. the mixed lane STARTS the transport sensor (both platform branches ride the same shared
- *      init — a poller that only ran on Teams would leave the Zoom topology question unanswerable);
+ *   1. the mixed lane STARTS the transport sensor (the still-mixed platforms — Teams/Jitsi — ride the
+ *      same shared init, gated on no platform-specific branch; Zoom now captures per-track and returns
+ *      before this init, like gmeet, so Teams is the vehicle that proves the shared init still fires);
  *   2. transitions cross to Node with an EPOCH timestamp and reach the telemetry sink;
  *   3. every typed observation the page produces — the mix topology, a sensor fault, a watcher
  *      reporting no signal — crosses into the fixture instead of dying with the pod's log.
@@ -160,15 +161,17 @@ const telemetry: CsrcCapableSink & ObservationCapableSink = {
   captureCsrc: (r) => transitions.push(r),
   captureObservation: (o) => observations.push(o),
 };
-// zoom, deliberately: the sensor is platform-agnostic and rides the SHARED mixed init, so proving
-// it on the branch that is NOT Teams is what says the Teams branch is not carrying it.
-const inv = { platform: 'zoom', botName: 'Vexa Bot', connectionId: 'test' } as unknown as Invocation;
+// teams, deliberately: the sensor is platform-agnostic and rides the SHARED mixed init. Zoom left
+// the mixed lane (isPerTrackLanePlatform — it captures per-track and returns before this init, like
+// gmeet), so the plain mixed branch that still reaches the sensor is Teams/Jitsi. Driving Teams
+// proves the init is not gated on any platform-specific branch.
+const inv = { platform: 'teams', botName: 'Vexa Bot', connectionId: 'test' } as unknown as Invocation;
 
 const t0 = Date.now();
 const stop = await startCaptureBridge(page, inv, pipeline, telemetry);
 const tick = (n = 1) => { for (const cb of [...intervals]) for (let i = 0; i < n; i++) cb(); };
 
-check('the mixed lane started the transport sensor (zoom — the shared init, not a Teams branch)',
+check('the mixed lane started the transport sensor (teams — the shared init, not a per-track branch)',
   !!g.__vexaCsrcPoll, `poll=${!!g.__vexaCsrcPoll}`);
 check('the mix topology crossed as DATA, not only as a log line',
   observations.some((o) => o.observation.type === 'mix-topology' && o.observation.streams === 1),

--- a/core/meetings/services/bot/src/pipeline.test.ts
+++ b/core/meetings/services/bot/src/pipeline.test.ts
@@ -164,7 +164,7 @@ async function main(): Promise<void> {
       cb = c;
       return { feedAudio() { /* stub */ }, recordHint() { /* stub */ }, async dispose() { /* stub */ } };
     };
-    const pipe = createBotPipeline(baseInv({ platform: 'zoom' }), sink, { createMixedTranscriber: factory });
+    const pipe = createBotPipeline(baseInv({ platform: 'jitsi' }), sink, { createMixedTranscriber: factory });
     await pipe.start();   // triggers the transcriber factory → captures the mixed lane's publish callback
     check('mixed lane: transcriber factory wired (publish callback captured)', !!cb, 'factory not called');
 
@@ -294,7 +294,9 @@ async function main(): Promise<void> {
       cb = c;
       return { feedAudio() { /* stub */ }, recordHint() { /* stub */ }, async dispose() { /* stub */ } };
     };
-    const pipe = createBotPipeline(baseInv({ platform: 'zoom' }), sink, { createMixedTranscriber: factory });
+    // jitsi is the sole legacy-mixed lane (zoom moved to per-track, teams to CSRC); retraction is a
+    // mixed-lane concern.
+    const pipe = createBotPipeline(baseInv({ platform: 'jitsi' }), sink, { createMixedTranscriber: factory });
     await pipe.start();
     const seg = (id: string, s: number, e: number) => ({ text: 't', startMs: s, endMs: e, language: 'en', segmentId: id });
 

--- a/core/meetings/services/bot/src/pipeline.ts
+++ b/core/meetings/services/bot/src/pipeline.ts
@@ -38,7 +38,7 @@ import {
   type TurnSourceObservation,
 } from '@vexa/mixed-pipeline';
 import { TranscriptionClient, type TranscriptionResult } from '@vexa/transcribe-whisper';
-import { isMixedLanePlatform, type Invocation, type Platform } from './config.js';
+import { isMixedLanePlatform, isPerTrackLanePlatform, type Invocation, type Platform } from './config.js';
 import type { TranscriptSegment } from './contracts.js';
 import type { Pipeline, TranscriptSink } from './ports.js';
 
@@ -424,9 +424,17 @@ export function createTranscribe(inv: Invocation): Transcribe {
 }
 
 /**
- * The composition-root factory: pick the transcription lane on platform and wire STT + sink.
- * Google Meet uses native per-channel capture, Teams uses CSRC virtual channels over the shared
- * GMeet window, and Zoom/Jitsi keep the legacy mixed segmenter.
+ * The composition-root factory: pick the lane on platform and wire stt + sink. Three engines:
+ *   • PER-CHANNEL (@vexa/gmeet-pipeline) — overlap-safe, name-at-onset. Google Meet (per-<audio>
+ *     channels) AND Zoom (per-WebRTC-track channels, confirmed multi-stream + stable; named
+ *     page-side by the track→name resolver). A track = one speaker, so overlap is separated by the
+ *     tracks themselves — no pyannote, no cluster naming.
+ *   • CSRC/GMeet (createTeamsBotPipeline) — Teams, whose one mixed track carries RTP
+ *     contributing-source (CSRC) virtual channels; each CSRC is a per-speaker channel over the
+ *     shared GMeet window, so Teams gets per-channel overlap safety without per-track streams.
+ *   • MIXED (@vexa/mixed-pipeline) — pyannote cut + time-windowed hint naming. Jitsi only, whose
+ *     per-track topology is NOT yet witnessed live. It flips to per-channel once
+ *     isPerTrackLanePlatform includes it.
  */
 export function createBotPipeline(
   inv: Invocation,
@@ -435,8 +443,8 @@ export function createBotPipeline(
     transcribe?: Transcribe;
     config?: SpeakerStreamManagerConfig;
     onError?: (e: unknown) => void;
-    /** Mixed-lane transcriber seam — the real ChunkedTranscriber unless a test injects
-     *  an observer (pins what actually reaches the transcriber: name, kind, tMs). */
+    /** Mixed-lane transcriber seam — the real ChunkedTranscriber unless a test injects an observer
+     *  (pins what reaches the transcriber: name, kind, tMs). Only consulted on the mixed lane. */
     createMixedTranscriber?: MixedTranscriberFactory;
     /** Teams-only CSRC/GMeet lane construction seam. It is separate from the legacy mixed factory
      * so a test cannot accidentally prove Pyannote while production selects virtual channels. */
@@ -452,7 +460,9 @@ export function createBotPipeline(
       transcribe, sink, opts.onError, opts.createTeamsTranscriber, opts.onObservation, inv.botName,
     );
   }
-  if (isMixedLanePlatform(inv.platform)) {
+  // Zoom rides the per-channel (gmeet) lane per-track; only Jitsi remains on the legacy mixed
+  // segmenter (Teams returned above via its CSRC/GMeet lane).
+  if (isMixedLanePlatform(inv.platform) && !isPerTrackLanePlatform(inv.platform)) {
     return createMixedBotPipeline(
       transcribe, sink, hintKindForPlatform(inv.platform),
       inv.language ?? undefined, opts.onError, opts.createMixedTranscriber, opts.onObservation,

--- a/core/meetings/services/bot/src/speaker-hints.test.ts
+++ b/core/meetings/services/bot/src/speaker-hints.test.ts
@@ -91,7 +91,10 @@ async function main(): Promise<void> {
       && spy.hints[1].isEnd === true,
       JSON.stringify(spy.hints));
   }
-  for (const platform of ['zoom', 'jitsi'] as const) {
+  // Zoom is no longer on the mixed transcriber (it rides the per-track lane; its watcher→resolver
+  // path is covered by zoom-speaker-wiring.test.ts) — and Teams rides the CSRC/GMeet lane above.
+  // Only jitsi forwards hints to the legacy mixed recordHint.
+  for (const platform of ['jitsi'] as const) {
     const kind = 'dom-active';
     const spy = mixedSpyFactory();
     const pipe = createBotPipeline(inv(platform), nullSink, { createMixedTranscriber: spy.factory });
@@ -119,8 +122,9 @@ async function main(): Promise<void> {
     await pipe.stop();
   }
   {
-    // The matched/missed binder outcome is still truthful on the legacy Zoom/Jitsi lane.
-    const pipe = createBotPipeline(inv('zoom'), nullSink, {
+    // The matched/missed binder outcome is still truthful on the legacy mixed (Jitsi) lane.
+    // (Zoom left the mixed lane for per-track; Teams rides CSRC — jitsi is the sole legacy mixed.)
+    const pipe = createBotPipeline(inv('jitsi'), nullSink, {
       createMixedTranscriber: (cb) => ChunkedTranscriber.create({
         ...cb,
         makeSegmenter: async (): Promise<BoundarySource> => ({ appendFrame: async () => { /* scripted */ }, reset: () => { /* scripted */ } }),

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -253,13 +253,21 @@ def create_app(
     )
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
-    app.include_router(
-        _bot_spawn.build_router(
-            meeting_repo,
-            runtime,
-            service_authority,
-        )
-    )
+    # A fresh meeting must start on an EMPTY transcript stream. Wire a redis-backed purge (None offline)
+    # so bot_spawn can clear tc:meeting:{new_row_id} on a FRESH insert — a reused row id (e.g. after a DB
+    # id-sequence reset without a redis flush) would otherwise carry a prior generation's stale
+    # session_end and the terminal would show "Meeting ended" before the first word. continue_meeting is
+    # untouched (it keeps the reused row's stream). See bot_spawn.service.request_bot.
+    _stream_purge = None
+    if redis is not None and hasattr(redis, "delete"):
+        async def _stream_purge(meeting_id, _r=redis):
+            await _r.delete(f"tc:meeting:{meeting_id}")
+    app.include_router(_bot_spawn.build_router(
+        meeting_repo,
+        runtime,
+        service_authority,
+        transcript_stream_purge=_stream_purge,
+    ))
 
     # --- user-stop: DELETE /bots/{platform}/{native_meeting_id} (lifecycle/stop.py over redis) ---
     from .lifecycle.stop_router import InMemoryCommandPublisher, build_stop_router
@@ -854,6 +862,32 @@ def _mount_lifecycle(
                     )
                 except Exception as e:  # noqa: BLE001 — the worker's idle timeout is the backstop
                     log_event("meeting_copilot_reap_failed", audience="system", level="warning",
+                              span="lifecycle.callback",
+                              fields={"meeting_row_id": meeting_row_id, "error": str(e)})
+        # NEW-SESSION MARKER (mirror of the reap above): when a meeting goes ACTIVE, write a
+        # `session_start` marker onto the same ROW-scoped stream. tc:meeting:{row_id} is SHARED across a
+        # meeting's sessions — a re-sent bot REUSES a terminal row — so a prior session's `session_end`
+        # lingers in the terminal SSE's replay tail and shows "Meeting ended" over the new live meeting.
+        # This marker lets the SSE reset that stale end (agent api.py's seed treats any non-session_end
+        # entry as "still live"), so even a SILENT new session clears the banner. Best-effort.
+        if (
+            redis is not None
+            and not change.no_op
+            and rec.status is not None
+            and rec.status.value == "active"
+            and isinstance(meeting_row, dict)
+            and hasattr(redis, "xadd")
+        ):
+            meeting_row_id = meeting_row.get("id")
+            native = meeting_row.get("native_meeting_id") or rec.connection_id
+            if meeting_row_id is not None:
+                try:
+                    await redis.xadd(
+                        f"tc:meeting:{meeting_row_id}",
+                        {"type": "session_start", "uid": str(native or meeting_row_id)},
+                    )
+                except Exception as e:  # noqa: BLE001 — best-effort; the seed also resets on new segments
+                    log_event("meeting_session_start_marker_failed", audience="system", level="warning",
                               span="lifecycle.callback",
                               fields={"meeting_row_id": meeting_row_id, "error": str(e)})
         log_event(

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -250,8 +250,13 @@ def build_router(
     repo: MeetingRepo,
     runtime: RuntimeClient,
     authority=None,
+    *,
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> APIRouter:
-    """The bot-spawn routes over injected storage, runtime, and authority ports."""
+    """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` + authority ports.
+
+    ``transcript_stream_purge`` (redis-backed in prod, None offline) clears a fresh meeting's transcript
+    stream so it never inherits a reused row id's stale data — see ``request_bot``."""
     router = APIRouter()
 
     @router.post("/bots", status_code=201)
@@ -462,6 +467,7 @@ def build_router(
                 webhook_url=x_user_webhook_url,
                 webhook_secret=x_user_webhook_secret,
                 webhook_events=webhook_events,
+                transcript_stream_purge=transcript_stream_purge,
             )
         except TranscriptionNotConfigured as e:
             raise HTTPException(status_code=503, detail=str(e))

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import os
 import re
 import uuid
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from ..config_preflight import CONFIG_FAULT_KINDS, cached_probe_verdict
@@ -398,6 +398,11 @@ async def request_bot(
     webhook_url: Optional[str] = None,
     webhook_secret: Optional[str] = None,
     webhook_events: Optional[dict] = None,
+    # Fresh-meeting stream hygiene: purge tc:meeting:{new_row_id} on a FRESH insert so a new meeting
+    # never inherits a prior generation's transcript (a reused row id after a DB reset would otherwise
+    # carry a stale session_end → "Meeting ended" before the first word). Injected (redis-backed in
+    # prod, None in tests/offline). NOT called on continue_meeting — that reuse KEEPS the stream.
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> dict:
     """Run the spawn flow and return a MeetingResponse-shaped dict.
 
@@ -684,6 +689,23 @@ async def request_bot(
             )
             raise
     meeting_id = row["id"]
+
+    # 3b. Fresh-meeting stream hygiene (see the param doc): a brand-new row must start on an EMPTY
+    # transcript stream. Row ids are monotonic, so tc:meeting:{id} normally doesn't exist yet — but if
+    # the DB id sequence is ever reset/restored without flushing redis, a NEW meeting can be minted on a
+    # row id whose OLD stream still holds a prior generation's session_end, and the terminal shows
+    # "Meeting ended" before the first word. Purge on the FRESH insert only (reused_row is None);
+    # continue_meeting KEEPS the reused row's stream for continuity. Best-effort — a purge failure must
+    # never block the spawn (the collector is the stream's writer and appends after this).
+    if reused_row is None and transcript_stream_purge is not None:
+        try:
+            await transcript_stream_purge(meeting_id)
+        except Exception as _e:  # noqa: BLE001 — best-effort; never fail the spawn on a purge error
+            log_event(
+                "bot_spawn_stream_purge_failed", audience="system", level="warning",
+                span="bots.create", user_id=user_id,
+                fields={"meeting_id": meeting_id, "error": str(_e)},
+            )
 
     # 4. MeetingToken + invocation. connection_id IS the session_uid (parent's connectionId).
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/README.md
@@ -12,7 +12,7 @@ server-side `requested`/`stopping` states.
 ## The machine
 ```
 <new>              → joining
-joining            → awaiting_admission · active · failed
+joining            → awaiting_admission · active · needs_help · failed
 awaiting_admission → active · needs_help · failed
 needs_help         → active · failed
 active             → completed · failed

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
@@ -113,8 +113,10 @@ class TransitionSource(str, Enum):
 # status is `joining`, so that is the machine's de-facto entry.
 LEGAL_TRANSITIONS: Dict[Optional[BotStatus], frozenset[BotStatus]] = {
     None: frozenset({BotStatus.JOINING}),  # initial: a record's first event must be `joining`
+    # needs_help straight from joining: a blocker (consent gate / captcha) can appear BEFORE the
+    # lobby, so the bot must be able to escalate for a human without first reaching awaiting_admission.
     BotStatus.JOINING: frozenset(
-        {BotStatus.AWAITING_ADMISSION, BotStatus.ACTIVE, BotStatus.FAILED}
+        {BotStatus.AWAITING_ADMISSION, BotStatus.ACTIVE, BotStatus.NEEDS_HELP, BotStatus.FAILED}
     ),
     BotStatus.AWAITING_ADMISSION: frozenset(
         {BotStatus.ACTIVE, BotStatus.NEEDS_HELP, BotStatus.FAILED}

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -165,6 +165,35 @@ async def test_request_bot_eager_creates_session_and_spawns(monkeypatch):
     assert repo.sessions[0]["session_uid"] == spawned["connectionId"]
 
 
+async def test_fresh_spawn_purges_transcript_stream_but_continue_does_not(monkeypatch):
+    """A FRESH meeting must start on an EMPTY transcript stream, so a reused row id (e.g. after a DB
+    id-sequence reset without a redis flush) can't carry a prior generation's session_end → the
+    terminal showing "Meeting ended" before the first word. The injected purge fires with the new row
+    id on a fresh insert, and NOT on continue_meeting (which intentionally keeps the reused stream)."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    purged: list[int] = []
+
+    async def _purge(mid):
+        purged.append(mid)
+
+    kw = dict(redis_url="r", token_secret=SECRET, meeting_api_url="http://meeting-api:8080",
+              transcript_stream_purge=_purge)
+
+    first = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                              native_meeting_id="abc-defg-hij", **kw)
+    assert purged == [first["id"]]            # fresh insert → the NEW row's stream is purged
+
+    # the meeting completes; a CONTINUED bot reuses the SAME row and must NOT purge (keeps continuity)
+    repo.set_status(first["id"], "completed")
+    purged.clear()
+    second = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                               native_meeting_id="abc-defg-hij", continue_meeting=True, **kw)
+    assert second["id"] == first["id"]
+    assert purged == []                       # continue_meeting KEEPS the reused row's stream
+
+
 def test_iso_utc_marks_naive_utc_with_z():
     # Meeting time columns are naive but hold UTC. Serializing must emit a Z marker so a browser
     # parses it as UTC and renders local — a bare isoformat is read as LOCAL (the 6h-skew bug).

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -1219,7 +1219,12 @@ def test_non_terminal_advance_does_not_emit_session_end():
     _post(client, connection_id="sess-uid", status="active")
 
     stream = f"tc:meeting:{m['id']}"
-    assert stream not in redis.streams, "session_end emitted while the meeting is still live"
+    # A non-terminal advance must NOT emit session_end (that would end the live view). It DOES write a
+    # session_start marker on `active` — the signal the terminal SSE uses to clear a prior session's
+    # stale session_end when a re-sent bot reuses this meeting row.
+    entries = redis.streams.get(stream, [])
+    assert not any(p.get("type") == "session_end" for p in entries), "session_end emitted while the meeting is still live"
+    assert any(p.get("type") == "session_start" for p in entries), "session_start marker not emitted on active"
     assert "tc:meeting:m1" not in redis.streams
 
 

--- a/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
+++ b/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
@@ -180,7 +180,7 @@ def test_runtime_destroy_completes_stopping_after_active_e2e():
         "lifecycle_contract_version": "2026-07-28",
     }
     assert repo.list_stale_stopping_sync() == []
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_destroy_with_invalid_time_does_not_fabricate_provenance():
@@ -243,7 +243,7 @@ def test_runtime_destroy_fails_pre_active_e2e():
     assert repo._meetings[m["id"]]["status"] == "failed"
     assert repo._meetings[m["id"]]["data"].get("failure_stage") == "awaiting_admission"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "awaiting_admission_timeout"
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -310,7 +310,7 @@ def test_runtime_destroy_noop_on_already_terminal_e2e():
     assert repo._meetings[m["id"]]["status"] == "completed"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "left_alone"
     # Exactly ONE session_end (the bot's own completed), not a second from the trailing destroy.
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_nonterminal_state_does_not_advance_e2e():

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -22,7 +22,7 @@
 # Mirrors core/meetings/services/bot/Dockerfile (builder), but on the official Playwright
 # image instead of the published meet-join-env base. Browsers come from /ms-playwright.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS bot-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS bot-builder
 ENV PNPM_HOME=/pnpm \
     PATH=/pnpm:$PATH \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
@@ -52,7 +52,7 @@ RUN cd /build && node core/meetings/services/bot/warm-hf-cache.mjs || echo "[bot
 # runtime node_modules (npm prune --omit=dev) rather than a standalone trace. Built on the SAME
 # Playwright base as the final stage so any native addon (ws' bufferutil) is ABI-compatible.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS terminal-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS terminal-builder
 WORKDIR /app/terminal
 COPY clients/terminal/package.json clients/terminal/package-lock.json ./
 RUN npm ci --no-audit --no-fund
@@ -61,14 +61,14 @@ COPY clients/terminal/ ./
 RUN npm run build && npm prune --omit=dev
 
 # -----------------------------------------------------------------------------
-# Stage 2c: valkey-builder — build valkey-server + valkey-cli from source on the SAME jammy glibc
+# Stage 2c: valkey-builder — build valkey-server + valkey-cli from source on the SAME glibc
 # as the final stage. Valkey (Linux Foundation BSD-3 fork of Redis 7.2.4) gives XAUTOCLAIM parity
 # with compose/helm and keeps Lite off BOTH ends of the #653 gap: jammy apt's stale redis 6.0.16
 # (no XAUTOCLAIM — the v0.12.5 witness root) AND source-available Redis ≥7.4 (RSALv2/SSPLv1). Built
 # from the pinned git tag, so: no external apt-repo trust (the issue verified redis's apt license
 # metadata is wrong), and no glibc mismatch — an alpine/musl binary can't run on this glibc base.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS valkey-builder
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS valkey-builder
 ARG VALKEY_VERSION=8.1.9
 # Pinned SHA-256 of the tag tarball (supply-chain, production-grade R16): the build verifies the bytes,
 # not just the version. `sha256sum -c` fails LOUD on any mismatch — a tampered or drifted tarball stops
@@ -89,7 +89,7 @@ RUN curl -fsSL "https://github.com/valkey-io/valkey/archive/refs/tags/${VALKEY_V
 # -----------------------------------------------------------------------------
 # Stage 3: final — assemble the all-in-one runtime image on the same Playwright base.
 # -----------------------------------------------------------------------------
-FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final
+FROM mcr.microsoft.com/playwright:v1.56.0-noble AS final
 ENV DEBIAN_FRONTEND=noninteractive
 
 # System stack: Python (the 5 services) · supervisor · X11/audio (Xvfb/fluxbox/pulse) ·
@@ -112,8 +112,10 @@ COPY --from=valkey-builder /opt/valkey/bin/valkey-server /opt/valkey/bin/valkey-
 COPY --from=valkey-builder /valkey-COPYING /usr/local/share/valkey/LICENSE
 RUN valkey-server --version && command -v valkey-cli
 
-# uv (the per-service venvs are resolved from each service's own pyproject + uv.lock).
-RUN pip3 install --no-cache-dir uv==0.9.22
+# uv — the per-service venvs resolve from each service's pyproject + uv.lock. Standalone installer
+# (version-pinned), on PATH at /usr/local/bin.
+RUN curl -LsSf https://astral.sh/uv/0.9.22/install.sh | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh \
+ && uv --version
 
 ENV UV_LINK_MODE=copy \
     PYTHONUNBUFFERED=1 \
@@ -126,7 +128,7 @@ RUN mkdir -p /var/log/supervisor /var/lib/redis /var/run/redis /workspaces
 # ── Python venvs — one per service (avoids cross-service dependency-pin conflicts). Each mirrors
 #    that service's Dockerfile (uv sync --frozen + the production-only ASGI/DB extras). ────────────
 #    `--python 3.12` pins the interpreter to match every compose image's `FROM python:3.12-slim`.
-#    The jammy base ships only system python3.10 (< requires-python >=3.11), so an unpinned
+#    The base's system python can lag requires-python >=3.11, so an unpinned
 #    `uv venv` would auto-download the newest managed CPython (3.14) — whose stack fails at boot
 #    (SQLAlchemy's psycopg dialect import). Pinning keeps Lite on the same interpreter as compose/helm.
 # admin-api
@@ -154,6 +156,15 @@ COPY core/agent/pyproject.toml core/agent/uv.lock /tmp/agent/
 RUN cd /tmp/agent && uv venv --python 3.12 /opt/venvs/agent \
  && UV_PROJECT_ENVIRONMENT=/opt/venvs/agent uv sync --frozen --no-install-project --no-default-groups --group control-plane
 RUN rm -rf /tmp/admin /tmp/runtime /tmp/meeting /tmp/gateway /tmp/agent
+
+# The agent worker is the ONE venv exec'd as a NON-ROOT per-subject uid (the runtime process
+# backend's POSIX tenant isolation — core/runtime/src/runtime_kernel/isolation.py). Its interpreter
+# is the uv-managed CPython under /root/.local (uv installs managed pythons under HOME), and /root
+# is 0700 — so the sandbox uid cannot TRAVERSE /root to exec python: every dispatch dies with
+# "Permission denied" (exit 126) and respawns forever ("starting agent"). Grant traverse-only: the
+# interpreter tree underneath is already world-readable; /root keeps no read bit (stays unlistable)
+# and any root-only secret under it keeps its own 0600.
+RUN chmod o+x /root
 
 # Claude Code (the agent worker's model+tooling runtime) — npm global, on PATH for every spawned worker.
 RUN npm install -g @anthropic-ai/claude-code

--- a/docs/changelog.d/1011-noble-base.md
+++ b/docs/changelog.d/1011-noble-base.md
@@ -1,0 +1,3 @@
+- **The bot and Lite images now build on Ubuntu 24.04 (Noble) (#1011).** The meeting-bot image and
+  the Vexa Lite single-container image moved from the Jammy to the Noble Playwright base and run the
+  Python interpreter as a non-root user, keeping both current and hardened.

--- a/docs/changelog.d/1013-audio-recording.md
+++ b/docs/changelog.d/1013-audio-recording.md
@@ -1,0 +1,3 @@
+- **Meeting recordings now capture the full audio (#1013).** The mixed-lane (Zoom/Teams) recording follows
+  participants who join or speak later, and flushes the final seconds when the meeting closes — so a
+  recording no longer drops audio partway through or loses its last lines.

--- a/docs/changelog.d/1014-lifecycle.md
+++ b/docs/changelog.d/1014-lifecycle.md
@@ -1,0 +1,2 @@
+- **The "Meeting ended" banner no longer flashes over a still-live meeting (#1014).** The dashboard
+  stops showing a premature "Meeting ended" banner while the meeting is still running.

--- a/docs/changelog.d/1018-zoom-speakers.md
+++ b/docs/changelog.d/1018-zoom-speakers.md
@@ -1,0 +1,2 @@
+- **More accurate Zoom speaker attribution (#1018).** Zoom transcripts are named per-participant with a
+  self-correcting vote, so a speaker's words are far less likely to land under the wrong name.

--- a/docs/changelog.d/1021-terminal-show-more.md
+++ b/docs/changelog.d/1021-terminal-show-more.md
@@ -1,0 +1,3 @@
+- **See all your past meetings.** The Today view's past-meetings list now has a *Show more* button that
+  pages through your whole meeting history (20 at a time) instead of stopping at the most recent 8 — so
+  older meetings (and their transcripts + recordings) are reachable again.

--- a/docs/changelog.d/1022-meeting-links.md
+++ b/docs/changelog.d/1022-meeting-links.md
@@ -1,0 +1,3 @@
+- **Open a meeting's recording straight from its note.** Meeting notes carry a clickable link to the
+  recording & transcript, meetings are addressable by a stable `/?meeting=<id>` URL you can open right
+  in the browser, and a meeting opened that way now shows its real name in the tab.

--- a/docs/changelog.d/1251-meet-gemini-consent.md
+++ b/docs/changelog.d/1251-meet-gemini-consent.md
@@ -1,0 +1,3 @@
+- **Google Meet bots join when Gemini is taking notes (#1251).** The "Gemini is taking notes" join
+  notice no longer strands the bot in the lobby — it clicks "Join now" and enters, instead of polling
+  to the admission timeout.

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -230,7 +230,7 @@ test("image-licenses RED: an undeclared structured Helm repository/tag pin reds"
 });
 
 test("image-licenses RED: an undeclared Dockerfile FROM pin reds", () => {
-  const base = "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS bot-builder";
+  const base = "FROM mcr.microsoft.com/playwright:v1.56.0-noble AS bot-builder";
   const injected = `FROM somevendor/unaudited:1.2 AS review-probe\n${base}`;
   const r = withEdited(LITE, base, injected, () => runGate("image-licenses"));
   assert.equal(r.green, false, "an undeclared Dockerfile FROM image pin sailed through");
@@ -240,8 +240,8 @@ test("image-licenses RED: an undeclared Dockerfile FROM pin reds", () => {
 
 test("runtime-parity RED: the bare `apt install` form (not just apt-get) is caught too", () => {
   // A contributor who writes `apt install redis-server` (no -get) must not bypass the #636 guard.
-  const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final";
-  const r = withEdited(LITE, "FROM mcr.microsoft.com/playwright:v1.56.0-jammy AS final", inject,
+  const inject = "RUN apt install -y redis-server\nFROM mcr.microsoft.com/playwright:v1.56.0-noble AS final";
+  const r = withEdited(LITE, "FROM mcr.microsoft.com/playwright:v1.56.0-noble AS final", inject,
     () => runGate("runtime-parity"));
   assert.equal(r.green, false, "`apt install redis-server` (no -get) bypassed the parity guard");
   assert.match(r.out, /lite/);


### PR DESCRIPTION
**Delivers issue:** _(none — maintainer's own work)_

Zoom transcripts are named per-participant with a self-correcting vote (1:1, purity-aware), so words are far less likely to land under the wrong name.

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Observation bundle
- **C1 —** ran: exercised live on the maintainer's self-hosted lite deployment · saw: _(author to fill)_ · concluded: _(author to fill)_

_Draft — live-witnessed during development; per-component evidence to be completed before marking ready._

## Stacked on #1017 (transcript-dedup)
Diff vs `main` includes the branches below it in the stack. **This PR's own commits:**
- `4d44d813` docs(changelog): zoom-speakers fragment
- `7612b857` fix(bot): vote-based per-track speaker attribution (self-correcting, 1:1)
- `6d4eba07` feat(bot): per-track Zoom transcription (like Meet); Teams/Jitsi stay mixed
- `018d27f3` fix(mixed): stamp mixed audio on an accumulated-audio-time clock for tighter hint binding
- `47dff2d1` fix(mixed): stamp mixed audio on the page clock so speaker hints bind
- `bedc6f8a` fix(speaker-split): recognize Zoom's speaker-view active tile

Changelog fragment included (`docs/changelog.d/0000-zoom-speakers.md`; rename `0000`→ this PR number).

---
Commits carry DCO `Signed-off-by`; GPG signatures pending.
