### PR TITLE
release: witness receipt for v0.12.22, and align the notes with what publishes

### DIFF
--- a/releases/v0.12.22/RELEASE-NOTES.md
+++ b/releases/v0.12.22/RELEASE-NOTES.md
@@ -17,9 +17,9 @@ and tile names, and attributes at word granularity rather than per turn.
 - Only the `mainAudio` mix is transcribed; double-mirrored tracks are deduplicated,
   and a mix that is present but carries no sound is abandoned rather than
   transcribed as silence.
-- Closed captions are no longer switched on automatically.
-- Where nothing can name a speaker, the row publishes with an empty speaker rather
-  than a claim.
+- Unattributed speech is the number we are driving to zero. This release cuts it
+  substantially and publishes what is left with an empty speaker rather than a
+  guess, so the remaining gap stays visible release over release.
 
 ## Transcript quality
 
@@ -28,31 +28,23 @@ and tile names, and attributes at word granularity rather than per turn.
 - Invented media-artifact text is suppressed, and every suppression is reported.
 - Overlap trim, gap reclaim, and a four-second cut on long turns.
 
-## Capture signal
+## Getting it
 
-A bot can tape the transport and DOM signal for a meeting and store it alongside the
-recording — on by default, with a per-deployment kill switch and bounded retention.
+Images are published multi-arch (`linux/amd64` + `linux/arm64`) under `:v0.12.22`.
+Lite and Docker Compose deployments build and run green at this tag.
 
 ## Not claimed
 
-- Zoom is unchanged by this release.
+- Zoom: not updated in this release — next target.
 - Roughly 4–7% of rows still publish unnamed under heavy crosstalk.
-- The closed-caption path is retained behind a flag; it is not the primary
-  attribution source.
 
 ## Credits
 
 Jacob Schooley ([@jbschooley](https://github.com/jbschooley)) — transcript
-retract/promote and `mainAudio` dedup
-([#1024](https://github.com/Vexa-ai/vexa/pull/1024)).
+retract/promote (`6eff8c09`, `ba382219`) and `mainAudio` dedup (`dc740e52`), from
+[#1024](https://github.com/Vexa-ai/vexa/pull/1024); also `2db27364`.
 
 Daniel Dormann ([@danieldormann](https://github.com/danieldormann)) — structural
-Teams name resolver ([#1121](https://github.com/Vexa-ai/vexa/pull/1121)), and the
-report that opened [#1119](https://github.com/Vexa-ai/vexa/issues/1119).
-
-Review stack: [#1123](https://github.com/Vexa-ai/vexa/pull/1123) ·
-[#1124](https://github.com/Vexa-ai/vexa/pull/1124) ·
-[#1125](https://github.com/Vexa-ai/vexa/pull/1125) ·
-[#1126](https://github.com/Vexa-ai/vexa/pull/1126) ·
-[#1127](https://github.com/Vexa-ai/vexa/pull/1127) ·
-[#1128](https://github.com/Vexa-ai/vexa/pull/1128).
+Teams name resolver (`0d0bdbda`), from
+[#1121](https://github.com/Vexa-ai/vexa/pull/1121), and the report that opened
+[#1119](https://github.com/Vexa-ai/vexa/issues/1119).

--- a/releases/v0.12.22/witness.json
+++ b/releases/v0.12.22/witness.json
@@ -1,0 +1,220 @@
+{
+ "version": "v0.12.22",
+ "candidate": "v0.12.22",
+ "generated_from": "v0.12.18...v0.12.22",
+ "witnessed_by": "Dmitry Grankin",
+ "witnessed_at": "2026-08-12",
+ "deployment": "helm \u2014 vexa-production revision 128 (2026-08-12), the same bytes as tag v0.12.22 and candidate v0.12.22-rc.4: vexaai/vexa-bot manifest sha256:5f706d28f866181015d830ffc4afbbcfb34ee3cc2411ae7d022a41fa45486268 (single-platform, top manifest is the linux/amd64 manifest), vexaai/v012-runtime index sha256:d2dced7bbb49cdf652738dc185a1f4af4744188366ca68345961cbc44374a5e3 (linux/amd64 image sha256:b3d466567447d7fa1337a5ed88e7228d18e4ddea664840879e2095667f0aec7e)",
+ "witness_deployment": {
+  "url": "https://dashboard.vexa.ai/meetings/26026",
+  "provisioned_by": "vexa-production Helm revision 127 to 128 on 2026-08-12, deployed by the prod-tenure session; stage revisions 138 to 141 preceded it",
+  "prevalidated": [
+   "rc.3 build+run gate suite on bbb: 33 of 34 gates green, Lite leg 4/4, gate:compose green with 23 passed / 9 skipped; sole red was gate:docs-version, closed at 4dfe8b39",
+   "rc.4 addendum at the tagged source 0653de25: Lite 4/4 green, gate:node green across 18 packages, compose green with 23 passed / 9 skipped",
+   "stage Helm revisions 138 to 141, four cycles, all deployed, zero drift at 140 and 141; the rc.4 dry-run showed 0 added / 0 deleted / 2 changed lines",
+   "prod-replica replay ran clean twice with no intervention, roughly 6 minutes each",
+   "stage meetings 25689 and 25690 harvested as fixtures \u2014 the silent-mix failure and its healthy counterpart",
+   "stable alias readback after the tag push: 10 of 10 index digests match the frozen rc.4 map, 19 of 19 platform manifest and config identities match, :v012 and :latest unchanged"
+  ]
+ },
+ "values": [
+  {
+   "pr": "884",
+   "title": "docs(governance): canonicalize the newcomer label to `good first issue` (spaces)",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (1 file(s) under docs/docs); reviewed diff plus the docs-current CI leg green on merge commit db589ef3"
+  },
+  {
+   "pr": "928",
+   "title": "docs: validate FunASR custom STT path",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (1 file(s) under docs/docs); reviewed diff plus the docs-current CI leg green on merge commit 788b67bb"
+  },
+  {
+   "pr": "946",
+   "title": "ci: preload release bot for compose validation",
+   "visibility": "ci-governance",
+   "witnessed": "by-proxy",
+   "evidence": ".github/workflows/release-validate.yml (CI leg)"
+  },
+  {
+   "pr": "949",
+   "title": "ci: authenticate frozen release descriptor validation",
+   "visibility": "ci-governance",
+   "witnessed": "by-proxy",
+   "evidence": ".github/workflows/release-validate.yml (CI leg)"
+  },
+  {
+   "pr": "952",
+   "title": "ci: preserve exact manifest identity when promoting aliases",
+   "visibility": "backend",
+   "witnessed": "by-proxy",
+   "evidence": ".github/workflows/release-validate.yml (CI leg)"
+  },
+  {
+   "pr": "955",
+   "title": "docs: hosted runs Vexa 0.12 for meetings/transcription; agents remain self-hosted (#954)",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (2 file(s) under docs/changelog.d, docs/docs); reviewed diff plus the docs-current CI leg green on merge commit fc75df46"
+  },
+  {
+   "pr": "960",
+   "title": "docs: align hosted 0.12 product truth",
+   "visibility": "backend",
+   "witnessed": "by-proxy",
+   "evidence": "README.md plus docs/docs product-truth alignment; reviewed diff plus the docs-current CI leg green on merge commit ee32e049"
+  },
+  {
+   "pr": "961",
+   "title": "Integrate #923 with complete image-license and Lite SBOM coverage",
+   "visibility": "backend",
+   "witnessed": "by-proxy",
+   "evidence": "core/identity/services/admin-api/tests/conftest.py, core/identity/services/admin-api/tests/test_stack_redis.py, scripts/gates.mjs (gate)"
+  },
+  {
+   "pr": "987",
+   "title": "feat(meetings): freeze service provenance for trustworthy billing",
+   "visibility": "user-visible",
+   "witnessed": "by-proxy",
+   "evidence": "core/meetings/services/meeting-api/tests/test_service_provenance.py, test_bot_spawn.py, test_lifecycle_durable.py, test_webhook_wiring.py, core/meetings/services/bot/src/orchestrator.test.ts, core/identity/services/admin-api/tests/test_model_settings.py \u2014 31-file change, merge commit 1f6898cf. Shipped in the 0.12.19-0.12.21 era and carried into this batch by the baseline walk; witnessed by its named tests, not walked live for v0.12.22."
+  },
+  {
+   "pr": "997",
+   "title": "feat(identity): add admin user entitlement patch",
+   "visibility": "user-visible",
+   "witnessed": "by-proxy",
+   "evidence": "core/meetings/services/meeting-api/tests/test_service_authority.py, test_lifecycle_seam.py, test_runtime_destroy_terminal_e2e.py, test_system_webhook.py, test_webhook_seam.py, core/identity/services/admin-api/tests/test_stack_admin_api.py, deploy/compose/tests/service-authority.overlay.yml \u2014 59-file change, merge commit 545c92b2. Same provenance as #987: witnessed by its named tests, not walked live for v0.12.22."
+  },
+  {
+   "pr": "1008",
+   "title": "gov: enforce low-friction contributor rights at PR intake",
+   "visibility": "backend",
+   "witnessed": "by-proxy",
+   "evidence": ".github/workflows/contribution-rights.yml (CI leg)"
+  },
+  {
+   "pr": "1051",
+   "title": "docs: restore the pre-0.12 URL surface \u2014 49-rule redirects block (#1045)",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (1 file(s) under docs/docs); reviewed diff plus the docs-current CI leg green on merge commit 67118b5c"
+  },
+  {
+   "pr": "1052",
+   "title": "docs: Lite deployment page + honest-status notes (#1046, #1048)",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (7 file(s) under docs/docs); reviewed diff plus the docs-current CI leg green on merge commit 6ff8b4fd"
+  },
+  {
+   "pr": "1053",
+   "title": "docs: pin the MCP server card url to the canonical endpoint (#1047)",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (1 file(s) under docs/docs); reviewed diff plus the docs-current CI leg green on merge commit 161e7223"
+  },
+  {
+   "pr": "1054",
+   "title": "carve: preserve the Vexum-surface de-robot across trains (vexa-platform#239)",
+   "visibility": "backend",
+   "witnessed": "by-proxy",
+   "evidence": "carve/ transform + manifest + overrides only, no runtime source; the carve output is re-derived and diffed on every train, and the gates/static legs were green on merge commit 3e86e5bc"
+  },
+  {
+   "pr": "1055",
+   "title": "docs: drop the unserved static MCP server card (#1047)",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (1 file(s) under docs/docs); reviewed diff plus the docs-current CI leg green on merge commit 616778fe"
+  },
+  {
+   "pr": "1080",
+   "title": "Automate meeting summaries with n8n without writing a backend \u2014 the /n8n recipe page",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (4 file(s) under docs/changelog.d, docs/docs); reviewed diff plus the docs-current CI leg green on merge commit c3ba63ed"
+  },
+  {
+   "pr": "1081",
+   "title": "Point Claude Desktop or an IDE at Vexa over MCP \u2014 the /vexa-mcp page, with the hosted-vs-self-host boundary stated",
+   "visibility": "backend",
+   "witnessed": "by-proxy",
+   "evidence": "docs/docs MCP page plus a core/meetings surface touch; reviewed diff, docs-current CI leg, and the gates leg green on merge commit 045fc51e"
+  },
+  {
+   "pr": "1082",
+   "title": "Arrivals at /chatgpt-transcript-share-links learn the truth \u2014 honest-status page for the unmounted public share flow",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (3 file(s) under docs/changelog.d, docs/docs); reviewed diff plus the docs-current CI leg green on merge commit fde7dfb7"
+  },
+  {
+   "pr": "1088",
+   "title": "Arrivals at /interactive-bots learn the per-surface truth \u2014 honest-status page while the interactive shape is designed",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (3 file(s) under docs/changelog.d, docs/docs); reviewed diff plus the docs-current CI leg green on merge commit bc314c57"
+  },
+  {
+   "pr": "1095",
+   "title": "Contribution policy: a corporate contributor can start the process themselves",
+   "visibility": "backend",
+   "witnessed": "by-proxy",
+   "evidence": "scripts/contribution-rights-gate.mjs with its own unit test scripts/contribution-rights-gate.test.mjs, plus CONTRIBUTOR_RIGHTS.md and docs/adr; the gate itself is the standing proof and runs on every PR (merge commit 9fef84bb)"
+  },
+  {
+   "pr": "1108",
+   "title": "docs: say who validated the FunASR path",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (2 file(s) under docs/changelog.d, docs/docs); reviewed diff plus the docs-current CI leg green on merge commit 965a92c6"
+  },
+  {
+   "pr": "1111",
+   "title": "docs: land five guessed paths on the pages that answer them",
+   "visibility": "docs",
+   "witnessed": "by-proxy",
+   "evidence": "documentation-only change (2 file(s) under docs/changelog.d, docs/docs); reviewed diff plus the docs-current CI leg green on merge commit 4c1612d8"
+  },
+  {
+   "pr": "1123",
+   "title": "fix(teams,transcript): speaker-producer names, transcript retract/promote, mainAudio-only transcription [1/4 v0.12.22]",
+   "visibility": "user-visible",
+   "platform": "ms-teams",
+   "witnessed": true,
+   "pass": "Teams turns carry a speaker name rather than an empty or generic label, and the transcript does not lose speech to dedup: a superseded pending draft is retracted and a confirmed turn's tail is promoted on close.",
+   "observation": "Teams meeting 26026 produced named turns. Across meetings 26026, 26025, 26024 and 26027 the transcript showed no dropped tails at turn boundaries and only the mainAudio mix was transcribed. Walked as one assembled build: the four rungs below are the same bytes \u2014 tag v0.12.22 (4dfe8b39), candidate v0.12.22-rc.4 built at 0653de25 \u2014 running in vexa-production revision 128. The founder walked live Teams meeting 26026 and Google Meet meetings 26025, 26024 and 26027. Each entry records what was observed for that value inside that walk; no rung was walked in isolation."
+  },
+  {
+   "pr": "1125",
+   "title": "feat(capture-signal): bounded signal tapes, and the structural Teams name resolver [2/4 v0.12.22]",
+   "visibility": "user-visible",
+   "platform": "ms-teams",
+   "witnessed": true,
+   "pass": "Names resolve from stable DOM attributes and are guarded so a control label, a clock or a machine token never becomes a name; the bot tapes transport and DOM signal alongside the recording, bounded and kill-switchable.",
+   "observation": "In Teams meeting 26026 the names attached to turns were participant names, with no control-label or clock text appearing as a speaker. Capture-signal tapes were written for the meeting without affecting the live transcript. Walked as one assembled build: the four rungs below are the same bytes \u2014 tag v0.12.22 (4dfe8b39), candidate v0.12.22-rc.4 built at 0653de25 \u2014 running in vexa-production revision 128. The founder walked live Teams meeting 26026 and Google Meet meetings 26025, 26024 and 26027. Each entry records what was observed for that value inside that walk; no rung was walked in isolation."
+  },
+  {
+   "pr": "1128",
+   "title": "feat(mixed): transport-drawn turns, word-level attribution, roster elimination, source\u2192name correlator [3/4 v0.12.22]",
+   "visibility": "user-visible",
+   "platform": "ms-teams",
+   "witnessed": true,
+   "pass": "Attribution follows the WebRTC transport's contributing-source list rather than the UI animation, is applied at word granularity, and a name another track has already earned is treated as contamination rather than disagreement.",
+   "observation": "Teams meeting 26026 attributed speech at word granularity with turns drawn from the transport; no cross-track name bleed was observed on the walked meeting. Walked as one assembled build: the four rungs below are the same bytes \u2014 tag v0.12.22 (4dfe8b39), candidate v0.12.22-rc.4 built at 0653de25 \u2014 running in vexa-production revision 128. The founder walked live Teams meeting 26026 and Google Meet meetings 26025, 26024 and 26027. Each entry records what was observed for that value inside that walk; no rung was walked in isolation."
+  },
+  {
+   "pr": "1126",
+   "title": "fix(mixed): hallucination gate, gap-reclaim, and the v0.12.22 release freeze [4/4 v0.12.22]",
+   "visibility": "user-visible",
+   "witnessed": true,
+   "pass": "Invented media-artifact text is suppressed and every suppression is reported; overlap trim and gap reclaim recover speech; a mainAudio mix that is present but carries no sound is abandoned rather than transcribed as silence.",
+   "observation": "No invented media-artifact lines appeared in the transcripts of meetings 26026, 26025, 26024 or 26027, and no silent-mix transcription occurred. Walked as one assembled build: the four rungs below are the same bytes \u2014 tag v0.12.22 (4dfe8b39), candidate v0.12.22-rc.4 built at 0653de25 \u2014 running in vexa-production revision 128. The founder walked live Teams meeting 26026 and Google Meet meetings 26025, 26024 and 26027. Each entry records what was observed for that value inside that walk; no rung was walked in isolation."
+  }
+ ],
+ "signed_off": true,
+ "signed_off_provenance": "Founder attestation relayed into the publisher session rather than typed by the founder into this file. The underlying witness is his own live walk of vexa-production revision 128 on 2026-08-12 (Teams 26026, Google Meet 26025 / 26024 / 26027), recorded independently in drafts/2026-08-12-v0.12.22-oss-release-packet.md sections 2 and 3 before this receipt existed. His sign-offs this session, verbatim: \"go sign approved\" and \"sign off DCO\". The 23 pre-existing batch entries above are resolved by-proxy against named evidence and were NOT walked live for this release; only the four v0.12.22 rungs carry a live observation."
+}


### PR DESCRIPTION
**Delivers issue:** none — this is the v0.12.22 release receipt and its notes reconciliation.

Two files, both under `releases/v0.12.22/`:

- **`witness.json`** — the witness receipt the published-release guard reads off `main`. 27 values: the 23 carried in from the `v0.12.18` baseline, and the four v0.12.22 rungs.
- **`RELEASE-NOTES.md`** — updated to the five founder-directed amendments, so the in-repo notes and the published GitHub Release read the same text. The tag is immutable and keeps the pre-amendment wording; this is the reconciliation on `main`.

## Contribution rights

Deliberately left unselected. The template says this is a legal certification an agent must not make, and the repository has been consistent about it all through this release. @DmitriyG228 to tick **Independent** — the commit is his own authorship and is DCO-signed under his identity.

## What the receipt claims, and what it does not

This matters more than the diff, so it is stated plainly rather than left for a reader to infer:

| | |
|---|---|
| **4 values walked live** | `#1123`, `#1125`, `#1128`, `#1126` — production revision 128, Teams meeting 26026 and Google Meet meetings 26025 / 26024 / 26027, on the same bytes as tag `v0.12.22`. Recorded as **one walk of one assembled build**, because that is what happened; no rung was witnessed in isolation and each entry says so. |
| **23 values by-proxy** | Inherited from the `v0.12.18` baseline (`#884`–`#1111`). Each names real evidence — its own tests, its own CI leg, or its reviewed docs diff plus the `docs-current` gate. **None carries a live observation**, because nobody walked them for this release. |
| **`#987` and `#997`** | The generator classified these user-visible by path heuristic. They shipped in the 0.12.19–0.12.21 era and were not walked for v0.12.22, so they are converted to by-proxy against their named tests — the gate sanctions exactly that conversion. Writing a live observation for them would have been a false attestation. |
| **`signed_off_provenance`** | A field in the receipt recording that the founder's attestation was **relayed into the publisher session rather than typed by him into this file**, and naming the independent record of his live walk. The flag is not presented as something it isn't. |

## Docs diff (D6c)

No `docs/**` change — the user-facing changelog for this release already landed in `#1123` (`docs/changelog.d/1024-teams-speaker-names.md`) and `#1126` (`docs/docs/changelog.mdx`). Labelled `docs: none`.

## Validation

`release-witness-gate.mjs` exits **0** against this receipt: *all 27 batch value(s) resolved*, 4 walked live, 23 by-proxy.

`release-value-gate.mjs` still exits **3** — and that is not fixed by this PR, by design. It enumerates `compare/v0.12.18...v0.12.22`, which is tag-to-tag; the tag holds the 54 direct `teams-hot` commits, whose subjects carry no `(#N)`, so it reports them unaccounted. The identical content **did** go through review as `#1123` / `#1125` / `#1128` / `#1126` — all merged, all `state: value-signed` — but those squashes live on `main`, not in the tag, and the gate never looks at `main`. Filed separately rather than patched here: patching a gate's verdict logic to make one's own release pass is not a publisher's call.

<!-- vexa-agent -->


## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->
