### PR TITLE
fix(terminal): forward workspace DELETE requests (#1034)

### DIFF
--- a/clients/terminal/src/app/api/workspace/[...seg]/__tests__/README.md
+++ b/clients/terminal/src/app/api/workspace/[...seg]/__tests__/README.md
@@ -1,0 +1,3 @@
+# workspace route tests
+
+Regression coverage for the workspace proxy route: workspace deletion, member removal, and invite revocation must forward their `DELETE` requests through the authenticated gateway edge.

--- a/clients/terminal/src/app/api/workspace/[...seg]/__tests__/route.test.ts
+++ b/clients/terminal/src/app/api/workspace/[...seg]/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => (name === "vexa-token" ? { name, value: "alice-tok" } : undefined),
+  }),
+}));
+
+import { DELETE } from "../route";
+
+function makeReq(search = ""): NextRequest {
+  return { nextUrl: { search }, headers: new Headers() } as unknown as NextRequest;
+}
+
+const ctx = (...seg: string[]) => ({ params: Promise.resolve({ seg }) });
+
+beforeEach(() => {
+  delete process.env.NEXT_PUBLIC_TERMINAL_MODE;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("workspace proxy DELETE", () => {
+  const deleteCases: Array<[string, string[], string, string]> = [
+    ["workspace deletion", ["workspace-1"], "", "/agent/workspace/workspace-1"],
+    ["member removal", ["members", "user-2"], "?workspace_id=workspace-1", "/agent/workspace/members/user-2?workspace_id=workspace-1"],
+    ["invite revocation", ["invites", "invite-3"], "?workspace_id=workspace-1", "/agent/workspace/invites/invite-3?workspace_id=workspace-1"],
+  ];
+
+  it.each(deleteCases)("forwards %s to the gateway", async (_name, seg, search, expectedPath) => {
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await DELETE(makeReq(search), ctx(...seg));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toContain(expectedPath);
+    expect(init.method).toBe("DELETE");
+    expect((init.headers as Record<string, string>)["X-API-Key"]).toBe("alice-tok");
+  });
+
+  it("preserves an upstream failure response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ detail: "not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    })));
+
+    const res = await DELETE(makeReq(), ctx("workspace-1"));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ detail: "not found" });
+  });
+});

--- a/clients/terminal/src/app/api/workspace/[...seg]/route.ts
+++ b/clients/terminal/src/app/api/workspace/[...seg]/route.ts
@@ -14,6 +14,39 @@ function refusedResponse(): Response | null {
 // One authenticated edge: workspace KG reads go through the gateway (which injects X-User-Id), not agent-api directly.
 const GATEWAY_URL = (process.env.GATEWAY_URL || "http://127.0.0.1:18056").replace(/\/$/, "");
 
+async function forwardWorkspaceWrite(
+  req: NextRequest,
+  ctx: { params: Promise<{ seg: string[] }> },
+  method: "POST" | "DELETE",
+) {
+  const refused = refusedResponse();
+  if (refused) return refused;
+  const { seg } = await ctx.params;
+  try {
+    const apiKey = await resolveApiKey();
+    const headers: Record<string, string> = apiKey ? { "X-API-Key": apiKey } : {};
+    const init: RequestInit & { duplex?: "half" } = { method, headers };
+
+    if (method === "POST") {
+      headers["Content-Type"] = req.headers.get("Content-Type") ?? "";
+      init.body = req.body;
+      init.duplex = "half";
+    }
+
+    const upstream = await fetch(`${GATEWAY_URL}/agent/workspace/${seg.join("/")}${req.nextUrl.search}`, init);
+    return new Response(await upstream.text(), {
+      status: upstream.status,
+      headers: { "Content-Type": upstream.headers.get("Content-Type") || "application/json" },
+    });
+  } catch (err) {
+    console.error(`[terminal-api] workspace ${method.toLowerCase()} proxy failed`, err);
+    return new Response(JSON.stringify({ error: "upstream_unavailable" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
 export async function GET(req: NextRequest, ctx: { params: Promise<{ seg: string[] }> }) {
   const refused = refusedResponse();
   if (refused) return refused;
@@ -37,29 +70,9 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ seg: string
 }
 
 export async function POST(req: NextRequest, ctx: { params: Promise<{ seg: string[] }> }) {
-  const refused = refusedResponse();
-  if (refused) return refused;
-  const { seg } = await ctx.params;
-  try {
-    const apiKey = await resolveApiKey();
-    const upstream = await fetch(`${GATEWAY_URL}/agent/workspace/${seg.join("/")}${req.nextUrl.search}`, {
-      method: "POST",
-      body: req.body,
-      headers: {
-        "Content-Type": req.headers.get("Content-Type") ?? "",
-        ...(apiKey ? { "X-API-Key": apiKey } : {}),
-      },
-      duplex: "half",
-    } as RequestInit & { duplex: "half" });
-    return new Response(await upstream.text(), {
-      status: upstream.status,
-      headers: { "Content-Type": upstream.headers.get("Content-Type") || "application/json" },
-    });
-  } catch (err) {
-    console.error("[terminal-api] workspace write proxy failed", err);
-    return new Response(JSON.stringify({ error: "upstream_unavailable" }), {
-      status: 502,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
+  return forwardWorkspaceWrite(req, ctx, "POST");
+}
+
+export async function DELETE(req: NextRequest, ctx: { params: Promise<{ seg: string[] }> }) {
+  return forwardWorkspaceWrite(req, ctx, "DELETE");
 }


### PR DESCRIPTION
<!-- The PR carries TWO artifacts, judged on different axes (docs/docs/governance/delivery.mdx D8):
     the OBSERVATION BUNDLE answers "is the value real?"; the DIFF answers "is it correct and safe?".
     A diff with no bundle is not reviewable. -->

> 👋 **Highly recommended (not required): say hi on [Discord](https://discord.gg/Ga9duGkVz9)** and
> tell us, in a sentence or two, **what** you're changing and **why** — the story behind the diff.
> It makes reviewing your value bundle faster and connects you with the reporter and the maintainers.
> Your PR is judged on its evidence, not on whether you show up — but showing up helps a lot.

**Delivers issue:** #1034

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [x] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle (the record of your harnessed loop)

- **C1 —** ran: focused workspace API route tests · saw: all 4 tests passed, covering workspace deletion, member removal, invite revocation, and upstream 404 forwarding · concluded: DELETE requests are forwarded correctly and upstream responses are preserved.

- **C2 —** ran: terminal TypeScript validation · saw: no type errors · concluded: the route changes are type-safe.

- **C3 —** ran: compared the existing `workspaceApi.ts` DELETE calls with the API route · saw: the client already issued DELETE operations that the route did not support · concluded: the route now supports the DELETE operations used by the client.

## Acceptance floor

| Row | Evidence |
|---|---|
| DELETE workspace requests work | DELETE requests are forwarded to the gateway workspace endpoint |
| DELETE member requests work | Member-removal requests use the correct path and authentication |
| DELETE invite requests work | Invite-revocation requests use the correct path and authentication |
| Upstream responses are preserved | Status, response body, and content type are passed through |
| No regression | Focused route tests, TypeScript validation, repository gates, and security checks passed |

## Docs diff (D6c)

No documentation changes are needed. This fixes an existing API route so it supports DELETE requests already issued by the terminal client. It does not change setup, configuration, or user-facing documentation.

## Security checks (required on the diff)

- No dependencies were added or changed.
- No secrets were introduced.
- Existing API-key authentication is preserved.
- Focused route tests and TypeScript validation passed.
- Repository security checks passed.

## Validation request

Please verify workspace deletion, member removal, and invite revocation through the terminal client against a running gateway deployment.

The contributor validated the route with focused tests and TypeScript checks. Live gateway-deployment validation remains for the reviewer or maintainer.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).

Tooling disclosure (optional, welcome, never an attribution): Implemented with assistance from Codex.