### PR TITLE
meeting-api: the meeting detail response ships only the fields it should

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -521,7 +521,8 @@ async def request_bot(
         if authenticated and auth_userdata_path:
             meeting_data["auth_userdata_path"] = auth_userdata_path
         # Per-user webhook config carried on the meeting (delivered by the lifecycle callback). These
-        # are stripped from any outbound meeting projection (webhooks.delivery._INTERNAL_DATA_KEYS).
+        # are stripped from any outbound meeting projection (webhooks.delivery._INTERNAL_DATA_KEYS)
+        # and from every API response edge (collector.projection.RESPONSE_OMIT_KEYS).
         if webhook_url:
             meeting_data["webhook_url"] = webhook_url
             if webhook_secret:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -330,10 +330,11 @@ class SqlAlchemyTranscriptStore:
         is where the (possibly slow) Redis await happens, so it can never pin a pooled connection or
         hold a snapshot/transaction open (the #508 fix).
 
-        This is a RESPONSE edge, so the calendar sources it ships are projected to their identity +
-        policy keys (``project_calendar_sources``) — the raw ICS event snapshot is sweep state, not
-        anyone's transcript."""
-        from .projection import project_calendar_sources
+        This is a RESPONSE edge, so ``data`` goes through ``project_response_data``: calendar sources
+        reduced to their identity + policy keys (the raw ICS event snapshot is sweep state, not anyone's
+        transcript), and credential/authorization keys dropped — this read authorizes a transcript-share
+        recipient and a bound-workspace member too, not only the owner."""
+        from .projection import project_response_data
 
         snap, seg_by_id, order = pg
         data = snap["data"]
@@ -370,7 +371,7 @@ class SqlAlchemyTranscriptStore:
             "end_time": _iso_utc(snap["end_time"]),
             "recordings": data.get("recordings", []),
             "notes": data.get("notes"),
-            "data": project_calendar_sources(data),
+            "data": project_response_data(data),
             "segments": segments,
         }
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -275,7 +275,7 @@ def build_router(
         meeting_id: int,
         x_user_id: Optional[str] = Header(default=None),
     ):
-        from .projection import project_calendar_sources
+        from .projection import project_response_data
 
         user_id = _resolve_user_id(x_user_id)
         meetings = await store.list_meetings(user_id, meeting_id=meeting_id)
@@ -286,7 +286,7 @@ def build_router(
         # response edge, because the same store call feeds calendar sync — which reads the
         # snapshot and writes it back, so a strip inside the store would erase it.
         return JSONResponse(content={
-            **meeting, "data": project_calendar_sources(meeting.get("data")),
+            **meeting, "data": project_response_data(meeting.get("data")),
         })
 
     # --- POST /meetings → CREATE a PLANNED meeting (intent status, NO bot spawned). The user plans a
@@ -422,7 +422,7 @@ def build_router(
     # --- the ROW-id PATCH/DELETE bodies, factored out so the native-keyed aliases (#579 C1) forward
     # to the SAME owner-scoped, FSM-refusing logic once they have resolved (platform, native) → row. ---
     async def _apply_meeting_patch(user_id: int, meeting_id: int, payload) -> dict:
-        from .projection import project_calendar_sources
+        from .projection import project_response_data
 
         if not isinstance(payload, dict):
             raise HTTPException(status_code=422, detail="body must be an object")
@@ -492,7 +492,7 @@ def build_router(
         # source's uid + event.resolved_start/calendar/component). Projected HERE, at the response
         # edge, so both the row-id and the native-keyed alias get it and the STORED row — which
         # calendar sync reconciles against — keeps the snapshot.
-        return {**row, "data": project_calendar_sources(row.get("data"))}
+        return {**row, "data": project_response_data(row.get("data"))}
 
     async def _apply_meeting_delete(user_id: int, meeting_id: int) -> None:
         result = await store.delete_planned_meeting(user_id, meeting_id)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -120,7 +120,7 @@ class InMemoryTranscriptStore:
         (native → newest) and ``get_transcript_by_id`` (exact row). Keyed by the row id ``mid``, so a
         by-id read returns exactly that row's segments/notes. Mirrors the real store's response
         projection of the calendar sources."""
-        from .projection import project_calendar_sources
+        from .projection import project_response_data
 
         m = self._meetings[mid]
         by_id = dict(m["segments"])
@@ -147,7 +147,7 @@ class InMemoryTranscriptStore:
             "end_time": m["end_time"],
             "recordings": m["data"].get("recordings", []),
             "notes": m["data"].get("notes"),
-            "data": project_calendar_sources(m["data"]),
+            "data": project_response_data(m["data"]),
             "segments": [_segment_to_api(s) for s in segments],
         }
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
@@ -8,12 +8,18 @@ consumer renders them.
 We cannot drop ``data`` from the list wholesale — the list genuinely renders a few LIGHT keys from it
 (a meeting's ``title``, connected ``docs``, ``scheduled_at``, the recording/transcribe flags). So the
 list keeps those light keys and drops only the heavy detail keys — the ones that made the response
-multi-MB and that the list never renders. Full ``data`` (every key) still ships on the detail path
-(``GET /meetings/{id}`` and the transcript endpoint).
+multi-MB and that the list never renders. The detail path (``GET /meetings/{id}`` and the transcript
+endpoints) still ships the rest of ``data``.
 
-This module holds the two things the real store (``adapters.py``) and the in-memory fake (``fakes.py``)
-must share so they can never diverge: the set of heavy keys dropped from a list row, and the default
-page size that bounds an otherwise-unbounded list.
+Size is not the only reason a key stays off a response. ``meeting.data`` is a shared row blob that
+also carries operational state — webhook signing config, share grants, session paths — which is not
+meeting content and which the read's access rule (owner OR transcript-share recipient OR bound-
+workspace member) would otherwise hand to a second party. Those keys (``RESPONSE_OMIT_KEYS``) are
+dropped on EVERY response edge, list and detail alike.
+
+This module holds what the real store (``adapters.py``), the router (``app.py``) and the in-memory
+fake (``fakes.py``) must share so they can never diverge: the heavy keys dropped from a list row, the
+keys dropped from every response, and the default page size that bounds an otherwise-unbounded list.
 """
 from __future__ import annotations
 
@@ -41,6 +47,52 @@ CALENDAR_SOURCE_LIST_KEYS = frozenset({
     "auto_join",
     "bot_name",
 })
+
+# ── Response-edge omissions ──────────────────────────────────────────────────────────────────────
+# ``meeting.data`` is a shared row blob: several producers write operational state into it that is
+# NOT the caller's meeting content. Some of that state is credential/authorization material, and a
+# meeting row is readable by more than its owner — the access rule on every read here is owner OR
+# transcript-share recipient OR member of the bound workspace (see ``list_meetings``' own comment).
+# So these keys are dropped on EVERY response edge, for EVERY viewer including the owner, matching
+# how the delivery path treats the same blob (``webhooks.delivery._INTERNAL_DATA_KEYS``) and how
+# every other surface reports the webhook config (``GET /user/webhook`` → ``webhook_secret_set`` +
+# a masked value, never the value).
+#
+# DENY-set, not allow-list, deliberately. ``data`` is an open multi-producer blob whose LIGHT keys
+# the detail view genuinely renders (title, docs, notes, scheduled_at, flags, completion_reason,
+# constructed_meeting_url, calendar_uid, …) and product work adds new ones continuously. An
+# allow-list at this edge would silently blank every future feature's field on the detail page —
+# a data-loss failure that no existing test would catch. The deny-by-default property an allow-list
+# buys is recovered instead by :data:`SENSITIVE_KEY_SUFFIXES` below, which drops credential-SHAPED
+# key names a future producer adds without anyone updating this set.
+RESPONSE_OMIT_KEYS = frozenset({
+    # Per-user webhook config, stamped onto the row at spawn so the lifecycle callback can sign
+    # deliveries. The signing secret is the whole security property of the webhook; the URL and the
+    # event filter are the owner's endpoint configuration. None of it is meeting content.
+    "webhook_secret",
+    "webhook_secrets",
+    "webhook_url",
+    "webhook_events",
+    "webhook_delivery",
+    "webhook_deliveries",
+    "outbound_events",
+    # Share/authz state: ``share_grants`` carries each link's ``secret_hash`` plus its allow-list and
+    # expiry, and ``transcript_viewers`` is the roster of every user id that can read the meeting.
+    # Both are the authorization machinery for this read, never its payload.
+    "share_grants",
+    "transcript_viewers",
+    # S3 path of the authenticated browser-session userdata used for authenticated spawns.
+    "auth_userdata_path",
+})
+
+# Credential-shaped key-name endings dropped in addition to :data:`RESPONSE_OMIT_KEYS`, so a key a
+# future producer stamps into ``data`` is omitted by DEFAULT rather than shipped until someone
+# notices. Matched on the whole key or its ``_``-suffixed tail, so ``token_count``/``secret_ballot``
+# and other legitimate names that merely CONTAIN a sensitive word are unaffected.
+SENSITIVE_KEY_SUFFIXES = (
+    "secret", "secrets", "token", "tokens", "password", "credential", "credentials",
+    "api_key", "apikey", "private_key", "signing_key", "access_key",
+)
 
 # Default page size applied on the list-view path when a caller passes no ``limit`` — turns an
 # unbounded full-table response (the outage's proximate trigger) into a bounded page. An explicit
@@ -76,17 +128,50 @@ def project_calendar_sources(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     return projected
 
 
+def is_sensitive_key(key: str) -> bool:
+    """True when ``key`` is named like credential material (see :data:`SENSITIVE_KEY_SUFFIXES`)."""
+    k = key.lower()
+    return any(k == s or k.endswith("_" + s) for s in SENSITIVE_KEY_SUFFIXES)
+
+
+def project_response_data(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return ``data`` shaped for an API RESPONSE: calendar sources reduced to their identity +
+    policy keys, and every credential/authorization key dropped.
+
+    This is the projection for the DETAIL paths (``GET /meetings/{id}`` and the transcript
+    endpoints), which ship ``data`` in full. Those reads authorize the owner, a transcript-share
+    recipient, AND a member of the bound workspace, so "the owner put it there" is not a reason for
+    a key to ride the response — the reader may be someone the owner shared one transcript with.
+
+    Pure and non-mutating (builds a new dict). It operates on the RESPONSE, never on the stored row,
+    so state the system genuinely needs — the webhook signing secret the lifecycle callback reads
+    from ``meeting_row["data"]`` at delivery time, the share grants the redeem path matches against,
+    the ICS snapshot the calendar sweep reconciles — is untouched in the database. A non-dict
+    ``data`` projects to ``{}``.
+    """
+    projected = project_calendar_sources(data)
+    return {
+        k: v for k, v in projected.items()
+        if k not in RESPONSE_OMIT_KEYS and not is_sensitive_key(k)
+    }
+
+
 def project_list_data(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Return ``data`` with the heavy :data:`LIST_OMIT_KEYS` dropped; every light key kept.
 
-    Pure and non-mutating (builds a new dict), so the caller's stored ``data`` is untouched and the
-    detail view still sees every key. A non-dict ``data`` projects to ``{}``.
+    The list is a response edge too — and the one where a share recipient first meets a meeting they
+    do not own — so it drops :data:`RESPONSE_OMIT_KEYS` as well. ``LIST_OMIT_KEYS`` is about SIZE
+    (keys no list row renders); the response omissions are about DISCLOSURE and apply on every path.
+
+    Pure and non-mutating (builds a new dict), so the caller's stored ``data`` is untouched. A
+    non-dict ``data`` projects to ``{}``.
     """
     if not isinstance(data, dict):
         return {}
     sources = project_calendar_sources(data).get("calendar_sources")
     projected = {k: v for k, v in data.items()
-                 if k not in LIST_OMIT_KEYS and k != "calendar_sources"}
+                 if k not in LIST_OMIT_KEYS and k != "calendar_sources"
+                 and k not in RESPONSE_OMIT_KEYS and not is_sensitive_key(k)}
     if isinstance(sources, list):
         projected["calendar_sources"] = sources
     return projected

--- a/core/meetings/services/meeting-api/tests/test_response_secret_projection.py
+++ b/core/meetings/services/meeting-api/tests/test_response_secret_projection.py
@@ -1,0 +1,258 @@
+"""``meeting.data`` operational state stays off the API response — on every read edge, for every viewer.
+
+The meeting row's ``data`` blob is shared: besides the meeting's own content it carries state other
+parts of the system stamped there — the per-user webhook signing config (``bot_spawn`` writes it so
+the lifecycle callback can sign deliveries), the transcript-share grants and viewer roster, the
+authenticated-session path. None of it is meeting content, and the reads that ship ``data`` authorize
+more than the owner: owner **or** transcript-share recipient **or** member of the bound workspace
+(the access union ``list_meetings`` documents). So the response edge projects it away.
+
+The share-recipient cases are the load-bearing ones: a second user, holding nothing but a redeemed
+transcript link, must receive the transcript and none of the owner's configuration. Every other
+surface already reports the webhook config the same way (``GET /user/webhook`` → ``webhook_secret_set``
+plus a masked value, never the value).
+
+The projection is a RESPONSE-edge transform and must not disturb the stored row — the delivery path
+reads the signing secret out of the meeting row at send time — so the last test signs a real delivery
+after a read has been served.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+from meeting_api.collector.projection import (
+    RESPONSE_OMIT_KEYS,
+    is_sensitive_key,
+    project_list_data,
+    project_response_data,
+)
+
+OWNER, VIEWER, STRANGER = 41, 42, 43
+PLAT, NID = "google_meet", "xyz-abcd-efg"
+SECRET = "whsec-owner-signing-key"
+HOOK = "https://hooks.example.com/owner-endpoint"
+
+# What a spawned meeting's row actually holds: real content next to the operational keys.
+ROW_DATA = {
+    "title": "Quarterly review",
+    "notes": "agenda in the doc",
+    "constructed_meeting_url": f"https://meet.google.com/{NID}",
+    "transcribe_enabled": True,
+    # operational state — none of it the reader's
+    "webhook_url": HOOK,
+    "webhook_secret": SECRET,
+    "webhook_events": {"meeting.status_change": True},
+    "auth_userdata_path": "s3://vexa-bot-userdata/owner/session.tar",
+}
+
+# Keys a reader may legitimately see — asserted present so the projection is proven to be a strip of
+# the operational keys and not a blanket erasure of ``data``.
+CONTENT_KEYS = ("title", "notes", "constructed_meeting_url", "transcribe_enabled")
+
+
+def _client(data=None):
+    store = InMemoryTranscriptStore()
+    store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID,
+                       data=dict(data if data is not None else ROW_DATA))
+    return store, TestClient(create_app(store, redis=None))
+
+
+def _mid(store):
+    return next(iter(store._meetings))
+
+
+def _share_with(client, uid):
+    """Owner mints an open share link; ``uid`` redeems it → a share-only reader of this meeting."""
+    token = client.post(f"/meetings/{PLAT}/{NID}/share", json={"mode": "open"},
+                        headers={"x-user-id": str(OWNER)}).json()["token"]
+    r = client.post("/transcripts/share/accept", json={"token": token},
+                    headers={"x-user-id": str(uid)})
+    assert r.status_code == 200 and r.json()["ok"] is True
+    return r
+
+
+def _assert_clean(data: dict, *, where: str):
+    """No omitted key, and nothing credential-SHAPED, survived into a response ``data`` blob."""
+    for key in RESPONSE_OMIT_KEYS:
+        assert key not in data, f"{where}: {key} rode the response"
+    leaked = [k for k in data if is_sensitive_key(k)]
+    assert not leaked, f"{where}: credential-shaped keys rode the response: {leaked}"
+    # and the value itself never appears, under any key or nesting
+    assert SECRET not in repr(data), f"{where}: the signing secret's VALUE rode the response"
+
+
+# ── the transcript detail edge ───────────────────────────────────────────────────────────────────
+
+def test_transcript_detail_omits_operational_keys_for_the_owner():
+    store, client = _client()
+    r = client.get(f"/transcripts/by-id/{_mid(store)}", headers={"x-user-id": str(OWNER)})
+    assert r.status_code == 200
+    data = r.json()["data"]
+    _assert_clean(data, where="GET /transcripts/by-id (owner)")
+    for k in CONTENT_KEYS:
+        assert k in data, f"the projection erased content key {k}"
+
+
+def test_transcript_detail_omits_operational_keys_for_a_share_recipient():
+    """THE case: a different user, holding only a redeemed transcript link, reads the transcript.
+
+    They are authorized for the meeting's content and nothing else — the owner's webhook signing
+    config is not part of what was shared with them.
+    """
+    store, client = _client()
+    _share_with(client, VIEWER)
+    r = client.get(f"/transcripts/by-id/{_mid(store)}", headers={"x-user-id": str(VIEWER)})
+    assert r.status_code == 200, "the share recipient must still be able to read the transcript"
+    _assert_clean(r.json()["data"], where="GET /transcripts/by-id (share recipient)")
+
+
+def test_share_recipient_still_gets_the_meetings_content():
+    """The projection must not cost the recipient the thing that WAS shared."""
+    store, client = _client()
+    _share_with(client, VIEWER)
+    data = client.get(f"/transcripts/by-id/{_mid(store)}",
+                      headers={"x-user-id": str(VIEWER)}).json()["data"]
+    for k in CONTENT_KEYS:
+        assert k in data, f"share recipient lost content key {k}"
+
+
+# ── the meeting detail + list edges ──────────────────────────────────────────────────────────────
+
+def test_meeting_detail_omits_operational_keys_for_owner_and_share_recipient():
+    store, client = _client()
+    mid = _mid(store)
+    _share_with(client, VIEWER)
+    for uid, who in ((OWNER, "owner"), (VIEWER, "share recipient")):
+        r = client.get(f"/meetings/{mid}", headers={"x-user-id": str(uid)})
+        assert r.status_code == 200
+        _assert_clean(r.json()["data"], where=f"GET /meetings/{{id}} ({who})")
+
+
+def test_meetings_list_omits_operational_keys_for_a_share_recipient():
+    """The list is where a recipient first meets a meeting they do not own — same rule applies."""
+    store, client = _client()
+    _share_with(client, VIEWER)
+    rows = client.get("/meetings", headers={"x-user-id": str(VIEWER)}).json()["meetings"]
+    assert rows, "the shared meeting must surface in the recipient's list"
+    for row in rows:
+        _assert_clean(row.get("data") or {}, where="GET /meetings (share recipient)")
+
+
+def test_stranger_still_gets_nothing():
+    """Unchanged: a user with neither ownership, share, nor workspace membership reads nothing."""
+    store, client = _client()
+    assert client.get(f"/transcripts/by-id/{_mid(store)}",
+                      headers={"x-user-id": str(STRANGER)}).status_code == 404
+
+
+# ── the projection functions themselves ──────────────────────────────────────────────────────────
+
+def test_projection_is_pure_and_leaves_the_stored_row_intact():
+    """It shapes the RESPONSE. The row keeps what the system needs to keep."""
+    stored = dict(ROW_DATA)
+    projected = project_response_data(stored)
+    assert stored == ROW_DATA, "the projection mutated its input"
+    assert "webhook_secret" not in projected and stored["webhook_secret"] == SECRET
+
+
+def test_share_grants_and_viewer_roster_stay_off_the_response():
+    """``share_grants`` carries each link's secret hash + allow-list; ``transcript_viewers`` is the
+    roster of everyone who can read the meeting. Both are this read's authorization machinery."""
+    store, client = _client()
+    _share_with(client, VIEWER)
+    data = client.get(f"/transcripts/by-id/{_mid(store)}",
+                      headers={"x-user-id": str(VIEWER)}).json()["data"]
+    assert "share_grants" not in data and "transcript_viewers" not in data
+    # the stored row still has them — redeeming a second link must keep working
+    assert client.post("/transcripts/share/accept",
+                       json={"token": client.post(f"/meetings/{PLAT}/{NID}/share",
+                                                  json={"mode": "open"},
+                                                  headers={"x-user-id": str(OWNER)}).json()["token"]},
+                       headers={"x-user-id": str(STRANGER)}).status_code == 200
+
+
+def test_credential_shaped_keys_are_dropped_by_default():
+    """A key a future producer stamps into ``data`` is omitted on NAME SHAPE, before anyone has
+    thought to add it to the deny-set — so the failure mode is a missing field, not a leak."""
+    blob = {"title": "t", "provider_api_key": "ak-1", "refresh_token": "rt-1",
+            "db_password": "pw", "signing_key": "sk-1", "some_secret": "s"}
+    for projected in (project_response_data(blob), project_list_data(blob)):
+        assert projected == {"title": "t"}, projected
+    # ...without catching names that merely CONTAIN a sensitive word
+    keep = {"token_count": 12, "secret_santa_notes": "x", "tokens_used": 3}
+    assert project_response_data(keep) == keep
+
+
+def test_response_omissions_cover_the_delivery_paths_internal_keys():
+    """The webhook delivery path already refuses to ship these in a payload
+    (``webhooks.delivery._INTERNAL_DATA_KEYS``). An API response is no less outbound than a webhook,
+    so the response edge must cover the same credential keys — this pins the two together."""
+    from meeting_api.webhooks.delivery import _INTERNAL_DATA_KEYS
+
+    credential_keys = {k for k in _INTERNAL_DATA_KEYS if "webhook" in k or is_sensitive_key(k)}
+    missing = credential_keys - RESPONSE_OMIT_KEYS
+    assert not missing, f"delivery strips these but the response edge does not: {sorted(missing)}"
+
+
+# ── the delivery path is untouched ───────────────────────────────────────────────────────────────
+
+def test_webhook_delivery_still_signs_after_a_read_has_been_served():
+    """The regression this fix must not cause. The signing secret lives on the meeting row because
+    the lifecycle callback reads it there at send time. The projection runs on the response edge, so
+    the row — and therefore the signature — is unaffected. Read first, then deliver, then verify.
+    """
+    from meeting_api.webhooks.delivery import sign_payload, verify_signature
+
+    store, client = _client()
+    mid = _mid(store)
+    # a read happens (this is what the projection touches)
+    assert client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).status_code == 200
+
+    # the delivery path's source of truth: the stored row, not the response
+    row_secret = store._meetings[mid]["data"]["webhook_secret"]
+    assert row_secret == SECRET, "the projection must not have touched the stored signing secret"
+    assert store._meetings[mid]["data"]["webhook_url"] == HOOK
+
+    body, ts = b'{"event_type":"meeting.completed"}', "1750000000"
+    headers = {"X-Webhook-Signature": sign_payload(body, row_secret, ts),
+               "X-Webhook-Timestamp": ts}
+    assert verify_signature(body, headers, SECRET), "signature must verify against the owner's secret"
+
+
+def test_webhook_sink_delivers_with_the_row_secret_end_to_end():
+    """The same property through the real sink: it signs with the secret handed to ``deliver``, which
+    the lifecycle callback sources from ``meeting_row["data"]`` — a path the projection never sees."""
+    from meeting_api.webhooks.delivery import WebhookSink, verify_signature
+
+    captured: dict = {}
+
+    async def transport(url, body, headers):
+        captured.update(url=url, body=body, headers=headers)
+
+        class _R:
+            status_code = 200
+        return _R()
+
+    store, client = _client()
+    mid = _mid(store)
+    client.get(f"/meetings/{mid}", headers={"x-user-id": str(OWNER)})  # serve a read first
+
+    data = store._meetings[mid]["data"]
+    sink = WebhookSink(transport=transport, resolver=lambda host: ["93.184.216.34"])
+    result = asyncio.run(sink.deliver(
+        data["webhook_url"],
+        {"event_type": "meeting.completed", "data": {"id": mid}},
+        data.get("webhook_secret"),
+        events_config={"meeting.completed": True},
+    ))
+
+    assert result.status == "delivered"
+    assert captured["url"] == HOOK
+    assert verify_signature(
+        captured["body"] if isinstance(captured["body"], bytes) else captured["body"].encode(),
+        captured["headers"], SECRET,
+    ), "the receiver's verification must still pass with the owner's secret"


### PR DESCRIPTION
**Delivers issue:** — (no public issue; filed privately)

Base: `codex/1150-calendar-multi`.

## What this changes

`meeting.data` is a shared row blob. Alongside the meeting's own content it carries operational state other parts of the system stamped there:

- the per-user webhook config (`bot_spawn/service.py` writes `webhook_url` / `webhook_secret` / `webhook_events` onto the row so the lifecycle callback can sign deliveries),
- the transcript share grants and viewer roster (`share_grants`, `transcript_viewers` — this read's authorization machinery),
- the authenticated-session path (`auth_userdata_path`).

The read paths that ship `data` authorize **owner OR transcript-share recipient OR bound-workspace member** (the access union `list_meetings` documents). So "the owner put it there" is not a reason for a key to ride the response — the reader may be someone the owner shared one transcript with. Every other surface already reports the webhook config this way: `GET /user/webhook` returns `webhook_secret_set` plus a masked value, never the value.

This adds `project_response_data` to `collector/projection.py`, next to the existing `project_calendar_sources` and `project_list_data`, and applies it on every response edge:

| Edge | Was | Now |
|---|---|---|
| `GET /transcripts/by-id/{id}` + `/transcripts/{platform}/{native}` (`_merge_live_segments`, real store and fake) | `project_calendar_sources` | `project_response_data` |
| `GET /meetings/{id}` | `project_calendar_sources` | `project_response_data` |
| `PATCH /meetings/{id}` echo (and its native-keyed alias) | `project_calendar_sources` | `project_response_data` |
| `GET /meetings`, `GET /bots`, `/bots/status` (`project_list_data`) | size-only omissions | size omissions + response omissions |

`LIST_OMIT_KEYS` stays what it is — about response SIZE. The new set is about disclosure and applies on every path, list and detail alike.

## Deny-set, not allow-list

The prompt for this change asked which shape and why. **Deny-set**, for one reason: `data` is an open multi-producer blob whose light keys the detail view genuinely renders (`title`, `notes`, `scheduled_at`, `docs`, flags, `completion_reason`, `constructed_meeting_url`, `calendar_uid`, …) and product work adds new ones continuously. An allow-list at this edge would silently blank every future feature's field on the detail page — a data-loss failure that no existing test would catch, and one that surfaces as a bug report rather than a test failure.

The deny-by-default property an allow-list buys is recovered separately: `SENSITIVE_KEY_SUFFIXES` drops credential-**shaped** key names a future producer adds before anyone updates the explicit set. Matched on the whole key or its `_`-suffixed tail, so `token_count` / `secret_santa_notes` are unaffected while `provider_api_key` / `refresh_token` / `signing_key` are dropped. Two tests hold this: one exercises both halves, and one pins `RESPONSE_OMIT_KEYS` to the delivery path's own `_INTERNAL_DATA_KEYS` — so a credential key added to one path fails the test until it is decided for the other.

## Webhook delivery is unaffected

The delivery path reads its config from `meeting_row["data"]` as returned by `meeting_repo.update_meeting_status` (`app.py:698-707`) — the stored row, not any response projection. `project_response_data` is pure and non-mutating and runs only at the response edge, so the row, the signature, and the share-redeem path that matches against `share_grants` all keep what they need.

Proven, not asserted: `test_webhook_delivery_still_signs_after_a_read_has_been_served` serves a read, then signs from the row secret and verifies; `test_webhook_sink_delivers_with_the_row_secret_end_to_end` drives the real `WebhookSink` through a fake transport and checks the receiver's `verify_signature` still passes.

## Recommendation, not implemented here (would widen the diff)

The projection is the immediate fix. The structural one is that the signing secret arguably does not need to live in `meetings.data` at all — the delivery path could read it from the user record at send time, the way identity already owns the config. Storing it per-meeting means every meeting row is a copy of a credential whose blast radius is every read path that ever ships `data`, and it goes stale when the user rotates the secret (in-flight meetings keep signing with the old one). Filing that separately is the right move: it touches the spawn path, the lifecycle callback, and the retry queue's persisted entries, and it needs a migration story for rows already carrying the value — none of which belongs in a change that has to land in a freeze window.

Two smaller notes for whoever picks that up:

- Rows already in the database still carry these keys. The projection means they stop being served, but a backfill that strips them from stored `data` would be the completion of it.
- `transcript_viewers` and `share_grants` are now off the response. No client in this repo reads either (checked `clients/`), but if a "shared with" UI is planned it should be served by a purpose-built endpoint rather than by reading the raw blob.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle

- **C1 — the response edges.** Ran the new suite against the pre-change source: the transcript detail, the meeting detail, and the list all returned the omitted keys to a second user holding nothing but a redeemed share link. Ran it against the change: all three return the meeting's content and none of the operational keys. Concluded the projection had to go on all three edges, not only the detail path — the list was carrying it too.
- **C2 — the delivery path.** Traced the signing config's reader to `meeting_row["data"]` from `update_meeting_status`, not from a response projection, then proved it: signature verifies after a read is served, and the real `WebhookSink` end-to-end still passes the receiver's check.
- **C3 — the blob audit.** Enumerated what actually gets written into `meeting.data` across `bot_spawn`, the share mint/redeem path, and calendar sync, and decided each key on least privilege rather than stripping one name. `bot_container_id`, `service_authority` and `transcription_provider` were considered and deliberately kept: not credentials, and `bot_container_id` is already a declared top-level response field.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 · omitted keys absent for the OWNER on the detail read | `test_transcript_detail_omits_operational_keys_for_the_owner`, `test_meeting_detail_omits_operational_keys_for_owner_and_share_recipient` |
| A2 · omitted keys absent for a transcript-share viewer who is a DIFFERENT user | `test_transcript_detail_omits_operational_keys_for_a_share_recipient`, `test_meetings_list_omits_operational_keys_for_a_share_recipient`, `test_share_grants_and_viewer_roster_stay_off_the_response` |
| A3 · the share recipient still receives what was shared | `test_share_recipient_still_gets_the_meetings_content` (asserts the content keys survive, so the fix is a strip and not an erasure) |
| A4 · webhook delivery still signs correctly | `test_webhook_delivery_still_signs_after_a_read_has_been_served`, `test_webhook_sink_delivers_with_the_row_secret_end_to_end` |
| A5 · future keys handled deliberately | `test_credential_shaped_keys_are_dropped_by_default`, `test_response_omissions_cover_the_delivery_paths_internal_keys` |
| A6 · no regression | meeting-api suite: **1147 passed, 3 skipped** (1135 + 12 new) |
| A7 · red before, green after | Each A1/A2 assertion fails against the pre-change source at the same base sha, on all three edges |

## Docs diff (D6c)

No user-facing docs change: no documented field is removed. The API reference does not document `data.webhook_*`, `data.share_grants`, `data.transcript_viewers` or `data.auth_userdata_path` as response fields — the webhook config is documented only on `GET /user/webhook`, which already reports it as `webhook_secret_set` plus a masked value. The reasoning lives in the module docstring of `collector/projection.py`, next to the existing `LIST_OMIT_KEYS` rationale, which is where the next person changing this edge will be.

## Security checks (required on the diff)

No dependency, licence, or build-surface change — the diff is four call-site edits, one new pure function, and a test file, all inside `core/meetings/services/meeting-api`. No new imports outside the package. Secrets scan is inert by construction: the change only ever removes keys from an outbound dict, and the one literal in the test file is a fixture string. The closing security bundle is the maintainer's.

## Validation request

Any competent non-author. What to watch, in order:

1. **The projection covers the edges it claims.** `grep -rn "project_calendar_sources\|project_response_data" core/meetings/services/meeting-api/src` — every response edge should now be `project_response_data`; the only remaining `project_calendar_sources` references are the function itself and its callers inside `projection.py`.
2. **The delivery path really is a different source.** `app.py:698` reads `meeting_row.get("data")` from `update_meeting_status`, not from a projected response. Worth a second pair of eyes — it is the one way this change could bite, and it is the reason for two tests rather than one.
3. **The deny-set is right.** `RESPONSE_OMIT_KEYS` in `collector/projection.py`. Each entry has a stated reason; disagree with any of them here rather than after merge. `transcript_viewers` is the one a reviewer might reasonably push back on.

**Deployment validated (D12b):** none. This is offline test-suite evidence against the in-memory fake and the shared projection module — the fake and the real store call the same function, which is why `projection.py` exists. Repo sha: base `8a68d94`. No stage or compose run was made; the freeze window did not allow one, and this PR does not claim one.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
