### PR TITLE
feat(gateway): add authenticated user event fan-out

### DIFF
--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -10,7 +10,7 @@
   "core/agent/contracts/workspace.v1": "4069d5a747914765ba2d4f2d4cf0968916be1208137f845a3f1691a241f7f20f",
   "core/gateway/contracts/api.v1": "9b3fbdc65a049460db486c14ad590b8b7f60fe55ec252db4e5ef5ac2d894e1e6",
   "core/gateway/contracts/logevent.v1": "7ab25cc7d935e03ea1aec29a0d717576bcfa1a37d7c412400227c98e1df3ed59",
-  "core/gateway/contracts/ws.v1": "77ce41cb384600acaf34402f4daf8d04b32063c662831238ba7a2e4195e80287",
+  "core/gateway/contracts/ws.v1": "6ff18db3316045d8b7055f95a261359e0dbbeaca3c7b1e2aa18f40ad7e0a4bfc",
   "core/identity/contracts/identity.v1": "36902fe610115088c855e7af607c1d778dbd3ab75512d8c71c8bf78cf1767dc7",
   "core/meetings/contracts/acts.v1": "1eaa34d27c52b0eb987a278115a1966c058f615ca16e3391b00107a6779dec4f",
   "core/meetings/contracts/captured-signal.v1": "6ab2c63f5164827d9735f51b0add4d30890972069f18b63d52255df33c36907d",

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -24,6 +24,7 @@ import hmac
 import json
 import logging
 import re
+import subprocess
 import time
 from pathlib import Path
 from typing import Callable, Iterator, Optional
@@ -69,6 +70,7 @@ from control_plane.workspace_membership import MembershipError, MembershipIndex,
 from control_plane.dispatch import Dispatcher
 from control_plane.events import event_to_invocation
 from shared.ports import SchedulerPort, StreamReader
+from shared.user_events import RedisUserEventPublisher, routine_status, workspace_committed
 from control_plane.workspace_reader import WorkspaceReader
 
 logger = logging.getLogger("agent_api.api")
@@ -933,6 +935,10 @@ def create_app(
     app.state.sessions = sess
     app.state.live_meetings = live
     app.state.scheduler = scheduler
+    # User-scoped WS notifications are best-effort. The APIs and workspace git history remain
+    # authoritative when Redis Pub/Sub is unavailable.
+    user_events = RedisUserEventPublisher(redis_url)
+    app.state.user_event_publisher = user_events
     settings = dispatcher.settings if dispatcher is not None else None
     # The SSE ownership gate's owner-lookup (P0): default = HTTP to meeting-api; injectable for L2 tests.
     _meeting_owner_lookup = meeting_owner_lookup or _http_meeting_owner_lookup(
@@ -1317,13 +1323,20 @@ def create_app(
         if scheduler is None or not invocations_url:
             raise HTTPException(status_code=501, detail="scheduler not wired")
         try:
+            subject = subject_of(request)
             routine = routines_mod.make_routine(
-                subject=subject_of(request), name=body.name, cron=body.cron, prompt=body.prompt,
+                subject=subject, name=body.name, cron=body.cron, prompt=body.prompt,
             )
             job_spec = routines_mod.compile_to_job(routine, invocations_url=invocations_url)
         except (ValueError, ValidationError) as e:  # bad cron form / non-conformant routine — fail loud
             raise HTTPException(status_code=400, detail=str(getattr(e, "message", e)))
         job = scheduler.schedule(job_spec)
+        job_id = job.get("job_id")
+        user_events.publish(
+            subject=subject,
+            suffix="routines",
+            frame=routine_status(subject=subject, routine_id=routine["id"], status="scheduled", job_id=job_id),
+        )
         ran_now = False
         if body.run_now:
             # Fire one immediate run via the dispatcher (no HTTP hop) so the author sees a result now.
@@ -1332,7 +1345,7 @@ def create_app(
                 ran_now = True
             except Exception:  # noqa: BLE001 — the routine is still scheduled even if the demo run fails
                 ran_now = False
-        return {"routine": routine, "job_id": job.get("job_id"), "ran_now": ran_now}
+        return {"routine": routine, "job_id": job_id, "ran_now": ran_now}
 
     @app.get("/api/routines")
     def list_routines(request: Request):
@@ -1367,6 +1380,15 @@ def create_app(
             raise HTTPException(status_code=404, detail="unknown routine")
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        user_events.publish(
+            subject=subject,
+            suffix="routines",
+            frame=routine_status(
+                subject=subject,
+                routine_id=workspace_routines_mod.routine_id_for_workspace_file(subject, name),
+                status="scheduled" if body.enabled else "disabled",
+            ),
+        )
         return {
             "ok": True,
             "name": name,
@@ -1383,6 +1405,12 @@ def create_app(
             meta = job.get("metadata") or {}
             if meta.get("routine_id") == routine_id and meta.get("owner") == subject:
                 scheduler.cancel_job(job["job_id"])
+                user_events.publish(
+                    subject=subject,
+                    suffix="routines",
+                    frame=routine_status(subject=subject, routine_id=routine_id, status="cancelled",
+                                         job_id=job.get("job_id")),
+                )
                 return {"ok": True, "routine_id": routine_id}
         raise HTTPException(status_code=404, detail="unknown routine")
 
@@ -1788,7 +1816,27 @@ def create_app(
         shared and feeds the mount preamble. Returns the normalized purpose actually stored."""
         subject = subject_of(request)
         ws = _manage_dir(subject, body.slug)
-        return {"purpose": write_purpose(ws, body.purpose)}
+        purpose = write_purpose(ws, body.purpose)
+        try:
+            proc = subprocess.run(
+                ["git", "-C", str(ws), "rev-parse", "HEAD"],
+                check=False, capture_output=True, text=True, timeout=3,
+            )
+            sha = proc.stdout.strip() if proc.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            sha = ""
+        if sha:
+            user_events.publish(
+                subject=subject,
+                suffix="workspace",
+                frame=workspace_committed(
+                    subject=subject,
+                    workspace_id=body.slug or "main",
+                    commit_sha=sha,
+                    message="workspace purpose updated",
+                ),
+            )
+        return {"purpose": purpose}
 
     @app.get("/api/meeting/stream")
     def meeting_stream(meeting_id: str, session_uid: str, request: Request):

--- a/core/agent/control_plane/dispatch.py
+++ b/core/agent/control_plane/dispatch.py
@@ -230,6 +230,8 @@ def build_unit_env(settings: Settings, invocation: dict, *, unit_id: str, token:
         "VEXA_WORKSPACE_STORE_URL": settings.workspace_store_url,
         "REDIS_URL": settings.redis_url,
     }
+    if str(identity.get("launcher") or "").startswith("schedule:"):
+        env["VEXA_ROUTINE_ID"] = str(identity["launcher"])[len("schedule:"):]
     # Attribution (D4 / WP-A1.2): the per-mount turn commit is authored by the dispatch PRINCIPAL (the
     # authenticated human whose input drives the turn), committer stays the platform. Until membership/
     # sharing lands (later WPs) the principal IS the subject; a caller that already resolved a distinct

--- a/core/agent/llm/ports.py
+++ b/core/agent/llm/ports.py
@@ -349,4 +349,7 @@ def run_harness_turn(
         except subprocess.CalledProcessError:
             continue  # one mount's commit failing must not abort the rest of the set
         if sha:
-            yield {"type": "commit", "sha": sha}
+            # The worker uses this additive field to attribute the commit to the correct mounted
+            # workspace when a turn has more than one writable mount. Existing consumers only
+            # depend on ``type`` and ``sha``.
+            yield {"type": "commit", "sha": sha, "workspace_path": str(mount)}

--- a/core/agent/shared/user_events.py
+++ b/core/agent/shared/user_events.py
@@ -1,0 +1,96 @@
+"""Small, best-effort publishers for the gateway's authenticated user fan-out.
+
+The gateway subscribes to ``u:{user_id}:*`` and forwards payloads unchanged.  This module keeps
+the producer-side topic names and ``ws.v1`` frame construction in one place for the agent control
+plane and worker.  Redis Pub/Sub is intentionally treated as a transient notification channel:
+the REST APIs remain the source of truth and a disconnected client can rebuild its view.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+
+def user_scope(subject: object) -> str:
+    """Map an agent subject (normally ``u_42``) to the gateway's user-id scope (``42``)."""
+    value = str(subject or "").strip()
+    if value.startswith("u_") and value[2:]:
+        return value[2:]
+    return value
+
+
+def _frame(*, frame_type: str, subject: object, **fields: Any) -> dict[str, Any]:
+    frame = {
+        "type": frame_type,
+        "event_id": f"evt_{uuid.uuid4().hex}",
+        "user_id": user_scope(subject),
+        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    frame.update(fields)
+    return frame
+
+
+def meetings_changed(*, subject: object, meeting_id: object, change: str,
+                     meeting: dict[str, Any] | None = None, revision: object = None) -> dict[str, Any]:
+    fields: dict[str, Any] = {"meeting_id": meeting_id, "change": change}
+    if meeting is not None:
+        fields["meeting"] = meeting
+    if revision is not None:
+        fields["revision"] = revision
+    return _frame(frame_type="meetings.changed", subject=subject, **fields)
+
+
+def workspace_committed(*, subject: object, workspace_id: object, commit_sha: str,
+                        message: str | None = None) -> dict[str, Any]:
+    fields: dict[str, Any] = {"workspace_id": workspace_id, "commit_sha": commit_sha}
+    if message:
+        fields["message"] = message
+    return _frame(frame_type="workspace.committed", subject=subject, **fields)
+
+
+def routine_status(*, subject: object, routine_id: str, status: str, job_id: str | None = None,
+                   error: str | None = None) -> dict[str, Any]:
+    fields: dict[str, Any] = {"routine_id": routine_id, "status": status}
+    if job_id:
+        fields["job_id"] = job_id
+    if error:
+        fields["error"] = error
+    return _frame(frame_type="routine.status", subject=subject, **fields)
+
+
+class RedisUserEventPublisher:
+    """Publish user events without making Redis availability a request/turn failure."""
+
+    def __init__(self, redis_url: str | None) -> None:
+        self._redis_url = (redis_url or "").strip()
+        self._redis = None
+
+    def _client(self):
+        if not self._redis_url:
+            return None
+        if self._redis is None:
+            import redis
+
+            self._redis = redis.Redis.from_url(
+                self._redis_url,
+                decode_responses=True,
+                socket_connect_timeout=2,
+                socket_timeout=2,
+            )
+        return self._redis
+
+    def publish(self, *, subject: object, suffix: str, frame: dict[str, Any]) -> bool:
+        """Publish a frame to ``u:{scope}:{suffix}``; return False on disabled/unavailable Redis."""
+        try:
+            client = self._client()
+        except Exception:  # noqa: BLE001 - missing Redis client/config is non-fatal to source writes
+            return False
+        if client is None:
+            return False
+        try:
+            client.publish(f"u:{user_scope(subject)}:{suffix}", json.dumps(frame, separators=(",", ":")))
+            return True
+        except Exception:  # noqa: BLE001 - event fan-out must never break the source operation
+            return False

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -37,6 +37,7 @@ from llm import (
 )
 from llm.errors import _AUTH_SIGNATURE_RE  # noqa: F401 — re-exported for the worker.worker shim
 from shared.seeding import resolve_seed_dir, seed_workspace, validate_seed
+from shared.user_events import RedisUserEventPublisher, routine_status, workspace_committed
 
 log = logging.getLogger("agent_api.worker")
 
@@ -336,9 +337,47 @@ def run_turn_over_workspace(
                                commit=commit, author=author, extra_mounts=extras)
         first = next(gen, None)
     captured: str | None = None
+    user_event_publisher = RedisUserEventPublisher(os.environ.get("REDIS_URL"))
+    routine_id = os.environ.get("VEXA_ROUTINE_ID", "").strip()
     for ev in (gen if first is None else itertools.chain([first], gen)):
         if ev.get("type") == "done" and ev.get("sessionId"):
             captured = ev["sessionId"]
+        if ev.get("type") == "done" and routine_id:
+            subject = os.environ.get("VEXA_OWNER", "").strip()
+            if subject:
+                ok = ev.get("ok", True)
+                user_event_publisher.publish(
+                    subject=subject,
+                    suffix="routines",
+                    frame=routine_status(
+                        subject=subject,
+                        routine_id=routine_id,
+                        status="succeeded" if ok else "failed",
+                        error=None if ok else str(ev.get("error") or ev.get("reply") or "routine failed"),
+                    ),
+                )
+        if ev.get("type") == "commit" and ev.get("sha"):
+            subject = os.environ.get("VEXA_OWNER", "").strip()
+            if subject:
+                committed_path = Path(ev.get("workspace_path") or work).resolve()
+                workspace_id = None
+                for mount in mounts:
+                    try:
+                        if Path(mount.get("path", "")).resolve() == committed_path:
+                            workspace_id = mount.get("id") or mount.get("slug")
+                            break
+                    except (TypeError, OSError):
+                        continue
+                workspace_id = workspace_id or ("main" if committed_path == work.resolve() else committed_path.name)
+                user_event_publisher.publish(
+                    subject=subject,
+                    suffix="workspace",
+                    frame=workspace_committed(
+                        subject=subject,
+                        workspace_id=workspace_id,
+                        commit_sha=str(ev["sha"]),
+                    ),
+                )
         yield ev
     if captured and session_continuity:
         sess_file.parent.mkdir(parents=True, exist_ok=True)

--- a/core/gateway/contracts/ws.v1/README.md
+++ b/core/gateway/contracts/ws.v1/README.md
@@ -29,8 +29,23 @@ SDKs, and any client build against.
     — from `bm:meeting:{id}:status` (status under `payload.status`).
   - `ChatMessage` `{type:"chat_message", sender?, text}` — from `va:meeting:{id}:chat`.
 
-  Data messages are **type-tagged and additive** (the gateway forwards the producer's raw
-  payload unchanged), so `type` + the listed required field are the floor; extra fields are allowed.
+  - `MeetingsChanged` `{type:"meetings.changed", event_id, meeting_id, change, ts, meeting?}` — from
+    `u:{user_id}:meetings`.
+  - `WorkspaceCommitted` `{type:"workspace.committed", event_id, workspace_id, commit_sha, ts}` — from
+    `u:{user_id}:workspace`.
+  - `RoutineStatus` `{type:"routine.status", event_id, routine_id, status, ts}` — from
+    `u:{user_id}:routines`.
+
+Data messages are **type-tagged and additive** (the gateway forwards the producer's raw
+payload unchanged), so `type` + the listed required fields are the floor; extra fields are allowed.
+
+### User scope
+
+After successful connect-time API-key resolution, the gateway subscribes to the Redis
+pattern `u:{resolved_user_id}:*`. The client cannot provide or alter this user id. The
+pattern currently covers `meetings`, `workspace`, and `routines` topics. Redis Pub/Sub
+does not replay missed messages; clients should fetch a REST snapshot after connect or
+reconnect and then apply live frames.
 
 ## The seam (what conforms to this)
 | Consumer | How |

--- a/core/gateway/contracts/ws.v1/golden/MeetingsChanged.updated.json
+++ b/core/gateway/contracts/ws.v1/golden/MeetingsChanged.updated.json
@@ -1,0 +1,9 @@
+{
+  "type": "meetings.changed",
+  "event_id": "evt_meeting_001",
+  "user_id": 42,
+  "meeting_id": 123,
+  "change": "updated",
+  "meeting": { "id": 123, "platform": "google_meet", "native_meeting_id": "abc-defg-hij", "status": "scheduled" },
+  "ts": "2026-08-04T12:00:00Z"
+}

--- a/core/gateway/contracts/ws.v1/golden/RoutineStatus.running.json
+++ b/core/gateway/contracts/ws.v1/golden/RoutineStatus.running.json
@@ -1,0 +1,10 @@
+{
+  "type": "routine.status",
+  "event_id": "evt_routine_001",
+  "user_id": 42,
+  "routine_id": "rt_abc123",
+  "status": "running",
+  "job_id": "job_123",
+  "error": null,
+  "ts": "2026-08-04T12:02:00Z"
+}

--- a/core/gateway/contracts/ws.v1/golden/WorkspaceCommitted.updated.json
+++ b/core/gateway/contracts/ws.v1/golden/WorkspaceCommitted.updated.json
@@ -1,0 +1,9 @@
+{
+  "type": "workspace.committed",
+  "event_id": "evt_workspace_001",
+  "user_id": 42,
+  "workspace_id": "personal",
+  "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+  "message": "Update decision notes",
+  "ts": "2026-08-04T12:01:00Z"
+}

--- a/core/gateway/contracts/ws.v1/ws.schema.json
+++ b/core/gateway/contracts/ws.v1/ws.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://vexa.ai/contracts/ws.v1",
   "title": "ws.v1 — the public live WebSocket multiplex (/ws), frozen to vexa main",
-  "description": "The /ws endpoint api-gateway serves: api_key auth (x-api-key header or ?api_key=), a subscribe/unsubscribe control protocol, and forwarded live data messages — transcript (the per-speaker confirmed/pending bundle) + transcription_segment from tc:meeting:{id}:mutable, meeting.status from bm:meeting:{id}:status, chat_message from va:meeting:{id}:chat. The gateway forwards the raw redis payload verbatim, so data messages are type-tagged and additive (extra fields allowed). Shapes are the canonical 0.10.6 contract (vexa-0.11 api-gateway + meetings.publish_meeting_status_change).",
+  "description": "The /ws endpoint api-gateway serves: api_key auth (x-api-key header or ?api_key=), a subscribe/unsubscribe control protocol, and forwarded live data messages. In addition to per-meeting channels, an authenticated socket is automatically pattern-subscribed to u:{user_id}:*; producers use u:{user_id}:meetings, u:{user_id}:workspace, and u:{user_id}:routines. The gateway forwards producer payloads verbatim, so data messages are type-tagged and additive. Redis Pub/Sub is transient and does not provide replay; clients should rehydrate from REST after reconnect.",
   "$defs": {
     "MeetingRef": {
       "type": "object",
@@ -103,6 +103,50 @@
         "ts": { "type": ["string", "null"] }
       }
     },
+    "MeetingsChanged": {
+      "type": "object",
+      "description": "A user-scoped meeting collection change from u:{user_id}:meetings. The meeting snapshot is optional so a client may use meeting_id + change and refetch details.",
+      "required": ["type", "event_id", "meeting_id", "change", "ts"],
+      "properties": {
+        "type": { "const": "meetings.changed" },
+        "event_id": { "type": "string", "minLength": 1 },
+        "user_id": { "type": ["integer", "string"] },
+        "meeting_id": { "type": ["integer", "string"] },
+        "change": { "type": "string", "enum": ["created", "updated", "deleted", "status_changed"] },
+        "meeting": { "type": ["object", "null"] },
+        "revision": { "type": ["integer", "string", "null"] },
+        "ts": { "type": "string", "minLength": 1 }
+      }
+    },
+    "WorkspaceCommitted": {
+      "type": "object",
+      "description": "A durable workspace git commit from u:{user_id}:workspace. The commit SHA is the idempotent state cursor; clients may refetch workspace/git for details.",
+      "required": ["type", "event_id", "workspace_id", "commit_sha", "ts"],
+      "properties": {
+        "type": { "const": "workspace.committed" },
+        "event_id": { "type": "string", "minLength": 1 },
+        "user_id": { "type": ["integer", "string"] },
+        "workspace_id": { "type": "string", "minLength": 1 },
+        "commit_sha": { "type": "string", "minLength": 1 },
+        "message": { "type": ["string", "null"] },
+        "ts": { "type": "string", "minLength": 1 }
+      }
+    },
+    "RoutineStatus": {
+      "type": "object",
+      "description": "A user-scoped routine lifecycle update from u:{user_id}:routines.",
+      "required": ["type", "event_id", "routine_id", "status", "ts"],
+      "properties": {
+        "type": { "const": "routine.status" },
+        "event_id": { "type": "string", "minLength": 1 },
+        "user_id": { "type": ["integer", "string"] },
+        "routine_id": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["created", "scheduled", "running", "succeeded", "failed", "disabled", "cancelled"] },
+        "job_id": { "type": ["string", "null"] },
+        "error": { "type": ["string", "null"] },
+        "ts": { "type": "string", "minLength": 1 }
+      }
+    },
     "ChatMessage": {
       "type": "object",
       "description": "server → client: a chat message from the bot (forwarded from va:meeting:{id}:chat)",
@@ -123,6 +167,8 @@
           "type": "string",
           "enum": [
             "missing_api_key",
+            "invalid_api_key",
+            "auth_unavailable",
             "invalid_json",
             "invalid_subscribe_payload",
             "invalid_unsubscribe_payload",

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -655,6 +655,30 @@ async def run_multiplex(ws: WebSocket, authorizer: Authorizer, redis: RedisBus) 
             except Exception:
                 pass
 
+    async def pattern_fan_in(pattern: str):
+        """Forward all Redis Pub/Sub events in the authenticated user namespace."""
+        pubsub = redis.pubsub()
+        await pubsub.psubscribe(pattern)
+        try:
+            async for message in pubsub.listen():
+                if message.get("type") != "pmessage":
+                    continue
+                data = message.get("data")
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8", errors="replace")
+                if not isinstance(data, str):
+                    continue
+                try:
+                    await ws.send_text(data)
+                except Exception:
+                    break
+        finally:
+            try:
+                await pubsub.punsubscribe(pattern)
+                await pubsub.close()
+            except Exception:
+                pass
+
     async def subscribe_meeting(platform: str, native_id: str, user_id, meeting_id):
         key = (platform, native_id, user_id)
         if key in subscribed_meetings:
@@ -680,8 +704,8 @@ async def run_multiplex(ws: WebSocket, authorizer: Authorizer, redis: RedisBus) 
     # frame is needed: the identity is resolved at connect. This reuses the SAME verbatim `fan_in`
     # path as the per-meeting channels — the gateway is a thin raw forwarder for the user channel
     # exactly as it is for tc:/bm:/va:. Per-meeting subscriptions below are unchanged.
-    user_channel = f"u:{user_id}:meetings"
-    user_sub_task = asyncio.create_task(fan_in([user_channel]))
+    user_pattern = f"u:{user_id}:*"
+    user_sub_task = asyncio.create_task(pattern_fan_in(user_pattern))
 
     try:
         while True:
@@ -748,9 +772,9 @@ async def run_multiplex(ws: WebSocket, authorizer: Authorizer, redis: RedisBus) 
                 subscribed: List[Dict[str, str]] = []
                 for item in authorized:
                     plat = item.get("platform"); nid = item.get("native_id")
-                    user_id = item.get("user_id"); meeting_id = item.get("meeting_id")
-                    if plat and nid and user_id and meeting_id:
-                        await subscribe_meeting(plat, nid, user_id, meeting_id)
+                    item_user_id = item.get("user_id"); meeting_id = item.get("meeting_id")
+                    if plat and nid and item_user_id and meeting_id:
+                        await subscribe_meeting(plat, nid, item_user_id, meeting_id)
                         subscribed.append({"platform": plat, "native_id": nid})
                 await ws.send_text(json.dumps({"type": "subscribed", "meetings": subscribed}))
 
@@ -795,9 +819,12 @@ async def run_multiplex(ws: WebSocket, authorizer: Authorizer, redis: RedisBus) 
     except WebSocketDisconnect:
         pass
     finally:
-        user_sub_task.cancel()  # Track G — tear down the user-scope fan-in on disconnect.
+        user_sub_task.cancel()  # tear down the user-scope fan-in on disconnect.
+        await asyncio.gather(user_sub_task, return_exceptions=True)
         for task in sub_tasks.values():
             task.cancel()
+        if sub_tasks:
+            await asyncio.gather(*sub_tasks.values(), return_exceptions=True)
 
 
 # Backward-compatible private alias (kept so any existing internal reference still resolves; the

--- a/core/gateway/services/gateway/src/gateway/ports.py
+++ b/core/gateway/services/gateway/src/gateway/ports.py
@@ -106,16 +106,24 @@ class DownstreamClient(Protocol):
 
 @runtime_checkable
 class PubSub(Protocol):
-    """A redis-style pub/sub subscription used by the ``/ws`` fan-in (``main.fan_in``)."""
+    """A Redis pub/sub subscription used by the ``/ws`` fan-in.
+
+    Ordinary meeting subscriptions emit ``message`` records. The authenticated user
+    scope uses ``PSUBSCRIBE`` and emits ``pmessage`` records.
+    """
 
     async def subscribe(self, *channels: str) -> None: ...
 
     async def unsubscribe(self, *channels: str) -> None: ...
 
+    async def psubscribe(self, *patterns: str) -> None: ...
+
+    async def punsubscribe(self, *patterns: str) -> None: ...
+
     async def close(self) -> None: ...
 
     def listen(self) -> AsyncIterator[dict]:
-        """Yield ``{"type": "message"|"subscribe", "data": <str>}`` dicts (redis-py shape)."""
+        """Yield Redis-shaped ``message``/``pmessage``/subscription records."""
         ...
 
 

--- a/core/gateway/services/gateway/tests/conftest.py
+++ b/core/gateway/services/gateway/tests/conftest.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from fnmatch import fnmatchcase
 from typing import Optional
 
 # fastapi-guard: keep it installed (so the integration is exercised) but in-memory and with
@@ -96,6 +97,7 @@ class FakePubSub:
         self._hub = hub
         self._queue: asyncio.Queue = asyncio.Queue()
         self._channels: list[str] = []
+        self._patterns: list[str] = []
 
     async def subscribe(self, *channels: str) -> None:
         self._channels = list(channels)
@@ -109,14 +111,26 @@ class FakePubSub:
             except ValueError:
                 pass
 
+    async def psubscribe(self, *patterns: str) -> None:
+        self._patterns = list(patterns)
+        for pattern in patterns:
+            self._hub._pattern_subs.setdefault(pattern, []).append(self._queue)
+
+    async def punsubscribe(self, *patterns: str) -> None:
+        for pattern in patterns or self._patterns:
+            try:
+                self._hub._pattern_subs.get(pattern, []).remove(self._queue)
+            except ValueError:
+                pass
+
     async def close(self) -> None:
         pass
 
     async def listen(self):
         yield {"type": "subscribe"}
         while True:
-            data = await self._queue.get()
-            yield {"type": "message", "data": data}
+            kind, data = await self._queue.get()
+            yield {"type": kind, "data": data}
 
 
 class FakeRedis:
@@ -124,10 +138,19 @@ class FakeRedis:
 
     def __init__(self):
         self._subs: dict[str, list[asyncio.Queue]] = {}
+        self._pattern_subs: dict[str, list[asyncio.Queue]] = {}
 
     def pubsub(self) -> FakePubSub:
         return FakePubSub(self)
 
-    async def publish(self, channel: str, data: str) -> None:
+    async def publish(self, channel: str, data: str) -> int:
+        delivered = 0
         for q in list(self._subs.get(channel, [])):
-            await q.put(data)
+            await q.put(("message", data))
+            delivered += 1
+        for pattern, queues in list(self._pattern_subs.items()):
+            if fnmatchcase(channel, pattern):
+                for q in list(queues):
+                    await q.put(("pmessage", data))
+                    delivered += 1
+        return delivered

--- a/core/gateway/services/gateway/tests/test_multiplex.py
+++ b/core/gateway/services/gateway/tests/test_multiplex.py
@@ -172,9 +172,9 @@ async def test_invalid_api_key_closes_4401():
     assert ws.close_code == 4401
 
 
-async def test_connect_auto_subscribes_user_channel_and_forwards():
-    # Track G: a valid connect resolves user_id (7) and auto-subscribes `u:7:meetings`, with no
-    # client `subscribe` frame. A frame published to that channel reaches the socket verbatim.
+async def test_connect_auto_subscribes_user_pattern_and_forwards():
+    # A valid connect resolves user_id (7) and auto-subscribes `u:7:*`, with no
+    # client `subscribe` frame. Frames on user topics reach the socket verbatim.
     ws = _WS(inbound=[], api_key=API_KEY, close_when_drained=False)
     redis, auth = _redis_and_auth()
     task = asyncio.ensure_future(_run_multiplex(ws, auth, redis))
@@ -197,6 +197,20 @@ async def test_connect_auto_subscribes_user_channel_and_forwards():
     assert any(
         f.get("type") == "meeting.status" and f.get("status") == "scheduled" for f in ws.sent
     ), ws.sent
+
+    await redis.publish("u:7:workspace", json.dumps({
+        "type": "workspace.committed", "workspace_id": "personal", "commit_sha": "abc123"
+    }))
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert any(f.get("type") == "workspace.committed" for f in ws.sent), ws.sent
+
+    await redis.publish("u:8:workspace", json.dumps({
+        "type": "workspace.committed", "workspace_id": "other", "commit_sha": "secret"
+    }))
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not any(f.get("commit_sha") == "secret" for f in ws.sent), ws.sent
 
     ws.disconnect()
     await task

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -27,7 +27,10 @@ the conformance harness — the conformance assertions therefore drive THIS ship
 from __future__ import annotations
 
 import asyncio
+import json
 import time
+import uuid
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import FastAPI, Request
@@ -39,6 +42,26 @@ from .collector.app import build_router as _build_collector_router
 from .collector.ports import RedisBus, TranscriptStore
 from .lifecycle.machine import LifecycleSink, MeetingStore
 from .obs import TraceMiddleware
+
+
+async def _publish_user_meetings_changed(redis, *, user_id, meeting_id, change: str,
+                                         meeting: Optional[dict] = None) -> None:
+    """Best-effort additive ``ws.v1`` collection notification for the authenticated user feed."""
+    if redis is None or user_id is None or meeting_id is None:
+        return
+    frame = {
+        "type": "meetings.changed",
+        "event_id": f"evt_{uuid.uuid4().hex}",
+        "meeting_id": meeting_id,
+        "change": change,
+        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if meeting is not None:
+        frame["meeting"] = meeting
+    try:
+        await redis.publish(f"u:{user_id}:meetings", json.dumps(frame, default=str))
+    except Exception:  # noqa: BLE001 - WS notification must not fail the lifecycle callback
+        pass
 
 
 def _xpending_total(summary) -> "Optional[int]":
@@ -503,6 +526,13 @@ def _mount_lifecycle(
                         log_event("user_meeting_status_publish_failed", audience="system",
                                   level="warning", span="lifecycle.callback",
                                   fields={"error": str(e)})
+                await _publish_user_meetings_changed(
+                    redis,
+                    user_id=user_id,
+                    meeting_id=meeting_id,
+                    change="status_changed",
+                    meeting=meeting_row,
+                )
         # COPILOT REAP (Bug 3): the moment a meeting lands TERMINAL, emit the `session_end` marker onto
         # the meeting copilot transcript feed — the EXACT stream the meeting copilot worker
         # (agent worker/meeting.py, via VEXA_TRANSCRIPT_STREAM) blocks on. The worker reaps immediately

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -31,6 +31,9 @@ gateway's contextvars (the cross-hop trace ``test_tracing.py`` asserts).
 """
 from __future__ import annotations
 
+import json
+import uuid
+from datetime import datetime, timezone
 from typing import Any, Callable, Optional
 
 from fastapi import APIRouter, FastAPI, Header, HTTPException, Query, Request, Response
@@ -68,8 +71,6 @@ async def _publish_user_meeting_status(
     (the gateway forwards the redis payload verbatim). No-op if redis is down / args missing."""
     if redis is None or user_id is None or meeting_id is None:
         return
-    import json as _json
-
     frame = {
         "type": "meeting.status",
         "meeting_id": meeting_id,
@@ -78,10 +79,38 @@ async def _publish_user_meeting_status(
         "when": when,
     }
     try:
-        await redis.publish(f"u:{user_id}:meetings", _json.dumps(frame))
+        await redis.publish(f"u:{user_id}:meetings", json.dumps(frame, default=str))
     except Exception as e:  # noqa: BLE001 — publish is best-effort
         log_event("user_meeting_status_publish_failed", audience="system", level="warning",
                   span="meetings.intent.publish", fields={"error": str(e)})
+
+
+async def _publish_user_meetings_changed(
+    redis,
+    *,
+    user_id,
+    meeting_id,
+    change: str,
+    meeting: Optional[dict] = None,
+    log_event: Callable[..., dict],
+) -> None:
+    """Publish the additive ``ws.v1`` collection-change frame beside legacy meeting.status."""
+    if redis is None or user_id is None or meeting_id is None:
+        return
+    frame = {
+        "type": "meetings.changed",
+        "event_id": f"evt_{uuid.uuid4().hex}",
+        "meeting_id": meeting_id,
+        "change": change,
+        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if meeting is not None:
+        frame["meeting"] = meeting
+    try:
+        await redis.publish(f"u:{user_id}:meetings", json.dumps(frame))
+    except Exception as e:  # noqa: BLE001 - notification fan-out must not fail the write
+        log_event("user_meetings_changed_publish_failed", audience="system", level="warning",
+                  span="meetings.changed.publish", fields={"error": str(e)})
 
 
 def _resolve_user_id(x_user_id: Optional[str]) -> int:
@@ -361,6 +390,10 @@ def build_router(
             redis, user_id=user_id, meeting_id=row.get("id"), native_id=native_id,
             status=row.get("status"), when=scheduled_at, log_event=log_event,
         )
+        await _publish_user_meetings_changed(
+            redis, user_id=user_id, meeting_id=row.get("id"), change="created",
+            meeting=row, log_event=log_event,
+        )
         return JSONResponse(status_code=201, content=row)
 
     # --- PATCH /meetings/{meeting_id} → EDIT a PLANNED meeting by ROW id (title / time / link /
@@ -443,6 +476,10 @@ def build_router(
             native_id=row.get("native_meeting_id"), status=row.get("status"),
             when=(row.get("data") or {}).get("scheduled_at"), log_event=log_event,
         )
+        await _publish_user_meetings_changed(
+            redis, user_id=user_id, meeting_id=meeting_id, change="updated",
+            meeting=row, log_event=log_event,
+        )
         return row
 
     async def _apply_meeting_delete(user_id: int, meeting_id: int) -> None:
@@ -460,6 +497,10 @@ def build_router(
         await _publish_user_meeting_status(
             redis, user_id=user_id, meeting_id=meeting_id, native_id=None,
             status="deleted", when=None, log_event=log_event,
+        )
+        await _publish_user_meetings_changed(
+            redis, user_id=user_id, meeting_id=meeting_id, change="deleted",
+            log_event=log_event,
         )
 
     @router.patch("/meetings/{meeting_id}")
@@ -780,6 +821,10 @@ def build_router(
                 status=intent,
                 when=result.get("scheduled_at"),
                 log_event=log_event,
+            )
+            await _publish_user_meetings_changed(
+                redis, user_id=user_id, meeting_id=result.get("id"), change="updated",
+                meeting=result, log_event=log_event,
             )
         return JSONResponse(content={
             "meeting_id": result.get("id"),

--- a/core/meetings/services/meeting-api/tests/test_meeting_intent.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_intent.py
@@ -110,8 +110,8 @@ def test_intent_publishes_user_channel_frame():
     client, _store, redis, mid = _client(status="idle")
     r = client.put(f"/meetings/{PLAT}/{NID}/intent", json={"intent": "scheduled", "at": AT}, headers=H)
     assert r.status_code == 200
-    assert len(redis.published) == 1
-    channel, raw = redis.published[0]
+    assert len(redis.published) == 2
+    channel, raw = next((c, p) for c, p in redis.published if json.loads(p)["type"] == "meeting.status")
     assert channel == f"u:{USER}:meetings"
     frame = json.loads(raw)
     assert frame == {
@@ -121,6 +121,10 @@ def test_intent_publishes_user_channel_frame():
         "status": "scheduled",
         "when": AT,
     }
+    changed = next(json.loads(p) for c, p in redis.published if json.loads(p)["type"] == "meetings.changed")
+    assert changed["meeting_id"] == mid
+    assert changed["change"] == "updated"
+    assert changed["user_id"] == str(USER)
 
 
 def test_intent_idempotent_noop_does_not_publish():


### PR DESCRIPTION
## Summary

Implement the world-facing WebSocket EDGE user fan-out for authenticated clients.

## Changes

- Automatically pattern-subscribe authenticated `/ws` connections to `u:{user_id}:*`.
- Preserve exact per-meeting subscriptions and clean up all async Redis listeners on disconnect.
- Add `ws.v1` frames for `meetings.changed`, `workspace.committed`, and `routine.status`.
- Wire meeting, workspace commit, and routine producers to publish user-scoped events.
- Add schemas, goldens, documentation, gateway fake Redis support, and focused fan-out coverage.

## Validation

- Modified Python modules compile successfully with `py_compile`.
- JSON schemas, goldens, and contract seal parse successfully.
- Standalone user-isolation acceptance test passes.
- `git diff --check` passes.

The full repository pytest/AJV commands could not run in the local environment because `uv`/`pytest` and the Node `ajv` dependency are unavailable.