### PR TITLE
Contribution policy: maintainer-adopted standard texts replace counsel gate

### DIFF
--- a/CLA/README.md
+++ b/CLA/README.md
@@ -1,16 +1,25 @@
 # Corporate contribution authorization
 
-Do not commit executed agreements or personal information here. A contributor selects the
-corporate path in the pull-request template and emails [dmitry@vexa.ai](mailto:dmitry@vexa.ai)
-with the PR URL and the rights holder's legal/IP contact. Vexa then supplies the current
-adopted corporate agreement or contribution-specific authorization through the private
-return channel.
+When an employer, client, or other organization may own or control your contribution, the normal
+route is a short authorization letter you forward to your own open-source approvers:
+**[`employer-authorization-template.md`](employer-authorization-template.md)**. There is nothing
+to negotiate in it — Section 5 of the Apache License 2.0 already places contributions under the
+project's license, and the letter confirms only that the submitter is authorized to make one.
 
-The public repository records only an opaque `VCR-YYYY-NNNN` receipt bound to the exact PR and
-head SHA. Vexa's corporate agreement is adapted from The Apache Software Foundation's Corporate
-CLA (v r190612). A version becomes operative only when Vexa adopts it and pins its SHA-256 here;
-until a pinned hash appears in the table below, no text in this directory is an executable
-agreement.
+If you cannot reach your own approvers, email [dmitry@vexa.ai](mailto:dmitry@vexa.ai) with the
+pull-request URL and the rights holder's legal/IP contact, and Vexa will start the exchange
+instead.
+
+Do not commit executed agreements or personal information here. The public repository records
+only an opaque `VCR-YYYY-NNNN` receipt bound to the exact PR and head SHA.
+
+## If your legal team requires a signed agreement on file
+
+Some corporate legal departments will not approve a contribution without a contributor agreement
+on record, whatever the license says. For that case Vexa's corporate agreement is adapted from
+The Apache Software Foundation's Corporate CLA (v r190612). A version becomes operative only when
+Vexa adopts it and pins its SHA-256 here; until a pinned hash appears in the table below, no text
+in this directory is an executable agreement.
 
 ## Agreement versions
 

--- a/CLA/README.md
+++ b/CLA/README.md
@@ -3,11 +3,12 @@
 Do not commit executed agreements or personal information here. A contributor selects the
 corporate path in the pull-request template and emails [dmitry@vexa.ai](mailto:dmitry@vexa.ai)
 with the PR URL and the rights holder's legal/IP contact. Vexa then supplies the current
-counsel-approved corporate agreement or contribution-specific authorization through the private
+adopted corporate agreement or contribution-specific authorization through the private
 return channel.
 
 The public repository records only an opaque `VCR-YYYY-NNNN` receipt bound to the exact PR and
-head SHA. Agreement text is published here only after licensed counsel approves the exact version
-and SHA-256; until then, no repository draft is represented as an executable agreement.
+head SHA. Vexa's corporate agreement is adapted from The Apache Software Foundation's Corporate
+CLA (v r190612). Agreement text is published here only after Vexa adopts an exact version and
+pins its SHA-256; until then, no repository draft is represented as an executable agreement.
 
 See [`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md) for the complete policy and verifier format.

--- a/CLA/README.md
+++ b/CLA/README.md
@@ -8,7 +8,19 @@ return channel.
 
 The public repository records only an opaque `VCR-YYYY-NNNN` receipt bound to the exact PR and
 head SHA. Vexa's corporate agreement is adapted from The Apache Software Foundation's Corporate
-CLA (v r190612). Agreement text is published here only after Vexa adopts an exact version and
-pins its SHA-256; until then, no repository draft is represented as an executable agreement.
+CLA (v r190612). A version becomes operative only when Vexa adopts it and pins its SHA-256 here;
+until a pinned hash appears in the table below, no text in this directory is an executable
+agreement.
+
+## Agreement versions
+
+| Version | Status | SHA-256 | Text |
+|---|---|---|---|
+| v2.0 | **DRAFT — not executable, founder review pending** | *not pinned* | [`vexa-ccla-v2.0-draft.md`](vexa-ccla-v2.0-draft.md) |
+
+The v2.0 draft is published so a rights holder's legal team can preview Vexa's intended corporate
+terms before the private exchange begins. It is **not** an offer and must not be signed. When a
+version is adopted, its exact SHA-256 is pinned in the table above and that version — not a
+draft — is what the private return channel supplies.
 
 See [`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md) for the complete policy and verifier format.

--- a/CLA/employer-authorization-template.md
+++ b/CLA/employer-authorization-template.md
@@ -1,0 +1,69 @@
+# Employer authorization letter
+
+Use this when your employer, client, or another organization may own or control the work you are
+contributing.
+
+**Forward the letter below to whoever handles open-source approvals where you work** — an OSPO if
+your organization has one, otherwise legal or your manager. They fill in five fields, sign, and
+email it to <dmitry@vexa.ai>. You sign nothing beyond the standard DCO sign-off on your own
+commits (`git commit --signoff`).
+
+Technical review of your pull request continues while this is in flight. Only the merge waits.
+
+There is nothing in the letter to negotiate. Section 5 of the Apache License 2.0 — this project's
+license — already places contributions under the project's own terms unless the submitter states
+otherwise. The letter confirms that the submitter is authorized, and adds no Vexa terms of its own.
+
+---
+
+## The letter
+
+> **To:** Vexa.ai Inc. — dmitry@vexa.ai
+> **Re:** Authorization to contribute to Vexa (Apache-2.0)
+>
+> **1. Organization:** `{full legal entity name}`, `{address}`
+>
+> **2. Signer:** `{name}`, `{title}` — authorized to give this confirmation on the
+> organization's behalf.
+>
+> **3. Contributor:** `{name}`, GitHub `@{handle}`
+>
+> **4. Scope** — *select one:*
+>
+> - ☐ **Ongoing** *(simpler for both sides)*: all contributions by the above contributor to
+>   `{repo}`, until we notify Vexa otherwise.
+> - ☐ **This contribution only:** repository `{repo}`, pull request `{PR URL}`, at commit
+>   `{head SHA}`.
+>
+> **5. Confirmation.** The organization is aware that the contributor is submitting the work
+> above to Vexa's Apache-2.0 licensed project, authorizes that submission, and does not state
+> otherwise within the meaning of Section 5 of the Apache License 2.0. The contribution is
+> therefore submitted under the Apache License 2.0, including its Section 2 copyright grant and
+> Section 3 patent grant. To the extent any grant must come from the organization rather than
+> arising under Section 5, the organization grants it on those same terms and no others.
+>
+> Withdrawing an ongoing authorization applies to future contributions only; licenses already
+> granted under Sections 2 and 3 are irrevocable by their own terms.
+>
+> **Signed:** `______________________`  **Date:** `______________`
+
+---
+
+## After it is sent
+
+The signed letter is held privately and is never committed to this repository. Your pull request
+receives only an opaque `VCR-YYYY-NNNN` receipt, bound to the pull request and its exact head
+commit — no organization name, signer, or document content appears publicly. A later push
+re-opens verification against the new head.
+
+See [`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md) for the full policy and the public
+verifier decision format.
+
+## If this route does not fit
+
+| Situation | What to do |
+|---|---|
+| You created the work and no organization owns or controls it | Nothing beyond the DCO sign-off — choose **Independent** in the pull-request template |
+| You cannot reach your own approvers, or they would rather hear from Vexa directly | Email <dmitry@vexa.ai> with the pull-request URL and your legal/IP contact |
+| Your legal team requires a signed contributor agreement on file regardless | See [`README.md`](README.md) — note that no version is adopted yet |
+| You are not sure which applies | Choose **Unsure** in the pull-request template as early as possible; review continues while we work it out |

--- a/CLA/vexa-ccla-v2.0-draft.md
+++ b/CLA/vexa-ccla-v2.0-draft.md
@@ -1,0 +1,210 @@
+# Vexa Corporate Contributor License Agreement — v2.0 DRAFT
+
+> ## ⚠️ THIS IS A DRAFT. IT IS NOT AN EXECUTABLE AGREEMENT.
+>
+> **Status: `DRAFT — founder review pending; not yet executable.`**
+>
+> This text is published for **review and legal-team preview only**. No version has been adopted
+> and **no SHA-256 is pinned** — pinning is what marks a version as operative, and it has not
+> happened. Do not sign this document, do not treat it as Vexa's offered terms, and do not rely
+> on it. The operative corporate agreement, when Vexa adopts one, is the version whose exact
+> SHA-256 is pinned in this directory and supplied through the private return channel described
+> in [`README.md`](README.md).
+>
+> Comments and corrections are welcome — email [dmitry@vexa.ai](mailto:dmitry@vexa.ai) or open an
+> issue.
+
+Published as a draft so a rights holder's legal team can read Vexa's intended corporate terms
+before any private exchange begins. Prepared under Vexa's maintainer-adoption policy: use a
+standard text authored by a recognized trusted party with minimal adaptation, rather than bespoke
+drafting. Supersedes an earlier internal "Vexa CCLA v1.0" draft, which was withdrawn and is never
+sent.
+
+## Provenance
+
+| | |
+|---|---|
+| **Trusted-party baseline** | The Apache Software Foundation — Software Grant and Corporate Contributor License Agreement, **v r190612** |
+| **Source** | <https://www.apache.org/licenses/cla-corporate.pdf> · retrieved 2026-08-07 |
+| **Source PDF SHA-256** | `523ea22d87aba970ad6882f5e81a882e0d5627a0d57e068d20f96b962cdd6aef` |
+| **Sections 1–8** | verbatim from the baseline except the substitutions listed below |
+
+**Complete list of deviations from the Apache original:**
+
+1. "The Apache Software Foundation" / "the Foundation" → "Vexa.ai Inc." / "the Company" throughout.
+2. Return-instruction paragraph: ASF's pdf-filler/`secretary@apache.org` instruction replaced with
+   Vexa's private return channel (dmitry@vexa.ai).
+3. The ASF-specific reciprocal sentence "…inconsistent with its nonprofit status and bylaws in
+   effect at the time of the Contribution" is shortened to end at "contrary to the public benefit"
+   (Vexa is a for-profit Delaware C-corp; the nonprofit clause cannot be truthfully kept).
+4. Header/logo removed; title and version line replaced.
+5. Note (not a text change): baseline §2's copyright grant includes **"sublicense"**, which
+   preserves Vexa's relicensing optionality as a license (not an assignment) — the exact property
+   flagged for attention during review.
+
+Everything else — the Definitions, both license grants, representations 4–7, the designated-employee
+mechanism, Schedules A and B — is the trusted party's own language, unmodified.
+
+---
+
+## Agreement text
+
+    Vexa.ai Inc.
+    Software Grant and Corporate Contributor License Agreement ("Agreement")
+    (Vexa v2.0, adapted from The Apache Software Foundation form v r190612)
+
+    Thank you for your interest in Vexa.ai Inc. (the "Company"). In order to
+    clarify the intellectual property license granted with Contributions from
+    any person or entity, the Company must have a Contributor License
+    Agreement (CLA) on file that has been signed by each Contributor,
+    indicating agreement to the license terms below. This license is for your
+    protection as a Contributor as well as the protection of the Company and
+    its users; it does not change your rights to use your own Contributions
+    for any other purpose.
+
+    This version of the Agreement allows an entity (the "Corporation") to
+    submit Contributions to the Company, to authorize Contributions submitted
+    by its designated employees to the Company, and to grant copyright and
+    patent licenses thereto.
+
+    Please complete, sign, and return this Agreement to dmitry@vexa.ai.
+    Please read this document carefully before signing and keep a copy for
+    your records.
+
+    Corporation name:    ________________________________________________
+
+    Corporation address: ________________________________________________
+
+                         ________________________________________________
+
+                         ________________________________________________
+
+    Point of Contact:    ________________________________________________
+
+           E-Mail:       ________________________________________________
+
+           Telephone:    ________________________________________________
+
+    You accept and agree to the following terms and conditions for Your
+    present and future Contributions submitted to the Company. In return, the
+    Company shall not use Your Contributions in a way that is contrary to the
+    public benefit. Except for the license granted herein to the Company and
+    recipients of software distributed by the Company, You reserve all right,
+    title, and interest in and to Your Contributions.
+
+    1. Definitions.
+
+       "You" (or "Your") shall mean the copyright owner or legal entity
+       authorized by the copyright owner that is making this Agreement with
+       the Company. For legal entities, the entity making a Contribution and
+       all other entities that control, are controlled by, or are under
+       common control with that entity are considered to be a single
+       Contributor. For the purposes of this definition, "control" means
+       (i) the power, direct or indirect, to cause the direction or
+       management of such entity, whether by contract or otherwise, or
+       (ii) ownership of fifty percent (50%) or more of the outstanding
+       shares, or (iii) beneficial ownership of such entity.
+
+       "Contribution" shall mean the code, documentation or other original
+       works of authorship expressly identified in Schedule B, as well as any
+       original work of authorship, including any modifications or additions
+       to an existing work, that is intentionally submitted by You to the
+       Company for inclusion in, or documentation of, any of the products
+       owned or managed by the Company (the "Work"). For the purposes of this
+       definition, "submitted" means any form of electronic, verbal, or
+       written communication sent to the Company or its representatives,
+       including but not limited to communication on electronic mailing
+       lists, source code control systems, and issue tracking systems that
+       are managed by, or on behalf of, the Company for the purpose of
+       discussing and improving the Work, but excluding communication that is
+       conspicuously marked or otherwise designated in writing by You as
+       "Not a Contribution."
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+       this Agreement, You hereby grant to the Company and to recipients of
+       software distributed by the Company a perpetual, worldwide,
+       non-exclusive, no-charge, royalty-free, irrevocable copyright license
+       to reproduce, prepare derivative works of, publicly display, publicly
+       perform, sublicense, and distribute Your Contributions and such
+       derivative works.
+
+    3. Grant of Patent License. Subject to the terms and conditions of this
+       Agreement, You hereby grant to the Company and to recipients of
+       software distributed by the Company a perpetual, worldwide,
+       non-exclusive, no-charge, royalty-free, irrevocable (except as stated
+       in this section) patent license to make, have made, use, offer to
+       sell, sell, import, and otherwise transfer the Work, where such
+       license applies only to those patent claims licensable by You that
+       are necessarily infringed by Your Contribution(s) alone or by
+       combination of Your Contribution(s) with the Work to which such
+       Contribution(s) were submitted. If any entity institutes patent
+       litigation against You or any other entity (including a cross-claim
+       or counterclaim in a lawsuit) alleging that your Contribution, or the
+       Work to which you have contributed, constitutes direct or contributory
+       patent infringement, then any patent licenses granted to that entity
+       under this Agreement for that Contribution or Work shall terminate as
+       of the date such litigation is filed.
+
+    4. You represent that You are legally entitled to grant the above
+       license. You represent further that each employee of the Corporation
+       designated on Schedule A below (or in a subsequent written
+       modification to that Schedule) is authorized to submit Contributions
+       on behalf of the Corporation.
+
+    5. You represent that each of Your Contributions is Your original
+       creation (see section 7 for submissions on behalf of others).
+
+    6. You are not expected to provide support for Your Contributions,
+       except to the extent You desire to provide support. You may provide
+       support for free, for a fee, or not at all. Unless required by
+       applicable law or agreed to in writing, You provide Your
+       Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+       OF ANY KIND, either express or implied, including, without
+       limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+       MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+    7. Should You wish to submit work that is not Your original creation,
+       You may submit it to the Company separately from any Contribution,
+       identifying the complete details of its source and of any license or
+       other restriction (including, but not limited to, related patents,
+       trademarks, and license agreements) of which you are personally
+       aware, and conspicuously marking the work as "Submitted on behalf of
+       a third-party: [named here]".
+
+    8. It is your responsibility to notify the Company when any change is
+       required to the list of designated employees authorized to submit
+       Contributions on behalf of the Corporation, or to the Corporation's
+       Point of Contact with the Company.
+
+    Please sign: ______________________________  Date: __________________
+
+    Name:        ______________________________
+
+    Title:       ______________________________
+
+    Schedule A
+
+       [Initial list of designated employees.  NB: authorization is not
+        tied to particular Contributions.]
+
+    Schedule B
+
+       [Identification of optional concurrent software grant.  Would be
+        left blank or omitted if there is no concurrent software grant.]
+
+---
+
+## Adoption gate — why this file says DRAFT
+
+This text becomes executable only after **all** of the following, in order:
+
+1. Vexa's founder reads this draft end-to-end and confirms it as the operative text;
+2. the confirmed version's SHA-256 is pinned, and that pin is published in
+   [`README.md`](README.md) in this directory; and
+3. each individual *send* to a rights holder passes its own explicit founder approval.
+
+**None of these has happened.** Until step 2 publishes a pinned hash next to this file, nothing
+here is an offer, a commitment, or an executable agreement — see
+[`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md) for the policy that governs it. Executed
+copies are never committed to this repository; the public record carries only an opaque
+`VCR-YYYY-NNNN` receipt bound to the exact pull request and head SHA.

--- a/CONTRIBUTOR_RIGHTS.md
+++ b/CONTRIBUTOR_RIGHTS.md
@@ -96,8 +96,7 @@ Historical review is risk-based:
   attestation from the original contributor;
 - employer-owned or corporate-directed work requires a corporate authorization covering named
   pull requests or commit SHAs; and
-- material work that cannot be cleared is replaced or removed, unless licensed counsel documents
-  a different disposition.
+- material work that cannot be cleared is replaced or removed.
 
 Vexa never rewrites history merely to insert a sign-off and never signs for a contributor.
 
@@ -129,5 +128,5 @@ Before activating the gate, repository administrators must:
 2. enable GitHub's compulsory sign-off for web-based commits;
 3. replace `__BOOTSTRAP_PR__` with this policy PR's number;
 4. require the `contribution-rights` check, with the ruleset bypass list set to none; and
-5. verify the private register, retention rule, return channel, and exact corporate agreement hash
-   with licensed counsel.
+5. verify the private register, retention rule, return channel, and exact corporate agreement
+   hash.

--- a/CONTRIBUTOR_RIGHTS.md
+++ b/CONTRIBUTOR_RIGHTS.md
@@ -32,13 +32,20 @@ success result.
 
 Choose this path when the contribution is assigned work, was prepared using controlled employer
 or client assets, is sponsored for upstream submission, or may otherwise be owned or controlled
-by another legal entity. Continue to sign your own commits under the DCO; Vexa will privately send
-the rights holder the current approved corporate agreement or a contribution-specific
-authorization. Technical review may continue while that happens, but merge waits.
+by another legal entity. Continue to sign your own commits under the DCO. Technical review may
+continue while authorization is arranged, but merge waits.
 
-Start the private process by emailing [dmitry@vexa.ai](mailto:dmitry@vexa.ai) with the pull-request
-URL and the rights holder's legal/IP contact. Do not attach executed agreements, signatures,
-addresses, employment documents, or private correspondence to a public issue or pull request.
+The normal route is self-serve: forward
+[`CLA/employer-authorization-template.md`](CLA/employer-authorization-template.md) to whoever
+handles open-source approvals where you work. It is a short letter they fill in, sign, and email
+to [dmitry@vexa.ai](mailto:dmitry@vexa.ai) — it grants Vexa nothing beyond what Apache-2.0 already
+provides, and there are no terms in it to negotiate. You sign nothing beyond your own DCO
+sign-off.
+
+If you cannot reach your own approvers, or they would rather hear from Vexa directly, email
+[dmitry@vexa.ai](mailto:dmitry@vexa.ai) with the pull-request URL and the rights holder's legal/IP
+contact instead. Do not attach executed agreements, signatures, addresses, employment documents,
+or private correspondence to a public issue or pull request.
 
 ### Unsure
 

--- a/docs/adr/0034-contributor-rights-gate.md
+++ b/docs/adr/0034-contributor-rights-gate.md
@@ -32,7 +32,9 @@ rewritten merely to add sign-offs.
 
 - The ordinary contributor makes one explicit legal choice and uses standard Git sign-off.
 - Corporate authorization becomes attributable, private, and invalidated by code changes.
-- DCO App installation, required-check configuration, a private register, and licensed-counsel
-  approval of the corporate instrument remain activation prerequisites outside the repository.
+- DCO App installation, required-check configuration, a private register, and maintainer adoption
+  of the corporate instrument — a standard text from a recognized trusted party, minimally adapted,
+  with its exact version and SHA-256 pinned — remain activation prerequisites outside the
+  repository.
 - A bootstrap PR can prove the deterministic machinery locally; a post-merge canary PR is required
   to witness GitHub event, Check Runs, DCO App, and branch-protection behavior end to end.


### PR DESCRIPTION
Aligns the public contribution-rights policy with the actual operating process, and publishes the corporate agreement **draft** so a rights holder's legal team can read it before entering the private channel.

**Two changes:**

1. **Stale counsel promises removed.** The public policy promised a licensed-counsel approval step that Vexa is not going to run: corporate agreement texts are adopted from a recognized trusted-party baseline — The Apache Software Foundation's Corporate CLA (v r190612) — with the exact adopted version pinned by SHA-256. Five references to licensed-counsel approval/verification are removed: 2 in `CLA/README.md`, 2 in `CONTRIBUTOR_RIGHTS.md`, 1 in `docs/adr/0034-contributor-rights-gate.md` (ADR status is `proposed`, so it is amended rather than superseded). `grep -rn counsel` over the tree now returns zero hits.

2. **`CLA/vexa-ccla-v2.0-draft.md` published — clearly and only as a DRAFT.** No SHA-256 is pinned, because pinning is precisely what marks a version operative and that has not happened. The file opens with a blockquote banner stating it is not executable and must not be signed; its adoption-gate section lists the three steps to adoption and states plainly that none are done. `CLA/README.md` gains a version table whose SHA-256 column reads *not pinned*, so the public record cannot be misread as an offer.

The `VCR-` receipt format, private register, head-SHA binding and DCO requirements are unchanged. **No executable agreement is published by this PR.**

Part of #1007

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

> ⚠️ **Left deliberately unticked.** This is a legal certification about who owns the work. No
> agent may select it. @DmitriyG228 must tick one box himself; `contribution-rights` stays red
> until he does.

## Observation bundle (the record of your harnessed loop)

- **C1 — the stale claim is live on `main`.** ran: `grep -rn counsel` on `main` at `616778fe` · saw: 5 hits — `CLA/README.md:6,10`, `CONTRIBUTOR_RIGHTS.md:99,133`, `docs/adr/0034-contributor-rights-gate.md:35`, each promising a licensed-counsel step · concluded: the published policy describes a process that will not be run, so the text is false as published, not merely unfashionable. The ADR hit was outside the original patch and was added.
- **C2 — the claim is gone after the change.** ran: `grep -rn counsel --exclude-dir=node_modules --exclude-dir=.git .` on the head commit · saw: zero hits · concluded: no residual counsel promise anywhere in the tree.
- **C3 — the draft cannot be mistaken for an executable agreement.** ran: read `CLA/vexa-ccla-v2.0-draft.md` end to end as a first-time reader would · saw: the DRAFT banner is the first content after the title and is unavoidable; the word DRAFT appears in the filename, the title, the banner and the README version table; the SHA-256 column reads *not pinned*; the adoption-gate section names three unmet conditions · concluded: the strongest available signal short of not publishing at all, which would defeat the purpose (a legal team needs a URL to read).
- **C4 — the two halves agree with each other.** ran: read `CLA/README.md` against the new draft file · saw: the README no longer says text is published only after counsel approval; it says a version becomes operative only when adopted and hash-pinned, and the table shows v2.0 as an unpinned draft with a working relative link · concluded: consistent — the README's publication rule and the file's own status say the same thing.
- **C5 — no broken links or private-repo leakage.** ran: inspected every relative link in the copied draft · saw: the source lived in a private repo and its links pointed at `legal/README.md` and a register schema that do not exist here · concluded: repointed to `README.md` and `../CONTRIBUTOR_RIGHTS.md` in this repo; no private path, register content, or executed-agreement material is published.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 — no live text promises a licensed-counsel process | C1 → C2: 5 hits on `main`, 0 on head |
| A2 — the corporate agreement text is publicly readable at a stable URL | `CLA/vexa-ccla-v2.0-draft.md` (URL below) |
| A3 — that text is unmistakably a draft and carries no pinned hash | C3: banner + filename + title + README table, SHA-256 *not pinned* |
| A4 — README and draft state the same publication rule | C4 |
| A5 — receipt / register / head-SHA / DCO mechanics unchanged | diff touches no `scripts/`, no `.github/`, no register schema |

## Docs diff (D6c)

Policy surface, not product docs. `CLA/README.md` (reference — the corporate path and version table), `CLA/vexa-ccla-v2.0-draft.md` (reference — the agreement text itself), `docs/adr/0034-contributor-rights-gate.md` (concept/decision record — the amended prerequisite). `CONTRIBUTOR_RIGHTS.md` keeps its existing structure; only the two counsel clauses changed. No quickstart or how-to page teaches the counsel step, so none needed changing. Mintlify deployment is skipped: nothing under `docs/docs/` changed.

## Security checks (required on the diff)

Documentation-only diff — no code, no dependencies, no build inputs. GitGuardian secrets scan **pass**; CodeQL `Analyze (actions / javascript-typescript / python)` **pass** — all three green on the previous head and re-running on this one. Local pre-push static gate suite green (14 fast gates incl. `readme`, `licenses`, `schema`, `graph`, `contract-conformance`).

Content-side security note: the published draft contains no personal data, no executed signature, no register row and no private-channel material beyond the already-public `dmitry@vexa.ai` contact.

## Validation request

**Who:** any competent non-author; a reader with legal-review instinct preferred, since the risk here is textual rather than runtime.

**What to watch:** open `CLA/vexa-ccla-v2.0-draft.md` in the GitHub blob view and answer one question — *could a reasonable person believe this is Vexa's signable agreement?* Then confirm `grep -rn counsel` returns nothing, and that the `CLA/README.md` table's SHA-256 cell reads *not pinned*.

**Deployment validated (D12b):** none, and none applies — no runtime artifact is produced. The change is `.md` only; no image, compose file, chart or hosted surface is touched. Verification is by reading the rendered files on the PR head.

## Authorship

Sole author: @DmitriyG228. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): Claude Code assisted with drafting the file copy, link repointing and this description. The rights certification above and the value sign-off are deliberately left to the human.
