### PR TITLE
docs: say who validated the FunASR path

### DIFF
--- a/docs/changelog.d/928-funasr-attribution.md
+++ b/docs/changelog.d/928-funasr-attribution.md
@@ -1,0 +1,1 @@
+docs: attribute the FunASR/SenseVoice client validation to the upstream maintainers who ran it, and state plainly that no Vexa maintainer has reproduced it (#928).

--- a/docs/docs/how-to/custom-stt.mdx
+++ b/docs/docs/how-to/custom-stt.mdx
@@ -49,12 +49,13 @@ ids, set the exact served name.
 ## Example: FunASR or SenseVoice
 
 <Note>
-**Client path validated; complete meeting deployment still needs a witness.** Vexa's actual
-`TranscriptionClient` has been run against the FunASR 1.3.26 OpenAI-compatible server with
-SenseVoice on CPU. Chinese, English, Cantonese, Japanese, Korean, and concatenated Chinese-English
-samples all produced non-empty transcripts, verbose segments, and duration metadata. A bot-in-meeting
-run and the `platform_settings` override path remain unwitnessed and are tracked in
-[#863](https://github.com/Vexa-ai/vexa/issues/863).
+**Client path validated upstream; complete meeting deployment still needs a witness.** The FunASR
+maintainers ran Vexa's own `TranscriptionClient` against the FunASR 1.3.26 OpenAI-compatible server
+with SenseVoice on CPU ([#928](https://github.com/Vexa-ai/vexa/pull/928)). Chinese, English,
+Cantonese, Japanese, Korean, and concatenated Chinese-English samples all produced non-empty
+transcripts, verbose segments, and duration metadata. **No Vexa maintainer has reproduced this** — a
+bot-in-meeting run and the `platform_settings` override path remain unwitnessed on either side, and
+are tracked in [#863](https://github.com/Vexa-ai/vexa/issues/863).
 </Note>
 
 Self-hosted FunASR/SenseVoice gateways are reported to be a good fit when you need local Chinese,


### PR DESCRIPTION
Follow-up to [#928](https://github.com/Vexa-ai/vexa/pull/928), promised in its review.

#928 replaced *"no Vexa maintainer has run Vexa against a FunASR or SenseVoice gateway"* with *"Vexa's actual `TranscriptionClient` **has been run** against…"* — passive voice that a reader takes as Vexa having validated the path. The run is the FunASR maintainers', not ours.

That distinction is the whole purpose of the note being replaced. A reader deciding whether to trust this path needs to know the witness is upstream and that we have not reproduced it. Naming the witness makes the evidence **more** useful, not less: an upstream maintainer validating our client is a stronger signal than an anonymous "has been run", and it tells the reader exactly which gap remains.

#928 was merged first rather than held for this, because the page it corrected was instructing readers to set a Hub checkpoint path (`FunAudioLLM/SenseVoiceSmall`) as the served model id, which does not work. Leaving a broken instruction live to preserve an attribution nuance was the worse trade.

Verified against the tree before publishing either change: `TRANSCRIPTION_SERVICE_URL`, `TRANSCRIPTION_MODEL` and the `/v1/audio/transcriptions` shape are exactly as the page describes.

Docs-only. No capability claim is added — one is narrowed.

## Contribution rights
- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

<!-- vexa-agent -->