### PR TITLE
[DEV] Meeting responses ship owner-private fields to the owner and nothing sensitive to anyone else

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -520,9 +520,12 @@ async def request_bot(
         # The serialization key for authenticated spawns — find_active_by_userdata matches on it.
         if authenticated and auth_userdata_path:
             meeting_data["auth_userdata_path"] = auth_userdata_path
-        # Per-user webhook config carried on the meeting (delivered by the lifecycle callback). These
-        # are stripped from any outbound meeting projection (webhooks.delivery._INTERNAL_DATA_KEYS)
-        # and from every API response edge (collector.projection.RESPONSE_OMIT_KEYS).
+        # Per-user webhook config carried on the meeting (delivered by the lifecycle callback).
+        # Stripped from any outbound meeting projection (webhooks.delivery._INTERNAL_DATA_KEYS). At
+        # the API response edge the treatment splits (collector.projection): `webhook_secret` is
+        # never served to anyone (SENSITIVE_OMIT_KEYS); `webhook_url`/`webhook_events` are served to
+        # the OWNER — the v0.10 REST contract reads them back off the meeting row — and stripped for
+        # a share/workspace reader (OWNER_ONLY_KEYS).
         if webhook_url:
             meeting_data["webhook_url"] = webhook_url
             if webhook_secret:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -324,7 +324,9 @@ class SqlAlchemyTranscriptStore:
         }
         return snap, seg_by_id, order
 
-    async def _merge_live_segments(self, pg: "tuple[dict, dict, list]") -> dict:
+    async def _merge_live_segments(
+        self, pg: "tuple[dict, dict, list]", *, viewer_is_owner: bool,
+    ) -> dict:
         """POST-SESSION half: merge the LIVE Redis in-flight hash, sort, derive absolute times, and
         assemble the api.v1 ``TranscriptionResponse`` dict. NO database session is open here — this
         is where the (possibly slow) Redis await happens, so it can never pin a pooled connection or
@@ -332,8 +334,14 @@ class SqlAlchemyTranscriptStore:
 
         This is a RESPONSE edge, so ``data`` goes through ``project_response_data``: calendar sources
         reduced to their identity + policy keys (the raw ICS event snapshot is sweep state, not anyone's
-        transcript), and credential/authorization keys dropped — this read authorizes a transcript-share
-        recipient and a bound-workspace member too, not only the owner."""
+        transcript), credential material dropped for everyone, and the owner's private configuration
+        dropped for everyone but the owner — this read authorizes a transcript-share recipient and a
+        bound-workspace member too, not only the owner.
+
+        ``viewer_is_owner`` is REQUIRED (no default) because both callers already know it: the
+        native-keyed read constrains ``Meeting.user_id == user_id`` in SQL, and the by-id read
+        evaluates an explicit owner branch inside its authorization check. Passing the decision down
+        beats re-deriving it here, where the caller's ``user_id`` is not even in scope."""
         from .projection import project_response_data
 
         snap, seg_by_id, order = pg
@@ -371,7 +379,7 @@ class SqlAlchemyTranscriptStore:
             "end_time": _iso_utc(snap["end_time"]),
             "recordings": data.get("recordings", []),
             "notes": data.get("notes"),
-            "data": project_response_data(data),
+            "data": project_response_data(data, viewer_is_owner=viewer_is_owner),
             "segments": segments,
         }
 
@@ -395,7 +403,9 @@ class SqlAlchemyTranscriptStore:
                 return None
             pg = await self._transcript_pg_part(db, meeting)
         # Session closed (transaction ended, connection returned to pool) BEFORE the Redis merge (#508).
-        return await self._merge_live_segments(pg)
+        # The SELECT above constrains ``Meeting.user_id == user_id``, so a row reached through this
+        # path is by construction the caller's own — the native-keyed read has no share branch.
+        return await self._merge_live_segments(pg, viewer_is_owner=True)
 
     async def get_transcript_by_id(self, user_id, meeting_id, member_workspaces=None) -> Optional[dict]:
         """Exact-row transcript for ``meeting.id == meeting_id``, authorized by the SAME three-way rule as
@@ -415,8 +425,9 @@ class SqlAlchemyTranscriptStore:
             if not meeting:
                 return None
             data = meeting.data if isinstance(meeting.data, dict) else {}
+            is_owner = meeting.user_id == user_id                                   # (a) owner
             authorized = (
-                meeting.user_id == user_id                                          # (a) owner
+                is_owner
                 or user_id in (data.get("transcript_viewers") or [])                # (c) transcript-share
                 or (bool(member_workspaces) and data.get("workspace_id") in member_workspaces)  # (b) bound ws member
             )
@@ -424,7 +435,9 @@ class SqlAlchemyTranscriptStore:
                 return None
             pg = await self._transcript_pg_part(db, meeting)
         # Session closed (transaction ended, connection returned to pool) BEFORE the Redis merge (#508).
-        return await self._merge_live_segments(pg)
+        # The response projection reuses branch (a) above — the SAME decision that authorized this
+        # read decides which tier of the blob it may carry, so the two can never disagree.
+        return await self._merge_live_segments(pg, viewer_is_owner=is_owner)
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
                             member_workspaces=None, list_view=False, meeting_id=None, slim=False):
@@ -510,6 +523,10 @@ class SqlAlchemyTranscriptStore:
                 has_more = False
 
             def _row(m):
+                # The ONE ownership decision this row makes. `shared` (the api.v1 field) and the
+                # response projection's viewer tier both read it, so a row can never claim to be the
+                # caller's while being projected as a stranger's, or the reverse.
+                is_owner = m.user_id == user_id
                 row = {
                     "id": m.id,
                     "user_id": m.user_id,
@@ -525,7 +542,7 @@ class SqlAlchemyTranscriptStore:
                     # (hoisted the same way as `_meeting_projection_from_row` in app.py).
                     "completion_reason": (m.data or {}).get("completion_reason") if isinstance(m.data, dict) else None,
                     "failure_stage": (m.data or {}).get("failure_stage") if isinstance(m.data, dict) else None,
-                    "shared": m.user_id != user_id,   # surfaced via a share/membership, not owned by the caller
+                    "shared": not is_owner,   # surfaced via a share/membership, not owned by the caller
                     "created_at": _iso_utc(m.created_at),
                     "updated_at": _iso_utc(m.updated_at),
                     # #584: the LIST drops the heavy detail keys (speaker_events/bot_logs/recordings/… —
@@ -536,8 +553,13 @@ class SqlAlchemyTranscriptStore:
                     # materialized every byte of `data` — 180 MB for one production account, 144 MB of
                     # it `bot_logs` that no endpoint renders. Four concurrent polls demanded ~740 MB
                     # transiently and OOM-killed the pod. Only callers that genuinely need full `data`
-                    # (the detail view, calendar sync, reconciliation) leave both flags off.
-                    "data": project_list_data(m.data) if (list_view or slim)
+                    # (the detail view, calendar sync, reconciliation) leave both flags off — and
+                    # those callers project at their own response edge (app.py) or are internal.
+                    #
+                    # #1243 follow-up: the projection is VIEWER-AWARE. The owner keeps their own
+                    # webhook config here, which is where a 0.10 client reads it back
+                    # (`test_10_user_webhook_config_flow`); a share/workspace reader does not.
+                    "data": project_list_data(m.data, viewer_is_owner=is_owner) if (list_view or slim)
                     else (m.data if isinstance(m.data, dict) else {}),
                 }
                 return row

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -285,8 +285,15 @@ def build_router(
         # Full `data` minus the raw ICS event snapshot: the projection happens HERE, at the
         # response edge, because the same store call feeds calendar sync — which reads the
         # snapshot and writes it back, so a strip inside the store would erase it.
+        #
+        # The projection is viewer-aware, and the viewer decision is READ BACK from the row rather
+        # than re-derived: `list_meetings` already evaluated its access union and stamped `shared`
+        # (`m.user_id != user_id`) on every row it returns. `is False` and not `not ...` on purpose —
+        # an absent or unknown `shared` must fall to the STRICT view, not the permissive one.
+        viewer_is_owner = meeting.get("shared") is False
         return JSONResponse(content={
-            **meeting, "data": project_response_data(meeting.get("data")),
+            **meeting,
+            "data": project_response_data(meeting.get("data"), viewer_is_owner=viewer_is_owner),
         })
 
     # --- POST /meetings → CREATE a PLANNED meeting (intent status, NO bot spawned). The user plans a
@@ -492,7 +499,12 @@ def build_router(
         # source's uid + event.resolved_start/calendar/component). Projected HERE, at the response
         # edge, so both the row-id and the native-keyed alias get it and the STORED row — which
         # calendar sync reconciles against — keeps the snapshot.
-        return {**row, "data": project_response_data(row.get("data"))}
+        #
+        # `viewer_is_owner=True` is a property of the write, not an assumption: `update_planned_meeting`
+        # selects `WHERE Meeting.id == meeting_id AND Meeting.user_id == user_id` (the fake mirrors it
+        # with the same guard) and returns None otherwise, so a non-owner never reaches this line —
+        # PATCH has no share or workspace branch. The echo is the owner reading their own row back.
+        return {**row, "data": project_response_data(row.get("data"), viewer_is_owner=True)}
 
     async def _apply_meeting_delete(user_id: int, meeting_id: int) -> None:
         result = await store.delete_planned_meeting(user_id, meeting_id)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -115,11 +115,12 @@ class InMemoryTranscriptStore:
         matches.sort(key=lambda kv: (kv[1].get("created_at") or "", kv[0]), reverse=True)
         return matches[0][0]
 
-    async def _transcript_doc(self, mid) -> dict:
+    async def _transcript_doc(self, mid, *, viewer_is_owner: bool) -> dict:
         """Build the api.v1 ``TranscriptionResponse`` for row ``mid`` — shared by ``get_transcript``
         (native → newest) and ``get_transcript_by_id`` (exact row). Keyed by the row id ``mid``, so a
-        by-id read returns exactly that row's segments/notes. Mirrors the real store's response
-        projection of the calendar sources."""
+        by-id read returns exactly that row's segments/notes. Mirrors the real store's viewer-aware
+        response projection, ``viewer_is_owner`` included — the fake and the real store must agree on
+        what a share recipient receives, since most of the suite drives the fake."""
         from .projection import project_response_data
 
         m = self._meetings[mid]
@@ -147,7 +148,7 @@ class InMemoryTranscriptStore:
             "end_time": m["end_time"],
             "recordings": m["data"].get("recordings", []),
             "notes": m["data"].get("notes"),
-            "data": project_response_data(m["data"]),
+            "data": project_response_data(m["data"], viewer_is_owner=viewer_is_owner),
             "segments": [_segment_to_api(s) for s in segments],
         }
 
@@ -155,7 +156,9 @@ class InMemoryTranscriptStore:
         mid = self._find(user_id, platform, native_meeting_id)
         if mid is None:
             return None
-        return await self._transcript_doc(mid)
+        # ``_find`` matches on ``m["user_id"] == user_id`` (mirroring the real store's SQL), so a row
+        # reached by the native-keyed path is always the caller's own.
+        return await self._transcript_doc(mid, viewer_is_owner=True)
 
     async def get_transcript_by_id(self, user_id, meeting_id, member_workspaces=None) -> Optional[dict]:
         """Exact-row transcript authorized by owner OR transcript-viewer OR bound-workspace member (mirrors
@@ -168,12 +171,14 @@ class InMemoryTranscriptStore:
         if m is None:
             return None
         data = m.get("data") if isinstance(m.get("data"), dict) else {}
+        is_owner = m.get("user_id") == user_id
         authorized = (
-            m.get("user_id") == user_id
+            is_owner
             or user_id in (data.get("transcript_viewers") or [])
             or (bool(member_workspaces) and data.get("workspace_id") in member_workspaces)
         )
-        return await self._transcript_doc(mid) if authorized else None
+        # Same decision, two uses: whether the read is allowed, and which tier of ``data`` it carries.
+        return await self._transcript_doc(mid, viewer_is_owner=is_owner) if authorized else None
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
                             member_workspaces=None, list_view=False, meeting_id=None, slim=False):
@@ -209,6 +214,9 @@ class InMemoryTranscriptStore:
             has_more = False
 
         def _row(mid, m):
+            # One ownership decision per row, feeding both `shared` and the projection's viewer tier
+            # (mirrors the real store's `_row`).
+            is_owner = m["user_id"] == user_id
             row = {
                 "id": mid,
                 "user_id": m["user_id"],
@@ -222,12 +230,14 @@ class InMemoryTranscriptStore:
                 # api.v1 MeetingResponse declares these at top level; the values live in `data`.
                 "completion_reason": (m.get("data") or {}).get("completion_reason") if isinstance(m.get("data"), dict) else None,
                 "failure_stage": (m.get("data") or {}).get("failure_stage") if isinstance(m.get("data"), dict) else None,
-                "shared": m["user_id"] != user_id,
+                "shared": not is_owner,
                 "created_at": m["created_at"],
                 "updated_at": m["updated_at"],
                 # #584 list_view / #803 slim: both drop the heavy detail keys and keep the light
                 # metadata. Only a caller that genuinely renders full `data` leaves both off.
-                "data": project_list_data(m["data"]) if (list_view or slim) else m["data"],
+                # The response omissions are viewer-aware — the owner keeps their own webhook config.
+                "data": project_list_data(m["data"], viewer_is_owner=is_owner) if (list_view or slim)
+                else m["data"],
             }
             return row
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
@@ -14,12 +14,30 @@ endpoints) still ships the rest of ``data``.
 Size is not the only reason a key stays off a response. ``meeting.data`` is a shared row blob that
 also carries operational state — webhook signing config, share grants, session paths — which is not
 meeting content and which the read's access rule (owner OR transcript-share recipient OR bound-
-workspace member) would otherwise hand to a second party. Those keys (``RESPONSE_OMIT_KEYS``) are
-dropped on EVERY response edge, list and detail alike.
+workspace member) would otherwise hand to a second party.
+
+That state is not one bucket, and treating it as one is what #1243 got wrong. It splits in two by
+WHO may see it, so the response projection is VIEWER-AWARE:
+
+* :data:`SENSITIVE_OMIT_KEYS` — credential material and other people's material. Off every edge for
+  every viewer, the OWNER INCLUDED: the signing secret, the per-link share grants, the S3 session
+  path. The owner has dedicated endpoints for all three and no meeting response needs to carry them.
+* :data:`OWNER_ONLY_KEYS` — owner-private but not credentials: the webhook endpoint + event filter
+  and the reader roster. The owner's own configuration on the owner's own meeting, which the v0.10
+  REST contract promises them (``compat/v010_rest_compat_test.py::test_10_user_webhook_config_flow``
+  reads ``data.webhook_url`` back from ``GET /meetings``). Stripped for anyone who is not the owner —
+  a transcript-share recipient receives the transcript, not the owner's endpoint configuration, and
+  must not be able to enumerate who else the meeting was shared with.
+
+Ownership is not re-derived here. Every caller already computed it — ``list_meetings`` builds its
+access union and stamps ``shared``, ``get_transcript_by_id`` evaluates an explicit owner branch,
+``update_planned_meeting`` is owner-scoped in SQL — so the decision is PASSED DOWN as
+``viewer_is_owner``. It defaults to ``False``, so a caller that forgets to thread it gets the STRICT
+view; the failure direction is a missing field, never a disclosure.
 
 This module holds what the real store (``adapters.py``), the router (``app.py``) and the in-memory
 fake (``fakes.py``) must share so they can never diverge: the heavy keys dropped from a list row, the
-keys dropped from every response, and the default page size that bounds an otherwise-unbounded list.
+two tiers of response omissions, and the default page size that bounds an otherwise-unbounded list.
 """
 from __future__ import annotations
 
@@ -48,47 +66,66 @@ CALENDAR_SOURCE_LIST_KEYS = frozenset({
     "bot_name",
 })
 
-# ── Response-edge omissions ──────────────────────────────────────────────────────────────────────
-# ``meeting.data`` is a shared row blob: several producers write operational state into it that is
-# NOT the caller's meeting content. Some of that state is credential/authorization material, and a
-# meeting row is readable by more than its owner — the access rule on every read here is owner OR
-# transcript-share recipient OR member of the bound workspace (see ``list_meetings``' own comment).
-# So these keys are dropped on EVERY response edge, for EVERY viewer including the owner, matching
-# how the delivery path treats the same blob (``webhooks.delivery._INTERNAL_DATA_KEYS``) and how
-# every other surface reports the webhook config (``GET /user/webhook`` → ``webhook_secret_set`` +
-# a masked value, never the value).
-#
-# DENY-set, not allow-list, deliberately. ``data`` is an open multi-producer blob whose LIGHT keys
-# the detail view genuinely renders (title, docs, notes, scheduled_at, flags, completion_reason,
-# constructed_meeting_url, calendar_uid, …) and product work adds new ones continuously. An
-# allow-list at this edge would silently blank every future feature's field on the detail page —
-# a data-loss failure that no existing test would catch. The deny-by-default property an allow-list
-# buys is recovered instead by :data:`SENSITIVE_KEY_SUFFIXES` below, which drops credential-SHAPED
-# key names a future producer adds without anyone updating this set.
-RESPONSE_OMIT_KEYS = frozenset({
-    # Per-user webhook config, stamped onto the row at spawn so the lifecycle callback can sign
-    # deliveries. The signing secret is the whole security property of the webhook; the URL and the
-    # event filter are the owner's endpoint configuration. None of it is meeting content.
+# ── Response-edge omissions · TIER 1: never shipped, to anyone ───────────────────────────────────
+# Credential material, and material belonging to people other than the reader. Dropped on EVERY
+# response edge for EVERY viewer INCLUDING THE OWNER — not because the owner is untrusted, but
+# because no meeting response is the right carrier for them and each already has a purpose-built
+# surface. This matches how the delivery path treats the same blob
+# (``webhooks.delivery._INTERNAL_DATA_KEYS``) and how ``GET /user/webhook`` reports the config
+# (``webhook_secret_set`` + a masked value, never the value).
+SENSITIVE_OMIT_KEYS = frozenset({
+    # The webhook SIGNING SECRET. It is the entire security property of the webhook: anyone holding
+    # it can forge a delivery the receiver will verify. The owner reads its presence from
+    # ``GET /user/webhook``; nothing needs the value back out of a meeting row.
     "webhook_secret",
     "webhook_secrets",
-    "webhook_url",
-    "webhook_events",
-    "webhook_delivery",
-    "webhook_deliveries",
-    "outbound_events",
-    # Share/authz state: ``share_grants`` carries each link's ``secret_hash`` plus its allow-list and
-    # expiry, and ``transcript_viewers`` is the roster of every user id that can read the meeting.
-    # Both are the authorization machinery for this read, never its payload.
+    # Per-link share grants: each carries its ``secret_hash`` plus the allow-list and expiry. This is
+    # the credential half of the share machinery, and the redeem path is its only legitimate reader.
     "share_grants",
-    "transcript_viewers",
-    # S3 path of the authenticated browser-session userdata used for authenticated spawns.
+    # S3 path of the authenticated browser-session userdata used for authenticated spawns — a
+    # pointer to a live browser session's cookies.
     "auth_userdata_path",
 })
 
-# Credential-shaped key-name endings dropped in addition to :data:`RESPONSE_OMIT_KEYS`, so a key a
-# future producer stamps into ``data`` is omitted by DEFAULT rather than shipped until someone
-# notices. Matched on the whole key or its ``_``-suffixed tail, so ``token_count``/``secret_ballot``
-# and other legitimate names that merely CONTAIN a sensitive word are unaffected.
+# ── Response-edge omissions · TIER 2: the OWNER's, and only the owner's ──────────────────────────
+# Owner-private, but NOT credentials — the owner's own configuration and roster on the owner's own
+# meeting. Shipped to the owner (v0.10 promises the webhook config back on the meeting row and
+# ``test_10_user_webhook_config_flow`` reads it there), stripped for every other viewer: a
+# transcript-share recipient was given a transcript, not the owner's endpoint configuration, and
+# must not be able to enumerate the meeting's other readers.
+OWNER_ONLY_KEYS = frozenset({
+    # Per-user webhook config, stamped onto the row at spawn so the lifecycle callback can deliver.
+    # The endpoint URL and the event filter are the owner's configuration — part of the v0.10 REST
+    # contract, and the reason #1243's unconditional strip was a backward-compatibility break.
+    "webhook_url",
+    "webhook_events",
+    # Delivery bookkeeping written back by the lifecycle callback: attempts, statuses, last error.
+    # The owner's operational state; meaningless and none of their business to anyone else.
+    "webhook_delivery",
+    "webhook_deliveries",
+    "outbound_events",
+    # The reader roster — every user id that can read this meeting. A share recipient enumerating it
+    # learns who ELSE the owner shared with, which is other people's material, not theirs.
+    "transcript_viewers",
+})
+
+# What a NON-OWNER's response drops explicitly: both tiers. Kept as one name because that is the
+# question most readers of this module are asking ("what does a stranger not get?"), and because the
+# delivery path's internal-key set is pinned against it.
+RESPONSE_OMIT_KEYS = SENSITIVE_OMIT_KEYS | OWNER_ONLY_KEYS
+
+# DENY-set, not allow-list, deliberately (unchanged from #1243). ``data`` is an open multi-producer
+# blob whose LIGHT keys the detail view genuinely renders (title, docs, notes, scheduled_at, flags,
+# completion_reason, constructed_meeting_url, calendar_uid, …) and product work adds new ones
+# continuously. An allow-list at this edge would silently blank every future feature's field on the
+# detail page — a data-loss failure that no existing test would catch, surfacing as a bug report.
+#
+# Credential-shaped key-name endings dropped in addition to the sets above, so a key a future
+# producer stamps into ``data`` is omitted by DEFAULT rather than shipped until someone notices.
+# This is a TIER-1 rule: a credential-shaped key is withheld from the owner too, because the whole
+# point is that nobody has yet decided what it is. Matched on the whole key or its ``_``-suffixed
+# tail, so ``token_count``/``secret_santa_notes`` and other names that merely CONTAIN a sensitive
+# word are unaffected.
 SENSITIVE_KEY_SUFFIXES = (
     "secret", "secrets", "token", "tokens", "password", "credential", "credentials",
     "api_key", "apikey", "private_key", "signing_key", "access_key",
@@ -134,14 +171,32 @@ def is_sensitive_key(key: str) -> bool:
     return any(k == s or k.endswith("_" + s) for s in SENSITIVE_KEY_SUFFIXES)
 
 
-def project_response_data(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-    """Return ``data`` shaped for an API RESPONSE: calendar sources reduced to their identity +
-    policy keys, and every credential/authorization key dropped.
+def omitted_keys(*, viewer_is_owner: bool) -> frozenset:
+    """The explicit key set a response drops for this viewer.
 
-    This is the projection for the DETAIL paths (``GET /meetings/{id}`` and the transcript
-    endpoints), which ship ``data`` in full. Those reads authorize the owner, a transcript-share
-    recipient, AND a member of the bound workspace, so "the owner put it there" is not a reason for
-    a key to ride the response — the reader may be someone the owner shared one transcript with.
+    ``viewer_is_owner`` is the caller's ALREADY-COMPUTED access decision, passed down rather than
+    re-derived (see the module docstring). It defaults nowhere: every call site names it, and the
+    two public projections below default it to ``False`` so an un-threaded caller gets the strict
+    view.
+    """
+    return SENSITIVE_OMIT_KEYS if viewer_is_owner else RESPONSE_OMIT_KEYS
+
+
+def project_response_data(
+    data: Optional[Dict[str, Any]], *, viewer_is_owner: bool = False,
+) -> Dict[str, Any]:
+    """Return ``data`` shaped for an API RESPONSE **to this viewer**: calendar sources reduced to
+    their identity + policy keys, credential material dropped for everyone, and the owner's private
+    configuration dropped for everyone but the owner.
+
+    This is the projection for the DETAIL paths (``GET /meetings/{id}``, the transcript endpoints,
+    the ``PATCH`` echo). Those reads authorize the owner, a transcript-share recipient, AND a member
+    of the bound workspace, so "the owner put it there" is not a reason for a key to ride the
+    response to a SECOND party — but it is exactly the reason the OWNER still gets their own webhook
+    configuration back, which the v0.10 REST contract promises them.
+
+    ``viewer_is_owner`` defaults to ``False`` (the strict view): a caller that has not threaded the
+    access decision fails toward a missing field, never toward a disclosure.
 
     Pure and non-mutating (builds a new dict). It operates on the RESPONSE, never on the stored row,
     so state the system genuinely needs — the webhook signing secret the lifecycle callback reads
@@ -149,29 +204,38 @@ def project_response_data(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     the ICS snapshot the calendar sweep reconciles — is untouched in the database. A non-dict
     ``data`` projects to ``{}``.
     """
+    omit = omitted_keys(viewer_is_owner=viewer_is_owner)
     projected = project_calendar_sources(data)
     return {
         k: v for k, v in projected.items()
-        if k not in RESPONSE_OMIT_KEYS and not is_sensitive_key(k)
+        if k not in omit and not is_sensitive_key(k)
     }
 
 
-def project_list_data(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def project_list_data(
+    data: Optional[Dict[str, Any]], *, viewer_is_owner: bool = False,
+) -> Dict[str, Any]:
     """Return ``data`` with the heavy :data:`LIST_OMIT_KEYS` dropped; every light key kept.
 
     The list is a response edge too — and the one where a share recipient first meets a meeting they
-    do not own — so it drops :data:`RESPONSE_OMIT_KEYS` as well. ``LIST_OMIT_KEYS`` is about SIZE
-    (keys no list row renders); the response omissions are about DISCLOSURE and apply on every path.
+    do not own — so it applies the same viewer-aware omissions as the detail path.
+    ``LIST_OMIT_KEYS`` is about SIZE (keys no list row renders) and is unconditional; the response
+    omissions are about DISCLOSURE and depend on who is reading.
+
+    The owner branch is load-bearing, not a convenience: a 0.10 client reads its applied
+    ``webhook_url`` back from ``GET /meetings`` (``test_10_user_webhook_config_flow``), so this edge
+    is where the v0.10 webhook-config contract actually lives.
 
     Pure and non-mutating (builds a new dict), so the caller's stored ``data`` is untouched. A
     non-dict ``data`` projects to ``{}``.
     """
     if not isinstance(data, dict):
         return {}
+    omit = omitted_keys(viewer_is_owner=viewer_is_owner)
     sources = project_calendar_sources(data).get("calendar_sources")
     projected = {k: v for k, v in data.items()
                  if k not in LIST_OMIT_KEYS and k != "calendar_sources"
-                 and k not in RESPONSE_OMIT_KEYS and not is_sensitive_key(k)}
+                 and k not in omit and not is_sensitive_key(k)}
     if isinstance(sources, list):
         projected["calendar_sources"] = sources
     return projected

--- a/core/meetings/services/meeting-api/tests/test_response_secret_projection.py
+++ b/core/meetings/services/meeting-api/tests/test_response_secret_projection.py
@@ -1,52 +1,70 @@
-"""``meeting.data`` operational state stays off the API response — on every read edge, for every viewer.
+"""``meeting.data`` on the API response: two tiers, decided by WHO is reading.
 
-The meeting row's ``data`` blob is shared: besides the meeting's own content it carries state other
-parts of the system stamped there — the per-user webhook signing config (``bot_spawn`` writes it so
-the lifecycle callback can sign deliveries), the transcript-share grants and viewer roster, the
-authenticated-session path. None of it is meeting content, and the reads that ship ``data`` authorize
-more than the owner: owner **or** transcript-share recipient **or** member of the bound workspace
-(the access union ``list_meetings`` documents). So the response edge projects it away.
+The meeting row's ``data`` blob is shared. Besides the meeting's own content it carries state other
+parts of the system stamped there — the per-user webhook config (``bot_spawn`` writes it so the
+lifecycle callback can deliver), the transcript-share grants and viewer roster, the
+authenticated-session path. The reads that ship ``data`` authorize more than the owner: owner **or**
+transcript-share recipient **or** member of the bound workspace (the access union ``list_meetings``
+documents). So the response edge projects — but not with one rule for everybody:
 
-The share-recipient cases are the load-bearing ones: a second user, holding nothing but a redeemed
-transcript link, must receive the transcript and none of the owner's configuration. Every other
-surface already reports the webhook config the same way (``GET /user/webhook`` → ``webhook_secret_set``
-plus a masked value, never the value).
+**Tier 1 · never shipped, to anyone** (``SENSITIVE_OMIT_KEYS`` + anything credential-SHAPED):
+``webhook_secret``, ``share_grants``, ``auth_userdata_path``. Credential material and other people's
+material. The owner is not excluded — they have dedicated endpoints for all three, and no meeting
+response is the right carrier.
+
+**Tier 2 · the owner's, and only the owner's** (``OWNER_ONLY_KEYS``): ``webhook_url``,
+``webhook_events``, ``transcript_viewers``. Owner-private but not credentials. The v0.10 REST
+contract promises the owner their own webhook config back on their own meeting row — the compat
+suite's ``test_10_user_webhook_config_flow`` reads ``data.webhook_url`` out of ``GET /meetings``
+after a spawn — so stripping it from the owner is a backward-compatibility break, not a hardening.
+Stripped for everyone else: a transcript-share recipient was given a transcript, not the owner's
+endpoint configuration, and must not be able to enumerate who ELSE the meeting was shared with.
+
+Both load-bearing cases have a test on every edge (list · meeting detail · transcript detail · PATCH
+echo): the owner keeps tier 2, a second user holding nothing but a redeemed share link keeps
+neither, and nobody at all sees tier 1.
 
 The projection is a RESPONSE-edge transform and must not disturb the stored row — the delivery path
-reads the signing secret out of the meeting row at send time — so the last test signs a real delivery
-after a read has been served.
+reads the signing secret out of the meeting row at send time — so the last two tests sign a real
+delivery after a read has been served.
 """
 from __future__ import annotations
 
 import asyncio
 
+import pytest
 from fastapi.testclient import TestClient
 
 from meeting_api.collector import create_app
 from meeting_api.collector.fakes import InMemoryTranscriptStore
 from meeting_api.collector.projection import (
+    OWNER_ONLY_KEYS,
     RESPONSE_OMIT_KEYS,
+    SENSITIVE_OMIT_KEYS,
     is_sensitive_key,
     project_list_data,
     project_response_data,
 )
 
-OWNER, VIEWER, STRANGER = 41, 42, 43
+OWNER, VIEWER, STRANGER, WS_MEMBER = 41, 42, 43, 44
 PLAT, NID = "google_meet", "xyz-abcd-efg"
 SECRET = "whsec-owner-signing-key"
 HOOK = "https://hooks.example.com/owner-endpoint"
+EVENTS = {"meeting.status_change": True}
+USERDATA = "s3://vexa-bot-userdata/owner/session.tar"
 
-# What a spawned meeting's row actually holds: real content next to the operational keys.
+# What a spawned meeting's row actually holds: real content next to both tiers of operational state.
 ROW_DATA = {
     "title": "Quarterly review",
     "notes": "agenda in the doc",
     "constructed_meeting_url": f"https://meet.google.com/{NID}",
     "transcribe_enabled": True,
-    # operational state — none of it the reader's
+    # tier 2 — the owner's own configuration
     "webhook_url": HOOK,
+    "webhook_events": EVENTS,
+    # tier 1 — credential material, nobody's to read
     "webhook_secret": SECRET,
-    "webhook_events": {"meeting.status_change": True},
-    "auth_userdata_path": "s3://vexa-bot-userdata/owner/session.tar",
+    "auth_userdata_path": USERDATA,
 }
 
 # Keys a reader may legitimately see — asserted present so the projection is proven to be a strip of
@@ -75,39 +93,155 @@ def _share_with(client, uid):
     return r
 
 
-def _assert_clean(data: dict, *, where: str):
-    """No omitted key, and nothing credential-SHAPED, survived into a response ``data`` blob."""
-    for key in RESPONSE_OMIT_KEYS:
+# ── the three assertions the whole file is made of ───────────────────────────────────────────────
+
+def _assert_no_credentials(data: dict, *, where: str):
+    """TIER 1. Nothing credential-shaped survived — for ANY viewer, the owner included."""
+    for key in SENSITIVE_OMIT_KEYS:
         assert key not in data, f"{where}: {key} rode the response"
     leaked = [k for k in data if is_sensitive_key(k)]
     assert not leaked, f"{where}: credential-shaped keys rode the response: {leaked}"
     # and the value itself never appears, under any key or nesting
     assert SECRET not in repr(data), f"{where}: the signing secret's VALUE rode the response"
+    assert USERDATA not in repr(data), f"{where}: the session userdata path rode the response"
 
 
-# ── the transcript detail edge ───────────────────────────────────────────────────────────────────
+def _assert_owner_private_absent(data: dict, *, where: str):
+    """TIER 2, non-owner view. The owner's configuration and reader roster are not this reader's."""
+    for key in OWNER_ONLY_KEYS:
+        assert key not in data, f"{where}: owner-private {key} rode the response to a non-owner"
+    assert HOOK not in repr(data), f"{where}: the owner's endpoint URL reached a non-owner"
 
-def test_transcript_detail_omits_operational_keys_for_the_owner():
+
+def _assert_owner_private_present(data: dict, *, where: str):
+    """TIER 2, owner view — the v0.10 contract. This is the assertion #1243 broke."""
+    assert data.get("webhook_url") == HOOK, (
+        f"{where}: the owner lost their own webhook_url — this is the v0.10 REST contract "
+        f"(compat test_10_user_webhook_config_flow reads it back off the meeting row)"
+    )
+    assert data.get("webhook_events") == EVENTS, f"{where}: the owner lost their own webhook_events"
+
+
+# ── TIER 2 · the owner keeps their own configuration, on every edge (the v0.10 regression) ───────
+
+def test_owner_keeps_their_webhook_config_on_the_meetings_list():
+    """THE regressed contract, on the exact edge the compat suite reads.
+
+    ``test_10_user_webhook_config_flow`` configures a webhook, spawns a bot, then polls
+    ``GET /meetings`` until the row carries ``data.webhook_url``. A single user, their own meeting.
+    #1243 stripped it unconditionally and that poll timed out.
+    """
     store, client = _client()
-    r = client.get(f"/transcripts/by-id/{_mid(store)}", headers={"x-user-id": str(OWNER)})
+    rows = client.get("/meetings", headers={"x-user-id": str(OWNER)}).json()["meetings"]
+    assert rows, "the owner's own meeting must be in their list"
+    data = rows[0]["data"]
+    _assert_owner_private_present(data, where="GET /meetings (owner)")
+    _assert_no_credentials(data, where="GET /meetings (owner)")
+
+
+def test_owner_keeps_their_webhook_config_on_the_meeting_detail():
+    store, client = _client()
+    data = client.get(f"/meetings/{_mid(store)}", headers={"x-user-id": str(OWNER)}).json()["data"]
+    _assert_owner_private_present(data, where="GET /meetings/{id} (owner)")
+    _assert_no_credentials(data, where="GET /meetings/{id} (owner)")
+
+
+@pytest.mark.parametrize("path_for", [
+    lambda store: f"/transcripts/by-id/{_mid(store)}",
+    lambda store: f"/transcripts/{PLAT}/{NID}",
+], ids=["by-id", "native"])
+def test_owner_keeps_their_webhook_config_on_the_transcript_detail(path_for):
+    store, client = _client()
+    r = client.get(path_for(store), headers={"x-user-id": str(OWNER)})
     assert r.status_code == 200
     data = r.json()["data"]
-    _assert_clean(data, where="GET /transcripts/by-id (owner)")
-    for k in CONTENT_KEYS:
-        assert k in data, f"the projection erased content key {k}"
+    _assert_owner_private_present(data, where="GET /transcripts (owner)")
+    _assert_no_credentials(data, where="GET /transcripts (owner)")
 
 
-def test_transcript_detail_omits_operational_keys_for_a_share_recipient():
+def test_owner_keeps_their_webhook_config_on_the_patch_echo():
+    """PATCH is owner-scoped in the store (``WHERE id = … AND user_id = …``), so its echo is always
+    the owner reading their own row back."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID,
+                             status="scheduled", data=dict(ROW_DATA))
+    client = TestClient(create_app(store, redis=None))
+    r = client.patch(f"/meetings/{mid}", json={"title": "renamed"},
+                     headers={"x-user-id": str(OWNER)})
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    _assert_owner_private_present(data, where="PATCH /meetings/{id} echo (owner)")
+    _assert_no_credentials(data, where="PATCH /meetings/{id} echo (owner)")
+
+
+def test_owner_sees_the_reader_roster_and_the_share_recipient_does_not():
+    """``transcript_viewers`` is the meeting's reader roster. The owner may see who they shared
+    with; a recipient enumerating it would learn who ELSE holds a link — other people's material."""
+    store, client = _client()
+    _share_with(client, VIEWER)
+    mid = _mid(store)
+
+    owner_data = client.get(f"/meetings/{mid}", headers={"x-user-id": str(OWNER)}).json()["data"]
+    assert VIEWER in (owner_data.get("transcript_viewers") or []), (
+        "the owner must still be able to see who their meeting is shared with"
+    )
+
+    viewer_data = client.get(f"/meetings/{mid}", headers={"x-user-id": str(VIEWER)}).json()["data"]
+    assert "transcript_viewers" not in viewer_data, "a recipient enumerated the reader roster"
+
+
+# ── TIER 2 · a NON-OWNER gets none of it, on every edge ──────────────────────────────────────────
+
+def test_share_recipient_gets_no_owner_private_keys_from_the_list():
+    """The list is where a recipient first meets a meeting they do not own."""
+    store, client = _client()
+    _share_with(client, VIEWER)
+    rows = client.get("/meetings", headers={"x-user-id": str(VIEWER)}).json()["meetings"]
+    assert rows, "the shared meeting must surface in the recipient's list"
+    for row in rows:
+        assert row["shared"] is True, "the row the recipient sees is not their own"
+        _assert_owner_private_absent(row["data"], where="GET /meetings (share recipient)")
+        _assert_no_credentials(row["data"], where="GET /meetings (share recipient)")
+
+
+def test_share_recipient_gets_no_owner_private_keys_from_the_meeting_detail():
+    store, client = _client()
+    _share_with(client, VIEWER)
+    data = client.get(f"/meetings/{_mid(store)}", headers={"x-user-id": str(VIEWER)}).json()["data"]
+    _assert_owner_private_absent(data, where="GET /meetings/{id} (share recipient)")
+    _assert_no_credentials(data, where="GET /meetings/{id} (share recipient)")
+
+
+def test_share_recipient_gets_no_owner_private_keys_from_the_transcript_detail():
     """THE case: a different user, holding only a redeemed transcript link, reads the transcript.
 
-    They are authorized for the meeting's content and nothing else — the owner's webhook signing
-    config is not part of what was shared with them.
+    They are authorized for the meeting's content and nothing else — the owner's webhook endpoint
+    configuration is not part of what was shared with them.
     """
     store, client = _client()
     _share_with(client, VIEWER)
     r = client.get(f"/transcripts/by-id/{_mid(store)}", headers={"x-user-id": str(VIEWER)})
     assert r.status_code == 200, "the share recipient must still be able to read the transcript"
-    _assert_clean(r.json()["data"], where="GET /transcripts/by-id (share recipient)")
+    _assert_owner_private_absent(r.json()["data"], where="GET /transcripts/by-id (share recipient)")
+    _assert_no_credentials(r.json()["data"], where="GET /transcripts/by-id (share recipient)")
+
+
+def test_bound_workspace_member_is_not_the_owner_either():
+    """The third branch of the access union. Membership authorizes the meeting, not the owner's
+    configuration — ``shared`` is true for them too."""
+    store, client = _client({**ROW_DATA, "workspace_id": "ws-42"})
+    mid = _mid(store)
+    hdrs = {"x-user-id": str(WS_MEMBER), "x-user-workspaces": "ws-42"}
+
+    r = client.get(f"/transcripts/by-id/{mid}", headers=hdrs)
+    assert r.status_code == 200, "a member of the bound workspace must still read the transcript"
+    _assert_owner_private_absent(r.json()["data"], where="GET /transcripts/by-id (workspace member)")
+    _assert_no_credentials(r.json()["data"], where="GET /transcripts/by-id (workspace member)")
+
+    rows = client.get("/meetings", headers=hdrs).json()["meetings"]
+    assert rows, "the bound meeting must surface in the member's list"
+    for row in rows:
+        _assert_owner_private_absent(row["data"], where="GET /meetings (workspace member)")
 
 
 def test_share_recipient_still_gets_the_meetings_content():
@@ -120,28 +254,6 @@ def test_share_recipient_still_gets_the_meetings_content():
         assert k in data, f"share recipient lost content key {k}"
 
 
-# ── the meeting detail + list edges ──────────────────────────────────────────────────────────────
-
-def test_meeting_detail_omits_operational_keys_for_owner_and_share_recipient():
-    store, client = _client()
-    mid = _mid(store)
-    _share_with(client, VIEWER)
-    for uid, who in ((OWNER, "owner"), (VIEWER, "share recipient")):
-        r = client.get(f"/meetings/{mid}", headers={"x-user-id": str(uid)})
-        assert r.status_code == 200
-        _assert_clean(r.json()["data"], where=f"GET /meetings/{{id}} ({who})")
-
-
-def test_meetings_list_omits_operational_keys_for_a_share_recipient():
-    """The list is where a recipient first meets a meeting they do not own — same rule applies."""
-    store, client = _client()
-    _share_with(client, VIEWER)
-    rows = client.get("/meetings", headers={"x-user-id": str(VIEWER)}).json()["meetings"]
-    assert rows, "the shared meeting must surface in the recipient's list"
-    for row in rows:
-        _assert_clean(row.get("data") or {}, where="GET /meetings (share recipient)")
-
-
 def test_stranger_still_gets_nothing():
     """Unchanged: a user with neither ownership, share, nor workspace membership reads nothing."""
     store, client = _client()
@@ -149,53 +261,107 @@ def test_stranger_still_gets_nothing():
                       headers={"x-user-id": str(STRANGER)}).status_code == 404
 
 
-# ── the projection functions themselves ──────────────────────────────────────────────────────────
+# ── TIER 1 · nobody, on any edge, ever ───────────────────────────────────────────────────────────
 
-def test_projection_is_pure_and_leaves_the_stored_row_intact():
-    """It shapes the RESPONSE. The row keeps what the system needs to keep."""
-    stored = dict(ROW_DATA)
-    projected = project_response_data(stored)
-    assert stored == ROW_DATA, "the projection mutated its input"
-    assert "webhook_secret" not in projected and stored["webhook_secret"] == SECRET
+def test_credentials_never_ship_to_anyone_on_any_edge():
+    """The property #1243 got right and this change must not weaken: the signing secret, the share
+    grants and the session path stay off every response — for the OWNER as much as for a stranger.
 
-
-def test_share_grants_and_viewer_roster_stay_off_the_response():
-    """``share_grants`` carries each link's secret hash + allow-list; ``transcript_viewers`` is the
-    roster of everyone who can read the meeting. Both are this read's authorization machinery."""
+    Runs after a share has been minted and redeemed, so ``share_grants`` and ``transcript_viewers``
+    are genuinely populated on the row rather than absent by accident.
+    """
     store, client = _client()
+    mid = _mid(store)
     _share_with(client, VIEWER)
-    data = client.get(f"/transcripts/by-id/{_mid(store)}",
-                      headers={"x-user-id": str(VIEWER)}).json()["data"]
-    assert "share_grants" not in data and "transcript_viewers" not in data
-    # the stored row still has them — redeeming a second link must keep working
-    assert client.post("/transcripts/share/accept",
-                       json={"token": client.post(f"/meetings/{PLAT}/{NID}/share",
-                                                  json={"mode": "open"},
-                                                  headers={"x-user-id": str(OWNER)}).json()["token"]},
-                       headers={"x-user-id": str(STRANGER)}).status_code == 200
+    assert "share_grants" in store._meetings[mid]["data"], "fixture did not populate share_grants"
+
+    for uid, who in ((OWNER, "owner"), (VIEWER, "share recipient")):
+        h = {"x-user-id": str(uid)}
+        edges = {
+            "GET /transcripts/by-id": client.get(f"/transcripts/by-id/{mid}", headers=h).json()["data"],
+            "GET /meetings/{id}": client.get(f"/meetings/{mid}", headers=h).json()["data"],
+            "GET /meetings": (client.get("/meetings", headers=h).json()["meetings"][0])["data"],
+        }
+        if uid == OWNER:
+            edges["GET /transcripts/{platform}/{native}"] = client.get(
+                f"/transcripts/{PLAT}/{NID}", headers=h).json()["data"]
+        for edge, data in edges.items():
+            _assert_no_credentials(data, where=f"{edge} ({who})")
 
 
-def test_credential_shaped_keys_are_dropped_by_default():
+def test_credential_shaped_keys_are_dropped_by_default_for_the_owner_too():
     """A key a future producer stamps into ``data`` is omitted on NAME SHAPE, before anyone has
-    thought to add it to the deny-set — so the failure mode is a missing field, not a leak."""
+    thought to add it to a set — so the failure mode is a missing field, not a leak. This is a
+    TIER-1 rule: it applies to the owner as well, because nobody has decided what the key IS yet."""
     blob = {"title": "t", "provider_api_key": "ak-1", "refresh_token": "rt-1",
             "db_password": "pw", "signing_key": "sk-1", "some_secret": "s"}
-    for projected in (project_response_data(blob), project_list_data(blob)):
-        assert projected == {"title": "t"}, projected
+    for owner in (True, False):
+        for projected in (project_response_data(blob, viewer_is_owner=owner),
+                          project_list_data(blob, viewer_is_owner=owner)):
+            assert projected == {"title": "t"}, (owner, projected)
     # ...without catching names that merely CONTAIN a sensitive word
     keep = {"token_count": 12, "secret_santa_notes": "x", "tokens_used": 3}
+    assert project_response_data(keep, viewer_is_owner=True) == keep
     assert project_response_data(keep) == keep
 
 
 def test_response_omissions_cover_the_delivery_paths_internal_keys():
     """The webhook delivery path already refuses to ship these in a payload
-    (``webhooks.delivery._INTERNAL_DATA_KEYS``). An API response is no less outbound than a webhook,
-    so the response edge must cover the same credential keys — this pins the two together."""
+    (``webhooks.delivery._INTERNAL_DATA_KEYS``). An API response to a party who is NOT the owner is
+    no less outbound than a webhook to a third party, so the non-owner view must cover the same
+    keys — this pins the two together. (The owner's own view is governed by the v0.10 contract
+    instead, which is why the pin is against the union and not against tier 1.)"""
     from meeting_api.webhooks.delivery import _INTERNAL_DATA_KEYS
 
     credential_keys = {k for k in _INTERNAL_DATA_KEYS if "webhook" in k or is_sensitive_key(k)}
     missing = credential_keys - RESPONSE_OMIT_KEYS
     assert not missing, f"delivery strips these but the response edge does not: {sorted(missing)}"
+
+
+# ── the projection functions themselves ──────────────────────────────────────────────────────────
+
+def test_the_two_tiers_are_disjoint_and_compose_into_the_non_owner_view():
+    """A key belongs to exactly one tier. Placing one in both would hide a decision nobody made."""
+    assert not (SENSITIVE_OMIT_KEYS & OWNER_ONLY_KEYS), "a key is in both tiers"
+    assert RESPONSE_OMIT_KEYS == SENSITIVE_OMIT_KEYS | OWNER_ONLY_KEYS
+    # the credential tier must not have drifted into containing the v0.10 contract's fields
+    assert {"webhook_url", "webhook_events"} <= OWNER_ONLY_KEYS
+    assert {"webhook_secret", "share_grants", "auth_userdata_path"} <= SENSITIVE_OMIT_KEYS
+
+
+def test_the_projections_default_to_the_strict_view():
+    """A caller that has not threaded the access decision must get the NON-owner view. The failure
+    direction of a forgotten keyword argument is a missing field, never a disclosure."""
+    for projected in (project_response_data(ROW_DATA), project_list_data(ROW_DATA)):
+        for key in RESPONSE_OMIT_KEYS:
+            assert key not in projected, f"the default view shipped {key}"
+        assert projected["title"] == "Quarterly review"
+
+
+def test_projection_is_pure_and_leaves_the_stored_row_intact():
+    """It shapes the RESPONSE. The row keeps what the system needs to keep — on both views."""
+    stored = dict(ROW_DATA)
+    for owner in (True, False):
+        projected = project_response_data(stored, viewer_is_owner=owner)
+        assert stored == ROW_DATA, "the projection mutated its input"
+        assert "webhook_secret" not in projected
+    assert stored["webhook_secret"] == SECRET
+
+
+def test_share_grants_stay_off_the_response_without_breaking_redemption():
+    """``share_grants`` carries each link's secret hash + allow-list — tier 1, off every response.
+    The STORED row still has it, so redeeming a second link keeps working."""
+    store, client = _client()
+    _share_with(client, VIEWER)
+    for uid in (OWNER, VIEWER):
+        data = client.get(f"/transcripts/by-id/{_mid(store)}",
+                          headers={"x-user-id": str(uid)}).json()["data"]
+        assert "share_grants" not in data
+    assert client.post("/transcripts/share/accept",
+                       json={"token": client.post(f"/meetings/{PLAT}/{NID}/share",
+                                                  json={"mode": "open"},
+                                                  headers={"x-user-id": str(OWNER)}).json()["token"]},
+                       headers={"x-user-id": str(STRANGER)}).status_code == 200
 
 
 # ── the delivery path is untouched ───────────────────────────────────────────────────────────────

--- a/core/meetings/services/meeting-api/tests/test_transcript_merge.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_merge.py
@@ -53,7 +53,9 @@ async def test_merge_assembles_response_and_merges_live_redis():
         "s-redis": json.dumps({"start": 1.0, "end": 2.0, "text": "in-flight", "segment_id": "s-redis"})}})
     store = SqlAlchemyTranscriptStore(session_factory=None, redis_client=redis)
 
-    doc = await store._merge_live_segments((_snap(), seg_by_id, order))
+    # ``viewer_is_owner`` is the caller's access decision, threaded in by both read paths; this test
+    # is about the MERGE, so it drives the owner view (what the native-keyed read always passes).
+    doc = await store._merge_live_segments((_snap(), seg_by_id, order), viewer_is_owner=True)
 
     # Top-level shape: exact keys, exact order.
     assert list(doc.keys()) == EXPECTED_KEYS
@@ -74,6 +76,6 @@ async def test_merge_without_redis_returns_persisted_only():
     """redis_client=None (or an empty hash) → the persisted segments still assemble cleanly, no crash."""
     seg_by_id, order = _pg_part()
     store = SqlAlchemyTranscriptStore(session_factory=None, redis_client=None)
-    doc = await store._merge_live_segments((_snap(), seg_by_id, order))
+    doc = await store._merge_live_segments((_snap(), seg_by_id, order), viewer_is_owner=True)
     assert [s["segment_id"] for s in doc["segments"]] == ["s-pg"]
     assert list(doc.keys()) == EXPECTED_KEYS


### PR DESCRIPTION
Refines [#1243](https://github.com/Vexa-ai/vexa/pull/1243) (merged). Base: `codex/1150-calendar-multi`.

## What #1243 got right

`meeting.data` is a shared row blob. Besides the meeting's own content it carries operational state
other parts of the system stamped there — the per-user webhook config, the transcript share grants
and viewer roster, the authenticated-session path. The reads that ship `data` authorize **owner OR
transcript-share recipient OR bound-workspace member**, so ownership of the row is not by itself a
reason for every key on it to ride the response. #1243 added `project_response_data` and applied it
on all four response edges (list, meeting detail, transcript detail, PATCH echo). That placement is
correct and this change keeps every bit of it: the same function, the same four call sites, the same
deny-set-not-allow-list decision, the same credential-shaped-key default.

## What it over-stripped

It stripped unconditionally — one rule for every reader — and the v0.10 backward-compat suite went
red on the rc.20 build:

```
compat/v010_rest_compat_test.py::test_10_user_webhook_config_flow
E  AssertionError: spawned meeting never carried webhook_url=https://…/hook/f2a4b412 in data
```

That flow is single-user: the same user configures a webhook, spawns a bot, and reads their own
meeting expecting `data.webhook_url`. So the v0.10 contract promises an OWNER their own webhook
configuration on their own meeting row, and the unconditional strip removed it for everyone rather
than for strangers.

## The two-tier model

The state in `data` is not one bucket. It splits by who may read it, so the projection splits with it.

| Tier | Keys | Owner | Non-owner |
|---|---|---|---|
| **1 · never shipped to anyone** | `webhook_secret` (+`webhook_secrets`), `share_grants`, `auth_userdata_path`, plus anything credential-**shaped** (`SENSITIVE_KEY_SUFFIXES`) | ✗ | ✗ |
| **2 · owner-private, not credentials** | `webhook_url`, `webhook_events`, `webhook_delivery`/`webhook_deliveries`/`outbound_events`, `transcript_viewers` | ✓ | ✗ |

Tier 1 is withheld from the owner too — not because the owner is untrusted, but because each of
these already has a purpose-built surface (`GET /user/webhook` reports `webhook_secret_set` plus a
masked value; the redeem path is the only legitimate reader of a grant's `secret_hash`) and no
meeting response is the right carrier. The credential-shaped-name rule stays in tier 1 for the same
reason: a key nobody has classified yet is withheld from everyone.

Tier 2 is the owner's own configuration and roster on the owner's own meeting. `webhook_url` /
`webhook_events` are the v0.10 contract. `transcript_viewers` is the reader roster — a share
recipient must not be able to enumerate who else the meeting was shared with, which is other
people's material rather than the owner's.

`RESPONSE_OMIT_KEYS` is now the union of the two — what a non-owner's response drops — so the test
pinning it against `webhooks.delivery._INTERNAL_DATA_KEYS` holds unchanged.

## Threading ownership

The response builders have to know whether the caller is the owner. Every edge had **already
computed that**, so the mechanism is to pass the existing decision down rather than re-derive
ownership at the edge:

| Edge | Where the decision already lived | How it reaches the projection |
|---|---|---|
| `GET /meetings`, `/bots`, `/bots/status` | `list_meetings._row` computed `m.user_id != user_id` for the api.v1 `shared` field | `_row` now computes `is_owner` **once** and feeds both `shared` and `project_list_data(..., viewer_is_owner=)`, so the two can never disagree |
| `GET /meetings/{id}` | the row `list_meetings` returned already carries `shared` | read back as `meeting.get("shared") is False` — `is False` and not `not …`, so an absent value falls to the strict view |
| `GET /transcripts/by-id/{id}` | `get_transcript_by_id`'s authorization check evaluates an explicit owner branch | that same boolean is bound to `is_owner` and passed into `_merge_live_segments` / `_transcript_doc` |
| `GET /transcripts/{platform}/{native}` | the SELECT constrains `Meeting.user_id == user_id` | passes `viewer_is_owner=True` by construction; this path has no share branch |
| `PATCH /meetings/{id}` echo (+ native alias) | `update_planned_meeting` selects `WHERE id = … AND user_id = …` and returns `None` otherwise | passes `viewer_is_owner=True`; a non-owner never reaches the echo |

No edge needed the strict fallback. `_merge_live_segments` / `_transcript_doc` take
`viewer_is_owner` as a **required** keyword — with exactly two callers each, forcing the decision is
cheaper than a default that can be silently wrong. The two public projections
(`project_response_data`, `project_list_data`) default it to `False`, so a future caller that
forgets to thread it gets the strict view: the failure direction is a missing field, never a
disclosure. `test_the_projections_default_to_the_strict_view` holds that.

## Delivery is still unaffected

Unchanged from #1243 and re-proven: the delivery path reads its signing config from
`meeting_row["data"]` as returned by `update_meeting_status` — the stored row, not any response
projection. Both of #1243's end-to-end tests are kept as-is and green
(`test_webhook_delivery_still_signs_after_a_read_has_been_served`,
`test_webhook_sink_delivers_with_the_row_secret_end_to_end`).

## Tests

`tests/test_response_secret_projection.py`: **21 tests** (was 12).

| Row | Evidence |
|---|---|
| A1 · owner keeps `webhook_url` + `webhook_events` on all four edges | `test_owner_keeps_their_webhook_config_on_the_meetings_list`, `…_on_the_meeting_detail`, `…_on_the_transcript_detail[by-id\|native]`, `…_on_the_patch_echo` |
| A2 · a transcript-share viewer gets none of tier 2, via list AND detail | `test_share_recipient_gets_no_owner_private_keys_from_the_list`, `…_from_the_meeting_detail`, `…_from_the_transcript_detail` |
| A2b · a bound-workspace member is not the owner either | `test_bound_workspace_member_is_not_the_owner_either` |
| A2c · the roster is owner-only, both directions in one test | `test_owner_sees_the_reader_roster_and_the_share_recipient_does_not` |
| A3 · tier 1 absent for everyone on every edge | `test_credentials_never_ship_to_anyone_on_any_edge`, `test_share_grants_stay_off_the_response_without_breaking_redemption`, `test_credential_shaped_keys_are_dropped_by_default_for_the_owner_too` |
| A4 · the recipient still receives what was shared | `test_share_recipient_still_gets_the_meetings_content`, `test_stranger_still_gets_nothing` |
| A5 · webhook delivery still signs | the two #1243 tests, unchanged |
| A6 · structural | `test_the_two_tiers_are_disjoint_and_compose_into_the_non_owner_view`, `test_the_projections_default_to_the_strict_view`, `test_projection_is_pure_and_leaves_the_stored_row_intact`, `test_response_omissions_cover_the_delivery_paths_internal_keys` |

**Red before, in both directions.** Forcing the tier decision to a constant and re-running:

- with #1243's unconditional strip → the **6 owner-view** tests fail;
- with a permissive always-owner view → the **6 non-owner-view** tests fail.

Neither direction is green by accident.

**Suite:** meeting-api `1154 passed, 5 skipped` (baseline at this base sha: `1145 passed, 5 skipped`).
Two tests in `test_transcript_merge.py` call the private `_merge_live_segments` directly and were
updated for the new required keyword — a call-signature change, no assertion touched.

## v0.10 compat proof

Run as the `validate-v010-compat` job invokes it (`.github/workflows/release-validate.yml`) — a real
compose stack, `V010_COMPAT=1 MOCK_BOT=1 BROWSER_IMAGE=mock-bot:… ./bin/stack-test compat` — on the
128-core build host, images built from source at each sha rather than pulled, so the leg exercises
this branch and not a published artifact. Same stack, same command, two shas:

**Base `8d4a1f4d` (this branch's base, i.e. #1243 as merged) — RED, the reported failure exactly:**

```
E  AssertionError: spawned meeting never carried webhook_url=https://v010-compat.example.com/hook/4f280dc5 in data
FAILED compat/v010_rest_compat_test.py::test_10_user_webhook_config_flow
1 failed, 6 passed, 3 xfailed in 114.51s
```

**This branch — GREEN:**

```
compat/v010_rest_compat_test.py::test_01_admin_user_token_lifecycle PASSED
compat/v010_rest_compat_test.py::test_02_admin_response_envelopes_v010_fields XFAIL
compat/v010_rest_compat_test.py::test_03_admin_via_gateway_v010_path XFAIL
compat/v010_rest_compat_test.py::test_04_bot_request_v010_flow PASSED
compat/v010_rest_compat_test.py::test_05_bots_status_v010_envelope PASSED
compat/v010_rest_compat_test.py::test_06_stop_bot_v010_contract XFAIL
compat/v010_rest_compat_test.py::test_07_stop_takes_effect PASSED
compat/v010_rest_compat_test.py::test_08_transcript_v010_shape PASSED
compat/v010_rest_compat_test.py::test_09_meetings_list_v010_shape PASSED
compat/v010_rest_compat_test.py::test_10_user_webhook_config_flow PASSED
compat/v010_rest_compat_test.py::test_11_user_webhook_echo_v010_shape XFAIL
======================== 7 passed, 4 xfailed in 58.71s =========================
```

The full `compat/` directory (REST + WS) on this branch: `9 passed, 5 xfailed`. Every xfail is a
pre-existing `strict=True` V010-BREAK marker, unchanged by this branch — the base run reaches fewer
of them only because it stops at the first hard failure.

`compat/v010_rest_compat_test.py` was **not** edited. It is the contract; wanting to edit it would
have meant the fix was still wrong.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Validation request

Any competent non-author. In order:

1. **The tier split itself.** `SENSITIVE_OMIT_KEYS` vs `OWNER_ONLY_KEYS` in
   `core/meetings/services/meeting-api/src/meeting_api/collector/projection.py`. Each key has a
   stated reason. `transcript_viewers` in tier 2 (owner sees their own roster) and
   `webhook_delivery`/`outbound_events` in tier 2 rather than tier 1 are the two a reviewer might
   reasonably push back on — say so here rather than after merge.
2. **The ownership threading.** `grep -rn "viewer_is_owner" core/meetings/services/meeting-api/src`
   — every call site should be reading a decision that already existed, not computing a new one. The
   `is False` at `collector/app.py`'s `get_meeting` is deliberate; a `not …` there would make an
   absent `shared` mean "owner".
3. **That the compat suite is untouched.** `git diff codex/1150-calendar-multi...  -- deploy/compose`
   should be empty.

**Deployment validated:** the v0.10 compat leg ran as a real compose stack (see above); the rest is
offline test-suite evidence against the in-memory fake and the shared projection module, which the
fake and the real store both call. No stage run.

## Authorship

Sole author: the human submitting this. No agent co-author trailers.
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
