### PR TITLE
[DEV] migrate tool: the two 0.10 → 0.12 database steps convergence cannot do, with glass-box docs

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/migrate/README.md
+++ b/core/identity/services/admin-api/src/admin_api/migrate/README.md
@@ -1,0 +1,31 @@
+# migrate — the 0.10 → 0.12 database migration tool
+
+`python -m admin_api.migrate check` / `python -m admin_api.migrate run --fix`.
+
+`../schema/sync.py` (`ensure_schema()`) converges the database to the models on every boot, inside
+one transaction, additively. Two steps of the 0.10 → 0.12 upgrade fall outside that on a populated
+database, and this package is those two:
+
+1. **dedup** — retire duplicate ACTIVE meeting rows per `(user_id, platform,
+   platform_specific_id)`. Convergence never rewrites an existing row's values.
+2. **the index** — build `uq_meeting_active_user_platform_native` with `CREATE UNIQUE INDEX
+   CONCURRENTLY`. Postgres refuses `CONCURRENTLY` inside a transaction block.
+
+Nothing else. `max_concurrent_bots` (MIGRATION-0003) is reported, never written — a product knob,
+not a migration step. Token scopes (MIGRATION-0004) are applied by convergence itself.
+
+| File | Owns |
+|---|---|
+| `sql.py` | every statement the tool can issue, one named constant each. `Q_` read-only, `W_` writes. |
+| `core.py` | state read, the pure `decide()` verdict, the keep/retire plan, the two executions, the `--json` document. |
+| `receipt.py` | the plain-text receipt renderer. |
+| `__main__.py` | the CLI: verbs, flags, connection, exit codes (`0` GO · `10` ACTION_REQUIRED · `20` STOP). |
+
+`check` and a `run` without `--fix` execute inside a `SET TRANSACTION READ ONLY` transaction, so a
+dry run cannot write even by mistake.
+
+Evals: `../../../tests/test_migrate_unit.py` (no database) and `../../../tests/test_stack_migrate.py`
+(testcontainers Postgres). Operator documentation, with every statement verbatim:
+`docs/docs/upgrade-migrate-tool.mdx`.
+
+_Governed by `docs/docs/governance/architecture.mdx` (P1–P12). This folder owns one concern; its public surface is its `index`/contract; it may depend only on what the dependency-rules allow._

--- a/core/identity/services/admin-api/src/admin_api/migrate/__init__.py
+++ b/core/identity/services/admin-api/src/admin_api/migrate/__init__.py
@@ -1,0 +1,30 @@
+"""0.10 → 0.12 database migration tool.
+
+`ensure_schema()` converges the database to the SQLAlchemy models on every admin-api boot, inside
+one transaction, additively. Two steps of the 0.10 → 0.12 upgrade fall outside what that can do on
+a live database, and this tool is those two steps:
+
+  1. retiring duplicate ACTIVE meeting rows, so the unique dedup index can be built at all
+     (a transaction-bound, never-rewrites convergence cannot change existing row values);
+  2. building `uq_meeting_active_user_platform_native` with `CREATE UNIQUE INDEX CONCURRENTLY`,
+     which Postgres refuses inside a transaction block.
+
+CLI: ``python -m admin_api.migrate check`` / ``python -m admin_api.migrate run --fix``.
+Documented at ``docs/docs/upgrade-migrate-tool.mdx``.
+"""
+from .core import (
+    ACTION_REQUIRED,
+    GO,
+    STOP,
+    State,
+    Verdict,
+    decide,
+    dedup_plan,
+    read_state,
+    state_to_json,
+)
+
+__all__ = [
+    "ACTION_REQUIRED", "GO", "STOP", "State", "Verdict",
+    "decide", "dedup_plan", "read_state", "state_to_json",
+]

--- a/core/identity/services/admin-api/src/admin_api/migrate/__main__.py
+++ b/core/identity/services/admin-api/src/admin_api/migrate/__main__.py
@@ -1,0 +1,254 @@
+"""``python -m admin_api.migrate`` — the 0.10 → 0.12 database migration tool.
+
+    python -m admin_api.migrate check [--json] [--dsn URL] [--receipt PATH]
+    python -m admin_api.migrate run  [--fix] [--keep-strategy newest|live-bot]
+                                     [--keep-meeting-id ID ...] [--retire-status failed|completed]
+                                     [--json] [--dsn URL] [--receipt PATH]
+
+`check` is the default verb and is strictly read-only: it opens one `READ ONLY` transaction, so
+the database itself refuses any write it could attempt. `run` without `--fix` is also read-only —
+it prints the statements it WOULD execute. Only `run --fix` writes.
+
+Connection: `--dsn`, else `DATABASE_URL`, else the `DB_*` environment the admin-api itself reads
+(`DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD`). An async driver in the URL is rewritten
+to the sync one — this tool needs `CREATE INDEX CONCURRENTLY` on a real autocommit connection.
+
+Exit codes:
+    0   GO — nothing left for this tool to do
+    10  ACTION_REQUIRED — `run --fix` closes the gap (also the exit of a dry run with work pending)
+    20  STOP — a human must act first; `run` refuses to proceed
+    1   execution failure
+    2   usage error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+from . import core, receipt
+from . import sql as S
+
+EXIT_GO = 0
+EXIT_FAILURE = 1
+EXIT_USAGE = 2
+EXIT_ACTION_REQUIRED = 10
+EXIT_STOP = 20
+
+_VERDICT_EXIT = {core.GO: EXIT_GO, core.ACTION_REQUIRED: EXIT_ACTION_REQUIRED, core.STOP: EXIT_STOP}
+
+
+def database_url(explicit: str | None = None) -> str:
+    """Sync (psycopg) Postgres URL. Mirrors `admin_api.__main__._database_url`'s env contract."""
+    url = explicit or os.getenv("DATABASE_URL")
+    if not url:
+        host = os.getenv("DB_HOST", "postgres")
+        port = os.getenv("DB_PORT", "5432")
+        name = os.getenv("DB_NAME", "vexa")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD", "postgres")
+        url = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{name}"
+    # CREATE INDEX CONCURRENTLY needs a real autocommit connection — force the sync driver.
+    return url.replace("postgresql+asyncpg://", "postgresql+psycopg://")
+
+
+def display_dsn(url: str) -> str:
+    """The URL with any password removed — receipts and JSON are shareable artefacts."""
+    if "@" not in url:
+        return url
+    scheme, rest = url.split("://", 1)
+    creds, host = rest.split("@", 1)
+    user = creds.split(":", 1)[0]
+    return f"{scheme}://{user}:***@{host}"
+
+
+def _read_only_state(engine, dsn_display: str):
+    """One READ ONLY transaction: state + verdict + dedup plan. Always rolled back."""
+    from ..schema.models import Base
+
+    with engine.connect() as conn:
+        with conn.begin() as txn:
+            conn.execute(text(S.Q_READ_ONLY_TXN))
+            st = core.read_state(conn, Base, dsn_display=dsn_display)
+            v = core.decide(st)
+            plan = core.dedup_plan(conn) if st.duplicate_rows else []
+            txn.rollback()
+    return st, v, plan
+
+
+def _emit(args, doc: dict, text_report: str) -> None:
+    if args.json:
+        print(json.dumps(doc, indent=2, default=str))
+    else:
+        print(text_report)
+    if args.receipt:
+        with open(args.receipt, "w", encoding="utf-8") as fh:
+            fh.write(text_report + "\n")
+        if not args.json:
+            print(f"\nreceipt written to {args.receipt}")
+
+
+def cmd_check(args) -> int:
+    url = database_url(args.dsn)
+    shown = display_dsn(url)
+    engine = create_engine(url)
+    try:
+        st, v, _plan = _read_only_state(engine, shown)
+    finally:
+        engine.dispose()
+    report = receipt.render(
+        verb="check", mode="READ-ONLY", st=st, verdict=v,
+        tool=core.TOOL, tool_version=core.TOOL_VERSION,
+    )
+    _emit(args, core.state_to_json(st, v), report)
+    return _VERDICT_EXIT[v.verdict]
+
+
+def cmd_run(args) -> int:
+    if args.retire_status not in S.TERMINAL_STATUSES:
+        print(f"error: --retire-status must be one of {S.TERMINAL_STATUSES}", file=sys.stderr)
+        return EXIT_USAGE
+
+    url = database_url(args.dsn)
+    shown = display_dsn(url)
+    engine = create_engine(url)
+    try:
+        from ..schema.models import Base
+
+        # ── phase 0: read-only state, verdict, plan ──────────────────────────────────────────
+        with engine.connect() as conn:
+            with conn.begin() as txn:
+                conn.execute(text(S.Q_READ_ONLY_TXN))
+                st = core.read_state(conn, Base, dsn_display=shown)
+                v = core.decide(st)
+                plan = core.dedup_plan(
+                    conn, keep_strategy=args.keep_strategy, keep_ids=args.keep_meeting_id,
+                ) if st.duplicate_rows else []
+                txn.rollback()
+
+        if v.verdict == core.STOP:
+            report = receipt.render(
+                verb="run", mode="REFUSED (check says STOP)", st=st, verdict=v, plan=plan,
+                tool=core.TOOL, tool_version=core.TOOL_VERSION,
+            )
+            _emit(args, core.state_to_json(st, v, plan), report)
+            return EXIT_STOP
+
+        losers = [r for r in plan if r.rank > 1]
+        drop_invalid = st.index.present and not st.index.valid
+        needs_index = not st.index.present or not st.index.valid
+
+        # ── dry run: print the statements, execute nothing ───────────────────────────────────
+        if not args.fix:
+            skipped: list[str] = []
+            if losers:
+                skipped.append(
+                    f"-- dedup plan query (keep-strategy={args.keep_strategy}, "
+                    f"keep-meeting-id={args.keep_meeting_id or []}):\n"
+                    + core.dedup_sql_for_docs(args.keep_strategy))
+                skipped.append(
+                    S.W_RETIRE_DUPLICATES.strip()
+                    + f"\n-- :retire_status = {args.retire_status!r}"
+                    + f"\n-- :loser_ids = {[r.meeting_id for r in losers]}")
+            if drop_invalid:
+                skipped.append(S.W_DROP_INDEX_CONCURRENTLY)
+            if needs_index:
+                skipped.append(S.W_CREATE_INDEX_CONCURRENTLY)
+            report = receipt.render(
+                verb="run", mode="DRY-RUN (no --fix; nothing was executed)", st=st, verdict=v,
+                plan=plan, skipped=skipped,
+                tool=core.TOOL, tool_version=core.TOOL_VERSION,
+            )
+            _emit(args, core.state_to_json(st, v, plan), report)
+            return _VERDICT_EXIT[v.verdict]
+
+        # ── phase 1: dedup ───────────────────────────────────────────────────────────────────
+        executed: list[core.Executed] = []
+        if losers:
+            with engine.begin() as conn:
+                executed.append(core.retire_duplicates(
+                    conn, losers, retire_status=args.retire_status,
+                    keep_strategy=args.keep_strategy,
+                ))
+            with engine.connect() as conn:
+                remaining = conn.execute(text(S.Q_ACTIVE_DUPLICATE_GROUPS)).mappings().all()
+            if remaining:
+                print("error: duplicate active meetings remain after dedup — refusing to build "
+                      f"the index. Groups left: {len(remaining)}", file=sys.stderr)
+                return EXIT_FAILURE
+
+        # ── phase 2: the index, outside any transaction ──────────────────────────────────────
+        if needs_index:
+            with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+                executed.extend(core.build_index(conn, drop_invalid_first=drop_invalid))
+
+        # ── phase 3: re-read and re-decide ───────────────────────────────────────────────────
+        st_after, v_after, _ = _read_only_state(engine, shown)
+        report = receipt.render(
+            verb="run", mode="EXECUTED (--fix)", st=st, verdict=v, plan=plan,
+            executed=executed, final_verdict=v_after,
+            tool=core.TOOL, tool_version=core.TOOL_VERSION,
+        )
+        _emit(args, core.state_to_json(st_after, v_after, plan), report)
+        return _VERDICT_EXIT[v_after.verdict]
+    finally:
+        engine.dispose()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    # SUPPRESS so the shared flags may appear before OR after the verb: without it the subparser
+    # re-applies its own defaults over a value already parsed at the top level.
+    common = argparse.ArgumentParser(add_help=False, argument_default=argparse.SUPPRESS)
+    common.add_argument("--dsn", help="Postgres URL. Default: DATABASE_URL, else the DB_* environment.")
+    common.add_argument("--json", action="store_true", help="machine-readable report on stdout")
+    common.add_argument("--receipt", metavar="PATH", help="write the plain-text receipt to PATH")
+
+    p = argparse.ArgumentParser(
+        prog="python -m admin_api.migrate",
+        parents=[common],
+        description="0.10 → 0.12 database migration tool: the two steps ensure_schema() cannot do.",
+    )
+    sub = p.add_subparsers(dest="verb")
+
+    sub.add_parser("check", parents=[common],
+                   help="read-only: report the delta and a GO / ACTION_REQUIRED / STOP verdict")
+
+    run = sub.add_parser("run", parents=[common],
+                         help="execute the dedup and the CONCURRENTLY index build")
+    run.add_argument("--fix", action="store_true",
+                     help="actually execute. Without it, run prints what it would do and writes nothing.")
+    run.add_argument("--keep-strategy", choices=sorted(S.ORDER_BY), default="newest",
+                     help="which row survives in a duplicate group (default: newest)")
+    run.add_argument("--keep-meeting-id", type=int, action="append", default=[], metavar="ID",
+                     help="force this meeting id to survive in its group; repeatable. Overrides --keep-strategy.")
+    run.add_argument("--retire-status", choices=sorted(S.TERMINAL_STATUSES), default="failed",
+                     help="terminal status written to the losing rows (default: failed)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = build_parser()
+    # `check` is the default verb: bare invocation, or only global flags, means check.
+    known = {"check", "run"}
+    if not any(a in known for a in argv):
+        argv = ["check", *argv]
+    args = parser.parse_args(argv)
+    # argparse puts subparser flags on the same namespace; give `check` the defaults it lacks.
+    for name, default in (("fix", False), ("keep_strategy", "newest"),
+                          ("keep_meeting_id", []), ("retire_status", "failed"),
+                          ("dsn", None), ("json", False), ("receipt", None)):
+        if not hasattr(args, name):
+            setattr(args, name, default)
+    try:
+        return cmd_run(args) if args.verb == "run" else cmd_check(args)
+    except Exception as exc:  # noqa: BLE001 — an operator tool reports, it does not traceback
+        print(f"error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/identity/services/admin-api/src/admin_api/migrate/core.py
+++ b/core/identity/services/admin-api/src/admin_api/migrate/core.py
@@ -1,0 +1,424 @@
+"""0.10 → 0.12 migration tool — state inspection, verdict, plan, execution.
+
+Two verbs, both defined here and driven by `admin_api.migrate.__main__`:
+
+  check   strictly read-only. Opens ONE `READ ONLY` transaction, reads state, returns a report.
+  run     executes the two steps `ensure_schema()` structurally cannot do on a live database —
+          the active-meeting dedup, and the CONCURRENTLY build of the dedup index. Nothing else.
+
+Why those two and only those two: `ensure_schema()` (`admin_api.schema.sync`) converges the DB to
+the SQLAlchemy models inside ONE transaction, additively — it adds missing tables, columns and
+indexes and never rewrites an existing value. So it cannot delete or retire a row (the dedup), and
+it cannot issue `CREATE INDEX CONCURRENTLY` (Postgres forbids that inside a transaction block).
+Everything else in the 0.10 → 0.12 delta is either additive (auto) or a product decision this tool
+deliberately leaves to a human — see `MAX_CONCURRENT_BOTS` below.
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import inspect, text
+
+from . import sql as S
+
+TOOL = "admin_api.migrate"
+TOOL_VERSION = "1"
+
+GO = "GO"
+ACTION_REQUIRED = "ACTION_REQUIRED"
+STOP = "STOP"
+
+#: The columns the dedup index must cover, in order. An index that already carries the name but a
+#: different shape is a human's decision to resolve — the tool will not drop it.
+EXPECTED_INDEX_COLUMNS = "(user_id, platform, platform_specific_id)"
+
+#: Rows that must exist in `meetings` for a dedup to be meaningful.
+REQUIRED_TABLES = ("meetings",)
+
+
+# --------------------------------------------------------------------------- #
+# state
+# --------------------------------------------------------------------------- #
+@dataclass
+class IndexState:
+    present: bool = False
+    valid: bool = False
+    unique: bool = False
+    ready: bool = False
+    indexdef: str | None = None
+
+    @property
+    def shape_ok(self) -> bool:
+        """Structural match, not string equality: Postgres re-renders `pg_get_indexdef` with its
+        own casts, so the test is that the index is UNIQUE, covers exactly the three key columns
+        in order, and is PARTIAL (carries a WHERE predicate)."""
+        if not self.present or not self.indexdef:
+            return False
+        return (
+            self.unique
+            and EXPECTED_INDEX_COLUMNS in self.indexdef.replace("USING btree ", "")
+            and " WHERE " in self.indexdef
+        )
+
+
+@dataclass
+class DuplicateGroup:
+    user_id: int
+    platform: str
+    platform_specific_id: str
+    active_dups: int
+    meeting_ids: list[int]
+
+
+@dataclass
+class State:
+    """Everything `check` read, before any interpretation."""
+    dsn_display: str = ""
+    server_version: str = ""
+    tables: list[str] = field(default_factory=list)
+    missing_tables: list[str] = field(default_factory=list)
+    missing_columns: dict[str, list[str]] = field(default_factory=dict)
+    missing_indexes: dict[str, list[str]] = field(default_factory=dict)
+    legacy_tables_present: list[str] = field(default_factory=list)
+    duplicate_groups: list[DuplicateGroup] = field(default_factory=list)
+    duplicate_rows: int = 0
+    index: IndexState = field(default_factory=IndexState)
+    max_concurrent_bots: list[dict[str, int]] = field(default_factory=list)
+    max_concurrent_bots_default: str | None = None
+    empty_scope_tokens: int = 0
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Verdict:
+    verdict: str
+    reasons: list[str]
+    actions: list[str]
+    blockers: list[str]
+
+
+# --------------------------------------------------------------------------- #
+# check — read-only
+# --------------------------------------------------------------------------- #
+def read_state(conn, base, dsn_display: str = "") -> State:
+    """Read every fact `check` reports. Issues only `Q_` statements from `sql.py`.
+
+    The caller opens the transaction and sets it READ ONLY; this function never commits.
+    """
+    st = State(dsn_display=dsn_display)
+    st.server_version = str(conn.execute(text("SHOW server_version")).scalar() or "")
+
+    insp = inspect(conn)
+    present = set(insp.get_table_names())
+    st.tables = sorted(present)
+    st.legacy_tables_present = sorted({"recordings", "media_files"} & present)
+
+    # Convergence delta vs the SQLAlchemy SSOT — what `ensure_schema()` will apply on next boot.
+    for table in base.metadata.sorted_tables:
+        if table.name not in present:
+            st.missing_tables.append(table.name)
+            continue
+        existing_cols = {c["name"] for c in insp.get_columns(table.name)}
+        missing = [c.name for c in table.columns if c.name not in existing_cols]
+        if missing:
+            st.missing_columns[table.name] = missing
+        existing_idx = {i["name"] for i in insp.get_indexes(table.name) if i["name"]}
+        missing_idx = [i.name for i in table.indexes if i.name and i.name not in existing_idx]
+        if missing_idx:
+            st.missing_indexes[table.name] = missing_idx
+
+    if "meetings" in present:
+        for row in conn.execute(text(S.Q_ACTIVE_DUPLICATE_GROUPS)).mappings():
+            st.duplicate_groups.append(DuplicateGroup(
+                user_id=row["user_id"],
+                platform=row["platform"],
+                platform_specific_id=row["platform_specific_id"],
+                active_dups=int(row["active_dups"]),
+                meeting_ids=list(row["meeting_ids"]),
+            ))
+        # Rows to retire = every row in a duplicate group beyond the one keeper.
+        st.duplicate_rows = sum(g.active_dups - 1 for g in st.duplicate_groups)
+
+        idx = conn.execute(text(S.Q_INDEX_STATE), {"index_name": S.INDEX_NAME}).mappings().first()
+        if idx:
+            st.index = IndexState(
+                present=True,
+                valid=bool(idx["indisvalid"]),
+                unique=bool(idx["indisunique"]),
+                ready=bool(idx["indisready"]),
+                indexdef=idx["indexdef"],
+            )
+    else:
+        st.notes.append("`meetings` table absent — nothing to dedup; ensure_schema() builds the "
+                        "table and its indexes cleanly on an empty database.")
+
+    if "users" in present:
+        st.max_concurrent_bots = [
+            {"limit": int(r["current_limit"]), "users": int(r["users"])}
+            for r in conn.execute(text(S.Q_MAX_CONCURRENT_BOTS)).mappings()
+        ]
+        st.max_concurrent_bots_default = conn.execute(
+            text(S.Q_MAX_CONCURRENT_BOTS_DEFAULT)).scalar()
+
+    if "api_tokens" in present:
+        cols = {c["name"] for c in insp.get_columns("api_tokens")}
+        if "scopes" in cols:
+            st.empty_scope_tokens = int(
+                conn.execute(text(S.Q_EMPTY_SCOPE_TOKENS)).scalar() or 0)
+        else:
+            st.notes.append("`api_tokens.scopes` absent (0.10-era). ensure_schema() adds the column "
+                            "and backfills every pre-existing token to the full scope set "
+                            "(MIGRATION-0004) on the next admin-api boot.")
+
+    return st
+
+
+def decide(st: State) -> Verdict:
+    """Pure. State in, verdict out — no I/O, so it is directly testable.
+
+    GO               nothing this tool must do before 0.12 admin-api boots.
+    ACTION_REQUIRED  `migrate run --fix` closes the gap.
+    STOP             a human must act; `run` refuses.
+    """
+    reasons: list[str] = []
+    actions: list[str] = []
+    blockers: list[str] = []
+
+    if "meetings" not in st.tables:
+        reasons.append("No `meetings` table — this database has not run a Vexa schema yet. "
+                       "ensure_schema() builds everything, including the dedup index.")
+        return Verdict(GO, reasons, actions, blockers)
+
+    if st.index.present and not st.index.shape_ok and st.index.valid:
+        blockers.append(
+            f"An index named `{S.INDEX_NAME}` already exists with a different shape "
+            f"({st.index.indexdef}). Expected a UNIQUE PARTIAL index on "
+            f"{EXPECTED_INDEX_COLUMNS}. The tool will not drop an index it did not build — "
+            "inspect it, then drop it by hand and re-run.")
+
+    if st.index.present and not st.index.valid:
+        reasons.append(f"`{S.INDEX_NAME}` exists but is INVALID — the corpse of a failed "
+                       "CONCURRENTLY build. It enforces nothing.")
+        actions.append("drop the invalid index CONCURRENTLY, then rebuild it")
+
+    if st.duplicate_rows:
+        reasons.append(
+            f"{st.duplicate_rows} active meeting row(s) across {len(st.duplicate_groups)} "
+            "duplicate key(s). A UNIQUE index cannot be built over them, and on 0.12.23+ a "
+            "failed UNIQUE index aborts admin-api startup.")
+        actions.append(f"retire {st.duplicate_rows} losing row(s) to a terminal status")
+
+    if not blockers:
+        if not st.index.present:
+            reasons.append(f"`{S.INDEX_NAME}` is absent — the cross-process spawn-dedup backstop "
+                           "does not exist on this database.")
+        if not st.index.present or not st.index.valid:
+            actions.append("build the dedup index with CREATE UNIQUE INDEX CONCURRENTLY")
+
+    if blockers:
+        return Verdict(STOP, reasons, actions, blockers)
+    if actions:
+        return Verdict(ACTION_REQUIRED, reasons, actions, blockers)
+
+    reasons.append(f"`{S.INDEX_NAME}` is present, UNIQUE, PARTIAL and VALID; no active duplicate "
+                   "meetings. The remaining 0.10 → 0.12 schema delta is additive and applies "
+                   "itself on the next admin-api boot.")
+    return Verdict(GO, reasons, actions, blockers)
+
+
+# --------------------------------------------------------------------------- #
+# run — the plan, then the execution
+# --------------------------------------------------------------------------- #
+@dataclass
+class PlanRow:
+    meeting_id: int
+    user_id: int
+    platform: str
+    platform_specific_id: str
+    status: str
+    bot_container_id: str | None
+    created_at: str
+    rank: int
+
+    @property
+    def action(self) -> str:
+        return "KEEP" if self.rank == 1 else "RETIRE"
+
+
+def dedup_plan(conn, keep_strategy: str = "newest", keep_ids: list[int] | None = None) -> list[PlanRow]:
+    """Row-by-row keep/retire plan. Read-only — this is what `run` prints without `--fix`."""
+    if keep_strategy not in S.ORDER_BY:
+        raise ValueError(f"unknown keep strategy: {keep_strategy}")
+    stmt = S.Q_DEDUP_PLAN.format(order=S.ORDER_BY[keep_strategy])
+    rows = conn.execute(text(stmt), {"keep_ids": list(keep_ids or [])}).mappings()
+    return [
+        PlanRow(
+            meeting_id=r["id"],
+            user_id=r["user_id"],
+            platform=r["platform"],
+            platform_specific_id=r["platform_specific_id"],
+            status=r["status"],
+            bot_container_id=r["bot_container_id"],
+            created_at=str(r["created_at"]),
+            rank=int(r["rn"]),
+        )
+        for r in rows
+    ]
+
+
+def dedup_sql_for_docs(keep_strategy: str = "newest") -> str:
+    """The exact statement `dedup_plan` issues, for the receipt and the docs page."""
+    return S.Q_DEDUP_PLAN.format(order=S.ORDER_BY[keep_strategy]).strip()
+
+
+@dataclass
+class Executed:
+    statement: str
+    params: dict[str, Any] | None
+    rowcount: int
+    seconds: float
+    detail: list[str] = field(default_factory=list)
+
+
+def retire_duplicates(conn, losers: list[PlanRow], retire_status: str, keep_strategy: str) -> Executed:
+    """Execute `W_RETIRE_DUPLICATES` over an id set computed and printed beforehand.
+
+    One statement, one transaction, ids bound explicitly. The stamp makes every touched row
+    findable afterwards: `SELECT * FROM meetings WHERE data ? 'dedup'`.
+    """
+    if retire_status not in S.TERMINAL_STATUSES:
+        raise ValueError(
+            f"retire status {retire_status!r} is not one of {S.TERMINAL_STATUSES} — the dedup "
+            "index's partial predicate excludes only those, so any other value leaves the row "
+            "inside the index and the build still fails.")
+    stamp = json.dumps({
+        "reason": "rob1_rob2_active_dedup",
+        "migration": "0002",
+        "tool": TOOL,
+        "keep_strategy": keep_strategy,
+        "at": datetime.now(timezone.utc).isoformat(),
+    })
+    ids = [r.meeting_id for r in losers]
+    t0 = time.monotonic()
+    result = conn.execute(text(S.W_RETIRE_DUPLICATES), {
+        "retire_status": retire_status, "stamp": stamp, "loser_ids": ids,
+    })
+    touched = [f"meeting {r['id']} → status={r['status']}" for r in result.mappings()]
+    return Executed(
+        statement=S.W_RETIRE_DUPLICATES.strip(),
+        params={"retire_status": retire_status, "stamp": stamp, "loser_ids": ids},
+        rowcount=len(touched),
+        seconds=round(time.monotonic() - t0, 3),
+        detail=touched,
+    )
+
+
+def build_index(autocommit_conn, drop_invalid_first: bool) -> list[Executed]:
+    """`CREATE UNIQUE INDEX CONCURRENTLY`, outside any transaction, then verify.
+
+    CONCURRENTLY is why this cannot ride `ensure_schema()`: Postgres refuses it inside a
+    transaction block, and `ensure_schema()` is one transaction. Plain `CREATE INDEX` would take
+    a lock that blocks every write to `meetings` for the duration of the build — not acceptable
+    on the hot spawn table.
+    """
+    out: list[Executed] = []
+    if drop_invalid_first:
+        t0 = time.monotonic()
+        autocommit_conn.execute(text(S.W_DROP_INDEX_CONCURRENTLY))
+        out.append(Executed(S.W_DROP_INDEX_CONCURRENTLY, None, 0,
+                            round(time.monotonic() - t0, 3),
+                            ["dropped INVALID index left by a failed CONCURRENTLY build"]))
+    t0 = time.monotonic()
+    autocommit_conn.execute(text(S.W_CREATE_INDEX_CONCURRENTLY))
+    seconds = round(time.monotonic() - t0, 3)
+
+    verify = autocommit_conn.execute(
+        text(S.Q_INDEX_STATE), {"index_name": S.INDEX_NAME}).mappings().first()
+    if not verify or not verify["indisvalid"] or not verify["indisunique"]:
+        raise RuntimeError(
+            f"{S.INDEX_NAME} did not verify after the build "
+            f"(present={bool(verify)}, valid={verify and verify['indisvalid']}). "
+            f"An INVALID index enforces nothing: drop it with "
+            f"`{S.W_DROP_INDEX_CONCURRENTLY}` and re-run.")
+    out.append(Executed(S.W_CREATE_INDEX_CONCURRENTLY, None, 0, seconds,
+                        ["verified: indisvalid=t indisunique=t", str(verify["indexdef"])]))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# report rendering
+# --------------------------------------------------------------------------- #
+def state_to_json(st: State, v: Verdict, plan: list[PlanRow] | None = None) -> dict[str, Any]:
+    """The `--json` document. Stable keys — this is the machine-readable contract."""
+    doc: dict[str, Any] = {
+        "tool": TOOL,
+        "tool_version": TOOL_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "database": {"target": st.dsn_display, "server_version": st.server_version},
+        "verdict": v.verdict,
+        "reasons": v.reasons,
+        "actions": v.actions,
+        "blockers": v.blockers,
+        "schema_delta": {
+            "missing_tables": st.missing_tables,
+            "missing_columns": st.missing_columns,
+            "missing_indexes": st.missing_indexes,
+            "legacy_tables_present": st.legacy_tables_present,
+            "applied_by": "ensure_schema() on admin-api boot (additive, never drops)",
+        },
+        "duplicate_active_meetings": {
+            "groups": len(st.duplicate_groups),
+            "rows_to_retire": st.duplicate_rows,
+            "detail": [
+                {
+                    "user_id": g.user_id,
+                    "platform": g.platform,
+                    "platform_specific_id": g.platform_specific_id,
+                    "active_rows": g.active_dups,
+                    "meeting_ids": g.meeting_ids,
+                }
+                for g in st.duplicate_groups
+            ],
+        },
+        "dedup_index": {
+            "name": S.INDEX_NAME,
+            "present": st.index.present,
+            "valid": st.index.valid,
+            "unique": st.index.unique,
+            "shape_ok": st.index.shape_ok,
+            "definition": st.index.indexdef,
+        },
+        "max_concurrent_bots": {
+            "note": "report only — this tool never writes this column (product knob, not a "
+                    "migration step). See MIGRATION-0003 for the one-line SQL.",
+            "column_default": st.max_concurrent_bots_default,
+            "histogram": st.max_concurrent_bots,
+            "accounts_at_1": next(
+                (h["users"] for h in st.max_concurrent_bots if h["limit"] == 1), 0),
+        },
+        "token_scopes": {
+            "empty_scope_tokens": st.empty_scope_tokens,
+            "note": "MIGRATION-0004 — backfilled automatically by ensure_schema() on boot.",
+        },
+        "notes": st.notes,
+    }
+    if plan is not None:
+        doc["dedup_plan"] = [
+            {
+                "meeting_id": r.meeting_id,
+                "action": r.action,
+                "rank": r.rank,
+                "user_id": r.user_id,
+                "platform": r.platform,
+                "platform_specific_id": r.platform_specific_id,
+                "status": r.status,
+                "bot_container_id": r.bot_container_id,
+                "created_at": r.created_at,
+            }
+            for r in plan
+        ]
+    return doc

--- a/core/identity/services/admin-api/src/admin_api/migrate/receipt.py
+++ b/core/identity/services/admin-api/src/admin_api/migrate/receipt.py
@@ -1,0 +1,121 @@
+"""The receipt — a plain-text record of everything a `migrate` invocation read and executed.
+
+One file, one invocation. It is the artefact an operator keeps: it names the database, the mode,
+every statement issued verbatim with its bound parameters, every row touched, and the verdict
+before and after. A dry run produces a receipt too, marked DRY-RUN, listing the statements that
+were NOT executed.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from .core import Executed, PlanRow, State, Verdict
+
+RULE = "=" * 78
+THIN = "-" * 78
+
+
+def _block(title: str) -> list[str]:
+    return ["", RULE, title, RULE]
+
+
+def render(
+    *,
+    verb: str,
+    mode: str,
+    st: State,
+    verdict: Verdict,
+    plan: list[PlanRow] | None = None,
+    executed: list[Executed] | None = None,
+    skipped: list[str] | None = None,
+    final_verdict: Verdict | None = None,
+    tool: str,
+    tool_version: str,
+) -> str:
+    L: list[str] = []
+    L.append(RULE)
+    L.append(f"{tool} v{tool_version} — receipt")
+    L.append(RULE)
+    L.append(f"verb           : {verb}")
+    L.append(f"mode           : {mode}")
+    L.append(f"generated (UTC): {datetime.now(timezone.utc).isoformat()}")
+    L.append(f"database       : {st.dsn_display}")
+    L.append(f"server_version : {st.server_version}")
+
+    L += _block("STATE READ")
+    L.append(f"tables                     : {', '.join(st.tables) or '(none)'}")
+    L.append(f"legacy tables present      : {', '.join(st.legacy_tables_present) or '(none)'}")
+    L.append(f"missing tables (additive)  : {', '.join(st.missing_tables) or '(none)'}")
+    L.append(f"missing columns (additive) : {st.missing_columns or '(none)'}")
+    L.append(f"missing indexes (additive) : {st.missing_indexes or '(none)'}")
+    L.append(f"dedup index                : present={st.index.present} valid={st.index.valid} "
+             f"unique={st.index.unique} shape_ok={st.index.shape_ok}")
+    if st.index.indexdef:
+        L.append(f"  definition               : {st.index.indexdef}")
+    L.append(f"duplicate active keys      : {len(st.duplicate_groups)}")
+    L.append(f"rows that would be retired : {st.duplicate_rows}")
+    for g in st.duplicate_groups:
+        L.append(f"  user={g.user_id} platform={g.platform} native={g.platform_specific_id} "
+                 f"active_rows={g.active_dups} ids={g.meeting_ids}")
+    L.append(f"max_concurrent_bots default: {st.max_concurrent_bots_default}")
+    L.append(f"max_concurrent_bots        : {st.max_concurrent_bots or '(no users table)'}")
+    L.append("  (report only — this tool never writes that column)")
+    L.append(f"api tokens with no scopes  : {st.empty_scope_tokens} "
+             "(MIGRATION-0004, applied by ensure_schema() on boot)")
+    for n in st.notes:
+        L.append(f"note: {n}")
+
+    L += _block("VERDICT (before)")
+    L.append(verdict.verdict)
+    for r in verdict.reasons:
+        L.append(f"  reason : {r}")
+    for a in verdict.actions:
+        L.append(f"  action : {a}")
+    for b in verdict.blockers:
+        L.append(f"  BLOCKER: {b}")
+
+    if plan is not None:
+        L += _block("DEDUP PLAN (row by row)")
+        if not plan:
+            L.append("(no duplicate active meetings)")
+        for r in plan:
+            L.append(f"  {r.action:<6} meeting_id={r.meeting_id} rank={r.rank} "
+                     f"user={r.user_id} platform={r.platform} native={r.platform_specific_id} "
+                     f"status={r.status} bot_container_id={r.bot_container_id} "
+                     f"created_at={r.created_at}")
+
+    if skipped:
+        L += _block("NOT EXECUTED (dry run)")
+        for s in skipped:
+            L.append(THIN)
+            L.append(s)
+
+    if executed is not None:
+        L += _block("EXECUTED")
+        if not executed:
+            L.append("(nothing — already converged)")
+        for e in executed:
+            L.append(THIN)
+            L.append(e.statement)
+            if e.params:
+                L.append(f"  params    : {e.params}")
+            L.append(f"  rowcount  : {e.rowcount}")
+            L.append(f"  duration  : {e.seconds}s")
+            for d in e.detail:
+                L.append(f"  {d}")
+
+    if final_verdict is not None:
+        L += _block("VERDICT (after)")
+        L.append(final_verdict.verdict)
+        for r in final_verdict.reasons:
+            L.append(f"  reason : {r}")
+        for a in final_verdict.actions:
+            L.append(f"  action : {a}")
+        for b in final_verdict.blockers:
+            L.append(f"  BLOCKER: {b}")
+
+    L.append("")
+    L.append(RULE)
+    L.append("end of receipt")
+    L.append(RULE)
+    return "\n".join(L)

--- a/core/identity/services/admin-api/src/admin_api/migrate/sql.py
+++ b/core/identity/services/admin-api/src/admin_api/migrate/sql.py
@@ -1,0 +1,129 @@
+"""Every SQL statement the migrate tool can issue, as a named constant.
+
+The tool executes these strings and nothing else. `docs/docs/upgrade-migrate-tool.mdx` quotes
+them verbatim; a change here is a change to that page.
+
+Read-only statements are prefixed `Q_`. Write statements are prefixed `W_` and are reachable
+only from `migrate run --fix`.
+"""
+from __future__ import annotations
+
+INDEX_NAME = "uq_meeting_active_user_platform_native"
+
+#: Terminal statuses. The dedup index's partial predicate excludes exactly these, so a retired
+#: duplicate must land on one of them or it stays inside the index and the build still fails.
+TERMINAL_STATUSES = ("completed", "failed")
+
+
+# --------------------------------------------------------------------------- #
+# Q_ — read-only
+# --------------------------------------------------------------------------- #
+
+#: MIGRATION-0002 step 1 pre-flight. `platform_specific_id IS NOT NULL` because a unique index
+#: treats NULLs as DISTINCT — rows with a NULL native id never collide and must not be touched.
+Q_ACTIVE_DUPLICATE_GROUPS = """
+SELECT user_id, platform, platform_specific_id,
+       count(*) AS active_dups,
+       array_agg(id ORDER BY created_at DESC, id DESC) AS meeting_ids
+FROM meetings
+WHERE status NOT IN ('completed', 'failed')
+  AND platform_specific_id IS NOT NULL
+GROUP BY user_id, platform, platform_specific_id
+HAVING count(*) > 1
+ORDER BY active_dups DESC
+"""
+
+#: Keep/retire plan: every row in every duplicate group, ranked. `rn = 1` is the keeper; every
+#: `rn > 1` is retired. `:keep_ids` is the explicit `--keep-meeting-id` override (an empty array
+#: when unused, which makes the first ORDER term false for every row and a no-op).
+#: `{order}` is substituted from `ORDER_BY` below — it is one of two fixed strings, never
+#: caller-supplied text.
+Q_DEDUP_PLAN = """
+WITH ranked AS (
+  SELECT id, user_id, platform, platform_specific_id, status, bot_container_id, created_at,
+         row_number() OVER (
+           PARTITION BY user_id, platform, platform_specific_id
+           ORDER BY {order}
+         ) AS rn
+  FROM meetings
+  WHERE status NOT IN ('completed', 'failed')
+    AND platform_specific_id IS NOT NULL
+)
+SELECT id, user_id, platform, platform_specific_id, status, bot_container_id, created_at, rn
+FROM ranked
+WHERE (user_id, platform, platform_specific_id) IN (
+        SELECT user_id, platform, platform_specific_id
+        FROM ranked
+        GROUP BY user_id, platform, platform_specific_id
+        HAVING count(*) > 1
+      )
+ORDER BY user_id, platform, platform_specific_id, rn
+"""
+
+#: The two orderings `--keep-strategy` selects between, each prefixed by the explicit-keep override.
+ORDER_BY = {
+    "newest": "(id = ANY(:keep_ids)) DESC, created_at DESC, id DESC",
+    "live-bot": "(id = ANY(:keep_ids)) DESC, (bot_container_id IS NOT NULL) DESC, created_at DESC, id DESC",
+}
+
+#: Index state. `indisvalid = false` is the corpse a failed CONCURRENTLY build leaves behind.
+Q_INDEX_STATE = """
+SELECT i.indisvalid, i.indisunique, i.indisready, pg_get_indexdef(i.indexrelid) AS indexdef
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname = :index_name
+  AND n.nspname = current_schema()
+"""
+
+#: MIGRATION-0003 pre-flight (report only — the tool never writes this column).
+Q_MAX_CONCURRENT_BOTS = """
+SELECT max_concurrent_bots AS current_limit, count(*) AS users
+FROM users
+GROUP BY max_concurrent_bots
+ORDER BY current_limit
+"""
+
+Q_MAX_CONCURRENT_BOTS_DEFAULT = """
+SELECT column_default
+FROM information_schema.columns
+WHERE table_schema = current_schema()
+  AND table_name = 'users'
+  AND column_name = 'max_concurrent_bots'
+"""
+
+#: MIGRATION-0004 (report only — `ensure_schema` applies this one itself on the next boot).
+Q_EMPTY_SCOPE_TOKENS = """
+SELECT count(*) AS empty_scope_tokens
+FROM api_tokens
+WHERE scopes = '{}'::text[] OR scopes IS NULL
+"""
+
+Q_READ_ONLY_TXN = "SET TRANSACTION READ ONLY"
+
+
+# --------------------------------------------------------------------------- #
+# W_ — writes. Reachable only under `run --fix`.
+# --------------------------------------------------------------------------- #
+
+#: Retire the losing rows to a terminal status and stamp `data.dedup` so every touched row stays
+#: queryable afterwards (`WHERE data ? 'dedup'`). Ids come from Q_DEDUP_PLAN, never recomputed
+#: inside the UPDATE — the receipt lists the exact set before it is written.
+W_RETIRE_DUPLICATES = """
+UPDATE meetings m
+SET status = :retire_status,
+    data   = jsonb_set(coalesce(m.data, '{}'::jsonb), '{dedup}', (:stamp)::jsonb)
+WHERE m.id = ANY(:loser_ids)
+RETURNING m.id, m.user_id, m.platform, m.platform_specific_id, m.status
+"""
+
+#: MIGRATION-0002 step 3. CONCURRENTLY cannot run inside a transaction block — the tool issues
+#: this on an AUTOCOMMIT connection.
+W_CREATE_INDEX_CONCURRENTLY = (
+    f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME}\n"
+    "ON meetings (user_id, platform, platform_specific_id)\n"
+    "WHERE status NOT IN ('completed', 'failed')"
+)
+
+#: Only ever issued against an index this tool has just observed as INVALID.
+W_DROP_INDEX_CONCURRENTLY = f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}"

--- a/core/identity/services/admin-api/tests/test_migrate_unit.py
+++ b/core/identity/services/admin-api/tests/test_migrate_unit.py
@@ -1,0 +1,236 @@
+"""Unit evals for the 0.10 → 0.12 migrate tool — no database, no docker.
+
+Covers the parts that are pure: the verdict function, the CLI's argument contract, the refusal
+paths, the two dedup orderings, and the `--json` document shape. The Postgres-backed behaviour
+(duplicate detection over real rows, the CONCURRENTLY build, idempotency, dry-run-writes-nothing)
+lives in `test_stack_migrate.py`.
+"""
+import json
+
+import pytest
+
+from admin_api.migrate import core
+from admin_api.migrate import sql as S
+from admin_api.migrate.__main__ import (
+    EXIT_USAGE, build_parser, database_url, display_dsn, main,
+)
+
+
+# --------------------------------------------------------------------------- #
+# decide() — the verdict is a pure function of state
+# --------------------------------------------------------------------------- #
+def _state(**kw) -> core.State:
+    st = core.State(tables=["users", "api_tokens", "meetings"])
+    for k, v in kw.items():
+        setattr(st, k, v)
+    return st
+
+
+def _valid_index() -> core.IndexState:
+    return core.IndexState(
+        present=True, valid=True, unique=True, ready=True,
+        indexdef="CREATE UNIQUE INDEX uq_meeting_active_user_platform_native ON public.meetings "
+                 "USING btree (user_id, platform, platform_specific_id) "
+                 "WHERE ((status)::text <> ALL (ARRAY['completed', 'failed']))",
+    )
+
+
+def test_go_when_index_valid_and_no_duplicates():
+    v = core.decide(_state(index=_valid_index()))
+    assert v.verdict == core.GO
+    assert v.actions == []
+
+
+def test_action_required_when_index_absent():
+    v = core.decide(_state())
+    assert v.verdict == core.ACTION_REQUIRED
+    assert any("CONCURRENTLY" in a for a in v.actions)
+
+
+def test_action_required_when_duplicates_present():
+    v = core.decide(_state(duplicate_rows=3, duplicate_groups=[
+        core.DuplicateGroup(1, "google_meet", "abc-def-ghi", 4, [4, 3, 2, 1])]))
+    assert v.verdict == core.ACTION_REQUIRED
+    assert any("retire 3" in a for a in v.actions)
+
+
+def test_invalid_index_is_fixable_not_a_stop():
+    idx = _valid_index()
+    idx.valid = False
+    v = core.decide(_state(index=idx))
+    assert v.verdict == core.ACTION_REQUIRED
+    assert any("drop the invalid index" in a for a in v.actions)
+
+
+def test_wrong_shaped_index_is_a_stop():
+    """A same-named index of a different shape is a human's call — the tool never drops it."""
+    idx = core.IndexState(
+        present=True, valid=True, unique=False, ready=True,
+        indexdef="CREATE INDEX uq_meeting_active_user_platform_native ON public.meetings "
+                 "USING btree (user_id)")
+    v = core.decide(_state(index=idx))
+    assert v.verdict == core.STOP
+    assert v.blockers and "different shape" in v.blockers[0]
+
+
+def test_empty_database_is_go():
+    v = core.decide(core.State(tables=[]))
+    assert v.verdict == core.GO
+
+
+def test_max_concurrent_bots_never_produces_an_action():
+    """Product knob, not a migration step: reported, never acted on."""
+    st = _state(index=_valid_index(),
+                max_concurrent_bots=[{"limit": 1, "users": 42}],
+                max_concurrent_bots_default="1")
+    v = core.decide(st)
+    assert v.verdict == core.GO
+    assert not any("max_concurrent_bots" in a for a in v.actions + v.reasons)
+    doc = core.state_to_json(st, v)
+    assert doc["max_concurrent_bots"]["accounts_at_1"] == 42
+
+
+# --------------------------------------------------------------------------- #
+# the --json document
+# --------------------------------------------------------------------------- #
+REQUIRED_JSON_KEYS = {
+    "tool", "tool_version", "generated_at", "database", "verdict", "reasons", "actions",
+    "blockers", "schema_delta", "duplicate_active_meetings", "dedup_index",
+    "max_concurrent_bots", "token_scopes", "notes",
+}
+
+
+def test_json_document_shape():
+    st = _state(index=_valid_index(), dsn_display="postgresql+psycopg://vexa:***@db:5432/vexa",
+                server_version="16.4")
+    doc = core.state_to_json(st, core.decide(st))
+    assert REQUIRED_JSON_KEYS <= set(doc)
+    assert doc["verdict"] in {core.GO, core.ACTION_REQUIRED, core.STOP}
+    assert doc["dedup_index"]["name"] == S.INDEX_NAME
+    assert set(doc["duplicate_active_meetings"]) == {"groups", "rows_to_retire", "detail"}
+    json.dumps(doc, default=str)   # serialisable as emitted
+
+
+def test_json_carries_the_dedup_plan_when_one_exists():
+    st = _state(duplicate_rows=1)
+    plan = [core.PlanRow(9, 1, "google_meet", "abc", "active", None, "2026-08-01", 1),
+            core.PlanRow(8, 1, "google_meet", "abc", "active", None, "2026-07-01", 2)]
+    doc = core.state_to_json(st, core.decide(st), plan)
+    assert [r["action"] for r in doc["dedup_plan"]] == ["KEEP", "RETIRE"]
+
+
+# --------------------------------------------------------------------------- #
+# refusal paths
+# --------------------------------------------------------------------------- #
+def test_retire_status_outside_the_partial_predicate_is_refused():
+    with pytest.raises(ValueError, match="not one of"):
+        core.retire_duplicates(None, [], retire_status="superseded", keep_strategy="newest")
+
+
+def test_unknown_keep_strategy_is_refused():
+    with pytest.raises(ValueError, match="unknown keep strategy"):
+        core.dedup_plan(None, keep_strategy="oldest")
+
+
+def test_cli_rejects_a_non_terminal_retire_status(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["run", "--retire-status", "superseded"])
+
+
+def test_cli_run_with_bad_status_returns_usage_exit(monkeypatch):
+    args = build_parser().parse_args(["run"])
+    args.retire_status = "superseded"
+    from admin_api.migrate.__main__ import cmd_run
+    assert cmd_run(args) == EXIT_USAGE
+
+
+# --------------------------------------------------------------------------- #
+# CLI contract
+# --------------------------------------------------------------------------- #
+def test_check_is_the_default_verb(monkeypatch):
+    seen = {}
+
+    def fake_check(args):
+        seen["verb"] = args.verb
+        seen["json"] = args.json
+        return 0
+
+    monkeypatch.setattr("admin_api.migrate.__main__.cmd_check", fake_check)
+    assert main([]) == 0
+    assert seen["verb"] == "check"       # no verb given → check
+    assert main(["--json"]) == 0
+    assert seen["json"] is True
+
+
+def test_run_defaults_to_dry_run():
+    args = build_parser().parse_args(["run"])
+    assert args.fix is False
+    assert args.keep_strategy == "newest"
+    assert args.retire_status == "failed"
+
+
+def test_shared_flags_work_on_both_sides_of_the_verb():
+    from admin_api.migrate.__main__ import main as _m  # noqa: F401  (import shape check)
+    for argv in (["run", "--json"], ["--json", "run"]):
+        args = build_parser().parse_args(argv)
+        assert getattr(args, "json", False) is True
+
+
+def test_keep_meeting_id_is_repeatable():
+    args = build_parser().parse_args(["run", "--keep-meeting-id", "7", "--keep-meeting-id", "9"])
+    assert args.keep_meeting_id == [7, 9]
+
+
+def test_main_reports_errors_without_a_traceback(monkeypatch, capsys):
+    def boom(_args):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr("admin_api.migrate.__main__.cmd_check", boom)
+    assert main(["check"]) == 1
+    assert "connection refused" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# connection handling
+# --------------------------------------------------------------------------- #
+def test_async_driver_is_rewritten_to_sync():
+    assert database_url("postgresql+asyncpg://u:p@h:5432/db").startswith("postgresql+psycopg://")
+
+
+def test_database_url_falls_back_to_the_admin_api_env(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("DB_HOST", "pg.internal")
+    monkeypatch.setenv("DB_NAME", "vexa_prod")
+    url = database_url(None)
+    assert "pg.internal" in url and url.endswith("/vexa_prod")
+
+
+def test_display_dsn_hides_the_password():
+    shown = display_dsn("postgresql+psycopg://vexa:hunter2@db:5432/vexa")
+    assert "hunter2" not in shown and "vexa:***@db:5432/vexa" in shown
+
+
+# --------------------------------------------------------------------------- #
+# the SQL surface itself
+# --------------------------------------------------------------------------- #
+def test_index_build_is_concurrently_and_partial():
+    stmt = S.W_CREATE_INDEX_CONCURRENTLY
+    assert "CONCURRENTLY" in stmt and "IF NOT EXISTS" in stmt
+    assert "WHERE status NOT IN ('completed', 'failed')" in stmt
+
+
+def test_dedup_orderings_are_deterministic():
+    """Both strategies end in `id DESC`, so no group can rank two rows equally."""
+    for order in S.ORDER_BY.values():
+        assert order.strip().endswith("id DESC")
+        assert order.startswith("(id = ANY(:keep_ids)) DESC")
+
+
+def test_live_bot_strategy_prefers_a_running_container():
+    assert "(bot_container_id IS NOT NULL) DESC" in S.ORDER_BY["live-bot"]
+
+
+def test_docs_sql_matches_what_the_tool_executes():
+    """The docs page quotes `dedup_sql_for_docs`; it must be the statement actually issued."""
+    assert core.dedup_sql_for_docs("newest") == \
+        S.Q_DEDUP_PLAN.format(order=S.ORDER_BY["newest"]).strip()

--- a/core/identity/services/admin-api/tests/test_stack_migrate.py
+++ b/core/identity/services/admin-api/tests/test_stack_migrate.py
@@ -1,0 +1,313 @@
+"""Postgres-backed evals for the 0.10 → 0.12 migrate tool (testcontainers).
+
+What the unit suite cannot prove without a real server:
+  1. duplicate detection over real rows, including the NULL-native-id rows that must NOT be touched
+  2. `run` without `--fix` writes nothing — asserted against a full before/after row snapshot
+  3. `run --fix` retires exactly the losing rows, keep-newest, and stamps `data.dedup`
+  4. the CONCURRENTLY build lands a VALID UNIQUE PARTIAL index and the constraint then bites
+  5. re-running is a no-op (idempotent) and the verdict is GO
+  6. `run` refuses when `check` says STOP
+  7. `--keep-meeting-id` and `--keep-strategy live-bot` override the default rule
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from admin_api.migrate import core
+from admin_api.migrate import sql as S
+from admin_api.migrate.__main__ import main
+from admin_api.schema.models import Base, Meeting, User
+from admin_api.schema.sync import ensure_schema_sync
+
+from conftest import requires_docker
+
+pytestmark = requires_docker
+
+T0 = datetime(2026, 8, 1, 12, 0, 0)
+
+
+@pytest.fixture()
+def engine(pg_url):
+    """A database shaped like a populated 0.10 install: schema converged, dedup index REMOVED."""
+    eng = create_engine(pg_url)
+    Base.metadata.drop_all(eng)
+    ensure_schema_sync(eng, Base)
+    with eng.connect() as conn:
+        conn.execute(text(f"DROP INDEX IF EXISTS {S.INDEX_NAME}"))
+        conn.commit()
+    yield eng
+    Base.metadata.drop_all(eng)
+    eng.dispose()
+
+
+def _seed(eng, rows):
+    """rows: (user_id, platform, native_id, status, minutes_offset, bot_container_id)."""
+    with Session(eng) as s:
+        s.add(User(id=1, email="one@example.com", max_concurrent_bots=1))
+        s.add(User(id=2, email="two@example.com", max_concurrent_bots=1))
+        s.flush()
+        for uid, plat, native, status, off, bot in rows:
+            s.add(Meeting(user_id=uid, platform=plat, platform_specific_id=native,
+                          status=status, bot_container_id=bot,
+                          created_at=T0 + timedelta(minutes=off)))
+        s.commit()
+
+
+def _snapshot(eng):
+    with eng.connect() as conn:
+        return conn.execute(text(
+            "SELECT id, user_id, platform, platform_specific_id, status, data "
+            "FROM meetings ORDER BY id")).mappings().all()
+
+
+def _state(eng):
+    with eng.connect() as conn:
+        with conn.begin() as txn:
+            conn.execute(text(S.Q_READ_ONLY_TXN))
+            st = core.read_state(conn, Base)
+            plan = core.dedup_plan(conn) if st.duplicate_rows else []
+            txn.rollback()
+    return st, core.decide(st), plan
+
+
+DUPES = [
+    # user 1, one native id, three active rows → 2 to retire, newest (offset 20) survives
+    (1, "google_meet", "aaa-bbb-ccc", "active", 0, None),
+    (1, "google_meet", "aaa-bbb-ccc", "requested", 10, None),
+    (1, "google_meet", "aaa-bbb-ccc", "active", 20, "container-newest"),
+    # same key but TERMINAL — outside the partial predicate, must be left alone
+    (1, "google_meet", "aaa-bbb-ccc", "completed", 30, None),
+    # user 2, two active rows on a different platform → 1 to retire
+    (2, "zoom", "999888777", "requested", 0, None),
+    (2, "zoom", "999888777", "active", 5, None),
+    # NULL native id — a unique index treats NULLs as DISTINCT, so these never collide
+    (2, "teams", None, "active", 0, None),
+    (2, "teams", None, "active", 1, None),
+    # a clean single active row
+    (1, "zoom", "111222333", "active", 0, None),
+]
+
+
+# --------------------------------------------------------------------------- #
+# 1. detection
+# --------------------------------------------------------------------------- #
+def test_detects_duplicate_active_meetings_and_leaves_null_and_terminal_rows_out(engine):
+    _seed(engine, DUPES)
+    st, verdict, plan = _state(engine)
+
+    keys = {(g.user_id, g.platform, g.platform_specific_id) for g in st.duplicate_groups}
+    assert keys == {(1, "google_meet", "aaa-bbb-ccc"), (2, "zoom", "999888777")}
+    assert st.duplicate_rows == 3                     # (3-1) + (2-1)
+    assert verdict.verdict == core.ACTION_REQUIRED
+
+    # The terminal row and both NULL-native rows are absent from the plan entirely.
+    planned_ids = {r.meeting_id for r in plan}
+    with engine.connect() as conn:
+        terminal_id = conn.execute(text(
+            "SELECT id FROM meetings WHERE status = 'completed'")).scalar()
+        null_ids = {r[0] for r in conn.execute(text(
+            "SELECT id FROM meetings WHERE platform_specific_id IS NULL")).all()}
+    assert terminal_id not in planned_ids
+    assert not (null_ids & planned_ids)
+
+
+def test_keep_newest_is_the_rule(engine):
+    _seed(engine, DUPES)
+    _st, _v, plan = _state(engine)
+    keepers = {r.meeting_id: r for r in plan if r.action == "KEEP"}
+    assert len(keepers) == 2
+    for r in keepers.values():
+        group = [p for p in plan if (p.user_id, p.platform, p.platform_specific_id)
+                 == (r.user_id, r.platform, r.platform_specific_id)]
+        assert r.created_at == max(p.created_at for p in group)
+
+
+def test_check_reports_accounts_at_the_old_default(engine):
+    _seed(engine, DUPES)
+    st, v, _ = _state(engine)
+    doc = core.state_to_json(st, v)
+    assert doc["max_concurrent_bots"]["accounts_at_1"] == 2
+    # ...and never proposes writing it.
+    assert not any("max_concurrent_bots" in a for a in doc["actions"] + doc["reasons"])
+
+
+# --------------------------------------------------------------------------- #
+# 2. dry run writes nothing
+# --------------------------------------------------------------------------- #
+def test_dry_run_produces_zero_writes(engine, pg_url, capsys):
+    _seed(engine, DUPES)
+    before = _snapshot(engine)
+    index_before = _state(engine)[0].index.present
+
+    rc = main(["run", "--dsn", pg_url])
+
+    after = _snapshot(engine)
+    assert after == before, "run without --fix must not write a single row"
+    assert _state(engine)[0].index.present == index_before
+    assert rc == 10                                   # ACTION_REQUIRED
+    out = capsys.readouterr().out
+    assert "DRY-RUN" in out
+    assert "NOT EXECUTED" in out
+    assert "CREATE UNIQUE INDEX CONCURRENTLY" in out
+
+
+def test_check_is_read_only_even_with_work_pending(engine, pg_url):
+    _seed(engine, DUPES)
+    before = _snapshot(engine)
+    assert main(["check", "--dsn", pg_url]) == 10
+    assert _snapshot(engine) == before
+
+
+# --------------------------------------------------------------------------- #
+# 3 + 4. the fix
+# --------------------------------------------------------------------------- #
+def test_fix_retires_losers_stamps_them_and_builds_a_valid_index(engine, pg_url, tmp_path):
+    _seed(engine, DUPES)
+    _st, _v, plan = _state(engine)
+    losers = {r.meeting_id for r in plan if r.action == "RETIRE"}
+    keepers = {r.meeting_id for r in plan if r.action == "KEEP"}
+
+    receipt_path = tmp_path / "receipt.txt"
+    rc = main(["run", "--fix", "--dsn", pg_url, "--receipt", str(receipt_path)])
+    assert rc == 0
+
+    with engine.connect() as conn:
+        retired = {r[0] for r in conn.execute(text(
+            "SELECT id FROM meetings WHERE data ? 'dedup'")).all()}
+        statuses = dict(conn.execute(text("SELECT id, status FROM meetings")).all())
+        idx = conn.execute(text(S.Q_INDEX_STATE), {"index_name": S.INDEX_NAME}).mappings().first()
+
+    assert retired == losers
+    assert all(statuses[i] == "failed" for i in losers)
+    assert all(statuses[i] != "failed" for i in keepers)
+    assert idx and idx["indisvalid"] and idx["indisunique"]
+
+    receipt = receipt_path.read_text()
+    assert "EXECUTED" in receipt
+    assert S.W_CREATE_INDEX_CONCURRENTLY.splitlines()[0] in receipt
+    for i in losers:
+        assert f"meeting_id={i}" in receipt
+
+
+def test_the_index_then_actually_blocks_a_duplicate_spawn(engine, pg_url):
+    _seed(engine, DUPES)
+    assert main(["run", "--fix", "--dsn", pg_url]) == 0
+    from sqlalchemy.exc import IntegrityError
+    with Session(engine) as s:
+        s.add(Meeting(user_id=1, platform="zoom", platform_specific_id="111222333",
+                      status="requested"))
+        with pytest.raises(IntegrityError):
+            s.commit()
+
+
+# --------------------------------------------------------------------------- #
+# 5. idempotency
+# --------------------------------------------------------------------------- #
+def test_second_run_is_a_no_op_and_the_verdict_is_go(engine, pg_url, capsys):
+    _seed(engine, DUPES)
+    assert main(["run", "--fix", "--dsn", pg_url]) == 0
+    after_first = _snapshot(engine)
+    capsys.readouterr()
+
+    assert main(["run", "--fix", "--dsn", pg_url]) == 0
+    assert _snapshot(engine) == after_first
+    assert "(nothing — already converged)" in capsys.readouterr().out
+
+    assert main(["check", "--dsn", pg_url]) == 0     # GO
+
+
+def test_run_on_an_already_clean_database_writes_nothing(engine, pg_url):
+    _seed(engine, [(1, "zoom", "111222333", "active", 0, None)])
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        conn.execute(text(S.W_CREATE_INDEX_CONCURRENTLY))
+    before = _snapshot(engine)
+    assert main(["run", "--fix", "--dsn", pg_url]) == 0
+    assert _snapshot(engine) == before
+
+
+def test_an_invalid_index_is_dropped_and_rebuilt(engine, pg_url):
+    """The corpse a failed CONCURRENTLY build leaves behind enforces nothing — the tool replaces it."""
+    _seed(engine, DUPES)
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        # Force an INVALID index the way Postgres does: a CONCURRENTLY build over dirty rows.
+        with pytest.raises(Exception):
+            conn.execute(text(S.W_CREATE_INDEX_CONCURRENTLY))
+    st, verdict, _ = _state(engine)
+    assert st.index.present and not st.index.valid
+    assert verdict.verdict == core.ACTION_REQUIRED
+
+    assert main(["run", "--fix", "--dsn", pg_url]) == 0
+    st_after, verdict_after, _ = _state(engine)
+    assert st_after.index.valid and st_after.index.unique
+    assert verdict_after.verdict == core.GO
+
+
+# --------------------------------------------------------------------------- #
+# 6. refusal
+# --------------------------------------------------------------------------- #
+def test_run_refuses_when_an_index_of_the_wrong_shape_holds_the_name(engine, pg_url, capsys):
+    _seed(engine, DUPES)
+    with engine.connect() as conn:
+        conn.execute(text(f"CREATE INDEX {S.INDEX_NAME} ON meetings (user_id)"))
+        conn.commit()
+    before = _snapshot(engine)
+
+    assert main(["run", "--fix", "--dsn", pg_url]) == 20
+    assert _snapshot(engine) == before
+    out = capsys.readouterr().out
+    assert "REFUSED" in out and "STOP" in out
+
+
+# --------------------------------------------------------------------------- #
+# 7. overrides
+# --------------------------------------------------------------------------- #
+def test_keep_meeting_id_overrides_keep_newest(engine, pg_url):
+    _seed(engine, DUPES)
+    _st, _v, plan = _state(engine)
+    oldest = min((r for r in plan if r.platform == "zoom"), key=lambda r: r.created_at)
+
+    assert main(["run", "--fix", "--dsn", pg_url,
+                 "--keep-meeting-id", str(oldest.meeting_id)]) == 0
+    with engine.connect() as conn:
+        status = conn.execute(text("SELECT status FROM meetings WHERE id = :i"),
+                              {"i": oldest.meeting_id}).scalar()
+    assert status != "failed", "the explicitly kept row must survive"
+
+
+def test_live_bot_strategy_keeps_the_row_with_a_container(engine, pg_url):
+    _seed(engine, [
+        (1, "google_meet", "aaa-bbb-ccc", "active", 0, "container-old"),
+        (1, "google_meet", "aaa-bbb-ccc", "active", 30, None),
+    ])
+    assert main(["run", "--fix", "--dsn", pg_url, "--keep-strategy", "live-bot"]) == 0
+    with engine.connect() as conn:
+        survivor = conn.execute(text(
+            "SELECT bot_container_id FROM meetings "
+            "WHERE status NOT IN ('completed','failed')")).scalar()
+    assert survivor == "container-old"
+
+
+def test_retire_status_completed_is_accepted(engine, pg_url):
+    _seed(engine, DUPES)
+    assert main(["run", "--fix", "--dsn", pg_url, "--retire-status", "completed"]) == 0
+    with engine.connect() as conn:
+        statuses = {r[0] for r in conn.execute(text(
+            "SELECT status FROM meetings WHERE data ? 'dedup'")).all()}
+    assert statuses == {"completed"}
+
+
+# --------------------------------------------------------------------------- #
+# --json over a real database
+# --------------------------------------------------------------------------- #
+def test_json_output_parses_and_carries_the_verdict(engine, pg_url, capsys):
+    import json as _json
+    _seed(engine, DUPES)
+    rc = main(["check", "--json", "--dsn", pg_url])
+    doc = _json.loads(capsys.readouterr().out)
+    assert rc == 10
+    assert doc["verdict"] == core.ACTION_REQUIRED
+    assert doc["duplicate_active_meetings"]["rows_to_retire"] == 3
+    assert doc["dedup_index"]["present"] is False
+    assert "***" in doc["database"]["target"] or "@" not in doc["database"]["target"]

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -101,6 +101,7 @@
           "deployment",
           "deployment-lite",
           "deployment-kubernetes",
+          "upgrade-migrate-tool",
           "configuration",
           "authenticated-bots",
           "model-credentials-licensing",

--- a/docs/docs/upgrade-migrate-tool.mdx
+++ b/docs/docs/upgrade-migrate-tool.mdx
@@ -1,0 +1,480 @@
+---
+title: "Upgrade migration tool"
+description: "The two database steps schema convergence cannot perform on a live 0.10 install — inspected, planned and executed by `python -m admin_api.migrate`, with every statement it issues shown here verbatim."
+---
+
+Upgrading a populated 0.10.x database to 0.12.x needs two operations that the admin-api's own
+schema convergence structurally cannot perform. `python -m admin_api.migrate` performs exactly
+those two and nothing else.
+
+This page documents what the tool reads, what it writes, and the exact SQL it issues. Every
+statement below is the string the tool executes — it is not a paraphrase.
+
+## What convergence does, and where it stops
+
+The admin-api runs `ensure_schema()`
+([`core/identity/services/admin-api/src/admin_api/schema/sync.py`](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/sync.py))
+on every boot. It converges the database to the SQLAlchemy models: create missing tables, add
+missing columns, backfill token scopes, add missing indexes. It runs inside **one transaction**
+and is **additive** — it never drops a table or a column, and it never rewrites the value of an
+existing row.
+
+Two consequences follow, and they are the whole reason this tool exists:
+
+| Step | Why convergence cannot do it |
+|---|---|
+| Retire duplicate **active** meeting rows | Convergence never rewrites existing row values. |
+| Build `uq_meeting_active_user_platform_native` **CONCURRENTLY** | Postgres refuses `CREATE INDEX CONCURRENTLY` inside a transaction block, and convergence is one transaction. |
+
+The rest of the 0.10 → 0.12 schema delta is additive and applies itself on the next admin-api
+boot, including the token-scope backfill
+([MIGRATION-0004](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0004-backfill-token-scopes.md)),
+which grandfathers pre-scope 0.10 API keys to the full scope set.
+
+On 0.12.23 and later, a UNIQUE index that cannot be created raises `SchemaInvariantError` and
+**aborts admin-api startup**. A database holding two or more active meetings on the same
+`(user_id, platform, platform_specific_id)` therefore stops the upgrade at boot.
+
+## Invocation
+
+```bash
+# read-only: what is the delta, and is it safe to deploy?
+python -m admin_api.migrate check
+
+# print the statements that would run — writes nothing
+python -m admin_api.migrate run
+
+# execute them
+python -m admin_api.migrate run --fix
+```
+
+Run it from the admin-api image, which already carries the code and the driver:
+
+```bash
+docker compose run --rm admin-api python -m admin_api.migrate check
+# Kubernetes
+kubectl exec deploy/vexa-admin-api -- python -m admin_api.migrate check
+```
+
+`check` is the default verb: a bare invocation runs it.
+
+### Connection
+
+`--dsn URL`, else `DATABASE_URL`, else the same `DB_HOST` / `DB_PORT` / `DB_NAME` / `DB_USER` /
+`DB_PASSWORD` variables the admin-api itself reads. An `asyncpg` URL is rewritten to `psycopg`:
+the index build needs a real autocommit connection. Receipts and JSON print the URL with the
+password replaced by `***`.
+
+### Options
+
+| Flag | Verb | Effect |
+|---|---|---|
+| `--fix` | `run` | Execute. Without it, `run` prints the statements and writes nothing. |
+| `--keep-strategy newest\|live-bot` | `run` | Which row survives a duplicate group. Default `newest`. |
+| `--keep-meeting-id ID` | `run` | Force this meeting id to survive in its group. Repeatable. Overrides the strategy. |
+| `--retire-status failed\|completed` | `run` | Terminal status written to losing rows. Default `failed`. |
+| `--json` | both | Machine-readable report on stdout. |
+| `--receipt PATH` | both | Write the plain-text receipt to `PATH`. |
+| `--dsn URL` | both | Connection string. |
+
+### Exit codes
+
+| Code | Verdict | Meaning |
+|---|---|---|
+| `0` | `GO` | Nothing left for this tool to do. Safe to deploy 0.12. |
+| `10` | `ACTION_REQUIRED` | `run --fix` closes the gap. Also the exit of a dry run with work pending. |
+| `20` | `STOP` | A human must act first. `run` refuses to proceed. |
+| `1` | — | Execution failure. |
+| `2` | — | Usage error. |
+
+## Phase 1 — `check`: what it reads
+
+`check` opens **one transaction and immediately marks it `READ ONLY`**, so the database itself
+rejects any write, and rolls it back at the end. It issues these statements and no others.
+
+```sql
+SET TRANSACTION READ ONLY
+```
+
+**Server version, tables, columns, indexes.** `SHOW server_version`, plus the SQLAlchemy
+inspector's catalogue reads, compared against the model metadata to produce the additive delta
+convergence will apply on the next boot: missing tables, missing columns, missing indexes, and
+whether the dead 0.10 `recordings` / `media_files` tables are still present.
+
+**Duplicate active meetings.**
+
+```sql
+SELECT user_id, platform, platform_specific_id,
+       count(*) AS active_dups,
+       array_agg(id ORDER BY created_at DESC, id DESC) AS meeting_ids
+FROM meetings
+WHERE status NOT IN ('completed', 'failed')
+  AND platform_specific_id IS NOT NULL
+GROUP BY user_id, platform, platform_specific_id
+HAVING count(*) > 1
+ORDER BY active_dups DESC
+```
+
+`platform_specific_id IS NOT NULL` because a unique index treats NULLs as distinct: rows with a
+NULL native id never collide, and the tool never touches them. `status NOT IN ('completed',
+'failed')` is the index's own partial predicate — terminal rows are outside the index and are
+likewise never touched.
+
+**Dedup index state.**
+
+```sql
+SELECT i.indisvalid, i.indisunique, i.indisready, pg_get_indexdef(i.indexrelid) AS indexdef
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname = :index_name
+  AND n.nspname = current_schema()
+```
+
+`indisvalid = false` is the corpse a failed `CONCURRENTLY` build leaves behind. It enforces
+nothing, and the tool treats it as work to redo, not as a present index.
+
+**Concurrent-bot limits — report only.**
+
+```sql
+SELECT max_concurrent_bots AS current_limit, count(*) AS users
+FROM users
+GROUP BY max_concurrent_bots
+ORDER BY current_limit
+```
+
+```sql
+SELECT column_default
+FROM information_schema.columns
+WHERE table_schema = current_schema()
+  AND table_name = 'users'
+  AND column_name = 'max_concurrent_bots'
+```
+
+**Token scopes — report only.**
+
+```sql
+SELECT count(*) AS empty_scope_tokens
+FROM api_tokens
+WHERE scopes = '{}'::text[] OR scopes IS NULL
+```
+
+## `max_concurrent_bots` is a product knob, not a migration step
+
+0.10 shipped `max_concurrent_bots` with a column default of `1`. 0.12 ships `3`. Convergence
+does not change an existing column's default and does not rewrite existing rows, so an upgraded
+database keeps `1` for every account that already existed.
+
+**This tool reports that and never writes it.** How many bots an account may run concurrently is
+a decision about your deployment, not a consequence of the schema version. Nothing in 0.12 fails
+because an account is still at `1`.
+
+If you decide to raise it, the raise-only statement is one line
+([MIGRATION-0003](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0003-default-max-concurrent-bots-3.md)):
+
+```sql
+UPDATE users SET max_concurrent_bots = 3 WHERE max_concurrent_bots < 3;
+```
+
+and, for direct inserts that rely on the column default:
+
+```sql
+ALTER TABLE users ALTER COLUMN max_concurrent_bots SET DEFAULT 3;
+```
+
+The `WHERE max_concurrent_bots < 3` predicate leaves accounts already granted more than 3
+untouched, and makes the statement idempotent.
+
+## Phase 2 — the dedup
+
+### The keep rule
+
+Within each duplicate group the tool ranks the rows and keeps rank 1. The default rule is
+**keep-newest**: `created_at DESC, id DESC`. The ordering ends in `id DESC`, so no two rows in a
+group can ever rank equally — the outcome is deterministic and a dry run predicts the fix exactly.
+
+| `--keep-strategy` | `ORDER BY` |
+|---|---|
+| `newest` (default) | `(id = ANY(:keep_ids)) DESC, created_at DESC, id DESC` |
+| `live-bot` | `(id = ANY(:keep_ids)) DESC, (bot_container_id IS NOT NULL) DESC, created_at DESC, id DESC` |
+
+`live-bot` prefers a row that still carries a bot container id, falling back to newest. Use it
+when the newest row is a spawn attempt and an older row is the one actually running.
+
+`--keep-meeting-id ID` is the leading term in both orderings: any id you name wins its group
+outright. With no ids given, `:keep_ids` is an empty array and the term is false for every row.
+
+The plan query, executed read-only:
+
+```sql
+WITH ranked AS (
+  SELECT id, user_id, platform, platform_specific_id, status, bot_container_id, created_at,
+         row_number() OVER (
+           PARTITION BY user_id, platform, platform_specific_id
+           ORDER BY (id = ANY(:keep_ids)) DESC, created_at DESC, id DESC
+         ) AS rn
+  FROM meetings
+  WHERE status NOT IN ('completed', 'failed')
+    AND platform_specific_id IS NOT NULL
+)
+SELECT id, user_id, platform, platform_specific_id, status, bot_container_id, created_at, rn
+FROM ranked
+WHERE (user_id, platform, platform_specific_id) IN (
+        SELECT user_id, platform, platform_specific_id
+        FROM ranked
+        GROUP BY user_id, platform, platform_specific_id
+        HAVING count(*) > 1
+      )
+ORDER BY user_id, platform, platform_specific_id, rn
+```
+
+Every row it returns appears in the receipt, one line each, marked `KEEP` (rank 1) or `RETIRE`.
+
+### The write
+
+Only under `--fix`, in one transaction, over the exact id list printed above:
+
+```sql
+UPDATE meetings m
+SET status = :retire_status,
+    data   = jsonb_set(coalesce(m.data, '{}'::jsonb), '{dedup}', (:stamp)::jsonb)
+WHERE m.id = ANY(:loser_ids)
+RETURNING m.id, m.user_id, m.platform, m.platform_specific_id, m.status
+```
+
+The ids are computed by the plan query and bound explicitly; the `UPDATE` does not recompute
+which rows lose. `RETURNING` supplies the row-by-row execution log.
+
+`:stamp` records why the row was retired:
+
+```json
+{
+  "reason": "rob1_rob2_active_dedup",
+  "migration": "0002",
+  "tool": "admin_api.migrate",
+  "keep_strategy": "newest",
+  "at": "2026-08-26T09:57:47.357541+00:00"
+}
+```
+
+Every touched row stays findable afterwards:
+
+```sql
+SELECT * FROM meetings WHERE data ? 'dedup';
+```
+
+`--retire-status` accepts only `failed` or `completed`. Those are exactly the two statuses the
+index's partial predicate excludes; any other value would leave the row inside the index and the
+build would still fail. The tool refuses anything else.
+
+## Phase 3 — the index
+
+```sql
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_meeting_active_user_platform_native
+ON meetings (user_id, platform, platform_specific_id)
+WHERE status NOT IN ('completed', 'failed')
+```
+
+**Why `CONCURRENTLY`, and why outside a transaction.** A plain `CREATE INDEX` takes a lock that
+blocks every write to `meetings` for the duration of the build. `meetings` is the table every bot
+spawn writes to, so on a live deployment that is an outage for the length of the build.
+`CONCURRENTLY` builds without blocking writes — and Postgres refuses it inside a transaction
+block. The tool issues it on a connection explicitly set to `AUTOCOMMIT`; there is no surrounding
+transaction to refuse.
+
+**What the index is for.** At most one active meeting per `(user_id, platform,
+platform_specific_id)`. It is the database-level backstop for spawn dedup: `create_meeting_guarded`
+holds an advisory transaction lock that serialises same-process spawns, and this index catches the
+cross-process race the advisory lock cannot. The resulting `IntegrityError` becomes
+`DuplicateMeeting` (HTTP 409). Terminal rows are outside the partial predicate, so a user can
+re-meet the same native id once the prior run ends.
+
+**Verification.** Immediately after the build, the tool re-reads `pg_index` and requires
+`indisvalid` and `indisunique`. If either is false it raises rather than reporting success — an
+INVALID index enforces nothing, and a silent one is the exact failure the index exists to prevent.
+
+**A previous failed build.** If `check` finds the index present but INVALID, `run --fix` drops it
+first and rebuilds:
+
+```sql
+DROP INDEX CONCURRENTLY IF EXISTS uq_meeting_active_user_platform_native
+```
+
+This is the only case in which the tool drops anything.
+
+## Abort conditions
+
+`run` refuses to proceed in these cases.
+
+| Condition | Verdict | What the tool does |
+|---|---|---|
+| An index of a **different shape** already holds the name `uq_meeting_active_user_platform_native` | `STOP` | Prints the existing definition and stops. It will not drop an index it did not build. Inspect it, drop it by hand, re-run. |
+| Duplicates remain after the dedup `UPDATE` | exit `1` | Does not attempt the index build. |
+| The index does not verify as VALID and UNIQUE after the build | exit `1` | Reports the state and the `DROP INDEX CONCURRENTLY` needed before a retry. |
+| `--retire-status` outside `failed` / `completed` | exit `2` | Rejects the argument before connecting. |
+
+The shape test is structural, not string equality: Postgres re-renders `pg_get_indexdef` with its
+own casts, so the tool requires that the index is UNIQUE, covers `(user_id, platform,
+platform_specific_id)` in that order, and carries a `WHERE` predicate.
+
+## Idempotency
+
+Re-running is safe and is a no-op:
+
+- The dedup plan query returns nothing once every group has one active row, so the `UPDATE` is
+  never issued.
+- The index build carries `IF NOT EXISTS`, and the tool skips the phase entirely when it already
+  observes a VALID index.
+- With both true, the verdict is `GO` and the `EXECUTED` section of the receipt reads
+  `(nothing — already converged)`.
+
+A `check` after a successful `run --fix` exits `0`.
+
+## Ordering against the deploy
+
+Run `check`, then `run --fix`, **before** deploying 0.12 to a populated database. With the index
+already present, the admin-api's convergence finds it by name and no-ops — the failure path that
+aborts startup never triggers.
+
+Token scopes are the other direction: MIGRATION-0004 is applied by convergence itself, on the
+first 0.12 boot. Nothing to run by hand.
+
+## The receipt
+
+Every invocation produces a plain-text receipt: to stdout by default, and to a file with
+`--receipt PATH`. A dry run produces one too, marked `DRY-RUN`, listing the statements that were
+**not** executed. The sections are fixed:
+
+| Section | Contents |
+|---|---|
+| Header | Tool version, verb, mode, UTC timestamp, database (password removed), server version |
+| `STATE READ` | Tables, additive delta, index state, duplicate groups with their meeting ids, concurrent-bot histogram, token-scope count |
+| `VERDICT (before)` | `GO` / `ACTION_REQUIRED` / `STOP`, with reasons, actions and blockers |
+| `DEDUP PLAN (row by row)` | One line per row in a duplicate group: `KEEP` or `RETIRE`, rank, key, status, container id, created_at |
+| `NOT EXECUTED (dry run)` | The verbatim statements a dry run declined to issue |
+| `EXECUTED` | Each statement verbatim, its bound parameters, rowcount, duration, and the rows it touched |
+| `VERDICT (after)` | The re-read verdict after execution |
+
+A `run --fix` receipt, abridged:
+
+```text
+==============================================================================
+admin_api.migrate v1 — receipt
+==============================================================================
+verb           : run
+mode           : EXECUTED (--fix)
+generated (UTC): 2026-08-26T09:57:47.422171+00:00
+database       : postgresql+psycopg://vexa:***@db:5432/vexa
+server_version : 16.13
+
+==============================================================================
+DEDUP PLAN (row by row)
+==============================================================================
+  KEEP   meeting_id=3 rank=1 user=1 platform=google_meet native=aaa-bbb-ccc status=active bot_container_id=c-newest created_at=2026-08-01 12:20:00
+  RETIRE meeting_id=2 rank=2 user=1 platform=google_meet native=aaa-bbb-ccc status=requested bot_container_id=None created_at=2026-08-01 12:10:00
+  RETIRE meeting_id=1 rank=3 user=1 platform=google_meet native=aaa-bbb-ccc status=active bot_container_id=None created_at=2026-08-01 12:00:00
+  KEEP   meeting_id=5 rank=1 user=2 platform=zoom native=999888777 status=active bot_container_id=None created_at=2026-08-01 12:05:00
+  RETIRE meeting_id=4 rank=2 user=2 platform=zoom native=999888777 status=requested bot_container_id=None created_at=2026-08-01 12:00:00
+
+==============================================================================
+EXECUTED
+==============================================================================
+------------------------------------------------------------------------------
+UPDATE meetings m
+SET status = :retire_status,
+    data   = jsonb_set(coalesce(m.data, '{}'::jsonb), '{dedup}', (:stamp)::jsonb)
+WHERE m.id = ANY(:loser_ids)
+RETURNING m.id, m.user_id, m.platform, m.platform_specific_id, m.status
+  params    : {'retire_status': 'failed', 'stamp': '{"reason": "rob1_rob2_active_dedup", ...}', 'loser_ids': [2, 1, 4]}
+  rowcount  : 3
+  duration  : 0.002s
+  meeting 1 → status=failed
+  meeting 2 → status=failed
+  meeting 4 → status=failed
+------------------------------------------------------------------------------
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_meeting_active_user_platform_native
+ON meetings (user_id, platform, platform_specific_id)
+WHERE status NOT IN ('completed', 'failed')
+  rowcount  : 0
+  duration  : 4.318s
+  verified: indisvalid=t indisunique=t
+
+==============================================================================
+VERDICT (after)
+==============================================================================
+GO
+```
+
+## Machine-readable output
+
+`--json` emits a stable document. Top-level keys: `tool`, `tool_version`, `generated_at`,
+`database`, `verdict`, `reasons`, `actions`, `blockers`, `schema_delta`,
+`duplicate_active_meetings`, `dedup_index`, `max_concurrent_bots`, `token_scopes`, `notes`, and
+`dedup_plan` when a plan exists.
+
+```json
+{
+  "tool": "admin_api.migrate",
+  "tool_version": "1",
+  "verdict": "ACTION_REQUIRED",
+  "reasons": [
+    "3 active meeting row(s) across 2 duplicate key(s). A UNIQUE index cannot be built over them, and on 0.12.23+ a failed UNIQUE index aborts admin-api startup."
+  ],
+  "actions": [
+    "retire 3 losing row(s) to a terminal status",
+    "build the dedup index with CREATE UNIQUE INDEX CONCURRENTLY"
+  ],
+  "blockers": [],
+  "duplicate_active_meetings": {
+    "groups": 2,
+    "rows_to_retire": 3,
+    "detail": [
+      {
+        "user_id": 1,
+        "platform": "google_meet",
+        "platform_specific_id": "aaa-bbb-ccc",
+        "active_rows": 3,
+        "meeting_ids": [3, 2, 1]
+      }
+    ]
+  },
+  "dedup_index": {
+    "name": "uq_meeting_active_user_platform_native",
+    "present": false,
+    "valid": false,
+    "unique": false,
+    "shape_ok": false,
+    "definition": null
+  },
+  "max_concurrent_bots": {
+    "note": "report only — this tool never writes this column (product knob, not a migration step). See MIGRATION-0003 for the one-line SQL.",
+    "column_default": "1",
+    "histogram": [{"limit": 1, "users": 2}],
+    "accounts_at_1": 2
+  }
+}
+```
+
+## Rollback
+
+Drop the index and revert the deploy:
+
+```sql
+DROP INDEX CONCURRENTLY IF EXISTS uq_meeting_active_user_platform_native;
+```
+
+The dedup is not automatically reversed. Every retired row carries `data.dedup`, so the affected
+set is exactly `SELECT * FROM meetings WHERE data ? 'dedup'` and the prior status of each is
+recoverable from a backup taken before the run. Retired rows are non-terminal spawns that the new
+constraint would have rejected anyway.
+
+## Source
+
+| | |
+|---|---|
+| Tool | [`core/identity/services/admin-api/src/admin_api/migrate/`](https://github.com/Vexa-ai/vexa/tree/main/core/identity/services/admin-api/src/admin_api/migrate) |
+| Every statement, as one constant each | [`migrate/sql.py`](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/migrate/sql.py) |
+| Convergence | [`schema/sync.py`](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/sync.py) |
+| Dedup index rationale | [MIGRATION-0002](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0002-meeting-active-dedup-index.md) |
+| Concurrent-bot default | [MIGRATION-0003](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0003-default-max-concurrent-bots-3.md) |
+| Token-scope backfill | [MIGRATION-0004](https://github.com/Vexa-ai/vexa/blob/main/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0004-backfill-token-scopes.md) |


### PR DESCRIPTION
Upgrading a populated 0.10.x database to 0.12.x is currently a manual SQL runbook: an operator
reads the migration notes, runs a pre-flight query, decides a dedup policy, writes an `UPDATE`,
and builds an index by hand. That is a product gap, not a documentation gap — the steps are
mechanical, the failure mode is severe, and every operator solves it from scratch.

This PR adds the tool that performs those steps, and documents it the way an enterprise operator
audits software: every statement it can issue is shown verbatim, and every phase says what it
reads and what it writes.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## Why a tool exists at all

`ensure_schema()` runs on every admin-api boot and converges the database to the SQLAlchemy
models. It runs inside **one transaction** and is **additive** — it never drops anything and never
rewrites the value of an existing row. Two steps of the 0.10 → 0.12 delta therefore fall outside
what it can do on a populated database:

| Step | Why convergence cannot do it |
|---|---|
| Retire duplicate **active** meeting rows | Convergence never rewrites existing row values. |
| Build `uq_meeting_active_user_platform_native` **CONCURRENTLY** | Postgres refuses `CREATE INDEX CONCURRENTLY` inside a transaction block. |

On 0.12.23+ ([#1187](https://github.com/Vexa-ai/vexa/issues/1187)) a UNIQUE index that cannot be
created raises `SchemaInvariantError` and **aborts admin-api startup**. A database holding two or
more active meetings on the same `(user_id, platform, platform_specific_id)` stops the upgrade at
boot, and the operator's first symptom is a pod that never answers `/health`.

## What it does

```bash
python -m admin_api.migrate check          # default verb, strictly read-only
python -m admin_api.migrate run            # prints the exact statements — writes nothing
python -m admin_api.migrate run --fix      # executes them
```

`check` — reports the convergence delta (missing tables/columns/indexes that `ensure_schema()`
will apply itself), duplicate active meetings per key with the offending rows listed, dedup-index
state including the INVALID corpse a failed `CONCURRENTLY` build leaves behind, accounts still at
the 0.10-era `max_concurrent_bots = 1`, and a `GO` / `ACTION_REQUIRED` / `STOP` verdict.
`--json` for machines; exit codes `0` / `10` / `20`.

`run` — dedup (keep-newest, deterministic, logged row by row), then `CREATE UNIQUE INDEX
CONCURRENTLY` outside any transaction, then verify `indisvalid` and `indisunique`. Idempotent: a
second run is a no-op and the verdict is `GO`.

Every invocation emits a plain-text receipt — state read, verdict, the row-by-row keep/retire
plan, each statement verbatim with its bound parameters and rowcount, and the re-read verdict
after execution. `--receipt PATH` writes it to a file.

## What it will not do

- **It will not write `max_concurrent_bots`.** 0.10's column default was `1` and 0.12's is `3`,
  and convergence changes neither on an existing database. **Founder ruling: that is a product
  knob, not a migration step** — how many bots an account may run concurrently is a decision about
  the deployment, and nothing in 0.12 fails because an account is still at `1`. `check` reports the
  histogram and the count at `1`; the docs carry the one-line raise-only SQL for an operator who
  chooses to run it.
- **It will not drop an index it did not build.** If an index of a different shape already holds
  the name, the verdict is `STOP` and `run` refuses, printing the existing definition.
- **It will not write without `--fix`.** `check` and a dry `run` execute inside a
  `SET TRANSACTION READ ONLY` transaction, so the database itself rejects a write. The test suite
  asserts this against a full before/after row snapshot rather than trusting the flag.
- **It does not touch token scopes.** MIGRATION-0004 is applied by convergence itself on the first
  0.12 boot.

## Glass-box documentation

**[`docs/docs/upgrade-migrate-tool.mdx`](https://github.com/Vexa-ai/vexa/blob/feat/0.10-0.12-migrate-tool/docs/docs/upgrade-migrate-tool.mdx)**
— registered in the nav under *Deployment & operations*, published at `/upgrade-migrate-tool`.

Per phase: what it reads, what it writes, **the exact SQL verbatim** (not paraphrased), why the
index must be `CONCURRENTLY` and out-of-transaction, the keep-newest rule and its two overrides,
the idempotency guarantees, the abort conditions, and the receipt format. Every statement lives as
one named constant in
[`migrate/sql.py`](https://github.com/Vexa-ai/vexa/blob/feat/0.10-0.12-migrate-tool/core/identity/services/admin-api/src/admin_api/migrate/sql.py),
and a unit test asserts the SQL the docs quote is the SQL the tool issues.

## Placement

`core/identity/services/admin-api/src/admin_api/migrate/`, invoked as `python -m
admin_api.migrate` — the same module-executable shape as `python -m admin_api` (the repo has no
console-script entry points and no `manage.py`). It sits in the service that already owns the
schema SSOT and convergence, and runs from the admin-api image with no extra dependencies:

```bash
docker compose run --rm admin-api python -m admin_api.migrate check
kubectl exec deploy/vexa-admin-api -- python -m admin_api.migrate check
```

## Tests

**40 new evals, 128 total in the admin-api suite, all green.**

| Suite | Needs docker | Covers |
|---|---|---|
| `tests/test_migrate_unit.py` (25) | no | `decide()` verdicts incl. the STOP path, `--json` shape, the refusal paths, CLI contract, DSN handling, the SQL surface, docs-SQL ≡ executed-SQL |
| `tests/test_stack_migrate.py` (15) | yes | duplicate detection over real rows incl. NULL-native-id and terminal rows left untouched; dry-run zero-writes asserted on a full snapshot; keep-newest; `--keep-meeting-id` and `--keep-strategy live-bot`; the `CONCURRENTLY` build; the constraint then rejecting a duplicate spawn; INVALID-index rebuild; idempotent re-run; the STOP refusal writing nothing; `--json` over a live database |

Docker-backed runs were executed on the container host, not a laptop.

```
128 passed, 47 warnings in 23.20s
```

Non-container gates green on the head: `readme`, `db-schema`, `docs-version`, `test-isolation`,
`schema`, `isolation-py`, `graph-py`.

## Runbook

[`#1332`](https://github.com/Vexa-ai/vexa/pull/1332) is documenting the manual runbook on its own
branch; this PR does not touch it. Once both merge, the runbook's manual-steps section should point
at the tool with the SQL retained as an appendix — filed as
[`#1333`](https://github.com/Vexa-ai/vexa/issues/1333).

## Validation request

A maintainer with a populated 0.10.x database, or a reviewer reading against
`admin_api/schema/sync.py` and MIGRATION-0002: that the two steps named are genuinely the two
convergence cannot do, that the SQL in the docs page is the SQL in `sql.py`, and that the read-only
transaction covers every path that is not `run --fix`.

**Deployment validated:** none. The evals run against ephemeral Postgres via testcontainers; the
tool has not been run against a production database in this PR.

**Do not merge on my say-so** — staged for maintainer review.

## Authorship
Sole author: the human submitting this. Tooling disclosure: drafted with Claude Code against
`admin_api/schema/sync.py`, `admin_api/schema/models.py`, and the in-repo MIGRATION-0002/0003/0004
runbooks.

<!-- vexa-agent -->
