### PR TITLE
docs(minutes): Vexa Minutes design docs — nine pages

### DIFF
--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -24,6 +24,20 @@
         ]
       },
       {
+        "group": "Vexa Minutes (design)",
+        "pages": [
+          "minutes/manifest",
+          "minutes/invitation",
+          "minutes/artifact",
+          "minutes/steering",
+          "minutes/interface",
+          "minutes/workspaces",
+          "minutes/setup",
+          "minutes/model",
+          "minutes/status"
+        ]
+      },
+      {
         "group": "How-to: Meetings",
         "pages": [
           "how-to/overview",

--- a/docs/docs/minutes/README.md
+++ b/docs/docs/minutes/README.md
@@ -1,0 +1,13 @@
+# Vexa Minutes — design docs
+
+The meeting-knowledge product, designed in the open through its own documentation. Nine pages,
+readable in order: `manifest` (what it is and how it spreads) → `invitation` (how meetings arrive:
+the catch-all domain, the Exchange send connector, and the one-mailbox fallback ladder) →
+`artifact` (the per-participant extract and how it is actually produced) → `steering` →
+`interface` → `workspaces` → `setup` → `model` (running on your own model: the /v1/messages
+requirement and the llm-shim) → `status` (what is real today, kept honest).
+
+Everything in the product is one operation — an agent working in a workspace. These pages are the
+design medium, not after-the-fact documentation: `status.mdx` marks what is built versus designed.
+
+Registered in `docs/docs.json` under the "Vexa Minutes (design)" nav group.

--- a/docs/docs/minutes/README.md
+++ b/docs/docs/minutes/README.md
@@ -2,7 +2,7 @@
 
 The meeting-knowledge product, designed in the open through its own documentation. Nine pages,
 readable in order: `manifest` (what it is and how it spreads) → `invitation` (how meetings arrive:
-the catch-all domain, the Exchange send connector, and the one-mailbox fallback ladder) →
+one mailbox, the `#room:` tag, the post-hoc assignment) →
 `artifact` (the per-participant extract and how it is actually produced) → `steering` →
 `interface` → `workspaces` → `setup` → `model` (running on your own model: the /v1/messages
 requirement and the llm-shim) → `status` (what is real today, kept honest).

--- a/docs/docs/minutes/README.md
+++ b/docs/docs/minutes/README.md
@@ -2,7 +2,7 @@
 
 The meeting-knowledge product, designed in the open through its own documentation. Nine pages,
 readable in order: `manifest` (what it is and how it spreads) → `invitation` (how meetings arrive:
-one mailbox, the `#room:` tag, the post-hoc assignment) →
+one mailbox, the `#group:` tag, the post-hoc assignment) →
 `artifact` (the per-participant extract and how it is actually produced) → `steering` →
 `interface` → `workspaces` → `setup` → `model` (running on your own model: the /v1/messages
 requirement and the llm-shim) → `status` (what is real today, kept honest).

--- a/docs/docs/minutes/artifact.mdx
+++ b/docs/docs/minutes/artifact.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Your extract"
-description: "The room's minutes, addressed to one person: what changed for you because this meeting happened."
+description: "The group's minutes, addressed to one person: what changed for you because this meeting happened."
 ---
 
 <Note>**Status:** produced and gated in dev; delivery over SMTP works; the agent-written artifact
@@ -9,11 +9,11 @@ waits on the credential decision. See [status](/minutes/status).</Note>
 ## Definition
 
 An **extract** is one output addressed to **exactly one person** about **one meeting**: the part
-of the room's minutes that changed something for them.
+of the group's minutes that changed something for them.
 
-The room keeps one record. Each member receives their own reading of it.
+The group keeps one record. Each member receives their own reading of it.
 
-An extract is deliberately *not* a summary. A summary is one text for a room, mostly restating what
+An extract is deliberately *not* a summary. A summary is one text for a group, mostly restating what
 everyone present already heard. A delta is different for every recipient, and its value is
 highest for the person who was least central to the conversation — the one who now has to act
 on something decided while they listened.
@@ -25,7 +25,7 @@ Sections appear only when they have content. An artifact where nothing changed f
 
 | Section | Answers |
 |---|---|
-| **Decided — affects you** | what the room settled that lands on your desk |
+| **Decided — affects you** | what the group settled that lands on your desk |
 | **You committed to** | what you said you would do, with any date attached |
 | **Owed to you** | what someone else took on for you |
 | **Changed since** | how this differs from the last time this group met |
@@ -36,7 +36,7 @@ dates and numbers, because a delta that generalises is a summary again.
 
 ## Three rules it obeys
 
-**It is not conditioned on whether you spoke.** Presence is enough for the room to have changed
+**It is not conditioned on whether you spoke.** Presence is enough for the group to have changed
 something for you. A person who listened for an hour still has a context delta.
 
 **It always links to its record.** The transcript is one click away, every time. This is the
@@ -44,13 +44,13 @@ honesty valve: transcription is imperfect, and a confident artifact built on a b
 is worse than nothing. When attribution is degraded, the artifact says so in a line rather than
 quietly asserting who said what.
 
-**It is built only from what the recipient is entitled to see.** A member of the room gets an
-extract informed by everything the room knows. Everyone else gets one built from the meeting
-record and **their own** room — never from a room they do not belong to. The same rule, applied
+**It is built only from what the recipient is entitled to see.** A member of the group gets an
+extract informed by everything the group knows. Everyone else gets one built from the meeting
+record and **their own** group — never from a group they do not belong to. The same rule, applied
 from wherever the recipient stands.
 
 Who the recipient *is* comes from the organisation's own directory, and is used only in their own
-extract and kept only in their own room. It is their data, serving them.
+extract and kept only in their own group. It is their data, serving them.
 
 ## How it is actually produced
 
@@ -58,7 +58,7 @@ When a meeting completes, the system raises **one event per participant** — an
 *who it concerns* — and each dispatches **a normal agent in the group's workspace**, prompted for
 that person.
 
-That is the same agent that answers chat, running the same way. It reads what the room knows, the
+That is the same agent that answers chat, running the same way. It reads what the group knows, the
 transcript and the prior record, and it writes.
 
 Three consequences worth holding on to:
@@ -89,7 +89,7 @@ conversation cannot be recalled.
 
 The signal that matters most is the **roster**, not the transcript — a real meeting whose
 speaker attribution collapsed looks, in the text alone, exactly like a recording of one person
-in a room. Because meetings arrive [by invitation](/minutes/invitation), the roster is
+in a group. Because meetings arrive [by invitation](/minutes/invitation), the roster is
 known before a word is transcribed.
 
 ## Delivery

--- a/docs/docs/minutes/artifact.mdx
+++ b/docs/docs/minutes/artifact.mdx
@@ -1,0 +1,101 @@
+---
+title: "Your extract"
+description: "The room's minutes, addressed to one person: what changed for you because this meeting happened."
+---
+
+<Note>**Status:** produced and gated in dev; delivery over SMTP works; the agent-written artifact
+waits on the credential decision. See [status](/minutes/status).</Note>
+
+## Definition
+
+An **extract** is one output addressed to **exactly one person** about **one meeting**: the part
+of the room's minutes that changed something for them.
+
+The room keeps one record. Each member receives their own reading of it.
+
+An extract is deliberately *not* a summary. A summary is one text for a room, mostly restating what
+everyone present already heard. A delta is different for every recipient, and its value is
+highest for the person who was least central to the conversation — the one who now has to act
+on something decided while they listened.
+
+## Shape
+
+Sections appear only when they have content. An artifact where nothing changed for you is
+**short**, and that is correct behaviour rather than a failure to try.
+
+| Section | Answers |
+|---|---|
+| **Decided — affects you** | what the room settled that lands on your desk |
+| **You committed to** | what you said you would do, with any date attached |
+| **Owed to you** | what someone else took on for you |
+| **Changed since** | how this differs from the last time this group met |
+| **Worth knowing** | context you'd want but wouldn't have asked for |
+
+Written in the meeting's own language. Addressed in the second person. Concrete about names,
+dates and numbers, because a delta that generalises is a summary again.
+
+## Three rules it obeys
+
+**It is not conditioned on whether you spoke.** Presence is enough for the room to have changed
+something for you. A person who listened for an hour still has a context delta.
+
+**It always links to its record.** The transcript is one click away, every time. This is the
+honesty valve: transcription is imperfect, and a confident artifact built on a bad transcript
+is worse than nothing. When attribution is degraded, the artifact says so in a line rather than
+quietly asserting who said what.
+
+**It is built only from what the recipient is entitled to see.** A member of the room gets an
+extract informed by everything the room knows. Everyone else gets one built from the meeting
+record and **their own** room — never from a room they do not belong to. The same rule, applied
+from wherever the recipient stands.
+
+Who the recipient *is* comes from the organisation's own directory, and is used only in their own
+extract and kept only in their own room. It is their data, serving them.
+
+## How it is actually produced
+
+When a meeting completes, the system raises **one event per participant** — an event that names
+*who it concerns* — and each dispatches **a normal agent in the group's workspace**, prompted for
+that person.
+
+That is the same agent that answers chat, running the same way. It reads what the room knows, the
+transcript and the prior record, and it writes.
+
+Three consequences worth holding on to:
+
+- **The artifact differs per participant because the prompt does.** One workspace serves the
+  whole group; each run is addressed to one person and asks what changed for *them*.
+- **Post-meeting is not a special path.** Incoming mail, a completed meeting, a task transition —
+  all ride one envelope into one dispatcher. A new trigger is a new name, not new machinery.
+- **Wiring the model backend lights up everything at once**, because there is only one thing to
+  wire. See [running it on your own model](/minutes/model).
+
+## Before anything is sent
+
+Every completed record passes an **eligibility gate** before anything is written. Not every record
+is a meeting: a bot left running through a private conversation, or a tab playing a video, will
+produce a clean and entirely plausible artifact if nothing stops it.
+
+The gate returns one of three verdicts:
+
+| Verdict | Meaning |
+|---|---|
+| `send` | deliver to every entitled participant |
+| `hold_for_creator` | deliver to the meeting's creator alone, with a plain note |
+| `suppress` | build nothing, deliver nothing |
+
+**Under doubt it holds.** A held real meeting costs one person one click; a delivered private
+conversation cannot be recalled.
+
+The signal that matters most is the **roster**, not the transcript — a real meeting whose
+speaker attribution collapsed looks, in the text alone, exactly like a recording of one person
+in a room. Because meetings arrive [by invitation](/minutes/invitation), the roster is
+known before a word is transcribed.
+
+## Delivery
+
+Email, to each participant's invited address, from the workspace's address. Self-hosted
+deployments provide their own SMTP relay; nothing routes through a third-party email API.
+
+If no relay is configured, artifacts **queue and say so loudly**. They are never silently
+dropped — a delivery system that fails quietly is indistinguishable from one that works.

--- a/docs/docs/minutes/interface.mdx
+++ b/docs/docs/minutes/interface.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The interface"
-description: "Three things: the record, the room, and the chat. Everything else is somewhere you never have to go."
+description: "Three things: the record, the group, and the chat. Everything else is somewhere you never have to go."
 ---
 
 <Note>**Status:** every piece described here exists in the terminal today. What Minutes adds is a
@@ -17,33 +17,33 @@ From there they have three things, and no fourth:
 | | What it is |
 |---|---|
 | **The record** | the meeting itself — who was there, what was said, what was decided. Where an extract's link lands, and what every claim in it can be checked against. |
-| **The room** | what this room knows, accumulated across its meetings, as plain documents you can read — and edit, if you have write access. |
-| **The chat** | ask the assistant anything, against the room you are standing in. |
+| **The group** | what this group knows, accumulated across its meetings, as plain documents you can read — and edit, if you have write access. |
+| **The chat** | ask the assistant anything, against the group you are standing in. |
 
-Across the top, the rooms they belong to: their own, plus any shared room they are a member of.
+Across the top, the groups they belong to: their own, plus any shared group they are a member of.
 Nothing else.
 
 ## Read, or read and write
 
-Membership carries one of two rights, per person, per room:
+Membership carries one of two rights, per person, per group:
 
-- **Read** — receive extracts, read the room's knowledge, ask the chat anything.
-- **Read and write** — the same, plus editing the room's documents directly and letting the
+- **Read** — receive extracts, read the group's knowledge, ask the chat anything.
+- **Read and write** — the same, plus editing the group's documents directly and letting the
   assistant write there on your behalf.
 
-Most members only ever need to read. Write access is for the people who curate what a room
+Most members only ever need to read. Write access is for the people who curate what a group
 knows.
 
-## Making a room, and letting people in
+## Making a group, and letting people in
 
-Anyone with write access can create a room and share it, two ways:
+Anyone with write access can create a group and share it, two ways:
 
 - **By address** — add people's email addresses. They receive their first extract after the next
   meeting; no invitation to accept, no account to create.
 - **By link** — share a join link, either open to anyone who holds it or restricted to a list of
   addresses you name.
 
-Both already exist in the substrate: invitations are minted against a room, carry a role, may be
+Both already exist in the substrate: invitations are minted against a group, carry a role, may be
 restricted to named addresses, expire, and can be revoked.
 
 ## What Minutes deliberately does not show
@@ -56,9 +56,9 @@ That is not a limitation to be lifted later. A person who arrived by clicking a 
 about a meeting they attended should meet a product with three things in it. The workbench stays
 available to the people who want it, as its own surface, for whom none of this is news.
 
-## Removing a room
+## Removing a group
 
-A room can be removed by its owner, confirmed by seeing its name and what goes with it: members
+A group can be removed by its owner, confirmed by seeing its name and what goes with it: members
 stop receiving extracts, and meetings already held keep their records. It is never a bare icon
 click.
 

--- a/docs/docs/minutes/interface.mdx
+++ b/docs/docs/minutes/interface.mdx
@@ -1,0 +1,74 @@
+---
+title: "The interface"
+description: "Three things: the record, the room, and the chat. Everything else is somewhere you never have to go."
+---
+
+<Note>**Status:** every piece described here exists in the terminal today. What Minutes adds is a
+**smaller shape** — fewer surfaces, and controls that appear only for the people they belong to.
+See [what is real today](/minutes/status).</Note>
+
+## What a person actually meets
+
+Someone receives an extract and clicks the link in it. **That click is the entire onboarding**,
+and it lands them on the meeting the extract was about.
+
+From there they have three things, and no fourth:
+
+| | What it is |
+|---|---|
+| **The record** | the meeting itself — who was there, what was said, what was decided. Where an extract's link lands, and what every claim in it can be checked against. |
+| **The room** | what this room knows, accumulated across its meetings, as plain documents you can read — and edit, if you have write access. |
+| **The chat** | ask the assistant anything, against the room you are standing in. |
+
+Across the top, the rooms they belong to: their own, plus any shared room they are a member of.
+Nothing else.
+
+## Read, or read and write
+
+Membership carries one of two rights, per person, per room:
+
+- **Read** — receive extracts, read the room's knowledge, ask the chat anything.
+- **Read and write** — the same, plus editing the room's documents directly and letting the
+  assistant write there on your behalf.
+
+Most members only ever need to read. Write access is for the people who curate what a room
+knows.
+
+## Making a room, and letting people in
+
+Anyone with write access can create a room and share it, two ways:
+
+- **By address** — add people's email addresses. They receive their first extract after the next
+  meeting; no invitation to accept, no account to create.
+- **By link** — share a join link, either open to anyone who holds it or restricted to a list of
+  addresses you name.
+
+Both already exist in the substrate: invitations are minted against a room, carry a role, may be
+restricted to named addresses, expire, and can be revoked.
+
+## What Minutes deliberately does not show
+
+The terminal underneath this is a full workbench — task lists, scheduled routines, entity
+browsers, API tokens, agent-composition controls, the private system store. **Minutes registers
+none of it.**
+
+That is not a limitation to be lifted later. A person who arrived by clicking a link in an email
+about a meeting they attended should meet a product with three things in it. The workbench stays
+available to the people who want it, as its own surface, for whom none of this is news.
+
+## Removing a room
+
+A room can be removed by its owner, confirmed by seeing its name and what goes with it: members
+stop receiving extracts, and meetings already held keep their records. It is never a bare icon
+click.
+
+## Why this is a shape, not a fork
+
+Every surface in the terminal is a self-contained module that registers itself; the shell renders
+whatever is registered. A different product is a **different set of registered surfaces**, not a
+different application — so Minutes and the full workbench stay one codebase, one release, and one
+set of fixes.
+
+In practice that made the difference between the two products a build-time mode rather than a
+rewrite: the surfaces Minutes leaves out simply never register, and the ones it keeps are the same
+modules the full workbench uses.

--- a/docs/docs/minutes/invitation.mdx
+++ b/docs/docs/minutes/invitation.mdx
@@ -1,11 +1,10 @@
 ---
 title: "How meetings arrive"
-description: "One mailbox, every address. Inviting the assistant is the whole of it — and no calendar is ever read."
+description: "One address. Inviting the assistant is the whole of it — and no calendar is ever read."
 ---
 
-<Note>**Status:** invitation parsing and series binding are built in dev; the catch-all mail
-domain described here is a deployment step that is not yet wired. See
-[what is real today](/minutes/status).</Note>
+<Note>**Status:** invitation parsing and series binding are built in dev; the mailbox ingest and
+the two binding mechanisms are not yet wired. See [what is real today](/minutes/status).</Note>
 
 ## The mechanism
 
@@ -20,79 +19,52 @@ credential anywhere in the deployment that can read anyone's calendar.** For a r
 that is not a convenience — it is the difference between a pilot that starts this month and one
 that waits on an internal request with no stated lead time.
 
-## One mailbox. Every address already exists.
+## One address, ever
 
-A single subdomain is pointed at one catch-all mailbox — one MX record, set once at install:
+The assistant has **one ordinary mailbox** — `vexa@example.com`. Requesting it is a routine
+service-account ticket in any estate; there is no mail-routing change, no subdomain, no connector,
+and nothing else to ask an admin for, ever.
 
-```
-meetings.example.com   MX → the assistant's mailbox (catch-all)
-```
+Everyone invites that same address to any meeting. **Which room a meeting belongs to is settled by
+binding, not by address:**
 
-From that moment **every address on that domain already resolves**, so a group costs nothing to
-create:
+| Mechanism | When | Cost |
+|---|---|---|
+| **`#room:` tag** in the invite description — `#room:architecture-review` | before the meeting | typed once per meeting identity |
+| **Organiser's click** on their artifact — *assign to a room* | after the meeting | one click, once |
+| **Neither** | — | the meeting is **personal**, and stays so |
 
-| Invite this | The meeting belongs to |
-|---|---|
-| `architecture-review@meetings.example.com` | the Architecture review group |
-| `monday-standup@meetings.example.com` | the Monday standup group |
-| `vexa@meetings.example.com` | **you** — the global assistant, your personal workspace |
+The binding sticks to the meeting's **calendar identity**: tag a recurring series once and every
+occurrence is attributed to the room from then on — the tag is not re-read, re-typed, or needed
+again. An ad-hoc meeting is tagged (or assigned) individually.
 
-Creating a group does not provision a mailbox, request an address, or wait on IT. It starts
-using an address that already works.
+**Unbound is private, always.** Recurrence is not groupness — a weekly 1:1 is recurring and
+private — and the two mistakes are not symmetric: a group meeting kept private costs one click, a
+private meeting fanned out to a group is a breach. Nothing is ever inferred from the title, the
+attendee list, or the subject matter.
 
-**Self-hosted deployments own this outright** — their domain, their mailbox, their perimeter.
-Mail about their meetings never leaves their estate.
+### The tag
 
-## In an Exchange estate
+The description is **organiser-authored**, so the tag carries exactly the authority of the click,
+just earlier — and the room receives its artifacts immediately, with no round-trip. Three
+refusals keep it safe:
 
-Where all meetings are internal mail — a bank, a ministry — the catch-all needs **no DNS change
-and no mailbox**. It is one send connector, created once by a mail admin:
+- A tag binds only if the organiser is admitted to that room by its membership mode — otherwise
+  knowing a room's name would let anyone write into its record.
+- An unknown room name never creates a room. Typo → personal, with a notice.
+- A tag by anyone other than the organiser does not exist: attendees cannot edit the invitation
+  that is sent.
 
-```
-address space:  meetings.example.com          (internal-only subdomain)
-smarthost:      the Minutes host, port 25     (the stack's SMTP ingress)
-```
+### The click
 
-Exchange routes by domain and never validates the localpart, so from that moment every address on
-the subdomain already routes to the assistant. No mailbox license, no recipient objects in the
-directory, no OAuth grant — and no per-group ticket, ever.
+Any unbound meeting's artifact goes to the organiser alone, written from their perspective,
+carrying one affordance: *keep this yours, or assign it to a room*. Doing nothing keeps it private
+forever. Assigning a recurring meeting binds the series; a single meeting binds itself.
 
-An invitation to a localpart **no group has claimed** does not create one silently. The organiser
-receives a reply saying the address is unclaimed and where to create the group — a typo must not
-mint a workspace.
-
-The connector is the thing to ask for by name — but it touches core mail routing, and in a
-regulated estate that can mean a review with its own clock. Two fallbacks, in order:
-
-- **One mailbox with plus-addressing** (`vexa+architecture-review@…`): per-group addresses with a
-  routine account request. **Exchange Online only** — on-prem Exchange does not support it.
-- **One mailbox, binding done in the product** — the floor that works everywhere. Everyone
-  invites the same address, and **every unbound meeting is personal**: the artifact goes to the
-  organiser alone, carrying one affordance — *keep this yours, or assign it to a room*. Doing
-  nothing keeps it private forever. Assigning a recurring meeting binds the series, so every later
-  occurrence flows to the room; a single meeting binds itself. Nothing is inferred — recurrence is
-  not groupness (a weekly 1:1 is recurring and private), and the two mistakes are not symmetric:
-  a group meeting kept private costs one click, a private meeting fanned out to a group is a
-  breach. The rule stays the same — the binding is settled before anything fans out — settled by
-  the organiser's click instead of by the address.
-
-  **Binding can also be settled before the meeting, in the invite itself:** a tag in the
-  meeting's description — `#room:architecture-review`. The description is organiser-authored, so
-  the authority is the same as the click, just earlier — and the group receives its artifacts
-  immediately, with no round-trip. The tag binds the meeting's calendar identity, so a tagged
-  recurring series is attributed to the room on every occurrence. Three refusals keep it safe: a
-  tag binds only if the organiser is admitted to that room by its membership mode (otherwise
-  knowing a room's name would let anyone write into its record); an unknown room name never
-  creates a room — typo, personal, notice; and an invited group address always outranks a tag.
-
-  End to end: invite the one address → the invitation email books the bot → it attends and the
-  record is captured → if the invite carried a valid `#room:` tag the meeting is already bound
-  and the group path runs at once; otherwise the agent runs in the **organiser's personal
-  workspace** and mails them their artifact, which carries *assign to a room* → on assignment the agent **runs again in the
-  room's workspace**, once per participant — a re-run, never a forward of the personal document —
-  and every recipient's email is also the door: reading needs nothing, and chatting is the first
-  click, where account and membership begin. Fan-out honours the room's membership mode: an
-  outside attendee receives the room's artifact only if the mode says anyone in the room.
+Assignment is a **re-run, never a forward**: the agent runs again in the room's workspace, once
+per participant — what a group receives was written from what the group knows, not leaked from a
+personal workspace. Fan-out honours the room's membership mode: an outside attendee receives the
+room's artifact only if the mode says anyone in the room.
 
 ## Personal meetings need no address of their own
 

--- a/docs/docs/minutes/invitation.mdx
+++ b/docs/docs/minutes/invitation.mdx
@@ -1,0 +1,125 @@
+---
+title: "How meetings arrive"
+description: "One mailbox, every address. Inviting the assistant is the whole of it — and no calendar is ever read."
+---
+
+<Note>**Status:** invitation parsing and series binding are built in dev; the catch-all mail
+domain described here is a deployment step that is not yet wired. See
+[what is real today](/minutes/status).</Note>
+
+## The mechanism
+
+The assistant reads **its own mailbox**. It never reads yours.
+
+You invite it to a meeting the way you invite a colleague. The invitation arrives in that
+mailbox exactly as it arrives for every other attendee, and the address you invited decides
+which workspace the meeting belongs to.
+
+There is no calendar connection to authorise, no OAuth screen, no admin consent, and **no
+credential anywhere in the deployment that can read anyone's calendar.** For a regulated buyer
+that is not a convenience — it is the difference between a pilot that starts this month and one
+that waits on an internal request with no stated lead time.
+
+## One mailbox. Every address already exists.
+
+A single subdomain is pointed at one catch-all mailbox — one MX record, set once at install:
+
+```
+meetings.example.com   MX → the assistant's mailbox (catch-all)
+```
+
+From that moment **every address on that domain already resolves**, so a group costs nothing to
+create:
+
+| Invite this | The meeting belongs to |
+|---|---|
+| `architecture-review@meetings.example.com` | the Architecture review group |
+| `monday-standup@meetings.example.com` | the Monday standup group |
+| `vexa@meetings.example.com` | **you** — the global assistant, your personal workspace |
+
+Creating a group does not provision a mailbox, request an address, or wait on IT. It starts
+using an address that already works.
+
+**Self-hosted deployments own this outright** — their domain, their mailbox, their perimeter.
+Mail about their meetings never leaves their estate.
+
+## In an Exchange estate
+
+Where all meetings are internal mail — a bank, a ministry — the catch-all needs **no DNS change
+and no mailbox**. It is one send connector, created once by a mail admin:
+
+```
+address space:  meetings.example.com          (internal-only subdomain)
+smarthost:      the Minutes host, port 25     (the stack's SMTP ingress)
+```
+
+Exchange routes by domain and never validates the localpart, so from that moment every address on
+the subdomain already routes to the assistant. No mailbox license, no recipient objects in the
+directory, no OAuth grant — and no per-group ticket, ever.
+
+An invitation to a localpart **no group has claimed** does not create one silently. The organiser
+receives a reply saying the address is unclaimed and where to create the group — a typo must not
+mint a workspace.
+
+The connector is the thing to ask for by name — but it touches core mail routing, and in a
+regulated estate that can mean a review with its own clock. Two fallbacks, in order:
+
+- **One mailbox with plus-addressing** (`vexa+architecture-review@…`): per-group addresses with a
+  routine account request. **Exchange Online only** — on-prem Exchange does not support it.
+- **One mailbox, binding done in the product** — the floor that works everywhere. Everyone
+  invites the same address, and **every unbound meeting is personal**: the artifact goes to the
+  organiser alone, carrying one affordance — *keep this yours, or assign it to a room*. Doing
+  nothing keeps it private forever. Assigning a recurring meeting binds the series, so every later
+  occurrence flows to the room; a single meeting binds itself. Nothing is inferred — recurrence is
+  not groupness (a weekly 1:1 is recurring and private), and the two mistakes are not symmetric:
+  a group meeting kept private costs one click, a private meeting fanned out to a group is a
+  breach. The rule stays the same — the binding is settled before anything fans out — settled by
+  the organiser's click instead of by the address.
+
+  End to end: invite the one address → the invitation email books the bot → it attends and the
+  record is captured → the agent runs in the **organiser's personal workspace** and mails them
+  their artifact, which carries *assign to a room* → on assignment the agent **runs again in the
+  room's workspace**, once per participant — a re-run, never a forward of the personal document —
+  and every recipient's email is also the door: reading needs nothing, and chatting is the first
+  click, where account and membership begin. Fan-out honours the room's membership mode: an
+  outside attendee receives the room's artifact only if the mode says anyone in the room.
+
+## Personal meetings need no address of their own
+
+Invite the global `vexa@` address and the meeting is **yours**: you are the only recipient, and
+the artifact is written from your own perspective.
+
+Which person it belongs to is not inferred — **the organiser is a field on the invitation.**
+Whoever scheduled the meeting owns it.
+
+## The invited address is the answer
+
+Which workspace a meeting belongs to is never guessed from the attendee list, the title, or the
+subject matter. **It is whichever address was invited**, and that is settled before the meeting
+starts.
+
+- The group address → that group's members receive artifacts.
+- The global address → you alone do.
+- Neither → the assistant was never there.
+
+After an admin types a group's address once, their calendar client remembers it. By the second
+meeting there is nothing to look up.
+
+## Recurring meetings
+
+An invitation to a recurring series binds the **series**. The assistant attends every occurrence
+until it is uninvited. An update that moves the time moves the booking; a cancellation stops
+attendance.
+
+## What it refuses
+
+**A forwarded invitation does not bind.** The attendee list is authoritative; merely arriving in
+the mailbox is not enough. Otherwise anyone could forward an invitation and put an assistant into
+a meeting its organiser never agreed to. The organiser receives an explanation instead.
+
+**An invitation with no timezone is refused, not guessed.** A floating start time is legal in the
+calendar standard and unambiguous only to the sender. Guessing a default would dial into a room
+an hour off.
+
+**An unresolvable invitation produces no group effect** — a notice to the sender, and nothing
+else. Never a broadcast.

--- a/docs/docs/minutes/invitation.mdx
+++ b/docs/docs/minutes/invitation.mdx
@@ -25,12 +25,12 @@ The assistant has **one ordinary mailbox** — `vexa@example.com`. Requesting it
 service-account ticket in any estate; there is no mail-routing change, no subdomain, no connector,
 and nothing else to ask an admin for, ever.
 
-Everyone invites that same address to any meeting. **Which room a meeting belongs to is settled by
+Everyone invites that same address to any meeting. **Which group a meeting belongs to is settled by
 binding, not by address:**
 
 | Mechanism | When | Cost |
 |---|---|---|
-| **`#room:` tag** in the invite description — `#room:architecture-review` | before the meeting | typed once per meeting identity |
+| **`#group:` tag** in the invite description — `#group:architecture-review` | before the meeting | typed once per meeting identity |
 | **Organiser's click** on their artifact — *assign to a room* | after the meeting | one click, once |
 | **Neither** | — | the meeting is **personal**, and stays so |
 
@@ -49,22 +49,32 @@ The description is **organiser-authored**, so the tag carries exactly the author
 just earlier — and the room receives its artifacts immediately, with no round-trip. Three
 refusals keep it safe:
 
-- A tag binds only if the organiser is admitted to that room by its membership mode — otherwise
-  knowing a room's name would let anyone write into its record.
-- An unknown room name never creates a room. Typo → personal, with a notice.
+- A tag binds only if the organiser is admitted to that group by its membership mode — otherwise
+  knowing a group's name would let anyone write into its record.
+- An unknown group name never creates a group. Typo → personal, with a notice.
 - A tag by anyone other than the organiser does not exist: attendees cannot edit the invitation
   that is sent.
 
-### The click
+### The two paths
 
-Any unbound meeting's artifact goes to the organiser alone, written from their perspective,
-carrying one affordance: *keep this yours, or assign it to a room*. Doing nothing keeps it private
-forever. Assigning a recurring meeting binds the series; a single meeting binds itself.
+**Base path — no binding.** Invite → transcript → the meeting lands in the **organiser's personal
+workspace** → the organiser is emailed their artifact — and **every other participant is emailed
+an invitation to chat with the meeting**. Clicking it mints their account and their own personal
+workspace, with this meeting in it. Nobody was onboarded; they attended a meeting and got a door.
+This is how the product spreads inside an organisation — and it is **limited to the
+organisation's email domain**: an outside attendee receives nothing on this path.
 
-Assignment is a **re-run, never a forward**: the agent runs again in the room's workspace, once
-per participant — what a group receives was written from what the group knows, not leaked from a
-personal workspace. Fan-out honours the room's membership mode: an outside attendee receives the
-room's artifact only if the mode says anyone in the room.
+The organiser's email also carries *assign to a group*: one click binds the meeting — and its
+series, if recurring — after the fact, and the group path below runs for it.
+
+**Group path — already bound.** The meeting identity already belongs to a group, or the invite
+carried `#group:name` → transcript → the run happens in the **group's workspace**, once per
+participant → **all participants are emailed** their artifact, each also a door into the group's
+chat. Fan-out honours the group's membership mode; outside attendees receive it only if the mode
+says anyone in the meeting.
+
+A group run is a run in the group's workspace from what the group knows — an assignment after the
+fact is a **re-run there, never a forward** of the organiser's personal document.
 
 ## Personal meetings need no address of their own
 

--- a/docs/docs/minutes/invitation.mdx
+++ b/docs/docs/minutes/invitation.mdx
@@ -76,9 +76,19 @@ regulated estate that can mean a review with its own clock. Two fallbacks, in or
   breach. The rule stays the same — the binding is settled before anything fans out — settled by
   the organiser's click instead of by the address.
 
+  **Binding can also be settled before the meeting, in the invite itself:** a tag in the
+  meeting's description — `#room:architecture-review`. The description is organiser-authored, so
+  the authority is the same as the click, just earlier — and the group receives its artifacts
+  immediately, with no round-trip. The tag binds the meeting's calendar identity, so a tagged
+  recurring series is attributed to the room on every occurrence. Three refusals keep it safe: a
+  tag binds only if the organiser is admitted to that room by its membership mode (otherwise
+  knowing a room's name would let anyone write into its record); an unknown room name never
+  creates a room — typo, personal, notice; and an invited group address always outranks a tag.
+
   End to end: invite the one address → the invitation email books the bot → it attends and the
-  record is captured → the agent runs in the **organiser's personal workspace** and mails them
-  their artifact, which carries *assign to a room* → on assignment the agent **runs again in the
+  record is captured → if the invite carried a valid `#room:` tag the meeting is already bound
+  and the group path runs at once; otherwise the agent runs in the **organiser's personal
+  workspace** and mails them their artifact, which carries *assign to a room* → on assignment the agent **runs again in the
   room's workspace**, once per participant — a re-run, never a forward of the personal document —
   and every recipient's email is also the door: reading needs nothing, and chatting is the first
   click, where account and membership begin. Fan-out honours the room's membership mode: an

--- a/docs/docs/minutes/invitation.mdx
+++ b/docs/docs/minutes/invitation.mdx
@@ -59,8 +59,9 @@ refusals keep it safe:
 
 **Base path — no binding.** Invite → transcript → the meeting lands in the **organiser's personal
 workspace** → the organiser is emailed their artifact — and **every other participant is emailed
-an invitation to chat with the meeting**. Clicking it mints their account and their own personal
-workspace, with this meeting in it. Nobody was onboarded; they attended a meeting and got a door.
+an invitation**: clicking it mints their account and their own personal workspace, with this
+meeting in it — chat is always scoped to a workspace; the meeting is the context it points at,
+never a chat surface of its own. Nobody was onboarded; they attended a meeting and got a door.
 This is how the product spreads inside an organisation — and it is **limited to the
 organisation's email domain**: an outside attendee receives nothing on this path.
 

--- a/docs/docs/minutes/invitation.mdx
+++ b/docs/docs/minutes/invitation.mdx
@@ -31,11 +31,11 @@ binding, not by address:**
 | Mechanism | When | Cost |
 |---|---|---|
 | **`#group:` tag** in the invite description — `#group:architecture-review` | before the meeting | typed once per meeting identity |
-| **Organiser's click** on their artifact — *assign to a room* | after the meeting | one click, once |
+| **Organiser's click** on their artifact — *assign to a group* | after the meeting | one click, once |
 | **Neither** | — | the meeting is **personal**, and stays so |
 
 The binding sticks to the meeting's **calendar identity**: tag a recurring series once and every
-occurrence is attributed to the room from then on — the tag is not re-read, re-typed, or needed
+occurrence is attributed to the group from then on — the tag is not re-read, re-typed, or needed
 again. An ad-hoc meeting is tagged (or assigned) individually.
 
 **Unbound is private, always.** Recurrence is not groupness — a weekly 1:1 is recurring and
@@ -46,7 +46,7 @@ attendee list, or the subject matter.
 ### The tag
 
 The description is **organiser-authored**, so the tag carries exactly the authority of the click,
-just earlier — and the room receives its artifacts immediately, with no round-trip. Three
+just earlier — and the group receives its artifacts immediately, with no round-trip. Three
 refusals keep it safe:
 
 - A tag binds only if the organiser is admitted to that group by its membership mode — otherwise
@@ -110,7 +110,7 @@ the mailbox is not enough. Otherwise anyone could forward an invitation and put 
 a meeting its organiser never agreed to. The organiser receives an explanation instead.
 
 **An invitation with no timezone is refused, not guessed.** A floating start time is legal in the
-calendar standard and unambiguous only to the sender. Guessing a default would dial into a room
+calendar standard and unambiguous only to the sender. Guessing a default would dial into a group
 an hour off.
 
 **An unresolvable invitation produces no group effect** — a notice to the sender, and nothing

--- a/docs/docs/minutes/manifest.mdx
+++ b/docs/docs/minutes/manifest.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Vexa Minutes"
-description: "The room accumulates what it knows, meeting after meeting — and each person receives their own extract of it."
+description: "The group accumulates what it knows, meeting after meeting — and each person receives their own extract of it."
 ---
 
 <Note>
@@ -11,19 +11,19 @@ deployment you can buy today.
 
 ## The one-sentence version
 
-**The room accumulates what it knows, meeting after meeting — and each person receives their own
+**The group accumulates what it knows, meeting after meeting — and each person receives their own
 extract of it.**
 
-A room is wherever meetings accumulate. Most are shared — the architecture review, the Monday
+A group is wherever meetings accumulate. Most are shared — the architecture review, the Monday
 standup, the vendor call — and each has its own address:
 
 > `vexa@example.com` — with `#group:architecture-review` in the description
 
 Putting that address on the calendar invitation, the way you would add a colleague, is the whole
-of the setup. **You also have a room of your own**: invite it with no tag at all,
+of the setup. **You also have a group of your own**: invite it with no tag at all,
 and the meeting is yours alone.
 
-Either way the room gets steadily better informed, and when a meeting ends, everyone entitled to
+Either way the group gets steadily better informed, and when a meeting ends, everyone entitled to
 it receives what changed for *them* because it happened. A single link is the only door into
 more.
 
@@ -50,21 +50,21 @@ having an account — and the moment they want more, one click gives them one.
 
 A colleague joins a call the assistant is in. Afterwards they receive their own extract —
 informed by who they are, from the organisation's own directory, and written from their own
-room. Nobody added them to anything. The next time they hold a meeting of their own, they invite
-`vexa@` to it, and now they have a room. When that work concerns a team, they make it a shared
-room, and everyone in *those* meetings starts receiving extracts too.
+group. Nobody added them to anything. The next time they hold a meeting of their own, they invite
+`vexa@` to it, and now they have a group. When that work concerns a team, they make it a shared
+group, and everyone in *those* meetings starts receiving extracts too.
 
 The loop runs entirely inside a boundary the organisation already trusts: same employer, same
 directory, same authorisation. **An extract reaching a colleague is an internal tool doing its
 job**, not an unsolicited message from a stranger.
 
-So an admin does not enumerate the organisation. They set up the handful of standing rooms that
+So an admin does not enumerate the organisation. They set up the handful of standing groups that
 already matter, and the rest arrives by attendance.
 
 <Note>
 **Outside that boundary it is a different question, and the default is different.** A guest from
-another company receives nothing unless the room is deliberately opened — and when it is, they
-receive the meeting they attended and none of the room's history.
+another company receives nothing unless the group is deliberately opened — and when it is, they
+receive the meeting they attended and none of the group's history.
 </Note>
 
 ## What a participant actually receives
@@ -74,8 +74,8 @@ already known to the person reading it.
 
 **The artifact is a context delta, addressed to one person: what changed for *you* because this
 meeting happened.** What was decided that affects you. What you committed to. What is now owed
-to you. What moved since last time. It is written whether or not you spoke — being in the room
-is enough for the room to have changed something.
+to you. What moved since last time. It is written whether or not you spoke — being in the group
+is enough for the group to have changed something.
 
 Two people in the same meeting receive different mail.
 
@@ -93,7 +93,7 @@ the invitation lands in that mailbox like any other attendee's copy; **the addre
 the workspace the meeting belongs to.**
 
 The assistant is one ordinary mailbox on your domain. A `#group:` tag in the invite — or the
-organiser's one click afterwards — decides which room a meeting belongs to; untagged means
+organiser's one click afterwards — decides which group a meeting belongs to; untagged means
 assistant, and a meeting invited that way belongs to whoever organised it. **Creating a group
 provisions nothing.**
 
@@ -138,13 +138,13 @@ A manifest is as much about refusals as promises.
 - **It does not email an artifact for a record that is not a meeting.** A bot left running
   through a private conversation, a recording of a video playing in a tab — these produce clean,
   plausible artifacts and must never be delivered. Every record passes an eligibility gate first,
-  and under any doubt it goes to the meeting's creator alone, never to a room.
+  and under any doubt it goes to the meeting's creator alone, never to a group.
 - **It does not hide the transcript behind the summary.** Every artifact links to the record it
   was built from. A confident delta over a bad transcript is worse than no delta at all.
 - **It does not let a machine accept anything.** No auto-approval into shared knowledge.
 - **It does not read your calendar, your mail, or your files** to do any of this.
 - **It does not decide for itself who is included.** Each group states whether it serves a named
-  list, your organisation, or everyone in the room — and an outsider in an open room gets the
+  list, your organisation, or everyone in the group — and an outsider in an open group gets the
   meeting they attended, never the group's history.
 
 <Card title="The admin's flow" icon="user-gear" href="/minutes/setup">

--- a/docs/docs/minutes/manifest.mdx
+++ b/docs/docs/minutes/manifest.mdx
@@ -17,10 +17,10 @@ extract of it.**
 A room is wherever meetings accumulate. Most are shared — the architecture review, the Monday
 standup, the vendor call — and each has its own address:
 
-> `architecture-review@meetings.example.com`
+> `vexa@example.com` — with `#room:architecture-review` in the description
 
 Putting that address on the calendar invitation, the way you would add a colleague, is the whole
-of the setup. **You also have a room of your own**: invite `vexa@meetings.example.com` instead,
+of the setup. **You also have a room of your own**: invite it with no tag at all,
 and the meeting is yours alone.
 
 Either way the room gets steadily better informed, and when a meeting ends, everyone entitled to
@@ -92,8 +92,8 @@ credential for anyone's calendar anywhere in the deployment. You invite an addre
 the invitation lands in that mailbox like any other attendee's copy; **the address you invited is
 the workspace the meeting belongs to.**
 
-One mail domain points at one catch-all mailbox, so every address on it already exists.
-`architecture-review@meetings.your-domain` is a group. `vexa@meetings.your-domain` is the global
+The assistant is one ordinary mailbox on your domain. A `#room:` tag in the invite — or the
+organiser's one click afterwards — decides which room a meeting belongs to; untagged means
 assistant, and a meeting invited that way belongs to whoever organised it. **Creating a group
 provisions nothing.**
 

--- a/docs/docs/minutes/manifest.mdx
+++ b/docs/docs/minutes/manifest.mdx
@@ -17,7 +17,7 @@ extract of it.**
 A room is wherever meetings accumulate. Most are shared — the architecture review, the Monday
 standup, the vendor call — and each has its own address:
 
-> `vexa@example.com` — with `#room:architecture-review` in the description
+> `vexa@example.com` — with `#group:architecture-review` in the description
 
 Putting that address on the calendar invitation, the way you would add a colleague, is the whole
 of the setup. **You also have a room of your own**: invite it with no tag at all,
@@ -92,7 +92,7 @@ credential for anyone's calendar anywhere in the deployment. You invite an addre
 the invitation lands in that mailbox like any other attendee's copy; **the address you invited is
 the workspace the meeting belongs to.**
 
-The assistant is one ordinary mailbox on your domain. A `#room:` tag in the invite — or the
+The assistant is one ordinary mailbox on your domain. A `#group:` tag in the invite — or the
 organiser's one click afterwards — decides which room a meeting belongs to; untagged means
 assistant, and a meeting invited that way belongs to whoever organised it. **Creating a group
 provisions nothing.**

--- a/docs/docs/minutes/manifest.mdx
+++ b/docs/docs/minutes/manifest.mdx
@@ -1,0 +1,156 @@
+---
+title: "Vexa Minutes"
+description: "The room accumulates what it knows, meeting after meeting — and each person receives their own extract of it."
+---
+
+<Note>
+**Status: designed and built in dev, not shipped.** This section is the manifest for a product
+under construction. Every page marks what is real. Nothing here is a capability claim about a
+deployment you can buy today.
+</Note>
+
+## The one-sentence version
+
+**The room accumulates what it knows, meeting after meeting — and each person receives their own
+extract of it.**
+
+A room is wherever meetings accumulate. Most are shared — the architecture review, the Monday
+standup, the vendor call — and each has its own address:
+
+> `architecture-review@meetings.example.com`
+
+Putting that address on the calendar invitation, the way you would add a colleague, is the whole
+of the setup. **You also have a room of your own**: invite `vexa@meetings.example.com` instead,
+and the meeting is yours alone.
+
+Either way the room gets steadily better informed, and when a meeting ends, everyone entitled to
+it receives what changed for *them* because it happened. A single link is the only door into
+more.
+
+## Nobody signs up
+
+**One person sets it up; everyone else is onboarded by receiving something.** The admin creates a
+group — a name, and who belongs — and invites its address to the meeting that group already
+holds. Every member then gets their own extract, and
+[their account comes into being when they click it](/minutes/setup), not before.
+
+Everyone else *receives* it:
+
+- the assistant appears in the meeting, because someone invited its address;
+- an email arrives afterwards, addressed to them specifically;
+- a link in that email opens a conversation, if they want one.
+
+Nobody else installs anything. Nobody else connects a calendar. **Activation happens *to* the
+participant, not *by* them.** A person can get value from this product for months without ever
+having an account — and the moment they want more, one click gives them one.
+
+## How it spreads
+
+**Inside an organisation, attending a meeting is the whole of adoption.**
+
+A colleague joins a call the assistant is in. Afterwards they receive their own extract —
+informed by who they are, from the organisation's own directory, and written from their own
+room. Nobody added them to anything. The next time they hold a meeting of their own, they invite
+`vexa@` to it, and now they have a room. When that work concerns a team, they make it a shared
+room, and everyone in *those* meetings starts receiving extracts too.
+
+The loop runs entirely inside a boundary the organisation already trusts: same employer, same
+directory, same authorisation. **An extract reaching a colleague is an internal tool doing its
+job**, not an unsolicited message from a stranger.
+
+So an admin does not enumerate the organisation. They set up the handful of standing rooms that
+already matter, and the rest arrives by attendance.
+
+<Note>
+**Outside that boundary it is a different question, and the default is different.** A guest from
+another company receives nothing unless the room is deliberately opened — and when it is, they
+receive the meeting they attended and none of the room's history.
+</Note>
+
+## What a participant actually receives
+
+Not a summary of the meeting. A summary is the same text for everyone, and most of it is
+already known to the person reading it.
+
+**The artifact is a context delta, addressed to one person: what changed for *you* because this
+meeting happened.** What was decided that affects you. What you committed to. What is now owed
+to you. What moved since last time. It is written whether or not you spoke — being in the room
+is enough for the room to have changed something.
+
+Two people in the same meeting receive different mail.
+
+<Card title="The artifact" icon="envelope" href="/minutes/artifact">
+  What it contains, what it refuses to contain, and why it links to the record.
+</Card>
+
+## Invitation, not integration
+
+The product reads **its own mailbox**. It never reads yours.
+
+There is no calendar integration in any direction — no Graph, no EWS, no iCal feed, and no read
+credential for anyone's calendar anywhere in the deployment. You invite an address to a meeting;
+the invitation lands in that mailbox like any other attendee's copy; **the address you invited is
+the workspace the meeting belongs to.**
+
+One mail domain points at one catch-all mailbox, so every address on it already exists.
+`architecture-review@meetings.your-domain` is a group. `vexa@meetings.your-domain` is the global
+assistant, and a meeting invited that way belongs to whoever organised it. **Creating a group
+provisions nothing.**
+
+This removes the single hardest dependency in an enterprise rollout, and it means nothing is ever
+inferred — not from the attendee list, not from the title, not from the subject matter.
+
+<Card title="How meetings arrive" icon="calendar" href="/minutes/invitation">
+  Recurring series, updates, cancellations, and what happens to an invitation we can't resolve.
+</Card>
+
+## One meeting, one workspace
+
+The assistant that writes your artifact has **exactly one** knowledge workspace mounted: the one
+belonging to the address that was invited. Not a composition, not a stack to choose from — one.
+
+That single constraint removes every configuration question a workspace model usually forces.
+Who receives this, where the knowledge is written, and what the assistant is allowed to see are
+all settled *before the meeting starts*, by which address someone put on the invitation.
+
+Your own assistant chat is the one place that sees more — everything you belong to — and it is
+the only one you open deliberately.
+
+<Card title="Workspaces" icon="folder" href="/minutes/workspaces">
+  Six rules, and the one constraint they all follow from: a meeting has exactly one workspace.
+</Card>
+
+## Steering, not configuration
+
+The link in the artifact opens a chat. Reply to it and you change what the product tracks for
+you next time — *"focus on decisions, skip the descriptions"*, *"I care about anything touching
+the migration"*. That instruction is a visible, editable document in your own layer, not opaque
+state you cannot inspect.
+
+Steering a **group's** behaviour works the same way, except the change queues as a proposal and
+the workspace owner accepts or rejects it. Rejection leaves no trace in the knowledge and a full
+trace in the record.
+
+## What it refuses to do
+
+A manifest is as much about refusals as promises.
+
+- **It does not email an artifact for a record that is not a meeting.** A bot left running
+  through a private conversation, a recording of a video playing in a tab — these produce clean,
+  plausible artifacts and must never be delivered. Every record passes an eligibility gate first,
+  and under any doubt it goes to the meeting's creator alone, never to a room.
+- **It does not hide the transcript behind the summary.** Every artifact links to the record it
+  was built from. A confident delta over a bad transcript is worse than no delta at all.
+- **It does not let a machine accept anything.** No auto-approval into shared knowledge.
+- **It does not read your calendar, your mail, or your files** to do any of this.
+- **It does not decide for itself who is included.** Each group states whether it serves a named
+  list, your organisation, or everyone in the room — and an outsider in an open room gets the
+  meeting they attended, never the group's history.
+
+<Card title="The admin's flow" icon="user-gear" href="/minutes/setup">
+  One field, one click, one invitation — and what the first meeting decides for you.
+</Card>
+
+<Card title="What is real today" icon="circle-check" href="/minutes/status">
+  Built, stubbed, and not started — per component, with no rounding up.
+</Card>

--- a/docs/docs/minutes/model.mdx
+++ b/docs/docs/minutes/model.mdx
@@ -66,7 +66,7 @@ endpoint serves a reasoning model, assume you need this until you have seen vali
 ## Choosing a model
 
 It needs reliable **structured output** and solid **tool use** — it reads and writes files in your
-rooms. Test with a real task, not a greeting: ask for a JSON extraction from a meeting line and
+groups. Test with a real task, not a greeting: ask for a JSON extraction from a meeting line and
 check it is well-formed *and* semantically right. A frequent failure is naming the person who
 **asked** rather than the person who must **act**.
 

--- a/docs/docs/minutes/model.mdx
+++ b/docs/docs/minutes/model.mdx
@@ -1,0 +1,80 @@
+---
+title: "Running it on your own model"
+description: "Minutes runs on any model, in your estate. One requirement: something must answer the Anthropic dialect — and we ship it."
+---
+
+<Note>**Status:** proven in dev against an OpenAI-only endpoint. Not yet run against a production
+model server. See [what is real today](/minutes/status).</Note>
+
+## The one requirement
+
+Everything in Minutes is one operation: **an agent working in a workspace**. Chat is that. A
+completed meeting raises one event per participant and dispatches that same agent in the group's
+workspace, prompted for that person.
+
+That runtime speaks one wire format: **`POST /v1/messages`**, the Anthropic dialect. So the
+requirement is not an Anthropic *model* — the model can be anything. It is that **something in your
+estate answers that route**.
+
+Self-hosted servers (vLLM, Ollama, llama.cpp, TGI) serve only `POST /v1/chat/completions`. Hosted
+gateways usually serve both — which is why pointing at one appears to work and pointing at your own
+box does not.
+
+The fix is a translator, not a second model. Proven in dev, with nothing from that vendor in the
+path:
+
+```json
+POST /v1/messages  →  {"model": "google/gemini-2.5-flash", "content": [{"text": "SPAWN OK…"}]}
+```
+
+## The front door
+
+```bash
+docker compose --profile llm-shim up -d llm-shim
+```
+
+It accepts the Anthropic dialect, forwards OpenAI to your endpoint, translates the answer back.
+Configure it with your endpoint, the model it serves, and its key (or none). Then point the
+deployment's model settings at the shim rather than at your endpoint.
+
+Skip it only if your endpoint already serves both dialects. If it is OpenAI-only, this is not
+optional — without it there is no working assistant.
+
+## The setting that silently breaks everything
+
+Some servers make a non-standard parameter load-bearing. The measured case: **a self-hosted
+reasoning model spends its whole token budget thinking and answers with nothing.** Not slower —
+broken. Turning thinking off fixes it completely.
+
+Such parameters have no field in the OpenAI dialect, so the shim passes them through explicitly:
+
+```yaml
+extra_body:
+  chat_template_kwargs:
+    enable_thinking: false
+```
+
+There is **no default** — this is a fact about your server, and a wrong guess is worse than none.
+It is a file you edit rather than an environment variable, because a variable that silently does
+nothing would fail here exactly as badly: unusable output, everything reporting healthy.
+
+<Warning>
+Not one vendor's quirk — it reproduces on separate deployments of the same model family. If your
+endpoint serves a reasoning model, assume you need this until you have seen valid output without it.
+</Warning>
+
+## Choosing a model
+
+It needs reliable **structured output** and solid **tool use** — it reads and writes files in your
+rooms. Test with a real task, not a greeting: ask for a JSON extraction from a meeting line and
+check it is well-formed *and* semantically right. A frequent failure is naming the person who
+**asked** rather than the person who must **act**.
+
+## What never leaves
+
+- **Model traffic** goes to your endpoint.
+- **Mail** goes through your relay.
+- **No calendar credential** exists in the deployment at all.
+- **No hosted fallback** is configured or defaulted. A fallback means that the moment your endpoint
+  fails, meeting content goes to a third party — silently, at the worst moment. Deciding otherwise
+  is a decision to write down.

--- a/docs/docs/minutes/setup.mdx
+++ b/docs/docs/minutes/setup.mdx
@@ -97,3 +97,22 @@ the deploy configuration, by the same person in the same sitting they were alrea
 
 Everything afterwards lands in **your** mailbox on **your** domain. Mail about
 your meetings never leaves your estate.
+
+## The growth switchboard
+
+Minutes ships **PLG-maximal: every spread mechanic on by default**, and the organisation governs
+them — each is a named switch in the admin panel, shown at first run, changeable any time:
+
+| Switch | Default | What it does |
+|---|---|---|
+| Confirm email to the inviter | on | instant "I'm booked" reply carrying the door |
+| Participant minutes | on | each org-domain participant gets their own minutes after the meeting |
+| Chat doors in emails | on | every minutes email is also an entry into the workspace |
+| Door mints an account | on | first click creates the reader's personal workspace |
+| Assign-to-group prompt | on | the organiser's email offers one-click group binding |
+| Group fan-out | on | bound meetings mail every member per the group's membership mode |
+
+Two things are **not** switches: recipients are always inside the organisation's mail domain, and
+nothing is ever sent to a party outside it without an explicit membership-mode decision. The
+switchboard governs how far the product spreads *inside* the house — the walls are not adjustable.
+

--- a/docs/docs/minutes/setup.mdx
+++ b/docs/docs/minutes/setup.mdx
@@ -14,10 +14,10 @@ exists.
 
 ## Step 1 — Create a group
 
-A room is a recurring meeting: *Architecture review*, *Monday standup*, *Vendor calls*.
+A group is a recurring meeting: *Architecture review*, *Monday standup*, *Vendor calls*.
 
 **Creating one is a conversation, not a form.** The assistant asks what it should be called, then
-what actually happens in that meeting — and from your own words it works out what kind of room it
+what actually happens in that meeting — and from your own words it works out what kind of group it
 is and says so:
 
 > *Sounds like a meeting with an outside party. I'll pay attention to:*
@@ -27,11 +27,11 @@ is and says so:
 > *Anything to add or change — or "looks right"?*
 
 Because it names its guess, a wrong one costs a sentence to fix. What you settle on becomes the
-room's **seed**: its purpose and the first page of its index, so it starts out knowing what it is
+group's **seed**: its purpose and the first page of its index, so it starts out knowing what it is
 for rather than empty.
 
 Last, who belongs — **your organisation** (anyone joining from your domain), **a list** you name,
-or **anyone in the room**. Organisation is what most standing meetings want: colleagues are
+or **anyone in the meeting**. Organisation is what most standing meetings want: colleagues are
 included by attending, outsiders never are, nothing to maintain.
 
 Naming it produces its address:

--- a/docs/docs/minutes/setup.mdx
+++ b/docs/docs/minutes/setup.mdx
@@ -36,7 +36,7 @@ included by attending, outsiders never are, nothing to maintain.
 
 Naming it produces its address:
 
-> **Architecture review → add `#room:architecture-review` to the meeting description**
+> **Architecture review → add `#group:architecture-review` to the meeting description**
 
 **Nothing is provisioned to make that address work.** One mail domain was pointed at one
 assistant's one mailbox; the tag in the description does the rest — see

--- a/docs/docs/minutes/setup.mdx
+++ b/docs/docs/minutes/setup.mdx
@@ -36,10 +36,10 @@ included by attending, outsiders never are, nothing to maintain.
 
 Naming it produces its address:
 
-> **Architecture review → `architecture-review@meetings.your-domain`**
+> **Architecture review → add `#room:architecture-review` to the meeting description**
 
 **Nothing is provisioned to make that address work.** One mail domain was pointed at one
-catch-all mailbox when the product was installed, so every address on it already resolves — see
+assistant's one mailbox; the tag in the description does the rest — see
 [how meetings arrive](/minutes/invitation).
 
 Do this for the meetings your organisation actually holds. It is the only setup step that
@@ -92,8 +92,8 @@ system.
 ## Self-hosted
 
 The person who runs the install is the admin. Setup is **one MX record** pointing a subdomain at
-the assistant's catch-all mailbox, plus the model credential and mail relay — all set once, in
+the assistant's one mailbox, plus the model credential and mail relay — all set once, in
 the deploy configuration, by the same person in the same sitting they were already having.
 
-Every group address afterwards lives on **your** domain and lands in **your** mailbox. Mail about
+Everything afterwards lands in **your** mailbox on **your** domain. Mail about
 your meetings never leaves your estate.

--- a/docs/docs/minutes/setup.mdx
+++ b/docs/docs/minutes/setup.mdx
@@ -1,0 +1,99 @@
+---
+title: "The admin's flow"
+description: "Create your groups, and everyone in them is onboarded by their first meeting."
+---
+
+<Note>**Status:** designed, not built — see [what is real today](/minutes/status).</Note>
+
+## The principle
+
+One person sets this up. **Everyone else is onboarded by receiving something**, not by
+completing anything: their account comes into being when they click their first artifact, and
+until then they need no password, no invitation to accept, and no knowledge that this product
+exists.
+
+## Step 1 — Create a group
+
+A room is a recurring meeting: *Architecture review*, *Monday standup*, *Vendor calls*.
+
+**Creating one is a conversation, not a form.** The assistant asks what it should be called, then
+what actually happens in that meeting — and from your own words it works out what kind of room it
+is and says so:
+
+> *Sounds like a meeting with an outside party. I'll pay attention to:*
+> *· What was promised, by which side · Open items and their deadlines · Anything that changes the
+> relationship*
+>
+> *Anything to add or change — or "looks right"?*
+
+Because it names its guess, a wrong one costs a sentence to fix. What you settle on becomes the
+room's **seed**: its purpose and the first page of its index, so it starts out knowing what it is
+for rather than empty.
+
+Last, who belongs — **your organisation** (anyone joining from your domain), **a list** you name,
+or **anyone in the room**. Organisation is what most standing meetings want: colleagues are
+included by attending, outsiders never are, nothing to maintain.
+
+Naming it produces its address:
+
+> **Architecture review → `architecture-review@meetings.your-domain`**
+
+**Nothing is provisioned to make that address work.** One mail domain was pointed at one
+catch-all mailbox when the product was installed, so every address on it already resolves — see
+[how meetings arrive](/minutes/invitation).
+
+Do this for the meetings your organisation actually holds. It is the only setup step that
+repeats, and it repeats a handful of times, once.
+
+## Step 2 — Invite the group to its meeting
+
+Add the group's address to the recurring calendar invitation, the way you would add a colleague.
+
+The assistant attends. When the meeting ends, **every member of that group receives their own
+artifact** — what changed for them because it happened.
+
+For a member, that email *is* the onboarding: it arrives addressed to them, it is useful on its
+own, and the link inside it is the only door they will ever be asked to walk through.
+
+## Step 3 — There is no step 3
+
+No member list to distribute, no invitations to chase, no software for anyone to install, and
+no calendar to connect — in any direction, for anyone.
+
+## What each member experiences
+
+| When | What happens to them |
+|---|---|
+| You add their email | nothing — no mail, no account |
+| The first meeting ends | an artifact arrives, addressed to them |
+| They click the link in it | their account and personal workspace come into being |
+| They reply in the chat | what they receive next time changes |
+
+**An account is a consequence of reading something useful**, not a precondition for it.
+
+## Personal meetings need no setup at all
+
+A member who invites the **global** `vexa@` address to their *own* meeting gets an artifact
+written from their own perspective, in their own workspace, seen by nobody else. No group, no
+address to look up, no configuration, nothing for you to approve.
+
+If that work should later be shared, they create a group from it themselves — see
+[rule 5](/minutes/workspaces#the-six-rules).
+
+## What being the admin means afterwards
+
+Day to day, the same as everyone else: you receive your own artifacts.
+
+Two things stay yours. **Who belongs to which group** — the mode, and the list where there is
+one, which is also who receives what. And **the model credential**, set once per deployment,
+stored so that it can be rotated and its last characters shown, but returned by no route in the
+system.
+
+## Self-hosted
+
+The person who runs the install is the admin. Setup is **one MX record** pointing a subdomain at
+the assistant's catch-all mailbox, plus the model credential and mail relay — all set once, in
+the deploy configuration, by the same person in the same sitting they were already having.
+
+Every group address afterwards lives on **your** domain and lands in **your** mailbox. Mail about
+your meetings never leaves your estate.

--- a/docs/docs/minutes/status.mdx
+++ b/docs/docs/minutes/status.mdx
@@ -1,0 +1,94 @@
+---
+title: "What is real today"
+description: "Per component: built, stubbed, or not started — and where this design overlaps something that already ships."
+---
+
+<Warning>
+**Nothing on these pages is shipped.** The product described in this section was designed on
+2026-08-16 and built in dev overnight across ten draft pull requests. None is merged, released,
+or running in production. This page exists so no other page has to hedge.
+</Warning>
+
+## Per component
+
+| Component | State | Evidence |
+|---|---|---|
+| **Meetings by invitation** | built in dev | parses Google + Exchange invitations, recurring series, updates, cancellations; 22/22 against an invitation corpus; live smoke against a dev mailbox |
+| **The eligibility gate** | built in dev | run over 22 real meeting records: 19 send, 1 hold, 2 suppress; both non-meetings caught by independent rules |
+| **Post-meeting dispatch** | built in dev | gather → gate → write → deliver → run log; 66 extracts from the same corpus; non-meetings produce zero |
+| **Writing the artifact** | **template only** | a deterministic template proves the loop end to end. The real thing is the agentic workspace operation — the same one that answers chat — and it needs the model backend wired per deployment. See [running it on your own model](/minutes/model). |
+| **Email delivery** | built in dev | SMTP, against a local sink; a production relay is a config value |
+| **Inbound mail (SMTP ingress)** | **not built** | invitations are parsed and series bind, but the stack has no `:25` listener yet — in dev, mail is read from a test sink's API. This is the one piece between the design and an Exchange send connector pointing at us. See [how meetings arrive](/minutes/invitation#in-an-exchange-estate). |
+| **The door + steering write** | built in dev | signed single-use links, lazy identity, scope enforcement, steering into the personal layer |
+| **The conversation behind the door** | **not built** | the reply box records; it does not answer |
+| **Participants on the record** | built in dev | invite roster stored and filterable |
+| **Context stack + triage** | built in dev | four layers, policy routing, owner triage, write-only secrets |
+| **The interface** | **built in dev** | a `minutes` terminal mode: three surfaces register (rooms · meetings · chat), the rest do not. Rooms are single-select — one room per meeting-bound turn — and the developer affordances (git panel, private-store toggle, repo attach) are absent |
+| **Room creation** | **built in dev** | a conversation, not a form: the assistant asks what the room is about, infers the kind of meeting from the answer, names the shape it picked so a wrong guess is correctable in one reply, and writes the room's purpose + index at creation |
+| **Room removal** | **built in dev** | confirmed by name; unshares then deletes, and resolves the rename that unsharing performs |
+| **Running on your own model** | **built in dev** | see [Running it on your own model](/minutes/model) — an opt-in Anthropic front door, plus a pass-through for server-specific parameters. Proven against an OpenAI-only endpoint, not yet against a production model server |
+| **Read-only membership** | **blocked** | see below |
+| **Organisation membership** | **blocked** | see below |
+| **Admin UI** | **not built** | the pieces exist; the flow described in [setup](/minutes/setup) has no interface |
+| **Real-time chat during a meeting** | **not started** | deliberately sequenced last |
+
+## Two blockers worth naming
+
+[The interface](/minutes/interface) offers members **read** or **read and write**. The substrate
+has both roles, but **only read/write is currently invitable** — the read-only tier is retained in
+the permission lattice and deliberately not offered when minting an invitation.
+
+Minutes needs it: most members of a room should be able to receive extracts and ask questions
+without being able to rewrite what the room knows. Re-enabling it is a small change to what an
+invitation may mint, not a new permission model.
+
+**Second: "your organisation" membership cannot be expressed yet.** Invitations match an exact
+email address and fail closed; there is no domain matching. So the mode that needs no upkeep — and
+that carries [how the product spreads](/minutes/manifest#how-it-spreads) — has nothing to mint
+today. It needs domain-scoped invitations: additive, and small.
+
+## The open decision
+
+**Whose model key.** The design assumes the workspace owner brings their own — a provider key
+or an endpoint, including a model inside their own network. The alternative, a shared key we
+meter, would route inference cost through billing machinery that is not ready for it.
+
+Until this is settled the pipeline runs on the deterministic template instead. This is the single
+decision blocking the product's headline feature — and it is one decision, not two: because the
+artifact is written by the same agentic operation that answers chat, wiring the model backend
+lights up both at once.
+
+## Where this sits on top of what already ships
+
+Most of the substrate this product needs **is already built**, and the design above deliberately
+adds as little as possible to it.
+
+**Already shipping, unchanged:** workspaces with owners, members and invitations; invitations
+restricted to an allowed email list; per-tenant isolation enforced below the application on every
+backend, with no opt-out; a private per-user store that is never shared; and a platform-owned
+policy area that an assistant turn is structurally forbidden to write — any attempt is reverted.
+
+**What the one-workspace-per-meeting rule removes.** An earlier draft of this design specified a
+four-layer context stack with policy-routed writes and a review queue for machine-proposed
+changes to shared knowledge. **A meeting-bound assistant needs none of it**, because it has
+exactly one workspace: nothing to compose, nothing to route between, one destination for what it
+learns. Composition and routing remain real, but they belong to the terminal and to a person's
+own assistant chat — not to this product.
+
+**What is genuinely new here:** meetings arriving by invitation to a workspace's own address; the
+eligibility gate; the extract as a per-person reading of the room's minutes; and delivery by email with a
+one-click door. Those four are the product. The rest is a naming convention over machinery that
+exists.
+
+**One thing to settle before any of it merges:** an implementation built ahead of this design
+introduced a second workspace and membership model in SQL, beside the git-backed one that ships.
+It should be reduced to the parts that are new, or dropped. **Two workspace models in one product
+is the failure mode to avoid.**
+
+## Also true
+
+**Naming this product resolved a collision worth recording.** "Artifact" was used here for the
+per-person context delta, and is used elsewhere in the codebase for a meeting's recordings and
+transcripts — the same word for two different things. Calling this product's output an
+**extract** leaves "artifact" to mean recordings and transcripts, and nothing has to be renamed
+in the code that already ships.

--- a/docs/docs/minutes/status.mdx
+++ b/docs/docs/minutes/status.mdx
@@ -18,7 +18,9 @@ or running in production. This page exists so no other page has to hedge.
 | **Post-meeting dispatch** | built in dev | gather → gate → write → deliver → run log; 66 extracts from the same corpus; non-meetings produce zero |
 | **Writing the artifact** | **template only** | a deterministic template proves the loop end to end. The real thing is the agentic workspace operation — the same one that answers chat — and it needs the model backend wired per deployment. See [running it on your own model](/minutes/model). |
 | **Email delivery** | built in dev | SMTP, against a local sink; a production relay is a config value |
-| **Inbound mail (SMTP ingress)** | **not built** | invitations are parsed and series bind, but the stack has no `:25` listener yet — in dev, mail is read from a test sink's API. This is the one piece between the design and an Exchange send connector pointing at us. See [how meetings arrive](/minutes/invitation#in-an-exchange-estate). |
+| **Inbound mail (mailbox ingest)** | **not built** | invitations are parsed and series bind, but nothing polls a real mailbox yet — in dev, mail is read from a test sink's API. One IMAP poller against the assistant's one mailbox closes it. |
+| **`#room:` binding tag** | **not built** | the tag in the invite description that assigns a meeting identity to a room — see [how meetings arrive](/minutes/invitation#the-tag) |
+| **Post-hoc assignment** | **not built** | the *assign to a room* affordance on the personal artifact, and the re-run it triggers |
 | **The door + steering write** | built in dev | signed single-use links, lazy identity, scope enforcement, steering into the personal layer |
 | **The conversation behind the door** | **not built** | the reply box records; it does not answer |
 | **Participants on the record** | built in dev | invite roster stored and filterable |

--- a/docs/docs/minutes/status.mdx
+++ b/docs/docs/minutes/status.mdx
@@ -19,15 +19,15 @@ or running in production. This page exists so no other page has to hedge.
 | **Writing the artifact** | **template only** | a deterministic template proves the loop end to end. The real thing is the agentic workspace operation — the same one that answers chat — and it needs the model backend wired per deployment. See [running it on your own model](/minutes/model). |
 | **Email delivery** | built in dev | SMTP, against a local sink; a production relay is a config value |
 | **Inbound mail (mailbox ingest)** | **not built** | invitations are parsed and series bind, but nothing polls a real mailbox yet — in dev, mail is read from a test sink's API. One IMAP poller against the assistant's one mailbox closes it. |
-| **`#group:` binding tag** | **not built** | the tag in the invite description that assigns a meeting identity to a room — see [how meetings arrive](/minutes/invitation#the-tag) |
-| **Post-hoc assignment** | **not built** | the *assign to a room* affordance on the personal artifact, and the re-run it triggers |
+| **`#group:` binding tag** | **not built** | the tag in the invite description that assigns a meeting identity to a group — see [how meetings arrive](/minutes/invitation#the-tag) |
+| **Post-hoc assignment** | **not built** | the *assign to a group* affordance on the personal artifact, and the re-run it triggers |
 | **The door + steering write** | built in dev | signed single-use links, lazy identity, scope enforcement, steering into the personal layer |
 | **The conversation behind the door** | **not built** | the reply box records; it does not answer |
 | **Participants on the record** | built in dev | invite roster stored and filterable |
 | **Context stack + triage** | built in dev | four layers, policy routing, owner triage, write-only secrets |
-| **The interface** | **built in dev** | a `minutes` terminal mode: three surfaces register (rooms · meetings · chat), the rest do not. Rooms are single-select — one room per meeting-bound turn — and the developer affordances (git panel, private-store toggle, repo attach) are absent |
-| **Room creation** | **built in dev** | a conversation, not a form: the assistant asks what the room is about, infers the kind of meeting from the answer, names the shape it picked so a wrong guess is correctable in one reply, and writes the room's purpose + index at creation |
-| **Room removal** | **built in dev** | confirmed by name; unshares then deletes, and resolves the rename that unsharing performs |
+| **The interface** | **built in dev** | a `minutes` terminal mode: three surfaces register (groups · meetings · chat), the rest do not. Groups are single-select — one group per meeting-bound turn — and the developer affordances (git panel, private-store toggle, repo attach) are absent |
+| **Group creation** | **built in dev** | a conversation, not a form: the assistant asks what the group is about, infers the kind of meeting from the answer, names the shape it picked so a wrong guess is correctable in one reply, and writes the group's purpose + index at creation |
+| **Group removal** | **built in dev** | confirmed by name; unshares then deletes, and resolves the rename that unsharing performs |
 | **Running on your own model** | **built in dev** | see [Running it on your own model](/minutes/model) — an opt-in Anthropic front door, plus a pass-through for server-specific parameters. Proven against an OpenAI-only endpoint, not yet against a production model server |
 | **Read-only membership** | **blocked** | see below |
 | **Organisation membership** | **blocked** | see below |
@@ -40,8 +40,8 @@ or running in production. This page exists so no other page has to hedge.
 has both roles, but **only read/write is currently invitable** — the read-only tier is retained in
 the permission lattice and deliberately not offered when minting an invitation.
 
-Minutes needs it: most members of a room should be able to receive extracts and ask questions
-without being able to rewrite what the room knows. Re-enabling it is a small change to what an
+Minutes needs it: most members of a group should be able to receive extracts and ask questions
+without being able to rewrite what the group knows. Re-enabling it is a small change to what an
 invitation may mint, not a new permission model.
 
 **Second: "your organisation" membership cannot be expressed yet.** Invitations match an exact
@@ -78,7 +78,7 @@ learns. Composition and routing remain real, but they belong to the terminal and
 own assistant chat — not to this product.
 
 **What is genuinely new here:** meetings arriving by invitation to a workspace's own address; the
-eligibility gate; the extract as a per-person reading of the room's minutes; and delivery by email with a
+eligibility gate; the extract as a per-person reading of the group's minutes; and delivery by email with a
 one-click door. Those four are the product. The rest is a naming convention over machinery that
 exists.
 

--- a/docs/docs/minutes/status.mdx
+++ b/docs/docs/minutes/status.mdx
@@ -19,7 +19,7 @@ or running in production. This page exists so no other page has to hedge.
 | **Writing the artifact** | **template only** | a deterministic template proves the loop end to end. The real thing is the agentic workspace operation — the same one that answers chat — and it needs the model backend wired per deployment. See [running it on your own model](/minutes/model). |
 | **Email delivery** | built in dev | SMTP, against a local sink; a production relay is a config value |
 | **Inbound mail (mailbox ingest)** | **not built** | invitations are parsed and series bind, but nothing polls a real mailbox yet — in dev, mail is read from a test sink's API. One IMAP poller against the assistant's one mailbox closes it. |
-| **`#room:` binding tag** | **not built** | the tag in the invite description that assigns a meeting identity to a room — see [how meetings arrive](/minutes/invitation#the-tag) |
+| **`#group:` binding tag** | **not built** | the tag in the invite description that assigns a meeting identity to a room — see [how meetings arrive](/minutes/invitation#the-tag) |
 | **Post-hoc assignment** | **not built** | the *assign to a room* affordance on the personal artifact, and the re-run it triggers |
 | **The door + steering write** | built in dev | signed single-use links, lazy identity, scope enforcement, steering into the personal layer |
 | **The conversation behind the door** | **not built** | the reply box records; it does not answer |

--- a/docs/docs/minutes/steering.mdx
+++ b/docs/docs/minutes/steering.mdx
@@ -1,0 +1,48 @@
+---
+title: "Steering and the door"
+description: "One click from an email into a conversation, and a reply that changes what the product tracks for you."
+---
+
+<Note>**Status:** the door, single-use links, lazy identity and the steering write are built in
+dev. The conversation itself is not — the reply box records, it does not yet answer.
+See [status](/minutes/status).</Note>
+
+## The door
+
+The link in an artifact is signed, single-use, and expiring. One click and you are in a session
+bound to your email identity — **no signup form, no password, no fields**.
+
+The first successful click is also the moment your identity comes into being: a user record and
+an empty personal instruction document. Before that click, nothing is stored on your behalf.
+An expired, replayed, or tampered link creates nothing at all.
+
+## What you can do behind it
+
+**Read the record** the artifact was built from.
+
+**Steer what happens next.** Reply in your own words — *"lead with decisions, skip the
+descriptions"*, *"flag anything that touches the migration"* — and it lands as a dated entry in
+your personal instruction document. That document is **visible and editable**: steering is not
+opaque state you have to reverse-engineer, it is a page you can open and rewrite.
+
+The next artifact you receive obeys it.
+
+## What the chat can see
+
+The chat opened from an artifact has **the same single workspace mounted as the artifact did** —
+the one belonging to the meeting. It cannot reach another group's knowledge, and it does not
+quietly widen because you asked a broader question.
+
+Your own assistant chat is the other surface: it sees every workspace you belong to, and it is
+the one you open deliberately rather than the one that arrives in your inbox.
+
+## What the door is not
+
+It is not the full terminal. The terminal — free workspace composition, direct file access, the
+engine room — remains a separate, deliberate surface for people who want it. The door is the
+narrow, safe entrance that a person who has never heard of this product can walk through while
+reading their mail.
+
+Scope travels with the link: it opens the meeting it was issued for, in that meeting's one
+workspace. Because [membership and receiving are the same list](/minutes/workspaces),
+there is no case where someone holds an artifact they may not discuss.

--- a/docs/docs/minutes/steering.mdx
+++ b/docs/docs/minutes/steering.mdx
@@ -39,7 +39,7 @@ the one you open deliberately rather than the one that arrives in your inbox.
 ## What the door is not
 
 It is not the full terminal. The terminal — free workspace composition, direct file access, the
-engine room — remains a separate, deliberate surface for people who want it. The door is the
+engine group — remains a separate, deliberate surface for people who want it. The door is the
 narrow, safe entrance that a person who has never heard of this product can walk through while
 reading their mail.
 

--- a/docs/docs/minutes/workspaces.mdx
+++ b/docs/docs/minutes/workspaces.mdx
@@ -6,6 +6,25 @@ description: "Six rules. A meeting has one workspace, and everything else follow
 <Note>**Status:** the rules are designed here; the underlying workspace, membership and isolation
 machinery **already ships** — see [what is real today](/minutes/status).</Note>
 
+## How the assistant's context is composed
+
+Every turn, the assistant works inside a stack of exactly three mounts:
+
+| Mount | Access | What it carries |
+|---|---|---|
+| **Your system space** (hidden) | private, per person | who you are — identity, sessions, settings. Present on every turn, even with everything else switched off. Never shareable. |
+| **`_global` — the organisation** | **read-only**, mounted for **everyone** | where the assistant is working: the organisation's name and domain, its glossary, its house rules. One repo; a change here reaches every member's assistant on their next turn. |
+| **The write workspace** | read-write, exactly one | the thing being actively worked: your Personal space, or the one group the turn belongs to. All writing lands here. |
+
+So context is made, not configured: the organisation tier says *where* the assistant works, the
+system tier says *who* it works for, and the write workspace says *what* it is working on now.
+
+**Writing `_global` is the admin's first-setup act.** It is read-only to everyone in daily use —
+which means someone must write it once, at installation. That is a guided conversation, not a
+file-editing exercise: the first admin's chat walks them through it — what the organisation is,
+its mail domain, the terms that mean something here, what must never leave — and writes the
+organisation tier from their answers. Amending it later is the same conversation again, admin-only.
+
 ## Three words, exactly
 
 | | What it is | Meetings get in by |

--- a/docs/docs/minutes/workspaces.mdx
+++ b/docs/docs/minutes/workspaces.mdx
@@ -1,0 +1,146 @@
+---
+title: "Workspaces"
+description: "Six rules. A meeting has one workspace, and everything else follows from that."
+---
+
+<Note>**Status:** the rules are designed here; the underlying workspace, membership and isolation
+machinery **already ships** — see [what is real today](/minutes/status).</Note>
+
+## The one constraint
+
+**A meeting has exactly one workspace.**
+
+You invited an address; that address is a workspace; that workspace owns the meeting. There is
+no composition step, no routing decision, and nothing for a participant to choose — because
+there is only ever one.
+
+Group addresses cost nothing to create: [one catch-all mail domain](/minutes/invitation)
+means every address on it already resolves. A group is a name, a member list, and an address that
+already worked before anyone thought of it.
+
+Everything below is a consequence of that sentence.
+
+## The six rules
+
+<Steps>
+<Step title="Everyone has one personal workspace">
+Created for you, never shared. Anything not addressed to a group lands here.
+</Step>
+
+<Step title="A group is a shared workspace with a name, an address, and a member list">
+The admin creates the organisation's standing groups. Any member can create another later.
+Naming it is what creates its address — `architecture-review@meetings.your-domain` — and nothing
+is provisioned to make that work.
+</Step>
+
+<Step title="A meeting belongs to whichever address was invited">
+Group address → that group. The global `vexa@` address → the organiser alone. Nothing is
+inferred from the attendee list, the title, or the subject matter.
+</Step>
+
+<Step title="Artifacts follow membership">
+A group meeting reaches every member. A personal meeting reaches only you.
+</Step>
+
+<Step title="Anything personal can become a group">
+Name it, add emails, and from then on that series is shared. What was already yours stays yours.
+</Step>
+
+<Step title="Each group decides who belongs — one of three ways">
+**A list** you curate, **your organisation** (anyone joining from your domain), or **anyone in
+the room**. No account exists until someone clicks their first artifact.
+</Step>
+</Steps>
+
+## Who belongs — the three modes
+
+Membership is one setting per group, not a product-wide policy. Different rooms want different
+answers, and the same deployment can hold all three.
+
+| Mode | Who receives artifacts | Use it for |
+|---|---|---|
+| **List** | exactly the emails you added | a small, named group; anything sensitive |
+| **Organisation** | anyone joining from your own email domain | standing internal meetings — colleagues are included automatically, outsiders never are |
+| **Open** | everyone in the room, inside or out | community calls, public office hours, anything you want to spread |
+
+**Organisation is the right default for a company.** It needs no upkeep — a colleague who joins
+the architecture review starts receiving artifacts because they were there, and a vendor sitting
+in the same call does not, because they are not one of you. Nobody maintains a list, and nobody
+is accidentally included.
+
+**List is for the rooms where being explicit is the point.** A board meeting, an incident review,
+anything where "who is on this" is itself a decision.
+
+**Open is the setting for reaching beyond your organisation**, and it is deliberately per-group.
+One open community call does not make your architecture review open. Growth *inside* the
+organisation needs no such setting — Organisation mode already does it.
+
+<Note>
+**Receiving and belonging are the same thing in List and Organisation mode** — if you get the
+artifact, you can open the chat and reach that group's accumulated knowledge.
+
+**Open mode is where they separate.** Someone outside your organisation who joins one call
+receives the artifact **for that meeting**, and nothing else. Attending once does not hand an
+outsider the group's history.
+</Note>
+
+## What the rules decide for you
+
+Because the workspace is settled *before the meeting starts*, three questions that normally need
+a settings screen never get asked:
+
+| Question | Settled by |
+|---|---|
+| Who receives this? | the group's member list |
+| Where does what we learned get written? | the one workspace that owns the meeting |
+| What is the assistant allowed to see? | that workspace, and nothing else |
+
+**Inside your organisation there is no recipient-who-isn't-a-member tier.** If you receive the
+artifact you can open the chat — one rule, both meanings. The single exception is an outsider in
+an open group, who gets the meeting they attended and no history.
+
+## Personal meetings
+
+Invite the **global** `vexa@` address to your own call and it belongs to you: **you are the only
+recipient, and the artifact is written from your own perspective.** Personal work needs no group,
+no address of its own, and no setup. A one-to-one with someone outside the
+company, a conversation you want kept, a call that belongs to no team — all of it accumulates in
+your personal workspace without anyone deciding anything.
+
+If it later turns out that others should have it, [rule 5](#the-six-rules) applies: make it a
+group, add the emails, and the next meeting in that series is shared.
+
+## Two meetings' worth of scope, and no more
+
+| Surface | What the assistant has mounted |
+|---|---|
+| **Artifact** | the meeting's one workspace |
+| **Chat from an artifact** | the same one workspace |
+| **Your own assistant chat** | every workspace you belong to |
+
+Only the last one holds more than a single workspace, and it is the only one **you** open
+deliberately. A person reading their mail never meets a scope question.
+
+<Note>
+**Two groups in one meeting.** If two group addresses are invited to the same call, the meeting
+is a single record and **each group gets its own run** — its own members, its own angle, its own
+workspace. Neither group sees the other's knowledge. Each run still mounts exactly one workspace;
+only the count of runs changes.
+</Note>
+
+## Why this stays simple
+
+A workspace model usually needs three more things: a way to compose several at once, a way to
+tell the assistant what belongs where, and a review queue for writes into shared knowledge.
+
+**A meeting-bound assistant needs none of them**, because it has one workspace. Composition,
+routing and review are real, and they live where they belong: in your own assistant chat and in
+the terminal, where a person is deliberately working across several workspaces at once.
+
+## Underneath
+
+Nothing here asks for a new substrate. Workspaces, membership, invitations restricted to an
+allowed email list, and per-tenant isolation are already built and enforced below the
+application: a worker's filesystem physically contains only the workspace it was dispatched
+with, on every backend, with no opt-out. **"The assistant can only see this meeting's
+workspace" is a property of the kernel, not a promise in a prompt.**

--- a/docs/docs/minutes/workspaces.mdx
+++ b/docs/docs/minutes/workspaces.mdx
@@ -19,11 +19,17 @@ Every turn, the assistant works inside a stack of exactly three mounts:
 So context is made, not configured: the organisation tier says *where* the assistant works, the
 system tier says *who* it works for, and the write workspace says *what* it is working on now.
 
-**Writing `_global` is the admin's first-setup act.** It is read-only to everyone in daily use —
-which means someone must write it once, at installation. That is a guided conversation, not a
-file-editing exercise: the first admin's chat walks them through it — what the organisation is,
-its mail domain, the terms that mean something here, what must never leave — and writes the
-organisation tier from their answers. Amending it later is the same conversation again, admin-only.
+**There is one workspace-setup flow, and it is a conversation.** The same chat-driven flow
+instantiates three ways, differing only in who runs it and which workspace it writes:
+
+| Who | Sets up | The conversation covers |
+|---|---|---|
+| **The admin, at installation** | `_global` | what the organisation is, its mail domain, the terms that mean something here, what must never leave. Read-only to everyone after; amending it is the same conversation again, admin-only. |
+| **A person, on first arrival** | their Personal space | who they are, their role — the assistant infers what it can (their email, what they said in the meeting they arrived from) and asks only what it cannot. |
+| **A member, creating a group** | the group | what the meeting series is about, what the group should pay attention to, who belongs. |
+
+One flow, not three — the assistant asks, infers, confirms, and writes the target workspace's
+seed. Nothing exists until the conversation says what the space is for.
 
 ## Three words, exactly
 

--- a/docs/docs/minutes/workspaces.mdx
+++ b/docs/docs/minutes/workspaces.mdx
@@ -6,6 +6,18 @@ description: "Six rules. A meeting has one workspace, and everything else follow
 <Note>**Status:** the rules are designed here; the underlying workspace, membership and isolation
 machinery **already ships** — see [what is real today](/minutes/status).</Note>
 
+## Three words, exactly
+
+| | What it is | Meetings get in by |
+|---|---|---|
+| **Meeting** | one held event with a calendar identity — a series is one identity | inviting `vexa@` |
+| **Personal** | *your* workspace; exists because you clicked a door or organised a meeting | default — unbound is personal |
+| **Group** | people + shared memory + a name that can own meetings | `#group:name`, or assignment |
+
+Underneath, Personal and a Group are both *workspaces* — the storage unit. The product
+distinction is one line: **a group is a workspace that other people are in.** ("Room" was this
+concept's earlier name and is retired.)
+
 ## The one constraint
 
 **A meeting has exactly one workspace.**

--- a/docs/docs/minutes/workspaces.mdx
+++ b/docs/docs/minutes/workspaces.mdx
@@ -48,27 +48,27 @@ Name it, add emails, and from then on that series is shared. What was already yo
 
 <Step title="Each group decides who belongs — one of three ways">
 **A list** you curate, **your organisation** (anyone joining from your domain), or **anyone in
-the room**. No account exists until someone clicks their first artifact.
+the group**. No account exists until someone clicks their first artifact.
 </Step>
 </Steps>
 
 ## Who belongs — the three modes
 
-Membership is one setting per group, not a product-wide policy. Different rooms want different
+Membership is one setting per group, not a product-wide policy. Different groups want different
 answers, and the same deployment can hold all three.
 
 | Mode | Who receives artifacts | Use it for |
 |---|---|---|
 | **List** | exactly the emails you added | a small, named group; anything sensitive |
 | **Organisation** | anyone joining from your own email domain | standing internal meetings — colleagues are included automatically, outsiders never are |
-| **Open** | everyone in the room, inside or out | community calls, public office hours, anything you want to spread |
+| **Open** | everyone in the group, inside or out | community calls, public office hours, anything you want to spread |
 
 **Organisation is the right default for a company.** It needs no upkeep — a colleague who joins
 the architecture review starts receiving artifacts because they were there, and a vendor sitting
 in the same call does not, because they are not one of you. Nobody maintains a list, and nobody
 is accidentally included.
 
-**List is for the rooms where being explicit is the point.** A board meeting, an incident review,
+**List is for the groups where being explicit is the point.** A board meeting, an incident review,
 anything where "who is on this" is itself a decision.
 
 **Open is the setting for reaching beyond your organisation**, and it is deliberately per-group.

--- a/docs/docs/minutes/workspaces.mdx
+++ b/docs/docs/minutes/workspaces.mdx
@@ -14,7 +14,7 @@ You invited an address; that address is a workspace; that workspace owns the mee
 no composition step, no routing decision, and nothing for a participant to choose — because
 there is only ever one.
 
-Groups cost nothing to create: [one mailbox and a `#room:` tag](/minutes/invitation)
+Groups cost nothing to create: [one mailbox and a `#group:` tag](/minutes/invitation)
 means every address on it already resolves. A group is a name, a member list, and an address that
 already worked before anyone thought of it.
 
@@ -29,12 +29,12 @@ Created for you, never shared. Anything not addressed to a group lands here.
 
 <Step title="A group is a shared workspace with a name, an address, and a member list">
 The admin creates the organisation's standing groups. Any member can create another later.
-Naming it is what creates its tag — `#room:architecture-review` — and nothing
+Naming it is what creates its tag — `#group:architecture-review` — and nothing
 is provisioned to make that work.
 </Step>
 
 <Step title="A meeting belongs to whichever address was invited">
-A `#room:` tag or a later assignment → that group. Neither → the organiser alone. Nothing is
+A `#group:` tag or a later assignment → that group. Neither → the organiser alone. Nothing is
 inferred from the attendee list, the title, or the subject matter.
 </Step>
 
@@ -122,7 +122,7 @@ Only the last one holds more than a single workspace, and it is the only one **y
 deliberately. A person reading their mail never meets a scope question.
 
 <Note>
-**Two groups in one meeting.** If two `#room:` tags are on the same call, the meeting
+**Two groups in one meeting.** If two `#group:` tags are on the same call, the meeting
 is a single record and **each group gets its own run** — its own members, its own angle, its own
 workspace. Neither group sees the other's knowledge. Each run still mounts exactly one workspace;
 only the count of runs changes.

--- a/docs/docs/minutes/workspaces.mdx
+++ b/docs/docs/minutes/workspaces.mdx
@@ -14,7 +14,7 @@ You invited an address; that address is a workspace; that workspace owns the mee
 no composition step, no routing decision, and nothing for a participant to choose — because
 there is only ever one.
 
-Group addresses cost nothing to create: [one catch-all mail domain](/minutes/invitation)
+Groups cost nothing to create: [one mailbox and a `#room:` tag](/minutes/invitation)
 means every address on it already resolves. A group is a name, a member list, and an address that
 already worked before anyone thought of it.
 
@@ -29,12 +29,12 @@ Created for you, never shared. Anything not addressed to a group lands here.
 
 <Step title="A group is a shared workspace with a name, an address, and a member list">
 The admin creates the organisation's standing groups. Any member can create another later.
-Naming it is what creates its address — `architecture-review@meetings.your-domain` — and nothing
+Naming it is what creates its tag — `#room:architecture-review` — and nothing
 is provisioned to make that work.
 </Step>
 
 <Step title="A meeting belongs to whichever address was invited">
-Group address → that group. The global `vexa@` address → the organiser alone. Nothing is
+A `#room:` tag or a later assignment → that group. Neither → the organiser alone. Nothing is
 inferred from the attendee list, the title, or the subject matter.
 </Step>
 
@@ -122,7 +122,7 @@ Only the last one holds more than a single workspace, and it is the only one **y
 deliberately. A person reading their mail never meets a scope question.
 
 <Note>
-**Two groups in one meeting.** If two group addresses are invited to the same call, the meeting
+**Two groups in one meeting.** If two `#room:` tags are on the same call, the meeting
 is a single record and **each group gets its own run** — its own members, its own angle, its own
 workspace. Neither group sees the other's knowledge. Each run still mounts exactly one workspace;
 only the count of runs changes.


### PR DESCRIPTION
The meeting-knowledge product designed through its own documentation: manifest, invitation (catch-all domain / Exchange send connector / one-mailbox fallback ladder), artifact, steering, interface, workspaces, setup, model (the `/v1/messages` requirement + llm-shim), status.

Architecture as ruled by the founder in review: everything is one operation — an agent in a workspace; post-meeting is one event per participant, run in the **group** workspace with a per-person prompt; unbound meetings are private, assignment is a re-run honouring the room's membership mode.

`status.mdx` marks built vs designed honestly. Renders locally via mint dev.

Draft: design docs, publishing gate is the founder's.

<!-- vexa-agent -->