### PR TITLE
[BUSINESS] docs(mcp): the command users actually ask for

### DIFF
--- a/docs/docs/vexa-mcp.mdx
+++ b/docs/docs/vexa-mcp.mdx
@@ -52,6 +52,22 @@ authenticated front door.
 account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
+### Claude Code — one command
+
+```bash
+claude mcp add --transport http vexa https://api.cloud.vexa.ai/mcp \
+  --header "Authorization: Bearer $VEXA_API_KEY"
+```
+
+Then run `/mcp` inside Claude Code to confirm it connected, and **restart** so the tools load.
+Self-hosted: swap the URL for your own gateway, e.g. `http://localhost:18056/mcp`.
+
+Keep this in **user** scope rather than a project `.mcp.json`: `claude mcp add` stores the header
+value literally in the config file it writes, so a project-scoped server puts a live key in a file
+you may commit.
+
+### Claude Desktop, ChatGPT, and other MCP hosts
+
 ```json Hosted
 {
   "mcpServers": {


### PR DESCRIPTION
## What

Every Vexa surface documents Claude Desktop's JSON config. **None documents `claude mcp add`** — the command someone means when they say "connect Claude to Vexa".

Adds it to `docs/docs/vexa-mcp.mdx`, with the two things that bite:
- **restart** — tools do not load into an already-running session
- **user scope, not a project `.mcp.json`** — `claude mcp add` writes the header value **literally** into the config file, so a project-scoped server puts a live key somewhere you may commit. Verified on a real machine: the key lands in plaintext in `~/.claude.json`, not the keychain.

## How it was found

A cold-start agent was given only *"connect me to Vexa"* and the public internet — no repo access. It had to invent the CLI form by translating the Desktop JSON, and guessed wrong on whether `${VEXA_API_KEY}` inside `--header` is expanded by `mcp-remote`, by the shell, or not at all. The docs snippet references that variable with no `env` block binding it.

It rated the end-to-end onboarding **4/10**, and the reason was discoverability, not the product.

## Two related findings, not fixed here

**1. `llms.txt` is already fixed in main, but the live site is stale.** [#1345](https://github.com/Vexa-ai/vexa/pull/1345) added the MCP entry yesterday. Today: repo `main` has 1 match, `https://docs.vexa.ai/llms.txt` has **0**. The page itself serves 200. So the content fix landed and the deploy is behind — worth someone confirming the docs build actually republishes `llms.txt`.

**2. The marketing page outranks the docs page in every query tried** ("vexa mcp", "vexa mcp server", "add vexa to claude", "vexa mcp server add to claude"). `docs.vexa.ai/vexa-mcp` appeared in **none** of them. That page's own defects are fixed in [`Vexa-ai/vexa-platform#382`](https://github.com/Vexa-ai/vexa-platform/pull/382); the ranking problem is separate and unowned.

<!-- vexa-agent -->