### PR TITLE
[DEV] fix(meetings): distinguish calendar discovery faults from absence

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -149,19 +149,33 @@ def build_production_app():
 
     # Calendar-sync user edges (GET/POST /user/calendar/sync): the SAME one-user pass the
     # background sweep runs, on demand — paste-a-feed gets an immediate result instead of a
-    # silent wait for the next tick (fail loud to the user). None-returns mean "no feed / sync
-    # unavailable" and the route answers 404/503 accordingly.
+    # silent wait for the next tick (fail loud to the user). ``None`` means authoritative no-feed;
+    # typed discovery faults remain retryable 503s and are never collapsed into that 404.
     async def _calendar_sync_now(user_id: int):
         admin_api_url = (os.getenv("ADMIN_API_URL") or "").rstrip("/")
         internal_secret = os.getenv("INTERNAL_API_SECRET") or ""
-        if not (admin_api_url and internal_secret):
-            return None
         import json as _json
+        from datetime import datetime, timezone
 
-        from .calendar_sync import fetch_configs, run_user_sync, store_stamp
+        from .calendar_sync import (
+            CALENDAR_CONFIG_UNAVAILABLE_DETAIL,
+            CalendarConfigDiscoveryError,
+            CalendarConfigDiscoveryKind,
+            fetch_user_config,
+            run_user_sync,
+            store_stamp,
+        )
 
-        configs = await fetch_configs(admin_api_url, internal_secret)
-        cfg = next((c for c in configs or [] if c.get("user_id") == user_id), None)
+        try:
+            if not (admin_api_url and internal_secret):
+                raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.CONFIGURATION)
+            cfg = await fetch_user_config(admin_api_url, internal_secret, user_id)
+        except CalendarConfigDiscoveryError:
+            await store_stamp(redis_client, user_id, {
+                "last_sync": datetime.now(timezone.utc).isoformat(),
+                "last_error": CALENDAR_CONFIG_UNAVAILABLE_DETAIL,
+            })
+            raise
         if cfg is None:
             return None
 
@@ -589,7 +603,7 @@ def _attach_background_loops(
 
         async def _tick():
             configs = await fetch_configs(admin_api_url, internal_secret)
-            for cfg in configs or []:
+            for cfg in configs:
                 try:  # one bad feed never stalls the sweep
                     stamp = await run_user_sync(transcript_store, cfg, publish=_cal_publish)
                 except Exception:

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/__init__.py
@@ -4,7 +4,15 @@ Public surface: ``parse_ics`` / ``sync_user`` (pure logic), the production I/O a
 ``fetch_ics`` / ``fetch_configs``, and the shared one-user pass ``run_user_sync`` (+ stamp
 helpers) used by BOTH the entrypoint's background poll loop and the user-facing sync-now edge.
 """
-from .adapters import fetch_configs, fetch_ics
+from .adapters import (
+    CALENDAR_CONFIG_UNAVAILABLE_DETAIL,
+    CalendarConfig,
+    CalendarConfigDiscoveryError,
+    CalendarConfigDiscoveryKind,
+    fetch_configs,
+    fetch_ics,
+    fetch_user_config,
+)
 from .service import parse_ics, sync_user
 
 
@@ -15,5 +23,9 @@ def __getattr__(name):  # lazy: runner imports back from this package
     raise AttributeError(name)
 
 
-__all__ = ["parse_ics", "sync_user", "fetch_ics", "fetch_configs",
-           "run_user_sync", "store_stamp", "read_stamp"]
+__all__ = [
+    "parse_ics", "sync_user", "fetch_ics", "fetch_configs", "fetch_user_config",
+    "CalendarConfig", "CalendarConfigDiscoveryError", "CalendarConfigDiscoveryKind",
+    "CALENDAR_CONFIG_UNAVAILABLE_DETAIL",
+    "run_user_sync", "store_stamp", "read_stamp",
+]

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/adapters.py
@@ -7,13 +7,48 @@ flip can never turn the poller into an internal-network probe. Size-capped: a fe
 ``MAX_ICS_BYTES`` is refused, not parsed.
 
 ``fetch_configs`` asks admin-api's internal edge (X-Internal-Secret) which users have a feed
-connected — the secret URL crosses only this internal hop.
+connected — the secret URL crosses only this internal hop. A validated list (including ``[]``)
+is authoritative. Transport/auth/upstream/shape faults raise a typed, sanitized exception so a
+caller can never mistake an unavailable identity service for "no feed connected".
 """
 from __future__ import annotations
 
-from typing import Optional
+from enum import StrEnum
+from typing import Optional, TypedDict
 
 MAX_ICS_BYTES = 2 * 1024 * 1024  # 2 MB — a personal calendar feed is KBs; refuse anything huge
+CALENDAR_CONFIG_UNAVAILABLE_DETAIL = "calendar configuration is temporarily unavailable"
+
+
+class CalendarConfig(TypedDict):
+    user_id: int
+    ics_url: str
+    auto_join: bool
+
+
+class CalendarConfigDiscoveryKind(StrEnum):
+    CONFIGURATION = "configuration"
+    TRANSPORT = "transport"
+    CONNECTIVITY = "connectivity"
+    AUTHENTICATION = "authentication"
+    UPSTREAM_STATUS = "upstream_status"
+    RESPONSE_SHAPE = "response_shape"
+
+
+class CalendarConfigDiscoveryError(RuntimeError):
+    """Sanitized failure of admin-api's internal calendar-config discovery edge.
+
+    ``kind`` is safe for system telemetry. The exception deliberately carries no URL, credential,
+    response body, user/account id, or underlying exception text.
+    """
+
+    source = "admin_api.calendar_configs"
+
+    def __init__(self, kind: CalendarConfigDiscoveryKind):
+        if not isinstance(kind, CalendarConfigDiscoveryKind):
+            raise TypeError("kind must be a CalendarConfigDiscoveryKind")
+        self.kind = kind
+        super().__init__(f"calendar config discovery failed ({kind.value})")
 
 
 async def fetch_ics(url: str, *, timeout_s: float = 15.0) -> tuple[Optional[str], Optional[str]]:
@@ -49,21 +84,74 @@ async def fetch_ics(url: str, *, timeout_s: float = 15.0) -> tuple[Optional[str]
 
 
 async def fetch_configs(admin_api_url: str, internal_secret: str,
-                        *, timeout_s: float = 10.0) -> Optional[list[dict]]:
-    """``[{user_id, ics_url, auto_join}]`` from admin-api's internal calendar-configs edge, or
-    ``None`` when identity is unreachable (the sweep skips the tick — fail-closed, not fail-silent)."""
+                        *, timeout_s: float = 10.0) -> list[CalendarConfig]:
+    """Return admin-api's authoritative ``[{user_id, ics_url, auto_join}]`` list.
+
+    A successful empty list means no user has a feed. Every non-authoritative outcome raises
+    ``CalendarConfigDiscoveryError``; callers may therefore reserve absence/404 for a completed,
+    validated discovery response only.
+    """
     import httpx
+
+    if not admin_api_url or not internal_secret:
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.CONFIGURATION)
+    try:
+        parsed_admin_api_url = httpx.URL(admin_api_url)
+    except (TypeError, httpx.InvalidURL):
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.CONFIGURATION) from None
+    if parsed_admin_api_url.scheme not in ("http", "https") or not parsed_admin_api_url.host:
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.CONFIGURATION)
+    endpoint = f"{str(parsed_admin_api_url).rstrip('/')}/internal/calendar-configs"
 
     try:
         async with httpx.AsyncClient(timeout=timeout_s) as client:
             resp = await client.get(
-                f"{admin_api_url.rstrip('/')}/internal/calendar-configs",
+                endpoint,
                 headers={"X-Internal-Secret": internal_secret},
             )
-        if resp.status_code != 200:
-            return None
+    except (httpx.InvalidURL, httpx.UnsupportedProtocol, httpx.LocalProtocolError):
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.CONFIGURATION) from None
+    except httpx.TimeoutException:
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.TRANSPORT) from None
+    except httpx.RequestError:
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.CONNECTIVITY) from None
+
+    if resp.status_code in (401, 403):
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.AUTHENTICATION)
+    if resp.status_code != 200:
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.UPSTREAM_STATUS)
+
+    try:
         body = resp.json()
-        configs = body.get("configs") if isinstance(body, dict) else None
-        return configs if isinstance(configs, list) else None
-    except Exception:
-        return None
+    except ValueError:
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.RESPONSE_SHAPE) from None
+
+    configs = body.get("configs") if isinstance(body, dict) else None
+    if not isinstance(configs, list):
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.RESPONSE_SHAPE)
+    validated: list[CalendarConfig] = []
+    seen_user_ids: set[int] = set()
+    for cfg in configs:
+        if not isinstance(cfg, dict):
+            raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.RESPONSE_SHAPE)
+        user_id = cfg.get("user_id")
+        if not isinstance(user_id, int) or isinstance(user_id, bool) or user_id in seen_user_ids:
+            raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.RESPONSE_SHAPE)
+        seen_user_ids.add(user_id)
+        if not isinstance(cfg.get("ics_url"), str) or not cfg["ics_url"]:
+            raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.RESPONSE_SHAPE)
+        if not isinstance(cfg.get("auto_join"), bool):
+            raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.RESPONSE_SHAPE)
+        validated.append({
+            "user_id": user_id,
+            "ics_url": cfg["ics_url"],
+            "auto_join": cfg["auto_join"],
+        })
+    return validated
+
+
+async def fetch_user_config(admin_api_url: str, internal_secret: str, user_id: int,
+                            *, timeout_s: float = 10.0) -> Optional[CalendarConfig]:
+    """Return the gateway-bound user's config, or ``None`` after authoritative absence only."""
+    configs = await fetch_configs(admin_api_url, internal_secret, timeout_s=timeout_s)
+    return next((cfg for cfg in configs if cfg["user_id"] == user_id), None)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -294,7 +294,30 @@ def build_router(
         user_id = _resolve_user_id(x_user_id)
         if calendar_sync_now is None:
             raise HTTPException(status_code=503, detail="calendar sync is not available")
-        stamp = await calendar_sync_now(user_id)
+        from ..calendar_sync import (
+            CALENDAR_CONFIG_UNAVAILABLE_DETAIL,
+            CalendarConfigDiscoveryError,
+        )
+
+        try:
+            stamp = await calendar_sync_now(user_id)
+        except CalendarConfigDiscoveryError as exc:
+            log_event(
+                "calendar_config_discovery_failed",
+                audience="system",
+                level="warning",
+                span="calendar.sync.discovery",
+                fields={"source": exc.source, "reason": exc.kind.value},
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "detail": CALENDAR_CONFIG_UNAVAILABLE_DETAIL,
+                    "code": "calendar_config_discovery_unavailable",
+                    "retryable": True,
+                },
+                headers={"Retry-After": "1", "Cache-Control": "no-store"},
+            )
         if stamp is None:
             raise HTTPException(status_code=404, detail="no calendar feed connected")
         return stamp

--- a/core/meetings/services/meeting-api/src/meeting_api/webhooks/ssrf.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/webhooks/ssrf.py
@@ -115,6 +115,11 @@ def _is_blocked_ip(ip_str: str) -> bool:
         ip = ipaddress.ip_address(ip_str)
     except ValueError:
         return True  # not a valid IP — block
+    # IPv4-mapped IPv6 (for example ::ffff:127.0.0.1) carries an IPv4 address through an IPv6
+    # literal. Classify the embedded address against the IPv4 blocklist; otherwise mapped
+    # loopback/private/metadata targets bypass the IPv6-only ranges below.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
     nets = _BLOCKED_IPV4_NETWORKS if ip.version == 4 else _BLOCKED_IPV6_NETWORKS
     return any(ip in net for net in nets)
 

--- a/core/meetings/services/meeting-api/tests/test_calendar_config_discovery.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_config_discovery.py
@@ -1,0 +1,136 @@
+"""#991 — admin-api calendar-config discovery keeps faults distinct from absence.
+
+The internal edge has three outcomes: a validated config list (possibly empty), a matching
+gateway-bound user's config (or authoritative absence), and a typed retryable discovery fault.
+Secret URLs, internal credentials, and response bodies never enter the exception surface.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from meeting_api.calendar_sync import (
+    CalendarConfigDiscoveryError,
+    CalendarConfigDiscoveryKind,
+    fetch_configs,
+    fetch_user_config,
+)
+
+ADMIN = "http://admin-api:8001"
+SECRET = "do-not-log-this-secret"
+
+
+def _mock_http(monkeypatch, handler):
+    real_client = httpx.AsyncClient
+
+    def client(*args, **kwargs):
+        return real_client(*args, transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client)
+
+
+async def test_authoritative_empty_is_a_successful_list(monkeypatch):
+    _mock_http(monkeypatch, lambda request: httpx.Response(200, json={"configs": []}))
+
+    assert await fetch_configs(ADMIN, SECRET) == []
+    assert await fetch_user_config(ADMIN, SECRET, 28) is None
+
+
+async def test_saved_config_discovery_selects_only_the_bound_user(monkeypatch):
+    configs = [
+        {"user_id": 11, "ics_url": "https://calendar.example/a.ics", "auto_join": True},
+        {"user_id": 28, "ics_url": "https://calendar.example/b.ics", "auto_join": False},
+    ]
+    seen = {}
+
+    def handler(request):
+        seen["path"] = request.url.path
+        seen["secret"] = request.headers.get("X-Internal-Secret")
+        return httpx.Response(200, json={"configs": configs})
+
+    _mock_http(monkeypatch, handler)
+
+    found = await fetch_user_config(ADMIN, SECRET, 28)
+    assert found == configs[1]
+    assert seen == {"path": "/internal/calendar-configs", "secret": SECRET}
+
+
+@pytest.mark.parametrize(
+    ("admin_api_url", "internal_secret"),
+    [
+        ("", SECRET),
+        ("http://", SECRET),
+        ("ftp://admin-api:8001", SECRET),
+        (ADMIN, ""),
+    ],
+)
+async def test_invalid_discovery_configuration_is_typed_and_sanitized(
+    admin_api_url, internal_secret,
+):
+    with pytest.raises(CalendarConfigDiscoveryError) as caught:
+        await fetch_configs(admin_api_url, internal_secret)
+
+    assert caught.value.kind is CalendarConfigDiscoveryKind.CONFIGURATION
+    assert SECRET not in str(caught.value)
+    if admin_api_url:
+        assert admin_api_url not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "kind"),
+    [
+        (401, {"detail": "rejected"}, "authentication"),
+        (403, {"detail": "rejected"}, "authentication"),
+        (500, {"detail": "database unavailable"}, "upstream_status"),
+        (200, {"wrong": []}, "response_shape"),
+        (200, {"configs": [{"user_id": 28}]}, "response_shape"),
+        (200, {"configs": [
+            {"user_id": 28, "ics_url": "https://calendar.example/a.ics"},
+        ]}, "response_shape"),
+        (200, {"configs": [
+            {"user_id": True, "ics_url": "https://calendar.example/a.ics", "auto_join": True},
+        ]}, "response_shape"),
+        (200, {"configs": [
+            {"user_id": 28, "ics_url": "https://calendar.example/a.ics", "auto_join": True},
+            {"user_id": 28, "ics_url": "https://calendar.example/b.ics", "auto_join": False},
+        ]}, "response_shape"),
+    ],
+)
+async def test_upstream_faults_are_typed_and_sanitized(monkeypatch, status, body, kind):
+    _mock_http(monkeypatch, lambda request: httpx.Response(status, json=body))
+
+    with pytest.raises(CalendarConfigDiscoveryError) as caught:
+        await fetch_configs(ADMIN, SECRET)
+
+    assert caught.value.kind is CalendarConfigDiscoveryKind(kind)
+    assert SECRET not in str(caught.value)
+    assert "calendar.example" not in str(caught.value)
+    assert "database unavailable" not in str(caught.value)
+
+
+async def test_invalid_json_is_a_typed_response_shape_fault(monkeypatch):
+    _mock_http(monkeypatch, lambda request: httpx.Response(200, text="not-json"))
+
+    with pytest.raises(CalendarConfigDiscoveryError, match="response_shape"):
+        await fetch_configs(ADMIN, SECRET)
+
+
+@pytest.mark.parametrize(
+    ("error_type", "kind"),
+    [
+        (httpx.ReadTimeout, "transport"),
+        (httpx.ConnectError, "connectivity"),
+    ],
+)
+async def test_transport_faults_are_typed_and_sanitized(monkeypatch, error_type, kind):
+    def handler(request):
+        raise error_type("sensitive network detail", request=request)
+
+    _mock_http(monkeypatch, handler)
+
+    with pytest.raises(CalendarConfigDiscoveryError) as caught:
+        await fetch_configs(ADMIN, SECRET)
+
+    assert caught.value.kind is CalendarConfigDiscoveryKind(kind)
+    assert "sensitive network detail" not in str(caught.value)
+    assert SECRET not in str(caught.value)

--- a/core/meetings/services/meeting-api/tests/test_calendar_sync_edges.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_sync_edges.py
@@ -13,6 +13,7 @@ from fastapi.testclient import TestClient
 
 from meeting_api.collector import create_app
 from meeting_api.collector.fakes import InMemoryTranscriptStore
+from meeting_api.calendar_sync import CalendarConfigDiscoveryError, CalendarConfigDiscoveryKind
 
 
 class _CaptureRedis:
@@ -69,6 +70,39 @@ def test_post_sync_now_404_when_no_feed():
     client, _ = _client(now_result=None)
     r = client.post("/user/calendar/sync", headers={"X-User-Id": "28"})
     assert r.status_code == 404
+
+
+def test_post_sync_discovery_fault_is_sanitized_retryable_503():
+    events = []
+
+    async def sync_now(_user_id: int):
+        raise CalendarConfigDiscoveryError(CalendarConfigDiscoveryKind.AUTHENTICATION)
+
+    def log_event(name, **fields):
+        events.append({"name": name, **fields})
+        return events[-1]
+
+    app = create_app(
+        InMemoryTranscriptStore(), redis=_CaptureRedis(),
+        calendar_sync_now=sync_now, calendar_sync_status=None,
+        log_event=log_event,
+    )
+    r = TestClient(app).post("/user/calendar/sync", headers={"X-User-Id": "28"})
+
+    assert r.status_code == 503
+    assert r.json() == {
+        "detail": "calendar configuration is temporarily unavailable",
+        "code": "calendar_config_discovery_unavailable",
+        "retryable": True,
+    }
+    assert r.headers["Retry-After"] == "1"
+    assert r.headers["Cache-Control"] == "no-store"
+    assert events[-1]["name"] == "calendar_config_discovery_failed"
+    assert events[-1]["fields"] == {
+        "source": "admin_api.calendar_configs",
+        "reason": "authentication",
+    }
+    assert "secret" not in repr(events).lower()
 
 
 def test_unwired_hooks_503():

--- a/core/meetings/services/meeting-api/tests/test_webhook_ssrf.py
+++ b/core/meetings/services/meeting-api/tests/test_webhook_ssrf.py
@@ -32,6 +32,8 @@ _PUBLIC = lambda host: ["93.184.216.34"]    # noqa: E731 — a public IP
         "http://192.168.1.10/hook",        # private
         "http://169.254.169.254/latest",   # cloud metadata (link-local)
         "https://[::1]/hook",              # ipv6 loopback
+        "https://[::ffff:127.0.0.1]/hook", # IPv4-mapped IPv6 loopback
+        "https://[::ffff:169.254.169.254]/", # IPv4-mapped cloud metadata
         "http://redis/hook",               # internal Docker service
         "http://meeting-api/internal",     # internal Docker service
         "http://metadata.google.internal/", # cloud metadata hostname

--- a/deploy/compose/tests/calendar-sync-wrong-secret.yml
+++ b/deploy/compose/tests/calendar-sync-wrong-secret.yml
@@ -1,0 +1,4 @@
+services:
+  meeting-api:
+    environment:
+      - INTERNAL_API_SECRET=t303-intentionally-wrong-internal-secret

--- a/deploy/compose/tests/calendar_sync_auth_fault_two_service_test.py
+++ b/deploy/compose/tests/calendar_sync_auth_fault_two_service_test.py
@@ -1,0 +1,123 @@
+"""#991 — real admin-api rejection remains a retryable meeting-api fault, never absence."""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+
+from conftest import http, requires_docker
+
+AUTH_FAULT_OVERLAY_ACTIVE = os.getenv("T303_CALENDAR_AUTH_FAULT") == "1"
+pytestmark = [
+    requires_docker,
+    pytest.mark.skipif(
+        not AUTH_FAULT_OVERLAY_ACTIVE,
+        reason="requires the explicit calendar-sync wrong-secret Compose overlay",
+    ),
+]
+
+WRONG_INTERNAL_SECRET = "t303-intentionally-wrong-internal-secret"
+
+
+def _admin_headers(stack):
+    return {"X-Admin-API-Key": stack.admin_token, "Content-Type": "application/json"}
+
+
+def _create_user_and_token(stack) -> tuple[int, str]:
+    email = f"calendar-991-auth-{uuid.uuid4().hex[:8]}@vexa.ai"
+    code, body = http(
+        "POST",
+        f"{stack.admin_api}/admin/users",
+        headers=_admin_headers(stack),
+        body=json.dumps({"email": email, "name": "calendar-991-auth", "max_concurrent_bots": 1}).encode(),
+    )
+    assert code in (200, 201), f"create user: {code} {body}"
+    user_id = body["id"]
+    code, body = http(
+        "POST",
+        f"{stack.admin_api}/admin/users/{user_id}/tokens?scopes=bot",
+        headers=_admin_headers(stack),
+        body=b"",
+    )
+    assert code == 201, f"mint token: {code} {body}"
+    return user_id, body["token"]
+
+
+def test_real_admin_rejection_is_retryable_503_not_false_404(stack):
+    user_id, token = _create_user_and_token(stack)
+    marker = "t303-auth-fault-private-feed-marker"
+    # Loopback keeps this test fail-closed even if its opt-in/overlay guard is later changed.
+    feed_url = f"https://127.0.0.1/{marker}/calendar.ics"
+    auth = {"X-API-Key": token, "Content-Type": "application/json"}
+
+    effective_secret = stack.exec(
+        "meeting-api", "python", "-c",
+        "import os; print(os.environ.get('INTERNAL_API_SECRET', ''))",
+    )
+    assert effective_secret == WRONG_INTERNAL_SECRET
+
+    code, saved = http(
+        "PUT",
+        f"{stack.gateway}/user/calendar",
+        headers=auth,
+        body=json.dumps({"ics_url": feed_url, "auto_join": False}).encode(),
+    )
+    assert code == 200, f"calendar save: {code} {saved}"
+    assert saved["ics_url_set"] is True
+    assert saved["auto_join"] is False
+    assert marker not in json.dumps(saved)
+
+    # The producer has the row under its correct internal credential.
+    code, discovered = http(
+        "GET",
+        f"{stack.admin_api}/internal/calendar-configs",
+        headers={"X-Internal-Secret": stack.internal_secret},
+    )
+    assert code == 200
+    assert any(cfg["user_id"] == user_id and cfg["ics_url"] == feed_url
+               for cfg in discovered["configs"])
+
+    # The exact credential meeting-api uses in this overlay is rejected by the real admin-api.
+    code, rejected = http(
+        "GET",
+        f"{stack.admin_api}/internal/calendar-configs",
+        headers={"X-Internal-Secret": WRONG_INTERNAL_SECRET},
+    )
+    assert code == 403, f"wrong-secret control: {code} {rejected}"
+
+    code, fault = http(
+        "POST",
+        f"{stack.gateway}/user/calendar/sync",
+        headers={"X-API-Key": token},
+    )
+    assert code == 503, f"sync discovery fault: {code} {fault}"
+    assert fault == {
+        "detail": "calendar configuration is temporarily unavailable",
+        "code": "calendar_config_discovery_unavailable",
+        "retryable": True,
+    }
+    assert code != 404
+
+    code, stamp = http(
+        "GET",
+        f"{stack.gateway}/user/calendar/sync",
+        headers={"X-API-Key": token},
+    )
+    assert code == 200
+    assert stamp["last_error"] == "calendar configuration is temporarily unavailable"
+    assert marker not in json.dumps(stamp)
+    assert WRONG_INTERNAL_SECRET not in json.dumps(stamp)
+
+    logs_by_service = {
+        service: stack.logs(service)
+        for service in ("meeting-api", "gateway", "admin-api")
+    }
+    meeting_logs = logs_by_service["meeting-api"]
+    assert "calendar_config_discovery_failed" in meeting_logs
+    assert "authentication" in meeting_logs
+    for logs in logs_by_service.values():
+        assert marker not in logs
+        assert WRONG_INTERNAL_SECRET not in logs
+        assert token not in logs

--- a/deploy/compose/tests/calendar_sync_two_service_test.py
+++ b/deploy/compose/tests/calendar_sync_two_service_test.py
@@ -1,0 +1,105 @@
+"""#991 — real admin-api save → meeting-api discovery → user sync witness.
+
+This is deliberately a Compose test, not a route-level fake: one gateway-bound identity saves its
+calendar in admin-api's Postgres-backed user record; meeting-api discovers that record over the
+real internal edge and reaches the SSRF-pinned feed-fetch stage. A second identity with no saved
+feed is the authoritative-absence control and must not inherit the first identity's config.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+from conftest import http, requires_docker
+
+pytestmark = requires_docker
+
+
+def _admin_headers(stack):
+    return {"X-Admin-API-Key": stack.admin_token, "Content-Type": "application/json"}
+
+
+def _create_user_and_token(stack) -> tuple[int, str]:
+    email = f"calendar-991-{uuid.uuid4().hex[:8]}@vexa.ai"
+    code, body = http(
+        "POST",
+        f"{stack.admin_api}/admin/users",
+        headers=_admin_headers(stack),
+        body=json.dumps({"email": email, "name": "calendar-991", "max_concurrent_bots": 1}).encode(),
+    )
+    assert code in (200, 201), f"create user: {code} {body}"
+    user_id = body["id"]
+    code, body = http(
+        "POST",
+        f"{stack.admin_api}/admin/users/{user_id}/tokens?scopes=bot",
+        headers=_admin_headers(stack),
+        body=b"",
+    )
+    assert code == 201, f"mint token: {code} {body}"
+    return user_id, body["token"]
+
+
+def test_saved_calendar_is_discovered_by_sync_for_the_same_identity(stack):
+    connected_user, token = _create_user_and_token(stack)
+    absent_user, absent_token = _create_user_and_token(stack)
+    marker = "t303-private-feed-marker"
+    # Loopback is accepted as a stored http(s) URL but refused by meeting-api's SSRF-pinned fetch.
+    # That deterministic safe refusal proves discovery reached feed fetch without any outside call.
+    feed_url = f"https://127.0.0.1/{marker}/calendar.ics"
+    connected_auth = {"X-API-Key": token, "Content-Type": "application/json"}
+
+    code, saved = http(
+        "PUT",
+        f"{stack.gateway}/user/calendar",
+        headers=connected_auth,
+        body=json.dumps({"ics_url": feed_url, "auto_join": False}).encode(),
+    )
+    assert code == 200, f"calendar save: {code} {saved}"
+    assert saved["ics_url_set"] is True
+    assert saved["auto_join"] is False
+    assert marker not in json.dumps(saved)
+
+    # The producer's internal response is authoritative and keyed to the saved user.
+    code, discovered = http(
+        "GET",
+        f"{stack.admin_api}/internal/calendar-configs",
+        headers={"X-Internal-Secret": stack.internal_secret},
+    )
+    assert code == 200, f"config discovery: {code} {discovered}"
+    assert {
+        "user_id": connected_user,
+        "ics_url": feed_url,
+        "auto_join": False,
+    } in discovered["configs"]
+
+    # Same identity: discovery succeeds and the request reaches feed fetch, so the result is a
+    # precise 200 sync stamp—not the misleading 404 "no calendar feed connected" from #991.
+    code, stamp = http(
+        "POST",
+        f"{stack.gateway}/user/calendar/sync",
+        headers={"X-API-Key": token},
+    )
+    assert code == 200, f"saved-config sync: {code} {stamp}"
+    assert stamp["last_error"] == "couldn't reach the URL (unreachable, timed out, or a blocked/internal address)"
+    assert marker not in json.dumps(stamp)
+    assert token not in json.dumps(stamp)
+
+    # The sanitized stamp is durable across the POST→GET service edge.
+    code, readback = http(
+        "GET",
+        f"{stack.gateway}/user/calendar/sync",
+        headers={"X-API-Key": token},
+    )
+    assert code == 200
+    assert readback == stamp
+
+    # Different bound identity: the completed authoritative list proves this user absent. It must
+    # neither select the connected user's feed nor turn absence into a retryable upstream fault.
+    code, missing = http(
+        "POST",
+        f"{stack.gateway}/user/calendar/sync",
+        headers={"X-API-Key": absent_token},
+    )
+    assert absent_user != connected_user
+    assert code == 404
+    assert missing == {"detail": "no calendar feed connected"}


### PR DESCRIPTION
**Delivers issue:** Part of #991. **Still a draft, deliberately** — one blocking incompatibility is named below, and it is not the author's call to resolve.

## Rung

**Built, rebased, unit-green at current `main`. Not ready for review.** Nothing here is merged, released, in an image, installed, or seen by the reporter.

## What changed 2026-08-19

The branch sat untouched for eleven days on a 2026-08-04 base. It is now rebased onto `main` at `e0b356d6`; the rebase changed no logical content (the diff against the new base is byte-identical to the diff against the old base, modulo hunk offsets).

    uv run --offline --project core/meetings/services/meeting-api pytest -q core/meetings/services/meeting-api/tests
    # 934 passed, 5 skipped, 1 warning in 14.35s   (at 2223efe2, base e0b356d6)

Re-run live, not quoted from the previous checkpoint.

## Blocking finding — this validator rejects the wire shape production already serves

`fetch_configs` in this branch raises `RESPONSE_SHAPE` when the `/internal/calendar-configs` response contains a row with no `ics_url`, or two rows carrying the same `user_id`. Both shapes are exactly what #1151's `admin_api/app/calendars.py::internal_connections` emits — multiple connections per user, plus URL-less `deleted` and `paused` tombstones — and production is already serving those routes.

Probed live: this branch's `fetch_configs`, over a real HTTP hop, against payloads produced by calling #1151's own `internal_connections`.

| Payload from `internal_connections` | This branch's `fetch_configs` | Route answers |
|---|---|---|
| legacy singular save (the reporter's state) | 1 config validated | 200 |
| one live plural connection | 1 config validated | 200 |
| **two live connections, one user** | **raises `response_shape`** | **503** |
| **live connection + deleted tombstone** | **raises `response_shape`** | **503** |
| **one paused connection** | **raises `response_shape`** | **503** |

Merged behind #1151, this turns calendar sync into a hard 503 for every user with a second calendar, a deleted calendar, or a paused one. That is worse than the 404 it was written to fix.

The row-level strictness is not required by any acceptance row in #991 — A2/A3 are about transport, auth, status and envelope faults, which the rest of the change already covers correctly. But relaxing it has its own customer-facing edge (silently skipping a malformed row reintroduces a false 404 for that user), so the shape of the fix is a maintainer decision, not an author default.

**Decision needed before this can go ready-for-review:** either (a) rebuild the validator against the plural connection contract and land this after #1151, or (b) land the fault taxonomy without row-level validation and let #1151 carry the plural shape, or (c) fold the taxonomy into #1151 and close this.

## What the change does (unchanged from the previous checkpoint)

- `fetch_configs` returns only a validated authoritative list — including an empty one — or raises a sanitized `CalendarConfigDiscoveryError` carrying a closed reason and no URL, credential, body, or account id.
- `fetch_user_config` returns "no configuration" only after authoritative discovery succeeded.
- `POST /user/calendar/sync` maps typed discovery faults to 503 with a stable retryable body, `Retry-After: 1`, `Cache-Control: no-store` — instead of 404 "no calendar feed connected".
- The background sweep propagates discovery failure instead of coercing it to an empty authoritative list.
- IPv4-mapped IPv6 addresses inherit the IPv4 unsafe-address classification.

## Acceptance floor against #991

| Row | State |
|---|---|
| A1 | LOCAL PASS at the previous head — real gateway PUT → admin persistence/discovery → same-token sync returns a sanitized 200, not 404. Not re-run at this head. |
| A2 | PARTIAL — units cover missing/malformed configuration, timeout, connectivity, 401/403, 500, invalid JSON, invalid shape; a real 403→503 Compose row passed previously. |
| A3 | LOCAL PASS at the previous head — authoritative absence maps to 404, real auth failure to 503. |
| A4 | PARTIAL — two independent users/tokens do not cross-select. No forged `X-User-Id` control on the calendar path. |
| A5 | OPEN — IPv4-mapped IPv6 SSRF case fixed and tested. No valid Outlook/M365 fetch→parse→import here; that row was closed separately against production on 2026-08-17 (#991), not by this branch. |
| A6 | PARTIAL — response/status surfaces sanitized; previous auth row scanned three services' last 400 lines. Not an all-service scan. |
| A7 | OPEN — no restart, second replica, or failover witness. |
| A- | PARTIAL — meeting-api suite green at this head (934/5). Gateway and admin-api suites, Lite, docs-current, and full repository CI not run here. |

Compose rows were **not** re-run at this head — the blocking finding above makes re-running them premature.

## Relation to the production verification on #991

The reporter's original mismatch **no longer reproduces on production** (evidence on #991, 2026-08-17). That was not this branch — `CalendarConfigDiscoveryError` exists on no other ref. What remains unproven there is the legacy `PUT /user/calendar` first-save path on an account that has never had a calendar, which needs an identity nobody could create under the governing constraints. Tracked as #1249 (human-only; not a dependency of this PR, and this PR is not a dependency of it).

Note also that the misleading taxonomy this branch repairs is **still present on `main` and on #1151** — `fetch_configs` there still returns `None` for every transport, auth, upstream-status and shape fault, and the route still calls that "no calendar feed connected".

## Environment note

`gate:schema` fails on a **pristine `origin/main`** worktree with an empty error string, because `validate.mjs` needs `ajv` and a fresh worktree has no `node_modules`. It reports nothing about why — the swallow tracked in #1107. With `node_modules` linked, the gate is green (25 contracts conform). Nothing to do with this change; recorded so the next person does not chase it.

## Rollback

Nothing merged, deployed, or released. Source rollback would be a reviewed revert.

## Authorship

Sole author: DmitriyG228. No agent co-author trailers.

Tooling disclosure: implementation and evidence preparation used Codex under human-gated external execution; the 2026-08-19 rebase, re-run and cross-branch probe used Claude Code under the same gate.

Part of #991

<!-- vexa-agent -->
