### PR TITLE
release: production-readiness harness — six-leg coverage as fail-closed machinery (stranded 08-18, surfacing for 0.12.24)

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -49,7 +49,7 @@ jobs:
       # only lane these files run in. Kept here, beside the gates they cover, rather than in the
       # node job, whose install/build cost buys them nothing.
       - name: gate script tests
-        run: node --test scripts/*.test.mjs release/*.test.mjs
+        run: node --test scripts/*.test.mjs release/*.test.mjs release/readiness/*.test.mjs
 
   python:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -914,6 +914,48 @@ jobs:
           path: guarantees.md
 
   # ──────────────────────────────────────────────────────────────────────────────────────────
+  # Production readiness — the six-leg coverage as machinery: train value · blast radius · full
+  # functionality (validate legs + API coverage as of docs) · security · compliance · promotion
+  # ceremony. Each leg's receipt must exist, be green, and be bound to the CURRENT candidate map
+  # sha; a re-cut strands every receipt taken against the old bytes and the runner names them.
+  #
+  # ADVISORY ON THIS TRAIN. `continue-on-error: true` keeps a red readiness verdict out of the
+  # release verdict while v0.12.23's receipts are backfilled from reviews that ran by hand, and
+  # NOTHING in this workflow `needs` this job — no existing gate changes behaviour.
+  #
+  # FLIP TO BLOCKING ON THE NEXT TRAIN: delete `continue-on-error`, and add `readiness` to the
+  # `promote` job's `needs`. Leave the rest exactly as it is.
+  readiness:
+    name: production readiness (advisory — blocking next train)
+    needs: resolve
+    if: always() && needs.resolve.result == 'success'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Pin to main for the same reason value-gate and witness-gate do: the manifest, the
+      # receipts and the runner must be the trusted ones, never the dispatched ref's. A train
+      # whose readiness manifest has not merged yet therefore reads as uncovered — which is the
+      # honest answer, not a harness fault.
+      - uses: actions/checkout@v4
+        with: { ref: main }
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - name: Advisory notice
+        run: |
+          {
+            echo "> ⚠️ **Production readiness is ADVISORY on this train and BLOCKING on the next.**"
+            echo "> A red verdict below does not stop this release. It will stop the next one."
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Six-leg readiness coverage, bound to the current candidate map
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -o pipefail
+          node release/readiness/check.mjs --phase staging | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # ──────────────────────────────────────────────────────────────────────────────────────────
   # The two enforced release gates (D9/D10/D15 — flipped from TO BUILD). They run ONLY on a
   # promote request (the tag-push validate run passes promote:false, so they skip and promote
   # skips with them). On a promote dispatch they are hard `needs` of promote: either reds → the

--- a/release/README.md
+++ b/release/README.md
@@ -31,3 +31,26 @@ packet afterwards. That step is the review, and it is written down in
 [`releases/README.md` § Bind, validate, freeze](../releases/README.md).
 `release-validate-gating.test.mjs` holds both halves in place: the freeze path
 may defer, and every promote / stable / already-mapped path still fails closed.
+
+## `readiness/` — the six-leg production-readiness harness
+
+`readiness/check.mjs` proves that a release's readiness coverage exists rather
+than being asserted. Six legs cover a candidate — train value as of PRs, blast
+radius as of PRs, full functionality (the validate legs plus API coverage as of
+the docs), security, compliance, and the promotion ceremony — and
+`releases/<version>/readiness.yaml` declares each one: whether a command or an
+agent protocol is its oracle, where its receipt lives, what its receipt binds
+to, and whether it fires at train formation, at staging, or both.
+
+The runner checks every receipt a phase requires: present, parseable, GREEN, and
+bound to the **current** candidate map sha. That binding is the mechanism.
+Re-cutting a candidate rewrites `releases/<version>/candidate-images.json`, so
+every receipt taken against the old bytes is stranded — the runner names those
+legs and prints the reason the manifest declares for each, because a review of a
+diff that is no longer shipping is not coverage.
+
+Full operator documentation — phases, receipt shape, the agent protocols — is in
+[`readiness/README.md`](readiness/README.md). The `readiness` job on
+`release-validate` is **advisory on this train and blocking on the next**;
+nothing `needs` it today, and it never substitutes for the witness or value
+gates, which stay human.

--- a/release/readiness/README.md
+++ b/release/readiness/README.md
@@ -1,0 +1,87 @@
+# `release/readiness/` — the six-leg production-readiness harness
+
+Six legs cover a release candidate. This directory makes that coverage a tool
+that fires at two named points instead of a habit that survives only while
+somebody remembers it.
+
+| # | Leg | Kind | Fires | Oracle |
+|---|---|---|---|---|
+| 1 | TRAIN VALUE as of PRs — every train PR carries a user-recognizable value sentence and a pass criterion | machine | formation | [`scripts/release-value-gate.mjs`](../../scripts/release-value-gate.mjs) |
+| 2 | BLAST RADIUS as of PRs — per-PR diff→surface map, covering evidence, uncovered cells named | agent | formation | [`protocols/blast-radius.md`](protocols/blast-radius.md) |
+| 3a | FULL FUNCTIONALITY — builds and runs in lite/compose with checks green | machine | staging | the `release-validate` legs |
+| 3b | FULL FUNCTIONALITY — API coverage as of docs: every documented endpoint probed against the staged candidate | agent | staging | [`protocols/api-docs-sweep.md`](protocols/api-docs-sweep.md) |
+| 4 | SECURITY — new surfaces, authz, deps in shipped images, secrets, injection | agent | both | [`protocols/security-review.md`](protocols/security-review.md) |
+| 5 | COMPLIANCE — legal/privacy **+** architecture **+** principles **+** delivery process | agent | both | [`protocols/compliance-review.md`](protocols/compliance-review.md) |
+| 6 | PROMOTION CEREMONY — rehearsal receipts green and bound | machine | staging | the platform rehearsal packet |
+
+## Running it
+
+```bash
+node release/readiness/check.mjs --phase formation --release v0.12.23
+node release/readiness/check.mjs --phase staging  --release v0.12.23
+```
+
+`RELEASE_VERSION` is read when `--release` is omitted, and a candidate suffix is
+stripped (`v0.12.23-rc.18` → `v0.12.23`) because receipts live under the stable
+release. Exit 0 is green; exit 1 is any leg missing, red, invalid, or stale.
+
+**Formation** requires the legs that fire when the train forms. **Staging**
+requires all six — a formation leg is not spent by having once been green.
+
+## The identity binding
+
+Every receipt records the sha256 of `releases/<version>/candidate-images.json`
+at the moment its leg ran. Re-cutting a candidate rewrites that file, so every
+receipt taken against the old bytes is stranded: the runner reports those legs
+STALE, names each one, and prints the reason the manifest declares for it. A
+security read of a diff that is no longer shipping is not coverage, and the
+repair is to **re-run the leg, never to re-stamp the receipt**.
+
+## The manifest
+
+`releases/<version>/readiness.yaml` enumerates the legs; each declares its kind,
+its oracle (a command for a machine leg, a protocol document for an agent leg),
+its receipt path, its identity binding, and its firing point. The runner refuses
+a manifest whose ordinals do not cover all six legs, so a leg cannot be dropped
+by editing quietly. It is read by a strict YAML subset parser rather than a
+dependency — release-time instruments enter no runtime image and must run on a
+bare `node` — and any construct that subset does not model throws with a line
+number instead of being guessed at.
+
+## Receipts
+
+One per leg at `releases/<version>/readiness/<leg>.receipt.json`. A receipt is a
+**pointer plus a verdict**; the findings live at `findings_ref`.
+
+```json
+{
+  "schema_version": 1,
+  "leg": "blast-radius",
+  "candidate_map_sha": "<sha256 of releases/<version>/candidate-images.json>",
+  "input_identity": "v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307",
+  "result": "green",
+  "findings_ref": "https://github.com/Vexa-ai/vexa/issues/1234",
+  "generated_at": "2026-08-18T15:57:00Z",
+  "generated_by": "agent (readiness session)"
+}
+```
+
+`result` is `green` | `red` | `stale`. Write the receipt **when the review is
+finished**, from the finished report — a receipt written ahead of its finding is
+a fabricated green, which is the single failure this harness exists to prevent.
+A leg with no receipt reads as uncovered, and that is the honest answer.
+
+The shape is documented in [`readiness.schema.json`](readiness.schema.json);
+[`check.mjs`](check.mjs) is the authoritative validator, and
+[`check.test.mjs`](check.test.mjs) asserts the two do not drift.
+
+## What this is not
+
+Readiness green means the coverage exists and is bound to the candidate that is
+shipping. It does **not** mean a human saw the value. The witness gate
+(guarantee 7) and the value gate (guarantee 8) stay human and are untouched by
+this harness — see [`releases/README.md`](../../releases/README.md).
+
+The `readiness` job on `release-validate` is **advisory on the 0.12.23 train and
+blocking on the next**: it runs with `continue-on-error` and nothing `needs` it.
+Flipping it is two edits, stated in the job's own comment.

--- a/release/readiness/check.mjs
+++ b/release/readiness/check.mjs
@@ -292,7 +292,21 @@ export function validateManifest(doc, expectedRelease) {
     if (leg.kind === "agent" && !hasProtocol) {
       fail(`${label}: an agent leg's oracle must be a protocol document`);
     }
-    if (hasCommand) requireText(leg.oracle, "command", label);
+    if (hasCommand) {
+      requireText(leg.oracle, "command", label);
+      // A version pinned INSIDE the oracle is the fourth place this release's number appears, after
+      // release / candidate_map / receipts_dir. The other three are checked above; without this one
+      // a manifest copied forward keeps running the previous release's oracle and reports green for
+      // a batch it never walked — the failure is silent, because the command still succeeds.
+      for (const pinned of leg.oracle.command.matchAll(/RELEASE_VERSION=(\S+)/g)) {
+        if (pinned[1] !== doc.release) {
+          fail(
+            `${label}: oracle pins RELEASE_VERSION=${pinned[1]} but this manifest is ${doc.release} ` +
+            `— the oracle would run against another release`,
+          );
+        }
+      }
+    }
     if (hasProtocol) {
       requireText(leg.oracle, "protocol", label);
       if (!PROTOCOL_PATH.test(leg.oracle.protocol)) {

--- a/release/readiness/check.mjs
+++ b/release/readiness/check.mjs
@@ -1,0 +1,562 @@
+#!/usr/bin/env node
+
+// Production-readiness runner — the six-leg coverage as machinery.
+//
+// A release is ready when six legs are covered: train value, blast radius, full functionality
+// (build/compose legs + API coverage as of docs), security, compliance, promotion ceremony.
+// Each leg declares — in `releases/<version>/readiness.yaml` — its kind, its oracle, its receipt
+// path, its identity binding, and the point it fires at. This runner proves the declaration:
+// every receipt a phase requires exists, parses, is GREEN, and is bound to the CURRENT candidate
+// map. A candidate re-cut changes the map's sha, which strands every receipt taken against the
+// old bytes: those legs are reported STALE by name, with the reason the manifest itself declares.
+//
+// Fail-closed by construction: an unreadable manifest, an unknown leg kind, a receipt for a leg
+// that is not declared, or a receipt whose identity does not bind are all failures — never a pass
+// with a warning. The alternative (a leg that quietly does not run) is the exact defect the
+// harness exists to remove.
+//
+// No runtime dependencies: release-time instruments never enter a Vexa image, and this one runs
+// on a bare `node` in any checkout, so the manifest is read by the strict YAML subset parser
+// below rather than by a library.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const PHASES = ["formation", "staging"];
+export const LEG_PHASES = ["formation", "staging", "both"];
+export const KINDS = ["machine", "agent"];
+export const RESULTS = ["green", "red", "stale"];
+
+// The six legs of the standard. A manifest that does not cover all six is not a readiness
+// manifest — dropping a leg must be impossible to do silently, which is the whole point.
+export const FOUNDER_LEGS = ["1", "2", "3", "4", "5", "6"];
+
+export const MANIFEST_REQUIRED = [
+  "schema_version",
+  "release",
+  "candidate_map",
+  "receipts_dir",
+  "legs",
+];
+export const LEG_REQUIRED = [
+  "id",
+  "leg",
+  "title",
+  "kind",
+  "phase",
+  "oracle",
+  "receipt",
+  "identity",
+];
+export const IDENTITY_REQUIRED = ["binds_candidate_map", "input", "stale_reason"];
+export const RECEIPT_REQUIRED = [
+  "schema_version",
+  "leg",
+  "candidate_map_sha",
+  "input_identity",
+  "result",
+  "findings_ref",
+  "generated_at",
+  "generated_by",
+];
+
+const VERSION = /^v\d+\.\d+\.\d+$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const LEG_ID = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const LEG_ORDINAL = /^([1-6])([ab])?$/;
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+const PROTOCOL_PATH = /^release\/readiness\/protocols\/[a-z0-9-]+\.md$/;
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+// ── the strict YAML subset ────────────────────────────────────────────────────────────────────
+// Mappings, sequences of mappings, and scalars, nested by two-space indentation. Everything else
+// — anchors, aliases, flow collections, block scalars, tabs — throws with a line number. A parser
+// that guesses at a construct it does not model is a parser that reads a manifest as something
+// other than what its author wrote, so this one refuses instead.
+
+function stripComment(line) {
+  let quote = null;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === "\\" && quote === '"') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "#" && (i === 0 || /\s/.test(line[i - 1]))) return line.slice(0, i);
+  }
+  return line;
+}
+
+function splitKey(content) {
+  let quote = null;
+  for (let i = 0; i < content.length; i += 1) {
+    const ch = content[i];
+    if (quote) {
+      if (ch === "\\" && quote === '"') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ":" && (i + 1 === content.length || content[i + 1] === " ")) {
+      return { key: content.slice(0, i).trim(), rest: content.slice(i + 1).trim() };
+    }
+  }
+  return null;
+}
+
+function parseScalar(raw, line) {
+  const text = raw.trim();
+  if (text === "") fail(`line ${line}: empty value; write an explicit null if that is meant`);
+  if (text[0] === '"') {
+    if (text.length < 2 || text[text.length - 1] !== '"') fail(`line ${line}: unterminated string`);
+    return text.slice(1, -1).replace(/\\(["\\])/g, "$1");
+  }
+  if (text[0] === "'") {
+    if (text.length < 2 || text[text.length - 1] !== "'") fail(`line ${line}: unterminated string`);
+    return text.slice(1, -1).replace(/''/g, "'");
+  }
+  if ("[{&*|>%@`".includes(text[0])) {
+    fail(`line ${line}: unsupported YAML construct "${text[0]}" — this manifest uses a strict subset`);
+  }
+  if (text === "true") return true;
+  if (text === "false") return false;
+  if (text === "null" || text === "~") return null;
+  if (/^-?\d+$/.test(text)) return Number(text);
+  return text;
+}
+
+function tokenize(text) {
+  const tokens = [];
+  const lines = text.split("\n");
+  for (let n = 0; n < lines.length; n += 1) {
+    const raw = lines[n];
+    if (raw.includes("\t")) fail(`line ${n + 1}: tabs are not allowed; indent with spaces`);
+    const stripped = stripComment(raw);
+    if (stripped.trim() === "") continue;
+    if (stripped.trim() === "---") continue;
+    const indent = stripped.length - stripped.trimStart().length;
+    if (indent % 2 !== 0) fail(`line ${n + 1}: indent ${indent} is not a multiple of two`);
+    let content = stripped.trim();
+    let dash = false;
+    if (content === "-") fail(`line ${n + 1}: empty sequence entry`);
+    if (content.startsWith("- ")) {
+      dash = true;
+      content = content.slice(2).trim();
+    }
+    tokens.push({ line: n + 1, indent, dash, content });
+  }
+  return tokens;
+}
+
+function parseNodes(tokens, start, indent) {
+  let pos = start;
+  const first = tokens[pos];
+  if (!first) fail("unexpected end of manifest");
+  if (first.indent !== indent) {
+    fail(`line ${first.line}: indent ${first.indent} where ${indent} was expected`);
+  }
+
+  if (first.dash) {
+    const items = [];
+    while (pos < tokens.length && tokens[pos].indent === indent && tokens[pos].dash) {
+      const head = tokens[pos];
+      const body = [{ line: head.line, indent: indent + 2, dash: false, content: head.content }];
+      pos += 1;
+      while (pos < tokens.length && tokens[pos].indent >= indent + 2) {
+        body.push(tokens[pos]);
+        pos += 1;
+      }
+      items.push(parseNodes(body, 0, indent + 2)[0]);
+    }
+    return [items, pos];
+  }
+
+  if (!splitKey(first.content)) {
+    if (tokens.length === pos + 1) return [parseScalar(first.content, first.line), pos + 1];
+    fail(`line ${first.line}: expected "key: value"`);
+  }
+
+  const map = {};
+  while (pos < tokens.length && tokens[pos].indent === indent) {
+    const token = tokens[pos];
+    if (token.dash) fail(`line ${token.line}: sequence entry inside a mapping`);
+    const pair = splitKey(token.content);
+    if (!pair) fail(`line ${token.line}: expected "key: value"`);
+    if (Object.prototype.hasOwnProperty.call(map, pair.key)) {
+      fail(`line ${token.line}: duplicate key "${pair.key}"`);
+    }
+    pos += 1;
+    if (pair.rest !== "") {
+      map[pair.key] = parseScalar(pair.rest, token.line);
+      continue;
+    }
+    const child = tokens[pos];
+    if (!child) fail(`line ${token.line}: "${pair.key}" has no value`);
+    if (child.indent === indent && child.dash) {
+      const [value, next] = parseNodes(tokens, pos, indent);
+      map[pair.key] = value;
+      pos = next;
+      continue;
+    }
+    if (child.indent <= indent) fail(`line ${token.line}: "${pair.key}" has no value`);
+    const [value, next] = parseNodes(tokens, pos, child.indent);
+    map[pair.key] = value;
+    pos = next;
+  }
+  return [map, pos];
+}
+
+export function parseManifestYaml(text) {
+  const tokens = tokenize(text);
+  if (tokens.length === 0) fail("manifest is empty");
+  const [doc, pos] = parseNodes(tokens, 0, 0);
+  if (pos !== tokens.length) fail(`line ${tokens[pos].line}: trailing content after the document`);
+  if (!isPlainObject(doc)) fail("manifest must be a mapping at the top level");
+  return doc;
+}
+
+// ── manifest + receipt validation ─────────────────────────────────────────────────────────────
+
+const isPlainObject = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+function requireFields(row, fields, label) {
+  for (const field of fields) {
+    if (row[field] === undefined) fail(`${label}: missing required field "${field}"`);
+  }
+}
+
+function requireText(row, field, label) {
+  if (typeof row[field] !== "string" || row[field].trim() === "") {
+    fail(`${label}: "${field}" must be a non-empty string`);
+  }
+}
+
+export function validateManifest(doc, expectedRelease) {
+  if (!isPlainObject(doc)) fail("manifest must be a mapping");
+  requireFields(doc, MANIFEST_REQUIRED, "manifest");
+  if (doc.schema_version !== 1) fail("manifest: schema_version must be 1");
+  if (!VERSION.test(doc.release)) fail(`manifest: invalid release "${doc.release}"`);
+  if (expectedRelease && doc.release !== expectedRelease) {
+    fail(`manifest release ${doc.release} does not match requested ${expectedRelease}`);
+  }
+  if (doc.candidate_map !== `releases/${doc.release}/candidate-images.json`) {
+    fail(
+      `manifest: candidate_map must be releases/${doc.release}/candidate-images.json ` +
+      `(got ${doc.candidate_map}) — the identity binding is to THIS release's frozen map`,
+    );
+  }
+  if (doc.receipts_dir !== `releases/${doc.release}/readiness`) {
+    fail(`manifest: receipts_dir must be releases/${doc.release}/readiness`);
+  }
+  if (!Array.isArray(doc.legs) || doc.legs.length === 0) fail("manifest: legs must be a non-empty list");
+
+  const ids = new Set();
+  for (const leg of doc.legs) {
+    if (!isPlainObject(leg)) fail("manifest: every leg must be a mapping");
+    const label = `leg ${leg.id ?? "<unnamed>"}`;
+    requireFields(leg, LEG_REQUIRED, label);
+    requireText(leg, "id", label);
+    if (!LEG_ID.test(leg.id)) fail(`${label}: id must be kebab-case`);
+    if (ids.has(leg.id)) fail(`manifest: duplicate leg id "${leg.id}"`);
+    ids.add(leg.id);
+    requireText(leg, "title", label);
+    if (typeof leg.leg !== "string" || !LEG_ORDINAL.test(leg.leg)) {
+      fail(`${label}: leg must be one of the six ordinals, optionally suffixed a/b (got ${leg.leg})`);
+    }
+    if (!KINDS.includes(leg.kind)) fail(`${label}: kind must be one of ${KINDS.join("|")}`);
+    if (!LEG_PHASES.includes(leg.phase)) fail(`${label}: phase must be one of ${LEG_PHASES.join("|")}`);
+
+    if (!isPlainObject(leg.oracle)) fail(`${label}: oracle must be a mapping`);
+    const hasCommand = leg.oracle.command !== undefined;
+    const hasProtocol = leg.oracle.protocol !== undefined;
+    if (hasCommand === hasProtocol) {
+      fail(`${label}: oracle must declare exactly one of command | protocol`);
+    }
+    if (leg.kind === "machine" && !hasCommand) {
+      fail(`${label}: a machine leg's oracle must be a command`);
+    }
+    if (leg.kind === "agent" && !hasProtocol) {
+      fail(`${label}: an agent leg's oracle must be a protocol document`);
+    }
+    if (hasCommand) requireText(leg.oracle, "command", label);
+    if (hasProtocol) {
+      requireText(leg.oracle, "protocol", label);
+      if (!PROTOCOL_PATH.test(leg.oracle.protocol)) {
+        fail(`${label}: protocol must live at release/readiness/protocols/<name>.md`);
+      }
+    }
+
+    if (leg.receipt !== `${doc.receipts_dir}/${leg.id}.receipt.json`) {
+      fail(`${label}: receipt must be ${doc.receipts_dir}/${leg.id}.receipt.json (got ${leg.receipt})`);
+    }
+
+    if (!isPlainObject(leg.identity)) fail(`${label}: identity must be a mapping`);
+    requireFields(leg.identity, IDENTITY_REQUIRED, `${label} identity`);
+    if (leg.identity.binds_candidate_map !== true) {
+      fail(`${label}: identity.binds_candidate_map must be true — every leg binds the candidate map`);
+    }
+    requireText(leg.identity, "input", `${label} identity`);
+    requireText(leg.identity, "stale_reason", `${label} identity`);
+    if (leg.identity.input_pattern !== undefined) {
+      requireText(leg.identity, "input_pattern", `${label} identity`);
+      try {
+        new RegExp(leg.identity.input_pattern);
+      } catch (error) {
+        fail(`${label}: identity.input_pattern is not a valid regular expression (${error.message})`);
+      }
+    }
+  }
+
+  const covered = new Set(doc.legs.map((leg) => LEG_ORDINAL.exec(leg.leg)[1]));
+  const uncovered = FOUNDER_LEGS.filter((ordinal) => !covered.has(ordinal));
+  if (uncovered.length > 0) {
+    fail(`manifest: the six-leg standard is not covered — no leg declares ${uncovered.join(", ")}`);
+  }
+  return doc;
+}
+
+export function validateReceipt(receipt, leg) {
+  const label = `receipt ${leg.id}`;
+  if (!isPlainObject(receipt)) fail(`${label}: must be a JSON object`);
+  requireFields(receipt, RECEIPT_REQUIRED, label);
+  if (receipt.schema_version !== 1) fail(`${label}: schema_version must be 1`);
+  if (receipt.leg !== leg.id) fail(`${label}: leg "${receipt.leg}" does not match the manifest leg "${leg.id}"`);
+  if (typeof receipt.candidate_map_sha !== "string" || !SHA256.test(receipt.candidate_map_sha)) {
+    fail(`${label}: candidate_map_sha must be a lowercase 64-hex sha256`);
+  }
+  requireText(receipt, "input_identity", label);
+  if (leg.identity.input_pattern) {
+    if (!new RegExp(leg.identity.input_pattern).test(receipt.input_identity)) {
+      fail(
+        `${label}: input_identity "${receipt.input_identity}" does not match the shape this leg ` +
+        `declares (${leg.identity.input_pattern})`,
+      );
+    }
+  }
+  if (!RESULTS.includes(receipt.result)) fail(`${label}: result must be one of ${RESULTS.join("|")}`);
+  requireText(receipt, "findings_ref", label);
+  requireText(receipt, "generated_by", label);
+  if (typeof receipt.generated_at !== "string" || !ISO_8601.test(receipt.generated_at)) {
+    fail(`${label}: generated_at must be an ISO-8601 timestamp`);
+  }
+  return receipt;
+}
+
+// ── phase selection ───────────────────────────────────────────────────────────────────────────
+
+// Formation requires the legs that fire when the train forms. Staging requires ALL six — a
+// formation leg is not spent by having once been green: if the candidate was re-cut after it ran,
+// its receipt is bound to bytes that are no longer shipping, and that is precisely what staging
+// has to catch.
+export function legsForPhase(doc, phase) {
+  if (!PHASES.includes(phase)) fail(`unknown phase "${phase}" — expected ${PHASES.join(" | ")}`);
+  if (phase === "staging") return doc.legs;
+  return doc.legs.filter((leg) => leg.phase === "formation" || leg.phase === "both");
+}
+
+export function stableRelease(version) {
+  const match = /^(v\d+\.\d+\.\d+)(?:-.*)?$/.exec(String(version || "").trim());
+  if (!match) fail(`cannot derive a stable release from "${version}"`);
+  return match[1];
+}
+
+export function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+// ── the check ─────────────────────────────────────────────────────────────────────────────────
+
+export function checkReadiness({ root = process.cwd(), manifestPath, release, phase }) {
+  if (!manifestPath && !release) fail("checkReadiness needs a release or an explicit manifest path");
+  const relativeManifest = manifestPath || `releases/${release}/readiness.yaml`;
+  const absoluteManifest = resolvePath(root, relativeManifest);
+  let manifestText;
+  try {
+    manifestText = readFileSync(absoluteManifest, "utf8");
+  } catch {
+    fail(`no readiness manifest at ${relativeManifest} — a release without one has no declared coverage`);
+  }
+  const doc = validateManifest(parseManifestYaml(manifestText), release);
+
+  const candidateMapPath = resolvePath(root, doc.candidate_map);
+  let currentSha;
+  try {
+    currentSha = sha256File(candidateMapPath);
+  } catch {
+    fail(`no candidate map at ${doc.candidate_map} — nothing to bind the readiness receipts to`);
+  }
+
+  const required = legsForPhase(doc, phase);
+  const rows = required.map((leg) => {
+    const row = { leg, status: null, detail: "", receipt: null };
+    let text;
+    try {
+      text = readFileSync(resolvePath(root, leg.receipt), "utf8");
+    } catch {
+      row.status = "missing";
+      row.detail = `no receipt at ${leg.receipt}`;
+      return row;
+    }
+    let receipt;
+    try {
+      receipt = JSON.parse(text);
+    } catch (error) {
+      row.status = "unparseable";
+      row.detail = `receipt is not valid JSON (${error.message})`;
+      return row;
+    }
+    try {
+      validateReceipt(receipt, leg);
+    } catch (error) {
+      row.status = "invalid";
+      row.detail = error.message;
+      return row;
+    }
+    row.receipt = receipt;
+    if (receipt.candidate_map_sha !== currentSha) {
+      row.status = "stale";
+      row.detail =
+        `bound to candidate map ${receipt.candidate_map_sha.slice(0, 12)}, ` +
+        `current is ${currentSha.slice(0, 12)}`;
+      return row;
+    }
+    if (receipt.result !== "green") {
+      row.status = receipt.result === "stale" ? "stale" : "red";
+      row.detail = `receipt declares result=${receipt.result} · ${receipt.findings_ref}`;
+      return row;
+    }
+    row.status = "green";
+    row.detail = receipt.findings_ref;
+    return row;
+  });
+
+  return {
+    release: doc.release,
+    phase,
+    manifest: relativeManifest,
+    candidate_map: doc.candidate_map,
+    candidate_map_sha: currentSha,
+    rows,
+    ok: rows.every((row) => row.status === "green"),
+  };
+}
+
+const MARK = {
+  green: "✅",
+  stale: "🕒",
+  red: "❌",
+  missing: "⛔",
+  invalid: "❌",
+  unparseable: "❌",
+};
+
+export function formatReport(report) {
+  const lines = [];
+  lines.push(`## Production readiness — ${report.release} · phase \`${report.phase}\``);
+  lines.push("");
+  lines.push(`Candidate map \`${report.candidate_map}\` → \`${report.candidate_map_sha}\``);
+  lines.push("");
+  lines.push("| Leg | # | Kind | Fires | Status | Evidence |");
+  lines.push("|---|---|---|---|---|---|");
+  for (const { leg, status, detail } of report.rows) {
+    lines.push(
+      `| ${leg.title} | ${leg.leg} | ${leg.kind} | ${leg.phase} | ${MARK[status]} ${status} | ${detail} |`,
+    );
+  }
+
+  const stale = report.rows.filter((row) => row.status === "stale");
+  if (stale.length > 0) {
+    lines.push("");
+    lines.push(
+      `**The candidate was re-cut after ${stale.length} leg${stale.length === 1 ? "" : "s"} ran.** ` +
+      "Their receipts are bound to bytes that are no longer shipping, so their coverage does not " +
+      "describe this candidate. Each must be re-run and its receipt re-bound:",
+    );
+    lines.push("");
+    for (const { leg, receipt, detail } of stale) {
+      const bound = receipt ? receipt.candidate_map_sha.slice(0, 12) : "unknown";
+      lines.push(`- \`${leg.id}\` — bound to \`${bound}\`, current \`${report.candidate_map_sha.slice(0, 12)}\`.`);
+      lines.push(`  Why it does not carry: ${leg.identity.stale_reason}`);
+      lines.push(`  Re-run: ${leg.oracle.command ? `\`${leg.oracle.command}\`` : leg.oracle.protocol}`);
+      if (!receipt) lines.push(`  (${detail})`);
+    }
+  }
+
+  const broken = report.rows.filter((row) => ["missing", "invalid", "unparseable", "red"].includes(row.status));
+  if (broken.length > 0) {
+    lines.push("");
+    lines.push(`**${broken.length} leg${broken.length === 1 ? " is" : "s are"} not covered:**`);
+    lines.push("");
+    for (const { leg, status, detail } of broken) {
+      lines.push(`- \`${leg.id}\` (${status}) — ${detail}`);
+      lines.push(`  Oracle: ${leg.oracle.command ? `\`${leg.oracle.command}\`` : leg.oracle.protocol}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(
+    report.ok
+      ? `✅ all ${report.rows.length} legs required at \`${report.phase}\` are green and bound to the current candidate.`
+      : `❌ readiness is not proven at \`${report.phase}\` — see the rows above.`,
+  );
+  return lines.join("\n");
+}
+
+function usage() {
+  console.error(
+    "usage: check.mjs --phase <formation|staging> [--release vX.Y.Z] [--manifest <path>] [--root <path>]\n" +
+    "       RELEASE_VERSION is read when --release is omitted; a candidate suffix is stripped.",
+  );
+  process.exit(2);
+}
+
+export function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (!flag.startsWith("--")) return null;
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith("--")) return null;
+    args[flag.slice(2)] = value;
+    i += 1;
+  }
+  return args;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  if (!args || !args.phase) usage();
+  const version = args.release || process.env.RELEASE_VERSION;
+  if (!version && !args.manifest) usage();
+  const report = checkReadiness({
+    root: args.root || process.cwd(),
+    manifestPath: args.manifest,
+    release: version ? stableRelease(version) : undefined,
+    phase: args.phase,
+  });
+  console.log(formatReport(report));
+  process.exit(report.ok ? 0 : 1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(`readiness: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/release/readiness/check.test.mjs
+++ b/release/readiness/check.test.mjs
@@ -1,0 +1,624 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  FOUNDER_LEGS,
+  IDENTITY_REQUIRED,
+  LEG_REQUIRED,
+  MANIFEST_REQUIRED,
+  RECEIPT_REQUIRED,
+  checkReadiness,
+  formatReport,
+  legsForPhase,
+  parseArgs,
+  parseManifestYaml,
+  stableRelease,
+  validateManifest,
+  validateReceipt,
+} from "./check.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, "..", "..");
+const RELEASE = "v0.12.23";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────────────────────
+
+function validManifest(release = RELEASE) {
+  return {
+    schema_version: 1,
+    release,
+    candidate_map: `releases/${release}/candidate-images.json`,
+    receipts_dir: `releases/${release}/readiness`,
+    legs: [
+      {
+        id: "train-value",
+        leg: "1",
+        title: "TRAIN VALUE as of PRs",
+        kind: "machine",
+        phase: "formation",
+        oracle: { command: "node scripts/release-value-gate.mjs" },
+        receipt: `releases/${release}/readiness/train-value.receipt.json`,
+        identity: {
+          binds_candidate_map: true,
+          input: "the batch range the value gate walked",
+          stale_reason: "a re-cut changes which PRs the promote hands users",
+        },
+      },
+      {
+        id: "blast-radius",
+        leg: "2",
+        title: "BLAST RADIUS as of PRs",
+        kind: "agent",
+        phase: "formation",
+        oracle: { protocol: "release/readiness/protocols/blast-radius.md" },
+        receipt: `releases/${release}/readiness/blast-radius.receipt.json`,
+        identity: {
+          binds_candidate_map: true,
+          input: "the diff the surface map was built from",
+          input_pattern: "^v\\d+\\.\\d+\\.\\d+\\.\\.[0-9a-f]{40}",
+          stale_reason: "the surface table describes a diff the re-cut candidate no longer ships",
+        },
+      },
+      {
+        id: "full-functionality",
+        leg: "3a",
+        title: "FULL FUNCTIONALITY — builds and runs",
+        kind: "machine",
+        phase: "staging",
+        oracle: { command: "gh workflow run release-validate.yml" },
+        receipt: `releases/${release}/readiness/full-functionality.receipt.json`,
+        identity: {
+          binds_candidate_map: true,
+          input: "the release-validate run URL",
+          stale_reason: "the legs pulled published bytes a re-cut replaces",
+        },
+      },
+      {
+        id: "api-docs-sweep",
+        leg: "3b",
+        title: "FULL FUNCTIONALITY — API coverage as of docs",
+        kind: "agent",
+        phase: "staging",
+        oracle: { protocol: "release/readiness/protocols/api-docs-sweep.md" },
+        receipt: `releases/${release}/readiness/api-docs-sweep.receipt.json`,
+        identity: {
+          binds_candidate_map: true,
+          input: "the documented surface and the deployment probed",
+          stale_reason: "the sweep probed image bytes a re-cut replaces",
+        },
+      },
+      {
+        id: "security-review",
+        leg: "4",
+        title: "SECURITY review",
+        kind: "agent",
+        phase: "both",
+        oracle: { protocol: "release/readiness/protocols/security-review.md" },
+        receipt: `releases/${release}/readiness/security-review.receipt.json`,
+        identity: {
+          binds_candidate_map: true,
+          input: "the reviewed diff plus shipped-image dependency state",
+          stale_reason: "a re-cut can add a surface or a dependency nobody reviewed",
+        },
+      },
+      {
+        id: "compliance-review",
+        leg: "5",
+        title: "COMPLIANCE review",
+        kind: "agent",
+        phase: "both",
+        oracle: { protocol: "release/readiness/protocols/compliance-review.md" },
+        receipt: `releases/${release}/readiness/compliance-review.receipt.json`,
+        identity: {
+          binds_candidate_map: true,
+          input: "the reviewed diff plus the issue/PR roster",
+          stale_reason: "custody and contract state are read off the exact commit set",
+        },
+      },
+      {
+        id: "promotion-ceremony",
+        leg: "6",
+        title: "PROMOTION CEREMONY",
+        kind: "machine",
+        phase: "staging",
+        oracle: { command: "make check-promotion-legs" },
+        receipt: `releases/${release}/readiness/promotion-ceremony.receipt.json`,
+        identity: {
+          binds_candidate_map: true,
+          input: "the rehearsal packet whose four legs rendered green",
+          stale_reason: "the rehearsal rendered the exact candidate digests",
+        },
+      },
+    ],
+  };
+}
+
+function validReceipt(leg, sha) {
+  return {
+    schema_version: 1,
+    leg: leg.id,
+    candidate_map_sha: sha,
+    input_identity: "v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307",
+    result: "green",
+    findings_ref: "https://github.com/Vexa-ai/vexa/pull/1234",
+    generated_at: "2026-08-18T15:57:00Z",
+    generated_by: "agent (readiness session)",
+  };
+}
+
+// A deliberately small emitter: every manifest fixture is authored as an object and rendered
+// through the same parser the runner uses, so a mutation test exercises the real read path.
+function emitYaml(value, indent = 0) {
+  const pad = " ".repeat(indent);
+  const scalar = (v) => {
+    if (typeof v === "boolean" || typeof v === "number") return String(v);
+    if (v === null) return "null";
+    const s = String(v);
+    const needsQuote =
+      s === "" ||
+      /^-?\d+$/.test(s) ||
+      ["true", "false", "null", "~"].includes(s) ||
+      /[:#'"]/.test(s) ||
+      /^[[{&*|>%@`-]/.test(s);
+    return needsQuote ? `'${s.replace(/'/g, "''")}'` : s;
+  };
+  const lines = [];
+  for (const [key, item] of Object.entries(value)) {
+    if (item === undefined) continue;
+    if (Array.isArray(item)) {
+      lines.push(`${pad}${key}:`);
+      for (const entry of item) {
+        const body = emitYaml(entry, indent + 4).split("\n");
+        lines.push(`${pad}  - ${body[0].trim()}`);
+        lines.push(...body.slice(1));
+      }
+      continue;
+    }
+    if (item !== null && typeof item === "object") {
+      lines.push(`${pad}${key}:`);
+      lines.push(emitYaml(item, indent + 2));
+      continue;
+    }
+    lines.push(`${pad}${key}: ${scalar(item)}`);
+  }
+  return lines.join("\n");
+}
+
+function scaffold(manifest, receipts = {}, { mapBody = '{"release":"v0.12.23"}' } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "readiness-"));
+  const releaseDir = join(root, "releases", manifest.release);
+  mkdirSync(join(releaseDir, "readiness"), { recursive: true });
+  writeFileSync(join(releaseDir, "candidate-images.json"), mapBody);
+  writeFileSync(join(releaseDir, "readiness.yaml"), `${emitYaml(manifest)}\n`);
+  for (const [id, receipt] of Object.entries(receipts)) {
+    writeFileSync(
+      join(releaseDir, "readiness", `${id}.receipt.json`),
+      typeof receipt === "string" ? receipt : JSON.stringify(receipt, null, 2),
+    );
+  }
+  return { root, sha: createHash("sha256").update(mapBody).digest("hex") };
+}
+
+function allGreen(manifest, sha) {
+  return Object.fromEntries(manifest.legs.map((leg) => [leg.id, validReceipt(leg, sha)]));
+}
+
+// ── the strict YAML subset ────────────────────────────────────────────────────────────────────
+
+test("parses mappings, nested mappings, sequences of mappings and quoted scalars", () => {
+  const doc = parseManifestYaml(
+    [
+      "# a comment",
+      "schema_version: 1",
+      "release: v0.12.23",
+      "flag: true",
+      "empty: null",
+      "quoted: 'a: colon # and a hash'",
+      'escaped: "say \\"hi\\""',
+      "legs:",
+      "  - id: one",
+      "    leg: '1'",
+      "    identity:",
+      "      binds_candidate_map: true",
+      "  - id: two",
+      "    leg: '3a'",
+      "",
+    ].join("\n"),
+  );
+  assert.equal(doc.schema_version, 1);
+  assert.equal(doc.flag, true);
+  assert.equal(doc.empty, null);
+  assert.equal(doc.quoted, "a: colon # and a hash");
+  assert.equal(doc.escaped, 'say "hi"');
+  assert.equal(doc.legs.length, 2);
+  assert.equal(doc.legs[0].identity.binds_candidate_map, true);
+  assert.equal(doc.legs[1].leg, "3a");
+});
+
+test("refuses the YAML it does not model rather than guessing at it", () => {
+  assert.throws(() => parseManifestYaml("a:\n\tb: 1\n"), /tabs are not allowed/);
+  assert.throws(() => parseManifestYaml("legs: [a, b]\n"), /unsupported YAML construct/);
+  assert.throws(() => parseManifestYaml("a: &anchor 1\n"), /unsupported YAML construct/);
+  assert.throws(() => parseManifestYaml("a: 1\na: 2\n"), /duplicate key/);
+  assert.throws(() => parseManifestYaml("a: 1\n   b: 2\n"), /not a multiple of two/);
+  assert.throws(() => parseManifestYaml("a:\n"), /has no value/);
+  assert.throws(() => parseManifestYaml("just a bare line\n"), /mapping at the top level/);
+  assert.throws(() => parseManifestYaml("a: 1\nbare\n"), /expected "key: value"/);
+  assert.throws(() => parseManifestYaml("a: 'unterminated\n"), /unterminated string/);
+  assert.throws(() => parseManifestYaml(""), /manifest is empty/);
+});
+
+// ── manifest validation ───────────────────────────────────────────────────────────────────────
+
+test("accepts a well-formed manifest and round-trips it through the parser", () => {
+  const doc = parseManifestYaml(emitYaml(validManifest()));
+  assert.equal(validateManifest(doc, RELEASE).legs.length, 7);
+});
+
+test("refuses a manifest that does not cover all six legs of the standard", () => {
+  const doc = validManifest();
+  doc.legs = doc.legs.filter((leg) => leg.leg !== "4");
+  assert.throws(() => validateManifest(doc), /six-leg standard is not covered.*4/s);
+
+  const partial = validManifest();
+  partial.legs = partial.legs.filter((leg) => !["3a", "3b"].includes(leg.leg));
+  assert.throws(() => validateManifest(partial), /no leg declares 3/);
+});
+
+test("refuses a manifest whose binding targets are not this release's frozen artefacts", () => {
+  const wrongMap = validManifest();
+  wrongMap.candidate_map = "releases/v0.12.22/candidate-images.json";
+  assert.throws(() => validateManifest(wrongMap), /candidate_map must be/);
+
+  const wrongDir = validManifest();
+  wrongDir.receipts_dir = "releases/v0.12.23/receipts";
+  assert.throws(() => validateManifest(wrongDir), /receipts_dir must be/);
+
+  const wrongVersion = validManifest();
+  assert.throws(() => validateManifest(wrongVersion, "v0.12.24"), /does not match requested/);
+
+  const badRelease = validManifest();
+  badRelease.release = "v0.12.23-rc.18";
+  assert.throws(() => validateManifest(badRelease), /invalid release/);
+
+  const badSchema = validManifest();
+  badSchema.schema_version = 2;
+  assert.throws(() => validateManifest(badSchema), /schema_version must be 1/);
+});
+
+test("a leg's kind and its oracle cannot disagree", () => {
+  const machineWithProtocol = validManifest();
+  machineWithProtocol.legs[0].oracle = { protocol: "release/readiness/protocols/x.md" };
+  assert.throws(() => validateManifest(machineWithProtocol), /machine leg's oracle must be a command/);
+
+  const agentWithCommand = validManifest();
+  agentWithCommand.legs[1].oracle = { command: "echo" };
+  assert.throws(() => validateManifest(agentWithCommand), /agent leg's oracle must be a protocol/);
+
+  const both = validManifest();
+  both.legs[1].oracle = { command: "echo", protocol: "release/readiness/protocols/x.md" };
+  assert.throws(() => validateManifest(both), /exactly one of command \| protocol/);
+
+  const neither = validManifest();
+  neither.legs[1].oracle = { note: "somebody looked at it" };
+  assert.throws(() => validateManifest(neither), /exactly one of command \| protocol/);
+
+  const strayProtocol = validManifest();
+  strayProtocol.legs[1].oracle = { protocol: "docs/whatever.md" };
+  assert.throws(() => validateManifest(strayProtocol), /release\/readiness\/protocols/);
+});
+
+test("every leg must declare a binding, a stated input and a stale reason", () => {
+  const unbound = validManifest();
+  unbound.legs[3].identity.binds_candidate_map = false;
+  assert.throws(() => validateManifest(unbound), /binds_candidate_map must be true/);
+
+  for (const field of IDENTITY_REQUIRED) {
+    const doc = validManifest();
+    delete doc.legs[3].identity[field];
+    assert.throws(() => validateManifest(doc), new RegExp(field));
+  }
+
+  const badPattern = validManifest();
+  badPattern.legs[1].identity.input_pattern = "([unclosed";
+  assert.throws(() => validateManifest(badPattern), /not a valid regular expression/);
+});
+
+test("a leg must carry every required field, a unique id, and its own receipt path", () => {
+  for (const field of LEG_REQUIRED) {
+    const doc = validManifest();
+    delete doc.legs[2][field];
+    assert.throws(() => validateManifest(doc), new RegExp(field));
+  }
+  for (const field of MANIFEST_REQUIRED) {
+    const doc = validManifest();
+    delete doc[field];
+    assert.throws(() => validateManifest(doc), new RegExp(field));
+  }
+
+  const duplicate = validManifest();
+  duplicate.legs[1].id = "train-value";
+  assert.throws(() => validateManifest(duplicate), /duplicate leg id/);
+
+  const misfiled = validManifest();
+  misfiled.legs[1].receipt = "releases/v0.12.23/readiness/blast.receipt.json";
+  assert.throws(() => validateManifest(misfiled), /receipt must be/);
+
+  const badOrdinal = validManifest();
+  badOrdinal.legs[1].leg = "7";
+  assert.throws(() => validateManifest(badOrdinal), /six ordinals/);
+
+  const badKind = validManifest();
+  badKind.legs[1].kind = "human";
+  assert.throws(() => validateManifest(badKind), /kind must be/);
+
+  const badPhase = validManifest();
+  badPhase.legs[1].phase = "promote";
+  assert.throws(() => validateManifest(badPhase), /phase must be/);
+});
+
+// ── receipt validation ────────────────────────────────────────────────────────────────────────
+
+test("accepts a well-formed receipt and refuses a malformed identity", () => {
+  const leg = validManifest().legs[1];
+  const sha = "a".repeat(64);
+  assert.equal(validateReceipt(validReceipt(leg, sha), leg).result, "green");
+
+  for (const field of RECEIPT_REQUIRED) {
+    const receipt = validReceipt(leg, sha);
+    delete receipt[field];
+    assert.throws(() => validateReceipt(receipt, leg), new RegExp(field));
+  }
+
+  const shortSha = validReceipt(leg, "abc");
+  assert.throws(() => validateReceipt(shortSha, leg), /lowercase 64-hex/);
+
+  const upperSha = validReceipt(leg, "A".repeat(64));
+  assert.throws(() => validateReceipt(upperSha, leg), /lowercase 64-hex/);
+
+  const wrongLeg = validReceipt(leg, sha);
+  wrongLeg.leg = "security-review";
+  assert.throws(() => validateReceipt(wrongLeg, leg), /does not match the manifest leg/);
+
+  const badResult = validReceipt(leg, sha);
+  badResult.result = "mostly";
+  assert.throws(() => validateReceipt(badResult, leg), /result must be one of/);
+
+  const badTime = validReceipt(leg, sha);
+  badTime.generated_at = "2026-08-18";
+  assert.throws(() => validateReceipt(badTime, leg), /ISO-8601/);
+});
+
+test("a receipt's input identity must have the shape its leg declares", () => {
+  const leg = validManifest().legs[1];
+  const sha = "a".repeat(64);
+
+  const abbreviated = validReceipt(leg, sha);
+  abbreviated.input_identity = "v0.12.22..c93a2437";
+  assert.throws(() => validateReceipt(abbreviated, leg), /does not match the shape this leg declares/);
+
+  const vague = validReceipt(leg, sha);
+  vague.input_identity = "the diff";
+  assert.throws(() => validateReceipt(vague, leg), /does not match the shape/);
+});
+
+// ── phase selection ───────────────────────────────────────────────────────────────────────────
+
+test("formation requires its own legs; staging requires all six", () => {
+  const doc = validManifest();
+  assert.deepEqual(
+    legsForPhase(doc, "formation").map((leg) => leg.id),
+    ["train-value", "blast-radius", "security-review", "compliance-review"],
+  );
+  assert.equal(legsForPhase(doc, "staging").length, doc.legs.length);
+  assert.throws(() => legsForPhase(doc, "promote"), /unknown phase/);
+});
+
+test("a candidate suffix resolves to the stable release the receipts live under", () => {
+  assert.equal(stableRelease("v0.12.23-rc.18"), "v0.12.23");
+  assert.equal(stableRelease("v0.12.23"), "v0.12.23");
+  assert.equal(stableRelease(" v1.2.3-260723.stage2 "), "v1.2.3");
+  assert.throws(() => stableRelease("0.12.23"), /cannot derive a stable release/);
+});
+
+test("argument parsing refuses a flag without a value", () => {
+  assert.deepEqual(parseArgs(["--phase", "staging"]), { phase: "staging" });
+  assert.equal(parseArgs(["--phase"]), null);
+  assert.equal(parseArgs(["--phase", "--release"]), null);
+  assert.equal(parseArgs(["staging"]), null);
+});
+
+// ── the check ─────────────────────────────────────────────────────────────────────────────────
+
+test("green when every required leg has a receipt bound to the current candidate map", () => {
+  const manifest = validManifest();
+  const { root, sha } = scaffold(manifest, {});
+  const receipts = allGreen(manifest, sha);
+  const staged = scaffold(manifest, receipts, { mapBody: '{"release":"v0.12.23"}' });
+  rmSync(root, { recursive: true, force: true });
+
+  const report = checkReadiness({ root: staged.root, release: RELEASE, phase: "staging" });
+  assert.equal(report.ok, true);
+  assert.equal(report.rows.length, 7);
+  assert.ok(report.rows.every((row) => row.status === "green"));
+  assert.match(formatReport(report), /all 7 legs required at `staging` are green/);
+  rmSync(staged.root, { recursive: true, force: true });
+});
+
+test("a re-cut candidate strands every receipt, naming the legs and why they no longer carry", () => {
+  const manifest = validManifest();
+  const first = scaffold(manifest, {});
+  const receipts = allGreen(manifest, first.sha);
+  // The candidate is re-cut: the map's bytes change, so its sha does — and the receipts taken
+  // against the old bytes now describe a candidate that is not shipping.
+  const { root } = scaffold(manifest, receipts, { mapBody: '{"release":"v0.12.23","recut":true}' });
+  rmSync(first.root, { recursive: true, force: true });
+
+  const report = checkReadiness({ root, release: RELEASE, phase: "staging" });
+  assert.equal(report.ok, false);
+  assert.equal(report.rows.filter((row) => row.status === "stale").length, 7);
+
+  const rendered = formatReport(report);
+  assert.match(rendered, /The candidate was re-cut after 7 legs ran/);
+  for (const leg of manifest.legs) {
+    assert.ok(rendered.includes(`\`${leg.id}\``), `${leg.id} is named`);
+    assert.ok(rendered.includes(leg.identity.stale_reason), `${leg.id} says why`);
+  }
+  assert.match(rendered, /readiness is not proven/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("a missing, unparseable, invalid or red receipt each fail closed with their own reason", () => {
+  const manifest = validManifest();
+  const probe = scaffold(manifest, {});
+  const sha = probe.sha;
+  rmSync(probe.root, { recursive: true, force: true });
+
+  const receipts = allGreen(manifest, sha);
+  delete receipts["api-docs-sweep"];
+  receipts["security-review"] = "{ not json";
+  receipts["compliance-review"] = { ...validReceipt(manifest.legs[5], sha), result: "red" };
+  receipts["promotion-ceremony"] = (() => {
+    const bad = validReceipt(manifest.legs[6], sha);
+    delete bad.findings_ref;
+    return bad;
+  })();
+
+  const { root } = scaffold(manifest, receipts);
+  const report = checkReadiness({ root, release: RELEASE, phase: "staging" });
+  const status = Object.fromEntries(report.rows.map((row) => [row.leg.id, row.status]));
+
+  assert.equal(report.ok, false);
+  assert.equal(status["api-docs-sweep"], "missing");
+  assert.equal(status["security-review"], "unparseable");
+  assert.equal(status["compliance-review"], "red");
+  assert.equal(status["promotion-ceremony"], "invalid");
+  assert.equal(status["train-value"], "green");
+
+  const rendered = formatReport(report);
+  assert.match(rendered, /4 legs are not covered/);
+  assert.match(rendered, /findings_ref/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("a receipt that declares itself stale is never read as green", () => {
+  const manifest = validManifest();
+  const probe = scaffold(manifest, {});
+  const receipts = allGreen(manifest, probe.sha);
+  receipts["blast-radius"] = { ...receipts["blast-radius"], result: "stale" };
+  rmSync(probe.root, { recursive: true, force: true });
+
+  const { root } = scaffold(manifest, receipts);
+  const report = checkReadiness({ root, release: RELEASE, phase: "formation" });
+  assert.equal(report.ok, false);
+  assert.equal(report.rows.find((row) => row.leg.id === "blast-radius").status, "stale");
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("formation passes on its own legs while staging still demands the rest", () => {
+  const manifest = validManifest();
+  const probe = scaffold(manifest, {});
+  const receipts = Object.fromEntries(
+    manifest.legs
+      .filter((leg) => leg.phase === "formation" || leg.phase === "both")
+      .map((leg) => [leg.id, validReceipt(leg, probe.sha)]),
+  );
+  rmSync(probe.root, { recursive: true, force: true });
+
+  const { root } = scaffold(manifest, receipts);
+  assert.equal(checkReadiness({ root, release: RELEASE, phase: "formation" }).ok, true);
+  assert.equal(checkReadiness({ root, release: RELEASE, phase: "staging" }).ok, false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("a release with no manifest and a manifest with no candidate map both fail closed", () => {
+  const root = mkdtempSync(join(tmpdir(), "readiness-"));
+  assert.throws(
+    () => checkReadiness({ root, release: RELEASE, phase: "staging" }),
+    /no readiness manifest at releases\/v0\.12\.23\/readiness\.yaml/,
+  );
+
+  const releaseDir = join(root, "releases", RELEASE);
+  mkdirSync(releaseDir, { recursive: true });
+  writeFileSync(join(releaseDir, "readiness.yaml"), `${emitYaml(validManifest())}\n`);
+  assert.throws(
+    () => checkReadiness({ root, release: RELEASE, phase: "staging" }),
+    /no candidate map at releases\/v0\.12\.23\/candidate-images\.json/,
+  );
+  rmSync(root, { recursive: true, force: true });
+});
+
+// ── the shipped artefacts ─────────────────────────────────────────────────────────────────────
+
+test("the shipped v0.12.23 manifest is valid and every declared protocol exists", () => {
+  const doc = validateManifest(
+    parseManifestYaml(readFileSync(join(REPO, "releases", RELEASE, "readiness.yaml"), "utf8")),
+    RELEASE,
+  );
+  for (const leg of doc.legs) {
+    if (leg.oracle.protocol) {
+      assert.ok(existsSync(join(REPO, leg.oracle.protocol)), `${leg.oracle.protocol} exists`);
+    }
+  }
+  assert.deepEqual(
+    doc.legs.filter((leg) => leg.kind === "agent").map((leg) => leg.id).sort(),
+    ["api-docs-sweep", "blast-radius", "compliance-review", "security-review"],
+  );
+  assert.deepEqual([...FOUNDER_LEGS].sort(), ["1", "2", "3", "4", "5", "6"]);
+});
+
+test("each protocol's worked input-identity example satisfies the shape its leg declares", () => {
+  const doc = parseManifestYaml(readFileSync(join(REPO, "releases", RELEASE, "readiness.yaml"), "utf8"));
+  const checked = [];
+  for (const leg of doc.legs) {
+    if (!leg.oracle.protocol || !leg.identity.input_pattern) continue;
+    const text = readFileSync(join(REPO, leg.oracle.protocol), "utf8");
+    const section = text.slice(text.indexOf("## Input identity"), text.indexOf("## Method"));
+    assert.ok(section.length > 0, `${leg.id}: protocol has an Input identity section`);
+    // The first unlabelled fenced block in that section is the worked example.
+    const example = /```\n([\s\S]*?)```/.exec(section);
+    assert.ok(example, `${leg.id}: protocol shows a worked input_identity`);
+    const value = example[1].trim();
+    assert.match(value, new RegExp(leg.identity.input_pattern));
+    // And it must survive the real receipt validator, not just the regex.
+    assert.doesNotThrow(() =>
+      validateReceipt(
+        { ...validReceipt(leg, "b".repeat(64)), input_identity: value },
+        leg,
+      ),
+    );
+    checked.push(leg.id);
+  }
+  assert.deepEqual(checked.sort(), ["api-docs-sweep", "blast-radius", "compliance-review", "security-review"]);
+});
+
+test("the published schema and the runner agree on what is required", () => {
+  const schema = JSON.parse(readFileSync(join(REPO, "release/readiness/readiness.schema.json"), "utf8"));
+  assert.equal(schema.schema_version, 1);
+  assert.deepEqual(schema.$defs.manifest.required.sort(), [...MANIFEST_REQUIRED].sort());
+  assert.deepEqual(schema.$defs.leg.required.sort(), [...LEG_REQUIRED].sort());
+  assert.deepEqual(schema.$defs.identity.required.sort(), [...IDENTITY_REQUIRED].sort());
+  assert.deepEqual(schema.$defs.receipt.required.sort(), [...RECEIPT_REQUIRED].sort());
+});
+
+test("the readiness job is wired in as advisory and gates nothing this train", () => {
+  const workflow = readFileSync(join(REPO, ".github/workflows/release-validate.yml"), "utf8");
+  const job = workflow.slice(workflow.indexOf("\n  readiness:"), workflow.indexOf("\n  value-gate:"));
+  assert.ok(job.length > 0, "the readiness job exists");
+  assert.match(job, /continue-on-error: true/);
+  assert.match(job, /check\.mjs --phase staging/);
+  assert.match(job, /ref: main/);
+
+  // Advisory means advisory: no existing job may depend on it, or it would gate this train.
+  const promote = workflow.slice(workflow.indexOf("\n  promote:"));
+  assert.doesNotMatch(promote.slice(0, promote.indexOf("steps:")), /readiness/);
+
+  // And the tests of the instrument itself have a lane in CI.
+  const gates = readFileSync(join(REPO, ".github/workflows/gates.yml"), "utf8");
+  assert.match(gates, /node --test .*release\/readiness\/\*\.test\.mjs/);
+});

--- a/release/readiness/check.test.mjs
+++ b/release/readiness/check.test.mjs
@@ -41,7 +41,7 @@ function validManifest(release = RELEASE) {
         title: "TRAIN VALUE as of PRs",
         kind: "machine",
         phase: "formation",
-        oracle: { command: "node scripts/release-value-gate.mjs" },
+        oracle: { command: `RELEASE_VERSION=${release} node scripts/release-value-gate.mjs` },
         receipt: `releases/${release}/readiness/train-value.receipt.json`,
         identity: {
           binds_candidate_map: true,
@@ -278,6 +278,14 @@ test("refuses a manifest whose binding targets are not this release's frozen art
   const wrongDir = validManifest();
   wrongDir.receipts_dir = "releases/v0.12.23/receipts";
   assert.throws(() => validateManifest(wrongDir), /receipts_dir must be/);
+
+  // The fourth place the release number appears is inside a machine leg's oracle. A manifest copied
+  // forward with this one left behind still runs — against the PREVIOUS release's batch — and
+  // reports green, which is the one failure here that makes no noise at all.
+  const staleOracle = validManifest();
+  const valueLeg = staleOracle.legs.find((leg) => leg.oracle?.command?.includes("RELEASE_VERSION="));
+  valueLeg.oracle.command = valueLeg.oracle.command.replace(/RELEASE_VERSION=\S+/, "RELEASE_VERSION=v0.12.22");
+  assert.throws(() => validateManifest(staleOracle), /would run against another release/);
 
   const wrongVersion = validManifest();
   assert.throws(() => validateManifest(wrongVersion, "v0.12.24"), /does not match requested/);

--- a/release/readiness/protocols/README.md
+++ b/release/readiness/protocols/README.md
@@ -1,0 +1,33 @@
+# `release/readiness/protocols/` — the agent legs
+
+Four of the six readiness legs are executed by a session rather than by a
+command. These documents are their oracle: a leg's manifest entry points at one
+of them, and the session follows it exactly.
+
+| Protocol | Leg | Fires | Proves |
+|---|---|---|---|
+| [`blast-radius.md`](blast-radius.md) | 2 | formation | Every train PR mapped diff→surface, each surface carrying covering evidence, and every uncovered cell named rather than assumed |
+| [`api-docs-sweep.md`](api-docs-sweep.md) | 3b | staging | Every endpoint the docs promise is probed against the staged candidate — errors and caps included, not only happy paths |
+| [`security-review.md`](security-review.md) | 4 | both | New surfaces, authz, dependencies inside shipped images, secrets and injection, each finding carrying its own blocking verdict |
+| [`compliance-review.md`](compliance-review.md) | 5 | both | Legal/privacy **and** architecture **and** principles **and** delivery process — the four-part scope is a founder ruling, not a reading |
+
+Each protocol states its inputs, the `input_identity` its receipt must carry,
+its method, its receipt, its blocking-verdict discipline, and the false greens
+it has already produced.
+
+**They are protocols, not checklists.** The method sections are written from the
+runs that produced them so two sessions reviewing two candidates produce
+comparable findings instead of two different improvisations. Where a run taught
+that a technique was insufficient — inferring reachability instead of proving
+it, reading a receipt instead of the run that wrote it, auditing a gate's output
+instead of the gate — the correction is in the method, not in a footnote.
+
+Two rules hold across all four:
+
+- **"Founder decision needed" is `red`.** It is a blocking verdict with a named
+  decision-holder, never a soft pass.
+- **A re-cut candidate strands the receipt.** The identity binding is the
+  point — re-run the leg, never re-stamp its receipt.
+
+See [`../README.md`](../README.md) for the harness, the phases and the receipt
+shape.

--- a/release/readiness/protocols/api-docs-sweep.md
+++ b/release/readiness/protocols/api-docs-sweep.md
@@ -1,0 +1,160 @@
+# API-docs sweep protocol
+
+Proves that every route, parameter, status code and response field the **published docs** promise
+behaves as documented against the staged candidate — the API-coverage half of the full-functionality
+leg, measured as-of-docs rather than as-of-code.
+
+**Leg id:** `api-docs-sweep` · **fires:** `staging` · **re-run:** on every candidate re-cut and on any
+change under `docs/docs/api/`.
+
+## Inputs
+
+| Input | How to obtain |
+|---|---|
+| Documented surface at the candidate | `git show <head>:docs/docs/api/meetings.mdx` (and `calendar.mdx`, `agent.mdx`, `errors.mdx`) |
+| Docs tree sha | `git rev-parse <head>:docs/docs/api` |
+| Staged base URL | the environment under the stage lock, e.g. `https://api.staging.vexa.ai` |
+| Proof the stage runs the candidate | `kubectl get pods -o jsonpath='{..imageID}'` ∩ `releases/<version>/candidate-images.json` digests; record the Helm revision |
+| API key(s) | a throwaway account per the scopes the docs name (`bot`, `tx`, `browser`); never a customer key, never prod |
+| Candidate map | `releases/<version>/candidate-images.json` |
+
+Read the docs from the **candidate commit**, not from the docs site — the site serves the last
+published build and will not carry this train's edits.
+
+## Input identity
+
+The documented surface swept, and the deployment it was probed against — the shape
+`releases/<version>/readiness.yaml` pins for this leg:
+
+```
+docs@8b31abbb8265588daf89e65456e98d4988bed327 against https://api.staging.vexa.ai
+```
+
+```bash
+printf 'docs@%s against %s\n' "$(git rev-parse "$HEAD":docs/docs/api)" "$API_BASE"
+```
+
+Either half moving — an edit under `docs/docs/api/`, or a redeploy — voids the receipt. Record the Helm
+revision and the deployed image digests in the findings.
+
+## Method
+
+1. **Enumerate the legs from the docs, and write the list down before probing.** One leg per documented
+   promise, not per endpoint. The enumeration is the denominator and it is fixed before any request is
+   sent. Sources of legs:
+   - every `bash <METHOD> <path>` block in each `.mdx`
+   - every row of each page's **Error summary** table (`409` on the cap, `422` on invalid input, `404`
+     on unknown/deleted/disabled, `503` when unwired, `204` with no body)
+   - every documented **compatibility / legacy** endpoint — documented means in the denominator, however
+     loudly the page says new integrations should use the plural API
+   - every documented **projection or redaction** claim (e.g. "every response edge projects
+     `calendar_sources` to exactly these four keys"; "the feed URL is never returned in full")
+   - every documented **default** (`auto_join` default, `bot_name` fallback chain, caps such as ten
+     active connections, 100-character names)
+
+   The rc.18 calendar sweep ran **14** legs on this basis: create · list · cap · patch · sync · dedup ·
+   edit · cancel · opt-out · legacy · encoding · delete · errors (13 passing, one failing).
+
+2. **Verify the environment is the candidate before the first probe.** Deployed imageIDs must appear in
+   `candidate-images.json`. If they do not, stop — the sweep proves nothing about this release.
+
+3. **Write each assertion from the doc, then send the request.** The documented status code, the
+   documented field names, the documented cardinality. Never read the response first and write the
+   assertion around it; that measures the implementation and calls it the docs.
+
+4. **Probe in lifecycle sequence, not as isolated calls.** Legs share state and the ordering is part of
+   the surface: create → list → hit the cap → patch → sync → re-sync for dedup → edit the imported plan
+   → cancel → per-meeting opt-out → the legacy singular route → hostile encoding → delete → error table.
+   A leg that only passes from a clean account is not the documented behaviour.
+
+5. **Include the hostile-input legs.** Path parameters carrying control characters, percent-encodings,
+   dot segments and over-long ids: the documented answer is a `4xx`, and any `5xx` is a leg failure
+   regardless of what the body says.
+
+6. **Record per leg: name · request · observed status · body excerpt · PASS/FAIL.** For every FAIL,
+   decide and state which artefact is wrong — the code or the doc — because the remedies go to different
+   places. Never leave it as "discrepancy".
+
+7. **Re-prove a fixed FAIL on the revision that carries the fix.** The denominator never shrinks: a leg
+   removed because it failed is a false green. rc.18's single FAIL (an auto-join retry storm) was fixed
+   and re-proven live before the leg counted.
+
+8. **Cross-check the documented surface against the sealed contract.** Any route documented and served
+   but absent from `core/gateway/contracts/api.v1/` is a real finding — hand it to the compliance leg
+   (§architecture) rather than absorbing it here. This leg's verdict is about docs↔runtime; contract
+   sealing is compliance's.
+
+9. **Commit the sweep as a script under `release/readiness/`.** An uncommitted sweep is a measurement,
+   not a gate — the next change to these routes has no barrier. This is the single most common defect in
+   this leg's history.
+
+10. **Tear down.** Delete probe calendars, stop probe bots, disarm anything that auto-joins, and record
+    the teardown in the findings. A probe feed left armed on a staging replica is how a bot walks into a
+    stranger's meeting.
+
+## Receipt
+
+`releases/v0.12.23/readiness/api-docs-sweep.receipt.json`:
+
+```json
+{
+  "schema_version": 1,
+  "leg": "api-docs-sweep",
+  "candidate_map_sha": "3422d02f02985ab0f02fc47f58a6b4b3e23f0163397f1073c004fe44624d764f",
+  "input_identity": "docs@8b31abbb8265588daf89e65456e98d4988bed327 against https://api.staging.vexa.ai",
+  "result": "green",
+  "findings_ref": "releases/v0.12.23/readiness/api-docs-sweep.md",
+  "generated_at": "2026-08-18T15:57:00Z",
+  "generated_by": "agent (readiness session · api-docs-sweep)"
+}
+```
+
+```bash
+V=v0.12.23; mkdir -p releases/$V/readiness
+MAP_SHA=$(shasum -a 256 releases/$V/candidate-images.json | cut -d' ' -f1)
+jq -n --arg s "$MAP_SHA" --arg i "$IDENTITY" --arg r green --arg f "$FINDINGS_REF" \
+  '{schema_version:1,leg:"api-docs-sweep",candidate_map_sha:$s,input_identity:$i,result:$r,
+    findings_ref:$f,generated_at:(now|todate),generated_by:"agent (readiness session)"}' \
+  > releases/$V/readiness/api-docs-sweep.receipt.json
+node release/readiness/check.mjs --phase staging --release $V
+```
+
+The findings file carries the full leg table with the `N/M` count. The receipt carries only the verdict
+and the pointer. A re-cut changes the map sha and this receipt goes `stale`.
+
+## Blocking-verdict discipline
+
+`green` requires **every** enumerated leg PASS on the deployed candidate. `N-1/N` is `red`, not "green
+with a note" — the missing leg is a published promise the product does not keep.
+
+**RED — blocks the train:**
+- A documented route answers `404`, `5xx`, or a status the docs' own error table does not list.
+- A documented field is absent, renamed, or carries a different type.
+- A documented redaction or projection claim fails — a credential or an internal snapshot rides a
+  response the docs say it never rides. This one blocks even at one occurrence.
+- A leg passes only because of a fix that is **unmerged**. An unmerged fix is not shipped.
+- The stage is not running candidate digests.
+
+**Rides to the next train:** wording and example drift that does not change behaviour; documented-but-
+unimplemented *future* surfaces already marked as such; undocumented-but-shipped routes (that is
+compliance's contract finding, filed here and carried there).
+
+**Waivers:** founder only, per leg, recorded in the receipt's `waivers[]` with the leg name, the issue
+link and the release it expires in. A docs fix is usually cheaper than a waiver — prefer correcting the
+page and re-running the leg.
+
+## Failure modes
+
+- **Sweeping an environment that is not the candidate.** A green sweep against yesterday's revision is a
+  green sweep of yesterday's release.
+- **Writing the assertion after seeing the response.** This converts every code defect into a docs
+  update and the leg can never fail.
+- **Counting a leg green off an unmerged fix**, or off a fix present in a branch build but not in the
+  published candidate images.
+- **Running the sweep by hand.** rc.18's 13/14 had no committed script — a real, well-designed
+  measurement that nobody, including us, can reproduce from the repo.
+- **Dropping the legacy/compat endpoints** because the page recommends the newer API. They are
+  documented, so existing integrations depend on them, so they are legs.
+- **Testing the happy path only.** The error table is roughly half the documented surface; a `409` cap
+  and a `503`-when-unwired are promises exactly as much as a `201`.
+- **Leaving probe state behind** — armed feeds, live bots, or a throwaway account with auto-join on.

--- a/release/readiness/protocols/blast-radius.md
+++ b/release/readiness/protocols/blast-radius.md
@@ -1,0 +1,177 @@
+# Blast-radius protocol
+
+Proves that every change riding the candidate has been mapped from its actual diff to the runtime
+surfaces it touches, and that each surface is either covered by a check that exists and ran on the
+shipped path, or **named as uncovered**.
+
+**Leg id:** `blast-radius` · **fires:** `formation` · **re-run:** on every candidate re-cut.
+
+## Inputs
+
+| Input | How to obtain |
+|---|---|
+| Baseline tag (last **shipped** release) | greatest lower tag carrying `releases/<tag>/witness.json` — a tagged-but-abandoned candidate is not a baseline |
+| Branch point | `git merge-base <baseline-tag> <candidate-head>` |
+| Candidate head sha | `git rev-parse <candidate-branch>` — full 40 chars |
+| Diff census | `git diff --stat <baseline-tag>..<head>` · `git log --oneline <baseline-tag>..<head> \| wc -l` |
+| Stated PR/issue roster | the release scope list you were handed — treat as a **claim**, not a fact |
+| Real merge roster | `git log --merges --oneline <baseline-tag>..<head>` |
+| PR state per item | `gh pr view <N> --json state,mergedAt,mergeCommit,baseRefName,headRefOid` |
+| Candidate map | `releases/<version>/candidate-images.json` — image classes (`prod_deployed` / `oss_only`) |
+| Workflow runs | `gh run list --workflow release-images.yml` · `gh run view <id> --json jobs` |
+| Sealed contract | `core/gateway/contracts/api.v1/` at the candidate |
+
+If the baseline tag and the branch point differ, diff them: `git diff --stat <baseline>..<branch-point>`.
+Commits that touch only release notes, witness or scripts carry nothing runtime, so the range is safe
+to treat as the train. Any runtime file there and the baseline is wrong.
+
+## Input identity
+
+The exact diff range — baseline tag, head at full 40 chars, nothing else (the shape
+`releases/<version>/readiness.yaml` pins for this leg):
+
+```
+v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307
+```
+
+```bash
+printf '%s..%s\n' "$PREV_TAG" "$(git rev-parse "$HEAD")"
+```
+
+A new commit on the candidate branch changes this string and voids the receipt. Record the baseline's
+resolved sha and the branch point in the findings, not in the identity.
+
+## Method
+
+1. **Fix the baseline, then the range.** Per the two-phase rule in `releases/README.md`, the batch is
+   *(last shipped) → (this version)*. Record commit count, file count and `+/−` lines.
+
+2. **Correct the roster before you analyse it.** Four checks per claimed item, each with a command:
+   - PR or issue? (`gh pr view` vs `gh issue view` — an issue number in a roster is a common defect)
+   - merged, or **closed-unmerged with a hand-merge**? (`mergedAt: null` + code present)
+   - is its merge commit an ancestor of the head? `git merge-base --is-ancestor <merge> <head>`
+   - what base did it merge into? A PR merged into the train branch, not `main`, fires no `Closes`.
+
+   Then invert it: `git log --merges <range>` and subtract the roster. **Anything in the train and
+   absent from the roster is the highest-priority row** — in the v0.12.23-rc.18 run the train's
+   highest-radius single change (a live-WS envelope swap) was not on the list being reviewed.
+
+3. **Decompose a mega-PR.** Any PR that is a large fraction of the diff and whose commit ranges have
+   genuinely different radii is split into lettered blocks (`a`–`e`), each with its own row and its
+   own commit range. One row per radius, not one row per PR number.
+
+4. **Map diff → surface, never PR description → surface.** For each row, derive five columns from the
+   file list alone:
+
+   | Column | Derived from | Rule |
+   |---|---|---|
+   | **Images** | which release Dockerfile copies the changed path | name the `candidate-images.json` key **and its class**; `oss_only` is not deployed to prod |
+   | **Routes** | router modules | list ADDED and CHANGED separately; a status-code change (`200`→`404`, new `409`) is a CHANGED route |
+   | **Data** | models, migrations, JSONB writers | name table and column. *"JSONB, no DDL, no migration"* is a finding, not an absence — it means rollback and mixed-version reads are untested |
+   | **Contract** | `core/gateway/contracts/api.v1/` | a zero-diff contract against N new routes is an uncovered cell, not a pass |
+   | **Wire / env** | message envelopes, config keys | name the **consumer**. A consumer outside the candidate map is an R-class risk on its own |
+
+5. **Establish what CI actually ran — read the runs, not the receipts.** For the candidate:
+   - Did the build run *conclude failure*? Which legs were `skipped` as a result? Those legs never ran.
+   - Is the green evidence a `workflow_dispatch` that **does not contain** the skipped legs?
+   - Which workflow holds the unit suites, and did it run on the exact head?
+   - Which tree was validated, and how does it differ from the head?
+   - Per-PR check state across all train PRs — a check that fails on every one is a finding
+     ([the rights-gate parse defect](https://github.com/Vexa-ai/vexa/pull/1095) surfaced exactly this way).
+
+6. **Fill the evidence column only with checks that exist and ran on the shipped path.** Name the file,
+   the workflow leg, or the dated live probe. "The suite is green" is not an entry.
+
+7. **Name the UNCOVERED cells.** A surface is uncovered when its only evidence is disqualified:
+
+   | Disqualifier | Why |
+   |---|---|
+   | fakes-only suite standing in for a DB constraint, advisory lock, or wall-clock behaviour | a partial unique index has no fake analogue |
+   | a suite that executes in **zero** workflows | `.gateignore`, absent from the workspace, or not a value-gate runtime prefix |
+   | a check that ran on a different tree than the one shipping | name the tree it ran on |
+   | an ad-hoc live probe with no committed script | real evidence, **not a regression barrier** — nobody, including us, can re-run it |
+   | a test asserting a property one layer above where it must hold | one line moving downstream reopens it silently |
+   | the production consumer of a changed contract sitting outside the candidate | nothing crosses that line |
+
+   Write the cell as a sentence naming the surface and what would have to be true. Never "needs more
+   testing".
+
+8. **Rank the uncovered cells R1…Rn by production risk**, each with a one-line statement of what breaks
+   and when. R1 is whatever breaks the deploy itself. Collapse cells that are the same defect wearing
+   different clothes and say so.
+
+9. **Write the negative space.** A short section naming what the evidence genuinely does prove, with the
+   best-evidenced change in the train called out as the standard the rest is read against — in rc.18
+   that was a live reprobe in which *each guard was proven load-bearing by neutering it*.
+
+10. **Publish findings, then the receipt.** Findings go to a GitHub issue or
+    `releases/<version>/readiness/blast-radius.md`. Read-only leg: no commits, comments or pushes to the
+    repositories under review.
+
+## Receipt
+
+`releases/v0.12.23/readiness/blast-radius.receipt.json`:
+
+```json
+{
+  "schema_version": 1,
+  "leg": "blast-radius",
+  "candidate_map_sha": "3422d02f02985ab0f02fc47f58a6b4b3e23f0163397f1073c004fe44624d764f",
+  "input_identity": "v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307",
+  "result": "red",
+  "findings_ref": "https://github.com/Vexa-ai/vexa/issues/1179",
+  "generated_at": "2026-08-18T15:57:00Z",
+  "generated_by": "agent (readiness session · blast-radius)"
+}
+```
+
+```bash
+V=v0.12.23; mkdir -p releases/$V/readiness
+MAP_SHA=$(shasum -a 256 releases/$V/candidate-images.json | cut -d' ' -f1)
+jq -n --arg s "$MAP_SHA" --arg i "$RANGE" --arg r red --arg f "$FINDINGS_URL" \
+  '{schema_version:1,leg:"blast-radius",candidate_map_sha:$s,input_identity:$i,result:$r,
+    findings_ref:$f,generated_at:(now|todate),generated_by:"agent (readiness session)"}' \
+  > releases/$V/readiness/blast-radius.receipt.json
+node release/readiness/check.mjs --phase formation --release $V
+```
+
+Re-cut the candidate and `candidate-images.json` changes, its sha changes, and this receipt is
+`stale`. Re-run the leg against the new range; do not re-stamp the sha.
+
+## Blocking-verdict discipline
+
+`green` requires every row's radius mapped **and** every uncovered cell either non-blocking or waived.
+
+**RED — blocks the train:**
+- A `prod_deployed` image carries a guarantee the release claims, and that guarantee's only evidence is
+  disqualified by the table in step 7.
+- A deploy precondition exists (manual DDL, an index prod lacks, an env var no chart pins) with **no
+  pre-flight assertion**. A human reading a runbook is not a gate.
+- The candidate build run failed and the green evidence came from a run missing those legs — red until
+  the legs run or the candidate is re-cut.
+- A wire or status-code contract changed and its production consumer is outside the candidate with no
+  compat leg.
+- The roster was wrong in a way that left a change unreviewed — re-run the leg; do not patch the table.
+
+**Rides to the next train:** uncovered cells on `oss_only` images; second-order gaps with a named owner
+and a filed issue; missing regression barriers for evidence that did run (file the "make it repeatable"
+issue and rank it).
+
+**Waivers:** founder only, one per cell, recorded as a `waivers[]` array in the receipt carrying the
+cell id, the issue link, and the release it expires in. `result` stays `red` until the waiver exists —
+"founder decision needed" is not `green`.
+
+## Failure modes
+
+- **Reviewing the roster instead of the diff.** rc.18's roster claimed a dashboard PR that is not an
+  ancestor of the head at all, and omitted the highest-radius change in the train.
+- **Counting a closed-unmerged PR as delivered.** Two PRs were CLOSED with `mergedAt: null` while their
+  branches were hand-merged — the code ships and the PR record reads "rejected".
+- **Taking any green run as the candidate's run.** The failed build skipped five delta/receipt legs; the
+  green evidence was a standalone dispatch that does not contain them.
+- **Reading suite size as coverage.** 68 files and 847 test functions proved nothing about a partial
+  unique index, an advisory lock, or backoff across row recreation — the suite is 100% fakes.
+- **Recording an ad-hoc live probe as a covering check.** It is evidence for *this* candidate and a
+  barrier for none.
+- **A receipt bound to a stale candidate map** after a re-cut — the leg reads green while describing a
+  release that is not shipping.

--- a/release/readiness/protocols/compliance-review.md
+++ b/release/readiness/protocols/compliance-review.md
@@ -1,0 +1,227 @@
+# Compliance review protocol
+
+Proves that the candidate keeps the promises made outside the code — the published legal and docs
+pages, the sealed architecture, the delivery constitution, and the custody record — and names every
+place where a promise and the shipping behaviour disagree.
+
+**Leg id:** `compliance-review` · **fires:** `both` · **re-run:** on every candidate re-cut and on any
+change to the roster (a merge, a close, a label).
+
+Scope is a founder ruling in four parts — **legal/privacy**, **architecture**, **principles**, **delivery
+process** — and all four run. An engineering audit, not legal advice: it names gaps so counsel can weigh
+them.
+
+## Inputs
+
+| Input | How to obtain |
+|---|---|
+| Diff range | the range the blast-radius leg fixed |
+| Merge state of the head | `git merge-base --is-ancestor <head> origin/main` — state the rung it establishes |
+| Roster snapshot | `gh pr list --state all --search 'base:<train-branch>' --json number,state,mergedAt,mergeCommit,headRefOid,author` |
+| Check-runs per merged head | `gh api repos/Vexa-ai/vexa/commits/<headRefOid>/check-runs` |
+| Issue orbit | `gh issue view <N> --json body,labels,state` for every issue the train touches |
+| Published pages | fetched live, dated in the findings: terms, DPA, privacy, `docs.vexa.ai/security-compliance`, the how-to pages a user reads while arming the feature |
+| Gate suite at the candidate | a **clean detached checkout** of `<head>`; `git status --porcelain` empty before and after |
+| Witness receipt | `releases/<version>/witness.json` + `scripts/release-witness-gate.mjs` |
+| Changelog fragments | `git ls-tree --name-only <head> docs/changelog.d/` |
+| Identity chain | map sha vs the pin in `release/candidate-image-map.test.mjs` vs `EXPECTED_MAP_SHA256` in `.github/workflows/release-validate.yml` |
+
+Every file claim is re-verified at the candidate — `git show <head>:<path>` or the detached checkout.
+
+## Input identity
+
+The reviewed diff plus the roster it was checked against — the shape
+`releases/<version>/readiness.yaml` pins for this leg:
+
+```
+v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307 + roster@9c41ab30e7f2b5d4
+```
+
+```bash
+ROSTER=$(gh pr list --state all --search "base:$TRAIN_BRANCH" \
+          --json number,state,mergedAt,mergeCommit,headRefOid | shasum -a 256 | cut -c1-16)
+printf '%s..%s + roster@%s\n' "$PREV_TAG" "$(git rev-parse "$HEAD")" "$ROSTER"
+```
+
+A PR merging, closing or relabelling changes the roster sha and voids the receipt — deliberately, since
+half this leg's findings are custody findings.
+
+## Method
+
+### A · Legal and privacy
+
+**A1 — recording consent and disclosure.** Establish what changed in *who gets recorded*, not in how;
+verify the before-state on a deployed revision rather than by reading. Build the disclosure table — one
+row per channel with `path:line` evidence: display name · platform-native recording indicator ·
+in-meeting chat announcement · spoken announcement · acknowledgment-before-capture — and check whether
+the *name itself* signals recording or may be set to a plausible human name. Then the published-documents
+table: each page, its published statement, and **true after this train?**, fetched live and dated.
+Finally name the strictest markets with live accounts or active deals, statutes in shape only, for counsel.
+
+**A2 — new personal-data classes.** Enumerate every field the train newly persists: exact column and JSONB
+key path, whether it is indexed, whether it rides an API response, and whether any of it is a **credential**
+(a secret feed address is a bearer credential granting continuing read). Credit the redactions that hold,
+naming the projection function. A severity label written for performance reasons ("row inflation") is
+re-read as a data-minimisation matter and re-triaged.
+
+**A3 — retention.** Search for any automated deletion: age sweeper, `retention_days`, object-storage
+lifecycle policy. Record the delta against the published retention promise as one sentence of the form
+*published: X · implemented: Y*.
+
+**A4 — erasure.** Does a user-deletion path exist at all? Then the FK graph — for each relevant foreign
+key, its `ON DELETE` and the consequence — because cascade-based erasure is unavailable if any edge is
+missing or RESTRICT. Then list what **this train adds to the erasure surface**, item by item, flagging
+anything inside a JSONB blob with no foreign key (an ordered-deletion plan does not reach it).
+
+**A5 — non-production copies.** Does the prod→staging scrub reach the new data classes? Read the script,
+its table filter and its transform, and distinguish a **credential scrub** (things that can act) from a
+**PII scrub** (things that can be read) — say which one exists. Verify against the branch the candidate
+actually staged from, not against `main`.
+
+**A6 — the pattern check.** List every privacy correction that is *written but unmerged* and that this
+train makes load-bearing, with commit, branch and issue — three existed in the rc.18 run. Shipping the
+feature while its mitigations sit on branches is the one sequencing decision that is genuinely one-way.
+
+### B · Architecture
+
+**B1 — seals move legally.** `contracts.seal.json` and `architecture.seal.json`: unchanged, or changed
+**atomically in one commit** together with the model and both generated projections. A seal moving in a
+commit that does not regenerate its projections is drift.
+
+**B2 — run the gate suite read-only** on a clean detached checkout of the candidate; record each line
+verbatim (dataflow counts, schema conformance, contract-version freeze, isolation, graph, exports,
+config-contract, db-schema/budget) and state which gates were **not** run — anything that builds images
+or starts containers — rather than implying a full pass.
+
+**B3 — no illegal shared writers.** For each carrier the train touches, confirm the declared writer set
+did not grow and that a new component reads over a declared edge rather than writing a store it does not
+own. Then check the gate *can see* multi-writer carriers at all: in the rc.18 run two declared ones never
+surfaced because the reporting loop short-circuited before the shared-writer push. A gate that cannot
+report is not evidence.
+
+**B4 — no contract widening without a version bump.** Enumerate every new public route, request parameter,
+response field and changed status code, and compare against the sealed contract's `info.version` and hash.
+Implementation ahead of contract is a gap — and check **why no gate caught it**: a conformance check scoped
+to a hard-coded allowlist filters new routes out of its own comparison and is green by construction. Name
+the structural hole as well as the instance, or it regresses next release.
+
+**B5 — allowlists and known-gaps.** Isolation config, allowed-edges tables and known-gaps ledgers must be
+untouched, or each growth justified in the same commit as the change that needed it.
+
+### C · Principles
+
+**C1 — value-sentence discipline (D5 / D5b).** Every issue the train delivers carries the mandated
+`### Value this issue delivers` heading, one witnessable sentence per value, first. Audit the **issues**,
+not the PRs — auditing a PR for a value section is a category error; find the owning issue. Release notes
+derive from these sentences, so any backfill is due before the notes are cut.
+
+**C2 — fixture discipline.** Fixtures must exercise the artefact the repo actually produces: a rights-gate
+fixture that put a marker on the same line as its checkbox — a shape the template never emits — won for
+months while the gate failed on every real PR. Also verify doctrine pointers resolve; a referenced file
+that does not exist is worse than no reference, since every agent told to read it first finds nothing.
+
+**C3 — one-loop-one-writer on the release machinery.** Grep every workflow at the candidate for
+`git commit` / `git push` / `create-pull-request`. Where a file genuinely has two participants, require a
+**named split** stated in the script itself. Flag hash-comparison hazards: a sha hand-maintained in three
+places is three writers on one value, and it has gone stale before.
+
+### D · Delivery process
+
+**D1 — witness receipt schema conformance.** Run the receipt against its own gate rather than reading it.
+Field names must be the gate's field names — the v0.12.23-rc.18 receipt wrote `pass_criterion` where the
+gate reads `pass`, so a substantively complete receipt could not pass. Confirm the founder-only field is
+unset by a human's choice rather than by omission.
+
+**D2 — issue custody.** Per PR: a closing reference, or a bare mention (a mention creates no closure)?
+Any PR **closed-unmerged while its code ships** via hand-merge — the receipt and GitHub then disagree
+about what happened. Do lifecycle labels match reality? If nothing is closed, establish the mechanism
+(PRs based on a train branch fire no `Closes` until the umbrella merges) — a mechanism is a different
+finding from neglect.
+
+**D3 — DCO sign-off.** `git log --format='%H %(trailers:key=Signed-off-by)' <range>`: merge commits are
+exempt, content commits are not. Then external contributions inside squashed maintainer PRs — check
+`Co-authored-by` trailers, since a rights gate keyed to the *PR author's* checkbox never reaches them,
+and a corporate contributor domain is the signal the employer-authorization path exists to catch.
+
+**D4 — contribution rights.** Read the check-runs on each merged PR's head sha. A merge past a red
+required governance check is a governance breach, reported with the mechanism distinguished: a body
+**clobbered** by a later edit versus one **created** without the template section (`userContentEdits`
+returning zero edits means it was never there). Confirm the branch ruleset requires the check with an
+empty bypass list, or record that you could not read the ruleset and why.
+
+**D5 — changelog fragments vs merged PRs.** Do not judge user-visibility yourself: use the witness
+receipt's own `visibility` stamps as the denominator and count fragments against it. A row the receipt
+calls user-visible with no fragment is a contradiction between two of our own artefacts.
+
+**D6 — identity chain.** Verify the candidate-map sha agrees across all three copies — map content, test
+pin, workflow arm — **at every rc in the series**, by hashing the blob at each commit; a break since
+repaired is still reported with the commits that broke and fixed it. Then check `build_source` ancestry:
+built from a commit that is not an ancestor of the tag means the published tag's history will not contain
+the commit its images came from. Confirm that topology is intended.
+
+## Receipt
+
+`releases/v0.12.23/readiness/compliance-review.receipt.json`:
+
+```json
+{
+  "schema_version": 1,
+  "leg": "compliance-review",
+  "candidate_map_sha": "3422d02f02985ab0f02fc47f58a6b4b3e23f0163397f1073c004fe44624d764f",
+  "input_identity": "v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307 + roster@9c41ab30e7f2b5d4",
+  "result": "red",
+  "findings_ref": "https://github.com/Vexa-ai/vexa/issues/1179",
+  "generated_at": "2026-08-18T15:57:00Z",
+  "generated_by": "agent (readiness session · compliance-review)"
+}
+```
+
+```bash
+V=v0.12.23; mkdir -p releases/$V/readiness
+MAP_SHA=$(shasum -a 256 releases/$V/candidate-images.json | cut -d' ' -f1)
+jq -n --arg s "$MAP_SHA" --arg i "$IDENTITY" --arg r red --arg f "$FINDINGS_URL" \
+  '{schema_version:1,leg:"compliance-review",candidate_map_sha:$s,input_identity:$i,result:$r,
+    findings_ref:$f,generated_at:(now|todate),generated_by:"agent (readiness session)"}' \
+  > releases/$V/readiness/compliance-review.receipt.json
+node release/readiness/check.mjs --phase staging --release $V
+```
+
+A re-cut voids the receipt; so does a roster change, which is why the roster sha is in the identity.
+
+## Blocking-verdict discipline
+
+`green` requires all four sub-parts run and no blocking gap open. **"Founder decision needed" is `red`,
+not `green`** — an undecided decision is an open gap, and the decision is what closes it.
+
+**RED — blocks the train:**
+- A published legal, security or docs page states something the candidate makes false, or false for a
+  materially larger population. A live public claim is not a soft gap.
+- A privacy mitigation this train makes load-bearing exists only as an unmerged branch.
+- The witness receipt cannot pass its own gate.
+- A merge past a red required governance check, until retro-attested (surgically — never overwrite a body
+  carrying a human attestation) or until the ruleset is confirmed and recorded.
+- A sealed contract moved without its projections, or a sealed route's status/shape changed under the
+  frozen version.
+- A non-production copy path that clones data the scrub does not reach, while that path is still armed.
+
+**Rides to the next train, with a filed issue and a due date:** additive unsealed routes, documented and
+with a `lane:contract` PR queued — that blocks OSS publication, not the deploy. Missing value sentences
+and changelog fragments, which block the **release-notes cut**. Third-party-notice disclosure gaps. Stale
+ADR text.
+
+**Waivers:** founder only, one per gap, recorded in the receipt's `waivers[]` with the gap id, the issue
+link and the release it expires in. Sequencing decisions ("ship before the legal-pages patch merges")
+are waivers and are recorded as such, not as green.
+
+## Failure modes
+
+- **Reading files from the working tree.** A tree sitting on a pre-train branch returns pre-train content;
+  in the rc.18 run that would have inverted the rights-gate finding entirely.
+- **Auditing PRs for value sections.** PRs are not the atom of value; find the owning issue.
+- **Reading a skipped required-shaped check as satisfied.** "All legs green" described a run with three
+  skipped legs, two of them the value and witness gates. Report `N green / M skipped` and name the skipped.
+- **Trusting a green gate that cannot fail.** An allowlist-scoped conformance check filters new routes out
+  of its own comparison; twelve new public routes could never turn it red.
+- **Counting a written fix as shipped.** A commit on a branch mitigates nothing.
+- **Treating a repaired identity-chain break as historical** — report it with the commits, since the
+  mechanism that allowed it is still there.

--- a/release/readiness/protocols/security-review.md
+++ b/release/readiness/protocols/security-review.md
@@ -1,0 +1,185 @@
+# Security review protocol
+
+Proves that nothing the candidate adds is reachable by an unauthenticated or cross-tenant path, that
+every finding carries a demonstrated — not inferred — exploit or refutation, and that the dependency
+state of the **shipped images** is known.
+
+**Leg id:** `security-review` · **fires:** `both` (diff reading at formation; live probes at staging) ·
+**re-run:** on every candidate re-cut and on any dependency-manifest change.
+
+## Inputs
+
+| Input | How to obtain |
+|---|---|
+| Diff range | `git diff --stat <prev-tag>..<head>` — the same range the blast-radius leg fixed |
+| The **built** tree | `candidate-images.json` → `build_source`; then `git diff --stat <head> <build_source>` |
+| Dependency manifests | `git ls-tree -r <head> -- 'pnpm-lock.yaml' '**/package-lock.json' '**/uv.lock' 'requirements*.txt'` |
+| Which manifest each image installs | read every release `Dockerfile` — `npm ci` vs `pnpm`, `--omit=dev`, what is copied into the final stage |
+| Open alerts | `gh api repos/Vexa-ai/vexa/dependabot/alerts?state=open --paginate` |
+| Staged base URL | for read-only edge probes only |
+| Throwaway credentials | from the operator's own secret store — verify they still authenticate before relying on them |
+
+Never read source from the working tree. `git show <head>:<path>` for every claim: a checkout sitting on
+an older branch returns pre-train content and produces the opposite finding.
+
+## Input identity
+
+The reviewed diff plus the dependency state of the shipped images — the shape
+`releases/<version>/readiness.yaml` pins for this leg:
+
+```
+v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307 + deps@1f3c9ab27d40e6b8
+```
+
+```bash
+DEPS=$(git ls-tree -r "$HEAD" -- pnpm-lock.yaml clients/terminal/package-lock.json \
+        '*/uv.lock' '*/requirements*.txt' | shasum -a 256 | cut -c1-16)
+printf '%s..%s + deps@%s\n' "$PREV_TAG" "$(git rev-parse "$HEAD")" "$DEPS"
+```
+
+A dependency bump changes the identity even when no source changes — that is deliberate.
+
+## Method
+
+1. **Settle tree identity first.** The reviewed commit is often not the commit the images were built
+   from. Diff head against `build_source` and state the result in one line: in the rc.18 run four files
+   differed — a workflow, a map test, the map, and the witness receipt — and **no source file differed**,
+   so every finding applied exactly to the built candidate. If source differs, review the built tree.
+
+2. **Read the diff for the trust boundaries, in this order:** identity-header stripping at the gateway ·
+   `user_id` scoping in every new SQL predicate · whether a resource id is resolved *inside the caller's
+   own document* or is a global key · mass assignment (`extra: forbid`, patch whitelists) · path
+   parameters reaching a proxied upstream · new primitives added without a scope predicate.
+
+3. **Prove it, do not infer it.** Every claim that a path is reachable or blocked is settled by
+   execution: drive the **exact** client the shipped code constructs (the same transport builder, the
+   same flags) against a local listener in a scratch directory, and paste the observed output —
+   `BLOCKED` / `HTTP 200` / measured bytes. Reading a guard and pronouncing it sound is how the rc.18
+   SSRF bypass survived a previous round: that review verified the *design*, which was good; the defect
+   was one missing address family in a constant.
+
+4. **Measure against the shipped code path at the shipped constants.** Run the actual parser, the actual
+   cap, the actual timeout. Report numbers: bytes buffered before the cap fires, peak RSS, rows emitted
+   per feed, CPU seconds per sweep. A cap that is checked after the whole body is in memory is a
+   post-hoc report, and only a measurement says so.
+
+5. **Write the reachability chain per finding**, every link named: entry route → auth requirement →
+   rate limit and any cooldown → the primitive → **impact scope**. Impact scope is the field that
+   decides severity: a single-tenant *path* into a shared control plane is cross-tenant *impact*.
+
+6. **Dependencies: trace, do not trust the SBOM.** For each open critical/high alert, answer two
+   questions separately: (a) does the vulnerable manifest get installed into a **published** image —
+   Dockerfile by Dockerfile, lockfile by lockfile; (b) is there a first-party call path — the specific
+   API, provider, or directive the advisory requires, grepped for in our code. Record "not reachable"
+   **with the precondition that would make it reachable** (one `"use server"` file, one env flag turning
+   on an outbound path). Collapse alert rows to distinct package × GHSA pairs before counting; Dependabot
+   files one row per manifest.
+
+   Two standing corrections found by the rc.18 run: the terminal **ships** (published image, and its
+   `npm ci` tree is baked into lite), and `scripts/sbom.mjs` is a repo inventory that unions dev trees —
+   it misreported a shipped version. A wrong SBOM is itself a finding: it is the artefact an auditor is
+   handed.
+
+7. **Secrets hygiene across every changed file:** keys, tokens, JWTs, private keys, URLs with embedded
+   auth, default/fallback secrets, secrets written to logs. Then the same pass over **fixtures and eval
+   corpora** — real participant names, real meeting links, real attendee emails entering a public repo
+   is the higher-probability leak. Confirm with `git ls-tree` that the gitignored inputs were in fact
+   never committed.
+
+8. **Injection and XSS pass:** every new query parameterized, every f-string SQL identified and its
+   interpolant proven to be a module constant; `dangerouslySetInnerHTML` / `eval` / `new Function` /
+   `document.write` in shipped client code; escaping of any string that originates from a meeting
+   participant.
+
+9. **Write the "Checked, and sound" section.** Numbered, each item with `path:line` and what was
+   *actively probed*, not assumed — identity boundary, cross-tenant expressibility, redaction on every
+   read path, ownership checks before storage access, new surfaces that turned out inert. This negative
+   space is half the deliverable: it is what lets the next reviewer skip what is settled and what makes
+   a later regression visible.
+
+10. **State what was not measured.** No image pulled, no layer scan, reachability inside third-party
+    libraries verified for which packages only, production env values not read. An unmeasured area is a
+    named gap, never silence.
+
+11. **Probe log.** Every live probe, read-only, with what was created and what was torn down. Exploit
+    demonstrations run **offline against the shipped source on localhost** — never against staging,
+    never against a third party. If nothing was created, say "nothing to tear down".
+
+12. **Assign a per-finding blocking verdict** using the rules below, and put the verdict table at the top
+    of the findings document.
+
+## Receipt
+
+`releases/v0.12.23/readiness/security-review.receipt.json`:
+
+```json
+{
+  "schema_version": 1,
+  "leg": "security-review",
+  "candidate_map_sha": "3422d02f02985ab0f02fc47f58a6b4b3e23f0163397f1073c004fe44624d764f",
+  "input_identity": "v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307 + deps@1f3c9ab27d40e6b8",
+  "result": "green",
+  "findings_ref": "https://github.com/Vexa-ai/vexa/issues/1179",
+  "generated_at": "2026-08-18T15:57:00Z",
+  "generated_by": "agent (readiness session · security-review)"
+}
+```
+
+```bash
+V=v0.12.23; mkdir -p releases/$V/readiness
+MAP_SHA=$(shasum -a 256 releases/$V/candidate-images.json | cut -d' ' -f1)
+jq -n --arg s "$MAP_SHA" --arg i "$IDENTITY" --arg r green --arg f "$FINDINGS_URL" \
+  '{schema_version:1,leg:"security-review",candidate_map_sha:$s,input_identity:$i,result:$r,
+    findings_ref:$f,generated_at:(now|todate),generated_by:"agent (readiness session)"}' \
+  > releases/$V/readiness/security-review.receipt.json
+node release/readiness/check.mjs --phase staging --release $V
+```
+
+A re-cut changes the map sha and the receipt goes `stale` — re-run the leg; the diff range may be
+unchanged but the shipped bytes are not.
+
+## Blocking-verdict discipline
+
+Every finding carries its own `Blocks?` cell in the findings table. The leg's `result` is `red` if any
+cell says yes.
+
+**RED — blocks the train:**
+- Reachable **unauthenticated**, at any severity.
+- Reachable **cross-tenant** — one account reading, writing or deleting another's data.
+- HIGH proven reachable by any authenticated account with **cross-tenant impact**, including availability
+  attacks on a shared control plane. This clause exists because the rc.18 run found the plain
+  cross-tenant-*path* rule missing exactly this class: one authenticated user OOMs `meeting-api` and
+  every tenant goes down with it.
+- A destructive primitive newly added to a channel whose writers are hostile-input-facing, with no
+  scope check.
+- Any HIGH left **unmeasured** — "probably not reachable" is not a verdict, and the leg cannot be green
+  while one exists.
+- A dependency vulnerability with a demonstrated first-party reachable path in a published image.
+
+**Rides to the next train, with a filed issue and a named owner:** authenticated, single-tenant HIGH
+where the fix is not trivial; MEDIUM / LOW / INFO; dependency alerts with no demonstrated path — carry
+the precondition sentence into the issue so the next review starts from it.
+
+**Fix in-train regardless of the verdict** when the patch is a few lines and closes a pre-existing
+exposure at the same time. Cheapness is a reason to fix, never a reason to downgrade.
+
+**Waivers:** founder only, per finding, recorded in the receipt's `waivers[]` with the finding id, the
+issue link, and the release it expires in. A waiver on an unmeasured finding is not available — measure
+first.
+
+## Failure modes
+
+- **Reviewing the design instead of the constant.** A guard whose structure is right and whose list is
+  missing one address family passes every design review and fails in production.
+- **Inferring reachability from a grep.** Greps establish *absence of a call site today*; they establish
+  nothing about a transport, a parser, or a redirect. Execute the shipped path.
+- **Trusting the repo SBOM as an image inventory.** It unions dev trees and non-shipping harnesses, and
+  it has misreported a shipped version.
+- **Assuming a client is dev-only.** The terminal is published and is baked into lite; every alert on its
+  tree rides into production images.
+- **Reviewing the wrong tree** — a stale working tree, or the reviewed head when the images were built
+  from a different commit.
+- **Closing a finding on a trust boundary that holds today.** "Redis is internal" was true and still left
+  a cross-meeting delete primitive on a channel written by containers that parse hostile meeting pages.
+- **A receipt bound to a stale candidate map, or to a pre-bump dependency identity** — the shipped bytes
+  changed and the review did not.

--- a/release/readiness/readiness.schema.json
+++ b/release/readiness/readiness.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vexa.ai/schemas/release/readiness.v1.json",
+  "title": "Production-readiness manifest and receipts",
+  "description": "Declarative shape of releases/<version>/readiness.yaml and its receipts at releases/<version>/readiness/<leg>.receipt.json. The authoritative validator is release/readiness/check.mjs — this document states the same contract for readers and for tools that do not run the checker; release/readiness/check.test.mjs asserts the two do not drift.",
+  "schema_version": 1,
+  "$defs": {
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "release", "candidate_map", "receipts_dir", "legs"],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "release": {
+          "type": "string",
+          "pattern": "^v\\d+\\.\\d+\\.\\d+$",
+          "description": "Stable release this manifest covers. Candidate suffixes are stripped before lookup."
+        },
+        "candidate_map": {
+          "type": "string",
+          "description": "Must be releases/<release>/candidate-images.json — the frozen map every receipt binds to."
+        },
+        "receipts_dir": {
+          "type": "string",
+          "description": "Must be releases/<release>/readiness."
+        },
+        "legs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/leg" },
+          "description": "Every one of the six standard legs must be represented; check.mjs refuses a manifest whose ordinals do not cover 1-6."
+        }
+      }
+    },
+    "leg": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "leg", "title", "kind", "phase", "oracle", "receipt", "identity"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$" },
+        "leg": {
+          "type": "string",
+          "pattern": "^[1-6][ab]?$",
+          "description": "Which of the six standard legs this row covers; a/b splits a leg with two oracles."
+        },
+        "title": { "type": "string", "minLength": 1 },
+        "kind": {
+          "enum": ["machine", "agent"],
+          "description": "machine legs are fired by a command; agent legs are executed by a session against a protocol document."
+        },
+        "phase": {
+          "enum": ["formation", "staging", "both"],
+          "description": "Firing point. A staging run requires every leg regardless of this value; formation requires formation and both."
+        },
+        "oracle": { "$ref": "#/$defs/oracle" },
+        "receipt": {
+          "type": "string",
+          "description": "Must be <receipts_dir>/<id>.receipt.json."
+        },
+        "identity": { "$ref": "#/$defs/identity" }
+      }
+    },
+    "oracle": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Exactly one of command | protocol. A machine leg declares a command; an agent leg declares a protocol document.",
+      "properties": {
+        "command": { "type": "string", "minLength": 1 },
+        "protocol": {
+          "type": "string",
+          "pattern": "^release/readiness/protocols/[a-z0-9-]+\\.md$"
+        }
+      },
+      "oneOf": [{ "required": ["command"] }, { "required": ["protocol"] }]
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["binds_candidate_map", "input", "stale_reason"],
+      "properties": {
+        "binds_candidate_map": {
+          "const": true,
+          "description": "Every leg binds the candidate map sha; a re-cut strands the receipt."
+        },
+        "input": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human statement of this leg's own input identity — what its receipt's input_identity names."
+        },
+        "input_pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional regular expression the receipt's input_identity must match."
+        },
+        "stale_reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why this leg's coverage stops describing the candidate once the map is re-cut. Rendered verbatim in the stale failure."
+        }
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "schema_version",
+        "leg",
+        "candidate_map_sha",
+        "input_identity",
+        "result",
+        "findings_ref",
+        "generated_at",
+        "generated_by"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "leg": { "type": "string", "description": "Must equal the manifest leg's id." },
+        "candidate_map_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "sha256 of the candidate map file's bytes at the time the leg ran."
+        },
+        "input_identity": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The leg's own input identity — diff range, docs tree sha, probed base URL, roster snapshot."
+        },
+        "result": { "enum": ["green", "red", "stale"] },
+        "findings_ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where the findings live: a GitHub URL or a repo-relative path. The receipt is a pointer plus a verdict."
+        },
+        "generated_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "generated_by": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "oneOf": [{ "$ref": "#/$defs/manifest" }, { "$ref": "#/$defs/receipt" }]
+}

--- a/releases/v0.12.23/readiness.yaml
+++ b/releases/v0.12.23/readiness.yaml
@@ -1,0 +1,116 @@
+# Production-readiness manifest — v0.12.23.
+#
+# The six legs of the readiness standard, each declaring what fires it, what proves it, where its
+# receipt lives, and what its receipt is bound to. Validated and enforced by
+# release/readiness/check.mjs; shape documented at release/readiness/readiness.schema.json.
+#
+# Leg 3 splits: 3a is the mechanical build/run proof the release-validate legs already give, 3b is
+# API coverage as of the docs — every documented endpoint probed against the staged candidate.
+#
+# Every leg binds the candidate map sha. Re-cutting the candidate re-writes
+# releases/v0.12.23/candidate-images.json, which strands every receipt taken against the old bytes:
+# check.mjs names those legs and prints the stale_reason declared here.
+
+schema_version: 1
+release: v0.12.23
+candidate_map: releases/v0.12.23/candidate-images.json
+receipts_dir: releases/v0.12.23/readiness
+
+legs:
+  - id: train-value
+    leg: '1'
+    title: TRAIN VALUE as of PRs
+    kind: machine
+    phase: formation
+    oracle:
+      command: RELEASE_VERSION=v0.12.23 node scripts/release-value-gate.mjs
+    receipt: releases/v0.12.23/readiness/train-value.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The batch range the value gate walked: <last shipped tag>...<this release>. Every PR in it carries a user-recognizable value sentence and a pass criterion, or is state: value-signed.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+$'
+      stale_reason: 'the batch is what the promote hands users; a re-cut can add or drop PRs, so the set of value sentences proven is no longer the set shipping'
+
+  - id: blast-radius
+    leg: '2'
+    title: BLAST RADIUS as of PRs
+    kind: agent
+    phase: formation
+    oracle:
+      protocol: release/readiness/protocols/blast-radius.md
+    receipt: releases/v0.12.23/readiness/blast-radius.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The exact diff the surface map was built from: <prev tag>..<candidate head sha>.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.[0-9a-f]{40}'
+      stale_reason: 'the per-PR diff-to-surface table describes a diff the re-cut candidate no longer ships, so its covering evidence and its named uncovered cells both stop applying'
+
+  - id: full-functionality
+    leg: '3a'
+    title: FULL FUNCTIONALITY — builds and runs (lite + compose)
+    kind: machine
+    phase: staging
+    oracle:
+      command: gh workflow run release-validate.yml -f version=<candidate> -f promote=false
+    receipt: releases/v0.12.23/readiness/full-functionality.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The release-validate run URL whose legs pulled the published candidate bytes.'
+      input_pattern: '^https://github\.com/Vexa-ai/vexa/actions/runs/\d+$'
+      stale_reason: 'the validate legs pull published image bytes by tag; a re-cut publishes different bytes under the candidate, so the run proved artifacts that are no longer the candidate'
+
+  - id: api-docs-sweep
+    leg: '3b'
+    title: FULL FUNCTIONALITY — API coverage as of docs
+    kind: agent
+    phase: staging
+    oracle:
+      protocol: release/readiness/protocols/api-docs-sweep.md
+    receipt: releases/v0.12.23/readiness/api-docs-sweep.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The documented surface swept and the deployment it was probed against: docs@<docs tree sha> against <base url>.'
+      input_pattern: '^docs@[0-9a-f]{40} against https?://\S+$'
+      stale_reason: 'the sweep probed a running deployment of specific image bytes; a re-cut changes those bytes, and a documented endpoint proven against the old ones is unproven against the new'
+
+  - id: security-review
+    leg: '4'
+    title: SECURITY review
+    kind: agent
+    phase: both
+    oracle:
+      protocol: release/readiness/protocols/security-review.md
+    receipt: releases/v0.12.23/readiness/security-review.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The reviewed diff plus the dependency state of the shipped images: <prev tag>..<candidate head sha> + deps@<lockfile sha256>.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.[0-9a-f]{40}'
+      stale_reason: 'new surfaces, authz paths and shipped-image dependencies are read out of the exact diff and the exact images; a re-cut can add either, and neither was reviewed'
+
+  - id: compliance-review
+    leg: '5'
+    title: COMPLIANCE review — legal, architecture, principles, delivery
+    kind: agent
+    phase: both
+    oracle:
+      protocol: release/readiness/protocols/compliance-review.md
+    receipt: releases/v0.12.23/readiness/compliance-review.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The reviewed diff plus the roster it was checked against: <prev tag>..<candidate head sha> + roster@<issue/PR snapshot>.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.[0-9a-f]{40}'
+      stale_reason: 'contract widening, sealed-gate state, changelog fragments and issue custody are all read off the exact commit set; a re-cut changes the commit set and the roster derived from it'
+
+  - id: promotion-ceremony
+    leg: '6'
+    title: PROMOTION CEREMONY — rehearsal receipts green and bound
+    kind: machine
+    phase: staging
+    oracle:
+      command: make check-promotion-legs validate-rehearsal-promotion-values
+    receipt: releases/v0.12.23/readiness/promotion-ceremony.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The rehearsal packet in Vexa-ai/vexa-platform whose four promotion legs rendered green in the scoped namespace, and whose carry rendered zero-diff against live prod.'
+      input_pattern: '^release-\d{3}-vexa-\d+\.\d+\.\d+\b'
+      stale_reason: 'the rehearsal rendered and applied the exact candidate digests; a re-cut changes those digests, so the rendered manifests and the zero-diff carry describe a promotion that is not the one about to happen'

--- a/releases/v0.12.23/readiness/README.md
+++ b/releases/v0.12.23/readiness/README.md
@@ -23,23 +23,32 @@ shasum -a 256 releases/v0.12.23/candidate-images.json   # → candidate_map_sha
 node release/readiness/check.mjs --phase staging --release v0.12.23
 ```
 
-## Status — receipts pending, deliberately not fabricated
+## Status — partial backfill, deliberately not completed
 
-**This directory is empty of receipts on purpose.** The six-leg coverage for v0.12.23-rc.18 was
-executed by hand — the train-value pass, the per-PR blast-radius map, the API sweep against staging,
-the security review, the compliance review, and the promotion rehearsal all ran, and their findings
-are what the harness was built from. Those reports live outside this repository today, and two of
-the reviews were still open when the harness landed.
+Two legs are covered. Five are not, and each is absent for a stated reason — a receipt written
+ahead of its finding is a false green, which is the single failure this harness exists to prevent.
 
-Receipts will be **backfilled from the completed reports**, one commit per leg, each carrying the
-`candidate_map_sha` of the candidate its report actually examined. Until a leg's report is final,
-its receipt does not exist — a receipt written ahead of its finding is a false green, which is the
-single failure this harness exists to prevent.
+| Leg | Receipt | Why |
+|---|---|---|
+| 3a `full-functionality` | ✅ green | `release-validate` run [32141246247](https://github.com/Vexa-ai/vexa/actions/runs/32141246247) — 9 legs SUCCESS, 3 SKIPPED (guarantee 7/8 + promote, none of them this leg's subject) |
+| 4 `security-review` | ✅ green | rc.18 review final: no unauthenticated and no cross-tenant path. Findings public as [#1231](https://github.com/Vexa-ai/vexa/issues/1231), [#1232](https://github.com/Vexa-ai/vexa/issues/1232), [#1233](https://github.com/Vexa-ai/vexa/issues/1233) |
+| 1 `train-value` | ⛔ none | **The leg has never run.** Its oracle exits 3 (*could not evaluate*): no `v0.12.23` tag exists on origin, so the batch `v0.12.22...v0.12.23` cannot be resolved and no truthful `input_identity` can be formed |
+| 2 `blast-radius` | ⛔ none | Report final and **red** (12 ranked uncovered cells, R1 prod-blocking), but its findings have no durable public home yet — see *Publication* below |
+| 3b `api-docs-sweep` | ⛔ none | Report final and **red** (5 release-blockers), same publication blocker |
+| 5 `compliance-review` | ⛔ none | Report final and **red** (2 blocking gaps, 2 founder-decision-needed — and *founder decision needed* is red, not green), same publication blocker. One slice is public as [#1234](https://github.com/Vexa-ai/vexa/issues/1234) |
+| 6 `promotion-ceremony` | ⛔ none | **Bound to rc.17, not rc.18.** The rehearsal packet `release-011-vexa-0.12.23` pins rc.17 digests and marks rc.18 a pending `LAST-MILE SUBSTITUTION POINT`; [vexa-platform#318](https://github.com/Vexa-ai/vexa-platform/pull/318) is open with `approved: false`, both rehearsals to be re-run, and the run-1/run-2 receipts deleted. **Re-run it — do not re-stamp it** |
 
-`check.mjs` therefore reports v0.12.23 as **not covered** until the backfill lands. That is the
-correct reading, not a harness defect: the readiness job on `release-validate` is advisory for this
-train (`continue-on-error: true`) and becomes blocking on the next one.
+### Publication
+
+Legs 2, 3b and 5 are final but their reports exist only as internal drafts. A receipt's
+`findings_ref` must point at a durable public artifact, so those three stay uncovered until their
+findings are published — as issues, or as `releases/v0.12.23/readiness/<leg>.md` in this repo.
+Publishing them is a disclosure decision, not a mechanical step: they carry unremediated findings.
+
+`check.mjs` therefore still reports v0.12.23 as **not covered**. That is the correct reading, not a
+harness defect: the readiness job on `release-validate` is advisory for this train
+(`continue-on-error: true`) and becomes blocking on the next one.
 
 Legs whose report examined a candidate older than the current
 [`../candidate-images.json`](../candidate-images.json) must be **re-run, not re-stamped** — the
-binding is the point.
+binding is the point. Leg 6 is exactly that case.

--- a/releases/v0.12.23/readiness/README.md
+++ b/releases/v0.12.23/readiness/README.md
@@ -1,0 +1,45 @@
+# v0.12.23 — readiness receipts
+
+One receipt per leg of [`../readiness.yaml`](../readiness.yaml), named `<leg>.receipt.json`, in the
+shape `release/readiness/readiness.schema.json` defines:
+
+```json
+{
+  "schema_version": 1,
+  "leg": "blast-radius",
+  "candidate_map_sha": "<sha256 of ../candidate-images.json>",
+  "input_identity": "v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307",
+  "result": "green",
+  "findings_ref": "https://github.com/Vexa-ai/vexa/issues/<n>",
+  "generated_at": "2026-08-18T15:57:00Z",
+  "generated_by": "agent (readiness session)"
+}
+```
+
+Bind the receipt to the candidate map it was taken against:
+
+```bash
+shasum -a 256 releases/v0.12.23/candidate-images.json   # → candidate_map_sha
+node release/readiness/check.mjs --phase staging --release v0.12.23
+```
+
+## Status — receipts pending, deliberately not fabricated
+
+**This directory is empty of receipts on purpose.** The six-leg coverage for v0.12.23-rc.18 was
+executed by hand — the train-value pass, the per-PR blast-radius map, the API sweep against staging,
+the security review, the compliance review, and the promotion rehearsal all ran, and their findings
+are what the harness was built from. Those reports live outside this repository today, and two of
+the reviews were still open when the harness landed.
+
+Receipts will be **backfilled from the completed reports**, one commit per leg, each carrying the
+`candidate_map_sha` of the candidate its report actually examined. Until a leg's report is final,
+its receipt does not exist — a receipt written ahead of its finding is a false green, which is the
+single failure this harness exists to prevent.
+
+`check.mjs` therefore reports v0.12.23 as **not covered** until the backfill lands. That is the
+correct reading, not a harness defect: the readiness job on `release-validate` is advisory for this
+train (`continue-on-error: true`) and becomes blocking on the next one.
+
+Legs whose report examined a candidate older than the current
+[`../candidate-images.json`](../candidate-images.json) must be **re-run, not re-stamped** — the
+binding is the point.

--- a/releases/v0.12.23/readiness/full-functionality.receipt.json
+++ b/releases/v0.12.23/readiness/full-functionality.receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "leg": "full-functionality",
+  "candidate_map_sha": "3422d02f02985ab0f02fc47f58a6b4b3e23f0163397f1073c004fe44624d764f",
+  "input_identity": "https://github.com/Vexa-ai/vexa/actions/runs/32141246247",
+  "result": "green",
+  "findings_ref": "https://github.com/Vexa-ai/vexa/actions/runs/32141246247",
+  "generated_at": "2026-08-18T15:41:08Z",
+  "generated_by": "agent (readiness backfill session · full-functionality)",
+  "notes": [
+    "release-validate run 32141246247 at validation_source 29eb4186: 9 legs SUCCESS (resolve, validate-mock-fsm, validate-v010-compat, validate-lite, validate-arm64, validate-bot-spawn, image-identity, validate-compose, validate-helm-k3s), 3 SKIPPED (value gate guarantee 8, witness gate guarantee 7, promote moving tag). The skipped three are not this leg's subject: guarantee 7/8 are human-only gates, and guarantee 8 is separately carried by the train-value leg.",
+    "The candidate map bytes moved after this run (31f8740b -> 3422d02f) solely to record this run's own validation_source/validation_run. No image digest, no candidate_tag and no build_source changed, so the candidate this run examined IS the candidate the current map describes; the receipt binds the current sha rather than the pre-freeze sha it could not have known.",
+    "OUT OF SCOPE, CARRIED BY blast-radius: candidate build run 32139430561 (release-images.yml) concluded FAILURE, so validate-bot-delta, validate-lite-delta-amd64, validate-lite-delta-arm64, candidate-delta-receipt and alias-candidate never ran for rc.18. Those legs belong to release-images.yml, not to this leg's declared oracle."
+  ]
+}

--- a/releases/v0.12.23/readiness/security-review.receipt.json
+++ b/releases/v0.12.23/readiness/security-review.receipt.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "leg": "security-review",
+  "candidate_map_sha": "3422d02f02985ab0f02fc47f58a6b4b3e23f0163397f1073c004fe44624d764f",
+  "input_identity": "v0.12.22..c93a24374c4337b226f74000dd5ca4d9fbcfe307",
+  "result": "green",
+  "findings_ref": "https://github.com/Vexa-ai/vexa/issues/1231",
+  "generated_at": "2026-08-18T15:41:08Z",
+  "generated_by": "agent (readiness backfill session · security-review)",
+  "notes": [
+    "Verdict as written by the rc.18 review: no blocking findings — nothing this train adds is reachable by an unauthenticated or a cross-tenant path. Secrets pass clean, injection pass clean. Three HIGH findings are authenticated and single-tenant, which under this leg's blocking-verdict discipline ride to the next train with filed issues and named owners.",
+    "Findings published as Vexa-ai/vexa#1231 (SSRF IPv4-mapped-IPv6 bypass, S1), #1232 (ICS fetch bounds + unbounded VEVENT count, S2/S3), #1233 (retract/disclosure + Next.js critical, S4/S5 + dependencies). findings_ref carries #1231; the other two are named here because the field takes one pointer.",
+    "Tree identity checked by the review: rc.18 images were built from c0571429 on release/0.12.23-rc.18-freeze, which is not a descendant of the reviewed c93a2437. git diff c93a2437 c0571429 returns four files — a workflow, a map test, the map, and the witness receipt — and NO source file differs, so every finding applies exactly to the built candidate.",
+    "IDENTITY GAP, disclosed: this leg's manifest input declares '<prev tag>..<candidate head sha> + deps@<lockfile sha256>'. The review recorded the dependency state as counts (56 open alerts: 2 critical / 27 high / 27 medium; 18 of 18 distinct vulns land in at least one published image; zero with a verified first-party reachable path) but never recorded a lockfile hash. The deps half is therefore absent from input_identity, which satisfies the declared regex but does NOT void this receipt on a dependency bump. Re-run the leg to restore the full binding."
+  ]
+}

--- a/releases/v0.12.24/readiness.yaml
+++ b/releases/v0.12.24/readiness.yaml
@@ -1,0 +1,116 @@
+# Production-readiness manifest — v0.12.24.
+#
+# The six legs of the readiness standard, each declaring what fires it, what proves it, where its
+# receipt lives, and what its receipt is bound to. Validated and enforced by
+# release/readiness/check.mjs; shape documented at release/readiness/readiness.schema.json.
+#
+# Leg 3 splits: 3a is the mechanical build/run proof the release-validate legs already give, 3b is
+# API coverage as of the docs — every documented endpoint probed against the staged candidate.
+#
+# Every leg binds the candidate map sha. Re-cutting the candidate re-writes
+# releases/v0.12.24/candidate-images.json, which strands every receipt taken against the old bytes:
+# check.mjs names those legs and prints the stale_reason declared here.
+
+schema_version: 1
+release: v0.12.24
+candidate_map: releases/v0.12.24/candidate-images.json
+receipts_dir: releases/v0.12.24/readiness
+
+legs:
+  - id: train-value
+    leg: '1'
+    title: TRAIN VALUE as of PRs
+    kind: machine
+    phase: formation
+    oracle:
+      command: RELEASE_VERSION=v0.12.24 node scripts/release-value-gate.mjs
+    receipt: releases/v0.12.24/readiness/train-value.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The batch range the value gate walked: <last shipped tag>...<this release>. Every PR in it carries a user-recognizable value sentence and a pass criterion, or is state: value-signed.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+$'
+      stale_reason: 'the batch is what the promote hands users; a re-cut can add or drop PRs, so the set of value sentences proven is no longer the set shipping'
+
+  - id: blast-radius
+    leg: '2'
+    title: BLAST RADIUS as of PRs
+    kind: agent
+    phase: formation
+    oracle:
+      protocol: release/readiness/protocols/blast-radius.md
+    receipt: releases/v0.12.24/readiness/blast-radius.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The exact diff the surface map was built from: <prev tag>..<candidate head sha>.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.[0-9a-f]{40}'
+      stale_reason: 'the per-PR diff-to-surface table describes a diff the re-cut candidate no longer ships, so its covering evidence and its named uncovered cells both stop applying'
+
+  - id: full-functionality
+    leg: '3a'
+    title: FULL FUNCTIONALITY — builds and runs (lite + compose)
+    kind: machine
+    phase: staging
+    oracle:
+      command: gh workflow run release-validate.yml -f version=<candidate> -f promote=false
+    receipt: releases/v0.12.24/readiness/full-functionality.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The release-validate run URL whose legs pulled the published candidate bytes.'
+      input_pattern: '^https://github\.com/Vexa-ai/vexa/actions/runs/\d+$'
+      stale_reason: 'the validate legs pull published image bytes by tag; a re-cut publishes different bytes under the candidate, so the run proved artifacts that are no longer the candidate'
+
+  - id: api-docs-sweep
+    leg: '3b'
+    title: FULL FUNCTIONALITY — API coverage as of docs
+    kind: agent
+    phase: staging
+    oracle:
+      protocol: release/readiness/protocols/api-docs-sweep.md
+    receipt: releases/v0.12.24/readiness/api-docs-sweep.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The documented surface swept and the deployment it was probed against: docs@<docs tree sha> against <base url>.'
+      input_pattern: '^docs@[0-9a-f]{40} against https?://\S+$'
+      stale_reason: 'the sweep probed a running deployment of specific image bytes; a re-cut changes those bytes, and a documented endpoint proven against the old ones is unproven against the new'
+
+  - id: security-review
+    leg: '4'
+    title: SECURITY review
+    kind: agent
+    phase: both
+    oracle:
+      protocol: release/readiness/protocols/security-review.md
+    receipt: releases/v0.12.24/readiness/security-review.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The reviewed diff plus the dependency state of the shipped images: <prev tag>..<candidate head sha> + deps@<lockfile sha256>.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.[0-9a-f]{40}'
+      stale_reason: 'new surfaces, authz paths and shipped-image dependencies are read out of the exact diff and the exact images; a re-cut can add either, and neither was reviewed'
+
+  - id: compliance-review
+    leg: '5'
+    title: COMPLIANCE review — legal, architecture, principles, delivery
+    kind: agent
+    phase: both
+    oracle:
+      protocol: release/readiness/protocols/compliance-review.md
+    receipt: releases/v0.12.24/readiness/compliance-review.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The reviewed diff plus the roster it was checked against: <prev tag>..<candidate head sha> + roster@<issue/PR snapshot>.'
+      input_pattern: '^v\d+\.\d+\.\d+\.\.[0-9a-f]{40}'
+      stale_reason: 'contract widening, sealed-gate state, changelog fragments and issue custody are all read off the exact commit set; a re-cut changes the commit set and the roster derived from it'
+
+  - id: promotion-ceremony
+    leg: '6'
+    title: PROMOTION CEREMONY — rehearsal receipts green and bound
+    kind: machine
+    phase: staging
+    oracle:
+      command: make check-promotion-legs validate-rehearsal-promotion-values
+    receipt: releases/v0.12.24/readiness/promotion-ceremony.receipt.json
+    identity:
+      binds_candidate_map: true
+      input: 'The rehearsal packet in Vexa-ai/vexa-platform whose four promotion legs rendered green in the scoped namespace, and whose carry rendered zero-diff against live prod.'
+      input_pattern: '^release-\d{3}-vexa-\d+\.\d+\.\d+\b'
+      stale_reason: 'the rehearsal rendered and applied the exact candidate digests; a re-cut changes those digests, so the rendered manifests and the zero-diff carry describe a promotion that is not the one about to happen'

--- a/releases/v0.12.24/readiness/README.md
+++ b/releases/v0.12.24/readiness/README.md
@@ -1,0 +1,85 @@
+# v0.12.24 — readiness receipts
+
+One receipt per leg of [`../readiness.yaml`](../readiness.yaml), named `<leg>.receipt.json`, in the
+shape [`release/readiness/readiness.schema.json`](../../../release/readiness/readiness.schema.json)
+defines. Bind each to the candidate map it was taken against:
+
+```bash
+shasum -a 256 releases/v0.12.24/candidate-images.json   # → candidate_map_sha
+node release/readiness/check.mjs --phase formation --release v0.12.24
+```
+
+## Status at formation — the manifest exists, no leg can be bound yet
+
+`check.mjs --release v0.12.24` currently stops before the leg table with one line:
+
+```
+readiness: no candidate map at releases/v0.12.24/candidate-images.json
+  — nothing to bind the readiness receipts to
+```
+
+That is the correct answer, not a gap to route around. **Every leg declares
+`binds_candidate_map: true`, and every receipt requires a `candidate_map_sha`** — so no receipt for
+this release can be written before a candidate exists. The candidate needs merged commits and a
+build run; at the time of writing **none of the train's twelve pull requests is merged**, and the
+merges are held by founder decisions, not by engineering (see
+[`DmitriyG228/biz#435`](https://github.com/DmitriyG228/biz/issues/435)).
+
+Writing the receipts anyway would mean inventing a binding. The v0.12.23 README states the rule this
+harness exists for, and it applies to its own operator: *a receipt written ahead of its finding is a
+false green.*
+
+| Leg | Receipt | Why not yet |
+|---|---|---|
+| 1 `train-value` | ⛔ none | No candidate map, and no `v0.12.24` tag: the batch `v0.12.23...v0.12.24` cannot be resolved, so the oracle cannot form a truthful `input_identity` |
+| 2 `blast-radius` | ⛔ none | Not run at this formation |
+| 3a `full-functionality` | ⛔ none | Staging leg; no candidate bytes to pull |
+| 3b `api-docs-sweep` | ⛔ none | Staging leg; nothing deployed to sweep |
+| 4 `security-review` | ⛔ none | **The review ran and is final — 🟢 green, no blocking finding.** Two blockers to binding, below |
+| 5 `compliance-review` | ⛔ none | **The review ran and is final — 🔴 red.** Most of its punch-list was cleared at formation (below); same two blockers to binding |
+| 6 `promotion-ceremony` | ⛔ none | Staging leg; no rehearsal packet for this release |
+
+### Legs 4 and 5 — two separate reasons neither can bind
+
+1. **No candidate map.** As above; and this leg's `input_pattern` is
+   `^v\d+\.\d+\.\d+\.\.[0-9a-f]{40}` — a *single* candidate head sha. At formation there are
+   **twelve unmerged heads and two different dependency hashes**, so no such sha exists to name.
+   The security review recorded this against itself rather than papering over it.
+2. **No durable public home for the findings.** A receipt's `findings_ref` must point at a durable
+   public artifact. Both reports exist only as drafts in a **private** repository and as comments on
+   a private issue. `Vexa-ai/vexa` is public; `DmitriyG228/biz` is not.
+
+**Publishing them is a disclosure decision, not a mechanical step** — it is the founder's call, not
+this session's. Either home works when made: issues on `Vexa-ai/vexa`, or
+`releases/v0.12.24/readiness/<leg>.md` in this repository.
+
+### What the two reviews are, stated plainly
+
+Both are **human formation artefacts**. `check.mjs` never executes a leg's oracle — it validates
+shape and binding only. **A receipt therefore proves that a review was bound to specific bytes; it
+never proves that the review happened, or that it was any good.** That is true of every agent leg in
+this manifest, and it is the reason the protocols are written down and the reports are readable.
+
+### Findings cleared at formation, before any candidate was cut
+
+The compliance verdict was red on a punch-list, and the punch-list was worked rather than deferred.
+Cleared and verified: two pull requests retargeted off a squash-merged base (by rebase — a bare
+retarget would have carried 223 files, not 15); two wrong auto-closes killed
+([#451](https://github.com/Vexa-ai/vexa/issues/451) and
+[#866](https://github.com/Vexa-ai/vexa/issues/866) both stay open, confirmed via
+`closingIssuesReferences`); customer material scrubbed out of
+[#1093](https://github.com/Vexa-ai/vexa/pull/1093)'s artefacts before they could reach this public
+repository; three false claims corrected in pull-request bodies; the `report_issue` credential hole
+closed with a red→green pair; `DELETE /recordings/{id}` scoped `BOT` so a read key cannot destroy;
+and **`contribution-rights` made a required check** — the structural finding, red on 8 of 11 pull
+requests while blocking nothing.
+
+### One finding against this harness itself
+
+The release number appears in **four** places in a manifest: `release`, `candidate_map`,
+`receipts_dir`, and the version pinned inside the `train-value` oracle's command. `check.mjs`
+guarded the first three and **not the fourth** — a manifest copied forward with a stale
+`RELEASE_VERSION=` still ran, against the *previous* release's batch, and reported green. Verified
+by mutating the v0.12.23 manifest, which printed
+`Oracle: RELEASE_VERSION=v0.12.22 …` under `--release v0.12.23` without complaint. Now guarded, with
+a test that fails without the guard.


### PR DESCRIPTION
Surfaces the stranded `readiness/harness` branch as a PR so it stops being invisible — built 2026-08-18 (2,425 lines: `release/readiness/check.mjs` + 624-line test suite, `readiness.schema.json`, all four agent-leg protocols, the v0.12.23 manifest, and receipts backfilled from the rc.18 reports), pushed, and never given a PR or blocker issue. 0.12.23 shipped with its six legs covered by hand-run session reviews while this codification sat unreachable; the `readiness` skill has been describing this branch as if merged.

**Not merge-ready as-is** — needs: a rebase onto current main (all-new files, expected near-clean), and a `releases/v0.12.24/readiness.yaml` manifest minted at that train's formation (the founder directed tonight that the train runs security/compliance/etc. validation — this is that machinery). The v0.12.23 files ride along as historical receipts. Intended to be taken by the 0.12.24 formation as a car.

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.

<!-- vexa-agent -->