### PR TITLE
fix(meetings): converge a stuck 'stopping' meeting on stop_grace (split of #1014)

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py
@@ -349,11 +349,18 @@ async def reconcile_stale_nonterminal_sweep(
             runtime, bot_container_id, meeting_id=meeting_id, log=log
         )
         if verdict != "confirmed":
+            # A `stopping` row = a stop was EXPLICITLY requested; the bot is meant to be leaving. Once
+            # its workload is untracked (the runtime has nothing left to tear down), converge it on the
+            # SHORT stop_grace, not the long untracked window. This is the restart-mid-leave case: on the
+            # process backend the bot dies WITH the runtime, so without this a `stopping` row sits
+            # untracked for the full untracked_grace (10 min default) — and the in-process window resets
+            # on every restart, so a redeploy burst can keep it stuck ~indefinitely (the observed bug).
+            esc_grace = stop_grace if status == "stopping" else untracked_grace
             if verdict == "untracked" and _untracked_window_elapsed(
-                tracker, meeting_id, seen_untracked, grace=untracked_grace, now=now
+                tracker, meeting_id, seen_untracked, grace=esc_grace, now=now
             ) and await _escalate_untracked_zombie(
                 meeting_id, status, session_uid, bot_container_id, post_lifecycle,
-                tracker, grace=untracked_grace, log=log, stop_requested=stop_requested,
+                tracker, grace=esc_grace, log=log, stop_requested=stop_requested,
             ):
                 reconciled += 1
             continue

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -951,10 +951,12 @@ def test_continuous_untracked_past_window_escalates_once_with_evidence():
     assert repo._meetings[m["id"]]["status"] == "failed"
 
 
-def test_stopping_untracked_past_window_escalates_too():
+def test_stopping_untracked_past_window_escalates_on_stop_grace():
     """The `stopping` zombie (user pressed Stop, then the runtime restarted on the process backend):
-    the teardown stays unconfirmable (404) forever — past the window it converges to `failed`
-    instead of retrying the dead DELETE every sweep for eternity."""
+    the teardown stays unconfirmable (404) forever. A stop was EXPLICITLY requested, so it converges
+    on the SHORT stop_grace — NOT the long untracked window — instead of sitting stuck for 10 min (or,
+    across a redeploy burst that keeps resetting the in-process window, ~forever). The restart-mid-
+    leave stuck-meeting fix."""
     repo = InMemoryMeetingRepo()
     m = _seed(repo, status="stopping")
     repo._meetings[m["id"]]["bot_container_id"] = "wl-gone"
@@ -963,10 +965,12 @@ def test_stopping_untracked_past_window_escalates_too():
     client = TestClient(create_app(meeting_repo=repo))
     tracker: dict = {}
 
-    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=0.0) == 0
+    # untracked_grace stays LONG (a live *active* bot keeps its full patience); a `stopping` row
+    # converges on stop_grace regardless — proving it's the short window driving the escalation.
+    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=600.0, stop_grace=0.0) == 0
     assert repo._meetings[m["id"]]["status"] == "stopping"  # window opened
 
-    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=0.0) == 1
+    assert _run_general_sweep_esc(client, repo, runtime, tracker, untracked_grace=600.0, stop_grace=0.0) == 1
     assert repo._meetings[m["id"]]["status"] == "failed"
     assert runtime.deleted == []
 

--- a/docs/changelog.d/1014-lifecycle.md
+++ b/docs/changelog.d/1014-lifecycle.md
@@ -1,0 +1,2 @@
+- **Two meeting-state fixes (#1014).** Restarting while a bot is still leaving no longer leaves the meeting
+  stuck in "stopping", and the "Meeting ended" banner no longer flashes over a still-live meeting.

--- a/docs/changelog.d/1014-lifecycle.md
+++ b/docs/changelog.d/1014-lifecycle.md
@@ -1,2 +1,0 @@
-- **Two meeting-state fixes (#1014).** Restarting while a bot is still leaving no longer leaves the meeting
-  stuck in "stopping", and the "Meeting ended" banner no longer flashes over a still-live meeting.

--- a/docs/changelog.d/1280-stopping-converge.md
+++ b/docs/changelog.d/1280-stopping-converge.md
@@ -1,0 +1,3 @@
+- **Restarting mid-leave no longer strands a meeting in "stopping" (#1280).** When Vexa restarted while a
+  bot was still leaving, the meeting could sit in "stopping" — shown as active — indefinitely across a
+  redeploy burst. A meeting whose stop was explicitly requested now converges on the short stop grace.


### PR DESCRIPTION
**Delivers issue:** _none — this is a maintainer split of [#1014](https://github.com/Vexa-ai/vexa/pull/1014), carrying one of its commits unchanged._

## Provenance

[#1014](https://github.com/Vexa-ai/vexa/pull/1014) carries two independent fixes. @DmitriyG228 asked for it to be broken up:

> this PR is doing too many things and says too little about that, need to break down
>
> — [#1014 (comment)](https://github.com/Vexa-ai/vexa/pull/1014#issuecomment-5361560631)

This is the first slice: **one commit, @jbschooley's, taken verbatim with authorship preserved.**

| | |
|---|---|
| **Commit** | [`9403e4ce`](https://github.com/Vexa-ai/vexa/commit/9403e4cea1593549484ab72988fff30a48f32edf) — `fix(meetings): converge a stuck 'stopping' meeting on stop_grace, not the untracked window` |
| **Author** | @jbschooley (`Jacob Schooley <jacob@schooley.com>`) — **unchanged**, including the original author date |
| **Diff** | byte-identical to `9403e4ce`. The only edit is a maintainer `Signed-off-by` trailer appended **alongside** the author's, which the DCO check requires of the committer |
| **Base** | cherry-picked onto `origin/main` — **no conflicts** |

Files: `core/meetings/services/meeting-api/src/meeting_api/lifecycle/reconcile.py` (+9/−2) · `core/meetings/services/meeting-api/tests/test_lifecycle_seam.py` (+9/−5) · one changelog fragment.

### What it fixes

A `stopping` row had a stop **explicitly requested** — the bot is meant to be leaving. When Vexa restarts mid-leave, the fresh runtime 404s the old worker, so the workload reads *untracked* and the escalation waited the full `untracked_grace` (10 min default). That window is in-process, so it **resets on every restart** — across a redeploy burst the row never accumulated a full window and sat stuck in `stopping` (shown active in the UI) indefinitely.

The fix escalates a `stopping` row's untracked workload on the short `stop_grace` instead. `active` / pre-active keep the conservative `untracked_grace` — a quiet-but-live bot must not be reaped.

### What was NOT taken, and where it lives

| Commit | Concern | Where it is |
|---|---|---|
| [`a17879cc`](https://github.com/Vexa-ai/vexa/commit/a17879cc04224d61b1d3b6285f84ffa135d5174a) | premature 'Meeting ended' banner | **stays in [#1014](https://github.com/Vexa-ai/vexa/pull/1014)** — it touches `bot_spawn/*` (rewritten since this branch was cut) and reaches into the agent control plane, so it needs its own review rather than riding this one |
| `62e183f6`, `23db8f6e` | recording / audio completeness | already their own PR — [#1013](https://github.com/Vexa-ai/vexa/pull/1013) |
| `13cb52ab` | runtime-configurable default bot name | already their own PR — [#1012](https://github.com/Vexa-ai/vexa/pull/1012) |
| `1639aadd` | noble base image + non-root interpreter exec | already their own PR — [#1011](https://github.com/Vexa-ai/vexa/pull/1011) |

Nothing was dropped and nothing was rewritten. [#1014](https://github.com/Vexa-ai/vexa/pull/1014) stays open and stays @jbschooley's.

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

**Why this box is ticked here, explicitly:** the certification is the **author's**, not the splitter's. @jbschooley ticked **Independent** on [#1014](https://github.com/Vexa-ai/vexa/pull/1014) for the branch containing this exact commit, and the commit is carried here unchanged. This PR adds no new authored content, so that attestation is what stands behind it — this box mirrors his, it does not replace it. His DCO `Signed-off-by` rides on the commit; mine is the committer's.

## Observation bundle (the record of your harnessed loop)

- **C1 — the whole service suite, on this head.** ran: `uv run --frozen pytest -q` in `core/meetings/services/meeting-api` · saw: `1154 passed, 5 skipped, 1 warning in 18.81s` · concluded: the change is green across the whole modular monolith, not just its own file.
- **C2 — negative control, so the test is proven load-bearing.** ran: restored `reconcile.py` to `origin/main` (fix removed), kept the new test, ran `pytest tests/test_lifecycle_seam.py -k stopping_untracked` · saw: `1 failed` — `test_stopping_untracked_past_window_escalates_on_stop_grace`, with the reconciler logging `termination UNCONFIRMED … NOT advancing the meeting` twice and the row still `stopping` · then restored the fix and saw `1 passed` · concluded: the test fails red without the source change and green with it, so it is actually pinning the behaviour and not passing vacuously. The test holds `untracked_grace=600.0` **long** and `stop_grace=0.0` short, which is what proves the short window is the one driving the escalation.
- **C3 — the lifecycle seam in isolation.** ran: `pytest tests/test_lifecycle_seam.py -q` · saw: `111 passed, 2 skipped` · concluded: no neighbouring lifecycle invariant regressed — in particular the `active` / pre-active rows still keep the conservative window.
- **C4 — the pre-push static gate suite.** ran: all 14 fast gates (`readme dataflow isolation isolation-py exports graph graph-py schema contract-version config-contract licenses execution-env test-isolation contract-conformance`) · saw: all green, push accepted — `✓ pre-push: static gates green` · concluded: no structural, contract, isolation or licence regression.

**Not claimed here:** the live behaviour. The restart-mid-leave convergence was witnessed by @jbschooley on his own self-hosted lite deployment and is recorded on [#1014](https://github.com/Vexa-ai/vexa/pull/1014); this PR does not re-witness it, and does not restate his observation as its own.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 — a `stopping` row whose workload is untracked converges on `stop_grace`, not `untracked_grace` | C2 — red without the fix, green with it, with `untracked_grace` deliberately held at 600s |
| A2 — `active` / pre-active rows keep the conservative `untracked_grace` (a quiet-but-live bot is not reaped) | C3 — `test_untracked_blip_does_not_escalate` and the rest of the seam suite still green |
| A3 — the commit is the author's, unmodified | `git show` diff compared line-for-line against `9403e4ce`: identical; `Author:` field unchanged |

## Docs diff (D6c)

One changelog fragment: `docs/changelog.d/1280-stopping-converge.md`.

The source commit's fragment (`1014-lifecycle.md`) announced **both** of [#1014](https://github.com/Vexa-ai/vexa/pull/1014)'s fixes in one bullet. Shipping it unchanged would put a banner fix into the release notes that this PR does not contain, so it is renamed to this PR and narrowed to the fix actually delivered — in a **separate maintainer commit**, so @jbschooley's commit stays byte-identical.

No other docs surface changes: the graces are internal reconciler tuning with no documented knob.

## Security checks (required on the diff)

- `gate:licenses` green (460 deps OSS-clean); **no dependency added, removed or moved**.
- No secrets and no new authority: the diff is 11 lines of Python in one service plus test and changelog text; nothing reads config, env or credentials.
- Blast radius: `reconcile_stale_nonterminal_sweep` only. It narrows *when* an already-`stopping`, already-untracked row escalates. It cannot reach a row that is not both.

## Validation request

Any competent non-author. What to watch: restart the runtime while a bot is mid-leave on the process backend and confirm the row converges to `failed` within `stop_grace` instead of hanging in `stopping` across a redeploy burst — and, as the negative control, that a quiet-but-live `active` bot is still *not* reaped inside `untracked_grace`.

**Deployment (D12b):** the source observation was on @jbschooley's self-hosted **lite** deployment, on his branch — provenance is his, on [#1014](https://github.com/Vexa-ai/vexa/pull/1014). This PR's own evidence above is the test and gate suite on this head against `origin/main` @ `7e35da6e`; no deployment was run for it, and none is claimed.

**Not for merge yet** — held for the maintainer's release sequencing.

## Authorship

**Author: @jbschooley.** The commit is his, carried verbatim, with his author identity and DCO sign-off intact. This PR authors no product code — it is a split, opened by @DmitriyG228 so the reconciler fix can be reviewed on its own merits without the concerns it was stacked with. The one maintainer-authored commit is the changelog-fragment rename described above.

<!-- vexa-agent -->
