### PR TITLE
release: freeze v0.12.25-rc.1 validation identity (all legs green)

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -250,7 +250,7 @@ jobs:
             v0.12.25-rc.1|v0.12.25)
               CANDIDATE_MAP=releases/v0.12.25/candidate-images.json
               EXPECTED_MAP_STABLE_TAG=v0.12.25
-              EXPECTED_MAP_SHA256=2f94ba3d48c57bd78bef3815b9982cfc4b633353c1a65cd1e20eb90f997eaa66
+              EXPECTED_MAP_SHA256=d9d0cdd13623cb1a9b3772adff271b2b1b0aa457c11a7286cfb13655d813b289
               EXPECTED_TOP_DESCRIPTORS=10
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -311,7 +311,7 @@ test("v0.12.25 canonical packet binds the rc.1 train candidate", () => {
   );
   assert.equal(
     createHash("sha256").update(raw).digest("hex"),
-    "2f94ba3d48c57bd78bef3815b9982cfc4b633353c1a65cd1e20eb90f997eaa66",
+    "d9d0cdd13623cb1a9b3772adff271b2b1b0aa457c11a7286cfb13655d813b289",
   );
   const map = validateCandidateMap(JSON.parse(raw), "v0.12.25");
   assert.equal(map.candidate_tag, "v0.12.25-rc.1");

--- a/releases/v0.12.25/candidate-images.json
+++ b/releases/v0.12.25/candidate-images.json
@@ -4,9 +4,9 @@
  "stable_tag": "v0.12.25",
  "candidate_tag": "v0.12.25-rc.1",
  "build_source": "dedb017355aa5a2827b6c910b87d91c730b33963",
- "validation_source": "dedb017355aa5a2827b6c910b87d91c730b33963",
+ "validation_source": "16a63f60ada8833ecc3e85cc1c92de8376493038",
  "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/33303578205",
- "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33303578205",
+ "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33334426153",
  "images": {
   "vexaai/v012-admin-api": {
    "class": "prod_deployed",


### PR DESCRIPTION
Step 3 of `releases/README.md` § Bind, validate, freeze: writes `validation_source` (16a63f60) + `validation_run` ([33334426153](https://github.com/Vexa-ai/vexa/actions/runs/33334426153), completed success, zero non-green jobs) into the v0.12.25 candidate map and re-pins the new sha256 (`d9d0cdd1…`) in the resolve table and the canonical test. After merge: stable tag `v0.12.25` at this commit → release-images publishes.

### Contribution Rights

- [x] I am the sole rights holder for my contribution. (Independent path.) <!-- rights:independent -->

*(release mechanics under the founder's standing release order + 'tick and release for me' delegation)*

<!-- vexa-agent -->