### PR TITLE
docs(readme): the front door now says what the docs say — hosted first, and four claims the tree does not support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 
 # Vexa
 
-**Open-source, self-hosted meeting bot & transcription API.**
+**Open-source meeting bots and real-time transcription — cloud or fully self-hosted.**
 
-A bot joins your Google Meet, Microsoft Teams, Zoom, and Jitsi calls and streams speaker-attributed
-transcripts in real time through an API *you* host — then feeds sandboxed agents that build a
-Markdown knowledge base your team owns. Self-hosted, Apache-2.0, air-gap-ready.
+A bot joins your Google Meet, Microsoft Teams, and Zoom calls and streams speaker-attributed
+transcripts in real time — through our API or one *you* host — then feeds sandboxed agents that build
+a Markdown knowledge base your team owns. Apache-2.0, air-gap-ready. (Jitsi: join + capture
+offline-proven, live validation pending — [#883](https://github.com/Vexa-ai/vexa/issues/883).)
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.12-informational.svg)](#-status--roadmap)
-[![Self-hosted](https://img.shields.io/badge/deploy-self--hosted-success.svg)](#-quickstart)
+[![Version](https://img.shields.io/badge/version-0.12-informational.svg)](#️-status--roadmap)
+[![Deploy](https://img.shields.io/badge/deploy-cloud%20or%20self--hosted-success.svg)](#-quickstart)
 [![Discord](https://img.shields.io/badge/chat-Discord-5865F2.svg)](https://discord.gg/Ga9duGkVz9)
 
 **[vexa.ai](https://vexa.ai)** runs Vexa 0.12 for meeting bots and transcription.
@@ -30,9 +31,10 @@ your meetings become.
 
 No one else has all three:
 
-1. **Vexa is *in* the meeting.** A real bot joins Meet, Teams, Zoom, and Jitsi and streams
-   speaker-attributed transcripts live. That bot fleet is the genuinely hard part — every
-   "chat with your docs" tool starts *after* a transcript exists. Vexa produces it.
+1. **Vexa is *in* the meeting.** A real bot joins Meet, Teams and Zoom — Jitsi offline-proven, live
+   validation pending — and streams speaker-attributed transcripts live. That bot fleet is the
+   genuinely hard part — every "chat with your docs" tool starts *after* a transcript exists. Vexa
+   produces it.
 
 2. **Your knowledge is files you own.** Meetings compile into Markdown in a git repo —
    portable, diffable, greppable. Knowledge as code.
@@ -46,28 +48,25 @@ No one else has all three:
 
 ---
 
-## Table of contents
-
-- [Quickstart](#-quickstart)
-- [How it works](#-how-it-works)
-- [The agentic runtime](#-the-agentic-runtime)
-- [Agents & your workspace](#-agents--your-workspace)
-- [The Terminal: AI-augmented meetings](#️-the-terminal-ai-augmented-meetings)
-- [How-to recipes](#-how-to-recipes)
-- [Deployment options](#-deployment-options)
-- [Deploy & configure](#-deploy--configure)
-- [How Vexa is different](#-how-vexa-is-different)
-- [For regulated enterprises](#-for-regulated-enterprises)
-- [API reference](#-api-reference)
-- [Status & roadmap](#-status--roadmap)
-- [Community & contributing](#-community--contributing)
-- [License](#-license)
-
----
-
 ## ⚡ Quickstart
 
-Self-host the whole stack on one host, then explore it in the Terminal or drive it over the API.
+**Just want a bot in a meeting?** Use the hosted service — no install. Sign in at
+[vexa.ai/signin](https://vexa.ai/signin), copy your key from [your account page](https://vexa.ai/account),
+and send a bot:
+
+```bash
+curl -X POST "https://api.cloud.vexa.ai/bots" \
+  -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"platform":"google_meet","native_meeting_id":"abc-defg-hij","bot_name":"Vexa"}'
+```
+
+New accounts get **$5 of free bot credit, no card required** — about 16 hours of bot time at
+$0.30/hr ([pricing](https://vexa.ai/pricing)). More calls: [Send a bot](https://docs.vexa.ai/how-to/send-a-bot).
+
+### Or self-host the whole stack
+
+That is also how you get the agent plane, which is not part of the hosted service.
+Self-host on one host, then explore it in the Terminal or drive it over the API.
 Linux (Ubuntu 24.04) is the production target; a Mac with Docker Desktop works fine for a local
 evaluation — everything runs in containers either way.
 
@@ -77,14 +76,14 @@ air-gapped setup. By default `POST /bots` **requires** STT and answers **503** w
 (`make all` warns when the credentials block in `.env` is empty). Capture-only is an explicit opt-out:
 `{"transcribe_enabled": false}` on the spawn (or set `TRANSCRIBE_ENABLED=false` for the deployment).
 
-> **Build machine:** The full stack (`make all`) requires at least **8 vCPUs and 16 GB RAM**. A smaller
-> box can run `make lite` (the single-container all-in-one image) but `make all` (Docker Compose) will
-> likely fail or timeout. `make lite` is the lighter path for resource-constrained hosts.
+> **Build machine:** `make all` **pulls** the published, release-validated images — no build, so a
+> modest box is fine. `make lite` (the single-container all-in-one image) is lighter still. Building
+> from this checkout instead (`make dev`, for contributors) wants **8 vCPUs and 16 GB RAM**.
 
 ```bash
 git clone https://github.com/Vexa-ai/vexa.git && cd vexa
-make all      # full Docker Compose stack — seeds .env, builds, prints your API key + URLs
-make bot      # build the meeting bot from source (required before a bot can join)
+make all      # full Docker Compose stack — seeds .env, pulls the images (bot included),
+              # prints your API key + URLs. Contributors: `make dev` builds from this checkout.
 ```
 
 When `make all` finishes it prints your key and URLs:
@@ -199,7 +198,7 @@ work: connect your calendar (ICS) and planned meetings appear with attendees —
 
 > **Status (honest):** capture, transcription, and speaker attribution are **production**; the
 > agent dispatch core is **built and proven live** end-to-end. What's still landing is tracked in
-> [Status](#-status--roadmap).
+> [Status](#️-status--roadmap).
 
 ---
 
@@ -269,7 +268,7 @@ curl -X POST "$API_BASE/agent/events" -H "X-API-Key: $API_KEY" -H "Content-Type:
 
 > **Live-meeting copilot** — cards for people, decisions, and action items *during* the call
 > (`POST /agent/meeting/start` → stream `GET /agent/meeting/stream`) — is on the roadmap; see
-> [Status](#-status--roadmap).
+> [Status](#️-status--roadmap).
 
 ---
 
@@ -295,7 +294,7 @@ multiuser from the start. One compliance rule when you go multiuser: other users
 on an **API key** (Commercial Terms), never a personal subscription credential — the
 [licensing page](https://docs.vexa.ai/model-credentials-licensing) spells out the boundary, and
 Settings → Models enforces per-user/global credential resolution. K8s backend status is tracked
-honestly in [Status](#-status--roadmap).
+honestly in [Status](#️-status--roadmap).
 
 ---
 
@@ -319,8 +318,8 @@ container, bound to loopback:
   Or use a free hosted token at [vexa.ai/account](https://vexa.ai/account) while testing.
 - **Bring your own inference** — point the agent at your own LLM endpoint; no inference leaves the network.
 - **Air-gapped** — everything in-VPC, **zero egress** — the posture the regulated verticals require.
-- **Targets** — `make all` · `make bot` (build the bot image from source — required, not pulled) ·
-  `make lite` · `make up` / `make down` · `make help`. Expose the Terminal via a TLS reverse proxy for
+- **Targets** — `make all` (pulls) · `make dev` (builds from this checkout) · `make lite` ·
+  `make probe` (full-journey smoke) · `make down` · `make help`. Expose the Terminal via a TLS reverse proxy for
   production; full guide in the [docs](https://docs.vexa.ai).
 
 ---
@@ -338,7 +337,7 @@ Against the tools developers actually weigh for meeting capture:
 |---|:---:|:---:|:---:|
 | Self-hosted / own your data | ✅ | ❌ their cloud | ✅ |
 | Real-time transcript API | ✅ | ✅ | 🟡 build it |
-| Joins **Meet + Teams + Zoom + Jitsi** | ✅ | 🟡 varies | ❌ enormous effort |
+| Joins **Meet + Teams + Zoom + Jitsi** | ✅ 3 production · 🟡 Jitsi | 🟡 varies | ❌ enormous effort |
 | Speaker attribution | ✅ | ✅ | 🟡 build it |
 | Knowledge as files you own | ✅ | ❌ | 🟡 build it |
 | Agents over your workspace | ✅ | ❌ | ❌ |
@@ -350,8 +349,9 @@ And it's *complementary* to the document-RAG and "second brain" tools — feed t
 attributed transcripts and let them do what they're good at.
 
 The full field — including [Attendee](https://github.com/attendee-labs/attendee) (the other
-open-source meeting-bot API) and the local-notetaker tools — is mapped honestly, trade-offs and
-all, in [How Vexa compares](https://docs.vexa.ai/comparison).
+meeting-bot API, source-available under the **Elastic License 2.0**, which does not permit providing
+it to third parties as a hosted or managed service) and the local-notetaker tools — is mapped
+honestly, trade-offs and all, in [How Vexa compares](https://docs.vexa.ai/comparison).
 
 ---
 
@@ -370,7 +370,7 @@ Companion** on the axes they structurally can't move:
 | Models | Vendor-hosted, fixed | **Bring your own** — local or hosted LLMs |
 | Commercial model | Rented, per-seat subscription | **Owned** — Apache-2.0, no per-seat tax |
 | Adaptable | Generic; no custom vocabulary; vendor roadmap queue | **Your engineers extend it directly** — domain vocabulary, underserved languages, custom workflows |
-| Meeting platforms | Teams-only / Zoom-only | **Meet + Teams + Zoom + Jitsi** |
+| Meeting platforms | Teams-only / Zoom-only | **Meet + Teams + Zoom** (+ Jitsi, live validation pending) |
 | Data control | Transits the vendor's cloud | **Never leaves your perimeter** |
 | Extensibility | Closed black box | Open source, API-first |
 
@@ -424,7 +424,9 @@ Two APIs behind the gateway, authenticated with `X-API-Key`. Base URL: `http://l
 | `POST` | `/agent/events` | Fire an integration event that dispatches an agent (e.g. email triage) |
 | `GET` | `/agent/workspace/tree` · `/agent/workspace/file` | Browse and read your Markdown workspace |
 
-`platform` ∈ `google_meet` · `teams` · `zoom` · `jitsi`. Full reference: **[docs.vexa.ai](https://docs.vexa.ai)**.
+`platform` ∈ `google_meet` · `teams` · `zoom` · `jitsi`. The gateway also serves an **MCP endpoint**
+at `/mcp` for agent clients ([docs](https://docs.vexa.ai/vexa-mcp)). Full reference:
+**[docs.vexa.ai](https://docs.vexa.ai)**.
 
 > **v0.12 note:** live bot-control — `PUT /bots/{…}/config` (change language/task mid-call) and
 > `POST /bots/{…}/speak` (TTS into the call) — plus the live-meeting copilot (`/agent/meeting/*`) and
@@ -435,13 +437,13 @@ Two APIs behind the gateway, authenticated with `X-API-Key`. Base URL: `http://l
 
 ## 🗺️ Status & roadmap
 
-Honest state of the **0.12** line (mirrors the [status page](https://docs.vexa.ai) — never aspirational):
+Honest state of the **0.12** line (mirrors the [status page](https://docs.vexa.ai/roadmap/status) — never aspirational):
 
 | Capability | State |
 |---|---|
 | Bot joins **Meet / Teams / Zoom** | ✅ Production |
 | Bot joins **Jitsi Meet** (meet.jit.si + self-hosted) | 🆕 Built & offline-proven; live validation pending |
-| Real-time transcription (Whisper) + speaker attribution | ✅ Production |
+| Real-time transcription (Whisper) + speaker attribution | ✅ Production — attribution is not guaranteed: the binder publishes an empty speaker rather than guessing (~4–7% of rows under heavy crosstalk) |
 | Redis transcript streaming | ✅ Production |
 | Recordings to your own object storage (MinIO) | ✅ Available |
 | **Runtime — Docker backend** (container per workload) | ✅ Production |
@@ -466,7 +468,7 @@ Honest state of the **0.12** line (mirrors the [status page](https://docs.vexa.a
 - **Discord** — [discord.gg/Ga9duGkVz9](https://discord.gg/Ga9duGkVz9)
 - **Roadmap** — the [board](https://github.com/orgs/Vexa-ai/projects/2), grouped by contributor
   lane, with [milestones](https://github.com/Vexa-ai/vexa/milestones) as the version gates.
-- **Contributing** — [how delivery works](docs/docs/governance/delivery.mdx): prepared issues
+- **Contributing** — [how delivery works](https://docs.vexa.ai/governance/delivery): prepared issues
   with acceptance tables that *guarantee* merge, and human validation credited as a first-class
   contribution (one page, law and how-to together).
 - **Contributor rights** — [one rights choice plus DCO](CONTRIBUTOR_RIGHTS.md) for individuals;

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -76,8 +76,8 @@ them.
 
 ```bash
 git clone https://github.com/Vexa-ai/vexa.git && cd vexa
-make all      # full stack via Docker Compose — seeds .env, brings everything up, prints your API key + URLs
-make bot      # build the meeting bot from source — needed before a bot can join a meeting
+make all      # full stack via Docker Compose — seeds .env, pulls the published images
+              # (bot included), brings everything up, prints your API key + URLs
 ```
 
 The API comes up at `http://localhost:18056` (gateway) and the terminal web


### PR DESCRIPTION
**Delivers issue:** — (README claim + coherence audit under standing docs authority; the counterpart of [`#1265`](https://github.com/Vexa-ai/vexa/pull/1265) / [`#1266`](https://github.com/Vexa-ai/vexa/pull/1266) / [`#1267`](https://github.com/Vexa-ai/vexa/pull/1267) on the surface those PRs did not touch)

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

## What

Today the docs front door was rewritten to lead with the wedge — *"Open-source meeting bots and
real-time transcription — cloud or fully self-hosted"* — and `/quickstart` + `/how-to/send-a-bot`
now lead with the **hosted** on-ramp. Nobody checked the README. It still led *"clone the repo"*,
and it still carried claims that [`#1265`](https://github.com/Vexa-ai/vexa/pull/1265) and
[`#1266`](https://github.com/Vexa-ai/vexa/pull/1266) removed from `docs/` but never from here.

The README is the #2/#3 referrer to the docs and the first thing an evaluator — or a coding agent
fetching raw markdown — reads. Every change below is a **claim removal, a claim downgrade, or a
broken link**. One capability is *named* that was already live and already documented (MCP); no new
capability is claimed and no platform is dropped.

### 1. Four claims the tree does not support

| Claim in the README | Ground truth |
|---|---|
| Lede: *"joins your Google Meet, Microsoft Teams, Zoom, and Jitsi calls and streams speaker-attributed transcripts in real time"*; *"Why Vexa"* bullet 1 repeats it; comparison table `Joins Meet + Teams + Zoom + Jitsi \| ✅`; enterprise table `Meet + Teams + Zoom + Jitsi` | **The README's own Status table, 8 rows below, says `Built & offline-proven; live validation pending`.** It contradicted itself on the same page. Qualified in all four places, wording taken verbatim from [`#1265`](https://github.com/Vexa-ai/vexa/pull/1265) / [`#883`](https://github.com/Vexa-ai/vexa/issues/883). Jitsi is qualified, not removed. |
| *"[Attendee] (the other **open-source** meeting-bot API)"* | Attendee is **Elastic License 2.0** — source-available, not OSI open source ([`#1266`](https://github.com/Vexa-ai/vexa/pull/1266)). A factual error about a third party's licence, and it also gave away our sharpest differentiator: we are the only permissively-licensed one. |
| *"The full stack (`make all`) requires at least **8 vCPUs and 16 GB RAM**. A smaller box … will likely fail or timeout."* | `make all` **pulls** published images. The 8/16 floor belongs to `make dev`. This told every evaluator they needed a bigger machine than they do, at the exact moment they decide whether to try it. |
| *"`make bot` — build the meeting bot from source (**required** before a bot can join)"* and *"required, not pulled"* | The install pulls the published bot. `make bot` is the contributor build path. The same stale line was on `docs/docs/index.mdx` and is removed there too. |

### 2. Coherence with the front door

- **Positioning sentence + deploy badge** now match the sentence already published on
  `docs/docs/index.mdx`. This adopts an existing decision; it does not make a new one.
- **Quickstart leads with the hosted call** — sign in, copy key, one `curl`, $5 credit, no card —
  then `### Or self-host the whole stack`, which is where the agent plane still lives. Mirrors
  `docs/docs/quickstart.mdx` § *"Just want a bot in a meeting?"*.
- **Speaker attribution** carries [`#1265`](https://github.com/Vexa-ai/vexa/pull/1265)'s third
  correction: the binder publishes an empty speaker rather than guessing, ~4–7% of rows under
  heavy crosstalk. The README said `✅ Production`, full stop.
- **MCP** is named once, in the API reference. It has been live on the hosted gateway since
  2026-07-24 ([`#1267`](https://github.com/Vexa-ai/vexa/pull/1267)) and the README did not mention
  it at all — the one surface an agent reads to learn how to connect.

### 3. Broken links

- `#-status--roadmap` — **dead in 5 places** (the version badge + 4 body cross-references). GitHub
  keeps the U+FE0F variation selector from `## 🗺️` in the slug, so the real id is
  `#️-status--roadmap`. `#-the-agentic-runtime` was dead the same way.
- `[status page](https://docs.vexa.ai)` pointed at the docs **root**, not
  [`/roadmap/status`](https://docs.vexa.ai/roadmap/status).
- `[how delivery works](docs/docs/governance/delivery.mdx)` pointed at the `.mdx` **source** rather
  than the published page.
- The hand-maintained **table of contents** is dropped: GitHub renders its own heading outline, it
  duplicated it, and it held two of the dead anchors. That is what pays for the hosted block —
  **net +2 lines** across the whole file.

## Observation bundle

- **C1 —** ran: read `README.md` at `origin/main` against `docs/docs/index.mdx`,
  `how-to/send-a-bot.mdx`, `quickstart.mdx`, `comparison.mdx` and `llms.txt` on the same commit ·
  saw: the README leads *self-hosted / `git clone`*, all five docs surfaces lead *cloud or
  self-hosted / one API call*; the README asserts Jitsi as a peer platform in 4 places while its own
  Status table at `README.md:445` denies it; `llms.txt` already lists only *"Google Meet / Microsoft
  Teams / Zoom"* · concluded: the README is the last surface still telling the old story, and it
  contradicts itself internally.
- **C2 —** ran: `curl raw.githubusercontent.com/attendee-labs/attendee/main/LICENSE` (re-confirming
  [`#1266`](https://github.com/Vexa-ai/vexa/pull/1266)) · saw: `Elastic License 2.0`, with the
  limitation *"You may not provide the software to third parties as a hosted or managed service"* ·
  concluded: *"the other open-source meeting-bot API"* is false as written.
- **C3 —** ran: `sed -n '1,45p' Makefile` and `grep -n 'up:|bot:|pull' deploy/compose/Makefile` ·
  saw: `Makefile:10` — *"make all   full Docker Compose stack from the **PUBLISHED images (bot
  included — pulled)**"*; `Makefile:27` — `make bot` is *"(dev path; install pulls the published
  bot)"*; `deploy/compose/Makefile:11` — *"Install pulls the published bot (vexaai/vexa-bot:v012)"*,
  and `up:` at `:70-79` runs `$(COMPOSE) pull` + `docker pull "$$_bi"` · concluded: both the 8/16
  build-machine warning and the *"`make bot` required"* instruction are false; `docs/quickstart.mdx`
  already says the correct thing, `docs/index.mdx` did not.
- **C4 —** ran: extracted every link in the README and issued `curl -sL -o /dev/null -w %{http_code}`
  against all 25 external URLs · saw: **all 200** — including
  [`/vexa-mcp`](https://docs.vexa.ai/vexa-mcp), [`/roadmap/status`](https://docs.vexa.ai/roadmap/status)
  and [`/governance/delivery`](https://docs.vexa.ai/governance/delivery), the three targets this PR
  introduces or re-points · concluded: no external link is broken; the broken ones were internal.
- **C5 —** ran: `curl -sL https://github.com/Vexa-ai/vexa | grep -o 'id="user-content-[^"]*"'` ·
  saw: the rendered ids are `user-content-️-status--roadmap` and `user-content-️-the-agentic-runtime`
  (**with** U+FE0F), while the README linked `#-status--roadmap` / `#-the-agentic-runtime`
  (**without**) · concluded: 6 in-page links were dead against the live rendered page, not
  theoretically. Re-checked after the edit: **0 broken anchors**.
- **C6 —** ran: probed the hosted base URL this PR now puts in the first code block —
  `POST https://api.cloud.vexa.ai/bots` and `/mcp` with no key · saw: `401` on both,
  `GET /bots/status` → `401` · concluded: the gateway and the MCP endpoint are live and the
  documented base URL is real, not aspirational.
- **C7 —** ran: `grep -rn "vexa-webapp|Vexa-Dashboard|services/dashboard"` over `origin/main` ·
  saw: **no hit** in any tracked file · concluded: the known-dead `github.com/Vexa-ai/vexa-webapp`
  pointer (confirmed `404`) is **not** carried by this repo — it lives on the `vexa.ai` website and
  the archived `Vexa-ai/Vexa-Dashboard` description, neither of which is fixable from here. Flagged,
  not fixed.

## Acceptance floor

| Row | Evidence |
|---|---|
| No claim survives that the tree contradicts | C1, C2, C3 — Jitsi qualified in all 4 places, Attendee licence corrected, both `make` claims corrected against `Makefile` + `deploy/compose/Makefile` |
| No new capability claimed | The only addition is the MCP endpoint, live since 2026-07-24 and already documented at [`/vexa-mcp`](https://docs.vexa.ai/vexa-mcp) ([`#1267`](https://github.com/Vexa-ai/vexa/pull/1267)) |
| Every link resolves | C4 (25/25 external → 200) + C5 (0 broken internal anchors, re-verified post-edit) |
| The README does not get longer | 485 → 487 lines; the hosted on-ramp is paid for by the duplicated table of contents |
| The README and the docs front door tell one story | Positioning sentence, deploy shape, first action and Jitsi status now match `docs/docs/index.mdx` + `/quickstart` + `/how-to/send-a-bot` + `/comparison` |

## Docs diff (D6c)

`docs/docs/index.mdx` — the *Try it* block carried the same false `make bot` line as the README
(*"needed before a bot can join a meeting"*). Corrected in the same commit so the two front doors
cannot disagree again. `docs/docs/quickstart.mdx` needed no change: it already says `make all`
pulls and that `make dev` is the 8/16 build path — it was the page that revealed the README was
wrong.

## Security checks (required on the diff)

No code, no dependencies, no configuration. Two markdown files; the only executable text is a
`curl` example against the already-public hosted gateway, carrying `$API_KEY` as a shell variable
and no literal credential.

## Validation request

Any competent non-author, on the rendered GitHub page: confirm the version badge and the four
*"see Status"* cross-references now scroll to the Status table (they did not before), that the
first code block is the hosted one-call, and that no remaining sentence presents Jitsi as
production or Attendee as open source. **Deployment validated (D12b):** none required — docs-only.
Link and anchor evidence in C4/C5/C6 was gathered against the live `docs.vexa.ai`,
`api.cloud.vexa.ai` and the rendered `github.com/Vexa-ai/vexa` page at `7e35da6e`.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
