### PR TITLE
feat(meetings): wire JoinRetryController into the composition root (#1190) — STACKED ON #1075

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -21,6 +21,13 @@ is wrapped in a per-loop Postgres advisory lock (``sweeps.single_flight``): the 
 interval, not once per replica. ``segment-consumer`` is intentionally left unguarded (Redis competing
 consumer). The former ``scheduler-tick`` loop was dead code (``app.state.scheduler`` was never wired —
 the ``Scheduler`` in ``scheduling/`` is an eval-only engine) and has been removed.
+
+  * **join-retry** (#1190) — the ``Scheduler`` is no longer eval-only: this entrypoint builds ONE,
+    owned by the ``JoinRetryController``, and drains it on a tick. A pre-active TRANSIENT join
+    failure schedules a bounded, backed-off ``POST /bots`` re-spawn (fresh ``meeting_session``, same
+    meeting row). Also unguarded, and for a different reason than segment-consumer: the job store is
+    in-process, so a cross-replica lock would suppress the tick of the replica actually holding the
+    job. Env-gated by ``JOIN_RETRY_ENABLED``.
 """
 from __future__ import annotations
 
@@ -182,6 +189,15 @@ def build_production_app():
         from .calendar_sync import read_stamp
         return await read_stamp(redis_client, user_id)
 
+    # JOIN-RETRY (#1190): the P3d controller, finally instantiated. Its scheduler fires the re-spawn
+    # through `_join_retry_dispatch` below; its trigger is the `join_retry` port `create_app` calls
+    # on every terminal `failed` advance. Built here (not in create_app) because it needs the same
+    # real repo/runtime the spawn path uses — and the tick loop that drains it is attached with the
+    # other background loops.
+    join_retry_coordinator, join_retry_scheduler = _build_join_retry(
+        meeting_repo, runtime_client, service_authority
+    )
+
     app = create_app(
         transcript_store=transcript_store,
         redis=segment_bus,
@@ -200,6 +216,7 @@ def build_production_app():
         transcript_finalizer=_transcript_finalizer,
         calendar_sync_now=_calendar_sync_now,
         calendar_sync_status=_calendar_sync_status,
+        join_retry=join_retry_coordinator.on_terminal_failed,
     )
 
     _attach_background_loops(
@@ -208,8 +225,112 @@ def build_production_app():
         system_webhook_sink=system_webhook_sink,
         session_factory=session_factory,
         storage=storage,
+        join_retry_scheduler=join_retry_scheduler if join_retry_coordinator.enabled else None,
     )
     return app
+
+
+# ── join-retry composition (#1190) ───────────────────────────────────────────────────────────────
+
+
+def join_retry_policy() -> "object":
+    """The env-resolved :class:`RetryPolicy`. Bounded attempts + backoff, and the founder-ruled
+    admission-timeout arm (``JOIN_RETRY_ADMISSION_TIMEOUT``, default OFF: the bot already stood at
+    the door for the whole lobby budget, so re-knocking only doubles the quota burn)."""
+    from .bot_spawn.env_flags import env_flag
+    from .lifecycle import RetryPolicy
+
+    default = RetryPolicy()
+    try:
+        max_attempts = max(1, int(os.getenv("JOIN_RETRY_MAX_ATTEMPTS") or default.max_attempts))
+    except ValueError:
+        max_attempts = default.max_attempts
+    raw_backoff = os.getenv("JOIN_RETRY_BACKOFF_S") or ""
+    backoff = []
+    for part in raw_backoff.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            backoff.append(float(part))
+        except ValueError:
+            backoff = []
+            break
+    return RetryPolicy(
+        max_attempts=max_attempts,
+        backoff=backoff or list(default.backoff),
+        retry_admission_timeout=env_flag("JOIN_RETRY_ADMISSION_TIMEOUT", False),
+    )
+
+
+def _build_join_retry(meeting_repo, runtime_client, service_authority):
+    """``(JoinRetryCoordinator, Scheduler)`` for this process.
+
+    The scheduler's dispatch is called SYNCHRONOUSLY from inside ``tick()``, while the re-spawn is an
+    ``async`` ``request_bot`` — so the dispatch hands the coroutine to the running event loop and
+    returns immediately. The call is made IN PROCESS rather than as an HTTP self-POST to the job's
+    own ``/bots`` URL, for the same reason the reconcile sweep drives the lifecycle callback in
+    process (``app._apply_lifecycle_event``): the loopback hop is fragile and buys nothing.
+
+    Bounding, therefore, is owned entirely by the controller (attempt cap + backoff + the
+    ``join_retry:{meeting_id}:{attempt}`` idempotency key), not by the scheduler's own job retry —
+    a dispatch that merely enqueues can never look "failed" to the scheduler.
+    """
+    from .bot_spawn.env_flags import env_flag
+    from .lifecycle import JoinRetryController, JoinRetryCoordinator
+    from .scheduling import Scheduler
+
+    enabled = env_flag("JOIN_RETRY_ENABLED", True)
+    meeting_api_url = os.getenv("MEETING_API_URL", "http://meeting-api:8080")
+
+    async def _respawn(body: dict) -> None:
+        from .bot_spawn.service import request_bot
+
+        try:
+            await request_bot(
+                meeting_repo,
+                runtime_client,
+                authority=service_authority,
+                user_id=body["user_id"],
+                platform=body["platform"],
+                native_meeting_id=body["native_meeting_id"],
+                meeting_url=body.get("meeting_url"),
+                # The whole point: reuse the terminal row (transcripts/recordings stay keyed to it),
+                # mint a FRESH meeting_session for this attempt.
+                continue_meeting=True,
+                token_secret=os.getenv("ADMIN_TOKEN") or None,
+                redis_url=os.getenv("REDIS_URL"),
+            )
+            log.info(
+                "join-retry re-spawned meeting=%s attempt=%s",
+                body.get("meeting_id"), body.get("attempt"),
+            )
+        except Exception:
+            # A failed re-spawn is the END of this meeting's retry chain: the attempt was consumed
+            # (the counter is already persisted) and no new terminal will arrive to drive the next
+            # one. Loud, and bounded — never a re-arm loop.
+            log.exception(
+                "join-retry re-spawn failed meeting=%s attempt=%s",
+                body.get("meeting_id"), body.get("attempt"),
+            )
+
+    def _dispatch(request: dict) -> dict:
+        body = request.get("body") or {}
+        asyncio.get_running_loop().create_task(_respawn(body))
+        return {"status": "dispatched", "attempt": body.get("attempt")}
+
+    scheduler = Scheduler(dispatch=_dispatch)
+    controller = JoinRetryController(scheduler, policy=join_retry_policy())
+    coordinator = JoinRetryCoordinator(
+        controller, meeting_repo, meeting_api_url=meeting_api_url, enabled=enabled,
+    )
+    log.info(
+        "join-retry %s (max_attempts=%s backoff=%s admission_timeout=%s)",
+        "enabled" if enabled else "DISABLED (JOIN_RETRY_ENABLED)",
+        controller.policy.max_attempts, controller.policy.backoff,
+        controller.policy.retry_admission_timeout,
+    )
+    return coordinator, scheduler
 
 
 def _minio_endpoint_url() -> str:
@@ -224,6 +345,7 @@ def _minio_endpoint_url() -> str:
 def _attach_background_loops(
     app, transcript_store, segment_bus, redis_client, meeting_repo=None, runtime=None,
     service_authority=None, system_webhook_sink=None, session_factory=None, storage=None,
+    join_retry_scheduler=None,
 ) -> None:
     """Register the FastAPI lifespan that starts/stops the control-plane poll loops.
 
@@ -638,6 +760,28 @@ def _attach_background_loops(
                 log.exception("signal tape janitor tick failed")
             await asyncio.sleep(signal_janitor_interval)
 
+    # JOIN-RETRY tick (#1190). The `scheduler-tick` loop this file removed was dead because
+    # `app.state.scheduler` was never wired; this one has an owner. DELIBERATELY NOT single-flighted:
+    # the Scheduler's job store is in-process, so each replica may only drain jobs IT scheduled — an
+    # advisory lock would let one replica's tick suppress the replica actually holding the job. The
+    # cross-replica bound is the idempotency key plus `create_meeting_guarded`'s per-user dedup.
+    join_retry_interval = float(os.getenv("JOIN_RETRY_TICK_INTERVAL_S", "5"))
+
+    async def _join_retry_loop() -> None:
+        if join_retry_scheduler is None:
+            return  # disabled (JOIN_RETRY_ENABLED=false) — no loop, no heartbeat
+        while True:
+            try:
+                fired = join_retry_scheduler.tick()
+                if fired:
+                    log.info("join-retry fired %s re-spawn job(s)", fired)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("join-retry tick failed")
+            ticks["join-retry"] = _time.monotonic()
+            await asyncio.sleep(join_retry_interval)
+
     @asynccontextmanager
     async def lifespan(_app):
         tasks = [
@@ -652,6 +796,7 @@ def _attach_background_loops(
             asyncio.create_task(_auto_join_loop(), name="auto-join"),
             asyncio.create_task(_calendar_sync_loop(), name="calendar-sync"),
             asyncio.create_task(_signal_tape_janitor_loop(), name="signal-tape-janitor"),
+            asyncio.create_task(_join_retry_loop(), name="join-retry"),
         ]
         log.info("meeting-api background loops started: %s", [t.get_name() for t in tasks])
         try:

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -17,8 +17,9 @@ sub-package of ``meeting_api`` mounted here (the v0.12 analog of the parent ``ma
 
 webhooks + scheduling are library bricks (no HTTP surface of their own in the core path — they are
 driven by the lifecycle/bot_spawn flows); they are re-exported from the package front door and wired
-by the production composition root in P3. continue_meeting / max-bots / join-retry / the segment
-consumer loop are P3 seams.
+by the production composition root in P3. continue_meeting / max-bots / the segment consumer loop
+are P3 seams; join-retry is one too, and #1190 filled it — the ``join_retry`` port below is called
+on every terminal ``failed`` advance.
 
 ``create_app`` takes every collaborator as an injected port (or builds a default in-memory stack for
 the app factory / tests), so the SAME app runs with real adapters in prod and in-process fakes in
@@ -182,6 +183,11 @@ def create_app(
     # calendar-sync user edges (async callables from the composition root; None → routes 503)
     calendar_sync_now: Optional["object"] = None,
     calendar_sync_status: Optional["object"] = None,
+    # join-retry (#1190) — awaited with the persisted meeting ROW the moment the FSM lands a
+    # `failed` terminal. Production wires lifecycle.JoinRetryCoordinator.on_terminal_failed: a
+    # pre-active TRANSIENT failure schedules a bounded, backed-off re-spawn (a fresh meeting_session
+    # on the same row). None → no retry at all, which is exactly the pre-#1190 behaviour.
+    join_retry: Optional["object"] = None,
 ) -> FastAPI:
     """Build the unified meeting-api app from the injected ports.
 
@@ -241,6 +247,7 @@ def create_app(
     app.state.delivery_ledger = delivery_ledger
     # The lifecycle callback publishes each persisted FSM advance to bm:meeting:{id}:status so the
     # gateway /ws (which SUBSCRIBEs that channel) forwards a ws.v1 BotStatus frame to the dashboard.
+    app.state.join_retry = join_retry
     _mount_lifecycle(
         app,
         sink,
@@ -250,6 +257,7 @@ def create_app(
         redis,
         transcript_finalizer,
         delivery_ledger,
+        join_retry,
     )
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
@@ -342,6 +350,7 @@ def _mount_lifecycle(
     redis: "object" = None,
     transcript_finalizer: "object" = None,
     delivery_ledger: "object" = None,
+    join_retry: "object" = None,
 ) -> None:
     """Register the lifecycle.v1 callback route on the unified app (the lifecycle receiver's
     ``/bots/internal/callback/lifecycle`` handler, sharing the app's TraceMiddleware).
@@ -836,6 +845,27 @@ def _mount_lifecycle(
                     log_event("meeting_copilot_reap_failed", audience="system", level="warning",
                               span="lifecycle.callback",
                               fields={"meeting_row_id": meeting_row_id, "error": str(e)})
+        # JOIN-RETRY (#1190) — the LAST thing a terminal `failed` advance does. The controller has
+        # existed since P3d with nothing calling it; this is the call. It reads its decision inputs
+        # off the persisted row (sealed `completion_reason`, #1075's `join_evidence`, the attempt
+        # counter) so the same inputs a human queries are the ones the machine used, and it fires
+        # only on a REAL advance (never an idempotent terminal replay — the bot retries its callback
+        # 3x, and each replay must NOT buy another re-spawn). Best-effort by contract: a retry is an
+        # optimization on a run that has already ended and must never fail the bot's callback.
+        if (
+            join_retry is not None
+            and terminal_advanced
+            and rec.status is not None
+            and rec.status.value == "failed"
+        ):
+            try:
+                await join_retry(meeting_row)
+            except Exception as e:  # noqa: BLE001 — the meeting is already terminal either way
+                log_event("join_retry_failed", audience="system", level="warning",
+                          span="lifecycle.callback",
+                          fields={"meeting_id": meeting_row.get("id")
+                                  if isinstance(meeting_row, dict) else None,
+                                  "error": str(e)})
         log_event(
             "meeting_lifecycle_advanced", audience="user", span="lifecycle.callback",
             meeting_id=rec.connection_id,

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -525,6 +525,41 @@
    "targets": []
   },
   {
+   "key": "JOIN_RETRY_ENABLED",
+   "class": "defaulted",
+   "default": "true",
+   "description": "#1190 master switch for bounded join-retry: on a pre-active TRANSIENT join failure the control plane schedules a fresh re-spawn (new meeting_session, same meeting row) instead of leaving the meeting dead on attempt 1. false disables the trigger entirely and the tick loop never starts — the pre-#1190 behaviour, one boolean away.",
+   "targets": []
+  },
+  {
+   "key": "JOIN_RETRY_MAX_ATTEMPTS",
+   "class": "defaulted",
+   "default": "3",
+   "description": "#1190 total attempts per meeting INCLUDING the original spawn (3 ⇒ the original plus at most two re-spawns). Unparseable values keep the default.",
+   "targets": []
+  },
+  {
+   "key": "JOIN_RETRY_BACKOFF_S",
+   "class": "defaulted",
+   "default": "30,120,300",
+   "description": "#1190 comma-separated backoff seconds per retry attempt; the last entry is reused past its length. A malformed list keeps the default rather than retrying with no delay.",
+   "targets": []
+  },
+  {
+   "key": "JOIN_RETRY_ADMISSION_TIMEOUT",
+   "class": "defaulted",
+   "default": "false",
+   "description": "#1190 whether a lobby expiry (awaiting_admission_timeout, or a join_failure whose #1075 evidence reads admission_timeout) is retried. OFF by founder ruling 2026-08-17: the bot already stood at the door for the whole lobby budget, so re-knocking doubles the quota burn against a host who did not answer. Opt in deliberately, never defaulted.",
+   "targets": []
+  },
+  {
+   "key": "JOIN_RETRY_TICK_INTERVAL_S",
+   "class": "defaulted",
+   "default": "5",
+   "description": "#1190 how often the join-retry scheduler is drained for due re-spawn jobs. Bounds the lateness of a retry, not its backoff.",
+   "targets": []
+  },
+  {
    "key": "CALENDAR_SYNC_INTERVAL_S",
    "class": "defaulted",
    "default": "300",

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/__init__.py
@@ -24,6 +24,10 @@ rejects illegal transitions.
   ``failed`` pre-active meeting carries in ``data.join_evidence``: WHAT happened and WHO it belongs
   to. ``classify_join_failure`` / ``attribute_join_failure`` derive them; ``build_join_evidence``
   assembles the persisted block.
+* ``JoinRetryController`` / ``retry_decision`` (P3d, WIRED in #1190) — bounded re-spawn on a
+  transient join failure, with the ``teams_auth_redirect`` trap closed by consulting the join
+  evidence at decision time. ``JoinRetryCoordinator`` is the composition-level trigger the
+  lifecycle callback calls on every pre-active ``failed`` terminal.
 """
 from .join_evidence import (
     JoinFailureAttribution,
@@ -45,13 +49,22 @@ from .machine import (
     TransitionSource,
     can_transition,
 )
+from .join_retry import (
+    JOIN_RETRY_DATA_KEY,
+    PRE_ACTIVE_FAILURE_STAGES,
+    JoinRetryCoordinator,
+    build_respawn_request,
+)
 from .retry import (
+    PERMANENT_EVIDENCE_REASONS,
     JoinRetryController,
     RetryClass,
     RetryOutcome,
     RetryPolicy,
     classify_retry,
+    evidence_reason,
     is_transient,
+    retry_decision,
 )
 from .stop import (
     LeaveCommandPublisher,
@@ -80,7 +93,14 @@ __all__ = [
     "build_join_evidence",
     "classify_join_failure",
     "LeaveCommandPublisher",
+    "JOIN_RETRY_DATA_KEY",
+    "PERMANENT_EVIDENCE_REASONS",
+    "PRE_ACTIVE_FAILURE_STAGES",
     "JoinRetryController",
+    "JoinRetryCoordinator",
+    "build_respawn_request",
+    "evidence_reason",
+    "retry_decision",
     "RetryClass",
     "RetryOutcome",
     "RetryPolicy",

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/join_retry.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/join_retry.py
@@ -1,0 +1,199 @@
+"""Join-retry, WIRED (#1190) — the glue between a terminal ``failed`` meeting and a real re-spawn.
+
+``retry.py`` has shipped a tested :class:`~meeting_api.lifecycle.retry.JoinRetryController` since
+P3d and it has had **zero instantiations outside its own module and tests**. Prod corroborates the
+consequence: every transient ``join_failure`` is one attempt, terminal. This module is the missing
+half — the two seams the controller needs to actually run:
+
+  * **the TRIGGER** — :class:`JoinRetryCoordinator`, called by the lifecycle callback the moment the
+    FSM lands a pre-active ``failed`` terminal. It reads the decision inputs off the DURABLE meeting
+    row (sealed ``completion_reason``, #1075's ``join_evidence``, the attempt counter), asks the
+    controller, and persists the new attempt number so the NEXT terminal knows which attempt it was.
+  * **the DISPATCH** — :func:`build_respawn_request`, the ``schedule.v1`` request one attempt fires:
+    a ``POST /bots`` with ``continue_meeting`` set, which reuses the SAME meeting row (transcripts
+    and recordings stay keyed to it) while minting a FRESH ``meeting_session``. That is what "each
+    retry is a fresh re-spawn" means concretely, and it is why the attempt counter can live in
+    ``meeting.data``: the row survives the retry.
+
+Everything here is offline-drivable: the coordinator takes the controller (itself over an injected
+``Scheduler`` + ``Clock``) and the meeting repo as ports, so the composition tests drive the whole
+path with a ``FakeClock`` and a capturing dispatch — no bot, no docker, no network.
+
+**Pre-active only.** A meeting that reached ``active`` was ADMITTED; whatever killed it afterwards is
+not a join failure and the join taxonomy has nothing truthful to say about it (the same carve
+``machine._capture_join_evidence`` makes). The coordinator refuses those rows outright.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from ..obs import log_event
+from .machine import CompletionReason
+from .retry import JoinRetryController, RetryOutcome
+
+__all__ = [
+    "JOIN_RETRY_DATA_KEY",
+    "PRE_ACTIVE_FAILURE_STAGES",
+    "JoinRetryCoordinator",
+    "build_respawn_request",
+]
+
+#: Where the attempt counter lives on the meeting row. It has to be DURABLE and it has to survive
+#: the re-spawn, which is exactly what ``continue_meeting``'s row reuse buys: ``reopen_meeting``
+#: clears the terminal attribution and keeps everything else, so attempt N is still readable when
+#: attempt N's own terminal lands.
+JOIN_RETRY_DATA_KEY = "join_retry"
+
+#: Failure stages at which the bot had not yet been admitted — the only rows a JOIN retry is about.
+PRE_ACTIVE_FAILURE_STAGES = frozenset({"requested", "joining", "awaiting_admission"})
+
+
+def build_respawn_request(
+    row: Dict[str, Any], attempt: int, *, meeting_api_url: str
+) -> Dict[str, Any]:
+    """The ``schedule.v1`` ``request`` for one retry attempt: a fresh ``POST /bots`` for this row.
+
+    The URL is the canonical ``POST /bots`` edge so the job is a conformant ``schedule.v1`` request
+    and reads truthfully in the job log — but the production dispatch calls ``request_bot`` IN
+    PROCESS rather than looping back over HTTP, the same call the reconcile sweep makes for the same
+    reason (``app._apply_lifecycle_event``: a 127.0.0.1 self-POST is a fragile hop that buys
+    nothing). ``body`` therefore carries every argument that call needs.
+    """
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    return {
+        "method": "POST",
+        "url": f"{(meeting_api_url or '').rstrip('/')}/bots",
+        "headers": {"x-user-id": str(row.get("user_id"))},
+        "body": {
+            "meeting_id": row.get("id"),
+            "attempt": attempt,
+            "user_id": row.get("user_id"),
+            "platform": row.get("platform"),
+            "native_meeting_id": row.get("native_meeting_id"),
+            "meeting_url": (
+                row.get("constructed_meeting_url") or data.get("constructed_meeting_url")
+            ),
+            # THE point of the retry shape: reuse the terminal row, mint a new session.
+            "continue_meeting": True,
+        },
+        "timeout": 30,
+    }
+
+
+def _completion_reason(raw: Any) -> Optional[CompletionReason]:
+    """The sealed reason off the row, or ``None`` for anything unrecognized (which classifies
+    PERMANENT — never retry what we cannot positively class)."""
+    try:
+        return CompletionReason(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _attempt(data: Dict[str, Any]) -> int:
+    block = data.get(JOIN_RETRY_DATA_KEY)
+    if isinstance(block, dict):
+        value = block.get("attempt")
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+    return 0
+
+
+class JoinRetryCoordinator:
+    """Terminal ``failed`` meeting row → at most ``policy.max_attempts`` bounded re-spawns.
+
+    One instance per process, built by the composition root and handed to ``create_app`` as the
+    ``join_retry`` port. ``enabled=False`` (``JOIN_RETRY_ENABLED=false``) makes every call a no-op
+    that still returns ``None`` — the kill switch is one boolean, not a code path.
+    """
+
+    def __init__(
+        self,
+        controller: JoinRetryController,
+        repo: Any,
+        *,
+        meeting_api_url: str = "http://meeting-api:8080",
+        enabled: bool = True,
+    ) -> None:
+        self._controller = controller
+        self._repo = repo
+        self._meeting_api_url = meeting_api_url
+        self.enabled = enabled
+
+    @property
+    def policy(self):
+        return self._controller.policy
+
+    async def on_terminal_failed(self, meeting_row: Any) -> Optional[RetryOutcome]:
+        """Called once per REAL ``failed`` terminal advance (never on an idempotent replay).
+
+        Returns the :class:`RetryOutcome` when a decision was made, ``None`` when the row is not a
+        join failure at all (disabled, post-admission, unknown row). Never raises: a retry is an
+        optimization on a run that has already ended, and it must not be able to fail the bot's
+        lifecycle callback — the caller wraps it too (belt and braces).
+        """
+        if not self.enabled or not isinstance(meeting_row, dict):
+            return None
+        meeting_id = meeting_row.get("id")
+        if not isinstance(meeting_id, int):
+            return None
+        data = meeting_row.get("data") if isinstance(meeting_row.get("data"), dict) else {}
+        if data.get("failure_stage") not in PRE_ACTIVE_FAILURE_STAGES:
+            return None  # admitted (or unattributed) — not a join failure
+        if data.get("stop_requested"):
+            return None  # the user ended this run; never auto-respawn their own stop
+        reason = _completion_reason(data.get("completion_reason"))
+        attempt = _attempt(data)
+
+        def _builder(_meeting_id: int, next_attempt: int) -> Dict[str, Any]:
+            return build_respawn_request(
+                meeting_row, next_attempt, meeting_api_url=self._meeting_api_url
+            )
+
+        outcome = self._controller.on_join_failure(
+            meeting_id,
+            reason,
+            attempt,
+            evidence=data.get("join_evidence"),
+            request_builder=_builder,
+        )
+        if outcome.action == "scheduled_retry":
+            # Durable, because the NEXT terminal has to know which attempt it was — and because the
+            # row is the only thing that survives a re-spawn (the FSM record is per-session).
+            await self._repo.merge_meeting_data(
+                meeting_id,
+                {
+                    JOIN_RETRY_DATA_KEY: {
+                        "attempt": attempt + 1,
+                        "max_attempts": self.policy.max_attempts,
+                        "job_id": outcome.job_id,
+                        "next_at": outcome.next_at,
+                        "reason": outcome.reason,
+                    }
+                },
+            )
+        log_event(
+            "join_retry_decision",
+            audience="system",
+            level="info" if outcome.action == "scheduled_retry" else "warning",
+            span="lifecycle.join_retry",
+            meeting_id=str(meeting_id),
+            fields={
+                "action": outcome.action,
+                "attempt": attempt,
+                "completion_reason": outcome.reason,
+                "join_evidence_reason": (
+                    data.get("join_evidence", {}).get("reason")
+                    if isinstance(data.get("join_evidence"), dict)
+                    else None
+                ),
+                "next_at": outcome.next_at,
+                "job_id": outcome.job_id,
+            },
+        )
+        return outcome
+
+
+#: The production dispatch's shape: given the job's ``request``, fire the re-spawn. The scheduler
+#: calls it SYNCHRONOUSLY from inside the tick, so the production implementation hands the actual
+#: (async) ``request_bot`` call to the running event loop — see ``__main__._attach_background_loops``.
+Dispatch = Callable[[Dict[str, Any]], Dict[str, Any]]

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/retry.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/retry.py
@@ -9,20 +9,41 @@ classification — NB: the PARENT meeting-api has no join-retry; this is NEW con
 modelled on the parent's closest precedent, ``post_meeting.AggregationFailureClass``'s
 transient/permanent split):
 
-  * **TRANSIENT → retry**: ``awaiting_admission_timeout``, ``join_failure`` (network / transient error).
+  * **TRANSIENT (a recoverable failure SHAPE)**: ``awaiting_admission_timeout``, ``join_failure``
+    (network / transient error). NB since #1190 a transient shape is a *candidate* for retry, not a
+    decision — see the two gates below.
   * **PERMANENT → no retry → failed**: ``awaiting_admission_rejected``, ``evicted``,
     ``validation_error``, ``max_bot_time_exceeded``, ``auth_session_missing`` (a re-spawn hits the
     same signed-out profile), and the user terminal ``stopped``.
 
 Bounded to a few attempts (config, default 3). Each attempt is its OWN ``meeting_session`` (a fresh
 ``connectionId``) — the scheduler fires a ``POST /bots`` re-spawn request for the next attempt.
+
+**Two things sit BETWEEN the sealed taxonomy above and an actual re-spawn** (#1190), because the
+sealed label alone is not a retry decision:
+
+  * **The redirect trap.** All 56 ``teams_auth_redirect`` failures in six weeks land as
+    ``completion_reason = join_failure`` — TRANSIENT by the sealed taxonomy, and a hard tenant
+    policy in fact. Retrying them 3× re-spawns against a wall that will never move. #1075's typed
+    join evidence already separates them (``JoinFailureReason.NAVIGATION_FAILURE``: the bot never
+    reached the meeting page), so the decision CONSULTS that evidence rather than re-deriving it —
+    see :data:`PERMANENT_EVIDENCE_REASONS`.
+  * **The admission-timeout arm.** ``awaiting_admission_timeout`` is a transient FAILURE SHAPE but a
+    permanent POLICY: the bot already stood at the door for the whole lobby budget, and re-knocking
+    doubles quota burn for nothing (founder ruling 2026-08-17). It is retried only when
+    :attr:`RetryPolicy.retry_admission_timeout` is explicitly turned on — default OFF.
+
+So ``classify_retry`` / ``is_transient`` stay what they always were, the FAILURE-SHAPE taxonomy, and
+:func:`retry_decision` is the single retryability AUTHORITY the controller obeys: taxonomy, then the
+policy arm, then the evidence guard.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
+from .join_evidence import JoinFailureReason
 from .machine import CompletionReason
 
 
@@ -66,17 +87,98 @@ def is_transient(reason: Optional[CompletionReason]) -> bool:
     return classify_retry(reason) is RetryClass.TRANSIENT
 
 
+#: Typed #1075 join-evidence reasons that make a re-spawn POINTLESS whatever the sealed
+#: ``CompletionReason`` says. The evidence axis is diagnostic by design, so this list is short and
+#: each entry names a wall a fresh session hits identically:
+#:
+#:   * ``NAVIGATION_FAILURE`` — the bot never reached the meeting page at all. THE REDIRECT TRAP:
+#:     ``teams_auth_redirect`` is one of ``join_evidence._NAVIGATION_MARKERS``, so every one of the
+#:     56 six-week failures classifies here while carrying a transient sealed ``join_failure``.
+#:   * ``PLATFORM_REJECTION`` — someone/something on the far side said no.
+#:   * ``AUTH_SESSION_MISSING`` — the browser profile is signed out; a re-spawn restores the same one.
+#:   * ``STOPPED_BEFORE_ADMISSION`` — the USER ended the run. Never auto-respawn a user's own stop.
+#:
+#: ``NEVER_REACHED_LOBBY`` and ``UNKNOWN`` are deliberately NOT here: they are the selector-rot and
+#: genuinely-unknown populations a fresh session can still win, and they are why wiring the retry has
+#: value at all.
+PERMANENT_EVIDENCE_REASONS: frozenset[JoinFailureReason] = frozenset(
+    {
+        JoinFailureReason.NAVIGATION_FAILURE,
+        JoinFailureReason.PLATFORM_REJECTION,
+        JoinFailureReason.AUTH_SESSION_MISSING,
+        JoinFailureReason.STOPPED_BEFORE_ADMISSION,
+    }
+)
+
+
+def evidence_reason(evidence: Any) -> Optional[JoinFailureReason]:
+    """The typed #1075 reason out of a persisted ``data['join_evidence']`` block (or a bare enum).
+
+    Total: an absent block, a foreign shape, or a reason string this control plane does not know
+    yields ``None`` — the decision then rests on the sealed taxonomy alone, exactly as before #1190.
+    """
+    if isinstance(evidence, JoinFailureReason):
+        return evidence
+    if isinstance(evidence, Mapping):
+        raw = evidence.get("reason")
+    elif isinstance(evidence, str):
+        raw = evidence
+    else:
+        return None
+    try:
+        return JoinFailureReason(raw)
+    except ValueError:
+        return None
+
+
 @dataclass
 class RetryPolicy:
-    """Bounded exponential backoff (mirrors the scheduler's Retry shape)."""
+    """Bounded exponential backoff (mirrors the scheduler's Retry shape) + the policy arms."""
 
     max_attempts: int = 3
     backoff: List[float] = field(default_factory=lambda: [30.0, 120.0, 300.0])
+    #: Founder ruling 2026-08-17 — a lobby expiry is NOT retried by default. The bot already spent
+    #: the whole ``bot_spawn.service.LOBBY_BUDGET_MS`` standing at the door; re-knocking doubles the
+    #: quota burn against a host who did not answer the first time. Turning it on is an explicit act
+    #: (``JOIN_RETRY_ADMISSION_TIMEOUT=true``), never a default.
+    retry_admission_timeout: bool = False
 
     def delay_for(self, attempt: int) -> float:
         """Backoff for the 1-indexed ``attempt`` (the last entry is reused past its length)."""
         idx = max(0, min(attempt - 1, len(self.backoff) - 1))
         return self.backoff[idx]
+
+
+def retry_decision(
+    reason: Optional[CompletionReason],
+    *,
+    evidence: Any = None,
+    policy: Optional[RetryPolicy] = None,
+) -> RetryClass:
+    """THE retryability authority (#1190). Three gates, each of which can only say PERMANENT:
+
+    1. **the sealed taxonomy** — :func:`classify_retry`; anything not positively transient stops here;
+    2. **the admission-timeout arm** — a lobby expiry, named EITHER by the sealed reason or by the
+       typed evidence (a ~13min ``join_failure`` whose evidence reads ``admission_timeout`` is the
+       same event under a different label), is permanent unless the policy explicitly enables it;
+    3. **the evidence guard** — :data:`PERMANENT_EVIDENCE_REASONS`, which is what closes the redirect
+       trap.
+
+    Fail-safe in the same direction as ``classify_retry``: every unusable input degrades to
+    PERMANENT-or-unchanged, never to "retry harder".
+    """
+    policy = policy or RetryPolicy()
+    if classify_retry(reason) is RetryClass.PERMANENT:
+        return RetryClass.PERMANENT
+    typed = evidence_reason(evidence)
+    if not policy.retry_admission_timeout and (
+        reason is CompletionReason.AWAITING_ADMISSION_TIMEOUT
+        or typed is JoinFailureReason.ADMISSION_TIMEOUT
+    ):
+        return RetryClass.PERMANENT
+    if typed in PERMANENT_EVIDENCE_REASONS:
+        return RetryClass.PERMANENT
+    return RetryClass.TRANSIENT
 
 
 @dataclass
@@ -99,16 +201,19 @@ class JoinRetryController:
     """Drive bounded join-retries through the runtime scheduler.
 
     ``on_join_failure(meeting_id, reason, attempt)`` is called when a meeting terminates ``failed``
-    with a join-failure reason. If the reason is TRANSIENT and we are under the attempt cap, it
-    schedules a fresh re-spawn (a new ``meeting_session``) at ``now + backoff`` and returns
-    ``scheduled_retry``; if the cap is hit it returns ``exhausted``; a PERMANENT reason returns
+    with a join-failure reason. If :func:`retry_decision` says TRANSIENT and we are under the attempt
+    cap, it schedules a fresh re-spawn (a new ``meeting_session``) at ``now + backoff`` and returns
+    ``scheduled_retry``; if the cap is hit it returns ``exhausted``; a PERMANENT decision returns
     ``permanent`` (no schedule). The scheduler + clock are injected (FakeClock + capture in the eval).
+
+    ``respawn_request`` may be left ``None`` when every call supplies its own ``request_builder``
+    (the composition root's shape: the builder closes over the terminal meeting row).
     """
 
     def __init__(
         self,
         scheduler,
-        respawn_request: RespawnRequestBuilder,
+        respawn_request: Optional[RespawnRequestBuilder] = None,
         *,
         policy: Optional[RetryPolicy] = None,
     ) -> None:
@@ -117,10 +222,24 @@ class JoinRetryController:
         self.policy = policy or RetryPolicy()
 
     def on_join_failure(
-        self, meeting_id: int, reason: Optional[CompletionReason], attempt: int
+        self,
+        meeting_id: int,
+        reason: Optional[CompletionReason],
+        attempt: int,
+        *,
+        evidence: Any = None,
+        request_builder: Optional[RespawnRequestBuilder] = None,
     ) -> RetryOutcome:
+        """Decide + (if transient) schedule the next attempt.
+
+        ``evidence`` is the meeting's persisted ``data['join_evidence']`` block (#1075) — the
+        redirect trap is closed by consulting it here, see :func:`retry_decision`.
+        ``request_builder`` overrides the constructor's builder for THIS call, so a composition root
+        can build a re-spawn request out of the terminal meeting row it is holding rather than
+        keeping per-meeting state on the controller.
+        """
         reason_v = reason.value if reason is not None else None
-        if not is_transient(reason):
+        if retry_decision(reason, evidence=evidence, policy=self.policy) is RetryClass.PERMANENT:
             return RetryOutcome(action="permanent", attempt=attempt, reason=reason_v)
 
         next_attempt = attempt + 1
@@ -131,10 +250,15 @@ class JoinRetryController:
         delay = self.policy.delay_for(next_attempt)
         now = self._scheduler.clock.now()
         execute_at = now + delay
+        build = request_builder or self._respawn_request
+        if build is None:
+            raise ValueError(
+                "JoinRetryController needs a respawn_request builder (constructor or per-call)"
+            )
         job = self._scheduler.schedule(
             {
                 "execute_at": execute_at,
-                "request": self._respawn_request(meeting_id, next_attempt),
+                "request": build(meeting_id, next_attempt),
                 "metadata": {
                     "kind": "join_retry",
                     "meeting_id": meeting_id,

--- a/core/meetings/services/meeting-api/tests/test_join_retry.py
+++ b/core/meetings/services/meeting-api/tests/test_join_retry.py
@@ -13,11 +13,14 @@ import pytest
 
 from meeting_api.lifecycle import (
     CompletionReason,
+    JoinFailureReason,
     JoinRetryController,
     RetryClass,
     RetryPolicy,
     classify_retry,
+    evidence_reason,
     is_transient,
+    retry_decision,
 )
 from meeting_api.scheduling import FakeClock, Scheduler
 
@@ -54,7 +57,7 @@ def test_unknown_reason_is_permanent_failsafe():
 
 # ── harness ─────────────────────────────────────────────────────────────────────────────────────
 
-def _build(max_attempts=3, backoff=(30.0, 120.0, 300.0)):
+def _build(max_attempts=3, backoff=(30.0, 120.0, 300.0), retry_admission_timeout=False):
     """A controller wired to a FakeClock-gated Scheduler with a capturing dispatch.
 
     The dispatch records every fired re-spawn request and mints a NEW session_uid per attempt
@@ -81,7 +84,10 @@ def _build(max_attempts=3, backoff=(30.0, 120.0, 300.0)):
 
     controller = JoinRetryController(
         scheduler, respawn_request,
-        policy=RetryPolicy(max_attempts=max_attempts, backoff=list(backoff)),
+        policy=RetryPolicy(
+            max_attempts=max_attempts, backoff=list(backoff),
+            retry_admission_timeout=retry_admission_timeout,
+        ),
     )
     return controller, scheduler, clock, fired
 
@@ -129,7 +135,7 @@ def test_transient_retries_with_backoff_until_cap():
 def test_transient_then_success_stops_retrying():
     """If a retry succeeds, no further retry is scheduled (the caller stops on success)."""
     controller, scheduler, clock, fired = _build(max_attempts=3)
-    out = controller.on_join_failure(MEETING_ID, CompletionReason.AWAITING_ADMISSION_TIMEOUT, attempt=0)
+    out = controller.on_join_failure(MEETING_ID, CompletionReason.JOIN_FAILURE, attempt=0)
     assert out.action == "scheduled_retry"
     clock.advance(30)
     scheduler.tick()  # retry #1 fires and (in this scenario) succeeds
@@ -158,6 +164,100 @@ def test_user_stop_is_permanent():
     assert out.action == "permanent"
     clock.advance(10_000)
     assert scheduler.tick() == 0
+
+
+# ── #1190: the decision authority — evidence guard + the admission-timeout arm ──────────────────
+
+
+def _evidence(reason: JoinFailureReason, **extra) -> dict:
+    return {"reason": reason.value, "attribution": "system_fault", "source": "bot", **extra}
+
+
+def test_redirect_shaped_join_failure_is_never_retried():
+    """THE REDIRECT TRAP (#1190). All 56 six-week `teams_auth_redirect` failures land as a sealed
+    `join_failure` — TRANSIENT by the taxonomy — and are a hard tenant policy in fact. #1075's typed
+    evidence classifies them `navigation_failure`; the decision consults it and refuses."""
+    ev = _evidence(JoinFailureReason.NAVIGATION_FAILURE, detail="teams_auth_redirect")
+    # the sealed label alone still reads transient — this is exactly why the guard exists
+    assert is_transient(CompletionReason.JOIN_FAILURE)
+    assert retry_decision(CompletionReason.JOIN_FAILURE, evidence=ev) is RetryClass.PERMANENT
+
+    controller, scheduler, clock, fired = _build()
+    out = controller.on_join_failure(
+        MEETING_ID, CompletionReason.JOIN_FAILURE, attempt=0, evidence=ev
+    )
+    assert out.action == "permanent"
+    assert out.job_id is None
+    clock.advance(10_000)
+    assert scheduler.tick() == 0
+    assert fired == []
+
+
+@pytest.mark.parametrize("reason", [
+    JoinFailureReason.NAVIGATION_FAILURE,
+    JoinFailureReason.PLATFORM_REJECTION,
+    JoinFailureReason.AUTH_SESSION_MISSING,
+    JoinFailureReason.STOPPED_BEFORE_ADMISSION,
+])
+def test_permanent_evidence_reasons_override_a_transient_seal(reason):
+    assert retry_decision(
+        CompletionReason.JOIN_FAILURE, evidence=_evidence(reason)
+    ) is RetryClass.PERMANENT
+
+
+@pytest.mark.parametrize("reason", [
+    JoinFailureReason.NEVER_REACHED_LOBBY,   # selector rot — a fresh session can still win
+    JoinFailureReason.UNKNOWN,               # the honest "we don't know" population
+])
+def test_recoverable_evidence_reasons_still_retry(reason):
+    assert retry_decision(
+        CompletionReason.JOIN_FAILURE, evidence=_evidence(reason)
+    ) is RetryClass.TRANSIENT
+
+
+def test_unusable_evidence_falls_back_to_the_sealed_taxonomy():
+    """Evidence is an OVERRIDE, never a precondition: an absent / foreign / newer-vocabulary block
+    leaves the decision exactly where it was before #1190."""
+    for junk in (None, {}, {"reason": "a_reason_from_a_newer_bot"}, "nonsense", 7):
+        assert evidence_reason(junk) in (None, JoinFailureReason.UNKNOWN)
+        assert retry_decision(CompletionReason.JOIN_FAILURE, evidence=junk) is RetryClass.TRANSIENT
+        assert retry_decision(CompletionReason.EVICTED, evidence=junk) is RetryClass.PERMANENT
+
+
+def test_admission_timeout_is_not_retried_by_default():
+    """Founder ruling 2026-08-17: the bot already stood at the door for the whole lobby budget."""
+    controller, scheduler, clock, fired = _build()
+    out = controller.on_join_failure(
+        MEETING_ID, CompletionReason.AWAITING_ADMISSION_TIMEOUT, attempt=0
+    )
+    assert out.action == "permanent"
+    clock.advance(10_000)
+    assert scheduler.tick() == 0
+    assert fired == []
+
+
+def test_admission_timeout_named_only_by_the_evidence_is_also_not_retried():
+    """The ~13min `join_failure` whose evidence reads `admission_timeout` is the SAME event under a
+    different label — the arm has to close on both axes or the ruling leaks through the seal."""
+    controller, scheduler, clock, fired = _build()
+    out = controller.on_join_failure(
+        MEETING_ID, CompletionReason.JOIN_FAILURE, attempt=0,
+        evidence=_evidence(JoinFailureReason.ADMISSION_TIMEOUT),
+    )
+    assert out.action == "permanent"
+    assert scheduler.list(status="pending") == []
+
+
+def test_admission_timeout_retries_when_the_config_arm_is_on():
+    controller, scheduler, clock, fired = _build(retry_admission_timeout=True)
+    out = controller.on_join_failure(
+        MEETING_ID, CompletionReason.AWAITING_ADMISSION_TIMEOUT, attempt=0
+    )
+    assert out.action == "scheduled_retry"
+    assert out.next_at == clock.now() + 30.0
+    clock.advance(30)
+    assert scheduler.tick() == 1
+    assert len(fired) == 1
 
 
 def test_each_attempt_is_a_distinct_idempotent_job():

--- a/core/meetings/services/meeting-api/tests/test_join_retry_wiring.py
+++ b/core/meetings/services/meeting-api/tests/test_join_retry_wiring.py
@@ -1,0 +1,339 @@
+"""#1190 — the WIRING eval: a terminal `failed` meeting actually produces a bounded re-spawn.
+
+`test_join_retry.py` proves the controller in isolation; this proves the two seams that were
+missing, which is the whole content of #1190:
+
+  * the TRIGGER — `JoinRetryCoordinator` reading its decision inputs off the DURABLE meeting row
+    (sealed `completion_reason`, #1075's `join_evidence`, the attempt counter) and persisting the
+    next attempt number, so a chain of terminals produces attempts 1, 2, … and then stops;
+  * the DISPATCH — the scheduled job carrying a real `POST /bots` re-spawn with `continue_meeting`
+    set, so each attempt is a FRESH `meeting_session` on the SAME meeting row.
+
+Plus the app-level leg: the shipped lifecycle callback calls the port on a real `failed` advance and
+NOT on an idempotent redelivery (the bot retries its terminal callback 3x — each replay must not buy
+another bot).
+
+OFFLINE — `FakeClock` + the mirrored `Scheduler` + a capturing dispatch + `InMemoryMeetingRepo`.
+No bot, no docker, no network.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meeting_api import create_app
+from meeting_api.bot_spawn.fakes import InMemoryMeetingRepo
+from meeting_api.lifecycle import (
+    JOIN_RETRY_DATA_KEY,
+    CompletionReason,
+    JoinFailureReason,
+    JoinRetryController,
+    JoinRetryCoordinator,
+    RetryPolicy,
+)
+from meeting_api.scheduling import FakeClock, Scheduler
+
+ENDPOINT = "/bots/internal/callback/lifecycle"
+
+
+# ── harness ─────────────────────────────────────────────────────────────────────────────────────
+
+
+class _Rig:
+    """A coordinator over a FakeClock-gated scheduler + a capturing dispatch + a real repo row.
+
+    `fail(...)` plays ONE terminal failure onto the row exactly as the lifecycle callback would
+    (stamping the terminal attribution into `meeting.data` first), then advances the clock past the
+    backoff and ticks — so `fired` holds the re-spawn requests a deployment would really have sent.
+    """
+
+    def __init__(self, *, max_attempts=3, backoff=(30.0, 120.0, 300.0),
+                 retry_admission_timeout=False, enabled=True):
+        self.repo = InMemoryMeetingRepo()
+        self.clock = FakeClock(start=1000.0)
+        self.fired: list[dict] = []
+        self.sessions = 0
+
+        def dispatch(request):
+            # Stand in for the production dispatch's in-process `request_bot(continue_meeting=True)`:
+            # a NEW session on the SAME meeting row, exactly as a real re-spawn mints.
+            self.sessions += 1
+            uid = f"sess-retry-{request['body']['attempt']}"
+            asyncio.run(self.repo.create_session(meeting_id=self.row["id"], session_uid=uid))
+            self.fired.append({"request": request, "session_uid": uid})
+            return {"status": "spawned", "session_uid": uid}
+
+        self.scheduler = Scheduler(dispatch=dispatch, clock=self.clock)
+        self.coordinator = JoinRetryCoordinator(
+            JoinRetryController(
+                self.scheduler,
+                policy=RetryPolicy(
+                    max_attempts=max_attempts, backoff=list(backoff),
+                    retry_admission_timeout=retry_admission_timeout,
+                ),
+            ),
+            self.repo,
+            meeting_api_url="http://meeting-api:8080",
+            enabled=enabled,
+        )
+        self.row = asyncio.run(self.repo.create_meeting(
+            user_id=7, platform="teams", native_meeting_id="19:meeting_abc",
+            data={"constructed_meeting_url": "https://teams.microsoft.com/l/meetup-join/19:meeting_abc"},
+        ))
+
+    def _row(self) -> dict:
+        """The row as the lifecycle callback would hand it over: a fresh dict, live `data`."""
+        return asyncio.run(self.repo.find_latest(7, "teams", "19:meeting_abc"))
+
+    def fail(self, completion_reason, *, evidence=None, stage="joining", stop_requested=False):
+        """Stamp one terminal `failed` attribution onto the row and run the coordinator on it."""
+        patch = {"completion_reason": getattr(completion_reason, "value", completion_reason),
+                 "failure_stage": stage}
+        if evidence is not None:
+            patch["join_evidence"] = evidence
+        if stop_requested:
+            patch["stop_requested"] = True
+        asyncio.run(self.repo.merge_meeting_data(self.row["id"], patch))
+        self.repo.set_status(self.row["id"], "failed")
+        return asyncio.run(self.coordinator.on_terminal_failed(self._row()))
+
+    def advance_and_tick(self, seconds: float) -> int:
+        self.clock.advance(seconds)
+        return self.scheduler.tick()
+
+    @property
+    def stored_attempt(self) -> int:
+        block = (self._row().get("data") or {}).get(JOIN_RETRY_DATA_KEY) or {}
+        return block.get("attempt", 0)
+
+
+def _evidence(reason: JoinFailureReason, **extra) -> dict:
+    return {"reason": reason.value, "attribution": "system_fault", "source": "bot", **extra}
+
+
+# ── transient: bounded re-spawns at 30/120/300, each a fresh session on the same row ─────────────
+
+
+def test_transient_join_failure_respawns_at_30s():
+    rig = _Rig()
+    out = rig.fail(CompletionReason.JOIN_FAILURE)
+
+    assert out.action == "scheduled_retry"
+    assert out.next_at == 1000.0 + 30.0
+    assert rig.stored_attempt == 1, "the attempt counter must be DURABLE — the row is what survives"
+
+    assert rig.advance_and_tick(29) == 0 and rig.fired == []   # not due yet
+    assert rig.advance_and_tick(1) == 1                        # due → one re-spawn
+    request = rig.fired[0]["request"]
+    assert request["method"] == "POST"
+    assert request["url"].endswith("/bots")
+    body = request["body"]
+    assert body["attempt"] == 1
+    assert body["continue_meeting"] is True, "a retry REUSES the meeting row and mints a new session"
+    assert body["platform"] == "teams"
+    assert body["native_meeting_id"] == "19:meeting_abc"
+    assert body["meeting_url"].endswith("19:meeting_abc")
+    assert request["headers"]["x-user-id"] == "7"
+
+
+def test_bounded_to_three_attempts_with_the_backoff_schedule():
+    """Attempt 0 is the original spawn: max_attempts=3 buys exactly TWO re-spawns, at 30s then 120s,
+    and the third terminal is exhausted — no fourth bot, ever."""
+    rig = _Rig(max_attempts=3)
+
+    assert rig.fail(CompletionReason.JOIN_FAILURE).action == "scheduled_retry"
+    assert rig.advance_and_tick(30) == 1
+
+    second = rig.fail(CompletionReason.JOIN_FAILURE)
+    assert second.action == "scheduled_retry"
+    assert second.next_at == rig.clock.now() + 120.0
+    assert rig.advance_and_tick(120) == 1
+
+    third = rig.fail(CompletionReason.JOIN_FAILURE)
+    assert third.action == "exhausted"
+
+    assert [f["request"]["body"]["attempt"] for f in rig.fired] == [1, 2]
+    assert len({f["session_uid"] for f in rig.fired}) == 2, "each attempt is its OWN session"
+    assert rig.advance_and_tick(10_000) == 0, "exhausted means exhausted"
+
+
+def test_success_on_attempt_two_stops_the_loop():
+    """The loop is terminal-driven: a successful re-spawn produces no further `failed` terminal, so
+    nothing calls the coordinator again and no job is left pending."""
+    rig = _Rig()
+    rig.fail(CompletionReason.JOIN_FAILURE)
+    assert rig.advance_and_tick(30) == 1
+    # attempt 1 joined — no terminal failure arrives
+    assert rig.scheduler.list(status="pending") == []
+    assert rig.advance_and_tick(10_000) == 0
+    assert len(rig.fired) == 1
+
+
+# ── the traps: what must NEVER re-spawn ─────────────────────────────────────────────────────────
+
+
+def test_redirect_shaped_failure_never_retries():
+    """#1190's binding constraint. `teams_auth_redirect` lands as a sealed `join_failure` (transient)
+    and is a hard tenant policy; #1075's evidence types it `navigation_failure` and the wiring
+    refuses. Wiring it without this guard would have re-spawned 3x against a wall."""
+    rig = _Rig()
+    out = rig.fail(
+        CompletionReason.JOIN_FAILURE,
+        evidence=_evidence(JoinFailureReason.NAVIGATION_FAILURE,
+                           detail="TeamsJoinRedirectError: teams_auth_redirect"),
+    )
+    assert out.action == "permanent"
+    assert rig.stored_attempt == 0
+    assert rig.advance_and_tick(10_000) == 0
+    assert rig.fired == []
+
+
+def test_rejected_never_retries():
+    rig = _Rig()
+    out = rig.fail(CompletionReason.AWAITING_ADMISSION_REJECTED, stage="awaiting_admission")
+    assert out.action == "permanent"
+    assert rig.advance_and_tick(10_000) == 0
+    assert rig.fired == []
+
+
+@pytest.mark.parametrize("reason", [
+    CompletionReason.EVICTED,
+    CompletionReason.AUTH_SESSION_MISSING,
+    CompletionReason.STOPPED,
+    CompletionReason.VALIDATION_ERROR,
+    CompletionReason.MAX_BOT_TIME_EXCEEDED,
+])
+def test_permanent_reasons_never_retry(reason):
+    rig = _Rig()
+    assert rig.fail(reason).action == "permanent"
+    assert rig.advance_and_tick(10_000) == 0
+
+
+def test_admission_timeout_never_retries_by_default():
+    """Founder ruling 2026-08-17 — the bot already stood at the door for the whole lobby budget."""
+    rig = _Rig()
+    out = rig.fail(
+        CompletionReason.AWAITING_ADMISSION_TIMEOUT, stage="awaiting_admission",
+        evidence=_evidence(JoinFailureReason.ADMISSION_TIMEOUT),
+    )
+    assert out.action == "permanent"
+    assert rig.advance_and_tick(10_000) == 0
+    assert rig.fired == []
+
+
+def test_admission_timeout_retries_only_behind_the_config_arm():
+    rig = _Rig(retry_admission_timeout=True)
+    out = rig.fail(CompletionReason.AWAITING_ADMISSION_TIMEOUT, stage="awaiting_admission")
+    assert out.action == "scheduled_retry"
+    assert rig.advance_and_tick(30) == 1
+
+
+def test_post_admission_failure_is_not_a_join_failure():
+    """A bot that reached `active` was ADMITTED; whatever killed it afterwards is not a join
+    failure and #1075 files no join evidence for it — the coordinator refuses the row outright."""
+    rig = _Rig()
+    assert rig.fail(CompletionReason.JOIN_FAILURE, stage="active") is None
+    assert rig.advance_and_tick(10_000) == 0
+
+
+def test_user_stop_marker_blocks_a_respawn():
+    rig = _Rig()
+    assert rig.fail(CompletionReason.JOIN_FAILURE, stop_requested=True) is None
+    assert rig.fired == []
+
+
+def test_disabled_is_a_total_no_op():
+    rig = _Rig(enabled=False)
+    assert rig.fail(CompletionReason.JOIN_FAILURE) is None
+    assert rig.advance_and_tick(10_000) == 0
+    assert rig.stored_attempt == 0
+
+
+def test_duplicate_terminal_for_the_same_attempt_is_idempotent():
+    """The idempotency key `join_retry:{meeting_id}:{attempt}` means a doubled decision for the same
+    attempt cannot buy two bots — the belt to the callback's own no-op replay gate."""
+    rig = _Rig()
+    a = rig.fail(CompletionReason.JOIN_FAILURE)
+    # replay the SAME attempt (the counter has moved, so force the original attempt number back)
+    asyncio.run(rig.repo.merge_meeting_data(rig.row["id"], {JOIN_RETRY_DATA_KEY: {"attempt": 0}}))
+    b = rig.fail(CompletionReason.JOIN_FAILURE)
+    assert a.job_id == b.job_id
+    assert len(rig.scheduler.list(status="pending")) == 1
+    assert rig.advance_and_tick(30) == 1
+
+
+# ── the app leg: the shipped lifecycle callback calls the port ──────────────────────────────────
+
+
+def _seeded_app(calls: list, *, session_uid="sess-uid"):
+    repo = InMemoryMeetingRepo()
+    row = asyncio.run(repo.create_meeting(
+        user_id=1, platform="google_meet", native_meeting_id="m1", data={},
+    ))
+    asyncio.run(repo.create_session(meeting_id=row["id"], session_uid=session_uid))
+    repo.set_status(row["id"], "joining")
+
+    async def _join_retry(meeting_row):
+        calls.append(meeting_row)
+
+    return TestClient(create_app(meeting_repo=repo, join_retry=_join_retry)), repo, row
+
+
+def test_failed_terminal_invokes_the_join_retry_port(goldens):
+    calls: list = []
+    client, repo, row = _seeded_app(calls)
+
+    r = client.post(ENDPOINT, json=goldens["failed-join-evidence"])
+
+    assert r.status_code == 200, r.text
+    assert len(calls) == 1, "a terminal `failed` advance must reach the retry port"
+    handed = calls[0]
+    assert handed["id"] == row["id"]
+    # The port is handed the PERSISTED row, so it decides on the same inputs a human would query.
+    assert handed["data"]["completion_reason"] == "awaiting_admission_timeout"
+    assert handed["data"]["join_evidence"]["reason"] == "admission_timeout"
+    # FM-003: the stage is derived server-side from the FSM's own state (the row was `joining`),
+    # never read off the payload — the retry decision inherits that discipline for free.
+    assert handed["data"]["failure_stage"] == "joining"
+
+
+def test_terminal_redelivery_does_not_buy_a_second_retry(goldens):
+    """The bot retries its terminal callback up to 3x. Each replay is an idempotent no-op advance —
+    and must not re-enter the retry decision, or one failure would spawn three bots."""
+    calls: list = []
+    client, repo, row = _seeded_app(calls)
+
+    assert client.post(ENDPOINT, json=goldens["failed-join-evidence"]).status_code == 200
+    assert client.post(ENDPOINT, json=goldens["failed-join-evidence"]).status_code == 200
+    assert client.post(ENDPOINT, json=goldens["failed-join-evidence"]).status_code == 200
+
+    assert len(calls) == 1
+
+
+def test_completed_terminal_never_reaches_the_retry_port(goldens):
+    calls: list = []
+    client, repo, row = _seeded_app(calls)
+    repo.set_status(row["id"], "active")
+
+    assert client.post(ENDPOINT, json=goldens["completed-stopped"]).status_code == 200
+    assert calls == []
+
+
+def test_a_throwing_retry_port_never_fails_the_bot_callback(goldens):
+    """A retry is an optimization on a run that has already ended. It must never be able to turn a
+    healthy terminal callback into an error the bot then retries."""
+    repo = InMemoryMeetingRepo()
+    row = asyncio.run(repo.create_meeting(
+        user_id=1, platform="google_meet", native_meeting_id="m1", data={}))
+    asyncio.run(repo.create_session(meeting_id=row["id"], session_uid="sess-uid"))
+    repo.set_status(row["id"], "joining")
+
+    async def _boom(meeting_row):
+        raise RuntimeError("scheduler exploded")
+
+    client = TestClient(create_app(meeting_repo=repo, join_retry=_boom))
+    r = client.post(ENDPOINT, json=goldens["failed-join-evidence"])
+    assert r.status_code == 200, r.text
+    assert r.json()["meeting_status"] == "failed"


### PR DESCRIPTION
Delivers issue: #1190

**STACKED ON #1075** — base branch is `feat/1059-join-evidence`, not `main`. The redirect guard reads #1075's typed join evidence, so this cannot be reviewed or merged ahead of it. Review the `1190-wire-join-retry` commit only.

## What was missing

`JoinRetryController` has shipped in `lifecycle/retry.py` since P3d with **zero instantiations outside its own module and tests**. Prod corroborates: every transient `join_failure` is a single attempt, terminal. This adds the two seams the controller never had.

**TRIGGER** — `JoinRetryCoordinator` (`lifecycle/join_retry.py`) is called by the lifecycle callback on every REAL pre-active `failed` terminal, and never on an idempotent redelivery (the bot retries its terminal callback 3×; without that gate one failure would buy three bots). It reads its decision inputs off the **durable meeting row** — sealed `completion_reason`, #1075's `join_evidence`, the attempt counter in `data.join_retry` — so the machine decides on the same facts a human queries, and the counter survives the re-spawn.

**DISPATCH** — each attempt is a `POST /bots` carrying `continue_meeting`: the **same meeting row** (transcripts and recordings stay keyed to it), a **fresh `meeting_session`**, idempotency key `join_retry:{meeting_id}:{attempt}`. The production dispatch calls `request_bot` **in process** rather than looping back over HTTP — the same choice `app._apply_lifecycle_event` documents for the reconcile sweep's synthetic terminals.

The scheduler is drained by a new `join-retry` background loop. It is deliberately **not** single-flighted: the job store is in-process, so a cross-replica advisory lock would suppress the tick of the replica actually holding the job.

## The design choice (the redirect trap)

**Consult the join-evidence reason at classify time.** All 56 `teams_auth_redirect` failures in six weeks land as `completion_reason = join_failure`, which the sealed taxonomy calls TRANSIENT while it is a hard tenant policy in fact — wiring as-is would re-spawn 3× against a wall that never moves. #1075 already classifies exactly this population as `JoinFailureReason.NAVIGATION_FAILURE` (`teams_auth_redirect` is one of its markers), so `retry_decision()` reads that verdict and refuses. That is smaller than the alternative: a sealed-reason addition would mean a second marker list in `retry.py` duplicating knowledge `join_evidence.py` already owns, and it would need re-deriving every time the bot's vocabulary moves.

The cost, stated plainly: the whole `NAVIGATION_FAILURE` class is permanent, including a genuinely transient `net::ERR_CONNECTION`. That is deliberate — if a transient-navigation cohort turns out to be worth recovering, the split belongs in `join_evidence`'s taxonomy as a new typed reason, not as a second opinion here.

`classify_retry` / `is_transient` keep their old meaning (the failure *shape*); `retry_decision` is the new single retryability *authority*: sealed taxonomy → policy arm → evidence guard, each of which can only say PERMANENT.

## Policy

| | |
|---|---|
| `join_failure` (transient evidence) | retried, ≤3 attempts total, 30 / 120 / 300s |
| `teams_auth_redirect` / any `navigation_failure` | **never** |
| `awaiting_admission_rejected`, `evicted`, `auth_session_missing`, `stopped`, `validation_error`, `max_bot_time_exceeded` | **never** (already correct in the taxonomy; verified by test) |
| `awaiting_admission_timeout` | **never** by default (founder ruling 2026-08-17) — and on both axes: a `join_failure` whose evidence reads `admission_timeout` is the same event under a different label. Behind `JOIN_RETRY_ADMISSION_TIMEOUT`. |
| failure at stage `active` | not a join failure — refused outright |
| `data.stop_requested` | never auto-respawn a user's own stop |

New env keys, all declared in `config.v1.json` (`targets: []`, matching the other tuning knobs): `JOIN_RETRY_ENABLED` (default **on**), `JOIN_RETRY_MAX_ATTEMPTS` (3), `JOIN_RETRY_BACKOFF_S` (`30,120,300`), `JOIN_RETRY_ADMISSION_TIMEOUT` (off), `JOIN_RETRY_TICK_INTERVAL_S` (5).

## Observation bundle

```
$ .venv/bin/python -m pytest tests/ -q
1020 passed, 5 skipped, 1 warning in 14.17s          # baseline on this branch: 989 passed, 5 skipped

$ .venv/bin/python -m pytest tests/test_join_retry.py tests/test_join_retry_wiring.py -q
45 passed in 0.35s
```

`tests/test_join_retry_wiring.py` drives the composition over `FakeClock` + the mirrored `Scheduler` + a capturing dispatch + `InMemoryMeetingRepo` — offline, no bot, no docker, no network:

- transient `join_failure` → re-spawn scheduled at exactly +30s, request carries `continue_meeting: true` and the row's platform/native id/url
- bounded to 3 attempts at 30 / 120 / 300s, each a distinct session, then `exhausted` — no fourth bot
- success on attempt 2 stops the loop (nothing pending, nothing further fires)
- redirect-shaped failure → zero retries; `rejected` / `evicted` / `auth_session_missing` / `stopped` → zero
- `admission_timeout` → zero; with the config arm on → retries
- app leg over the shipped `TestClient`: a real `failed` advance reaches the port with the persisted row; three terminal redeliveries produce **one** decision; a `completed` terminal never reaches it; a throwing port still returns 200

Config-contract checks that this change could break, run by hand (the node gates need `node_modules`, absent in this environment): the declaration validates against `deploy/contracts/config.v1/config.schema.json`, and the undeclared-env-read scan over `src/` reports none. `gate:readme`, `gate:isolation-py`, `gate:graph-py`, `gate:test-isolation` all green.

## Gaps

- **The live leg is not done.** #1190's second acceptance row — a bot killed mid-join on the staging host, exactly one re-spawn observed in `status_transition` — needs a deploy and is not in this PR.
- **Pending retries are in-process.** The `Scheduler` brick is in-memory, so a replica restart between the decision and the fire drops that attempt. The durable attempt counter means nothing double-fires; it just does not resume. A durable job store is a separate change.
- **The re-spawn passes no `max_concurrent`.** A retry continues an already-approved spawn whose slot the failed bot released; the runtime kernel's `QuotaExceeded` stays the backstop.

---

### Contribution rights

- [ ] `rights:independent` — I wrote this independently and have the right to contribute it.
- [ ] `rights:corporate` — my employer permits this contribution.
- [ ] `rights:unsure` — I am not sure and would like a maintainer to advise.

Left unselected on purpose: only the human submitting this may make that certification.

<!-- vexa-agent -->
