### PR TITLE
release: version → 0.12.26

### DIFF
--- a/deploy/helm/charts/vexa/Chart.yaml
+++ b/deploy/helm/charts/vexa/Chart.yaml
@@ -4,7 +4,7 @@ description: Vexa v0.12 — self-hostable real-time meeting transcription + agen
 type: application
 # Chart version (SemVer). appVersion tracks the v0.12 control-plane image tag the chart deploys.
 version: 0.12.1
-appVersion: "0.12.25"
+appVersion: "0.12.26"
 home: https://github.com/Vexa-ai/vexa
 sources:
   - https://github.com/Vexa-ai/vexa

--- a/docs/changelog.d/1011-noble-base.md
+++ b/docs/changelog.d/1011-noble-base.md
@@ -1,6 +1,0 @@
-- **The bot and Lite images now build on Ubuntu 24.04 (Noble) (#1011).** The meeting-bot image and
-  the Vexa Lite single-container image moved from the Jammy to the Noble Playwright base — one base
-  for both. Self-hosters running the agent worker also get a fix: it already exec'd its Python
-  interpreter as a non-root per-subject uid, but that interpreter lives under `/root`, which is
-  `0700`, so every dispatch died with `Permission denied` and respawned. `/root` is now
-  traverse-only for others (`chmod o+x`); it stays unlistable and root-owned files keep their modes.

--- a/docs/changelog.d/1018-zoom-speakers.md
+++ b/docs/changelog.d/1018-zoom-speakers.md
@@ -1,2 +1,0 @@
-- **More accurate Zoom speaker attribution (#1018).** Zoom transcripts are named per-participant with a
-  self-correcting vote, so a speaker's words are far less likely to land under the wrong name.

--- a/docs/changelog.d/1148-text-only-stt.md
+++ b/docs/changelog.d/1148-text-only-stt.md
@@ -1,4 +1,0 @@
-- **Text-only custom STT responses now reach the transcript (#1148).** OpenAI-compatible
-  endpoints may return only `text`; the mixed pipeline now assigns that text to the submitted
-  speech window instead of discarding it for missing provider timestamps. See
-  [Custom STT endpoints](/how-to/custom-stt).

--- a/docs/changelog.d/1258-runtime-default-bot-name.md
+++ b/docs/changelog.d/1258-runtime-default-bot-name.md
@@ -1,7 +1,0 @@
-- **Self-host: `DEFAULT_BOT_NAME` now names the bots the terminal sends (#1258).** The terminal hardcoded
-  `bot_name: "Vexa"` on every join, so the variable compose, Lite and helm already passed to
-  meeting-api could never take effect. The terminal now omits `bot_name` and lets the deployment
-  decide, making a rename a `.env` edit plus a meeting-api restart — no terminal rebuild. The stock
-  name is unchanged (`Vexa`), an explicit `bot_name` in `POST /bots` still wins, and
-  `NEXT_PUBLIC_DEFAULT_BOT_NAME` is now a real terminal build arg for baking a name into the image.
-  See [Configuration](/configuration#bot-participant-name).

--- a/docs/changelog.d/1342-voxtral-json.md
+++ b/docs/changelog.d/1342-voxtral-json.md
@@ -1,3 +1,0 @@
-- **Custom STT: JSON-only Voxtral models now transcribe meetings.** Vexa negotiates down from
-  `verbose_json` to `json` once when a backend rejects verbose output, while Whisper backends keep
-  their richer segment metadata. See [Use a custom STT endpoint](/how-to/custom-stt).

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -3,10 +3,10 @@ title: "Changelog & migration"
 description: "Release notes and what changes between major versions."
 ---
 
-{/* docs-reflects: 0.12.25 — the released version these docs describe. CI (gate:docs-version) keeps
+{/* docs-reflects: 0.12.26 — the released version these docs describe. CI (gate:docs-version) keeps
     this equal to Chart.yaml appVersion; the release version-bump updates it. */}
 
-> 📌 **These docs reflect Vexa `v0.12.25`** — the current release candidate control-plane. Older self-hosts
+> 📌 **These docs reflect Vexa `v0.12.26`** — the current release candidate control-plane. Older self-hosts
 > should read against their pinned version.
 
 The authoritative, per-release changelog is on **GitHub Releases**:
@@ -1012,6 +1012,33 @@ fix(gates): every gate failure now prints its diagnostic — an empty stdout Buf
 - **Restarting mid-leave no longer strands a meeting in "stopping" (#1280).** When Vexa restarted while a
   bot was still leaving, the meeting could sit in "stopping" — shown as active — indefinitely across a
   redeploy burst. A meeting whose stop was explicitly requested now converges on the short stop grace.
+
+- **The bot and Lite images now build on Ubuntu 24.04 (Noble) (#1011).** The meeting-bot image and
+  the Vexa Lite single-container image moved from the Jammy to the Noble Playwright base — one base
+  for both. Self-hosters running the agent worker also get a fix: it already exec'd its Python
+  interpreter as a non-root per-subject uid, but that interpreter lives under `/root`, which is
+  `0700`, so every dispatch died with `Permission denied` and respawned. `/root` is now
+  traverse-only for others (`chmod o+x`); it stays unlistable and root-owned files keep their modes.
+
+- **More accurate Zoom speaker attribution (#1018).** Zoom transcripts are named per-participant with a
+  self-correcting vote, so a speaker's words are far less likely to land under the wrong name.
+
+- **Text-only custom STT responses now reach the transcript (#1148).** OpenAI-compatible
+  endpoints may return only `text`; the mixed pipeline now assigns that text to the submitted
+  speech window instead of discarding it for missing provider timestamps. See
+  [Custom STT endpoints](/how-to/custom-stt).
+
+- **Self-host: `DEFAULT_BOT_NAME` now names the bots the terminal sends (#1258).** The terminal hardcoded
+  `bot_name: "Vexa"` on every join, so the variable compose, Lite and helm already passed to
+  meeting-api could never take effect. The terminal now omits `bot_name` and lets the deployment
+  decide, making a rename a `.env` edit plus a meeting-api restart — no terminal rebuild. The stock
+  name is unchanged (`Vexa`), an explicit `bot_name` in `POST /bots` still wins, and
+  `NEXT_PUBLIC_DEFAULT_BOT_NAME` is now a real terminal build arg for baking a name into the image.
+  See [Configuration](/configuration#bot-participant-name).
+
+- **Custom STT: JSON-only Voxtral models now transcribe meetings.** Vexa negotiates down from
+  `verbose_json` to `json` once when a backend rejects verbose output, while Whisper backends keep
+  their richer segment metadata. See [Use a custom STT endpoint](/how-to/custom-stt).
 
 ## Versioning
 

--- a/docs/docs/changelog.mdx
+++ b/docs/docs/changelog.mdx
@@ -1023,6 +1023,14 @@ fix(gates): every gate failure now prints its diagnostic — an empty stdout Buf
 - **More accurate Zoom speaker attribution (#1018).** Zoom transcripts are named per-participant with a
   self-correcting vote, so a speaker's words are far less likely to land under the wrong name.
 
+- **Known limit — the Zoom bot joins as a web client, so not every Zoom meeting can be
+  recorded.** Some Zoom accounts and meetings block automated browser clients outright; the bot is
+  refused at the door there, ends as `failed` with reason `zoom_requires_rtms`, and no transcript is
+  produced. This is a platform policy on the host's side, not a fault in the bot — those meetings
+  need Zoom's Realtime Media Streams path, which this release does not ship
+  ([#706](https://github.com/Vexa-ai/vexa/issues/706)). Meetings that do admit a web client are
+  unaffected, and this release also improves the bot's ability to be admitted at all.
+
 - **Text-only custom STT responses now reach the transcript (#1148).** OpenAI-compatible
   endpoints may return only `text`; the mixed pipeline now assigns that text to the submitted
   speech window instead of discarding it for missing provider timestamps. See

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexa",
-  "version": "0.12.25",
+  "version": "0.12.26",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",


### PR DESCRIPTION
Release commit for v0.12.26 — bumps `package.json` and the chart `appVersion`, folds the five pending changelog fragments into `changelog.mdx`, and advances the `docs-reflects` stamp so `gate:docs-version` stays green.

Fragments folded: noble base (#1011, @jbschooley) · Zoom per-participant speakers (#1018, @jbschooley) · text-only STT (#1148) · runtime DEFAULT_BOT_NAME (#1258) · Voxtral JSON-only (#1342).

The cross-check in `release-images` compares the tag base against these declared versions, so this must land before `v0.12.26-rc.1` is tagged.

### Contribution Rights

- [x] I am the sole rights holder for my contribution. (Independent path.) <!-- rights:independent -->

<!-- vexa-agent -->