### PR TITLE
fix(join): resolve the platform from the hostname, not a substring of the URL

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/resolvePlatform.test.ts && tsx src/__tests__/localePin.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/scripts/debug-join.ts
+++ b/core/meetings/modules/join/scripts/debug-join.ts
@@ -14,7 +14,7 @@
  */
 import { chromium } from "playwright-extra";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
-import { joinMeeting, startDebugView, leaveGoogleMeet, leaveMicrosoftTeams, leaveZoomMeeting, getJoinBrowserArgs } from "../src/index";
+import { joinMeeting, resolvePlatform, startDebugView, leaveGoogleMeet, leaveMicrosoftTeams, leaveZoomMeeting, getJoinBrowserArgs, type Platform } from "../src/index";
 
 
 if (process.platform !== "linux" || !process.env.DISPLAY) {
@@ -24,13 +24,12 @@ if (process.platform !== "linux" || !process.env.DISPLAY) {
 }
 
 const url = process.argv[2];
-const isMeetUrl = !!url && url.includes("meet.google.com");
-const isTeamsUrl = !!url && (url.includes("teams.microsoft.com") || url.includes("teams.live.com"));
-const isZoomUrl = !!url && (() => {
-  try { const h = new URL(url).hostname; return h === "zoom.us" || h.endsWith(".zoom.us"); }
-  catch { return false; }
-})();
-if (!isMeetUrl && !isTeamsUrl && !isZoomUrl) {
+// One rule for "which platform is this URL": the package's own resolver, which matches on the
+// hostname rather than a substring of the URL. joinMeeting() below infers the platform the same
+// way, so the usage check and the join can no longer disagree about what the URL is.
+let platform: Platform | null = null;
+try { platform = url ? resolvePlatform(url) : null; } catch { platform = null; }
+if (platform !== "google_meet" && platform !== "teams" && platform !== "zoom") {
   console.error("Usage: tsx scripts/debug-join.ts <google-meet, teams, or zoom url>");
   process.exit(1);
 }
@@ -122,7 +121,7 @@ if (!isMeetUrl && !isTeamsUrl && !isZoomUrl) {
   // reconnect grace period; Teams/Meet can linger too).
   if (result.admitted) {
     try {
-      const leave = isZoomUrl ? leaveZoomMeeting : isTeamsUrl ? leaveMicrosoftTeams : leaveGoogleMeet;
+      const leave = platform === "zoom" ? leaveZoomMeeting : platform === "teams" ? leaveMicrosoftTeams : leaveGoogleMeet;
       const left = await leave(page, undefined, "debug_harness_done");
       console.log(`Graceful leave: ${left ? "ok" : "leave button not found (already out?)"}`);
     } catch (err: any) {

--- a/core/meetings/modules/join/src/__tests__/resolvePlatform.test.ts
+++ b/core/meetings/modules/join/src/__tests__/resolvePlatform.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `resolvePlatform` matches the HOSTNAME, exactly or as a dotted subdomain — never a substring
+ * of the URL.
+ *
+ * The Google Meet and Teams branches used to ask `meetingUrl.includes("meet.google.com")` and
+ * `meetingUrl.includes("teams.microsoft.com") || …("teams.live.com")` — a test against the whole
+ * URL string, which any host satisfies by carrying the platform's name in its query string, its
+ * path, or as a prefix of a domain the caller registered. The resolved platform picks the join
+ * flow, its selectors, and its anonymous-join assumptions, so it has to be a fact about the host.
+ *
+ * Same rule, same shape as `msteams/auth-redirect.test.ts`'s lookalike assertions, which already
+ * guard `isMicrosoftLoginUrl` / `isTeamsMeetingUrl`; all of them now run through the one helper
+ * in `shared/host-match.ts`.
+ *
+ * Run: npx tsx core/meetings/modules/join/src/__tests__/resolvePlatform.test.ts
+ */
+
+import { resolvePlatform, type Platform } from '../index';
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail?: string) {
+  if (ok) { console.log(`  \x1b[32mPASS\x1b[0m  ${name}`); passed++; }
+  else { console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ''}`); failed++; }
+}
+
+/** resolvePlatform(url) → the platform, or the string 'THREW' when it refused. */
+function resolved(url: string): Platform | 'THREW' {
+  try { return resolvePlatform(url); } catch { return 'THREW'; }
+}
+
+// ── Hosts that are NOT the platform, but carry its name ───────────────────────
+// Every one of these resolved to a platform under the substring test (or would have, had the
+// zoom/jitsi branches been written the same way). None may resolve to anything.
+const LOOKALIKES: [string, string][] = [
+  ['https://evil.example/?x=meet.google.com', 'platform name in the query string'],
+  ['https://evil.example/meet.google.com/abc-defg-hij', 'platform name in the path'],
+  ['https://evil.example/#meet.google.com', 'platform name in the fragment'],
+  ['https://meet.google.com.attacker.example/abc-defg-hij', 'platform name as a domain prefix'],
+  ['https://notmeet.google.com/abc-defg-hij', 'suffix without the label boundary'],
+  ['https://meet.google.com@attacker.example/abc-defg-hij', 'platform name in the userinfo'],
+  ['https://evil.example/?x=teams.microsoft.com', 'teams name in the query string'],
+  ['https://teams.microsoft.com.evil.example/l/meetup-join/19%3ameeting_abc%40thread.v2/0', 'teams as a domain prefix'],
+  ['https://teams.live.com.evil.example/meet/33832851446746', 'teams.live as a domain prefix'],
+  ['https://notteams.live.com/meet/33832851446746', 'teams suffix without the label boundary'],
+  ['https://teams.microsoft.com.us/l/meetup-join/19%3ameeting_abc%40thread.v2/0', 'lookalike TLD swap'],
+  ['https://zoom.us.attacker.example/j/12345678901', 'zoom as a domain prefix'],
+  ['https://notzoom.us/j/12345678901', 'zoom suffix without the label boundary'],
+  ['https://meet.jit.si.attacker.example/VexaStandup', 'jitsi as a domain prefix'],
+  ['https://8x8.vc.attacker.example/VexaStandup', '8x8 as a domain prefix'],
+];
+
+// ── Hosts that ARE the platform. Every shape the resolver accepted before, plus the gov/DoD and
+//    cloud.microsoft Teams hosts it now shares with the join flow's own host list. ────────────
+const REAL: [string, Platform][] = [
+  ['https://meet.google.com/abc-defg-hij', 'google_meet'],
+  ['https://meet.google.com/abc-defg-hij?authuser=0', 'google_meet'],
+  ['https://MEET.GOOGLE.COM/abc-defg-hij', 'google_meet'],
+  ['https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc123%40thread.v2/0?context=%7b%7d', 'teams'],
+  ['https://teams.microsoft.com/meet/33832851446746?p=abc', 'teams'],
+  ['https://emea.teams.microsoft.com/l/meetup-join/19%3ameeting_abc%40thread.v2/0', 'teams'],
+  ['https://teams.live.com/meet/33832851446746?p=abc', 'teams'],
+  // Aligned with msteams/auth-redirect.ts's TEAMS_HOST_SUFFIXES — the join flow already treats
+  // these as "on the meeting", so the resolver no longer refuses what the flow supports.
+  ['https://gov.teams.microsoft.us/l/meetup-join/19%3ameeting_abc%40thread.v2/0', 'teams'],
+  ['https://dod.teams.microsoft.us/l/meetup-join/19%3ameeting_abc%40thread.v2/0', 'teams'],
+  ['https://teams.cloud.microsoft/v2/?meetingjoin=true', 'teams'],
+  ['https://zoom.us/j/12345678901', 'zoom'],
+  ['https://us02web.zoom.us/j/12345678901?pwd=xyz', 'zoom'],
+  ['https://company.zoom.us/j/12345678901', 'zoom'],
+  ['https://meet.jit.si/VexaStandup', 'jitsi'],
+  ['https://8x8.vc/vpaas-magic-cookie-abc123/VexaStandup', 'jitsi'],
+  ['https://call.8x8.vc/VexaStandup', 'jitsi'],
+];
+
+// ── Neither: no host to speak of. Refused, as before. ────────────────────────
+const GARBAGE = ['', 'not a url', 'meeting', 'https://', 'https://example.com/join/1234'];
+
+function main() {
+  console.log('\n=== resolvePlatform matches the hostname, not a substring of the URL ===\n');
+
+  console.log('  -- lookalike hosts are refused --');
+  for (const [url, why] of LOOKALIKES) {
+    const got = resolved(url);
+    check(`${why}: ${url}`, got === 'THREW', `resolved to "${got}"`);
+  }
+
+  console.log('\n  -- real platform hosts still resolve --');
+  for (const [url, want] of REAL) {
+    const got = resolved(url);
+    check(`${want}: ${url}`, got === want, `resolved to "${got}"`);
+  }
+
+  console.log('\n  -- unrecognized input is refused --');
+  for (const url of GARBAGE) {
+    const got = resolved(url);
+    check(`refused: ${JSON.stringify(url)}`, got === 'THREW', `resolved to "${got}"`);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -12,6 +12,7 @@ import { waitForGoogleMeetingAdmission, checkForGoogleAdmissionSilent } from "./
 import { prepareForRecording, leaveGoogleMeet } from "./googlemeet/leave";
 import { startGoogleRemovalMonitor } from "./googlemeet/removal";
 import { joinMicrosoftTeams } from "./msteams/join";
+import { isTeamsMeetingUrl } from "./msteams/auth-redirect";
 import { waitForTeamsMeetingAdmission, checkForTeamsAdmissionSilent } from "./msteams/admission";
 import { prepareForRecording as prepareForTeamsRecording, leaveMicrosoftTeams } from "./msteams/leave";
 import { startTeamsRemovalMonitor } from "./msteams/removal";
@@ -24,6 +25,7 @@ import { waitForJitsiMeetingAdmission, checkForJitsiAdmissionSilent } from "./ji
 import { leaveJitsiMeeting } from "./jitsi/leave";
 import { startJitsiRemovalMonitor } from "./jitsi/removal";
 import { startDebugView } from "./shared/escalation";
+import { hostOf, hostMatches } from "./shared/host-match";
 import { setHooks, type BotConfig, type Hooks, type JoinState } from "./_host";
 import { JOIN_BROWSER_ARGS, getJoinBrowserArgs } from "./browser-args";
 
@@ -58,20 +60,38 @@ export interface JoinOptions {
   hooks?: Partial<Hooks>;
 }
 
-/** Infer the platform from the meeting URL. Throws on an unrecognized host. */
+/** Google Meet's only meeting host. */
+const GOOGLE_MEET_DOMAINS = ["meet.google.com"];
+// Canonical zoom.us / *.zoom.us only — white-label portals (LFX etc.) can't be
+// inferred from the URL; the embedder passes platform: "zoom" explicitly.
+const ZOOM_DOMAINS = ["zoom.us"];
+// Same rule for Jitsi: only the canonical public deployments are inferable —
+// a self-hosted Jitsi lives on an arbitrary host, so the embedder passes
+// platform: "jitsi" explicitly.
+const JITSI_DOMAINS = ["meet.jit.si", "8x8.vc"];
+
+/**
+ * Infer the platform from the meeting URL. Throws on an unrecognized host.
+ *
+ * The match is on the HOSTNAME, exact or as a dotted subdomain (`shared/host-match.ts`).
+ * Matching a substring of the whole URL instead would let a host that is not the platform
+ * carry the platform's name in its query string, its path, or as a prefix of a domain the
+ * caller registered — and the resolved platform decides which join flow, which selectors and
+ * which credential-free anonymous-join assumptions the bot then applies to that page.
+ *
+ * There is no generic fallback here on purpose: a host that matches none of the four lists is
+ * refused, so nothing can be re-admitted below by a looser heuristic.
+ */
 export function resolvePlatform(meetingUrl: string): Platform {
-  if (meetingUrl.includes("meet.google.com")) return "google_meet";
-  if (meetingUrl.includes("teams.microsoft.com") || meetingUrl.includes("teams.live.com")) return "teams";
-  // Canonical zoom.us / *.zoom.us only — white-label portals (LFX etc.) can't be
-  // inferred from the URL; the embedder passes platform: "zoom" explicitly.
-  // Same rule for Jitsi: only the canonical public deployments are inferable —
-  // a self-hosted Jitsi lives on an arbitrary host, so the embedder passes
-  // platform: "jitsi" explicitly.
-  try {
-    const host = new URL(meetingUrl).hostname;
-    if (host === "zoom.us" || host.endsWith(".zoom.us")) return "zoom";
-    if (host === "meet.jit.si" || host === "8x8.vc" || host.endsWith(".8x8.vc")) return "jitsi";
-  } catch { /* fall through to throw below */ }
+  const host = hostOf(meetingUrl);
+  if (host !== null) {
+    if (hostMatches(host, ...GOOGLE_MEET_DOMAINS)) return "google_meet";
+    // The package's canonical Teams host list lives in msteams/auth-redirect.ts, where the join
+    // flow uses it to assert it is on the meeting; read it from there rather than duplicating it.
+    if (isTeamsMeetingUrl(meetingUrl)) return "teams";
+    if (hostMatches(host, ...ZOOM_DOMAINS)) return "zoom";
+    if (hostMatches(host, ...JITSI_DOMAINS)) return "jitsi";
+  }
   throw new Error(`Cannot infer platform from meeting URL: ${meetingUrl}`);
 }
 

--- a/core/meetings/modules/join/src/msteams/auth-redirect.ts
+++ b/core/meetings/modules/join/src/msteams/auth-redirect.ts
@@ -19,6 +19,8 @@
  * `CompletionReason` (`join_failure`, transient) carrying a discriminating reason text.
  */
 
+import { hostOf, urlHostMatches } from "../shared/host-match";
+
 /** Machine-readable discriminator: the navigation landed on a Microsoft sign-in host. */
 export const TEAMS_AUTH_REDIRECT = "teams_auth_redirect";
 
@@ -42,34 +44,24 @@ const MICROSOFT_LOGIN_HOSTS = [
   "login.microsoftonline.de",
 ];
 
-/** Hosts that ARE the Teams web client (world-wide, GCC/DoD, and the cloud.microsoft rename). */
-const TEAMS_HOST_SUFFIXES = [
+/** Hosts that ARE the Teams web client (world-wide, GCC/DoD, and the cloud.microsoft rename).
+ *  This is the package's canonical Teams host list — `resolvePlatform` reads it through
+ *  `isTeamsMeetingUrl` rather than keeping a second copy. */
+export const TEAMS_HOST_SUFFIXES = [
   "teams.microsoft.com",
   "teams.live.com",
   "teams.microsoft.us",
   "teams.cloud.microsoft",
 ];
 
-function hostOf(url: string): string | null {
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
 /** True iff `url` is a Microsoft identity sign-in page. */
 export function isMicrosoftLoginUrl(url: string): boolean {
-  const host = hostOf(url);
-  if (!host) return false;
-  return MICROSOFT_LOGIN_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+  return urlHostMatches(url, ...MICROSOFT_LOGIN_HOSTS);
 }
 
 /** True iff `url` is served by the Teams web client. */
 export function isTeamsMeetingUrl(url: string): boolean {
-  const host = hostOf(url);
-  if (!host) return false;
-  return TEAMS_HOST_SUFFIXES.some((h) => host === h || host.endsWith(`.${h}`));
+  return urlHostMatches(url, ...TEAMS_HOST_SUFFIXES);
 }
 
 /** The hostname of the meeting link the join was asked to open (null when unparseable). */

--- a/core/meetings/modules/join/src/shared/host-match.ts
+++ b/core/meetings/modules/join/src/shared/host-match.ts
@@ -1,0 +1,37 @@
+/**
+ * host-match.ts — the ONE rule this package uses to decide whether a URL belongs to a platform.
+ *
+ * A hostname's registrable domain is its RIGHTMOST part, so the only sound test for "is this
+ * host Google Meet / Teams / Zoom / Jitsi" is equality with the platform's domain, or a dotted
+ * suffix of it. Two weaker tests look right and are not:
+ *
+ *   • `url.includes("meet.google.com")` — matches anywhere in the URL, so the platform name can
+ *     sit in a query string or a path segment of a host that is not the platform at all.
+ *   • `host.endsWith("teams.live.com")` — no leading dot, so it also matches `notteams.live.com`.
+ *
+ * Both put the host under the control of whoever supplied the link. `hostMatches` is the
+ * label-boundary version: the leading dot is what makes the suffix test a boundary rather than
+ * a substring. `msteams/auth-redirect.ts` already carried this rule for the Microsoft sign-in
+ * and Teams host lists; it now lives here so `resolvePlatform` and the redirect guard share one
+ * implementation instead of drifting copies.
+ */
+
+/** The lowercased hostname of `url`, or null when it does not parse as an absolute URL. */
+export function hostOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/** True iff `host` IS one of `domains` or a dotted subdomain of one — never a substring match. */
+export function hostMatches(host: string, ...domains: readonly string[]): boolean {
+  return domains.some((d) => host === d || host.endsWith(`.${d}`));
+}
+
+/** `hostMatches` applied to a URL string; false when the URL does not parse. */
+export function urlHostMatches(url: string, ...domains: readonly string[]): boolean {
+  const host = hostOf(url);
+  return host !== null && hostMatches(host, ...domains);
+}

--- a/docs/changelog.d/1170-join-platform-host-match.md
+++ b/docs/changelog.d/1170-join-platform-host-match.md
@@ -1,0 +1,12 @@
+- **The join layer infers a meeting's platform from the link's hostname, not from a substring of the
+  URL (#1170).** `resolvePlatform()` recognised Google Meet and Teams by looking for the platform's
+  name anywhere in the meeting URL, so a host that merely carried that name — in a query string, or
+  as a prefix of a domain whoever supplied the link registered — was classified as that platform and
+  driven through its join flow. A host now has to *be* the platform's domain or a subdomain of it:
+  the rule the Teams sign-in-redirect guard already applied, now shared by both. Sibling of #1168
+  (meetings API) and #1169 (MCP and terminal client). Nothing legitimate changes — `meet.google.com`,
+  `teams.microsoft.com` and `teams.live.com` with their tenant subdomains, `zoom.us` with its
+  regional and vanity subdomains, `meet.jit.si` and `8x8.vc` all resolve exactly as before. Two links
+  that used to be refused now resolve: Teams' gov/DoD (`teams.microsoft.us`) and `teams.cloud.microsoft`
+  hosts, which this layer's Teams join flow already treated as the meeting, and a link whose host is
+  written in uppercase.


### PR DESCRIPTION
**Delivers issue:** none — sibling of #1168 and #1169, the same defect in the join layer's own resolver.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## The defect

`core/meetings/modules/join/src/index.ts` decided a meeting's platform from a substring of the
whole URL, not from its host:

```ts
if (meetingUrl.includes("meet.google.com")) return "google_meet";
if (meetingUrl.includes("teams.microsoft.com") || meetingUrl.includes("teams.live.com")) return "teams";
```

A hostname's registrable domain is its rightmost part, so this is true for hosts that are not the
platform — the name can sit in a query string, in a path segment, or as a *prefix* of a domain
whoever supplied the link registered. The resolved platform decides which join flow runs, which
selectors it drives, and that it may proceed anonymously; those are assumptions about the site the
browser is on, so the input to them has to be a fact about the host.

The same two lines were duplicated in `scripts/debug-join.ts`. The zoom and jitsi branches in the
same function were already exact-host, which is the style the fix adopts.

**Reachability, stated plainly.** `core/meetings/services/bot/src/join-driver.ts:60,65` always
passes `platform` explicitly, so the live bot-spawn path never calls `resolvePlatform` today. It is
reachable through `@vexa/join`'s exported API, through `scripts/debug-join.ts`, and through any
future call site that omits `platform` — which is what `JoinOptions.platform` being optional invites.

## The change

`src/shared/host-match.ts` — `hostOf` / `hostMatches` / `urlHostMatches`, where `hostMatches` is
equality with the domain or a dotted suffix of it, and nothing else. This is not a new rule:
`msteams/auth-redirect.ts` already applied it to the Microsoft sign-in and Teams host lists, with
lookalike rejection asserted in `auth-redirect.test.ts`. It moves to `shared/` so both callers use
one implementation instead of two that drift.

- `resolvePlatform` matches on the hostname for all four platforms.
- Its Teams branch calls `isTeamsMeetingUrl` rather than keeping a second host list — the join flow
  and the resolver now cannot disagree about what a Teams host is.
- `auth-redirect.ts` keeps its lists and loses its private copy of the matcher.
- `scripts/debug-join.ts` calls `resolvePlatform` instead of re-implementing it, so its usage check
  and the `joinMeeting()` it then makes (which omits `platform`) classify the URL identically.

**No fall-through to re-admit a lookalike.** #1168 and #1169 both had one: a host refused by the
exact-match branches satisfied a self-hosted-Jitsi naming heuristic below them and was re-admitted.
This resolver has no such heuristic — self-hosted Jitsi is not inferable, the embedder passes
`platform: "jitsi"` explicitly, and the four branches are followed by a throw. A `_is_platform_lookalike`
equivalent would have nothing to guard. Verified by the lookalike cases below, which include
`meet.jit.si.attacker.example` and `8x8.vc.attacker.example`.

## Behaviours preserved

Regression cases in the new test file, all of which also pass against the unfixed resolver:

- Google Meet — `meet.google.com`, with query parameters.
- Teams — `teams.microsoft.com` `/l/meetup-join/` and `/meet/` links, tenant subdomains
  (`emea.teams.microsoft.com`), `teams.live.com/meet/<id>?p=`.
- Zoom — `zoom.us`, `us02web.zoom.us`, `company.zoom.us` (customer vanity).
- Jitsi — `meet.jit.si`, `8x8.vc` including the JaaS `vpaas-magic-cookie-…` path, `call.8x8.vc`.
- Unparseable and unrecognized input is still refused with the same message.

Three link shapes that used to be **refused** now resolve, and are called out because they are the
change's only widening:

| Shape | Why |
|---|---|
| `gov.` / `dod.teams.microsoft.us` | in `auth-redirect.ts`'s `TEAMS_HOST_SUFFIXES`, so the Teams join flow already treated them as the meeting while the resolver refused them |
| `teams.cloud.microsoft` | same list — the cloud.microsoft rename |
| an uppercase host (`MEET.GOOGLE.COM/…`) | `includes()` was case-sensitive; hostnames are not |

Zoom and Jitsi keep the same rule expressed through the shared helper, with one widening of the same
kind: `*.meet.jit.si` now resolves alongside the apex, a subdomain of Jitsi's own deployment domain.

## Test evidence

New file `src/__tests__/resolvePlatform.test.ts`, in the module's existing tsx style, wired into the
package's `test` script.

`core/meetings/modules/join` — `npm test` (the whole module suite, 19 files): green, exit 0. The new
file: **36 passed, 0 failed**.

**Negative control** — `src/index.ts` reverted to `origin/main`, the new tests kept:
**21 passed, 15 failed**. Eleven of the fifteen are lookalike hosts the unfixed resolver classified
as a platform:

```
evil.example/?x=meet.google.com                      → google_meet   (query string)
evil.example/meet.google.com/abc-defg-hij            → google_meet   (path segment)
evil.example/#meet.google.com                        → google_meet   (fragment)
meet.google.com.attacker.example                     → google_meet   (domain prefix)
notmeet.google.com                                   → google_meet   (no label boundary)
meet.google.com@attacker.example                     → google_meet   (userinfo)
evil.example/?x=teams.microsoft.com                  → teams         (query string)
teams.microsoft.com.evil.example                     → teams         (domain prefix)
teams.live.com.evil.example                          → teams         (domain prefix)
notteams.live.com                                    → teams         (no label boundary)
teams.microsoft.com.us                               → teams         (TLD swap)
```

The other four are the widened shapes in the table above (`gov.`/`dod.teams.microsoft.us`,
`teams.cloud.microsoft`, the uppercase host), which the unfixed resolver refused.

The four remaining lookalikes in the class — `zoom.us.attacker.example`, `notzoom.us`,
`meet.jit.si.attacker.example`, `8x8.vc.attacker.example` — were already rejected by the exact zoom
and jitsi branches and are kept as regressions.

Static gates run locally: `gate:isolation` (18 bricks), `gate:readme`, `gate:exports` — green.
`npm run check:isolation` in the module — green. `npm run build` (tsc) — clean.

## On the compiled artifact

The task this came from expected `core/meetings/modules/join/dist/index.js` to be a checked-in
build that also needed rebuilding. It is not: `dist/` is in the repo's root `.gitignore` (line 2),
`git ls-files` shows no tracked file under `core/meetings/modules/join/dist/`, and the module's
`.dockerignore` excludes `dist` from the build context. The bot image compiles the module from
source inside the builder stage (`pnpm --filter "@vexa/bot..." run build`,
`core/meetings/services/bot/Dockerfile`), and `Dockerfile.debug` mounts `src/` and runs it under
tsx. Any `dist/` on a developer's checkout is a local artifact.

So there is nothing to commit, and this PR hand-edits nothing. `npm run build` was still run to
confirm the compiled output carries the fix: `dist/index.js` calls `hostOf`/`hostMatches`,
`dist/shared/host-match.js` is emitted, and no `includes("meet.google.com")` or
`includes("teams.microsoft.com")` survives anywhere in the built output.

## Docs diff (D6c)

`docs/changelog.d/1170-join-platform-host-match.md`.

## Validation request

Any competent non-author. What to watch: run `npm test` in `core/meetings/modules/join`, then revert
`src/index.ts` to `origin/main` and run it again — the fifteen failures above should reproduce, and
the eleven lookalike lines are the finding. No deployment is exercised; this is a pure function with
no live call site today (see reachability, above).

## Relationship to #1168 / #1169

Same defect class, third and last of the server-side copies in the repository. #1168 fixed
`meeting-api`'s parser, #1169 fixed the MCP service's and the terminal client's twin of it. Those
two share a `_host_matches` helper and needed a lookalike guard for their Jitsi fall-through; this
one shares the equivalent TypeScript helper with the module's own Teams redirect guard and has no
fall-through to guard.

<!-- vexa-agent -->

