### PR TITLE
fix(teams-capture): resolve speaker names structurally, not by obfusc…

### DIFF
--- a/core/meetings/modules/teams-capture/src/index.ts
+++ b/core/meetings/modules/teams-capture/src/index.ts
@@ -13,6 +13,8 @@ export {
   teamsNameSelectors,
   teamsParticipantIdSelectors,
   teamsMeetingContainerSelectors,
+  plausibleNameFromLeaves,
+  TEAMS_NAME_FORBIDDEN,
 } from './msteams-speakers.js';
 export type { TeamsSpeakers, TeamsSpeakersOptions, TeamsSpeakerIdentity } from './msteams-speakers.js';
 export { createTeamsChat } from './teams-chat.js';

--- a/core/meetings/modules/teams-capture/src/msteams-speakers.ts
+++ b/core/meetings/modules/teams-capture/src/msteams-speakers.ts
@@ -61,6 +61,57 @@ export const teamsMeetingContainerSelectors: string[] = [
 
 const VOICE_LEVEL_SELECTOR = '[data-tid="voice-level-stream-outline"]';
 
+/** Control-affordance labels that share a tile with the display name and must never be
+ *  mistaken for it. Matched as case-insensitive substrings. */
+export const TEAMS_NAME_FORBIDDEN: string[] = [
+  'more_vert', 'mic_off', 'mic', 'videocam', 'videocam_off',
+  'present_to_all', 'devices', 'speaker', 'speakers', 'microphone',
+  'camera', 'camera_off', 'share', 'chat', 'participant', 'user',
+];
+
+/** First leaf-text fragment in `element` that can plausibly be a display name.
+ *  
+ *  Teams renders the display name in a div whose only distinguishing
+ *  attribute is a build-specific obfuscated class like '___2u340f0'with no data-tid, title or 
+ *  aria-label to key on.
+ *  
+ *  Leaves only ('childElementCount === 0'), so a wrapper's concatenated text can never win.
+ *  De-duplicated, because Teams nests the same name twice. Rejects control labels, bare
+ *  timestamps, and any fragment without a letter in it. 
+ */
+export function plausibleNameFromLeaves(
+  element: { querySelectorAll(sel: string): ArrayLike<{ childElementCount: number; textContent: string | null }> },
+  forbidden: string[] = TEAMS_NAME_FORBIDDEN,
+): string {
+  const seen = new Set<string>();
+  const leaves = element.querySelectorAll('*');
+
+  for (let i = 0; i < leaves.length; i++) {
+    const el = leaves[i];
+
+    // skip non-leaf elements
+    if (el.childElementCount !== 0) continue; 
+
+    const text = (el.textContent || '').trim();
+
+    // skip duplicate text
+    if (!text || seen.has(text)) continue; 
+
+    seen.add(text);
+
+    // skip text that probably isn't a name
+    if (text.length < 2 || text.length > 50) continue;
+    if (!/\p{L}/u.test(text)) continue;                       // digits/glyphs only → not a name
+    if (/^\d{1,2}:\d{2}/.test(text)) continue;                // "10:42 AM"
+
+    // skip text that contains forbidden substrings
+    const lower = text.toLowerCase();
+    if (forbidden.some((sub) => lower.includes(sub.toLowerCase()))) continue;
+    return text;
+  }
+  return '';   // name not resolvable yet — emit NO hint rather than a meaningless GUID
+}
+
 export interface TeamsSpeakerIdentity {
   id: string;
   name: string;
@@ -120,11 +171,7 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
   }
 
   function extractName(element: HTMLElement): string {
-    const forbidden = [
-      'more_vert', 'mic_off', 'mic', 'videocam', 'videocam_off',
-      'present_to_all', 'devices', 'speaker', 'speakers', 'microphone',
-      'camera', 'camera_off', 'share', 'chat', 'participant', 'user',
-    ];
+    const forbidden = TEAMS_NAME_FORBIDDEN;
     for (const selector of teamsNameSelectors) {
       const nameElement = element.querySelector(selector) as HTMLElement | null;
       if (!nameElement) continue;
@@ -145,7 +192,8 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
         if (nameText.length > 1 && nameText.length < 50) return nameText;
       }
     }
-    return '';   // name not resolvable yet — emit NO hint rather than a meaningless GUID
+    // Structural fallback — the durable path; see plausibleNameFromLeaves.
+    return plausibleNameFromLeaves(element, forbidden);
   }
 
   function getIdentity(element: HTMLElement): Identity {

--- a/core/meetings/modules/teams-capture/src/teams-capture.test.ts
+++ b/core/meetings/modules/teams-capture/src/teams-capture.test.ts
@@ -12,6 +12,7 @@ import {
   teamsNameSelectors,
   teamsParticipantIdSelectors,
   teamsMeetingContainerSelectors,
+  plausibleNameFromLeaves,
 } from './index.js';
 
 let failed = 0;
@@ -80,6 +81,50 @@ check('participant selectors are a non-empty string[]', teamsParticipantSelector
 check('name selectors non-empty', teamsNameSelectors.length > 0);
 check('participant-id selectors include [data-tid]', teamsParticipantIdSelectors.includes('[data-tid]'));
 check('container selectors fall back to body', teamsMeetingContainerSelectors.includes('body'));
+
+// ── plausibleNameFromLeaves: the rot-proof name path ──────────────────────────
+// Captured from a live Teams meeting (2026-08): the roster tile carries NO data-tid,
+// title or aria-label, and the name div's only marker is an obfuscated build-specific
+// class. The previously hardcoded `___2u340f0` had rotted to `___12zni01`, which
+// suppressed every speaker hint and collapsed the transcript to a single 'Speaker'.
+{
+  const tile = e('div', { class: '___1504rl1 f1euv43f ftuwxu6 f4d9j23', role: 'menuitem' }, [
+    e('div', { class: '___12zni01 f1cmbuwj fv6wr3j fz5stix f1p9o1ba' }, [
+      t('div', 'Priya Nair', { class: '___12zni01 f1cmbuwj fv6wr3j fz5stix f1p9o1ba' }),
+    ]),
+  ]);
+  check('name: live 2026-08 roster tile resolves despite the rotted class',
+    plausibleNameFromLeaves(tile as never) === 'Priya Nair');
+
+  // A future obfuscated class must not regress it — structure, not the hash, is the key.
+  const rotated = e('div', { class: '___zzzzzz9 whatever', role: 'menuitem' }, [
+    t('div', 'Tariq Baig', { class: '___future0 abc' }),
+  ]);
+  check('name: survives a further class rotation',
+    plausibleNameFromLeaves(rotated as never) === 'Tariq Baig');
+
+  // Control affordances share the tile and must never win.
+  const noisy = e('div', {}, [
+    t('span', 'mic_off', {}),
+    t('span', '10:42 AM', {}),
+    t('span', '2', {}),
+    t('div', 'Priya Nair', {}),
+  ]);
+  check('name: skips control labels, timestamps and bare digits',
+    plausibleNameFromLeaves(noisy as never) === 'Priya Nair');
+
+  // No resolvable name → empty, so emit() still suppresses rather than inventing a GUID.
+  const empty = e('div', {}, [t('span', 'mic_off', {}), t('span', '', {})]);
+  check('name: unresolvable stays empty (no hint is better than a wrong hint)',
+    plausibleNameFromLeaves(empty as never) === '');
+
+  // A wrapper's concatenated text must never win over its leaves.
+  const nested = e('div', {}, [
+    e('div', {}, [t('span', 'Priya Nair', {}), t('span', 'Presenting', {})]),
+  ]);
+  check('name: leaf wins over concatenated wrapper text',
+    plausibleNameFromLeaves(nested as never) === 'Priya Nair');
+}
 
 // ── createTeamsChat extraction ────────────────────────────────────────────────
 {


### PR DESCRIPTION
**Delivers issue:** #1119 

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit carries my DCO `Signed-off-by`.

## Observation bundle (the record of your harnessed loop)

- **C1 — the symptom, and where it is NOT.** ran: three live Teams meetings on the published
  `v012` bot; queried `transcriptions`. saw: 76 segments, **0** carrying a speaker name — every
  turn labelled `Speaker`, one distinct value. Bot logs showed
  `[TeamsSpeakers] Scanned 4 participants, observing 1 with signal` — so detection was alive —
  alongside `hint-counters bridge-crossed=0 pipeline-received=0 binder-matched=0 binder-missed=0`.
  concluded: hints are not merely rejected downstream, they are never emitted. `bridge-crossed`
  increments as the *first* statement of the hint sink, so 0 means the sink was never called.

- **C2 — the gate.** ran: read `msteams-speakers.ts` `emit()` and `extractName()`. saw:
  `if (!identity.name) return;` — every hint is gated on a resolved name. A `Removed:  (13f2…)`
  log line carried an **empty** name. concluded: `extractName()` returns `''`; everything
  downstream is blocked by that one value. The failure is silent and total.

- **C3 — ground truth, not guesswork.** ran: added a temporary dump to `getIdentity()` logging the
  first three unnamed tiles' attributes and text-carrying descendants; rebuilt the bot; ran one
  meeting. saw: the roster tile carries **no `data-tid`, no `title`, no `aria-label`**, and the
  name div's only marker is an obfuscated build class — `___12zni01`, where
  `teamsNameSelectors[0]` hardcodes `___2u340f0`. concluded: selector rot. Writing a new hardcoded
  hash would only reset the rot timer; the fix has to be structural.

- **C4 — the fix.** ran: added `plausibleNameFromLeaves()` — leaf-text scan rejecting control
  labels, timestamps and letterless fragments — mirroring the heuristic fallback the chat reader in
  this same module already uses (`teams-chat.ts:109`). Hoisted it to module scope and exported it
  so the name path is unit-testable for the first time. saw: typecheck clean, 16/16 tests green.
  concluded: the existing selector list still runs first and is unchanged; the fallback only
  engages when it misses.

- **C5 — live witness.** ran: rebuilt the bot from this branch, ran a live Teams meeting with two
  German-speaking participants. saw: **13/13 confirmed segments correctly attributed by name**,
  two distinct speakers, against 0 of 76 before. concluded: value is real at the altitude of the
  claim (D12 — speaker behaviour needs a live multi-speaker meeting).

## Acceptance floor

| Row | Evidence |
|---|---|
| **A1 — red→green on the live DOM** | RED: the pre-fix selector-only path against the captured tile returns `""`. GREEN: `✅ name: live 2026-08 roster tile resolves despite the rotted class`. Base sha `4c1612d8`. |
| **A2 — rot-resistance (the actual defect class)** | `✅ name: survives a further class rotation` — fixture uses a deliberately invented future class (`___future0`), so the next Teams build cannot regress this the way `___2u340f0` did. |
| **A3 — negative control, shown red** | `✅ name: unresolvable stays empty (no hint is better than a wrong hint)` — a tile with no name-shaped text still yields `''`, so `emit()` suppresses rather than inventing a GUID. No green-on-empty. |
| **A4 — no false positives from tile furniture** | `✅ name: skips control labels, timestamps and bare digits` and `✅ name: leaf wins over concatenated wrapper text`. |
| **A5 — no regression** | 16/16 tests pass; the 11 pre-existing chat/selector tests are untouched and green. `tsc --noEmit` clean. |
| **A6 — live, multi-speaker** | 13/13 confirmed segments named across 2 speakers on a real Teams call; 0/76 on the same stack before the change. |

## Docs diff (D6c)

No docs change. This is an internal DOM-extraction fallback inside `@vexa/teams-capture` with no
reader-facing surface: no new configuration, no API field, no changed behaviour to teach. The
user-visible effect is that documented behaviour (named speakers) starts working again. If
reviewers would rather see the rot hazard recorded for operators, the natural home is a short note
in the Teams section of the bots docs — happy to add it.

## Security checks (required on the diff)

- **Dependencies:** none added, removed or upgraded. The module still has zero runtime
  dependencies (`package.json` unchanged) — nothing for a licence scan to flag (P17).
- **Secrets:** none introduced. Test fixtures use invented names (`Priya Nair`, `Tariq Baig`),
  matching the fictional names already used by this file's chat tests. No captured meeting content,
  no real participant names, no hostnames.
- **SAST/injection surface:** the new code is pure string inspection of DOM text — no `eval`, no
  `innerHTML`, no network, no filesystem, no dynamic selector construction. It reads
  `textContent` and returns a string. Runs in the browser context with no new privileges.
- **Input handling:** length-bounded (2–50 chars) and character-class filtered, so hostile page
  text cannot produce an unbounded or control-character speaker label.

## Validation request

**Who:** any competent non-author; the originating reporter preferred. Needs a Microsoft Teams
account and one other participant.

**What they'll watch:** join a Teams meeting with 2+ people who each speak, then confirm the
transcript shows **distinct participant names** rather than a single `Speaker`. Corroborating
instrument channels: `hint-counters bridge-crossed` > 0 in the bot log (it was 0 before), and
`select speaker, count(*) from transcriptions where meeting_id = <id> group by 1` showing more
than one distinct value.

**Deployment validated (D12b):** full Docker Compose stack (`deploy/compose`), published images at
tag `v012`, with the meeting bot rebuilt from this branch via `make -C deploy/compose bot`
(`vexa/vexa-bot:dev`). Long-lived install, base sha `4c1612d8`. Env deltas from stock: Microsoft
OAuth configured, MinIO host ports remapped off a portainer collision, self-hosted
`deploy/transcription` unit (`large-v3`, `int8`) reached over the compose network.

**Not validated:** Lite, k8s/helm and hosted. This change is browser-side DOM extraction with no
deployment-specific path, so I expect no divergence — but nobody ran them, so they stay honestly
unclaimed.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): diagnosis, patch drafting and the
test fixtures were produced in a Claude Code session; every claim above was checked against the
running stack and the numbers come from its database.

---

## Known and deliberately out of scope

Pending drafts are persisted with their own segment ids (`turn:44:p0` beside the confirmed
`turn:44:0`), and a draft emitted before its hint binds keeps the `Speaker` fallback — so a UI
rendering both shows the same utterance twice, once mislabelled. In the validation meeting this was
1 of 24 segments. `pipeline.ts:146` says "late attribution still repaints by segment_id", but the
draft and the confirmed segment have *different* ids, so nothing supersedes the draft.

This is independent of selector rot, lives in the mixed lane's publish/persist path rather than in
`teams-capture`, and would affect any platform on that lane. It is **not** the same as #868, which
concerns valid names being *rejected at binding* by a confidence gate; this is a draft published
*before* a name exists. Happy to file it separately.