### PR TITLE
feat: delete completed meeting artifacts

### DIFF
--- a/core/gateway/contracts/api.v1/KNOWN_GAPS.json
+++ b/core/gateway/contracts/api.v1/KNOWN_GAPS.json
@@ -65,12 +65,6 @@
       "path": "/bots/id/{meeting_id}",
       "reason": "api.v1 declares it (desc: 'Forward to meeting-api GET /bots/{meeting_id}') but the gateway maps the meeting-detail read to GET /meetings/{meeting_id} instead; the dashboard reads /meetings/{id}. Deferred reconcile (drop from api.v1 or implement) is a lane:contract change (A1/A2, MATURITY-FINDINGS.md).",
       "issue": "https://github.com/Vexa-ai/vexa/issues/591"
-    },
-    {
-      "method": "DELETE",
-      "path": "/recordings/{recording_id}",
-      "reason": "api.v1 declares recording delete; not implemented in the 0.12 carve (no consumer wired it — recording delete rides DELETE /meetings/{platform}/{native}, which purges the meeting's recordings). Deferred reconcile (A2, MATURITY-FINDINGS.md).",
-      "issue": "https://github.com/Vexa-ai/vexa/issues/591"
     }
   ],
   "shape_gaps": [

--- a/core/gateway/contracts/api.v1/validate.mjs
+++ b/core/gateway/contracts/api.v1/validate.mjs
@@ -33,6 +33,7 @@ const CORE = [
   ["/bots/{platform}/{native_meeting_id}/speak", "post"],
   ["/transcripts/{platform}/{native_meeting_id}", "get"],
   ["/recordings", "get"], ["/recordings/{recording_id}", "get"],
+  ["/recordings/{recording_id}", "delete"],
   ["/meetings", "get"],
 ];
 for (const [p, m] of CORE) check(`${m.toUpperCase()} ${p}`, !!oas.paths?.[p]?.[m]);

--- a/core/gateway/services/conformance/src/gateway_conformance/contracts.py
+++ b/core/gateway/services/conformance/src/gateway_conformance/contracts.py
@@ -134,5 +134,6 @@ def api_core_paths() -> list[tuple[str, str]]:
         ("/transcripts/{platform}/{native_meeting_id}", "get"),
         ("/recordings", "get"),
         ("/recordings/{recording_id}", "get"),
+        ("/recordings/{recording_id}", "delete"),
         ("/meetings", "get"),
     ]

--- a/core/gateway/services/conformance/src/gateway_conformance/fake_meeting_api.py
+++ b/core/gateway/services/conformance/src/gateway_conformance/fake_meeting_api.py
@@ -206,4 +206,8 @@ def build_fake_downstream() -> FastAPI:
     async def get_recording(recording_id: int):
         return {"id": recording_id, "media_files": []}
 
+    @app.delete("/recordings/{recording_id}")
+    async def delete_recording(recording_id: int):
+        return {"status": "deleted", "recording_id": recording_id}
+
     return app

--- a/core/gateway/services/conformance/tests/test_api_surface.py
+++ b/core/gateway/services/conformance/tests/test_api_surface.py
@@ -44,6 +44,7 @@ CORE_CASES = [
     ("GET", "/transcripts/google_meet/abc-defg-hij", 200, "TranscriptionResponse"),
     ("GET", "/recordings", 200, None),
     ("GET", "/recordings/1", 200, None),
+    ("DELETE", "/recordings/1", 200, None),
     ("GET", "/meetings", 200, "MeetingListResponse"),
 ]
 
@@ -65,10 +66,11 @@ def test_core_paths_match_validate_mjs():
         ("/bots/{platform}/{native_meeting_id}/speak", "post"),
         ("/transcripts/{platform}/{native_meeting_id}", "get"),
         ("/recordings", "get"), ("/recordings/{recording_id}", "get"),
+        ("/recordings/{recording_id}", "delete"),
         ("/meetings", "get"),
     }
     assert driven == sealed, f"driven set != sealed CORE set: {driven ^ sealed}"
-    assert len(driven) == 10
+    assert len(driven) == 11
 
 
 @pytest.mark.parametrize("method,url,ok_status,component", CORE_CASES,

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -381,6 +381,10 @@ def create_app(
     async def get_recording(recording_id: int, request: Request):
         return await _forward("GET", _meeting(f"/recordings/{recording_id}"), request)
 
+    @app.delete("/recordings/{recording_id}")
+    async def delete_recording(recording_id: int, request: Request):
+        return await _forward("DELETE", _meeting(f"/recordings/{recording_id}"), request)
+
     # finalize-on-read master metadata (audio|video); the recording player fetches this, then the
     # raw_url it returns. ?type= is preserved by _forward.
     @app.get("/recordings/{recording_id}/master")

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -89,6 +89,18 @@ def test_authed_request_passes_body_and_status_verbatim():
     assert r.json() == {"id": 99, "platform": "google_meet"}
 
 
+def test_recording_delete_is_forwarded_to_meeting_api():
+    downstream = FakeDownstream(
+        status_code=200, body={"status": "deleted", "recording_id": 42}
+    )
+    client, _ = _client(downstream=downstream)
+    response = client.delete("/recordings/42", headers=AUTH)
+    assert response.status_code == 200
+    assert downstream.last["method"] == "DELETE"
+    assert downstream.last["url"] == "http://meeting-api/recordings/42"
+    assert downstream.last["headers"]["x-user-id"] == "7"
+
+
 def test_range_response_preserves_content_range_headers():
     """A 206 from a recording /raw byte stream must keep its Content-Range/Accept-Ranges on the way
     out. Without them the response is a malformed 206 and browsers abort <audio>/<video> playback

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -271,18 +271,27 @@ def create_app(
     # workload (the leave command alone is fire-and-forget — a booting bot may never receive it → orphan).
     app.include_router(build_stop_router(meeting_repo, command_publisher, runtime))
 
+    # Resolve the shared recording storage before mounting the collector: completed-meeting erasure
+    # uses this same port to delete objects before its transcript/JSONB finalization.
+    if storage is None:
+        storage = _recordings_fakes().InMemoryStorage()
+
+    async def _delete_recording_objects(recording: dict) -> list[str]:
+        from .recordings.deletion import delete_recording_objects
+
+        return await delete_recording_objects(storage, recording)
+
     # --- collector: transcripts + meetings + ws-authorize (api.v1) ---
     if transcript_store is None:
         transcript_store = _collector_fakes().InMemoryTranscriptStore()
     app.include_router(_build_collector_router(transcript_store, redis,
                                             calendar_sync_now=calendar_sync_now,
-                                            calendar_sync_status=calendar_sync_status))
+                                            calendar_sync_status=calendar_sync_status,
+                                            artifact_object_deleter=_delete_recording_objects))
 
     # --- recordings: chunk upload + finalize → meeting.data JSONB (recording.v1) ---
     if recording_repo is None:
         recording_repo = _recordings_fakes().InMemoryRecordingRepo()
-    if storage is None:
-        storage = _recordings_fakes().InMemoryStorage()
     app.include_router(_recordings.build_router(recording_repo, storage, token_secret=token_secret))
 
     # --- webhooks: GET /webhooks/deliveries — the per-user delivery history the dashboard reads (#841) ---

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -138,12 +138,20 @@ class SqlAlchemyMeetingRepo:
 
         async with self._session_factory() as db:
             m = (
-                await db.execute(select(Meeting).where(Meeting.id == meeting_id))
+                await db.execute(
+                    select(Meeting).where(Meeting.id == meeting_id).with_for_update()
+                )
             ).scalars().first()
+            data = dict(m.data) if isinstance(m.data, dict) else {}
+            deletion_pending = data.get("artifact_deletion") or any(
+                r.get("deletion_pending") for r in (data.get("recordings") or [])
+                if isinstance(r, dict)
+            )
+            if m.status not in ("completed", "failed") or deletion_pending:
+                raise DuplicateMeeting("Terminal meeting is no longer reusable")
             m.status = "requested"
             m.end_time = None
             m.bot_container_id = None
-            data = dict(m.data) if isinstance(m.data, dict) else {}
             for k in ("completion_reason", "failure_stage"):
                 data.pop(k, None)
             for key, value in (data_patch or {}).items():

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -182,6 +182,13 @@ class InMemoryMeetingRepo:
 
     async def reopen_meeting(self, *, meeting_id, data_patch=None) -> dict:
         row = self._meetings[meeting_id]
+        data = row.get("data") or {}
+        deletion_pending = data.get("artifact_deletion") or any(
+            r.get("deletion_pending") for r in (data.get("recordings") or [])
+            if isinstance(r, dict)
+        )
+        if row.get("status") not in ("completed", "failed") or deletion_pending:
+            raise DuplicateMeeting("Terminal meeting is no longer reusable")
         row["status"] = "requested"
         row["end_time"] = None
         row["bot_container_id"] = None

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -310,7 +310,16 @@ async def request_bot(
     reused_row: Optional[dict] = None
     if continue_meeting:
         latest = await repo.find_latest(user_id, platform, native_meeting_id)
-        if latest and latest.get("status") in _TERMINAL_STATUSES:
+        latest_data = (latest or {}).get("data", {})
+        deletion = latest_data.get("artifact_deletion") or {}
+        recording_delete = any(
+            r.get("deletion_pending") for r in (latest_data.get("recordings") or [])
+            if isinstance(r, dict)
+        )
+        if (
+            latest and latest.get("status") in _TERMINAL_STATUSES
+            and not deletion and not recording_delete
+        ):
             reused_row = latest
 
     # 2+2b+3. Dedup + max-bots cap + INSERT, made ATOMIC (ROB1/ROB2). Replaces the old read-check-

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -386,6 +386,10 @@ class SqlAlchemyTranscriptStore:
             meeting = (await db.execute(stmt)).scalars().first()
             if not meeting:
                 return None
+            data = meeting.data if isinstance(meeting.data, dict) else {}
+            deletion_state = data.get("artifact_deletion") or {}
+            if deletion_state and deletion_state.get("state", "completed") == "completed":
+                return None
             pg = await self._transcript_pg_part(db, meeting)
         # Session closed (transaction ended, connection returned to pool) BEFORE the Redis merge (#508).
         return await self._merge_live_segments(pg)
@@ -408,6 +412,9 @@ class SqlAlchemyTranscriptStore:
             if not meeting:
                 return None
             data = meeting.data if isinstance(meeting.data, dict) else {}
+            deletion_state = data.get("artifact_deletion") or {}
+            if deletion_state and deletion_state.get("state", "completed") == "completed":
+                return None
             authorized = (
                 meeting.user_id == user_id                                          # (a) owner
                 or user_id in (data.get("transcript_viewers") or [])                # (c) transcript-share
@@ -1078,6 +1085,85 @@ class SqlAlchemyTranscriptStore:
             await db.delete(meeting)
             await db.commit()
             return True
+
+    async def prepare_completed_artifact_deletion(self, user_id, meeting_id) -> "Optional[dict]":
+        from datetime import datetime, timezone
+
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from .models import Meeting
+
+        async with self._session_factory() as db:
+            meeting = (await db.execute(
+                select(Meeting).where(Meeting.id == meeting_id, Meeting.user_id == user_id)
+                .with_for_update()
+            )).scalars().first()
+            if meeting is None:
+                return None
+            if meeting.status not in ("completed", "failed"):
+                return {"error": "conflict"}
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            prior = data.get("artifact_deletion") or {}
+            already_deleted = bool(
+                prior and prior.get("state", "completed") == "completed"
+            )
+            if not already_deleted:
+                data["artifact_deletion"] = {
+                    "state": "pending",
+                    "requested_at": prior.get("requested_at")
+                    or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    "scope": "primary_transcript_and_recording_storage",
+                    "backup_residuals": "expire_under_deployment_retention_policy",
+                }
+                meeting.data = data
+                flag_modified(meeting, "data")
+                await db.commit()
+            return {
+                "meeting_id": meeting.id,
+                "recordings": list(data.get("recordings") or []),
+                "already_deleted": already_deleted,
+            }
+
+    async def finalize_completed_artifact_deletion(self, user_id, meeting_id) -> "Optional[bool]":
+        from datetime import datetime, timezone
+
+        from sqlalchemy import delete, select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from .models import Meeting, Transcription
+
+        async with self._session_factory() as db:
+            meeting = (await db.execute(
+                select(Meeting).where(Meeting.id == meeting_id, Meeting.user_id == user_id)
+                .with_for_update()
+            )).scalars().first()
+            if meeting is None:
+                return None
+            if meeting.status not in ("completed", "failed"):
+                return False
+            await db.execute(delete(Transcription).where(Transcription.meeting_id == meeting_id))
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            for key in ("recordings", "processed", "notes", "share_grants", "transcript_viewers"):
+                data.pop(key, None)
+            data["artifact_deletion"] = {
+                "state": "completed",
+                "completed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "scope": "primary_transcript_and_recording_storage",
+                "backup_residuals": "expire_under_deployment_retention_policy",
+            }
+            meeting.data = data
+            flag_modified(meeting, "data")
+            await db.commit()
+
+        # The DB tombstone makes this retryable: if Redis cleanup fails, a repeat reaches this same
+        # terminal row and tries the cache/stream cleanup again without resurrecting durable data.
+        if self._redis is not None:
+            await self._redis.delete(
+                f"meeting:{meeting_id}:segments", f"proc:meeting:{meeting_id}"
+            )
+            await self._redis.srem("active_meetings", str(meeting_id))
+        return True
 
 
 class RedisStreamBus:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -102,6 +102,7 @@ def build_router(
     log_event: Callable[..., dict] = _default_log_event,
     calendar_sync_now: Optional[Callable] = None,
     calendar_sync_status: Optional[Callable] = None,
+    artifact_object_deleter: Optional[Callable] = None,
 ) -> APIRouter:
     """The collector's READ-side + authorizer routes as a mountable ``APIRouter``.
 
@@ -445,14 +446,47 @@ def build_router(
         )
         return row
 
-    async def _apply_meeting_delete(user_id: int, meeting_id: int) -> None:
+    async def _apply_meeting_delete(user_id: int, meeting_id: int) -> dict:
         result = await store.delete_planned_meeting(user_id, meeting_id)
         if result is None:
             raise HTTPException(status_code=404, detail="Meeting not found")
         if result is False:
-            raise HTTPException(
-                status_code=409, detail="Meeting is no longer planned (bot lifecycle owns it)"
+            plan = await store.prepare_completed_artifact_deletion(user_id, meeting_id)
+            if plan is None:
+                raise HTTPException(status_code=404, detail="Meeting not found")
+            if plan.get("error") == "conflict":
+                raise HTTPException(
+                    status_code=409,
+                    detail="Meeting artifacts can only be deleted after the lifecycle is terminal",
+                )
+
+            recordings = list(plan.get("recordings") or [])
+            if recordings and artifact_object_deleter is None:
+                raise HTTPException(status_code=503, detail="Artifact storage deletion unavailable")
+            deleted_objects = 0
+            for recording in recordings:
+                # Storage FIRST. Any exception deliberately aborts before DB paths/transcripts are
+                # scrubbed, so the same owner-scoped request can retry with the original keys.
+                deleted_objects += len(await artifact_object_deleter(recording))
+
+            finalized = await store.finalize_completed_artifact_deletion(user_id, meeting_id)
+            if finalized is None:
+                raise HTTPException(status_code=404, detail="Meeting not found")
+            if finalized is False:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Meeting artifacts can only be deleted after the lifecycle is terminal",
+                )
+            log_event(
+                "meeting_artifacts_deleted", audience="user", span="meetings.artifacts.delete",
+                user_id=user_id, meeting_id=str(meeting_id),
+                fields={"recordings": len(recordings), "objects": deleted_objects,
+                        "already_deleted": bool(plan.get("already_deleted"))},
             )
+            return {
+                "kind": "artifacts", "objects_deleted": deleted_objects,
+                "already_deleted": bool(plan.get("already_deleted")),
+            }
         log_event(
             "meeting_plan_deleted", audience="user", span="meetings.plan.delete",
             user_id=user_id, meeting_id=str(meeting_id), fields={},
@@ -461,6 +495,7 @@ def build_router(
             redis, user_id=user_id, meeting_id=meeting_id, native_id=None,
             status="deleted", when=None, log_event=log_event,
         )
+        return {"kind": "plan"}
 
     @router.patch("/meetings/{meeting_id}")
     async def patch_planned_meeting(
@@ -527,11 +562,18 @@ def build_router(
                 status_code=404,
                 detail=f"Meeting not found for platform {platform} and ID {native_meeting_id}",
             )
-        await _apply_meeting_delete(user_id, meeting_id)
-        return JSONResponse(content={
+        receipt = await _apply_meeting_delete(user_id, meeting_id)
+        body = {
             "status": "deleted", "id": meeting_id,
             "platform": platform, "native_meeting_id": native_meeting_id,
-        })
+        }
+        if receipt["kind"] == "artifacts":
+            body.update({
+                "deleted": "completed_meeting_artifacts",
+                "objects_deleted": receipt["objects_deleted"],
+                "backup_residuals": "expire_under_deployment_retention_policy",
+            })
+        return JSONResponse(content=body)
 
     # --- GET /bots/{platform}/{native_meeting_id}/chat (#579 C3, sealed api.v1 ChatMessagesResponse).
     # Thin HONEST restore: the route + owner boundary are real (unowned/unknown native → 404), but

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -152,6 +152,9 @@ class InMemoryTranscriptStore:
         mid = self._find(user_id, platform, native_meeting_id)
         if mid is None:
             return None
+        deletion = self._meetings[mid].get("data", {}).get("artifact_deletion") or {}
+        if deletion and deletion.get("state", "completed") == "completed":
+            return None
         return await self._transcript_doc(mid)
 
     async def get_transcript_by_id(self, user_id, meeting_id, member_workspaces=None) -> Optional[dict]:
@@ -165,6 +168,9 @@ class InMemoryTranscriptStore:
         if m is None:
             return None
         data = m.get("data") if isinstance(m.get("data"), dict) else {}
+        deletion = data.get("artifact_deletion") or {}
+        if deletion and deletion.get("state", "completed") == "completed":
+            return None
         authorized = (
             m.get("user_id") == user_id
             or user_id in (data.get("transcript_viewers") or [])
@@ -466,6 +472,58 @@ class InMemoryTranscriptStore:
         if m["status"] not in ("idle", "scheduled"):
             return False
         del self._meetings[meeting_id]
+        return True
+
+    async def prepare_completed_artifact_deletion(self, user_id, meeting_id):
+        from datetime import datetime, timezone
+
+        m = self._meetings.get(meeting_id)
+        if m is None or m["user_id"] != user_id:
+            return None
+        if m["status"] not in ("completed", "failed"):
+            return {"error": "conflict"}
+        data = dict(m.get("data") or {})
+        prior = data.get("artifact_deletion") or {}
+        already_deleted = bool(prior and prior.get("state", "completed") == "completed")
+        if not already_deleted:
+            data["artifact_deletion"] = {
+                "state": "pending",
+                "requested_at": prior.get("requested_at")
+                or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "scope": "primary_transcript_and_recording_storage",
+                "backup_residuals": "expire_under_deployment_retention_policy",
+            }
+            m["data"] = data
+        return {
+            "meeting_id": meeting_id,
+            "recordings": list(data.get("recordings") or []),
+            "already_deleted": already_deleted,
+        }
+
+    async def finalize_completed_artifact_deletion(self, user_id, meeting_id):
+        from datetime import datetime, timezone
+
+        m = self._meetings.get(meeting_id)
+        if m is None or m["user_id"] != user_id:
+            return None
+        if m["status"] not in ("completed", "failed"):
+            return False
+        m["segments"] = {}
+        data = dict(m.get("data") or {})
+        for key in ("recordings", "processed", "notes", "share_grants", "transcript_viewers"):
+            data.pop(key, None)
+        data["artifact_deletion"] = {
+            "state": "completed",
+            "completed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "scope": "primary_transcript_and_recording_storage",
+            "backup_residuals": "expire_under_deployment_retention_policy",
+        }
+        m["data"] = data
+        if self._redis is not None:
+            await self._redis.delete(
+                f"meeting:{meeting_id}:segments", f"proc:meeting:{meeting_id}"
+            )
+            await self._redis.srem("active_meetings", str(meeting_id))
         return True
 
     def _row_or_placeholder(self, meeting_id) -> dict:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -193,6 +193,29 @@ class TranscriptStore(Protocol):
         FSM-owned (→ 409). An FSM row is never deletable from here."""
         ...
 
+    async def prepare_completed_artifact_deletion(
+        self, user_id: int, meeting_id: int
+    ) -> Optional[dict]:
+        """OWNER-scoped snapshot for a completed/failed meeting's artifact erasure.
+
+        Returns ``None`` for unknown/unowned, ``{"error": "conflict"}`` while the FSM is active,
+        or a retryable snapshot containing the persisted recording metadata. It records a
+        ``pending`` tombstone under the row lock so ``continue_meeting`` cannot reopen the row, but
+        retains every artifact and path; storage failures therefore remain addressable/retryable.
+        """
+        ...
+
+    async def finalize_completed_artifact_deletion(
+        self, user_id: int, meeting_id: int
+    ) -> Optional[bool]:
+        """After object deletion succeeds, erase transcript rows and recording metadata atomically.
+
+        The terminal meeting/lifecycle row is retained with an artifact-deletion tombstone. Returns
+        ``None`` for unknown/unowned and ``False`` if the meeting is no longer terminal. Repeated
+        calls on the tombstone are successful no-ops.
+        """
+        ...
+
 
 @runtime_checkable
 class PubSub(Protocol):

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/adapters.py
@@ -202,6 +202,36 @@ class SqlAlchemyRecordingRepo:
             m = (await db.execute(select(Meeting).where(Meeting.id == meeting_id))).scalars().first()
             return m.user_id if m else None
 
+    async def prepare_recording_deletion(self, user_id, recording_id):
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            meetings = (await db.execute(
+                select(Meeting).where(Meeting.user_id == user_id).with_for_update()
+            )).scalars().all()
+            for meeting in meetings:
+                data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+                recordings = list(data.get("recordings") or [])
+                recording = next((r for r in recordings if r.get("id") == recording_id), None)
+                if recording is None:
+                    continue
+                if meeting.status not in ("completed", "failed"):
+                    return {"error": "conflict"}
+                prepared = {
+                    **recording, "deletion_pending": True, "meeting_id": meeting.id,
+                }
+                data["recordings"] = [
+                    prepared if r.get("id") == recording_id else r for r in recordings
+                ]
+                meeting.data = data
+                flag_modified(meeting, "data")
+                await db.commit()
+                return prepared
+            return None
+
     async def list_meeting_recordings(self, user_id):
         from sqlalchemy import select
 

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/deletion.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/deletion.py
@@ -1,0 +1,76 @@
+"""Owner-scoped recording-object deletion primitives.
+
+Object storage is erased before JSONB metadata is removed.  That ordering is deliberate: if an
+S3/MinIO delete fails, the persisted paths remain addressable and the same request can be retried.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from .ports import RecordingRepo, Storage
+
+
+class MeetingNotTerminal(Exception):
+    """The recording exists, but its meeting lifecycle may still produce more artifacts."""
+
+
+def _recording_prefix(recording: dict) -> Optional[str]:
+    """Return the canonical key prefix for every chunk/master belonging to ``recording``."""
+    user_id = recording.get("user_id")
+    recording_id = recording.get("id")
+    session_uid = recording.get("session_uid")
+    if user_id is None or recording_id is None or not session_uid:
+        return None
+    return f"recordings/{user_id}/{recording_id}/{session_uid}/"
+
+
+async def recording_object_keys(storage: Storage, recording: dict) -> list[str]:
+    """Discover every current object plus any explicitly persisted legacy/master path."""
+    keys: set[str] = set()
+    prefix = _recording_prefix(recording)
+    if prefix:
+        keys.update(await storage.list(prefix))
+    for media_file in recording.get("media_files") or []:
+        path = media_file.get("storage_path") if isinstance(media_file, dict) else None
+        if path:
+            keys.add(path)
+    return sorted(keys)
+
+
+async def delete_recording_objects(storage: Storage, recording: dict) -> list[str]:
+    """Delete all discoverable objects idempotently and return the keys attempted."""
+    keys = await recording_object_keys(storage, recording)
+    for key in keys:
+        await storage.delete(key)
+    return keys
+
+
+async def delete_owned_recording(
+    repo: RecordingRepo, storage: Storage, *, user_id: int, recording_id: int
+) -> Optional[dict]:
+    """Delete one caller-owned recording; unknown and unowned ids are indistinguishable.
+
+    Storage deletion completes before the atomic JSONB mutation.  A storage exception therefore
+    leaves the recording metadata intact for a safe retry.
+    """
+    recording = await repo.prepare_recording_deletion(user_id, recording_id)
+    if recording is None:
+        return None
+    if recording.get("error") == "conflict":
+        raise MeetingNotTerminal
+
+    meeting_id = int(recording["meeting_id"])
+    deleted_keys = await delete_recording_objects(storage, recording)
+
+    def _remove(current: list[dict]):
+        remaining = [r for r in current if r.get("id") != recording_id]
+        return remaining, len(remaining) != len(current)
+
+    await repo.mutate_recordings(meeting_id, _remove)
+    return {
+        "status": "deleted",
+        "recording_id": recording_id,
+        "meeting_id": meeting_id,
+        "objects_deleted": len(deleted_keys),
+        "scope": "primary_object_storage",
+    }

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/fakes.py
@@ -75,8 +75,12 @@ class InMemoryRecordingRepo:
         self._meetings: dict[int, dict] = {}
         self._sessions: dict[str, int] = {}
 
-    def seed(self, *, meeting_id: int, user_id: int, session_uid: str) -> None:
-        self._meetings.setdefault(meeting_id, {"user_id": user_id, "recordings": []})
+    def seed(
+        self, *, meeting_id: int, user_id: int, session_uid: str, status: str = "active"
+    ) -> None:
+        self._meetings.setdefault(
+            meeting_id, {"user_id": user_id, "status": status, "recordings": []}
+        )
         self._sessions[session_uid] = meeting_id
 
     async def find_session(self, session_uid: str) -> Optional[dict]:
@@ -101,6 +105,25 @@ class InMemoryRecordingRepo:
 
     async def owner_of(self, meeting_id: int) -> Optional[int]:
         return self._meetings.get(meeting_id, {}).get("user_id")
+
+    async def prepare_recording_deletion(self, user_id: int, recording_id: int) -> Optional[dict]:
+        for meeting_id, meeting in self._meetings.items():
+            if meeting.get("user_id") != user_id:
+                continue
+            recording = next(
+                (r for r in meeting.get("recordings", []) if r.get("id") == recording_id), None
+            )
+            if recording is None:
+                continue
+            if meeting.get("status") not in ("completed", "failed"):
+                return {"error": "conflict"}
+            prepared = {**recording, "deletion_pending": True, "meeting_id": meeting_id}
+            meeting["recordings"] = [
+                prepared if r.get("id") == recording_id else r
+                for r in meeting.get("recordings", [])
+            ]
+            return prepared
+        return None
 
     async def list_meeting_recordings(self, user_id: int) -> list[dict]:
         out: list[dict] = []

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/ports.py
@@ -89,6 +89,17 @@ class RecordingRepo(Protocol):
         """The ``user_id`` that owns ``meeting_id`` — used to scope ``GET /recordings`` listing."""
         ...
 
+    async def prepare_recording_deletion(
+        self, user_id: int, recording_id: int
+    ) -> Optional[dict]:
+        """Lock and mark one owner-scoped recording deletion-pending while retaining its paths.
+
+        Returns ``None`` for unknown/unowned and ``{"error": "conflict"}`` for a non-terminal
+        meeting. The pending marker prevents ``continue_meeting`` from reopening the terminal row
+        while object deletion is in flight.
+        """
+        ...
+
     async def list_meeting_recordings(self, user_id: int) -> list[dict]:
         """Every recording across the user's meetings (for ``GET /recordings``)."""
         ...

--- a/core/meetings/services/meeting-api/src/meeting_api/recordings/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/recordings/router.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, File, Form, Header, HTTPException, Request, Uploa
 from fastapi.responses import JSONResponse, Response
 
 from .ports import RecordingRepo, Storage
+from .deletion import MeetingNotTerminal, delete_owned_recording
 from .service import (
     SIGNAL_MEDIA_TYPE,
     InvalidSignalTape,
@@ -231,6 +232,31 @@ def build_router(
         if rec is None:
             raise HTTPException(status_code=404, detail="Recording not found")
         return JSONResponse(content=rec)
+
+    @router.delete("/recordings/{recording_id}")
+    async def delete_recording(
+        recording_id: int,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        """Delete one owned recording's primary-storage objects and JSONB metadata.
+
+        Unknown and unowned ids both return 404. Storage is deleted first so a backend failure
+        leaves the metadata/path available for a retry rather than orphaning an undiscoverable
+        object. Backup expiry remains a deployment retention concern, not a claim of this route.
+        """
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            receipt = await delete_owned_recording(
+                repo, storage, user_id=user_id, recording_id=recording_id
+            )
+        except MeetingNotTerminal:
+            raise HTTPException(
+                status_code=409,
+                detail="Recording can only be deleted after the meeting lifecycle is terminal",
+            )
+        if receipt is None:
+            raise HTTPException(status_code=404, detail="Recording not found")
+        return JSONResponse(content=receipt)
 
     @router.get("/recordings/{recording_id}/master")
     async def get_recording_master(

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from meeting_api.bot_spawn import (
+    DuplicateMeeting,
     QuotaExceeded,
     SpawnFailed,
     build_invocation,
@@ -572,6 +573,33 @@ async def test_continue_meeting_refreezes_provider_for_the_new_session(monkeypat
     )
 
     assert repo._meetings[first["id"]]["data"]["transcription_provider"] == "vexa"
+
+
+async def test_continue_meeting_never_reopens_an_artifact_deletion_tombstone(monkeypatch):
+    """A deletion-pending/completed terminal row is immutable lifecycle evidence, not a row the
+    continue path may reopen while storage erasure is in progress or after it completes."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt-env.vexa.ai")
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient()
+    first = await request_bot(
+        repo, runtime, user_id=USER, platform="google_meet",
+        native_meeting_id="deleted-artifact-row", redis_url="redis://redis:6379/0",
+        token_secret=SECRET,
+    )
+    repo.set_status(first["id"], "completed")
+    repo._meetings[first["id"]]["data"]["artifact_deletion"] = {"state": "pending"}
+    with pytest.raises(DuplicateMeeting):
+        await repo.reopen_meeting(meeting_id=first["id"])
+
+    continued = await request_bot(
+        repo, runtime, user_id=USER, platform="google_meet",
+        native_meeting_id="deleted-artifact-row", continue_meeting=True,
+        redis_url="redis://redis:6379/0", token_secret=SECRET,
+    )
+
+    assert continued["id"] != first["id"]
+    assert repo._meetings[first["id"]]["status"] == "completed"
+    assert first["id"] not in repo.reopened
 
 
 async def test_request_bot_env_transcription_model_rides_invocation(monkeypatch):

--- a/core/meetings/services/meeting-api/tests/test_completed_artifact_deletion.py
+++ b/core/meetings/services/meeting-api/tests/test_completed_artifact_deletion.py
@@ -1,0 +1,136 @@
+"""#116 — completed meeting transcript + recording-object erasure."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+from meeting_api.recordings.fakes import InMemoryStorage
+
+
+OWNER = 7
+OTHER = 8
+MEETING_ID = 41
+RECORDING_ID = 9001
+PREFIX = f"recordings/{OWNER}/{RECORDING_ID}/sess-41/audio/"
+
+
+def _recording() -> dict:
+    return {
+        "id": RECORDING_ID,
+        "meeting_id": MEETING_ID,
+        "user_id": OWNER,
+        "session_uid": "sess-41",
+        "status": "completed",
+        "media_files": [{
+            "id": 22,
+            "type": "audio",
+            "format": "wav",
+            "storage_path": f"{PREFIX}master.wav",
+        }],
+    }
+
+
+def _fixture(*, status: str = "completed", storage_cls=InMemoryStorage):
+    store = InMemoryTranscriptStore()
+    store.seed_meeting(
+        meeting_id=MEETING_ID,
+        user_id=OWNER,
+        platform="google_meet",
+        native_meeting_id="private-room",
+        status=status,
+        data={
+            "recordings": [_recording()],
+            "processed": {"views": [{"doc": {"notes": ["derived"]}}]},
+            "notes": "derived summary",
+            "share_grants": [{"id": "share"}],
+            "transcript_viewers": [OTHER],
+        },
+        segments=[{
+            "segment_id": "s1", "start": 0, "end": 1,
+            "text": "confidential", "language": "en",
+        }],
+    )
+    storage = storage_cls()
+    storage.blobs[f"{PREFIX}000000.wav"] = b"chunk"
+    storage.blobs[f"{PREFIX}master.wav"] = b"master"
+    return store, storage, TestClient(
+        create_app(transcript_store=store, storage=storage),
+        raise_server_exceptions=False,
+    )
+
+
+def test_owner_deletes_completed_artifacts_but_terminal_meeting_row_survives():
+    store, storage, client = _fixture()
+
+    response = client.delete(
+        f"/meetings/{MEETING_ID}", headers={"x-user-id": str(OWNER)}
+    )
+    assert response.status_code == 204
+    assert storage.blobs == {}
+    assert client.get(
+        "/transcripts/google_meet/private-room", headers={"x-user-id": str(OWNER)}
+    ).status_code == 404
+
+    meeting = store._meetings[MEETING_ID]
+    assert meeting["status"] == "completed", "terminal lifecycle evidence is retained"
+    assert meeting["segments"] == {}
+    assert "recordings" not in meeting["data"]
+    assert "processed" not in meeting["data"]
+    assert "notes" not in meeting["data"]
+    assert meeting["data"]["artifact_deletion"]["backup_residuals"] == (
+        "expire_under_deployment_retention_policy"
+    )
+
+
+def test_non_owner_gets_indistinguishable_404_and_cannot_delete_any_artifact():
+    store, storage, client = _fixture()
+
+    response = client.delete(
+        f"/meetings/{MEETING_ID}", headers={"x-user-id": str(OTHER)}
+    )
+    assert response.status_code == 404
+    assert sorted(storage.blobs) == [f"{PREFIX}000000.wav", f"{PREFIX}master.wav"]
+    assert store._meetings[MEETING_ID]["segments"]["s1"]["text"] == "confidential"
+
+
+def test_storage_failure_preserves_paths_and_transcript_for_retry():
+    class FailsOnceStorage(InMemoryStorage):
+        def __init__(self):
+            super().__init__()
+            self.fail = True
+
+        async def delete(self, key: str) -> None:
+            if self.fail:
+                self.fail = False
+                raise RuntimeError("injected object-store failure")
+            await super().delete(key)
+
+    store, storage, client = _fixture(storage_cls=FailsOnceStorage)
+
+    first = client.delete(f"/meetings/{MEETING_ID}", headers={"x-user-id": str(OWNER)})
+    assert first.status_code == 500
+    assert store._meetings[MEETING_ID]["data"]["recordings"][0]["id"] == RECORDING_ID
+    assert store._meetings[MEETING_ID]["data"]["artifact_deletion"]["state"] == "pending"
+    assert client.get(
+        "/transcripts/google_meet/private-room", headers={"x-user-id": str(OWNER)}
+    ).status_code == 200
+
+    retry = client.delete(f"/meetings/{MEETING_ID}", headers={"x-user-id": str(OWNER)})
+    assert retry.status_code == 204
+    assert storage.blobs == {}
+    assert "recordings" not in store._meetings[MEETING_ID]["data"]
+    assert store._meetings[MEETING_ID]["data"]["artifact_deletion"]["state"] == "completed"
+
+
+def test_completed_artifact_delete_is_idempotent_and_active_lifecycle_is_not_deleted():
+    store, storage, client = _fixture()
+    headers = {"x-user-id": str(OWNER)}
+    assert client.delete(f"/meetings/{MEETING_ID}", headers=headers).status_code == 204
+    assert client.delete(f"/meetings/{MEETING_ID}", headers=headers).status_code == 204
+
+    active_store, active_storage, active_client = _fixture(status="active")
+    response = active_client.delete(f"/meetings/{MEETING_ID}", headers=headers)
+    assert response.status_code == 409
+    assert active_store._meetings[MEETING_ID]["status"] == "active"
+    assert active_storage.blobs

--- a/core/meetings/services/meeting-api/tests/test_contract_conformance.py
+++ b/core/meetings/services/meeting-api/tests/test_contract_conformance.py
@@ -62,10 +62,6 @@ WAIVED: dict[tuple[str, str], str] = {
         "actually maps GET /meetings/{meeting_id} → meeting-api GET /meetings/{meeting_id}; the "
         "dashboard meeting-detail reads /meetings/{id}. Deferred reconcile (drop or implement) is a "
         "lane:contract change (A1/A2, MATURITY-FINDINGS.md).",
-    ("DELETE", "/recordings/{recording_id}"):
-        "api.v1 declares recording delete; not implemented in the v0.12 carve (no consumer wired "
-        "it — delete rides DELETE /meetings/{p}/{n}, which purges the meeting's recordings). "
-        "Deferred reconcile (A2, MATURITY-FINDINGS.md).",
     ("PUT", "/bots/{platform}/{native_meeting_id}/config"):
         "Voice/config command to an ACTIVE bot (language/task update) — a bot-command-channel path, "
         "not meeting-api persistence. Deferred with the voice-agent carve; the gateway forwards it.",

--- a/core/meetings/services/meeting-api/tests/test_recordings.py
+++ b/core/meetings/services/meeting-api/tests/test_recordings.py
@@ -8,6 +8,7 @@ session-resolution seams behave.
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from meeting_api.bot_spawn import mint_meeting_token
@@ -62,6 +63,77 @@ def _client_for(repo, storage):
     app = FastAPI()
     app.include_router(build_router(repo, storage, token_secret=SECRET))
     return TestClient(app)
+
+
+def test_delete_recording_is_owner_scoped_storage_first_and_removes_metadata():
+    repo, storage = _seeded()
+    repo._meetings[MEETING_ID]["status"] = "completed"
+    import asyncio
+
+    receipt = asyncio.run(upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=_wav(), media_format="wav", chunk_seq=0, is_final=True,
+    ))
+    rid = receipt["recording_id"]
+    client = _client_for(repo, storage)
+
+    assert client.delete(f"/recordings/{rid}", headers={"x-user-id": "999"}).status_code == 404
+    assert storage.blobs, "another tenant cannot touch storage"
+    deleted = client.delete(f"/recordings/{rid}", headers={"x-user-id": str(USER)})
+    assert deleted.status_code == 200
+    assert deleted.json()["scope"] == "primary_object_storage"
+    assert storage.blobs == {}
+    assert asyncio.run(repo.get_recordings(MEETING_ID)) == []
+
+
+def test_delete_recording_storage_failure_keeps_metadata_retryable():
+    class FailsOnceStorage(InMemoryStorage):
+        def __init__(self):
+            super().__init__()
+            self.fail = True
+
+        async def delete(self, key: str) -> None:
+            if self.fail:
+                self.fail = False
+                raise RuntimeError("injected delete failure")
+            await super().delete(key)
+
+    import asyncio
+
+    repo = InMemoryRecordingRepo()
+    repo.seed(
+        meeting_id=MEETING_ID, user_id=USER, session_uid=SESSION_UID, status="completed"
+    )
+    storage = FailsOnceStorage()
+    receipt = asyncio.run(upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=_wav(), media_format="wav", chunk_seq=0, is_final=True,
+    ))
+    rid = receipt["recording_id"]
+    client = TestClient(FastAPI(), raise_server_exceptions=False)
+    client.app.include_router(build_router(repo, storage, token_secret=SECRET))
+
+    headers = {"x-user-id": str(USER)}
+    assert client.delete(f"/recordings/{rid}", headers=headers).status_code == 500
+    assert asyncio.run(repo.get_recordings(MEETING_ID))[0]["id"] == rid
+    assert client.delete(f"/recordings/{rid}", headers=headers).status_code == 200
+    assert asyncio.run(repo.get_recordings(MEETING_ID)) == []
+
+
+def test_delete_recording_does_not_become_an_active_bot_stop_operation():
+    import asyncio
+
+    repo, storage = _seeded()
+    receipt = asyncio.run(upload_chunk(
+        repo, storage, token_meeting_id=MEETING_ID, session_uid=SESSION_UID,
+        data=_wav(), media_format="wav", chunk_seq=0, is_final=False,
+    ))
+    response = _client_for(repo, storage).delete(
+        f"/recordings/{receipt['recording_id']}", headers={"x-user-id": str(USER)}
+    )
+    assert response.status_code == 409
+    assert storage.blobs
+    assert asyncio.run(repo.get_recordings(MEETING_ID))
 
 
 # ── flow: upload folds chunks into JSONB; finalize builds the master ─────────────────────────────

--- a/docs/docs/api/errors.mdx
+++ b/docs/docs/api/errors.mdx
@@ -39,9 +39,10 @@ failures (`422`).
 - `404` reading a transcript for a meeting that was never started.
 - `POST /meetings` (plan) → `409` when a non-terminal meeting already exists for that link; `422`
   on an unrecognizable `meeting_url`.
-- `PATCH`/`DELETE /meetings/{id}` → `409` once the bot lifecycle owns the record (a planned meeting
-  is only editable while it's still planned); `409` on `PATCH` when the new link collides with
-  another active meeting.
+- `PATCH /meetings/{id}` → `409` once the bot lifecycle owns the record (a planned meeting is only
+  editable while it's still planned); `409` when the new link collides with another active meeting.
+- `DELETE /meetings/{id}` deletes a plan before spawn or deletes transcript/recording artifacts after
+  the lifecycle is terminal; it returns `409` while the meeting is in flight.
 - `POST /bots` → `409` when a bot is already active on that link (a *planned* record on the link is
   fine — the spawn claims it); `429` past your concurrency limit.
 - A bot that fails to join surfaces in `GET /bots/status` rather than as an HTTP error on `POST /bots`

--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -79,7 +79,7 @@ curl -X POST "$API_BASE/meetings" \
 Returns `201` with the meeting record. `409` when a non-terminal meeting already exists for the
 same link.
 
-### Edit or delete a plan
+### Edit a plan or delete meeting artifacts
 
 Planned meetings are addressed **by record id** (a plan without a link has no platform/native
 path). Send only the fields you're changing; `null` clears a field (`scheduled_at: null` flips the
@@ -95,13 +95,28 @@ curl -X PATCH "$API_BASE/meetings/12345" \
 curl -X DELETE "$API_BASE/meetings/12345" -H "X-API-Key: $API_KEY"
 ```
 
-Both answer `404` for a record you don't own and `409` once the bot lifecycle owns the record.
+`PATCH` is plan-only. `DELETE` has two deliberately distinct meanings:
+
+- For an `idle`/`scheduled` plan, it deletes the plan row.
+- For a `completed`/`failed` meeting, it deletes durable transcript rows, transcript-derived
+  notes/shares, recording objects from primary object storage, and recording metadata. The terminal
+  meeting row remains as lifecycle evidence, but transcript reads return `404`.
+
+Both answer an owner-indistinguishable `404` for an unknown or unowned record. An in-flight meeting
+(`requested` through `stopping`) answers `409`; use `DELETE /bots/{platform}/{native_meeting_id}` to
+stop a bot, then delete artifacts after the meeting becomes terminal.
 
 The same edit/delete is also reachable **by native key** — `PATCH`/`DELETE
 /meetings/{platform}/{native_meeting_id}` — which resolves `(platform, native_meeting_id)` to your
-newest owned row and applies the same rules (`404` unknown/unowned, `409` once FSM-owned). Use it
+newest owned row and applies the same rules (`404` unknown/unowned, `409` while in flight). Use it
 when you address meetings by their join-link identity rather than the record id; `DELETE` answers
 `200` on this path (the by-record-id `DELETE` answers `204`).
+
+<Warning>
+Deletion confirms erasure from the live Postgres/Redis state and configured primary object storage.
+It does **not** claim immediate erasure from database snapshots, object-store version history, or
+other backups; those residuals expire under the operator's deployment retention policy.
+</Warning>
 
 ## api.v1 native-id support (per route)
 
@@ -346,6 +361,17 @@ curl -H "X-API-Key: $API_KEY" "$API_BASE/recordings"
 ```bash Recording detail — GET /recordings/{recording_id}
 curl -H "X-API-Key: $API_KEY" "$API_BASE/recordings/42"
 ```
+
+```bash Delete one recording — DELETE /recordings/{recording_id}
+curl -X DELETE -H "X-API-Key: $API_KEY" "$API_BASE/recordings/42"
+```
+
+After the meeting is terminal, recording deletion is owner-scoped (`404` for unknown and unowned
+ids; `409` while the meeting is in flight) and removes all discovered
+chunks/masters from configured primary object storage before removing the recording metadata. If
+storage deletion fails, metadata is retained so the same request can be retried safely. This route
+does not delete the meeting transcript; use `DELETE /meetings/{meeting_id}` after completion to erase
+the meeting's transcript and all of its recordings together.
 
 ```bash Master metadata (finalize-on-read) — GET /recordings/{recording_id}/master?type=audio
 curl -H "X-API-Key: $API_KEY" "$API_BASE/recordings/42/master?type=audio"

--- a/docs/docs/how-to/recordings.mdx
+++ b/docs/docs/how-to/recordings.mdx
@@ -62,6 +62,21 @@ curl -I -H "X-API-Key: $API_KEY" -H "Range: bytes=0-1023" \
 Recordings live in the bucket configured by `MINIO_*` ([Configuration](/configuration#database-storage)).
 On a self-host that's infrastructure you control; air-gapped deployments keep recordings entirely in-VPC.
 
+## Delete a recording
+
+```bash
+curl -X DELETE -H "X-API-Key: $API_KEY" "$API_BASE/recordings/42"
+```
+
+After the meeting becomes terminal, the owner-scoped delete removes the recording's chunks and
+master from configured primary object storage before removing its metadata (`409` while the meeting
+is still in flight). A storage error leaves the metadata intact so you can safely retry. To erase a
+completed meeting's transcript and every recording together, use
+`DELETE /meetings/{meeting_id}`.
+
+Deletion does not promise immediate removal from database snapshots, object-store version history,
+or backups. Those copies expire according to the retention policy of the deployment operator.
+
 <Note>
 A recording is the raw meeting audio. For the **text** of who-said-what with timestamps, use the
 [transcript](/how-to/send-a-bot#2-read-the-transcript) — see the


### PR DESCRIPTION
Refs #116.

## Value

Owners can erase completed meeting transcripts and recording artifacts from Vexa's live primary stores while lifecycle evidence remains tombstoned. Unknown and foreign-owner resources are indistinguishable, active meetings are rejected, and failed storage deletion remains retryable.

This does not promise immediate erasure from snapshots, object-version history, or backups; those remain subject to deployment retention policy.

## Independent witness

- commit: `3ae320562534561d62c999486144aeddcb8e5874`
- tree: `20dbd9f234340da1020004e8fb41f1f0cbec61fc`
- meeting-api: 922 passed, 5 skipped
- gateway: 112 passed, 1 xfailed
- conformance: 86 passed
- focused oracle: 11/11
- isolated Compose/Postgres/Redis/S3-compatible black box: owner/non-owner/active/idempotency/storage-failure-retry/transcript+recording deletion/terminal tombstone all passed

## Contributor rights

- [x] Independent — standing founder declaration applies to Dmitriy's own Vexa contributions.
- [ ] Employer/client authorization required
- [ ] Unsure

Every commit carries Dmitriy's matching DCO sign-off.
