### PR TITLE
identity: let Settings-configured transcription backends name their m…

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -233,7 +233,7 @@ class CalendarPatch(BaseModel):
 # (dispatch/bot_spawn only override what is set here).
 MODEL_MODES = ("subscription", "custom")
 _MODELS_FIELDS = ("mode", "model", "meeting_model", "base_url", "api_key", "effort")
-_TRANSCRIPTION_FIELDS = ("url", "token")
+_TRANSCRIPTION_FIELDS = ("url", "token", "model")
 # "setup" tracks the admin first-run wizard: per-step state ("done" / "skipped") + overall
 # completion — the terminal re-surfaces the wizard until it reads completed. Plain strings,
 # no secrets, admin-gated like the other keys.
@@ -262,6 +262,7 @@ class ModelPrefsUpdate(BaseModel):
 class TranscriptionPrefsUpdate(BaseModel):
     url: Optional[str] = None
     token: Optional[str] = None
+    model: Optional[str] = None
 
 
 def _mask_secret(secret: Optional[str]) -> Optional[str]:

--- a/core/identity/services/admin-api/tests/test_model_settings.py
+++ b/core/identity/services/admin-api/tests/test_model_settings.py
@@ -149,3 +149,30 @@ def test_bot_context_carries_effective_transcription(client):
     cfg = client.get("/user/transcription", headers={"X-API-Key": tok}).json()
     assert cfg["url"] == "https://stt-mine.example.com"
     assert cfg["token_set"] is False
+
+def test_bot_context_transcription_carries_model(client):
+    """#1338: a Settings-configured STT can name its model. The bot-context `transcription"""
+    "object carries `model` (non-secret model id, not a credential) and the Settings API"""
+    "accepts it — symmetric with the env path's TRANSCRIPTION_MODEL."""
+    uid, tok = _user_token(client, email="stt-model@vexa.ai")
+
+    # Customer backend WITHOUT a model → no model key (byte-identical to pre-fix behaviour)
+    client.put("/user/transcription", headers={"X-API-Key": tok},
+               json={"url": "https://stt-mine.example.com", "token": "tok-mine"})
+    r = client.get(f"/internal/users/{uid}/bot-context", headers=_internal())
+    tx = r.json()["transcription"]
+    assert tx["url"] == "https://stt-mine.example.com"
+    assert tx["provider"] == "customer"
+    assert "model" not in tx
+
+    # Set a model → the bot-context carries it, and the customer token is still NOT leaked
+    client.put("/user/transcription", headers={"X-API-Key": tok},
+               json={"url": "https://stt-mine.example.com", "token": "tok-mine",
+                     "model": "customer-stt-model"})
+    tx2 = client.get(f"/internal/users/{uid}/bot-context", headers=_internal()).json()["transcription"]
+    assert tx2["model"] == "customer-stt-model"
+    assert tx2["provider"] == "customer"
+    # the platform credential rule is unchanged: the customer token stays the customer's
+    assert tx2.get("token") == "tok-mine"
+
+

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -499,6 +499,36 @@ async def test_request_bot_configured_transcription_backend_overrides_env(monkey
     row = next(iter(repo._meetings.values()))
     assert row["data"]["transcription_provider"] == "customer"
 
+async def test_request_bot_configured_transcription_model_rides_invocation(monkeypatch):
+    """REGRESSION (#1338): a customer-configured STT backend that carries a `model` in the
+    bot-context must ride the invocation — symmetric with the env path's TRANSCRIPTION_MODEL.
+    (Consumer-side regression guard: the spawn side reads the field; #1338 is what makes
+    admin-api actually emit it for a Settings-configured backend.)"""
+    from meeting_api.bot_spawn import service as spawn_service
+
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt-env.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-env")
+    monkeypatch.setenv("TRANSCRIPTION_MODEL", "env-model")
+
+    # admin-api resolves the customer backend and carries its served model id
+    async def fake_resolve(user_id):
+        assert user_id == USER
+        return {"transcription": {"url": "https://stt-mine.example.com",
+                                 "model": "customer-stt-model",
+                                 "provider": "customer"}}
+
+    monkeypatch.setattr(spawn_service, "_fetch_bot_context", fake_resolve)
+    repo = InMemoryMeetingRepo()
+    runtime = FakeRuntimeClient()
+    await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                      native_meeting_id="abc-defg-hij", redis_url="redis://redis:6379/0",
+                      token_secret=SECRET)
+    inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
+    assert inv["transcriptionServiceUrl"] == "https://stt-mine.example.com"
+    # the customer backend's model must ride the invocation (not the env model, not dropped)
+    assert inv["transcriptionModel"] == "customer-stt-model"
+    row = next(iter(repo._meetings.values()))
+    assert row["data"]["transcription_provider"] == "customer"
 
 async def test_request_bot_env_transcription_stays_without_settings(monkeypatch):
     """No configured backend (unset ADMIN_API_URL / nothing stored) → the pre-Settings env path,


### PR DESCRIPTION
   ### Value this PR delivers

   A user who configures their transcription backend in Settings (their own STT endpoint) can name the model it serves, the same way
 the deployment's env path does today.

   Fixes #1338.

   ### Why this matters

   The STT client sends `response_format=verbose_json` and a `model` form part on every request. For the **env** backend, the
 deployment names the model via `TRANSCRIPTION_MODEL` and it rides the invocation fine. But a **Settings-configured** backend — the
 exact path a self-hosted operator uses to point Vexa at their own gateway (Groq, vLLM/LiteLLM, a hosted STT) — has **no way to name a
 model**: the bot-context `transcription` object was built from `("url", "token")` only, and the Settings API
 (`TranscriptionPrefsUpdate`) had no `model` field. So a customer-configured STT was silently locked to the client's `whisper-1`
 default, regardless of what the gateway actually serves.

   ### The fix (2 lines)

   - `core/identity/services/admin-api/src/admin_api/app/main.py`:
     - `_TRANSCRIPTION_FIELDS = ("url", "token", "model")`
     - `TranscriptionPrefsUpdate` gains `model: Optional[str] = None`

   The bot-context builder already loops over `_TRANSCRIPTION_FIELDS`, so the model rides the same user-pref > platform resolution as
 `url`/`token` with no structural change. **The consumer was already ready** — `meeting_api/bot_spawn/service.py:326` does
 `transcription_model = configured.get("model") or None`; it just never received one.

   ### Scope note (intentional)

   `model` is a **non-secret model id, not a credential**. Carrying it does not weaken the customer token non-disclosure rule — a
 customer backend's token is still never backfilled from the platform record (that would disclose a Vexa provider credential to a
 customer host). That existing test stays green and unchanged.

   ### Acceptance

   - **A1** A Settings-configured STT with a model set → the bot-context `transcription` carries `model`, and the spawned invocation's
 `transcriptionModel` equals it.
   - **A2** (consumer-side regression guard) a bot-context `transcription` carrying a `model` rides the invocation's
 `transcriptionModel`.
   - **A3** A Settings-configured STT with **no** model set → no `model` key → the client keeps its default. Byte-identical to prior
 behaviour for everyone who doesn't set one.
   - **A4** No regression: `test_model_settings` (admin-api) + `test_bot_spawn` (meeting-api) green; customer-token non-disclosure
 assertion unchanged.

   ### Observation bundle (my live witness)

   - admin-api `tests/test_model_settings.py`: **6 passed** (incl. new `test_bot_context_transcription_carries_model` + unchanged
 `test_bot_context_carries_effective_transcription`).
   - meeting-api `tests/test_bot_spawn.py`: **61 passed** (incl. new
 `test_request_bot_configured_transcription_model_rides_invocation`).
   - Gate suite: every gate **SAME as clean `main`** — my change introduces **zero** new gate failures. (Two gates, `schema event.v1`
 and `config-contract`, fail identically on clean `main` — pre-existing, not from this change.)
   - `py_compile` clean on all three touched files.

   ### Contribution Rights

   <!-- rights:independent -->

   - [x] I am the sole rights holder for my contribution. (Independent path.)

   ### Docs

   `docs: none` — no `docs/` surface changed (a config field + tests).

   ### Authorship

   Agent-assisted, human-owned. No agent co-author trailers.