### PR TITLE
terminal: a meeting you can link to — /meetings/<id>

### DIFF
--- a/clients/terminal/DECISIONS.md
+++ b/clients/terminal/DECISIONS.md
@@ -92,3 +92,28 @@ A pass to make the first-run + workspace experience real (no mocks, no dead UI):
   folds the meeting's live transcript (redis `tc:meeting:{native}`) into the prompt server-side, fresh each
   turn. The client adds no prompt preamble and points at no notes file. (Replaced the earlier notes-file
   workaround, itself a stand-in for the unwired `meeting.read_transcript` MCP tool that hung the worker.)
+
+## D7 — the open meeting is addressable: `/meetings/<id>`
+Until now the terminal was a **single route** (`/`). Which meeting was open lived only in the dockview
+layout in `localStorage` (`vexa.terminal.dock.v3`), so a hard reload restored it *in that browser* while
+the URL referenced nothing: a meeting could not be pasted to a colleague, bookmarked, or reopened in a
+fresh session. The only URL that ever reached a meeting was a `?tshare=` token, and that flow deliberately
+strips itself back to `/` after redeeming.
+
+- **The reference is the meetings-domain ROW id** — the same `id` the client already keys the tab, the
+  live streams (`tc:meeting:{id}`) and `GET /api/transcripts/by-id/{id}` by. **No API change is implied.**
+  The public transcript API still keys by `platform/native_meeting_id`; the route carries only the id the
+  existing client data paths already resolve, so nothing about fetching moved.
+- **One shell, two routes.** `src/app/meetings/[meetingId]/page.tsx` renders the same `<App/>` as `/`.
+  A second app would drift; a route that only *deep-links* would fork the layout logic.
+- **The URL follows the active tab, it does not drive it.** In-app navigation (row click, preview slot,
+  restored dock) is unchanged and remains the interactive path; a `history.replaceState` effect mirrors
+  the active meeting tab into the address bar (`replaceState`, not push — the workbench keeps its own
+  history under Escape / Alt+Left). Only `/` and `/meetings/<id>` are ever rewritten.
+- **Landing is the existing first-view resolver**, extended with `routeMeetingId` — ranked below a
+  just-redeemed share (that stash belongs to *this* navigation) and above everything else, and applying
+  to a returning user, because opening that address IS the explicit act. A passively-mounted shared
+  workspace does not ride along; a just-accepted invite does.
+- **An unknown id is an answer, not a spinner.** A dead reference is a normal outcome of a shareable URL,
+  so the tab renders a not-found state — gated on the meetings list having *answered at least once*
+  (`useLiveMeetingsLoaded`), so an offline list can never make a live meeting look deleted.

--- a/clients/terminal/src/app/__tests__/meetingRoute.test.ts
+++ b/clients/terminal/src/app/__tests__/meetingRoute.test.ts
@@ -1,0 +1,53 @@
+/** The addressable-meeting URL contract: `/meetings/<id>` parses back to exactly the id that was put
+ *  in, refuses anything it can't own, and never widens into another route. */
+import { describe, it, expect } from "vitest";
+import { isMeetingRouteId, isOwnedPath, meetingIdFromPath, meetingPath } from "../meetingRoute";
+
+describe("meetingPath — id → URL", () => {
+  it("a row id becomes /meetings/<id>", () => expect(meetingPath("482")).toBe("/meetings/482"));
+  it("a native meeting code survives", () => expect(meetingPath("abc-defg-hij")).toBe("/meetings/abc-defg-hij"));
+  it("a teams thread id is percent-encoded", () => {
+    expect(meetingPath("19:meeting_abc@thread.v2")).toBe("/meetings/19%3Ameeting_abc%40thread.v2");
+  });
+  it("an unusable id falls back to the home route (never a broken URL)", () => {
+    expect(meetingPath("")).toBe("/");
+    expect(meetingPath("a/b")).toBe("/");
+    expect(meetingPath("has space")).toBe("/");
+  });
+});
+
+describe("meetingIdFromPath — URL → id", () => {
+  it("reads the id back", () => expect(meetingIdFromPath("/meetings/482")).toBe("482"));
+  it("decodes percent-encoding (round-trips meetingPath)", () => {
+    const id = "19:meeting_abc@thread.v2";
+    expect(meetingIdFromPath(meetingPath(id))).toBe(id);
+  });
+  it("tolerates a trailing slash", () => expect(meetingIdFromPath("/meetings/482/")).toBe("482"));
+  it("is null off the meeting route", () => {
+    expect(meetingIdFromPath("/")).toBeNull();
+    expect(meetingIdFromPath("/meetings")).toBeNull();
+    expect(meetingIdFromPath("/settings/482")).toBeNull();
+    expect(meetingIdFromPath(null)).toBeNull();
+  });
+  it("rejects an empty id, extra segments, and a malformed escape", () => {
+    expect(meetingIdFromPath("/meetings/")).toBeNull();
+    expect(meetingIdFromPath("/meetings/482/transcript")).toBeNull();
+    expect(meetingIdFromPath("/meetings/%E0%A4%A")).toBeNull();
+  });
+  it("rejects an id that could escape the segment", () => {
+    expect(isMeetingRouteId("../../api/admin")).toBe(false);
+    expect(isMeetingRouteId("a".repeat(129))).toBe(false);
+    expect(isMeetingRouteId("482")).toBe(true);
+  });
+});
+
+describe("isOwnedPath — which URLs the sync effect may rewrite", () => {
+  it("owns home and meeting routes", () => {
+    expect(isOwnedPath("/")).toBe(true);
+    expect(isOwnedPath("/meetings/482")).toBe(true);
+  });
+  it("leaves every other route alone", () => {
+    expect(isOwnedPath("/debug/transcript")).toBe(false);
+    expect(isOwnedPath("/meetings/482/extra")).toBe(false);
+  });
+});

--- a/clients/terminal/src/app/meetingRoute.ts
+++ b/clients/terminal/src/app/meetingRoute.ts
@@ -1,0 +1,51 @@
+/** meetingRoute — the URL shape that makes an open meeting REFERENCEABLE.
+ *
+ *  Before this, the terminal was a single route (`/`): which meeting was open lived only in the
+ *  dockview layout in localStorage. That survives a reload in the same browser, but the URL is not a
+ *  reference — you cannot paste a meeting to a colleague, bookmark it, or reopen it in a fresh session.
+ *
+ *  The durable reference is `/meetings/<meeting id>`, where the id is the meetings-domain ROW id the
+ *  client already keys everything by (`MeetingMock.id` — the same id `GET /api/transcripts/by-id/{id}`
+ *  and the row-keyed live streams use). No API change is implied: the route only carries the id the
+ *  existing client data paths already resolve. In-app navigation (clicking a row, the preview slot) is
+ *  unchanged — the URL is kept in sync behind it.
+ *
+ *  Pure + dependency-free so the parsing/formatting contract is unit-tested without a DOM or a router. */
+
+/** The single route prefix. */
+export const MEETING_ROUTE_PREFIX = "/meetings/";
+
+/** Ids we are willing to put in, and take out of, a path segment. Row ids are numeric today, but a
+ *  reference may also carry a native meeting code (`abc-defg-hij`, `19:meeting_…@thread.v2`,
+ *  `room@jitsi.example.org`), so the charset is permissive — and bounded, with no path separators,
+ *  whitespace or wildcards, so a hostile URL can never widen into another route or a request path. */
+const ID_RE = /^[A-Za-z0-9._:@=+-]{1,128}$/;
+
+/** True if `id` is a syntactically usable meeting reference. Says nothing about existence — an id that
+ *  passes here and resolves to nothing renders the not-found state. */
+export function isMeetingRouteId(id: string): boolean {
+  return ID_RE.test(id);
+}
+
+/** The canonical path for a meeting id, or `/` when the id is unusable. */
+export function meetingPath(id: string): string {
+  const v = (id ?? "").trim();
+  return isMeetingRouteId(v) ? `${MEETING_ROUTE_PREFIX}${encodeURIComponent(v)}` : "/";
+}
+
+/** The meeting id carried by a pathname, or null when the path is not a meeting route.
+ *  Tolerates a trailing slash and percent-encoding; rejects extra segments and bad ids. */
+export function meetingIdFromPath(pathname: string | null | undefined): string | null {
+  if (!pathname || !pathname.startsWith(MEETING_ROUTE_PREFIX)) return null;
+  const rest = pathname.slice(MEETING_ROUTE_PREFIX.length).replace(/\/+$/, "");
+  if (!rest || rest.includes("/")) return null;
+  let id: string;
+  try { id = decodeURIComponent(rest); } catch { return null; }   // malformed %-escape
+  return isMeetingRouteId(id) ? id : null;
+}
+
+/** True if this pathname is one WE own (`/` or a meeting route) — the URL-sync effect only ever
+ *  rewrites these two shapes, so it can never clobber a route someone else adds later. */
+export function isOwnedPath(pathname: string | null | undefined): boolean {
+  return pathname === "/" || meetingIdFromPath(pathname) !== null;
+}

--- a/clients/terminal/src/app/meetings/README.md
+++ b/clients/terminal/src/app/meetings/README.md
@@ -1,0 +1,6 @@
+# app/meetings
+
+The addressable meeting route. `/meetings/<id>` renders the same workbench shell as `/`, so an open
+meeting has a URL that can be pasted, bookmarked and reloaded — the durable reference behind the
+in-app (dockview) navigation, which is unchanged. The id is the meetings-domain row id; the shape and
+the parsing contract live in `../meetingRoute.ts`.

--- a/clients/terminal/src/app/meetings/[meetingId]/README.md
+++ b/clients/terminal/src/app/meetings/[meetingId]/README.md
@@ -1,0 +1,5 @@
+# app/meetings/[meetingId]
+
+One page: the workbench, with the meeting id carried in the path. `Workbench.resolveFirstView` reads it
+(via `meetingIdFromPath`) at first render and opens that meeting's tab; an id that resolves to nothing
+renders the meeting tab's not-found state.

--- a/clients/terminal/src/app/meetings/[meetingId]/page.tsx
+++ b/clients/terminal/src/app/meetings/[meetingId]/page.tsx
@@ -1,0 +1,10 @@
+/** `/meetings/<id>` — the addressable meeting route.
+ *
+ *  Renders the SAME workbench shell as `/`; the id in the path is read by the first-view resolver
+ *  (Workbench.resolveFirstView), which opens that meeting's tab. Keeping one shell means a meeting URL
+ *  is a real reference — reload it, share it, open it in a fresh session — with no second app to drift. */
+import { App } from "../../App";
+
+export default function MeetingPage() {
+  return <App />;
+}

--- a/clients/terminal/src/surfaces/__tests__/meetingNotFound.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/meetingNotFound.test.tsx
@@ -1,0 +1,50 @@
+/** What an addressable meeting URL does with an id that isn't ours.
+ *
+ *  `/meetings/<id>` can be pasted, bookmarked and reloaded, so a dead reference is a NORMAL outcome —
+ *  a deleted row, a typo, someone else's un-shared meeting. It must read as an answer, never as a
+ *  crash and never as a "Connecting…" that never ends. The resolution is a pure function of (row,
+ *  list-has-answered) precisely so a network blip can't make a live meeting look deleted.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MeetingNotFound, meetingResolution } from "../meeting";
+import type { MeetingMock } from "../meetingModel";
+
+const row = (id: string): MeetingMock => ({
+  id, native_id: "abc-defg-hij", title: "Google Meet · abc-defg-hij", when: "now",
+  status: "past", live_status: "completed", platform: "Google Meet", has_recording: false,
+  docs: [], participants: [], mentioned: [], actions: [], transcript: [], insights: [],
+} as MeetingMock);
+
+afterEach(cleanup);
+
+describe("meetingResolution — (row, list answered) → what the tab shows", () => {
+  it("row present → resolved", () => expect(meetingResolution(row("482"), true)).toBe("resolved"));
+  it("no row and the list has NOT answered yet → still resolving (never a premature not-found)", () => {
+    expect(meetingResolution(undefined, false)).toBe("resolving");
+  });
+  it("no row once the list HAS answered → not-found", () => {
+    expect(meetingResolution(undefined, true)).toBe("not-found");
+  });
+  it("a resolved row is resolved even before the list settles (an optimistic row still renders)", () => {
+    expect(meetingResolution(row("482"), false)).toBe("resolved");
+  });
+});
+
+describe("MeetingNotFound — the clean dead end", () => {
+  it("names the id that failed to resolve", () => {
+    render(<MeetingNotFound meetingId="9999" />);
+    expect(screen.getByText("Meeting not found")).toBeTruthy();
+    expect(screen.getByText("9999")).toBeTruthy();
+  });
+
+  it("offers a way out when one is wired", () => {
+    render(<MeetingNotFound meetingId="9999" onOpenToday={() => {}} />);
+    expect(screen.getByRole("button", { name: "Open today" })).toBeTruthy();
+  });
+
+  it("an id-less route still renders an answer, not an empty shell", () => {
+    render(<MeetingNotFound meetingId="" />);
+    expect(screen.getByText("Meeting not found")).toBeTruthy();
+  });
+});

--- a/clients/terminal/src/surfaces/liveMeetings.ts
+++ b/clients/terminal/src/surfaces/liveMeetings.ts
@@ -129,6 +129,9 @@ function formatTranscriptTime(start?: number | null): string {
 const LIVE_STATUSES = new Set(["active", "joining", "requested", "awaiting_admission", "needs_help", "stopping"]);
 
 let meetings: MeetingMock[] = [];
+let loaded = false;        // a snapshot has come back at least once — an id absent from the list is then
+                           // genuinely unknown (not merely not-fetched-yet), which is what lets a meeting
+                           // route render a not-found state instead of a forever-"Connecting…" shell.
 let wsConnected = false;   // the live meeting.status stream's connection state — part of the store's external state
 const subs = new Set<() => void>();
 let started = false;
@@ -213,12 +216,15 @@ async function snapshot() {
     const key = (m: MeetingMock[]) => m.map((x) =>
       `${x.id}|${x.live_status}|${x.has_recording}|${x.title_custom ?? ""}|${x.scheduled_at ?? ""}|${x.workspace_id ?? ""}|${x.auto_join ?? ""}|${x.auto_join_error ?? ""}|${x.native_id ?? ""}|${(x.attendees ?? []).map((a) => a.email).join("+")}`,
     ).join(",");
-    if (key(next) !== key(meetings)) {
+    const wasLoaded = loaded;
+    loaded = true;
+    if (!wasLoaded || key(next) !== key(meetings)) {
       meetings = next;
       subs.forEach((f) => f());
     }
   } catch {
-    /* offline — keep last known */
+    /* offline — keep last known, and stay UNLOADED: an unreachable list must not make every meeting
+       look deleted. The view keeps resolving until a snapshot actually answers. */
   }
 }
 
@@ -329,6 +335,18 @@ export function useLiveMeetingsConnection(): boolean {
   return useSyncExternalStore(
     (cb) => { subs.add(cb); return () => subs.delete(cb); },
     () => wsConnected,
+    () => false,
+  );
+}
+
+/** Subscribe a component to whether the meetings list has ANSWERED at least once. `false` means "still
+ *  resolving"; `true` means the list is authoritative, so an id missing from it does not exist for this
+ *  user (deleted, never existed, or owned by someone else and not shared). */
+export function useLiveMeetingsLoaded(): boolean {
+  ensureStarted();
+  return useSyncExternalStore(
+    (cb) => { subs.add(cb); return () => subs.delete(cb); },
+    () => loaded,
     () => false,
   );
 }

--- a/clients/terminal/src/surfaces/meeting.tsx
+++ b/clients/terminal/src/surfaces/meeting.tsx
@@ -12,7 +12,7 @@ import { ContextMenu, copyText } from "../ui-kit/ContextMenu";
 import { MEETING_CANVAS_CONTENT_INSET, MeetingCanvasView } from "../canvas/MeetingCanvasView";
 import { type MeetingMock } from "./meetingModel";
 import { ApiError, presentError } from "./apiClient";
-import { useLiveMeetings, useLiveMeetingsConnection, liveMeetingsNow, refreshMeetings } from "./liveMeetings";
+import { useLiveMeetings, useLiveMeetingsConnection, useLiveMeetingsLoaded, liveMeetingsNow, refreshMeetings } from "./liveMeetings";
 import { usePreviewPinTab } from "./previewPinTab";
 import { defaultBotName } from "./defaultBotName";
 import { parseMeetingInput } from "./meetingId";
@@ -801,8 +801,45 @@ export function meetingHeaderState(m: MeetingMock | undefined, connected: boolea
   return connected ? "live" : "reconnecting";
 }
 
+/** Whether a requested meeting id has RESOLVED, is still resolving, or does not exist for this user.
+ *  `listLoaded` is the meetings list having answered at least once — without it an id that simply hasn't
+ *  been fetched yet is indistinguishable from one that doesn't exist, and an addressable URL
+ *  (`/meetings/<id>`) would show a permanent "Connecting…" for a deleted or foreign meeting.
+ *  Exported for the routing test. */
+export type MeetingResolution = "resolving" | "resolved" | "not-found";
+export function meetingResolution(m: MeetingMock | undefined, listLoaded: boolean): MeetingResolution {
+  if (m) return "resolved";
+  return listLoaded ? "not-found" : "resolving";
+}
+
+/** The clean terminal state for an id that isn't ours (deleted, mistyped, someone else's un-shared
+ *  meeting). A dead reference is a normal outcome of a shareable URL, so it reads as an answer — not an
+ *  error, not a spinner that never ends. Pure (no services) so it renders in a test as-is. */
+export function MeetingNotFound({ meetingId, onOpenToday }: { meetingId: string; onOpenToday?: () => void }) {
+  return (
+    <div role="status" style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", padding: 24 }}>
+      <div style={{ maxWidth: 380, textAlign: "center" }}>
+        <div style={{ fontSize: 15, color: "var(--t1)", fontWeight: 550, marginBottom: 6 }}>Meeting not found</div>
+        <div style={{ fontSize: 12.5, color: "var(--t3)", lineHeight: 1.55 }}>
+          {meetingId
+            ? <>Nothing here matches <span style={{ fontFamily: "var(--mono)", color: "var(--t2)" }}>{meetingId}</span>. It may have been deleted, or it belongs to someone who hasn&apos;t shared it with you.</>
+            : <>This link doesn&apos;t carry a meeting. Open one from your day.</>}
+        </div>
+        {onOpenToday && (
+          <button onClick={onOpenToday}
+            style={{ marginTop: 16, fontSize: 12.5, padding: "5px 12px", background: "transparent", border: "1px solid var(--line2)", color: "var(--t2)", borderRadius: 7, cursor: "pointer" }}>
+            Open today
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function MeetingTab({ params }: TabProps) {
+  const layout = useService(LayoutServiceId);
   const liveList = useLiveMeetings();
+  const listLoaded = useLiveMeetingsLoaded();
   const connected = useLiveMeetingsConnection();
   const requestedMeetingId = params.meetingId as string;
   // ONE resolver, shared with the canvas body (useMeeting.resolveMeeting): the real meetings list is the
@@ -811,6 +848,18 @@ function MeetingTab({ params }: TabProps) {
   // id with a neutral header (never a wrong/mock meeting), so the header can't disagree with the body.
   const m = liveList.find((x) => x.id === requestedMeetingId || x.native_id === requestedMeetingId);
   const header = meetingHeaderState(m, connected);
+
+  // An unknown id — a stale/foreign/mistyped meeting URL — is a clean dead end, never a crash and never
+  // an endless "Connecting…". Only once the list has actually answered (P0: an offline list keeps
+  // resolving, so a network blip can't make a live meeting look deleted).
+  if (meetingResolution(m, listLoaded) === "not-found") {
+    return (
+      <MeetingNotFound
+        meetingId={requestedMeetingId}
+        onOpenToday={() => layout.openTab({ id: "today", title: "Today", kind: "today", params: {} })}
+      />
+    );
+  }
 
   return (
     <div style={{ width: "100%", height: "100%", minHeight: 0, display: "flex", flexDirection: "column", padding: "16px 0 24px", boxSizing: "border-box" }}>

--- a/clients/terminal/src/workbench/Workbench.tsx
+++ b/clients/terminal/src/workbench/Workbench.tsx
@@ -26,6 +26,7 @@ import { Chat } from "../surfaces/chat";
 import { resolveDocRef } from "../ui-kit/docLinks";
 import { liveMeetingsNow } from "../surfaces/liveMeetings";
 import { firstViewPlan } from "./firstView";
+import { isOwnedPath, meetingIdFromPath, meetingPath } from "../app/meetingRoute";
 import { OPEN_ENTITY_EVENT } from "../canvas/actions";
 import { useTheme } from "../app/theme";
 import { meetingsOnly } from "../app/mode";
@@ -338,6 +339,29 @@ export function Workbench() {
   // `fresh` = the dock restored no tabs (a genuine first landing). A returning user with a saved layout
   // gets ONLY the explicit shared-meeting arm (they clicked a share link) — never a surprise re-pin.
   const firstViewDone = useRef(false);
+  // The meeting id carried by the URL (`/meetings/<id>`), captured at FIRST RENDER — before any effect
+  // (including the URL-sync effect below) can rewrite the address bar. This is the durable reference:
+  // a hard reload, a pasted link, or a brand-new session all arrive here.
+  const routeMeetingId = useRef<string | null>(
+    typeof window === "undefined" ? null : meetingIdFromPath(window.location.pathname),
+  );
+
+  // ── URL SYNC — the open meeting is reflected in the address bar, so what's on screen is always
+  // referenceable. `replaceState` (not push): in-app navigation keeps its own history (Escape /
+  // Alt+Left via layout.goBack), and we never want a stack of dockview states in the browser's.
+  // Only the two shapes we own (`/`, `/meetings/<id>`) are ever rewritten; query + hash are preserved
+  // so an in-flight ?invite= / ?tshare= round-trip is untouched.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mid = activeTab?.kind === "meeting" ? String((activeTab.params as { meetingId?: unknown })?.meetingId ?? "") : "";
+    const cur = window.location.pathname;
+    if (!isOwnedPath(cur)) return;
+    const next = mid ? meetingPath(mid) : "/";
+    if (next === cur) return;
+    try { window.history.replaceState(window.history.state, "", next + window.location.search + window.location.hash); }
+    catch { /* history unavailable (sandboxed frame) — the in-app path still works */ }
+  }, [activeTab]);
+
   const resolveFirstView = async (fresh: boolean) => {
     // an explicit shared meeting from a ?tshare= link (InviteRedeemer stashed it before the reload)
     let sharedMeetingId: string | null = null;
@@ -363,7 +387,10 @@ export function Workbench() {
     };
     const openMeeting = (mid: string, reveal: boolean) => {
       if (reveal && !meetOnly) layout.setActiveList("meetings");
-      layout.openTab({ id: `meeting:${mid}`, title: "Shared meeting", kind: "meeting", params: { meetingId: mid } });
+      // A meeting reached by URL is just "Meeting" until the row resolves; one reached by a share link
+      // is labelled as such. Either way the tab id is the same, so it de-dupes with a restored tab.
+      const title = mid === routeMeetingId.current && !sharedMeetingId ? "Meeting" : "Shared meeting";
+      layout.openTab({ id: `meeting:${mid}`, title, kind: "meeting", params: { meetingId: mid } });
     };
     // `forceKnowledge` = land ON the Knowledge section unconditionally (an accepted invite is explicit —
     // the shared workspace's tree must show, even for a returning user whose saved rail was Meetings/etc).
@@ -375,7 +402,7 @@ export function Workbench() {
       layout.openTab({ id: slug ? `doc:${slug}:README.md` : "doc:README.md", title: "README.md", kind: "doc", params: { path: "README.md", slug } });
     };
 
-    const plan = firstViewPlan({ sharedMeetingId, acceptedSlug, sharedSlug, liveMeetingId: liveMeetingsNow()[0]?.id ?? null, fresh });
+    const plan = firstViewPlan({ sharedMeetingId, routeMeetingId: routeMeetingId.current, acceptedSlug, sharedSlug, liveMeetingId: liveMeetingsNow()[0]?.id ?? null, fresh });
     switch (plan.kind) {
       case "meeting-and-workspace": openMeeting(plan.meetingId, false); pinReadme(plan.slug, !!acceptedSlug); break;  // README pinned last → focused
       case "meeting":               openMeeting(plan.meetingId, true); break;

--- a/clients/terminal/src/workbench/__tests__/firstView.test.ts
+++ b/clients/terminal/src/workbench/__tests__/firstView.test.ts
@@ -3,7 +3,7 @@ import { firstViewPlan } from "../firstView";
 
 /** The landing priority: what the user sees on first view, by what's SHARED with them. */
 describe("firstViewPlan — landing priority resolution", () => {
-  const base = { sharedMeetingId: null, acceptedSlug: null, sharedSlug: null, liveMeetingId: null, fresh: true } as const;
+  const base = { sharedMeetingId: null, routeMeetingId: null, acceptedSlug: null, sharedSlug: null, liveMeetingId: null, fresh: true } as const;
 
   it("nothing shared, fresh dock → the Meetings day (Today)", () => {
     expect(firstViewPlan({ ...base })).toEqual({ kind: "own-day" });
@@ -28,6 +28,37 @@ describe("firstViewPlan — landing priority resolution", () => {
 
   it("an explicit shared meeting outranks a known live meeting", () => {
     expect(firstViewPlan({ ...base, sharedMeetingId: "m7", liveMeetingId: "live9" })).toEqual({ kind: "meeting", meetingId: "m7" });
+  });
+
+  describe("an ADDRESSED meeting (`/meetings/<id>` — the durable reference)", () => {
+    it("the URL's meeting is the view", () => {
+      expect(firstViewPlan({ ...base, routeMeetingId: "482" })).toEqual({ kind: "meeting", meetingId: "482" });
+    });
+
+    it("outranks a known live meeting (the address bar said which one)", () => {
+      expect(firstViewPlan({ ...base, routeMeetingId: "482", liveMeetingId: "live9" })).toEqual({ kind: "meeting", meetingId: "482" });
+    });
+
+    it("a just-redeemed share link still outranks the URL", () => {
+      expect(firstViewPlan({ ...base, routeMeetingId: "482", sharedMeetingId: "m7" })).toEqual({ kind: "meeting", meetingId: "m7" });
+    });
+
+    it("a passively-mounted shared workspace does NOT ride along — the address is the meeting", () => {
+      expect(firstViewPlan({ ...base, routeMeetingId: "482", sharedSlug: "deal-ab12" })).toEqual({ kind: "meeting", meetingId: "482" });
+    });
+
+    it("a JUST-ACCEPTED invite does ride along (both were explicit acts)", () => {
+      expect(firstViewPlan({ ...base, routeMeetingId: "482", acceptedSlug: "deal-ab12" }))
+        .toEqual({ kind: "meeting-and-workspace", meetingId: "482", slug: "deal-ab12" });
+    });
+
+    it("applies to a RETURNING user — a reloaded meeting URL restores that meeting, not the saved layout", () => {
+      expect(firstViewPlan({ ...base, fresh: false, routeMeetingId: "482" })).toEqual({ kind: "meeting", meetingId: "482" });
+    });
+
+    it("no URL id → landing is unchanged (the day)", () => {
+      expect(firstViewPlan({ ...base, routeMeetingId: null })).toEqual({ kind: "own-day" });
+    });
   });
 
   describe("a returning user (dock restored tabs — not fresh)", () => {

--- a/clients/terminal/src/workbench/firstView.ts
+++ b/clients/terminal/src/workbench/firstView.ts
@@ -8,6 +8,10 @@
 export interface FirstViewInputs {
   /** an explicit shared meeting from a ?tshare= link (InviteRedeemer stashed it before the reload) */
   sharedMeetingId: string | null;
+  /** the meeting id carried by the URL (`/meetings/<id>`) — the durable reference. Like a share link
+   *  this is an EXPLICIT act (the user opened that address), so it applies to a returning user too:
+   *  a reloaded/pasted meeting URL must restore that meeting, not the last saved layout. */
+  routeMeetingId?: string | null;
   /** a workspace whose invite the user JUST accepted (?invite= link — InviteRedeemer stashed its id
    *  before the reload). Like an accepted shared meeting, this is an EXPLICIT act: pin its README even
    *  for a returning user with a saved layout (they clicked the invite; the shared ws must show). */
@@ -35,8 +39,13 @@ export function firstViewPlan(i: FirstViewInputs): FirstViewPlan {
   // A just-accepted invite is an explicit shared workspace — it outranks the passive active-set `sharedSlug`
   // and, like an accepted shared meeting, applies even to a returning (non-fresh) user.
   const slug = i.acceptedSlug ?? i.sharedSlug;
+  // A just-redeemed share outranks the address bar (it was stashed by THIS navigation).
   if (i.sharedMeetingId && slug) return { kind: "meeting-and-workspace", meetingId: i.sharedMeetingId, slug };
   if (i.sharedMeetingId) return { kind: "meeting", meetingId: i.sharedMeetingId };
+  // Then the URL. A plain meeting address shows THE MEETING and nothing else — a passively-mounted
+  // shared workspace must not hijack it; only a just-accepted invite (explicit) rides alongside.
+  if (i.routeMeetingId && i.acceptedSlug) return { kind: "meeting-and-workspace", meetingId: i.routeMeetingId, slug: i.acceptedSlug };
+  if (i.routeMeetingId) return { kind: "meeting", meetingId: i.routeMeetingId };
   if (i.acceptedSlug) return { kind: "workspace-readme", slug: i.acceptedSlug };  // explicit accept → pin regardless of a saved dock
   if (!i.fresh) return { kind: "noop" };
   if (i.liveMeetingId) return { kind: "live-meeting", meetingId: i.liveMeetingId };


### PR DESCRIPTION
## What

The Terminal's meeting view is now addressable: **`/meetings/<meeting id>`**. Opening a meeting puts its
id in the URL; loading that URL directly — hard reload, pasted link, fresh session — restores the same
meeting view; an unknown or foreign id renders a clean not-found state.

## Today's behaviour (what this changes)

The terminal is a **single route** (`/`). Which meeting is open lives only in the dockview layout in
`localStorage` (`vexa.terminal.dock.v3`), so a hard reload restores the tab *in that browser* while the
URL references nothing — a meeting cannot be pasted to a colleague, bookmarked, or reopened in a fresh
session. The only URL that ever reached a meeting was a `?tshare=` token, and that flow deliberately
strips itself back to `/` after redeeming (it stashes the id in `localStorage` for the first-view
resolver). An id absent from the meetings list also rendered a permanent "Connecting…" header.

## Design

- **The reference is the meetings-domain ROW id** — the id the client already keys the tab, the
  row-keyed live streams (`tc:meeting:{id}`) and `GET /api/transcripts/by-id/{id}` by. **No API change
  is implied**: the public transcript API still keys by `platform/native_meeting_id`; the route only
  carries the id the existing client data paths already resolve.
- **One shell, two routes.** `src/app/meetings/[meetingId]/page.tsx` renders the same `<App/>` as `/`.
- **The URL follows the active tab; it does not drive it.** In-app navigation (row click, preview slot,
  restored dock) is untouched and stays the interactive path. A `history.replaceState` effect mirrors the
  active meeting tab into the address bar — `replaceState`, not push, since the workbench keeps its own
  history under Escape / Alt+Left — and only ever rewrites the two shapes it owns (`/`, `/meetings/<id>`).
- **Landing goes through the existing first-view resolver**, extended with `routeMeetingId`: ranked below
  a just-redeemed share (that stash belongs to *this* navigation), above everything else, and applying to
  a returning user, because opening the address is the explicit act. A passively-mounted shared workspace
  does not ride along; a just-accepted invite does.
- **An unknown id is an answer, not a spinner** — gated on the meetings list having answered at least
  once (`useLiveMeetingsLoaded`), so an offline list can never make a live meeting look deleted.
- OAuth already round-trips `pathname + search`, so a meeting URL survives sign-in.

## Files

| File | |
|---|---|
| `clients/terminal/src/app/meetingRoute.ts` | new — pure path ⇄ id contract (bounded id charset, no extra segments) |
| `clients/terminal/src/app/meetings/[meetingId]/page.tsx` | new — the route, rendering the same `<App/>` |
| `clients/terminal/src/workbench/firstView.ts` | `routeMeetingId` input + its priority |
| `clients/terminal/src/workbench/Workbench.tsx` | reads the route id at first render; URL-sync effect |
| `clients/terminal/src/surfaces/liveMeetings.ts` | `useLiveMeetingsLoaded()` — has the list answered yet |
| `clients/terminal/src/surfaces/meeting.tsx` | `meetingResolution()` + `MeetingNotFound` |
| `clients/terminal/DECISIONS.md` | D7 |

## Tests

New: `src/app/__tests__/meetingRoute.test.ts` (round-trip, encoding, trailing slash, rejected ids /
extra segments / malformed escapes, which paths may be rewritten) · `src/surfaces/__tests__/meetingNotFound.test.tsx`
(resolving vs not-found vs resolved, and the rendered dead end). Extended: `src/workbench/__tests__/firstView.test.ts`
(7 routed-landing cases).

```
vitest run   → 56 files, 424 passed
tsc --noEmit → clean
next build   → clean; ƒ /meetings/[meetingId] present
gate:readme  → green
```

Not merged. No changes outside `clients/terminal/`.

<!-- vexa-agent -->
