### PR TITLE
docs: name the hosted dashboard's URL where pages send readers to it

### DIFF
--- a/docs/docs/api/calendar.mdx
+++ b/docs/docs/api/calendar.mdx
@@ -95,8 +95,9 @@ The eleventh active connection returns **409 Conflict**. Invalid names, bot name
 return **422 Unprocessable Entity**.
 
 Creating the connection does not itself wait for provider publication. Call the connection's
-[Sync now](#sync-now) endpoint immediately when you want a fresh result; the hosted Dashboard does
-this automatically after Connect.
+[Sync now](#sync-now) endpoint immediately when you want a fresh result. The hosted dashboard
+([dashboard.vexa.ai](https://dashboard.vexa.ai)) calls it for you right after Connect; a
+self-hosted deployment, or any client driving this API directly, has to make that call itself.
 
 ## Update one calendar
 
@@ -118,8 +119,9 @@ Supply any subset of:
 
 Returns the updated masked connection with **200 OK**. An unknown or deleted ID returns
 **404 Not Found**. A PATCH does not run synchronization automatically; call Sync now after changing
-fields that must be reconciled onto existing planned meetings. The hosted Dashboard does this after
-changing auto-join or bot name.
+fields that must be reconciled onto existing planned meetings. The hosted dashboard
+([dashboard.vexa.ai](https://dashboard.vexa.ai)) calls it for you after a change to auto-join or bot
+name; drive this API directly and the call is yours to make.
 
 ## Disconnect one calendar
 

--- a/docs/docs/core/meetings.mdx
+++ b/docs/docs/core/meetings.mdx
@@ -53,7 +53,8 @@ later; a plan without a time sits in `idle` until you schedule it.
 Connect your calendar with its **secret ICS address** (Google Calendar and Outlook both provide
 one — see [Calendar sync](/how-to/calendar-sync)); no OAuth needed. Connecting syncs immediately
 and answers with the result — every sync failure is stamped as a human-readable status
-(`GET /user/calendars/{calendar_id}/sync`, shown on the Dashboard Calendar page), never swallowed — failures
+(`GET /user/calendars/{calendar_id}/sync`, surfaced on the Calendar page of the hosted dashboard at
+[dashboard.vexa.ai](https://dashboard.vexa.ai)), never swallowed — failures
 are loud here, like everywhere in the lifecycle. A background sweep re-fetches
 the feed (`CALENDAR_SYNC_INTERVAL_S`; self-hosted default 5 minutes, hosted rollout 60 seconds)
 and upserts planned meetings:

--- a/docs/docs/how-to/calendar-sync.mdx
+++ b/docs/docs/how-to/calendar-sync.mdx
@@ -60,10 +60,16 @@ settings ("Reset" in Google Calendar) — then reconnect with the new address.
 
 ## 2. Connect it — and get an answer immediately
 
-In the hosted dashboard, open **Calendar** from the sidebar. Give the connection a recognizable
+On hosted Vexa, the dashboard lives at **[dashboard.vexa.ai](https://dashboard.vexa.ai)** — a
+different host from `vexa.ai`, which carries the site and sign-in and has no calendar page. Sign
+in there and open **Calendar** from the sidebar. Give the connection a recognizable
 name such as **Work** or **Personal**, paste the secret address, choose whether meetings from that
 calendar should auto-join, and click **Connect**. Repeat this for each feed you want Vexa to follow
 (up to 10 active connections).
+
+Everything the dashboard does here is the [calendar API](/api/calendar) underneath, so a self-hosted
+deployment — which ships the API but not the hosted dashboard — connects feeds the same way with
+`POST /user/calendars`. The API is the complete surface; the examples are below.
 
 The same page groups **Upcoming auto-joins** by source calendar. Each calendar has its own
 **Default bot name**, used when that calendar arms an unattended join. For a meeting present in

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -51,8 +51,8 @@ meeting's row in the Terminal — auto-join failures are stamped **onto the meet
 
 - **No meeting link** — a plan without a Meet/Zoom/Teams link has nothing to join. Attach the link
   in the meeting's prep view.
-- **Auto-join is off** — the per-meeting toggle, or the source calendar's Auto-join switch on the
-  Dashboard Calendar page.
+- **Auto-join is off** — the per-meeting toggle, or the source calendar's Auto-join switch
+  (dashboard Calendar page on hosted; `PATCH /user/calendars/{calendar_id}` anywhere).
 - **Concurrency cap** — you were already running `max_concurrent_bots` bots at start time. The row
   shows the cap error and retries after a backoff (default 5 min).
 - **The start time is long past** — a meeting more than the grace window (default 10 min) past its
@@ -63,9 +63,11 @@ meeting's row in the Terminal — auto-join failures are stamped **onto the meet
 
 ## Calendar isn't syncing
 
-**Start with the connection's status line** — the Dashboard Calendar page shows each feed's last
-sync outcome and every failure names itself (`⚠ Last sync failed: …`). **Sync now** re-runs that
-connection, and the API mirrors both: `GET /user/calendars/{calendar_id}/sync` (last status),
+**Start with the connection's status line** — on hosted Vexa that is the Calendar page of the
+dashboard at [dashboard.vexa.ai](https://dashboard.vexa.ai), which shows each feed's last
+sync outcome, and every failure names itself (`⚠ Last sync failed: …`). **Sync now** re-runs that
+connection. Self-hosted deployments do not ship that dashboard, and the API carries the same two
+facts either way: `GET /user/calendars/{calendar_id}/sync` (last status),
 `POST /user/calendars/{calendar_id}/sync` (run now).
 The full message-by-message reference is in
 [Calendar sync → Reading the sync status](/how-to/calendar-sync#reading-the-sync-status). The


### PR DESCRIPTION
**Delivers issue:** n/a — defect found while auditing live docs against the live product on 2026-08-20.

Four docs pages send the reader to "the hosted dashboard" / "the Dashboard Calendar page" and none of them says where that is. A reader who looks on the main site finds nothing. The dashboard is on a separate host.

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## Observation bundle (the record of your harnessed loop)

- **C1 — where the reader would look.** ran: `curl -o /dev/null -w '%{http_code} -> %{redirect_url}'` against the main site · saw: `vexa.ai/signin` **200**, `vexa.ai/account` **307 → /signin?callbackUrl=…/account`**, `vexa.ai/calendar` **404**, `vexa.ai/dashboard` **404** · concluded: the instruction "open Calendar from the sidebar" is unactionable for anyone who starts at `vexa.ai` — there is no calendar surface there at all.
- **C2 — where it actually is.** ran: the same probe against `dashboard.vexa.ai` · saw: `/` **200** (title `Vexa Dashboard`), `/calendar` **200**, `/login` **200**, `/settings` **200** · concluded: the pages' claim is **true**, just unaddressable. The fix is a URL, not a retraction — I checked this before rewriting, because the first read of the defect assumed the UI did not exist and that would have replaced a true sentence with a false one.
- **C3 — is the dashboard in this tree?** ran: `git grep -i dashboard origin/main -- docs/ deploy/` · saw: the only in-tree "dashboard" is the **deprecated 0.10 UI**, off by default, pinned to an external `vexaai/dashboard` image (`docs/docs/deployment-kubernetes.mdx:310-327`); the OSS client is the Terminal · concluded: `dashboard.vexa.ai` is hosted-only, so every one of these pages needed the *self-hosted* half of the answer as well — which is why each edit also names the API path.
- **C4 — do the API paths I point at exist?** ran: grep for the route decorators on `origin/main` · saw: `core/identity/services/admin-api/src/admin_api/app/main.py:543,548,568,593` (`GET|POST /user/calendars`, `PATCH|DELETE /user/calendars/{calendar_id}`) and `core/meetings/services/meeting-api/src/meeting_api/collector/app.py:328,337` (`GET|POST /user/calendars/{calendar_id}/sync`), all allow-listed in `core/gateway/services/gateway/src/gateway/app.py:130-139` · concluded: every endpoint named in the new text is real and reachable through the gateway.
- **C5 — did I catch all of them?** ran: `grep -rn -i dashboard docs/docs/` · saw: after the diff, the only remaining un-URL'd mentions are `changelog.mdx:646` and the k8s page's deprecated-UI section · concluded: both are correct as they stand — see the note on scope below.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 · every page that sends a reader to the hosted dashboard names its URL | `how-to/calendar-sync.mdx`, `troubleshooting.mdx`, `core/meetings.mdx`, `api/calendar.mdx` — C5 grep shows no un-URL'd mention left in scope |
| A2 · no true claim is downgraded to a false one | C2 — the dashboard Calendar page is live; the text keeps the claim and adds the address |
| A3 · the self-hosted reader is answered too | each edit names the API route that does the same job; C4 proves each route exists on `main` |
| A4 · nothing is claimed beyond what was observed | only unauthenticated reachability was probed, so the text says where the dashboard is and what it does after Connect — it makes no claim about sign-in, admin, or entitlement behaviour |

## Docs diff (D6c)

| Page | Altitude | Change |
|---|---|---|
| `how-to/calendar-sync.mdx` | how-to | step 2 names `dashboard.vexa.ai`, states it is a different host from `vexa.ai`, and adds the self-hosted route through `POST /user/calendars` |
| `api/calendar.mdx` | reference | the two "the hosted Dashboard does this automatically" sentences now say which host, and that a direct API client makes the call itself |
| `troubleshooting.mdx` | how-to | the calendar-sync entry points at the right host and gives the API equivalents for self-hosted; the auto-join bullet gains `PATCH /user/calendars/{calendar_id}` |
| `core/meetings.mdx` | concept | the sync-status aside names the host |

**Deliberately unchanged:** `changelog.mdx:646` ("the hosted dashboard does not read this ledger yet") is a dated release note. Per ADR-0022 the source states the designed present and history stays in the ledger, so a past release entry is not restated. `deployment-kubernetes.mdx` refers to the deprecated in-tree 0.10 dashboard, a different artifact, and is already accurate.

## Security checks (required on the diff)

Prose-only diff across four `.mdx` files — no code, no dependencies, no build inputs, so dependency/licence scan and SAST have no surface. Secrets: the diff adds four occurrences of one public hostname and five public API paths; no key, token, or ICS address appears. The ICS-secret warnings already on `calendar-sync.mdx` are untouched.

## Validation request

Any competent non-author: open each of the four changed pages and confirm the dashboard link resolves and the API route named beside it exists in `api/calendar.mdx`. **Deployment validated: hosted** — provenance is live HTTP probes of `vexa.ai` and `dashboard.vexa.ai` on 2026-08-20 (C1, C2), against docs built from `origin/main` at the time of writing. No Lite / compose / k8s deployment was run; this diff changes no runtime behaviour, and the self-hosted claims it adds are proven from route definitions on `main` (C4) rather than from a deployment, which I am stating rather than leaving implied.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
