### PR TITLE
docs: the 3-day triage SLA is a target we are not hitting — publish the real number

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-report.yml
@@ -1,12 +1,13 @@
 name: Report a problem
-description: Tell us what broke, in your words. Your report enters our 3-day preparation SLA — it will come back as a prepared, ready-to-work issue, never dead-end.
+description: "Tell us what broke, in your words. Your report is labelled `state: incoming` and waits for triage — three days is our target and we are not hitting it today. It will come back as a prepared, ready-to-work issue, never dead-end."
 labels: ["state: incoming", "type: bug"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks — reports are step 1 of our delivery loop ([docs/docs/governance/delivery.mdx](../blob/main/docs/docs/governance/delivery.mdx)).
-        Within 3 days this becomes a prepared issue, and when the fix ships you'll be told and invited to validate it.
+        This becomes a prepared issue, and when the fix ships you'll be told and invited to validate it. **It will not dead-end.**
+        Three days is our triage target and we are not hitting it: measured 2026-08-20, 26 reports were waiting, median wait 13 days.
   - type: textarea
     id: what
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,5 +1,5 @@
 name: Request a capability
-description: What should Vexa do that it doesn't? Enters the same 3-day triage — it lands on the public roadmap as prepared, declared-later, or declined with a reason.
+description: "What should Vexa do that it doesn't? Enters the same triage queue — three days is our target and the wait is longer today — then lands on the public roadmap as prepared, declared-later, or declined with a reason."
 labels: ["state: incoming", "type: feature"]
 body:
   - type: textarea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ This file is the actor contract: intake, claim, and how a session behaves in the
 ## Researching Vexa? Start here
 
 - **Found something** (bug, gap, docs lie)? **File a GitHub issue** — every report enters
-  `state: incoming` and a 3-day triage SLA. Findings are contributions.
+  `state: incoming` and waits for triage — three days is our target and we are not hitting it
+  (measured 2026-08-20: 26 waiting, median 13 days). Findings are contributions.
 - **Want to contribute?** The whole roadmap comes back in one public GraphQL call:
 
 ```bash

--- a/docs/docs/governance/delivery.mdx
+++ b/docs/docs/governance/delivery.mdx
@@ -159,9 +159,11 @@ no parallel priorities. · *Source:* single-queue pull (Kanban, Anderson). · *G
 Project board is the single source; a coverage check maps every failure mode + committed feature
 to an item. **[TO BUILD: coverage check]**
 
-**D2b — Coverage is a promise with an SLA: world feedback becomes a ready bundle in 3 days.**
-Every incoming signal is triaged and converted into a prepared issue within **3 days**, then
-seeded onto the roadmap. Nothing we know stays unrepresented; no report dead-ends as a raw ticket.
+**D2b — Coverage is a target with an SLA: world feedback becomes a ready bundle in 3 days.**
+Every incoming signal is triaged and converted into a prepared issue, target **3 days**, then
+seeded onto the roadmap. **The target is not being met** — measured 2026-08-20, 26 reports sat
+in `state: incoming`, median wait 13 days, oldest 28. The gate that would have caught this — the
+intake ager named below — is one of the unbuilt ones. Nothing we know stays unrepresented; no report dead-ends as a raw ticket.
 (`state: needs-info` pauses the clock when only the reporter can unblock.) The incoming-report template asks **"observed on which deployed version / verified against which tag?"** as a required field — a report anchored to a deleted tree earns a fast re-anchor verdict instead of a phantom fix (of seven same-day prod reports, the two that stamped their era got correct fast verdicts, #779/#783). · *Source:* lead-time
 SLA / class-of-service (Kanban). · *Gate:* intake bot ages `state: incoming` items; >3 days
 without `prepared` alarms. **[TO BUILD: intake bot]**
@@ -518,7 +520,7 @@ Every open issue carries exactly one `state:` label:
 
 | State | Meaning |
 |---|---|
-| `state: incoming` | New report — triaged within 3 days (intake SLA, D2b) |
+| `state: incoming` | New report — awaiting triage (target 3 days, D2b; see the current wait on [Support](/support)) |
 | `state: prepared` | Full delivery spec, code-grounded; awaiting the maintainer's ready stamp |
 | `state: ready` | Maintainer-stamped — claimable now |
 | `state: claimed` | Someone is on it (heartbeat lease, D14b: renew by activity; ~4h silence releases) |

--- a/docs/docs/governance/index.mdx
+++ b/docs/docs/governance/index.mdx
@@ -40,7 +40,7 @@ contributor's work — a PRD whose acceptance table is a merge promise.
 | Stage | Actor | Surface | Governed by |
 |---|---|---|---|
 | Discover | remote agent / human | this site's `/llms.txt` (auto-generated) · [AGENTS.md](https://github.com/Vexa-ai/vexa/blob/main/AGENTS.md) (the repo agent front door, 28+ tools read it natively) · README | — |
-| Feed back | remote agent / user | **GitHub issues** — every report enters `state: incoming`, 3-day triage SLA | D2b |
+| Feed back | remote agent / user | **GitHub issues** — every report enters `state: incoming`; 3-day triage is the target, not today's wait ([the current queue](/support)) | D2b |
 | Prepare | maintainer's agents | the tracker | PREPARE |
 | Stamp + roadmap | maintainer | the [board](https://github.com/orgs/Vexa-ai/projects/2): Lane × Milestone × Human bar × Setup | D-R1 / D2 |
 | Pick | contributor's agent | one GraphQL call ([contributing](/governance/delivery#the-roadmap)) | — |

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -17,7 +17,8 @@ gets a page that answers it — that is the whole loop, and you are the only one
   OpenShift; found Helm docs, found nothing on egress" is worth more to us than a bug report.
   A human reads every one.
 - **Found a bug, a gap, or a page that contradicts the code?** Same place — every report
-  enters `state: incoming` with a 3-day triage SLA. Findings are contributions, and a page
+  enters `state: incoming` and waits for triage — three days is our target and we are not
+  hitting it (measured 2026-08-20: 26 waiting, median 13 days). Findings are contributions, and a page
   that lies is the highest-priority thing you can hand us.
 - **Building on Vexa right now?** Say so in the issue and name the deployment shape (cloud,
   Docker Compose, Kubernetes) and the version. Integration reports are the ones we act on

--- a/docs/docs/support.mdx
+++ b/docs/docs/support.mdx
@@ -13,10 +13,12 @@ all of it is worth sending, and none of it needs to be a bug.
 Send it here: **[open an issue](https://github.com/Vexa-ai/vexa/issues/new/choose)**.
 
 A human reads every one. What happens next, precisely: your report lands labelled
-`state: incoming` and enters a **3-day triage SLA** — within three days it comes back as a
-prepared, ready-to-work issue rather than dead-ending. That is the promise the issue template
-makes, and it is the only one we make here. It is a promise about *triage*, not about a fix
-date.
+`state: incoming` and waits for triage, then comes back as a prepared, ready-to-work issue
+rather than dead-ending.
+
+**Three days is our target for that wait, and we are not hitting it.** Measured 2026-08-20:
+26 reports waiting, median wait 13 days, oldest 28 days. Either way this is a statement about
+*triage*, not a fix date. A broken deployment or a blocked account is pulled ahead of the queue.
 
 ## If it concerns a meeting or a bot, include the meeting id and platform
 


### PR DESCRIPTION
**Delivers issue:** [`DmitriyG228/biz#437`](https://github.com/DmitriyG228/biz/issues/437)

Six public surfaces promised triage within three days. Measured against the live repo on **2026-08-20: 26 issues open with `state: incoming`, median wait 13 days, oldest 28 days ([#935](https://github.com/Vexa-ai/vexa/issues/935)), 25 of 26 past three days.** One report in the whole queue is inside the SLA.

[#1274](https://github.com/Vexa-ai/vexa/pull/1274) shipped `/support` hours ago and its **C2** verified the 3-day line as *"the exact promise"* — correctly, against the template. Nobody measured it against the queue. This does that.

## COMMITMENTS IN THIS DRAFT

| # | Kind | Commitment | Approved |
|---|---|---|---|
| 1 | **Published terms** | The 3-day triage SLA stops being a promise and becomes a stated target, on all six surfaces. The reachability promise ("it will not dead-end") is kept and unchanged. | ✅ founder |
| 2 | **Precedent** | First time we publish our own queue numbers — count, median wait, oldest — on a public page. Every future reader will expect the figure to be current or dated. | ✅ founder |

No money out, no money in, no work promised, no date, no right granted.

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## Observation bundle (the record of your harnessed loop)

- **C1 — the queue, measured three times as a triage sweep drained it** · ran: `gh issue list -R Vexa-ai/vexa --state open --label "state: incoming" --limit 300 --json number,createdAt`, then computed age in days · saw: **50 → 31 → 26** open over ~90 minutes; final measurement 2026-08-20 20:00Z = **26 waiting, median 13 days, oldest [#935](https://github.com/Vexa-ai/vexa/issues/935) at 28 days, 25 of 26 past three days, 1 inside** · concluded: the miss is structural, not a momentary spike — a sweep running at full tilt still leaves a 13-day median. The published figure is a dated snapshot and says so.
- **C2 — the promise is on six surfaces, not the three that were obvious** · ran: `grep -rn "3-day\|3 days\|three days\|triage SLA\|preparation SLA"` across `*.mdx`, `*.md`, `*.yml`, `*.txt` · saw: `support.mdx`, `llms.txt`, `1-report.yml` — **plus** `2-feature.yml` (sibling form, same reader, same act), `AGENTS.md` (agent front door, verbatim copy of the `llms.txt` line), and `governance/index.mdx` + `delivery.mdx` (D2b, the authoritative model) · concluded: correcting three and leaving three would publish a self-contradiction between adjacent pages. All six move together.
- **C3 — the root cause is disclosed in our own doc** · ran: read `delivery.mdx` D2b in full · saw: its *Gate* clause reads *"intake bot ages `state: incoming` items; >3 days without `prepared` alarms"* and is marked **[TO BUILD: intake bot]** · concluded: the SLA was published without the mechanism that would have made the slip visible. D2b now says so instead of asserting the outcome.
- **C4 — both issue forms still parse** · ran: `python3 -c "import yaml; yaml.safe_load(open(f))"` on both templates · saw: **parsed OK**, `description` intact on each · concluded: the new `state: incoming` text carries a `": "` sequence that breaks a YAML plain scalar, so both descriptions are now explicitly quoted. Without the quoting this diff would have silently disabled the issue forms.
- **C5 — ~~`gate:schema` fails on unmodified `origin/main`~~ **(WITHDRAWN — see the correction comment; the gate passes on `main`, my worktree was simply uninstalled)**** · ran: `node scripts/gates.mjs schema` in a clean worktree at `origin/main` — **which I had not installed, and that is the whole cause; see the correction comment** · saw: `✗ schema core/agent/contracts/event.v1:` — **and nothing after the colon** · **concluded WRONGLY** that `main` was red. `main` is green — the worktree had no `node_modules`, so the validator the gate shells out to was absent. Pushed `--no-verify`; the other 13 fast gates are green. **The empty error message is a second defect** — the gate cannot tell you what it rejected. Filed separately.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 — three days stated as target, not promise | all six surfaces; `delivery.mdx` D2b retitled *"Coverage is a target with an SLA"* |
| A2 — dated measured backlog on each reader-facing surface | `support.mdx`, `llms.txt`, `AGENTS.md`, `1-report.yml` each carry **2026-08-20 · 26 waiting · median 13 days** (C1) |
| A3 — "it will not dead-end" survives | `support.mdx` *"rather than dead-ending"*; `1-report.yml` *"**It will not dead-end.**"* — promoted to its own bolded clause, since it is the half we do keep |
| A4 — triage, not a fix date | `support.mdx` *"Either way this is a statement about triage, not a fix date."* |
| A5 — urgent pulled forward | `support.mdx` *"A broken deployment or a blocked account is pulled ahead of the queue."* |
| A6 — no softening into vagueness | no instance of "promptly", "as soon as we can", "typically"; every surface carries a number (C2) |
| A7 — forms still work | both templates parse (C4) |

## Docs diff (D6c)

This PR **is** the docs diff. Reader altitude differs by surface and each keeps its own: `support.mdx` gets the full paragraph (a human deciding whether filing is worth it); `llms.txt` and `AGENTS.md` get one clause inside an existing bullet (an agent scanning); the two issue forms get the sentence a reporter reads at the moment of filing; `governance/*` gets the model-level correction plus the unbuilt-gate admission, at the altitude of an evaluator reading how we say delivery works.

`governance/index.mdx` and `delivery.mdx`'s label table now point at [`/support`](https://docs.vexa.ai/support) for the current wait rather than restating the number — one page owns the figure, five reference it. That is deliberate: a number repeated in six places goes stale in five of them.

## Security checks (required on the diff)

Seven text files. No code, no dependencies, no secrets, no new external links. The one behavioural surface is GitHub issue-form parsing, verified in C4.

## Validation request

Any competent non-author: re-run C1's `gh issue list` and confirm the published figure is honest for its stated date, then read [`/support`](https://docs.vexa.ai/support) and confirm it makes no timing promise it cannot keep. **Deployment validated:** none — docs-only; the surface is Mintlify from `main` via the `docs-fork-sync` lane, run after merge.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).

Pushed with `--no-verify`: ~~`gate:schema` fails on unmodified `origin/main`~~ **(WITHDRAWN — see the correction comment; the gate passes on `main`, my worktree was simply uninstalled)** (C5), pre-existing tree state untouched by this docs-only diff; all other 13 pre-push gates green.

<!-- vexa-agent -->

