### PR TITLE
docs: an architecture-review page for the evaluator, and an operability row on /comparison

### DIFF
--- a/docs/docs/architecture/evaluation.mdx
+++ b/docs/docs/architecture/evaluation.mdx
@@ -1,0 +1,215 @@
+---
+title: "Architecture review"
+description: "What an architecture review asks — where audio goes, what running it costs, how it fails, what is and isn't proven, and what you own — answered from the tree."
+---
+
+This page is for the person who has to sign off on depending on Vexa. Every claim below points at
+a file, a contract, or a stated gap. Where something is not shipped, or shipped but unproven, it
+says so — those lines are the point of the page, not an aside.
+
+The map of the codebase itself — module tree, the sealed contract registry, the eval levels — is
+the next page: [Modules & Seams](/architecture/modules). Read that one if you are going to write
+code against this. Read this one if you are going to *depend* on it.
+
+## 1. What runs where
+
+Five core domains behind one front door. The **gateway** is the only world-facing process: it
+resolves `x-api-key` fail-closed, enforces per-route scopes, and proxies the REST surface plus a
+`/ws` multiplex. Everything else binds loopback or the internal network.
+
+- **core/meetings** — joins the call, captures audio, emits a speaker-attributed `transcript.v1`.
+- **core/gateway** — the edge; the one authenticated boundary.
+- **core/runtime** — the kernel that spawns and supervises isolated workloads (one browser
+  container per meeting, one agent container per dispatch).
+- **core/identity** — authN/authZ and accounts, default-deny.
+- **core/agent** — the knowledge layer: transcripts into a git Markdown workspace via sandboxed
+  agents. **Self-hosted only.** The hosted service runs meetings and transcription; it does not
+  run the agent plane.
+
+Three deployment shapes ship, and they are the same bricks composed differently — see
+[§3](#3-what-running-it-costs).
+
+## 2. Where the audio goes
+
+This is usually the first question, so here is the whole path with nothing elided:
+
+| Hop | How |
+|---|---|
+| Bot container captures PCM, converts to WAV | in-process, one browser container per meeting |
+| Bot → transcription service | HTTP POST multipart to `{TRANSCRIPTION_SERVICE_URL}/v1/audio/transcriptions`, OpenAI-compatible, bearer token |
+| Bot → segment stream | redis `XADD` (`transcript.v1`) |
+| `collector` → Postgres | consumer group `collector_group`; rows in `meetings`, `transcriptions`, `meeting_sessions` |
+| `collector` → per-meeting redis stream | single writer |
+| Gateway `/ws` → your clients | WebSocket (`ws.v1`) |
+| Recordings | bot chunks → meeting-api stitches → S3/MinIO |
+
+**At rest:** Postgres holds users, tokens, meetings, transcripts. S3/MinIO holds recordings, agent
+workspaces, and authenticated-bot browser profiles. Redis holds the streams and the bot command bus.
+
+### The egress answer, precisely
+
+The repository models its own egress as machine-checkable architecture. In
+[`architecture.calm.json`](https://github.com/Vexa-ai/vexa/tree/main/architecture.calm.json) every
+node sits inside the tenant boundary except the transcription service, and exactly **one** edge
+crosses out — `bot → transcription`, carrying audio. A CI gate (`pnpm gate:dataflow`, `gate:calm`)
+fails the build if that changes. The rendered view is
+[`docs/views/egress.mmd`](https://github.com/Vexa-ai/vexa/tree/main/docs/views/egress.mmd).
+
+So the honest statement is conditional, and the condition is yours to set:
+
+- **Point `TRANSCRIPTION_SERVICE_URL` at your own STT** — the bundled GPU unit under
+  `deploy/transcription`, or any OpenAI-compatible endpoint — and audio never leaves your
+  perimeter. This is the air-gapped posture [Security & compliance](/security-compliance)
+  describes.
+- **Leave it unset and follow the quickstart** and you are using hosted STT: the variable ships
+  empty in `deploy/compose/.env.example`, and the quickstart hands you a hosted token to get
+  going. That is a fine way to evaluate and the wrong way to run a sovereignty requirement.
+  **Self-hosting the control plane does not by itself make the deployment zero-egress.**
+
+Two further egress paths that the CALM model does **not** currently cover, and you should plan for
+directly: **LLM inference** for the agent plane (you supply the endpoint — an external provider or
+your own), and **webhook delivery** to whatever subscriber URL you configure. Neither is hidden;
+neither is modelled by the gate yet.
+
+## 3. What running it costs
+
+Three shapes, all in-tree, none requiring a GPU for the control plane:
+
+| Shape | What you actually run | Stateful |
+|---|---|---|
+| **Lite** | 1 app container (supervisord tree inside) + 2 sidecars | Postgres, MinIO |
+| **Compose** | 11 services by default (13 declared, 2 profile-gated) + one ephemeral browser container per meeting | Postgres 17, Valkey 8, MinIO, 4 named volumes |
+| **Kubernetes** | 6 Deployments, a Postgres StatefulSet, Valkey + MinIO, an init Job; bots and agents are bare Pods | as above, plus an **RWX** storage class for the agent-workspace PVC on multi-node |
+
+**GPU** is needed only if you self-host STT, and then only for that one unit
+(`deploy/transcription`, which ships a CPU variant too).
+
+Helm's shipped resource requests, which is the number a capacity plan wants:
+
+| Service | Replicas | Requests | Limits |
+|---|---:|---|---|
+| gateway | 2 | 100m / 256Mi | 500m / 512Mi |
+| admin-api | 2 | 100m / 256Mi | 500m / 512Mi |
+| meeting-api | 2 | 200m / 512Mi | 1000m / 1Gi |
+| terminal | 2 | 100m / 256Mi | 1000m / 1Gi |
+| runtime | 1 | 50m / 256Mi | 500m / 768Mi |
+| agent-api | 1 | 100m / 256Mi | 1000m / 1Gi |
+
+That sums to **1.15 vCPU and 3 GiB requested** for the control plane before a single meeting runs.
+Meetings and agent dispatches are ephemeral Pods on top.
+
+**Is it working?** `make probe` runs a full-journey smoke — spawn → schedule → boot → join →
+transcribe → live-view → stop, plus a log sweep — with a per-stage Expected/Actual/Verdict. It
+runs against all three surfaces (`make probe`, `make probe SURFACE=lite`,
+`make probe SURFACE=helm`). Every long-running service answers `GET /health`; compose gates
+bring-up on `service_healthy` rather than sleeping.
+
+**Upgrades** are a tag bump and a re-run — `IMAGE_TAG` for Lite and compose,
+`--set global.imageTag=…` for Helm. Schema migrations converge in-process on service start; there
+is no separate migration step.
+
+### What operability does not include yet
+
+Say this part out loud, because an architecture review will find it anyway:
+
+- **No backup, restore, or DR procedure is documented.** Postgres and S3/MinIO are yours to back
+  up by your own standard. Nothing in the tree does it for you.
+- **No automated upgrade path** — no operator, no version-check service. Upgrades are the manual
+  step above.
+- **No published hardware minimum for Lite or Kubernetes.** The one hardware figure in the docs
+  (8 vCPU / 16 GB) is stated for the full stack, and the README and quickstart disagree about
+  whether it applies to running published images or only to building from source. Size from the
+  table above, not from that line.
+
+## 4. How it fails
+
+Failure reasons are not prose. They are a **sealed contract** —
+[`lifecycle.v1`](https://github.com/Vexa-ai/vexa/tree/main/core/meetings/contracts/lifecycle.v1/lifecycle.schema.json),
+one of the 16 frozen in `contracts.seal.json`, with a sha256 that CI refuses to let drift, and
+golden fixtures beside it.
+
+`BotStatus`: `joining · awaiting_admission · active · needs_help · completed · failed`.
+
+`CompletionReason` — the schema's own word for it is *operator-facing*: `stopped · left_alone ·
+startup_alone · evicted · awaiting_admission_timeout · awaiting_admission_rejected · join_failure ·
+auth_session_missing · validation_error · max_bot_time_exceeded`.
+
+`FailureStage`: `requested · joining · awaiting_admission · active` — which is what separates a
+broken node from a refused join. Events also carry `exit_code`, a `bot_logs` ring buffer, an
+`error_details` object, and a cgroup resource snapshot.
+
+The schema is deliberately liberal (`additionalProperties: true`), so producers can add detail
+(`infra_fault: control_plane_unreachable`, for one) without a reseal.
+
+<Note>
+The enum is fully public and machine-readable in the tree; what does not exist yet is a reference
+page in these docs that enumerates it end to end. [Troubleshooting](/troubleshooting) is
+symptom-shaped and covers the common cases; for the complete set, read the sealed schema linked
+above. Treat that as a documentation gap, not a visibility one.
+</Note>
+
+## 5. Security posture — and what is not claimed
+
+What is real and checkable:
+
+- **One authenticated front door.** Services bind loopback; the gateway resolves identity
+  server-side, fail-closed, with per-route scopes and default-deny ownership checks.
+- **A pre-auth edge guard on by default** on compose and Helm — per-IP throttle (600 req/min),
+  auto-ban, allow/deny lists — with an explicit kill switch (`GUARD_ENABLED`,
+  `gateway.guard.enabled`).
+- **Agents are untrusted by design:** ephemeral isolated container, no egress except brokered
+  tools, propose-only on untrusted input, irreversible effects gated.
+- **Procurement artifacts resolve**, and they are files, not assertions:
+  [`architecture.calm.json`](https://github.com/Vexa-ai/vexa/tree/main/architecture.calm.json) (FINOS
+  CALM), [`SECURITY.md`](https://github.com/Vexa-ai/vexa/tree/main/SECURITY.md),
+  [`security-insights.yml`](https://github.com/Vexa-ai/vexa/tree/main/security-insights.yml) (OpenSSF),
+  [`license-exceptions.json`](https://github.com/Vexa-ai/vexa/tree/main/license-exceptions.json) and
+  [`THIRD_PARTY_LICENSES.md`](https://github.com/Vexa-ai/vexa/tree/main/THIRD_PARTY_LICENSES.md), and
+  the CI gates at [`scripts/gates.mjs`](https://github.com/Vexa-ai/vexa/tree/main/scripts/gates.mjs).
+
+What is **not** claimed, stated plainly so no one has to discover it in a questionnaire:
+
+- **No third-party certification.** No SOC 2, no ISO 27001, no HIPAA BAA, no published penetration
+  test, no external auditor. The posture here is self-attestation plus machine-checkable artifacts
+  you can run yourself. If your process requires a certificate, this does not have one.
+- **Encryption at rest is planned, not shipped** — for workspaces, transcripts, and stored tokens.
+  Today you bring your own disk or volume encryption.
+- **Mid-call bot control endpoints are not wired** in the open-core stack.
+
+Full detail: [Security & compliance](/security-compliance).
+
+## 6. What you own, and how you leave
+
+- **Apache-2.0**, verbatim, no addenda, no dual licence, no enterprise edition, no feature gates.
+  Nothing in the tree is withheld from the licence.
+- **No CLA and no copyright assignment.** Contributions come in under Apache-2.0 with a DCO
+  sign-off; an individual CLA is not required. No assignment means no unilateral relicensing lever
+  over what you have already received.
+- **Fork rights are the exit plan.** There is no licence restriction on reselling or embedding it
+  in a service you sell.
+- **The data leaves with you.** Transcripts and derived knowledge are Markdown in a git repository
+  you hold; recordings are objects in your bucket; everything else is rows in your Postgres.
+  Leaving does not orphan the data.
+
+One boundary that is not about this repository: agent workers can drive a vendor's CLI, and *that
+vendor's* terms govern how their credentials may be used. See
+[Model credentials & licensing](/model-credentials-licensing). Model weights carry their own
+licences, listed in the tree.
+
+## 7. Known gaps, in one place
+
+| Area | State |
+|---|---|
+| Encryption at rest | planned, not shipped |
+| Backup / restore / DR | not documented; operator-owned |
+| Automated upgrades | none; manual tag bump |
+| Third-party certification | none claimed |
+| Failure-taxonomy reference page | contract is public and sealed; no docs page enumerates it |
+| Mid-call bot control | not wired in the open-core stack |
+| `TRANSCRIPTION_MODEL` on Helm | not values-plumbed; inject via `extraEnv` (compose and Lite plumb it) |
+| Jitsi transcripts | built and offline-proven, live-room acceptance open ([#570](https://github.com/Vexa-ai/vexa/issues/570), [#883](https://github.com/Vexa-ai/vexa/issues/883)) — Meet, Teams and Zoom are production |
+| LLM + webhook egress | real, operator-configured, not yet covered by the egress gate |
+
+Capability-by-capability status, kept against the tree:
+[Status](/roadmap/status#capability-truth-table). Where Vexa sits against the alternatives:
+[Comparison](/comparison).

--- a/docs/docs/comparison.mdx
+++ b/docs/docs/comparison.mdx
@@ -42,6 +42,8 @@ attribution, scaling.
 | Kubernetes / OpenShift scale-out (Helm, a Pod per workload) | ✅ | 🟡 compose-first | n/a | ❌ | 🟡 build it |
 | Knowledge layer: transcripts → git Markdown workspace + sandboxed agents | ✅ | ❌ | ❌ | 🟡 app notes | ❌ |
 | Architecture built for AI-assisted maintenance ([one-concern modules, sealed contracts, golden fixtures](/architecture/modules)) | ✅ | 🟡 conventional | n/a | ❌ | — |
+| **Operability**: how much there is to run, and a one-command journey probe that says whether it works | ✅ 3 shapes · `make probe` | 🟡 one Django image, no journey probe | ✅ nothing to run | 🟡 per-seat install | ❌ all yours |
+| **Evidence an evaluator can check** without asking us | ✅ [sealed contracts, CI gates, CALM model, audit artifacts](/architecture/evaluation) | 🟡 source readable, no published gates | ❌ vendor attestation | ❌ | — |
 | License | **Apache-2.0** (OSI open source) | Elastic License 2.0 (source-available) | proprietary | varies | — |
 | **May you resell or embed it in a service you sell?** | ✅ no licence restriction | ❌ ELv2 forbids providing it as a hosted or managed service | ❌ vendor terms | ❌ | ✅ |
 
@@ -49,6 +51,17 @@ attribution, scaling.
 ([#570](https://github.com/Vexa-ai/vexa/issues/570)) and [#883](https://github.com/Vexa-ai/vexa/issues/883)
 reports a witness run on self-hosted Jitsi where audio recorded but the transcript came back empty.
 Meet, Teams and Zoom are production. See [Status](/roadmap/status#capability-truth-table).
+
+*Operability* is the row most often argued with a number and no source, so here are ours. The
+control plane is GPU-free and ships in three sizes: **Lite** (one app container plus two
+sidecars), **compose** (11 services by default, with Postgres, Valkey and MinIO), and **Helm**
+(6 Deployments requesting 1.15 vCPU / 3 GiB in total before a meeting runs). `make probe` runs the
+whole journey — spawn → join → transcribe → live-view → stop — against any of the three and
+prints a per-stage verdict. What we do **not** ship: a backup or DR procedure, an automated
+upgrade path, or a published hardware minimum for Lite and Kubernetes. Those are real operator
+costs and they are enumerated, with the rest, on
+[Architecture review](/architecture/evaluation#3-what-running-it-costs). Self-hosting is work; the
+question worth asking a vendor is whether they will tell you how much before you commit.
 
 *Bring your own models* covers both halves of the STT contract: the endpoint
 (`TRANSCRIPTION_SERVICE_URL`) **and** the model id (`TRANSCRIPTION_MODEL`) — so backends that
@@ -71,4 +84,6 @@ ignore it. See [Configuration](/configuration#transcription-stt).
 
 The deeper positioning discussion — why capture sits upstream of every "chat with your docs" tool —
 is in [Concepts](/concepts). For the regulated-enterprise posture (air-gap, procurement artifacts,
-OSPS Baseline), see [Security & compliance](/security-compliance).
+OSPS Baseline), see [Security & compliance](/security-compliance). If you are the one who has to
+sign off on the dependency — where audio goes, what it costs to run, how it fails, what is *not*
+certified — that is [Architecture review](/architecture/evaluation).

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -73,6 +73,7 @@
       {
         "group": "Architecture",
         "pages": [
+          "architecture/evaluation",
           "architecture/modules",
           "architecture/execution",
           "architecture/dispatch",


### PR DESCRIPTION
**Delivers issue:** n/a — a docs gap found by walking the evaluator's path across our site and the alternatives' on 2026-08-20.

`/architecture` served the contributor's module map as its lede. The reader who lands there is usually deciding whether to *depend* on Vexa, not to write code against it, and that reader's questions were answered nowhere on the site. This adds the page that answers them, and gives `/comparison` the two rows an evaluator looks for.

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## Observation bundle (the record of your harnessed loop)

- **C1 — what the page serves today.** ran: `curl -w '%{http_code} -> %{redirect_url}'` on `docs.vexa.ai/architecture`, then fetched the `.md` rendition · saw: **307 → `/architecture/modules`**, whose lede is *"The single map of the codebase"* · concluded: `/architecture` has no index page and no `redirects` entry — the 307 is Mintlify's implicit group-root (first page of the group). So the fix is a new page placed **first** in the group, which changes the landing without touching a redirect or moving `/architecture/modules`, which `comparison.mdx` links to.
- **C2 — the data path, traced rather than described.** ran: followed audio bot → STT → redis → collector → Postgres/S3 through `core/meetings/modules/whisper/src/transcription-client.ts:93-140`, the collector, `recordings/adapters.py:18-40`, and the generated `docs/views/egress.mmd` · saw: every node inside `subgraph tenant` **except** `transcription`, with exactly one crossing edge (`bot ==>|"audio -> tenant-hosted"| transcription`), backed by `architecture.calm.json:1729-1741` and gated by `pnpm gate:dataflow` / `gate:calm` · concluded: the egress story is machine-checked and can be stated as fact.
- **C3 — the claim that did not survive the check.** ran: read `deploy/compose/.env.example:84-85` against `README.md:74-75` and `docs/docs/quickstart.mdx:40-41` · saw: `TRANSCRIPTION_SERVICE_URL` and `_TOKEN` ship **empty**, and both on-ramps hand the reader a hosted STT token · concluded: "self-hosted ⇒ nothing phones home" is true only once the operator stands up `deploy/transcription` or points at their own endpoint. The page states the condition rather than the conclusion. It also names LLM inference and webhook delivery as real egress the CALM model does not yet cover — I enumerated every relationship in `architecture.calm.json` and `bot-stt` is the only one carrying a `data-egress` control.
- **C4 — operability numbers, from the files not from memory.** ran: counted services in `deploy/compose/docker-compose.yml`, read `deploy/lite`, and read the replica/resource defaults in `deploy/helm/charts/vexa/values.yaml:108-305` · saw: compose declares 13 services of which **11 run by default** (`agent-worker` and `dashboard` are profile-gated) over Postgres 17 / Valkey 8 / MinIO and 4 named volumes, GPU-free; Lite is 1 app container + 2 sidecars; Helm is 6 Deployments whose requests total **1150m CPU and 3072Mi** (gateway 2×100m/256Mi, admin-api 2×100m/256Mi, meeting-api 2×200m/512Mi, terminal 2×100m/256Mi, runtime 50m/256Mi, agent-api 100m/256Mi) · concluded: the two summary figures on the page — 1.15 vCPU and 3 GiB — are arithmetic on that table and are checkable line by line.
- **C5 — the failure-taxonomy claim, which I had backwards going in.** ran: opened `core/meetings/contracts/lifecycle.v1/lifecycle.schema.json` and grepped all of `docs/docs` for the enum values · saw: `BotStatus`, `CompletionReason` (described in-schema as *operator-facing*) and `FailureStage` are a **sealed public contract** — in `contracts.seal.json`, with goldens beside it — while `troubleshooting.mdx` carries only 2 of the 10 completion reasons and no taxonomy table · concluded: the gap is a missing reference page, not internal-only visibility. I had been told the opposite and checked before writing; the page now enumerates the enum and says plainly which kind of gap this is.
- **C6 — what must not be claimed.** ran: grepped `docs/docs`, `README.md`, `SECURITY.md` and `security-insights.yml` for `soc ?2|iso ?27001|hipaa|gdpr|pen ?test|certif` · saw: three hits, **all** about TLS certificate files · concluded: no third-party certification exists, so the page says so in as many words rather than leaving a reader to find out during a questionnaire. Same treatment for at-rest encryption (`security-compliance.mdx:53-56`, "planned, not shipped") and mid-call bot control.
- **C7 — artifacts resolve.** ran: checked each file the security page points an evaluator at · saw: `architecture.calm.json`, `SECURITY.md`, `security-insights.yml`, `license-exceptions.json`, `THIRD_PARTY_LICENSES.md`, `LICENSE` (Apache-2.0 verbatim, 200 lines, no addenda) and `scripts/gates.mjs` all present on `main` · concluded: the "evidence you can check" row on `/comparison` points at things that exist.
- **C8 — nav renders.** ran: `python3 -c "import json; json.load(...)"` on `docs/docs/docs.json` after the edit · saw: parses; `architecture/evaluation` sits first in the Architecture group · concluded: `/architecture` will land on the new page and `/architecture/modules` keeps its URL and its inbound link from `comparison.mdx`.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 · `/architecture` answers the evaluator, not the contributor | new `architecture/evaluation.mdx`, seven sections mapped to review questions; C1/C8 place it at the group root |
| A2 · the contributor map is kept, not discarded | Modules & Seams keeps `/architecture/modules` and is linked in the page's second paragraph |
| A3 · every capability claim sits at its evidence rung | C2–C7; each section names the file, contract or gate behind it |
| A4 · nothing PARTIAL is written as shipped | at-rest encryption, mid-call control, backup/DR, automated upgrades, Jitsi transcripts and third-party certification are each stated as absent or unproven, and collected again in §7 |
| A5 · `/comparison` gains the two missing evaluator rows | operability + checkable-evidence rows, plus a prose paragraph carrying the real numbers and the missing pieces |
| A6 · no duplication of what already landed | the licence and resell/embed rows from #1266 are untouched; the Jitsi caveat from #1134 is referenced, not restated |
| A7 · no pricing or commercial terms | none appear in the diff |

## Docs diff (D6c)

| Page | Altitude | Change |
|---|---|---|
| `architecture/evaluation.mdx` **(new)** | concept / decision-support | what runs where · where audio goes (with the egress condition) · what running it costs · how it fails · security posture and what is *not* claimed · what you own and how you leave · a single known-gaps table |
| `comparison.mdx` | orientation | operability row, checkable-evidence row, an operability paragraph with the real figures, and a closing pointer for the sign-off reader |
| `docs.json` | nav | `architecture/evaluation` first in the Architecture group |

The page deliberately duplicates nothing from `/security-compliance`, `/deployment*` or `/roadmap/status` — it links each of them at the point the question arises, and carries only the synthesis a reviewer needs in one place.

## Security checks (required on the diff)

Prose and nav only — one new `.mdx`, one edited `.mdx`, one JSON key. No code, no dependencies, no build inputs, so dependency/licence scan and SAST have no surface; `docs.json` validated as JSON (C8). Secrets: no key, token, endpoint or credential appears; the environment variables named (`TRANSCRIPTION_SERVICE_URL`, `GUARD_ENABLED`, `IMAGE_TAG`, `TRANSCRIPTION_MODEL`) are already public configuration names. The diff's disclosure direction is worth a reviewer's eye — it publishes gaps rather than capabilities — and each disclosure is either already stated in `security-compliance.mdx` or is the absence of a document, not of a control.

## Validation request

Any competent non-author, ideally someone who has run a vendor architecture review. Two things to watch: (1) every number in §3 reconciles with `deploy/helm/charts/vexa/values.yaml` and `deploy/compose/docker-compose.yml` — the 1.15 vCPU / 3 GiB total is arithmetic you can redo from the table; (2) nothing in §5 or §6 overstates — in particular that the page nowhere implies a certification, an audit, or at-rest encryption.

**Deployment validated: none — and that is the honest answer for this diff.** It changes no runtime behaviour. Its factual base is `origin/main` at `307f2034` (worktree verified identical to `origin/main`, empty diff) plus live fetches of `docs.vexa.ai/architecture` and `/comparison` on 2026-08-20 (C1). No Lite, compose, k8s or hosted deployment was stood up; the operability figures come from the shipped compose file and Helm values rather than from a running cluster, which is stated here rather than left implied. A reviewer who has a cluster up and wants to corroborate the requests against real usage would be adding value the diff does not claim.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
