### PR TITLE
fix(release): re-pin the v0.12.23 stable-promotion map identity to the rc.21 freeze

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -1001,7 +1001,7 @@ jobs:
               EXPECTED_MAP_SHA256=80fe23246f94557279b4da2792119489f7c60f8e452b83de2c1c33ef48ebd03f
               ;;
             v0.12.23)
-              EXPECTED_MAP_SHA256=76df3a63fd9b96aa2803bdfb51afbfd28da986feb72800433ca7ed72ff9ccb24
+              EXPECTED_MAP_SHA256=c5a310465b9005573c9fef79534e34a7822447d6c7004f24271ed59df61fe2a6
               ;;
             *)
               echo "::error ::$VERSION has no reviewed stable-promotion map identity"


### PR DESCRIPTION
The `:v012` promotion arm of `release-validate.yml` pins `EXPECTED_MAP_SHA256=76df3a63…`, a hash of an earlier `releases/v0.12.23/candidate-images.json` freeze. The map was re-frozen through the rc cycles and only the validate arm (line 253) was re-pinned; the shipped map at tag `v0.12.23` hashes `c5a31046…`. Both arms hash the same file and must agree — v0.12.18 pins one value in both. Without this, the stable-promotion dispatch for v0.12.23 refuses against the exact map it shipped.

One line: `76df3a63…` → `c5a31046…` in the promotion arm.

<!-- vexa-agent -->

## Contribution rights

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.