### PR TITLE
release: freeze v0.12.26-rc.1 validation identity

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -250,7 +250,7 @@ jobs:
             v0.12.26-rc.1|v0.12.26)
               CANDIDATE_MAP=releases/v0.12.26/candidate-images.json
               EXPECTED_MAP_STABLE_TAG=v0.12.26
-              EXPECTED_MAP_SHA256=72d974ecc2cef7b1060c2919569ee8e9cdf7c3b87c48ce0a879de2415b0e2ab9
+              EXPECTED_MAP_SHA256=91e5d99e0b1c801902a2da3b7f4f5b4f78a23339a30ca87311cee81f4639477f
               EXPECTED_TOP_DESCRIPTORS=10
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -332,7 +332,7 @@ test("v0.12.26 canonical packet binds the rc.1 train candidate", () => {
   );
   assert.equal(
     createHash("sha256").update(raw).digest("hex"),
-    "72d974ecc2cef7b1060c2919569ee8e9cdf7c3b87c48ce0a879de2415b0e2ab9",
+    "91e5d99e0b1c801902a2da3b7f4f5b4f78a23339a30ca87311cee81f4639477f",
   );
   const map = validateCandidateMap(JSON.parse(raw), "v0.12.26");
   assert.equal(map.candidate_tag, "v0.12.26-rc.1");

--- a/releases/v0.12.26/candidate-images.json
+++ b/releases/v0.12.26/candidate-images.json
@@ -4,9 +4,9 @@
  "stable_tag": "v0.12.26",
  "candidate_tag": "v0.12.26-rc.1",
  "build_source": "1affc96953a406aba0e1d744efde907c407cac43",
- "validation_source": "1affc96953a406aba0e1d744efde907c407cac43",
+ "validation_source": "eb89a53c06d2f94d6df62eb03b1bb3d3207ae828",
  "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/33413673541",
- "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33413673541",
+ "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33421145816",
  "images": {
   "vexaai/v012-admin-api": {
    "class": "prod_deployed",


### PR DESCRIPTION
Step 3 of Bind, validate, freeze. Writes `validation_source` (`eb89a53c`) and `validation_run` ([33421145816](https://github.com/Vexa-ai/vexa/actions/runs/33421145816) — completed success) into the v0.12.26 packet and re-pins the resulting sha256 (`91e5d99e…`) in the resolve table and the canonical test. 16/16 packet tests pass.

Note for the record: the first validate attempt failed on six legs with `unauthenticated pull rate limit` — every one of them after a successful `docker login`, while our account had 191/200 pulls remaining. That is the shared-runner anonymous limit, filed as #1379; the re-run passed unchanged.

After merge: stable tag v0.12.26.

### Contribution Rights

- [x] I am the sole rights holder for my contribution. (Independent path.) <!-- rights:independent -->

<!-- vexa-agent -->