### PR TITLE
Fix/claude code effort flag

### DIFF
--- a/clients/terminal/src/surfaces/settings.tsx
+++ b/clients/terminal/src/surfaces/settings.tsx
@@ -148,6 +148,13 @@ function ModelsSection() {
     { key: "api_key", label: "API key", placeholder: "unchanged unless typed", secret: true, showIf: (v: Record<string, string>) => v.mode === "custom" },
     { key: "model", label: "Chat model", placeholder: "deployment default (e.g. sonnet)" },
     { key: "meeting_model", label: "Meeting model", placeholder: "defaults to chat model" },
+    { key: "effort", label: "Reasoning effort", placeholder: "CLI default (e.g. medium)", options: [
+      { value: "", label: "CLI default" },
+      { value: "low", label: "low" },
+      { value: "medium", label: "medium" },
+      { value: "high", label: "high" },
+      { value: "xhigh", label: "xhigh" },
+    ] },
   ];
   const transcriptionFields = [
     { key: "url", label: "Service URL", placeholder: "deployment default" },

--- a/clients/terminal/src/surfaces/settingsApi.ts
+++ b/clients/terminal/src/surfaces/settingsApi.ts
@@ -8,6 +8,7 @@ export type ModelPrefs = {
   mode?: "subscription" | "custom" | null;
   model?: string | null;
   meeting_model?: string | null;
+  effort?: string | null; // reasoning-effort pin (low|medium|high|xhigh) for the agent harness
   base_url?: string | null;
   api_key_set?: boolean;
   api_key?: string | null; // masked on read (********abcd) — write-only in the clear

--- a/core/agent/control_plane/dispatch.py
+++ b/core/agent/control_plane/dispatch.py
@@ -168,6 +168,14 @@ def overlay_model_config(env: dict[str, str], config: dict, *, allowlist: str = 
     elif meeting_model:
         logger.warning("meeting model %r not in VEXA_MODEL_ALLOWLIST — using deployment default",
                        meeting_model)
+    # Reasoning-effort pin for the claude-code harness (Settings → Models "effort"). Empty ⇒ unset ⇒
+    # the CLI's own default (no flag on the argv); an explicit value reaches the worker env and the
+    # harness passes it through as --effort. Backends that validate the OpenAI-compatible
+    # reasoning_effort field (vLLM/LiteLLM groups) reject the CLI's default high when it is outside
+    # their allowlist; the pin overrides that default.
+    effort = (config.get("effort") or "").strip()
+    if effort:
+        env["VEXA_AGENT_EFFORT"] = effort
     if (config.get("mode") or "").strip() != "custom":
         return
     base_url = (config.get("base_url") or "").strip()

--- a/core/agent/llm/claude_code.py
+++ b/core/agent/llm/claude_code.py
@@ -110,6 +110,7 @@ def build_argv(
     session: Optional[str] = None,
     model: Optional[str] = None,
     mcp_config: Optional[str] = None,
+    effort: Optional[str] = None,
 ) -> list[str]:
     """The headless Claude Code argv — `claude -p <prompt> --output-format stream-json [...]`.
 
@@ -118,6 +119,11 @@ def build_argv(
     does the git commit). `--mcp-config <file>` + `--strict-mcp-config` attach EXACTLY the unit's
     granted MCP tools (the toolbelt) and nothing else. The container sandbox is the other
     enforcement layer.
+
+    `effort` — when set — pins the session's reasoning effort (`--effort low|medium|high|xhigh`).
+    Backends that validate the OpenAI-compatible `reasoning_effort` field (e.g. vLLM/LiteLLM model
+    groups) reject the CLI's default `high` when it is outside their allowlist; an explicit value
+    overrides that default. Unset ⇒ no flag ⇒ the CLI's own behaviour, unchanged.
     """
     argv = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose",
             "--include-partial-messages", "--permission-mode", "acceptEdits"]
@@ -130,6 +136,8 @@ def build_argv(
         argv += ["--resume", session]
     if model:
         argv += ["--model", model]
+    if effort:
+        argv += ["--effort", effort]
     return argv
 
 
@@ -218,6 +226,7 @@ class ClaudeCodeHarness:
                  session: Optional[str] = None, model: Optional[str] = None,
                  mcp_config: Optional[str] = None) -> Iterator[dict]:
         argv = build_argv(prompt, allowed_tools=allowed_tools, session=session, model=model,
+                          effort=(os.environ.get("VEXA_AGENT_EFFORT") or None),
                           mcp_config=mcp_config)
         yield from parse_stream_json(self._exec(argv, str(work)))
 

--- a/core/agent/tests/test_llm_claude_code.py
+++ b/core/agent/tests/test_llm_claude_code.py
@@ -118,7 +118,14 @@ def test_build_argv_core_flags_and_session_model():
     assert "--allowedTools" in argv and "Read" in argv
     assert "--resume" in argv and "s1" in argv
     assert "--model" in argv and "m1" in argv
+    # unset effort ⇒ NO --effort flag (the CLI's own default behaviour is preserved byte-for-byte)
+    assert "--effort" not in argv
 
+
+def test_build_argv_effort_pin():
+    argv = build_argv("hi", effort="medium")
+    assert "--effort" in argv and "medium" in argv
+    assert argv[argv.index("--effort") + 1] == "medium"
 
 # ── the untrusted-subprocess env scrub (data-plane tenancy) ──────────────────
 # The model-driven harness CLI exposes a Bash tool. It must NOT inherit the worker's REDIS_URL (which

--- a/core/agent/tests/test_unit_foundation.py
+++ b/core/agent/tests/test_unit_foundation.py
@@ -364,6 +364,24 @@ def test_dispatcher_model_config_overrides_deployment_models():
     assert env["VEXA_MEETING_MODEL"] == "my-meeting"
 
 
+def test_dispatcher_model_config_stamps_reasoning_effort():
+    """Settings → Models effort pin reaches the worker env as VEXA_AGENT_EFFORT (the claude-code
+    harness passes it through as --effort). Absent ⇒ no env key ⇒ the CLI's own default."""
+    rt = _FakeRuntime()
+    mc = _FakeModelConfig({"model": "my-model", "effort": "medium"})
+    d = dispatch.Dispatcher(load_settings(), rt, _FakeIdentity(), model_config=mc)
+    d.dispatch(VALID_INV)
+    _, _profile, env = rt.spawned[0]
+    assert env["VEXA_AGENT_EFFORT"] == "medium"
+    # no effort configured ⇒ no env key at all (unset must mean "don't touch the CLI default")
+    rt2 = _FakeRuntime()
+    d2 = dispatch.Dispatcher(load_settings(), rt2, _FakeIdentity(),
+                           model_config=_FakeModelConfig({"model": "my-model"}))
+    d2.dispatch(VALID_INV)
+    _, _profile2, env2 = rt2.spawned[0]
+    assert "VEXA_AGENT_EFFORT" not in env2
+
+
 def test_dispatcher_model_config_custom_mode_stamps_both_call_shapes():
     """mode:custom points the harness (ANTHROPIC_*) AND the completion adapters (VEXA_LLM_*) at
     the supplied gateway. Dispatch-stamped keys WIN downstream (docker_backend copies its own env

--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -232,7 +232,7 @@ class CalendarPatch(BaseModel):
 # resolves FIELD-BY-FIELD user > platform; the process env stays the bottom fallback downstream
 # (dispatch/bot_spawn only override what is set here).
 MODEL_MODES = ("subscription", "custom")
-_MODELS_FIELDS = ("mode", "model", "meeting_model", "base_url", "api_key")
+_MODELS_FIELDS = ("mode", "model", "meeting_model", "base_url", "api_key", "effort")
 _TRANSCRIPTION_FIELDS = ("url", "token")
 # "setup" tracks the admin first-run wizard: per-step state ("done" / "skipped") + overall
 # completion — the terminal re-surfaces the wizard until it reads completed. Plain strings,
@@ -256,6 +256,7 @@ class ModelPrefsUpdate(BaseModel):
     meeting_model: Optional[str] = None
     base_url: Optional[str] = None
     api_key: Optional[str] = None
+    effort: Optional[str] = None  # claude-code reasoning-effort pin (low|medium|high|xhigh); empty = unset
 
 
 class TranscriptionPrefsUpdate(BaseModel):
@@ -699,6 +700,7 @@ def create_app() -> FastAPI:
             "model": prefs.get("model"),
             "meeting_model": prefs.get("meeting_model"),
             "base_url": prefs.get("base_url"),
+            "effort": prefs.get("effort"),
             "api_key_set": bool(prefs.get("api_key")),
             "api_key": _mask_secret(prefs.get("api_key")),
         }


### PR DESCRIPTION
   **Delivers issue:** #1336

   ## Contribution rights
   - [X] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
   <!-- rights:independent -->
   - [ ] **Employer/client authorization required:** an employer, client, or other entity owns or may control this contribution. I am requesting Vexa's private corporate-authorization process.
   <!-- rights:corporate -->
   - [ ] **Unsure:** I need a private rights review before merge.
   <!-- rights:uncertain -->

   ## What & why
   The claude-code CLI defaults to `reasoning_effort: high`; gateways that validate that field (vLLM/LiteLLM model groups) reject it with `400 Unexpected reasoning effort high`, which bricks chat. This makes the effort user-configurable in Settings → Models and passes it
 to the CLI as `--effort`.

   ## Observation bundle
   - C1 (dispatch + admin-api + terminal): added the effort field, stamped it into the worker env as VEXA_AGENT_EFFORT, surfaced it in Settings. Saw: the spawned worker's env carried VEXA_AGENT_EFFORT=medium; the Settings select saved. Concluded: the pin crosses the
 model-config edge.
   - C2 (harness): build_argv(effort=...) appends --effort. Saw: --effort medium on the argv when set, none when unset. Concluded: argv is byte-identical to before when unset.

   ## Acceptance floor
   | Row | Evidence |
   |---|---|
   | A1 chat on a validating gateway succeeds (was 400 on default high) | live :dev compose, head b76f8520 — a full agent turn completed with effort medium |
   | A2 --effort on argv when set / absent when unset | test_build_argv_effort_pin + test_build_argv_core_flags_and_session_model |
   | A3 VEXA_AGENT_EFFORT in env when set / absent when unset | test_dispatcher_model_config_stamps_reasoning_effort |
   | A- no-regression | touched lanes (agent control-plane, admin-api, terminal) + repo gates green at head |

   ## Docs diff
   None — a new Settings field on an existing page, not a documented capability or deployment knob; the field label/placeholder carry the in-UI explanation. (Label: docs: none)

   ## Security checks
   No new dependencies, no secrets, no config surface beyond one user model-pref string.

   ## Validation request
   An operator on a self-hosted compose pointed at a reasoning_effort-validating gateway: set the effort in Settings → Models, send a chat turn, watch it land. Deployment: full compose, agent profile, :dev images built from b76f8520.