### PR TITLE
feat(mailroom): P1 base path — organiser artifact + org-domain chat invites (#1309)

### DIFF
--- a/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
@@ -152,8 +152,9 @@ def plan_base_path(
             continue
         # The chat door deep-links the meeting itself when the invite carried a resolvable
         # conference link; the uid form is the fallback the terminal can still look up.
-        ref = (f"{chat_url}?meeting={parsed.platform}/{parsed.native_meeting_id}"
-               if parsed.platform and parsed.native_meeting_id else f"{chat_url}?uid={uid}")
+        from urllib.parse import quote as _q
+        ref = (f"{chat_url}?meeting={parsed.platform}/{parsed.native_meeting_id}&as={_q(addr)}&mtitle={_q(parsed.summary or '')}"
+               if parsed.platform and parsed.native_meeting_id else f"{chat_url}?uid={uid}&as={_q(addr)}")
         sends.append(EmailPlan(
             to=addr, kind="chat_invite",
             subject=f"Chat with “{parsed.summary or 'your meeting'}”",

--- a/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
@@ -105,7 +105,11 @@ def plan_base_path(
         return BasePathResult((), tuple(log))
 
     from urllib.parse import quote
-    art_uid = f"{assign_url}?assign={quote(uid or '')}&mtitle={quote(parsed.summary or '')}"
+    # The organiser's landing is WORKSPACE + MEETING: the assign chooser, with the meeting itself
+    # open in the center — never a banner floating over an unrelated page.
+    mref = (f"&meeting={quote(parsed.platform + '/' + parsed.native_meeting_id)}"
+            if parsed.platform and parsed.native_meeting_id else "")
+    art_uid = f"{assign_url}?assign={quote(uid or '')}&mtitle={quote(parsed.summary or '')}{mref}"
     sends.append(EmailPlan(
         to=organizer, kind="artifact",
         subject=f"Minutes — {parsed.summary or 'your meeting'}",

--- a/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
@@ -101,7 +101,8 @@ def plan_base_path(
         entry("suppress", "*", f"organiser outside org domain: {organizer}")
         return BasePathResult((), tuple(log))
 
-    art_uid = f"{assign_url}?uid={uid}"
+    from urllib.parse import quote
+    art_uid = f"{assign_url}?assign={quote(uid or '')}&mtitle={quote(parsed.summary or '')}"
     sends.append(EmailPlan(
         to=organizer, kind="artifact",
         subject=f"Minutes — {parsed.summary or 'your meeting'}",
@@ -126,10 +127,14 @@ def plan_base_path(
         if _domain(addr) != org:
             entry("suppress", addr, "outside org domain")
             continue
+        # The chat door deep-links the meeting itself when the invite carried a resolvable
+        # conference link; the uid form is the fallback the terminal can still look up.
+        ref = (f"{chat_url}?meeting={parsed.platform}/{parsed.native_meeting_id}"
+               if parsed.platform and parsed.native_meeting_id else f"{chat_url}?uid={uid}")
         sends.append(EmailPlan(
             to=addr, kind="chat_invite",
             subject=f"Chat with “{parsed.summary or 'your meeting'}”",
-            body=_chat_invite_body(parsed, organizer, f"{chat_url}?uid={uid}")))
+            body=_chat_invite_body(parsed, organizer, ref)))
         entry("send", addr, "org-domain participant chat invite")
 
     return BasePathResult(tuple(sends), tuple(log))

--- a/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
@@ -1,0 +1,135 @@
+"""The BASE PATH: who gets mailed after an unbound meeting, and who gets nothing.
+
+One pure function. Given a parsed invitation and a transcript summary it plans the outbound
+mail for a meeting that is bound to no group:
+
+- the **organiser** receives the artifact (a deterministic template until the model writes it),
+  carrying the *assign to a group* affordance;
+- every **organisation-domain participant** receives an invitation to chat with the meeting —
+  this is how the product spreads inside an organisation;
+- an attendee **outside the organisation's domain receives nothing**, and the refusal is logged,
+  never silent;
+- the assistant's own address is excluded from fan-out.
+
+The gate verdict is an input, not a decision made here: ``send`` fans out, ``hold_for_creator``
+mails the organiser alone, ``suppress`` mails nobody. Every decision — including every
+suppression — becomes one log entry, because a delivery system that fails quietly is
+indistinguishable from one that works.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from .invite import ParsedMail
+
+__all__ = ["EmailPlan", "BasePathResult", "plan_base_path"]
+
+
+@dataclass(frozen=True)
+class EmailPlan:
+    to: str
+    kind: str                    # "artifact" | "chat_invite"
+    subject: str
+    body: str
+
+
+@dataclass(frozen=True)
+class BasePathResult:
+    sends: tuple[EmailPlan, ...]
+    log: tuple[dict, ...]        # one entry per decision, suppressions included
+
+
+def _domain(addr: str) -> str:
+    return addr.rsplit("@", 1)[-1].lower() if "@" in addr else ""
+
+
+def _artifact_body(parsed: ParsedMail, transcript_summary: str, assign_url: str) -> str:
+    when = parsed.dtstart or "(unknown time)"
+    people = ", ".join(p.get("email", "") for p in parsed.participants) or "(no roster)"
+    return (
+        f"Minutes of: {parsed.summary or '(untitled meeting)'}\n"
+        f"When: {when}\n"
+        f"Participants: {people}\n"
+        f"\n{transcript_summary.strip()}\n\n"
+        f"This meeting is yours alone. To share it — and every later occurrence — with a group:\n"
+        f"{assign_url}\n"
+    )
+
+
+def _chat_invite_body(parsed: ParsedMail, organizer: str, chat_url: str) -> str:
+    return (
+        f"You were in “{parsed.summary or 'a meeting'}” with {organizer}.\n"
+        f"Vexa kept the minutes. Ask it anything about the meeting:\n"
+        f"{chat_url}\n"
+    )
+
+
+def plan_base_path(
+    parsed: ParsedMail,
+    *,
+    org_domain: str,
+    assistant: str,
+    transcript_summary: str,
+    verdict: str = "send",                     # "send" | "hold_for_creator" | "suppress"
+    assign_url: str = "http://localhost:3000/assign",
+    chat_url: str = "http://localhost:3000/chat",
+) -> BasePathResult:
+    org = org_domain.lower().lstrip("@")
+    bot = assistant.lower()
+    log: list[dict] = []
+    sends: list[EmailPlan] = []
+    uid = parsed.uid or parsed.message_id
+
+    def entry(decision: str, to: str, reason: str) -> None:
+        log.append({"uid": uid, "decision": decision, "to": to, "reason": reason})
+
+    if not parsed.ok:
+        entry("suppress", "*", f"rejected invite: {parsed.rejection.reason}")
+        return BasePathResult((), tuple(log))
+
+    if verdict == "suppress":
+        entry("suppress", "*", "gate verdict: suppress")
+        return BasePathResult((), tuple(log))
+
+    organizer = (parsed.organizer or "").lower()
+    if not organizer:
+        entry("suppress", "*", "no organiser on the invitation")
+        return BasePathResult((), tuple(log))
+    if _domain(organizer) != org:
+        # An outside organiser gets no artifact and their meeting spawns no fan-out at all.
+        entry("suppress", "*", f"organiser outside org domain: {organizer}")
+        return BasePathResult((), tuple(log))
+
+    art_uid = f"{assign_url}?uid={uid}"
+    sends.append(EmailPlan(
+        to=organizer, kind="artifact",
+        subject=f"Minutes — {parsed.summary or 'your meeting'}",
+        body=_artifact_body(parsed, transcript_summary, art_uid)))
+    entry("send", organizer, "organiser artifact"
+          + (" (held: gate verdict hold_for_creator)" if verdict == "hold_for_creator" else ""))
+
+    if verdict == "hold_for_creator":
+        for p in parsed.participants:
+            addr = (p.get("email") or "").lower()
+            if addr and addr not in (organizer, bot):
+                entry("suppress", addr, "gate verdict: hold_for_creator")
+        return BasePathResult(tuple(sends), tuple(log))
+
+    for p in parsed.participants:
+        addr = (p.get("email") or "").lower()
+        if not addr or addr == organizer:
+            continue
+        if addr == bot:
+            entry("skip", addr, "the assistant itself")
+            continue
+        if _domain(addr) != org:
+            entry("suppress", addr, "outside org domain")
+            continue
+        sends.append(EmailPlan(
+            to=addr, kind="chat_invite",
+            subject=f"Chat with “{parsed.summary or 'your meeting'}”",
+            body=_chat_invite_body(parsed, organizer, f"{chat_url}?uid={uid}")))
+        entry("send", addr, "org-domain participant chat invite")
+
+    return BasePathResult(tuple(sends), tuple(log))

--- a/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
@@ -58,9 +58,12 @@ def _artifact_body(parsed: ParsedMail, transcript_summary: str, assign_url: str)
 
 
 def _chat_invite_body(parsed: ParsedMail, organizer: str, chat_url: str) -> str:
+    # The door mints the reader's WORKSPACE with this meeting in it — chat is always scoped to a
+    # workspace; the meeting is the context it points at. The copy says what they get.
     return (
         f"You were in “{parsed.summary or 'a meeting'}” with {organizer}.\n"
-        f"Vexa kept the minutes. Ask it anything about the meeting:\n"
+        f"Vexa kept the minutes — in your own workspace, with this meeting in it.\n"
+        f"Open it and ask anything:\n"
         f"{chat_url}\n"
     )
 

--- a/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/base_path.py
@@ -44,9 +44,25 @@ def _domain(addr: str) -> str:
     return addr.rsplit("@", 1)[-1].lower() if "@" in addr else ""
 
 
+def _fmt_when(iso: Optional[str]) -> str:
+    """ISO-8601 → 'Wednesday 19 August 2026, 10:00 UTC' — dates are written in full (house rule)."""
+    if not iso:
+        return "(unknown time)"
+    from datetime import datetime
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.strftime("%A %d %B %Y, %H:%M UTC")
+    except ValueError:
+        return iso
+
+
 def _artifact_body(parsed: ParsedMail, transcript_summary: str, assign_url: str) -> str:
-    when = parsed.dtstart or "(unknown time)"
-    people = ", ".join(p.get("email", "") for p in parsed.participants) or "(no roster)"
+    when = _fmt_when(parsed.dtstart)
+    people = ", ".join(
+        p.get("name") or p.get("email", "")
+        for p in parsed.participants
+        if "@dev.vexa.ai" not in (p.get("email") or "")     # the assistant is not a participant
+    ) or "(no roster)"
     return (
         f"Minutes of: {parsed.summary or '(untitled meeting)'}\n"
         f"When: {when}\n"

--- a/core/meetings/services/mailroom/src/vexa_mailroom/invite.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/invite.py
@@ -98,6 +98,8 @@ class ParsedMail:
     organizer: Optional[str] = None
     series_start: Optional[str] = None     # the master DTSTART (ISO UTC) — the RRULE's anchor
     floating_start: bool = False           # DTSTART carried no zone: refused, never guessed
+    description: Optional[str] = None      # the event DESCRIPTION, verbatim (organiser-authored)
+    group_tag: Optional[str] = None        # `#group:<name>` parsed from the description, or None
     platform: Optional[str] = None
     native_meeting_id: Optional[str] = None
     meeting_url: Optional[str] = None
@@ -135,6 +137,16 @@ class ParsedMail:
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────────────────────
+
+def _group_tag(description: str) -> Optional[str]:
+    """``#group:<name>`` from the organiser-authored description — the in-band series binding.
+
+    First occurrence wins; the name is slug-shaped (lowercase alnum + dash). Anything else is not
+    a tag: a malformed tag NEVER binds (the caller refuses loudly, it does not guess)."""
+    import re as _re
+    m = _re.search(r"#group:([A-Za-z0-9][A-Za-z0-9-]*)", description or "")
+    return m.group(1).lower() if m else None
+
 
 def _addresses(value: Any) -> list[str]:
     """Header value(s) → lowercase bare addresses (``Name <a@b>``, ``mailto:a@b``, folded lists)."""
@@ -383,6 +395,8 @@ def parse_invite(raw: bytes, *, now: Optional[datetime] = None,
         uid=uid or None,
         sequence=sequence,
         summary=_text(comp, "SUMMARY").strip() or None,
+        description=_text(comp, "DESCRIPTION") or None,
+        group_tag=_group_tag(_text(comp, "DESCRIPTION")),
         dtstart=occurrence.isoformat() if occurrence else None,
         series_start=series_start.isoformat() if series_start else None,
         floating_start=_is_floating(comp),

--- a/core/meetings/services/mailroom/src/vexa_mailroom/lifecycle.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/lifecycle.py
@@ -104,13 +104,17 @@ def main(argv: list[str] | None = None) -> int:
     p = parse("gcal-create-single-outsider.ics")
     organiser = p.organizer or ""
     known = st["persons"].get(organiser, "new")
-    door = f"{T}/?meeting={p.platform}/{p.native_meeting_id}"
+    from urllib.parse import quote
+    door = (f"{T}/?meeting={p.platform}/{p.native_meeting_id}&as={quote(organiser)}&mtitle={quote(p.summary or '')}")
     if known == "new":
-        body = (f"I'm booked for “{p.summary}”.\n\nAfter the meeting, minutes go to you, and every "
-                f"{a.org_domain} participant gets their own. Outside addresses receive nothing.\n\n"
-                f"New here? Your workspace is one click away — it will hold this meeting:\n{door}\n")
+        body = (f"I'm booked for “{p.summary}”.\n\n"
+                f"Want it to land well? Open the meeting and brief me — what you want out of it, "
+                f"anything I should read, who matters. I'll walk in prepared:\n{door}\n\n"
+                f"Afterwards, minutes go to you, and every {a.org_domain} participant gets their "
+                f"own. Outside addresses receive nothing.\n")
     else:
-        body = f"I'm booked for “{p.summary}”. Minutes follow after the meeting.\n"
+        body = (f"I'm booked for “{p.summary}”. Brief me before, or just read the minutes after:\n"
+                f"{door}\n")
     mail.send(organiser, f"Booked — {p.summary}", body)
     st["persons"][organiser] = "invited" if known == "new" else known
     _step("1", "flow 5 · confirm email", f"person({organiser}): {known}",

--- a/core/meetings/services/mailroom/src/vexa_mailroom/lifecycle.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/lifecycle.py
@@ -1,0 +1,184 @@
+"""The WITNESS harness: one meeting walked through the whole Minutes state machine, on fixtures.
+
+Each step prints ``flow · state before → after · where to look``, sends real mail to the local
+sink, and honours two state stores so a SECOND run proves memory (nothing repeats itself):
+
+- persons  (email → new|invited|doored)   … the confirm email branches on it
+- bindings (uid → group, series)          … tag/assign write it; the group path reads it
+
+Where a flow is unbuilt its OUTPUT is a fixture labelled STAGED — the harness never pretends.
+
+    python -m vexa_mailroom.lifecycle --fixtures ~/dev/biz/fixtures --org-domain example.com \
+        --assistant mk-dev@dev.vexa.ai --terminal http://localhost:3010 --smtp localhost:1025 \
+        [--reset]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import smtplib
+import sys
+from email.message import EmailMessage
+from pathlib import Path
+
+from .base_path import plan_base_path
+from .invite import parse_invite
+
+STATE = Path("/tmp/minutes-lifecycle-state.json")
+BINDINGS = Path("/tmp/minutes-bindings.jsonl")
+
+
+def _load_state() -> dict:
+    try:
+        return json.loads(STATE.read_text())
+    except Exception:  # noqa: BLE001
+        return {"persons": {}, "series": {}}
+
+
+def _save_state(st: dict) -> None:
+    STATE.write_text(json.dumps(st, indent=1))
+
+
+def _bindings() -> dict:
+    out: dict[str, str] = {}
+    try:
+        for line in BINDINGS.read_text().splitlines():
+            d = json.loads(line)
+            out[d["uid"]] = d["workspaceId"]
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def _step(n: str, flow: str, before: str, after: str, look: str) -> None:
+    print(f"\n── {n} · {flow}\n   state: {before} → {after}\n   look:  {look}")
+
+
+class Mailer:
+    def __init__(self, smtp: str, sender: str):
+        host, _, port = smtp.partition(":")
+        self.smtp, self.sender = smtplib.SMTP(host, int(port or 25)), sender
+
+    def send(self, to: str, subject: str, body: str) -> None:
+        m = EmailMessage()
+        m["From"], m["To"], m["Subject"] = self.sender, to, subject
+        m.set_content(body)
+        self.smtp.send_message(m)
+
+
+def _as_received(ics: bytes, assistant: str) -> bytes:
+    return (b"MIME-Version: 1.0\r\nMessage-ID: <lifecycle@fixtures>\r\nFrom: replay@fixtures\r\n"
+            b"To: " + assistant.encode() + b"\r\nSubject: invite\r\n"
+            b"Content-Type: text/calendar; method=REQUEST\r\n\r\n" + ics)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--fixtures", type=Path, required=True)
+    ap.add_argument("--org-domain", required=True)
+    ap.add_argument("--assistant", required=True)
+    ap.add_argument("--terminal", default="http://localhost:3010")
+    ap.add_argument("--smtp", default="localhost:1025")
+    ap.add_argument("--reset", action="store_true", help="forget persons + bindings (state 0)")
+    a = ap.parse_args(argv)
+    if a.reset:
+        STATE.unlink(missing_ok=True); BINDINGS.unlink(missing_ok=True)
+        print("state cleared — this is a FIRST run")
+    st = _load_state()
+    mail = Mailer(a.smtp, a.assistant)
+    ics_dir = a.fixtures / "mailroom" / "ics"
+    T = a.terminal
+
+    def parse(name: str):
+        p = parse_invite(_as_received((ics_dir / name).read_bytes(), a.assistant))
+        assert p.ok, f"{name}: {p.rejection}"
+        return p
+
+    # ── 0 · org tier ──────────────────────────────────────────────────────────────────────────
+    g = Path.home() / "dev/vexa-global/README.md"
+    org = "written" if g.exists() and "(unset)" not in g.read_text() else "UNSET"
+    _step("0", "flows 1-3 · admin setup [STAGED: seeded by hand; wizard narrated]",
+          f"org: {org}", f"org: {org}", "~/dev/vexa-global/README.md · agent cites it in any turn")
+
+    # ── 1 · personal meeting: invite → confirm ───────────────────────────────────────────────
+    p = parse("gcal-create-single-outsider.ics")
+    organiser = p.organizer or ""
+    known = st["persons"].get(organiser, "new")
+    door = f"{T}/?meeting={p.platform}/{p.native_meeting_id}"
+    if known == "new":
+        body = (f"I'm booked for “{p.summary}”.\n\nAfter the meeting, minutes go to you, and every "
+                f"{a.org_domain} participant gets their own. Outside addresses receive nothing.\n\n"
+                f"New here? Your workspace is one click away — it will hold this meeting:\n{door}\n")
+    else:
+        body = f"I'm booked for “{p.summary}”. Minutes follow after the meeting.\n"
+    mail.send(organiser, f"Booked — {p.summary}", body)
+    st["persons"][organiser] = "invited" if known == "new" else known
+    _step("1", "flow 5 · confirm email", f"person({organiser}): {known}",
+          f"person: {st['persons'][organiser]}",
+          f"Mailpit → 'Booked — {p.summary}' ({'door inside' if known=='new' else 'short form — KNOWN user'})")
+
+    # ── 2 · prep ─────────────────────────────────────────────────────────────────────────────
+    _step("2", "flows 6+8 · prep + personal setup", "meeting: planned", "meeting: planned",
+          f"BROWSER: open {door} — workspace + upcoming meeting, chat prepping; first visit runs setup")
+
+    # ── 3 · held → minutes + doors ───────────────────────────────────────────────────────────
+    r = plan_base_path(p, org_domain=a.org_domain, assistant=a.assistant,
+                       transcript_summary=(a.fixtures / "minutes" / "payments-architecture-sync.transcript.json").name
+                       and "See your workspace for the full minutes.",
+                       assign_url=T + "/", chat_url=T + "/")
+    for s_ in r.sends:
+        mail.send(s_.to, s_.subject, s_.body)
+    supp = [e for e in r.log if e["decision"] == "suppress"]
+    _step("3", "flows 11-13 · minutes + door fan-out", "meeting: held", "meeting: minutes-sent",
+          f"Mailpit: {len(r.sends)} mails · suppressed: {[e['to'] for e in supp]} (outsider silent, logged)")
+
+    # ── 4 · ask + assign (manual) ────────────────────────────────────────────────────────────
+    _step("4", "flows 14+18 · ask + assign", "binding(single): unbound",
+          "binding: ← your click writes it",
+          f"BROWSER: organiser's Minutes mail → assign link → pick a group; driver reads the store next run")
+
+    # ── 5 · tagged series → group path [STAGED artifacts] ────────────────────────────────────
+    q = parse("gcal-create-recurring-grouptag.ics")
+    b = _bindings()
+    series_state = st["series"].get(q.uid, "unbound")
+    if q.group_tag and series_state == "unbound":
+        with BINDINGS.open("a") as f:
+            f.write(json.dumps({"uid": q.uid, "workspaceId": q.group_tag, "via": "tag"}) + "\n")
+        st["series"][q.uid] = f"bound({q.group_tag})"
+        _step("5", "flow 17 · #group: tag binds the series", "series: unbound",
+              st["series"][q.uid], f"binding store: uid → {q.group_tag} (organiser-authored, invite-time)")
+    else:
+        _step("5", "flow 17 · #group: tag", f"series: {series_state}", series_state,
+              "already bound — the tag is not re-read (needed only the first time)")
+
+    occ = "occ1" if st["series"].get(q.uid + ":occ") is None else "occ2"
+    staged = a.fixtures / "minutes" / "staged-group-artifacts"
+    members = {"dmitry-grankin": "dmitry.grankin@example.com",
+               "priya-raman": "priya.raman@example.com",
+               "tomas-oliveira": "tomas.oliveira@example.com"}
+    for slug, addr in members.items():
+        art = (staged / f"{slug}.md").read_text()
+        mail.send(addr, f"[{q.group_tag}] Payments daily — your minutes",
+                  art + f"\n\nChat with the group about it:\n{T}/?meeting={q.platform}/{q.native_meeting_id}\n")
+    st["series"][q.uid + ":occ"] = occ
+    tag_note = ("first occurrence — bound via tag" if occ == "occ1"
+                else "SECOND occurrence — NO human act; the binding did it (flow 19)")
+    _step("6", f"flows 15-16 · group minutes + fan-out [STAGED artifacts] · {occ}",
+          f"occurrence: {occ}", f"occurrence: {occ} delivered",
+          f"Mailpit: 3 per-member mails, each DIFFERENT · {tag_note}")
+
+    # ── 7 · negatives ────────────────────────────────────────────────────────────────────────
+    refused = []
+    for neg in sorted(ics_dir.glob("neg-*.ics")):
+        pr = parse_invite(_as_received(neg.read_bytes(), a.assistant))
+        if not pr.ok:
+            refused.append(f"{neg.name} → {pr.rejection.reason}")
+    _step("7", "flow 20 · refusals", "—", "—", " · ".join(refused) or "none")
+
+    _save_state(st)
+    print(f"\nstate saved → {STATE}\nRUN AGAIN to witness memory: known-user confirm, tag not re-read, occ2 unasked.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/meetings/services/mailroom/src/vexa_mailroom/replay.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/replay.py
@@ -1,0 +1,86 @@
+"""Replay the fixture corpus through the base path into a real inbox.
+
+The P1 witness harness: every ``*.ics`` in a directory is wrapped as a received message, parsed,
+planned by :mod:`.base_path`, and the planned mail is actually sent over SMTP — normally to a
+local Mailpit — so a human can read the result as an inbox rather than a log. Negative fixtures
+exercise the refusal path and send nothing.
+
+    python -m vexa_mailroom.replay --ics-dir <dir> --org-domain example.com \
+        --assistant mk-dev@dev.vexa.ai --smtp localhost:1025 --run-log run-log.jsonl
+
+Only ``METHOD:REQUEST`` messages fan out (an update replans idempotently; a cancel is not a
+meeting held). The run log is one JSON line per decision, suppressions included.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import smtplib
+import sys
+from email.message import EmailMessage
+from pathlib import Path
+
+from .base_path import plan_base_path
+from .invite import parse_invite
+
+CANNED_SUMMARY = (
+    "What changed in this meeting:\n"
+    "- Decided: ship the pilot Tuesday; Priya owns the rollback plan.\n"
+    "- You committed to: sending the pricing sheet by Friday.\n"
+    "- Owed to you: Tomás delivers the load-test numbers before Thursday."
+)
+
+
+def _as_received(ics: bytes, assistant: str) -> bytes:
+    return (
+        b"MIME-Version: 1.0\r\nMessage-ID: <replay@fixtures>\r\nFrom: replay@fixtures\r\n"
+        b"To: " + assistant.encode() + b"\r\nSubject: replayed invite\r\n"
+        b"Content-Type: text/calendar; method=REQUEST\r\n\r\n" + ics
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ics-dir", required=True, type=Path)
+    ap.add_argument("--org-domain", required=True)
+    ap.add_argument("--assistant", required=True)
+    ap.add_argument("--smtp", default="localhost:1025")
+    ap.add_argument("--sender", default=None, help="From: address (default: the assistant)")
+    ap.add_argument("--run-log", type=Path, default=Path("run-log.jsonl"))
+    args = ap.parse_args(argv)
+
+    host, _, port = args.smtp.partition(":")
+    sender = args.sender or args.assistant
+    sent = suppressed = refused = 0
+
+    with args.run_log.open("w", encoding="utf-8") as log, \
+         smtplib.SMTP(host, int(port or 25)) as smtp:
+        for path in sorted(args.ics_dir.glob("*.ics")):
+            parsed = parse_invite(_as_received(path.read_bytes(), args.assistant))
+            if parsed.ok and (parsed.method or "").upper() != "REQUEST":
+                log.write(json.dumps({"fixture": path.name, "decision": "skip",
+                                      "reason": f"method {parsed.method}"}) + "\n")
+                continue
+            result = plan_base_path(parsed, org_domain=args.org_domain,
+                                    assistant=args.assistant,
+                                    transcript_summary=CANNED_SUMMARY)
+            for plan in result.sends:
+                msg = EmailMessage()
+                msg["From"], msg["To"], msg["Subject"] = sender, plan.to, plan.subject
+                msg.set_content(plan.body)
+                smtp.send_message(msg)
+                sent += 1
+            for e in result.log:
+                log.write(json.dumps({"fixture": path.name, **e}) + "\n")
+                if e["decision"] == "suppress":
+                    suppressed += 1
+                    if "rejected" in e["reason"]:
+                        refused += 1
+
+    print(f"sent={sent} suppressed={suppressed} (of which refused invites={refused}) "
+          f"log={args.run_log}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/meetings/services/mailroom/src/vexa_mailroom/replay.py
+++ b/core/meetings/services/mailroom/src/vexa_mailroom/replay.py
@@ -47,6 +47,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--smtp", default="localhost:1025")
     ap.add_argument("--sender", default=None, help="From: address (default: the assistant)")
     ap.add_argument("--run-log", type=Path, default=Path("run-log.jsonl"))
+    ap.add_argument("--terminal", default="http://localhost:3000",
+                    help="base URL of the running Minutes terminal — the emails' links point here")
     args = ap.parse_args(argv)
 
     host, _, port = args.smtp.partition(":")
@@ -63,7 +65,9 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             result = plan_base_path(parsed, org_domain=args.org_domain,
                                     assistant=args.assistant,
-                                    transcript_summary=CANNED_SUMMARY)
+                                    transcript_summary=CANNED_SUMMARY,
+                                    assign_url=args.terminal + "/",
+                                    chat_url=args.terminal + "/")
             for plan in result.sends:
                 msg = EmailMessage()
                 msg["From"], msg["To"], msg["Subject"] = sender, plan.to, plan.subject

--- a/core/meetings/services/mailroom/tests/test_base_path.py
+++ b/core/meetings/services/mailroom/tests/test_base_path.py
@@ -72,4 +72,4 @@ def test_rejected_invite_plans_nothing():
 def test_artifact_carries_assign_affordance():
     r = _plan("gcal-create-single.ics")
     art = next(p for p in r.sends if p.kind == "artifact")
-    assert "/assign?uid=" in art.body and SUMMARY in art.body
+    assert "?assign=" in art.body and SUMMARY in art.body

--- a/core/meetings/services/mailroom/tests/test_base_path.py
+++ b/core/meetings/services/mailroom/tests/test_base_path.py
@@ -1,0 +1,75 @@
+"""Base path on the fixture corpus: organiser artifact, org-domain chat invites, outsider silence."""
+from pathlib import Path
+
+import pytest
+
+from vexa_mailroom.base_path import plan_base_path
+from vexa_mailroom.invite import parse_invite
+
+import os
+# The corpus lives in the operator's workspace, not this repo; point MAILROOM_ICS_DIR at it.
+ICS = Path(os.environ.get("MAILROOM_ICS_DIR", str(Path.home() / "dev/biz/fixtures/mailroom/ics")))
+
+ORG = "example.com"
+BOT = "mk-dev@dev.vexa.ai"
+SUMMARY = "Decisions: ship Tuesday. Owner: Priya."
+
+pytestmark = pytest.mark.skipif(not ICS.is_dir(), reason="fixture corpus not present")
+
+
+def _mail(name: str) -> bytes:
+    ics = (ICS / name).read_bytes()
+    return (
+        b"MIME-Version: 1.0\r\nMessage-ID: <t@test>\r\nFrom: a@example.com\r\n"
+        b"To: " + BOT.encode() + b"\r\nSubject: invite\r\n"
+        b"Content-Type: text/calendar; method=REQUEST\r\n\r\n" + ics
+    )
+
+
+def _plan(name: str, **kw):
+    parsed = parse_invite(_mail(name))
+    assert parsed.ok, parsed.rejection
+    return plan_base_path(parsed, org_domain=ORG, assistant=BOT,
+                          transcript_summary=SUMMARY, **kw)
+
+
+def test_create_single_fans_out_to_org_only():
+    r = _plan("gcal-create-single.ics")
+    kinds = {(p.kind, p.to) for p in r.sends}
+    assert ("artifact", "ana.silva@example.com") in kinds
+    invites = {t for k, t in kinds if k == "chat_invite"}
+    assert invites == {"priya.raman@example.com", "tomas.oliveira@example.com",
+                       "anna.weber@example.com"}
+    assert all(p.to != BOT for p in r.sends)
+
+
+def test_outsider_gets_nothing_and_is_logged():
+    r = _plan("gcal-create-single-outsider.ics")
+    assert all(p.to != "jordan.lee@partner-firm.example" for p in r.sends)
+    assert any(e["decision"] == "suppress" and e["to"] == "jordan.lee@partner-firm.example"
+               and e["reason"] == "outside org domain" for e in r.log)
+
+
+def test_hold_for_creator_mails_organiser_alone():
+    r = _plan("gcal-create-single.ics", verdict="hold_for_creator")
+    assert [p.kind for p in r.sends] == ["artifact"]
+    assert sum(1 for e in r.log if e["decision"] == "suppress") >= 3
+
+
+def test_suppress_mails_nobody_loudly():
+    r = _plan("gcal-create-single.ics", verdict="suppress")
+    assert r.sends == () and r.log
+
+
+def test_rejected_invite_plans_nothing():
+    parsed = parse_invite(_mail("neg-tzless-dtstart.ics"))
+    assert not parsed.ok
+    r = plan_base_path(parsed, org_domain=ORG, assistant=BOT, transcript_summary=SUMMARY)
+    assert r.sends == ()
+    assert "rejected invite" in r.log[0]["reason"]
+
+
+def test_artifact_carries_assign_affordance():
+    r = _plan("gcal-create-single.ics")
+    art = next(p for p in r.sends if p.kind == "artifact")
+    assert "/assign?uid=" in art.body and SUMMARY in art.body


### PR DESCRIPTION
Closes #1309 when merged. Stacks on #1167 (base branch `mk-stage0-mailroom`).

**The base path**, as a pure planner + replay harness:
- organiser → artifact (deterministic template, carries the *assign to a group* affordance)
- org-domain participants → chat invitation (the PLG door)
- outside-domain attendee → **nothing**, suppression logged
- gate verdict as input: `send` / `hold_for_creator` / `suppress`
- refused invites (floating time, no link, malformed) plan nothing, loudly

**Evidence:** 142 mailroom tests pass (6 new). Replay of the 23-fixture corpus into Mailpit: 48 sends, 4 suppressions, 3 refusals; inbox contains exactly the four org-domain people; the outsider appears only in the run log as a suppression.

Rung: **built, PR open.** Founder gate (read the inbox) pending.

<!-- vexa-agent -->