### PR TITLE
fix(zoom): detect auth_session_missing as a typed join-failure (#1061)

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/zoom/session.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -156,4 +156,10 @@ export {
 } from "./msteams/auth-redirect";
 export type { TeamsJoinRedirectReason } from "./msteams/auth-redirect";
 export { joinZoomMeeting, buildZoomWebClientUrl, waitForZoomMeetingAdmission, checkForZoomAdmissionSilent, leaveZoomMeeting, dismissZoomPopups, startZoomRemovalMonitor };
+// The Zoom dead-profile guard (#1061). ZoomAuthSessionError is an AdmissionError subclass, so the
+// JoinDriver's existing `instanceof` catch already maps it to the PERMANENT `auth_session_missing`;
+// it is exported so an embedder can tell "OUR credential is dead" (platform-owned, pages an
+// operator) apart from the host-policy sign-in wall that shares the sealed reason.
+export { ZoomAuthSessionError, classifyZoomSession, ZOOM_AUTH_SESSION_MISSING } from "./zoom/session";
+export type { ZoomSessionObservation, ZoomSessionVerdict, ZoomSignedOutSignal } from "./zoom/session";
 export { joinJitsiMeeting, buildJitsiMeetingUrl, waitForJitsiMeetingAdmission, checkForJitsiAdmissionSilent, leaveJitsiMeeting, startJitsiRemovalMonitor };

--- a/core/meetings/modules/join/src/zoom/README.md
+++ b/core/meetings/modules/join/src/zoom/README.md
@@ -2,5 +2,10 @@
 
 Enter a Zoom meeting via the **web client only** (`buildZoomWebClientUrl` → join). No
 native Zoom SDK (proprietary, Cat-X under P17 — deliberately not promoted). `join.ts`,
-`admission.ts`, `leave.ts` (popup dismissal), `removal.ts`, `selectors.ts`. Imports host
-symbols from `../_host`, `playwright`, and Node builtins only.
+`admission.ts`, `leave.ts` (popup dismissal), `removal.ts`, `selectors.ts`, `session.ts`.
+Imports host symbols from `../_host`, `playwright`, and Node builtins only.
+
+`session.ts` is the **dead-profile guard** (#1061): in authenticated mode it decides whether
+the restored Zoom profile is still signed in, and throws the typed, PERMANENT
+`auth_session_missing` when it is not — a state that otherwise surfaces minutes later as a
+nameless join-button timeout. Detection only; re-authenticating the profile is follow-up work.

--- a/core/meetings/modules/join/src/zoom/join.ts
+++ b/core/meetings/modules/join/src/zoom/join.ts
@@ -8,7 +8,9 @@ import {
   zoomPreviewMuteSelector,
   zoomPreviewVideoSelector,
   zoomPermissionDismissSelector,
+  zoomSignInWallTexts,
 } from "./selectors";
+import { assertZoomAuthSession } from "./session";
 
 // NOTE vs the monolith: the audio-join flow (prepareZoomWebMeeting) and the
 // per-speaker capture pipeline are RECORDING/HOST concerns and stay outside
@@ -125,17 +127,12 @@ export async function joinZoomMeeting(
     // a field that never appears. Detect early and fail fast with a
     // structured reason so the host receives auth_required, not a
     // generic timeout.
-    const authRequired = await page.evaluate(() => {
+    // The phrase list moved to selectors.ts (#1061) so this guest-mode probe and the
+    // authenticated-mode dead-profile guard read the SAME wall text — one source of truth.
+    const authRequired = await page.evaluate((phrases: string[]) => {
       const body = (document.body?.innerText || '').toLowerCase();
-      const signInIndicators = [
-        'sign in to join this meeting',
-        'sign in to join',
-        'authentication is required',
-        'only authenticated users can join',
-        'this meeting requires authentication',
-      ];
-      return signInIndicators.some(s => body.includes(s));
-    }).catch(() => false);
+      return phrases.some(s => body.includes(s.toLowerCase()));
+    }, zoomSignInWallTexts).catch(() => false);
     if (authRequired && !authenticated) {
       log('[Zoom Web] Sign-in page detected — meeting requires authenticated users');
       // PERMANENT: the host restricted entry to signed-in users and this bot has no session — a
@@ -143,9 +140,10 @@ export async function joinZoomMeeting(
       // path uses; the retry classifier already treats it as no-retry.
       throw new AdmissionError('auth_session_missing', '[Zoom Web] auth_required: meeting host has restricted entry to authenticated Zoom users; bot cannot join without a Zoom account session');
     }
-    if (authRequired && authenticated) {
-      log('[Zoom Web] Authenticated mode: sign-in text present, proceeding (the persistent context should already carry a Zoom session)');
-    }
+    // NB: authenticated mode does NOT decide here. The same wall text means something different
+    // when we hold a profile (a DEAD profile, #1061), and the sign-in REDIRECT variant carries no
+    // wall text at all — so authenticated mode is adjudicated once, by the guard below, on the
+    // page we actually settle on.
 
     if (!isError) break; // Pre-join page loaded
 
@@ -156,6 +154,13 @@ export async function joinZoomMeeting(
     log(`[Zoom Web] Host not started yet (title="${title}"). Retrying in ${HOST_NOT_STARTED_RETRY_INTERVAL_MS / 1000}s...`);
     await page.waitForTimeout(HOST_NOT_STARTED_RETRY_INTERVAL_MS);
   }
+
+  // #1061 — authenticated mode only: is the profile we restored actually still signed in?
+  // A dead profile is PERMANENT (a re-spawn restores the same dead cookies), so it must be named
+  // here, before we spend the join budget on a pre-join page that can never enable Join. Runs on
+  // the settled page so it sees BOTH shapes of the state: the sign-in redirect (no wall text) and
+  // the sign-in wall (no redirect). Not-signed-out returns quietly and the join proceeds as before.
+  if (authenticated) await assertZoomAuthSession(page, 'pre_join_load');
 
   // Notify the host: joining
   await callJoiningCallback(botConfig);
@@ -280,6 +285,11 @@ export async function joinZoomMeeting(
       if (current) {
         log(`[Zoom Web] Signed-in name pre-filled ("${current}") — using account identity`);
       } else {
+        // #1061 — an EMPTY name field in authenticated mode is the GUEST lobby's shape: Zoom stopped
+        // recognising the account and is asking us who we are. The guard convicts only when the
+        // account cookie is provably gone too, so an ambiguous empty field still falls through to
+        // the pre-existing fallback below rather than refusing a legitimate join.
+        await assertZoomAuthSession(page, 'pre_join_name_field');
         await nameField.click({ timeout: 5000 }).catch(() => {});
         await page.keyboard.type(botName, { delay: 30 });
         log(`[Zoom Web] Signed-in name field empty — typed fallback "${botName}"`);

--- a/core/meetings/modules/join/src/zoom/selectors.ts
+++ b/core/meetings/modules/join/src/zoom/selectors.ts
@@ -84,6 +84,33 @@ export const zoomBotBlockTexts = [
   "sign in to join",
 ];
 
+// ---- Sign-in wall / dead-profile signal (#1061) ----
+// Zoom asks for a sign-in in TWO different situations, and the page text is the
+// same in both:
+//   (a) guest mode + the host enabled "Only authenticated users can join" — the
+//       meeting's policy, nothing wrong on our side;
+//   (b) AUTHENTICATED mode (BOT_AUTHENTICATED=true, a persistent profile restored
+//       from userdata) whose Zoom session has EXPIRED — the profile is signed out,
+//       so Zoom treats the bot as a guest and asks it to sign in.
+// (b) is the dead-profile defect: it is permanent (a re-spawn restores the same
+// dead profile) and platform-owned. Which of the two is in play is decided by
+// `botConfig.authenticated`, not by the text — see session.ts.
+// Case-insensitive substring match against document.body.innerText.
+export const zoomSignInWallTexts = [
+  'sign in to join this meeting',
+  'sign in to join',
+  'authentication is required',
+  'only authenticated users can join',
+  'this meeting requires authentication',
+];
+
+// A canonical-Zoom URL carrying one of these path markers means the web client
+// bounced us to the account sign-in flow — the same markers @vexa/remote-browser's
+// session validator keys "are we still logged in?" on. Matched ONLY on zoom.us /
+// *.zoom.us: a white-label portal (LFX, corporate) can legitimately have /login in
+// its own path while our Zoom session is perfectly alive.
+export const zoomSignInUrlMarkers = ['/signin', '/login'];
+
 // ---- Leave dialog (after clicking Leave button) ----
 // Verified from live DOM: the "Leave Meeting" button has class leave-meeting-options__btn--danger
 // aria-label is empty so text-based selectors are unreliable; use the CSS class directly

--- a/core/meetings/modules/join/src/zoom/session.test.ts
+++ b/core/meetings/modules/join/src/zoom/session.test.ts
@@ -1,0 +1,262 @@
+/**
+ * #1061 — the Zoom dead-profile guard, pinned in the ACTUAL join path.
+ *
+ * THE DEFECT: on hosted prod every `auth_session_missing` in the release is Zoom (4 of 23 Zoom
+ * meetings; no other platform produces the reason). The reason is PERMANENT by design, so a bot
+ * profile whose Zoom session died keeps consuming customer meetings until a human re-authenticates
+ * it — and until this change the state had no name: authenticated mode LOGGED the sign-in wall and
+ * proceeded, so the failure surfaced minutes later as a nameless join-button timeout.
+ *
+ * WHAT THIS FILE PINS
+ *   1. `classifyZoomSession` convicts on each recorded signed-out signature — the sign-in redirect,
+ *      the sign-in wall, and the guest lobby (empty name field + no account cookie).
+ *   2. It does NOT convict on a normal Zoom join failure — a healthy signed-in pre-join, a
+ *      host-not-started error page, a passcode screen, the RTMS anti-bot wall, or the ambiguous
+ *      halves of the guest-lobby rule (empty name field alone / missing cookie alone). Those keep
+ *      their existing outcomes; a false positive here would refuse a real join PERMANENTLY.
+ *   3. The guard is WIRED: driving the shipped `joinZoomMeeting` over a fabricated Page in
+ *      authenticated mode throws `ZoomAuthSessionError` with outcome `auth_session_missing` and
+ *      never types a guest name — so deleting the guard call from join.ts turns this suite RED
+ *      offline (the #756 lesson: a classifier test alone proves nothing about the join path).
+ *   4. GUEST mode is untouched: the same wall text still reports the host-policy `auth_required`,
+ *      because "the host restricted this meeting" is not "our credential is dead".
+ *   5. The reason text carries a short raw detail (`zoom_auth_session_missing <signal> …`) and
+ *      never leaks the meeting passcode from the `?pwd=` query.
+ *
+ * FIXTURE HONESTY: the page states below are FABRICATED from the shipped join path's own account of
+ * signed-in vs guest Zoom pre-join and from @vexa/remote-browser's session validator (sign-in URL
+ * markers + the `zm_aid` account cookie). No live dead Zoom profile was replayed — this proves the
+ * CLASSIFICATION and the WIRING, not that Zoom's dead-profile page has exactly this shape.
+ *
+ * No browser, no live meeting, no Zoom.
+ *
+ * Run: npx tsx src/zoom/session.test.ts
+ */
+
+import { joinZoomMeeting } from "./join";
+import {
+  classifyZoomSession,
+  isZoomSignInUrl,
+  redactZoomUrl,
+  ZoomAuthSessionError,
+  ZOOM_ACCOUNT_COOKIE_NAME,
+  ZOOM_AUTH_SESSION_MISSING,
+  type ZoomSessionObservation,
+} from "./session";
+import { AdmissionError } from "../shared/admission";
+
+let passed = 0, failed = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ""}`); failed++; }
+}
+
+const WC_URL = "https://app.zoom.us/wc/84335626851/join?pwd=super-secret-passcode";
+
+/** A healthy signed-in pre-join: account identity in the name field, live account cookie. */
+const HEALTHY: ZoomSessionObservation = {
+  url: WC_URL,
+  signInWallText: null,
+  nameFieldPresent: true,
+  nameFieldValue: "Vexa Bot",
+  accountCookiePresent: true,
+  phase: "pre_join_load",
+};
+
+const obs = (o: Partial<ZoomSessionObservation>): ZoomSessionObservation => ({ ...HEALTHY, ...o });
+
+// ── The fabricated Page ─────────────────────────────────────────────────────────────────────
+// Covers exactly the surface joinZoomMeeting touches. `bodyText` drives every page.evaluate probe
+// (run in-node against a stand-in `document`, the same pattern as zoom/admission.test.ts); `fields`
+// drives the locators; `cookies` drives the account-cookie read.
+function makePage(o: {
+  url?: string;
+  bodyText?: string;
+  title?: string;
+  nameFieldValue?: string | null;   // null = the field does not render
+  /** Hide the name field for the first N visibility probes — the React pre-join card renders a
+   *  beat after the page settles, which is why the guard is asked TWICE along the join path. */
+  nameFieldHiddenForProbes?: number;
+  cookies?: Array<{ name: string; value: string }> | "unreadable";
+}) {
+  const url = o.url ?? WC_URL;
+  const bodyText = o.bodyText ?? "";
+  const typed: string[] = [];
+  const clicked: string[] = [];
+  const nameValue = o.nameFieldValue === undefined ? "Vexa Bot" : o.nameFieldValue;
+  const hasNameField = nameValue !== null;
+
+  let nameProbes = 0;
+  const hiddenFor = o.nameFieldHiddenForProbes ?? 0;
+  const locator = (sel: string): any => {
+    const isName = sel.includes("#input-for-name");
+    return {
+      first: () => locator(sel),
+      isVisible: async () => (isName ? hasNameField && nameProbes++ >= hiddenFor : false),
+      inputValue: async () => (isName ? (nameValue as string) : ""),
+      click: async () => { clicked.push(sel); },
+      fill: async () => {},
+      getAttribute: async () => null,
+      count: async () => 0,
+      waitFor: async () => {},
+    };
+  };
+
+  const page: any = {
+    typed, clicked,
+    url: () => url,
+    title: async () => o.title ?? "Zoom Meeting",
+    goto: async () => {},
+    waitForTimeout: async () => {},
+    waitForSelector: async () => ({}),
+    waitForFunction: async () => ({}),
+    keyboard: { type: async (t: string) => { typed.push(t); } },
+    locator,
+    evaluate: async (fn: any, arg?: any) => {
+      (globalThis as any).document = {
+        body: { innerText: bodyText },
+        querySelector: () => null,
+      };
+      try { return fn(arg); } finally { delete (globalThis as any).document; }
+    },
+    context: () => ({
+      cookies: async () => {
+        if (o.cookies === "unreadable") throw new Error("no cookie jar on this context");
+        return o.cookies ?? [{ name: ZOOM_ACCOUNT_COOKIE_NAME, value: "acct-1" }];
+      },
+    }),
+  };
+  return page;
+}
+
+const run = (page: any, authenticated: boolean) =>
+  joinZoomMeeting(page, "https://zoom.us/j/84335626851?pwd=super-secret-passcode", "Vexa Bot", {
+    platform: "zoom", authenticated, passcode: "super-secret-passcode",
+  } as any);
+
+async function outcomeOf(p: Promise<unknown>): Promise<{ err: any; label: string }> {
+  try { await p; return { err: null, label: "resolved" }; }
+  catch (e: any) {
+    return {
+      err: e,
+      label: e instanceof AdmissionError ? `AdmissionError:${e.outcome}` : `Error:${e.message}`,
+    };
+  }
+}
+
+(async () => {
+  console.log("\n=== 1. classifyZoomSession convicts on each recorded signed-out signature ===");
+
+  {
+    const v = classifyZoomSession(obs({ url: "https://zoom.us/signin?_x=1", nameFieldValue: "" }));
+    check("sign-in redirect → signed out (signin_redirect)", v.signedOut && v.signal === "signin_redirect", JSON.stringify(v));
+  }
+  {
+    const v = classifyZoomSession(obs({ signInWallText: "sign in to join this meeting", nameFieldValue: "" }));
+    check("sign-in wall text → signed out (signin_wall)", v.signedOut && v.signal === "signin_wall", JSON.stringify(v));
+    check("…and the matched phrase is carried in the detail",
+      v.signedOut && v.detail.includes('matched="sign in to join this meeting"'), JSON.stringify(v));
+  }
+  {
+    const v = classifyZoomSession(obs({ nameFieldValue: "   ", accountCookiePresent: false }));
+    check("guest lobby (blank name field + no account cookie) → signed out (guest_lobby)",
+      v.signedOut && v.signal === "guest_lobby", JSON.stringify(v));
+  }
+
+  console.log("\n=== 2. …and NOT on a normal Zoom join failure (a false positive refuses a real join) ===");
+
+  check("healthy signed-in pre-join → not signed out", !classifyZoomSession(HEALTHY).signedOut);
+  check("host not started (error page, no wall text) → not signed out",
+    !classifyZoomSession(obs({ nameFieldPresent: false, nameFieldValue: "" })).signedOut);
+  check("RTMS anti-bot wall text is NOT a session verdict",
+    !classifyZoomSession(obs({ signInWallText: null, nameFieldValue: "Vexa Bot" })).signedOut);
+  check("empty name field ALONE (cookie still live) → not signed out",
+    !classifyZoomSession(obs({ nameFieldValue: "", accountCookiePresent: true })).signedOut);
+  check("missing cookie ALONE (account name pre-filled) → not signed out",
+    !classifyZoomSession(obs({ nameFieldValue: "Vexa Bot", accountCookiePresent: false })).signedOut);
+  check("empty name field + UNREADABLE cookie jar → not signed out (unknown never convicts)",
+    !classifyZoomSession(obs({ nameFieldValue: "", accountCookiePresent: null })).signedOut);
+  check("a white-label portal's own /login path is NOT a Zoom sign-in redirect",
+    !isZoomSignInUrl("https://zoom-lfx.platform.linuxfoundation.org/login/meeting/96088138284"));
+  check("canonical *.zoom.us /signin IS a Zoom sign-in redirect",
+    isZoomSignInUrl("https://us05web.zoom.us/signin"));
+
+  console.log("\n=== 3. the guard is WIRED into joinZoomMeeting (authenticated mode) ===");
+
+  {
+    // Sign-in wall on the settled pre-join page, holding a profile → dead profile.
+    const page = makePage({ bodyText: "Sign in to join this meeting", nameFieldValue: null });
+    const { err, label } = await outcomeOf(run(page, true));
+    check("authenticated + sign-in wall → ZoomAuthSessionError('auth_session_missing')",
+      err instanceof ZoomAuthSessionError && err.outcome === "auth_session_missing", label);
+    check("…and it is an AdmissionError, so the JoinDriver maps it PERMANENT (never re-spawned)",
+      err instanceof AdmissionError, label);
+    check("…and no guest name was typed (no silent downgrade to an anonymous join)",
+      page.typed.length === 0, `typed: ${page.typed}`);
+  }
+  {
+    // The redirect variant: no wall text at all, just a bounce to the account sign-in flow.
+    const page = makePage({ url: "https://zoom.us/signin?redirect=wc", nameFieldValue: null });
+    const { err, label } = await outcomeOf(run(page, true));
+    check("authenticated + sign-in redirect (no wall text) → ZoomAuthSessionError",
+      err instanceof ZoomAuthSessionError && err.signal === "signin_redirect", label);
+  }
+  {
+    // Guest lobby: empty name field AND the account cookie gone.
+    const page = makePage({ nameFieldValue: "", cookies: [{ name: "_zm_ssid", value: "anon" }] });
+    const { err, label } = await outcomeOf(run(page, true));
+    check("authenticated + empty name field + no account cookie → ZoomAuthSessionError (guest_lobby)",
+      err instanceof ZoomAuthSessionError && err.signal === "guest_lobby", label);
+    check("…and no guest name was typed", page.typed.length === 0, `typed: ${page.typed}`);
+  }
+  {
+    // The card renders LATE: nothing convicts at pre_join_load (no field yet, no wall text), and
+    // the guest lobby only becomes readable at the name-field step. Pins the SECOND call site.
+    const page = makePage({
+      nameFieldValue: "", nameFieldHiddenForProbes: 1, cookies: [{ name: "_zm_ssid", value: "anon" }],
+    });
+    const { err, label } = await outcomeOf(run(page, true));
+    check("late-rendering guest lobby → caught at the name-field step, not silently typed over",
+      err instanceof ZoomAuthSessionError && err.detail.includes("phase=pre_join_name_field"), label);
+    check("…and no guest name was typed", page.typed.length === 0, `typed: ${page.typed}`);
+  }
+  {
+    // `_zm_ssid` alone must NOT read as a session — Zoom sets it on the anonymous sign-in page.
+    const v = classifyZoomSession(obs({ nameFieldValue: "", accountCookiePresent: false }));
+    check("_zm_ssid is not an account cookie: its presence cannot rescue a guest lobby", v.signedOut);
+  }
+
+  console.log("\n=== 4. a HEALTHY authenticated join is untouched, and guest mode keeps its own reason ===");
+
+  {
+    const page = makePage({});  // account name pre-filled, live cookie, no wall text
+    const { err, label } = await outcomeOf(run(page, true));
+    check("authenticated + healthy profile → join proceeds (no error)", err === null, label);
+    check("…and the account identity was kept (no fallback name typed)",
+      page.typed.length === 0, `typed: ${page.typed}`);
+  }
+  {
+    const page = makePage({ bodyText: "Sign in to join this meeting", nameFieldValue: null });
+    const { err, label } = await outcomeOf(run(page, false));
+    check("GUEST + sign-in wall → still the host-policy auth_required reason, not the dead-profile one",
+      err instanceof AdmissionError && !(err instanceof ZoomAuthSessionError)
+        && err.outcome === "auth_session_missing" && err.message.includes("auth_required"), label);
+  }
+
+  console.log("\n=== 5. the raw detail is short, greppable, and leaks no passcode ===");
+
+  {
+    const page = makePage({ bodyText: "Only authenticated users can join", nameFieldValue: null });
+    const { err } = await outcomeOf(run(page, true));
+    const msg = String(err?.message ?? "");
+    check(`reason text leads with the ${ZOOM_AUTH_SESSION_MISSING} tag`, msg.includes(ZOOM_AUTH_SESSION_MISSING), msg);
+    check("…names the phase it was observed in", msg.includes("phase=pre_join_load"), msg);
+    check("…and never carries the ?pwd= passcode", !msg.includes("super-secret-passcode"), msg);
+    check("…and stays short enough for a lifecycle reason field (<240 chars)", msg.length < 240, `len=${msg.length}`);
+  }
+  check("redactZoomUrl drops the query string",
+    redactZoomUrl(WC_URL) === "https://app.zoom.us/wc/84335626851/join", redactZoomUrl(WC_URL));
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/core/meetings/modules/join/src/zoom/session.ts
+++ b/core/meetings/modules/join/src/zoom/session.ts
@@ -1,0 +1,193 @@
+/**
+ * Zoom auth-session guard (#1061) — name the SIGNED-OUT BOT PROFILE.
+ *
+ * THE PRODUCTION DEFECT: on hosted prod (since 2026-07-25) every `auth_session_missing` in the
+ * release is Zoom — 4 of 23 Zoom meetings, and no other platform produces the reason at all. The
+ * reason is PERMANENT by design (`lifecycle/retry.py`: "signed-out profile — a re-spawn hits the
+ * same dead profile"), so the state does not heal: every meeting routed to that profile burns.
+ *
+ * THE GAP THIS FILE CLOSES: today the join path detects a Zoom sign-in wall only in GUEST mode,
+ * where it means "the host restricted entry to authenticated users" (a meeting-policy fact, not our
+ * fault). In AUTHENTICATED mode — the mode that actually owns a profile that can die — the same
+ * wall was logged and walked past ("proceeding (the persistent context should already carry a Zoom
+ * session)"). The join then failed minutes later as a nameless join-button timeout, so the one
+ * state that says "our credential is dead, page someone" was the one state nothing surfaced.
+ *
+ * SHAPE: a pure classifier over an observation record, so the decision is unit-testable with no
+ * browser (session.test.ts), plus a thin reader that fills the record off a live Page. Mirrors
+ * googlemeet/join.ts's `isGoogleSignedOutLobby` + `AuthSessionError` — same typed outcome, same
+ * PERMANENT mapping through the JoinDriver, one guard per platform.
+ *
+ * SCOPE: DETECTION ONLY. Re-authenticating the dead profile (the self-heal) is deliberately out of
+ * scope and tracked as follow-up work — this file's whole job is to make the state say its name.
+ *
+ * FIXTURE HONESTY: the signals below are derived from the SHIPPED join path's own account of
+ * signed-in vs guest Zoom pre-join, from @vexa/remote-browser's session validator (`validate.ts`:
+ * sign-in URL markers + the `zm_aid` account cookie, with `_zm_ssid` explicitly rejected as a
+ * logged-in signal because Zoom sets it the instant the sign-in page loads), and from the issue's
+ * production evidence. They have NOT been replayed against a live dead Zoom profile.
+ */
+import type { Page } from "playwright";
+import { AdmissionError } from "../shared/admission";
+import { log } from "../_host";
+import { zoomNameInputSelector, zoomSignInWallTexts, zoomSignInUrlMarkers } from "./selectors";
+
+/**
+ * The cookie only a REAL Zoom ACCOUNT session carries. `_zm_ssid` is deliberately NOT here: Zoom
+ * sets it on the anonymous sign-in page too, so its presence proves nothing (the same false-positive
+ * @vexa/remote-browser's login flow already learned the hard way).
+ */
+export const ZOOM_ACCOUNT_COOKIE_NAME = "zm_aid";
+
+/** Which observation carried the verdict. Recorded in the raw detail so a triage can grep it. */
+export type ZoomSignedOutSignal = "signin_redirect" | "signin_wall" | "guest_lobby";
+
+/** The short machine-greppable tag that leads the failure reason text. */
+export const ZOOM_AUTH_SESSION_MISSING = "zoom_auth_session_missing";
+
+/**
+ * Thrown when AUTHENTICATED mode finds a signed-out Zoom profile. Extends AdmissionError so the
+ * JoinDriver's single `instanceof` catch maps the typed `auth_session_missing` outcome onto the
+ * PERMANENT completion reason, instead of re-raising into a transient (re-spawned) join_failure.
+ * The `detail` also rides the Error `message`, which is what the driver carries into the terminal
+ * lifecycle row's reason text (#926) — the only evidence channel available on main today.
+ */
+export class ZoomAuthSessionError extends AdmissionError {
+  readonly signal: ZoomSignedOutSignal;
+  readonly detail: string;
+  constructor(signal: ZoomSignedOutSignal, detail: string) {
+    super("auth_session_missing", `[Zoom Web] ${ZOOM_AUTH_SESSION_MISSING}: ${detail}`);
+    this.name = "ZoomAuthSessionError";
+    this.signal = signal;
+    this.detail = detail;
+  }
+}
+
+/** What the classifier reads off the pre-join page. Plain data — no Page, no DOM, no I/O. */
+export interface ZoomSessionObservation {
+  /** page.url() at observation time. */
+  url: string;
+  /** The matched sign-in-wall phrase, or null when no wall text is on the page. */
+  signInWallText: string | null;
+  /** Did the guest name-entry field render at all? */
+  nameFieldPresent: boolean;
+  /** Its current value — '' when it rendered empty. */
+  nameFieldValue: string;
+  /** true / false when the cookie jar was readable; null when it was not (never a verdict). */
+  accountCookiePresent: boolean | null;
+  /** Where in the join path this was taken — carried into the detail for triage. */
+  phase: string;
+}
+
+export type ZoomSessionVerdict =
+  | { signedOut: false }
+  | { signedOut: true; signal: ZoomSignedOutSignal; detail: string };
+
+/** Drop the query string — a Zoom join URL carries `?pwd=` and a meeting passcode must not be logged. */
+export function redactZoomUrl(raw: string): string {
+  if (!raw) return "";
+  try {
+    const u = new URL(raw);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return raw.split("?")[0];
+  }
+}
+
+/** Is this a canonical-Zoom sign-in / login URL? Canonical hosts only — see zoomSignInUrlMarkers. */
+export function isZoomSignInUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    const canonical = u.hostname === "zoom.us" || u.hostname.endsWith(".zoom.us");
+    if (!canonical) return false;
+    const path = u.pathname.toLowerCase();
+    return zoomSignInUrlMarkers.some((m) => path.includes(m));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The verdict. Called ONLY in authenticated mode — in guest mode a sign-in prompt is the host's
+ * policy, not a dead credential, and the existing guest-mode branch already reports that.
+ *
+ * Ordered by strength, and every rule is written to fail OPEN on ambiguity: a false positive
+ * refuses a legitimate join with a PERMANENT, un-retried reason, which is strictly worse than the
+ * status quo (a nameless timeout that at least retries).
+ *
+ *  1. `signin_redirect` — the canonical Zoom web client bounced us to zoom.us/signin. A live
+ *     session is never bounced. Decisive on its own.
+ *  2. `signin_wall`     — Zoom rendered "sign in to join …" while we claim to hold a session. A
+ *     signed-in client is not asked to sign in. Decisive on its own; this is exactly the state the
+ *     old code logged and walked past.
+ *  3. `guest_lobby`     — the guest name-entry field rendered EMPTY *and* the account cookie is
+ *     provably absent. Neither half is decisive alone: the shipped join path already tolerates a
+ *     signed-in pre-join whose name field comes up empty ("typed fallback"), and keying on a cookie
+ *     name alone would blanket-refuse every authenticated Zoom join the day Zoom renames it. An
+ *     unreadable cookie jar (null) is not "absent" and never convicts.
+ */
+export function classifyZoomSession(obs: ZoomSessionObservation): ZoomSessionVerdict {
+  const where = `url=${redactZoomUrl(obs.url)} phase=${obs.phase}`;
+
+  if (isZoomSignInUrl(obs.url)) {
+    return { signedOut: true, signal: "signin_redirect", detail: `signin_redirect ${where}` };
+  }
+  if (obs.signInWallText) {
+    return {
+      signedOut: true,
+      signal: "signin_wall",
+      detail: `signin_wall matched="${obs.signInWallText}" ${where}`,
+    };
+  }
+  if (obs.nameFieldPresent && obs.nameFieldValue.trim() === "" && obs.accountCookiePresent === false) {
+    return {
+      signedOut: true,
+      signal: "guest_lobby",
+      detail: `guest_lobby empty_name_field no_${ZOOM_ACCOUNT_COOKIE_NAME}_cookie ${where}`,
+    };
+  }
+  return { signedOut: false };
+}
+
+/** Read the classifier's inputs off a live page. Every probe is individually best-effort: one
+ *  unreadable signal must not blind the others (and unreadable never convicts — see classify). */
+export async function observeZoomSession(page: Page, phase: string): Promise<ZoomSessionObservation> {
+  let url = "";
+  try { url = page.url(); } catch { /* navigating — leave blank */ }
+
+  const signInWallText = await page
+    .evaluate((phrases: string[]) => {
+      const body = (document.body?.innerText || "").toLowerCase();
+      for (const p of phrases) if (body.includes(p.toLowerCase())) return p;
+      return null;
+    }, zoomSignInWallTexts)
+    .catch(() => null);
+
+  const nameField = page.locator(zoomNameInputSelector).first();
+  const nameFieldPresent = await nameField.isVisible({ timeout: 1000 }).catch(() => false);
+  const nameFieldValue = nameFieldPresent ? await nameField.inputValue().catch(() => "") : "";
+
+  let accountCookiePresent: boolean | null = null;
+  try {
+    const cookies = (await page.context().cookies()) as Array<{ name: string; value: string }>;
+    accountCookiePresent = cookies.some((c) => c.name === ZOOM_ACCOUNT_COOKIE_NAME && !!c.value);
+  } catch { /* no readable jar (a non-persistent stand-in context) — stays null, never a verdict */ }
+
+  return { url, signInWallText, nameFieldPresent, nameFieldValue, accountCookiePresent, phase };
+}
+
+/**
+ * The guard the join path calls in authenticated mode: observe, classify, and THROW the typed
+ * PERMANENT failure when the profile is signed out. A not-signed-out verdict returns quietly, so
+ * the join proceeds exactly as it does today.
+ */
+export async function assertZoomAuthSession(page: Page, phase: string): Promise<void> {
+  const verdict = classifyZoomSession(await observeZoomSession(page, phase));
+  if (!verdict.signedOut) return;
+  log(
+    `[Zoom Web] ⛔ ${ZOOM_AUTH_SESSION_MISSING}: the bot's Zoom profile is SIGNED OUT — ${verdict.detail}. ` +
+    `PERMANENT: a re-spawn restores the same dead profile, so every meeting routed to it fails until ` +
+    `the profile is re-authenticated (\`make login\` / provision-cli, AUTH_PLATFORM=zoom).`,
+  );
+  throw new ZoomAuthSessionError(verdict.signal, verdict.detail);
+}


### PR DESCRIPTION
Part of the **Join-Evidence Instrument train (#1072)**, milestone `train/observability`.

**Delivers issue:** #1061

Closes #1061.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

> ⚠️ **Left deliberately unselected — this is a legal certification and the template forbids an
> agent selecting it.** The `contribution-rights` / `evaluate` checks stay red until the human
> author ticks exactly one box below. For a maintainer-authored change in this repo the
> *Independent* path is the usual one, but that determination is the author's to make.

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## The gap

`auth_session_missing` is PERMANENT by design (`lifecycle/retry.py`: *"signed-out profile — a re-spawn hits the same dead profile"*), so the state never heals: every meeting routed to that profile burns until a human re-authenticates it. #1061's production evidence: **4 of 23 Zoom meetings in the release, and no other platform produces the reason at all.**

But in **authenticated mode** — the only mode that owns a profile that *can* die — the join path did not detect the state at all. It logged the Zoom sign-in wall and walked past it:

```ts
if (authRequired && authenticated) {
  log('[Zoom Web] Authenticated mode: sign-in text present, proceeding (the persistent context should already carry a Zoom session)');
}
```

The join then died minutes later on a Join button that could never enable, reported as a nameless timeout. So the one state that means *"our credential is dead, page an operator"* was the one state nothing surfaced.

**A finding worth naming for triage:** today's Zoom `auth_session_missing` is emitted **only** from the guest-mode branch, where it means *the host restricted this meeting to authenticated users* — a meeting-policy fact, platform-innocent. The dead-profile cause and the host-policy cause therefore share one sealed reason. This PR keeps the sealed reason (correct for both: both are permanent) but makes them **distinguishable** by raw detail and by error class.

## What this does

New `core/meetings/modules/join/src/zoom/session.ts` — a pure classifier over an observation record plus a thin live-page reader. Deliberately mirrors `googlemeet/join.ts`'s `isGoogleSignedOutLobby` + `AuthSessionError`: same typed outcome, same permanent mapping, one guard per platform.

In authenticated mode the guard convicts on three signatures, ordered by strength:

| signal | evidence | decisive alone? |
|---|---|---|
| `signin_redirect` | the canonical Zoom web client bounced us to `zoom.us/signin` — a live session is never bounced (same URL markers `@vexa/remote-browser`'s `validate.ts` keys its session check on) | yes |
| `signin_wall` | Zoom rendered *"sign in to join …"* while we claim to hold a session — a signed-in client is not asked to sign in | yes |
| `guest_lobby` | the guest name field rendered **empty** *and* the `zm_aid` account cookie is provably absent | **no — both halves required** |

It throws `ZoomAuthSessionError`, an `AdmissionError` subclass, at two points: on the settled pre-join page (`phase=pre_join_load`, catches redirect + wall) and at the moment the old code was about to type a guest fallback name into an empty field (`phase=pre_join_name_field`, catches a late-rendering guest lobby).

### Every rule fails OPEN on ambiguity

A false positive refuses a real customer join with a **permanent, un-retried** reason — strictly worse than the status quo, which at least retries. So:

- `guest_lobby` needs *both* halves. The shipped path already tolerates a signed-in pre-join whose name field comes up empty ("typed fallback"), and keying on a cookie name alone would blanket-refuse every authenticated Zoom join the day Zoom renames it.
- An **unreadable** cookie jar is `null`, not "absent", and never convicts.
- `_zm_ssid` is **not** an account cookie — Zoom sets it the instant the anonymous sign-in page loads. Only `zm_aid` counts (the same false positive `@vexa/remote-browser`'s login flow already learned the hard way).
- `signin_redirect` matches **canonical `zoom.us` / `*.zoom.us` only** — a white-label portal (LFX, corporate) can legitimately have `/login` in its own path while our session is perfectly alive.
- **Guest mode is untouched.** The same wall text still reports the host-policy `auth_required`.

### Raw detail

The short, greppable detail rides the existing reason text:

```
[Zoom Web] zoom_auth_session_missing: signin_wall matched="sign in to join this meeting"
url=https://app.zoom.us/wc/84335626851/join phase=pre_join_load
```

The `?pwd=` query is stripped — a Zoom join URL carries the meeting passcode and it must not reach a log line or `meeting.data.last_error`.

## Deliberately minimal in shared files (re: #1059)

The general typed-evidence pipeline on `feat/1059-join-evidence` is upgrading the shared failure-reporting transport. **This PR touches none of it** — no `shared/admission.ts`, no `join-driver.ts`, no `contracts.ts`, no `orchestrator.ts`, no `ports.ts`, no schema/seal. It emits through the mechanism exactly as it exists on `main`: `ZoomAuthSessionError extends AdmissionError`, so the JoinDriver's *existing* single `instanceof` catch already maps `outcome: 'auth_session_missing'` → `auth_missing` → the permanent `CompletionReason`, and the driver's existing `reason: e.message` carry (#926) is what transports the detail. That means the detail currently lands in the **generic reason string** rather than a structured evidence field — accepted for now; **the #1059 train upgrades the transport**, and this classifier's typed `signal` / `detail` are already exported and ready to be lifted into it with no change to the detection logic.

The only shared file touched is the package's public export list (`src/index.ts`, +6 lines in the zoom export block), so an embedder can tell "our credential is dead" apart from the host-policy wall.

## Tests

`src/zoom/session.test.ts` — **29 rows, no browser, no live meeting, no Zoom.** Module suite: **264 rows green** across 20 test files. Full `turbo run test`: 34/34 workspaces green. Pre-push static gates green.

1. **Convicts** on each recorded signed-out signature (redirect / wall / guest lobby), with the matched phrase carried into the detail.
2. **Does not convict** on a normal Zoom join failure: healthy signed-in pre-join, host-not-started error page, the RTMS anti-bot wall, empty-name-field-alone, missing-cookie-alone, unreadable cookie jar, a white-label `/login` path.
3. **The guard is wired** — the suite drives the shipped `joinZoomMeeting` over a fabricated Page (the `zoom/admission.test.ts` pattern), asserts `ZoomAuthSessionError` with `outcome === 'auth_session_missing'`, and asserts **no guest name was typed** (no silent downgrade to an anonymous join). *Negative control run: commenting out the two guard calls turns 8 rows RED offline* — the #756 lesson that a classifier test alone proves nothing about the join path.
4. **Guest mode keeps its own reason**, and a healthy authenticated join is untouched (account identity kept, no fallback typed).
5. The reason text leads with the greppable tag, names its phase, stays under 240 chars, and **never carries the passcode**.

## Fixture honesty

**The Zoom dead-profile state was not reproduced live.** The signatures are derived from the shipped join path's own account of signed-in vs guest Zoom pre-join, from `@vexa/remote-browser`'s session validator (sign-in URL markers + the `zm_aid` account cookie, with `_zm_ssid` explicitly rejected), and from the issue's production evidence. The tests prove the **classification** and the **wiring**; they cannot prove Zoom's dead-profile page has exactly this shape. Detection is built **against the recorded signature only** — the first live occurrence should be checked against these three signals, and a captured DOM should replace the fabricated fixtures.

## Follow-up: self-heal (NOT in this PR)

1. On `auth_session_missing`, mark the bot profile/identity **dead** in the control plane and stop routing meetings to it — today it keeps consuming customer meetings until a human notices.
2. Page an operator: the reason is permanent, so a dead credential should alert, not silently fail (#1061's own ask).
3. Re-auth needs a human at a Zoom sign-in page — `provision-cli` (`AUTH_PLATFORM=zoom`, VNC) is the existing flow; automating it means storing Zoom account credentials + surviving MFA, which is a security decision, not a code change.
4. A cheap pre-flight is the honest middle: run `validateLoggedIn` against the restored profile **before** meetings are routed to it, on a schedule, and fail loudly on expiry.
5. Belongs with the fault-owner axis work, where this classifies cleanly as `platform`.

## Observation bundle (the record of your harnessed loop)

- **C1 — the gap is real, not theoretical.** ran: read the shipped Zoom join path against #1061's production evidence · saw: authenticated mode's only response to the sign-in wall was `log(… proceeding …)`, and the *sole* Zoom source of `auth_session_missing` on `main` is the **guest**-mode branch (host policy, not a dead profile) · concluded: the dead-profile state is unrepresented, and the sealed reason currently conflates two different fault owners.
- **C2 — pick signals that cannot fail open, and cannot over-fire.** ran: cross-read `@vexa/remote-browser/validate.ts` + `login.ts` for what already distinguishes a live Zoom session · saw: sign-in URL markers and the `zm_aid` account cookie, with `_zm_ssid` explicitly rejected as a logged-in signal (a false positive that flow already ate) · concluded: two decisive signals (redirect, wall) plus one that convicts only on *both* halves (guest lobby), because a false positive here refuses a real join permanently.
- **C3 — prove the guard is wired, not just correct.** ran: `npx tsx src/zoom/session.test.ts` at head, then again with both `assertZoomAuthSession` calls commented out · saw: 29 green at head; **8 rows RED with the guard removed**, including "no guest name was typed" flipping to `typed: Vexa Bot` · concluded: the suite pins the join path itself, not a classifier in isolation (the #756 lesson).
- **C4 — no collateral.** ran: `npm test` in `@vexa/join`, `turbo run test` across the workspace, the 14 pre-push static gates · saw: 264 / 264 module rows, 34 / 34 workspaces, all gates green · concluded: safe to open.

## Acceptance floor

| Row | Evidence |
|---|---|
| **A1 — the signed-out Zoom profile is detected** | `classifyZoomSession` convicts on all three recorded signatures (`signin_redirect`, `signin_wall`, `guest_lobby`) — §1 of `src/zoom/session.test.ts`, 4 rows green. |
| **A2 — it surfaces as a TYPED failure reason `auth_session_missing`** | Driving the shipped `joinZoomMeeting` throws `ZoomAuthSessionError` with `outcome === 'auth_session_missing'`, and it `instanceof AdmissionError` so the existing JoinDriver maps it PERMANENT — §3, 7 rows green. Negative control: guard removed → 8 rows red. |
| **A3 — with a short raw-detail string** | `zoom_auth_session_missing: <signal> … url=… phase=…`, asserted greppable, phase-tagged, < 240 chars, and passcode-free — §5, 5 rows green. |
| **A4 — a normal Zoom join failure does NOT yield it** | Healthy signed-in pre-join, host-not-started, RTMS anti-bot wall, empty-field-alone, missing-cookie-alone, unreadable cookie jar, white-label `/login` — §2 + §4, 10 rows green. |
| **A5 — self-heal specced, not built** | "Follow-up: self-heal" above, 5 lines. No control-plane, retry, or credential code in the diff. |

## Docs diff (D6c)

`src/zoom/README.md` — the module's own file inventory, now naming `session.ts` and what it decides. No reader-facing page changed: this PR alters no API, no configuration knob, and no operator procedure. The **operator** story it implies (a dead Zoom profile should page someone, and `make login` re-provisions it) belongs with the self-heal follow-up, where there is an actual action for a reader to take; documenting an alert that does not exist yet would be a docs claim ahead of the code. `docs-current` green.

## Security checks (required on the diff)

- **No new dependencies.** The diff adds one source file and one test file inside `@vexa/join`; `pnpm-lock.yaml` untouched. `gate:licenses` green.
- **Isolation preserved.** `npm run check:isolation` → 56 files scanned, every import stays inside the package. `gate:isolation` green.
- **Secret/PII handling is part of the change, not incidental to it:** the failure detail passes through `redactZoomUrl`, which strips the query string, because a Zoom join URL carries `?pwd=<meeting passcode>` and this string lands in logs and `meeting.data.last_error`. Pinned by a test row asserting the passcode never appears in the message. Cookie *names* are read; no cookie value is ever logged.
- GitGuardian green; CodeQL running on the PR.

## Validation request

**Who:** the maintainer who reported #1061 (they hold the production evidence and can see the affected profile).

**What to watch:** this is a **detection-only** change, so the validation that matters is the *first live occurrence*, not a staged run — confirm that a real signed-out Zoom profile produces `completion_reason=auth_session_missing` with a `zoom_auth_session_missing <signal> …` reason string, and that the `<signal>` matches what the browser actually showed. A live occurrence that does **not** match one of the three signals is a finding and should replace the fabricated fixtures with the captured DOM.

**Deployment validated: NONE — claimed honestly.** No Lite / compose / k8s / hosted run was performed, and the Zoom dead-profile state was **not reproduced live**. Evidence here is offline: 264 module test rows + 34 workspace suites + 14 static gates, at head sha of this branch, on a fresh worktree off `origin/main` with stock env. The detection is built **against the recorded signature only**.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code; the contribution-rights certification above is deliberately left unselected for the human author.
