### PR TITLE
carve: preserve the Vexum-surface de-robot across trains (vexa-platform#239)

### DIFF
--- a/carve/manifest.sh
+++ b/carve/manifest.sh
@@ -74,6 +74,14 @@ export CARVE_MAILMAP="$MONO/carve/mailmap.txt"
 # Each line: "<override-file-under-carve/overrides/>  <dest-path-in-carve>"
 export CARVE_OVERRIDES=(
   "Makefile:Makefile"          # compose-only entrypoint (mono's references removed deploy/lite)
+  # De-robot the Vexum surface (vexa-platform#239): docs.core.vexa.ai stays up for
+  # humans, invisible to robots. These four files + the docs.json seo transform in
+  # transform.sh are PROJECTION-ONLY — they must never appear in the mono's docs/docs
+  # (they would noindex docs.vexa.ai).
+  "docs-robots.txt:docs/docs/robots.txt"          # Disallow: / (replaces generated allow-all)
+  "docs-sitemap.xml:docs/docs/sitemap.xml"        # empty urlset (replaces 51-URL generated map)
+  "docs-llms.txt:docs/docs/llms.txt"              # Vexum-scoped stub → canonical docs.vexa.ai
+  "docs-llms-full.txt:docs/docs/llms-full.txt"    # same stub (generated one is the full 555KB dup)
 )
 
 # --- Deterministic transforms applied after materialize ----------------------

--- a/carve/overrides/docs-llms-full.txt
+++ b/carve/overrides/docs-llms-full.txt
@@ -1,0 +1,9 @@
+# Vexa — Vexum governance surface
+
+> docs.core.vexa.ai is the Vexum-governed FINOS contribution surface of Vexa, kept online for
+> human reviewers. It is intentionally excluded from search indexing and AI ingestion.
+
+The canonical documentation and the canonical machine index live at:
+
+- [Vexa documentation](https://docs.vexa.ai/)
+- [Canonical llms.txt](https://docs.vexa.ai/llms.txt)

--- a/carve/overrides/docs-llms.txt
+++ b/carve/overrides/docs-llms.txt
@@ -1,0 +1,9 @@
+# Vexa — Vexum governance surface
+
+> docs.core.vexa.ai is the Vexum-governed FINOS contribution surface of Vexa, kept online for
+> human reviewers. It is intentionally excluded from search indexing and AI ingestion.
+
+The canonical documentation and the canonical machine index live at:
+
+- [Vexa documentation](https://docs.vexa.ai/)
+- [Canonical llms.txt](https://docs.vexa.ai/llms.txt)

--- a/carve/overrides/docs-robots.txt
+++ b/carve/overrides/docs-robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/carve/overrides/docs-sitemap.xml
+++ b/carve/overrides/docs-sitemap.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>

--- a/carve/transform.sh
+++ b/carve/transform.sh
@@ -42,3 +42,18 @@ json.dump(d,open("package.json","w"),indent=2); open("package.json","a").write("
 PY
   fi
 fi
+
+# De-robot the Vexum surface (vexa-platform#239): noindex every docs.core.vexa.ai page.
+# PROJECTION-ONLY — pairs with the carve/overrides/docs-* files; the mono's docs.json
+# must never carry this key (it would noindex docs.vexa.ai).
+if [ -f docs/docs/docs.json ]; then
+  python3 - <<'PY'
+import json
+p = "docs/docs/docs.json"
+d = json.load(open(p))
+d["seo"] = {"metatags": {"robots": "noindex, nofollow"}}
+json.dump(d, open(p, "w"), indent=2)
+open(p, "a").write("\n")
+print("derobot: seo.metatags.robots=noindex,nofollow stamped on docs.json")
+PY
+fi


### PR DESCRIPTION
**Delivers issue:** Vexa-ai/vexa-platform#239 (C2, durability half)

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. I am requesting Vexa's private corporate-authorization process. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->

## Value

The de-robot of docs.core.vexa.ai landed live via vexa-core #38/#39 and is verified (robots `Disallow: /`, empty sitemap, Vexum-scoped `llms.txt`/`llms-full.txt`, `noindex, nofollow` meta on every page). But `docs/docs` in vexa-core is a carved projection — the **next owner-triggered carve train would silently overwrite all of it**. This PR encodes the de-robot in the carve layer, where the projection is defined, so every future train reproduces it deterministically.

## Change

- `carve/overrides/docs-{robots.txt,sitemap.xml,llms.txt,llms-full.txt}` + `CARVE_OVERRIDES` registrations — copied over the materialized tree each train.
- `carve/transform.sh` — stamps `seo.metatags.robots: "noindex, nofollow"` into the projected `docs/docs/docs.json`.

**Projection-only by construction:** nothing here lands in the mono's `docs/docs/`, so docs.vexa.ai's indexing is untouched (the failure mode this design prevents — a back-synced noindex would de-index the canonical site).

## Observation bundle

- **C1 —** the same four files + seo key, applied directly to vexa-core (#38/#39) · verified live on docs.core.vexa.ai (curl receipts on vexa-platform#239) · concluded the mechanism works; this PR is the same content routed through the carve layer.
- **C2 —** `bash -n` on both edited scripts · clean · transform block appends after the existing package.json hook, same python3-heredoc idiom as the CALM prune above it.

## Sequencing note

The primary checkout has uncommitted in-flight edits to `carve/manifest.sh` / `carve/transform.sh` (another session: a `bot-eval-README` override + CALM `DROP_PATHS` expansion + mailmap rows). This PR adds adjacent-but-distinct lines; that session rebases trivially. Flagged here per the hot-file rule.

## Security checks

Shell + static text, no deps. CodeQL/GitGuardian on the PR.

## Validation request

Real validation is the next carve train: after it runs, docs.core.vexa.ai must still serve the de-robot surfaces (the four curl checks on vexa-platform#239). Until then this is dormant config; the live state is already witnessed.