### PR TITLE
fix(terminal): a refused Join says why, instead of "your key doesn't have access"

### DIFF
--- a/clients/terminal/src/surfaces/ServiceDenialPanel.tsx
+++ b/clients/terminal/src/surfaces/ServiceDenialPanel.tsx
@@ -1,0 +1,86 @@
+"use client";
+/** ServiceDenialPanel — the in-flow rendering of a refused Join.
+ *
+ *  A panel, not a transient error line: a paywall is a thing the customer has to ACT on, and the
+ *  one-line red `⚠ …` the join surfaces use for "bad link" both loses the fix and (on the sidebar)
+ *  clears itself after 5s. Styling follows the terminal's existing inline-notice idiom — CSS-var
+ *  semantic colours, tinted wash + border, `Icon` from the ui-kit (cf. `workbench/OpsNotice.tsx`
+ *  and `canvas/MeetingHealthBanner.tsx`).
+ *
+ *  Twin of `services/dashboard/src/components/join/service-denial-panel.tsx`; the WORDS live in
+ *  `surfaces/serviceDenial.ts` and are shared with it, only the skin differs.
+ */
+import { Icon } from "../ui-kit";
+import { denialActionUrl, type ServiceDenialKind, type ServiceDenialPresentation } from "./serviceDenial";
+
+/** `--danger` is destructive/errors ONLY and `--warn` is attention-not-error (globals.css §semantic
+ *  set), so a paywall — the account is fine, it needs money — is warn, and only a reason this build
+ *  has never heard of (a bug) is danger. */
+const TONE: Record<ServiceDenialKind, { fg: string; bg: string; icon: string }> = {
+  paywall: { fg: "var(--warn)", bg: "var(--warnbg)", icon: "zap" },
+  setup: { fg: "var(--warn)", bg: "var(--warnbg)", icon: "gear" },
+  limit: { fg: "var(--accent)", bg: "var(--accentbg)", icon: "info" },
+  retryable: { fg: "var(--t2)", bg: "var(--panel2)", icon: "refresh" },
+  unknown: { fg: "var(--danger)", bg: "var(--dangerbg)", icon: "alert" },
+};
+
+export function ServiceDenialPanel({
+  presentation,
+  onRetry,
+}: {
+  presentation: ServiceDenialPresentation;
+  onRetry?: () => void;
+}) {
+  const { kind, title, body, action, retryable, reason } = presentation;
+  const tone = TONE[kind];
+
+  return (
+    <div
+      role="alert"
+      data-testid="service-denial-panel"
+      data-denial-kind={kind}
+      data-denial-reason={reason}
+      style={{
+        display: "flex", flexDirection: "column", gap: 5,
+        marginTop: 6, padding: "8px 10px", borderRadius: 7,
+        background: tone.bg,
+        border: `1px solid color-mix(in srgb, ${tone.fg} 40%, transparent)`,
+      }}
+    >
+      <span style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, fontWeight: 600, color: tone.fg }}>
+        <Icon name={tone.icon} size={12} style={{ color: tone.fg, flex: "none" }} />
+        {title}
+      </span>
+      <span style={{ fontSize: 11, color: "var(--t2)", lineHeight: 1.5 }}>{body}</span>
+      {(action || (retryable && onRetry)) && (
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2 }}>
+          {action && (
+            <a
+              href={denialActionUrl(action.href)}
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                background: "var(--accent)", color: "var(--on-accent)", borderRadius: 6,
+                padding: "4px 10px", fontSize: 11.5, fontWeight: 600, textDecoration: "none",
+              }}
+            >
+              {action.label}
+            </a>
+          )}
+          {retryable && onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              style={{
+                background: "transparent", color: "var(--t2)", border: "1px solid var(--line2)",
+                borderRadius: 6, padding: "4px 10px", fontSize: 11.5, fontWeight: 600, cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/terminal/src/surfaces/__tests__/meetingActions.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/meetingActions.test.tsx
@@ -106,9 +106,28 @@ describe("actionsFor — each action fires the correct endpoint+body", () => {
       actionLabel: "Stop",
       native: NATIVE,
       message: "Couldn't reach the Vexa server — check that the stack is running.",
+      // A transport failure is not the service authority refusing — no denial panel.
+      denial: null,
     });
     // Operator channel: the raw plumbing stays on the console (P18).
     expect(warn).toHaveBeenCalledWith("meeting action failed", expect.objectContaining({ actionId: "stop", message: "Failed to fetch" }));
+  });
+
+  it("a 403 service_not_allowed on Send now yields the DENIAL, never 'your key doesn't have access' (Vexa-ai/vexa-platform#291)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const onFailure = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: false, status: 403, statusText: "Forbidden", url: "/api/bots",
+      json: async () => ({ detail: { code: "service_not_allowed", reason: "insufficient_balance", decision_id: "d-1" } }),
+    } as unknown as Response);
+
+    await actionsFor(row("idle")).find((a) => a.id === "send")!.run(onFailure);
+
+    const failure = onFailure.mock.calls[0][0];
+    expect(failure.denial).toMatchObject({ kind: "paywall", title: "Out of credit" });
+    expect(failure.message).toContain("Out of credit");
+    expect(failure.message).not.toMatch(/doesn't have access/i);
+    warn.mockRestore();
   });
 
   it("a 404 on Stop yields the HUMAN no-longer-active message + a reconciling re-snapshot — never the raw JSON body (issue #674)", async () => {

--- a/clients/terminal/src/surfaces/__tests__/serviceDenialVocabulary.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/serviceDenialVocabulary.test.ts
@@ -1,0 +1,227 @@
+/** The denial-reason vocabulary, pinned — TERMINAL twin.
+ *
+ *  `core/meetings/contracts/service-authority.v1` (this repo) is SEALED and types
+ *  `Decision.reason` as an OPAQUE `{"type":"string","minLength":1}` — by design, since that
+ *  contract is deliberately policy-free. Nothing on the wire constrains the set, and the set is now
+ *  consumed by THREE copy modules across TWO repositories:
+ *
+ *    1. Vexa-ai/vexa           clients/terminal/src/surfaces/serviceDenial.ts        (this one)
+ *    2. Vexa-ai/vexa           services/dashboard/src/lib/service-denial.ts
+ *    3. Vexa-ai/vexa-platform  services/webapp/apps/webapp/lib/service-denial-view.ts
+ *
+ *  Three hand-maintained copies with nothing checking them against each other is the silent-drift
+ *  class: a reason added in the authority renders here as a raw "service not allowed: <code>",
+ *  which is the customer-visible failure that opened Vexa-ai/vexa-platform#291.
+ *
+ *  This file is the terminal's pin. Its twins — which carry the same literal — are
+ *  `services/dashboard/tests/service-denial-vocabulary.test.ts` (this repo) and
+ *  `services/webapp/apps/webapp/__tests__/service-authority-reason-vocabulary.test.ts` (platform),
+ *  the latter additionally deriving the set from `ServiceAuthorityReason` and `decisionReason()` at
+ *  their source. Change one, change all six places named below.
+ *
+ *  NOTE FOR THE MERGER: the two older pins' failure messages still name only FOUR places, because
+ *  they predate this module. Reconcile all three message lists at merge time.
+ *
+ *  Narrowing `reason` to an enum in the contract is the deeper fix, and it is a BREAKING change to
+ *  a frozen `.vN`: it needs a `service-authority.v2` on a `lane:contract` human-reviewed PR
+ *  (gate:contract-version), not an edit to v1.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../apiClient";
+import {
+  SERVICE_DENIAL_REASONS,
+  isAccessError,
+  resolveJoinError,
+  serviceDenialPresentation,
+} from "../serviceDenial";
+
+const PINNED_REASON_VOCABULARY = [
+  "allowed",
+  "billing_setup_required",
+  "insufficient_balance",
+  "payment_past_due",
+  "spend_cap_reached",
+  "concurrency_limit_reached",
+  "billing_unavailable",
+] as const;
+
+const CROSS_REPO_FIXUP = [
+  "The denial-reason vocabulary changed. Update ALL of:",
+  "  1. this pin (Vexa-ai/vexa clients/terminal/src/surfaces/__tests__/serviceDenialVocabulary.test.ts)",
+  "  2. Vexa-ai/vexa clients/terminal/src/surfaces/serviceDenial.ts (the terminal copy module)",
+  "  3. Vexa-ai/vexa services/dashboard/src/lib/service-denial.ts (the dashboard copy module)",
+  "  4. Vexa-ai/vexa services/dashboard/tests/service-denial-vocabulary.test.ts (the dashboard pin)",
+  "  5. Vexa-ai/vexa-platform services/webapp/apps/webapp/lib/service-denial-view.ts (the webapp copy module)",
+  "  6. Vexa-ai/vexa-platform services/webapp/apps/webapp/__tests__/service-authority-reason-vocabulary.test.ts (the webapp pin)",
+  "A reason with copy on only one surface reaches customers as a raw code.",
+].join("\n");
+
+const sorted = (values: readonly string[]) => [...new Set(values)].sort();
+
+const denial = (status: number, reason: string) =>
+  new ApiError(status, `{"code":"service_not_allowed","reason":"${reason}"}`, "/api/bots", {
+    detail: { code: "service_not_allowed", reason, decision_id: "d-1" },
+  });
+
+describe("service-authority denial-reason vocabulary (Vexa-ai/vexa-platform#291)", () => {
+  it("maps exactly the pinned vocabulary — no more, no less", () => {
+    expect(sorted(SERVICE_DENIAL_REASONS), CROSS_REPO_FIXUP).toEqual(
+      sorted(PINNED_REASON_VOCABULARY),
+    );
+  });
+
+  it("gives every pinned reason real copy, never the verbatim fallback", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      for (const reason of PINNED_REASON_VOCABULARY) {
+        const view = serviceDenialPresentation(reason);
+        expect(view.body, `${reason}\n${CROSS_REPO_FIXUP}`).not.toContain(
+          `service not allowed: ${reason}. If this keeps happening`,
+        );
+        expect(view.body).not.toMatch(/access denied/i);
+        expect(view.title.length).toBeGreaterThan(0);
+      }
+      // Not one of them fell through to the unmapped branch.
+      expect(consoleError, CROSS_REPO_FIXUP).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("keeps 'allowed' out of the denial-styled kinds", () => {
+    // `allowed` is in the vocabulary because the authority emits it, but it is not a denial: a
+    // caller reaching the view with it has mismatched allow/reason and must not be shown a paywall.
+    expect(serviceDenialPresentation("allowed").kind).toBe("unknown");
+    expect(serviceDenialPresentation("allowed").action).toBeNull();
+  });
+
+  it("says the same sentence the dashboard says, word for word", () => {
+    // The byte-alignment claim in serviceDenial.ts's header, made checkable for the two lines a
+    // customer is most likely to screenshot at us.
+    expect(serviceDenialPresentation("insufficient_balance")).toMatchObject({
+      kind: "paywall",
+      title: "Out of credit",
+      body:
+        "Your prepaid balance is empty. Add funds and the bot joins immediately — " +
+        "nothing else about your account needs changing.",
+      action: { label: "Add funds", href: "/account?tab=bots" },
+    });
+    expect(serviceDenialPresentation("billing_unavailable")).toMatchObject({
+      kind: "retryable",
+      title: "Billing system temporarily unavailable",
+      body:
+        "Your account is fine — we could not reach the billing ledger just now. " +
+        "Try again shortly.",
+      retryable: true,
+    });
+  });
+
+  it("puts the caller's numbers in the copy when it has them", () => {
+    expect(serviceDenialPresentation("insufficient_balance", {
+      balanceCents: 250, planLabel: "Pay-as-you-go",
+    }).body).toContain("Your prepaid balance on Pay-as-you-go is $2.50.");
+    expect(serviceDenialPresentation("concurrency_limit_reached", {
+      concurrencyCeiling: 1,
+    }).body).toContain("Your plan runs 1 bot at once");
+    expect(serviceDenialPresentation("concurrency_limit_reached", {
+      concurrencyCeiling: 3,
+    }).body).toContain("Your plan runs 3 bots at once");
+  });
+});
+
+describe("access failures are never dressed as a paywall", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  let consoleWarn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
+  it("renders a 401 as an access error, not a denial panel", () => {
+    const error = new ApiError(401, "Invalid API token", "/api/bots", { detail: "Invalid API token" });
+    expect(resolveJoinError(error).kind).toBe("message");
+    expect(isAccessError(error)).toBe(true);
+  });
+
+  it("renders a genuine permission 403 as an access error, not a paywall", () => {
+    // A real permission fault: 403, but no `service_not_allowed` code in the body. Routing this to
+    // the paywall would tell a customer to pay for a problem money cannot fix.
+    const error = new ApiError(403, "Not authorized to access this meeting", "/api/bots", {
+      detail: "Not authorized to access this meeting",
+    });
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("message");
+    if (state.kind !== "message") throw new Error("unreachable");
+    expect(state.headline).not.toMatch(/credit|balance|billing|payment/i);
+    expect(isAccessError(error)).toBe(true);
+  });
+
+  it("does not confuse a 401 that happens to carry a denial-shaped body", () => {
+    // Defence in depth: the 401 branch short-circuits before body sniffing, so an expired token can
+    // never be presented as a billing problem.
+    const error = denial(401, "insufficient_balance");
+    expect(resolveJoinError(error).kind).toBe("message");
+    expect(isAccessError(error)).toBe(true);
+  });
+
+  it("still routes a real 403 denial to the paywall panel", () => {
+    // The positive control for the three negatives above, and the regression this PR exists for:
+    // before it, this error rendered as "Your key doesn't have access to this."
+    const error = denial(403, "insufficient_balance");
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("denial");
+    if (state.kind !== "denial") throw new Error("unreachable");
+    expect(state.presentation.kind).toBe("paywall");
+    expect(state.presentation.title).toBe("Out of credit");
+    expect(isAccessError(error)).toBe(false);
+  });
+
+  it("routes the 503 authority outage to a retryable panel, not a paywall", () => {
+    const error = new ApiError(503, "", "/api/bots", {
+      detail: { code: "service_authority_unavailable", reason: "service_authority_unavailable" },
+    });
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("denial");
+    if (state.kind !== "denial") throw new Error("unreachable");
+    expect(state.presentation.kind).toBe("retryable");
+    expect(state.presentation.retryable).toBe(true);
+    expect(state.presentation.action).toBeNull();
+  });
+
+  it("recovers a denial whose body only survived as the flattened detail string", () => {
+    // `ApiError.detail` is the operator string. A call site built before `ApiError.body` existed
+    // still produces a transparent panel rather than "Your key doesn't have access to this."
+    const error = new ApiError(
+      403,
+      '{"code":"service_not_allowed","reason":"payment_past_due"}',
+      "/api/bots",
+    );
+    const state = resolveJoinError(error);
+    expect(state.kind).toBe("denial");
+    if (state.kind !== "denial") throw new Error("unreachable");
+    expect(state.presentation.title).toBe("Payment past due");
+  });
+
+  it("logs an unmapped reason in a production build so the net can see it", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    try {
+      const state = resolveJoinError(denial(403, "region_unsupported"));
+      expect(state.kind).toBe("denial");
+      if (state.kind !== "denial") throw new Error("unreachable");
+      // Verbatim in front of the customer — never flattened to "Access denied".
+      expect(state.presentation.kind).toBe("unknown");
+      expect(state.presentation.body).toContain("service not allowed: region_unsupported");
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("unmapped service-authority reason: region_unsupported"),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/clients/terminal/src/surfaces/apiClient.ts
+++ b/clients/terminal/src/surfaces/apiClient.ts
@@ -13,7 +13,18 @@
 import { track, endpointLabel } from "@/app/analytics";
 
 export class ApiError extends Error {
-  constructor(public readonly status: number, public readonly detail: string, public readonly url: string) {
+  /** `detail` is the FLATTENED operator string (what goes in the message / the console). `body` is
+   *  the parsed failure body as it came off the wire, kept because some failures are STRUCTURED and
+   *  flattening them destroys the only thing the user needs: a `403
+   *  {"detail":{"code":"service_not_allowed","reason":"insufficient_balance"}}` is a paywall, and
+   *  once it is a string it is indistinguishable from a permissions fault (see
+   *  `surfaces/serviceDenial.ts`). Undefined when the body was absent or not JSON. */
+  constructor(
+    public readonly status: number,
+    public readonly detail: string,
+    public readonly url: string,
+    public readonly body?: unknown,
+  ) {
     super(`${url} → ${status || "network"}${detail ? `: ${detail}` : ""}`);
     this.name = "ApiError";
   }
@@ -81,16 +92,24 @@ export async function getJson<T = unknown>(url: string, init?: RequestInit): Pro
     throw new ApiError(0, e instanceof Error ? e.message : "network error", url);
   }
   usage(r.status, r.ok);
-  if (!r.ok) {
-    let detail = "";
-    try {
-      const b = (await r.json()) as { detail?: unknown; error?: unknown };
-      const d = b?.detail ?? b?.error;
-      detail = typeof d === "string" ? d : d != null ? JSON.stringify(d).slice(0, 200) : "";
-    } catch {
-      /* body wasn't JSON — the status alone is the signal */
-    }
-    throw new ApiError(r.status, detail, url);
-  }
+  if (!r.ok) throw await readApiFailure(r, url);
   return (await r.json()) as T;
+}
+
+/** Turn a non-ok `Response` into the typed `ApiError`. Reads the body ONCE and keeps it both ways:
+ *  flattened into `detail` for the operator channel, and intact on `body` for the presenters that
+ *  need the structure (the service-authority denial mapping). Shared so the surfaces that call
+ *  `fetch` directly — the join/bot-spawn edges — produce the same error object `getJson` does. */
+export async function readApiFailure(r: Response, url: string = r.url): Promise<ApiError> {
+  let detail = "";
+  let body: unknown;
+  try {
+    body = (await r.json()) as unknown;
+    const b = body as { detail?: unknown; error?: unknown } | null;
+    const d = b?.detail ?? b?.error;
+    detail = typeof d === "string" ? d : d != null ? JSON.stringify(d).slice(0, 200) : "";
+  } catch {
+    /* body wasn't JSON — the status alone is the signal */
+  }
+  return new ApiError(r.status, detail, url, body);
 }

--- a/clients/terminal/src/surfaces/meeting.tsx
+++ b/clients/terminal/src/surfaces/meeting.tsx
@@ -11,7 +11,9 @@ import { Icon } from "../ui-kit";
 import { ContextMenu, copyText } from "../ui-kit/ContextMenu";
 import { MEETING_CANVAS_CONTENT_INSET, MeetingCanvasView } from "../canvas/MeetingCanvasView";
 import { type MeetingMock } from "./meetingModel";
-import { ApiError, presentError } from "./apiClient";
+import { ApiError, presentError, readApiFailure } from "./apiClient";
+import { resolveJoinError, serviceDenialFromError, type ServiceDenialPresentation } from "./serviceDenial";
+import { ServiceDenialPanel } from "./ServiceDenialPanel";
 import { useLiveMeetings, useLiveMeetingsConnection, liveMeetingsNow, refreshMeetings } from "./liveMeetings";
 import { usePreviewPinTab } from "./previewPinTab";
 import { defaultBotName } from "./defaultBotName";
@@ -276,20 +278,18 @@ const STATUS_BADGE: Record<string, { label: string; color: string; bg: string; k
 };
 const badgeFor = (raw?: string) => STATUS_BADGE[raw ?? ""] ?? { label: raw ?? "—", color: "var(--t3)", bg: "var(--panel2)", kind: "terminal" as BadgeKind };
 
-type MeetingActionFailure = { actionId: string; actionLabel: string; native: string; message: string };
+type MeetingActionFailure = {
+  actionId: string; actionLabel: string; native: string; message: string;
+  /** Set when the service authority REFUSED (403 service_not_allowed / 503 authority-unavailable).
+   *  The row renders the panel instead of the one-line message, and does not auto-clear it. */
+  denial?: ServiceDenialPresentation | null;
+};
 type MeetingActionFailureHandler = (failure: MeetingActionFailure) => void;
 type RowAction = { id: string; label: string; tone: "accent" | "live" | "muted"; run: (onFailure?: MeetingActionFailureHandler) => Promise<void> | void };
 
-/** A non-ok action response as a STRUCTURED failure (status + backend detail), never a raw body. */
-async function readFailure(r: Response): Promise<ApiError> {
-  let detail = "";
-  try {
-    const b = (await r.json()) as { detail?: unknown; error?: unknown };
-    const d = b?.detail ?? b?.error;
-    detail = typeof d === "string" ? d : d != null ? JSON.stringify(d).slice(0, 200) : "";
-  } catch { /* body wasn't JSON — the status alone is the signal */ }
-  return new ApiError(r.status, detail, r.url);
-}
+/** A non-ok action response as a STRUCTURED failure (status + backend detail + the intact body),
+ *  never a raw string. Shared with `getJson`'s error path so both edges produce the same object. */
+const readFailure = (r: Response): Promise<ApiError> => readApiFailure(r);
 
 /** User-truth message for a failed bot/row action (issue #674): a `404` means the backend no
  *  longer has this meeting — the list re-snapshot (runMeetingAction's `finally`) reconciles the
@@ -300,6 +300,10 @@ export function presentMeetingActionFailure(error: unknown): string {
     if (error.status === 404) return "This meeting is no longer active — refreshing the list.";
     if (error.status === 409) return "That meeting already has a bot.";
   }
+  // A service-authority refusal (paywall / cap / billing outage) says WHY in its own words —
+  // "Your key doesn't have access to this." is a lie about a bot the account simply cannot afford.
+  const denial = serviceDenialFromError(error);
+  if (denial) return `${denial.title} — ${denial.body}`;
   return presentError(error).headline;
 }
 
@@ -310,7 +314,7 @@ async function runMeetingAction(action: Omit<MeetingActionFailure, "message">, r
   } catch (error) {
     // Operator channel keeps the full plumbing (P18); the UI channel gets the presented truth.
     console.warn("meeting action failed", { ...action, message: String(error instanceof Error ? error.message : error) });
-    onFailure?.({ ...action, message: presentMeetingActionFailure(error) });
+    onFailure?.({ ...action, message: presentMeetingActionFailure(error), denial: serviceDenialFromError(error) });
   } finally {
     refreshMeetings();
   }
@@ -456,6 +460,9 @@ function MeetingRow({ m }: { m: MeetingMock }) {
   const isIntent = INTENT_STATUSES.has(m.live_status ?? "");
   useEffect(() => {
     if (!actionFailure) return;
+    // A service denial is a thing the user must ACT on (add funds, finish setup, raise the cap) —
+    // it must not evaporate on a 6s timer the way a transient "already has a bot" should.
+    if (actionFailure.denial) return;
     const t = window.setTimeout(() => setActionFailure(null), 6000);
     return () => window.clearTimeout(t);
   }, [actionFailure]);
@@ -474,7 +481,11 @@ function MeetingRow({ m }: { m: MeetingMock }) {
           ⚠ Auto-join failed: {m.auto_join_error}
         </div>
       )}
-      {actionFailure && (
+      {actionFailure?.denial ? (
+        <div onClick={(e) => e.stopPropagation()}>
+          <ServiceDenialPanel presentation={actionFailure.denial} />
+        </div>
+      ) : actionFailure && (
         <div role="status" aria-live="polite" style={{ fontSize: 11, color: "var(--danger)", marginTop: 4, lineHeight: 1.35 }}>
           {actionFailure.actionLabel} failed: {actionFailure.message}
         </div>
@@ -649,13 +660,15 @@ function MeetingsList() {
   const [url, setUrl] = useState("");
   const [sent, setSent] = useState<null | "sending" | "ok" | "err">(null);
   const [errMsg, setErrMsg] = useState<string | null>(null);
+  const [denial, setDenial] = useState<ServiceDenialPresentation | null>(null);
   const addBot = async () => {
     const u = url.trim();
     if (!u || sent === "sending") return;
     // Parse + validate the pasted link/id against the platform formats (mirrors join-form).
     const parsed = parseMeetingInput(u, await getJitsiHosts());
-    if (!parsed) { setSent("err"); setErrMsg("That doesn't look like a Meet / Zoom / Teams / Jitsi link."); setTimeout(() => setSent(null), 5000); return; }
-    setSent("sending"); setErrMsg(null);
+    if (!parsed) { setSent("err"); setErrMsg("That doesn't look like a Meet / Zoom / Teams / Jitsi link."); setDenial(null); setTimeout(() => setSent(null), 5000); return; }
+    setSent("sending"); setErrMsg(null); setDenial(null);
+    let refused = false;
     try {
       // POST /bots through the authed gateway proxy (X-API-Key injected server-side from the cookie token).
       const r = await fetch("/api/bots", {
@@ -671,15 +684,21 @@ function MeetingsList() {
       } else {
         // Surface the REAL reason, not a generic "bad link" (the cap/dup/auth cases are common).
         setSent("err");
-        setErrMsg(
-          r.status === 429 ? "You're at your meeting limit — stop one first."
-            : r.status === 409 ? "That meeting already has a bot."
-              : r.status === 401 ? "Not signed in — sign in and retry."
-                : presentError(await readFailure(r)).headline,
-        );
+        if (r.status === 429) { setErrMsg("You're at your meeting limit — stop one first."); }
+        else if (r.status === 409) { setErrMsg("That meeting already has a bot."); }
+        else if (r.status === 401) { setErrMsg("Not signed in — sign in and retry."); }
+        else {
+          // 403 service_not_allowed / 503 service_authority_unavailable are the service authority
+          // refusing, not an access fault: they get their own words and their own fix.
+          const state = resolveJoinError(await readFailure(r));
+          if (state.kind === "denial") { setDenial(state.presentation); setErrMsg(null); refused = true; }
+          else setErrMsg(state.headline);
+        }
       }
     } catch { setSent("err"); setErrMsg("Couldn't reach the server."); }
-    setTimeout(() => setSent(null), 5000);
+    // The transient flash clears itself; a denial panel is sticky until the next attempt — a
+    // paywall the user has to act on must not vanish on a 5s timer.
+    if (!refused) setTimeout(() => setSent(null), 5000);
   };
   return (
     <div style={{ padding: "8px" }}>
@@ -697,7 +716,9 @@ function MeetingsList() {
           </button>
         </div>
         {sent === "ok" && <div style={{ fontSize: 11, color: "var(--green)", marginTop: 5, lineHeight: 1.4 }}>Bot sent — admit it in the meeting; it appears here once it starts transcribing.</div>}
-        {sent === "err" && <div style={{ fontSize: 11, color: "var(--danger)", marginTop: 5, lineHeight: 1.4 }}>{errMsg ?? "Couldn't send."}</div>}
+        {denial
+          ? <ServiceDenialPanel presentation={denial} onRetry={() => void addBot()} />
+          : sent === "err" && <div style={{ fontSize: 11, color: "var(--danger)", marginTop: 5, lineHeight: 1.4 }}>{errMsg ?? "Couldn't send."}</div>}
         <div style={{ marginTop: 8 }}>
           <PlanMeetingButton />
           <CalendarSyncButton variant="row" />

--- a/clients/terminal/src/surfaces/meetingPrep.tsx
+++ b/clients/terminal/src/surfaces/meetingPrep.tsx
@@ -18,7 +18,9 @@ import { DateTimePicker } from "../ui-kit/DateTimePicker";
 import { copyText } from "../ui-kit/ContextMenu";
 import { useLiveMeetings, refreshMeetings } from "./liveMeetings";
 import type { MeetingMock } from "./meetingModel";
-import { presentError } from "./apiClient";
+import { presentError, readApiFailure } from "./apiClient";
+import { resolveJoinError, type ServiceDenialPresentation } from "./serviceDenial";
+import { ServiceDenialPanel } from "./ServiceDenialPanel";
 import { createPlannedMeeting, updatePlannedMeeting, deletePlannedMeeting } from "./plannedApi";
 import { createSharedWorkspace, listSharedMemberships, listWorkspaceTree, mintInvite, readWorkspaceFile, type Membership } from "./workspaceApi";
 import { findBriefNote, isExampleNote } from "./briefNote";
@@ -200,6 +202,8 @@ function MeetingPrepTab({ params }: TabProps) {
   const [seededFor, setSeededFor] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // A refused Join renders as its own in-flow panel, not as the generic one-line error.
+  const [denial, setDenial] = useState<ServiceDenialPresentation | null>(null);
   const [shares, setShares] = useState<Membership[]>([]);
   const [inviteLink, setInviteLink] = useState<string | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);       // ⋯ row: link edit / unbind / delete
@@ -235,16 +239,23 @@ function MeetingPrepTab({ params }: TabProps) {
 
   const sendNow = async () => {
     if (!m?.native_id) return;
-    setBusy(true); setErr(null);
+    setBusy(true); setErr(null); setDenial(null);
     try {
       const platformSlug = m.platform === "Google Meet" ? "google_meet" : m.platform.toLowerCase().replace(/\s+/g, "_");
       const r = await fetch("/api/bots", {
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ platform: platformSlug, native_meeting_id: m.native_id, ...(m.meeting_url ? { meeting_url: m.meeting_url } : {}), bot_name: defaultBotName() }),
       });
-      if (!r.ok) throw new Error((await r.text().catch(() => "")).slice(0, 180) || `${r.status}`);
+      // The body used to be read as raw TEXT and rethrown as a bare Error, so a denial payload
+      // reached the presenter JSON-shaped and came out as "Something went wrong". Read it as the
+      // typed ApiError instead, so 403 service_not_allowed can be told from a permissions fault.
+      if (!r.ok) throw await readApiFailure(r, "/api/bots");
       refreshMeetings();
-    } catch (e) { setErr(presentError(e).headline); }
+    } catch (e) {
+      const state = resolveJoinError(e);
+      if (state.kind === "denial") setDenial(state.presentation);
+      else setErr(state.headline);
+    }
     finally { setBusy(false); }
   };
 
@@ -567,6 +578,7 @@ function MeetingPrepTab({ params }: TabProps) {
           </div>
         )}
 
+        {denial && <ServiceDenialPanel presentation={denial} onRetry={() => void sendNow()} />}
         {err && <div role="alert" style={{ marginTop: 12, fontSize: 12, color: "var(--danger)" }}>⚠ {err}</div>}
       </div>
     </div>

--- a/clients/terminal/src/surfaces/meetingsOnboarding.tsx
+++ b/clients/terminal/src/surfaces/meetingsOnboarding.tsx
@@ -18,6 +18,9 @@ import { useService } from "../platform";
 import { LayoutServiceId } from "../workbench/layout";
 import { Icon } from "../ui-kit";
 import { parseMeetingInput } from "./meetingId";
+import { readApiFailure } from "./apiClient";
+import { resolveJoinError, type ServiceDenialPresentation } from "./serviceDenial";
+import { ServiceDenialPanel } from "./ServiceDenialPanel";
 import { getJitsiHosts } from "./jitsiHosts";
 import { presentError } from "./apiClient";
 import { refreshMeetings } from "./liveMeetings";
@@ -138,12 +141,13 @@ function DropBotInline() {
   const [url, setUrl] = useState("");
   const [sent, setSent] = useState<null | "sending" | "ok" | "err">(null);
   const [msg, setMsg] = useState<string | null>(null);
+  const [denial, setDenial] = useState<ServiceDenialPresentation | null>(null);
   const send = async () => {
     const u = url.trim();
     if (!u || sent === "sending") return;
     const parsed = parseMeetingInput(u, await getJitsiHosts());
-    if (!parsed) { setSent("err"); setMsg("That doesn't look like a Meet / Zoom / Teams / Jitsi link."); return; }
-    setSent("sending"); setMsg(null);
+    if (!parsed) { setSent("err"); setMsg("That doesn't look like a Meet / Zoom / Teams / Jitsi link."); setDenial(null); return; }
+    setSent("sending"); setMsg(null); setDenial(null);
     try {
       const r = await fetch("/api/bots", {
         method: "POST",
@@ -154,12 +158,18 @@ function DropBotInline() {
         setSent("ok"); setUrl("");
         refreshMeetings(); setTimeout(refreshMeetings, 2000); setTimeout(refreshMeetings, 6000);
       } else {
-        const detail = (await r.text().catch(() => "")).replace(/\s+/g, " ").slice(0, 160);
         setSent("err");
-        setMsg(r.status === 429 ? "You're at your meeting limit — stop one first."
-          : r.status === 409 ? "That meeting already has a bot."
-            : r.status === 401 ? "Not signed in — sign in and retry."
-              : `Couldn't send (${r.status})${detail ? `: ${detail}` : ""}`);
+        if (r.status === 429) setMsg("You're at your meeting limit — stop one first.");
+        else if (r.status === 409) setMsg("That meeting already has a bot.");
+        else if (r.status === 401) setMsg("Not signed in — sign in and retry.");
+        else {
+          // Everything else used to land as `Couldn't send (403): {"code":"service_not_allowed",…}`
+          // — the raw denial payload, in the user's face. A service-authority refusal now gets its
+          // own panel; the rest still goes through the presenter seam.
+          const state = resolveJoinError(await readApiFailure(r, "/api/bots"));
+          if (state.kind === "denial") { setDenial(state.presentation); setMsg(null); }
+          else setMsg(state.headline);
+        }
       }
     } catch { setSent("err"); setMsg("Couldn't reach the server."); }
   };
@@ -174,7 +184,9 @@ function DropBotInline() {
         </button>
       </div>
       {sent === "ok" && <div style={{ fontSize: 11, color: "var(--green)", lineHeight: 1.4 }}>Bot sent — admit it in the meeting.</div>}
-      {sent === "err" && msg && <div role="alert" style={{ fontSize: 11, color: "var(--danger)", lineHeight: 1.4 }}>⚠ {msg}</div>}
+      {denial
+        ? <ServiceDenialPanel presentation={denial} onRetry={() => void send()} />
+        : sent === "err" && msg && <div role="alert" style={{ fontSize: 11, color: "var(--danger)", lineHeight: 1.4 }}>⚠ {msg}</div>}
     </div>
   );
 }

--- a/clients/terminal/src/surfaces/serviceDenial.ts
+++ b/clients/terminal/src/surfaces/serviceDenial.ts
@@ -1,0 +1,335 @@
+/** serviceDenial — the customer-facing rendering of a refused Join, for the terminal.
+ *
+ *  The meeting API refuses a bot with
+ *  `403 {"detail":{"code":"service_not_allowed","reason":<reason>,"decision_id":…}}`
+ *  (core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py), and reports its own
+ *  outage as `503 {"detail":{"code":"service_authority_unavailable",…}}`.
+ *
+ *  Before this change every one of those reasons reached the terminal user as the flat 403 line
+ *  "Your key doesn't have access to this." (apiClient.presentError) — or, on the drop-a-bot card,
+ *  as `Couldn't send (403): {"code":"service_not_allowed",…}` — so a paywall was indistinguishable
+ *  from an outage and from a permissions fault.
+ *
+ *  This is the THIRD twin of one hand-maintained mapping. The other two:
+ *    · Vexa-ai/vexa           services/dashboard/src/lib/service-denial.ts
+ *    · Vexa-ai/vexa-platform  services/webapp/apps/webapp/lib/service-denial-view.ts
+ *  All three surfaces must say the same sentence about the same account, so the copy below is kept
+ *  byte-aligned with those modules; change one, change all three. The pin test at
+ *  `src/surfaces/__tests__/serviceDenialVocabulary.test.ts` is what stops the drift.
+ *
+ *  Deliberately free of React and of network access.
+ */
+import { ApiError, presentError } from "./apiClient";
+
+export const SERVICE_NOT_ALLOWED_CODE = "service_not_allowed";
+export const SERVICE_AUTHORITY_UNAVAILABLE_CODE = "service_authority_unavailable";
+
+/** The vocabulary the service authority emits. Mirrors `ServiceAuthorityReason` in the platform
+ *  repo. A reason outside this union is rendered verbatim rather than flattened — see
+ *  {@link unknownServiceDenial}. */
+export type ServiceAuthorityReason =
+  | "allowed"
+  | "billing_setup_required"
+  | "insufficient_balance"
+  | "payment_past_due"
+  | "spend_cap_reached"
+  | "concurrency_limit_reached"
+  | "billing_unavailable";
+
+/** What the customer can DO about it, which is the only distinction the UI needs to style:
+ *   - `paywall`   — they are out of money; one payment fixes it.
+ *   - `setup`     — billing is not finished; one setup flow fixes it.
+ *   - `limit`     — a ceiling they chose or bought; the number is named.
+ *   - `retryable` — our side; the account is fine and waiting helps.
+ *   - `unknown`   — a reason this build has never heard of. Shown verbatim. */
+export type ServiceDenialKind = "paywall" | "setup" | "limit" | "retryable" | "unknown";
+
+export interface ServiceDenialAction {
+  label: string;
+  /** Path on the account/billing origin, not on the terminal. */
+  href: string;
+}
+
+export interface ServiceDenialPresentation {
+  reason: string;
+  kind: ServiceDenialKind;
+  title: string;
+  body: string;
+  action: ServiceDenialAction | null;
+  /** True when simply trying again later is a sane instruction. */
+  retryable: boolean;
+}
+
+export interface ServiceDenialFacts {
+  /** Live prepaid balance in cents, when the caller knows it. */
+  balanceCents?: number | null;
+  /** Concurrent-bot ceiling, for the concurrency reason. */
+  concurrencyCeiling?: number | null;
+  /** Human plan label, e.g. "Pay-as-you-go". */
+  planLabel?: string | null;
+}
+
+const ADD_FUNDS: ServiceDenialAction = { label: "Add funds", href: "/account?tab=bots" };
+const FINISH_SETUP: ServiceDenialAction = { label: "Finish billing setup", href: "/account?tab=bots" };
+const UPDATE_PAYMENT: ServiceDenialAction = { label: "Update payment method", href: "/account?tab=balance" };
+const REVIEW_SPEND_CAP: ServiceDenialAction = { label: "Review spend cap", href: "/account?tab=balance" };
+
+/** Account + billing live on the hosted webapp origin, not on the terminal (which is
+ *  self-hostable). Same origin the setup gate already sends people to for a hosted token. */
+export const ACCOUNT_ORIGIN = "https://www.vexa.ai";
+
+/** Absolute URL for a denial action. */
+export function denialActionUrl(href: string, origin: string = ACCOUNT_ORIGIN): string {
+  return `${origin.replace(/\/+$/, "")}${href}`;
+}
+
+function usd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function balanceSentence(facts: ServiceDenialFacts): string {
+  const cents = facts.balanceCents;
+  if (typeof cents !== "number" || !Number.isSafeInteger(cents) || cents < 0) {
+    return "Your prepaid balance is empty.";
+  }
+  const plan = facts.planLabel ? ` on ${facts.planLabel}` : "";
+  return `Your prepaid balance${plan} is ${usd(cents)}.`;
+}
+
+function concurrencySentence(facts: ServiceDenialFacts): string {
+  const ceiling = facts.concurrencyCeiling;
+  if (typeof ceiling !== "number" || !Number.isSafeInteger(ceiling) || ceiling < 0) {
+    return "Every bot your plan allows is already in a meeting.";
+  }
+  return (
+    `Your plan runs ${ceiling} bot${ceiling === 1 ? "" : "s"} at once, ` +
+    "and they are all in meetings."
+  );
+}
+
+/** `reason` is whatever the API said. A reason this build does not know is rendered VERBATIM
+ *  rather than flattened into "Access denied" — an unmapped code in front of the customer is a bug
+ *  we want reported, not hidden. */
+export function serviceDenialPresentation(
+  reason: string,
+  facts: ServiceDenialFacts = {},
+): ServiceDenialPresentation {
+  switch (reason as ServiceAuthorityReason) {
+    case "allowed":
+      // Not a denial. Callers that reach here have mismatched allow/reason.
+      return {
+        reason,
+        kind: "unknown",
+        title: "Service not allowed",
+        body: `service not allowed: ${reason}`,
+        action: null,
+        retryable: true,
+      };
+    case "insufficient_balance":
+      return {
+        reason,
+        kind: "paywall",
+        title: "Out of credit",
+        body:
+          `${balanceSentence(facts)} Add funds and the bot joins ` +
+          "immediately — nothing else about your account needs changing.",
+        action: ADD_FUNDS,
+        retryable: false,
+      };
+    case "billing_setup_required":
+      return {
+        reason,
+        kind: "setup",
+        title: "Billing setup not finished",
+        body:
+          "Your billing account is still being set up, so bots cannot " +
+          "join yet. Finishing setup takes a minute.",
+        action: FINISH_SETUP,
+        retryable: false,
+      };
+    case "payment_past_due":
+      return {
+        reason,
+        kind: "paywall",
+        title: "Payment past due",
+        body:
+          "Your last payment did not go through, so bots are paused. " +
+          "Updating the payment method resumes them.",
+        action: UPDATE_PAYMENT,
+        retryable: false,
+      };
+    case "spend_cap_reached":
+      return {
+        reason,
+        kind: "limit",
+        title: "Monthly spend cap reached",
+        body:
+          "You set a hard spend cap and this month has reached it. " +
+          "Raising or clearing the cap resumes bots.",
+        action: REVIEW_SPEND_CAP,
+        retryable: false,
+      };
+    case "concurrency_limit_reached":
+      return {
+        reason,
+        kind: "limit",
+        title: "All bots are busy",
+        body: `${concurrencySentence(facts)} One will free up when a meeting ends.`,
+        action: null,
+        retryable: true,
+      };
+    case "billing_unavailable":
+      return {
+        reason,
+        kind: "retryable",
+        title: "Billing system temporarily unavailable",
+        body:
+          "Your account is fine — we could not reach the billing ledger " +
+          "just now. Try again shortly.",
+        action: null,
+        retryable: true,
+      };
+    default:
+      return unknownServiceDenial(reason);
+  }
+}
+
+function unknownServiceDenial(reason: string): ServiceDenialPresentation {
+  const label = reason.trim() || "unspecified";
+  // Fail loud in the logs, PRODUCTION INCLUDED — never in the customer's face.
+  // An unmapped reason is a prod-only event by definition: it means the service authority
+  // (Vexa-ai/vexa-platform lib/billing-spend-policy.ts) shipped a reason ahead of this module's
+  // copy. A dev-only console.error is silent exactly where the drift actually happens, so the net
+  // has no signal.
+  console.error(
+    `[service-denial] unmapped service-authority reason: ${label}. ` +
+      "Add it to serviceDenialPresentation before it reaches a customer.",
+  );
+  return {
+    reason,
+    kind: "unknown",
+    title: "Service not allowed",
+    body:
+      `service not allowed: ${label}. If this keeps happening, send us ` +
+      "this code and we will tell you exactly what it means.",
+    action: null,
+    retryable: true,
+  };
+}
+
+/** Compile-time exhaustiveness: adding a reason without a branch above turns this into a type
+ *  error, so the vocabulary cannot drift ahead of the copy. */
+const MAPPED_REASONS: Record<ServiceAuthorityReason, true> = {
+  allowed: true,
+  billing_setup_required: true,
+  insufficient_balance: true,
+  payment_past_due: true,
+  spend_cap_reached: true,
+  concurrency_limit_reached: true,
+  billing_unavailable: true,
+};
+
+export const SERVICE_DENIAL_REASONS = Object.keys(MAPPED_REASONS) as ServiceAuthorityReason[];
+
+/** Reads a denial out of an API error body.
+ *
+ *  Two shapes are accepted because both are on the wire: FastAPI nests the payload under `detail`
+ *  (`{"detail":{"code":…,"reason":…}}`, which is what `POST /bots` emits), and the platform routes
+ *  emit the object bare. Returns null when the body is not a denial, so callers keep their own
+ *  handling for genuine auth or transport faults. */
+export function serviceDenialFromResponseBody(
+  body: unknown,
+  facts: ServiceDenialFacts = {},
+): ServiceDenialPresentation | null {
+  const payload = unwrapDetail(body);
+  if (typeof payload !== "object" || payload === null) return null;
+  const record = payload as Record<string, unknown>;
+  const code = typeof record.code === "string" ? record.code : null;
+  const reason = typeof record.reason === "string" ? record.reason : null;
+  if (code === SERVICE_NOT_ALLOWED_CODE) {
+    return serviceDenialPresentation(reason ?? "", facts);
+  }
+  if (code === SERVICE_AUTHORITY_UNAVAILABLE_CODE) {
+    // 503 from the same gate: our side, account untouched, retrying helps.
+    return {
+      reason: reason ?? SERVICE_AUTHORITY_UNAVAILABLE_CODE,
+      kind: "retryable",
+      title: "Billing system temporarily unavailable",
+      body:
+        "Your account is fine — we could not reach the billing ledger " +
+        "just now. Try again shortly.",
+      action: null,
+      retryable: true,
+    };
+  }
+  return null;
+}
+
+function unwrapDetail(body: unknown): unknown {
+  if (typeof body !== "object" || body === null) return body;
+  const record = body as Record<string, unknown>;
+  if ("code" in record) return record;
+  if ("detail" in record) return record.detail;
+  return record;
+}
+
+/** Reads a denial off a thrown error. Only 4xx/5xx bodies carrying the denial code qualify — a
+ *  401, or a 403 that is a genuine permission fault, returns null and keeps its access-error
+ *  rendering.
+ *
+ *  The terminal's `ApiError` flattens the backend `detail` to a string for the operator channel, so
+ *  the STRUCTURED body is carried alongside it (`ApiError.body`) and read here. A body that only
+ *  survived as a JSON string is still parsed, so a call site that predates the structured field
+ *  cannot silently render a paywall as "access denied". */
+export function serviceDenialFromError(
+  error: unknown,
+  facts: ServiceDenialFacts = {},
+): ServiceDenialPresentation | null {
+  if (!(error instanceof ApiError)) return null;
+  if (error.status === 401) return null;
+  const fromBody = serviceDenialFromResponseBody(error.body, facts);
+  if (fromBody) return fromBody;
+  return serviceDenialFromResponseBody(parseMaybeJson(error.detail), facts);
+}
+
+function parseMaybeJson(detail: string): unknown {
+  const t = detail.trim();
+  if (!t.startsWith("{")) return null;
+  try {
+    return JSON.parse(t);
+  } catch {
+    return null;
+  }
+}
+
+/** The rendering states a failed Join can land in.
+ *
+ *  Kept as a pure function so every join surface (the sidebar "Add bot", the drop-a-bot card, the
+ *  row "Send now", the prep tab) agrees on which state a given error produces, and so the mapping
+ *  is testable without a DOM.
+ *
+ *  - `denial`  — the service authority refused. Rendered as an in-flow panel with its own words
+ *                and, where one exists, one fixing action. Never a transient line: a paywall the
+ *                customer must act on should not read like a typo in the meeting link.
+ *  - `message` — everything else, including genuine authz failures; the existing presenter seam
+ *                (`presentError`) owns the words. */
+export type JoinErrorState =
+  | { kind: "denial"; presentation: ServiceDenialPresentation }
+  | { kind: "message"; headline: string };
+
+export function resolveJoinError(
+  error: unknown,
+  facts: ServiceDenialFacts = {},
+): JoinErrorState {
+  const denial = serviceDenialFromError(error, facts);
+  if (denial) return { kind: "denial", presentation: denial };
+  return { kind: "message", headline: presentError(error).headline };
+}
+
+/** True when the error is a genuine authorization failure, not a service denial. */
+export function isAccessError(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+  if (error.status === 401) return true;
+  if (error.status !== 403) return false;
+  return serviceDenialFromError(error) === null;
+}


### PR DESCRIPTION
## What changed

The Terminal client reached parity with the hosted dashboard on paywall and transparent join-denial errors.

`meeting-api` refuses a bot with `403 {"detail":{"code":"service_not_allowed","reason":…,"decision_id":…}}` and reports its own outage as `503 service_authority_unavailable` ([`bot_spawn/router.py`](https://github.com/Vexa-ai/vexa/blob/main/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py#L425-L441)). The terminal read neither.

### What a 403 said before this PR

| Surface | What the user saw on a paywall |
|---|---|
| Sidebar **Add bot** (`meeting.tsx` `MeetingsList`) | "Your key doesn't have access to this." — `presentError`'s flat 403 line |
| Row **Send now** (`actionsFor` → `presentMeetingActionFailure`) | same flat line, auto-cleared after 6s |
| Onboarding **drop-a-bot card** (`meetingsOnboarding.tsx`) | `Couldn't send (403): {"code":"service_not_allowed","reason":"insufficient_balance"}` — the raw payload |
| Prep tab **Send now** (`meetingPrep.tsx`) | "Something went wrong — details are in the browser console." (body read as text, rethrown as a bare `Error`, so the JSON-shaped message failed `presentError`'s `isProse` check) |
| Any of them, on the 503 | "The request failed (503)." |

An empty prepaid balance was indistinguishable from an outage and from a permissions fault.

### What it says now

`clients/terminal/src/surfaces/serviceDenial.ts` maps the seven-reason vocabulary — `allowed`, `billing_setup_required`, `insufficient_balance`, `payment_past_due`, `spend_cap_reached`, `concurrency_limit_reached`, `billing_unavailable` — to copy kept **byte-aligned** with `services/dashboard/src/lib/service-denial.ts` and with `Vexa-ai/vexa-platform` `services/webapp/apps/webapp/lib/service-denial-view.ts`, and classifies each into what the customer can DO: `paywall` / `setup` / `limit` / `retryable` / `unknown`.

- An **unmapped** reason renders VERBATIM (`service not allowed: <code>`) with a `console.error` **in production too** — an unmapped reason is a prod-only event by definition (it means the authority shipped a reason ahead of this copy), so a dev-only log has no signal exactly where the drift happens.
- A **401**, and a **403 without the denial code**, keep their access-error rendering. Routing a real permission fault to the paywall would tell someone to pay for a problem money cannot fix.

`clients/terminal/src/surfaces/ServiceDenialPanel.tsx` renders it **in-flow, not as a transient line** — a paywall is a thing the user must act on, and the sidebar's error line cleared itself after 5s (the meeting row's after 6s); both are now sticky when the failure is a denial. Styling is the terminal's own idiom (CSS-var semantic tones, ui-kit `Icon`), not the dashboard's Tailwind: `--warn` carries `paywall`/`setup` because the account is fine and needs money, and only an unmapped reason — a bug — gets `--danger`.

### The plumbing that made it possible

`ApiError` gains `body`: the parsed failure body as it came off the wire. It was already being flattened to a string for the operator channel, and **flattening is exactly what destroyed the distinction**. `getJson`'s error path moved into an exported `readApiFailure()` so the four join edges that call `fetch()` directly produce the same error object. The denial reader also parses a JSON-shaped `detail` string, so a call site predating the structured field still renders transparently rather than silently regressing to "access denied".

## The pin now has THREE twins — please reconcile at merge time

`clients/terminal/src/surfaces/__tests__/serviceDenialVocabulary.test.ts` is the twin of the dashboard's `services/dashboard/tests/service-denial-vocabulary.test.ts`. Its failure message names all **six** places a reason must be added, because there are now **three** copy modules across two repos, not two:

1. `Vexa-ai/vexa` `clients/terminal/src/surfaces/serviceDenial.ts` (new)
2. `Vexa-ai/vexa` `services/dashboard/src/lib/service-denial.ts`
3. `Vexa-ai/vexa-platform` `services/webapp/apps/webapp/lib/service-denial-view.ts`

**The two older pins' failure messages still say FOUR places**, because they predate this module. Updating them was deliberately left out of this PR to keep it to one surface — the three message lists should be reconciled when this merges, alongside #1176 and `Vexa-ai/vexa-platform#292`.

The deeper fix remains narrowing `reason` to an enum in `core/meetings/contracts/service-authority.v1`, which is SEALED and types `Decision.reason` as an opaque string. That is a breaking change to a frozen `.vN` and needs a `service-authority.v2` on a `lane:contract` PR, not an edit to v1.

## Verification

- `npx vitest run` (`clients/terminal`) — **55 files, 411 tests, all pass**, including 12 new vocabulary/access-boundary assertions and one new row-action denial test.
- `npx tsc --noEmit` — clean.
- `npx next build` — clean.
- `pre-push` fast gate suite (14 static gates) — green.

One pre-existing test was updated: `meetingActions.test.tsx` pins the exact `MeetingActionFailure` shape, which gains the additive `denial` field.

### Note on `gate:schema`

The first push attempt aborted on `gate:schema`, which reproduces identically on a clean `origin/main` checkout with zero changes. The cause is environmental, not a schema violation: in a fresh worktree without root `node_modules`, every contract's `validate.mjs` dies with `Cannot find package 'ajv'`, and the gate reports it as an empty-bodied failure. Worth noting because the empty body makes it read as a real conformance failure — the gate swallows `ERR_MODULE_NOT_FOUND` into `""`. With root deps present the gate passes on all 25 contracts.

Refs `Vexa-ai/vexa-platform#291`
Refs #1176 (the pattern source — reason→copy mapping, kind system, in-flow panel, vocabulary pin)

<!-- vexa-agent -->
