### PR TITLE
test(meetings): env-gated real-Postgres fixture + isolation/containment coverage (#1068)

### DIFF
--- a/core/meetings/services/meeting-api/tests/pg_fixtures.py
+++ b/core/meetings/services/meeting-api/tests/pg_fixtures.py
@@ -1,0 +1,214 @@
+"""Env-gated REAL-Postgres fixtures for the meeting-api suite (#1068).
+
+Why this file exists
+--------------------
+The tenancy boundary the product actually ships is **SQL**: ``list_meetings`` builds an access
+UNION (owner / transcript-share viewer / bound-workspace member) and ANDs any JSONB ``@>``
+containment filter onto the outer query; every owner-scoped mutation re-selects
+``WHERE user_id AND platform AND platform_specific_id … FOR UPDATE`` before it writes. CI, however,
+only ever asserted that boundary against ``InMemoryTranscriptStore`` — hand-written Python
+predicates (``m["user_id"] == user_id``). A regression in the real SQL (an accidental ``OR``, a
+dropped ``user_id`` predicate, a filter applied outside the union) keeps every fake-based test green
+while leaking across tenants in production. #1068.
+
+So: a fixture that stands the REAL schema up in a REAL Postgres and hands back the PRODUCTION
+adapter (``SqlAlchemyTranscriptStore``), so the thing CI guards is the thing that ships.
+
+The gate convention (mirrored from ``test_single_flight.py``)
+------------------------------------------------------------
+Exactly the shape ``test_pg_advisory_lock_runs_on_real_postgres`` already established:
+
+    @requires_pg            # == @pytest.mark.skipif(not os.getenv("MEETING_API_TEST_DATABASE_URL"))
+
+With ``MEETING_API_TEST_DATABASE_URL`` unset — the default gate run, ``pnpm gate:python`` — every
+consumer SKIPS with a readable reason and the suite stays green with no database anywhere.
+
+Running the gated lane
+----------------------
+The gate venv deliberately has no SQLAlchemy/asyncpg (``pyproject.toml`` carries no ``greenlet``
+pin precisely because the fakes never import them), so the drivers are supplied ad-hoc::
+
+    docker run --rm -d --name mapi-pg -e POSTGRES_PASSWORD=test -p 5433:5432 postgres:16
+    MEETING_API_TEST_DATABASE_URL=postgresql+asyncpg://postgres:test@localhost:5433/postgres \
+      uv run --with 'sqlalchemy[asyncio]>=2' --with asyncpg --with greenlet \
+      pytest -q tests/test_pg_isolation.py
+
+A plain ``postgresql://`` URL is accepted too — it is normalized to the asyncpg driver below. If
+the env var IS set but the drivers are missing, the fixture ``importorskip``s rather than erroring,
+so a half-configured environment reports "skipped, install X" instead of a collection blow-up.
+
+Isolation + teardown
+--------------------
+Each pytest SESSION gets its OWN uniquely-named schema (``mapi_test_<12 hex>``) inside whatever
+database the URL points at. The engine pins ``search_path`` to that schema, so
+``Base.metadata.create_all`` builds the ``meetings`` / ``transcriptions`` / ``meeting_sessions``
+tables — GIN indexes, partial unique index and all — entirely inside it. ``public`` is never
+touched, so pointing the env var at a scratch database with other content is safe.
+
+Teardown is trapped twice: the session fixture drops the schema in a ``finally:`` (so a failing or
+erroring test still drops it), and the same idempotent drop is registered with ``atexit`` as a
+belt-and-braces path for aborted runs (``-x``, KeyboardInterrupt, an exception during collection).
+The drop is ``DROP SCHEMA IF EXISTS … CASCADE`` and runs at most once. Should even that fail, the
+schema name is printed as a warning so an operator can drop the orphan by hand rather than
+discovering it months later.
+"""
+from __future__ import annotations
+
+import asyncio
+import atexit
+import os
+import uuid
+import warnings
+
+import pytest
+
+PG_URL_ENV = "MEETING_API_TEST_DATABASE_URL"
+
+#: The suite-wide gate. Identical in shape to ``test_single_flight.py``'s real-PG conformance
+#: guard, so there is one convention for "this test needs a real Postgres", not two.
+requires_pg = pytest.mark.skipif(
+    not os.getenv(PG_URL_ENV),
+    reason=f"real-Postgres coverage; set {PG_URL_ENV} to run",
+)
+
+#: The tables the production adapter reads/writes, in FK-safe truncation order.
+_TABLES = ("transcriptions", "meeting_sessions", "meetings")
+
+
+def _async_url(raw: str) -> str:
+    """Normalize a Postgres URL to the asyncpg driver ``create_async_engine`` needs.
+
+    ``postgresql+asyncpg://…`` passes through untouched (the form the existing advisory-lock test
+    already expects); bare ``postgres://`` / ``postgresql://`` are rewritten so a URL copied from
+    ``psql`` or a compose file works without editing.
+    """
+    if "+" in raw.split("://", 1)[0]:
+        return raw
+    scheme, sep, rest = raw.partition("://")
+    if not sep:
+        return raw
+    return f"postgresql+asyncpg://{rest}" if scheme in ("postgres", "postgresql") else raw
+
+
+async def _create_schema(url: str, schema: str) -> None:
+    """CREATE SCHEMA + ``Base.metadata.create_all`` inside it, on a throwaway engine."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from meeting_api.sessions.models import Base
+
+    admin = create_async_engine(url, poolclass=_null_pool())
+    try:
+        async with admin.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+    finally:
+        await admin.dispose()
+
+    engine = create_async_engine(url, poolclass=_null_pool(), **_search_path(schema))
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    finally:
+        await engine.dispose()
+
+
+async def _drop_schema(url: str, schema: str) -> None:
+    """Idempotent ``DROP SCHEMA IF EXISTS … CASCADE`` on a fresh connection.
+
+    Deliberately its own engine: the test's engine may be in an unusable state (a poisoned
+    transaction, a connection killed mid-statement) exactly when teardown matters most.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(url, poolclass=_null_pool())
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+    finally:
+        await engine.dispose()
+
+
+def _null_pool():
+    from sqlalchemy.pool import NullPool
+
+    return NullPool
+
+
+def _search_path(schema: str) -> dict:
+    """Engine kwargs pinning every connection's ``search_path`` to the temp schema.
+
+    asyncpg applies ``server_settings`` per connection, so unqualified table names in the models
+    (``__tablename__ = "meetings"``) resolve inside the temp schema for DDL and DML alike — no
+    ``schema=`` annotation on the production models, which must stay exactly as they ship.
+    """
+    return {"connect_args": {"server_settings": {"search_path": schema}}}
+
+
+@pytest.fixture(scope="session")
+def pg_schema() -> str:
+    """A uniquely-named schema holding the real meeting-api tables, dropped when the session ends.
+
+    Synchronous on purpose. It owns its own short-lived event loops via ``asyncio.run`` so it never
+    borrows (or outlives) pytest-asyncio's per-test loop — a session-scoped *async* fixture would
+    bind an engine to a loop that is closed before teardown runs.
+    """
+    pytest.importorskip("sqlalchemy", reason="real-Postgres lane needs SQLAlchemy (async)")
+    pytest.importorskip("asyncpg", reason="real-Postgres lane needs the asyncpg driver")
+    pytest.importorskip("greenlet", reason="SQLAlchemy's async bridge needs greenlet")
+
+    url = _async_url(os.environ[PG_URL_ENV])
+    schema = f"mapi_test_{uuid.uuid4().hex[:12]}"
+    dropped = {"done": False}
+
+    def _drop_once() -> None:
+        if dropped["done"]:
+            return
+        dropped["done"] = True
+        try:
+            asyncio.run(_drop_schema(url, schema))
+        except Exception as exc:  # never mask the real test failure — report the orphan instead
+            warnings.warn(
+                f"{PG_URL_ENV}: failed to drop temp schema {schema!r} ({exc!r}). "
+                f'Drop it by hand: DROP SCHEMA IF EXISTS "{schema}" CASCADE;',
+                stacklevel=1,
+            )
+
+    # Belt: fires on an aborted run (-x, KeyboardInterrupt, a collection-time raise) where pytest
+    # never reaches the finalizer below. Braces: the `finally` on the happy/failing path.
+    atexit.register(_drop_once)
+    asyncio.run(_create_schema(url, schema))
+    try:
+        yield schema
+    finally:
+        _drop_once()
+        atexit.unregister(_drop_once)
+
+
+@pytest.fixture
+async def pg_store(pg_schema):
+    """The PRODUCTION ``SqlAlchemyTranscriptStore`` over the temp schema — not a fake.
+
+    Yields ``(store, session_factory)``: the store is what the routes call, the session factory is
+    for seeding rows and for reading the table back to prove a refused write left no trace.
+
+    Tables are truncated before each test (``RESTART IDENTITY CASCADE``) so row ids are predictable
+    and tests do not leak into one another. ``redis_client=None`` keeps the read path pure-Postgres —
+    the live in-flight-segment merge is a separate concern with its own fakeredis coverage.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from meeting_api.collector.adapters import SqlAlchemyTranscriptStore
+
+    url = _async_url(os.environ[PG_URL_ENV])
+    engine = create_async_engine(url, **_search_path(pg_schema))
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(f"TRUNCATE {', '.join(_TABLES)} RESTART IDENTITY CASCADE")
+            )
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        yield SqlAlchemyTranscriptStore(session_factory, redis_client=None), session_factory
+    finally:
+        await engine.dispose()

--- a/core/meetings/services/meeting-api/tests/test_pg_isolation.py
+++ b/core/meetings/services/meeting-api/tests/test_pg_isolation.py
@@ -1,0 +1,311 @@
+"""The tenancy boundary, asserted against REAL Postgres instead of the in-memory fake (#1068).
+
+``test_xtenant_isolation.py`` proves the cross-tenant contract at the ROUTE seam over
+``InMemoryTranscriptStore``: correct, fast, offline — and blind to the SQL that actually enforces
+the boundary in production. The fake's isolation is hand-written Python (``m["user_id"] ==
+user_id``); the shipped isolation is a UNION of index-scannable access branches plus per-mutation
+``WHERE user_id … FOR UPDATE`` re-selects, with any JSONB ``@>`` containment filter ANDed onto the
+outer query. Those two are equal only by convention — nothing mechanical held them together, which
+is the same failure class the #637 advisory-lock witness already cost us once (the fake never
+executed the SQL, so a ``pg_try_advisory_lock(int4, bigint)`` mismatch reached a live meeting).
+
+Every test here drives the PRODUCTION ``SqlAlchemyTranscriptStore`` against a real ``meetings``
+table in a throwaway schema. Gated on ``MEETING_API_TEST_DATABASE_URL`` — see ``pg_fixtures.py``
+for the fixture, its teardown guarantee, and the exact command that runs this lane.
+
+Three consumers, one per gap named in #1068 / the #1067 review:
+  1. cross-user isolation on the READ surface (list · get · get-by-id · authorize-subscribe),
+  2. 404-when-not-owned across the owner-scoped MUTATION surface, plus proof no write landed,
+  3. JSONB ``@>`` containment with TYPED values (number · bool · array · string) — the gap the
+     #1067 filter fix could only cover at the SQL-construction layer and in a hand-written fake.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# The fixtures live in their own module (imported, not conftest-registered) so this lane adds no
+# shared-file surface. `requires_pg` is the same skipif shape test_single_flight.py established.
+from pg_fixtures import pg_schema, pg_store, requires_pg  # noqa: F401  (pytest fixture injection)
+
+USER_A = 4001
+USER_B = 4002
+PLATFORM = "google_meet"
+SHARED_NATIVE = "abc-defg-hij"   # the SAME meeting link, run by BOTH users — the collision case
+A_ONLY_NATIVE = "aaa-aaaa-aaa"   # a link only user A ever ran — the not-owned-at-all case
+
+
+async def _seed_meeting(session_factory, *, user_id, native, status="completed", data=None,
+                        segment_text=None):
+    """INSERT one ``meetings`` row (+ optionally one ``transcriptions`` segment) via the ORM.
+
+    Seeding through the models rather than through the adapter keeps the assertions honest: if a
+    read path is broken, the seed is not broken in the same direction.
+    """
+    from meeting_api.sessions.models import Meeting, Transcription
+
+    async with session_factory() as db:
+        m = Meeting(user_id=user_id, platform=PLATFORM, platform_specific_id=native,
+                    status=status, data=dict(data or {}))
+        db.add(m)
+        await db.flush()
+        if segment_text is not None:
+            db.add(Transcription(meeting_id=m.id, start_time=1.0, end_time=2.0,
+                                 text=segment_text, speaker="Alice", language="en",
+                                 segment_id=f"seg-{m.id}"))
+        await db.commit()
+        return m.id
+
+
+async def _row_state(session_factory, meeting_id) -> dict:
+    """Re-read the row straight from Postgres — the no-write-landed oracle."""
+    from sqlalchemy import select
+
+    from meeting_api.sessions.models import Meeting
+
+    async with session_factory() as db:
+        m = (await db.execute(select(Meeting).where(Meeting.id == meeting_id))).scalars().first()
+        return {"exists": m is not None,
+                "status": None if m is None else m.status,
+                "data": {} if m is None else dict(m.data or {})}
+
+
+# ── 1 · cross-user isolation on the READ surface ────────────────────────────────────────────────
+
+@requires_pg
+async def test_cross_user_isolation_on_real_postgres(pg_store):
+    """User B must never see user A's meeting — on ANY read path, against the real access UNION.
+
+    Both users ran a bot on the SAME native link, so ``platform_specific_id`` alone cannot
+    disambiguate them; only the ``user_id`` predicate can. The fake asserts this with a Python
+    comparison. Here the three shipped branches (owner / transcript-share viewer / bound-workspace
+    member) are compiled into an actual ``UNION ALL`` and executed, so an accidental ``OR``, a
+    dropped ``user_id`` predicate, or a widened branch surfaces as a leak on one of these lines.
+    """
+    store, sf = pg_store
+    a_id = await _seed_meeting(sf, user_id=USER_A, native=SHARED_NATIVE, segment_text="A secret")
+    b_id = await _seed_meeting(sf, user_id=USER_B, native=SHARED_NATIVE, segment_text="B secret")
+    a_solo = await _seed_meeting(sf, user_id=USER_A, native=A_ONLY_NATIVE, segment_text="A alone")
+    assert len({a_id, b_id, a_solo}) == 3, "seed must produce three distinct rows"
+
+    # LIST — each user sees only their own rows.
+    a_list = await store.list_meetings(USER_A)
+    b_list = await store.list_meetings(USER_B)
+    assert {m["id"] for m in a_list} == {a_id, a_solo}
+    assert {m["id"] for m in b_list} == {b_id}
+    assert all(m["user_id"] == USER_A for m in a_list)
+    assert all(m["user_id"] == USER_B for m in b_list)
+
+    # LIST narrowed to the shared link's platform — the native-id collision does not merge tenants.
+    assert {m["id"] for m in await store.list_meetings(USER_B, platform=PLATFORM)} == {b_id}
+    # LIST addressed at a specific row id — the detail path is union-scoped too, not id-scoped.
+    assert await store.list_meetings(USER_B, meeting_id=a_id) == []
+    assert [m["id"] for m in await store.list_meetings(USER_A, meeting_id=a_id)] == [a_id]
+
+    # GET by (user, platform, native) — the shared link resolves per-owner, never cross-tenant.
+    a_doc = await store.get_transcript(USER_A, PLATFORM, SHARED_NATIVE)
+    b_doc = await store.get_transcript(USER_B, PLATFORM, SHARED_NATIVE)
+    assert a_doc["id"] == a_id and [s["text"] for s in a_doc["segments"]] == ["A secret"]
+    assert b_doc["id"] == b_id and [s["text"] for s in b_doc["segments"]] == ["B secret"]
+    assert await store.get_transcript(USER_B, PLATFORM, A_ONLY_NATIVE) is None
+
+    # GET by ROW id — the P0 path. B addressing A's row id is refused (the route maps None → 404).
+    assert await store.get_transcript_by_id(USER_B, a_id) is None, "B read A's row by id — LEAK"
+    assert await store.get_transcript_by_id(USER_B, a_solo) is None
+    assert (await store.get_transcript_by_id(USER_A, a_id))["id"] == a_id
+
+    # AUTHORIZE-SUBSCRIBE — the live-feed boundary; B resolves to B's row, never A's.
+    assert await store.authorize_subscribe(USER_B, PLATFORM, SHARED_NATIVE) == b_id
+    assert await store.authorize_subscribe(USER_A, PLATFORM, SHARED_NATIVE) == a_id
+    assert await store.authorize_subscribe(USER_B, PLATFORM, A_ONLY_NATIVE) is None
+
+    # The union's SHARE branch is itself a real JSONB `@>` containment (`to_jsonb(<int>)` probed
+    # against `data.transcript_viewers`). It must WIDEN for a genuine viewer …
+    shared_id = await _seed_meeting(sf, user_id=USER_A, native="shr-eeee-fff",
+                                    data={"transcript_viewers": [USER_B]})
+    b_after_share = await store.list_meetings(USER_B)
+    assert {m["id"] for m in b_after_share} == {b_id, shared_id}
+    assert next(m for m in b_after_share if m["id"] == shared_id)["shared"] is True
+    assert (await store.get_transcript_by_id(USER_B, shared_id))["id"] == shared_id
+
+    # … and must NOT widen on a type-confused entry. `to_jsonb(4002)` is the JSON NUMBER 4002 and
+    # Postgres `@>` is type-exact, so a stored STRING "4002" grants nothing. Same typed-value
+    # semantics the custom-metadata filter rides on, proven here on the branch that ships today.
+    string_viewer = await _seed_meeting(sf, user_id=USER_A, native="str-eeee-fff",
+                                        data={"transcript_viewers": [str(USER_B)]})
+    assert string_viewer not in {m["id"] for m in await store.list_meetings(USER_B)}, \
+        'a string "4002" viewer entry must not authorize the integer user 4002'
+
+
+# ── 2 · 404-when-not-owned across the owner-scoped MUTATION surface ─────────────────────────────
+
+@requires_pg
+async def test_owner_scoped_mutations_404_when_not_owned(pg_store):
+    """Every owner-scoped write refuses a non-owner with ``None`` (→ 404) and leaves NO trace.
+
+    Each method re-selects ``WHERE user_id AND platform AND platform_specific_id … FOR UPDATE``
+    (or ``WHERE id AND user_id`` for the row-addressed ones) before it mutates — the exact shape
+    ``merge_custom_metadata`` uses for the #1064 metadata PATCH. The fake returns ``None`` from a
+    Python guard; here the refusal has to come from the SQL, and each row is read back afterwards
+    to prove the write did not land through some other path.
+
+    ``A_ONLY_NATIVE`` is deliberately a link user B has NEVER run: against a shared native, a
+    passing call could be B legitimately mutating B's own row and the assertion would prove nothing.
+    """
+    store, sf = pg_store
+    a_id = await _seed_meeting(sf, user_id=USER_A, native=A_ONLY_NATIVE, status="completed",
+                               data={"constructed_meeting_url": "https://meet/aaa"})
+    a_planned = await _seed_meeting(sf, user_id=USER_A, native="pln-aaaa-aaa", status="scheduled",
+                                    data={"title": "A's plan"})
+    before, before_planned = await _row_state(sf, a_id), await _row_state(sf, a_planned)
+
+    # native-addressed owner-scoped writes
+    assert await store.bind_workspace(USER_B, PLATFORM, A_ONLY_NATIVE, "ws-of-b") is None
+    assert await store.connect_doc(USER_B, PLATFORM, A_ONLY_NATIVE,
+                                   {"workspace": "ws-of-b", "path": "/pwn.md"}) is None
+    assert await store.disconnect_doc(USER_B, PLATFORM, A_ONLY_NATIVE, "/pwn.md") is None
+    assert await store.set_intent(USER_B, PLATFORM, A_ONLY_NATIVE, "idle") is None
+    assert await store.mint_transcript_share(USER_B, PLATFORM, A_ONLY_NATIVE) is None
+
+    # row-id-addressed owner-scoped writes (the shape the metadata PATCH shares)
+    assert await store.update_planned_meeting(USER_B, a_planned, {"title": "pwned"}) is None
+    assert await store.delete_planned_meeting(USER_B, a_planned) is None
+
+    # NOTHING landed: both rows byte-identical, and the planned row still exists.
+    assert await _row_state(sf, a_id) == before, "a refused mutation still wrote to A's row"
+    assert await _row_state(sf, a_planned) == before_planned
+    assert before_planned["exists"] and before_planned["status"] == "scheduled"
+
+    # Positive control — the SAME calls succeed for the owner, so the refusals above are the
+    # `user_id` predicate doing its job, not the methods being inert.
+    assert await store.bind_workspace(USER_A, PLATFORM, A_ONLY_NATIVE, "ws-of-a") == "ws-of-a"
+    assert await store.connect_doc(USER_A, PLATFORM, A_ONLY_NATIVE,
+                                   {"workspace": "ws-of-a", "path": "/notes.md"}) == [
+        {"workspace": "ws-of-a", "path": "/notes.md"}]
+    assert (await store.update_planned_meeting(
+        USER_A, a_planned, {"title": "kept"}))["data"]["title"] == "kept"
+    assert await store.delete_planned_meeting(USER_A, a_planned) is True
+    assert (await _row_state(sf, a_planned))["exists"] is False
+
+    # …and B still cannot read what A just wrote.
+    assert await store.get_transcript_by_id(USER_B, a_id) is None
+    assert (await _row_state(sf, a_id))["data"]["workspace_id"] == "ws-of-a"
+
+
+# ── 3 · JSONB `@>` containment with TYPED values ────────────────────────────────────────────────
+#
+# #1067 fixed the wire→JSON coercion for `?custom.*` filters ("42" must become the NUMBER 42 before
+# it reaches `@>`, or a numeric attribute is unfilterable). With no table-creating fixture in this
+# suite, that fix could only be asserted at the SQL-CONSTRUCTION layer plus a hand-written fake —
+# nothing ever executed `@>` against Postgres, so "the fake mirrors JSONB containment" stayed an
+# assumption. These two tests are the missing oracle.
+
+def _custom_contains(needle: dict):
+    """The whole-column containment predicate the metadata filter compiles to.
+
+    ``data @> {"custom": …}`` (not ``data->'custom' @> …``) so the existing whole-column GIN index
+    ``ix_meeting_data_gin`` can serve it. The probe is bound as a Python OBJECT and left for
+    SQLAlchemy's JSONB type to serialize — see the double-encoding guard below for why that detail
+    is load-bearing.
+    """
+    from sqlalchemy import cast
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    from meeting_api.sessions.models import Meeting
+
+    return Meeting.data.op("@>")(cast({"custom": needle}, JSONB))
+
+
+CUSTOM = {"score": 42, "flagged": True, "tags": ["red", "blue"], "owner": "ada"}
+
+
+@requires_pg
+@pytest.mark.parametrize(
+    "probe,should_match",
+    [
+        ({"score": 42}, True),                     # number ≡ number
+        ({"score": "42"}, False),                  # number ≢ the string "42" — `@>` is type-exact
+        ({"score": 42.0}, True),                   # 42 and 42.0 are the same jsonb numeric
+        ({"flagged": True}, True),                 # bool ≡ bool
+        ({"flagged": "true"}, False),              # bool ≢ the string "true"
+        ({"flagged": False}, False),               # the OTHER bool matches nothing
+        ({"tags": ["red"]}, True),                 # array containment is ⊆, not equality
+        ({"tags": ["blue", "red"]}, True),         # …and order-insensitive
+        ({"tags": ["green"]}, False),
+        # NESTED scalar-vs-array does NOT match. Postgres' "an array may contain a primitive"
+        # exception applies ONLY at the top level of the comparison, never inside an object — so a
+        # tag filter must probe with a one-element ARRAY, not a bare scalar.
+        ({"tags": "red"}, False),
+        ({"owner": "ada"}, True),                  # string ≡ string (what coercion must not break)
+        ({"owner": "ADA"}, False),                 # …and it is case-sensitive
+        ({"score": 42, "flagged": True}, True),    # multi-key: ALL pairs must be contained
+        ({"score": 42, "flagged": False}, False),
+        ({"missing": 1}, False),                   # an absent key contains nothing
+    ],
+)
+async def test_jsonb_containment_typed_values_on_real_postgres(pg_store, probe, should_match):
+    """Real-Postgres ``@>`` semantics for numeric / bool / array / string metadata values.
+
+    Each row of the matrix is a coercion rule the request boundary has to honour, checked against
+    the database rather than against a Python re-implementation of it. The probe is ALSO run for a
+    second user holding byte-identical ``data.custom``: a filter is only ever ANDed onto the access
+    union and must never widen it.
+    """
+    from sqlalchemy import select
+
+    from meeting_api.sessions.models import Meeting
+
+    store, sf = pg_store
+    a_id = await _seed_meeting(sf, user_id=USER_A, native=SHARED_NATIVE, data={"custom": CUSTOM})
+    b_id = await _seed_meeting(sf, user_id=USER_B, native=SHARED_NATIVE, data={"custom": CUSTOM})
+
+    async with sf() as db:
+        def _q(user_id):
+            return select(Meeting.id).where(Meeting.user_id == user_id, _custom_contains(probe))
+        a_hits = set((await db.execute(_q(USER_A))).scalars().all())
+        b_hits = set((await db.execute(_q(USER_B))).scalars().all())
+
+    assert a_hits == ({a_id} if should_match else set()), (
+        f"real-PG `@>` disagreed for {probe!r}: expected match={should_match}, got {a_hits}")
+    # User scoping is what keeps a matching filter from becoming a cross-tenant read: B's identical
+    # payload matches for B and ONLY for B.
+    assert b_hits == ({b_id} if should_match else set())
+    assert a_id not in b_hits and b_id not in a_hits, "containment filter leaked across users"
+
+
+@requires_pg
+async def test_containment_probe_must_be_a_jsonb_object_not_a_double_encoded_string(pg_store):
+    """The construction trap the fake could not see: ``cast(json.dumps(obj), JSONB)`` matches NOTHING.
+
+    ``JSONB``'s bind processor serializes whatever Python value it is handed. Hand it a dict and the
+    parameter arrives as the jsonb OBJECT the filter needs; hand it an ALREADY-serialized string and
+    it is serialized a second time, so the parameter arrives as a jsonb STRING SCALAR
+    (``'"{\\"custom\\": …}"'``). ``object @> string-scalar`` is simply false — no error, no warning,
+    just a filter that silently returns zero rows for every query.
+
+    An in-memory fake that re-implements containment in Python cannot expose this: it never builds
+    the bind parameter. That is the whole argument for this file.
+    """
+    from sqlalchemy import cast, select
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    from meeting_api.sessions.models import Meeting
+
+    store, sf = pg_store
+    a_id = await _seed_meeting(sf, user_id=USER_A, native=SHARED_NATIVE, data={"custom": CUSTOM})
+    needle = {"custom": {"score": 42}}
+
+    async with sf() as db:
+        # The probe parameter itself: a dict binds as an object, a pre-serialized string does not.
+        assert isinstance((await db.execute(select(cast(needle, JSONB)))).scalar(), dict)
+        double = (await db.execute(select(cast(json.dumps(needle), JSONB)))).scalar()
+        assert isinstance(double, str), (
+            "cast(json.dumps(obj), JSONB) no longer double-encodes — the trap this test guards is "
+            "gone and the guard can be relaxed")
+
+        good = select(Meeting.id).where(_custom_contains({"score": 42}))
+        bad = select(Meeting.id).where(Meeting.data.op("@>")(cast(json.dumps(needle), JSONB)))
+        assert (await db.execute(good)).scalars().all() == [a_id]
+        assert (await db.execute(bad)).scalars().all() == [], (
+            "a double-encoded probe matched a row — this test's premise is wrong")

--- a/core/meetings/services/meeting-api/tests/test_pg_isolation.py
+++ b/core/meetings/services/meeting-api/tests/test_pg_isolation.py
@@ -256,7 +256,10 @@ async def test_jsonb_containment_typed_values_on_real_postgres(pg_store, probe, 
 
     from meeting_api.sessions.models import Meeting
 
-    store, sf = pg_store
+    # The adapter is not called here on purpose: `list_meetings` grows its `custom_filter=` argument
+    # with #1064/#1067, which is not on main yet. What IS pinned is the predicate that filter
+    # compiles to, executed on the real engine (see gap 1 in the PR body).
+    _store, sf = pg_store
     a_id = await _seed_meeting(sf, user_id=USER_A, native=SHARED_NATIVE, data={"custom": CUSTOM})
     b_id = await _seed_meeting(sf, user_id=USER_B, native=SHARED_NATIVE, data={"custom": CUSTOM})
 
@@ -292,7 +295,7 @@ async def test_containment_probe_must_be_a_jsonb_object_not_a_double_encoded_str
 
     from meeting_api.sessions.models import Meeting
 
-    store, sf = pg_store
+    _store, sf = pg_store
     a_id = await _seed_meeting(sf, user_id=USER_A, native=SHARED_NATIVE, data={"custom": CUSTOM})
     needle = {"custom": {"score": 42}}
 


### PR DESCRIPTION
**Delivers issue:** #1068

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> ⚠️ **Two human actions are outstanding, and neither may be done by an agent.**
> 1. **Select exactly one rights path above** — the template states plainly that this is a legal
>    certification an agent must not make on your behalf, so all three boxes are left unchecked and
>    `contribution-rights` is red until you tick one.
> 2. **DCO sign-off** — neither commit (`43f0d88e`, `af7082ca`) carries a `Signed-off-by` trailer, for the same reason.
>    `.github/dco.yml` allows individual remediation commits, so `git commit --amend -s` (or a
>    remediation commit) closes it.
>
> The PR is a **draft** and is not to be merged or un-drafted without founder review.

---

Closes #1068. Part of the Join-Evidence Instrument train (#1072).

The cross-user isolation and 404-when-not-owned guarantees were asserted **only** against
`InMemoryTranscriptStore` — hand-written Python predicates (`m["user_id"] == user_id`), not the SQL
that actually enforces the boundary in production. A regression in the access UNION (an accidental
`OR`, a dropped `user_id` predicate, a filter applied before the union) or in a per-mutation
`WHERE user_id … FOR UPDATE` re-select would keep every fake-based test green while leaking across
tenants. Same failure class as the #637 advisory-lock witness: the fake never executed the SQL.

Two new files. **No `conftest.py` change, no production-source change.**

---

## Fixture design — `tests/pg_fixtures.py`

| | |
|---|---|
| **Gate** | `requires_pg` = `@pytest.mark.skipif(not os.getenv("MEETING_API_TEST_DATABASE_URL"))` — the exact shape `test_single_flight.py::test_pg_advisory_lock_runs_on_real_postgres` already established. One convention for "needs a real Postgres", not two. |
| **Isolation** | Each pytest **session** gets its own uniquely-named schema, `mapi_test_<12 hex>`, inside whatever database the URL points at. The engine pins `search_path` to it via asyncpg `server_settings`, so `Base.metadata.create_all` builds `meetings` / `transcriptions` / `meeting_sessions` — GIN indexes, partial unique index and all — entirely inside that schema. **`public` is never touched**, so pointing the env var at a scratch database with other content is safe. |
| **What it yields** | `pg_store` → `(SqlAlchemyTranscriptStore, session_factory)`. The **production adapter**, not a fake. The session factory is for seeding rows and for reading the table back to prove a refused write left no trace. Tables are `TRUNCATE … RESTART IDENTITY CASCADE`d before each test. |
| **Loop discipline** | The session-scoped fixture is **synchronous** and owns short-lived loops via `asyncio.run`. A session-scoped *async* fixture would bind an engine to pytest-asyncio's per-test loop, which is closed before teardown runs. |
| **Skip when unset** | 18 tests skip with `real-Postgres coverage; set MEETING_API_TEST_DATABASE_URL to run`. |
| **Skip when half-configured** | Env var set but drivers missing → `importorskip` reports `real-Postgres lane needs SQLAlchemy (async)` instead of a collection blow-up. (The existing advisory-lock test hard-imports `sqlalchemy` in its body and errors in that state — noted below.) |

### Teardown guarantee

Trapped twice, and the drop is idempotent (`DROP SCHEMA IF EXISTS … CASCADE`, guarded by a
once-flag) so both paths are safe:

1. **`finally:` around the `yield`** — covers a failing or erroring test.
2. **`atexit`** — covers an aborted run (`-x`, KeyboardInterrupt, a raise during collection) where
   the finalizer is never reached. Unregistered on the normal path.

The drop opens its **own** engine: the test's engine may be unusable (poisoned transaction,
connection killed mid-statement) exactly when teardown matters most. If the drop itself fails it
emits a `warning` naming the orphan schema and the exact `DROP SCHEMA` to run — it never masks the
real test failure.

**Proven, not asserted:** a deliberately-failing test was run against the fixture and the schema was
still gone afterwards (`select nspname from pg_namespace where nspname like 'mapi_test_%'` → empty).
After every run in this PR the throwaway Postgres was left with zero non-system schemas and zero
relations in `public`.

---

## The three consumers — `tests/test_pg_isolation.py`

All drive the production `SqlAlchemyTranscriptStore` against a real `meetings` table.

**1 · Cross-user isolation** (`test_cross_user_isolation_on_real_postgres`)
Two users ran a bot on the **same** native link, so `platform_specific_id` alone cannot
disambiguate them — only the `user_id` predicate can. Asserts B never sees A on any read path:
`list_meetings` (plain, `platform=`-narrowed, `meeting_id=`-addressed), `get_transcript`,
`get_transcript_by_id` (the P0 by-row path), `authorize_subscribe`. Then exercises the union's real
JSONB share branch: it **widens** for a genuine `transcript_viewers` entry (row surfaces with
`shared: true`), and does **not** widen for a type-confused string `"4002"` against the integer
probe `to_jsonb(4002)`.

**2 · 404-when-not-owned** (`test_owner_scoped_mutations_404_when_not_owned`)
Every owner-scoped write refused for a non-owner **and** proven to leave no trace — `bind_workspace`,
`connect_doc`, `disconnect_doc`, `set_intent`, `mint_transcript_share` (native-addressed) plus
`update_planned_meeting`, `delete_planned_meeting` (row-id-addressed, the shape
`merge_custom_metadata` shares). The target is a link user B has **never** run: against a shared
native a passing call could be B legitimately mutating B's own row and the assertion would prove
nothing. Rows are read straight back from Postgres and compared byte-for-byte. A positive control
runs the same calls as the owner, so the refusals are the `user_id` predicate working, not the
methods being inert.

**3 · Typed JSONB `@>` containment** (`test_jsonb_containment_typed_values_on_real_postgres`,
15 parametrized cases + `test_containment_probe_must_be_a_jsonb_object_not_a_double_encoded_string`)
The gap the #1067 review named. Number ≡ number but ≢ `"42"`; `42` ≡ `42.0`; bool ≡ bool but ≢
`"true"`; array containment is ⊆ and order-insensitive; string is case-sensitive; multi-key requires
all pairs; an absent key contains nothing. Each probe is also run for a second user holding
byte-identical `data.custom` — a filter is only ever ANDed onto the access union and must never
widen it.

---

## ⚠ Two findings this fixture produced on its first run — both about #1067, not about this PR

Neither is fixed here (different branch, different PR); both are reproduced on `postgres:16`.

**(a) The `?custom.*` filter on `feat/1064-agent-meeting-metadata` returns zero rows for every
query on real Postgres.** The shipped construction is

```python
Meeting.data.op("@>")(cast(_json.dumps({"custom": dict(custom_filter)}), JSONB))
```

`JSONB`'s bind processor serializes whatever Python value it is handed — so an **already-serialized
string** is serialized a second time and the parameter arrives as a jsonb **string scalar**
(`'"{\"custom\": …}"'`). `object @> string-scalar` is simply false: no error, no warning, just a
filter that silently matches nothing. Running that branch's actual
`SqlAlchemyTranscriptStore.list_meetings(custom_filter=…)` against real Postgres:

```
no filter                              -> [1]
custom_filter={'score': 42}            -> []
custom_filter={'owner': 'ada'}         -> []
custom_filter={'flagged': True}        -> []
custom_filter={'tags': ['sales']}      -> []
```

Fix is one line — bind the Python object and let SQLAlchemy serialize it once:
`cast({"custom": dict(custom_filter)}, JSONB)`. `merge_custom_metadata` on that branch is fine
(owner → merged dict, non-owner → `None`, verified against the same database). This is precisely the
bug class #1068 was filed to catch, and it is why
`test_containment_probe_must_be_a_jsonb_object_not_a_double_encoded_string` exists in this PR.

**(b) The nested scalar-vs-array claim in that branch's comment is false on real Postgres.** The
comment states `{"tags": ["sales","q3"]} @> {"tags": "sales"}` is TRUE and calls it "the primary
tag-filter use case". Postgres' *"an array may contain a primitive"* exception applies **only at the
top level** of the comparison, never inside an object:

```
'["foo","bar"]'::jsonb        @> '"bar"'::jsonb        → t
'{"tags":["foo","bar"]}'::jsonb @> '{"tags":"bar"}'::jsonb   → f
'{"tags":["foo","bar"]}'::jsonb @> '{"tags":["bar"]}'::jsonb → t
```

A tag filter must probe with a **one-element array**. Pinned as a case in the matrix here.

---

## Run modes

**Gated lane** (throwaway Postgres; the gate venv deliberately carries no SQLAlchemy/asyncpg —
`pyproject.toml` has no `greenlet` pin for exactly that reason — so the drivers are supplied ad-hoc):

```
docker run --rm -d --name mapi-pg -e POSTGRES_PASSWORD=test -p 5433:5432 postgres:16
MEETING_API_TEST_DATABASE_URL=postgresql+asyncpg://postgres:test@localhost:5433/postgres \
  uv run --with 'sqlalchemy[asyncio]>=2' --with asyncpg --with greenlet pytest -q
```

| Mode | Result |
|---|---|
| **Baseline** (`main`, before this PR) | `888 passed, 5 skipped` — 893 collected |
| **Default gate run** (`uv run pytest -q`, no env var) | `888 passed, 23 skipped` — 911 collected; the 18 new tests skip, **nothing else changed** |
| **PG-gated** (env var + drivers) | `909 passed, 2 skipped` — the 2 remaining skips are the pre-existing `test_lifecycle_seam.py` pair; the 18 new tests and the previously-skipped SQLAlchemy-dependent ones all run green |
| **Env var set, drivers absent** | `18 skipped` with `real-Postgres lane needs SQLAlchemy (async)` |
| **New file alone** | `18 passed in 3.5s` |

Repo gates: the 14-check pre-push set is green (`readme dataflow isolation isolation-py exports
graph graph-py schema contract-version config-contract licenses execution-env test-isolation
contract-conformance`), and `gate:python` is green across every Python package.

---

## Known gaps (honest)

1. **#1064/#1067 is not on `main`.** `custom_filter` and `merge_custom_metadata` live on the open
   PR #1067, so consumer 3 could not be driven end-to-end through
   `list_meetings(custom_filter=…)` here. It pins the `@>` semantics and the bind construction the
   filter depends on instead; consumer 2 covers the *identical* `WHERE user_id … FOR UPDATE` shape
   through the owner-scoped mutations that do ship on `main`. When #1067 merges, upgrading consumer
   3 to call `list_meetings(custom_filter=…)` and `merge_custom_metadata` is a few lines — but note
   finding (a) must be fixed first or that call cannot pass.
2. **CI does not run this lane yet.** No Postgres service and no SQLAlchemy/asyncpg in the
   meeting-api job. I deliberately did not add a `[dependency-groups]` entry to `pyproject.toml`
   because it would force a `uv.lock` regeneration on a test-only change. Wiring the workflow (a
   `postgres:16` service + `uv run --with …`) is a small follow-up and the fixture is ready for it.
3. **Pre-existing inconsistency:** `test_pg_advisory_lock_runs_on_real_postgres` hard-imports
   `sqlalchemy` inside the test body, so with the env var set and drivers absent it **errors** where
   the new lane skips. Not touched here (it is not this PR's file), but worth a one-line
   `importorskip`.
4. **The schema is built from the per-service mirror** (`meeting_api.sessions.models`), not from the
   admin-api SSOT or a migration. Mirror-vs-SSOT drift is `gate:db-schema`'s job, not this
   fixture's — naming it so nobody reads this lane as drift coverage.
5. **No concurrency coverage** — two sessions racing the same `FOR UPDATE` row is a real property
   this fixture now makes testable, but it is outside #1068's ask.
6. **Session-scoped schema, function-scoped truncate.** Tests in this file are not safe to run under
   `pytest-xdist` against one schema; nothing in the repo runs them that way today.
