### PR TITLE
fix(identity): fail closed when a UNIQUE index cannot be created

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/__main__.py
+++ b/core/identity/services/admin-api/src/admin_api/__main__.py
@@ -12,6 +12,10 @@ import logging
 import os
 import socket
 
+# Dependency-free by design (no SQLAlchemy) so this module stays importable in the offline gate
+# venv — see `schema/errors.py`.
+from .schema.errors import SchemaInvariantError
+
 logger = logging.getLogger("admin_api.boot")
 
 # #901: bounded initial-DB-connect retry. On a cold start the Postgres DNS name may not resolve
@@ -32,6 +36,11 @@ _TRANSIENT_OS_ERRORS = (socket.gaierror, ConnectionError, TimeoutError, OSError)
 
 
 def _is_transient_connect_error(exc: BaseException) -> bool:
+    # #1186: a blocked UNIQUE index is a DATA problem, never a connectivity one. Retrying it ten
+    # times just delays the same verdict, so it short-circuits ahead of the OSError chain walk
+    # (the driver error it chains from could otherwise drag an OSError into the __context__).
+    if isinstance(exc, SchemaInvariantError):
+        return False
     seen = set()
     cur: BaseException | None = exc
     while cur is not None and id(cur) not in seen:
@@ -112,6 +121,15 @@ def build_production_app():
         # #901: the first connect here is where a cold-start DNS race surfaces (socket.gaierror);
         # retry with bounded backoff so a not-yet-ready Postgres doesn't exit(3) into the restart
         # loop. After the bound it re-raises loud — a persistently unreachable DB still fails.
+        #
+        # #1186: convergence is also the readiness gate for the schema INVARIANTS. If a UNIQUE
+        # index cannot be created (duplicate rows block it), ensure_schema raises
+        # SchemaInvariantError out of this ASGI-lifespan startup hook; uvicorn aborts startup and
+        # exits(3), so the port never binds, /health never answers, and the compose healthcheck /
+        # k8s startupProbe+readinessProbe never pass. Deliberate: the spawn path documents relying
+        # on uq_meeting_active_user_platform_native as its DB backstop, so a DB where that index is
+        # absent must not be served by a process that assumes it. Not retried (see
+        # _is_transient_connect_error) — it needs an operator, not a backoff.
         await _connect_with_retry(lambda: ensure_schema(app_db.get_engine(), Base))
 
     return app

--- a/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0002-meeting-active-dedup-index.md
+++ b/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0002-meeting-active-dedup-index.md
@@ -124,6 +124,22 @@ With the index already present and committed, the admin-api boot's `ensure_schem
 `uq_meeting_active_user_platform_native` in the existing-index set (matched by name) and **no-ops** —
 the swallow/poison hazard never triggers because there is nothing left to build.
 
+## If you skipped steps 1–3 (#1186)
+
+This runbook exists because `ensure_schema` used to **swallow** a failed unique-index create. It no
+longer does: as of #1186 a UNIQUE index that cannot be built raises `SchemaInvariantError` out of
+the admin-api startup hook, so the process exits(3), `/health` never answers, and the compose
+healthcheck / k8s startup+readiness probes never pass.
+
+That is the intended behaviour — the spawn path documents this index as its DB backstop, so a DB
+where it is absent must not be served by a process that assumes it exists. Verified in production
+2026-08-17: the index had **never** existed, blocked by 4 stale duplicate rows, silently
+re-attempted and re-swallowed on every restart, with the lone WARNING log-rotating away inside a
+day.
+
+**Recovery is steps 1–3 above**, run against the DB the failing pod points at, then restart. The
+raised message names the index, the table, the underlying Postgres error, and points back here.
+
 ## Rollback
 
 `DROP INDEX CONCURRENTLY IF EXISTS uq_meeting_active_user_platform_native;` then revert the SSOT

--- a/core/identity/services/admin-api/src/admin_api/schema/errors.py
+++ b/core/identity/services/admin-api/src/admin_api/schema/errors.py
@@ -1,0 +1,15 @@
+"""Schema-convergence errors.
+
+Deliberately dependency-free (no SQLAlchemy import) so ``admin_api.__main__`` — which must stay
+importable in the offline gate venv where SQLAlchemy/asyncpg are absent — can name this type
+without dragging the ORM in.
+"""
+from __future__ import annotations
+
+
+class SchemaInvariantError(RuntimeError):
+    """A UNIQUE index the application treats as an invariant could not be created.
+
+    Raised out of ``ensure_schema`` and NOT retried: it is a data problem, not a connectivity
+    one, so the only cure is operator action on the rows that block the index.
+    """

--- a/core/identity/services/admin-api/src/admin_api/schema/sync.py
+++ b/core/identity/services/admin-api/src/admin_api/schema/sync.py
@@ -18,7 +18,11 @@ import logging
 from sqlalchemy import inspect, text
 from sqlalchemy.engine import Connection
 
+from .errors import SchemaInvariantError
+
 logger = logging.getLogger("admin_api.schema.sync")
+
+__all__ = ["SchemaInvariantError", "ensure_schema", "ensure_schema_sync"]
 
 # SQLAlchemy type name → Postgres column type (for additive ALTER TABLE).
 _TYPE_MAP = {
@@ -87,8 +91,28 @@ def _sync_columns(conn: Connection, base):
 
 
 def _sync_indexes(conn: Connection, base):
+    """Additive index convergence — tolerant for non-unique, FAIL CLOSED for unique (#1186).
+
+    A non-unique index is a performance hint: losing one degrades latency, nothing else, so a
+    failed CREATE stays tolerated at DEBUG. A UNIQUE index is an *invariant the application code
+    relies on* — ``uq_meeting_active_user_platform_native`` is the documented DB backstop for the
+    one-bot-per-room spawn guard (meeting-api ``bot_spawn/adapters.py``). Logging that one and
+    continuing produced exactly the failure #1186 records: the index never existed in production
+    because 4 stale duplicate rows blocked it, every restart re-attempted and re-swallowed it, and
+    the WARNING log-rotated away inside a day while the service reported itself healthy.
+
+    So a unique-index failure now raises ``SchemaInvariantError``, which aborts ``ensure_schema``
+    and therefore the admin-api startup hook — the process never binds, /health never answers, the
+    startup/readiness probes never pass. That is intentional: a database whose duplicate rows block
+    a load-bearing unique index MUST NOT be served by a process that assumes the index exists. The
+    operator's next step is in the message.
+
+    Failures are collected across all tables before raising, so one restart surfaces every blocking
+    index rather than one per fix-and-retry cycle.
+    """
     inspector = inspect(conn)
     existing_tables = set(inspector.get_table_names())
+    unique_failures: list[tuple[str, str, str]] = []   # (table, index, underlying error)
     for table in base.metadata.sorted_tables:
         if table.name not in existing_tables:
             continue
@@ -98,17 +122,41 @@ def _sync_indexes(conn: Connection, base):
                 continue
             # Per-index SAVEPOINT: a failed CREATE INDEX (e.g. a UNIQUE index on a table that still
             # holds rows violating it) must NOT poison the surrounding convergence transaction —
-            # without the nested begin, the aborted txn would roll back the whole ensure_schema pass.
+            # without the nested begin, the aborted txn would roll back the whole ensure_schema pass
+            # before we can report WHICH index failed and why.
             try:
                 with conn.begin_nested():
                     index.create(conn)
             except Exception as e:
-                # Most often a benign race (index already present under a different detection path) —
-                # but a UNIQUE index failing on duplicate data is a real, actionable miss, so surface
-                # it at WARNING rather than swallowing it at debug. The savepoint rolled back, so the
-                # rest of the convergence still applies.
-                level = logging.WARNING if getattr(index, "unique", False) else logging.DEBUG
-                logger.log(level, "index %s not created: %s", index.name, e)
+                if getattr(index, "unique", False):
+                    logger.error(
+                        "schema-sync: UNIQUE index %s on %s NOT created: %s",
+                        index.name, table.name, e,
+                    )
+                    unique_failures.append((table.name, str(index.name), str(e)))
+                    continue
+                # Non-unique: most often a benign race (index already present under a different
+                # detection path). The savepoint rolled back; the rest of the convergence applies.
+                logger.debug("index %s not created: %s", index.name, e)
+    if unique_failures:
+        raise SchemaInvariantError(_unique_index_failure_message(unique_failures))
+
+
+def _unique_index_failure_message(failures: list[tuple[str, str, str]]) -> str:
+    """Operator-facing text: which index, on what table, the underlying error, what to do next."""
+    lines = [
+        "schema-sync FAILED CLOSED: {n} UNIQUE index(es) could not be created, and admin-api "
+        "will not start without them — application code treats these as invariants, not as "
+        "performance hints.".format(n=len(failures)),
+    ]
+    for table, index, err in failures:
+        lines.append(f"  - UNIQUE index {index} on table {table}: {err}")
+    lines.append(
+        "Remediation: duplicate rows block this unique index; resolve them (find the rows that "
+        "collide on the index's key columns and delete or terminate the extras), then restart. "
+        "See https://github.com/Vexa-ai/vexa/issues/1186"
+    )
+    return "\n".join(lines)
 
 
 # MIGRATION-0004-backfill-token-scopes — grandfather pre-scope (0.10-era) API tokens.

--- a/core/identity/services/admin-api/tests/test_schema_sync_fail_closed.py
+++ b/core/identity/services/admin-api/tests/test_schema_sync_fail_closed.py
@@ -1,0 +1,165 @@
+"""#1186 · a UNIQUE index that cannot be created must FAIL CLOSED.
+
+Prod evidence (2026-08-17): `uq_meeting_active_user_platform_native` — the DB backstop the spawn
+path documents relying on (meeting-api `bot_spawn/adapters.py`) — had NEVER existed. Four stale
+duplicate active rows blocked it, `_sync_indexes` caught the failure, logged one WARNING and
+continued, every restart repeated the cycle, and the WARNING log-rotated away inside a day. The
+service reported itself healthy the entire time.
+
+Discriminating red→green (the old code passes NONE of the unique cases):
+  * a UNIQUE index failing to create   → raises, message names the index, the table, the
+    underlying error, and the remediation (before: WARNING + continue)
+  * several unique failures            → ONE raise listing all of them (one restart, one fix pass)
+  * a NON-unique index failing         → still tolerated, convergence continues (performance
+    hint, not an invariant)
+  * nothing failing                    → no raise
+
+No DB and no docker: these exercise `_sync_indexes`' branch logic directly with fakes. The real
+Postgres round-trip (drop the index, plant duplicates, re-converge) is the docker-gated
+`test_meeting_active_unique_index_blocked_fails_closed` in `test_stack_postgres.py`.
+"""
+from __future__ import annotations
+
+import logging
+from contextlib import nullcontext
+
+import pytest
+
+from admin_api.schema import sync as sync_mod
+from admin_api.schema.errors import SchemaInvariantError
+
+BLOCKED = "could not create unique index \"uq_x\"\nDETAIL:  Key (a)=(1) is duplicated."
+
+
+class _FakeIndex:
+    def __init__(self, name, *, unique, error=None):
+        self.name = name
+        self.unique = unique
+        self._error = error
+        self.created = False
+
+    def create(self, conn):
+        if self._error is not None:
+            raise self._error
+        self.created = True
+
+
+class _FakeTable:
+    def __init__(self, name, indexes):
+        self.name = name
+        self.indexes = indexes
+
+
+class _FakeBase:
+    def __init__(self, tables):
+        self.metadata = type("_M", (), {"sorted_tables": tables})()
+
+
+class _FakeConn:
+    """Only what `_sync_indexes` touches: a savepoint context manager."""
+
+    def __init__(self):
+        self.savepoints = 0
+
+    def begin_nested(self):
+        self.savepoints += 1
+        return nullcontext()
+
+
+class _FakeInspector:
+    def __init__(self, tables):
+        self._tables = [t.name for t in tables]
+
+    def get_table_names(self):
+        return list(self._tables)
+
+    def get_indexes(self, table_name):
+        return []          # nothing pre-exists → every index is attempted
+
+
+@pytest.fixture()
+def patched_inspect(monkeypatch):
+    def _apply(tables):
+        monkeypatch.setattr(sync_mod, "inspect", lambda conn: _FakeInspector(tables))
+    return _apply
+
+
+def _run(tables, patched_inspect):
+    patched_inspect(tables)
+    conn = _FakeConn()
+    sync_mod._sync_indexes(conn, _FakeBase(tables))
+    return conn
+
+
+def test_unique_index_failure_fails_closed(patched_inspect):
+    """The #1186 case: the unique index cannot be built → raise, don't log-and-continue."""
+    idx = _FakeIndex("uq_meeting_active_user_platform_native", unique=True,
+                     error=Exception(BLOCKED))
+    tables = [_FakeTable("meetings", [idx])]
+
+    with pytest.raises(SchemaInvariantError) as ei:
+        _run(tables, patched_inspect)
+
+    msg = str(ei.value)
+    assert "uq_meeting_active_user_platform_native" in msg, "message must NAME the index"
+    assert "meetings" in msg, "message must name the table"
+    assert "is duplicated" in msg, "message must carry the underlying DB error"
+    assert "duplicate rows block this unique index" in msg, "message must state the remediation"
+    assert "restart" in msg
+    assert "github.com/Vexa-ai/vexa/issues/1186" in msg
+
+
+def test_non_unique_index_failure_is_still_tolerated(patched_inspect, caplog):
+    """A plain index is a performance hint — losing it must NOT stop the service booting."""
+    failing = _FakeIndex("ix_meetings_created_at", unique=False, error=Exception("boom"))
+    following = _FakeIndex("ix_meetings_user_id", unique=False)
+    tables = [_FakeTable("meetings", [failing, following])]
+
+    with caplog.at_level(logging.DEBUG, logger="admin_api.schema.sync"):
+        _run(tables, patched_inspect)          # no raise
+
+    assert following.created, "convergence must continue past a tolerated failure"
+    assert any("ix_meetings_created_at" in r.getMessage() for r in caplog.records)
+
+
+def test_all_unique_failures_reported_in_one_raise(patched_inspect):
+    """One restart surfaces every blocking index — not one per fix-and-retry cycle."""
+    tables = [
+        _FakeTable("meetings", [_FakeIndex("uq_a", unique=True, error=Exception("dup a"))]),
+        _FakeTable("users", [_FakeIndex("uq_b", unique=True, error=Exception("dup b"))]),
+    ]
+    with pytest.raises(SchemaInvariantError) as ei:
+        _run(tables, patched_inspect)
+    msg = str(ei.value)
+    assert "uq_a" in msg and "uq_b" in msg
+    assert "2 UNIQUE index(es)" in msg
+
+
+def test_unique_failure_does_not_abort_the_rest_of_the_index_pass(patched_inspect):
+    """The raise happens AFTER the loop, so non-unique convergence still gets attempted —
+    the operator sees the complete picture in one pass."""
+    later = _FakeIndex("ix_after", unique=False)
+    tables = [_FakeTable("meetings", [
+        _FakeIndex("uq_blocked", unique=True, error=Exception("dup")),
+        later,
+    ])]
+    with pytest.raises(SchemaInvariantError):
+        _run(tables, patched_inspect)
+    assert later.created
+
+
+def test_clean_convergence_does_not_raise(patched_inspect):
+    tables = [_FakeTable("meetings", [
+        _FakeIndex("uq_ok", unique=True),
+        _FakeIndex("ix_ok", unique=False),
+    ])]
+    _run(tables, patched_inspect)      # no raise
+
+
+def test_schema_invariant_error_is_not_treated_as_a_transient_connect_error():
+    """#901's boot retry must NOT burn its budget on a data problem (and must not swallow it)."""
+    from admin_api.__main__ import _is_transient_connect_error
+
+    err = SchemaInvariantError("blocked")
+    err.__cause__ = ConnectionResetError("driver socket noise")   # chain that would match #901
+    assert _is_transient_connect_error(err) is False

--- a/core/identity/services/admin-api/tests/test_stack_postgres.py
+++ b/core/identity/services/admin-api/tests/test_stack_postgres.py
@@ -191,6 +191,56 @@ def test_meeting_active_unique_partial_index(engine):
         s.commit()   # no collision — all prior rows are terminal
 
 
+def test_meeting_active_unique_index_blocked_fails_closed(engine):
+    """#1186 — real Postgres: duplicate active rows block the backstop index → ensure_schema RAISES.
+
+    Reproduces the production shape exactly (verified 2026-08-17: the index had NEVER existed,
+    blocked by 4 stale duplicate rows, re-attempted and re-swallowed on every restart while the
+    WARNING log-rotated away inside a day):
+
+      1. drop `uq_meeting_active_user_platform_native` (the state prod was actually in);
+      2. plant two active rows for the same (user, platform, native id) — legal without the index;
+      3. re-converge → SchemaInvariantError naming the index, the table, the underlying Postgres
+         error, and the remediation. BEFORE this fix: one WARNING, convergence "succeeds",
+         admin-api boots green with a decorative backstop.
+      4. resolve the duplicate → convergence succeeds and the index is present and unique.
+    """
+    from admin_api.schema.errors import SchemaInvariantError
+    from admin_api.schema.sync import ensure_schema_sync
+
+    idx_name = "uq_meeting_active_user_platform_native"
+    key = dict(user_id=99, platform="google_meet", platform_specific_id="blk-ced-idx")
+
+    with engine.begin() as c:
+        c.execute(text(f"DROP INDEX IF EXISTS {idx_name}"))
+    assert idx_name not in {i["name"] for i in inspect(engine).get_indexes("meetings")}
+
+    with Session(engine) as s:                       # legal only while the index is absent
+        s.add(Meeting(status="active", **key))
+        s.add(Meeting(status="active", **key))
+        s.commit()
+
+    with pytest.raises(SchemaInvariantError) as ei:
+        ensure_schema_sync(engine, Base)
+    msg = str(ei.value)
+    assert idx_name in msg, "message must name the index"
+    assert "meetings" in msg, "message must name the table"
+    assert "duplicate" in msg.lower(), "message must carry the blocking cause"
+    assert "restart" in msg and "issues/1186" in msg, "message must state the remediation"
+
+    # Still absent — the failure was not silently converged away.
+    assert idx_name not in {i["name"] for i in inspect(engine).get_indexes("meetings")}
+
+    # Operator resolves the duplicate → convergence completes and the invariant exists.
+    with Session(engine) as s:
+        dup = s.query(Meeting).filter_by(status="active", **key).order_by(Meeting.id.desc()).first()
+        dup.status = "failed"
+        s.commit()
+    ensure_schema_sync(engine, Base)
+    built = {i["name"]: i for i in inspect(engine).get_indexes("meetings")}
+    assert idx_name in built and built[idx_name]["unique"] is True
+
+
 def test_backfill_grandfathers_empty_token_scopes(engine):
     """MIGRATION-0004 (issue #578) — a 0.10-era token row with scopes='{}' (what the additive
     ADD COLUMN leaves behind on upgrade) is grandfathered to the full valid-scope set by


### PR DESCRIPTION
`uq_meeting_active_user_platform_native` — the DB backstop meeting-api's `bot_spawn/adapters.py` documents relying on — has never existed in production (verified 2026-08-17): 4 stale duplicate rows blocked it, `_sync_indexes` swallowed the failure on every restart, and the lone WARNING log-rotated away inside a day while admin-api reported itself healthy.

A UNIQUE index that cannot be created now raises `SchemaInvariantError` out of `ensure_schema`, aborting admin-api's ASGI startup hook — uvicorn exits(3), `/health` never answers, the compose healthcheck and k8s startup/readiness probes never pass. The message names each index, its table, the underlying Postgres error, and the remediation. Non-unique index failures stay tolerated (performance, not invariants). Not retried by #901's connect backoff — a data problem needs an operator.

Tests: `tests/test_schema_sync_fail_closed.py` (non-docker, 6 cases) and `test_meeting_active_unique_index_blocked_fails_closed` (docker-gated, reproduces the prod shape on real Postgres). Full suite green locally: 87 passed.

Refs #1186

<!-- vexa-agent -->
