### PR TITLE
fix(meetings): one bot per room — adopt live rows, guard the auto-join dispatch

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -532,6 +532,25 @@ class SqlAlchemyMeetingRepo:
             )).scalars().all()
             return [_row_to_dict(m) for m in rows]
 
+    async def list_live_meetings(self) -> list[dict]:
+        """Every row a bot currently OWNS (``auto_join.LIVE_STATUSES``) with a joinable link — the
+        auto-join sweep's duplicate-dispatch guard reads it to answer "is someone already in this
+        room?" for a due row that a sibling row (manual send, un-adopted calendar import) covers."""
+        from sqlalchemy import select
+
+        from ..sessions.models import Meeting
+        from .auto_join import LIVE_STATUSES
+
+        async with self._session_factory() as db:
+            rows = (await db.execute(
+                select(Meeting).where(
+                    Meeting.status.in_(LIVE_STATUSES),
+                    Meeting.platform_specific_id.isnot(None),
+                    Meeting.platform != "unknown",
+                )
+            )).scalars().all()
+            return [_row_to_dict(m) for m in rows]
+
     async def merge_meeting_data(self, meeting_id, patch: dict) -> None:
         """Merge ``patch`` into ``meeting.data`` (a ``None`` value REMOVES the key) — the sweep's
         error/backoff stamping primitive. Row-locked; a missing row is a no-op."""

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
@@ -9,6 +9,13 @@ out of the sweep's predicate, and the per-user advisory lock serializes it again
 manual "Send bot now" (that race surfaces here as ``DuplicateMeeting`` — someone already joined —
 counted, never error-stamped).
 
+Defense in depth behind that dedup: before spawning, the tick asks the repo which
+(user, platform, native) tuples a bot ALREADY owns (``list_live_meetings`` over ``LIVE_STATUSES``)
+and refuses a due row whose room is already covered by a DIFFERENT row — stamping
+``data.auto_join_error`` with the holding meeting id. Two Vexa bots in one meeting is never
+correct however the two rows came to exist (live 2026-08-17: a manual "Send bot now" row plus a
+calendar import of the same Meet that failed to adopt it).
+
 Failures are LOUD, never silent (P18/P10): a cap/quota rejection or spawn failure stamps
 ``data.auto_join_error`` (+ ``data.auto_join_next_retry`` backoff so one bad row doesn't re-fire
 every tick) — the terminal surfaces it on the meeting row.
@@ -70,6 +77,28 @@ def due_rows(rows: list[dict], *, now: datetime,
             continue
         due.append(row)
     return due
+
+
+# Every status in which a bot OWNS the room. A due row whose (user, platform, native) is held by
+# one of these on ANOTHER row must never spawn: two Vexa bots in one meeting is customer-visible
+# and never correct, however the two rows came to exist.
+LIVE_STATUSES = (
+    "requested", "joining", "awaiting_admission", "active",
+    "needs_help", "needs_human_help", "stopping",
+)
+
+
+def live_keys(rows: Optional[list]) -> dict[tuple, Any]:
+    """``{(user_id, platform, native_meeting_id): meeting_id}`` over the repo's live rows."""
+    out: dict[tuple, Any] = {}
+    for row in rows or ():
+        if not isinstance(row, dict):
+            continue
+        key = (row.get("user_id"), row.get("platform"), row.get("native_meeting_id"))
+        if key[0] is None or not key[1] or not key[2]:
+            continue
+        out.setdefault(key, row.get("id"))
+    return out
 
 
 def _calendar_bot_name(data: dict) -> Optional[str]:
@@ -145,18 +174,25 @@ async def auto_join_tick(
 
     rows = await repo.list_scheduled_meetings()
     due = due_rows(rows, now=now, lead_s=lead_s, grace_s=grace_s)
-    counters = {"due": len(due), "spawned": 0, "already": 0, "errors": 0, "skipped_uncapped": 0}
+    counters = {"due": len(due), "spawned": 0, "already": 0, "errors": 0,
+                "skipped_uncapped": 0, "skipped_live": 0}
+    # Duplicate-dispatch guard (defense in depth behind create_meeting_guarded's dedup): a bot
+    # already owning this (user, platform, native) on a DIFFERENT row means the meeting is covered.
+    live = live_keys(
+        await repo.list_live_meetings() if hasattr(repo, "list_live_meetings") else None
+    )
     ctx_cache: dict[int, Optional[dict]] = {}
     uncapped_warned = False
 
-    async def _stamp_error(row: dict, message: str) -> None:
-        counters["errors"] += 1
+    async def _stamp_error(row: dict, message: str, *, counter: str = "errors",
+                           event: str = "auto_join_failed") -> None:
+        counters[counter] += 1
         next_retry = (now + timedelta(seconds=retry_backoff_s)).isoformat()
         await repo.merge_meeting_data(row["id"], {
             "auto_join_error": message,
             "auto_join_next_retry": next_retry,
         })
-        log_event("auto_join_failed", audience="user", level="warning", span="meetings.auto_join",
+        log_event(event, audience="user", level="warning", span="meetings.auto_join",
                   user_id=row["user_id"], meeting_id=str(row["id"]),
                   fields={"error": message, "next_retry": next_retry})
         if publish_status is not None:
@@ -169,6 +205,19 @@ async def auto_join_tick(
 
     for row in due:
         user_id = row["user_id"]
+        holder = live.get((user_id, row.get("platform"), row.get("native_meeting_id")))
+        if holder is not None and holder != row.get("id"):
+            # A bot is already in this room on another row — the classic shape is a manual
+            # "Send bot now" plus a calendar import of the same link that failed to adopt it
+            # (live 2026-08-17: rows 26237 live + 26251 imported, native mjm-dycn-qdp). Refuse
+            # LOUDLY (P18): the row carries the reason the terminal renders, never a silent skip.
+            await _stamp_error(
+                row,
+                f"a bot is already in this meeting (meeting {holder}) — auto-join skipped so a "
+                f"second bot never joins",
+                counter="skipped_live", event="auto_join_skipped_live",
+            )
+            continue
         gate_error = gate()
         if gate_error:
             await _stamp_error(row, gate_error)

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -170,6 +170,16 @@ class InMemoryMeetingRepo:
             and m["platform"] not in (None, "", "unknown")
         ]
 
+    async def list_live_meetings(self) -> list:
+        from .auto_join import LIVE_STATUSES
+
+        return [
+            dict(m) for m in self._meetings.values()
+            if m["status"] in LIVE_STATUSES
+            and m["native_meeting_id"] is not None
+            and m["platform"] not in (None, "", "unknown")
+        ]
+
     async def merge_meeting_data(self, meeting_id, patch) -> None:
         m = self._meetings.get(meeting_id)
         if m is None:

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/service.py
@@ -16,6 +16,11 @@ no native id) so the terminal can render the honest "bot not armed — no link" 
 the event silently vanishing. A link appearing in a later feed sweep arms the existing row.
 ``STATUS:CANCELLED`` events and UIDs that vanish from the feed cancel their still-planned row;
 a row the bot FSM owns (live/completed) is NEVER touched by sync.
+
+Adoption by link is by (platform, native) over EVERY non-terminal row, intent AND live. An
+imported event whose meeting is already running attaches its calendar identity to that live row
+(``_attach_live_source`` — uid/sources only, never ``auto_join``/``scheduled_at``/status) rather
+than importing a sibling: a sibling is what the auto-join sweep sends a SECOND bot for.
 """
 from __future__ import annotations
 
@@ -314,6 +319,43 @@ def _replace_source(sources: list[dict], source: dict) -> list[dict]:
     return out
 
 
+async def _attach_live_source(store, user_id: int, row: dict, ev: dict, *,
+                              calendar_id: Optional[str], calendar_name: Optional[str],
+                              bot_name: Optional[str], auto_join_default: bool):
+    """Attach this calendar's source to a row the bot FSM already owns — IDENTITY ONLY.
+
+    An event whose meeting is ALREADY LIVE (the user sent a bot by hand, or an earlier occurrence
+    is still running) must not import as a sibling row: the auto-join sweep would then dispatch a
+    SECOND bot into the same room at the scheduled start (observed live 2026-08-17 — rows
+    26237 live + 26251 imported, one native ``mjm-dycn-qdp``, two bots).
+
+    Only the calendar identity keys are merged (``calendar_uid`` + ``calendar_sources`` and the
+    singular mirrors). ``auto_join``, ``auto_join_user_set``, ``calendar_managed``, ``scheduled_at``
+    and ``status`` are NEVER written here: adopting a live row must never re-arm it, and the row's
+    auto-join marker belongs to the user's own PATCH.
+    """
+    attach = getattr(store, "attach_calendar_source", None)
+    if attach is None:
+        return None
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    sources: Optional[list[dict]]
+    if calendar_id:
+        source = _source_entry(
+            calendar_id, calendar_name, ev["uid"], auto_join_default,
+            bot_name=bot_name, metadata=ev.get("metadata"),
+        )
+        existing = _calendar_sources(data)
+        sources = _replace_source(existing, source)
+        if sources == existing and data.get("calendar_uid") == ev["uid"]:
+            return None
+    else:
+        # legacy singular feed: never steal a row another UID already stamped
+        if data.get("calendar_uid"):
+            return None
+        sources = None
+    return await attach(user_id, row["id"], calendar_uid=ev["uid"], calendar_sources=sources)
+
+
 def _remember(rows: list, row: dict) -> None:
     """Fold a created/updated row back into the caller's row list — the sweep reads a user's rows
     ONCE per tick and drives every one of their connections off that one list."""
@@ -381,6 +423,11 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
             continue
         if uid and uid not in by_uid:
             by_uid[uid] = row
+        # The adoption index admits EVERY non-terminal row — intent (idle/scheduled) AND the FSM
+        # statuses (requested/joining/awaiting_admission/active/needs_help/stopping). A live row is
+        # still the meeting on that link, so an imported event attaches to it (identity only)
+        # instead of creating a sibling; only completed/failed rows are past (their link may be
+        # re-met, which is what the DB's partial unique index allows).
         if row.get("native_meeting_id"):
             by_native.setdefault((row["platform"], row["native_meeting_id"]), row)
 
@@ -461,7 +508,24 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
                     out["updated"].append({"id": adopted["id"], "native": adopted.get("native_meeting_id"),
                                            "status": adopted.get("status"),
                                            "when": (adopted.get("data") or {}).get("scheduled_at")})
-            continue  # an FSM row on that link → leave it alone; next sweep reconciles
+            else:
+                # an FSM row on that link (live/joining/stopping) — it IS this event's meeting.
+                # Stamp the calendar identity onto it so the terminal shows the link and the next
+                # sweep matches it by UID; never create a sibling the auto-join sweep would send a
+                # SECOND bot for, and never touch status / auto_join / scheduled_at.
+                attached = await _attach_live_source(
+                    store, user_id, manual, ev,
+                    calendar_id=calendar_id, calendar_name=calendar_name,
+                    bot_name=bot_name, auto_join_default=auto_join_default,
+                )
+                if isinstance(attached, dict) and not attached.get("error"):
+                    by_native[(ev["platform"], ev["native_meeting_id"])] = attached
+                    _remember(rows, attached)
+                    out["updated"].append({"id": attached["id"],
+                                           "native": attached.get("native_meeting_id"),
+                                           "status": attached.get("status"),
+                                           "when": (attached.get("data") or {}).get("scheduled_at")})
+            continue  # never duplicate a row that already exists for this link
 
         inherited_ws = series_ws.get(ev["uid"])  # None = no binding OR tombstoned — both mean "don't"
         created = await store.create_planned_meeting(

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -981,6 +981,44 @@ class SqlAlchemyTranscriptStore:
             await db.refresh(m)
             return self._planned_row(m)
 
+    async def attach_calendar_source(self, user_id, meeting_id, *, calendar_uid,
+                                     calendar_sources=None) -> "Optional[dict]":
+        """Stamp calendar IDENTITY onto a row in ANY status (the live-row adoption path).
+
+        Deliberately narrower than ``update_planned_meeting``, which refuses an FSM-owned row: an
+        imported event whose meeting is already live must attach to THAT row rather than create a
+        sibling the auto-join sweep would send a second bot for. Identity keys only — status,
+        ``auto_join``, ``auto_join_user_set``, ``calendar_managed`` and ``scheduled_at`` are never
+        written here, so adopting a live row can never re-arm or re-dispatch it."""
+        from sqlalchemy import bindparam, select, text
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from .models import Meeting
+
+        async with self._session_factory() as db:
+            await db.execute(
+                text("SELECT pg_advisory_xact_lock(:uid)").bindparams(bindparam("uid", user_id))
+            )
+            meeting = (await db.execute(
+                select(Meeting).where(Meeting.id == meeting_id, Meeting.user_id == user_id)
+                .with_for_update()
+            )).scalars().first()
+            if meeting is None:
+                return None
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            if calendar_uid:
+                data["calendar_uid"] = calendar_uid
+            if calendar_sources:
+                data["calendar_sources"] = [dict(s) for s in calendar_sources]
+                primary = calendar_sources[0]
+                data["calendar_connection_id"] = primary.get("id")
+                data["calendar_name"] = primary.get("name") or "Calendar"
+            meeting.data = data
+            flag_modified(meeting, "data")
+            await db.commit()
+            await db.refresh(meeting)
+            return self._planned_row(meeting)
+
     async def update_planned_meeting(self, user_id, meeting_id, updates) -> "Optional[dict]":
         """ROW-id-addressed PATCH of a planned row (intent status only). ``updates`` carries only
         the keys the caller sent — presence means apply (None clears where documented)."""

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -409,6 +409,22 @@ class InMemoryTranscriptStore:
         )
         return self._planned_row(mid)
 
+    async def attach_calendar_source(self, user_id, meeting_id, *, calendar_uid,
+                                     calendar_sources=None):
+        """Identity-only stamp on a row in ANY status — mirrors the adapter (live-row adoption)."""
+        m = self._meetings.get(meeting_id)
+        if m is None or m["user_id"] != user_id:
+            return None
+        data = m["data"]
+        if calendar_uid:
+            data["calendar_uid"] = calendar_uid
+        if calendar_sources:
+            data["calendar_sources"] = [dict(s) for s in calendar_sources]
+            primary = calendar_sources[0]
+            data["calendar_connection_id"] = primary.get("id")
+            data["calendar_name"] = primary.get("name") or "Calendar"
+        return self._planned_row(meeting_id)
+
     async def update_planned_meeting(self, user_id, meeting_id, updates):
         m = self._meetings.get(meeting_id)
         if m is None or m["user_id"] != user_id:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -188,6 +188,22 @@ class TranscriptStore(Protocol):
         ``{"error": "duplicate"}`` when a new native id collides with another non-terminal row."""
         ...
 
+    async def attach_calendar_source(
+        self, user_id: int, meeting_id: int, *, calendar_uid: str,
+        calendar_sources: Optional[list] = None,
+    ) -> Optional[dict]:
+        """Stamp calendar IDENTITY onto a row in ANY status — including one the bot FSM owns.
+
+        The narrow complement of ``update_planned_meeting``: calendar sync uses it when an imported
+        event's meeting is ALREADY LIVE, so the live row carries the calendar's uid/sources instead
+        of a duplicate planned row being created beside it (which the auto-join sweep would then
+        dispatch a SECOND bot for). Writes ONLY ``calendar_uid`` / ``calendar_sources`` and the
+        singular ``calendar_connection_id`` / ``calendar_name`` mirrors — never ``auto_join``,
+        ``auto_join_user_set``, ``calendar_managed``, ``scheduled_at`` or ``status``.
+
+        Returns the row (``list_meetings`` shape), or ``None`` when the user owns no such row."""
+        ...
+
     async def delete_planned_meeting(self, user_id: int, meeting_id: int) -> Optional[bool]:
         """OWNER-scoped delete of a PLANNED (``idle``/``scheduled``) row. Returns ``True`` on
         delete, ``None`` when the user owns no such row (→ 404), ``False`` when the row is

--- a/core/meetings/services/meeting-api/tests/test_auto_join_sweep.py
+++ b/core/meetings/services/meeting-api/tests/test_auto_join_sweep.py
@@ -53,7 +53,7 @@ async def test_due_row_spawns_and_claims_in_place():
     repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
     mid = _seed(repo, at=NOW + timedelta(seconds=30))  # inside the 60s lead window
     counters = await _tick(repo, runtime)
-    assert counters == {"due": 1, "spawned": 1, "already": 0, "errors": 0, "skipped_uncapped": 0}
+    assert counters == {"due": 1, "spawned": 1, "already": 0, "errors": 0, "skipped_uncapped": 0, "skipped_live": 0}
     row = repo._meetings[mid]
     assert row["status"] == "requested"          # the SAME row was claimed
     assert row["data"]["title"] == "t"           # planned keys survive
@@ -130,7 +130,7 @@ async def test_second_tick_is_a_noop():
     _seed(repo)
     await _tick(repo, runtime)
     counters = await _tick(repo, runtime)
-    assert counters == {"due": 0, "spawned": 0, "already": 0, "errors": 0, "skipped_uncapped": 0}
+    assert counters == {"due": 0, "spawned": 0, "already": 0, "errors": 0, "skipped_uncapped": 0, "skipped_live": 0}
     assert len(runtime.specs) == 1  # exactly one spawn ever
 
 
@@ -220,7 +220,7 @@ async def test_unreachable_identity_skips_fail_closed():
         return None  # configured but unreachable
 
     counters = await _tick(repo, runtime, fetch_bot_context=ctx)
-    assert counters == {"due": 1, "spawned": 0, "already": 0, "errors": 0, "skipped_uncapped": 0}
+    assert counters == {"due": 1, "spawned": 0, "already": 0, "errors": 0, "skipped_uncapped": 0, "skipped_live": 0}
     assert runtime.specs == []  # never spawns past a cap it could not read
 
 
@@ -230,7 +230,7 @@ async def test_no_admin_edge_fails_closed_refuses_uncapped_spawn():
     repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
     _seed(repo)
     counters = await _tick(repo, runtime, fetch_bot_context=None, allow_uncapped=False)
-    assert counters == {"due": 1, "spawned": 0, "already": 0, "errors": 0, "skipped_uncapped": 1}
+    assert counters == {"due": 1, "spawned": 0, "already": 0, "errors": 0, "skipped_uncapped": 1, "skipped_live": 0}
     assert runtime.specs == []  # never spawns uncapped past a cap we cannot resolve
 
 
@@ -261,3 +261,46 @@ def test_due_rows_window_edges():
     # malformed / missing time → never due
     assert not due_rows([{"id": 2, "user_id": USER, "platform": PLAT,
                           "native_meeting_id": NID, "data": {}}], now=NOW)
+
+
+# ---- duplicate-dispatch guard (live 2026-08-17: two Vexa bots in mjm-dycn-qdp) --------
+
+async def test_live_row_on_same_link_blocks_the_sweep():
+    """Two rows, one native id, one of them LIVE → the sweep refuses, loudly.
+
+    The staging shape: user 23 sent a bot by hand (row 26237, admitted + transcribing) while the
+    connected calendar imported the same Meet as a second row (26251). At start time the sweep
+    dispatched a SECOND bot. A duplicate dispatch is never correct however the rows arose.
+    """
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    _seed(repo, mid=26237, status="active", at=None)          # the manual bot, in the room
+    due = _seed(repo, mid=26251, status="scheduled", at=NOW)  # the un-adopted calendar import
+    counters = await _tick(repo, runtime)
+    assert counters["due"] == 1
+    assert counters["spawned"] == 0
+    assert counters["skipped_live"] == 1
+    assert runtime.specs == []                       # no second bot
+    assert repo._meetings[due]["status"] == "scheduled"
+    err = repo._meetings[due]["data"]["auto_join_error"]
+    assert "26237" in err and "already in this meeting" in err
+    assert repo._meetings[due]["data"]["auto_join_next_retry"]  # backoff stamped, not re-fired
+
+
+async def test_live_row_for_another_user_does_not_block():
+    """The guard is per (user, platform, native) — a different tenant in the same room is theirs."""
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    _seed(repo, mid=1, status="active", at=None, user_id=99)
+    _seed(repo, mid=2, status="scheduled", at=NOW)
+    counters = await _tick(repo, runtime)
+    assert counters["spawned"] == 1 and counters["skipped_live"] == 0
+
+
+async def test_live_keys_ignores_terminal_and_linkless_rows():
+    from meeting_api.bot_spawn.auto_join import live_keys
+
+    keys = live_keys([
+        {"id": 1, "user_id": USER, "platform": PLAT, "native_meeting_id": NID},
+        {"id": 2, "user_id": USER, "platform": "unknown", "native_meeting_id": None},
+        {"id": 3, "user_id": None, "platform": PLAT, "native_meeting_id": "x"},
+    ])
+    assert keys == {(USER, PLAT, NID): 1}

--- a/core/meetings/services/meeting-api/tests/test_calendar_sync.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_sync.py
@@ -249,6 +249,51 @@ async def test_sync_adopts_manual_plan_on_same_link():
     assert row["status"] == "scheduled"               # feed time attached
 
 
+async def test_sync_adopts_a_LIVE_row_on_the_same_link_and_never_duplicates_it():
+    """The live 2026-08-17 defect: a manual bot is already in the room when the calendar imports
+    the same Meet. The import must attach to the live row — a sibling row is what the auto-join
+    sweep then sends a SECOND bot for (rows 26237 live + 26251 imported, native mjm-dycn-qdp)."""
+    store = InMemoryTranscriptStore()
+    live = store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status="active", data={"title": "sent by hand"},
+        constructed_meeting_url="https://meet.google.com/abc-defg-hij",
+    )
+    result = await sync_user(store, USER, parse_ics(_ics(_event()), now=NOW),
+                             calendar_id="work", calendar_name="Work")
+    rows = await store.list_meetings(USER)
+    assert len(rows) == 1                              # ONE row — no sibling to dispatch for
+    (row,) = rows
+    assert row["id"] == live
+    assert row["status"] == "active"                   # the FSM still owns it
+    assert result["counts"] == {"created": 0, "updated": 1, "cancelled": 0}
+    data = row["data"]
+    assert data["calendar_uid"] == "uid-1"             # calendar identity attached
+    assert [s["id"] for s in data["calendar_sources"]] == ["work"]
+    assert data["calendar_connection_id"] == "work"
+    # adopting a LIVE row must never re-arm it: no auto_join, no calendar_managed, no re-schedule
+    assert "auto_join" not in data
+    assert "calendar_managed" not in data
+    assert "scheduled_at" not in data
+
+
+async def test_live_row_adoption_is_idempotent_and_survives_the_feed_vanishing():
+    store = InMemoryTranscriptStore()
+    store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status="active", data={},
+    )
+    parsed = parse_ics(_ics(_event()), now=NOW)
+    await sync_user(store, USER, parsed, calendar_id="work", calendar_name="Work")
+    again = await sync_user(store, USER, parsed, calendar_id="work", calendar_name="Work")
+    assert again["counts"] == {"created": 0, "updated": 0, "cancelled": 0}   # nothing to re-write
+    gone = await sync_user(store, USER, parse_ics(_ics(), now=NOW),
+                           calendar_id="work", calendar_name="Work")
+    assert gone["counts"]["cancelled"] == 0                                  # never retires a live row
+    (row,) = await store.list_meetings(USER)
+    assert row["status"] == "active"
+
+
 async def test_sync_other_users_rows_untouched():
     store = InMemoryTranscriptStore()
     await sync_user(store, USER, parse_ics(_ics(_event()), now=NOW))


### PR DESCRIPTION
## Live evidence — staging rev 190, 2026-08-17 16:50 UTC

User 23 manually sent a bot into Google Meet `mjm-dycn-qdp` (meeting row **26237** — admitted, actively transcribing). Their connected calendar imported the same meeting as a **second** row **26251**. At the scheduled start the auto-join sweep dispatched a second bot for 26251:

```
bot_join_requested   (bots.create)
auto_join_spawned    meeting_id=26251  native=mjm-dycn-qdp     # 1ms later
```

Two Vexa bots in one meeting — customer-visible.

## What the code said

`calendar_sync.sync_user`'s by-native adoption index already admits **every non-terminal row** (only `completed`/`failed` are excluded), and a non-intent match already short-circuited the create. What it did **not** do was write anything: the live row never received the calendar's `calendar_uid`/`calendar_sources`, so it stayed invisible to the uid path and the calendar's event remained homeless every sweep. `update_planned_meeting` cannot fill that gap — it refuses any FSM-owned row by design.

The sweep, meanwhile, relied entirely on `create_meeting_guarded`'s in-transaction dedup to notice a bot already in the room. That dedup is scoped to four statuses (`requested`/`joining`/`awaiting_admission`/`active`) and to the spawn transaction; it is not a statement the sweep can read, log, or stamp on a row — so when it does not fire, the sweep spawns silently.

## What changed

**1. Adoption (`calendar_sync/service.py`)** — an imported event whose meeting is already live now attaches to that row via a new store primitive `attach_calendar_source(user_id, meeting_id, *, calendar_uid, calendar_sources)`. It writes calendar identity onto a row in **any** status and nothing else: no `auto_join`, no `auto_join_user_set`, no `calendar_managed`, no `scheduled_at`, no `status`. Adopting a live row can never re-arm or re-dispatch it, and the legacy singular-feed path still refuses to steal a row another uid already stamped. Implemented on the port, the SQLAlchemy store and the in-memory fake.

**2. Dispatch guard (`bot_spawn/auto_join.py`)** — the tick reads `repo.list_live_meetings()` (statuses `requested`/`joining`/`awaiting_admission`/`active`/`needs_help`/`needs_human_help`/`stopping`) and refuses any due row whose `(user, platform, native)` a **different** row already holds. The refusal is loud, per P18: `data.auto_join_error` names the holding meeting id, `auto_join_next_retry` carries the backoff, a new `skipped_live` counter and an `auto_join_skipped_live` event are emitted. A duplicate dispatch is never correct regardless of how the rows came to exist.

## Tests

`946 passed, 5 skipped` in `core/meetings/services/meeting-api` (baseline on the candidate: `941 passed, 5 skipped` — +5 new, 0 regressions).

New:
- `test_sync_adopts_a_LIVE_row_on_the_same_link_and_never_duplicates_it` — manual row active + imported event on the same native → one row, one adoption, identity attached, `auto_join`/`calendar_managed`/`scheduled_at` absent.
- `test_live_row_adoption_is_idempotent_and_survives_the_feed_vanishing`
- `test_live_row_on_same_link_blocks_the_sweep` — rows 26237 live + 26251 scheduled → `spawned: 0`, `skipped_live: 1`, no runtime spec, reason stamped naming 26237.
- `test_live_row_for_another_user_does_not_block` — the guard is per tenant.
- `test_live_keys_ignores_terminal_and_linkless_rows`

The four existing exact-counter assertions in `test_auto_join_sweep.py` gained `skipped_live: 0`.

Refs #1150

<!-- vexa-agent -->
