### PR TITLE
fix(mixed): raise CSRC_INACTIVE_MS 400 → 800 ms, measured on live Teams

### DIFF
--- a/core/meetings/modules/mixed-capture-core/src/csrc-poll.test.ts
+++ b/core/meetings/modules/mixed-capture-core/src/csrc-poll.test.ts
@@ -81,11 +81,11 @@ const receiver = (sources: () => ContributingSourceLike[]) => ({
   t += 200; poll.poll();
   check('inside the inactivity window a stale entry is NOT yet a deactivation',
     out.length === 1, JSON.stringify(out));
-  t += 300; poll.poll();   // 500ms > 400ms default
+  t += 700; poll.poll();   // 900ms > 800ms default
   check('past inactiveMs the deactivation is SYNTHESIZED (the transport never sends this edge)',
     out.length === 2 && out[1].active === false && out[1].csrc === 7 && out[1].tMs === t,
     JSON.stringify(out));
-  check('the default inactivity window is 400ms', CSRC_INACTIVE_MS === 400);
+  check('the default inactivity window is 800ms', CSRC_INACTIVE_MS === 800);
 
   // Speaking again is a NEW activation — turns are edges, not a level.
   speaking = true; lastSpoke = t; poll.poll();
@@ -117,7 +117,7 @@ const receiver = (sources: () => ContributingSourceLike[]) => ({
     JSON.stringify(out));
   check('health counts both as active', poll.health().active === 2, JSON.stringify(poll.health()));
   live.delete(11);
-  t += 500; poll.poll();
+  t += 900; poll.poll();
   check('only the source that went quiet deactivates; the other stays open',
     out.length === 3 && out[2].csrc === 11 && out[2].active === false && poll.health().active === 1,
     JSON.stringify(out));

--- a/core/meetings/modules/mixed-capture-core/src/csrc-poll.test.ts
+++ b/core/meetings/modules/mixed-capture-core/src/csrc-poll.test.ts
@@ -81,7 +81,10 @@ const receiver = (sources: () => ContributingSourceLike[]) => ({
   t += 200; poll.poll();
   check('inside the inactivity window a stale entry is NOT yet a deactivation',
     out.length === 1, JSON.stringify(out));
-  t += 700; poll.poll();   // 900ms > 800ms default
+  t += 550; poll.poll();   // 750ms staleness — just inside the 800ms window
+  check('just inside the window the entry is STILL held open (the boundary, not the middle)',
+    out.length === 1, JSON.stringify(out));
+  t += 100; poll.poll();   // 850ms > 800ms default
   check('past inactiveMs the deactivation is SYNTHESIZED (the transport never sends this edge)',
     out.length === 2 && out[1].active === false && out[1].csrc === 7 && out[1].tMs === t,
     JSON.stringify(out));

--- a/core/meetings/modules/mixed-capture-core/src/csrc-poll.ts
+++ b/core/meetings/modules/mixed-capture-core/src/csrc-poll.ts
@@ -112,7 +112,7 @@ export interface CsrcPollOptions {
   receivers?: () => CsrcReceiverLike[];
   /** Poll cadence in ms. Default 100 — the granularity the transport itself updates at. */
   pollMs?: number;
-  /** How long a source stays active after its last observed contribution. Default 400 ms. */
+  /** How long a source stays active after its last observed contribution. Default 800 ms. */
   inactiveMs?: number;
   /** Epoch-ms clock (injectable for tests). */
   now?: () => number;
@@ -133,8 +133,13 @@ export interface CsrcPoll {
 
 /** The transport updates roughly per packet; 100 ms is one packet-train, not an arbitrary tick. */
 export const CSRC_POLL_MS = 100;
-/** Chosen to span a packet gap (jitter, DTX, a brief pause) without holding a finished turn open. */
-export const CSRC_INACTIVE_MS = 400;
+/** Chosen to span a packet gap (jitter, DTX, a brief pause) without holding a finished turn open.
+ *  Measured on a live Microsoft Teams meeting (2026-08-20): replaying this transition logic over a
+ *  599-sample tape of a 6 s speech / 7 s silence cycle yields 10 deactivations at 400 ms —
+ *  fragmenting one speech phase into segments as short as 0.1 s — against 7 at 800 ms, where the
+ *  reconstructed segments match the fixture's real structure. Teams' mixer pauses inside a turn
+ *  for longer than one packet-train, so 400 ms closes turns that are still open. */
+export const CSRC_INACTIVE_MS = 800;
 /** Beyond this, a timestamp is not the clock we think it is. Mirrors the bridge's hint guard. */
 const MAX_CLOCK_SKEW_MS = 10 * 60 * 1000;
 

--- a/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
+++ b/core/meetings/modules/mixed-pipeline/src/chunked-transcriber.ts
@@ -651,8 +651,8 @@ export class ChunkedTranscriber {
         if (!mine()) return;
         if (this.turn && ev.tracks) this.turn.spanTracks = ev.tracks;
         // A segmenter's speech-end lands a little early and needs a trailing STT pad; a transport
-        // deactivation already carries the sensor's own 400ms inactivity window, so padding it
-        // again would only feed Whisper more silence.
+        // deactivation already carries the sensor's own inactivity window (CSRC_INACTIVE_MS), so
+        // padding it again would only feed Whisper more silence.
         this.closeTurn(ev.t1, ev.reason === 'silence' ? SILENCE_CLOSE_CONTEXT_MS : 0);
       },
     };

--- a/core/meetings/modules/mixed-pipeline/src/turn-source.ts
+++ b/core/meetings/modules/mixed-pipeline/src/turn-source.ts
@@ -203,9 +203,11 @@ const envNumber = (name: string, fallback: number): number => {
   return Number.isFinite(n) && n > 0 ? n : fallback;
 };
 
-/** How long a source may go quiet before its turn is closed. The sensor already waits 400ms before
- *  declaring a deactivation, so this is the SECOND grace: it spans a breath, a DTX gap, a dropped
- *  packet train. Too small shatters a sentence into turns; too large merges a real handoff. */
+/** How long a source may go quiet before its turn is closed. The sensor already waits
+ *  CSRC_INACTIVE_MS (800 ms, measured on live Teams) before declaring a deactivation, so this is
+ *  the SECOND grace: it spans a breath, a DTX gap, a dropped packet train. Too small shatters a
+ *  sentence into turns; too large merges a real handoff. Combined worst-case close latency is the
+ *  sum of both graces (~1.4 s at the defaults). */
 export const CSRC_HYSTERESIS_MS = envNumber('VEXA_CSRC_HYSTERESIS_MS', 600);
 /** Energetic audio this long with NOT ONE transition ⇒ the transport stopped talking to us while
  *  the meeting continued. Measured in audio time, on frames that carry energy, so an honestly

--- a/core/meetings/services/bot/src/csrc-capture.boundary.test.ts
+++ b/core/meetings/services/bot/src/csrc-capture.boundary.test.ts
@@ -139,7 +139,7 @@ async function main(): Promise<void> {
     await page.evaluate('window.__fixtureSpeakingSince = performance.now();');
     await sleep(400);
     await page.evaluate('window.__fixtureSpeakingSince = null;');
-    await sleep(900);                                    // > the 400ms inactivity window
+    await sleep(1300);                                   // > the 800ms inactivity window, with real-clock margin
     await stop();
     await recorder.close();
 


### PR DESCRIPTION
A measurement-backed default change to the CSRC sensor's inactivity window, from running your mixed-capture lane against live Microsoft Teams meetings downstream

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required**
  <!-- rights:corporate -->
- [ ] **Unsure**
  <!-- rights:uncertain -->

Commits are DCO-signed.

## What and why

`CSRC_INACTIVE_MS` moves from 400 to 800 ms. Measured, not guessed: replaying the transition logic over a **599-sample tape of a live Teams meeting** (a 6 s speech / 7 s silence cycle, captured 2026-08-20) yields:

| inactiveMs | synthesized deactivations | segment quality |
|---|---|---|
| 400 ms | **10** | one speech phase fragments into segments as short as 0.1 s |
| 800 ms | **7** | reconstructed segments match the fixture's real structure |

Teams' mixer pauses inside a turn for longer than one packet-train, so at 400 ms the sensor synthesizes deactivations for turns that are still open — and each false edge is a turn boundary the downstream namer has to un-learn. 800 ms still closes a finished turn well inside the UA's own multi-second "recently contributed" retention, and `inactiveMs` remains configurable per poller for callers that want the old value.

Side observation from the same capture, relevant to anyone weighing `audioLevel` heuristics: on Chrome, `audioLevel` was **absent in 1200 of 1200 observations** — not merely optional in practice, but never present.

## Changes

- `mixed-capture-core/src/csrc-poll.ts` — the constant (with the measurement recorded in its doc comment) and the option's doc line.
- `mixed-capture-core/src/csrc-poll.test.ts` — the timing steps that encoded 400 ms, **plus a boundary straddle** (still open at 750 ms staleness, deactivated at 850 ms) so the behavior itself — not only the pinned constant — catches a regression. Verified by mutation: reverting the constant to 400 now fails 3 checks (2 behavioral), previously only the pinned literal.
- `services/bot/src/csrc-capture.boundary.test.ts` — the fourth timing the first commit missed: the real-browser test slept 900 ms, a cushion the bump silently cut from 500 ms to 100 ms (one poll tick) over Playwright scheduling jitter. Now 1300 ms, comment corrected.
- `mixed-pipeline/src/turn-source.ts` — `CSRC_HYSTERESIS_MS`'s doc called the sensor's grace "400ms" (now stale); corrected, and the **combined worst-case close latency (~1.4 s at the defaults, up from ~1.0 s)** is stated where the tuning decision lives.
- `mixed-pipeline/src/chunked-transcriber.ts` — the same stale 400 ms in the trailing-pad rationale, de-numericized.

## For the maintainers — two open points, honestly stated

1. **Composed latency:** with the sensor at 800 ms, `CSRC_INACTIVE_MS + CSRC_HYSTERESIS_MS` rises 1.0 s → 1.4 s worst-case before `CsrcTurnSource` closes a turn. Since the CSRC path is diagnostic-only today (`capture-bridge.ts` marks it NOT wired to `__vexaSpeakerHint`), nothing user-visible shifts — but if/when the transport becomes the turn spine, you may want to re-tune `CSRC_HYSTERESIS_MS` (env-overridable) against the new baseline. Happy to run that measurement on our Teams tapes if useful.
2. **Overlap analysis:** our tape counted deactivation fragmentation only; a contested-turn/overlap rate at 400 vs 800 ms was not measured. The `inactiveMs` option keeps the old behavior reachable if you want to hold the default pending that.

docs: no changelog fragment — the CSRC sensor is diagnostic-only (not wired to transcript output), per the `changelog.d` no-user-visible-effect carve-out. Say the word if you'd rather have one anyway.

Happy to adjust shape (e.g. keep 400 and change only the bot's call site) if you'd rather hold the sensor's default — the measurement is the contribution either way.