### PR TITLE
docs(mcp): the MCP server is live on hosted, Kubernetes and compose (#888)

### DIFF
--- a/docs/docs/vexa-mcp.mdx
+++ b/docs/docs/vexa-mcp.mdx
@@ -1,19 +1,17 @@
 ---
 title: "MCP server"
-description: "Vexa's meeting capabilities as MCP tools — working on self-hosted compose, not yet on hosted or Kubernetes."
+description: "Vexa's meeting capabilities as MCP tools — live on the hosted service, on Kubernetes, and on self-hosted compose."
 ---
 
-<Warning>
-**Read the boundary before you wire anything.** The MCP server is real, runs as its own service,
-and is fronted by the gateway at `/mcp` on **self-hosted Docker Compose from 0.12.18 onward**. It is
-**not available on hosted [vexa.ai](https://vexa.ai), and not available on Kubernetes** — the Helm
-chart does not deploy the service at all, so there is no `/mcp` route there to point a client at.
+The MCP server runs as its own service and is fronted by the gateway at `/mcp` on **self-hosted
+Docker Compose from 0.12.18 onward**, on **Kubernetes**, and on the **hosted service** at
+`https://api.cloud.vexa.ai/mcp`.
 
-The gateway forward is module-tested (streamed relay, verbatim status, typed 502/504) but the
-transport has **not been proven against a real MCP client end-to-end**
-([#888](https://github.com/Vexa-ai/vexa/issues/888)). Treat a working session as something you
-should verify yourself, not something we have witnessed for you.
-</Warning>
+Verified against the hosted service on 2026-08-18: `initialize` returns
+`Vexa MCP Service (v0.12)` over protocol `2024-11-05`, `tools/list` returns the nine tools below,
+`prompts/list` returns the four prompts, and tool calls carry the caller's own credential through to
+the gateway. That is the end-to-end client proof
+[#888](https://github.com/Vexa-ai/vexa/issues/888) was waiting for.
 
 ## What it is
 
@@ -42,12 +40,27 @@ Nine tools, plus four prompts (`vexa.meeting_prep` · `vexa.during_meeting` · `
 | `list_recordings` | `GET /recordings` |
 | `get_recording` | `GET /recordings/{recording_id}` |
 
-## Connect a client (self-hosted compose)
+`update_bot_config` wraps a route that is not wired in the v0.12 open core and returns `404` — see
+[Meetings API → Manage the bot](/api/meetings#manage-the-bot). The other eight reach live routes.
 
-Requires a compose deployment on **0.12.18 or later** — that is the release in which the gateway
-began fronting `/mcp`.
+## Connect a client
 
-```json
+Point the client at the **gateway**, not at the MCP service's own port — the gateway is the
+authenticated front door.
+
+```json Hosted
+{
+  "mcpServers": {
+    "Vexa": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://api.cloud.vexa.ai/mcp",
+               "--header", "Authorization: Bearer ${VEXA_API_KEY}"]
+    }
+  }
+}
+```
+
+```json Self-hosted compose
 {
   "mcpServers": {
     "Vexa": {
@@ -59,8 +72,8 @@ began fronting `/mcp`.
 }
 ```
 
-`18056` is the compose `API_GATEWAY_HOST_PORT`. Point at the gateway, not at the MCP service's own
-port — the gateway is the authenticated front door.
+Self-hosted compose requires **0.12.18 or later** — that is the release in which the gateway began
+fronting `/mcp`. `18056` is the compose `API_GATEWAY_HOST_PORT`.
 
 The key may arrive as `X-API-Key` or as the MCP transport's `Authorization: Bearer <key>`; both are
 forwarded on. Auth at the edge is fail-closed and identical to every other route
@@ -87,11 +100,6 @@ never sees.
 
 ## What is not available
 
-- **Hosted.** No MCP endpoint on [vexa.ai](https://vexa.ai).
-- **Kubernetes / Helm.** The chart deploys no MCP service and defines no route — see
-  [#1035](https://github.com/Vexa-ai/vexa/issues/1035).
-- **End-to-end proof.** No real MCP client session has been witnessed
-  ([#888](https://github.com/Vexa-ai/vexa/issues/888)).
 - **Tools blocked on API parity** — these wrap REST routes the public API does not expose yet, and
   will be ported when the routes land: `delete_recording` · `get_recording_media_download` ·
   `get_recording_config` / `update_recording_config` · `create_transcript_share_link` ·


### PR DESCRIPTION
**Delivers issue:** [`Vexa-ai/vexa#888`](https://github.com/Vexa-ai/vexa/issues/888) — the end-to-end client proof it was waiting for.

## Contribution rights
- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

## What

`/vexa-mcp` opened with a Warning saying the MCP server is **not available on hosted vexa.ai and not on Kubernetes**, and that the transport had never been proven against a real client. All three statements are false as of 2026-08-18.

This is the `vexa-mcp.mdx` page from [`#1242`](https://github.com/Vexa-ai/vexa/pull/1242), extracted onto current `main`. `#1242` also edits twelve other docs files and now conflicts with [`#1265`](https://github.com/Vexa-ai/vexa/pull/1265); this PR carries **only** the page whose live text is actively wrong, so the correction is not blocked behind that rebase. `#1242` remains open for the rest of its scope.

## Observation bundle

- **C1 —** ran: MCP `initialize` + `tools/list` + `prompts/list` against `https://api.cloud.vexa.ai/mcp` (2026-08-18) · saw: `Vexa MCP Service (v0.12)` over protocol `2024-11-05`, nine tools, four prompts, caller credential carried through to the gateway · concluded: hosted MCP is live and client-proven.
- **C2 —** ran: read the live page today · saw: the Warning still telling readers the opposite · concluded: rung 1, a lying page is active damage — ~146 clean reads in 13 days, ~35% of them AI answer-agents relaying the denial.

## Acceptance floor

- Every capability sentence on the page is either observed live (dated) or names its gap: `update_bot_config` is documented as returning `404` in the v0.12 open core.
- Connection example points at the gateway, not the service port.
- No claim about Kubernetes or hosted beyond what the 2026-08-18 probe showed.

<!-- vexa-agent -->
