### PR TITLE
fix(mixed): hallucination gate, gap-reclaim, and the v0.12.22 release freeze [4/4 v0.12.22]

### DIFF
--- a/core/meetings/modules/mixed-capture-core/src/index.ts
+++ b/core/meetings/modules/mixed-capture-core/src/index.ts
@@ -11,8 +11,13 @@ export { createMixedAudioCapture } from './mixed-audio.js';
 export type { MixedAudioCapture, MixedAudioOptions } from './mixed-audio.js';
 export { installRemoteAudioHook, observedPeerConnections } from './webrtc-audio-hook.js';
 export type { WebRtcAudioHookOptions, ObservedPeerConnection } from './webrtc-audio-hook.js';
-export { selectTeamsMixStreams, TEAMS_MAIN_AUDIO_GRACE_MS } from './teams-main-audio.js';
-export type { TeamsMixSelection, MainAudioAbsentObservation, StreamLike } from './teams-main-audio.js';
+export {
+  selectTeamsMixStreams, mainAudioProvedSilent,
+  TEAMS_MAIN_AUDIO_GRACE_MS, TEAMS_MAIN_AUDIO_SILENCE_MS, TEAMS_MAIN_AUDIO_ENERGY_RMS,
+} from './teams-main-audio.js';
+export type {
+  TeamsMixSelection, MainAudioAbsentObservation, MainAudioSilentObservation, StreamLike,
+} from './teams-main-audio.js';
 // The transport sensor: RTP contributing sources → active/inactive transitions (observation only).
 export { createCsrcPoll, toEpochMs, CSRC_POLL_MS, CSRC_INACTIVE_MS } from './csrc-poll.js';
 export type {

--- a/core/meetings/modules/mixed-capture-core/src/teams-main-audio.test.ts
+++ b/core/meetings/modules/mixed-capture-core/src/teams-main-audio.test.ts
@@ -8,7 +8,7 @@
  *
  * Run: npx tsx src/teams-main-audio.test.ts
  */
-import { selectTeamsMixStreams, type StreamLike } from './teams-main-audio.js';
+import { selectTeamsMixStreams, mainAudioProvedSilent, type StreamLike } from './teams-main-audio.js';
 
 let failed = 0;
 const check = (name: string, cond: boolean, detail = ''): void => {
@@ -80,6 +80,42 @@ const stream = (...ids: string[]): StreamLike => ({ getAudioTracks: () => ids.ma
 {
   const r = selectTeamsMixStreams([], { firstMissMs: null, nowMs: 1_000_000 });
   check('no streams at all is handled without throwing', r.streams.length === 0, r.outcome);
+}
+
+// ── 8. PRESENCE IS NOT LIVENESS. The mix appeared, was captured, and carried pure silence.
+// Observed live on staging 2026-08-11: three remote tracks mirrored, the mainAudio pick connected,
+// and not one word ever transcribed — no boundaries, no turns, every speaker hint missed. ──
+{
+  check('a mix that has never been captured is NOT yet silent (no premature abandon)',
+    mainAudioProvedSilent({ captureStartedMs: null, energeticMs: 0, nowMs: 1_000_000 }) === false);
+  check('inside the silence window it is given the benefit of the doubt',
+    mainAudioProvedSilent({ captureStartedMs: 1_000_000, energeticMs: 0, nowMs: 1_010_000, silenceMs: 20_000 }) === false);
+  check('a mix that carried ANY energy is never abandoned, however quiet the room since',
+    mainAudioProvedSilent({ captureStartedMs: 1_000_000, energeticMs: 40, nowMs: 9_000_000, silenceMs: 20_000 }) === false);
+  check('captured past the window with zero energy is proved dead',
+    mainAudioProvedSilent({ captureStartedMs: 1_000_000, energeticMs: 0, nowMs: 1_020_000, silenceMs: 20_000 }) === true);
+}
+
+// ── 9. The verdict changes the pick: a PRESENT but silent mix falls back to every track. ──
+{
+  const all = [stream('abc-1'), stream('mainAudio-0'), stream('def-2')];
+  const healthy = selectTeamsMixStreams(all, { firstMissMs: null, nowMs: 1_000_000 });
+  check('while the mix looks alive it is still preferred alone',
+    healthy.outcome === 'main-audio' && healthy.streams.length === 1, healthy.outcome);
+
+  const dead = selectTeamsMixStreams(all,
+    { firstMissMs: null, nowMs: 1_000_000, mainAudioSilent: true, mainAudioCapturedMs: 21_000 });
+  check('a mix proved silent is abandoned for ALL tracks',
+    dead.outcome === 'fallback-all' && dead.streams.length === 3, `${dead.outcome}/${dead.streams.length}`);
+  check('and it says why, naming the tracks so the pick is diagnosable',
+    dead.observation?.kind === 'main-audio-silent' && (dead.observation as any).capturedMs === 21_000
+      && (dead.observation?.trackIds || []).includes('mainAudio-0'),
+    JSON.stringify(dead.observation));
+
+  const rescans = [1_000_000, 1_002_000, 1_004_000].map((now) =>
+    selectTeamsMixStreams(all, { firstMissMs: null, nowMs: now, mainAudioSilent: true, mainAudioCapturedMs: 21_000 }));
+  check('the silent fallback re-reports on every rescan too (no one-shot latch)',
+    rescans.every((r) => r.observation?.kind === 'main-audio-silent'));
 }
 
 if (failed) { console.error(`\n❌ teams-main-audio: ${failed} check(s) FAILED.`); process.exit(1); }

--- a/core/meetings/modules/mixed-capture-core/src/teams-main-audio.ts
+++ b/core/meetings/modules/mixed-capture-core/src/teams-main-audio.ts
@@ -39,33 +39,100 @@ export interface MainAudioAbsentObservation {
   action: string;
 }
 
+/** Emitted whenever the mix was PRESENT and picked, but carried no energetic audio at all. */
+export interface MainAudioSilentObservation {
+  kind: 'main-audio-silent';
+  platform: 'teams';
+  /** How long the picked mix was captured before it was abandoned. */
+  capturedMs: number;
+  streamCount: number;
+  trackIds: string[];
+  action: string;
+}
+
 export interface TeamsMixSelection {
   /** The streams to feed the mixer. */
   streams: StreamLike[];
   /** 'main-audio' — the mix alone · 'waiting' — inside grace, capture nothing yet ·
-   *  'fallback-all' — grace expired, capturing everything (possibly double-fed). */
+   *  'fallback-all' — capturing everything, because the mix never appeared OR never carried sound. */
   outcome: 'main-audio' | 'waiting' | 'fallback-all';
-  observation?: MainAudioAbsentObservation;
+  observation?: MainAudioAbsentObservation | MainAudioSilentObservation;
 }
 
 export const TEAMS_MAIN_AUDIO_GRACE_MS = 15000;
 
+/** How long a PICKED mix may stay wholly silent before it is abandoned for every track. */
+export const TEAMS_MAIN_AUDIO_SILENCE_MS = 20000;
+
+/** Matches the lane's own silence floor (chunked-transcriber DROP_RMS / turn-source DEATH_RMS). */
+export const TEAMS_MAIN_AUDIO_ENERGY_RMS = 0.006;
+
+/**
+ * Has the picked mix proved itself DEAD — captured for long enough, with no energetic audio ever?
+ *
+ * The absence fallback above only ever asked "did a mainAudio track appear?". A track that appears
+ * and then carries pure silence answers yes and passes every check, so the bot captures a silent
+ * stream for the whole meeting while three real ones sit mirrored and unused. That produces no
+ * pyannote boundaries, so no turn ever opens, so every speaker hint arrives with nothing to overlap
+ * and no audio is ever submitted for transcription — an empty transcript from a completely healthy
+ * looking bot. Worse, the lane's own rescue path cannot fire either: the transport watchdog demotes
+ * csrc back to pyannote only after CSRC_DEATH_MS of ENERGETIC audio, which silence never supplies.
+ * Presence is not liveness, and this is the check that says so.
+ *
+ * @param captureStartedMs  when the picked mix first produced a capture callback (null = not yet)
+ * @param energeticMs       accumulated ms of audio at or above the energy floor
+ */
+export function mainAudioProvedSilent(
+  { captureStartedMs, energeticMs, nowMs, silenceMs = TEAMS_MAIN_AUDIO_SILENCE_MS }:
+    { captureStartedMs: number | null; energeticMs: number; nowMs: number; silenceMs?: number },
+): boolean {
+  if (captureStartedMs === null) return false;   // nothing captured yet — not evidence of silence
+  if (energeticMs > 0) return false;             // it spoke at least once; it is a real mix
+  return nowMs - captureStartedMs >= silenceMs;
+}
+
 const hasMainAudio = (s: StreamLike): boolean =>
   (s.getAudioTracks?.() || []).some((t) => String(t?.id || '').toLowerCase().startsWith('mainaudio'));
+
+const trackIdsOf = (streams: StreamLike[]): string[] =>
+  (streams || [])
+    .flatMap((s) => (s.getAudioTracks?.() || []).map((t) => String(t?.id || '')))
+    .slice(0, 8);
 
 /**
  * @param streams      every mirrored remote stream
  * @param firstMissMs  when the mix was FIRST observed missing (the caller persists this across rescans)
  * @param nowMs        current time
  * @param graceMs      how long to wait for the mix before falling back
+ * @param mainAudioSilent  the caller's latched verdict from `mainAudioProvedSilent` — the picked mix
+ *                     was captured and never carried sound, so it must not be preferred again
+ * @param mainAudioCapturedMs  how long that silent mix was captured, for the report
  */
 export function selectTeamsMixStreams(
   streams: StreamLike[],
-  { firstMissMs, nowMs, graceMs = TEAMS_MAIN_AUDIO_GRACE_MS }:
-    { firstMissMs: number | null; nowMs: number; graceMs?: number },
+  { firstMissMs, nowMs, graceMs = TEAMS_MAIN_AUDIO_GRACE_MS, mainAudioSilent = false, mainAudioCapturedMs = 0 }:
+    { firstMissMs: number | null; nowMs: number; graceMs?: number; mainAudioSilent?: boolean; mainAudioCapturedMs?: number },
 ): TeamsMixSelection {
   const main = (streams || []).filter(hasMainAudio);
-  if (main.length) return { streams: main, outcome: 'main-audio' };
+  if (main.length && !mainAudioSilent) return { streams: main, outcome: 'main-audio' };
+
+  // The mix is THERE but proved silent: take everything instead. Doubled words are recoverable;
+  // a silent meeting is not. Re-emitted on every rescan, like the absent case, so a bot running on
+  // the fallback never looks healthy while capturing the wrong thing.
+  if (main.length && mainAudioSilent) {
+    return {
+      streams: streams || [],
+      outcome: 'fallback-all',
+      observation: {
+        kind: 'main-audio-silent',
+        platform: 'teams',
+        capturedMs: Math.max(0, Math.round(mainAudioCapturedMs)),
+        streamCount: (streams || []).length,
+        trackIds: trackIdsOf(streams),
+        action: 'mainAudio mix was picked but carried NO energetic audio — capturing ALL tracks instead',
+      },
+    };
+  }
 
   const waitedMs = firstMissMs === null ? 0 : Math.max(0, nowMs - firstMissMs);
   if (waitedMs < graceMs) return { streams: [], outcome: 'waiting' };

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -164,6 +164,9 @@ const TAIL_DEDUP_REACH_MS = 4000;
  *  re-asserted about every 2 s, so a second either way catches the current speaker without reaching
  *  into the neighbouring turn. Tunable via VEXA_CONTESTED_HINT_TOLERANCE_MS. */
 const CONTESTED_HINT_TOLERANCE_MS = Number((typeof process !== 'undefined' && process.env?.VEXA_CONTESTED_HINT_TOLERANCE_MS) || 1000);
+/** Tile re-assertions a participant must have somewhere in the meeting before the tiles may be used
+ *  to rule FOR or AGAINST them in a contested span. */
+const CONTESTED_MIN_TILE_EVIDENCE = Number((typeof process !== 'undefined' && process.env?.VEXA_CONTESTED_MIN_TILE_EVIDENCE) || 3);
 /** Comparison tokens: case- and punctuation-insensitive, so "глюнки." matches "глюнки". */
 const tokens = (t: string): string[] => (t.toLowerCase().match(/[\p{L}\p{N}']+/gu) ?? []);
 const ORPHAN_ADJACENT_MS = Number((typeof process !== 'undefined' && process.env?.VEXA_ORPHAN_ADJACENT_MS) || 1500);
@@ -1298,7 +1301,6 @@ export class ChunkedTranscriber {
     const src = this.csrcSource;
     if (!src || this.authoritative !== 'csrc') return [{ name: fallbackName, ...seg }];
     const words = seg.words?.filter((w) => typeof w.start === 'number' && (w.word ?? '').trim());
-    if (!words || words.length === 0) return [{ name: fallbackName, ...seg }];
 
     const nameAt = (tMs: number): string => {
       const o = src.ownerAt(tMs);
@@ -1314,16 +1316,37 @@ export class ChunkedTranscriber {
         // sees the outline move; the speaker re-emits one every couple of seconds while the held
         // source emits nothing. A strict majority within a second either side decides it, and two
         // people genuinely talking at once still tie and still resolve to nobody.
-        const lit = this.trackNamer.hintLeaderAt(tMs, CONTESTED_HINT_TOLERANCE_MS)
-          ?? this.trackNamer.litNameAt(tMs);
-        if (lit) {
-          for (const t of src.tracksAudibleAt(tMs)) {
-            if (this.trackNamer.nameFor(t) === this.trackNamer.canonicalCase(lit)) return this.trackNamer.labelFor(t);
+        // THE TILES ONLY GET A VOTE IF THEY CAN TESTIFY ABOUT EVERYONE IN THE MIX. On the m30 tape
+        // the outline lights for exactly ONE of the two participants for the whole meeting, so a
+        // tile majority there says "leo" no matter who is speaking — one-sided by construction, and
+        // reading the other man's silence as absence put nine wrong names into the transcript the
+        // first time this rule ran. A signal that has never once named someone cannot be evidence
+        // that they are not the one talking.
+        const audible = src.tracksAudibleAt(tMs);
+        const everyoneTestified = audible.every((t) => {
+          const n = this.trackNamer.nameFor(t);
+          return n !== null && this.trackNamer.hintEvidenceFor(n) >= CONTESTED_MIN_TILE_EVIDENCE;
+        });
+        if (everyoneTestified) {
+          const lit = this.trackNamer.hintLeaderAt(tMs, CONTESTED_HINT_TOLERANCE_MS)
+            ?? this.trackNamer.litNameAt(tMs);
+          if (lit) {
+            for (const t of audible) {
+              if (this.trackNamer.nameFor(t) === this.trackNamer.canonicalCase(lit)) return this.trackNamer.labelFor(t);
+            }
           }
         }
       }
       return PROVISIONAL_SPEAKER;
     };
+
+    // WITHOUT word timestamps the segment is still a span, and the span still has an owner. Falling
+    // back to the turn's own name here meant a decoder that returns no words could never resolve a
+    // contested span at all — every one of them would publish as "Speaker" no matter how clearly the
+    // tiles said who was talking. Ask once, for the whole segment, at its midpoint.
+    if (!words || words.length === 0) {
+      return [{ name: nameAt((seg.startMs + seg.endMs) / 2), ...seg }];
+    }
 
     const out: Array<{ name: string; text: string; startMs: number; endMs: number; language: string }> = [];
     for (const w of words) {

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -160,6 +160,10 @@ const TAIL_DEDUP_CHARS = 120;
 const TAIL_DEDUP_MIN_TOKENS = 3;
 /** Only windows starting this close behind the confirmed boundary can be re-emitting it. */
 const TAIL_DEDUP_REACH_MS = 4000;
+/** How far either side of a contested instant to count tile re-assertions. A speaker's outline is
+ *  re-asserted about every 2 s, so a second either way catches the current speaker without reaching
+ *  into the neighbouring turn. Tunable via VEXA_CONTESTED_HINT_TOLERANCE_MS. */
+const CONTESTED_HINT_TOLERANCE_MS = Number((typeof process !== 'undefined' && process.env?.VEXA_CONTESTED_HINT_TOLERANCE_MS) || 1000);
 /** Comparison tokens: case- and punctuation-insensitive, so "глюнки." matches "глюнки". */
 const tokens = (t: string): string[] => (t.toLowerCase().match(/[\p{L}\p{N}']+/gu) ?? []);
 const ORPHAN_ADJACENT_MS = Number((typeof process !== 'undefined' && process.env?.VEXA_ORPHAN_ADJACENT_MS) || 1500);
@@ -1300,9 +1304,18 @@ export class ChunkedTranscriber {
       const o = src.ownerAt(tMs);
       if (o.trackId) return this.trackNamer.labelFor(o.trackId);
       if (o.contested) {
-        // The transport says two people are audible. The tiles get the casting vote — but only if
-        // they name exactly one person AND that person owns one of the tracks in the mix.
-        const lit = this.trackNamer.litNameAt(tMs);
+        // The transport says two sources are audible — but on the staging Jacob call that claim was
+        // mostly the mixer HOLDING a source open, not two people speaking: both tracks read active
+        // across 2% of the meeting yet produced 22% of the rows, all of them refused, all of them
+        // in the middle of one man's continuous speech. Asking whether a tile was LIT could not
+        // separate them, because a lit interval survives silence by construction.
+        //
+        // So ask which tile was being RE-ASSERTED instead. A hint event is emitted when the watcher
+        // sees the outline move; the speaker re-emits one every couple of seconds while the held
+        // source emits nothing. A strict majority within a second either side decides it, and two
+        // people genuinely talking at once still tie and still resolve to nobody.
+        const lit = this.trackNamer.hintLeaderAt(tMs, CONTESTED_HINT_TOLERANCE_MS)
+          ?? this.trackNamer.litNameAt(tMs);
         if (lit) {
           for (const t of src.tracksAudibleAt(tMs)) {
             if (this.trackNamer.nameFor(t) === this.trackNamer.canonicalCase(lit)) return this.trackNamer.labelFor(t);

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -82,6 +82,13 @@ const SILENCE_PROMPT_RESET_MS = 3000;
 /** Cap on the UNCONFIRMED window — if stability stalls this long, the open turn
  *  force-rolls into a fresh turn (everything confirms). Inside Whisper's input. */
 const TURN_MAX_MS = 28_000;
+/** PROVISIONAL CUT. A continuous monologue produces no boundary, so its first FINAL used to wait
+ *  for the speaker to pause — measured at ~9 s on a live meeting, which is the founder's latency
+ *  complaint. Past this much unconfirmed audio the open turn is rolled: everything so far confirms
+ *  and a fresh turn continues on the SAME track, so attribution is untouched and only the
+ *  granularity of the finals changes. Well inside TURN_MAX_MS, which remains the Whisper-window
+ *  bound rather than a latency control. Tunable via VEXA_PROVISIONAL_CUT_MS. */
+const PROVISIONAL_CUT_MS = Number((typeof process !== 'undefined' && process.env?.VEXA_PROVISIONAL_CUT_MS) || 4000);
 /** Pyannote's speech-end frame can land a little early. On a clean
  *  speaker→silence close, send a small trailing context pad to STT so final
  *  phones/words survive, while clipping published timestamps to the committed
@@ -146,6 +153,15 @@ const TURN_SOURCE_GRACE_MS = Number((typeof process !== 'undefined' && process.e
 /** What an unattributable piece is published as. The host renders a provisional segmentation id the
  *  same way; naming it here keeps the two spellings of "we do not know" in one place. */
 const PROVISIONAL_SPEAKER = 'Speaker';
+/** How much of the just-confirmed text is remembered for the re-emission check. */
+const TAIL_DEDUP_CHARS = 120;
+/** Shortest repeat treated as a re-emission rather than as speech. Two tokens is a real thing a
+ *  person says twice ("да, да"); this is deliberately above that. */
+const TAIL_DEDUP_MIN_TOKENS = 3;
+/** Only windows starting this close behind the confirmed boundary can be re-emitting it. */
+const TAIL_DEDUP_REACH_MS = 4000;
+/** Comparison tokens: case- and punctuation-insensitive, so "глюнки." matches "глюнки". */
+const tokens = (t: string): string[] => (t.toLowerCase().match(/[\p{L}\p{N}']+/gu) ?? []);
 const ORPHAN_ADJACENT_MS = Number((typeof process !== 'undefined' && process.env?.VEXA_ORPHAN_ADJACENT_MS) || 1500);
 
 export interface ChunkSegment {
@@ -369,6 +385,8 @@ export class ChunkedTranscriber {
   private latestAudioMs = 0;
   private pumping = false;
   private lastConfirmedText = '';
+  /** The tail of the most recently confirmed text — what a re-emission would repeat. */
+  private lastConfirmedTail = '';
   /** Audio-time end of the last processed commit — used to detect the silence
    *  gap that resets the prompt (SILENCE_PROMPT_RESET_MS). */
   private lastAudioEndMs = 0;
@@ -465,6 +483,18 @@ export class ChunkedTranscriber {
       // drain loop; with no further boundaries nothing would re-pump it.
       if (t.queue.length > 0) { void t.pump(); return; }
       if (!t.turn) return;
+      // A monologue confirms on a cadence instead of waiting for a pause. Only fires while the
+      // turn is genuinely growing (unconfirmed audio beyond the cut length) and has text pending,
+      // so a silent open turn is not chopped into empty pieces.
+      if (t.turn.trackId
+        && t.turn.pendingTail.length > 0
+        && t.latestAudioMs - t.turn.confirmedUpToMs > PROVISIONAL_CUT_MS) {
+        const rolled = t.turn;
+        t.queue.push({ kind: 'close', t1: t.latestAudioMs });
+        t.queue.push(t.rollOpen(rolled, t.latestAudioMs));
+        void t.pump();
+        return;
+      }
       if (t.latestAudioMs - t.turn.confirmedUpToMs > TURN_MAX_MS) {
         // The roll is a Whisper-window bound, not a speaker change: the successor is the SAME
         // speaker, so it inherits the track. Dropping the trackId here would hand every monologue
@@ -1051,6 +1081,33 @@ export class ChunkedTranscriber {
     }
     turn.lastVoicedWallMs = this.now();   // voiced update arrived — resets the TTL idle-finalize
 
+    // TAIL DEDUP — the second half of the overlap fix. Advancing the window is the structural cure,
+    // but a decoder handed a window that STARTS mid-phrase will still sometimes reach backwards for
+    // context it can hear in the ring's pad. So a leading run of tokens that merely repeats the end
+    // of what was just confirmed is dropped, bounded hard: only at the very start of the first
+    // segment, only when the repeat is at least MIN tokens (so a genuine "да, да" survives), and
+    // only while the window begins close behind the confirmed boundary.
+    if (this.lastConfirmedTail && mapped.length > 0 && spanStart <= this.confirmedHighWaterMs + TAIL_DEDUP_REACH_MS) {
+      const first = mapped[0];
+      const tailTokens = tokens(this.lastConfirmedTail);
+      const headTokens = tokens(first.text);
+      let repeat = 0;
+      for (let n = Math.min(tailTokens.length, headTokens.length); n >= TAIL_DEDUP_MIN_TOKENS; n--) {
+        if (tailTokens.slice(-n).join(' ') === headTokens.slice(0, n).join(' ')) { repeat = n; break; }
+      }
+      if (repeat > 0) {
+        const kept = first.text.split(/\s+/).slice(repeat).join(' ').trim();
+        this.log(`[ChunkedTranscriber] dropped ${repeat} leading token(s) duplicating the confirmed tail`);
+        if (kept) {
+          first.text = kept;
+          if (first.words && first.words.length > repeat) first.words = first.words.slice(repeat);
+        } else {
+          mapped.shift();
+          if (mapped.length === 0) { if (closing) await this.closeOut(turn); return; }
+        }
+      }
+    }
+
     // LocalAgreement-N (shared confirm core, @vexa/transcribe-buffer): confirm whole
     // leading segments whose words are stable across N (default 3) consecutive
     // submissions; the still-forming tail stays pending. On close everything confirms.
@@ -1105,8 +1162,25 @@ export class ChunkedTranscriber {
       if (!cs) { cs = []; this.clusterSegments.set(turn.clusterId, cs); }
       cs.push(...pieces.filter((p) => p.name === name).map((p) => p.seg));
       this.clusterName.set(turn.clusterId, name);
-      turn.confirmedUpToMs = spanStart + mapped[confirmCount - 1].relEnd * 1000;
+      // ADVANCE PAST WHAT WAS CONFIRMED, USING THE MOST PRECISE BOUNDARY AVAILABLE.
+      //
+      // The window used to advance to the whisper SEGMENT's end, which is routinely earlier than
+      // the audio that produced it. The next window therefore re-fed the tail of already-final
+      // speech, Whisper re-emitted it as the new row's prefix, and — because only DRAFTS can be
+      // retracted and a confirmed row is immutable — the duplicate published. On m36 that is the
+      // pair "Есть какие-то реал-тайм глюнки." followed by "Есть какие-то реал-тайм глюнки, но, в
+      // основном, …": one pause, one resume, one sentence said twice.
+      //
+      // Word timestamps make the boundary exact, so use the last CONFIRMED WORD's end where the
+      // decoder gave us one and fall back to the segment's end where it did not. Audio that has
+      // produced a final is never transcribed again.
+      const lastConfirmed = mapped[confirmCount - 1];
+      const lastWord = lastConfirmed.words?.[lastConfirmed.words.length - 1];
+      const boundaryRelSec = Math.max(lastConfirmed.relEnd, lastWord?.end ?? 0);
+      turn.confirmedUpToMs = spanStart + boundaryRelSec * 1000;
       this.confirmedHighWaterMs = Math.max(this.confirmedHighWaterMs, turn.confirmedUpToMs);
+      // Remember the tail of what just went out, so a re-emission of it can be recognised as one.
+      this.lastConfirmedTail = confirmed.map((c) => c.text).join(' ').slice(-TAIL_DEDUP_CHARS);
       const txt = confirmed.map(s => s.text).join(' ');
       this.lastConfirmedText = (this.lastConfirmedText + ' ' + txt).slice(-PROMPT_TAIL_CHARS * 2);
       turn.pendingName = !closing && tail.length > 0 ? name : null;

--- a/core/meetings/modules/mixed-pipeline/src/track-namer.ts
+++ b/core/meetings/modules/mixed-pipeline/src/track-namer.ts
@@ -382,6 +382,16 @@ export class TrackNamer {
     return ranked[0][0];
   }
 
+  /** How many times this name's tile has been re-asserted all session. Zero means the UI has never
+   *  once testified about this person — and a signal that has never named someone cannot be read as
+   *  evidence that they are NOT the one speaking. */
+  hintEvidenceFor(name: string): number {
+    const want = this.canonicalCase(name).toLowerCase();
+    let n = 0;
+    for (const ev of this.hintEvents) if (this.canonicalCase(ev.name).toLowerCase() === want) n++;
+    return n;
+  }
+
   /** The ONE name the UI showed lit at this instant, or null when none or several were. Used only
    *  to break a tie the transport itself cannot: when two sources are audible, the tiles are the
    *  second, independent opinion about which of THOSE TWO was speaking. Constrained to names the

--- a/core/meetings/modules/mixed-pipeline/src/track-namer.ts
+++ b/core/meetings/modules/mixed-pipeline/src/track-namer.ts
@@ -523,7 +523,13 @@ export class TrackNamer {
 
   /** Can this track's leading candidate be believed yet? */
   private evaluate(trackId: string, atMs: number): void {
-    if (this.named.has(trackId)) return;
+    const existing = this.named.get(trackId);
+    // A track named by ELIMINATION may still be re-examined, for one purpose only: to upgrade the
+    // record when direct evidence arrives for the same name. Elimination can beat the evidence path
+    // to the punch — on the m36 tape a track was labelled [elimination] while holding 46.9 s of its
+    // own unambiguous DOM evidence, so the audit trail understated its own confidence and read as
+    // the weaker claim. The NAME never changes here; only the account of how it was reached.
+    if (existing && existing.source === 'evidence') return;
     const byName = this.evidence.get(trackId);
     if (!byName) return;
     // EVIDENCE FOR SOMEONE ELSE'S NAME IS NOT DISAGREEMENT. A track accrues time for a name that
@@ -550,11 +556,26 @@ export class TrackNamer {
     const total = ranked.reduce((s, e) => s + e.supportMs, 0);
     const share = total > 0 ? lead.supportMs / total : 0;
     if (share < this.minShare) return;                        // this track's tiles disagree
-    if (this.owner.has(lead.name)) return;                    // that person is already someone else
+    const holder = this.owner.get(lead.name) ?? this.owner.get(this.canonicalCase(lead.name));
+    if (holder !== undefined && holder !== trackId) return;   // that person is already someone else
     // Exclusivity the other way: does this track hold the clear majority of that NAME's evidence?
     let nameTotal = 0;
     for (const [, m] of this.evidence) { const e = m.get(lead.name); if (e) nameTotal += e.supportMs; }
     if (nameTotal > 0 && lead.supportMs / nameTotal < this.minOwnerShare) return;
+    if (existing) {
+      // Same name, better provenance: upgrade in place. A DIFFERENT name is never accepted — an
+      // elimination that has already been published is not overturned by later evidence, it is a
+      // contradiction worth seeing rather than silently resolving.
+      if (existing.name !== this.canonicalCase(lead.name) && existing.name !== lead.name) {
+        this.log(`track ${trackId} evidence names "${lead.name}" but it was already eliminated to "${existing.name}" — keeping the published name`);
+        return;
+      }
+      existing.source = 'evidence';
+      existing.confidence = share;
+      existing.evidence = ranked;
+      this.log(`track ${trackId} upgraded to [evidence] (${Math.round(lead.supportMs)}ms over ${lead.episodes} episode(s))`);
+      return;
+    }
     this.bind(trackId, lead.name, 'evidence', share, ranked, atMs,
       `${Math.round(lead.supportMs)}ms over ${lead.episodes} episode(s), share ${share.toFixed(2)}`);
   }

--- a/core/meetings/modules/mixed-pipeline/src/track-namer.ts
+++ b/core/meetings/modules/mixed-pipeline/src/track-namer.ts
@@ -190,6 +190,9 @@ export class TrackNamer {
   private rosterPolluted = new Set<string>();
   /** The producer's own account of whether it could name everyone it could see. */
   private rosterCoverage: { named: number; participants: number } | null = null;
+  /** Raw, lag-corrected hint arrivals — the POSITIVE evidence, as opposed to the merged intervals
+   *  above which are mostly the absence of an end event. Bounded like everything else here. */
+  private hintEvents: Array<{ name: string; tMs: number }> = [];
   /** lowercased name → the roster's own casing, so a tile that renders "leo" and a roster that
    *  renders "Leo" do not become two people, and the rendered form is the one Teams considers
    *  canonical. Never rewrites the name itself — a " (Unverified)" suffix is Teams' statement. */
@@ -239,6 +242,10 @@ export class TrackNamer {
   /** A DOM tile lit (or explicitly went dark). */
   recordHint(name: string, tMs: number, isEnd = false): void {
     if (!name || this.unnameable(name)) return;
+    if (!isEnd) {
+      this.hintEvents.push({ name, tMs: tMs - HINT_LAG_MS });
+      if (this.hintEvents.length > 20_000) this.hintEvents.splice(0, this.hintEvents.length - 20_000);
+    }
     this.paint(name, tMs - HINT_LAG_MS, HINT_GRACE_MS, 'dom', isEnd);
   }
 
@@ -342,6 +349,39 @@ export class TrackNamer {
   /** The name this track earned, or null. NEVER a guess. */
   nameFor(trackId: string): string | null { return this.named.get(trackId)?.name ?? null; }
 
+  /**
+   * The name whose tile was RE-ASSERTED most often around this instant, or null when nothing leads.
+   *
+   * `litNameAt` asks whether a tile was lit, and on the staging Jacob call that question could not
+   * separate anybody: the mixer held both sources active for the whole of each contested span and
+   * both tiles read lit throughout, so every one of eighteen spans in the middle of one man's
+   * continuous speech published as "Speaker" — with correctly named rows on both sides of them.
+   *
+   * A lit INTERVAL is mostly the absence of an end event: it is extended by grace and it survives
+   * silence. A hint EVENT is positive evidence, emitted when the watcher sees the outline move, and
+   * a speaker who is actually talking re-emits one every couple of seconds. Counting the events
+   * rather than measuring the interval separates the person speaking from the person the mixer is
+   * merely still carrying — 1308 events for the man speaking against 97 for the man held open, on
+   * that call.
+   *
+   * A strict majority is required, so two people genuinely talking at once still resolves to
+   * nobody.
+   */
+  hintLeaderAt(tMs: number, tolMs: number): string | null {
+    const from = tMs - tolMs;
+    const to = tMs + tolMs;
+    const votes = new Map<string, number>();
+    for (const ev of this.hintEvents) {
+      if (ev.tMs < from) continue;
+      if (ev.tMs > to) break;                    // the log is append-ordered
+      votes.set(ev.name, (votes.get(ev.name) ?? 0) + 1);
+    }
+    if (votes.size === 0) return null;
+    const ranked = [...votes.entries()].sort((a, b) => b[1] - a[1]);
+    if (ranked.length > 1 && ranked[0][1] === ranked[1][1]) return null;   // a tie decides nothing
+    return ranked[0][0];
+  }
+
   /** The ONE name the UI showed lit at this instant, or null when none or several were. Used only
    *  to break a tie the transport itself cannot: when two sources are audible, the tiles are the
    *  second, independent opinion about which of THOSE TWO was speaking. Constrained to names the
@@ -426,6 +466,7 @@ export class TrackNamer {
     this.trackSpans.clear(); this.nameSpans.clear(); this.evidence.clear();
     this.named.clear(); this.owner.clear(); this.roster.clear(); this.canonical.clear();
     this.rosterPolluted.clear(); this.rosterCoverage = null; this.order = []; this.letters.clear();
+    this.hintEvents = [];
     this.upTo = 0; this.newest = 0; this.origin = null; this.episode = null;
   }
 

--- a/core/meetings/services/bot/build-browser-utils.mjs
+++ b/core/meetings/services/bot/build-browser-utils.mjs
@@ -73,6 +73,7 @@ import {
   createMixedAudioCapture,
   installRemoteAudioHook,
   selectTeamsMixStreams,
+  mainAudioProvedSilent,
   createCsrcPoll,
 } from ${JSON.stringify(MIXED)};
 import {
@@ -103,6 +104,7 @@ const VexaBrowserUtils = {
   createMixedAudioCapture,   // capture-bridge.ts: w.VexaBrowserUtils.createMixedAudioCapture
   installRemoteAudioHook,
   selectTeamsMixStreams,     // capture-bridge.ts setupMix: Teams mix vs fail-open (one impl, unit-tested)
+  mainAudioProvedSilent,     // capture-bridge.ts setupMix: presence is not liveness — abandon a silent mix
   createCsrcPoll,            // capture-bridge.ts: the transport sensor (RTP contributing sources → transitions)
   // ── recording (all platforms): MediaRecorder → recording.v1 chunks ──
   createRecordingTap,        // capture-bridge.ts: w.VexaBrowserUtils.createRecordingTap

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -781,7 +781,7 @@ export async function startCaptureBridge(
   // ── Start the page-side capture (VexaBrowserUtils preferred; production inline fallback). ──
   // The body of this callback runs IN THE BROWSER (Playwright serializes it); DOM globals are
   // reached via globalThis (this file type-checks against the Node lib — no DOM types here).
-  await page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName, mainAudioGraceMs }) => {
+  await page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName, mainAudioGraceMs, mainAudioSilenceMs, mainAudioEnergyRms }) => {
     const w = (globalThis as any) as Record<string, any>;
     if (isMixed) {
       // Zoom/Teams: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
@@ -802,7 +802,27 @@ export async function startCaptureBridge(
           // implementation; a hand-copied twin here would drift from the test on the first edit.
           const select = w.VexaBrowserUtils?.selectTeamsMixStreams;
           if (select) {
-            const sel = select(streams, { firstMissMs: w.__vexaTeamsNoMainSince ?? null, nowMs: Date.now(), graceMs: mainAudioGraceMs });
+            // PRESENCE IS NOT LIVENESS. A mainAudio track that appears and then carries pure silence
+            // passes the absence check forever, so the bot captures nothing while the real tracks sit
+            // mirrored and unused — and the lane's own csrc→pyannote watchdog cannot rescue it,
+            // because that demotion needs ENERGETIC audio to fire. Latch the verdict once (so the
+            // pick cannot oscillate as the fallback's own audio arrives) and keep reporting it.
+            const provedSilent = w.VexaBrowserUtils?.mainAudioProvedSilent;
+            if (!w.__vexaTeamsMainAudioDead && provedSilent?.({
+              captureStartedMs: w.__vexaMixCaptureStartedMs ?? null,
+              energeticMs: w.__vexaMixEnergeticMs || 0,
+              nowMs: Date.now(),
+              silenceMs: mainAudioSilenceMs,
+            })) {
+              w.__vexaTeamsMainAudioDead = true;
+            }
+            const sel = select(streams, {
+              firstMissMs: w.__vexaTeamsNoMainSince ?? null,
+              nowMs: Date.now(),
+              graceMs: mainAudioGraceMs,
+              mainAudioSilent: !!w.__vexaTeamsMainAudioDead,
+              mainAudioCapturedMs: w.__vexaMixCaptureStartedMs ? Date.now() - w.__vexaMixCaptureStartedMs : 0,
+            });
             if (sel.outcome === 'main-audio') { w.__vexaTeamsNoMainSince = null; }
             else { w.__vexaTeamsNoMainSince = w.__vexaTeamsNoMainSince || Date.now(); }
             // Re-emitted on EVERY falling-back rescan, deliberately: the latched one-shot warning it
@@ -843,7 +863,20 @@ export async function startCaptureBridge(
         }
         if (!w.__vexaMixedCapture && w.__vexaMixSeen.size && w.VexaBrowserUtils?.createMixedAudioCapture) {
           w.__vexaMixedCapture = true; // guard re-entry while the async create resolves
-          Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(w.__vexaMixDest.stream, (pcm: Float32Array) => w.__vexaPerSpeakerAudioData(0, Array.from(pcm))))
+          // Meter the mix as it is captured: the silence verdict above needs to know whether the
+          // stream we PICKED ever carried sound, and this callback is the only place that sees it.
+          const meterAndForward = (pcm: Float32Array): void => {
+            if (w.__vexaMixCaptureStartedMs === undefined || w.__vexaMixCaptureStartedMs === null) {
+              w.__vexaMixCaptureStartedMs = Date.now();
+            }
+            let sum = 0;
+            for (let i = 0; i < pcm.length; i++) sum += pcm[i] * pcm[i];
+            if (pcm.length && Math.sqrt(sum / pcm.length) >= mainAudioEnergyRms) {
+              w.__vexaMixEnergeticMs = (w.__vexaMixEnergeticMs || 0) + (pcm.length / 16000) * 1000;
+            }
+            w.__vexaPerSpeakerAudioData(0, Array.from(pcm));
+          };
+          Promise.resolve(w.VexaBrowserUtils.createMixedAudioCapture(w.__vexaMixDest.stream, meterAndForward))
             .then((cap: any) => { w.__vexaMixedCapture = cap; return cap?.start?.(); })
             .then(async () => {
               await w.__vexaRemoteAudioReady?.();
@@ -1020,7 +1053,10 @@ export async function startCaptureBridge(
     }
   }, { isMixed: mixed, isJitsi: jitsi, isTeams: inv.platform === 'teams', isZoom: inv.platform === 'zoom', botName: inv.botName,
       // How long the Teams lane waits for the server mix before capturing every track instead.
-      mainAudioGraceMs: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_GRACE_MS || 15000) }).catch((e) => {
+      mainAudioGraceMs: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_GRACE_MS || 15000),
+      // How long a PICKED mix may stay wholly silent before the lane abandons it for every track.
+      mainAudioSilenceMs: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_SILENCE_MS || 20000),
+      mainAudioEnergyRms: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_ENERGY_RMS || 0.006) }).catch((e) => {
     console.error(`[bot] capture bridge: page-side start failed: ${String(e)}`); // L4: surfaces only on the VM
   });
 

--- a/core/meetings/services/bot/src/pipeline.test.ts
+++ b/core/meetings/services/bot/src/pipeline.test.ts
@@ -177,12 +177,24 @@ async function main(): Promise<void> {
 
     const junk = sink.published.find((s) => s.segment_id === 'turn:54:0');
     const real = sink.published.find((s) => s.segment_id === 'turn:55:0');
-    check('unattributed turn: speaker is the stable "Speaker" label, not the seg_N cluster id',
-      junk?.speaker === 'Speaker', JSON.stringify(junk));
+    // Founder ruling (rc.3 witness call): a row we could not attribute publishes an EMPTY speaker.
+    // "Speaker" advertised a failed claim to the customer in their own transcript; a blank reads as
+    // continuation. The refusal is not hidden — speaker_key below still carries the track identity,
+    // and the observations sidecar carries why — it just stops being addressed to the reader.
+    check('unattributed turn: speaker is EMPTY, never the seg_N id and never a "Speaker" placeholder',
+      junk?.speaker === '', JSON.stringify(junk));
     check('unattributed turn: segment_id keeps the unique turn key (late-attribution repaint anchor)',
       junk?.segment_id === 'turn:54:0', junk?.segment_id);
-    check('unattributed turn: speaker_key keeps the unique turn key (NOT collapsed to "Speaker")',
+    check('unattributed turn: speaker_key keeps the unique turn key — the identity survives the blank',
       junk?.speaker_key === 'turn:54:0', junk?.speaker_key);
+    // The letter tracks are the other spelling of "a distinct person we could not name", and the
+    // founder's ruling was about unknown speakers plural — they blank too.
+    cb!.publish('Speaker B', [{ text: 'and this', startMs: 3000, endMs: 4000, language: 'en', segmentId: 'turn:56:0' }], []);
+    await sleep(20);
+    const letter = sink.published.find((s) => s.segment_id === 'turn:56:0');
+    check('a letter track ("Speaker B") also publishes an empty speaker',
+      letter?.speaker === '', JSON.stringify(letter));
+    check('…and keeps its own identity in speaker_key', letter?.speaker_key === 'turn:56:0', letter?.speaker_key);
     check('no seg_N string ever leaks as a display speaker across the mixed lane',
       sink.published.every((s) => !/^seg_\d+$/.test(s.speaker ?? '')), JSON.stringify(sink.published.map((s) => s.speaker)));
     check('a REAL speaker name passes through the boundary untouched',

--- a/core/meetings/services/bot/src/pipeline.ts
+++ b/core/meetings/services/bot/src/pipeline.ts
@@ -111,7 +111,9 @@ const isoFromEpochSeconds = (s: number | undefined): string | undefined =>
 function toBotSegment(seg: LaneSegment): TranscriptSegment {
   return {
     segment_id: seg.segment_id,
-    speaker: seg.speaker,
+    // The gmeet lane publishes the same 'Speaker' placeholder for an unnamed channel, and it
+    // reaches the same dashboard — so it gets the same treatment. One rule, both lanes.
+    speaker: displaySpeaker(seg.speaker ?? ''),
     speaker_key: seg.speaker_key,
     text: seg.text,
     start: seg.start,
@@ -157,14 +159,34 @@ function laneSink(publish: TranscriptSink['publish'], onError?: (e: unknown) => 
  *  `startMs/1000` is epoch seconds. Without it the live `:mutable` bundle carries a null
  *  absolute_start_time and the dashboard renderer SKIPS every pending draft (it keys on absolute
  *  time), so Teams/Zoom transcripts only appeared after a reload (the REST read re-derives it). */
+/**
+ * Labels that name NOBODY, in every spelling the lane produces: the provisional segmentation id,
+ * the word the lane publishes it as, and the stable letter a distinct-but-unnamed transport track
+ * carries. All three are INTERNAL — they are how the lane talks to itself about a refusal.
+ */
+const UNATTRIBUTED_LABEL = /^(?:seg_\d+|Speaker|Speaker [A-Z]+)$/;
+
+/**
+ * What a viewer sees when we could not name the speaker: NOTHING.
+ *
+ * Founder ruling from the rc.3 witness call. A row labelled "Speaker" advertises a failed claim —
+ * it is the product telling the customer, in the customer's own transcript, that it tried and
+ * missed. A blank simply reads as continuation of the passage. The refusal has not been hidden: the
+ * track identity survives in `speaker_key`, and WHY the lane refused lives in the observations
+ * sidecar beside the tape. What changes is that the failure stops being addressed to the customer.
+ *
+ * This is the one place the mapping happens. The lane keeps its internal labels, so the replay
+ * harness and every score built on it keep counting refusals exactly as before rather than going
+ * blind the moment the display string changed.
+ */
+function displaySpeaker(internal: string): string {
+  return UNATTRIBUTED_LABEL.test(internal) ? '' : internal;
+}
+
 function chunkToBotSegment(speaker: string, c: ChunkSegment, completed: boolean): TranscriptSegment {
   return {
     segment_id: c.segmentId,
-    // Provisional cluster ids (seg_N) are an internal key, never a display name; while
-    // unattributed, emit the stable 'Speaker' label the gmeet lane uses (gmeet-pipeline.ts:52)
-    // so per-speaker consumers group as one speaker, not hundreds; late attribution still
-    // repaints by segment_id.
-    speaker: /^seg_\d+$/.test(speaker) ? 'Speaker' : speaker,
+    speaker: displaySpeaker(speaker),
     speaker_key: c.segmentId,
     text: c.text,
     start: c.startMs / 1000,

--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.18"
+appVersion: "0.12.22"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -3,10 +3,10 @@ title: "Changelog & migration"
 description: "Release notes and what changes between major versions."
 ---
 
-{/* docs-reflects: 0.12.18 — the released version these docs describe. CI (gate:docs-version) keeps
+{/* docs-reflects: 0.12.22 — the released version these docs describe. CI (gate:docs-version) keeps
     this equal to Chart.yaml appVersion; the release version-bump updates it. */}
 
-> 📌 **These docs reflect Vexa `v0.12.18`** — the latest released control-plane. Older self-hosts
+> 📌 **These docs reflect Vexa `v0.12.22`** — the latest released control-plane. Older self-hosts
 > should read against their pinned version.
 
 The authoritative, per-release changelog is on **GitHub Releases**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.18",
+  "version": "0.12.22",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",

--- a/releases/v0.12.22/RELEASE-NOTES.md
+++ b/releases/v0.12.22/RELEASE-NOTES.md
@@ -1,0 +1,58 @@
+# v0.12.22 — Teams speaker attribution
+
+Teams turns now carry the speaker's name. The bot reads who is audible from the
+WebRTC transport's contributing sources, correlates that against the roster panel
+and tile names, and attributes at word granularity rather than per turn.
+
+## Teams
+
+- Speaker names resolve from stable DOM attributes, guarded so a control label, a
+  clock or a machine token can never become a name
+  ([#1119](https://github.com/Vexa-ai/vexa/issues/1119)).
+- The audible-source signal comes from the RTP contributing-source list, so
+  attribution follows the transport rather than the UI's animation, and stream
+  selection is verified against voice energy.
+- Names are applied at word granularity. A name another track has already earned
+  is treated as contamination, not as disagreement.
+- Only the `mainAudio` mix is transcribed; double-mirrored tracks are deduplicated,
+  and a mix that is present but carries no sound is abandoned rather than
+  transcribed as silence.
+- Closed captions are no longer switched on automatically.
+- Where nothing can name a speaker, the row publishes with an empty speaker rather
+  than a claim.
+
+## Transcript quality
+
+- Superseded pending drafts are retracted, and a confirmed turn's dangling tail is
+  promoted on close, so dedup no longer loses speech.
+- Invented media-artifact text is suppressed, and every suppression is reported.
+- Overlap trim, gap reclaim, and a four-second cut on long turns.
+
+## Capture signal
+
+A bot can tape the transport and DOM signal for a meeting and store it alongside the
+recording — on by default, with a per-deployment kill switch and bounded retention.
+
+## Not claimed
+
+- Zoom is unchanged by this release.
+- Roughly 4–7% of rows still publish unnamed under heavy crosstalk.
+- The closed-caption path is retained behind a flag; it is not the primary
+  attribution source.
+
+## Credits
+
+Jacob Schooley ([@jbschooley](https://github.com/jbschooley)) — transcript
+retract/promote and `mainAudio` dedup
+([#1024](https://github.com/Vexa-ai/vexa/pull/1024)).
+
+Daniel Dormann ([@danieldormann](https://github.com/danieldormann)) — structural
+Teams name resolver ([#1121](https://github.com/Vexa-ai/vexa/pull/1121)), and the
+report that opened [#1119](https://github.com/Vexa-ai/vexa/issues/1119).
+
+Review stack: [#1123](https://github.com/Vexa-ai/vexa/pull/1123) ·
+[#1124](https://github.com/Vexa-ai/vexa/pull/1124) ·
+[#1125](https://github.com/Vexa-ai/vexa/pull/1125) ·
+[#1126](https://github.com/Vexa-ai/vexa/pull/1126) ·
+[#1127](https://github.com/Vexa-ai/vexa/pull/1127) ·
+[#1128](https://github.com/Vexa-ai/vexa/pull/1128).

--- a/releases/v0.12.22/candidate-images.json
+++ b/releases/v0.12.22/candidate-images.json
@@ -1,0 +1,206 @@
+{
+  "schema_version": 1,
+  "release": "v0.12.22",
+  "stable_tag": "v0.12.22",
+  "candidate_tag": "v0.12.22-rc.4",
+  "build_source": "0653de255957dcf2009781b14b01479bc6b0d107",
+  "validation_source": "0653de255957dcf2009781b14b01479bc6b0d107",
+  "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/31538709323",
+  "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/31538709323",
+  "images": {
+    "vexaai/v012-admin-api": {
+      "class": "prod_deployed",
+      "digest": "sha256:23932797a64e0cd94d2712fcd319a2199123cf8b0d2044129a2d9c39f74375d0",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:948854354f0f11d2443cd6ec76a89be6c7279d77c66649c84e7e9af1510ff030",
+          "config_digest": "sha256:6cc88933ba45f1c3fdb9eb4842dcadd89c9d675379a61861acceb9467bc0fc85"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:e2b4b4c4da5b6b9f55df61c114bb14fa10d2ebf46b448ec1637518f0889450ea",
+          "config_digest": "sha256:fdfb804988eecba5f5a15bd6eddbddf13e857748b7b0fbf3b51ced7892a6ddfb"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25 plus hosted production rev128 running imageID sha256:948854354f0f11d2443cd6ec76a89be6c7279d77c66649c84e7e9af1510ff030 (linux/amd64 child manifest of this index), founder-witnessed 2026-08-12"
+    },
+    "vexaai/v012-runtime": {
+      "class": "prod_deployed",
+      "digest": "sha256:d2dced7bbb49cdf652738dc185a1f4af4744188366ca68345961cbc44374a5e3",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:b3d466567447d7fa1337a5ed88e7228d18e4ddea664840879e2095667f0aec7e",
+          "config_digest": "sha256:63f7a4b377c5664884cbe5070843293927ed6e0c49d10206a478c4e9ee510cf1"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:340c23c88255e8d11e60a1df841758ded9076a255d738ad124bdafb1b0dd8e3a",
+          "config_digest": "sha256:69b314903e5dd47f7cf6106db3425f28ca76bb274262b7a006416a57a982b6bf"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25 plus hosted production rev128 running imageID sha256:b3d466567447d7fa1337a5ed88e7228d18e4ddea664840879e2095667f0aec7e (linux/amd64 child manifest of this index), read back post-rev-128 on 2026-08-12"
+    },
+    "vexaai/v012-agent-worker": {
+      "class": "oss_only",
+      "digest": "sha256:dab9fb35d8c4c756c0968405ec6788c2a1395a80aa6e812002857232b2c57735",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:b1a6f789f2052e4afcb2be759129a37cbec46342fa0bdb9ffe9b68301b5c0dd4",
+          "config_digest": "sha256:0f25ff0ec121620d3704fdbfbb8a7b9d2a5861d4ae78264a32403387fa666a8c"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:9dbc6f3b9a40fdcdcc7f541dd22387e2827def8e35d9312a9d016e1fdd858207",
+          "config_digest": "sha256:395b82de0a4950c079e17ba328909cc32c0ef114233c9bac8a0cc8551644f166"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25; dev:builds gate suite green at d7c1dedb (parent of the ship SHA) and gate:node green at 0653de25 on bbb"
+    },
+    "vexaai/v012-agent-api": {
+      "class": "oss_only",
+      "digest": "sha256:e2f5b2832783841cc1c7abfcd81a6148ff13a10f34ac098b740a097ba4e1fd24",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:ad4d7493012824fc6e7e7595c46955571d76505a61282fdccb5d2ac58df0f088",
+          "config_digest": "sha256:b4faf42317860a95d4acc15e60e4337f5ee8fe86c52d532b323db8559a2133f2"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:f4f7ee5fff40bf3a5e55df2f987ef21cd4e2cfbdbe9e21facb1084c4b9e0a418",
+          "config_digest": "sha256:07f40af476e9df5348f54cc8c803f8de75154fca1207c3a10128832fe8d4acda"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25; dev:builds gate suite green at d7c1dedb (parent of the ship SHA) and gate:node green at 0653de25 on bbb"
+    },
+    "vexaai/v012-meeting-api": {
+      "class": "prod_deployed",
+      "digest": "sha256:b9b3f4bd9ae6949f55c93db2ad5d60b0a249a9e181758bca2fcd59fb1d376824",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:8b578e65b2ee4f35be7b6e54ca8720201792aaaba6b592cdc4c724b5dcc6e9c3",
+          "config_digest": "sha256:d5a5cb3d31d2c20b8cdf839a9f6bd789d9b5ecc28774c3604e2ce7fa9cf23d9b"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:d49297919ba16e7405d36cd30f1d561c2fae2fc3533df91c26695735da854c47",
+          "config_digest": "sha256:b00a0dcfdd1c079eb708b308b68fe04a675cdebe5a20f9aa3732b47d3490c6b3"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25 plus hosted production rev128 running imageID sha256:8b578e65b2ee4f35be7b6e54ca8720201792aaaba6b592cdc4c724b5dcc6e9c3 on 3 pods (linux/amd64 child manifest of this index), founder-witnessed 2026-08-12"
+    },
+    "vexaai/v012-gateway": {
+      "class": "prod_deployed",
+      "digest": "sha256:8a184f480ad7052fadf268e78bde764d4e087d45af0258fd512fb207dc9871b6",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:bc3ff1fb197df6871ef05d8b65f087e00a768b248e8bc4d6124b24397deef3d1",
+          "config_digest": "sha256:2282c318588af2357a49654fdc32097c09bc9b119ba93c493547b2827e709707"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:6a40f1ed5f6f8ed9287d98b6cfddca8b3f4404e9f9ef329a08b0505cbcdc2c81",
+          "config_digest": "sha256:489a7ff40f7f8d43339215bb3b53628c43642d3d6bf6e3151d0e65fa1d24196c"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25 plus hosted production rev128 running imageID sha256:bc3ff1fb197df6871ef05d8b65f087e00a768b248e8bc4d6124b24397deef3d1 on 2 pods (linux/amd64 child manifest of this index), read back post-rev-128 on 2026-08-12"
+    },
+    "vexaai/v012-mcp": {
+      "class": "oss_only",
+      "digest": "sha256:4793a2047804796f14a70a51a779abfbadb937a5dd1103c4922f308bf694ecdc",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:f7bbe274330b2292e0220659218aedb527c26682ac4d31c9dc0142717891999b",
+          "config_digest": "sha256:6518fa29cf047e906a5ebc50757505d29563c724aee7d794cb5bc86e823929d7"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:09f59c0c70f966601b362fccf2eb420d263c27e41d857d1944cb8a25bc5686ac",
+          "config_digest": "sha256:9c234fa1b558948687d7d9ea60c244dbfaacef35497ce7507171dedb3f6aaa9b"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25; dev:builds gate suite green at d7c1dedb (parent of the ship SHA) and gate:node green at 0653de25 on bbb"
+    },
+    "vexaai/v012-terminal": {
+      "class": "oss_only",
+      "digest": "sha256:61886c75f7a8c587e792893a2fba47c6ff1bb1d0b63b156ab13b13cea1e161cc",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:b11de8e372062bc1a817a8500ac7128f032ee6fb864b36455216d5b73e9e6966",
+          "config_digest": "sha256:e37fcb77bc9cc5108015040f0d34c491f82f2efc4a03fbc051547a89dce4001a"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:3c7191089ed5b405fa55dededc6bf2722b90e9eabfdaf8a4ad16b6894225cddb",
+          "config_digest": "sha256:018aa566f8832d231bf687c7173edcacd458fb3577b5b15a9a664d9ae7cfa400"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25; dev:builds gate suite green at d7c1dedb (parent of the ship SHA), lite front-door probe of the terminal UI green at 0653de25 on bbb"
+    },
+    "vexaai/vexa-bot": {
+      "class": "prod_deployed",
+      "digest": "sha256:5f706d28f866181015d830ffc4afbbcfb34ee3cc2411ae7d022a41fa45486268",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:5f706d28f866181015d830ffc4afbbcfb34ee3cc2411ae7d022a41fa45486268",
+          "config_digest": "sha256:31ac76cd4536079c9bc9f1ee5ab8dd6a8741d59500a429248ba90b69b6484a6c"
+        }
+      },
+      "evidence": "candidate build run 31538709323 at 0653de25 plus hosted production rev128 runtime BROWSER_IMAGE sha256:5f706d28f866181015d830ffc4afbbcfb34ee3cc2411ae7d022a41fa45486268 (single-platform manifest; top digest equals the platform digest), founder-witnessed on Teams meeting 26026 and Google Meet 26025/26024 on 2026-08-12; staging helm rev 141 zero drift"
+    },
+    "vexaai/vexa-lite": {
+      "class": "oss_only",
+      "digest": "sha256:de252fdc232f25803c339371be62ef1ba6b407d8f44913a16d0ae94da94178a4",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:e78e119c48b79cd6ca00a880d483bb2994c0f6dcdbc33de81795df4c88f75925",
+          "config_digest": "sha256:6e8794bad2b957f543491557cd782bec1b635ceaf41f8bb012c1b249962d2988"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:511f492e9c8af54afb79a239e2964c32ea95ce0fbded69be7bdeff35860b1828",
+          "config_digest": "sha256:110c2764ddc091f910279ad621032ee8aa4295b46932cf2e8d2e2d77e0bde94f"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31538709323 at 0653de25; dev:builds lite leg 4/4 green at 0653de25 on bbb (build, up, front doors, concurrent-bots) and compose leg green (23 passed, 9 skipped)"
+    }
+  }
+}


### PR DESCRIPTION
Invented media-artifact text is suppressed and every suppression reported; the segmenter's silence verdict no longer deletes speech that was reclaimed from the gap.

213 assertions green across `mixed-pipeline`, `teams-capture` and `mixed-capture-core`; 20 commits (4 new), 50 files.

Stack position 4 of 6 — base `rc-2-teams-name-resolver` (#1125). v0.12.22-rc.1 staging candidate.
Next: #1127

<!-- vexa-agent -->


## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->
