### PR TITLE
docs: send-a-bot and quickstart open with the hosted on-ramp

### DIFF
--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -1,10 +1,54 @@
 ---
 title: "Send a bot and get a transcript"
-description: "Capture a Google Meet, Zoom, Teams, or Jitsi call in real time."
+description: "Send a bot to a Google Meet, Zoom, Teams, or Jitsi call and get a real-time transcript — hosted in one API call, or self-hosted under Apache-2.0."
 ---
 
 A Vexa bot joins a call like any participant and streams back a **speaker-attributed** transcript. No
 plugin, no host configuration.
+
+## Get an API key
+
+There are two ways to run Vexa. Both speak the same API; only the base URL differs.
+
+### Hosted
+
+1. Sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google account.
+2. Copy your API key from [your account page](https://vexa.ai/account).
+3. Send a bot:
+
+```bash
+curl -X POST "https://api.cloud.vexa.ai/bots" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"platform":"google_meet","native_meeting_id":"abc-defg-hij","bot_name":"Vexa"}'
+```
+
+`native_meeting_id` is the id inside the join URL — `abc-defg-hij` in
+`https://meet.google.com/abc-defg-hij`.
+
+New accounts get **$5 of free bot credit and no credit card is required** — about 16 hours of bot
+time at $0.30/hr ([pricing](https://vexa.ai/pricing)).
+
+### Self-hosted
+
+Vexa is Apache-2.0 and runs entirely inside your own perimeter. `make all` pulls the published
+images and prints an API key when the stack is up:
+
+```bash
+git clone https://github.com/Vexa-ai/vexa.git && cd vexa
+make all
+```
+
+Full walkthrough: [Quickstart](/quickstart). Base URLs, scopes, and key rotation:
+[Authentication](/authentication).
+
+### Set your base URL
+
+The rest of this page uses `$API_BASE` and `$API_KEY`:
+
+| Deployment | `API_BASE` |
+|---|---|
+| Hosted | `https://api.cloud.vexa.ai` |
+| Self-hosted (`make all` / compose) | `http://localhost:18056` |
 
 ## 1. Send the bot
 

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -49,7 +49,8 @@ most coding agents).
 
 ## Docs
 
-- [Quickstart](https://docs.vexa.ai/quickstart.md): clone → running stack → bot in a meeting
+- [Quickstart](https://docs.vexa.ai/quickstart.md): hosted (sign in → API key → one call) or self-host (clone → running stack → bot in a meeting)
+- [Send a bot](https://docs.vexa.ai/how-to/send-a-bot.md): get a key (hosted or self-hosted), send the bot, read the transcript
 - [Authentication](https://docs.vexa.ai/authentication.md): API keys and scopes
 - [Meetings API](https://docs.vexa.ai/api/meetings.md): plan meetings, send bots, real-time transcripts, recordings
 - [Agent API](https://docs.vexa.ai/api/agent.md): dispatch units, chat turns, routines, workspace

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -1,6 +1,26 @@
 ---
 title: "Quickstart"
-description: "From zero to your first transcript and your first agent — in about five minutes."
+description: "From zero to your first transcript and your first agent — hosted in one API call, or self-hosted in about five minutes."
+---
+
+## Just want a bot in a meeting?
+
+Use the hosted service — no install. Sign in at [vexa.ai/signin](https://vexa.ai/signin) with a
+Google account, copy your API key from [your account page](https://vexa.ai/account), and send a bot:
+
+```bash
+curl -X POST "https://api.cloud.vexa.ai/bots" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"platform":"google_meet","native_meeting_id":"abc-defg-hij","bot_name":"Vexa"}'
+```
+
+`native_meeting_id` is the id inside the join URL — `abc-defg-hij` in
+`https://meet.google.com/abc-defg-hij`. New accounts get **$5 of free bot credit and no credit card
+is required** — about 16 hours of bot time at $0.30/hr ([pricing](https://vexa.ai/pricing)). More
+calls: [Send a bot](/how-to/send-a-bot).
+
+The rest of this page self-hosts the whole stack, which is how you get the agent plane as well.
+
 ---
 
 This walkthrough takes you from a clean machine to **two first wins**: a bot capturing a live


### PR DESCRIPTION
**Delivers issue:** — (grow card 2, founder-approved 2026-08-20)

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

## What

`/how-to/send-a-bot` (431 clean reads/12d, 49% AI answer-agents) and `/quickstart` (352, 47%) both led self-host-first; an agent asked "how do I get a bot into my meeting" relayed "clone the repo". Both now open with the hosted path ($5 free credit, no card, one curl) and keep the full self-host path unchanged below. `llms.txt`'s "clone → running stack" line reworded; `/how-to/send-a-bot` added to its index (it was absent despite being the most-fetched page).

## Observation bundle

- **C1 —** ran: clean-read counts per page over 12d edge observations · saw: send-a-bot 431 (49% agent, all ChatGPT-class), quickstart 352 (47%) · concluded: the most-relayed how-to answered a hosted question with a self-host instruction.
- **C2 —** ran: live probe of api.cloud.vexa.ai + grep of bot_spawn router · saw: 401 on missing key; router parses exactly platform/native_meeting_id/meeting_url/bot_name · concluded: the curl in the page is the real contract.

## Acceptance floor

- $5 credit / no card / $0.30/hr: verbatim from vexa.ai/pricing FAQ (mirrored on the homepage FAQ).
- Hosted base URL: authentication.mdx:19, api/meetings.mdx:14, live 401 probe.
- No heading renamed; every existing anchor resolves; self-host content unchanged.

<!-- vexa-agent -->

