### PR TITLE
docs: two write-discipline rules for agents working this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,24 @@ Layout: pnpm + turbo monorepo — `core/` (gateway, agent, runtime, identity, me
 published law), `calm/` (FINOS CALM model). Licensing is FINOS-gated: new deps must be
 Category A (MIT/BSD/Apache); weak-copyleft needs an entry in `license-exceptions.json`
 (ADR-0004) — never add GPL/AGPL.
+
+## Never replace a pull-request or issue body wholesale
+
+`gh pr edit --body-file` and `gh issue edit --body-file` overwrite everything, including the
+*Contribution rights* checkbox and any verdict a human put there. On 2026-08-09 that wiped a ticked
+box on #1095, reset `contribution-rights`, and the clobbered state was then reported back as fact —
+sending a maintainer to redo something already done, in two separate sessions. Re-read the live body
+and re-apply what a human set, or edit surgically. Same care for labels, reviews and approvals.
+
+The rights declaration and the DCO sign-off are the human's alone (`CONTRIBUTOR_RIGHTS.md § Agent-assisted
+contributions`): an agent may install and verify the sign-off mechanism and repair unsigned commits
+*after* the human picks a path, and may never choose that path or sign for anyone.
+
+## When a check contradicts what you can see, read the check
+
+`contribution-rights` failed on every pull request from its activation until 2026-08-09 because
+`scripts/contribution-rights-gate.mjs` tested the rights marker's own line for a checkbox, while
+the template leaves the marker on a continuation line. Nobody noticed for months: it is not a
+required check, so everything merged anyway, and the unit fixture encoded the same wrong assumption
+it was meant to guard. A gate that disagrees with the visible state is a finding, not an obstacle —
+and a fixture that mirrors the implementation instead of the real artifact proves nothing.


### PR DESCRIPTION
Both from the 2026-08-09 contributor-rights session, written where DEV sessions will actually read them rather than only in the business workspace.

**Never replace a PR or issue body wholesale.** `gh pr edit --body-file` overwrote the body of #1095 and wiped a ticked *Contribution rights* checkbox, resetting the check that reads it. The clobbered state was then reported back as fact — sending a maintainer to re-tick an already-ticked box, in two separate sessions.

**When a check contradicts what you can see, read the check.** `contribution-rights` had failed on every pull request since activation because `scripts/contribution-rights-gate.mjs` tested the rights marker's own line for a checkbox, while `.github/PULL_REQUEST_TEMPLATE.md` leaves the marker on a continuation line. Unnoticed for months: not a required check, so everything merged anyway, and the unit fixture encoded the same wrong assumption it was meant to guard. Fixed in #1095.

Docs-only. No code, no dependencies, no build inputs.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> Left unticked deliberately — @DmitriyG228 ticks it. The head commit already carries his DCO sign-off, since the rights path on the parent work was chosen in-session.

## Authorship

Sole author: @DmitriyG228. Claude Code assisted with drafting. No agent co-author trailers.