### PR TITLE
fix(mcp): match meeting hosts exactly, not by substring

### DIFF
--- a/clients/terminal/src/surfaces/__tests__/meetingId.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/meetingId.test.ts
@@ -115,6 +115,58 @@ describe("parseMeetingInput", () => {
     expect(parseMeetingInput("https://jitsi.example.org/a/b")).toBeNull();
   });
 
+  it("matches platform hosts exactly or as a dotted subdomain, never by substring", () => {
+    // A substring test puts the host under the control of whoever pasted the link: the platform
+    // name becomes a prefix of a domain they registered. Mirrors the server parsers' rule.
+    for (const url of [
+      // A "meet" LABEL would otherwise re-admit these through the self-hosted jitsi door.
+      "https://meet.google.com.attacker.example/abc-defg-hij",
+      "https://meet.zoom.us.attacker.example/j/12345678901",
+      "https://meet.teams.microsoft.com.evil.example/meet/33832851446746",
+      // Substring / suffix-without-the-dot matches on the zoom and teams branches.
+      "https://zoom.us.attacker.example/j/12345678901",
+      "https://zoomgov.com.attacker.example/j/12345678901",
+      "https://zoom.attacker.example/j/12345678901",
+      "https://notzoom.com/j/12345678901",
+      "https://notteams.live.com/meet/33832851446746",
+      "https://eviltteams.live.com/meet/33832851446746",
+      "https://teams.live.com.evil.example/meet/33832851446746",
+      "https://teams.microsoft.com.evil.example/l/meetup-join/19%3ameeting_abc123%40thread.v2/0",
+    ]) {
+      expect(parseMeetingInput(url), url).toBeNull();
+    }
+  });
+
+  it("keeps every real platform host parsing", () => {
+    const cases: [string, string, string][] = [
+      ["https://meet.google.com/abc-defg-hij", "google_meet", "abc-defg-hij"],
+      ["https://zoom.us/j/12345678901", "zoom", "12345678901"],
+      ["https://us02web.zoom.us/j/12345678901", "zoom", "12345678901"],
+      ["https://company.zoom.us/j/12345678901?pwd=xyz", "zoom", "12345678901"],
+      ["https://zoomgov.com/j/12345678901", "zoom", "12345678901"],
+      ["https://frbmeetings.zoomgov.com/j/12345678901", "zoom", "12345678901"],
+      ["https://teams.live.com/meet/33832851446746?p=abc", "teams", "33832851446746"],
+      ["https://teams.microsoft.com/meet/33832851446746?p=abc", "teams", "33832851446746"],
+      ["https://foo.teams.microsoft.com/meet/33832851446746?p=abc", "teams", "33832851446746"],
+      ["https://meet.jit.si/VexaStandup", "jitsi", "VexaStandup"],
+      ["https://jitsi.example.org/MyRoom", "jitsi", "MyRoom@jitsi.example.org"],
+      ["https://meet.example.org/TeamSync", "jitsi", "TeamSync@meet.example.org"],
+      ["https://eu.meet.example.org/Weekly", "jitsi", "Weekly@eu.meet.example.org"],
+    ];
+    for (const [url, platform, native_meeting_id] of cases) {
+      expect(parseMeetingInput(url), url).toEqual({ platform, native_meeting_id });
+    }
+  });
+
+  it("honours a declared jitsi host even when it looks like a platform", () => {
+    // An operator naming their own deployment is an explicit opt-in, not a guess, so the
+    // lookalike rule applies only to the naming heuristics.
+    expect(parseMeetingInput("https://meet.google.com.internal.example/Standup", ["meet.google.com.internal.example"])).toEqual({
+      platform: "jitsi",
+      native_meeting_id: "Standup@meet.google.com.internal.example",
+    });
+  });
+
   it("returns null for garbage", () => {
     expect(parseMeetingInput("")).toBeNull();
     expect(parseMeetingInput("not a meeting")).toBeNull();

--- a/clients/terminal/src/surfaces/meetingId.ts
+++ b/clients/terminal/src/surfaces/meetingId.ts
@@ -3,7 +3,10 @@
  *    google_meet → abc-defg-hij   ·   zoom → 9–11 digits   ·   teams → non-empty (passcode handled elsewhere)
  *    jitsi → the meet.jit.si room name, or room@host for a self-hosted deployment (a single
  *    URL-safe path segment; declared VEXA_JITSI_HOSTS arrive via the `jitsiHosts` parameter).
- *  Accepts either a raw id or a full meeting URL the user pasted. */
+ *  Accepts either a raw id or a full meeting URL the user pasted.
+ *  Hosts are matched EXACTLY or as a dotted subdomain (`hostMatches`) — never by substring,
+ *  which would read `meet.google.com.attacker.example` as Google Meet. The server parsers
+ *  (`meeting_api.collector.meeting_link`, `vexa_mcp.link_parser`) carry the same helper. */
 
 export type Platform = "google_meet" | "teams" | "zoom" | "jitsi";
 
@@ -17,6 +20,29 @@ const ZOOM_ID = /\d{9,11}/;
 // A Jitsi room: one URL-safe path segment (no separators/whitespace) — the id is embedded
 // back into the construct-URL template, so the encoded form is the id.
 const JITSI_ROOM = /^[^/?#\s]+$/;
+
+// Zoom's meeting domains: canonical zoom.us (+ every regional subdomain — us02web, a
+// customer's company.zoom.us) and the US-government tenant. Matches the server parsers.
+const ZOOM_DOMAINS = ["zoom.us", "zoomgov.com"] as const;
+// Every domain a hosted platform claims. Used both to match and to recognize a lookalike.
+const PLATFORM_DOMAINS = ["meet.google.com", ...ZOOM_DOMAINS, "teams.microsoft.com", "teams.live.com"] as const;
+
+/** Exact host, or a subdomain of one of `domains` — never a substring match.
+ *  A substring test (`host.includes("meet.google.com")`) also accepts
+ *  `meet.google.com.attacker.example`: the platform name is a *prefix* of a domain whoever
+ *  pasted the link controls. The registrable domain is the rightmost part of a hostname, so
+ *  the only sound test is equality or a dotted suffix. */
+function hostMatches(host: string, ...domains: readonly string[]): boolean {
+  return domains.some((d) => host === d || host.endsWith(`.${d}`));
+}
+
+/** True when `host` merely CONTAINS a platform's domain without being it or a subdomain of it.
+ *  Such a host must not reach the jitsi naming heuristics either: `meet.google.com.attacker.example`
+ *  carries a "meet" LABEL, so the self-hosted fallback would otherwise adopt it as a jitsi room.
+ *  Declared hosts (`jitsiHosts`) are unaffected — an operator naming their deployment is not a guess. */
+function isPlatformLookalike(host: string): boolean {
+  return PLATFORM_DOMAINS.some((d) => host.includes(d) && !hostMatches(host, d));
+}
 
 /** True if `id` is a valid native id for `platform`. */
 export function isValidMeetingId(platform: Platform, id: string): boolean {
@@ -50,15 +76,15 @@ export function parseMeetingInput(raw: string, jitsiHosts: readonly string[] = [
 
   if (url) {
     const host = url.hostname.toLowerCase();
-    if (host.includes("meet.google.com")) {
+    if (hostMatches(host, "meet.google.com")) {
       const code = url.pathname.split("/").filter(Boolean).pop()?.toLowerCase() ?? "";
       return isValidMeetingId("google_meet", code) ? { platform: "google_meet", native_meeting_id: code } : null;
     }
-    if (host.includes("zoom")) {
+    if (hostMatches(host, ...ZOOM_DOMAINS)) {
       const m = url.pathname.match(ZOOM_ID) || url.search.match(ZOOM_ID);
       return m ? { platform: "zoom", native_meeting_id: m[0] } : null;
     }
-    if (host.includes("teams.microsoft.com") || host.includes("teams.live.com")) {
+    if (hostMatches(host, "teams.microsoft.com", "teams.live.com")) {
       // Classic deep link carries the thread id (…/l/meetup-join/19:meeting_…@thread.v2).
       const decoded = decodeURIComponent(input);
       const thread = decoded.match(/19:meeting_[^@%\s/]+@thread\.v2/i);
@@ -77,9 +103,13 @@ export function parseMeetingInput(raw: string, jitsiHosts: readonly string[] = [
     // recommended naming, regionalized). The room is the path's single segment, kept exactly
     // as pasted (case + percent-encoding preserved — the raw URL rides along as meeting_url,
     // so the bot lands on the right deployment).
+    // A host that merely LOOKS like a hosted platform is excluded from the naming heuristics
+    // outright: the branches above already refused it by name, and
+    // meet.google.com.attacker.example carries a "meet" label that would otherwise let it back
+    // in through this door. Declared hosts are an explicit opt-in and stay unaffected.
     const jitsiHost =
       host === "meet.jit.si" || jitsiHosts.includes(host) ||
-      host.includes("jitsi") || host.split(".").includes("meet");
+      (!isPlatformLookalike(host) && (host.includes("jitsi") || host.split(".").includes("meet")));
     if (jitsiHost) {
       const room = url.pathname.replace(/^\/+|\/+$/g, "");
       if (!room || !JITSI_ROOM.test(room)) return null;

--- a/core/meetings/services/mcp/src/vexa_mcp/link_parser.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/link_parser.py
@@ -4,6 +4,10 @@ Pure function (no network): a full meeting URL → platform / native_meeting_id 
 (+ the raw URL for legacy Teams enterprise links, + the non-default Teams host for
 enterprise short links). Raises HTTPException(422) for unsupported/invalid URLs so the
 FastAPI tool route (and the MCP transport on top of it) surfaces a proper error.
+
+Hosts are matched EXACTLY or as a dotted subdomain (``_host_matches``) — never by substring,
+which would read ``zoom.us.attacker.example`` as Zoom. meeting-api's parser
+(``meeting_api.collector.meeting_link``) carries the same helper; the two are meant to agree.
 """
 from __future__ import annotations
 
@@ -32,13 +36,60 @@ _TEAMS_ENTERPRISE_HOSTS = {
     "dod.teams.microsoft.us",
 }
 
+# Zoom's meeting domains. Canonical zoom.us (+ every regional subdomain: us02web, us05web, a
+# customer's company.zoom.us) and the US-government tenant. Matches the join brick's own rule
+# (``modules/join/src/index.ts::resolvePlatform``) — a white-label portal is not inferable from
+# its URL, so it is not listed here and never was.
+_ZOOM_DOMAINS = ("zoom.us", "zoomgov.com")
+# Zoom Events registration portals — recognised only to refuse them with a useful message.
+_ZOOM_EVENTS_DOMAINS = ("events.zoom.us", "ev.zoom.com")
+# Every domain a hosted platform claims. Used both to match and to recognise a lookalike.
+_PLATFORM_DOMAINS = (
+    "meet.google.com",
+    *_ZOOM_DOMAINS,
+    *_ZOOM_EVENTS_DOMAINS,
+    "teams.live.com",
+    "teams.microsoft.com",
+    "teams.microsoft.us",
+)
+
+
+def _host_matches(host: str, *domains: str) -> bool:
+    """Exact host, or a subdomain of one of ``domains`` — never a substring match.
+
+    A substring test (``"zoom.us" in host``) also accepts ``zoom.us.attacker.example``: the
+    platform name is a *prefix* of an arbitrary domain the submitter controls, so anyone who
+    can hand this service a meeting URL chooses the host the bot's browser later opens. The
+    registrable domain is the rightmost part of a hostname, so the only sound test is equality
+    or a dotted suffix — the leading dot is what makes the suffix test a label boundary rather
+    than a substring (``host.endswith("teams.live.com")`` matches ``notteams.live.com``).
+
+    meeting-api's parser (``meeting_api.collector.meeting_link``) carries the same helper; the
+    two must agree, since a URL accepted here is handed to ``POST /meetings`` for a second parse.
+    """
+    return any(host == d or host.endswith("." + d) for d in domains)
+
+
+def _is_platform_lookalike(host: str) -> bool:
+    """True when ``host`` merely CONTAINS a platform's domain without being it or a subdomain
+    of it — ``meet.google.com.attacker.example``, ``zoom.us.attacker.example``.
+
+    Such a host is not the platform, and it must not reach the jitsi naming heuristics either:
+    ``meet.google.com.attacker.example`` carries a "meet" LABEL, so the self-hosted fallback at
+    the bottom of the parser would otherwise adopt it as a jitsi room and hand the bot the same
+    submitter-chosen host the exact-match rules just refused. Explicitly declared hosts
+    (``VEXA_JITSI_HOSTS``) are unaffected — an operator naming their own deployment is not a guess.
+    """
+    return any(d in host and not _host_matches(host, d) for d in _PLATFORM_DOMAINS)
+
 
 def _is_teams_enterprise_host(host: str) -> bool:
-    return (
-        host in _TEAMS_ENTERPRISE_HOSTS
-        or host.endswith(".teams.microsoft.us")
-        or host.endswith(".teams.microsoft.com")
-    )
+    """teams.microsoft.com, the gov/dod tenants, and any tenant subdomain of either.
+
+    Unchanged in reach: these suffix tests already carried the leading dot, so they were always
+    label-boundary tests; they are routed through ``_host_matches`` so one rule governs the file.
+    """
+    return _host_matches(host, *_TEAMS_ENTERPRISE_HOSTS) or host.endswith(".teams.microsoft.us")
 
 
 def parse_meeting_url(meeting_url: str) -> ParseMeetingLinkResponse:
@@ -75,7 +126,7 @@ def parse_meeting_url(meeting_url: str) -> ParseMeetingLinkResponse:
         )
 
     # Teams personal (teams.live.com/meet/<digits>?p=<passcode>)
-    if host.endswith("teams.live.com"):
+    if _host_matches(host, "teams.live.com"):
         m = re.match(r"^/meet/(\d{10,15})/?$", path)
         if not m:
             raise HTTPException(status_code=422, detail="Unsupported teams.live.com URL format. Expected /meet/<10-15 digit id>.")
@@ -141,14 +192,14 @@ def parse_meeting_url(meeting_url: str) -> ParseMeetingLinkResponse:
         )
 
     # Zoom Events — not joinable via shareable URL (check before general zoom.us match)
-    if host in {"events.zoom.us", "ev.zoom.com"} or host.endswith(".events.zoom.us"):
+    if _host_matches(host, *_ZOOM_EVENTS_DOMAINS):
         raise HTTPException(
             status_code=422,
             detail="Zoom Events links are not supported. Attendees receive unique per-registrant join links via email; these cannot be shared with a bot.",
         )
 
     # Zoom: zoom.us (all subdomains) and zoomgov.com
-    if "zoom.us" in host or "zoomgov.com" in host:
+    if _host_matches(host, *_ZOOM_DOMAINS):
         parts = [p for p in path.split("/") if p]
         native_id = ""
         if len(parts) >= 2 and parts[0] in {"j", "w"}:
@@ -179,8 +230,12 @@ def parse_meeting_url(meeting_url: str) -> ParseMeetingLinkResponse:
     configured_hosts = {
         h.strip().lower() for h in os.getenv("VEXA_JITSI_HOSTS", "").split(",") if h.strip()
     }
+    # A host that merely LOOKS like a hosted platform is excluded from the naming heuristics
+    # outright: the branches above already refused it by name, and
+    # meet.google.com.attacker.example carries a "meet" label that would otherwise let it back
+    # in through this door and hand the bot the host the exact-match rules just rejected.
     explicit_jitsi = host == "meet.jit.si" or host in configured_hosts
-    inferred_jitsi = "jitsi" in host or "meet" in host.split(".")
+    inferred_jitsi = not _is_platform_lookalike(host) and ("jitsi" in host or "meet" in host.split("."))
     if explicit_jitsi or inferred_jitsi:
         room = path.strip("/")
         if not room or not re.fullmatch(r"[^/?#\s]+", room):

--- a/core/meetings/services/mcp/tests/test_parse_meeting_link.py
+++ b/core/meetings/services/mcp/tests/test_parse_meeting_link.py
@@ -238,6 +238,79 @@ class TestJitsi:
         assert_422("https://meetings.example.org/Room", "unknown provider")
 
 
+class TestHostMatchingIsExact:
+    """A platform host is matched exactly or as a dotted subdomain — never by substring.
+
+    A substring test puts the host the bot's browser opens under the submitter's control: the
+    platform name becomes a prefix of a domain they registered. The parse is the only thing
+    between a submitted URL and a real navigation, so a host that is not the platform must
+    resolve to no platform at all — including via the self-hosted jitsi fallback, which a
+    google-meet lookalike would otherwise satisfy on its "meet" label.
+
+    Mirrors meeting-api's ``TestHostMatchingIsExact`` (#1168); the two parsers must agree.
+    """
+
+    @pytest.mark.parametrize("url", [
+        # A "meet" LABEL would otherwise re-admit these through the self-hosted jitsi door.
+        "https://meet.google.com.attacker.example/abc-defg-hij",
+        "https://meet.zoom.us.attacker.example/j/12345678901",
+        "https://meet.teams.microsoft.com.evil.example/meet/9361792952021",
+        # Substring matches on the zoom / teams branches.
+        "https://zoom.us.attacker.example/j/12345678901",
+        "https://zoomgov.com.attacker.example/j/12345678901",
+        "https://notteams.live.com/meet/9361792952021?p=abc",
+        "https://eviltteams.live.com/meet/9361792952021?p=abc",
+        "https://teams.live.com.evil.example/meet/9361792952021?p=abc",
+        "https://teams.microsoft.com.evil.example/meet/9361792952021",
+        "https://teams.microsoft.com.evil.example/l/meetup-join/19%3ameeting_YWJj%40thread.v2/0",
+        # No platform domain at all, just the word.
+        "https://zoom.attacker.example/j/12345678901",
+        "https://notzoom.com/j/12345678901",
+    ])
+    def test_lookalike_host_resolves_to_no_platform(self, url):
+        assert_422(url, "unknown provider")
+
+    @pytest.mark.parametrize("url,platform,native_id", [
+        # Google Meet: the exact host only — it has no meeting subdomains.
+        ("https://meet.google.com/abc-defg-hij", "google_meet", "abc-defg-hij"),
+        # Zoom: the apex, the regional subdomains, a customer vanity host, and the gov tenant.
+        ("https://zoom.us/j/12345678901", "zoom", "12345678901"),
+        ("https://us02web.zoom.us/j/12345678901", "zoom", "12345678901"),
+        ("https://company.zoom.us/j/12345678901?pwd=xyz", "zoom", "12345678901"),
+        ("https://zoomgov.com/j/12345678901", "zoom", "12345678901"),
+        ("https://frbmeetings.zoomgov.com/j/12345678901?pwd=xyz", "zoom", "12345678901"),
+        # Teams: personal, enterprise, the gov/dod tenants, and a tenant subdomain.
+        ("https://teams.live.com/meet/9361792952021?p=abc", "teams", "9361792952021"),
+        ("https://teams.microsoft.com/meet/33749853217630?p=abc", "teams", "33749853217630"),
+        ("https://gov.teams.microsoft.us/meet/12345678901234", "teams", "12345678901234"),
+        ("https://dod.teams.microsoft.us/meet/12345678901234", "teams", "12345678901234"),
+        ("https://contoso.teams.microsoft.us/meet/12345678901234", "teams", "12345678901234"),
+        ("https://foo.teams.microsoft.com/meet/33749853217630?p=abc", "teams", "33749853217630"),
+        # Self-hosted jitsi conventions: canonical, a jitsi-named host, a "meet" label at the
+        # front, and the same label mid-hostname (regionalized deployments).
+        ("https://meet.jit.si/VexaStandup", "jitsi", "VexaStandup"),
+        ("https://jitsi.example.org/MyRoom", "jitsi", "MyRoom@jitsi.example.org"),
+        ("https://meet.example.org/TeamSync", "jitsi", "TeamSync@meet.example.org"),
+        ("https://eu.meet.example.org/Weekly", "jitsi", "Weekly@eu.meet.example.org"),
+    ])
+    def test_real_platform_hosts_still_parse(self, url, platform, native_id):
+        r = parse(url)
+        assert (r.platform, r.native_meeting_id) == (platform, native_id)
+
+    def test_zoom_events_still_refused_by_name(self):
+        # The dedicated message survives; it is a rejection either way, but a useful one.
+        assert_422("https://events.zoom.us/ev/abc123", "zoom events")
+
+    def test_declared_jitsi_host_is_honoured_even_if_it_looks_like_a_platform(self, monkeypatch):
+        # An operator naming their own deployment is an explicit opt-in, not a guess, so the
+        # lookalike rule applies only to the naming heuristics — never to VEXA_JITSI_HOSTS.
+        monkeypatch.setenv("VEXA_JITSI_HOSTS", "meet.google.com.internal.example")
+        r = parse("https://meet.google.com.internal.example/Standup")
+        assert r.platform == "jitsi"
+        assert r.native_meeting_id == "Standup@meet.google.com.internal.example"
+        assert r.warnings == []
+
+
 class TestMisc:
     def test_empty_url_rejected(self):
         assert_422("", "empty")

--- a/docs/changelog.d/1169-mcp-meeting-host-exact-match.md
+++ b/docs/changelog.d/1169-mcp-meeting-host-exact-match.md
@@ -1,0 +1,11 @@
+- **The MCP service matches meeting links to a platform by exact host, not by substring (#1169).**
+  Its link parser used to recognise Zoom by looking for `zoom.us`/`zoomgov.com` anywhere in the
+  hostname, and personal Teams links with a suffix test that was missing its leading dot — both
+  also accepted hosts that merely began with the platform's name and belonged to whoever submitted
+  the URL. Hosts now have to *be* the platform's domain or a subdomain of it, and a host that only
+  looks like one can no longer slip back in through the self-hosted Jitsi naming heuristics. The
+  terminal client's copy of the parser gets the same treatment. Sibling of #1168, which made the
+  change in the meetings API. Nothing legitimate changes: `zoom.us` and its regional/vanity
+  subdomains, `zoomgov.com`, `teams.live.com`, `teams.microsoft.com` with its gov/dod tenants,
+  `meet.google.com`, `meet.jit.si`, the `meet.example.org` self-hosted convention and anything
+  declared in `VEXA_JITSI_HOSTS` all parse exactly as before.


### PR DESCRIPTION
**Delivers issue:** none — sibling of #1168, found while hardening the same parser family.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

Sibling of #1168, which made the same change in `meeting-api`'s parser. The two implementations
now agree: same `_host_matches` helper, same lookalike guard, same list of preserved shapes.

## The defect

`core/meetings/services/mcp/src/vexa_mcp/link_parser.py` decided a URL's platform from its
hostname using tests that are true for hosts that are not the platform:

| Line | Test | Also true for |
|---|---|---|
| Zoom | `"zoom.us" in host or "zoomgov.com" in host` | any host containing that string anywhere |
| Teams personal | `host.endswith("teams.live.com")` | the missing leading dot makes this a substring test |
| jitsi fallback | `"meet" in host.split(".")` | a host that failed the exact Meet check but carries a `meet` label |

A hostname's registrable domain is its rightmost part, so a substring or dot-less suffix test
accepts hosts that merely *begin* with the platform's name and belong to whoever submitted the
URL. The parse is the only thing between a submitted URL and a real browser navigation in our
infrastructure, and this service is server-side and reachable through the hosted API.

The third row is the part #1168 found the hard way and the reason fixing only the zoom and teams
branches is not enough: a host refused by the exact-match rules falls through to the self-hosted
jitsi naming heuristic, satisfies it on a `meet` label, and is re-admitted as a jitsi room — the
same host the rules above just rejected. `_is_platform_lookalike` closes that door.

## The change

`_host_matches(host, *domains)` — equality or a dotted suffix, nothing else — is now the only
host test in the file. `_is_platform_lookalike(host)` recognises a host that *contains* a
platform's domain without being it or a subdomain of it, and excludes it from the jitsi naming
heuristics. `_is_teams_enterprise_host` is routed through the same helper; its reach is unchanged
(its suffix tests already carried the leading dot).

`VEXA_JITSI_HOSTS` is unaffected: an operator naming their own deployment is an explicit opt-in,
not a guess, so declared hosts bypass the lookalike rule — and a declared host that happens to
contain a platform domain now resolves as jitsi instead of being swallowed by the Meet branch.

## Behaviours preserved

Verified by regression cases in the same test class, all of which also pass against the unfixed
parser:

- Zoom — `zoom.us`, `us02web.zoom.us`, `company.zoom.us` (customer vanity), `zoomgov.com`,
  `frbmeetings.zoomgov.com`; `/j/`, `/w/`, `/wc/join/` paths; 9–11 digit ids; the `/my/` and
  Zoom Events refusals keep their specific messages.
- Teams — `teams.live.com`, `teams.microsoft.com`, `foo.teams.microsoft.com`,
  `gov.`/`dod.`/`contoso.teams.microsoft.us`; short `/meet/<id>`, `/v2/` deep link, legacy
  `/l/meetup-join/` hash form.
- Google Meet — `meet.google.com` standard codes, Workspace nicknames, the `/lookup/` refusal.
- Jitsi — `meet.jit.si`, `jitsi.example.org`, `meet.example.org`, `eu.meet.example.org`
  (regionalized `meet` label), `VEXA_JITSI_HOSTS`-declared hosts, and the room-name rules.

## Test evidence

`core/meetings/services/mcp` (the `gate:python` command, `uv run pytest -q`): **103 passed**,
72 of them in `test_parse_meeting_link.py`.

**Negative control** — source reverted to the unfixed parser, new tests kept:
**7 failed, 65 passed**. The seven are exactly the host shapes the fix is for:

```
meet.google.com.attacker.example        (exact-Meet refused → re-admitted as jitsi)
meet.zoom.us.attacker.example           (      "                    "             )
meet.teams.microsoft.com.evil.example   (      "                    "             )
zoom.us.attacker.example                (substring)
zoomgov.com.attacker.example            (substring)
notteams.live.com                       (endswith, no leading dot)
eviltteams.live.com                     (endswith, no leading dot)
```

The remaining lookalike cases in the class (`zoom.attacker.example`, `notzoom.com`,
`teams.live.com.evil.example`, `teams.microsoft.com.evil.example`) were already rejected here and
are kept as regressions.

Static gates run locally: `gate:isolation`, `gate:exports`, `gate:graph` — green.

## Terminal client twin

`clients/terminal/src/surfaces/meetingId.ts` is the documented twin of the fixed server parser and
had all three substring branches plus the same fall-through. It is small and has a dedicated test
file, so it is fixed in this PR rather than left to disagree.

`clients/terminal`: **401 passed** (54 files), `tsc --noEmit` clean. Negative control on the
eleven lookalike hosts against the unfixed twin: **11 of 11 accepted**, 11 of 11 rejected after.
Its `host.includes("zoom")` was the broadest test of the three, which is why more shapes moved
here than in the mcp parser.

<!-- vexa-agent -->
