### PR TITLE
docs: 0.10 → 0.12.x upgrade runbook — DB pre-flight first, LimitRange floor, prod-migration provenance

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0001-drop-recordings.md
+++ b/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0001-drop-recordings.md
@@ -1,7 +1,17 @@
 # MIGRATION-0001 — drop the dead `recordings` + `media_files` tables
 
-**Status:** applied in the v0.12 schema definition (`schema/models.py`). NOT executed against
-any live/prod DB — this is a schema-model decision + eval, per Group-1 scope.
+**Status:** applied in the v0.12 schema definition (`schema/models.py`) — a schema-model decision
++ eval, per Group-1 scope.
+
+The **drop itself** has still not been executed against any live/prod DB, and does not need to be:
+the v0.12 schema simply never creates these tables, and `ensure_schema` never drops. On a DB
+upgraded in place from 0.10 the legacy `recordings` / `media_files` tables are left standing and
+unused — see "If ever applied to a real DB" below.
+
+> **Note (2026-08-26):** the surrounding v0.12 schema convergence **has** run against a live
+> production database — Vexa Cloud upgraded its own production 0.10 → 0.12 over the full live DB in
+> July 2026. Do not read this file's status line as "the 0.10 → 0.12 upgrade is untried in
+> production"; only the legacy-table DROP is untried, deliberately.
 
 ## Verdict: the `recordings` table is DEAD
 

--- a/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0001-drop-recordings.md
+++ b/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0001-drop-recordings.md
@@ -3,15 +3,11 @@
 **Status:** applied in the v0.12 schema definition (`schema/models.py`) — a schema-model decision
 + eval, per Group-1 scope.
 
-The **drop itself** has still not been executed against any live/prod DB, and does not need to be:
-the v0.12 schema simply never creates these tables, and `ensure_schema` never drops. On a DB
-upgraded in place from 0.10 the legacy `recordings` / `media_files` tables are left standing and
-unused — see "If ever applied to a real DB" below.
-
-> **Note (2026-08-26):** the surrounding v0.12 schema convergence **has** run against a live
-> production database — Vexa Cloud upgraded its own production 0.10 → 0.12 over the full live DB in
-> July 2026. Do not read this file's status line as "the 0.10 → 0.12 upgrade is untried in
-> production"; only the legacy-table DROP is untried, deliberately.
+Schema convergence: validated against a full production migration (July 2026). The legacy-table
+DROP has not been run in production, and does not need to be: the v0.12 schema never creates these
+tables, and `ensure_schema` never drops. On a DB upgraded in place from 0.10 the legacy
+`recordings` / `media_files` tables are left standing and unused — see "If ever applied to a real
+DB" below.
 
 ## Verdict: the `recordings` table is DEAD
 

--- a/core/identity/services/admin-api/src/admin_api/schema/README.md
+++ b/core/identity/services/admin-api/src/admin_api/schema/README.md
@@ -5,4 +5,11 @@ MeetingSession). `sync.py` is `ensure_schema()` — idempotent, additive, never-
 (the parent's no-alembic discipline). The dead `recordings`/`media_files` tables are dropped —
 see `MIGRATION-0001-drop-recordings.md`.
 
+**Upgrade provenance:** the 0.10 → 0.12 convergence has been executed against a live production
+database (Vexa Cloud's own, over the full live DB, July 2026), plus the out-of-band steps in
+`MIGRATION-0002` (verified in production 2026-08-17) and `MIGRATION-0005` (2026-08-18). The
+per-file "out-of-band, human-run ops step" language describes **who runs the statement**, not an
+untried path. The operator-facing runbook is `docs/docs/changelog.mdx` §
+*Upgrade runbook: 0.10 to 0.12.x*.
+
 _Governed by `docs/docs/governance/architecture.mdx` (P1–P12). This folder owns one concern; its public surface is its `index`/contract; it may depend only on what the dependency-rules allow._

--- a/core/identity/services/admin-api/src/admin_api/schema/README.md
+++ b/core/identity/services/admin-api/src/admin_api/schema/README.md
@@ -5,11 +5,8 @@ MeetingSession). `sync.py` is `ensure_schema()` — idempotent, additive, never-
 (the parent's no-alembic discipline). The dead `recordings`/`media_files` tables are dropped —
 see `MIGRATION-0001-drop-recordings.md`.
 
-**Upgrade provenance:** the 0.10 → 0.12 convergence has been executed against a live production
-database (Vexa Cloud's own, over the full live DB, July 2026), plus the out-of-band steps in
-`MIGRATION-0002` (verified in production 2026-08-17) and `MIGRATION-0005` (2026-08-18). The
-per-file "out-of-band, human-run ops step" language describes **who runs the statement**, not an
-untried path. The operator-facing runbook is `docs/docs/changelog.mdx` §
-*Upgrade runbook: 0.10 to 0.12.x*.
+**Upgrade path:** the 0.10 → 0.12 convergence is validated against a full production migration
+(July 2026), together with the out-of-band steps in `MIGRATION-0002` and `MIGRATION-0005`. The
+operator-facing runbook is `docs/docs/changelog.mdx` § *Upgrade runbook: 0.10 to 0.12.x*.
 
 _Governed by `docs/docs/governance/architecture.mdx` (P1–P12). This folder owns one concern; its public surface is its `index`/contract; it may depend only on what the dependency-rules allow._

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -66,7 +66,7 @@ Upgrade **0.10.x → the latest 0.12.x release** in one step. There is no staged
 is needed: schema convergence is **state-based, not sequential** (see below), so stopping on an
 older 0.12.x buys nothing and costs you the fixes shipped since. In particular, older 0.12.x
 releases lack the fail-closed schema check described below, so a missing dedup index degrades
-**silently** instead of refusing to start — the exact failure mode that check was added for.
+**silently** instead of refusing to start — the failure mode that check exists to catch.
 
 #### The database: no Alembic, three manual steps
 
@@ -127,10 +127,10 @@ ALTER TABLE users ALTER COLUMN max_concurrent_bots SET DEFAULT 3;
 UPDATE users SET max_concurrent_bots = 3 WHERE max_concurrent_bots < 3;
 ```
 
-**3 · API-token scopes — automatic, listed so you can verify it ran.** 0.10 tokens predate the
-`scopes` column, so the additive `ADD COLUMN` leaves them empty, and an empty scope set is a `403`
-on every core route. This one **is** applied for you on boot, precisely because the failure would
-otherwise be an invisible revocation of every existing customer key
+**3 · API-token scopes — applied automatically on boot.** 0.10 tokens predate the `scopes` column,
+so the additive `ADD COLUMN` leaves them empty, and an empty scope set is a `403` on every core
+route. `ensure_schema` backfills them at startup; left unbackfilled, an empty scope set is an
+invisible revocation of every existing customer key
 ([`MIGRATION-0004`](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0004-backfill-token-scopes.md)).
 Empty rows converge to the full valid-scope set; already-scoped tokens are never widened.
 

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -145,10 +145,11 @@ the manual steps above still have to be run against the database yourself.
 Every bot and agent is spawned as its own bare Pod, and a spawned Pod declares **no resource
 requests or limits of its own**. In a quota-controlled namespace this means the namespace's
 `LimitRange` defaults are what the bot actually gets — and browser-based bots need real headroom.
-Either run Vexa in a namespace with no `LimitRange`, or set its `default` **and** `defaultRequest`
-to **`cpu: "2"`, `memory: 4096Mi`**. `4096Mi` is a floor, not a suggestion — around 2 GB the bot is
-OOM-killed on Teams meetings. Too small a default shows up as a bot that dies mid-join, not as a
-scheduling error. See
+Either run Vexa in a namespace with no `LimitRange`, or give that namespace the defaults Vexa's own
+production runs: `default` `{cpu: 1500m, memory: 2560Mi}`, `defaultRequest`
+`{cpu: 1000m, memory: 1100Mi}`. The `2560Mi` limit is a hard ceiling, not a suggestion — a Teams
+call spikes past 2 Gi. Too small a default shows up as a bot that dies mid-join, not as a scheduling
+error. See
 [Kubernetes (Helm)](/deployment-kubernetes#namespace-limitrange-defaults).
 
 ### Parity with the 0.10.x line

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -54,6 +54,103 @@ notable line and the migration notes between majors.
 - **Re-check your secrets.** Set real values for `ADMIN_TOKEN`, `INTERNAL_API_SECRET`,
   `VEXA_DISPATCH_SIGNING_KEY`, and DB/MinIO credentials — see [Configuration](/configuration).
 
+### Upgrade runbook: 0.10 to 0.12.x
+
+The items above are the client-side contract changes. This section is the **operator** runbook for
+moving an existing 0.10.x install — with a populated database — onto the current 0.12.x line. The
+path was validated against a production migration in July 2026.
+
+#### Go straight to the latest 0.12.x — no intermediate hop
+
+Upgrade **0.10.x → the latest 0.12.x release** in one step. There is no staged upgrade path and none
+is needed: schema convergence is **state-based, not sequential** (see below), so stopping on an
+older 0.12.x buys nothing and costs you the fixes shipped since. In particular, older 0.12.x
+releases lack the fail-closed schema check described below, so a missing dedup index degrades
+**silently** instead of refusing to start — the exact failure mode that check was added for.
+
+#### The database: no Alembic, three manual steps
+
+Vexa has **no migration tool**. `ensure_schema()` runs on every admin-api boot and *converges* the
+schema: `create_all` → additive `ADD COLUMN` → data backfills → index sync. It never drops a table,
+never rewrites an existing value, and never issues `ALTER … SET DEFAULT`. That is what makes the
+upgrade order-independent — and it is also why three things a live 0.10 database needs are **not**
+done for you.
+
+Run these against the database **before** you deploy 0.12.x, as standalone `psql` statements (not
+wrapped in a `BEGIN`). The runbooks with full SQL, policy notes, and rollback live beside the schema
+in the repo:
+[`core/identity/services/admin-api/src/admin_api/schema/`](https://github.com/Vexa-ai/vexa/tree/main/core/identity/services/admin-api/src/admin_api/schema).
+
+**1 · Pre-flight the active-meeting dedup index — do this first.** 0.12.x adds a partial UNIQUE index
+over `meetings (user_id, platform, platform_specific_id)` for non-terminal rows. If the table already
+holds two or more active rows for the same key, the index **cannot be built** — and admin-api
+**fails closed**: startup raises, the process exits `3`, `/health` never answers, and the compose
+healthcheck / Kubernetes probes never pass. Check for duplicates before you deploy anything
+(read-only):
+
+```sql
+SELECT user_id, platform, platform_specific_id,
+       count(*) AS active_dups,
+       array_agg(id ORDER BY created_at DESC, id DESC) AS meeting_ids
+FROM meetings
+WHERE status NOT IN ('completed', 'failed')
+  AND platform_specific_id IS NOT NULL
+GROUP BY user_id, platform, platform_specific_id
+HAVING count(*) > 1
+ORDER BY active_dups DESC;
+```
+
+Zero rows → go straight to building the index. Rows returned → retire the stale duplicates to a
+terminal status first (policy and the exact statement are in
+[`MIGRATION-0002`](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0002-meeting-active-dedup-index.md)),
+re-run the query until it is empty, then build the index out of band so the build does not lock
+writes on the hot spawn table:
+
+```sql
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_meeting_active_user_platform_native
+ON meetings (user_id, platform, platform_specific_id)
+WHERE status NOT IN ('completed', 'failed');
+```
+
+`CONCURRENTLY` is why this is manual: `ensure_schema` runs inside a single transaction, and
+`CREATE INDEX CONCURRENTLY` cannot. With the index already present, the boot-time sync matches it by
+name and no-ops.
+
+**2 · Raise the `max_concurrent_bots` default.** The per-user default moved **1 → 3** in 0.12. The
+additive column sync neither changes the column default nor backfills existing rows, so on an
+upgraded database every existing user stays on their old value. Raise-only, so it never lowers an
+account already granted more
+([`MIGRATION-0003`](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0003-default-max-concurrent-bots-3.md)):
+
+```sql
+ALTER TABLE users ALTER COLUMN max_concurrent_bots SET DEFAULT 3;
+UPDATE users SET max_concurrent_bots = 3 WHERE max_concurrent_bots < 3;
+```
+
+**3 · API-token scopes — automatic, listed so you can verify it ran.** 0.10 tokens predate the
+`scopes` column, so the additive `ADD COLUMN` leaves them empty, and an empty scope set is a `403`
+on every core route. This one **is** applied for you on boot, precisely because the failure would
+otherwise be an invisible revocation of every existing customer key
+([`MIGRATION-0004`](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0004-backfill-token-scopes.md)).
+Empty rows converge to the full valid-scope set; already-scoped tokens are never widened.
+
+<Note>
+Running on Kubernetes with the Helm chart? The chart's migration Job is off by default
+(`migrations.enabled: false`) — the convergence you rely on is the one admin-api runs at boot, and
+the manual steps above still have to be run against the database yourself.
+</Note>
+
+#### Kubernetes: check the namespace LimitRange before you upgrade
+
+Every bot and agent is spawned as its own bare Pod, and a spawned Pod declares **no resource
+requests or limits of its own**. In a quota-controlled namespace this means the namespace's
+`LimitRange` defaults are what the bot actually gets — and browser-based bots need real headroom.
+Either run Vexa in a namespace with no `LimitRange`, or set its `default` **and** `defaultRequest`
+to **`cpu: "2"`, `memory: 4096Mi`**. `4096Mi` is a floor, not a suggestion — around 2 GB the bot is
+OOM-killed on Teams meetings. Too small a default shows up as a bot that dies mid-join, not as a
+scheduling error. See
+[Kubernetes (Helm)](/deployment-kubernetes#namespace-limitrange-defaults).
+
 ### Parity with the 0.10.x line
 
 The public `api.v1` contract is sealed **hash-equal to `main`'s OpenAPI 1.5.0** and enforced in CI
@@ -371,7 +468,7 @@ probe), not inferred from planning docs.
 - **Governance: four D-book amendments from the v0.12.12 retro (#785).** TAKE verdicts now name the head sha they examined (a later push makes the endorsement historical); one rule governs sealed-contract re-stamps (a back-compatible re-seal may ride a `lane:contract` PR whose merge is the ruling, breaking changes get an issue-recorded ruling first); the closure mechanism gains mechanism-vs-tree verification over open prepared issues (catching deliveries no link sweep sees); and the incoming-report template now requires the deployed version / verified tag. See [Delivery](/governance/delivery).
 
 - **Security floor: adm-zip bumped to 0.6.0 via pnpm override (#773).** Closes Dependabot high
-  GHSA-xcpc-8h2w-3j85 (crafted-ZIP 4 GB allocation in adm-zip <0.6.0), which rode in through
+  GHSA-xcpc-8h2w-3j85 (crafted-ZIP 4 GB allocation in adm-zip `<0.6.0`), which rode in through
   onnxruntime-node's install-time unpack under `@vexa/mixed-pipeline`. Exposure was
   postinstall-only, but the resolution layer now excludes the vulnerable range entirely.
 

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -146,10 +146,14 @@ install. Agent-worker Pods are smaller than a bot and are over-provisioned by th
 is the intended trade — they are small and few.
 
 <Note>
-**`/dev/shm` on Kubernetes.** Chromium wants a real shared-memory mount; the Docker backend gives a
-spawned bot `2g` by default (`DOCKER_SHM_SIZE`), and Teams calls are the workload that needs it. The
-k8s backend has **no equivalent knob in `v0.12.23`** — a spawned Pod takes the kubelet's default
-`/dev/shm`, which is one more reason not to trim the memory ceiling above.
+**`/dev/shm` — 2 Gi, and on Kubernetes there is no knob for it.** The bot runs Chromium **without**
+`--disable-dev-shm-usage`, so it needs a real shared-memory mount, and Teams is the workload that
+actually consumes it. The Docker backend sizes it at **`2g`** by default (`DOCKER_SHM_SIZE`); on
+Kubernetes the equivalent is **`2Gi`**, but the k8s backend exposes **no setting for it in
+`v0.12.23`** — the only spawn-time knobs it reads are `RUNTIME_K8S_TOLERATIONS` and
+`RUNTIME_K8S_NODE_SELECTOR`. A spawned Pod therefore takes the kubelet's default `/dev/shm`, which on
+most distributions is far below 2 Gi. Two consequences: do not trim the memory ceiling above, and if
+Teams calls crash the browser on your cluster, an undersized `/dev/shm` is the first thing to check.
 </Note>
 
 ### Autoscaling and bot bursts — the fresh-node reachability gate

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -129,7 +129,7 @@ spec:
     defaultRequest: {cpu: 1000m, memory: 1100Mi}
 ```
 
-**Sizing basis, measured, not guessed:** a live bot runs ~1.0–1.3 Gi steady state, which is what the
+**Sizing basis:** a live bot runs ~1.0–1.3 Gi steady state, which is what the
 request is sized to; a Teams call spikes past 2 Gi, which is what the 2560Mi limit is sized to (an
 OOM at ~2 Gi is why that ceiling exists). These values have run production since April 2026.
 

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -107,6 +107,40 @@ an in-image executable against the published images, so a profile that diverges 
 fails the release rather than a customer's install.
 </Warning>
 
+### Namespace LimitRange defaults
+
+A spawned bot or agent Pod carries **no resource requests or limits of its own** — the chart does not
+stamp any onto it. On a plain namespace that is fine (the Pod is unbounded and the scheduler places it
+on capacity). In a **quota-controlled namespace**, however, a `LimitRange` supplies the defaults, and
+whatever it says is what the bot gets.
+
+The bot runs a real browser. Either run Vexa's spawn namespace with **no `LimitRange` at all**, or
+give that namespace defaults big enough for a browser:
+
+```yaml
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: runtime-defaults
+spec:
+  limits:
+  - type: Container
+    default:        {cpu: "2", memory: 4096Mi}
+    defaultRequest: {cpu: "2", memory: 4096Mi}
+```
+
+<Warning>
+**Do not set memory below `4096Mi`.** It is a hard floor, not a starting point: around 2 GB the bot
+is OOM-killed on Teams meetings. Also check that the namespace's `max` (and any `ResourceQuota`)
+is not *below* these defaults, or the Pod is rejected at admission instead.
+</Warning>
+
+Under-provisioned defaults do not fail loudly at schedule time — the Pod is admitted and then
+OOM-killed or CPU-starved partway through the join, which reads as a flaky bot rather than a quota
+problem. Check with `kubectl get limitrange -n <namespace> -o yaml` before an upgrade or a first
+install. Agent-worker Pods are smaller than a bot and are over-provisioned by this default; that is
+the intended trade — they are small and few.
+
 ### Autoscaling and bot bursts — the fresh-node reachability gate
 
 Because every bot is its own bare Pod, a burst of meeting requests can push the cluster autoscaler to

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -115,7 +115,7 @@ on capacity). In a **quota-controlled namespace**, however, a `LimitRange` suppl
 whatever it says is what the bot gets.
 
 The bot runs a real browser. Either run Vexa's spawn namespace with **no `LimitRange` at all**, or
-give that namespace defaults big enough for a browser:
+give that namespace the defaults Vexa's own production runs:
 
 ```yaml
 apiVersion: v1
@@ -125,21 +125,32 @@ metadata:
 spec:
   limits:
   - type: Container
-    default:        {cpu: "2", memory: 4096Mi}
-    defaultRequest: {cpu: "2", memory: 4096Mi}
+    default:        {cpu: 1500m, memory: 2560Mi}
+    defaultRequest: {cpu: 1000m, memory: 1100Mi}
 ```
 
+**Sizing basis, measured, not guessed:** a live bot runs ~1.0–1.3 Gi steady state, which is what the
+request is sized to; a Teams call spikes past 2 Gi, which is what the 2560Mi limit is sized to (an
+OOM at ~2 Gi is why that ceiling exists). These values have run production since April 2026.
+
 <Warning>
-**Do not set memory below `4096Mi`.** It is a hard floor, not a starting point: around 2 GB the bot
-is OOM-killed on Teams meetings. Also check that the namespace's `max` (and any `ResourceQuota`)
-is not *below* these defaults, or the Pod is rejected at admission instead.
+**Do not set the memory limit below `2560Mi`** — it is a hard ceiling, not a starting point. Also
+check that the namespace's `max` (and any `ResourceQuota`) is not *below* these defaults, or the Pod
+is rejected at admission instead of merely being under-provisioned.
 </Warning>
 
 Under-provisioned defaults do not fail loudly at schedule time — the Pod is admitted and then
 OOM-killed or CPU-starved partway through the join, which reads as a flaky bot rather than a quota
 problem. Check with `kubectl get limitrange -n <namespace> -o yaml` before an upgrade or a first
-install. Agent-worker Pods are smaller than a bot and are over-provisioned by this default; that is
-the intended trade — they are small and few.
+install. Agent-worker Pods are smaller than a bot and are over-provisioned by these defaults; that
+is the intended trade — they are small and few.
+
+<Note>
+**`/dev/shm` on Kubernetes.** Chromium wants a real shared-memory mount; the Docker backend gives a
+spawned bot `2g` by default (`DOCKER_SHM_SIZE`), and Teams calls are the workload that needs it. The
+k8s backend has **no equivalent knob in `v0.12.23`** — a spawned Pod takes the kubelet's default
+`/dev/shm`, which is one more reason not to trim the memory ceiling above.
+</Note>
 
 ### Autoscaling and bot bursts — the fresh-node reachability gate
 


### PR DESCRIPTION
**Delivers issue:** #1005 (the quota-controlled-namespace half — documentation; the code fix is #1093)

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> ⚠️ Left unticked deliberately — this is a legal certification and an agent must not select it.
> Maintainer: tick one box to clear `contribution-rights`.

## What this adds

A public **operator** runbook for 0.10.x → 0.12.x. Until now the docs carried only the client-side
contract changes ("Migrating from 0.10"); everything an operator with a populated database has to do
lived in the per-migration files under `core/identity/.../schema/`, which nobody upgrading finds.

New `### Upgrade runbook: 0.10 to 0.12.x` in [`docs/docs/changelog.mdx`](https://github.com/Vexa-ai/vexa/blob/main/docs/docs/changelog.mdx):

1. **Go straight to the latest 0.12.x** — convergence is state-based, not sequential, so an
   intermediate pin buys nothing; older 0.12.x also lacks the fail-closed schema check, where a
   missing dedup index degrades *silently* instead of refusing to start.
2. **The three manual DB steps, pre-flight first.** No Alembic — `ensure_schema()` converges
   additively on every admin-api boot, which is exactly why three things are not done for you.
   The `#1187` UNIQUE-index abort leads: if `meetings` holds ≥2 active rows per
   `(user_id, platform, platform_specific_id)`, admin-api exits `3` and `/health` never answers,
   so the read-only duplicate query (verbatim from `MIGRATION-0002`) runs **before** anything is
   deployed. Then `CREATE UNIQUE INDEX CONCURRENTLY`, then the `max_concurrent_bots` 1 → 3 default
   + raise-only backfill. Token-scope backfill is listed as automatic so operators can verify it ran.
3. **Quota-controlled Kubernetes** — spawned Pods declare no resources, so the namespace
   `LimitRange` is what a bot actually gets.

New `### Namespace LimitRange defaults` in `docs/docs/deployment-kubernetes.mdx` carries the YAML:
`default` `{cpu: 1500m, memory: 2560Mi}` and `defaultRequest` `{cpu: 1000m, memory: 1100Mi}` — the
values Vexa's own production runs, as posted on #1005 — with `2560Mi` stated as a **hard ceiling**
(a Teams call spikes past 2 Gi; an OOM at ~2 Gi is why that ceiling exists), plus the reminder to
check the namespace `max` / `ResourceQuota` is not below the defaults. The `/dev/shm` note names the
gap explicitly: the bot runs Chromium **without** `--disable-dev-shm-usage` and Docker sizes the
mount at `2g` (`DOCKER_SHM_SIZE`), but the k8s backend exposes **no equivalent setting** in
`v0.12.23` — its only spawn-time knobs are `RUNTIME_K8S_TOLERATIONS` and `RUNTIME_K8S_NODE_SELECTOR`. `#1093` is the permanent fix; this is the standing
guidance for anyone on a released 0.12.x.

## What this corrects

`MIGRATION-0001`'s status line — *"NOT executed against any live/prod DB"* — predates the July 2026
production 0.10 → 0.12 migration and was being read as *the upgrade itself is untried in
production*. It isn't: only the legacy-table **DROP** is untried, deliberately (0.12 never creates
those tables and convergence never drops, so an upgraded DB just leaves them standing). Scoped the
claim to that, and recorded the upgrade provenance in the schema `README.md` so the next reader of
"out-of-band, human-run ops step" understands it describes *who runs the statement*, not an
unexercised path.

Also backticks an unescaped `<0.6.0` further down the changelog: as MDX that is an unclosed tag, and
it made the whole file unparseable to `mint broken-links` (pre-existing on `main`).

## Verification

- `node scripts/gates.mjs docs-version` — green (docs reflect v0.12.23 = `Chart.yaml` appVersion).
- `npx mint broken-links` over `docs/docs` — **no broken links**; before the `<0.6.0` fix it could
  not parse `changelog.mdx` at all.
- Every SQL statement is copied verbatim from the in-repo migration runbooks, not rewritten.
- `migrations.enabled: false` checked against `deploy/helm/charts/vexa/values.yaml`.
- "spawned Pods declare no resources" checked against `core/runtime/src/runtime_kernel/k8s_backend.py`
  (no `resources`/`limits`/`requests` anywhere in it).

Docs-only; no code paths touched. **Do not merge on my say-so** — this is staged for maintainer review.


## Docs diff (D6c)

| Page | Change |
|---|---|
| `docs/docs/changelog.mdx` | new `### Upgrade runbook: 0.10 to 0.12.x` — straight jump, the three manual DB steps (pre-flight first), the LimitRange pointer. Anchor: `/changelog#upgrade-runbook-010-to-012x` |
| `docs/docs/deployment-kubernetes.mdx` | new `### Namespace LimitRange defaults` — the YAML, the measured sizing basis, the `/dev/shm` gap. Anchor: `/deployment-kubernetes#namespace-limitrange-defaults` |
| `core/identity/.../schema/MIGRATION-0001-drop-recordings.md`, `.../schema/README.md` | in-repo migration docs — stale status line corrected, upgrade provenance recorded |

Altitudes: the changelog carries the *task* (upgrade this install), the Kubernetes page carries the
*reference* (what a spawned Pod needs), and each links to the other rather than restating it.

## Security checks (required on the diff)

Docs-only diff — no dependencies, no code paths, no new endpoints. `Analyze (actions / javascript-typescript / python)`, `CodeQL`, and `GitGuardian` are green on the head commit. One string change in prose (`<0.6.0` → `` `<0.6.0` ``) touches an advisory *description*, not a version constraint.

## Validation request

Any competent non-author with a 0.10.x install, or a maintainer reading against the schema files:
the SQL is verbatim from the in-repo runbooks and the LimitRange values are production's own
`RUNTIME_K8S_RESOURCES`, so the check is that the docs match those two sources, and that the
pre-flight genuinely precedes deploy in the ordering as written.

**Deployment validated (D12b):** none run for this change — it is documentation. The behaviour it
describes is the July 2026 production 0.10 → 0.12 migration (hosted, Kubernetes) and the
LimitRange values currently live on that same deployment.

## Authorship
Sole author: the human submitting this. Tooling disclosure: drafted with Claude Code against the
in-repo migration runbooks, `core/runtime/src/runtime_kernel/k8s_backend.py`, and the Helm values.

<!-- vexa-agent -->

