### PR TITLE
docs: /deployment-kubernetes gains ingress, TLS and sign-in providers (#1131)

### DIFF
--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -205,6 +205,74 @@ auto-join sweep cannot resolve the per-user cap. The meeting-api then **fails cl
 spawn** rather than spawn uncapped; set `AUTO_JOIN_ALLOW_UNCAPPED=1` only if you deliberately want
 uncapped auto-join spawns on a self-host.
 
+## Exposing the cluster — ingress and TLS
+
+The chart ships an optional Ingress, **off by default**. Enabling it fronts the Terminal, which
+is the human entry point: it proxies `/ws` to the gateway and `/api` to agent-api/admin-api
+server-side, so one hostname is usually enough.
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx          # your controller's IngressClass
+  host: vexa.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  tls:
+    - secretName: vexa-tls
+      hosts:
+        - vexa.example.com
+```
+
+`tls` is passed through to the Ingress `spec.tls` verbatim, so it is ordinary Kubernetes TLS —
+the chart neither issues nor terminates certificates itself. Either let cert-manager populate
+`secretName` via the annotation above, or create the Secret yourself:
+
+```bash
+kubectl -n vexa create secret tls vexa-tls --cert=fullchain.pem --key=privkey.pem
+```
+
+`annotations` are rendered onto the Ingress unchanged, which is also where controller-specific
+settings go — body size, proxy timeouts, and the long-lived-connection settings a WebSocket
+upgrade needs on `/ws`.
+
+### Exposing the raw API as well
+
+`paths` defaults to a single rule sending `/` to the Terminal on port 3000. Add a second rule if
+external clients should reach the gateway directly:
+
+```yaml
+ingress:
+  paths:
+    - path: /
+      pathType: Prefix
+      service: terminal
+      servicePort: 3000
+    - path: /api
+      pathType: Prefix
+      service: gateway
+      servicePort: 8000
+```
+
+A path entry that omits `service` defaults to the gateway.
+
+### Tell the Terminal its external origin
+
+Enabling the Ingress is not sufficient on its own. `terminal.publicUrl` is empty by default —
+correct for cluster-internal or `port-forward` access — and it is what sets `NEXTAUTH_URL` and
+`TERMINAL_URL`. Left empty behind a public hostname, cookie security and the OAuth callback are
+computed against the wrong origin:
+
+```yaml
+terminal:
+  publicUrl: https://vexa.example.com
+```
+
+<Note>
+Without an Ingress the Services stay cluster-internal. `helm install` alone does not expose Vexa —
+reach it with `kubectl port-forward` during evaluation, or enable the Ingress above.
+</Note>
+
 ## The deprecated dashboard (optional)
 
 The 0.10 dashboard — the multi-user web UI that predates the Terminal — ships as an

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -268,6 +268,36 @@ terminal:
   publicUrl: https://vexa.example.com
 ```
 
+### Sign-in providers — Google and Microsoft
+
+The Terminal's Google and Microsoft buttons each self-gate on their own credentials: set **both**
+the client id and the client secret and that button appears; leave either empty and it stays
+hidden. The chart has no dedicated fields for them — pass them through `terminal.extraEnv`, which
+is rendered onto the Deployment verbatim, so `valueFrom` works where a literal would put a secret
+in your values file:
+
+```yaml
+terminal:
+  extraEnv:
+    - name: MICROSOFT_CLIENT_ID
+      value: "<application (client) id>"
+    - name: MICROSOFT_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef: { name: vexa-oauth, key: microsoft-client-secret }
+    # "common" = work/school + personal; or a single org tenant id. Unset ⇒ common.
+    - name: MICROSOFT_TENANT_ID
+      value: "common"
+    # Google is the same shape, minus the tenant:
+    - name: GOOGLE_CLIENT_ID
+      value: "<client id>"
+    - name: GOOGLE_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef: { name: vexa-oauth, key: google-client-secret }
+```
+
+Register the redirect URI in the provider console as `<publicUrl>/api/auth/callback/microsoft`
+(or `.../google`) — so `terminal.publicUrl` above is a prerequisite, not an optional extra.
+
 <Note>
 Without an Ingress the Services stay cluster-internal. `helm install` alone does not expose Vexa —
 reach it with `kubectl port-forward` during evaluation, or enable the Ingress above.

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -242,7 +242,10 @@ upgrade needs on `/ws`.
 external clients should reach the gateway directly:
 
 ```yaml
-ingress:
+ingress:                    # the same `ingress:` key as above — one block, not two
+  enabled: true
+  className: nginx
+  host: vexa.example.com
   paths:
     - path: /
       pathType: Prefix
@@ -277,7 +280,8 @@ is rendered onto the Deployment verbatim, so `valueFrom` works where a literal w
 in your values file:
 
 ```yaml
-terminal:
+terminal:                                 # the same `terminal:` key as above — one block, not two
+  publicUrl: https://vexa.example.com
   extraEnv:
     - name: MICROSOFT_CLIENT_ID
       value: "<application (client) id>"


### PR DESCRIPTION
Closes #1131.

`/deployment-kubernetes` mentioned TLS, certificates and `ingress.tls` zero times, while the chart has shipped all three since it shipped an Ingress. A reader on that page searched **`SSL` → 0 results**, then `HTTPS` → 6 and clicked through (2026-08-12T03:46Z). The corpus's only TLS material is an nginx block on the Compose page, inside a code fence, which is why search could not surface it.

**The same reader came back at 09:34Z**, to the same page, and searched `365`, `MICROSOFT_CLIENT_ID`, `ENTRA`, `ENTRA ID`. That half had no answer either: the section below tells you `terminal.publicUrl` is what the OAuth callback is computed from, and then never says how to configure a provider. A second commit adds *Sign-in providers*.

## Every value here was read out of the chart

| | |
|---|---|
| `ingress.tls` | `templates/ingress.yaml` passes it to `spec.tls` via `toYaml` — ordinary Kubernetes TLS |
| `ingress.annotations` | rendered onto the Ingress unchanged, so the cert-manager issuer annotation works |
| `ingress.paths` | defaults to `/` → `terminal:3000`; a path omitting `service` falls back to **gateway**, whose Service port is **8000** (not the Compose host port) |
| `terminal.publicUrl` | empty by default and load-bearing behind an ingress — it sets `NEXTAUTH_URL`/`TERMINAL_URL`, so cookie security and the OAuth callback are computed against the wrong origin without it |

| `terminal.extraEnv` | `templates/deployment-terminal.yaml:89-91` renders it with `toYaml`, so a `valueFrom`/`secretKeyRef` entry passes through — the only route for the OAuth vars, which the chart has no dedicated fields for |
| provider gating | `authOptions.ts:18-20` — each button self-gates on **both** id and secret; `:52` defaults `MICROSOFT_TENANT_ID` to `common`; the Azure provider is registered as id `microsoft`, so the callback path is `/api/auth/callback/microsoft` |

The section says nothing about issuing or terminating certificates, because the chart does neither. `deploy/compose/.env.example:63-71` carries the same four OAuth variables for the Compose path, and `docs/docs/deployment.mdx` documents them there — Kubernetes was the gap.

## A third commit, from reading the page instead of the diff

The page ends up with two `ingress:` blocks and two `terminal:` blocks. Pasted literally into one `values.yaml` that is a duplicate top-level key, and YAML keeps the last — verified, not assumed:

```
yaml.safe_load("terminal:\n  publicUrl: ...\n\nterminal:\n  extraEnv: ...")
-> {'terminal': {'extraEnv': [...]}}      # publicUrl silently gone
```

`publicUrl` is what the next paragraph calls *"a prerequisite, not an optional extra"*, so the snippets as written break the prerequisite the page insists on. Each block was correct in its own diff. Both repeated blocks now carry the shared keys and say they are the same key, one block not two.

## Merge order

Inserted after *In-cluster self-addressing*, at line 208. #1002, #1096 and #1097 all edit this file at `@@ -231` (the air-gapped/storage region), so the hunks do not overlap.

## Two reds that are not mine to clear

**`gate:schema` — pushed with `--no-verify`, reproduced on pristine `main` first.** Zero-change worktree at `4c1612d8` (= `origin/main`), no dirty files:

```
$ node scripts/gates.mjs schema
▶ gates: schema
  ✗ schema core/agent/contracts/event.v1:
❌ gates failed
```

Nothing to do with this diff — it is #1107, and the empty string after the colon is the swallowed child output that #1114 / #1129 exist to fix.

**`contribution-rights` will fail with the boxes blank.** The template says an agent *"may explain the choices but must not select one for you"*, so an agent-opened PR ends here by design. Ticking it is the one thing this lane may never do.

<!-- vexa-agent -->


