### PR TITLE
fix(gateway): let a bot-scoped key read its own meetings + transcripts (#1062) — TEMP PATCH pending #1066

### DIFF
--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -60,10 +60,18 @@ def _auth_unavailable_response(exc: Exception, *, span: str) -> Response:
 
 # Route-prefix → required scope set. Mirrors main.py ROUTE_SCOPES (main.py:59-65) for the CORE
 # surface the gateway lane carves; multi-scope tokens pass for any of their domains.
+#
+# #1062 — the headline flow "send a bot → read its transcript" must work with ONE key. A `bot`
+# scope therefore reads /meetings + /transcripts too (not only /recordings): these routes are
+# already USER-scoped downstream (the key resolves to a user_id and meeting-api returns ONLY that
+# user's rows), so accepting `bot` here lets a user read the data their OWN bot captured — it does
+# NOT let a bot key reach another user's meetings. The scope gate was redundantly strict on top of
+# the user-scoping. `tx` stays a valid transcription-only reader; /bots still requires `bot`/`browser`
+# (a `tx`-only key correctly 403s on /bots).
 ROUTE_SCOPES: Dict[str, Set[str]] = {
     "/bots": {"bot", "browser"},
-    "/transcripts": {"tx"},
-    "/meetings": {"tx"},
+    "/transcripts": {"tx", "bot"},
+    "/meetings": {"tx", "bot"},
     "/recordings": {"tx", "bot"},
 }
 

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -80,6 +80,73 @@ def test_insufficient_scope_is_403():
     assert "scope" in r.json()["detail"].lower()
 
 
+def _bot_only():
+    """A `bot`-scoped token (no `tx`) — the key a headless bot-runner holds."""
+    return FakeAuthorizer(user={"user_id": 7, "scopes": ["bot"], "max_concurrent": 1})
+
+
+def test_bot_scope_reads_own_meetings():
+    """#1062: the SAME key that spawns a bot must read that bot's meetings. A `bot`-scoped token on
+    GET /meetings now passes (was a 403 — /meetings required `tx` only), forwarding to meeting-api,
+    which owner-scopes the rows to this user_id. Fixes the "send a bot → can't list its meetings" gap."""
+    client, downstream = _client(authorizer=_bot_only())
+    r = client.get("/meetings", headers=AUTH)
+    assert r.status_code == 200
+    assert downstream.last["method"] == "GET"
+    assert downstream.last["url"].endswith("/meetings") and "meeting-api" in downstream.last["url"]
+    assert downstream.last["headers"]["x-user-id"] == "7"  # owner-scoped downstream, not client-set
+
+
+def test_bot_scope_reads_own_transcript_by_id():
+    """#1062: a `bot`-scoped token on GET /transcripts/by-id/{id} now passes (was 403 — /transcripts
+    required `tx` only). The by-row-id read is owner-scoped downstream, so the bot key reads ONLY the
+    transcript of a meeting this user owns. Completes the one-key "send a bot → read its transcript" flow."""
+    client, downstream = _client(authorizer=_bot_only())
+    r = client.get("/transcripts/by-id/1234", headers=AUTH)
+    assert r.status_code == 200
+    assert downstream.last["method"] == "GET"
+    assert downstream.last["url"].endswith("/transcripts/by-id/1234")
+    assert "meeting-api" in downstream.last["url"]
+
+
+def test_bot_scope_reads_own_native_transcript():
+    """#1062: same carve for the native-keyed transcript read GET /transcripts/{platform}/{native}."""
+    client, downstream = _client(authorizer=_bot_only())
+    r = client.get("/transcripts/google_meet/abc-defg-hij", headers=AUTH)
+    assert r.status_code == 200
+    assert downstream.last["url"].endswith("/transcripts/google_meet/abc-defg-hij")
+    assert "meeting-api" in downstream.last["url"]
+
+
+def test_bot_scope_still_reads_bots():
+    """#1062 regression guard: widening /meetings + /transcripts to accept `bot` must not affect
+    /bots — a `bot`-scoped token still reaches its own /bots routes."""
+    client, _ = _client(authorizer=_bot_only())
+    assert client.get("/bots/status", headers=AUTH).status_code == 200
+
+
+def test_tx_only_token_still_denied_on_bots():
+    """#1062 regression guard: the fix must NOT weaken /bots. A `tx`-only token (transcription-only)
+    still 403s on a /bots route — scopes stay a real boundary; only the redundant strictness on the
+    user-scoped read routes is removed. (Duplicates test_insufficient_scope_is_403 as an explicit
+    #1062 non-regression anchor.)"""
+    client, _ = _client(authorizer=FakeAuthorizer(user={"user_id": 7, "scopes": ["tx"], "max_concurrent": 1}))
+    r = client.get("/bots/status", headers=AUTH)
+    assert r.status_code == 403
+    assert "scope" in r.json()["detail"].lower()
+
+
+def test_tx_scope_still_reads_meetings_and_transcripts():
+    """#1062 regression guard: `tx` remains a valid reader of /meetings + /transcripts (the fix ADDs
+    `bot` alongside `tx`, it does not replace it) — the existing transcription-only integration path
+    is untouched."""
+    client, downstream = _client(authorizer=FakeAuthorizer(user={"user_id": 7, "scopes": ["tx"], "max_concurrent": 1}))
+    assert client.get("/meetings", headers=AUTH).status_code == 200
+    assert downstream.last["url"].endswith("/meetings")
+    assert client.get("/transcripts/by-id/1234", headers=AUTH).status_code == 200
+    assert downstream.last["url"].endswith("/transcripts/by-id/1234")
+
+
 def test_authed_request_passes_body_and_status_verbatim():
     """On success the downstream status + body are returned verbatim."""
     downstream = FakeDownstream(status_code=201, body={"id": 99, "platform": "google_meet"})

--- a/deploy/compose/tests/stack_test.py
+++ b/deploy/compose/tests/stack_test.py
@@ -171,11 +171,19 @@ def test_02_auth_surface(stack):
     code, body = http("GET", f"{stack.gateway}/meetings", headers={"x-api-key": "vxa_tx_not-a-real-token"})
     assert code == 401, f"invalid key → {code} {body}"
 
-    # REJECT out-of-scope → 403: a bot-only token on /meetings (which requires the tx scope).
+    # ACCEPT own-resource → 200: a bot-only token reads its own /meetings (#1062 — the key that
+    # captures a meeting owns its record; meetings are user-scoped upstream, so this exposes
+    # only the caller's own data).
     bot_only = _mint_token(stack, user_id, "bot")
     code, body = http("GET", f"{stack.gateway}/meetings", headers={"x-api-key": bot_only})
-    assert code == 403, f"out-of-scope bot token on /meetings → {code} {body}"
-    print(f"\n[2/auth] mint→accept(200)·missing(401)·invalid(401)·out-of-scope(403); proxy reached meeting-api")
+    assert code == 200 and isinstance(body, dict) and "meetings" in body, f"bot token on own /meetings → {code} {body}"
+
+    # REJECT out-of-scope → 403: a browser-only token on /meetings (requires tx or bot) — keeps
+    # the scope gate's negative case alive now that bot legitimately reads meetings.
+    browser_only = _mint_token(stack, user_id, "browser")
+    code, body = http("GET", f"{stack.gateway}/meetings", headers={"x-api-key": browser_only})
+    assert code == 403, f"out-of-scope browser token on /meetings → {code} {body}"
+    print(f"\n[2/auth] mint→accept(200)·missing(401)·invalid(401)·bot-own(200)·out-of-scope(403); proxy reached meeting-api")
 
 
 # ── 4. transcript dataflow (no meeting) ──────────────────────────────────────────────────────────

--- a/docs/docs/authentication.mdx
+++ b/docs/docs/authentication.mdx
@@ -66,9 +66,13 @@ is refused with `422` — never silently dropped.
 
 | Scope | Grants |
 |---|---|
-| `bot` | send and manage meeting bots, read transcripts |
-| `tx` | transcription / transcript access |
-| `browser` | browser-tool capabilities |
+| `bot` | send and manage meeting bots, **and read your own meetings, transcripts, and recordings** |
+| `tx` | read meetings, transcripts, and recordings (transcription-only reader — cannot send bots) |
+| `browser` | browser-tool capabilities (send and manage bots) |
+
+A single `bot` key completes the headline flow end to end — `POST /bots` → `GET /transcripts/by-id/{meeting_id}` —
+with no second key. Reads are always scoped to the caller's own meetings: a key never sees another
+user's data, whatever its scope.
 
 Keys are prefixed by their primary scope — `vxa_bot_…`, `vxa_tx_…`, `vxa_browser_…`. A key without a
 recognized scope is rejected.


### PR DESCRIPTION
## The bug (#1062)

The headline flow — **send a bot → read its transcript** — cannot be completed with a single API key, because `bot` and `tx` are mutually-exclusive scopes at the gateway. A user who holds a `bot`-scoped key to spawn bots gets 403'd when they try to list the resulting meetings or read the transcripts those bots produced.

### Reproduction (verified live 2026-08-08)

| Request | `bot`-scoped key | `tx`-scoped key |
|---|---|---|
| `GET /bots` | ✅ 200 | ❌ 403 |
| `POST /bots` | ✅ ok | ❌ 403 |
| `GET /recordings` | ✅ 200 | ✅ 200 |
| `GET /meetings` | ❌ **403** | ✅ 200 |
| `GET /transcripts/by-id/{id}` | ❌ **403** | ✅ 200 |

There is no single key that can both spawn a bot **and** read what it captured. That is the P0.

## Root cause

`ROUTE_SCOPES` in `core/gateway/services/gateway/src/gateway/app.py` gated `/meetings` and `/transcripts` on `{tx}` only:

```python
ROUTE_SCOPES = {
    "/bots":        {"bot", "browser"},
    "/transcripts": {"tx"},          # ← bot key 403s here
    "/meetings":    {"tx"},          # ← bot key 403s here
    "/recordings":  {"tx", "bot"},
}
```

`bot` is **intended** to read the meetings + transcripts of the bots it created (`tx` is a separate transcription-only scope). So this gate is a bug, not the intended boundary.

## The fix

Add `bot` alongside `tx` on `/meetings` and `/transcripts`:

```python
ROUTE_SCOPES = {
    "/bots":        {"bot", "browser"},
    "/transcripts": {"tx", "bot"},   # +bot
    "/meetings":    {"tx", "bot"},   # +bot
    "/recordings":  {"tx", "bot"},
}
```

### Why this is safe — the routes are already user-scoped

`/meetings` and `/transcripts` are **user-scoped downstream**: the gateway resolves the key to a `user_id`, injects `X-User-Id`, and meeting-api returns **only that user's** rows (the `/transcripts/by-id/{id}` route is owner-scoped per row — the same P0 cross-tenant fix already in the tree). So accepting `bot` on these prefixes lets a user read the data their **own** bot captured; it does **not** let a bot key read another user's meetings or transcripts. The scope gate was redundantly strict *on top of* the user-scoping that already enforces ownership.

`tx` stays a valid transcription-only reader (added `bot`, did not replace `tx`). `/bots` is unchanged and still requires `bot`/`browser` — a `tx`-only key correctly continues to 403 there.

> Note: the historical `services/api-gateway/main.py` this file was carved from is no longer in the tree, so `app.py`'s `ROUTE_SCOPES` is now the single live source — there is no second copy to drift against.

## Tests (all green)

Added to `core/gateway/services/gateway/tests/test_proxy.py`:

- ✅ `bot`-scoped token → `GET /meetings` now **passes** (was 403), forwards to meeting-api with `X-User-Id` injected.
- ✅ `bot`-scoped token → `GET /transcripts/by-id/{id}` and `GET /transcripts/{platform}/{native}` now **pass** (were 403).
- ✅ `bot`-scoped token → `GET /bots` still passes (regression guard).
- ✅ `tx`-only token → `/bots` still **403** (regression guard; preserves the existing `test_insufficient_scope_is_403` boundary).
- ✅ `tx`-scoped token → `/meetings` + `/transcripts` still pass (the fix adds `bot`, it does not remove `tx`).

Verified the new positive tests go **RED** against the unfixed `ROUTE_SCOPES` (`request_denied_scope … required:["tx"]`) and **GREEN** with the fix.

```
gateway suite:     117 passed, 1 xfailed
conformance suite:  84 passed
```

Run: `cd core/gateway/services/gateway && uv run pytest -q` (and `../conformance` likewise).

## Follow-up (design note — NOT in this PR)

The next step the founder wants is for **agents to attach custom metadata to meetings** so an agent can "own the data" for retrieve + search. The natural home is the existing `meeting.data` JSONB blob (`core/meetings/services/meeting-api/src/meeting_api/`), which already holds recording/config keys.

Proposed follow-on feature (separate issue, not this PR): a namespaced **`PATCH /meetings/{id}/metadata`** that writes under `data.custom.*` only — never clobbering the recording/config keys already in `data` — scoped so the **owning user's key** can write (same user-scoping this PR relies on for reads). This keeps agent-authored metadata isolated from system-managed meeting state and makes it addressable for later retrieve/search.

---

Fixes #1062. **Draft** — founder reviews before ready-for-review.

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. I am requesting Vexa's private corporate-authorization process. <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge. <!-- rights:uncertain -->