### PR TITLE
feat(gateway): GET /version — the deployment says what it is running

### DIFF
--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -13,7 +13,9 @@ behavior is the v0.12 carve of the deployed ``services/api-gateway/main.py``:
     unknown_action / invalid_subscribe_payload / invalid_unsubscribe_payload / missing_api_key
     error vocabulary; raw redis payloads forwarded over ``tc:…:mutable`` / ``bm:…:status`` /
     ``va:…:chat`` (main.py:2165-2340),
-  * ``/health`` — liveness ``{status:"ok", service:"gateway"}`` (gate:health discovers it).
+  * ``/health`` — liveness ``{status:"ok", service:"gateway"}`` (gate:health discovers it),
+  * ``/version`` — the running release identity read from the environment at request time, so a
+    UI can report what the deployment IS rather than what its own build was baked against.
 
 The collaborators (admin-api, downstream services, redis) are injected as PORTS (``ports.py``)
 so the same app runs with real adapters in prod (``adapters.py``) and in-process fakes in the
@@ -124,6 +126,23 @@ def create_app(
     @app.get("/health")
     async def health():
         return {"status": "ok", "service": "gateway"}
+
+    # --- /version — what release is ACTUALLY running here. Public and unauthenticated for the
+    # same reason /health is: a UI, a probe or an operator must be able to ask the deployment
+    # what it is without holding a key. The values come from the process environment
+    # (VEXA_VERSION / VEXA_REVISION), which the chart renders from the SAME value that pins the
+    # gateway image tag — so the string cannot drift from the image serving the request.
+    #
+    # There is deliberately NO fallback constant. A frontend that bakes a backend version at
+    # build time keeps reporting it long after the backend moved on; that is exactly the lie
+    # this route exists to end. Unset env → "unknown", which is true.
+    @app.get("/version")
+    async def version():
+        return {
+            "service": "gateway",
+            "version": os.getenv("VEXA_VERSION") or "unknown",
+            "revision": os.getenv("VEXA_REVISION") or "unknown",
+        }
 
     # --- /auth/me — caller identity from the API key (GET /auth/me with x-api-key →
     # user_id/email/scopes); the dashboard's login + session-validation resolve the user via this.

--- a/core/gateway/services/gateway/src/gateway/config.v1.json
+++ b/core/gateway/services/gateway/src/gateway/config.v1.json
@@ -1,160 +1,219 @@
 {
- "contract": "config.v1",
- "service": "gateway",
- "keys": [
-  {
-   "key": "INTERNAL_API_SECRET",
-   "class": "required-explicit",
-   "secret": true,
-   "description": "shared internal secret attached as X-Internal-Secret on the admin-api /internal/validate hop (adapters.py:67-69). Unset, admin-api rejects validation and EVERY API-key check 503s (fail-closed) — so the boot refuses instead of coming up green and 503ing every call (the 2026-04-23 failure shape, #526)."
-  },
-  {
-   "key": "ADMIN_API_URL",
-   "class": "defaulted",
-   "default": "http://admin-api:8001",
-   "description": "admin-api base URL for the /internal/validate token-resolution hop"
-  },
-  {
-   "key": "MEETING_API_URL",
-   "class": "defaulted",
-   "default": "http://meeting-api:8080",
-   "description": "meeting-api base URL — the proxy forward target and the /ws/authorize-subscribe hop"
-  },
-  {
-   "key": "AGENT_API_URL",
-   "class": "defaulted",
-   "default": "http://agent-api:8100",
-   "description": "agent control-plane base URL fronted under /api/*",
-   "targets": ["helm", "lite"]
-  },
-  {
-   "key": "MCP_URL",
-   "class": "defaulted",
-   "default": "http://mcp:8010",
-   "description": "MCP service base URL — the streamable-HTTP transport fronted under /mcp (GET streams the SSE leg, POST forwards buffered)",
-   "targets": ["compose"]
-  },
-  {
-   "key": "REDIS_URL",
-   "class": "defaulted",
-   "default": "redis://redis:6379/0",
-   "description": "pub/sub bus backing the /ws fan-in"
-  },
-  {
-   "key": "LOG_LEVEL",
-   "class": "defaulted",
-   "default": "info",
-   "description": "log verbosity"
-  },
-  {
-   "key": "HOST",
-   "class": "defaulted",
-   "default": "0.0.0.0",
-   "description": "uvicorn bind host",
-   "targets": ["lite"]
-  },
-  {
-   "key": "PORT",
-   "class": "defaulted",
-   "default": "8056",
-   "description": "uvicorn bind port",
-   "targets": ["lite"]
-  },
-  {
-   "key": "GUARD_ENABLED",
-   "class": "defaulted",
-   "default": "true",
-   "description": "edge protection (fastapi-guard) master switch — ON by default (#555)"
-  },
-  {
-   "key": "GUARD_WS_ENABLED",
-   "class": "defaulted",
-   "default": "false",
-   "description": "extend the edge guard to the /ws upgrade path"
-  },
-  {
-   "key": "GUARD_ENABLE_REDIS",
-   "class": "defaulted",
-   "default": "true",
-   "description": "back the guard's rate-limit/ban buckets with Redis (shared across replicas)",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_RATE_LIMIT_RPM",
-   "class": "defaulted",
-   "default": "600",
-   "description": "per-IP request budget per window",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_RATE_LIMIT_WINDOW",
-   "class": "defaulted",
-   "default": "60",
-   "description": "rate-limit window (seconds)",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_AUTO_BAN_THRESHOLD",
-   "class": "defaulted",
-   "default": "10",
-   "description": "violations before an IP is auto-banned",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_AUTO_BAN_DURATION",
-   "class": "defaulted",
-   "default": "3600",
-   "description": "auto-ban duration (seconds)",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_IP_WHITELIST",
-   "class": "defaulted",
-   "default": "",
-   "description": "comma-separated IPs never rate-limited/banned",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_IP_BLACKLIST",
-   "class": "defaulted",
-   "default": "",
-   "description": "comma-separated IPs always blocked",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_TRUSTED_PROXIES",
-   "class": "defaulted",
-   "default": "",
-   "description": "comma-separated proxy IPs whose X-Forwarded-For is trusted for client-IP resolution",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_TRUST_X_FORWARDED_PROTO",
-   "class": "defaulted",
-   "default": "false",
-   "description": "trust X-Forwarded-Proto from the proxy for scheme resolution",
-   "targets": ["compose", "helm"]
-  },
-  {
-   "key": "GUARD_BLOCKED_COUNTRIES",
-   "class": "defaulted",
-   "default": "",
-   "description": "comma-separated country codes to block (geo-IP)",
-   "targets": ["compose"]
-  },
-  {
-   "key": "GUARD_BLOCK_CLOUD_PROVIDERS",
-   "class": "defaulted",
-   "default": "",
-   "description": "block known cloud/hosting provider ranges",
-   "targets": ["compose"]
-  },
-  {
-   "key": "GUARD_REDIS_PREFIX",
-   "class": "defaulted",
-   "default": "vexa:guard:",
-   "description": "Redis key prefix for the guard's rate-limit/ban buckets",
-   "targets": []
-  }
- ]
+  "contract": "config.v1",
+  "service": "gateway",
+  "keys": [
+    {
+      "key": "INTERNAL_API_SECRET",
+      "class": "required-explicit",
+      "secret": true,
+      "description": "shared internal secret attached as X-Internal-Secret on the admin-api /internal/validate hop (adapters.py:67-69). Unset, admin-api rejects validation and EVERY API-key check 503s (fail-closed) — so the boot refuses instead of coming up green and 503ing every call (the 2026-04-23 failure shape, #526)."
+    },
+    {
+      "key": "ADMIN_API_URL",
+      "class": "defaulted",
+      "default": "http://admin-api:8001",
+      "description": "admin-api base URL for the /internal/validate token-resolution hop"
+    },
+    {
+      "key": "MEETING_API_URL",
+      "class": "defaulted",
+      "default": "http://meeting-api:8080",
+      "description": "meeting-api base URL — the proxy forward target and the /ws/authorize-subscribe hop"
+    },
+    {
+      "key": "AGENT_API_URL",
+      "class": "defaulted",
+      "default": "http://agent-api:8100",
+      "description": "agent control-plane base URL fronted under /api/*",
+      "targets": [
+        "helm",
+        "lite"
+      ]
+    },
+    {
+      "key": "MCP_URL",
+      "class": "defaulted",
+      "default": "http://mcp:8010",
+      "description": "MCP service base URL — the streamable-HTTP transport fronted under /mcp (GET streams the SSE leg, POST forwards buffered)",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "REDIS_URL",
+      "class": "defaulted",
+      "default": "redis://redis:6379/0",
+      "description": "pub/sub bus backing the /ws fan-in"
+    },
+    {
+      "key": "LOG_LEVEL",
+      "class": "defaulted",
+      "default": "info",
+      "description": "log verbosity"
+    },
+    {
+      "key": "VEXA_VERSION",
+      "class": "defaulted",
+      "default": "unknown",
+      "description": "release identity disclosed by GET /version. Rendered by the chart from the SAME expression as the gateway image tag, so the version this deployment reports cannot drift from the image serving the request. Read per request, never captured at import. Unset => \"unknown\": a frontend that baked a backend version at build time displayed 0.12.18 against a 0.12.22-rc.3 cluster, and a stale number is worse than none because a reader acts on it.",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "VEXA_REVISION",
+      "class": "defaulted",
+      "default": "unknown",
+      "description": "git revision of the deployed build, disclosed alongside VEXA_VERSION at GET /version. Optional (global.imageRevision in the chart); unset => \"unknown\", never guessed.",
+      "targets": [
+        "helm"
+      ]
+    },
+    {
+      "key": "HOST",
+      "class": "defaulted",
+      "default": "0.0.0.0",
+      "description": "uvicorn bind host",
+      "targets": [
+        "lite"
+      ]
+    },
+    {
+      "key": "PORT",
+      "class": "defaulted",
+      "default": "8056",
+      "description": "uvicorn bind port",
+      "targets": [
+        "lite"
+      ]
+    },
+    {
+      "key": "GUARD_ENABLED",
+      "class": "defaulted",
+      "default": "true",
+      "description": "edge protection (fastapi-guard) master switch — ON by default (#555)"
+    },
+    {
+      "key": "GUARD_WS_ENABLED",
+      "class": "defaulted",
+      "default": "false",
+      "description": "extend the edge guard to the /ws upgrade path"
+    },
+    {
+      "key": "GUARD_ENABLE_REDIS",
+      "class": "defaulted",
+      "default": "true",
+      "description": "back the guard's rate-limit/ban buckets with Redis (shared across replicas)",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_RATE_LIMIT_RPM",
+      "class": "defaulted",
+      "default": "600",
+      "description": "per-IP request budget per window",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_RATE_LIMIT_WINDOW",
+      "class": "defaulted",
+      "default": "60",
+      "description": "rate-limit window (seconds)",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_AUTO_BAN_THRESHOLD",
+      "class": "defaulted",
+      "default": "10",
+      "description": "violations before an IP is auto-banned",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_AUTO_BAN_DURATION",
+      "class": "defaulted",
+      "default": "3600",
+      "description": "auto-ban duration (seconds)",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_IP_WHITELIST",
+      "class": "defaulted",
+      "default": "",
+      "description": "comma-separated IPs never rate-limited/banned",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_IP_BLACKLIST",
+      "class": "defaulted",
+      "default": "",
+      "description": "comma-separated IPs always blocked",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_TRUSTED_PROXIES",
+      "class": "defaulted",
+      "default": "",
+      "description": "comma-separated proxy IPs whose X-Forwarded-For is trusted for client-IP resolution",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_TRUST_X_FORWARDED_PROTO",
+      "class": "defaulted",
+      "default": "false",
+      "description": "trust X-Forwarded-Proto from the proxy for scheme resolution",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "GUARD_BLOCKED_COUNTRIES",
+      "class": "defaulted",
+      "default": "",
+      "description": "comma-separated country codes to block (geo-IP)",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "GUARD_BLOCK_CLOUD_PROVIDERS",
+      "class": "defaulted",
+      "default": "",
+      "description": "block known cloud/hosting provider ranges",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "GUARD_REDIS_PREFIX",
+      "class": "defaulted",
+      "default": "vexa:guard:",
+      "description": "Redis key prefix for the guard's rate-limit/ban buckets",
+      "targets": []
+    }
+  ]
 }

--- a/core/gateway/services/gateway/src/gateway/edge_guard.py
+++ b/core/gateway/services/gateway/src/gateway/edge_guard.py
@@ -66,6 +66,11 @@ _GUARD_EXCLUDE_PATHS = [
     "/favicon.ico",
     "/static",
     "/health",
+    # /version is the same shape as /health: a constant-cost, keyless, public disclosure of what
+    # this deployment is. It is excluded because every dashboard/webapp page load asks for it
+    # through ONE server-side proxy — a single pod IP would otherwise spend the whole per-IP
+    # budget on it and the UI would fall back to "unknown" under normal traffic.
+    "/version",
 ]
 
 

--- a/core/gateway/services/gateway/tests/test_version.py
+++ b/core/gateway/services/gateway/tests/test_version.py
@@ -1,0 +1,54 @@
+"""/version — the deployment reports what it IS, or says it does not know.
+
+The route exists because a frontend cannot honestly report a backend version it baked at its
+own build time: dashboard.staging.vexa.ai showed "v0.12.18" for days while the cluster served
+v0.12.22-rc.3. The only honest source is the running backend, asked at request time.
+
+Two properties are load-bearing and both are asserted here:
+  * the value is read from the environment ON EACH REQUEST — a redeploy that changes the env
+    changes the answer without rebuilding anything;
+  * an unset environment yields "unknown", never a constant. A stale number is worse than no
+    number, because a reader acts on it.
+"""
+from fastapi.testclient import TestClient
+
+from gateway import create_app
+from conftest import FakeAuthorizer, FakeDownstream, FakeRedis
+
+
+def _client():
+    return TestClient(create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis()))
+
+
+def test_version_reports_the_environment(monkeypatch):
+    monkeypatch.setenv("VEXA_VERSION", "0.12.22-rc.3")
+    monkeypatch.setenv("VEXA_REVISION", "0653de25")
+    r = _client().get("/version")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["service"] == "gateway"
+    assert body["version"] == "0.12.22-rc.3"
+    assert body["revision"] == "0653de25"
+
+
+def test_version_says_unknown_rather_than_a_constant(monkeypatch):
+    monkeypatch.delenv("VEXA_VERSION", raising=False)
+    monkeypatch.delenv("VEXA_REVISION", raising=False)
+    body = _client().get("/version").json()
+    assert body["version"] == "unknown"
+    assert body["revision"] == "unknown"
+
+
+def test_version_reflects_a_changed_environment_without_a_rebuild(monkeypatch):
+    """Read per request, not captured at import — the regression that made the badge lie."""
+    client = _client()
+    monkeypatch.setenv("VEXA_VERSION", "0.12.18")
+    assert client.get("/version").json()["version"] == "0.12.18"
+    monkeypatch.setenv("VEXA_VERSION", "0.12.22-rc.3")
+    assert client.get("/version").json()["version"] == "0.12.22-rc.3"
+
+
+def test_version_needs_no_api_key(monkeypatch):
+    """Public like /health — a UI reports the version before anyone has signed in."""
+    monkeypatch.setenv("VEXA_VERSION", "0.12.22")
+    assert _client().get("/version").status_code == 200

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -382,6 +382,10 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      # What GET /version discloses. Interpolated from the SAME IMAGE_TAG that selects the image
+      # above, so the version this stack reports is the image it is running — a UI asks the
+      # gateway at page load instead of baking a backend version into its own build.
+      - VEXA_VERSION=${IMAGE_TAG:-dev}
       # fastapi-guard edge layer (edge_guard.py): per-IP throttle + auto-ban at the edge.
       # ON by default with generous limits (owner ruling — protection that ships dark protects
       # nobody). Opt out with GUARD_ENABLED=false in .env; all keys interpolate from .env.

--- a/deploy/helm/charts/vexa/templates/_helpers.tpl
+++ b/deploy/helm/charts/vexa/templates/_helpers.tpl
@@ -215,3 +215,13 @@ become non-blocking. Industry-standard Redis-as-stream-buffer config.
 {{- required "INVALID redis.durability config: stopWritesOnBgsaveError=yes requires appendonly=yes (paired AOF + BGSAVE durability invariant — see v0.10.5 Pack C.5). Without AOF, blocking writes on BGSAVE failure means writes that arrive while BGSAVE is failing have no durable record anywhere." "" -}}
 {{- end -}}
 {{- end -}}
+
+{{/* The tag of the gateway image this release actually runs — the SAME expression the gateway
+container's `image:` field uses, so the version the gateway discloses at /version cannot drift
+from the image serving the request. It is a helper rather than a repeated literal precisely so
+the two cannot be edited apart; deploy/helm/tests/test_template.sh asserts they render equal.
+Deliberately NOT the chart appVersion: appVersion is what the chart was written for, the image
+tag is what is running. */}}
+{{- define "vexa.gatewayImageTag" -}}
+{{- .Values.global.imageTag | default .Values.gateway.image.tag -}}
+{{- end -}}

--- a/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         - name: gateway
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ .Values.gateway.image.repository }}:{{ .Values.global.imageTag | default .Values.gateway.image.tag }}"
+          image: "{{ .Values.gateway.image.repository }}:{{ include "vexa.gatewayImageTag" . }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http
@@ -53,6 +53,17 @@ spec:
                   key: INTERNAL_API_SECRET
             - name: LOG_LEVEL
               value: {{ .Values.gateway.logLevel | default "info" | quote }}
+            # What /version discloses. Rendered from the same helper as the container's image
+            # tag above, so "the version this deployment reports" and "the image this deployment
+            # runs" are one value with one editable source. A UI asks the gateway at page load
+            # instead of baking a backend version into its own build — the bake is how
+            # dashboard.staging.vexa.ai advertised 0.12.18 while the cluster served 0.12.22-rc.3.
+            - name: VEXA_VERSION
+              value: {{ include "vexa.gatewayImageTag" . | quote }}
+            {{- with .Values.global.imageRevision }}
+            - name: VEXA_REVISION
+              value: {{ . | quote }}
+            {{- end }}
             # fastapi-guard edge layer (edge_guard.py): per-IP throttle + auto-ban at the edge.
             # ON by default with generous limits (owner ruling); opt out with
             # --set gateway.guard.enabled=false. guard.wsEnabled is the optional /ws hook (off,

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -11,6 +11,10 @@
 
 global:
   imageTag: ""              # When set, overrides every service image tag (build-once promotion).
+  # Optional git revision of the build being deployed. Rendered into the gateway as VEXA_REVISION
+  # and disclosed at GET /version alongside the tag. Empty → /version reports "unknown", which is
+  # the honest answer; it is never filled in with a guess or a chart constant.
+  imageRevision: ""
   imagePullPolicy: Always
   imagePullSecrets: []
   clusterDomain: cluster.local

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -198,4 +198,17 @@ else
   echo "  FAIL: migrations Job ignored global.imageTag — schema/code skew risk (#900): $MIG_IMG"; fail=1
 fi
 
+# version truth — the gateway's VEXA_VERSION env (what /version discloses) must render to the
+# SAME string as its own image tag. A UI reports the backend version by asking /version at page
+# load; if this env could drift from the image, the answer would be the old lie in a new place.
+VER_RENDER="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set global.imageTag=vVERSION-TRUTH --show-only templates/deployment-gateway.yaml)"
+gw_img="$(grep -E '^\s+image: "vexaai/v012-gateway:' <<< "$VER_RENDER" | sed 's/.*://; s/"//')"
+gw_ver="$(grep -A1 'name: VEXA_VERSION' <<< "$VER_RENDER" | grep 'value:' | sed 's/.*value: *//; s/"//g')"
+if [ -n "$gw_ver" ] && [ "$gw_img" = "$gw_ver" ]; then
+  echo "  OK: gateway VEXA_VERSION == gateway image tag ($gw_ver)"
+else
+  echo "  FAIL: gateway image tag '$gw_img' != VEXA_VERSION '$gw_ver' — /version would lie"; fail=1
+fi
+
 [ "$fail" -eq 0 ] && { echo "gate:helm PASS"; exit 0; } || { echo "gate:helm FAIL"; exit 1; }


### PR DESCRIPTION
`dashboard.staging.vexa.ai` showed **v0.12.18** while the cluster served **v0.12.22-rc.3**, during a deploy verification. The number was a build-time constant inside the dashboard image, describing the backend that image had been baked against. A frontend cannot honestly report a backend version it compiled in.

So the backend answers for itself.

- **`GET /version`** on the gateway — public and keyless like `/health`, reads `VEXA_VERSION` / `VEXA_REVISION` from the environment **on every request**, returns `"unknown"` when unset. No fallback constant: a stale number is worse than none, because a reader acts on it.
- The chart renders `VEXA_VERSION` through the **same helper** as the gateway container's `image:` tag, so what a deployment reports and what it runs are one value with one editable source. `deploy/helm/tests/test_template.sh` fails the render if they diverge.
- Compose interpolates it from the same `IMAGE_TAG` that selects the image.
- `/version` joins `/health` in the edge-guard exclusions: one server-side proxy asks it on every page load, and a single pod IP would otherwise spend its whole per-IP budget on it.

Additive and off the RC path — it adds a route and an env, changes no existing behaviour. Stacks alongside the v0.12.22-rc.1 set (#1123–#1128); ships as a follow-up deploy **after** 0.12.22, not part of the promotion.

**Validation**
- gateway suite `115 passed, 1 xfailed` (4 new tests: env-read-per-request, `"unknown"` on unset, keyless)
- `gate:helm PASS`, `gate:config-contract` green (5 services · 208 keys)
- image built on bbb and run twice from the **same image**: stamped env → `{"version":"0.12.22-rc.3","revision":"5f314bbd"}`; unstamped → `{"version":"unknown","revision":"unknown"}`

The two frontends that consume this are `Vexa-ai/vexa` branch `dashboard-version-truth` and `Vexa-ai/vexa-platform` branch `version-truth`. Until the gateway carries the route, both chips honestly read *version unknown*.

<!-- vexa-agent -->
