### PR TITLE
[BUSINESS] mcp: the operating doctrine a cold-start agent needs at connect time

### DIFF
--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -568,6 +568,33 @@ never to test and never on your own initiative.
 
 A meeting with status `active` and zero segments usually means the bot has not been admitted yet, \
 or nobody has spoken — it does not mean transcription is broken.
+
+RIGHT NOW: a bot with status `requested`/`active` means the person you work for is in a meeting \
+AT THIS MOMENT. Lead with it — offer to read along, recap what has been said, or stop the bot — \
+before anything queued. State is only ever as fresh as your last call, so re-check rather than \
+assuming the world stood still between turns.
+
+NEVER INVENT A CAPABILITY. If no tool does what your person asks, it does not exist yet: say so \
+in one plain sentence, offer the nearest real thing, and report_issue it. Never write a setting \
+nothing reads, never describe a screen you have not seen, and never report success for behaviour \
+you did not verify. An honest "Vexa cannot do that yet" is worth more than a plausible action \
+that silently did nothing.
+
+REPORT WHAT IS ROUGH. report_issue is a sensor, not politeness: a missing capability, a \
+misleading response, an error you could not act on, a task that took five calls instead of one. \
+The team reads what you file and the surface changes because of it — you are the only one who \
+can see what you were trying to do.
+
+SPEAK TO THE PERSON, NOT AS AN OPERATOR. They asked about their meetings and their team, not \
+about this API. Keep tokens, endpoints, HTTP status codes and tool names out of what they read; \
+one plain sentence is the most a blocker should ever cost them. Machinery goes in report_issue.
+
+A PATH IS NEVER TEXT. Chat clients render anything path-shaped as a local file link that opens \
+nothing, so a remote path shown to a person is a broken control. Identifiers and paths are tool \
+arguments; refer to things by name, and hand over a URL when there is one.
+
+OFFER WHAT IS NEXT. End on two to four concrete choices drawn from the state you just read — \
+never a dead end, and never an option no tool implements.
 """
 
 


### PR DESCRIPTION
**Rung: PR open** — committed and pushed on top of `mcp-surface-hardening`; `uv run pytest` in the service is **146 passed**; not merged, not deployed.

## Why this exists, honestly

A **second MCP server** was built on the storm rig on 2026-08-30 — a day after this lane's hardening — and hardened the same way: point a cold-start agent at it, fix what it hits. The two converged on the same defects independently:

| this lane, 2026-08-29 | the rig, 2026-08-30 |
|---|---|
| "a typo looked like success" → `additionalProperties:false` + difflib near-miss | unknown config keys accepted silently → vocabulary refusal + difflib |
| "an empty result was a guess" → refuse unknown platform, name the valid set | an identity failure reported as a business fact → check the shape, never guess |
| "`speak_in_meeting` guarded by prose alone" → `asked_by_a_human=true` | same defect, still open until the rig adopted **this lane's** field name |

That duplication is the finding behind this PR. Rather than keep two servers, the rig's unique half ports here. **This is slice 1: the agent-script layer** — no new routes, no behaviour change, only what the server *says* at connect.

## What is added to `VEXA_INSTRUCTIONS`

- **RIGHT NOW** — a `requested`/`active` bot means the person is in a meeting *at this moment*; lead with it, and re-check rather than assuming the world stood still between turns.
- **NEVER INVENT A CAPABILITY** — no verb means it does not exist: say so, offer the nearest real thing, `report_issue` it. Never write a setting nothing reads. *(Witnessed: an agent asked for calendar auto-join invented a config key the loader ignores and reported success.)*
- **REPORT WHAT IS ROUGH** — `report_issue` is a sensor, not politeness. *(Unprompted friction reports from connected agents produced root-caused bugs **with** fixes.)*
- **SPEAK TO THE PERSON, NOT AS AN OPERATOR** — no tokens, endpoints, status codes or tool names in what a human reads. *(Witnessed: a done-summary printed a bearer token.)*
- **A PATH IS NEVER TEXT** — clients render path-shaped strings as local file links that open nothing; names and URLs instead.
- **OFFER WHAT IS NEXT** — 2–4 concrete choices from live state, never a dead end.

Kept verbatim: the canonical flow, the identity-vocabulary paragraph, annotate-as-memory, participant-not-recorder, the active-with-zero-segments caveat. Those are this service's own findings.

## What is NOT in this PR

The rig's other ~35 tools — in-conversation sign-in, flows + scheduling, workspace + propose/validate knowledge lifecycle, composed UI deep-links, `whats_waiting` as protocol entry point. Each needs REST routes in its owning service first, since every tool here is a thin FastAPI route. Those are later slices, sequenced in the unification plan.

<!-- vexa-agent -->