### PR TITLE
fix(meetings): keep calendar snapshots out of lists

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
@@ -1,9 +1,9 @@
 """List-view shaping for the meetings list (#584).
 
 The meetings-list endpoints (``GET /bots``, ``GET /meetings``) return a row PER meeting. Each row used
-to embed that meeting's full ``data`` JSONB — transcripts, speaker events, logs, recordings. On a real
-583-meeting account the list response was 4.6 MB, and serializing it on the meeting-api event loop
-under morning load wedged the loop and caused a ~1.5 h hosted read outage (2026-07-15).
+to embed that meeting's full ``data`` JSONB — transcripts, speaker events, logs, recordings, and
+calendar event snapshots. Those details can make a single page multi-megabyte even though no list
+consumer renders them.
 
 We cannot drop ``data`` from the list wholesale — the list genuinely renders a few LIGHT keys from it
 (a meeting's ``title``, connected ``docs``, ``scheduled_at``, the recording/transcribe flags). So the
@@ -20,11 +20,9 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 # Heavy per-meeting ``data`` keys the list NEVER renders — dropped from list rows. Everything else
-# (title, docs, scheduled_at, workspace_id, constructed_meeting_url, recording/transcribe flags, …)
-# rides along, because the list DOES render some of it. Full ``data`` stays on ``GET /meetings/{id}``.
-# Measured weight on the outage account (sum across meetings / max in one): speaker_events 155 MB /
-# 3.2 MB, bot_logs 78 MB, recordings 13 MB, status_transition 6 MB, last_error 2 MB / 2 MB,
-# chat_messages 796 KB. Dropping these removes ~99% of the list's bytes.
+# (title, docs, scheduled_at, calendar_connection_id, calendar_uid, workspace_id,
+# constructed_meeting_url, recording/transcribe flags, …) rides along, because the list DOES render
+# some of it. Full ``data`` stays on ``GET /meetings/{id}``.
 LIST_OMIT_KEYS = frozenset({
     "speaker_events",
     "bot_logs",
@@ -33,6 +31,7 @@ LIST_OMIT_KEYS = frozenset({
     "chat_messages",
     "error_details",
     "last_error",
+    "calendar_sources",
 })
 
 # Default page size applied on the list-view path when a caller passes no ``limit`` — turns an

--- a/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
+++ b/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
@@ -37,6 +37,9 @@ HEAVY_DATA = {
     "constructed_meeting_url": "https://meet.google.com/abc-defg-hij",
     "title": "Weekly sync",
     "docs": [{"workspace": "u", "path": "notes.md"}],
+    "calendar_connection_id": "calendar-primary",
+    "calendar_uid": "weekly-sync@example.com",
+    "scheduled_at": "2026-08-20T10:00:00Z",
     # heavy detail keys the LIST must never ship (the outage cause)
     "speaker_events": [{"i": i, "t": "x" * 64} for i in range(2000)],   # the ~3 MB-class key
     "bot_logs": ["log-line " * 8] * 2000,
@@ -44,10 +47,23 @@ HEAVY_DATA = {
     "status_transition": [{"to": "active"}],
     "chat_messages": [{"m": "hi"}],
     "last_error": {"trace": "x" * 5000},
+    "calendar_sources": [{
+        "calendar_connection_id": "calendar-primary",
+        "calendar_uid": "weekly-sync@example.com",
+        "display_name": "Primary calendar",
+        "event": {
+            "component": {
+                "properties": [
+                    {"name": f"X-PROVIDER-{i:04d}", "value": "x" * 128}
+                    for i in range(2000)
+                ],
+            },
+        },
+    }],
 }
 
 HEAVY_KEYS = ("speaker_events", "bot_logs", "recordings", "status_transition",
-              "chat_messages", "error_details", "last_error")
+              "chat_messages", "error_details", "last_error", "calendar_sources")
 
 
 def _client(store):
@@ -89,6 +105,9 @@ def test_list_row_drops_heavy_data_keeps_light(path):
     # …but the light metadata the list actually renders survives.
     assert row["data"].get("title") == "Weekly sync"
     assert row["data"].get("docs") == [{"workspace": "u", "path": "notes.md"}]
+    assert row["data"].get("calendar_connection_id") == "calendar-primary"
+    assert row["data"].get("calendar_uid") == "weekly-sync@example.com"
+    assert row["data"].get("scheduled_at") == "2026-08-20T10:00:00Z"
     assert row["constructed_meeting_url"] == "https://meet.google.com/abc-defg-hij"
     assert row["status"] == "active" and row["native_meeting_id"] == "abc-defg-hij"
     # the whole list response is a few KB, not the multi-MB the stored data would make.
@@ -109,6 +128,7 @@ def test_get_meeting_by_id_still_returns_full_data():
     assert detail.status_code == 200
     body = detail.json()
     assert "data" in body and "speaker_events" in body["data"] and "recordings" in body["data"]
+    assert body["data"]["calendar_sources"][0]["calendar_connection_id"] == "calendar-primary"
 
 
 # ── C2 · default page size + honest has_more ───────────────────────────────────────────────────────
@@ -141,6 +161,43 @@ def test_bots_excludes_planned_rows_before_page_and_has_more_are_computed():
     assert response.status_code == 200
     assert [meeting["status"] for meeting in response.json()["meetings"]] == ["completed"]
     assert response.json()["has_more"] is False
+
+
+def test_populated_calendar_account_history_is_compact_and_excludes_plans():
+    """A populated first page keeps run history small even when Calendar stores full event snapshots."""
+    store = InMemoryTranscriptStore()
+    calendar_sources = HEAVY_DATA["calendar_sources"]
+    for i in range(50):
+        status = "scheduled" if i < 11 else "failed" if i < 14 else "completed"
+        data = {
+            "title": f"Meeting {i}",
+            "calendar_connection_id": "calendar-primary",
+            "calendar_uid": f"meeting-{i}@example.com",
+            "scheduled_at": f"2026-08-{(i % 20) + 1:02d}T10:00:00Z",
+        }
+        if i < 16:
+            data["calendar_sources"] = calendar_sources
+        store.seed_meeting(
+            user_id=USER,
+            platform="google_meet",
+            native_meeting_id=f"calendar-{i:02d}",
+            status=status,
+            created_at=f"2026-08-14T{(i // 60):02d}:{i % 60:02d}:00Z",
+            data=data,
+        )
+
+    response = _client(store).get(
+        "/bots", headers=HEADERS, params={"exclude_planned": "true", "limit": 50},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["meetings"]) == 39
+    assert {meeting["status"] for meeting in body["meetings"]} == {"completed", "failed"}
+    assert all("calendar_sources" not in meeting["data"] for meeting in body["meetings"])
+    assert all(meeting["data"]["calendar_uid"] for meeting in body["meetings"])
+    assert body["has_more"] is False
+    assert len(response.content) < 50_000, f"history page too large: {len(response.content)} bytes"
 
 
 async def test_list_view_applies_default_limit_and_has_more():

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -282,8 +282,10 @@ curl -H "X-API-Key: $API_KEY" "$API_BASE/meetings/12345"
 The two list endpoints — `GET /bots` and `GET /meetings` — return **lightweight rows**. Each row keeps
 its light metadata (id, status, times, `title`, connected docs) but **omits the heavy `data` detail
 keys**: `speaker_events`, `bot_logs`, `recordings`, `status_transition`, `chat_messages`,
-`error_details`, and `last_error`. Fetch a meeting's full `data` from `GET /meetings/{meeting_id}` — the
-detail endpoint is unaffected and still returns every key.
+`error_details`, `last_error`, and the complete `calendar_sources` event snapshots. Compact calendar
+identity such as `calendar_connection_id`, `calendar_uid`, and `scheduled_at` remains available in a
+list row. Fetch a meeting's full `data` from `GET /meetings/{meeting_id}` — the detail endpoint is
+unaffected and still returns every key.
 
 The list is also **paged**: with no `limit`, a default page size of `50` applies (pass `limit`/`offset`
 to page explicitly). `GET /bots` returns `has_more: true` when more rows remain past the current page.


### PR DESCRIPTION
## What changed

- omit full `calendar_sources` event snapshots from `/bots`, `/meetings`, and `/bots/status` list projections
- preserve compact Calendar identity/provenance fields in list rows
- keep full `calendar_sources` on `GET /meetings/{id}`
- document the list/detail contract
- add a populated-account regression fixture proving planned rows stay out of Meetings

## Root cause

The staged Calendar candidate stored full provider event snapshots in `meetings.data.calendar_sources`. List projection did not classify that new key as heavy, so a 50-row first page for the affected account serialized about 4.8 MB before the Dashboard could render. The staged Meeting API image also predated the existing `exclude_planned=true` handler.

## User impact

The Meetings page now receives past run history only and the first-page payload is bounded. Scheduled Calendar meetings remain on the Calendar page. Meeting detail retains complete provenance.

## Validation

Exact commit: `8885c73dd4def70d057475ee150482c2fc8f5684`

- red proof on pre-fix base: 3 failing route tests showing `calendar_sources` leakage
- focused fixed suite: 16 passed
- full Meeting API suite on BBB: 936 passed, 3 skipped
- exact static gates on BBB: green; contract conformance: 5 passed in pinned image
- production-shaped 50-row fixture: 11 scheduled, 3 failed, 36 completed, 16 heavy provenance rows
- actual Compose gateway result: 39 history rows, zero scheduled rows, zero heavy rows, 24,787 bytes, 153 ms
- ten actual Dashboard `/meetings` renders: 77–168 ms total
- isolated 11-service BBB stack healthy; STAGE and PROD untouched

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Fixes the list-performance/history portion of #1150.