### PR TITLE
[BUSINESS] MCP: a dogfood stack that validates the deployed surface, and the surface fixes it found

### DIFF
--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -25,6 +25,9 @@ from typing import Any, Dict, List, Optional
 import httpx
 import mcp.types as mcp_types
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi_mcp import FastApiMCP
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
@@ -381,6 +384,73 @@ class ReportIssue(BaseModel):
         return self
 
 
+# ---------------------------
+# Meeting identity — ONE vocabulary across the whole surface
+# ---------------------------
+# Every tool that RETURNS a meeting returns ``platform`` + ``native_meeting_id`` (so does the
+# public REST API: ``/transcripts/{platform}/{native_meeting_id}``). Three tools used to ACCEPT
+# ``meeting_platform`` + ``meeting_id`` instead, so no tool's output could be fed to the next
+# tool's input without a rename nothing documented. A model chaining calls reads
+# ``native_meeting_id`` off one result and passes it to the next — the correct inference, and it
+# failed. The canonical names below are the ones every tool returns; the old spellings stay as
+# deprecated aliases so no existing client breaks.
+_PLATFORM_DESC = (
+    "Meeting platform: google_meet, teams, zoom, jitsi. Same value that request_meeting_bot, "
+    "list_meetings and parse_meeting_link return as `platform`. Defaults to google_meet."
+)
+_ID_DESC = (
+    "The meeting's native id — exactly the `native_meeting_id` returned by request_meeting_bot, "
+    "list_meetings or parse_meeting_link (e.g. 'abc-defg-hij' for Google Meet)."
+)
+_LEGACY_PLATFORM_DESC = "DEPRECATED alias for `platform`. Use `platform`."
+_LEGACY_ID_DESC = "DEPRECATED alias for `native_meeting_id`. Use `native_meeting_id`."
+
+
+def _resolve_identity(
+    tool: str,
+    platform: Optional[str],
+    native_meeting_id: Optional[str],
+    legacy_platform: Optional[str],
+    legacy_id: Optional[str],
+) -> tuple[str, str]:
+    """Accept the canonical names or the deprecated aliases; fail with a message you can act on."""
+    mid = (native_meeting_id or legacy_id or "").strip()
+    plat = (platform or legacy_platform or "google_meet").strip()
+    if not mid:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{tool}: missing the meeting id. Pass `native_meeting_id` (the field "
+                f"request_meeting_bot / list_meetings / parse_meeting_link return), optionally "
+                f"with `platform`. Received: native_meeting_id=None, meeting_id=None."
+            ),
+        )
+    return plat, mid
+
+
+# What a client is told the moment it connects. Per-tool descriptions cannot carry orientation —
+# this is the map: what Vexa is, and the one sequence that matters.
+VEXA_INSTRUCTIONS = """\
+Vexa puts a transcription bot into a live meeting (Google Meet, Microsoft Teams, Zoom, Jitsi) and \
+gives you the transcript while the meeting is still running.
+
+The canonical flow:
+  1. parse_meeting_link(meeting_url)  → platform + native_meeting_id (pure; no side effects)
+  2. request_meeting_bot(meeting_url) → sends the bot. A human in the meeting must ADMIT it, so
+     expect a delay between `requested` and `active`.
+  3. get_meeting_transcript(platform, native_meeting_id) → segments, WHILE the meeting runs.
+     Poll it to follow a live meeting; pass `since_index` to get only what is new since your last
+     call instead of re-reading the whole transcript.
+  4. stop_bot(platform, native_meeting_id) when you are done.
+
+Identity: every tool returns `platform` + `native_meeting_id`, and every tool accepts those same \
+two names. Feed one tool's output straight into the next.
+
+A meeting with status `active` and zero segments usually means the bot has not been admitted yet, \
+or nobody has spoken — it does not mean transcription is broken.
+"""
+
+
 def create_app(
     gateway_url: Optional[str] = None,
     *,
@@ -440,6 +510,43 @@ def create_app(
     @app.get("/health", include_in_schema=False)
     async def health():
         return {"status": "ok", "service": "mcp"}
+
+    # --- validation errors an agent can act on.
+    # The stock message is "Input validation error: 'meeting_id' is a required property": it names
+    # neither the tool nor what was actually sent, so a caller that guessed a near-miss parameter
+    # name has no way to self-correct except by re-reading the schema. Name the tool, echo the
+    # parameters received, and point at the near-miss.
+    @app.exception_handler(RequestValidationError)
+    async def _validation_error(request: Request, exc: RequestValidationError):
+        tool = "unknown_tool"
+        route = request.scope.get("route")
+        if route is not None:
+            tool = getattr(route, "operation_id", None) or getattr(route, "name", None) or tool
+
+        received = sorted(set(request.query_params.keys()))
+        missing = [
+            str(err["loc"][-1]) for err in exc.errors()
+            if err.get("type") == "missing" and err.get("loc")
+        ]
+        hints = []
+        for want in missing:
+            near = [
+                got for got in received
+                if got != want and (got in want or want in got or got.endswith(want) or want.endswith(got))
+            ]
+            if near:
+                hints.append(f"you sent `{near[0]}` — this tool expects `{want}`")
+        detail = {
+            "tool": tool,
+            "message": f"{tool}: invalid arguments.",
+            "missing": missing,
+            "received": received or ["(none)"],
+            "errors": exc.errors(),
+        }
+        if hints:
+            detail["hint"] = "; ".join(hints)
+            detail["message"] = f"{tool}: invalid arguments — {detail['hint']}."
+        return JSONResponse(status_code=422, content=jsonable_encoder({"detail": detail}))
 
     # ---------------------------
     # Tools (each a FastAPI route; operation_id = MCP tool name)
@@ -506,29 +613,40 @@ def create_app(
         """
         return await make_request("GET", f"{base_url}/bots/status", api_key)
 
-    @app.put("/bot-config/{meeting_platform}/{meeting_id}", operation_id="update_bot_config")
+    @app.put("/bot-config", operation_id="update_bot_config")
     async def update_bot_config(
-        meeting_id: str,
         data: UpdateBotConfig,
-        meeting_platform: str = "google_meet",
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        meeting_id: Optional[str] = Query(None, deprecated=True, description=_LEGACY_ID_DESC),
+        meeting_platform: Optional[str] = Query(None, deprecated=True, description=_LEGACY_PLATFORM_DESC),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
         Update the configuration of an active bot (e.g., changing the transcription language).
+        Identify the meeting with `platform` + `native_meeting_id` — the exact field names
+        request_meeting_bot, list_meetings and parse_meeting_link hand back.
         """
-        url = f"{base_url}/bots/{meeting_platform}/{meeting_id}/config"
-        return await make_request("PUT", url, api_key, data.model_dump())
+        plat, mid = _resolve_identity(
+            "update_bot_config", platform, native_meeting_id, meeting_platform, meeting_id
+        )
+        return await make_request("PUT", f"{base_url}/bots/{plat}/{mid}/config", api_key, data.model_dump())
 
-    @app.delete("/bot/{meeting_platform}/{meeting_id}", operation_id="stop_bot")
+    @app.delete("/bot", operation_id="stop_bot")
     async def stop_bot(
-        meeting_id: str,
-        meeting_platform: str = "google_meet",
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        meeting_id: Optional[str] = Query(None, deprecated=True, description=_LEGACY_ID_DESC),
+        meeting_platform: Optional[str] = Query(None, deprecated=True, description=_LEGACY_PLATFORM_DESC),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
         Remove an active bot from a meeting.
+        Identify the meeting with `platform` + `native_meeting_id` — the exact field names
+        request_meeting_bot, list_meetings and parse_meeting_link hand back.
         """
-        return await make_request("DELETE", f"{base_url}/bots/{meeting_platform}/{meeting_id}", api_key)
+        plat, mid = _resolve_identity("stop_bot", platform, native_meeting_id, meeting_platform, meeting_id)
+        return await make_request("DELETE", f"{base_url}/bots/{plat}/{mid}", api_key)
 
     @app.get("/meetings", operation_id="list_meetings")
     async def list_meetings(
@@ -552,17 +670,53 @@ def create_app(
             params["platform"] = platform
         return await make_request("GET", f"{base_url}/meetings", api_key, params=params or None)
 
-    @app.get("/meeting-transcript/{meeting_platform}/{meeting_id}", operation_id="get_meeting_transcript")
+    @app.get("/meeting-transcript", operation_id="get_meeting_transcript")
     async def get_meeting_transcript(
-        meeting_id: str,
-        meeting_platform: str = "google_meet",
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        since_index: Optional[int] = Query(
+            None,
+            ge=0,
+            description=(
+                "Return only segments at or after this index. Pass the `next_index` from your "
+                "previous call to follow a live meeting without re-reading what you already have."
+            ),
+        ),
+        meeting_id: Optional[str] = Query(None, deprecated=True, description=_LEGACY_ID_DESC),
+        meeting_platform: Optional[str] = Query(None, deprecated=True, description=_LEGACY_PLATFORM_DESC),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
-        Get the real-time transcript for a meeting (segments with speaker, timestamp, text).
-        Can be called during or after the meeting.
+        Get the transcript for a meeting (segments with speaker, timestamp, text). Works DURING the
+        meeting as well as after — poll it to follow a live one.
+
+        Identify the meeting with `platform` + `native_meeting_id` — the exact field names
+        request_meeting_bot, list_meetings and parse_meeting_link hand back.
+
+        To follow a live meeting cheaply, pass `since_index` = the `next_index` from your previous
+        call; you get only what has been said since, instead of the whole transcript every time.
         """
-        return await make_request("GET", f"{base_url}/transcripts/{meeting_platform}/{meeting_id}", api_key)
+        plat, mid = _resolve_identity(
+            "get_meeting_transcript", platform, native_meeting_id, meeting_platform, meeting_id
+        )
+        result = await make_request("GET", f"{base_url}/transcripts/{plat}/{mid}", api_key)
+
+        # The cursor is applied here rather than at the gateway: the scarce resource is the
+        # CALLER's context window, not the hop to meeting-api. `total_segments`/`next_index` are
+        # always reported against the full transcript so a caller can tell "nothing new" from
+        # "nothing at all", and can resume after dropping its own state.
+        if isinstance(result, dict):
+            key = "segments" if isinstance(result.get("segments"), list) else (
+                "transcripts" if isinstance(result.get("transcripts"), list) else None
+            )
+            if key:
+                segments = result[key]
+                total = len(segments)
+                start = min(since_index, total) if since_index is not None else 0
+                result = {**result, key: segments[start:], "total_segments": total, "next_index": total}
+                if since_index is not None:
+                    result["since_index"] = start
+        return result
 
     @app.get("/recordings", operation_id="list_recordings")
     async def list_recordings(
@@ -773,6 +927,10 @@ def create_app(
     # MCP mount + prompts
     # ---------------------------
     mcp = FastApiMCP(app, headers=["authorization", "x-api-key"])
+    # Orientation at connect time. FastApiMCP has no `instructions` kwarg, but the lowlevel
+    # Server it wraps carries the field the spec defines — a client that connects should not have
+    # to infer what Vexa is from nine tool descriptions.
+    mcp.server.instructions = VEXA_INSTRUCTIONS
 
     @mcp.server.list_prompts()
     async def _list_prompts() -> mcp_types.ListPromptsResult:

--- a/core/meetings/services/mcp/tests/test_app.py
+++ b/core/meetings/services/mcp/tests/test_app.py
@@ -5,6 +5,8 @@ with the caller's key as X-API-Key, and auth is fail-closed (401 with a Bearer h
 """
 import json
 
+import pytest
+
 from conftest import API_KEY, FakeGateway
 
 
@@ -104,7 +106,9 @@ def test_request_meeting_bot_409_reports_already_exists(client, gateway: FakeGat
 
 
 def test_update_bot_config_path_and_payload(client, gateway, auth):
-    r = client.put("/bot-config/teams/9361792952021", headers=auth, json={"language": "es"})
+    r = client.put(
+        "/bot-config?platform=teams&native_meeting_id=9361792952021", headers=auth, json={"language": "es"}
+    )
     assert r.status_code == 200
     req = gateway.requests[-1]
     assert (req.method, req.url.path) == ("PUT", "/bots/teams/9361792952021/config")
@@ -112,9 +116,48 @@ def test_update_bot_config_path_and_payload(client, gateway, auth):
 
 
 def test_stop_bot_path(client, gateway, auth):
-    client.delete("/bot/google_meet/abc-defg-hij", headers=auth)
+    client.delete("/bot?platform=google_meet&native_meeting_id=abc-defg-hij", headers=auth)
     req = gateway.requests[-1]
     assert (req.method, req.url.path) == ("DELETE", "/bots/google_meet/abc-defg-hij")
+
+
+# --- one identity vocabulary across the surface ------------------------------
+# Every tool RETURNS `platform` + `native_meeting_id`; three tools used to ACCEPT
+# `meeting_platform` + `meeting_id`, so no tool's output could be fed to the next tool's
+# input without a rename nothing documented. Canonical names must work, the deprecated
+# aliases must keep working, and platform must default rather than being mandatory.
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "platform=zoom&native_meeting_id=12345678901",   # canonical
+        "meeting_platform=zoom&meeting_id=12345678901",  # deprecated aliases
+        "platform=zoom&meeting_id=12345678901",          # mixed
+    ],
+)
+def test_transcript_accepts_canonical_and_legacy_identity(client, gateway, auth, query):
+    r = client.get(f"/meeting-transcript?{query}", headers=auth)
+    assert r.status_code == 200
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("GET", "/transcripts/zoom/12345678901")
+
+
+def test_transcript_platform_defaults_to_google_meet(client, gateway, auth):
+    client.get("/meeting-transcript?native_meeting_id=abc-defg-hij", headers=auth)
+    assert gateway.requests[-1].url.path == "/transcripts/google_meet/abc-defg-hij"
+
+
+def test_stop_bot_accepts_legacy_identity(client, gateway, auth):
+    client.delete("/bot?meeting_platform=teams&meeting_id=9361792952021", headers=auth)
+    assert gateway.requests[-1].url.path == "/bots/teams/9361792952021"
+
+
+def test_missing_meeting_id_names_the_tool_and_the_field(client, gateway, auth):
+    r = client.get("/meeting-transcript?platform=zoom", headers=auth)
+    assert r.status_code == 422
+    detail = str(r.json()["detail"])
+    assert "get_meeting_transcript" in detail
+    assert "native_meeting_id" in detail
 
 
 def test_list_meetings_params(client, gateway, auth):
@@ -125,9 +168,50 @@ def test_list_meetings_params(client, gateway, auth):
 
 
 def test_get_meeting_transcript_path(client, gateway, auth):
-    client.get("/meeting-transcript/zoom/12345678901", headers=auth)
+    client.get("/meeting-transcript?platform=zoom&native_meeting_id=12345678901", headers=auth)
     req = gateway.requests[-1]
     assert (req.method, req.url.path) == ("GET", "/transcripts/zoom/12345678901")
+
+
+# --- following a live meeting without re-reading it --------------------------
+# The scarce resource is the CALLER's context window, not the hop to meeting-api: polling a live
+# meeting used to re-download every segment spoken so far on every call. `since_index` returns
+# only what is new; `total_segments`/`next_index` always describe the FULL transcript so a caller
+# can tell "nothing new" from "nothing at all" and can resume after losing its own state.
+
+def _transcript_route(gateway, n):
+    gateway.routes[("GET", "/transcripts/google_meet/abc-defg-hij")] = (
+        200,
+        {"status": "active", "segments": [{"speaker": "A", "text": f"line {i}"} for i in range(n)]},
+    )
+
+
+def test_transcript_since_index_returns_only_new_segments(client, gateway, auth):
+    _transcript_route(gateway, 6)
+    body = client.get(
+        "/meeting-transcript?native_meeting_id=abc-defg-hij&since_index=4", headers=auth
+    ).json()
+    assert [s["text"] for s in body["segments"]] == ["line 4", "line 5"]
+    assert (body["total_segments"], body["next_index"], body["since_index"]) == (6, 6, 4)
+
+
+def test_transcript_without_cursor_returns_everything(client, gateway, auth):
+    _transcript_route(gateway, 3)
+    body = client.get("/meeting-transcript?native_meeting_id=abc-defg-hij", headers=auth).json()
+    assert len(body["segments"]) == 3
+    assert body["next_index"] == 3
+    assert "since_index" not in body
+
+
+def test_transcript_cursor_past_the_end_is_empty_not_an_error(client, gateway, auth):
+    """The steady state of following a live meeting: caller is caught up, nothing new was said."""
+    _transcript_route(gateway, 2)
+    body = client.get(
+        "/meeting-transcript?native_meeting_id=abc-defg-hij&since_index=99", headers=auth
+    ).json()
+    assert body["segments"] == []
+    assert body["total_segments"] == 2
+    assert body["next_index"] == 2
 
 
 def test_list_recordings_params(client, gateway, auth):

--- a/core/meetings/services/mcp/tests/test_mcp_surface.py
+++ b/core/meetings/services/mcp/tests/test_mcp_surface.py
@@ -66,3 +66,16 @@ def test_prompts_only_reference_ported_tools():
 def test_unknown_prompt_raises():
     with pytest.raises(ValueError):
         get_prompt_result("vexa.nope")
+
+
+# --- orientation at connect time ---------------------------------------------
+# A client that connects should not have to infer what Vexa is from nine tool descriptions.
+# `instructions` is the MCP field for that, and it shipped empty.
+
+def test_server_ships_instructions():
+    app = create_app("http://gateway.test", transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+    instructions = app.state.mcp.server.instructions
+    assert instructions, "MCP server must ship `instructions` — a connecting client gets no map without it"
+    # The canonical flow and the identity vocabulary are the two things it exists to say.
+    for expected in ("parse_meeting_link", "request_meeting_bot", "get_meeting_transcript", "native_meeting_id"):
+        assert expected in instructions

--- a/deploy/dogfood/.gitignore
+++ b/deploy/dogfood/.gitignore
@@ -1,0 +1,4 @@
+# The live env carries this stack's real secrets, and .dogfood-key is a live API key.
+# Only the .example ships.
+.env.dogfood
+.dogfood-key

--- a/deploy/dogfood/Makefile
+++ b/deploy/dogfood/Makefile
@@ -1,0 +1,91 @@
+# deploy/dogfood — the long-lived MCP validation + dogfooding stack.
+#
+# The container targets (up/down/pull/logs/key) are meant to run ON THE STACK HOST (bbb), never on
+# a laptop. The probe targets (validate/validate-local/connect) are pure HTTP and run anywhere.
+#
+# This drives the STOCK deploy/compose stack with a dogfood .env — there is no overlay and no fork.
+# A dogfooding stack that differs from what users run stops being evidence about what users run.
+
+DOGFOOD_ENV ?= .env.dogfood
+COMPOSE_FILE ?= ../compose/docker-compose.yml
+PROJECT ?= vexa-dogfood
+COMPOSE = docker compose -p $(PROJECT) --env-file $(DOGFOOD_ENV) -f $(COMPOSE_FILE)
+
+# Public front door (nginx → gateway). Override for a local/tunnelled probe.
+MCP_URL ?= https://mcp.dev.vexa.ai/mcp
+LOCAL_MCP_URL ?= http://127.0.0.1:18456/mcp
+EMAIL ?= dmitry@vexa.ai
+SCOPES ?= bot,tx
+
+.PHONY: help up down pull ps logs key validate validate-local connect nginx-check env-check
+
+help:
+	@echo "  on the stack host (bbb):"
+	@echo "    make up             pull published images + bring the dogfood stack up"
+	@echo "    make down           stop it (volumes survive)"
+	@echo "    make ps / logs      inspect it"
+	@echo "    make key            mint + print an API key for EMAIL=$(EMAIL)"
+	@echo "    make nginx-check    verify the two vhosts are installed and nginx is happy"
+	@echo "  from anywhere:"
+	@echo "    make validate       drive $(MCP_URL) as a real MCP client"
+	@echo "    make validate-local same, against $(LOCAL_MCP_URL) (host-local, bypasses nginx)"
+	@echo "    make connect        print the exact 'claude mcp add' line for this endpoint"
+
+env-check:
+	@[ -f $(DOGFOOD_ENV) ] || { \
+	  echo "✗ no $(DOGFOOD_ENV) — cp env.dogfood.example $(DOGFOOD_ENV) and fill the CHANGE-ME values"; \
+	  exit 1; }
+	@if grep -q 'CHANGE-ME' $(DOGFOOD_ENV); then \
+	  echo "✗ $(DOGFOOD_ENV) still has CHANGE-ME placeholders:"; \
+	  grep -n 'CHANGE-ME' $(DOGFOOD_ENV) | sed 's/^/    /'; \
+	  echo "  this stack is internet-reachable through nginx — the compose dev defaults are not acceptable here."; \
+	  exit 1; fi
+
+## up — pull the published, release-validated images and start. Never builds from source: the
+## point of dogfooding is to live on the bytes a user would get.
+up: env-check
+	$(COMPOSE) pull
+	$(COMPOSE) up -d --no-build
+	@echo "→ stack up. gateway=127.0.0.1:18456  mcp=127.0.0.1:18410  terminal=127.0.0.1:15400"
+
+down:
+	$(COMPOSE) down
+
+pull: env-check
+	$(COMPOSE) pull
+
+ps:
+	$(COMPOSE) ps
+
+logs:
+	$(COMPOSE) logs -f --tail=100 $(SVC)
+
+## key — mint an API key against THIS stack's admin-api, reusing deploy/compose/bin/provision-token
+## (same job, already idempotent on the user). Prints ONLY the token, so it pipes.
+## Note: the USER is resolve-or-create, but each run mints a FRESH token — run it once and keep the
+## value; don't call it on a loop or you accumulate live tokens.
+key: env-check
+	@ADMIN_TOKEN="$$(grep -E '^ADMIN_TOKEN=' $(DOGFOOD_ENV) | head -1 | cut -d= -f2-)" \
+	 ADMIN_API_URL="http://127.0.0.1:$$(grep -E '^ADMIN_API_PORT=' $(DOGFOOD_ENV) | head -1 | cut -d= -f2-)" \
+	 EMAIL="$(EMAIL)" SCOPES="$(SCOPES)" ../compose/bin/provision-token
+
+validate:
+	@./bin/mcp-validate --url "$(MCP_URL)" $(if $(VEXA_API_KEY),--key "$(VEXA_API_KEY)",)
+
+validate-local:
+	@./bin/mcp-validate --url "$(LOCAL_MCP_URL)" $(if $(VEXA_API_KEY),--key "$(VEXA_API_KEY)",)
+
+## connect — the one line a human runs to attach Claude Code to this endpoint. Today it carries a
+## key in a header; when the OAuth work lands the --header disappears and this becomes a login.
+connect:
+	@echo 'claude mcp add --transport http vexa-dogfood $(MCP_URL) \'
+	@echo '  --header "Authorization: Bearer $$VEXA_API_KEY"'
+	@echo
+	@echo 'Then: /mcp inside Claude Code to confirm it connected.'
+
+nginx-check:
+	@for h in mcp.dev.vexa.ai dogfood.dev.vexa.ai; do \
+	  printf '  %-22s ' "$$h"; \
+	  curl -sS -o /dev/null -w 'HTTP %{http_code} (TLS %{ssl_verify_result})\n' "https://$$h/health" || echo unreachable; \
+	done
+	@nginx -t 2>&1 | sed 's/^/  /' || true

--- a/deploy/dogfood/README.md
+++ b/deploy/dogfood/README.md
@@ -1,0 +1,116 @@
+# deploy/dogfood — the long-lived MCP validation + dogfooding stack
+
+A Vexa stack that stays up, fronted by a real hostname over real TLS, so two things can happen that
+a `docker compose up` in a terminal cannot do:
+
+1. **Validate the MCP service as deployed.** `core/meetings/services/mcp/tests/` proves the app
+   in-process against a faked gateway. That is the right test and it does not answer the question
+   an MCP client asks: *does the transport work through the proxy chain, with a real key, against a
+   real gateway?* `bin/mcp-validate` answers that one.
+2. **Dogfood it.** Point Claude at it and use Vexa the way a customer would — which is the only way
+   the onboarding defects surface, because they are all in the part no test covers: getting a key,
+   storing it, and attaching the server.
+
+## There is no compose overlay here, deliberately
+
+This directory holds a `.env`, an nginx vhost, a probe, and a Makefile. It drives the **stock**
+`deploy/compose/docker-compose.yml` unchanged.
+
+That is the design, not laziness. A dogfooding stack that differs structurally from what users run
+stops being evidence about what users run. Everything this directory sets is a *value* — ports,
+image tag, secrets, hostnames — never a structural change. If dogfooding ever needs a change to the
+stack's shape, that change belongs in the stack, where users get it too.
+
+## Layout
+
+| File | What |
+|---|---|
+| `env.dogfood.example` | the `.env` for the stock stack — a port block offset from the compose defaults so this can sit beside a release-train stack with no collision |
+| `nginx/mcp.dev.vexa.ai.conf` | the two vhosts, on the host's existing `*.dev.vexa.ai` wildcard cert |
+| `bin/mcp-validate` | drives the endpoint as a real MCP client; stdlib-only, runs from anywhere |
+| `Makefile` | `up · down · ps · logs · key · validate · connect · nginx-check` |
+
+## Hostnames
+
+Both are **one label** under `dev.vexa.ai`, because the host's wildcard DNS record and wildcard
+certificate each cover exactly one level — a four-label name would need its own cert and record.
+
+| Host | → | What it is |
+|---|---|---|
+| `mcp.dev.vexa.ai` | gateway `127.0.0.1:18456` | the MCP endpoint (`/mcp`) and the API front door |
+| `dogfood.dev.vexa.ai` | terminal `127.0.0.1:15400` | where a human signs in and copies an API key |
+
+## Bring-up
+
+On the stack host (never a laptop — container workloads run on `bbb`):
+
+```bash
+cd deploy/dogfood
+cp env.dogfood.example .env.dogfood     # then fill every CHANGE-ME
+make up                                 # pulls published images, starts the stock stack
+make key EMAIL=you@example.com          # mint an API key — prints only the token
+sudo cp nginx/mcp.dev.vexa.ai.conf /etc/nginx/sites-available/mcp.dev.vexa.ai
+sudo ln -s /etc/nginx/sites-available/mcp.dev.vexa.ai /etc/nginx/sites-enabled/mcp.dev.vexa.ai.conf
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+`make up` refuses to run while `CHANGE-ME` remains in the env file. This stack is internet-reachable
+through nginx, and the compose dev defaults (`ADMIN_TOKEN=dev-admin-token`, `DB_PASSWORD=postgres`)
+are not acceptable on something with a public hostname. `make up` also never builds: it pulls the
+published, release-validated tag, because a dogfood stack running a local source build proves
+nothing about the release.
+
+## Validating
+
+```bash
+VEXA_API_KEY=vxa_… make validate          # the public endpoint, through nginx
+VEXA_API_KEY=vxa_… make validate-local    # host-local, bypassing nginx — isolates proxy faults
+```
+
+The probe reports two families, and the split is the point:
+
+**CONFORMANCE — is this an MCP server?** `initialize` · `tools/list` against the exact 9 tools the
+service declares · `prompts/list` against the 4 prompts · a pure `parse_meeting_link` call (no
+gateway hop, so it isolates the transport) · a real `list_meetings` call (the full
+MCP → gateway → meeting-api path with your key) · and a fail-closed check that a bogus key is
+*rejected* rather than passed through as an anonymous call. Drift in the tool set fails either
+direction: a missing tool is a regression, an undeclared extra one is a README that stopped being
+true. These govern the exit code.
+
+**NATIVE-READY — is this a connector, or does a human still paste a key?** RFC 9728
+protected-resource metadata · the `WWW-Authenticate` challenge on 401 · authorization-server
+metadata. These are the mechanical difference between "add a custom MCP server and paste a header"
+and what Gmail does — click connect, log in in a browser, never see a credential. They are
+**expected to fail today**; the probe prints them as a measured distance rather than hiding them,
+and `--require-native` makes them binding once that work is expected to hold.
+
+## What is verified as of 2026-08-29
+
+Against `https://mcp.dev.vexa.ai/mcp`, images `v0.12.23`, through nginx and TLS:
+
+- All 6 conformance checks pass. Server identifies as `Vexa MCP Service (v0.12) v1.28.1`,
+  protocol `2025-06-18`, sessioned.
+- The `GET /mcp` SSE leg survives the proxy: headers arrive immediately, `content-type:
+  text/event-stream`, the stream then holds open silently with no gateway-manufactured 503. This
+  is the `Vexa-ai/vexa#795` failure mode not happening, and it is why the vhost keeps
+  `proxy_buffering off` (inherited from `proxy_vexa.conf`) and additionally disables `gzip` — a
+  compression filter re-buffers an event stream even when proxy buffering is off.
+- All 3 native-ready checks report GAP. The endpoint is key-paste only.
+
+## Attaching Claude
+
+```bash
+claude mcp add --transport http vexa-dogfood https://mcp.dev.vexa.ai/mcp \
+  --header "Authorization: Bearer $VEXA_API_KEY"
+```
+
+Two known sharp edges in that line, both of which the native-ready work removes rather than
+documents around:
+
+- `claude mcp add` has been observed writing **resolved** values back into `.mcp.json` instead of
+  preserving `${VAR}` syntax, which turns a shared project config into a committed credential.
+  Keep this server in user scope, not a checked-in `.mcp.json`.
+- Claude Code strips environment variables whose names contain `KEY`, `TOKEN`, `SECRET` and
+  similar from spawned server processes. That sanitizer is about child-process env, not about
+  header expansion, but it is close enough to the blast radius that a name like `VEXA_API_KEY`
+  deserves an actual check on your machine rather than an assumption.

--- a/deploy/dogfood/bin/README.md
+++ b/deploy/dogfood/bin/README.md
@@ -1,0 +1,30 @@
+# deploy/dogfood/bin — the probe
+
+`mcp-validate` drives a RUNNING Vexa MCP endpoint as a real MCP client.
+
+The MCP service's own tests (`core/meetings/services/mcp/tests/`) prove the app in-process against
+a faked gateway. That is the right test, and it cannot answer the question an MCP client asks:
+*does the transport work through the proxy chain, with a real key, against a real gateway?* This
+answers that one.
+
+Stdlib only — no install step; runs from a laptop or from the stack host.
+
+```bash
+./mcp-validate --url https://mcp.dev.vexa.ai/mcp --key "$VEXA_API_KEY"
+./mcp-validate --url http://127.0.0.1:18456/mcp --json
+```
+
+Two families of check, and the split is the point:
+
+**CONFORMANCE — is this an MCP server?** `initialize` · the exact declared tool set · the prompt
+catalog · a pure tool call (isolating the transport from the gateway) · a real gateway call · and
+a fail-closed check that a bogus key is *rejected* rather than forwarded as an anonymous call.
+Drift in the tool set fails either direction: a missing tool is a regression, an undeclared extra
+one is a README that stopped being true. **These govern the exit code.**
+
+**NATIVE-READY — is this a connector, or does a human still paste a key?** RFC 9728
+protected-resource metadata · the `WWW-Authenticate` challenge on 401 · authorization-server
+metadata. These are the mechanical difference between "add a custom MCP server and paste a header"
+and what a first-class connector does. They are **expected to fail** until the OAuth work lands;
+the run prints them as a measured distance rather than hiding them. `--require-native` makes them
+binding once that work is expected to hold.

--- a/deploy/dogfood/bin/mcp-validate
+++ b/deploy/dogfood/bin/mcp-validate
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""mcp-validate — drive a RUNNING Vexa MCP endpoint as a real MCP client and report what it is.
+
+This is not a unit test. ``core/meetings/services/mcp/tests/`` already proves the app in-process
+against a faked gateway. This proves the DEPLOYED surface: the transport as an MCP client actually
+speaks it, through whatever proxy chain fronts it, with a real API key against a real gateway.
+
+Two families of check, and the second is the point:
+
+  CONFORMANCE  — does the endpoint behave as an MCP server?
+                 initialize · tools/list · prompts/list · a real tools/call round trip ·
+                 auth passthrough (good key works, bad key 401s).
+
+  NATIVE-READY — is it a *connector*, or does a human still have to paste a key?
+                 RFC 9728 protected-resource metadata · the 401 WWW-Authenticate challenge ·
+                 authorization-server metadata. These are what make Claude offer a browser
+                 login instead of asking for a header, i.e. what "native like Gmail" means
+                 mechanically. They are EXPECTED TO FAIL until the OAuth work lands; the run
+                 prints them as a measured distance, not as noise.
+
+Stdlib only — no install step, runs from the laptop or from bbb.
+
+    ./mcp-validate --url https://mcp.dev.vexa.ai/mcp --key "$VEXA_API_KEY"
+    ./mcp-validate --url http://127.0.0.1:18456/mcp --key "$VEXA_API_KEY" --json
+
+Exit code is 0 when every CONFORMANCE check passes; NATIVE-READY failures never fail the run
+(use --require-native to make them binding once the OAuth work is expected to hold).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+PROTOCOL_VERSION = "2025-06-18"
+
+# The surface core/meetings/services/mcp/README.md declares. Drift here is a finding either way:
+# a missing tool is a regression, an extra one is a doc that stopped being true.
+EXPECTED_TOOLS = {
+    "parse_meeting_link",
+    "request_meeting_bot",
+    "get_bot_status",
+    "update_bot_config",
+    "stop_bot",
+    "list_meetings",
+    "get_meeting_transcript",
+    "list_recordings",
+    "get_recording",
+}
+EXPECTED_PROMPTS = {
+    "vexa.meeting_prep",
+    "vexa.during_meeting",
+    "vexa.post_meeting",
+    "vexa.teams_link_help",
+}
+
+
+@dataclass
+class Check:
+    name: str
+    family: str  # "conformance" | "native-ready"
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class Session:
+    url: str
+    key: str | None
+    timeout: float
+    session_id: str | None = None
+    checks: list[Check] = field(default_factory=list)
+
+    def record(self, name: str, family: str, ok: bool, detail: str = "") -> bool:
+        self.checks.append(Check(name, family, ok, detail))
+        return ok
+
+
+def _sse_to_payload(body: str) -> Any:
+    """Pull the first JSON-RPC message out of a text/event-stream response body."""
+    for raw in body.splitlines():
+        if raw.startswith("data:"):
+            chunk = raw[5:].strip()
+            if chunk:
+                try:
+                    return json.loads(chunk)
+                except json.JSONDecodeError:
+                    continue
+    raise ValueError("no JSON payload in event-stream body")
+
+
+def rpc(
+    sess: Session,
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    key: str | None = "__default__",
+    notify: bool = False,
+    request_id: int = 1,
+) -> tuple[int, dict[str, str], Any]:
+    """One JSON-RPC call over streamable HTTP. Returns (status, headers, decoded-or-raw-body)."""
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        payload["params"] = params
+    if not notify:
+        payload["id"] = request_id
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    token = sess.key if key == "__default__" else key
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if sess.session_id:
+        headers["mcp-session-id"] = sess.session_id
+        headers["MCP-Protocol-Version"] = PROTOCOL_VERSION
+
+    req = urllib.request.Request(
+        sess.url, data=json.dumps(payload).encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=sess.timeout) as resp:
+            status, hdrs, body = resp.status, dict(resp.headers), resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:  # 4xx/5xx still carry a body worth reading
+        status, hdrs, body = e.code, dict(e.headers or {}), e.read().decode(errors="replace")
+    except urllib.error.URLError as e:
+        return 0, {}, f"transport error: {e.reason}"
+
+    hdrs = {k.lower(): v for k, v in hdrs.items()}
+    if not sess.session_id and hdrs.get("mcp-session-id"):
+        sess.session_id = hdrs["mcp-session-id"]
+
+    ctype = hdrs.get("content-type", "")
+    decoded: Any = body
+    try:
+        decoded = _sse_to_payload(body) if "text/event-stream" in ctype else json.loads(body)
+    except (ValueError, json.JSONDecodeError):
+        pass
+    return status, hdrs, decoded
+
+
+def get(url: str, timeout: float, key: str | None = None) -> tuple[int, dict[str, str], str]:
+    headers = {"Accept": "application/json"}
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, {k.lower(): v for k, v in resp.headers.items()}, resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, {k.lower(): v for k, v in (e.headers or {}).items()}, e.read().decode(errors="replace")
+    except urllib.error.URLError as e:
+        return 0, {}, f"transport error: {e.reason}"
+
+
+# ── conformance ──────────────────────────────────────────────────────────────────────────────
+
+def check_initialize(sess: Session) -> bool:
+    status, _, body = rpc(
+        sess,
+        "initialize",
+        {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "vexa-mcp-validate", "version": "1"},
+        },
+    )
+    result = body.get("result") if isinstance(body, dict) else None
+    if status != 200 or not result:
+        return sess.record("initialize", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    server = result.get("serverInfo", {}) or {}
+    negotiated = result.get("protocolVersion", "?")
+    rpc(sess, "notifications/initialized", {}, notify=True)
+    return sess.record(
+        "initialize",
+        "conformance",
+        True,
+        f"server={server.get('name', '?')} v{server.get('version', '?')} protocol={negotiated}"
+        + (f" session={sess.session_id[:8]}…" if sess.session_id else " session=stateless"),
+    )
+
+
+def check_tools(sess: Session) -> bool:
+    status, _, body = rpc(sess, "tools/list", {}, request_id=2)
+    result = body.get("result") if isinstance(body, dict) else None
+    if status != 200 or not result:
+        return sess.record("tools/list", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    got = {t.get("name") for t in result.get("tools", [])}
+    missing, extra = EXPECTED_TOOLS - got, got - EXPECTED_TOOLS
+    if missing or extra:
+        bits = []
+        if missing:
+            bits.append(f"missing {sorted(missing)}")
+        if extra:
+            bits.append(f"undeclared {sorted(extra)}")
+        return sess.record("tools/list", "conformance", False, f"{len(got)} tools; " + "; ".join(bits))
+    return sess.record("tools/list", "conformance", True, f"all {len(EXPECTED_TOOLS)} declared tools present")
+
+
+def check_prompts(sess: Session) -> bool:
+    status, _, body = rpc(sess, "prompts/list", {}, request_id=3)
+    result = body.get("result") if isinstance(body, dict) else None
+    if status != 200 or not result:
+        return sess.record("prompts/list", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    got = {p.get("name") for p in result.get("prompts", [])}
+    missing = EXPECTED_PROMPTS - got
+    if missing:
+        return sess.record("prompts/list", "conformance", False, f"missing {sorted(missing)}")
+    return sess.record("prompts/list", "conformance", True, f"all {len(EXPECTED_PROMPTS)} prompts present")
+
+
+def _tool_payload(body: Any) -> Any:
+    """Unwrap a tools/call result into the tool's own JSON, whatever content shape carried it."""
+    result = body.get("result") if isinstance(body, dict) else None
+    if not isinstance(result, dict):
+        return None
+    if isinstance(result.get("structuredContent"), dict):
+        return result["structuredContent"]
+    for item in result.get("content", []) or []:
+        if item.get("type") == "text":
+            try:
+                return json.loads(item.get("text", ""))
+            except (ValueError, json.JSONDecodeError):
+                return item.get("text")
+    return result
+
+
+def check_pure_tool_call(sess: Session) -> bool:
+    """parse_meeting_link — the one tool with no gateway hop. Proves the transport round trip alone."""
+    status, _, body = rpc(
+        sess,
+        "tools/call",
+        {"name": "parse_meeting_link", "arguments": {"meeting_url": "https://meet.google.com/abc-defg-hij"}},
+        request_id=4,
+    )
+    payload = _tool_payload(body)
+    if status != 200 or not isinstance(payload, dict):
+        return sess.record("tools/call parse_meeting_link", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    if payload.get("platform") != "google_meet" or payload.get("native_meeting_id") != "abc-defg-hij":
+        return sess.record("tools/call parse_meeting_link", "conformance", False, f"unexpected parse: {payload}")
+    return sess.record("tools/call parse_meeting_link", "conformance", True, "google_meet / abc-defg-hij")
+
+
+def check_gateway_tool_call(sess: Session) -> bool:
+    """list_meetings — the full path: MCP → gateway → meeting-api, with the caller's real key."""
+    if not sess.key:
+        return sess.record("tools/call list_meetings", "conformance", False, "no --key supplied")
+    status, _, body = rpc(sess, "tools/call", {"name": "list_meetings", "arguments": {"limit": 1}}, request_id=5)
+    payload = _tool_payload(body)
+    if status != 200:
+        return sess.record("tools/call list_meetings", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    if isinstance(body, dict) and body.get("result", {}).get("isError"):
+        return sess.record("tools/call list_meetings", "conformance", False, f"tool error: {str(payload)[:200]}")
+    shape = type(payload).__name__
+    n = len(payload.get("meetings", [])) if isinstance(payload, dict) else "?"
+    return sess.record("tools/call list_meetings", "conformance", True, f"gateway reached; {shape}, {n} meeting(s)")
+
+
+def check_auth_rejected(sess: Session) -> bool:
+    """A bogus key must NOT reach the gateway as an anonymous call. Fail-closed is the whole seam."""
+    status, _, body = rpc(
+        sess,
+        "tools/call",
+        {"name": "list_meetings", "arguments": {"limit": 1}},
+        key="obviously-not-a-real-vexa-key",
+        request_id=6,
+    )
+    payload = _tool_payload(body)
+    is_error = bool(isinstance(body, dict) and body.get("result", {}).get("isError"))
+    blob = json.dumps(payload) if not isinstance(payload, str) else payload
+    rejected = status in (401, 403) or is_error or "401" in (blob or "") or "403" in (blob or "")
+    return sess.record(
+        "auth fail-closed",
+        "conformance",
+        rejected,
+        "bad key rejected" if rejected else f"BAD KEY WAS ACCEPTED — HTTP {status}: {str(payload)[:200]}",
+    )
+
+
+# ── native-readiness (the OAuth connector surface) ────────────────────────────────────────────
+
+def check_www_authenticate(sess: Session) -> bool:
+    """MCP spec: an unauthorized request MUST be answered with a WWW-Authenticate carrying
+    resource_metadata. That header is the thread Claude pulls to offer a browser login."""
+    status, hdrs, _ = rpc(sess, "tools/call", {"name": "list_meetings", "arguments": {}}, key=None, request_id=7)
+    challenge = hdrs.get("www-authenticate", "")
+    if "resource_metadata" in challenge:
+        return sess.record("401 WWW-Authenticate", "native-ready", True, challenge[:160])
+    return sess.record(
+        "401 WWW-Authenticate",
+        "native-ready",
+        False,
+        f"HTTP {status}, no resource_metadata challenge"
+        + (f" (got: {challenge[:80]})" if challenge else " (no WWW-Authenticate header)"),
+    )
+
+
+def check_protected_resource_metadata(sess: Session) -> bool:
+    """RFC 9728. MCP servers MUST serve this; clients MUST use it for AS discovery."""
+    parts = urllib.parse.urlsplit(sess.url)
+    origin = f"{parts.scheme}://{parts.netloc}"
+    # Path-aware form first (RFC 9728 §3.1), then the origin-level fallback.
+    candidates = [
+        f"{origin}/.well-known/oauth-protected-resource{parts.path}",
+        f"{origin}/.well-known/oauth-protected-resource",
+    ]
+    for url in candidates:
+        status, _, body = get(url, sess.timeout)
+        if status == 200:
+            try:
+                doc = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            servers = doc.get("authorization_servers") or []
+            return sess.record(
+                "RFC 9728 protected-resource metadata",
+                "native-ready",
+                bool(servers),
+                f"{url} → resource={doc.get('resource', '?')} as={servers}",
+            )
+    return sess.record(
+        "RFC 9728 protected-resource metadata",
+        "native-ready",
+        False,
+        "not served at either well-known path",
+    )
+
+
+def check_as_metadata(sess: Session) -> bool:
+    """RFC 8414 / OIDC discovery on the same origin — the fallback a client tries when it has a
+    resource but no explicit AS. Presence here is what turns `claude mcp add` into a login."""
+    parts = urllib.parse.urlsplit(sess.url)
+    origin = f"{parts.scheme}://{parts.netloc}"
+    for path in ("/.well-known/oauth-authorization-server", "/.well-known/openid-configuration"):
+        status, _, body = get(f"{origin}{path}", sess.timeout)
+        if status == 200:
+            try:
+                doc = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            return sess.record(
+                "authorization-server metadata",
+                "native-ready",
+                bool(doc.get("authorization_endpoint") and doc.get("token_endpoint")),
+                f"{path} → issuer={doc.get('issuer', '?')}",
+            )
+    return sess.record("authorization-server metadata", "native-ready", False, "no AS metadata on this origin")
+
+
+# ── driver ───────────────────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--url", required=True, help="MCP endpoint, e.g. https://mcp.dev.vexa.ai/mcp")
+    ap.add_argument("--key", default=None, help="Vexa API key (falls back to $VEXA_API_KEY)")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--json", action="store_true", help="emit machine-readable results")
+    ap.add_argument(
+        "--require-native",
+        action="store_true",
+        help="make the OAuth connector checks binding on the exit code (they are informational by default)",
+    )
+    args = ap.parse_args()
+
+    import os
+
+    key = args.key or os.environ.get("VEXA_API_KEY") or None
+    sess = Session(url=args.url, key=key, timeout=args.timeout)
+
+    if check_initialize(sess):
+        check_tools(sess)
+        check_prompts(sess)
+        check_pure_tool_call(sess)
+        check_gateway_tool_call(sess)
+        check_auth_rejected(sess)
+    check_www_authenticate(sess)
+    check_protected_resource_metadata(sess)
+    check_as_metadata(sess)
+
+    conformance = [c for c in sess.checks if c.family == "conformance"]
+    native = [c for c in sess.checks if c.family == "native-ready"]
+    conf_ok = all(c.ok for c in conformance) and len(conformance) == 6
+    native_ok = all(c.ok for c in native)
+
+    if args.json:
+        print(json.dumps(
+            {
+                "url": args.url,
+                "conformance_ok": conf_ok,
+                "native_ready": native_ok,
+                "checks": [vars(c) for c in sess.checks],
+            },
+            indent=2,
+        ))
+    else:
+        print(f"\n  MCP endpoint: {args.url}\n")
+        print("  CONFORMANCE — is this an MCP server?")
+        for c in conformance:
+            print(f"    {'PASS' if c.ok else 'FAIL'}  {c.name:<34} {c.detail}")
+        if not conformance:
+            print("    FAIL  initialize never completed; nothing else could run")
+        print("\n  NATIVE-READY — is this a connector, or does a human paste a key?")
+        for c in native:
+            print(f"    {'PASS' if c.ok else 'GAP '}  {c.name:<34} {c.detail}")
+        verdict = "MCP-conformant" if conf_ok else "NOT CONFORMANT"
+        native_verdict = (
+            "OAuth connector surface present"
+            if native_ok
+            else "key-paste only — no OAuth connector surface yet"
+        )
+        print(f"\n  → {verdict}; {native_verdict}\n")
+
+    if not conf_ok:
+        return 1
+    return 1 if (args.require_native and not native_ok) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/dogfood/env.dogfood.example
+++ b/deploy/dogfood/env.dogfood.example
@@ -1,0 +1,92 @@
+# deploy/dogfood — the long-lived MCP validation + dogfooding stack.
+#
+# This is a .env for the STOCK deploy/compose stack, not a fork of it. There is deliberately no
+# compose overlay here: a dogfooding stack that differs from what users run stops being evidence
+# about what users run. Everything below is a value, not a structural change.
+#
+# Install:  cp env.dogfood.example ../compose/.env.dogfood   (then edit the secrets)
+# Bring up: make -C deploy/dogfood up
+#
+# The port block is offset from the default compose block (180xx/130xx/5458/900x) so this stack
+# can sit alongside a release-train stack on the same host without a single collision.
+
+COMPOSE_PROJECT_NAME=vexa-dogfood
+
+# ── ports (dogfood block — every one offset from the deploy/compose defaults) ─────────────────
+API_GATEWAY_HOST_PORT=18456
+ADMIN_API_PORT=18457
+MEETING_API_PORT=18480
+RUNTIME_API_PORT=18490
+AGENT_API_PORT=18500
+MCP_HOST_PORT=18410
+TERMINAL_PORT=15400
+POSTGRES_HOST_PORT=5468
+MINIO_HOST_PORT=9400
+MINIO_CONSOLE_HOST_PORT=9401
+
+# ── images ────────────────────────────────────────────────────────────────────────────────────
+# Published, release-validated bytes only. A dogfood stack running a local source build proves
+# nothing about the release — pin the released tag you actually want to be living on, and bump it
+# deliberately. (`v012` is NOT a tag that exists; the published tags are `v0.12.NN`.)
+IMAGE_TAG=v0.12.23
+BROWSER_IMAGE=vexaai/vexa-bot:${IMAGE_TAG}
+# runtime spawns bot containers through the mounted docker.sock — this must be the HOST's docker
+# gid or every spawn fails on permission. On bbb: 998. Check with `getent group docker | cut -d: -f3`.
+DOCKER_GID=998
+LOG_LEVEL=info
+
+# ── datastores (stack-local; this stack owns its own universe) ─────────────────────────────────
+DB_NAME=vexa
+DB_USER=postgres
+DB_PASSWORD=CHANGE-ME
+STORAGE_BACKEND=minio
+MINIO_ROOT_USER=vexa-access-key
+MINIO_ROOT_PASSWORD=CHANGE-ME
+MINIO_ACCESS_KEY=vexa-access-key
+MINIO_SECRET_KEY=CHANGE-ME
+MINIO_BUCKET=vexa
+MINIO_ENDPOINT=minio:9000
+MINIO_SECURE=false
+
+# ── secrets ───────────────────────────────────────────────────────────────────────────────────
+# Long-lived and internet-reachable through nginx, so these are NOT the compose dev defaults.
+# Generate: openssl rand -hex 32
+ADMIN_TOKEN=CHANGE-ME
+INTERNAL_API_SECRET=CHANGE-ME
+VEXA_DISPATCH_SIGNING_KEY=CHANGE-ME
+NEXTAUTH_SECRET=CHANGE-ME
+
+# ── transcription ─────────────────────────────────────────────────────────────────────────────
+# bbb already runs transcription workers behind transcription-lb. Point at the same endpoint the
+# host's other stacks use rather than standing up GPU workers this stack does not need.
+TRANSCRIPTION_SERVICE_URL=
+TRANSCRIPTION_SERVICE_TOKEN=
+TRANSCRIPTION_MODEL=
+
+# ── public identity ───────────────────────────────────────────────────────────────────────────
+# The hostnames nginx fronts. Both are ONE label under dev.vexa.ai, deliberately: the existing
+# wildcard cert (*.dev.vexa.ai) and the wildcard DNS record cover exactly one level, so a
+# four-label name like terminal.mcp.dev.vexa.ai would need its own cert and its own record.
+#   mcp.dev.vexa.ai      → gateway  (the MCP endpoint + the API front door)
+#   dogfood.dev.vexa.ai  → terminal (where a human signs in and copies their API key)
+# CORS_ORIGINS must carry the terminal origin or browser login breaks.
+NEXTAUTH_URL=https://dogfood.dev.vexa.ai
+CORS_ORIGINS=https://mcp.dev.vexa.ai,https://dogfood.dev.vexa.ai
+
+# Google/Microsoft sign-in for the terminal. Each self-gates: set BOTH id and secret to show the
+# button. Redirect URI to register: ${NEXTAUTH_URL}/api/auth/callback/google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+MICROSOFT_TENANT_ID=common
+
+# Hidden admin panel — comma-separated email allowlist. Empty = off for everyone.
+VEXA_ADMIN_EMAILS=
+
+DEFAULT_BOT_NAME=Vexa
+RATE_LIMIT_RPM=
+RATE_LIMIT_ADMIN_RPM=
+RATE_LIMIT_WS_RPM=
+GA_MEASUREMENT_ID=
+VEXA_JITSI_HOSTS=

--- a/deploy/dogfood/nginx/README.md
+++ b/deploy/dogfood/nginx/README.md
@@ -1,0 +1,34 @@
+# deploy/dogfood/nginx — the vhosts
+
+`mcp.dev.vexa.ai.conf` serves the dogfood stack on two hostnames, both **one label** under
+`dev.vexa.ai` because the host's wildcard DNS record and wildcard certificate each cover exactly
+one level — a four-label name would need its own cert and its own record.
+
+| host | → | what it is |
+|---|---|---|
+| `mcp.dev.vexa.ai` | gateway `127.0.0.1:18456` | the MCP endpoint (`/mcp`) and the API front door |
+| `dogfood.dev.vexa.ai` | terminal `127.0.0.1:15400` | where a human signs in and copies an API key |
+
+An explicit `server_name` takes precedence over the `*.dev.vexa.ai` wildcard block, which
+otherwise routes everything to the K8s ingress.
+
+## Why the MCP vhost is not a stock proxy block
+
+The transport's two legs are not the same animal, and conflating them is a documented failure
+(`Vexa-ai/vexa#795`): `POST /mcp` is a short request/response, but `GET /mcp` is the server→client
+SSE stream — headers, then silence until the server pushes. A proxy that buffers that leg waits on
+the next body read of a healthy stream, hits its read timeout, and answers with a
+gateway-manufactured 503 the MCP service never saw.
+
+The shared `proxy_vexa.conf` already carries what that needs (`proxy_buffering off`,
+`proxy_read_timeout 86400`). This vhost adds the two things it does not: `gzip off` — a compression
+filter re-buffers an event stream even when proxy buffering is off — and
+`proxy_request_buffering off`.
+
+Install:
+
+```bash
+sudo cp mcp.dev.vexa.ai.conf /etc/nginx/sites-available/mcp.dev.vexa.ai
+sudo ln -s /etc/nginx/sites-available/mcp.dev.vexa.ai /etc/nginx/sites-enabled/mcp.dev.vexa.ai.conf
+sudo nginx -t && sudo systemctl reload nginx
+```

--- a/deploy/dogfood/nginx/mcp.dev.vexa.ai.conf
+++ b/deploy/dogfood/nginx/mcp.dev.vexa.ai.conf
@@ -1,0 +1,62 @@
+# Vexa MCP dogfood stack :: two hostnames on the existing *.dev.vexa.ai wildcard.
+#
+#   mcp.dev.vexa.ai      → gateway  127.0.0.1:18456   the MCP endpoint (/mcp) + the API front door
+#   dogfood.dev.vexa.ai  → terminal 127.0.0.1:15400   sign in, copy an API key
+#
+# An explicit server_name takes precedence over the *.dev.vexa.ai wildcard block in
+# dev.vexa.ai.conf, which otherwise routes everything to the K8s ingress on 8443.
+#
+# DNS + TLS need no work: *.dev.vexa.ai already CNAMEs to this host and the
+# dev.vexa.ai-0001 cert is a wildcard covering exactly one label.
+#
+# Install (sudo):
+#   cp mcp.dev.vexa.ai.conf /etc/nginx/sites-available/mcp.dev.vexa.ai
+#   ln -s /etc/nginx/sites-available/mcp.dev.vexa.ai /etc/nginx/sites-enabled/mcp.dev.vexa.ai.conf
+#   nginx -t && systemctl reload nginx
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.dev.vexa.ai;
+
+    ssl_certificate     /etc/letsencrypt/live/dev.vexa.ai-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dev.vexa.ai-0001/privkey.pem;
+
+    # The MCP transport's two legs are not the same animal, and conflating them is the documented
+    # failure (Vexa-ai/vexa#795): POST /mcp is a short request/response, but GET /mcp is the
+    # server→client SSE stream — headers, then silence until the server pushes. A proxy that
+    # buffers that leg waits on the next body read of a healthy stream, hits its read timeout,
+    # and manufactures a 503 the MCP service never saw.
+    #
+    # proxy_vexa.conf already carries what that requires — `proxy_buffering off` and
+    # `proxy_read_timeout 86400` — so the shared include is correct here rather than in spite of
+    # itself. The two lines below are the ones it does NOT cover.
+    location / {
+        proxy_pass http://127.0.0.1:18456;
+        include    /etc/nginx/proxy_vexa.conf;
+
+        # Never let nginx's own gzip filter sit in front of an event stream: it buffers to fill a
+        # compression window, which reintroduces exactly the stall the setting above removes.
+        gzip off;
+        # No response chunk may wait on a nginx-side buffer boundary either.
+        proxy_request_buffering off;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name dogfood.dev.vexa.ai;
+
+    ssl_certificate     /etc/letsencrypt/live/dev.vexa.ai-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dev.vexa.ai-0001/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:15400;
+        include    /etc/nginx/proxy_vexa.conf;
+    }
+}
+
+server {
+    listen 80;
+    server_name mcp.dev.vexa.ai dogfood.dev.vexa.ai;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
First of a stacked pair. This one is the harness plus the MCP-surface fixes it immediately surfaced; [the follow-up](https://github.com/Vexa-ai/vexa/pulls) adds annotate/search on top.

## Why a stack

`core/meetings/services/mcp/tests/` proves the app in-process against a faked gateway. That is the right test and it cannot answer what an MCP client asks: **does the transport work through the proxy chain, with a real key, against a real gateway?**

`deploy/dogfood/` answers that. It drives the **stock** `deploy/compose` stack with a `.env` — no overlay, no fork — because a dogfooding stack that differs structurally from what users run stops being evidence about what users run. Ports are offset so it coexists with a release-train stack; `make up` refuses to start while `CHANGE-ME` remains, and never builds (published tags only).

`bin/mcp-validate` reports two families:
- **CONFORMANCE** — initialize · exact tool set · prompts · a pure call · a real gateway call · fail-closed on a bogus key. Governs the exit code.
- **NATIVE-READY** — RFC 9728 metadata · the 401 `WWW-Authenticate` challenge · AS metadata. Expected to fail today; printed as a measured distance to a real connector rather than hidden.

## What it found within the hour

**1. The tool surface could not be chained.** Every tool *returns* `platform` + `native_meeting_id`; three tools *accepted* `meeting_platform` + `meeting_id`. A model reads `native_meeting_id` off one result and passes it to the next tool — the correct inference, and it failed. Reproduced by a reader who had just read the service README. Canonical names now match the outputs everywhere; old spellings stay as deprecated aliases so no client breaks.

**2. `Input validation error: 'meeting_id' is a required property`** named neither the tool nor what was sent. Errors now name the tool, echo the parameters received, and point at the near-miss.

**3. `initialize` shipped `instructions: None`.** A connecting client had nine tool descriptions and no map. It now gets the canonical flow, the identity rule, and the one gotcha that otherwise reads as a bug — `active` + zero segments means the bot is not admitted yet, not that transcription is broken.

**4. Following a live meeting re-downloaded the whole transcript every poll**, burning caller context linearly in meeting length. `get_meeting_transcript` takes `since_index` and reports `total_segments`/`next_index` against the full transcript, so a caller can tell "nothing new" from "nothing at all" and can resume after losing its own state.

## Verified

Live on a real Google Meet with a real bot and real transcription (English + Russian), through nginx and TLS. The `GET /mcp` SSE leg survives the proxy — headers immediately, stream held open, no manufactured 503 (`#795` not happening), which is why the vhost adds `gzip off` on top of the shared include.

A cold-start agent given only the endpoint and a key — no Vexa knowledge, no repo access — completed 4 of 5 tasks and rated the surface 8/10, singling out the `instructions` gotcha line. Its remaining findings are addressed in the follow-up PR.

## Not in scope

No OAuth. The native-ready checks stay red until that lands; `--require-native` flips them binding when it does.

<!-- vexa-agent -->