### PR TITLE
fix(calendar): a bot never returns to a meeting it already served — the full terminal-outcome matrix + stop eviction

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -95,6 +95,27 @@ class SqlAlchemyMeetingRepo:
             m = (await db.execute(stmt)).scalars().first()
             return _row_to_dict(m) if m else None
 
+    async def find_active_rows(self, user_id, platform, native_meeting_id) -> list:
+        """Every non-terminal row for (user, platform, native), newest first — the user-stop's
+        eviction set. ``stopping`` is included: it is still non-terminal, and the caller
+        de-duplicates on ``data.stop_requested``, not on status."""
+        from sqlalchemy import select
+
+        from ..sessions.models import Meeting
+
+        async with self._session_factory() as db:
+            stmt = (
+                select(Meeting)
+                .where(
+                    Meeting.user_id == user_id,
+                    Meeting.platform == platform,
+                    Meeting.platform_specific_id == native_meeting_id,
+                    Meeting.status.notin_(("completed", "failed")),
+                )
+                .order_by(Meeting.created_at.desc(), Meeting.id.desc())
+            )
+            return [_row_to_dict(m) for m in (await db.execute(stmt)).scalars().all()]
+
     async def find_active_by_userdata(self, userdata_s3_path) -> Optional[dict]:
         from sqlalchemy import select
 

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/fakes.py
@@ -51,6 +51,17 @@ class InMemoryMeetingRepo:
                 return dict(m)
         return None
 
+    async def find_active_rows(self, user_id, platform, native_meeting_id) -> list:
+        rows = [
+            dict(m) for m in self._meetings.values()
+            if m["user_id"] == user_id
+            and m["platform"] == platform
+            and m["native_meeting_id"] == native_meeting_id
+            and m["status"] not in ("completed", "failed")
+        ]
+        rows.sort(key=lambda m: m.get("id") or 0, reverse=True)   # newest first, as the SQL does
+        return rows
+
     async def find_active_by_userdata(self, userdata_s3_path) -> Optional[dict]:
         for m in self._meetings.values():
             if (

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/ports.py
@@ -34,6 +34,22 @@ class MeetingRepo(Protocol):
         set; ``stopping`` is in-flight too — see ``_ACTIVE_STATUSES``)."""
         ...
 
+    async def find_active_rows(
+        self, user_id: int, platform: str, native_meeting_id: str
+    ) -> list[dict]:
+        """EVERY non-terminal row the user has for ``(platform, native_id)``, newest first.
+
+        ``find_active`` answers "is this room taken?" and returns one row, which is all the POST
+        dedup needs. The user STOP needs all of them: a stop means the MEETING, not one container.
+        A second row on the same link is not hypothetical — it is the shape the auto-join sweep's
+        duplicate guard exists for (a manual "Send bot now" plus a calendar import that failed to
+        adopt it, live 2026-08-17) — and stopping only the newest left the sibling waiting in the
+        lobby to walk in after the user had said no.
+
+        ACTIVE here includes ``stopping``: a row already on its way out is still non-terminal, and
+        the caller de-duplicates on the ``stop_requested`` flag rather than on status."""
+        ...
+
     async def find_active_by_userdata(self, userdata_s3_path: str) -> Optional[dict]:
         """Any user's ACTIVE meeting whose spawn carried this ``userdata_s3_path``
         (``meeting.data.auth_userdata_path``), or ``None``. The per-identity serialization

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/service.py
@@ -22,13 +22,27 @@ imported event whose meeting is already running attaches its calendar identity t
 (``_attach_live_source`` — uid/sources only, never ``auto_join``/``scheduled_at``/status) rather
 than importing a sibling: a sibling is what the auto-join sweep sends a SECOND bot for.
 
-TERMINAL rows are past and are never matched or adopted — but they are not weightless. When the
-auto-join sweep dispatched for one (``data.auto_join_last_attempt``) and its bot then FAILED to
-join, the row goes terminal, leaves this module's index, and the very next sweep of the same feed
-finds an unmatched UID and creates a sibling that is due on sight — a fresh bot every sync
-interval until the grace window closes (live 2026-08-17, user 13820). So the replacement row
-CARRIES that spent attempt forward (``_spent_attempt``), scoped to the OCCURRENCE and not the UID:
-a weekly meeting whose bot failed today still sends one tomorrow.
+TERMINAL rows are past and are never matched or adopted — but they are not weightless, and WHICH
+terminal a row reached decides opposite things about whether its occurrence still wants a bot. That
+decision is not made here: ``lifecycle.occurrence.disposition`` owns the whole table (USER_STOPPED /
+SERVED / RETRY over every status × completion_reason the codebase can emit), and this module asks it.
+
+A **RETRY** occurrence is unserved — the bot never reached the room. When the auto-join sweep
+dispatched for one (``data.auto_join_last_attempt``) and its bot then failed to join, the row goes
+terminal, leaves this module's index, and the very next sweep of the same feed finds an unmatched UID
+and creates a sibling that is due on sight — a fresh bot every sync interval until the grace window
+closes (live 2026-08-17, user 13820). So the replacement row CARRIES that spent attempt forward
+(``_spent_attempt``), scoped to the OCCURRENCE and not the UID: a weekly meeting whose bot failed
+today still sends one tomorrow.
+
+A **SERVED** or **USER_STOPPED** occurrence is finished, and recreating it hands the sweep a row to
+send a second bot on. That is exactly what happened on stage rev 192: meeting 26312 was deliberately
+stopped at 22:28:31, sync recreated the occurrence as 26313 at 22:28:46, and the sweep — its 300s
+backoff since 22:21:01 legitimately elapsed — dispatched a fresh bot at 22:28:47, into the founder's
+meeting, uninvited. So a finished occurrence is NOT recreated (``_finished_row``): it is already in
+the user's list as the terminal meeting that carries its transcript, which is a truer record than an
+empty planned sibling, and no row means nothing for the sweep to arm. Occurrence-scoped like the
+backoff (``OCCURRENCE_MATCH_S``), so next week's instance imports armed.
 """
 from __future__ import annotations
 
@@ -36,6 +50,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, Optional
 
 from ..collector.meeting_link import find_meeting_link
+from ..lifecycle import may_dispatch_again
 
 # How far ahead the importer looks (events beyond it import on a later sweep) and how far back a
 # started occurrence still counts as "next" (keeps a due row alive while the auto-join grace runs).
@@ -394,10 +409,35 @@ def _same_occurrence(left: Any, right: Any) -> bool:
     return abs((a - b).total_seconds()) <= OCCURRENCE_MATCH_S
 
 
-def _spent_attempt(row: dict, ev: dict) -> Optional[dict]:
-    """The auto-join backoff a TERMINAL row leaves owed to a re-import of the SAME occurrence.
+def _finished_row(row: Optional[dict], ev: dict) -> Optional[dict]:
+    """The terminal row that already FINISHED this event's occurrence, or ``None``.
 
-    ``None`` when nothing is owed. A terminal row that carries ``auto_join_last_attempt`` is a row
+    Finished means ``lifecycle.occurrence`` classed the row SERVED (the bot reached the room and the
+    visit is over) or USER_STOPPED (the user said no). Either way the occurrence must not be
+    recreated: the recreated row is what the auto-join sweep dispatches a SECOND bot on once the
+    backoff elapses (stage rev 192: 26312 completed/stopped 22:28:31 → 26313 recreated 22:28:46 →
+    bot dispatched 22:28:47, uninvited, into a meeting the founder had ended).
+
+    Deliberately NOT gated on ``auto_join_last_attempt`` the way ``_spent_attempt`` is. The backoff
+    needs positive evidence of a dispatch because it is a rate limit on retries; this is not a retry
+    rule but an eligibility rule, and an occurrence the user botted BY HAND and then stopped is as
+    finished as one the sweep dispatched.
+
+    Occurrence-scoped (``OCCURRENCE_MATCH_S``), never UID-scoped: today's weekly standup being
+    finished says nothing about next week's, which imports armed.
+    """
+    if not isinstance(row, dict) or may_dispatch_again(row):
+        return None
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    if not _same_occurrence(data.get("scheduled_at"), ev.get("scheduled_at")):
+        return None
+    return row
+
+
+def _spent_attempt(row: dict, ev: dict) -> Optional[dict]:
+    """The auto-join backoff a FAILED row leaves owed to a re-import of the SAME occurrence.
+
+    ``None`` when nothing is owed. A ``failed`` row that carries ``auto_join_last_attempt`` is a row
     the auto-join sweep dispatched a bot for; if the bot then failed to join, the row went terminal
     and dropped out of both the sweep's predicate and this module's ``by_uid`` index — so the very
     next sync saw an unmatched UID and created a sibling, which was due on sight. The result was a
@@ -411,7 +451,7 @@ def _spent_attempt(row: dict, ev: dict) -> Optional[dict]:
     send one tomorrow. Same UID + a ``scheduled_at`` outside ``OCCURRENCE_MATCH_S`` is a different
     occurrence and owes nothing.
     """
-    if row.get("status") not in _TERMINAL:
+    if not may_dispatch_again(row) or row.get("status") not in _TERMINAL:
         return None
     data = row.get("data") if isinstance(row.get("data"), dict) else {}
     attempted_at = data.get("auto_join_last_attempt")
@@ -467,10 +507,14 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
         rows = await store.list_meetings(user_id)
     by_uid: dict[str, dict] = {}
     by_native: dict[tuple, dict] = {}
-    # Terminal rows the auto-join sweep ALREADY dispatched for, newest attempt per UID. Not an
+    # FAILED rows the auto-join sweep already dispatched for, newest attempt per UID. Not an
     # adoption index — a terminal row is never adopted — but the carrier of the retry backoff a
     # spent attempt owes, so recreating the row cannot re-arm it instantly (see _spent_attempt).
     terminal_attempts: dict[str, dict] = {}
+    # FINISHED rows per UID (served, or user-stopped), newest occurrence wins. A finished
+    # occurrence is never recreated as a dispatchable row (see _finished_row). Kept separate from
+    # the backoff index because the two dispositions decide opposite things.
+    finished_rows: dict[str, dict] = {}
     # Series workspace map (prep-v3 slice a): a NEW occurrence of a known calendar UID inherits
     # the workspace of the series' newest row that carries one — recurring meetings keep their
     # room without asking. An explicit unbind writes `workspace_unbound` on the row, which the
@@ -497,18 +541,31 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
                 series_stamp[uid] = stamp
                 series_ws[uid] = None if data.get("workspace_unbound") else data.get("workspace_id")
         if row.get("status") in _TERMINAL:
-            # A terminal row is past — it never matches, adopts, or gets touched. But if the
-            # auto-join sweep dispatched for it, the backoff that dispatch earned is still owed,
-            # and the row about to replace it is the only thing left to carry it. Keep the NEWEST
-            # attempt per UID; the occurrence check happens where the event is known.
-            attempted_at = _as_utc(_parse_iso(data.get("auto_join_last_attempt")))
-            if uid and attempted_at is not None:
-                held = terminal_attempts.get(uid)
-                previous = _as_utc(_parse_iso(
-                    (held.get("data") or {}).get("auto_join_last_attempt")
-                )) if held else None
-                if previous is None or previous <= attempted_at:
-                    terminal_attempts[uid] = row
+            # A terminal row is past — it never matches, adopts, or gets touched. What it leaves
+            # behind depends on how the run ENDED, and the two answers are opposites.
+            if uid and not may_dispatch_again(row):
+                # FINISHED (served, or the user stopped it). This occurrence must never be
+                # recreated as a dispatchable row. Keep the NEWEST occurrence per UID; the
+                # occurrence match happens where the event is known, so a stale week's finished
+                # run never suppresses this week's.
+                held = finished_rows.get(uid)
+                previous = _as_utc(_parse_iso((held.get("data") or {}).get("scheduled_at"))) \
+                    if held else None
+                current = _as_utc(_parse_iso(data.get("scheduled_at")))
+                if previous is None or (current is not None and previous <= current):
+                    finished_rows[uid] = row
+            elif uid:
+                # UNSERVED failure: a retry is owed, but if the sweep dispatched for it, the
+                # backoff that dispatch earned is owed too, and the row about to replace it is the
+                # only thing left to carry it. Keep the NEWEST attempt per UID.
+                attempted_at = _as_utc(_parse_iso(data.get("auto_join_last_attempt")))
+                if attempted_at is not None:
+                    held = terminal_attempts.get(uid)
+                    previous = _as_utc(_parse_iso(
+                        (held.get("data") or {}).get("auto_join_last_attempt")
+                    )) if held else None
+                    if previous is None or previous <= attempted_at:
+                        terminal_attempts[uid] = row
             continue
         if uid and uid not in by_uid:
             by_uid[uid] = row
@@ -615,6 +672,14 @@ async def sync_user(store, user_id: int, parsed: dict, *, auto_join_default: boo
                                            "status": attached.get("status"),
                                            "when": (attached.get("data") or {}).get("scheduled_at")})
             continue  # never duplicate a row that already exists for this link
+
+        # This occurrence is FINISHED — the bot came and the visit ended, or the user stopped it.
+        # Recreating it hands the auto-join sweep something to dispatch on, which is how an
+        # uninvited bot walked back into a meeting the founder had stopped 15 seconds earlier
+        # (stage rev 192, 26312 → 26313). Nothing to create: the occurrence is already in the
+        # user's list as the terminal meeting, carrying its transcript.
+        if _finished_row(finished_rows.get(ev["uid"]), ev) is not None:
+            continue
 
         inherited_ws = series_ws.get(ev["uid"])  # None = no binding OR tombstoned — both mean "don't"
         # A spent auto-join attempt on THIS occurrence rides onto the new row, so the sweep sees the

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/__init__.py
@@ -20,6 +20,9 @@ rejects illegal transitions.
   ``meeting.status_change`` webhook body.
 * ``build_status_change_envelope`` (P3a) — wrap a ``StatusChange`` as a sealed ``webhook.v1``
   ``Envelope`` (event_type ``meeting.status_change``).
+* ``Disposition`` / ``disposition`` / ``may_dispatch_again`` — what a TERMINAL row leaves owed to
+  its calendar occurrence (served · user-stopped · retry). The one table deciding whether a bot may
+  go back into a meeting it has already been in; ``calendar_sync`` asks it before recreating a row.
 """
 from .machine import (
     BotStatus,
@@ -33,6 +36,11 @@ from .machine import (
     StatusChange,
     TransitionSource,
     can_transition,
+)
+from .occurrence import (
+    Disposition,
+    disposition,
+    may_dispatch_again,
 )
 from .retry import (
     JoinRetryController,
@@ -79,4 +87,7 @@ __all__ = [
     "request_stop",
     "stop_event_for",
     "can_transition",
+    "Disposition",
+    "disposition",
+    "may_dispatch_again",
 ]

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/occurrence.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/occurrence.py
@@ -1,0 +1,126 @@
+"""May a calendar OCCURRENCE be dispatched a bot again, given how its last run ended?
+
+One decision, one table. Calendar sync recreates a terminal row's occurrence so the auto-join sweep
+can retry it (#1200); this module decides whether that occurrence is still *owed* a bot at all.
+
+The bug this exists to close (stage rev 192, witnessed live): meeting 26312 ended
+``completed``/``stopped`` at 22:28:31 — the bot had joined, done its job, and been deliberately
+stopped. Sync recreated the occurrence as 26313 at 22:28:46, the sweep's 300s backoff since 22:21:01
+had legitimately elapsed, and at 22:28:47 an uninvited bot walked back into the founder's meeting.
+The retry gate was a RATE limit (how recently did we try?) where it needed an ELIGIBILITY rule
+(should we ever try again?). Backoff cannot fix "never".
+
+The rule, in priority order:
+
+1. **USER_STOPPED** — positive evidence the user stopped it (``data.stop_requested``, or
+   ``completion_reason='stopped'``). Final for the occurrence at ANY lifecycle stage: a stop pressed
+   while the bot sat in the waiting room is the user saying no just as loudly as one pressed
+   mid-meeting. Founder ruling 2026-08-17: *"explicit stop must be stop"*.
+2. **SERVED** — the bot reached the room and the visit is over. ``status='completed'`` (the FSM
+   admits COMPLETED only from ACTIVE — see ``machine.LEGAL_TRANSITIONS`` — so every completed row is
+   a row whose bot got in), or ``status='failed'`` with ``failure_stage='active'`` (admitted, then
+   the run broke). A second bot here is a second visit, not a retry.
+3. **RETRY** — failure class, and the bot never reached the room. Only these stay eligible, and only
+   behind the sweep's backoff (#1200's storm ceiling: one dispatch per backoff per occurrence).
+
+The retry set is DERIVED from the sealed taxonomy already in ``retry.py`` (TRANSIENT =
+``join_failure`` / ``awaiting_admission_timeout``) plus two values that taxonomy does not carry:
+
+* ``start_failed`` — written straight to ``data.completion_reason`` by ``fail_meeting`` and NOT a
+  member of the sealed ``CompletionReason`` enum. The workload never started, so the bot never got
+  near the meeting; that is the most retryable failure there is.
+* absent/unknown reason — no producer emits one today (the bot stamps a reason on every terminal
+  edge, and ``reconcile`` derives one), so this is legacy and synthetic rows. Retryable ONLY because
+  rule 2 already caught the shape that matters: a reason-less row whose ``failure_stage`` is
+  ``active`` is SERVED. Without positive evidence the bot was admitted, the pre-#1200 behaviour
+  stands and the backoff bounds it.
+
+Every other reason is SERVED: the host rejected us (``awaiting_admission_rejected``), the profile is
+signed out (``auth_session_missing``), the request was malformed (``validation_error``), or the
+reason belongs to the active phase at all (``evicted``, ``left_alone``, ``startup_alone``,
+``max_bot_time_exceeded``) — in which case the bot was in the room whatever the stage says.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Optional
+
+from .machine import CompletionReason
+from .retry import _TRANSIENT
+
+# The user-stop reason, the one value that is final regardless of status or stage.
+USER_STOP_REASON = CompletionReason.STOPPED.value
+
+# Out-of-enum reasons this codebase writes directly to ``data.completion_reason``. Enumerated
+# because the sealed enum is not the whole truth: ``fail_meeting`` writes ``start_failed`` without
+# ever going through ``CompletionReason``.
+START_FAILED = "start_failed"
+
+# The complete set of terminal reasons an UNSERVED occurrence may be dispatched for again.
+RETRYABLE_REASONS: frozenset[str] = frozenset(
+    {reason.value for reason in _TRANSIENT} | {START_FAILED}
+)
+
+# Every reason value this codebase can put on a terminal row. The matrix test asserts this is
+# exhaustive over the sealed enum, so a new CompletionReason cannot be added without deciding — and
+# testing — which side of this gate it falls on.
+KNOWN_REASONS: frozenset[str] = frozenset(
+    {reason.value for reason in CompletionReason} | {START_FAILED}
+)
+
+# The stage that means the bot was ADMITTED. A failed run attributed to it reached the meeting.
+ACTIVE_STAGE = "active"
+
+TERMINAL_STATUSES = ("completed", "failed")
+
+
+class Disposition(str, Enum):
+    """What a terminal row leaves owed to its occurrence."""
+
+    USER_STOPPED = "user_stopped"   # the user said no — never dispatch again
+    SERVED = "served"               # the bot came and the visit is over — never dispatch again
+    RETRY = "retry"                 # unserved failure — eligible again once the backoff elapses
+
+    @property
+    def dispatchable(self) -> bool:
+        """May the occurrence be given another bot (subject to the sweep's backoff)?"""
+        return self is Disposition.RETRY
+
+
+def disposition(row: Any) -> Optional[Disposition]:
+    """Classify a TERMINAL meeting row. ``None`` when the row is not terminal (nothing decided).
+
+    Reads only ``status`` and ``data`` — the same shape calendar sync, the auto-join sweep and the
+    repo adapters all hand around, so one rule serves every caller.
+    """
+    if not isinstance(row, dict):
+        return None
+    status = row.get("status")
+    if status not in TERMINAL_STATUSES:
+        return None
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    reason = data.get("completion_reason")
+    reason = reason if isinstance(reason, str) and reason else None
+
+    # 1. The user stopped it. Strongest signal, checked first, honoured at every stage — including a
+    #    stop while the bot was still joining or waiting to be admitted, which lands as
+    #    `failed`/`stopped` (stop.classify_user_stop) and would otherwise read as a failure to retry.
+    if data.get("stop_requested") or reason == USER_STOP_REASON:
+        return Disposition.USER_STOPPED
+
+    # 2. The bot reached the room. `completed` is only reachable from ACTIVE; a `failed` run
+    #    attributed to the ACTIVE stage was admitted and then broke.
+    if status == "completed" or data.get("failure_stage") == ACTIVE_STAGE:
+        return Disposition.SERVED
+
+    # 3. Pre-active failure: retry only what is positively retryable (unknown reasons included, see
+    #    the module docstring — rule 2 already claimed the admitted shape).
+    if reason is None or reason in RETRYABLE_REASONS:
+        return Disposition.RETRY
+    return Disposition.SERVED
+
+
+def may_dispatch_again(row: Any) -> bool:
+    """Is this terminal row's occurrence still eligible for another auto-join dispatch?"""
+    verdict = disposition(row)
+    return verdict is None or verdict.dispatchable

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/stop_router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/stop_router.py
@@ -5,9 +5,13 @@ The stop *logic* lives in ``stop.py`` (``request_stop`` → publish a ``leave`` 
 composition, P2), behaviour-matched to the parent ``meetings.stop_bot``:
 
   1. Resolve the caller (``x-user-id`` the gateway injects after it validates ``x-api-key``).
-  2. ``find_active`` the user's non-terminal meeting for ``(platform, native_id)`` — 404 if none.
-  3. Mark it ``stopping`` + ``stop_requested`` (so the exit is later attributed to a user stop, never a
-     silent failure), then PUBLISH ``bot_commands:meeting:{id}`` ``{"action":"leave"}``.
+  2. ``find_active_rows`` — EVERY non-terminal meeting the user has for ``(platform, native_id)``,
+     404 if none. Not one row: *"explicit stop must be stop, evict"* (founder ruling 2026-08-17).
+     The user pressed stop once and means the MEETING, so a sibling row still waiting in the lobby
+     is taken down with it. Stopping only the newest let that sibling walk in after the user said no.
+  3. Mark them ``stopping`` + ``stop_requested`` (so each exit is later attributed to a user stop,
+     never a silent failure — and so ``lifecycle.occurrence`` never lets the calendar re-dispatch
+     the occurrence), then PUBLISH ``bot_commands:meeting:{id}`` ``{"action":"leave"}`` per row.
   4. The bot honours the command, leaves, and emits its terminal ``lifecycle.v1`` event — which the
      existing ``/bots/internal/callback/lifecycle`` handler classifies (→ ``completed``/``failed``,
      ``meeting.status_change`` webhook fires). This route TRIGGERS the stop; it never jumps the FSM itself.
@@ -93,49 +97,52 @@ def build_stop_router(repo: MeetingRepo, publisher: CommandPublisher, runtime=No
                     f"must be one of: {', '.join(sorted(_SUPPORTED_PLATFORMS))}"
                 ),
             )
-        meeting = await repo.find_active(user_id, platform, native_meeting_id)
-        if not meeting:
+        # EVERY non-terminal row for this room, not just the newest. "The user pressed stop once
+        # and means the meeting, not one container" (founder ruling 2026-08-17). `find_active`
+        # returns one row — enough for the POST dedup, wrong here: a sibling row still waiting in
+        # the lobby survived the stop and walked in afterwards. The shapes that produce a sibling
+        # are known and live (a manual "Send bot now" plus a calendar import that failed to adopt
+        # it — rows 26237 + 26251 on one native id, 2026-08-17).
+        rows = await _active_rows(repo, user_id, platform, native_meeting_id)
+        if not rows:
             raise HTTPException(status_code=404, detail="No active meeting for this bot")
         # The stop trigger is ONE-SHOT. Redelivering DELETE must not re-publish a leave command or
         # re-tear-down a workload, so the guard is the user-intent flag itself rather than a status
         # side-effect: `stop_requested` is set by the first stop and is true regardless of which
         # status the meeting was stopped at. (Reading it off the status cannot work — the SQL
         # adapter's active set contains `stopping`, so a second DELETE still FINDS the row.)
-        if (meeting.get("data") or {}).get("stop_requested"):
-            raise HTTPException(status_code=404, detail="No active meeting for this bot")
-        meeting_id = meeting["id"]
-        status = meeting.get("status")
-        bot_container_id = meeting.get("bot_container_id")
-        # Mark stop-requested, keyed by the latest session so the exit classifier reads the user-intent
-        # signal. Best-effort: an unknown session no-ops.
         #
-        # `stopping` is written ONLY over a status where the bot actually reached the meeting. It means
-        # "a live bot is being asked to leave", and the whole terminal chain reads it that way:
-        # `reconcile._WAS_ACTIVE_STATUSES` completes it, and `machine._PERSISTED_STATUS_TO_BOTSTATUS`
-        # rehydrates it as ACTIVE. Writing it over a PRE-ACTIVE status (a bot still in the waiting room)
-        # destroyed the only record of the stage the bot died in, and every downstream reader then
-        # concluded the bot had been live — so a bot that was never admitted was persisted as
-        # `completed` with zero transcript, via an `awaiting_admission → completed` edge the state
-        # machine does not even consider legal (#807). A pre-active bot has nothing to leave: its
-        # workload is torn down directly below, and the terminal is attributed to the stage it really
-        # reached.
-        sessions = await repo.list_sessions(meeting_id=meeting_id)
-        if sessions:
-            await repo.update_meeting_status(
-                session_uid=sessions[-1],
-                status=status if status in _BOOTING_STATUSES else "stopping",
-                data={"stop_requested": True},
-            )
-        # Publish the leave command — an ACTIVE (listening) bot honours it, leaves, emits its terminal event.
+        # Applied PER ROW, not to the response as a whole: a second DELETE that finds every row
+        # already stop-requested is the redelivery this guards (404), but one that finds a NEW
+        # sibling — spawned after the first stop — must still take it down.
+        pending = [row for row in rows if not (row.get("data") or {}).get("stop_requested")]
+        if not pending:
+            raise HTTPException(status_code=404, detail="No active meeting for this bot")
+        meeting, siblings = pending[0], pending[1:]
+        meeting_id = meeting["id"]
+
+        # Mark EVERY pending row stop-requested BEFORE publishing anything. The flag is the durable
+        # record of user intent: the exit classifier reads it to attribute the terminal to a user
+        # stop, and `lifecycle.occurrence` reads it to keep the calendar from ever re-dispatching
+        # this occurrence. Persisting all of them first means a Redis outage below (503) still
+        # leaves every row correctly attributed for the reconcile sweep to converge.
+        for row in pending:
+            await _mark_stop_requested(repo, row)
+
+        # Publish the leave command — an ACTIVE (listening) bot honours it, leaves, emits its terminal
+        # event. One command per row: each bot listens on its OWN meeting-scoped channel, so evicting a
+        # sibling means addressing it by its own id, never the primary's.
         # #809: this is a GENUINELY Redis-dependent path (pub/sub is the only delivery). During a Redis
         # outage it must fail NARROWLY per-request (503, retryable) — not as an opaque 500 stack trace,
-        # and never process-wide. The `stopping` mark above is already persisted to Postgres, so the
-        # stop-reconcile sweep still converges the meeting when Redis returns; a 503 tells the caller to
+        # and never process-wide. The `stopping` marks above are already persisted to Postgres, so the
+        # stop-reconcile sweep still converges the meetings when Redis returns; a 503 tells the caller to
         # retry the leave once the cache is back.
         try:
-            await publisher.publish(
-                leave_command_channel(meeting_id), json.dumps(leave_command_payload(meeting_id))
-            )
+            for row in pending:
+                await publisher.publish(
+                    leave_command_channel(row["id"]),
+                    json.dumps(leave_command_payload(row["id"])),
+                )
         except HTTPException:
             raise
         except Exception as e:  # noqa: BLE001 — Redis unreachable → narrow, retryable failure
@@ -144,21 +151,94 @@ def build_stop_router(repo: MeetingRepo, publisher: CommandPublisher, runtime=No
                 detail="stop command bus (redis) unavailable; the stop is recorded and will "
                        "reconcile when redis returns — retry to re-issue the leave",
             ) from e
+
         # GUARANTEE no orphan: a stop must not rely solely on a fire-and-forget command the bot may never
         # receive. A BOOTING bot (status in _BOOTING_STATUSES) has likely not subscribed yet → directly
         # tear its workload down (it has nothing to finalize). Best-effort: logged, never fails the stop.
-        if runtime is not None and bot_container_id and status in _BOOTING_STATUSES:
-            try:
-                await runtime.delete_workload(bot_container_id)
-            except Exception as e:  # noqa: BLE001 — teardown is best-effort; the reconcile loop backstops
-                _log_stop_teardown_failed(meeting_id, bot_container_id, e)
+        # A waiting SIBLING is almost always in exactly that state, which is why it outlived the stop.
+        if runtime is not None:
+            for row in pending:
+                container = row.get("bot_container_id")
+                if container and row.get("status") in _BOOTING_STATUSES:
+                    try:
+                        await runtime.delete_workload(container)
+                    except Exception as e:  # noqa: BLE001 — best-effort; reconcile backstops
+                        _log_stop_teardown_failed(row["id"], container, e)
+
+        if siblings:
+            _log_stop_evicted(meeting_id, [row["id"] for row in siblings], native_meeting_id)
         return {
             "status": "stopping",
             "meeting_id": meeting_id,
             "native_meeting_id": native_meeting_id,
+            # Named so the caller can see the stop took the ROOM, not one container. Present
+            # always (empty in the ordinary one-row case) — an optional key would make "no
+            # siblings" and "an older build" indistinguishable.
+            "also_stopped": [row["id"] for row in siblings],
         }
 
     return router
+
+
+async def _active_rows(repo, user_id: int, platform: str, native_meeting_id: str) -> list:
+    """Every non-terminal row for the room, newest first — via ``find_active_rows`` when the repo
+    offers it, else the single-row ``find_active`` it supersedes.
+
+    The fallback is not decoration: ``MeetingRepo`` is a Protocol with several implementations, and
+    a stop that raised AttributeError against an older one would be a worse failure than a stop that
+    covers one row. Where the port is present the eviction is complete."""
+    lister = getattr(repo, "find_active_rows", None)
+    if lister is not None:
+        return list(await lister(user_id, platform, native_meeting_id) or ())
+    single = await repo.find_active(user_id, platform, native_meeting_id)
+    return [single] if single else []
+
+
+async def _mark_stop_requested(repo, row: dict) -> None:
+    """Persist the user-stop intent on one row, keyed by its latest session.
+
+    `stopping` is written ONLY over a status where the bot actually reached the meeting. It means
+    "a live bot is being asked to leave", and the whole terminal chain reads it that way:
+    `reconcile._WAS_ACTIVE_STATUSES` completes it, and `machine._PERSISTED_STATUS_TO_BOTSTATUS`
+    rehydrates it as ACTIVE. Writing it over a PRE-ACTIVE status (a bot still in the waiting room)
+    destroyed the only record of the stage the bot died in, and every downstream reader then
+    concluded the bot had been live — so a bot that was never admitted was persisted as
+    `completed` with zero transcript, via an `awaiting_admission → completed` edge the state
+    machine does not even consider legal (#807). A pre-active bot has nothing to leave: its
+    workload is torn down directly by the caller, and the terminal is attributed to the stage it
+    really reached.
+
+    A row with NO session yet (spawned so recently that the session write has not landed) still has
+    to carry the flag — it is the only durable evidence the user said no, and without it the
+    calendar would recreate this occurrence and send another bot. Fall back to a direct data merge.
+    """
+    status = row.get("status")
+    sessions = await repo.list_sessions(meeting_id=row["id"])
+    if sessions:
+        await repo.update_meeting_status(
+            session_uid=sessions[-1],
+            status=status if status in _BOOTING_STATUSES else "stopping",
+            data={"stop_requested": True},
+        )
+        return
+    merge = getattr(repo, "merge_meeting_data", None)
+    if merge is not None:
+        await merge(row["id"], {"stop_requested": True})
+
+
+def _log_stop_evicted(meeting_id, sibling_ids, native_meeting_id) -> None:
+    """A stop that took down MORE than the row the caller named is a fact worth a line: it means a
+    duplicate bot existed for that room, and the count is the only cheap signal of how often."""
+    try:
+        from ..obs import log_event
+
+        log_event(
+            "stop_evicted_siblings", audience="operator", level="warning", span="bots.stop",
+            fields={"meeting_id": meeting_id, "evicted": sibling_ids,
+                    "native_meeting_id": native_meeting_id},
+        )
+    except Exception:
+        pass
 
 
 def _log_stop_teardown_failed(meeting_id, workload_id, err) -> None:

--- a/core/meetings/services/meeting-api/tests/test_auto_join_occurrence_matrix.py
+++ b/core/meetings/services/meeting-api/tests/test_auto_join_occurrence_matrix.py
@@ -1,0 +1,259 @@
+"""The auto-join re-dispatch DECISION MATRIX — every terminal outcome × its retry decision.
+
+The defect this closes was witnessed once (stage rev 192: meeting 26312 ended ``completed``/
+``stopped`` at 22:28:31, sync recreated the occurrence as 26313 at 22:28:46, and the sweep sent a
+fresh bot at 22:28:47 into a meeting the founder had deliberately ended). Fixing and replaying that
+one incident would leave its whole CLASS open — the same shape exists for a stop pressed in the
+lobby, for a host who rejected the bot, for a signed-out profile. So the deliverable is the table,
+not the case: every terminal outcome the codebase can emit gets a row here and a test of its own.
+
+Each cell drives the REAL seam end to end — seed a terminal row of that shape, sync the same feed,
+run the sweep past its backoff and inside the grace — and asserts whether a bot goes back in. The
+backoff is deliberately spent in every cell (``auto_join_last_attempt`` at the occurrence start,
+swept 301s later) so each cell isolates ELIGIBILITY from RATE: #1200 answered "how soon may we try
+again", and this answers "may we ever".
+
+``test_matrix_covers_every_reason_the_codebase_can_emit`` is the loud failure a future outcome
+trips: add a value to ``CompletionReason`` (or another out-of-enum reason to ``occurrence``) without
+deciding its row here and this file fails, naming the value.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from meeting_api.calendar_sync import parse_ics, sync_user
+from meeting_api.lifecycle.machine import CompletionReason
+from meeting_api.lifecycle.occurrence import (
+    KNOWN_REASONS,
+    Disposition,
+    disposition,
+)
+from test_calendar_sync import START, USER, _event, _ics, _storm_rig, _sweep
+
+# Decisions, named as the matrix column they select.
+RETRY = Disposition.RETRY                # eligible again once the backoff elapses
+SERVED = Disposition.SERVED              # the bot reached the room — never again
+USER_STOPPED = Disposition.USER_STOPPED  # the user said no — never again
+
+
+class Cell:
+    """One row of the matrix: a terminal shape and the decision it must produce."""
+
+    def __init__(self, name: str, *, status: str, reason=None, stage=None,
+                 stop_requested: bool = False, expect: Disposition, why: str) -> None:
+        self.name = name
+        self.status = status
+        self.reason = reason
+        self.stage = stage
+        self.stop_requested = stop_requested
+        self.expect = expect
+        self.why = why
+
+    @property
+    def dispatches(self) -> bool:
+        return self.expect is Disposition.RETRY
+
+    def data(self, scheduled_at: str) -> dict:
+        data = {
+            "calendar_uid": "uid-1",
+            "auto_join": True,
+            "scheduled_at": scheduled_at,
+            # Every cell has ALREADY spent a dispatch: the question under test is eligibility,
+            # never how recently we tried.
+            "auto_join_last_attempt": scheduled_at,
+        }
+        if self.reason is not None:
+            data["completion_reason"] = self.reason
+        if self.stage is not None:
+            data["failure_stage"] = self.stage
+        if self.stop_requested:
+            data["stop_requested"] = True
+        return data
+
+    def __repr__(self) -> str:  # pragma: no cover — pytest id only
+        return self.name
+
+
+# ---------------------------------------------------------------------------------------------
+# THE MATRIX. Columns: terminal status · completion_reason · failure_stage · user-stop evidence
+# → decision. Ordered by decision so the shape of the table is readable as a table.
+# ---------------------------------------------------------------------------------------------
+MATRIX: list[Cell] = [
+    # ---- RETRY: the bot never reached the room and the failure is not the room's answer -------
+    Cell("failed/join_failure@joining", status="failed", reason="join_failure", stage="joining",
+         expect=RETRY, why="the transient join fault #1200 was built for — the bot never got in"),
+    Cell("failed/join_failure@requested", status="failed", reason="join_failure",
+         stage="requested", expect=RETRY,
+         why="died before it even reported — nothing about the meeting refused us"),
+    Cell("failed/awaiting_admission_timeout", status="failed",
+         reason="awaiting_admission_timeout", stage="awaiting_admission", expect=RETRY,
+         why="nobody let it out of the lobby in time; TRANSIENT in retry.py — the host may be late"),
+    Cell("failed/start_failed", status="failed", reason="start_failed", stage="requested",
+         expect=RETRY,
+         why="fail_meeting's out-of-enum reason: the WORKLOAD never started, the most retryable "
+             "failure there is"),
+    Cell("failed/no-reason", status="failed", reason=None, stage=None, expect=RETRY,
+         why="no producer emits this today; retryable only because the admitted shape is already "
+             "claimed by failure_stage=active below — this is the pre-#1200 status quo, "
+             "backoff-bounded"),
+
+    # ---- SERVED: the bot reached the room, or the room's answer was no -----------------------
+    Cell("completed/left_alone", status="completed", reason="left_alone", expect=SERVED,
+         why="the meeting ended and the bot left — the ordinary success"),
+    Cell("completed/startup_alone", status="completed", reason="startup_alone", expect=SERVED,
+         why="it got in and found an empty room; a real outcome, not a fault to retry"),
+    Cell("completed/evicted", status="completed", reason="evicted", expect=SERVED,
+         why="someone REMOVED it from the meeting — sending it back is the rudest possible retry"),
+    Cell("completed/max_bot_time_exceeded", status="completed", reason="max_bot_time_exceeded",
+         expect=SERVED, why="it hit its own time cap; a fresh bot would restart the same clock"),
+    Cell("completed/no-reason", status="completed", reason=None, expect=SERVED,
+         why="completed is reachable ONLY from ACTIVE (machine.LEGAL_TRANSITIONS) — the bot was "
+             "in the room whether or not anything recorded why it left"),
+    Cell("failed/awaiting_admission_rejected", status="failed",
+         reason="awaiting_admission_rejected", stage="awaiting_admission", expect=SERVED,
+         why="the host said NO; PERMANENT in retry.py — a retry re-knocks on a slammed door"),
+    Cell("failed/auth_session_missing", status="failed", reason="auth_session_missing",
+         stage="joining", expect=SERVED,
+         why="signed-out profile; a re-spawn hits the same dead cookie jar"),
+    Cell("failed/validation_error", status="failed", reason="validation_error", stage="requested",
+         expect=SERVED, why="the request itself is malformed — identical on every retry"),
+    Cell("failed/join_failure@active", status="failed", reason="join_failure", stage="active",
+         expect=SERVED,
+         why="attributed to the ACTIVE stage: the bot WAS admitted (orchestrator's pipeline-start "
+             "failure) and a retry would be a second visit, not a retry"),
+    Cell("failed/no-reason@active", status="failed", reason=None, stage="active", expect=SERVED,
+         why="positive evidence of admission with no reason recorded — the stage decides"),
+    Cell("failed/left_alone", status="failed", reason="left_alone", stage="active", expect=SERVED,
+         why="reconcile's was-active escalation; an active-phase reason means it reached the room"),
+
+    # ---- USER_STOPPED: the user said no. Final at EVERY stage --------------------------------
+    # Founder ruling 2026-08-17: "explicit stop must be stop, evict."
+    Cell("completed/stopped", status="completed", reason="stopped", expect=USER_STOPPED,
+         why="the witnessed incident, exactly: stopped mid-meeting at 22:28:31, bot back at "
+             "22:28:47"),
+    Cell("failed/stopped@awaiting_admission", status="failed", reason="stopped",
+         stage="awaiting_admission", stop_requested=True, expect=USER_STOPPED,
+         why="stopped while WAITING to be admitted — the FSM's only legal pre-active terminal is "
+             "`failed`, but the user said no just as loudly as one pressed mid-meeting"),
+    Cell("failed/stopped@joining", status="failed", reason="stopped", stage="joining",
+         stop_requested=True, expect=USER_STOPPED,
+         why="stopped before it ever knocked; nothing here is a fault to retry"),
+    Cell("stop_requested-flag-only", status="failed", reason="join_failure", stage="joining",
+         stop_requested=True, expect=USER_STOPPED,
+         why="the row's own terminal blamed the network, but the user had already pressed stop — "
+             "user intent outranks the fault the race happened to record"),
+]
+
+
+# ---------------------------------------------------------------------------------------------
+# The exhaustiveness gate — a new outcome cannot enter the enum without entering the table.
+# ---------------------------------------------------------------------------------------------
+
+def test_matrix_covers_every_reason_the_codebase_can_emit():
+    """Add a CompletionReason (or another out-of-enum reason) and this fails until it has a row.
+
+    Asserted against ``occurrence.KNOWN_REASONS`` (the sealed enum PLUS the out-of-enum values this
+    codebase writes straight to ``data.completion_reason``) rather than against the enum alone —
+    ``start_failed`` is exactly the value an enum-only check would have missed.
+    """
+    covered = {cell.reason for cell in MATRIX}
+    missing = KNOWN_REASONS - covered
+    assert not missing, (
+        f"completion reasons with no matrix row: {sorted(missing)} — every terminal outcome needs "
+        f"a decision (retry / served / user-stopped) and a test of its own"
+    )
+    assert None in covered, "the absent-reason cell is load-bearing — legacy rows carry no reason"
+
+
+def test_known_reasons_covers_the_sealed_enum():
+    """``KNOWN_REASONS`` must be a superset of the sealed enum: the gate above is only as complete
+    as the set it checks against."""
+    assert {reason.value for reason in CompletionReason} <= KNOWN_REASONS
+
+
+def test_every_cell_has_a_distinct_name():
+    names = [cell.name for cell in MATRIX]
+    assert len(names) == len(set(names))
+
+
+# ---------------------------------------------------------------------------------------------
+# One test per cell — the pure classification, then the live seam.
+# ---------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cell", MATRIX, ids=lambda c: c.name)
+def test_cell_disposition(cell: Cell):
+    """The classification itself: this terminal shape → this decision. (Cell rationale in ``why``.)"""
+    row = {"id": 1, "status": cell.status, "data": cell.data(START.isoformat())}
+    assert disposition(row) is cell.expect, cell.why
+
+
+@pytest.mark.parametrize("cell", MATRIX, ids=lambda c: c.name)
+async def test_cell_dispatch_through_the_live_seam(cell: Cell):
+    """The consequence: after this terminal outcome, does a bot go back into the meeting?
+
+    Drives the real path — calendar sync recreating (or not) the occurrence, then the auto-join
+    sweep at +301s, which is past the 300s backoff and inside the 600s grace. That is the exact
+    window in which the witnessed bot returned, so a cell that dispatches here is a cell that
+    dispatches in production.
+    """
+    store, repo, runtime = _storm_rig()
+    feed = _ics(_event(start="20260708T150000Z"))
+    terminal_id = store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status=cell.status, data=cell.data(START.isoformat()),
+    )
+
+    await sync_user(store, USER, parse_ics(feed, now=START + timedelta(seconds=10)))
+    counters = await _sweep(repo, runtime, START + timedelta(seconds=301))
+
+    recreated = [
+        row for row in await store.list_meetings(USER)
+        if row["id"] != terminal_id and row.get("status") not in ("completed", "failed")
+    ]
+    if cell.dispatches:
+        assert recreated, f"{cell.name}: the occurrence is unserved and must re-arm — {cell.why}"
+        assert counters["spawned"] == 1, f"{cell.name}: {cell.why}"
+        assert len(runtime.specs) == 1
+    else:
+        assert not recreated, (
+            f"{cell.name}: recreated a dispatchable row for a finished occurrence — {cell.why}"
+        )
+        assert counters["spawned"] == 0 and not runtime.specs, (
+            f"{cell.name}: a bot went back into the meeting — {cell.why}"
+        )
+
+
+# ---------------------------------------------------------------------------------------------
+# Recurrence — the suppression is occurrence-scoped, and every cell must respect that.
+# ---------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cell", MATRIX, ids=lambda c: c.name)
+async def test_cell_never_suppresses_the_next_occurrence(cell: Cell):
+    """Whatever today's outcome was, NEXT WEEK's instance of the same UID arms normally.
+
+    The one way this whole mechanism could fail catastrophically is by binding a decision to the
+    calendar UID instead of the occurrence: a single stopped standup would then silence the series
+    forever. Scoped by ``OCCURRENCE_MATCH_S``, and pinned here for every cell rather than for the
+    one that happened to be written first.
+    """
+    store, _repo, _runtime = _storm_rig()
+    weekly = _ics(_event(start="20260708T150000Z", rrule="FREQ=WEEKLY"))
+    store.seed_meeting(
+        user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
+        status=cell.status, data=cell.data(START.isoformat()),
+    )
+
+    # Two hours on: today's occurrence is out of the window, so the feed's event for this UID is
+    # next week's — a DIFFERENT occurrence, which today's outcome says nothing about.
+    result = await sync_user(store, USER, parse_ics(weekly, now=START + timedelta(hours=2)))
+
+    assert result["counts"]["created"] == 1, (
+        f"{cell.name}: today's outcome suppressed NEXT WEEK's meeting — the decision is scoped to "
+        f"the occurrence, never to the calendar UID"
+    )
+    fresh = next(row for row in await store.list_meetings(USER) if row["status"] == "scheduled")
+    assert fresh["data"]["scheduled_at"] == "2026-07-15T15:00:00+00:00"
+    assert fresh["data"].get("auto_join") is not False
+    assert "stop_requested" not in fresh["data"]

--- a/core/meetings/services/meeting-api/tests/test_calendar_sync.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_sync.py
@@ -839,14 +839,21 @@ async def test_recreated_row_carries_the_attempt_only_for_the_same_occurrence():
 
 async def test_terminal_row_the_sweep_never_dispatched_for_owes_no_backoff():
     """Positive evidence only. A row that reached terminal WITHOUT an auto-join dispatch (a manual
-    "Send bot now", a meeting the user simply held) is not evidence of a spent attempt — the
-    re-imported occurrence arms normally."""
+    "Send bot now" whose bot could not get in) is not evidence of a spent attempt — the re-imported
+    occurrence arms normally, with no backoff to wait out.
+
+    The fixture is a FAILED row, not a completed one. A completed row is a served occurrence and is
+    no longer recreated at all (``lifecycle.occurrence`` — an occurrence whose bot did the job never
+    gets another), so it cannot carry this rule; the retry-eligible shape is the pre-active failure.
+    """
     store, _repo, _runtime = _storm_rig()
     feed = _ics(_event(start="20260708T150000Z"))
     store.seed_meeting(
         user_id=USER, platform="google_meet", native_meeting_id="abc-defg-hij",
-        status="completed", data={"calendar_uid": "uid-1", "auto_join": True,
-                                  "scheduled_at": START.isoformat()},
+        status="failed", data={"calendar_uid": "uid-1", "auto_join": True,
+                               "completion_reason": "join_failure",
+                               "failure_stage": "joining",
+                               "scheduled_at": START.isoformat()},
     )
 
     await sync_user(store, USER, parse_ics(feed, now=START + timedelta(seconds=10)))

--- a/core/meetings/services/meeting-api/tests/test_stop_route.py
+++ b/core/meetings/services/meeting-api/tests/test_stop_route.py
@@ -128,3 +128,154 @@ def test_second_delete_never_re_stops_a_pre_active_bot():
         second = TestClient(app).delete(f"/bots/google_meet/once-{stage}", headers={"x-user-id": "7"})
         assert second.status_code == 404, f"{stage}: a redelivered stop must not re-trigger"
         assert len(pub.published) == published, f"{stage}: second DELETE re-published a leave command"
+
+
+# ── "explicit stop must be stop, evict" (founder ruling 2026-08-17) ──────────────────────────────
+#
+# A stop means the MEETING, not one container. `find_active` returns the newest row — enough for the
+# POST dedup, wrong for a stop: a SIBLING row on the same (user, platform, native) survived, and a
+# sibling still waiting in the lobby walked into the meeting after the user had said no. Siblings
+# are not hypothetical; they are the exact shape the auto-join sweep's duplicate guard exists for
+# (a manual "Send bot now" plus a calendar import that failed to adopt it — rows 26237 + 26251 on
+# one native id, live 2026-08-17).
+
+
+def _stopped(repo, user_id, platform, native):
+    rows = asyncio.run(repo.find_active_rows(user_id, platform, native))
+    return [row for row in rows if (row.get("data") or {}).get("stop_requested")]
+
+
+def test_stop_evicts_a_sibling_waiting_in_the_lobby():
+    """The founder's case: one bot is live, a second is still `awaiting_admission`. ONE stop takes
+    both down — flag, leave command, and (for the booting one) its workload."""
+    repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+    app = create_app(meeting_repo=repo, command_publisher=pub)
+    live = _seed(repo, user_id=7, platform="google_meet", native="mjm", status="active")
+    waiting = _seed(repo, user_id=7, platform="google_meet", native="mjm",
+                    status="awaiting_admission")
+
+    r = TestClient(app).delete("/bots/google_meet/mjm", headers={"x-user-id": "7"})
+    assert r.status_code == 200, r.text
+
+    stopped_ids = {row["id"] for row in _stopped(repo, 7, "google_meet", "mjm")}
+    assert stopped_ids == {live["id"], waiting["id"]}, (
+        "the stop left a sibling running — it will join the meeting the user just ended"
+    )
+
+    # each bot listens on its OWN meeting-scoped channel, so eviction means addressing it by id
+    channels = {chan for chan, _ in pub.published}
+    assert channels == {
+        f"bot_commands:meeting:{live['id']}",
+        f"bot_commands:meeting:{waiting['id']}",
+    }
+    # `also_stopped` names what the stop took BEYOND the row the caller would have gotten from
+    # `find_active` (the newest — here the waiting sibling). Reported so a duplicate bot is
+    # visible in the response and not merely in a log line.
+    assert r.json()["meeting_id"] == waiting["id"]
+    assert r.json()["also_stopped"] == [live["id"]]
+
+
+def test_stop_evicts_every_pre_active_sibling_and_preserves_each_stage():
+    """Eviction must not cost the #807 guarantee: each evicted row keeps the stage it died in."""
+    repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+    app = create_app(meeting_repo=repo, command_publisher=pub)
+    seeded = {
+        stage: _seed(repo, user_id=7, platform="google_meet", native="multi", status=stage)
+        for stage in ("requested", "joining", "awaiting_admission")
+    }
+
+    r = TestClient(app).delete("/bots/google_meet/multi", headers={"x-user-id": "7"})
+    assert r.status_code == 200, r.text
+
+    rows = {row["id"]: row for row in asyncio.run(repo.find_active_rows(7, "google_meet", "multi"))}
+    assert len(rows) == 3
+    for stage, meeting in seeded.items():
+        row = rows[meeting["id"]]
+        assert (row["data"] or {}).get("stop_requested") is True, f"{stage} survived the stop"
+        assert row["status"] == stage, f"{stage}: eviction overwrote the stage it died in (#807)"
+
+
+def test_stopped_siblings_never_re_dispatch_the_occurrence():
+    """The two halves meeting: every row the stop evicted classifies USER_STOPPED, so calendar sync
+    will not recreate the occurrence for ANY of them. Eviction without this would only move the
+    problem — the sibling dies now and is reborn on the next sync."""
+    from meeting_api.lifecycle.occurrence import Disposition, disposition
+
+    repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+    app = create_app(meeting_repo=repo, command_publisher=pub)
+    _seed(repo, user_id=7, platform="google_meet", native="reborn", status="active")
+    _seed(repo, user_id=7, platform="google_meet", native="reborn", status="awaiting_admission")
+
+    assert TestClient(app).delete(
+        "/bots/google_meet/reborn", headers={"x-user-id": "7"}
+    ).status_code == 200
+
+    for row in asyncio.run(repo.find_active_rows(7, "google_meet", "reborn")):
+        # the bots' own terminal events land later; the flag is what survives into them
+        for terminal in ("completed", "failed"):
+            assert disposition({**row, "status": terminal}) is Disposition.USER_STOPPED, (
+                "a stopped row whose terminal lands as %s must stay final for the occurrence"
+                % terminal
+            )
+
+
+def test_a_sibling_spawned_after_the_stop_is_still_evicted():
+    """The one-shot guard is PER ROW, not per request. A redelivered DELETE is a no-op (404), but a
+    NEW sibling that appeared after the first stop is a new bot heading for the same meeting — and
+    the user's stop already said no to that room."""
+    repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+    app = create_app(meeting_repo=repo, command_publisher=pub)
+    _seed(repo, user_id=7, platform="google_meet", native="late", status="active")
+
+    assert TestClient(app).delete(
+        "/bots/google_meet/late", headers={"x-user-id": "7"}
+    ).status_code == 200
+    published = len(pub.published)
+
+    # nothing new → the redelivery guard holds
+    assert TestClient(app).delete(
+        "/bots/google_meet/late", headers={"x-user-id": "7"}
+    ).status_code == 404
+    assert len(pub.published) == published
+
+    # a fresh sibling arrives → the stop reaches it
+    latecomer = _seed(repo, user_id=7, platform="google_meet", native="late", status="joining")
+    r = TestClient(app).delete("/bots/google_meet/late", headers={"x-user-id": "7"})
+    assert r.status_code == 200, r.text
+    assert (chan := f"bot_commands:meeting:{latecomer['id']}") in {c for c, _ in pub.published}, chan
+
+
+def test_stop_tears_down_an_evicted_siblings_workload():
+    """A booting sibling has not subscribed to its command channel yet, which is precisely why it
+    outlived the stop. The leave command alone cannot reach it — its workload must be torn down."""
+    from meeting_api.bot_spawn.fakes import FakeRuntimeClient
+
+    repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+    runtime = FakeRuntimeClient()
+    app = create_app(meeting_repo=repo, command_publisher=pub, runtime=runtime)
+    _seed(repo, user_id=7, platform="google_meet", native="tear", status="active")
+    booting = _seed(repo, user_id=7, platform="google_meet", native="tear", status="joining")
+    asyncio.run(repo.set_bot_container(meeting_id=booting["id"], bot_container_id="wl-booting"))
+
+    assert TestClient(app).delete(
+        "/bots/google_meet/tear", headers={"x-user-id": "7"}
+    ).status_code == 200
+    assert "wl-booting" in runtime.deleted, (
+        "the evicted sibling's workload survived — a bot nobody can command is still joining"
+    )
+
+
+def test_stop_marks_a_row_that_has_no_session_yet():
+    """A row spawned so recently that its session write has not landed still has to carry the user
+    intent — the flag is the only durable evidence, and without it the calendar recreates the
+    occurrence and sends another bot."""
+    repo, pub = InMemoryMeetingRepo(), InMemoryCommandPublisher()
+    app = create_app(meeting_repo=repo, command_publisher=pub)
+    sessionless = asyncio.run(repo.create_meeting(
+        user_id=7, platform="google_meet", native_meeting_id="nosess", data={}
+    ))
+
+    r = TestClient(app).delete("/bots/google_meet/nosess", headers={"x-user-id": "7"})
+    assert r.status_code == 200, r.text
+    rows = {row["id"]: row for row in asyncio.run(repo.find_active_rows(7, "google_meet", "nosess"))}
+    assert (rows[sessionless["id"]]["data"] or {}).get("stop_requested") is True


### PR DESCRIPTION
## The witness

Stage rev 192, 2026-08-17 — a calendar occurrence (Teams), meeting row 26312:

| time | what happened |
|---|---|
| 22:21:01 | the auto-join sweep dispatched a bot for the occurrence (`auto_join_last_attempt` stamped) |
| 22:28:31 | **26312 → `completed` / `stopped`** — the bot had joined, done its job, and was deliberately stopped |
| 22:28:46 | calendar sync recreated the occurrence as row **26313** (the #1200 carry path: terminal row inside the occurrence window → recreate with the spent-attempt stamps) |
| 22:28:47 | the sweep dispatched a **fresh bot** — the 300s backoff since 22:21:01 had legitimately elapsed, and the grace window was still open |

An uninvited bot walked back into the founder's meeting 16 seconds after he ended it.

## The defect

#1200 built a **rate limit** — *how soon may we try again* — where an **eligibility rule** was needed — *may we ever*. Backoff cannot express "never", so every served occurrence sat one elapsed interval away from a second bot. The retry gate keyed on `status in ("completed", "failed")`, which treats "the bot did the job and left" identically to "the bot never got in".

## The decision matrix

The witnessed cell is one of twenty. `lifecycle/occurrence.py` is the whole table, enumerated from the code — the sealed `CompletionReason` enum, plus `start_failed` which `fail_meeting` writes straight to `data.completion_reason` without ever passing through the enum, plus the absent-reason case.

| terminal status | `completion_reason` | `failure_stage` | user-stop evidence | decision | why |
|---|---|---|---|---|---|
| `failed` | `join_failure` | `joining` | — | **retry after backoff** | the transient join fault #1200 was built for |
| `failed` | `join_failure` | `requested` | — | **retry after backoff** | died before it reported; nothing refused us |
| `failed` | `awaiting_admission_timeout` | `awaiting_admission` | — | **retry after backoff** | nobody let it out of the lobby in time; TRANSIENT in `retry.py` |
| `failed` | `start_failed` | `requested` | — | **retry after backoff** | out-of-enum: the *workload* never started |
| `failed` | *(absent)* | *(absent)* | — | **retry after backoff** | no producer emits this; pre-#1200 status quo, backoff-bounded |
| `completed` | `left_alone` | — | — | occurrence served · no dispatch | the meeting ended and the bot left |
| `completed` | `startup_alone` | — | — | occurrence served · no dispatch | it got in and found an empty room |
| `completed` | `evicted` | — | — | occurrence served · no dispatch | someone *removed* it — the rudest possible retry |
| `completed` | `max_bot_time_exceeded` | — | — | occurrence served · no dispatch | a fresh bot restarts the same clock |
| `completed` | *(absent)* | — | — | occurrence served · no dispatch | `COMPLETED` is reachable only from `ACTIVE` (`machine.LEGAL_TRANSITIONS`) — the bot was in the room |
| `failed` | `awaiting_admission_rejected` | `awaiting_admission` | — | occurrence served · no dispatch | the host said **no**; PERMANENT in `retry.py` |
| `failed` | `auth_session_missing` | `joining` | — | occurrence served · no dispatch | a re-spawn hits the same signed-out profile |
| `failed` | `validation_error` | `requested` | — | occurrence served · no dispatch | identical on every retry |
| `failed` | `join_failure` | **`active`** | — | occurrence served · no dispatch | it *was* admitted (pipeline-start failure) — a retry is a second visit |
| `failed` | *(absent)* | **`active`** | — | occurrence served · no dispatch | positive evidence of admission; the stage decides |
| `failed` | `left_alone` | `active` | — | occurrence served · no dispatch | an active-phase reason means it reached the room |
| `completed` | `stopped` | — | — | **user-stopped** · no dispatch | *the witnessed incident* |
| `failed` | `stopped` | `awaiting_admission` | `stop_requested` | **user-stopped** · no dispatch | stopped while waiting to be admitted — still the user saying no |
| `failed` | `stopped` | `joining` | `stop_requested` | **user-stopped** · no dispatch | stopped before it ever knocked |
| `failed` | `join_failure` | `joining` | `stop_requested` | **user-stopped** · no dispatch | the terminal blamed the network, but the user had already pressed stop |

Three rules, in priority order: **user-stop evidence wins at any stage** → **admitted-to-the-room wins** → then and only then, positively-retryable failures retry (behind #1200's backoff).

`tests/test_auto_join_occurrence_matrix.py` mirrors the table cell for cell — one `Cell` per row, three tests each (the classification, the live seam through sync + sweep at +301s, and next-occurrence-still-arms) — and `test_matrix_covers_every_reason_the_codebase_can_emit` fails **by name** when a `CompletionReason` gains a value with no row.

## No-recreate, not recreate-disarmed

Sync now skips creating a row for a finished occurrence rather than creating a disarmed one. The occurrence is already in the user's list — as the terminal meeting carrying its transcript, which is a truer record than an empty planned sibling next to it. And a disarmed row would be a persistent liability: it is the UID's row, so the *next* occurrence matches it by uid and updates in place, inheriting `auto_join: false` — next week's bot silently never comes. `_source_updates` also recomputes `auto_join` from calendar policy whenever the source entry changes, so the disarm would not even hold reliably within the occurrence. No row carries no state and cannot leak across occurrences.

## "Explicit stop must be stop, evict"

Per the founder ruling. `DELETE /bots` resolved **one** row (`find_active`, newest first) — enough for the POST dedup, wrong for a stop. A sibling row on the same `(user, platform, native)` survived the stop and joined afterwards; that two-rows-one-native shape is not hypothetical, it is exactly what the sweep's duplicate-dispatch guard exists for (rows 26237 + 26251, native `mjm-dycn-qdp`, 2026-08-17).

The stop now takes the **room**: new `find_active_rows` port → every non-terminal row gets the `stop_requested` flag, its own meeting-scoped leave command, and workload teardown if it is still booting (a booting sibling has not subscribed to its command channel — which is precisely why it outlived the stop). The one-shot redelivery guard moves **per row**, so a repeated `DELETE` is still a 404 while a sibling spawned *after* the stop is still evicted. The response gains `also_stopped` so a duplicate bot is visible, not just logged.

Eviction and the matrix are one fix, not two: every evicted row carries `stop_requested`, which is what classifies it USER_STOPPED above. Eviction alone would have moved the problem to the next sync.

## Preserved

- #1200's storm tests are **untouched and green** — the storm ceiling, the occurrence scoping, and the one-retry-after-backoff are unchanged for failure-class outcomes.
- Recurrence: every cell is asserted not to suppress the next occurrence. The scope is `OCCURRENCE_MATCH_S`, never the calendar UID — one stopped standup must never silence the series.
- `test_terminal_row_the_sweep_never_dispatched_for_owes_no_backoff` keeps its rule but moves its fixture from a `completed` row to a `failed`/`join_failure` one: a completed row is now a served occurrence and no longer recreated at all, so it cannot carry a rule about the backoff a *recreated* row owes. Every assertion is unchanged.

## Tests

`meeting-api`: **961 → 1030 passed**, 3 skipped, no regressions. 15 of the 20 matrix cells fail without this change; 4 of the 5 eviction tests fail without it (verified by mutation).

Not merged, not deployed.

Refs #1150

<!-- vexa-agent -->
