### PR TITLE
feat(terminal): delete a completed meeting's artifacts from the UI (#1197)

### DIFF
--- a/clients/terminal/src/surfaces/__tests__/meetingActions.test.tsx
+++ b/clients/terminal/src/surfaces/__tests__/meetingActions.test.tsx
@@ -57,8 +57,48 @@ describe("actionsFor — offered action sets per status", () => {
       expect(ids(s)).toEqual(["stop"]);
     }
   });
-  it("completed/failed/stopped → Re-send", () => {
-    for (const s of ["completed", "failed", "stopped"]) expect(ids(s)).toEqual(["resend"]);
+  it("completed/failed/stopped → Re-send + Delete data", () => {
+    for (const s of ["completed", "failed", "stopped"]) expect(ids(s)).toEqual(["resend", "erase"]);
+  });
+  it("only the terminal erase carries the danger tone (the plan Delete must not)", () => {
+    expect(actionsFor(row("completed")).find((a) => a.id === "erase")!.tone).toBe("danger");
+    expect(actionsFor(row("idle")).find((a) => a.id === "delete")!.tone).toBe("muted");
+  });
+});
+
+describe("erase — a confirm gate stands in front of an irreversible delete (#116)", () => {
+  const eraseOn = (s: string) => actionsFor(row(s)).find((a) => a.id === "erase")!;
+
+  it("declining the confirm issues NO request at all", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    eraseOn("completed").run();
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepting the confirm DELETEs the row-id meeting route", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    eraseOn("completed").run();
+    const { url, init } = lastFetch();
+    expect(url).toBe(`/api/meetings/${NATIVE}`);
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBeUndefined();
+  });
+
+  it("the prompt names recordings only when the row has one", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    actionsFor({ ...row("completed"), has_recording: true }).find((a) => a.id === "erase")!.run();
+    expect(confirmSpy.mock.calls[0][0]).toContain("transcript and recordings");
+    actionsFor({ ...row("completed"), has_recording: false }).find((a) => a.id === "erase")!.run();
+    expect(confirmSpy.mock.calls[1][0]).not.toContain("recordings");
+  });
+
+  it("the prompt states that the loss is permanent and backups will not recover it", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    eraseOn("completed").run();
+    const prompt = String(confirmSpy.mock.calls[0][0]);
+    expect(prompt).toMatch(/cannot be undone/i);
+    expect(prompt).toMatch(/backups are not a recovery path/i);
   });
 });
 

--- a/clients/terminal/src/surfaces/meeting.tsx
+++ b/clients/terminal/src/surfaces/meeting.tsx
@@ -278,7 +278,10 @@ const badgeFor = (raw?: string) => STATUS_BADGE[raw ?? ""] ?? { label: raw ?? "�
 
 type MeetingActionFailure = { actionId: string; actionLabel: string; native: string; message: string };
 type MeetingActionFailureHandler = (failure: MeetingActionFailure) => void;
-type RowAction = { id: string; label: string; tone: "accent" | "live" | "muted"; run: (onFailure?: MeetingActionFailureHandler) => Promise<void> | void };
+// `live` colours a control acting on a RUNNING bot; `danger` colours an IRREVERSIBLE one on a
+// terminal row. Both render in --danger — the split is so a reader can tell "stop the bot" from
+// "destroy the artifacts" at the call site rather than from the colour.
+type RowAction = { id: string; label: string; tone: "accent" | "live" | "muted" | "danger"; run: (onFailure?: MeetingActionFailureHandler) => Promise<void> | void };
 
 /** A non-ok action response as a STRUCTURED failure (status + backend detail), never a raw body. */
 async function readFailure(r: Response): Promise<ApiError> {
@@ -344,6 +347,21 @@ export function actionsFor(m: MeetingMock): RowAction[] {
   // Delete a PLANNED row — ROW-id addressed (a link-less plan has no platform/native path).
   const del = (onFailure?: MeetingActionFailureHandler) =>
     runMeetingAction({ actionId: "delete", actionLabel: "Delete", native }, fetch(`/api/meetings/${encodeURIComponent(m.id)}`, { method: "DELETE" }), onFailure);
+  // Erase a TERMINAL row's artifacts — same row-id DELETE as `del`, a different act. On a plan that
+  // route removes a row nobody has data in yet; on a completed meeting it destroys the transcript and
+  // the recording objects. Irreversible, and backups are NOT a recovery path (they expire under the
+  // operator's retention policy), so it is confirm-gated: the confirm resolves BEFORE fetch is
+  // constructed, because fetch is eager and a declined confirm must issue no request at all.
+  const erase = (onFailure?: MeetingActionFailureHandler) => {
+    const what = m.has_recording ? "transcript and recordings" : "transcript";
+    const ok = typeof window !== "undefined" && window.confirm(
+      `Permanently delete the ${what} for "${m.title}"?\n\n` +
+      "This cannot be undone, and backups are not a recovery path.",
+    );
+    if (!ok) return;
+    return runMeetingAction({ actionId: "erase", actionLabel: "Delete data", native },
+      fetch(`/api/meetings/${encodeURIComponent(m.id)}`, { method: "DELETE" }), onFailure);
+  };
   // Cancel (clear the time) on a LINK-LESS planned row — PATCH by row id (no native path exists).
   const cancelById = (onFailure?: MeetingActionFailureHandler) =>
     runMeetingAction({ actionId: "cancel", actionLabel: "Cancel", native }, fetch(`/api/meetings/${encodeURIComponent(m.id)}`, {
@@ -381,7 +399,10 @@ export function actionsFor(m: MeetingMock): RowAction[] {
     case "requested": case "joining": case "awaiting_admission": case "needs_help": case "active": case "stopping":
       return [{ id: "stop", label: "Stop", tone: "live", run: stop }];
     case "completed": case "failed": case "stopped": default:
-      return [{ id: "resend", label: "Re-send", tone: "accent", run: send }];
+      return [
+        { id: "resend", label: "Re-send", tone: "accent", run: send },
+        { id: "erase", label: "Delete data", tone: "danger", run: erase },
+      ];
   }
 }
 
@@ -418,7 +439,7 @@ function RowActions({ m, showBadge, reveal, onActionStart, onActionFailure }: { 
         <div style={{ position: "absolute", top: "100%", right: 0, marginTop: 4, minWidth: 132, background: "var(--panel)", border: "1px solid var(--line2)", borderRadius: 8, boxShadow: "0 6px 20px rgba(0,0,0,.28)", padding: 4, zIndex: 40 }}>
           {acts.map((a) => (
             <button key={a.id} onClick={(e) => { e.stopPropagation(); setOpen(false); onActionStart?.(); void a.run(onActionFailure); }}
-              style={{ display: "block", width: "100%", textAlign: "left", background: "transparent", border: "none", color: a.tone === "live" ? "var(--danger)" : a.tone === "muted" ? "var(--t2)" : "var(--accent)", borderRadius: 6, padding: "6px 9px", fontSize: 12, fontWeight: 550, cursor: "pointer" }}
+              style={{ display: "block", width: "100%", textAlign: "left", background: "transparent", border: "none", color: a.tone === "live" || a.tone === "danger" ? "var(--danger)" : a.tone === "muted" ? "var(--t2)" : "var(--accent)", borderRadius: 6, padding: "6px 9px", fontSize: 12, fontWeight: 550, cursor: "pointer" }}
               onMouseEnter={(ev) => (ev.currentTarget.style.background = "var(--panel2)")} onMouseLeave={(ev) => (ev.currentTarget.style.background = "transparent")}>
               {a.label}
             </button>
@@ -769,7 +790,7 @@ export function BotControls({ m, connected = true }: { m: MeetingMock; connected
   return (
     <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flex: "none" }}>
       {acts.map((a) => {
-        const danger = a.tone === "live";
+        const danger = a.tone === "live" || a.tone === "danger";
         return (
           <button key={a.id} disabled={disabled}
             title={!connected ? "Live connection lost — reconnecting…" : undefined}

--- a/deploy/compose/tests/stack_test.py
+++ b/deploy/compose/tests/stack_test.py
@@ -21,6 +21,10 @@ ALWAYS-ON (the routine `gate:compose` subset):
   6b (wiring)       — the scheduler re-spawn path is present; the backoff proof LEANS on the offline
                       P3 test_join_retry.py (deterministic forcing of a transient failure on a LIVE
                       bot is slow/flaky — split documented in the README).
+  8  artifact        — a completed meeting's transcript rows, live segment hash and recording objects
+     deletion         are erased by the owner's DELETE, PROVEN in postgres·minio·redis rather than by
+                      the API's own 404 (which the tombstone alone would satisfy); a non-owner's
+                      DELETE is a 404 that touches nothing.
 
 COMPOSE_BOT=1 (opt-in; real bot lifecycle — slow + needs the ~7GB vexaai/vexa-bot:v012 image):
   3  bot spawn      — POST /bots → meeting-api spawns via runtime → a real `vexa-mtg-…` container
@@ -567,3 +571,108 @@ def test_07_webhook_delivery_outcome_reported(stack):
     assert blocked["fields"]["target_host"] == "receiver.internal"
     assert blocked["fields"]["event_type"] in ("meeting.status_change", "meeting.completed")
     print(f"\n[7/webhook] outcomes reported for meeting {meeting_id}: {sorted(outcomes)}")
+
+
+# ── 8. completed-artifact deletion (#116) ────────────────────────────────────────────────────────
+
+def test_08_completed_artifact_deletion(stack):
+    """Erasure is proven against the STORAGE, never against the API's own answer.
+
+    A `404` from the read path is satisfied by the tombstone alone, so an API-only assertion cannot
+    distinguish real erasure from a hidden-but-retained transcript. Every green below is therefore a
+    direct psql / mc / redis-cli observation of the durable state.
+    """
+    user_id = STATE["user_id"]
+    token = STATE["token_full"]
+    platform, native_id = "google_meet", f"del-{uuid.uuid4().hex[:8]}"
+    meeting_id, session_uid = _insert_meeting(stack, user_id, platform, native_id)
+
+    # --- durable transcript rows (the postgres artifact) -----------------------------------------
+    for i, line in enumerate(("confidential therapy line one", "confidential therapy line two")):
+        stack.psql(
+            "INSERT INTO transcriptions "
+            "(meeting_id, session_uid, segment_id, start_time, end_time, text, language, speaker) "
+            f"VALUES ({meeting_id}, '{session_uid}', 'seg-{i}', {i}.0, {i + 1}.0, "
+            f"'{line}', 'en', 'Patient');"
+        )
+    # --- a live segment in redis (the cache artifact) --------------------------------------------
+    stack.redis_cli("HSET", f"meeting:{meeting_id}:segments", "seg-live",
+                    json.dumps({"text": "confidential live", "start": 0, "end": 1}))
+
+    # --- a real recording object in minio (the object-store artifact) ----------------------------
+    rec_token = mint_meeting_token(meeting_id, user_id, platform, native_id, secret=stack.admin_token)
+    chunk = _canonical_wav(b"gate-compose-deletion-chunk-pcm-payload")
+    body, ctype = _multipart(
+        {"session_uid": session_uid, "media_type": "audio", "media_format": "wav",
+         "chunk_seq": "0", "is_final": "true"},
+        file_field="file", filename="chunk0.wav", file_bytes=chunk, content_type="audio/wav",
+    )
+    code, receipt = http("POST", f"{stack.meeting_api}/internal/recordings/upload",
+                         headers={"Authorization": f"Bearer {rec_token}", "Content-Type": ctype},
+                         body=body)
+    assert code == 200, f"upload → {code} {receipt}"
+    recording_id = receipt["recording_id"]
+    prefix = f"recordings/{user_id}/{recording_id}/"
+    # Finalize so a master exists too — deletion must sweep the whole prefix, not just the chunks.
+    code, master = http("GET", f"{stack.meeting_api}/recordings/{recording_id}/master?type=audio",
+                        headers={"x-user-id": str(user_id)})
+    assert code == 200, f"finalize master → {code} {master}"
+
+    # The lifecycle must be terminal before artifacts are deletable.
+    stack.psql(f"UPDATE meetings SET status = 'completed' WHERE id = {meeting_id};")
+
+    # --- RED: every artifact is present in its own store -----------------------------------------
+    rows_before = int(stack.psql(f"SELECT count(*) FROM transcriptions WHERE meeting_id = {meeting_id};"))
+    objects_before = stack.minio_ls(prefix)
+    redis_before = stack.redis_cli("EXISTS", f"meeting:{meeting_id}:segments").strip()
+    assert rows_before == 2, f"expected 2 durable transcript rows, saw {rows_before}"
+    assert objects_before, f"expected recording objects under {prefix}, saw none"
+    assert redis_before == "1", f"expected the live segment hash to exist, EXISTS → {redis_before}"
+    code, _ = http("GET", f"{stack.gateway}/transcripts/{platform}/{native_id}",
+                   headers={"x-api-key": token})
+    assert code == 200, f"transcript should read 200 before deletion → {code}"
+
+    # --- NEGATIVE CONTROL: a different user cannot erase this meeting ----------------------------
+    other_user = _create_user(stack, max_bots=1)
+    other_token = _mint_token(stack, other_user, "bot,tx")
+    code, _ = http("DELETE", f"{stack.gateway}/meetings/{platform}/{native_id}",
+                   headers={"x-api-key": other_token})
+    assert code == 404, f"non-owner DELETE must be an indistinguishable 404 → {code}"
+    assert int(stack.psql(f"SELECT count(*) FROM transcriptions WHERE meeting_id = {meeting_id};")) == 2, \
+        "a non-owner DELETE destroyed transcript rows"
+    assert stack.minio_ls(prefix), "a non-owner DELETE destroyed recording objects"
+
+    # --- the owner's delete, through the gateway (the customer's own path) -----------------------
+    code, receipt = http("DELETE", f"{stack.gateway}/meetings/{platform}/{native_id}",
+                         headers={"x-api-key": token})
+    assert code == 200, f"owner DELETE → {code} {receipt}"
+
+    # --- GREEN: observed in the stores themselves, not through the API ---------------------------
+    rows_after = int(stack.psql(f"SELECT count(*) FROM transcriptions WHERE meeting_id = {meeting_id};"))
+    objects_after = stack.minio_ls(prefix)
+    redis_after = stack.redis_cli("EXISTS", f"meeting:{meeting_id}:segments").strip()
+    assert rows_after == 0, f"transcript rows SURVIVED deletion in postgres: {rows_after}"
+    assert objects_after == [], f"recording objects SURVIVED deletion in minio: {objects_after}"
+    assert redis_after == "0", f"live segment hash SURVIVED deletion in redis: {redis_after}"
+
+    # The terminal row is retained as lifecycle evidence, carrying the tombstone.
+    assert stack.psql(f"SELECT status FROM meetings WHERE id = {meeting_id};") == "completed"
+    assert stack.psql(
+        f"SELECT data->'artifact_deletion'->>'state' FROM meetings WHERE id = {meeting_id};"
+    ) == "completed"
+    assert stack.psql(
+        f"SELECT data ? 'recordings' FROM meetings WHERE id = {meeting_id};"
+    ) == "f", "recording metadata survived in the meeting JSONB"
+
+    code, _ = http("GET", f"{stack.gateway}/transcripts/{platform}/{native_id}",
+                   headers={"x-api-key": token})
+    assert code == 404, f"transcript still readable after deletion → {code}"
+
+    # Idempotent: the same owner-scoped call on a tombstoned meeting is a successful no-op.
+    code, _ = http("DELETE", f"{stack.gateway}/meetings/{platform}/{native_id}",
+                   headers={"x-api-key": token})
+    assert code == 200, f"repeat DELETE → {code}"
+
+    print(f"\n[8/deletion] meeting {meeting_id}: postgres rows {rows_before}→{rows_after} · "
+          f"minio {len(objects_before)}→{len(objects_after)} objects · redis hash {redis_before}→{redis_after} · "
+          f"non-owner 404 with artifacts intact · tombstone retained")

--- a/docs/changelog.d/1188-completed-artifact-delete.md
+++ b/docs/changelog.d/1188-completed-artifact-delete.md
@@ -1,0 +1,8 @@
+- **Delete a completed meeting's transcript and recordings (#116).** `DELETE /meetings/{meeting_id}`
+  and `DELETE /meetings/{platform}/{native_meeting_id}` previously answered `409` once a meeting had
+  started; for a `completed`/`failed` meeting they now erase its transcript rows, transcript-derived
+  notes and shares, and its recording objects in primary object storage. Deletion is owner-scoped,
+  the terminal meeting row survives as lifecycle evidence, and transcript reads return `404`
+  afterwards. `DELETE /recordings/{recording_id}` erases one recording's objects on its own. Erasure
+  covers live storage, not backups or object-store version history, which expire under the
+  operator's retention policy. See [Meetings API](/api/meetings).

--- a/docs/changelog.d/1198-ui-delete-completed-artifacts.md
+++ b/docs/changelog.d/1198-ui-delete-completed-artifacts.md
@@ -1,0 +1,6 @@
+- **Delete a completed meeting's data from the terminal UI (#1197).** Finished meetings
+  (`completed`/`failed`/`stopped`) now carry a **Delete data** action that erases the transcript and
+  any recordings, alongside the existing `Re-send`. It is confirm-gated and irreversible — the prompt
+  names what will be destroyed and states that backups are not a recovery path. Planned meetings keep
+  their existing `Delete`, which only removes a plan that has no data yet. See
+  [Meetings API](/api/meetings).


### PR DESCRIPTION
**Delivers issue:** #1197
**Stacked on #1188 — base is `codex/116-completed-artifact-delete`, not `main`.** Until that merges,
`DELETE` on a completed meeting answers `409` and this button would surface an error. Land it after,
never before. Retarget to `main` once #1188 is in.

Our legal pages say transcripts are kept *"until you delete via API/UI"*. #1188 delivers the API
half. Terminal rows offered only `Re-send`, so a finished confidential meeting could not be erased
from the product the user is actually looking at. This is the UI half.

## Contribution rights

<!-- Untouched on purpose: a legal certification an agent must not select.
     @DmitriyG228 — tick exactly one before merge. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

The commit carries `Signed-off-by: DmitriyG228`, matching repository-local identity. **No box is
ticked — a human must select one.**

## What this changes

`completed`/`failed`/`stopped` rows gain a **Delete data** action firing the same owner-scoped
`DELETE /api/meetings/{id}` that #1188 implements. Three details are the actual design:

1. **The confirm resolves before `fetch` is constructed.** `fetch` is eager — building it inside the
   action and then deciding would fire the request regardless of the answer. A declined confirm must
   issue *no request at all*, and that is the property most likely to rot silently, so it has a test
   that fails if the guard is removed.
2. **The prompt does not overpromise recovery.** It names what is destroyed (recordings only when the
   row has one), says it cannot be undone, and states backups are not a recovery path — matching the
   boundary #1188's docs draw. A confirmation that implies a backup could restore this would be worse
   than none.
3. **A `danger` tone, rather than reusing `live`.** Both render in `--danger`, but `live` means "acts
   on a running bot" — reusing it for an irreversible erase on a terminal row would make the call
   site lie. The plan-row `Delete` deliberately keeps its `muted` tone: it removes a row nobody has
   data in yet, which is not the same act.

## Observation bundle

- **C1 — the offered set and the endpoint.** ran: `meetingActions.test.tsx` · saw: `23 passed` ·
  concluded: terminal rows now offer `["resend", "erase"]`, erase fires exactly
  `DELETE /api/meetings/{id}` with no body, and the plan `Delete` is untouched.
- **C2 — the guard is real, not decorative.** ran: deleted the `if (!ok) return;` line and re-ran ·
  saw: `× declining the confirm issues NO request at all` → `1 failed | 22 passed` · restored ⇒
  `23 passed`. concluded: the gate is load-bearing; a future refactor that drops it goes red rather
  than silently shipping a one-click irreversible delete.
- **C3 — no collateral.** ran: full terminal suite, then `gate:node` · saw: `54 files, 403 passed`
  and `18 package(s) · build + test green` · concluded: the added tone and action break nothing.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 | C1 — `["resend","erase"]` on completed/failed/stopped; plan rows unchanged |
| A2 | **C2** — the red→green pair on the guard itself |
| A3 | C1 — prompt asserted to name recordings conditionally, to say "cannot be undone", and to state backups are not a recovery path |
| A4 | C1 — `DELETE /api/meetings/{id}`, no body |
| A5 | C1 — erase is `danger`, plan `Delete` is `muted` |

## Docs diff (D6c)

`docs/changelog.d/` fragment. No reference page changes: #1188 already documents the endpoint's two
meanings and the backup boundary, and this PR adds no API surface — it puts an existing route behind
a button.

## Security checks (required on the diff)

No dependency added. The destructive path is owner-scoped **server-side** by #1188 — this button
carries no authorization of its own and must not be read as adding any; it can only ask for what the
caller already owns, and an unowned id answers `404`.

The review question worth asking here is not "is the request right" but **"can this fire without a
human meaning it"** — that is what C2 pins.

## What is undone

1. **No live UI witness.** The behavior is proven at the unit layer; I have not run the terminal in a
   browser and clicked the button against a live stack. That is the honest gap in this bundle.
2. **`window.confirm`, not an in-app dialog.** It matches the surrounding code (`schedule` uses
   `window.prompt`) and is unbypassable, which is the property that matters for an irreversible act.
   A styled dialog is a real improvement, and a separate one.

## Validation request

**Preferred validator:** any competent non-author. **Deployment:** hosted, after #1188.

Watch two things: the confirm cannot be skipped, and **Cancel leaves the data intact** — check the
transcript still reads back afterwards, not just that the row looks unchanged.

## Rung

**PR open**, stacked on an unmerged PR. Not merged, not released, not in any image, not deployed,
not witnessed live.

<!-- vexa-agent -->
