### PR TITLE
docs: pin the MCP server card url to the canonical endpoint (#1047)

### DIFF
--- a/docs/docs/.well-known/mcp/server-card.json
+++ b/docs/docs/.well-known/mcp/server-card.json
@@ -1,0 +1,62 @@
+{
+  "name": "Vexa Docs MCP",
+  "description": "Search and retrieve Vexa documentation",
+  "version": "1.0.0",
+  "serverInfo": {
+    "name": "Vexa Docs MCP",
+    "version": "1.0.0"
+  },
+  "url": "https://docs.vexa.ai/mcp",
+  "transport": "http",
+  "capabilities": {
+    "tools": true,
+    "resources": true
+  },
+  "authentication": "none",
+  "tools": [
+    {
+      "name": "search_vexa",
+      "description": "Search across the Vexa knowledge base to find relevant information, code examples, API references, and guides. Use this tool when you need to answer questions about Vexa, find specific documentation, understand how features work, or locate implementation details. The search returns contextual content with titles and direct links to the documentation pages. If you need the full content of a specific page, use the query_docs_filesystem tool to `head` or `cat` the page path (append `.mdx` to the path returned from search — e.g. `head -200 /api-reference/create-customer.mdx`).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "A query to search the content with."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "query_docs_filesystem_vexa",
+      "description": "Run a read-only shell-like query against a virtualized, in-memory filesystem rooted at `/` that contains ONLY the Vexa documentation pages and OpenAPI specs. This is NOT a shell on any real machine — nothing runs on the user's computer, the server host, or any network. The filesystem is a sandbox backed by documentation chunks.\n\nThis is how you read documentation pages: there is no separate \"get page\" tool. To read a page, pass its `.mdx` path (e.g. `/quickstart.mdx`, `/api-reference/create-customer.mdx`) to `head` or `cat`. To search the docs with exact keyword or regex matches, use `rg`. To understand the docs structure, use `tree` or `ls`.\n\n**Workflow:** Start with the search tool for broad or conceptual queries like \"how to authenticate\" or \"rate limiting\". Use this tool when you need exact keyword/regex matching, structural exploration, or to read the full content of a specific page by path.\n\nSupported commands: rg (ripgrep), grep, find, tree, ls, cat, head, tail, stat, wc, sort, uniq, cut, sed, awk, jq, plus basic text utilities. No writes, no network, no process control. Run `--help` on any command for usage.\n\nEach call is STATELESS: the working directory always resets to `/` and no shell variables, aliases, or history carry over between calls. If you need to operate in a subdirectory, chain commands in one call with `&&` or pass absolute paths (e.g., `cd /api-reference && ls` or `ls /api-reference`). Do NOT assume that `cd` in one call affects the next call.\n\nExamples:\n- `tree / -L 2` — see the top-level directory layout\n- `rg -il \"rate limit\" /` — find all files mentioning \"rate limit\"\n- `rg -C 3 \"apiKey\" /api-reference/` — show matches with 3 lines of context around each hit\n- `head -80 /quickstart.mdx` — read the top 80 lines of a specific page\n- `head -80 /quickstart.mdx /installation.mdx /guides/first-deploy.mdx` — read multiple pages in one call\n- `cat /api-reference/create-customer.mdx` — read a full page when you need everything\n- `cat /openapi/spec.json | jq '.paths | keys'` — list OpenAPI endpoints\n\nOutput is truncated to 30KB per call. Prefer targeted `rg -C` or `head -N` over broad `cat` on large files. To read only the relevant sections of a large file, use `rg -C 3 \"pattern\" /path/file.mdx`. Batch multiple file reads into a single `head` or `cat` call whenever possible.\n\nWhen referencing pages in your response to the user, convert filesystem paths to URL paths by removing the `.mdx` extension. For example, `/quickstart.mdx` becomes `/quickstart` and `/api-reference/overview.mdx` becomes `/api-reference/overview`.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "A shell command to run against the virtualized documentation filesystem (e.g., `rg -il \"keyword\" /`, `tree / -L 2`, `head -80 /path/file.mdx`)."
+          }
+        },
+        "required": [
+          "command"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Delivers issue:** #1047

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. I am requesting Vexa's private corporate-authorization process. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Value

Every docs page's `link:` header points agents at `/.well-known/mcp/server-card.json`, whose `url` field advertises the internal Mintlify deploy alias (`vexa.main-kill-isr.mintlify.me/mcp`), not the canonical endpoint.

## Observation bundle

- **C1 — decision rule resolved:** POSTed an MCP `initialize` to `https://docs.vexa.ai/mcp` · saw a full handshake answer (HTTP 200, `serverInfo: Vexa`, tools+resources capabilities) · concluded the canonical endpoint works — per #1047's rule, the card gets **pointed there**, not removed.
- **C2 — config surface:** walked the entire Mintlify docs.json schema — zero keys control the server card (only `contextual` menu options mention MCP); Mintlify docs say the well-known discovery documents "require no configuration" and are auto-served. A fresh redeploy (post-#1051) did **not** regenerate the card with the custom domain — the alias is sticky.
- **C3 — the override experiment:** Mintlify's documented override mechanism is a static file at the project root (verified for robots.txt/sitemap.xml/llms.txt). This PR ships the card as a static asset — byte-identical to the generated one except `url` → `https://docs.vexa.ai/mcp`.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 (`link:` header shows canonical) | header already points at the (relative) card path; post-deploy: `curl -s https://docs.vexa.ai/.well-known/mcp/server-card.json | jq .url` must return `https://docs.vexa.ai/mcp` |
| A2 (endpoint answers a handshake) | verified pre-merge: canonical `/mcp` answers `initialize` (evidence on #1047) |

If the platform route wins over the static asset (post-deploy check), the card stays generated, this file gets reverted, and #1047 records that the fix is Mintlify-dashboard/support-side — honest either way.

## Docs diff (D6c)

Machine-surface-only; no content page.

## Security checks

Static JSON, no deps. CodeQL/GitGuardian on the PR.

## Validation request

Post-deploy `jq .url` check, recorded on #1047. Deployment: docs.vexa.ai.