### PR TITLE
feat(workspaces): the context stack — layers, membership, policy-routed writes, owner triage

### DIFF
--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -517,6 +517,18 @@
    ]
   },
   {
+   "unique-id": "context-stack.v1",
+   "node-type": "contract",
+   "name": "context-stack.v1",
+   "description": "context-stack.v1 — sealed/published contract (agent)",
+   "metadata": [
+    {
+     "path": "core/agent/contracts/context-stack.v1",
+     "domain": "agent"
+    }
+   ]
+  },
+  {
    "unique-id": "workspace.v1",
    "node-type": "contract",
    "name": "workspace.v1",
@@ -1115,6 +1127,17 @@
    ]
   },
   {
+   "unique-id": "context-stack",
+   "node-type": "module",
+   "name": "context-stack",
+   "description": "context-stack — atomic module in agent",
+   "metadata": [
+    {
+     "path": "core/agent/modules/context-stack"
+    }
+   ]
+  },
+  {
    "unique-id": "platform",
    "node-type": "system",
    "name": "platform",
@@ -1269,8 +1292,10 @@
       "tool.v1",
       "unit.v1",
       "processed-notes.v1",
+      "context-stack.v1",
       "workspace.v1",
       "agent-worker",
+      "context-stack",
       "out-stream",
       "unit-in",
       "proc-stream",

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "f21af00839331cbf0c2eab14c0796442fe04c91e3b70bbfede4d53467a498abc"
+  "architecture.calm.json": "8e68fbfefa8b48bee6597ad7c4a7b1af3b5f354bedc3418409d92ecda0a0b1ea"
 }

--- a/core/agent/contracts/README.md
+++ b/core/agent/contracts/README.md
@@ -17,6 +17,7 @@ proactive cards, and tool calls.
 | **`tool.v1`** | a tool/integration grant — `{ scope, grant, cred_ref, transport, barriers }`; injected as `claude --allowedTools` + MCP. | no |
 | **`event.v1`** | an external event (e.g. email, meeting) mapped into a `unit.v1` Invocation — generic event ingress. | no |
 | **`proactive-card.v1`** | a proactive output card with actions (agent-initiated surface). | no |
+| **`context-stack.v1`** | the four layers a product-mode turn composes — global · group · personal · user-system — with the policy field that routes every write, the proposal queue an owner triages, and `SecretMetadata`, the whole read surface of a workspace secret. | no |
 | **`invoke.v1`** | the legacy meetings→agent invocation seam. **Sealed**; retiring as callers move to `unit.v1`. | **yes** |
 
 Note: `schedule.v1` (the Scheduler job spec routines compile to) is owned by `runtime`, not `agent` —

--- a/core/agent/contracts/context-stack.v1/README.md
+++ b/core/agent/contracts/context-stack.v1/README.md
@@ -1,0 +1,38 @@
+# context-stack.v1 — the four layers a product-mode turn composes — UNSEALED
+
+Every product-mode agent turn runs one composition, and this contract is its vocabulary.
+
+| Layer | Access | Content |
+|---|---|---|
+| **global** | read-only, hidden | product-level knowledge/behaviour, ours |
+| **group** | read/write **via triage** | shared; writes land as **proposals the owner triages** — PR-style, never direct |
+| **personal** | read/write | always exists for every user — *the user is not a group* |
+| **user-system** | read, hidden, never sharable | sessions, chat history; holds no external credentials ever |
+
+Three things in here are decisions rather than description:
+
+- **`policy` is one field, and it is also the layer.** A workspace's policy answers both *where it
+  sits in the composition* and *how a write to it lands*. Two fields could disagree, and the only
+  disagreement that matters — a group workspace taking direct writes — is exactly the bypass of
+  owner triage the product forbids.
+- **A `ResolvedStack` is pointers, not content.** Each slot names a workspace and its layer's
+  access rules; reading a document is a separate, separately-authorised act. That is what lets a
+  user be re-pointed at a different personal workspace, or compose several groups, without any
+  shape here changing.
+- **`SecretMetadata` is the whole read surface of a workspace secret.** No shape in this contract
+  has a field secret material could ride in. Setting a secret is the only place a value appears,
+  and it appears going in.
+
+Shapes: `Policy` · `Write` · `Role` · `ProposalState` · `Workspace` · `Membership` ·
+`ContextRevision` · `Proposal` · `StackSlot` · `Denial` · `ResolvedStack` · `ContextDelta` ·
+`Routing` · `AccessDecision` · `SecretMetadata`.
+
+Implemented by [`core/agent/modules/context-stack/`](../../modules/context-stack/README.md),
+whose `to_contract()` methods emit these shapes — its `tests/test_contract.py` validates live
+output against this schema, so the contract cannot drift from the code while the goldens still
+pass. There is no entry in `contracts/loader.py`: nothing validates these at runtime yet, and a
+validator no caller reaches is worse than none.
+
+**Status: UNSEALED** (in development) — not yet pinned in `contracts.seal.json`; `gate:schema`
+validates its goldens, `gate:contract-version` reports it unsealed. Sealed via
+`pnpm seal:contracts` on a `lane:contract` review.

--- a/core/agent/contracts/context-stack.v1/context-stack.schema.json
+++ b/core/agent/contracts/context-stack.v1/context-stack.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vexa.ai/schemas/context-stack.v1",
+  "title": "context-stack.v1",
+  "description": "The context stack: the four layers a product-mode agent turn composes, and the shapes around them. Global is read-only and hidden (product-level knowledge, ours); group is read/write VIA TRIAGE (writes land as proposals the owner decides, never direct); personal is read/write and exists for every user (the user is not a group); user-system is read, hidden, never sharable, and holds no external credentials ever. A workspace carries ONE explicit `policy` field which is both its layer in the stack and the rule by which a write to it lands — deliberately not two fields, because the only way two could disagree is a group workspace taking direct writes, which is the bypass of triage the product forbids. Stack slots are POINTERS: a ResolvedStack names workspaces and their access rules, never their content, and a user can be re-pointed at a different personal workspace without a schema change. SecretMetadata is the WHOLE read surface of a workspace secret — there is no shape here in which secret material can be returned.",
+  "$defs": {
+    "Policy": {
+      "description": "A workspace's policy field, which is also its layer in the stack. The order of the stack is the order of this list.",
+      "enum": ["global", "group", "personal", "user-system"]
+    },
+    "Write": {
+      "description": "How a context delta addressed to a layer lands. `via-triage` is the group layer's whole point: the delta becomes a Proposal and enters context only when a human owner accepts it.",
+      "enum": ["none", "direct", "via-triage", "platform-only"]
+    },
+    "Role": {
+      "description": "Owner: workspace config, membership, triage, secrets. Member: chat and knowledge.",
+      "enum": ["owner", "member"]
+    },
+    "ProposalState": {
+      "description": "A proposal is pending until a human owner answers it. There is no machine-written state.",
+      "enum": ["pending", "accepted", "rejected"]
+    },
+    "Workspace": {
+      "description": "A workspace: an address (meetings arrive by inviting it, so the invited address IS the group resolution), a name (which names the bot), a policy, an owner. A personal workspace is the one-member case of this, not a second kind.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "address", "policy", "owner_subject"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string", "description": "Names the bot." },
+        "address": { "type": "string", "format": "email", "description": "The workspace's own mailbox address." },
+        "policy": { "$ref": "#/$defs/Policy" },
+        "owner_subject": { "type": "string" }
+      }
+    },
+    "Membership": {
+      "description": "One seat. Group setup is a set of member emails and nothing more, so the email rides on the row rather than being resolved from a directory.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace_id", "subject", "role"],
+      "properties": {
+        "workspace_id": { "type": "string" },
+        "subject": { "type": "string" },
+        "role": { "$ref": "#/$defs/Role" },
+        "email": { "type": ["string", "null"] },
+        "added_by": { "type": "string" },
+        "added_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "ContextRevision": {
+      "description": "One append-only revision of one context document; the current state of a document is its highest revision. Append-only because triage needs a before and an after, a rejected proposal must leave no trace in context while leaving a full trace in the record, and compaction can only ever be a readable artifact over a history that was kept. Deletion is a tombstone (`deleted: true`), never a removed row.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace_id", "path", "revision", "body", "author_subject", "source_kind"],
+      "properties": {
+        "workspace_id": { "type": "string" },
+        "path": { "type": "string" },
+        "revision": { "type": "integer", "minimum": 1 },
+        "body": { "type": "string" },
+        "deleted": { "type": "boolean" },
+        "author_subject": { "type": "string", "description": "Who wrote the knowledge — the proposer, on an accepted delta, not the owner who accepted it." },
+        "source_kind": { "type": "string", "description": "meeting | chat | triage | seed" },
+        "source_ref": { "type": ["string", "null"], "description": "The source meeting or chat." },
+        "from_proposal_id": { "type": ["integer", "null"], "description": "Set when this revision exists because an owner accepted a proposal." }
+      }
+    },
+    "Proposal": {
+      "description": "A proposed context delta awaiting a human owner's answer. A decided proposal always names who decided and when — enforced by a CHECK constraint, not only by the code that writes it.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "workspace_id", "path", "body", "proposer_subject", "state"],
+      "properties": {
+        "id": { "type": "integer" },
+        "workspace_id": { "type": "string" },
+        "path": { "type": "string" },
+        "body": { "type": "string" },
+        "proposer_subject": { "type": "string" },
+        "source_kind": { "type": "string" },
+        "source_ref": { "type": ["string", "null"] },
+        "state": { "$ref": "#/$defs/ProposalState" },
+        "decided_by": { "type": ["string", "null"], "description": "The human owner. Null only while pending." },
+        "decided_at": { "type": ["string", "null"], "format": "date-time" },
+        "decision_note": { "type": ["string", "null"] }
+      }
+    },
+    "StackSlot": {
+      "description": "One mounted layer: a pointer to a workspace plus that layer's access rules. Never content — reading a document is a separate, separately-authorised act.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layer", "workspace_id", "name", "address", "write", "hidden", "sharable"],
+      "properties": {
+        "layer": { "$ref": "#/$defs/Policy" },
+        "workspace_id": { "type": "string" },
+        "name": { "type": "string" },
+        "address": { "type": "string" },
+        "write": { "$ref": "#/$defs/Write" },
+        "hidden": { "type": "boolean" },
+        "sharable": { "type": "boolean" }
+      }
+    },
+    "Denial": {
+      "description": "A slot that was asked for and not mounted. Recorded rather than swallowed: a stack quietly shorter than the user expects is a bug nobody can see.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layer", "reason"],
+      "properties": {
+        "layer": { "$ref": "#/$defs/Policy" },
+        "workspace_id": { "type": ["string", "null"] },
+        "reason": {
+          "description": "Stable code.",
+          "enum": [
+            "not-member",
+            "not-owner",
+            "policy-mismatch",
+            "dangling-pointer",
+            "global-not-provisioned",
+            "personal-not-provisioned",
+            "user-system-not-provisioned"
+          ]
+        }
+      }
+    },
+    "ResolvedStack": {
+      "description": "The ordered composition for one user: global → group(s) → personal → user-system. `pinned` is the product path, where the group slot is derived from membership and there is nothing to compose; `free` is the terminal's, where pointer rows choose. A user in no group resolves to three slots and that is the participant case, not a degraded one.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject", "mode", "slots", "denied"],
+      "properties": {
+        "subject": { "type": "string" },
+        "mode": { "enum": ["pinned", "free"] },
+        "slots": { "type": "array", "items": { "$ref": "#/$defs/StackSlot" } },
+        "denied": { "type": "array", "items": { "$ref": "#/$defs/Denial" } }
+      }
+    },
+    "ContextDelta": {
+      "description": "What changed in a context because a meeting happened. Addressed to a workspace; the workspace's policy decides where it lands.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace_id", "path", "body", "author_subject"],
+      "properties": {
+        "workspace_id": { "type": "string" },
+        "path": { "type": "string" },
+        "body": { "type": "string" },
+        "author_subject": { "type": "string" },
+        "source_kind": { "type": "string" },
+        "source_ref": { "type": ["string", "null"] }
+      }
+    },
+    "Routing": {
+      "description": "Where a delta lands, decided before anything is written. `proposal` on the group layer is the ceiling of the machine path: no volume of machine writes reaches `accepted`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["destination", "layer", "workspace_id", "reason"],
+      "properties": {
+        "destination": { "enum": ["direct", "proposal", "refused"] },
+        "layer": { "$ref": "#/$defs/Policy" },
+        "workspace_id": { "type": "string" },
+        "reason": {
+          "enum": [
+            "personal-policy-writes-direct",
+            "group-policy-routes-to-triage",
+            "global-is-read-only",
+            "user-system-is-platform-only",
+            "not-member",
+            "accepted-by-owner"
+          ]
+        }
+      }
+    },
+    "AccessDecision": {
+      "description": "The verdict on one attempt. Default-deny: every allow is an explicit rule and everything unnamed is refused. `reason` is a stable code — a refusal that cannot say why is not auditable, and this is the field a regulated buyer's access-rights question is answered from.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allow", "subject", "workspace_id", "policy", "action", "reason"],
+      "properties": {
+        "allow": { "type": "boolean" },
+        "subject": { "type": "string" },
+        "workspace_id": { "type": "string" },
+        "policy": { "$ref": "#/$defs/Policy" },
+        "action": { "enum": ["read", "write", "triage", "secrets", "share"] },
+        "reason": {
+          "enum": [
+            "owner",
+            "member",
+            "global-readable",
+            "not-member",
+            "not-owner",
+            "global-is-read-only",
+            "user-system-is-platform-only",
+            "user-system-holds-no-credentials",
+            "global-secrets-are-deployment-config",
+            "personal-is-not-a-group",
+            "layer-not-sharable",
+            "layer-has-no-proposal-queue",
+            "default-deny"
+          ]
+        }
+      }
+    },
+    "SecretMetadata": {
+      "description": "The WHOLE read surface of a workspace secret. There is no material field and no other shape in this contract carries one: a read returns last-4, the version, and who set it when. Setting is the only place a value appears, and it appears going in. The material itself is readable by exactly one function at LLM-call time, which is not reachable from any route.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace_id", "name", "last4", "version", "set_by", "set_at"],
+      "properties": {
+        "workspace_id": { "type": "string" },
+        "name": { "type": "string" },
+        "last4": { "type": "string", "maxLength": 4 },
+        "version": { "type": "integer", "minimum": 1 },
+        "set_by": { "type": "string" },
+        "set_at": { "type": "string", "format": "date-time" },
+        "rotated_at": { "type": ["string", "null"], "format": "date-time" }
+      }
+    }
+  }
+}

--- a/core/agent/contracts/context-stack.v1/golden/AccessDecision.non-member-group-read-deny.json
+++ b/core/agent/contracts/context-stack.v1/golden/AccessDecision.non-member-group-read-deny.json
@@ -1,0 +1,8 @@
+{
+  "allow": false,
+  "subject": "outsider@example.com",
+  "workspace_id": "acme",
+  "policy": "group",
+  "action": "read",
+  "reason": "not-member"
+}

--- a/core/agent/contracts/context-stack.v1/golden/AccessDecision.owner-triage-allow.json
+++ b/core/agent/contracts/context-stack.v1/golden/AccessDecision.owner-triage-allow.json
@@ -1,0 +1,8 @@
+{
+  "allow": true,
+  "subject": "owner@example.com",
+  "workspace_id": "acme",
+  "policy": "group",
+  "action": "triage",
+  "reason": "owner"
+}

--- a/core/agent/contracts/context-stack.v1/golden/AccessDecision.user-system-secrets-deny.json
+++ b/core/agent/contracts/context-stack.v1/golden/AccessDecision.user-system-secrets-deny.json
@@ -1,0 +1,8 @@
+{
+  "allow": false,
+  "subject": "member@example.com",
+  "workspace_id": "system-x",
+  "policy": "user-system",
+  "action": "secrets",
+  "reason": "user-system-holds-no-credentials"
+}

--- a/core/agent/contracts/context-stack.v1/golden/ContextDelta.from-meeting.json
+++ b/core/agent/contracts/context-stack.v1/golden/ContextDelta.from-meeting.json
@@ -1,0 +1,8 @@
+{
+  "workspace_id": "acme",
+  "path": "kg/pricing.md",
+  "body": "Renewal moved to Q3.",
+  "author_subject": "member@example.com",
+  "source_kind": "meeting",
+  "source_ref": "meeting-42"
+}

--- a/core/agent/contracts/context-stack.v1/golden/ContextRevision.accepted-from-proposal.json
+++ b/core/agent/contracts/context-stack.v1/golden/ContextRevision.accepted-from-proposal.json
@@ -1,0 +1,11 @@
+{
+  "workspace_id": "acme",
+  "path": "kg/pricing.md",
+  "revision": 1,
+  "body": "Renewal moved to Q3.",
+  "deleted": false,
+  "author_subject": "member@example.com",
+  "source_kind": "triage",
+  "source_ref": "meeting-42",
+  "from_proposal_id": 1
+}

--- a/core/agent/contracts/context-stack.v1/golden/Denial.non-member-group-pointer.json
+++ b/core/agent/contracts/context-stack.v1/golden/Denial.non-member-group-pointer.json
@@ -1,0 +1,5 @@
+{
+  "layer": "group",
+  "workspace_id": "acme",
+  "reason": "not-member"
+}

--- a/core/agent/contracts/context-stack.v1/golden/Membership.member.json
+++ b/core/agent/contracts/context-stack.v1/golden/Membership.member.json
@@ -1,0 +1,8 @@
+{
+  "workspace_id": "acme",
+  "subject": "member@example.com",
+  "role": "member",
+  "email": "member@example.com",
+  "added_by": "owner@example.com",
+  "added_at": "2026-08-17T09:00:00Z"
+}

--- a/core/agent/contracts/context-stack.v1/golden/Proposal.accepted-by-owner.json
+++ b/core/agent/contracts/context-stack.v1/golden/Proposal.accepted-by-owner.json
@@ -1,0 +1,13 @@
+{
+  "id": 1,
+  "workspace_id": "acme",
+  "path": "kg/pricing.md",
+  "body": "Renewal moved to Q3.",
+  "proposer_subject": "member@example.com",
+  "source_kind": "meeting",
+  "source_ref": "meeting-42",
+  "state": "accepted",
+  "decided_by": "owner@example.com",
+  "decided_at": "2026-08-17T00:53:50.417831Z",
+  "decision_note": "checked"
+}

--- a/core/agent/contracts/context-stack.v1/golden/Proposal.pending.json
+++ b/core/agent/contracts/context-stack.v1/golden/Proposal.pending.json
@@ -1,0 +1,13 @@
+{
+  "id": 1,
+  "workspace_id": "acme",
+  "path": "kg/pricing.md",
+  "body": "Renewal moved to Q3.",
+  "proposer_subject": "member@example.com",
+  "source_kind": "meeting",
+  "source_ref": "meeting-42",
+  "state": "pending",
+  "decided_by": null,
+  "decided_at": null,
+  "decision_note": null
+}

--- a/core/agent/contracts/context-stack.v1/golden/README.md
+++ b/core/agent/contracts/context-stack.v1/golden/README.md
@@ -1,0 +1,7 @@
+# golden — context-stack.v1
+
+`<Shape>.<case>.json`, each validated against `#/$defs/<Shape>` by `validate.mjs` under
+`gate:schema`. Every file here was **emitted by the implementation**, not hand-written: a member
+proposing into a group and the owner accepting it, a participant with no group resolving to three
+layers, a non-member's pointer at a group being denied, and a BYOT key's metadata after it was
+set. So the cases are the behaviour, not an author's idea of it. The goldens ARE the spec (P8).

--- a/core/agent/contracts/context-stack.v1/golden/ResolvedStack.member-pinned.json
+++ b/core/agent/contracts/context-stack.v1/golden/ResolvedStack.member-pinned.json
@@ -1,0 +1,43 @@
+{
+  "subject": "member@example.com",
+  "mode": "pinned",
+  "slots": [
+    {
+      "layer": "global",
+      "workspace_id": "global",
+      "name": "Vexa",
+      "address": "global@vexa.ai",
+      "write": "none",
+      "hidden": true,
+      "sharable": false
+    },
+    {
+      "layer": "group",
+      "workspace_id": "acme",
+      "name": "Acme",
+      "address": "acme@vexa.ai",
+      "write": "via-triage",
+      "hidden": false,
+      "sharable": true
+    },
+    {
+      "layer": "personal",
+      "workspace_id": "personal-member@example.com",
+      "name": "member@example.com (personal)",
+      "address": "member-personal@vexa.ai",
+      "write": "direct",
+      "hidden": false,
+      "sharable": false
+    },
+    {
+      "layer": "user-system",
+      "workspace_id": "user-system-member@example.com",
+      "name": "member@example.com (system)",
+      "address": "member-system@vexa.ai",
+      "write": "platform-only",
+      "hidden": true,
+      "sharable": false
+    }
+  ],
+  "denied": []
+}

--- a/core/agent/contracts/context-stack.v1/golden/ResolvedStack.participant-no-group.json
+++ b/core/agent/contracts/context-stack.v1/golden/ResolvedStack.participant-no-group.json
@@ -1,0 +1,34 @@
+{
+  "subject": "outsider@example.com",
+  "mode": "pinned",
+  "slots": [
+    {
+      "layer": "global",
+      "workspace_id": "global",
+      "name": "Vexa",
+      "address": "global@vexa.ai",
+      "write": "none",
+      "hidden": true,
+      "sharable": false
+    },
+    {
+      "layer": "personal",
+      "workspace_id": "personal-outsider@example.com",
+      "name": "outsider@example.com (personal)",
+      "address": "outsider-personal@vexa.ai",
+      "write": "direct",
+      "hidden": false,
+      "sharable": false
+    },
+    {
+      "layer": "user-system",
+      "workspace_id": "user-system-outsider@example.com",
+      "name": "outsider@example.com (system)",
+      "address": "outsider-system@vexa.ai",
+      "write": "platform-only",
+      "hidden": true,
+      "sharable": false
+    }
+  ],
+  "denied": []
+}

--- a/core/agent/contracts/context-stack.v1/golden/Routing.group-to-triage.json
+++ b/core/agent/contracts/context-stack.v1/golden/Routing.group-to-triage.json
@@ -1,0 +1,6 @@
+{
+  "destination": "proposal",
+  "layer": "group",
+  "workspace_id": "acme",
+  "reason": "group-policy-routes-to-triage"
+}

--- a/core/agent/contracts/context-stack.v1/golden/Routing.personal-direct.json
+++ b/core/agent/contracts/context-stack.v1/golden/Routing.personal-direct.json
@@ -1,0 +1,6 @@
+{
+  "destination": "direct",
+  "layer": "personal",
+  "workspace_id": "personal-member@example.com",
+  "reason": "personal-policy-writes-direct"
+}

--- a/core/agent/contracts/context-stack.v1/golden/SecretMetadata.byot-llm-key.json
+++ b/core/agent/contracts/context-stack.v1/golden/SecretMetadata.byot-llm-key.json
@@ -1,0 +1,9 @@
+{
+  "workspace_id": "acme",
+  "name": "llm_api_key",
+  "last4": "cafe",
+  "version": 1,
+  "set_by": "owner@example.com",
+  "set_at": "2026-08-17T00:53:50.420675Z",
+  "rotated_at": null
+}

--- a/core/agent/contracts/context-stack.v1/golden/StackSlot.group.json
+++ b/core/agent/contracts/context-stack.v1/golden/StackSlot.group.json
@@ -1,0 +1,9 @@
+{
+  "layer": "group",
+  "workspace_id": "acme",
+  "name": "Acme",
+  "address": "acme@vexa.ai",
+  "write": "via-triage",
+  "hidden": false,
+  "sharable": true
+}

--- a/core/agent/contracts/context-stack.v1/golden/Workspace.group.json
+++ b/core/agent/contracts/context-stack.v1/golden/Workspace.group.json
@@ -1,0 +1,7 @@
+{
+  "id": "acme",
+  "name": "Acme",
+  "address": "acme@vexa.ai",
+  "policy": "group",
+  "owner_subject": "owner@example.com"
+}

--- a/core/agent/contracts/context-stack.v1/validate.mjs
+++ b/core/agent/contracts/context-stack.v1/validate.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/** gate:schema for context-stack.v1 — golden `<Shape>.<case>.json` validates against #/$defs/<Shape>. */
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(readFileSync(join(HERE, "context-stack.schema.json"), "utf8"));
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(schema);
+
+const dir = join(HERE, "golden");
+const files = readdirSync(dir).filter((n) => n.endsWith(".json"));
+let failed = 0;
+for (const f of files) {
+  const shape = f.split(".")[0];
+  const validate = ajv.compile({ $ref: `${schema.$id}#/$defs/${shape}` });
+  const data = JSON.parse(readFileSync(join(dir, f), "utf8"));
+  if (validate(data)) console.log(`  ✓ ${f} ≡ ${shape}`);
+  else { console.error(`  ✗ ${f} (${shape}): ${ajv.errorsText(validate.errors)}`); failed++; }
+}
+console.log(failed ? `context-stack.v1: ${failed} golden(s) FAILED` : `context-stack.v1: ${files.length} goldens conform`);
+process.exit(failed ? 1 : 0);

--- a/core/agent/modules/README.md
+++ b/core/agent/modules/README.md
@@ -1,0 +1,12 @@
+# modules — `agent`
+
+Self-contained modules of the agent domain: a piece of the agent's behaviour with its own
+dependencies, its own tests, and no connection or process of its own. A module is mounted by a
+service; it never stands one up.
+
+| Module | What it owns |
+|---|---|
+| [`context-stack`](context-stack/README.md) | the four layers a product-mode turn composes — global · group · personal · user-system — their membership and policy-routed writes, the owner's triage queue, and a write-only workspace-secret surface. |
+
+The domain's other code sits beside this directory rather than in it: `control_plane/` (the
+dispatcher and the terminal-side workspace machinery), `worker/`, `shared/`, `llm/`, `contracts/`.

--- a/core/agent/modules/context-stack/README.md
+++ b/core/agent/modules/context-stack/README.md
@@ -1,0 +1,88 @@
+# context-stack — the four layers, their membership, and policy-routed writes
+
+The context stack is the primitive a product-mode agent turn runs on: **global → group(s) →
+personal → user-system**. This module owns its schema, its composition resolver, the router that
+decides where a context delta lands, the owner's triage queue, and a write-only surface for
+workspace secrets.
+
+| Layer | Access | Content |
+|---|---|---|
+| **global** | read-only, hidden | product-level knowledge/behaviour, ours |
+| **group** | read/write **via triage** | shared; writes land as **proposals the owner triages** — PR-style, never direct |
+| **personal** | read/write | always exists for every user — *the user is not a group* |
+| **user-system** | read, hidden, never sharable | sessions, chat history; holds no external credentials ever |
+
+Start at [`src/context_stack/layers.py`](src/context_stack/layers.py): the table above is code,
+once, and every rule in the module reads it rather than restating it.
+
+## What each file is
+
+| File | What it owns |
+|---|---|
+| `layers.py` | the four layers and their fixed access rules. One table, no second copy. |
+| `models.py` | the six tables. Context is append-only; stack slots carry no foreign key; a decided proposal is required by a CHECK constraint to name a human. Each argued in place. |
+| `store.py` | the repository. Persistence only — it decides nothing and it never commits. |
+| `access.py` | who may do what, default-deny, pure. Every refusal carries a stable code. |
+| `workspaces.py` | provisioning and membership. Group setup is a set of member emails. |
+| `resolver.py` | composition. Pinned (the product) and free (the terminal) differ in one place. |
+| `router.py` | the **machine path**: a delta lands where its workspace's policy says. |
+| `triage.py` | the **human path**: an owner accepts or rejects. |
+| `secrets.py` | set · rotate · delete · read metadata. Never a value. |
+| `material.py` | the one function that reads secret material, alone in its own module. |
+| `api.py` | an `APIRouter` a service mounts. Not an app; wires no database. |
+
+## Three decisions worth knowing before reading the code
+
+**Policy is the layer.** A workspace carries one `policy` field, and it answers both *where the
+workspace sits in the stack* and *how a write to it lands*. Two fields could disagree, and the
+only disagreement that matters — a group workspace accepting direct writes — is precisely the
+bypass of owner triage the product forbids. One field cannot express it.
+
+**Context is append-only.** Triage needs a before and an after; a rejected proposal must leave no
+trace in context while leaving a full trace in the record; compaction can only ever be a readable
+artifact over a history that was kept. It also matches what the knowledge store already is — these
+workspaces are git repos, where a write has always been an append. Deletion is a tombstone.
+
+**No machine ever writes acknowledgement.** Four guards, at four levels: `triage.py` depends on
+`router.py`'s types, so the machine path importing the human path is a cycle Python refuses to
+load; `actor` is required with no default and no service principal; the actor must hold the owner
+role; and `ck_proposal_decision_is_attributed` refuses any decided row that does not name who
+decided and when. There is no auto-accept, and adding one is not a small edit.
+
+## The secret surface is write-only
+
+Set, rotate, delete, and read metadata. Every management function returns `SecretMetadata`, which
+has no field material could be put in — the surface is write-only because of the type, not because
+of the callers. The one reader lives in `material.py`, is imported by neither `secrets.py` nor
+`api.py`, and returns a handle whose `repr`, `str` and `format` are all redacted.
+
+In the pilot exactly one secret is user-supplied: the LLM key or endpoint the workspace owner
+brings. Self-hosted it is a k8s Secret and never reaches this table.
+
+**Plaintext at rest**, deliberately — the level the saved GitHub token already sits at
+(access-controlled, not encrypted). Envelope encryption is not built here: it earns its keep when
+group-scoped integration tokens arrive with grant rows and expiries. Until then, a full server
+compromise reads this column: use a revocable, minimally-scoped key.
+
+## Running it
+
+```bash
+cd core/agent/modules/context-stack && uv run pytest -q     # 73 tests, no docker, no network
+```
+
+The tests build the real DDL on in-memory SQLite, so CHECK and UNIQUE constraints are exercised
+rather than described. `pnpm gate:python` picks this package up mechanically (a `pyproject.toml`
+plus a non-empty `tests/`).
+
+## What is not here
+
+No admin UI, no address allocation or mailbox provisioning, no LLM chat, no migration of existing
+users, and no deployment wiring — the module owns no connection, and no service mounts it yet.
+Because nothing creates these tables in a deployment, they are **not in `schema.seal.json`**;
+sealing now would freeze a claim nothing is making. When a service adopts the module, add
+`models.py` to `MODEL_FILES` in `scripts/schema_digest.py` and re-seal on a `lane:schema` review.
+
+Contract: [`core/agent/contracts/context-stack.v1/`](../../contracts/context-stack.v1/README.md).
+The existing terminal-side workspace model it will have to meet is documented at
+[`docs/docs/core/workspaces.mdx`](../../../../docs/docs/core/workspaces.mdx); the product-side
+model is [`docs/docs/core/context-stack.mdx`](../../../../docs/docs/core/context-stack.mdx).

--- a/core/agent/modules/context-stack/pyproject.toml
+++ b/core/agent/modules/context-stack/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "vexa-context-stack"
+version = "0.12.0"
+description = "The context stack — the four layers a product-mode agent turn composes (global · group · personal · user-system), their membership and policy-routed writes, owner triage of group proposals, and a write-only workspace-secret surface."
+requires-python = ">=3.11"
+# The module owns no connection: a mounting service injects an AsyncSession, so nothing here
+# constructs an engine or holds a pool. FastAPI is the HTTP surface (an APIRouter, not an app).
+dependencies = [
+    "sqlalchemy[asyncio]>=2,<3",
+    "fastapi>=0.110,<1",
+    "pydantic>=2,<3",
+]
+
+[dependency-groups]
+# Tests run the real DDL on in-memory SQLite — real constraints, no docker, no network.
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1,<2",
+    "aiosqlite>=0.20,<1",
+    "httpx>=0.27,<1",
+    # Validates this module's live output against the published context-stack.v1 schema, so the
+    # contract cannot drift from the code while its goldens still pass.
+    "jsonschema>=4.21,<5",
+    "referencing>=0.31",
+]
+
+[tool.uv]
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+# Every test here drives an async store; `auto` keeps the marker off ~50 tests without changing
+# what any of them prove.
+asyncio_mode = "auto"

--- a/core/agent/modules/context-stack/src/README.md
+++ b/core/agent/modules/context-stack/src/README.md
@@ -1,0 +1,4 @@
+# src — context-stack
+
+One top-level package, `context_stack`. `pythonpath = ["src"]` in `pyproject.toml` puts it on the
+path for tests; a mounting service imports it the same way.

--- a/core/agent/modules/context-stack/src/context_stack/README.md
+++ b/core/agent/modules/context-stack/src/context_stack/README.md
@@ -1,0 +1,12 @@
+# context_stack
+
+Read [`layers.py`](layers.py) first — the four-layer table lives there once, and every other file
+reads it rather than restating it. The parent [README](../../README.md) has the file-by-file map
+and the three decisions behind the shape.
+
+Two boundaries inside this package are load-bearing and both are asserted by tests:
+
+- `router.py` (the machine path) cannot reach `triage.py` (the human path). The dependency runs
+  the other way, so importing it back is a cycle Python refuses to load.
+- `material.py` — the one reader of secret material — is imported by neither `secrets.py` nor
+  `api.py`, which is what makes "no endpoint returns a secret" a fact about the import graph.

--- a/core/agent/modules/context-stack/src/context_stack/__init__.py
+++ b/core/agent/modules/context-stack/src/context_stack/__init__.py
@@ -1,0 +1,105 @@
+"""The context stack: the four layers every product-mode agent turn composes.
+
+| Layer           | Access                       | Content                                            |
+|-----------------|------------------------------|-----------------------------------------------------|
+| **global**      | read-only, hidden            | product-level knowledge/behaviour, ours              |
+| **group**       | read/write via triage        | shared; writes land as proposals the owner triages   |
+| **personal**    | read/write                   | always exists for every user — the user is not a group |
+| **user-system** | read, hidden, never sharable | sessions, chat history; holds no external credentials |
+
+Read ``layers.py`` first — the table above lives there as code, once.
+
+``material`` is deliberately absent from this front door. The one function that reads secret
+material is ``context_stack.material.use_material``, and importing it has to be an explicit act
+by the one caller that needs it at LLM-call time. Everything else gets
+:class:`context_stack.secrets.SecretMetadata`, which has no material field.
+"""
+
+from __future__ import annotations
+
+from .access import AccessDecision, Action, decide
+from .errors import (
+    AccessDenied,
+    ContextStackError,
+    InvalidWorkspace,
+    NotFound,
+    ProposalAlreadyDecided,
+)
+from .layers import RULES, STACK_ORDER, Policy, Role, Write
+from .models import (
+    Base,
+    ContextRevision,
+    Membership,
+    Proposal,
+    StackPointer,
+    Workspace,
+    WorkspaceSecret,
+)
+from .resolver import Denial, Mode, ResolvedStack, StackSlot, resolve_stack
+from .router import ContextDelta, Destination, Landed, Routing, land_delta, route
+from .secrets import SecretMetadata, delete_secret, get_metadata, list_metadata, set_secret
+from .store import ContextStackStore, MemberRef, ProposalRef, RevisionRef, WorkspaceRef
+from .triage import accept_proposal, pending_proposals, reject_proposal
+from .workspaces import add_member, create_workspace, ensure_personal, ensure_user_system, remove_member
+
+__all__ = [
+    # the layer table
+    "Policy",
+    "Role",
+    "Write",
+    "RULES",
+    "STACK_ORDER",
+    # schema
+    "Base",
+    "Workspace",
+    "Membership",
+    "ContextRevision",
+    "Proposal",
+    "StackPointer",
+    "WorkspaceSecret",
+    # store
+    "ContextStackStore",
+    "WorkspaceRef",
+    "MemberRef",
+    "RevisionRef",
+    "ProposalRef",
+    # provisioning + membership
+    "create_workspace",
+    "ensure_personal",
+    "ensure_user_system",
+    "add_member",
+    "remove_member",
+    # composition
+    "resolve_stack",
+    "Mode",
+    "ResolvedStack",
+    "StackSlot",
+    "Denial",
+    # write routing (machine path)
+    "route",
+    "land_delta",
+    "ContextDelta",
+    "Routing",
+    "Destination",
+    "Landed",
+    # triage (human path)
+    "accept_proposal",
+    "reject_proposal",
+    "pending_proposals",
+    # access
+    "decide",
+    "Action",
+    "AccessDecision",
+    # secrets — metadata only
+    "SecretMetadata",
+    "set_secret",
+    "delete_secret",
+    "get_metadata",
+    "list_metadata",
+    # errors
+    "ContextStackError",
+    "AccessDenied",
+    "NotFound",
+    "InvalidWorkspace",
+    "ProposalAlreadyDecided",
+]

--- a/core/agent/modules/context-stack/src/context_stack/access.py
+++ b/core/agent/modules/context-stack/src/context_stack/access.py
@@ -1,0 +1,137 @@
+"""Who may do what to a workspace. Default-deny, pure, and the only place the answer is decided.
+
+Every allow is an explicit rule; anything the rules do not name is refused with ``default-deny``.
+The decision is a value, not a boolean — a refusal that cannot say why is not auditable, and the
+access-rights question a regulated buyer asks is answered by reading these codes, not by reading
+control flow.
+
+Follows the shape ``identity_core.access`` already uses in this repo: a frozen decision carrying
+subject, resource, action and a stable machine reason.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .layers import RULES, Policy, Role, Write
+
+
+class Action(str, Enum):
+    """What is being attempted."""
+
+    READ = "read"
+    """Read the layer's context."""
+
+    WRITE = "write"
+    """Land a context delta. An allow does NOT mean a direct write — see ``Routing``."""
+
+    TRIAGE = "triage"
+    """Accept or reject a proposal. Owner only."""
+
+    SECRETS = "secrets"
+    """Set, rotate or delete a workspace secret. Owner only."""
+
+    SHARE = "share"
+    """Add or remove a member."""
+
+
+@dataclass(frozen=True)
+class AccessDecision:
+    """The verdict. ``reason`` is a stable code, never free text."""
+
+    allow: bool
+    subject: str
+    workspace_id: str
+    policy: Policy
+    action: Action
+    reason: str
+
+    def to_contract(self) -> dict:
+        """The ``context-stack.v1`` AccessDecision shape."""
+        return {
+            "allow": self.allow,
+            "subject": self.subject,
+            "workspace_id": self.workspace_id,
+            "policy": self.policy.value,
+            "action": self.action.value,
+            "reason": self.reason,
+        }
+
+
+def decide(
+    *,
+    subject: str,
+    workspace_id: str,
+    policy: Policy,
+    role: Role | None,
+    action: Action,
+) -> AccessDecision:
+    """Decide one attempt. ``role`` is the actor's membership role, or ``None`` for a non-member.
+
+    Pure: it reads no store and performs no I/O, so the whole policy is one readable table and a
+    caller cannot accidentally make a different decision by holding a different session.
+    """
+    rules = RULES[policy]
+
+    def verdict(allow: bool, reason: str) -> AccessDecision:
+        return AccessDecision(
+            allow=allow,
+            subject=subject,
+            workspace_id=workspace_id,
+            policy=policy,
+            action=action,
+            reason=reason,
+        )
+
+    if action is Action.READ:
+        # Global is product-level knowledge, mounted by everyone's stack and hidden from all of
+        # them. Every other layer is membership-gated, which is what keeps a non-member out of a
+        # group's context.
+        if rules.readable_by_everyone:
+            return verdict(True, "global-readable")
+        if role is None:
+            return verdict(False, "not-member")
+        return verdict(True, role.value)
+
+    if action is Action.WRITE:
+        if rules.write is Write.NONE:
+            return verdict(False, "global-is-read-only")
+        if rules.write is Write.PLATFORM_ONLY:
+            return verdict(False, "user-system-is-platform-only")
+        if role is None:
+            return verdict(False, "not-member")
+        return verdict(True, role.value)
+
+    if action is Action.TRIAGE:
+        # Only the group layer has a queue at all, and only its owner answers it.
+        if rules.write is not Write.VIA_TRIAGE:
+            return verdict(False, "layer-has-no-proposal-queue")
+        if role is not Role.OWNER:
+            return verdict(False, "not-owner")
+        return verdict(True, "owner")
+
+    if action is Action.SECRETS:
+        # The user-system layer holds no external credentials ever, and the global layer's
+        # credentials are deployment config rather than rows an owner sets. Both refusals are
+        # properties of the layer, checked before the role — so no role can reach them.
+        if not rules.holds_credentials:
+            if policy is Policy.USER_SYSTEM:
+                return verdict(False, "user-system-holds-no-credentials")
+            return verdict(False, "global-secrets-are-deployment-config")
+        if role is not Role.OWNER:
+            return verdict(False, "not-owner")
+        return verdict(True, "owner")
+
+    if action is Action.SHARE:
+        # "The user is not a group": a personal workspace is the one-member case, so it has no
+        # second member to add. Making it shared means making it a group workspace.
+        if policy is Policy.PERSONAL:
+            return verdict(False, "personal-is-not-a-group")
+        if not rules.sharable:
+            return verdict(False, "layer-not-sharable")
+        if role is not Role.OWNER:
+            return verdict(False, "not-owner")
+        return verdict(True, "owner")
+
+    return verdict(False, "default-deny")

--- a/core/agent/modules/context-stack/src/context_stack/api.py
+++ b/core/agent/modules/context-stack/src/context_stack/api.py
@@ -1,0 +1,443 @@
+"""The HTTP surface: an ``APIRouter`` a service mounts. It is not an app and it wires no database.
+
+The routes exist so the two invariants this module is built around can be checked mechanically
+rather than argued:
+
+* **No route returns secret material.** The secret routes' response model is
+  :class:`SecretMetadataOut`, which has no material field, and this module does not import
+  ``context_stack.material`` — the only place material is readable. Both are asserted by
+  enumerating the routes in ``tests/test_api_surface.py``, which also sets a known key and calls
+  every readable route to confirm the value comes back from none of them.
+* **No route accepts a proposal automatically.** There is one accept route, it is a POST, and it
+  takes its actor from the gateway-verified caller identity. There is no accept-all, no
+  auto-accept flag, and no route that decides a proposal as a side effect of anything else.
+
+The actor is read from ``X-User-Email`` — the header the gateway already stamps, and the same
+identifier group setup uses, since a group is a set of member emails.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel
+
+from . import secrets as secrets_surface
+from . import triage, workspaces
+from .errors import (
+    AccessDenied,
+    ContextStackError,
+    InvalidWorkspace,
+    NotFound,
+    ProposalAlreadyDecided,
+)
+from .layers import Policy, Role
+from .resolver import Mode, resolve_stack
+from .router import ContextDelta, land_delta
+from .store import ContextStackStore
+
+
+# ── wire shapes ───────────────────────────────────────────────────────────────────────────────
+
+
+class WorkspaceIn(BaseModel):
+    workspace_id: str
+    name: str
+    address: str
+    policy: Policy
+    member_emails: list[str] = []
+
+
+class WorkspaceOut(BaseModel):
+    id: str
+    name: str
+    address: str
+    policy: Policy
+    owner_subject: str
+
+
+class MemberIn(BaseModel):
+    subject: str
+    email: str | None = None
+
+
+class MemberOut(BaseModel):
+    subject: str
+    role: Role
+    email: str | None
+
+
+class RemovedOut(BaseModel):
+    removed: bool
+
+
+class SlotOut(BaseModel):
+    layer: Policy
+    workspace_id: str
+    name: str
+    address: str
+    write: str
+    hidden: bool
+    sharable: bool
+
+
+class DenialOut(BaseModel):
+    layer: Policy
+    workspace_id: str | None
+    reason: str
+
+
+class StackOut(BaseModel):
+    subject: str
+    mode: Mode
+    slots: list[SlotOut]
+    denied: list[DenialOut]
+
+
+class DeltaIn(BaseModel):
+    workspace_id: str
+    path: str
+    body: str
+    source_kind: str = "meeting"
+    source_ref: str | None = None
+
+
+class LandedOut(BaseModel):
+    destination: str
+    layer: Policy
+    workspace_id: str
+    reason: str
+    revision_id: int | None = None
+    proposal_id: int | None = None
+
+
+class ProposalOut(BaseModel):
+    id: int
+    workspace_id: str
+    path: str
+    body: str
+    proposer_subject: str
+    state: str
+    decided_by: str | None
+    decision_note: str | None
+
+
+class DecisionIn(BaseModel):
+    note: str | None = None
+
+
+class DocumentOut(BaseModel):
+    workspace_id: str
+    path: str
+    revision: int
+    body: str
+    deleted: bool
+    author_subject: str
+
+
+class SecretIn(BaseModel):
+    material: str
+
+
+class SecretMetadataOut(BaseModel):
+    """The whole read surface of a workspace secret. Adding a field here is the only way to leak
+    one, which is the point: it would be a visible edit to a declared shape."""
+
+    workspace_id: str
+    name: str
+    last4: str
+    version: int
+    set_by: str
+    set_at: str
+    rotated_at: str | None
+
+
+# ── error translation ─────────────────────────────────────────────────────────────────────────
+
+_STATUS = {
+    AccessDenied: 403,
+    NotFound: 404,
+    InvalidWorkspace: 409,
+    ProposalAlreadyDecided: 409,
+}
+
+
+@contextmanager
+def _translating() -> Iterator[None]:
+    """Turn a refusal into an HTTP status that keeps the machine-readable code."""
+    try:
+        yield
+    except ContextStackError as exc:
+        status = next((s for t, s in _STATUS.items() if isinstance(exc, t)), 400)
+        raise HTTPException(status_code=status, detail={"code": exc.code, "message": exc.message})
+
+
+def _actor(x_user_email: str = Header(..., alias="X-User-Email")) -> str:
+    """The caller, as the gateway verified them. Never taken from a body."""
+    return x_user_email
+
+
+def create_router(get_store: Callable[..., ContextStackStore]) -> APIRouter:
+    """Build the router against a store dependency the mounting service provides."""
+    router = APIRouter(tags=["context-stack"])
+
+    @router.post("/workspaces", response_model=WorkspaceOut)
+    async def create_workspace(
+        body: WorkspaceIn,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> WorkspaceOut:
+        with _translating():
+            workspace = await workspaces.create_workspace(
+                store,
+                workspace_id=body.workspace_id,
+                name=body.name,
+                address=body.address,
+                policy=body.policy,
+                owner_subject=actor,
+                owner_email=actor,
+                member_emails=tuple(body.member_emails),
+            )
+        return WorkspaceOut(**vars(workspace))
+
+    @router.get("/workspaces/{workspace_id}", response_model=WorkspaceOut)
+    async def read_workspace(
+        workspace_id: str,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> WorkspaceOut:
+        with _translating():
+            workspace = await _readable(store, workspace_id, actor)
+        return WorkspaceOut(**vars(workspace))
+
+    @router.post("/workspaces/{workspace_id}/members", response_model=MemberOut)
+    async def add_member(
+        workspace_id: str,
+        body: MemberIn,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> MemberOut:
+        with _translating():
+            member = await workspaces.add_member(
+                store,
+                workspace_id=workspace_id,
+                subject=body.subject,
+                email=body.email or body.subject,
+                actor=actor,
+            )
+        return MemberOut(subject=member.subject, role=member.role, email=member.email)
+
+    @router.delete("/workspaces/{workspace_id}/members/{subject}", response_model=RemovedOut)
+    async def remove_member(
+        workspace_id: str,
+        subject: str,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> RemovedOut:
+        with _translating():
+            removed = await workspaces.remove_member(
+                store, workspace_id=workspace_id, subject=subject, actor=actor
+            )
+        return RemovedOut(removed=removed)
+
+    @router.get("/stack", response_model=StackOut)
+    async def read_stack(
+        mode: Mode = Mode.PINNED,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> StackOut:
+        """The caller's own stack. There is no subject parameter: a stack is composed for the
+        person asking, so no caller can ask for someone else's composition."""
+        with _translating():
+            resolved = await resolve_stack(store, subject=actor, mode=mode)
+        return StackOut(
+            subject=resolved.subject,
+            mode=resolved.mode,
+            slots=[SlotOut(**s.to_contract()) for s in resolved.slots],
+            denied=[DenialOut(**d.to_contract()) for d in resolved.denied],
+        )
+
+    @router.post("/context/deltas", response_model=LandedOut)
+    async def land(
+        body: DeltaIn,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> LandedOut:
+        with _translating():
+            landed = await land_delta(
+                store,
+                ContextDelta(
+                    workspace_id=body.workspace_id,
+                    path=body.path,
+                    body=body.body,
+                    author_subject=actor,
+                    source_kind=body.source_kind,
+                    source_ref=body.source_ref,
+                ),
+            )
+        return LandedOut(
+            **landed.routing.to_contract(),
+            revision_id=landed.revision.id if landed.revision else None,
+            proposal_id=landed.proposal.id if landed.proposal else None,
+        )
+
+    @router.get("/workspaces/{workspace_id}/context", response_model=DocumentOut)
+    async def read_document(
+        workspace_id: str,
+        path: str,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> DocumentOut:
+        with _translating():
+            await _readable(store, workspace_id, actor)
+            revision = await store.current_revision(workspace_id=workspace_id, path=path)
+            if revision is None:
+                raise NotFound(f"no document {path!r} in {workspace_id!r}")
+        return DocumentOut(
+            workspace_id=revision.workspace_id,
+            path=revision.path,
+            revision=revision.revision,
+            body=revision.body,
+            deleted=revision.deleted,
+            author_subject=revision.author_subject,
+        )
+
+    @router.get("/workspaces/{workspace_id}/proposals", response_model=list[ProposalOut])
+    async def read_proposals(
+        workspace_id: str,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> list[ProposalOut]:
+        with _translating():
+            pending = await triage.pending_proposals(
+                store, workspace_id=workspace_id, actor=actor
+            )
+        return [_proposal_out(p) for p in pending]
+
+    @router.post("/proposals/{proposal_id}/accept", response_model=LandedOut)
+    async def accept(
+        proposal_id: int,
+        body: DecisionIn | None = None,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> LandedOut:
+        """The owner accepts. One proposal, one human, one call — there is no batch form."""
+        with _translating():
+            landed = await triage.accept_proposal(
+                store,
+                proposal_id=proposal_id,
+                actor=actor,
+                note=body.note if body else None,
+            )
+        return LandedOut(
+            **landed.routing.to_contract(),
+            revision_id=landed.revision.id if landed.revision else None,
+            proposal_id=landed.proposal.id if landed.proposal else None,
+        )
+
+    @router.post("/proposals/{proposal_id}/reject", response_model=ProposalOut)
+    async def reject(
+        proposal_id: int,
+        body: DecisionIn | None = None,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> ProposalOut:
+        with _translating():
+            decided = await triage.reject_proposal(
+                store,
+                proposal_id=proposal_id,
+                actor=actor,
+                note=body.note if body else None,
+            )
+        return _proposal_out(decided)
+
+    @router.put("/workspaces/{workspace_id}/secrets/{name}", response_model=SecretMetadataOut)
+    async def set_secret(
+        workspace_id: str,
+        name: str,
+        body: SecretIn,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> SecretMetadataOut:
+        """Set or rotate. The response is metadata — the request is the only place a value ever
+        appears on this surface."""
+        with _translating():
+            metadata = await secrets_surface.set_secret(
+                store, workspace_id=workspace_id, name=name, material=body.material, actor=actor
+            )
+        return SecretMetadataOut(**metadata.to_contract())
+
+    @router.get("/workspaces/{workspace_id}/secrets", response_model=list[SecretMetadataOut])
+    async def list_secrets(
+        workspace_id: str,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> list[SecretMetadataOut]:
+        with _translating():
+            rows = await secrets_surface.list_metadata(
+                store, workspace_id=workspace_id, actor=actor
+            )
+        return [SecretMetadataOut(**m.to_contract()) for m in rows]
+
+    @router.get("/workspaces/{workspace_id}/secrets/{name}", response_model=SecretMetadataOut)
+    async def read_secret_metadata(
+        workspace_id: str,
+        name: str,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> SecretMetadataOut:
+        with _translating():
+            metadata = await secrets_surface.get_metadata(
+                store, workspace_id=workspace_id, name=name, actor=actor
+            )
+        return SecretMetadataOut(**metadata.to_contract())
+
+    @router.delete("/workspaces/{workspace_id}/secrets/{name}", response_model=RemovedOut)
+    async def delete_secret(
+        workspace_id: str,
+        name: str,
+        store: ContextStackStore = Depends(get_store),
+        actor: str = Depends(_actor),
+    ) -> RemovedOut:
+        with _translating():
+            removed = await secrets_surface.delete_secret(
+                store, workspace_id=workspace_id, name=name, actor=actor
+            )
+        return RemovedOut(removed=removed)
+
+    return router
+
+
+def _proposal_out(proposal) -> ProposalOut:  # noqa: ANN001 - store.ProposalRef
+    return ProposalOut(
+        id=proposal.id,
+        workspace_id=proposal.workspace_id,
+        path=proposal.path,
+        body=proposal.body,
+        proposer_subject=proposal.proposer_subject,
+        state=proposal.state,
+        decided_by=proposal.decided_by,
+        decision_note=proposal.decision_note,
+    )
+
+
+async def _readable(store: ContextStackStore, workspace_id: str, actor: str):
+    """Load a workspace the actor is allowed to read, or refuse. The group-read boundary."""
+    from .access import Action, decide
+
+    workspace = await store.get_workspace(workspace_id)
+    if workspace is None:
+        raise NotFound(f"no workspace {workspace_id!r}")
+    role = await store.role_of(workspace_id=workspace_id, subject=actor)
+    verdict = decide(
+        subject=actor,
+        workspace_id=workspace_id,
+        policy=workspace.policy,
+        role=role,
+        action=Action.READ,
+    )
+    if not verdict.allow:
+        raise AccessDenied(f"{actor} may not read {workspace_id}", decision=verdict)
+    return workspace

--- a/core/agent/modules/context-stack/src/context_stack/errors.py
+++ b/core/agent/modules/context-stack/src/context_stack/errors.py
@@ -1,0 +1,43 @@
+"""Errors, each carrying a stable machine code.
+
+Every refusal in this module names *why* with a code a caller can branch on and a log can be
+searched for. Free-text reasons drift; codes do not.
+"""
+
+from __future__ import annotations
+
+
+class ContextStackError(Exception):
+    """Base class. ``code`` is stable; ``message`` is for humans."""
+
+    code = "context-stack-error"
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        if code is not None:
+            self.code = code
+
+
+class NotFound(ContextStackError):
+    code = "not-found"
+
+
+class AccessDenied(ContextStackError):
+    """A decision refused the actor. ``decision`` carries the full verdict for the audit trail."""
+
+    code = "access-denied"
+
+    def __init__(self, message: str, *, decision) -> None:  # noqa: ANN001 - avoids a circular import
+        super().__init__(message, code=decision.reason)
+        self.decision = decision
+
+
+class InvalidWorkspace(ContextStackError):
+    code = "invalid-workspace"
+
+
+class ProposalAlreadyDecided(ContextStackError):
+    """A decided proposal is final. Re-deciding would silently rewrite a human's answer."""
+
+    code = "proposal-already-decided"

--- a/core/agent/modules/context-stack/src/context_stack/layers.py
+++ b/core/agent/modules/context-stack/src/context_stack/layers.py
@@ -1,0 +1,142 @@
+"""The four layers, as one table.
+
+The context stack is the product's central primitive: every product-mode agent turn composes
+four layers, and each layer's access rules are FIXED properties of the layer — not per-workspace
+configuration. That table appears exactly once, here, so a reader can check it against the
+product spec line by line and so no call site can invent a fifth combination.
+
+| Layer       | Access                | Content                                            |
+|-------------|-----------------------|----------------------------------------------------|
+| global      | read-only, hidden     | product-level knowledge/behaviour, ours             |
+| group       | read/write via triage | shared; writes land as proposals the owner triages  |
+| personal    | read/write            | always exists for every user — the user is not a group |
+| user-system | read, hidden, never sharable | sessions, chat history; holds no external credentials |
+
+**Policy IS the layer.** A workspace carries one explicit ``policy`` field, and that single value
+answers both questions the stack asks of it: *where does it sit in the composition* (its layer) and
+*how does a write to it land* (direct / via triage / refused). They are deliberately not two
+columns. Two columns can disagree, and the only disagreement that matters — a workspace sitting at
+the group layer while accepting direct writes — is precisely the bypass of owner triage the product
+forbids. One field cannot express it.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Mapping
+
+
+class Policy(str, Enum):
+    """A workspace's policy field — also its layer in the stack. See the module docstring."""
+
+    GLOBAL = "global"
+    GROUP = "group"
+    PERSONAL = "personal"
+    USER_SYSTEM = "user-system"
+
+
+class Write(str, Enum):
+    """How a context delta addressed to a layer lands."""
+
+    NONE = "none"
+    """Nothing writes here through this module (global is ours, shipped with the product)."""
+
+    DIRECT = "direct"
+    """Straight into the layer's context as a new revision."""
+
+    VIA_TRIAGE = "via-triage"
+    """Into the workspace's proposal queue. Never into context until a human owner accepts."""
+
+    PLATFORM_ONLY = "platform-only"
+    """Written by the platform (sessions, chat history), never by a context delta."""
+
+
+class Role(str, Enum):
+    """The two roles. Owner: config, membership, triage, secrets. Member: chat, knowledge."""
+
+    OWNER = "owner"
+    MEMBER = "member"
+
+
+class LayerRules:
+    """The fixed properties of one layer. Constructed only in :data:`RULES`."""
+
+    __slots__ = (
+        "order",
+        "write",
+        "hidden",
+        "sharable",
+        "readable_by_everyone",
+        "holds_credentials",
+    )
+
+    def __init__(
+        self,
+        *,
+        order: int,
+        write: Write,
+        hidden: bool,
+        sharable: bool,
+        readable_by_everyone: bool,
+        holds_credentials: bool,
+    ) -> None:
+        self.order = order
+        self.write = write
+        self.hidden = hidden
+        self.sharable = sharable
+        self.readable_by_everyone = readable_by_everyone
+        self.holds_credentials = holds_credentials
+
+
+RULES: Mapping[Policy, LayerRules] = {
+    # Product-level knowledge and behaviour, ours. Every stack mounts it; nobody sees it and
+    # nothing in this module writes it — it ships with the product. Its credentials are
+    # deployment config (a k8s Secret, a chart value), not rows a workspace owner sets.
+    Policy.GLOBAL: LayerRules(
+        order=0,
+        write=Write.NONE,
+        hidden=True,
+        sharable=False,
+        readable_by_everyone=True,
+        holds_credentials=False,
+    ),
+    # The shared layer, and the ONLY sharable one. A member may propose; only the owner accepts.
+    # The owner-supplied LLM key (BYOT) belongs here or on personal — the two layers a user owns.
+    Policy.GROUP: LayerRules(
+        order=1,
+        write=Write.VIA_TRIAGE,
+        hidden=False,
+        sharable=True,
+        readable_by_everyone=False,
+        holds_credentials=True,
+    ),
+    # Always exists for every user. One member — the user is not a group, so it cannot take a
+    # second member; a workspace that needs two members is a group workspace.
+    Policy.PERSONAL: LayerRules(
+        order=2,
+        write=Write.DIRECT,
+        hidden=False,
+        sharable=False,
+        readable_by_everyone=False,
+        holds_credentials=True,
+    ),
+    # Sessions and chat history. Hidden, never sharable, and it HOLDS NO EXTERNAL CREDENTIALS
+    # EVER — stated in the spec as a property of the layer, so it is one here: the secret surface
+    # refuses this layer outright rather than relying on nobody trying.
+    Policy.USER_SYSTEM: LayerRules(
+        order=3,
+        write=Write.PLATFORM_ONLY,
+        hidden=True,
+        sharable=False,
+        readable_by_everyone=False,
+        holds_credentials=False,
+    ),
+}
+
+STACK_ORDER: tuple[Policy, ...] = tuple(sorted(RULES, key=lambda p: RULES[p].order))
+"""global → group → personal → user-system. The pinned product composition's slot order."""
+
+SINGLETON_LAYERS: frozenset[Policy] = frozenset(
+    {Policy.GLOBAL, Policy.PERSONAL, Policy.USER_SYSTEM}
+)
+"""Layers that hold exactly one workspace per user. Only the group layer composes several."""

--- a/core/agent/modules/context-stack/src/context_stack/material.py
+++ b/core/agent/modules/context-stack/src/context_stack/material.py
@@ -1,0 +1,65 @@
+"""The one reader of secret material, kept in its own module so the import is visible.
+
+A workspace secret has to be usable — a BYOT key that nothing can read is not a key. But "usable"
+means one caller at one moment: the code that builds the LLM call for a dispatch. It does not mean
+a read endpoint, and the difference between those two is the whole of the leak this design is
+built against.
+
+So the reader lives here, alone. ``secrets.py`` (the management surface) does not import it and
+``api.py`` (the HTTP surface) does not import it, which makes "no endpoint returns a secret" a
+fact about the import graph that a test can assert, rather than a promise about serializers.
+
+The value comes back wrapped. :class:`Material` keeps it off every repr, str and format — the
+three ways a value ends up in a log without anyone deciding to put it there — and hands it over
+only through ``reveal()``, which is one grep away from an audit of every use. Same shape as
+``identity_core.secrets.BrokeredSecret``, which solves this problem for deployment secrets; this
+is its workspace-scoped counterpart, and the two should become one port when a service holds both.
+"""
+
+from __future__ import annotations
+
+from .errors import NotFound
+from .store import ContextStackStore
+
+REDACTED = "***REDACTED***"
+
+
+class Material:
+    """A secret value that will not print itself."""
+
+    __slots__ = ("_value", "workspace_id", "name", "purpose")
+
+    def __init__(self, value: str, *, workspace_id: str, name: str, purpose: str) -> None:
+        self._value = value
+        self.workspace_id = workspace_id
+        self.name = name
+        self.purpose = purpose
+
+    def reveal(self) -> str:
+        """The value. Every call site is meant to be findable by grepping for this name."""
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"<Material {self.workspace_id}/{self.name} {REDACTED}>"
+
+    __str__ = __repr__
+
+    def __format__(self, _spec: str) -> str:
+        return REDACTED
+
+
+async def use_material(
+    store: ContextStackStore, *, workspace_id: str, name: str, purpose: str
+) -> Material:
+    """Read a workspace secret for use at call time. Not reachable from any route.
+
+    ``purpose`` is required so that the reason is recorded at the call site rather than
+    reconstructed from a stack trace later; it is what an access-rights audit reads.
+    """
+    row = await store.secret_row(workspace_id=workspace_id, name=name)
+    if row is None:
+        raise NotFound(f"no secret {name!r} on workspace {workspace_id!r}")
+    return Material(row.material, workspace_id=workspace_id, name=name, purpose=purpose)
+
+
+__all__ = ["Material", "use_material", "REDACTED"]

--- a/core/agent/modules/context-stack/src/context_stack/models.py
+++ b/core/agent/modules/context-stack/src/context_stack/models.py
@@ -1,0 +1,221 @@
+"""The relational schema: workspaces, memberships, context revisions, proposals, pointers, secrets.
+
+Six tables. Three of their shapes are decisions rather than transcription, and each is argued at
+its table below: context is **append-only revisions**, stack slots are **unconstrained pointers**,
+and a decided proposal is **required by a CHECK constraint to name a human**.
+
+Style follows ``admin_api.schema.models`` — SQLAlchemy 2.0 with ``declarative_base()`` and
+``Column(...)``, which is also the form ``scripts/schema_digest.py`` parses when a schema is
+sealed. Columns stay on portable types (no ``JSONB``, no ``ARRAY``): the tests run this DDL on
+SQLite and a service will run it on Postgres, and a schema that only exists in one dialect cannot
+be tested where it is cheap to test.
+
+These tables are **not sealed**. ``schema.seal.json`` freezes the schema that deployed services
+create; no service mounts this module yet, so sealing now would freeze a claim that nothing is
+making. When a service adopts it, add this file to ``MODEL_FILES`` in
+``scripts/schema_digest.py`` and re-seal with ``pnpm seal:schema`` on a ``lane:schema`` review.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.sql import func
+
+Base = declarative_base()
+
+_POLICIES = "'global', 'group', 'personal', 'user-system'"
+_ROLES = "'owner', 'member'"
+_STATES = "'pending', 'accepted', 'rejected'"
+
+
+class Workspace(Base):
+    """A workspace: an address, a name, a policy, an owner.
+
+    The **address** is how meetings arrive — the bot has a mailbox and each workspace has its own
+    address, invited like any attendee, so the invited address IS the group resolution. The
+    **name** names the bot. The **policy** is the layer (see ``layers.py``).
+
+    A personal workspace is a row here like any other, with ``policy='personal'``. It is the
+    one-member case, not a second kind of thing.
+    """
+
+    __tablename__ = "workspaces"
+
+    id = Column(String(64), primary_key=True)
+    name = Column(String(255), nullable=False)
+    address = Column(String(320), unique=True, index=True, nullable=False)
+    policy = Column(String(16), nullable=False, index=True)
+    owner_subject = Column(String(255), nullable=False, index=True)
+    created_at = Column(DateTime, server_default=func.now(), default=func.now())
+
+    __table_args__ = (CheckConstraint(f"policy IN ({_POLICIES})", name="ck_workspace_policy"),)
+
+
+class Membership(Base):
+    """Who is in a workspace, and as what.
+
+    Group setup is a set of member emails and nothing more, so ``email`` is carried on the row
+    rather than looked up from a directory this module does not have — the same choice
+    ``policy/members.json`` already makes in the git workspace store.
+    """
+
+    __tablename__ = "workspace_memberships"
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(String(64), ForeignKey("workspaces.id"), nullable=False, index=True)
+    subject = Column(String(255), nullable=False, index=True)
+    email = Column(String(320), nullable=True)
+    role = Column(String(16), nullable=False)
+    added_by = Column(String(255), nullable=False)
+    added_at = Column(DateTime, server_default=func.now(), default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "subject", name="uq_membership_workspace_subject"),
+        CheckConstraint(f"role IN ({_ROLES})", name="ck_membership_role"),
+    )
+
+
+class ContextRevision(Base):
+    """One append-only revision of one context document. Current state = the highest revision.
+
+    **Why append-only rather than mutable rows with a version column.** Triage is the reason. An
+    owner accepting a proposal has to be able to see what the group's context said before and what
+    it says after, and a rejected proposal has to leave no trace in context while leaving a full
+    trace in the record. Both are free when a write is an append and impossible to reconstruct
+    once an UPDATE has overwritten the previous body. It also matches what the knowledge store
+    already is — the workspaces this module describes are git repos, where a write has always been
+    an append — so a later projection of these rows onto that store preserves semantics instead of
+    inventing them. The cost is growth, which is the open compaction problem; compaction is itself
+    intended to be a readable artifact, and it can only read a history that was kept.
+
+    Deletion is a tombstone revision (``deleted=True``), never a DELETE, for the same reason.
+    """
+
+    __tablename__ = "context_revisions"
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(String(64), ForeignKey("workspaces.id"), nullable=False, index=True)
+    path = Column(String(512), nullable=False)
+    revision = Column(Integer, nullable=False)
+    body = Column(Text, nullable=False)
+    deleted = Column(Boolean, nullable=False, default=False)
+    author_subject = Column(String(255), nullable=False)
+    source_kind = Column(String(32), nullable=False)
+    source_ref = Column(String(255), nullable=True)
+    # Set when this revision exists because an owner accepted a proposal. The reverse pointer
+    # (proposal → revision) is deliberately absent: two FKs between the same pair of tables is a
+    # cycle, and one direction answers both questions.
+    from_proposal_id = Column(Integer, ForeignKey("context_proposals.id"), nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "path", "revision", name="uq_revision_ws_path_rev"),
+        Index("ix_revision_ws_path", "workspace_id", "path"),
+    )
+
+
+class Proposal(Base):
+    """A proposed context delta awaiting a human owner's answer.
+
+    The write router puts every group-policy delta here. Nothing moves it out except an owner
+    calling accept or reject.
+
+    ``ck_proposal_decision_is_attributed`` is where "no machine ever writes acknowledgement" stops
+    being a convention. A row is either pending with no decider, or decided and naming who decided
+    and when — the database rejects any other state, so no code path, present or future, can mark
+    a proposal accepted without putting a name on it.
+    """
+
+    __tablename__ = "context_proposals"
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(String(64), ForeignKey("workspaces.id"), nullable=False, index=True)
+    path = Column(String(512), nullable=False)
+    body = Column(Text, nullable=False)
+    proposer_subject = Column(String(255), nullable=False, index=True)
+    source_kind = Column(String(32), nullable=False)
+    source_ref = Column(String(255), nullable=True)
+    state = Column(String(16), nullable=False, default="pending", index=True)
+    decided_by = Column(String(255), nullable=True)
+    decided_at = Column(DateTime, nullable=True)
+    decision_note = Column(Text, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), default=func.now())
+
+    __table_args__ = (
+        CheckConstraint(f"state IN ({_STATES})", name="ck_proposal_state"),
+        CheckConstraint(
+            "(state = 'pending' AND decided_by IS NULL AND decided_at IS NULL)"
+            " OR (state <> 'pending' AND decided_by IS NOT NULL AND decided_at IS NOT NULL)",
+            name="ck_proposal_decision_is_attributed",
+        ),
+    )
+
+
+class StackPointer(Base):
+    """One slot of one user's composed stack, pointing at a workspace.
+
+    **``workspace_id`` carries no foreign key, on purpose.** The stack slots are pointers, not
+    foreign-key constraints: a user can be re-pointed at a different personal workspace, or
+    compose several groups, and the terminal keeps free composition while the product ships a
+    pinned default. A constraint here would turn re-pointing into a schema problem and would make
+    a pointer at a workspace this deployment does not hold — a not-yet-provisioned one, a
+    workspace on another store — an insert error instead of what it actually is: a resolvable
+    condition. The resolver reports such a pointer as a ``dangling-pointer`` denial and continues.
+
+    Rows are optional. A user with no rows resolves through the pinned product composition, which
+    is the participant case and the common one.
+    """
+
+    __tablename__ = "stack_pointers"
+
+    id = Column(Integer, primary_key=True)
+    subject = Column(String(255), nullable=False, index=True)
+    slot = Column(String(16), nullable=False)
+    workspace_id = Column(String(64), nullable=False)
+    position = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime, server_default=func.now(), default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("subject", "slot", "workspace_id", name="uq_pointer_subject_slot_ws"),
+        CheckConstraint(f"slot IN ({_POLICIES})", name="ck_pointer_slot"),
+    )
+
+
+class WorkspaceSecret(Base):
+    """A workspace-scoped secret. Set by the owner; no endpoint ever returns ``material``.
+
+    In the pilot exactly one secret is user-supplied: the LLM key/endpoint (BYOT). ``last4`` and
+    the surrounding metadata are what a read returns — the whole read surface is defined by
+    :class:`context_stack.secrets.SecretMetadata`, which has no material field to populate.
+
+    ``material`` is plaintext at rest, matching the level the saved GitHub token already sits at
+    (access-controlled, not encrypted). Envelope encryption is deliberately not built here: it
+    earns its keep when integration tokens arrive, and building it now would be machinery around
+    a single key.
+    """
+
+    __tablename__ = "workspace_secrets"
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(String(64), ForeignKey("workspaces.id"), nullable=False, index=True)
+    name = Column(String(64), nullable=False)
+    material = Column(Text, nullable=False)
+    last4 = Column(String(4), nullable=False)
+    version = Column(Integer, nullable=False, default=1)
+    set_by = Column(String(255), nullable=False)
+    set_at = Column(DateTime, server_default=func.now(), default=func.now())
+    rotated_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (UniqueConstraint("workspace_id", "name", name="uq_secret_workspace_name"),)

--- a/core/agent/modules/context-stack/src/context_stack/resolver.py
+++ b/core/agent/modules/context-stack/src/context_stack/resolver.py
@@ -1,0 +1,215 @@
+"""Composition: given a user, return the ordered stack as pointers.
+
+Two modes, because the schema and the product want different things and the founder ruling is that
+both are true at once — **loosely coupled by schema, pinned by product**.
+
+``PINNED`` is the product path. The group slot is *derived* from membership: a user gets exactly
+the groups they belong to, in a deterministic order, and there is nothing to compose. An ordinary
+participant never sees composition because there is none to see.
+
+``FREE`` is what the terminal already does. A slot with pointer rows uses them, in their order;
+a slot without falls back to the pinned derivation. So free composition is a superset, reached by
+writing pointers, not by a different code path — and the two modes cannot drift apart because the
+fallback is the pinned function itself.
+
+The modes differ in exactly one place: the group slot. The three singleton slots honour a pointer
+in both modes, because re-pointing a user at a different personal workspace changes *which*
+workspace fills a slot, not the shape of the stack — that is migration, and the pinned product
+path needs it to work.
+
+What comes back is **pointers, never content**: each slot names a workspace and the access rules
+of its layer. Reading a document is a separate, separately-authorised act.
+
+Every slot is authorised before it is returned. A pointer at a group the user does not belong to
+is dropped, not mounted — a non-member never reaches group context, whichever mode resolved the
+stack, and the reason is recorded in ``denied`` rather than swallowed, because a stack that is
+quietly shorter than the user expects is a bug nobody can see.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .access import Action, decide
+from .layers import RULES, SINGLETON_LAYERS, STACK_ORDER, Policy, Write
+from .store import ContextStackStore, WorkspaceRef
+
+
+class Mode(str, Enum):
+    PINNED = "pinned"
+    """The product's fixed composition: global → the user's groups → personal → user-system."""
+
+    FREE = "free"
+    """The terminal's composition: pointer rows where they exist, the pinned derivation elsewhere."""
+
+
+@dataclass(frozen=True)
+class StackSlot:
+    """One mounted layer. A pointer plus the layer's access rules — no context."""
+
+    layer: Policy
+    workspace_id: str
+    name: str
+    address: str
+    write: Write
+    hidden: bool
+    sharable: bool
+
+    def to_contract(self) -> dict:
+        return {
+            "layer": self.layer.value,
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "address": self.address,
+            "write": self.write.value,
+            "hidden": self.hidden,
+            "sharable": self.sharable,
+        }
+
+
+@dataclass(frozen=True)
+class Denial:
+    """A slot that was asked for and not mounted, with a stable reason code."""
+
+    layer: Policy
+    workspace_id: str | None
+    reason: str
+
+    def to_contract(self) -> dict:
+        return {
+            "layer": self.layer.value,
+            "workspace_id": self.workspace_id,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedStack:
+    subject: str
+    mode: Mode
+    slots: tuple[StackSlot, ...]
+    denied: tuple[Denial, ...]
+
+    def at(self, layer: Policy) -> tuple[StackSlot, ...]:
+        return tuple(s for s in self.slots if s.layer is layer)
+
+    @property
+    def workspace_ids(self) -> tuple[str, ...]:
+        return tuple(s.workspace_id for s in self.slots)
+
+    def to_contract(self) -> dict:
+        return {
+            "subject": self.subject,
+            "mode": self.mode.value,
+            "slots": [s.to_contract() for s in self.slots],
+            "denied": [d.to_contract() for d in self.denied],
+        }
+
+
+def _slot(workspace: WorkspaceRef) -> StackSlot:
+    rules = RULES[workspace.policy]
+    return StackSlot(
+        layer=workspace.policy,
+        workspace_id=workspace.id,
+        name=workspace.name,
+        address=workspace.address,
+        write=rules.write,
+        hidden=rules.hidden,
+        sharable=rules.sharable,
+    )
+
+
+async def resolve_stack(
+    store: ContextStackStore, *, subject: str, mode: Mode = Mode.PINNED
+) -> ResolvedStack:
+    """The ordered stack for one user. Default is the product's pinned composition.
+
+    A user in no group resolves to global → personal → user-system, and that is the participant
+    case: someone who was on a meeting invitation, has never joined a group, and still gets an
+    artifact built from the meeting record and their own personal context.
+    """
+    slots: list[StackSlot] = []
+    denied: list[Denial] = []
+    by_slot: dict[Policy, list[str]] = {}
+    for pointer in await store.pointers(subject):
+        by_slot.setdefault(pointer.slot, []).append(pointer.workspace_id)
+
+    for layer in STACK_ORDER:
+        # The one difference between the modes: pinned always derives the group slot from
+        # membership, so the product's composition is not something a stored row can reshape.
+        # The singleton slots honour their pointer in both modes — re-pointing a user at a
+        # different personal workspace changes which workspace fills a slot, not the shape of
+        # the stack, so it is migration, not composition, and the product needs it to work.
+        targets = None if (mode is Mode.PINNED and layer is Policy.GROUP) else by_slot.get(layer)
+        if targets:
+            resolved, refusals = await _from_pointers(store, subject, layer, targets)
+        else:
+            resolved, refusals = await _pinned(store, subject, layer)
+        slots.extend(resolved)
+        denied.extend(refusals)
+
+    return ResolvedStack(
+        subject=subject, mode=mode, slots=tuple(slots), denied=tuple(denied)
+    )
+
+
+async def _pinned(
+    store: ContextStackStore, subject: str, layer: Policy
+) -> tuple[list[StackSlot], list[Denial]]:
+    """The derivation. Groups come from membership; the singleton layers from ownership."""
+    if layer is Policy.GROUP:
+        groups = await store.memberships_of(subject, policy=Policy.GROUP)
+        return [_slot(w) for w in groups], []
+
+    if layer is Policy.GLOBAL:
+        workspace = await store.global_workspace()
+        if workspace is None:
+            return [], [Denial(layer=layer, workspace_id=None, reason="global-not-provisioned")]
+        return [_slot(workspace)], []
+
+    workspace = await store.owned_workspace(subject, layer)
+    if workspace is None:
+        # Personal is supposed to exist for every user; user-system likewise. Reporting the gap
+        # beats raising, because the rest of the stack is still usable and the caller can see
+        # exactly which layer is missing instead of losing the whole resolution to one exception.
+        return [], [Denial(layer=layer, workspace_id=None, reason=f"{layer.value}-not-provisioned")]
+    return [_slot(workspace)], []
+
+
+async def _from_pointers(
+    store: ContextStackStore, subject: str, layer: Policy, targets: list[str]
+) -> tuple[list[StackSlot], list[Denial]]:
+    """Free composition for one slot, authorised pointer by pointer."""
+    slots: list[StackSlot] = []
+    denied: list[Denial] = []
+    found = await store.workspaces_by_id(targets)
+
+    for workspace_id in targets:
+        workspace = found.get(workspace_id)
+        if workspace is None:
+            # The pointer has no foreign key by design; a target this deployment does not hold is
+            # a condition to report, not a crash.
+            denied.append(Denial(layer=layer, workspace_id=workspace_id, reason="dangling-pointer"))
+            continue
+        if workspace.policy is not layer:
+            denied.append(Denial(layer=layer, workspace_id=workspace_id, reason="policy-mismatch"))
+            continue
+        role = await store.role_of(workspace_id=workspace_id, subject=subject)
+        verdict = decide(
+            subject=subject,
+            workspace_id=workspace_id,
+            policy=workspace.policy,
+            role=role,
+            action=Action.READ,
+        )
+        if not verdict.allow:
+            denied.append(
+                Denial(layer=layer, workspace_id=workspace_id, reason=verdict.reason)
+            )
+            continue
+        slots.append(_slot(workspace))
+        if layer in SINGLETON_LAYERS:
+            break
+
+    return slots, denied

--- a/core/agent/modules/context-stack/src/context_stack/router.py
+++ b/core/agent/modules/context-stack/src/context_stack/router.py
@@ -1,0 +1,134 @@
+"""Where a context delta lands. The machine path — and it has a ceiling.
+
+A meeting produces deltas: what changed in a context because the meeting happened. Each one is
+addressed to a workspace, and that workspace's policy field decides the rest:
+
+* **personal policy** → straight into personal context as a new revision.
+* **group policy** → the group's proposal queue, PR-style. Never direct. The owner triages.
+* **global policy** → refused. Global is ours and read-only.
+* **user-system policy** → refused. Sessions and chat history are the platform's to write.
+
+**No machine ever writes acknowledgement.** Accept and reject live in ``triage.py``, and the
+dependency runs one way: triage imports this module's types, so this module importing triage is a
+cycle Python refuses to load. The wiring that would let a meeting accept its own proposal is not
+merely absent, it cannot be added here — the most this path can produce on the group layer is a
+``pending`` row. See ``triage.py`` for the other two guards (a required owner ``actor``, and a
+table CHECK that refuses any decided proposal not naming who decided and when).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .errors import NotFound
+from .layers import RULES, Policy, Write
+from .store import ContextStackStore, ProposalRef, RevisionRef
+
+
+class Destination(str, Enum):
+    DIRECT = "direct"
+    """Appended to the workspace's context now."""
+
+    PROPOSAL = "proposal"
+    """Queued for the owner. Not in context, and will not be until a human says so."""
+
+    REFUSED = "refused"
+    """Nothing was written."""
+
+
+@dataclass(frozen=True)
+class ContextDelta:
+    """What changed in a context because a meeting (or a chat) happened."""
+
+    workspace_id: str
+    path: str
+    body: str
+    author_subject: str
+    source_kind: str = "meeting"
+    source_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class Routing:
+    """The routing verdict, before anything is written."""
+
+    destination: Destination
+    layer: Policy
+    workspace_id: str
+    reason: str
+
+    def to_contract(self) -> dict:
+        return {
+            "destination": self.destination.value,
+            "layer": self.layer.value,
+            "workspace_id": self.workspace_id,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class Landed:
+    """Where a delta actually went. On a refusal both ids are absent."""
+
+    routing: Routing
+    revision: RevisionRef | None = None
+    proposal: ProposalRef | None = None
+
+
+def route(*, policy: Policy, workspace_id: str, member: bool) -> Routing:
+    """The routing table, as a pure function of policy and membership. No I/O, no store.
+
+    Split out from :func:`land_delta` so the table can be read — and tested — without a database.
+    The rule is the product decision; the write is only its consequence.
+    """
+    write = RULES[policy].write
+
+    if write is Write.NONE:
+        return Routing(Destination.REFUSED, policy, workspace_id, "global-is-read-only")
+    if write is Write.PLATFORM_ONLY:
+        return Routing(Destination.REFUSED, policy, workspace_id, "user-system-is-platform-only")
+    if not member:
+        # A non-member cannot even propose. A queue anyone may fill is a queue the owner stops
+        # reading, and a group's context should be unreachable from outside the group in both
+        # directions, not just on the read side.
+        return Routing(Destination.REFUSED, policy, workspace_id, "not-member")
+    if write is Write.VIA_TRIAGE:
+        return Routing(Destination.PROPOSAL, policy, workspace_id, "group-policy-routes-to-triage")
+    return Routing(Destination.DIRECT, policy, workspace_id, "personal-policy-writes-direct")
+
+
+async def land_delta(store: ContextStackStore, delta: ContextDelta) -> Landed:
+    """Route a delta and write it where the routing says."""
+    workspace = await store.get_workspace(delta.workspace_id)
+    if workspace is None:
+        raise NotFound(f"no workspace {delta.workspace_id!r}")
+
+    role = await store.role_of(workspace_id=workspace.id, subject=delta.author_subject)
+    routing = route(policy=workspace.policy, workspace_id=workspace.id, member=role is not None)
+
+    if routing.destination is Destination.REFUSED:
+        return Landed(routing=routing)
+
+    if routing.destination is Destination.PROPOSAL:
+        proposal = await store.insert_proposal(
+            workspace_id=workspace.id,
+            path=delta.path,
+            body=delta.body,
+            proposer_subject=delta.author_subject,
+            source_kind=delta.source_kind,
+            source_ref=delta.source_ref,
+        )
+        await store.commit()
+        return Landed(routing=routing, proposal=proposal)
+
+    revision = await store.append_revision(
+        workspace_id=workspace.id,
+        path=delta.path,
+        body=delta.body,
+        author_subject=delta.author_subject,
+        source_kind=delta.source_kind,
+        source_ref=delta.source_ref,
+    )
+    await store.commit()
+    return Landed(routing=routing, revision=revision)

--- a/core/agent/modules/context-stack/src/context_stack/secrets.py
+++ b/core/agent/modules/context-stack/src/context_stack/secrets.py
@@ -1,0 +1,147 @@
+"""Workspace secrets — a write-only surface. Set, rotate, delete, and read metadata. Never a value.
+
+In the pilot exactly one secret is user-supplied: the LLM key or endpoint the workspace owner
+brings (BYOT). Self-hosted, it is a k8s Secret and never reaches this table at all; hosted, it is
+a row here.
+
+**The surface is write-only and that is a property of the return type, not a rule about callers.**
+Every function in this module returns :class:`SecretMetadata`, which has no field the material
+could be put in. There is nothing to remember not to include, and adding one would be a visible
+change to a dataclass rather than an accident in a serializer. The single function that reads
+material lives in ``material.py``, is never imported here or by the HTTP surface, and returns a
+handle whose repr is redacted.
+
+This is the exact inverse of a defect this codebase has already had: a settings read that returned
+key material to its caller. A product that asks an owner for their provider key has to be the
+other thing.
+
+**Plaintext at rest**, deliberately. Envelope encryption is not built here: it earns its keep when
+integration tokens arrive at group scope with grant rows and expiries, and building the machinery
+now would wrap a single key in a key-management system nobody is yet asking for. Until then this
+row sits at the level the saved GitHub token already sits at — access-controlled, not encrypted —
+which is a property to state plainly rather than imply, and it means a full server compromise
+reads it. Use a revocable, minimally-scoped key.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from .access import Action, decide
+from .errors import AccessDenied, InvalidWorkspace, NotFound
+from .store import ContextStackStore, WorkspaceRef
+
+MIN_MATERIAL_LEN = 8
+"""Below this, ``last4`` would be most of the secret. A short key is a mistyped key anyway."""
+
+
+@dataclass(frozen=True)
+class SecretMetadata:
+    """Everything a read of a workspace secret returns. There is no material field, by design."""
+
+    workspace_id: str
+    name: str
+    last4: str
+    version: int
+    set_by: str
+    set_at: datetime
+    rotated_at: datetime | None
+
+    def to_contract(self) -> dict:
+        return {
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "last4": self.last4,
+            "version": self.version,
+            "set_by": self.set_by,
+            "set_at": self.set_at.isoformat(),
+            "rotated_at": self.rotated_at.isoformat() if self.rotated_at else None,
+        }
+
+
+def _metadata(row) -> SecretMetadata:  # noqa: ANN001 - models.WorkspaceSecret, kept out of the surface
+    return SecretMetadata(
+        workspace_id=row.workspace_id,
+        name=row.name,
+        last4=row.last4,
+        version=row.version,
+        set_by=row.set_by,
+        set_at=row.set_at,
+        rotated_at=row.rotated_at,
+    )
+
+
+async def set_secret(
+    store: ContextStackStore, *, workspace_id: str, name: str, material: str, actor: str
+) -> SecretMetadata:
+    """Set or rotate a workspace secret. Owner only.
+
+    Set and rotate are one operation because they are one operation: writing a new value over the
+    old one, bumping the version, stamping who did it. A separate rotate endpoint that did the
+    same thing would be a second path to keep correct.
+    """
+    workspace = await _require(store, workspace_id)
+    await _authorise(store, workspace, actor)
+    if len(material) < MIN_MATERIAL_LEN:
+        raise InvalidWorkspace(f"secret material must be at least {MIN_MATERIAL_LEN} characters")
+    row = await store.upsert_secret(
+        workspace_id=workspace_id, name=name, material=material, set_by=actor
+    )
+    await store.commit()
+    return _metadata(row)
+
+
+async def delete_secret(
+    store: ContextStackStore, *, workspace_id: str, name: str, actor: str
+) -> bool:
+    """Remove a workspace secret. Owner only."""
+    workspace = await _require(store, workspace_id)
+    await _authorise(store, workspace, actor)
+    removed = await store.delete_secret_row(workspace_id=workspace_id, name=name)
+    await store.commit()
+    return removed
+
+
+async def get_metadata(
+    store: ContextStackStore, *, workspace_id: str, name: str, actor: str
+) -> SecretMetadata:
+    """Last-4, version, who set it and when. Owner only, and never the value."""
+    workspace = await _require(store, workspace_id)
+    await _authorise(store, workspace, actor)
+    row = await store.secret_row(workspace_id=workspace_id, name=name)
+    if row is None:
+        raise NotFound(f"no secret {name!r} on workspace {workspace_id!r}")
+    return _metadata(row)
+
+
+async def list_metadata(
+    store: ContextStackStore, *, workspace_id: str, actor: str
+) -> tuple[SecretMetadata, ...]:
+    """Every secret on the workspace, as metadata. Owner only."""
+    workspace = await _require(store, workspace_id)
+    await _authorise(store, workspace, actor)
+    return tuple(_metadata(row) for row in await store.secret_rows(workspace_id))
+
+
+async def _require(store: ContextStackStore, workspace_id: str) -> WorkspaceRef:
+    workspace = await store.get_workspace(workspace_id)
+    if workspace is None:
+        raise NotFound(f"no workspace {workspace_id!r}")
+    return workspace
+
+
+async def _authorise(store: ContextStackStore, workspace: WorkspaceRef, actor: str) -> None:
+    role = await store.role_of(workspace_id=workspace.id, subject=actor)
+    verdict = decide(
+        subject=actor,
+        workspace_id=workspace.id,
+        policy=workspace.policy,
+        role=role,
+        action=Action.SECRETS,
+    )
+    if not verdict.allow:
+        raise AccessDenied(f"{actor} may not manage secrets on {workspace.id}", decision=verdict)
+
+
+__all__ = ["SecretMetadata", "set_secret", "delete_secret", "get_metadata", "list_metadata"]

--- a/core/agent/modules/context-stack/src/context_stack/store.py
+++ b/core/agent/modules/context-stack/src/context_stack/store.py
@@ -1,0 +1,512 @@
+"""The repository over the six tables. Persistence only — it decides nothing.
+
+Every policy question (who may read, where a write lands, who may accept) is answered in
+``access.py``, ``router.py`` and ``secrets.py``. Keeping the store dumb is what makes those
+answers testable in one place instead of being re-derived beside every query.
+
+The store never commits. An operation that writes twice — accepting a proposal appends a revision
+*and* marks the proposal decided — must be one transaction, and only the caller knows where the
+transaction ends. Operations in this package commit at their own boundary; a service that composes
+them into a larger unit of work keeps its own.
+
+ORM rows do not leave the package. Every method returns a frozen value object, so a caller cannot
+lazy-load its way to a column the surface deliberately withholds — the mechanism that makes "no
+endpoint returns secret material" a property of the types rather than of every call site. The
+secret accessors at the bottom are the single exception and stay inside the package: ``secrets.py``
+turns a row into metadata, ``material.py`` is the one reader of the material itself, and nothing
+else imports them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Sequence
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import models
+from .layers import Policy, Role
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@dataclass(frozen=True)
+class WorkspaceRef:
+    """A workspace's identity and policy. Never its context, never its secrets."""
+
+    id: str
+    name: str
+    address: str
+    policy: Policy
+    owner_subject: str
+
+
+@dataclass(frozen=True)
+class MemberRef:
+    subject: str
+    role: Role
+    email: str | None
+
+
+@dataclass(frozen=True)
+class RevisionRef:
+    id: int
+    workspace_id: str
+    path: str
+    revision: int
+    body: str
+    deleted: bool
+    author_subject: str
+    source_kind: str
+    source_ref: str | None
+    from_proposal_id: int | None
+
+
+@dataclass(frozen=True)
+class ProposalRef:
+    id: int
+    workspace_id: str
+    path: str
+    body: str
+    proposer_subject: str
+    source_kind: str
+    source_ref: str | None
+    state: str
+    decided_by: str | None
+    decided_at: datetime | None
+    decision_note: str | None
+
+
+@dataclass(frozen=True)
+class PointerRef:
+    subject: str
+    slot: Policy
+    workspace_id: str
+    position: int
+
+
+def _workspace(row: models.Workspace) -> WorkspaceRef:
+    return WorkspaceRef(
+        id=row.id,
+        name=row.name,
+        address=row.address,
+        policy=Policy(row.policy),
+        owner_subject=row.owner_subject,
+    )
+
+
+def _revision(row: models.ContextRevision) -> RevisionRef:
+    return RevisionRef(
+        id=row.id,
+        workspace_id=row.workspace_id,
+        path=row.path,
+        revision=row.revision,
+        body=row.body,
+        deleted=bool(row.deleted),
+        author_subject=row.author_subject,
+        source_kind=row.source_kind,
+        source_ref=row.source_ref,
+        from_proposal_id=row.from_proposal_id,
+    )
+
+
+def _proposal(row: models.Proposal) -> ProposalRef:
+    return ProposalRef(
+        id=row.id,
+        workspace_id=row.workspace_id,
+        path=row.path,
+        body=row.body,
+        proposer_subject=row.proposer_subject,
+        source_kind=row.source_kind,
+        source_ref=row.source_ref,
+        state=row.state,
+        decided_by=row.decided_by,
+        decided_at=row.decided_at,
+        decision_note=row.decision_note,
+    )
+
+
+class ContextStackStore:
+    """Async repository. One instance wraps one :class:`AsyncSession`."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def commit(self) -> None:
+        await self.session.commit()
+
+    # ── workspaces ────────────────────────────────────────────────────────────────────────────
+
+    async def insert_workspace(
+        self,
+        *,
+        id: str,
+        name: str,
+        address: str,
+        policy: Policy,
+        owner_subject: str,
+    ) -> WorkspaceRef:
+        # Stamped Python-side rather than by the server default: creation order is what the
+        # pinned derivation orders by, and Postgres and SQLite disagree about how much of a
+        # timestamp they keep. A tie in the store would become an arbitrary personal workspace
+        # in someone's stack.
+        row = models.Workspace(
+            id=id,
+            name=name,
+            address=address,
+            policy=policy.value,
+            owner_subject=owner_subject,
+            created_at=_utcnow(),
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return _workspace(row)
+
+    async def get_workspace(self, workspace_id: str) -> WorkspaceRef | None:
+        row = await self.session.get(models.Workspace, workspace_id)
+        return _workspace(row) if row is not None else None
+
+    async def get_workspace_by_address(self, address: str) -> WorkspaceRef | None:
+        stmt = select(models.Workspace).where(models.Workspace.address == address)
+        row = (await self.session.execute(stmt)).scalar_one_or_none()
+        return _workspace(row) if row is not None else None
+
+    async def owned_workspace(self, subject: str, policy: Policy) -> WorkspaceRef | None:
+        """The one workspace at a singleton layer this subject owns, if it exists."""
+        stmt = (
+            select(models.Workspace)
+            .where(
+                models.Workspace.owner_subject == subject,
+                models.Workspace.policy == policy.value,
+            )
+            .order_by(models.Workspace.created_at, models.Workspace.id)
+        )
+        row = (await self.session.execute(stmt)).scalars().first()
+        return _workspace(row) if row is not None else None
+
+    async def global_workspace(self) -> WorkspaceRef | None:
+        """The product's global layer. One exists; the oldest wins if a deployment holds several,
+        so resolution is deterministic rather than dependent on row order."""
+        stmt = (
+            select(models.Workspace)
+            .where(models.Workspace.policy == Policy.GLOBAL.value)
+            .order_by(models.Workspace.created_at, models.Workspace.id)
+        )
+        row = (await self.session.execute(stmt)).scalars().first()
+        return _workspace(row) if row is not None else None
+
+    async def workspaces_by_id(self, ids: Sequence[str]) -> dict[str, WorkspaceRef]:
+        if not ids:
+            return {}
+        stmt = select(models.Workspace).where(models.Workspace.id.in_(list(ids)))
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return {row.id: _workspace(row) for row in rows}
+
+    # ── membership ────────────────────────────────────────────────────────────────────────────
+
+    async def insert_membership(
+        self,
+        *,
+        workspace_id: str,
+        subject: str,
+        role: Role,
+        added_by: str,
+        email: str | None = None,
+    ) -> MemberRef:
+        row = models.Membership(
+            workspace_id=workspace_id,
+            subject=subject,
+            role=role.value,
+            added_by=added_by,
+            email=email,
+            added_at=_utcnow(),
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return MemberRef(subject=subject, role=role, email=email)
+
+    async def delete_membership(self, *, workspace_id: str, subject: str) -> bool:
+        stmt = delete(models.Membership).where(
+            models.Membership.workspace_id == workspace_id,
+            models.Membership.subject == subject,
+        )
+        result = await self.session.execute(stmt)
+        await self.session.flush()
+        return bool(result.rowcount)
+
+    async def role_of(self, *, workspace_id: str, subject: str) -> Role | None:
+        """The actor's role in the workspace, or ``None`` when they are not a member."""
+        stmt = select(models.Membership.role).where(
+            models.Membership.workspace_id == workspace_id,
+            models.Membership.subject == subject,
+        )
+        value = (await self.session.execute(stmt)).scalar_one_or_none()
+        return Role(value) if value is not None else None
+
+    async def members(self, workspace_id: str) -> tuple[MemberRef, ...]:
+        stmt = (
+            select(models.Membership)
+            .where(models.Membership.workspace_id == workspace_id)
+            .order_by(models.Membership.id)
+        )
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return tuple(
+            MemberRef(subject=r.subject, role=Role(r.role), email=r.email) for r in rows
+        )
+
+    async def member_count(self, workspace_id: str) -> int:
+        stmt = select(func.count()).select_from(models.Membership).where(
+            models.Membership.workspace_id == workspace_id
+        )
+        return int((await self.session.execute(stmt)).scalar_one())
+
+    async def memberships_of(
+        self, subject: str, *, policy: Policy | None = None
+    ) -> tuple[WorkspaceRef, ...]:
+        """Every workspace this subject is a member of, oldest first, name-tiebroken."""
+        stmt = (
+            select(models.Workspace)
+            .join(models.Membership, models.Membership.workspace_id == models.Workspace.id)
+            .where(models.Membership.subject == subject)
+            .order_by(models.Workspace.created_at, models.Workspace.id)
+        )
+        if policy is not None:
+            stmt = stmt.where(models.Workspace.policy == policy.value)
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return tuple(_workspace(r) for r in rows)
+
+    # ── stack pointers ────────────────────────────────────────────────────────────────────────
+
+    async def pointers(self, subject: str) -> tuple[PointerRef, ...]:
+        stmt = (
+            select(models.StackPointer)
+            .where(models.StackPointer.subject == subject)
+            .order_by(models.StackPointer.position, models.StackPointer.id)
+        )
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return tuple(
+            PointerRef(
+                subject=r.subject,
+                slot=Policy(r.slot),
+                workspace_id=r.workspace_id,
+                position=r.position,
+            )
+            for r in rows
+        )
+
+    async def set_pointer(
+        self, *, subject: str, slot: Policy, workspace_id: str, position: int = 0
+    ) -> PointerRef:
+        """Point a slot at a workspace.
+
+        A singleton slot holds one pointer: setting it replaces whatever it held, which is what
+        re-pointing a user's personal workspace is. The group slot accumulates.
+        """
+        from .layers import SINGLETON_LAYERS
+
+        if slot in SINGLETON_LAYERS:
+            await self.clear_pointers(subject=subject, slot=slot)
+        row = models.StackPointer(
+            subject=subject, slot=slot.value, workspace_id=workspace_id, position=position
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return PointerRef(
+            subject=subject, slot=slot, workspace_id=workspace_id, position=position
+        )
+
+    async def clear_pointers(self, *, subject: str, slot: Policy) -> int:
+        stmt = delete(models.StackPointer).where(
+            models.StackPointer.subject == subject,
+            models.StackPointer.slot == slot.value,
+        )
+        result = await self.session.execute(stmt)
+        await self.session.flush()
+        return int(result.rowcount or 0)
+
+    # ── context revisions ─────────────────────────────────────────────────────────────────────
+
+    async def append_revision(
+        self,
+        *,
+        workspace_id: str,
+        path: str,
+        body: str,
+        author_subject: str,
+        source_kind: str,
+        source_ref: str | None = None,
+        deleted: bool = False,
+        from_proposal_id: int | None = None,
+    ) -> RevisionRef:
+        stmt = select(func.max(models.ContextRevision.revision)).where(
+            models.ContextRevision.workspace_id == workspace_id,
+            models.ContextRevision.path == path,
+        )
+        highest = (await self.session.execute(stmt)).scalar_one_or_none()
+        row = models.ContextRevision(
+            workspace_id=workspace_id,
+            path=path,
+            revision=(highest or 0) + 1,
+            body=body,
+            deleted=deleted,
+            author_subject=author_subject,
+            source_kind=source_kind,
+            source_ref=source_ref,
+            from_proposal_id=from_proposal_id,
+            created_at=_utcnow(),
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return _revision(row)
+
+    async def current_revision(self, *, workspace_id: str, path: str) -> RevisionRef | None:
+        """The highest revision of one document, tombstone included (callers check ``deleted``)."""
+        stmt = (
+            select(models.ContextRevision)
+            .where(
+                models.ContextRevision.workspace_id == workspace_id,
+                models.ContextRevision.path == path,
+            )
+            .order_by(models.ContextRevision.revision.desc())
+            .limit(1)
+        )
+        row = (await self.session.execute(stmt)).scalars().first()
+        return _revision(row) if row is not None else None
+
+    async def revisions(self, *, workspace_id: str, path: str) -> tuple[RevisionRef, ...]:
+        stmt = (
+            select(models.ContextRevision)
+            .where(
+                models.ContextRevision.workspace_id == workspace_id,
+                models.ContextRevision.path == path,
+            )
+            .order_by(models.ContextRevision.revision)
+        )
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return tuple(_revision(r) for r in rows)
+
+    async def documents(self, workspace_id: str) -> tuple[str, ...]:
+        stmt = (
+            select(models.ContextRevision.path)
+            .where(models.ContextRevision.workspace_id == workspace_id)
+            .distinct()
+            .order_by(models.ContextRevision.path)
+        )
+        return tuple((await self.session.execute(stmt)).scalars().all())
+
+    # ── proposals ─────────────────────────────────────────────────────────────────────────────
+
+    async def insert_proposal(
+        self,
+        *,
+        workspace_id: str,
+        path: str,
+        body: str,
+        proposer_subject: str,
+        source_kind: str,
+        source_ref: str | None = None,
+    ) -> ProposalRef:
+        row = models.Proposal(
+            workspace_id=workspace_id,
+            path=path,
+            body=body,
+            proposer_subject=proposer_subject,
+            source_kind=source_kind,
+            source_ref=source_ref,
+            state="pending",
+            created_at=_utcnow(),
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return _proposal(row)
+
+    async def get_proposal(self, proposal_id: int) -> ProposalRef | None:
+        row = await self.session.get(models.Proposal, proposal_id)
+        return _proposal(row) if row is not None else None
+
+    async def proposals(
+        self, *, workspace_id: str, state: str | None = None
+    ) -> tuple[ProposalRef, ...]:
+        stmt = select(models.Proposal).where(models.Proposal.workspace_id == workspace_id)
+        if state is not None:
+            stmt = stmt.where(models.Proposal.state == state)
+        stmt = stmt.order_by(models.Proposal.id)
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return tuple(_proposal(r) for r in rows)
+
+    async def record_decision(
+        self, *, proposal_id: int, state: str, decided_by: str, note: str | None
+    ) -> ProposalRef:
+        """Stamp a human's answer onto a proposal.
+
+        ``decided_by`` has no default and is not optional anywhere up the call chain, and the
+        table's CHECK constraint refuses a decided row without it.
+        """
+        row = await self.session.get(models.Proposal, proposal_id)
+        if row is None:  # pragma: no cover - callers load the proposal first
+            raise LookupError(proposal_id)
+        row.state = state
+        row.decided_by = decided_by
+        row.decided_at = _utcnow()
+        row.decision_note = note
+        await self.session.flush()
+        return _proposal(row)
+
+    # ── secrets (rows in, metadata out — see secrets.py for the surface) ──────────────────────
+
+    async def upsert_secret(
+        self, *, workspace_id: str, name: str, material: str, set_by: str
+    ) -> models.WorkspaceSecret:
+        stmt = select(models.WorkspaceSecret).where(
+            models.WorkspaceSecret.workspace_id == workspace_id,
+            models.WorkspaceSecret.name == name,
+        )
+        row = (await self.session.execute(stmt)).scalar_one_or_none()
+        now = _utcnow()
+        if row is None:
+            row = models.WorkspaceSecret(
+                workspace_id=workspace_id,
+                name=name,
+                material=material,
+                last4=material[-4:],
+                version=1,
+                set_by=set_by,
+                set_at=now,
+            )
+            self.session.add(row)
+        else:
+            row.material = material
+            row.last4 = material[-4:]
+            row.version = row.version + 1
+            row.set_by = set_by
+            row.rotated_at = now
+        await self.session.flush()
+        return row
+
+    async def secret_row(self, *, workspace_id: str, name: str) -> models.WorkspaceSecret | None:
+        stmt = select(models.WorkspaceSecret).where(
+            models.WorkspaceSecret.workspace_id == workspace_id,
+            models.WorkspaceSecret.name == name,
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def secret_rows(self, workspace_id: str) -> tuple[models.WorkspaceSecret, ...]:
+        stmt = (
+            select(models.WorkspaceSecret)
+            .where(models.WorkspaceSecret.workspace_id == workspace_id)
+            .order_by(models.WorkspaceSecret.name)
+        )
+        return tuple((await self.session.execute(stmt)).scalars().all())
+
+    async def delete_secret_row(self, *, workspace_id: str, name: str) -> bool:
+        stmt = delete(models.WorkspaceSecret).where(
+            models.WorkspaceSecret.workspace_id == workspace_id,
+            models.WorkspaceSecret.name == name,
+        )
+        result = await self.session.execute(stmt)
+        await self.session.flush()
+        return bool(result.rowcount)

--- a/core/agent/modules/context-stack/src/context_stack/triage.py
+++ b/core/agent/modules/context-stack/src/context_stack/triage.py
@@ -1,0 +1,123 @@
+"""Owner triage: accept or reject a proposed context delta. The human path.
+
+This module is deliberately separate from ``router.py``. The router is the machine path — a
+meeting produces deltas and they land — and its ceiling on the group layer is a ``pending`` row.
+**No machine ever writes acknowledgement**, and that is the shape of the code rather than a note
+about how to use it.
+
+Four guards, at four different levels, and each would hold if the others were removed:
+
+1. **The import direction.** This module depends on the router's types; the router therefore
+   cannot import this one without a cycle Python refuses to load. A call chain from a meeting to
+   an acceptance is not something a later edit can add here by accident.
+2. ``actor`` is a required keyword with no default and no service principal. Every accept and
+   every reject names a person.
+3. The actor must hold the **owner** role — triage is one of the four things an owner does
+   (config, membership, triage, secrets). A member may propose and may not decide.
+4. ``ck_proposal_decision_is_attributed`` on ``context_proposals`` refuses any decided row that
+   does not carry ``decided_by`` and ``decided_at``. A caller that bypassed this module entirely
+   still cannot leave an unattributed acceptance in the table.
+
+There is no accept-all, no auto-accept, and no policy knob that turns one on. The batching
+question the roadmap raises — whether factual deltas can be auto-accepted while behavioural ones
+queue — is a live design question, not a switch left in the code.
+"""
+
+from __future__ import annotations
+
+from .access import Action, decide
+from .errors import AccessDenied, NotFound, ProposalAlreadyDecided
+from .router import Destination, Landed, Routing
+from .store import ContextStackStore, ProposalRef, WorkspaceRef
+
+
+async def pending_proposals(
+    store: ContextStackStore, *, workspace_id: str, actor: str
+) -> tuple[ProposalRef, ...]:
+    """The owner's queue. Reading it is itself owner-gated — a queue is a view of what a group's
+    members are trying to write, which is not a member's to read."""
+    workspace = await _workspace(store, workspace_id)
+    await _authorise(store, workspace, actor)
+    return await store.proposals(workspace_id=workspace_id, state="pending")
+
+
+async def accept_proposal(
+    store: ContextStackStore, *, proposal_id: int, actor: str, note: str | None = None
+) -> Landed:
+    """The owner accepts: the proposed body becomes the group context's next revision.
+
+    The revision keeps the *proposer* as its author and records ``from_proposal_id``, so the
+    history says who wrote the knowledge and who let it in — two different people, both named.
+    """
+    proposal, workspace = await _pending(store, proposal_id)
+    await _authorise(store, workspace, actor)
+
+    revision = await store.append_revision(
+        workspace_id=workspace.id,
+        path=proposal.path,
+        body=proposal.body,
+        author_subject=proposal.proposer_subject,
+        source_kind="triage",
+        source_ref=proposal.source_ref,
+        from_proposal_id=proposal.id,
+    )
+    decided = await store.record_decision(
+        proposal_id=proposal.id, state="accepted", decided_by=actor, note=note
+    )
+    await store.commit()
+    return Landed(
+        routing=Routing(Destination.DIRECT, workspace.policy, workspace.id, "accepted-by-owner"),
+        revision=revision,
+        proposal=decided,
+    )
+
+
+async def reject_proposal(
+    store: ContextStackStore, *, proposal_id: int, actor: str, note: str | None = None
+) -> ProposalRef:
+    """The owner rejects: nothing enters context, and the record keeps why and by whom."""
+    proposal, workspace = await _pending(store, proposal_id)
+    await _authorise(store, workspace, actor)
+    decided = await store.record_decision(
+        proposal_id=proposal.id, state="rejected", decided_by=actor, note=note
+    )
+    await store.commit()
+    return decided
+
+
+async def _pending(
+    store: ContextStackStore, proposal_id: int
+) -> tuple[ProposalRef, WorkspaceRef]:
+    proposal = await store.get_proposal(proposal_id)
+    if proposal is None:
+        raise NotFound(f"no proposal {proposal_id}")
+    if proposal.state != "pending":
+        # A decided proposal is final. Re-deciding would overwrite one human's answer with
+        # another's under the same id, and the record would show only the second.
+        raise ProposalAlreadyDecided(
+            f"proposal {proposal_id} was already {proposal.state} by {proposal.decided_by}"
+        )
+    return proposal, await _workspace(store, proposal.workspace_id)
+
+
+async def _workspace(store: ContextStackStore, workspace_id: str) -> WorkspaceRef:
+    workspace = await store.get_workspace(workspace_id)
+    if workspace is None:
+        raise NotFound(f"no workspace {workspace_id!r}")
+    return workspace
+
+
+async def _authorise(store: ContextStackStore, workspace: WorkspaceRef, actor: str) -> None:
+    role = await store.role_of(workspace_id=workspace.id, subject=actor)
+    verdict = decide(
+        subject=actor,
+        workspace_id=workspace.id,
+        policy=workspace.policy,
+        role=role,
+        action=Action.TRIAGE,
+    )
+    if not verdict.allow:
+        raise AccessDenied(f"{actor} may not triage {workspace.id}", decision=verdict)
+
+
+__all__ = ["accept_proposal", "reject_proposal", "pending_proposals"]

--- a/core/agent/modules/context-stack/src/context_stack/workspaces.py
+++ b/core/agent/modules/context-stack/src/context_stack/workspaces.py
@@ -1,0 +1,164 @@
+"""Provisioning and membership — the operations that create a workspace and decide who is in it.
+
+Workspace identity is an address and a name: the bot has a mailbox, each workspace has its own
+address, and users invite that address to a meeting like any attendee, so the invited address IS
+the group resolution — there is nothing to infer. The name names the bot.
+
+Group setup is a set of member emails and nothing more. A personal workspace is the one-member
+case of the same thing, not a second kind of object, which is why it is created by the same
+function with a different policy.
+"""
+
+from __future__ import annotations
+
+from .access import Action, AccessDecision, decide
+from .errors import AccessDenied, InvalidWorkspace, NotFound
+from .layers import Policy, Role
+from .store import ContextStackStore, MemberRef, WorkspaceRef
+
+
+async def create_workspace(
+    store: ContextStackStore,
+    *,
+    workspace_id: str,
+    name: str,
+    address: str,
+    policy: Policy,
+    owner_subject: str,
+    owner_email: str | None = None,
+    member_emails: tuple[str, ...] = (),
+) -> WorkspaceRef:
+    """Create a workspace and seat its owner. ``member_emails`` is the whole of group setup.
+
+    Members are seated by email because that is the only identifier the setup flow has. The
+    subject and the email are the same string until a directory exists to tell them apart; the
+    row keeps both columns so that stops being true without a migration.
+    """
+    if await store.get_workspace(workspace_id) is not None:
+        raise InvalidWorkspace(f"workspace {workspace_id!r} already exists")
+    if await store.get_workspace_by_address(address) is not None:
+        raise InvalidWorkspace(f"address {address!r} is already bound to a workspace")
+
+    workspace = await store.insert_workspace(
+        id=workspace_id,
+        name=name,
+        address=address,
+        policy=policy,
+        owner_subject=owner_subject,
+    )
+    await store.insert_membership(
+        workspace_id=workspace_id,
+        subject=owner_subject,
+        role=Role.OWNER,
+        added_by=owner_subject,
+        email=owner_email,
+    )
+    for email in member_emails:
+        if email == owner_email or email == owner_subject:
+            continue
+        await add_member(
+            store, workspace_id=workspace_id, subject=email, email=email, actor=owner_subject
+        )
+    await store.commit()
+    return workspace
+
+
+async def ensure_personal(
+    store: ContextStackStore, *, subject: str, address: str, name: str | None = None
+) -> WorkspaceRef:
+    """The personal workspace every user has. Idempotent — provisioning runs more than once."""
+    existing = await store.owned_workspace(subject, Policy.PERSONAL)
+    if existing is not None:
+        return existing
+    return await create_workspace(
+        store,
+        workspace_id=f"personal-{subject}",
+        name=name or f"{subject} (personal)",
+        address=address,
+        policy=Policy.PERSONAL,
+        owner_subject=subject,
+        owner_email=subject if "@" in subject else None,
+    )
+
+
+async def ensure_user_system(
+    store: ContextStackStore, *, subject: str, address: str
+) -> WorkspaceRef:
+    """The per-user hidden layer: sessions and chat history. Never sharable, never a credential."""
+    existing = await store.owned_workspace(subject, Policy.USER_SYSTEM)
+    if existing is not None:
+        return existing
+    return await create_workspace(
+        store,
+        workspace_id=f"user-system-{subject}",
+        name=f"{subject} (system)",
+        address=address,
+        policy=Policy.USER_SYSTEM,
+        owner_subject=subject,
+    )
+
+
+async def add_member(
+    store: ContextStackStore,
+    *,
+    workspace_id: str,
+    subject: str,
+    actor: str,
+    email: str | None = None,
+    role: Role = Role.MEMBER,
+) -> MemberRef:
+    """Seat a member. Owner-only, and only on a layer that is sharable at all."""
+    workspace = await _require(store, workspace_id)
+    _require_allowed(
+        await _decide(store, workspace, actor=actor, action=Action.SHARE),
+        f"{actor} may not add members to {workspace_id}",
+    )
+    if await store.role_of(workspace_id=workspace_id, subject=subject) is not None:
+        return MemberRef(subject=subject, role=role, email=email)
+    member = await store.insert_membership(
+        workspace_id=workspace_id, subject=subject, role=role, added_by=actor, email=email
+    )
+    await store.commit()
+    return member
+
+
+async def remove_member(
+    store: ContextStackStore, *, workspace_id: str, subject: str, actor: str
+) -> bool:
+    """Unseat a member. Owner-only. The owner's own row is not removable — a workspace without an
+    owner has nobody to triage it, and the queue would silently stop being answerable."""
+    workspace = await _require(store, workspace_id)
+    _require_allowed(
+        await _decide(store, workspace, actor=actor, action=Action.SHARE),
+        f"{actor} may not remove members from {workspace_id}",
+    )
+    if subject == workspace.owner_subject:
+        raise InvalidWorkspace("the owner's membership cannot be removed")
+    removed = await store.delete_membership(workspace_id=workspace_id, subject=subject)
+    await store.commit()
+    return removed
+
+
+async def _decide(
+    store: ContextStackStore, workspace: WorkspaceRef, *, actor: str, action: Action
+) -> AccessDecision:
+    role = await store.role_of(workspace_id=workspace.id, subject=actor)
+    return decide(
+        subject=actor,
+        workspace_id=workspace.id,
+        policy=workspace.policy,
+        role=role,
+        action=action,
+    )
+
+
+async def _require(store: ContextStackStore, workspace_id: str) -> WorkspaceRef:
+    workspace = await store.get_workspace(workspace_id)
+    if workspace is None:
+        raise NotFound(f"no workspace {workspace_id!r}")
+    return workspace
+
+
+def _require_allowed(decision: AccessDecision, message: str) -> None:
+    if not decision.allow:
+        raise AccessDenied(message, decision=decision)

--- a/core/agent/modules/context-stack/tests/README.md
+++ b/core/agent/modules/context-stack/tests/README.md
@@ -1,0 +1,19 @@
+# tests — context-stack
+
+Real DDL on in-memory SQLite: CHECK and UNIQUE constraints are exercised, not described. No
+docker, no network, no live stack.
+
+| File | Level | Proves |
+|---|---|---|
+| `test_resolution.py` | L2 | the stack resolves in layer order for a member, a non-member, several groups and none; slots are pointers carrying their layer's rules; a bad pointer is denied, not fatal |
+| `test_routing.py` | L2 | the routing table both ways — group → the queue, personal → context — plus the two refusing layers, and that 100 machine deltas accept none of themselves |
+| `test_triage.py` | L2/L3 | accept applies, reject does not, a member may propose and not decide, a decision is final; and the four structural guards against machine acknowledgement |
+| `test_enforcement.py` | L2 | seven routes into a group, all closed to a non-member; personal is not a small group; user-system is never sharable; the whole decision table's allow-list written out |
+| `test_secrets.py` | L2 | set → rotate → metadata read, with the surface enumerated and every return searched for the value; the user-system layer holds no credentials ever |
+| `test_api_surface.py` | L3 | the route table is exactly this; no response model has a field a secret could ride in; a real key comes back from no route; one accept route and no bulk form |
+| `test_contract.py` | L1 | live output conforms to `context-stack.v1`, so the published shape cannot drift from the code while its goldens still pass |
+| `test_repointing.py` | L2 | a user can be re-pointed at a different personal workspace, in the product path as well as free composition |
+
+Two negative controls were run by hand against this suite and both were caught: a route that
+returned key material (caught at three levels — the import graph, the response model, and the live
+sweep), and a router that accepted its own proposal (which does not even import, by construction).

--- a/core/agent/modules/context-stack/tests/conftest.py
+++ b/core/agent/modules/context-stack/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Fixtures: a real database, built from the real DDL, per test.
+
+SQLite in memory with a ``StaticPool``, so every connection in a test sees the same database —
+without it, an in-memory SQLite gives each connection its own empty one and the tests would pass
+against nothing. Constraints are on (``PRAGMA foreign_keys=ON``), which matters: several of the
+invariants under test are CHECK and UNIQUE constraints rather than Python.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from context_stack import ContextStackStore, Policy
+from context_stack.models import Base
+from context_stack.workspaces import create_workspace
+
+
+@pytest_asyncio.fixture
+async def engine():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _fk_on(dbapi_connection, _record):  # noqa: ANN001 - sqlalchemy event signature
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def store(session_factory):
+    async with session_factory() as session:
+        yield ContextStackStore(session)
+
+
+@pytest.fixture
+def make_workspace(store):
+    """Create a workspace of any policy. Returns the async callable, not a workspace."""
+
+    async def _make(
+        workspace_id: str,
+        policy: Policy,
+        owner: str,
+        *,
+        members: tuple[str, ...] = (),
+        name: str | None = None,
+    ):
+        return await create_workspace(
+            store,
+            workspace_id=workspace_id,
+            name=name or workspace_id,
+            address=f"{workspace_id}@vexa.ai",
+            policy=policy,
+            owner_subject=owner,
+            owner_email=owner,
+            member_emails=members,
+        )
+
+    return _make
+
+
+OWNER = "owner@example.com"
+MEMBER = "member@example.com"
+OUTSIDER = "outsider@example.com"

--- a/core/agent/modules/context-stack/tests/test_api_surface.py
+++ b/core/agent/modules/context-stack/tests/test_api_surface.py
@@ -1,0 +1,272 @@
+"""L3 — the HTTP surface, enumerated: no route returns a secret, and no route auto-accepts.
+
+Three levels of evidence, weakest to strongest:
+
+1. The route table is written out. A new route fails this test until someone adds it here, which
+   is the moment to ask what it returns.
+2. Every response model is walked recursively for a field that could carry material.
+3. A real key is set through the API, then **every readable route is called and its bytes are
+   searched for it**. That is the check the settings-read defect needed: not "does this endpoint
+   leak" but "does any of them".
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from context_stack import api
+from context_stack.api import create_router
+from context_stack.store import ContextStackStore
+
+from conftest import MEMBER, OUTSIDER, OWNER
+
+KEY = "sk-live-do-not-return-me-9999"
+
+EXPECTED_ROUTES = {
+    ("POST", "/workspaces"),
+    ("GET", "/workspaces/{workspace_id}"),
+    ("POST", "/workspaces/{workspace_id}/members"),
+    ("DELETE", "/workspaces/{workspace_id}/members/{subject}"),
+    ("GET", "/stack"),
+    ("POST", "/context/deltas"),
+    ("GET", "/workspaces/{workspace_id}/context"),
+    ("GET", "/workspaces/{workspace_id}/proposals"),
+    ("POST", "/proposals/{proposal_id}/accept"),
+    ("POST", "/proposals/{proposal_id}/reject"),
+    ("PUT", "/workspaces/{workspace_id}/secrets/{name}"),
+    ("GET", "/workspaces/{workspace_id}/secrets"),
+    ("GET", "/workspaces/{workspace_id}/secrets/{name}"),
+    ("DELETE", "/workspaces/{workspace_id}/secrets/{name}"),
+}
+
+FORBIDDEN_FIELDS = {"material", "value", "secret", "plaintext", "credential", "api_key", "token"}
+
+
+@pytest.fixture
+def router():
+    """The module's own surface. Enumerated directly, so FastAPI's documentation endpoints — the
+    app's, not ours — never enter the count."""
+    return create_router(lambda: None)
+
+
+@pytest.fixture
+def client(session_factory):
+    """An app carrying only this router, with a fresh session per request."""
+
+    async def get_store():
+        async with session_factory() as session:
+            yield ContextStackStore(session)
+
+    app = FastAPI()
+    app.include_router(create_router(get_store))
+    with TestClient(app) as client:
+        yield client
+
+
+def _as(client, subject: str):
+    client.headers.update({"X-User-Email": subject})
+    return client
+
+
+def _routes(router) -> set[tuple[str, str]]:
+    return {
+        (method, route.path)
+        for route in router.routes
+        for method in getattr(route, "methods", ()) or ()
+        if method not in {"HEAD", "OPTIONS"}
+    }
+
+
+def _fields(model, seen=None) -> set[str]:
+    """Every field name reachable from a response model, recursively."""
+    seen = seen if seen is not None else set()
+    if model in seen or not (isinstance(model, type) and issubclass(model, BaseModel)):
+        return set()
+    seen.add(model)
+    names: set[str] = set()
+    for name, field in model.model_fields.items():
+        names.add(name)
+        annotation = field.annotation
+        for candidate in (annotation, *getattr(annotation, "__args__", ())):
+            names |= _fields(candidate, seen)
+    return names
+
+
+# ── 1. the table ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_the_route_table_is_exactly_this(router):
+    """Adding a route means adding a row here, which is where its response gets looked at."""
+    assert _routes(router) == EXPECTED_ROUTES
+
+
+def test_there_is_exactly_one_accept_route_and_no_bulk_form(router):
+    """No auto-accept, no accept-all: the API cannot drain a triage queue in one call."""
+    accepting = [path for _, path in _routes(router) if "accept" in path]
+
+    assert accepting == ["/proposals/{proposal_id}/accept"]
+    assert not [p for _, p in _routes(router) if any(w in p for w in ("auto", "bulk", "batch"))]
+
+
+def test_no_route_reaches_the_one_reader_of_material():
+    """``api.py`` does not import ``context_stack.material``. Read from the parse tree, so the
+    docstring may name the rule without breaking it."""
+    tree = ast.parse(inspect.getsource(api))
+    imported = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)}
+    referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    }
+
+    assert not [m for m in imported if m and "material" in m]
+    assert "use_material" not in referenced
+
+
+# ── 2. the response models ────────────────────────────────────────────────────────────────────
+
+
+def test_no_response_model_has_a_field_a_secret_could_ride_in(router):
+    """Walk every declared response model, recursively, for a field that could carry material."""
+    offenders = {}
+    for route in router.routes:
+        model = getattr(route, "response_model", None)
+        if model is None:
+            continue
+        for candidate in (model, *getattr(model, "__args__", ())):
+            leaking = _fields(candidate) & FORBIDDEN_FIELDS
+            if leaking:
+                offenders[route.path] = leaking
+
+    assert offenders == {}
+
+
+# ── 3. the live sweep ─────────────────────────────────────────────────────────────────────────
+
+
+def test_a_real_key_comes_back_from_no_route(client):
+    """Set a key through the API, then call every readable route and search the bytes for it."""
+    owner = _as(client, OWNER)
+    owner.post(
+        "/workspaces",
+        json={
+            "workspace_id": "acme",
+            "name": "Acme",
+            "address": "acme@vexa.ai",
+            "policy": "group",
+            "member_emails": [MEMBER],
+        },
+    ).raise_for_status()
+    set_response = owner.put(
+        "/workspaces/acme/secrets/llm_api_key", json={"material": KEY}
+    )
+    assert set_response.status_code == 200
+    assert set_response.json()["last4"] == "9999"
+
+    owner.post(
+        "/context/deltas",
+        json={"workspace_id": "acme", "path": "kg/x.md", "body": "a delta"},
+    ).raise_for_status()
+
+    readable = [
+        "/workspaces/acme",
+        "/workspaces/acme/secrets",
+        "/workspaces/acme/secrets/llm_api_key",
+        "/workspaces/acme/proposals",
+        "/workspaces/acme/context?path=kg/x.md",
+        "/stack",
+        "/stack?mode=free",
+        "/openapi.json",
+    ]
+
+    for path in readable:
+        response = owner.get(path)
+        assert KEY not in response.text, f"{path} returned the secret"
+        assert KEY.encode() not in response.content, f"{path} returned the secret"
+
+    # The set route is the only place a value appears on this surface, and it appears going in.
+    assert KEY not in set_response.text
+
+
+def test_every_readable_route_is_swept(router):
+    """The sweep above is only as good as its coverage: assert it hit every GET route there is."""
+    swept = {"/workspaces/{workspace_id}", "/workspaces/{workspace_id}/secrets",
+             "/workspaces/{workspace_id}/secrets/{name}", "/workspaces/{workspace_id}/proposals",
+             "/workspaces/{workspace_id}/context", "/stack"}
+
+    assert {path for method, path in _routes(router) if method == "GET"} == swept
+
+
+# ── the surface behaves, too ──────────────────────────────────────────────────────────────────
+
+
+def test_the_full_triage_round_trip_over_http(client):
+    """Member proposes → it is not in context → owner accepts → it is."""
+    owner = _as(client, OWNER)
+    owner.post(
+        "/workspaces",
+        json={
+            "workspace_id": "acme",
+            "name": "Acme",
+            "address": "acme@vexa.ai",
+            "policy": "group",
+            "member_emails": [MEMBER],
+        },
+    ).raise_for_status()
+
+    landed = _as(client, MEMBER).post(
+        "/context/deltas",
+        json={"workspace_id": "acme", "path": "kg/pricing.md", "body": "Renewal Q3"},
+    ).json()
+    assert landed["destination"] == "proposal"
+    assert _as(client, MEMBER).get("/workspaces/acme/context?path=kg/pricing.md").status_code == 404
+
+    assert _as(client, MEMBER).post(f"/proposals/{landed['proposal_id']}/accept").status_code == 403
+
+    accepted = _as(client, OWNER).post(
+        f"/proposals/{landed['proposal_id']}/accept", json={"note": "checked"}
+    )
+    assert accepted.status_code == 200
+    document = _as(client, MEMBER).get("/workspaces/acme/context?path=kg/pricing.md").json()
+    assert document["body"] == "Renewal Q3"
+
+
+def test_an_outsider_gets_403_from_the_group_routes(client):
+    """The enforcement case over HTTP, with the machine-readable reason preserved."""
+    owner = _as(client, OWNER)
+    owner.post(
+        "/workspaces",
+        json={
+            "workspace_id": "acme",
+            "name": "Acme",
+            "address": "acme@vexa.ai",
+            "policy": "group",
+            "member_emails": [MEMBER],
+        },
+    ).raise_for_status()
+    owner.put("/workspaces/acme/secrets/llm_api_key", json={"material": KEY}).raise_for_status()
+
+    outsider = _as(client, OUTSIDER)
+    for path in (
+        "/workspaces/acme",
+        "/workspaces/acme/proposals",
+        "/workspaces/acme/secrets",
+        "/workspaces/acme/secrets/llm_api_key",
+    ):
+        response = outsider.get(path)
+        assert response.status_code == 403, path
+        assert response.json()["detail"]["code"] in {"not-member", "not-owner"}
+        assert KEY not in response.text
+
+
+def test_a_caller_can_only_resolve_their_own_stack(router):
+    """There is no subject parameter on /stack — a composition is built for whoever is asking."""
+    signature = inspect.signature(
+        next(r.endpoint for r in router.routes if getattr(r, "path", "") == "/stack")
+    )
+
+    assert "subject" not in signature.parameters

--- a/core/agent/modules/context-stack/tests/test_contract.py
+++ b/core/agent/modules/context-stack/tests/test_contract.py
@@ -1,0 +1,146 @@
+"""L1 — the published contract: what this module emits conforms to ``context-stack.v1``.
+
+``gate:schema`` already proves the goldens match the schema. This proves the other half — that
+live output matches it too — so the published shape cannot drift from the code that produces it
+while the goldens sit there still passing.
+
+The schema is loaded **by path**, never by importing the owning domain, which is the convention
+``core/agent/contracts/loader.py`` already follows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+from referencing import Registry, Resource
+
+from context_stack import (
+    Action,
+    ContextDelta,
+    Mode,
+    Policy,
+    Role,
+    accept_proposal,
+    decide,
+    land_delta,
+    resolve_stack,
+    set_secret,
+)
+from context_stack.workspaces import ensure_personal, ensure_user_system
+
+from conftest import MEMBER, OUTSIDER, OWNER
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "contracts"
+    / "context-stack.v1"
+    / "context-stack.schema.json"
+)
+
+
+@pytest.fixture(scope="session")
+def schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _validator(schema: dict, shape: str) -> jsonschema.Draft202012Validator:
+    registry = Registry().with_resource(schema["$id"], Resource.from_contents(schema))
+    return jsonschema.Draft202012Validator(
+        {"$ref": f"{schema['$id']}#/$defs/{shape}"}, registry=registry
+    )
+
+
+def test_the_schema_is_where_the_goldens_are(schema):
+    """A wrong path here would make every assertion below vacuous."""
+    assert schema["$id"] == "https://vexa.ai/schemas/context-stack.v1"
+    assert (SCHEMA_PATH.parent / "golden").is_dir()
+
+
+def test_the_layer_enum_matches_the_code(schema):
+    """The four layers, in stack order, in both places."""
+    assert schema["$defs"]["Policy"]["enum"] == [p.value for p in Policy]
+    assert [p.value for p in Policy] == ["global", "group", "personal", "user-system"]
+
+
+async def test_a_resolved_stack_conforms(schema, store, make_workspace):
+    await make_workspace("global", Policy.GLOBAL, "vexa")
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await ensure_personal(store, subject=MEMBER, address="p@vexa.ai")
+    await ensure_user_system(store, subject=MEMBER, address="s@vexa.ai")
+
+    for mode in (Mode.PINNED, Mode.FREE):
+        stack = await resolve_stack(store, subject=MEMBER, mode=mode)
+        _validator(schema, "ResolvedStack").validate(stack.to_contract())
+        for slot in stack.slots:
+            _validator(schema, "StackSlot").validate(slot.to_contract())
+
+
+async def test_a_denial_conforms(schema, store, make_workspace):
+    """Every denial reason the resolver can emit is in the published enum."""
+    await make_workspace("acme", Policy.GROUP, OWNER)
+    await store.set_pointer(subject=OUTSIDER, slot=Policy.GROUP, workspace_id="acme")
+    await store.set_pointer(subject=OUTSIDER, slot=Policy.PERSONAL, workspace_id="ghost")
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=OUTSIDER, mode=Mode.FREE)
+
+    assert stack.denied
+    for denial in stack.denied:
+        _validator(schema, "Denial").validate(denial.to_contract())
+
+
+async def test_both_routings_conform(schema, store, make_workspace):
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    personal = await ensure_personal(store, subject=MEMBER, address="p@vexa.ai")
+
+    group = await land_delta(
+        store,
+        ContextDelta(workspace_id="acme", path="kg/x.md", body="b", author_subject=MEMBER),
+    )
+    direct = await land_delta(
+        store,
+        ContextDelta(workspace_id=personal.id, path="n/x.md", body="b", author_subject=MEMBER),
+    )
+    accepted = await accept_proposal(store, proposal_id=group.proposal.id, actor=OWNER)
+
+    for landed in (group, direct, accepted):
+        _validator(schema, "Routing").validate(landed.routing.to_contract())
+
+
+def test_every_access_decision_conforms(schema):
+    """Exhaust the decision table against the published reason enum: no code the schema lacks."""
+    import itertools
+
+    for policy, role, action in itertools.product(Policy, (None, Role.MEMBER, Role.OWNER), Action):
+        verdict = decide(
+            subject="s", workspace_id="w", policy=policy, role=role, action=action
+        )
+        _validator(schema, "AccessDecision").validate(verdict.to_contract())
+
+
+async def test_secret_metadata_conforms_and_the_shape_holds_no_material(schema, store, make_workspace):
+    """The published shape has no material field, and what the code emits fits it exactly —
+    ``additionalProperties: false`` means a leaked field would fail this test, not pass it."""
+    await make_workspace("acme", Policy.GROUP, OWNER)
+    metadata = await set_secret(
+        store,
+        workspace_id="acme",
+        name="llm_api_key",
+        material="sk-live-000000000000cafe",
+        actor=OWNER,
+    )
+
+    _validator(schema, "SecretMetadata").validate(metadata.to_contract())
+
+    published = schema["$defs"]["SecretMetadata"]
+    assert published["additionalProperties"] is False
+    assert "material" not in published["properties"]
+    assert not [
+        name
+        for shape in schema["$defs"].values()
+        for name in shape.get("properties", {})
+        if name in {"material", "plaintext", "secret_value"}
+    ]

--- a/core/agent/modules/context-stack/tests/test_enforcement.py
+++ b/core/agent/modules/context-stack/tests/test_enforcement.py
@@ -1,0 +1,180 @@
+"""L2 — enforcement, tested adversarially: every way a non-member might reach group context.
+
+The rule is one sentence — a non-member must never read group context — and the tests are the
+ways round it: resolve a stack, read the workspace, read a document, read the queue, propose into
+it, decide in it, add yourself to it. Each is refused with a stable code.
+
+The default-deny half is proved by exhausting the decision table rather than by sampling it.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from context_stack import (
+    AccessDenied,
+    Action,
+    ContextDelta,
+    Destination,
+    InvalidWorkspace,
+    Policy,
+    Role,
+    add_member,
+    decide,
+    land_delta,
+    pending_proposals,
+    remove_member,
+    resolve_stack,
+)
+from context_stack.api import _readable
+
+from conftest import MEMBER, OUTSIDER, OWNER
+
+
+async def test_every_route_to_a_group_is_closed_to_a_non_member(store, make_workspace):
+    """Seven attempts, one workspace, zero reachable."""
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await land_delta(
+        store,
+        ContextDelta(
+            workspace_id="acme", path="kg/pricing.md", body="secret plan", author_subject=MEMBER
+        ),
+    )
+
+    # 1. the composed stack does not contain it
+    stack = await resolve_stack(store, subject=OUTSIDER)
+    assert "acme" not in stack.workspace_ids
+
+    # 2. reading the workspace itself
+    with pytest.raises(AccessDenied) as workspace_read:
+        await _readable(store, "acme", OUTSIDER)
+    assert workspace_read.value.decision.reason == "not-member"
+
+    # 3. the read decision, directly
+    assert not decide(
+        subject=OUTSIDER, workspace_id="acme", policy=Policy.GROUP, role=None, action=Action.READ
+    ).allow
+
+    # 4. reading the proposal queue
+    with pytest.raises(AccessDenied):
+        await pending_proposals(store, workspace_id="acme", actor=OUTSIDER)
+
+    # 5. writing into it
+    landed = await land_delta(
+        store,
+        ContextDelta(workspace_id="acme", path="kg/x.md", body="x", author_subject=OUTSIDER),
+    )
+    assert landed.routing.destination is Destination.REFUSED
+
+    # 6. adding themselves to it
+    with pytest.raises(AccessDenied) as self_add:
+        await add_member(store, workspace_id="acme", subject=OUTSIDER, actor=OUTSIDER)
+    assert self_add.value.decision.reason == "not-owner"
+
+    # 7. a member cannot let them in either — sharing is the owner's
+    with pytest.raises(AccessDenied) as member_add:
+        await add_member(store, workspace_id="acme", subject=OUTSIDER, actor=MEMBER)
+    assert member_add.value.decision.reason == "not-owner"
+
+
+async def test_one_users_personal_layer_is_closed_to_another(store, make_workspace):
+    """Personal is read/write for its owner and nobody else — it is not a small group."""
+    await make_workspace("personal-o", Policy.PERSONAL, OWNER)
+
+    with pytest.raises(AccessDenied) as raised:
+        await _readable(store, "personal-o", MEMBER)
+
+    assert raised.value.decision.reason == "not-member"
+
+
+async def test_user_system_is_never_sharable(store, make_workspace):
+    """Hidden, one per user, never shared. Sharing it is refused at the layer, not per workspace."""
+    await make_workspace("system-o", Policy.USER_SYSTEM, OWNER)
+
+    with pytest.raises(AccessDenied) as raised:
+        await add_member(store, workspace_id="system-o", subject=MEMBER, actor=OWNER)
+
+    assert raised.value.decision.reason == "layer-not-sharable"
+
+
+async def test_personal_cannot_take_a_second_member(store, make_workspace):
+    """"The user is not a group": a personal workspace is the one-member case, so there is no
+    second seat. A workspace that needs two members is a group workspace."""
+    await make_workspace("personal-o", Policy.PERSONAL, OWNER)
+
+    with pytest.raises(AccessDenied) as raised:
+        await add_member(store, workspace_id="personal-o", subject=MEMBER, actor=OWNER)
+
+    assert raised.value.decision.reason == "personal-is-not-a-group"
+    assert await store.member_count("personal-o") == 1
+
+
+async def test_global_is_readable_by_everyone_and_writable_by_nobody(store, make_workspace):
+    """Product-level knowledge: mounted by every stack, owned by us, changed by neither."""
+    await make_workspace("global", Policy.GLOBAL, "vexa")
+
+    assert (await _readable(store, "global", OUTSIDER)).policy is Policy.GLOBAL
+    assert not decide(
+        subject="vexa",
+        workspace_id="global",
+        policy=Policy.GLOBAL,
+        role=Role.OWNER,
+        action=Action.WRITE,
+    ).allow
+    with pytest.raises(AccessDenied):
+        await add_member(store, workspace_id="global", subject=OUTSIDER, actor="vexa")
+
+
+async def test_the_owners_seat_cannot_be_removed(store, make_workspace):
+    """A workspace with no owner has nobody to triage it, and its queue silently stops being
+    answerable."""
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+
+    with pytest.raises(InvalidWorkspace):
+        await remove_member(store, workspace_id="acme", subject=OWNER, actor=OWNER)
+
+    assert await store.role_of(workspace_id="acme", subject=OWNER) is Role.OWNER
+    assert await remove_member(store, workspace_id="acme", subject=MEMBER, actor=OWNER)
+
+
+def test_the_decision_table_denies_by_default():
+    """Exhaust it: every (policy, role, action) triple resolves to an explicit allow rule or a
+    refusal with a named reason. No combination falls through to an accidental allow."""
+    allowed = set()
+    for policy, role, action in itertools.product(Policy, (None, Role.MEMBER, Role.OWNER), Action):
+        verdict = decide(
+            subject="s", workspace_id="w", policy=policy, role=role, action=action
+        )
+        assert verdict.reason, f"{policy}/{role}/{action} has no reason code"
+        if verdict.allow:
+            allowed.add((policy, role, action))
+
+    # The complete allow-list, written out. A new allow anywhere changes this set, and changing
+    # it is the point at which someone has to justify the new permission.
+    assert allowed == {
+        # global: everyone reads, nobody writes, nobody shares, and its credentials are
+        # deployment config rather than rows — so not even its owner sets a secret here
+        (Policy.GLOBAL, None, Action.READ),
+        (Policy.GLOBAL, Role.MEMBER, Action.READ),
+        (Policy.GLOBAL, Role.OWNER, Action.READ),
+        # group: members read and write (via triage), the owner also triages, shares, holds keys
+        (Policy.GROUP, Role.MEMBER, Action.READ),
+        (Policy.GROUP, Role.MEMBER, Action.WRITE),
+        (Policy.GROUP, Role.OWNER, Action.READ),
+        (Policy.GROUP, Role.OWNER, Action.WRITE),
+        (Policy.GROUP, Role.OWNER, Action.TRIAGE),
+        (Policy.GROUP, Role.OWNER, Action.SECRETS),
+        (Policy.GROUP, Role.OWNER, Action.SHARE),
+        # personal: the owner's, and only theirs
+        (Policy.PERSONAL, Role.MEMBER, Action.READ),
+        (Policy.PERSONAL, Role.MEMBER, Action.WRITE),
+        (Policy.PERSONAL, Role.OWNER, Action.READ),
+        (Policy.PERSONAL, Role.OWNER, Action.WRITE),
+        (Policy.PERSONAL, Role.OWNER, Action.SECRETS),
+        # user-system: read only. No context delta writes it, and it holds no external
+        # credentials ever — so SECRETS is absent for every role, including the owner's
+        (Policy.USER_SYSTEM, Role.MEMBER, Action.READ),
+        (Policy.USER_SYSTEM, Role.OWNER, Action.READ),
+    }

--- a/core/agent/modules/context-stack/tests/test_repointing.py
+++ b/core/agent/modules/context-stack/tests/test_repointing.py
@@ -1,0 +1,107 @@
+"""L2 — the loose-coupling ruling: a user can be re-pointed at a different personal workspace.
+
+Slots are pointers, not foreign-key constraints. Re-pointing has to work in the *product* path,
+not only in free composition — it is how a personal workspace is migrated, and an ordinary user
+must not have to see composition for it to happen.
+"""
+
+from __future__ import annotations
+
+from context_stack import ContextDelta, Destination, Mode, Policy, land_delta, resolve_stack
+from context_stack.workspaces import ensure_personal
+
+from conftest import OWNER
+
+
+async def test_repointing_personal_changes_the_pinned_stack(store, make_workspace):
+    """The ruling, in the product path. No pointer → the user's own personal workspace; a pointer
+    → the workspace it names, in pinned mode as well as free."""
+    original = await ensure_personal(store, subject=OWNER, address=f"p-{OWNER}@vexa.ai")
+
+    before = await resolve_stack(store, subject=OWNER)
+    assert before.at(Policy.PERSONAL)[0].workspace_id == original.id
+
+    replacement = await make_workspace("personal-new", Policy.PERSONAL, OWNER)
+    await store.set_pointer(
+        subject=OWNER, slot=Policy.PERSONAL, workspace_id=replacement.id
+    )
+    await store.commit()
+
+    for mode in (Mode.PINNED, Mode.FREE):
+        after = await resolve_stack(store, subject=OWNER, mode=mode)
+        assert after.at(Policy.PERSONAL)[0].workspace_id == "personal-new"
+        assert len(after.at(Policy.PERSONAL)) == 1
+
+
+async def test_repointing_moves_where_personal_writes_land(store, make_workspace):
+    """A re-pointed slot is not cosmetic: the delta goes to the workspace the stack now names."""
+    await ensure_personal(store, subject=OWNER, address=f"p-{OWNER}@vexa.ai")
+    await make_workspace("personal-new", Policy.PERSONAL, OWNER)
+    await store.set_pointer(subject=OWNER, slot=Policy.PERSONAL, workspace_id="personal-new")
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=OWNER)
+    target = stack.at(Policy.PERSONAL)[0].workspace_id
+    landed = await land_delta(
+        store,
+        ContextDelta(
+            workspace_id=target, path="notes/x.md", body="after the move", author_subject=OWNER
+        ),
+    )
+
+    assert landed.routing.destination is Destination.DIRECT
+    assert (
+        await store.current_revision(workspace_id="personal-new", path="notes/x.md")
+    ).body == "after the move"
+
+
+async def test_repointing_replaces_rather_than_accumulates(store, make_workspace):
+    """A singleton slot holds one pointer. Re-pointing twice leaves one, not three."""
+    await ensure_personal(store, subject=OWNER, address=f"p-{OWNER}@vexa.ai")
+    await make_workspace("personal-a", Policy.PERSONAL, OWNER)
+    await make_workspace("personal-b", Policy.PERSONAL, OWNER)
+
+    await store.set_pointer(subject=OWNER, slot=Policy.PERSONAL, workspace_id="personal-a")
+    await store.set_pointer(subject=OWNER, slot=Policy.PERSONAL, workspace_id="personal-b")
+    await store.commit()
+
+    pointers = [p for p in await store.pointers(OWNER) if p.slot is Policy.PERSONAL]
+    stack = await resolve_stack(store, subject=OWNER)
+
+    assert [p.workspace_id for p in pointers] == ["personal-b"]
+    assert stack.at(Policy.PERSONAL)[0].workspace_id == "personal-b"
+
+
+async def test_a_pointer_survives_its_target_being_absent(store, make_workspace):
+    """No foreign key, on purpose. Pointing at a workspace this deployment does not hold is a row
+    that inserts and a resolution that reports — not an integrity error at write time."""
+    await ensure_personal(store, subject=OWNER, address=f"p-{OWNER}@vexa.ai")
+
+    await store.set_pointer(
+        subject=OWNER, slot=Policy.PERSONAL, workspace_id="not-provisioned-yet"
+    )
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=OWNER)
+
+    assert stack.at(Policy.PERSONAL) == ()
+    assert [
+        (d.workspace_id, d.reason) for d in stack.denied if d.layer is Policy.PERSONAL
+    ] == [("not-provisioned-yet", "dangling-pointer")]
+
+
+async def test_user_system_can_be_repointed_too(store, make_workspace):
+    """The same mechanism on the other hidden singleton — one rule, not a personal special case."""
+    from context_stack.workspaces import ensure_user_system
+
+    await ensure_user_system(store, subject=OWNER, address=f"s-{OWNER}@vexa.ai")
+    await make_workspace("system-new", Policy.USER_SYSTEM, OWNER)
+
+    await store.set_pointer(
+        subject=OWNER, slot=Policy.USER_SYSTEM, workspace_id="system-new"
+    )
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=OWNER)
+
+    assert stack.at(Policy.USER_SYSTEM)[0].workspace_id == "system-new"

--- a/core/agent/modules/context-stack/tests/test_resolution.py
+++ b/core/agent/modules/context-stack/tests/test_resolution.py
@@ -1,0 +1,195 @@
+"""L2 — stack resolution: member, non-member, multi-group, no-group, and the pinned/free split.
+
+Proves the composition resolver returns the four layers in order, as pointers, with the group slot
+holding exactly what the subject is entitled to and nothing else.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from context_stack import Mode, Policy, Write, resolve_stack
+from context_stack.workspaces import ensure_personal, ensure_user_system
+
+from conftest import MEMBER, OUTSIDER, OWNER
+
+
+async def _provision(store, make_workspace, subject: str) -> None:
+    """Global (once), plus the two singleton layers every user has."""
+    if await store.global_workspace() is None:
+        await make_workspace("global", Policy.GLOBAL, "vexa")
+    await ensure_personal(store, subject=subject, address=f"personal-{subject}@vexa.ai")
+    await ensure_user_system(store, subject=subject, address=f"system-{subject}@vexa.ai")
+
+
+async def test_no_group_resolves_to_three_layers(store, make_workspace):
+    """The participant case: someone in no group still gets global → personal → user-system."""
+    await _provision(store, make_workspace, OUTSIDER)
+
+    stack = await resolve_stack(store, subject=OUTSIDER)
+
+    assert [s.layer for s in stack.slots] == [
+        Policy.GLOBAL,
+        Policy.PERSONAL,
+        Policy.USER_SYSTEM,
+    ]
+    assert stack.at(Policy.GROUP) == ()
+    assert stack.denied == ()
+
+
+async def test_member_gets_the_group_layer_in_stack_order(store, make_workspace):
+    """A member's stack carries the group between global and personal."""
+    await _provision(store, make_workspace, MEMBER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+
+    stack = await resolve_stack(store, subject=MEMBER)
+
+    assert [s.layer for s in stack.slots] == [
+        Policy.GLOBAL,
+        Policy.GROUP,
+        Policy.PERSONAL,
+        Policy.USER_SYSTEM,
+    ]
+    assert stack.at(Policy.GROUP)[0].workspace_id == "acme"
+
+
+async def test_non_member_never_sees_the_group(store, make_workspace):
+    """The enforcement case. A group exists; the outsider's stack does not contain it."""
+    await _provision(store, make_workspace, OUTSIDER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+
+    stack = await resolve_stack(store, subject=OUTSIDER)
+
+    assert stack.at(Policy.GROUP) == ()
+    assert "acme" not in stack.workspace_ids
+
+
+async def test_multi_group_composes_every_membership(store, make_workspace):
+    """Several groups all mount, in a deterministic order."""
+    await _provision(store, make_workspace, MEMBER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await make_workspace("beta", Policy.GROUP, OWNER, members=(MEMBER,))
+    await make_workspace("gamma", Policy.GROUP, OWNER)  # not a member
+
+    stack = await resolve_stack(store, subject=MEMBER)
+
+    assert [s.workspace_id for s in stack.at(Policy.GROUP)] == ["acme", "beta"]
+
+
+async def test_slots_carry_the_layer_rules_not_content(store, make_workspace):
+    """A slot is a pointer plus its layer's access rules — the spec's table, per slot."""
+    await _provision(store, make_workspace, MEMBER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+
+    stack = await resolve_stack(store, subject=MEMBER)
+    by_layer = {s.layer: s for s in stack.slots}
+
+    assert (by_layer[Policy.GLOBAL].write, by_layer[Policy.GLOBAL].hidden) == (Write.NONE, True)
+    assert by_layer[Policy.GROUP].write is Write.VIA_TRIAGE
+    assert by_layer[Policy.GROUP].sharable is True
+    assert by_layer[Policy.PERSONAL].write is Write.DIRECT
+    assert by_layer[Policy.PERSONAL].sharable is False
+    assert (
+        by_layer[Policy.USER_SYSTEM].write,
+        by_layer[Policy.USER_SYSTEM].hidden,
+        by_layer[Policy.USER_SYSTEM].sharable,
+    ) == (Write.PLATFORM_ONLY, True, False)
+    assert not any(hasattr(s, "body") for s in stack.slots)
+
+
+async def test_free_mode_composes_a_subset_of_the_groups_you_belong_to(store, make_workspace):
+    """Free composition: pointers pick which groups mount, and in what order."""
+    await _provision(store, make_workspace, MEMBER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await make_workspace("beta", Policy.GROUP, OWNER, members=(MEMBER,))
+    await store.set_pointer(
+        subject=MEMBER, slot=Policy.GROUP, workspace_id="beta", position=0
+    )
+    await store.commit()
+
+    free = await resolve_stack(store, subject=MEMBER, mode=Mode.FREE)
+    pinned = await resolve_stack(store, subject=MEMBER, mode=Mode.PINNED)
+
+    assert [s.workspace_id for s in free.at(Policy.GROUP)] == ["beta"]
+    assert [s.workspace_id for s in pinned.at(Policy.GROUP)] == ["acme", "beta"]
+
+
+async def test_pinned_mode_ignores_group_pointers(store, make_workspace):
+    """The product's composition is not reshapeable by a stored row — the pinned half of the
+    'loosely coupled by schema, pinned by product' ruling."""
+    await _provision(store, make_workspace, MEMBER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await make_workspace("beta", Policy.GROUP, OWNER, members=(MEMBER,))
+    await store.set_pointer(subject=MEMBER, slot=Policy.GROUP, workspace_id="beta")
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=MEMBER, mode=Mode.PINNED)
+
+    assert [s.workspace_id for s in stack.at(Policy.GROUP)] == ["acme", "beta"]
+
+
+async def test_free_pointer_at_a_group_you_are_not_in_is_denied(store, make_workspace):
+    """Adversarial: composing your way into someone else's group. The slot is dropped and the
+    refusal is recorded rather than swallowed."""
+    await _provision(store, make_workspace, OUTSIDER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await store.set_pointer(subject=OUTSIDER, slot=Policy.GROUP, workspace_id="acme")
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=OUTSIDER, mode=Mode.FREE)
+
+    assert stack.at(Policy.GROUP) == ()
+    assert [(d.workspace_id, d.reason) for d in stack.denied] == [("acme", "not-member")]
+
+
+async def test_pointer_at_the_wrong_layer_is_denied(store, make_workspace):
+    """Policy is the layer: a group workspace cannot be mounted into the personal slot."""
+    await _provision(store, make_workspace, MEMBER)
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await store.set_pointer(subject=MEMBER, slot=Policy.PERSONAL, workspace_id="acme")
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=MEMBER, mode=Mode.FREE)
+
+    assert [(d.workspace_id, d.reason) for d in stack.denied] == [("acme", "policy-mismatch")]
+    assert stack.at(Policy.PERSONAL) == ()
+
+
+async def test_dangling_pointer_reports_rather_than_raises(store, make_workspace):
+    """Pointers carry no foreign key on purpose; a target this deployment does not hold is a
+    resolvable condition, and the rest of the stack still resolves."""
+    await _provision(store, make_workspace, MEMBER)
+    await store.set_pointer(subject=MEMBER, slot=Policy.GROUP, workspace_id="ghost")
+    await store.commit()
+
+    stack = await resolve_stack(store, subject=MEMBER, mode=Mode.FREE)
+
+    assert [(d.workspace_id, d.reason) for d in stack.denied] == [("ghost", "dangling-pointer")]
+    assert [s.layer for s in stack.slots] == [
+        Policy.GLOBAL,
+        Policy.PERSONAL,
+        Policy.USER_SYSTEM,
+    ]
+
+
+async def test_missing_personal_is_reported_not_fatal(store, make_workspace):
+    """Personal is supposed to exist for everyone. When it does not, the gap is named and the
+    remaining layers still resolve."""
+    await make_workspace("global", Policy.GLOBAL, "vexa")
+
+    stack = await resolve_stack(store, subject=OUTSIDER)
+
+    reasons = {d.reason for d in stack.denied}
+    assert reasons == {"personal-not-provisioned", "user-system-not-provisioned"}
+    assert [s.layer for s in stack.slots] == [Policy.GLOBAL]
+
+
+@pytest.mark.parametrize("mode", [Mode.PINNED, Mode.FREE])
+async def test_global_is_mounted_by_everyone(store, make_workspace, mode):
+    """Global is product-level knowledge: every stack has it, nobody is a member of it."""
+    await _provision(store, make_workspace, OUTSIDER)
+
+    stack = await resolve_stack(store, subject=OUTSIDER, mode=mode)
+
+    assert stack.at(Policy.GLOBAL)[0].workspace_id == "global"
+    assert await store.role_of(workspace_id="global", subject=OUTSIDER) is None

--- a/core/agent/modules/context-stack/tests/test_routing.py
+++ b/core/agent/modules/context-stack/tests/test_routing.py
@@ -1,0 +1,160 @@
+"""L2 — the write router: policy decides where a delta lands, both ways.
+
+Group-policy content goes to the proposal queue and stays there; personal-policy content goes
+into context directly. The two refusing layers are proved too, because a router that only ever
+says yes has no table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from context_stack import ContextDelta, Destination, Policy, Write, land_delta, route
+from context_stack.layers import RULES
+
+from conftest import MEMBER, OUTSIDER, OWNER
+
+
+# ── the table, without a database ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("policy", "member", "destination", "reason"),
+    [
+        (Policy.PERSONAL, True, Destination.DIRECT, "personal-policy-writes-direct"),
+        (Policy.GROUP, True, Destination.PROPOSAL, "group-policy-routes-to-triage"),
+        (Policy.GROUP, False, Destination.REFUSED, "not-member"),
+        (Policy.PERSONAL, False, Destination.REFUSED, "not-member"),
+        (Policy.GLOBAL, True, Destination.REFUSED, "global-is-read-only"),
+        (Policy.USER_SYSTEM, True, Destination.REFUSED, "user-system-is-platform-only"),
+    ],
+)
+def test_routing_table(policy, member, destination, reason):
+    """Every cell of the routing table, as a pure function of policy and membership."""
+    routing = route(policy=policy, workspace_id="w", member=member)
+    assert (routing.destination, routing.reason) == (destination, reason)
+
+
+def test_no_layer_routes_a_group_write_direct():
+    """The invariant the split of policy-and-layer into one field exists to protect: nothing can
+    be at the group layer and take direct writes."""
+    for policy, rules in RULES.items():
+        if policy is Policy.GROUP:
+            assert rules.write is Write.VIA_TRIAGE
+        else:
+            assert rules.write is not Write.VIA_TRIAGE
+
+
+# ── the same table, against the store ─────────────────────────────────────────────────────────
+
+
+async def test_personal_delta_lands_in_context_immediately(store, make_workspace):
+    """Personal-policy content → personal context directly."""
+    await make_workspace("personal-o", Policy.PERSONAL, OWNER)
+
+    landed = await land_delta(
+        store,
+        ContextDelta(
+            workspace_id="personal-o",
+            path="notes/acme.md",
+            body="They run Teams, not Meet.",
+            author_subject=OWNER,
+            source_ref="meeting-42",
+        ),
+    )
+
+    assert landed.routing.destination is Destination.DIRECT
+    assert landed.proposal is None
+    current = await store.current_revision(workspace_id="personal-o", path="notes/acme.md")
+    assert current.revision == 1
+    assert current.body == "They run Teams, not Meet."
+
+
+async def test_group_delta_lands_in_the_queue_and_not_in_context(store, make_workspace):
+    """Group-policy content → the proposal queue. PR-style, never direct: the document does not
+    exist in the group's context until an owner says so."""
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+
+    landed = await land_delta(
+        store,
+        ContextDelta(
+            workspace_id="acme",
+            path="kg/pricing.md",
+            body="Renewal moved to Q3.",
+            author_subject=MEMBER,
+            source_ref="meeting-42",
+        ),
+    )
+
+    assert landed.routing.destination is Destination.PROPOSAL
+    assert landed.revision is None
+    assert landed.proposal.state == "pending"
+    assert await store.current_revision(workspace_id="acme", path="kg/pricing.md") is None
+
+
+async def test_a_hundred_group_deltas_accept_none_of_themselves(store, make_workspace):
+    """The machine path has a ceiling. However much a meeting produces, nothing is accepted —
+    acceptance is a human act and no volume of machine writes reaches it."""
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+
+    for i in range(100):
+        await land_delta(
+            store,
+            ContextDelta(
+                workspace_id="acme", path=f"kg/{i}.md", body=str(i), author_subject=MEMBER
+            ),
+        )
+
+    assert len(await store.proposals(workspace_id="acme", state="pending")) == 100
+    assert await store.proposals(workspace_id="acme", state="accepted") == ()
+    assert await store.documents("acme") == ()
+
+
+async def test_appending_to_the_same_path_makes_a_new_revision(store, make_workspace):
+    """Context is append-only: a second write supersedes, and the first is still readable."""
+    await make_workspace("personal-o", Policy.PERSONAL, OWNER)
+    delta = ContextDelta(
+        workspace_id="personal-o", path="notes/acme.md", body="v1", author_subject=OWNER
+    )
+    await land_delta(store, delta)
+    await land_delta(store, ContextDelta(**{**vars(delta), "body": "v2"}))
+
+    history = await store.revisions(workspace_id="personal-o", path="notes/acme.md")
+
+    assert [(r.revision, r.body) for r in history] == [(1, "v1"), (2, "v2")]
+
+
+async def test_outsider_cannot_even_propose(store, make_workspace):
+    """A queue anyone may fill is a queue the owner stops reading."""
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+
+    landed = await land_delta(
+        store,
+        ContextDelta(
+            workspace_id="acme", path="kg/x.md", body="spam", author_subject=OUTSIDER
+        ),
+    )
+
+    assert landed.routing.destination is Destination.REFUSED
+    assert landed.routing.reason == "not-member"
+    assert await store.proposals(workspace_id="acme") == ()
+
+
+async def test_global_and_user_system_refuse_context_deltas(store, make_workspace):
+    """Global is ours and read-only; user-system is the platform's to write."""
+    await make_workspace("global", Policy.GLOBAL, "vexa")
+    await make_workspace("system-o", Policy.USER_SYSTEM, OWNER)
+
+    for workspace_id, reason in (
+        ("global", "global-is-read-only"),
+        ("system-o", "user-system-is-platform-only"),
+    ):
+        landed = await land_delta(
+            store,
+            ContextDelta(
+                workspace_id=workspace_id, path="x.md", body="b", author_subject=OWNER
+            ),
+        )
+        assert landed.routing.destination is Destination.REFUSED
+        assert landed.routing.reason == reason
+        assert await store.documents(workspace_id) == ()

--- a/core/agent/modules/context-stack/tests/test_secrets.py
+++ b/core/agent/modules/context-stack/tests/test_secrets.py
@@ -1,0 +1,195 @@
+"""L2 — the write-only secret surface: set → rotate → read metadata, and no path to the value.
+
+The strong test here is not that a particular function withholds the material; it is that the
+whole surface has nowhere to put it. The types are enumerated, the module's public functions are
+enumerated, and their returns are searched for the value.
+
+``tests/test_api_surface.py`` does the same over the HTTP routes.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import inspect
+
+import pytest
+
+from context_stack import (
+    AccessDenied,
+    InvalidWorkspace,
+    NotFound,
+    Policy,
+    SecretMetadata,
+    get_metadata,
+    list_metadata,
+    secrets as secrets_surface,
+    set_secret,
+    delete_secret,
+)
+from context_stack.material import REDACTED, use_material
+
+from conftest import MEMBER, OUTSIDER, OWNER
+
+KEY = "sk-live-000000000000cafe"
+ROTATED = "sk-live-111111111111beef"
+
+
+async def test_set_rotate_and_read_metadata(store, make_workspace):
+    """The whole owner-facing lifecycle. Rotation bumps the version and moves last-4; neither
+    call, at any point, hands back a key."""
+    await make_workspace("acme", Policy.GROUP, OWNER)
+
+    first = await set_secret(
+        store, workspace_id="acme", name="llm_api_key", material=KEY, actor=OWNER
+    )
+    assert (first.last4, first.version, first.rotated_at) == ("cafe", 1, None)
+
+    second = await set_secret(
+        store, workspace_id="acme", name="llm_api_key", material=ROTATED, actor=OWNER
+    )
+    assert (second.last4, second.version) == ("beef", 2)
+    assert second.rotated_at is not None
+
+    read = await get_metadata(store, workspace_id="acme", name="llm_api_key", actor=OWNER)
+    assert (read.last4, read.version, read.set_by) == ("beef", 2, OWNER)
+
+    assert await delete_secret(store, workspace_id="acme", name="llm_api_key", actor=OWNER)
+    with pytest.raises(NotFound):
+        await get_metadata(store, workspace_id="acme", name="llm_api_key", actor=OWNER)
+
+
+def test_the_metadata_type_has_nowhere_to_put_a_secret():
+    """The surface is write-only because of the type, not because of the callers."""
+    fields = {f.name for f in dataclasses.fields(SecretMetadata)}
+
+    assert fields == {
+        "workspace_id",
+        "name",
+        "last4",
+        "version",
+        "set_by",
+        "set_at",
+        "rotated_at",
+    }
+    assert not fields & {"material", "value", "secret", "plaintext", "key"}
+
+
+async def test_no_function_on_the_surface_returns_the_value(store, make_workspace):
+    """Enumerate the module's public functions, call each, and search every return for the key.
+
+    This is the check that would have caught the settings-read defect this design inverts: the
+    question is not whether one endpoint leaks, it is whether any of them do.
+    """
+    await make_workspace("acme", Policy.GROUP, OWNER)
+    await set_secret(store, workspace_id="acme", name="llm_api_key", material=KEY, actor=OWNER)
+
+    public = [
+        name
+        for name, obj in vars(secrets_surface).items()
+        if inspect.iscoroutinefunction(obj) and not name.startswith("_")
+    ]
+    assert set(public) == {"set_secret", "delete_secret", "get_metadata", "list_metadata"}
+
+    results = [
+        await get_metadata(store, workspace_id="acme", name="llm_api_key", actor=OWNER),
+        await list_metadata(store, workspace_id="acme", actor=OWNER),
+        await set_secret(
+            store, workspace_id="acme", name="llm_api_key", material=KEY, actor=OWNER
+        ),
+        await delete_secret(store, workspace_id="acme", name="llm_api_key", actor=OWNER),
+    ]
+
+    for result in results:
+        assert KEY not in repr(result)
+        assert KEY not in str(result)
+
+
+async def test_only_the_owner_touches_secrets(store, make_workspace):
+    """Secrets are one of the four things an owner does. A member is not an owner."""
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    await set_secret(store, workspace_id="acme", name="llm_api_key", material=KEY, actor=OWNER)
+
+    for actor in (MEMBER, OUTSIDER):
+        with pytest.raises(AccessDenied) as write:
+            await set_secret(
+                store, workspace_id="acme", name="llm_api_key", material="hijacked-key", actor=actor
+            )
+        with pytest.raises(AccessDenied) as read:
+            await get_metadata(store, workspace_id="acme", name="llm_api_key", actor=actor)
+        assert write.value.decision.reason == "not-owner"
+        assert read.value.decision.reason == "not-owner"
+
+
+async def test_the_user_system_layer_holds_no_credentials_ever(store, make_workspace):
+    """A spec property of the layer, enforced as one: not even the owner can put a key there."""
+    await make_workspace("system-o", Policy.USER_SYSTEM, OWNER)
+
+    with pytest.raises(AccessDenied) as raised:
+        await set_secret(
+            store, workspace_id="system-o", name="llm_api_key", material=KEY, actor=OWNER
+        )
+
+    assert raised.value.decision.reason == "user-system-holds-no-credentials"
+
+
+async def test_global_secrets_are_deployment_config(store, make_workspace):
+    """Ours, and they live in a k8s Secret or a chart value — not in a workspace row."""
+    await make_workspace("global", Policy.GLOBAL, "vexa")
+
+    with pytest.raises(AccessDenied) as raised:
+        await set_secret(
+            store, workspace_id="global", name="llm_api_key", material=KEY, actor="vexa"
+        )
+
+    assert raised.value.decision.reason == "global-secrets-are-deployment-config"
+
+
+async def test_a_short_secret_is_refused(store, make_workspace):
+    """Below the minimum, last-4 would be most of the key — and a key that short is a typo."""
+    await make_workspace("acme", Policy.GROUP, OWNER)
+
+    with pytest.raises(InvalidWorkspace):
+        await set_secret(store, workspace_id="acme", name="llm_api_key", material="abc", actor=OWNER)
+
+
+async def test_the_one_reader_wraps_what_it_returns(store, make_workspace):
+    """Material is readable exactly once, at call time, through a handle that keeps itself out of
+    logs: repr, str and format are all redacted, and ``reveal()`` is one grep from an audit."""
+    await make_workspace("acme", Policy.GROUP, OWNER)
+    await set_secret(store, workspace_id="acme", name="llm_api_key", material=KEY, actor=OWNER)
+
+    handle = await use_material(
+        store, workspace_id="acme", name="llm_api_key", purpose="llm-dispatch"
+    )
+
+    assert handle.reveal() == KEY
+    assert KEY not in repr(handle)
+    assert KEY not in str(handle)
+    assert KEY not in f"{handle}"
+    assert REDACTED in f"{handle}"
+    assert handle.purpose == "llm-dispatch"
+
+
+def test_the_management_surface_does_not_import_the_reader():
+    """``secrets.py`` manages; ``material.py`` reads. The separation is what makes the import
+    graph — rather than a code review — the thing that keeps a value out of a response.
+
+    Read from the parse tree: the docstring names the other module on purpose, and prose about
+    the rule is not a violation of it.
+    """
+    tree = ast.parse(inspect.getsource(secrets_surface))
+
+    imported = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)} | {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    }
+
+    assert not [m for m in imported if m and "material" in m]
+    assert "use_material" not in referenced
+    assert "Material" not in referenced

--- a/core/agent/modules/context-stack/tests/test_triage.py
+++ b/core/agent/modules/context-stack/tests/test_triage.py
@@ -1,0 +1,200 @@
+"""L2/L3 — owner triage: accept, reject, and the guards that keep a machine out of both.
+
+The rule under test is "no machine ever writes acknowledgement". It is enforced three ways and
+each is proved separately here: the actor is required and must be the owner; the machine path in
+``router.py`` has no import of the triage module; and the table refuses a decided row that does
+not name a human.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+
+import pytest
+from sqlalchemy import text
+
+from context_stack import (
+    AccessDenied,
+    ContextDelta,
+    Policy,
+    ProposalAlreadyDecided,
+    accept_proposal,
+    land_delta,
+    pending_proposals,
+    reject_proposal,
+    router,
+    triage,
+)
+
+from conftest import MEMBER, OUTSIDER, OWNER
+
+
+async def _proposed(store, make_workspace, body: str = "Renewal moved to Q3."):
+    await make_workspace("acme", Policy.GROUP, OWNER, members=(MEMBER,))
+    landed = await land_delta(
+        store,
+        ContextDelta(
+            workspace_id="acme",
+            path="kg/pricing.md",
+            body=body,
+            author_subject=MEMBER,
+            source_ref="meeting-42",
+        ),
+    )
+    return landed.proposal
+
+
+async def test_accept_applies_the_delta_to_group_context(store, make_workspace):
+    """Accept is the only way group context gains a revision."""
+    proposal = await _proposed(store, make_workspace)
+
+    landed = await accept_proposal(store, proposal_id=proposal.id, actor=OWNER, note="checked")
+
+    current = await store.current_revision(workspace_id="acme", path="kg/pricing.md")
+    assert current.body == "Renewal moved to Q3."
+    assert current.from_proposal_id == proposal.id
+    assert landed.proposal.state == "accepted"
+    assert landed.proposal.decided_by == OWNER
+    assert landed.proposal.decided_at is not None
+
+
+async def test_accepted_revision_credits_the_proposer_and_the_decider(store, make_workspace):
+    """Two people, both named: who wrote the knowledge, and who let it in."""
+    proposal = await _proposed(store, make_workspace)
+
+    landed = await accept_proposal(store, proposal_id=proposal.id, actor=OWNER)
+
+    assert landed.revision.author_subject == MEMBER
+    assert landed.revision.source_kind == "triage"
+    assert landed.proposal.decided_by == OWNER
+
+
+async def test_reject_leaves_context_untouched_and_keeps_the_record(store, make_workspace):
+    """Rejection writes nothing to context and loses nothing from the record."""
+    proposal = await _proposed(store, make_workspace)
+
+    decided = await reject_proposal(
+        store, proposal_id=proposal.id, actor=OWNER, note="already covered"
+    )
+
+    assert decided.state == "rejected"
+    assert decided.decided_by == OWNER
+    assert decided.decision_note == "already covered"
+    assert await store.current_revision(workspace_id="acme", path="kg/pricing.md") is None
+    assert decided.body == "Renewal moved to Q3."
+
+
+async def test_a_member_may_propose_but_not_decide(store, make_workspace):
+    """Triage is one of the four things an owner does. A member's write is a proposal, full stop."""
+    proposal = await _proposed(store, make_workspace)
+
+    with pytest.raises(AccessDenied) as accepted:
+        await accept_proposal(store, proposal_id=proposal.id, actor=MEMBER)
+    with pytest.raises(AccessDenied) as rejected:
+        await reject_proposal(store, proposal_id=proposal.id, actor=MEMBER)
+
+    assert accepted.value.decision.reason == "not-owner"
+    assert rejected.value.decision.reason == "not-owner"
+    assert (await store.get_proposal(proposal.id)).state == "pending"
+
+
+async def test_an_outsider_cannot_decide_or_even_read_the_queue(store, make_workspace):
+    """Adversarial: the queue is a view of what a group's members are writing."""
+    proposal = await _proposed(store, make_workspace)
+
+    with pytest.raises(AccessDenied) as decided:
+        await accept_proposal(store, proposal_id=proposal.id, actor=OUTSIDER)
+    with pytest.raises(AccessDenied) as read:
+        await pending_proposals(store, workspace_id="acme", actor=OUTSIDER)
+
+    assert decided.value.decision.reason == "not-owner"
+    assert read.value.decision.reason == "not-owner"
+
+
+async def test_a_decided_proposal_is_final(store, make_workspace):
+    """Re-deciding would overwrite one human's answer with another's under the same id."""
+    proposal = await _proposed(store, make_workspace)
+    await accept_proposal(store, proposal_id=proposal.id, actor=OWNER)
+
+    with pytest.raises(ProposalAlreadyDecided):
+        await reject_proposal(store, proposal_id=proposal.id, actor=OWNER)
+
+
+async def test_the_owners_queue_holds_only_pending_work(store, make_workspace):
+    """What the owner is asked to look at shrinks as they answer it."""
+    first = await _proposed(store, make_workspace, body="one")
+    landed = await land_delta(
+        store,
+        ContextDelta(
+            workspace_id="acme", path="kg/other.md", body="two", author_subject=MEMBER
+        ),
+    )
+
+    await accept_proposal(store, proposal_id=first.id, actor=OWNER)
+    queue = await pending_proposals(store, workspace_id="acme", actor=OWNER)
+
+    assert [p.id for p in queue] == [landed.proposal.id]
+
+
+# ── the structural guards ─────────────────────────────────────────────────────────────────────
+
+
+def test_no_auto_accept_exists_anywhere_in_the_surface():
+    """Enumerate the triage surface: two decision verbs, both requiring a named human. No
+    accept-all, no auto-accept, no default actor."""
+    verbs = {
+        name
+        for name, obj in vars(triage).items()
+        if callable(obj) and not name.startswith("_") and getattr(obj, "__module__", "") == triage.__name__
+    }
+    assert verbs == {"accept_proposal", "reject_proposal", "pending_proposals"}
+
+    for name in verbs:
+        signature = inspect.signature(getattr(triage, name))
+        actor = signature.parameters["actor"]
+        assert actor.default is inspect.Parameter.empty, f"{name} defaults its actor"
+        assert actor.kind is inspect.Parameter.KEYWORD_ONLY, f"{name} takes a positional actor"
+
+    assert not [
+        name
+        for name in dir(triage)
+        if not name.startswith("__") and re.search(r"auto|accept_all|bulk|batch", name, re.I)
+    ]
+
+
+def test_the_machine_path_cannot_reach_the_human_path():
+    """``router.py`` is what a meeting drives. It imports no triage module and names no accept
+    symbol, so there is no call chain from a meeting to an acceptance.
+
+    Read from the parse tree, not the text: prose about the rule is not a violation of it.
+    """
+    tree = ast.parse(inspect.getsource(router))
+    imported = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)} | {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    }
+
+    assert not [m for m in imported if m and "triage" in m]
+    assert not [r for r in referenced if "accept" in r or "triage" in r]
+
+
+async def test_the_table_refuses_an_unattributed_decision(store, make_workspace):
+    """The last guard: even a caller bypassing this package entirely cannot leave an accepted
+    proposal that names nobody."""
+    proposal = await _proposed(store, make_workspace)
+
+    with pytest.raises(Exception) as raised:
+        await store.session.execute(
+            text("UPDATE context_proposals SET state='accepted' WHERE id=:id"),
+            {"id": proposal.id},
+        )
+        await store.session.commit()
+
+    assert "ck_proposal_decision_is_attributed" in str(raised.value)

--- a/core/agent/modules/context-stack/uv.lock
+++ b/core/agent/modules/context-stack/uv.lock
@@ -1,0 +1,673 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a3/07297917485ee2ca85bc3c8dc6ed85ad3fffcf424047fba62671dba68e97/greenlet-3.5.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:be63afcbbccfad3dd95a1ba12ada84dab2ef32031973d80b5b92df67fa763a61", size = 294165, upload-time = "2026-08-10T13:25:17.987Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/6f732f9314cda54c5fd48a7620c7160f4f286967e8045ad94b9d66ce80b7/greenlet-3.5.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a268024ce2d7d2b04694bf1594058981a9fa663d1df4b762dee499211ed7c1c", size = 613610, upload-time = "2026-08-10T14:14:33.829Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c0/b27589e25d220289edcd4d582b2b17b83058d1a56d53d971b6ea1a34f10d/greenlet-3.5.5-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35cbb8bf55ace57fbccb4fb8622c4521713acd8691e77f4696d416ea7ca527da", size = 625481, upload-time = "2026-08-10T14:27:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/39/82/5c873dbb4fb001d22fbbd50e80d4c1b0181ddae106856132160f84b94e88/greenlet-3.5.5-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:abc8bc8d9f935cd685457545b6a53863a877fdc12c2c0f5ee9beee18d9db139c", size = 633329, upload-time = "2026-08-10T14:30:06.062Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2d/f2c928218ac52f26d7a2c188c171d1b7e728b23782cb3347e7b4fce1493a/greenlet-3.5.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cc6df89ec5302337adc9cf096221cbed2510fd444b0e0f1586cf0470740864", size = 624562, upload-time = "2026-08-10T13:40:48.064Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/f7df98e72a8eb4a7edfec5a08d6d1a4ab53a52c95ba0b2ea6c10b8dd9bd0/greenlet-3.5.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:3134291427bb0f3526e9d90311988caf336eb43730e95244997a4fb15f45144f", size = 428145, upload-time = "2026-08-10T14:30:01.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4a/92fc51d5d35912f4f06eec037ba347985defd0be47463a010a325634d9d2/greenlet-3.5.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d9b454c5fc48aeaa7c4337813dbf513a6870468e426438a04d922c6d0fe63db", size = 1584909, upload-time = "2026-08-10T14:15:04.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/58/ed98b80ac5738c149a5258544843c45601ade1fd70f61740cdaead6351b3/greenlet-3.5.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03551ed792cb1b4fc0277a0c60dfd8c343894a0ba06fe60dcd22f568b433da39", size = 1651184, upload-time = "2026-08-10T13:40:28.879Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/be/b582ceb80cefdf9d8da34078714e4b12b3d16f509dee0f65e40a5cc8fc7d/greenlet-3.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:ab3df3dffb58bf70564e93a5cec7941e4d9faa5a36cc4234a10d3131afe04f53", size = 323280, upload-time = "2026-08-10T13:26:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/18/5313c4c58598c38b0373c013e4ff2b3e6d258aaaa338f373335ebecdaddd/greenlet-3.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:2b70a766135540c472ac1393d57c2e1b4a2eb85bf526a1e41e6d096173a8cee5", size = 307785, upload-time = "2026-08-10T13:28:34.874Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/30/87c212b5c684d0e72974f1063b7a9687631e8985902c06e1016542c874e7/greenlet-3.5.5-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ca5d6ae0739e5764f2cfcfaa562ac5a990cbdaedca93251c5e3cf07c362371f", size = 629504, upload-time = "2026-08-10T14:30:07.967Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/eb487fafc9f50ffff2b1e0b697f70fb34bf150821c08ab225aacf5583a7e/greenlet-3.5.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1b5ed9162c0c098e0bbc2cf88a94f433c1b8926f831745252e099e5d83e17759", size = 432462, upload-time = "2026-08-10T14:30:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/eaa476d6bf3816828d0d70e80dcc36bf30a058233bd889e707e693f6e860/greenlet-3.5.5-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7278591501941bb2456af102bb9cd59aab48c6cfd6e2dd68fa1290bb0c49a42", size = 632726, upload-time = "2026-08-10T14:30:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/0cc2849ede68579291e9c59b3ab6ec1958f98681cca5b14d8fc75bf674a4/greenlet-3.5.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:4dfc7c4470354e7b09184d1a3a985761053a2fd694ddb5b5c80242afc2c8c90b", size = 434966, upload-time = "2026-08-10T14:30:03.729Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/649cb5c09d4d81f6dd1444e75474a7206784743283a21d24171562ac4899/greenlet-3.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:1af90aa4bc129883b340cdd6957a3bc74f60528a4993bbd1f53aaebe1d9981cc", size = 308260, upload-time = "2026-08-10T13:27:50.795Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/08/cc5f7627b92f1456bc0b5fb7e98af4600248abe422a44da0d17a3fe6a448/sqlalchemy-2.0.52-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0c3ce43907374889f3352bdcc6195c970148a2cb71574cd0237a5071a37fb6c", size = 2172460, upload-time = "2026-08-11T20:58:22.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/9a2abad8bfc8fdcd38c64adc056aeefab7aaa96ecd32f5e8c140e6375f17/sqlalchemy-2.0.52-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a0d48c4b80717c61385b4e966e087c839a66cfd7b780641dcb428f4dba65608", size = 3355720, upload-time = "2026-08-11T21:00:06.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/e75597b5841043e3c74055d00d4feb53d9a49a5c89ba2450d2d9aab53597/sqlalchemy-2.0.52-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:938325a5373267afc53bfbe72983b20fbd64ca47842aac62433c3da1137ecff1", size = 3354394, upload-time = "2026-08-11T21:05:51.454Z" },
+    { url = "https://files.pythonhosted.org/packages/12/25/410fbc6c2f1fa8310f4ef1b6847d47d0ac1c042c7b4e81eaaca063d030a9/sqlalchemy-2.0.52-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5f8438a98d49424acf69d0d53c0a522951dfe49a6f2d86417fbb37ad3066ab43", size = 3306991, upload-time = "2026-08-11T21:00:08.603Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ba/25ffd5c24681ea4b46e62c80ceca8200ce204de1773366321306cf3f608a/sqlalchemy-2.0.52-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4699dbb8d396d199e7e78fd4d525e3ad3d6008a9c8c0160b87e74c606c2c3736", size = 3327454, upload-time = "2026-08-11T21:05:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f1/0f1b1d4800e51218e736a06ed55a3b2a59c257600bbaca7673bf13d2dbec/sqlalchemy-2.0.52-cp311-cp311-win32.whl", hash = "sha256:cef328349452ae152637df4d11ce5a0919ecdf0a363e16c830c3518ee33bde72", size = 2131248, upload-time = "2026-08-11T21:09:50.765Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/04d2ac5ad66f3d31278f37064ed5f5ef3fe653f7bdaa67036663f223d186/sqlalchemy-2.0.52-cp311-cp311-win_amd64.whl", hash = "sha256:f1c850792a3b25a3ad74dade3f05e4f402cdebfea27438bcadafaa1617f77bcc", size = 2156943, upload-time = "2026-08-11T21:09:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/1b77a026d161f98a08f11af1a5f6c47b98ee7c7e2648af525a1004826c78/sqlalchemy-2.0.52-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be8c49131665dfe2cc74c498aa1240ffb548d0fd901325dd11c2c7a18956f727", size = 2170940, upload-time = "2026-08-11T20:58:11.25Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bd/f444444adb37b5d53753fb1730ee7a421628e2e3b756c4da461af7e6394a/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2d9e507a458832adcfbd8af6e2036ddf069b7710b799448542ebccae2dceee", size = 3383415, upload-time = "2026-08-11T21:02:38.534Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/2eadf93a552568c57e8680b7e58bb5e9770d80942a1bdbaf4f2f63f0d7c8/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8738008376d22f30f411ea3efecf39b51110b6996d80bb73786f30bcfdd5fd3b", size = 3398577, upload-time = "2026-08-11T21:16:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c3/2887cf9dd111d1fbf05d22165b404c221ef43e029f7a2695e7302f27a7cc/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37a4d548327b6cab9c7d8cdb4e0e82feabee0110c4d150059068e2d1cfbd99ee", size = 3328225, upload-time = "2026-08-11T21:02:40.183Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0f/466bdf9e1feeeef5587f868c187d8687e21ff8c85b1775e9041130181132/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e49f51a5d59857a7a0dcaf9469febf7197d9394bd88f00d69c2c4e848112cdbf", size = 3357374, upload-time = "2026-08-11T21:17:01.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/20/5c2b4583904af4173076dda1c9e53c9e2ffc7a702d2efde0216bbacbf7cb/sqlalchemy-2.0.52-cp312-cp312-win32.whl", hash = "sha256:afda3ec521d0517d0de783fc70030775841900896d832de5bbd066549290470e", size = 2129366, upload-time = "2026-08-11T21:14:50.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/06/543dab8ef62d4e9fb96fb31a30c2b8b14a8763bccf48d428294d6b3041c0/sqlalchemy-2.0.52-cp312-cp312-win_amd64.whl", hash = "sha256:2d5e53e36e37129fe0be8b9d08b6e4052c10a963ee6cda56c8c10dcc194b99ca", size = 2157344, upload-time = "2026-08-11T21:14:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/18/e30c6fe1eca1bf34a39fbdd6066121cc9974c850faf6f349eac563697a26/sqlalchemy-2.0.52-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2eb3c6a64b1bfe6704777cfd504e7b8ad093a5f3e03ce67663a5e6742f294e43", size = 2167724, upload-time = "2026-08-11T20:58:12.679Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/56/2e17d161a4f7ecc1c2ffb93e607b4e1898bb551b451b283235acb8f6ce47/sqlalchemy-2.0.52-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:923bb183c1dc64fdf7b717965e3d59938ec4f8b8710b419a21ce403e5da9a9e1", size = 3321189, upload-time = "2026-08-11T21:02:41.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/b8/8490916e893f3f8d74dc9cc54c078619364999dee37047a188e73abbc852/sqlalchemy-2.0.52-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:651d6d8782e80679e6151707c7b490834d46ada526328895abf567f25e63d29c", size = 3338185, upload-time = "2026-08-11T21:17:02.597Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f7/752cc8ee453da222829b3f5c4613614bf750d97429363b70414fa10478e4/sqlalchemy-2.0.52-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b08cddb8989775e3c88799d86704bdfc3ee6e9846118201aa5997f16f27e3a15", size = 3271698, upload-time = "2026-08-11T21:02:43.963Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e6/074ade0c07b9e4c8e8bca46820320ed94df9702afdb6f2af06623068d2e6/sqlalchemy-2.0.52-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ab66fa9618269390d4dfa222f2f2f88f7bc4bf5da13905131b818217db7e8057", size = 3308936, upload-time = "2026-08-11T21:17:04.172Z" },
+    { url = "https://files.pythonhosted.org/packages/66/07/557c0d04716705599227945ac14e0a17ad0338e899f37d8c2ddff4dcc663/sqlalchemy-2.0.52-cp313-cp313-win32.whl", hash = "sha256:c63bda077685c85ca513286547a531ba57e7a68cf0a7ed3bafcc2bbd18896f4d", size = 2127308, upload-time = "2026-08-11T21:14:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4e/226eda27654318ce525d043025221f689abef883da2c7126f9065121618c/sqlalchemy-2.0.52-cp313-cp313-win_amd64.whl", hash = "sha256:9876b09b9f1ce7398b0ffece585c0a911244c53191187341f6bcae640e133751", size = 2153876, upload-time = "2026-08-11T21:14:55.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f5/71cb30af58c9b80a4e1fac0b73bb48f86d497a774a6a2eb6d2f1e657bb73/sqlalchemy-2.0.52-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:410d52be41d17f1a236d19520fbe776257dc16516ed06bd16d433311842aefd9", size = 2169537, upload-time = "2026-08-11T20:58:13.855Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/93/d07ebd645d1b07b6b5ed63450a70f063a346a7e0f2c8810daf2e532400cb/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfe9ce533dbe4d0a2ae1486546619bd30b76bcd670539a44d910361376175f5e", size = 3319606, upload-time = "2026-08-11T21:02:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/5c/290c84c7c2566ecd3b65baaae0fddec9bc33b033b398a06123bb86fbfc6e/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:812bae5138bfc0aa46fb0686da0fc7f581f68e2bbb05bc24c3713bebaedd1437", size = 3323642, upload-time = "2026-08-11T21:17:05.675Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/2cc160590ca49173359557880b92a0572293ccb899e8f6cedf150c5a3ddf/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:50bff43b632a56fbf5ed9afdd76307e1512b62051bcd5afb341ae67205bbb6c8", size = 3268125, upload-time = "2026-08-11T21:02:47.649Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f3/ea8933fc9f7d1353e9c2ff9965eae687c4cef181120574591ed2fa0633e1/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:49565daf5af554f538e23aef1fc81a95a4e49658f152285e45c02f5fc44f04cd", size = 3289516, upload-time = "2026-08-11T21:17:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/45/67/05cf86541c1e1716fca1e4a996954a439cd74501707cda607fb7cb02ef50/sqlalchemy-2.0.52-cp314-cp314-win32.whl", hash = "sha256:ab9da41e61b9979b910499d633b241df20c51ee5037e5405b11c2faac3cbe1a2", size = 2130249, upload-time = "2026-08-11T21:14:57.273Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d7/8ac6ffa1e36169e762ef65bd835046abb2251b1bc17f8f6708e14ed8d31f/sqlalchemy-2.0.52-cp314-cp314-win_amd64.whl", hash = "sha256:a593db51b3bae75db17a5738ad5f992244b3a03863f83c28117ee482c6a3f76d", size = 2156718, upload-time = "2026-08-11T21:14:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4b/e01a737eef378e734cc6394a82248a6ce13b167dfa36c731075ce9fc9c64/sqlalchemy-2.0.52-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1e61d08bdf4ee2f41024569e3400de7d6734ba498144766b11260936ccfa582", size = 2190344, upload-time = "2026-08-11T19:53:21.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "vexa-context-stack"
+version = "0.12.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "pydantic" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "aiosqlite" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "referencing" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.110,<1" },
+    { name = "pydantic", specifier = ">=2,<3" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2,<3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiosqlite", specifier = ">=0.20,<1" },
+    { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "jsonschema", specifier = ">=4.21,<5" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1,<2" },
+    { name = "referencing", specifier = ">=0.31" },
+]

--- a/docs/changelog.d/context-stack-workspaces.md
+++ b/docs/changelog.d/context-stack-workspaces.md
@@ -1,0 +1,6 @@
+- **The context stack** — the four layers a product-mode agent turn composes (global · group ·
+  personal · user-system) now exist as a module: workspace identity (an address that meetings are
+  invited to, a name that names the bot), membership with owner/member roles, an explicit policy
+  field that routes every context delta, a proposal queue an owner triages, and a write-only
+  surface for workspace secrets. Group writes land as proposals and never as direct writes; no
+  machine can accept one. See [The context stack](/core/context-stack).

--- a/docs/docs/core/context-stack.mdx
+++ b/docs/docs/core/context-stack.mdx
@@ -1,0 +1,121 @@
+---
+title: "The context stack"
+description: "The four layers a product-mode agent turn composes, the policy field that routes every write, and the owner triage that keeps a group's knowledge answerable."
+---
+
+Every product-mode agent turn runs one composition. This page is the model; the code is
+`core/agent/modules/context-stack/`, the published shapes are
+`core/agent/contracts/context-stack.v1/`. Status is marked ✅ built / 🟡 partial / ⬜ planned.
+
+<Note>
+This is the **product** model. The terminal's workspace model — flat, freely composed, git-backed
+— is documented at [Workspaces & live collaboration](/core/workspaces) and is what runs today.
+The two meet where the pinned composition below is derived from membership.
+</Note>
+
+## The four layers
+
+| Layer | Access | Content |
+|---|---|---|
+| **Global** | read-only, hidden | product-level knowledge and behaviour, ours |
+| **Group** | read/write **via triage** | shared knowledge; writes land as **proposals the owner triages** — PR-style, never direct |
+| **Personal** | read/write | always exists for every user — *the user is not a group* |
+| **User-system** | read, hidden, never sharable | sessions, chat history; holds no external credentials ever |
+
+A turn composes them in that order: **global → group(s) → personal → user-system**. ✅
+
+## A workspace is an address, a name, a policy and an owner
+
+The bot has a mailbox and **each workspace has its own address**. Users invite the address to a
+meeting like any attendee, so the invited address *is* the group resolution — there is nothing to
+infer and no calendar to read. The workspace's **name** names the bot.
+
+**Group setup is a set of member emails**, and nothing more. A **personal** workspace is the
+one-member case of the same object, not a second kind of thing — it cannot take a second member,
+because a workspace that needs two members is a group workspace. ✅
+
+**Roles** are owner and member. The owner does four things: workspace config, membership, triage,
+and secrets. A member chats and contributes knowledge. ✅
+
+## The policy field routes every write
+
+Each workspace carries one explicit **policy** field, and it answers both questions the stack asks:
+where the workspace sits in the composition, and how a write to it lands.
+
+| Policy | A context delta addressed to it |
+|---|---|
+| personal | goes into context directly, as a new revision |
+| group | goes into the **proposal queue**. Never direct |
+| global | refused — global is ours and read-only |
+| user-system | refused — sessions and chat history are the platform's to write |
+
+Policy and layer are deliberately **one field, not two**. Two fields can disagree, and the only
+disagreement that matters is a workspace sitting at the group layer while taking direct writes —
+exactly the bypass of owner triage the model forbids. ✅
+
+## No machine ever writes acknowledgement
+
+A meeting produces deltas, and on the group layer the most that path can produce is a **pending**
+proposal. Accepting is a human act by the workspace owner: there is no auto-accept function, no
+bulk form, no endpoint that decides a proposal as a side effect, and no default actor anywhere.
+
+Accepting appends the proposed body as the group context's next revision, crediting the
+**proposer** as its author and the **owner** as its decider — two people, both named. Rejecting
+writes nothing to context and keeps the full record of what was proposed and why it was declined.
+✅
+
+Context is **append-only**: current state is the highest revision of a document, deletion is a
+tombstone, and no write overwrites the body that preceded it. That is what lets triage show a
+before and an after, and what a future compaction pass would read. ✅
+
+## Loosely coupled by schema, pinned by product
+
+The stack slots are **pointers**, not foreign-key constraints. A user can be re-pointed at a
+different personal workspace, or compose several groups, without any schema change — and the
+terminal keeps its free composition.
+
+The **product** ships a pinned default composition, so ordinary users never see composition at
+all. The two modes differ in exactly one place: **pinned derives the group slot from membership**,
+so what you get is exactly the groups you belong to. The three singleton slots honour an explicit
+pointer in both modes, because re-pointing changes *which* workspace fills a slot rather than the
+shape of the stack — that is migration, not composition. ✅
+
+A user in **no group** resolves to global → personal → user-system, and that is the participant
+case, not a degraded one: someone on a meeting invitation who has never joined a group still
+receives an artifact built from the meeting record and their own personal context. ✅
+
+**A non-member never reaches group context.** The composed stack omits it, a pointer at it is
+dropped with a recorded reason, reading it is refused, and proposing into it is refused too — a
+queue anyone may fill is a queue the owner stops reading. ✅
+
+## Workspace secrets are write-only
+
+An owner can **set, rotate, delete** a workspace secret and read its **metadata** — last four
+characters, version, who set it and when. **No endpoint returns a secret.** The management surface
+returns a metadata type with no field material could be put in, and the one function that reads
+material at LLM-call time is not reachable from any route. ✅
+
+In the pilot exactly one secret is user-supplied: the **LLM key or endpoint** the workspace owner
+brings (BYOT). Self-hosted it is a k8s Secret and never becomes a row at all.
+
+The stored value is **plaintext at rest** — the same level as the saved GitHub token
+(access-controlled, not encrypted), so a full server compromise reads it: use a revocable,
+minimally-scoped key. Envelope encryption is deliberately deferred until group-scoped integration
+tokens arrive with grant rows and expiries. ⬜
+
+The **user-system layer holds no external credentials ever**, and that is enforced rather than
+intended: not even its owner can put a key there. Global's credentials are deployment config — a
+k8s Secret or a chart value — not workspace rows. ✅
+
+## Not built yet
+
+⬜ Admin UI · ⬜ address allocation and mailbox provisioning · ⬜ LLM chat over the composed stack ·
+⬜ migration of existing terminal workspaces onto this model · ⬜ deployment wiring (no service
+mounts the module yet, so its tables are not in `schema.seal.json`) · ⬜ a batching or
+auto-accept-factual-deltas policy for triage load · ⬜ context compaction.
+
+## Related
+
+- [Workspaces & live collaboration](/core/workspaces) — the terminal-side model that runs today.
+- `core/agent/contracts/context-stack.v1/` — the published shapes.
+- `core/agent/modules/context-stack/README.md` — the file-by-file map and the decisions behind it.

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -61,7 +61,8 @@
           "core/agents",
           "core/runtime",
           "core/identity",
-          "core/workspaces"
+          "core/workspaces",
+          "core/context-stack"
         ]
       },
       {

--- a/docs/views/architecture.dsl
+++ b/docs/views/architecture.dsl
@@ -48,8 +48,10 @@ system agent  # copilot; owns the processed (cleaned) transcript + signals
   contract tool.v1
   contract unit.v1
   contract processed-notes.v1
+  contract context-stack.v1
   contract workspace.v1
   service agent-worker
+  module context-stack
   data-asset out-stream [writers: agent-worker]
   data-asset unit-in
   data-asset proc-stream [writers: agent-worker]


### PR DESCRIPTION
## The four layers

Every product-mode agent turn composes one stack. This PR makes it exist.

| Layer | Access | Content |
|---|---|---|
| **Global** | read-only, hidden | product-level knowledge/behaviour, ours |
| **Group** | read/write **via triage** | shared; writes land as **proposals the owner triages** — PR-style, never direct |
| **Personal** | read/write | always exists for every user — *the user is not a group* |
| **User-system** | read, hidden, never sharable | sessions, chat history; **holds no external credentials ever** |

New module `core/agent/modules/context-stack/` (Python, `uv`, its own tests), new published contract `core/agent/contracts/context-stack.v1/`, new docs page `core/context-stack`. Nothing existing is edited beyond registering the two new nodes in `architecture.calm.json` (P23), one row in the agent contracts table, and the docs nav.

## The schema — six tables

`workspaces` (id · name · **address** · **policy** · owner) · `workspace_memberships` (workspace · subject · role · email) · `context_revisions` · `context_proposals` · `stack_pointers` · `workspace_secrets`.

Three of those shapes are decisions, argued at the table in `models.py`:

**Context is append-only.** Current state is the highest revision of a document; deletion is a tombstone. Triage needs a before and an after, a rejected proposal has to leave no trace in context while leaving a full trace in the record, and compaction — an open problem — can only ever be a readable artifact over a history that was kept. It also matches what the knowledge store already is: these workspaces are git repos, where a write has always been an append.

**A decided proposal must name a human, by CHECK constraint.** `ck_proposal_decision_is_attributed`: a row is either pending with no decider, or decided and naming who decided and when. No code path, present or future, can mark a proposal accepted without putting a name on it.

**`stack_pointers.workspace_id` carries no foreign key, on purpose.** See below.

## Loosely coupled by schema, pinned by product

The slots are pointers. A user can be re-pointed at a different personal workspace, or compose several groups, and the terminal keeps free composition — a constraint there would turn re-pointing into a schema problem and make a pointer at a workspace this deployment does not hold an insert error rather than what it actually is: a resolvable condition (reported as a `dangling-pointer` denial).

The product path is pinned. `resolve_stack(mode=PINNED)` **derives the group slot from membership**, so an ordinary participant gets exactly the groups they belong to and there is nothing to compose. The two modes differ in exactly one place — the three singleton slots honour an explicit pointer in both, because re-pointing changes *which* workspace fills a slot rather than the shape of the stack. That is migration, not composition, and the product needs it to work.

A user in **no group** resolves to global → personal → user-system. That is the participant case, not a degraded one.

## The policy field routes every write

One field, not two. A workspace's `policy` answers both *where it sits in the stack* and *how a write to it lands*. Two fields can disagree, and the only disagreement that matters is a workspace sitting at the group layer while taking direct writes — precisely the bypass of owner triage the model forbids. One field cannot express it.

| Policy | A context delta addressed to it |
|---|---|
| personal | direct — a new revision |
| group | the proposal queue |
| global | refused (`global-is-read-only`) |
| user-system | refused (`user-system-is-platform-only`) |

A non-member cannot even propose: a queue anyone may fill is a queue the owner stops reading.

## No machine ever writes acknowledgement

Four guards, at four levels, each holding if the others were removed:

1. **The import direction.** `triage.py` depends on `router.py`'s types, so the machine path importing the human path is a cycle Python refuses to load. Verified by mutation (below): the wiring that would let a meeting accept its own proposal does not merely not exist — it does not import.
2. `actor` is a required keyword-only argument with no default and no service principal.
3. The actor must hold the **owner** role. A member may propose and may not decide.
4. The CHECK constraint above.

There is no auto-accept, no accept-all, and no bulk route. The batching question the roadmap raises — auto-accepting factual deltas while behavioural ones queue — is a live design question, not a switch left in the code.

## The secret surface is write-only

Set · rotate · delete · read metadata. **No endpoint returns a secret** — and that is a property of the types, not a rule about callers: every management function returns `SecretMetadata`, which has no field material could be put in, so there is nothing to remember not to serialize. The single function that reads material at LLM-call time lives alone in `material.py`, is imported by neither `secrets.py` nor `api.py`, and returns a handle whose `repr`, `str` and `format` are all redacted.

**This is the direct inverse of a known settings-read defect that returned key material to its caller.** A product that asks an owner for their provider key has to be the other thing, so the invariant is tested three ways rather than asserted once.

No envelope-encryption machinery, per the spec: the stored value is **plaintext at rest**, the level the saved GitHub token already sits at (access-controlled, not encrypted). A full server compromise reads it — use a revocable, minimally-scoped key. It earns encryption when group-scoped integration tokens arrive with grant rows and expiries.

Two layer-level refusals fall out of the spec and are enforced, not intended: **user-system holds no external credentials ever** (not even its owner can put a key there), and global's credentials are deployment config, not workspace rows.

## Test evidence

`cd core/agent/modules/context-stack && uv run pytest -q` → **73 passed**, ~2s, no docker and no network. The real DDL runs on in-memory SQLite with `PRAGMA foreign_keys=ON`, so the CHECK and UNIQUE constraints above are exercised rather than described.

| Suite | Proves |
|---|---|
| `test_resolution.py` (12) | layer order for member / non-member / multi-group / no-group; slots carry their layer's rules and no content; free vs pinned; wrong-layer, non-member and dangling pointers each denied with a code |
| `test_routing.py` (10) | every cell of the routing table, pure and against the store; 100 machine deltas accept none of themselves; a second write to a path is a new revision, not an overwrite |
| `test_triage.py` (10) | accept applies and credits proposer *and* decider; reject leaves context untouched and the record whole; member and outsider both refused; a decided proposal is final; the four structural guards |
| `test_enforcement.py` (7) | **seven routes into a group, all closed to a non-member**; personal refuses a second member (`personal-is-not-a-group`); user-system is never sharable; the owner's seat cannot be removed; the whole (policy × role × action) allow-list written out exhaustively |
| `test_secrets.py` (8) | set → rotate → metadata read; the surface enumerated and every return searched for the key; user-system and global secret refusals |
| `test_api_surface.py` (9) | the route table is exactly 14 rows; no response model has a field a secret could ride in, recursively; **a real key is set and every readable route called and searched for it**; one accept route, no bulk form |
| `test_contract.py` (7) | live `to_contract()` output conforms to `context-stack.v1`, so the published shape cannot drift while the goldens still pass |
| `test_repointing.py` (5) | a user can be re-pointed at a different personal workspace, in the **pinned** path as well as free; the re-pointed slot is where writes then land |

**Negative controls, run by hand.** Green tests prove nothing until you have seen them go red:

- *Made `GET /workspaces/{id}/secrets/{name}` return the key* (a material field on the response model, populated from `use_material`). Caught at all three levels — the import-graph assertion, the response-model walk, and the live sweep.
- *Made the router accept its own proposal.* It **would not import** — `ImportError: cannot import name 'Destination' from partially initialized module 'context_stack.router' (most likely due to a circular import)`. The guarantee is structural, which is stronger than what was designed for.

**Repo gates.** `readme` · `dataflow` (P23, after registering both nodes and `pnpm seal:arch`) · `isolation` · `isolation-py` · `graph` · `graph-py` · `test-isolation` · `schema` (26 contracts; the 16 new goldens conform) · `contract-version` (reports `context-stack.v1` unsealed, correct while in development) · `config-contract` · `db-schema` · `db-budget` · `exports` · `python` (13 packages) · `licenses` · `image-licenses` · `runtime-parity` · `docs-version` · `lite-makefile` — all green. The docker-dependent tail (`compose`, `compose-stress`, `compose-chaos`, `stack`, `eval-baseline`) was **not run locally**: container workloads belong on `bbb`, and this change touches no deploy, compose or meetings surface. CI owns them.

The 16 goldens were **emitted by the implementation**, not hand-written — a member proposing and the owner accepting, a participant with no group, a denied pointer, a BYOT key's metadata — so the published cases are the behaviour rather than an author's idea of it.

## What is NOT done

Named plainly, because none of it is implied by the above:

- **No admin UI.** No create-workspace → name → set key → paste emails flow.
- **No address allocation or mailbox provisioning.** A workspace has an `address` column; nothing mints one, nothing receives mail at one, and no invite is parsed.
- **No LLM chat.** Nothing composes the resolved stack into a prompt or calls a model. `use_material` has no caller yet.
- **No migration of existing users.** The terminal's flat git-backed model (`docs/docs/core/workspaces.mdx`) still runs; the two models are documented side by side and are not reconciled. That reconciliation is the real next piece of work.
- **No deployment wiring.** The module owns no connection — a mounting service injects an `AsyncSession`. No service mounts it, nothing creates these tables, and they are therefore **deliberately absent from `schema.seal.json`**: sealing now would freeze a claim nothing is making. When a service adopts it, add `models.py` to `MODEL_FILES` in `scripts/schema_digest.py` and re-seal on a `lane:schema` review.
- **No hosted-vs-self-host split.** Self-host's k8s Secret path is described and not built.
- **No triage-load policy.** If every meeting emits five proposals the owner drowns by week two. Deliberately no knob yet.
- **No context compaction.** Append-only is the choice that makes compaction possible and also makes it necessary.
- **Not in `contracts/loader.py`.** Nothing validates these shapes at runtime yet, and a validator no caller reaches is worse than none.

## Places the spec was ambiguous, where a decision was made

Each is reversible; flag any that reads wrong and it changes.

1. **Policy and layer are one field.** The spec names a "policy field" and separately tabulates layers. Modelled as one value doing both jobs. Two fields would be more permissive but admit a group workspace that writes direct.
2. **Singleton pointers are honoured in the pinned path.** "Pinned by product" could mean the product ignores pointers entirely — but then re-pointing a personal workspace, which the ruling requires, would only work in the terminal. Pinned therefore fixes only the *group* slot.
3. **Free composition cannot express "zero groups".** Absent pointers fall back to the derivation, so a user cannot compose an empty group set. An explicit empty marker would be needed.
4. **A non-member cannot propose into a group**, not just cannot read it. The spec is explicit on reads only.
5. **Reading the proposal queue is owner-gated**, not member-visible. A queue is a view of what members are trying to write.
6. **A decided proposal is final** — no re-deciding under the same id.
7. **User-system and global refuse secrets outright.** Read from "holds no external credentials ever" as a layer property rather than as prose about intent.
8. **Ambiguous personal resolution.** A user owning several personal workspaces with no pointer resolves to the oldest. Pointers exist precisely for that case.
9. **`subject` is the email** until a directory distinguishes them; both columns exist so that can change without a migration.
10. **The actor comes from `X-User-Email`**, the header the gateway already stamps.
11. **The schema is not sealed** (see above) — arguably it should be sealed now to lock the review.

---

Contract: `core/agent/contracts/context-stack.v1/` · Module map and decisions: `core/agent/modules/context-stack/README.md` · Product model: `docs/docs/core/context-stack.mdx`

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. This branch carries
none: the certification and the sign-off are the human's to make, and were deliberately left for
you rather than pre-filled.

<!-- vexa-agent -->
