### PR TITLE
fix(agent): keep API routines in workspace lifecycle (#1032)

### DIFF
--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -1316,19 +1316,46 @@ def create_app(
     def create_routine(body: RoutineCreate, request: Request):
         if scheduler is None or not invocations_url:
             raise HTTPException(status_code=501, detail="scheduler not wired")
+        subject = subject_of(request)
         try:
             routine = routines_mod.make_routine(
-                subject=subject_of(request), name=body.name, cron=body.cron, prompt=body.prompt,
+                subject=subject,
+                name=body.name,
+                cron=body.cron,
+                prompt=body.prompt,
+                routine_id=workspace_routines_mod.routine_id_for_workspace_file(subject, body.name),
             )
-            job_spec = routines_mod.compile_to_job(routine, invocations_url=invocations_url)
+            workspace_routines_mod.write_routine_file(
+                subject,
+                body.name,
+                cron=body.cron,
+                prompt=body.prompt,
+                workspaces_dir=wsr.root,
+            )
+            workspace_routines_mod.reconcile_workspace_routines(
+                subject,
+                scheduler=scheduler,
+                invocations_url=invocations_url,
+                workspaces_dir=wsr.root,
+            )
         except (ValueError, ValidationError) as e:  # bad cron form / non-conformant routine — fail loud
             raise HTTPException(status_code=400, detail=str(getattr(e, "message", e)))
-        job = scheduler.schedule(job_spec)
+        job = next(
+            (
+                candidate
+                for candidate in scheduler.list_jobs(limit=1000)
+                if (candidate.get("metadata") or {}).get("routine_id") == routine["id"]
+                and (candidate.get("metadata") or {}).get("owner") == subject
+            ),
+            None,
+        )
+        if job is None:
+            raise HTTPException(status_code=500, detail="routine was not scheduled")
         ran_now = False
         if body.run_now:
             # Fire one immediate run via the dispatcher (no HTTP hop) so the author sees a result now.
             try:
-                dispatcher.dispatch(job_spec["request"]["body"])
+                dispatcher.dispatch(job["request"]["body"])
                 ran_now = True
             except Exception:  # noqa: BLE001 — the routine is still scheduled even if the demo run fails
                 ran_now = False
@@ -1379,11 +1406,26 @@ def create_app(
         if scheduler is None:
             raise HTTPException(status_code=501, detail="scheduler not wired")
         subject = subject_of(request)
-        for job in scheduler.list_jobs():
+        matches = []
+        for job in scheduler.list_jobs(limit=1000):
             meta = job.get("metadata") or {}
             if meta.get("routine_id") == routine_id and meta.get("owner") == subject:
+                matches.append(job)
+        if matches:
+            names = {
+                (job.get("metadata") or {}).get("name")
+                for job in matches
+                if (job.get("metadata") or {}).get("name")
+            }
+            for job in matches:
                 scheduler.cancel_job(job["job_id"])
-                return {"ok": True, "routine_id": routine_id}
+            for name in names:
+                workspace_routines_mod.remove_routine_file(
+                    subject,
+                    name,
+                    workspaces_dir=wsr.root,
+                )
+            return {"ok": True, "routine_id": routine_id}
         raise HTTPException(status_code=404, detail="unknown routine")
 
     # ── events (MVP3) — the GENERIC event-source ingress: any event.v1 Event → a unit.v1 dispatch →

--- a/core/agent/control_plane/workspace_routines.py
+++ b/core/agent/control_plane/workspace_routines.py
@@ -199,6 +199,41 @@ def set_routine_file_enabled(
     return path
 
 
+def write_routine_file(
+    subject: str,
+    name: str,
+    *,
+    cron: str,
+    prompt: str,
+    workspaces_dir: str | Path = "/workspaces",
+) -> Path:
+    """Author an API-created routine in the same workspace format as an agent-authored routine."""
+    path = _safe_routine_path(workspaces_dir, subject, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frontmatter = yaml.safe_dump(
+        {"enabled": True, "cron": cron, "prompt": prompt},
+        sort_keys=False,
+        default_flow_style=False,
+    ).rstrip()
+    path.write_text(f"---\n{frontmatter}\n---\n")
+    return path
+
+
+def remove_routine_file(
+    subject: str,
+    name: str,
+    *,
+    workspaces_dir: str | Path = "/workspaces",
+) -> bool:
+    """Remove a routine file if it exists, returning whether a file was removed."""
+    path = _safe_routine_path(workspaces_dir, subject, name)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
 def routine_cards_for_subject(
     subject: str,
     *,
@@ -225,6 +260,15 @@ def routine_cards_for_subject(
     routines_dir = ws / ROUTINES_DIR
     cards: list[dict] = []
     for path in sorted(routines_dir.glob("*.md")) if routines_dir.exists() else []:
+        try:
+            text = path.read_text()
+        except OSError:
+            continue
+        # Workspace seed explanations such as README.md are not routine definitions. Keep the
+        # listing aligned with set_routine_file_enabled(), which requires YAML frontmatter.
+        frontmatter, _ = _split_frontmatter(text, label=path.as_posix())
+        if not frontmatter:
+            continue
         rid = routine_id_for_workspace_file(subject, path.stem)
         job_card = job_by_rid.get(rid)
         cards.append(_routine_card_from_file(path, subject=subject, job_card=job_card))

--- a/core/agent/tests/test_routines.py
+++ b/core/agent/tests/test_routines.py
@@ -116,9 +116,10 @@ def _app(scheduler, *, reader=None):
     )), dispatcher
 
 
-def test_create_and_list_routines_over_http():
+def test_create_list_toggle_and_delete_routine_over_http(tmp_path):
     scheduler = _FakeScheduler()
-    client, dispatcher = _app(scheduler)
+    workspaces = tmp_path / "workspaces"
+    client, dispatcher = _app(scheduler, reader=WorkspaceReader(str(workspaces)))
 
     r = client.post("/api/routines", json={
         "subject": "u_jane", "name": "Morning brief", "cron": "0 8 * * *",
@@ -130,6 +131,8 @@ def test_create_and_list_routines_over_http():
     assert body["ran_now"] is True            # the immediate demo run dispatched the unit
     assert dispatcher.dispatched and dispatcher.dispatched[0]["identity"]["subject"] == "u_jane"
     assert len(scheduler.jobs) == 1           # the cron job is registered
+    routine_path = workspaces / "u_jane" / "routines" / "Morning brief.md"
+    assert routine_path.exists()
 
     listed = client.get("/api/routines", params={"subject": "u_jane"}).json()["routines"]
     assert len(listed) == 1 and listed[0]["name"] == "Morning brief"
@@ -139,10 +142,29 @@ def test_create_and_list_routines_over_http():
     # A different subject sees none (owner-scoped). Subject is the authenticated X-User-Id (P20).
     assert client.get("/api/routines", headers={"X-User-Id": "u_bob"}).json()["routines"] == []
 
-    # Delete cancels the scheduled job.
+    disabled = client.patch(
+        "/api/routines/Morning brief/enabled",
+        params={"subject": "u_jane"},
+        json={"enabled": False},
+    )
+    assert disabled.status_code == 200, disabled.text
+    assert disabled.json()["reconcile"]["cancelled"] == 1
+    assert client.get("/api/routines", params={"subject": "u_jane"}).json()["routines"][0]["enabled"] is False
+
+    enabled = client.patch(
+        "/api/routines/Morning brief/enabled",
+        params={"subject": "u_jane"},
+        json={"enabled": True},
+    )
+    assert enabled.status_code == 200, enabled.text
+    assert enabled.json()["reconcile"]["scheduled"] == 1
+    assert len(scheduler.jobs) == 1
+
+    # Delete cancels the scheduled job and removes the workspace source, so reconcile cannot resurrect it.
     rid = body["routine"]["id"]
     assert client.delete(f"/api/routines/{rid}", params={"subject": "u_jane"}).status_code == 200
     assert scheduler.jobs == []
+    assert not routine_path.exists()
 
 
 def test_routines_501_when_scheduler_not_wired():

--- a/core/agent/tests/test_workspace_routines.py
+++ b/core/agent/tests/test_workspace_routines.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from control_plane.workspace_routines import load_routine_file, reconcile_workspace_routines, set_routine_file_enabled
+from control_plane.workspace_routines import (
+    load_routine_file,
+    reconcile_workspace_routines,
+    routine_cards_for_subject,
+    set_routine_file_enabled,
+)
 from tests.test_routines import _FakeScheduler
 
 
@@ -157,3 +162,23 @@ def test_reconcile_removed_or_disabled_file_cancels_job(tmp_path):
 
     assert result.cancelled == 2
     assert scheduler.jobs == []
+
+
+def test_routine_cards_skip_workspace_readmes(tmp_path):
+    workspaces = tmp_path / "workspaces"
+    _write(workspaces / "u_jane" / "routines" / "README.md", "# Routine examples\n")
+    _write(
+        workspaces / "u_jane" / "routines" / "brief.md",
+        "---\nenabled: true\ncron: '0 9 * * *'\nprompt: Do the brief.\n---\n",
+    )
+    scheduler = _FakeScheduler()
+    reconcile_workspace_routines(
+        "u_jane",
+        scheduler=scheduler,
+        invocations_url="http://agent-api:8100/invocations",
+        workspaces_dir=workspaces,
+    )
+
+    cards = routine_cards_for_subject("u_jane", jobs=scheduler.jobs, workspaces_dir=workspaces)
+
+    assert [card["name"] for card in cards] == ["brief"]


### PR DESCRIPTION
<!-- The PR carries TWO artifacts, judged on different axes (docs/docs/governance/delivery.mdx D8):
     the OBSERVATION BUNDLE answers "is the value real?"; the DIFF answers "is it correct and safe?".
     A diff with no bundle is not reviewable. -->

> 👋 **Highly recommended (not required): say hi on [Discord](https://discord.gg/Ga9duGkVz9)** and
> tell us, in a sentence or two, **what** you're changing and **why** — the story behind the diff.
> It makes reviewing your value bundle faster and connects you with the reporter and the maintainers.
> Your PR is judged on its evidence, not on whether you show up — but showing up helps a lot.

**Delivers issue:** #1032

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [x] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle (the record of your harnessed loop)

- **C1 —** ran: reviewed the routine creation and listing flow · saw: API-created routines were stored only as scheduler jobs while the interface relied on workspace files · concluded: both surfaces were using different sources of truth.

- **C2 —** ran: updated API routine creation · saw: routines are now written to the workspace and reconciled with the scheduler · concluded: API-created routines now follow the same lifecycle as workspace-authored routines.

- **C3 —** ran: updated deletion and routine listing · saw: deleted routine files are removed and frontmatter-free files such as `README.md` are ignored · concluded: deleted routines cannot return and README files are no longer shown as routines.

- **C4 —** ran: added regression tests · saw: create → list → disable → enable → delete is covered, along with README filtering · concluded: the main lifecycle is protected against regression.

- **C5 —** ran: syntax validation and repository checks · saw: Python, Node, gates, Lite smoke, and security checks passed in CI · concluded: the implementation is ready for review.

## Acceptance floor

| Row | Evidence |
|---|---|
| API-created routines appear in the panel | Lifecycle test covers create → list |
| API-created routines can be enabled and disabled | Lifecycle test covers both PATCH transitions |
| Deleted routines stay deleted | Test verifies the scheduler job and workspace file are removed |
| README files are not shown as routines | `test_routine_cards_skip_workspace_readmes` verifies frontmatter filtering |
| No regression | Python, Node, gates, Lite smoke, and security checks passed in CI |

## Docs diff (D6c)

No documentation changes are needed. This fixes the control-plane routine lifecycle without changing setup or user-facing configuration.

## Security checks (required on the diff)

- No dependencies were added or changed.
- No secrets were introduced.
- Existing workspace path-safety validation remains in use.
- No new external services or permissions were added.

## Validation request

Please run:

```bash
pytest core/agent/tests/test_routines.py core/agent/tests/test_workspace_routines.py -q