### PR TITLE
docs: Settings API reference — the account-scoped config surface agents keep asking for

### DIFF
--- a/docs/docs/api/README.md
+++ b/docs/docs/api/README.md
@@ -1,4 +1,6 @@
 # api — OpenAPI surfaces (Mintlify pages)
 
 Consumer-facing API references: `agent.mdx` (the agent-api control plane — invocations, chat SSE,
-sessions, routines) and `meetings.mdx` (the meetings/bot control plane).
+sessions, routines), `meetings.mdx` (the meetings/bot control plane), `calendar.mdx` (ICS
+connections and sync), and `settings.mdx` (identity plus the per-account settings blob — model,
+transcription, and webhook configuration).

--- a/docs/docs/api/settings.mdx
+++ b/docs/docs/api/settings.mdx
@@ -1,0 +1,278 @@
+---
+title: "Settings API"
+description: "Read your identity and limits, and configure the per-account settings Vexa stores: model credentials, transcription backend, and webhook delivery."
+---
+
+Vexa's settings are **per API-key owner** — there is one settings blob per account, and the server
+derives whose it is from your key. There is no organization or workspace settings tier.
+
+All requests use the same API-key authentication as the rest of Vexa:
+
+```bash
+-H "X-API-Key: $API_KEY"
+```
+
+Every route on this page accepts a key holding either the `bot` or the `tx` scope. See
+[Authentication](/authentication) for minting and scoping keys.
+
+## Where each setting lives
+
+| You want to change | Where |
+|---|---|
+| Model provider, model names, credentials | [Model configuration](#model-configuration), below |
+| Transcription backend URL and token | [Transcription backend](#transcription-backend), below |
+| Webhook URL, secret, event filter | [Webhook configuration](#webhook-configuration), below |
+| Calendar connections and auto-join | [Calendar API](/api/calendar) |
+| API keys — mint, scope, revoke | [Authentication](/authentication) |
+| A single bot's language, task, or name | per request on [`POST /bots`](/api/meetings#send-a-bot-to-a-meeting) |
+| Ports, storage, STT engine, rate limits | environment variables — [Configuration](/configuration) |
+
+Settings written here are **account-level overrides of the deployment's defaults**, resolved
+field by field: a field you set wins; a field you leave unset falls through to the deployment
+configuration. Clearing a field returns it to the deployment default.
+
+## Identity
+
+```bash GET /auth/me
+curl "$API_BASE/auth/me" -H "X-API-Key: $API_KEY"
+```
+
+```json Response — 200
+{
+  "user_id": 1,
+  "email": "jane@acme.com",
+  "scopes": ["bot", "tx"],
+  "max_concurrent": 3
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `user_id` | The account this key resolves to. |
+| `email` | The account's email address. |
+| `scopes` | The scopes carried by *this key*, not by the account. |
+| `max_concurrent` | How many bots this account may run at once. Changing it is an [admin operation](#account-limits-admin-tier). |
+
+This is the cheapest way to check that a key is live and which scopes it holds. A key with only the
+`browser` scope can call this route and nothing else.
+
+## Model configuration
+
+The account's LLM settings, used by the [agent control plane](/api/agent) and meeting-time
+summarization.
+
+```bash GET /user/models
+curl "$API_BASE/user/models" -H "X-API-Key: $API_KEY"
+```
+
+```json Response — 200
+{
+  "mode": "custom",
+  "model": "gpt-4o",
+  "meeting_model": "gpt-4o-mini",
+  "base_url": "https://api.example.com/v1",
+  "api_key_set": true,
+  "api_key": "********1f4c"
+}
+```
+
+The stored credential never leaves in the clear: `api_key` is masked to its last four characters,
+enough to recognize which credential is set, and `api_key_set` states whether one exists at all.
+An unset field reads as `null`.
+
+```bash PUT /user/models
+curl -X PUT "$API_BASE/user/models" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"mode":"custom","base_url":"https://api.example.com/v1","api_key":"sk-…"}'
+```
+
+Returns the same masked shape as the read, with **200 OK**.
+
+<ParamField body="mode" type="string">
+  `subscription` or `custom` — which credential terms this account operates under. Any other value
+  returns **422**. See [Model credentials & licensing](/model-credentials-licensing).
+</ParamField>
+<ParamField body="model" type="string">
+  Model name for general agent work.
+</ParamField>
+<ParamField body="meeting_model" type="string">
+  Model name for meeting-time work, when it should differ from `model`.
+</ParamField>
+<ParamField body="base_url" type="string">
+  OpenAI-compatible endpoint. Must be an `http` or `https` URL with a hostname, or the request
+  returns **422**.
+</ParamField>
+<ParamField body="api_key" type="string">
+  Credential for that endpoint. Stored, never echoed in the clear.
+</ParamField>
+
+The update is **partial**: only the fields present in the body change. Sending a field as an empty
+string clears it, and a cleared field falls back to the deployment default. Clearing every field
+removes the account override entirely. String fields longer than 2,048 characters return **422**.
+
+## Transcription backend
+
+The account's override of the deployment's speech-to-text endpoint. Leave it unset to use whatever
+the deployment configures — see [Bring your own STT](/how-to/custom-stt).
+
+```bash GET /user/transcription
+curl "$API_BASE/user/transcription" -H "X-API-Key: $API_KEY"
+```
+
+```json Response — 200
+{
+  "url": "https://stt.example.com",
+  "token_set": true,
+  "token": "********9a2b"
+}
+```
+
+```bash PUT /user/transcription
+curl -X PUT "$API_BASE/user/transcription" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"url":"https://stt.example.com","token":"…"}'
+```
+
+<ParamField body="url" type="string">
+  Transcription endpoint. Must be an `http` or `https` URL with a hostname.
+</ParamField>
+<ParamField body="token" type="string">
+  Credential for that endpoint. Masked on every read-back, exactly like the model credential.
+</ParamField>
+
+Same partial-update and clearing rules as [model configuration](#model-configuration).
+
+## Webhook configuration
+
+<Warning>
+Webhook **delivery** has never been proven against a real external receiver — see
+[Webhooks](/webhooks) for what is and is not established. The configuration endpoints below are
+the settings surface for it; they store what you send.
+</Warning>
+
+```bash GET /user/webhook
+curl "$API_BASE/user/webhook" -H "X-API-Key: $API_KEY"
+```
+
+```json Response — 200
+{
+  "webhook_url": "https://hooks.example.com/vexa",
+  "webhook_secret_set": true,
+  "webhook_secret": "********c3d1",
+  "webhook_events": {"meeting.completed": true}
+}
+```
+
+```bash PUT /user/webhook
+curl -X PUT "$API_BASE/user/webhook" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{
+    "webhook_url": "https://hooks.example.com/vexa",
+    "webhook_secret": "a-long-random-string",
+    "webhook_events": {"meeting.completed": true}
+  }'
+```
+
+<ParamField body="webhook_url" type="string" required>
+  Where Vexa POSTs events. Required on every write — this endpoint replaces the URL, it does not
+  patch it.
+</ParamField>
+<ParamField body="webhook_secret" type="string">
+  HMAC signing secret. Written only when non-empty: sending `""` leaves the stored secret in place
+  rather than clearing it.
+</ParamField>
+<ParamField body="webhook_events" type="object">
+  A `{event_type: boolean}` filter. When you have never set one, **only `meeting.completed`
+  fires**. An explicit `false` suppresses an event; an event you do not mention falls back to that
+  default.
+</ParamField>
+
+The write returns the account record with **200 OK**; the stored secret is omitted from it. Read it
+back with `GET /user/webhook`, where it appears masked.
+
+### Delivery history
+
+```bash GET /user/webhook/deliveries
+curl "$API_BASE/user/webhook/deliveries?limit=50" -H "X-API-Key: $API_KEY"
+```
+
+```json Response — 200
+{
+  "deliveries": [
+    {
+      "event_type": "meeting.completed",
+      "event_id": "e2f1…",
+      "target_host": "hooks.example.com",
+      "outcome": "delivered",
+      "status_code": 200,
+      "attempt": 0,
+      "meeting_id": 812,
+      "created_at": "2026-08-14T15:30:00Z"
+    }
+  ]
+}
+```
+
+Newest first. `limit` accepts 1–500 and defaults to 100; a value outside that range returns **422**.
+Vexa retains the most recent 100 attempts per account — this is a recent-history window, not an
+audit log.
+
+A row carries the target **host only**, never the configured URL or the secret: a webhook URL can
+carry a token in its path or query.
+
+| `outcome` | Meaning |
+|---|---|
+| `delivered` | The receiver accepted it. |
+| `queued` | The attempt failed retryably and is queued for another sweep. |
+| `suppressed` | Your event filter is not subscribed to this event type. |
+| `blocked` | The target was refused before any request left Vexa. |
+| `failed` | The attempt failed and was not queued. |
+
+An empty `deliveries` array means no attempt has been recorded for this account — including when
+the feature has never fired at all.
+
+## Account limits (admin tier)
+
+Concurrency is an account limit, not a self-serve setting: it is changed with the **admin** key on
+the admin API, not with your `X-API-Key`.
+
+```bash PATCH /admin/users/{user_id}
+curl -X PATCH "$ADMIN/admin/users/1" \
+  -H "X-Admin-API-Key: $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d '{"max_concurrent_bots": 5}'
+```
+
+Returns the updated account with **200 OK**; an unknown id returns **404**. A body that changes
+nothing returns **422** — the patch requires at least one field. Unrecognized fields are refused
+rather than dropped.
+
+The same patch also accepts a `data` object of platform-billing fields, which the hosted
+deployment's billing integration writes. A self-hosted deployment does not need it.
+
+Creating accounts and minting keys are covered in [Authentication](/authentication).
+
+## What is not configurable through the API
+
+These have no settings endpoint today. They are listed so you can stop looking for one.
+
+| Not available | What exists instead |
+|---|---|
+| Organization or team settings | Settings are per API-key owner only. |
+| Self-serve key management with your `X-API-Key` | Minting and revoking keys requires the admin key ([Authentication](/authentication)). |
+| A default language, task, or bot name for all bots | Set per request on `POST /bots`; calendar connections carry their own `bot_name` ([Calendar API](/api/calendar)). |
+| Notification or email preferences | No such setting is stored. |
+| Reading your own plan, quota usage, or billing state | `GET /auth/me` returns `max_concurrent` only. |
+| Retention or data-deletion policy | Delete individual meetings via the [Meetings API](/api/meetings). |
+
+## Error summary
+
+| Status | Operations | Meaning |
+|---|---|---|
+| `200` | all reads and writes on this page | Request completed. |
+| `401` | all | API key missing, unknown, or revoked. |
+| `403` | all | The key does not carry a scope this route accepts. |
+| `404` | admin patch | No account with that id. |
+| `422` | model, transcription, webhook writes, admin patch | Invalid `mode`, a non-`http(s)` URL, a string over 2,048 characters, an out-of-range `limit`, or an unrecognized field. |
+| `503` | all | Identity resolution is unavailable — the key was not rejected, it could not be checked. |
+
+See the full [error reference](/api/errors).

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -88,6 +88,7 @@
         "pages": [
           "api/meetings",
           "api/calendar",
+          "api/settings",
           "api/agent",
           "api/errors"
         ]
@@ -149,6 +150,10 @@
     {
       "source": "/websocket",
       "destination": "/how-to/stream-transcript"
+    },
+    {
+      "source": "/settings",
+      "destination": "/api/settings"
     },
     {
       "source": "/self-hosted-management",


### PR DESCRIPTION
**Delivers issue:** — (grow card 3, founder-approved 2026-08-20)

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

# [DOCS] Settings API reference — the account-configuration surface that had no page

Adds `docs/docs/api/settings.mdx`, a nav entry under **API reference**, and a `/settings → /api/settings` redirect.

## Why

`/api/settings`, `/settings` and `/api/settings.md` together took **134 requests over 11 days** on
docs.vexa.ai for a page that does not exist — the single most concentrated documented miss on the
docs surface. A share of those are agents requesting `/api/settings.md` **by name**, i.e. integrators'
tooling assumes a settings API reference exists at that path and is fetching it as a machine-readable
source. Every one of those 134 got a miss.

The endpoints have existed for releases. Only their *reference page* was missing: `/user/models` and
`/user/transcription` appear in the docs exactly once each, as row entries in the scope table on
`/authentication`, with no shape, no fields, and no example.

## What the page documents, and the evidence for each endpoint

Every endpoint below exists in the tree at `origin/main` (`beb24f32`). Paths rot, so they are here
and not on the page.

| Endpoint | Defined at | Gateway route |
|---|---|---|
| `GET /auth/me` | `core/gateway/services/gateway/src/gateway/app.py:307` | same (terminates at the gateway) |
| `GET /user/models` | `core/identity/services/admin-api/src/admin_api/app/main.py:693` | `app.py:748` |
| `PUT /user/models` | `admin_api/app/main.py:684` | `app.py:744` |
| `GET /user/transcription` | `admin_api/app/main.py:714` | `app.py:756` |
| `PUT /user/transcription` | `admin_api/app/main.py:706` | `app.py:752` |
| `GET /user/webhook` | `admin_api/app/main.py:513` | `app.py:671` |
| `PUT /user/webhook` | `admin_api/app/main.py:495` | `app.py:666` |
| `GET /user/webhook/deliveries` | `core/meetings/services/meeting-api/src/meeting_api/app.py:310` | `app.py:680` (forwards to meeting-api `/webhooks/deliveries`) |
| `PATCH /admin/users/{user_id}` | `admin_api/app/main.py:407` | admin tier — not gateway-fronted |

Supporting behaviour, also read from source rather than assumed:

- **Scopes.** Every `/user/*` route on the page is `BOT_OR_TX` in the gateway's route→scope table,
  `gateway/app.py:141-147`. `/auth/me` has no entry and needs only a resolvable key — which is why
  the page repeats `/authentication`'s claim that a `browser`-only key can call it and nothing else.
- **Partial update, empty-string clears, 2,048-char cap, `mode ∈ {subscription, custom}`,
  `http(s)`-only URLs.** `_validate_config_fields` / `_apply_config_update` / `MODEL_MODES`,
  `admin_api/app/main.py:234, 274-308`; applied by `_put_user_prefs` at `main.py:670`.
- **Secret masking (`********` + last 4).** `_mask_secret`, `admin_api/app/main.py:266`; the webhook
  read-back masks inline at `main.py:513-527`; `UserResponse` drops `webhook_secret` entirely via its
  `field_serializer`, `main.py:145`.
- **`webhook_secret: ""` does not clear the stored secret.** `if webhook_update.webhook_secret:` —
  `admin_api/app/main.py:502`. The page states this rather than implying a symmetric clear.
- **Only `meeting.completed` fires without an explicit filter.** `_DEFAULT_ENABLED`,
  `meeting_api/webhooks/delivery.py:32`; filter logic `is_event_enabled`, `delivery.py:116-128`.
- **Delivery-row fields, host-only redaction, 100-per-account cap, `limit` 1–500.**
  `meeting_api/webhooks/ledger.py:36-64` (`_ALLOWED_FIELDS`, `build_delivery_record`,
  `DEFAULT_MAX_PER_USER`); `limit` bounds at `meeting_api/app.py:313`.
- **Outcome taxonomy `delivered | queued | suppressed | blocked | failed`.** `DeliveryResult.status`,
  `meeting_api/webhooks/delivery.py:135`.
- **Admin patch semantics** (at-least-one-field → 422, `extra: forbid`, 404 on unknown id).
  `UserAdminPatch`, `admin_api/app/main.py:124-136`; handler `main.py:407-427`.
- **503, not 401, when identity resolution is down.** `AuthUnavailable` → `_auth_unavailable_response`,
  `gateway/app.py:315`.

## Scope decisions

**The page is titled "Settings API" and it earns that.** The first thing checked was whether a page
by that name would be a capability claim the code cannot back — the failure mode being a documented
surface that turns out to be aspirational. It is not: there is a real per-account settings blob
(`users.data`) with self-serve read/write endpoints for models, transcription and webhooks, plus an
identity read. Nine operations, all live.

What it deliberately does **not** do:

- **No duplication.** Calendar settings already have `/api/calendar`; key minting already has
  `/authentication`; per-bot config already has `/api/meetings`. The page opens with a
  "where each setting lives" table routing to them instead of restating them.
- **Webhook delivery carries its warning forward.** `/webhooks` states that delivery has never fired
  against a real external receiver. The settings page repeats that warning inline and links it, so
  documenting the *configuration* endpoints cannot be read as a claim that delivery is proven.
- **No billing field enumeration.** `PATCH /admin/users/{id}` accepts a `PlatformBillingDataPatch`
  (`main.py:97`) full of Stripe-shaped fields. The page says the patch accepts platform-billing
  fields written by the hosted billing integration, and stops there.
- **Internal routes stay internal.** `GET`/`PUT /internal/settings/{key}` (`main.py:980, 988`) is a
  real platform-settings surface, but it is `include_in_schema=False`, sits behind
  `X-Internal-Secret`, and is not gateway-fronted. Not documented.
- **Frontmatter matches its neighbours** (`title` + `description` only). No page under `docs/docs/`
  carries `created`/`updated` keys; adding them here would be the only instance in the tree.

## What the 134 requests wanted that we do not have → product intake

The page ends with an explicit "what is not configurable through the API" table. That table is the
honest half of this change and each row is a candidate intake item, not a doc gap:

1. **No organization / team / workspace settings tier.** Settings are per API-key owner, full stop.
   For a buyer evaluating multi-seat use this is the likeliest reason they went looking for
   `/api/settings` in the first place.
2. **No self-serve key management at the user tier.** Minting and revoking a key requires the
   *admin* key (`verify_admin_token` on every `/admin/*` route). An integrator holding only their own
   `X-API-Key` cannot rotate it. This is the sharpest gap between what a "settings API" normally means
   and what exists.
3. **No account-level bot defaults** — default language, task, or bot name for all bots. Language and
   task are per `POST /bots`; `bot_name` exists only per calendar connection.
4. **No self-serve read of plan, quota usage, or billing state.** `GET /auth/me` returns
   `max_concurrent` and nothing else; every billing field is admin-write-only.
5. **No notification or retention preferences.** No such setting is stored anywhere in `users.data`.

Filing 1 and 2 is the recommended follow-up; they are the two a reader is most likely to have come
for.

## Demand data

| Path | Requests, 11 days |
|---|---|
| `/api/settings` + `/settings` + `/api/settings.md` | **134** |

`/api/settings.md` being requested by name is the notable signal: that is agent tooling fetching a
markdown source, not a human browsing. Publishing at `/api/settings` makes both the human path and
the `.md` fetch resolve, and `/settings` now redirects there.

## Files

- `docs/docs/api/settings.mdx` — new
- `docs/docs/docs.json` — nav entry under "API reference", after `api/calendar`; `/settings` redirect
- `docs/docs/api/README.md` — index line updated (it had also never been updated for `calendar.mdx`)

<!-- vexa-agent -->

