### PR TITLE
[DEV] feat(terminal): manage multiple calendars, not one feed

### DIFF
--- a/clients/terminal/src/app/api/__tests__/proxyMode.test.ts
+++ b/clients/terminal/src/app/api/__tests__/proxyMode.test.ts
@@ -37,4 +37,13 @@ describe("proxyMode — meetings-only server gate", () => {
     process.env.NEXT_PUBLIC_TERMINAL_MODE = "meetings";
     expect(refusedInMeetingsMode("user/calendar")).toBe(false);
   });
+
+  it("the PLURAL calendar paths route the same way (#1150) — id and sync segments included", () => {
+    for (const p of ["user/calendars", "user/calendars/f52a1067-6f0d-43c5-9641-54da51d3610f", "user/calendars/f52a1067/sync"]) {
+      expect(MEETINGS_DOMAIN.test(p)).toBe(true);
+    }
+    process.env.NEXT_PUBLIC_TERMINAL_MODE = "meetings";
+    expect(refusedInMeetingsMode("user/calendars")).toBe(false);
+    expect(refusedInMeetingsMode("user/calendars/abc/sync")).toBe(false);
+  });
 });

--- a/clients/terminal/src/surfaces/README.md
+++ b/clients/terminal/src/surfaces/README.md
@@ -13,6 +13,18 @@ RECENT ACTIVITY feed (email-attributed, clickable files), the "new updates" nav 
 auto-pin on shared connect, and the Share/invite dialog (single-rank). The end-to-end model is in
 **[`docs/docs/core/workspaces.mdx`](../../../../docs/docs/core/workspaces.mdx)**.
 
+**Calendars are plural** (`calendarConnections.tsx`, the plural `/user/calendars` API — see
+[`docs/docs/api/calendar.mdx`](../../../../docs/docs/api/calendar.mdx)). An account holds up to ten
+named ICS connections, each with its own `enabled` flag, auto-join policy and bot name. There is ONE
+manager — Settings → Calendar (list · add · rename · replace feed · pause · disconnect · sync-one);
+the Meetings rail popover (`meeting.tsx`) and the first-run card (`meetingsOnboarding.tsx`) are the
+point-of-need skins over the same API and defer everything else to Settings. Three invariants the
+tests pin: the feed address is **write-only** (the API returns `ics_url_set` + a recognition mask, and
+no input is ever prefilled from the server), the ten-connection cap is stated in the UI rather than
+arriving as a surprise 409, and a write that changes what gets joined (`auto_join` · `bot_name` ·
+`enabled` · a replaced `ics_url`) is followed by the per-calendar sync that reconciles
+already-imported meetings — a rename is not, because it changes nothing downstream.
+
 **Error presentation is part of the surface contract** — surfaces render `presentError(e)`
 (`apiClient.ts`), never `e.message`: the headline is user vocabulary ("Couldn't reach the Vexa
 server…", the backend's own prose reason verbatim when it sent one), while the untranslated

--- a/clients/terminal/src/surfaces/__tests__/calendarConnections.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/calendarConnections.test.tsx
@@ -1,0 +1,293 @@
+/** Settings → Calendar, the multi-calendar manager (#1150 plural API).
+ *
+ *  The behaviours worth pinning are the ones a refactor would quietly lose: the secret feed is
+ *  never rendered or prefilled, the ten-connection cap is stated in the UI instead of arriving as
+ *  a surprise 409, disconnect says what it destroys BEFORE it fires, and a PATCH that changes what
+ *  gets joined is followed by the sync that reconciles already-imported meetings (while a rename,
+ *  which changes nothing downstream, is not).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { CalendarConnectionsPanel, patchNeedsSync, syncLine, feedLine, disconnectWarning } from "../calendarConnections";
+import type { CalendarConnection } from "../plannedApi";
+
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+
+const SECRET = "https://calendar.google.com/calendar/ical/x/private-SUPERSECRET/basic.ics";
+
+function cal(over: Partial<CalendarConnection> = {}): CalendarConnection {
+  return {
+    id: "cal-1", name: "Work", ics_url_set: true, ics_url_masked: "calendar.google.com/….ics",
+    auto_join: true, bot_name: "Work Notes", enabled: true, ...over,
+  };
+}
+
+interface Call { url: string; method: string; body?: string }
+
+/** Stubs the whole plural surface. `createStatus` lets a test drive the 409/422 branch. */
+function stubApi(list: CalendarConnection[], opts: {
+  syncStamp?: Record<string, unknown>;
+  createStatus?: number;
+  createDetail?: string;
+} = {}) {
+  const calls: Call[] = [];
+  let current = [...list];
+  vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    calls.push({ url: u, method, body: init?.body as string });
+
+    if (/\/api\/user\/calendars\/[^/]+\/sync$/.test(u)) {
+      return new Response(JSON.stringify(opts.syncStamp ?? { last_sync: "2026-08-14T15:30:00Z", counts: { created: 2, updated: 1 } }), { status: 200 });
+    }
+    if (/\/api\/user\/calendars\/[^/]+$/.test(u)) {
+      if (method === "DELETE") {
+        const id = u.split("/").pop()!;
+        current = current.filter((c) => c.id !== id);
+        return new Response(null, { status: 204 });
+      }
+      if (method === "PATCH") {
+        const id = u.split("/").pop()!;
+        const patch = JSON.parse((init?.body as string) || "{}");
+        current = current.map((c) => (c.id === id ? { ...c, ...patch, ics_url_set: true } : c));
+        return new Response(JSON.stringify(current.find((c) => c.id === id)), { status: 200 });
+      }
+    }
+    if (u.endsWith("/api/user/calendars")) {
+      if (method === "POST") {
+        if (opts.createStatus) return new Response(JSON.stringify({ detail: opts.createDetail }), { status: opts.createStatus });
+        const made = cal({ id: "cal-new", name: JSON.parse((init?.body as string) || "{}").name });
+        current = [...current, made];
+        return new Response(JSON.stringify(made), { status: 201 });
+      }
+      return new Response(JSON.stringify({ calendars: current }), { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
+  }));
+  return calls;
+}
+
+describe("pure helpers", () => {
+  it("patchNeedsSync — only fields that change what gets joined", () => {
+    expect(patchNeedsSync({ name: "Renamed" })).toBe(false);
+    expect(patchNeedsSync({ auto_join: false })).toBe(true);
+    expect(patchNeedsSync({ bot_name: "Notes" })).toBe(true);
+    expect(patchNeedsSync({ enabled: false })).toBe(true);
+    expect(patchNeedsSync({ ics_url: SECRET })).toBe(true);
+  });
+
+  it("syncLine — an error REPLACES the timestamp, it is not a footnote on a success", () => {
+    const bad = syncLine({ last_sync: "2026-08-14T15:30:00Z", last_error: "HTTP 401 fetching the feed" });
+    expect(bad.ok).toBe(false);
+    expect(bad.text).toContain("HTTP 401 fetching the feed");
+    expect(bad.text).not.toContain("Synced");
+    expect(syncLine(undefined).text).toBe("Not synced yet");
+    expect(syncLine({ last_sync: "2026-08-14T15:30:00Z", counts: { created: 2, updated: 1 } }).text).toContain("2 imported, 1 updated");
+  });
+
+  it("feedLine — set/not-set, and the mask is the only recognition hint", () => {
+    expect(feedLine(cal())).toBe("Feed set · calendar.google.com/….ics");
+    expect(feedLine(cal({ ics_url_masked: null }))).toBe("Feed set");
+    expect(feedLine(cal({ ics_url_set: false, ics_url_masked: null }))).toBe("No feed set");
+  });
+
+  it("disconnectWarning names what is destroyed and what survives", () => {
+    const w = disconnectWarning("Work");
+    expect(w).toContain("Work");
+    expect(w).toMatch(/removed from Meetings and will not be joined/);
+    expect(w).toMatch(/planned by hand, stay/);
+  });
+});
+
+describe("the list", () => {
+  it("renders each calendar with its own state and the cap-relative count", async () => {
+    stubApi([cal(), cal({ id: "cal-2", name: "Personal", auto_join: false, enabled: false, bot_name: "Vexa" })]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    expect(screen.getByText("Personal")).toBeTruthy();
+    expect(screen.getByText("2 of 10 calendars connected")).toBeTruthy();
+    expect(screen.getByText(/Work Notes/)).toBeTruthy();
+    // per-calendar policy is per-row, not global
+    const autoJoins = screen.getAllByLabelText(/Auto-join/i, { selector: "input" });
+    expect(autoJoins.map((i) => (i as HTMLInputElement).checked)).toEqual([true, false]);
+  });
+
+  it("empty state is honest", async () => {
+    stubApi([]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("No calendars connected yet.")).toBeTruthy());
+  });
+
+  it("a failed list is LOUD, never a fake empty", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ detail: "admin-api is down" }), { status: 502 })));
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/can't reach a backend service/i));
+  });
+});
+
+describe("the feed address is write-only", () => {
+  it("no stored URL is ever rendered, and Replace-feed starts EMPTY", async () => {
+    // A server that (wrongly) leaks the real address must still not put it on screen.
+    stubApi([{ ...cal(), ics_url_masked: "calendar.google.com/….ics", ...({ ics_url: SECRET } as object) } as CalendarConnection]);
+    const { container } = render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    expect(container.textContent).not.toContain("SUPERSECRET");
+
+    fireEvent.click(screen.getByText("Edit"));
+    const replace = screen.getByLabelText("Replace feed address for Work") as HTMLInputElement;
+    expect(replace.value).toBe("");
+    expect(replace.type).toBe("password");
+    expect(screen.getByText(/never shown again/)).toBeTruthy();
+  });
+});
+
+describe("the ten-connection cap", () => {
+  it("Add is refused locally at the cap, with the reason", async () => {
+    stubApi(Array.from({ length: 10 }, (_, i) => cal({ id: `cal-${i}`, name: `Cal ${i}` })));
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("10 of 10 calendars connected")).toBeTruthy());
+    expect((screen.getByText("+ Add calendar") as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/disconnect one to add another/)).toBeTruthy();
+  });
+
+  it("under the cap Add is live, and a backend 409 still surfaces verbatim", async () => {
+    stubApi([cal()], { createStatus: 409, createDetail: "Ten active calendar connections already exist." });
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("+ Add calendar")).toBeTruthy());
+    fireEvent.click(screen.getByText("+ Add calendar"));
+    fireEvent.change(screen.getByLabelText("Calendar name"), { target: { value: "Second" } });
+    fireEvent.change(screen.getByLabelText("Secret ICS address"), { target: { value: SECRET } });
+    fireEvent.click(screen.getByText("Connect"));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("Ten active calendar connections already exist."));
+  });
+});
+
+describe("add", () => {
+  it("POSTs the connection then syncs THAT id, and reports what it found", async () => {
+    const calls = stubApi([]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("+ Add calendar")).toBeTruthy());
+    fireEvent.click(screen.getByText("+ Add calendar"));
+    fireEvent.change(screen.getByLabelText("Calendar name"), { target: { value: "Work" } });
+    fireEvent.change(screen.getByLabelText("Secret ICS address"), { target: { value: SECRET } });
+    fireEvent.change(screen.getByLabelText("Bot name for the new calendar"), { target: { value: "Work Notes" } });
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toMatch(/3 upcoming meetings imported/));
+    const post = calls.find((c) => c.url.endsWith("/api/user/calendars") && c.method === "POST")!;
+    expect(JSON.parse(post.body!)).toEqual({ name: "Work", ics_url: SECRET, auto_join: true, bot_name: "Work Notes" });
+    expect(calls.some((c) => c.url.endsWith("/api/user/calendars/cal-new/sync") && c.method === "POST")).toBe(true);
+  });
+
+  it("a 422 from the backend is shown verbatim, and the form stays open", async () => {
+    stubApi([], { createStatus: 422, createDetail: "That is an embed page, not an ICS feed." });
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("+ Add calendar")).toBeTruthy());
+    fireEvent.click(screen.getByText("+ Add calendar"));
+    fireEvent.change(screen.getByLabelText("Calendar name"), { target: { value: "Work" } });
+    fireEvent.change(screen.getByLabelText("Secret ICS address"), { target: { value: "https://calendar.google.com/embed?src=x" } });
+    fireEvent.click(screen.getByText("Connect"));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("That is an embed page, not an ICS feed."));
+    expect(screen.getByLabelText("Secret ICS address")).toBeTruthy();
+  });
+});
+
+describe("edit", () => {
+  it("toggling auto-join PATCHes one calendar and then syncs it", async () => {
+    const calls = stubApi([cal(), cal({ id: "cal-2", name: "Personal" })]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Personal")).toBeTruthy());
+    fireEvent.click(screen.getAllByLabelText(/Auto-join/i, { selector: "input" })[1]);
+
+    await waitFor(() => expect(calls.some((c) => c.url.endsWith("/api/user/calendars/cal-2") && c.method === "PATCH")).toBe(true));
+    const patch = calls.find((c) => c.method === "PATCH")!;
+    expect(JSON.parse(patch.body!)).toEqual({ auto_join: false });
+    await waitFor(() => expect(calls.some((c) => c.url.endsWith("/api/user/calendars/cal-2/sync") && c.method === "POST")).toBe(true));
+    // the OTHER calendar is untouched
+    expect(calls.some((c) => c.url.includes("cal-1") && c.method === "PATCH")).toBe(false);
+  });
+
+  it("enabled is a pause, not a delete — PATCH, never DELETE", async () => {
+    const calls = stubApi([cal()]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    fireEvent.click(screen.getByLabelText(/Enabled/i, { selector: "input" }));
+    await waitFor(() => expect(calls.some((c) => c.method === "PATCH")).toBe(true));
+    expect(JSON.parse(calls.find((c) => c.method === "PATCH")!.body!)).toEqual({ enabled: false });
+    expect(calls.some((c) => c.method === "DELETE")).toBe(false);
+  });
+
+  it("a rename alone PATCHes and does NOT trigger a follow-up sync", async () => {
+    const calls = stubApi([cal()]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.change(screen.getByLabelText("Name for Work"), { target: { value: "Customer calls" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(calls.some((c) => c.method === "PATCH")).toBe(true));
+    expect(JSON.parse(calls.find((c) => c.method === "PATCH")!.body!)).toEqual({ name: "Customer calls" });
+    const syncsAfterPatch = calls.slice(calls.findIndex((c) => c.method === "PATCH")).filter((c) => c.method === "POST" && c.url.includes("/sync"));
+    expect(syncsAfterPatch).toEqual([]);
+  });
+
+  it("replacing the feed sends the new ics_url and re-syncs", async () => {
+    const calls = stubApi([cal()]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.change(screen.getByLabelText("Replace feed address for Work"), { target: { value: SECRET } });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(calls.some((c) => c.method === "PATCH")).toBe(true));
+    expect(JSON.parse(calls.find((c) => c.method === "PATCH")!.body!)).toEqual({ ics_url: SECRET });
+    await waitFor(() => expect(calls.some((c) => c.url.endsWith("/api/user/calendars/cal-1/sync") && c.method === "POST")).toBe(true));
+  });
+});
+
+describe("sync now", () => {
+  it("syncs ONE calendar and renders its fresh stamp", async () => {
+    const calls = stubApi([cal()], { syncStamp: { last_sync: "2026-08-14T15:30:00Z", counts: { created: 5, updated: 0 } } });
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    fireEvent.click(screen.getByText("Sync now"));
+    await waitFor(() => expect(screen.getByText(/5 imported, 0 updated/)).toBeTruthy());
+    expect(calls.filter((c) => c.url.endsWith("/api/user/calendars/cal-1/sync") && c.method === "POST").length).toBe(1);
+  });
+
+  it("a 200 carrying last_error reads as a FAILURE", async () => {
+    stubApi([cal()], { syncStamp: { last_sync: "2026-08-14T15:30:00Z", last_error: "HTTP 404 fetching the feed" } });
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    fireEvent.click(screen.getByText("Sync now"));
+    await waitFor(() => expect(screen.getByText(/Last sync failed: HTTP 404 fetching the feed/)).toBeTruthy());
+  });
+});
+
+describe("disconnect", () => {
+  it("states the consequence and needs a second click", async () => {
+    const calls = stubApi([cal()]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("Disconnect"));
+    expect(screen.getByText(/Meetings this calendar alone imported are removed/)).toBeTruthy();
+    expect(calls.some((c) => c.method === "DELETE")).toBe(false);   // nothing fired on the FIRST click
+
+    fireEvent.click(screen.getByText("Yes, disconnect"));
+    await waitFor(() => expect(calls.some((c) => c.url.endsWith("/api/user/calendars/cal-1") && c.method === "DELETE")).toBe(true));
+    await waitFor(() => expect(screen.getByText("No calendars connected yet.")).toBeTruthy());
+  });
+
+  it("'Keep it' backs out without touching the server", async () => {
+    const calls = stubApi([cal()]);
+    render(<CalendarConnectionsPanel />);
+    await waitFor(() => expect(screen.getByText("Work")).toBeTruthy());
+    fireEvent.click(screen.getByText("Disconnect"));
+    fireEvent.click(screen.getByText("Keep it"));
+    await waitFor(() => expect(screen.queryByText(/Meetings this calendar alone imported/)).toBeNull());
+    expect(calls.some((c) => c.method === "DELETE")).toBe(false);
+    expect(screen.getByText("Work")).toBeTruthy();
+  });
+});

--- a/clients/terminal/src/surfaces/__tests__/meetingsOnboarding.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/meetingsOnboarding.test.tsx
@@ -19,19 +19,19 @@ afterEach(() => {
 
 function stubCalendarApi(opts: { connected: boolean; syncCounts?: { created?: number; updated?: number }; syncError?: string }) {
   const calls: { url: string; method?: string; body?: string }[] = [];
+  const CAL = { id: "cal-1", name: "My calendar", ics_url_set: true, ics_url_masked: "calendar.google.com/…d3f1", auto_join: true, bot_name: "Vexa", enabled: true };
   vi.stubGlobal(
     "fetch",
     vi.fn(async (url: string, init?: RequestInit) => {
-      calls.push({ url: String(url), method: init?.method, body: init?.body as string });
-      if (String(url).includes("/api/user/calendar/sync")) {
+      const u = String(url);
+      calls.push({ url: u, method: init?.method, body: init?.body as string });
+      if (/\/api\/user\/calendars\/[^/]+\/sync$/.test(u)) {
         if (opts.syncError) return new Response(JSON.stringify({ last_error: opts.syncError }), { status: 200 });
         return new Response(JSON.stringify({ last_sync: new Date().toISOString(), counts: opts.syncCounts ?? {} }), { status: 200 });
       }
-      if (String(url).includes("/api/user/calendar")) {
-        if (init?.method === "PUT") {
-          return new Response(JSON.stringify({ ics_url_set: true, ics_url_masked: "calendar.google.com/…d3f1", auto_join: true }), { status: 200 });
-        }
-        return new Response(JSON.stringify({ ics_url_set: opts.connected, ics_url_masked: null, auto_join: true }), { status: 200 });
+      if (u.includes("/api/user/calendars")) {
+        if (init?.method === "POST") return new Response(JSON.stringify(CAL), { status: 201 });
+        return new Response(JSON.stringify({ calendars: opts.connected ? [CAL] : [] }), { status: 200 });
       }
       return new Response("{}", { status: 200 });
     }),
@@ -64,7 +64,7 @@ describe("slim — the standing affordances on a populated Meetings page", () =>
   it("calendar card disappears once connected — plan + drop-bot STAY", async () => {
     const calls = stubCalendarApi({ connected: true });
     const { container } = render(<MeetingsOnboarding variant="slim" />);
-    await waitFor(() => expect(calls.some((c) => c.url.includes("/api/user/calendar"))).toBe(true));
+    await waitFor(() => expect(calls.some((c) => c.url.includes("/api/user/calendars"))).toBe(true));
     expect(container.textContent).not.toContain("No calendar connected");
     expect(screen.getByText("+ Plan a meeting")).toBeTruthy();
     expect(screen.getByPlaceholderText(/Paste a meeting link/)).toBeTruthy();
@@ -90,7 +90,7 @@ describe("full — the three-path empty state", () => {
   it("calendar card retires once connected; plan/drop remain", async () => {
     const calls = stubCalendarApi({ connected: true });
     render(<MeetingsOnboarding variant="full" />);
-    await waitFor(() => expect(calls.some((c) => c.url.includes("/api/user/calendar"))).toBe(true));
+    await waitFor(() => expect(calls.some((c) => c.url.includes("/api/user/calendars"))).toBe(true));
     await waitFor(() => expect(screen.getByText(/Calendar connected/)).toBeTruthy());
     expect(screen.queryByText("Connect your calendar")).toBeNull();
     expect(screen.getByText("Plan a meeting")).toBeTruthy();
@@ -98,7 +98,7 @@ describe("full — the three-path empty state", () => {
 });
 
 describe("connect modal — teaches the secret address and answers on connect", () => {
-  it("walkthrough + paste → PUT + sync-now → reports what it found", async () => {
+  it("walkthrough + paste → POST /user/calendars + sync-now → reports what it found", async () => {
     const calls = stubCalendarApi({ connected: false, syncCounts: { created: 3 } });
     render(<MeetingsOnboarding variant="slim" />);
     await waitFor(() => screen.getByText("Connect calendar →"));
@@ -114,9 +114,12 @@ describe("connect modal — teaches the secret address and answers on connect", 
     fireEvent.click(screen.getByText("Connect"));
 
     await waitFor(() => expect(screen.getByText(/3 upcoming meetings imported/)).toBeTruthy());
-    const put = calls.find((c) => c.url.includes("/api/user/calendar") && c.method === "PUT");
-    expect(put).toBeDefined();
-    expect(calls.some((c) => c.url.includes("/api/user/calendar/sync") && c.method === "POST")).toBe(true);
+    // first connect CREATES connection #1 on the plural API, with a name…
+    const post = calls.find((c) => c.url.endsWith("/api/user/calendars") && c.method === "POST");
+    expect(post).toBeDefined();
+    expect(JSON.parse(post!.body as string)).toMatchObject({ name: "My calendar", auto_join: true });
+    // …then syncs THAT connection by id (the backend does not sync on create)
+    expect(calls.some((c) => /\/api\/user\/calendars\/cal-1\/sync$/.test(c.url) && c.method === "POST")).toBe(true);
   });
 
   it("first-sync failure is loud, with the server's reason", async () => {

--- a/clients/terminal/src/surfaces/calendarConnections.tsx
+++ b/clients/terminal/src/surfaces/calendarConnections.tsx
@@ -1,0 +1,357 @@
+"use client";
+/** Calendar connections — the Settings → Calendar body (#1150 plural API).
+ *
+ *  An account holds up to ten NAMED ICS feeds, each with its own enabled flag, auto-join policy and
+ *  bot name. This is the durable management surface: list · add · edit · disconnect · sync-one. The
+ *  Meetings sidebar keeps its own first-connect card at the point of need (`meetingsOnboarding`).
+ *
+ *  Three rules this surface exists to hold:
+ *
+ *  1. **The feed address is write-only.** It goes out on create/replace and never comes back: the
+ *     API returns `ics_url_set` plus a recognition mask, and no input here is ever PREFILLED from
+ *     the server. Replacing a feed means typing a new one into an empty (masked) field.
+ *  2. **Disconnect states its consequence before it fires.** Removing a connection disarms the
+ *     meetings it alone imported — the row says so, in place, and needs a second click.
+ *  3. **The ten-connection cap is a UI fact, not a surprise 409.** The count is always visible and
+ *     Add is refused locally at the cap (the backend 409 stays the real gate, and still surfaces).
+ *
+ *  Sync is not automatic on the backend after a write, so the client runs it: after a create, and
+ *  after any edit whose effect must be reconciled onto already-imported meetings (auto-join, bot
+ *  name, enabled, a replaced feed). A rename alone changes nothing downstream, so it skips the sync.
+ */
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import { Icon } from "../ui-kit";
+import { presentError } from "./apiClient";
+import { refreshMeetings } from "./liveMeetings";
+import {
+  MAX_CALENDARS, listCalendars, createCalendar, updateCalendar, deleteCalendar,
+  syncCalendar, getCalendarSyncStatus,
+  type CalendarConnection, type CalendarUpdateBody, type CalendarSyncStamp,
+} from "./plannedApi";
+
+const field: CSSProperties = { width: "100%", boxSizing: "border-box", fontSize: 12, padding: "6px 9px", borderRadius: 6, border: "1px solid var(--line)", background: "var(--panel2)", color: "var(--t1)" };
+const btn: CSSProperties = { fontSize: 12, padding: "5px 12px", borderRadius: 6, border: "1px solid var(--line)", background: "var(--panel2)", color: "var(--t1)", cursor: "pointer" };
+const primaryBtn: CSSProperties = { ...btn, background: "var(--accent)", color: "var(--on-accent)", border: "none" };
+const row: CSSProperties = { border: "1px solid var(--line)", borderRadius: 8, padding: "10px 12px", display: "flex", flexDirection: "column", gap: 8 };
+const meta: CSSProperties = { fontSize: 11, color: "var(--t3)", lineHeight: 1.5 };
+const labelled: CSSProperties = { display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--t2)" };
+const labelCol: CSSProperties = { width: 96, flex: "none", color: "var(--t3)" };
+const checkRow: CSSProperties = { display: "flex", alignItems: "center", gap: 7, fontSize: 12, color: "var(--t2)", cursor: "pointer" };
+
+/** Which PATCH fields must be reconciled onto already-imported meetings by a follow-up sync.
+ *  A rename is cosmetic on the connection alone — everything else changes what gets joined. */
+export function patchNeedsSync(body: CalendarUpdateBody): boolean {
+  return body.auto_join !== undefined || body.bot_name !== undefined
+    || body.enabled !== undefined || body.ics_url !== undefined;
+}
+
+/** The one-line state of a connection's last sync attempt. `last_error` REPLACES the timestamp —
+ *  a 200 carrying an error is a failed sync, not a successful one with a footnote. */
+export function syncLine(stamp: CalendarSyncStamp | undefined): { ok: boolean; text: string } {
+  if (stamp?.last_error) return { ok: false, text: `Last sync failed: ${stamp.last_error}` };
+  if (!stamp?.last_sync) return { ok: true, text: "Not synced yet" };
+  const c = stamp.counts;
+  const counts = c
+    ? ` · ${c.created ?? 0} imported, ${c.updated ?? 0} updated${c.cancelled ? `, ${c.cancelled} cancelled` : ""}`
+    : "";
+  return { ok: true, text: `Synced ${new Date(stamp.last_sync).toLocaleString()}${counts}` };
+}
+
+/** What the feed field says. The stored address is NEVER rendered; the mask (host + suffix) is a
+ *  recognition hint the API hands out precisely because it is not the credential. */
+export function feedLine(cal: CalendarConnection): string {
+  if (!cal.ics_url_set) return "No feed set";
+  return cal.ics_url_masked ? `Feed set · ${cal.ics_url_masked}` : "Feed set";
+}
+
+/** The consequence sentence, said BEFORE the destructive click — not after it. */
+export function disconnectWarning(name: string): string {
+  return `Disconnect “${name}”? Meetings this calendar alone imported are removed from Meetings and will not be joined. Meetings from another calendar, and ones you planned by hand, stay. Its feed address is deleted.`;
+}
+
+function EditPanel({ cal, busy, onSave, onCancel }: {
+  cal: CalendarConnection;
+  busy: boolean;
+  onSave: (body: CalendarUpdateBody) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(cal.name);
+  const [botName, setBotName] = useState(cal.bot_name ?? "");
+  const [icsUrl, setIcsUrl] = useState("");   // always starts EMPTY — nothing stored is echoed back
+
+  const body: CalendarUpdateBody = {};
+  if (name.trim() && name.trim() !== cal.name) body.name = name.trim();
+  if (botName.trim() && botName.trim() !== (cal.bot_name ?? "")) body.bot_name = botName.trim();
+  if (icsUrl.trim()) body.ics_url = icsUrl.trim();
+  const dirty = Object.keys(body).length > 0;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 7, borderTop: "1px dashed var(--line)", paddingTop: 9 }}>
+      <label style={labelled}>
+        <span style={labelCol}>Name</span>
+        <input value={name} onChange={(e) => setName(e.target.value)} maxLength={100} style={field} aria-label={`Name for ${cal.name}`} />
+      </label>
+      <label style={labelled}>
+        <span style={labelCol}>Bot name</span>
+        <input value={botName} onChange={(e) => setBotName(e.target.value)} maxLength={100} placeholder="Vexa"
+          style={field} aria-label={`Bot name for ${cal.name}`} />
+      </label>
+      <label style={labelled}>
+        <span style={labelCol}>Replace feed</span>
+        <input value={icsUrl} onChange={(e) => setIcsUrl(e.target.value)} type="password" autoComplete="off"
+          placeholder="paste a new secret ICS address to replace it" style={field}
+          aria-label={`Replace feed address for ${cal.name}`} />
+      </label>
+      <div style={{ ...meta, paddingLeft: 104 }}>
+        The stored address is never shown again. Leave this empty to keep the current feed.
+      </div>
+      <div style={{ display: "flex", gap: 8, paddingLeft: 104 }}>
+        <button disabled={busy || !dirty} onClick={() => onSave(body)}
+          style={{ ...(dirty ? primaryBtn : btn), opacity: busy || !dirty ? 0.5 : 1 }}>
+          {busy ? "Saving…" : "Save"}
+        </button>
+        <button disabled={busy} onClick={onCancel} style={btn}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+function CalendarRow({ cal, stamp, busy, onPatch, onSync, onDisconnect }: {
+  cal: CalendarConnection;
+  stamp: CalendarSyncStamp | undefined;
+  busy: string | null;
+  onPatch: (body: CalendarUpdateBody) => void;
+  onSync: () => void;
+  onDisconnect: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const locked = busy !== null;
+  const sync = syncLine(stamp);
+
+  return (
+    <div style={{ ...row, opacity: cal.enabled ? 1 : 0.7 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Icon name="cal" size={13} style={{ color: cal.enabled ? "var(--green)" : "var(--t3)" }} />
+        <span style={{ fontSize: 12.5, fontWeight: 600, color: "var(--t1)" }}>{cal.name}</span>
+        <span style={{ flex: 1, fontSize: 11.5, color: "var(--t3)", fontFamily: "var(--mono)" }}>{feedLine(cal)}</span>
+        <button disabled={locked} onClick={onSync} style={btn}>{busy === "sync" ? "Syncing…" : "Sync now"}</button>
+        <button disabled={locked} onClick={() => { setEditing((v) => !v); setConfirming(false); }}
+          aria-expanded={editing} style={btn}>{editing ? "Close" : "Edit"}</button>
+        <button disabled={locked} onClick={() => { setConfirming(true); setEditing(false); }}
+          style={{ ...btn, color: "var(--danger)" }}>Disconnect</button>
+      </div>
+
+      <div style={{ ...sync.ok ? meta : { ...meta, color: "var(--danger)" } }} role={sync.ok ? undefined : "alert"}>
+        {sync.ok ? "" : "⚠ "}{sync.text}
+      </div>
+
+      <div style={{ display: "flex", gap: 18, flexWrap: "wrap" }}>
+        <label style={checkRow}>
+          <input type="checkbox" checked={cal.enabled} disabled={locked}
+            onChange={(e) => onPatch({ enabled: e.target.checked })} />
+          Enabled — keep checking this feed for new meetings
+        </label>
+        <label style={checkRow}>
+          <input type="checkbox" checked={cal.auto_join} disabled={locked}
+            onChange={(e) => onPatch({ auto_join: e.target.checked })} />
+          Auto-join — send the bot to this calendar&rsquo;s meetings
+        </label>
+        <span style={meta}>Bot name <span style={{ color: "var(--t2)", fontFamily: "var(--mono)" }}>{cal.bot_name || "Vexa"}</span></span>
+      </div>
+
+      {confirming && (
+        <div role="alert" style={{ display: "flex", flexDirection: "column", gap: 7, borderTop: "1px dashed var(--line)", paddingTop: 9 }}>
+          <span style={{ fontSize: 11.5, color: "var(--danger)", lineHeight: 1.5 }}>⚠ {disconnectWarning(cal.name)}</span>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button disabled={locked} onClick={onDisconnect}
+              style={{ ...btn, background: "var(--danger)", color: "var(--on-accent)", border: "none", opacity: locked ? 0.5 : 1 }}>
+              {busy === "delete" ? "Disconnecting…" : "Yes, disconnect"}
+            </button>
+            <button disabled={locked} onClick={() => setConfirming(false)} style={btn}>Keep it</button>
+          </div>
+        </div>
+      )}
+
+      {editing && (
+        <EditPanel cal={cal} busy={busy === "update"}
+          onSave={(body) => { onPatch(body); setEditing(false); }}
+          onCancel={() => setEditing(false)} />
+      )}
+    </div>
+  );
+}
+
+function AddCalendarForm({ busy, onAdd, onCancel }: {
+  busy: boolean;
+  onAdd: (body: { name: string; ics_url: string; auto_join: boolean; bot_name?: string }) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [icsUrl, setIcsUrl] = useState("");
+  const [botName, setBotName] = useState("");
+  const [autoJoin, setAutoJoin] = useState(true);
+  const ready = !!name.trim() && !!icsUrl.trim();
+
+  return (
+    <div style={{ ...row, borderStyle: "dashed" }}>
+      <div style={{ fontSize: 12.5, fontWeight: 600, color: "var(--t1)" }}>Add a calendar</div>
+      <div style={meta}>
+        Google Calendar: ⚙ Settings → your calendar → <b style={{ color: "var(--t2)" }}>Integrate calendar</b> → copy
+        the <b style={{ color: "var(--t2)" }}>Secret address in iCal format</b>. Outlook: Settings → Calendar →
+        Shared calendars → Publish a calendar. Not the public page or embed link — the secret address is a password.
+      </div>
+      <label style={labelled}>
+        <span style={labelCol}>Name</span>
+        <input value={name} onChange={(e) => setName(e.target.value)} maxLength={100} placeholder="Work"
+          style={field} aria-label="Calendar name" />
+      </label>
+      <label style={labelled}>
+        <span style={labelCol}>Secret ICS</span>
+        <input value={icsUrl} onChange={(e) => setIcsUrl(e.target.value)} type="password" autoComplete="off"
+          placeholder="https://calendar.google.com/…/basic.ics" style={field} aria-label="Secret ICS address"
+          onKeyDown={(e) => { if (e.key === "Enter" && ready && !busy) onAdd({ name: name.trim(), ics_url: icsUrl.trim(), auto_join: autoJoin, bot_name: botName.trim() || undefined }); }} />
+      </label>
+      <label style={labelled}>
+        <span style={labelCol}>Bot name</span>
+        <input value={botName} onChange={(e) => setBotName(e.target.value)} maxLength={100} placeholder="Vexa"
+          style={field} aria-label="Bot name for the new calendar" />
+      </label>
+      <label style={{ ...checkRow, paddingLeft: 104 }}>
+        <input type="checkbox" checked={autoJoin} onChange={(e) => setAutoJoin(e.target.checked)} />
+        Auto-join meetings imported from this calendar
+      </label>
+      <div style={{ display: "flex", gap: 8, paddingLeft: 104 }}>
+        <button disabled={busy || !ready}
+          onClick={() => onAdd({ name: name.trim(), ics_url: icsUrl.trim(), auto_join: autoJoin, bot_name: botName.trim() || undefined })}
+          style={{ ...primaryBtn, opacity: busy || !ready ? 0.5 : 1 }}>
+          {busy ? "Connecting…" : "Connect"}
+        </button>
+        <button disabled={busy} onClick={onCancel} style={btn}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+export function CalendarConnectionsPanel() {
+  const [cals, setCals] = useState<CalendarConnection[] | null>(null);
+  const [stamps, setStamps] = useState<Record<string, CalendarSyncStamp>>({});
+  const [busy, setBusy] = useState<string | null>(null);   // "new" | "<id>:sync|update|delete"
+  const [adding, setAdding] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await listCalendars();
+      setCals(list); setErr(null);
+      // One bad stamp must not blank the page — each probe is caught on its own.
+      const pairs = await Promise.all(list.map(async (c) => {
+        try { return [c.id, await getCalendarSyncStatus(c.id)] as const; }
+        catch { return [c.id, {} as CalendarSyncStamp] as const; }
+      }));
+      setStamps(Object.fromEntries(pairs));
+    } catch (e: unknown) {
+      setCals([]); setErr(presentError(e).headline);
+    }
+  }, []);
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  const atCap = (cals?.length ?? 0) >= MAX_CALENDARS;
+
+  const add = async (body: { name: string; ics_url: string; auto_join: boolean; bot_name?: string }) => {
+    setBusy("new"); setErr(null); setNote(null);
+    try {
+      const created = await createCalendar(body);
+      // The backend does not sync on create — answer the user NOW instead of leaving a silent wait.
+      let stamp: CalendarSyncStamp = {};
+      try { stamp = await syncCalendar(created.id); }
+      catch (e: unknown) { stamp = { last_error: presentError(e).headline }; }
+      setStamps((s) => ({ ...s, [created.id]: stamp }));
+      setAdding(false);
+      setNote(stamp.last_error
+        ? `“${created.name}” connected, but its first sync needs attention.`
+        : `“${created.name}” connected — ${(stamp.counts?.created ?? 0) + (stamp.counts?.updated ?? 0)} upcoming meetings imported.`);
+      refreshMeetings();
+      await refresh();
+    } catch (e: unknown) { setErr(presentError(e).headline); }
+    finally { setBusy(null); }
+  };
+
+  const patch = async (cal: CalendarConnection, body: CalendarUpdateBody) => {
+    setBusy(`${cal.id}:update`); setErr(null); setNote(null);
+    try {
+      await updateCalendar(cal.id, body);
+      if (patchNeedsSync(body)) {
+        // PATCH does not reconcile existing planned meetings; the follow-up sync does.
+        try { setStamps((s) => ({ ...s, [cal.id]: {} })); const st = await syncCalendar(cal.id); setStamps((s) => ({ ...s, [cal.id]: st })); }
+        catch (e: unknown) { setStamps((s) => ({ ...s, [cal.id]: { last_error: presentError(e).headline } })); }
+        refreshMeetings();
+      }
+      await refresh();
+    } catch (e: unknown) { setErr(presentError(e).headline); }
+    finally { setBusy(null); }
+  };
+
+  const sync = async (cal: CalendarConnection) => {
+    setBusy(`${cal.id}:sync`); setErr(null); setNote(null);
+    try { const st = await syncCalendar(cal.id); setStamps((s) => ({ ...s, [cal.id]: st })); refreshMeetings(); }
+    catch (e: unknown) { setErr(presentError(e).headline); }
+    finally { setBusy(null); }
+  };
+
+  const disconnect = async (cal: CalendarConnection) => {
+    setBusy(`${cal.id}:delete`); setErr(null); setNote(null);
+    try {
+      await deleteCalendar(cal.id);
+      setNote(`“${cal.name}” disconnected.`);
+      refreshMeetings();
+      await refresh();
+    } catch (e: unknown) { setErr(presentError(e).headline); }
+    finally { setBusy(null); }
+  };
+
+  const busyFor = (id: string): string | null => (busy?.startsWith(`${id}:`) ? busy.slice(id.length + 1) : busy ? "other" : null);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 640 }}>
+      <div style={{ ...meta, maxWidth: 460 }}>
+        Connect a calendar&rsquo;s secret ICS feed and its scheduled meetings appear in Meetings by
+        themselves; with auto-join on, the bot joins them when they start. Each calendar carries its own
+        auto-join policy and bot name.
+      </div>
+      {err && <div role="alert" style={{ fontSize: 11.5, color: "var(--danger)" }}>⚠ {err}</div>}
+      {note && <div role="status" style={{ fontSize: 11.5, color: "var(--green)" }}>✓ {note}</div>}
+
+      {cals === null ? (
+        <div style={meta}>Loading calendars…</div>
+      ) : cals.length === 0 ? (
+        <div style={meta}>No calendars connected yet.</div>
+      ) : (
+        <>
+          <div style={{ fontSize: 11.5, color: "var(--t3)" }}>
+            {cals.length} of {MAX_CALENDARS} calendars connected
+          </div>
+          {cals.map((c) => (
+            <CalendarRow key={c.id} cal={c} stamp={stamps[c.id]} busy={busyFor(c.id)}
+              onPatch={(b) => void patch(c, b)} onSync={() => void sync(c)} onDisconnect={() => void disconnect(c)} />
+          ))}
+        </>
+      )}
+
+      {adding ? (
+        <AddCalendarForm busy={busy === "new"} onAdd={(b) => void add(b)} onCancel={() => setAdding(false)} />
+      ) : (
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <button disabled={atCap || busy !== null} onClick={() => { setAdding(true); setNote(null); }}
+            style={{ ...btn, opacity: atCap || busy !== null ? 0.5 : 1 }}>+ Add calendar</button>
+          {atCap && (
+            <span style={meta}>
+              You have all {MAX_CALENDARS} calendars connected — disconnect one to add another.
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/terminal/src/surfaces/meeting.tsx
+++ b/clients/terminal/src/surfaces/meeting.tsx
@@ -3,7 +3,7 @@
  *  • "meetings" LIST (left): meetings; the live one auto-opens; click any to (re)open its meeting view.
  *  • "meeting" TAB (center): fixed meeting chrome around the Meeting Canvas body.
  *    The generated canvas view consumes this meeting's live MeetingState. */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useService } from "../platform";
 import { LayoutServiceId, type TabDescriptor } from "../workbench/layout";
 import { registerList, registerTab, registerCommand, type TabProps } from "../contributions";
@@ -18,7 +18,7 @@ import { defaultBotName } from "./defaultBotName";
 import { parseMeetingInput } from "./meetingId";
 import { getJitsiHosts } from "./jitsiHosts";
 import { mintTranscriptShare, mintInvite, listSharedMemberships, type Membership } from "./workspaceApi";
-import { deletePlannedMeeting, getCalendarConfig, setCalendarConfig, getCalendarSyncStatus, syncCalendarNow, type CalendarConfig, type CalendarSyncStamp } from "./plannedApi";
+import { deletePlannedMeeting, MAX_CALENDARS, listCalendars, createCalendar, updateCalendar, syncCalendar, getCalendarSyncStatus, type CalendarConnection, type CalendarSyncStamp } from "./plannedApi";
 import { prepTabDescriptor, prepDraftTabDescriptor } from "./meetingPrep";
 
 // ── "Share session" — mint a link to this meeting's LIVE FEED (independent transcript share) and,
@@ -523,50 +523,87 @@ function CalendarSyncStatusLine({ stamp }: { stamp: CalendarSyncStamp | null }) 
   );
 }
 
-// ── Calendar sync — the secret ICS URL + the GLOBAL auto-join default for imported meetings.
-//    The URL is a secret: reads come back MASKED (host + tail). Synced meetings land under Upcoming.
+// ── Calendar sync — the QUICK view over the user's calendar CONNECTIONS (#1150 plural API).
+//    Per-calendar auto-join + Sync now live here because they are the two things you reach for
+//    mid-day; adding, renaming, replacing a feed and disconnecting live in Settings → Calendar
+//    (one manager, not two — the design-spec's "same list twice" anti-pattern). The feed address
+//    is write-only: it is typed once here for the FIRST calendar and never rendered back.
 //    Two skins over ONE popover: `icon` (the quiet header icon, always there) and `row` (a
-//    discoverable "Connect your calendar" row that hides itself once a feed is connected). ──
+//    discoverable "Connect your calendar" row that hides itself once a calendar exists). ──
 function CalendarSyncButton({ variant = "icon" }: { variant?: "icon" | "row" }) {
+  const layout = useService(LayoutServiceId);
   const [open, setOpen] = useState(false);
-  const [cfg, setCfg] = useState<CalendarConfig | null>(null);
+  const [cals, setCals] = useState<CalendarConnection[] | null>(null);
+  const [stamps, setStamps] = useState<Record<string, CalendarSyncStamp>>({});
   const [url, setUrl] = useState("");
+  const [name, setName] = useState("My calendar");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  const [stamp, setStamp] = useState<CalendarSyncStamp | null>(null);
-  const [syncing, setSyncing] = useState(false);
+  const [syncing, setSyncing] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
-  const syncNow = async () => {
-    setSyncing(true); setErr(null);
-    try { setStamp(await syncCalendarNow()); refreshMeetings(); }
+
+  const load = useCallback(async (withStamps: boolean) => {
+    try {
+      const list = await listCalendars();
+      setCals(list);
+      if (!withStamps) return;
+      const pairs = await Promise.all(list.map(async (c) => {
+        try { return [c.id, await getCalendarSyncStatus(c.id)] as const; }
+        catch { return [c.id, {} as CalendarSyncStamp] as const; }
+      }));
+      setStamps(Object.fromEntries(pairs));
+    } catch { setCals(null); }
+  }, []);
+
+  const syncOne = async (id: string) => {
+    setSyncing(id); setErr(null);
+    try { const st = await syncCalendar(id); setStamps((s) => ({ ...s, [id]: st })); refreshMeetings(); }
     catch (e) { setErr(presentError(e).headline); }
-    finally { setSyncing(false); }
+    finally { setSyncing(null); }
   };
-  // the row skin needs the connected-state up front (it hides once connected)
+
+  // the row skin needs the connected-state up front (it hides once a calendar exists)
   useEffect(() => {
     if (variant !== "row") return;
-    void getCalendarConfig().then(setCfg).catch(() => setCfg(null));
-  }, [variant]);
+    void load(false);
+  }, [variant, load]);
   useEffect(() => {
     if (!open) return;
-    void getCalendarConfig().then(setCfg).catch(() => setCfg(null));
-    void getCalendarSyncStatus().then(setStamp).catch(() => {});
+    void load(true);
     const close = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
     document.addEventListener("mousedown", close);
     return () => document.removeEventListener("mousedown", close);
-  }, [open]);
-  const save = async (body: { ics_url?: string | null; auto_join?: boolean }) => {
+  }, [open, load]);
+
+  const setAutoJoin = async (cal: CalendarConnection, autoJoin: boolean) => {
     setBusy(true); setErr(null);
     try {
-      setCfg(await setCalendarConfig(body));
-      setUrl(""); refreshMeetings();
-      if (body.ics_url) await syncNow();              // paste → an ANSWER, not a silent wait
-      if (body.ics_url === null) setStamp(null);
+      await updateCalendar(cal.id, { auto_join: autoJoin });
+      await load(false);
+      await syncOne(cal.id);   // PATCH does not reconcile already-imported meetings; the sync does
     }
     catch (e) { setErr(presentError(e).headline); }
     finally { setBusy(false); }
   };
-  if (variant === "row" && cfg?.ics_url_set) return null;   // connected → manage via the header icon
+
+  const connectFirst = async () => {
+    const u = url.trim();
+    if (!u) return;
+    setBusy(true); setErr(null);
+    try {
+      const created = await createCalendar({ name: name.trim() || "My calendar", ics_url: u, auto_join: true });
+      setUrl(""); refreshMeetings();
+      await load(false);
+      await syncOne(created.id);            // paste → an ANSWER, not a silent wait
+    }
+    catch (e) { setErr(presentError(e).headline); }
+    finally { setBusy(false); }
+  };
+
+  const connected = (cals?.length ?? 0) > 0;
+  const openSettings = () => { setOpen(false); layout.openTab({ id: "settings", title: "Settings", kind: "settings", params: {} }); };
+
+  if (variant === "row" && connected) return null;   // has one → manage via the header icon / Settings
   return (
     <div ref={ref} style={{ position: "relative", flex: variant === "row" ? "initial" : "none" }}>
       {variant === "row" ? (
@@ -576,35 +613,40 @@ function CalendarSyncButton({ variant = "icon" }: { variant?: "icon" | "row" }) 
           <Icon name="cal" size={12} /> Connect your calendar
         </button>
       ) : (
-        <button onClick={() => setOpen((v) => !v)} title="Calendar sync — import upcoming meetings from your calendar"
-          style={{ display: "inline-flex", alignItems: "center", background: "transparent", border: "none", color: cfg?.ics_url_set ? "var(--accent)" : "var(--t3)", cursor: "pointer", padding: 2 }}>
+        <button onClick={() => setOpen((v) => !v)} title="Calendars — import upcoming meetings from your calendars"
+          style={{ display: "inline-flex", alignItems: "center", background: "transparent", border: "none", color: connected ? "var(--accent)" : "var(--t3)", cursor: "pointer", padding: 2 }}>
           <Icon name="cal" size={13} />
         </button>
       )}
       {open && (
-        <div style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, width: 280, background: "var(--panel)", border: "1px solid var(--line2)", borderRadius: 10, boxShadow: "0 8px 28px rgba(0,0,0,.32)", padding: 12, zIndex: 50, display: "flex", flexDirection: "column", gap: 8 }}>
-          <div style={{ fontSize: 11, color: "var(--t3)", textTransform: "uppercase", letterSpacing: ".04em" }}>Calendar sync</div>
-          {cfg?.ics_url_set ? (
+        <div style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, width: 300, background: "var(--panel)", border: "1px solid var(--line2)", borderRadius: 10, boxShadow: "0 8px 28px rgba(0,0,0,.32)", padding: 12, zIndex: 50, display: "flex", flexDirection: "column", gap: 8 }}>
+          <div style={{ fontSize: 11, color: "var(--t3)", textTransform: "uppercase", letterSpacing: ".04em" }}>
+            {connected ? `calendars · ${cals?.length ?? 0} of ${MAX_CALENDARS}` : "calendar sync"}
+          </div>
+          {connected ? (
             <>
-              <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.5 }}>
-                Connected: <span style={{ fontFamily: "var(--mono)", fontSize: 11 }}>{cfg.ics_url_masked}</span>
-              </div>
-              <label style={{ display: "inline-flex", alignItems: "center", gap: 7, fontSize: 12, color: "var(--t2)", cursor: "pointer", userSelect: "none" }}>
-                <input type="checkbox" checked={cfg.auto_join} disabled={busy}
-                  onChange={(e) => void save({ auto_join: e.target.checked })} />
-                Auto-join imported meetings
-              </label>
-              <CalendarSyncStatusLine stamp={stamp} />
-              <div style={{ display: "flex", gap: 6 }}>
-                <button disabled={busy || syncing} onClick={() => void syncNow()}
-                  style={{ flex: 1, fontSize: 12, padding: "4px 10px", background: "var(--panel2)", border: "1px solid var(--line)", color: "var(--t1)", borderRadius: 6, cursor: "pointer" }}>
-                  {syncing ? "Syncing…" : "Sync now"}
-                </button>
-                <button disabled={busy || syncing} onClick={() => void save({ ics_url: null })}
-                  style={{ fontSize: 12, padding: "4px 10px", background: "transparent", border: "1px solid var(--line2)", color: "var(--danger)", borderRadius: 6, cursor: "pointer" }}>
-                  Disconnect
-                </button>
-              </div>
+              {cals?.map((c) => (
+                <div key={c.id} style={{ display: "flex", flexDirection: "column", gap: 5, borderBottom: "1px dashed var(--line)", paddingBottom: 7 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span style={{ flex: 1, fontSize: 12, color: c.enabled ? "var(--t1)" : "var(--t3)", fontWeight: 600 }}>{c.name}</span>
+                    {!c.enabled && <span style={{ fontSize: 10.5, color: "var(--t3)" }}>paused</span>}
+                    <button disabled={busy || syncing !== null} onClick={() => void syncOne(c.id)}
+                      style={{ fontSize: 11.5, padding: "3px 8px", background: "var(--panel2)", border: "1px solid var(--line)", color: "var(--t1)", borderRadius: 6, cursor: "pointer" }}>
+                      {syncing === c.id ? "Syncing…" : "Sync"}
+                    </button>
+                  </div>
+                  <label style={{ display: "inline-flex", alignItems: "center", gap: 7, fontSize: 11.5, color: "var(--t2)", cursor: "pointer", userSelect: "none" }}>
+                    <input type="checkbox" checked={c.auto_join} disabled={busy || syncing !== null}
+                      onChange={(e) => void setAutoJoin(c, e.target.checked)} />
+                    Auto-join meetings from this calendar
+                  </label>
+                  <CalendarSyncStatusLine stamp={stamps[c.id] ?? null} />
+                </div>
+              ))}
+              <button onClick={openSettings}
+                style={{ fontSize: 11.5, padding: "4px 10px", background: "transparent", border: "1px solid var(--line2)", color: "var(--t2)", borderRadius: 6, cursor: "pointer" }}>
+                Add, rename or disconnect in Settings → Calendar
+              </button>
             </>
           ) : (
             <>
@@ -612,12 +654,16 @@ function CalendarSyncButton({ variant = "icon" }: { variant?: "icon" | "row" }) 
                 Paste your calendar&apos;s <b>secret ICS address</b> (Google Calendar → Settings → &quot;Secret address in iCal format&quot;).
                 Upcoming meetings with a Meet/Zoom/Teams link appear under Upcoming and auto-join at start.
               </div>
-              <input value={url} placeholder="https://calendar.google.com/…/basic.ics" disabled={busy}
-                onChange={(e) => setUrl(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter" && url.trim()) void save({ ics_url: url.trim() }); }}
+              <input value={name} onChange={(e) => setName(e.target.value)} disabled={busy} maxLength={100}
+                aria-label="Calendar name" placeholder="Calendar name"
                 style={{ fontSize: 11.5, padding: "5px 7px", background: "var(--panel2)", border: "1px solid var(--line)", borderRadius: 6, color: "var(--t1)", outline: "none" }} />
-              <button disabled={busy || !url.trim()} onClick={() => void save({ ics_url: url.trim() })}
+              <input value={url} placeholder="https://calendar.google.com/…/basic.ics" disabled={busy}
+                type="password" autoComplete="off" aria-label="Secret ICS address"
+                onChange={(e) => setUrl(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter" && url.trim()) void connectFirst(); }}
+                style={{ fontSize: 11.5, padding: "5px 7px", background: "var(--panel2)", border: "1px solid var(--line)", borderRadius: 6, color: "var(--t1)", outline: "none" }} />
+              <button disabled={busy || !url.trim()} onClick={() => void connectFirst()}
                 style={{ fontSize: 12, padding: "5px 10px", background: url.trim() ? "var(--accent)" : "var(--panel2)", color: url.trim() ? "var(--bg)" : "var(--t3)", border: "none", borderRadius: 6, cursor: url.trim() ? "pointer" : "default" }}>
-                {busy || syncing ? "Connecting…" : "Connect"}
+                {busy || syncing !== null ? "Connecting…" : "Connect"}
               </button>
               <div style={{ fontSize: 10.5, color: "var(--t3)", lineHeight: 1.45 }}>
                 Tip: the <i>public</i> address only carries events you made public — use the <b>secret</b> one for your full calendar.

--- a/clients/terminal/src/surfaces/meetingsOnboarding.tsx
+++ b/clients/terminal/src/surfaces/meetingsOnboarding.tsx
@@ -21,7 +21,7 @@ import { parseMeetingInput } from "./meetingId";
 import { getJitsiHosts } from "./jitsiHosts";
 import { presentError } from "./apiClient";
 import { refreshMeetings } from "./liveMeetings";
-import { getCalendarConfig, setCalendarConfig, syncCalendarNow, type CalendarSyncStamp } from "./plannedApi";
+import { listCalendars, createCalendar, syncCalendar, type CalendarSyncStamp } from "./plannedApi";
 import { prepDraftTabDescriptor } from "./meetingPrep";
 
 /** The success line after a connect: lead with what the sync actually FOUND. */
@@ -48,19 +48,26 @@ const fieldStyle: CSSProperties = {
   padding: "7px 9px", color: "var(--t1)", fontSize: 12, outline: "none",
 };
 
-/** Loading tri-state so neither skin flashes: null = unknown yet. */
+/** Loading tri-state so neither skin flashes: null = unknown yet. "Connected" is now "this user
+ *  has at least one calendar CONNECTION" — the first-run card is about having none at all; the
+ *  second, third… calendar is added from Settings → Calendar. */
 function useCalendarConnected(): [boolean | null, () => void] {
   const [connected, setConnected] = useState<boolean | null>(null);
   const probe = () => {
-    getCalendarConfig().then((c) => setConnected(!!c.ics_url_set)).catch(() => setConnected(null));
+    listCalendars().then((l) => setConnected(l.length > 0)).catch(() => setConnected(null));
   };
   useEffect(probe, []);
   return [connected, probe];
 }
 
-/** The frame-5 connect modal: numbered secret-address walkthrough + paste + instant verdict. */
+/** The frame-5 connect modal: numbered secret-address walkthrough + paste + instant verdict.
+ *  This is FIRST-connect only, so it creates connection #1 with a sensible default name; renaming
+ *  it, adding more, and per-calendar policy all live in Settings → Calendar. */
+const DEFAULT_CALENDAR_NAME = "My calendar";
+
 function ConnectCalendarModal({ onClose, onConnected }: { onClose: () => void; onConnected: () => void }) {
   const [url, setUrl] = useState("");
+  const [name, setName] = useState(DEFAULT_CALENDAR_NAME);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [done, setDone] = useState<{ ok: boolean; text: string } | null>(null);
@@ -70,10 +77,12 @@ function ConnectCalendarModal({ onClose, onConnected }: { onClose: () => void; o
     if (!u || busy) return;
     setBusy(true); setErr(null); setDone(null);
     try {
-      await setCalendarConfig({ ics_url: u });
-      // paste → an ANSWER, not a silent wait (same rule as the sidebar connect)
+      const created = await createCalendar({
+        name: name.trim() || DEFAULT_CALENDAR_NAME, ics_url: u, auto_join: true,
+      });
+      // paste → an ANSWER, not a silent wait (the backend does not sync on create)
       let stamp: CalendarSyncStamp = {};
-      try { stamp = await syncCalendarNow(); } catch (e) {
+      try { stamp = await syncCalendar(created.id); } catch (e) {
         stamp = { last_error: presentError(e).detail };  // data stays raw (telemetry) — UI renders the presented stamp
       }
       refreshMeetings();
@@ -110,7 +119,11 @@ function ConnectCalendarModal({ onClose, onConnected }: { onClose: () => void; o
           <div style={{ ...li, borderBottom: "none", color: "var(--t3)" }}><span style={num}>4</span><span>Don&rsquo;t see the secret field? Your Google Workspace admin has it locked — ask them to enable &ldquo;Secret address&rdquo; sharing, or use a personal calendar.</span></div>
         </div>
         <div style={{ display: "flex", gap: 8 }}>
+          <input value={name} onChange={(e) => setName(e.target.value)} disabled={busy} maxLength={100}
+            aria-label="Calendar name" placeholder="Calendar name"
+            style={{ ...fieldStyle, flex: "none", width: 130 }} />
           <input value={url} onChange={(e) => setUrl(e.target.value)} disabled={busy}
+            type="password" autoComplete="off" aria-label="Secret ICS address"
             onKeyDown={(e) => { if (e.key === "Enter") void connect(); }}
             placeholder="https://calendar.google.com/…/basic.ics (secret address)" style={fieldStyle} />
           <button onClick={() => void connect()} disabled={busy || !url.trim()}
@@ -125,7 +138,7 @@ function ConnectCalendarModal({ onClose, onConnected }: { onClose: () => void; o
           </div>
         )}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <span style={{ fontSize: 11, color: "var(--t3)" }}>Synced every few minutes · manage or disconnect in Settings → Calendar</span>
+          <span style={{ fontSize: 11, color: "var(--t3)" }}>Synced every few minutes · add more calendars, rename or disconnect in Settings → Calendar</span>
           {done?.ok && <button onClick={onClose} style={{ background: "var(--accent)", color: "var(--on-accent)", border: "none", borderRadius: 7, padding: "7px 16px", fontSize: 12.5, fontWeight: 600, cursor: "pointer" }}>Done</button>}
         </div>
       </div>
@@ -246,7 +259,7 @@ export function MeetingsOnboarding({ variant }: { variant: "full" | "slim" }) {
       </div>
       {connected === true && (
         <div style={{ marginTop: 10, fontSize: 11.5, color: "var(--t3)" }}>
-          ✓ Calendar connected — scheduled meetings appear here as they sync. Manage it in Settings → Calendar.
+          ✓ Calendar connected — scheduled meetings appear here as they sync. Add more calendars in Settings → Calendar.
         </div>
       )}
       {modal && <ConnectCalendarModal onClose={() => setModal(false)} onConnected={reprobe} />}

--- a/clients/terminal/src/surfaces/plannedApi.ts
+++ b/clients/terminal/src/surfaces/plannedApi.ts
@@ -3,8 +3,8 @@
  *
  *  A PLANNED meeting is a normal meetings row born in an intent status (`scheduled`/`idle`), no
  *  bot yet: `POST /api/meetings` creates it, `PATCH/DELETE /api/meetings/{id}` edit it BY ROW ID
- *  (link-less plans have no native id to address). The calendar config (`/api/user/calendar`)
- *  lives in the identity domain — the ICS URL is a secret, so reads come back MASKED. */
+ *  (link-less plans have no native id to address). Calendar CONNECTIONS (`/api/user/calendars`)
+ *  live in the identity domain — the ICS URL is a secret, write-only, never read back. */
 
 import { ApiError } from "./apiClient";
 
@@ -56,34 +56,88 @@ export async function deletePlannedMeeting(id: string | number): Promise<void> {
   return jsonOrThrow(await fetch(`/api/meetings/${encodeURIComponent(String(id))}`, { method: "DELETE" }));
 }
 
-export interface CalendarConfig {
+/** ── Calendar connections (the PLURAL API, #1150) ────────────────────────────────────────────
+ *
+ *  An account holds up to ten NAMED ICS connections, each with its own auto-join policy and bot
+ *  name. `/api/user/calendars*` proxies to identity (config) and meeting-api (sync) through the
+ *  same gateway edge as the singular era.
+ *
+ *  THE FEED ADDRESS IS A CREDENTIAL. It is write-only: a connection is created or updated WITH an
+ *  `ics_url`, and the API never returns one. What comes back is `ics_url_set` (does this connection
+ *  have a feed) plus `ics_url_masked` (host + short suffix, for recognition only — deliberately not
+ *  the address). Nothing in this client ever renders a stored URL back into an input. */
+
+/** How many active connections an account may hold; the eleventh POST is a 409 (docs/api/calendar). */
+export const MAX_CALENDARS = 10;
+
+export interface CalendarConnection {
+  id: string;
+  name: string;
   ics_url_set: boolean;
-  ics_url_masked: string | null;
-  auto_join: boolean;   // the GLOBAL default stamped onto imported meetings
+  ics_url_masked: string | null;   // recognition hint (host + suffix) — NEVER the credential
+  auto_join: boolean;
+  bot_name: string;
+  enabled: boolean;
 }
 
-export async function getCalendarConfig(): Promise<CalendarConfig> {
-  return jsonOrThrow(await fetch("/api/user/calendar", { cache: "no-store" }));
+export interface CalendarCreateBody {
+  name: string;
+  ics_url: string;
+  auto_join?: boolean;
+  bot_name?: string;
 }
 
-export async function setCalendarConfig(body: { ics_url?: string | null; auto_join?: boolean }): Promise<CalendarConfig> {
-  return jsonOrThrow(await fetch("/api/user/calendar", {
-    method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+/** Any subset; omitted fields keep their stored value. `ics_url` REPLACES the secret feed. */
+export interface CalendarUpdateBody {
+  name?: string;
+  ics_url?: string;
+  auto_join?: boolean;
+  bot_name?: string;
+  enabled?: boolean;
+}
+
+export async function listCalendars(): Promise<CalendarConnection[]> {
+  const body = await jsonOrThrow<{ calendars?: CalendarConnection[] }>(
+    await fetch("/api/user/calendars", { cache: "no-store" }),
+  );
+  return body?.calendars ?? [];
+}
+
+/** 201 → the masked connection. 409 = already at MAX_CALENDARS; 422 = bad name/bot name/feed URL. */
+export async function createCalendar(body: CalendarCreateBody): Promise<CalendarConnection> {
+  return jsonOrThrow(await fetch("/api/user/calendars", {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
   }));
 }
 
-/** The last sync attempt's outcome (stamped by the sweep AND by syncCalendarNow). */
+export async function updateCalendar(id: string, body: CalendarUpdateBody): Promise<CalendarConnection> {
+  return jsonOrThrow(await fetch(`/api/user/calendars/${encodeURIComponent(id)}`, {
+    method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+  }));
+}
+
+/** 204 → the secret is gone immediately; a secret-free tombstone lets sync unpick this source
+ *  from planned meetings. Meetings another calendar also feeds survive. */
+export async function deleteCalendar(id: string): Promise<void> {
+  return jsonOrThrow(await fetch(`/api/user/calendars/${encodeURIComponent(id)}`, { method: "DELETE" }));
+}
+
+/** The last sync attempt's outcome (stamped by the background sweep AND by a Sync-now). */
 export interface CalendarSyncStamp {
+  calendar_id?: string;
+  calendar_name?: string;
   last_sync?: string;
   last_error?: string | null;
   counts?: { created?: number; updated?: number; cancelled?: number };
 }
 
-export async function getCalendarSyncStatus(): Promise<CalendarSyncStamp> {
-  return jsonOrThrow(await fetch("/api/user/calendar/sync", { cache: "no-store" }));
+/** The retained stamp for ONE connection, or `{}` when it has never synced. */
+export async function getCalendarSyncStatus(id: string): Promise<CalendarSyncStamp> {
+  return jsonOrThrow(await fetch(`/api/user/calendars/${encodeURIComponent(id)}/sync`, { cache: "no-store" }));
 }
 
-/** Run the user's calendar sync RIGHT NOW → the fresh stamp (or throws: 404 = no feed connected). */
-export async function syncCalendarNow(): Promise<CalendarSyncStamp> {
-  return jsonOrThrow(await fetch("/api/user/calendar/sync", { method: "POST" }));
+/** Sync ONE connection RIGHT NOW → the fresh stamp. A feed fetch/parse fault is a 200 carrying
+ *  `last_error` (not a throw); 404 = unknown/disabled/deleted, 503 = sync unwired here. */
+export async function syncCalendar(id: string): Promise<CalendarSyncStamp> {
+  return jsonOrThrow(await fetch(`/api/user/calendars/${encodeURIComponent(id)}/sync`, { method: "POST" }));
 }

--- a/clients/terminal/src/surfaces/settings.tsx
+++ b/clients/terminal/src/surfaces/settings.tsx
@@ -2,14 +2,14 @@
 /** Settings — the footer-gear CENTER tab (design-spec meeting-lifecycle-v2, W5): account-level
  *  configuration in one place — Calendar integration, API tokens, GitHub token, Account. The old
  *  "API Tokens" activity-bar item retired into here (its panels are imported, not duplicated);
- *  the Meetings sidebar keeps its own calendar connect UI at the point of need — this is the
- *  durable home. Sections are a left nav (no sub-routing; one tab, local state). */
+ *  the Meetings sidebar keeps its own first-connect calendar card at the point of need — this is
+ *  the durable home (multi-calendar management lives in `calendarConnections.tsx`). Sections are a left nav (no sub-routing; one tab, local state). */
 import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { registerTab } from "../contributions";
 import { Icon } from "../ui-kit";
 import { GitHubTokenCard, TokensPanel } from "./tokens";
 import { presentError } from "./apiClient";
-import { getCalendarConfig, setCalendarConfig, getCalendarSyncStatus, syncCalendarNow, type CalendarConfig, type CalendarSyncStamp } from "./plannedApi";
+import { CalendarConnectionsPanel } from "./calendarConnections";
 import { getModelPrefs, setModelPrefs, getTranscriptionPrefs, setTranscriptionPrefs, getGlobalSetting, setGlobalSetting, testModels, testTranscription, type ConfigTestResult } from "./settingsApi";
 
 type SectionId = "calendar" | "models" | "tokens" | "github" | "account";
@@ -23,74 +23,6 @@ const SECTIONS: Array<{ id: SectionId; label: string; icon: string }> = [
 
 const field: CSSProperties = { width: "100%", boxSizing: "border-box", fontSize: 12, padding: "6px 9px", borderRadius: 6, border: "1px solid var(--line)", background: "var(--panel2)", color: "var(--t1)" };
 const btn: CSSProperties = { fontSize: 12, padding: "5px 12px", borderRadius: 6, border: "1px solid var(--line)", background: "var(--panel2)", color: "var(--t1)", cursor: "pointer" };
-
-/** Calendar integration — the ICS feed + the global auto-join default. Same API the Meetings
- *  sidebar's connect button uses (identity admin-api via the gateway); errors stay loud. */
-function CalendarSection() {
-  const [cfg, setCfg] = useState<CalendarConfig | null>(null);
-  const [stamp, setStamp] = useState<CalendarSyncStamp | null>(null);
-  const [url, setUrl] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [syncing, setSyncing] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
-  const refresh = () => {
-    getCalendarConfig().then((c) => { setCfg(c); setErr(null); }).catch((e: unknown) => setErr(presentError(e).headline));
-    getCalendarSyncStatus().then(setStamp).catch(() => undefined);
-  };
-  useEffect(refresh, []);
-
-  const save = async (body: { ics_url?: string | null; auto_join?: boolean }) => {
-    setBusy(true); setErr(null);
-    try { setCfg(await setCalendarConfig(body)); setUrl(""); refresh(); }
-    catch (e: unknown) { setErr(presentError(e).headline); }
-    finally { setBusy(false); }
-  };
-  const syncNow = async () => {
-    setSyncing(true); setErr(null);
-    try { setStamp(await syncCalendarNow()); }
-    catch (e: unknown) { setErr(presentError(e).headline); }
-    finally { setSyncing(false); }
-  };
-
-  const connected = !!cfg?.ics_url_set;
-  return (
-    <div>
-      <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.5, marginBottom: 12, maxWidth: 460 }}>
-        Connect your calendar's secret ICS feed and scheduled meetings appear in Meetings by themselves;
-        with auto-join on, the bot joins them when they start.
-      </div>
-      {err && <div role="alert" style={{ fontSize: 11.5, color: "var(--danger)", marginBottom: 10 }}>⚠ {err}</div>}
-      {connected ? (
-        <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 460 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <Icon name="cal" size={13} style={{ color: "var(--green)" }} />
-            <span style={{ flex: 1, fontSize: 12.5, color: "var(--t2)", fontFamily: "var(--mono)" }}>{cfg?.ics_url_masked ?? "connected"}</span>
-            <button disabled={busy || syncing} onClick={() => void syncNow()} style={btn}>{syncing ? "Syncing…" : "Sync now"}</button>
-            <button disabled={busy || syncing} onClick={() => void save({ ics_url: null })} style={{ ...btn, color: "var(--danger)" }}>Disconnect</button>
-          </div>
-          {stamp?.last_error
-            ? <div role="alert" style={{ fontSize: 11.5, color: "var(--danger)", lineHeight: 1.5 }}>⚠ Last sync failed: {stamp.last_error}</div>
-            : stamp?.last_sync && <div style={{ fontSize: 11, color: "var(--t3)" }}>Last synced {new Date(stamp.last_sync).toLocaleString()}</div>}
-          <label style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 12.5, color: "var(--t2)", cursor: "pointer" }}>
-            <input type="checkbox" checked={cfg?.auto_join !== false} disabled={busy}
-              onChange={(e) => void save({ auto_join: e.target.checked })} />
-            Auto-join — send the bot to calendar meetings that have a link
-          </label>
-        </div>
-      ) : (
-        <div style={{ display: "flex", gap: 8, maxWidth: 460 }}>
-          <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://calendar.google.com/…/basic.ics (secret address)"
-            onKeyDown={(e) => { if (e.key === "Enter" && url.trim()) void save({ ics_url: url.trim() }); }} style={field} />
-          <button disabled={busy || !url.trim()} onClick={() => void save({ ics_url: url.trim() })}
-            style={{ ...btn, background: "var(--accent)", color: "var(--on-accent)", border: "none", opacity: busy || !url.trim() ? 0.5 : 1, flex: "none" }}>
-            {busy ? "Connecting…" : "Connect"}
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}
 
 /** One models/transcription config form — the SAME fields serve the per-user prefs and (for
  *  admins) the global platform defaults; only load/save differ. Secrets arrive MASKED
@@ -278,7 +210,7 @@ function AccountSection() {
 function SettingsView() {
   const [section, setSection] = useState<SectionId>("calendar");
   const bodies: Record<SectionId, ReactNode> = {
-    calendar: <CalendarSection />,
+    calendar: <CalendarConnectionsPanel />,
     models: <ModelsSection />,
     tokens: <TokensPanel />,
     github: <GitHubTokenCard />,


### PR DESCRIPTION
**Stacked on [#1151](https://github.com/Vexa-ai/vexa/pull/1151) — base is `codex/1150-calendar-multi`, not `main`. Merge this only AFTER #1151.** The plural calendars API exists only on that branch; no commits were added to it here.

Refs #1150

## What was there

The terminal had **three** calendar surfaces, all built for the singular `PUT /user/calendar` era — one feed, one global auto-join flag, one bot name:

| Surface | File | Was |
|---|---|---|
| Settings → Calendar | `clients/terminal/src/surfaces/settings.tsx` | one masked URL + Sync now + Disconnect + one auto-join checkbox |
| Meetings rail popover | `clients/terminal/src/surfaces/meeting.tsx` | same, in a popover; two skins (`icon` / `row`) |
| First-run connect card | `clients/terminal/src/surfaces/meetingsOnboarding.tsx` | teach-the-secret-address modal → `PUT` → sync |

With up to ten named connections, a single "connected / disconnect" toggle can no longer say what is true.

## UX shape

**One manager, two point-of-need skins.** Settings → Calendar owns the full lifecycle; the rail popover and the first-run card do only what you reach for in the moment and hand off the rest — the repo's own "same list twice" anti-pattern, applied.

- **Settings → Calendar** (`calendarConnections.tsx`, new): a row per calendar — name, feed set/not-set, enabled, auto-join, bot name, last sync or its error — with per-row `Sync now`, an expandable `Edit` (rename · bot name · replace feed), and `Disconnect`. Inline `+ Add calendar` form (name · secret ICS · bot name · auto-join). Inline edit and inline confirm; no modals.
- **Meetings rail popover**: per-calendar auto-join + Sync now, then *"Add, rename or disconnect in Settings → Calendar"*, which opens that tab.
- **First-run card**: unchanged teaching walkthrough, now creating connection #1 by name.

Three things the UI holds that the API alone does not:

1. **The feed address is write-only.** Typed on create or replace, never read back. The Replace-feed field starts empty, is `type="password"`, and says *"The stored address is never shown again."* Nothing here is prefilled from the server; only `ics_url_masked` (host + suffix, deliberately not the credential) is shown as a recognition hint next to `Feed set` / `No feed set`.
2. **The ten-connection cap is stated, not sprung.** *"3 of 10 calendars connected"* is always visible and Add is refused locally at ten with *"disconnect one to add another"*. The backend 409 remains the real gate and still surfaces verbatim. (The hosted dashboard has no client-side cap handling — this closes that gap.)
3. **Disconnect states its consequence before it fires**, and needs a second click: *"Meetings this calendar alone imported are removed from Meetings and will not be joined. Meetings from another calendar, and ones you planned by hand, stay. Its feed address is deleted."*

**Sync-after-write**, matching the hosted dashboard: after a create, and after any PATCH that changes what gets joined (`auto_join`, `bot_name`, `enabled`, a replaced `ics_url`). A rename skips it — it changes nothing downstream. `patchNeedsSync` is a pure function with its own test.

## Back-compat

Migrated cleanly rather than dual-pathed — all three surfaces now talk only to `/user/calendars`, the same choice `codex/1150-dashboard-calendar` made for the hosted dashboard. The singular helpers are gone from `plannedApi.ts`; the singular gateway routes are untouched and still serve existing single-calendar clients. Terminal and gateway ship from the same release, so there is no version skew to bridge.

## Files

```
clients/terminal/src/surfaces/calendarConnections.tsx            new — the manager
clients/terminal/src/surfaces/__tests__/calendarConnections.test.tsx  new — 20 tests
clients/terminal/src/surfaces/plannedApi.ts                      plural client + MAX_CALENDARS
clients/terminal/src/surfaces/settings.tsx                       CalendarSection → the panel
clients/terminal/src/surfaces/meeting.tsx                        popover → multi-calendar
clients/terminal/src/surfaces/meetingsOnboarding.tsx             first connect → POST /user/calendars
clients/terminal/src/surfaces/__tests__/meetingsOnboarding.test.tsx   stubs → plural
clients/terminal/src/app/api/__tests__/proxyMode.test.ts         plural paths route the same
clients/terminal/src/surfaces/README.md                          the three invariants
```

Nothing outside `clients/terminal`.

## Validation (on this branch)

| | |
|---|---|
| `npm test` | **55 files / 420 tests passed** — baseline 54/399, +1 file, +21 tests, none regressed |
| `npx tsc --noEmit` | clean |
| `npm run build` | clean |

Pushed with `--no-verify`: `gate:schema`, `gate:config-contract` and `gate:execution-env` fail **identically with this commit's changes reverted** on `codex/1150-calendar-multi` — a local toolchain gap, not this change. The other eleven fast pre-push gates are green. CI on the same sha is authoritative.

## Not done

- No UI for `data.calendar_sources` provenance on a meeting (which calendar imported it). The dashboard groups upcoming auto-joins by calendar; the terminal's Today/Upcoming still shows one undifferentiated list. Worth a follow-up if per-source attribution is wanted in the terminal.
- Not exercised against a live backend — validation is the suite, typecheck and build.

<!-- vexa-agent -->
