### PR TITLE
release: bind v0.12.26-rc.1 train-candidate packet

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -247,6 +247,13 @@ jobs:
               EXPECTED_TOP_DESCRIPTORS=10
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;
+            v0.12.26-rc.1|v0.12.26)
+              CANDIDATE_MAP=releases/v0.12.26/candidate-images.json
+              EXPECTED_MAP_STABLE_TAG=v0.12.26
+              EXPECTED_MAP_SHA256=72d974ecc2cef7b1060c2919569ee8e9cdf7c3b87c48ce0a879de2415b0e2ab9
+              EXPECTED_TOP_DESCRIPTORS=10
+              EXPECTED_PLATFORM_IDENTITIES=19
+              ;;
             v0.12.25-rc.1|v0.12.25)
               CANDIDATE_MAP=releases/v0.12.25/candidate-images.json
               EXPECTED_MAP_STABLE_TAG=v0.12.25

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -325,3 +325,16 @@ test("v0.12.25 canonical packet binds the rc.1 train candidate", () => {
     "sha256:65f6904b98abb110f591c5082f12319955723e2a6e2c777f26aac9709548f00a",
   );
 });
+
+test("v0.12.26 canonical packet binds the rc.1 train candidate", () => {
+  const raw = readFileSync(
+    new URL("../releases/v0.12.26/candidate-images.json", import.meta.url),
+  );
+  assert.equal(
+    createHash("sha256").update(raw).digest("hex"),
+    "72d974ecc2cef7b1060c2919569ee8e9cdf7c3b87c48ce0a879de2415b0e2ab9",
+  );
+  const map = validateCandidateMap(JSON.parse(raw), "v0.12.26");
+  assert.equal(map.candidate_tag, "v0.12.26-rc.1");
+  assert.equal(map.images["vexaai/vexa-bot"].digest, "sha256:d0d0444e04932a911866b8e9c4e6629a7830339bafb0c76117186479f62cbffa");
+});

--- a/releases/v0.12.26/candidate-images.json
+++ b/releases/v0.12.26/candidate-images.json
@@ -1,0 +1,206 @@
+{
+ "schema_version": 1,
+ "release": "v0.12.26",
+ "stable_tag": "v0.12.26",
+ "candidate_tag": "v0.12.26-rc.1",
+ "build_source": "1affc96953a406aba0e1d744efde907c407cac43",
+ "validation_source": "1affc96953a406aba0e1d744efde907c407cac43",
+ "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/33413673541",
+ "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33413673541",
+ "images": {
+  "vexaai/v012-admin-api": {
+   "class": "prod_deployed",
+   "digest": "sha256:f3557703c2f6cd81415b279082f4d453e368dd7ef859fab9f8d5ad6362414336",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:690f2c9893f7afe0a966dd9e2469658b238b8af8f32673766818c0be34e12d71",
+     "config_digest": "sha256:2a26a6c157f1d18ac3a2b4079007e07191a6e5e664293c74ed3b032b091c8eb4"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:e4f0dde3d60ad6b634e3e561471d52031fd05d97692d7213d3e628e489fb4aaa",
+     "config_digest": "sha256:f5c4a7a6887200aa0ebf13fb443bc8201982d7dde6df30eab49bb3a8b836ef98"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-runtime": {
+   "class": "prod_deployed",
+   "digest": "sha256:fdead2ca35fb40d1114cba08627f22a699c9f51eb1fd8d2d40703b7557066995",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:6566919ea7a5be2940144326eb96c12794546c660e26bbc12a0c70b68a612f33",
+     "config_digest": "sha256:b618fdef734f0bd4dd40d8ba514de9b21b895f0a0caee3ef9e60eb0edf401716"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:07bdbcc5f7bea719bdea4173d8433cda90937f2a4b833ebf17aee77b7f4b0df6",
+     "config_digest": "sha256:2a57c36d172397e4c85961172b475cb99858b75b0cfa75f788f1053c886aaf72"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-agent-worker": {
+   "class": "oss_only",
+   "digest": "sha256:7023c016c5acf2aab62ff242de316a938b0f6375fc32aa973e3134d493cfe89e",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:d10e415955e2e385f63728822d1634d7c6fd30c4617caa2ce6b47991f878a7da",
+     "config_digest": "sha256:bd16bfde61b26228df77de4ee222ce8b9fe8b2902f84e324a7b51c533bbae69d"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:6a9c38fc98e95fe8fc02cf583f229231e495393847dcb163e966126921f6694c",
+     "config_digest": "sha256:bb843587012978eefc34160111188bedb2a45a47e48fbc770b7525af2b349ddd"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-agent-api": {
+   "class": "oss_only",
+   "digest": "sha256:1db8bb9d7d3e691e6a7759c361dc5f3e11795f16e244e02d44c610b86d002530",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:3271cc25b6813263c19c4a9f75a10a76e1ae4fe822718c57362a0e1875110773",
+     "config_digest": "sha256:981a7d87f79102d2972d01459f7c66bc4627484aac290086e23192f67d86814e"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:f0375e792a165fa6aae72c565e8630250eb79abc95c0c9b8ed6ad714d2b1aafd",
+     "config_digest": "sha256:388a64bfb2609881782e027a56807de1a579f94834d38968b0041deab575b189"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-meeting-api": {
+   "class": "prod_deployed",
+   "digest": "sha256:4a123760a5c962d680d55aaee6d2f272b61b224680711c71b4cb57f9b90f1519",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:afe93abe21fc4506aec65af861f39e10b13b52102b1ef3167b2b59db2de3f9cb",
+     "config_digest": "sha256:f3459132624564ff6db95645f02347952ccdc30a371058091d7a5a2712397279"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:bb6732e8e617661811f4a7b0b90e140d04fe47cdb76bea98725526b57ce57fa3",
+     "config_digest": "sha256:d16f75dd0a6ced0d1eb85d6e59214250adb13b8f9c9935d7fc6f621a538b941c"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-gateway": {
+   "class": "prod_deployed",
+   "digest": "sha256:519678806cef721347bc817c326a418dfd090be997edb11295d1acb63b7c6dcb",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:5dfefd95a628262f8a9a2f58e2215bd10bfacb36b07c89686707e7d4cca462af",
+     "config_digest": "sha256:8b7d71d1cd60e1e963e17bd1343b9d457a8820e68152153ed171b69bde6f4194"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:c19240b7be21d67fdd0102e326eb7c52537b68d87d6f59822f3e885dcedba289",
+     "config_digest": "sha256:55022a7f4a42e0d79edf6b1328eebe395861f5aa79ab5c92fe65d3f0224e97e3"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-mcp": {
+   "class": "oss_only",
+   "digest": "sha256:f6c5a721b405c4165e24e134379cfddfa27b394ba1b9d020300ea5c49fe55810",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:9bb4347630217cc0f646856ee2a3b43f76296990c03a15e8b093d4e6377a19f2",
+     "config_digest": "sha256:0c055316f589b378c64e10af9e27d612bfdd4cb18f69079f3c1ce84dd2f19a33"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:1c0efe2b6d8b915d5a0dca897d168eabebadca8f7ed51910e82966df3c7beee8",
+     "config_digest": "sha256:fe8529c4663a420754b8a437250088c6436e52995d8b388c056a64bd41b0599d"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-terminal": {
+   "class": "oss_only",
+   "digest": "sha256:03737b939b23090ec61b779cc2095508029f73c1169bb3daf8cf659e4a59444b",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:7fa0469ed1926d3b396d46d27f5cc746dec21dc4db6295fa563c26534abad883",
+     "config_digest": "sha256:d7681dfd6d4409900cc7a1d64d7f164ecae8ffb55151658dac2d9d9cb3b48720"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:f16c0ff70e066c5a83864e7ec4e55bb1c2f60475e47ae5de0db393311a27d58f",
+     "config_digest": "sha256:8c74205b462b3ce0508b01c4975d19238b341784338d1c663186a92424e52d05"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/vexa-bot": {
+   "class": "prod_deployed",
+   "digest": "sha256:d0d0444e04932a911866b8e9c4e6629a7830339bafb0c76117186479f62cbffa",
+   "platforms": [
+    "linux/amd64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:d0d0444e04932a911866b8e9c4e6629a7830339bafb0c76117186479f62cbffa",
+     "config_digest": "sha256:1abce93162f3e1fc9f6bc0bca11b85ab7e739f96dd8bcc52e23efcf8ac0af80e"
+    }
+   },
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  },
+  "vexaai/vexa-lite": {
+   "class": "oss_only",
+   "digest": "sha256:700340d418797499aeeb8c22bf7ae65a7607673c7f42bc1d07b22f36f8c30118",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:c64f595daf3d4aede33cb808ef8ce46788a952511a69c2ad4bf6482c70394f3c",
+     "config_digest": "sha256:f1f2ba912fccc6aa287bbb7ba849a6124c566ee966de9702e696d2582b9c517d"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:1fe8ab6164659b12ba44a2ca1f78da9644bb14fb0542e21941e3e8876d32efa1",
+     "config_digest": "sha256:42aaa7a458c335e2da90a2ecd70330fa939049b18ee73cb7d8603ee853ff9668"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33413673541 at 1affc969; exact registry identities collected after the image job completed"
+  }
+ }
+}


### PR DESCRIPTION
Step 1 of `releases/README.md` § Bind, validate, freeze. Binds `releases/v0.12.26/candidate-images.json` from the exact published registry identities of the ten `v0.12.26-rc.1` images (10 top descriptors, 19 platform identities; bot amd64-only) and pins its sha256 (`72d974ec…`) in the two asserting places: the `release-validate` resolve table and the canonical-packet test.

Build run: [33413673541](https://github.com/Vexa-ai/vexa/actions/runs/33413673541) — completed success, lite and the full compose set published.

### Contribution Rights

- [x] I am the sole rights holder for my contribution. (Independent path.) <!-- rights:independent -->

<!-- vexa-agent -->