### PR TITLE
docs: Lite deployment page + honest-status notes (#1046, #1048)

### DIFF
--- a/docs/docs/core/runtime.mdx
+++ b/docs/docs/core/runtime.mdx
@@ -75,7 +75,8 @@ workspace mount** — worker Pods get one `subPath` + `readOnly` volumeMount per
 against the store PVC (the same per-mount isolation the Docker backend enforces with volume-subpath
 binds). The in-cluster substrate — ServiceAccount + RBAC to create Pods, the store PVC — ships as the
 **Helm chart** in `deploy/helm`. The simplest self-hosted paths remain **Docker Compose** (`make all`)
-and the one-container **lite** (`make lite`) — see [Deployment](/deployment). Code:
+— see [Deployment](/deployment) — and the one-container **lite** (`make lite`) — see
+[Vexa Lite](/deployment-lite). Code:
 `core/runtime/src/runtime_kernel/k8s_backend.py` + `mounts.py:k8s_volume_mounts` (Pod spec) vs
 `docker_backend.py` (the reference bind + credential path).</Note>
 

--- a/docs/docs/deployment-lite.mdx
+++ b/docs/docs/deployment-lite.mdx
@@ -1,0 +1,121 @@
+---
+title: "Vexa Lite (single container)"
+description: "The whole control plane in one container — process runtime backend, no Docker socket, two datastore sidecars."
+---
+
+Vexa Lite packs every control-plane service into a single image (`vexaai/vexa-lite`) and runs
+bots and agent workers as **in-container processes** (`RUNTIME_BACKEND=process`) — no Docker
+socket, no per-bot containers. Two sidecars carry state: Postgres and MinIO. Lite is one of the
+three supported deploy paths (lite · [compose](/deployment) · [Kubernetes](/deployment-kubernetes))
+and ships from the same images and contracts.
+
+## Quick start
+
+```bash
+git clone https://github.com/Vexa-ai/vexa.git && cd vexa
+make lite
+```
+
+`make lite` (= `make -C deploy/lite all`) writes a minimal `.env` if you don't have one, pulls
+`vexaai/vexa-lite:$IMAGE_TAG` (default `v012`; a locally built `vexa-lite:dev` wins when present),
+starts the `vexa-lite-postgres` and `vexa-lite-minio` sidecars on the `vexa-lite-net` Docker
+network, boots the app container, waits on the gateway health endpoint, and probes the three
+front doors:
+
+| Front door | Port |
+|---|---|
+| **gateway** — the public REST API | `8056` |
+| **terminal** — the workbench UI | `3001` |
+| **agent-api** — the agent control plane (reached directly, not via the gateway) | `8100` |
+
+On first boot Lite mints its own credentials — a `self-host@vexa.ai` user and `bot,tx`-scoped API
+keys — and hands them to the terminal, so `http://localhost:3001` opens signed in. Set
+`VEXA_API_KEY` in `.env` to bring your own key and skip the minting.
+
+Transcription needs a backend: point `TRANSCRIPTION_SERVICE_URL` / `TRANSCRIPTION_SERVICE_TOKEN`
+at a [transcription unit](/deployment#transcription-the-separate-gpu-unit), or run the bundled
+CPU sidecar:
+
+```bash
+# CPU Whisper (faster-whisper tiny.en, English-only) on :8083 — for trying it, not for real meetings
+make -C deploy/lite up LOCAL_STT=1
+make -C deploy/lite stt-smoke   # synthesizes speech in a container, asserts a transcript comes back
+```
+
+Without a transcription backend, bots join and capture but produce no text — a default
+`POST /bots` answers `503` unless the spawn opts out
+([capture-only](/how-to/send-a-bot#capture-only-no-stt)).
+
+## What's in the container
+
+One supervisord tree runs the services a compose deployment spreads across containers:
+
+| Program | Role |
+|---|---|
+| **gateway** (`:8056`), **terminal** (`:3001`), **agent-api** (`:8100`) | the three published front doors |
+| **meeting-api, admin-api, runtime** | loopback-only (`127.0.0.1`) — reach them with `docker exec` |
+| **valkey** | in-container Redis-compatible store, loopback-only |
+| **Xvfb · fluxbox · pulseaudio · x11vnc · noVNC** | the shared virtual display and audio graph bots run on |
+
+Bots and agent workers are **not** supervisord programs — the runtime spawns them as child
+processes, one per meeting and per agent dispatch. Inspect a running deployment with:
+
+```bash
+docker logs -f vexa-lite                            # all service logs go to stdout
+docker exec vexa-lite supervisorctl status          # the service tree
+docker exec vexa-lite ps aux | grep dist/index.js   # live bot processes
+```
+
+## Configuration
+
+Lite reads the repo-root `.env` (via `docker run --env-file`) plus the flags the Makefile sets
+explicitly. Every key in the [configuration reference](/configuration) applies; mind its warning
+about inline `# comments` in `.env` values — it exists because of Lite's `--env-file` semantics.
+
+If `~/.claude/.credentials.json` exists on the host, `make lite` mounts it read-only into the
+container so agents run on your Claude subscription without copying credentials into `.env`.
+
+## Persistence and upgrade
+
+State lives in the sidecars' named volumes and survives app-container replacement:
+
+| Data | Where |
+|---|---|
+| Users, meetings, transcripts (Postgres) | volume `vexa-lite-pgdata` |
+| Recordings + agent workspaces (MinIO) | volume `vexa-lite-miniodata` |
+| Valkey state and `/workspaces` scratch | **in-container, ephemeral** — mount `/var/lib/redis` yourself if you need it kept |
+
+Upgrading is re-running with a newer image: set `IMAGE_TAG` in `.env` (pin a specific release so
+deploys are reproducible), then `make lite` again — it replaces the app container and leaves the
+sidecars and their volumes untouched. Schema converges in-process on service startup; there is no
+separate migration step.
+
+```bash
+make -C deploy/lite down                                # containers go, volumes stay
+docker volume rm vexa-lite-pgdata vexa-lite-miniodata   # full wipe
+```
+
+## Is this install actually working? — `make probe SURFACE=lite`
+
+```bash
+make probe SURFACE=lite
+```
+
+The probe mints a key and drives the whole journey — spawn → boot → join → transcribe →
+live-view → stop. Lite runs the **real** bot in-process, so a dead meeting URL ends in a truthful
+named failure, never a fake green. The container also carries a Docker `HEALTHCHECK` on the
+gateway's `/health` (30s interval, 120s start period).
+
+## Limits vs compose and Kubernetes
+
+- **One shared display.** Bots share a single Xvfb — best for one browser session at a time.
+  Compose isolates bots in containers; the Helm chart gives each bot its own Pod.
+- **Ephemeral Valkey.** In-container with no volume by default.
+- **Agent API is not gateway-fronted.** Clients reach `:8100` directly; gateway-fronting is
+  roadmap.
+- **No MCP service.** The compose stack's `/mcp` surface does not exist in Lite.
+- **Sidecar ports are unpublished.** Postgres and the MinIO console are reachable only on the
+  Docker network, not from the host.
+
+Outgrown it? Switch to [compose](/deployment) — same images, same contracts. Per-feature honest
+status: [Roadmap → Status](/roadmap/status).

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -4,7 +4,9 @@ description: "Self-host Vexa with Docker Compose — air-gapped, with bring-your
 ---
 
 Vexa runs **in your own environment** — open-source, self-hostable, air-gappable. Data, recordings, and
-agent state stay on infrastructure you control.
+agent state stay on infrastructure you control. This page is the Docker Compose path; the other two
+supported shapes are [Vexa Lite](/deployment-lite) (one container, no Docker socket) and
+[Kubernetes](/deployment-kubernetes) (Helm, a Pod per bot).
 
 ## Quick start (Docker Compose)
 

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -92,6 +92,7 @@
         "group": "Deployment & operations",
         "pages": [
           "deployment",
+          "deployment-lite",
           "deployment-kubernetes",
           "configuration",
           "authenticated-bots",
@@ -126,8 +127,7 @@
   "redirects": [
     {
       "source": "/vexa-lite-deployment",
-      "destination": "/quickstart",
-      "permanent": false
+      "destination": "/deployment-lite"
     },
     {
       "source": "/user_api_guide",
@@ -230,8 +230,7 @@
     },
     {
       "source": "/vexa-lite-deployment.md",
-      "destination": "/quickstart.md",
-      "permanent": false
+      "destination": "/deployment-lite.md"
     },
     {
       "source": "/websocket.md",

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -24,6 +24,9 @@ The only thing that changes between platforms is the `platform` value.
       -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
       -d '{"platform":"zoom","native_meeting_id":"81234567890","bot_name":"Vexa"}'
     ```
+
+    Zoom joins via the **web client** in 0.12.x; the native SDK / OBF-token path is not
+    carried and returns with the Zoom track — see [Roadmap → Status](/roadmap/status).
   </Tab>
   <Tab title="Microsoft Teams">
     ```bash

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -54,7 +54,7 @@ most coding agents).
 - [Meetings API](https://docs.vexa.ai/api/meetings.md): plan meetings, send bots, real-time transcripts, recordings
 - [Agent API](https://docs.vexa.ai/api/agent.md): dispatch units, chat turns, routines, workspace
 - [Errors](https://docs.vexa.ai/api/errors.md): status codes and shapes across both APIs
-- [Deployment](https://docs.vexa.ai/deployment.md): compose · lite · [Kubernetes](https://docs.vexa.ai/deployment-kubernetes.md)
+- [Deployment](https://docs.vexa.ai/deployment.md): compose · [Vexa Lite](https://docs.vexa.ai/deployment-lite.md) · [Kubernetes](https://docs.vexa.ai/deployment-kubernetes.md)
 - [Configuration](https://docs.vexa.ai/configuration.md): every env var and capability
 - [Troubleshooting](https://docs.vexa.ai/troubleshooting.md)
 

--- a/docs/docs/webhooks.mdx
+++ b/docs/docs/webhooks.mdx
@@ -1,0 +1,29 @@
+---
+title: "Webhooks"
+description: "User webhook delivery in 0.12.x — built and module-tested, unproven against a real external receiver."
+---
+
+<Warning>
+User webhooks are present in the codebase but have **never fired against a real external
+receiver** — module tests use an in-memory transport. Treat the feature as untested until a
+live delivery is proven. This page exists so the old `/webhooks` URL states that honestly
+instead of returning a 404 or redirecting to a page that implies a documented, working feature.
+</Warning>
+
+## What exists in code
+
+- Self-serve configuration (`PUT /user/webhook`): URL, secret, and event selection, with the
+  secret masked on read-back.
+- The `webhook.v1` delivery module: HMAC-signed payloads with a retry queue.
+
+## What has not been proven
+
+- No delivery has ever reached a real external receiver; all module tests run against an
+  in-memory transport.
+- There is no settings UI for webhook configuration.
+- Exactly-once emission and outage-durable retry are prepared as
+  [#519](https://github.com/Vexa-ai/vexa/issues/519) and
+  [#520](https://github.com/Vexa-ai/vexa/issues/520), whose acceptance tables carry the
+  live-receiver leg.
+
+The live status row for this feature is maintained on [Roadmap → Status](/roadmap/status).


### PR DESCRIPTION
**Delivers issue:** #1046, #1048

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. I am requesting Vexa's private corporate-authorization process. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Value

The top measured docs gap (`/vexa-lite-deployment`, ~2.8k views, no successor) gets its page, and two places where reader demand meets dropped/untested features get honest status instead of silence.

## Observation bundle

- **C1 — Lite page grounding:** read `deploy/lite/` end-to-end (Makefile, supervisord.conf, entrypoint.sh, probe.sh, bin/, tests/, Dockerfile.lite) before writing a word · saw the actual mechanics: `RUNTIME_BACKEND=process`, 13 supervisord programs, 3 published front doors (8056/3001/8100), pgdata+miniodata volumes, zero-login key mint, `IMAGE_TAG` default `v012` · concluded and documented **only what the code does**. Known tree discrepancies deliberately not documented: no `make lite-down` (doesn't exist — page teaches `make -C deploy/lite down`), no dashboard (not shipped in lite despite stale refs), no noVNC host access (EXPOSEd, never published).
- **C2 — Zoom line:** changelog carries the "not carried — web client only" verdict; `grep -rn ZOOM_SDK` across the tree → **0 hits** · the send-a-bot Zoom tab now carries the one dry line, matching `/roadmap/status` in substance.
- **C3 — webhooks stub:** verified `PUT/GET /user/webhook` exist (gateway → admin-api) and `webhook.v1` contract module exists; `/roadmap/status` row says "never fired against a real external receiver … treat as untested" · the stub at `/webhooks` states exactly that, hidden from nav (routable by URL, out of sidebar/search).

## Acceptance floor

| Row | Evidence |
|---|---|
| #1046 A1 (page end-to-end: run, configure, limits, upgrade) | `docs/docs/deployment-lite.mdx` — sections Quick start / What's in the container / Configuration / Persistence and upgrade / probe / Limits |
| #1046 A2 (registered in nav) | docs.json "Deployment & operations": `deployment` → **`deployment-lite`** → `deployment-kubernetes` |
| #1046 A3 (redirect repointed) | `/vexa-lite-deployment(.md)` → `/deployment-lite(.md)` (was `/quickstart`, `permanent:false` for exactly this) — asserted live post-deploy |
| #1048 A1 (Zoom tab status line) | send-a-bot Zoom tab, dry one-liner + `/roadmap/status` link |
| #1048 A2 (webhooks stub, /webhooks resolves to it) | page created **at** `/webhooks` — the retired URL serves the stub directly (and `/webhooks.md` rides Mintlify's `.md` layer); asserted live post-deploy |

## Docs diff (D6c)

This PR **is** docs: two new pages + three cross-link touches (`deployment.mdx`, `core/runtime.mdx`, `llms.txt` — the llms.txt lite entry pointed at `/deployment`, which had no lite content). Anchors used (`#transcription-the-separate-gpu-unit`, `#capture-only-no-stt`) verified as live `id=` attributes.

## Security checks

Docs-only. CodeQL/GitGuardian on the PR.

## Validation request

Post-deploy loop: `/deployment-lite` 200 + in nav, `/vexa-lite-deployment` → `/deployment-lite`, `/webhooks` 200 stub, `/webhooks.md` 200, Zoom tab line renders. Receipts land on #1046/#1048. Deployment validated: docs.vexa.ai (Mintlify auto-deploy from main).