### PR TITLE
docs: configuring Vexa over the API — the /api/settings page for the self-serve /user/* routes (#1091)

### DIFF
--- a/docs/changelog.d/1091-settings-api-page.md
+++ b/docs/changelog.d/1091-settings-api-page.md
@@ -1,0 +1,7 @@
+- **Configuring Vexa over the API is documented (#1091).** New [Settings API](/api/settings) page
+  covers the self-serve `/user/*` routes that were shipped but unwritten: model credential
+  (`/user/models`), transcription backend (`/user/transcription`), webhooks and their delivery
+  history (`/user/webhook`, `/user/webhook/deliveries`), with the field validation, the
+  partial-update-and-clear semantics, and the rule that a stored secret is never echoed back in the
+  clear. It also states the thing the path name invites you to assume and which is not true: there is
+  **no** aggregate `GET /settings`, and the deployment-wide admin tier is not on the public API at all.

--- a/docs/docs/api/settings.mdx
+++ b/docs/docs/api/settings.mdx
@@ -1,0 +1,229 @@
+---
+title: "Settings API"
+description: "Configure your account over the API — model credentials, transcription backend, webhooks, calendar. Secrets are masked on read-back."
+---
+
+Everything the Terminal's **Settings** panel writes is also an ordinary API call. This page is the
+reference for the self-serve configuration surface: **per-user** settings, read and written with your
+own API key, on the same authenticated edge as every other route.
+
+<Note>
+**There is no single `/settings` endpoint.** Settings are per-domain routes under `/user/*` — one
+resource per concern (`/user/models`, `/user/transcription`, `/user/webhook`, `/user/calendar`).
+`GET /settings` returns `404` on every deployment; there is no aggregate read and no aggregate write.
+</Note>
+
+## Base URL & auth
+
+| | |
+|---|---|
+| Hosted | `https://api.cloud.vexa.ai` |
+| Self-hosted | `http://localhost:18056` (the gateway; `API_GATEWAY_HOST_PORT`, default `18056`) |
+
+```bash
+-H "X-API-Key: <API_KEY>"
+```
+
+**No scope is required.** Unlike `/bots` and `/transcripts`, the `/user/*` routes carry no scope
+requirement — any valid key may manage its own account's settings, and only its own. The gateway
+resolves the key to a user and injects that identity downstream; you cannot name another user's
+account in a request. See [Authentication](/authentication).
+
+## The surface at a glance
+
+| What you're configuring | Routes | Secrets involved |
+|---|---|---|
+| **Model credential** — which model, and whose key pays for it | `GET` · `PUT /user/models` | `api_key` |
+| **Transcription backend** — the STT service your bots use | `GET` · `PUT /user/transcription` | `token` |
+| **Webhooks** — where signed meeting events are POSTed | `GET` · `PUT /user/webhook`, `GET /user/webhook/deliveries` | `webhook_secret` |
+| **Calendar sync** — the ICS feed Vexa imports meetings from | `GET` · `PUT /user/calendar`, `GET` · `POST /user/calendar/sync` — documented under [Meetings API → Calendar](/api/meetings#calendar-sync) | `ics_url` |
+| **API keys themselves** | minted by an admin, not here — see [Authentication](/authentication) | the key |
+
+## How a settings write behaves
+
+Three rules hold across every route on this page.
+
+1. **`PUT` is a partial update, not a replace.** Only the fields present in the body change. Omitted
+   fields keep their stored value.
+2. **An empty string clears a field.** `{"model": ""}` removes the stored `model` and falls back to
+   the next tier. Clearing every field of a config removes it entirely.
+3. **Secrets are write-only.** A secret is accepted in the clear on `PUT` and never echoed back.
+   Reads return a masked form (`********abcd` — the last four characters) plus a boolean saying
+   whether one is set. There is no route that returns a stored secret.
+
+The `PUT` returns the same masked read-back shape the `GET` returns, so one call is enough to write
+and confirm.
+
+## Models
+
+The model credential your chat turns and meeting agents run on.
+
+```bash GET /user/models
+curl -H "X-API-Key: $API_KEY" "$API_BASE/user/models"
+```
+
+```json
+{
+  "mode": "custom",
+  "model": "claude-sonnet-4-5",
+  "meeting_model": "claude-haiku-4-5",
+  "base_url": "https://llm.example.com/v1",
+  "api_key_set": true,
+  "api_key": "********f0a1"
+}
+```
+
+<ParamField body="mode" type="string">
+`subscription` — use the deployment's brokered credential (a mounted Claude Code subscription or a
+deployment-level API key). `custom` — use your own Anthropic-/OpenAI-compatible endpoint (a LiteLLM
+or OpenRouter gateway, a self-hosted open-weights model). Any other value is refused with `422`.
+</ParamField>
+<ParamField body="model" type="string">Model name for chat turns.</ParamField>
+<ParamField body="meeting_model" type="string">Model name for meeting-time work, when it should differ from `model`.</ParamField>
+<ParamField body="base_url" type="string">Endpoint for `custom` mode. Must be an `http`/`https` URL with a hostname, else `422`.</ParamField>
+<ParamField body="api_key" type="string">Your provider key. Write-only — reads return `api_key_set` plus the masked `api_key`.</ParamField>
+
+```bash PUT /user/models
+curl -X PUT "$API_BASE/user/models" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"mode":"custom","base_url":"https://llm.example.com/v1","api_key":"sk-…"}'
+```
+
+```bash PUT /user/models — clear one field, keep the rest
+curl -X PUT "$API_BASE/user/models" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"meeting_model":""}'
+```
+
+**Resolution order is per field: your setting, then the deployment's default, then the environment.**
+Each field resolves independently — setting only `model` leaves `base_url` resolving from the
+deployment tier. Which credential is appropriate for your licensing situation is a separate question
+with a real answer: see [Model credentials & licensing](/model-credentials-licensing).
+
+## Transcription
+
+The speech-to-text backend your bots send audio to. Setting it here overrides the deployment's
+`TRANSCRIPTION_SERVICE_URL` / `TRANSCRIPTION_SERVICE_TOKEN` for **your** meetings only.
+
+```bash GET /user/transcription
+curl -H "X-API-Key: $API_KEY" "$API_BASE/user/transcription"
+```
+
+```json
+{ "url": "https://stt.example.com/v1", "token_set": true, "token": "********9c3d" }
+```
+
+<ParamField body="url" type="string">STT endpoint. Must be an `http`/`https` URL with a hostname, else `422`.</ParamField>
+<ParamField body="token" type="string">Bearer token for that endpoint. Write-only — masked on read.</ParamField>
+
+```bash PUT /user/transcription
+curl -X PUT "$API_BASE/user/transcription" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"url":"https://stt.example.com/v1","token":"…"}'
+```
+
+If no transcription backend resolves at any tier, a default `POST /bots` answers **`503`** naming the
+unset keys rather than spawning a bot that will never transcribe. Bringing your own STT — including
+the Whisper-compatible shapes that work — is walked through in [Use your own STT](/how-to/custom-stt).
+
+## Webhooks
+
+Where Vexa POSTs signed meeting events.
+
+```bash GET /user/webhook
+curl -H "X-API-Key: $API_KEY" "$API_BASE/user/webhook"
+```
+
+```json
+{
+  "webhook_url": "https://hooks.example.com/vexa",
+  "webhook_secret_set": true,
+  "webhook_secret": "********2b7e",
+  "webhook_events": { "meeting.completed": true }
+}
+```
+
+<ParamField body="webhook_url" type="string" required>Absolute destination URL. Required on `PUT`.</ParamField>
+<ParamField body="webhook_secret" type="string">HMAC secret for signing the envelope. Write-only — masked on read. Omit it on a later `PUT` to keep the stored one.</ParamField>
+<ParamField body="webhook_events" type="object">Map of event name to boolean, e.g. `{"meeting.completed": true}`. Omit to leave the current selection untouched.</ParamField>
+
+```bash PUT /user/webhook
+curl -X PUT "$API_BASE/user/webhook" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"webhook_url":"https://hooks.example.com/vexa","webhook_secret":"…",
+       "webhook_events":{"meeting.completed":true}}'
+```
+
+### Delivery history
+
+```bash GET /user/webhook/deliveries
+curl -H "X-API-Key: $API_KEY" "$API_BASE/user/webhook/deliveries?limit=50"
+```
+
+```json
+{
+  "deliveries": [
+    { "event_type": "meeting.completed", "event_id": "evt_…", "target_host": "hooks.example.com",
+      "outcome": "delivered", "status_code": 200, "attempt": 0, "meeting_id": 4821,
+      "created_at": "2026-08-08T09:14:22Z" }
+  ]
+}
+```
+
+Newest first. `limit` is `1`–`500`, default `100`; the ledger keeps a recent window per user
+(100 rows), not an audit log of all time. `outcome` is one of `delivered` · `queued` · `suppressed` ·
+`blocked` · `failed`.
+
+**A row carries the target *host*, never the full URL and never the secret** — a webhook URL can
+carry a token in its path or query, and a delivery record does not need it.
+
+<Warning>
+**Honest status.** The user-webhook path is built and module-tested — self-serve config, the
+`webhook.v1` HMAC envelope, the retry queue, this delivery ledger — but it has **never been fired
+against a real external receiver**; the module tests use an in-memory transport, and there is no
+settings UI for it in the Terminal yet. Treat it as untested until you have proven a live delivery
+into your own endpoint. Exactly-once emission and outage-durable retry are tracked as
+[#519](https://github.com/Vexa-ai/vexa/issues/519) / [#520](https://github.com/Vexa-ai/vexa/issues/520).
+The live status row is maintained on [Roadmap → Status](/roadmap/status).
+</Warning>
+
+## Calendar
+
+`GET` · `PUT /user/calendar` and `GET` · `POST /user/calendar/sync` follow the same idioms — the ICS
+URL is a secret, masked to host plus last four on read-back; `{"ics_url": null}` disconnects. They are
+documented with the meeting flow they belong to, in
+[Meetings API → Calendar sync](/api/meetings#calendar-sync) and
+[Sync your calendar](/how-to/calendar-sync).
+
+## Platform-wide defaults are not on the public API
+
+An operator can set **deployment-wide** defaults for the same two config domains — the tier that
+resolves under a user's own settings. That tier is deliberately **not exposed on the public API**: it
+is reachable only from the Terminal's admin surface, which proxies to an internal, internal-secret-gated
+route on the identity service. A non-admin sees `404`, indistinguishable from the route being absent.
+
+If you are self-hosting and want to set the defaults for everyone, use the Terminal's setup wizard or
+**Settings → Models**, or set them in the deployment environment — see
+[Configuration](/configuration). There is no public REST call for it, and pointing an agent at
+`/api/admin/settings/...` against the gateway will not work: that path belongs to the Terminal web
+app, not to the API.
+
+## Errors
+
+| Status | When |
+|---|---|
+| `401` | missing or invalid `X-API-Key` |
+| `404` | you addressed a route that does not exist — including `/settings` itself, and the admin tier when you are not an admin |
+| `422` | `mode` outside `subscription`/`custom`; a `base_url`/`url` that isn't an `http(s)` URL with a hostname; any value over 2048 characters |
+
+Full vocabulary at [Errors](/api/errors).
+
+## Verifying a setting actually works
+
+Writing a credential and having it *resolve* are two different things. The Terminal's Settings panel
+tests the **effective** configuration — the same user-then-deployment-then-environment resolution a
+real chat turn or bot spawn applies — and reports the failure with the remedy named. Use it after any
+change here; a `200` from `PUT` means stored, not reachable.
+
+If a setting looks right and behaviour disagrees, [Troubleshooting](/troubleshooting) covers the
+common causes.

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -87,6 +87,7 @@
         "pages": [
           "api/meetings",
           "api/agent",
+          "api/settings",
           "api/errors"
         ]
       },


### PR DESCRIPTION
**Delivers issue:** #1091

`/api/settings` and `/api/settings.md` were both dead. The judgement this PR turns on is whether the
demand was for a capability we have — it is. The routes exist, are public, and are live on hosted;
they were simply never written down.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> ⚠️ **Left deliberately unselected.** The rights selection is a legal certification and the
> template says an agent must not make it. The same applies to the DCO `Signed-off-by` trailer,
> which the single commit on this branch does **not** carry. Both need the human author before this
> can leave draft: tick exactly one box above, and `git commit --amend -s` (then force-push).

## Observation bundle

- **C1 — does a settings endpoint exist in the tree?** ran: grep for settings routes across the
  gateway, admin-api, agent control plane and the terminal client · saw: `/user/models`,
  `/user/transcription`, `/user/webhook`, `/user/webhook/deliveries` fronted by the gateway
  (`core/gateway/services/gateway/src/gateway/app.py:476-531`) and implemented in admin-api
  (`core/identity/services/admin-api/src/admin_api/app/main.py:429-575`); no route named `/settings`
  anywhere · concluded: the capability is real but lives at per-domain paths.

- **C2 — is it live, or only in the tree?** ran: unauthenticated probes against
  `https://api.cloud.vexa.ai` · saw: `/user/models` → `401`, `/user/transcription` → `401`,
  `/user/webhook` → `401`, `/settings` → `404`, `/user/nonexistent` → `404` · concluded: the `401`s
  are a genuine existence signal (the same edge answers `404` for an absent path), and the aggregate
  `/settings` genuinely does not exist. This is the check that decided the outcome: had the probes
  come back `404`, the right output would have been an issue, not a page.

- **C3 — is it already documented?** ran: grep the docs tree for the routes and for "settings" ·
  saw: `configuration.mdx`, `model-credentials-licensing.mdx` and `quickstart.mdx` name
  "Settings → Models" as a Terminal affordance only; the HTTP surface appears nowhere ·
  concluded: undocumented, so a new page rather than a redirect.

- **C4 — what must the page refuse to say?** ran: read the admin tier
  (`/internal/settings/{key}`, `include_in_schema=False`, internal-secret gated) and
  `roadmap/status.mdx`'s webhook row · saw: the global tier is not on the public API, and the user
  webhook has never been fired at a real external receiver · concluded: both belong on the page as
  explicit boundaries, not omissions.

## Acceptance floor

| Row | Evidence |
|---|---|
| Oracle 1 — `/api/settings` and `/api/settings.md` return `200` | pending deploy; page added at `docs/docs/api/settings.mdx` and registered in the **API reference** nav group in `docs/docs/docs.json`, which is what makes both variants resolve |
| Oracle 2a — a cold reader can name the route for a custom model endpoint | `## Models` documents `PUT /user/models` with `mode: custom` + `base_url` + `api_key`, with a runnable curl |
| Oracle 2b — a cold reader knows secrets are never echoed back | stated twice: rule 3 of "How a settings write behaves", and again per-field (`api_key_set` / `token_set` / `webhook_secret_set` plus the `********abcd` mask) |
| Oracle 2c — a cold reader answers "is there a `GET /settings`?" with **no** | the first `<Note>` on the page, above every route, plus a `404` row in the error table |

## Docs diff (D6c)

- **`docs/docs/api/settings.mdx`** (new) — reference altitude, sitting beside `api/meetings` and
  `api/agent`. Covers base URL + auth (no scope required for `/user/*`), the three write rules
  (partial update · empty string clears · secrets are write-only), then Models, Transcription and
  Webhooks route by route with field validation and the real `422` conditions.
- **`docs/docs/docs.json`** — `api/settings` added to the **API reference** group.
- **`docs/changelog.d/1091-settings-api-page.md`** — the fragment.
- **Calendar deliberately not duplicated.** `/user/calendar` is already documented under
  [Meetings API → Calendar sync](/api/meetings#calendar-sync); the settings page links out rather
  than forking a second copy that will drift.
- **`roadmap/status.mdx` needed no change** — its webhook row already carries the untested-receiver
  caveat; the new page cites it rather than restating it as fresh news.

## Security checks (required on the diff)

Docs-only diff: three files, no code, no dependencies, no build inputs — no dependency/licence delta
to scan and no SAST surface. The relevant security property here is **disclosure**, and it was
checked by hand: the page contains no keys, no tokens, no customer identifiers, and no internal
telemetry. It documents masking as a guarantee rather than exhibiting any masked value from a real
account, and it deliberately declines to document the internal admin tier as if it were callable.

Pre-push gate suite ran green on this branch (14 fast static gates, no `--no-verify`), plus
`gate:docs-version`.

## Validation request

Any competent non-author. What to watch, in order of load:

1. **The refusal is correct and prominent.** `https://api.cloud.vexa.ai/settings` → `404`. If a
   reviewer reads the page and comes away thinking an aggregate settings endpoint exists, the page
   has failed at its main job.
2. **Every documented route resolves.** Probe `/user/models`, `/user/transcription`,
   `/user/webhook` on your own deployment with a real key; confirm the read-back masks the secret.
3. **The webhook warning still matches reality.** If a live external delivery has since been
   witnessed, that paragraph is stale and should be corrected before merge, not after.

**Deployment validated:** none — docs-only. The route-existence claims were validated against
**hosted** (`api.cloud.vexa.ai`, unauthenticated probes, 2026-08-08); the field/validation/masking
claims were read off `origin/main` at `fde7dfb7`. No authenticated round-trip was performed, so the
response bodies shown are derived from the handlers, not captured from a live account — worth a
reviewer's key.

## Authorship

Drafted by an agent under the turbine rotation; the human author is the sole submitter and has not
yet made the rights or DCO certifications (see the warning above). No agent co-author trailers (D13).
