### PR TITLE
fix(meeting-api): match meeting hosts exactly, not by substring

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/collector/meeting_link.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/meeting_link.py
@@ -7,6 +7,10 @@ DESCRIPTION). Pure string logic — no I/O, no framework imports; the one config
 ``VEXA_JITSI_HOSTS`` (P14, declared in config.v1.json), consulted per call so tests and
 reloads see the live env.
 
+Hosts are matched EXACTLY or as a dotted subdomain (``_host_matches``) — never by substring,
+which would read ``meet.google.com.attacker.example`` as Google Meet. ``vexa_mailroom``'s
+vendored copy carries the same helper; the two parsers are meant to agree.
+
 Id formats (mirrors the dashboard join-form):
   * google_meet → ``abc-defg-hij``
   * zoom        → 9–11 digits
@@ -30,6 +34,43 @@ _TEAMS_SHORT = re.compile(r"/meet/([^/?#]+)", re.IGNORECASE)
 # A Jitsi room is the URL path's single segment; permissive by design (jitsi accepts nearly any
 # room string) but excludes separators/whitespace so a mangled URL never yields a bogus room.
 _JITSI_ROOM = re.compile(r"^[^/?#\s]+$")
+
+# Zoom's meeting domains. Canonical zoom.us (+ every regional subdomain: us02web, us05web, a
+# customer's company.zoom.us) and the US-government tenant. Matches the join brick's own rule
+# (``modules/join/src/index.ts::resolvePlatform``) — a white-label portal is not inferable from
+# its URL, so it is not listed here and never was.
+_ZOOM_DOMAINS = ("zoom.us", "zoomgov.com")
+# Every domain a hosted platform claims. Used both to match and to recognise a lookalike.
+_PLATFORM_DOMAINS = ("meet.google.com", *_ZOOM_DOMAINS, "teams.microsoft.com", "teams.live.com")
+
+
+def _host_matches(host: str, *domains: str) -> bool:
+    """Exact host, or a subdomain of one of ``domains`` — never a substring match.
+
+    A substring test (``"meet.google.com" in host``) also accepts
+    ``meet.google.com.attacker.example``: the platform name is a *prefix* of an arbitrary
+    domain the submitter controls, so anyone who can post a meeting URL chooses the host the
+    bot's browser later opens. The registrable domain is the rightmost part of a hostname, so
+    the only sound test is equality or a dotted suffix.
+
+    The mailroom's vendored copy (``vexa_mailroom.meeting_link``) carries the same helper; the
+    two parsers must agree, since the mailroom hands its ``meeting_url`` to ``POST /meetings``
+    for a second parse.
+    """
+    return any(host == d or host.endswith("." + d) for d in domains)
+
+
+def _is_platform_lookalike(host: str) -> bool:
+    """True when ``host`` merely CONTAINS a platform's domain without being it or a subdomain
+    of it — ``meet.google.com.attacker.example``, ``zoom.us.attacker.example``.
+
+    Such a host is not the platform, and it must not reach the jitsi naming heuristics either:
+    ``meet.google.com.attacker.example`` carries a "meet" LABEL, so the self-hosted fallback
+    below would otherwise adopt it as a jitsi room and hand the bot the same attacker-chosen
+    host the exact-match rule just refused. Explicitly declared hosts (``VEXA_JITSI_HOSTS``)
+    are unaffected — an operator naming their own deployment is not a guess.
+    """
+    return any(d in host and not _host_matches(host, d) for d in _PLATFORM_DOMAINS)
 
 
 def _configured_jitsi_hosts() -> set[str]:
@@ -61,13 +102,13 @@ def parse_meeting_url(raw: str, *, generic_hosts: bool = True) -> Optional[tuple
     parsed = urlparse(value)
     host = (parsed.hostname or "").lower()
     if host:
-        if "meet.google.com" in host:
+        if _host_matches(host, "meet.google.com"):
             code = next((p for p in reversed(parsed.path.split("/")) if p), "").lower()
             return ("google_meet", code) if _GMEET_ID.match(code) else None
-        if "zoom" in host:
+        if _host_matches(host, *_ZOOM_DOMAINS):
             m = _ZOOM_ID.search(parsed.path) or _ZOOM_ID.search(parsed.query)
             return ("zoom", m.group(0)) if m else None
-        if "teams.microsoft.com" in host or "teams.live.com" in host:
+        if _host_matches(host, "teams.microsoft.com", "teams.live.com"):
             # Classic deep link carries the thread id (…/l/meetup-join/19:meeting_…@thread.v2).
             thread = _TEAMS_THREAD.search(unquote(value))
             if thread:
@@ -93,8 +134,15 @@ def parse_meeting_url(raw: str, *, generic_hosts: bool = True) -> Optional[tuple
             # jitsi's recommended naming, regionalized). Both are too loose for the ICS scan,
             # where an event description full of arbitrary links (jitsi.github.io docs, vendor
             # meet.* products) must not import as joinable rooms — there, only the explicit
-            # hosts above count; VEXA_JITSI_HOSTS is the opt-in.
-            or (generic_hosts and ("jitsi" in host or "meet" in host.split(".")))
+            # hosts above count; VEXA_JITSI_HOSTS is the opt-in. A host that merely LOOKS like
+            # a hosted platform is excluded outright: the branches above already refused it by
+            # name, and meet.google.com.attacker.example carries a "meet" label that would
+            # otherwise let it back in through this door.
+            or (
+                generic_hosts
+                and not _is_platform_lookalike(host)
+                and ("jitsi" in host or "meet" in host.split("."))
+            )
         )
         if is_jitsi_host:
             room = parsed.path.strip("/")

--- a/core/meetings/services/meeting-api/tests/test_meeting_link.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_link.py
@@ -6,6 +6,8 @@ with jitsi as the newest row. Pure string logic — no app, no DB.
 """
 from __future__ import annotations
 
+import pytest
+
 from meeting_api.bot_spawn.service import construct_meeting_url
 from meeting_api.collector.meeting_link import find_meeting_link, parse_meeting_url
 
@@ -62,6 +64,71 @@ class TestParseExistingPlatformsUnchanged:
 
     def test_teams_short(self):
         assert parse_meeting_url("https://teams.live.com/meet/9361792952021?p=abc") == ("teams", "9361792952021")
+
+
+class TestHostMatchingIsExact:
+    """A platform host is matched exactly or as a dotted subdomain — never by substring.
+
+    A substring test puts the host the bot's browser opens under the submitter's control: the
+    platform name becomes a prefix of a domain they registered. The parse is the only thing
+    standing between a submitted URL and a real navigation, so a host that is not the platform
+    must resolve to no platform at all — including via the self-hosted jitsi fallback, which a
+    google-meet lookalike would otherwise satisfy on its "meet" label.
+    """
+
+    @pytest.mark.parametrize("url", [
+        "https://meet.google.com.attacker.example/abc-defg-hij",
+        "https://zoom.attacker.example/j/84335626851",
+        "https://zoom.us.attacker.example/j/84335626851",
+        "https://notzoom.com/j/84335626851",
+        "https://teams.microsoft.com.evil.example/meet/9361792952021",
+        "https://teams.live.com.evil.example/meet/9361792952021",
+        "https://teams.microsoft.com.evil.example/l/meetup-join/19%3ameeting_YWJj%40thread.v2/0",
+    ])
+    def test_lookalike_host_resolves_to_no_platform(self, url):
+        assert parse_meeting_url(url) is None
+        # …in the pasted-link mode too, where the jitsi naming heuristics are live.
+        assert parse_meeting_url(url, generic_hosts=True) is None
+        assert find_meeting_link(f"Join here: {url} thanks") is None
+
+    @pytest.mark.parametrize("url,expected", [
+        # Google Meet: the exact host only — it has no meeting subdomains.
+        ("https://meet.google.com/abc-defg-hij", ("google_meet", "abc-defg-hij")),
+        # Zoom: the apex, the regional subdomains, a customer vanity host, and the gov tenant.
+        ("https://zoom.us/j/84335626851", ("zoom", "84335626851")),
+        ("https://us02web.zoom.us/j/84335626851", ("zoom", "84335626851")),
+        ("https://us05web.zoom.us/j/84335626851?pwd=x", ("zoom", "84335626851")),
+        ("https://company.zoom.us/j/84335626851", ("zoom", "84335626851")),
+        ("https://zoomgov.com/j/84335626851", ("zoom", "84335626851")),
+        # Teams: both hosts, both link shapes, plus a tenant subdomain.
+        ("https://teams.live.com/meet/9361792952021?p=abc", ("teams", "9361792952021")),
+        ("https://teams.microsoft.com/meet/9351274713?p=abc", ("teams", "9351274713")),
+        ("https://teams.microsoft.com/l/meetup-join/19%3ameeting_YWJj%40thread.v2/0",
+         ("teams", "19:meeting_YWJj@thread.v2")),
+        ("https://foo.teams.microsoft.com/meet/9351274713?p=abc", ("teams", "9351274713")),
+    ])
+    def test_real_platform_hosts_still_parse(self, url, expected):
+        assert parse_meeting_url(url) == expected
+
+    @pytest.mark.parametrize("url,expected", [
+        # The self-hosted jitsi conventions are untouched: a jitsi-named host, a "meet" LABEL
+        # at the front, and the same label mid-hostname (regionalized deployments).
+        ("https://meet.jit.si/VexaStandup", ("jitsi", "VexaStandup")),
+        ("https://jitsi.example.org/MyRoom", ("jitsi", "MyRoom@jitsi.example.org")),
+        ("https://meet.example.org/TeamSync", ("jitsi", "TeamSync@meet.example.org")),
+        ("https://eu.meet.example.org/Weekly", ("jitsi", "Weekly@eu.meet.example.org")),
+    ])
+    def test_self_hosted_jitsi_conventions_survive(self, url, expected):
+        assert parse_meeting_url(url) == expected
+
+    def test_declared_jitsi_host_is_honoured_even_if_it_looks_like_a_platform(self, monkeypatch):
+        # An operator naming their own deployment is an explicit opt-in, not a guess, so the
+        # lookalike rule does not apply to VEXA_JITSI_HOSTS — only to the naming heuristics.
+        monkeypatch.setenv("VEXA_JITSI_HOSTS", "meet.google.com.internal.example")
+        assert parse_meeting_url("https://meet.google.com.internal.example/Standup") == (
+            "jitsi",
+            "Standup@meet.google.com.internal.example",
+        )
 
 
 class TestFindMeetingLinkJitsi:

--- a/docs/changelog.d/1168-meeting-host-exact-match.md
+++ b/docs/changelog.d/1168-meeting-host-exact-match.md
@@ -1,0 +1,7 @@
+- **Meeting links are matched to a platform by exact host, not by substring (#1168).** The link
+  parser used to classify a URL by looking for `meet.google.com`, `zoom` or `teams.microsoft.com`
+  anywhere in the hostname, which also accepted hosts that merely began with one of those names
+  and belonged to whoever submitted the URL. Hosts now have to *be* the platform's domain or a
+  subdomain of it, and Zoom is recognised on `zoom.us` / `zoomgov.com` rather than on the word
+  "zoom". Self-hosted Jitsi is unaffected: `meet.jit.si`, jitsi-named hosts, the `meet.example.org`
+  naming convention and anything declared in `VEXA_JITSI_HOSTS` parse exactly as before.


### PR DESCRIPTION
**Delivers issue:** none — found while dogfooding the link parser.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## What was wrong

`collector/meeting_link.py::parse_meeting_url` classified the meeting platform with **substring
tests on the hostname**:

```python
if "meet.google.com" in host:      # also true for meet.google.com.<anything-else>
if "zoom" in host:                 # also true for any host with "zoom" in it
if "teams.microsoft.com" in host:  # also true for teams.microsoft.com.<anything-else>
```

A hostname *contains* the platform's domain whenever the platform's domain is a prefix of it, and
the registrable part of a hostname is on the right, not the left. So a host that belongs to
whoever submitted the URL satisfied these tests and was accepted as a genuine platform link.

This is not cosmetic. `parse_meeting_url` is what decides whether a submitted URL becomes a
meeting; the URL rides along as `meeting_url`, and a bot later opens it in a real browser. An
accepted host is therefore a host we navigate to. On a hosted deployment the submitter is any API
caller, so the host reached was theirs to choose rather than ours — including hosts that resolve
somewhere inside the deployment's own network. Matching the host exactly is the fix for all of it.

The same class was flagged by CodeQL on the mailroom branch, which is where the fix below comes
from.

## The fix

`_host_matches(host, *domains)` — equality, or a dotted-suffix subdomain. Ported from the
mailroom's vendored copy (`vexa_mailroom.meeting_link`), not reinvented, so **the two parsers now
agree**; that matters because the mailroom hands its extracted `meeting_url` to `POST /meetings`,
which parses it a second time with this copy.

Zoom's domains are now named (`zoom.us`, `zoomgov.com`) instead of inferred from the substring
`"zoom"`. That is the rule the join brick already applies
(`modules/join/src/index.ts::resolvePlatform` — `host === "zoom.us" || host.endsWith(".zoom.us")`);
this parser was the outlier.

`_is_platform_lookalike` closes the same gap in the self-hosted jitsi fallback. A host of the form
`meet.google.com.<other-domain>` carries a `meet` *label*, so after the exact-match rule refused
it, the jitsi naming heuristic would have adopted it as a self-hosted room and handed the bot the
same host by another route. Hosts an operator has explicitly declared in `VEXA_JITSI_HOSTS` are
deliberately exempt — naming your own deployment is a decision, not a guess.

### Preserved

| Shape | Still parses |
|---|---|
| `meet.google.com/abc-defg-hij` | google_meet |
| `zoom.us`, `us02web.zoom.us`, `us05web.zoom.us`, `company.zoom.us`, `zoomgov.com` | zoom |
| `teams.live.com/meet/<id>`, `teams.microsoft.com/meet/<id>`, `foo.teams.microsoft.com` | teams |
| `teams.microsoft.com/l/meetup-join/19:meeting_…@thread.v2` | teams |
| `meet.jit.si/<room>` | jitsi |
| `jitsi.example.org/<room>` (jitsi-named host, pasted links) | jitsi |
| `meet.example.org`, `eu.meet.example.org` (the `meet` LABEL rule, pasted links) | jitsi |
| any host in `VEXA_JITSI_HOSTS`, in strict mode and in the ICS scan | jitsi |
| bare `abc-defg-hij` / bare 9–11 digits | google_meet / zoom |

### Now rejected

Hosts that merely contain a platform's domain, in both the pasted-link and ICS-scan modes:
`meet.google.com.<other>`, `zoom.us.<other>`, `teams.microsoft.com.<other>`,
`teams.live.com.<other>`, and hosts that merely have `zoom` somewhere in the name
(`zoom.<other>`, `notzoom.com`). `meetings.example.org` stays rejected as before — `meet` must be
a whole label.

The change only ever *narrows* what is accepted, so nothing the mailroom accepts is rejected here.

## Observation bundle (the record of your harnessed loop)

- **C1 — the defect is real on `main`.** ran: the new `TestHostMatchingIsExact` cases against the
  unmodified parser (`git stash` on the source file only) · saw: **8 failed, 14 passed** — every
  lookalike host in the table above parsed as a genuine platform link, e.g.
  `meet.google.com.<other>/abc-defg-hij` → `("google_meet", "abc-defg-hij")` · concluded: the
  substring tests, not an edge case in the callers, are what accepts these.
- **C2 — the fix closes it without collateral.** ran: `uv run pytest -q` in
  `core/meetings/services/meeting-api` · saw: **936 passed, 5 skipped** (was 924 before the 12 new
  cases; every pre-existing jitsi, zoom, teams and calendar-sync assertion unchanged) · concluded:
  the narrowing costs none of the legitimate shapes the suite already pins.
- **C3 — the two parsers agree.** ran: read `vexa_mailroom.meeting_link` and its
  `tests/test_meeting_link.py` goldens before writing anything · saw: the same `_host_matches`
  helper and the same lookalike expectations · concluded: ported rather than reinvented, so the
  mailroom's second-parse contract holds.

## Acceptance floor

| Row | Evidence |
|---|---|
| Lookalike platform hosts resolve to no platform | `TestHostMatchingIsExact::test_lookalike_host_resolves_to_no_platform` — 7 hosts × (default mode, `generic_hosts=True`, free-text scan). Negative control in C1: all 7 fail red on the unfixed parser. |
| Every legitimate host shape still parses | `test_real_platform_hosts_still_parse` (10 cases) + `test_self_hosted_jitsi_conventions_survive` (4 cases) + the untouched `TestParseJitsi` / `TestConfiguredJitsiHosts` / `test_parse_meeting_url_formats`. |
| `VEXA_JITSI_HOSTS` still wins | `test_declared_jitsi_host_is_honoured_even_if_it_looks_like_a_platform`. |
| Full suite green | `uv run pytest -q` → 936 passed, 5 skipped. |
| Repo gates green | The pre-push hook's 14 static gates all green: readme, dataflow, isolation, isolation-py, exports, graph, graph-py, schema, contract-version, config-contract, licenses, execution-env, test-isolation, contract-conformance. Full suite rides CI. |

## Docs diff (D6c)

Changelog fragment in `docs/changelog.d/`. No reference page changes: the accepted host shapes are
the ones the docs already document — this removes shapes that were never documented as supported.

## Security checks (required on the diff)

No dependency, licence or generated-artifact surface is touched — the diff is one pure-string
module plus its tests. Static gates listed above ran green locally. CodeQL and the full `gates`
suite ride CI on this PR.

## Validation request

Any competent non-author reviewer, on the diff itself: the parse table above is the whole contract,
and the test file is written to be read as that table. What to watch is the **preserved** column —
the risk in this change is over-narrowing, not under-narrowing, so a reviewer who runs a real
customer's Zoom or Teams link through `parse_meeting_url` and gets the same answer as before has
checked the thing that matters. No deployment was exercised: pure string logic, no I/O, no
framework imports.

## Notes for the maintainer

- **Contribution-rights boxes are deliberately left unticked** — that selection is a legal
  certification and is the submitter's to make, not an agent's.
- **The commit carries no `Signed-off-by`** for the same reason; `.github/dco.yml` allows
  individual remediation.
- **Overlap with #1164 (`mk-stage0-connector`):** none at file level. #1164 touches
  `collector/{app,adapters,fakes,ports}.py` and `tests/test_connector_access.py`; this PR touches
  `collector/meeting_link.py` and `tests/test_meeting_link.py`. Same package, disjoint files, both
  cut from current `origin/main`. `app.py` calls `parse_meeting_url`, but its signature is
  unchanged and the behaviour only narrows, so the two should merge in either order.

<!-- vexa-agent -->

