### PR TITLE
gov: publish Harmony CCLA candidate flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,9 @@
   under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
   <!-- rights:independent -->
 - [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
-  may control this contribution. I am requesting Vexa's private corporate-authorization process.
+  may control this contribution. I will use Vexa's public blank-agreement index and private return
+  process described in
+  [CLA/README.md](https://github.com/Vexa-ai/vexa/blob/main/CLA/README.md).
   <!-- rights:corporate -->
 - [ ] **Unsure:** I need a private rights review before merge.
   <!-- rights:uncertain -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,16 +13,12 @@
 <!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
      must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->
 
-- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
+- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it <!-- rights:independent -->
   under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
-  <!-- rights:independent -->
-- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
+- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or <!-- rights:corporate -->
   may control this contribution. I will use Vexa's public blank-agreement index and private return
-  process described in
-  [CLA/README.md](https://github.com/Vexa-ai/vexa/blob/main/CLA/README.md).
-  <!-- rights:corporate -->
-- [ ] **Unsure:** I need a private rights review before merge.
-  <!-- rights:uncertain -->
+  process described in [CLA/README.md](https://github.com/Vexa-ai/vexa/blob/main/CLA/README.md).
+- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->
 
 Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
 independent path means no individual CLA is required. Corporate and unsure paths do not stop

--- a/.github/workflows/contribution-rights.yml
+++ b/.github/workflows/contribution-rights.yml
@@ -16,7 +16,9 @@ permissions:
   checks: write
 
 concurrency:
-  group: contribution-rights-${{ github.event.pull_request.number || github.event.issue.number || github.event.merge_group.head_sha }}
+  # check_run events have no PR/issue number. Key them by their unique run id so an unrelated
+  # check completion cannot cancel the DCO event before it publishes dco-no-override.
+  group: contribution-rights-${{ github.event.pull_request.number || github.event.issue.number || github.event.merge_group.head_sha || github.event.check_run.id || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/CLA/Corporate_CLA.draft.md
+++ b/CLA/Corporate_CLA.draft.md
@@ -1,0 +1,222 @@
+# Vexa Entity Contributor License Agreement
+
+**Harmony Entity Contributor License Agreement v1.0 — Vexa configuration candidate**
+
+> **Not currently offered for signature.** This candidate preserves the Harmony Entity Contributor
+> License Agreement v1.0 and makes only the project substitutions and option selections identified
+> in the configuration record below. Founder approval may select this candidate, but the signature
+> version is published only after licensed counsel approves its exact bytes and SHA-256.
+
+Thank you for your interest in contributing to the Vexa open-source project managed by
+**Vexa.ai Inc.**, a Delaware corporation (**We** or **Us**).
+
+This contributor agreement (**Agreement**) documents the rights granted by contributors to Us. To
+make this document effective, please sign it and email the complete executed document to
+[dmitry@vexa.ai](mailto:dmitry@vexa.ai) with the relevant pull-request URL and covered GitHub
+identities. Do not post an executed document, signature, address, contributor roster, employment
+record, or private correspondence in a public repository, issue, or pull request. This is a legally
+binding document, so please read it carefully before agreeing to it. The Agreement may cover more
+than one software project managed by Us.
+
+## 1. Definitions
+
+**You** means any Legal Entity on behalf of whom a Contribution has been received by Us. **Legal
+Entity** means an entity which is not a natural person. **Affiliates** means other Legal Entities
+that control, are controlled by, or are under common control with that Legal Entity. For the
+purposes of this definition, **control** means (i) the power, direct or indirect, to cause the
+direction or management of such Legal Entity, whether by contract or otherwise, (ii) ownership of
+fifty percent (50%) or more of the outstanding shares or securities which vote to elect the
+management or other persons who direct such Legal Entity, or (iii) beneficial ownership of such
+entity.
+
+**Contribution** means any work of authorship that is Submitted by You to Us in which You own or
+assert ownership of the Copyright. If You do not own the Copyright in the entire work of authorship,
+identify each third-party portion in the pull request with its source, exact license and version,
+required notices, modifications, and known restrictions. Obtain any separate authorization We
+request before merge.
+
+**Copyright** means all rights protecting works of authorship owned or controlled by You or Your
+Affiliates, including copyright, moral, and neighboring rights, as appropriate, for the full term
+of their existence including any extensions by You.
+
+**Material** means the work of authorship which is made available by Us to third parties. When this
+Agreement covers more than one software project, the Material means the work of authorship to which
+the Contribution was Submitted. After You Submit the Contribution, it may be included in the
+Material.
+
+**Submit** means any form of electronic, verbal, or written communication sent to Us or our
+representatives, including but not limited to electronic mailing lists, source-code control systems,
+and issue-tracking systems that are managed by, or on behalf of, Us for the purpose of discussing
+and improving the Material, but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as **Not a Contribution**.
+
+**Submission Date** means the date on which You Submit a Contribution to Us.
+
+**Effective Date** means the date You execute this Agreement or the date You first Submit a
+Contribution to Us, whichever is earlier.
+
+**Media** means any portion of a Contribution which is not software.
+
+## 2. Grant of Rights
+
+### 2.1 Copyright License
+
+(a) You retain ownership of the Copyright in Your Contribution and have the same rights to use or
+license the Contribution which You would have had without entering into the Agreement.
+
+(b) To the maximum extent permitted by the relevant law, You grant to Us a perpetual, worldwide,
+non-exclusive, transferable, royalty-free, irrevocable license under the Copyright covering the
+Contribution, with the right to sublicense such rights through multiple tiers of sublicensees, to
+reproduce, modify, display, perform, and distribute the Contribution as part of the Material;
+provided that this license is conditioned upon compliance with Section 2.3.
+
+### 2.2 Patent License
+
+For patent claims, including without limitation method, process, and apparatus claims, which You or
+Your Affiliates own, control, or have the right to grant, now or in the future, You grant to Us a
+perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable patent license, with
+the right to sublicense these rights through multiple tiers of sublicensees, to make, have made,
+use, sell, offer for sale, import, and otherwise transfer the Contribution and the Contribution in
+combination with the Material (and portions of such combination). This license is granted only to
+the extent that the exercise of the licensed rights infringes such patent claims; and provided that
+this license is conditioned upon compliance with Section 2.3.
+
+### 2.3 Outbound License — Harmony Option One
+
+As a condition on the grant of rights in Sections 2.1 and 2.2, We agree to license the Contribution
+only under the terms of the license or licenses which We are using on the Submission Date for the
+Material, including any rights to adopt any future version of a license if permitted. The Vexa
+repository identified at <https://github.com/Vexa-ai/vexa> is licensed under the
+[Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) on the date of this
+candidate.
+
+No additional outbound license is selected for Media.
+
+### 2.4 Moral Rights
+
+If moral rights apply to the Contribution, to the maximum extent permitted by law, You waive and
+agree not to assert such moral rights against Us or our successors in interest, or any of our
+licensees, either direct or indirect.
+
+### 2.5 Our Rights
+
+You acknowledge that We are not obligated to use Your Contribution as part of the Material and may
+decide to include any Contribution We consider appropriate.
+
+### 2.6 Reservation of Rights
+
+Any rights not expressly licensed under this section are expressly reserved by You.
+
+## 3. Agreement
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You or Your Affiliates own the Copyright and patent claims covering the Contribution which are
+required to grant the rights under Section 2.
+
+(c) The grant of rights under Section 2 does not violate any grant of rights which You or Your
+Affiliates have made to third parties.
+
+(d) You have followed the non-owner instructions in the definition of Contribution if You do not
+own the Copyright in the entire work of authorship Submitted.
+
+## 4. Disclaimer
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED **AS IS**. MORE
+PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING, WITHOUT LIMITATION, ANY IMPLIED
+WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT ARE EXPRESSLY
+DISCLAIMED BY YOU TO US. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY
+IS LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+## 5. Consequential Damage Waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU BE LIABLE FOR ANY LOSS OF
+PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL,
+OR EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY
+(CONTRACT, TORT, OR OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+## 6. Miscellaneous
+
+### 6.1 Governing Law
+
+This Agreement will be governed by and construed in accordance with the laws of the State of
+Delaware, United States, excluding its conflicts-of-law provisions. Under certain circumstances,
+the governing law in this section might be superseded by the United Nations Convention on Contracts
+for the International Sale of Goods (**UN Convention**), and the parties intend to avoid the
+application of the UN Convention to this Agreement and thus exclude it in its entirety.
+
+### 6.2 Entire Agreement
+
+This Agreement sets out the entire agreement between You and Us for Your Contributions to Us and
+overrides all other agreements or understandings.
+
+### 6.3 Assignment
+
+If You or We assign the rights or obligations received through this Agreement to a third party, as
+a condition of the assignment, that third party must agree in writing to abide by all the rights
+and obligations in the Agreement.
+
+### 6.4 Waiver
+
+The failure of either party to require performance by the other party of any provision of this
+Agreement in one situation shall not affect the right of a party to require such performance at any
+time in the future. A waiver of performance under a provision in one situation shall not be
+considered a waiver of performance in the future or a waiver of the provision in its entirety.
+
+### 6.5 Severability
+
+If any provision of this Agreement is found void and unenforceable, such provision will be replaced
+to the extent possible with a provision that comes closest to the meaning of the original provision
+and which is enforceable. The terms and conditions set forth in this Agreement shall apply
+notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the
+maximum extent possible under law.
+
+## Signatures
+
+### You — contributing Legal Entity
+
+- Full legal name: ____________________________________________________________
+- Jurisdiction of formation: __________________________________________________
+- Registration or stable entity identifier: ___________________________________
+- Signatory name: _____________________________________________________________
+- Signatory title: ____________________________________________________________
+- Address: ___________________________________________________________________
+- Email: _____________________________________________________________________
+- Signature: __________________________________________________________________
+- Date: _______________________________________________________________________
+
+### Us — Vexa.ai Inc.
+
+- Name: Dmitry Grankin
+- Title: Chief Executive Officer
+- Address: 16192 Coastal Highway, Lewes, Delaware 19958, United States
+- Email: dmitry@vexa.ai
+- Signature: __________________________________________________________________
+- Date: _______________________________________________________________________
+
+## Configuration and attribution record
+
+This candidate is based on the
+[Harmony Entity Contributor License Agreement, Version 1.0](https://www.harmonyagreements.org/docs/ha-cla-e-v1.pdf),
+published 4 July 2011. The Harmony work is licensed under the
+[Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
+
+Vexa selected or substituted only the following template fields:
+
+| Harmony field or option | Vexa selection |
+|---|---|
+| `[PROJECT_NAME]` / We / Us | Vexa open-source project / Vexa.ai Inc. |
+| `[SUBMISSION_INSTRUCTIONS]` | Executed document to `dmitry@vexa.ai` with PR URL and covered GitHub identities; private material stays off GitHub |
+| `[NONOWNER_INSTRUCTIONS]` | Identify third-party portions, source, license/version, notices, modifications, and restrictions in the PR; obtain any separately requested authorization before merge |
+| Section 2.2 affiliate option | Included: `You or Your Affiliates` |
+| Section 2.3 outbound option | Harmony Option One: the license used for the Material on the Submission Date; currently Apache-2.0 |
+| Additional Media license | None |
+| `[JURISDICTION]` | State of Delaware, United States |
+| Signature fields | Vexa.ai Inc. identity and operational entity-identification fields |
+
+The DCO requirement, private corporate register, designated-contributor mapping, exact-PR/head
+receipt, amendment/termination administration, and merge gate are operational controls in
+[`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md). They are intentionally not custom clauses in
+this Harmony-based agreement.

--- a/CLA/README.md
+++ b/CLA/README.md
@@ -1,13 +1,43 @@
 # Corporate contribution authorization
 
-Do not commit executed agreements or personal information here. A contributor selects the
-corporate path in the pull-request template and emails [dmitry@vexa.ai](mailto:dmitry@vexa.ai)
-with the PR URL and the rights holder's legal/IP contact. Vexa then supplies the current
-counsel-approved corporate agreement or contribution-specific authorization through the private
-return channel.
+This directory is the canonical public distribution point for Vexa's blank corporate contributor
+agreement. Vexa does not require a rights holder to request a private copy before legal review can
+start.
 
-The public repository records only an opaque `VCR-YYYY-NNNN` receipt bound to the exact PR and
-head SHA. Agreement text is published here only after licensed counsel approves the exact version
-and SHA-256; until then, no repository draft is represented as an executable agreement.
+## Current blank agreement
+
+**No corporate agreement is currently published for signature.** The historical Vexa CCLA v1.0
+was not approved for use unchanged. Do not sign or rely on a copy obtained from repository history.
+
+The proposed replacement is a minimally configured
+[`Harmony Entity CLA v1.0 candidate`](Corporate_CLA.draft.md). It is public for review, not for
+signature or reliance. Founder approval can select it as Vexa's preferred candidate;
+licensed-counsel approval of the exact bytes and SHA-256 is still required before it becomes the
+current blank agreement.
+
+After licensed counsel approves the exact agreement, this section will identify:
+
+- the public blank agreement and its immutable GitHub blob URL;
+- its version, effective date, and SHA-256; and
+- the private return channel and expected acknowledgement time.
+
+That metadata is part of the signing packet. Any change to the agreement produces a new version
+and requires a new counsel approval and hash.
+
+## Corporate path
+
+1. Select **Employer/client authorization required** in the pull request and continue signing your
+   own commits under the DCO.
+2. If a current agreement is listed above, download that public blank form and have an authorized
+   representative of the rights holder review and sign it.
+3. Return the executed agreement privately to [dmitry@vexa.ai](mailto:dmitry@vexa.ai), with the
+   pull-request URL and the contributors it covers. If no agreement is listed, use the same address
+   to request a contribution-specific authorization route.
+4. Vexa verifies the legal entity, signer authority, contributor and contribution coverage before
+   recording an opaque receipt against the exact pull-request head.
+
+Do not commit or post executed agreements, signatures, addresses, contributor rosters, employment
+documents, legal contacts, or private correspondence. The public repository records only an opaque
+`VCR-YYYY-NNNN` receipt bound to the exact pull request and head SHA.
 
 See [`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md) for the complete policy and verifier format.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@ one-call roadmap fetch, claiming, and the session rules. Security reports: [`SEC
 
 Every new pull request selects exactly one rights path: independent, employer/client-controlled,
 or unsure. Independent contributors sign each commit under DCO 1.1 and do **not** sign an
-individual CLA. Corporate or uncertain contributions enter private rights review while technical
-review continues; only merge waits. Read [`CONTRIBUTOR_RIGHTS.md`](CONTRIBUTOR_RIGHTS.md) for the
-exact choices, `git commit --signoff` workflow, safe remediation commands, and corporate process.
+individual CLA. For employer/client-controlled work, Vexa's
+[`CLA/` agreement index](CLA/README.md) publishes the current counsel-approved blank corporate
+agreement when available; the executed copy and legal correspondence return privately. Technical
+review continues while authorization is completed; only merge waits. Read
+[`CONTRIBUTOR_RIGHTS.md`](CONTRIBUTOR_RIGHTS.md) for the exact choices, `git commit --signoff`
+workflow, safe remediation commands, and corporate process.

--- a/CONTRIBUTOR_RIGHTS.md
+++ b/CONTRIBUTOR_RIGHTS.md
@@ -32,13 +32,18 @@ success result.
 
 Choose this path when the contribution is assigned work, was prepared using controlled employer
 or client assets, is sponsored for upstream submission, or may otherwise be owned or controlled
-by another legal entity. Continue to sign your own commits under the DCO; Vexa will privately send
-the rights holder the current approved corporate agreement or a contribution-specific
-authorization. Technical review may continue while that happens, but merge waits.
+by another legal entity. Continue to sign your own commits under the DCO. Vexa publishes the
+current counsel-approved blank corporate agreement, when available, through the canonical
+[`CLA/` agreement index](CLA/README.md); a rights holder can download it without first asking Vexa
+for a private copy. Technical review may continue while authorization is completed, but merge
+waits.
 
-Start the private process by emailing [dmitry@vexa.ai](mailto:dmitry@vexa.ai) with the pull-request
-URL and the rights holder's legal/IP contact. Do not attach executed agreements, signatures,
-addresses, employment documents, or private correspondence to a public issue or pull request.
+Have an authorized representative return the executed agreement privately to
+[dmitry@vexa.ai](mailto:dmitry@vexa.ai), with the pull-request URL and the contributors it covers.
+If the agreement index says that no agreement is currently published, use the same address to
+request a contribution-specific authorization route. Do not attach executed agreements,
+signatures, addresses, contributor rosters, employment documents, legal contacts, or private
+correspondence to a public issue or pull request.
 
 ### Unsure
 
@@ -130,4 +135,6 @@ Before activating the gate, repository administrators must:
 3. replace `__BOOTSTRAP_PR__` with this policy PR's number;
 4. require the `contribution-rights` check, with the ruleset bypass list set to none; and
 5. verify the private register, retention rule, return channel, and exact corporate agreement hash
-   with licensed counsel.
+   with licensed counsel; and
+6. publish the approved blank agreement through `CLA/README.md`, including its immutable blob URL,
+   version, effective date, and SHA-256, without publishing any executed copy or personal data.

--- a/docs/adr/0034-contributor-rights-gate.md
+++ b/docs/adr/0034-contributor-rights-gate.md
@@ -13,10 +13,12 @@ corporate evidence because it can survive later pushes and does not identify a p
 
 New pull requests choose exactly one of three paths: independent, employer/client-controlled, or
 unsure. Independent contributors use DCO 1.1 per commit and no individual CLA. Corporate work uses
-the same individual DCO plus a private corporate agreement or narrow authorization. The public
-gate accepts only a designated verifier's opaque receipt decision naming the PR and exact head SHA.
-A push invalidates that verification. Rights review can proceed alongside technical review; merge
-is the only blocked transition.
+the same individual DCO plus a corporate agreement or narrow authorization. The current
+counsel-approved blank agreement and immutable version metadata are published through `CLA/`; only
+the executed instrument, personal data, and correspondence remain private. The public gate accepts
+only a designated verifier's opaque receipt decision naming the PR and exact head SHA. A push
+invalidates that verification. Rights review can proceed alongside technical review; merge is the
+only blocked transition.
 
 The maintained DCO App owns DCO identity/trailer verification. Vexa does not reproduce that logic
 with a regular expression and does not allow third parties or maintainers to sign for an author.
@@ -31,7 +33,8 @@ rewritten merely to add sign-offs.
 ## Consequences
 
 - The ordinary contributor makes one explicit legal choice and uses standard Git sign-off.
-- Corporate authorization becomes attributable, private, and invalidated by code changes.
+- Corporate terms are publicly reviewable without a request round trip; executed authorization
+  remains attributable, private, and invalidated by code changes.
 - DCO App installation, required-check configuration, a private register, and licensed-counsel
   approval of the corporate instrument remain activation prerequisites outside the repository.
 - A bootstrap PR can prove the deterministic machinery locally; a post-merge canary PR is required

--- a/docs/changelog.d/1007-public-corporate-cla-flow.md
+++ b/docs/changelog.d/1007-public-corporate-cla-flow.md
@@ -1,0 +1,5 @@
+- **Corporate contribution terms can be reviewed without a private-copy round trip (#1007).**
+  Vexa's contributor-rights guide now identifies the public blank-agreement index and keeps
+  executed agreements, signatures, and legal correspondence in the private return channel. The
+  proposed Harmony Entity CLA remains explicitly unavailable for signature until licensed counsel
+  approves its exact version.

--- a/docs/docs/governance/contributor-rights.mdx
+++ b/docs/docs/governance/contributor-rights.mdx
@@ -10,12 +10,16 @@ The canonical policy and operational commands live in
 | Path | Contributor action | Merge evidence |
 |---|---|---|
 | Independent | Select the declaration and sign each commit with `git commit --signoff` | Declaration plus the required DCO check; no individual CLA |
-| Employer/client-controlled | Select the corporate path and provide a legal/IP contact privately | Individual DCO plus a private authorization receipt bound to the current PR head |
+| Employer/client-controlled | Select the corporate path, download the current public blank agreement when available, and return the executed copy privately | Individual DCO plus a private authorization receipt bound to the current PR head |
 | Unsure | Select unsure as early as possible | Rights review resolves the path before merge |
 
 Technical review may continue during rights review. A later push invalidates a corporate
 verification, and only a designated verifier can bind a private receipt to the new head. Executed
 agreements, signatures, addresses, and employment information never belong in public PR comments.
+The canonical [`CLA/` agreement index](https://github.com/Vexa-ai/vexa/blob/main/CLA/README.md)
+publishes the current counsel-approved blank form and immutable version metadata when one is
+available; blank terms are public, while executed instruments and legal correspondence remain
+private.
 
 ## Agent-assisted flow
 

--- a/scripts/contribution-rights-gate.mjs
+++ b/scripts/contribution-rights-gate.mjs
@@ -7,10 +7,18 @@ const RIGHTS = ["independent", "corporate", "uncertain"];
 const DECISION_MARKER = "<!-- vexa-contribution-rights-decision:v1 -->";
 
 function selectedRights(body = "") {
+  const lines = body.split("\n");
   return RIGHTS.filter((right) => {
     const marker = `<!-- rights:${right} -->`;
-    const line = body.split("\n").find((candidate) => candidate.includes(marker)) || "";
-    return /^\s*-\s*\[[xX]\]/.test(line);
+    const markerIndex = lines.findIndex((candidate) => candidate.includes(marker));
+    if (markerIndex < 0) return false;
+    const markerLine = lines[markerIndex];
+    const checkboxLine = /^\s*-\s*\[[ xX]\]/.test(markerLine)
+      ? markerLine
+      : /^\s*<!-- rights:[a-z]+ -->\s*$/.test(markerLine) && markerIndex > 0
+        ? lines[markerIndex - 1]
+        : "";
+    return /^\s*-\s*\[[xX]\]/.test(checkboxLine);
   });
 }
 

--- a/scripts/contribution-rights-gate.test.mjs
+++ b/scripts/contribution-rights-gate.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { evaluatePullRequest, run } from "./contribution-rights-gate.mjs";
@@ -38,6 +39,17 @@ test("requires exactly one declaration", () => {
   assert.equal(evaluatePullRequest(pr({ body: body("none") }), [], config).ok, false);
   const multiple = `${body("independent")}`.replace("[ ] An employer", "[x] An employer");
   assert.equal(evaluatePullRequest(pr({ body: multiple }), [], config).ok, false);
+});
+
+test("the checked independent choice in the repository template is accepted", () => {
+  const template = readFileSync(new URL("../.github/pull_request_template.md", import.meta.url), "utf8");
+  const selected = template.replace("- [ ] **Independent:**", "- [x] **Independent:**");
+  assert.equal(evaluatePullRequest(pr({ body: selected }), [], config).ok, true);
+});
+
+test("a marker on the immediately following line remains compatible", () => {
+  const splitMarker = body("independent").replace(" <!-- rights:independent -->", "\n  <!-- rights:independent -->");
+  assert.equal(evaluatePullRequest(pr({ body: splitMarker }), [], config).ok, true);
 });
 
 test("independent path passes without a CLA", () => {

--- a/scripts/contribution-rights-policy.test.mjs
+++ b/scripts/contribution-rights-policy.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+test("the corporate path publishes blank terms and keeps executed records private", () => {
+  const index = read("CLA/README.md");
+  const policy = read("CONTRIBUTOR_RIGHTS.md");
+  const template = read(".github/pull_request_template.md");
+
+  assert.match(index, /canonical public distribution point/i);
+  assert.match(index, /Return the executed agreement privately/i);
+  assert.match(policy, /publishes the\s+current counsel-approved blank corporate agreement/i);
+  assert.match(template, /public blank-agreement index and private return/i);
+  assert.doesNotMatch(policy, /Vexa will privately send/i);
+});
+
+test("DCO check events cannot be cancelled by unrelated check completions", () => {
+  const workflow = read(".github/workflows/contribution-rights.yml");
+
+  assert.match(workflow, /github\.event\.check_run\.id/);
+  assert.match(workflow, /github\.run_id/);
+});
+
+test("an unavailable agreement is stated explicitly instead of exposing an unapproved draft", () => {
+  const index = read("CLA/README.md");
+  const candidate = read("CLA/Corporate_CLA.draft.md");
+
+  assert.match(index, /No corporate agreement is currently published for signature/i);
+  assert.match(index, /historical Vexa CCLA v1\.0\s+was not approved for use unchanged/i);
+  assert.match(index, /Do not sign or rely on a copy obtained from repository history/i);
+  assert.match(index, /Harmony Entity CLA v1\.0 candidate/i);
+  assert.match(candidate, /Not currently offered for signature/i);
+  assert.match(candidate, /Harmony Entity Contributor License Agreement, Version 1\.0/i);
+  assert.match(candidate, /Harmony Option One/i);
+  assert.match(candidate, /currently Apache-2\.0/i);
+  assert.doesNotMatch(candidate, /Harmony Option (?:Two|Three|Four|Five)/i);
+});


### PR DESCRIPTION
## What changed

- publish `CLA/README.md` as the canonical public blank-agreement index;
- add a Harmony Entity CLA v1.0 configuration candidate, explicitly **not offered for signature** until licensed counsel approves its exact bytes and SHA-256;
- keep executed agreements, signatures, contributor rosters, and legal correspondence private;
- update the PR template, contributor policy, ADR, contributor guide, and public governance docs;
- fix the `check_run` concurrency key so unrelated check completions cannot cancel the DCO event before `dco-no-override` is published;
- align the rights markers with their checkboxes and retain compatibility with the immediately-following-line form;
- add policy, parser/template, and concurrency regression coverage plus a contributor-facing changelog fragment.

Refs #1007 — the issue remains open because counsel activation and the real corporate-path canary are not completed by this PR.

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Observation bundle

Expected: a corporation can obtain the exact public blank terms without a private-copy round trip, while no unapproved agreement is presented for signature; the DCO policy receipt cannot be cancelled by unrelated repository check events; the checked repository template must be accepted by the parser.

Actual:

- `node --test scripts/contribution-rights-gate.test.mjs scripts/contribution-rights-policy.test.mjs` — 23/23 pass;
- `git diff --check` — pass;
- repository pre-push suite — all 14 static gates pass on both pushed commits;
- the first live PR run correctly exposed the template/parser marker mismatch; the signed follow-up commit fixes it without rewriting history;
- all GitHub machine checks are green on head `77c5a1b0eeec0eff0cc629df420388d160be15d9`;
- the maintainer applied `state: value-signed` to that unchanged head;
- full local `node scripts/gates.mjs all` was attempted: relevant/static gates passed, while local transcription health/pytest and Docker Compose readiness remained red due the checkout/runtime environment. GitHub CI is the authoritative full-suite result for this SHA.

Verdict: the public candidate/distribution choreography, DCO concurrency receipt, and actual-template parser path are ready for repository review. This PR does **not** activate the candidate as Vexa's signable corporate agreement and does not represent licensed-counsel approval.

## Security and privacy

No executed agreement, signature, address, private legal contact, contributor roster, or private correspondence is committed. Corporate verification remains an opaque receipt bound to the exact PR head.