### PR TITLE
[DEV] Release notes tell users what changed — changelog fragments for the 0.12.23 fix series

### DIFF
--- a/docs/changelog.d/1185-one-bot-per-meeting.md
+++ b/docs/changelog.d/1185-one-bot-per-meeting.md
@@ -1,0 +1,3 @@
+- **One bot per meeting, even under concurrent requests (#1185).** Simultaneous requests for the
+  same meeting now resolve to a single bot rather than occasionally admitting two, and a request
+  for a meeting that is already live adopts the running bot instead of starting a second one.

--- a/docs/changelog.d/1187-schema-fail-closed.md
+++ b/docs/changelog.d/1187-schema-fail-closed.md
@@ -1,0 +1,5 @@
+- **Self-hosted deployments fail closed when the one-bot-per-meeting guarantee cannot be enforced
+  (#1187).** The admin service now refuses to start if its database is missing the unique index
+  that prevents duplicate live meetings, instead of starting and allowing duplicates to slip
+  through. Operators upgrading an existing deployment apply the schema migration shipped with this
+  release before rolling out. See [Deployment](/deployment).

--- a/docs/changelog.d/1200-auto-join-backoff.md
+++ b/docs/changelog.d/1200-auto-join-backoff.md
@@ -1,0 +1,3 @@
+- **A failed auto-join retries on a bounded backoff instead of repeatedly (#1200).** When a
+  calendar occurrence's bot fails to join, the next attempt waits out a fixed backoff, and the
+  reason for the wait is readable on the meeting instead of being silent.

--- a/docs/changelog.d/1210-auto-join-timing.md
+++ b/docs/changelog.d/1210-auto-join-timing.md
@@ -1,0 +1,3 @@
+- **Scheduled bots arrive two minutes early and wait longer to be admitted (#1210).** Calendar
+  auto-joins now dispatch two minutes before the scheduled start rather than one, and a bot waits
+  up to fifteen minutes in the lobby before giving up. See [Calendar sync](/how-to/calendar-sync).

--- a/docs/changelog.d/1211-served-occurrence-not-rearmed.md
+++ b/docs/changelog.d/1211-served-occurrence-not-rearmed.md
@@ -1,0 +1,3 @@
+- **A meeting already served or stopped is never re-armed (#1211).** Calendar sync no longer
+  recreates and re-dispatches an occurrence whose bot already attended the meeting or was stopped
+  by the user; only genuine failures retry, and only within that occurrence's own window.

--- a/docs/changelog.d/1212-stop-is-stop.md
+++ b/docs/changelog.d/1212-stop-is-stop.md
@@ -1,0 +1,5 @@
+- **An explicit stop is honoured on every path (#1212).** Stopping a scheduled meeting before its
+  bot is dispatched now cancels that occurrence instead of letting the sweep send a bot anyway; a
+  stop that races a starting bot leaves nothing running; and a stopped meeting records the stop as
+  its outcome rather than a join failure. A meeting the user stopped can no longer be continued in
+  place — request a new bot instead.

--- a/docs/changelog.d/1217-calendar-bot-recording.md
+++ b/docs/changelog.d/1217-calendar-bot-recording.md
@@ -1,0 +1,4 @@
+- **Calendar auto-joined meetings are recorded like manually started ones (#1217).** A bot
+  dispatched from a connected calendar now follows the same recording setting as one started from
+  the API or the dashboard. Previously those meetings were transcribed but never recorded, and the
+  meeting page reported the missing audio as normal. See [Calendar sync](/how-to/calendar-sync).

--- a/docs/changelog.d/1228-teams-speaker-names.md
+++ b/docs/changelog.d/1228-teams-speaker-names.md
@@ -1,0 +1,5 @@
+- **Teams speaker names no longer lock to the wrong participant (#1228).** When a participant
+  joined during the first minute, a name could be bound permanently to another speaker's audio and
+  never revised, leaving one person's words under another's name for the rest of the meeting. Names
+  earned before the participant list is complete are now provisional and corrected as evidence
+  arrives.


### PR DESCRIPTION
**Delivers issue:** the release-notes half of #1151's fix series

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## What this fixes

The 0.12.23 train shipped changelog fragments for its feature work (#1150 multi-calendar, #499
Teams CSRC) but **none for the fix series** that came out of the code review and the overnight
staging validation. As it stood, `prod:release-oss` would have published notes that never told a
user that calendar bots now record, that an explicit stop is honoured, that bots arrive two minutes
before the meeting, or that the Teams speaker-naming defect is fixed.

Eight fragments added, one per PR, in the house voice:

| fragment | change |
|---|---|
| `1217-calendar-bot-recording.md` | calendar auto-joins record like manual ones |
| `1212-stop-is-stop.md` | an explicit stop is honoured on every path |
| `1228-teams-speaker-names.md` | Teams names no longer lock to the wrong participant |
| `1210-auto-join-timing.md` | −2 min dispatch, 15 min lobby wait |
| `1200-auto-join-backoff.md` | failed auto-join retries on a bounded backoff |
| `1211-served-occurrence-not-rearmed.md` | a served or stopped meeting is never re-armed |
| `1185-one-bot-per-meeting.md` | one bot per meeting under concurrency |
| `1187-schema-fail-closed.md` | self-hosted fail-closed on the missing uniqueness index |

## Observation bundle

- `node scripts/changelog-collect.mjs --check` — all eight fragments parse and render into the
  `0.12.x maintenance fixes` section; preview inspected line by line, exit 0.
- All 14 pre-push static gates green (no `--no-verify`).

## Judgment calls

- **#1200 and #1211 get separate fragments**, per the README's one-file-per-PR rule — they are
  distinct user-visible behaviours (bounded retry vs. never re-arming a served occurrence).
- **#1187 gets a fragment despite being a backend invariant**, because it is operator-visible for
  self-hosted deployments: the admin service will refuse to start until the schema migration is
  applied, which an upgrading operator must know before rolling out.
- **`499-teams-csrc-attribution.md` left untouched** — it carries a stale claim about contested
  words being explicitly marked (reverted by #1162); a separate session is repairing that and this
  PR does not duplicate the work.

Refs #1185 #1187 #1200 #1210 #1211 #1212 #1217 #1228
<!-- vexa-agent -->
