### PR TITLE
[DOCS] Correct three over-claims: video recording, Jitsi status, speaker attribution

### DIFF
--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -29,9 +29,15 @@ Pass one of these as `platform`:
 | Google Meet | `google_meet` |
 | Zoom | `zoom` |
 | Microsoft Teams | `teams` |
-| Jitsi Meet | `jitsi` |
+| Jitsi Meet | `jitsi` * |
 
 The bot joins like any participant — no plugins, no host configuration.
+
+\* **Jitsi is join + capture offline-proven; live validation is pending.** Meet, Zoom and Teams are
+production. On Jitsi the bot joins and records audio, but transcripts are not yet proven live —
+[#883](https://github.com/Vexa-ai/vexa/issues/883) reports a witness run on self-hosted
+docker-jitsi-meet where the speaker binder matched **0 of 122** frames and the meeting completed
+with 0 transcript segments. Track [#570](https://github.com/Vexa-ai/vexa/issues/570).
 
 For `jitsi`, the full `meeting_url` is **required** (like Zoom): a Jitsi room name is scoped
 to a deployment — `MyRoom` exists on meet.jit.si *and* on every self-hosted instance — so only
@@ -170,7 +176,7 @@ guessing. Undetermined windows yield `language: null`. (0.10's `allowed_language
 the 0.12 API.)</ParamField>
 <ParamField body="task" type="string">`transcribe` (default) or `translate`.</ParamField>
 <ParamField body="transcribe_enabled" type="boolean">Whether this spawn should request transcription. **Resolution:** an explicit value wins; else the deployment env `TRANSCRIBE_ENABLED`; else `true`. Non-boolean values (other than the common string forms `true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`) are refused with `422` (`transcribe_enabled must be a boolean`). When the resolved value is `true` and no STT backend is configured, `POST /bots` answers **503** with a detail naming the unset keys, e.g. `no transcription backend configured — set it in Settings or environment variables TRANSCRIPTION_SERVICE_URL + TRANSCRIPTION_SERVICE_TOKEN`. Set `false` for **capture-only** (bot may still join; no STT client is constructed).</ParamField>
-<ParamField body="recording_enabled" type="boolean">Whether this spawn should persist an audio/video recording. Same resolution pattern as `transcribe_enabled` against env `RECORDING_ENABLED` (default `true` at the env resolver; the service default when callers omit it follows the request/env chain). Capture-only (`transcribe_enabled=false`) is **not** the same as recorded — recording is gated separately.</ParamField>
+<ParamField body="recording_enabled" type="boolean">Whether this spawn should persist an **audio** recording (see [Recordings](/how-to/recordings) — there is no video recording path). Same resolution pattern as `transcribe_enabled` against env `RECORDING_ENABLED` (default `true` at the env resolver; the service default when callers omit it follows the request/env chain). Capture-only (`transcribe_enabled=false`) is **not** the same as recorded — recording is gated separately.</ParamField>
 
 ```bash POST /bots
 curl -X POST "$API_BASE/bots" \
@@ -296,8 +302,12 @@ them consume a history page.
 
 ## Speaker-attributed transcripts
 
-Each segment is **diarized** — attributed to a speaker (a bound display name, or a provisional label
-until it binds) — with **word-level timestamps** (`words[]`) and a `confidence`. Speaker attribution is
+Each segment carries **word-level timestamps** (`words[]`) and a `confidence`, and most segments are
+**diarized** — attributed to a bound speaker display name. **Attribution is not guaranteed:** when the
+binder cannot resolve a turn it publishes the segment with an **empty speaker** rather than guessing, so
+your client must handle unattributed segments. Under heavy crosstalk roughly **4–7% of rows publish
+unnamed** ([v0.12.22 release notes](https://github.com/Vexa-ai/vexa/releases/tag/v0.12.22)).
+Speaker attribution is
 text-level (who said what), via speaker binding / clustering / captions — *not* separate audio tracks.
 Times are seconds from session start; `absolute_start_time` / `absolute_end_time` give wall-clock.
 

--- a/docs/docs/core/meetings.mdx
+++ b/docs/docs/core/meetings.mdx
@@ -84,7 +84,9 @@ guarantees:
 ### Capture
 
 The bot joins natively, in real time, with no plugins or host configuration — it attends like any
-participant, on [**Google Meet**, **Zoom**, **Microsoft Teams**, and **Jitsi Meet**](/api/meetings#platforms).
+participant, on [**Google Meet**, **Zoom**, and **Microsoft Teams**](/api/meetings#platforms) in
+production, plus [**Jitsi Meet**](/api/meetings#platforms) — join + capture offline-proven, live
+validation pending ([#883](https://github.com/Vexa-ai/vexa/issues/883)).
 Mechanically it is a **browser [container](/concepts#container) spawned by the
 [runtime](/core/runtime)** — the same runtime an agent runs in. The speaker-attributed (diarized)
 transcript streams live over the [API](/api/meetings) and WebSocket.

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -80,6 +80,9 @@ The only thing that changes between platforms is the `platform` value.
     ```
   </Tab>
   <Tab title="Jitsi Meet">
+    Jitsi is **join + capture offline-proven; live validation pending** — Meet, Zoom and Teams are
+    production. See [#883](https://github.com/Vexa-ai/vexa/issues/883).
+
     ```bash
     # the room name is the id; meeting_url is REQUIRED — a room name is scoped to a
     # deployment (meet.jit.si or your self-hosted instance), so the URL says which one
@@ -131,7 +134,7 @@ curl -X POST "$API_BASE/bots" \
 
 Or set `TRANSCRIBE_ENABLED=false` in the deployment env so every spawn defaults to capture-only.
 Recording is separate: pass `recording_enabled` / `RECORDING_ENABLED` if you also need persisted
-audio. See [Configuration](/configuration#transcription-stt).
+audio — audio only; there is no video recording path. See [Configuration](/configuration#transcription-stt).
 
 On Meet and Teams the bot may wait in the lobby until a host admits it; a Jitsi room with the
 lobby enabled behaves the same way.

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -8,7 +8,7 @@ description: "Open-source meeting bots & real-time transcription API — Apache-
   Open-source meeting bots and real-time transcription — cloud or fully self-hosted.
 </div>
 
-A bot joins Google Meet, Zoom, Teams or Jitsi; you get the transcript live over the API. Apache-2.0 all the way down.
+A bot joins Google Meet, Zoom or Teams; you get the transcript live over the API. Apache-2.0 all the way down. (Jitsi: join + capture offline-proven, live validation pending — [#883](https://github.com/Vexa-ai/vexa/issues/883).)
 
 <Note>
   **These docs cover Vexa 0.12.** Hosted [vexa.ai](https://vexa.ai) runs the 0.12 meeting and transcription experience. The agent plane is currently self-hosted only — [self-host Vexa](#try-it) to run the full stack.
@@ -38,7 +38,7 @@ them.
 <CardGroup cols={2}>
   <Card title="Meetings" icon="video" href="/core/meetings">
     Plan, capture, and share meetings — calendar sync, auto-joining bots, real-time transcripts from
-    Google Meet, Zoom, Teams, and Jitsi. Usable standalone as a meeting API.
+    Google Meet, Zoom, and Teams (plus Jitsi, live validation pending). Usable standalone as a meeting API.
   </Card>
   <Card title="Agents" icon="robot" href="/core/agents">
     Sandboxed, scalable agents over your workspace. Put them to work on any knowledge — with or without
@@ -65,7 +65,7 @@ them.
 
 ## What it does
 
-- **Captures meetings natively** — real-time transcripts from [Google Meet, Zoom, Teams, and Jitsi](/core/meetings), no plugins or recorders. **Whisper included**.
+- **Captures meetings natively** — real-time transcripts from [Google Meet, Zoom, and Teams](/core/meetings), no plugins or recorders. **Whisper included**. Jitsi joins and captures (offline-proven), but live transcript validation is still pending — [#883](https://github.com/Vexa-ai/vexa/issues/883).
 - **Meets you at your calendar** — [connect a secret ICS address](/how-to/calendar-sync) and upcoming meetings import automatically; the bot [auto-joins](/core/meetings#auto-join--scheduled-means-the-bot-comes) each one at start. [Plan a meeting](/how-to/plan-a-meeting) ahead and share its prep workspace with the people you're meeting.
 - **Turns knowledge into code** — meetings and emails become a living, Markdown [workspace](/concepts#workspace) that agents treat as their working directory.
 - **Runs agents safely** — every [agent](/core/agents) executes in an isolated, ephemeral [container](/concepts#container): no egress except through brokered tools, thousands in parallel, no lateral movement.


### PR DESCRIPTION
**Delivers issue:** — (docs claim audit, founder-approved 2026-08-20 "fix everything")

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

# [DOCS] Three claims the docs make that the tree does not support

Every change here is a claim **removal or downgrade**. No new capability is documented and no
platform is dropped — Jitsi is qualified, not removed.

## 1. Video recording — `recording_enabled` persists audio, not video

`docs/docs/api/meetings.mdx` said `recording_enabled` controls "whether this spawn should persist an
**audio/video** recording". No shipped path records video, and the docs contradicted themselves:
`docs/docs/how-to/recordings.mdx` already says "The recording is the meeting audio".

Observation — `VideoRecordingService` has zero call sites repo-wide (definition, re-export and prose only):

```
$ grep -rn "VideoRecordingService" . | grep -v node_modules | grep -v "\.git/"
core/meetings/modules/recording/src/video-recording.ts:18:  * VideoRecordingService captures the Xvfb display using ffmpeg x11grab and
core/meetings/modules/recording/src/video-recording.ts:23:  *   const svc = new VideoRecordingService(meetingId, sessionUid);
core/meetings/modules/recording/src/video-recording.ts:30: export class VideoRecordingService {
core/meetings/modules/recording/README.md:9,11,29         (prose)
core/meetings/modules/recording/src/README.md:10          (prose)
core/meetings/modules/recording/src/index.ts:7,18         (comment + re-export)
```

Nothing instantiates it. The bot wires audio only (`services/bot/src/recording.ts:66`), and
`bot/src/config.ts:74` declares `captureModes` without consuming it.

**Before → after:** "persist an audio/video recording" → "persist an **audio** recording (see
[Recordings](/how-to/recordings) — there is no video recording path)". `how-to/send-a-bot.mdx` gains
the same "audio only" qualifier where it mentions `recording_enabled`.

## 2. Jitsi presented as a full production platform

`docs/docs/comparison.mdx` and `docs/docs/roadmap/status.mdx` already carry the honest version.
The high-traffic pages did not. Ground truth, `README.md:443`:

```
| Bot joins **Jitsi Meet** (meet.jit.si + self-hosted) | 🆕 Built & offline-proven; live validation pending |
```

and Vexa-ai/vexa#883 records a live witness run on self-hosted docker-jitsi-meet where the speaker
binder matched **0 of 122** frames — audio recorded, 0 transcript segments. Live-room acceptance
(#570) is still open.

Grep of the whole docs tree for Jitsi claims (`grep -rni jitsi docs/docs/`) found the unqualified
ones on four pages; all four now qualify it as **join + capture offline-proven, live validation
pending**, linking #883:

| File | Before | After |
|---|---|---|
| `index.mdx:11` | "A bot joins Google Meet, Zoom, Teams or Jitsi" | Meet/Zoom/Teams, + parenthetical Jitsi caveat |
| `index.mdx:41` | "Google Meet, Zoom, Teams, and Jitsi" | "…and Teams (plus Jitsi, live validation pending)" |
| `index.mdx:68` | "real-time transcripts from Meet, Zoom, Teams, and Jitsi" | Meet/Zoom/Teams + a sentence on Jitsi's state |
| `api/meetings.mdx:32` | `| Jitsi Meet | jitsi |` in the platform table, unmarked | footnoted `*` with the #883 detail below the table |
| `core/meetings.mdx:87` | four platforms, equal footing | three production + Jitsi qualified |
| `how-to/send-a-bot.mdx:82` | Jitsi tab, no caveat | caveat line above the curl |

`quickstart.mdx` mentions no platform list, so nothing to change there.

## 3. Speaker attribution promised a provisional label that always binds

`docs/docs/api/meetings.mdx` § *Speaker-attributed transcripts* said each segment is attributed to
"a bound display name, **or a provisional label until it binds**" — which tells an integrator every
segment eventually carries a speaker. It does not. From the v0.12.22 release notes:

```
$ gh release view v0.12.22 --repo Vexa-ai/vexa --json body -q .body | grep -in "unnamed|empty speaker"
21:  substantially and publishes what is left with an empty speaker rather than a
39:- Roughly 4–7% of rows still publish unnamed under heavy crosstalk.
```

Tree agrees: `core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts:305-309` — "While null
the turn is UNATTRIBUTED".

**Before → after:** the provisional-label promise is replaced with the shipped behavior — the binder
publishes an **empty speaker** rather than a guess, clients must handle unattributed segments, and
roughly **4–7% of rows publish unnamed** under heavy crosstalk, citing the v0.12.22 release notes.

## Acceptance floor

- No claim in this diff is stronger than the tree or the release notes support.
- The two recording pages (`api/meetings.mdx`, `how-to/recordings.mdx`) now agree.
- Jitsi remains a documented, callable platform on every page it appeared on.
- Docs-only: no code, config, or nav changes.

<!-- vexa-agent -->
