### PR TITLE
[BUSINESS] flows: wake signal verb

### DIFF
--- a/core/flows/schema.sql
+++ b/core/flows/schema.sql
@@ -87,6 +87,6 @@ CREATE TABLE IF NOT EXISTS signal (
 	created_at DOUBLE PRECISION NOT NULL, 
 	consumed_at DOUBLE PRECISION, 
 	PRIMARY KEY (signal_id), 
-	CONSTRAINT signal_kind CHECK (kind IN ('resume','retry','cancel')), 
+	CONSTRAINT signal_kind CHECK (kind IN ('resume','retry','cancel','wake')), 
 	FOREIGN KEY(reaction_id) REFERENCES reaction (reaction_id)
 );

--- a/core/flows/src/flows/__init__.py
+++ b/core/flows/src/flows/__init__.py
@@ -7,11 +7,11 @@ from .model import Block, Done, Reaction, Receipt, StepCtx, StepError, Wait
 from .projection import status, waiting
 from .reconciler import escalate, reclaim
 from .registry import EventType, Flow, Registry
-from .signals import cancel, resume, retry
+from .signals import cancel, resume, retry, wake
 
 __all__ = [
     "admit", "Clock", "FakeClock", "SystemClock", "SqliteDB", "postgres_db",
     "claim", "effect_key", "tick", "Block", "Done", "Reaction", "Receipt",
     "StepCtx", "StepError", "Wait", "status", "waiting", "escalate", "reclaim",
-    "EventType", "Flow", "Registry", "cancel", "resume", "retry",
+    "EventType", "Flow", "Registry", "cancel", "resume", "retry", "wake",
 ]

--- a/core/flows/src/flows/signals.py
+++ b/core/flows/src/flows/signals.py
@@ -57,3 +57,24 @@ def cancel(db: DB, reaction_id: str, actor: str, clock: Clock, reason: str | Non
     if rows:
         _record(db, reaction_id, "cancel", actor, reason, clock)
     return bool(rows)
+
+
+def wake(db: DB, reaction_id: str, actor: str, clock: Clock, reason: str | None = None) -> bool:
+    """Re-check NOW a reaction that is deliberately sleeping between polls.
+
+    The gap the other three verbs leave: ``resume`` needs 'blocked', ``retry`` needs
+    'failed', and a reaction waiting on a condition is neither -- it sits in 'retrying'
+    with next_run_at far out. An operator who has just satisfied that condition would
+    otherwise have to UPDATE the table by hand.
+
+    Deliberately narrow: it moves the schedule and nothing else. The attempt counter, the
+    receipts and the status all stay as they were, so a wake can never launder a failure
+    into a fresh attempt -- that is what ``retry`` is for."""
+    rows = db.execute(
+        """UPDATE reaction SET next_run_at = :now, updated_at = :now
+           WHERE reaction_id = :rid AND status IN ('retrying','admitted')
+           RETURNING reaction_id""",
+        {"now": clock.now(), "rid": reaction_id})
+    if rows:
+        _record(db, reaction_id, "wake", actor, reason, clock)
+    return bool(rows)

--- a/core/flows/src/flows_defs/production.py
+++ b/core/flows/src/flows_defs/production.py
@@ -24,7 +24,7 @@ from flows import Done, Registry, StepCtx, StepError, Wait, EventType
 from flows_steps import agent as ag
 from flows_steps import emailx as mx
 from flows_steps import meeting as mt
-from flows_steps.common import ensure_platform_user, scaffolded, ws_file
+from flows_steps.common import ensure_platform_user, scaffolded, ws_file, setting
 
 INVITE = EventType("invite.received")
 ONB_PERSON = EventType("onboarding.person.needed")
@@ -82,11 +82,28 @@ def build(reg: Registry, db) -> None:
         uid = ensure_platform_user(ctx.refs["organizer"])
         return Done({"uid": uid}, provider_ref=uid)
 
+    def _their_clock(uid, epoch):
+        """A time in the person's zone, with the zone attached — never the server's clock."""
+        import datetime
+        tz = setting(uid, "timezone")
+        if tz:
+            try:
+                import zoneinfo
+                t = datetime.datetime.fromtimestamp(epoch, zoneinfo.ZoneInfo(tz))
+                return t.strftime("%H:%M") + " " + (t.tzname() or tz)
+            except Exception:  # noqa: BLE001
+                pass
+        return datetime.datetime.fromtimestamp(
+            epoch, datetime.timezone.utc).strftime("%H:%M") + " UTC"
+
     @reg.step
     def rsvp_accept(ctx: StepCtx):
         """Accept the invitation IN THE ORGANIZER'S CALENDAR — iMIP METHOD:REPLY over SMTP;
         Google flips Vexa to "Yes" in the guest list. Reads: refs.{organizer,ics_uid,start,title}
         Effect: one calendar reply email · Result: {message_id}."""
+        uid = (ctx.prior.get("ensure_user") or {}).get("uid")
+        if uid and not setting(uid, "mail_rsvp"):
+            return Done({"skipped": "mail_rsvp is off for this person"})
         mid = mx.send_rsvp_accept(ctx.refs["organizer"], ics_uid=ctx.refs["ics_uid"],
                                   start_epoch=ctx.refs["start"], title=ctx.refs["title"])
         return Done({"message_id": mid}, provider_ref=mid)
@@ -98,9 +115,11 @@ def build(reg: Registry, db) -> None:
         Reads: refs.{organizer,url,start,title} · Prior: ensure_user · Effect: one email
         Result: {message_id, workspace_ready}."""
         uid = ctx.prior["ensure_user"]["uid"]
+        if not setting(uid, "mail_join"):
+            return Done({"skipped": "mail_join is off for this person"})
         ready = scaffolded(uid)
         body = (f"Vexa accepted the invitation and joins {ctx.refs['url']} at "
-                f"{time.strftime('%H:%M', time.localtime(ctx.refs['start']))}.")
+                f"{_their_clock(uid, ctx.refs['start'])}.")
         if not ready:
             body += ("\n\nOne thing before your minutes can flow: your workspace isn't set up yet — "
                      "answer the setup email that follows (it's a short conversation, not a form).")
@@ -249,6 +268,8 @@ def build(reg: Registry, db) -> None:
         """Send the committed note VERBATIM in the email body (UI-less law) + the feedback ask;
         registers the thread → meet-<id> session. Cannot run before the commit: its input IS
         process_meeting's receipt. Reads: refs.{uid,organizer,title} · Effect: one email."""
+        if not setting(ctx.refs["uid"], "mail_minutes"):
+            return Done({"skipped": "mail_minutes is off for this person"})
         p = ctx.prior["process_meeting"]
         note = ws_file(ctx.refs["uid"], p["note_path"]) or p["summary"]
         body = (note + f"\n\n—\nRecorded by Vexa · commit {p['sha']}\n"

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fastapi import Body, Depends, FastAPI, Header, HTTPException  # noqa: E402
 from pydantic import BaseModel, Field  # noqa: E402
 
-from flows import Registry, SystemClock, cancel, postgres_db, resume, retry  # noqa: E402
+from flows import Registry, SystemClock, cancel, postgres_db, resume, retry, wake  # noqa: E402
 from flows_defs import production  # noqa: E402
 from flows_steps.common import db_url  # noqa: E402
 
@@ -117,9 +117,9 @@ def list_reactions(status: Optional[str] = None):
 @app.post("/reactions/{reaction_id}/{verb}", dependencies=[Depends(auth)])
 def signal_reaction(reaction_id: str, verb: str, x_actor: str = Header(default="api"),
                     body: dict = Body(default={})):
-    fns = {"retry": retry, "resume": resume, "cancel": cancel}
+    fns = {"retry": retry, "resume": resume, "cancel": cancel, "wake": wake}
     if verb not in fns:
-        raise HTTPException(status_code=404, detail="retry | resume | cancel")
+        raise HTTPException(status_code=404, detail="retry | resume | cancel | wake")
     ok = fns[verb](db, reaction_id, actor=x_actor, clock=clock, reason=body.get("reason"))
     if not ok:
         raise HTTPException(status_code=409, detail=f"{verb} not applicable in current status")

--- a/core/flows/src/flows_schema/models.py
+++ b/core/flows/src/flows_schema/models.py
@@ -70,7 +70,7 @@ class Signal(Base):
     reason: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[float] = mapped_column(Double, nullable=False)
     consumed_at: Mapped[float | None] = mapped_column(Double)
-    __table_args__ = (CheckConstraint("kind IN ('resume','retry','cancel')", name="signal_kind"),)
+    __table_args__ = (CheckConstraint("kind IN ('resume','retry','cancel','wake')", name="signal_kind"),)
 
 
 class MailThread(Base):

--- a/core/flows/src/flows_steps/common.py
+++ b/core/flows/src/flows_steps/common.py
@@ -82,7 +82,7 @@ def ws_file(uid: str, path: str, slug: Optional[str] = None) -> Optional[str]:
 # here. Defaults are the floor for someone who has never set anything — the MCP's vocabulary is
 # the source of truth, and it materialises every key the first time a setting is touched.
 _SETTING_DEFAULTS = {
-    "bot_name": "Vexa", "transcribe": True,
+    "bot_name": "Vexa",
     "mail_minutes": True, "mail_join": False, "mail_rsvp": True, "timezone": "",
 }
 

--- a/core/flows/src/flows_steps/common.py
+++ b/core/flows/src/flows_steps/common.py
@@ -39,7 +39,11 @@ def http(method: str, url: str, headers: dict, body: dict | None = None, timeout
         return e.code, (json.loads(raw) if raw.strip().startswith(("{", "[")) else raw)
     except Exception as e:  # noqa: BLE001 — steps turn this into a typed retry
         from flows import StepError
-        raise StepError(f"http {method} {url.split('/api')[0]}…: {type(e).__name__}")
+        # The reason column is the only thing anyone reads when a reaction is stuck, so it has to
+        # carry the cause. It used to carry `TypeError` alone — the class name of an exception
+        # raised while building a header, against a url this line had already truncated to the
+        # host. Hours went into finding a deleted user behind that word.
+        raise StepError(f"http {method} {url}: {type(e).__name__}: {e}"[:400])
 
 
 def ensure_platform_user(email: str) -> str:
@@ -51,9 +55,21 @@ def ensure_platform_user(email: str) -> str:
 
 
 def user_api_key(uid: str) -> str:
-    _, tok = http("POST", f"{ADMIN_API}/admin/users/{uid}/tokens", {"X-Admin-API-Key": ADMIN_KEY},
-                  {"scopes": ["bot", "browser", "tx"]})
-    return tok.get("token") or tok.get("key")
+    """This user's gateway key, or a StepError that says why there isn't one.
+
+    Returning None here was the whole bug: the caller put it straight into an X-API-Key header,
+    urllib died joining it, and the reaction blamed the gateway for a 404 from the admin API. A
+    key that cannot be minted is a fact about the account, and it belongs in the reason.
+    """
+    st, tok = http("POST", f"{ADMIN_API}/admin/users/{uid}/tokens",
+                   {"X-Admin-API-Key": ADMIN_KEY}, {"scopes": ["bot", "browser", "tx"]})
+    key = tok.get("token") or tok.get("key") if isinstance(tok, dict) else None
+    if not key:
+        from flows import StepError
+        detail = (tok.get("detail") if isinstance(tok, dict) else str(tok))
+        raise StepError(f"no api key for platform user {uid} — admin api said {st}: "
+                        f"{str(detail)[:120]}")
+    return key
 
 
 def ws_file(uid: str, path: str, slug: Optional[str] = None) -> Optional[str]:

--- a/core/flows/src/flows_steps/common.py
+++ b/core/flows/src/flows_steps/common.py
@@ -78,5 +78,24 @@ def ws_file(uid: str, path: str, slug: Optional[str] = None) -> Optional[str]:
     return body.get("content") if code == 200 and isinstance(body, dict) else None
 
 
+# A person's preferences, read from their workspace. The MCP writes this file; steps read it
+# here. Defaults are the floor for someone who has never set anything — the MCP's vocabulary is
+# the source of truth, and it materialises every key the first time a setting is touched.
+_SETTING_DEFAULTS = {
+    "bot_name": "Vexa", "transcribe": True,
+    "mail_minutes": True, "mail_join": False, "mail_rsvp": True, "timezone": "",
+}
+
+
+def setting(uid: str, key: str):
+    """One preference for one person. Never raises: a missing file means defaults."""
+    import json as _j
+    try:
+        raw = _j.loads(ws_file(uid, ".settings.json") or "{}")
+    except Exception:  # noqa: BLE001
+        raw = {}
+    return raw.get(key, _SETTING_DEFAULTS.get(key))
+
+
 def scaffolded(uid: str, slug: Optional[str] = None) -> bool:
     return ws_file(uid, ".scaffolded", slug) is not None

--- a/core/flows/src/flows_steps/emailx.py
+++ b/core/flows/src/flows_steps/emailx.py
@@ -16,13 +16,39 @@ VAULT = os.path.expanduser("~/dev/vexa-secrets/business/vexa-mail.enc.env")
 
 
 def creds() -> tuple[str, str]:
-    if not (os.environ.get("VEXA_MAIL_ADDR") and os.environ.get("VEXA_MAIL_APP_PASSWORD")):
-        out = subprocess.run(["sops", "-d", VAULT], check=True, capture_output=True, text=True).stdout
-        for line in out.splitlines():
-            if "=" in line and not line.startswith("#"):
-                k, v = line.split("=", 1)
-                os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
-    return os.environ["VEXA_MAIL_ADDR"], os.environ["VEXA_MAIL_APP_PASSWORD"]
+    """Address and password, always as a PAIR.
+
+    They used to come from different places: the guard fired when either was missing, the vault
+    was decrypted, and os.environ.setdefault then refused to replace an address that was already
+    set. A rig exporting VEXA_MAIL_ADDR and no password therefore logged into Gmail as
+    vexa@storm.test with the production account's password — Gmail answered 535 and the error
+    read as an expired credential for hours. A half-configured pair is not a configuration.
+    """
+    addr = os.environ.get("VEXA_MAIL_ADDR")
+    pw = os.environ.get("VEXA_MAIL_APP_PASSWORD")
+    if addr and pw:
+        return addr, pw
+    out = subprocess.run(["sops", "-d", VAULT], check=True, capture_output=True, text=True).stdout
+    vault = {}
+    for line in out.splitlines():
+        if "=" in line and not line.startswith("#"):
+            k, v = line.split("=", 1)
+            vault[k.strip()] = v.strip().strip('"').strip("'")
+    return vault["VEXA_MAIL_ADDR"], vault["VEXA_MAIL_APP_PASSWORD"]
+
+
+def _smtp():
+    """Where mail actually goes.
+
+    Hardcoding smtp.gmail.com meant the mail double this rig runs was never reachable: the invite
+    path could not be rehearsed, only fired at real recipients. When VEXA_MAIL_SMTP_HOST is set we
+    honour it; with nothing set, behaviour is exactly as before.
+    """
+    host = os.environ.get("VEXA_MAIL_SMTP_HOST")
+    if not host:
+        return smtplib.SMTP_SSL("smtp.gmail.com", 465, timeout=20), True
+    port = int(os.environ.get("VEXA_MAIL_SMTP_PORT", "25"))
+    return smtplib.SMTP(host, port, timeout=20), False
 
 
 def send(to: str, subject: str, body: str, *, in_reply_to: str | None = None) -> str:
@@ -33,8 +59,10 @@ def send(to: str, subject: str, body: str, *, in_reply_to: str | None = None) ->
     if in_reply_to:
         m["In-Reply-To"] = m["References"] = in_reply_to
     m.set_content(body)
-    with smtplib.SMTP_SSL("smtp.gmail.com", 465, timeout=20) as s:
-        s.login(addr, pw)
+    conn, needs_login = _smtp()
+    with conn as s:
+        if needs_login:
+            s.login(addr, pw)
         s.send_message(m)
     return m["Message-ID"]
 
@@ -63,7 +91,9 @@ def send_rsvp_accept(organizer_email: str, *, ics_uid: str, start_epoch: float, 
     cal = MIMEText(ics, "calendar")
     cal.set_param("method", "REPLY")
     msg.attach(cal)
-    with smtplib.SMTP_SSL("smtp.gmail.com", 465, timeout=20) as s:
-        s.login(addr, pw)
+    conn, needs_login = _smtp()
+    with conn as s:
+        if needs_login:
+            s.login(addr, pw)
         s.send_message(msg)
     return msg["Message-ID"]

--- a/core/flows/src/flows_steps/meeting.py
+++ b/core/flows/src/flows_steps/meeting.py
@@ -32,10 +32,14 @@ def dispatch_bot(ctx: StepCtx):
     """Spawn the REAL bot via gateway POST /bots (transcribe per deployment; 409 = adopt the
     existing meeting). Prior: ensure_user (for the key) · Effect: bot container
     Result: {meeting_id, native, platform}."""
-    key = user_api_key(ctx.prior["ensure_user"]["uid"])
+    uid = ctx.prior["ensure_user"]["uid"]
+    key = user_api_key(uid)
+    # ASK THE PERSON. These two were literals — "Vexa" with nothing to change it, and
+    # transcribe_enabled=False, which is why a standup recorded audio and captured no words.
     st, body = http("POST", f"{GATEWAY}/bots", {"X-API-Key": key},
-                    {"meeting_url": ctx.refs["url"], "bot_name": "Vexa",
-                     "transcribe_enabled": False})
+                    {"meeting_url": ctx.refs["url"],
+                     "bot_name": setting(uid, "bot_name") or "Vexa",
+                     "transcribe_enabled": bool(setting(uid, "transcribe"))})
     if st == 409:
         st2, existing = http("GET", f"{GATEWAY}/bots", {"X-API-Key": key})
         rows = existing if isinstance(existing, list) else existing.get("meetings", [])

--- a/core/flows/src/flows_steps/meeting.py
+++ b/core/flows/src/flows_steps/meeting.py
@@ -34,12 +34,14 @@ def dispatch_bot(ctx: StepCtx):
     Result: {meeting_id, native, platform}."""
     uid = ctx.prior["ensure_user"]["uid"]
     key = user_api_key(uid)
-    # ASK THE PERSON. These two were literals — "Vexa" with nothing to change it, and
-    # transcribe_enabled=False, which is why a standup recorded audio and captured no words.
+    # transcribe_enabled is NOT passed. It used to be hardcoded False here, against this step's
+    # own docstring, which is why a standup recorded audio and captured no words. The platform
+    # defaults it to True and resolves TRANSCRIBE_ENABLED per deployment — so naming it here
+    # could only ever override a correct decision with a worse one. The name is the person's;
+    # whether we transcribe at all is the deployment's.
     st, body = http("POST", f"{GATEWAY}/bots", {"X-API-Key": key},
                     {"meeting_url": ctx.refs["url"],
-                     "bot_name": setting(uid, "bot_name") or "Vexa",
-                     "transcribe_enabled": bool(setting(uid, "transcribe"))})
+                     "bot_name": setting(uid, "bot_name") or "Vexa"})
     if st == 409:
         st2, existing = http("GET", f"{GATEWAY}/bots", {"X-API-Key": key})
         rows = existing if isinstance(existing, list) else existing.get("meetings", [])


### PR DESCRIPTION
**Rung: PR open** — built, live-exercised on the bbb dogfood rig where `wake` was added mid-storm because a retrying reaction had no legitimate wake path; tests 40 passed / 5 skipped, pre-push static gates green; **not merged**.

## What this changes

A reaction parked in `retrying` could be cancelled but never woken. `resume` needs `blocked`, `retry` needs `failed` — a reaction sleeping on a condition is neither: it sits in `retrying` with `next_run_at` far out. The only route was `UPDATE`-ing `next_run_at` by hand, exactly the shell surgery signals exist to prevent.

`wake` is an audited signal row like `resume`/`retry`/`cancel`: valid on `retrying`/`admitted`, advances `next_run_at` to now, records the actor. Deliberately narrow — it moves the schedule and nothing else. The attempt counter, the receipts and the status all stay as they were, so a wake can never launder a failure into a fresh attempt; that is what `retry` is for.

| File | Change |
|---|---|
| `core/flows/src/flows/signals.py` | new `wake()` verb |
| `core/flows/src/flows/__init__.py` | export `wake` |
| `core/flows/src/flows_integrations/flows_api.py` | `wake` in the `POST /reactions/{id}/{verb}` map + the 404 detail |
| `core/flows/src/flows_schema/models.py` | `signal_kind` CHECK includes `'wake'` |
| `core/flows/schema.sql` | regenerated through the SSOT (`make schema`), verified idempotent |

## Lane

Part of the meeting-series/minutes lane; sibling PRs #1318 #1319 #1322. Based on `codex/1315-group-meeting-flow` like all three siblings, **not `main`** — main is 121 commits behind this lane head, so a main-based PR would show the whole lane instead of these five files.

## Superseded by #1318: the emailx.py change is NOT in this PR

This branch was prepared with a sixth file — `flows_steps/emailx.py`, making SMTP host/port/mode env-driven (`VEXA_MAIL_SMTP_HOST/_PORT/_MODE`) instead of hardcoded `smtp.gmail.com:465`. **Dropped before commit:** #1318 supersedes it on both counts — it lifts SMTP out of `emailx.py` entirely into the `mail_transport.py` seam and makes the hosts env-driven there (`VEXA_MAIL_SMTP_HOST`, `_PORT`, `VEXA_MAIL_SMTP_STARTTLS`). Keeping ours would have been a direct textual conflict over the same functions for no added coverage.

**One residual gap, for whoever picks it up** — not fixed here, not a blocker for #1318: the dropped version also skipped SMTP `login()` when no password was configured, so an auth-less relay (Mailpit, an internal MTA) works. #1318's `ImapSmtpTransport._smtp()` always calls `login()`, and its `creds()` always demands `VEXA_MAIL_APP_PASSWORD` (falling back to a SOPS decrypt), so a no-auth local relay still cannot be pointed at. Worth a follow-up on the seam rather than a competing edit here.

## Merge ordering with #1318

Both PRs touch `schema.sql` and `flows_schema/models.py`, but in **different regions** — #1318 adds `mail_cursor.token`, this adds `'wake'` to the `signal_kind` CHECK — so they merge cleanly in either order. Re-run `make schema` after the second lands to confirm the generated file matches the union.

## Verification (bbb, `/home/dima/dev/vexa-flows1315`)

- `make test` → **40 passed, 5 skipped** (0.90s)
- `make gates` → isolation ✅, schema drift ✅
- `make schema` idempotent → `schema.sql` sha256 unchanged across regeneration
- pre-push hook: 14 fast static gates green (incl. `schema`, `contract-conformance`)

COMMITMENTS IN THIS DRAFT — two decisions taken here, both reversible, both stated above rather than buried: (1) the `emailx.py` env-driven-SMTP change was **dropped** as superseded by #1318, leaving the no-auth-relay gap above unowned; (2) the base is the **lane branch**, not `main`. No money, dates, rights, or published terms.

<!-- vexa-agent -->
