### PR TITLE
docs(comparison): Attendee is ELv2 source-available, not Apache-2.0 — and the resell/embed row that follows from it

### DIFF
--- a/docs/docs/comparison.mdx
+++ b/docs/docs/comparison.mdx
@@ -13,8 +13,10 @@ works org-wide (IT deploys it once; every meeting can be captured, governed, aud
 
 - **Vexa** (this project) — Apache-2.0, self-hosted, bot + real-time STT + speaker attribution +
   the agent/knowledge layer, air-gappable end to end.
-- **[Attendee](https://github.com/attendee-labs/attendee)** — the other credible open-source
-  meeting-bot API (Django/Postgres/Redis). A solid, conventional capture API you build on.
+- **[Attendee](https://github.com/attendee-labs/attendee)** — a source-available meeting-bot API
+  (Django/Postgres/Redis) under the **Elastic License 2.0**, not an open-source license: ELv2 states
+  *"You may not provide the software to third parties as a hosted or managed service."* They also run
+  a hosted cloud. Good software; the licence is the difference.
 - **Hosted bot APIs** (e.g. Recall.ai) — mature and convenient, but your meetings transit their
   cloud; nothing to self-host.
 
@@ -40,7 +42,8 @@ attribution, scaling.
 | Kubernetes / OpenShift scale-out (Helm, a Pod per workload) | ✅ | 🟡 compose-first | n/a | ❌ | 🟡 build it |
 | Knowledge layer: transcripts → git Markdown workspace + sandboxed agents | ✅ | ❌ | ❌ | 🟡 app notes | ❌ |
 | Architecture built for AI-assisted maintenance ([one-concern modules, sealed contracts, golden fixtures](/architecture/modules)) | ✅ | 🟡 conventional | n/a | ❌ | — |
-| License | Apache-2.0 | Apache-2.0 | proprietary | varies | — |
+| License | **Apache-2.0** (OSI open source) | Elastic License 2.0 (source-available) | proprietary | varies | — |
+| **May you resell or embed it in a service you sell?** | ✅ no licence restriction | ❌ ELv2 forbids providing it as a hosted or managed service | ❌ vendor terms | ❌ | ✅ |
 
 *Jitsi* is built and offline-proven, but not yet transcript-proven: live-room acceptance is open
 ([#570](https://github.com/Vexa-ai/vexa/issues/570)) and [#883](https://github.com/Vexa-ai/vexa/issues/883)
@@ -56,7 +59,8 @@ ignore it. See [Configuration](/configuration#transcription-stt).
 
 - **Choose Attendee** if you want *only* a capture API with the most conventional stack possible,
   you're happy wiring your own transcription provider, and the knowledge/agent layer is something
-  you'd rather build yourself. It's good software and the comparison keeps us honest.
+  you'd rather build yourself — and you are **not** reselling it or embedding it in a service you
+  offer to others, which ELv2 does not permit. It's good software and the comparison keeps us honest.
 - **Choose a hosted API** if your compliance posture allows a vendor cloud and you want zero
   operations. That's a real trade — it's just not the one this project exists for.
 - **Choose a local notetaker** for personal note-taking on your own laptop with no IT involvement.


### PR DESCRIPTION
**Delivers issue:** — (founder correction 2026-08-20)

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

## What

The comparison table listed Attendee's licence as **Apache-2.0**. It is the **Elastic License 2.0** — source-available, not OSI open source — and the prose called Attendee "the other credible open-source meeting-bot API".

Three corrections:
1. Table licence row: `Apache-2.0 | Apache-2.0` → `**Apache-2.0** (OSI open source) | Elastic License 2.0 (source-available)`.
2. New table row — **"May you resell or embed it in a service you sell?"** — the practical consequence of the licence difference, which the table had no way to express.
3. Prose: Attendee described as source-available under ELv2, with the operative clause quoted, and noting they also run a hosted cloud. The "when to choose what" entry now says plainly that ELv2 does not permit reselling or embedding it in a service offered to others.

## Observation bundle

- **C1 —** ran: `curl raw.githubusercontent.com/attendee-labs/attendee/main/LICENSE` · saw: `Elastic License 2.0 (ELv2)` and the limitation *"You may not provide the software to third parties as a hosted or managed service, where the service provides users with access to any substantial set of the features or functionality of the software."* · concluded: the licence cell was factually wrong.
- **C2 —** ran: `GET api.github.com/repos/attendee-labs/attendee` · saw: `license.spdx_id = NOASSERTION`, `name = Other` · concluded: GitHub does not classify it as an open-source licence either.
- **C3 —** ran: fetched the project README · saw: hosted signup at `app.attendee.dev` and "reduce costs by 10x compared to closed source vendors" · concluded: they run a commercial cloud, so "self-host-only" framing would also be wrong.

## Acceptance floor

- No claim about Attendee that their own LICENSE and README do not support; the ELv2 limitation is quoted, not paraphrased.
- Vexa's own row unchanged (Apache-2.0), no new Vexa capability claims.
- Table structure unchanged apart from the one added row.

<!-- vexa-agent -->
