### PR TITLE
docs: deprecate legacy dashboard in favor of terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Self-host the whole stack on one host, then explore it in the Terminal or drive 
 Linux (Ubuntu 24.04) is the production target; a Mac with Docker Desktop works fine for a local
 evaluation — everything runs in containers either way.
 
+> **Client direction:** the legacy hosted Dashboard is being deprecated in favor of the Terminal,
+> which is the primary UI for new self-hosted and product workflows.
+
 **Prerequisites** — `make`, **Docker engine ≥ v26** (`make all` checks), and transcription: a free token at
 [vexa.ai/account](https://vexa.ai/account), or self-host the (GPU) transcription unit for a fully
 air-gapped setup. By default `POST /bots` **requires** STT and answers **503** when it is missing


### PR DESCRIPTION
**Delivers:** release documentation alignment for v0.12.23

## Contribution rights

- [ ] Independent
- [ ] Employer/client authorization required
- [ ] Unsure

The legal contribution-rights selection is intentionally left for the human contributor.

## Observation bundle

- PROD currently runs the separately built legacy Dashboard at source `fa667cd11d95afec551437373c1bdbcaf816a3a0`, subtree `eaa03b2c066c9f3dd9f96d487114636db998ff08`, digest `sha256:57a1c4f09664972ea227c8bdf282585d80ff79c2862e0dc922b88155ac4fc9b3`.
- OSS main already presents Terminal as the primary self-hosted workbench; this direction note makes the legacy Dashboard retirement explicit without importing its vendored source.

## Validation

- Static pre-push gates passed; the uv-dependent contract-conformance test was run directly: 5/5 passed.
- `git diff --check` passed.

## Docs diff

README Quickstart now states that the legacy hosted Dashboard is being deprecated in favor of Terminal.

## Authorship

Sole author: DmitriyG228. No agent co-author trailers.