### PR TITLE
docs: front door leads with the wedge — meeting bots + real-time transcription

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -1,22 +1,20 @@
 ---
 title: "Vexa"
 sidebarTitle: "Overview"
-description: "Sandboxed AI agents that grow corporate knowledge from your meetings and docs — open-source, self-hosted, air-gappable."
+description: "Open-source meeting bots & real-time transcription API — Apache-2.0, cloud or self-hosted, air-gappable."
 ---
 
 <div style={{ fontSize: "2rem", fontWeight: 600, lineHeight: 1.25, margin: "0.5rem 0 1.5rem" }}>
-  Sandboxed agents that grow corporate knowledge from your meetings and docs.
+  Open-source meeting bots and real-time transcription — cloud or fully self-hosted.
 </div>
 
-Real-time transcripts from Google Meet, Zoom, Teams, and Jitsi (Whisper included), fed to agents that build knowledge as code — fully self-hosted.
+A bot joins Google Meet, Zoom, Teams or Jitsi; you get the transcript live over the API. Apache-2.0 all the way down.
 
 <Note>
-  **These docs cover Vexa 0.12.** Hosted [vexa.ai](https://vexa.ai) runs the 0.12 meeting and transcription experience. Sandboxed knowledge agents are currently self-hosted only — [self-host Vexa](#try-it) to run the full meetings → agents stack.
+  **These docs cover Vexa 0.12.** Hosted [vexa.ai](https://vexa.ai) runs the 0.12 meeting and transcription experience. The agent plane is currently self-hosted only — [self-host Vexa](#try-it) to run the full stack.
 </Note>
 
-Vexa tightens the loop every organization runs on: **sense → think → act**. Meetings and docs are
-the data; agents turn data into signal, and signal into action that changes the world. The faster that
-loop turns, the smarter the org gets.
+When transcripts alone stop being enough, the same stack grows into meeting intelligence — we build it with the teams who run it.
 
 ## Why
 


### PR DESCRIPTION
**Delivers issue:** — (positioning correction, founder-directed 2026-08-20)

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## What

The docs front door (`/`) leads with what Vexa ships today — meeting bots + real-time transcription, cloud or self-hosted — instead of the agent-plane framing.

`/` is the most-read page on docs.vexa.ai (1,496 clean reads in the last 12 days, ~22% of them AI answer-agents that relay the first sentence verbatim). The previous hero described the knowledge-agent layer; the hero now matches the README, vexa.ai and llms.txt, which all lead with the bot + transcription API.

## Observation bundle (the record of your harnessed loop)

- **C1 —** ran: clean-read count over 12 days of edge observations for `/` · saw: 1,469 reads of `/` + 27 of `/index`, 325 `answer`-class agents · concluded: the hero is the single most-relayed sentence we serve, and it contradicted the README/vexa.ai/llms.txt positioning.
- **C2 —** ran: `grep -rn "Sandboxed agents"` across docs tree, README, llms.txt, vexa.ai · saw: only `index.mdx` leads with the agent-plane framing · concluded: one-page fix restores coherence.

## Acceptance floor

- Hero, description, second line, and the sense→think→act paragraph replaced per founder-approved text (2026-08-20, verbatim).
- Version Note reworded ("Sandboxed knowledge agents" → "The agent plane") — same fact.
- No sections removed, no anchors changed, agent-plane docs untouched.

<!-- vexa-agent -->
