### PR TITLE
fix(meetings): one auto-join per backoff per occurrence, and three disclosure leaks

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -68,18 +68,25 @@ CALENDAR_SYNC_CONCURRENCY = 4
 
 async def _sync_user_calendars(store, redis_client, user_id: int, configs: list,
                                *, publish=None, client=None) -> list:
-    """Sync ONE user's calendar connections and return their per-connection stamps.
+    """Sync ONE user's calendar connections and return their ACTIVE connections' stamps.
 
     The user's meeting rows are read ONCE here and threaded through every connection —
     ``sync_user`` keeps the list current as it writes, so a second calendar sees the first one's
     inserts without a second full read. Each connection's stamp is persisted under its own key,
-    exactly as the per-connection panel reads it."""
+    exactly as the per-connection panel reads it.
+
+    Every config passed in IS synced, tombstones included — that empty-feed pass is how a deleted
+    connection's sources get stripped and its rows retired. But a tombstone's stamp is neither
+    persisted nor RETURNED: the returned list is what ``aggregate_stamps`` turns into the
+    user-visible ``calendars[]`` roster, and a connection the user deleted has no place in it."""
     from .calendar_sync import run_user_sync, store_stamp
 
     rows = await store.list_meetings(user_id)
     stamps = []
     for cfg in configs:
         stamp = await run_user_sync(store, cfg, publish=publish, rows=rows, client=client)
+        if cfg.get("deleted"):
+            continue
         stamp["calendar_id"] = cfg.get("calendar_id")
         stamp["calendar_name"] = cfg.get("calendar_name")
         await store_stamp(redis_client, user_id, stamp, cfg.get("calendar_id"))
@@ -185,11 +192,13 @@ def build_production_app():
             return None
         import json as _json
 
-        from .calendar_sync import aggregate_stamps, fetch_configs, store_stamp
+        from .calendar_sync import (active_configs, aggregate_stamps, fetch_configs,
+                                    store_stamp)
 
         configs = await fetch_configs(admin_api_url, internal_secret)
-        selected = [c for c in configs or [] if c.get("user_id") == user_id and
-                    (calendar_id is None or c.get("calendar_id") == calendar_id)]
+        # ACTIVE connections only — a deleted one is the background sweep's to retire, never a feed
+        # the user can sync and never a roster the response names. None here → the route's 404.
+        selected = active_configs(configs, user_id, calendar_id)
         if not selected:
             return None
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
@@ -20,6 +20,14 @@ Failures are LOUD, never silent (P18/P10): a cap/quota rejection or spawn failur
 ``data.auto_join_error`` (+ ``data.auto_join_next_retry`` backoff so one bad row doesn't re-fire
 every tick) — the terminal surfaces it on the meeting row.
 
+Every dispatch also stamps ``data.auto_join_last_attempt`` BEFORE it is made. That records the
+attempt rather than its outcome, so it outlives outcomes this row never gets to write: a spawn
+that succeeds and a bot that then fails to JOIN takes the row terminal, calendar sync creates a
+sibling row for the same occurrence, and without the stamp the sibling was due the instant it
+existed — one bot every sync interval for the whole grace window (live 2026-08-17, user 13820).
+``calendar_sync`` carries the stamp onto the sibling, and ``due_rows`` honours it, so the ceiling
+is ONE dispatch per backoff interval per occurrence however many rows that occurrence acquires.
+
 ``auto_join`` defaults ON when the key is absent — planning a meeting with a time means the bot
 comes, opting out is the explicit act.
 
@@ -57,9 +65,22 @@ def _parse_iso(value: Any) -> Optional[datetime]:
 
 
 def due_rows(rows: list[dict], *, now: datetime,
-             lead_s: float = DEFAULT_LEAD_S, grace_s: float = DEFAULT_GRACE_S) -> list[dict]:
+             lead_s: float = DEFAULT_LEAD_S, grace_s: float = DEFAULT_GRACE_S,
+             retry_backoff_s: float = DEFAULT_RETRY_BACKOFF_S) -> list[dict]:
     """The PURE due-filter over ``scheduled`` rows: auto_join on (absent = on), a joinable link,
-    ``scheduled_at`` inside [start - lead, start + grace], and past any error backoff."""
+    ``scheduled_at`` inside [start - lead, start + grace], past any error backoff, and past the
+    backoff owed to the LAST DISPATCH ATTEMPT for this occurrence (``auto_join_last_attempt``).
+
+    The last-attempt rule is what bounds the retry storm to one dispatch per backoff interval per
+    occurrence. ``auto_join_next_retry`` only ever covered failures the sweep itself saw (a cap
+    rejection, a spawn refusal): when the spawn SUCCEEDED and the bot then failed to join, the row
+    went terminal carrying no backoff at all, calendar sync recreated a sibling for the same
+    occurrence, and the sibling was immediately due — a fresh bot every sync interval until the
+    grace window closed (measured live 2026-08-17: meeting 26265 failed 20:06:25, sibling 26267
+    created 20:06:35, dispatched 20:06:42). ``auto_join_last_attempt`` records the ATTEMPT rather
+    than its outcome, so it survives the outcome — and calendar sync carries it onto the sibling it
+    creates for the same occurrence, which is how the backoff outlives the row it was earned on.
+    """
     due: list[dict] = []
     for row in rows:
         data = row.get("data") if isinstance(row.get("data"), dict) else {}
@@ -74,6 +95,9 @@ def due_rows(rows: list[dict], *, now: datetime,
             continue
         retry_at = _parse_iso(data.get("auto_join_next_retry"))
         if retry_at is not None and now < retry_at:
+            continue
+        attempted_at = _parse_iso(data.get("auto_join_last_attempt"))
+        if attempted_at is not None and now < attempted_at + timedelta(seconds=retry_backoff_s):
             continue
         due.append(row)
     return due
@@ -173,7 +197,8 @@ async def auto_join_tick(
     gate = transcribe_gate if transcribe_gate is not None else _production_transcribe_gate
 
     rows = await repo.list_scheduled_meetings()
-    due = due_rows(rows, now=now, lead_s=lead_s, grace_s=grace_s)
+    due = due_rows(rows, now=now, lead_s=lead_s, grace_s=grace_s,
+                   retry_backoff_s=retry_backoff_s)
     counters = {"due": len(due), "spawned": 0, "already": 0, "errors": 0,
                 "skipped_uncapped": 0, "skipped_live": 0}
     # Duplicate-dispatch guard (defense in depth behind create_meeting_guarded's dedup): a bot
@@ -248,6 +273,12 @@ async def auto_join_tick(
                 continue
 
         data = row.get("data") if isinstance(row.get("data"), dict) else {}
+        # Record the ATTEMPT before making it. Written first so it survives everything the attempt
+        # can do next — including the two outcomes that leave no trace on this row: a spawn that
+        # succeeds and a bot that then fails to join (the row goes terminal, and calendar sync
+        # recreates it), or a process death mid-spawn. The stamp is what ``due_rows`` and calendar
+        # sync both read to hold the next dispatch for one backoff interval.
+        await repo.merge_meeting_data(row["id"], {"auto_join_last_attempt": now.isoformat()})
         try:
             await request_bot(
                 repo, runtime,

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/__init__.py
@@ -9,11 +9,13 @@ from .service import parse_ics, sync_user
 
 
 def __getattr__(name):  # lazy: runner imports back from this package
-    if name in ("run_user_sync", "aggregate_stamps", "store_stamp", "read_stamp"):
+    if name in ("run_user_sync", "aggregate_stamps", "store_stamp", "read_stamp",
+                "active_configs"):
         from . import runner
         return getattr(runner, name)
     raise AttributeError(name)
 
 
 __all__ = ["parse_ics", "sync_user", "fetch_ics", "fetch_configs", "build_ics_client",
-           "run_user_sync", "aggregate_stamps", "store_stamp", "read_stamp"]
+           "run_user_sync", "aggregate_stamps", "store_stamp", "read_stamp",
+           "active_configs"]

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/runner.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/runner.py
@@ -12,6 +12,28 @@ from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Optional
 
 
+def active_configs(configs: Optional[list], user_id: int,
+                   calendar_id: Optional[str] = None) -> list[dict]:
+    """This user's LIVE calendar connections — a TOMBSTONE is never one.
+
+    A deleted connection still gets synced by the BACKGROUND sweep (an empty feed, so ``sync_user``
+    strips its sources and retires the rows only it managed), but it is not something the user can
+    sync on demand and it is not part of any roster they may read back: they removed it. Measured
+    live 2026-08-17 — a user whose only connections were deleted got ``200`` from
+    ``POST /user/calendar/sync`` plus a ``calendars[]`` array naming every one of them, where the
+    documented answer is ``404`` (no active feed) and the roster is not theirs to see.
+
+    A PAUSED connection is NOT a tombstone: the user still has it, the panel still lists it, and
+    syncing it is how a pause takes effect. Only ``deleted`` is excluded.
+    """
+    return [
+        cfg for cfg in configs or []
+        if cfg.get("user_id") == user_id
+        and not cfg.get("deleted")
+        and (calendar_id is None or cfg.get("calendar_id") == calendar_id)
+    ]
+
+
 async def run_user_sync(
     store: Any,
     cfg: dict,

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/service.py
@@ -21,6 +21,14 @@ Adoption by link is by (platform, native) over EVERY non-terminal row, intent AN
 imported event whose meeting is already running attaches its calendar identity to that live row
 (``_attach_live_source`` — uid/sources only, never ``auto_join``/``scheduled_at``/status) rather
 than importing a sibling: a sibling is what the auto-join sweep sends a SECOND bot for.
+
+TERMINAL rows are past and are never matched or adopted — but they are not weightless. When the
+auto-join sweep dispatched for one (``data.auto_join_last_attempt``) and its bot then FAILED to
+join, the row goes terminal, leaves this module's index, and the very next sweep of the same feed
+finds an unmatched UID and creates a sibling that is due on sight — a fresh bot every sync
+interval until the grace window closes (live 2026-08-17, user 13820). So the replacement row
+CARRIES that spent attempt forward (``_spent_attempt``), scoped to the OCCURRENCE and not the UID:
+a weekly meeting whose bot failed today still sends one tomorrow.
 """
 from __future__ import annotations
 
@@ -33,6 +41,12 @@ from ..collector.meeting_link import find_meeting_link
 # started occurrence still counts as "next" (keeps a due row alive while the auto-join grace runs).
 DEFAULT_HORIZON_DAYS = 14
 DEFAULT_LOOKBACK_S = 900
+
+# How close two ``scheduled_at`` values must be to be the SAME occurrence of a UID. A feed nudging
+# a start by a few seconds between sweeps is the same occurrence; the next occurrence of any real
+# recurrence is minutes-to-days away, never inside this. Deliberately far below the shortest
+# plausible recurrence interval — the suppression this scopes must NEVER reach tomorrow's meeting.
+OCCURRENCE_MATCH_S = 300
 
 _INTENT = ("idle", "scheduled")
 _TERMINAL = ("completed", "failed")
@@ -135,9 +149,16 @@ def _component_metadata(comp, *, include_components: bool = True,
     Values stay in their canonical iCalendar representation so timezone identifiers, recurrence
     rules, custom X-properties, attendee parameters, and provider extensions survive without a
     provider-specific schema. Repeated properties remain ordered arrays.
+
+    ``recursive=False`` is load-bearing: icalendar's ``property_items`` defaults to walking the
+    component's DESCENDANTS as well, so the flat property map for one VEVENT absorbed every OTHER
+    VEVENT's UID/SUMMARY/DESCRIPTION/ATTENDEE/LOCATION when called on the Calendar, and every
+    VALARM's when called on an event (measured live 2026-08-17: four UIDs inside one event's
+    snapshot — a cross-event property bleed AND O(N²) stored bytes). Child components still ride
+    along, in their own ``components`` entries, via the explicit ``subcomponents`` walk below.
     """
     properties: dict[str, list[dict]] = {}
-    for raw_name, value in comp.property_items():
+    for raw_name, value in comp.property_items(recursive=False):
         name = str(raw_name).upper()
         if name in ("BEGIN", "END"):
             continue
@@ -356,6 +377,58 @@ async def _attach_live_source(store, user_id: int, row: dict, ev: dict, *,
     return await attach(user_id, row["id"], calendar_uid=ev["uid"], calendar_sources=sources)
 
 
+def _parse_iso(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _same_occurrence(left: Any, right: Any) -> bool:
+    """Do two ISO ``scheduled_at`` values name the same occurrence (within OCCURRENCE_MATCH_S)?"""
+    a, b = _as_utc(_parse_iso(left)), _as_utc(_parse_iso(right))
+    if a is None or b is None:
+        return False
+    return abs((a - b).total_seconds()) <= OCCURRENCE_MATCH_S
+
+
+def _spent_attempt(row: dict, ev: dict) -> Optional[dict]:
+    """The auto-join backoff a TERMINAL row leaves owed to a re-import of the SAME occurrence.
+
+    ``None`` when nothing is owed. A terminal row that carries ``auto_join_last_attempt`` is a row
+    the auto-join sweep dispatched a bot for; if the bot then failed to join, the row went terminal
+    and dropped out of both the sweep's predicate and this module's ``by_uid`` index — so the very
+    next sync saw an unmatched UID and created a sibling, which was due on sight. The result was a
+    fresh bot every sync interval until the grace window expired (live 2026-08-17, user 13820:
+    26265 failed 20:06:25 → 26267 created 20:06:35 → dispatched 20:06:42).
+
+    The fix is to carry the attempt forward, not to suppress the import: the row still appears, the
+    terminal still renders it, and it re-arms once the backoff the sweep owns has elapsed.
+
+    Scoped to the OCCURRENCE, never to the UID: a weekly meeting whose bot failed today must still
+    send one tomorrow. Same UID + a ``scheduled_at`` outside ``OCCURRENCE_MATCH_S`` is a different
+    occurrence and owes nothing.
+    """
+    if row.get("status") not in _TERMINAL:
+        return None
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    attempted_at = data.get("auto_join_last_attempt")
+    if not isinstance(attempted_at, str) or not attempted_at:
+        return None  # positive evidence only — a row nothing auto-dispatched owes no backoff
+    if not _same_occurrence(data.get("scheduled_at"), ev.get("scheduled_at")):
+        return None
+    error = data.get("auto_join_error")
+    if not isinstance(error, str) or not error:
+        # The sweep's spawn SUCCEEDED and the bot failed later, so no spawn-side error was ever
+        # stamped. Say the true thing rather than nothing (P18) — this row is not firing yet, and
+        # the terminal has to be able to tell the user why.
+        error = (f"the previous auto-join for this occurrence ended '{row.get('status')}' "
+                 f"(meeting {row.get('id')}) — waiting out the auto-join backoff before retrying")
+    return {"auto_join_last_attempt": attempted_at, "auto_join_error": error}
+
+
 def _remember(rows: list, row: dict) -> None:
     """Fold a created/updated row back into the caller's row list — the sweep reads a user's rows
     ONCE per tick and drives every one of their connections off that one list."""
@@ -394,6 +467,10 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
         rows = await store.list_meetings(user_id)
     by_uid: dict[str, dict] = {}
     by_native: dict[tuple, dict] = {}
+    # Terminal rows the auto-join sweep ALREADY dispatched for, newest attempt per UID. Not an
+    # adoption index — a terminal row is never adopted — but the carrier of the retry backoff a
+    # spent attempt owes, so recreating the row cannot re-arm it instantly (see _spent_attempt).
+    terminal_attempts: dict[str, dict] = {}
     # Series workspace map (prep-v3 slice a): a NEW occurrence of a known calendar UID inherits
     # the workspace of the series' newest row that carries one — recurring meetings keep their
     # room without asking. An explicit unbind writes `workspace_unbound` on the row, which the
@@ -420,6 +497,18 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
                 series_stamp[uid] = stamp
                 series_ws[uid] = None if data.get("workspace_unbound") else data.get("workspace_id")
         if row.get("status") in _TERMINAL:
+            # A terminal row is past — it never matches, adopts, or gets touched. But if the
+            # auto-join sweep dispatched for it, the backoff that dispatch earned is still owed,
+            # and the row about to replace it is the only thing left to carry it. Keep the NEWEST
+            # attempt per UID; the occurrence check happens where the event is known.
+            attempted_at = _as_utc(_parse_iso(data.get("auto_join_last_attempt")))
+            if uid and attempted_at is not None:
+                held = terminal_attempts.get(uid)
+                previous = _as_utc(_parse_iso(
+                    (held.get("data") or {}).get("auto_join_last_attempt")
+                )) if held else None
+                if previous is None or previous <= attempted_at:
+                    terminal_attempts[uid] = row
             continue
         if uid and uid not in by_uid:
             by_uid[uid] = row
@@ -528,6 +617,10 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
             continue  # never duplicate a row that already exists for this link
 
         inherited_ws = series_ws.get(ev["uid"])  # None = no binding OR tombstoned — both mean "don't"
+        # A spent auto-join attempt on THIS occurrence rides onto the new row, so the sweep sees the
+        # backoff it already earned instead of a virgin row that is due on sight.
+        spent = _spent_attempt(terminal_attempts[ev["uid"]], ev) \
+            if ev["uid"] in terminal_attempts else None
         created = await store.create_planned_meeting(
             user_id,
             platform=ev["platform"] or "unknown",   # link-less imports use the link-less-plan shape
@@ -545,6 +638,8 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
             workspace_id=inherited_ws,
             workspace_source="series" if inherited_ws else None,
             attendees=ev.get("attendees") or None,
+            auto_join_last_attempt=(spent or {}).get("auto_join_last_attempt"),
+            auto_join_error=(spent or {}).get("auto_join_error"),
         )
         if isinstance(created, dict) and not created.get("error"):
             by_native[(ev["platform"], ev["native_meeting_id"])] = created

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -922,10 +922,17 @@ class SqlAlchemyTranscriptStore:
                                      title=None, scheduled_at=None, meeting_url=None,
                                      workspace_id=None, auto_join=True, calendar_uid=None,
                                      calendar_source=None,
-                                     workspace_source=None, attendees=None) -> dict:
+                                     workspace_source=None, attendees=None,
+                                     auto_join_last_attempt=None,
+                                     auto_join_error=None) -> dict:
         """Insert a PLANNED row (intent status, no bot). Takes the SAME per-user advisory lock as
         ``bot_spawn.create_meeting_guarded`` so planned-create serializes with concurrent spawns
-        and calendar sync; the unique partial index remains the DB-level backstop (→ duplicate)."""
+        and calendar sync; the unique partial index remains the DB-level backstop (→ duplicate).
+
+        ``auto_join_last_attempt``/``auto_join_error`` seed the row with a backoff already earned
+        elsewhere — calendar sync passes them when this row replaces a terminal one the auto-join
+        sweep already dispatched for, so the replacement is not due the instant it exists. Written
+        in the INSERT, not patched after, so no sweep tick can see the row without them."""
         from sqlalchemy import bindparam, select, text
         from sqlalchemy.exc import IntegrityError
 
@@ -951,6 +958,10 @@ class SqlAlchemyTranscriptStore:
             data["calendar_managed"] = True
         if attendees:
             data["attendees"] = attendees
+        if auto_join_last_attempt:
+            data["auto_join_last_attempt"] = auto_join_last_attempt
+        if auto_join_error:
+            data["auto_join_error"] = auto_join_error
         status = "scheduled" if scheduled_at else "idle"
 
         async with self._session_factory() as db:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -422,6 +422,8 @@ def build_router(
     # --- the ROW-id PATCH/DELETE bodies, factored out so the native-keyed aliases (#579 C1) forward
     # to the SAME owner-scoped, FSM-refusing logic once they have resolved (platform, native) → row. ---
     async def _apply_meeting_patch(user_id: int, meeting_id: int, payload) -> dict:
+        from .projection import project_calendar_sources
+
         if not isinstance(payload, dict):
             raise HTTPException(status_code=422, detail="body must be an object")
 
@@ -485,7 +487,12 @@ def build_router(
             native_id=row.get("native_meeting_id"), status=row.get("status"),
             when=(row.get("data") or {}).get("scheduled_at"), log_event=log_event,
         )
-        return row
+        # The raw ICS event snapshot never rides a response — on ANY read path, and the PATCH's
+        # echo of the updated row is one (measured live 2026-08-17: a PATCH reply carried the
+        # source's uid + event.resolved_start/calendar/component). Projected HERE, at the response
+        # edge, so both the row-id and the native-keyed alias get it and the STORED row — which
+        # calendar sync reconciles against — keeps the snapshot.
+        return {**row, "data": project_calendar_sources(row.get("data"))}
 
     async def _apply_meeting_delete(user_id: int, meeting_id: int) -> None:
         result = await store.delete_planned_meeting(user_id, meeting_id)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -379,7 +379,9 @@ class InMemoryTranscriptStore:
                                      title=None, scheduled_at=None, meeting_url=None,
                                      workspace_id=None, auto_join=True, calendar_uid=None,
                                      calendar_source=None,
-                                     workspace_source=None, attendees=None):
+                                     workspace_source=None, attendees=None,
+                                     auto_join_last_attempt=None,
+                                     auto_join_error=None):
         if self._dup_non_terminal(user_id, platform, native_meeting_id):
             return {"error": "duplicate"}
         data: dict = {"auto_join": bool(auto_join)}
@@ -402,6 +404,10 @@ class InMemoryTranscriptStore:
             data["calendar_managed"] = True
         if attendees:
             data["attendees"] = attendees
+        if auto_join_last_attempt:
+            data["auto_join_last_attempt"] = auto_join_last_attempt
+        if auto_join_error:
+            data["auto_join_error"] = auto_join_error
         mid = self.seed_meeting(
             user_id=user_id, platform=platform, native_meeting_id=native_meeting_id,
             status="scheduled" if scheduled_at else "idle",

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -160,6 +160,8 @@ class TranscriptStore(Protocol):
         calendar_source: Optional[dict] = None,
         workspace_source: Optional[str] = None,
         attendees: Optional[list] = None,
+        auto_join_last_attempt: Optional[str] = None,
+        auto_join_error: Optional[str] = None,
     ) -> dict:
         """Create a PLANNED meeting row — status ``scheduled`` (when ``scheduled_at`` is set) or
         ``idle`` — with NO bot spawned. Link-less plans use ``platform='unknown'`` +
@@ -169,7 +171,13 @@ class TranscriptStore(Protocol):
         Serializes with concurrent spawns via the same per-user advisory lock
         ``create_meeting_guarded`` takes. Returns the created row (``list_meetings`` shape), or
         ``{"error": "duplicate"}`` when a NON-TERMINAL row already exists for
-        ``(user, platform, native)`` (the route maps it → 409)."""
+        ``(user, platform, native)`` (the route maps it → 409).
+
+        ``auto_join_last_attempt`` / ``auto_join_error`` seed the row with an auto-join backoff
+        earned elsewhere. Calendar sync passes them when this row replaces a TERMINAL row the
+        auto-join sweep already dispatched for, so a re-imported occurrence is not due the instant
+        it exists. They must land in the INSERT, never in a follow-up patch: a sweep tick between
+        the two would spawn."""
         ...
 
     async def update_planned_meeting(

--- a/core/meetings/services/meeting-api/tests/test_auto_join_sweep.py
+++ b/core/meetings/services/meeting-api/tests/test_auto_join_sweep.py
@@ -304,3 +304,39 @@ async def test_live_keys_ignores_terminal_and_linkless_rows():
         {"id": 3, "user_id": None, "platform": PLAT, "native_meeting_id": "x"},
     ])
     assert keys == {(USER, PLAT, NID): 1}
+
+
+# ---- the attempt stamp that outlives the row (live 2026-08-17: a bot every ~2.5 min) --------
+
+async def test_dispatch_records_the_attempt_before_making_it():
+    """``auto_join_last_attempt`` records the ATTEMPT, not its outcome — so it survives the two
+    outcomes that write nothing back to this row: a spawn that succeeds and a bot that then fails
+    to JOIN (the row goes terminal and calendar sync recreates it), and a death mid-spawn."""
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    mid = _seed(repo)
+    await _tick(repo, runtime)
+    assert repo._meetings[mid]["data"]["auto_join_last_attempt"] == NOW.isoformat()
+
+
+async def test_attempt_stamp_survives_a_failed_spawn_and_holds_the_next_tick():
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient(fail=True)
+    mid = _seed(repo)
+    assert (await _tick(repo, runtime))["errors"] == 1
+    assert repo._meetings[mid]["data"]["auto_join_last_attempt"] == NOW.isoformat()
+    assert (await _tick(repo, runtime, now=NOW + timedelta(seconds=1)))["due"] == 0
+
+
+def test_due_rows_hold_a_row_carrying_a_spent_attempt_until_the_backoff_expires():
+    """The pure guard behind the storm fix: a row seeded with an attempt calendar sync carried
+    over from the terminal row it replaced is NOT due until one backoff interval has passed."""
+    def row(**extra):
+        return {"id": 26267, "user_id": USER, "platform": PLAT, "native_meeting_id": NID,
+                "data": {"scheduled_at": NOW.isoformat(), **extra}}
+
+    spent = (NOW - timedelta(seconds=10)).isoformat()
+    assert not due_rows([row(auto_join_last_attempt=spent)], now=NOW, retry_backoff_s=300)
+    assert due_rows([row(auto_join_last_attempt=spent)],
+                    now=NOW + timedelta(seconds=291), retry_backoff_s=300)
+    # a garbage stamp never silently pins a row out of the sweep forever
+    assert due_rows([row(auto_join_last_attempt="not-a-time")], now=NOW)
+    assert due_rows([row()], now=NOW)

--- a/core/meetings/services/meeting-api/tests/test_calendar_sync.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_sync.py
@@ -720,3 +720,167 @@ async def test_shared_rows_stay_current_across_a_users_calendars():
     (row,) = await store.list_meetings(USER)
     assert [source["id"] for source in row["data"]["calendar_sources"]] == ["work", "personal"]
     assert [entry["id"] for entry in rows] == [row["id"]]
+
+
+# ---- the auto-join retry storm (live 2026-08-17, user 13820) --------------------------------
+
+class _SharedStore(InMemoryTranscriptStore):
+    """The transcript store, over rows the bot-spawn repo also understands.
+
+    Production has ONE ``meetings`` table that calendar sync and the auto-join sweep both reach
+    through different ports. The two in-memory fakes model that table twice, and the storm lives in
+    the SEAM between them — so the reproduction below has to share one table, not two. The extra
+    keys are the repo shape's (``id`` is the dict key in the store, a column in the repo)."""
+
+    def seed_meeting(self, **kwargs) -> int:
+        mid = super().seed_meeting(**kwargs)
+        row = self._meetings[mid]
+        row["id"] = mid
+        row["platform_specific_id"] = row["native_meeting_id"]
+        return mid
+
+
+def _storm_rig():
+    """(store, repo, runtime) over ONE row table — calendar sync writes it, the sweep dispatches
+    off it, exactly as the two services do against one Postgres."""
+    from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
+
+    store = _SharedStore()
+    repo = InMemoryMeetingRepo()
+    repo._meetings = store._meetings   # one table, two ports
+    repo._next_id = 10_000             # spawn-minted ids never collide with the store's
+    return store, repo, FakeRuntimeClient()
+
+
+async def _sweep(repo, runtime, at):
+    from meeting_api.bot_spawn.auto_join import auto_join_tick
+
+    return await auto_join_tick(
+        repo, runtime, transcribe_gate=lambda: None, now=at,
+        token_secret="s", redis_url="redis://r", allow_uncapped=True,
+    )
+
+
+START = datetime(2026, 7, 8, 15, 0, 0, tzinfo=timezone.utc)   # the event's own start
+
+
+async def test_failed_auto_join_does_not_restorm_through_a_recreated_row():
+    """Spawn → the bot fails to join → re-sync the SAME feed → NO second dispatch inside the
+    backoff, exactly ONE once it expires.
+
+    The measured shape (staging 2026-08-17, user 13820): meeting 26265's bot failed at 20:06:25,
+    calendar sync recreated the same UID as row 26267 at 20:06:35, and the sweep dispatched again
+    at 20:06:42 — one bot every ~2.5 minutes until the 600s grace closed. The terminal row dropped
+    out of sync's UID index, so a sibling was created; the sibling was brand new, so it carried no
+    backoff and was due on sight.
+    """
+    store, repo, runtime = _storm_rig()
+    feed = _ics(_event(start="20260708T150000Z"))
+
+    # 1. the feed imports and the sweep sends the bot
+    await sync_user(store, USER, parse_ics(feed, now=START))
+    assert (await _sweep(repo, runtime, START))["spawned"] == 1
+    (first,) = await store.list_meetings(USER)
+    assert first["status"] == "requested"
+    assert first["data"]["auto_join_last_attempt"] == START.isoformat()
+
+    # 2. the bot fails to JOIN — the row goes terminal with no spawn-side error on it
+    store._meetings[first["id"]]["status"] = "failed"
+
+    # 3. the next sync of the same feed recreates the occurrence (the terminal row is past)…
+    failed_at = START + timedelta(seconds=10)
+    result = await sync_user(store, USER, parse_ics(feed, now=failed_at))
+    assert result["counts"]["created"] == 1
+    fresh = next(r for r in await store.list_meetings(USER) if r["id"] != first["id"])
+    assert fresh["status"] == "scheduled"
+    # …carrying the spent attempt, and saying why it is not firing (P18 — never a silent hold)
+    assert fresh["data"]["auto_join_last_attempt"] == START.isoformat()
+    assert "backoff" in fresh["data"]["auto_join_error"]
+
+    # 4. …and it does NOT re-dispatch inside the backoff — the storm, absent
+    for delay in (10, 150, 299):
+        counters = await _sweep(repo, runtime, START + timedelta(seconds=delay))
+        assert counters["due"] == 0 and counters["spawned"] == 0, f"re-stormed at +{delay}s"
+    assert len(runtime.specs) == 1
+
+    # 5. one retry once the backoff expires (still inside the 600s grace)
+    counters = await _sweep(repo, runtime, START + timedelta(seconds=301))
+    assert counters == {"due": 1, "spawned": 1, "already": 0, "errors": 0,
+                        "skipped_uncapped": 0, "skipped_live": 0}
+    assert len(runtime.specs) == 2
+
+
+async def test_recreated_row_carries_the_attempt_only_for_the_same_occurrence():
+    """The suppression is OCCURRENCE-scoped, never UID-scoped: a weekly meeting whose bot failed
+    today still sends one next week. Same UID, a start a week out → nothing owed, armed on sight."""
+    store, _repo, _runtime = _storm_rig()
+    weekly = _ics(_event(start="20260708T150000Z", rrule="FREQ=WEEKLY"))
+
+    # today's occurrence was dispatched for and ended failed
+    store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status="failed", data={
+            "calendar_uid": "uid-1", "auto_join": True,
+            "scheduled_at": START.isoformat(),
+            "auto_join_last_attempt": START.isoformat(),
+        },
+    )
+
+    # sync two hours later — today's occurrence is out of the window, next week's is the event
+    later = START + timedelta(hours=2)
+    result = await sync_user(store, USER, parse_ics(weekly, now=later))
+
+    assert result["counts"]["created"] == 1
+    fresh = next(r for r in await store.list_meetings(USER) if r["status"] == "scheduled")
+    assert fresh["data"]["scheduled_at"] == "2026-07-15T15:00:00+00:00"
+    assert "auto_join_last_attempt" not in fresh["data"]   # a different occurrence owes nothing
+    assert "auto_join_error" not in fresh["data"]
+
+
+async def test_terminal_row_the_sweep_never_dispatched_for_owes_no_backoff():
+    """Positive evidence only. A row that reached terminal WITHOUT an auto-join dispatch (a manual
+    "Send bot now", a meeting the user simply held) is not evidence of a spent attempt — the
+    re-imported occurrence arms normally."""
+    store, _repo, _runtime = _storm_rig()
+    feed = _ics(_event(start="20260708T150000Z"))
+    store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status="completed", data={"calendar_uid": "uid-1", "auto_join": True,
+                                  "scheduled_at": START.isoformat()},
+    )
+
+    await sync_user(store, USER, parse_ics(feed, now=START + timedelta(seconds=10)))
+
+    fresh = next(r for r in await store.list_meetings(USER) if r["status"] == "scheduled")
+    assert "auto_join_last_attempt" not in fresh["data"]
+    assert "auto_join_error" not in fresh["data"]
+
+
+# ---- one event's snapshot is ONE event's (live 2026-08-17: 4 UIDs in one snapshot) -----------
+
+def test_event_snapshot_holds_only_its_own_properties():
+    """icalendar's ``property_items`` walks DESCENDANTS by default, so every event's stored
+    snapshot embedded every OTHER event's UID/SUMMARY/DESCRIPTION/ATTENDEE/LOCATION — a
+    cross-event disclosure inside one row, and O(N²) stored bytes. Measured live: four UIDs in
+    one event's snapshot."""
+    feed = _ics(
+        _event(uid="uid-1", summary="Mine", location="https://meet.google.com/abc-defg-hij",
+               description="my agenda"),
+        _event(uid="uid-2", summary="Someone else's board review",
+               location="https://meet.google.com/xyz-wxyz-abc", description="their agenda"),
+        _event(uid="uid-3", summary="A third", location="https://meet.google.com/qqq-wwww-eee"),
+    )
+    events = parse_ics(feed, now=NOW)["events"]
+    assert len(events) == 3
+
+    for event in events:
+        props = event["metadata"]["component"]["properties"]
+        assert [entry["value"] for entry in props["UID"]] == [event["uid"]]
+        assert len(props["SUMMARY"]) == 1
+        assert len(props["LOCATION"]) == 1
+    # and the calendar-level snapshot is the CALENDAR's properties, not every event's
+    calendar = events[0]["metadata"]["calendar"]["properties"]
+    assert set(calendar) == {"VERSION", "PRODID"}
+    # nobody else's agenda rides in mine
+    assert "their agenda" not in str(events[0]["metadata"])
+    assert "Someone else's board review" not in str(events[0]["metadata"])

--- a/core/meetings/services/meeting-api/tests/test_calendar_sync_edges.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_sync_edges.py
@@ -161,3 +161,61 @@ def test_patching_auto_join_off_survives_the_next_calendar_sweep():
     (row,) = asyncio.run(store.list_meetings(28))
     assert row["data"]["auto_join"] is False
     assert row["data"]["calendar_name"] == "Work calendar"
+
+
+# ---- ACTIVE connections only — a tombstone is neither syncable nor listable ------------------
+# Live 2026-08-17: a user whose calendar connections were ALL deleted got 200 from
+# POST /user/calendar/sync plus a `calendars[]` array naming every deleted one. The documented
+# answer is 404 (no active feed), and a roster the user already removed is not theirs to read back.
+
+def _cfg(calendar_id, *, user_id=13820, **extra):
+    return {"user_id": user_id, "calendar_id": calendar_id,
+            "calendar_name": f"{calendar_id} calendar",
+            "ics_url": f"https://cal.example/{calendar_id}.ics", **extra}
+
+
+def test_active_configs_excludes_tombstones_and_other_users():
+    from meeting_api.calendar_sync import active_configs
+
+    configs = [
+        _cfg("work"),
+        _cfg("dead", deleted=True),
+        _cfg("paused-but-mine", paused=True),
+        _cfg("someone-elses", user_id=99),
+    ]
+    assert [c["calendar_id"] for c in active_configs(configs, 13820)] == [
+        "work", "paused-but-mine",   # PAUSED is not a tombstone — the user still has it
+    ]
+
+
+def test_active_configs_empty_when_every_connection_is_deleted():
+    """The exact staging shape → the sync-now hook returns None → the route answers 404."""
+    from meeting_api.calendar_sync import active_configs
+
+    configs = [_cfg("dead-1", deleted=True), _cfg("dead-2", deleted=True)]
+    assert active_configs(configs, 13820) == []
+    assert active_configs(configs, 13820, "dead-1") == []
+    assert active_configs(None, 13820) == []
+
+
+def test_active_configs_scopes_to_one_connection():
+    from meeting_api.calendar_sync import active_configs
+
+    configs = [_cfg("work"), _cfg("personal")]
+    assert [c["calendar_id"] for c in active_configs(configs, 13820, "personal")] == ["personal"]
+    assert active_configs(configs, 13820, "never-connected") == []
+
+
+def test_no_response_ever_names_a_deleted_connection():
+    """Whatever a stamp roster is built from, a tombstone is not in it."""
+    from meeting_api.calendar_sync import active_configs, aggregate_stamps
+
+    configs = [_cfg("work"), _cfg("dead", deleted=True)]
+    stamps = [{"calendar_id": c["calendar_id"], "calendar_name": c["calendar_name"],
+               "last_sync": "2026-08-17T20:06:00+00:00", "last_error": None,
+               "counts": {"created": 0, "updated": 0, "cancelled": 0}}
+              for c in active_configs(configs, 13820)]
+
+    aggregate = aggregate_stamps(stamps)
+    assert [s["calendar_id"] for s in aggregate["calendars"]] == ["work"]
+    assert "dead" not in str(aggregate)

--- a/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
+++ b/core/meetings/services/meeting-api/tests/test_slim_meetings_list.py
@@ -153,6 +153,11 @@ def test_transcript_by_id_projects_calendar_sources_and_keeps_the_stored_snapsho
     The transcript reaches workspace members and share recipients as well as the owner, and the
     snapshot carries the whole calendar component — attendees, organizer, description. So the
     projection is unconditional, and the STORED row still has everything the sweep reconciles on.
+
+    "Unconditional" means EVERY response edge, and a PATCH's echo of the row it just wrote is one
+    — it was the edge this test's claim did not actually cover (live 2026-08-17: a PATCH reply
+    carried the source's uid plus event.resolved_start / calendar / component). The test below
+    pins both PATCH routes.
     """
     store = InMemoryTranscriptStore()
     mid = _seed_heavy(store)
@@ -168,6 +173,40 @@ def test_transcript_by_id_projects_calendar_sources_and_keeps_the_stored_snapsho
     (stored,) = store._meetings[mid]["data"]["calendar_sources"]
     assert stored["event"]["component"]["properties"]
     assert stored["uid"] == "weekly-sync@example.com"
+
+
+PROJECTED_SOURCE = {
+    "id": "calendar-primary",
+    "name": "Primary calendar",
+    "auto_join": True,
+    "bot_name": "Work Notes",
+}
+
+
+@pytest.mark.parametrize("path", ["/meetings/{mid}", "/meetings/google_meet/abc-defg-hij"])
+def test_patch_response_projects_calendar_sources_on_both_routes(path):
+    """The PATCH echo is a response, so the raw ICS snapshot is not in it — on the row-id route and
+    on the native-keyed alias, which forward to the same handler. Measured live 2026-08-17: a
+    ``PATCH /meetings/{id}`` reply shipped ``uid`` + ``event.resolved_start``/``calendar``/
+    ``component`` back to the caller."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status="scheduled", data=dict(HEAVY_DATA),
+    )
+
+    r = _client(store).patch(path.format(mid=mid), headers=HEADERS,
+                             json={"title": "Renamed by the user"})
+
+    assert r.status_code == 200
+    (source,) = r.json()["data"]["calendar_sources"]
+    assert source == PROJECTED_SOURCE          # no uid, no event snapshot
+    assert "resolved_start" not in r.text
+    assert r.json()["data"]["title"] == "Renamed by the user"
+    # …and the STORED row keeps everything calendar sync reconciles against
+    (stored,) = store._meetings[mid]["data"]["calendar_sources"]
+    assert stored["uid"] == "weekly-sync@example.com"
+    assert stored["event"]["component"]["properties"]
 
 
 # ── C2 · default page size + honest has_more ───────────────────────────────────────────────────────


### PR DESCRIPTION
Four defects from the staging API sweep of 2026-08-17 (user 13820), all in `core/meetings/services/meeting-api`. Evidence is live staging logs.

## 1. Auto-join retry storm

```
20:06:25  meeting 26265 -> failed (bot never joined; terminal)
20:06:35  calendar sync recreates the same UID as row 26267
20:06:42  the auto-join sweep dispatches a second bot off the fresh row
```

Repeating every ~2.5 min until the 600s grace closed.

`calendar_sync/service.py` drops terminal rows from its by-UID index, so the next sweep of the same feed sees an unmatched UID and creates a sibling row. The sibling is brand new, so it carries no backoff and is due on sight. `auto_join_next_retry` could not help: it only ever recorded failures the sweep itself saw, and here the **spawn succeeded** — the bot failed later, inside the FSM.

The sweep now stamps `data.auto_join_last_attempt` **before** each dispatch — the attempt, not its outcome, so it survives an outcome this row never gets to write. `due_rows` honours it for one `retry_backoff_s`, and calendar sync carries it (plus a stated reason) onto the row it creates in a terminal row's place.

Scoped to the **occurrence**, not the UID: same UID with a `scheduled_at` more than `OCCURRENCE_MATCH_S` away is a different occurrence and owes nothing, so a weekly meeting whose bot failed today still sends one next week. Ceiling: one dispatch per backoff interval per occurrence, however many rows that occurrence acquires.

## 2. Tombstone roster disclosure + contract miss

`POST /user/calendar/sync` with zero active connections returned `200` plus a `calendars[]` array naming every **deleted** connection. Documented answer is `404`. Tombstones are still synced by the background sweep — that empty-feed pass is how their rows retire — but are no longer syncable on demand and no longer appear in any roster.

## 3. `PATCH /meetings/{id}` leaked the full event snapshot

The reply carried the calendar source's `uid` plus `event.resolved_start` / `calendar` / `component`. The projection every other read path applies now covers both PATCH routes (row-id and native-keyed); the stored row keeps the snapshot calendar sync reconciles against.

## 4. Cross-event property bleed in stored snapshots

icalendar's `property_items` defaults to `recursive=True`, so every event's snapshot embedded every **other** event's UID / SUMMARY / DESCRIPTION / ATTENDEE / LOCATION — measured: 4 UIDs in one snapshot. A disclosure inside one row, and O(N²) stored bytes. Now `recursive=False`; child components still ride along via the explicit `subcomponents` walk.

## Tests

946 → 959 passing, 5 skipped. New:

- the storm reproduced end to end over one shared row table — spawn → fail terminal → re-sync the same feed → no dispatch inside the backoff, exactly one after it
- a recurring event's next occurrence still arms
- a terminal row the sweep never dispatched for owes no backoff (positive evidence only)
- the sweep's pure `due_rows` guard, incl. a malformed stamp never pinning a row out forever
- the `404` contract: tombstones excluded, paused connections kept, roster never names a deleted one
- both PATCH routes projected, stored row intact
- single-event property scope

Not merged, not deployed.

Refs #1150

<!-- vexa-agent -->
