### PR TITLE
[DEV] fix(auto-join): calendar bots record like manual bots (#1216)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py
@@ -31,6 +31,12 @@ is ONE dispatch per backoff interval per occurrence however many rows that occur
 ``auto_join`` defaults ON when the key is absent — planning a meeting with a time means the bot
 comes, opting out is the explicit act.
 
+The bot that comes is the SAME bot POST /bots sends: recording and transcription resolve through
+``env_flags.resolve_spawn_flag``, the one resolver the route uses, so a calendar bot records like a
+manual one (#1216). Passing nothing meant inheriting ``request_bot``'s ``recording_enabled=False``
+default, and every calendar-joined meeting on stage rev 194 came back unrecorded while manual ones
+recorded — a split default nobody chose.
+
 The tick is a pure-ish function over injected ports (repo, runtime, context fetcher, clock) — the
 entrypoint (``__main__``) wraps it in the standard poll loop; tests drive single ticks offline.
 """
@@ -45,6 +51,7 @@ from ..service_authority import (
     ServiceAuthorityDenied,
     ServiceAuthorityUnavailable,
 )
+from .env_flags import resolve_spawn_flag
 from .ports import MaxBotsExceeded, MeetingStopped, QuotaExceeded, SpawnFailed
 from .service import DuplicateMeeting, request_bot
 
@@ -225,6 +232,16 @@ async def auto_join_tick(
     )
     ctx_cache: dict[int, Optional[dict]] = {}
     uncapped_warned = False
+    # A calendar bot records and transcribes exactly like a manual one (founder ruling
+    # 2026-08-17: the split default is not a policy, it is a bug). `request_bot` defaults
+    # `recording_enabled=False` for its own callers' safety, so a sweep that passed nothing spawned
+    # every calendar bot with `capture_modes=None` — no recording pipeline, `data.recording_enabled
+    # = false`, and a dashboard that says "No audio recording for this meeting" as if that were
+    # normal (#1216; stage rev 194 meeting 26353 auto/0 recordings vs 26354 manual/893KB master.webm,
+    # 10 of 10 auto-joined rows unrecorded). Resolved through the SAME resolver POST /bots uses, so
+    # the two spawners cannot drift again; there is no per-user setting today, and this invents none.
+    recording_enabled = resolve_spawn_flag("RECORDING_ENABLED", default=True)
+    transcribe_enabled = resolve_spawn_flag("TRANSCRIBE_ENABLED", default=True)
 
     async def _stamp_error(row: dict, message: str, *, counter: str = "errors",
                            event: str = "auto_join_failed") -> None:
@@ -305,6 +322,8 @@ async def auto_join_tick(
                 native_meeting_id=row["native_meeting_id"],
                 meeting_url=data.get("constructed_meeting_url"),
                 bot_name=_calendar_bot_name(data) or ctx.get("bot_name"),
+                recording_enabled=recording_enabled,
+                transcribe_enabled=transcribe_enabled,
                 max_concurrent=ctx.get("max_concurrent"),
                 webhook_url=ctx.get("webhook_url"),
                 webhook_secret=ctx.get("webhook_secret"),

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/env_flags.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/env_flags.py
@@ -48,3 +48,45 @@ def env_flag(name: str, default: bool = True, raw: Optional[str] = None) -> bool
         name, value, "/".join(_TRUE), "/".join(_FALSE), default,
     )
     return default
+
+
+class InvalidFlagValue(ValueError):
+    """A caller-supplied flag value that is neither a bool nor a recognized boolean string."""
+
+    def __init__(self, field: str):
+        super().__init__(f"{field} must be a boolean")
+        self.field = field
+
+
+def resolve_spawn_flag(
+    env_name: str,
+    value: Optional[object] = None,
+    *,
+    default: bool = True,
+    field: Optional[str] = None,
+) -> bool:
+    """THE single resolution for a spawn boolean, shared by every caller of ``request_bot``.
+
+    An explicit caller value wins; otherwise the env decides (through ``env_flag``, so a
+    set-but-empty value keeps the default rather than inverting it). The caller value is
+    type-validated — a bool is honored, a recognized string is parsed, an empty string is an
+    explicit False (a request body that says ``""`` asked for off), and anything else raises
+    ``InvalidFlagValue`` rather than being ``bool()``-coerced (which turned ``"false"`` into True).
+
+    It lives HERE, not in ``router.py``, because the HTTP route is not the only spawner: the
+    auto-join sweep spawns the same bots and must resolve the same way. When the sweep read no
+    default at all it inherited ``request_bot``'s ``recording_enabled=False`` and every
+    calendar-joined bot silently skipped recording while every manual bot recorded (#1216, proven
+    on stage rev 194 by meetings 26353/26354). One resolver is what makes that drift impossible.
+    """
+    if value is None:
+        return env_flag(env_name, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in _TRUE:
+            return True
+        if v in _FALSE or v == "":
+            return False
+    raise InvalidFlagValue(field or env_name.lower())

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -25,7 +25,7 @@ from ..service_authority import (
     ServiceAuthorityDenied,
     ServiceAuthorityUnavailable,
 )
-from .env_flags import env_flag
+from .env_flags import InvalidFlagValue, resolve_spawn_flag
 from .ports import (
     AuthSessionBusy,
     AuthSessionNotConfigured,
@@ -57,44 +57,27 @@ NATIVE_MEETING_ID_URL_CHARS = "?#&=/"
 
 
 def _resolve_recording_enabled(value: Optional[object]) -> bool:
-    """Recording default: an explicit request value wins; else the ``RECORDING_ENABLED`` env
-    (default ``true``), so a dashboard bot records by default. The request value is type-validated —
-    a bool is honored, a string is parsed (``"true"``/``"false"`` etc.), and any other type is a 422
-    (NOT silently ``bool()``-coerced, which would turn the string ``"false"`` into ``True``).
+    """Recording default for POST /bots: the HTTP skin over the shared ``resolve_spawn_flag`` —
+    an explicit request value wins, else the ``RECORDING_ENABLED`` env (default ``true``), so a
+    dashboard bot records by default. An unparseable value is a 422, never a silent ``bool()``
+    coercion (which would turn the string ``"false"`` into ``True``).
 
-    The env is read through ``env_flag``, so a set-but-empty ``RECORDING_ENABLED=`` keeps the
-    default instead of resolving False (see env_flags — the v0.12.5 witness bug)."""
-    if value is None:
-        return env_flag("RECORDING_ENABLED", True)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        v = value.strip().lower()
-        if v in ("true", "1", "yes", "on"):
-            return True
-        if v in ("false", "0", "no", "off", ""):
-            return False
-    raise HTTPException(status_code=422, detail="recording_enabled must be a boolean")
+    The resolution itself lives in ``env_flags`` so the auto-join sweep resolves IDENTICALLY
+    (#1216): calendar-joined bots record exactly like manual ones."""
+    try:
+        return resolve_spawn_flag("RECORDING_ENABLED", value, default=True,
+                                  field="recording_enabled")
+    except InvalidFlagValue as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
 
 def _resolve_transcribe_enabled(value: Optional[object]) -> bool:
-    """Transcription default: an explicit request value wins; else the ``TRANSCRIBE_ENABLED`` env
-    (default ``true``). Type-validated like ``recording_enabled`` (CC3) — a bare ``bool(...)`` turned the
-    JSON string ``"false"`` into ``True``, silently ENABLING transcription a caller asked to disable.
-
-    The env is read through ``env_flag``: a set-but-empty ``TRANSCRIBE_ENABLED=`` kept the default
-    OFF and shipped capture-only bots to every Lite self-host (the v0.12.5 witness bug)."""
-    if value is None:
-        return env_flag("TRANSCRIBE_ENABLED", True)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        v = value.strip().lower()
-        if v in ("true", "1", "yes", "on"):
-            return True
-        if v in ("false", "0", "no", "off", ""):
-            return False
-    raise HTTPException(status_code=422, detail="transcribe_enabled must be a boolean")
+    """Transcription default for POST /bots — same shared resolver, same 422 skin (CC3)."""
+    try:
+        return resolve_spawn_flag("TRANSCRIBE_ENABLED", value, default=True,
+                                  field="transcribe_enabled")
+    except InvalidFlagValue as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
 
 def _resolve_automatic_leave(value: Optional[object]) -> dict:

--- a/core/meetings/services/meeting-api/tests/test_auto_join_recording_parity.py
+++ b/core/meetings/services/meeting-api/tests/test_auto_join_recording_parity.py
@@ -1,0 +1,139 @@
+"""A calendar-joined bot records exactly like a manual one (#1216).
+
+The defect, proven on stage rev 194: the auto-join sweep called ``request_bot`` without
+``recording_enabled``, so it inherited that parameter's ``False`` default → ``capture_modes=None``
+→ no recording pipeline at all, ``data.recording_enabled = false``, and a dashboard that renders
+"No audio recording for this meeting" as if that were the normal outcome. The HTTP path resolved
+the same flag from the request body else ``RECORDING_ENABLED`` (default true), so **manual bots
+recorded and calendar bots never did** — 10 of 10 auto-joined rows unrecorded. Evidence pair:
+meeting 26353 (auto, ``BOT_CONFIG.recordingEnabled=False``, 0 recordings) against 26354 (manual,
+True, ``master.webm`` 893KB).
+
+Founder ruling 2026-08-17: the split default is not a policy, it is a bug — calendar bots record
+like manual bots. There is no per-user recording setting today and this pins none: parity with the
+env default is the whole contract.
+
+The second class of test here is the one that keeps it fixed: the sweep and the route must resolve
+recording through the SAME function, so a future change to one cannot silently move only one of
+them. That is why ``resolve_spawn_flag`` lives in ``env_flags`` rather than in ``router``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from meeting_api.bot_spawn.auto_join import auto_join_tick
+from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
+from meeting_api.bot_spawn.router import (
+    _resolve_recording_enabled,
+    _resolve_transcribe_enabled,
+)
+
+USER = 7
+PLAT, NID = "google_meet", "abc-defg-hij"
+NOW = datetime(2026, 8, 17, 15, 0, 0, tzinfo=timezone.utc)
+
+_NO_GATE = lambda: None  # noqa: E731 — these tests bypass the STT capability gate
+
+
+def _seed(repo, *, mid=1):
+    repo._meetings[mid] = {
+        "id": mid, "user_id": USER, "platform": PLAT,
+        "native_meeting_id": NID, "platform_specific_id": NID,
+        "status": "scheduled", "bot_container_id": None, "start_time": None, "end_time": None,
+        "data": {"title": "t", "auto_join": True, "scheduled_at": NOW.isoformat()},
+        "created_at": "2026-08-17T09:00:00Z", "updated_at": "2026-08-17T09:00:00Z",
+    }
+    return mid
+
+
+async def _sweep_bot_config(monkeypatch, **env):
+    """One sweep tick; returns (BOT_CONFIG dict the runtime was handed, meeting.data)."""
+    for key, value in env.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    mid = _seed(repo)
+    counters = await auto_join_tick(
+        repo, runtime, transcribe_gate=_NO_GATE, now=NOW,
+        token_secret="s", redis_url="redis://r", allow_uncapped=True,
+    )
+    assert counters["spawned"] == 1, counters
+    config = json.loads(runtime.specs[0]["env"]["VEXA_BOT_CONFIG"])
+    return config, repo._meetings[mid]["data"]
+
+
+# ---- (1) the sweep records by default, and honours an explicit opt-out ----------------------
+
+async def test_sweep_dispatched_bot_records_under_default_env(monkeypatch):
+    """THE regression: with no ``RECORDING_ENABLED`` set at all, a calendar bot records."""
+    config, data = await _sweep_bot_config(monkeypatch, RECORDING_ENABLED=None)
+    assert config["recordingEnabled"] is True, (
+        "a calendar-joined bot must record like a manual one (#1216) — "
+        "recordingEnabled=False is the stage rev 194 defect"
+    )
+    assert config["captureModes"] == ["audio", "video"], (
+        "recording_enabled=False collapses capture_modes to None — no recording pipeline runs"
+    )
+    assert data["recording_enabled"] is True, "the meeting row must not read back unrecorded"
+
+
+async def test_sweep_dispatched_bot_records_when_env_set_but_empty(monkeypatch):
+    """``RECORDING_ENABLED=`` from an --env-file is not an explicit opt-out (the v0.12.5 shape)."""
+    config, _ = await _sweep_bot_config(monkeypatch, RECORDING_ENABLED="")
+    assert config["recordingEnabled"] is True
+
+
+async def test_sweep_respects_an_explicit_recording_opt_out(monkeypatch):
+    """The deployment that says false still gets false — parity means parity in both directions."""
+    config, data = await _sweep_bot_config(monkeypatch, RECORDING_ENABLED="false")
+    assert config["recordingEnabled"] is False
+    assert config.get("captureModes") is None  # None-stripped from the invocation
+    assert data["recording_enabled"] is False
+
+
+async def test_sweep_transcribes_by_default_and_respects_the_opt_out(monkeypatch):
+    """Same inherited-default class, same fix: the sweep read no ``TRANSCRIBE_ENABLED`` at all, so
+    ``TRANSCRIBE_ENABLED=false`` disabled transcription for POST /bots but not for the sweep."""
+    config, _ = await _sweep_bot_config(monkeypatch, TRANSCRIBE_ENABLED=None)
+    assert config["transcribeEnabled"] is True
+    config, _ = await _sweep_bot_config(monkeypatch, TRANSCRIBE_ENABLED="false")
+    assert config["transcribeEnabled"] is False
+
+
+# ---- (2) the two spawners cannot drift apart again ------------------------------------------
+
+@pytest.mark.parametrize("raw", [None, "", "true", "false", "1", "0", "yes", "off", "maybe"])
+async def test_sweep_and_route_resolve_recording_identically(monkeypatch, raw):
+    """Parity, pinned across the whole env vocabulary — including the unrecognized value, which
+    must keep the default on BOTH paths rather than opting either one out."""
+    config, _ = await _sweep_bot_config(monkeypatch, RECORDING_ENABLED=raw)
+    route = _resolve_recording_enabled(None)  # what POST /bots would send with no body value
+    assert config["recordingEnabled"] is route, (
+        f"RECORDING_ENABLED={raw!r}: the sweep spawned recordingEnabled="
+        f"{config['recordingEnabled']} while POST /bots would spawn {route}"
+    )
+
+
+@pytest.mark.parametrize("raw", [None, "", "true", "false", "0", "maybe"])
+async def test_sweep_and_route_resolve_transcription_identically(monkeypatch, raw):
+    config, _ = await _sweep_bot_config(monkeypatch, TRANSCRIBE_ENABLED=raw)
+    assert config["transcribeEnabled"] is _resolve_transcribe_enabled(None)
+
+
+def test_both_route_resolvers_are_the_shared_resolver():
+    """Structural half of the parity guarantee: one source of truth, not two copies that agree
+    today. A copy-paste divergence is exactly how #1216 shipped."""
+    import inspect
+
+    from meeting_api.bot_spawn import env_flags
+
+    for fn in (_resolve_recording_enabled, _resolve_transcribe_enabled):
+        assert "resolve_spawn_flag" in inspect.getsource(fn), (
+            f"{fn.__name__} must delegate to env_flags.resolve_spawn_flag, never re-implement it"
+        )
+    assert callable(env_flags.resolve_spawn_flag)


### PR DESCRIPTION
## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

---

## The defect

The auto-join sweep spawns bots through the same `request_bot` flow `POST /bots` runs — but it never passed `recording_enabled`, so it inherited that parameter's `False` default (`bot_spawn/service.py:270`). That collapses `capture_modes` to `None` (`service.py:584`): no recording pipeline is started at all, the meeting row reads back `data.recording_enabled = false`, and the dashboard renders "No audio recording for this meeting" as if that were the normal outcome.

The HTTP path resolved the same flag from the request body else the `RECORDING_ENABLED` env, defaulting true (`bot_spawn/router.py::_resolve_recording_enabled`). So **manual bots recorded and calendar bots never did**, silently.

**Evidence (stage rev 194):**

| meeting | how it joined | `BOT_CONFIG.recordingEnabled` | recordings |
|---|---|---|---|
| 26353 | calendar auto-join | `False` | none |
| 26354 | manual "Send bot now" | `True` | `master.webm`, 893 KB |

10 of 10 auto-joined rows were unrecorded.

## The ruling

Founder, 2026-08-17: calendar auto-joined bots record by default, exactly like manual bots — the split default is "stupid policy". No per-user recording setting exists today and this PR invents none; env-default-true parity is the whole fix.

## The change

`_resolve_recording_enabled` / `_resolve_transcribe_enabled` moved out of `router.py` into `env_flags.resolve_spawn_flag`, and both spawners now call it. The router keeps its thin HTTP skin (a bad value is still a 422 with the same detail); the sweep resolves once per tick and passes the result to `request_bot`. One source of truth rather than two copies that happen to agree today — a copy-paste divergence is exactly how this shipped.

`request_bot`'s own `recording_enabled=False` default is left alone: explicit caller resolution is the pattern here, and both callers now resolve explicitly.

**Other-callers audit:** `request_bot` has exactly two non-test callers — `router.py:393` and `auto_join.py:300`. No third caller silently inherits the default.

**Same class, found in the audit:** the sweep also passed no `transcribe_enabled`, inheriting `request_bot`'s `True`. That is right by accident under the default env and wrong under `TRANSCRIBE_ENABLED=false`, which disabled transcription for the route but not for the sweep. Fixed the same way and pinned by the same parity test.

## Tests

New `tests/test_auto_join_recording_parity.py` (20 tests):

1. **Behaviour** — a sweep-dispatched bot carries `recordingEnabled=True` and `captureModes=["audio","video"]` under the default env, under a set-but-empty `RECORDING_ENABLED=` (the `--env-file` shape), and `False` under an explicit `RECORDING_ENABLED=false`; the meeting row's `data.recording_enabled` matches.
2. **Parity** — across the whole env vocabulary (`unset`, `""`, `true`, `false`, `1`, `0`, `yes`, `off`, and an unrecognized `maybe`), what the sweep dispatches equals what `POST /bots` would resolve, plus a structural check that neither route resolver re-implements the shared one.

Red pre-fix: 12 of 20 fail on the parent commit with the source change reverted. Full meeting-api suite green: **1133 passed, 5 skipped** (1113 before this PR's 20).

Fixes #1216

<!-- vexa-agent -->

