### PR TITLE
[DEV] API keys only do what their scope allows — enforce scope on bot lifecycle and user-config routes

### DIFF
--- a/core/gateway/services/gateway/src/gateway/__init__.py
+++ b/core/gateway/services/gateway/src/gateway/__init__.py
@@ -6,8 +6,10 @@ SAME app runs with real adapters in prod and in-process fakes in the conformance
 
 Public surface (the front door):
   - ``create_app(authorizer, downstream, redis, ...)`` — the FastAPI gateway (REST proxy,
-    fail-closed auth + scope 403, verbatim body passthrough; the ``/ws`` multiplex;
-    ``/health``).
+    fail-closed auth + deny-by-default scope 403, verbatim body passthrough; the ``/ws``
+    multiplex; ``/health``). Raises if any route it registers declares no scope.
+  - ``ROUTE_SCOPES`` / ``UNSCOPED_ROUTES`` / ``undeclared_routes(app)`` — the scope model and
+    the executable form of the deny-by-default invariant.
   - ``run_multiplex(ws, authorizer, redis)`` — the ``/ws`` control loop + fan-in, exposed so the
     conformance ws-harness drives the SHIPPED multiplex without reaching for a private.
   - ``ports`` — the Protocols: ``Authorizer``, ``DownstreamClient``, ``RedisBus`` (+ helpers).
@@ -19,13 +21,15 @@ shipped app; this package imports nothing from conformance.
 """
 from __future__ import annotations
 
-from .app import ROUTE_SCOPES, create_app, run_multiplex
+from .app import ROUTE_SCOPES, UNSCOPED_ROUTES, create_app, run_multiplex, undeclared_routes
 from .ports import Authorizer, DownstreamClient, PubSub, RedisBus
 
 __all__ = [
     "create_app",
     "run_multiplex",
     "ROUTE_SCOPES",
+    "UNSCOPED_ROUTES",
+    "undeclared_routes",
     "Authorizer",
     "DownstreamClient",
     "RedisBus",

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -5,7 +5,9 @@ behavior is the v0.12 carve of the deployed ``services/api-gateway/main.py``:
 
   * the ``forward_request`` auth middleware — ``x-api-key`` resolved via the ``Authorizer``
     port (admin-api ``/internal/validate``); fail-closed 401 when missing/invalid; scope 403
-    via ``ROUTE_SCOPES`` (main.py:287-369, 59-65),
+    via ``ROUTE_SCOPES`` (main.py:287-369, 59-65), now DENY-BY-DEFAULT: the table is keyed by
+    (method, route template) and is exhaustive over the router, so an undeclared route is
+    refused at request time and refuses to build at all,
   * the CORE proxy routes — each forwards its method to the matching downstream URL and returns
     the downstream body + status VERBATIM (main.py:450-831, 367),
   * the ``/ws`` multiplex control loop + redis pub/sub fan-in — subscribe → Subscribed ack;
@@ -29,13 +31,14 @@ import asyncio
 import json
 import os
 from contextlib import AsyncExitStack
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
 from urllib.parse import quote
 
 import httpx  # the downstream adapter's transport errors are mapped to 502/504 (not leaked as a 500)
 
 from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse
+from fastapi.routing import APIRoute
 
 from .obs import TRACE_HEADER, TraceMiddleware, get_trace_id, log_event, set_user_id
 from .ports import Authorizer, AuthUnavailable, DownstreamClient, RedisBus
@@ -59,14 +62,143 @@ def _auth_unavailable_response(exc: Exception, *, span: str) -> Response:
         headers={"Retry-After": "1"},
     )
 
-# Route-prefix → required scope set. Mirrors main.py ROUTE_SCOPES (main.py:59-65) for the CORE
-# surface the gateway lane carves; multi-scope tokens pass for any of their domains.
-ROUTE_SCOPES: Dict[str, Set[str]] = {
-    "/bots": {"bot", "browser"},
-    "/transcripts": {"tx"},
-    "/meetings": {"tx"},
-    "/recordings": {"tx", "bot"},
+# --- the scope model -------------------------------------------------------------------------
+# The three key scopes, as ``docs/docs/authentication.mdx`` defines them:
+#   bot     — "send and manage meeting bots, read transcripts"
+#   tx      — "transcription / transcript access"
+#   browser — "browser-tool capabilities"
+#
+# Read as capabilities, that gives one rule per domain:
+#   BOT       anything that can make a bot EXIST, stop existing, or change how it behaves — the
+#             whole /bots surface, and the calendar connections, because auto-join turns a feed
+#             into bot spawns (the same cost vector as POST /bots, reached by another door).
+#   TX        the transcript/meeting data plane: meeting records, transcripts.
+#   BOT_OR_TX account-level config and reads that belong to either service domain (recordings,
+#             webhook config + delivery history, model/transcription prefs, agent, MCP). Neither
+#             scope alone is privileged over the other here; what matters is that a key with
+#             NEITHER — a browser-only key — is refused.
+#   browser   grants NO gateway route. v0.12 serves no browser-tool surface at this edge, so a
+#             browser-only key can authenticate (GET /auth/me) and do nothing else.
+BOT: FrozenSet[str] = frozenset({"bot"})
+TX: FrozenSet[str] = frozenset({"tx"})
+BOT_OR_TX: FrozenSet[str] = frozenset({"bot", "tx"})
+
+# (HTTP method, ROUTE TEMPLATE) → the scopes that satisfy it; a multi-scope token passes when it
+# holds ANY of them. Keyed by the route's own template (``request.scope["route"].path``), never by
+# a path PREFIX: prefix matching is what let ``/user/webhook`` and ``/user/calendar`` fall through
+# to "no entry, therefore no check", and what made ``{"bot","browser"}`` on the ``/bots`` prefix
+# hand a browser-only key the whole bot lifecycle (rc.18 sweep finding B2 — a browser-only key
+# spawned container ``mtg-26362-7c9e8908`` on staging and then stopped it).
+#
+# THIS TABLE IS EXHAUSTIVE AND ENFORCED AS SUCH. A proxied route that is absent from it is DENIED
+# at request time and, so the hole cannot ship, refuses to build at all: ``create_app`` raises when
+# any registered ``APIRoute`` is neither declared here nor in ``UNSCOPED_ROUTES``. Adding a route
+# therefore requires deciding its scope — the check is not an allowlist anyone must remember to
+# extend, it is a wall the new route walks into.
+ROUTE_SCOPES: Dict[Tuple[str, str], FrozenSet[str]] = {
+    # --- bot lifecycle: spawn · stop · list · status · config · speak · chat-read ---
+    ("GET", "/bots"): BOT,
+    ("POST", "/bots"): BOT,
+    ("GET", "/bots/status"): BOT,
+    ("DELETE", "/bots/{platform}/{native_meeting_id}"): BOT,
+    ("PUT", "/bots/{platform}/{native_meeting_id}/config"): BOT,
+    ("POST", "/bots/{platform}/{native_meeting_id}/speak"): BOT,
+    ("GET", "/bots/{platform}/{native_meeting_id}/chat"): BOT,
+    # --- the meeting record plane ---
+    ("GET", "/meetings"): TX,
+    ("POST", "/meetings"): TX,
+    ("GET", "/meetings/{meeting_id}"): TX,
+    ("PATCH", "/meetings/{meeting_id}"): TX,
+    ("DELETE", "/meetings/{meeting_id}"): TX,
+    ("PATCH", "/meetings/{platform}/{native_meeting_id}"): TX,
+    ("DELETE", "/meetings/{platform}/{native_meeting_id}"): TX,
+    ("PUT", "/meetings/{platform}/{native_meeting_id}/intent"): TX,
+    ("POST", "/meetings/{platform}/{native_meeting_id}/share"): TX,
+    ("POST", "/meetings/{platform}/{native_meeting_id}/workspace"): TX,
+    # --- transcripts ---
+    ("GET", "/transcripts/by-id/{meeting_id}"): TX,
+    ("GET", "/transcripts/{platform}/{native_meeting_id}"): TX,
+    ("POST", "/transcripts/{platform}/{native_meeting_id}/share"): TX,
+    ("POST", "/transcripts/share/accept"): TX,
+    # --- recordings (unchanged: the sealed table already accepted either domain) ---
+    ("GET", "/recordings"): BOT_OR_TX,
+    ("GET", "/recordings/{recording_id}"): BOT_OR_TX,
+    ("GET", "/recordings/{recording_id}/master"): BOT_OR_TX,
+    ("GET", "/recordings/{recording_id}/media/{media_file_id}/raw"): BOT_OR_TX,
+    ("GET", "/recordings/{recording_id}/media/{media_file_id}/download"): BOT_OR_TX,
+    # --- calendar connections: BOT, because auto-join spawns bots from the feed ---
+    ("GET", "/user/calendar"): BOT,
+    ("PUT", "/user/calendar"): BOT,
+    ("GET", "/user/calendar/sync"): BOT,
+    ("POST", "/user/calendar/sync"): BOT,
+    ("GET", "/user/calendars"): BOT,
+    ("POST", "/user/calendars"): BOT,
+    ("PATCH", "/user/calendars/{calendar_id}"): BOT,
+    ("DELETE", "/user/calendars/{calendar_id}"): BOT,
+    ("GET", "/user/calendars/{calendar_id}/sync"): BOT,
+    ("POST", "/user/calendars/{calendar_id}/sync"): BOT,
+    # --- the rest of the self-serve account config (no bot-spawn power of its own) ---
+    ("GET", "/user/webhook"): BOT_OR_TX,
+    ("PUT", "/user/webhook"): BOT_OR_TX,
+    ("GET", "/user/webhook/deliveries"): BOT_OR_TX,
+    ("GET", "/user/models"): BOT_OR_TX,
+    ("PUT", "/user/models"): BOT_OR_TX,
+    ("GET", "/user/transcription"): BOT_OR_TX,
+    ("PUT", "/user/transcription"): BOT_OR_TX,
+    # --- the agent control plane. Per-RESOURCE authorization here is still the open Stage-3 gap
+    # (see the strict-xfail in tests/test_proxy.py); this table only settles which KEYS reach it.
+    ("POST", "/agent/chat"): BOT_OR_TX,
+    ("GET", "/agent/meeting/stream"): BOT_OR_TX,
+    ("GET", "/agent/{path:path}"): BOT_OR_TX,
+    ("POST", "/agent/{path:path}"): BOT_OR_TX,
+    ("PUT", "/agent/{path:path}"): BOT_OR_TX,
+    ("PATCH", "/agent/{path:path}"): BOT_OR_TX,
+    ("DELETE", "/agent/{path:path}"): BOT_OR_TX,
+    # --- the MCP front door. Its tools call BACK through this gateway with the caller's own key,
+    # so /bots is gated on that second hop too; this is the first hop.
+    ("GET", "/mcp"): BOT_OR_TX,
+    ("POST", "/mcp"): BOT_OR_TX,
+    ("PUT", "/mcp"): BOT_OR_TX,
+    ("PATCH", "/mcp"): BOT_OR_TX,
+    ("DELETE", "/mcp"): BOT_OR_TX,
+    ("OPTIONS", "/mcp"): BOT_OR_TX,
+    ("GET", "/mcp/{path:path}"): BOT_OR_TX,
+    ("POST", "/mcp/{path:path}"): BOT_OR_TX,
+    ("PUT", "/mcp/{path:path}"): BOT_OR_TX,
+    ("PATCH", "/mcp/{path:path}"): BOT_OR_TX,
+    ("DELETE", "/mcp/{path:path}"): BOT_OR_TX,
+    ("OPTIONS", "/mcp/{path:path}"): BOT_OR_TX,
 }
+
+# The routes that carry NO scope requirement, declared explicitly so "no entry" can mean "denied"
+# everywhere else. Both are identity-only and forward nothing downstream: /health is the LB probe
+# (unauthenticated by design) and /auth/me is "who is this key" — a browser-only key must be able
+# to learn that it is a browser-only key.
+UNSCOPED_ROUTES: FrozenSet[Tuple[str, str]] = frozenset({
+    ("GET", "/health"),
+    ("GET", "/auth/me"),
+})
+
+
+def undeclared_routes(app: FastAPI) -> List[Tuple[str, str]]:
+    """Every (method, route-template) on ``app`` with no entry in ROUTE_SCOPES or UNSCOPED_ROUTES.
+
+    The executable form of the deny-by-default invariant, used by ``create_app``'s build-time
+    assertion and by the guard test. WebSocket routes are out of frame: ``/ws`` is not an
+    ``APIRoute``, it does not pass through ``_authorize``, and its subscribe leg authorizes each
+    meeting against the caller's ownership downstream.
+    """
+    missing: List[Tuple[str, str]] = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue  # FastAPI's own /openapi.json + /docs + /redoc, and the /ws socket
+        for method in sorted(route.methods or ()):
+            if method == "HEAD":
+                continue  # never registered by FastAPI itself; mirrors its GET sibling if it is
+            key = (method, route.path)
+            if key not in ROUTE_SCOPES and key not in UNSCOPED_ROUTES:
+                missing.append(key)
+    return missing
 
 # Default sentinel base URL. The DownstreamClient (real httpx or the fake ASGI transport) resolves
 # it; what matters is the PATH the gateway forwards to (verbatim from the route). v0.12 P2 folded
@@ -117,11 +249,28 @@ def _invalid_path_param_response() -> Response:
     )
 
 
-def _required_scopes(path: str) -> Optional[Set[str]]:
-    for prefix, scopes in ROUTE_SCOPES.items():
-        if path.startswith(prefix):
-            return scopes
-    return None
+def _required_scopes(request: Request) -> Optional[FrozenSet[str]]:
+    """The scopes declared for the route this request MATCHED, or ``None`` when it declares none.
+
+    Resolved from the matched route's template (``request.scope["route"].path``) rather than from
+    the request path, so ``/user/calendars/{id}`` is one declaration instead of a prefix that also
+    swallows whatever route is added beside it next. ``None`` means DENY: the caller of this
+    function fails closed, so a route that reaches ``_authorize`` without a declaration answers 403
+    instead of forwarding.
+    """
+    route = request.scope.get("route")
+    path = getattr(route, "path", None)
+    if not path:
+        return None
+    return ROUTE_SCOPES.get((request.method.upper(), path))
+
+
+def _insufficient_scope_response() -> Response:
+    return Response(
+        content=json.dumps({"detail": "Insufficient scope for this endpoint"}),
+        status_code=403,
+        media_type="application/json",
+    )
 
 
 def create_app(
@@ -221,28 +370,37 @@ def create_app(
                 headers={"Retry-After": "1"},
             )
 
-        # Scope enforcement (main.py:341-351).
-        # Stage 3 SCAFFOLD (not delivered): the agent domain (/api/*) carries NO scope today, so a valid
-        # key reaches any agent route. When Stage 3 lands, add agent-route scopes here (or a canAccess
-        # default-deny resolved per (user_id, resource owner)) so a key can read ONLY its owner's
-        # workspace/sessions/routines — see core/agent canAccess + the capability-token seam.
-        required = _required_scopes(request.url.path)
-        if required is not None:
-            user_scopes = set(user_data.get("scopes", []))
-            if not user_scopes & required:
-                log_event(
-                    "request_denied_scope",
-                    audience="user",
-                    level="warning",
-                    span="auth",
-                    user_id=user_id,
-                    fields={"method": method, "path": request.url.path, "required": sorted(required)},
-                )
-                return None, Response(
-                    content=json.dumps({"detail": "Insufficient scope for this endpoint"}),
-                    status_code=403,
-                    media_type="application/json",
-                )
+        # Scope enforcement — DENY BY DEFAULT. Every proxied route declares its scopes in
+        # ROUTE_SCOPES; an undeclared route is refused here rather than forwarded, so the failure
+        # mode of forgetting a declaration is a 403 the author trips over, not an open door. (The
+        # build-time check in create_app means an undeclared route cannot normally reach this at
+        # all — this is the second wall, for a route registered onto the app after construction.)
+        #
+        # Per-RESOURCE authorization remains separate and still open on the agent domain: this
+        # decides WHICH KEYS reach a route, not which of the owner's objects they may touch. See
+        # the strict-xfail on GET /agent/meeting/stream in tests/test_proxy.py.
+        required = _required_scopes(request)
+        if required is None:
+            log_event(
+                "request_denied_undeclared_route",
+                audience="system",
+                level="error",
+                span="auth",
+                user_id=user_id,
+                fields={"method": method, "path": request.url.path},
+            )
+            return None, _insufficient_scope_response()
+        user_scopes = set(user_data.get("scopes", []))
+        if not user_scopes & required:
+            log_event(
+                "request_denied_scope",
+                audience="user",
+                level="warning",
+                span="auth",
+                user_id=user_id,
+                fields={"method": method, "path": request.url.path, "required": sorted(required)},
+            )
+            return None, _insufficient_scope_response()
 
         # USER-facing event: the request was accepted on behalf of this user.
         log_event(
@@ -499,8 +657,9 @@ def create_app(
     # Identity OWNS the config (user.data JSONB via admin-api); the gateway is the public edge for
     # it, exactly like the meeting routes: _forward resolves the key via /internal/validate (the
     # Authorizer), injects identity headers, and returns the downstream body + status verbatim.
-    # No ROUTE_SCOPES entry — any valid key may manage its own webhook (parity with 0.10.6, which
-    # gated it on api_key_scheme alone).
+    # Scoped BOT_OR_TX: the webhook is account config for the two service domains, so a key that
+    # owns either may manage it — but a key that owns NEITHER may not. Until rc.18 this route had
+    # no entry at all, and "no entry" meant "no check" (sweep finding B2).
     def _admin(path: str) -> str:
         return f"{admin_api_url}{path}"
 
@@ -516,15 +675,16 @@ def create_app(
     # #841: the per-user webhook DELIVERY HISTORY — the queryable record of real delivery outcomes
     # (the user-facing completion of #815→#817). Unlike the config above (identity-owned, admin-api),
     # the deliveries live in meeting-api (the dispatcher that records each outcome), so this forwards
-    # THERE. No ROUTE_SCOPES entry (any valid key reads its own history, parity with /user/webhook);
-    # the shared auth prep injects X-User-Id so meeting-api scopes the read to the owner.
+    # THERE. Scoped BOT_OR_TX like the config above; the shared auth prep injects X-User-Id so
+    # meeting-api scopes the read to the owner.
     @app.get("/user/webhook/deliveries")
     async def get_user_webhook_deliveries(request: Request):
         return await _forward("GET", _meeting("/webhooks/deliveries"), request)
 
     # ---- user self-serve calendar-sync config (identity owns it, same shape as /user/webhook).
-    # The ICS URL is a secret — admin-api masks it on every read-back. No ROUTE_SCOPES entry
-    # (any valid key manages its own calendar), parity with the webhook self-serve. ----
+    # The ICS URL is a secret — admin-api masks it on every read-back. Scoped BOT, not BOT_OR_TX:
+    # a connection with auto_join on turns every event in the feed into a bot spawn, so managing
+    # one is bot-lifecycle power reached through a different door. ----
     # calendar-sync feedback edges live in MEETING-api (they run the sync), unlike the config
     # (identity). Registered before the config routes only for reading clarity - paths are exact.
     @app.get("/user/calendar/sync")
@@ -580,7 +740,7 @@ def create_app(
         return await _forward("POST", _meeting(f"/user/calendars/{segment}/sync"), request)
 
     # ---- user self-serve model + transcription prefs (identity owns them, same shape as
-    # /user/webhook: secrets masked by admin-api on every read-back, no ROUTE_SCOPES entry). ----
+    # /user/webhook: secrets masked by admin-api on every read-back, scoped BOT_OR_TX). ----
     @app.put("/user/models")
     async def set_user_models(request: Request):
         return await _forward("PUT", _admin("/user/models"), request)
@@ -753,6 +913,20 @@ def create_app(
     @app.websocket("/ws")
     async def websocket_multiplex(ws: WebSocket):
         await run_multiplex(ws, authorizer, redis)
+
+    # ---- deny by default, at BUILD time ----
+    # The route table is now complete, so every route must have declared its scopes. Refusing to
+    # BUILD is the point: a 403 at request time only tells whoever hits the route, and only after
+    # it ships, whereas this fires in every unit test, every conformance run and the container's
+    # own start-up. An under-declared gateway does not boot.
+    missing = undeclared_routes(app)
+    if missing:
+        raise RuntimeError(
+            "gateway routes with no scope declaration: "
+            + ", ".join(f"{m} {p}" for m, p in missing)
+            + " — add each to gateway.app.ROUTE_SCOPES (or, for an identity-only route that needs "
+            "no scope, to UNSCOPED_ROUTES)."
+        )
 
     return app
 

--- a/core/gateway/services/gateway/tests/test_scope_matrix.py
+++ b/core/gateway/services/gateway/tests/test_scope_matrix.py
@@ -1,0 +1,301 @@
+"""The per-route scope matrix, and the deny-by-default guard that keeps it complete.
+
+Motivated by the rc.18 documented-API sweep against staging (finding B2): a key holding ONLY the
+``browser`` scope returned 201 on ``POST /bots`` and scheduled a real bot container
+(``mtg-26362-7c9e8908``), then stopped it with ``DELETE``. Same hole on ``GET /bots``,
+``/bots/status``, ``/bots/{p}/{n}/chat``, ``/user/webhook`` and ``/user/calendar``, while
+``/meetings``, ``/transcripts/*`` and ``/recordings`` refused it correctly — the mechanism existed
+and those routes simply were not using it.
+
+Two causes, one per family:
+  * ``/bots`` was declared ``{"bot", "browser"}``, so ``browser`` alone satisfied it;
+  * ``/user/*`` had no declaration at all, and an absent declaration meant "no check".
+
+This module is the executable spec for both halves: a matrix of every protected route against every
+single-scope key, and a guard proving a route with no declaration is denied rather than forwarded.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+import gateway.app as app_module
+from gateway import ROUTE_SCOPES, UNSCOPED_ROUTES, create_app, undeclared_routes
+from conftest import VALID_KEY, FakeAuthorizer, FakeDownstream, FakeRedis
+
+AUTH = {"x-api-key": VALID_KEY}
+
+# One concrete request per protected route template. Path params are filled with fixtures the
+# downstream fake never looks at — the assertion is on the EDGE's verdict, which is reached before
+# any forward. Every entry is checked against the router's own table by
+# ``test_matrix_covers_every_declared_route`` below, so this list cannot silently drift.
+CASES = [
+    # method, url, route template
+    ("GET", "/bots", "/bots"),
+    ("POST", "/bots", "/bots"),
+    ("GET", "/bots/status", "/bots/status"),
+    ("DELETE", "/bots/google_meet/abc-defg-hij", "/bots/{platform}/{native_meeting_id}"),
+    ("PUT", "/bots/google_meet/abc-defg-hij/config", "/bots/{platform}/{native_meeting_id}/config"),
+    ("POST", "/bots/google_meet/abc-defg-hij/speak", "/bots/{platform}/{native_meeting_id}/speak"),
+    ("GET", "/bots/google_meet/abc-defg-hij/chat", "/bots/{platform}/{native_meeting_id}/chat"),
+
+    ("GET", "/meetings", "/meetings"),
+    ("POST", "/meetings", "/meetings"),
+    ("GET", "/meetings/42", "/meetings/{meeting_id}"),
+    ("PATCH", "/meetings/42", "/meetings/{meeting_id}"),
+    ("DELETE", "/meetings/42", "/meetings/{meeting_id}"),
+    ("PATCH", "/meetings/google_meet/abc-defg-hij", "/meetings/{platform}/{native_meeting_id}"),
+    ("DELETE", "/meetings/google_meet/abc-defg-hij", "/meetings/{platform}/{native_meeting_id}"),
+    ("PUT", "/meetings/google_meet/abc-defg-hij/intent",
+     "/meetings/{platform}/{native_meeting_id}/intent"),
+    ("POST", "/meetings/google_meet/abc-defg-hij/share",
+     "/meetings/{platform}/{native_meeting_id}/share"),
+    ("POST", "/meetings/google_meet/abc-defg-hij/workspace",
+     "/meetings/{platform}/{native_meeting_id}/workspace"),
+
+    ("GET", "/transcripts/by-id/42", "/transcripts/by-id/{meeting_id}"),
+    ("GET", "/transcripts/google_meet/abc-defg-hij", "/transcripts/{platform}/{native_meeting_id}"),
+    ("POST", "/transcripts/google_meet/abc-defg-hij/share",
+     "/transcripts/{platform}/{native_meeting_id}/share"),
+    ("POST", "/transcripts/share/accept", "/transcripts/share/accept"),
+
+    ("GET", "/recordings", "/recordings"),
+    ("GET", "/recordings/5", "/recordings/{recording_id}"),
+    ("GET", "/recordings/5/master", "/recordings/{recording_id}/master"),
+    ("GET", "/recordings/5/media/9/raw", "/recordings/{recording_id}/media/{media_file_id}/raw"),
+    ("GET", "/recordings/5/media/9/download",
+     "/recordings/{recording_id}/media/{media_file_id}/download"),
+
+    ("GET", "/user/calendar", "/user/calendar"),
+    ("PUT", "/user/calendar", "/user/calendar"),
+    ("GET", "/user/calendar/sync", "/user/calendar/sync"),
+    ("POST", "/user/calendar/sync", "/user/calendar/sync"),
+    ("GET", "/user/calendars", "/user/calendars"),
+    ("POST", "/user/calendars", "/user/calendars"),
+    ("PATCH", "/user/calendars/work-1", "/user/calendars/{calendar_id}"),
+    ("DELETE", "/user/calendars/work-1", "/user/calendars/{calendar_id}"),
+    ("GET", "/user/calendars/work-1/sync", "/user/calendars/{calendar_id}/sync"),
+    ("POST", "/user/calendars/work-1/sync", "/user/calendars/{calendar_id}/sync"),
+
+    ("GET", "/user/webhook", "/user/webhook"),
+    ("PUT", "/user/webhook", "/user/webhook"),
+    ("GET", "/user/webhook/deliveries", "/user/webhook/deliveries"),
+    ("GET", "/user/models", "/user/models"),
+    ("PUT", "/user/models", "/user/models"),
+    ("GET", "/user/transcription", "/user/transcription"),
+    ("PUT", "/user/transcription", "/user/transcription"),
+
+    ("POST", "/agent/chat", "/agent/chat"),
+    ("GET", "/agent/meeting/stream", "/agent/meeting/stream"),
+    ("GET", "/agent/sessions", "/agent/{path:path}"),
+    ("POST", "/agent/routines", "/agent/{path:path}"),
+    ("PUT", "/agent/workspace/swap", "/agent/{path:path}"),
+    ("PATCH", "/agent/routines/x/enabled", "/agent/{path:path}"),
+    ("DELETE", "/agent/routines/x", "/agent/{path:path}"),
+
+    ("GET", "/mcp", "/mcp"),
+    ("POST", "/mcp", "/mcp"),
+    ("PUT", "/mcp", "/mcp"),
+    ("PATCH", "/mcp", "/mcp"),
+    ("DELETE", "/mcp", "/mcp"),
+    ("OPTIONS", "/mcp", "/mcp"),
+    ("GET", "/mcp/session", "/mcp/{path:path}"),
+    ("POST", "/mcp/session", "/mcp/{path:path}"),
+    ("PUT", "/mcp/session", "/mcp/{path:path}"),
+    ("PATCH", "/mcp/session", "/mcp/{path:path}"),
+    ("DELETE", "/mcp/session", "/mcp/{path:path}"),
+    ("OPTIONS", "/mcp/session", "/mcp/{path:path}"),
+]
+
+SCOPES = ["bot", "tx", "browser"]
+
+MATRIX = [
+    (method, url, template, scope)
+    for method, url, template in CASES
+    for scope in SCOPES
+]
+
+
+def _client(scopes):
+    """A gateway whose authorizer hands back a key carrying exactly ``scopes``."""
+    app = create_app(
+        FakeAuthorizer(user={"user_id": 7, "scopes": list(scopes), "max_concurrent": 3,
+                             "email": "u@example.com"}),
+        FakeDownstream(status_code=200, body={"ok": True}),
+        FakeRedis(),
+    )
+    return TestClient(app)
+
+
+def _request(client, method, url):
+    body = {} if method in ("POST", "PUT", "PATCH") else None
+    return client.request(method, url, headers=AUTH, json=body)
+
+
+@pytest.mark.parametrize(
+    "method,url,template,scope", MATRIX,
+    ids=[f"{m} {u} [{s}]" for m, u, _t, s in MATRIX],
+)
+def test_scope_matrix(method, url, template, scope):
+    """Every protected route × every single-scope key → allow or deny, per ROUTE_SCOPES.
+
+    The matrix is derived from the SHIPPED table rather than restated, so the assertion is
+    "the edge does what the declaration says" and the declaration is reviewed once, above.
+    """
+    allowed = scope in ROUTE_SCOPES[(method, template)]
+    r = _request(_client([scope]), method, url)
+    if allowed:
+        assert r.status_code != 403, f"{method} {url} with [{scope}] should pass the scope gate"
+    else:
+        assert r.status_code == 403, f"{method} {url} with [{scope}] → {r.status_code}, expected 403"
+        assert r.json()["detail"] == "Insufficient scope for this endpoint"
+
+
+def test_browser_only_key_reaches_no_route_at_all():
+    """The headline of rc.18 B2, stated as one fact: ``browser`` grants nothing at this edge.
+
+    v0.12 serves no browser-tool surface through the gateway, so a browser-only key must be able to
+    authenticate and do nothing else. RED before the fix on 7 routes — most consequentially
+    ``POST /bots``, which really did schedule a container on staging.
+    """
+    client = _client(["browser"])
+    for method, url, _template in CASES:
+        assert _request(client, method, url).status_code == 403, f"{method} {url} let a browser key in"
+
+
+def test_browser_only_key_can_still_read_its_own_identity():
+    """The one thing it may do: find out what it is. /auth/me carries no scope BY DECLARATION
+    (UNSCOPED_ROUTES), not by omission — otherwise a browser key could not discover its own limits."""
+    r = _client(["browser"]).get("/auth/me", headers=AUTH)
+    assert r.status_code == 200
+    assert r.json()["scopes"] == ["browser"]
+
+
+def test_browser_only_key_never_reaches_the_downstream():
+    """Fail-closed, not fail-late: the spawn is refused at the EDGE, so meeting-api is never asked
+    to create anything. On staging the forward DID happen — a bot container was scheduled."""
+    downstream = FakeDownstream(status_code=201, body={"id": 26362})
+    app = create_app(
+        FakeAuthorizer(user={"user_id": 7, "scopes": ["browser"], "max_concurrent": 3}),
+        downstream, FakeRedis(),
+    )
+    r = TestClient(app).post("/bots", headers=AUTH,
+                             json={"platform": "google_meet", "native_meeting_id": "lbc-jstz-znj"})
+    assert r.status_code == 403
+    assert downstream.last is None, "the under-scoped spawn must not reach meeting-api"
+
+
+def test_bot_scope_still_runs_the_bot_lifecycle():
+    """Negative control on the tightening: the scope the docs say owns bots still owns them, so
+    this is a fix and not a lockout. A ``bot``-only key spawns and stops."""
+    client = _client(["bot"])
+    assert client.post("/bots", headers=AUTH,
+                       json={"platform": "google_meet", "native_meeting_id": "abc"}).status_code == 200
+    assert client.delete("/bots/google_meet/abc", headers=AUTH).status_code == 200
+    assert client.get("/bots/status", headers=AUTH).status_code == 200
+
+
+def test_a_bot_and_tx_key_reaches_every_route():
+    """The shape every real key has (the terminal mints bot+tx+browser; the docs' own mint example
+    is bot+tx) is unaffected end to end — no route in the matrix regresses to 403."""
+    client = _client(["bot", "tx"])
+    for method, url, _template in CASES:
+        assert _request(client, method, url).status_code != 403, f"{method} {url} regressed"
+
+
+# --- deny by default -----------------------------------------------------------------------------
+
+def test_every_registered_route_declares_its_scopes():
+    """Exhaustive over the ROUTER, not over a hand-kept list: any route on the app that declares no
+    scope is the finding. This is the check that would have caught /user/webhook and /user/calendar
+    when they were added."""
+    app = create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())
+    assert undeclared_routes(app) == []
+
+
+def test_the_guard_actually_catches_an_undeclared_route():
+    """Negative control on the guard itself — a green check that cannot go red proves nothing.
+    Register a new route on a built app and the guard must name it."""
+    app = create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())
+
+    async def _new_endpoint():  # pragma: no cover - never called
+        return {}
+
+    app.router.routes.append(APIRoute("/user/quota", _new_endpoint, methods=["PUT"]))
+    assert undeclared_routes(app) == [("PUT", "/user/quota")]
+
+
+def test_an_undeclared_route_is_denied_at_request_time():
+    """The second wall, exercised through the real request path: with its declaration removed, a
+    route refuses a FULL-scope key rather than forwarding it. So the failure mode of forgetting a
+    declaration is a 403 the author trips over — never an open door."""
+    app = create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())
+    client = TestClient(app)
+    assert client.get("/bots/status", headers=AUTH).status_code == 200  # bot+tx+browser key
+
+    saved = dict(ROUTE_SCOPES)
+    try:
+        del ROUTE_SCOPES[("GET", "/bots/status")]
+        r = client.get("/bots/status", headers=AUTH)
+        assert r.status_code == 403
+        assert r.json()["detail"] == "Insufficient scope for this endpoint"
+    finally:
+        ROUTE_SCOPES.clear()
+        ROUTE_SCOPES.update(saved)
+
+
+def test_an_undeclared_route_cannot_be_built():
+    """The first wall: create_app refuses to return an app whose router has an undeclared route.
+    An under-declared gateway does not boot — the hole cannot reach an image."""
+    saved = dict(ROUTE_SCOPES)
+    try:
+        del ROUTE_SCOPES[("POST", "/bots")]
+        with pytest.raises(RuntimeError) as exc:
+            create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())
+        assert "POST /bots" in str(exc.value)
+    finally:
+        ROUTE_SCOPES.clear()
+        ROUTE_SCOPES.update(saved)
+
+
+def test_matrix_covers_every_declared_route():
+    """The matrix above is exhaustive over ROUTE_SCOPES — no declaration goes unexercised, and no
+    stale CASES row survives a route being removed."""
+    covered = {(method, template) for method, _url, template in CASES}
+    assert covered == set(ROUTE_SCOPES), (
+        f"declared but unexercised: {sorted(set(ROUTE_SCOPES) - covered)}; "
+        f"exercised but undeclared: {sorted(covered - set(ROUTE_SCOPES))}"
+    )
+
+
+def test_unscoped_routes_are_identity_only():
+    """The escape hatch stays small and deliberate: only /health (the LB probe) and /auth/me (who
+    am I) may carry no scope, and neither forwards anything downstream."""
+    assert UNSCOPED_ROUTES == frozenset({("GET", "/health"), ("GET", "/auth/me")})
+
+
+def test_scope_lookup_denies_when_the_matched_route_is_unknowable():
+    """``_required_scopes`` is the single decision point, and its ``None`` means DENY. If Starlette
+    ever stopped publishing the matched route, the edge must close, not open."""
+
+    class _NoRoute:
+        method = "GET"
+        scope: dict = {}
+
+    assert app_module._required_scopes(_NoRoute()) is None
+
+
+def test_route_scope_declarations_only_use_real_scopes():
+    """A typo'd scope name ('bots', 'transcript') would be unsatisfiable and lock a route out
+    silently; the vocabulary is the one admin-api mints against."""
+    vocabulary = {"bot", "tx", "browser"}
+    for key, scopes in ROUTE_SCOPES.items():
+        assert scopes, f"{key} declares an EMPTY scope set — that denies every key"
+        assert set(scopes) <= vocabulary, f"{key} declares unknown scope(s) {set(scopes) - vocabulary}"
+
+
+def test_app_is_a_fastapi_instance_after_the_build_guard():
+    """Sanity: the build-time assertion runs AFTER every route is registered and returns the app."""
+    assert isinstance(create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis()), FastAPI)

--- a/docs/docs/authentication.mdx
+++ b/docs/docs/authentication.mdx
@@ -66,9 +66,15 @@ is refused with `422` — never silently dropped.
 
 | Scope | Grants |
 |---|---|
-| `bot` | send and manage meeting bots, read transcripts |
-| `tx` | transcription / transcript access |
-| `browser` | browser-tool capabilities |
+| `bot` | bot lifecycle — `POST`/`GET`/`DELETE /bots`, `/bots/status`, bot config — and the calendar connections (`/user/calendar`, `/user/calendars/*`), because an auto-join feed spawns bots |
+| `tx` | the transcript and meeting-record plane — `/meetings*`, `/transcripts/*` |
+| `browser` | browser-tool capabilities. **Reaches no API route today** — a browser-only key can call `/auth/me` and nothing else |
+
+`/recordings*`, `/user/webhook*`, `/user/models`, `/user/transcription`, `/agent/*` and `/mcp` accept
+either `bot` or `tx`. Most keys want both: `{"scopes":["bot","tx"]}`.
+
+Every route requires a scope. A key that holds none of the scopes a route accepts gets `403`,
+whichever route it is.
 
 Keys are prefixed by their primary scope — `vxa_bot_…`, `vxa_tx_…`, `vxa_browser_…`. A key without a
 recognized scope is rejected.


### PR DESCRIPTION
A key holding only the `browser` scope could spawn bots. The rc.18 documented-API sweep against
staging caught it doing exactly that.

**Delivers issue:** _(none — found by the rc.18 documented-API sweep against `api.staging.vexa.ai`,
helm rev 196, gateway `sha256:274bd1b6…`)_

## The defect

`POST /bots` with a key whose scopes are `["browser"]` and nothing else:

```
POST https://api.staging.vexa.ai/bots
  X-API-Key: vxa_browser_…            ← scopes: ["browser"]
  {"platform":"google_meet","native_meeting_id":"lbc-jstz-znj","transcribe_enabled":false}
→ 201  {"id":26362,"status":"requested","bot_container_id":"mtg-26362-7c9e8908", …}

DELETE /bots/google_meet/lbc-jstz-znj   (same key)
→ 200  {"status":"stopping","meeting_id":26362, …}
```

A bot container was really scheduled, and then really stopped. The same key also passed
`GET /bots`, `GET /bots/status`, `GET /bots/{p}/{n}/chat`, `GET /user/webhook` and
`GET /user/calendar`. `/meetings`, `/transcripts/*` and `/recordings` refused it correctly with
`403` — the mechanism existed; these routes were not using it.

This is a cost and abuse vector, not a tenancy break: the same sweep verified cross-tenant access
is sound (`404` on another user's meeting, share tokens bounded, `/ws` subscribe authorizes per
meeting). What leaked is capability *within* the owner's account — the scope you would hand a
lower-trust surface was a full bot-control credential.

Two causes, and the second is the one that would have recurred:

- **`/bots` was declared `{"bot", "browser"}`.** The check is `user_scopes & required`, so
  `browser` alone satisfied it.
- **`/user/*` was declared nothing at all, and nothing meant no check.** `ROUTE_SCOPES` was a path
  **prefix** map; `_required_scopes` returned `None` on a miss and the caller read `None` as "this
  route needs no scope" and forwarded. Every route added since — webhook, calendar, models,
  transcription, agent, MCP — was therefore open by default, and no author had to decide anything.

## The scope model applied

`docs/docs/authentication.mdx` is the only place the scopes are defined, and it defines them as
capabilities, not as routes. Read that way:

| | Reaches |
|---|---|
| **`bot`** | anything that can make a bot exist, stop existing, or change how it behaves — the whole `/bots` surface, **and the calendar connections** |
| **`tx`** | the transcript / meeting-record plane — `/meetings*`, `/transcripts/*` |
| **`bot` or `tx`** | `/recordings*`, `/user/webhook*`, `/user/models`, `/user/transcription`, `/agent/*`, `/mcp*` |
| **`browser`** | nothing. v0.12 serves no browser-tool surface at this edge |
| **no scope** | `/health` and `/auth/me` only — declared as such in `UNSCOPED_ROUTES`, not by omission |

Calendar is under `bot` rather than "any account config" because a connection with `auto_join` on
turns every event in the feed into a bot spawn. That is the same cost vector as `POST /bots`,
reached through a different door, so it takes the same scope.

**Where the docs are ambiguous, and what was chosen.** The scopes table said `bot` grants "send and
manage meeting bots, **read transcripts**", while the shipped code has always required `tx` for
`/transcripts/*`. Both readings cannot hold. Taking the least-privilege one, the *code* is right and
the sentence was wrong, so this PR corrects the page rather than widening `bot` — that keeps
enforcement strictly a tightening, with no route becoming reachable to a key that could not reach it
before. The docs are otherwise silent on every `/user/*` route (the sweep also recorded them as
undocumented), so the model above is stated on that page now.

**Only behaviour change for a key holding a real service scope: none.** Every provisioning path in
the tree mints `bot,tx` (`deploy/lite/bin/provision-key.sh`, `deploy/lite/probe.sh`,
`deploy/compose/bin/dashboard-harness.sh`) and the terminal's login mint is `bot,tx,browser`.
Legacy un-prefixed tokens are grandfathered to all three. The one credential that loses power is
the browser-only key — which is the finding.

## What fails closed now

Deny-by-default was implemented, not deferred. The table is keyed by **(method, route template)**
and is exhaustive over the router, and a miss **denies**. Two walls:

1. **At request time** — an undeclared route answers `403` instead of forwarding.
2. **At build time** — `create_app` raises if any registered route declares nothing. An
   under-declared gateway does not boot, so the hole cannot reach an image. Adding a route now
   requires deciding its scope; this is a wall the new route walks into, not an allowlist someone
   must remember to extend.

Deliberately **out** of this diff:

- **`/ws`.** It is not an `APIRoute` and does not pass through `_authorize`; its subscribe leg
  already authorizes each meeting against the caller's ownership downstream. Adding a scope gate
  there means adding a frame to a documented protocol vocabulary, which is a wider blast radius
  than this change should carry on a release train. Named here so it is a decision, not an omission.
- **Per-resource authorization.** This settles which *keys* reach a route, never which of the
  owner's objects they may touch. The strict-`xfail` on `GET /agent/meeting/stream` still marks that
  gap open.
- **Sweep finding D3** — the `403` detail string is `"Insufficient scope for this endpoint"` where
  the docs say `"Token scope not authorized for this endpoint"`. Left alone: separate decision
  (change the string or the page), and clients may be matching on the shipped one.

## Observation bundle (the record of your harnessed loop)

- **C1 — the defect reproduces in-process, before touching it.** Ran the shipped `create_app` at
  base `c93a2437` with an authorizer returning `scopes: ["browser"]`, against the 62 protected
  `(method, route)` pairs. Saw **43 of 62 reached** — `POST /bots` and `DELETE /bots/{p}/{n}` among
  them, plus every `/user/*`, `/agent/*` and `/mcp` route. Concluded the staging observation is a
  code property, not a deployment artefact, and the `/user/*` half is the larger hole.
- **C2 — the same probe, post-fix.** Ran it against head: **0 of 62**. Concluded the gate closes
  uniformly, and the browser-only key now reaches nothing.
- **C3 — the tightening is not a lockout.** Ran the matrix with `bot`-only and `bot,tx` keys. Saw
  `bot` still spawning, stopping and listing bots, and `bot,tx` reaching every one of the 62 routes.
  Concluded no real key regresses.
- **C4 — the fail-closed is at the edge, not late.** Asserted `FakeDownstream.last is None` after a
  refused `POST /bots`. Concluded meeting-api is never asked to create anything — on staging it was,
  and a container existed as a result.
- **C5 — pre-push gate suite.** `gate:schema` failed on first push. Read the gate rather than
  bypassing: it fails identically on the untouched base commit, with `ERR_MODULE_NOT_FOUND: ajv` —
  a fresh worktree with no `node_modules`, not a repo defect. After `pnpm install --frozen-lockfile`
  all 14 fast gates are green. Worth noting anyway: `gateSchema` prints
  `e.stdout || e.stderr || e` from a `stdio: "pipe"` exec, and the useful message went to a stream
  it did not show — the gate reported a failure with an empty reason.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 · a `browser`-only key cannot spawn a bot | `test_browser_only_key_never_reaches_the_downstream` — `403` **and** the downstream is never called. Red at base: `POST /bots` → `200`, forwarded |
| A2 · the gap is closed on every route the sweep named | `test_browser_only_key_reaches_no_route_at_all` over all 62 `(method, url)` pairs. Red at base: 43 reached |
| A3 · per-route × per-scope matrix | `test_scope_matrix` — 62 routes × 3 scopes = **186 parametrized cases**, expectation read from the shipped `ROUTE_SCOPES` so the table is reviewed once |
| A4 · the matrix is exhaustive over the router | `test_matrix_covers_every_declared_route` (cases ≡ declarations, both directions) + `test_every_registered_route_declares_its_scopes` (no route on the app is undeclared) |
| A5 · a new route without a declaration is denied | `test_an_undeclared_route_is_denied_at_request_time` (403 to a **full-scope** key, through the real request path) and `test_an_undeclared_route_cannot_be_built` (`create_app` raises) |
| A6 · the guard can go red | `test_the_guard_actually_catches_an_undeclared_route` — registers a new `APIRoute` on a built app; the guard must name it |
| A7 · no regression for real keys | `test_a_bot_and_tx_key_reaches_every_route`, `test_bot_scope_still_runs_the_bot_lifecycle`, and the two suites below |

**Counts.** Gateway unit suite `core/gateway/services/gateway`: **315 passed, 1 xfailed** (was 115
passed, 1 xfailed at base — the delta is this PR's 200 new cases). Gateway conformance suite
`core/gateway/services/conformance`: **84 passed**, unchanged, including its own pre-existing
`test_insufficient_scope_is_rejected`. Pre-push static gates: **14/14 green**.

Base `c93a2437` · head `2b995088`.

## Docs diff (D6c)

`docs/docs/authentication.mdx` § Scopes — the table now says what each scope actually reaches,
including that `browser` reaches no route, plus the sentence that was missing: every route requires
a scope. Reference altitude, matching how that page already teaches (a table plus the mint example).

`docs/docs/api/errors.mdx` needed no change: "`403` when the key lacks the route's scope" was
already correct and is now true everywhere rather than only on the Meetings surface.

## Security checks (required on the diff)

The diff adds no dependency and no runtime import beyond `fastapi.routing.APIRoute`, which FastAPI
already provides — nothing to scan for licences or CVEs. No secret, credential or token value
appears in the diff or in the tests (the fixture key is the suite's existing `vxa_test_unit_key`).
The change is itself the SAST-relevant finding: the authorization decision moved from
prefix-match-with-a-permissive-miss to exhaustive-table-with-a-denying-miss. The staging evidence
above carries no key material; the one real token in the sweep was revoked (`401` verified) before
the report was written.

## Validation request

Any competent non-author; the rc.18 sweep operator preferred, since they hold the staging fixtures.

**What to watch:** mint a `browser`-only key and a `bot,tx` key for one throwaway user against a
build of this branch, then run `POST /bots` on both. The browser key must get `403` with no
container scheduled (check `GET /bots/status` and the pod list, not just the response), and the
`bot,tx` key must still spawn and stop normally. Then `GET /user/calendar` and `PUT /user/webhook`
on the browser key — both `403`.

**Deployment validated here:** in-process only (`TestClient` over the shipped `create_app`, both
suites). **Not** validated on Lite, full compose, k8s or hosted — nobody ran those, and this stays
honestly unclaimed. The staging evidence in this PR is of the **defect**, captured on rev 196
before the fix existed; the fix has not been on staging.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
