### PR TITLE
[DEV] validation branch: #1005 + #1006 installable together (DO NOT MERGE)

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -181,6 +181,9 @@ jobs:
         run: |
           bash deploy/helm/tests/test_helm_lint.sh
           bash deploy/helm/tests/test_template.sh
+          # #1006 — the mirror-only invariant: no image this chart can cause a cluster to pull may
+          # fall back to a public registry, helm hooks and runtime-spawned Pods included.
+          bash deploy/helm/tests/test_mirror_only.sh
 
       - name: Pinned render — every image ref follows global.imageTag
         env:

--- a/MARVIN-TEST-KIT-1005.md
+++ b/MARVIN-TEST-KIT-1005.md
@@ -1,0 +1,315 @@
+# Test kit — #1005 on a quota-controlled cluster
+
+For the validator running this on a real quota-enforcing namespace (OpenShift dev cluster included).
+Branch `1005-runtime-resources`, based on `616778fe`.
+
+**What you are proving:** the two Pods the runtime creates *dynamically* — the meeting bot and the
+agent worker — now declare CPU and memory requests **and** limits, so your namespace admits them
+instead of rejecting them. Nothing else about the release changes.
+
+**What has already been proven, and where** — so you can skip re-doing it:
+
+| Already green | Where |
+|---|---|
+| Both profiles admitted under a `ResourceQuota` requiring all four values, sized independently | k3d v1.35.5, namespace `vexa-quota` — see `OBSERVATION-BUNDLE-1005.md` A1/A2 |
+| Image, command, env, labels, tolerations, nodeSelector, workspace mounts all survive | same, A3 |
+| Removing one dimension reds admission; restoring it greens the same spawn | same, A4 |
+| Offline runtime suite, Helm render, Compose stack, all 34 repo gates | same, A- |
+
+**What only your cluster can prove:** OpenShift SCC behaviour on the spawned Pods, your real quota
+headroom, and whether the real bot image lives inside the memory ceiling you set. Read
+[the honest caveats](#honest-caveats) before you start — one of them is likely to bite.
+
+---
+
+## 1 · Install
+
+Two values blocks matter. The first is the new one.
+
+```yaml
+# values-quota.yaml
+runtime:
+  backend: k8s
+  # Sizing for the Pods the runtime SPAWNS. NOT runtime.resources (which sizes the runtime
+  # Deployment itself). One value per dimension sets BOTH the request and the limit.
+  workloadResources:
+    meetingBot:
+      cpu: 2                 # → requests/limits cpu: 2000m
+      memoryMb: 4096         # → requests/limits memory: 4096Mi
+    agentWorker:
+      cpu: 0.5               # → requests/limits cpu: 500m
+      memoryMb: 1024         # → requests/limits memory: 1024Mi
+```
+
+```bash
+helm upgrade --install vexa deploy/helm/charts/vexa \
+  -n <your-namespace> --create-namespace \
+  -f values-quota.yaml \
+  --set global.imageTag=<TAG> \
+  --set secrets.adminApiToken=$ADMIN_TOKEN \
+  --set secrets.internalApiSecret=$INTERNAL_API_SECRET
+```
+
+Confirm the sizing reached the runtime before you spawn anything:
+
+```bash
+kubectl -n <your-namespace> get deploy vexa-runtime -o json \
+  | jq '.spec.template.spec.containers[0].env[]
+        | select(.name|test("^RUNTIME_(BOT|AGENT_WORKER)_"))'
+```
+
+Expected — four entries, non-empty:
+
+```json
+{"name":"RUNTIME_BOT_CPU","value":"2"}
+{"name":"RUNTIME_BOT_MEMORY_MB","value":"4096"}
+{"name":"RUNTIME_AGENT_WORKER_CPU","value":"0.5"}
+{"name":"RUNTIME_AGENT_WORKER_MEMORY_MB","value":"1024"}
+```
+
+If they are empty strings, the chart values did not land — the spawned Pods will declare nothing and
+your namespace will reject them exactly as before. Fix this before going further.
+
+> **Sizing note, not a formality.** `memoryMb` is a **hard ceiling**: a workload exceeding it is
+> OOM-killed. Before this change nothing was enforced, so bots ran unbounded and we have no measured
+> figure to hand you. `4096` above is deliberately more generous than the chart default (`2048`).
+> Start high, watch actual usage, then tighten — do not start at the default and discover the ceiling
+> as a dropped meeting.
+
+---
+
+## 2 · Spawn both profiles and watch
+
+Trigger one meeting bot (your normal `POST /bots` path) and one agent dispatch. Then, for each:
+
+```bash
+kubectl -n <your-namespace> get pods -l runtime.managed=true
+kubectl -n <your-namespace> get pod <pod> -o json | jq '{
+  qos:        .status.qosClass,
+  phase:      .status.phase,
+  resources:  .spec.containers[0].resources,
+  image:      .spec.containers[0].image,
+  command:    .spec.containers[0].command,
+  envCount:   (.spec.containers[0].env|length),
+  labels:     .metadata.labels
+}'
+```
+
+### Expected observations
+
+| Pod | Name shape | Expect |
+|---|---|---|
+| meeting bot | `vexa-<meeting-workload-id>` | `resources.requests` **and** `.limits` = `{cpu: 2, memory: 4096Mi}`; `qosClass: Guaranteed`; `phase: Running`; **no** `command` (the bot image's own ENTRYPOINT boots it); `labels` carry `runtime.managed=true` + `runtime.workload_id` |
+| agent worker | `vexa-agent-…` | `resources` = `{cpu: 500m, memory: 1Gi}` — **different from the bot**; `qosClass: Guaranteed`; `command: ["python","-m","worker"]` |
+
+`2000m`/`500m` display as `2`/`500m` — the API server normalizes; either spelling is the same value.
+
+Quota consumption should move:
+
+```bash
+kubectl -n <your-namespace> describe resourcequota
+```
+
+Both classes should appear in `requests.cpu` / `limits.memory` usage while running, and drop back when
+the workloads finish.
+
+### The one-line red control (optional, 30 seconds)
+
+Proves the quota is really enforcing and that the values came from Vexa, not from a LimitRange:
+
+```bash
+kubectl -n <your-namespace> run quota-probe --image=busybox:1.36 --restart=Never -- sleep 30
+```
+
+Expected: **rejected** — `must specify limits.cpu … requests.memory …`. If this *succeeds*, a
+LimitRange is defaulting your namespace, and per the issue's closing rule a green run there does not
+prove Vexa emitted the resources. Re-check with the `jq` above: the values must equal what you set in
+`values-quota.yaml`, not the LimitRange defaults.
+
+---
+
+## 3 · Capture this on failure
+
+Please attach all of it — partial reports cost a round trip.
+
+```bash
+NS=<your-namespace>; POD=<the failing pod>
+
+# 1. Did admission reject the spawn? The runtime logs the API server's own reason verbatim.
+kubectl -n $NS logs deploy/vexa-runtime --tail=200 | grep -iE "kubectl create|forbidden|StartFailed"
+
+# 2. Namespace events — quota denials, SCC denials, scheduling failures all land here
+kubectl -n $NS get events --sort-by=.lastTimestamp | tail -40
+
+# 3. The Pod as the API server accepted it (or the whole object if it never got created)
+kubectl -n $NS get pod $POD -o yaml
+
+# 4. Why it is not running
+kubectl -n $NS describe pod $POD
+
+# 5. What the workload itself said
+kubectl -n $NS logs $POD --previous --tail=200 || kubectl -n $NS logs $POD --tail=200
+
+# 6. Quota state at the time
+kubectl -n $NS describe resourcequota
+kubectl -n $NS get limitrange -o yaml     # if any — see the LimitRange note above
+```
+
+Reading the three failure shapes:
+
+| Symptom | Almost certainly |
+|---|---|
+| No Pod at all; runtime log says `forbidden: failed quota: … must specify …` | the sizing env did not reach the runtime, or one dimension is empty — recheck §1 |
+| No Pod; message mentions `unable to validate against any security context constraint` | **SCC**, not quota — see caveats below |
+| Pod exists, `Pending`, events say `Insufficient cpu/memory` | your quota or node headroom is smaller than the size you set — lower `cpu`/`memoryMb` or raise the quota |
+| Pod runs then dies with `OOMKilled` (exit 137) | `memoryMb` is too low for the real workload — raise it |
+
+---
+
+## Honest caveats
+
+**1 · Spawned-Pod SCC on OpenShift is untested — this is the most likely surprise.**
+You proved the *control plane* satisfies your SCC. The bot and agent Pods are **different objects**:
+bare Pods created by the runtime at spawn time, not children of any Deployment, so they inherit
+nothing from the control-plane pod templates. A `restricted-v2` SCC may additionally require
+`runAsNonRoot`, a dropped capability set, or a `seccompProfile` on those Pods — **this change adds
+none of those**, and no OpenShift cluster was available to test it. If §2 fails with an SCC message
+rather than a quota message, that is a *separate, known-open* gap: capture the event text and the SCC
+name (`kubectl -n $NS get pod $POD -o jsonpath='{.metadata.annotations.openshift\.io/scc}'`) and send
+it — it is a follow-up issue, not a defect in this one.
+
+**2 · The memory ceiling is a guess until you measure it.** No live meeting has run under an enforced
+limit. Set generously, observe (`kubectl top pod`), then tighten.
+
+**3 · Enforcement is Kubernetes-only.** The docker and process backends accept the same resource
+intent and do not act on it. Compose and Lite deployments are unchanged; no parity is claimed.
+
+**4 · Guaranteed QoS changes scheduling density.** Request equals limit by design (runtime.v1 carries
+one value per dimension). Reserved capacity is now real — a node that used to fit N unbounded bots
+fits `floor(allocatable / size)` of them.
+
+**5 · What the k3d validation substituted.** The live legs in the bundle ran `busybox:1.36` in place
+of the bot and worker images, so the *declaration and admission* path is proven against a real API
+server but the real images were never run inside the limits. Your run is the first that does that —
+which is exactly why it is the one that closes the issue.
+
+---
+
+## Appendix · the exact scripts used for the recorded evidence
+
+Re-runnable against any cluster; drop them in a scratch dir.
+
+<details><summary><code>quota-ns.yaml</code></summary>
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vexa-quota
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: require-requests-and-limits
+  namespace: vexa-quota
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 4Gi
+    limits.cpu: "4"
+    limits.memory: 4Gi
+    pods: "10"
+```
+</details>
+
+<details><summary><code>quota-validate.py</code> — spawns both profiles through the real kernel</summary>
+
+Run from `core/runtime` as
+`PYTHONPATH=src uv run python quota-validate.py {green|red-unsized|red-no-memory}`.
+
+```python
+import json, os, subprocess, sys, time
+NS = "vexa-quota"
+
+def kubectl(*args, stdin=None, check=True):
+    r = subprocess.run(["kubectl", *args], capture_output=True, text=True, input=stdin)
+    if check and r.returncode != 0:
+        raise SystemExit(f"kubectl {' '.join(args)} FAILED:\n{r.stderr}")
+    return r
+
+def pod_json(name):
+    return json.loads(kubectl("get", "pod", name, "-n", NS, "-o", "json").stdout)
+
+def spawn(profile_name, workload_id):
+    from runtime_kernel import Runtime
+    from runtime_kernel.k8s_backend import K8sBackend
+    from runtime_kernel.models import WorkloadSpec
+    from runtime_kernel.profiles import apply_command_overrides, default_registry
+    rt = Runtime(backend=K8sBackend(namespace=NS),
+                 profiles=apply_command_overrides(default_registry()), grace_sec=5.0)
+    return rt, rt.create(WorkloadSpec(workloadId=workload_id, profile=profile_name,
+                                      env={"VEXA_X": "y"}))
+
+def main():
+    os.environ["BROWSER_IMAGE"] = os.environ["AGENT_WORKER_IMAGE"] = "busybox:1.36"
+    os.environ["AGENT_IMAGE"] = "busybox:1.36"
+    os.environ["AGENT_WORKER_COMMAND"] = os.environ["BOT_COMMAND"] = "sleep 120"
+    mode = sys.argv[1] if len(sys.argv) > 1 else "green"
+    if mode == "green":
+        os.environ["RUNTIME_BOT_CPU"] = "1";            os.environ["RUNTIME_BOT_MEMORY_MB"] = "512"
+        os.environ["RUNTIME_AGENT_WORKER_CPU"] = "0.25"; os.environ["RUNTIME_AGENT_WORKER_MEMORY_MB"] = "256"
+    elif mode == "red-no-memory":
+        os.environ["RUNTIME_BOT_CPU"] = "1";            os.environ.pop("RUNTIME_BOT_MEMORY_MB", None)
+        os.environ["RUNTIME_AGENT_WORKER_CPU"] = "0.25"; os.environ.pop("RUNTIME_AGENT_WORKER_MEMORY_MB", None)
+    elif mode == "red-unsized":
+        for k in ("RUNTIME_BOT_CPU", "RUNTIME_BOT_MEMORY_MB",
+                  "RUNTIME_AGENT_WORKER_CPU", "RUNTIME_AGENT_WORKER_MEMORY_MB"):
+            os.environ.pop(k, None)
+
+    print(f"=== MODE: {mode} ===")
+    for profile, wid in (("meeting-bot", f"mtg-{mode}"), ("agent", f"agent-{mode}")):
+        kubectl("delete", "pod", f"vexa-{wid}", "-n", NS, "--ignore-not-found",
+                "--grace-period=0", "--force", check=False)
+        print(f"\n--- profile={profile} workloadId={wid} ---")
+        try:
+            rt, status = spawn(profile, wid)
+        except Exception as exc:
+            print(f"SPAWN REJECTED: {type(exc).__name__}: {str(exc)[:600]}")
+            continue
+        print(f"kernel state: {status.state.value}")
+        c = pod_json(f"vexa-{wid}")["spec"]["containers"][0]
+        print("ADMITTED. container.resources =", json.dumps(c.get("resources", {})))
+        print("image =", c["image"], "| command =", c.get("command"))
+        deadline, phase = time.time() + 60, ""
+        while time.time() < deadline:
+            phase = pod_json(f"vexa-{wid}")["status"]["phase"]
+            if phase == "Running":
+                break
+            time.sleep(2)
+        print("phase =", phase, "| qosClass =", pod_json(f"vexa-{wid}")["status"].get("qosClass"))
+        rt.stop(wid); rt.destroy(wid)
+        print("terminal:", rt.get(wid).state.value)
+
+if __name__ == "__main__":
+    main()
+```
+</details>
+
+<details><summary><code>a3-live.py</code> — proves no generated field is erased</summary>
+
+Creates a small PVC, spawns one Pod carrying resources + tolerations + nodeSelector + a two-mount
+workspace set, and prints what the API server accepted. Full source in the session scratch; the
+essential call is:
+
+```python
+K8sBackend(namespace=NS).start(
+    wid, Runnable(image="busybox:1.36", command=["sleep", "120"]), env,
+    Resources(cpu=0.5, memoryMb=256),
+)
+```
+
+with `RUNTIME_K8S_TOLERATIONS` / `RUNTIME_K8S_NODE_SELECTOR` set in the process env and
+`VEXA_WORKSPACE_MOUNT_SOURCE` / `_TARGET` / `VEXA_MOUNTS` in the workload env. Then read the Pod back
+and assert `image`, `command`, `env`, `labels`, `restartPolicy`, `tolerations`, `nodeSelector`,
+`volumes`, `volumeMounts` and `resources` are all present on the accepted object.
+</details>

--- a/OBSERVATION-BUNDLE-1005.md
+++ b/OBSERVATION-BUNDLE-1005.md
@@ -1,0 +1,460 @@
+# Observation bundle — #1005 · runtime workloads carry CPU/memory requests and limits
+
+**Issue:** [Vexa-ai/vexa#1005](https://github.com/Vexa-ai/vexa/issues/1005) — *Quota-controlled
+clusters start every runtime workload — apply resources to bot and agent-worker Pods*
+**Branch:** `1005-runtime-resources` · **base:** `616778fe394919f871d792fd6214ea23d0aeac6e` (origin/main)
+**Implementation commit (the anchor for every row below):** `b3bed7b8` — *fix(runtime): spawned Pods
+declare CPU/memory requests and limits (#1005)*. Not pushed; the founder opens the PR (the
+contribution-rights declaration is a human decision, per `CONTRIBUTOR_RIGHTS.md`).
+**Validation cluster:** k3d `k3d-vexa1005`, Kubernetes **v1.35.5+k3s1**, single server node, Docker 29.1.3
+**Quota namespace:** `vexa-quota` with a `ResourceQuota` naming `requests.cpu`, `requests.memory`,
+`limits.cpu`, `limits.memory` — the shape that forces every container to declare all four.
+
+Facts first; my reading is labelled and lives at the end.
+
+---
+
+## The acceptance table
+
+| # | Observation | Verdict | Evidence |
+|---|---|---|---|
+| **A1** | Meeting-bot Pod carries configured CPU/memory requests and limits and is admitted under quota | **GREEN** | [A1](#a1--meeting-bot-admitted-under-quota) |
+| **A2** | Agent-worker Pod carries **independently** configured requests and limits and is admitted under the same quota | **GREEN** | [A2](#a2--agent-worker-admitted-independently-sized) |
+| **A3** | Image, command, env, labels, scheduling and workspace mounts survive resource injection | **GREEN** (live + offline, with the negative control shown red) | [A3](#a3--every-generated-field-survives) |
+| **A4** | Omitting one required request or limit makes admission red; restoring it makes the same spawn green | **GREEN** | [A4](#a4--red-green-on-one-missing-dimension) |
+| **A5** | Both profiles reach truthful bounded terminal states on a real API server | **GREEN** | [A5](#a5--truthful-bounded-terminal-states) |
+| **A-** | Runtime, Helm, docs-current, architecture and repository gates green at head | **GREEN** | [A-](#a---gates) |
+
+**Coverage caveat carried through every live row:** the live legs ran with `busybox:1.36`
+substituted for the meeting-bot and agent-worker images (`BROWSER_IMAGE` / `AGENT_WORKER_IMAGE`),
+so what is proven is the **resource declaration and admission path through the real kernel, the real
+profile registry and a real API server** — not that the 3.6 GB bot image boots inside those limits.
+Sizing the real images for real meetings is the operator decision the chart now exposes; see
+[Honest limits](#what-was-not-checked).
+
+---
+
+## A1 · Meeting-bot admitted under quota
+
+**Expected:** with `RUNTIME_BOT_CPU=1` / `RUNTIME_BOT_MEMORY_MB=512`, a `meeting-bot` workload created
+through the real `Runtime` + `K8sBackend` is admitted into `vexa-quota`, and the accepted Pod object
+carries `requests` **and** `limits` for cpu and memory.
+
+**Negative control (current head, pre-change shape):** unset all four sizing knobs — the same spawn is
+rejected because it declares nothing. Run first:
+
+```
+=== MODE: red-unsized ===
+--- profile=meeting-bot workloadId=mtg-red-unsized ---
+SPAWN REJECTED: StartFailed: kubectl create -f - -n vexa-quota failed: Error from server (Forbidden):
+error when creating "STDIN": pods "vexa-mtg-red-unsized" is forbidden: failed quota:
+require-requests-and-limits: must specify limits.cpu for: vexa-mtg-red-unsized;
+limits.memory for: vexa-mtg-red-unsized; requests.cpu for: vexa-mtg-red-unsized;
+requests.memory for: vexa-mtg-red-unsized
+```
+
+**Actual (sized):**
+
+```
+=== MODE: green ===
+--- profile=meeting-bot workloadId=mtg-green ---
+kernel state: running
+ADMITTED. container.resources = {"limits": {"cpu": "1", "memory": "512Mi"},
+                                 "requests": {"cpu": "1", "memory": "512Mi"}}
+image = busybox:1.36 | command = ['sleep', '120']
+labels = {"runtime.managed": "true", "runtime.workload_id": "mtg-green"}
+env names = ['VEXA_X']
+phase = Running | qosClass = Guaranteed
+terminal: destroyed
+```
+
+**Verdict: GREEN.** Red→green on the same spawn, same namespace, same quota. (`1000m` is normalized to
+`1` by the API server; the submitted manifest carries `1000m`.)
+
+---
+
+## A2 · Agent-worker admitted, independently sized
+
+**Expected:** in the SAME run and SAME namespace, `profile=agent` is admitted carrying a **different**
+size, sourced from its own knobs (`RUNTIME_AGENT_WORKER_CPU=0.25` / `RUNTIME_AGENT_WORKER_MEMORY_MB=256`).
+
+**Negative control:** same `red-unsized` run —
+
+```
+--- profile=agent workloadId=agent-red-unsized ---
+SPAWN REJECTED: StartFailed: … pods "vexa-agent-red-unsized" is forbidden: failed quota:
+require-requests-and-limits: must specify limits.cpu …; limits.memory …; requests.cpu …;
+requests.memory for: vexa-agent-red-unsized
+```
+
+**Actual:**
+
+```
+--- profile=agent workloadId=agent-green ---
+kernel state: running
+ADMITTED. container.resources = {"limits": {"cpu": "250m", "memory": "256Mi"},
+                                 "requests": {"cpu": "250m", "memory": "256Mi"}}
+phase = Running | qosClass = Guaranteed
+terminal: destroyed
+```
+
+**Verdict: GREEN.** `250m/256Mi` for the agent vs `1/512Mi` for the bot, in one run — the two classes
+are genuinely sized apart, not off one shared knob. Offline counterparts:
+`test_profile_default_applies_when_the_caller_omits_resources`,
+`test_default_registry_sizes_the_two_profiles_independently`.
+
+---
+
+## A3 · Every generated field survives
+
+**Expected:** a Pod carrying resources **and** workspace volumeMounts **and** the runtime's scheduling
+constraints is accepted with its image, command, env, labels and restart policy intact.
+
+**Negative control (the mechanism this change replaced), run live on the same cluster:**
+
+```
+$ kubectl run vexa-neg-control --image=busybox:1.36 --restart=Never -n vexa-quota \
+    --overrides='{"spec":{"containers":[{"name":"vexa-neg-control","resources":{…}}]}}'
+The Pod "vexa-neg-control" is invalid: spec.containers[0].image: Required value
+```
+
+A partial `containers` entry in `kubectl run --overrides` is a JSON **merge** patch: it replaces the
+generated containers list wholesale and the image/env/command are gone. The issue predicted this; it
+reproduces exactly.
+
+**Actual (this change's mechanism — a complete Pod manifest submitted via `kubectl create -f -`),
+read back from the API server after acceptance:**
+
+```
+ACCEPTED BY THE API SERVER — surviving fields:
+  image        : busybox:1.36
+  command      : ['sleep', '120']
+  env          : [VEXA_BOT_CONFIG, VEXA_WORKSPACE_MOUNT_SOURCE, VEXA_WORKSPACE_MOUNT_TARGET, VEXA_MOUNTS]
+  labels       : {"runtime.managed": "true", "runtime.workload_id": "a3-survive"}
+  restartPolicy: Never
+  tolerations  : [{"effect": "NoSchedule", "key": "vexa.ai/bots", "operator": "Exists"}]
+  nodeSelector : {"kubernetes.io/os": "linux"}
+  volumes      : [{"name": "workspace-store", "persistentVolumeClaim": {"claimName": "vexa-workspaces-a3"}}]
+  volumeMounts : [{"mountPath": "/workspaces/u1", "name": "workspace-store", "subPath": "u1"},
+                  {"mountPath": "/workspaces/deal-9", "name": "workspace-store", "readOnly": true,
+                   "subPath": "deal-9"}]
+  resources    : {"limits": {"cpu": "500m", "memory": "256Mi"},
+                  "requests": {"cpu": "500m", "memory": "256Mi"}}
+```
+
+**Verdict: GREEN.** Resources and per-mount volumeMounts coexist on one container — the combination
+the old override mechanism could not produce. Offline counterpart:
+`test_pod_carries_resources_and_every_pre_existing_field`.
+
+**Bonus finding, closed by the same change:** the pre-change code emitted a partial `containers`
+override *whenever a workspace mount set was present* (`k8s_backend.py:102-103` at the base commit),
+which is exactly the shape shown red above. Any k8s spawn carrying a workspace PVC was therefore
+rejected at the API server before this change. Nothing in the issue named it; it fell out of building
+the complete Pod.
+
+---
+
+## A4 · Red→green on one missing dimension
+
+**Expected:** declare cpu but omit memory ⇒ admission red, naming only the memory dimension; restore
+memory ⇒ the same spawn green.
+
+**Actual (memory omitted, both profiles):**
+
+```
+=== MODE: red-no-memory ===
+--- profile=meeting-bot workloadId=mtg-red-no-memory ---
+SPAWN REJECTED: … is forbidden: failed quota: require-requests-and-limits:
+must specify limits.memory for: vexa-mtg-red-no-memory; requests.memory for: vexa-mtg-red-no-memory
+
+--- profile=agent workloadId=agent-red-no-memory ---
+SPAWN REJECTED: … must specify limits.memory for: vexa-agent-red-no-memory;
+requests.memory for: vexa-agent-red-no-memory
+```
+
+The cpu complaints are **absent** — the cpu declaration was accepted; only the omitted dimension reds.
+Restoring it is the A1/A2 `green` run above (same script, same namespace, same quota).
+
+**Verdict: GREEN.**
+
+---
+
+## A5 · Truthful bounded terminal states
+
+**Expected:** a spawned workload reaches `Running` on a real API server, and `stop` → `destroy` drive
+the kernel to `destroyed` with the Pod actually removed. A rejected spawn records an honest terminal
+state rather than a false success.
+
+**Actual:**
+
+- both green profiles: `phase = Running`, `qosClass = Guaranteed`, then `terminal: destroyed`;
+- every rejection above surfaced as `StartFailed` carrying the API server's own reason text — the
+  kernel's existing contract (persist `stopped`/`start_failed`, emit the event, then raise) held
+  through the new submit path;
+- `tests/test_k8s_backend.py::test_k8s_backend_real_pod_lifecycle` — the repo's own cluster-dependent
+  lifecycle test — **ran** against this cluster instead of skipping, and passed (create → Pod exists →
+  `Running` → stop → destroy → Pod gone) through the rewritten `kubectl create -f -` path.
+
+**Verdict: GREEN.**
+
+---
+
+## A- · Gates
+
+```
+$ COMPOSE_PROJECT=vexa-gate-1005 ONNXRUNTIME_NODE_INSTALL=skip node scripts/gates.mjs all
+```
+
+All 34 gates green, including:
+
+| Gate | Result |
+|---|---|
+| `gate:python` | 12 packages · pytest green (runtime: **178 passed**, 0 skipped — up from 159 passed / 1 skipped at base) |
+| `gate:config-contract` | 5 services · 207 declared keys · declarations ≡ deploy surfaces ≡ code reads (the 4 new `RUNTIME_*` keys declared and rendered) |
+| `gate:compose` | REAL compose stack proven bot-ready (health · auth · transcript · recording · control-plane) — the Compose regression leg for the Backend port change |
+| `gate:graph-py` / `gate:isolation-py` | the new `backend → models`, `profiles → models` edges are allowed |
+| `gate:schema` / `gate:contract-version` | 25 sealed contracts unchanged — runtime.v1 was **not** touched |
+| `gate:docs-version` | docs reflect v0.12.18 ≡ Chart.yaml appVersion |
+
+`deploy/helm/tests/test_template.sh` → `gate:helm PASS`.
+
+**Two environmental reds, both resolved, neither caused by this diff.** The first `gates all` run failed
+`gate:compose` with `Error response from daemon: No such container: dcfe28d7c034…`. That container is
+a **2-week-old exited container from another checkout** (`/Users/dmitriygrankin/dev/vexa-926`, label
+`com.docker.compose.project=vexa-compose-gate`) holding the `vexa-compose-gate_redis-data` volume; the
+daemon holds a dangling reference the volume cannot be freed from. The conftest ships
+`COMPOSE_PROJECT` explicitly "override on a shared host" — running under `vexa-gate-1005` is green.
+This diff touches no compose file.
+
+**The re-run at the committed head could not complete — the host, not the code.** After the green run
+the only edits were docstring/comment corrections in `k8s_backend.py`, `mounts.py` and
+`test_mounts.py` (folded into the same commit; no behaviour change). Re-verifying them ran into a
+degraded host, in three stages, each recorded rather than retried away:
+
+1. `gates all` died with `zsh: no space left on device` during `pytest core/agent` — the volume was
+   down to **1.6 GiB free** after the k3d cluster and the compose image builds. I tore down the k3d
+   cluster and the `vexa-gate-1005` compose project to return the space (2.8 GiB free after).
+2. `gate:python` then blocked indefinitely at `core/identity/services/admin-api` — a **concurrent
+   session** (`/Users/dmitriygrankin/dev/vexa-turbine-first-turn`) was running that same package's
+   testcontainer suite at the same time. Both processes sat at 0% CPU. `admin-api` is untouched by
+   this diff.
+3. The runtime suite then hung too. Bisected to exactly one file: **`tests/test_docker_backend.py`**,
+   which drives the real Docker socket. By then `docker ps` itself did not return — the Docker
+   Desktop daemon was wedged under the disk pressure.
+
+What DID run at the committed head, in ~2.5 s total:
+
+| Selection | Result |
+|---|---|
+| whole runtime suite minus `test_docker_backend.py`, `test_worker_image.py`, `test_readopt.py`, `test_start_conflict.py` | **149 passed, 1 skipped** |
+| `test_readopt.py` + `test_start_conflict.py` | **20 passed** |
+| `test_worker_image.py` | **7 passed** |
+| the four files touched by the comment-only amend | **58 passed** |
+
+**176 passed / 1 skipped** across those selections (the skip is the k8s cluster test, once the k3d
+cluster was torn down). Only `test_docker_backend.py` is unaccounted for at the exact head SHA — and
+it passed in the full green run above, on the same code.
+
+**So: re-run `gates all` on a quiet host with disk headroom before the PR opens.** Nothing is
+suspected; the claim simply deserves to sit on the exact head SHA rather than on its
+comment-identical parent.
+
+---
+
+## Helm render evidence (issue's required Helm leg)
+
+Rendered from `deploy/helm/charts/vexa` with `-f values-test.yaml`:
+
+| Case | `RUNTIME_BOT_CPU` / `_MEMORY_MB` | `RUNTIME_AGENT_WORKER_CPU` / `_MEMORY_MB` |
+|---|---|---|
+| shipped defaults | `"1"` / `"2048"` | `"0.5"` / `"1024"` |
+| distinct overrides (`--set …meetingBot.cpu=2,…memoryMb=4096,…agentWorker.cpu=0.25,…memoryMb=512`) | `"2"` / `"4096"` | `"0.25"` / `"512"` |
+| all four set to `""` (the unset case) | `""` / `""` | `""` / `""` |
+| `--set runtime.backend=docker` | not rendered (0 occurrences) | not rendered |
+
+The unset case is the optional-contract preservation C3 asks for: empty ⇒ the profile builds no
+`Resources` ⇒ the Pod declares nothing ⇒ exactly the pre-change spawn. Offline counterpart:
+`test_default_registry_emits_no_resources_when_unset`.
+
+---
+
+## What changed (the seams)
+
+| Seam | File | Change |
+|---|---|---|
+| C1 · resource intent crosses the port | `core/runtime/src/runtime_kernel/backend.py` | `Backend.start(..., resources: Optional[Resources] = None)` |
+| C1 | `core/runtime/src/runtime_kernel/kernel.py` | `effective_resources = spec.resources or profile.resources`, passed to `backend.start`; `_coerce_registry` now accepts a full `Profile` |
+| C1 | `core/runtime/src/runtime_kernel/models.py` | `Resources` fields floored at `ge=0`, mirroring the sealed schema's `minimum: 0` — a negative fails at parse, before any spawn |
+| C2 | `core/runtime/src/runtime_kernel/k8s_backend.py` | new `resource_requirements()` + `build_pod()`; `start()` submits a complete manifest via `kubectl create -f -` instead of `kubectl run --overrides` |
+| C3 | `core/runtime/src/runtime_kernel/profiles.py` | `Profile.resources`; per-class env knobs parsed in `default_registry()`, non-numeric fatal at boot |
+| C3 | `deploy/helm/charts/vexa/values.yaml`, `templates/deployment-runtime.yaml` | `runtime.workloadResources.{meetingBot,agentWorker}.{cpu,memoryMb}` → 4 env keys (k8s backend only) |
+| — | `core/runtime/src/runtime_kernel/{docker,process}_backend.py` | accept `resources`, do not enforce; the k8s-only boundary is stated in each docstring |
+| docs | `docs/changelog.d/1005-runtime-resources.md`, `deploy/helm/charts/vexa/README.md` | changelog fragment (the `docs-current` touch) + a values/behaviour section |
+| tests | `core/runtime/tests/test_workload_resources.py` (new, 16 tests) + 4 existing files updated | see below |
+
+**Design decisions worth reviewing:**
+
+1. **One value → both request and limit.** runtime.v1 carries one `cpu` and one `memoryMb`. Both map
+   to request *and* limit, per the issue's "do not invent separate request/limit semantics inside
+   sealed v1". Consequence: Guaranteed QoS, and `memoryMb` is a hard OOM ceiling.
+2. **GPU maps to `limits["nvidia.com/gpu"]` only** — extended resources are limits-side in Kubernetes
+   (the request is derived and a differing request is rejected). This is emission only; no device
+   plugin, node pool or live GPU spawn was exercised.
+3. **`0` is treated as unset.** Schema-legal, but a quota reads `cpu: 0` as a zero request, not as
+   "unspecified" — emitting it would be worse than omitting it.
+4. **The producers were not changed.** See the deviation note below.
+
+---
+
+## Deviation from the issue's trace
+
+**The issue's trace is accurate at the base commit** — every `file:line` claim spot-checked and held
+(`models.py:35-52` optional `Resources`; `kernel.py` calling `backend.start(workloadId, runnable,
+effective_env)` and dropping `spec.resources`; `k8s_backend.py` generating `kubectl run` with no
+container resources; `bot_spawn/invocation.py::build_workload_spec` and
+`core/agent/shared/adapters.py::RuntimeHttpClient.spawn` emitting no resources).
+
+Three departures, each with its reason:
+
+1. **`kubectl run --dry-run=client -o json` — the issue's suggested generator — is not viable.**
+   The issue offers it as "a viable fork". On kubectl **v1.34.1** it performs API discovery *before*
+   generating and exits 1 with **zero stdout** when no server is reachable:
+
+   ```
+   $ kubectl run test1 --image=alpine --restart=Never --dry-run=client -o json
+   EXIT=1 · stdout bytes: 0
+   The connection to the server localhost:8080 was refused - did you specify the right host or port?
+   ```
+
+   Adopting it would also add an API round trip to every spawn and make the offline unit tests
+   depend on a live cluster. I build the Pod object in Python instead (`build_pod`) and submit it
+   with `kubectl create -f -` — the same "complete Pod object, merge resources by container name,
+   submit it" the issue's C2 asks for, minus the generator.
+
+2. **Producers were not given resource configuration; the per-profile default in the runtime is the
+   configuration seam.** My task brief asked for producer-side emission; the issue's C3 asks for
+   "explicit per-profile spawned-workload resource values … Profile defaults apply when callers omit
+   resources; explicit workload resources override them." I followed the issue. Consequences:
+   `bot_spawn/invocation.py` and `core/agent/shared/adapters.py` are untouched; sizing is a
+   deployment concern in the chart, not per-request control-plane state; and the override path is
+   live and tested (`test_explicit_spec_resources_override_the_profile_default`) for any producer
+   that later wants per-workload sizing. Independent configurability — the actual requirement — is
+   satisfied per class.
+
+3. **Docker enforcement was not added.** The issue permits either ("if Docker enforcement is added,
+   use native host config and test it. Otherwise document the k8s-only enforcement boundary without
+   implying parity"). Compose has no admission controller to satisfy, and a `HostConfig.Memory`
+   ceiling would newly OOM-kill live meeting bots that run unbounded today. Boundary documented in
+   `backend.py`, both backend docstrings, and the chart README.
+
+---
+
+## Tests
+
+New: `core/runtime/tests/test_workload_resources.py` — 16 tests, all offline.
+
+| Concern | Test |
+|---|---|
+| spec resources reach the backend | `test_spec_resources_reach_the_backend` |
+| profile default applies when omitted; two classes sized apart | `test_profile_default_applies_when_the_caller_omits_resources` |
+| explicit spec wins over the profile default | `test_explicit_spec_resources_override_the_profile_default` |
+| unconfigured ⇒ `None` (optional contract) | `test_unconfigured_profile_preserves_the_optional_contract` |
+| negative values rejected before spawn | `test_negative_resources_are_rejected_before_spawn` (cpu/memory/gpu) |
+| `0` treated as unset | `test_zero_resources_are_not_emitted` |
+| v1 → requests+limits mapping | `test_resource_requirements_maps_v1_to_requests_and_limits` |
+| GPU → limits only | `test_gpu_maps_to_the_limits_side_only` |
+| A3 offline: every field survives | `test_pod_carries_resources_and_every_pre_existing_field` |
+| no resources ⇒ no `resources` key | `test_pod_without_resources_omits_the_field_entirely` |
+| scheduling shapes the Pod without leaking into container env | `test_runtime_scheduling_env_shapes_the_pod_without_becoming_container_config` |
+| the submit is `create -f -` with the manifest on stdin | `test_k8s_start_submits_the_pod_via_create_stdin` |
+| per-class env sizing; unset; partial (memory only) | `test_default_registry_sizes_the_two_profiles_independently`, `…_emits_no_resources_when_unset`, `test_partial_profile_sizing_is_honoured` |
+| malformed sizing fatal at boot | `test_malformed_profile_sizing_is_fatal_at_boot` |
+
+Updated (mechanism changed, semantics preserved): `test_k8s_command_wiring.py` (asserts the submitted
+manifest instead of the `kubectl run` argv — the #675 guarantee that meeting-bot carries **no**
+`command` is still asserted), `test_readopt.py` (adoption labels now read from the manifest),
+`test_lifecycle.py` + `test_start_failed.py` (fake backends take the 4-arg port).
+
+Runtime suite: **159 passed / 1 skipped at base → 178 passed / 0 skipped at head** (the skip
+disappeared because a cluster was reachable, so the real-Pod lifecycle test actually ran).
+
+---
+
+## What was NOT checked
+
+- **The real bot and agent-worker images under these limits.** Every live leg substituted
+  `busybox:1.36`. Whether `vexaai/vexa-bot` runs inside `2048Mi` is untested; the shipped default
+  is a starting point, not a measurement. **Nobody should treat the default as a validated bot
+  memory budget.**
+- **OpenShift restricted SCC on the SPAWNED Pods.** Untested here (k3d has no SCC). The buyer proved
+  control-plane SCC; the spawned Pod is a *different* object and a restricted SCC may still require
+  `runAsNonRoot` / dropped capabilities / a `seccompProfile` that this change does not add. Called
+  out in the test kit as the top thing to watch.
+- **GPU emission end-to-end.** `nvidia.com/gpu` mapping is unit-tested; no GPU node, device plugin or
+  live GPU spawn was exercised.
+- **A LimitRange-defaulted namespace.** The issue's closing rule ("LimitRange-defaulted fields do not
+  prove Vexa emitted resources") is honoured by construction — `vexa-quota` has no LimitRange, so the
+  values observed on the Pods came from Vexa. Behaviour when a LimitRange *also* exists (and whose
+  values win) was not exercised.
+- **Multi-node scheduling pressure.** Single-node k3d; Guaranteed QoS changes scheduling density on
+  a real cluster and that was not measured.
+- **`docs/docs/deployment-kubernetes.mdx`** was deliberately not edited — it is a known hot,
+  non-union-mergeable file and the changelog fragment carries `docs-current`. The page should gain a
+  paragraph on spawned-Pod resources in a sequenced follow-up (the issue's docs surface names it).
+- **Lite/process substrate** beyond the signature change (it accepts and ignores; nothing to enforce).
+
+---
+
+## Exact commands run
+
+```bash
+# worktree, based on origin/main
+git fetch origin
+git worktree add -b 1005-runtime-resources .claude/worktrees/1005-runtime-resources origin/main
+
+# offline suite (base, then head)
+cd core/runtime && uv sync --group dev && uv run pytest -q
+
+# helm
+cd deploy/helm/charts/vexa
+helm template vexa . -n vexa -f values-test.yaml
+helm template vexa . -n vexa -f values-test.yaml \
+  --set runtime.workloadResources.meetingBot.cpu=2 \
+  --set runtime.workloadResources.meetingBot.memoryMb=4096 \
+  --set runtime.workloadResources.agentWorker.cpu=0.25 \
+  --set runtime.workloadResources.agentWorker.memoryMb=512
+helm template vexa . -n vexa -f values-test.yaml \
+  --set runtime.workloadResources.meetingBot.cpu="" --set runtime.workloadResources.meetingBot.memoryMb="" \
+  --set runtime.workloadResources.agentWorker.cpu="" --set runtime.workloadResources.agentWorker.memoryMb=""
+helm template vexa . -n vexa -f values-test.yaml --set runtime.backend=docker
+sh deploy/helm/tests/test_template.sh
+
+# live cluster
+brew install k3d && k3d cluster create vexa1005 --agents 0 --wait
+kubectl apply -f <quota-ns.yaml>      # namespace vexa-quota + ResourceQuota (yaml inlined in the kit)
+cd core/runtime
+PYTHONPATH=src uv run python <quota-validate.py> red-unsized     # A1/A2 negative control
+PYTHONPATH=src uv run python <quota-validate.py> green           # A1/A2/A5
+PYTHONPATH=src uv run python <quota-validate.py> red-no-memory   # A4
+PYTHONPATH=src uv run python <a3-live.py>                        # A3
+kubectl run vexa-neg-control --image=busybox:1.36 --restart=Never -n vexa-quota \
+  --overrides='{"spec":{"containers":[{"name":"vexa-neg-control","resources":{…}}]}}'   # A3 control
+
+# gates
+COMPOSE_PROJECT=vexa-gate-1005 ONNXRUNTIME_NODE_INSTALL=skip node scripts/gates.mjs all
+```
+
+The three validation scripts (`quota-ns.yaml`, `quota-validate.py`, `a3-live.py`) are reproduced in
+[`MARVIN-TEST-KIT-1005.md`](MARVIN-TEST-KIT-1005.md) so a non-author can re-run every live row.
+
+---
+
+## My reading (labelled as mine, downstream of the data)
+
+The value the issue asks for is real and observed: both shipped workload classes are admitted into a
+namespace that rejects undeclared containers, sized apart, with every pre-existing Pod field intact,
+and the red control reproduces on demand. The two things I would not let ride into a customer test
+unstated are (a) the shipped `meetingBot.memoryMb: 2048` default is a *guess*, not a measurement, and
+a bad guess becomes a mid-meeting OOM kill rather than a visible failure; and (b) the spawned-Pod SCC
+question on OpenShift is genuinely open — the buyer's earlier control-plane SCC proof does not carry
+to a `kubectl create`d bare Pod. Both are in the test kit as the first things to look at.

--- a/core/runtime/src/runtime_kernel/backend.py
+++ b/core/runtime/src/runtime_kernel/backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Optional, Protocol
 
+from .models import Resources
 from .profiles import Runnable
 
 
@@ -19,7 +20,22 @@ class WorkloadHandle:
 class Backend(Protocol):
     name: str
 
-    def start(self, workload_id: str, runnable: Runnable, env: dict[str, str]) -> WorkloadHandle: ...
+    def start(
+        self,
+        workload_id: str,
+        runnable: Runnable,
+        env: dict[str, str],
+        resources: Optional[Resources] = None,
+    ) -> WorkloadHandle:
+        """Start the workload. ``resources`` is the effective sizing the kernel resolved (the spec's
+        own, else the profile's deployment default); ``None`` means unsized — today's behaviour.
+
+        ENFORCEMENT IS PER-SUBSTRATE and deliberately NOT claimed at parity: only the k8s backend
+        acts on it (a namespace ResourceQuota can require every container to declare requests and
+        limits). docker/process accept it and do not enforce — there is no quota admission on those
+        substrates, and a silently-introduced memory limit would OOM-kill live workloads that run
+        unbounded today."""
+        ...
     def exit_code(self, h: WorkloadHandle) -> Optional[int]:
         """None while running; the exit code once exited."""
         ...

--- a/core/runtime/src/runtime_kernel/config.v1.json
+++ b/core/runtime/src/runtime_kernel/config.v1.json
@@ -108,6 +108,42 @@
    ]
   },
   {
+   "key": "RUNTIME_BOT_CPU",
+   "class": "defaulted",
+   "default": "(unset — the meeting-bot class declares no cpu, preserving runtime.v1's optional resources)",
+   "description": "k8s backend: CPU cores every SPAWNED meeting-bot Pod declares. runtime.v1 carries one value per dimension, so it sets BOTH the container's request and its limit (Guaranteed QoS) — the declaration a namespace ResourceQuota admits on (#1005). Unset/empty ⇒ no cpu declared (the pre-#1005 unbounded spawn); a non-numeric value is fatal at boot",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
+   "key": "RUNTIME_BOT_MEMORY_MB",
+   "class": "defaulted",
+   "default": "(unset — the meeting-bot class declares no memory, preserving runtime.v1's optional resources)",
+   "description": "k8s backend: memory (MiB) every SPAWNED meeting-bot Pod declares, as BOTH request and limit. A HARD ceiling — a bot exceeding it is OOM-killed mid-meeting — so size it for real meetings, not for the smallest node. Unset/empty ⇒ no memory declared; a non-numeric value is fatal at boot (#1005)",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
+   "key": "RUNTIME_AGENT_WORKER_CPU",
+   "class": "defaulted",
+   "default": "(unset — the agent-worker class declares no cpu, preserving runtime.v1's optional resources)",
+   "description": "k8s backend: CPU cores every SPAWNED agent-worker Pod declares, as BOTH request and limit. Sized INDEPENDENTLY of the meeting bot — a code harness is not a browser — so an operator can right-size each class alone (#1005). Unset/empty ⇒ no cpu declared; a non-numeric value is fatal at boot",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
+   "key": "RUNTIME_AGENT_WORKER_MEMORY_MB",
+   "class": "defaulted",
+   "default": "(unset — the agent-worker class declares no memory, preserving runtime.v1's optional resources)",
+   "description": "k8s backend: memory (MiB) every SPAWNED agent-worker Pod declares, as BOTH request and limit. Unset/empty ⇒ no memory declared; a non-numeric value is fatal at boot (#1005)",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
    "key": "BROWSER_IMAGE",
    "class": "capability",
    "capability": "bot_spawn",

--- a/core/runtime/src/runtime_kernel/docker_backend.py
+++ b/core/runtime/src/runtime_kernel/docker_backend.py
@@ -19,6 +19,7 @@ from urllib.parse import quote
 import requests_unixsocket
 
 from .backend import WorkloadHandle
+from .models import Resources
 from .mounts import workspace_binds
 from .profiles import Runnable
 
@@ -174,7 +175,19 @@ class DockerBackend:
             )
         return target
 
-    def start(self, workload_id: str, runnable: Runnable, env: dict[str, str]) -> WorkloadHandle:
+    def start(
+        self,
+        workload_id: str,
+        runnable: Runnable,
+        env: dict[str, str],
+        resources: Optional[Resources] = None,
+    ) -> WorkloadHandle:
+        """``resources`` is accepted and NOT enforced here — the enforcement boundary is k8s-only,
+        and this backend claims no parity with it. Compose/Lite have no admission controller
+        demanding a declared request+limit, and translating the intent into ``HostConfig.Memory``
+        would introduce an OOM-kill ceiling on live meeting bots that run unbounded today: a
+        behaviour change on the most-used substrate, bought for no admission benefit. A deployment
+        that wants Docker enforcement adds it as its own change, with its own live evidence."""
         if not runnable.image:
             raise ValueError("docker backend requires an image")
         name = self._cname(workload_id)

--- a/core/runtime/src/runtime_kernel/k8s_backend.py
+++ b/core/runtime/src/runtime_kernel/k8s_backend.py
@@ -1,7 +1,12 @@
 """K8sBackend — runs a workload as a real Kubernetes Pod (the cluster substrate). Uses the kubectl CLI
 via subprocess (no client lib), matching the DockerBackend approach. Implements the same Backend port,
 so the kernel's runtime.v1 lifecycle is identical to process/docker. A workload is a bare Pod with
-restart=Never; the kernel owns restart policy, so the Pod must not resurrect itself."""
+restart=Never; the kernel owns restart policy, so the Pod must not resurrect itself.
+
+The spawn submits a COMPLETE Pod manifest (``build_pod`` → ``kubectl create -f -``). Owning the whole
+object is what lets a container carry CPU/memory requests and limits — the declaration a namespace
+ResourceQuota admits on — WITHOUT a partial ``kubectl run --overrides`` containers entry, whose JSON
+merge replaces the generated container wholesale and strips its image, env and command."""
 from __future__ import annotations
 
 import json
@@ -10,11 +15,17 @@ import subprocess
 from typing import Optional
 
 from .backend import WorkloadHandle
+from .models import Resources
 from .mounts import k8s_volume_mounts
 from .profiles import Runnable
 
 MANAGED_LABEL = "runtime.managed"
 WORKLOAD_ID_LABEL = "runtime.workload_id"
+
+# The extended-resource name a GPU request carries. Kubernetes requires extended resources on the
+# LIMITS side; the request is set equal to the limit automatically, and a requests-side entry that
+# differs is rejected — so runtime.v1's single `gpu` count maps to limits only.
+GPU_RESOURCE = "nvidia.com/gpu"
 
 # The runtime's OWN scheduling constraints, serialized as JSON by the chart from
 # global.tolerations / global.nodeSelector (see deployment-runtime.yaml). A spawned workload is a bare
@@ -54,8 +65,8 @@ def _runtime_scheduling_env() -> dict[str, str]:
     return {k: os.environ[k] for k in (TOLERATIONS_ENV, NODE_SELECTOR_ENV) if os.environ.get(k)}
 
 
-def _kubectl(*args: str, check: bool = True) -> subprocess.CompletedProcess:
-    r = subprocess.run(["kubectl", *args], capture_output=True, text=True)
+def _kubectl(*args: str, check: bool = True, stdin: Optional[str] = None) -> subprocess.CompletedProcess:
+    r = subprocess.run(["kubectl", *args], capture_output=True, text=True, input=stdin)
     if check and r.returncode != 0:
         raise RuntimeError(f"kubectl {' '.join(args)} failed: {r.stderr.strip()}")
     return r
@@ -73,7 +84,7 @@ def _stop_grace_sec() -> int:
 
 
 def pod_overrides(env: dict[str, str], *, container_name: str) -> Optional[dict]:
-    """The ``kubectl run --overrides`` spec for a spawned Pod, built from the SAME env. It carries two
+    """The env-derived OVERLAY ``build_pod`` merges onto a spawned Pod's spec. It carries two
     independent seams:
 
       * the workspace store mount set (WP-A1.1): the store PVC (``VEXA_WORKSPACE_MOUNT_SOURCE`` = the
@@ -82,10 +93,10 @@ def pod_overrides(env: dict[str, str], *, container_name: str) -> Optional[dict]
         so the bare ``kubectl run`` Pod — which inherits none of the runtime Deployment's scheduling —
         lands where the runtime itself is allowed to run instead of stranding Pending on a tainted pool.
 
-    The spec is built whenever EITHER seam is present; returns None only when neither is (no override
-    needed). Building it for scheduling alone is load-bearing: a plain meeting bot has no workspace PVC,
-    so a volumes-only early return would silently drop its tolerations and re-create the bug. Pure/
-    env-driven → unit-tested offline (no kubectl)."""
+    The overlay is built whenever EITHER seam is present; returns None only when neither is (nothing
+    to merge). Building it for scheduling alone is load-bearing: a plain meeting bot has no workspace
+    PVC, so a volumes-only early return would silently drop its tolerations and re-create the bug.
+    Pure/env-driven → unit-tested offline (no kubectl)."""
     pvc = env.get("VEXA_WORKSPACE_MOUNT_SOURCE")
     root = env.get("VEXA_WORKSPACE_MOUNT_TARGET")
     volumes, volume_mounts = k8s_volume_mounts(env, pvc_name=pvc or "", store_target=root or "")
@@ -93,11 +104,10 @@ def pod_overrides(env: dict[str, str], *, container_name: str) -> Optional[dict]
     node_selector = _scheduling_json(env, NODE_SELECTOR_ENV, dict)
     if not volumes and not tolerations and not node_selector:
         return None
-    # ``kubectl run --overrides`` merges the containers LIST by replacement (json-merge, not
-    # strategic), so a containers entry here wipes the generated container — image, env, command —
-    # and the API server rejects the Pod (`spec.containers[0].image: Required value`), killing the
-    # spawn instantly. Emit ``containers`` ONLY when volumeMounts force it (the workspace-store
-    # seam); pod-level fields (tolerations/nodeSelector) merge fine without touching the list.
+    # ``containers`` is emitted ONLY when volumeMounts force it (the workspace-store seam);
+    # pod-level fields (tolerations/nodeSelector) shape the Pod without touching the list. Keeping
+    # the overlay minimal is what lets ``build_pod`` merge it BY CONTAINER NAME onto the generated
+    # container instead of replacing it.
     spec: dict = {}
     if volume_mounts:
         spec["containers"] = [{"name": container_name, "volumeMounts": volume_mounts}]
@@ -108,6 +118,110 @@ def pod_overrides(env: dict[str, str], *, container_name: str) -> Optional[dict]
     if node_selector:
         spec["nodeSelector"] = node_selector
     return {"spec": spec}
+
+
+def resource_requirements(resources: Optional[Resources]) -> Optional[dict]:
+    """Map runtime.v1 ``Resources`` to a container's ``resources`` block.
+
+    v1 carries ONE value per dimension, so cpu/memory set BOTH the request and the limit — the
+    minimum non-breaking contract for a namespace whose ResourceQuota requires each container to
+    declare both, and Guaranteed QoS for the workload. The sealed contract does not model separate
+    request/limit semantics and this mapping does not invent them.
+
+    ``0`` is schema-legal but meaningless as a Kubernetes quantity (a zero request is not "unset" to
+    a quota), so it is treated as unset. All-unset ⇒ None: no ``resources`` key is emitted at all
+    and the spawn is byte-identical to the pre-sizing behaviour."""
+    if resources is None:
+        return None
+    requests: dict[str, str] = {}
+    limits: dict[str, str] = {}
+    if resources.cpu:
+        # millicores: the canonical k8s CPU quantity, and exact for the fractional values v1 allows
+        # (0.5 → "500m") where a bare float would serialize as an unstable "0.5".
+        quantity = f"{round(resources.cpu * 1000)}m"
+        requests["cpu"] = limits["cpu"] = quantity
+    if resources.memoryMb:
+        quantity = f"{resources.memoryMb}Mi"
+        requests["memory"] = limits["memory"] = quantity
+    if resources.gpu:
+        limits[GPU_RESOURCE] = str(resources.gpu)          # extended resource: limits side only
+    block: dict[str, dict[str, str]] = {}
+    if requests:
+        block["requests"] = requests
+    if limits:
+        block["limits"] = limits
+    return block or None
+
+
+def build_pod(
+    *,
+    name: str,
+    workload_id: str,
+    runnable: Runnable,
+    env: dict[str, str],
+    namespace: Optional[str],
+    resources: Optional[Resources],
+    overlay_env: Optional[dict[str, str]] = None,
+) -> dict:
+    """The COMPLETE Pod object a spawn submits — every field the workload needs, in one manifest.
+
+    Why a whole object rather than ``kubectl run --overrides``: that flag merges the container LIST
+    by REPLACEMENT (JSON merge patch), so any partial ``containers`` entry erases the generated
+    container's image/env/command and the API server rejects the Pod outright. Owning the object
+    makes the merge OURS and deterministic — the overlay's per-container fields are merged BY
+    CONTAINER NAME onto the generated container, so resources, workspace volumeMounts, image,
+    command, env, labels and scheduling all coexist instead of clobbering each other.
+
+    ``env`` is the container's env VERBATIM; ``overlay_env`` (default: ``env``) is the wider env the
+    pod-shaping overlay is derived from. They differ because the runtime's own scheduling knobs live
+    in its process env, not in the workload's — and must shape the Pod without being injected into
+    the workload's container as config.
+
+    Pure and env-driven ⇒ the whole manifest is asserted offline, with no cluster and no kubectl.
+    (``kubectl run --dry-run=client`` is NOT a viable generator here: v1.34 performs API discovery
+    before generating and exits 1 with no output when no server is reachable.)"""
+    container: dict = {
+        "name": name,
+        "image": runnable.image,
+        "env": [{"name": k, "value": v} for k, v in env.items()],
+    }
+    if runnable.command:
+        # Explicit argv REPLACES the image ENTRYPOINT. Absent ⇒ the image's own entrypoint boots,
+        # which is what the shipped meeting-bot image requires (#675).
+        container["command"] = list(runnable.command)
+    requirements = resource_requirements(resources)
+    if requirements:
+        container["resources"] = requirements
+
+    metadata: dict = {
+        "name": name,
+        # Adoption labels (the orphaned-live-bot fix): a recreated runtime re-discovers its
+        # still-running Pods by this label pair and re-registers them (see the kernel's adopt()).
+        "labels": {MANAGED_LABEL: "true", WORKLOAD_ID_LABEL: workload_id},
+    }
+    if namespace:
+        metadata["namespace"] = namespace
+
+    # restart=Never: the kernel owns restart policy, so the Pod must not resurrect itself.
+    pod: dict = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": metadata,
+        "spec": {"containers": [container], "restartPolicy": "Never"},
+    }
+
+    overlay_source = env if overlay_env is None else overlay_env
+    overlay = (pod_overrides(overlay_source, container_name=name) or {}).get("spec", {})
+    for key in ("volumes", "tolerations", "nodeSelector"):
+        if overlay.get(key):
+            pod["spec"][key] = overlay[key]
+    for overlay_container in overlay.get("containers", []):
+        if overlay_container.get("name") != name:
+            continue                                       # merge BY NAME — never by position
+        for key, value in overlay_container.items():
+            if key != "name":
+                container[key] = value
+    return pod
 
 
 class K8sBackend:
@@ -123,30 +237,34 @@ class K8sBackend:
     def _ns_args(self) -> list[str]:
         return ["-n", self._ns] if self._ns else []
 
-    def start(self, workload_id: str, runnable: Runnable, env: dict[str, str]) -> WorkloadHandle:
+    def start(
+        self,
+        workload_id: str,
+        runnable: Runnable,
+        env: dict[str, str],
+        resources: Optional[Resources] = None,
+    ) -> WorkloadHandle:
+        """Submit the workload's complete Pod manifest. ``resources`` (the kernel's effective sizing:
+        the spec's own, else the profile's chart-configured default) becomes the container's
+        requests+limits, which is what a namespace ResourceQuota admits on."""
         if not runnable.image:
             raise ValueError("k8s backend requires an image")
         name = self._pname(workload_id)
-        args = [
-            "run", name, f"--image={runnable.image}", "--restart=Never",
-            # Adoption labels (the orphaned-live-bot fix): a recreated runtime re-discovers its
-            # still-running Pods by this label pair and re-registers them (see the kernel's adopt()).
-            f"--labels={MANAGED_LABEL}=true,{WORKLOAD_ID_LABEL}={workload_id}",
-            *self._ns_args(),
-        ]
-        for k, v in env.items():
-            args += [f"--env={k}={v}"]
-        # The --overrides spec carries the workspace mount set (WP-A1.1: the store PVC bound per-mount,
-        # container name = Pod name for a `run` Pod) AND the runtime's own scheduling constraints. The
-        # latter live in the runtime's PROCESS env (the chart sets them on the runtime Deployment), not
-        # in the per-workload spec.env, so overlay them here; the workload's own --env (above) is left
-        # untouched — scheduling shapes the Pod, it is not container config.
-        overrides = pod_overrides({**env, **_runtime_scheduling_env()}, container_name=name)
-        if overrides:
-            args += ["--overrides", json.dumps(overrides)]
-        if runnable.command:
-            args += ["--command", "--", *runnable.command]
-        _kubectl(*args)
+        # The workspace mount set and the runtime's OWN scheduling constraints both shape the Pod.
+        # The latter live in the runtime's PROCESS env (the chart sets them on the runtime
+        # Deployment), not in the per-workload spec.env — which is built per-workload by different
+        # producers (meeting-api for a bot, agent-api for a worker) — so they ride overlay_env: they
+        # shape the Pod without becoming container config the workload never asked for.
+        pod = build_pod(
+            name=name,
+            workload_id=workload_id,
+            runnable=runnable,
+            env=env,
+            namespace=self._ns,
+            resources=resources,
+            overlay_env={**env, **_runtime_scheduling_env()},
+        )
+        _kubectl("create", "-f", "-", *self._ns_args(), stdin=json.dumps(pod))
         return WorkloadHandle(id=workload_id, impl=name)
 
     def find(self, workload_id: str) -> Optional[WorkloadHandle]:

--- a/core/runtime/src/runtime_kernel/kernel.py
+++ b/core/runtime/src/runtime_kernel/kernel.py
@@ -19,7 +19,7 @@ from .backend import Backend, WorkloadHandle
 from .clock import Clock, SystemClock
 from .models import RuntimeEvent, RuntimeState, StopReason, WorkloadSpec, WorkloadStatus
 from .process_backend import ProcessBackend
-from .profiles import ProfileRegistry, Runnable, default_registry
+from .profiles import Profile, ProfileRegistry, Runnable, default_registry
 from .store import (
     InMemoryStore,
     OwnerResolver,
@@ -196,7 +196,14 @@ class Runtime:
             # layered on top so an explicit spec value always wins. Without this merge the base_env
             # never reaches the spawned pod and chart-set tuning is dead config (issue #771).
             effective_env = {**profile.base_env, **spec.env}
-            self._handles[spec.workloadId] = self.backend.start(spec.workloadId, runnable, effective_env)
+            # Resource intent must cross the Backend port or it is dead contract: the schema accepts
+            # `resources`, and a quota-controlled namespace rejects every container that declares
+            # none. The spec's own sizing wins; otherwise the profile's deployment default (the
+            # chart's per-class sizing) applies; neither ⇒ None, today's unsized spawn.
+            effective_resources = spec.resources or profile.resources
+            self._handles[spec.workloadId] = self.backend.start(
+                spec.workloadId, runnable, effective_env, effective_resources,
+            )
         except Exception as exc:
             # Record the honest terminal state (persist + emit) FIRST — GET /workloads and the
             # callback stream must still see stopped/start_failed — THEN raise so the API answers a
@@ -289,12 +296,16 @@ def _coerce_registry(profiles) -> ProfileRegistry:
         return default_registry()
     if isinstance(profiles, ProfileRegistry):
         return profiles
-    runnables: dict[str, Runnable] = {}
+    resolved: dict[str, object] = {}
     for name, value in profiles.items():
-        if isinstance(value, Runnable):
-            runnables[name] = value
+        # A full Profile carries the deployment defaults (timeouts, base env, per-class sizing); a
+        # bare Runnable or command list is the shorthand for "how to run it, nothing configured".
+        if isinstance(value, (Profile, Runnable)):
+            resolved[name] = value
         elif isinstance(value, list):
-            runnables[name] = Runnable(command=value)
+            resolved[name] = Runnable(command=value)
         else:
-            raise TypeError(f"profile {name!r}: expected Runnable or command list, got {type(value)}")
-    return ProfileRegistry(runnables)
+            raise TypeError(
+                f"profile {name!r}: expected Profile, Runnable or command list, got {type(value)}"
+            )
+    return ProfileRegistry(resolved)

--- a/core/runtime/src/runtime_kernel/models.py
+++ b/core/runtime/src/runtime_kernel/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class RuntimeState(str, Enum):
@@ -33,10 +33,14 @@ class BackendKind(str, Enum):
 
 
 class Resources(BaseModel):
+    """The workload's resource intent. ONE value per dimension: on Kubernetes ``cpu``/``memoryMb``
+    set BOTH the container's request and its limit (Guaranteed QoS) — sealed v1 models no separate
+    request/limit semantics. The floors mirror the JSON Schema's ``minimum: 0``, so a negative
+    value is rejected at parse time and never reaches a backend."""
     model_config = {"extra": "forbid"}
-    cpu: Optional[float] = None
-    memoryMb: Optional[int] = None
-    gpu: Optional[int] = None
+    cpu: Optional[float] = Field(default=None, ge=0)
+    memoryMb: Optional[int] = Field(default=None, ge=0)
+    gpu: Optional[int] = Field(default=None, ge=0)
 
 
 class WorkloadSpec(BaseModel):

--- a/core/runtime/src/runtime_kernel/mounts.py
+++ b/core/runtime/src/runtime_kernel/mounts.py
@@ -133,7 +133,7 @@ def k8s_volume_mounts(env: Mapping[str, str], *, pvc_name: str, store_target: st
     mount on its own PVC is a later WP. Pure + env-driven (no kubectl) so the k8s mount plumbing is
     unit-tested offline.
 
-    Returns ``(volumes, volume_mounts)`` ready to splat into a Pod ``--overrides`` spec."""
+    Returns ``(volumes, volume_mounts)`` ready to merge into a Pod spec and its container."""
     if not pvc_name or not store_target:
         return [], []
     vol_name = "workspace-store"

--- a/core/runtime/src/runtime_kernel/process_backend.py
+++ b/core/runtime/src/runtime_kernel/process_backend.py
@@ -26,6 +26,7 @@ from typing import Optional
 
 from .backend import WorkloadHandle
 from .isolation import apply_process_isolation, child_env_for, plan_process_isolation, preexec_for
+from .models import Resources
 from .mounts import mount_set
 from .profiles import Runnable
 
@@ -78,7 +79,16 @@ class ProcessBackend:
         # exit codes are unobservable without a live handle anyway.
         self._capture: dict[str, dict] = {}
 
-    def start(self, workload_id: str, runnable: Runnable, env: dict[str, str]) -> WorkloadHandle:
+    def start(
+        self,
+        workload_id: str,
+        runnable: Runnable,
+        env: dict[str, str],
+        resources: Optional[Resources] = None,
+    ) -> WorkloadHandle:
+        """``resources`` is accepted and NOT enforced: a child process has no admission gate to
+        satisfy, and cgroup limits are the host's concern on this substrate. The enforcement
+        boundary is k8s-only and no parity is claimed."""
         if not runnable.command:
             raise ValueError("process backend requires a command")
         # Workspace mount set (WP-A1.1): the lite/process backend shares the HOST filesystem — there is

--- a/core/runtime/src/runtime_kernel/profiles.py
+++ b/core/runtime/src/runtime_kernel/profiles.py
@@ -20,6 +20,8 @@ import shlex
 from dataclasses import dataclass, field, replace
 from typing import Optional
 
+from .models import Resources
+
 
 @dataclass(frozen=True)
 class Runnable:
@@ -37,6 +39,10 @@ class Profile:
     max_lifetime_sec: Optional[int] = None
     # Base env the profile always sets; the spec's env is layered on top at create() time.
     base_env: dict[str, str] = field(default_factory=dict)
+    # Deployment-wide sizing for THIS workload class, independent of every other class (the chart
+    # renders it per profile). Applied at create() when the caller emits no resources of its own;
+    # an explicit spec.resources always wins. None ⇒ unsized (the optional contract preserved).
+    resources: Optional[Resources] = None
 
 
 class ProfileRegistry:
@@ -87,6 +93,37 @@ def worker_image_for(agent_image: str) -> str:
     return f"{repo}{sep}{tag}"
 
 
+# Per-profile spawned-workload sizing, read from the runtime's OWN env (the chart renders it from
+# runtime.workloadResources.<class>). Distinct keys per class: a meeting bot is a Chromium browser,
+# an agent worker is a code harness — they are sized independently, never off one shared knob.
+_RESOURCE_ENV = {
+    "meeting-bot": ("RUNTIME_BOT_CPU", "RUNTIME_BOT_MEMORY_MB"),
+    "agent": ("RUNTIME_AGENT_WORKER_CPU", "RUNTIME_AGENT_WORKER_MEMORY_MB"),
+}
+
+
+def _numeric_env(key: str, cast):
+    """One resource knob from env. Unset/empty ⇒ None (unsized). A non-numeric value is FATAL:
+    a resource constraint silently dropped is exactly the defect this seam closes — an unsized Pod
+    that a quota-controlled namespace rejects, or admits without the bound the operator asked for."""
+    raw = os.environ.get(key, "").strip()
+    if not raw:
+        return None
+    try:
+        return cast(raw)
+    except ValueError as exc:
+        raise ValueError(f"{key} must be numeric, got {raw!r}") from exc
+
+
+def _profile_resources(profile: str) -> Optional[Resources]:
+    cpu_key, mem_key = _RESOURCE_ENV[profile]
+    cpu = _numeric_env(cpu_key, float)
+    memory_mb = _numeric_env(mem_key, int)
+    if cpu is None and memory_mb is None:
+        return None
+    return Resources(cpu=cpu, memoryMb=memory_mb)
+
+
 def default_registry() -> ProfileRegistry:
     """The real, deployment-shaped registry. Images come from env (no `:latest` fallback — a missing
     image surfaces as an empty string the backend rejects, matching 0.11's fail-visible stance)."""
@@ -128,6 +165,7 @@ def default_registry() -> ProfileRegistry:
                 ),
                 idle_timeout_sec=0,  # 0 ⇒ managed externally; enforcement skips it
                 base_env=bot_tuning_env,
+                resources=_profile_resources("meeting-bot"),
             ),
             # Claude Code agent — the in-container worker harness (worker): consumes the
             # dispatch from env, runs the governed turn over the mounted workspace, XADDs UnitEvents to
@@ -142,6 +180,7 @@ def default_registry() -> ProfileRegistry:
                 idle_timeout_sec=300,
                 max_lifetime_sec=3600,
                 base_env={},
+                resources=_profile_resources("agent"),
             ),
         }
     )

--- a/core/runtime/tests/test_k8s_command_wiring.py
+++ b/core/runtime/tests/test_k8s_command_wiring.py
@@ -1,18 +1,21 @@
 """A1 (#675) — OFFLINE proof that the k8s backend execs an in-image path for the meeting-bot profile.
 
-`kubectl run --command -- <argv>` REPLACES the image entrypoint (sets Pod.spec.containers[].command).
-So whatever the meeting-bot profile carries as its command becomes argv[0] of the Pod. The shipped bot
-image has ENTRYPOINT ["/app/entrypoint.sh"] and no /app/vexa-bot/ directory — so a profile command of
+An explicit `command` on a Pod's container REPLACES the image entrypoint. So whatever the meeting-bot
+profile carries as its command becomes argv[0] of the Pod. The shipped bot image has
+ENTRYPOINT ["/app/entrypoint.sh"] and no /app/vexa-bot/ directory — so a profile command of
 /app/vexa-bot/entrypoint.sh makes every k8s spawn StartError (exit 128, "no such file or directory").
 
-The fix drops the meeting-bot profile command: the k8s backend then omits `--command` entirely and the
-Pod boots the image ENTRYPOINT — the real launcher. These tests capture the exact kubectl argv without
-a cluster (the live-cluster lifecycle lives in test_k8s_backend.py) by stubbing the module's _kubectl.
+The fix drops the meeting-bot profile command: the backend then omits `command` from the container
+entirely and the Pod boots the image ENTRYPOINT — the real launcher. These tests capture the exact
+submitted Pod manifest without a cluster (the live-cluster lifecycle lives in test_k8s_backend.py) by
+stubbing the module's _kubectl.
 
-RED on main: pre-fix the meeting-bot runnable carries ["/app/vexa-bot/entrypoint.sh"], so the argv here
-would contain `--command -- /app/vexa-bot/entrypoint.sh` and the assertions below fail.
+RED on main: pre-fix the meeting-bot runnable carries ["/app/vexa-bot/entrypoint.sh"], so the
+container below would carry that `command` and the assertions fail.
 """
 from __future__ import annotations
+
+import json
 
 import runtime_kernel.k8s_backend as k8s_backend
 from runtime_kernel import default_registry
@@ -20,12 +23,13 @@ from runtime_kernel.k8s_backend import K8sBackend
 from runtime_kernel.profiles import Runnable
 
 
-def _capture_run_argv(monkeypatch) -> list:
-    """Stub the module-level _kubectl so start() runs offline; return the captured argv list."""
-    calls: list[list[str]] = []
+def _capture_submitted_pods(monkeypatch) -> list:
+    """Stub the module-level _kubectl so start() runs offline; return the captured Pod manifests."""
+    pods: list[dict] = []
 
-    def fake_kubectl(*args, check=True):
-        calls.append(list(args))
+    def fake_kubectl(*args, check=True, stdin=None):
+        if stdin:
+            pods.append(json.loads(stdin))
 
         class _R:
             returncode = 0
@@ -35,13 +39,13 @@ def _capture_run_argv(monkeypatch) -> list:
         return _R()
 
     monkeypatch.setattr(k8s_backend, "_kubectl", fake_kubectl)
-    return calls
+    return pods
 
 
-def test_meeting_bot_k8s_run_omits_command_uses_image_entrypoint(monkeypatch):
-    """The meeting-bot profile has no command ⇒ `kubectl run` carries NO `--command`, so the Pod execs
-    the shipped bot image's own ENTRYPOINT (the real, in-image launcher)."""
-    calls = _capture_run_argv(monkeypatch)
+def test_meeting_bot_k8s_pod_omits_command_uses_image_entrypoint(monkeypatch):
+    """The meeting-bot profile has no command ⇒ the submitted Pod's container carries NO `command`,
+    so it execs the shipped bot image's own ENTRYPOINT (the real, in-image launcher)."""
+    pods = _capture_submitted_pods(monkeypatch)
     monkeypatch.setenv("BROWSER_IMAGE", "vexaai/vexa-bot:test")
     runnable = default_registry().resolve("meeting-bot")
     assert runnable.command is None  # the source of the fix (#675)
@@ -49,22 +53,19 @@ def test_meeting_bot_k8s_run_omits_command_uses_image_entrypoint(monkeypatch):
 
     K8sBackend(namespace="ns").start("mtg-1", runnable, env={"VEXA_BOT_CONFIG": "{}"})
 
-    run_argv = calls[0]
-    assert run_argv[0] == "run"
+    container = pods[0]["spec"]["containers"][0]
     # No entrypoint replacement: the image ENTRYPOINT (/app/entrypoint.sh) boots the container.
-    assert "--command" not in run_argv
-    # And the phantom path never appears anywhere in the argv.
-    assert not any("/app/vexa-bot/entrypoint.sh" in a for a in run_argv)
+    assert "command" not in container
+    # And the phantom path never appears anywhere in the manifest.
+    assert "/app/vexa-bot/entrypoint.sh" not in json.dumps(pods[0])
 
 
-def test_k8s_run_still_replaces_entrypoint_for_a_profile_that_has_a_command(monkeypatch):
-    """The append/replace machinery is intact: a profile that DOES carry a command (e.g. agent) still
-    gets `--command -- <argv>` — the fix is scoped to dropping the bogus meeting-bot command, not to
+def test_k8s_pod_still_replaces_entrypoint_for_a_profile_that_has_a_command(monkeypatch):
+    """The replace machinery is intact: a profile that DOES carry a command (e.g. agent) still gets
+    it as the container's argv — the fix is scoped to dropping the bogus meeting-bot command, not to
     removing entrypoint replacement wholesale."""
-    calls = _capture_run_argv(monkeypatch)
+    pods = _capture_submitted_pods(monkeypatch)
     K8sBackend(namespace="ns").start(
         "agent-1", Runnable(image="img", command=["python", "-m", "worker"]), env={}
     )
-    run_argv = calls[0]
-    i = run_argv.index("--command")
-    assert run_argv[i:] == ["--command", "--", "python", "-m", "worker"]
+    assert pods[0]["spec"]["containers"][0]["command"] == ["python", "-m", "worker"]

--- a/core/runtime/tests/test_lifecycle.py
+++ b/core/runtime/tests/test_lifecycle.py
@@ -75,7 +75,7 @@ class _FakeBackend:
         self.envs: dict[str, dict[str, str]] = {}
         self.exit_codes: dict[str, int | None] = {}
 
-    def start(self, workload_id, runnable, env):
+    def start(self, workload_id, runnable, env, resources=None):
         self.starts.append(workload_id)
         self.envs[workload_id] = dict(env)
         self.exit_codes[workload_id] = None

--- a/core/runtime/tests/test_mounts.py
+++ b/core/runtime/tests/test_mounts.py
@@ -196,10 +196,9 @@ def test_k8s_pod_overrides_tolerations_only_no_pvc_builds_a_valid_spec():
     assert spec["tolerations"] == _TOL
     assert spec["nodeSelector"] == _SEL
     assert "volumes" not in spec                           # no PVC ⇒ no volumes, but scheduling stands
-    # LOAD-BEARING (witnessed live, v0.12.8 staging): `kubectl run --overrides` merges the containers
-    # LIST by replacement, so ANY containers entry here wipes the generated container's image/env/command
-    # and the API server rejects the Pod (`spec.containers[0].image: Required value`) — the spawn dies in
-    # <1s. Scheduling-only overrides must NOT touch the containers list.
+    # The overlay stays MINIMAL: scheduling shapes the Pod, so it never reaches into the containers
+    # list. `build_pod` merges what IS here by container NAME onto the generated container, and an
+    # entry carrying nothing but a name would be pure noise in the submitted manifest.
     assert "containers" not in spec
 
 

--- a/core/runtime/tests/test_readopt.py
+++ b/core/runtime/tests/test_readopt.py
@@ -368,10 +368,12 @@ def test_adopt_noop_on_backends_without_discovery():
 def test_k8s_start_stamps_adoption_labels(monkeypatch):
     from runtime_kernel import k8s_backend
 
-    calls: list[tuple[str, ...]] = []
+    import json as _json
 
-    def fake_kubectl(*args: str, check: bool = True):
-        calls.append(args)
+    calls: list[dict] = []
+
+    def fake_kubectl(*args: str, check: bool = True, stdin=None):
+        calls.append({"args": args, "stdin": stdin})
         class R:  # noqa: N801 — minimal stand-in
             returncode = 0
             stdout = ""
@@ -383,8 +385,11 @@ def test_k8s_start_stamps_adoption_labels(monkeypatch):
 
     be = k8s_backend.K8sBackend()
     be.start("mtg-2-d93eee39", Runnable(image="img"), {})
-    (run_args,) = calls
-    assert "--labels=runtime.managed=true,runtime.workload_id=mtg-2-d93eee39" in run_args
+    (call,) = calls
+    pod = _json.loads(call["stdin"])            # the labels ride the submitted manifest
+    assert pod["metadata"]["labels"] == {
+        "runtime.managed": "true", "runtime.workload_id": "mtg-2-d93eee39",
+    }
 
 
 def test_k8s_discovers_pods_by_label(monkeypatch):

--- a/core/runtime/tests/test_start_failed.py
+++ b/core/runtime/tests/test_start_failed.py
@@ -26,7 +26,7 @@ class _DeadAtStartBackend:
 
     name = "docker"
 
-    def start(self, workload_id, runnable, env):
+    def start(self, workload_id, runnable, env, resources=None):
         raise RuntimeError(_MISSING_IMAGE_MSG)
 
     def exit_code(self, h):  # pragma: no cover — never reached (start raised)
@@ -89,7 +89,7 @@ def test_post_workloads_healthy_spawn_still_201():
     the fix does not turn healthy spawns into 502s."""
 
     class _OkBackend(_DeadAtStartBackend):
-        def start(self, workload_id, runnable, env):
+        def start(self, workload_id, runnable, env, resources=None):
             return WorkloadHandle(id=workload_id, impl=workload_id)
 
         def exit_code(self, h):

--- a/core/runtime/tests/test_workload_resources.py
+++ b/core/runtime/tests/test_workload_resources.py
@@ -1,0 +1,290 @@
+"""#1005 — resource intent reaches the substrate, so a quota-controlled namespace admits both
+shipped workload classes (meeting-bot and agent worker).
+
+Three seams, all provable OFFLINE (no cluster):
+
+  * C1 — an accepted ``WorkloadSpec.resources`` crosses the Backend port (the kernel used to drop it),
+    and a profile's chart-configured default applies when the caller omits it;
+  * C2 — the k8s backend submits a COMPLETE Pod object carrying ``resources.requests`` and
+    ``resources.limits`` alongside every field the spawn already generated (image, command, env,
+    labels, volumes/volumeMounts, tolerations, nodeSelector);
+  * C3 — the two profiles are sized INDEPENDENTLY from the runtime's own env, and an unset profile
+    preserves the optional contract (no resources emitted — today's behaviour).
+
+runtime.v1 carries ONE cpu and ONE memoryMb per workload; the Kubernetes mapping sets BOTH the
+request and the limit from that single value (Guaranteed QoS). The sealed v1 contract does not model
+separate request/limit semantics and this change does not invent them.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import runtime_kernel.k8s_backend as k8s_backend
+from runtime_kernel import Runtime
+from runtime_kernel.k8s_backend import K8sBackend, build_pod, resource_requirements
+from runtime_kernel.models import Resources, WorkloadSpec
+from runtime_kernel.profiles import Profile, Runnable, default_registry
+
+
+# ── C1 · resource intent crosses the Backend port ────────────────────────────────────────────
+class _RecordingBackend:
+    """A fake backend that records exactly what the kernel handed it."""
+
+    name = "process"
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def start(self, workload_id, runnable, env, resources=None):
+        self.calls.append({"workload_id": workload_id, "env": env, "resources": resources})
+        return k8s_backend.WorkloadHandle(id=workload_id, impl=workload_id)
+
+    def exit_code(self, h):
+        return None
+
+    def terminate(self, h):
+        pass
+
+    def kill(self, h):
+        pass
+
+    def cleanup(self, h):
+        pass
+
+
+def _runtime(backend, profiles) -> Runtime:
+    return Runtime(backend=backend, profiles=profiles, grace_sec=0.1)
+
+
+def test_spec_resources_reach_the_backend():
+    """The exact resources the caller accepted are the resources the backend is asked to enforce."""
+    be = _RecordingBackend()
+    rt = _runtime(be, {"meeting-bot": Runnable(image="bot")})
+    rt.create(WorkloadSpec(
+        workloadId="mtg-1", profile="meeting-bot", env={},
+        resources=Resources(cpu=1.5, memoryMb=3072),
+    ))
+    assert be.calls[0]["resources"] == Resources(cpu=1.5, memoryMb=3072)
+
+
+def test_profile_default_applies_when_the_caller_omits_resources():
+    """C3: per-profile deployment sizing applies to callers that emit no resources — the meeting
+    and agent producers stay resource-agnostic; the operator sizes each class in the chart."""
+    be = _RecordingBackend()
+    rt = _runtime(be, {
+        "meeting-bot": Profile(name="meeting-bot", runnable=Runnable(image="bot"),
+                               resources=Resources(cpu=1.0, memoryMb=2048)),
+        "agent": Profile(name="agent", runnable=Runnable(image="worker"),
+                         resources=Resources(cpu=0.5, memoryMb=1024)),
+    })
+    rt.create(WorkloadSpec(workloadId="mtg-2", profile="meeting-bot", env={}))
+    rt.create(WorkloadSpec(workloadId="agent-2", profile="agent", env={}))
+    assert be.calls[0]["resources"] == Resources(cpu=1.0, memoryMb=2048)
+    assert be.calls[1]["resources"] == Resources(cpu=0.5, memoryMb=1024)  # INDEPENDENTLY sized
+
+
+def test_explicit_spec_resources_override_the_profile_default():
+    be = _RecordingBackend()
+    rt = _runtime(be, {"meeting-bot": Profile(
+        name="meeting-bot", runnable=Runnable(image="bot"),
+        resources=Resources(cpu=1.0, memoryMb=2048),
+    )})
+    rt.create(WorkloadSpec(
+        workloadId="mtg-3", profile="meeting-bot", env={},
+        resources=Resources(cpu=4.0, memoryMb=8192),
+    ))
+    assert be.calls[0]["resources"] == Resources(cpu=4.0, memoryMb=8192)
+
+
+def test_unconfigured_profile_preserves_the_optional_contract():
+    """No profile default and no spec resources ⇒ None reaches the backend: the pre-#1005 shape,
+    so an operator who sizes nothing keeps today's (unbounded) behaviour."""
+    be = _RecordingBackend()
+    rt = _runtime(be, {"meeting-bot": Runnable(image="bot")})
+    rt.create(WorkloadSpec(workloadId="mtg-4", profile="meeting-bot", env={}))
+    assert be.calls[0]["resources"] is None
+
+
+# ── C1 · malformed / negative values fail before the spawn ───────────────────────────────────
+@pytest.mark.parametrize("bad", [{"cpu": -1}, {"memoryMb": -512}, {"gpu": -1}])
+def test_negative_resources_are_rejected_before_spawn(bad):
+    """The sealed schema floors every resource at 0; the models reject a negative at parse time,
+    so a malformed spec never reaches a backend."""
+    with pytest.raises(Exception):
+        WorkloadSpec(workloadId="w", profile="meeting-bot", env={}, resources=Resources(**bad))
+
+
+def test_zero_resources_are_not_emitted():
+    """0 is schema-legal but meaningless as a k8s quantity — treat it as unset rather than
+    submitting `cpu: 0` (which a quota reads as a zero request)."""
+    assert resource_requirements(Resources(cpu=0, memoryMb=0)) is None
+
+
+# ── C2 · the k8s Pod carries requests+limits AND every generated field ───────────────────────
+def test_resource_requirements_maps_v1_to_requests_and_limits():
+    req = resource_requirements(Resources(cpu=1.5, memoryMb=2048))
+    assert req == {
+        "requests": {"cpu": "1500m", "memory": "2048Mi"},
+        "limits": {"cpu": "1500m", "memory": "2048Mi"},
+    }
+
+
+def test_gpu_maps_to_the_limits_side_only():
+    """`nvidia.com/gpu` is an extended resource: Kubernetes requires the limit, and the request is
+    set equal to it automatically. Emitting it only under limits is the documented positive mapping."""
+    req = resource_requirements(Resources(gpu=1))
+    assert req["limits"]["nvidia.com/gpu"] == "1"
+    assert "nvidia.com/gpu" not in req.get("requests", {})
+
+
+def test_pod_carries_resources_and_every_pre_existing_field():
+    """A3: resource injection must not erase image, command, env, labels, scheduling or mounts —
+    the exact failure mode a partial `containers` entry in `kubectl run --overrides` produces."""
+    env = {
+        "VEXA_BOT_CONFIG": "{}",
+        "VEXA_WORKSPACE_MOUNT_SOURCE": "vexa-workspaces",
+        "VEXA_WORKSPACE_MOUNT_TARGET": "/workspaces",
+        "VEXA_MOUNTS": json.dumps([
+            {"slug": "u1", "path": "/workspaces/u1", "role": "private", "write": True,
+             "primary": True},
+        ]),
+        k8s_backend.TOLERATIONS_ENV: json.dumps([{"key": "vexa", "operator": "Exists"}]),
+        k8s_backend.NODE_SELECTOR_ENV: json.dumps({"pool": "bots"}),
+    }
+    pod = build_pod(
+        name="vexa-mtg-9",
+        workload_id="mtg-9",
+        runnable=Runnable(image="vexaai/vexa-bot:test", command=["python", "-m", "worker"]),
+        env=env,
+        namespace="vexa",
+        resources=Resources(cpu=1, memoryMb=2048),
+    )
+    assert pod["apiVersion"] == "v1" and pod["kind"] == "Pod"
+    assert pod["metadata"]["name"] == "vexa-mtg-9"
+    assert pod["metadata"]["namespace"] == "vexa"
+    assert pod["metadata"]["labels"] == {
+        k8s_backend.MANAGED_LABEL: "true", k8s_backend.WORKLOAD_ID_LABEL: "mtg-9",
+    }
+    spec = pod["spec"]
+    assert spec["restartPolicy"] == "Never"          # the kernel owns restart policy
+    assert spec["tolerations"] == [{"key": "vexa", "operator": "Exists"}]
+    assert spec["nodeSelector"] == {"pool": "bots"}
+    assert spec["volumes"], "workspace store volume survived"
+    c = spec["containers"][0]
+    assert c["name"] == "vexa-mtg-9"
+    assert c["image"] == "vexaai/vexa-bot:test"       # NOT erased
+    assert c["command"] == ["python", "-m", "worker"]  # NOT erased
+    assert {"name": "VEXA_BOT_CONFIG", "value": "{}"} in c["env"]  # NOT erased
+    assert c["volumeMounts"], "workspace volumeMounts survived"
+    assert c["resources"] == {
+        "requests": {"cpu": "1000m", "memory": "2048Mi"},
+        "limits": {"cpu": "1000m", "memory": "2048Mi"},
+    }
+
+
+def test_pod_without_resources_omits_the_field_entirely():
+    pod = build_pod(name="vexa-w", workload_id="w", runnable=Runnable(image="img"),
+                    env={}, namespace=None, resources=None)
+    assert "resources" not in pod["spec"]["containers"][0]
+    assert "namespace" not in pod["metadata"]
+    assert "command" not in pod["spec"]["containers"][0]   # image ENTRYPOINT is authoritative
+
+
+def test_runtime_scheduling_env_shapes_the_pod_without_becoming_container_config(monkeypatch):
+    """The runtime's OWN scheduling knobs must reach the Pod spec and STOP there — a workload's
+    container env is the producer's contract, not a dumping ground for the backend's config."""
+    calls: list[dict] = []
+
+    def fake_kubectl(*args, check=True, stdin=None):
+        calls.append({"args": list(args), "stdin": stdin})
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(k8s_backend, "_kubectl", fake_kubectl)
+    monkeypatch.setenv(k8s_backend.TOLERATIONS_ENV, json.dumps([{"key": "vexa", "operator": "Exists"}]))
+    monkeypatch.setenv(k8s_backend.NODE_SELECTOR_ENV, json.dumps({"pool": "bots"}))
+    K8sBackend(namespace="ns").start("mtg-6", Runnable(image="img"), env={"A": "b"})
+    pod = json.loads(calls[0]["stdin"])
+    assert pod["spec"]["tolerations"] == [{"key": "vexa", "operator": "Exists"}]
+    assert pod["spec"]["nodeSelector"] == {"pool": "bots"}
+    assert pod["spec"]["containers"][0]["env"] == [{"name": "A", "value": "b"}]
+
+
+def test_k8s_start_submits_the_pod_via_create_stdin(monkeypatch):
+    """The spawn submits a complete manifest on stdin (`kubectl create -f -`) — not a partial
+    `--overrides` merge, which json-merge-REPLACES the generated containers list."""
+    calls: list[dict] = []
+
+    def fake_kubectl(*args, check=True, stdin=None):
+        calls.append({"args": list(args), "stdin": stdin})
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(k8s_backend, "_kubectl", fake_kubectl)
+    K8sBackend(namespace="ns").start(
+        "mtg-5", Runnable(image="img"), env={"A": "b"}, resources=Resources(cpu=2, memoryMb=4096),
+    )
+    assert calls[0]["args"] == ["create", "-f", "-", "-n", "ns"]
+    pod = json.loads(calls[0]["stdin"])
+    assert pod["spec"]["containers"][0]["resources"]["requests"] == {"cpu": "2000m", "memory": "4096Mi"}
+    assert pod["spec"]["containers"][0]["resources"]["limits"] == {"cpu": "2000m", "memory": "4096Mi"}
+
+
+# ── C3 · the two profiles are sized independently from the runtime's env ─────────────────────
+def test_default_registry_sizes_the_two_profiles_independently(monkeypatch):
+    monkeypatch.setenv("BROWSER_IMAGE", "bot:test")
+    monkeypatch.setenv("AGENT_IMAGE", "vexaai/v012-agent-api:test")
+    monkeypatch.setenv("RUNTIME_BOT_CPU", "1")
+    monkeypatch.setenv("RUNTIME_BOT_MEMORY_MB", "2048")
+    monkeypatch.setenv("RUNTIME_AGENT_WORKER_CPU", "0.5")
+    monkeypatch.setenv("RUNTIME_AGENT_WORKER_MEMORY_MB", "1024")
+    reg = default_registry()
+    assert reg.get("meeting-bot").resources == Resources(cpu=1.0, memoryMb=2048)
+    assert reg.get("agent").resources == Resources(cpu=0.5, memoryMb=1024)
+
+
+def test_default_registry_emits_no_resources_when_unset(monkeypatch):
+    """The chart's unset case: no env ⇒ no profile default ⇒ the optional contract is preserved."""
+    monkeypatch.setenv("BROWSER_IMAGE", "bot:test")
+    monkeypatch.setenv("AGENT_IMAGE", "vexaai/v012-agent-api:test")
+    for key in ("RUNTIME_BOT_CPU", "RUNTIME_BOT_MEMORY_MB",
+                "RUNTIME_AGENT_WORKER_CPU", "RUNTIME_AGENT_WORKER_MEMORY_MB"):
+        monkeypatch.delenv(key, raising=False)
+    reg = default_registry()
+    assert reg.get("meeting-bot").resources is None
+    assert reg.get("agent").resources is None
+
+
+def test_partial_profile_sizing_is_honoured(monkeypatch):
+    """Memory only (the common quota shape: memory is the scarce resource) is a legal sizing."""
+    monkeypatch.setenv("BROWSER_IMAGE", "bot:test")
+    monkeypatch.setenv("AGENT_IMAGE", "a:test")
+    monkeypatch.delenv("RUNTIME_BOT_CPU", raising=False)
+    monkeypatch.setenv("RUNTIME_BOT_MEMORY_MB", "2048")
+    reg = default_registry()
+    assert reg.get("meeting-bot").resources == Resources(memoryMb=2048)
+    assert resource_requirements(reg.get("meeting-bot").resources) == {
+        "requests": {"memory": "2048Mi"}, "limits": {"memory": "2048Mi"},
+    }
+
+
+def test_malformed_profile_sizing_is_fatal_at_boot(monkeypatch):
+    """A silently dropped resource constraint is exactly the bug this fixes — a non-numeric knob
+    must fail loud at registry construction, never fail open into an unsized spawn."""
+    monkeypatch.setenv("BROWSER_IMAGE", "bot:test")
+    monkeypatch.setenv("AGENT_IMAGE", "a:test")
+    monkeypatch.setenv("RUNTIME_BOT_CPU", "one-and-a-half")
+    with pytest.raises(ValueError, match="RUNTIME_BOT_CPU"):
+        default_registry()

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -24,6 +24,12 @@ template:
 test:
 	bash tests/test_helm_lint.sh
 	bash tests/test_template.sh
+	bash tests/test_mirror_only.sh
+
+## mirror-test — just the mirror-only render invariant (#1006): nothing the chart can cause a
+## cluster to pull may fall back to a public registry — hooks and runtime-spawned Pods included.
+mirror-test:
+	bash tests/test_mirror_only.sh
 
 ## build — build the 5 control-plane images (:dev) via the compose build
 build:
@@ -53,4 +59,4 @@ down:
 	-sudo KUBECONFIG=$(KUBECONFIG) helm uninstall $(RELEASE) -n $(NAMESPACE)
 	-sudo KUBECONFIG=$(KUBECONFIG) kubectl delete namespace $(NAMESPACE) --wait=false
 
-.PHONY: lint template test build k3s-import install status smoke down
+.PHONY: lint template test mirror-test build k3s-import install status smoke down

--- a/deploy/helm/charts/vexa/README.md
+++ b/deploy/helm/charts/vexa/README.md
@@ -61,9 +61,71 @@ Provide your own `labelSelector` in a constraint to opt out of the automatic inj
 default (the shipped value) renders nothing — single-node / k3s installs are unaffected. Use
 `ScheduleAnyway`, not `DoNotSchedule`, unless you can guarantee enough nodes, or pods stay Pending.
 
+## Image references
+
+Every image in this chart resolves by **one rule**, in this order — nothing else participates:
+
+| # | Value | Result |
+|---|---|---|
+| 1 | `<x>.image` / `<x>Image` — an explicit **full reference** | used **verbatim** |
+| 2 | `<x>.digest` / `<x>ImageDigest` — `sha256:<64 lowercase hex>` | `<repository>@<digest>` |
+| 3 | `<x>.repository` + `<x>.tag` | `<repository>:<tag>` |
+
+**An explicit full reference wins. `global.imageTag` never rewrites it** — it only supplies the tag
+on leg 3, for the images that have no explicit identity. That is the deterministic precedence a
+private-mirror install depends on; before v0.12.19 two of the runtime's spawned references ignored
+it (see [#1006](https://github.com/Vexa-ai/vexa/issues/1006)).
+
+The chart **fails closed** rather than guessing. `helm template` errors, and nothing renders, when:
+
+- an explicit full reference **and** a digest are both set on the same image (two identities, no
+  defensible winner);
+- a digest is not exactly `sha256:` + 64 **lowercase** hex — truncated, uppercase or non-`sha256`
+  is refused, never quietly downgraded to a mutable tag;
+- a full reference contains whitespace;
+- the repository is empty on legs 2–3, or the tag is empty on leg 3.
+
+### The runtime-spawned images
+
+Three images are **not containers in any rendered manifest**. The chart hands them to the runtime
+as env (`BROWSER_IMAGE`, `AGENT_IMAGE`, `AGENT_WORKER_IMAGE`) and the runtime creates those Pods
+later. `kubectl get deploy -o yaml` will never name them, and a mirror that holds only what the
+manifests show will fail at the first meeting, not at install:
+
+| Env | Explicit reference | Digest | Composed default |
+|---|---|---|---|
+| `BROWSER_IMAGE` (the bot, ~3.6 GB) | `runtime.browserImage` | `runtime.browserImageDigest` | `runtime.browserImageRepository` + `runtime.browserImageTag` |
+| `AGENT_IMAGE` | `runtime.agentImage` | `runtime.agentImageDigest` | `runtime.agentImageRepository` + `runtime.agentImageTag`, both defaulting to `agentApi.image.*` |
+| `AGENT_WORKER_IMAGE` | `runtime.agentWorkerImage` | `runtime.agentWorkerImageDigest` | `runtime.agentWorkerImageRepository` + `runtime.agentWorkerImageTag` |
+
+The post-install **`minio-init` hook Job** is the fourth easily-missed pull: `minio.mc.reference` /
+`minio.mc.digest` / `minio.mc.image.repository` + `minio.mc.image.tag`. It is deliberately **not** wired to
+`global.imageTag` — it is a third-party image, not part of the Vexa release set.
+
+```yaml
+# A mirror-only install pinning exact bytes.
+global:
+  imageTag: v0.12.19
+  imagePullSecrets: [{ name: internal-registry-pull }]
+runtime:
+  image: { repository: registry.example.internal/vexa/v012-runtime }
+  browserImage: "registry.example.internal/vexa/vexa-bot@sha256:<64 hex>"
+  agentImage:   "registry.example.internal/vexa/v012-agent-api:v0.12.19"
+  agentWorkerImageRepository: registry.example.internal/vexa/v012-agent-worker
+  agentWorkerImageDigest: "sha256:<64 hex>"
+minio:
+  image: { repository: registry.example.internal/mirror/minio, tag: latest }
+  mc:    { digest: "sha256:<64 hex>", image: { repository: registry.example.internal/mirror/mc } }
+```
+
 ## Validate (no cluster)
 
 ```bash
 helm lint .
 helm template vexa . -n vexa -f values-test.yaml
+make -C ../.. test          # deploy/helm: lint + render assertions + the mirror-only invariant
 ```
+
+`tests/test_mirror_only.sh` renders `tests/values-mirror-only.yaml` — every image pointed at one
+unresolvable internal registry — and asserts that no container image, hook image or runtime-spawn
+reference falls outside it. Run it after any change that touches an image reference.

--- a/deploy/helm/charts/vexa/README.md
+++ b/deploy/helm/charts/vexa/README.md
@@ -61,6 +61,38 @@ Provide your own `labelSelector` in a constraint to opt out of the automatic inj
 default (the shipped value) renders nothing — single-node / k3s installs are unaffected. Use
 `ScheduleAnyway`, not `DoNotSchedule`, unless you can guarantee enough nodes, or pods stay Pending.
 
+## Sizing the spawned bot and agent-worker Pods
+
+The `runtime` creates the meeting-bot and agent-worker Pods dynamically. Namespace policy commonly
+**requires every container to declare CPU and memory requests *and* limits** — a `ResourceQuota`
+naming `requests.cpu`/`limits.memory`, or a restricted OpenShift project. A Pod that declares none
+is rejected at admission, and the meeting or dispatch never starts.
+
+`runtime.workloadResources` sizes the two classes **independently** (this is *not*
+`runtime.resources`, which sizes the runtime Deployment itself):
+
+```yaml
+runtime:
+  workloadResources:
+    meetingBot:   { cpu: 1,   memoryMb: 2048 }   # Chromium + capture pipeline
+    agentWorker:  { cpu: 0.5, memoryMb: 1024 }   # code harness
+```
+
+| Value | Renders as | Notes |
+|---|---|---|
+| `cpu` | container `requests.cpu` **and** `limits.cpu`, in millicores (`0.5` → `500m`) | one value per dimension is runtime.v1's shape; there is no separate request/limit knob |
+| `memoryMb` | container `requests.memory` **and** `limits.memory`, in MiB (`2048` → `2048Mi`) | a **hard ceiling** — a workload exceeding it is OOM-killed |
+| either, set to `""` | nothing rendered for that class | preserves the optional contract: an unsized Pod, exactly as before |
+
+Request equals limit, so both classes get **Guaranteed** QoS. The shipped defaults are conservative
+and sized to fit a small dev cluster — raise `meetingBot.memoryMb` for real meetings rather than
+discovering the ceiling as a mid-meeting OOM kill. A caller may also override per workload by
+sending `resources` in its `runtime.v1` `WorkloadSpec`; the chart values are the default that
+applies when it does not.
+
+Enforcement is **Kubernetes-only**. The docker and process backends accept the same resource intent
+and do not act on it — they have no admission controller to satisfy, and no parity is claimed.
+
 ## Validate (no cluster)
 
 ```bash

--- a/deploy/helm/charts/vexa/README.md
+++ b/deploy/helm/charts/vexa/README.md
@@ -150,6 +150,61 @@ minio:
   mc:    { digest: "sha256:<64 hex>", image: { repository: registry.example.internal/mirror/mc } }
 ```
 
+## Testing #1005 + #1006 on your own cluster (validation branch)
+
+`deploy/helm/values-oenb-validation.yaml` is a ready-to-edit values file for validating both fixes
+on a quota-controlled, mirror-only cluster. Replace every `REPLACE-ME.registry.internal` with your
+registry and install with `-f`.
+
+**Point it at your own registry.** The #1005 fix is Python under `core/runtime/`, so it exists only
+inside a **rebuilt runtime image** — no published tag contains it. Build it from this branch, push it
+to your registry, and set `runtime.image.repository` / `.tag` to that copy:
+
+```bash
+docker build -t <your-registry>/vexa/v012-runtime:<your-tag> core/runtime
+docker push     <your-registry>/vexa/v012-runtime:<your-tag>
+```
+
+#1006 is chart-only, so it needs no rebuild — it works against images you already mirror.
+
+> ### ⚠️ `global.imageTag` silently overrides the runtime tag
+>
+> The runtime Deployment renders
+> `image: "{{ .Values.runtime.image.repository }}:{{ .Values.global.imageTag | default .Values.runtime.image.tag }}"`.
+>
+> **If `global.imageTag` is set, it wins over `runtime.image.tag` — with no error and no warning.**
+> Setting it to a release tag (the natural move on a mirror-only install, since it pins every other
+> image at once) gives you the **old runtime without the #1005 fix** while your values file appears
+> to pin the fixed one. Every Pod goes Running, your spawned bots still declare no resources, the
+> quota still rejects them, and you conclude the fix is broken — having never run it.
+>
+> Either leave `global.imageTag` **unset**, or set it to **the same tag you built the runtime with**.
+> Then confirm what you actually got, before trusting any spawn:
+>
+> ```bash
+> kubectl -n <ns> get deploy <release>-vexa-runtime \
+>   -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+> ```
+>
+> (Tracked upstream as [#1001](https://github.com/Vexa-ai/vexa/issues/1001) — a digest helper for
+> long-running Deployments — which is still open.)
+
+Confirm the sizing reached the runtime too — four entries, all non-empty:
+
+```bash
+kubectl -n <ns> get deploy <release>-vexa-runtime -o json \
+  | jq '.spec.template.spec.containers[0].env[]
+        | select(.name|test("^RUNTIME_(BOT|AGENT_WORKER)_(CPU|MEMORY_MB)$"))'
+```
+
+Empty strings mean the chart values did not land, and the spawned Pods will declare nothing —
+exactly the pre-#1005 behaviour.
+
+**The `minio-init` hook Job is the trap that bites before either fix does.** It is a post-install
+hook, so on a quota-controlled namespace it is rejected, retried forever, and `helm install --wait`
+**hangs** while every Deployment sits Running — a failure that looks nothing like a quota problem.
+Size it via `minio.mc.resources` (defaulted in this branch, absent from `main`).
+
 ## Validate (no cluster)
 
 ```bash

--- a/deploy/helm/charts/vexa/templates/_helpers.tpl
+++ b/deploy/helm/charts/vexa/templates/_helpers.tpl
@@ -96,34 +96,113 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
-{{/* The on-demand bot image the runtime spawns (BROWSER_IMAGE). The bot is published, never built by
-this chart. runtime.browserImage is the explicit value; global.imageTag (set) pins the standard repo. */}}
-{{- define "vexa.botImage" -}}
-{{- if .Values.runtime.browserImage -}}
-{{- .Values.runtime.browserImage -}}
-{{- else if .Values.global.imageTag -}}
-{{- printf "vexaai/vexa-bot:%s" .Values.global.imageTag -}}
+{{/*
+vexa.imageRef — the ONE image-reference rule (#1006).
+
+Call:
+  include "vexa.imageRef" (dict "field"      "<values path, quoted back in errors>"
+                                "reference"  <explicit full reference, or "">
+                                "digest"     <"sha256:<64 hex>", or "">
+                                "repository" <repository>
+                                "tag"        <tag>)
+
+Precedence — three legs, checked in this order, and nothing else participates:
+
+  1. `reference` non-empty  → emitted VERBATIM. An operator who names a full reference gets
+     exactly that reference; a global tag NEVER rewrites it. This is the leg mirror-only
+     clusters depend on: before #1006 two of the three spawned-workload references silently
+     ignored it and rendered a Docker Hub reference, so a cluster with no public egress could
+     not run the product no matter what it configured.
+  2. `digest` non-empty     → "<repository>@<digest>".
+  3. otherwise              → "<repository>:<tag>" — the legacy path, unchanged. The CALLER
+     decides whether global.imageTag supplies that tag.
+
+Fails CLOSED — `helm template` errors and nothing renders — on an ambiguous or malformed
+identity, instead of silently ranking one input over another:
+
+  - `reference` AND `digest` both set: two identities declared, no defensible winner;
+  - a `digest` that is not exactly sha256:<64 lowercase hex> (truncated, uppercase, non-sha256);
+  - a `reference` containing whitespace;
+  - an empty repository on leg 2 or 3, or an empty tag on leg 3.
+
+Silence here would mean an operator who typoed a digest deploys a mutable tag believing they
+pinned bytes. See docs/docs/deployment-kubernetes.mdx § Running from a private registry mirror.
+*/}}
+{{- define "vexa.imageRef" -}}
+{{- $field := .field -}}
+{{- $ref := .reference | default "" | toString | trim -}}
+{{- $digest := .digest | default "" | toString | trim -}}
+{{- $repo := .repository | default "" | toString | trim -}}
+{{- $tag := .tag | default "" | toString | trim -}}
+{{- if and $ref $digest -}}
+{{- fail (printf "INVALID image identity for %s: an explicit full reference (%q) and a digest (%q) are both set. Declare exactly one — the chart refuses to guess which bytes you meant." $field $ref $digest) -}}
+{{- end -}}
+{{- if $ref -}}
+{{- if regexMatch "[[:space:]]" $ref -}}
+{{- fail (printf "INVALID image reference for %s: %q contains whitespace." $field $ref) -}}
+{{- end -}}
+{{- $ref -}}
+{{- else if $digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $digest) -}}
+{{- fail (printf "INVALID image digest for %s: %q. Expected exactly sha256:<64 lowercase hex> — a truncated, uppercase or non-sha256 digest is refused rather than silently falling back to a mutable tag." $field $digest) -}}
+{{- end -}}
+{{- if not $repo -}}
+{{- fail (printf "INVALID image identity for %s: a digest is set but the repository is empty." $field) -}}
+{{- end -}}
+{{- printf "%s@%s" $repo $digest -}}
 {{- else -}}
-vexaai/vexa-bot:v012
+{{- if not $repo -}}
+{{- fail (printf "INVALID image identity for %s: no reference, no digest, and an empty repository." $field) -}}
+{{- end -}}
+{{- if not $tag -}}
+{{- fail (printf "INVALID image identity for %s: no reference, no digest, and an empty tag for repository %q." $field $repo) -}}
+{{- end -}}
+{{- printf "%s:%s" $repo $tag -}}
 {{- end -}}
 {{- end -}}
 
-{{/* The agent-api image ref (AGENT_IMAGE the runtime spawns workers from). global.imageTag wins. */}}
-{{- define "vexa.agentImage" -}}
-{{- if .Values.global.imageTag -}}
-{{- printf "%s:%s" .Values.agentApi.image.repository .Values.global.imageTag -}}
-{{- else -}}
-{{- .Values.runtime.agentImage | default (printf "%s:%s" .Values.agentApi.image.repository .Values.agentApi.image.tag) -}}
+{{/* The on-demand bot image the runtime spawns (BROWSER_IMAGE). The bot is published, never built
+by this chart. Identity per vexa.imageRef; global.imageTag only ever supplies the tag leg. */}}
+{{- define "vexa.botImage" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "runtime.browserImage"
+      "reference" .Values.runtime.browserImage
+      "digest" .Values.runtime.browserImageDigest
+      "repository" .Values.runtime.browserImageRepository
+      "tag" (.Values.global.imageTag | default .Values.runtime.browserImageTag)) -}}
 {{- end -}}
+
+{{/* The agent-api image ref (AGENT_IMAGE the runtime spawns workers from). Its composed leg falls
+back to the agent-api Deployment's own repository/tag, so mirroring `agentApi.image` keeps carrying
+the spawned copy with it. */}}
+{{- define "vexa.agentImage" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "runtime.agentImage"
+      "reference" .Values.runtime.agentImage
+      "digest" .Values.runtime.agentImageDigest
+      "repository" (.Values.runtime.agentImageRepository | default .Values.agentApi.image.repository)
+      "tag" (.Values.global.imageTag | default .Values.runtime.agentImageTag | default .Values.agentApi.image.tag)) -}}
 {{- end -}}
 
 {{/* The agent-worker image ref (AGENT_WORKER_IMAGE; the dedicated worker build — core/agent/worker/Dockerfile — NOT the agent-api image). */}}
 {{- define "vexa.agentWorkerImage" -}}
-{{- if .Values.global.imageTag -}}
-{{- printf "vexaai/v012-agent-worker:%s" .Values.global.imageTag -}}
-{{- else -}}
-{{- .Values.runtime.agentWorkerImage | default "vexaai/v012-agent-worker:v012" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "runtime.agentWorkerImage"
+      "reference" .Values.runtime.agentWorkerImage
+      "digest" .Values.runtime.agentWorkerImageDigest
+      "repository" .Values.runtime.agentWorkerImageRepository
+      "tag" (.Values.global.imageTag | default .Values.runtime.agentWorkerImageTag)) -}}
 {{- end -}}
+
+{{/* The MinIO client image the post-install bucket-init Job runs. Same one rule, deliberately NOT
+wired to global.imageTag: it is a third-party image, not part of the Vexa release set. */}}
+{{- define "vexa.minioClientImage" -}}
+{{- include "vexa.imageRef" (dict
+      "field" "minio.mc"
+      "reference" .Values.minio.mc.reference
+      "digest" .Values.minio.mc.digest
+      "repository" .Values.minio.mc.image.repository
+      "tag" .Values.minio.mc.image.tag) -}}
 {{- end -}}
 
 {{- define "vexa.postgresCredentialsSecretName" -}}

--- a/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
@@ -119,6 +119,20 @@ spec:
               value: {{ .Values.runtime.tolerations | default .Values.global.tolerations | toJson | quote }}
             - name: RUNTIME_K8S_NODE_SELECTOR
               value: {{ .Values.runtime.nodeSelector | default .Values.global.nodeSelector | toJson | quote }}
+            # Per-class sizing for SPAWNED Pods (#1005). A namespace whose policy requires every
+            # container to declare CPU/memory requests AND limits rejects an unsized Pod at admission,
+            # so both shipped workload classes carry their own — sized independently, since a Chromium
+            # meeting bot and a code-harness agent worker are nothing alike. One value per dimension
+            # (runtime.v1's shape) sets BOTH the request and the limit. Empty ⇒ that class emits no
+            # resources, preserving the optional contract and the pre-#1005 unbounded spawn.
+            - name: RUNTIME_BOT_CPU
+              value: {{ .Values.runtime.workloadResources.meetingBot.cpu | default "" | quote }}
+            - name: RUNTIME_BOT_MEMORY_MB
+              value: {{ .Values.runtime.workloadResources.meetingBot.memoryMb | default "" | quote }}
+            - name: RUNTIME_AGENT_WORKER_CPU
+              value: {{ .Values.runtime.workloadResources.agentWorker.cpu | default "" | quote }}
+            - name: RUNTIME_AGENT_WORKER_MEMORY_MB
+              value: {{ .Values.runtime.workloadResources.agentWorker.memoryMb | default "" | quote }}
             {{- end }}
             {{- with .Values.runtime.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/charts/vexa/templates/job-minio-init.yaml
+++ b/deploy/helm/charts/vexa/templates/job-minio-init.yaml
@@ -28,7 +28,10 @@ spec:
       {{- end }}
       containers:
         - name: minio-init
-          image: minio/mc:latest
+          {{- /* #1006 — a configurable identity (minio.mc.reference / .digest / .image.*), not a
+          hardcoded mutable public tag. This hook is what made mirror-only installs fail LAST: the
+          whole control plane came up, then the bucket-init Job reached for Docker Hub. */}}
+          image: {{ include "vexa.minioClientImage" . | quote }}
           imagePullPolicy: IfNotPresent
           # v0.10.5 Pack A.3 — replace `sleep 5` with poll-until-ready (#249).
           # On a fresh PVC, MinIO can take 30+ seconds to attach + initialize.

--- a/deploy/helm/charts/vexa/templates/job-minio-init.yaml
+++ b/deploy/helm/charts/vexa/templates/job-minio-init.yaml
@@ -33,6 +33,13 @@ spec:
           whole control plane came up, then the bucket-init Job reached for Docker Hub. */}}
           image: {{ include "vexa.minioClientImage" . | quote }}
           imagePullPolicy: IfNotPresent
+          {{- /* This hook Job is a Pod like any other: a namespace whose ResourceQuota names
+          requests.cpu/limits.memory REJECTS it when it declares nothing, and because it is a
+          post-install hook the Job retries forever and `helm install --wait` never returns while
+          every long-running Deployment sits Running. #1005 sized the runtime-SPAWNED Pods; this
+          Job is neither a Deployment nor runtime-spawned, so it was missed by both. */}}
+          resources:
+            {{- toYaml .Values.minio.mc.resources | nindent 12 }}
           # v0.10.5 Pack A.3 — replace `sleep 5` with poll-until-ready (#249).
           # On a fresh PVC, MinIO can take 30+ seconds to attach + initialize.
           # Hardcoded 5s sleep races MinIO startup → `mc mb` runs against an

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -224,11 +224,42 @@ runtime:
   service:
     type: ClusterIP
     port: 8090
-  # Images the runtime spawns. browserImage = the bot (published ~3.6GB, a reference, never built by
-  # this chart). agentImage/agentWorkerImage default to the v012 agent repos at global.imageTag.
-  browserImage: ""            # empty → follows global.imageTag (fallback vexaai/vexa-bot:v012)
-  agentImage: "vexaai/v012-agent-api:v012"
-  agentWorkerImage: "vexaai/v012-agent-worker:v012"
+  # ---------------------------------------------------------------------------------------------
+  # Images the runtime SPAWNS on demand. These never appear as a `image:` field in any manifest —
+  # they are handed to the runtime as BROWSER_IMAGE / AGENT_IMAGE / AGENT_WORKER_IMAGE env, and the
+  # runtime creates the Pod. A private mirror must therefore hold them even though `kubectl get
+  # deploy -o yaml` never names them. browserImage = the bot (published ~3.6 GB, a reference, never
+  # built by this chart).
+  #
+  # Each image takes ONE identity, resolved by the same rule everywhere in this chart (see
+  # charts/vexa/README.md § Image references):
+  #   1. <x>Image            — an explicit full reference. WINS; global.imageTag never rewrites it.
+  #   2. <x>ImageDigest      — sha256:<64 hex> → "<repository>@<digest>".
+  #   3. <x>ImageRepository + <x>ImageTag — the legacy composed path; global.imageTag, when set,
+  #                            supplies the tag.
+  # Setting BOTH an explicit reference and a digest fails the render rather than picking one, as
+  # does a malformed digest. Empty repository/tag on the composed leg fails too.
+  #
+  # #1006: before this, agentImage and agentWorkerImage were DISCARDED whenever global.imageTag was
+  # set, so a mirror-only cluster rendered Docker Hub references it could not pull. The defaults
+  # below render byte-identically to the previous defaults.
+  browserImage: ""
+  browserImageDigest: ""
+  browserImageRepository: "vexaai/vexa-bot"
+  browserImageTag: "v012"
+
+  agentImage: ""
+  agentImageDigest: ""
+  # Empty repository/tag → the agent-api Deployment's own image.repository/image.tag, so mirroring
+  # `agentApi.image` carries the spawned copy with it.
+  agentImageRepository: ""
+  agentImageTag: ""
+
+  agentWorkerImage: ""
+  agentWorkerImageDigest: ""
+  agentWorkerImageRepository: "vexaai/v012-agent-worker"
+  agentWorkerImageTag: "v012"
+  # ---------------------------------------------------------------------------------------------
   logLevel: "info"
   speakerStream:
     minAudioSec: ""
@@ -406,6 +437,22 @@ minio:
   image:
     repository: minio/minio
     tag: latest
+  # The MinIO client image the post-install bucket-init Job runs. That Job is a helm HOOK, so it is
+  # easy to miss when inventorying what a cluster pulls — and the install fails without it. Same one
+  # identity rule as every other image here: `reference` (an explicit full reference) wins, else
+  # `digest` → repository@digest, else image.repository:image.tag. Deliberately NOT wired to
+  # global.imageTag — this is a third-party image, not part of the Vexa release set.
+  #
+  # #1006: the Job used to hardcode `minio/mc:latest` — unconfigurable AND mutable. The default
+  # below is the exact RELEASE tag `minio/mc:latest` resolved to when it was pinned (both
+  # sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727), so the bytes an
+  # unconfigured install pulls are unchanged; only the identity became explicit.
+  mc:
+    reference: ""   # explicit full reference — wins over repository/tag/digest below
+    digest: ""      # sha256:<64 hex> → "<repository>@<digest>"
+    image:
+      repository: minio/mc
+      tag: RELEASE.2025-08-13T08-35-41Z
   accessKey: vexa-access-key
   secretKey: vexa-secret-key
   bucket: vexa

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -474,6 +474,14 @@ minio:
     image:
       repository: minio/mc
       tag: RELEASE.2025-08-13T08-35-41Z
+    # The bucket-init hook Job's OWN sizing. A quota-controlled namespace (ResourceQuota naming
+    # requests.cpu/requests.memory/limits.cpu/limits.memory, or a restricted OpenShift project)
+    # rejects a Pod that declares nothing — and this Job retries forever, so `helm install --wait`
+    # hangs instead of failing. It is a hook Job, so neither #1005 (runtime-spawned Pods) nor the
+    # per-component `resources:` blocks covered it. Set to {} to emit nothing.
+    resources:
+      requests: { cpu: 10m, memory: 32Mi }
+      limits:   { cpu: 200m, memory: 128Mi }
   accessKey: vexa-access-key
   secretKey: vexa-secret-key
   bucket: vexa

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -241,6 +241,27 @@ runtime:
   resources:
     requests: { cpu: 50m, memory: 256Mi }
     limits:   { cpu: 500m, memory: 768Mi }
+  # Sizing for the Pods the runtime SPAWNS (backend=k8s) — NOT `runtime.resources` above, which sizes
+  # the runtime Deployment itself. Namespace policy commonly REQUIRES every container to declare CPU
+  # and memory requests AND limits (a ResourceQuota naming requests.cpu/limits.memory, or a restricted
+  # OpenShift project); a spawned Pod that declares none is rejected at admission and the meeting or
+  # dispatch never starts (#1005).
+  #
+  # The two classes are sized INDEPENDENTLY: a meeting bot is a Chromium browser + capture pipeline,
+  # an agent worker is a code harness. runtime.v1 carries ONE value per dimension, so each value sets
+  # BOTH the request and the limit (Guaranteed QoS) — there is no separate request/limit knob.
+  #
+  # The defaults below are conservative and sized to fit a small dev cluster. RAISE THEM for real
+  # meetings: memoryMb is a hard ceiling, and a bot that exceeds it is OOM-killed mid-meeting (before
+  # #1005 nothing was enforced, so bots ran unbounded). Set a class's values to "" to emit no
+  # resources for it at all and keep exactly the pre-#1005 unbounded behaviour.
+  workloadResources:
+    meetingBot:
+      cpu: 1                    # cores → requests/limits cpu: 1000m
+      memoryMb: 2048            # MiB   → requests/limits memory: 2048Mi
+    agentWorker:
+      cpu: 0.5                  # cores → requests/limits cpu: 500m
+      memoryMb: 1024            # MiB   → requests/limits memory: 1024Mi
   # Per-component override of global.topologySpreadConstraints (same shape). Applies to the runtime
   # Deployment's OWN pods (not the bot/agent Pods it spawns — those carry runtime.tolerations/
   # nodeSelector via the RUNTIME_K8S_* env below). Omit `labelSelector` and the runtime's own pod

--- a/deploy/helm/tests/README.md
+++ b/deploy/helm/tests/README.md
@@ -1,3 +1,7 @@
 # helm · tests
 
-Smoke tests for the `vexa` Helm chart: `test_helm_lint.sh` (chart lint) and `test_template.sh` (render/template validation). Run as part of the helm deploy checks.
+Static tests for the `vexa` Helm chart — no cluster required. Run by `make -C deploy/helm test` and by the Helm static-gates step in `release-images.yml`.
+
+- **`test_helm_lint.sh`** — chart lint (default values + `values-test.yaml`).
+- **`test_template.sh`** — the `gate:helm` render assertions: the carved control plane is present and correctly wired.
+- **`test_mirror_only.sh`** — the mirror-only invariant ([#1006](https://github.com/Vexa-ai/vexa/issues/1006)). Renders `values-mirror-only.yaml`, which points every image the chart can cause a cluster to pull at one unresolvable internal registry, and fails if any container image, helm-hook image or **runtime-spawn reference** (`BROWSER_IMAGE` / `AGENT_IMAGE` / `AGENT_WORKER_IMAGE` — Pods the runtime creates later, which appear in no rendered manifest) falls outside it. It also proves the legacy `repository:tag` path is unchanged and that ambiguous or malformed image identities fail the render closed. Every assertion carries its own negative control.

--- a/deploy/helm/tests/test_mirror_only.sh
+++ b/deploy/helm/tests/test_mirror_only.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# gate:helm-mirror (#1006) — the mirror-only render invariant.
+#
+# A private-registry cluster denies public-registry egress. The chart must therefore be able to
+# render with EVERY image it can cause the cluster to pull pointed at one internal registry, with
+# no undeclared public fallback anywhere — including the two surfaces that are easy to miss:
+#
+#   • helm HOOK manifests (the post-install minio-init Job), which never show up in `kubectl get
+#     deploy` and used to hardcode `minio/mc:latest`;
+#   • RUNTIME-SPAWNED workloads (bot / agent / agent-worker), which are not containers in any
+#     rendered manifest at all — they are references handed to the runtime as env, and the runtime
+#     creates those Pods later. Long-running Deployments alone are NOT sufficient coverage.
+#
+# Every assertion below carries its own negative control: the fixture is perturbed to reintroduce
+# the exact failure and the check must go RED, then the unperturbed fixture must be GREEN. A test
+# that cannot be made to fail proves nothing.
+#
+# No cluster required.
+set -uo pipefail
+
+HELM_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHART="$HELM_DIR/charts/vexa"
+FIXTURE="$HELM_DIR/tests/values-mirror-only.yaml"
+MIRROR="registry.internal.invalid/"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "SKIP: helm not installed"; exit 0
+fi
+
+fail=0
+ok()   { echo "  OK: $*"; }
+bad()  { echo "  FAIL: $*"; fail=1; }
+
+render() { helm template vexa "$CHART" -n vexa -f "$FIXTURE" "$@" 2>&1; }
+
+# --- the inventory ----------------------------------------------------------------------------
+# Two classes, collected separately because they are two different mistakes:
+#   container images   → every `image:` field in every rendered manifest (containers AND
+#                        initContainers — the field name is the same, so both are caught).
+#   spawn references   → the runtime Deployment's *_IMAGE env values.
+container_images() {
+  grep -hoE '^[[:space:]]+image:[[:space:]]*"?[^"[:space:]]+' <<<"$1" \
+    | sed -E 's/^[[:space:]]*image:[[:space:]]*"?//'
+}
+spawn_refs() {
+  awk '/- name: (BROWSER_IMAGE|AGENT_IMAGE|AGENT_WORKER_IMAGE)$/{n=$3; getline; sub(/^[[:space:]]*value:[[:space:]]*"?/,""); sub(/"$/,""); print n"="$0}' <<<"$1"
+}
+
+echo "=== gate:helm-mirror — mirror-only render invariant (#1006) ==="
+
+RENDER="$(render)"
+if [ $? -ne 0 ]; then echo "  FAIL: mirror-only fixture did not render:"; echo "$RENDER"; exit 1; fi
+
+# ---------------------------------------------------------------------------------------------
+# A3 — every container image and every spawn reference belongs to the configured mirror.
+# ---------------------------------------------------------------------------------------------
+check_all_mirrored() {  # <render> → prints offenders, returns 1 if any
+  local r="$1" offenders=""
+  local ref
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    case "$ref" in "$MIRROR"*) ;; *) offenders="$offenders container:$ref " ;; esac
+  done < <(container_images "$r")
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    case "${ref#*=}" in "$MIRROR"*) ;; *) offenders="$offenders spawn:$ref " ;; esac
+  done < <(spawn_refs "$r")
+  [ -z "$offenders" ] && return 0
+  printf '%s\n' "$offenders"; return 1
+}
+
+n_container="$(container_images "$RENDER" | grep -c . || true)"
+n_spawn="$(spawn_refs "$RENDER" | grep -c . || true)"
+if [ "$n_container" -lt 10 ] || [ "$n_spawn" -ne 3 ]; then
+  bad "inventory looks wrong — $n_container container images (want >=10), $n_spawn spawn refs (want 3). A shrinking inventory silently narrows this gate."
+else
+  ok "inventoried $n_container container images + $n_spawn runtime-spawn references"
+fi
+
+if offenders="$(check_all_mirrored "$RENDER")"; then
+  ok "A3 · every container image and spawn reference is on the configured mirror"
+else
+  bad "A3 · references outside the mirror: $offenders"
+fi
+
+# A3 negative control — reintroduce ONE undeclared public reference; the invariant must go red.
+for probe in \
+  "--set minio.mc.image.repository=minio/mc --set minio.mc.digest= --set minio.mc.image.tag=latest" \
+  "--set runtime.agentWorkerImageRepository=vexaai/v012-agent-worker --set runtime.agentWorkerImageDigest=" \
+  "--set runtime.agentImage=vexaai/v012-agent-api:v012"
+do
+  # shellcheck disable=SC2086
+  PROBE_RENDER="$(render $probe)"
+  if check_all_mirrored "$PROBE_RENDER" >/dev/null; then
+    bad "A3 negative control did NOT go red for [$probe] — the invariant cannot see this class of leak"
+  else
+    ok "A3 negative control red as required for [$probe]"
+  fi
+done
+
+# ---------------------------------------------------------------------------------------------
+# A1 — the three explicit spawn identities survive a global tag. This is the reported bug.
+# ---------------------------------------------------------------------------------------------
+BOT_WANT='registry.internal.invalid/vexa/vexa-bot@sha256:1111111111111111111111111111111111111111111111111111111111111111'
+AGENT_WANT='registry.internal.invalid/vexa/v012-agent-api:mirrored-2222'
+WORKER_WANT='registry.internal.invalid/vexa/v012-agent-worker@sha256:3333333333333333333333333333333333333333333333333333333333333333'
+GLOBAL_TAG="$(grep -E '^\s+imageTag:' "$FIXTURE" | head -1 | sed -E 's/.*: *"?([^"]*)"?.*/\1/')"
+
+check_spawn() {  # <render> <env-name> <exact-wanted-ref>
+  local got
+  got="$(spawn_refs "$1" | grep "^$2=" | cut -d= -f2-)"
+  [ "$got" = "$3" ] && return 0
+  echo "$2 = ${got:-<absent>} (want $3)"; return 1
+}
+for pair in "BROWSER_IMAGE:$BOT_WANT" "AGENT_IMAGE:$AGENT_WANT" "AGENT_WORKER_IMAGE:$WORKER_WANT"; do
+  env_name="${pair%%:*}"; want="${pair#*:}"
+  if msg="$(check_spawn "$RENDER" "$env_name" "$want")"; then
+    ok "A1 · $env_name is the exact configured reference, with global.imageTag=$GLOBAL_TAG set"
+  else
+    bad "A1 · $msg"
+  fi
+done
+# A1 also means the global tag did not leak into any spawn reference.
+if spawn_refs "$RENDER" | grep -q ":${GLOBAL_TAG}\$"; then
+  bad "A1 · a spawn reference carries global.imageTag ($GLOBAL_TAG) — the explicit reference was rewritten"
+else
+  ok "A1 · global.imageTag rewrote none of the three spawn references"
+fi
+
+# ---------------------------------------------------------------------------------------------
+# A2 — the minio-init hook Job renders the exact configured reference.
+# ---------------------------------------------------------------------------------------------
+MC_WANT='registry.internal.invalid/mirror/mc@sha256:4444444444444444444444444444444444444444444444444444444444444444'
+MC_GOT="$(helm template vexa "$CHART" -n vexa -f "$FIXTURE" --show-only templates/job-minio-init.yaml 2>&1 \
+  | grep -E '^\s+image:' | sed -E 's/^\s*image:\s*"?//; s/"$//')"
+if [ "$MC_GOT" = "$MC_WANT" ]; then
+  ok "A2 · minio-init Job uses the configured digest ($MC_GOT)"
+else
+  bad "A2 · minio-init Job image is '$MC_GOT', want '$MC_WANT'"
+fi
+if [ "$MC_GOT" = "minio/mc:latest" ]; then
+  bad "A2 · minio-init Job still renders the pre-#1006 hardcoded public reference"
+fi
+
+# ---------------------------------------------------------------------------------------------
+# A4 — the legacy composed path stays green; ambiguous or malformed identities fail CLOSED.
+# ---------------------------------------------------------------------------------------------
+# Legacy: stock values (no explicit reference, no digest anywhere) must still render the historical
+# Docker Hub references, and global.imageTag must still drive all three spawn refs.
+LEGACY="$(helm template vexa "$CHART" -n vexa 2>&1)"
+for want in "vexaai/vexa-bot:v012" "vexaai/v012-agent-api:v012" "vexaai/v012-agent-worker:v012"; do
+  if grep -q "value: \"$want\"" <<<"$LEGACY"; then
+    ok "A4 · legacy default renders $want unchanged"
+  else
+    bad "A4 · legacy default lost $want — backward compatibility broken"
+  fi
+done
+LEGACY_TAGGED="$(helm template vexa "$CHART" -n vexa --set global.imageTag=vLEGACY 2>&1)"
+n_tagged="$(spawn_refs "$LEGACY_TAGGED" | grep -c ':vLEGACY$' || true)"
+if [ "$n_tagged" -eq 3 ]; then
+  ok "A4 · global.imageTag still supplies the tag for all 3 spawn refs when none is explicit"
+else
+  bad "A4 · global.imageTag drove $n_tagged/3 spawn refs on stock values"
+fi
+
+# Fail-closed: each of these must make `helm template` EXIT NON-ZERO. A render that succeeds here
+# is the dangerous outcome — the operator believes they pinned bytes and did not.
+must_fail() {  # <label> <expected-substring> <helm args…>
+  local label="$1" expect="$2"; shift 2
+  local out rc
+  out="$(helm template vexa "$CHART" -n vexa -f "$FIXTURE" "$@" 2>&1)"; rc=$?
+  if [ $rc -eq 0 ]; then
+    bad "A4 · $label RENDERED instead of failing closed"
+  elif grep -q "$expect" <<<"$out"; then
+    ok "A4 · $label fails closed"
+  else
+    bad "A4 · $label failed, but not with the expected message (want '$expect'): $(head -3 <<<"$out")"
+  fi
+}
+must_fail "reference + digest on the same image (ambiguous)" "an explicit full reference" \
+  --set runtime.agentImageDigest=sha256:5555555555555555555555555555555555555555555555555555555555555555
+must_fail "truncated digest" "Expected exactly sha256" --set minio.mc.digest=sha256:abc123
+must_fail "uppercase digest" "Expected exactly sha256" \
+  --set minio.mc.digest=sha256:AAAA111111111111111111111111111111111111111111111111111111111111
+must_fail "non-sha256 digest" "Expected exactly sha256" \
+  --set minio.mc.digest=sha512:1111111111111111111111111111111111111111111111111111111111111111
+must_fail "empty repository with no reference or digest" "empty repository" \
+  --set runtime.agentWorkerImageDigest= --set runtime.agentWorkerImageRepository=
+must_fail "empty tag with no reference or digest" "empty tag" \
+  --set runtime.agentWorkerImageDigest= --set global.imageTag= --set runtime.agentWorkerImageTag=
+
+[ "$fail" -eq 0 ] && { echo "gate:helm-mirror PASS"; exit 0; } || { echo "gate:helm-mirror FAIL"; exit 1; }

--- a/deploy/helm/tests/values-mirror-only.yaml
+++ b/deploy/helm/tests/values-mirror-only.yaml
@@ -1,0 +1,84 @@
+# Mirror-only fixture (#1006) — every image this chart can cause a cluster to pull is pointed at a
+# single private registry, and NOTHING may fall back to a public one.
+#
+# `registry.internal.invalid` is deliberately unresolvable: the fixture is a RENDER proof, and a
+# reference that cannot resolve makes an accidental live pull impossible. `tests/test_mirror_only.sh`
+# renders this file and asserts every container image plus every runtime-spawn image reference
+# carries the prefix below.
+#
+# `global.imageTag` is set ON PURPOSE. It is the load-bearing part of the fixture: a global tag must
+# supply a tag to the images that have no explicit identity, and must never rewrite one that does.
+
+global:
+  imageTag: "v0.0.0-mirror"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets:
+    - name: internal-registry-pull
+
+secrets:
+  adminApiToken: "test-admin-token"
+  internalApiSecret: "vexa-internal-secret"
+  dispatchSigningKey: "dev-dispatch-signing-key"
+
+# ---- long-running components: repository from the mirror, tag from global.imageTag ----
+gateway:
+  image:
+    repository: registry.internal.invalid/vexa/v012-gateway
+adminApi:
+  image:
+    repository: registry.internal.invalid/vexa/v012-admin-api
+meetingApi:
+  image:
+    repository: registry.internal.invalid/vexa/v012-meeting-api
+agentApi:
+  image:
+    repository: registry.internal.invalid/vexa/v012-agent-api
+terminal:
+  image:
+    repository: registry.internal.invalid/vexa/v012-terminal
+
+runtime:
+  backend: "k8s"
+  image:
+    repository: registry.internal.invalid/vexa/v012-runtime
+  # The three SPAWNED workloads, one per identity form the chart accepts, so the fixture proves all
+  # three legs at once:
+  #   bot          → explicit full reference carrying a digest
+  #   agent        → explicit full reference carrying a tag
+  #   agent-worker → repository + digest (composed by the chart)
+  # None of them may be rewritten by global.imageTag above.
+  browserImage: "registry.internal.invalid/vexa/vexa-bot@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  agentImage: "registry.internal.invalid/vexa/v012-agent-api:mirrored-2222"
+  agentWorkerImageRepository: "registry.internal.invalid/vexa/v012-agent-worker"
+  agentWorkerImageDigest: "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+
+# ---- bundled infrastructure + install hooks ----
+postgres:
+  image: registry.internal.invalid/mirror/postgres:17-alpine
+redis:
+  image: registry.internal.invalid/mirror/valkey:8-alpine
+pgbouncer:
+  enabled: true
+  image: registry.internal.invalid/mirror/pgbouncer:latest
+
+minio:
+  image:
+    repository: registry.internal.invalid/mirror/minio
+    tag: mirrored
+  # The post-install bucket-init Job. Before #1006 this Job ignored every value here and pulled
+  # `minio/mc:latest` from Docker Hub.
+  mc:
+    digest: "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    image:
+      repository: registry.internal.invalid/mirror/mc
+
+# The migrations Job is off by default; a mirror-only operator running it must be covered too.
+migrations:
+  enabled: true
+
+# The deprecated dashboard stays off (its own pinned tag, not part of the release set).
+dashboard:
+  enabled: false
+
+ingress:
+  enabled: false

--- a/deploy/helm/values-oenb-validation.yaml
+++ b/deploy/helm/values-oenb-validation.yaml
@@ -1,0 +1,129 @@
+# =====================================================================================
+# VALIDATION VALUES — Vexa-ai/vexa#1005 (spawned-Pod resources) + #1006 (mirror-only images)
+#
+# THIS IS NOT A RELEASE ARTEFACT. It exists so ONE person can install this branch on a
+# quota-controlled, mirror-only cluster and check that the two fixes behave. Do not carry
+# it into production values.
+#
+# -------------------------------------------------------------------------------------
+# ⚠️  READ THIS FIRST — THE ONE WAY THIS TEST SILENTLY LIES TO YOU  ⚠️
+# -------------------------------------------------------------------------------------
+# The runtime Deployment renders its image as:
+#
+#     image: "{{ .Values.runtime.image.repository }}:{{ .Values.global.imageTag |
+#              default .Values.runtime.image.tag }}"
+#
+# `global.imageTag`, WHEN SET, OVERRIDES `runtime.image.tag` — silently. There is no
+# error, no warning, and every Pod still goes Running.
+#
+# So if you set `global.imageTag: v0.12.18` (the natural thing to do on a mirror-only
+# install, because it pins every OTHER image at once) you get the OLD runtime, WITHOUT
+# the #1005 fix, while this file appears to have pinned the fixed one. Your spawned bot
+# Pods then declare no resources, your quota rejects them, and you conclude the fix does
+# not work — when in fact you never ran it.
+#
+# YOU HAVE EXACTLY TWO SAFE CHOICES:
+#
+#   (A) Leave `global.imageTag` UNSET (this file's default — the `global:` block below
+#       deliberately does not define it). Every other image then uses its own default
+#       tag, and the runtime uses `runtime.image.tag` below.
+#
+#   (B) Set `global.imageTag` to THE SAME test tag you built the runtime with, and make
+#       sure your registry serves that tag for every other Vexa image too.
+#
+# Anything else — a global.imageTag that differs from runtime.image.tag — produces a
+# GREEN-BUT-WRONG result. Verify with the one command in the VERIFY block at the bottom
+# BEFORE you trust any spawn.
+#
+# (The underlying hole is Vexa-ai/vexa#1001 — a digest helper for long-running
+# Deployments — which is still open. Until it lands, this override is load-bearing.)
+# =====================================================================================
+
+global:
+  # NOTE THE ABSENCE. `imageTag` is intentionally NOT set here — see choice (A) above.
+  # Uncomment ONLY to exercise choice (B), and only with the identical tag used below.
+  # imageTag: "oenb-val-1005-1006"
+
+  # A mirror-only cluster pulls from its own registry; add the pull secret that reaches it.
+  imagePullSecrets: []
+  # imagePullSecrets:
+  #   - name: internal-registry-pull
+
+  # `Always` is the chart default. On a mirror-only cluster that is usually what you want.
+  # Set `IfNotPresent` if you side-loaded the image onto the nodes instead of pushing it
+  # to a registry (that is what our own local validation did — see the PR description).
+  imagePullPolicy: Always
+
+runtime:
+  backend: k8s
+
+  # ---- #1005: the runtime image that CONTAINS the fix -------------------------------
+  # The #1005 fix is PYTHON, in core/runtime/. It only exists inside a REBUILT runtime
+  # image. No published tag contains it today. Point these at wherever your Harbor holds
+  # the image you (or we) built from this branch.
+  image:
+    repository: REPLACE-ME.registry.internal/vexa/v012-runtime
+    tag: oenb-val-1005-1006          # ← overridden by global.imageTag if that is set. See banner.
+
+  # ---- #1005: sizing for the Pods the runtime SPAWNS ---------------------------------
+  # NOT `runtime.resources` (which sizes the runtime Deployment itself). One value per
+  # dimension sets BOTH the request and the limit → Guaranteed QoS.
+  #
+  # memoryMb is a HARD CEILING: a workload exceeding it is OOM-killed. Nothing was
+  # enforced before #1005, so we have no measured figure for a real meeting. START HIGH
+  # and tighten — do not discover the ceiling as a dropped meeting.
+  workloadResources:
+    meetingBot:
+      cpu: 2                          # → requests/limits cpu: 2000m
+      memoryMb: 4096                  # → requests/limits memory: 4096Mi  (chart default 2048 is dev-sized)
+    agentWorker:
+      cpu: 0.5                        # → requests/limits cpu: 500m
+      memoryMb: 1024                  # → requests/limits memory: 1024Mi
+
+  # ---- #1006: the three runtime-spawned images your mirror must hold -----------------
+  # These are NEVER an `image:` field in any rendered manifest — the chart hands them to
+  # the runtime as env and the runtime creates those Pods later. `kubectl get deploy -o yaml`
+  # will never name them, so a mirror populated by reading the manifests WILL miss them and
+  # fail at the first meeting, not at install.
+  #
+  # An explicit full reference WINS and global.imageTag never rewrites it (that is the #1006
+  # fix). Prefer digests for the bot.
+  browserImage: "REPLACE-ME.registry.internal/vexa/vexa-bot:v012"        # the bot, ~3.6 GB
+  agentImage: "REPLACE-ME.registry.internal/vexa/v012-agent-api:v012"
+  agentWorkerImage: "REPLACE-ME.registry.internal/vexa/v012-agent-worker:v012"
+
+# ---- The fourth easily-missed pull, and a quota trap -------------------------------
+# The post-install `minio-init` hook Job. On a quota-controlled namespace it is REJECTED
+# unless it declares resources, and because it is a hook that retries forever,
+# `helm install --wait` HANGS while every Deployment sits happily Running. This branch
+# adds the `resources` block below; upstream main does not have it yet.
+minio:
+  mc:
+    reference: "REPLACE-ME.registry.internal/mirror/mc:RELEASE.2025-08-13T08-35-41Z"
+    resources:
+      requests: { cpu: 10m, memory: 32Mi }
+      limits:   { cpu: 200m, memory: 128Mi }
+  image:
+    repository: REPLACE-ME.registry.internal/mirror/minio
+    tag: latest
+
+# =====================================================================================
+# VERIFY — run BOTH before you trust any result.
+#
+# 1. Did the runtime you actually got contain the fix?  (catches the global.imageTag trap)
+#
+#      kubectl -n <ns> get deploy <release>-vexa-runtime \
+#        -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+#
+#    It MUST print the repository:tag you set above. If it prints anything else,
+#    global.imageTag overrode you — STOP, you are about to test the old runtime.
+#
+# 2. Did the sizing reach the runtime?
+#
+#      kubectl -n <ns> get deploy <release>-vexa-runtime -o json \
+#        | jq '.spec.template.spec.containers[0].env[]
+#              | select(.name|test("^RUNTIME_(BOT|AGENT_WORKER)_(CPU|MEMORY_MB)$"))'
+#
+#    Expect four entries, all NON-EMPTY. Empty strings mean the values did not land and
+#    the spawned Pods will declare nothing — exactly the pre-#1005 behaviour.
+# =====================================================================================

--- a/docs/changelog.d/1005-runtime-resources.md
+++ b/docs/changelog.d/1005-runtime-resources.md
@@ -1,0 +1,12 @@
+- **Spawned bot and agent-worker Pods declare CPU/memory requests and limits, so quota-controlled
+  namespaces admit them (#1005).** The runtime accepted `resources` on a `runtime.v1` WorkloadSpec
+  but dropped it before the backend, so every dynamically created Pod was unsized — and a namespace
+  whose policy requires each container to declare requests *and* limits (a `ResourceQuota`, a
+  restricted OpenShift project) rejected both shipped workload classes at admission. Resource intent
+  now crosses the backend port, and the Kubernetes backend submits a complete Pod manifest carrying
+  the container's requests and limits alongside its image, command, env, labels, workspace mounts
+  and scheduling. Size the two classes independently with the chart's `runtime.workloadResources`
+  (`meetingBot` / `agentWorker`); each value sets both the request and the limit, and leaving a
+  class empty keeps the previous unsized behaviour. Enforcement is Kubernetes-only — the docker and
+  process backends accept the same intent without acting on it. See
+  [Deployment](/deployment-kubernetes).

--- a/docs/changelog.d/1006-mirror-only-image-references.md
+++ b/docs/changelog.d/1006-mirror-only-image-references.md
@@ -1,0 +1,12 @@
+- **Helm: a private-registry mirror can now hold every image the chart pulls (#1006).** Two of the
+  runtime's spawned-workload references — `runtime.agentImage` and `runtime.agentWorkerImage` — were
+  silently discarded whenever `global.imageTag` was set, rendering Docker Hub references a
+  mirror-only cluster cannot pull; the `minio-init` hook Job hardcoded `minio/mc:latest`. The chart
+  now resolves every image by one documented rule: an explicit full reference wins and
+  `global.imageTag` never rewrites it, otherwise `repository@digest`, otherwise `repository:tag`.
+  Ambiguous identities (a full reference *and* a digest) and malformed digests fail the render
+  instead of silently falling back to a mutable tag. The MinIO client image is configurable
+  (`minio.mc.reference` / `.digest` / `.image.repository` + `.image.tag`) and its default is the pinned RELEASE
+  tag `latest` resolved to, so the bytes an unconfigured install pulls are unchanged. With stock
+  values the render is otherwise byte-identical to v0.12.18. New `deploy/helm/tests/test_mirror_only.sh` renders a mirror-only fixture and fails if
+  any container, hook or runtime-spawn reference falls outside the configured registry.

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -231,9 +231,82 @@ binds into each worker Pod as a PVC, scoped per-mount). The Compose stack is the
 most production mileage today; the chart is the right starting point for a cluster
 evaluation — track the [status page](/roadmap/status).
 
-## Air-gapped clusters
+## Air-gapped clusters and private registry mirrors
 
-Everything the chart deploys pulls from images you build and host in your own registry; pair it
-with the [self-hosted transcription unit](/deployment#transcription-the-separate-gpu-unit) and
-your own LLM endpoint ([Configuration](/configuration)) for a zero-egress posture. See
+Everything the chart deploys can pull from a registry you host; pair it with the
+[self-hosted transcription unit](/deployment#transcription-the-separate-gpu-unit) and your own LLM
+endpoint ([Configuration](/configuration)) for a zero-egress posture. See
 [Security & compliance](/security-compliance).
+
+### One rule for every image reference
+
+| # | Value | Result |
+|---|---|---|
+| 1 | an explicit **full reference** (`runtime.browserImage`, `minio.mc.reference`, …) | used **verbatim** |
+| 2 | a **digest** (`runtime.browserImageDigest`, `minio.mc.digest`, …) | `<repository>@<digest>` |
+| 3 | `repository` + `tag` | `<repository>:<tag>` |
+
+**An explicit full reference wins; `global.imageTag` never rewrites it.** The global tag only
+supplies the tag on leg 3, for images that have no explicit identity of their own.
+
+The chart **fails closed** — `helm template` errors and nothing renders — if an image's identity is
+ambiguous (a full reference *and* a digest on the same image) or malformed (a digest that is not
+exactly `sha256:` + 64 lowercase hex). A typo'd digest is refused rather than quietly resolving to a
+mutable tag.
+
+### What your mirror has to hold
+
+Three of these are invisible to `kubectl get deploy -o yaml`, which is exactly why a mirror-only
+install could get most of the way up and then fail:
+
+| Image | Why it is pulled | Where you point it |
+|---|---|---|
+| gateway · admin-api · meeting-api · runtime · agent-api · terminal | long-running Deployments | `<component>.image.repository` (+ `global.imageTag`) |
+| Postgres · Valkey/Redis · MinIO · PgBouncer (if enabled) | bundled infrastructure | `postgres.image` · `redis.image` · `minio.image` · `pgbouncer.image` |
+| MinIO client (`mc`) | **post-install hook Job** that creates the bucket — not a Deployment, easy to miss when inventorying, and the install fails without it | `minio.mc.reference` / `.digest` / `.image.repository` + `.image.tag` |
+| DB migrations | opt-in hook Job (`migrations.enabled`) | `migrations.image.repository` (falls back to `meetingApi.image.*`) |
+| **meeting bot (~3.6 GB)** · **agent** · **agent-worker** | **spawned by the runtime at meeting time** — not containers in any rendered manifest. The chart passes them as `BROWSER_IMAGE` / `AGENT_IMAGE` / `AGENT_WORKER_IMAGE` env and the runtime creates those Pods later | `runtime.browserImage` · `runtime.agentImage` · `runtime.agentWorkerImage` (or the matching `…Digest` / `…Repository` + `…Tag`) |
+
+The three spawned images fail **late**: the control plane goes green and the first meeting dies with
+`ImagePullBackOff` on a Pod nobody was watching. Mirror them at install time.
+
+```yaml
+global:
+  imageTag: v0.12.19
+  imagePullSecrets: [{ name: internal-registry-pull }]
+runtime:
+  image: { repository: registry.example.internal/vexa/v012-runtime }
+  browserImage: "registry.example.internal/vexa/vexa-bot@sha256:<64 hex>"
+  agentImage:   "registry.example.internal/vexa/v012-agent-api:v0.12.19"
+  agentWorkerImageRepository: registry.example.internal/vexa/v012-agent-worker
+  agentWorkerImageDigest: "sha256:<64 hex>"
+minio:
+  image: { repository: registry.example.internal/mirror/minio, tag: latest }
+  mc:    { digest: "sha256:<64 hex>", image: { repository: registry.example.internal/mirror/mc } }
+```
+
+Prove it before you install — the render tells you everything, no cluster needed:
+
+```bash
+helm template vexa deploy/helm/charts/vexa -n vexa -f my-values.yaml \
+  | grep -E '^\s+image:|_IMAGE$' -A1
+```
+
+Anything in that output that is not your registry is something your cluster will try to pull from
+the internet.
+
+### Upgrading from v0.12.18 or earlier
+
+Behaviour changed in one direction only: **explicit references are now honoured where they were
+previously discarded.**
+
+- If you set `runtime.agentImage` or `runtime.agentWorkerImage` *and* `global.imageTag`, the
+  explicit reference used to be silently overwritten by the global tag. It is now used. If you were
+  relying on the global tag to win, clear the explicit value (`--set runtime.agentImage=`) and set
+  `runtime.agentImageRepository` instead.
+- The `minio-init` Job no longer hardcodes `minio/mc:latest`. The default is the pinned
+  `minio/mc:RELEASE.2025-08-13T08-35-41Z` — the same bytes `latest` resolved to at pin time — so an
+  unconfigured install pulls the same image it did before, now by an explicit name.
+- With stock values the rendered manifests are byte-identical to v0.12.18 **except** that one line:
+  every other image reference is unchanged. Nothing moves unless you had set one of the two values
+  that were being ignored.

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -202,7 +202,12 @@ const MINIO_JOB = "deploy/helm/charts/vexa/templates/job-minio-init.yaml";
 test("image-licenses RED: an undeclared image pinned in a helm TEMPLATE (not just values) reds", () => {
   // The gate must read helm templates, not only compose + values — a literal `image:` in a template
   // is a real pin. An undeclared one must red, else the 'green gate ships an un-audited component' hole.
-  const r = withEdited(MINIO_JOB, "image: minio/mc:latest", "image: somevendor/unaudited:1.2",
+  // Anchor on the image LINE, not on a specific value: #1006 replaced the hardcoded
+  // `minio/mc:latest` with a configurable helper call, so a literal-string anchor
+  // silently became a fixture that could not be built — and this test correctly
+  // refused to pass vacuously rather than proving nothing. The regex keeps exactly
+  // one `image:` key; a duplicate would change what helm renders, not just what it pins.
+  const r = withEdited(MINIO_JOB, /^(\s*)image: .*$/m, "$1image: somevendor/unaudited:1.2",
     () => runGate("image-licenses"));
   assert.equal(r.green, false, "an undeclared image in a helm template sailed through — the gate never read templates");
   assert.match(r.out, /undeclared pinned image/);


### PR DESCRIPTION
## What this is

**A validation branch, not a merge candidate.** It exists so one engineer can `git clone`, install, and test the fixes for [#1005](https://github.com/Vexa-ai/vexa/issues/1005) and [#1006](https://github.com/Vexa-ai/vexa/issues/1006) on a quota-controlled, mirror-only cluster. Please do not merge it — merge [#1093](https://github.com/Vexa-ai/vexa/pull/1093) and [#1096](https://github.com/Vexa-ai/vexa/pull/1096) on their own merits.

Composition, off `origin/main` @ `fde7dfb7`:

| Commit | Content |
|---|---|
| `6a5aefb7` | merge `1005-runtime-resources` (= [#1093](https://github.com/Vexa-ai/vexa/pull/1093)) — spawned Pods declare CPU/memory. **Python under `core/runtime/`, so it needs a rebuilt runtime image.** |
| `99668602` | merge `1006-mirror-images` (= [#1096](https://github.com/Vexa-ai/vexa/pull/1096)) — mirror-only image references. **Chart-only; works against published images.** |
| `28d0b330` | validation values file + README, and one new fix found while proving this (below) |

One merge conflict, in `deploy/helm/charts/vexa/README.md`: purely additive — #1005 adds *Sizing the spawned bot and agent-worker Pods*, #1006 adds *Image references*. Both kept, in that order. `values.yaml` auto-merged cleanly (disjoint keys under `runtime:`).

---

## ⚠️ The install blocker we found — it is not either of the two fixes

**The `minio-init` post-install hook Job declared no resources.** On a namespace whose `ResourceQuota` names `requests.cpu`/`limits.memory`, that Pod is rejected. Because it is a *hook* Job, it retries forever, so **`helm install --wait` hangs indefinitely while every Deployment sits happily `Running`** — a failure that looks nothing like a quota problem.

Reproduced live, before the fix, on the first install attempt:

```
Warning FailedCreate job/vexa-vexa-minio-init  Error creating: pods "vexa-vexa-minio-init-t8n9g"
is forbidden: failed quota: require-requests-and-limits: must specify limits.cpu for: minio-init;
limits.memory for: minio-init; requests.cpu for: minio-init; requests.memory for: minio-init
```

…repeated on backoff, release stuck at `STATUS: pending-install`, while all 13 other Pods were `Running`.

Neither #1005 (which sizes *runtime-spawned* Pods) nor the per-component `resources:` blocks cover it, because it is a hook Job that is neither. `28d0b330` adds a `minio.mc.resources` value and wires it into the Job template. After that fix the same install reached `STATUS: deployed` with `vexa-vexa-minio-init` `Completed`.

**This would have hit the customer before either fix got a chance to be evaluated.** It should be fixed on `main` independently of this branch — filed as [#1098](https://github.com/Vexa-ai/vexa/issues/1098).

---

## Observation bundle

Environment: `bbb`, fresh k3d cluster `oenbval`, Kubernetes **v1.35.5+k3s1**, namespace `vexa-quota`.

Quota under test — all four dimensions, which is what forces every container to declare requests *and* limits:

```yaml
spec:
  hard:
    requests.cpu: "16"      limits.cpu: "32"
    requests.memory: 32Gi   limits.memory: 64Gi
```

Runtime image built from this branch on `bbb`, **not pushed to any registry**, side-loaded via `k3d image import`:

```
vexa/v012-runtime:oenb-val-1005-1006
sha256:a83951231a51c452a94ed96eb18bb1aefa5a8c88e893a6f97e7a9e43f99a63e0   (284 MB)
```

| # | Observation | Verdict |
|---|---|---|
| **N1** | Unsized probe Pod **REJECTED** by the quota — run *before* anything else | **RED, as required** |
| **N2** | Zero `LimitRange` objects in the namespace (so nothing is defaulting the pods) | **confirmed, 0 items** |
| **N3** | Negative control **re-run after** the green result — still rejected | **RED, as required** |
| **A0** | `helm install` reaches `STATUS: deployed` under the quota (after the minio-init fix) | **GREEN** |
| **A1** | Deployed runtime is the locally-built image, digest matched | **GREEN** |
| **A2** | Sizing env reached the runtime Deployment | **GREEN** |
| **A3** | meeting-bot Pod admitted, carrying **configured** requests + limits, `Guaranteed` | **GREEN** |
| **A4** | agent-worker Pod admitted, **independently** sized, `Guaranteed` | **GREEN** |
| **A5** | Runtime unit suite on the merged branch | **177 passed, 1 skipped** |
| **A6** | `make -C deploy/helm test` (incl. the mirror-only invariant) on Linux | **PASS** |

### N1 · negative control, run first

```
$ kubectl apply -f - <<< '<pod with no resources>'
Error from server (Forbidden): error when creating "STDIN": pods "probe-unsized" is forbidden:
failed quota: require-requests-and-limits: must specify limits.cpu for: probe; limits.memory for:
probe; requests.cpu for: probe; requests.memory for: probe
```

A sized probe in the same namespace was accepted, and `kubectl get limitrange -o json` reported `0` items — so admission is genuinely driven by the declared resources, not by a namespace default. **N3** re-ran the identical unsized probe *after* the green results and it was rejected again, so the green result cannot be explained by the quota having lapsed.

### A1/A2 · what actually got deployed

```
$ kubectl -n vexa-quota get deploy vexa-vexa-runtime -o jsonpath='{...containers[0].image}'
vexa/v012-runtime:oenb-val-1005-1006

$ kubectl ... containerStatuses[0].imageID
sha256:a83951231a51c452a94ed96eb18bb1aefa5a8c88e893a6f97e7a9e43f99a63e0   ← the image built here

$ kubectl -n vexa-quota exec deploy/vexa-vexa-runtime -- env | grep RUNTIME_
RUNTIME_BACKEND=k8s        POD_NAMESPACE=vexa-quota
RUNTIME_BOT_CPU=1          RUNTIME_BOT_MEMORY_MB=512
RUNTIME_AGENT_WORKER_CPU=0.25   RUNTIME_AGENT_WORKER_MEMORY_MB=256
```

### A3/A4 · the Pods the runtime spawned

Both created through the real runtime HTTP API (`POST /workloads`) against the real `K8sBackend`, which reported `"backend":"k8s"` on both spawns.

```
=== vexa-mtg-v2 ===            (profile meeting-bot, configured cpu 1 / 512 MiB)
  resources : {"limits":   {"cpu": "1",    "memory": "512Mi"},
               "requests": {"cpu": "1",    "memory": "512Mi"}}
  qosClass  : Guaranteed
  labels    : {"runtime.managed": "true", "runtime.workload_id": "mtg-v2"}

=== vexa-agent-v2 ===          (profile agent, configured cpu 0.25 / 256 MiB)
  resources : {"limits":   {"cpu": "250m", "memory": "256Mi"},
               "requests": {"cpu": "250m", "memory": "256Mi"}}
  qosClass  : Guaranteed
  labels    : {"runtime.managed": "true", "runtime.workload_id": "agent-v2"}
```

Both **admitted** by the same quota that rejected the unsized probe seconds earlier and seconds later; both carry the **configured** values, sized **independently** per class; both `Guaranteed`.

---

## Honest limits — read these before trusting the result

1. **Placeholder images.** `BROWSER_IMAGE` and `AGENT_WORKER_IMAGE` were set to `busybox:1.36`, not the real 3.6 GB bot. What is proven is the **resource-declaration and admission path** through the real kernel, real profile registry and real API server — **not** that the real bot boots inside those limits. Sizing the real images for real meetings remains the operator's call. Consequently `vexa-mtg-v2` reached `Succeeded` and `vexa-agent-v2` reached `StartError` (`exec: "python": executable file not found` — busybox has no Python). Those terminal states are artefacts of the placeholder; **admission and the resources block are what this proves**, and both are exactly right.
2. **`imagePullPolicy=IfNotPresent`** was set for this run because the image was side-loaded rather than pushed. The chart default is `Always`; a real mirror-only install keeps `Always` and pulls from its registry.
3. **Nothing was published.** The runtime image exists only on `bbb` and inside the k3d cluster. Per founder decision we publish only once the customer names the exact tag and repository path his Harbor can reach.
4. **Not tested:** OpenShift SCC behaviour on spawned Pods, real Harbor pull-secret paths, the customer's actual quota headroom, and whether the real bot lives inside any given memory ceiling.
5. **`make -C deploy/helm test` fails on macOS** — `tests/test_mirror_only.sh` uses `sed -E 's/^\s*image:...'`, and BSD sed does not support `\s`, so the A2 assertion mis-parses. It passes on Linux. Pre-existing in #1096, unrelated to this branch, but it will bite any maintainer running the gate on a Mac.
6. **One unexplained reading, recorded rather than explained away.** During the teardown/reinstall window (between `helm uninstall` and the clean reinstall) an earlier spawn returned `"backend":"docker"` and failed with `exitCode 1`, creating no Pod, even though the Deployment carried `RUNTIME_BACKEND=k8s`. `WorkloadStatus.backend` is read from the live backend object (`self.backend.name`), so a `DockerBackend` really was in use in whichever process served that request — and `_build_backend()` has no silent fallback path. I could not subsequently identify that process (the Service may have been routing to a terminating Pod of the previous, wedged release). **It did not reproduce on the clean install**, where both spawns reported `k8s` and produced real Pods. Flagging it because a runtime that can end up on the docker backend while its env says `k8s` would be a genuine bug, and I did not root-cause it.
7. **`MARVIN-TEST-KIT-1005.md` and `OBSERVATION-BUNDLE-1005.md` sit in the repo root**, inherited from `1005-runtime-resources`. I deliberately did not delete them (conservative merge), but they should not ship on `main` — flagging for #1093.

---

## For the operator: the trap that produces a green-but-wrong result

The runtime Deployment renders:

```
image: "{{ .Values.runtime.image.repository }}:{{ .Values.global.imageTag | default .Values.runtime.image.tag }}"
```

**`global.imageTag`, when set, silently overrides `runtime.image.tag`.** Setting it to a release tag — the natural move on a mirror-only install, since it pins every other image at once — yields the **old runtime without the #1005 fix**, with no error and no warning. Every Pod goes `Running`, the spawned bots still declare nothing, the quota still rejects them, and the conclusion is "the fix does not work" — having never run it.

Either leave `global.imageTag` unset, or set it to the same tag the runtime was built with. Then verify before trusting any spawn:

```bash
kubectl -n <ns> get deploy <release>-vexa-runtime \
  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
```

This hole exists because [#1001](https://github.com/Vexa-ai/vexa/issues/1001) (a digest helper for long-running Deployments) is still open. It is called out in a banner at the top of `deploy/helm/values-oenb-validation.yaml` and in the chart README.

---

## Contribution rights

- [ ] I certify that I have the right to submit this contribution

**Left unticked deliberately** — @DmitriyG228 please tick. This box is a legal certification and an agent must never make it on a human's behalf. All three commits carry DCO `Signed-off-by`.
