### PR TITLE
helm: apply global security context to Redis

### DIFF
--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -24,6 +24,7 @@ template:
 test:
 	bash tests/test_helm_lint.sh
 	bash tests/test_template.sh
+	bash tests/test_redis_security_context.sh
 
 ## build — build the 5 control-plane images (:dev) via the compose build
 build:

--- a/deploy/helm/charts/vexa/templates/deployment-redis.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-redis.yaml
@@ -21,6 +21,10 @@ spec:
         {{- include "vexa.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: redis
     spec:
+      {{- with .Values.global.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # v0.10.5 Pack I.s — stateful-pod anti-affinity (#272 iter-5).
       # See deployment-minio.yaml header for the full rationale.
       affinity:
@@ -40,6 +44,10 @@ spec:
       {{- end }}
       containers:
         - name: redis
+          {{- with .Values.global.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.redis.image }}"
           imagePullPolicy: IfNotPresent
           {{- /* v0.10.5 Pack C.5 — paired-durability invariant guard */}}

--- a/deploy/helm/tests/test_redis_security_context.sh
+++ b/deploy/helm/tests/test_redis_security_context.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HELM_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHART="$HELM_DIR/charts/vexa"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "SKIP: helm not installed"
+  exit 0
+fi
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "=== gate:helm-redis-security-context ==="
+
+empty="$(helm template vexa "$CHART" -n vexa --show-only templates/deployment-redis.yaml \
+  --set global.podSecurityContext=null \
+  --set global.securityContext=null)"
+if grep -q 'securityContext:' <<<"$empty"; then
+  fail "empty global security contexts changed the Redis manifest"
+fi
+echo "  OK: empty global contexts preserve the Redis manifest"
+
+rendered="$(helm template vexa "$CHART" -n vexa --show-only templates/deployment-redis.yaml \
+  --set global.podSecurityContext.runAsNonRoot=true \
+  --set global.podSecurityContext.seccompProfile.type=RuntimeDefault \
+  --set global.securityContext.allowPrivilegeEscalation=false \
+  --set global.securityContext.runAsNonRoot=true \
+  --set global.securityContext.capabilities.drop[0]=ALL)"
+
+pod_spec="$(sed -n '/^    spec:/,/^      containers:/p' <<<"$rendered")"
+container_spec="$(sed -n '/^        - name: redis$/,/^      volumes:/p' <<<"$rendered")"
+
+grep -q '^      securityContext:$' <<<"$pod_spec" || fail "Redis Pod is missing global.podSecurityContext"
+grep -q '^        runAsNonRoot: true$' <<<"$pod_spec" || fail "Redis Pod is missing runAsNonRoot"
+grep -q '^          type: RuntimeDefault$' <<<"$pod_spec" || fail "Redis Pod is missing seccompProfile"
+grep -q '^          securityContext:$' <<<"$container_spec" || fail "Redis container is missing global.securityContext"
+grep -q '^            allowPrivilegeEscalation: false$' <<<"$container_spec" || fail "Redis container is missing allowPrivilegeEscalation"
+grep -q '^            runAsNonRoot: true$' <<<"$container_spec" || fail "Redis container is missing runAsNonRoot"
+grep -q '^              - ALL$' <<<"$container_spec" || fail "Redis container is missing dropped capabilities"
+
+echo "  OK: Redis consumes the chart-wide restricted security contexts"
+echo "gate:helm-redis-security-context PASS"

--- a/docs/changelog.d/1330-redis-security-context.md
+++ b/docs/changelog.d/1330-redis-security-context.md
@@ -1,0 +1,1 @@
+Redis now receives the chart-wide pod and container security contexts, matching the other Helm-managed Vexa services.


### PR DESCRIPTION
Delivers #1330

## Contribution rights

- [x] **Employer/client authorization required:** Biji-Biji Initiative controls this contribution; requesting Vexa private corporate authorization.

## Observation bundle

- **C1 — Redis template:** rendered the Redis Deployment with populated global pod and container security contexts. The pre-change template had no `securityContext` blocks; the candidate renders both blocks at the Pod and Redis-container scopes.
- **C2 — regression harness:** `make -C deploy/helm test` is green at `05c52d3baf49fa2a4a836c6b5ef493b6a91e0b12`; the new `test_redis_security_context.sh` verifies both the configured and explicitly-empty cases.

## Acceptance floor

| Row | Evidence |
|---|---|
| Configured context | The focused script renders restricted fields and asserts the pod and container scopes independently. |
| Empty context | The focused script sets both global maps to `null` and asserts no Redis `securityContext` is rendered. |
| Regression | Full Helm lint/template suite passes at the exact head. |

No image, cluster, database, provider, customer, or production action was performed.

## Docs diff

No new values or user-facing behavior: this applies the existing global values contract to the one component that omitted it.

## Security checks

- `ubs` found no supported-language files in this YAML/Bash-only change; no scanner ran.
- `make -C deploy/helm test`: green.

## Validation request

A non-author should run `make -C deploy/helm test` at the exact head and attest the render output. A restricted-cluster admission run is deliberately a later deployment validation, not claimed here.

## Authorship

Sole author: Kali.
Tooling disclosure: automated coding tools were used as instruments; no co-author trailers are included.