### PR TITLE
[DEV] release-images: a red build means the build failed — stop failing every rc freeze on unknowable map identity

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -736,6 +736,15 @@ jobs:
   # witness.json) and every batch change is accepted (release-value-gate), a maintainer dispatches
   # release-validate with promote:true, which then clears the witness-gate + value-gate and pauses
   # on the `release-promote` Environment for the owner's approval before :v012 moves.
+  #
+  # #1237 — what this nested call can and cannot prove at FREEZE time. release-validate's
+  # packet-bound candidate-map identity check reads a map that records the digests THIS build
+  # has only just published, so on a new rc the map cannot exist yet. release-validate defers
+  # that one check (with a notice in its run summary and a line in the guarantee block) and
+  # runs every other leg against the published bytes; a human then binds the packet and
+  # dispatches release-validate standalone, where the identity IS enforced. The consequence
+  # for this workflow's conclusion is the point: release-images is red when the build or the
+  # published artifacts are wrong, and green when they are not.
   validate:
     needs: [preflight, build, build-bot, alias-candidate, sbom]
     if: >-

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -12,7 +12,9 @@
 #                      validate-harness fix is testable BEFORE it merges to main
 #
 #   resolve         version well-formed · every published manifest resolves + carries linux/amd64
-#                   (and linux/arm64 for matrix images except vexa-bot)
+#                   (and linux/arm64 for matrix images except vexa-bot) · plus the packet-bound
+#                   candidate-map identity, enforced on every promote / stable / already-mapped
+#                   version and deferred-with-a-notice in the freeze window (#1237)
 #   image-identity  every published image CONTAINS what its NAME promises — runs in PARALLEL
 #                   with the validate legs (all consume the same published bytes); it gates
 #                   PROMOTE, not the validate verdict, so it no longer sits serially between
@@ -125,12 +127,25 @@ jobs:
   # with linux/amd64 (all images) and linux/arm64 (matrix images except vexa-bot). Everything
   # downstream fans out from here IN PARALLEL — nothing heavier stands between "validate
   # requested" and the first validate leg starting.
+  #
+  # Two checks live here and they are NOT the same check (#1237):
+  #   floor    — version-agnostic: every published manifest resolves with its required platforms.
+  #              Unconditional; a red here means the set is not published as claimed.
+  #   identity — the packet-bound candidate map (a human-reviewed sha256 pinned in the table
+  #              below). Enforced on every promote, every stable version, and every version a
+  #              committed map already names; DEFERRED WITH A LOUD NOTICE only in the freeze
+  #              window, where the map records digests the build has only just published and so
+  #              cannot exist yet. The deferral is rendered in the guarantee block.
   resolve:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.version }}
       prerelease: ${{ steps.version.outputs.prerelease }}
+      # 'true' when this run PROVED the packet-bound candidate-map identity; 'false' when it
+      # deferred it (see the identity step). The guarantee block renders the difference — a
+      # deferral that does not reach the notes is the silent skip this gate exists to prevent.
+      identity_verified: ${{ steps.identity.outputs.enforce }}
     steps:
       - name: Resolve the version under validation
         id: version
@@ -148,13 +163,82 @@ jobs:
       - uses: actions/checkout@v4
       - name: Registry validator controls
         run: node --test scripts/registry-candidate-validate.test.mjs
-      - name: Every frozen descriptor resolves through authenticated registry reads
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # ── the always-on floor (restored, #1237) ────────────────────────────────────────────────
+      # This job's contract — stated in its own header and in delivery.mdx — is "every published
+      # manifest resolves and carries the platforms it claims". #949 REPLACED that version-agnostic
+      # check with the version-pinned map check below, which silently narrowed the floor to nothing
+      # for any version not in the table. The floor is back, and it is unconditional: it holds for
+      # every version, reviewed or not, and it is what makes a deferred identity check safe.
+      #
+      # `imagetools inspect` prints no Platform line for classic-driver (schema-v2) manifests even
+      # when the registry descriptor says linux/amd64 — the bot image is built on the classic driver
+      # by design, so read the registry descriptor instead; it is authoritative for both shapes.
+      - name: Every published manifest resolves and carries required platforms
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
+          for img in $ALL_IMAGES; do
+            echo "== $img:$VERSION"
+            # NOTE: a `IMG=... cmd | python3` prefix binds the var only to the first
+            # pipeline command — python3 would KeyError. Export it instead.
+            export IMG="$img"
+            docker manifest inspect -v "$img:$VERSION" | python3 -c "
+          import os, sys, json
+          img = os.environ['IMG']
+          d = json.load(sys.stdin)
+          items = d if isinstance(d, list) else [d]
+          plats = {(m.get('Descriptor', {}).get('platform', {}).get('os'),
+                    m.get('Descriptor', {}).get('platform', {}).get('architecture'))
+                   for m in items}
+          required = {('linux', 'amd64')}
+          if img != 'vexaai/vexa-bot':
+            required.add(('linux', 'arm64'))
+          missing = required - plats
+          if missing:
+            print(f'missing platforms: {sorted(missing)}', file=sys.stderr)
+            sys.exit(1)
+          " || { echo "::error ::$img:$VERSION missing required platform manifest(s) — is the set published?"; exit 1; }
+          done
+          echo "✓ all $(wc -w <<<"$ALL_IMAGES") manifests present with required platforms"
+
+      # ── packet-bound candidate-map identity: when it is enforced, and when it is deferred ─────
+      # The table below is a REVIEW RECORD, not data: a human read that version's committed
+      # candidate map and pinned its sha256 here. A version can only reach the table AFTER its
+      # images exist, because the map records the digests the build published. So at FREEZE time —
+      # the tag-push build that publishes a new rc — the identity is not merely unreviewed, it is
+      # UNKNOWABLE. Failing there made every successful rc freeze conclude FAILURE by construction
+      # (#1237: identical on rc.14/15/16/17/18, all of which published all ten images).
+      #
+      # Deferral is allowed on exactly one shape, and it is announced loudly:
+      #   prerelease  AND  promote:false  AND  no reviewed arm  AND  no committed map naming this
+      #   version  →  identity verification deferred to the standalone release-validate dispatch.
+      # Everything else fails closed, unchanged:
+      #   · any promote request                → the moving tag never moves on an unreviewed map
+      #   · any stable (non-prerelease) version → the witnessed/aliased candidate must be reviewed
+      #   · any version a committed map already names → identity is KNOWABLE, so it must be reviewed
+      # The floor above still runs in every case, and `promote` carries its own independent
+      # stable-promotion map-identity table further down. This gate is defence in depth, not the
+      # only wall between an unreviewed image and prod.
+      - name: Resolve the packet-bound candidate-map identity
+        id: identity
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          PROMOTE: ${{ inputs.promote }}
+        run: |
+          set -euo pipefail
+          CANDIDATE_MAP=""
+          EXPECTED_MAP_STABLE_TAG=""
+          EXPECTED_MAP_SHA256=""
+          EXPECTED_TOP_DESCRIPTORS=""
+          EXPECTED_PLATFORM_IDENTITIES=""
+          REVIEWED=true
           case "$VERSION" in
             v0.12.18)
               CANDIDATE_MAP=releases/v0.12.18/candidate-images.json
@@ -171,10 +255,68 @@ jobs:
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;
             *)
-              echo "::error ::$VERSION has no reviewed, packet-bound candidate-map identity"
-              exit 1
+              REVIEWED=false
               ;;
           esac
+
+          # Is a committed map already claiming this exact version? Then the identity is knowable
+          # and an unreviewed run must fail closed — deferral covers only the freeze window in
+          # which no map can exist yet.
+          BARE="${VERSION#v}"; BASE="${BARE%%-*}"
+          COMMITTED_MAP="releases/v$BASE/candidate-images.json"
+          MAP_CLAIMS_VERSION=false
+          if [ -f "$COMMITTED_MAP" ]; then
+            CLAIMED_TAGS="$(node -e '
+              const { readFileSync } = require("node:fs");
+              const map = JSON.parse(readFileSync(process.argv[1], "utf8"));
+              console.log([map.candidate_tag || "-", map.stable_tag || "-"].join(" "));
+            ' "$COMMITTED_MAP")"
+            for tag in $CLAIMED_TAGS; do
+              if [ "$tag" = "$VERSION" ]; then MAP_CLAIMS_VERSION=true; fi
+            done
+          fi
+
+          ENFORCE=true
+          REASON="$VERSION has a reviewed, packet-bound candidate-map identity"
+          if [ "$REVIEWED" != "true" ]; then
+            if [ "$PROMOTE" = "true" ]; then
+              REASON="a promote was requested"
+            elif [ "$PRERELEASE" != "true" ]; then
+              REASON="$VERSION is a stable version (witnessed/aliased candidates are always reviewed)"
+            elif [ "$MAP_CLAIMS_VERSION" = "true" ]; then
+              REASON="$COMMITTED_MAP already names $VERSION, so its identity is knowable"
+            else
+              ENFORCE=false
+            fi
+          fi
+
+          if [ "$ENFORCE" = "true" ] && [ "$REVIEWED" != "true" ]; then
+            echo "::error ::$VERSION has no reviewed, packet-bound candidate-map identity — required here because $REASON. Bind the candidate packet (releases/v$BASE/candidate-images.json) and pin its sha256 in this workflow's resolve table; see releases/README.md § Bind, validate, freeze."
+            exit 1
+          fi
+
+          {
+            echo "CANDIDATE_MAP=$CANDIDATE_MAP"
+            echo "EXPECTED_MAP_STABLE_TAG=$EXPECTED_MAP_STABLE_TAG"
+            echo "EXPECTED_MAP_SHA256=$EXPECTED_MAP_SHA256"
+            echo "EXPECTED_TOP_DESCRIPTORS=$EXPECTED_TOP_DESCRIPTORS"
+            echo "EXPECTED_PLATFORM_IDENTITIES=$EXPECTED_PLATFORM_IDENTITIES"
+          } >> "$GITHUB_ENV"
+          echo "enforce=$ENFORCE" >> "$GITHUB_OUTPUT"
+          if [ "$ENFORCE" = "true" ]; then
+            echo "✓ enforcing packet-bound identity for $VERSION ($CANDIDATE_MAP)"
+          else
+            echo "· $VERSION has no committed candidate map yet — identity verification deferred"
+          fi
+
+      - name: Every frozen descriptor resolves through authenticated registry reads
+        if: steps.identity.outputs.enforce == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
           node scripts/registry-candidate-validate.mjs \
             --candidate-map "$CANDIDATE_MAP" \
             --tag "$VERSION" \
@@ -182,6 +324,21 @@ jobs:
             --expected-map-sha256 "$EXPECTED_MAP_SHA256" \
             --expected-top-descriptors "$EXPECTED_TOP_DESCRIPTORS" \
             --expected-platform-identities "$EXPECTED_PLATFORM_IDENTITIES"
+
+      # A skip nobody can see is the same defect as a red nobody can trust. This run's conclusion
+      # says the images published and the legs passed; this notice says what it did NOT prove.
+      - name: Identity verification deferred — say so, loudly
+        if: steps.identity.outputs.enforce != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          MSG="**${VERSION}: packet-bound candidate-map identity NOT verified in this run.** No candidate map names ${VERSION} yet — the map records the digests this build just published, so its identity is not knowable at freeze time. Verification is DEFERRED to the standalone \`release-validate\` dispatch that runs after the packet is bound and its sha256 pinned in the resolve table (releases/README.md § Bind, validate, freeze). This run proves the published manifests resolve with their required platforms and that every validation leg passes on the published bytes. Promote and stable-tag paths remain fail-closed and cannot run on a deferred identity."
+          echo "::notice title=candidate-map identity DEFERRED::$MSG"
+          {
+            echo "> ⚠️ $MSG"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ──────────────────────────────────────────────────────────────────────────────────────────
   # Image-identity smoke — a dumb, loud assertion that every published image CONTAINS what its
@@ -701,6 +858,7 @@ jobs:
       - name: Generate the guarantee block from leg results
         env:
           R_RESOLVE: ${{ needs.resolve.result }}
+          R_MAP_IDENTITY: ${{ needs.resolve.outputs.identity_verified }}
           R_IDENTITY: ${{ needs.image-identity.result }}
           R_COMPOSE: ${{ needs.validate-compose.result }}
           R_MOCKFSM: ${{ needs.validate-mock-fsm.result }}
@@ -722,12 +880,23 @@ jobs:
               *)          printf '❌ (%s)' "$1" ;;
             esac
           }
+          # The deferral valve (#1237). resolve may legitimately DEFER the packet-bound
+          # candidate-map identity check at freeze time — the map records digests the build
+          # just published, so it cannot exist yet. A deferral that does not reach the notes
+          # is a silent skip, which is the same defect as a red nobody can trust. Say it here.
+          map_identity() {
+            case "$R_MAP_IDENTITY" in
+              true)  printf '; packet-bound candidate-map identity verified' ;;
+              false) printf '; ⚠️ packet-bound candidate-map identity **DEFERRED** to the standalone release-validate run (no map names this candidate yet — #1237)' ;;
+              *)     printf '; packet-bound candidate-map identity — not reported' ;;
+            esac
+          }
           {
             echo "## The guarantee — $VERSION ([this run]($RUN_URL))"
             echo
             echo "| # | Guarantee | Proof in this run |"
             echo "|---|---|---|"
-            echo "| 1 | Every artifact users pull is the artifact we proved | $(m "$R_RESOLVE") manifests resolve; every leg pulls published bytes only |"
+            echo "| 1 | Every artifact users pull is the artifact we proved | $(m "$R_RESOLVE") manifests resolve$(map_identity); every leg pulls published bytes only |"
             echo "| 2 | Every documented install path stands up and is exercised to its leg's scope (NOT full end-to-end — real audio→words is row 3) | compose $(s "$R_COMPOSE" "installs + API/data-plane wiring, synthetic transcript; real bot in row 5") · FSM $(s "$R_MOCKFSM" "meeting-lifecycle FSM via mock bot, no real browser/STT") · lite $(s "$R_LITE" "front doors + ≥2 concurrent real-bot spawn, no meeting/STT assertion") · helm $(s "$R_HELM" "installs + healthy, bot/meeting/STT not exercised") |"
             echo "| 3 | Real audio → correct, speaker-attributed words | ⚠️ NOT machine-proven in this run — witness-pass only until the wav→words leg (#560) ships |"
             echo "| 4 | A fresh machine with nothing on it succeeds | ⚠️ fresh-VM leg runs outside this workflow — attach its evidence to the notes or state unclaimed |"

--- a/release/README.md
+++ b/release/README.md
@@ -24,3 +24,10 @@ never moved by a replacement-candidate run.
 The map records the top-level descriptor plus each selected platform manifest
 and image-config digest, so production imageID evidence is compared at the
 correct OCI identity layer.
+
+A map cannot exist before the build that publishes the digests it records, so
+the freeze build defers its identity check with a notice and a human binds the
+packet afterwards. That step is the review, and it is written down in
+[`releases/README.md` § Bind, validate, freeze](../releases/README.md).
+`release-validate-gating.test.mjs` holds both halves in place: the freeze path
+may defer, and every promote / stable / already-mapped path still fails closed.

--- a/release/release-validate-gating.test.mjs
+++ b/release/release-validate-gating.test.mjs
@@ -1,0 +1,303 @@
+// Gating controls for release-validate's `resolve` job (#1237).
+//
+// `release-images` concluded FAILURE on every successful rc freeze because the nested
+// `validate / resolve` leg pinned the sha256 of a candidate map that cannot exist until that
+// very build publishes the images. These tests hold the repaired gating in place from both
+// sides:
+//
+//   fail-closed   an unreviewed version still fails when a promote is requested, when the
+//                 version is stable, or when a committed map already names it
+//   fail-open     ONLY in the freeze window — a prerelease, promote:false, no reviewed arm,
+//                 no committed map naming it — and the deferral is VISIBLE
+//
+// The decision block is bash embedded in YAML, so these tests EXECUTE it rather than
+// pattern-matching it: the step body is lifted out of the workflow and run under bash with the
+// inputs GitHub Actions would supply. A regex suite would pass on a gate that no longer gates.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const VALIDATE_WORKFLOW = new URL(
+  "../.github/workflows/release-validate.yml",
+  import.meta.url,
+);
+const IMAGES_WORKFLOW = new URL(
+  "../.github/workflows/release-images.yml",
+  import.meta.url,
+);
+
+const validateYaml = readFileSync(VALIDATE_WORKFLOW, "utf8");
+const imagesYaml = readFileSync(IMAGES_WORKFLOW, "utf8");
+
+const IDENTITY_STEP = "Resolve the packet-bound candidate-map identity";
+
+/** Lift a step's `run: |` body out of a workflow file, dedented to column 0. */
+function extractRunBlock(yaml, stepName) {
+  const lines = yaml.split("\n");
+  const start = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
+  assert.ok(start >= 0, `step not found: ${stepName}`);
+  let cursor = start;
+  while (cursor < lines.length && !/^\s*run: \|\s*$/.test(lines[cursor])) cursor += 1;
+  assert.ok(cursor < lines.length, `step has no literal run block: ${stepName}`);
+  const bodyIndent = lines[cursor].search(/\S/) + 2;
+  const body = [];
+  for (let index = cursor + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim() === "") {
+      body.push("");
+      continue;
+    }
+    if (line.search(/\S/) < bodyIndent) break;
+    body.push(line.slice(bodyIndent));
+  }
+  return body.join("\n");
+}
+
+const identityScript = extractRunBlock(validateYaml, IDENTITY_STEP);
+
+/**
+ * Run the identity gate exactly as the runner would: a temp workdir standing in for the
+ * checkout, `$GITHUB_ENV` / `$GITHUB_OUTPUT` as real files, the step's env as GitHub renders it.
+ */
+function runIdentityGate(t, { version, promote = false, prerelease, map = null }) {
+  const dir = mkdtempSync(join(tmpdir(), "release-validate-gate-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  if (map) {
+    const base = version.replace(/^v/, "").split("-")[0];
+    mkdirSync(join(dir, "releases", `v${base}`), { recursive: true });
+    writeFileSync(
+      join(dir, "releases", `v${base}`, "candidate-images.json"),
+      JSON.stringify(map, null, 2),
+    );
+  }
+
+  const githubEnv = join(dir, "github.env");
+  const githubOutput = join(dir, "github.output");
+  writeFileSync(githubEnv, "");
+  writeFileSync(githubOutput, "");
+
+  const result = spawnSync("bash", ["-c", identityScript], {
+    cwd: dir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      VERSION: version,
+      PRERELEASE: String(prerelease),
+      PROMOTE: String(promote),
+      GITHUB_ENV: githubEnv,
+      GITHUB_OUTPUT: githubOutput,
+    },
+  });
+
+  const parse = (file) =>
+    Object.fromEntries(
+      readFileSync(file, "utf8")
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => {
+          const at = line.indexOf("=");
+          return [line.slice(0, at), line.slice(at + 1)];
+        }),
+    );
+
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    outputs: parse(githubOutput),
+    exported: parse(githubEnv),
+  };
+}
+
+const mapFor = (candidateTag, stableTag) => ({
+  schema_version: 1,
+  release: stableTag,
+  stable_tag: stableTag,
+  candidate_tag: candidateTag,
+});
+
+// ── the freeze window: the only shape allowed to defer ─────────────────────────────────────────
+
+test("a freeze build of an unreviewed rc no longer fails — identity is deferred, not asserted", (t) => {
+  const run = runIdentityGate(t, {
+    version: "v0.12.23-rc.19",
+    promote: false,
+    prerelease: true,
+  });
+  assert.equal(run.status, 0, run.stdout + run.stderr);
+  assert.equal(run.outputs.enforce, "false");
+  assert.match(run.stdout, /identity verification deferred/i);
+});
+
+test("a stale map naming an EARLIER candidate does not make the new candidate's identity knowable", (t) => {
+  // The exact rc.19-after-rc.18 shape: releases/v0.12.23/candidate-images.json exists on the
+  // branch, but it describes rc.18. Treating "a map file exists" as "identity is knowable"
+  // would reproduce #1237 one commit later.
+  const run = runIdentityGate(t, {
+    version: "v0.12.23-rc.19",
+    promote: false,
+    prerelease: true,
+    map: mapFor("v0.12.23-rc.18", "v0.12.23"),
+  });
+  assert.equal(run.status, 0, run.stdout + run.stderr);
+  assert.equal(run.outputs.enforce, "false");
+});
+
+// ── everything else still fails closed ─────────────────────────────────────────────────────────
+
+test("a promote request on an unreviewed version still fails closed", (t) => {
+  const run = runIdentityGate(t, {
+    version: "v0.12.23-rc.19",
+    promote: true,
+    prerelease: true,
+  });
+  assert.notEqual(run.status, 0);
+  assert.match(run.stdout, /has no reviewed, packet-bound candidate-map identity/);
+  assert.match(run.stdout, /a promote was requested/);
+});
+
+test("a stable version with no reviewed identity still fails closed", (t) => {
+  const run = runIdentityGate(t, {
+    version: "v0.12.24",
+    promote: false,
+    prerelease: false,
+  });
+  assert.notEqual(run.status, 0);
+  assert.match(run.stdout, /has no reviewed, packet-bound candidate-map identity/);
+  assert.match(run.stdout, /stable version/);
+});
+
+test("a committed map that NAMES this candidate makes identity knowable — unreviewed fails closed", (t) => {
+  const run = runIdentityGate(t, {
+    version: "v0.12.23-rc.19",
+    promote: false,
+    prerelease: true,
+    map: mapFor("v0.12.23-rc.19", "v0.12.23"),
+  });
+  assert.notEqual(run.status, 0);
+  assert.match(run.stdout, /has no reviewed, packet-bound candidate-map identity/);
+  assert.match(run.stdout, /already names v0\.12\.23-rc\.19/);
+});
+
+test("a committed map whose STABLE tag is this version fails closed when unreviewed", (t) => {
+  const run = runIdentityGate(t, {
+    version: "v0.12.24",
+    promote: false,
+    prerelease: false,
+    map: mapFor("v0.12.24-rc.1", "v0.12.24"),
+  });
+  assert.notEqual(run.status, 0);
+  assert.match(run.stdout, /has no reviewed, packet-bound candidate-map identity/);
+});
+
+// ── the reviewed path is untouched ─────────────────────────────────────────────────────────────
+
+test("a reviewed version enforces and hands the pinned packet identity to the validator", (t) => {
+  const run = runIdentityGate(t, {
+    version: "v0.12.23-rc.18",
+    promote: false,
+    prerelease: true,
+  });
+  assert.equal(run.status, 0, run.stdout + run.stderr);
+  assert.equal(run.outputs.enforce, "true");
+  assert.deepEqual(run.exported, {
+    CANDIDATE_MAP: "releases/v0.12.23/candidate-images.json",
+    EXPECTED_MAP_STABLE_TAG: "v0.12.23",
+    EXPECTED_MAP_SHA256:
+      "3422d02f02985ab0f02fc47f58a6b4b3e23f0163397f1073c004fe44624d764f",
+    EXPECTED_TOP_DESCRIPTORS: "10",
+    EXPECTED_PLATFORM_IDENTITIES: "19",
+  });
+});
+
+test("the pinned resolve arms match the committed candidate maps they claim", () => {
+  const arms = [...validateYaml.matchAll(
+    /CANDIDATE_MAP=(\S+)\n\s+EXPECTED_MAP_STABLE_TAG=(\S+)\n\s+EXPECTED_MAP_SHA256=([0-9a-f]{64})/g,
+  )];
+  assert.ok(arms.length >= 2, "expected the reviewed-identity table to hold pinned arms");
+  for (const [, mapPath, stableTag] of arms) {
+    const map = JSON.parse(
+      readFileSync(new URL(`../${mapPath}`, import.meta.url), "utf8"),
+    );
+    assert.equal(map.stable_tag, stableTag, mapPath);
+  }
+});
+
+// ── the deferral must be visible, and the floor must be unconditional ──────────────────────────
+
+test("the deferral is announced as a notice AND written to the run summary", () => {
+  const deferral = extractRunBlock(validateYaml, "Identity verification deferred — say so, loudly");
+  assert.match(deferral, /::notice title=candidate-map identity DEFERRED::/);
+  assert.match(deferral, /GITHUB_STEP_SUMMARY/);
+  assert.match(deferral, /standalone/);
+});
+
+test("the guarantee block renders the deferral instead of claiming a proof it does not have", () => {
+  assert.match(validateYaml, /R_MAP_IDENTITY: \$\{\{ needs\.resolve\.outputs\.identity_verified \}\}/);
+  assert.match(validateYaml, /map_identity\(\) \{[\s\S]*DEFERRED[\s\S]*\}/);
+  assert.match(
+    validateYaml,
+    /Every artifact users pull is the artifact we proved \| \$\(m "\$R_RESOLVE"\) manifests resolve\$\(map_identity\)/,
+  );
+});
+
+test("the version-agnostic manifest floor runs on EVERY version, reviewed or not", () => {
+  // #949 replaced this floor with the version-pinned map check; #1237 restored it. It is what
+  // makes a deferred identity check safe, so it must never acquire an `if:`.
+  const step = validateYaml.match(
+    /- name: Every published manifest resolves and carries required platforms\n([\s\S]*?)\n {6}- (?:name|uses):/,
+  );
+  assert.ok(step, "the always-on manifest floor is missing from resolve");
+  assert.doesNotMatch(step[1].split("run: |")[0], /^\s+if:/m);
+  assert.match(step[1], /missing required platform manifest\(s\)/);
+  assert.match(step[1], /for img in \$ALL_IMAGES/);
+});
+
+test("the identity check is the only thing the freeze path may skip", () => {
+  const resolveJob = validateYaml.match(/\n {2}resolve:\n([\s\S]*?)\n {2}# ─/)[1];
+  const conditional = [...resolveJob.matchAll(/^ {6}- name: (.+)\n(?: {8}.+\n)*? {8}if: (.+)$/gm)]
+    .map(([, name]) => name);
+  assert.deepEqual(conditional, [
+    "Every frozen descriptor resolves through authenticated registry reads",
+    "Identity verification deferred — say so, loudly",
+  ]);
+});
+
+// ── promote stays fully fail-closed, on its own independent table ──────────────────────────────
+
+test("promote keeps its own reviewed stable-promotion map identity, fail-closed on unknown versions", () => {
+  const promoteJob = validateYaml.slice(validateYaml.indexOf("\n  promote:"));
+  assert.match(promoteJob, /has no reviewed stable-promotion map identity[\s\S]*?exit 1/);
+  assert.match(promoteJob, /--expected-map-sha256 "\$EXPECTED_MAP_SHA256"/);
+  assert.match(promoteJob, /--candidate-map "releases\/\$VERSION\/candidate-images\.json"/);
+  // Prereleases and non-promote runs can never reach it, whatever resolve decided.
+  assert.match(
+    validateYaml,
+    /if: needs\.resolve\.outputs\.prerelease == 'false' && inputs\.promote/,
+  );
+  assert.match(promoteJob, /environment: release-promote/);
+  for (const gate of ["witness-gate", "value-gate"]) {
+    assert.ok(promoteJob.includes(`- ${gate}`), `promote lost its ${gate} dependency`);
+  }
+});
+
+test("stable-tag aliasing still proves the packet map before any tag moves", () => {
+  // release-images' alias-candidate job is the other place a candidate becomes a stable tag.
+  // It must keep refusing on any drift from the committed map.
+  assert.match(imagesYaml, /node release\/candidate-image-map\.mjs check "\$MAP" "\$VERSION"/);
+  assert.match(imagesYaml, /refusing to overwrite \$stable at \$stable_digest \(packet pins \$digest\)/);
+  assert.match(imagesYaml, /readback \$readback != witnessed \$digest/);
+  assert.match(imagesYaml, /if: needs\.preflight\.outputs\.reuse_candidate == 'true'/);
+});
+
+test("the freeze build still hands off to release-validate, and still never promotes", () => {
+  const validateCall = imagesYaml.slice(imagesYaml.indexOf("\n  validate:\n"));
+  assert.match(validateCall, /uses: \.\/\.github\/workflows\/release-validate\.yml/);
+  assert.match(validateCall, /promote: false/);
+  assert.doesNotMatch(validateCall, /promote: true/);
+});

--- a/releases/README.md
+++ b/releases/README.md
@@ -31,6 +31,53 @@ Release happens before the witness pass is signed.
    `:vX.Y.Z` images and runs `release-validate` with **`promote: false`** — the L4 legs prove the
    published bytes, but `:v012` does **not** move. The release candidate now exists to be witnessed.
 
+   That run proves the published manifests resolve with their required platforms and that every
+   validation leg passes on the published bytes. It does **not** prove the *packet-bound
+   candidate-map identity*, because the map records the digests this build has only just
+   published — at freeze time the identity is not unreviewed, it is unknowable. The run says so:
+   a `candidate-map identity DEFERRED` notice and a ⚠️ in guarantee line 1. Step 1a closes it.
+
+### 1a. Bind, validate, freeze — the human step (load-bearing, once per candidate)
+
+Nothing automates this and nothing can: pinning a map's sha256 into the workflow **is** the
+review. Until it is done, the candidate has no reviewed identity — which is exactly what the
+promote and stable-tag gates refuse to move on.
+
+1. **Bind the packet.** Write `releases/v<BASE>/candidate-images.json` from the *exact published*
+   registry identities of the ten images (10 top descriptors, 19 platform identities — the bot is
+   amd64-only), then pin its hash in **both** places that assert it:
+   - the reviewed-identity table in the `resolve` job of
+     [`.github/workflows/release-validate.yml`](../.github/workflows/release-validate.yml)
+     (`CANDIDATE_MAP` / `EXPECTED_MAP_STABLE_TAG` / `EXPECTED_MAP_SHA256` / the two counts), and
+   - the canonical-packet assertion in
+     [`release/candidate-image-map.test.mjs`](../release/candidate-image-map.test.mjs).
+
+   ```bash
+   REF=vexaai/vexa-lite:vX.Y.Z-rc.N
+   docker buildx imagetools inspect "$REF" --format '{{json .}}' | jq '.manifest'   # top + platforms
+   docker manifest inspect -v "$REF" | jq -r '.[].OCIManifest.config.digest'        # image configs
+   node release/candidate-image-map.mjs check releases/vX.Y.Z/candidate-images.json vX.Y.Z
+   shasum -a 256 releases/vX.Y.Z/candidate-images.json     # → EXPECTED_MAP_SHA256
+   ```
+
+   Commit as `release: bind <candidate> train-candidate packet`.
+
+2. **Validate.** Dispatch `release-validate` standalone **from that branch** with
+   `version: vX.Y.Z-rc.N`, `promote: false`. The identity check now enforces (the arm exists), and
+   the legs re-run in minutes against the already-published images — no rebuild.
+
+3. **Freeze.** Write the run's `validation_source` / `validation_run` back into the map, re-hash,
+   and re-pin the new `EXPECTED_MAP_SHA256` in the same two places (writing the fields changes the
+   map, so the hash changes with them). Commit as
+   `release: freeze <candidate> validation identity (run <id>, all legs green)`.
+
+**Where the identity check stays fail-closed** — a deferral is only ever the freeze window:
+any `promote: true` dispatch, any stable (non-prerelease) version, and any version a committed
+map already names all still refuse to run without a reviewed, pinned identity. `promote` carries
+its own independent stable-promotion map table on top of that, and `release-images`'
+`alias-candidate` job proves every digest against the committed map before a stable tag is
+written. See [`Vexa-ai/vexa#1237`](https://github.com/Vexa-ai/vexa/issues/1237).
+
 2. **Witness** — the human walks a **DELIVERED deployment** (D-L4): the agent provisions a fresh
    self-host of the **published** `:vX.Y.Z` images, pre-validates it autonomously (health, UI,
    auth path, STT readiness), and hands the human a **running UI URL — never a setup recipe**.


### PR DESCRIPTION
**Delivers issue:** [`Vexa-ai/vexa#1237`](https://github.com/Vexa-ai/vexa/issues/1237)

Fixes #1237

## Root cause

`release-images` concluded **FAILURE on every successful rc freeze, by construction.**

The workflow ends by calling [`.github/workflows/release-validate.yml`](https://github.com/Vexa-ai/vexa/blob/main/.github/workflows/release-validate.yml) as a nested `validate` job. That workflow's `resolve` job carried a hardcoded `case "$VERSION"` mapping each version to a `CANDIDATE_MAP` + `EXPECTED_MAP_SHA256`, and exited 1 with `<version> has no reviewed, packet-bound candidate-map identity` for anything unlisted.

**The map records the digests the build just published**, so it cannot exist before the build runs. At freeze time the identity is not merely unreviewed — it is *unknowable*. Every downstream job `needs: resolve`, so one red there skipped the entire validation half.

Verified identical on rc.14 ([32066734685](https://github.com/Vexa-ai/vexa/actions/runs/32066734685)), rc.15 ([32078414374](https://github.com/Vexa-ai/vexa/actions/runs/32078414374)), rc.16 ([32095685040](https://github.com/Vexa-ai/vexa/actions/runs/32095685040)), rc.17 ([32114472336](https://github.com/Vexa-ai/vexa/actions/runs/32114472336)), rc.18 ([32139430561](https://github.com/Vexa-ai/vexa/actions/runs/32139430561)). rc.18's job list is the shape of all five:

```
success  preflight · build-bot · sbom · build ×9      ← ten images published
failure  validate / resolve
skipped  image-identity · validate-compose · validate-mock-fsm · validate-v010-compat
skipped  validate-bot-spawn · validate-lite · validate-arm64 · validate-helm-k3s
```

**A second finding fell out of the investigation.** [#949](https://github.com/Vexa-ai/vexa/pull/949) (`ci: authenticate frozen release descriptor validation`, 2026-07-24) did not *add* the map check — it **replaced** the version-agnostic *"every published manifest resolves and carries required platforms"* check with it. That deleted the only floor `resolve` had for any version outside the table, while the job's own header comment and [`delivery.mdx`](https://github.com/Vexa-ai/vexa/blob/main/docs/docs/governance/delivery.mdx) went on describing the deleted behaviour. So the gate was simultaneously too strict (red on knowable-later identity) and too loose (no floor at all when it wasn't red).

## Option chosen: (b), split the gate — with the floor restored underneath it

`resolve` now holds **two checks that are not the same check**:

| | What | When |
|---|---|---|
| **floor** | every published manifest resolves and carries its required platforms (linux/amd64 all; +linux/arm64 for matrix images except `vexa-bot`) | **unconditional** — restored verbatim from pre-#949 |
| **identity** | the packet-bound candidate map: a human-reviewed sha256 pinned in the resolve table | enforced on every promote / stable / already-mapped version; **deferred with a loud notice** in the freeze window |

Deferral is permitted on exactly one shape, and it is a conjunction of four conditions:

```
prerelease  AND  promote:false  AND  no reviewed arm  AND  no committed map naming this version
```

The fourth condition is the one that matters and is why "does the map file exist?" was not enough on its own. `releases/v0.12.23/candidate-images.json` **exists on this branch** and describes rc.18. A file-existence test would call rc.19's identity "knowable", enforce, and fail on rc.18's digests — reproducing #1237 one commit later. The gate reads the map's `candidate_tag` / `stable_tag` and asks whether it names *this* version. If a map already names it, identity **is** knowable, so an unreviewed run fails closed.

### The skip is visible, in three places

A silent skip is the same defect as an untrustworthy red, inverted. So:

1. `::notice title=candidate-map identity DEFERRED::…` in the run's annotations;
2. a ⚠️ blockquote in `$GITHUB_STEP_SUMMARY`;
3. **guarantee line 1 renders it** — `resolve` gained an `identity_verified` output and the guarantee block's row 1 now reads `… manifests resolve; ⚠️ packet-bound candidate-map identity **DEFERRED** to the standalone release-validate run …` instead of an unqualified ✅. The guarantee block is what the release notes paste verbatim, so the deferral reaches the reader who would otherwise be misled — the exact failure mode #1237 describes.

## What stays fail-closed

Nothing that guards an image reaching prod was weakened. Enumerated, because that is the load-bearing claim:

| Path | Guard | Status |
|---|---|---|
| **promote** (`:v012` / `:latest` move) | its **own independent** `case "$VERSION"` stable-promotion map table → `has no reviewed stable-promotion map identity`, exit 1 | untouched |
| promote | `registry-manifest-alias.mjs --expected-map-sha256` per repository, then a full `registry-candidate-validate.mjs` readback against `v012` | untouched |
| promote | `release-promote` Environment (owner's manual approval), `witness-gate` + `value-gate` as hard `needs`, `prerelease == 'false' && inputs.promote` | untouched |
| **any promote dispatch** reaching `resolve` | `PROMOTE=true` ⇒ identity **enforced**, never deferrable | new, explicit |
| **stable (non-prerelease) versions** | ⇒ identity **enforced** | new, explicit |
| **already-mapped versions** | a committed map naming this version ⇒ identity **enforced** | new, explicit |
| **stable-tag aliasing** (`alias-candidate` in `release-images`) | `candidate-image-map.mjs check`, per-platform manifest + config digest equality, `refusing to overwrite $stable at $stable_digest (packet pins $digest)`, and a post-write readback | untouched |

The deferral therefore only ever applies to a prerelease candidate that is not being promoted, aliased, or witnessed. Such a candidate cannot move a stable tag from this path at all.

## Rejected alternatives

**(a) Make the nested `validate` job conditional — skip it when no map exists.** Rejected. It buys the honest conclusion at the price of *all* freeze-time proving: no image-identity, no compose, no lite, no helm-k3s, no arm64, no v010-compat. That is where the chain is today by accident (the resolve red skips them), and turning an accident into the design makes `release-images`' documented "publish + prove" contract permanently false. Option (b) gets the honest conclusion *and* runs the legs.

**(c) Have `release-images` emit the candidate map itself.** Rejected on principle, not mechanics. The pinned sha256 is a **review record** — a human read that map and vouched for it. A map the build generates about itself and then validates against itself is a tautology; it would convert a review gate into a self-attestation while leaving the annotation looking identical. It also needs either `contents: write` on the release workflow or artifact plumbing across the `workflow_call` boundary, both of which enlarge the blast radius of the thing guarding prod.

**Refinement of (b) worth flagging:** the issue's framing was "apply the sha256 check only on the standalone/promote path". Distinguishing nested-from-standalone via `github.event_name` is unreliable — a called workflow inherits the *caller's* event, so a dispatched `release-images` looks like a dispatched `release-validate`. The four-condition rule above is equivalent in effect, robust to event plumbing, and states the actual invariant: *defer only while the identity is genuinely unknowable.*

## Residual risk, stated plainly

The validation legs have **not run inside `release-images` since #949** — the resolve red has skipped them on every tag push for ~3 weeks. After this merges, the next freeze is the first time they execute in that chain. They pass in the standalone dispatch on every rc (rc.14–rc.18 all recorded "all legs green"), so green is the expectation, but a leg failing there will now redden `release-images`. That is a *true* red about published artifacts, and within the issue's intent. If it proves noisy in practice, option (a) is the fallback — at the documented cost of proving nothing at freeze time.

## The documentation gap (part of the finding)

**The human step that makes this work was load-bearing on every rc and written down nowhere.** [`releases/README.md`](https://github.com/Vexa-ai/vexa/blob/main/releases/README.md) documented a two-phase flow — *publish+validate → witness → promote → publish Release* — that does not function without an undocumented step between phases 1 and 2. The git history is the only record it exists: `release: bind rc.N train-candidate packet` → standalone `release-validate` dispatch → `release: freeze rc.N validation identity (run <id>, all legs green)`, repeated verbatim for rc.10 through rc.18. Nothing automates it, and nothing can: **pinning the map's sha256 into the workflow *is* the review.**

Added as `releases/README.md` § **1a. Bind, validate, freeze** — the two files that must be re-pinned together (the resolve table and the canonical-packet assertion in `release/candidate-image-map.test.mjs`), the registry commands that produce the digests, why the hash changes twice (writing `validation_run` back into the map changes the map), and where identity stays fail-closed. `release/README.md` gained a pointer.

## Tests

New file `release/release-validate-gating.test.mjs` — **15 tests**, picked up by the existing `node --test scripts/*.test.mjs release/*.test.mjs` leg in `gates.yml`. Full suite: **114 pass, 0 fail** (99 pre-existing + 15).

These are not regex assertions over YAML. The decision block is bash embedded in a workflow, so the test **lifts the step's `run:` body out of the file and executes it under `bash`** with the env GitHub Actions would supply (`VERSION`, `PRERELEASE`, `PROMOTE`, `$GITHUB_ENV`, `$GITHUB_OUTPUT`) against a temp checkout. A pattern suite would pass on a gate that no longer gates.

| | Test | Asserts |
|---|---|---|
| 1 | freeze build of an unreviewed rc | exit 0, `enforce=false` — **the red test for #1237** |
| 2 | stale map naming an *earlier* candidate | exit 0, `enforce=false` — the rc.19-after-rc.18 trap |
| 3 | promote request, unreviewed version | **exit 1**, `has no reviewed, packet-bound candidate-map identity` |
| 4 | stable version, unreviewed | **exit 1** |
| 5 | committed map *names* this candidate | **exit 1** — identity knowable ⇒ must be reviewed |
| 6 | committed map's `stable_tag` is this version | **exit 1** |
| 7 | reviewed version (rc.18) | `enforce=true`, exact map path + sha256 + counts exported |
| 8 | every pinned arm's `EXPECTED_MAP_STABLE_TAG` matches its committed map's `stable_tag` | — |
| 9–10 | the deferral is a `::notice` **and** a summary line **and** a rendered guarantee-block clause | — |
| 11–12 | the manifest floor has no `if:`; the identity check is the *only* thing the freeze path may skip | — |
| 13 | promote's independent map table, `--expected-map-sha256`, `release-promote` environment, witness+value `needs` | — |
| 14 | `alias-candidate` still proves the packet map before any stable tag is written | — |
| 15 | `release-images` still hands off to `release-validate` and still never promotes | — |

**Mutation-checked** — three mutants introduced and confirmed red, so the suite is known to bite:

| Mutant | Result |
|---|---|
| restore the unconditional failure (the original #1237 bug) | 2 red |
| invert the promote guard (`PROMOTE = "false"`) | 5 red |
| put `if: enforce == 'true'` on the manifest floor | 2 red |

Not run locally: the workflows themselves (they need Docker Hub credentials and published images). Both files parse clean under `yaml.safe_load`. The repo has no `actionlint` leg.

## Base branch

Based on **`codex/1150-calendar-multi`** as instructed. I believe **`main` is the better base** and would recommend retargeting: this is a CI-gating repair with no dependency on the 0.12.23 train's content, `release-validate.yml` is dispatched *from any branch* by design, and `witness-gate` / `value-gate` deliberately `checkout ref: main` so the gate code is the trusted copy. Landing it on `main` means the next freeze — on any branch — gets the fix; landing it on the train means it arrives whenever that train merges, and every rc until then keeps producing the misleading red that already cost one release-readiness review a wrong conclusion. Not retargeted unilaterally.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle

- **C1 — the failure is structural, not incidental.** Ran: `gh run view` on all five rc build runs. Saw: every build/publish job green, `validate / resolve` the single red, every validate leg skipped. Concluded: the ordering is inherent — adding an arm per rc reproduces it on the next one — so the gating must move, not the data.
- **C2 — the gate replaced a floor rather than adding to one.** Ran: `git show ec52e772 -- .github/workflows/release-validate.yml` (#949). Saw: the version-agnostic manifest-resolution check **deleted** in the same hunk that introduced the `case` table. Concluded: restoring the floor is part of the fix, not scope creep — it is what makes a deferred identity check safe, and the job's header had been describing it all along.
- **C3 — "does a map exist" is the wrong condition.** Ran: `ls releases/v0.12.23/` and read its `candidate_tag`. Saw: the file exists and names rc.18. Concluded: file-existence would enforce rc.18's digests against rc.19 and fail — the gate must ask whether the map names *this* version. Test 2 pins it.
- **C4 — the suite bites.** Ran: three mutants against the new tests. Saw: 2 / 5 / 2 red respectively. Concluded: the tests test the gate, not its spelling.
- **C5 — the human step is undocumented.** Ran: `git log -- releases/ .github/workflows/release-validate.yml`, then read `releases/README.md` end to end. Saw: a `bind → dispatch → freeze` cycle repeated verbatim for nine consecutive candidates, and a README describing a flow that does not function without it. Concluded: the documentation gap is part of the finding, so the PR closes it.

## Acceptance floor

| Row | Evidence |
|---|---|
| Oracle: a freeze build that publishes all ten images concludes **success** | Test 1 — the freeze shape (`prerelease`, `promote:false`, unreviewed, no map naming it) exits 0 with `enforce=false`, so `resolve` no longer fails and no downstream leg is skipped. Mutant 1 (the original gate restored) turns it red. |
| Oracle: a build that fails to publish concludes **failure** | The restored floor (tests 11–12) runs unconditionally and reds on any image whose manifest is absent or missing a required platform — `::error ::$img:$VERSION missing required platform manifest(s) — is the set published?` |
| Gating changed, not data | No rc arm added. The `case` table is byte-identical to `main`'s; only its `*)` arm changed from `exit 1` to `REVIEWED=false`. |
| Promote path unweakened | Tests 3, 13, 14 + the fail-closed table above. |
| Skip is visible | Tests 9–10: `::notice`, `$GITHUB_STEP_SUMMARY`, and guarantee line 1. |

## Docs diff (D6c)

- [`releases/README.md`](https://github.com/Vexa-ai/vexa/blob/main/releases/README.md) — new § **1a. Bind, validate, freeze** (the operator's runbook: the undocumented human step, the two files re-pinned together, the registry commands, why the hash changes twice, where identity stays fail-closed), plus a paragraph in step 1 stating what the freeze run does and does not prove.
- [`release/README.md`](https://github.com/Vexa-ai/vexa/blob/main/release/README.md) — why a map cannot precede the build that produces it; pointer to § Bind, validate, freeze and to the new gating test.
- Both workflow files — the comments carry the *reasoning* (the ordering constraint, the floor-vs-identity split, why #949's narrowing mattered), so the next reader does not re-derive it.
- `docs/docs/governance/delivery.mdx` needed no change: its L4 row describes `release-validate` proving the published images, which is now true again in the freeze chain rather than skipped.

## Security checks (required on the diff)

No dependency, package-manifest, or runtime-code change — the diff is two workflow files, two READMEs, and one new test file. No new secrets, permissions, or network egress; `resolve` regains the `docker/login-action` it carried before #949, using the same two existing repository secrets. The change strictly *narrows* what may pass unverified: the previously-absent manifest floor now runs on every version, and three enforcement conditions (promote / stable / already-mapped) are stated explicitly where the old code had one blanket refusal that the chain routed around by hand. `gh` reports 56 pre-existing Dependabot findings on the default branch, untouched by and unrelated to this diff.

## Validation request

Any competent non-author. The cheapest real proof is the next `release-images` freeze on a new rc tag: **expect a green conclusion**, a `candidate-map identity DEFERRED` annotation, the ⚠️ in guarantee line 1, and every validation leg *executed* rather than skipped — then the standalone `release-validate` dispatch after binding the packet should go green with the identity **enforced** (guarantee line 1 reading `identity verified`).

Offline, `node --test release/release-validate-gating.test.mjs` reproduces the whole decision table in ~0.2s without credentials.

Deployment validated: **none** — no runtime artifact changes. The change is release-CI gating only; its behaviour is proven by executing the gate's own decision block (15 tests, 3 mutants) rather than by a deployment.

## Authorship

Agent-drafted under founder direction; **the founder is the sole author for DCO purposes** and the contribution-rights box above is deliberately left **unticked** — only he may tick it. Commit is `Signed-off-by: DmitriyG228`. Tooling disclosure: Claude Code.

<!-- vexa-agent -->
