### PR TITLE
fix(helm): single-replica drain deadlock + the false non-root claim; configurable security context for spawned Pods (#1100, #1101, #1102)

### DIFF
--- a/core/runtime/src/runtime_kernel/config.v1.json
+++ b/core/runtime/src/runtime_kernel/config.v1.json
@@ -108,6 +108,24 @@
    ]
   },
   {
+   "key": "RUNTIME_K8S_POD_SECURITY_CONTEXT",
+   "class": "defaulted",
+   "default": "(unset \u2014 the chart renders this env only when runtime.workloadSecurityContext.pod is set; unset or {} \u21d2 no securityContext is emitted on the spawned Pod)",
+   "description": "k8s backend: JSON PodSecurityContext stamped onto every SPAWNED Pod's spec. A bare `kubectl run` bot/agent Pod inherits nothing from the runtime Deployment and today carries NO security context at all \u2014 the likeliest rejection on a namespace enforcing OpenShift restricted-v2 or the upstream Pod Security restricted profile (#1102). Default-absent is deliberate: the images carry no Dockerfile USER (0 of 15) and run as root, so a defaulted runAsNonRoot would break every existing install. Malformed JSON is fatal at spawn",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
+   "key": "RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT",
+   "class": "defaulted",
+   "default": "(unset \u2014 the chart renders this env only when runtime.workloadSecurityContext.container is set; unset or {} \u21d2 no securityContext is emitted on the spawned container)",
+   "description": "k8s backend: JSON container SecurityContext stamped onto the SPAWNED Pod's container, merged by container name alongside the workspace volumeMounts. Same contract and same default-absent guarantee as RUNTIME_K8S_POD_SECURITY_CONTEXT (#1102). Ordering dependency noted in k8s_backend.pod_overrides: `kubectl run --overrides` replaces the containers LIST wholesale, so this knob is only safe to switch on once the whole-manifest submission from #1005 (PR #1093) lands",
+   "targets": [
+    "helm"
+   ]
+  },
+  {
    "key": "BROWSER_IMAGE",
    "class": "capability",
    "capability": "bot_spawn",

--- a/core/runtime/src/runtime_kernel/k8s_backend.py
+++ b/core/runtime/src/runtime_kernel/k8s_backend.py
@@ -25,13 +25,31 @@ WORKLOAD_ID_LABEL = "runtime.workload_id"
 TOLERATIONS_ENV = "RUNTIME_K8S_TOLERATIONS"      # JSON array of toleration objects
 NODE_SELECTOR_ENV = "RUNTIME_K8S_NODE_SELECTOR"  # JSON object of node-label selectors
 
+# The security context a spawned workload declares, serialized as JSON by the chart from
+# runtime.workloadSecurityContext.{pod,container}. A spawned Pod carries NO securityContext today —
+# no runAsNonRoot, no dropped capabilities, no seccompProfile — which is the likeliest reason a
+# restricted admission policy (OpenShift's `restricted-v2` SCC, or the upstream Pod Security
+# "restricted" profile) rejects it outright. That policy shape cannot be tested on k3d, which has no
+# SCC admission at all, so this is a CONFIGURABLE seam and not a guess about what the policy wants.
+#
+# DEFAULT IS ABSENT, on purpose. This repository's images carry no `USER` directive (0 of 15
+# Dockerfiles), so they run as root; a defaulted `runAsNonRoot: true` would stop every existing
+# operator's bots from starting in order to satisfy one cluster's policy. Whether these images can
+# run as an arbitrary non-root UID at all is untested and tracked separately.
+POD_SECURITY_CONTEXT_ENV = "RUNTIME_K8S_POD_SECURITY_CONTEXT"              # JSON PodSecurityContext
+CONTAINER_SECURITY_CONTEXT_ENV = "RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT"  # JSON SecurityContext
+
 
 def _scheduling_json(env: dict[str, str], key: str, expected: type) -> Optional[object]:
-    """Parse one scheduling knob (``key``) from ``env`` as JSON of ``expected`` shape. Unset or empty
+    """Parse one pod-shaping knob (``key``) from ``env`` as JSON of ``expected`` shape. Unset or empty
     (the chart's default ``[]`` / ``{}`` serialize to ``"[]"`` / ``"{}"``) ⇒ None (no constraint,
     today's behaviour). Malformed JSON or a wrong shape is FATAL (raise) — a scheduling constraint
     silently dropped is exactly the bug this fixes (a stranded Pending Pod, a silent meeting failure),
-    so it must fail loud at spawn, never fail open like the workspace mount set."""
+    so it must fail loud at spawn, never fail open like the workspace mount set.
+
+    Named for its first caller (scheduling); it now also parses the security-context knobs, which
+    need exactly the same contract — a security context silently dropped is a Pod rejected at
+    admission with a cause the operator cannot see."""
     raw = env.get(key)
     if raw is None or (isinstance(raw, str) and not raw.strip()):
         return None
@@ -47,11 +65,13 @@ def _scheduling_json(env: dict[str, str], key: str, expected: type) -> Optional[
 
 
 def _runtime_scheduling_env() -> dict[str, str]:
-    """The runtime's own scheduling knobs from its PROCESS env (set by the chart on the runtime
+    """The runtime's own pod-shaping knobs from its PROCESS env (set by the chart on the runtime
     Deployment). Overlaid onto the per-workload spawn env for ``pod_overrides`` — spec.env cannot
     carry these: it is built per-workload by different producers (meeting-api for a bot, agent-api for
-    an agent worker), whereas the scheduling constraints are a property of the runtime/backend."""
-    return {k: os.environ[k] for k in (TOLERATIONS_ENV, NODE_SELECTOR_ENV) if os.environ.get(k)}
+    an agent worker), whereas the scheduling constraints and the security context are properties of
+    the runtime/backend deployment, decided by the operator who installs the chart."""
+    keys = (TOLERATIONS_ENV, NODE_SELECTOR_ENV, POD_SECURITY_CONTEXT_ENV, CONTAINER_SECURITY_CONTEXT_ENV)
+    return {k: os.environ[k] for k in keys if os.environ.get(k)}
 
 
 def _kubectl(*args: str, check: bool = True) -> subprocess.CompletedProcess:
@@ -73,40 +93,66 @@ def _stop_grace_sec() -> int:
 
 
 def pod_overrides(env: dict[str, str], *, container_name: str) -> Optional[dict]:
-    """The ``kubectl run --overrides`` spec for a spawned Pod, built from the SAME env. It carries two
+    """The ``kubectl run --overrides`` spec for a spawned Pod, built from the SAME env. It carries three
     independent seams:
 
       * the workspace store mount set (WP-A1.1): the store PVC (``VEXA_WORKSPACE_MOUNT_SOURCE`` = the
         claim name on k8s) exposes every in-store workspace via per-mount subPath volumeMounts;
       * the runtime's scheduling constraints (``RUNTIME_K8S_TOLERATIONS`` / ``RUNTIME_K8S_NODE_SELECTOR``)
         so the bare ``kubectl run`` Pod — which inherits none of the runtime Deployment's scheduling —
-        lands where the runtime itself is allowed to run instead of stranding Pending on a tainted pool.
+        lands where the runtime itself is allowed to run instead of stranding Pending on a tainted pool;
+      * the workload security context (``RUNTIME_K8S_POD_SECURITY_CONTEXT`` /
+        ``RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT``) so an operator whose namespace enforces a
+        restricted admission policy can declare what that policy demands, instead of the spawn
+        carrying no security context at all and being rejected with no configurable remedy.
 
-    The spec is built whenever EITHER seam is present; returns None only when neither is (no override
+    The spec is built whenever ANY seam is present; returns None only when none is (no override
     needed). Building it for scheduling alone is load-bearing: a plain meeting bot has no workspace PVC,
     so a volumes-only early return would silently drop its tolerations and re-create the bug. Pure/
-    env-driven → unit-tested offline (no kubectl)."""
+    env-driven → unit-tested offline (no kubectl).
+
+    Both security-context knobs default to ABSENT (the chart's ``{}`` serializes to ``"{}"`` ⇒ None),
+    so an install that does not set them produces exactly the spec it produced before this seam
+    existed — byte-identical."""
     pvc = env.get("VEXA_WORKSPACE_MOUNT_SOURCE")
     root = env.get("VEXA_WORKSPACE_MOUNT_TARGET")
     volumes, volume_mounts = k8s_volume_mounts(env, pvc_name=pvc or "", store_target=root or "")
     tolerations = _scheduling_json(env, TOLERATIONS_ENV, list)
     node_selector = _scheduling_json(env, NODE_SELECTOR_ENV, dict)
-    if not volumes and not tolerations and not node_selector:
+    pod_security_context = _scheduling_json(env, POD_SECURITY_CONTEXT_ENV, dict)
+    container_security_context = _scheduling_json(env, CONTAINER_SECURITY_CONTEXT_ENV, dict)
+    if not any((volumes, tolerations, node_selector, pod_security_context, container_security_context)):
         return None
     # ``kubectl run --overrides`` merges the containers LIST by replacement (json-merge, not
     # strategic), so a containers entry here wipes the generated container — image, env, command —
     # and the API server rejects the Pod (`spec.containers[0].image: Required value`), killing the
-    # spawn instantly. Emit ``containers`` ONLY when volumeMounts force it (the workspace-store
-    # seam); pod-level fields (tolerations/nodeSelector) merge fine without touching the list.
+    # spawn instantly. Emit ``containers`` ONLY when a container-scoped field forces it (the
+    # workspace-store mounts, or the container security context); pod-level fields (tolerations /
+    # nodeSelector / pod securityContext) merge fine without touching the list.
+    #
+    # KNOWN ORDERING DEPENDENCY: that clobbering is a real defect of the ``--overrides`` submission
+    # path, not a hypothetical — it is what #1005's PR (#1093) fixes by submitting a complete Pod
+    # manifest and merging the overlay BY CONTAINER NAME. Until that lands, ANY containers entry
+    # here — including the pre-existing workspace-mount one — is replaced wholesale. So the
+    # CONTAINER-level knob is wired and shaped correctly but is only safe to switch on once the
+    # whole-manifest submission is in place; the POD-level knob is safe today. Both default to
+    # absent, so no existing install is affected either way.
     spec: dict = {}
+    container: dict = {"name": container_name}
     if volume_mounts:
-        spec["containers"] = [{"name": container_name, "volumeMounts": volume_mounts}]
+        container["volumeMounts"] = volume_mounts
+    if container_security_context:
+        container["securityContext"] = container_security_context
+    if len(container) > 1:                               # more than just the name ⇒ worth emitting
+        spec["containers"] = [container]
     if volumes:
         spec["volumes"] = volumes
     if tolerations:
         spec["tolerations"] = tolerations
     if node_selector:
         spec["nodeSelector"] = node_selector
+    if pod_security_context:
+        spec["securityContext"] = pod_security_context
     return {"spec": spec}
 
 

--- a/core/runtime/tests/test_mounts.py
+++ b/core/runtime/tests/test_mounts.py
@@ -255,6 +255,102 @@ def test_k8s_start_overlays_runtime_process_scheduling_env(monkeypatch):
     assert ov["spec"]["nodeSelector"] == _SEL
 
 
+# ── spawned-workload security context: configurable, default ABSENT ──────────
+#
+# A spawned Pod carries NO securityContext today, which is the likeliest reason a restricted
+# admission policy (OpenShift restricted-v2 / Pod Security "restricted") rejects it. The seam below
+# lets an operator declare one. It DEFAULTS TO ABSENT on purpose: this repo's images carry no
+# Dockerfile `USER`, so they run as root, and a defaulted runAsNonRoot would break every existing
+# install. Whether the images tolerate an arbitrary non-root UID is untested and tracked separately.
+
+_POD_SC = {"runAsNonRoot": True, "runAsUser": 1000740000,
+           "seccompProfile": {"type": "RuntimeDefault"}}
+_CTR_SC = {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}}
+
+
+def _sc_env(*, pod=None, container=None, **kw):
+    e = _env(**kw) if kw else {}
+    if pod is not None:
+        e["RUNTIME_K8S_POD_SECURITY_CONTEXT"] = json.dumps(pod)
+    if container is not None:
+        e["RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT"] = json.dumps(container)
+    return e
+
+
+def test_k8s_pod_overrides_default_emits_no_security_context():
+    """THE DEFAULT-ABSENT GUARANTEE. Unset, and the chart's empty default (`{}` → the template emits
+    no env at all; `"{}"` if one ever reaches us) both produce a spec with no securityContext at any
+    level — byte-identical to the pre-seam spawn. This is the assertion that keeps the fix from
+    shipping a break to every operator whose root-running images start fine today."""
+    assert pod_overrides({}, container_name="x") is None
+    assert pod_overrides({"RUNTIME_K8S_POD_SECURITY_CONTEXT": "{}",
+                          "RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT": "{}"},
+                         container_name="x") is None
+    # and with another seam present, the spec still carries no security context anywhere
+    ov = pod_overrides(_sc_env(pod={}, container={}, source="vexa-agent-workspaces"),
+                       container_name="vexa-worker-u1")
+    assert "securityContext" not in ov["spec"]
+    assert "securityContext" not in ov["spec"]["containers"][0]
+
+
+def test_k8s_pod_overrides_pod_level_security_context_needs_no_containers_entry():
+    """A POD-level security context is a pod-scoped field, so it merges without touching the
+    containers LIST — the same property that makes tolerations/nodeSelector safe under
+    `kubectl run --overrides`, whose JSON merge replaces that list wholesale."""
+    ov = pod_overrides(_sc_env(pod=_POD_SC), container_name="vexa-mtg-9")
+    assert ov["spec"]["securityContext"] == _POD_SC
+    assert "containers" not in ov["spec"]                  # list untouched ⇒ image/env/command survive
+
+
+def test_k8s_pod_overrides_container_level_security_context_rides_the_named_container():
+    """A CONTAINER-level security context is container-scoped, so it must ride a containers entry —
+    keyed BY NAME, exactly like the workspace-mount seam it shares the entry with."""
+    ov = pod_overrides(_sc_env(container=_CTR_SC), container_name="vexa-mtg-9")
+    (container,) = ov["spec"]["containers"]
+    assert container["name"] == "vexa-mtg-9"
+    assert container["securityContext"] == _CTR_SC
+    assert "volumeMounts" not in container                 # no PVC ⇒ no mounts, security context stands
+
+
+def test_k8s_pod_overrides_security_context_coexists_with_every_other_seam():
+    """All four seams in one spawn — workspace mounts, scheduling, pod- and container-level security
+    context — with the two container-scoped fields sharing ONE by-name entry rather than two."""
+    ov = pod_overrides(
+        {**_sched_env(tolerations=_TOL, node_selector=_SEL, source="vexa-agent-workspaces"),
+         **_sc_env(pod=_POD_SC, container=_CTR_SC)},
+        container_name="vexa-worker-u1",
+    )
+    spec = ov["spec"]
+    assert spec["securityContext"] == _POD_SC
+    assert spec["tolerations"] == _TOL and spec["nodeSelector"] == _SEL
+    assert spec["volumes"][0]["persistentVolumeClaim"]["claimName"] == "vexa-agent-workspaces"
+    (container,) = spec["containers"]                      # ONE entry, not one per container-scoped seam
+    assert container["securityContext"] == _CTR_SC
+    assert container["volumeMounts"][0]["mountPath"] == "/workspaces/u1"
+
+
+def test_k8s_pod_overrides_malformed_security_context_json_fails_loud():
+    """Same contract as the scheduling knobs: a security context silently dropped is a Pod rejected at
+    admission with a cause the operator cannot see, so malformed input raises at spawn."""
+    with pytest.raises(ValueError, match="RUNTIME_K8S_POD_SECURITY_CONTEXT"):
+        pod_overrides({"RUNTIME_K8S_POD_SECURITY_CONTEXT": "{not json"}, container_name="x")
+    with pytest.raises(ValueError, match="RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT"):
+        pod_overrides({"RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT": "[1,2]"}, container_name="x")
+
+
+def test_k8s_start_overlays_runtime_process_security_context_env(monkeypatch):
+    """The security context is a property of the RUNTIME deployment (the operator installing the
+    chart), not of the workload spec built per-workload by meeting-api/agent-api — so it rides the
+    same process-env overlay the scheduling constraints do."""
+    from runtime_kernel.k8s_backend import _runtime_scheduling_env
+    monkeypatch.setenv("RUNTIME_K8S_POD_SECURITY_CONTEXT", json.dumps(_POD_SC))
+    monkeypatch.setenv("RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT", json.dumps(_CTR_SC))
+    overlay = _runtime_scheduling_env()
+    ov = pod_overrides({**_env(source="vexa-agent-workspaces"), **overlay}, container_name="w")
+    assert ov["spec"]["securityContext"] == _POD_SC
+    assert ov["spec"]["containers"][0]["securityContext"] == _CTR_SC
+
+
 # ── process: shares the host FS — no binds, but N-mount aware (parity) ────────
 
 def test_process_backend_reads_the_mount_set_without_binding(tmp_path):

--- a/deploy/helm/charts/vexa/README.md
+++ b/deploy/helm/charts/vexa/README.md
@@ -61,6 +61,68 @@ Provide your own `labelSelector` in a constraint to opt out of the automatic inj
 default (the shipped value) renders nothing — single-node / k3s installs are unaffected. Use
 `ScheduleAnyway`, not `DoNotSchedule`, unless you can guarantee enough nodes, or pods stay Pending.
 
+## Disruption budgets and single-replica components
+
+The four stateless components ship with a PodDisruptionBudget enabled, paired with `replicaCount: 2`.
+The budgets are expressed as **`maxUnavailable: 1`**, not `minAvailable: 1`, and the template enforces
+that independently: **below two replicas it emits `maxUnavailable: 1` whatever the values say.**
+
+This matters the moment a component drops to one replica, which quota-constrained clusters routinely
+force:
+
+| Budget | at `replicaCount: 2` | at `replicaCount: 1` |
+|---|---|---|
+| `minAvailable: 1` | 1 disruption allowed | **0 allowed — `kubectl drain` hangs forever** |
+| `maxUnavailable: 1` | 1 disruption allowed | 1 allowed — the node drains |
+
+A `minAvailable: 1` budget on a one-replica Deployment buys no availability (there is no peer to fail
+over to) and costs the cluster operator the ability to cordon a node at all. Reported by an operator
+running this chart on a quota-controlled OpenShift cluster; previously the only remedy was to disable
+the PDB by hand.
+
+At three or more replicas `maxUnavailable: 1` is *stricter* than `minAvailable: 1` — one eviction at a
+time rather than N−1. Set `podDisruptionBudgets.<component>.minAvailable` explicitly to choose the
+other trade; it is honoured at two replicas and above, and overridden below that.
+
+Separate from [#990](https://github.com/Vexa-ai/vexa/issues/990), which is about a PDB rendered for a
+*disabled* component and therefore selecting zero pods.
+
+## Security context on spawned workloads
+
+`global.securityContext` / `global.podSecurityContext` apply to the chart's own Deployments. The Pods
+the runtime **spawns** with `runtime.backend: k8s` (meeting bots, agent workers) are bare `kubectl run`
+Pods and inherit nothing from the runtime Deployment — they carry **no security context at all**. On a
+namespace enforcing OpenShift's `restricted-v2` SCC or the upstream Pod Security *restricted* profile,
+that is the likeliest admission rejection.
+
+`runtime.workloadSecurityContext` supplies one. Both halves default to empty, and empty means the
+field is omitted entirely — leave them alone and the spawned Pod spec is byte-identical to before this
+knob existed.
+
+```yaml
+runtime:
+  workloadSecurityContext:
+    pod:                                  # a PodSecurityContext, passed through verbatim
+      runAsNonRoot: true
+      seccompProfile: { type: RuntimeDefault }
+    container:                            # a container SecurityContext, passed through verbatim
+      allowPrivilegeEscalation: false
+      capabilities: { drop: ["ALL"] }
+```
+
+**Read this before setting `runAsNonRoot` or `runAsUser`.** No Dockerfile in this repository contains a
+`USER` directive — 0 of 15, checkable with `git grep -nE '^\s*USER ' -- '*Dockerfile*'` — so every image
+starts as its base image's default UID, which is root. Whether the bot and agent-worker images can run
+as an **arbitrary** non-root UID is **untested**: the bot image runs Chromium under Xvfb and PulseAudio
+and writes to `/app`, `/opt/hf-cache` and `/tmp`; the agent-worker runs a Claude Code harness over a
+mounted workspace. Tracked at [#1102](https://github.com/Vexa-ai/vexa/issues/1102) — the answer needs a
+real image on a real restricted cluster, not a values change. That is precisely why the default here is
+absent rather than hardened-looking.
+
+The values cross the port as `RUNTIME_K8S_POD_SECURITY_CONTEXT` / `RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT`
+(JSON) on the runtime Deployment, the same way `RUNTIME_K8S_TOLERATIONS` / `RUNTIME_K8S_NODE_SELECTOR`
+do. Malformed JSON fails loud at spawn rather than silently dropping the constraint.
+
 ## Validate (no cluster)
 
 ```bash

--- a/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
@@ -119,6 +119,24 @@ spec:
               value: {{ .Values.runtime.tolerations | default .Values.global.tolerations | toJson | quote }}
             - name: RUNTIME_K8S_NODE_SELECTOR
               value: {{ .Values.runtime.nodeSelector | default .Values.global.nodeSelector | toJson | quote }}
+            {{- /* Security context for SPAWNED Pods. Same reason as the scheduling knobs above: a bare
+                 `kubectl run` bot/agent Pod inherits nothing from this Deployment, so it carries no
+                 securityContext at all and a namespace enforcing a restricted admission policy
+                 rejects it with no knob the operator can reach. Emitted ONLY when configured — the
+                 default (`{}`) renders NOTHING here, not even this comment, so the runtime
+                 Deployment and every spawned Pod stay byte-identical to today's and the images
+                 (which have no Dockerfile `USER`, and therefore run as root) keep starting. See
+                 runtime.workloadSecurityContext in values.yaml before setting these. */ -}}
+            {{- with .Values.runtime.workloadSecurityContext }}
+            {{- with .pod }}
+            - name: RUNTIME_K8S_POD_SECURITY_CONTEXT
+              value: {{ toJson . | quote }}
+            {{- end }}
+            {{- with .container }}
+            - name: RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT
+              value: {{ toJson . | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- with .Values.runtime.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/charts/vexa/templates/pdb.yaml
+++ b/deploy/helm/charts/vexa/templates/pdb.yaml
@@ -2,18 +2,37 @@
 PodDisruptionBudget templates.
 
 Rendered once per service block under .Values.podDisruptionBudgets
-when that block has `enabled: true`. Disabled by default on all
-services so `helm install` on a single-replica / single-node cluster
-doesn't block `kubectl drain` during development.
+when that block has `enabled: true`. The four stateless services
+(gateway, adminApi, meetingApi, terminal) ship ENABLED, paired with
+replicaCount 2; runtime and agentApi ship disabled. State-bearing
+infra has no PDB block at all.
 
-On multi-node production clusters, flip `enabled: true` per service
-and raise `replicaCount` + `minAvailable` together — a PDB with
-minAvailable: 1 on a replicaCount: 1 deployment WILL block node
-drains indefinitely, which is typically the opposite of what you
-want.
+THE ONE-REPLICA RULE. `minAvailable: 1` on a component with one
+replica sets disruptionsAllowed to 0: voluntary eviction becomes
+impossible, `kubectl drain` hangs forever, and a cluster operator
+cannot cordon a node — with no availability bought in exchange, since
+the single pod has no peer to fail over to. Any operator who reduces a
+component to one replica (quota-constrained clusters routinely do)
+walks into this by following the chart's own defaults.
+
+So the budget is REPLICA-AWARE: below two replicas this template
+emits `maxUnavailable: 1` regardless of what the block configures.
+That is the only budget expression that is not a deadlock at one
+replica, and it degrades honestly — it protects nothing, because at
+one replica there is nothing to protect.
+
+Reported against the shipped defaults on a quota-constrained cluster
+(#1100). Distinct from #990 (a PDB rendered for a DISABLED component,
+selecting zero pods). That one is about orphaned budgets; this one is about a
+budget on a workload that does exist and has exactly one replica.
 */}}
 {{- range $name, $cfg := .Values.podDisruptionBudgets }}
 {{- if $cfg.enabled }}
+{{/* The PDB map keys ARE the component value keys, so the component's own
+     replicaCount resolves by lookup. Missing/unset ⇒ assume 1 (fail safe:
+     a budget we cannot prove has peers must not be able to block a drain). */}}
+{{- $component := default dict (index $.Values $name) }}
+{{- $replicas := int (default 1 $component.replicaCount) }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -23,12 +42,18 @@ metadata:
     {{- include "vexa.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $name | kebabcase }}
 spec:
-  {{- if hasKey $cfg "minAvailable" }}
+  {{- if lt $replicas 2 }}
+  # {{ $name }}.replicaCount = {{ $replicas }}. A minAvailable budget here would set
+  # disruptionsAllowed=0 and hang every `kubectl drain` of this node; maxUnavailable: 1
+  # is the only non-blocking expression at one replica. Raise replicaCount to 2+ to get
+  # the configured budget back.
+  maxUnavailable: 1
+  {{- else if hasKey $cfg "minAvailable" }}
   minAvailable: {{ $cfg.minAvailable }}
   {{- else if hasKey $cfg "maxUnavailable" }}
   maxUnavailable: {{ $cfg.maxUnavailable }}
   {{- else }}
-  minAvailable: 1
+  maxUnavailable: 1
   {{- end }}
   selector:
     matchLabels:

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -33,8 +33,25 @@ global:
   #       whenUnsatisfiable: ScheduleAnyway
   topologySpreadConstraints: []
   podSecurityContext: {}
-  # Hardened defaults: block privilege escalation, drop all caps. Images run non-root via their
-  # Dockerfile USER. Override per-component only if a workload genuinely needs a cap back.
+  # Hardened defaults: block privilege escalation, drop all capabilities. Override per-component
+  # only if a workload genuinely needs a cap back.
+  #
+  # NON-ROOT IS NOT ASSERTED HERE, and the note that used to claim it was wrong. It said the images
+  # "run non-root via their Dockerfile USER"; no Dockerfile in this repository contains a `USER`
+  # directive — 0 of the 15 tracked Dockerfiles, verifiable with
+  # `git grep -n '^\s*USER ' -- '*Dockerfile*'`. Every image therefore starts as whatever UID its
+  # base image runs as, which is root for all of them.
+  #
+  # So `runAsNonRoot` / `runAsUser` are deliberately absent rather than set to a hardened-looking
+  # value: asserting non-root would be an unverified claim, and on a cluster that enforces it the
+  # container would fail to start (CreateContainerConfigError). Whether these images tolerate an
+  # arbitrary non-root UID at all is untested — tracked at
+  # https://github.com/Vexa-ai/vexa/issues/1102 (the inaccurate comment this replaces: #1101).
+  #
+  # On a cluster that assigns a UID by policy (OpenShift `restricted-v2` allocates one from the
+  # namespace range) the assigned UID wins over the image default regardless of this block, and the
+  # control-plane images have been observed starting that way. The spawned bot / agent-worker Pods
+  # have NOT — see runtime.workloadSecurityContext below.
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -256,6 +273,36 @@ runtime:
   # RUNTIME_K8S_NODE_SELECTOR (JSON) and stamped onto every spawned Pod's spec.
   # tolerations: []            # override global.tolerations for spawned Pods (list of toleration objects)
   # nodeSelector: {}           # override global.nodeSelector for spawned Pods (node-label map)
+  #
+  # Security context for the Pods the runtime SPAWNS (backend=k8s) — NOT global.securityContext
+  # above, which applies to the chart's own Deployments. A spawned bot / agent-worker Pod is a bare
+  # `kubectl run` Pod, so it inherits nothing from the runtime Deployment: today it carries NO
+  # securityContext at all — no runAsNonRoot, no dropped capabilities, no seccompProfile. On a
+  # namespace enforcing a restricted admission policy (OpenShift `restricted-v2`, or the upstream
+  # Pod Security "restricted" profile) that is the likeliest rejection, and the operator currently
+  # has no knob to fix it.
+  #
+  # BOTH DEFAULT TO EMPTY, and empty means the field is omitted entirely — an install that leaves
+  # these alone produces exactly the Pod spec it produced before this seam existed. That default is
+  # deliberate and is NOT an oversight to be "hardened" later without testing: this repository's
+  # images carry no `USER` directive, so they run as root, and defaulting `runAsNonRoot: true` here
+  # would stop every existing operator's bots from starting. Whether the bot and agent-worker images
+  # can run as an arbitrary non-root UID is UNTESTED — read
+  # https://github.com/Vexa-ai/vexa/issues/1102 before setting runAsUser/runAsNonRoot.
+  #
+  # `pod` is a PodSecurityContext, `container` a container SecurityContext; both are passed through
+  # verbatim as JSON, so any field either object supports works without a chart change. Example for
+  # a restricted-profile namespace, once you have confirmed the images tolerate it:
+  #   workloadSecurityContext:
+  #     pod:
+  #       runAsNonRoot: true
+  #       seccompProfile: { type: RuntimeDefault }
+  #     container:
+  #       allowPrivilegeEscalation: false
+  #       capabilities: { drop: ["ALL"] }
+  workloadSecurityContext:
+    pod: {}
+    container: {}
   extraEnv: []
 
 # Agent control plane — /invocations dispatch + /api/chat SSE (compose: agent-api → :8100).
@@ -440,22 +487,37 @@ ingress:
 # ---------- PodDisruptionBudgets (optional) ----------
 # Stateless services default on (paired with replicaCount 2). Keys are the component value keys;
 # kebabcase maps to the component label (e.g. agentApi → agent-api). State-bearing infra stays off.
+#
+# The budgets are expressed as `maxUnavailable`, NOT `minAvailable`. Both keep at least one pod
+# serving at replicaCount 2, but they behave completely differently when a component is reduced to
+# ONE replica — which quota-constrained clusters routinely do:
+#
+#   minAvailable: 1  at replicaCount 1 → disruptionsAllowed 0 → `kubectl drain` HANGS FOREVER.
+#   maxUnavailable: 1 at replicaCount 1 → disruptionsAllowed 1 → the node drains.
+#
+# Reported against the shipped defaults on a quota-constrained cluster (#1100).
+# templates/pdb.yaml enforces this independently: below two replicas it emits `maxUnavailable: 1`
+# whatever a block configures, so an operator who carries a minAvailable override forward from an
+# older values file cannot deadlock their own drains either.
+#
+# At three or more replicas `maxUnavailable: 1` is STRICTER than `minAvailable: 1` (one eviction at
+# a time rather than N-1). That is the intended trade: a rolling drain, not a simultaneous one.
 podDisruptionBudgets:
   gateway:
     enabled: true
-    minAvailable: 1
+    maxUnavailable: 1
   adminApi:
     enabled: true
-    minAvailable: 1
+    maxUnavailable: 1
   meetingApi:
     enabled: true
-    minAvailable: 1
+    maxUnavailable: 1
   terminal:
     enabled: true
-    minAvailable: 1
+    maxUnavailable: 1
   runtime:
     enabled: false        # default replicaCount 1; only enable with backend=k8s + replicas>1
-    minAvailable: 1
+    maxUnavailable: 1
   agentApi:
     enabled: false        # single-replica (shared workspace); don't block drains
-    minAvailable: 1
+    maxUnavailable: 1

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -198,4 +198,56 @@ else
   echo "  FAIL: migrations Job ignored global.imageTag — schema/code skew risk (#900): $MIG_IMG"; fail=1
 fi
 
+# #1100 — a component at replicaCount 1 must NOT get a drain-blocking budget. `minAvailable: 1`
+# on one replica sets disruptionsAllowed=0: `kubectl drain` hangs forever and the operator cannot
+# cordon the node, while protecting nothing. The template is replica-aware, so this holds even when
+# the values explicitly ask for minAvailable — which is the shape an operator carries forward from
+# an older values file. Asserted against the SHIPPED defaults, not values-test.yaml — values-test
+# disables five of the six PDB blocks, so it cannot see the defect an operator actually meets.
+PDB1="$(helm template vexa "$CHART" -n vexa \
+  --set gateway.replicaCount=1 --set adminApi.replicaCount=1 \
+  --set meetingApi.replicaCount=1 --set terminal.replicaCount=1 \
+  --set podDisruptionBudgets.gateway.minAvailable=1 \
+  --show-only templates/pdb.yaml)"
+if grep -qE '^\s+minAvailable:' <<< "$PDB1"; then
+  echo "  FAIL: a PDB renders minAvailable at replicaCount 1 — that deadlocks kubectl drain (#1100)"; fail=1
+else
+  echo "  OK: no minAvailable budget at replicaCount 1 (drains stay possible, #1100)"
+fi
+pdb1_max="$(grep -cE '^\s+maxUnavailable: 1' <<< "$PDB1" || true)"
+if [ "$pdb1_max" -ge 4 ]; then
+  echo "  OK: every enabled PDB degrades to maxUnavailable: 1 at one replica ($pdb1_max)"
+else
+  echo "  FAIL: want >=4 maxUnavailable budgets at replicaCount 1, got $pdb1_max"; fail=1
+fi
+# At two replicas an EXPLICIT minAvailable is the operator's call and must be honoured — the guard
+# is scoped to the deadlock case, not a blanket override.
+PDB2="$(helm template vexa "$CHART" -n vexa \
+  --set gateway.replicaCount=2 --set podDisruptionBudgets.gateway.minAvailable=1 \
+  --show-only templates/pdb.yaml)"
+if grep -qE '^\s+minAvailable: 1' <<< "$PDB2"; then
+  echo "  OK: explicit minAvailable honoured at replicaCount 2 (guard is deadlock-scoped, #1100)"
+else
+  echo "  FAIL: explicit minAvailable dropped at replicaCount 2 — the guard is over-reaching"; fail=1
+fi
+
+# #1102 — spawned-workload security context. DEFAULT ABSENT is the load-bearing property: the images
+# carry no Dockerfile USER and run as root, so a defaulted runAsNonRoot would stop every existing
+# operator's bots. Red->green control direction: nothing when unset, both env vars once set.
+if grep -q 'RUNTIME_K8S_POD_SECURITY_CONTEXT\|RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT' <<< "$RENDER"; then
+  echo "  FAIL: spawned-workload securityContext env rendered with empty default (must render nothing)"; fail=1
+else
+  echo "  OK: no spawned-workload securityContext env when unset (default absent, #1102)"
+fi
+RENDER_SC="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set-json 'runtime.workloadSecurityContext.pod={"runAsNonRoot":true}' \
+  --set-json 'runtime.workloadSecurityContext.container={"allowPrivilegeEscalation":false}' \
+  --show-only templates/deployment-runtime.yaml)"
+if grep -q 'RUNTIME_K8S_POD_SECURITY_CONTEXT' <<< "$RENDER_SC" \
+   && grep -q 'RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT' <<< "$RENDER_SC"; then
+  echo "  OK: runtime carries both spawned-workload securityContext env vars when set (#1102)"
+else
+  echo "  FAIL: spawned-workload securityContext values did not reach the runtime env (#1102)"; fail=1
+fi
+
 [ "$fail" -eq 0 ] && { echo "gate:helm PASS"; exit 0; } || { echo "gate:helm FAIL"; exit 1; }

--- a/docs/changelog.d/1100-1101-pdb-and-nonroot-claim.md
+++ b/docs/changelog.d/1100-1101-pdb-and-nonroot-claim.md
@@ -1,0 +1,26 @@
+- **Single-replica components no longer deadlock node drains ([#1100](https://github.com/Vexa-ai/vexa/issues/1100)).**
+  The chart's default PodDisruptionBudgets were `minAvailable: 1`, which allows **zero** disruptions
+  when a component runs one replica — `kubectl drain` hangs forever and a cluster operator cannot
+  cordon the node, while protecting nothing (a single pod has no peer to fail over to). The shipped
+  budgets are now `maxUnavailable: 1`, and `templates/pdb.yaml` enforces it independently: below two
+  replicas it emits `maxUnavailable: 1` whatever the values say, so an operator carrying an older
+  `minAvailable` override forward cannot deadlock their own drains either. At two replicas the two
+  expressions are equivalent; at three or more `maxUnavailable: 1` is stricter (one eviction at a
+  time), which is the intended trade. Reported by an operator running the chart on a
+  quota-controlled OpenShift cluster, whose only remedy was to disable the PDB by hand.
+- **The chart no longer claims the images run non-root ([#1101](https://github.com/Vexa-ai/vexa/issues/1101)).**
+  `values.yaml` asserted that images "run non-root via their Dockerfile USER". No Dockerfile in this
+  repository contains a `USER` directive — 0 of 15 — so every image starts as its base image's
+  default UID, which is root. The comment now states that, gives the command that verifies it, and
+  explains why `runAsNonRoot`/`runAsUser` are deliberately absent rather than set to an unverified
+  hardened-looking value. No behavioural change.
+- **Spawned bot and agent-worker Pods can carry a security context ([#1102](https://github.com/Vexa-ai/vexa/issues/1102)).**
+  New `runtime.workloadSecurityContext.{pod,container}`. A spawned Pod is a bare `kubectl run` Pod
+  that inherits nothing from the runtime Deployment, so until now it carried no security context at
+  all — the likeliest rejection on a namespace enforcing OpenShift `restricted-v2` or the upstream
+  Pod Security *restricted* profile, and untested, since the only cluster validation this path has
+  had is k3d, which has no SCC admission. Both halves **default to empty and empty omits the field
+  entirely**, so an install that leaves them alone renders byte-identically. The default is absent
+  rather than hardened on purpose: whether these images tolerate an arbitrary non-root UID is an
+  open question tracked at #1102, and a `runAsNonRoot: true` default would break every existing
+  operator's bots to satisfy one cluster's policy.


### PR DESCRIPTION
**Delivers:** [#1100](https://github.com/Vexa-ai/vexa/issues/1100) · [#1101](https://github.com/Vexa-ai/vexa/issues/1101) · builds the seam [#1102](https://github.com/Vexa-ai/vexa/issues/1102) needs, without answering #1102's question.

On **2026-08-05** an engineer running the official chart on a quota-controlled, mirror-only OpenShift cluster reported four things. Two became [#1005](https://github.com/Vexa-ai/vexa/issues/1005) and [#1006](https://github.com/Vexa-ai/vexa/issues/1006), both fixed. **Two were acknowledged in writing that day and never filed** — the PDB deadlock at one replica, and a `values.yaml` comment claiming the images run non-root via a Dockerfile `USER`. They sat in email for five days. This PR files them ([#1100](https://github.com/Vexa-ai/vexa/issues/1100), [#1101](https://github.com/Vexa-ai/vexa/issues/1101)) and fixes them, and adds the configurable security-context seam their restricted-SCC question actually needs.

Base `9fef84bb` → head `bbb1bb25`. Two commits: the runtime seam, then the chart.

---

## What each piece does

### A · A single-replica component can no longer block a node drain (#1100)

`minAvailable: 1` on a Deployment with one replica sets `disruptionsAllowed` to **0**. Voluntary eviction becomes impossible, `kubectl drain` hangs forever, and a cluster operator cannot cordon a node — while nothing is protected, because a single pod has no peer to fail over to. The chart shipped four such budgets enabled by default, so any operator reducing those components to one replica walked into it by following the chart's own defaults. We told the reporter to disable the PDB by hand. The chart should not require that.

Fixed twice over, deliberately:

1. the shipped blocks are now `maxUnavailable: 1` — equivalent at two replicas, and the only non-deadlocking expression at one;
2. `templates/pdb.yaml` is **replica-aware**: below two replicas it emits `maxUnavailable: 1` whatever the block configures, so an operator carrying a `minAvailable` override forward from an older values file cannot deadlock their own drains either. At two replicas and above an explicit `minAvailable` is honoured — the guard is scoped to the deadlock case, not a blanket override.

The template's own docstring claimed PDBs were *"Disabled by default on all services so `helm install` on a single-replica / single-node cluster doesn't block `kubectl drain`"* while the chart shipped four enabled. Corrected.

**Not [#990](https://github.com/Vexa-ai/vexa/issues/990).** That is a budget rendered for a *disabled* component, selecting zero pods (`expectedPods=0`, a persistent `KubePdbNotEnoughHealthyPods` warning). This is a budget on a workload that does exist and has exactly one replica. Both touch `templates/pdb.yaml`; neither subsumes the other, and whichever lands second rebases.

### B · The chart no longer claims the images run non-root (#1101)

`values.yaml` said, above `global.securityContext`: *"Images run non-root via their Dockerfile USER."* **There is no `USER` directive in any Dockerfile in this repository.**

```
$ git ls-files | grep -iE '(^|/)Dockerfile' | grep -v dockerignore | wc -l
      15
$ git grep -nE '^[[:space:]]*USER[[:space:]]' -- '*Dockerfile*'
(no output)
```

**0 of 15.** Every base image in use defaults to root: `python:3.10-slim`, `python:3.12-slim`, `node:20-slim`, `node:22-slim`, `mcr.microsoft.com/playwright:v1.56.0-jammy`, `nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04`, `vexa/meet-join-env:dev`. The only `USER` strings anywhere are `DB_USER=postgres` assignments.

The comment now states that, gives the verification command, and says why `runAsNonRoot` / `runAsUser` are **deliberately absent** rather than replaced with another hardened-looking assertion: setting them would be unverified, and enforcing them would break startup. It also scopes what *is* known — policy-assigned UIDs win over the image default, the reporter's control-plane pods started that way, and the spawned Pods have never been observed doing it.

`allowPrivilegeEscalation: false` and `capabilities.drop: ["ALL"]` stay; those two are real.

### C · Spawned Pods can carry a security context — configurable, default absent (#1102)

The Pods the runtime spawns are bare `kubectl run` Pods that inherit nothing from the runtime Deployment, and they carry **no `securityContext` at all** — no `runAsNonRoot`, no dropped capabilities, no `seccompProfile`. On a restricted SCC that is the likeliest rejection, and it is untested: the only cluster validation this path has had is k3d, which has no SCC admission whatsoever.

New `runtime.workloadSecurityContext.{pod,container}` crosses the port the way [#1005](https://github.com/Vexa-ai/vexa/issues/1005)'s resource intent does — a chart value, rendered onto the runtime Deployment's env, read by the backend — reusing the exact door `RUNTIME_K8S_TOLERATIONS` / `RUNTIME_K8S_NODE_SELECTOR` already use, because a security context is a property of the *runtime deployment* (the operator installing the chart) and not of the per-workload spec that meeting-api and agent-api build.

**The default is absent, and that is the point, not an oversight.** `runAsNonRoot: true` as a default would break every existing operator's bots, because our images have no `USER` and run as root. Shipping that to satisfy one cluster would be shipping a break to everyone else.

**What this PR does not do:** answer whether the bot and agent-worker images can run as an arbitrary non-root UID. That needs a real image on a real restricted cluster — writable paths, `/etc/passwd` presence, Chromium's requirements, the PulseAudio graph. Filed with the evidence at [#1102](https://github.com/Vexa-ai/vexa/issues/1102) rather than guessed at here. #1102 is the spawned-workload half of [#976](https://github.com/Vexa-ai/vexa/issues/976)'s item 1.

---

## Observation bundle

### C1 · The PDB defect reproduces on the shipped chart, render-only

Ran `helm template` on the base commit with the four stateless components at one replica. Saw four budgets, every one drain-blocking. Concluded the reporter's failure is in the chart's defaults, not their overlay.

```
### BEFORE (9fef84bb)  ·  replicaCount=1
    vexa-vexa-admin-api-pdb      minAvailable: 1     ← disruptionsAllowed 0
    vexa-vexa-gateway-pdb        minAvailable: 1     ← disruptionsAllowed 0
    vexa-vexa-meeting-api-pdb    minAvailable: 1     ← disruptionsAllowed 0
    vexa-vexa-terminal-pdb       minAvailable: 1     ← disruptionsAllowed 0
### BEFORE (9fef84bb)  ·  replicaCount=2
    vexa-vexa-admin-api-pdb      minAvailable: 1
    vexa-vexa-gateway-pdb        minAvailable: 1
    vexa-vexa-meeting-api-pdb    minAvailable: 1
    vexa-vexa-terminal-pdb       minAvailable: 1
### AFTER (bbb1bb25)  ·  replicaCount=1
    vexa-vexa-admin-api-pdb      maxUnavailable: 1   ← drains
    vexa-vexa-gateway-pdb        maxUnavailable: 1   ← drains
    vexa-vexa-meeting-api-pdb    maxUnavailable: 1   ← drains
    vexa-vexa-terminal-pdb       maxUnavailable: 1   ← drains
### AFTER (bbb1bb25)  ·  replicaCount=2
    vexa-vexa-admin-api-pdb      maxUnavailable: 1
    vexa-vexa-gateway-pdb        maxUnavailable: 1
    vexa-vexa-meeting-api-pdb    maxUnavailable: 1
    vexa-vexa-terminal-pdb       maxUnavailable: 1
```

Reproduce either side with:

```bash
helm template vexa deploy/helm/charts/vexa \
  --set gateway.replicaCount=1 --set adminApi.replicaCount=1 \
  --set meetingApi.replicaCount=1 --set terminal.replicaCount=1 \
  -s templates/pdb.yaml
```

### C2 · The replica-aware guard beats an explicit `minAvailable`, and only where it must

Ran the head chart with `podDisruptionBudgets.gateway.minAvailable=1` forced — the shape an operator carries forward from an older values file. Saw the guard override it at one replica and stand aside at two. Concluded the guard is scoped to the deadlock rather than confiscating the knob.

```
# replicaCount=1, --set podDisruptionBudgets.gateway.minAvailable=1
  name: vexa-vexa-gateway-pdb
  # gateway.replicaCount = 1. A minAvailable budget here would set
  # disruptionsAllowed=0 and hang every `kubectl drain` of this node; maxUnavailable: 1
  # is the only non-blocking expression at one replica. Raise replicaCount to 2+ to get
  # the configured budget back.
  maxUnavailable: 1

# replicaCount=2, same --set
  name: vexa-vexa-gateway-pdb
  minAvailable: 1                     ← operator intent honoured
```

### C3 · The security-context default is absent, proven by a whole-chart render diff

Ran `helm template` at stock values on both commits and diffed the entire output. Saw the **four PDB budget lines and nothing else** — no security-context env, no whitespace churn. Concluded the new seam is invisible until an operator asks for it, so no existing install changes behaviour.

```diff
$ diff <(helm template vexa <base>/deploy/helm/charts/vexa) \
       <(helm template vexa <head>/deploy/helm/charts/vexa)
14c14
<   minAvailable: 1
---
>   maxUnavailable: 1
33c33
<   minAvailable: 1
---
>   maxUnavailable: 1
52c52
<   minAvailable: 1
---
>   maxUnavailable: 1
71c71
<   minAvailable: 1
---
>   maxUnavailable: 1
```

```
$ helm template vexa deploy/helm/charts/vexa -s templates/deployment-runtime.yaml \
    | grep -c SECURITY_CONTEXT
0
```

### C4 · The seam carries a real restricted-profile context when set

Ran the head chart with a `restricted-v2`-shaped values overlay. Saw both env vars reach the runtime Deployment with the JSON intact. Concluded the values reach the backend that stamps them.

```yaml
runtime:
  workloadSecurityContext:
    pod:       { runAsNonRoot: true, runAsUser: 1000740000, seccompProfile: { type: RuntimeDefault } }
    container: { allowPrivilegeEscalation: false, capabilities: { drop: ["ALL"] } }
```

```
- name: RUNTIME_K8S_POD_SECURITY_CONTEXT
  value: "{\"runAsNonRoot\":true,\"runAsUser\":1000740000,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}}"
- name: RUNTIME_K8S_CONTAINER_SECURITY_CONTEXT
  value: "{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]}}"
```

### C5 · Six offline tests on the backend, five of them red on the base commit

Ran the new `test_mounts.py` cases against **base** `9fef84bb` first, then head. Saw 5 fail / 1 pass, then 6 pass. Concluded the tests bind to the new behaviour rather than passing vacuously.

```
# base 9fef84bb — RED
FAILED test_k8s_pod_overrides_pod_level_security_context_needs_no_containers_entry
FAILED test_k8s_pod_overrides_container_level_security_context_rides_the_named_container
FAILED test_k8s_pod_overrides_security_context_coexists_with_every_other_seam
FAILED test_k8s_pod_overrides_malformed_security_context_json_fails_loud
FAILED test_k8s_start_overlays_runtime_process_security_context_env
5 failed, 1 passed
```

The one that passes on both is `test_k8s_pod_overrides_default_emits_no_security_context` — the default-absent guarantee, which **must** hold before and after. A red there would mean the PR changed default behaviour.

```
# head bbb1bb25 — GREEN
165 passed, 1 skipped        (core/runtime full suite)
```

### C6 · The chart gate carries the fix, and fails without it

Ran `deploy/helm/tests/test_template.sh` at head, then the same five new assertions against the base chart. Concluded the gate would catch a regression of either fix.

```
# head — GREEN
  OK: no minAvailable budget at replicaCount 1 (drains stay possible, #1100)
  OK: every enabled PDB degrades to maxUnavailable: 1 at one replica (4)
  OK: explicit minAvailable honoured at replicaCount 2 (guard is deadlock-scoped, #1100)
  OK: no spawned-workload securityContext env when unset (default absent, #1102)
  OK: runtime carries both spawned-workload securityContext env vars when set (#1102)
gate:helm PASS

# same assertions against the base chart — RED
  FAIL: a PDB renders minAvailable at replicaCount 1 — that deadlocks kubectl drain (#1100)
  FAIL: spawned-workload securityContext values did not reach the runtime env (#1102)
gate:helm FAIL
```

Also green at head: `helm lint` (0 failed), `values-test.yaml` and `values-staging.yaml` render, and `node scripts/gates.mjs config-contract` — which initially **failed** this branch, correctly, because the chart set two env keys the runtime's `config.v1.json` did not declare. Both are declared now (`5 adopted services · 205 declared keys`).

---

## Acceptance

| Row | Evidence |
|---|---|
| A1 · At `replicaCount: 1` no enabled PDB blocks a drain | **GREEN** — C1, red control shown first |
| A2 · At `replicaCount: 2` budgets still permit one disruption and keep one pod serving | **GREEN** — C1 |
| A3 · An explicit `minAvailable` is overridden at one replica, honoured at two | **GREEN** — C2 |
| A4 · The stock render is otherwise unchanged | **GREEN** — C3, whole-chart diff is four lines |
| B1 · The values comment states the 0-of-15 fact with its verification command | **GREEN** — B above; command output quoted |
| B2 · No new unsupported assertion replaces it | **GREEN** — no `runAsNonRoot`/`runAsUser` default introduced anywhere |
| C1 · An operator can supply pod- and container-level security context for spawned workloads | **GREEN** — C4 |
| C2 · Default-absent leaves the spawned Pod spec byte-identical | **GREEN** — C3 + `test_k8s_pod_overrides_default_emits_no_security_context`, which passes on **both** commits |
| C3 · Malformed input fails loud at spawn, not open | **GREEN** — C5 |
| A- · No-regression: runtime suite, gate:helm, gate:config-contract, helm lint at head | **GREEN** — C5, C6 |

---

## Stated honestly — what is NOT proven here

- **No cluster was used.** Every proof above is `helm template` and offline unit tests. That is sufficient for the PDB fix (a rendered budget is the whole artefact) and for the default-absent guarantee, and it is **not** sufficient for the claim that a security context we stamp is *accepted* by a restricted SCC. Nobody on this side has such a cluster. `bbb`, the build host, is at 89% of 14.8 TiB on its image filesystem — above kubelet's 85% GC threshold — so a k3d cluster there cannot reliably start pods right now; and k3d has no SCC admission anyway, so it could not have answered the question even with room.
- **The container-level knob has an ordering dependency, and it is real, not hypothetical.** `kubectl run --overrides` merges the containers list by JSON-merge *replacement*, so any `containers` entry — including the pre-existing workspace-mount one — replaces the generated container and strips its image, env and command. [#1093](https://github.com/Vexa-ai/vexa/pull/1093) fixes that by submitting a complete Pod manifest and merging the overlay by container name. **The pod-level knob is safe today; the container-level knob is shaped, tested and documented but should not be switched on until #1093 lands.** It is unreachable by default, and the constraint is written into `k8s_backend.py` and `config.v1.json` next to the code. This PR does not make that situation worse — it inherits it from the seam it extends.
- **The 0-of-15 `USER` count is exact for this repository only.** `vexa/meet-join-env:dev` is a published base image built elsewhere; nothing in our layers changes its UID, but its own contents were not audited.
- **Nothing here says the bot can run non-root.** See #1102.

## Docs (D6c)

- `deploy/helm/charts/vexa/README.md` — two new sections: the one-replica PDB rule with the `minAvailable` vs `maxUnavailable` table, and spawned-workload security context with the read-this-first warning.
- `deploy/helm/charts/vexa/values.yaml` — the corrected non-root note and the new `runtime.workloadSecurityContext` block, both with the reasoning inline.
- `docs/changelog.d/1100-1101-pdb-and-nonroot-claim.md` — changelog fragment for all three.

## Security checks

No new dependencies, no new network surface, no secrets. The runtime diff parses two additional JSON env values into a Pod spec overlay; the chart diff changes a disruption-budget expression, corrects a comment, and adds two conditionally-rendered env vars. The security-relevant *removal* is a false non-root claim — a values file that told auditors the images were non-root when no image declares a UID.

## Contribution rights

<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> ⚠️ **Left unticked deliberately.** The branch, the proofs and this description were prepared by an
> agent; the rights declaration is a legal certification a human must make. @DmitriyG228 — please
> tick one box. Both commits carry a DCO `Signed-off-by`.

## Validation request

**Requested witness: the original reporter**, on the cluster that produced the report. Two things only they can check:

1. **The PDB fix, on their own overlay.** `helm upgrade` at this head, then `kubectl drain` a node carrying a single-replica component. It should complete instead of hanging, with no PDB disabled by hand.
2. **Whether a restricted-SCC-shaped security context makes a bot spawn admit.** Set `runtime.workloadSecurityContext.container` only (leave `pod` empty until [#1093](https://github.com/Vexa-ai/vexa/pull/1093) merges — see the ordering dependency above) and attempt a real bot spawn. **Do not set `runAsNonRoot`** — our images have no `USER`, and that is exactly the untested question at [#1102](https://github.com/Vexa-ai/vexa/issues/1102). A failure there is the most valuable result this PR can produce, because it would answer #1102.

**Deployment validated:** Helm render only (`helm template`, `helm lint`, `gate:helm`, `gate:config-contract`) plus the offline runtime suite. No Kubernetes cluster, no OpenShift, no container run.
