### PR TITLE
dashboard: meetings list sorts by event time, non-terminal pinned (#1222)

### DIFF
--- a/services/dashboard/src/lib/meeting-list.test.ts
+++ b/services/dashboard/src/lib/meeting-list.test.ts
@@ -1,0 +1,74 @@
+// #1222 — the list orders by MEETING EVENT time, non-terminal rows pinned first, matching the
+// server (meeting-api list_meetings). The witnessed failure: a calendar row imported Aug 16,
+// live Aug 18, sat at position 19 under 18 rows created since the import.
+import { describe, expect, it } from "vitest";
+
+import { compareMeetingsListOrder } from "./meeting-list";
+import type { Meeting } from "@/types/vexa";
+
+function meeting(partial: Partial<Meeting> & { id: string }): Meeting {
+  return {
+    platform: "google_meet",
+    platform_specific_id: `native-${partial.id}`,
+    status: "completed",
+    start_time: null,
+    end_time: null,
+    bot_container_id: null,
+    data: {},
+    created_at: "2026-08-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+describe("compareMeetingsListOrder", () => {
+  it("puts the live calendar meeting (imported days ago) at position 0", () => {
+    const live = meeting({
+      id: "26298", status: "active",
+      created_at: "2026-08-16T22:40:00Z",
+      data: { scheduled_at: "2026-08-18T09:00:00Z" },
+    });
+    const sinceImport = Array.from({ length: 18 }, (_, i) => meeting({
+      id: `${26300 + i}`, status: "completed",
+      created_at: `2026-08-17T${String(i).padStart(2, "0")}:00:00Z`,
+      start_time: `2026-08-17T${String(i).padStart(2, "0")}:00:30Z`,
+    }));
+    const sorted = [...sinceImport, live].sort(compareMeetingsListOrder);
+    expect(sorted[0].id).toBe("26298");
+  });
+
+  it("pins every non-terminal status above a fresher terminal row", () => {
+    const freshTerminal = meeting({
+      id: "9", status: "completed", created_at: "2026-08-18T12:00:00Z",
+      start_time: "2026-08-18T12:00:30Z",
+    });
+    const pinned = (["scheduled", "requested", "joining", "awaiting_admission", "active",
+      "stopping"] as const).map((status, i) => meeting({
+      id: `${i + 1}`, status, created_at: "2026-08-10T00:00:00Z",
+      data: { scheduled_at: `2026-08-1${i}T09:00:00Z` },
+    }));
+    const sorted = [freshTerminal, ...pinned].sort(compareMeetingsListOrder);
+    expect(sorted[sorted.length - 1].id).toBe("9");
+  });
+
+  it("orders within a group by scheduled_at ?? start_time ?? created_at desc, id tiebreak", () => {
+    const byStart = meeting({ id: "3", created_at: "2026-08-10T00:00:00Z",
+      start_time: "2026-08-17T10:00:00Z" });
+    const byCreated = meeting({ id: "4", created_at: "2026-08-16T00:00:00Z" });
+    const byScheduled = meeting({ id: "5", created_at: "2026-08-01T00:00:00Z",
+      data: { scheduled_at: "2026-08-18T09:00:00Z" } });
+    const tieOld = meeting({ id: "6", created_at: "2026-08-15T00:00:00Z" });
+    const tieNew = meeting({ id: "7", created_at: "2026-08-15T00:00:00Z" });
+    const sorted = [tieOld, byStart, byCreated, tieNew, byScheduled]
+      .sort(compareMeetingsListOrder);
+    expect(sorted.map((m) => m.id)).toEqual(["5", "3", "4", "7", "6"]);
+  });
+
+  it("degrades a malformed scheduled_at to start_time/created_at instead of NaN-scrambling", () => {
+    const bad = meeting({ id: "1", created_at: "2026-08-18T08:00:00Z",
+      data: { scheduled_at: "not-a-timestamp" } });
+    const good = meeting({ id: "2", created_at: "2026-08-17T00:00:00Z",
+      data: { scheduled_at: "2026-08-18T09:00:00Z" } });
+    const sorted = [bad, good].sort(compareMeetingsListOrder);
+    expect(sorted.map((m) => m.id)).toEqual(["2", "1"]);
+  });
+});

--- a/services/dashboard/src/lib/meeting-list.ts
+++ b/services/dashboard/src/lib/meeting-list.ts
@@ -42,6 +42,33 @@ export function isHiddenDeletedMeeting(meeting: Meeting): boolean {
   return meeting.data?.redacted === true || !meeting.platform_specific_id;
 }
 
+// #1222: the list orders by MEETING EVENT time with non-terminal rows pinned first — the exact
+// key the server emits (meeting-api list_meetings: status-pin DESC, COALESCE(data.scheduled_at,
+// start_time, created_at) DESC, id DESC). A calendar-managed row is created at IMPORT time, so
+// the old created_at sort buried a meeting that was live right now under every row created since
+// the import. The client sort must match or pagination merges re-shuffle the server's pages.
+const PINNED_STATUSES = new Set<Meeting["status"]>([
+  "scheduled", "requested", "joining", "awaiting_admission", "active", "stopping",
+]);
+
+function eventTime(meeting: Meeting): number {
+  const scheduled = typeof meeting.data?.scheduled_at === "string"
+    ? Date.parse(meeting.data.scheduled_at) : NaN;
+  if (!Number.isNaN(scheduled)) return scheduled;
+  const start = meeting.start_time ? Date.parse(meeting.start_time) : NaN;
+  if (!Number.isNaN(start)) return start;
+  const created = Date.parse(meeting.created_at);
+  return Number.isNaN(created) ? 0 : created;
+}
+
+export function compareMeetingsListOrder(a: Meeting, b: Meeting): number {
+  const pin = Number(PINNED_STATUSES.has(b.status)) - Number(PINNED_STATUSES.has(a.status));
+  if (pin !== 0) return pin;
+  const time = eventTime(b) - eventTime(a);
+  if (time !== 0) return time;
+  return (Number(b.id) || 0) - (Number(a.id) || 0);
+}
+
 export function prepareMeetingPage(
   rawMeetings: RawMeeting[],
   hasMore: boolean,
@@ -49,8 +76,6 @@ export function prepareMeetingPage(
   const meetings = rawMeetings
     .map(mapRawMeeting)
     .filter((meeting) => !isHiddenDeletedMeeting(meeting));
-  meetings.sort(
-    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-  );
+  meetings.sort(compareMeetingsListOrder);
   return { meetings, hasMore };
 }

--- a/services/dashboard/src/stores/meetings-store.ts
+++ b/services/dashboard/src/stores/meetings-store.ts
@@ -6,6 +6,7 @@ import {
   createTranscriptManager,
 } from "@vexaai/transcript-rendering";
 import {
+  compareMeetingsListOrder,
   type InitialMeetingsPage,
   isHiddenDeletedMeeting,
   MEETINGS_PAGE_SIZE,
@@ -164,9 +165,8 @@ export const useMeetingsStore = create<MeetingsState>((set, get) => ({
       const PAGE = MEETINGS_PAGE_SIZE;
       const result = await vexaAPI.getMeetings({ limit: PAGE, offset: 0, ...activeFilters });
       const meetings = result.meetings.filter((m) => !isHiddenDeletedMeeting(m));
-      meetings.sort((a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
+      // #1222: match the server's list ordering (event time, non-terminal rows pinned).
+      meetings.sort(compareMeetingsListOrder);
       // #304: advance _offset by the UNFILTERED page size (PAGE), NOT by
       // meetings.length. The API returns up to PAGE rows; client-side
       // filter may drop some (redacted shells); next request must ask
@@ -210,9 +210,8 @@ export const useMeetingsStore = create<MeetingsState>((set, get) => ({
       const seen = new Set(meetings.map((m) => m.id));
       const deduped = newMeetings.filter((m) => !seen.has(m.id));
       const merged = [...meetings, ...deduped];
-      merged.sort((a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
+      // #1222: match the server's list ordering (event time, non-terminal rows pinned).
+      merged.sort(compareMeetingsListOrder);
       set({
         meetings: merged,
         hasMore: result.has_more,

--- a/services/dashboard/src/types/vexa.ts
+++ b/services/dashboard/src/types/vexa.ts
@@ -54,6 +54,9 @@ export interface MeetingData {
   completion_reason?: string;
   // Status history
   status_transition?: StatusTransition[];
+  // The meeting's EVENT time (ISO-8601) — set on planned/calendar-managed rows; the list
+  // orders by it (#1222).
+  scheduled_at?: string;
   calendar_uid?: string;
   calendar_connection_id?: string;
   calendar_name?: string;


### PR DESCRIPTION
Client half of #1222 — companion to #1226 (server ordering). **Do not merge — next rc or next train, founder's call.** Based on `codex/prod-dashboard-source-accounting` because the retained dashboard source lives only there (34565b48).

The store re-sorted every page by `created_at`, which would re-bury the live calendar meeting client-side even after the server orders correctly (witnessed prod 2026-08-18: row 26298 at position 19 while the founder was in it). One comparator in `lib/meeting-list.ts` now matches the server key exactly — non-terminal pin (scheduled/requested/joining/awaiting_admission/active/stopping), then `data.scheduled_at ?? start_time ?? created_at` DESC, then id DESC — used by `prepareMeetingPage` and both store sorts (`fetchMeetings`, `fetchMoreMeetings`).

Tests: comparator suite in `meeting-list.test.ts` incl. the 26298 shape at position 0; vitest 67/67 green. `tsc --noEmit` shows only the pre-existing `release-version.generated.json` build-artifact error.

Rung: PR open, not merged.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

> ⚠️ **Left unticked deliberately.** This section was appended by the 0.12.24 car session
> (`angry-margulis-b594ff`) because the description was missing it entirely and the
> `contribution-rights` gate had nothing to read. The choice is a legal certification and belongs
> to the human author — no agent may make it. Nothing else in this description was altered.
