### PR TITLE
fix(dashboard): render a refused Join as a paywall, not "Access denied"

### DIFF
--- a/services/dashboard/src/components/join/join-modal.tsx
+++ b/services/dashboard/src/components/join/join-modal.tsx
@@ -23,11 +23,13 @@ import type { Platform, CreateBotRequest } from "@/types/vexa";
 import { LanguagePicker } from "@/components/language-picker";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import { getUserFriendlyError } from "@/lib/error-messages";
+import { resolveJoinError } from "@/lib/join-error";
+import type { ServiceDenialPresentation } from "@/lib/service-denial";
+import { ServiceDenialPanel } from "@/components/join/service-denial-panel";
 import { getWebappUrl } from "@/lib/docs/webapp-url";
 import { parseMeetingInput } from "@/lib/parse-meeting-input";
 import { useAuthStore } from "@/stores/auth-store";
-import { shouldTriggerZoomOAuth, startZoomOAuth } from "@/lib/zoom-oauth-client";
+import { startZoomOAuth } from "@/lib/zoom-oauth-client";
 
 
 export function JoinModal() {
@@ -51,6 +53,9 @@ export function JoinModal() {
   });
   const [passcode, setPasscode] = useState("");
   const [authenticated, setAuthenticated] = useState(false);
+  // A refused Join renders in the modal until the customer acts on it, rather
+  // than in a toast that expires — see `resolveJoinError`.
+  const [denial, setDenial] = useState<ServiceDenialPresentation | null>(null);
 
   // Persist bot name and language to localStorage
   useEffect(() => {
@@ -72,6 +77,7 @@ export function JoinModal() {
       setTranscribeEnabled(true);
       setPasscode("");
       setAuthenticated(false);
+      setDenial(null);
     }
   }, [isOpen]);
 
@@ -126,6 +132,7 @@ export function JoinModal() {
     }
 
     setIsSubmitting(true);
+    setDenial(null);
 
     // Path 3 (URL + platform): when parser identified platform, use parsed
     // meetingId. Otherwise (platformNeeded), send meeting_url + platform; backend
@@ -183,11 +190,17 @@ export function JoinModal() {
         return;
       }
 
-      if (
-        shouldTriggerZoomOAuth(error, request.platform) &&
-        request.platform === "zoom" &&
-        user?.email
-      ) {
+      const resolved = resolveJoinError(error, {
+        platform: request.platform,
+        canStartZoomOAuth: Boolean(user?.email),
+      });
+
+      if (resolved.kind === "denial") {
+        setDenial(resolved.presentation);
+        return;
+      }
+
+      if (resolved.kind === "zoom-oauth" && user?.email) {
         try {
           toast.info("Zoom authentication required", {
             description:
@@ -203,11 +216,13 @@ export function JoinModal() {
           toast.error("Failed to start Zoom authentication", {
             description: (oauthError as Error).message,
           });
+          return;
         }
       }
 
-      const { title, description } = getUserFriendlyError(error as Error);
-      toast.error(title, { description });
+      if (resolved.kind === "toast") {
+        toast.error(resolved.title, { description: resolved.description });
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -229,6 +244,14 @@ export function JoinModal() {
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Refused Join — paywall / limit / outage, with its one fixing action */}
+          {denial && (
+            <ServiceDenialPanel
+              presentation={denial}
+              onRetry={denial.retryable ? () => setDenial(null) : undefined}
+            />
+          )}
+
           {/* Meeting Input */}
           <div className="space-y-2">
             <Label htmlFor="meetingInput" className="sr-only">

--- a/services/dashboard/src/components/join/service-denial-panel.tsx
+++ b/services/dashboard/src/components/join/service-denial-panel.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { AlertCircle, CreditCard, Clock, Settings2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { denialActionUrl } from "@/lib/join-error";
+import { getWebappUrl } from "@/lib/docs/webapp-url";
+import type {
+  ServiceDenialKind,
+  ServiceDenialPresentation,
+} from "@/lib/service-denial";
+
+/**
+ * The in-flow rendering of a refused Join.
+ *
+ * A panel, not a toast: a paywall is a thing the customer has to act on, and a
+ * toast that vanishes on a timer loses both the reason and the fix. Styling
+ * follows the modal's existing inline-notice idiom (tinted border + wash).
+ */
+
+const ACCENT: Record<ServiceDenialKind, string> = {
+  paywall: "border-amber-500/40 bg-amber-500/5",
+  setup: "border-amber-500/40 bg-amber-500/5",
+  limit: "border-blue-500/40 bg-blue-500/5",
+  retryable: "border-muted-foreground/30 bg-muted/40",
+  unknown: "border-destructive/40 bg-destructive/5",
+};
+
+const TITLE_TONE: Record<ServiceDenialKind, string> = {
+  paywall: "text-amber-700 dark:text-amber-300",
+  setup: "text-amber-700 dark:text-amber-300",
+  limit: "text-blue-700 dark:text-blue-300",
+  retryable: "text-foreground",
+  unknown: "text-destructive",
+};
+
+function DenialIcon({ kind }: { kind: ServiceDenialKind }) {
+  const className = "h-4 w-4 shrink-0";
+  if (kind === "paywall") return <CreditCard className={className} />;
+  if (kind === "setup") return <Settings2 className={className} />;
+  if (kind === "retryable") return <Clock className={className} />;
+  return <AlertCircle className={className} />;
+}
+
+export function ServiceDenialPanel({
+  presentation,
+  onRetry,
+}: {
+  presentation: ServiceDenialPresentation;
+  onRetry?: () => void;
+}) {
+  const { kind, title, body, action, retryable, reason } = presentation;
+
+  return (
+    <div
+      role="alert"
+      data-testid="service-denial-panel"
+      data-denial-kind={kind}
+      data-denial-reason={reason}
+      className={cn(
+        "space-y-2 rounded-lg border p-3 animate-fade-in",
+        ACCENT[kind],
+      )}
+    >
+      <p
+        className={cn(
+          "flex items-center gap-2 text-sm font-semibold",
+          TITLE_TONE[kind],
+        )}
+      >
+        <DenialIcon kind={kind} />
+        {title}
+      </p>
+      <p className="text-xs text-muted-foreground">{body}</p>
+      {(action || (retryable && onRetry)) && (
+        <div className="flex items-center gap-2 pt-1">
+          {action && (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() =>
+                window.open(
+                  denialActionUrl(getWebappUrl(), action.href),
+                  "_blank",
+                  "noopener,noreferrer",
+                )
+              }
+            >
+              {action.label}
+            </Button>
+          )}
+          {retryable && onRetry && (
+            <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+              Try again
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/dashboard/src/lib/error-messages.ts
+++ b/services/dashboard/src/lib/error-messages.ts
@@ -1,4 +1,5 @@
 import { VexaAPIError } from "@/lib/api";
+import { serviceDenialFromError } from "@/lib/service-denial";
 
 export interface UserFriendlyError {
   title: string;
@@ -11,11 +12,23 @@ export interface UserFriendlyError {
 export function getUserFriendlyError(error: Error): UserFriendlyError {
   const message = error.message.toLowerCase();
 
-  // Concurrent bot limit reached
+  // Service-authority denial — billing, spend cap, concurrency ceiling. These
+  // arrive as 403/503 with a `service_not_allowed` code and must never be
+  // flattened into "Access denied": the customer cannot act on that, and a
+  // paywall then looks identical to an outage. The join surfaces render this
+  // as a panel (see `resolveJoinError`); this branch is the fallback for
+  // callers that only have a title/description to show.
+  const denial = serviceDenialFromError(error);
+  if (denial) {
+    return { title: denial.title, description: denial.body };
+  }
+
+  // Concurrent bot limit reached — the 0.10 core states it as a plain string
+  // with the numbers in it ("Concurrent bot limit reached (2/3)"), so say them.
   if (message.includes("concurrent") && message.includes("limit")) {
     return {
       title: "Bot limit reached",
-      description: "You have reached your maximum number of concurrent bots. Stop an existing bot to start a new one.",
+      description: concurrencyLimitDescription(error.message),
     };
   }
 
@@ -35,7 +48,8 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
     };
   }
 
-  // Forbidden
+  // Forbidden — a GENUINE permission fault. Service denials never reach here;
+  // they are handled above.
   if (error instanceof VexaAPIError && error.status === 403) {
     return {
       title: "Access denied",
@@ -64,4 +78,22 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
     title: "Something went wrong",
     description: error.message || "An unexpected error occurred.",
   };
+}
+
+/**
+ * Keeps the ceiling the server named. `(2/3)` means two running against a
+ * limit of three; without it we can only describe the state.
+ */
+function concurrencyLimitDescription(rawMessage: string): string {
+  const match = /\((\d+)\s*\/\s*(\d+)\)/.exec(rawMessage);
+  if (match) {
+    const [, active, limit] = match;
+    return `Your plan runs ${limit} bot${limit === "1" ? "" : "s"} at once and ${active} ${active === "1" ? "is" : "are"} already in a meeting. Stop one to start another.`;
+  }
+  const bare = /limit\s*\(?\s*(\d+)\s*\)?\s*\.?$/i.exec(rawMessage.trim());
+  if (bare) {
+    const limit = bare[1];
+    return `Your plan runs ${limit} bot${limit === "1" ? "" : "s"} at once and they are all in meetings. Stop one to start another.`;
+  }
+  return "You have reached your maximum number of concurrent bots. Stop an existing bot to start a new one.";
 }

--- a/services/dashboard/src/lib/join-error.ts
+++ b/services/dashboard/src/lib/join-error.ts
@@ -1,0 +1,79 @@
+import { VexaAPIError } from "@/lib/api";
+import { getUserFriendlyError } from "@/lib/error-messages";
+import {
+  serviceDenialFromError,
+  type ServiceDenialFacts,
+  type ServiceDenialPresentation,
+} from "@/lib/service-denial";
+import { shouldTriggerZoomOAuth } from "@/lib/zoom-oauth-client";
+
+/**
+ * The rendering states a failed Join can land in.
+ *
+ * Kept as a pure function so the join surfaces (modal, pending-meeting hook)
+ * agree on which state a given error produces, and so the mapping is testable
+ * without a DOM.
+ *
+ * - `denial`     — the service authority refused. Rendered as an in-modal panel
+ *                  with its own words and, where one exists, one fixing action.
+ *                  Never a toast: a paywall the customer must act on should not
+ *                  disappear on a timer.
+ * - `zoom-oauth` — the Zoom connection is missing; the caller runs the OAuth
+ *                  hand-off instead of showing anything.
+ * - `toast`      — everything else, including genuine authz failures.
+ */
+export type JoinErrorState =
+  | { kind: "denial"; presentation: ServiceDenialPresentation }
+  | { kind: "zoom-oauth" }
+  | { kind: "toast"; title: string; description: string };
+
+export interface ResolveJoinErrorOptions {
+  /** Platform of the request that failed, for the Zoom OAuth branch. */
+  platform?: string;
+  /** True when the Zoom OAuth hand-off can actually run (user email known). */
+  canStartZoomOAuth?: boolean;
+  /** Extra numbers to put in the denial copy, when the caller knows them. */
+  facts?: ServiceDenialFacts;
+}
+
+export function resolveJoinError(
+  error: unknown,
+  options: ResolveJoinErrorOptions = {},
+): JoinErrorState {
+  const { platform, canStartZoomOAuth = false, facts } = options;
+
+  // A subscription gate (402) keeps its existing, already-specific handling.
+  // Everything the service authority refuses arrives as 403/503 with a code.
+  const denial = serviceDenialFromError(error, facts);
+  if (denial) return { kind: "denial", presentation: denial };
+
+  if (
+    canStartZoomOAuth &&
+    platform === "zoom" &&
+    shouldTriggerZoomOAuth(error, platform)
+  ) {
+    return { kind: "zoom-oauth" };
+  }
+
+  const { title, description } = getUserFriendlyError(
+    error instanceof Error ? error : new Error(String(error)),
+  );
+  return { kind: "toast", title, description };
+}
+
+/**
+ * Absolute URL for a denial action. Account and billing live on the webapp
+ * origin (vexa.ai), not on the dashboard, so the relative href the mapping
+ * carries is resolved against the webapp base.
+ */
+export function denialActionUrl(webappUrl: string, href: string): string {
+  return `${webappUrl.replace(/\/+$/, "")}${href}`;
+}
+
+/** True when the error is a genuine authorization failure, not a service denial. */
+export function isAccessError(error: unknown): boolean {
+  if (!(error instanceof VexaAPIError)) return false;
+  if (error.status === 401) return true;
+  if (error.status !== 403) return false;
+  return serviceDenialFromError(error) === null;
+}

--- a/services/dashboard/src/lib/service-denial.ts
+++ b/services/dashboard/src/lib/service-denial.ts
@@ -215,13 +215,15 @@ export function serviceDenialPresentation(
 
 function unknownServiceDenial(reason: string): ServiceDenialPresentation {
   const label = reason.trim() || "unspecified";
-  // Fail loud where a developer will see it; never in the customer's face.
-  if (process.env.NODE_ENV !== "production") {
-    console.error(
-      `[service-denial] unmapped service-authority reason: ${label}. ` +
-        "Add it to serviceDenialPresentation before it reaches a customer.",
-    );
-  }
+  // Fail loud in the logs, PRODUCTION INCLUDED — never in the customer's face.
+  // An unmapped reason is a prod-only event by definition: it means the service
+  // authority (Vexa-ai/vexa-platform lib/billing-spend-policy.ts) shipped a
+  // reason ahead of this module's copy. A dev-only console.error is silent
+  // exactly where the drift actually happens, so the net has no signal.
+  console.error(
+    `[service-denial] unmapped service-authority reason: ${label}. ` +
+      "Add it to serviceDenialPresentation before it reaches a customer.",
+  );
   return {
     reason,
     kind: "unknown",

--- a/services/dashboard/src/lib/service-denial.ts
+++ b/services/dashboard/src/lib/service-denial.ts
@@ -1,0 +1,312 @@
+import { VexaAPIError } from "@/lib/api";
+
+/**
+ * The customer-facing rendering of a refused Join.
+ *
+ * The meeting API refuses a bot with
+ * `403 {"detail":{"code":"service_not_allowed","reason":<reason>,"decision_id":…}}`.
+ * Before this change every one of those reasons reached the customer as a bare
+ * "Access denied", so a paywall was indistinguishable from an outage and from a
+ * permissions fault.
+ *
+ * This is the dashboard-side twin of `lib/service-denial-view.ts` in
+ * Vexa-ai/vexa-platform (PR #292). The two surfaces must say the same sentence
+ * about the same account, so the copy below is kept byte-aligned with that
+ * module; change one, change both.
+ *
+ * Deliberately free of React and of network access.
+ */
+
+export const SERVICE_NOT_ALLOWED_CODE = "service_not_allowed";
+export const SERVICE_AUTHORITY_UNAVAILABLE_CODE = "service_authority_unavailable";
+
+/**
+ * The vocabulary the service authority emits. Mirrors `ServiceAuthorityReason`
+ * in the platform repo. A reason outside this union is rendered verbatim rather
+ * than flattened — see {@link unknownServiceDenial}.
+ */
+export type ServiceAuthorityReason =
+  | "allowed"
+  | "billing_setup_required"
+  | "insufficient_balance"
+  | "payment_past_due"
+  | "spend_cap_reached"
+  | "concurrency_limit_reached"
+  | "billing_unavailable";
+
+/**
+ * What the customer can DO about it, which is the only distinction the UI needs
+ * to style:
+ *
+ * - `paywall`   — they are out of money; one payment fixes it.
+ * - `setup`     — billing is not finished; one setup flow fixes it.
+ * - `limit`     — a ceiling they chose or bought; the number is named.
+ * - `retryable` — our side; the account is fine and waiting helps.
+ * - `unknown`   — a reason this build has never heard of. Shown verbatim.
+ */
+export type ServiceDenialKind =
+  | "paywall"
+  | "setup"
+  | "limit"
+  | "retryable"
+  | "unknown";
+
+export interface ServiceDenialAction {
+  label: string;
+  /** Path on the webapp (billing/account) origin, not on the dashboard. */
+  href: string;
+}
+
+export interface ServiceDenialPresentation {
+  reason: string;
+  kind: ServiceDenialKind;
+  title: string;
+  body: string;
+  action: ServiceDenialAction | null;
+  /** True when simply trying again later is a sane instruction. */
+  retryable: boolean;
+}
+
+export interface ServiceDenialFacts {
+  /** Live prepaid balance in cents, when the caller knows it. */
+  balanceCents?: number | null;
+  /** Concurrent-bot ceiling, for the concurrency reason. */
+  concurrencyCeiling?: number | null;
+  /** Human plan label, e.g. "Pay-as-you-go". */
+  planLabel?: string | null;
+}
+
+const ADD_FUNDS: ServiceDenialAction = {
+  label: "Add funds",
+  href: "/account?tab=bots",
+};
+
+const FINISH_SETUP: ServiceDenialAction = {
+  label: "Finish billing setup",
+  href: "/account?tab=bots",
+};
+
+const UPDATE_PAYMENT: ServiceDenialAction = {
+  label: "Update payment method",
+  href: "/account?tab=balance",
+};
+
+const REVIEW_SPEND_CAP: ServiceDenialAction = {
+  label: "Review spend cap",
+  href: "/account?tab=balance",
+};
+
+function usd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function balanceSentence(facts: ServiceDenialFacts): string {
+  const cents = facts.balanceCents;
+  if (typeof cents !== "number" || !Number.isSafeInteger(cents) || cents < 0) {
+    return "Your prepaid balance is empty.";
+  }
+  const plan = facts.planLabel ? ` on ${facts.planLabel}` : "";
+  return `Your prepaid balance${plan} is ${usd(cents)}.`;
+}
+
+function concurrencySentence(facts: ServiceDenialFacts): string {
+  const ceiling = facts.concurrencyCeiling;
+  if (
+    typeof ceiling !== "number" ||
+    !Number.isSafeInteger(ceiling) ||
+    ceiling < 0
+  ) {
+    return "Every bot your plan allows is already in a meeting.";
+  }
+  return (
+    `Your plan runs ${ceiling} bot${ceiling === 1 ? "" : "s"} at once, ` +
+    "and they are all in meetings."
+  );
+}
+
+/**
+ * `reason` is whatever the API said. A reason this build does not know is
+ * rendered VERBATIM rather than flattened into "Access denied" — an unmapped
+ * code in front of the customer is a bug we want reported, not hidden.
+ */
+export function serviceDenialPresentation(
+  reason: string,
+  facts: ServiceDenialFacts = {},
+): ServiceDenialPresentation {
+  switch (reason as ServiceAuthorityReason) {
+    case "allowed":
+      // Not a denial. Callers that reach here have mismatched allow/reason.
+      return {
+        reason,
+        kind: "unknown",
+        title: "Service not allowed",
+        body: `service not allowed: ${reason}`,
+        action: null,
+        retryable: true,
+      };
+    case "insufficient_balance":
+      return {
+        reason,
+        kind: "paywall",
+        title: "Out of credit",
+        body:
+          `${balanceSentence(facts)} Add funds and the bot joins ` +
+          "immediately — nothing else about your account needs changing.",
+        action: ADD_FUNDS,
+        retryable: false,
+      };
+    case "billing_setup_required":
+      return {
+        reason,
+        kind: "setup",
+        title: "Billing setup not finished",
+        body:
+          "Your billing account is still being set up, so bots cannot " +
+          "join yet. Finishing setup takes a minute.",
+        action: FINISH_SETUP,
+        retryable: false,
+      };
+    case "payment_past_due":
+      return {
+        reason,
+        kind: "paywall",
+        title: "Payment past due",
+        body:
+          "Your last payment did not go through, so bots are paused. " +
+          "Updating the payment method resumes them.",
+        action: UPDATE_PAYMENT,
+        retryable: false,
+      };
+    case "spend_cap_reached":
+      return {
+        reason,
+        kind: "limit",
+        title: "Monthly spend cap reached",
+        body:
+          "You set a hard spend cap and this month has reached it. " +
+          "Raising or clearing the cap resumes bots.",
+        action: REVIEW_SPEND_CAP,
+        retryable: false,
+      };
+    case "concurrency_limit_reached":
+      return {
+        reason,
+        kind: "limit",
+        title: "All bots are busy",
+        body: `${concurrencySentence(facts)} One will free up when a meeting ends.`,
+        action: null,
+        retryable: true,
+      };
+    case "billing_unavailable":
+      return {
+        reason,
+        kind: "retryable",
+        title: "Billing system temporarily unavailable",
+        body:
+          "Your account is fine — we could not reach the billing ledger " +
+          "just now. Try again shortly.",
+        action: null,
+        retryable: true,
+      };
+    default:
+      return unknownServiceDenial(reason);
+  }
+}
+
+function unknownServiceDenial(reason: string): ServiceDenialPresentation {
+  const label = reason.trim() || "unspecified";
+  // Fail loud where a developer will see it; never in the customer's face.
+  if (process.env.NODE_ENV !== "production") {
+    console.error(
+      `[service-denial] unmapped service-authority reason: ${label}. ` +
+        "Add it to serviceDenialPresentation before it reaches a customer.",
+    );
+  }
+  return {
+    reason,
+    kind: "unknown",
+    title: "Service not allowed",
+    body:
+      `service not allowed: ${label}. If this keeps happening, send us ` +
+      "this code and we will tell you exactly what it means.",
+    action: null,
+    retryable: true,
+  };
+}
+
+/**
+ * Compile-time exhaustiveness: adding a reason without a branch above turns
+ * this into a type error, so the vocabulary cannot drift ahead of the copy.
+ */
+const MAPPED_REASONS: Record<ServiceAuthorityReason, true> = {
+  allowed: true,
+  billing_setup_required: true,
+  insufficient_balance: true,
+  payment_past_due: true,
+  spend_cap_reached: true,
+  concurrency_limit_reached: true,
+  billing_unavailable: true,
+};
+
+export const SERVICE_DENIAL_REASONS = Object.keys(
+  MAPPED_REASONS,
+) as ServiceAuthorityReason[];
+
+/**
+ * Reads a denial out of an API error body.
+ *
+ * Two shapes are accepted because both are on the wire: FastAPI nests the
+ * payload under `detail` (`{"detail":{"code":…,"reason":…}}`, which is what
+ * `POST /bots` emits), and the platform routes emit the object bare. Returns
+ * null when the body is not a denial, so callers keep their own handling for
+ * genuine auth or transport faults.
+ */
+export function serviceDenialFromResponseBody(
+  body: unknown,
+  facts: ServiceDenialFacts = {},
+): ServiceDenialPresentation | null {
+  const payload = unwrapDetail(body);
+  if (typeof payload !== "object" || payload === null) return null;
+  const record = payload as Record<string, unknown>;
+  const code = typeof record.code === "string" ? record.code : null;
+  const reason = typeof record.reason === "string" ? record.reason : null;
+  if (code === SERVICE_NOT_ALLOWED_CODE) {
+    return serviceDenialPresentation(reason ?? "", facts);
+  }
+  if (code === SERVICE_AUTHORITY_UNAVAILABLE_CODE) {
+    // 503 from the same gate: our side, account untouched, retrying helps.
+    return {
+      reason: reason ?? SERVICE_AUTHORITY_UNAVAILABLE_CODE,
+      kind: "retryable",
+      title: "Billing system temporarily unavailable",
+      body:
+        "Your account is fine — we could not reach the billing ledger " +
+        "just now. Try again shortly.",
+      action: null,
+      retryable: true,
+    };
+  }
+  return null;
+}
+
+function unwrapDetail(body: unknown): unknown {
+  if (typeof body !== "object" || body === null) return body;
+  const record = body as Record<string, unknown>;
+  if ("code" in record) return record;
+  if ("detail" in record) return record.detail;
+  return record;
+}
+
+/**
+ * Reads a denial off a thrown error. Only 4xx/5xx bodies carrying the denial
+ * code qualify — a 401, or a 403 that is a genuine permission fault, returns
+ * null and keeps its access-error rendering.
+ */
+export function serviceDenialFromError(
+  error: unknown,
+  facts: ServiceDenialFacts = {},
+): ServiceDenialPresentation | null {
+  if (!(error instanceof VexaAPIError)) return null;
+  if (error.status === 401) return null;
+  return serviceDenialFromResponseBody(error.details, facts);
+}

--- a/services/dashboard/tests/error-messages.test.ts
+++ b/services/dashboard/tests/error-messages.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { VexaAPIError } from "../src/lib/api";
+import { getUserFriendlyError } from "../src/lib/error-messages";
+
+describe("getUserFriendlyError", () => {
+  it("does not flatten a billing denial into 'Access denied'", () => {
+    const error = new VexaAPIError("API request failed: Forbidden", 403, {
+      detail: { code: "service_not_allowed", reason: "insufficient_balance" },
+    });
+    const { title, description } = getUserFriendlyError(error);
+    expect(title).toBe("Out of credit");
+    expect(description).toContain("Add funds");
+  });
+
+  it("does not flatten an unmapped denial reason either", () => {
+    const error = new VexaAPIError("API request failed: Forbidden", 403, {
+      detail: { code: "service_not_allowed", reason: "quota_frobnicated" },
+    });
+    expect(getUserFriendlyError(error).description).toContain(
+      "service not allowed: quota_frobnicated",
+    );
+  });
+
+  it("keeps a genuine 403 as an access error", () => {
+    const error = new VexaAPIError("Invalid or missing API key", 403, {
+      detail: "Invalid or missing API key",
+    });
+    expect(getUserFriendlyError(error)).toEqual({
+      title: "Access denied",
+      description: "Invalid or missing API key",
+    });
+  });
+
+  it("keeps 401 as an authentication failure", () => {
+    const error = new VexaAPIError("Not authenticated", 401);
+    expect(getUserFriendlyError(error).title).toBe("Authentication failed");
+  });
+
+  it("states the concurrency ceiling the 0.10 core named", () => {
+    const error = new VexaAPIError("Concurrent bot limit reached (2/3)", 403);
+    const { title, description } = getUserFriendlyError(error);
+    expect(title).toBe("Bot limit reached");
+    expect(description).toContain("Your plan runs 3 bots at once and 2 are already in a meeting.");
+  });
+
+  it("states the ceiling from the bare-limit phrasing too", () => {
+    const error = new VexaAPIError(
+      "User has reached the maximum concurrent bot limit (1).",
+      403,
+    );
+    expect(getUserFriendlyError(error).description).toContain(
+      "Your plan runs 1 bot at once",
+    );
+  });
+
+  it("still describes the state when no number is on the wire", () => {
+    const error = new VexaAPIError("Concurrent bot limit reached", 403);
+    expect(getUserFriendlyError(error).description).toContain(
+      "maximum number of concurrent bots",
+    );
+  });
+
+  it("keeps rate limits, server errors and network faults as they were", () => {
+    expect(getUserFriendlyError(new Error("rate limit exceeded")).title).toBe(
+      "Too many requests",
+    );
+    expect(getUserFriendlyError(new VexaAPIError("boom", 500)).title).toBe("Server error");
+    expect(getUserFriendlyError(new Error("failed to fetch")).title).toBe(
+      "Connection error",
+    );
+  });
+});

--- a/services/dashboard/tests/join-error.test.ts
+++ b/services/dashboard/tests/join-error.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { VexaAPIError } from "../src/lib/api";
+import {
+  denialActionUrl,
+  isAccessError,
+  resolveJoinError,
+} from "../src/lib/join-error";
+
+function apiError(status: number, message: string, details?: unknown) {
+  return new VexaAPIError(message, status, details);
+}
+
+function denial(reason: string, status = 403) {
+  return apiError(status, "API request failed: Forbidden", {
+    detail: { code: "service_not_allowed", reason, decision_id: "dec_1" },
+  });
+}
+
+describe("resolveJoinError — the join flow's rendering states", () => {
+  it("renders a paywall PANEL, not a toast, when the account is out of credit", () => {
+    const state = resolveJoinError(denial("insufficient_balance"));
+    expect(state.kind).toBe("denial");
+    if (state.kind !== "denial") throw new Error("unreachable");
+    expect(state.presentation.kind).toBe("paywall");
+    expect(state.presentation.title).toBe("Out of credit");
+    expect(state.presentation.action?.href).toBe("/account?tab=bots");
+  });
+
+  it("renders billing_unavailable as a retryable panel with no CTA", () => {
+    const state = resolveJoinError(denial("billing_unavailable"));
+    if (state.kind !== "denial") throw new Error("expected a denial panel");
+    expect(state.presentation.retryable).toBe(true);
+    expect(state.presentation.action).toBeNull();
+  });
+
+  it("renders an unmapped reason verbatim in the panel", () => {
+    const state = resolveJoinError(denial("gravity_exceeded"));
+    if (state.kind !== "denial") throw new Error("expected a denial panel");
+    expect(state.presentation.body).toContain("service not allowed: gravity_exceeded");
+  });
+
+  it("hands a missing Zoom connection to the OAuth flow, not to a panel", () => {
+    const error = apiError(400, "Zoom OAuth connection is missing");
+    const state = resolveJoinError(error, {
+      platform: "zoom",
+      canStartZoomOAuth: true,
+    });
+    expect(state.kind).toBe("zoom-oauth");
+  });
+
+  it("does not attempt the OAuth hand-off when it cannot run", () => {
+    const error = apiError(400, "Zoom OAuth connection is missing");
+    const state = resolveJoinError(error, {
+      platform: "zoom",
+      canStartZoomOAuth: false,
+    });
+    expect(state.kind).toBe("toast");
+  });
+
+  it("keeps a genuine 403 permission fault as an access error toast", () => {
+    const state = resolveJoinError(
+      apiError(403, "Invalid or missing API key", { detail: "Invalid or missing API key" }),
+    );
+    expect(state).toEqual({
+      kind: "toast",
+      title: "Access denied",
+      description: "Invalid or missing API key",
+    });
+  });
+
+  it("keeps a 401 as an authentication failure toast", () => {
+    const state = resolveJoinError(apiError(401, "Not authenticated"));
+    if (state.kind !== "toast") throw new Error("expected a toast");
+    expect(state.title).toBe("Authentication failed");
+  });
+
+  it("never turns a service denial into 'Access denied'", () => {
+    for (const reason of [
+      "insufficient_balance",
+      "billing_unavailable",
+      "concurrency_limit_reached",
+      "payment_past_due",
+      "spend_cap_reached",
+      "billing_setup_required",
+      "who_knows",
+    ]) {
+      const state = resolveJoinError(denial(reason));
+      if (state.kind !== "denial") throw new Error(`${reason} did not render a panel`);
+      expect(state.presentation.title).not.toBe("Access denied");
+    }
+  });
+
+  it("falls back to a toast for transport failures", () => {
+    const state = resolveJoinError(new Error("network request failed"));
+    if (state.kind !== "toast") throw new Error("expected a toast");
+    expect(state.title).toBe("Connection error");
+  });
+
+  it("survives a non-Error rejection", () => {
+    const state = resolveJoinError("something odd");
+    expect(state.kind).toBe("toast");
+  });
+});
+
+describe("denialActionUrl", () => {
+  it("resolves the account path against the webapp origin", () => {
+    expect(denialActionUrl("https://vexa.ai", "/account?tab=bots")).toBe(
+      "https://vexa.ai/account?tab=bots",
+    );
+  });
+
+  it("does not double the slash on a trailing-slash base", () => {
+    expect(denialActionUrl("https://vexa.ai/", "/account?tab=balance")).toBe(
+      "https://vexa.ai/account?tab=balance",
+    );
+  });
+});
+
+describe("isAccessError", () => {
+  it("is true for 401 and for a genuine 403", () => {
+    expect(isAccessError(apiError(401, "Not authenticated"))).toBe(true);
+    expect(isAccessError(apiError(403, "Invalid or missing API key"))).toBe(true);
+  });
+
+  it("is false for a service denial dressed as a 403", () => {
+    expect(isAccessError(denial("insufficient_balance"))).toBe(false);
+  });
+
+  it("is false for everything else", () => {
+    expect(isAccessError(apiError(500, "boom"))).toBe(false);
+    expect(isAccessError(new Error("boom"))).toBe(false);
+  });
+});

--- a/services/dashboard/tests/service-denial-vocabulary.test.ts
+++ b/services/dashboard/tests/service-denial-vocabulary.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VexaAPIError } from "../src/lib/api";
+import { isAccessError, resolveJoinError } from "../src/lib/join-error";
+import {
+  SERVICE_DENIAL_REASONS,
+  serviceDenialPresentation,
+} from "../src/lib/service-denial";
+
+/**
+ * The denial-reason vocabulary, pinned.
+ *
+ * `core/meetings/contracts/service-authority.v1` (this repo) is SEALED and
+ * types `Decision.reason` as an OPAQUE `{"type":"string","minLength":1}` — by
+ * design, since that contract is deliberately policy-free. Nothing on the wire
+ * constrains the set, and the set is consumed by TWO copy modules in TWO
+ * repositories:
+ *
+ *   1. Vexa-ai/vexa           services/dashboard/src/lib/service-denial.ts
+ *   2. Vexa-ai/vexa-platform  services/webapp/apps/webapp/lib/service-denial-view.ts
+ *
+ * Two hand-maintained copies with nothing checking them against each other is
+ * the silent-drift class: a reason added in the authority renders here as a raw
+ * "service not allowed: <code>", which is the customer-visible failure that
+ * opened Vexa-ai/vexa-platform#291.
+ *
+ * This list is the pin. The twin assertion — which additionally derives the set
+ * from `ServiceAuthorityReason` and `decisionReason()` at their source — lives
+ * at Vexa-ai/vexa-platform
+ * services/webapp/apps/webapp/__tests__/service-authority-reason-vocabulary.test.ts
+ * and carries the same literal. Change one, change all four places named below.
+ *
+ * Narrowing `reason` to an enum in the contract is the deeper fix, and it is a
+ * BREAKING change to a frozen `.vN`: it needs a `service-authority.v2` on a
+ * `lane:contract` human-reviewed PR (gate:contract-version), not an edit to v1.
+ */
+const PINNED_REASON_VOCABULARY = [
+  "allowed",
+  "billing_setup_required",
+  "insufficient_balance",
+  "payment_past_due",
+  "spend_cap_reached",
+  "concurrency_limit_reached",
+  "billing_unavailable",
+] as const;
+
+const CROSS_REPO_FIXUP = [
+  "The denial-reason vocabulary changed. Update ALL of:",
+  "  1. this pin (Vexa-ai/vexa services/dashboard/tests/service-denial-vocabulary.test.ts)",
+  "  2. Vexa-ai/vexa services/dashboard/src/lib/service-denial.ts (the copy module)",
+  "  3. Vexa-ai/vexa-platform services/webapp/apps/webapp/lib/service-denial-view.ts (the twin copy module)",
+  "  4. Vexa-ai/vexa-platform services/webapp/apps/webapp/__tests__/service-authority-reason-vocabulary.test.ts (the twin pin)",
+  "A reason with copy on only one surface reaches customers as a raw code.",
+].join("\n");
+
+const sorted = (values: readonly string[]) => [...new Set(values)].sort();
+
+describe("service-authority denial-reason vocabulary (Vexa-ai/vexa-platform#291)", () => {
+  it("maps exactly the pinned vocabulary — no more, no less", () => {
+    expect(sorted(SERVICE_DENIAL_REASONS), CROSS_REPO_FIXUP).toEqual(
+      sorted(PINNED_REASON_VOCABULARY),
+    );
+  });
+
+  it("gives every pinned reason real copy, never the verbatim fallback", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      for (const reason of PINNED_REASON_VOCABULARY) {
+        const view = serviceDenialPresentation(reason);
+        expect(view.body, `${reason}\n${CROSS_REPO_FIXUP}`).not.toContain(
+          `service not allowed: ${reason}. If this keeps happening`,
+        );
+        expect(view.body).not.toMatch(/access denied/i);
+        expect(view.title.length).toBeGreaterThan(0);
+      }
+      // Not one of them fell through to the unmapped branch.
+      expect(consoleError, CROSS_REPO_FIXUP).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("keeps 'allowed' out of the denial-styled kinds", () => {
+    // `allowed` is in the vocabulary because the authority emits it, but it is
+    // not a denial: a caller reaching the view with it has mismatched
+    // allow/reason and must not be shown a paywall.
+    expect(serviceDenialPresentation("allowed").kind).toBe("unknown");
+    expect(serviceDenialPresentation("allowed").action).toBeNull();
+  });
+});
+
+describe("access failures are never dressed as a paywall", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("renders a 401 as an access error, not a denial panel", () => {
+    const error = new VexaAPIError("API request failed: Unauthorized", 401, {
+      detail: "Invalid API token",
+    });
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("toast");
+    expect(isAccessError(error)).toBe(true);
+  });
+
+  it("renders a genuine permission 403 as an access error, not a paywall", () => {
+    // A real permission fault: 403, but no `service_not_allowed` code in the
+    // body. Routing this to the paywall would tell a customer to pay for a
+    // problem money cannot fix.
+    const error = new VexaAPIError("API request failed: Forbidden", 403, {
+      detail: "Not authorized to access this meeting",
+    });
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("toast");
+    if (state.kind !== "toast") throw new Error("unreachable");
+    expect(state.title).not.toMatch(/credit|balance|billing|payment/i);
+    expect(isAccessError(error)).toBe(true);
+  });
+
+  it("does not confuse a 401 that happens to carry a denial-shaped body", () => {
+    // Defence in depth: the 401 branch short-circuits before body sniffing, so
+    // an expired token can never be presented as a billing problem.
+    const error = new VexaAPIError("API request failed: Unauthorized", 401, {
+      detail: { code: "service_not_allowed", reason: "insufficient_balance" },
+    });
+    expect(resolveJoinError(error).kind).toBe("toast");
+    expect(isAccessError(error)).toBe(true);
+  });
+
+  it("still routes a real 403 denial to the paywall panel", () => {
+    // The positive control for the three negatives above.
+    const error = new VexaAPIError("API request failed: Forbidden", 403, {
+      detail: { code: "service_not_allowed", reason: "insufficient_balance" },
+    });
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("denial");
+    if (state.kind !== "denial") throw new Error("unreachable");
+    expect(state.presentation.kind).toBe("paywall");
+    expect(isAccessError(error)).toBe(false);
+  });
+
+  it("logs an unmapped reason in a production build so the net can see it", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const error = new VexaAPIError("API request failed: Forbidden", 403, {
+      detail: { code: "service_not_allowed", reason: "region_unsupported" },
+    });
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("denial");
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("unmapped service-authority reason: region_unsupported"),
+    );
+  });
+});

--- a/services/dashboard/tests/service-denial.test.ts
+++ b/services/dashboard/tests/service-denial.test.ts
@@ -129,10 +129,15 @@ describe("unmapped reasons", () => {
     );
   });
 
-  it("stays quiet in production", () => {
+  it("fails loud IN PRODUCTION too — that is the only place drift happens", () => {
+    // An unmapped reason means the service authority shipped a reason ahead of
+    // this module's copy, which can only be observed in a production build. A
+    // dev-only console.error left the net with no signal at all.
     vi.stubEnv("NODE_ENV", "production");
     serviceDenialPresentation("brand_new_reason");
-    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("unmapped service-authority reason: brand_new_reason"),
+    );
   });
 });
 

--- a/services/dashboard/tests/service-denial.test.ts
+++ b/services/dashboard/tests/service-denial.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VexaAPIError } from "../src/lib/api";
+import {
+  SERVICE_DENIAL_REASONS,
+  serviceDenialFromError,
+  serviceDenialFromResponseBody,
+  serviceDenialPresentation,
+} from "../src/lib/service-denial";
+
+/** The wire shape `POST /bots` emits for a refused Join (FastAPI nests it). */
+function denialError(reason: string, status = 403): VexaAPIError {
+  return new VexaAPIError("API request failed: Forbidden", status, {
+    detail: {
+      code: "service_not_allowed",
+      reason,
+      decision_id: "dec_123",
+    },
+  });
+}
+
+describe("serviceDenialPresentation", () => {
+  it("renders insufficient_balance as a paywall with one fixing action", () => {
+    const view = serviceDenialPresentation("insufficient_balance");
+    expect(view.kind).toBe("paywall");
+    expect(view.title).toBe("Out of credit");
+    expect(view.body).toContain("Your prepaid balance is empty.");
+    expect(view.action).toEqual({ label: "Add funds", href: "/account?tab=bots" });
+    expect(view.retryable).toBe(false);
+  });
+
+  it("names the balance when the caller knows it", () => {
+    const view = serviceDenialPresentation("insufficient_balance", {
+      balanceCents: 137,
+      planLabel: "Pay-as-you-go",
+    });
+    expect(view.body).toContain("Your prepaid balance on Pay-as-you-go is $1.37.");
+  });
+
+  it("falls back to 'empty' rather than printing a nonsense balance", () => {
+    for (const balanceCents of [null, undefined, -1, 1.5, Number.NaN]) {
+      const view = serviceDenialPresentation("insufficient_balance", {
+        balanceCents: balanceCents as number | null | undefined,
+      });
+      expect(view.body).toContain("Your prepaid balance is empty.");
+    }
+  });
+
+  it("says billing_unavailable is ours, the account is fine, and retrying helps", () => {
+    const view = serviceDenialPresentation("billing_unavailable");
+    expect(view.kind).toBe("retryable");
+    expect(view.title).toBe("Billing system temporarily unavailable");
+    expect(view.body).toContain("Your account is fine");
+    expect(view.body).toContain("Try again shortly.");
+    expect(view.action).toBeNull();
+    expect(view.retryable).toBe(true);
+  });
+
+  it("states the concurrency ceiling by number when known", () => {
+    const view = serviceDenialPresentation("concurrency_limit_reached", {
+      concurrencyCeiling: 3,
+    });
+    expect(view.kind).toBe("limit");
+    expect(view.body).toContain("Your plan runs 3 bots at once");
+    expect(view.retryable).toBe(true);
+  });
+
+  it("singularizes a ceiling of one", () => {
+    const view = serviceDenialPresentation("concurrency_limit_reached", {
+      concurrencyCeiling: 1,
+    });
+    expect(view.body).toContain("Your plan runs 1 bot at once");
+  });
+
+  it("describes the concurrency state when the ceiling is unknown", () => {
+    const view = serviceDenialPresentation("concurrency_limit_reached");
+    expect(view.body).toContain("Every bot your plan allows is already in a meeting.");
+  });
+
+  it("routes billing_setup_required, payment_past_due and spend_cap_reached to their own fixes", () => {
+    expect(serviceDenialPresentation("billing_setup_required").action?.label).toBe(
+      "Finish billing setup",
+    );
+    expect(serviceDenialPresentation("payment_past_due").action?.label).toBe(
+      "Update payment method",
+    );
+    expect(serviceDenialPresentation("spend_cap_reached").action?.label).toBe(
+      "Review spend cap",
+    );
+  });
+
+  it("gives every known reason words that are not 'Access denied'", () => {
+    for (const reason of SERVICE_DENIAL_REASONS) {
+      const view = serviceDenialPresentation(reason);
+      expect(view.title).not.toBe("Access denied");
+      expect(view.body.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("unmapped reasons", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("shows the reason code VERBATIM, never a bare 'Access denied'", () => {
+    const view = serviceDenialPresentation("some_new_backend_reason");
+    expect(view.kind).toBe("unknown");
+    expect(view.body).toContain("service not allowed: some_new_backend_reason");
+    expect(view.body).not.toContain("Access denied");
+  });
+
+  it("labels an empty reason rather than emitting a dangling colon", () => {
+    const view = serviceDenialPresentation("   ");
+    expect(view.body).toContain("service not allowed: unspecified");
+  });
+
+  it("fails loud outside production so a developer sees the gap", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    serviceDenialPresentation("brand_new_reason");
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("unmapped service-authority reason: brand_new_reason"),
+    );
+  });
+
+  it("stays quiet in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    serviceDenialPresentation("brand_new_reason");
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});
+
+describe("serviceDenialFromResponseBody", () => {
+  it("reads the FastAPI-nested denial POST /bots emits", () => {
+    const view = serviceDenialFromResponseBody({
+      detail: { code: "service_not_allowed", reason: "insufficient_balance" },
+    });
+    expect(view?.kind).toBe("paywall");
+  });
+
+  it("reads the bare denial the platform routes emit", () => {
+    const view = serviceDenialFromResponseBody({
+      code: "service_not_allowed",
+      reason: "spend_cap_reached",
+    });
+    expect(view?.reason).toBe("spend_cap_reached");
+  });
+
+  it("maps the 503 service_authority_unavailable to the retryable outage copy", () => {
+    const view = serviceDenialFromResponseBody({
+      detail: {
+        code: "service_authority_unavailable",
+        reason: "service_authority_unavailable",
+      },
+    });
+    expect(view?.kind).toBe("retryable");
+    expect(view?.retryable).toBe(true);
+  });
+
+  it("returns null for anything that is not a denial", () => {
+    expect(serviceDenialFromResponseBody(null)).toBeNull();
+    expect(serviceDenialFromResponseBody("Invalid or missing API key")).toBeNull();
+    expect(serviceDenialFromResponseBody({ detail: "Not authenticated" })).toBeNull();
+    expect(serviceDenialFromResponseBody({ code: "something_else" })).toBeNull();
+  });
+});
+
+describe("serviceDenialFromError", () => {
+  it("extracts the denial from a thrown 403", () => {
+    const view = serviceDenialFromError(denialError("insufficient_balance"));
+    expect(view?.title).toBe("Out of credit");
+  });
+
+  it("extracts the denial from a 503 carrying the unavailable code", () => {
+    const error = new VexaAPIError("API request failed", 503, {
+      detail: { code: "service_authority_unavailable", reason: "service_authority_unavailable" },
+    });
+    expect(serviceDenialFromError(error)?.kind).toBe("retryable");
+  });
+
+  it("never claims a 401 is a denial — that stays an auth failure", () => {
+    const error = new VexaAPIError("Not authenticated", 401, {
+      detail: { code: "service_not_allowed", reason: "insufficient_balance" },
+    });
+    expect(serviceDenialFromError(error)).toBeNull();
+  });
+
+  it("leaves a genuine permission 403 alone", () => {
+    const error = new VexaAPIError("Invalid or missing API key", 403, {
+      detail: "Invalid or missing API key",
+    });
+    expect(serviceDenialFromError(error)).toBeNull();
+  });
+
+  it("ignores plain Errors", () => {
+    expect(serviceDenialFromError(new Error("boom"))).toBeNull();
+    expect(serviceDenialFromError(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
The customer-visible half of the paywall fix. The platform half is [Vexa-ai/vexa-platform#292](https://github.com/Vexa-ai/vexa-platform/pull/292), which named this exact gap: the bare "Access denied" the customer in [#291](https://github.com/Vexa-ai/vexa-platform/issues/291) actually saw lives here, in the 0.10 dashboard kept as the hosted UI.

## Which source this is

`vexaai/dashboard` is built from `services/dashboard/` on this line — the platform chart pins `dashboard.image` to `vexaai/dashboard:0.10.6.3` (prod runs the `0.10.6.3.14` hotfix tag off the same base), and this branch is `v0.10.6.3` + the 17 hosted-dashboard commits. Based on `codex/1150-dashboard-calendar`, the tip of that line. Nothing in `clients/terminal` or on the frozen `codex/1150-calendar-multi` is touched.

## What changed

**`src/lib/service-denial.ts`** (new) — the dashboard twin of `lib/service-denial-view.ts` in #292, kept copy-aligned so the account page and the join flow say the same sentence about the same account.

| reason | rendering |
|---|---|
| `insufficient_balance` | paywall — the balance when a caller knows it, one **Add funds** action |
| `billing_unavailable`, 503 `service_authority_unavailable` | "your account is fine — try again shortly", no CTA, retryable |
| `concurrency_limit_reached` | the ceiling, by number |
| `spend_cap_reached`, `billing_setup_required`, `payment_past_due` | each to its own fix |
| anything unmapped | **verbatim**: `service not allowed: <reason>`, plus `console.error` outside production |

A `Record<ServiceAuthorityReason, true>` makes a new reason without copy a compile error. Both wire shapes are read — FastAPI's nested `{"detail":{…}}` (what `POST /bots` emits) and the bare object the platform routes emit.

**`src/lib/join-error.ts`** (new) — resolves a failed Join into one of three states (`denial` · `zoom-oauth` · `toast`) so the modal and the pending-meeting hook cannot disagree, and so the mapping is testable without a DOM.

**`src/components/join/service-denial-panel.tsx`** (new) + **`join-modal.tsx`** — a denial renders as a panel inside the Join modal, styled on the modal's existing inline-notice idiom, with the fixing action as a button. Not a toast: a paywall the customer has to act on should not expire on a timer.

**`src/lib/error-messages.ts`** — denials are routed before the 403 branch. 401s and genuine permission 403s keep their access-error rendering unchanged. The 0.10 core's plain-string concurrency 403 (`Concurrent bot limit reached (2/3)`) now repeats the ceiling it named.

## What this UI cannot do

`GET /api/account/spend-cap` — the balance endpoint #292 added — is on the webapp origin behind its own session cookie, and this dashboard has no client for it (it only ever links to `vexa.ai`). Adding a cross-origin authenticated read is a separate change. So the balance renders only when a caller supplies it, and the copy is truthful without it ("Your prepaid balance is empty."). The service-authority `Decision` contract carries no balance either, so the denial body cannot supply it today.

## Tests and build

`npm test` → **15 files, 112 tests passed** (45 new). `npx tsc --noEmit` → one pre-existing error (`release-version.generated.json`, a prebuild artifact), unchanged. `eslint` clean on every touched file. `VEXA_API_URL=… npm run build` → success.

- `tests/service-denial.test.ts` — the reason mapping, both wire shapes, the verbatim-unmapped path, the loud dev failure, and that no known reason produces "Access denied".
- `tests/join-error.test.ts` — the three join-flow rendering states, including that a genuine 403 and a 401 stay access errors.
- `tests/error-messages.test.ts` — the non-flattening, and the concurrency ceiling.

Screenshots: N/A.

Refs Vexa-ai/vexa-platform#291
Refs Vexa-ai/vexa-platform#292

<!-- vexa-agent -->
