### PR TITLE
helm: support immutable image digests

### DIFF
--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -24,6 +24,7 @@ template:
 test:
 	bash tests/test_helm_lint.sh
 	bash tests/test_template.sh
+	bash tests/test_image_digests.sh
 
 ## build — build the 5 control-plane images (:dev) via the compose build
 build:

--- a/deploy/helm/charts/vexa/templates/_helpers.tpl
+++ b/deploy/helm/charts/vexa/templates/_helpers.tpl
@@ -33,6 +33,65 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-%s" (include "vexa.fullname" $root) $component | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Render a structured image reference. Digest mode is deliberately exclusive with every tag source:
+an operator must clear both the component tag and (where applicable) global.imageTag. This makes a
+supposedly immutable release fail before Kubernetes sees it when a mutable selector survives.
+
+Call: include "vexa.imageRef" (dict "root" . "image" .Values.gateway.image "useGlobalTag" true)
+*/}}
+{{- define "vexa.imageRef" -}}
+{{- $root := required "vexa.imageRef requires root" .root -}}
+{{- if $root.Values.sourceRevision -}}
+{{- $sealedRevision := required "OSS-SOURCE-REVISION is required when sourceRevision is set" (trim ($root.Files.Get "OSS-SOURCE-REVISION")) -}}
+{{- if ne $root.Values.sourceRevision $sealedRevision -}}
+{{- fail "sourceRevision does not match packaged OSS source" -}}
+{{- end -}}
+{{- end -}}
+{{- $image := required "vexa.imageRef requires image" .image -}}
+{{- $repository := required "image.repository is required" $image.repository -}}
+{{- $digest := default "" $image.digest -}}
+{{- $tag := default "" $image.tag -}}
+{{- $globalTag := "" -}}
+{{- if .useGlobalTag -}}
+{{- $globalTag = default "" $root.Values.global.imageTag -}}
+{{- end -}}
+{{- if $digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $digest) -}}
+{{- fail (printf "invalid image digest %q for %s: expected sha256 followed by 64 lowercase hexadecimal characters" $digest $repository) -}}
+{{- end -}}
+{{- if or $tag $globalTag -}}
+{{- fail (printf "image %s selects digest %s but also selects a mutable tag; clear image.tag and global.imageTag" $repository $digest) -}}
+{{- end -}}
+{{- printf "%s@%s" $repository $digest -}}
+{{- else -}}
+{{- $effectiveTag := default $tag $globalTag -}}
+{{- required (printf "image.tag is required for %s when image.digest is empty" $repository) $effectiveTag | printf "%s:%s" $repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Preserve legacy scalar image values while allowing an explicit immutable repository+digest. */}}
+{{- define "vexa.scalarImageRef" -}}
+{{- $legacy := default "" .legacy -}}
+{{- $repository := default "" .repository -}}
+{{- $digest := default "" .digest -}}
+{{- if $digest -}}
+{{- if $legacy -}}
+{{- fail "a scalar image tag and imageDigest cannot both be set; clear image when using imageRepository+imageDigest" -}}
+{{- end -}}
+{{- $repository = required "imageRepository is required when imageDigest is set" $repository -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $digest) -}}
+{{- fail (printf "invalid image digest %q for %s: expected sha256 followed by 64 lowercase hexadecimal characters" $digest $repository) -}}
+{{- end -}}
+{{- printf "%s@%s" $repository $digest -}}
+{{- else -}}
+{{- if $repository -}}
+{{- fail "imageRepository cannot be set without imageDigest" -}}
+{{- end -}}
+{{- required "legacy image is required when imageDigest is empty" $legacy -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "vexa.redisUrl" -}}
 {{- if .Values.redis.enabled -}}
 {{- printf "redis://%s.%s.svc.%s:%d/0" (include "vexa.componentName" (list . "redis")) .Release.Namespace .Values.global.clusterDomain (.Values.redis.service.port | int) -}}
@@ -99,7 +158,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* The on-demand bot image the runtime spawns (BROWSER_IMAGE). The bot is published, never built by
 this chart. runtime.browserImage is the explicit value; global.imageTag (set) pins the standard repo. */}}
 {{- define "vexa.botImage" -}}
-{{- if .Values.runtime.browserImage -}}
+{{- if or .Values.runtime.browserImageDigest .Values.runtime.browserImageRepository -}}
+{{- if .Values.global.imageTag -}}
+{{- fail "runtime.browserImageDigest and global.imageTag cannot both be set" -}}
+{{- end -}}
+{{- include "vexa.scalarImageRef" (dict "legacy" .Values.runtime.browserImage "repository" .Values.runtime.browserImageRepository "digest" .Values.runtime.browserImageDigest) -}}
+{{- else if .Values.runtime.browserImage -}}
 {{- .Values.runtime.browserImage -}}
 {{- else if .Values.global.imageTag -}}
 {{- printf "vexaai/vexa-bot:%s" .Values.global.imageTag -}}
@@ -110,7 +174,12 @@ vexaai/vexa-bot:v012
 
 {{/* The agent-api image ref (AGENT_IMAGE the runtime spawns workers from). global.imageTag wins. */}}
 {{- define "vexa.agentImage" -}}
+{{- if or .Values.runtime.agentImageDigest .Values.runtime.agentImageRepository -}}
 {{- if .Values.global.imageTag -}}
+{{- fail "runtime.agentImageDigest and global.imageTag cannot both be set" -}}
+{{- end -}}
+{{- include "vexa.scalarImageRef" (dict "legacy" .Values.runtime.agentImage "repository" .Values.runtime.agentImageRepository "digest" .Values.runtime.agentImageDigest) -}}
+{{- else if .Values.global.imageTag -}}
 {{- printf "%s:%s" .Values.agentApi.image.repository .Values.global.imageTag -}}
 {{- else -}}
 {{- .Values.runtime.agentImage | default (printf "%s:%s" .Values.agentApi.image.repository .Values.agentApi.image.tag) -}}
@@ -119,7 +188,12 @@ vexaai/vexa-bot:v012
 
 {{/* The agent-worker image ref (AGENT_WORKER_IMAGE; the dedicated worker build — core/agent/worker/Dockerfile — NOT the agent-api image). */}}
 {{- define "vexa.agentWorkerImage" -}}
+{{- if or .Values.runtime.agentWorkerImageDigest .Values.runtime.agentWorkerImageRepository -}}
 {{- if .Values.global.imageTag -}}
+{{- fail "runtime.agentWorkerImageDigest and global.imageTag cannot both be set" -}}
+{{- end -}}
+{{- include "vexa.scalarImageRef" (dict "legacy" .Values.runtime.agentWorkerImage "repository" .Values.runtime.agentWorkerImageRepository "digest" .Values.runtime.agentWorkerImageDigest) -}}
+{{- else if .Values.global.imageTag -}}
 {{- printf "vexaai/v012-agent-worker:%s" .Values.global.imageTag -}}
 {{- else -}}
 {{- .Values.runtime.agentWorkerImage | default "vexaai/v012-agent-worker:v012" -}}

--- a/deploy/helm/charts/vexa/templates/deployment-admin-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-admin-api.yaml
@@ -30,7 +30,7 @@ spec:
         - name: admin-api
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ .Values.adminApi.image.repository }}:{{ .Values.global.imageTag | default .Values.adminApi.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.adminApi.image "useGlobalTag" true) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
@@ -41,7 +41,7 @@ spec:
         - name: agent-api
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ .Values.agentApi.image.repository }}:{{ .Values.global.imageTag | default .Values.agentApi.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.agentApi.image "useGlobalTag" true) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/charts/vexa/templates/deployment-dashboard.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-dashboard.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           # NB: deliberately NOT prefixed by global.imageTag — the dashboard is a deprecated
           # external image on its own pinned tag, not part of the release image set.
-          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.dashboard.image "useGlobalTag" false) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         - name: gateway
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ .Values.gateway.image.repository }}:{{ .Values.global.imageTag | default .Values.gateway.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.gateway.image "useGlobalTag" true) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-meeting-api.yaml
@@ -31,7 +31,7 @@ spec:
         - name: meeting-api
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ .Values.meetingApi.image.repository }}:{{ .Values.global.imageTag | default .Values.meetingApi.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.meetingApi.image "useGlobalTag" true) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           lifecycle:
             preStop:

--- a/deploy/helm/charts/vexa/templates/deployment-minio.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-minio.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
       containers:
         - name: minio
-          image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.minio.image "useGlobalTag" false) | quote }}
           imagePullPolicy: IfNotPresent
           command:
             - minio

--- a/deploy/helm/charts/vexa/templates/deployment-pgbouncer.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-pgbouncer.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: pgbouncer
-          image: "{{ .Values.pgbouncer.image }}"
+          image: {{ include "vexa.scalarImageRef" (dict "legacy" .Values.pgbouncer.image "repository" .Values.pgbouncer.imageRepository "digest" .Values.pgbouncer.imageDigest) | quote }}
           imagePullPolicy: IfNotPresent
           env:
             - name: DB_HOST

--- a/deploy/helm/charts/vexa/templates/deployment-redis.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-redis.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       containers:
         - name: redis
-          image: "{{ .Values.redis.image }}"
+          image: {{ include "vexa.scalarImageRef" (dict "legacy" .Values.redis.image "repository" .Values.redis.imageRepository "digest" .Values.redis.imageDigest) | quote }}
           imagePullPolicy: IfNotPresent
           {{- /* v0.10.5 Pack C.5 — paired-durability invariant guard */}}
           {{- include "vexa.validateRedisDurability" . }}

--- a/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-runtime.yaml
@@ -34,7 +34,7 @@ spec:
         - name: runtime
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ .Values.runtime.image.repository }}:{{ .Values.global.imageTag | default .Values.runtime.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.runtime.image "useGlobalTag" true) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-terminal.yaml
@@ -30,7 +30,7 @@ spec:
         - name: terminal
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ .Values.terminal.image.repository }}:{{ .Values.global.imageTag | default .Values.terminal.image.tag }}"
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.terminal.image "useGlobalTag" true) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/charts/vexa/templates/job-migrations.yaml
+++ b/deploy/helm/charts/vexa/templates/job-migrations.yaml
@@ -42,7 +42,8 @@ spec:
         - name: migrations
           securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
-          image: "{{ default .Values.meetingApi.image.repository .Values.migrations.image.repository }}:{{ .Values.global.imageTag | default (default .Values.meetingApi.image.tag .Values.migrations.image.tag) }}"
+          {{- $migrationImage := dict "repository" (default .Values.meetingApi.image.repository .Values.migrations.image.repository) "tag" (default .Values.meetingApi.image.tag .Values.migrations.image.tag) "digest" (default .Values.meetingApi.image.digest .Values.migrations.image.digest) }}
+          image: {{ include "vexa.imageRef" (dict "root" . "image" $migrationImage "useGlobalTag" true) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command:
             - /bin/sh

--- a/deploy/helm/charts/vexa/templates/job-minio-init.yaml
+++ b/deploy/helm/charts/vexa/templates/job-minio-init.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: minio-init
-          image: minio/mc:latest
+          image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.minio.clientImage "useGlobalTag" false) | quote }}
           imagePullPolicy: IfNotPresent
           # v0.10.5 Pack A.3 — replace `sleep 5` with poll-until-ready (#249).
           # On a fresh PVC, MinIO can take 30+ seconds to attach + initialize.

--- a/deploy/helm/charts/vexa/templates/statefulset-postgres.yaml
+++ b/deploy/helm/charts/vexa/templates/statefulset-postgres.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
         - name: postgres
-          image: "{{ .Values.postgres.image }}"
+          image: {{ include "vexa.scalarImageRef" (dict "legacy" .Values.postgres.image "repository" .Values.postgres.imageRepository "digest" .Values.postgres.imageDigest) | quote }}
           imagePullPolicy: IfNotPresent
           # idle_in_transaction_session_timeout=60s auto-kills orphaned
           # transactions (defense-in-depth against DB session leaks in meeting-api).

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -109,6 +109,7 @@ gateway:
   image:
     repository: vexaai/v012-gateway
     tag: v012
+    digest: ""
   service:
     type: ClusterIP
     port: 8000
@@ -146,6 +147,7 @@ adminApi:
   image:
     repository: vexaai/v012-admin-api
     tag: v012
+    digest: ""
   service:
     type: ClusterIP
     port: 8001
@@ -181,6 +183,7 @@ meetingApi:
   image:
     repository: vexaai/v012-meeting-api
     tag: v012
+    digest: ""
   service:
     type: ClusterIP
     port: 8080
@@ -226,14 +229,21 @@ runtime:
   image:
     repository: vexaai/v012-runtime
     tag: v012
+    digest: ""
   service:
     type: ClusterIP
     port: 8090
   # Images the runtime spawns. browserImage = the bot (published ~3.6GB, a reference, never built by
   # this chart). agentImage/agentWorkerImage default to the v012 agent repos at global.imageTag.
-  browserImage: ""            # empty → follows global.imageTag (fallback vexaai/vexa-bot:v012)
-  agentImage: "vexaai/v012-agent-api:v012"
-  agentWorkerImage: "vexaai/v012-agent-worker:v012"
+  browserImage: ""            # legacy full tag ref; clear when using browserImageRepository+Digest
+  browserImageRepository: ""
+  browserImageDigest: ""
+  agentImage: "vexaai/v012-agent-api:v012" # legacy full tag ref; clear for digest mode
+  agentImageRepository: ""
+  agentImageDigest: ""
+  agentWorkerImage: "vexaai/v012-agent-worker:v012" # legacy full tag ref; clear for digest mode
+  agentWorkerImageRepository: ""
+  agentWorkerImageDigest: ""
   logLevel: "info"
   speakerStream:
     minAudioSec: ""
@@ -270,6 +280,7 @@ agentApi:
   image:
     repository: vexaai/v012-agent-api
     tag: v012
+    digest: ""
   service:
     type: ClusterIP
     port: 8100
@@ -293,6 +304,7 @@ terminal:
   image:
     repository: vexaai/v012-terminal
     tag: v012
+    digest: ""
   service:
     type: ClusterIP
     port: 3000
@@ -319,6 +331,7 @@ dashboard:
   image:
     repository: vexaai/dashboard
     tag: 0.10.6.3.14
+    digest: ""
   service:
     type: ClusterIP
     port: 3000
@@ -343,6 +356,7 @@ migrations:
   image:
     repository: ""
     tag: ""
+    digest: ""
   resources:
     requests: { cpu: 50m, memory: 128Mi }
     limits:   { cpu: 200m, memory: 256Mi }
@@ -354,6 +368,8 @@ pgbouncer:
   # fixed slot budget or when scaling replicas. When on, every service's DB_HOST routes through it.
   enabled: false
   image: edoburu/pgbouncer:latest
+  imageRepository: ""
+  imageDigest: ""
   replicaCount: 1
   poolMode: transaction
   defaultPoolSize: 20
@@ -370,6 +386,8 @@ pgbouncer:
 postgres:
   enabled: true
   image: postgres:17-alpine
+  imageRepository: ""
+  imageDigest: ""
   credentialsSecretName: postgres-credentials
   idleInTransactionTimeoutMs: 60000
   service:
@@ -388,6 +406,8 @@ redis:
   # Redis ≥7.4. Wire-compatible (RESP): the `redis.*` keys, redisConfig.url, and the durability
   # helper are unchanged so existing values overrides keep working; only the engine swaps (#653).
   image: valkey/valkey:8-alpine
+  imageRepository: ""
+  imageDigest: ""
   service:
     port: 6379
   persistence:
@@ -411,6 +431,11 @@ minio:
   image:
     repository: minio/minio
     tag: latest
+    digest: ""
+  clientImage:
+    repository: minio/mc
+    tag: latest
+    digest: ""
   accessKey: vexa-access-key
   secretKey: vexa-secret-key
   bucket: vexa

--- a/deploy/helm/tests/README.md
+++ b/deploy/helm/tests/README.md
@@ -1,3 +1,5 @@
 # helm · tests
 
-Smoke tests for the `vexa` Helm chart: `test_helm_lint.sh` (chart lint) and `test_template.sh` (render/template validation). Run as part of the helm deploy checks.
+Smoke tests for the `vexa` Helm chart: `test_helm_lint.sh` (chart lint), `test_template.sh`
+(render/template validation), and `test_image_digests.sh` (immutable image references and
+fail-closed tag/digest ambiguity). Run as part of the Helm deploy checks.

--- a/deploy/helm/tests/fixtures/README.md
+++ b/deploy/helm/tests/fixtures/README.md
@@ -1,0 +1,4 @@
+# Helm test fixtures
+
+Static values files used only by the chart render gates. `values-image-digests.yaml` uses synthetic
+SHA-256 values to prove immutable-reference rendering and never names a runnable release artifact.

--- a/deploy/helm/tests/fixtures/values-image-digests.yaml
+++ b/deploy/helm/tests/fixtures/values-image-digests.yaml
@@ -1,0 +1,46 @@
+global:
+  imageTag: ""
+
+gateway:
+  image: {repository: vexaai/v012-gateway, tag: "", digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+adminApi:
+  image: {repository: vexaai/v012-admin-api, tag: "", digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+meetingApi:
+  image: {repository: vexaai/v012-meeting-api, tag: "", digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}
+runtime:
+  image: {repository: vexaai/v012-runtime, tag: "", digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}
+  browserImage: ""
+  browserImageRepository: vexaai/vexa-bot
+  browserImageDigest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  agentImage: ""
+  agentImageRepository: vexaai/v012-agent-api
+  agentImageDigest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  agentWorkerImage: ""
+  agentWorkerImageRepository: vexaai/v012-agent-worker
+  agentWorkerImageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+agentApi:
+  image: {repository: vexaai/v012-agent-api, tag: "", digest: "sha256:2222222222222222222222222222222222222222222222222222222222222222"}
+terminal:
+  image: {repository: vexaai/v012-terminal, tag: "", digest: "sha256:3333333333333333333333333333333333333333333333333333333333333333"}
+dashboard:
+  enabled: true
+  image: {repository: vexaai/dashboard, tag: "", digest: "sha256:4444444444444444444444444444444444444444444444444444444444444444"}
+migrations:
+  enabled: true
+  image: {repository: vexaai/v012-meeting-api, tag: "", digest: "sha256:5555555555555555555555555555555555555555555555555555555555555555"}
+pgbouncer:
+  enabled: true
+  image: ""
+  imageRepository: edoburu/pgbouncer
+  imageDigest: "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+postgres:
+  image: ""
+  imageRepository: postgres
+  imageDigest: "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+redis:
+  image: ""
+  imageRepository: redis
+  imageDigest: "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+minio:
+  image: {repository: minio/minio, tag: "", digest: "sha256:9999999999999999999999999999999999999999999999999999999999999999"}
+  clientImage: {repository: minio/mc, tag: "", digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"}

--- a/deploy/helm/tests/test_image_digests.sh
+++ b/deploy/helm/tests/test_image_digests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HELM_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHART="$HELM_DIR/charts/vexa"
+FIXTURE="$HELM_DIR/tests/fixtures/values-image-digests.yaml"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/vexa-image-digests.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "SKIP: helm not installed"
+  exit 0
+fi
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+expect_render_failure() {
+  local label="$1"; shift
+  if helm template vexa "$CHART" -n vexa "$@" >/dev/null 2>&1; then
+    fail "$label rendered successfully"
+  fi
+  echo "  OK: $label fails closed"
+}
+
+echo "=== gate:helm-image-digests ==="
+
+legacy="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml")"
+grep -q 'image: "vexaai/v012-gateway:v012"' <<<"$legacy" || fail "legacy tag path changed"
+grep -q 'value: "vexaai/vexa-bot:v012"' <<<"$legacy" || fail "legacy spawned bot path changed"
+echo "  OK: empty digest preserves legacy tag references"
+
+pinned="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" -f "$FIXTURE")"
+refs=()
+while IFS= read -r ref; do
+  refs+=("$ref")
+done < <(awk '/^[[:space:]]+image: / {gsub(/^[[:space:]]+image: /, ""); gsub(/"/, ""); print}' <<<"$pinned")
+[[ ${#refs[@]} -eq 13 ]] || fail "expected 13 chart-owned Pod/Job images, got ${#refs[@]}"
+for ref in "${refs[@]}"; do
+  [[ "$ref" =~ ^[^:@]+([^@]*)?@sha256:[0-9a-f]{64}$ ]] || fail "mutable or malformed rendered image: $ref"
+done
+for env_name in BROWSER_IMAGE AGENT_IMAGE AGENT_WORKER_IMAGE; do
+  ref="$(awk -v name="$env_name" '$0 ~ "name: "name {getline; sub(/^[[:space:]]+value: /, ""); gsub(/"/, ""); print; exit}' <<<"$pinned")"
+  [[ "$ref" =~ @sha256:[0-9a-f]{64}$ ]] || fail "$env_name is not immutable: $ref"
+done
+echo "  OK: all rendered and spawned runtime images use repository@sha256"
+
+cp -R "$CHART" "$TMP/chart"
+sealed_revision=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+printf '%s\n' "$sealed_revision" > "$TMP/chart/OSS-SOURCE-REVISION"
+helm template vexa "$TMP/chart" -n vexa -f "$TMP/chart/values-test.yaml" \
+  --set sourceRevision="$sealed_revision" >/dev/null
+if helm template vexa "$TMP/chart" -n vexa -f "$TMP/chart/values-test.yaml" \
+  --set sourceRevision=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb >/dev/null 2>&1; then
+  fail "wrong full-length OSS source revision rendered"
+fi
+echo "  OK: advertised OSS revision is bound to packaged source"
+
+expect_render_failure "truncated digest" --set gateway.image.tag= --set gateway.image.digest=sha256:abc
+expect_render_failure "uppercase digest" --set gateway.image.tag= --set gateway.image.digest=sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+expect_render_failure "wrong digest algorithm" --set gateway.image.tag= --set gateway.image.digest=sha512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+expect_render_failure "component digest plus component tag" --set gateway.image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+expect_render_failure "component digest plus global tag" --set gateway.image.tag= --set gateway.image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --set global.imageTag=mutable
+expect_render_failure "scalar digest plus legacy tag" --set redis.imageDigest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --set redis.imageRepository=redis
+expect_render_failure "scalar repository without digest" --set redis.imageRepository=redis-custom
+expect_render_failure "spawned digest plus legacy tag" --set runtime.browserImageDigest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --set runtime.browserImageRepository=vexaai/vexa-bot --set runtime.browserImage=mutable:tag
+expect_render_failure "spawned digest plus global tag" --set runtime.browserImageDigest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --set runtime.browserImageRepository=vexaai/vexa-bot --set runtime.browserImage= --set global.imageTag=mutable
+expect_render_failure "spawned repository without digest" --set runtime.browserImageRepository=vexaai/vexa-bot-custom
+
+echo "gate:helm-image-digests PASS"

--- a/docs/changelog.d/1001-helm-image-digests.md
+++ b/docs/changelog.d/1001-helm-image-digests.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Helm deployments can now pin every chart-owned and runtime-spawned image by immutable SHA-256
+  digest, with render-time rejection of malformed digests and tag/digest ambiguity.

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -333,6 +333,21 @@ binds into each worker Pod as a PVC, scoped per-mount). The Compose stack is the
 most production mileage today; the chart is the right starting point for a cluster
 evaluation — track the [status page](/roadmap/status).
 
+## Immutable image references
+
+Every chart-owned Pod and Job image can be selected by digest. For structured image values, set
+`image.digest: sha256:<64 lowercase hex>` and clear both `image.tag` and `global.imageTag`. The chart
+fails to render when a digest is malformed or a mutable tag remains selected. The bundled
+Postgres, Redis and PgBouncer images preserve their legacy scalar `image` setting; immutable mode
+uses `imageRepository` plus `imageDigest` and requires `image` to be empty. The runtime's spawned
+bot, agent and agent-worker references likewise use their `*ImageRepository` and `*ImageDigest`
+values with the legacy full-reference value cleared.
+
+Digest syntax is only the deployment declaration. Release validation must also compare the
+expected registry digest with each running Pod's `status.containerStatuses[].imageID`, and must
+observe spawned bot and agent Pods separately. A successful Helm render does not prove that the
+registry or cluster ran the intended bytes.
+
 ## Air-gapped clusters
 
 Everything the chart deploys pulls from images you build and host in your own registry; pair it

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -202,7 +202,10 @@ const MINIO_JOB = "deploy/helm/charts/vexa/templates/job-minio-init.yaml";
 test("image-licenses RED: an undeclared image pinned in a helm TEMPLATE (not just values) reds", () => {
   // The gate must read helm templates, not only compose + values — a literal `image:` in a template
   // is a real pin. An undeclared one must red, else the 'green gate ships an un-audited component' hole.
-  const r = withEdited(MINIO_JOB, "image: minio/mc:latest", "image: somevendor/unaudited:1.2",
+  const r = withEdited(
+    MINIO_JOB,
+    'image: {{ include "vexa.imageRef" (dict "root" . "image" .Values.minio.clientImage "useGlobalTag" false) | quote }}',
+    "image: somevendor/unaudited:1.2",
     () => runGate("image-licenses"));
   assert.equal(r.green, false, "an undeclared image in a helm template sailed through — the gate never read templates");
   assert.match(r.out, /undeclared pinned image/);


### PR DESCRIPTION
Delivers #1001

## Contribution rights

- [x] **Employer/client authorization required:** Biji-Biji Initiative controls this contribution; requesting Vexa private corporate authorization.

## Observation bundle

- **C1 — structured chart-owned images:** ran `make -C deploy/helm test` at `9772dabc7e7177a6956c59bf4b88b29e5af35a8f`; lint, existing template assertions, and digest regression tests passed.
- **C2 — immutable runtime inputs:** the new render fixture proves every chart-owned workload image and every runtime-spawned bot/agent reference resolves to `repository@sha256:<64 lowercase hex>`.
- **C3 — false controls:** the digest suite proves malformed, truncated, uppercase, non-sha256, tag-plus-digest, and incomplete repository/digest inputs fail before Kubernetes.

## Acceptance floor

| Row | Evidence |
|---|---|
| Exact digest contract | `make -C deploy/helm test` passes on `9772dabc7e7177a6956c59bf4b88b29e5af35a8f`; all chart-owned images and spawned references use the structured helper. |
| Legacy tags | `test_image_digests.sh` confirms the existing tag render before digest mode. |
| Fail closed | The same test exercises malformed and ambiguous selectors as negative controls. |
| Runtime image inventory | The fixture covers all chart-owned Pod/Job images plus the three runtime spawn references. |

No registry, cluster, database, provider, customer, or production action was performed.

## Docs diff

- Helm values reference and Kubernetes deployment guide document the immutable-reference contract and required running-image verification.
- The changelog fragment records the behavior without touching the hot changelog file.

## Security checks

- `ubs` over all 23 changed files: no critical or warning findings.
- `node scripts/gates.mjs image-licenses`: green.
- `node scripts/gates.test.mjs`: 19/19 pass.
- Focused Helm assertions: green.
- The full repository gate begins with existing schema/config-contract failures on the unchanged main base; this patch changes neither subsystem.

## Validation request

A non-author should run `make -C deploy/helm test` at the exact head, review the rendered digest and negative-control output, and attest the Helm/docs behavior. No live deployment is claimed; cluster imageID readback remains a later deployment gate.

## Authorship

Sole author: Kali.
Tooling disclosure: automated coding tools were used as instruments; no co-author trailers are included.