### PR TITLE
fix(gmeet): a dead meeting code is its own outcome, detected before the join-CTA hunt (#1325)

### DIFF
--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -16,7 +16,7 @@
   "core/meetings/contracts/captured-signal.v1": "976b79778e50ae5bbfea2cd968a936df628cce025475aca54587122332b62972",
   "core/meetings/contracts/flagged-issue.v1": "4b868f57298131f8eec8246d86d57251f259927d8bfd7df5a0f6016a10f16211",
   "core/meetings/contracts/invocation.v1": "c7d7f6b95f11da595d0a9e27a429774cdefcc997831cbedff061ebcc2aafbbb8",
-  "core/meetings/contracts/lifecycle.v1": "95392746da49c7c61ec81863e6b836af5acb879f979918753fc8fcf92583b820",
+  "core/meetings/contracts/lifecycle.v1": "2e00df82885e58aadb9e840852610ab5e9914ac40a229ff807d31fbd51ed1d78",
   "core/meetings/contracts/service-authority.v1": "cbcb1662424e180faebc9170896cc270985d8510b50f51ae1e9b32bc2e6050e6",
   "core/meetings/contracts/transcript.v1": "7d07d0fbac77f6562af64ae6c6286051e0e07763f427347d4e7b7735eaa0f9c8",
   "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",

--- a/core/meetings/contracts/lifecycle.v1/README.md
+++ b/core/meetings/contracts/lifecycle.v1/README.md
@@ -16,7 +16,9 @@ failed             ∅   (terminal)
 attribution (the control plane's reconcile path, when the workload dies before the bot reports
 `active`): `awaiting_admission` → `awaiting_admission_timeout` (reaped while waiting in the lobby —
 the room never admitted the bot), `requested`/`joining` → `join_failure` (died before it could
-join). The machine-checked
+join). A `meeting_not_found` is NOT a stage attribution: it is the platform answering that the
+meeting space does not exist (a dead, revoked or mistyped code), which is permanent by nature and
+must never be retried (#1325). The machine-checked
 `canTransition` lives in the **runtime/bot implementation** (Stage 2) — the contract documents it; the
 impl enforces it (lean: no separate harness, B8).
 

--- a/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.failed-meeting-not-found.json
+++ b/core/meetings/contracts/lifecycle.v1/golden/LifecycleEvent.failed-meeting-not-found.json
@@ -1,0 +1,9 @@
+{
+  "connection_id": "sess-uid",
+  "status": "failed",
+  "timestamp": "2026-08-25T16:56:19.000Z",
+  "exit_code": 1,
+  "failure_stage": "joining",
+  "completion_reason": "meeting_not_found",
+  "reason": "Google Meet has no such meeting space (startup code 217) — Meet says: \"Check your meeting code\". The link is dead, revoked or mistyped — there is no lobby to join and a retry cannot help. url=https://meet.google.com/aaa-bbbb-ccc"
+}

--- a/core/meetings/contracts/lifecycle.v1/lifecycle.schema.json
+++ b/core/meetings/contracts/lifecycle.v1/lifecycle.schema.json
@@ -9,7 +9,7 @@
     },
     "CompletionReason": {
       "description": "Why a `completed` run ended (operator-facing).",
-      "enum": ["stopped", "left_alone", "startup_alone", "evicted", "awaiting_admission_timeout", "awaiting_admission_rejected", "join_failure", "auth_session_missing", "validation_error", "max_bot_time_exceeded"]
+      "enum": ["stopped", "left_alone", "startup_alone", "evicted", "awaiting_admission_timeout", "awaiting_admission_rejected", "join_failure", "auth_session_missing", "meeting_not_found", "validation_error", "max_bot_time_exceeded"]
     },
     "FailureStage": {
       "description": "Furthest stage reached, for `failed` attribution.",

--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/meeting-not-found.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/scripts/capture-entrypoint.sh
+++ b/core/meetings/modules/join/scripts/capture-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Xvfb + capture-page-dom.ts. Sibling of docker-entrypoint.sh, but it captures a
+# page instead of joining a meeting (see capture-page-dom.ts / #857).
+set -e
+: "${CAPTURE_URL:?set CAPTURE_URL}"
+Xvfb :99 -screen 0 1920x1080x24 -ac +extension RANDR >/tmp/xvfb.log 2>&1 &
+export DISPLAY=:99
+for i in $(seq 1 20); do xdpyinfo -display :99 >/dev/null 2>&1 && break; sleep 0.25; done
+echo "[capture-entrypoint] DISPLAY :99 up — capturing ${CAPTURE_URL}"
+exec npx tsx scripts/capture-page-dom.ts

--- a/core/meetings/modules/join/scripts/capture-page-dom.ts
+++ b/core/meetings/modules/join/scripts/capture-page-dom.ts
@@ -1,0 +1,90 @@
+/**
+ * capture-page-dom.ts — capture a REAL platform page as a checked-in fixture.
+ *
+ * Runs inside the hot debug container (same Xvfb + humanized X11 + stealth browser
+ * as the join harness), so what it captures is what the BOT sees, not what a
+ * developer's desktop Chrome sees. Its whole reason to exist is #857: every DOM
+ * fixture in this module is fabricated, and a fabricated fixture cannot prove a
+ * detector fires on the page production actually renders.
+ *
+ *   docker run --rm -v $PWD/src:/pkg/src -v $PWD/scripts:/pkg/scripts \
+ *     -v $PWD/capture:/pkg/capture \
+ *     -e CAPTURE_URL="https://meet.google.com/aaa-bbbb-ccc" \
+ *     -e CAPTURE_NAME=gmeet-404-meeting-not-found \
+ *     --entrypoint bash meet-join-debug scripts/capture-entrypoint.sh
+ *
+ * Writes to /pkg/capture/<name>.{html,json,png}: the rendered outerHTML, a
+ * metadata sidecar (url, final url, title, html.lang, console lines, response
+ * status), and a screenshot. NEVER captures cookies, storage or headers.
+ */
+import { chromium } from "playwright-extra";
+import StealthPlugin from "puppeteer-extra-plugin-stealth";
+import { getJoinBrowserArgs } from "../src/index";
+import * as fs from "fs";
+import * as path from "path";
+
+const url = process.env.CAPTURE_URL || process.argv[2];
+const name = process.env.CAPTURE_NAME || "capture";
+const settleMs = Number(process.env.CAPTURE_SETTLE_MS || 15000);
+const outDir = process.env.CAPTURE_DIR || "/pkg/capture";
+
+if (!url) {
+  console.error("Usage: CAPTURE_URL=<url> CAPTURE_NAME=<slug> tsx scripts/capture-page-dom.ts");
+  process.exit(1);
+}
+
+(async () => {
+  const stealth = StealthPlugin();
+  stealth.enabledEvasions.delete("iframe.contentWindow");
+  stealth.enabledEvasions.delete("media.codecs");
+  stealth.enabledEvasions.delete("user-agent-override");
+  chromium.use(stealth);
+
+  const browser = await chromium.launch({ headless: false, args: getJoinBrowserArgs() });
+  const context = await browser.newContext({ permissions: ["camera", "microphone"], viewport: null });
+  const page = await context.newPage();
+
+  const consoleLines: string[] = [];
+  page.on("console", (m) => consoleLines.push(`[${m.type()}] ${m.text()}`));
+  page.on("pageerror", (e) => consoleLines.push(`[pageerror] ${String(e)}`));
+
+  const resp = await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(settleMs);
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const html = await page.evaluate(() => document.documentElement.outerHTML);
+  const meta = await page.evaluate(() => ({
+    title: document.title,
+    lang: document.documentElement.getAttribute("lang") || "",
+    navigatorLanguage: navigator.language || "",
+    bodyText: (document.body?.innerText || "").replace(/\s+/g, " ").trim().slice(0, 4000),
+    buttonLabels: Array.from(document.querySelectorAll("button")).map(
+      (b) => (b.textContent || "").replace(/\s+/g, " ").trim(),
+    ),
+  }));
+
+  fs.writeFileSync(path.join(outDir, `${name}.html`), html, "utf8");
+  fs.writeFileSync(
+    path.join(outDir, `${name}.json`),
+    JSON.stringify(
+      {
+        requestedUrl: url,
+        finalUrl: page.url(),
+        httpStatus: resp ? resp.status() : null,
+        capturedAt: new Date().toISOString(),
+        settleMs,
+        ...meta,
+        console: consoleLines,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  try { await page.screenshot({ path: path.join(outDir, `${name}.png`), fullPage: true }); } catch { /* best-effort */ }
+
+  console.log(`=== CAPTURED ${name}: status=${resp ? resp.status() : "?"} finalUrl=${page.url()} htmlBytes=${html.length} consoleLines=${consoleLines.length} ===`);
+  console.log(`--- body text ---\n${meta.bodyText.slice(0, 800)}`);
+  console.log(`--- buttons --- ${JSON.stringify(meta.buttonLabels)}`);
+  await browser.close();
+})();

--- a/core/meetings/modules/join/src/googlemeet/fixtures/README.md
+++ b/core/meetings/modules/join/src/googlemeet/fixtures/README.md
@@ -1,0 +1,46 @@
+# fixtures — captured platform pages
+
+**Everything in this directory is a REAL capture.** That is the whole point of it existing.
+
+Every other Google Meet DOM in this module is fabricated, and says so:
+`join-cta.test.ts` opens with *"FIXTURE HONESTY (#857): the lobby DOMs below are
+FABRICATED, not captured."* A fabricated fixture proves the location logic against a real
+DOM engine; it cannot prove Google's page has that shape. This directory is where the
+second kind of proof lives.
+
+## The rule
+
+A file lands here only if it was served by the platform and captured through
+[`../../../scripts/capture-page-dom.ts`](../../../scripts/capture-page-dom.ts), which runs
+inside the hot debug container (`Dockerfile.debug` — Xvfb, humanized X11, the stealth
+chromium the bot actually joins with). Capturing through a developer's desktop browser
+does not count: the page a bot is served is not always the page a person is served.
+
+Each capture is a pair:
+
+| file | holds |
+|---|---|
+| `<name>.html` | the relevant **subtree**, verbatim, under a comment header recording provenance and what the capture proves |
+| `<name>.meta.json` | requested/final URL, HTTP status, title, `html.lang`, `navigator.language`, body text, button labels, the console lines, and which URLs it reproduced on |
+
+Nothing is edited, reordered or invented — if a capture needs explaining, the explanation
+goes in the header comment, never in the markup.
+
+## Sanitizing
+
+Capture the subtree that matters, not the document: a full Meet page is ~2.4 MB, almost
+all of it script. Check that what you commit contains no `<script>`, no `<style>`, and no
+token-shaped strings. The capture script never reads cookies, storage or headers, so the
+only way secrets get in here is by committing more of the page than the fixture needs.
+
+## Inventory
+
+| fixture | captured | what it is |
+|---|---|---|
+| `gmeet-404-meeting-not-found` | 2026-08-25 | Google Meet's "Check your meeting code" screen for a meeting space that does not exist (`data-startup-code="217"`). Consumed by [`../meeting-not-found.test.ts`](../meeting-not-found.test.ts). Filed as [#1325](https://github.com/Vexa-ai/vexa/issues/1325). |
+
+Still uncaptured, in the order they are worth having: a real Meet lobby (which is what
+[#857](https://github.com/Vexa-ai/vexa/issues/857) actually asks for and would let the
+fabricated `join-cta.test.ts` DOMs be replaced), a real host denial, and the Zoom LFX
+white-label wrapper ([#1261](https://github.com/Vexa-ai/vexa/issues/1261)). The first two
+need a second Google account willing to host and not admit; the third needs only a URL.

--- a/core/meetings/modules/join/src/googlemeet/fixtures/gmeet-404-meeting-not-found.html
+++ b/core/meetings/modules/join/src/googlemeet/fixtures/gmeet-404-meeting-not-found.html
@@ -1,0 +1,43 @@
+<!--
+  REAL CAPTURED FIXTURE — Google Meet "meeting space does not exist" (404) screen.
+
+  Provenance
+    captured   : 2026-08-25
+    harness    : core/meetings/modules/join/scripts/capture-page-dom.ts, run in the
+                 hot debug container (Dockerfile.debug, Xvfb + stealth chromium,
+                 the SAME browser shape the bot joins with) on the bbb host.
+    url        : https://meet.google.com/aaa-bbbb-ccc?hl=en   (a well-formed code
+                 that does not exist; reproduced identically on zzz-yyyy-xxx)
+    http status: 200 (the SPA renders the error; the 404 is the call-setup gRPC)
+    console    : "Failed to load resource: the server responded with a status of
+                 404", then ConnectError x3 and DisconnectedError x5 — byte-for-byte
+                 the signature of prod pods vexa-mtg-26920 / 26921 (2026-08-25),
+                 whose gRPC body read: startupCode: 217, statusCode = 404,
+                 "Requested meeting space does not exist."
+
+  Scope of the capture
+    This is the ERROR-SCREEN SUBTREE only (the div carrying data-startup-code),
+    lifted verbatim from a 2.4 MB document. Nothing was edited, reordered or
+    invented. No cookies, storage, headers or tokens are present — the subtree
+    contains no <script> at all.
+
+  What it proves, and what it corrects
+    1. The screen carries NO join CTA and NO name input. The bot's CTA hunt
+       therefore cannot succeed, and burns its full 60s budget before failing
+       as a generic join_failure.
+    2. The visible copy is "Check your meeting code". NONE of the eight
+       meeting-not-found strings in googleRejectionIndicators ("Meeting not
+       found", "Invalid meeting", "Meeting link expired", …) appear anywhere in
+       the document — those constants were written from imagination, and would
+       have missed this page even if the rejection classifier ran on it.
+    3. The load-bearing signal is STRUCTURAL and locale-agnostic:
+       data-startup-code="217" on the screen container (the same 217 the prod
+       logs print), with data-call-ended="true" on its action buttons.
+    4. "Return to home screen" IS on this page — the same button #471
+       reclassified as a WAITING-room indicator. It must never be the
+       discriminator on its own.
+
+  Unlike the fabricated lobby DOMs in join-cta.test.ts (#857), this file is what
+  Google served.
+-->
+<div class="Fi0Gqc" jsmodel="bFXJu;dpAgje;b0G1je;CcZnhe;" jscontroller="VQ0pCb" jsaction="rcuQ6b:npT2md;VtyfMc:dKWjke;g4fFwf:XkK76;xUQhpc:xmTXPc;ZCn1R:iSJdFd;zXn74e:ddcBJb;oqU8Mc:R0j0c;JIbuQc:JtKe5e(Cjidie),JtKe5e(eHOY6b)" data-companion-mode="false" data-present-mode="false" data-startup-code="217" data-timeout="60000" data-hc-context="4"><div class="lAqQo"><div jscontroller="VMxNjf" class="ODnRWe ptkrG" jsaction="rcuQ6b:pGhgu" jslog="341317;"><div class="RBze0e" jsname="UaslIb"></div></div><h1 jsname="r4nke" class="roSPhc">Check your meeting code</h1><div class="ZQRLqf eZsbJ"><span jsname="PIJwL" class="rzFq7e">Make sure you entered the correct meeting code in the URL, for example: https://meet.google.com/<strong>xxx-yyyy-zzz</strong></span><a jsname="ttVHBc" class="FCnE8d" target="_blank" href="https://support.google.com/meet/answer/10710509?hl=en">Learn more</a></div><div jsname="c6xFrd" class="kJU3pb" data-initial-focus-index="1"><div data-call-ended="true" jscontroller="bNxobe" jsaction="JIbuQc:UxAr5b(dqt8Pb); auxclick:UxAr5b(dqt8Pb)" jslazy="true" data-companion-landing="false" data-present-landing="false" data-is-connection-lost="false" jsname="WIVZEd"><div class="VfPpkd-dgl2Hf-ppHlrf-sM5MNb" data-is-touch-wrapper="true"><button class="UywwFc-LgbsSe UywwFc-LgbsSe-OWXEXe-dgl2Hf UywwFc-StrnGf-YYd4I-VtOx3e UywwFc-kSE8rc-StrnGf-pvxB9-WPi0i ctOmyb q7vyEf" jscontroller="O626Fe" jsaction="click:h5M12e;clickmod:h5M12e;pointerdown:FEiYhc;pointerup:mF5Elf;pointerenter:EX0mI;pointerleave:vpvbp;pointercancel:xyn4sd;contextmenu:xexox; focus:h06R8; blur:zjh6rb;mlnRJb:fLiPzd" data-idom-class="ctOmyb q7vyEf" jsname="dqt8Pb"><span class="XjoK4b"></span><span class="MMvswb"><span class="OLCwg"></span></span><span class="UTNHae" jscontroller="LBaJxb" jsname="m9ZlFb" jsaction="QBlI0e:u4uo5d;BTifte:aV6zj;nqgE9d:f6959e;fHTtBd:ynrQde"></span><span class="UywwFc-RLmnJb"></span><span jsname="Xr1QTb" class="UywwFc-kBDsod-Rtc0Jf UywwFc-kBDsod-Rtc0Jf-OWXEXe-M1Soyc"></span><span jsname="V67aGc" class="UywwFc-vQzf8d">Return to home screen</span><span jsname="UkTUqb" class="UywwFc-kBDsod-Rtc0Jf UywwFc-kBDsod-Rtc0Jf-OWXEXe-UbuQg"></span></button></div></div></div><div></div><div jscontroller="HBEM0c" jsaction="JIbuQc:N7Eqid(rhHFf)" data-call-ended="true" jsname="eHOY6b"><div class="VfPpkd-dgl2Hf-ppHlrf-sM5MNb" data-is-touch-wrapper="true"><button class="mUIrbf-LgbsSe mUIrbf-LgbsSe-OWXEXe-dgl2Hf mUIrbf-StrnGf-YYd4I-VtOx3e mUIrbf-kSE8rc-StrnGf-pvxB9-WPi0i pjt2We" jscontroller="O626Fe" jsaction="click:h5M12e;clickmod:h5M12e;pointerdown:FEiYhc;pointerup:mF5Elf;pointerenter:EX0mI;pointerleave:vpvbp;pointercancel:xyn4sd;contextmenu:xexox; focus:h06R8; blur:zjh6rb;mlnRJb:fLiPzd" data-idom-class="pjt2We" jsname="rhHFf"><span class="XjoK4b"></span><span class="UTNHae" jscontroller="LBaJxb" jsname="m9ZlFb" jsaction="QBlI0e:u4uo5d;BTifte:aV6zj;nqgE9d:f6959e;fHTtBd:ynrQde"></span><span class="mUIrbf-RLmnJb"></span><span jsname="Xr1QTb" class="mUIrbf-kBDsod-Rtc0Jf mUIrbf-kBDsod-Rtc0Jf-OWXEXe-M1Soyc"></span><span jsname="V67aGc" class="mUIrbf-vQzf8d">Submit feedback</span><span jsname="UkTUqb" class="mUIrbf-kBDsod-Rtc0Jf mUIrbf-kBDsod-Rtc0Jf-OWXEXe-UbuQg"></span></button></div></div><div class="MnEWhe" jsname="dhb4h"><div class="RcVecb k3Pzib" jscontroller="x5KxXb" jsaction="rcuQ6b:LzZigc; click:Xc0iL(DPJEMd)"><div class="QoXy2c oJeWuf"><img class="kbSJDc Ce1Y1c" src="https://www.gstatic.com/meet/security_shield_356739b7c38934eec8fb0c8e93de8543.svg" alt="Your meeting is safe" data-iml="3408.7000000178814"><div class="u6zaz"><div class="uh5bac"><h2 class="x4jUzd H72fcf">Your meeting is safe</h2></div><div class="RV5qrc oMJK7">No one can join a meeting unless invited or admitted by the host</div></div></div><div class="YW6vzb"><div class="VfPpkd-dgl2Hf-ppHlrf-sM5MNb" data-is-touch-wrapper="true"><div class="mUIrbf-LgbsSe mUIrbf-LgbsSe-OWXEXe-dgl2Hf mUIrbf-kSE8rc-StrnGf-pvxB9-WPi0i" jscontroller="w9C4d" jsaction="click:h5M12e;clickmod:h5M12e;pointerdown:FEiYhc;pointerup:mF5Elf;pointerenter:EX0mI;pointerleave:vpvbp;pointercancel:xyn4sd;contextmenu:xexox; focus:h06R8; blur:zjh6rb;mlnRJb:fLiPzd" jsname="DPJEMd"><span class="UTNHae" jscontroller="LBaJxb" jsname="m9ZlFb"></span><span jsname="Xr1QTb" class="mUIrbf-kBDsod-Rtc0Jf mUIrbf-kBDsod-Rtc0Jf-OWXEXe-M1Soyc"></span><span jsname="V67aGc" aria-hidden="true" class="mUIrbf-vQzf8d">Learn more</span><span jsname="UkTUqb" class="mUIrbf-kBDsod-Rtc0Jf mUIrbf-kBDsod-Rtc0Jf-OWXEXe-UbuQg"></span><a jsname="hSRGPd" class="mUIrbf-mRLv6 mUIrbf-RLmnJb" href="https://support.google.com/meet/answer/9852160?hl=en" target="_blank" aria-label="Learn more about Google Meet Security &amp; Privacy"></a><span class="XjoK4b mUIrbf-UHGRz"></span></div></div></div></div></div><div jscontroller="RbmC9c" jsaction="rcuQ6b:hqBxXc;YTHmR:P2SeKf;j6YYD:QnPxmd"><div class="cvdVze xo0BHf"><div jscontroller="fKbxOb" class="M1BHXd fleoac" jsname="EEHqpf" jsaction="rcuQ6b:I3Yihd;UeMS3d:I3Yihd" data-line-width="4"><canvas aria-hidden="true" class="XMqAKd" jsname="UzWXSb" width="56" height="56"></canvas><div class="BOo8qd" jsname="Vgu1H" role="timer" aria-label="Returning to home screen">44</div></div><span class="vsfDSb">Returning to home screen</span></div></div></div><div jscontroller="sUf34" jsaction="rcuQ6b:rpmuJd;sb6yqe:aeKUqf" data-hc-context="4" data-hc-mark-fully-rendered="true" style="display: none;"><div></div></div><div style="display: none;"></div></div>

--- a/core/meetings/modules/join/src/googlemeet/fixtures/gmeet-404-meeting-not-found.meta.json
+++ b/core/meetings/modules/join/src/googlemeet/fixtures/gmeet-404-meeting-not-found.meta.json
@@ -1,0 +1,41 @@
+{
+  "capturedAt": "2026-08-25",
+  "harness": "core/meetings/modules/join/scripts/capture-page-dom.ts (Dockerfile.debug container, host bbb)",
+  "requestedUrl": "https://meet.google.com/aaa-bbbb-ccc?hl=en",
+  "finalUrl": "https://meet.google.com/aaa-bbbb-ccc?hl=en",
+  "httpStatus": 200,
+  "title": "Meet",
+  "htmlLang": "en",
+  "navigatorLanguage": "en-US",
+  "bodyText": "Check your meeting code Make sure you entered the correct meeting code in the URL, for example: https://meet.google.com/xxx-yyyy-zzzLearn more Return to home screen Submit feedback Your meeting is safe No one can join a meeting unless invited or admitted by the host Learn more 44 Returning to home screen 45 seconds left",
+  "buttonLabels": [
+    "Return to home screen",
+    "Submit feedback"
+  ],
+  "console": [
+    "[log] %c%s color:teal;font-size:24px Developing an extension for Meet? An add-on would work better.",
+    "[log] %c%s color:teal;font-size:16px Extensions frequently cause user issues by altering the page.",
+    "[log] %c%s font-size:16px https://developers.google.com/meet/add-ons",
+    "[log] %c%s color: red; background: yellow; font-size: 24px; WARNING!",
+    "[log] %c%s font-size: 18px; Using this console may allow attackers to impersonate you and steal your information using an attack called Self-XSS.\nDo not enter or paste code that you do not understand.",
+    "[warning] [GroupMarkerNotSet(crbug.com/242999)!:A098EA01A4260000]Automatic fallback to software WebGL has been deprecated. Please use the --enable-unsafe-swiftshader (about:flags#enable-unsafe-swiftshader) flag to opt in to lower security guarantees for trusted content.",
+    "[info] WebGPU is experimental on this platform. See https://github.com/gpuweb/gpuweb/wiki/Implementation-Status#implementation-status",
+    "[warning] Failed to create WebGPU Context Provider",
+    "[error] Failed to load resource: the server responded with a status of 404 ()",
+    "[pageerror] ConnectError: _.NN",
+    "[pageerror] ConnectError: _.NN",
+    "[pageerror] ConnectError: _.NN",
+    "[pageerror] DisconnectedError: _.bXg",
+    "[pageerror] DisconnectedError: _.bXg",
+    "[pageerror] DisconnectedError: _.bXg",
+    "[pageerror] DisconnectedError: _.bXg",
+    "[pageerror] DisconnectedError: _.bXg"
+  ],
+  "reproducedOn": [
+    "https://meet.google.com/aaa-bbbb-ccc?hl=en",
+    "https://meet.google.com/zzz-yyyy-xxx?hl=en"
+  ],
+  "fullDocumentBytes": 2478178,
+  "capturedSubtree": "the div carrying data-startup-code (the error screen), verbatim",
+  "note": "Sanitized by construction: subtree only, no <script>, no cookies/storage/headers."
+}

--- a/core/meetings/modules/join/src/googlemeet/join.ts
+++ b/core/meetings/modules/join/src/googlemeet/join.ts
@@ -9,7 +9,10 @@ import {
   googleAuthJoinCtaSelectors,
   googleSignedOutLobbyProbeSelectors,
   googleLobbyIconGlyphSelectors,
-  googleLobbyCtaMaxLabelChars
+  googleLobbyCtaMaxLabelChars,
+  googleStartupErrorScreenSelectors,
+  googleStartupErrorHeadingSelectors,
+  googleMeetingNotFoundStartupCodes
 } from "./selectors";
 import { HumanizedInteractor, MOCAP_LIBRARY } from "./humanized";
 import { AdmissionError } from "../shared/admission";
@@ -50,10 +53,150 @@ export function resolveUiInteractionMode(botConfig: BotConfig): "humanized" | "s
   return botConfig.platform === "google_meet" ? "humanized" : "synthetic";
 }
 
+/**
+ * ── The meeting-does-not-exist screen (#1325) ───────────────────────────────
+ *
+ * A dead / revoked / mistyped Meet code does not produce a lobby. Meet's
+ * call-setup RPC returns 404 ("Requested meeting space does not exist") and the
+ * SPA renders an error screen with NO join CTA and NO name input, stamping the
+ * failure code on the screen container as `data-startup-code` (217 for this
+ * class — the same 217 the bot's console prints from Google's own gRPC body).
+ *
+ * Before this existed the bot could not see that screen at all. It entered the
+ * CTA hunt, burned the full 60s budget, and — because the error screen counts
+ * itself down and navigates back to the Meet home page at ~60s — often ended up
+ * filling the home page's "Enter a code or link" box before giving up as a
+ * generic `join_failure`, which the retry classifier then treats as TRANSIENT
+ * and re-spawns against a code that can never exist.
+ *
+ * The existing `googleRejectionIndicators` copy could never have caught it: that
+ * classifier runs inside admission polling, which only begins AFTER a join CTA is
+ * clicked, and none of its eight meeting-not-found strings appear on the real
+ * page anyway (fixtures/gmeet-404-meeting-not-found.html).
+ */
+
+/** What the startup-error screen scan found. `code` is null when no such screen
+ *  is present — which is the ordinary case on every lobby. */
+export interface MeetStartupError { code: string | null; heading: string; body: string }
+export interface MeetStartupErrorOptions { screenSelector: string; headingSelector: string }
+
+/**
+ * Locale-agnostic scan for Meet's startup-error screen.
+ *
+ * RUNS IN BROWSER CONTEXT (page.evaluate serializes this function's source), so
+ * — like findLobbyPrimaryCta — it closes over nothing, reads only its argument
+ * and `document`, and uses plain CSS. That also makes it directly executable
+ * against a jsdom document, which is how meeting-not-found.test.ts pins it
+ * against the REAL captured page rather than a mock.
+ *
+ * The discriminator is the `data-startup-code` attribute, never a word of copy.
+ * An empty attribute value is NOT an error screen — the code must be present and
+ * non-empty for the screen to be claimed.
+ */
+export function findMeetStartupError(opts: MeetStartupErrorOptions): MeetStartupError {
+  const screen = document.querySelector(opts.screenSelector);
+  if (screen === null) return { code: null, heading: "", body: "" };
+  const raw = screen.getAttribute("data-startup-code");
+  const code = raw === null ? "" : raw.trim();
+  if (code.length === 0) return { code: null, heading: "", body: "" };
+  const headEl = screen.querySelector(opts.headingSelector);
+  const heading = headEl === null ? "" : (headEl.textContent || "").replace(/\s+/g, " ").trim();
+  const body = (screen.textContent || "").replace(/\s+/g, " ").trim().slice(0, 300);
+  return { code: code, heading: heading, body: body };
+}
+
+/** No error screen. The one value this module returns whenever it has not
+ *  POSITIVELY recognized a startup-error screen. */
+const NO_STARTUP_ERROR: MeetStartupError = { code: null, heading: "", body: "" };
+
+/**
+ * Run findMeetStartupError in the page.
+ *
+ * FAIL-OPEN BY CONSTRUCTION. This guard terminates a join, so it must only ever
+ * act on a result it positively recognizes: anything else — an evaluate that
+ * threw (navigation mid-flight, closed page), a non-object, a missing or
+ * non-string `code` — resolves to "no error screen" and the join proceeds. The
+ * cost of a false negative is the pre-existing 60s timeout; the cost of a false
+ * positive is refusing a meeting that was joinable.
+ */
+export async function readMeetStartupError(page: Page): Promise<MeetStartupError> {
+  const opts: MeetStartupErrorOptions = {
+    screenSelector: googleStartupErrorScreenSelectors.join(", "),
+    headingSelector: googleStartupErrorHeadingSelectors.join(", "),
+  };
+  let r: any;
+  try {
+    r = await page.evaluate(findMeetStartupError, opts);
+  } catch {
+    return NO_STARTUP_ERROR;
+  }
+  if (r === null || typeof r !== "object") return NO_STARTUP_ERROR;
+  if (typeof r.code !== "string" || r.code.length === 0) return NO_STARTUP_ERROR;
+  return {
+    code: r.code,
+    heading: typeof r.heading === "string" ? r.heading : "",
+    body: typeof r.body === "string" ? r.body : "",
+  };
+}
+
+/**
+ * Typed error for a startup-error screen. `meeting_not_found` ONLY for codes we
+ * have captured AND corroborated in production (googleMeetingNotFoundStartupCodes);
+ * every other code still terminates the join fast — the screen carries no CTA, so
+ * waiting is provably pointless — but is reported as a plain `join_failure`,
+ * because naming a class we have not evidenced is how the copy list above got
+ * written.
+ */
+export function startupErrorToAdmissionError(e: MeetStartupError, url: string): AdmissionError {
+  const code = e.code === null ? "?" : e.code;
+  const said = e.heading.length > 0 ? ` — Meet says: "${e.heading}"` : "";
+  if (e.code !== null && googleMeetingNotFoundStartupCodes.indexOf(e.code) >= 0) {
+    return new AdmissionError(
+      "meeting_not_found",
+      `Google Meet has no such meeting space (startup code ${code})${said}. ` +
+        `The link is dead, revoked or mistyped — there is no lobby to join and a retry cannot help. url=${url}`,
+    );
+  }
+  return new AdmissionError(
+    "join_failure",
+    `Google Meet rendered a startup-error screen (startup code ${code})${said}, which carries no join control. url=${url}`,
+  );
+}
+
+/**
+ * THROW if the page is a Meet startup-error screen. Called (a) once immediately
+ * after navigation, before any CTA or name-input hunting begins — the "pre-CTA"
+ * position that is the whole point of #1325 — and (b) on the poll cadence inside
+ * the selector waits, so a screen that arrives late is still caught in seconds
+ * rather than at the end of a 60s or 120s budget.
+ *
+ * It runs AHEAD of the ordered selector list inside those waits, deliberately.
+ * On the captured error screen the list's broad locale-agnostic backstop
+ * (`button[jsname]:not([aria-label]):has(span)`) matches "Return to home screen"
+ * — the FIRST such button on the page — so a list-first order does not merely
+ * waste the budget, it clicks a control that navigates away from the meeting.
+ * The guard is cheap (one querySelector) and returns immediately on any page
+ * without a startup-error screen, which is every lobby.
+ */
+export async function guardMeetStartupError(page: Page): Promise<void> {
+  const err = await readMeetStartupError(page);
+  if (err.code === null) return;
+  let url = "?";
+  try { url = page.url(); } catch { /* best-effort */ }
+  try {
+    await page.screenshot({ path: "/app/storage/screenshots/bot-checkpoint-startup-error.png", fullPage: true });
+  } catch { /* best-effort */ }
+  log(`📸 Screenshot: Meet startup-error screen (data-startup-code=${err.code}) — "${err.heading}"`);
+  throw startupErrorToAdmissionError(err, url);
+}
+
 /** Poll cadence for the ordered selector resolvers. */
 const SELECTOR_POLL_MS = 300;
 /** The structural CTA scan runs every Nth poll — it is a full-document walk. */
 const CTA_SCAN_EVERY_POLLS = 5;
+/** The startup-error probe (#1325) runs every Nth poll. Cheap (one querySelector),
+ *  but there is no reason to run it 3× a second. */
+const STARTUP_ERROR_EVERY_POLLS = 4;
 /** The scan only starts once the lobby SPA has had time to finish rendering:
  *  a half-built lobby can momentarily expose exactly one text button that is
  *  not the CTA, and the scan's whole safety argument is uniqueness. */
@@ -221,12 +364,18 @@ export async function waitForAnySelector(
   label: string
 ): Promise<{ handle: ElementHandle<Element>; selector: string }> {
   const started = Date.now();
+  let polls = 0;
   do {
+    // #1325 FIRST, not last: on the real error screen the list's broad structural
+    // backstop matches "Return to home screen", so a list-first order would click
+    // the wrong control and navigate off the meeting.
+    if (polls % STARTUP_ERROR_EVERY_POLLS === 0) await guardMeetStartupError(page);
     const hit = await firstVisibleSelector(page, selectors);
     if (hit) {
       log(`Located ${label} via selector: ${hit.selector}`);
       return hit;
     }
+    polls++;
     await page.waitForTimeout(SELECTOR_POLL_MS);
   } while (Date.now() - started < timeoutMs);
 
@@ -265,6 +414,12 @@ export async function waitForLobbyCta(
   // no text-labelled button", never "the scan never got to look".
   let lastLabels: string[] | null = null;
   do {
+    // #1325 FIRST, not last — see waitForAnySelector. The error screen's
+    // "Return to home screen" button satisfies the list's broad structural
+    // backstop (`button[jsname]:not([aria-label]):has(span)`) and sits ahead of
+    // "Submit feedback" in DOM order, so on a dead meeting code a list-first
+    // order resolves it AS THE JOIN CTA and clicks it.
+    if (polls % STARTUP_ERROR_EVERY_POLLS === 0) await guardMeetStartupError(page);
     const hit = await firstVisibleSelector(page, selectors);
     if (hit) {
       log(`Located ${label} via selector: ${hit.selector}`);
@@ -331,6 +486,13 @@ export async function joinGoogleMeeting(
 
   // Brief wait for page elements to settle (networkidle already ensures page loaded)
   await page.waitForTimeout(1000);
+
+  // PRE-CTA (#1325): if Meet answered "no such meeting space", say so NOW. This
+  // runs before the humanized input layer, before the name input and before any
+  // CTA hunting — on a dead code the old path burned 60s looking for a button
+  // that a 404 screen never renders, then reported a generic join_failure the
+  // control plane retried.
+  await guardMeetStartupError(page);
 
   // Record the resolved UI locale on the SUCCESS path too (#856): the locale used
   // to be invisible until a failure. observedPageContext reads navigator.language

--- a/core/meetings/modules/join/src/googlemeet/meeting-not-found.test.ts
+++ b/core/meetings/modules/join/src/googlemeet/meeting-not-found.test.ts
@@ -1,0 +1,311 @@
+/**
+ * The Google Meet "meeting space does not exist" screen (#1325) — driven by the
+ * first REAL captured Meet DOM in this repository.
+ *
+ * THE BUG (prod pods vexa-mtg-26920 / 26921, 2026-08-25, one minute apart):
+ * a dead meeting code makes Meet's call-setup RPC answer
+ * `startupCode: 217 … statusCode = 404 … "Requested meeting space does not
+ * exist."`, and the SPA renders an error screen with NO join CTA and NO name
+ * input. The bot could not see that screen, so it entered the join-CTA hunt,
+ * exhausted the full 60s budget and exited code 1 as a generic `join_failure` —
+ * a reason the retry classifier treats as TRANSIENT, so the control plane
+ * re-spawned a bot against a code that can never exist.
+ *
+ * FIXTURE HONESTY, the other way round for once. Every other Meet DOM in this
+ * module is FABRICATED and says so (#857). The fixture this file loads is NOT:
+ * `fixtures/gmeet-404-meeting-not-found.html` is the error-screen subtree lifted
+ * verbatim from a page Google served on 2026-08-25, captured by
+ * `scripts/capture-page-dom.ts` inside the hot debug container — the same Xvfb +
+ * stealth-chromium shape the bot joins with — against
+ * `https://meet.google.com/aaa-bbbb-ccc`, and reproduced identically on a second
+ * dead code. Its sidecar `.meta.json` carries the console lines, which match the
+ * production pods.
+ *
+ * WHAT THIS FILE PINS
+ *   1. PRE-CTA, and it has to be: on the real page the shipped join-CTA list and
+ *      name-input list resolve NOTHING, and the structural scan refuses (two
+ *      text buttons). Detection therefore cannot live downstream of a CTA click.
+ *   2. The detector fires on the real page, reads the real code (217), and types
+ *      it as `meeting_not_found`.
+ *   3. The copy constants were imagination. NONE of the eight meeting-not-found
+ *      strings in `googleRejectionIndicators` appear on the page Google serves —
+ *      which is why the discriminator is `data-startup-code`, not words.
+ *   4. It cannot fire on a lobby: the fabricated lobby DOMs, an empty attribute,
+ *      and a bare "Return to home screen" button (the #471 WAITING indicator,
+ *      which this page also renders) all resolve to "no error screen".
+ *   5. An unevidenced startup code still terminates fast, but is NOT named
+ *      `meeting_not_found`.
+ *
+ * No browser, no live meeting, no Google.
+ *
+ * Run: npx tsx src/googlemeet/meeting-not-found.test.ts
+ */
+
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'fs';
+import { join as pathJoin } from 'path';
+import {
+  googleJoinButtonSelectors,
+  googleAuthJoinCtaSelectors,
+  googleNameInputSelectors,
+  googleRejectionIndicators,
+  googleLobbyIconGlyphSelectors,
+  googleLobbyCtaMaxLabelChars,
+  googleStartupErrorScreenSelectors,
+  googleStartupErrorHeadingSelectors,
+  googleMeetingNotFoundStartupCodes,
+  googleMeetingNotFoundCopy,
+} from './selectors';
+import {
+  findMeetStartupError, startupErrorToAdmissionError, findLobbyPrimaryCta,
+  readMeetStartupError, waitForLobbyCta, waitForAnySelector,
+} from './join';
+import { AdmissionError } from '../shared/admission';
+import type { MeetStartupError } from './join';
+
+let passed = 0, failed = 0;
+function assert(cond: boolean, msg: string): void {
+  if (cond) { passed++; console.log(`  \x1b[32mPASS\x1b[0m  ${msg}`); }
+  else { failed++; console.log(`  \x1b[31mFAIL\x1b[0m  ${msg}`); }
+}
+
+// ── The REAL capture ────────────────────────────────────────────────────────
+const FIXTURE_DIR = pathJoin(__dirname, 'fixtures');
+const REAL_404 = readFileSync(pathJoin(FIXTURE_DIR, 'gmeet-404-meeting-not-found.html'), 'utf8');
+const REAL_404_META = JSON.parse(
+  readFileSync(pathJoin(FIXTURE_DIR, 'gmeet-404-meeting-not-found.meta.json'), 'utf8'),
+);
+
+// ── Negative controls ───────────────────────────────────────────────────────
+// A minimal English lobby, in the shape join-cta.test.ts fabricates: a name
+// input, icon affordances, and an "Ask to join" CTA.
+const LOBBY = `<!doctype html><html lang="en"><body>
+  <div jscontroller="dyDNGc" class="lobby">
+    <input jsname="YPqjbf" type="text" aria-label="Your name" value="">
+    <button jsname="hw0c9" aria-label="Turn off microphone"><i class="google-material-icons">mic</i></button>
+    <button jsname="psRWwc" aria-label="Turn off camera"><i class="google-material-icons">videocam</i></button>
+    <button jsname="Qx7uuf" class="UywwFc-LgbsSe" data-cta="1"><span jsname="V67aGc">Ask to join</span></button>
+  </div></body></html>`;
+
+// The #471 waiting screen: "Return to home screen" WITHOUT the error container.
+// The real 404 page renders that same button, so it must never discriminate.
+const WAITING_ROOM = `<!doctype html><html lang="en"><body>
+  <div><span>Asking to be let in...</span>
+  <button jsname="dqt8Pb"><span jsname="V67aGc">Return to home screen</span></button>
+  </div></body></html>`;
+
+// The attribute present but empty — "the screen exists" must mean a real code.
+const EMPTY_CODE = `<!doctype html><html lang="en"><body>
+  <div class="Fi0Gqc" data-startup-code=""><h1 jsname="r4nke">Something</h1></div></body></html>`;
+
+// A startup-error screen carrying a code we have NOT evidenced.
+const UNKNOWN_CODE = `<!doctype html><html lang="en"><body>
+  <div class="Fi0Gqc" data-startup-code="150"><h1 jsname="r4nke">You can't join this video call</h1></div>
+  </body></html>`;
+
+function mount(html: string): Document {
+  const dom = new JSDOM(html, { pretendToBeVisual: true });
+  dom.window.Element.prototype.getBoundingClientRect = function (this: Element) {
+    const tag = this.tagName.toLowerCase();
+    const w = tag === 'button' || tag === 'input' ? 120 : 400;
+    const h = tag === 'button' || tag === 'input' ? 36 : 200;
+    return { width: w, height: h, top: 0, left: 0, right: w, bottom: h, x: 0, y: 0, toJSON() { return {}; } };
+  };
+  (globalThis as any).document = dom.window.document;
+  return dom.window.document;
+}
+
+const SCAN_OPTS = {
+  screenSelector: googleStartupErrorScreenSelectors.join(', '),
+  headingSelector: googleStartupErrorHeadingSelectors.join(', '),
+};
+const detect = (html: string) => { mount(html); return findMeetStartupError(SCAN_OPTS); };
+
+/** Playwright selector semantics against a real DOM (same emulation as join-cta.test.ts). */
+function selectorMatches(doc: Document, selector: string): Element[] {
+  if (selector.startsWith('//')) {
+    const r = doc.evaluate(selector, doc, null, 7, null);
+    const out: Element[] = [];
+    for (let i = 0; i < r.snapshotLength; i++) out.push(r.snapshotItem(i) as Element);
+    return out;
+  }
+  const has = /^(.*):has-text\("(.+)"\)$/.exec(selector);
+  if (has) {
+    const needle = has[2].toLowerCase();
+    return Array.from(doc.querySelectorAll(has[1] || '*')).filter((el) =>
+      (el.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase().includes(needle));
+  }
+  const text = /^text=("?)(.+?)\1$/.exec(selector);
+  if (text) {
+    const needle = text[2].toLowerCase();
+    return Array.from(doc.querySelectorAll('*')).filter((el) =>
+      (el.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase().includes(needle));
+  }
+  try { return Array.from(doc.querySelectorAll(selector)); } catch { return []; }
+}
+
+const anyMatch = (doc: Document, list: string[]) =>
+  list.filter((sel) => selectorMatches(doc, sel).length > 0);
+
+(async () => {
+  console.log('\n=== 0. The fixture is a real capture, not a story about one ===');
+  {
+    assert(REAL_404_META.capturedAt === '2026-08-25' && /capture-page-dom\.ts/.test(REAL_404_META.harness),
+      `provenance recorded: captured ${REAL_404_META.capturedAt} by ${REAL_404_META.harness}`);
+    assert(REAL_404_META.console.some((l: string) => l.includes('status of 404')),
+      'the capture carries the browser 404 — the same console line the prod pods printed');
+    assert(REAL_404_META.console.filter((l: string) => l.includes('ConnectError')).length > 0 &&
+           REAL_404_META.console.filter((l: string) => l.includes('DisconnectedError')).length > 0,
+      'and the ConnectError / DisconnectedError pair from vexa-mtg-26920 / 26921');
+    assert(REAL_404_META.reproducedOn.length >= 2,
+      `deterministic: reproduced on ${REAL_404_META.reproducedOn.length} distinct dead codes`);
+    const body = REAL_404.replace(/^<!--[\s\S]*?-->\s*/, '');   // the provenance header is ours, not Google's
+    assert(!/<script/i.test(body) && !/<style/i.test(body),
+      'the checked-in subtree carries no <script> and no <style> — nothing executable, nothing secret');
+  }
+
+  console.log('\n=== 1. WHY IT MUST BE PRE-CTA — the real page offers the join path nothing to find ===');
+  {
+    const doc = mount(REAL_404);
+
+    // Worse than "matches nothing": the list's broad locale-agnostic backstop
+    // matches, and what it matches is the button that LEAVES the meeting.
+    const exact = anyMatch(doc, googleJoinButtonSelectors.filter((s) => !s.includes(':not([aria-label])')));
+    assert(exact.length === 0,
+      'no EXACT join-CTA selector matches the real 404 page (there is no CTA to match)');
+
+    const backstop = 'button[jsname]:not([aria-label]):has(span)';
+    const hits = selectorMatches(doc, backstop);
+    const firstText = hits.length > 0 ? (hits[0].textContent || '').replace(/\s+/g, ' ').trim() : '';
+    assert(googleJoinButtonSelectors.includes(backstop) && firstText === 'Return to home screen',
+      'but the SHIPPED structural backstop matches — and its first hit is "Return to home screen", ' +
+      'the control that navigates OFF the meeting. A list-first order does not waste 60s, it mis-clicks');
+    assert(googleAuthJoinCtaSelectors.includes(backstop),
+      'the authenticated CTA list carries the same backstop, so the authenticated path had the same exposure');
+
+    const name = anyMatch(doc, googleNameInputSelectors);
+    assert(name.length === 0,
+      'NO entry in googleNameInputSelectors matches either — the page has no <input> at all');
+
+    const scan = findLobbyPrimaryCta({
+      iconGlyphSelector: googleLobbyIconGlyphSelectors.join(', '),
+      maxLabelChars: googleLobbyCtaMaxLabelChars,
+    });
+    assert(scan.el === null && scan.labels.length === 2,
+      `the structural scan refuses too — two text buttons, [${scan.labels.join(' | ')}]`);
+
+    // Everything downstream of a CTA click is therefore unreachable on this page.
+    assert(scan.labels.includes('Return to home screen'),
+      'and the page DOES render "Return to home screen" — the #471 WAITING indicator, on a dead meeting');
+  }
+
+  console.log('\n=== 2. The copy constants were imagination (the finding that forced a structural signal) ===');
+  {
+    const doc = mount(REAL_404);
+    const notFoundCopy = googleRejectionIndicators.filter((s) =>
+      /meeting not found|invalid meeting|meeting link expired|unable to join|access denied|can't join the meeting|meeting has ended/i.test(s));
+    assert(notFoundCopy.length >= 8,
+      `googleRejectionIndicators carries ${notFoundCopy.length} meeting-not-found copy entries`);
+    const hits = anyMatch(doc, notFoundCopy);
+    assert(hits.length === 0,
+      'and NOT ONE of them matches the page Google actually serves — the whole list would have missed');
+    assert(googleMeetingNotFoundCopy.some((c) => REAL_404.includes(c)),
+      `the real copy is "${googleMeetingNotFoundCopy[0]}" — captured, not guessed`);
+  }
+
+  console.log('\n=== 3. The detector fires on the real page, and reads the real code ===');
+  {
+    const e = detect(REAL_404);
+    assert(e.code === '217', `data-startup-code read as "${e.code}" — the same 217 the prod gRPC body printed`);
+    assert(e.heading === 'Check your meeting code', `heading captured for the diagnostic: "${e.heading}"`);
+    assert(googleMeetingNotFoundStartupCodes.includes(e.code!),
+      '217 is in the evidenced meeting-not-found code set');
+
+    const err = startupErrorToAdmissionError(e, 'https://meet.google.com/aaa-bbbb-ccc');
+    assert(err instanceof AdmissionError && err.outcome === 'meeting_not_found',
+      'typed as AdmissionError("meeting_not_found") — NOT the generic join_failure prod recorded');
+    assert(err.message.includes('217') && err.message.includes('Check your meeting code') &&
+           err.message.includes('aaa-bbbb-ccc'),
+      'the message carries code + Meet\'s own words + the url, so meeting.data.last_error diagnoses alone');
+    assert(/retry cannot help/i.test(err.message),
+      'and says why no retry can help — the reason this reason is PERMANENT');
+  }
+
+  console.log('\n=== 4. It cannot fire on a joinable page (the expensive direction to get wrong) ===');
+  {
+    assert(detect(LOBBY).code === null, 'an English lobby with a CTA → no error screen');
+    assert(detect(WAITING_ROOM).code === null,
+      '"Return to home screen" alone (the #471 waiting screen) → no error screen; the button never discriminates');
+    assert(detect(EMPTY_CODE).code === null, 'data-startup-code="" → not an error screen (a code must be a code)');
+    assert(detect('<!doctype html><html><body><div>nothing here</div></body></html>').code === null,
+      'an unrelated page → no error screen');
+
+    // And the lobby still resolves its CTA — detection changed nothing about joining.
+    const doc = mount(LOBBY);
+    assert(anyMatch(doc, googleJoinButtonSelectors).length > 0,
+      'the lobby CTA still resolves by the shipped list (the join path is untouched)');
+  }
+
+  console.log('\n=== 5. An unevidenced startup code: fail fast, but do not name what we have not seen ===');
+  {
+    const e = detect(UNKNOWN_CODE);
+    assert(e.code === '150', 'an unknown startup-error screen is still recognised as one');
+    const err = startupErrorToAdmissionError(e, 'https://meet.google.com/xxx-yyyy-zzz');
+    assert(err.outcome === 'join_failure',
+      'but is typed join_failure, not meeting_not_found — we have not earned that name for code 150');
+    assert(err.message.includes('150') && /no join control/.test(err.message),
+      'while still saying what it saw, so the next occurrence is one look away from a diagnosis');
+  }
+
+  console.log('\n=== 6. Ordering, on a page object — the guard runs BEFORE the selector list resolves anything ===');
+  {
+    // A page that is the real 404 screen AND on which the shipped backstop selector
+    // is visible: exactly the production shape. If the list won the race, the join
+    // would click "Return to home screen"; the guard must win instead.
+    const backstop = 'button[jsname]:not([aria-label]):has(span)';
+    const errorScreenPage = (over: Partial<MeetStartupError> = {}) => ({
+      url: () => 'https://meet.google.com/aaa-bbbb-ccc',
+      locator: (sel: string) => ({
+        first: () => ({
+          isVisible: async () => sel === backstop,
+          elementHandle: async () => (sel === backstop ? { __element: true } : null),
+        }),
+      }),
+      waitForTimeout: async () => { await new Promise((r) => setTimeout(r, 1)); },
+      screenshot: async () => {},
+      evaluate: async () => ({ code: '217', heading: 'Check your meeting code', body: '', ...over }),
+      evaluateHandle: async () => ({
+        getProperty: async () => ({ jsonValue: async () => [], asElement: () => null }),
+        dispose: async () => {},
+      }),
+    });
+
+    let thrown: any = null;
+    try {
+      await waitForLobbyCta(errorScreenPage() as any, googleJoinButtonSelectors, 5000, 'join button');
+    } catch (e) { thrown = e; }
+    assert(thrown instanceof AdmissionError && thrown.outcome === 'meeting_not_found',
+      'waitForLobbyCta throws meeting_not_found even though the backstop selector IS visible — no mis-click');
+
+    thrown = null;
+    try {
+      await waitForAnySelector(errorScreenPage() as any, googleNameInputSelectors, 5000, 'name input');
+    } catch (e) { thrown = e; }
+    assert(thrown instanceof AdmissionError && thrown.outcome === 'meeting_not_found',
+      'the 120s name-input wait terminates on the same guard, in one poll rather than two minutes');
+
+    // Fail-open: a page whose evaluate returns something unrecognised must NOT abort a join.
+    const junkPage = {
+      url: () => 'https://meet.google.com/abc-defg-hij',
+      evaluate: async () => ({ lang: 'en', nav: 'en-US' }),   // the shape observedPageContext returns
+    };
+    assert((await readMeetStartupError(junkPage as any)).code === null,
+      'an unrecognised evaluate result → no error screen (the guard fails OPEN, never closed)');
+    const throwingPage = { url: () => 'x', evaluate: async () => { throw new Error('navigating'); } };
+    assert((await readMeetStartupError(throwingPage as any)).code === null,
+      'an evaluate that throws mid-navigation → no error screen either');
+  }
+
+  console.log(`\n${failed === 0 ? '\x1b[32m' : '\x1b[31m'}${passed} passed, ${failed} failed\x1b[0m\n`);
+  process.exit(failed === 0 ? 0 : 1);
+})();

--- a/core/meetings/modules/join/src/googlemeet/selectors.ts
+++ b/core/meetings/modules/join/src/googlemeet/selectors.ts
@@ -101,7 +101,16 @@ export const googleRejectionIndicators: string[] = [
   'text=Ask to join again',
   'button:has-text("Ask to join again")',
 
-  // Meeting not found or access denied patterns
+  // Meeting not found or access denied patterns.
+  //
+  // ⚠️ 2026-08-25 (#1325): the eight strings below were written from imagination
+  // and NONE of them appear on the page Google actually serves for a dead meeting
+  // code — that page says "Check your meeting code" (see
+  // fixtures/gmeet-404-meeting-not-found.html, the first REAL captured Meet DOM in
+  // this repo). They are kept because they may still match OTHER Meet error
+  // screens we have not captured, but they must not be relied on for the
+  // meeting-does-not-exist class: that class is detected STRUCTURALLY, ahead of
+  // the join CTA, via googleStartupErrorScreenSelector below.
   'text="Meeting not found"',
   'text="Can\'t join the meeting"',
   'text="Unable to join"',
@@ -474,6 +483,52 @@ export const googlePeopleButtonSelectors: string[] = [
   'button[data-tooltip*="Participants"]'
 ];
 
+// ── Meet startup-error screen (#1325) ───────────────────────────────────────
+//
+// When the call-setup RPC fails, Meet does NOT render a lobby: it renders an
+// error screen with no join CTA and no name input, and it stamps the failure
+// code onto that screen's container as `data-startup-code`. A dead / revoked /
+// mistyped meeting code produces `data-startup-code="217"`, which is the very
+// same `startupCode: 217` the bot's own console prints alongside Google's gRPC
+// body `statusCode = 404 … "Requested meeting space does not exist."` (prod pods
+// vexa-mtg-26920 / 26921, 2026-08-25).
+//
+// This attribute is the discriminator BECAUSE it is not words: it survives every
+// locale and every copy revision, which the copy list above demonstrably did not.
+// Captured, not imagined — fixtures/gmeet-404-meeting-not-found.html.
+//
+// Consumed in BROWSER CONTEXT by findMeetStartupError (join.ts), so these are
+// plain CSS and are declared in browserContextSelectorArrays below.
+export const googleStartupErrorScreenSelectors: string[] = [
+  '[data-startup-code]'
+];
+
+// The error screen's heading element, whose text is the localized reason
+// ("Check your meeting code" in en). Read for the diagnostic message only —
+// never as the discriminator.
+export const googleStartupErrorHeadingSelectors: string[] = [
+  '[jsname="r4nke"]',
+  'h1'
+];
+
+// Startup codes that mean THE MEETING SPACE DOES NOT EXIST, mapped to the typed
+// `meeting_not_found` admission outcome (permanent: a re-spawn cannot succeed).
+// 217 is the only value we have captured AND corroborated against a production
+// gRPC body; a startup-error screen carrying any OTHER code still terminates the
+// join fast (the screen has no CTA — waiting is pointless) but is reported as a
+// plain join_failure with the code in the message, because we have not earned
+// the right to name it.
+export const googleMeetingNotFoundStartupCodes: string[] = [
+  '217'
+];
+
+// The en-US copy this screen renders, kept for the human-readable diagnostic and
+// as a corroborating (never sole) signal. Verbatim from the capture.
+export const googleMeetingNotFoundCopy: string[] = [
+  'Check your meeting code',
+  'Requested meeting space does not exist'
+];
+
 // EXECUTION-CONTEXT DECLARATION — consumed by src/shared/selector-validity.test.ts.
 // Arrays named here ship into page.evaluate and run through
 // document.querySelector, so the gate additionally CSS-parses them: a
@@ -484,5 +539,7 @@ export const googlePeopleButtonSelectors: string[] = [
 export const browserContextSelectorArrays: string[] = [
   'googleLeaveButtonMatchers',
   'googleLobbyIconGlyphSelectors',
+  'googleStartupErrorScreenSelectors',
+  'googleStartupErrorHeadingSelectors',
 ];
 

--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -137,7 +137,8 @@ export async function joinMeeting(page: Page, opts: JoinOptions): Promise<JoinRe
 }
 
 export { joinGoogleMeeting, waitForGoogleMeetingAdmission, checkForGoogleAdmissionSilent, prepareForRecording, leaveGoogleMeet, startGoogleRemovalMonitor };
-// AdmissionError carries a TYPED `outcome` (denial / lobby_timeout / join_failure / auth_session_missing).
+// AdmissionError carries a TYPED `outcome` (denial / lobby_timeout / join_failure / auth_session_missing /
+// meeting_not_found).
 // It is THROWN by the join/admission path; the JoinDriver adapter catches it and maps the outcome → a
 // JoinOutcome so a host DENIAL is recorded as a permanent `rejected` — and a signed-out profile
 // (AuthSessionError, an AdmissionError subclass) as the permanent `auth_session_missing` — never
@@ -145,6 +146,11 @@ export { joinGoogleMeeting, waitForGoogleMeetingAdmission, checkForGoogleAdmissi
 export { AdmissionError } from "./shared/admission";
 export type { AdmissionOutcome } from "./shared/admission";
 export { AuthSessionError } from "./googlemeet/join";
+// #1325: Meet answers a dead meeting code with a startup-error screen that has no join CTA — detected
+// PRE-CTA and thrown as the PERMANENT `meeting_not_found`, so the control plane stops re-spawning
+// bots against a code that cannot exist.
+export { findMeetStartupError, readMeetStartupError, guardMeetStartupError, startupErrorToAdmissionError } from "./googlemeet/join";
+export type { MeetStartupError, MeetStartupErrorOptions } from "./googlemeet/join";
 export { joinMicrosoftTeams, waitForTeamsMeetingAdmission, checkForTeamsAdmissionSilent, prepareForTeamsRecording, leaveMicrosoftTeams, startTeamsRemovalMonitor };
 // The Teams anonymous-join origin guard. A meetup-join redirected to the Microsoft sign-in host
 // terminates the join THERE with `TeamsJoinRedirectError` — deliberately not an AdmissionError, so

--- a/core/meetings/modules/join/src/shared/admission.ts
+++ b/core/meetings/modules/join/src/shared/admission.ts
@@ -4,6 +4,9 @@
  * denial               — a moderator/host explicitly rejected the bot from the lobby/waiting room.
  * lobby_timeout        — the bot stayed in the lobby/waiting state past the admission timeout.
  * join_failure         — the bot never reached the lobby / no admission signal ever appeared.
+ * meeting_not_found    — the platform answered that the meeting SPACE does not exist (a dead,
+ *                        revoked or mistyped code). There is no lobby to reach and no CTA to
+ *                        click, so waiting cannot help and a re-spawn can never succeed.
  * auth_session_missing — authenticated mode found a signed-out browser profile (the guest lobby
  *                        rendered); the profile is dead, so a re-spawn can never succeed.
  *
@@ -12,7 +15,12 @@
  * `shared/` so each platform throws the SAME class the driver checks with `instanceof`, without
  * coupling one platform sibling to another.
  */
-export type AdmissionOutcome = "denial" | "lobby_timeout" | "join_failure" | "auth_session_missing";
+export type AdmissionOutcome =
+  | "denial"
+  | "lobby_timeout"
+  | "join_failure"
+  | "auth_session_missing"
+  | "meeting_not_found";
 
 export class AdmissionError extends Error {
   readonly outcome: AdmissionOutcome;

--- a/core/meetings/services/bot/src/contracts.ts
+++ b/core/meetings/services/bot/src/contracts.ts
@@ -29,6 +29,8 @@ export type CompletionReason =
   | 'awaiting_admission_rejected'
   | 'join_failure'
   | 'auth_session_missing'
+  /** the platform answered that the meeting SPACE does not exist (#1325) */
+  | 'meeting_not_found'
   | 'validation_error'
   | 'max_bot_time_exceeded';
 

--- a/core/meetings/services/bot/src/join-driver.test.ts
+++ b/core/meetings/services/bot/src/join-driver.test.ts
@@ -20,7 +20,7 @@ const check = (name: string, cond: boolean) => {
 // JoinOutcomes the orchestrator (OUTCOME_FAIL) + retry.py treat as PERMANENT (no retry):
 // 'rejected' → awaiting_admission_rejected. Transient (retried): 'timeout' → awaiting_admission_timeout,
 // 'error'/'blocked' → join_failure.
-const PERMANENT_OUTCOMES = new Set<JoinOutcome>(['rejected', 'auth_missing']);
+const PERMANENT_OUTCOMES = new Set<JoinOutcome>(['rejected', 'auth_missing', 'meeting_not_found']);
 
 console.log('\n=== join-driver: AdmissionError outcome → JoinOutcome (G1) ===');
 
@@ -58,6 +58,17 @@ check('TeamsJoinRedirectError is NOT an AdmissionError (driver re-raises → mes
   !(teamsRedirect instanceof AdmissionError));
 check('TeamsJoinRedirectError carries the typed reasonCode in its message',
   teamsRedirect.message.startsWith(`${TEAMS_AUTH_REDIRECT}:`));
+
+// #1325 — a dead / revoked / mistyped Google Meet code. Meet renders a startup-error screen with no
+// join CTA, detected PRE-CTA; the outcome must be its own PERMANENT reason. Before this it fell out
+// as a generic `join_failure`, which `retry.py` classes TRANSIENT — so the control plane re-spawned
+// bots against a meeting space that does not exist.
+check('meeting_not_found → meeting_not_found', admissionOutcomeToJoinOutcome('meeting_not_found') === 'meeting_not_found');
+const gone = new AdmissionError('meeting_not_found', 'Google Meet has no such meeting space (startup code 217)');
+const goneMapped = admissionOutcomeToJoinOutcome(gone.outcome);
+check('AdmissionError("meeting_not_found") is caught by the driver (instanceof AdmissionError)', gone instanceof AdmissionError);
+check('a dead meeting code is PERMANENT (no re-spawn can conjure the space into existence)', PERMANENT_OUTCOMES.has(goneMapped));
+check('and it is NOT the transient/retried join_failure prod recorded', goneMapped !== 'error' && goneMapped !== 'timeout');
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/core/meetings/services/bot/src/join-driver.ts
+++ b/core/meetings/services/bot/src/join-driver.ts
@@ -27,7 +27,9 @@ import type { JoinDriver, JoinOutcome, JoinResult } from './ports.js';
  * `lobby_timeout` → `timeout` → `awaiting_admission_timeout` (transient, a legit retry); a `join_failure`
  * stays `error` → `join_failure` (transient); an `auth_session_missing` (signed-out profile in
  * authenticated mode) → `auth_missing` → `auth_session_missing` (PERMANENT — a re-spawn against a dead
- * profile can never succeed). NB: a distinct `blocked` reason needs a sealed-contract
+ * profile can never succeed); a `meeting_not_found` (Meet's startup-error screen for a dead meeting
+ * code, #1325) → `meeting_not_found` → `meeting_not_found` (PERMANENT — no re-spawn can conjure the
+ * meeting space into existence). NB: a distinct `blocked` reason needs a sealed-contract
  * `CompletionReason` value (lane:contract) — until then a detected block surfaces via this same path.
  */
 export function admissionOutcomeToJoinOutcome(outcome: AdmissionOutcome): JoinOutcome {
@@ -35,6 +37,7 @@ export function admissionOutcomeToJoinOutcome(outcome: AdmissionOutcome): JoinOu
     case 'denial':               return 'rejected';
     case 'lobby_timeout':        return 'timeout';
     case 'auth_session_missing': return 'auth_missing';
+    case 'meeting_not_found':    return 'meeting_not_found';
     case 'join_failure':         return 'error';
     default:                     return 'error';
   }
@@ -72,7 +75,7 @@ export function createBrowserJoinDriver(page: Page, inv: Invocation): JoinDriver
           hooks: { onState: (s: JoinState) => { const bs = mapState(s); if (bs) void report(bs); } },
         });
       } catch (e) {
-        // A TYPED admission verdict (denial/lobby_timeout/join_failure) → map its outcome so the
+        // A TYPED admission verdict (denial/lobby_timeout/join_failure/meeting_not_found) → map its outcome so the
         // control plane records the truth, not a generic retried `join_failure` (G1). CARRY the
         // AdmissionError's own message as the reason text (#926) — that's the real Zoom cause
         // ("auth_required: …", "host did not start …") the terminal lifecycle row would otherwise

--- a/core/meetings/services/bot/src/orchestrator.ts
+++ b/core/meetings/services/bot/src/orchestrator.ts
@@ -93,6 +93,7 @@ const OUTCOME_FAIL: Record<Exclude<JoinOutcome, 'admitted'>, CompletionReason> =
   timeout: 'awaiting_admission_timeout',
   blocked: 'join_failure',
   auth_missing: 'auth_session_missing',
+  meeting_not_found: 'meeting_not_found',
   error: 'join_failure',
 };
 

--- a/core/meetings/services/bot/src/ports.ts
+++ b/core/meetings/services/bot/src/ports.ts
@@ -17,7 +17,11 @@ import type { BotStatus, LifecycleEvent, Act, TranscriptSegment } from './contra
 
 /** The outcome of the join+admission attempt (an Anti-Corruption verdict, P5 — the
  *  platform's many failure modes translated into the bot's vocabulary). */
-export type JoinOutcome = 'admitted' | 'rejected' | 'timeout' | 'blocked' | 'auth_missing' | 'error';
+export type JoinOutcome =
+  | 'admitted' | 'rejected' | 'timeout' | 'blocked' | 'auth_missing'
+  /** the platform says the meeting SPACE does not exist — permanent, never retried (#1325) */
+  | 'meeting_not_found'
+  | 'error';
 
 /** A join verdict that CARRIES its human reason text. A non-admitted platform failure is born with
  *  a message (the @vexa/join AdmissionError text: "auth_required: …", "host did not start …") — but

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/README.md
@@ -52,7 +52,8 @@ webhook body `{old_status, new_status, reason, transition_source ∈ user_stop|b
 
 ## P3d taxonomy
 TRANSIENT → retry: `awaiting_admission_timeout`, `join_failure`. PERMANENT → no retry → failed:
-`awaiting_admission_rejected`, `evicted`, `validation_error`, `max_bot_time_exceeded`, user `stopped`
+`awaiting_admission_rejected`, `evicted`, `validation_error`, `max_bot_time_exceeded`,
+`auth_session_missing`, `meeting_not_found` (the meeting space does not exist — #1325), user `stopped`
 (+ `left_alone`/`startup_alone`, which are normal outcomes). Unknown/None → PERMANENT (fail-safe).
 
 ## Evals

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/machine.py
@@ -45,6 +45,7 @@ class CompletionReason(str, Enum):
     AWAITING_ADMISSION_REJECTED = "awaiting_admission_rejected"
     JOIN_FAILURE = "join_failure"
     AUTH_SESSION_MISSING = "auth_session_missing"
+    MEETING_NOT_FOUND = "meeting_not_found"
     VALIDATION_ERROR = "validation_error"
     MAX_BOT_TIME_EXCEEDED = "max_bot_time_exceeded"
 

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/occurrence.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/occurrence.py
@@ -36,7 +36,8 @@ The retry set is DERIVED from the sealed taxonomy already in ``retry.py`` (TRANS
   stands and the backoff bounds it.
 
 Every other reason is SERVED: the host rejected us (``awaiting_admission_rejected``), the profile is
-signed out (``auth_session_missing``), the request was malformed (``validation_error``), or the
+signed out (``auth_session_missing``), the meeting space does not exist (``meeting_not_found`` —
+a dead, revoked or mistyped code; #1325), the request was malformed (``validation_error``), or the
 reason belongs to the active phase at all (``evicted``, ``left_alone``, ``startup_alone``,
 ``max_bot_time_exceeded``) — in which case the bot was in the room whatever the stage says.
 """

--- a/core/meetings/services/meeting-api/src/meeting_api/lifecycle/retry.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/lifecycle/retry.py
@@ -12,7 +12,8 @@ transient/permanent split):
   * **TRANSIENT → retry**: ``awaiting_admission_timeout``, ``join_failure`` (network / transient error).
   * **PERMANENT → no retry → failed**: ``awaiting_admission_rejected``, ``evicted``,
     ``validation_error``, ``max_bot_time_exceeded``, ``auth_session_missing`` (a re-spawn hits the
-    same signed-out profile), and the user terminal ``stopped``.
+    same signed-out profile), ``meeting_not_found`` (the platform says the meeting SPACE does not
+    exist — no re-spawn can conjure it into being; #1325), and the user terminal ``stopped``.
 
 Bounded to a few attempts (config, default 3). Each attempt is its OWN ``meeting_session`` (a fresh
 ``connectionId``) — the scheduler fires a ``POST /bots`` re-spawn request for the next attempt.
@@ -48,6 +49,7 @@ _PERMANENT: frozenset[CompletionReason] = frozenset(
         CompletionReason.MAX_BOT_TIME_EXCEEDED,
         CompletionReason.STOPPED,        # user stop is terminal — never retried
         CompletionReason.AUTH_SESSION_MISSING,  # signed-out profile — a re-spawn hits the same dead profile
+        CompletionReason.MEETING_NOT_FOUND,  # dead/revoked/mistyped code — the space does not exist (#1325)
         CompletionReason.STARTUP_ALONE,  # alone-on-start is a real outcome, not a transient fault
         CompletionReason.LEFT_ALONE,     # a normal completion, not a failure
     }

--- a/core/meetings/services/meeting-api/tests/test_auto_join_occurrence_matrix.py
+++ b/core/meetings/services/meeting-api/tests/test_auto_join_occurrence_matrix.py
@@ -117,6 +117,11 @@ MATRIX: list[Cell] = [
     Cell("failed/auth_session_missing", status="failed", reason="auth_session_missing",
          stage="joining", expect=SERVED,
          why="signed-out profile; a re-spawn hits the same dead cookie jar"),
+    Cell("failed/meeting_not_found", status="failed", reason="meeting_not_found", stage="joining",
+         expect=SERVED,
+         why="Google Meet answered that the meeting SPACE does not exist (#1325) — a dead, revoked "
+             "or mistyped code. Nothing about a re-dispatch conjures it into being, and before the "
+             "reason existed this landed as a TRANSIENT join_failure that the sweep kept retrying"),
     Cell("failed/validation_error", status="failed", reason="validation_error", stage="requested",
          expect=SERVED, why="the request itself is malformed — identical on every retry"),
     Cell("failed/join_failure@active", status="failed", reason="join_failure", stage="active",

--- a/docs/changelog.d/1325-gmeet-meeting-not-found.md
+++ b/docs/changelog.d/1325-gmeet-meeting-not-found.md
@@ -1,0 +1,7 @@
+- **A dead Google Meet code now ends in seconds with its own reason, not a retried `join_failure`
+  (#1325).** When Meet answers that a meeting space does not exist, it renders an error screen with
+  no join control at all. The bot used to hunt that screen for a join button for the full 60s budget
+  and report the generic `join_failure` — a reason the control plane classes transient, so it
+  re-spawned bots against a code that can never exist. The screen is now detected before any button
+  hunting and reported as the new `meeting_not_found` completion reason, which is permanent and
+  never retried.

--- a/docs/docs/architecture/evaluation.mdx
+++ b/docs/docs/architecture/evaluation.mdx
@@ -132,7 +132,7 @@ golden fixtures beside it.
 
 `CompletionReason` — the schema's own word for it is *operator-facing*: `stopped · left_alone ·
 startup_alone · evicted · awaiting_admission_timeout · awaiting_admission_rejected · join_failure ·
-auth_session_missing · validation_error · max_bot_time_exceeded`.
+auth_session_missing · meeting_not_found · validation_error · max_bot_time_exceeded`.
 
 `FailureStage`: `requested · joining · awaiting_admission · active` — which is what separates a
 broken node from a refused join. Events also carry `exit_code`, a `bot_logs` ring buffer, an


### PR DESCRIPTION
**Delivers issue:** [#1325](https://github.com/Vexa-ai/vexa/issues/1325)

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> ⚠️ **Two attestations here are deliberately left for a human, and both are currently red.**
> The `contribution-rights` gate wants exactly one box above ticked, and `DCO` wants a
> `Signed-off-by` trailer on both commits. Both are legal certifications — an agent must not tick
> the box or write the sign-off on someone's behalf, so this PR ships them unfilled rather than
> forged. Ticking the box, and `git rebase --signoff origin/main && git push --force-with-lease`,
> are the two human steps between this and a mergeable PR.

## The failure this ends

A Google Meet code that no longer exists (expired, revoked, mistyped, a stale calendar entry) does
not render a lobby. Meet's call-setup gRPC returns **404 — "Requested meeting space does not
exist"** and the SPA renders an error screen with **no join CTA and no name input**.

The bot did not know that screen existed. It entered the join-CTA hunt, spent its **full 60s budget**
polling for a button that will never appear, exited 1, and the JoinDriver mapped it to the generic
**`join_failure`** — a reason the retry classifier treats as **transient**, so the control plane
**re-spawned a bot against a meeting code that cannot ever exist**.

Two production pods, one minute apart, same operator (2026-08-25):

| pod | window (UTC) | outcome |
|---|---|---|
| `vexa-mtg-26920-d320aaea` | 16:56:17 → 16:57:25 | 68s, exit 1, `join_failure` |
| `vexa-mtg-26921-e1dc9521` | 16:57:12 → 16:58:19 | 67s, exit 1, `join_failure` |

## The structural gap

`googleRejectionIndicators` in `selectors.ts` already carried `"Meeting not found"` /
`"Invalid meeting"` / `"Meeting link expired"` copy. **It was structurally unreachable for this
failure**: `classifyGoogleRejection` runs inside admission polling, which only starts *after a join
CTA has been clicked* — and this page has no CTA. The one classifier that could name the failure
sat behind a gate the failure can never pass through.

## What the real capture corrected

Captured 2026-08-25 through the repo's own debug harness against
`https://meet.google.com/aaa-bbbb-ccc`, reproduced identically on a second dead code:

1. **The visible copy is "Check your meeting code".** Not one of the sixteen meeting-not-found
   strings in `googleRejectionIndicators` appears anywhere in the 2.4 MB document. Those constants
   were written from imagination and would have missed this page even if the classifier had run.
   The test asserts this directly, so the finding cannot quietly rot.
2. **The load-bearing signal is structural:** `data-startup-code="217"` on the error-screen
   container — the same `217` the prod gRPC body printed. Locale-agnostic; it does not depend on
   Google's wording.
3. The page **does** render a `Return to home screen` button — the control
   [#471](https://github.com/Vexa-ai/vexa/issues/471) reclassified as a *waiting-room* indicator, and
   the one our structural CTA backstop matches **first**. So the pre-fix behaviour was not merely
   "waste 60s": on the authenticated path it could **click the control that navigates off the
   meeting**. The test pins that the button never discriminates on its own.

## The change

- **Pre-CTA guard** (`join.ts`): `readMeetStartupError` → `startupErrorToAdmissionError` →
  `guardMeetStartupError`, run **before** the join-CTA list resolves anything and inside both the
  CTA wait and the 120s name-input wait. It reads `data-startup-code` structurally, never copy.
- **Evidenced codes only.** `217` is in `googleMeetingNotFoundStartupCodes` and types
  `AdmissionError("meeting_not_found")`. An *unrecognised* startup-error screen still fails fast, but
  as `join_failure` — we do not name what we have not captured. The guard **fails open**: an
  unparseable evaluate result or a mid-navigation throw yields no error screen, so a joinable page
  can never be killed by it.
- **A distinct reason, wired end to end.** `meeting_not_found` added to the sealed
  `lifecycle.v1` `CompletionReason` enum (re-sealed, golden added), `JoinOutcome`, the bot
  `CompletionReason`, `OUTCOME_FAIL`, and the meeting-api `CompletionReason` — so it reaches
  `meetings.data.completion_reason`.
- **Permanent by classification.** `classify_retry` is PERMANENT-by-default and
  `meeting_not_found` is deliberately absent from `_TRANSIENT`, so the control plane stops
  re-spawning against a dead code. Documented in `retry.py`, `occurrence.py` and the lifecycle READMEs.
- The error message carries **code + Meet's own heading + the URL**, so `last_error` diagnoses
  without a log dive.

## Fixture provenance

`core/meetings/modules/join/src/googlemeet/fixtures/gmeet-404-meeting-not-found.html`
(+ `.meta.json`) — **the repo's first real captured Meet DOM**
([#857](https://github.com/Vexa-ai/vexa/issues/857): every other Meet fixture is fabricated and says
so). Captured by the new `scripts/capture-page-dom.ts` running inside `Dockerfile.debug` — Xvfb,
humanized X11, the stealth chromium the bot actually joins with — because the page a bot is served
is not always the page a person is served.

Sanitized by construction: the error-screen subtree verbatim, no `<script>`, no cookies, storage or
headers. The `.meta.json` records requested/final URL, HTTP status, `navigator.language`, body text,
button labels, console tail, the second reproducing code, and the full document size.
`fixtures/README.md` states the rule for what may land there.

## Validation

All run against this branch at `591e3f4b`.

| suite | result |
|---|---|
| `core/meetings/modules/join` — full `npm test` (21 files) | green, exit 0 |
| `src/googlemeet/meeting-not-found.test.ts` (the real fixture) | **32 passed, 0 failed** |
| `core/meetings/services/bot` — `src/join-driver.test.ts` | 17 passed, 0 failed |
| `meeting-api` pytest, lifecycle/retry/occurrence/machine selection | 322 passed, 2 skipped |
| `gate:contract-version` | 25 sealed contracts frozen |
| `gate:schema` | 25 contracts conform (goldens ≡ schema) |
| `gate:readme` | 327 dirs each carry a README |

No container workload ran on the laptop: every suite above is `tsx`/`pytest`/Node, and the capture
itself ran in Docker on the build host, not here.

## Collision check

Branch is cut from and current with `main` (`4647c96e`). Of the open PRs touching these files:
[#1252](https://github.com/Vexa-ai/vexa/pull/1252) and
[#1251](https://github.com/Vexa-ai/vexa/pull/1251) touch `selectors.ts`, `contracts.ts` and
`machine.py` but neither adds a `CompletionReason` and neither touches `googlemeet/join.ts`; the
edits here are additive to those files.
[#1196](https://github.com/Vexa-ai/vexa/pull/1196) touches `retry.py` but not its taxonomy sets.

## Not in scope

The Zoom LFX white-label wrapper ([#1261](https://github.com/Vexa-ai/vexa/issues/1261)) and the
lobby-timeout population ([#1110](https://github.com/Vexa-ai/vexa/issues/1110)) are separate failure
classes and are untouched. Nothing here re-types an existing completion reason — only the
previously-unnameable case gets the new name.

**Do not merge without review.** Rung: **PR open**.

<!-- vexa-agent -->
