### PR TITLE
fix(teams): preserve live drafts and fail closed on speaker identity

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -164,9 +164,9 @@ jobs:
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;
             v0.12.23-rc.10)
-              CANDIDATE_MAP=releases/v0.12.23/candidate-images.bootstrap.json
+              CANDIDATE_MAP=releases/v0.12.23/candidate-images.json
               EXPECTED_MAP_STABLE_TAG=v0.12.23
-              EXPECTED_MAP_SHA256=a993d466d3aa083dafde3e882375b70d1e1c95120af5f2dc542c856c8e80039f
+              EXPECTED_MAP_SHA256=5ad5bd86f5eb8e8a9fe48ef921189998b81fd09af621375b2bf7539d00c37562
               EXPECTED_TOP_DESCRIPTORS=10
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -157,7 +157,16 @@ jobs:
           set -euo pipefail
           case "$VERSION" in
             v0.12.18)
+              CANDIDATE_MAP=releases/v0.12.18/candidate-images.json
+              EXPECTED_MAP_STABLE_TAG=v0.12.18
               EXPECTED_MAP_SHA256=80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f
+              EXPECTED_TOP_DESCRIPTORS=10
+              EXPECTED_PLATFORM_IDENTITIES=19
+              ;;
+            v0.12.23-rc.10)
+              CANDIDATE_MAP=releases/v0.12.23/candidate-images.bootstrap.json
+              EXPECTED_MAP_STABLE_TAG=v0.12.23
+              EXPECTED_MAP_SHA256=a993d466d3aa083dafde3e882375b70d1e1c95120af5f2dc542c856c8e80039f
               EXPECTED_TOP_DESCRIPTORS=10
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;
@@ -167,8 +176,9 @@ jobs:
               ;;
           esac
           node scripts/registry-candidate-validate.mjs \
-            --candidate-map "releases/$VERSION/candidate-images.json" \
+            --candidate-map "$CANDIDATE_MAP" \
             --tag "$VERSION" \
+            --expected-map-stable-tag "$EXPECTED_MAP_STABLE_TAG" \
             --expected-map-sha256 "$EXPECTED_MAP_SHA256" \
             --expected-top-descriptors "$EXPECTED_TOP_DESCRIPTORS" \
             --expected-platform-identities "$EXPECTED_PLATFORM_IDENTITIES"

--- a/core/meetings/modules/mixed-pipeline/README.md
+++ b/core/meetings/modules/mixed-pipeline/README.md
@@ -14,9 +14,11 @@ mixed PCM is routed only to the CSRC owners active at that moment; genuine overl
 feed more than one virtual channel. Each channel uses the shared faithful Google Meet window
 ([`buffer`](../buffer/) LocalAgreement, prompt feedback, full-text fallback and timeout flush), and
 [`TrackNamer`](src/track-namer.ts) earns the CSRC-to-display-name binding from Teams evidence.
-After confirmation, [`teams-contested-word-marker.ts`](src/teams-contested-word-marker.ts) marks
-only phrases proven duplicated by routed-audio overlap, matching text, and nearby Whisper word
-times. Both rows stay in the API as `⟦words⟧{CSRC A↔CSRC B}`; the pipeline does not choose a winner.
+After confirmation, [`teams-contested-word-marker.ts`](src/teams-contested-word-marker.ts) detects
+phrases proven duplicated by routed-audio overlap, matching text, and nearby Whisper word times.
+The unresolved-pair count stays in pipeline telemetry, both rows keep their verbatim confirmed text,
+and the pipeline does not choose a winner. CSRC diagnostic notation is evaluation-only and never
+enters the API, Dashboard, or exports.
 
 There is **no Pyannote, diarization, clustering, embedding, or voiceprint in the Teams path**.
 Pyannote remains packaged only because Zoom/Jitsi still use the legacy lane; deleting it from those
@@ -61,10 +63,11 @@ segmenter (`makeSegmenter`) and a scripted/stub Whisper, so the ONNX model is ne
 loaded and there is no network:
 - `confirm-loop.golden.test.ts` — pins the LocalAgreement-3 confirm/pending/prompt/id
   loop (the shared `@vexa/transcribe-buffer` behavior) with a scripted stub Whisper.
-- `teams-contested-word-marker.test.ts` — pins exact, symmetric, no-winner marking and its routed
-  overlap/word-time negative controls.
-- `teams-csrc-gmeet-pipeline.test.ts` — proves the actual Teams publish callback receives the marked
-  API rows while the shared GMeet-compatible buffer remains unchanged.
+- `teams-contested-word-marker.test.ts` — pins the evaluation-only exact, symmetric diagnostic and
+  its routed-overlap/word-time negative controls.
+- `teams-csrc-gmeet-pipeline.test.ts` — proves the production Teams publish callback keeps confirmed
+  text verbatim while telemetry counts the unresolved pair and the shared GMeet-compatible buffer
+  remains unchanged.
 - `naming.smoke.test.ts` — a hint name binds to a segmentation turn (hints-only namer).
 - `claim.smoke.test.ts` — late-box claim: a turn that finalized provisionally is
   repainted to the speaker whose box lit within `CLAIM_WINDOW_MS`.

--- a/core/meetings/modules/mixed-pipeline/TEAMS_CSRC_CONTESTED_TRANSCRIPTS.md
+++ b/core/meetings/modules/mixed-pipeline/TEAMS_CSRC_CONTESTED_TRANSCRIPTS.md
@@ -6,7 +6,7 @@ transport, transcript context, Whisper confidence, row length, or timing coverag
 
 ## Current contract
 
-A phrase is marked contested only when rows from different CSRCs satisfy all three observations:
+A phrase is detected as contested only when rows from different CSRCs satisfy all three observations:
 
 1. their routed mixed-audio intervals overlap;
 2. their normalized transcript contains the same contiguous phrase above the configured text
@@ -14,7 +14,8 @@ A phrase is marked contested only when rows from different CSRCs satisfy all thr
 3. consensus Whisper word times for that phrase are close enough across the two lane windows.
 
 This is duplicate detection, not speaker identification. Every detected pair stays in the
-transcript under both CSRCs and only the exact shared phrase is wrapped:
+transcript under both CSRCs with verbatim confirmed text. The exact shared phrase may be wrapped in
+evaluation-only diagnostics:
 
 ```text
 CSRC 201: it. ⟦It's not like plug and⟧{CSRC 201↔CSRC 840} plug.
@@ -23,11 +24,12 @@ CSRC 840: ⟦It's not like plug and⟧{CSRC 840↔CSRC 201} play kind of PowerPo
 
 There is no winner, loser, score, confidence, deletion, or reassignment. Different simultaneous
 wording remains ordinary independent speech. If word-time evidence is missing or too distant, the
-detector emits no contested marker rather than widening the marked interval.
+detector records no contested pair rather than widening the detected interval.
 
-The production detector is post-confirm and pre-publish inside the Teams pipeline. The browser
-evaluation copy stays independent so a fixture can audit the production output rather than create
-it:
+The production detector is post-confirm inside the Teams pipeline and exposes only the unresolved
+pair count through pipeline health. Public transcript text is never rewritten. The browser
+evaluation copy stays independent and may render the explicit notation so a fixture can audit the
+detector rather than create production output:
 
 ```text
 /Users/dmitriygrankin/dev/vexa/core/meetings/modules/mixed-pipeline/src/teams-contested-word-marker.ts
@@ -37,8 +39,9 @@ it:
 /Users/dmitriygrankin/dev/vexa/core/meetings/modules/mixed-pipeline/eval-ui/teams-csrc-live-model.mjs
 ```
 
-The API text is the source of the marker. Terminal rendering may hide the wire suffix visually,
-but it must not infer, widen, resolve, or delete a contest.
+The marker is an evaluation diagnostic, not a transcript wire format. The API, Dashboard and
+exports receive the original confirmed text. A consumer must not infer, widen, resolve, or delete a
+contest from text.
 
 ## Why the heuristic resolver is rejected
 
@@ -54,8 +57,8 @@ mixed PCM + CSRC activity
         -> per-CSRC continuous GMeet-compatible windows
         -> confirmed rows
         -> overlap + same phrase + word-time proximity
-        -> wrap exact words on both rows as contested
-        -> publish without guessing ownership
+        -> count the unresolved pair in telemetry
+        -> publish both verbatim rows without guessing ownership
 ```
 
 ## Future fix: session-local diarization centroids
@@ -86,8 +89,8 @@ padding. Run speaker-change/overlap segmentation inside that raw mixed-audio cut
 physical waveform shared by the rival lanes—not one independent audio sample per CSRC.
 
 If the envelope contains one stable voice region, embed that region and compare it with the eligible
-session centroids. If it contains simultaneous voices that cannot be separated, keep the existing
-contested notation. Whisper word times locate the experiment window; they never identify the voice.
+session centroids. If it contains simultaneous voices that cannot be separated, keep both verbatim
+rows unresolved. Whisper word times locate the experiment window; they never identify the voice.
 
 ### 3. Resolve or abstain
 
@@ -136,5 +139,5 @@ interface TeamsContestedAcousticResolution {
   by aggregate accuracy alone; and
 - meeting teardown proves no centroid remains addressable.
 
-Until those gates pass, contested words remain duplicated and explicitly wrapped. That is the only
-safe current behavior.
+Until those gates pass, contested words remain duplicated with verbatim text and an internal
+unresolved-pair signal. That is the only safe current behavior.

--- a/core/meetings/modules/mixed-pipeline/src/teams-contested-word-marker.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/teams-contested-word-marker.test.ts
@@ -73,4 +73,4 @@ check('same text far apart in Whisper word time is not a contest',
   detectTeamsWordContest(left, distantRight, distantSubmissions, spans) === null);
 
 if (failed > 0) process.exit(1);
-console.log('\n✅ Teams contested-word marking stays post-confirm, exact, symmetric, and unresolved.');
+console.log('\n✅ Teams contested-word evaluation diagnostics stay exact, symmetric, and unresolved.');

--- a/core/meetings/modules/mixed-pipeline/src/teams-csrc-gmeet-pipeline.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/teams-csrc-gmeet-pipeline.test.ts
@@ -186,12 +186,14 @@ await boundedPipeline.dispose();
 
 let contestNow = 0;
 const contestedDurable = new Map<string, TeamsCsrcTranscriptSegment>();
+const contestedCallbacks: TeamsCsrcTranscriptSegment[] = [];
 const contestedPipeline = new TeamsCsrcGmeetPipeline({
   lookbackMs: 0,
   flickerHoldMs: 0,
   onsetGapMs: 1000,
   buffer: { scheduleSubmissions: false, now: () => contestNow, silenceRmsThreshold: 0 },
   onSegment: (segment) => {
+    contestedCallbacks.push({ ...segment });
     if (!segment.completed && !segment.text.trim()) contestedDurable.delete(segment.segmentId);
     else contestedDurable.set(segment.segmentId, segment);
   },
@@ -235,13 +237,23 @@ contestNow = 6000;
 await contestedPipeline.requestTranscription(201);
 await contestedPipeline.requestTranscription(840);
 const contestedRows = [...contestedDurable.values()].filter((segment) => segment.completed);
-check('actual Teams pipeline marks exact duplicated words symmetrically before API publication',
+const contestedTextCallbacks = contestedCallbacks.filter((segment) => segment.text.trim());
+check('every live publication callback keeps contest diagnostics out of transcript text',
+  contestedTextCallbacks.length > 0
+    && contestedTextCallbacks.every((segment) => !segment.text.includes('{CSRC ')
+      && !segment.text.includes('⟦') && !segment.text.includes('↔'))
+    && contestedTextCallbacks.every((segment) => segment.csrc === 201
+      ? segment.text === 'ask amazing amazing like really good'
+      : segment.csrc === 840 && segment.text === 'amazing amazing like really good answer'),
+  JSON.stringify(contestedCallbacks));
+check('actual Teams pipeline keeps confirmed public text verbatim when it detects a contest',
   contestedRows.some((segment) => segment.csrc === 201
-    && segment.text.includes('⟦amazing amazing like really good⟧{CSRC 201↔CSRC 840}'))
+    && segment.text === 'ask amazing amazing like really good')
     && contestedRows.some((segment) => segment.csrc === 840
-      && segment.text.includes('⟦amazing amazing like really good⟧{CSRC 840↔CSRC 201}')),
+      && segment.text === 'amazing amazing like really good answer')
+    && contestedRows.every((segment) => !segment.text.includes('{CSRC ') && !segment.text.includes('⟦')),
   JSON.stringify(contestedRows));
-check('the pipeline health exposes the unresolved pair', contestedPipeline.health().contestedPairs === 1,
+check('the pipeline health still exposes the unresolved pair without mutating transcript text', contestedPipeline.health().contestedPairs === 1,
   JSON.stringify(contestedPipeline.health()));
 await contestedPipeline.dispose();
 

--- a/core/meetings/modules/mixed-pipeline/src/teams-csrc-gmeet-pipeline.ts
+++ b/core/meetings/modules/mixed-pipeline/src/teams-csrc-gmeet-pipeline.ts
@@ -7,7 +7,6 @@ import type { TranscriptionResult } from '@vexa/transcribe-whisper';
 import { teamsWindowHallucinationRule } from './hallucination-gate.js';
 import {
   detectTeamsWordContest,
-  markTeamsWordContests,
   type TeamsContestSubmission,
   type TeamsRoutedSpan,
   type TeamsWordContest,
@@ -135,9 +134,10 @@ interface PendingDraft {
  * whether each window's prompt/continuity makes Whisper follow its established speaker is an
  * empirical property, never claimed as acoustic source separation.
  *
- * Time-and-word duplicates across simultaneously active CSRC lanes are marked post-confirm and
- * pre-publish. Both rows remain and no winner is inferred. The shared GMeet-compatible buffer is
- * unchanged; the deferred embedding resolver is documented in ../TEAMS_CSRC_CONTESTED_TRANSCRIPTS.md.
+ * Time-and-word duplicates across simultaneously active CSRC lanes are detected post-confirm for
+ * telemetry. Both rows remain, their public text stays verbatim, and no winner is inferred. The
+ * shared GMeet-compatible buffer is unchanged; the deferred embedding resolver is documented in
+ * ../TEAMS_CSRC_CONTESTED_TRANSCRIPTS.md.
  */
 export class TeamsCsrcGmeetPipeline {
   private readonly manager: GmeetCompatibleBuffer;
@@ -158,7 +158,7 @@ export class TeamsCsrcGmeetPipeline {
   private readonly sourceLastAudioMs = new Map<string, number>();
   /** Latest public row by stable id, retained only so a late proven name can repaint it. */
   private readonly published = new Map<string, TeamsCsrcTranscriptSegment>();
-  /** Unmarked rows are the evidence source; public rows may contain unresolved contest notation. */
+  /** Verbatim rows are the evidence source; diagnostic contest notation never enters public text. */
   private readonly rawPublished = new Map<string, TeamsCsrcTranscriptSegment>();
   private readonly contestSubmissions: TeamsContestSubmission[] = [];
   private readonly routedSpans: TeamsRoutedSpan[] = [];
@@ -489,7 +489,8 @@ export class TeamsCsrcGmeetPipeline {
       this.latestRoutedSpan.set(csrc, span);
     }
     // Word-contest evidence is needed only while a rival timestamp-overlapping row can still
-    // arrive. Keep the markers themselves for the meeting, but bound raw word traces and spans.
+    // arrive. Retain the detected pair count for meeting telemetry, but bound raw word traces and
+    // routed spans. Diagnostic notation must never be written into the customer transcript.
     const evidenceFloorMs = endMs - 120_000;
     for (let index = this.routedSpans.length - 1; index >= 0; index--) {
       if (this.routedSpans[index].endMs < evidenceFloorMs) this.routedSpans.splice(index, 1);
@@ -530,9 +531,10 @@ export class TeamsCsrcGmeetPipeline {
   }
 
   private reconcilePublished(): void {
-    const contests = [...this.contests.values()];
     for (const raw of this.rawPublished.values()) {
-      const desired = { ...raw, text: markTeamsWordContests(raw, contests) };
+      // Contest detection is internal abstention/telemetry. Customer transcript text is always
+      // Whisper's confirmed text verbatim; implementation diagnostics never enter public rows.
+      const desired = raw;
       const previous = this.published.get(raw.segmentId);
       if (previous && previous.text === desired.text && previous.speaker === desired.speaker
           && previous.completed === desired.completed && previous.startMs === desired.startMs

--- a/core/meetings/modules/mixed-pipeline/src/track-namer.smoke.test.ts
+++ b/core/meetings/modules/mixed-pipeline/src/track-namer.smoke.test.ts
@@ -124,6 +124,7 @@ check('identity suffix normalization keeps its existing semantics without a back
   n.noteHeard('201');
   n.noteHeard('1266');
   for (const nm of ['leo (Unverified)', 'Dmitry Grankin']) { n.recordRosterName(nm, 0); n.recordRosterName(nm, 100); }
+  n.recordRosterCoverage(2, 2, 100);
   n.tick(6000);   // past the roster settle, before any speaking evidence exists
   check('two unnamed tracks and two unclaimed names ⇒ elimination REFUSES',
     n.nameFor('201') === null && n.nameFor('1266') === null, JSON.stringify(n.stats().how));
@@ -167,6 +168,7 @@ check('identity suffix normalization keeps its existing semantics without a back
   check('an uncorroborated roster name cannot pair with anything',
     n.nameFor('solo') === null, JSON.stringify(n.stats().roster));
   n.recordRosterName('Flicker', 100);
+  n.recordRosterCoverage(1, 1, 100);
   n.tick(60_000);   // the room settled and nobody new appeared
   check('a second sighting plus a settled roster makes it usable',
     n.nameFor('solo') === 'Flicker', JSON.stringify(n.stats().how));
@@ -281,6 +283,62 @@ check('identity suffix normalization keeps its existing semantics without a back
     m.nameFor('b') === 'Bo' && m.naming('b')?.source === 'elimination', JSON.stringify(m.stats().how));
 }
 {
+  // Silence from the producer is not evidence that the roster was complete. The legacy behavior
+  // treated a missing coverage statement as permission and could therefore draw elimination from a
+  // partial selector result. A modern Teams producer always states coverage; absence fails closed.
+  const n = namer({ rosterSightings: 2 });
+  n.noteHeard('a'); n.noteHeard('b');
+  for (const nm of ['Ana', 'Bo']) { n.recordRosterName(nm, 0); n.recordRosterName(nm, 10); }
+  for (const t0 of [10_000, 30_000]) {
+    n.setTrackActive('a', true, t0);
+    for (let t = t0; t < t0 + 4000; t += 1000) n.recordHint('Ana', t + 1000);
+    n.setTrackActive('a', false, t0 + 4000);
+  }
+  n.tick(60_000);
+  check('NO coverage statement means NO roster elimination',
+    n.naming('a')?.source === 'evidence' && n.nameFor('b') === null, JSON.stringify(n.stats()));
+}
+{
+  // A transient empty DOM scan is not a proof that the previously retained roster became complete.
+  // The producer can report 0/0 while Teams re-mounts its participant surface; old names persist so
+  // the empty coverage statement must never revive an elimination from stale presence.
+  const n = namer({ rosterSightings: 2 });
+  n.noteHeard('solo');
+  n.recordRosterName('Ana', 0); n.recordRosterName('Ana', 10);
+  n.recordRosterCoverage(1, 2, 20);
+  n.recordRosterCoverage(0, 0, 30);
+  n.tick(60_000);
+  check('0/0 coverage cannot turn a retained roster name into a speaker',
+    n.nameFor('solo') === null, JSON.stringify(n.stats()));
+}
+{
+  // Nor may a later complete-looking subset (1/1) authorize an old second name retained from an
+  // earlier scan. Coverage must account for every usable identity elimination would draw from.
+  const n = namer({ rosterSightings: 2 });
+  n.noteHeard('a'); n.noteHeard('b');
+  for (const nm of ['Ana', 'Bo']) { n.recordRosterName(nm, 0); n.recordRosterName(nm, 10); }
+  for (const t0 of [10_000, 30_000]) {
+    n.setTrackActive('a', true, t0);
+    for (let t = t0; t < t0 + 4000; t += 1000) n.recordHint('Ana', t + 1000);
+    n.setTrackActive('a', false, t0 + 4000);
+  }
+  n.recordRosterCoverage(1, 1, 40_000);
+  n.tick(60_000);
+  check('coverage for a subset cannot eliminate from the larger retained roster',
+    n.naming('a')?.source === 'evidence' && n.nameFor('b') === null, JSON.stringify(n.stats()));
+}
+{
+  // The inverse skew is unsafe too: coverage may say it named two participants before the second
+  // roster-name observation crosses the bridge. The one retained name is not the complete set.
+  const n = namer({ rosterSightings: 2 });
+  n.noteHeard('solo');
+  n.recordRosterName('Ana', 0); n.recordRosterName('Ana', 10);
+  n.recordRosterCoverage(2, 2, 20);
+  n.tick(60_000);
+  check('coverage larger than the retained roster cannot eliminate from a partial identity set',
+    n.nameFor('solo') === null, JSON.stringify(n.stats()));
+}
+{
   // The placeholder never becomes a name on ANY path — it arrives shaped exactly like one.
   const n = namer({ rosterSightings: 2, selfName: 'Vexa' });
   n.setTrackActive('1', true, 0);
@@ -335,6 +393,25 @@ check('identity suffix normalization keeps its existing semantics without a back
     !held || /^Speaker /.test(held), `${held}`);
   check('the refusal is emitted as a typed observation, so a tape shows it',
     seen.includes('bot-family-in-roster:Vexa (Unverified)'), JSON.stringify(seen));
+}
+{
+  // Meeting 26218: the local bot joined as "Vexa", while a second bot used meeting-api's generated
+  // fallback identity. Teams qualified it, so the generic machine-token filter did not see the raw
+  // `VexaBot-<hex>` token. With one audio track and false 1/1 coverage, roster elimination painted
+  // every human word with that bot's name. The generated namespace is exact and reserved.
+  for (const selfName of ['Vexa', 'VexaBot-fd5f86', 'Meeting Assistant']) {
+    const seen: string[] = [];
+    const n = namer({ selfName, onObservation: (o) => seen.push(`${o.type}:${o.name}`) });
+    n.setTrackActive('201', true, 0);
+    for (const t of [0, 100, 200]) n.recordRosterName('VexaBot-8f264c (Gość) 2', t);
+    n.recordRosterCoverage(1, 1, 200);
+    n.setTrackActive('201', false, 8000);
+    n.tick(60_000);
+    check(`m26218: generated bot never names speech when self is "${selfName}"`,
+      n.nameFor('201') === null && n.labelFor('201') === 'Speaker A', JSON.stringify(n.stats()));
+    check(`m26218: generated bot refusal is observable when self is "${selfName}"`,
+      seen.includes('bot-family-in-roster:VexaBot-8f264c (Gość) 2'), JSON.stringify(seen));
+  }
 }
 
 // ── 9) …and a roster of ONLY bots is INCOMPLETE, not complete ───────────────────────────────────

--- a/core/meetings/modules/mixed-pipeline/src/track-namer.ts
+++ b/core/meetings/modules/mixed-pipeline/src/track-namer.ts
@@ -123,7 +123,7 @@ const PLACEHOLDER_NAMES = new Set([
 ]);
 
 const IDENTITY_QUALIFIERS = new Set([
-  'unverified', 'guest', 'bot', 'external', 'extern', 'invite', 'invité', 'gast', 'гость',
+  'unverified', 'guest', 'bot', 'external', 'extern', 'invite', 'invité', 'gast', 'gość', 'гость', '外部',
 ]);
 
 const stripParenthesizedIdentitySuffix = (
@@ -161,14 +161,22 @@ const stripNumericIdentitySuffix = (value: string): string => {
 /** Teams' qualifiers, stripped for identity comparison only — never for display. */
 export function normalizeNameForIdentity(value: string): string {
   let normalized = String(value || '').trimEnd();
-  normalized = stripParenthesizedIdentitySuffix(
-    normalized,
-    (suffix) => IDENTITY_QUALIFIERS.has(suffix.toLowerCase()),
-  );
-  normalized = stripParenthesizedIdentitySuffix(normalized, isAsciiDigits);
-  normalized = stripNumericIdentitySuffix(normalized);
+  for (;;) {
+    const previous = normalized;
+    normalized = stripParenthesizedIdentitySuffix(
+      normalized,
+      (suffix) => IDENTITY_QUALIFIERS.has(suffix.toLowerCase()),
+    );
+    normalized = stripParenthesizedIdentitySuffix(normalized, isAsciiDigits);
+    normalized = stripNumericIdentitySuffix(normalized);
+    if (normalized === previous) break;
+  }
   return normalized.trim().toLowerCase();
 }
+
+// meeting-api's exact fallback when a caller supplies no bot name. This reserved machine namespace
+// is safe to recognize; fuzzy role words ("bot", "assistant", "notetaker") are not.
+const GENERATED_DEFAULT_BOT_ID = /^vexabot-[0-9a-f]{6}$/iu;
 
 export type NameEvidenceKind = 'dom' | 'caption';
 
@@ -445,9 +453,10 @@ export class TrackNamer {
   /** Is this name one of OUR OWN KIND — a bot spawned from the same configured stem? Distinct from
    *  `unnameable`, which asks whether the name is ours exactly. Roster-only by design. */
   private botFamily(name: string): boolean {
-    if (!this.selfStem) return false;
     const id = normalizeNameForIdentity(name);
     if (!id) return false;
+    if (GENERATED_DEFAULT_BOT_ID.test(id)) return true;
+    if (!this.selfStem) return false;
     return id.split(' ')[0] === this.selfStem;
   }
 
@@ -936,7 +945,10 @@ export class TrackNamer {
     // participants it could not name, the unclaimed set is missing people and the "only one left"
     // is an artefact of what we failed to read. m34 again: four tiles, two names — and the two it
     // could not name included the human the rule then mislabelled.
-    if (this.rosterCoverage && this.rosterCoverage.named < this.rosterCoverage.participants) return;
+    if (!this.rosterCoverage
+      || this.rosterCoverage.participants <= 0
+      || this.rosterCoverage.named !== this.rosterCoverage.participants
+      || this.rosterCoverage.named !== this.roster.size) return;
     const unnamed = this.order.filter((t) => !this.named.has(t));
     if (unnamed.length !== 1) return;
     // A ROSTER THAT IS STILL FILLING IS NOT A ROSTER YOU CAN ELIMINATE AGAINST. Sightings arrive one

--- a/core/meetings/modules/teams-capture/README.md
+++ b/core/meetings/modules/teams-capture/README.md
@@ -6,12 +6,15 @@ Runs **inside the meeting page**. Like Zoom, Teams delivers one mixed audio stre
 [`@vexa/mixed-capture-core`](../mixed-capture-core/)), so this brick provides only the **WHO** signal —
 no audio of its own:
 
-- `createTeamsSpeakers` — watches Teams' voice-level "blue-square" outline
-  (`[data-tid="voice-level-stream-outline"]` + `vdi-frame-occlusion` on it or an ancestor = actively
-  speaking; NO caption dependency) and emits debounced speaking start/stop per participant → a
-  `mixed-capture.v1` **hint** (kind `dom-outline`). A ~2 s heartbeat re-asserts the current speaker so a
-  consumer that started mid-turn learns who's talking without waiting for the next transition. This
-  module OWNS the Teams speaker-detection selectors — it also exports `teamsParticipantSelectors`,
+- `createTeamsSpeakers` — discovers both Teams' exact voice-level "blue-square" outline
+  (`[data-tid="voice-level-stream-outline"]`) and stable participant stream wrapper
+  (`[data-stream-type][data-tid]`) directly, then canonicalizes nested tile/list surfaces onto them.
+  Ordered style, aria and class indicators emit debounced speaking start/stop per participant → a
+  `mixed-capture.v1` **hint** (kind `dom-outline`), with NO caption dependency. A ~2 s heartbeat
+  re-asserts the current speaker so a consumer that started mid-turn learns who's talking without
+  waiting for the next transition. Missing outlines emit value-free structural diagnostics rather
+  than names or DOM text. This module OWNS the Teams speaker-detection selectors — it also exports
+  `teamsParticipantSelectors`,
   `teamsNameSelectors`, `teamsParticipantIdSelectors`, `teamsMeetingContainerSelectors` (single source;
   the bot's `selectors.ts` re-exports from here).
 - `createTeamsChat` — reads the chat panel (content tier); emits each new message as `{ sender, text }`.

--- a/core/meetings/modules/teams-capture/src/msteams-captions.ts
+++ b/core/meetings/modules/teams-capture/src/msteams-captions.ts
@@ -62,7 +62,7 @@
  * observation and NO caption event. Unknown stays unknown — a diagnostic that
  * becomes a speaker name is a fabricated speaker name.
  */
-import { isTeamsDisplayNameCandidate } from './msteams-speakers.js';
+import { isSelfDisplayName, isTeamsDisplayNameCandidate } from './msteams-speakers.js';
 
 /** Teams live-caption selectors. The wrapper + the two leaf atoms are the 0.10
  * pair, verified live on host AND guest views; the rest are candidates carried so
@@ -250,7 +250,6 @@ export function createTeamsCaptions(opts: TeamsCaptionsOptions): TeamsCaptions {
   const stabilizeMs = opts.stabilizeMs ?? 900;
   const pollMs = opts.pollMs ?? 250;
   const absentAfterMs = opts.absentAfterMs ?? 30_000;
-  const selfLower = (opts.selfName || '').toLowerCase();
 
   const startedAt = now();
   // 'unknown' — nothing seen yet (the enable step may still be in flight);
@@ -431,7 +430,7 @@ export function createTeamsCaptions(opts: TeamsCaptionsOptions): TeamsCaptions {
     const rawSpeaker = (authors.nodes[authors.nodes.length - 1].textContent || '').trim();
     if (!rawSpeaker) { emitUnresolved('author-empty'); return; }
     if (!isTeamsDisplayNameCandidate(rawSpeaker)) { emitUnresolved('author-not-name-shaped'); return; }
-    if (selfLower && rawSpeaker.toLowerCase().includes(selfLower)) {
+    if (isSelfDisplayName(rawSpeaker, opts.selfName)) {
       counters.self++;
       // Our own captions end the previous speaker's entry all the same.
       if (pending && !pending.emitted) emitCaption(pending, true);

--- a/core/meetings/modules/teams-capture/src/msteams-speakers.ts
+++ b/core/meetings/modules/teams-capture/src/msteams-speakers.ts
@@ -176,12 +176,30 @@ const TEAMS_PLACEHOLDER_NAMES = new Set([
  * is Teams' statement about the participant and the transcript keeps it verbatim.
  */
 export function normalizeDisplayNameForIdentity(value: string): string {
-  return (value || '')
-    .replace(/\s*\((?:unverified|guest|bot|external|extern|invit[ée]|gast|gość|гость|外部)\)\s*$/giu, '')
-    .replace(/\s+\(\d+\)\s*$/, '')
-    .replace(/\s+\d+$/, '')
-    .trim()
-    .toLowerCase();
+  let normalized = String(value || '').trimEnd();
+  // Teams can stack a collision suffix after a qualifier ("Name (Guest) 2"). Peel until stable so
+  // the order in which Teams appended the decorations cannot change identity equality.
+  for (;;) {
+    const previous = normalized;
+    normalized = normalized
+      .replace(/\s*\((?:unverified|guest|bot|external|extern|invit[ée]|gast|gość|гость|外部)\)\s*$/giu, '')
+      .replace(/\s+\(\d+\)\s*$/, '')
+      .replace(/\s+\d+$/, '')
+      .trimEnd();
+    if (normalized === previous) break;
+  }
+  return normalized.trim().toLowerCase();
+}
+
+/** The exact machine namespace meeting-api owns for an omitted bot name.
+ *
+ * `VexaBot-${uuid.hex[:6]}` is generated in meeting-api. Teams may append an identity qualifier
+ * or collision suffix, so compare only after the same identity normalization used everywhere
+ * else. This is deliberately exact: words such as "bot", "assistant" and "notetaker" also occur
+ * in legitimate human display names and are not identity evidence.
+ */
+export function isGeneratedDefaultBotDisplayName(value: string): boolean {
+  return /^vexabot-[0-9a-f]{6}$/iu.test(normalizeDisplayNameForIdentity(value));
 }
 
 /** Is `name` the local participant (our bot), whatever qualifier Teams hung off it? */
@@ -205,6 +223,7 @@ export function isTeamsDisplayNameCandidate(value: string): boolean {
   // walk through the door its bare form is refused at.
   if (TEAMS_PLACEHOLDER_NAMES.has(normalized)) return false;
   if (TEAMS_PLACEHOLDER_NAMES.has(normalizeDisplayNameForIdentity(candidate))) return false;
+  if (isGeneratedDefaultBotDisplayName(candidate)) return false;
   return !TEAMS_CONTROL_LABELS.has(normalized)
     && !TEAMS_TIMER_LABEL.test(normalized)
     && !TEAMS_CLOCK_PREFIX.test(normalized)
@@ -246,29 +265,45 @@ export function teamsNameFromStream(element: HTMLElement): string {
  * Names go through `isTeamsDisplayNameCandidate` like every other path in this file, so the panel
  * cannot introduce a name the tiles would have been refused.
  */
-export function readTeamsRosterPanel(root: ParentNode = document): string[] {
+export interface TeamsRosterPanelState {
+  /** Distinct display names resolved from panel rows. */
+  names: string[];
+  /** One entry per distinct panel row; null means the row existed but no safe identity resolved. */
+  entries: Array<string | null>;
+}
+
+export function readTeamsRosterPanelState(root: ParentNode = document): TeamsRosterPanelState {
   const names: string[] = [];
-  const seen = new Set<string>();
+  const entries: Array<string | null> = [];
+  const seenNames = new Set<string>();
+  const seenEntries = new Set<Element>();
   for (const panelSel of teamsRosterPanelSelectors) {
     let panels: Element[] = [];
     try { panels = Array.from(root.querySelectorAll(panelSel)); } catch { continue; }
     for (const panel of panels) {
       for (const entrySel of teamsRosterEntrySelectors) {
-        let entries: Element[] = [];
-        try { entries = Array.from(panel.querySelectorAll(entrySel)); } catch { continue; }
-        for (const entry of entries) {
+        let matchedEntries: Element[] = [];
+        try { matchedEntries = Array.from(panel.querySelectorAll(entrySel)); } catch { continue; }
+        for (const entry of matchedEntries) {
           if (!(entry instanceof HTMLElement)) continue;
+          if (seenEntries.has(entry)) continue;
+          seenEntries.add(entry);
           // Same resolution order as a tile, minus the stream wrapper a roster row does not have:
           // stable attributes first, then the structural leaf scan (#1121) as the rot-proof floor.
           const name = extractTeamsSpeakerName(entry);
-          if (!name || seen.has(name)) continue;
-          seen.add(name);
+          entries.push(name || null);
+          if (!name || seenNames.has(name)) continue;
+          seenNames.add(name);
           names.push(name);
         }
       }
     }
   }
-  return names;
+  return { names, entries };
+}
+
+export function readTeamsRosterPanel(root: ParentNode = document): string[] {
+  return readTeamsRosterPanelState(root).names;
 }
 
 /** Resolve the display name carried by one participant tile.
@@ -557,9 +592,6 @@ type SpeakingState = 'speaking' | 'silent' | 'unknown';
 
 export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
   const log = opts.log || (() => { /* silent */ });
-  // Kept for the substring test below (a tile whose label EMBEDS the bot name); identity
-  // comparisons go through isSelfDisplayName, which strips Teams' qualifiers first.
-  const selfLower = (opts.selfName || '').toLowerCase();
   const debounceMs = opts.debounceMs ?? 300;
   const heartbeatMs = opts.heartbeatMs ?? 2000;
   const indicatorSilentMs = opts.indicatorSilentMs ?? 60_000;
@@ -991,7 +1023,6 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
     }
     unresolvedEpisodes.delete(identity.id);
     if (isSelfDisplayName(identity.name, opts.selfName)) return;                 // our bot, any qualifier
-    if (selfLower && identity.name.toLowerCase().includes(selfLower)) return;   // …or embedding our name
     if (edge === 'end' && !namedEpisodes.delete(identity.id)) return;
     log(`${state === 'speaking' ? '🎤' : '🔇'} [TeamsSpeakers] ${state === 'speaking' ? 'SPEAKER_START' : 'SPEAKER_END'}: ${identity.name} (${identity.id})`);
     if (edge === 'start') emitNamedStart(identity);
@@ -1096,7 +1127,7 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
     let found = 0; let observable = 0;
     scanCounter++;
     const namesThisScan = new Set<string>();
-    let selfTilesThisScan = 0;
+    let unresolvedParticipantSurfaces = 0;
     for (const selector of allSelectors) {
       document.querySelectorAll(selector).forEach(el => {
         if (el instanceof HTMLElement && !seen.has(el)) {
@@ -1106,8 +1137,9 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
           // voice outline is invisible to every other path in this file, and they are exactly the
           // person an elimination argument is for.
           const rosterName = extractTeamsSpeakerName(el);
-          if (rosterName && isSelfDisplayName(rosterName, opts.selfName)) selfTilesThisScan++;
+          if (rosterName && isSelfDisplayName(rosterName, opts.selfName)) { /* local bot */ }
           else if (rosterName) namesThisScan.add(rosterName);
+          else unresolvedParticipantSurfaces++;
           if (hasRequiredSignal(el)) { observable++; observeParticipant(el); }
           else emitSignalAbsent(el);   // counted and reported, never hinted
         }
@@ -1117,8 +1149,9 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
     // into the same stream — a name is a name whichever surface showed it — but counted separately,
     // because "the tiles are gone and the panel saved us" is exactly the state worth being able to
     // see in a fixture afterwards.
-    let panelNames: string[] = [];
-    try { panelNames = readTeamsRosterPanel(document); } catch { panelNames = []; }
+    let panelState: TeamsRosterPanelState = { names: [], entries: [] };
+    try { panelState = readTeamsRosterPanelState(document); } catch { panelState = { names: [], entries: [] }; }
+    const panelNames = panelState.names;
     for (const n of panelNames) if (!isSelfDisplayName(n, opts.selfName)) namesThisScan.add(n);
     lastPanelCount = panelNames.length;
 
@@ -1128,19 +1161,18 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
     // heartbeat: it is a state, and an unchanged state repeated 1800 times is not information.
     const usableNames = new Set([...namesThisScan].filter(
       (n) => isTeamsDisplayNameCandidate(n) && !isSelfDisplayName(n, opts.selfName)));
-    // PEOPLE, NOT ELEMENTS. `found` counts matched ELEMENTS, and Teams renders each participant on
-    // more than one surface — a video tile AND a roster row both match, so a six-person meeting
-    // reported twelve. The consumer reads this as "named 6 of 12" and concludes the roster is half
-    // missing, which permanently disables the elimination rule in exactly the multi-party rooms it
-    // was built for. Measured on the first prod fixture: 3/6, 4/8, 5/10, 6/12, 6/14 — participants
-    // exactly double the names, every scan.
-    //
-    // There is no honest way to count PEOPLE from an element sweep, so it no longer pretends to.
-    // The count is the distinct names resolved; when the roster PANEL was readable it is the
-    // authority, because a panel row is one participant by construction. A scan that resolved every
-    // name it could see reports complete, and one that could not stays short.
-    const participants = Math.max(usableNames.size, panelNames.filter(
-      (n) => !isSelfDisplayName(n, opts.selfName)).length);
+    // COMPLETENESS MUST FAIL CLOSED WITHOUT PRETENDING DOM ELEMENTS ARE PEOPLE. Teams may render the
+    // same named participant on several selector surfaces, so resolved display names are deduped.
+    // An unresolved surface cannot be deduped safely: each is therefore one additional lower-bound
+    // participant. Meeting 26218 had zero usable names and four unresolved surfaces, so it is 0/4;
+    // an ordinary two-person room rendered twice per person but named on every surface is 2/2.
+    const nonSelfPanelEntries = panelState.entries.filter(
+      (name) => !name || !isSelfDisplayName(name, opts.selfName));
+    const distinctUsablePanelNames = new Set(nonSelfPanelEntries.filter(
+      (name): name is string => !!name && isTeamsDisplayNameCandidate(name)));
+    const unresolvedPanelParticipants = Math.max(
+      0, nonSelfPanelEntries.length - distinctUsablePanelNames.size);
+    const participants = usableNames.size + unresolvedParticipantSurfaces + unresolvedPanelParticipants;
     const coverageKey = `${usableNames.size}/${participants}`;
     if (coverageKey !== lastCoverageKey) {
       lastCoverageKey = coverageKey;

--- a/core/meetings/modules/teams-capture/src/msteams-speakers.ts
+++ b/core/meetings/modules/teams-capture/src/msteams-speakers.ts
@@ -29,6 +29,13 @@
  */
 
 export const teamsParticipantSelectors: string[] = [
+  // Start from the exact speaking atom. Its enclosing stream wrapper joins the
+  // active signal to the display name without depending on a gallery layout.
+  '[data-tid="voice-level-stream-outline"]',
+  // The stream wrapper is the canonical participant surface: Teams carries the
+  // display name in data-tid and nests the voice-level outline below it.  Broad
+  // tile/roster selectors remain fallbacks for layouts without this wrapper.
+  '[data-stream-type][data-tid]',
   '[data-tid*="participant"]',
   '[aria-label*="participant"]',
   '[data-tid*="roster"]',
@@ -109,6 +116,20 @@ export const teamsMeetingContainerSelectors: string[] = [
 ];
 
 const VOICE_LEVEL_SELECTOR = '[data-tid="voice-level-stream-outline"]';
+const STREAM_WRAPPER_SELECTOR = '[data-stream-type][data-tid]';
+const STABLE_PARTICIPANT_ROOT_SELECTOR = [
+  '[data-participant-id]',
+  '[data-user-id]',
+  '[data-object-id]',
+  '[data-acc-element-id]',
+  '[data-tid*="participant-tile"]',
+  '[data-tid*="participantTile"]',
+  '[data-tid*="video-tile"]',
+  '[data-tid*="videoTile"]',
+].join(', ');
+function matchesSelector(element: HTMLElement, selector: string): boolean {
+  try { return (element as any).matches?.(selector) === true; } catch { return false; }
+}
 const TEAMS_CONTROL_LABELS = new Set([
   'more_vert', 'mic_off', 'mic', 'videocam', 'videocam_off',
   'present_to_all', 'devices', 'speaker', 'speakers', 'microphone',
@@ -246,7 +267,9 @@ export function isTeamsDisplayNameCandidate(value: string): boolean {
  * Origin: Jacob Schooley, Vexa-ai/vexa#1024 (commit 6fab915e); the guard is added here.
  */
 export function teamsNameFromStream(element: HTMLElement): string {
-  const voiceOutline = element.querySelector(VOICE_LEVEL_SELECTOR) as HTMLElement | null;
+  const voiceOutline = matchesSelector(element, VOICE_LEVEL_SELECTOR)
+    ? element
+    : element.querySelector(VOICE_LEVEL_SELECTOR) as HTMLElement | null;
   const streamEl = (voiceOutline && (voiceOutline as any).closest?.('[data-stream-type][data-tid]'))
     || (element as any).closest?.('[data-stream-type][data-tid]')
     || element.querySelector('[data-stream-type][data-tid]');
@@ -531,7 +554,7 @@ export type TeamsProducerObservation =
 
 /** Coverage + liveness of the WHO signal, for a caller that wants to surface it. */
 export interface TeamsSpeakerHealth {
-  /** Participant-shaped elements the selectors matched on the last scan. */
+  /** Canonical participant surfaces discovered on the last scan. */
   found: number;
   /** …of which carry the voice-level outline (only these can ever be named). */
   observable: number;
@@ -600,7 +623,7 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
   const now = opts.now ?? (() => Date.now());
 
   // ── Coverage accounting (Gate A) ──
-  // Every tile the selectors match is COUNTED, whether or not it is observable.
+  // Every canonical participant surface is COUNTED, whether or not it is observable.
   // The old code returned silently on a missing outline, so 3 of 4 participants
   // were invisible: not observed, not named, and not reported as missing.
   const coverage = { found: 0, observable: 0, roster: 0 };
@@ -622,18 +645,23 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
   const cache = new Map<HTMLElement, Identity>();
 
   function extractId(element: HTMLElement): string {
+    const isStreamWrapper = matchesSelector(element, STREAM_WRAPPER_SELECTOR);
     let id = element.getAttribute('data-acc-element-id') ||
-      element.getAttribute('data-tid') ||
       element.getAttribute('data-participant-id') ||
       element.getAttribute('data-user-id') ||
       element.getAttribute('data-object-id') ||
+      // On a stream wrapper data-tid is the display NAME, not an identity key.
+      // Two people can share a display name, so keep them element-distinct.
+      (!isStreamWrapper ? element.getAttribute('data-tid') : null) ||
       element.getAttribute('id');
     if (!id) {
-      const stableChild = element.querySelector(teamsParticipantIdSelectors.join(', '));
+      const stableChild = element.querySelector(
+        '[data-participant-id], [data-user-id], [data-object-id], [data-acc-element-id]');
       if (stableChild) {
-        id = stableChild.getAttribute('data-tid') ||
-          stableChild.getAttribute('data-participant-id') ||
-          stableChild.getAttribute('data-user-id');
+        id = stableChild.getAttribute('data-participant-id') ||
+          stableChild.getAttribute('data-user-id') ||
+          stableChild.getAttribute('data-object-id') ||
+          stableChild.getAttribute('data-acc-element-id');
       }
     }
     if (!id) {
@@ -659,6 +687,40 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
       identity.name = extractName(element);   // the name div often renders after the tile
     }
     return identity;
+  }
+
+  /**
+   * Collapse nested selector surfaces onto the element that actually joins
+   * identity to the speaking signal.
+   *
+   * Teams may expose an outer participant tile, a list item and the nested
+   * stream wrapper at the same time. Observing/counting each match independently
+   * creates duplicate participants and can strand the name on one subtree while
+   * the voice outline lives on another. The stream wrapper is therefore the
+   * canonical floor. When it sits inside a root carrying a stable participant
+   * identifier, retain that root so state survives name/layout changes.
+   */
+  function canonicalParticipantSurface(element: HTMLElement): HTMLElement {
+    const outline = matchesSelector(element, VOICE_LEVEL_SELECTOR)
+      ? element
+      : element.querySelector(VOICE_LEVEL_SELECTOR) as HTMLElement | null;
+    const stream = (matchesSelector(element, STREAM_WRAPPER_SELECTOR) ? element : null)
+      || (outline && (outline as any).closest?.(STREAM_WRAPPER_SELECTOR))
+      || element.querySelector(STREAM_WRAPPER_SELECTOR);
+    if (!(stream instanceof HTMLElement)) {
+      const signalRoot = outline && (outline as any).closest?.(STABLE_PARTICIPANT_ROOT_SELECTOR);
+      return signalRoot instanceof HTMLElement ? signalRoot : element;
+    }
+    const stableRoot = (stream as any).closest?.(STABLE_PARTICIPANT_ROOT_SELECTOR);
+    return stableRoot instanceof HTMLElement ? stableRoot : stream;
+  }
+
+  function participantSurfaceShape(element: HTMLElement): string {
+    const stream = matchesSelector(element, STREAM_WRAPPER_SELECTOR)
+      ? 'self'
+      : element.querySelector(STREAM_WRAPPER_SELECTOR) ? 'descendant' : 'absent';
+    const stableRoot = matchesSelector(element, STABLE_PARTICIPANT_ROOT_SELECTOR) ? 'yes' : 'no';
+    return `stream=${stream} stable-root=${stableRoot}`;
   }
 
   // ── State machine (200ms hysteresis, signal-required) ──
@@ -840,7 +902,9 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
   }
 
   function detectSpeakingState(element: HTMLElement): Detection {
-    const voiceOutline = element.querySelector(VOICE_LEVEL_SELECTOR) as HTMLElement | null;
+    const voiceOutline = matchesSelector(element, VOICE_LEVEL_SELECTOR)
+      ? element
+      : element.querySelector(VOICE_LEVEL_SELECTOR) as HTMLElement | null;
     if (!voiceOutline) return { isSpeaking: false, hasSignal: false };
     let memory = signalMemory.get(element);
     if (!memory) {
@@ -879,7 +943,8 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
   }
 
   function hasRequiredSignal(element: HTMLElement): boolean {
-    return element.querySelector(VOICE_LEVEL_SELECTOR) !== null;
+    return matchesSelector(element, VOICE_LEVEL_SELECTOR)
+      || element.querySelector(VOICE_LEVEL_SELECTOR) !== null;
   }
 
   // ── Gate A: a tile without the outline is ACCOUNTED FOR, never hinted ──
@@ -894,7 +959,8 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
       reason: 'outline-missing',
       tMs: now(),
     });
-    log('[TeamsSpeakers] signal-absent reason=outline-missing signal=dom-outline');
+    log('[TeamsSpeakers] signal-absent reason=outline-missing signal=dom-outline '
+      + participantSurfaceShape(element));
   }
 
   /**
@@ -1086,7 +1152,9 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
     const identity = getIdentity(element);
     (element as any).dataset.vexaObserverAttached = 'true';
     log(`👁️ [TeamsSpeakers] Observing: ${identity.name} (${identity.id})`);
-    const voiceOutline = element.querySelector(VOICE_LEVEL_SELECTOR) as HTMLElement | null;
+    const voiceOutline = matchesSelector(element, VOICE_LEVEL_SELECTOR)
+      ? element
+      : element.querySelector(VOICE_LEVEL_SELECTOR) as HTMLElement | null;
     if (!voiceOutline) return;
     const voiceObserver = new MutationObserver(() => checkAndEmit(identity));
     voiceObserver.observe(voiceOutline, { attributes: true, attributeFilter: ['style', 'class', 'aria-hidden'] });
@@ -1130,18 +1198,20 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
     let unresolvedParticipantSurfaces = 0;
     for (const selector of allSelectors) {
       document.querySelectorAll(selector).forEach(el => {
-        if (el instanceof HTMLElement && !seen.has(el)) {
-          seen.add(el);
+        if (el instanceof HTMLElement) {
+          const surface = canonicalParticipantSurface(el);
+          if (seen.has(surface)) return;
+          seen.add(surface);
           found++;
           // The roster walk is deliberately BEFORE the signal gate: a participant whose tile has no
           // voice outline is invisible to every other path in this file, and they are exactly the
           // person an elimination argument is for.
-          const rosterName = extractTeamsSpeakerName(el);
+          const rosterName = extractTeamsSpeakerName(surface);
           if (rosterName && isSelfDisplayName(rosterName, opts.selfName)) { /* local bot */ }
           else if (rosterName) namesThisScan.add(rosterName);
           else unresolvedParticipantSurfaces++;
-          if (hasRequiredSignal(el)) { observable++; observeParticipant(el); }
-          else emitSignalAbsent(el);   // counted and reported, never hinted
+          if (hasRequiredSignal(surface)) { observable++; observeParticipant(surface); }
+          else emitSignalAbsent(surface);   // counted and reported, never hinted
         }
       });
     }
@@ -1206,18 +1276,24 @@ export function createTeamsSpeakers(opts: TeamsSpeakersOptions): TeamsSpeakers {
         if (node.nodeType !== Node.ELEMENT_NODE) return;
         const el = node as HTMLElement;
         for (const selector of allSelectors) {
-          if (el.matches(selector)) observeParticipant(el);
+          if (el.matches(selector)) observeParticipant(canonicalParticipantSurface(el));
           el.querySelectorAll(selector).forEach(child => {
-            if (child instanceof HTMLElement) observeParticipant(child);
+            if (child instanceof HTMLElement) observeParticipant(canonicalParticipantSurface(child));
           });
         }
       });
       mutation.removedNodes.forEach(node => {
         if (node.nodeType !== Node.ELEMENT_NODE) return;
         const el = node as HTMLElement;
-        for (const selector of teamsParticipantSelectors) {
-          if (!el.matches(selector)) continue;
-          const identity = cache.get(el);
+        const removed = new Set<HTMLElement>();
+        for (const selector of allSelectors) {
+          if (el.matches(selector)) removed.add(canonicalParticipantSurface(el));
+          el.querySelectorAll(selector).forEach(child => {
+            if (child instanceof HTMLElement) removed.add(canonicalParticipantSurface(child));
+          });
+        }
+        for (const surface of removed) {
+          const identity = cache.get(surface);
           if (identity) removeParticipant(identity);
         }
       });

--- a/core/meetings/modules/teams-capture/src/roster-panel.test.ts
+++ b/core/meetings/modules/teams-capture/src/roster-panel.test.ts
@@ -15,7 +15,9 @@
  *
  * Run: npx tsx src/roster-panel.test.ts
  */
-import { readTeamsRosterPanel, isTeamsDisplayNameCandidate } from './msteams-speakers.js';
+import {
+  readTeamsRosterPanel, readTeamsRosterPanelState, isTeamsDisplayNameCandidate,
+} from './msteams-speakers.js';
 
 let failed = 0;
 const check = (name: string, cond: boolean, detail?: string): void => {
@@ -64,6 +66,15 @@ Object.setPrototypeOf(makeDom, Object.prototype);
     names.includes('Dmitry Grankin'), JSON.stringify(names));
   check('and yields each participant once, however many selectors matched',
     names.length === new Set(names).size, JSON.stringify(names));
+}
+{
+  const dom = makeDom({ panel: ['Dmitry Grankin', 'mic_off'] });
+  (globalThis as any).HTMLElement = Object;
+  const state = readTeamsRosterPanelState(dom);
+  check('the panel accounts for an unresolved row instead of dropping it from completeness',
+    state.names.length === 1 && state.names[0] === 'Dmitry Grankin'
+      && state.entries.length === 2 && state.entries[1] === null,
+    JSON.stringify(state));
 }
 {
   // A CLOSED panel is the m37 state. It must return nothing — and must not throw, because the scan

--- a/core/meetings/modules/teams-capture/src/teams-captions.test.ts
+++ b/core/meetings/modules/teams-capture/src/teams-captions.test.ts
@@ -251,6 +251,16 @@ check('text candidates lead with [data-tid="closed-caption-text"]',
   h.destroy();
 }
 
+// ── 5b. A human name containing the bot name is not the bot ─────────────────
+{
+  const rows = [captionRow('Vexa Petrova', 'a real human keeps her caption attribution')];
+  const h = harness(e('body', {}, [hostWrapper(rows)]), { selfName: 'Vexa' });
+  h.tick(1000); h.tick(1000);
+  check('caption self filtering is exact and preserves Vexa Petrova',
+    h.captions.length === 1 && h.captions[0]?.speaker === 'Vexa Petrova', JSON.stringify(h.captions));
+  h.destroy();
+}
+
 // ── 6. destroy() flushes an entry still refining, marked stable:false ────────
 {
   const rows = [captionRow('Tariq B', 'mid sentence when the meeting end')];

--- a/core/meetings/modules/teams-capture/src/teams-capture.test.ts
+++ b/core/meetings/modules/teams-capture/src/teams-capture.test.ts
@@ -79,6 +79,9 @@ function firstChatMessage(root: FakeEl): { sender: string; text: string } | unde
 
 // ── Exported selector surface (the bot re-exports these — keep them sane) ──────
 check('participant selectors are a non-empty string[]', teamsParticipantSelectors.length > 0 && teamsParticipantSelectors.every((s) => typeof s === 'string'));
+check('participant discovery starts from the exact voice outline and stable stream wrapper',
+  teamsParticipantSelectors[0] === '[data-tid="voice-level-stream-outline"]'
+    && teamsParticipantSelectors[1] === '[data-stream-type][data-tid]');
 check('name selectors non-empty', teamsNameSelectors.length > 0);
 check('participant-id selectors include [data-tid]', teamsParticipantIdSelectors.includes('[data-tid]'));
 check('container selectors fall back to body', teamsMeetingContainerSelectors.includes('body'));

--- a/core/meetings/modules/teams-capture/src/teams-name-hygiene.test.ts
+++ b/core/meetings/modules/teams-capture/src/teams-name-hygiene.test.ts
@@ -12,7 +12,8 @@
  * Run: npx tsx src/teams-name-hygiene.test.ts
  */
 import {
-  isTeamsDisplayNameCandidate, isSelfDisplayName, normalizeDisplayNameForIdentity,
+  isGeneratedDefaultBotDisplayName, isTeamsDisplayNameCandidate, isSelfDisplayName,
+  normalizeDisplayNameForIdentity,
 } from './msteams-speakers.js';
 
 let failed = 0;
@@ -32,6 +33,20 @@ check('identity normalisation strips the qualifier but the DISPLAY name is untou
   normalizeDisplayNameForIdentity('Leo (Unverified)') === 'leo'
   && isTeamsDisplayNameCandidate('Leo (Unverified)'));
 
+// ── meeting-api's generated fallback bot identity ────────────────────────────────────────────────
+for (const generated of [
+  'VexaBot-8f264c', 'VexaBot-8f264c (Unverified)', 'VexaBot-8f264c (Guest)',
+  'VexaBot-8f264c 2', 'VexaBot-8f264c (2)', 'VexaBot-8f264c (Gość) 2',
+  'VexaBot-8f264c (外部) (2)',
+]) {
+  check(`generated bot: "${generated}" is recognized exactly`,
+    isGeneratedDefaultBotDisplayName(generated), generated);
+  check(`generated bot: "${generated}" can never become a human name`,
+    !isTeamsDisplayNameCandidate(generated), generated);
+}
+check('stacked Teams suffixes still compare as the local bot',
+  isSelfDisplayName('Vexa (Guest) 2', 'Vexa'));
+
 // ── the platform's placeholders ──────────────────────────────────────────────────────────────────
 for (const placeholder of [
   'Unknown user', 'unknown user', 'Unknown User', 'Unknown', 'Guest', 'Anonymous',
@@ -44,7 +59,11 @@ check('m26132: a bare lowercase media label cannot become Julian\'s name',
   !isTeamsDisplayNameCandidate('datenanalyse'));
 
 // ── and the humans still get through ─────────────────────────────────────────────────────────────
-for (const real of ['Dmitry Grankin', 'leo (Unverified)', 'Anne-Marie', 'Jean-Luc Picard', 'Максим', 'Bo']) {
+for (const real of [
+  'Dmitry Grankin', 'leo (Unverified)', 'Anne-Marie', 'Jean-Luc Picard', 'Максим', 'Bo',
+  'Vexa Petrova', 'Vexana Petrova', 'Robin Botman', 'Assistant Smith', 'VexaBot Smith',
+  'VexaBot-8f264', 'VexaBot-8f264cc', 'VexaBot-8f26zz',
+]) {
   check(`human: "${real}" is still a name`, isTeamsDisplayNameCandidate(real), real);
 }
 

--- a/core/meetings/modules/teams-capture/src/teams-speaker-indicators.test.ts
+++ b/core/meetings/modules/teams-capture/src/teams-speaker-indicators.test.ts
@@ -111,12 +111,17 @@ function makeTile(id: string, name: string, opts: { outline: boolean }): { tile:
   return { tile, outline };
 }
 
-function installDocument(tiles: FakeEl[]): FakeEl {
-  const body = new FakeEl('body', {}, tiles);
+function installDocument(tiles: FakeEl[], panelRows: FakeEl[] = []): FakeEl {
+  const panel = panelRows.length ? new FakeEl('div', { 'data-tid': 'roster' }, panelRows) : null;
+  const body = new FakeEl('body', {}, panel ? [...tiles, panel] : tiles);
   g.document = {
     body,
     querySelector: (s: string) => (s === '[role="main"]' ? body : null),
-    querySelectorAll: (s: string) => (s === '[data-tid*="participant"]' ? tiles : []),
+    querySelectorAll: (s: string) => {
+      if (s === '[data-tid*="participant"]') return tiles;
+      if (panel && compile(s)(panel)) return [panel];
+      return [];
+    },
   };
   return body;
 }
@@ -129,7 +134,8 @@ interface Harness {
   advance: (ms: number) => void;
 }
 function start(tiles: FakeEl[], overrides: Record<string, unknown> = {}): Harness {
-  installDocument(tiles);
+  const { panelRows = [], ...watcherOverrides } = overrides as { panelRows?: FakeEl[] };
+  installDocument(tiles, panelRows);
   rafQueue = [];
   let clock = 1_700_000_000_000;
   const hints: Array<{ name: string; id: string; isEnd: boolean }> = [];
@@ -143,7 +149,7 @@ function start(tiles: FakeEl[], overrides: Record<string, unknown> = {}): Harnes
     log: (m) => logs.push(m),
     onSpeaking: (name, id, isEnd) => hints.push({ name, id, isEnd }),
     onObservation: (o) => observations.push(o),
-    ...overrides,
+    ...watcherOverrides,
   } as any);
   return { watcher, hints, observations, logs, advance: (ms) => { clock += ms; } };
 }
@@ -206,6 +212,25 @@ const ofType = (observations: TeamsProducerObservation[], type: string): TeamsPr
   check('animation: END carries the same name', h.hints[1]?.name === 'Alpha Example');
   check('animation: health reports one speaking transition', h.watcher.health().transitions === 1,
     JSON.stringify(h.watcher.health()));
+  h.watcher.destroy();
+}
+
+// ── 1a. A human whose name contains the configured bot name is still a human ─
+{
+  const { tile, outline } = makeTile('vexa-human', 'Vexa Petrova', { outline: true });
+  const h = start([tile], { selfName: 'Vexa' });
+  await settle();
+  h.advance(250);
+  outline!.setAttribute('style', 'height: 2px;');
+  frame();
+  await settle();
+  h.advance(250);
+  outline!.setAttribute('style', 'height: 14px; transform: scaleY(0.7);');
+  frame();
+  await settle();
+  check('exact self filtering preserves a real human whose name contains the bot name',
+    h.hints.length === 1 && h.hints[0]?.name === 'Vexa Petrova' && !h.hints[0]?.isEnd,
+    JSON.stringify(h.hints));
   h.watcher.destroy();
 }
 
@@ -391,6 +416,71 @@ const ofType = (observations: TeamsProducerObservation[], type: string): TeamsPr
     ofType(h.observations, 'indicator-silent').length === 1,
     JSON.stringify(ofType(h.observations, 'indicator-silent')));
   check('regression: diagnostics never crossed into the hint stream', h.hints.length === 0);
+  h.watcher.destroy();
+}
+
+// ── 5b. ROSTER COMPLETENESS — meeting 26218's false 1/1 is forbidden ─────────
+{
+  // Teams can render one participant on more than one DOM surface. Every surface resolves a name,
+  // so four elements representing two people are complete 2/2 rather than the old broken 2/4.
+  const tiles = [
+    makeTile('alpha-tile', 'Alpha Example', { outline: true }).tile,
+    makeTile('alpha-row', 'Alpha Example', { outline: false }).tile,
+    makeTile('beta-tile', 'Beta Example', { outline: true }).tile,
+    makeTile('beta-row', 'Beta Example', { outline: false }).tile,
+  ];
+  const h = start(tiles, { selfName: 'Vexa' });
+  await settle();
+  const rosterCoverage = ofType(h.observations, 'roster-coverage') as any[];
+  const last = rosterCoverage[rosterCoverage.length - 1];
+  check('coverage dedupes named duplicate surfaces into two complete participants',
+    last?.named === 2 && last?.participants === 2, JSON.stringify(rosterCoverage));
+  h.watcher.destroy();
+}
+{
+  const panelRows = [
+    new FakeEl('div', { role: 'treeitem' }, [new FakeEl('span', {}, [], 'Dmitry Grankin')]),
+    new FakeEl('div', { role: 'treeitem' }, [new FakeEl('span', {}, [], 'mic_off')]),
+  ];
+  const h = start([], { selfName: 'Vexa', panelRows });
+  await settle();
+  const rosterCoverage = ofType(h.observations, 'roster-coverage') as any[];
+  const last = rosterCoverage[rosterCoverage.length - 1];
+  check('an unresolved roster-panel row keeps one readable name at incomplete 1/2',
+    last?.named === 1 && last?.participants === 2, JSON.stringify(rosterCoverage));
+  h.watcher.destroy();
+}
+{
+  const tiles = [
+    makeTile('p1', 'Dmitry Grankin', { outline: true }).tile,
+    makeTile('p2', 'video-stream-2', { outline: false }).tile,
+    makeTile('p3', 'participant-tile-3', { outline: false }).tile,
+    makeTile('p4', 'voice-level-stream-outline', { outline: false }).tile,
+  ];
+  const h = start(tiles, { selfName: 'Vexa' });
+  await settle();
+  const rosterCoverage = ofType(h.observations, 'roster-coverage') as any[];
+  const last = rosterCoverage[rosterCoverage.length - 1];
+  check('m26218 coverage: one resolved name across four matched participants is 1/4, never 1/1',
+    last?.named === 1 && last?.participants === 4, JSON.stringify(rosterCoverage));
+  h.watcher.destroy();
+}
+{
+  const tiles = [
+    makeTile('p1', 'VexaBot-8f264c (Unverified)', { outline: true }).tile,
+    makeTile('p2', 'video-stream-2', { outline: false }).tile,
+    makeTile('p3', 'participant-tile-3', { outline: false }).tile,
+    makeTile('p4', 'voice-level-stream-outline', { outline: false }).tile,
+  ];
+  const h = start(tiles, { selfName: 'Vexa' });
+  await settle();
+  const rosterCoverage = ofType(h.observations, 'roster-coverage') as any[];
+  const rosterNames = ofType(h.observations, 'roster-name') as any[];
+  const last = rosterCoverage[rosterCoverage.length - 1];
+  check('m26218 generated bot: it never enters the roster-name stream',
+    rosterNames.every((o) => o.name !== 'VexaBot-8f264c (Unverified)'), JSON.stringify(rosterNames));
+  check('m26218 generated bot: unresolved four-surface scan reports 0/4 and cannot eliminate',
+    last?.named === 0 && last?.participants === 4, JSON.stringify(rosterCoverage));
   h.watcher.destroy();
 }
 

--- a/core/meetings/modules/teams-capture/src/teams-speaker-indicators.test.ts
+++ b/core/meetings/modules/teams-capture/src/teams-speaker-indicators.test.ts
@@ -10,7 +10,8 @@
  *   2. a tile found WITHOUT an outline is reported `signal-absent` and never hinted
  *   3. `indicator-silent` fires once per window when observable > 0 and nothing speaks
  *   4. coverage accounting (found / observable / named / transitions) is correct
- *   5. REGRESSION — today's live production failure, pinned: 4 tiles, 1 outline,
+ *   5. direct outline/stream anchors remain discoverable without a matching outer tile
+ *   6. REGRESSION — today's live production failure, pinned: 4 tiles, 1 outline,
  *      no indicator ever fires ⇒ 0 hints, 3 signal-absent, indicator-silent fires
  *
  * Run: npx tsx src/teams-speaker-indicators.test.ts
@@ -102,23 +103,43 @@ const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 5));
 
 /** One participant tile: `[data-stream-type][data-tid="<name>"]` wrapper (Teams'
  *  stable name attribute) around an optional voice-level outline. */
-function makeTile(id: string, name: string, opts: { outline: boolean }): { tile: FakeEl; outline: FakeEl | null } {
+function makeTile(
+  id: string,
+  name: string,
+  opts: { outline: boolean },
+): { tile: FakeEl; stream: FakeEl; outline: FakeEl | null } {
   const outline = opts.outline
     ? new FakeEl('div', { 'data-tid': 'voice-level-stream-outline', style: 'height: 0px;' })
     : null;
-  const inner = new FakeEl('div', { 'data-tid': name, 'data-stream-type': 'Video' }, outline ? [outline] : []);
-  const tile = new FakeEl('div', { 'data-tid': `participant-tile-${id}`, 'data-participant-id': id }, [inner]);
-  return { tile, outline };
+  const stream = new FakeEl('div', { 'data-tid': name, 'data-stream-type': 'Video' }, outline ? [outline] : []);
+  const tile = new FakeEl('div', { 'data-tid': `participant-tile-${id}`, 'data-participant-id': id }, [stream]);
+  return { tile, stream, outline };
 }
 
-function installDocument(tiles: FakeEl[], panelRows: FakeEl[] = []): FakeEl {
+function installDocument(
+  tiles: FakeEl[],
+  panelRows: FakeEl[] = [],
+  opts: { streamWrappersOnly?: boolean; outlineAtomsOnly?: boolean } = {},
+): FakeEl {
   const panel = panelRows.length ? new FakeEl('div', { 'data-tid': 'roster' }, panelRows) : null;
   const body = new FakeEl('body', {}, panel ? [...tiles, panel] : tiles);
   g.document = {
     body,
     querySelector: (s: string) => (s === '[role="main"]' ? body : null),
     querySelectorAll: (s: string) => {
-      if (s === '[data-tid*="participant"]') return tiles;
+      if (s === '[data-tid="voice-level-stream-outline"]') {
+        if (opts.streamWrappersOnly) return [];
+        return tiles.map((tile) => tile.matches(s) ? tile : tile.querySelector(s))
+          .filter((el): el is FakeEl => !!el);
+      }
+      if (s === '[data-stream-type][data-tid]') {
+        if (opts.outlineAtomsOnly) return [];
+        return tiles.map((tile) => tile.matches(s) ? tile : tile.querySelector(s))
+          .filter((el): el is FakeEl => !!el);
+      }
+      if (s === '[data-tid*="participant"]') {
+        return opts.streamWrappersOnly || opts.outlineAtomsOnly ? [] : tiles;
+      }
       if (panel && compile(s)(panel)) return [panel];
       return [];
     },
@@ -134,8 +155,14 @@ interface Harness {
   advance: (ms: number) => void;
 }
 function start(tiles: FakeEl[], overrides: Record<string, unknown> = {}): Harness {
-  const { panelRows = [], ...watcherOverrides } = overrides as { panelRows?: FakeEl[] };
-  installDocument(tiles, panelRows);
+  const {
+    panelRows = [], streamWrappersOnly = false, outlineAtomsOnly = false, ...watcherOverrides
+  } = overrides as {
+    panelRows?: FakeEl[];
+    streamWrappersOnly?: boolean;
+    outlineAtomsOnly?: boolean;
+  };
+  installDocument(tiles, panelRows, { streamWrappersOnly, outlineAtomsOnly });
   rafQueue = [];
   let clock = 1_700_000_000_000;
   const hints: Array<{ name: string; id: string; isEnd: boolean }> = [];
@@ -310,6 +337,10 @@ const ofType = (observations: TeamsProducerObservation[], type: string): TeamsPr
   check('signal-absent: carries no display name and no DOM text',
     !!absent[0] && !JSON.stringify(absent[0]).includes('Beta') && Object.keys(absent[0]).length === 5,
     JSON.stringify(absent[0]));
+  check('signal-absent: logs a value-free structural fingerprint',
+    h.logs.some((line) => line.includes('stream=descendant stable-root=yes'))
+      && h.logs.every((line) => !line.includes('Beta Example')),
+    JSON.stringify(h.logs));
   check('signal-absent: produces no hint', h.hints.length === 0, JSON.stringify(h.hints));
 
   // Even when the blind tile's markup churns, it stays unobservable and unhinted.
@@ -374,6 +405,139 @@ const ofType = (observations: TeamsProducerObservation[], type: string): TeamsPr
     h.logs.some((l) => l.includes('Scanned 3 participants, observing 2 with signal (signal-absent 1)')),
     JSON.stringify(h.logs));
   check('coverage: no coverage-low WARN at 2/3', !h.logs.some((l) => l.includes('WARN coverage-low')));
+  h.watcher.destroy();
+}
+
+// ── 4a. The exact speaking atom is independently discoverable ────────────────
+// The outline itself is the strongest layout-independent anchor. Its ancestor
+// stream wrapper supplies the name even when no outer tile selector matches.
+{
+  const { tile, outline } = makeTile('outline-dmitry', 'Dmitry Grankin', { outline: true });
+  const h = start([tile], { outlineAtomsOnly: true });
+  await settle();
+
+  const health = h.watcher.health();
+  check('outline-only layout: canonical participant is found once',
+    health.found === 1 && health.observable === 1 && health.named === 1,
+    JSON.stringify(health));
+  h.advance(250);
+  outline!.setAttribute('style', 'height: 2px;');
+  frame();
+  await settle();
+  h.advance(250);
+  outline!.setAttribute('style', 'height: 14px; transform: scaleY(0.7);');
+  frame();
+  await settle();
+  check('outline-only layout: speaking atom joins to the stream-wrapper name',
+    h.hints.length === 1 && h.hints[0]?.name === 'Dmitry Grankin' && !h.hints[0]?.isEnd,
+    JSON.stringify(h.hints));
+  h.watcher.destroy();
+}
+
+// The outline can also survive a layout that omits the stream wrapper. In that
+// shape, climb to a stable participant root and use the guarded visible-name
+// leaf fallback; the speaking atom still must never become a nameless hint.
+{
+  const nameLeaf = new FakeEl('div', {}, [], 'Dmitry Grankin');
+  const outline = new FakeEl('div', {
+    'data-tid': 'voice-level-stream-outline', style: 'height: 0px;',
+  });
+  const stableRoot = new FakeEl('div', { 'data-participant-id': 'dmitry-no-stream' }, [
+    nameLeaf, outline,
+  ]);
+  const h = start([stableRoot], { outlineAtomsOnly: true });
+  await settle();
+
+  check('outline-only fallback: stable root supplies the guarded visible name',
+    h.watcher.health().found === 1 && h.watcher.health().named === 1,
+    JSON.stringify(h.watcher.health()));
+  h.advance(250);
+  outline.setAttribute('style', 'height: 2px;');
+  frame();
+  await settle();
+  h.advance(250);
+  outline.setAttribute('style', 'height: 14px; transform: scaleY(0.7);');
+  frame();
+  await settle();
+  check('outline-only fallback: speaking evidence emits the visible human name',
+    h.hints.length === 1 && h.hints[0]?.name === 'Dmitry Grankin', JSON.stringify(h.hints));
+  h.watcher.destroy();
+}
+
+// ── 4b. The stable stream wrapper is independently discoverable ──────────────
+// Teams can render the visible name and active-speaker outline inside a stream
+// wrapper while the surrounding participant tile no longer matches any of the
+// broad layout selectors. The wrapper is sufficient evidence by itself.
+{
+  const { tile, outline } = makeTile('dmitry', 'Dmitry Grankin', { outline: true });
+  const h = start([tile], { streamWrappersOnly: true });
+  await settle();
+
+  const health = h.watcher.health();
+  check('stream-only layout: canonical wrapper is found once',
+    health.found === 1 && health.observable === 1 && health.named === 1,
+    JSON.stringify(health));
+  const rosterNames = ofType(h.observations, 'roster-name') as any[];
+  check('stream-only layout: stable data-tid yields the human name',
+    rosterNames.some((o) => o.name === 'Dmitry Grankin'), JSON.stringify(rosterNames));
+
+  h.advance(250);
+  outline!.setAttribute('style', 'height: 2px;');
+  frame();
+  await settle();
+  h.advance(250);
+  outline!.setAttribute('style', 'height: 14px; transform: scaleY(0.7);');
+  frame();
+  await settle();
+  check('stream-only layout: speaking evidence emits the resolved name',
+    h.hints.length === 1 && h.hints[0]?.name === 'Dmitry Grankin' && !h.hints[0]?.isEnd,
+    JSON.stringify(h.hints));
+  h.watcher.destroy();
+}
+
+// Two stream wrappers may legitimately expose the same display name. Without a
+// participant ID, their element identity remains distinct; the human-readable
+// data-tid must never collapse their speaking state into one participant.
+{
+  const outlineA = new FakeEl('div', {
+    'data-tid': 'voice-level-stream-outline', style: 'height: 0px;',
+  });
+  const outlineB = new FakeEl('div', {
+    'data-tid': 'voice-level-stream-outline', style: 'height: 0px;',
+  });
+  const streamA = new FakeEl('div', {
+    'data-tid': 'Alex Smith', 'data-stream-type': 'Video',
+  }, [outlineA]);
+  const streamB = new FakeEl('div', {
+    'data-tid': 'Alex Smith', 'data-stream-type': 'Video',
+  }, [outlineB]);
+  const h = start([streamA, streamB], { streamWrappersOnly: true });
+  await settle();
+
+  check('same-name streams: both canonical participants are retained',
+    h.watcher.health().found === 2 && h.watcher.health().observable === 2,
+    JSON.stringify(h.watcher.health()));
+  h.advance(250);
+  outlineA.setAttribute('style', 'height: 2px;');
+  frame();
+  await settle();
+  h.advance(250);
+  outlineA.setAttribute('style', 'height: 14px; transform: scaleY(0.7);');
+  frame();
+  await settle();
+  h.advance(250);
+  outlineB.setAttribute('style', 'height: 2px;');
+  frame();
+  await settle();
+  h.advance(250);
+  outlineB.setAttribute('style', 'height: 14px; transform: scaleY(0.7);');
+  frame();
+  await settle();
+  const starts = h.hints.filter((hint) => !hint.isEnd);
+  check('same-name streams: speaking state uses two distinct IDs',
+    starts.length === 2 && starts[0]?.name === 'Alex Smith' && starts[1]?.name === 'Alex Smith'
+    && starts[0]?.id !== starts[1]?.id,
+    JSON.stringify(starts));
   h.watcher.destroy();
 }
 

--- a/core/meetings/services/bot/src/adapters/transcript-redis.test.ts
+++ b/core/meetings/services/bot/src/adapters/transcript-redis.test.ts
@@ -94,6 +94,38 @@ async function main(): Promise<void> {
     check('string-id: channel = tc:meeting:abc-defg-hij:mutable', pubs[0]?.channel === 'tc:meeting:abc-defg-hij:mutable', pubs[0]?.channel);
   }
 
+  // ── Teams/GMeet-compatible live envelope: same-id mutates, distinct pending ids coexist ──
+  {
+    const { client, pubs } = fakeClient();
+    const sink = createRedisTranscriptSink({ client, meetingId: 42, liveEnvelope: 'speaker-snapshot' });
+    const draftA = { ...seg, segment_id: 'csrc-201:1000', speaker: '', speaker_key: 'csrc:201', text: 'hello', completed: false };
+    const draftAGrown = { ...draftA, text: 'hello world' };
+    const draftB = { ...seg, segment_id: 'csrc-201:2000', speaker: '', speaker_key: 'csrc:201', text: 'next thought', completed: false };
+    await sink.publish(draftA);
+    await sink.publish(draftAGrown);
+    await sink.publish(draftB);
+
+    const first = JSON.parse(pubs[0]!.message);
+    const grown = JSON.parse(pubs[1]!.message);
+    const coexist = JSON.parse(pubs[2]!.message);
+    check('snapshot: stable CSRC key is the replacement scope', first.speaker === 'csrc:201', String(first.speaker));
+    check('snapshot: same id replaces its draft text', grown.pending.length === 1 && grown.pending[0].text === 'hello world', JSON.stringify(grown.pending));
+    check('snapshot: distinct pending ids coexist', coexist.pending.length === 2, JSON.stringify(coexist.pending));
+
+    await sink.publish({ ...draftAGrown, completed: true });
+    const confirmed = JSON.parse(pubs[3]!.message);
+    check('snapshot: confirmation replaces only its own draft',
+      confirmed.confirmed.length === 1 && confirmed.confirmed[0].segment_id === draftA.segment_id
+        && confirmed.pending.length === 1 && confirmed.pending[0].segment_id === draftB.segment_id,
+      JSON.stringify(confirmed));
+
+    await sink.retract?.([draftB.segment_id]);
+    const cleared = JSON.parse(pubs[4]!.message);
+    check('snapshot: retract publishes the surviving complete pending set',
+      cleared.speaker === 'csrc:201' && cleared.confirmed.length === 0 && cleared.pending.length === 0,
+      JSON.stringify(cleared));
+  }
+
   if (failed) { console.error(`\n❌ transcript-redis (L3): ${failed} check(s) FAILED.`); process.exit(1); }
   console.log('\n✅ transcript-redis (L3): XADDs the transcription_segments stream + PUBLISHes tc:meeting:{id}:mutable, payload round-trips a schema-valid transcript.v1 segment.');
 }

--- a/core/meetings/services/bot/src/adapters/transcript-redis.ts
+++ b/core/meetings/services/bot/src/adapters/transcript-redis.ts
@@ -39,16 +39,51 @@ export interface RedisTranscriptSinkOptions {
   /** The native meeting code (e.g. `abc-defg-hij`). Stamped on the segment so the agent watcher keys
    *  on the native id WITHOUT a /meetings lookup (P23: one writer, no re-derivation). */
   nativeMeetingId?: string;
+  /** Live WebSocket envelope. `speaker-snapshot` is the Dashboard's GMeet-compatible contract:
+   * each message replaces the complete pending set for one stable speaker key while confirmed
+   * rows remain additive. Keep the legacy one-segment envelope as the default for every platform
+   * until its migration is proved independently. */
+  liveEnvelope?: 'segment' | 'speaker-snapshot';
 }
 
 /** Build the live transcript sink. `publish` XADDs the durable feed AND publishes the live
  *  mutable channel for one segment (best-effort fan-out; rejections propagate to the engine,
  *  which decides whether a publish failure is fatal). */
 export function createRedisTranscriptSink(opts: RedisTranscriptSinkOptions): TranscriptSink {
-  const { client, meetingId, nativeMeetingId } = opts;
+  const { client, meetingId, nativeMeetingId, liveEnvelope = 'segment' } = opts;
   const channel = mutableChannel(meetingId);
+  const pendingBySpeakerKey = new Map<string, Map<string, TranscriptSegment>>();
+
+  const speakerKeyFor = (segment: TranscriptSegment): string =>
+    segment.speaker_key || segment.speaker || '';
+
+  /** Mutate the local pending snapshot synchronously, before either Redis await, so concurrent
+   * pipeline callbacks capture monotonically ordered snapshots rather than racing on I/O. */
+  function liveMessageFor(segment: TranscriptSegment): string {
+    if (liveEnvelope === 'segment') {
+      return JSON.stringify({ type: 'transcript', meeting: { id: meetingId }, segment });
+    }
+
+    const speakerKey = speakerKeyFor(segment);
+    const pending = pendingBySpeakerKey.get(speakerKey) ?? new Map<string, TranscriptSegment>();
+    if (segment.completed) pending.delete(segment.segment_id);
+    else pending.set(segment.segment_id, segment);
+    if (pending.size > 0) pendingBySpeakerKey.set(speakerKey, pending);
+    else pendingBySpeakerKey.delete(speakerKey);
+
+    return JSON.stringify({
+      type: 'transcript',
+      meeting: { id: meetingId },
+      // This field is the pending-snapshot identity, not a display label. CSRC-backed Teams rows
+      // therefore stay isolated even while their human-facing `segment.speaker` is intentionally blank.
+      speaker: speakerKey,
+      confirmed: segment.completed ? [segment] : [],
+      pending: [...pending.values()],
+    });
+  }
 
   async function publish(segment: TranscriptSegment): Promise<void> {
+    const liveMessage = liveMessageFor(segment);
     // Leg 1: durable stream → collector. The collector's `ingest` REQUIRES the envelope
     // `{ type, meeting_id, segments:[…] }` — meeting_id to route the segment to its meeting, a
     // `segments` LIST to drain (a payload missing either is silently dropped: ingest.py `return 0`).
@@ -60,8 +95,7 @@ export function createRedisTranscriptSink(opts: RedisTranscriptSinkOptions): Tra
     await client.xAdd(TRANSCRIPTION_STREAM, '*', { payload });
 
     // Leg 2: live mutable channel → gateway → dashboard.
-    const msg = JSON.stringify({ type: 'transcript', meeting: { id: meetingId }, segment });
-    await client.publish(channel, msg);
+    await client.publish(channel, liveMessage);
   }
 
   /** Withdraw previously-published segments by id (a superseded/over-extended pending draft). Rides the
@@ -73,8 +107,29 @@ export function createRedisTranscriptSink(opts: RedisTranscriptSinkOptions): Tra
       type: 'transcript_retract', meeting_id: meetingId, native_meeting_id: nativeMeetingId, segment_ids: segmentIds,
     });
     await client.xAdd(TRANSCRIPTION_STREAM, '*', { payload });
-    const msg = JSON.stringify({ type: 'transcript_retract', meeting: { id: meetingId }, segment_ids: segmentIds });
-    await client.publish(channel, msg);
+    if (liveEnvelope === 'segment') {
+      const msg = JSON.stringify({ type: 'transcript_retract', meeting: { id: meetingId }, segment_ids: segmentIds });
+      await client.publish(channel, msg);
+      return;
+    }
+
+    // The Dashboard consumes full-replace pending snapshots. Re-publish only keys whose snapshot
+    // changed; confirmed rows are not retracted by this Teams-only draft path.
+    const ids = new Set(segmentIds);
+    const changed: Array<{ speakerKey: string; pending: TranscriptSegment[] }> = [];
+    for (const [speakerKey, pending] of pendingBySpeakerKey) {
+      let removed = false;
+      for (const id of ids) removed = pending.delete(id) || removed;
+      if (!removed) continue;
+      if (pending.size === 0) pendingBySpeakerKey.delete(speakerKey);
+      changed.push({ speakerKey, pending: [...pending.values()] });
+    }
+    for (const snapshot of changed) {
+      await client.publish(channel, JSON.stringify({
+        type: 'transcript', meeting: { id: meetingId }, speaker: snapshot.speakerKey,
+        confirmed: [], pending: snapshot.pending,
+      }));
+    }
   }
 
   return { publish, retract };

--- a/core/meetings/services/bot/src/index.ts
+++ b/core/meetings/services/bot/src/index.ts
@@ -177,7 +177,13 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number
   const transcriptClient = redisClientFrom(inv.redisUrl);
   const actsClient = redisActsClientFrom(inv.redisUrl);
   const liveTranscript: TranscriptSink = createRedisTranscriptSink({
-    client: transcriptClient, meetingId, nativeMeetingId: inv.nativeMeetingId,
+    client: transcriptClient,
+    meetingId,
+    nativeMeetingId: inv.nativeMeetingId,
+    // Teams is the current blast radius. Its CSRC lanes need the same complete per-speaker pending
+    // snapshot the Dashboard already consumes for GMeet-style live rendering. Leave every sibling
+    // platform on the existing wire until this is proven on STAGE and deliberately imported back.
+    liveEnvelope: inv.platform === 'teams' ? 'speaker-snapshot' : 'segment',
   });
   const liveActs = createRedisActsSource({ client: actsClient, meetingId });
 

--- a/core/meetings/services/bot/src/teams-speaker-animation.boundary.test.ts
+++ b/core/meetings/services/bot/src/teams-speaker-animation.boundary.test.ts
@@ -18,8 +18,9 @@
  * A shim-only test is not sufficient evidence for this behaviour. This one runs
  * the REAL page code at the REAL frame cadence with the REAL wall clock:
  *   1. the built bundle exposes createTeamsSpeakers;
- *   2. headless Chromium loads a Teams-shaped fixture — a tile whose outline's
- *      inline style animates like a voice bar, plus a tile with NO outline;
+ *   2. headless Chromium loads a Teams-shaped fixture — a stream wrapper whose
+ *      outer layout matches no participant selector and whose outline animates
+ *      like a voice bar, plus a tile with NO outline;
  *   3. startCaptureBridge (the real function) wires the page; the fixture drives
  *      10 style updates at 150ms; the test asserts ONE START then ONE END cross
  *      Node-side with the participant's name, and ZERO hints for the tile that
@@ -55,11 +56,11 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 // Carol's tile carries no outline at all (the #481 1:1-layout class): no signal
 // ⇒ no hint, ever — never a guessed one.
 const FIXTURE = `<!doctype html><html><body>
-  <div data-tid="participant-tile-1" id="t1">
+  <section id="t1">
     <div data-tid="Alice Real" data-stream-type="Video">
       <div data-tid="voice-level-stream-outline" id="o1" style="transform:scaleY(0.1)"></div>
     </div>
-  </div>
+  </section>
   <div data-tid="participant-tile-3" id="t3" title="Carol NoOutline">
     <span title="Carol NoOutline">Carol NoOutline</span>
   </div>

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.meetingApi.terminationGracePeriodSeconds | default 30 }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       {{- with .Values.global.imagePullSecrets }}
@@ -32,6 +33,13 @@ spec:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           image: "{{ .Values.meetingApi.image.repository }}:{{ .Values.global.imageTag | default .Values.meetingApi.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - {{ printf "sleep %v" (.Values.meetingApi.preStopDelaySeconds | default 5) | quote }}
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -173,6 +173,11 @@ adminApi:
 meetingApi:
   enabled: true
   replicaCount: 2
+  # Keep the process alive briefly after Kubernetes marks the Pod terminating. This gives
+  # EndpointSlice/kube-proxy enough time to stop routing fresh connections to the old IP before
+  # Uvicorn exits; it is especially important when multiple co-located replicas disappear.
+  preStopDelaySeconds: 5
+  terminationGracePeriodSeconds: 30
   image:
     repository: vexaai/v012-meeting-api
     tag: v012

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -40,6 +40,11 @@ need 1 'serviceAccountName: vexa-vexa-runtime' "runtime SA bound"
 need 1 'key: CLAUDE_CODE_OAUTH_TOKEN' "agent-api CLAUDE_CODE_OAUTH_TOKEN secret ref"
 need 2 'key: ANTHROPIC_AUTH_TOKEN'    "ANTHROPIC_AUTH_TOKEN secret refs (agent-api + runtime)"
 need 2 'name: MEETING_API_URL' "MEETING_API_URL set on gateway AND meeting-api"
+# A terminating meeting-api must stay alive until EndpointSlice/kube-proxy stops routing its IP.
+# Without this drain, deleting two co-located replicas produced immediate connection refusals even
+# while the third replica remained Ready.
+need 1 'terminationGracePeriodSeconds: 30' "meeting-api termination budget rendered"
+need 1 '^[[:space:]]+- "sleep 5"$' "meeting-api preStop endpoint-drain delay rendered"
 # #677: agent-api MUST get VEXA_MEETING_API_URL or its live-SSE owner-lookup calls the compose-only
 # http://meeting-api:8080 (unresolvable in-cluster) → fail-closed 403 for the meeting's own owner.
 # Only agent-api carries the VEXA_-prefixed spelling, so assert exactly 1.

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -85,6 +85,32 @@ test("v0.12.23 bootstrap packet freezes build identity without claiming validati
   );
 });
 
+test("v0.12.23 canonical packet freezes the successful rc.10 validation", () => {
+  const raw = readFileSync(
+    new URL("../releases/v0.12.23/candidate-images.json", import.meta.url),
+  );
+  assert.equal(
+    createHash("sha256").update(raw).digest("hex"),
+    "5ad5bd86f5eb8e8a9fe48ef921189998b81fd09af621375b2bf7539d00c37562",
+  );
+  const map = validateCandidateMap(JSON.parse(raw), "v0.12.23");
+  assert.equal(map.candidate_tag, "v0.12.23-rc.10");
+  assert.equal(map.build_source, "a7d49881eb8ff53b438537c59a8d480ec8f97593");
+  assert.equal(map.validation_source, "644ca4ce62de61b55abadb029ef7fbd7f7fd7757");
+  assert.equal(
+    map.validation_run,
+    "https://github.com/Vexa-ai/vexa/actions/runs/31950949704",
+  );
+  assert.equal(Object.keys(map.images).length, 10);
+  assert.equal(
+    Object.values(map.images).reduce(
+      (count, image) => count + Object.keys(image.platform_manifests).length,
+      0,
+    ),
+    19,
+  );
+});
+
 test("refuses a missing image", () => {
   const doc = validMap();
   delete doc.images["vexaai/v012-runtime"];

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -57,6 +58,31 @@ function validMap() {
 
 test("accepts the exact candidate set", () => {
   assert.equal(validateCandidateMap(validMap(), "v0.12.18").release, "v0.12.18");
+});
+
+test("v0.12.23 bootstrap packet freezes build identity without claiming validation", () => {
+  const raw = readFileSync(
+    new URL("../releases/v0.12.23/candidate-images.bootstrap.json", import.meta.url),
+  );
+  assert.equal(
+    createHash("sha256").update(raw).digest("hex"),
+    "a993d466d3aa083dafde3e882375b70d1e1c95120af5f2dc542c856c8e80039f",
+  );
+  const map = JSON.parse(raw);
+  assert.equal(map.packet_state, "bootstrap");
+  assert.equal(map.release, "v0.12.23");
+  assert.equal(map.stable_tag, "v0.12.23");
+  assert.equal(map.candidate_tag, "v0.12.23-rc.10");
+  assert.equal(map.validation_source, undefined);
+  assert.equal(map.validation_run, undefined);
+  assert.equal(Object.keys(map.images).length, 10);
+  assert.equal(
+    Object.values(map.images).reduce(
+      (count, image) => count + Object.keys(image.platform_manifests).length,
+      0,
+    ),
+    19,
+  );
 });
 
 test("refuses a missing image", () => {

--- a/releases/v0.12.23/candidate-images.bootstrap.json
+++ b/releases/v0.12.23/candidate-images.bootstrap.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "packet_state": "bootstrap",
+  "release": "v0.12.23",
+  "stable_tag": "v0.12.23",
+  "candidate_tag": "v0.12.23-rc.10",
+  "build_source": "a7d49881eb8ff53b438537c59a8d480ec8f97593",
+  "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/31948654678",
+  "images": {
+    "vexaai/v012-admin-api": {
+      "class": "prod_deployed",
+      "digest": "sha256:6b32a88e17c4313555ea7e5d4b5dfe7e8f112f46731ae435503699e5b28d419f",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:7011ef574558fbe3b702863b2469c77073571fbe5ab090f7d46d6d8cdb325a9c",
+          "config_digest": "sha256:68a2dd9c59dabf43e0eaf6fc14f10fecbf7d730a276e7622f4bef36f8ae9847e"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:b8876478c46a5eb6a6cf682e554f41ad6f925bc42630981a974ccf8157819c76",
+          "config_digest": "sha256:3db61636aae07b66e4fcb2e171d25c130e3a3a9e8c8d822f8b0b1ba602c6f77a"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-runtime": {
+      "class": "prod_deployed",
+      "digest": "sha256:db02704e22c5939d36e71397ef0c6393fd3f5e902812dcf40f7973d9f5a7278f",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:38d9d219fb588ddfb1fae1408856ba049d662085c930d18635589ef432b8b2dd",
+          "config_digest": "sha256:aab3f78e1618d1394ab53c54f58134c7feab9b88755b7e5ef0186a106069f9ba"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:d771eb73c5b3192049952ac3f1907035ae7412dceeb792d8ccfa144765930b90",
+          "config_digest": "sha256:d229ca0c0cbec1769c0a0b172626b2532730c5f8317c8e4cb759ac393b9dc815"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-agent-worker": {
+      "class": "oss_only",
+      "digest": "sha256:80dbdacf623f30d60d0bbaff5ecd498225b981ded3cdf40256bc502f38aaf323",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:911d5c8f81b39378f9d7ff1fa0c21dec562e0140966b14c5d203d5595b98ce44",
+          "config_digest": "sha256:0f83556bfa9e16126dc1ada0839aa587277c9515301d0bd36859761bc4f437f1"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:0d619625555ce1a9d9caf026a531a34d5c9fc83fd4f07dc8da14e311bd64adad",
+          "config_digest": "sha256:b1799dbefc260e8813d4eb6cac7c07974d16d262215b227cf18628f7f7bf0e13"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-agent-api": {
+      "class": "oss_only",
+      "digest": "sha256:bec44f393e21fbf8ae0d64b9086978b7c7fb443a80b3db5d0bf99e3178e05b8b",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:1edbb09788d2970e59886480d5b8483e4be7352a7f074901561b73cd5350280c",
+          "config_digest": "sha256:6426ddd41c98b43368ed127d4b4d7e88c722c6b358cc343068f783eeaa2cfae3"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:aa140ed868a4be50654117e13e036b8e919450fa4e4377de10ef86ef3745905c",
+          "config_digest": "sha256:864befb003f456c8be462a91b4ed22ebc4788b4783be7071e14dced6108db675"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-meeting-api": {
+      "class": "prod_deployed",
+      "digest": "sha256:fa5380365602bd91529be805601ce4b719ef662d63a25a2de86f46366c648c5b",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:7109fbf02a8c86de0ff07b4844f178696f3dc3c63273439a162916000ea6bc2e",
+          "config_digest": "sha256:694fcfa1a754b3e93cee9fe5aa132ffb5bb0e65061565e704872d35b01e7bdb1"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:8568f25c860a98951bf5522555c6741172e235e859985308530d0aeafb81dd15",
+          "config_digest": "sha256:bf46dbbd8d8aaf21d9eb4eb7abfe25ad9aa3ddff5f8cdade8378f3691607c80c"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-gateway": {
+      "class": "prod_deployed",
+      "digest": "sha256:bb640ce0c3b315a3dfaec25fe36a395ef54e90ac6a5eae86cc1eb52fadb87ef0",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:0d93b79bb518dbd462f850d8ecd6d6690d27e3283c66880b0ee3e373e9b2445c",
+          "config_digest": "sha256:7d1d2f3792558b8fc46cc34351b2899d36d05b9a94d85a7259c217ef16cf7420"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:7624774e52381a66082f714ed88d2de7e5a42a2127ad57791cb72fb884546a23",
+          "config_digest": "sha256:92b951e6256decfb1a4be9f5bed912ac142db8b00313b8a1af9219665818f30b"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-mcp": {
+      "class": "oss_only",
+      "digest": "sha256:dc3746d8a35b132bb385d1d15ca0f708f5b45fb6a7713ee8e3f75e31ab71f10d",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:caa06837a7b9344e1e90e603185e6ef68ec41c078253bf60fc74519f81611efd",
+          "config_digest": "sha256:c3b46277354fcd624a0b9aaec40cfd6b880b3387b49858be6ef9f256abe3bfcb"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:47d8ce9f92ae07808cba9a727d049cc594b7fd6a4b8ffeb6ad269fa26cd4a5bc",
+          "config_digest": "sha256:244d0143f9edd917355b4803e7c26616a5fa3864158d3fe5c50342c264a8c362"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-terminal": {
+      "class": "oss_only",
+      "digest": "sha256:c4ebff39ec687a6e61703e1cc0bf3a7c51a7f1a330a681060389c114ff8e5d72",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:6fdf3f927874e7596dda07ae151231ea1ea4cdc227faad030cb4fbe811939a50",
+          "config_digest": "sha256:41844170da6ab1cc321c2d5fd452f79cd184b45c478a6a988eb7d225b1d69b47"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:478b8bf599c07d16b4dea5715c90f67c1d61c572088423ae5c05dd71bc108a33",
+          "config_digest": "sha256:f01f72c5d57206179060dc58ef8d41f8cbd8977abeea9f8af9d88681a86c4ece"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/vexa-bot": {
+      "class": "prod_deployed",
+      "digest": "sha256:459d626d18c5551559da6edb68c136731836184ce0f4143a29567c5aa00f68a1",
+      "platforms": ["linux/amd64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:459d626d18c5551559da6edb68c136731836184ce0f4143a29567c5aa00f68a1",
+          "config_digest": "sha256:4118e84fc00083b70a75331dfc7d5f95a540eb26f6e0f94d88f166a327d3d2af"
+        }
+      },
+      "attestations": false,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact bot digest deployed on STAGE Helm revision 185"
+    },
+    "vexaai/vexa-lite": {
+      "class": "oss_only",
+      "digest": "sha256:c392bc8f38b513481fecd896be3607e85775a5ad128603175b34bb4edd850997",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:232ef59eaa654a7f5d08113e2e9cb94b917d9fdd34967ca7515dc5c628f94796",
+          "config_digest": "sha256:1a0126713b6f801e9b1925291076df17fdf25fdc25970428161c59002d5c3a0e"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:0d74949c35317720d57b112dfbc5a84e490cc93ac8fa612c7ebbf3c62a0b354f",
+          "config_digest": "sha256:75e42d039421babab8deb2fc53b6de081c5a80e9da6e93b5ca105a9a9ba533f7"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    }
+  }
+}

--- a/releases/v0.12.23/candidate-images.json
+++ b/releases/v0.12.23/candidate-images.json
@@ -1,0 +1,178 @@
+{
+  "schema_version": 1,
+  "release": "v0.12.23",
+  "stable_tag": "v0.12.23",
+  "candidate_tag": "v0.12.23-rc.10",
+  "build_source": "a7d49881eb8ff53b438537c59a8d480ec8f97593",
+  "validation_source": "644ca4ce62de61b55abadb029ef7fbd7f7fd7757",
+  "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/31948654678",
+  "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/31950949704",
+  "images": {
+    "vexaai/v012-admin-api": {
+      "class": "prod_deployed",
+      "digest": "sha256:6b32a88e17c4313555ea7e5d4b5dfe7e8f112f46731ae435503699e5b28d419f",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:7011ef574558fbe3b702863b2469c77073571fbe5ab090f7d46d6d8cdb325a9c",
+          "config_digest": "sha256:68a2dd9c59dabf43e0eaf6fc14f10fecbf7d730a276e7622f4bef36f8ae9847e"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:b8876478c46a5eb6a6cf682e554f41ad6f925bc42630981a974ccf8157819c76",
+          "config_digest": "sha256:3db61636aae07b66e4fcb2e171d25c130e3a3a9e8c8d822f8b0b1ba602c6f77a"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-runtime": {
+      "class": "prod_deployed",
+      "digest": "sha256:db02704e22c5939d36e71397ef0c6393fd3f5e902812dcf40f7973d9f5a7278f",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:38d9d219fb588ddfb1fae1408856ba049d662085c930d18635589ef432b8b2dd",
+          "config_digest": "sha256:aab3f78e1618d1394ab53c54f58134c7feab9b88755b7e5ef0186a106069f9ba"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:d771eb73c5b3192049952ac3f1907035ae7412dceeb792d8ccfa144765930b90",
+          "config_digest": "sha256:d229ca0c0cbec1769c0a0b172626b2532730c5f8317c8e4cb759ac393b9dc815"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-agent-worker": {
+      "class": "oss_only",
+      "digest": "sha256:80dbdacf623f30d60d0bbaff5ecd498225b981ded3cdf40256bc502f38aaf323",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:911d5c8f81b39378f9d7ff1fa0c21dec562e0140966b14c5d203d5595b98ce44",
+          "config_digest": "sha256:0f83556bfa9e16126dc1ada0839aa587277c9515301d0bd36859761bc4f437f1"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:0d619625555ce1a9d9caf026a531a34d5c9fc83fd4f07dc8da14e311bd64adad",
+          "config_digest": "sha256:b1799dbefc260e8813d4eb6cac7c07974d16d262215b227cf18628f7f7bf0e13"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-agent-api": {
+      "class": "oss_only",
+      "digest": "sha256:bec44f393e21fbf8ae0d64b9086978b7c7fb443a80b3db5d0bf99e3178e05b8b",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:1edbb09788d2970e59886480d5b8483e4be7352a7f074901561b73cd5350280c",
+          "config_digest": "sha256:6426ddd41c98b43368ed127d4b4d7e88c722c6b358cc343068f783eeaa2cfae3"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:aa140ed868a4be50654117e13e036b8e919450fa4e4377de10ef86ef3745905c",
+          "config_digest": "sha256:864befb003f456c8be462a91b4ed22ebc4788b4783be7071e14dced6108db675"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-meeting-api": {
+      "class": "prod_deployed",
+      "digest": "sha256:fa5380365602bd91529be805601ce4b719ef662d63a25a2de86f46366c648c5b",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:7109fbf02a8c86de0ff07b4844f178696f3dc3c63273439a162916000ea6bc2e",
+          "config_digest": "sha256:694fcfa1a754b3e93cee9fe5aa132ffb5bb0e65061565e704872d35b01e7bdb1"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:8568f25c860a98951bf5522555c6741172e235e859985308530d0aeafb81dd15",
+          "config_digest": "sha256:bf46dbbd8d8aaf21d9eb4eb7abfe25ad9aa3ddff5f8cdade8378f3691607c80c"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-gateway": {
+      "class": "prod_deployed",
+      "digest": "sha256:bb640ce0c3b315a3dfaec25fe36a395ef54e90ac6a5eae86cc1eb52fadb87ef0",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:0d93b79bb518dbd462f850d8ecd6d6690d27e3283c66880b0ee3e373e9b2445c",
+          "config_digest": "sha256:7d1d2f3792558b8fc46cc34351b2899d36d05b9a94d85a7259c217ef16cf7420"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:7624774e52381a66082f714ed88d2de7e5a42a2127ad57791cb72fb884546a23",
+          "config_digest": "sha256:92b951e6256decfb1a4be9f5bed912ac142db8b00313b8a1af9219665818f30b"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-mcp": {
+      "class": "oss_only",
+      "digest": "sha256:dc3746d8a35b132bb385d1d15ca0f708f5b45fb6a7713ee8e3f75e31ab71f10d",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:caa06837a7b9344e1e90e603185e6ef68ec41c078253bf60fc74519f81611efd",
+          "config_digest": "sha256:c3b46277354fcd624a0b9aaec40cfd6b880b3387b49858be6ef9f256abe3bfcb"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:47d8ce9f92ae07808cba9a727d049cc594b7fd6a4b8ffeb6ad269fa26cd4a5bc",
+          "config_digest": "sha256:244d0143f9edd917355b4803e7c26616a5fa3864158d3fe5c50342c264a8c362"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/v012-terminal": {
+      "class": "oss_only",
+      "digest": "sha256:c4ebff39ec687a6e61703e1cc0bf3a7c51a7f1a330a681060389c114ff8e5d72",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:6fdf3f927874e7596dda07ae151231ea1ea4cdc227faad030cb4fbe811939a50",
+          "config_digest": "sha256:41844170da6ab1cc321c2d5fd452f79cd184b45c478a6a988eb7d225b1d69b47"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:478b8bf599c07d16b4dea5715c90f67c1d61c572088423ae5c05dd71bc108a33",
+          "config_digest": "sha256:f01f72c5d57206179060dc58ef8d41f8cbd8977abeea9f8af9d88681a86c4ece"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    },
+    "vexaai/vexa-bot": {
+      "class": "prod_deployed",
+      "digest": "sha256:459d626d18c5551559da6edb68c136731836184ce0f4143a29567c5aa00f68a1",
+      "platforms": ["linux/amd64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:459d626d18c5551559da6edb68c136731836184ce0f4143a29567c5aa00f68a1",
+          "config_digest": "sha256:4118e84fc00083b70a75331dfc7d5f95a540eb26f6e0f94d88f166a327d3d2af"
+        }
+      },
+      "attestations": false,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact bot digest deployed on STAGE Helm revision 185"
+    },
+    "vexaai/vexa-lite": {
+      "class": "oss_only",
+      "digest": "sha256:c392bc8f38b513481fecd896be3607e85775a5ad128603175b34bb4edd850997",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "platform_manifests": {
+        "linux/amd64": {
+          "manifest_digest": "sha256:232ef59eaa654a7f5d08113e2e9cb94b917d9fdd34967ca7515dc5c628f94796",
+          "config_digest": "sha256:1a0126713b6f801e9b1925291076df17fdf25fdc25970428161c59002d5c3a0e"
+        },
+        "linux/arm64": {
+          "manifest_digest": "sha256:0d74949c35317720d57b112dfbc5a84e490cc93ac8fa612c7ebbf3c62a0b354f",
+          "config_digest": "sha256:75e42d039421babab8deb2fc53b6de081c5a80e9da6e93b5ca105a9a9ba533f7"
+        }
+      },
+      "attestations": true,
+      "evidence": "candidate build run 31948654678 at a7d49881; exact registry identities collected after the image job completed"
+    }
+  }
+}


### PR DESCRIPTION
## What this owns

This is the reviewable delta from the combined Calendar + Teams release branch in [Vexa-ai/vexa#1151 “feat(calendar,teams): stage multi-feed and CSRC transcription”](https://github.com/Vexa-ai/vexa/pull/1151).

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

It carries three release-continuity fixes:

- drain meeting-api endpoints before pod exit so an upgrade does not strand active meeting work;
- preserve concurrent Teams pending drafts instead of letting one lane replace another;
- fail closed when Teams does not provide complete, trustworthy speaker identity evidence.

## Speaker incident and root cause

STAGE meeting 26218 labeled every human transcript row as `VexaBot-8f264c (Unverified)`. Teams exposed four participant-shaped surfaces but only one readable roster label. The producer incorrectly published that as complete `1/1` coverage, allowing roster elimination to promote our generated bot name to the human audio track.

The fix:

- recognizes only meeting-api's exact reserved generated-bot namespace (`VexaBot-<six hex>`), without fuzzy `bot`/`assistant`/`notetaker` heuristics;
- normalizes Teams identity qualifiers and collision suffixes consistently;
- filters the local bot by exact normalized identity, preserving legitimate human names such as `Vexa Petrova`;
- counts unresolved Teams participant/panel surfaces conservatively and deduplicates resolved names;
- permits elimination only with non-zero, exact-cardinality coverage matching the retained roster.

Missing, partial, stale, or skewed coverage therefore produces an honest generic speaker instead of a confident wrong human.

## Evidence

Exact incident fixture:

`/private/tmp/vexa-stage-m26218-speaker-incident/captured-signal-live/92bf9a0a-ab58-44db-8cdb-2f0773cfa302.captured-signal.jsonl`

- before: 29/29 durable rows labeled `VexaBot-8f264c (Unverified)` by roster elimination;
- after: 29/29 durable rows remain `Speaker A` because the fixture contains no human identity evidence;
- segment IDs, timestamps, text, order, and row count are identical after removing `speaker`;
- zero transcription gaps and zero text mutation.

Diverse frozen-source replay controls cover clean solo, overlap, crowd/rotation, partial roster, and long multi-speaker fixtures under `/private/tmp/teams-speaker-fix-candidate-v2/`:

- m34, m26027, m26043, m30, m26123, and m26132 are byte-identical to their baseline `transcript.txt`, `durable.json`, and `writes.jsonl` artifacts;
- m36 ends with the same 23/23 rows named Dmitry; its only change is a temporary generic label until direct evidence arrives in this old fixture without coverage telemetry;
- every candidate retains zero durable draft-only IDs and zero draft/confirmed shadow rows;
- a repeated m26218 replay is byte-identical, and source hashes stayed frozen across the matrix.

## Validation

- `pnpm --filter @vexa/teams-capture test`
- `pnpm --filter @vexa/teams-capture build`
- `pnpm --filter @vexa/mixed-pipeline test`
- `pnpm --filter @vexa/mixed-pipeline build`
- `pnpm --filter @vexa/mixed-pipeline run check:isolation`
- `git diff --check`
- all 14 repository pre-push static gates

All changed-package and pre-push gates are green. The wider repository `all` lane still exposes pre-existing unrelated workspace debt outside this Teams release delta; this PR does not widen its blast radius to repair those surfaces.

## Blast radius

Microsoft Teams capture, Teams speaker naming, pending transcript publication, and meeting-api shutdown continuity only. Google Meet and Zoom wiring are unchanged.

## Release path

The exact source built successfully as immutable `v0.12.23-rc.10`:

`vexaai/vexa-bot@sha256:459d626d18c5551559da6edb68c136731836184ce0f4143a29567c5aa00f68a1`

That digest is pinned by [Vexa-ai/vexa-platform#288 “feat(stage): combine Calendar #1150 and Teams rc.10 candidate”](https://github.com/Vexa-ai/vexa-platform/pull/288) and is live on STAGE at Helm revision 185 with rollback anchor 184. All 14 Deployments converged and the guarded continuity wrapper completed green.

The candidate-map gate is closed. The canonical packet at `releases/v0.12.23/candidate-images.json` is frozen at SHA-256 `5ad5bd86f5eb8e8a9fe48ef921189998b81fd09af621375b2bf7539d00c37562`; [release validation run 31951789671](https://github.com/Vexa-ai/vexa/actions/runs/31951789671) passed at exact head `272b5117629666f14148f20aa4a0f8469d1f831d`, proving 10 top descriptors, 19 platform identities, 18 linked attestations, and all eight runtime validation legs. It ran with `promote=false`; no moving tag changed.

One gate remains explicit:

- the intended test account must complete the live Calendar auto-join and Teams named-speaker witness. The available dashboard browser session belongs to a different account and was not used beyond read-only identification.

PROD is untouched.
