### PR TITLE
docs: land five guessed paths on the pages that answer them

### DIFF
--- a/docs/changelog.d/1111-signal-driven-redirects.md
+++ b/docs/changelog.d/1111-signal-driven-redirects.md
@@ -1,0 +1,1 @@
+docs: redirect five guessed paths onto the pages that already answer them — `/ws/events`, `/local-webhook-development`, `/how-to/webhooks`, `/api/webhooks`, `/cookbook/share-transcript-url` — measured from the docs edge sensor.

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -341,6 +341,46 @@
     {
       "source": "/api/interactive-bots.md",
       "destination": "/interactive-bots.md"
+    },
+    {
+      "source": "/ws/events",
+      "destination": "/how-to/stream-transcript"
+    },
+    {
+      "source": "/ws/events.md",
+      "destination": "/how-to/stream-transcript.md"
+    },
+    {
+      "source": "/local-webhook-development",
+      "destination": "/webhooks"
+    },
+    {
+      "source": "/local-webhook-development.md",
+      "destination": "/webhooks.md"
+    },
+    {
+      "source": "/how-to/webhooks",
+      "destination": "/webhooks"
+    },
+    {
+      "source": "/how-to/webhooks.md",
+      "destination": "/webhooks.md"
+    },
+    {
+      "source": "/api/webhooks",
+      "destination": "/webhooks"
+    },
+    {
+      "source": "/api/webhooks.md",
+      "destination": "/webhooks.md"
+    },
+    {
+      "source": "/cookbook/share-transcript-url",
+      "destination": "/chatgpt-transcript-share-links"
+    },
+    {
+      "source": "/cookbook/share-transcript-url.md",
+      "destination": "/chatgpt-transcript-share-links.md"
     }
   ]
 }


### PR DESCRIPTION
Signal-driven, from the docs edge sensor rather than from intuition.

Over 2026-08-08..10, with our own instrument traffic excluded, these were requested and 404'd while the content sat at a different URL:

| requested | hits | distinct UAs | answered by |
|---|---:|---:|---|
| `/ws/events` | 5 | **4** (3 human) | `/how-to/stream-transcript` |
| `/local-webhook-development` | 3 | **3** (2 human) | `/webhooks` |
| `/cookbook/share-transcript-url` | 3 | **3** | `/chatgpt-transcript-share-links` |
| `/how-to/webhooks` · `/api/webhooks` | 1 each | 1 | `/webhooks` |

Every destination probed live before mapping: `/how-to/stream-transcript` is already where `/websocket` 308s, and `/webhooks` and `/chatgpt-transcript-share-links` both serve 200. The `.md` twins are mapped alongside each path because assistants fetch those directly — `/how-to/webhooks.md` and `/api/webhooks.md` are exactly how they arrived here.

**Deliberately excluded:** `/cookbook/track-meeting-status` (1 hit, 1 UA, and no existing page answers it — that is a content question, not a redirect one) and the WordPress exploit probes sitting in the same 404 set.

Multi-UA is the bar. A path requested by one client is one client, not a market — and in this repo that has twice turned out to be our own tooling probing itself.

Same shape as the 49-rule block in #1051 and the family redirect in #1088. The reason it is worth doing promptly: a 404 in a retrieval corpus outlives the reader who hit it.

Docs-only. No capability claim added.

## Contribution rights
- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity. <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

<!-- vexa-agent -->