### PR TITLE
CLA: accept the ASWF 2020 v2 CCLA as an alternative corporate instrument

### DIFF
--- a/CLA/README.md
+++ b/CLA/README.md
@@ -13,8 +13,19 @@ instead.
 Do not commit executed agreements or personal information here. The public repository records
 only an opaque `VCR-YYYY-NNNN` receipt bound to the exact PR and head SHA.
 
-Vexa publishes no contributor agreement, and asks no one to sign one. If your legal team requires
-a signed agreement on file, email [dmitry@vexa.ai](mailto:dmitry@vexa.ai) and we will work out an
-instrument that fits.
+## If your legal team requires a signed agreement
+
+Vexa requires no contributor agreement from anyone. Some organizations nonetheless need one on
+file, and for them a novel one-page letter is the expensive artifact — an unfamiliar text starts a
+custom legal review, while a familiar one is a signature.
+
+So Vexa also accepts the **[ASWF 2020 v2 CCLA](ccla-aswf2020.md)** — the Academy Software
+Foundation's Apache-derived corporate CLA, reproduced with its three header fields completed for
+Vexa and no term altered. Studios and vendors across the ASWF ecosystem have had this exact text
+through legal for years.
+
+It is an accepted alternative, never a requirement, and it is per-project: an existing ASWF CLA
+signed for another project does not cover Vexa. If neither instrument fits, email
+[dmitry@vexa.ai](mailto:dmitry@vexa.ai) and we will work out one that does.
 
 See [`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md) for the complete policy and verifier format.

--- a/CLA/ccla-aswf2020.md
+++ b/CLA/ccla-aswf2020.md
@@ -1,0 +1,186 @@
+<!--
+  Source: ASWF 2020 v2 CCLA, AcademySoftwareFoundation/tac
+  https://github.com/AcademySoftwareFoundation/tac/blob/main/process/cla/ccla_template_aswf2020.md
+  Licensed CC BY 4.0 by the Academy Software Foundation. Reproduced with the
+  template's three header fields completed; the terms are unmodified.
+-->
+
+# Corporate Contributor License Agreement — Vexa
+
+This is the **ASWF 2020 v2 CCLA**, published by the Academy Software Foundation and derived from
+the Apache Software Foundation's CCLA. Its three header fields are completed for Vexa; **no term
+has been altered**. Diff it against
+[the ASWF original](https://github.com/AcademySoftwareFoundation/tac/blob/main/process/cla/ccla_template_aswf2020.md)
+before review.
+
+Signing this is **optional**. It exists for organizations whose legal teams have already cleared
+this text and would rather sign a known instrument than review a new one. The default corporate
+route remains [`employer-authorization-template.md`](employer-authorization-template.md), and the
+individual route remains DCO sign-off — see [`CONTRIBUTOR_RIGHTS.md`](../CONTRIBUTOR_RIGHTS.md).
+
+**The "CLA Tool" named in sections 4 and 8** is EasyCLA for Linux Foundation–hosted projects. Vexa
+is not LF-hosted, so for this Agreement the CLA Tool is Vexa's private contribution-rights
+register: the CLA Manager emails [dmitry@vexa.ai](mailto:dmitry@vexa.ai) to change either list, and
+each change is recorded against an opaque `VCR-YYYY-NNNN` receipt. Executed agreements and personal
+information stay in that private register and are never committed to this repository.
+
+Email the signed PDF to [dmitry@vexa.ai](mailto:dmitry@vexa.ai). Do not attach it to a public
+issue or pull request.
+
+---
+
+Project Name: Vexa
+
+Project Entity: Vexa.ai Inc.
+
+If emailing signed PDF, send to: dmitry@vexa.ai
+
+**Software Grant and Corporate Contributor License Agreement
+("Agreement") v2.0**
+
+Thank you for your interest in the project specified above (the
+"Project"). In order to clarify the intellectual property license
+granted with Contributions from any person or entity, the Project must
+have a Contributor License Agreement (CLA) on file that has been signed
+by each Contributor, indicating agreement to the license terms below.
+This license is for your protection as a Contributor as well as the
+protection of the Project and its users; it does not change your rights
+to use your own Contributions for any other purpose.
+
+This version of the Agreement allows an entity (the "Corporation") to
+submit Contributions to the Project, to authorize Contributions
+submitted by its designated employees to the Project, and to grant
+copyright and patent licenses thereto.
+
+If you have not already done so, please complete and sign this Agreement
+using the electronic signature portal made available to you by the
+Project or its third-party service providers, or email a PDF of the
+signed agreement to the email address specified above. Please read this
+document carefully before signing and keep a copy for your records.
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to the Project. In return,
+the Project shall not use Your Contributions in a way that is contrary
+to the public benefit or inconsistent with its charter at the time of
+the Contribution. Except for the license granted herein to the Project
+and recipients of software distributed by the Project, You reserve all
+right, title, and interest in and to Your Contributions.
+
+1.  Definitions.
+
+    "You" (or "Your") shall mean the copyright owner or legal entity
+    authorized by the copyright owner that is making this Agreement with
+    the Project. For legal entities, the entity making a Contribution
+    and all other entities that control, are controlled by, or are under
+    common control with that entity are considered to be a single
+    Contributor. For the purposes of this definition, "control"
+    means (i) the power, direct or indirect, to cause the direction or
+    management of such entity, whether by contract or otherwise, or (ii)
+    ownership of fifty percent (50%) or more of the outstanding shares,
+    or (iii) beneficial ownership of such entity.
+
+    "Contribution" shall mean the code, documentation or other original
+    works of authorship, including any modifications or additions to an
+    existing work, that is intentionally submitted by You to the Project
+    for inclusion in, or documentation of, any of the products owned or
+    managed by the Project (the "Work"). For the purposes of this
+    definition, "submitted" means any form of electronic, verbal, or
+    written communication sent to the Project or its representatives,
+    including but not limited to communication on electronic mailing
+    lists, source code control systems, and issue tracking systems that
+    are managed by, or on behalf of, the Project for the purpose of
+    discussing and improving the Work, but excluding communication that
+    is conspicuously marked or otherwise designated in writing by You as
+    "Not a Contribution."
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this Agreement, You hereby grant to the Project and to recipients of
+    software distributed by the Project a perpetual, worldwide, non-
+    exclusive, no-charge, royalty-free, irrevocable copyright license to
+    reproduce, prepare derivative works of, publicly display, publicly
+    perform, sublicense, and distribute Your Contributions and such
+    derivative works.
+
+3.  Grant of Patent License. Subject to the terms and conditions of this
+    Agreement, You hereby grant to the Project and to recipients of
+    software distributed by the Project a perpetual, worldwide, non-
+    exclusive, no-charge, royalty-free, irrevocable (except as stated in
+    this section) patent license to make, have made, use, offer to sell,
+    sell, import, and otherwise transfer the Work, where such license
+    applies only to those patent claims licensable by You that are
+    necessarily infringed by Your Contribution(s) alone or by
+    combination of Your Contribution(s) with the Work to which such
+    Contribution(s) were submitted. If any entity institutes patent
+    litigation against You or any other entity (including a cross- claim
+    or counterclaim in a lawsuit) alleging that your Contribution, or
+    the Work to which you have contributed, constitutes direct or
+    contributory patent infringement, then any patent licenses granted
+    to that entity under this Agreement for that Contribution or Work
+    shall terminate as of the date such litigation is filed.
+
+4.  You represent that You are legally entitled to grant the above
+    license. You represent further that the employee of the Corporation
+    designated as the Initial CLA Manager below (and each who is
+    designated in a subsequent written modification to the list of CLA
+    Managers) (each, a "CLA Manager") is authorized to maintain (1) the
+    list of employees of the Corporation who are authorized to submit
+    Contributions on behalf of the Corporation, and (2) the list of CLA
+    Managers; in each case, using the designated system for managing
+    such lists (the "CLA Tool").
+
+5.  You represent that each of Your Contributions is Your original
+    creation (see section 7 for submissions on behalf of others).
+
+6.  You are not expected to provide support for Your Contributions,
+    except to the extent You desire to provide support. You may provide
+    support for free, for a fee, or not at all. Unless required by
+    applicable law or agreed to in writing, You provide Your
+    Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied, including, without
+    limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+    MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7.  Should You wish to submit work that is not Your original creation,
+    You may submit it to the Project separately from any Contribution,
+    identifying the complete details of its source and of any license or
+    other restriction (including, but not limited to, related patents,
+    trademarks, and license agreements) of which you are personally
+    aware, and conspicuously marking the work as "Submitted on behalf of
+    a third-party: [named here]".
+
+8.  It is your responsibility to use the CLA Tool when any change is
+    required to the list of designated employees authorized to submit
+    Contributions on behalf of the Corporation, or to the list of the
+    CLA Managers.
+
+[Please complete and sign on the next page.]
+
+
+Please sign:
+______________________________ Date:
+_________________
+
+Signatory Name:
+______________________________________________________
+
+Signatory E-mail:
+________________________________________________
+
+Signatory Title:
+_____________________________________________________
+
+Corporation Name:
+________________________________________________
+
+Corporation Address:
+_________________________________________________
+
+_________________________________________________
+
+_________________________________________________
+
+Initial CLA Manager Name:
+____________________________________________
+
+Initial CLA Manager E-Mail:
+__________________________________________

--- a/CONTRIBUTOR_RIGHTS.md
+++ b/CONTRIBUTOR_RIGHTS.md
@@ -41,6 +41,12 @@ handles open-source approvals where you work. It is a short letter they fill in,
 to [dmitry@vexa.ai](mailto:dmitry@vexa.ai) — it adds no terms beyond what Apache-2.0 already
 provides. You sign nothing beyond your own DCO sign-off.
 
+If your organization's process cannot route a letter it has not seen before, Vexa also accepts the
+[ASWF 2020 v2 CCLA](CLA/ccla-aswf2020.md) — the Academy Software Foundation's Apache-derived
+corporate CLA, reproduced with only its header fields completed. It is an accepted alternative and
+never a requirement; either instrument satisfies this path. Note that it is per-project, so an
+ASWF CLA signed for another project does not cover Vexa.
+
 If you cannot reach your own approvers, or they would rather hear from Vexa directly, email
 [dmitry@vexa.ai](mailto:dmitry@vexa.ai) with the pull-request URL and the rights holder's legal/IP
 contact instead. Do not attach executed agreements, signatures, addresses, employment documents,


### PR DESCRIPTION
Adds the **ASWF 2020 v2 CCLA**, filled for Vexa, as an *accepted alternative* on the corporate contribution path.

## Why

The one-page [employer-authorization letter](CLA/employer-authorization-template.md) is the cheaper artifact for us and, for some organizations, the expensive one for them. A text their legal has never seen starts a custom review with no predictable exit; a text their legal has already cleared is a signature. That is a process constraint, not a legal one, and only the contributor's employer can tell us which applies.

Apache-2.0 §5 reasoning is unchanged and still correct — it was simply not the binding constraint in every case.

## What this does not do

**Vexa still requires no contributor agreement from anyone.** The individual path remains DCO sign-off. The default corporate path remains the authorization letter. This is an option for organizations that want a known instrument, never a requirement, and nothing is published as one.

## The text

`CLA/ccla-aswf2020.md` reproduces the [ASWF 2020 v2 CCLA](https://github.com/AcademySoftwareFoundation/tac/blob/main/process/cla/ccla_template_aswf2020.md) (CC BY 4.0, attributed in the file header). Diff against the ASWF original is **exactly three lines**, all in the header:

```
Project Name:   [COMMON NAME]        → Vexa
Project Entity: [SERIES ENTITY]      → Vexa.ai Inc.
If emailing signed PDF, send to: …   → dmitry@vexa.ai
```

No term is altered. That is the whole value of the route — a reviewer who diffs it gets a clean result — so it was verified mechanically rather than asserted, and anyone can repeat the check against the upstream file.

## The CLA Tool

Sections 4 and 8 reference a "CLA Tool" for maintaining the CLA-manager and authorized-employee lists. For LF-hosted projects that is EasyCLA. Vexa is not LF-hosted, so **the clause wording is left untouched** and the tool is defined outside the agreement, in the file header: Vexa's existing private contribution-rights register, with a `VCR-YYYY-NNNN` receipt per change. Editing pre-approved clauses would forfeit the only advantage this instrument has.

## Note for reviewers

CCLA §2 grants a **sublicensable** copyright licence, which is broader than Apache-2.0 §5's inbound=outbound. That is the standard objection to company-held CLAs, and it is why this lands as an alternative rather than a requirement.

Executed agreements and personal information stay in the private register and are never committed here.

<!-- vexa-agent -->


## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

