### PR TITLE
docs(adr): authorized Zoom join goes through RTMS, not the Meeting SDK — ZAK is a Cat-X credential we cannot ship (#1289)

### DIFF
--- a/docs/adr/0035-authorized-zoom-join.md
+++ b/docs/adr/0035-authorized-zoom-join.md
@@ -1,0 +1,130 @@
+# ADR 0035 — Authorized Zoom join goes through RTMS, not the Meeting SDK (P17)
+
+**Status:** proposed · 2026-08-20 · constrained by **P17** (ADR-0004) · decides
+[#1289](https://github.com/Vexa-ai/vexa/issues/1289) · selects
+[#706](https://github.com/Vexa-ai/vexa/issues/706)
+
+## Context
+
+Vexa joins Zoom through **Zoom's own first-party web client** and nothing else.
+`buildZoomWebClientUrl()` rewrites `zoom.us/j/<id>?pwd=…` to `app.zoom.us/wc/<id>/join`, and
+`joinZoomMeeting()` drives that page with Playwright — type a guest name, clear the consent banner,
+grant mic, click Join
+([`core/meetings/modules/join/src/zoom/join.ts`](../../core/meetings/modules/join/src/zoom/join.ts)).
+There is a second identity mode, `BotConfig.authenticated`, but it is not an API credential: it is a
+**persistent Chromium profile whose cookies a human placed there by signing in once over VNC**
+([`@vexa/remote-browser` `provisionLogin()`](../../core/meetings/modules/remote-browser/src/login.ts)).
+One shared Zoom identity, provisioned by hand, reused across bots.
+
+Neither mode is an *authorized* join in Zoom's sense. We hold **no ZAK, no On-Behalf-Of (OBF) token,
+no join token, and no OAuth grant from the meeting's account.** The word "authorized" here is Zoom's:
+a participant whose entry is backed by a credential the host's account issued.
+
+Zoom is closing the door on the unauthorized path, and our own code already watches it close.
+`detectZoomBotBlock()` matches the wall Zoom serves to automated browsers —
+
+> "We detected you may be a bot. Automated bots aren't allowed to join this meeting or webinar and
+> must use Zoom RTMS. … Sign in to join"
+
+— and fails fast with the reason `zoom_requires_rtms`
+([`zoom/admission.ts`](../../core/meetings/modules/join/src/zoom/admission.ts)). That wall is keyed to
+the meeting/account, not to IP reputation: verified identical from a datacenter IP and a residential
+IP on the same meeting. **The sanctioned path is named in the error text by Zoom itself.**
+
+Meanwhile [`attendee-labs/attendee`](https://github.com/attendee-labs/attendee), the closest
+open-source competitor, ships "ZAK token, OnBehalf token and Join token support" on its public
+roadmap. This is the one named platform capability a direct OSS competitor advertises and we do not,
+and it lands on `send-a-bot-to-the-meeting` — **558 clean docs reads**, our fourth-most-read job
+([`job-matrix.yaml`](https://github.com/DmitriyG228/biz/blob/main/graph/traffic/read-models/job-matrix.yaml)).
+
+So the obvious move is "add ZAK." **The obvious move is not available to us, and the reason is
+structural rather than a matter of effort.**
+
+**ZAK and OBF are Meeting SDK credentials.** Zoom's authorization docs define them only against the
+Meeting SDK; there is no parameter by which `app.zoom.us/wc/` accepts one
+([Meeting SDK authorization](https://developers.zoom.us/docs/meeting-sdk/auth/)). Adopting ZAK is
+therefore not a patch to our join path — **it is replacing Zoom's web client with the Zoom Meeting
+SDK as our client stack.**
+
+And the Meeting SDK is proprietary. Zoom grants a *"limited, revocable, non-exclusive,
+non-transferable, non-assignable, non-sublicensable"* licence, retains all IP, and **prohibits
+sublicensing and redistribution**; third-party distribution needs written approval
+([Zoom API License and Terms of Use](https://www.zoom.com/en/trust/legal/zoom-api-license-and-tou/)).
+**P17** forbids exactly this: *"source-available/proprietary … are forbidden. The platform must drop
+into a regulated org with zero licence encumbrance"*
+([architecture.mdx](../docs/governance/architecture.mdx), enforced by `gate:licenses` per ADR-0004).
+[`zoom/README.md`](../../core/meetings/modules/join/src/zoom/README.md) already records the call in
+one line: *"No native Zoom SDK (proprietary, Cat-X under P17 — deliberately not promoted)."*
+
+The cost is not abstract. Vexa is Apache-2.0 and self-hostable, and `self-host-vexa` is our
+**most-read job at 972 reads**, the one coordinate where the field survey calls us *"provably ahead —
+only Apache-2.0 bot API at scale."* A non-sublicensable SDK cannot ship inside an Apache-2.0
+self-hostable image; every self-hoster would have to accept Zoom's SDK terms themselves.
+**Matching Attendee on ZAK by vendoring the Meeting SDK would trade our strongest position for our
+fourth-strongest.** That is the trade this ADR exists to refuse.
+
+## Decision
+
+**Authorized Zoom access goes through Zoom RTMS (Realtime Media Streams). We do not vendor the Zoom
+Meeting SDK, and we do not implement ZAK, OBF, or join tokens.**
+
+Three consequences follow directly.
+
+**1. RTMS is a lane, not a join.** RTMS delivers live audio, video, and transcript data
+server-side over a WebSocket, driven by `meeting.rtms_started` / `meeting.rtms_stopped` webhooks. It
+is reachable with **native WebSockets** — no `zoom/rtms` C++ wrapper, which would re-import the
+Cat-X problem ([RTMS docs](https://developers.zoom.us/docs/rtms/),
+[native WebSockets guide](https://developers.zoom.us/blog/realtime-mediastreams-websockets/)). No
+browser enters the meeting, so no bot appears in the participant list and the anti-bot wall is not
+in the path. The lane's build is [#706](https://github.com/Vexa-ai/vexa/issues/706); this ADR settles
+*which* lane, not how it is built.
+
+**2. RTMS is per-tenant, and that is a product fact, not a detail.** RTMS requires a **General App**
+in the Zoom Marketplace (Server-to-Server OAuth and Webhook-only apps do not work), installed **on
+the account whose meetings are streamed**, with auto-start enabled under *"Auto-start apps that
+access shared realtime meeting content"*, holding `meeting:rtms:read` plus per-medium scopes
+([getting started](https://developers.zoom.us/docs/rtms/meetings/getting-started/)). So RTMS covers
+**a customer's own meetings**, once their admin installs our app. It does **not** cover pasting an
+arbitrary external Zoom link. Anyone promising "authorized join for any Zoom URL" on the back of RTMS
+is promising something RTMS does not do.
+
+**3. The web client stays, and keeps its two modes.** RTMS does not replace the browser join; it
+covers the meetings the browser cannot legitimately enter. Anonymous guest join remains the default
+for meetings that permit it. The `authenticated` cookie-profile mode remains for meetings requiring a
+signed-in user. Both are licence-clean and neither is deprecated by this decision.
+
+**The honest capability statement**, which supersedes any "we support Zoom" shorthand:
+
+| Path | Credential | Covers | Licence | Ships in self-host |
+|---|---|---|---|---|
+| Web client, anonymous | none | meetings that admit guests | clean | ✅ today |
+| Web client, `authenticated` | human-provisioned cookie profile | meetings requiring a signed-in user | clean | ✅ today |
+| **RTMS** | OAuth General App installed on the **customer's** account | that customer's own meetings, incl. bot-blocked ones | clean (native WebSocket) | ✅ planned |
+| Meeting SDK + ZAK/OBF | OAuth → ZAK/OBF | external meetings, authorized | **Cat X — refused** | ❌ never |
+
+## Consequences
+
+- **Two live docs pages currently promise the opposite and must be corrected when this ADR is
+  accepted.** [`changelog.mdx:80`](../docs/changelog.mdx) says BYO OBF/ZAK plus the native SDK path is
+  *"planned back in the 0.12.x Zoom track"*, and
+  [`roadmap/status.mdx:118`](../docs/roadmap/status.mdx) carries the same row. Both predate the P17
+  reading above. They are rows A2/A3 of [#1289](https://github.com/Vexa-ai/vexa/issues/1289) and are
+  deliberately **not** changed by this ADR's own PR — the docs should not assert a decision that is
+  still `proposed`.
+- **We will not reach ZAK parity with Attendee, by choice, and we say so publicly.** The comparison
+  is not "Attendee has a feature we lack" but "Attendee vendors a proprietary SDK and we do not."
+  Any `/comparison` or docs claim on this must state the licence reason; silence reads as a gap.
+- **`zoom_requires_rtms` currently degrades on the way out.** The join layer knows the exact cause and
+  passes it to `callBlockedCallback`, but the `AdmissionError` it throws carries outcome `denial`, so
+  it lands in `CompletionReason.AWAITING_ADMISSION_REJECTED`
+  ([`lifecycle/machine.py`](../../core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py))
+  — indistinguishable from a host clicking Deny. An operator cannot tell "this meeting needs RTMS"
+  from "the host refused us," which is precisely the signal that would tell a customer to install the
+  app. A distinct terminal reason is the smallest useful follow-on.
+- **A Zoom Marketplace General App becomes a product surface we own** — listing, review, scopes,
+  install flow, per-tenant credential storage. That is onboarding and trust-boundary work
+  (ADR-0003), not just an ingest lane.
+- **This ADR is revisited only if Zoom relicenses the Meeting SDK permissively, or ships an
+  authorized join credential usable without it.** Neither is on their public roadmap today.
+- **Not decided here:** the RTMS ingest implementation, its mapping onto the meeting lifecycle, or
+  whether the hosted plane offers it before self-host. Those belong to the ingest issue.


### PR DESCRIPTION
**Delivers issue:** #1289 (row A1 only — A2–A5 are deliberately undone, see *What this does not do*)

---

## COMMITMENTS IN THIS DRAFT

| # | Kind | Commitment | Needs a go |
|---|---|---|---|
| 1 | **Published terms** | The ADR states we will **never** ship the Zoom Meeting SDK / ZAK / OBF path. It lands `Status: proposed` and no user-facing page repeats it in this PR — but merging an ADR is how this repo makes a decision binding. | **Yes** — this is the founder's ruling, not mine. |
| 2 | **A precedent** | First ADR to refuse a competitor-visible capability on licence grounds. The second such refusal becomes policy whether or not anyone writes it down. | **Yes** |
| 3 | **Work we will do** | Names RTMS (#706) as the lane we intend to build. No date, no scope, no resourcing. | **Yes** — it is a direction, not a schedule. |

Money out: none. Money in: none. Dates: none. Rights granted: none.

---

## What this PR actually delivers

One file: `docs/adr/0035-authorized-zoom-join.md`. It settles **which** authorized-Zoom path we take,
and records why the obvious one is closed to us.

The finding that drives it: **ZAK and OBF are Meeting SDK credentials.** Zoom defines them only
against the Meeting SDK and `app.zoom.us/wc/` accepts neither
([Meeting SDK authorization](https://developers.zoom.us/docs/meeting-sdk/auth/)). So "add ZAK" is not
a patch to `zoom/join.ts` — it is swapping Zoom's web client for the proprietary Zoom Meeting SDK,
which Zoom licenses *"non-sublicensable"* with redistribution forbidden
([API License and ToU](https://www.zoom.com/en/trust/legal/zoom-api-license-and-tou/)). **P17**
classifies that as Category X. `zoom/README.md` already recorded the call in one line; the ADR
supplies the reasoning, the sources, and the consequence.

It also publishes the honest four-path capability table (anonymous web · authenticated web · RTMS ·
Meeting SDK-refused) and states RTMS's product constraint plainly: RTMS needs a General App
**installed on the customer's own Zoom account**, so it covers *their* meetings, not an arbitrary
pasted link.

## What this does not do — read this before reviewing

- **It does not implement anything.** No RTMS adapter, no ingest, no code at all. #706 owns the build.
- **It does not correct the two docs pages that currently promise the opposite.**
  `docs/docs/changelog.mdx:80` says BYO OBF/ZAK plus the native SDK path is *"planned back in the
  0.12.x Zoom track"*; `docs/docs/roadmap/status.mdx:118` carries the same row. Both are wrong under
  this ADR. **They are left alone on purpose** — docs should not assert a decision whose ADR is still
  `proposed`. Rows A2/A3 of #1289 pick them up once this is accepted.
- **It does not add a terminal reason for `zoom_requires_rtms`.** The join layer knows the exact cause
  and passes it to `callBlockedCallback`, but the `AdmissionError` it throws carries outcome `denial`,
  so it lands in `CompletionReason.AWAITING_ADMISSION_REJECTED` — indistinguishable from a host
  clicking Deny. Logged as a consequence in the ADR; not fixed here.
- **It does not touch `core/meetings/modules/join/src/zoom/README.md`** — PR #1073 is already editing
  that file. Checked before writing.

Full ZAK/OnBehalf support is a train-sized feature. This is the decision that says we are not building
it, and what we build instead. That is the whole increment.

## Contribution rights

Not selected. **Rights box left for the founder — agents do not sign attestations.**

- [ ] **Independent** <!-- rights:independent -->
- [ ] **Employer/client authorization required** <!-- rights:corporate -->
- [ ] **Unsure** <!-- rights:uncertain -->

## Observation bundle

- **C1 — established what we actually do on Zoom today.** Ran: read
  `core/meetings/modules/join/src/zoom/{join,admission,selectors}.ts`, `_host.ts`, and
  `core/meetings/modules/remote-browser/src/{index,login}.ts`. Saw: `buildZoomWebClientUrl()` rewrites
  to `app.zoom.us/wc/<id>/join`; a second mode `BotConfig.authenticated` exists but is a **persistent
  Chromium profile whose cookies a human placed there over VNC**, not an API credential; zero
  occurrences of ZAK, OBF, join token, signature, or SDK. Concluded: "web-client-only" is right, but
  incomplete — there are two identity modes, and neither is authorized in Zoom's sense.
- **C2 — established why ZAK is not simply unbuilt.** Ran: fetched Zoom's Meeting SDK auth docs, the
  OBF FAQ, and the API License and ToU. Saw: ZAK/OBF are Meeting-SDK-only, and the SDK licence is
  non-sublicensable with redistribution forbidden. Cross-read `docs/adr/0004` and
  `docs/docs/governance/architecture.mdx:65` (P17). Concluded: the gap is created by a gated
  architectural decision, not by missing effort — and vendoring the SDK would break the Apache-2.0
  self-host story that is our most-read job (972 reads).
- **C3 — checked the gap is not already filed.** Ran: read #706, #938, #1061, #515, #966 in full plus
  nine keyword searches (`ZAK`, `RTMS`, `zoom oauth`, `zoom sdk`, `join token`, `meeting_token`,
  `OnBehalfOf`, `zoom marketplace`, `zoom in:title`). Saw: #706 **is** the RTMS lane and owns the
  build; #938 lists "Meeting SDK or RTMS authorization" under *Explicitly unclaimed* and terminated
  `no_lawful_candidate`; #1061 is a signed-out browser profile. The *decision* is recorded nowhere.
  Concluded: file #1289 for the decision, do not duplicate #706, and sharpen #706 by comment instead.
- **C4 — collision check before writing.** Ran: `gh pr view --json files` on the four open Zoom PRs
  (#1073, #1018, #967, #957) and `git log origin/main -- .../zoom/`. Saw: **#1073 already edits
  `zoom/README.md`.** Concluded: branch from fresh `origin/main`, touch only `docs/adr/`, leave the
  Zoom README to #1073.
- **C5 — gate run, and an unexpected finding.** Ran: `git push` in a fresh worktree. Saw:
  `pre-push: gate:schema FAILED`. Ran `pnpm gate:schema` directly → pnpm installed deps, then
  `✓ gate:schema — 25 contract(s) conform (goldens ≡ schema)`, `✅ gates green`. Concluded: the ADR
  did not fail the gate; **the fresh worktree had no `node_modules`, and a missing install is
  indistinguishable from a real violation** — an independent live reproduction of #1279. Pushed clean
  after install; no `--no-verify` used.

## Acceptance floor

| Row (from #1289) | Evidence |
|---|---|
| A1 — ADR states the decision, the P17 reasoning with sources, and the four-row capability table | `docs/adr/0035-authorized-zoom-join.md` — Decision section + capability table; every external claim carries its source link; every repo claim carries a verified relative path |
| A2 — `changelog.mdx:80` corrected | **Not done, deliberately.** ADR is `proposed`; see *What this does not do* |
| A3 — `roadmap/status.mdx:118` corrected | **Not done, deliberately.** Same reason |
| A4 — #706 cross-linked as the selected lane | ADR header (`selects #706`) + Decision §1 + a sharpening comment on #706 |
| A5 — no claim implies authorized join for an arbitrary external Zoom URL | Decision §2 states the per-tenant constraint explicitly and names the false promise it forecloses |

## Docs diff (D6c)

`docs/adr/0035-authorized-zoom-join.md` — new. ADR altitude: one decision, its context, its
trade-off, per `docs/adr/README.md`.

No `docs/changelog.d/` fragment: docs-only, no user-visible change
(`docs/changelog.d/README.md` — *"repo-tooling / docs-only / test-only changes with no user-visible
effect don't add a changelog line"*). Reader-facing pages change in the A2/A3 follow-on, not here.

All six relative links verified to resolve from `docs/adr/`.

## Security checks

Not applicable to the diff — one new Markdown file, no dependency, code, config, or workflow change.
`gate:schema` green (25 contracts). The ADR's *content* is a licence-compliance finding: it keeps a
Category-X dependency out of the tree, which is `gate:licenses`/P17 working as designed.

## Validation request

Any competent non-author, founder preferred — this is a decision, not a behaviour. What to watch:
(1) is the claim *"ZAK/OBF cannot be used with `app.zoom.us/wc/`"* right, since the whole argument
rests on it; (2) is P17 genuinely binding here, or is a Category-B-style logged exception available
that I did not consider; (3) is RTMS's per-tenant constraint stated strongly enough that nobody
later reads it as "authorized join for any Zoom link".

No deployment validated — nothing to deploy.

## Authorship

Drafted by an agent under founder direction; the human submitting this is the author and holds the
rights attestation, which is unticked above and stays that way until they tick it.

<!-- vexa-agent -->
