### PR TITLE
fix(gates): stop gate:schema swallowing child error output (#1107)

### DIFF
--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -219,7 +219,13 @@ function gateSchema() {
   if (!contracts.length) { console.log("  ✓ gate:schema — no contracts yet (green-on-empty)"); return true; }
   for (const d of contracts) {
     try { execSync(`node ${JSON.stringify(join(d, "validate.mjs"))} --check`, { stdio: "pipe" }); }
-    catch (e) { return fail([`schema ${rel(d)}:\n${(e.stdout || e.stderr || e).toString()}`]); }
+    catch (e) {
+      // e.stdout is a zero-length Buffer (truthy) when the child wrote only to stderr — length-check both.
+      const out = (e.stdout?.length ? e.stdout : e.stderr?.length ? e.stderr : e).toString();
+      const hint = /ERR_MODULE_NOT_FOUND/.test(out)
+        ? "\n  hint: contract validators need dev dependencies — run `npm install` first" : "";
+      return fail([`schema ${rel(d)}:\n${out}${hint}`]);
+    }
   }
   console.log(`  ✓ gate:schema — ${contracts.length} contract(s) conform (goldens ≡ schema)`);
   return true;


### PR DESCRIPTION
**Delivers issue:** #1107

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

(Selected by the contributor personally; commit carries my DCO sign-off.)

## Observation bundle

- **C1 — reproduce the swallow** · ran: `node scripts/gates.mjs schema` on a fresh clone (no install), stock `main` (4c1612d) · saw:
  ```
  ▶ gates: schema
    ✗ schema core/agent/contracts/event.v1:
  ```
  — blank line where the diagnostic should be · concluded: bug confirmed as filed; `e.stdout` is a zero-length Buffer (truthy), so `e.stdout || e.stderr` short-circuits on it.
- **C2 — fix restores the message** · ran: same command with this diff applied · saw:
  ```
  ▶ gates: schema
    ✗ schema core/agent/contracts/event.v1:
  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ajv' imported from .../core/agent/contracts/event.v1/validate.mjs
    ...
    hint: contract validators need dev dependencies — run `npm install` first
  ```
  · concluded: real diagnostic surfaces, plus an actionable hint for the fresh-worktree case (issue part 2), so the operator's move is `npm install`, not `--no-verify`.
- **C3 — green path unchanged** · ran: `pnpm install` then `node scripts/gates.mjs schema` · saw: `✓ gate:schema — 1 contract(s) conform (goldens ≡ schema)` · concluded: no behavior change when the child succeeds; the diff only touches the catch block.

## Acceptance floor

The issue predates a maintainer acceptance table; rows above map to its two reported defects (swallowed message; unactionable fresh-worktree failure). The third defect the issue names — CI and the local hook disagreeing on the same named gate — is out of scope here and still open.

## Finding (while validating)

`node scripts/gates.mjs all` on a clean checkout also fails in `@vexa/terminal`: 5 vitest tests fail with `Cannot read properties of undefined (reading 'clear')` on `localStorage` (env: macOS, Node v26.5.0, pnpm 11.7.0) — `layout.preview.test.ts` (4) and `chatContext.test.ts` (1). Unrelated to this diff; looks like the vitest environment not providing `localStorage` on newer Node. Same "local gate red, CI green" divergence #1107 describes. Happy to file it separately if useful.
