### PR TITLE
fix(auto-join): dispatch 2 min early, wait 15 min in the lobby (#1208)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -537,8 +537,12 @@ def _attach_background_loops(
     # is fetched from admin-api's internal edge. Fail-closed: unset ADMIN_API_URL/INTERNAL_API_SECRET
     # makes the cap unresolvable, so the sweep REFUSES to spawn (AUTO_JOIN_ALLOW_UNCAPPED=1 is the
     # explicit self-host opt-in); an UNREACHABLE identity likewise skips the tick.
+    from .bot_spawn.auto_join import DEFAULT_LEAD_S
+
     auto_join_interval = float(os.getenv("AUTO_JOIN_SWEEP_INTERVAL_S", "30"))
-    auto_join_lead = float(os.getenv("AUTO_JOIN_LEAD_S", "60"))
+    # The DEFAULT lives in one place (``auto_join.DEFAULT_LEAD_S``) so the sweep's own default and
+    # the entrypoint's env fallback can never drift apart. Deploy values may still override it.
+    auto_join_lead = float(os.getenv("AUTO_JOIN_LEAD_S", str(DEFAULT_LEAD_S)))
     auto_join_grace = float(os.getenv("AUTO_JOIN_GRACE_S", "600"))
     auto_join_backoff = float(os.getenv("AUTO_JOIN_RETRY_BACKOFF_S", "300"))
     admin_api_url = (os.getenv("ADMIN_API_URL") or "").rstrip("/")

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
@@ -49,7 +49,11 @@ from .ports import MaxBotsExceeded, QuotaExceeded, SpawnFailed
 from .service import DuplicateMeeting, request_bot
 
 # Sweep cadence/window env vocabulary (config.v1: all optional, sane defaults).
-DEFAULT_LEAD_S = 60          # AUTO_JOIN_LEAD_S — join this many seconds BEFORE scheduled_at
+# 120s (#1208): the bot must be STANDING IN THE LOBBY when the meeting starts, not setting out then
+# — spawn, browser boot and the join flow all happen inside the lead. Two minutes early plus the
+# 15-minute lobby budget (``bot_spawn.service.lobby_budget_ms``) is the pair that makes "the bot is
+# already there" true for a host who joins late.
+DEFAULT_LEAD_S = 120         # AUTO_JOIN_LEAD_S — join this many seconds BEFORE scheduled_at
 DEFAULT_GRACE_S = 600        # AUTO_JOIN_GRACE_S — never join more than this AFTER scheduled_at
 DEFAULT_RETRY_BACKOFF_S = 300  # AUTO_JOIN_RETRY_BACKOFF_S — error-stamped rows wait this long
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -102,8 +102,10 @@ def _resolve_automatic_leave(value: Optional[object]) -> dict:
     Admission keeps its deployment default. The active-phase silence timeout is omitted when the
     caller does not set it, allowing the bot module's configurable ten-minute default to apply.
     """
+    from .service import lobby_budget_ms
+
     if value is None:
-        return {"waitingRoomTimeout": 600_000}
+        return {"waitingRoomTimeout": lobby_budget_ms()}
     if not isinstance(value, dict):
         raise HTTPException(status_code=422, detail="automatic_leave must be an object")
 
@@ -125,7 +127,7 @@ def _resolve_automatic_leave(value: Optional[object]) -> dict:
             raise HTTPException(status_code=422, detail=f"automatic_leave.{primary} must be a positive integer")
         return raw
 
-    waiting_room = timeout("max_wait_for_admission", "waiting_room_timeout") or 600_000
+    waiting_room = timeout("max_wait_for_admission", "waiting_room_timeout") or lobby_budget_ms()
     resolved = {"waitingRoomTimeout": waiting_room}
     no_one_joined = timeout("no_one_joined_timeout")
     everyone_left = timeout("max_time_left_alone", "everyone_left_timeout")

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -51,15 +51,44 @@ from .ports import (
 
 # Re-exported here (defined in ports.py to avoid an adapters→service circular import) so callers that
 # already do ``from .service import DuplicateMeeting`` (the router) keep working.
-__all__ = ["request_bot", "construct_meeting_url", "DuplicateMeeting", "LOBBY_BUDGET_MS"]
+__all__ = [
+    "request_bot", "construct_meeting_url", "DuplicateMeeting",
+    "LOBBY_BUDGET_MS", "DEFAULT_LOBBY_BUDGET_S", "lobby_budget_ms",
+]
 
 # The waiting-room budget the control plane ISSUES to every bot it spawns (``automatic_leave
 # .waitingRoomTimeout``): how long the bot may sit in a lobby, silently polling, before it gives up
 # and reports its own ``awaiting_admission_timeout``. It is a DEADLINE WE WROTE, so every window the
 # control plane measures a not-yet-admitted bot against must outlast it — the reconcile sweep derives
-# its pre-active grace from this constant (``lifecycle.reconcile.default_preactive_grace``) rather
+# its pre-active grace from this budget (``lifecycle.reconcile.default_preactive_grace``) rather
 # than carrying a second, independently-drifting number (#862).
-LOBBY_BUDGET_MS = 600_000
+#
+# 15 minutes by default (#1208): an auto-joined bot is dispatched BEFORE the scheduled start
+# (``AUTO_JOIN_LEAD_S``), so it reaches the lobby before a human host is there to admit it — the
+# budget has to cover the human's lateness, not just the click. The prior 10-minute budget is
+# exactly the ~10.4-minute banding the admission-timeout failure class shows in prod (#267): bots
+# were dying ON the deadline we handed them, which is a budget too small, not a join defect.
+DEFAULT_LOBBY_BUDGET_S = 900
+LOBBY_BUDGET_MS = DEFAULT_LOBBY_BUDGET_S * 1000
+
+
+def lobby_budget_ms() -> int:
+    """The lobby budget (ms) this deployment issues — ``VEXA_LOBBY_BUDGET_S``, default 900.
+
+    Read at CALL time, never frozen at import, so every window derived from it (the reconcile
+    sweep's pre-active grace) sees the same value the spawn path issues even when the env is set
+    after import. Unparseable or non-positive values fall back to the default rather than issuing a
+    deadline of zero — a bot given a zero budget gives up before it has knocked."""
+    raw = os.getenv("VEXA_LOBBY_BUDGET_S")
+    if raw is None or not raw.strip():
+        return DEFAULT_LOBBY_BUDGET_S * 1000
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return DEFAULT_LOBBY_BUDGET_S * 1000
+    if seconds <= 0:
+        return DEFAULT_LOBBY_BUDGET_S * 1000
+    return int(seconds * 1000)
 
 # Non-terminal statuses (parent's active set) — a prior meeting in one of these blocks a new spawn.
 _ACTIVE_STATUSES = ("requested", "joining", "awaiting_admission", "active", "stopping")
@@ -497,7 +526,7 @@ async def request_bot(
         # Explicit caller windows win; otherwise omit everyoneLeftTimeout so the bot's
         # silence-window module default applies (the lobby window stays forgiving for
         # human-in-the-loop dashboard joins).
-        automatic_leave=automatic_leave or {"waitingRoomTimeout": LOBBY_BUDGET_MS},
+        automatic_leave=automatic_leave or {"waitingRoomTimeout": lobby_budget_ms()},
     )
 
     # 5. Spawn over runtime.v1.

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -375,8 +375,15 @@
   {
    "key": "RECONCILE_PREACTIVE_GRACE_S",
    "class": "defaulted",
-   "default": "660",
-   "description": "grace (s) before a meeting whose bot has NOT yet reached the room (requested/joining/awaiting_admission) is reconciled — derived from the lobby budget the spawn issues (waitingRoomTimeout 600s) plus headroom, so the control plane is never less patient than the deadline it handed the bot (#862)",
+   "default": "960 (VEXA_LOBBY_BUDGET_S + 60)",
+   "description": "grace (s) before a meeting whose bot has NOT yet reached the room (requested/joining/awaiting_admission) is reconciled — DERIVED from the lobby budget the spawn issues (VEXA_LOBBY_BUDGET_S, default 900s) plus 60s of headroom, so the control plane is never less patient than the deadline it handed the bot (#862, #1208)",
+   "targets": []
+  },
+  {
+   "key": "VEXA_LOBBY_BUDGET_S",
+   "class": "defaulted",
+   "default": "900",
+   "description": "lobby budget (s) issued to every spawned bot as automatic_leave.waitingRoomTimeout — how long it may wait for admission before reporting awaiting_admission_timeout. 15 min so an auto-joined bot outwaits a late host (#1208); the reconcile pre-active grace derives from it, so raising it never leaves a waiter reaped by a shorter watchdog. An explicit automatic_leave.max_wait_for_admission on POST /bots still wins.",
    "targets": []
   },
   {
@@ -506,8 +513,8 @@
   {
    "key": "AUTO_JOIN_LEAD_S",
    "class": "defaulted",
-   "default": "60",
-   "description": "auto-join lead (s) — the bot is sent this long before data.scheduled_at",
+   "default": "120",
+   "description": "auto-join lead (s) — the bot is sent this long before data.scheduled_at, so it is standing in the lobby at the scheduled start rather than setting out then (#1208). Deploy values may override.",
    "targets": []
   },
   {

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
@@ -169,14 +169,15 @@ def _workload_evidence(bot_container_id: Optional[str], info: Optional[dict]) ->
 def default_preactive_grace() -> float:
     """The pre-active reap floor, DERIVED from the lobby budget the control plane itself issues.
 
-    A not-yet-admitted bot holds a deadline WE wrote (``bot_spawn.service.LOBBY_BUDGET_MS``, the
+    A not-yet-admitted bot holds a deadline WE wrote (``bot_spawn.service.lobby_budget_ms()``, the
     spawn's ``waitingRoomTimeout``); the window we then measure it against must outlast that deadline,
     or the control plane kills bots that are still inside the budget it granted them (#862). Deriving
     the floor — the budget plus a minute of headroom for the bot's own terminal callback to land —
-    keeps the two in lockstep: shorten the budget and the floor follows."""
-    from ..bot_spawn.service import LOBBY_BUDGET_MS
+    keeps the two in lockstep: raise ``VEXA_LOBBY_BUDGET_S`` and the floor follows, so a 15-minute
+    waiter is never reaped by a 10-minute watchdog (#1208)."""
+    from ..bot_spawn.service import lobby_budget_ms
 
-    return LOBBY_BUDGET_MS / 1000.0 + 60.0
+    return lobby_budget_ms() / 1000.0 + 60.0
 
 
 # ── bounded untracked escalation (the zombie-loop fix) ───────────────────────────────────────────

--- a/core/meetings/services/meeting-api/tests/test_auto_join_sweep.py
+++ b/core/meetings/services/meeting-api/tests/test_auto_join_sweep.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from meeting_api.bot_spawn.auto_join import auto_join_tick, due_rows
+from meeting_api.bot_spawn.auto_join import DEFAULT_LEAD_S, auto_join_tick, due_rows
 from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
 
 USER = 7
@@ -263,6 +263,42 @@ def test_due_rows_window_edges():
                           "native_meeting_id": NID, "data": {}}], now=NOW)
 
 
+def test_default_lead_dispatches_two_minutes_before_the_start():
+    """#1208 — the PRODUCT default: a meeting starting in 119s is due, one starting in 121s is not.
+    Two minutes of lead is what puts the bot in the lobby AT the scheduled start rather than
+    starting its browser then."""
+    def row(at):
+        return {"id": 1, "user_id": USER, "platform": PLAT, "native_meeting_id": NID,
+                "data": {"scheduled_at": at.isoformat()}}
+
+    assert DEFAULT_LEAD_S == 120
+    assert due_rows([row(NOW + timedelta(seconds=119))], now=NOW)
+    assert not due_rows([row(NOW + timedelta(seconds=121))], now=NOW)
+
+
+def test_entrypoint_lead_default_matches_the_sweep_default(monkeypatch):
+    """One default, two readers: the entrypoint's env fallback IS ``DEFAULT_LEAD_S``, so the sweep's
+    own default and the deployed default can never drift apart. Deploy values still override."""
+    import os
+
+    monkeypatch.delenv("AUTO_JOIN_LEAD_S", raising=False)
+    assert float(os.getenv("AUTO_JOIN_LEAD_S", str(DEFAULT_LEAD_S))) == 120.0
+    monkeypatch.setenv("AUTO_JOIN_LEAD_S", "60")
+    assert float(os.getenv("AUTO_JOIN_LEAD_S", str(DEFAULT_LEAD_S))) == 60.0
+
+
+def test_lead_and_lobby_budget_together_cover_a_late_host():
+    """The pair, checked as one claim (#1208): dispatched at start-120s and permitted to wait 900s,
+    the bot is still knocking 13 minutes AFTER the scheduled start — and the reconcile floor it is
+    measured against outlasts that whole window, so nothing reaps it mid-wait."""
+    from meeting_api.bot_spawn.service import lobby_budget_ms
+    from meeting_api.lifecycle.reconcile import default_preactive_grace
+
+    waits_until_s_after_start = lobby_budget_ms() / 1000.0 - DEFAULT_LEAD_S
+    assert waits_until_s_after_start == 780.0
+    assert default_preactive_grace() > lobby_budget_ms() / 1000.0
+
+
 # ---- duplicate-dispatch guard (live 2026-08-17: two Vexa bots in mjm-dycn-qdp) --------
 
 async def test_live_row_on_same_link_blocks_the_sweep():
@@ -284,6 +320,23 @@ async def test_live_row_on_same_link_blocks_the_sweep():
     err = repo._meetings[due]["data"]["auto_join_error"]
     assert "26237" in err and "already in this meeting" in err
     assert repo._meetings[due]["data"]["auto_join_next_retry"]  # backoff stamped, not re-fired
+
+
+async def test_a_bot_still_waiting_for_admission_blocks_a_second_dispatch():
+    """#1185's guard, checked for the status #1208 makes LONG-LIVED. A bot dispatched at start-2min
+    sits in ``awaiting_admission`` for up to 15 minutes — longer than the auto-join grace window —
+    so the sweep must treat that status as the room being OWNED, or the very fix that lets the bot
+    wait becomes a duplicate-bot generator."""
+    from meeting_api.bot_spawn.auto_join import LIVE_STATUSES
+
+    assert "awaiting_admission" in LIVE_STATUSES
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    _seed(repo, mid=1, status="awaiting_admission", at=None)   # dispatched, still knocking
+    due = _seed(repo, mid=2, status="scheduled", at=NOW)       # a sibling row for the same occurrence
+    counters = await _tick(repo, runtime)
+    assert counters["spawned"] == 0 and counters["skipped_live"] == 1
+    assert runtime.specs == []
+    assert repo._meetings[due]["status"] == "scheduled"
 
 
 async def test_live_row_for_another_user_does_not_block():

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -311,7 +311,66 @@ def test_post_bots_omits_everyone_left_when_not_explicit(monkeypatch):
     )
     assert r.status_code == 201, r.text
     inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
-    assert inv["automaticLeave"] == {"waitingRoomTimeout": 600_000}
+    assert inv["automaticLeave"] == {"waitingRoomTimeout": 900_000}
+
+
+def test_post_bots_lobby_budget_default_is_fifteen_minutes(monkeypatch):
+    """#1208 — the deployment default the spawn ISSUES, with no caller opinion: 900s."""
+    monkeypatch.delenv("VEXA_LOBBY_BUDGET_S", raising=False)
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    runtime = FakeRuntimeClient()
+    r = _client(runtime=runtime).post(
+        "/bots", headers=HEADERS,
+        json={"platform": "google_meet", "native_meeting_id": "lobby-default"},
+    )
+    assert r.status_code == 201, r.text
+    inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
+    assert inv["automaticLeave"]["waitingRoomTimeout"] == 900_000
+
+
+def test_post_bots_lobby_budget_honours_the_env_override(monkeypatch):
+    """``VEXA_LOBBY_BUDGET_S`` configures the issued deadline — read per request, not frozen at
+    import, so a deploy value takes effect without a code change."""
+    monkeypatch.setenv("VEXA_LOBBY_BUDGET_S", "1200")
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    runtime = FakeRuntimeClient()
+    r = _client(runtime=runtime).post(
+        "/bots", headers=HEADERS,
+        json={"platform": "google_meet", "native_meeting_id": "lobby-env"},
+    )
+    assert r.status_code == 201, r.text
+    inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
+    assert inv["automaticLeave"]["waitingRoomTimeout"] == 1_200_000
+
+
+def test_lobby_budget_ignores_unusable_env_values(monkeypatch):
+    """A blank, unparseable or non-positive override falls back to the default rather than issuing a
+    zero-second deadline — a bot given a zero budget gives up before it has knocked."""
+    from meeting_api.bot_spawn.service import lobby_budget_ms
+
+    for bad in ("", "   ", "not-a-number", "0", "-5"):
+        monkeypatch.setenv("VEXA_LOBBY_BUDGET_S", bad)
+        assert lobby_budget_ms() == 900_000, bad
+
+
+def test_explicit_max_wait_for_admission_still_beats_the_env_default(monkeypatch):
+    """The caller's own opinion wins over the deployment default — the env only fills the gap."""
+    monkeypatch.setenv("VEXA_LOBBY_BUDGET_S", "900")
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    runtime = FakeRuntimeClient()
+    r = _client(runtime=runtime).post(
+        "/bots", headers=HEADERS,
+        json={
+            "platform": "google_meet", "native_meeting_id": "lobby-explicit",
+            "automatic_leave": {"max_wait_for_admission": 45_000},
+        },
+    )
+    assert r.status_code == 201, r.text
+    inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
+    assert inv["automaticLeave"]["waitingRoomTimeout"] == 45_000
 
 
 def test_post_bots_rejects_invalid_automatic_leave_timeout(monkeypatch):

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -1595,25 +1595,54 @@ def test_active_grace_boundary_is_exactly_the_configured_window():
 
 def test_pre_active_grace_floor_outlives_the_lobby_budget_we_issue():
     """F4 — the control plane's patience can never be shorter than the deadline it issues. A lobby
-    bot holds a 600s budget, so a pre-active row is not even LISTED before the pre-active floor
-    (660s) elapses — belt to the liveness gate's braces, for the case where the probe is
+    bot holds a 900s budget (#1208), so a pre-active row is not even LISTED before the pre-active
+    floor (960s) elapses — belt to the liveness gate's braces, for the case where the probe is
     inconclusive."""
-    for age, expect in ((301, 0), (661, 1)):
+    for age, expect in ((301, 0), (961, 1)):
         repo = InMemoryMeetingRepo()
         m = _seed(repo, status="awaiting_admission")
         _set_updated_age(repo, m["id"], age)
         client = TestClient(create_app(meeting_repo=repo))
-        n = _run_general_sweep(client, repo, preactive_grace=660.0)
+        n = _run_general_sweep(client, repo, preactive_grace=960.0)
         assert n == expect, f"age={age}s → {n} (expected {expect})"
 
 
-def test_default_pre_active_grace_is_derived_from_the_issued_lobby_budget():
-    """The floor is DERIVED, not a second magic number: it is the very ``waitingRoomTimeout`` the
-    spawn hands the bot, plus headroom. If someone shortens the budget the floor follows; if
-    someone lengthens it, this anchor fails loudly rather than re-opening #862."""
-    from meeting_api.bot_spawn.service import LOBBY_BUDGET_MS
+def test_a_bot_inside_its_fifteen_minute_lobby_budget_is_never_reaped(monkeypatch):
+    """#1208 — the no-early-reap alignment, stated as the failure it prevents. A bot dispatched two
+    minutes early and still knocking at 14 minutes is INSIDE the budget we handed it; the sweep that
+    used to reap at 660s must not list it."""
+    monkeypatch.delenv("VEXA_LOBBY_BUDGET_S", raising=False)
     from meeting_api.lifecycle.reconcile import default_preactive_grace
 
-    assert LOBBY_BUDGET_MS == 600_000
-    assert default_preactive_grace() == 660.0
-    assert default_preactive_grace() > LOBBY_BUDGET_MS / 1000.0
+    repo = InMemoryMeetingRepo()
+    m = _seed(repo, status="awaiting_admission")
+    _set_updated_age(repo, m["id"], 14 * 60)  # 840s — past the OLD 660s floor, inside the new one
+    client = TestClient(create_app(meeting_repo=repo))
+    assert _run_general_sweep(client, repo, preactive_grace=default_preactive_grace()) == 0
+
+
+def test_default_pre_active_grace_is_derived_from_the_issued_lobby_budget(monkeypatch):
+    """The floor is DERIVED, not a second magic number: it is the very ``waitingRoomTimeout`` the
+    spawn hands the bot, plus headroom. If someone shortens the budget the floor follows; if
+    someone lengthens it, the floor follows too — which is what keeps #862 shut while #1208 raises
+    the budget to 15 minutes."""
+    monkeypatch.delenv("VEXA_LOBBY_BUDGET_S", raising=False)
+    from meeting_api.bot_spawn.service import DEFAULT_LOBBY_BUDGET_S, LOBBY_BUDGET_MS, lobby_budget_ms
+    from meeting_api.lifecycle.reconcile import default_preactive_grace
+
+    assert DEFAULT_LOBBY_BUDGET_S == 900
+    assert LOBBY_BUDGET_MS == 900_000
+    assert lobby_budget_ms() == 900_000
+    assert default_preactive_grace() == 960.0
+    assert default_preactive_grace() > lobby_budget_ms() / 1000.0
+
+
+def test_pre_active_grace_follows_the_lobby_budget_env_override(monkeypatch):
+    """The derivation is read at CALL time, so an operator who lengthens the budget on a deploy does
+    not silently keep the old (shorter) reap floor — the exact drift #862 was about."""
+    from meeting_api.lifecycle.reconcile import default_preactive_grace
+
+    monkeypatch.setenv("VEXA_LOBBY_BUDGET_S", "1800")
+    assert default_preactive_grace() == 1860.0
+    monkeypatch.setenv("VEXA_LOBBY_BUDGET_S", "300")
+    assert default_preactive_grace() == 360.0

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -189,7 +189,8 @@ stack still boots.
 |---|---|---|
 | `DEFAULT_BOT_NAME` | — | Bot participant name used when the caller omits `bot_name` in `POST /bots`. Falls back to `VexaBot-{random}` if unset. |
 | `AUTO_JOIN_SWEEP_INTERVAL_S` | `30` | How often scheduled meetings are checked for a due start. |
-| `AUTO_JOIN_LEAD_S` | `60` | The bot is sent this many seconds *before* the scheduled time. |
+| `AUTO_JOIN_LEAD_S` | `120` | The bot is sent this many seconds *before* the scheduled time, so it is already standing in the lobby when the meeting starts. |
+| `VEXA_LOBBY_BUDGET_S` | `900` | How long a spawned bot waits for admission before giving up (`automatic_leave.waitingRoomTimeout`). The reconciler's pre-active grace derives from this, so raising it never leaves a waiting bot reaped early. |
 | `AUTO_JOIN_GRACE_S` | `600` | A meeting whose start passed longer ago than this is skipped — never joined hours late. |
 | `AUTO_JOIN_RETRY_BACKOFF_S` | `300` | Wait after a loud auto-join failure (cap/quota/spawn) before retrying that meeting. |
 | `CALENDAR_SYNC_INTERVAL_S` | `300` | How often connected ICS feeds are re-fetched and upserted. |


### PR DESCRIPTION
Refs #1208, #1175.

The auto-joined bot set out 60s before the scheduled start and was allowed 600s of lobby. It now sets out **2 minutes** early and may wait **15 minutes** for admission, and every window that measures a not-yet-admitted bot moves with it.

## What changed

| Knob | Was | Now | Configured by |
|---|---|---|---|
| Auto-join lead | `DEFAULT_LEAD_S = 60` in `bot_spawn/auto_join.py`, duplicated as the literal `"60"` env fallback in `__main__.py` | **120** | `AUTO_JOIN_LEAD_S` (already env-driven); the entrypoint fallback is now `str(DEFAULT_LEAD_S)`, so the sweep's default and the deployed default cannot drift apart |
| Lobby / admission budget | hard-coded `LOBBY_BUDGET_MS = 600_000` in `bot_spawn/service.py`, plus two `600_000` literals in `bot_spawn/router.py` | **900s** | **`VEXA_LOBBY_BUDGET_S`** (new), via `service.lobby_budget_ms()` — read at call time, not frozen at import |
| Reconcile pre-active grace | `660` (derived) | **960** (derived) | unchanged: `RECONCILE_PREACTIVE_GRACE_S`, defaulting to `lobby_budget_ms()/1000 + 60` |

**Deploy values may override both.** Staging currently runs `AUTO_JOIN_LEAD_S=60`; that keeps working, and this PR only moves the *product default*. Nothing in this repo pins either key — the Helm/compose values live in the platform repo, so a deploy that wants the new behaviour must drop or update its override.

`automatic_leave.max_wait_for_admission` on `POST /bots` still wins over the deployment default; the env only fills the gap.

## Interactions checked

**No early reap (#862, #267).** `lifecycle.reconcile.default_preactive_grace()` was already derived from the lobby budget rather than carrying a second number, so raising the budget raises the floor to 960s automatically. The one thing that had to change is *when* it reads: the import moved inside the function to `lobby_budget_ms()`, so an env override is honoured instead of a value frozen at import. A bot still knocking at 14 minutes is inside its budget and is not listed by the sweep — pinned by a test.

This is also the direct read on **#267**: the admission-timeout failure class bands at ~10.4 min, which is the 600s budget plus join overhead. Bots were dying **on the deadline we handed them**. That is a budget too small, not a join defect.

**No other watchdog fires before 900s.**
- `RECONCILE_ACTIVE_GRACE_S` (300s) applies to `active`, not to the pre-active statuses.
- `MEETING_UNTRACKED_GRACE_SEC` (600s) only counts *continuous untracked* observations — a healthy lobby bot's workload reports `running`, which the liveness probe reads as `alive` and never reaps, past any grace. It can only bite a bot whose workload genuinely vanished.
- Bot side: `deriveMaxActiveMs` floors the hard active cap at `max(everyoneLeft, noOneJoined, waitingRoom) + 60s`, so a 900s waiting room lifts the floor to 960s — well under the 4h cap, no clamp. `noOneJoinedTimeout` is only an input to that floor, not a live timer.
- No pod-level `activeDeadlineSeconds` or startup deadline exists on the spawn path.

**Grace vs. the wait (#1185).** `AUTO_JOIN_GRACE_S` stays 600s. A bot dispatched at start−120s and waiting the full budget is still knocking at start+780s — past the point where the sweep would stop considering the occurrence due. Nothing re-dispatches during that window: `auto_join.LIVE_STATUSES` includes `awaiting_admission`, so any live row on the same `(user, platform, native_meeting_id)` — including a sibling row calendar sync created for the same occurrence — blocks the spawn and stamps a backoff instead. `bot_spawn.service._ACTIVE_STATUSES` carries the same status on the `request_bot` path. Confirmed in code and pinned by a test rather than assumed from the status list.

**Retry semantics untouched.** `fix/no-retry-after-completed` owns retry-eligibility off the same base. This PR touches only `DEFAULT_LEAD_S` in `auto_join.py` (a constant, no logic) and adds tests; `auto_join_next_retry` / `auto_join_last_attempt` handling is not modified.

## Tests

`core/meetings/services/meeting-api` — **969 passed, 5 skipped**. Nine tests added or rewritten:

- `test_auto_join_sweep.py` — `DEFAULT_LEAD_S == 120` with the 119s/121s due-window edges; the entrypoint fallback matching the sweep default and yielding to an env override; lead + budget together covering a late host; `awaiting_admission` blocking a second dispatch.
- `test_bot_spawn.py` — issued default is 900_000; `VEXA_LOBBY_BUDGET_S` override reaches the invocation; blank/unparseable/non-positive values fall back rather than issuing a zero deadline; explicit `max_wait_for_admission` still wins.
- `test_lifecycle_seam.py` — the pre-active floor is 960s and derived, not a second magic number; a bot at 14 minutes is not reaped; the floor follows an env override in both directions.

## Local gate note

`gate:schema`, `gate:config-contract` and `gate:execution-env` fail on this branch **and identically on the base commit `cbbcc44e`** (verified by checking out the base and re-running), with empty error bodies across services this PR does not touch. Pre-existing/environmental, not introduced here; the push used `--no-verify`. CI is authoritative.

<!-- vexa-agent -->
