### PR TITLE
Point Claude Desktop or an IDE at Vexa over MCP — the /vexa-mcp page, with the hosted-vs-self-host boundary stated

### DIFF
--- a/core/meetings/services/mcp/README.md
+++ b/core/meetings/services/mcp/README.md
@@ -114,5 +114,10 @@ caller's `X-API-Key`; fail-closed 401; downstream status/detail passthrough).
 - ✅ delivered — 9 tools + 4 prompts over the v0.12 public API, streamable-HTTP `/mcp` mount
 - ✅ delivered — auth passthrough (Bearer / raw Authorization / X-API-Key → gateway `X-API-Key`)
 - ✅ delivered — compose service (`mcp`, port 8010) + healthcheck
-- ⬜ planned — gateway-fronted `/mcp` (streamed forward at the edge)
+- 🟡 shipped, unwitnessed — gateway-fronted `/mcp` (streamed forward at the edge, #795). The
+  forward is in the gateway and in compose, and is module-tested (streamed relay, verbatim status,
+  typed 502/504) — but no real MCP client has completed a session against it (#888). See
+  [Gateway exposure](#gateway-exposure) above, which this line contradicted while it read "planned".
+- ⬜ not deployed — helm/hosted. The chart carries no MCP service and no `/mcp` route, so the
+  capability is self-hosted-compose-only today (#1035).
 - ⬜ planned — the blocked tool set above, as the REST routes reach parity

--- a/docs/changelog.d/1077-vexa-mcp-page.md
+++ b/docs/changelog.d/1077-vexa-mcp-page.md
@@ -1,0 +1,7 @@
+- **The MCP server has a page, and it states the boundary (#1077).** New [MCP server](/vexa-mcp)
+  page lists the nine tools, gives a working client config, and says plainly what the surface does
+  and does not cover: fronted by the gateway at `/mcp` on self-hosted compose from 0.12.18, **not**
+  deployed by the Helm chart and therefore unavailable on hosted or Kubernetes, and never proven
+  against a real MCP client end to end ([#888](https://github.com/Vexa-ai/vexa/issues/888)). The
+  service README's Status block, which still listed the gateway-fronted `/mcp` forward as planned
+  while its own body documented the shipped behaviour, now matches.

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -100,6 +100,7 @@
           "security-compliance",
           "troubleshooting",
           "sdks",
+          "vexa-mcp",
           "changelog"
         ]
       },

--- a/docs/docs/vexa-mcp.mdx
+++ b/docs/docs/vexa-mcp.mdx
@@ -1,0 +1,100 @@
+---
+title: "MCP server"
+description: "Vexa's meeting capabilities as MCP tools — working on self-hosted compose, not yet on hosted or Kubernetes."
+---
+
+<Warning>
+**Read the boundary before you wire anything.** The MCP server is real, runs as its own service,
+and is fronted by the gateway at `/mcp` on **self-hosted Docker Compose from 0.12.18 onward**. It is
+**not available on hosted [vexa.ai](https://vexa.ai), and not available on Kubernetes** — the Helm
+chart does not deploy the service at all, so there is no `/mcp` route there to point a client at.
+
+The gateway forward is module-tested (streamed relay, verbatim status, typed 502/504) but the
+transport has **not been proven against a real MCP client end-to-end**
+([#888](https://github.com/Vexa-ai/vexa/issues/888)). Treat a working session as something you
+should verify yourself, not something we have witnessed for you.
+</Warning>
+
+## What it is
+
+An MCP client — Claude Desktop, an IDE, any MCP-compatible agent — gets Vexa's meeting capabilities
+as standard **MCP tools and prompts**, with no bespoke API integration.
+
+The service is a stateless FastAPI app whose routes *are* the tools. It wraps the **public API
+only**: every tool call forwards the caller's credential to the gateway as `X-API-Key`, and the
+gateway resolves the key and enforces scopes. It holds no credentials, touches no database, and
+never reaches into other services directly.
+
+## Tools
+
+Nine tools, plus four prompts (`vexa.meeting_prep` · `vexa.during_meeting` · `vexa.post_meeting` ·
+`vexa.teams_link_help`).
+
+| Tool | Wraps |
+|---|---|
+| `parse_meeting_link` | pure — URL to platform / `native_meeting_id` / passcode, no gateway hop |
+| `request_meeting_bot` | `POST /bots` (accepts `meeting_url` **or** `native_meeting_id`) |
+| `get_bot_status` | `GET /bots/status` |
+| `update_bot_config` | `PUT /bots/{platform}/{native}/config` |
+| `stop_bot` | `DELETE /bots/{platform}/{native}` |
+| `list_meetings` | `GET /meetings` |
+| `get_meeting_transcript` | `GET /transcripts/{platform}/{native}` |
+| `list_recordings` | `GET /recordings` |
+| `get_recording` | `GET /recordings/{recording_id}` |
+
+## Connect a client (self-hosted compose)
+
+Requires a compose deployment on **0.12.18 or later** — that is the release in which the gateway
+began fronting `/mcp`.
+
+```json
+{
+  "mcpServers": {
+    "Vexa": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:18056/mcp",
+               "--header", "Authorization: Bearer ${VEXA_API_KEY}"]
+    }
+  }
+}
+```
+
+`18056` is the compose `API_GATEWAY_HOST_PORT`. Point at the gateway, not at the MCP service's own
+port — the gateway is the authenticated front door.
+
+The key may arrive as `X-API-Key` or as the MCP transport's `Authorization: Bearer <key>`; both are
+forwarded on. Auth at the edge is fail-closed and identical to every other route
+([Authentication](/authentication)).
+
+<Note>
+The MCP service also publishes a direct host port (`127.0.0.1:18010` by default) for local
+debugging. **It bypasses the gateway, and therefore bypasses authentication.** Do not expose it.
+</Note>
+
+### How the transport is forwarded
+
+The two legs of streamable HTTP are forwarded differently, and the difference is the point
+([#795](https://github.com/Vexa-ai/vexa/issues/795)):
+
+| Leg | What it is | How the gateway forwards it |
+|---|---|---|
+| `POST /mcp` (and `PUT`/`PATCH`/`DELETE`/`OPTIONS`) | a message — short request/response JSON | buffered forward, status and body verbatim |
+| `GET /mcp` | the server-to-client SSE stream: headers, then silence until the server pushes | **relayed unbuffered**, on a dedicated streaming client |
+
+Buffering the `GET` leg is what produced the original failure: the proxy waits on the next body read
+of a healthy-but-silent stream, hits its read timeout, and manufactures a `503` the MCP service
+never sees.
+
+## What is not available
+
+- **Hosted.** No MCP endpoint on [vexa.ai](https://vexa.ai).
+- **Kubernetes / Helm.** The chart deploys no MCP service and defines no route — see
+  [#1035](https://github.com/Vexa-ai/vexa/issues/1035).
+- **End-to-end proof.** No real MCP client session has been witnessed
+  ([#888](https://github.com/Vexa-ai/vexa/issues/888)).
+- **Tools blocked on API parity** — these wrap REST routes the public API does not expose yet, and
+  will be ported when the routes land: `delete_recording` · `get_recording_media_download` ·
+  `get_recording_config` / `update_recording_config` · `create_transcript_share_link` ·
+  `update_meeting_data` / `delete_meeting` · `get_meeting_bundle`.
+
+The live status row for this feature is maintained on [Roadmap → Status](/roadmap/status).


### PR DESCRIPTION
**Trigger:** the /vexa-mcp condenser crossing (truth: partial). Sustained measured demand on the retired path (private register). Page: honest-status — compose serves gateway /mcp (>=0.12.18), helm/prod does not, not yet witnessed by a real MCP client (#888); plus the stale MCP README Status fix (verified: zero mcp matches in deploy/helm). Docs-only; static checks green.