### PR TITLE
build(dashboard): publish the image on an attested path

### DIFF
--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -1,0 +1,173 @@
+name: dashboard-image
+# The hosted Dashboard image, built where its provenance survives.
+#
+# `vexaai/dashboard` was the one image in the release set whose provenance was
+# not registry-verifiable: hand-built on an operator's host and shipped with a
+# classic `docker push`, which cannot carry an attestation. The build record
+# existed only in that host's local buildx cache, one `docker buildx prune` from
+# gone, and the image config carried no labels at all.
+#
+# This workflow is the attested path. Every push emits SLSA provenance
+# (mode=max) and an SBOM as registry referrers, and stamps the OCI labels, so
+# the answer to "what is this image and where did it come from?" is readable
+# from Docker Hub by anyone, with no SSH access to any machine.
+#
+# Dashboard is deliberately NOT in releases/*/candidate-images.json: it is a
+# hosted platform deployment, deprecated in favour of Terminal for new
+# self-hosted installs, and it does not carry an OSS release tag. It is built
+# here — in the repo that owns its source — rather than joining the OSS
+# candidate set. See services/dashboard/README.md § Build and provenance.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish (e.g. 0.10.6.4-<slug>). Defaults to a timestamp.'
+        required: false
+        type: string
+      move_dev:
+        description: 'Point :dev at this build'
+        required: false
+        default: true
+        type: boolean
+  pull_request:
+    paths:
+      - 'services/dashboard/**'
+      - 'packages/transcript-rendering/**'
+      - '.github/workflows/dashboard-image.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # A build that never runs in CI is a build nobody knows is broken. This proves
+  # the image assembles from a clean checkout of the merge result — the check
+  # that a repo-root COPY of a file no longer in the tree would have failed.
+  verify-builds:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build (no push) — the Dockerfile still assembles from this tree
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/dashboard/Dockerfile
+          push: false
+          build-args: |
+            VEXA_IMAGE_REVISION=${{ github.event.pull_request.head.sha }}
+            VEXA_IMAGE_SOURCE=${{ github.server_url }}/${{ github.repository }}
+            VEXA_API_URL=http://build-only.invalid
+
+  publish:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Hub credentials present?
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ] \
+            || { echo "::error ::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not configured"; exit 1; }
+
+      - name: Resolve the publish identity
+        id: id
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$(date -u +%y%m%d-%H%M)}"
+          # The tag lands in an image reference; keep it to what a reference allows.
+          case "$TAG" in
+            *[!A-Za-z0-9._-]*) echo "::error ::illegal tag '$TAG'"; exit 1 ;;
+          esac
+          {
+            echo "tag=$TAG"
+            echo "revision=$GITHUB_SHA"
+            echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_OUTPUT"
+          echo "✓ publishing vexaai/dashboard:$TAG from $GITHUB_SHA"
+
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # provenance=mode=max + sbom=true are what make this build inspectable
+      # from the registry. Dropping them returns the image to the unverifiable
+      # state this workflow exists to end.
+      - name: Build + push with SLSA provenance and SBOM
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/dashboard/Dockerfile
+          push: true
+          platforms: linux/amd64
+          provenance: mode=max
+          sbom: true
+          tags: vexaai/dashboard:${{ steps.id.outputs.tag }}
+          build-args: |
+            VEXA_IMAGE_REVISION=${{ steps.id.outputs.revision }}
+            VEXA_IMAGE_CREATED=${{ steps.id.outputs.created }}
+            VEXA_IMAGE_VERSION=${{ steps.id.outputs.tag }}
+            VEXA_IMAGE_SOURCE=${{ github.server_url }}/${{ github.repository }}
+
+      # Fail closed on the exact defect that motivated this workflow: an image
+      # on the registry whose provenance cannot be read back off the registry.
+      - name: Read the provenance back off Docker Hub
+        env:
+          REF: vexaai/dashboard:${{ steps.id.outputs.tag }}
+          WANT_REV: ${{ steps.id.outputs.revision }}
+        run: |
+          set -euo pipefail
+          GOT_REV="$(docker buildx imagetools inspect "$REF" --format '{{json .Image}}' | python3 -c '
+          import json,sys
+          d=json.load(sys.stdin)
+          imgs=list(d.values()) if isinstance(d,dict) and "config" not in d and "Config" not in d else [d]
+          for i in imgs:
+              lab=(i.get("config") or i.get("Config") or {}).get("Labels") or {}
+              r=lab.get("org.opencontainers.image.revision")
+              if r: print(r); break')"
+          [ "$GOT_REV" = "$WANT_REV" ] \
+            || { echo "::error ::revision label is '$GOT_REV', expected '$WANT_REV'"; exit 1; }
+
+          PROV="$(docker buildx imagetools inspect "$REF" --format '{{json .Provenance}}')"
+          [ -n "$PROV" ] && [ "$PROV" != "null" ] && [ "$PROV" != "{}" ] \
+            || { echo "::error ::no provenance attestation reached the registry for $REF"; exit 1; }
+
+          echo "✓ $REF carries revision $GOT_REV and a registry-readable provenance attestation"
+
+      - name: Point :dev at this build
+        if: inputs.move_dev
+        run: |
+          docker buildx imagetools create \
+            -t vexaai/dashboard:dev "vexaai/dashboard:${{ steps.id.outputs.tag }}"
+          echo "✓ :dev → ${{ steps.id.outputs.tag }}"
+
+      - name: Publish the build receipt
+        env:
+          REF: vexaai/dashboard:${{ steps.id.outputs.tag }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "$REF" --raw > dashboard-image-descriptor.json
+          {
+            echo "### vexaai/dashboard:${{ steps.id.outputs.tag }}"
+            echo ""
+            echo "- revision: \`${{ steps.id.outputs.revision }}\`"
+            echo "- digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- built by: \`${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\`"
+            echo "- provenance: SLSA mode=max, readable via \`docker buildx imagetools inspect --format '{{json .Provenance}}'\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-image-${{ steps.id.outputs.tag }}
+          path: dashboard-image-descriptor.json

--- a/docs/changelog.d/1228-dashboard-build-provenance.md
+++ b/docs/changelog.d/1228-dashboard-build-provenance.md
@@ -1,0 +1,17 @@
+### Dashboard build provenance
+
+- **The Dashboard image is now built on an attested path.** `vexaai/dashboard` was the one image in
+  the release set whose provenance could not be verified from the registry: it was hand-built on an
+  operator's host and shipped with a classic `docker push`, which cannot carry an attestation, and
+  its config carried no OCI labels at all. Provenance was recoverable only by SSH into that one
+  machine, from a garbage-collected build cache. A new `dashboard-image` workflow builds and pushes
+  it with SLSA provenance (`mode=max`) and an SBOM, stamps
+  `org.opencontainers.image.revision`/`.source`/`.created`/`.version`, and fails the run if the
+  attestation did not reach Docker Hub. `make push` gained the equivalent single-invocation buildx
+  path for manual builds, and refuses a dirty tree. The Dashboard build is owned by `Vexa-ai/vexa`;
+  it stays outside the OSS candidate map. See
+  [`services/dashboard/README.md`](https://github.com/Vexa-ai/vexa/blob/main/services/dashboard/README.md).
+- **The Dashboard image builds again.** Its Dockerfile still copied a root `VERSION` file that no
+  longer exists in the tree, so any `docker build` of it failed at that layer; the release identity
+  it feeds already falls back to the Helm chart `appVersion`. Pull requests touching
+  `services/dashboard/**` now build the image in CI, so this cannot go unnoticed again.

--- a/services/dashboard/Dockerfile
+++ b/services/dashboard/Dockerfile
@@ -21,13 +21,12 @@ COPY services/dashboard/public ./public
 COPY services/dashboard/scripts ./scripts
 COPY services/dashboard/next.config.ts services/dashboard/tsconfig.json services/dashboard/postcss.config.mjs services/dashboard/eslint.config.mjs ./
 COPY services/dashboard/components.json ./
-COPY VERSION /repo/VERSION
 COPY deploy/helm/charts/vexa/Chart.yaml /repo/deploy/helm/charts/vexa/Chart.yaml
 
 # Version disclosure (NEXT_PUBLIC_VEXA_OSS_VERSION + RELEASE_DATE).
 #
 # The generator validates any env/build-arg override against the canonical
-# VERSION and Chart.yaml copied above, then the assertion checks the compiled
+# Chart.yaml appVersion copied above, then the assertion checks the compiled
 # Next.js bundle. This prevents digest-retagged or stale-build dashboard images
 # from silently displaying an older release identity.
 ARG NEXT_PUBLIC_VEXA_OSS_VERSION
@@ -61,5 +60,28 @@ USER nextjs
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
+
+# Provenance disclosure (OCI image spec), the registry-readable half of build
+# identity. The published image answers "which commit is this?" off its own
+# config, so provenance survives without shell access to the machine that built
+# it. `latest-drift` reads image.revision back the same way.
+#
+# Fail closed: an unset revision is exactly the unidentifiable build this
+# disclosure exists to prevent, so the build stops rather than publishing one.
+ARG VEXA_IMAGE_REVISION
+ARG VEXA_IMAGE_CREATED
+ARG VEXA_IMAGE_VERSION
+ARG VEXA_IMAGE_SOURCE=https://github.com/Vexa-ai/vexa
+
+RUN [ -n "$VEXA_IMAGE_REVISION" ] || { \
+      echo "ERROR: VEXA_IMAGE_REVISION build-arg is required (git commit sha)" >&2; exit 1; }
+
+LABEL org.opencontainers.image.title="Vexa Dashboard" \
+      org.opencontainers.image.description="Vexa Dashboard web UI" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="$VEXA_IMAGE_SOURCE" \
+      org.opencontainers.image.revision="$VEXA_IMAGE_REVISION" \
+      org.opencontainers.image.created="$VEXA_IMAGE_CREATED" \
+      org.opencontainers.image.version="$VEXA_IMAGE_VERSION"
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/services/dashboard/Makefile
+++ b/services/dashboard/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build push set-latest set-dev set-staging help
+.PHONY: build push set-latest set-dev set-staging help check-clean builder verify
 
 # DockerHub configuration
 DOCKERHUB_USER ?= vexaai
@@ -9,9 +9,34 @@ IMAGE_TAG ?= $(shell date +%y%m%d-%H%M)
 LOCAL_TAG := $(DOCKERHUB_USER)/$(IMAGE_NAME):$(IMAGE_TAG)
 LAST_TAG_FILE := .last-tag
 
-# Paths (Makefile and Dockerfile are in the same directory, context is repo root)
-DOCKERFILE := $(shell pwd)/Dockerfile
-CONTEXT := $(shell pwd)
+# Paths. The Dockerfile sits beside this Makefile but its COPY paths are
+# repo-root relative (services/dashboard/…, packages/…, deploy/…), so the build
+# context is the repo root two levels up — not the directory make runs in.
+HERE := $(dir $(lastword $(MAKEFILE_LIST)))
+DOCKERFILE := $(abspath $(HERE)Dockerfile)
+CONTEXT := $(abspath $(HERE)../..)
+
+# Provenance. The published image must answer "which commit is this?" from its
+# own registry metadata, so the revision is read from git rather than typed.
+# A dirty tree cannot be described by a commit sha: the label would name a
+# source that does not match what was built, so the build refuses. Override
+# with ALLOW_DIRTY=1 for throwaway local images that are never pushed.
+GIT_REVISION ?= $(shell git -C $(CONTEXT) rev-parse HEAD)
+IMAGE_CREATED ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+IMAGE_SOURCE ?= https://github.com/Vexa-ai/vexa
+ALLOW_DIRTY ?= 0
+
+# Attestations require the docker-container driver; the default "docker" driver
+# silently drops them, which is how a build record stays on the build host and
+# never reaches the registry.
+BUILDX_BUILDER ?= vexa-attested
+PLATFORMS ?= linux/amd64
+
+PROVENANCE_ARGS := \
+	--build-arg VEXA_IMAGE_REVISION=$(GIT_REVISION) \
+	--build-arg VEXA_IMAGE_CREATED=$(IMAGE_CREATED) \
+	--build-arg VEXA_IMAGE_VERSION=$(IMAGE_TAG) \
+	--build-arg VEXA_IMAGE_SOURCE=$(IMAGE_SOURCE)
 
 # Function to set a tag on DockerHub using buildx imagetools
 define set_tag
@@ -25,24 +50,60 @@ help:
 	@echo ""
 	@echo "Usage:"
 	@echo "  make build                  - Build locally with timestamp tag"
-	@echo "  make push                   - Build, push timestamp tag, update :dev"
+	@echo "  make push                   - Build + push with SLSA provenance and SBOM, update :dev"
+	@echo "  make verify [TAG=]          - Read labels + attestations back off the registry"
 	@echo "  make set-latest [TAG=]      - Set :latest to specified tag (or last pushed)"
 	@echo "  make set-staging [TAG=]     - Set :staging to specified tag (or last pushed)"
 	@echo "  make set-dev [TAG=]         - Set :dev to specified tag (or last pushed)"
 	@echo ""
-	@echo "Current tag: $(IMAGE_TAG)"
+	@echo "Prefer CI: .github/workflows/dashboard-image.yml builds the same image"
+	@echo "with a GitHub-issued builder identity. This Makefile is the manual path."
+	@echo ""
+	@echo "Current tag: $(IMAGE_TAG)   revision: $(GIT_REVISION)"
 
-build:
-	@echo "Building $(LOCAL_TAG)..."
-	docker build -f $(DOCKERFILE) -t $(LOCAL_TAG) $(CONTEXT)
+check-clean:
+	@if [ "$(ALLOW_DIRTY)" != "1" ] && [ -n "$$(git -C $(CONTEXT) status --porcelain)" ]; then \
+		echo "ERROR: working tree is dirty — revision $(GIT_REVISION) would not describe this build."; \
+		echo "       Commit first, or pass ALLOW_DIRTY=1 for a local image you will not push."; \
+		exit 1; \
+	fi
+
+builder:
+	@docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1 || \
+		docker buildx create --name $(BUILDX_BUILDER) --driver docker-container >/dev/null
+
+build: check-clean builder
+	@echo "Building $(LOCAL_TAG) at revision $(GIT_REVISION)..."
+	docker buildx build --builder $(BUILDX_BUILDER) --load \
+		-f $(DOCKERFILE) -t $(LOCAL_TAG) $(PROVENANCE_ARGS) $(CONTEXT)
 	@echo "$(IMAGE_TAG)" > $(LAST_TAG_FILE)
 	@echo "Build complete: $(LOCAL_TAG)"
 
-push: build
-	@echo "Pushing $(LOCAL_TAG)..."
-	docker push $(LOCAL_TAG)
+# Build and push in ONE buildx invocation: the SLSA provenance and SBOM are
+# emitted as referrers alongside the manifest as it is pushed. A separate
+# `docker push` of a previously-built image cannot carry them — the attestation
+# stays in the local build record and dies with the next `buildx prune`.
+push: check-clean builder
+	@echo "Building + pushing $(LOCAL_TAG) at revision $(GIT_REVISION) with attestations..."
+	docker buildx build --builder $(BUILDX_BUILDER) --push \
+		--platform $(PLATFORMS) \
+		--provenance=mode=max --sbom=true \
+		-f $(DOCKERFILE) -t $(LOCAL_TAG) $(PROVENANCE_ARGS) $(CONTEXT)
+	@echo "$(IMAGE_TAG)" > $(LAST_TAG_FILE)
 	@echo "Push complete: $(LOCAL_TAG)"
 	$(call set_tag,dev,$(IMAGE_TAG))
+
+# Read provenance back off the registry — the check that the attestation
+# actually rode along instead of staying on this machine.
+verify:
+	@echo "Labels on $(DOCKERHUB_USER)/$(IMAGE_NAME):$(or $(TAG),$(IMAGE_TAG)):"
+	@docker buildx imagetools inspect $(DOCKERHUB_USER)/$(IMAGE_NAME):$(or $(TAG),$(IMAGE_TAG)) \
+		--format '{{json .Image}}' | grep -o '"org.opencontainers.image.[a-z]*":"[^"]*"' || \
+		echo "  (none — image carries no OCI labels)"
+	@echo "Attestations:"
+	@docker buildx imagetools inspect $(DOCKERHUB_USER)/$(IMAGE_NAME):$(or $(TAG),$(IMAGE_TAG)) \
+		--format '{{json .Provenance}}' | head -c 400 || true
+	@echo ""
 
 set-latest:
 	@TAG_TO_USE="$(TAG)"; \

--- a/services/dashboard/README.md
+++ b/services/dashboard/README.md
@@ -46,6 +46,62 @@ docker run --rm -p 3000:3000 \
 
 Then open `http://localhost:3000`. (The container listens on port 3000; the `npm run dev` server uses port 3001.)
 
+## Build and provenance
+
+**This repository (`Vexa-ai/vexa`) owns the Dashboard build.** The source lives here
+under `services/dashboard`, and the image is built here — not in `Vexa-ai/vexa-platform`,
+which holds no Dashboard source and runs no image-building CI.
+
+Dashboard is a hosted platform deployment and is deliberately **not** part of the OSS
+candidate set in `releases/*/candidate-images.json`. It carries its own tag line rather
+than an OSS release tag, and it is deprecated in favour of
+[Terminal](../../clients/terminal) for new self-hosted installations. Being outside the
+candidate map is a release-scope decision, not a provenance exemption: the image is still
+built on an attested path.
+
+### The attested path
+
+[`.github/workflows/dashboard-image.yml`](../../.github/workflows/dashboard-image.yml) is
+how `vexaai/dashboard` is published. Run it via workflow dispatch with the tag to publish.
+Each run stamps the OCI labels, emits SLSA provenance (`mode=max`) and an SBOM as registry
+referrers, and then reads them back off Docker Hub — the run fails if the provenance did
+not reach the registry.
+
+A pull request touching `services/dashboard/**` builds the image without pushing, so a
+Dockerfile that no longer assembles is caught before it reaches a release.
+
+### Manual builds
+
+`make push` in this directory is the manual equivalent, for when CI is not an option:
+
+```bash
+make push IMAGE_TAG=0.10.6.4-myslug
+```
+
+It builds and pushes in a single `docker buildx build --push --provenance=mode=max
+--sbom=true` invocation. That single invocation is the point — building first and
+`docker push`-ing afterwards leaves the attestation in the local build record, where it is
+one `docker buildx prune` from gone and reachable only by shell access to the build host.
+The target refuses to run against a dirty tree, since the revision label would then name a
+source that does not match what was built.
+
+### Verifying a published image
+
+```bash
+make verify TAG=0.10.6.4-myslug
+```
+
+Or directly, against any image in the release set:
+
+```bash
+docker buildx imagetools inspect vexaai/dashboard:<tag> --format '{{json .Provenance}}'
+docker buildx imagetools inspect vexaai/dashboard:<tag> --format '{{json .Image}}'
+```
+
+The image config carries `org.opencontainers.image.revision`, `.source`, `.created`, and
+`.version`. `revision` is the commit this image was built from; it is the field the
+`latest-drift` workflow reads to detect stale published images.
+
 ## Local Development
 
 The dashboard lives in the Vexa monorepo at `services/dashboard/`.


### PR DESCRIPTION
`vexaai/dashboard` was the one image in the release set whose provenance was not registry-verifiable. It was hand-built on an operator's host and shipped with a classic `docker push` — which cannot carry an attestation — and its config carried no OCI labels at all. The SLSA record lived in that host's local buildx cache: one `docker buildx prune` from gone, and reachable only by shell access to one machine.

## What changes

- **`services/dashboard/Dockerfile`** — stamps `org.opencontainers.image.revision` / `.source` / `.created` / `.version` from build args, so a published image answers *"which commit is this?"* from its own config. **The build refuses an unset revision**: an unidentifiable image is the defect being closed, not an acceptable default.
- **`.github/workflows/dashboard-image.yml`** (new) — the attested publish path. Emits SLSA provenance (`mode=max`) and an SBOM as registry referrers, then **reads them back off Docker Hub and fails the run if they did not arrive**. Also builds the image on any PR touching `services/dashboard/**`.
- **`services/dashboard/Makefile`** — `make push` becomes one buildx invocation that builds and pushes together, since a separate push leaves the attestation behind. It refuses a dirty tree, where the revision label would name a source that does not match what was built.
- **`services/dashboard/README.md`** — states build ownership: Dashboard's build is owned by this repository, which holds its source; `vexa-platform` has neither. It stays outside the OSS candidate map — a release-scope decision, not a provenance exemption.

Two defects surfaced while wiring this up, both fixed here:

- The Dockerfile copied a root `VERSION` file that no longer exists in the tree, so **any `docker build` of it failed at that layer**. The release identity it fed already falls back to the Helm chart `appVersion`. The new CI build on `services/dashboard/**` means a Dockerfile that cannot assemble is caught before a release depends on it.
- The Makefile's build context was its own directory, but the Dockerfile's `COPY` paths are repo-root relative.

## Base — this stacks on #1183

`services/dashboard/` **does not exist on `main`**. It is introduced by draft PR #1183 (`codex/prod-dashboard-source-accounting`), so this PR is based on that branch rather than `main`. It cannot merge before #1183 does.

## What was NOT verified locally

**The full image build and the attestation push were not exercised on this machine.** Docker Hub returned HTTP 429 (rate limit) during the attempt, so neither the end-to-end buildx build nor the read-back-the-referrers step ran locally. **CI closes this** — `dashboard-image.yml` performs exactly that build and fails if the attestation and SBOM did not land on the registry. Treat the workflow's first green run as the verification, not this description.

**Correction — 0.12.24 formation reviews, 2026-08-21.** Three findings, each verified against the
diff. Recorded here so none of them can enter a release receipt unchallenged.

- **"Attested" is the wrong word.** What ships is BuildKit's **unsigned SLSA provenance referrer**
  (`provenance: mode=max`, `sbom: true`), not a signed attestation. This repository's actual
  attestation mechanism is `actions/attest-build-provenance@v2`
  (`.github/workflows/release-attest.yml:23`) with `id-token: write` + `attestations: write`; this
  workflow **uses neither and grants neither**. Anyone able to push to `vexaai/dashboard` can push an
  image with fabricated provenance and fabricated labels. Correct wording is **"registry-readable
  build metadata"**. It is build identity, not a trust anchor.
- **Nothing verifies it, at consume or deploy time.** There is no `cosign verify` and no
  `gh attestation verify` against any image anywhere in the tree. The only reader is
  `.github/workflows/latest-drift.yml`, which reads the forgeable
  `org.opencontainers.image.revision` **label**, and only for `vexaai/vexa-lite:latest`.
- **"The Dashboard image builds again" is not true yet, and the workflow has never built.** Both the
  workflow (`context: .`) and `services/dashboard/Makefile` (`CONTEXT := $(abspath $(HERE)../..)`)
  build from the repository root, so the **root** `.dockerignore` applies — and it excludes
  `**/dist/` (line 9). `services/dashboard/Dockerfile:8` copies
  `packages/transcript-rendering/dist/`, which that pattern removes from the build context, so the
  `COPY` cannot resolve. The changelog fragment's "builds again" claim needs the exclusion fixed
  first.

**Scheduling note.** This PR targets `codex/prod-dashboard-source-accounting`, whose own pull request
(https://github.com/Vexa-ai/vexa/pull/1183, hosted Dashboard source into OSS main) is **open and
draft**. Every file this PR touches is absent from `main`, so it cannot be retargeted there and
cannot ship until #1183 does.

## Deliberately not touched

**`.github/workflows/release-images.yml` is untouched.** It is a hot shared file feeding a frozen release packet; editing it here would put an unrelated change into a candidate that is already bound. The dashboard image gets its own workflow instead.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

<!-- vexa-agent -->
