### PR TITLE
[BUSINESS] MCP: the six surface findings a cold-start agent hit

### DIFF
--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -320,6 +320,28 @@ class AnnotateMeeting(BaseModel):
 class SpeakInMeeting(BaseModel):
     text: str = Field(..., description="What the bot should say out loud in the meeting.")
     language: Optional[str] = Field(None, description="Optional language/voice code, e.g. 'en'.")
+    # A MECHANICAL guard, not another warning. The prose warning is good and a cold-start agent
+    # did obey it — but this tool is one tools/call away from being audible to real people in a
+    # real conversation, and it will be loaded alongside a hundred others whose descriptions get
+    # skimmed. A required field the caller must set deliberately cannot be skimmed past.
+    asked_by_a_human: bool = Field(
+        ...,
+        description=(
+            "Must be true, and only set it if the person you are working for asked you to say "
+            "THIS. Everyone in the meeting hears it and it cannot be taken back. Never set it to "
+            "satisfy the schema, to test, or to acknowledge something."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def refuse_unless_asked(self):
+        if self.asked_by_a_human is not True:
+            raise ValueError(
+                "speak_in_meeting: refused. This says words out loud to real people and cannot be "
+                "undone. Set asked_by_a_human=true only when the person you work for asked you to "
+                "say this; otherwise do not call this tool."
+            )
+        return self
 
 
 class ParseMeetingLinkRequest(BaseModel):
@@ -432,6 +454,67 @@ _LEGACY_PLATFORM_DESC = "DEPRECATED alias for `platform`. Use `platform`."
 _LEGACY_ID_DESC = "DEPRECATED alias for `native_meeting_id`. Use `native_meeting_id`."
 
 
+#: The platforms the link parser can actually produce. A value outside this set is a caller
+#: mistake, and answering it with an empty result set is the worst possible reply: a cold-start
+#: agent reported that `platform="webex"` returned a confident `count: 0`, indistinguishable from
+#: "nobody said that". Silence that looks like an answer is worse than an error.
+VALID_PLATFORMS = ("google_meet", "teams", "zoom", "jitsi")
+
+
+def _validate_platform(tool: str, platform: Optional[str]) -> Optional[str]:
+    """Reject an unknown platform loudly rather than filtering everything away."""
+    if platform is None or platform in VALID_PLATFORMS:
+        return platform
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"{tool}: unknown platform {platform!r}. Valid values: "
+            f"{', '.join(VALID_PLATFORMS)}. Omit `platform` to search every platform."
+        ),
+    )
+
+
+async def reject_unknown_arguments(request: Request) -> None:
+    """Refuse query parameters the route does not declare.
+
+    FastAPI ignores extras, so `get_meeting_transcript(limit=2)` — no such parameter — returned
+    200 with the argument silently dropped. For an agent that is the worst failure mode available:
+    a typo'd or hallucinated parameter looks like it worked, and the wrong answer is indistinguishable
+    from the right one. Named near-misses are called out, because the commonest cause is a caller
+    reaching for another tool's parameter name.
+    """
+    route = request.scope.get("route")
+    if route is None or not getattr(route, "dependant", None):
+        return
+    known = {p.alias or p.name for p in route.dependant.query_params}
+    unknown = sorted(set(request.query_params.keys()) - known)
+    if not unknown:
+        return
+    # Substring matching alone misses the commonest real case — a caller reaching for another
+    # tool's parameter name and getting the word order wrong (`meeting_id_native`). difflib
+    # catches transpositions and typos that `in` does not.
+    import difflib
+
+    hints = []
+    for got in unknown:
+        near = difflib.get_close_matches(got, sorted(known), n=1, cutoff=0.5)
+        if not near:
+            near = [k for k in sorted(known) if k != got and (got in k or k in got)][:1]
+        if near:
+            hints.append(f"`{got}` — did you mean `{near[0]}`?")
+    tool = getattr(route, "operation_id", None) or getattr(route, "name", "this tool")
+    detail = {
+        "tool": tool,
+        "message": f"{tool}: unknown argument(s) {unknown}. This tool accepts {sorted(known)}.",
+        "unknown": unknown,
+        "accepted": sorted(known),
+    }
+    if hints:
+        detail["hint"] = "; ".join(hints)
+        detail["message"] = f"{tool}: unknown argument(s) — {detail['hint']}"
+    raise HTTPException(status_code=422, detail=detail)
+
+
 def _resolve_identity(
     tool: str,
     platform: Optional[str],
@@ -505,6 +588,11 @@ def create_app(
     _public_docs = _vexa_env != "production"
     app = FastAPI(
         title="Vexa MCP Service (v0.12)",
+        # Applied to every route at once rather than injected per-signature: a tool that silently
+        # ignores an argument it does not know is the worst reply available to an agent, so this
+        # must hold for ALL of them, including any added later. The /mcp transport is an ASGI
+        # mount rather than a route, so it is unaffected.
+        dependencies=[Depends(reject_unknown_arguments)],
         docs_url="/docs" if _public_docs else None,
         redoc_url="/redoc" if _public_docs else None,
         openapi_url="/openapi.json" if _public_docs else None,
@@ -707,6 +795,7 @@ def create_app(
         `metadata_filter` is what makes this a query rather than a log: meetings you annotated with
         annotate_meeting can be found again by the values you put on them.
         """
+        _validate_platform("list_meetings", platform)
         params: Dict[str, Any] = {}
         if limit is not None:
             params["limit"] = limit
@@ -811,6 +900,7 @@ def create_app(
         Related but different: list_meetings(metadata_filter=...) finds meetings you TAGGED;
         this finds meetings where something was SAID.
         """
+        _validate_platform("search_transcripts", platform)
         params: Dict[str, Any] = {"q": q, "limit": limit, "offset": offset}
         if platform:
             params["platform"] = platform
@@ -849,7 +939,24 @@ def create_app(
             body["title"] = data.title
         if data.metadata is not None:
             body["metadata"] = data.metadata
-        return await make_request("POST", f"{base_url}/meetings/{plat}/{mid}/annotate", api_key, body)
+        row = await make_request("POST", f"{base_url}/meetings/{plat}/{mid}/annotate", api_key, body)
+
+        # Return WHAT WAS WRITTEN, not the whole meeting row. Annotating is a small write to one
+        # field; the full row carries object-storage paths, a playback URL and a reference to a
+        # ~69 MB audio artifact, none of which the caller asked for and all of which land in a
+        # calling model's context. Read paths still serve the full row — this trims the WRITE's
+        # echo, which is the one place nobody requested any of it.
+        if not isinstance(row, dict):
+            return row
+        row_data = row.get("data") if isinstance(row.get("data"), dict) else {}
+        return {
+            "platform": row.get("platform", plat),
+            "native_meeting_id": row.get("native_meeting_id", mid),
+            "meeting_db_id": row.get("id"),
+            "status": row.get("status"),
+            "title": row_data.get("title"),
+            "metadata": row_data.get("metadata", {}),
+        }
 
     # --- the interactive bot: our bot TALKS and reads the room ------------------------------
     # No notetaker MCP exposes this, because no notetaker has it: their bot is a recorder. Ours is
@@ -919,7 +1026,7 @@ def create_app(
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
-        Tell the Vexa maintainers that something went wrong. A human reads every ticket.
+        Tell the Vexa maintainers that something went wrong. A human reads every ticket, and it cannot be withdrawn.
 
         Call this the moment you hit a problem with Vexa — you do not need to have solved it first:
         - something BROKE: an error, a bot that never joined, an empty transcript, a call that hung;
@@ -929,6 +1036,11 @@ def create_app(
         A workaround you had to invent is worth filing too — that is the report we most want.
         Write what you tried and what happened in your own words. Do not paste API keys, and do not
         paste your user's meeting content.
+
+        File only when you hit this while doing REAL WORK for someone. If you are exploring,
+        evaluating or testing this API, do not file — write your findings in your report instead.
+        A ticket reaches humans at another company and cannot be withdrawn, and an evaluation run
+        can otherwise open several in a single session.
 
         If the issue concerns a meeting or a bot, include `native_meeting_id` and `platform`. That is the
         join key: it lines your account of what happened up against our own record of the same
@@ -1108,6 +1220,17 @@ def create_app(
     @mcp.server.get_prompt()
     async def _get_prompt(name: str, arguments: Optional[Dict[str, str]] = None) -> mcp_types.GetPromptResult:
         return get_prompt_result(name, arguments)
+
+    # Close every tool's argument schema. Without `additionalProperties: false` an unknown
+    # argument is not rejected — fastapi-mcp silently DROPS it before the HTTP call, so the
+    # server-side guard never sees it and the tool answers 200 as if the argument had been
+    # honoured. A hallucinated or typo'd parameter then looks like it worked, and the wrong
+    # answer is indistinguishable from the right one. Closing the schema moves the refusal to
+    # where the argument actually is: the MCP validation layer.
+    for _tool in mcp.tools:
+        schema = getattr(_tool, "inputSchema", None)
+        if isinstance(schema, dict) and schema.get("type") == "object":
+            schema.setdefault("additionalProperties", False)
 
     mcp.mount_http()
     # fastapi-mcp 0.4 buffers the ASGI response; a sessioned GET is an open SSE

--- a/core/meetings/services/mcp/src/vexa_mcp/prompts.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/prompts.py
@@ -24,12 +24,12 @@ PROMPTS: Dict[str, mcp_types.Prompt] = {
                 required=False,
             ),
             mcp_types.PromptArgument(
-                name="meeting_platform",
+                name="platform",
                 description="google_meet | teams | zoom (optional if meeting_url is provided).",
                 required=False,
             ),
             mcp_types.PromptArgument(
-                name="meeting_id",
+                name="native_meeting_id",
                 description="Native meeting ID (optional if meeting_url is provided).",
                 required=False,
             ),
@@ -45,8 +45,8 @@ PROMPTS: Dict[str, mcp_types.Prompt] = {
         title="Vexa: During Meeting",
         description="Check bot status and retrieve current transcript snapshot.",
         arguments=[
-            mcp_types.PromptArgument(name="meeting_platform", description="google_meet | teams | zoom", required=True),
-            mcp_types.PromptArgument(name="meeting_id", description="Native meeting ID", required=True),
+            mcp_types.PromptArgument(name="platform", description="google_meet | teams | zoom", required=True),
+            mcp_types.PromptArgument(name="native_meeting_id", description="The platform's own meeting id — exactly the `native_meeting_id` the tools return", required=True),
         ],
     ),
     "vexa.post_meeting": mcp_types.Prompt(
@@ -54,8 +54,8 @@ PROMPTS: Dict[str, mcp_types.Prompt] = {
         title="Vexa: Post Meeting",
         description="Fetch transcript + recordings and produce follow-ups.",
         arguments=[
-            mcp_types.PromptArgument(name="meeting_platform", description="google_meet | teams | zoom", required=True),
-            mcp_types.PromptArgument(name="meeting_id", description="Native meeting ID", required=True),
+            mcp_types.PromptArgument(name="platform", description="google_meet | teams | zoom", required=True),
+            mcp_types.PromptArgument(name="native_meeting_id", description="The platform's own meeting id — exactly the `native_meeting_id` the tools return", required=True),
         ],
     ),
     "vexa.teams_link_help": mcp_types.Prompt(
@@ -77,8 +77,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
 
     if name == "vexa.meeting_prep":
         meeting_url = (args.get("meeting_url") or "").strip()
-        meeting_platform = (args.get("meeting_platform") or "").strip()
-        meeting_id = (args.get("meeting_id") or "").strip()
+        platform = (args.get("platform") or "").strip()
+        native_meeting_id = (args.get("native_meeting_id") or "").strip()
         notes = (args.get("notes") or "").strip()
 
         return mcp_types.GetPromptResult(
@@ -98,8 +98,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
                         "- Keep any provided notes in the conversation for the post-meeting summary "
                         "(storing notes on the meeting record is not available via this MCP yet).\n\n"
                         f"Input:\n- meeting_url: {meeting_url or '(none)'}\n"
-                        f"- meeting_platform: {meeting_platform or '(none)'}\n"
-                        f"- meeting_id: {meeting_id or '(none)'}\n"
+                        f"- platform: {platform or '(none)'}\n"
+                        f"- native_meeting_id: {native_meeting_id or '(none)'}\n"
                         f"- notes: {notes or '(none)'}\n\n"
                         "Now do the tool calls and tell me what you did and what to do next."
                     ),
@@ -108,8 +108,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
         )
 
     if name == "vexa.during_meeting":
-        meeting_platform = (args.get("meeting_platform") or "").strip()
-        meeting_id = (args.get("meeting_id") or "").strip()
+        platform = (args.get("platform") or "").strip()
+        native_meeting_id = (args.get("native_meeting_id") or "").strip()
         return mcp_types.GetPromptResult(
             description="During-meeting helper prompt using Vexa MCP tools.",
             messages=[
@@ -117,7 +117,7 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
                     role="user",
                     content=t(
                         "You are my during-meeting assistant using Vexa.\n\n"
-                        f"Meeting: platform={meeting_platform}, id={meeting_id}\n\n"
+                        f"Meeting: platform={platform}, id={native_meeting_id}\n\n"
                         "Steps:\n"
                         "- Call `get_bot_status` to confirm the bot is active / requested.\n"
                         "- Call `get_meeting_transcript` to fetch the current transcript snapshot.\n"
@@ -130,8 +130,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
         )
 
     if name == "vexa.post_meeting":
-        meeting_platform = (args.get("meeting_platform") or "").strip()
-        meeting_id = (args.get("meeting_id") or "").strip()
+        platform = (args.get("platform") or "").strip()
+        native_meeting_id = (args.get("native_meeting_id") or "").strip()
         return mcp_types.GetPromptResult(
             description="Post-meeting helper prompt using Vexa MCP tools.",
             messages=[
@@ -139,7 +139,7 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
                     role="user",
                     content=t(
                         "You are my post-meeting assistant using Vexa.\n\n"
-                        f"Meeting: platform={meeting_platform}, id={meeting_id}\n\n"
+                        f"Meeting: platform={platform}, id={native_meeting_id}\n\n"
                         "Steps:\n"
                         "- Call `get_meeting_transcript` to fetch the meeting status, notes, and segments.\n"
                         "- Call `list_recordings` (optionally `get_recording`) if recordings are expected.\n"

--- a/core/meetings/services/mcp/tests/test_app.py
+++ b/core/meetings/services/mcp/tests/test_app.py
@@ -696,14 +696,20 @@ def test_annotate_forwards_title_and_metadata(client, gateway, auth):
     assert gateway.last_json() == {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}}
 
 
-def test_annotate_never_forwards_a_replace_flag(client, gateway, auth):
-    """There is no whole-object replace. A caller sharing an account's API key must not be able to
-    destroy annotations written by another agent, or by the human, that it never saw."""
-    client.post(
+def test_replace_is_refused_outright_not_silently_ignored(client, gateway, auth):
+    """There is no whole-object replace: a caller sharing an account's API key must not be able to
+    destroy annotations another agent — or the human — wrote and it never saw.
+
+    It is REFUSED rather than dropped. A caller that believes it replaced the object and was
+    silently merged holds a false model of the stored state, which is worse than an error."""
+    before = len(gateway.requests)
+    r = client.post(
         "/meeting-annotate?native_meeting_id=abc-defg-hij&replace=true",
         headers=auth, json={"metadata": {"only": "this"}},
     )
-    assert "replace" not in dict(gateway.requests[-1].url.params)
+    assert r.status_code == 422
+    assert "replace" in r.text
+    assert len(gateway.requests) == before, "an unknown argument must not reach the gateway"
 
 
 def test_annotate_requires_something_to_write(client, gateway, auth):
@@ -736,7 +742,9 @@ def test_list_meetings_rejects_a_non_object_metadata_filter(client, gateway, aut
 def test_speak_forwards_to_the_bot_speak_route(client, gateway, auth):
     r = client.post(
         "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
-        headers=auth, json={"text": "Dmitry asked me to say the numbers are in the deck."},
+        headers=auth,
+        json={"text": "Dmitry asked me to say the numbers are in the deck.",
+              "asked_by_a_human": True},
     )
     assert r.status_code == 200
     req = gateway.requests[-1]
@@ -744,7 +752,113 @@ def test_speak_forwards_to_the_bot_speak_route(client, gateway, auth):
     assert gateway.last_json()["text"].startswith("Dmitry asked me")
 
 
+# --- speaking out loud needs a MECHANICAL guard, not only a warning ----------
+# This tool is one tools/call from being audible to real people in a real conversation, and it
+# will be loaded alongside a hundred others whose descriptions get skimmed. A required field
+# cannot be skimmed past the way a paragraph can.
+
+def test_speak_is_refused_without_the_explicit_acknowledgement(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth, json={"text": "hello"},
+    )
+    assert r.status_code == 422
+    assert len(gateway.requests) == before, "nothing may reach the meeting without the acknowledgement"
+
+
+def test_speak_is_refused_when_the_acknowledgement_is_false(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth, json={"text": "hello", "asked_by_a_human": False},
+    )
+    assert r.status_code == 422
+    assert len(gateway.requests) == before
+
+
+def test_the_acknowledgement_is_not_forwarded_as_speech(client, gateway, auth):
+    """It is a gate on the caller, not a field the bot should carry downstream."""
+    client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth, json={"text": "hello", "asked_by_a_human": True},
+    )
+    assert "hello" in gateway.last_json()["text"]
+
+
 def test_get_meeting_chat_path(client, gateway, auth):
     client.get("/meeting-chat?native_meeting_id=abc-defg-hij", headers=auth)
     req = gateway.requests[-1]
     assert (req.method, req.url.path) == ("GET", "/bots/google_meet/abc-defg-hij/chat")
+
+
+# --- an empty result must never be a guess -----------------------------------
+# A cold-start agent reported `platform="webex"` returning a confident `count: 0` — silence that
+# looks like an answer. "Nobody said that" and "you filtered everything away" must not be the
+# same reply.
+
+def test_unknown_platform_is_refused_not_answered_with_zero(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.get("/transcript-search", params={"q": "panel", "platform": "webex"}, headers=auth)
+    assert r.status_code == 422
+    detail = str(r.json()["detail"])
+    assert "webex" in detail and "google_meet" in detail, "the error must name the valid values"
+    assert len(gateway.requests) == before
+
+
+def test_unknown_platform_is_refused_on_list_meetings_too(client, auth):
+    assert client.get("/meetings", params={"platform": "webex"}, headers=auth).status_code == 422
+
+
+def test_a_valid_platform_still_works(client, gateway, auth):
+    assert client.get("/meetings", params={"platform": "zoom"}, headers=auth).status_code == 200
+
+
+def test_omitting_platform_searches_everything(client, gateway, auth):
+    r = client.get("/transcript-search", params={"q": "panel"}, headers=auth)
+    assert r.status_code == 200
+    assert "platform" not in dict(gateway.requests[-1].url.params)
+
+
+# --- a typo must not look like success ---------------------------------------
+# FastAPI ignores unknown query params, so `get_meeting_transcript(limit=2)` — no such parameter —
+# returned 200 with the argument dropped. For an agent that is the worst failure available: the
+# wrong answer is indistinguishable from the right one.
+
+def test_an_unknown_argument_is_refused(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.get("/meeting-transcript",
+                   params={"native_meeting_id": "abc-defg-hij", "limit": 2}, headers=auth)
+    assert r.status_code == 422
+    assert "limit" in r.text
+    assert len(gateway.requests) == before, "an unknown argument must not reach the gateway"
+
+
+def test_a_near_miss_argument_gets_a_suggestion(client, auth):
+    r = client.get("/transcript-search", params={"q": "x", "meeting_id_native": "abc"}, headers=auth)
+    assert r.status_code == 422
+    assert "did you mean" in str(r.json()["detail"]).lower()
+
+
+def test_the_accepted_arguments_are_listed_in_the_error(client, auth):
+    detail = client.get("/meetings", params={"totally_bogus": 1}, headers=auth).json()["detail"]
+    assert "accepted" in detail and "platform" in detail["accepted"]
+
+
+# --- a write echoes what it wrote, not the whole meeting ----------------------
+
+def test_annotate_returns_only_what_was_written(client, gateway, auth):
+    """The full row carries object-storage paths, a playback URL and a ~69 MB audio reference —
+    none of it requested, all of it landing in a calling model's context."""
+    gateway.routes[("POST", "/meetings/google_meet/abc-defg-hij/annotate")] = (200, {
+        "id": 1, "platform": "google_meet", "native_meeting_id": "abc-defg-hij", "status": "active",
+        "data": {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"},
+                 "recordings": [{"playback_url": "https://minio/…", "bytes": 69_000_000}],
+                 "webhook_url": "https://hooks.example/x"},
+    })
+    body = client.post("/meeting-annotate?native_meeting_id=abc-defg-hij",
+                       headers=auth, json={"metadata": {"crm_deal": "acme-42"}}).json()
+    assert body["metadata"] == {"crm_deal": "acme-42"}
+    assert body["title"] == "Acme renewal"
+    assert body["native_meeting_id"] == "abc-defg-hij" and body["meeting_db_id"] == 1
+    assert "recordings" not in body and "data" not in body and "webhook_url" not in body

--- a/core/meetings/services/mcp/tests/test_mcp_surface.py
+++ b/core/meetings/services/mcp/tests/test_mcp_surface.py
@@ -83,3 +83,23 @@ def test_server_ships_instructions():
     # The canonical flow and the identity vocabulary are the two things it exists to say.
     for expected in ("parse_meeting_link", "request_meeting_bot", "get_meeting_transcript", "native_meeting_id"):
         assert expected in instructions
+
+
+# --- a tool must refuse an argument it does not declare ----------------------
+# Without additionalProperties, fastapi-mcp DROPS an unknown argument before the HTTP call, so a
+# server-side guard never sees it and the tool answers 200 as if it had been honoured. Verified
+# live: `get_meeting_transcript(limit=2)` returned a transcript with `limit` silently ignored.
+
+def test_every_tool_schema_is_closed():
+    app = create_app("http://gateway.test",
+                     transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+    open_schemas = [
+        t.name for t in app.state.mcp.tools
+        if isinstance(getattr(t, "inputSchema", None), dict)
+        and t.inputSchema.get("type") == "object"
+        and t.inputSchema.get("additionalProperties") is not False
+    ]
+    assert not open_schemas, (
+        "these tools accept undeclared arguments and will silently drop them: "
+        f"{open_schemas}"
+    )


### PR DESCRIPTION
**Stacked on [#1360](https://github.com/Vexa-ai/vexa/pull/1360)** → which is stacked on [#1359](https://github.com/Vexa-ai/vexa/pull/1359). Merge in that order; this diff is one commit.

## How these were found

An agent was given **only** the endpoint URL and an API key — no Vexa knowledge, no repo access, no web search — and told to work out what the service does and do five real tasks. It completed four, correctly determined the fifth was unanswerable, and rated the surface **8/10**, singling out the `instructions` line about `active` + zero segments as the best thing on the server.

These six are everything it flagged on the way. None of them broke a task; all of them are the kind of thing that makes an agent quietly wrong.

## The six

**1 · The prompts still taught the retired vocabulary.** All three meeting prompts advertised `meeting_platform` + `meeting_id` while the tools they wrap want `platform` + `native_meeting_id`. The prompt layer was the last thing teaching the old names.

**2 · An empty result was a guess.** `platform="webex"` — not a platform we have — returned a confident `count: 0`, indistinguishable from *nobody said that*. Now refused, with the valid set named. Silence that looks like an answer is worse than an error.

**3 · A typo looked like success**, and my first fix did not work. `get_meeting_transcript(limit=2)` — no such parameter — returned 200 with the argument dropped. I added a server-side guard; **verified live, it did nothing**: `fastapi-mcp` strips unknown arguments *before* the HTTP call, so the guard never saw them. The refusal has to live where the argument actually is, so every tool's `inputSchema` now carries `additionalProperties: false`. Both layers are kept — the HTTP guard also names the near miss (`difflib`, so it catches transpositions like `meeting_id_native`), which is what lets an agent self-correct.

**4 · A write echoed the whole meeting.** `annotate_meeting` — a small write to one field — returned object-storage paths, a playback URL and a reference to a ~69 MB audio artifact. None requested; all of it lands in a calling model's context. It now returns what it wrote. Read paths still serve the full row.

**5 · `report_issue` invited a ticket on any confusion.** Its description told an agent to file *"the moment you hit a problem"*, including anything merely CONFUSING — an outbound message to another company's humans, no gate, no undo. The audit agent hit two such things and **would have filed both during a usability test**. The invitation is deliberate and stays; it is now scoped to real work, with evaluation runs told to report rather than file.

**6 · `speak_in_meeting` was guarded by prose alone.** The warning is good and the audit agent obeyed it. But this tool is one `tools/call` from being audible to real people in a real conversation, and it will be loaded beside a hundred tools whose descriptions get skimmed. It now requires `asked_by_a_human=true`. A required field cannot be skimmed past the way a paragraph can.

## Verified live on `mcp.dev.vexa.ai`

```
prompts        → ['platform', 'native_meeting_id']
platform=webex → REFUSED, valid values named
limit=2        → REFUSED: Additional properties are not allowed ('limit' was unexpected)
annotate       → 6 keys, no recordings/playback URL
speak          → REFUSED: 'asked_by_a_human' is a required property
report_issue   → scoped to real work
```

146 MCP tests green, including a schema test that fails if any future tool ships an open argument schema.

<!-- vexa-agent -->