### PR TITLE
fix(helm): honor explicit runtime image references and configure minio-init (#1006)

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -181,6 +181,9 @@ jobs:
         run: |
           bash deploy/helm/tests/test_helm_lint.sh
           bash deploy/helm/tests/test_template.sh
+          # #1006 — the mirror-only invariant: no image this chart can cause a cluster to pull may
+          # fall back to a public registry, helm hooks and runtime-spawned Pods included.
+          bash deploy/helm/tests/test_mirror_only.sh
 
       - name: Pinned render — every image ref follows global.imageTag
         env:

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -24,6 +24,12 @@ template:
 test:
 	bash tests/test_helm_lint.sh
 	bash tests/test_template.sh
+	bash tests/test_mirror_only.sh
+
+## mirror-test — just the mirror-only render invariant (#1006): nothing the chart can cause a
+## cluster to pull may fall back to a public registry — hooks and runtime-spawned Pods included.
+mirror-test:
+	bash tests/test_mirror_only.sh
 
 ## build — build the 5 control-plane images (:dev) via the compose build
 build:
@@ -53,4 +59,4 @@ down:
 	-sudo KUBECONFIG=$(KUBECONFIG) helm uninstall $(RELEASE) -n $(NAMESPACE)
 	-sudo KUBECONFIG=$(KUBECONFIG) kubectl delete namespace $(NAMESPACE) --wait=false
 
-.PHONY: lint template test build k3s-import install status smoke down
+.PHONY: lint template test mirror-test build k3s-import install status smoke down

--- a/deploy/helm/charts/vexa/README.md
+++ b/deploy/helm/charts/vexa/README.md
@@ -61,9 +61,71 @@ Provide your own `labelSelector` in a constraint to opt out of the automatic inj
 default (the shipped value) renders nothing — single-node / k3s installs are unaffected. Use
 `ScheduleAnyway`, not `DoNotSchedule`, unless you can guarantee enough nodes, or pods stay Pending.
 
+## Image references
+
+Every image in this chart resolves by **one rule**, in this order — nothing else participates:
+
+| # | Value | Result |
+|---|---|---|
+| 1 | `<x>.image` / `<x>Image` — an explicit **full reference** | used **verbatim** |
+| 2 | `<x>.digest` / `<x>ImageDigest` — `sha256:<64 lowercase hex>` | `<repository>@<digest>` |
+| 3 | `<x>.repository` + `<x>.tag` | `<repository>:<tag>` |
+
+**An explicit full reference wins. `global.imageTag` never rewrites it** — it only supplies the tag
+on leg 3, for the images that have no explicit identity. That is the deterministic precedence a
+private-mirror install depends on; before v0.12.19 two of the runtime's spawned references ignored
+it (see [#1006](https://github.com/Vexa-ai/vexa/issues/1006)).
+
+The chart **fails closed** rather than guessing. `helm template` errors, and nothing renders, when:
+
+- an explicit full reference **and** a digest are both set on the same image (two identities, no
+  defensible winner);
+- a digest is not exactly `sha256:` + 64 **lowercase** hex — truncated, uppercase or non-`sha256`
+  is refused, never quietly downgraded to a mutable tag;
+- a full reference contains whitespace;
+- the repository is empty on legs 2–3, or the tag is empty on leg 3.
+
+### The runtime-spawned images
+
+Three images are **not containers in any rendered manifest**. The chart hands them to the runtime
+as env (`BROWSER_IMAGE`, `AGENT_IMAGE`, `AGENT_WORKER_IMAGE`) and the runtime creates those Pods
+later. `kubectl get deploy -o yaml` will never name them, and a mirror that holds only what the
+manifests show will fail at the first meeting, not at install:
+
+| Env | Explicit reference | Digest | Composed default |
+|---|---|---|---|
+| `BROWSER_IMAGE` (the bot, ~3.6 GB) | `runtime.browserImage` | `runtime.browserImageDigest` | `runtime.browserImageRepository` + `runtime.browserImageTag` |
+| `AGENT_IMAGE` | `runtime.agentImage` | `runtime.agentImageDigest` | `runtime.agentImageRepository` + `runtime.agentImageTag`, both defaulting to `agentApi.image.*` |
+| `AGENT_WORKER_IMAGE` | `runtime.agentWorkerImage` | `runtime.agentWorkerImageDigest` | `runtime.agentWorkerImageRepository` + `runtime.agentWorkerImageTag` |
+
+The post-install **`minio-init` hook Job** is the fourth easily-missed pull: `minio.mc.reference` /
+`minio.mc.digest` / `minio.mc.image.repository` + `minio.mc.image.tag`. It is deliberately **not** wired to
+`global.imageTag` — it is a third-party image, not part of the Vexa release set.
+
+```yaml
+# A mirror-only install pinning exact bytes.
+global:
+  imageTag: v0.12.19
+  imagePullSecrets: [{ name: internal-registry-pull }]
+runtime:
+  image: { repository: registry.example.internal/vexa/v012-runtime }
+  browserImage: "registry.example.internal/vexa/vexa-bot@sha256:<64 hex>"
+  agentImage:   "registry.example.internal/vexa/v012-agent-api:v0.12.19"
+  agentWorkerImageRepository: registry.example.internal/vexa/v012-agent-worker
+  agentWorkerImageDigest: "sha256:<64 hex>"
+minio:
+  image: { repository: registry.example.internal/mirror/minio, tag: latest }
+  mc:    { digest: "sha256:<64 hex>", image: { repository: registry.example.internal/mirror/mc } }
+```
+
 ## Validate (no cluster)
 
 ```bash
 helm lint .
 helm template vexa . -n vexa -f values-test.yaml
+make -C ../.. test          # deploy/helm: lint + render assertions + the mirror-only invariant
 ```
+
+`tests/test_mirror_only.sh` renders `tests/values-mirror-only.yaml` — every image pointed at one
+unresolvable internal registry — and asserts that no container image, hook image or runtime-spawn
+reference falls outside it. Run it after any change that touches an image reference.

--- a/deploy/helm/charts/vexa/templates/_helpers.tpl
+++ b/deploy/helm/charts/vexa/templates/_helpers.tpl
@@ -96,34 +96,113 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
-{{/* The on-demand bot image the runtime spawns (BROWSER_IMAGE). The bot is published, never built by
-this chart. runtime.browserImage is the explicit value; global.imageTag (set) pins the standard repo. */}}
-{{- define "vexa.botImage" -}}
-{{- if .Values.runtime.browserImage -}}
-{{- .Values.runtime.browserImage -}}
-{{- else if .Values.global.imageTag -}}
-{{- printf "vexaai/vexa-bot:%s" .Values.global.imageTag -}}
+{{/*
+vexa.imageRef — the ONE image-reference rule (#1006).
+
+Call:
+  include "vexa.imageRef" (dict "field"      "<values path, quoted back in errors>"
+                                "reference"  <explicit full reference, or "">
+                                "digest"     <"sha256:<64 hex>", or "">
+                                "repository" <repository>
+                                "tag"        <tag>)
+
+Precedence — three legs, checked in this order, and nothing else participates:
+
+  1. `reference` non-empty  → emitted VERBATIM. An operator who names a full reference gets
+     exactly that reference; a global tag NEVER rewrites it. This is the leg mirror-only
+     clusters depend on: before #1006 two of the three spawned-workload references silently
+     ignored it and rendered a Docker Hub reference, so a cluster with no public egress could
+     not run the product no matter what it configured.
+  2. `digest` non-empty     → "<repository>@<digest>".
+  3. otherwise              → "<repository>:<tag>" — the legacy path, unchanged. The CALLER
+     decides whether global.imageTag supplies that tag.
+
+Fails CLOSED — `helm template` errors and nothing renders — on an ambiguous or malformed
+identity, instead of silently ranking one input over another:
+
+  - `reference` AND `digest` both set: two identities declared, no defensible winner;
+  - a `digest` that is not exactly sha256:<64 lowercase hex> (truncated, uppercase, non-sha256);
+  - a `reference` containing whitespace;
+  - an empty repository on leg 2 or 3, or an empty tag on leg 3.
+
+Silence here would mean an operator who typoed a digest deploys a mutable tag believing they
+pinned bytes. See docs/docs/deployment-kubernetes.mdx § Running from a private registry mirror.
+*/}}
+{{- define "vexa.imageRef" -}}
+{{- $field := .field -}}
+{{- $ref := .reference | default "" | toString | trim -}}
+{{- $digest := .digest | default "" | toString | trim -}}
+{{- $repo := .repository | default "" | toString | trim -}}
+{{- $tag := .tag | default "" | toString | trim -}}
+{{- if and $ref $digest -}}
+{{- fail (printf "INVALID image identity for %s: an explicit full reference (%q) and a digest (%q) are both set. Declare exactly one — the chart refuses to guess which bytes you meant." $field $ref $digest) -}}
+{{- end -}}
+{{- if $ref -}}
+{{- if regexMatch "[[:space:]]" $ref -}}
+{{- fail (printf "INVALID image reference for %s: %q contains whitespace." $field $ref) -}}
+{{- end -}}
+{{- $ref -}}
+{{- else if $digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $digest) -}}
+{{- fail (printf "INVALID image digest for %s: %q. Expected exactly sha256:<64 lowercase hex> — a truncated, uppercase or non-sha256 digest is refused rather than silently falling back to a mutable tag." $field $digest) -}}
+{{- end -}}
+{{- if not $repo -}}
+{{- fail (printf "INVALID image identity for %s: a digest is set but the repository is empty." $field) -}}
+{{- end -}}
+{{- printf "%s@%s" $repo $digest -}}
 {{- else -}}
-vexaai/vexa-bot:v012
+{{- if not $repo -}}
+{{- fail (printf "INVALID image identity for %s: no reference, no digest, and an empty repository." $field) -}}
+{{- end -}}
+{{- if not $tag -}}
+{{- fail (printf "INVALID image identity for %s: no reference, no digest, and an empty tag for repository %q." $field $repo) -}}
+{{- end -}}
+{{- printf "%s:%s" $repo $tag -}}
 {{- end -}}
 {{- end -}}
 
-{{/* The agent-api image ref (AGENT_IMAGE the runtime spawns workers from). global.imageTag wins. */}}
-{{- define "vexa.agentImage" -}}
-{{- if .Values.global.imageTag -}}
-{{- printf "%s:%s" .Values.agentApi.image.repository .Values.global.imageTag -}}
-{{- else -}}
-{{- .Values.runtime.agentImage | default (printf "%s:%s" .Values.agentApi.image.repository .Values.agentApi.image.tag) -}}
+{{/* The on-demand bot image the runtime spawns (BROWSER_IMAGE). The bot is published, never built
+by this chart. Identity per vexa.imageRef; global.imageTag only ever supplies the tag leg. */}}
+{{- define "vexa.botImage" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "runtime.browserImage"
+      "reference" .Values.runtime.browserImage
+      "digest" .Values.runtime.browserImageDigest
+      "repository" .Values.runtime.browserImageRepository
+      "tag" (.Values.global.imageTag | default .Values.runtime.browserImageTag)) -}}
 {{- end -}}
+
+{{/* The agent-api image ref (AGENT_IMAGE the runtime spawns workers from). Its composed leg falls
+back to the agent-api Deployment's own repository/tag, so mirroring `agentApi.image` keeps carrying
+the spawned copy with it. */}}
+{{- define "vexa.agentImage" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "runtime.agentImage"
+      "reference" .Values.runtime.agentImage
+      "digest" .Values.runtime.agentImageDigest
+      "repository" (.Values.runtime.agentImageRepository | default .Values.agentApi.image.repository)
+      "tag" (.Values.global.imageTag | default .Values.runtime.agentImageTag | default .Values.agentApi.image.tag)) -}}
 {{- end -}}
 
 {{/* The agent-worker image ref (AGENT_WORKER_IMAGE; the dedicated worker build — core/agent/worker/Dockerfile — NOT the agent-api image). */}}
 {{- define "vexa.agentWorkerImage" -}}
-{{- if .Values.global.imageTag -}}
-{{- printf "vexaai/v012-agent-worker:%s" .Values.global.imageTag -}}
-{{- else -}}
-{{- .Values.runtime.agentWorkerImage | default "vexaai/v012-agent-worker:v012" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "runtime.agentWorkerImage"
+      "reference" .Values.runtime.agentWorkerImage
+      "digest" .Values.runtime.agentWorkerImageDigest
+      "repository" .Values.runtime.agentWorkerImageRepository
+      "tag" (.Values.global.imageTag | default .Values.runtime.agentWorkerImageTag)) -}}
 {{- end -}}
+
+{{/* The MinIO client image the post-install bucket-init Job runs. Same one rule, deliberately NOT
+wired to global.imageTag: it is a third-party image, not part of the Vexa release set. */}}
+{{- define "vexa.minioClientImage" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "minio.mc"
+      "reference" .Values.minio.mc.reference
+      "digest" .Values.minio.mc.digest
+      "repository" .Values.minio.mc.image.repository
+      "tag" .Values.minio.mc.image.tag) -}}
 {{- end -}}
 
 {{- define "vexa.postgresCredentialsSecretName" -}}

--- a/deploy/helm/charts/vexa/templates/job-minio-init.yaml
+++ b/deploy/helm/charts/vexa/templates/job-minio-init.yaml
@@ -28,7 +28,10 @@ spec:
       {{- end }}
       containers:
         - name: minio-init
-          image: minio/mc:latest
+          {{- /* #1006 — a configurable identity (minio.mc.reference / .digest / .image.*), not a
+          hardcoded mutable public tag. This hook is what made mirror-only installs fail LAST: the
+          whole control plane came up, then the bucket-init Job reached for Docker Hub. */}}
+          image: {{ include "vexa.minioClientImage" . | quote }}
           imagePullPolicy: IfNotPresent
           # v0.10.5 Pack A.3 — replace `sleep 5` with poll-until-ready (#249).
           # On a fresh PVC, MinIO can take 30+ seconds to attach + initialize.

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -224,11 +224,42 @@ runtime:
   service:
     type: ClusterIP
     port: 8090
-  # Images the runtime spawns. browserImage = the bot (published ~3.6GB, a reference, never built by
-  # this chart). agentImage/agentWorkerImage default to the v012 agent repos at global.imageTag.
-  browserImage: ""            # empty → follows global.imageTag (fallback vexaai/vexa-bot:v012)
-  agentImage: "vexaai/v012-agent-api:v012"
-  agentWorkerImage: "vexaai/v012-agent-worker:v012"
+  # ---------------------------------------------------------------------------------------------
+  # Images the runtime SPAWNS on demand. These never appear as a `image:` field in any manifest —
+  # they are handed to the runtime as BROWSER_IMAGE / AGENT_IMAGE / AGENT_WORKER_IMAGE env, and the
+  # runtime creates the Pod. A private mirror must therefore hold them even though `kubectl get
+  # deploy -o yaml` never names them. browserImage = the bot (published ~3.6 GB, a reference, never
+  # built by this chart).
+  #
+  # Each image takes ONE identity, resolved by the same rule everywhere in this chart (see
+  # charts/vexa/README.md § Image references):
+  #   1. <x>Image            — an explicit full reference. WINS; global.imageTag never rewrites it.
+  #   2. <x>ImageDigest      — sha256:<64 hex> → "<repository>@<digest>".
+  #   3. <x>ImageRepository + <x>ImageTag — the legacy composed path; global.imageTag, when set,
+  #                            supplies the tag.
+  # Setting BOTH an explicit reference and a digest fails the render rather than picking one, as
+  # does a malformed digest. Empty repository/tag on the composed leg fails too.
+  #
+  # #1006: before this, agentImage and agentWorkerImage were DISCARDED whenever global.imageTag was
+  # set, so a mirror-only cluster rendered Docker Hub references it could not pull. The defaults
+  # below render byte-identically to the previous defaults.
+  browserImage: ""
+  browserImageDigest: ""
+  browserImageRepository: "vexaai/vexa-bot"
+  browserImageTag: "v012"
+
+  agentImage: ""
+  agentImageDigest: ""
+  # Empty repository/tag → the agent-api Deployment's own image.repository/image.tag, so mirroring
+  # `agentApi.image` carries the spawned copy with it.
+  agentImageRepository: ""
+  agentImageTag: ""
+
+  agentWorkerImage: ""
+  agentWorkerImageDigest: ""
+  agentWorkerImageRepository: "vexaai/v012-agent-worker"
+  agentWorkerImageTag: "v012"
+  # ---------------------------------------------------------------------------------------------
   logLevel: "info"
   speakerStream:
     minAudioSec: ""
@@ -406,6 +437,22 @@ minio:
   image:
     repository: minio/minio
     tag: latest
+  # The MinIO client image the post-install bucket-init Job runs. That Job is a helm HOOK, so it is
+  # easy to miss when inventorying what a cluster pulls — and the install fails without it. Same one
+  # identity rule as every other image here: `reference` (an explicit full reference) wins, else
+  # `digest` → repository@digest, else image.repository:image.tag. Deliberately NOT wired to
+  # global.imageTag — this is a third-party image, not part of the Vexa release set.
+  #
+  # #1006: the Job used to hardcode `minio/mc:latest` — unconfigurable AND mutable. The default
+  # below is the exact RELEASE tag `minio/mc:latest` resolved to when it was pinned (both
+  # sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727), so the bytes an
+  # unconfigured install pulls are unchanged; only the identity became explicit.
+  mc:
+    reference: ""   # explicit full reference — wins over repository/tag/digest below
+    digest: ""      # sha256:<64 hex> → "<repository>@<digest>"
+    image:
+      repository: minio/mc
+      tag: RELEASE.2025-08-13T08-35-41Z
   accessKey: vexa-access-key
   secretKey: vexa-secret-key
   bucket: vexa

--- a/deploy/helm/tests/README.md
+++ b/deploy/helm/tests/README.md
@@ -1,3 +1,7 @@
 # helm · tests
 
-Smoke tests for the `vexa` Helm chart: `test_helm_lint.sh` (chart lint) and `test_template.sh` (render/template validation). Run as part of the helm deploy checks.
+Static tests for the `vexa` Helm chart — no cluster required. Run by `make -C deploy/helm test` and by the Helm static-gates step in `release-images.yml`.
+
+- **`test_helm_lint.sh`** — chart lint (default values + `values-test.yaml`).
+- **`test_template.sh`** — the `gate:helm` render assertions: the carved control plane is present and correctly wired.
+- **`test_mirror_only.sh`** — the mirror-only invariant ([#1006](https://github.com/Vexa-ai/vexa/issues/1006)). Renders `values-mirror-only.yaml`, which points every image the chart can cause a cluster to pull at one unresolvable internal registry, and fails if any container image, helm-hook image or **runtime-spawn reference** (`BROWSER_IMAGE` / `AGENT_IMAGE` / `AGENT_WORKER_IMAGE` — Pods the runtime creates later, which appear in no rendered manifest) falls outside it. It also proves the legacy `repository:tag` path is unchanged and that ambiguous or malformed image identities fail the render closed. Every assertion carries its own negative control.

--- a/deploy/helm/tests/test_mirror_only.sh
+++ b/deploy/helm/tests/test_mirror_only.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# gate:helm-mirror (#1006) — the mirror-only render invariant.
+#
+# A private-registry cluster denies public-registry egress. The chart must therefore be able to
+# render with EVERY image it can cause the cluster to pull pointed at one internal registry, with
+# no undeclared public fallback anywhere — including the two surfaces that are easy to miss:
+#
+#   • helm HOOK manifests (the post-install minio-init Job), which never show up in `kubectl get
+#     deploy` and used to hardcode `minio/mc:latest`;
+#   • RUNTIME-SPAWNED workloads (bot / agent / agent-worker), which are not containers in any
+#     rendered manifest at all — they are references handed to the runtime as env, and the runtime
+#     creates those Pods later. Long-running Deployments alone are NOT sufficient coverage.
+#
+# Every assertion below carries its own negative control: the fixture is perturbed to reintroduce
+# the exact failure and the check must go RED, then the unperturbed fixture must be GREEN. A test
+# that cannot be made to fail proves nothing.
+#
+# No cluster required.
+set -uo pipefail
+
+HELM_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHART="$HELM_DIR/charts/vexa"
+FIXTURE="$HELM_DIR/tests/values-mirror-only.yaml"
+MIRROR="registry.internal.invalid/"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "SKIP: helm not installed"; exit 0
+fi
+
+fail=0
+ok()   { echo "  OK: $*"; }
+bad()  { echo "  FAIL: $*"; fail=1; }
+
+render() { helm template vexa "$CHART" -n vexa -f "$FIXTURE" "$@" 2>&1; }
+
+# --- the inventory ----------------------------------------------------------------------------
+# Two classes, collected separately because they are two different mistakes:
+#   container images   → every `image:` field in every rendered manifest (containers AND
+#                        initContainers — the field name is the same, so both are caught).
+#   spawn references   → the runtime Deployment's *_IMAGE env values.
+container_images() {
+  grep -hoE '^[[:space:]]+image:[[:space:]]*"?[^"[:space:]]+' <<<"$1" \
+    | sed -E 's/^[[:space:]]*image:[[:space:]]*"?//'
+}
+spawn_refs() {
+  awk '/- name: (BROWSER_IMAGE|AGENT_IMAGE|AGENT_WORKER_IMAGE)$/{n=$3; getline; sub(/^[[:space:]]*value:[[:space:]]*"?/,""); sub(/"$/,""); print n"="$0}' <<<"$1"
+}
+
+echo "=== gate:helm-mirror — mirror-only render invariant (#1006) ==="
+
+RENDER="$(render)"
+if [ $? -ne 0 ]; then echo "  FAIL: mirror-only fixture did not render:"; echo "$RENDER"; exit 1; fi
+
+# ---------------------------------------------------------------------------------------------
+# A3 — every container image and every spawn reference belongs to the configured mirror.
+# ---------------------------------------------------------------------------------------------
+check_all_mirrored() {  # <render> → prints offenders, returns 1 if any
+  local r="$1" offenders=""
+  local ref
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    case "$ref" in "$MIRROR"*) ;; *) offenders="$offenders container:$ref " ;; esac
+  done < <(container_images "$r")
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    case "${ref#*=}" in "$MIRROR"*) ;; *) offenders="$offenders spawn:$ref " ;; esac
+  done < <(spawn_refs "$r")
+  [ -z "$offenders" ] && return 0
+  printf '%s\n' "$offenders"; return 1
+}
+
+n_container="$(container_images "$RENDER" | grep -c . || true)"
+n_spawn="$(spawn_refs "$RENDER" | grep -c . || true)"
+if [ "$n_container" -lt 10 ] || [ "$n_spawn" -ne 3 ]; then
+  bad "inventory looks wrong — $n_container container images (want >=10), $n_spawn spawn refs (want 3). A shrinking inventory silently narrows this gate."
+else
+  ok "inventoried $n_container container images + $n_spawn runtime-spawn references"
+fi
+
+if offenders="$(check_all_mirrored "$RENDER")"; then
+  ok "A3 · every container image and spawn reference is on the configured mirror"
+else
+  bad "A3 · references outside the mirror: $offenders"
+fi
+
+# A3 negative control — reintroduce ONE undeclared public reference; the invariant must go red.
+for probe in \
+  "--set minio.mc.image.repository=minio/mc --set minio.mc.digest= --set minio.mc.image.tag=latest" \
+  "--set runtime.agentWorkerImageRepository=vexaai/v012-agent-worker --set runtime.agentWorkerImageDigest=" \
+  "--set runtime.agentImage=vexaai/v012-agent-api:v012"
+do
+  # shellcheck disable=SC2086
+  PROBE_RENDER="$(render $probe)"
+  if check_all_mirrored "$PROBE_RENDER" >/dev/null; then
+    bad "A3 negative control did NOT go red for [$probe] — the invariant cannot see this class of leak"
+  else
+    ok "A3 negative control red as required for [$probe]"
+  fi
+done
+
+# ---------------------------------------------------------------------------------------------
+# A1 — the three explicit spawn identities survive a global tag. This is the reported bug.
+# ---------------------------------------------------------------------------------------------
+BOT_WANT='registry.internal.invalid/vexa/vexa-bot@sha256:1111111111111111111111111111111111111111111111111111111111111111'
+AGENT_WANT='registry.internal.invalid/vexa/v012-agent-api:mirrored-2222'
+WORKER_WANT='registry.internal.invalid/vexa/v012-agent-worker@sha256:3333333333333333333333333333333333333333333333333333333333333333'
+GLOBAL_TAG="$(grep -E '^\s+imageTag:' "$FIXTURE" | head -1 | sed -E 's/.*: *"?([^"]*)"?.*/\1/')"
+
+check_spawn() {  # <render> <env-name> <exact-wanted-ref>
+  local got
+  got="$(spawn_refs "$1" | grep "^$2=" | cut -d= -f2-)"
+  [ "$got" = "$3" ] && return 0
+  echo "$2 = ${got:-<absent>} (want $3)"; return 1
+}
+for pair in "BROWSER_IMAGE:$BOT_WANT" "AGENT_IMAGE:$AGENT_WANT" "AGENT_WORKER_IMAGE:$WORKER_WANT"; do
+  env_name="${pair%%:*}"; want="${pair#*:}"
+  if msg="$(check_spawn "$RENDER" "$env_name" "$want")"; then
+    ok "A1 · $env_name is the exact configured reference, with global.imageTag=$GLOBAL_TAG set"
+  else
+    bad "A1 · $msg"
+  fi
+done
+# A1 also means the global tag did not leak into any spawn reference.
+if spawn_refs "$RENDER" | grep -q ":${GLOBAL_TAG}\$"; then
+  bad "A1 · a spawn reference carries global.imageTag ($GLOBAL_TAG) — the explicit reference was rewritten"
+else
+  ok "A1 · global.imageTag rewrote none of the three spawn references"
+fi
+
+# ---------------------------------------------------------------------------------------------
+# A2 — the minio-init hook Job renders the exact configured reference.
+# ---------------------------------------------------------------------------------------------
+MC_WANT='registry.internal.invalid/mirror/mc@sha256:4444444444444444444444444444444444444444444444444444444444444444'
+MC_GOT="$(helm template vexa "$CHART" -n vexa -f "$FIXTURE" --show-only templates/job-minio-init.yaml 2>&1 \
+  | grep -E '^\s+image:' | sed -E 's/^\s*image:\s*"?//; s/"$//')"
+if [ "$MC_GOT" = "$MC_WANT" ]; then
+  ok "A2 · minio-init Job uses the configured digest ($MC_GOT)"
+else
+  bad "A2 · minio-init Job image is '$MC_GOT', want '$MC_WANT'"
+fi
+if [ "$MC_GOT" = "minio/mc:latest" ]; then
+  bad "A2 · minio-init Job still renders the pre-#1006 hardcoded public reference"
+fi
+
+# ---------------------------------------------------------------------------------------------
+# A4 — the legacy composed path stays green; ambiguous or malformed identities fail CLOSED.
+# ---------------------------------------------------------------------------------------------
+# Legacy: stock values (no explicit reference, no digest anywhere) must still render the historical
+# Docker Hub references, and global.imageTag must still drive all three spawn refs.
+LEGACY="$(helm template vexa "$CHART" -n vexa 2>&1)"
+for want in "vexaai/vexa-bot:v012" "vexaai/v012-agent-api:v012" "vexaai/v012-agent-worker:v012"; do
+  if grep -q "value: \"$want\"" <<<"$LEGACY"; then
+    ok "A4 · legacy default renders $want unchanged"
+  else
+    bad "A4 · legacy default lost $want — backward compatibility broken"
+  fi
+done
+LEGACY_TAGGED="$(helm template vexa "$CHART" -n vexa --set global.imageTag=vLEGACY 2>&1)"
+n_tagged="$(spawn_refs "$LEGACY_TAGGED" | grep -c ':vLEGACY$' || true)"
+if [ "$n_tagged" -eq 3 ]; then
+  ok "A4 · global.imageTag still supplies the tag for all 3 spawn refs when none is explicit"
+else
+  bad "A4 · global.imageTag drove $n_tagged/3 spawn refs on stock values"
+fi
+
+# Fail-closed: each of these must make `helm template` EXIT NON-ZERO. A render that succeeds here
+# is the dangerous outcome — the operator believes they pinned bytes and did not.
+must_fail() {  # <label> <expected-substring> <helm args…>
+  local label="$1" expect="$2"; shift 2
+  local out rc
+  out="$(helm template vexa "$CHART" -n vexa -f "$FIXTURE" "$@" 2>&1)"; rc=$?
+  if [ $rc -eq 0 ]; then
+    bad "A4 · $label RENDERED instead of failing closed"
+  elif grep -q "$expect" <<<"$out"; then
+    ok "A4 · $label fails closed"
+  else
+    bad "A4 · $label failed, but not with the expected message (want '$expect'): $(head -3 <<<"$out")"
+  fi
+}
+must_fail "reference + digest on the same image (ambiguous)" "an explicit full reference" \
+  --set runtime.agentImageDigest=sha256:5555555555555555555555555555555555555555555555555555555555555555
+must_fail "truncated digest" "Expected exactly sha256" --set minio.mc.digest=sha256:abc123
+must_fail "uppercase digest" "Expected exactly sha256" \
+  --set minio.mc.digest=sha256:AAAA111111111111111111111111111111111111111111111111111111111111
+must_fail "non-sha256 digest" "Expected exactly sha256" \
+  --set minio.mc.digest=sha512:1111111111111111111111111111111111111111111111111111111111111111
+must_fail "empty repository with no reference or digest" "empty repository" \
+  --set runtime.agentWorkerImageDigest= --set runtime.agentWorkerImageRepository=
+must_fail "empty tag with no reference or digest" "empty tag" \
+  --set runtime.agentWorkerImageDigest= --set global.imageTag= --set runtime.agentWorkerImageTag=
+
+[ "$fail" -eq 0 ] && { echo "gate:helm-mirror PASS"; exit 0; } || { echo "gate:helm-mirror FAIL"; exit 1; }

--- a/deploy/helm/tests/values-mirror-only.yaml
+++ b/deploy/helm/tests/values-mirror-only.yaml
@@ -1,0 +1,84 @@
+# Mirror-only fixture (#1006) — every image this chart can cause a cluster to pull is pointed at a
+# single private registry, and NOTHING may fall back to a public one.
+#
+# `registry.internal.invalid` is deliberately unresolvable: the fixture is a RENDER proof, and a
+# reference that cannot resolve makes an accidental live pull impossible. `tests/test_mirror_only.sh`
+# renders this file and asserts every container image plus every runtime-spawn image reference
+# carries the prefix below.
+#
+# `global.imageTag` is set ON PURPOSE. It is the load-bearing part of the fixture: a global tag must
+# supply a tag to the images that have no explicit identity, and must never rewrite one that does.
+
+global:
+  imageTag: "v0.0.0-mirror"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets:
+    - name: internal-registry-pull
+
+secrets:
+  adminApiToken: "test-admin-token"
+  internalApiSecret: "vexa-internal-secret"
+  dispatchSigningKey: "dev-dispatch-signing-key"
+
+# ---- long-running components: repository from the mirror, tag from global.imageTag ----
+gateway:
+  image:
+    repository: registry.internal.invalid/vexa/v012-gateway
+adminApi:
+  image:
+    repository: registry.internal.invalid/vexa/v012-admin-api
+meetingApi:
+  image:
+    repository: registry.internal.invalid/vexa/v012-meeting-api
+agentApi:
+  image:
+    repository: registry.internal.invalid/vexa/v012-agent-api
+terminal:
+  image:
+    repository: registry.internal.invalid/vexa/v012-terminal
+
+runtime:
+  backend: "k8s"
+  image:
+    repository: registry.internal.invalid/vexa/v012-runtime
+  # The three SPAWNED workloads, one per identity form the chart accepts, so the fixture proves all
+  # three legs at once:
+  #   bot          → explicit full reference carrying a digest
+  #   agent        → explicit full reference carrying a tag
+  #   agent-worker → repository + digest (composed by the chart)
+  # None of them may be rewritten by global.imageTag above.
+  browserImage: "registry.internal.invalid/vexa/vexa-bot@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  agentImage: "registry.internal.invalid/vexa/v012-agent-api:mirrored-2222"
+  agentWorkerImageRepository: "registry.internal.invalid/vexa/v012-agent-worker"
+  agentWorkerImageDigest: "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+
+# ---- bundled infrastructure + install hooks ----
+postgres:
+  image: registry.internal.invalid/mirror/postgres:17-alpine
+redis:
+  image: registry.internal.invalid/mirror/valkey:8-alpine
+pgbouncer:
+  enabled: true
+  image: registry.internal.invalid/mirror/pgbouncer:latest
+
+minio:
+  image:
+    repository: registry.internal.invalid/mirror/minio
+    tag: mirrored
+  # The post-install bucket-init Job. Before #1006 this Job ignored every value here and pulled
+  # `minio/mc:latest` from Docker Hub.
+  mc:
+    digest: "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    image:
+      repository: registry.internal.invalid/mirror/mc
+
+# The migrations Job is off by default; a mirror-only operator running it must be covered too.
+migrations:
+  enabled: true
+
+# The deprecated dashboard stays off (its own pinned tag, not part of the release set).
+dashboard:
+  enabled: false
+
+ingress:
+  enabled: false

--- a/docs/changelog.d/1006-mirror-only-image-references.md
+++ b/docs/changelog.d/1006-mirror-only-image-references.md
@@ -1,0 +1,12 @@
+- **Helm: a private-registry mirror can now hold every image the chart pulls (#1006).** Two of the
+  runtime's spawned-workload references — `runtime.agentImage` and `runtime.agentWorkerImage` — were
+  silently discarded whenever `global.imageTag` was set, rendering Docker Hub references a
+  mirror-only cluster cannot pull; the `minio-init` hook Job hardcoded `minio/mc:latest`. The chart
+  now resolves every image by one documented rule: an explicit full reference wins and
+  `global.imageTag` never rewrites it, otherwise `repository@digest`, otherwise `repository:tag`.
+  Ambiguous identities (a full reference *and* a digest) and malformed digests fail the render
+  instead of silently falling back to a mutable tag. The MinIO client image is configurable
+  (`minio.mc.reference` / `.digest` / `.image.repository` + `.image.tag`) and its default is the pinned RELEASE
+  tag `latest` resolved to, so the bytes an unconfigured install pulls are unchanged. With stock
+  values the render is otherwise byte-identical to v0.12.18. New `deploy/helm/tests/test_mirror_only.sh` renders a mirror-only fixture and fails if
+  any container, hook or runtime-spawn reference falls outside the configured registry.

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -231,9 +231,82 @@ binds into each worker Pod as a PVC, scoped per-mount). The Compose stack is the
 most production mileage today; the chart is the right starting point for a cluster
 evaluation — track the [status page](/roadmap/status).
 
-## Air-gapped clusters
+## Air-gapped clusters and private registry mirrors
 
-Everything the chart deploys pulls from images you build and host in your own registry; pair it
-with the [self-hosted transcription unit](/deployment#transcription-the-separate-gpu-unit) and
-your own LLM endpoint ([Configuration](/configuration)) for a zero-egress posture. See
+Everything the chart deploys can pull from a registry you host; pair it with the
+[self-hosted transcription unit](/deployment#transcription-the-separate-gpu-unit) and your own LLM
+endpoint ([Configuration](/configuration)) for a zero-egress posture. See
 [Security & compliance](/security-compliance).
+
+### One rule for every image reference
+
+| # | Value | Result |
+|---|---|---|
+| 1 | an explicit **full reference** (`runtime.browserImage`, `minio.mc.reference`, …) | used **verbatim** |
+| 2 | a **digest** (`runtime.browserImageDigest`, `minio.mc.digest`, …) | `<repository>@<digest>` |
+| 3 | `repository` + `tag` | `<repository>:<tag>` |
+
+**An explicit full reference wins; `global.imageTag` never rewrites it.** The global tag only
+supplies the tag on leg 3, for images that have no explicit identity of their own.
+
+The chart **fails closed** — `helm template` errors and nothing renders — if an image's identity is
+ambiguous (a full reference *and* a digest on the same image) or malformed (a digest that is not
+exactly `sha256:` + 64 lowercase hex). A typo'd digest is refused rather than quietly resolving to a
+mutable tag.
+
+### What your mirror has to hold
+
+Three of these are invisible to `kubectl get deploy -o yaml`, which is exactly why a mirror-only
+install could get most of the way up and then fail:
+
+| Image | Why it is pulled | Where you point it |
+|---|---|---|
+| gateway · admin-api · meeting-api · runtime · agent-api · terminal | long-running Deployments | `<component>.image.repository` (+ `global.imageTag`) |
+| Postgres · Valkey/Redis · MinIO · PgBouncer (if enabled) | bundled infrastructure | `postgres.image` · `redis.image` · `minio.image` · `pgbouncer.image` |
+| MinIO client (`mc`) | **post-install hook Job** that creates the bucket — not a Deployment, easy to miss when inventorying, and the install fails without it | `minio.mc.reference` / `.digest` / `.image.repository` + `.image.tag` |
+| DB migrations | opt-in hook Job (`migrations.enabled`) | `migrations.image.repository` (falls back to `meetingApi.image.*`) |
+| **meeting bot (~3.6 GB)** · **agent** · **agent-worker** | **spawned by the runtime at meeting time** — not containers in any rendered manifest. The chart passes them as `BROWSER_IMAGE` / `AGENT_IMAGE` / `AGENT_WORKER_IMAGE` env and the runtime creates those Pods later | `runtime.browserImage` · `runtime.agentImage` · `runtime.agentWorkerImage` (or the matching `…Digest` / `…Repository` + `…Tag`) |
+
+The three spawned images fail **late**: the control plane goes green and the first meeting dies with
+`ImagePullBackOff` on a Pod nobody was watching. Mirror them at install time.
+
+```yaml
+global:
+  imageTag: v0.12.19
+  imagePullSecrets: [{ name: internal-registry-pull }]
+runtime:
+  image: { repository: registry.example.internal/vexa/v012-runtime }
+  browserImage: "registry.example.internal/vexa/vexa-bot@sha256:<64 hex>"
+  agentImage:   "registry.example.internal/vexa/v012-agent-api:v0.12.19"
+  agentWorkerImageRepository: registry.example.internal/vexa/v012-agent-worker
+  agentWorkerImageDigest: "sha256:<64 hex>"
+minio:
+  image: { repository: registry.example.internal/mirror/minio, tag: latest }
+  mc:    { digest: "sha256:<64 hex>", image: { repository: registry.example.internal/mirror/mc } }
+```
+
+Prove it before you install — the render tells you everything, no cluster needed:
+
+```bash
+helm template vexa deploy/helm/charts/vexa -n vexa -f my-values.yaml \
+  | grep -E '^\s+image:|_IMAGE$' -A1
+```
+
+Anything in that output that is not your registry is something your cluster will try to pull from
+the internet.
+
+### Upgrading from v0.12.18 or earlier
+
+Behaviour changed in one direction only: **explicit references are now honoured where they were
+previously discarded.**
+
+- If you set `runtime.agentImage` or `runtime.agentWorkerImage` *and* `global.imageTag`, the
+  explicit reference used to be silently overwritten by the global tag. It is now used. If you were
+  relying on the global tag to win, clear the explicit value (`--set runtime.agentImage=`) and set
+  `runtime.agentImageRepository` instead.
+- The `minio-init` Job no longer hardcodes `minio/mc:latest`. The default is the pinned
+  `minio/mc:RELEASE.2025-08-13T08-35-41Z` — the same bytes `latest` resolved to at pin time — so an
+  unconfigured install pulls the same image it did before, now by an explicit name.
+- With stock values the rendered manifests are byte-identical to v0.12.18 **except** that one line:
+  every other image reference is unchanged. Nothing moves unless you had set one of the two values
+  that were being ignored.

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -202,7 +202,12 @@ const MINIO_JOB = "deploy/helm/charts/vexa/templates/job-minio-init.yaml";
 test("image-licenses RED: an undeclared image pinned in a helm TEMPLATE (not just values) reds", () => {
   // The gate must read helm templates, not only compose + values — a literal `image:` in a template
   // is a real pin. An undeclared one must red, else the 'green gate ships an un-audited component' hole.
-  const r = withEdited(MINIO_JOB, "image: minio/mc:latest", "image: somevendor/unaudited:1.2",
+  // Anchor on the image LINE, not on a specific value: #1006 replaced the hardcoded
+  // `minio/mc:latest` with a configurable helper call, so a literal-string anchor
+  // silently became a fixture that could not be built — and this test correctly
+  // refused to pass vacuously rather than proving nothing. The regex keeps exactly
+  // one `image:` key; a duplicate would change what helm renders, not just what it pins.
+  const r = withEdited(MINIO_JOB, /^(\s*)image: .*$/m, "$1image: somevendor/unaudited:1.2",
     () => runGate("image-licenses"));
   assert.equal(r.green, false, "an undeclared image in a helm template sailed through — the gate never read templates");
   assert.match(r.out, /undeclared pinned image/);


### PR DESCRIPTION
**Delivers issue:** Closes #1006

A cluster that pulls only from a private mirror could not run Vexa no matter what it configured. Three of the images the chart causes a cluster to pull ignored the operator entirely.

Reported by an engineer running the official chart on a quota-controlled, mirror-only OpenShift cluster. In his words, spotting it *"cost me a while before I spotted the Docker Hub path sitting in the render."*

## What was broken

- `runtime.agentImage` and `runtime.agentWorkerImage` were **discarded whenever `global.imageTag` was set** — the chart rendered `vexaai/v012-agent-api:<tag>` and a hardcoded `vexaai/v012-agent-worker:<tag>` instead. Both are *spawned* Pods, so they fail **late**: the control plane goes green and the first meeting dies on `ImagePullBackOff`.
- The `minio-init` hook Job hardcoded `minio/mc:latest` — unconfigurable, and mutable.

## What changed

Every image now resolves by one rule, `vexa.imageRef`:

1. an explicit full reference wins, and **`global.imageTag` never rewrites it**;
2. else `repository@digest`;
3. else `repository:tag`.

Ambiguous identities (a full reference *and* a digest) and malformed digests **fail the render closed** rather than silently resolving to a mutable tag. A typo'd digest must not deploy bytes the operator did not choose.

## Observation bundle

**C1 — the same test, unchanged, is RED at base and GREEN at head.**

At base (`fde7dfb7`), `gate:helm-mirror` exits 1 with 11 failures. The load-bearing ones:

```
AGENT_WORKER_IMAGE = vexaai/v012-agent-worker:v0.0.0-mirror   (explicit reference discarded)
runtime.agentImage discarded
image: minio/mc:latest
+ all six fail-closed cases rendering instead of erroring
```

At head (`ae3bb7ae`): **20 OKs**, and all three A3 negative-control probes go red as required.

**C2 — the byte-diff proves the change is surgical.** Rendering base vs head across four overlays, **exactly one line differs anywhere**: the mc tag. Every other image byte-identical. The `minio/mc` default moved from mutable `latest` to the pinned `RELEASE.2025-08-13T08-35-41Z`, verified against Docker Hub as the same digest — `sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727`. **The bytes are unchanged; the identity is now explicit.**

**C3 — gates at the exact pushed head, on a 128-core host: 35/35 green, exit 0.**

*(Operator note for future runs: a first attempt showed 7 red purely because `uv` is not on a non-interactive ssh PATH on that host. With `PATH="$HOME/.local/bin:$PATH"` it is clean.)*

**A regression guard ships with it.** `deploy/helm/tests/test_mirror_only.sh` + `values-mirror-only.yaml`, wired into `make -C deploy/helm test` and the CI Helm-gates step, so this cannot come back silently.

**C4 — the live mirror-only cluster leg is now complete, and it is why this says `Closes`.** On one k3d cluster with a private registry and public egress blackholed (`alpine:3.19` → `ImagePullBackOff`, probe pod gets a sandbox and an IP, then fails the pull), base and head were installed from the same values file minutes apart:

```
NAME  NAMESPACE     REVISION  STATUS    CHART        APP VERSION
vexa  vexa-mirror   1         deployed  vexa-0.12.1  0.12.18     <-- head 401a444f
vexa  vexa-base     1         failed    vexa-0.12.1  0.12.18     <-- base fde7dfb7
```

At base the control plane goes green and then the install dies on the hook — `vexa-vexa-minio-init image=minio/mc:latest` → `ImagePullBackOff`, with `AGENT_WORKER_IMAGE=vexaai/v012-agent-worker:mirrored` sitting in the runtime waiting to fail even later. At head the release reaches `deployed` in 24s, the `minio-init` Job completes `1/1` from `k3d-mirror1006:5111/mirror/mc@sha256:bdfae21c…` and creates the bucket, all three spawned-image envs resolve exactly as configured, and a scan of every live object returns zero Docker Hub references. Full bundle: https://github.com/Vexa-ai/vexa/pull/1096#issuecomment-5233650174

## What was NOT checked

- **OpenShift with public egress disabled.** We have no OpenShift. Not run, not simulated.
- **No live meeting spawn.** The bot and agent-worker mirror entries are `alpine:3.20` stand-ins, so the leg proves the *references* resolve in a sealed cluster — never that the real 3.6 GB bot boots.

### A finding the issue did not predict

**A `registries.yaml` mirror entry alone did not prevent Docker Hub fallback.** Containerd pulled from Docker Hub anyway; the registry hostnames had to be blackholed in the node's `/etc/hosts` before the cluster was genuinely sealed. Any operator who believes a mirror entry equals no egress is wrong, and that is worth knowing independently of this fix.

**And a genuinely sealed k3s node cannot start *any* pod unless the sandbox image is already local.** `sandbox = "rancher/mirrored-pause:3.6"` is pinned in the node's containerd config, so it is never subject to the operator's mirror values. When it was absent, k3s's own `local-path` provisioner helper pod could not start either, so **every PVC in the cluster hung `Pending`** and the resulting `helm status: failed` looked like a chart problem when it was cluster prep. Neither of these is a chart defect, but both are what an air-gapped operator hits before they ever reach Vexa — `docs/docs/deployment-kubernetes.mdx` is where someone would look for them.

## Two things a reviewer should look at deliberately

1. **`runtime.agentImage`'s default flips from `"vexaai/v012-agent-api:v012"` to `""`**, with the composed leg falling back to `agentApi.image.*`. Deliberate — otherwise anyone who mirrored `agentApi.image.repository` would have regressed to Docker Hub — but it is a values-default change, not just a helper change.
2. **`docs/docs/deployment-kubernetes.mdx` is a known hot, non-union-mergeable file**, and its "Air-gapped clusters" section is rewritten here. It previously asserted that everything the chart deploys pulls from images you build and host in your own registry — which this bug falsified. Sequence against any other change touching that page.

Related: #1001 (the digest helper for the six long-running Deployments) remains open. `vexa.imageRef` is built for it to adopt; this PR does not convert them.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> ⚠️ **Unticked deliberately.** The branch, the validation and this description were prepared by an
> agent; the rights declaration is a legal certification a human must make. @DmitriyG228 — tick one
> box. The commit already carries a DCO `Signed-off-by`.

