### PR TITLE
[BUSINESS] MCP: annotate, query and search — make meeting data something an agent can build on

### DIFF
--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -113,6 +113,7 @@ ROUTE_SCOPES: Dict[Tuple[str, str], FrozenSet[str]] = {
     ("PATCH", "/meetings/{platform}/{native_meeting_id}"): TX,
     ("DELETE", "/meetings/{platform}/{native_meeting_id}"): TX,
     ("PUT", "/meetings/{platform}/{native_meeting_id}/intent"): TX,
+    ("POST", "/meetings/{platform}/{native_meeting_id}/annotate"): TX,
     ("POST", "/meetings/{platform}/{native_meeting_id}/share"): TX,
     ("POST", "/meetings/{platform}/{native_meeting_id}/workspace"): TX,
     # A participants read is meeting DATA, not bot control — same plane as the transcript it is
@@ -631,6 +632,14 @@ def create_app(
     # User-owned scheduling intent (schedule/cancel) — the Meetings surface's Schedule/Cancel action
     # PUTs here; forwards to meeting-api's PUT /meetings/{platform}/{native}/intent (owner-scoped).
     # Mint an INDEPENDENT transcript share link for a meeting (owner) — Lane A / M0.
+    # The caller's own description of a meeting — title + arbitrary metadata — writable in ANY
+    # status (meeting-api refuses nothing here; nothing in the dispatch pipeline reads it).
+    @app.post("/meetings/{platform}/{native_meeting_id}/annotate")
+    async def annotate_meeting(platform: str, native_meeting_id: str, request: Request):
+        return await _forward(
+            "POST", _meeting(f"/meetings/{platform}/{native_meeting_id}/annotate"), request
+        )
+
     @app.post("/meetings/{platform}/{native_meeting_id}/share")
     async def mint_transcript_share(platform: str, native_meeting_id: str, request: Request):
         return await _forward("POST", _meeting(f"/meetings/{platform}/{native_meeting_id}/share"), request)

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -121,6 +121,7 @@ ROUTE_SCOPES: Dict[Tuple[str, str], FrozenSet[str]] = {
     ("GET", "/meetings/{platform}/{native_meeting_id}/participants"): TX,
     # --- transcripts ---
     ("GET", "/transcripts/by-id/{meeting_id}"): TX,
+    ("GET", "/transcripts/search"): TX,
     ("GET", "/transcripts/{platform}/{native_meeting_id}"): TX,
     ("POST", "/transcripts/{platform}/{native_meeting_id}/share"): TX,
     ("POST", "/transcripts/share/accept"): TX,
@@ -567,6 +568,12 @@ def create_app(
     @app.post("/transcripts/{platform}/{native_meeting_id}/share")
     async def mint_transcript_share_alias(platform: str, native_meeting_id: str, request: Request):
         return await _forward("POST", _meeting(f"/meetings/{platform}/{native_meeting_id}/share"), request)
+
+    # Declared BEFORE /transcripts/{platform}/... so `search` is matched as a literal, not
+    # captured as a platform name.
+    @app.get("/transcripts/search")
+    async def search_transcripts(request: Request):
+        return await _forward("GET", _meeting("/transcripts/search"), request)
 
     @app.get("/transcripts/{platform}/{native_meeting_id}")
     async def transcript(platform: str, native_meeting_id: str, request: Request):

--- a/core/gateway/services/gateway/tests/test_scope_matrix.py
+++ b/core/gateway/services/gateway/tests/test_scope_matrix.py
@@ -50,6 +50,8 @@ CASES = [
     ("DELETE", "/meetings/google_meet/abc-defg-hij", "/meetings/{platform}/{native_meeting_id}"),
     ("PUT", "/meetings/google_meet/abc-defg-hij/intent",
      "/meetings/{platform}/{native_meeting_id}/intent"),
+    ("POST", "/meetings/google_meet/abc-defg-hij/annotate",
+     "/meetings/{platform}/{native_meeting_id}/annotate"),
     ("POST", "/meetings/google_meet/abc-defg-hij/share",
      "/meetings/{platform}/{native_meeting_id}/share"),
     ("POST", "/meetings/google_meet/abc-defg-hij/workspace",

--- a/core/gateway/services/gateway/tests/test_scope_matrix.py
+++ b/core/gateway/services/gateway/tests/test_scope_matrix.py
@@ -46,6 +46,7 @@ CASES = [
     ("GET", "/meetings/42", "/meetings/{meeting_id}"),
     ("PATCH", "/meetings/42", "/meetings/{meeting_id}"),
     ("DELETE", "/meetings/42", "/meetings/{meeting_id}"),
+    ("GET", "/transcripts/search", "/transcripts/search"),
     ("PATCH", "/meetings/google_meet/abc-defg-hij", "/meetings/{platform}/{native_meeting_id}"),
     ("DELETE", "/meetings/google_meet/abc-defg-hij", "/meetings/{platform}/{native_meeting_id}"),
     ("PUT", "/meetings/google_meet/abc-defg-hij/intent",

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -87,8 +87,8 @@ def _description_of(data: "ReportIssue") -> str:
     parts = [f"What I tried:\n{data.what_i_tried}", f"What happened:\n{data.what_happened}"]
     where = data.deployment + (f" {data.version}" if data.version else "")
     parts.append(f"Deployment: {where}")
-    if data.meeting_id:
-        parts.append(f"Meeting: {data.platform or 'unknown platform'} / {data.meeting_id}")
+    if data.native_meeting_id:
+        parts.append(f"Meeting: {data.platform or 'unknown platform'} / {data.native_meeting_id}")
     if data.logs:
         parts.append(f"Logs:\n{data.logs}")
     return "\n\n".join(parts)
@@ -137,8 +137,8 @@ def _github_issue_body(payload: Dict[str, Any]) -> str:
     lines.append(str(payload.get("what_happened") or "—"))
     lines.append("")
     lines.append("### Join key")
-    if payload.get("meeting_id"):
-        lines.append(f"- **meeting_id:** `{payload['meeting_id']}`")
+    if payload.get("native_meeting_id"):
+        lines.append(f"- **native_meeting_id:** `{payload['native_meeting_id']}`")
         lines.append(f"- **platform:** `{payload.get('platform') or 'unknown'}`")
         entity = payload.get("entity")
         if isinstance(entity, dict):
@@ -351,7 +351,7 @@ class ReportIssue(BaseModel):
             "plus the version if you know it (e.g. 'self-hosted 0.12.3')."
         ),
     )
-    meeting_id: Optional[str] = Field(
+    native_meeting_id: Optional[str] = Field(
         None,
         description=(
             "The native meeting id this issue concerns (e.g. 'abc-defg-hij'). Include it whenever "
@@ -402,7 +402,7 @@ class ReportIssue(BaseModel):
         self.what_i_tried = _clip(self.what_i_tried, _MAX_TEXT_CHARS)
         self.what_happened = _clip(self.what_happened, _MAX_TEXT_CHARS)
         self.deployment = _clip(self.deployment, 200)
-        self.meeting_id = _clip(self.meeting_id, 200)
+        self.native_meeting_id = _clip(self.native_meeting_id, 200)
         self.platform = _clip(self.platform, 50)
         self.version = _clip(self.version, 100)
         self._logs_truncated = bool(self.logs and len(self.logs.strip()) > _MAX_LOGS_CHARS)
@@ -828,17 +828,20 @@ def create_app(
         data: AnnotateMeeting,
         native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
         platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
-        replace: bool = Query(False, description="Replace the whole metadata object instead of merging."),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
         Set the meeting's title and/or attach arbitrary metadata to it. Works DURING a live meeting
         and after it has ended.
 
-        `metadata` is your own JSON — a CRM id, a ticket, tags, your own summary, anything. It
-        merges key-wise (send a key as null to delete it; pass replace=true to swap the whole
-        object), and you can find those meetings again with
-        `list_meetings(metadata_filter={"your_key": "your_value"})`.
+        `metadata` is your own JSON — a CRM id, a ticket, tags, your own summary, anything.
+        It always MERGES key-wise, and sending a key as null deletes exactly that key. You can
+        only ever affect keys you name: other agents and the human may have written annotations
+        here that you cannot see, and nothing you send can destroy them.
+
+        Find these meetings again with
+        `list_meetings(metadata_filter='{"your_key":"your_value"}')` — note the filter is a JSON
+        STRING, not an object.
         """
         plat, mid = _resolve_identity("annotate_meeting", platform, native_meeting_id, None, None)
         body: Dict[str, Any] = {}
@@ -846,10 +849,7 @@ def create_app(
             body["title"] = data.title
         if data.metadata is not None:
             body["metadata"] = data.metadata
-        return await make_request(
-            "POST", f"{base_url}/meetings/{plat}/{mid}/annotate", api_key, body,
-            params={"replace": "true"} if replace else None,
-        )
+        return await make_request("POST", f"{base_url}/meetings/{plat}/{mid}/annotate", api_key, body)
 
     # --- the interactive bot: our bot TALKS and reads the room ------------------------------
     # No notetaker MCP exposes this, because no notetaker has it: their bot is a recorder. Ours is
@@ -930,7 +930,7 @@ def create_app(
         Write what you tried and what happened in your own words. Do not paste API keys, and do not
         paste your user's meeting content.
 
-        If the issue concerns a meeting or a bot, include `meeting_id` and `platform`. That is the
+        If the issue concerns a meeting or a bot, include `native_meeting_id` and `platform`. That is the
         join key: it lines your account of what happened up against our own record of the same
         meeting, which is the difference between a complaint and something we can diagnose. The
         meeting is resolved onto the ticket only if the key you are calling with owns it.
@@ -992,20 +992,20 @@ def create_app(
         # still files the ticket (with the id quoted as text, entity null), because a ticket we
         # refused to accept teaches us nothing.
         entity: Optional[Dict[str, Any]] = None
-        if data.meeting_id:
+        if data.native_meeting_id:
             rows = meetings if isinstance(meetings, list) else (meetings or {}).get("meetings", [])
             for m in rows if isinstance(rows, list) else []:
                 if not isinstance(m, dict):
                     continue
-                if m.get("native_meeting_id") != data.meeting_id:
+                if m.get("native_meeting_id") != data.native_meeting_id:
                     continue
                 if data.platform and m.get("platform") != data.platform:
                     continue
                 entity = {
                     "type": "meeting",
-                    "id": data.meeting_id,
+                    "id": data.native_meeting_id,
                     "platform": m.get("platform"),
-                    "url": f"/transcripts/{m.get('platform')}/{data.meeting_id}",
+                    "url": f"/transcripts/{m.get('platform')}/{data.native_meeting_id}",
                 }
                 break
 
@@ -1029,7 +1029,7 @@ def create_app(
             "deployment": data.deployment,
             "version": data.version,
             "severity": data.severity,
-            "meeting_id": data.meeting_id,
+            "native_meeting_id": data.native_meeting_id,
             "platform": data.platform,
             "entity": entity,
             "logs": data.logs,

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -783,6 +783,41 @@ def create_app(
                     result["since_index"] = start
         return result
 
+    @app.get("/transcript-search", operation_id="search_transcripts")
+    async def search_transcripts(
+        q: str = Query(..., min_length=1, description=(
+            'What was said. Supports "quoted phrases", `or`, and `-excluded` terms. '
+            "Malformed input never errors, so you can pass a user's words through as-is."
+        )),
+        limit: int = Query(20, ge=1, le=100, description="Max hits (default 20)."),
+        offset: int = Query(0, ge=0),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        native_meeting_id: Optional[str] = Query(
+            None, description="Restrict the search to ONE meeting. " + _ID_DESC
+        ),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        Search what was SAID across your meetings. Use this instead of pulling transcripts and
+        reading them — it returns ranked snippets, not whole transcripts.
+
+        Each hit carries the meeting's `platform` + `native_meeting_id`, the speaker, the
+        timestamp, and a snippet with the match wrapped in <mark> tags. Feed those identity fields
+        straight into get_meeting_transcript when you need the full context around a hit.
+
+        This is lexical search with stemming, not semantic: "renewal" finds "renewals" but will
+        NOT find "extend the contract". Search the words people actually said.
+
+        Related but different: list_meetings(metadata_filter=...) finds meetings you TAGGED;
+        this finds meetings where something was SAID.
+        """
+        params: Dict[str, Any] = {"q": q, "limit": limit, "offset": offset}
+        if platform:
+            params["platform"] = platform
+        if native_meeting_id:
+            params["native_meeting_id"] = native_meeting_id
+        return await make_request("GET", f"{base_url}/transcripts/search", api_key, params=params)
+
     # --- annotations: the caller's OWN description of a meeting -----------------------------
     # This is the join key between a Vexa meeting and everything else the agent knows. Without it
     # an agent can read a transcript and can do nothing with the fact afterwards: there is nowhere

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -18,6 +18,7 @@ conformance tests drive the SHIPPED app in-process with a fake gateway — the r
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -296,6 +297,31 @@ class UpdateBotConfig(BaseModel):
     language: str = Field(..., description="New language code for transcription (e.g., 'en', 'es')")
 
 
+class AnnotateMeeting(BaseModel):
+    title: Optional[str] = Field(
+        None, description="Human-readable title for the meeting. Max 512 chars."
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Arbitrary JSON you own — CRM ids, ticket refs, tags, your own summary. Merges "
+            "key-wise with what is already there; send a key as null to delete just that key. "
+            "Retrieve these meetings later with list_meetings(metadata_filter=...)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_something_to_write(self):
+        if self.title is None and self.metadata is None:
+            raise ValueError("Nothing to annotate: provide title and/or metadata.")
+        return self
+
+
+class SpeakInMeeting(BaseModel):
+    text: str = Field(..., description="What the bot should say out loud in the meeting.")
+    language: Optional[str] = Field(None, description="Optional language/voice code, e.g. 'en'.")
+
+
 class ParseMeetingLinkRequest(BaseModel):
     meeting_url: str = Field(..., description="Full meeting URL to parse.")
 
@@ -445,6 +471,17 @@ The canonical flow:
 
 Identity: every tool returns `platform` + `native_meeting_id`, and every tool accepts those same \
 two names. Feed one tool's output straight into the next.
+
+Make the data yours: annotate_meeting attaches a title and arbitrary metadata — a CRM id, a \
+ticket, tags, your own summary — to a meeting, DURING it or after it ended. Anything you put \
+there you can find again with list_meetings(metadata_filter={...}), searched in the database \
+rather than on one page. If you learn something durable about a meeting, write it back; that is \
+what lets the next agent (or the next you) pick it up.
+
+The bot is a PARTICIPANT, not just a recorder: get_meeting_chat reads the in-call chat, and \
+speak_in_meeting says something out loud to everyone present. Speaking is irreversible and \
+visible to real people — do it only when the person you work for asked you to say that thing, \
+never to test and never on your own initiative.
 
 A meeting with status `active` and zero segments usually means the bot has not been admitted yet, \
 or nobody has spoken — it does not mean transcription is broken.
@@ -654,10 +691,21 @@ def create_app(
         offset: Optional[int] = Query(0, ge=0, description="Number of meetings to skip"),
         status: Optional[str] = Query(None, description="Filter by status: active, completed, failed"),
         platform: Optional[str] = Query(None, description="Filter by platform: google_meet, teams, zoom"),
+        metadata_filter: Optional[str] = Query(
+            None,
+            description=(
+                'JSON object — return only meetings whose metadata (set via annotate_meeting) '
+                'CONTAINS it, e.g. {"crm_deal":"acme-42"}. Extra keys on the meeting still match. '
+                "Filtered in the database, so this searches your whole history, not just one page."
+            ),
+        ),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
-        List meetings associated with your API key (pagination + status/platform filters).
+        List meetings associated with your API key (pagination + status/platform/metadata filters).
+
+        `metadata_filter` is what makes this a query rather than a log: meetings you annotated with
+        annotate_meeting can be found again by the values you put on them.
         """
         params: Dict[str, Any] = {}
         if limit is not None:
@@ -668,6 +716,23 @@ def create_app(
             params["status"] = status
         if platform:
             params["platform"] = platform
+        if metadata_filter:
+            # Validate here so a malformed filter is a clear tool error rather than a gateway 422
+            # the agent has to decode. A filter that silently failed to apply would be worse than
+            # an error: the agent would read a full unfiltered list as "these all match".
+            try:
+                parsed = json.loads(metadata_filter)
+            except (TypeError, ValueError):
+                raise HTTPException(
+                    status_code=422,
+                    detail="list_meetings: 'metadata_filter' must be a JSON object string, e.g. {\"crm_deal\":\"acme-42\"}",
+                )
+            if not isinstance(parsed, dict):
+                raise HTTPException(
+                    status_code=422,
+                    detail="list_meetings: 'metadata_filter' must be a JSON OBJECT, not a bare value or array.",
+                )
+            params["metadata"] = metadata_filter
         return await make_request("GET", f"{base_url}/meetings", api_key, params=params or None)
 
     @app.get("/meeting-transcript", operation_id="get_meeting_transcript")
@@ -717,6 +782,75 @@ def create_app(
                 if since_index is not None:
                     result["since_index"] = start
         return result
+
+    # --- annotations: the caller's OWN description of a meeting -----------------------------
+    # This is the join key between a Vexa meeting and everything else the agent knows. Without it
+    # an agent can read a transcript and can do nothing with the fact afterwards: there is nowhere
+    # to record that this meeting is the Acme renewal, nowhere to keep its own summary, and so no
+    # way to find the meeting again by anything other than its platform id.
+    @app.post("/meeting-annotate", operation_id="annotate_meeting")
+    async def annotate_meeting(
+        data: AnnotateMeeting,
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        replace: bool = Query(False, description="Replace the whole metadata object instead of merging."),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        Set the meeting's title and/or attach arbitrary metadata to it. Works DURING a live meeting
+        and after it has ended.
+
+        `metadata` is your own JSON — a CRM id, a ticket, tags, your own summary, anything. It
+        merges key-wise (send a key as null to delete it; pass replace=true to swap the whole
+        object), and you can find those meetings again with
+        `list_meetings(metadata_filter={"your_key": "your_value"})`.
+        """
+        plat, mid = _resolve_identity("annotate_meeting", platform, native_meeting_id, None, None)
+        body: Dict[str, Any] = {}
+        if data.title is not None:
+            body["title"] = data.title
+        if data.metadata is not None:
+            body["metadata"] = data.metadata
+        return await make_request(
+            "POST", f"{base_url}/meetings/{plat}/{mid}/annotate", api_key, body,
+            params={"replace": "true"} if replace else None,
+        )
+
+    # --- the interactive bot: our bot TALKS and reads the room ------------------------------
+    # No notetaker MCP exposes this, because no notetaker has it: their bot is a recorder. Ours is
+    # a participant, so an agent connected here can answer a question out loud in the meeting it is
+    # listening to. These wrap gateway routes that already exist and were simply unreachable.
+    @app.post("/meeting-speak", operation_id="speak_in_meeting")
+    async def speak_in_meeting(
+        data: SpeakInMeeting,
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        SPEAK OUT LOUD in a live meeting through the Vexa bot. Everyone in the meeting hears it.
+
+        This is an irreversible, human-visible action in a real conversation — never call it to
+        test, to acknowledge, or on your own initiative. Say something only when the person you are
+        working for has asked you to say that thing.
+        """
+        plat, mid = _resolve_identity("speak_in_meeting", platform, native_meeting_id, None, None)
+        return await make_request(
+            "POST", f"{base_url}/bots/{plat}/{mid}/speak", api_key, data.model_dump(exclude_none=True)
+        )
+
+    @app.get("/meeting-chat", operation_id="get_meeting_chat")
+    async def get_meeting_chat(
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        Read the meeting's in-call chat messages. Complements the transcript: links, spellings and
+        side comments land in chat and are never spoken aloud.
+        """
+        plat, mid = _resolve_identity("get_meeting_chat", platform, native_meeting_id, None, None)
+        return await make_request("GET", f"{base_url}/bots/{plat}/{mid}/chat", api_key)
 
     @app.get("/recordings", operation_id="list_recordings")
     async def list_recordings(

--- a/core/meetings/services/mcp/src/vexa_mcp/identity.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/identity.py
@@ -1,0 +1,122 @@
+"""The meeting-identity vocabulary — ONE name per concept, declared as data so a test can enforce it.
+
+## Why this file exists
+
+The MCP surface shipped three tools that ACCEPTED ``meeting_platform`` + ``meeting_id`` while every
+tool RETURNED ``platform`` + ``native_meeting_id``. No tool's output could be fed into the next
+tool's input, which is the one thing a model chaining calls will always try. That was found by a
+reader who had just read the service README, and fixed.
+
+**Hours later the same defect was reintroduced** — a new ``search_transcripts`` tool returned
+``meeting_id`` holding the INTEGER row id, colliding with the deprecated alias for the NATIVE
+STRING id. Feeding that tool's own output into ``get_meeting_transcript`` produced
+``404 Meeting not found for platform google_meet and ID 1``.
+
+Two occurrences in one day, by the same author, with the rule written down in between. The
+conclusion is not "be more careful": a convention that lives only in prose and review is enforced
+by nobody at 3am, and the failure is silent — every field is individually reasonable, and only the
+JOIN between two tools is wrong. So the vocabulary is declared here as DATA and asserted by
+``tests/test_identity_vocabulary.py`` against the surface the server actually emits.
+
+## The vocabulary
+
+Three concepts, three names, and they never overlap:
+
+===================  =======  ===============================================================
+name                 type     what it is
+===================  =======  ===============================================================
+``platform``         str      the meeting platform: google_meet | teams | zoom | jitsi
+``native_meeting_id``str      the PLATFORM's own id — "abc-defg-hij", "9361792952021"
+``meeting_db_id``    int      VEXA's internal row id. Never the platform's.
+===================  =======  ===============================================================
+
+``meeting_id`` is **not** in that table, deliberately: it is the name that meant all three at
+different times, so it is retired as a concept. It survives only as a deprecated INPUT alias.
+
+## The two rules a name must satisfy
+
+1. **A deprecated alias may appear only as an INPUT, only alongside its canonical name, and only
+   when its description says DEPRECATED.** A tool that accepts an alias without the canonical name
+   forces callers onto the old vocabulary; one that does not mark it teaches the old vocabulary.
+2. **A deprecated alias may NEVER appear in an OUTPUT.** This is the rule the search regression
+   broke. Outputs are what the next call is built from, so an ambiguous output name is the bug —
+   it is what turns "feed one tool's output into the next" from a promise into a 404.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+#: concept -> the JSON type it always has. Nothing else may carry these names.
+CANONICAL_IDENTITY: Dict[str, str] = {
+    "platform": "string",
+    "native_meeting_id": "string",
+    "meeting_db_id": "integer",
+}
+
+#: retired name -> what to use instead. Accepted on input for backwards compatibility; never emitted.
+DEPRECATED_ALIASES: Dict[str, str] = {
+    "meeting_id": "native_meeting_id",
+    "meeting_platform": "platform",
+}
+
+
+def check_tool_inputs(tools: List[Dict[str, Any]]) -> List[str]:
+    """Rule 1 over an MCP ``tools/list`` payload. Returns human-readable violations."""
+    violations: List[str] = []
+    for tool in tools:
+        name = tool.get("name", "?")
+        props = (tool.get("inputSchema", {}) or {}).get("properties", {}) or {}
+        for alias, canonical in DEPRECATED_ALIASES.items():
+            if alias not in props:
+                continue
+            if canonical not in props:
+                violations.append(
+                    f"{name}: accepts deprecated `{alias}` but NOT canonical `{canonical}` — "
+                    f"a caller feeding another tool's output has nowhere to put it"
+                )
+            description = (props[alias].get("description") or "").upper()
+            if "DEPRECATED" not in description:
+                violations.append(
+                    f"{name}: `{alias}` is not marked DEPRECATED in its description, so the schema "
+                    f"teaches the retired name as if it were current (use `{canonical}`)"
+                )
+    return violations
+
+
+def check_output_names(tool_name: str, payload: Any) -> List[str]:
+    """Rule 2 against a tool's actual RETURNED payload. Recurses into dicts and lists.
+
+    Checks the alias names AND the types of the canonical ones — the search regression emitted a
+    correctly-spelled name carrying the wrong kind of value, which a name-only check would pass.
+    """
+    violations: List[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, list):
+            for item in node[:5]:            # a page is homogeneous; five is plenty
+                walk(item, f"{path}[]")
+            return
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            here = f"{path}.{key}" if path else key
+            if key in DEPRECATED_ALIASES:
+                violations.append(
+                    f"{tool_name}: returns `{here}` — a deprecated alias must never be EMITTED "
+                    f"(use `{DEPRECATED_ALIASES[key]}`); an ambiguous output name is what makes "
+                    f"the next call fail"
+                )
+            elif key in CANONICAL_IDENTITY and value is not None:
+                expected = CANONICAL_IDENTITY[key]
+                actual = "integer" if isinstance(value, int) and not isinstance(value, bool) else (
+                    "string" if isinstance(value, str) else type(value).__name__
+                )
+                if actual != expected:
+                    violations.append(
+                        f"{tool_name}: `{here}` is {actual} but `{key}` is always {expected} "
+                        f"({value!r}) — the same name must not carry two kinds of value"
+                    )
+            walk(value, here)
+
+    walk(payload, "")
+    return violations

--- a/core/meetings/services/mcp/tests/test_app.py
+++ b/core/meetings/services/mcp/tests/test_app.py
@@ -677,3 +677,72 @@ def test_github_format_still_never_forwards_the_api_key(client, gateway: FakeGat
     req = _sink_requests(gateway)[-1]
     assert API_KEY not in req.content.decode()
     assert API_KEY not in json.dumps(dict(req.headers))
+
+
+# --- annotations: the caller's own description of a meeting ------------------
+# The join key between a Vexa meeting and everything else the agent knows. Previously impossible:
+# PATCH /meetings answered 409 for the entire useful life of a meeting (once a bot was dispatched),
+# and there was no metadata field at all.
+
+def test_annotate_forwards_title_and_metadata(client, gateway, auth):
+    r = client.post(
+        "/meeting-annotate?platform=google_meet&native_meeting_id=abc-defg-hij",
+        headers=auth,
+        json={"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}},
+    )
+    assert r.status_code == 200
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("POST", "/meetings/google_meet/abc-defg-hij/annotate")
+    assert gateway.last_json() == {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}}
+
+
+def test_annotate_replace_is_forwarded_as_a_query_flag(client, gateway, auth):
+    client.post(
+        "/meeting-annotate?native_meeting_id=abc-defg-hij&replace=true",
+        headers=auth, json={"metadata": {"only": "this"}},
+    )
+    assert dict(gateway.requests[-1].url.params) == {"replace": "true"}
+
+
+def test_annotate_requires_something_to_write(client, gateway, auth):
+    r = client.post("/meeting-annotate?native_meeting_id=abc-defg-hij", headers=auth, json={})
+    assert r.status_code == 422
+
+
+def test_list_meetings_forwards_metadata_filter(client, gateway, auth):
+    client.get('/meetings?metadata_filter={"crm_deal":"acme-42"}', headers=auth)
+    assert dict(gateway.requests[-1].url.params)["metadata"] == '{"crm_deal":"acme-42"}'
+
+
+def test_list_meetings_rejects_a_malformed_metadata_filter(client, gateway, auth):
+    """A filter that silently failed to apply is WORSE than an error: the agent would read a full
+    unfiltered list as 'these all match'."""
+    before = len(gateway.requests)
+    r = client.get("/meetings?metadata_filter=not-json", headers=auth)
+    assert r.status_code == 422
+    assert "metadata_filter" in str(r.json()["detail"])
+    assert len(gateway.requests) == before, "must not reach the gateway with a bad filter"
+
+
+def test_list_meetings_rejects_a_non_object_metadata_filter(client, gateway, auth):
+    r = client.get("/meetings?metadata_filter=[1,2]", headers=auth)
+    assert r.status_code == 422
+
+
+# --- the interactive bot: ours talks, theirs records -------------------------
+
+def test_speak_forwards_to_the_bot_speak_route(client, gateway, auth):
+    r = client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth, json={"text": "Dmitry asked me to say the numbers are in the deck."},
+    )
+    assert r.status_code == 200
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("POST", "/bots/teams/9361792952021/speak")
+    assert gateway.last_json()["text"].startswith("Dmitry asked me")
+
+
+def test_get_meeting_chat_path(client, gateway, auth):
+    client.get("/meeting-chat?native_meeting_id=abc-defg-hij", headers=auth)
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("GET", "/bots/google_meet/abc-defg-hij/chat")

--- a/core/meetings/services/mcp/tests/test_app.py
+++ b/core/meetings/services/mcp/tests/test_app.py
@@ -251,7 +251,7 @@ TICKET = {
     "what_i_tried": "POST /bots for a google_meet room via the MCP request_meeting_bot tool",
     "what_happened": "The bot never appeared in the meeting and bot-status stayed empty for 3 min",
     "deployment": "self-hosted 0.12.3",
-    "meeting_id": "abc-defg-hij",
+    "native_meeting_id": "abc-defg-hij",
     "platform": "google_meet",
     "logs": "RuntimeError: admission timeout",
 }
@@ -270,9 +270,9 @@ def test_report_issue_without_sink_returns_503(client, gateway, auth, monkeypatc
 
 
 # Filing spends the OPERATOR's sink credential, so the caller's own credential is checked first.
-# The ticket carrying no meeting_id is the case that matters: it is the one with no other reason
+# The ticket carrying no native_meeting_id is the case that matters: it is the one with no other reason
 # to touch the gateway, so it is the one an unvalidated key would ride through.
-TICKET_NO_MEETING = {k: v for k, v in TICKET.items() if k not in ("meeting_id", "platform")}
+TICKET_NO_MEETING = {k: v for k, v in TICKET.items() if k not in ("native_meeting_id", "platform")}
 
 
 def test_report_issue_refuses_a_credential_the_gateway_rejects(client, gateway: FakeGateway, auth, monkeypatch):
@@ -303,7 +303,7 @@ def test_report_issue_files_a_ticket_that_names_no_meeting(client, gateway: Fake
 
     assert r.status_code == 200
     body = json.loads(_sink_requests(gateway)[-1].content)
-    assert body["meeting_id"] is None
+    assert body["native_meeting_id"] is None
     assert body["entity"] is None
 
 
@@ -320,7 +320,7 @@ def test_report_issue_forwards_ticket_to_sink(client, gateway: FakeGateway, auth
     assert body["what_happened"] == TICKET["what_happened"]
     assert body["deployment"] == "self-hosted 0.12.3"
     # the join key onto the cluster's own record of the same meeting
-    assert body["meeting_id"] == "abc-defg-hij"
+    assert body["native_meeting_id"] == "abc-defg-hij"
     assert body["platform"] == "google_meet"
     assert body["logs"] == "RuntimeError: admission timeout"
     assert body["logs_truncated"] is False
@@ -439,10 +439,10 @@ def test_report_issue_sink_failure_surfaces_as_502(client, gateway: FakeGateway,
     assert "sink rejected" in str(r.json()["detail"])
 
 
-def test_report_issue_without_meeting_id_still_authenticates_the_caller(client, gateway: FakeGateway, auth, monkeypatch):
+def test_report_issue_without_native_meeting_id_still_authenticates_the_caller(client, gateway: FakeGateway, auth, monkeypatch):
     """With no entity to resolve there is still a credential to check, and it is checked once."""
     monkeypatch.setenv("VEXA_TICKET_SINK_URL", SINK_URL)
-    payload = {k: v for k, v in TICKET.items() if k not in ("meeting_id", "platform")}
+    payload = {k: v for k, v in TICKET.items() if k not in ("native_meeting_id", "platform")}
     client.post("/report-issue", headers=auth, json=payload)
     hops = [r for r in gateway.requests if r.url.host == "gateway.test"]
     assert [(r.method, r.url.path) for r in hops] == [("GET", "/meetings")]
@@ -472,7 +472,7 @@ def test_report_issue_resolves_entity_only_for_a_meeting_the_caller_owns(
     assert json.loads(_sink_requests(gateway)[-1].content)["entity"]["id"] == "abc-defg-hij"
 
 
-def test_report_issue_unowned_meeting_id_files_without_an_entity(client, gateway: FakeGateway, auth, monkeypatch):
+def test_report_issue_unowned_native_meeting_id_files_without_an_entity(client, gateway: FakeGateway, auth, monkeypatch):
     """A quoted id the caller does not own is text, never a resolved join — and never fatal.
 
     The gateway answers with the caller's OWN meetings, so an id belonging to someone else is
@@ -480,12 +480,12 @@ def test_report_issue_unowned_meeting_id_files_without_an_entity(client, gateway
     """
     monkeypatch.setenv("VEXA_TICKET_SINK_URL", SINK_URL)
     gateway.routes[("GET", "/meetings")] = (200, [{"native_meeting_id": "mine", "platform": "google_meet"}])
-    r = client.post("/report-issue", headers=auth, json={**TICKET, "meeting_id": "someone-elses"})
+    r = client.post("/report-issue", headers=auth, json={**TICKET, "native_meeting_id": "someone-elses"})
     assert r.status_code == 200
     assert r.json()["entity"] is None
     body = json.loads(_sink_requests(gateway)[-1].content)
     assert body["entity"] is None
-    assert body["meeting_id"] == "someone-elses"     # quoted, not resolved
+    assert body["native_meeting_id"] == "someone-elses"     # quoted, not resolved
 
 
 def test_report_issue_meeting_absent_from_callers_meetings_does_not_resolve(
@@ -515,7 +515,7 @@ def test_report_issue_has_no_url_shaped_field_and_fetches_nothing(client, gatewa
 
     monkeypatch.setenv("VEXA_TICKET_SINK_URL", SINK_URL)
     poisoned = {
-        **{k: v for k, v in TICKET.items() if k not in ("meeting_id", "platform")},
+        **{k: v for k, v in TICKET.items() if k not in ("native_meeting_id", "platform")},
         "what_happened": "see http://169.254.169.254/latest/meta-data/ and file:///etc/passwd",
         "logs": "http://localhost:6379/ http://internal.svc/admin",
     }
@@ -582,7 +582,7 @@ def test_raw_is_the_default_and_is_byte_unchanged(client, gateway: FakeGateway, 
     assert set(body) == {
         "source", "tool", "reported_at", "fingerprint", "caller_fingerprint", "summary",
         "description", "what_i_tried", "what_happened", "deployment", "version", "severity",
-        "meeting_id", "platform", "entity", "logs", "logs_truncated",
+        "native_meeting_id", "platform", "entity", "logs", "logs_truncated",
     }
     assert req.headers["content-type"] == "application/json"
     assert req.headers["authorization"] == "Bearer sink-secret"
@@ -637,7 +637,7 @@ def test_github_body_calls_out_the_meeting_join_key(client, gateway: FakeGateway
 
 def test_github_body_states_when_no_meeting_was_supplied(client, gateway: FakeGateway, auth, monkeypatch):
     _gh(monkeypatch)
-    ticket = {k: v for k, v in TICKET.items() if k not in {"meeting_id", "platform"}}
+    ticket = {k: v for k, v in TICKET.items() if k not in {"native_meeting_id", "platform"}}
     client.post("/report-issue", headers=auth, json=ticket)
     md = json.loads(_sink_requests(gateway)[-1].content)["body"]
     assert "### Join key" in md
@@ -696,12 +696,14 @@ def test_annotate_forwards_title_and_metadata(client, gateway, auth):
     assert gateway.last_json() == {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}}
 
 
-def test_annotate_replace_is_forwarded_as_a_query_flag(client, gateway, auth):
+def test_annotate_never_forwards_a_replace_flag(client, gateway, auth):
+    """There is no whole-object replace. A caller sharing an account's API key must not be able to
+    destroy annotations written by another agent, or by the human, that it never saw."""
     client.post(
         "/meeting-annotate?native_meeting_id=abc-defg-hij&replace=true",
         headers=auth, json={"metadata": {"only": "this"}},
     )
-    assert dict(gateway.requests[-1].url.params) == {"replace": "true"}
+    assert "replace" not in dict(gateway.requests[-1].url.params)
 
 
 def test_annotate_requires_something_to_write(client, gateway, auth):

--- a/core/meetings/services/mcp/tests/test_identity_vocabulary.py
+++ b/core/meetings/services/mcp/tests/test_identity_vocabulary.py
@@ -1,0 +1,163 @@
+"""THE GATE — one name per concept, asserted against the surface the server actually emits.
+
+This file exists because the same defect shipped TWICE IN ONE DAY, by the same author, with the
+rule written down in between:
+
+  * morning — three tools ACCEPTED ``meeting_platform`` + ``meeting_id`` while every tool RETURNED
+    ``platform`` + ``native_meeting_id``, so no tool's output composed into the next tool's input.
+    Found by a reader who had just read the README. Fixed, and the fix was documented.
+  * hours later — a NEW ``search_transcripts`` tool RETURNED ``meeting_id`` holding the integer row
+    id, colliding with the deprecated alias for the native string id. Feeding that tool's own
+    output into ``get_meeting_transcript`` gave ``404 … and ID 1``.
+
+The lesson is not "read the docs more carefully". A naming convention enforced only by prose and
+review is enforced by nobody, and this failure is SILENT: every field is individually plausible
+and only the join between two tools is wrong, so nothing fails until a caller chains them.
+
+So the vocabulary is data (``vexa_mcp.identity``) and this asserts it mechanically. It runs over
+the DERIVED surface — the schemas FastAPI/FastApiMCP actually produce and the payloads the tools
+actually return — not over source, because the bug is emergent from that derivation.
+
+``instructions`` promises callers: *"every tool returns `platform` + `native_meeting_id`, and every
+tool accepts those same two names. Feed one tool's output straight into the next."* These tests
+are what make that a checkable claim instead of a hope.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from conftest import API_KEY
+from vexa_mcp import create_app
+from vexa_mcp.identity import (
+    CANONICAL_IDENTITY,
+    DEPRECATED_ALIASES,
+    check_output_names,
+    check_tool_inputs,
+)
+
+GATEWAY_URL = "http://gateway.test"
+
+
+def _tools(app):
+    """The MCP tool surface as a client receives it — derived, not declared."""
+    return [
+        {"name": name, "inputSchema": tool.inputSchema}
+        for name, tool in app.state.mcp.tools.items()
+    ] if isinstance(getattr(app.state.mcp, "tools", None), dict) else [
+        {"name": t.name, "inputSchema": t.inputSchema} for t in app.state.mcp.tools
+    ]
+
+
+@pytest.fixture
+def app():
+    return create_app(GATEWAY_URL, transport=httpx.MockTransport(
+        lambda r: httpx.Response(200, json={})))
+
+
+# ---- rule 1: a deprecated alias may appear only on INPUT, only beside its canonical name ----
+
+def test_no_tool_accepts_a_retired_name_without_its_replacement(app):
+    violations = check_tool_inputs(_tools(app))
+    assert not violations, (
+        "The identity vocabulary is broken on the tool INPUT surface:\n  - "
+        + "\n  - ".join(violations)
+        + "\n\nEvery tool that names a meeting must accept `platform` + `native_meeting_id` — the "
+          "exact field names the tools RETURN. A retired name may ride along as a deprecated alias, "
+          "but never alone and never unmarked."
+    )
+
+
+def test_the_canonical_names_are_actually_used_somewhere(app):
+    """Guards the guard: a vocabulary nothing uses would let every check above pass vacuously."""
+    names = {p for t in _tools(app) for p in (t["inputSchema"].get("properties") or {})}
+    assert {"platform", "native_meeting_id"} <= names
+
+
+# ---- rule 2: a deprecated alias may NEVER be emitted -----------------------------------
+
+def _payloads_from_gateway(monkeypatch_payload):
+    """Drive every read tool against a fake gateway returning a realistic identity-bearing body."""
+    return httpx.MockTransport(lambda r: httpx.Response(200, json=monkeypatch_payload))
+
+
+@pytest.mark.parametrize("payload,label", [
+    ({"meeting_id": 1, "platform": "google_meet"}, "integer meeting_id at the top level"),
+    ({"hits": [{"meeting_id": 7, "native_meeting_id": "abc-defg-hij"}]}, "meeting_id nested in a list"),
+    ({"meetings": [{"meeting_platform": "zoom"}]}, "meeting_platform nested in a list"),
+])
+def test_the_output_check_catches_a_retired_name(payload, label):
+    """The regression this file exists for, in miniature: these SHOULD be reported."""
+    violations = check_output_names("some_tool", payload)
+    assert violations, f"a retired name went unreported: {label}"
+
+
+@pytest.mark.parametrize("payload,label", [
+    ({"native_meeting_id": 7}, "native_meeting_id carrying an int"),
+    ({"meeting_db_id": "abc-defg-hij"}, "meeting_db_id carrying a string"),
+])
+def test_the_output_check_catches_a_canonical_name_with_the_wrong_kind_of_value(payload, label):
+    """The subtler half: a correctly-SPELLED name holding the wrong kind of value is exactly what
+    shipped — a name-only check would have passed it."""
+    assert check_output_names("some_tool", payload), f"type confusion went unreported: {label}"
+
+
+def test_a_clean_payload_reports_nothing():
+    clean = {"meetings": [{"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                           "meeting_db_id": 1, "title": "Acme renewal"}]}
+    assert check_output_names("some_tool", clean) == []
+
+
+def test_live_tool_outputs_carry_no_retired_names(app):
+    """The real gate: drive the tools and inspect what they actually hand back.
+
+    The MCP service forwards gateway bodies verbatim, so this catches a retired name introduced
+    EITHER here or upstream in meeting-api — which is where the search regression actually lived.
+    """
+    from fastapi.testclient import TestClient
+
+    # A gateway body shaped like the real one, using only canonical names. If a tool renames or
+    # re-wraps a field on the way out, the check sees it.
+    body = {
+        "meetings": [{"platform": "google_meet", "native_meeting_id": "abc-defg-hij", "id": 1}],
+        "hits": [{"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                  "meeting_db_id": 1, "speaker": "A", "snippet": "x"}],
+    }
+    client = TestClient(create_app(
+        GATEWAY_URL, transport=httpx.MockTransport(lambda r: httpx.Response(200, json=body))))
+    auth = {"Authorization": f"Bearer {API_KEY}"}
+
+    checked = 0
+    for path, params in [
+        ("/meetings", {}),
+        ("/transcript-search", {"q": "panel"}),
+        ("/meeting-transcript", {"native_meeting_id": "abc-defg-hij"}),
+        ("/bot-status", {}),
+        ("/recordings", {}),
+        ("/meeting-chat", {"native_meeting_id": "abc-defg-hij"}),
+    ]:
+        r = client.get(path, params=params, headers=auth)
+        if r.status_code != 200:
+            continue
+        checked += 1
+        violations = check_output_names(path, r.json())
+        assert not violations, (
+            "A tool EMITS a retired identity name — this is the defect that shipped twice:\n  - "
+            + "\n  - ".join(violations)
+            + "\n\nOutputs are what the next call is built from. An ambiguous output name is what "
+              "turns 'feed one tool's output into the next' into a 404."
+        )
+    assert checked >= 5, "too few tools exercised for this gate to mean anything"
+
+
+# ---- the vocabulary itself stays coherent ----------------------------------------------
+
+def test_no_alias_shadows_a_canonical_name():
+    assert not (set(DEPRECATED_ALIASES) & set(CANONICAL_IDENTITY)), (
+        "a retired name must not also be canonical — that is the ambiguity, not the fix"
+    )
+
+
+def test_every_alias_points_at_a_real_canonical_name():
+    for alias, canonical in DEPRECATED_ALIASES.items():
+        assert canonical in CANONICAL_IDENTITY, f"`{alias}` redirects to unknown `{canonical}`"

--- a/core/meetings/services/mcp/tests/test_mcp_surface.py
+++ b/core/meetings/services/mcp/tests/test_mcp_surface.py
@@ -1,4 +1,4 @@
-"""L1 — the MCP surface: the /mcp mount exists, exactly the 13 tools are exposed,
+"""L1 — the MCP surface: the /mcp mount exists, exactly the 14 tools are exposed,
 and the 4 prompts render."""
 import httpx
 import pytest
@@ -20,6 +20,7 @@ EXPECTED_TOOLS = {
     "annotate_meeting",
     "speak_in_meeting",
     "get_meeting_chat",
+    "search_transcripts",
 }
 
 

--- a/core/meetings/services/mcp/tests/test_mcp_surface.py
+++ b/core/meetings/services/mcp/tests/test_mcp_surface.py
@@ -1,4 +1,4 @@
-"""L1 — the MCP surface: the /mcp mount exists, exactly the 10 tools are exposed,
+"""L1 — the MCP surface: the /mcp mount exists, exactly the 13 tools are exposed,
 and the 4 prompts render."""
 import httpx
 import pytest
@@ -17,6 +17,9 @@ EXPECTED_TOOLS = {
     "list_recordings",
     "get_recording",
     "report_issue",
+    "annotate_meeting",
+    "speak_in_meeting",
+    "get_meeting_chat",
 }
 
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -1163,7 +1163,11 @@ class SqlAlchemyTranscriptStore:
         cfg = self.FTS_CONFIG
         sql = sql_text(f"""
             SELECT t.id                AS segment_row_id,
-                   t.meeting_id        AS meeting_id,
+                   -- `meeting_db_id`, never `meeting_id`: the INT row id must not travel
+                   -- under the name that means the platform's STRING id on every other
+                   -- tool. Emitting it as `meeting_id` is the regression this branch's
+                   -- identity gate exists to stop.
+                   t.meeting_id        AS meeting_db_id,
                    m.platform          AS platform,
                    m.platform_specific_id AS native_meeting_id,
                    t.start_time        AS start,
@@ -1237,8 +1241,8 @@ class SqlAlchemyTranscriptStore:
                 f"USING gin (to_tsvector('{self.FTS_CONFIG}', text))"))
             return {"status": "created", "index": name}
 
-    async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None,
-                               replace_metadata=False) -> "Optional[dict]":
+    async def annotate_meeting(self, user_id, meeting_id, *, title=None,
+                               metadata=None) -> "Optional[dict]":
         """Caller-owned annotations on a row in ANY status (see ports.annotate_meeting).
 
         Modelled on ``attach_calendar_source``, not on ``update_planned_meeting``: nothing written
@@ -1274,18 +1278,16 @@ class SqlAlchemyTranscriptStore:
 
             if metadata is not None:
                 touched = True
-                if replace_metadata:
-                    merged = {k: v for k, v in metadata.items() if v is not None}
-                else:
-                    current = data.get("metadata")
-                    merged = dict(current) if isinstance(current, dict) else {}
-                    for k, v in metadata.items():
-                        # An explicit null DELETES the key — the only way to take back one
-                        # annotation without replacing the whole object.
-                        if v is None:
-                            merged.pop(k, None)
-                        else:
-                            merged[k] = v
+                # ALWAYS a merge. A caller can only ever affect keys it names — an explicit null
+                # deletes exactly one. There is no whole-object replace, so nothing a writer never
+                # saw can be destroyed by it.
+                current = data.get("metadata")
+                merged = dict(current) if isinstance(current, dict) else {}
+                for k, v in metadata.items():
+                    if v is None:
+                        merged.pop(k, None)
+                    else:
+                        merged[k] = v
                 # Bound the MERGED result, never the patch alone: a cap on each write is not a cap
                 # at all when writes merge. Refuse rather than truncate — silently storing part of
                 # what a caller sent is a worse failure than telling them it did not fit.

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -1188,6 +1188,13 @@ class SqlAlchemyTranscriptStore:
                             merged.pop(k, None)
                         else:
                             merged[k] = v
+                # Bound the MERGED result, never the patch alone: a cap on each write is not a cap
+                # at all when writes merge. Refuse rather than truncate — silently storing part of
+                # what a caller sent is a worse failure than telling them it did not fit.
+                from .projection import check_metadata_bounds
+                reason = check_metadata_bounds(merged)
+                if reason:
+                    return {"error": "metadata_too_large", "detail": reason}
                 data["metadata"] = merged
 
             if touched:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -1139,6 +1139,104 @@ class SqlAlchemyTranscriptStore:
             await db.refresh(meeting)
             return self._planned_row(meeting)
 
+    # The text-search config, used for BOTH the index expression and every query. These MUST be
+    # the same string: an index on to_tsvector('english', text) is invisible to a query that says
+    # to_tsvector('simple', text), and the failure is silent — correct answers, seq scan, no error.
+    FTS_CONFIG = "english"
+
+    async def search_transcripts(self, user_id, query, *, limit=20, offset=0,
+                                 platform=None, native_meeting_id=None) -> list[dict]:
+        """Owner-scoped FTS over transcript segments (see ports.search_transcripts).
+
+        Measured on 210k segments across two tenants (dogfood, 2026-08-29): a rare term took
+        914ms unindexed for a 400-meeting tenant and 0.108ms with the GIN index — and 45.7ms →
+        0.126ms even for a 24-meeting one, because the dominant cost is computing to_tsvector()
+        per row at query time, not finding the rows. The index is part of the feature, not a
+        later optimisation.
+        """
+        from sqlalchemy import text as sql_text
+
+        q = (query or "").strip()
+        if not q:
+            return []
+
+        cfg = self.FTS_CONFIG
+        sql = sql_text(f"""
+            SELECT t.id                AS segment_row_id,
+                   t.meeting_id        AS meeting_id,
+                   m.platform          AS platform,
+                   m.platform_specific_id AS native_meeting_id,
+                   t.start_time        AS start,
+                   t.end_time          AS "end",
+                   t.speaker           AS speaker,
+                   t.language          AS language,
+                   ts_rank_cd(to_tsvector('{cfg}', t.text), qq) AS rank,
+                   ts_headline('{cfg}', t.text, qq,
+                       'StartSel=<mark>,StopSel=</mark>,MaxWords=24,MinWords=8,MaxFragments=2') AS snippet,
+                   t.text              AS text
+            FROM transcriptions t
+            JOIN meetings m ON m.id = t.meeting_id,
+                 websearch_to_tsquery('{cfg}', :q) AS qq
+            WHERE m.user_id = :uid
+              AND to_tsvector('{cfg}', t.text) @@ qq
+              -- Explicit casts: asyncpg cannot infer a bind parameter's type when it appears
+              -- only in `IS NULL` ("could not determine data type of parameter $3"), so an
+              -- optional filter must state its own type.
+              AND (CAST(:platform AS text) IS NULL OR m.platform = CAST(:platform AS text))
+              AND (CAST(:native AS text) IS NULL
+                   OR m.platform_specific_id = CAST(:native AS text))
+            ORDER BY rank DESC, t.meeting_id DESC, t.start_time ASC
+            LIMIT :lim OFFSET :off
+        """)
+        async with self._session_factory() as db:
+            rows = (await db.execute(sql, {
+                "q": q, "uid": user_id, "platform": platform, "native": native_meeting_id,
+                "lim": max(1, min(int(limit or 20), 100)), "off": max(0, int(offset or 0)),
+            })).mappings().all()
+        return [dict(r) for r in rows]
+
+    async def ensure_fts_index(self) -> dict:
+        """Build the transcript FTS index CONCURRENTLY, idempotently, out of band.
+
+        Deliberately NOT part of ``_sync_indexes``: that wraps each index in a SAVEPOINT, and
+        ``CREATE INDEX CONCURRENTLY`` cannot run inside a transaction block. It also must not run
+        in-band at boot — a plain CREATE INDEX takes ACCESS EXCLUSIVE on ``transcriptions``, the
+        highest-row-count table, which would stall startup for as long as the build takes.
+
+        Safe to call on every boot BECAUSE SEARCH WORKS WITHOUT IT: a missing or half-built index
+        means a slower query, never a wrong answer and never a failed request. That is what keeps
+        this off the deploy's critical path — unlike ``meeting_event_time`` (MIGRATION-0005),
+        whose absence makes every list request fail.
+
+        Handles the one real trap: a failed CONCURRENTLY build leaves an INVALID index behind that
+        Postgres silently never uses. We detect it via ``pg_index.indisvalid``, drop it, and let
+        the next call rebuild.
+        """
+        from sqlalchemy import text as sql_text
+
+        name = "ix_transcription_text_fts"
+        # AUTOCOMMIT: CREATE/DROP INDEX CONCURRENTLY cannot run in a transaction block.
+        engine = self._session_factory.kw["bind"] if hasattr(self._session_factory, "kw") else None
+        engine = engine or getattr(self, "_engine", None)
+        if engine is None:
+            return {"status": "skipped", "reason": "no engine handle"}
+
+        async with engine.connect() as conn:
+            conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+            state = (await conn.execute(sql_text(
+                "SELECT i.indisvalid FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                "WHERE c.relname = :n"), {"n": name})).scalar()
+            if state is True:
+                return {"status": "present", "index": name}
+            if state is False:
+                # A previous CONCURRENTLY build failed. The leftover is INVALID and unusable —
+                # Postgres will not error on it, it will simply never use it. Drop and rebuild.
+                await conn.execute(sql_text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))
+            await conn.execute(sql_text(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON transcriptions "
+                f"USING gin (to_tsvector('{self.FTS_CONFIG}', text))"))
+            return {"status": "created", "index": name}
+
     async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None,
                                replace_metadata=False) -> "Optional[dict]":
         """Caller-owned annotations on a row in ANY status (see ports.annotate_meeting).

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -447,8 +447,9 @@ class SqlAlchemyTranscriptStore:
         return await self._merge_live_segments(pg, viewer_is_owner=is_owner)
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
-                            member_workspaces=None, list_view=False, meeting_id=None, slim=False):
-        from sqlalchemy import cast, func, select, text, union_all
+                            member_workspaces=None, list_view=False, meeting_id=None, slim=False,
+                            metadata_filter=None):
+        from sqlalchemy import cast, func, literal, select, text, union_all
         from sqlalchemy.dialects.postgresql import JSONB
 
         from .models import Meeting
@@ -517,6 +518,19 @@ class SqlAlchemyTranscriptStore:
                     s = s.where(Meeting.id == meeting_id)
                 if platform:
                     s = s.where(Meeting.platform == platform)
+                if metadata_filter:
+                    # JSONB containment on the whole `data` blob, nesting the caller's filter under
+                    # `metadata` — `data @> '{"metadata": {...}}'`. Written against `data` (not
+                    # `data->'metadata'`) deliberately: THAT is the shape `ix_meeting_data_gin`
+                    # indexes, so this stays an index scan instead of degrading to a seq scan the
+                    # moment an account has history. Filtering in SQL rather than in Python is also
+                    # the difference between "the meetings tagged acme-42" and "the tagged ones on
+                    # the page you happened to fetch" — the latter is a wrong answer, not a slow one.
+                    s = s.where(
+                        cast(Meeting.data, JSONB).op("@>")(
+                            cast(literal(json.dumps({"metadata": metadata_filter})), JSONB)
+                        )
+                    )
                 if fetch_bound is not None:
                     # ORDER BY inside a compound member is only meaningful (and only kept by
                     # the compiler) together with LIMIT; an unbounded branch returns its full
@@ -1121,6 +1135,65 @@ class SqlAlchemyTranscriptStore:
                 data["calendar_name"] = primary.get("name") or "Calendar"
             meeting.data = data
             flag_modified(meeting, "data")
+            await db.commit()
+            await db.refresh(meeting)
+            return self._planned_row(meeting)
+
+    async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None,
+                               replace_metadata=False) -> "Optional[dict]":
+        """Caller-owned annotations on a row in ANY status (see ports.annotate_meeting).
+
+        Modelled on ``attach_calendar_source``, not on ``update_planned_meeting``: nothing written
+        here is read by the dispatch pipeline, so there is no FSM to fight and no status check."""
+        from sqlalchemy import bindparam, select, text
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from .models import Meeting
+
+        async with self._session_factory() as db:
+            await db.execute(
+                text("SELECT pg_advisory_xact_lock(:uid)").bindparams(bindparam("uid", user_id))
+            )
+            meeting = (await db.execute(
+                select(Meeting).where(Meeting.id == meeting_id, Meeting.user_id == user_id)
+                .with_for_update()
+            )).scalars().first()
+            if meeting is None:
+                return None
+
+            # `title` lives in the data blob, NOT as a column — same place update_planned_meeting
+            # puts it. Both writes therefore go through `data`, and both need flag_modified.
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            touched = False
+
+            if title is not None:
+                cleaned = (title or "").strip()[:512]
+                if cleaned:
+                    data["title"] = cleaned
+                else:
+                    data.pop("title", None)   # empty string clears it
+                touched = True
+
+            if metadata is not None:
+                touched = True
+                if replace_metadata:
+                    merged = {k: v for k, v in metadata.items() if v is not None}
+                else:
+                    current = data.get("metadata")
+                    merged = dict(current) if isinstance(current, dict) else {}
+                    for k, v in metadata.items():
+                        # An explicit null DELETES the key — the only way to take back one
+                        # annotation without replacing the whole object.
+                        if v is None:
+                            merged.pop(k, None)
+                        else:
+                            merged[k] = v
+                data["metadata"] = merged
+
+            if touched:
+                meeting.data = data
+                flag_modified(meeting, "data")
+
             await db.commit()
             await db.refresh(meeting)
             return self._planned_row(meeting)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+import json
+
 from fastapi import APIRouter, FastAPI, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 
@@ -196,13 +198,29 @@ def build_router(
         status: Optional[str] = Query(default=None),
         platform: Optional[str] = Query(default=None),
         exclude_planned: bool = Query(default=False),
+        metadata: Optional[str] = Query(
+            default=None,
+            description=(
+                'JSON object. Returns only meetings whose caller-set metadata CONTAINS it — e.g. '
+                '{"crm_deal":"acme-42"}. Containment, so extra keys on the row still match. '
+                "Filtered in SQL against the data GIN index, not on the fetched page."
+            ),
+        ),
     ):
         user_id = _resolve_user_id(x_user_id)
         member_workspaces = {w.strip() for w in (x_user_workspaces or "").split(",") if w.strip()}
         status_filter = status if status is not None else (_NON_PLANNED_STATUSES if exclude_planned else None)
+        metadata_filter = None
+        if metadata:
+            try:
+                metadata_filter = json.loads(metadata)
+            except Exception:
+                raise HTTPException(status_code=422, detail="'metadata' must be a JSON object")
+            if not isinstance(metadata_filter, dict):
+                raise HTTPException(status_code=422, detail="'metadata' must be a JSON object")
         meetings, _has_more = await store.list_meetings(
             user_id, status=status_filter, platform=platform, limit=limit, offset=offset,
-            member_workspaces=member_workspaces, list_view=True,
+            member_workspaces=member_workspaces, list_view=True, metadata_filter=metadata_filter,
         )
         log_event(
             "meetings_listed",
@@ -589,6 +607,67 @@ def build_router(
     # refuses an FSM-owned row with 409). Unknown/unowned native → 404. Additive: the int routes are
     # unchanged. DELETE returns 200 + a small body (the sealed native-delete response), NOT the 204
     # the row-id route returns. ---
+    # --- POST /meetings/{platform}/{native_meeting_id}/annotate → the caller's OWN description of
+    # a meeting: `title` and arbitrary `metadata`. Works in ANY status, unlike the PATCH below.
+    #
+    # The split is by WHAT is written, not when. PATCH edits the INSTRUCTIONS for a meeting (url,
+    # schedule, auto-join) and is refused once the FSM owns the row, because changing dispatch
+    # parameters under a running bot fights it. Annotations are the caller's DESCRIPTION: nothing
+    # in the pipeline reads them, so writing them can never re-arm, re-dispatch or re-route
+    # anything — and the moments a description is most worth writing are exactly the ones the FSM
+    # owns. Mid-meeting ("this is the Acme renewal call") and after it ends (the agent's own
+    # summary) were both previously impossible: PATCH answered 409 for the entire useful life of
+    # a meeting.
+    #
+    # `metadata` merges key-wise; an explicit null deletes one key; ?replace=true swaps the object.
+    @router.post("/meetings/{platform}/{native_meeting_id}/annotate")
+    async def annotate_native_meeting(
+        platform: str,
+        native_meeting_id: str,
+        request: Request,
+        replace: bool = Query(default=False, description="Replace the metadata object instead of merging."),
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=422, detail="invalid JSON body")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=422, detail="body must be an object")
+
+        title = payload.get("title")
+        if title is not None and not isinstance(title, str):
+            raise HTTPException(status_code=422, detail="'title' must be a string")
+        metadata = payload.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise HTTPException(status_code=422, detail="'metadata' must be an object")
+        if title is None and metadata is None:
+            raise HTTPException(
+                status_code=422,
+                detail="nothing to annotate: send 'title' and/or 'metadata'",
+            )
+
+        meeting_id = await _resolve_owned_native(user_id, platform, native_meeting_id)
+        if meeting_id is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Meeting not found for platform {platform} and ID {native_meeting_id}",
+            )
+        row = await store.annotate_meeting(
+            user_id, meeting_id, title=title, metadata=metadata, replace_metadata=replace,
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Meeting not found")
+        log_event(
+            "meeting_annotated", audience="user", span="meetings.annotate",
+            user_id=user_id, meeting_id=str(meeting_id),
+            fields={"title": title is not None,
+                    "metadata_keys": sorted(metadata.keys()) if metadata else [],
+                    "replace": replace, "status": row.get("status")},
+        )
+        return JSONResponse(content=row)
+
     @router.patch("/meetings/{platform}/{native_meeting_id}")
     async def patch_native_meeting(
         platform: str,

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -659,6 +659,10 @@ def build_router(
         )
         if row is None:
             raise HTTPException(status_code=404, detail="Meeting not found")
+        if isinstance(row, dict) and row.get("error") == "metadata_too_large":
+            # 413, not 422: the request is well-formed, it is the SIZE that is refused. Nothing is
+            # written — a partial store would be worse than the refusal.
+            raise HTTPException(status_code=413, detail=row.get("detail", "metadata too large"))
         log_event(
             "meeting_annotated", audience="user", span="meetings.annotate",
             user_id=user_id, meeting_id=str(meeting_id),

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -654,13 +654,16 @@ def build_router(
     # summary) were both previously impossible: PATCH answered 409 for the entire useful life of
     # a meeting.
     #
-    # `metadata` merges key-wise; an explicit null deletes one key; ?replace=true swaps the object.
+    # `metadata` ALWAYS merges key-wise; an explicit null deletes exactly one key. There is
+    # deliberately NO whole-object replace: every writer on an account shares one API key, so a
+    # replace would let any caller destroy annotations written by another agent — or by the human
+    # — that it never saw and could not have known about. Merge plus explicit nulls expresses
+    # every legitimate edit while making "corrupt what you did not write" unrepresentable.
     @router.post("/meetings/{platform}/{native_meeting_id}/annotate")
     async def annotate_native_meeting(
         platform: str,
         native_meeting_id: str,
         request: Request,
-        replace: bool = Query(default=False, description="Replace the metadata object instead of merging."),
         x_user_id: Optional[str] = Header(default=None),
     ):
         user_id = _resolve_user_id(x_user_id)
@@ -689,9 +692,7 @@ def build_router(
                 status_code=404,
                 detail=f"Meeting not found for platform {platform} and ID {native_meeting_id}",
             )
-        row = await store.annotate_meeting(
-            user_id, meeting_id, title=title, metadata=metadata, replace_metadata=replace,
-        )
+        row = await store.annotate_meeting(user_id, meeting_id, title=title, metadata=metadata)
         if row is None:
             raise HTTPException(status_code=404, detail="Meeting not found")
         if isinstance(row, dict) and row.get("error") == "metadata_too_large":
@@ -703,7 +704,7 @@ def build_router(
             user_id=user_id, meeting_id=str(meeting_id),
             fields={"title": title is not None,
                     "metadata_keys": sorted(metadata.keys()) if metadata else [],
-                    "replace": replace, "status": row.get("status")},
+                    "status": row.get("status")},
         )
         return JSONResponse(content=row)
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -145,6 +145,41 @@ def build_router(
         )
         return JSONResponse(content=doc)
 
+    # --- GET /transcripts/search?q= → ranked, snippeted hits across the caller's OWN transcripts.
+    # Registered BEFORE /transcripts/{platform}/{native_meeting_id} so `search` is not swallowed
+    # as a platform — the same ordering `by-id` above depends on.
+    #
+    # This answers what metadata cannot: not "meetings I tagged X" but "meetings where someone
+    # SAID X". Owner-scoped only, deliberately narrower than GET /meetings (which also surfaces
+    # share-recipient and workspace rows) — a search that over-returns is a disclosure, so it
+    # fails closed until widening it has had its own review.
+    @router.get("/transcripts/search")
+    async def search_transcripts(
+        request: Request,
+        q: str = Query(..., min_length=1, description=(
+            "Search text. Supports \"quoted phrases\", `or`, and `-excluded` terms "
+            "(websearch syntax). Malformed input never errors."
+        )),
+        limit: int = Query(20, ge=1, le=100),
+        offset: int = Query(0, ge=0),
+        platform: Optional[str] = Query(None, description="Restrict to one platform."),
+        native_meeting_id: Optional[str] = Query(None, description="Restrict to one meeting."),
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        if not (q or "").strip():
+            raise HTTPException(status_code=422, detail="'q' must not be blank")
+        hits = await store.search_transcripts(
+            user_id, q, limit=limit, offset=offset,
+            platform=platform, native_meeting_id=native_meeting_id,
+        )
+        log_event(
+            "transcripts_searched", audience="user", span="transcripts.search",
+            user_id=user_id,
+            fields={"query_chars": len(q), "hits": len(hits), "platform": platform},
+        )
+        return JSONResponse(content={"query": q, "hits": hits, "count": len(hits)})
+
     # --- GET /transcripts/{platform}/{native_meeting_id} → api.v1 TranscriptionResponse ---
     @router.get("/transcripts/{platform}/{native_meeting_id}")
     async def get_transcript(

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -187,9 +187,22 @@ class InMemoryTranscriptStore:
         return await self._transcript_doc(mid, viewer_is_owner=is_owner) if authorized else None
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
-                            member_workspaces=None, list_view=False, meeting_id=None, slim=False):
+                            member_workspaces=None, list_view=False, meeting_id=None, slim=False,
+                            metadata_filter=None):
         from .projection import DEFAULT_LIST_LIMIT, list_order_key, project_list_data
         mws = member_workspaces or set()
+
+        def metadata_matches(m):
+            """Mirror of the adapter's JSONB `@>` on `data.metadata`: every key in the filter must
+            be present with an equal value. Containment, not equality — extra keys on the row do
+            not disqualify it."""
+            if not metadata_filter:
+                return True
+            data = m.get("data") if isinstance(m.get("data"), dict) else {}
+            stored = data.get("metadata")
+            if not isinstance(stored, dict):
+                return False
+            return all(stored.get(k) == v for k, v in metadata_filter.items())
 
         def accessible(m):
             data = m.get("data") if isinstance(m.get("data"), dict) else {}
@@ -204,6 +217,7 @@ class InMemoryTranscriptStore:
                                     else m["status"] == status))
             and (meeting_id is None or mid == meeting_id)
             and (platform is None or m["platform"] == platform)
+            and metadata_matches(m)
         ]
         if list_view:
             # #1222: the USER-FACING list orders by (non-terminal pin, event time) — the meeting
@@ -477,6 +491,36 @@ class InMemoryTranscriptStore:
             primary = calendar_sources[0]
             data["calendar_connection_id"] = primary.get("id")
             data["calendar_name"] = primary.get("name") or "Calendar"
+        return self._planned_row(meeting_id)
+
+    async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None,
+                               replace_metadata=False):
+        """Caller-owned annotations on a row in ANY status — mirrors the adapter. No status check:
+        nothing written here is read by the dispatch pipeline, so there is no FSM to fight."""
+        m = self._meetings.get(meeting_id)
+        if m is None or m["user_id"] != user_id:
+            return None
+        data = m["data"]
+        # `title` lives in the data blob, NOT as a top-level field — mirrors the adapter and
+        # update_planned_meeting. Writing it anywhere else persists nothing.
+        if title is not None:
+            cleaned = (title or "").strip()[:512]
+            if cleaned:
+                data["title"] = cleaned
+            else:
+                data.pop("title", None)
+        if metadata is not None:
+            if replace_metadata:
+                data["metadata"] = {k: v for k, v in metadata.items() if v is not None}
+            else:
+                current = data.get("metadata")
+                merged = dict(current) if isinstance(current, dict) else {}
+                for k, v in metadata.items():
+                    if v is None:
+                        merged.pop(k, None)   # explicit null deletes one key
+                    else:
+                        merged[k] = v
+                data["metadata"] = merged
         return self._planned_row(meeting_id)
 
     async def update_planned_meeting(self, user_id, meeting_id, updates):

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -511,7 +511,7 @@ class InMemoryTranscriptStore:
                 data.pop("title", None)
         if metadata is not None:
             if replace_metadata:
-                data["metadata"] = {k: v for k, v in metadata.items() if v is not None}
+                merged = {k: v for k, v in metadata.items() if v is not None}
             else:
                 current = data.get("metadata")
                 merged = dict(current) if isinstance(current, dict) else {}
@@ -520,7 +520,13 @@ class InMemoryTranscriptStore:
                         merged.pop(k, None)   # explicit null deletes one key
                     else:
                         merged[k] = v
-                data["metadata"] = merged
+            # Bound the MERGED result, never the patch alone — mirrors the adapter. Checked
+            # BEFORE anything is stored, so a refusal writes nothing at all.
+            from .projection import check_metadata_bounds
+            reason = check_metadata_bounds(merged)
+            if reason:
+                return {"error": "metadata_too_large", "detail": reason}
+            data["metadata"] = merged
         return self._planned_row(meeting_id)
 
     async def update_planned_meeting(self, user_id, meeting_id, updates):

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -544,7 +544,9 @@ class InMemoryTranscriptStore:
                 )
                 hits.append({
                     "segment_row_id": seg.get("segment_id"),
-                    "meeting_id": mid,
+                    # `meeting_db_id`, never `meeting_id`: the int row id must not travel under
+                    # the name that means the platform's STRING id everywhere else.
+                    "meeting_db_id": mid,
                     "platform": m["platform"],
                     "native_meeting_id": m["native_meeting_id"],
                     "start": float(seg.get("start", 0.0)),
@@ -557,7 +559,7 @@ class InMemoryTranscriptStore:
                     "snippet": snippet,
                     "text": text,
                 })
-        hits.sort(key=lambda h: (-h["rank"], -h["meeting_id"], h["start"]))
+        hits.sort(key=lambda h: (-h["rank"], -h["meeting_db_id"], h["start"]))
         lim = max(1, min(int(limit or 20), 100))
         off = max(0, int(offset or 0))
         return hits[off:off + lim]
@@ -567,8 +569,7 @@ class InMemoryTranscriptStore:
         which is exactly the property that makes skipping the real build safe."""
         return {"status": "skipped", "reason": "in-memory store"}
 
-    async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None,
-                               replace_metadata=False):
+    async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None):
         """Caller-owned annotations on a row in ANY status — mirrors the adapter. No status check:
         nothing written here is read by the dispatch pipeline, so there is no FSM to fight."""
         m = self._meetings.get(meeting_id)
@@ -584,16 +585,15 @@ class InMemoryTranscriptStore:
             else:
                 data.pop("title", None)
         if metadata is not None:
-            if replace_metadata:
-                merged = {k: v for k, v in metadata.items() if v is not None}
-            else:
-                current = data.get("metadata")
-                merged = dict(current) if isinstance(current, dict) else {}
-                for k, v in metadata.items():
-                    if v is None:
-                        merged.pop(k, None)   # explicit null deletes one key
-                    else:
-                        merged[k] = v
+            # ALWAYS a merge — mirrors the adapter. No whole-object replace exists, so a caller
+            # can never destroy a key it did not name.
+            current = data.get("metadata")
+            merged = dict(current) if isinstance(current, dict) else {}
+            for k, v in metadata.items():
+                if v is None:
+                    merged.pop(k, None)   # explicit null deletes exactly one key
+                else:
+                    merged[k] = v
             # Bound the MERGED result, never the patch alone — mirrors the adapter. Checked
             # BEFORE anything is stored, so a refusal writes nothing at all.
             from .projection import check_metadata_bounds

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -493,6 +493,80 @@ class InMemoryTranscriptStore:
             data["calendar_name"] = primary.get("name") or "Calendar"
         return self._planned_row(meeting_id)
 
+    async def search_transcripts(self, user_id, query, *, limit=20, offset=0,
+                                 platform=None, native_meeting_id=None):
+        """A DELIBERATELY CRUDE stand-in for Postgres FTS — enough to test the ROUTE's contract
+        (owner scoping, filters, paging, hit shape), never the search semantics.
+
+        Case-insensitive whole-word AND matching, quoted phrases, `-term` negation. It does NOT
+        stem, does NOT rank by cover density, and does NOT implement `or`. Anything asserting real
+        tsquery behaviour must run against Postgres — meeting-api has no `requires_docker` lane
+        the way admin-api does, so that assertion lives in this branch's live validation.
+        Pretending otherwise here would produce tests that pass while production is wrong.
+        """
+        import re as _re
+
+        q = (query or "").strip()
+        if not q:
+            return []
+
+        phrases = _re.findall(r'"([^"]+)"', q)
+        rest = _re.sub(r'"[^"]*"', " ", q)
+        negations = [w[1:].lower() for w in rest.split() if w.startswith("-") and len(w) > 1]
+        terms = [w.lower() for w in rest.split() if not w.startswith("-")]
+
+        def matches(text: str) -> bool:
+            low = text.lower()
+            words = set(_re.findall(r"\w+", low))
+            if any(n in words for n in negations):
+                return False
+            if not all(p.lower() in low for p in phrases):
+                return False
+            return all(t in words for t in terms)
+
+        hits = []
+        for mid, m in self._meetings.items():
+            if m["user_id"] != user_id:
+                continue          # owner-scoped, fail-closed — mirrors the adapter
+            if platform and m["platform"] != platform:
+                continue
+            if native_meeting_id and m["native_meeting_id"] != native_meeting_id:
+                continue
+            for seg in m["segments"].values():
+                text = seg.get("text") or ""
+                if not matches(text):
+                    continue
+                low = text.lower()
+                needle = (phrases + terms or [""])[0].lower()
+                i = low.find(needle)
+                snippet = text if i < 0 else (
+                    ("…" if i > 30 else "") + text[max(0, i - 30): i + len(needle) + 60] + "…"
+                )
+                hits.append({
+                    "segment_row_id": seg.get("segment_id"),
+                    "meeting_id": mid,
+                    "platform": m["platform"],
+                    "native_meeting_id": m["native_meeting_id"],
+                    "start": float(seg.get("start", 0.0)),
+                    "end": float(seg.get("end", 0.0)),
+                    "speaker": seg.get("speaker"),
+                    "language": seg.get("language"),
+                    # A flat count, NOT ts_rank_cd — enough to make ordering deterministic in a
+                    # test, not a claim about relevance.
+                    "rank": float(sum(low.count(t) for t in terms) + len(phrases)),
+                    "snippet": snippet,
+                    "text": text,
+                })
+        hits.sort(key=lambda h: (-h["rank"], -h["meeting_id"], h["start"]))
+        lim = max(1, min(int(limit or 20), 100))
+        off = max(0, int(offset or 0))
+        return hits[off:off + lim]
+
+    async def ensure_fts_index(self):
+        """No index to build without Postgres. The fake always answers 'search works anyway',
+        which is exactly the property that makes skipping the real build safe."""
+        return {"status": "skipped", "reason": "in-memory store"}
+
     async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None,
                                replace_metadata=False):
         """Caller-owned annotations on a row in ANY status — mirrors the adapter. No status check:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -243,6 +243,44 @@ class TranscriptStore(Protocol):
         Returns the row (``list_meetings`` shape), or ``None`` when the user owns no such row."""
         ...
 
+    async def search_transcripts(
+        self,
+        user_id: int,
+        query: str,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        platform: Optional[str] = None,
+        native_meeting_id: Optional[str] = None,
+    ) -> list[dict]:
+        """Full-text search over the CALLER'S OWN transcript segments, ranked, with snippets.
+
+        Answers the question metadata cannot: not "meetings I tagged X" but "meetings where
+        someone SAID X". Without it the only way to answer that is to pull every transcript and
+        read it — precisely the thing an agent must not do.
+
+        Lexical, not semantic: Postgres FTS over ``to_tsvector('english', text)``. The query is
+        parsed with ``websearch_to_tsquery`` so a caller gets quoted phrases, ``or`` and ``-term``
+        negation for free, and — unlike ``to_tsquery`` — malformed input never raises. Ranked by
+        ``ts_rank_cd`` (cover density: term frequency weighted by proximity; NOT BM25 — no IDF, no
+        length normalisation). Each hit carries a ``ts_headline`` snippet rather than the whole
+        segment, which is what keeps a result cheap in a calling model's context.
+
+        ``'english'`` is the text-search config for BOTH indexing and querying, and it must stay
+        the same on both sides or the index goes unused. It is not an English-only decision:
+        English stemming leaves unknown tokens (e.g. Cyrillic) untouched, so non-English terms
+        still match EXACTLY — what is lost is stemming for those languages, while ``'simple'``
+        would have thrown away English stemming for everyone.
+
+        OWNER-SCOPED ONLY — fail-closed, and deliberately narrower than ``list_meetings``, which
+        also surfaces share-recipient and workspace-member rows. Widening search to those is a
+        separate decision with its own review; a search that over-returns is a disclosure.
+
+        Each hit: ``meeting_id`` · ``platform`` · ``native_meeting_id`` · ``start``/``end`` ·
+        ``speaker`` · ``language`` · ``rank`` · ``snippet`` · ``text``. Newest-meeting-first
+        within equal rank so a tie is deterministic."""
+        ...
+
     async def annotate_meeting(
         self, user_id: int, meeting_id: int, *,
         title: Optional[str] = None,

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -60,9 +60,15 @@ class TranscriptStore(Protocol):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         member_workspaces: "Optional[set[str]]" = None,
+        metadata_filter: "Optional[dict]" = None,
     ) -> list[dict]:
         """The user's meetings, newest first — a list of api.v1 ``MeetingResponse``-shaped dicts
-        (the body of ``MeetingListResponse``)."""
+        (the body of ``MeetingListResponse``).
+
+        ``metadata_filter`` selects rows whose ``data.metadata`` CONTAINS the given object (JSONB
+        ``@>``, served by ``ix_meeting_data_gin``). It is what turns the list from a log into a
+        queryable store: an agent that stamped ``{"crm_deal": "acme-42"}`` onto its meetings can
+        ask for exactly those back instead of paging the account and filtering client-side."""
         ...
 
     async def authorize_subscribe(
@@ -235,6 +241,34 @@ class TranscriptStore(Protocol):
         ``auto_join_user_set``, ``calendar_managed``, ``scheduled_at`` or ``status``.
 
         Returns the row (``list_meetings`` shape), or ``None`` when the user owns no such row."""
+        ...
+
+    async def annotate_meeting(
+        self, user_id: int, meeting_id: int, *,
+        title: Optional[str] = None,
+        metadata: "Optional[dict]" = None,
+        replace_metadata: bool = False,
+    ) -> Optional[dict]:
+        """Attach the CALLER's own annotations to a row in ANY status — including one the bot FSM
+        owns, and including one already completed.
+
+        The sibling of ``attach_calendar_source`` (identity stamped onto a live row) rather than of
+        ``update_planned_meeting`` (which refuses an FSM row, because dispatch parameters must not
+        change under a running bot). The distinction is what is being written, not when:
+        ``update_planned_meeting`` edits the INSTRUCTIONS for a meeting — url, schedule, auto-join
+        — and changing those mid-flight fights the FSM. ``title`` and ``metadata`` are the caller's
+        DESCRIPTION of a meeting. Nothing in the pipeline reads them, so writing them can never
+        re-arm, re-dispatch or re-route anything — and the moments a description is most worth
+        writing are exactly the ones the FSM owns: mid-meeting, and after it ends.
+
+        ``metadata`` is arbitrary caller-owned JSON stored at ``data.metadata``. It MERGES key-wise
+        by default (a key set to ``None`` is deleted); ``replace_metadata=True`` swaps the whole
+        object. It is the join key between a Vexa meeting and everything else the caller knows —
+        a CRM record, a ticket, its own summary — and it is queryable through
+        ``list_meetings(metadata_filter=...)``.
+
+        Returns the updated row (``list_meetings`` shape), or ``None`` when the user owns no such
+        row (→ 404). Never returns a conflict: there is no state in which annotating is refused."""
         ...
 
     async def delete_planned_meeting(self, user_id: int, meeting_id: int) -> Optional[bool]:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -285,7 +285,6 @@ class TranscriptStore(Protocol):
         self, user_id: int, meeting_id: int, *,
         title: Optional[str] = None,
         metadata: "Optional[dict]" = None,
-        replace_metadata: bool = False,
     ) -> Optional[dict]:
         """Attach the CALLER's own annotations to a row in ANY status — including one the bot FSM
         owns, and including one already completed.
@@ -299,9 +298,12 @@ class TranscriptStore(Protocol):
         re-arm, re-dispatch or re-route anything — and the moments a description is most worth
         writing are exactly the ones the FSM owns: mid-meeting, and after it ends.
 
-        ``metadata`` is arbitrary caller-owned JSON stored at ``data.metadata``. It MERGES key-wise
-        by default (a key set to ``None`` is deleted); ``replace_metadata=True`` swaps the whole
-        object. It is the join key between a Vexa meeting and everything else the caller knows —
+        ``metadata`` is arbitrary caller-owned JSON stored at ``data.metadata``. It ALWAYS merges
+        key-wise; a key set to ``None`` deletes that one key. There is deliberately NO whole-object
+        replace: every writer shares one API key, so a replace would let a caller destroy keys
+        written by another agent — or by the human — that it never saw. Merge plus explicit nulls
+        expresses every legitimate edit while making it impossible to affect a key you did not
+        name. It is the join key between a Vexa meeting and everything else the caller knows —
         a CRM record, a ticket, its own summary — and it is queryable through
         ``list_meetings(metadata_filter=...)``.
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
@@ -41,6 +41,8 @@ two tiers of response omissions, and the default page size that bounds an otherw
 """
 from __future__ import annotations
 
+import json
+
 from typing import Any, Dict, Optional
 
 # Heavy per-meeting ``data`` keys the list NEVER renders — dropped from list rows. Everything else
@@ -290,3 +292,42 @@ def project_list_data(
     if isinstance(sources, list):
         projected["calendar_sources"] = sources
     return projected
+
+
+# --- caller-supplied metadata: bounds -------------------------------------------------------
+# Arbitrary caller JSON, persisted to a JSONB column, GIN-indexed on write, and echoed in EVERY
+# list response. Unbounded, one caller's junk becomes everyone's cost forever. Measured on the
+# dogfood stack before these caps existed: a 10 MB value was accepted in 3s, after which
+# `GET /meetings` returned 10.3 MB on every call — and an MCP client feeds that straight into a
+# model's context window, so the read side is the real blast radius, not the disk.
+#
+# The bounds are checked against the MERGED result, never the patch alone: a cap on each write is
+# not a cap at all when writes merge (100 calls of 15 KB is 1.5 MB).
+#
+# 16 KB is generous for what this field is FOR — join keys, tags, an agent's own short summary.
+# Anything larger is a document, and a document belongs behind a link the metadata points at.
+_MAX_METADATA_BYTES = 16 * 1024
+_MAX_METADATA_KEYS = 64
+_MAX_METADATA_KEY_CHARS = 128
+
+
+def check_metadata_bounds(merged: dict) -> Optional[str]:
+    """Return a human-readable reason the merged metadata is out of bounds, or None if it fits."""
+    if len(merged) > _MAX_METADATA_KEYS:
+        return f"too many metadata keys: {len(merged)} (max {_MAX_METADATA_KEYS})"
+    for key in merged:
+        if len(str(key)) > _MAX_METADATA_KEY_CHARS:
+            return (
+                f"metadata key too long: {len(str(key))} chars "
+                f"(max {_MAX_METADATA_KEY_CHARS}) — {str(key)[:40]}…"
+            )
+    try:
+        size = len(json.dumps(merged).encode("utf-8"))
+    except (TypeError, ValueError):
+        return "metadata must be JSON-serializable"
+    if size > _MAX_METADATA_BYTES:
+        return (
+            f"metadata too large: {size} bytes after merge (max {_MAX_METADATA_BYTES}). "
+            "Store large content elsewhere and put a reference here."
+        )
+    return None

--- a/core/meetings/services/meeting-api/tests/test_identity_vocabulary.py
+++ b/core/meetings/services/meeting-api/tests/test_identity_vocabulary.py
@@ -1,0 +1,138 @@
+"""THE GATE, response side — no route may EMIT a retired identity name.
+
+meeting-api owns the response shapes the MCP tools forward verbatim, so this is where the
+regression actually lived: ``search_transcripts`` selected ``t.meeting_id AS meeting_id``, putting
+the INTEGER row id under the name three other tools use for the NATIVE STRING id. Feeding that
+tool's own output into ``get_meeting_transcript`` produced ``404 … and ID 1``.
+
+It was the second occurrence of that defect class in one day, by the same author, with the rule
+written down in between — so it is asserted here rather than remembered.
+
+The vocabulary MIRRORS ``vexa_mcp.identity`` (the input-side gate lives there, against the MCP
+tool schemas). The two services have separate dependency trees and cannot import each other, so
+this is a deliberate mirror in the same style as the ``sessions/models.py`` ↔ admin-api schema
+mirror. If you change one, change both — and the constants below are tiny precisely so that stays
+cheap.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+#: MIRROR of vexa_mcp.identity.CANONICAL_IDENTITY — concept -> the kind of value it always holds.
+CANONICAL_IDENTITY = {"platform": str, "native_meeting_id": str, "meeting_db_id": int}
+#: MIRROR of vexa_mcp.identity.DEPRECATED_ALIASES — retired name -> replacement. Never emitted.
+DEPRECATED_ALIASES = {"meeting_id": "native_meeting_id", "meeting_platform": "platform"}
+
+USER = 7
+H = {"x-user-id": str(USER)}
+PLAT, NID = "google_meet", "abc-defg-hij"
+
+
+class _NullRedis:
+    async def publish(self, channel, data):
+        return None
+
+
+def emitted_violations(where: str, payload, *, path: str = "") -> list[str]:
+    """Every retired name, and every canonical name carrying the wrong kind of value."""
+    out: list[str] = []
+    if isinstance(payload, list):
+        for item in payload[:5]:
+            out += emitted_violations(where, item, path=f"{path}[]")
+        return out
+    if not isinstance(payload, dict):
+        return out
+    for key, value in payload.items():
+        here = f"{path}.{key}" if path else key
+        if key in DEPRECATED_ALIASES:
+            out.append(f"{where}: emits `{here}` (retired; use `{DEPRECATED_ALIASES[key]}`)")
+        elif key in CANONICAL_IDENTITY and value is not None:
+            want = CANONICAL_IDENTITY[key]
+            if want is int and (not isinstance(value, int) or isinstance(value, bool)):
+                out.append(f"{where}: `{here}` should be an int, got {value!r}")
+            if want is str and not isinstance(value, str):
+                out.append(f"{where}: `{here}` should be a string, got {value!r}")
+        out += emitted_violations(where, value, path=here)
+    return out
+
+
+def _client():
+    store = InMemoryTranscriptStore()
+    store.seed_meeting(
+        user_id=USER, platform=PLAT, native_meeting_id=NID, meeting_id=1, status="completed",
+        segments=[{"segment_id": "s1", "start": 0.0, "end": 2.0,
+                   "text": "take the back of the panel", "speaker": "Dmitriy", "language": "en"}],
+    )
+    return TestClient(create_app(store, redis=_NullRedis()))
+
+
+# ---- the gate ---------------------------------------------------------------------------
+
+def test_no_route_emits_a_retired_identity_name():
+    """Drives every identity-bearing read route and inspects what it actually returns."""
+    client = _client()
+    checked = 0
+    for label, path, params in [
+        ("GET /meetings", "/meetings", {}),
+        ("GET /transcripts/search", "/transcripts/search", {"q": "panel"}),
+        ("GET /transcripts/{platform}/{native}", f"/transcripts/{PLAT}/{NID}", {}),
+        ("GET /transcripts/by-id", "/transcripts/by-id/1", {}),
+    ]:
+        r = client.get(path, params=params, headers=H)
+        if r.status_code != 200:
+            continue
+        checked += 1
+        violations = emitted_violations(label, r.json())
+        assert not violations, (
+            "A route EMITS a retired identity name — the defect that shipped twice:\n  - "
+            + "\n  - ".join(violations)
+            + "\n\nOutputs are what a caller builds the NEXT call from, so an ambiguous output "
+              "name is the bug: it turns 'feed one tool's output into the next' into a 404."
+        )
+    assert checked >= 3, "too few routes exercised for this gate to mean anything"
+
+
+def test_search_hits_carry_the_names_the_next_call_needs():
+    """The composability promise, made concrete: a search hit must be feedable straight into the
+    transcript route without renaming anything."""
+    client = _client()
+    hits = client.get("/transcripts/search", params={"q": "panel"}, headers=H).json()["hits"]
+    assert hits, "fixture produced no hits; the rest of this test would be vacuous"
+    hit = hits[0]
+    assert "platform" in hit and "native_meeting_id" in hit
+    # The actual round trip — this is what 404'd before.
+    r = client.get(f"/transcripts/{hit['platform']}/{hit['native_meeting_id']}", headers=H)
+    assert r.status_code == 200, (
+        f"a search hit could not be fed into the transcript route: {r.status_code} {r.text[:200]}"
+    )
+
+
+def test_the_integer_row_id_is_never_called_meeting_id():
+    """Specifically pins the regression: the int row id travels as `meeting_db_id`, never under
+    the name that means the platform's string id elsewhere."""
+    client = _client()
+    hit = client.get("/transcripts/search", params={"q": "panel"}, headers=H).json()["hits"][0]
+    assert "meeting_id" not in hit
+    assert isinstance(hit.get("meeting_db_id"), int)
+    assert isinstance(hit.get("native_meeting_id"), str)
+
+
+# ---- guards on the checker itself --------------------------------------------------------
+
+def test_the_checker_catches_the_exact_regression():
+    """A gate that only ever passes proves nothing. This is the shape that shipped."""
+    assert emitted_violations("x", {"hits": [{"meeting_id": 1}]})
+    assert emitted_violations("x", {"meeting_platform": "zoom"})
+    assert emitted_violations("x", {"native_meeting_id": 7})      # right name, wrong kind
+    assert emitted_violations("x", {"meeting_db_id": "abc-defg"})  # right name, wrong kind
+    assert emitted_violations("x", [{"nested": {"meeting_id": 2}}])
+
+
+def test_the_checker_passes_a_clean_payload():
+    assert emitted_violations("x", {
+        "platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+        "meeting_db_id": 1, "speaker": "Dmitriy",
+    }) == []

--- a/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
@@ -104,11 +104,24 @@ def test_explicit_null_deletes_one_key():
     assert store._meetings[mid]["data"]["metadata"] == {"crm_deal": "acme-42"}
 
 
-def test_replace_swaps_the_whole_object():
+def test_there_is_no_whole_object_replace():
+    """A caller must not be able to destroy annotations it never saw. Every writer on an account
+    shares one API key, so a replace would let any agent wipe keys written by another agent — or
+    by the human. `replace` was removed; the flag is now inert and merge is the only behaviour."""
     client, store, mid = _client()
     _annotate(client, {"metadata": {"crm_deal": "acme-42", "owner": "dmitry"}})
     _annotate(client, {"metadata": {"only": "this"}}, replace="true")
-    assert store._meetings[mid]["data"]["metadata"] == {"only": "this"}
+    assert store._meetings[mid]["data"]["metadata"] == {
+        "crm_deal": "acme-42", "owner": "dmitry", "only": "this",
+    }, "an unknown `replace` flag must not resurrect destructive behaviour"
+
+
+def test_a_writer_can_only_remove_keys_it_names():
+    """The positive form of the same property: deletion is per-key and explicit."""
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"written_by_someone_else": "keep me", "mine": "x"}})
+    _annotate(client, {"metadata": {"mine": None}})
+    assert store._meetings[mid]["data"]["metadata"] == {"written_by_someone_else": "keep me"}
 
 
 def test_title_and_metadata_are_independent():
@@ -248,6 +261,6 @@ def test_a_realistic_annotation_still_fits():
     assert store._meetings[mid]["data"]["metadata"]["crm_deal"] == "acme-42"
 
 
-def test_replace_is_bounded_too():
+def test_bounds_hold_regardless_of_unknown_flags():
     client, _store, _mid = _client()
     assert _annotate(client, {"metadata": {"blob": "x" * 20000}}, replace="true").status_code == 413

--- a/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
@@ -193,3 +193,61 @@ def test_malformed_metadata_filter_is_422_not_a_silent_full_list():
     client, _store, _mid = _client()
     assert client.get("/meetings", params={"metadata": "not-json"}, headers=H).status_code == 422
     assert client.get("/meetings", params={"metadata": "[1,2]"}, headers=H).status_code == 422
+
+
+# ---- bounds: one caller's junk must not become everyone's cost ----------------------
+# Measured on the dogfood stack BEFORE these caps: a 10 MB metadata value was accepted in 3s,
+# after which GET /meetings returned 10.3 MB on EVERY call. The read side is the real blast
+# radius — an MCP client feeds a list response straight into a model's context window.
+
+def test_oversized_metadata_is_refused_with_413():
+    client, store, mid = _client()
+    r = _annotate(client, {"metadata": {"blob": "x" * 20000}})
+    assert r.status_code == 413
+    assert "too large" in r.text
+    assert "metadata" not in store._meetings[mid]["data"], "nothing may be written on refusal"
+
+
+def test_the_cap_is_on_the_MERGED_result_not_the_patch():
+    """A cap on each write is not a cap at all when writes merge: many small writes must not add
+    up past the ceiling."""
+    client, store, mid = _client()
+    for i in range(4):
+        r = _annotate(client, {"metadata": {f"chunk{i}": "x" * 5000}})
+        if r.status_code == 413:
+            break
+    else:
+        raise AssertionError("merged growth was never refused")
+    import json as _json
+    assert len(_json.dumps(store._meetings[mid]["data"]["metadata"])) <= 16 * 1024
+
+
+def test_too_many_keys_is_refused():
+    client, _store, _mid = _client()
+    r = _annotate(client, {"metadata": {f"k{i}": 1 for i in range(200)}})
+    assert r.status_code == 413
+    assert "too many metadata keys" in r.text
+
+
+def test_overlong_key_is_refused():
+    client, _store, _mid = _client()
+    r = _annotate(client, {"metadata": {"k" * 300: "v"}})
+    assert r.status_code == 413
+    assert "key too long" in r.text
+
+
+def test_a_realistic_annotation_still_fits():
+    """The cap must not get in the way of what this field is FOR: join keys, tags, a short summary."""
+    client, store, mid = _client()
+    r = _annotate(client, {"metadata": {
+        "crm_deal": "acme-42", "owner": "dmitry", "stage": "discovery",
+        "tags": ["renewal", "technical"],
+        "summary": "They want SSO before renewal. " * 40,
+    }})
+    assert r.status_code == 200, r.text
+    assert store._meetings[mid]["data"]["metadata"]["crm_deal"] == "acme-42"
+
+
+def test_replace_is_bounded_too():
+    client, _store, _mid = _client()
+    assert _annotate(client, {"metadata": {"blob": "x" * 20000}}, replace="true").status_code == 413

--- a/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
@@ -1,0 +1,195 @@
+"""POST /meetings/{platform}/{native_meeting_id}/annotate — the caller's OWN description.
+
+`title` and arbitrary `metadata`, writable in ANY status. This is the surface that makes a Vexa
+meeting joinable to everything else the caller knows: a CRM id, a ticket, tags, an agent's own
+summary. It is REST-first — the MCP tool is a thin wrapper over exactly these routes, so anything
+proven here holds for curl, the SDKs and any MCP client alike.
+
+The split against PATCH /meetings/{platform}/{native} is by WHAT is written, not when. PATCH edits
+the INSTRUCTIONS for a meeting (url, schedule, auto-join) and is refused once the FSM owns the row.
+Annotations are read by nothing in the dispatch pipeline, so writing them can never re-arm or
+re-route anything — and the moments a description is most worth writing (mid-meeting, and after it
+ends) are exactly the ones PATCH answered 409 for.
+
+Drives the collector ``create_app`` over the in-memory fake, OFFLINE (TestClient, no docker/DB).
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+USER = 7
+H = {"x-user-id": str(USER)}
+PLAT, NID = "google_meet", "abc-defg-hij"
+
+
+class _NullRedis:
+    async def publish(self, channel, data):
+        return None
+
+
+def _client(status="active"):
+    """Default status is `active` deliberately: the FSM-owned state is the one that matters."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=NID, status=status)
+    return TestClient(create_app(store, redis=_NullRedis())), store, mid
+
+
+def _annotate(client, body, **params):
+    return client.post(f"/meetings/{PLAT}/{NID}/annotate", json=body, headers=H, params=params)
+
+
+# ---- the whole point: it works while the bot FSM owns the row ------------------------
+
+def test_annotate_works_on_a_live_meeting():
+    """PATCH answers 409 here. Annotating must not — a meeting is most worth describing while
+    it is happening."""
+    client, store, mid = _client(status="active")
+    r = _annotate(client, {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}})
+    assert r.status_code == 200, r.text
+    assert store._meetings[mid]["status"] == "active", "annotating must not touch status"
+
+
+def test_patch_still_refuses_a_live_meeting():
+    """The complement: dispatch parameters stay protected. This branch widens what can be
+    written, not who owns the FSM."""
+    client, _store, _mid = _client(status="active")
+    r = client.patch(f"/meetings/{PLAT}/{NID}", json={"title": "nope"}, headers=H)
+    assert r.status_code == 409
+
+
+# ---- title round-trips (it lives in the data blob, not a column) ---------------------
+
+def test_title_is_persisted_and_read_back():
+    """Regression: the first implementation assigned `meeting.title`, which is not a column —
+    SQLAlchemy accepted the attribute and persisted nothing, and a forwarding-only test could
+    not see it. Assert the STORED value, not the request that was sent."""
+    client, store, mid = _client()
+    r = _annotate(client, {"title": "Fan vibration debug"})
+    assert r.status_code == 200, r.text
+    assert store._meetings[mid]["data"]["title"] == "Fan vibration debug"
+
+
+def test_empty_title_clears_it():
+    client, store, mid = _client()
+    _annotate(client, {"title": "temporary"})
+    _annotate(client, {"title": ""})
+    assert "title" not in store._meetings[mid]["data"]
+
+
+def test_title_is_capped_at_512_chars():
+    client, store, mid = _client()
+    _annotate(client, {"title": "x" * 900})
+    assert len(store._meetings[mid]["data"]["title"]) == 512
+
+
+# ---- metadata merge semantics --------------------------------------------------------
+
+def test_metadata_merges_key_wise():
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"crm_deal": "acme-42", "owner": "dmitry"}})
+    _annotate(client, {"metadata": {"stage": "discovery"}})
+    assert store._meetings[mid]["data"]["metadata"] == {
+        "crm_deal": "acme-42", "owner": "dmitry", "stage": "discovery",
+    }
+
+
+def test_explicit_null_deletes_one_key():
+    """The only way to take back a single annotation without replacing the whole object."""
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"crm_deal": "acme-42", "owner": "dmitry"}})
+    _annotate(client, {"metadata": {"owner": None}})
+    assert store._meetings[mid]["data"]["metadata"] == {"crm_deal": "acme-42"}
+
+
+def test_replace_swaps_the_whole_object():
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"crm_deal": "acme-42", "owner": "dmitry"}})
+    _annotate(client, {"metadata": {"only": "this"}}, replace="true")
+    assert store._meetings[mid]["data"]["metadata"] == {"only": "this"}
+
+
+def test_title_and_metadata_are_independent():
+    """Writing one must not clear the other — they share the same data blob."""
+    client, store, mid = _client()
+    _annotate(client, {"title": "Acme renewal"})
+    _annotate(client, {"metadata": {"crm_deal": "acme-42"}})
+    data = store._meetings[mid]["data"]
+    assert data["title"] == "Acme renewal"
+    assert data["metadata"] == {"crm_deal": "acme-42"}
+
+
+# ---- refusals ------------------------------------------------------------------------
+
+def test_empty_body_is_refused():
+    client, _store, _mid = _client()
+    r = _annotate(client, {})
+    assert r.status_code == 422
+    assert "title" in r.text and "metadata" in r.text
+
+
+def test_non_object_metadata_is_refused():
+    client, _store, _mid = _client()
+    assert _annotate(client, {"metadata": ["not", "an", "object"]}).status_code == 422
+
+
+def test_unknown_meeting_is_404():
+    client, _store, _mid = _client()
+    r = client.post(
+        f"/meetings/{PLAT}/no-such-meeting/annotate", json={"title": "x"}, headers=H,
+    )
+    assert r.status_code == 404
+
+
+def test_another_users_meeting_is_404_not_403():
+    """Owner-scoped, and it must not confirm the row exists to a stranger."""
+    client, _store, _mid = _client()
+    r = client.post(
+        f"/meetings/{PLAT}/{NID}/annotate", json={"title": "x"}, headers={"x-user-id": "999"},
+    )
+    assert r.status_code == 404
+
+
+# ---- query by metadata: containment, in the store, not on a page ----------------------
+
+def _seed(store, native, metadata):
+    mid = store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=native, status="completed")
+    store._meetings[mid]["data"]["metadata"] = metadata
+    return mid
+
+
+def test_list_filters_by_metadata_containment():
+    client, store, _mid = _client()
+    _seed(store, "deal-one", {"crm_deal": "acme-42", "stage": "discovery"})
+    _seed(store, "deal-two", {"crm_deal": "other-1"})
+    r = client.get("/meetings", params={"metadata": '{"crm_deal":"acme-42"}'}, headers=H)
+    assert r.status_code == 200, r.text
+    got = [m["native_meeting_id"] for m in r.json()["meetings"]]
+    assert got == ["deal-one"]
+
+
+def test_metadata_filter_is_containment_not_equality():
+    """Extra keys on the meeting must not disqualify it — mirrors JSONB `@>`."""
+    client, store, _mid = _client()
+    _seed(store, "deal-one", {"crm_deal": "acme-42", "stage": "discovery", "owner": "dmitry"})
+    r = client.get("/meetings", params={"metadata": '{"stage":"discovery"}'}, headers=H)
+    assert [m["native_meeting_id"] for m in r.json()["meetings"]] == ["deal-one"]
+
+
+def test_metadata_filter_requires_every_key_to_match():
+    client, store, _mid = _client()
+    _seed(store, "deal-one", {"crm_deal": "acme-42"})
+    r = client.get(
+        "/meetings", params={"metadata": '{"crm_deal":"acme-42","stage":"closed"}'}, headers=H,
+    )
+    assert r.json()["meetings"] == []
+
+
+def test_malformed_metadata_filter_is_422_not_a_silent_full_list():
+    """A filter that silently failed to apply would be a WRONG answer, not a slow one: the caller
+    would read an unfiltered list as 'these all match'."""
+    client, _store, _mid = _client()
+    assert client.get("/meetings", params={"metadata": "not-json"}, headers=H).status_code == 422
+    assert client.get("/meetings", params={"metadata": "[1,2]"}, headers=H).status_code == 422

--- a/core/meetings/services/meeting-api/tests/test_transcript_search.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_search.py
@@ -1,0 +1,152 @@
+"""GET /transcripts/search — full-text search over the caller's OWN transcript segments.
+
+Answers what metadata cannot: not "meetings I tagged X" but "meetings where someone SAID X".
+
+SCOPE OF THIS FILE: the route's CONTRACT — owner scoping, filters, paging, hit shape, refusals.
+NOT the search semantics. The in-memory fake is a crude stand-in (whole-word AND, quoted phrases,
+`-negation`); it does not stem, does not rank by cover density, and does not implement `or`.
+Real tsquery behaviour is a Postgres property and meeting-api has no `requires_docker` lane the
+way admin-api does — asserting it here would produce green tests over wrong production code.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+USER, OTHER = 7, 99
+H = {"x-user-id": str(USER)}
+PLAT = "google_meet"
+
+
+class _NullRedis:
+    async def publish(self, channel, data):
+        return None
+
+
+def _seg(i, text, speaker="Dmitriy", start=0.0):
+    return {"segment_id": f"s{i}", "start": start, "end": start + 2, "text": text,
+            "speaker": speaker, "language": "en"}
+
+
+def _client():
+    store = InMemoryTranscriptStore()
+    store.seed_meeting(
+        user_id=USER, platform=PLAT, native_meeting_id="acme-call", meeting_id=1,
+        segments=[
+            _seg(1, "we should revisit the pricing before the renewal", start=0),
+            _seg(2, "the latency numbers look fine", speaker="Ana", start=10),
+            _seg(3, "lets align on scope before the demo", start=20),
+        ],
+    )
+    store.seed_meeting(
+        user_id=USER, platform="teams", native_meeting_id="globex-call", meeting_id=2,
+        segments=[_seg(4, "pricing came up again on the globex call", start=0)],
+    )
+    # Another tenant's meeting, same words — must never surface.
+    store.seed_meeting(
+        user_id=OTHER, platform=PLAT, native_meeting_id="secret-call", meeting_id=3,
+        segments=[_seg(5, "our pricing is confidential", speaker="Someone Else", start=0)],
+    )
+    return TestClient(create_app(store, redis=_NullRedis())), store
+
+
+def _search(client, q, **params):
+    return client.get("/transcripts/search", params={"q": q, **params}, headers=H)
+
+
+# ---- the core question -------------------------------------------------------------
+
+def test_finds_what_was_said_across_meetings():
+    client, _ = _client()
+    r = _search(client, "pricing")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["count"] == 2
+    assert {h["native_meeting_id"] for h in body["hits"]} == {"acme-call", "globex-call"}
+
+
+def test_a_hit_carries_the_identity_needed_to_fetch_the_transcript():
+    """The whole point of a hit: an agent must be able to feed it straight into
+    get_meeting_transcript without inventing anything."""
+    client, _ = _client()
+    hit = _search(client, "latency").json()["hits"][0]
+    for field in ("platform", "native_meeting_id", "start", "end", "speaker", "snippet", "rank"):
+        assert field in hit, f"hit is missing {field}"
+    assert hit["platform"] == PLAT and hit["native_meeting_id"] == "acme-call"
+    assert hit["speaker"] == "Ana"
+
+
+def test_snippet_not_the_whole_corpus():
+    client, _ = _client()
+    hit = _search(client, "latency").json()["hits"][0]
+    assert "latency" in hit["snippet"].lower()
+
+
+# ---- isolation: the property that must never regress --------------------------------
+
+def test_another_tenants_transcript_never_surfaces():
+    """Owner-scoped, fail-closed. A search that over-returns is a disclosure, not a bug."""
+    client, _ = _client()
+    hits = _search(client, "pricing").json()["hits"]
+    assert all(h["native_meeting_id"] != "secret-call" for h in hits)
+    assert all(h["speaker"] != "Someone Else" for h in hits)
+
+
+def test_the_other_tenant_can_see_their_own():
+    client, _ = _client()
+    r = client.get("/transcripts/search", params={"q": "pricing"}, headers={"x-user-id": str(OTHER)})
+    assert [h["native_meeting_id"] for h in r.json()["hits"]] == ["secret-call"]
+
+
+# ---- filters + paging ---------------------------------------------------------------
+
+def test_platform_filter():
+    client, _ = _client()
+    hits = _search(client, "pricing", platform="teams").json()["hits"]
+    assert [h["native_meeting_id"] for h in hits] == ["globex-call"]
+
+
+def test_single_meeting_filter():
+    client, _ = _client()
+    hits = _search(client, "pricing", native_meeting_id="acme-call").json()["hits"]
+    assert [h["native_meeting_id"] for h in hits] == ["acme-call"]
+
+
+def test_limit_and_offset():
+    client, _ = _client()
+    assert len(_search(client, "pricing", limit=1).json()["hits"]) == 1
+    first = _search(client, "pricing", limit=1).json()["hits"][0]
+    second = _search(client, "pricing", limit=1, offset=1).json()["hits"][0]
+    assert first != second
+
+
+# ---- refusals ------------------------------------------------------------------------
+
+def test_blank_query_is_refused():
+    client, _ = _client()
+    assert client.get("/transcripts/search", params={"q": "   "}, headers=H).status_code == 422
+
+
+def test_missing_query_is_refused():
+    client, _ = _client()
+    assert client.get("/transcripts/search", headers=H).status_code == 422
+
+
+def test_no_identity_is_401():
+    client, _ = _client()
+    assert client.get("/transcripts/search", params={"q": "pricing"}).status_code == 401
+
+
+def test_no_match_is_an_empty_result_not_an_error():
+    client, _ = _client()
+    body = _search(client, "zzzznotpresent").json()
+    assert body["count"] == 0 and body["hits"] == []
+
+
+def test_search_is_not_swallowed_as_a_platform_name():
+    """`/transcripts/search` must route to search, not to
+    `/transcripts/{platform}/{native}` with platform='search'."""
+    client, _ = _client()
+    assert _search(client, "pricing").status_code == 200


### PR DESCRIPTION
**Stacked on [#1359](https://github.com/Vexa-ai/vexa/pull/1359)** — base is `mcp-dogfood-stack`, so this diff is only the four commits on top. Merge that one first.

REST-first throughout; the MCP tools are thin wrappers, so curl, the SDKs and n8n get all of it.

## The problem

Vexa was a read-mostly stream, not a store an agent could participate in. You could start a bot and read a transcript; you could not annotate, link, search or write back — so a Vexa meeting could not be joined to anything else the caller knew. Measured against a live meeting before this branch:

```
PATCH title on a live meeting  → 409  "Meeting is no longer planned (bot lifecycle owns it)"
PATCH {"metadata": {...}}      → 422  "no editable fields in body"
search                         → did not exist
```

## What lands

**`POST /meetings/{platform}/{native}/annotate`** — title + arbitrary metadata, in **any** status. The FSM split is by *what* is written, not when: PATCH edits the INSTRUCTIONS for a meeting (url, schedule, auto-join) and is still refused once a bot is dispatched. Annotations are the caller's DESCRIPTION; nothing in the pipeline reads them, so writing them can never re-arm or re-route anything — and the moments a meeting is most worth describing (mid-call, and after) were exactly the ones PATCH refused. Modelled on `attach_calendar_source`, the existing any-status write.

**`GET /meetings?metadata={...}`** — JSONB containment over the whole history. No migration: `meetings.data` is already JSONB with a GIN index, so metadata lands at `data.metadata` and the filter rides `ix_meeting_data_gin`. Filtering in SQL rather than on the fetched page is a correctness property, not a speed one — a client-side filter over one page answers a different question than the one asked.

**`GET /transcripts/search?q=`** — the gap metadata cannot close: not "meetings I tagged X" but "meetings where someone SAID X". Lexical, stated plainly: `websearch_to_tsquery` (quoted phrases, `or`, `-negation`, never raises on messy input) against a GIN index on `to_tsvector('english', text)`, ranked by `ts_rank_cd` — cover density, **not BM25**, no IDF or length normalisation. `ts_headline` snippets, not whole segments.

**Two tools no notetaker MCP has**, wrapping gateway routes that already existed and were unreachable: `speak_in_meeting` and `get_meeting_chat`. Their bot records; ours participates.

## Three things worth reviewing closely

**Metadata was unbounded and I shipped it that way first.** Measured: a 10 MB value accepted in 3.0s, after which `GET /meetings` returned **10.3 MB on every call**. The read side is the blast radius — an MCP client feeds a list response straight into a model's context. Now 16 KB / 64 keys / 128-char keys, checked against the **merged** result (a per-write cap is no cap when writes merge), 413, nothing written on refusal.

**`replace` is removed outright.** Every writer on an account shares one API key, so a whole-object replace let any agent destroy annotations written by another agent — or by the human — that it never saw. Merge plus explicit per-key nulls expresses every legitimate edit while making "affect a key you did not name" unrepresentable. Read everything, edit only what you name.

**The identity vocabulary is now a gate, because prose failed twice in one day.** [#1359](https://github.com/Vexa-ai/vexa/pull/1359) fixed the input side; hours later I reintroduced it on the output side — `search_transcripts` returned `meeting_id` holding the integer row id, colliding with the deprecated alias for the native string id, so feeding my own tool's output into `get_meeting_transcript` gave `404 … and ID 1`. The failure is silent: every field is individually plausible and only the join between two tools is wrong.

`vexa_mcp/identity.py` declares three concepts, three names, three types. Two gates assert it against the surface the server **emits** (not source — the bug is emergent from the FastAPI→OpenAPI→MCP derivation). Both were verified to **fail** on the reintroduced bug before being kept, and the meeting-api gate caught a third instance nobody had noticed on its first run.

## The index

Part of the feature, not a later optimisation. On 210k segments across two tenants: a rare term took **914 ms unindexed** vs **0.108 ms indexed** for a 400-meeting tenant — and 45.7 ms → 0.126 ms even for a 24-meeting one, because the cost is computing `to_tsvector()` per row, not finding rows. 1.6 MB on a 24 MB table, `CONCURRENTLY` in 1.35 s.

`ensure_fts_index()` builds it concurrently, idempotently, handling the INVALID leftover a failed concurrent build leaves behind. Deliberately **not** in `_sync_indexes` (SAVEPOINTs; `CONCURRENTLY` cannot run in a transaction; an in-band build would take ACCESS EXCLUSIVE on the largest table at boot). Safe anytime **because search works without it** — a missing index is a slow query, never a failed one, which is what keeps it off the deploy critical path unlike MIGRATION-0005.

**Not done, and named:** `ensure_fts_index()` is not yet wired to a startup hook — meeting-api has none, and adding one belongs with the admin-api schema-sync owner rather than inside a search feature.

## Verified

Live on `mcp.dev.vexa.ai` against a real meeting, over plain REST and over MCP. 134 MCP + 1233 meeting-api + 330 gateway green.

<!-- vexa-agent -->