### PR TITLE
join: let a bot broadcast a still card instead of an empty camera feed

### DIFF
--- a/core/meetings/modules/join/package.json
+++ b/core/meetings/modules/join/package.json
@@ -6,12 +6,17 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/msteams/join-passcode.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts",
+    "test": "tsx src/shared/selector-validity.test.ts && tsx src/googlemeet/admission.test.ts && tsx src/googlemeet/join-cta.test.ts && tsx src/googlemeet/session.test.ts && tsx src/googlemeet/leave.test.ts && tsx src/googlemeet/humanized/humanized.test.ts && tsx src/msteams/modals.test.ts && tsx src/msteams/admission.test.ts && tsx src/msteams/leave.test.ts && tsx src/msteams/removal.test.ts && tsx src/msteams/auth-redirect.test.ts && tsx src/msteams/join-passcode.test.ts && tsx src/zoom/join.test.ts && tsx src/zoom/admission.test.ts && tsx src/jitsi/join.test.ts && tsx src/jitsi/password.test.ts && tsx src/jitsi/admission.test.ts && tsx src/__tests__/defaultBotName.test.ts && tsx src/__tests__/unknownPlatform.test.ts && tsx src/__tests__/localePin.test.ts && tsx src/__tests__/fakeVideoTile.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "dependencies": {

--- a/core/meetings/modules/join/src/__tests__/fakeVideoTile.test.ts
+++ b/core/meetings/modules/join/src/__tests__/fakeVideoTile.test.ts
@@ -1,0 +1,100 @@
+// BOT_FAKE_VIDEO_FILE / BOT_CAMERA_ENABLED — a bot can broadcast a still card (identity +
+// a recording notice) instead of an empty feed. Pure unit checks, no browser.
+//
+// The load-bearing case is #3: --use-file-for-fake-video-capture must appear EXACTLY ONCE on
+// a launched command line. A duplicate is invisible in either source file and only shows up
+// on a running bot's /proc/<pid>/cmdline, so it is asserted here instead.
+import { getJoinBrowserArgs, resolveFakeVideoFile, resolveCameraEnabled } from "../browser-args";
+import {
+  googleCameraOnIndicatorSelector,
+  googleCameraOffIndicatorSelector,
+} from "../googlemeet/selectors";
+
+let passed = 0, failed = 0;
+function assert(cond: boolean, msg: string): void {
+  if (cond) { passed++; console.log(`  \x1b[32mPASS\x1b[0m  ${msg}`); }
+  else { failed++; console.log(`  \x1b[31mFAIL\x1b[0m  ${msg}`); }
+}
+
+const countFlag = (args: string[], flag: string): number =>
+  args.filter((a) => a === flag || a.startsWith(`${flag}=`)).length;
+
+console.log("\n=== 1. Default: an empty feed, and no fake device ===");
+{
+  delete process.env.BOT_FAKE_VIDEO_FILE;
+  delete process.env.BOT_CAMERA_ENABLED;
+  assert(resolveFakeVideoFile() === "/dev/null", "resolveFakeVideoFile() defaults to /dev/null");
+  assert(resolveCameraEnabled() === false, "resolveCameraEnabled() defaults to false");
+  const args = getJoinBrowserArgs();
+  assert(
+    args.includes("--use-file-for-fake-video-capture=/dev/null"),
+    "the launch args carry the empty feed by default",
+  );
+  assert(
+    !args.includes("--use-fake-device-for-media-stream"),
+    "no fake DEVICE by default — the flag also replaces the microphone with a beep",
+  );
+}
+
+console.log("\n=== 2. Negative control: the knobs really drive it (A2) ===");
+{
+  process.env.BOT_FAKE_VIDEO_FILE = "/opt/card.y4m";
+  process.env.BOT_CAMERA_ENABLED = "1";
+  assert(resolveFakeVideoFile() === "/opt/card.y4m", "BOT_FAKE_VIDEO_FILE is honoured");
+  assert(resolveCameraEnabled() === true, "BOT_CAMERA_ENABLED=1 is honoured");
+  const args = getJoinBrowserArgs();
+  assert(
+    args.includes("--use-file-for-fake-video-capture=/opt/card.y4m"),
+    "the file follows the knob — the knob is not a no-op",
+  );
+  assert(
+    args.includes("--use-fake-device-for-media-stream"),
+    "the fake device ships WITH a file: without it Chromium enumerates no videoinput at all",
+  );
+}
+
+console.log("\n=== 3. One flag, one owner: never duplicated ===");
+{
+  process.env.BOT_FAKE_VIDEO_FILE = "/opt/card.y4m";
+  const args = getJoinBrowserArgs();
+  assert(
+    countFlag(args, "--use-file-for-fake-video-capture") === 1,
+    "--use-file-for-fake-video-capture appears exactly once",
+  );
+  assert(
+    countFlag(args, "--use-fake-device-for-media-stream") === 1,
+    "--use-fake-device-for-media-stream appears exactly once",
+  );
+  delete process.env.BOT_FAKE_VIDEO_FILE;
+  delete process.env.BOT_CAMERA_ENABLED;
+}
+
+console.log("\n=== 4. BOT_CAMERA_ENABLED accepts the shapes a deployment writes ===");
+{
+  for (const [v, want] of [["1", true], ["true", true], ["TRUE", true], ["0", false], ["", false], ["no", false]] as const) {
+    process.env.BOT_CAMERA_ENABLED = v;
+    assert(resolveCameraEnabled() === want, `BOT_CAMERA_ENABLED=${JSON.stringify(v)} -> ${want}`);
+  }
+  delete process.env.BOT_CAMERA_ENABLED;
+}
+
+console.log("\n=== 5. The camera toggle's two states are distinguishable ===");
+{
+  // Meet's aria-label names the ACTION, not the state, so the two selectors must not
+  // overlap — otherwise a caller cannot drive the toggle to a wanted state.
+  assert(
+    googleCameraOnIndicatorSelector !== googleCameraOffIndicatorSelector,
+    "the on-state and off-state selectors are distinct",
+  );
+  assert(
+    googleCameraOnIndicatorSelector.includes("Turn off camera"),
+    "the ON indicator matches the control offered while the camera is on",
+  );
+  assert(
+    googleCameraOffIndicatorSelector.includes("Turn on camera"),
+    "the OFF indicator matches the control offered while the camera is off",
+  );
+}
+
+console.log(`\n=== summary: ${passed} passed, ${failed} failed ===`);
+process.exit(failed > 0 ? 1 : 0);

--- a/core/meetings/modules/join/src/browser-args.ts
+++ b/core/meetings/modules/join/src/browser-args.ts
@@ -44,6 +44,43 @@ export function getLocaleBrowserArgs(): string[] {
   return [`--lang=${locale}`, `--accept-lang=${acceptLang}`];
 }
 
+/**
+ * The file played as the camera feed (`.y4m` or `.mjpeg` — Chromium accepts no other
+ * format, see media/capture/video/file_video_capture_device.cc). Deployment knob in the
+ * same shape as BOT_UI_LOCALE above; the default `/dev/null` is an empty feed, so a
+ * deployment that sets nothing gets a bot with no video at all.
+ *
+ * A single frame is enough for a permanent still, because Chromium rewinds at EOF:
+ *   if (current_byte_index_ >= mapped_file_->bytes().size())
+ *     current_byte_index_ = first_frame_byte_index_;
+ *
+ * Prefer a low-frame-rate Y4M over MJPEG: MJPEG is pinned to 30 fps by the
+ * kMJpegFrameRate constant, whereas a Y4M declares its own rate in its header (F tag)
+ * and Chromium honours it for playback timing. Outgoing encode is paid in CPU, and CPU —
+ * not RAM — is what caps the number of bots per host (see the ~115%/bot figure measured
+ * for --in-process-gpu below).
+ *
+ * The path must resolve INSIDE the container: mount the file as a volume.
+ */
+export function resolveFakeVideoFile(): string {
+  const v = (process.env.BOT_FAKE_VIDEO_FILE || "").trim();
+  return v.length > 0 ? v : "/dev/null";
+}
+
+/**
+ * Should the bot keep its camera ON? Deployment knob; the default `false` switches the
+ * camera off in the lobby, which is what a recorder bot wants — it has nothing to film.
+ *
+ * Only meaningful together with BOT_FAKE_VIDEO_FILE: a camera on with no file broadcasts
+ * nothing. The `cameraEnabled` field in the invocation.v1 contract expresses the same
+ * intent per-invocation; this knob is deployment-wide and is what the join lane reads,
+ * for the same reason BOT_UI_LOCALE is (modules never import services).
+ */
+export function resolveCameraEnabled(): boolean {
+  const v = (process.env.BOT_CAMERA_ENABLED || "").trim().toLowerCase();
+  return v === "1" || v === "true";
+}
+
 export const JOIN_BROWSER_ARGS: readonly string[] = [
   "--incognito",
   "--no-sandbox",
@@ -64,7 +101,9 @@ export const JOIN_BROWSER_ARGS: readonly string[] = [
   // Start AudioContexts in 'running', not 'suspended' — the capture taps remote participant audio
   // via createMediaStreamSource; without this the worklet never fires and no PCM flows. (L4.)
   "--autoplay-policy=no-user-gesture-required",
-  "--use-file-for-fake-video-capture=/dev/null",
+  // --use-file-for-fake-video-capture is NOT here: it resolves a deployment knob at call
+  // time, so it lives in getJoinBrowserArgs() alongside the locale flags. No caller reads
+  // this array directly — every launch path goes through getJoinBrowserArgs().
   "--disable-blink-features=AutomationControlled",
   "--disable-features=VizDisplayCompositor",
   "--disable-site-isolation-trials",
@@ -74,5 +113,21 @@ export const JOIN_BROWSER_ARGS: readonly string[] = [
  *  the pinned-locale flags (#856) so every launch path — production bot and the
  *  debug harness — is byte-identical and speaks the same UI language. */
 export function getJoinBrowserArgs(): string[] {
-  return [...JOIN_BROWSER_ARGS, ...getLocaleBrowserArgs()];
+  const fakeVideoFile = resolveFakeVideoFile();
+  const args = [...JOIN_BROWSER_ARGS];
+
+  // The two flags are one mechanism and ship together. --use-file-for-fake-video-capture
+  // names the frames; --use-fake-device-for-media-stream is what makes Chromium ADVERTISE a
+  // capture device for them to feed. Without the latter, no videoinput is enumerated in the
+  // container at all: Meet has no camera to turn on, the file is never read, and the bot
+  // shows Meet's generated initial (2026-09-01, Google Meet).
+  //
+  // Gated on an actual file because the device flag also replaces the MICROPHONE with a
+  // synthetic beep — a deployment with no BOT_FAKE_VIDEO_FILE must not inherit that beep.
+  if (fakeVideoFile !== "/dev/null") {
+    args.push("--use-fake-device-for-media-stream");
+  }
+  args.push(`--use-file-for-fake-video-capture=${fakeVideoFile}`);
+
+  return [...args, ...getLocaleBrowserArgs()];
 }

--- a/core/meetings/modules/join/src/googlemeet/join.ts
+++ b/core/meetings/modules/join/src/googlemeet/join.ts
@@ -5,7 +5,8 @@ import {
   googleNameInputSelectors,
   googleJoinButtonSelectors,
   googleMicrophoneButtonSelectors,
-  googleCameraButtonSelectors,
+  googleCameraOnIndicatorSelector,
+  googleCameraOffIndicatorSelector,
   googleAuthJoinCtaSelectors,
   googleSignedOutLobbyProbeSelectors,
   googleLobbyIconGlyphSelectors,
@@ -13,7 +14,7 @@ import {
 } from "./selectors";
 import { HumanizedInteractor, MOCAP_LIBRARY } from "./humanized";
 import { AdmissionError } from "../shared/admission";
-import { resolveBotUiLocale } from "../browser-args";
+import { resolveBotUiLocale, resolveCameraEnabled } from "../browser-args";
 
 /** Thrown when authenticated mode detects a signed-out browser profile. Extends AdmissionError so
  *  the JoinDriver's single `instanceof` catch maps the typed `auth_session_missing` outcome to a
@@ -180,6 +181,55 @@ async function observedPageContext(page: Page): Promise<string> {
     return `url=${url} html.lang=${ctx.lang || "?"} navigator.language=${ctx.nav || "?"}`;
   } catch {
     return `url=${url} html.lang=? navigator.language=?`;
+  }
+}
+
+/**
+ * Drive Meet's camera toggle to an ASSERTED state instead of assuming one.
+ *
+ * Meet's control is a toggle whose aria-label names the ACTION, not the state:
+ * "Turn off camera" is only present while the camera is ON, "Turn on camera" only while it
+ * is OFF. So the button to click is always the one advertising the transition we want.
+ *
+ * Both directions have to be asserted, because not clicking is not the same as turning the
+ * camera on: whether the lobby opens with the camera on or off depends on the launch flags
+ * (2026-09-01, Google Meet: with --use-fake-device-for-media-stream the lobby opens camera-ON,
+ * without it no videoinput is enumerated at all). A caller that merely skipped the mute click
+ * would broadcast nothing and show Meet's generated initial instead.
+ *
+ * Clicks go through the caller's humanized clicker: a synthetic click here bypasses the
+ * anti-detection motion the rest of the join path relies on.
+ */
+async function setGoogleCameraState(
+  page: Page,
+  wantOn: boolean,
+  clickHandle: (handle: ElementHandle<Element>, label: string) => Promise<void>,
+): Promise<void> {
+  // The button that CHANGES the state to the one we want: to turn the camera ON we click
+  // the control that is only present while it is OFF, and vice versa.
+  const selector = wantOn
+    ? googleCameraOffIndicatorSelector
+    : googleCameraOnIndicatorSelector;
+  try {
+    const handle = await page.waitForSelector(selector, { timeout: 3000 });
+    if (handle) {
+      await clickHandle(handle, "camera");
+      log(wantOn ? "Camera turned ON (BOT_CAMERA_ENABLED)." : "Camera turned off.");
+      return;
+    }
+  } catch (e) {
+    // Absent means the camera is already in the wanted state, or the control is missing.
+    // Those two are very different when diagnosing, so probe the opposite control to say
+    // which one it was instead of logging an ambiguous "already X or not found".
+  }
+  const oppositeSelector = wantOn
+    ? googleCameraOnIndicatorSelector
+    : googleCameraOffIndicatorSelector;
+  const alreadyThere = (await page.$(oppositeSelector)) !== null;
+  if (alreadyThere) {
+    log(wantOn ? "Camera was already ON." : "Camera was already off.");
+  } else {
+    log("Camera control not found at all (neither on nor off state).");
   }
 }
 
@@ -408,12 +458,11 @@ export async function joinGoogleMeeting(
       log("Microphone already muted or not found.");
     }
 
-    try {
-      const cameraHandle = await page.waitForSelector(googleCameraButtonSelectors[0], { timeout: 3000 });
-      if (cameraHandle) { await clickHandle(cameraHandle, "camera"); log("Camera turned off."); }
-    } catch (e) {
-      log("Camera already off or not found.");
-    }
+    // The camera stays off unless BOT_CAMERA_ENABLED says otherwise. A recorder bot has
+    // nothing to film, but a deployment may want to broadcast a still card (identity +
+    // "this meeting is being recorded") via BOT_FAKE_VIDEO_FILE, which requires the
+    // camera to be ON. Default is unchanged: off.
+    await setGoogleCameraState(page, resolveCameraEnabled(), clickHandle);
 
     // Authenticated lobby: one primary CTA — "Join now" (standard join),
     // "Switch here" (same account already in the call) or "Ask to join"
@@ -471,12 +520,8 @@ export async function joinGoogleMeeting(
       log("Microphone already muted or not found.");
     }
 
-    try {
-      const cameraHandle = await page.waitForSelector(googleCameraButtonSelectors[0], { timeout: 1000 });
-      if (cameraHandle) await clickHandle(cameraHandle, "camera");
-    } catch (e) {
-      log("Camera already off or not found.");
-    }
+    // Guest lobby: same rule as the authenticated path above.
+    await setGoogleCameraState(page, resolveCameraEnabled(), clickHandle);
 
     const { handle: joinHandle } = await waitForLobbyCta(
       page,

--- a/core/meetings/modules/join/src/googlemeet/selectors.ts
+++ b/core/meetings/modules/join/src/googlemeet/selectors.ts
@@ -338,6 +338,15 @@ export const googleCameraButtonSelectors: string[] = [
   'button[aria-label*="Turn on camera"]'
 ];
 
+// Meet's camera control is a TOGGLE whose aria-label names the ACTION, not the current
+// state: "Turn off camera" exists only while the camera is ON, "Turn on camera" only while
+// it is OFF. Split out so a caller can DRIVE the toggle to a wanted state instead of
+// blindly clicking it — the mixed list above cannot express that, since its first entry
+// matches only one of the two states. Locale-safe for the same reason as the rest of this
+// file: --lang pins the browser UI to en-US (#856).
+export const googleCameraOnIndicatorSelector = 'button[aria-label*="Turn off camera"]';
+export const googleCameraOffIndicatorSelector = 'button[aria-label*="Turn on camera"]';
+
 export const googleMicrophoneButtonSelectors: string[] = [
   '[aria-label*="Turn off microphone"]',
   'button[aria-label*="Turn off microphone"]',

--- a/core/meetings/modules/remote-browser/src/args.ts
+++ b/core/meetings/modules/remote-browser/src/args.ts
@@ -38,7 +38,12 @@ export function getAuthenticatedBrowserArgs(): string[] {
     '--disable-site-isolation-trials',
     '--in-process-gpu',
     '--use-fake-ui-for-media-stream',
-    '--use-file-for-fake-video-capture=/dev/null',
+    // --use-file-for-fake-video-capture belongs to the join lane alone (browser-args.ts),
+    // which resolves it from BOT_FAKE_VIDEO_FILE. Setting it here too would place it TWICE on
+    // the launched command line, because capture-bridge.ts composes
+    // [...getAuthenticatedBrowserArgs(), ...getJoinBrowserArgs()] — and a duplicated flag is
+    // only visible on a running bot's /proc/<pid>/cmdline, never in either source file.
+    // One flag, one owner.
     '--disable-features=VizDisplayCompositor',
     '--password-store=basic',
   ];

--- a/core/meetings/modules/remote-browser/src/auth.smoke.test.ts
+++ b/core/meetings/modules/remote-browser/src/auth.smoke.test.ts
@@ -39,6 +39,12 @@ check(authArgs.includes('--disable-blink-features=AutomationControlled'),
 check(!authArgs.includes('--incognito'),
   'authenticated args must NOT be incognito (wipes stored cookies)');
 check(authArgs.includes('--no-sandbox'), 'authenticated args must include --no-sandbox (container)');
+// --use-file-for-fake-video-capture is owned by the join lane (@vexa/join, browser-args.ts),
+// which resolves it from BOT_FAKE_VIDEO_FILE. Setting it here as well places it TWICE on the
+// launched command line, since capture-bridge composes both arrays — a duplicate that is
+// invisible in either source file and only shows on a running bot's /proc/<pid>/cmdline.
+check(!authArgs.some((a) => a.startsWith('--use-file-for-fake-video-capture')),
+  'authenticated args must NOT set --use-file-for-fake-video-capture (owned by the join lane)');
 
 const sessionArgs = getBrowserSessionArgs();
 for (const bad of FORBIDDEN) {

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -125,6 +125,41 @@ terminal's `build.args` in compose) and rebuild the image — a rename then cost
 which is why the runtime variable is the better knob. Direct `joinMeeting` callers read
 `DEFAULT_BOT_NAME` too and fall back to `Vexa Join Layer`.
 
+## Bot video tile (a still card)
+
+A bot has nothing to film, so by default its camera is off and its fake video feed is `/dev/null`
+— other participants see the name above and nothing else. Two knobs let it broadcast a **still
+card** instead: its identity, and whatever notice you owe the room, such as the fact that the
+meeting is being recorded.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BOT_FAKE_VIDEO_FILE` | `/dev/null` | Absolute in-container path to the file played as the camera feed. Chromium accepts **only** `.y4m` and `.mjpeg`. Mount the file into the bot's container — a path that resolves on the host but not inside it silently yields no video. |
+| `BOT_CAMERA_ENABLED` | `false` | Keep the camera on in the lobby instead of switching it off. Accepts `1` or `true`. Only meaningful together with `BOT_FAKE_VIDEO_FILE`: a camera on with no file broadcasts nothing. |
+
+Both default to today's behaviour, so a deployment that sets neither is unaffected.
+
+**One frame is enough.** Chromium rewinds the file at EOF, so a single-frame file shows
+permanently:
+
+```bash
+ffmpeg -i card.png -vframes 1 -r 1 -vf scale=1280:720 -pix_fmt yuv420p card.y4m
+```
+
+Prefer Y4M over MJPEG for a still: MJPEG plays at a fixed 30 fps, whereas a Y4M declares its own
+rate in its header (the `F` tag, set by `-r` above) and Chromium honours it. Outgoing encode is
+paid in CPU, and CPU is what caps bots per host — so a low frame rate buys concurrency. The
+trade-off is sharpness: at 1 fps a 720p source is relayed to participants at a lower resolution by
+WebRTC adaptation, which is fine for a legible card and poor for anything detailed.
+
+The colour space produced by the command above (`C420jpeg`) is accepted as-is; the
+`C420mpeg2` → `C420` rewrite that circulates online is not needed here.
+
+Note the microphone side effect: broadcasting a file makes the browser use fake capture devices,
+which replaces the microphone with a synthetic tone. It reaches neither the meeting (the bot mutes
+itself) nor the recording (which taps remote participant audio, not the mic), but a deployment
+relying on the bot's own microphone for anything else should know.
+
 ## Database & storage
 
 | Variable | Default | Purpose |


### PR DESCRIPTION
**Delivers issue:** #1382 — `Closes #1382`.

Prepared retroactively and said so in the issue rather than back-dated: the work came out of
self-hosting, not from the roadmap. The acceptance table there is the floor I set before starting,
and the bundle below maps to it row by row in its numbering.

## Contribution rights

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [x] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

All four commits carry my own DCO `Signed-off-by`.

## What this does

A bot can broadcast a **still card** — who it is, and a notice that the meeting is being recorded —
instead of an empty camera feed. Two deployment knobs, in the same shape as `BOT_UI_LOCALE` (#856):

| Knob | Default | Effect |
|---|---|---|
| `BOT_FAKE_VIDEO_FILE` | `/dev/null` | the `.y4m` / `.mjpeg` file played as the camera feed |
| `BOT_CAMERA_ENABLED` | `false` | keep the camera on in the lobby instead of switching it off |

**Defaults are byte-identical to current behaviour.** A deployment that sets neither gets exactly
today's bot — empty feed, camera off. Nothing changes for anyone who does not opt in.

`invocation.v1` already declares `cameraEnabled` and `defaultAvatarUrl`; ADR 0035 states the
position plainly — *"the vocabulary is complete; seven of the eleven verbs have no bot handler"*.
This finishes one of those intents rather than inventing a new one, and does it in the join lane,
where the launch environment already lives.

Our use case: a French sales-assistant product whose bot joins customer meetings. The bot never
speaks, so what it *displays* is the only notice third parties receive — which is why the card
matters to us beyond branding.

## Observation bundle (the record of your harnessed loop)

- **C1 — the knobs alone are not enough.** Ran: bot into a live Meet call with
  `BOT_FAKE_VIDEO_FILE` set and the camera left uncut. Saw: no card; the bot appeared as Meet's
  generated initial, and the bot log said the camera control was untouched. Concluded: something
  upstream of the toggle was missing, so I stopped adding UI logic and went to look at what the
  browser actually received.
- **C2 — the flag was arriving twice.** Ran: `tr '\0' '\n' < /proc/<pid>/cmdline` on the running
  bot. Saw: `--use-file-for-fake-video-capture` **twice** — `/dev/null` from
  `getAuthenticatedBrowserArgs()` and my file from `getJoinBrowserArgs()`, because `capture-bridge`
  composes both. Concluded: one owner, and a test that counts occurrences, since neither source
  file can show a duplicate.
- **C3 — still no card, so the premise was wrong.** Ran: same call after de-duplicating; confirmed
  exactly one occurrence carrying my file. Saw: still no video. Concluded: the file flag does not
  make a camera *exist*. Adding `--use-fake-device-for-media-stream` produced the card on the next
  run, and the bot log then read `Camera was already ON.` — the lobby had opened camera-on by
  itself, so the correct fix was to assert state, not to click.
- **C4 — the microphone side effect had to be measured, not assumed.** The device flag replaces the
  mic with a synthetic tone, and this bot's whole job is recording. Ran: a 41.6 s call, spoke a few
  words, then decoded the uploaded chunks. Saw: RMS −37.3 dB overall with signal above −50 dB on
  **5 seconds out of 41**. Concluded: no leak — a beep in the capture path would put signal on 41
  of 41. This is why the device flag is gated on an actual file rather than always on.
- **C5 — one measurement I made was wrong, and it is worth flagging.** Reading the decoded WAV
  *from a pipe* reported **22,369 seconds** for 669 KB, because a streamed WAV declares a bogus
  size in its header. Concluded: write the file to disk and cross-check two independent ways (frame
  count and file size), which is how the 41.6 s figure above was obtained.

## Acceptance floor

Mapped to #1382's table, in the issue's own numbering. A6 and A7 are beyond the floor —
kept because they are what the run actually produced, not to raise the bar.

| Row | Evidence |
|---|---|
| A1 — the card is visible to other participants as a video tile | The bot's tile renders the card in the meeting grid, labelled with its `bot_name`. Screenshot in a follow-up comment |
| A2 — the bot arrives with the camera on, no post-join click | Bot log: `Camera was already ON.` — the helper found the toggle in the wanted state and clicked nothing |
| A3 — the flag reaches Chromium exactly once, with the deployment's value | `/proc/<pid>/cmdline`: `--use-fake-device-for-media-stream` and `--use-file-for-fake-video-capture=<file>`, one occurrence each. Negative control: before the de-duplication, two occurrences with `/dev/null` first |
| A4 — audio capture is not polluted by the synthetic microphone | 41.6 s recorded, RMS −37.3 dB, signal above −50 dB on 5 s of 41 (C4) |
| A5 — no regression in admission | Meet offered `"Accept 1 guest"`, the same wording as before the change — broadcasting video did not move the bot into the "potential risk" queue |
| A6 — encode cost is not the limiting factor at this frame rate | Container CPU at **39% of 4 cores** with one bot broadcasting a 1 fps 720p still |
| A7 — defaults unchanged | `fakeVideoTile.test.ts` case 1 asserts `/dev/null` and camera-off with no env set, and asserts the device flag is **absent** by default |

**Not checked** — stated so the bundle does not imply more than was measured:

- **Teams, Zoom, Jitsi.** The camera-state helper is Google-Meet-only here. The two knobs are
  platform-independent but were only exercised on Meet.
- **Datacenter egress.** Our own measurement of Google's "potential risk" classification tracks the
  **source IP**, not the bot: the same version and name is classified differently from a hosted IP
  than from a residential connection. So A5 says nothing about a datacenter deploy.
- **Whether Chromium honours the first or the last occurrence** of a repeated flag. The fix does
  not depend on it.
- **MJPEG.** Only `.y4m` was exercised.
- **The full compose deployment.** Validated on Lite only (see below).

One observation that may interest you more than it does us: at 1 fps, Meet relays the tile at
**640×360** even though the source is 1280×720 (read from `videoWidth`/`videoHeight` on the
receiving element), with CPU at 39% — so it is WebRTC adaptation, not encode pressure. We keep
1 fps deliberately, trading sharpness for bots-per-host.

## Docs diff (D6c)

`docs/docs/configuration.mdx` — a new **"Bot video tile (a still card)"** section, placed
immediately after "Bot participant name" because it is the same reader question (what other
participants see) at the same altitude. It carries the two variables with their defaults, the
one-frame `ffmpeg` recipe, the Y4M-over-MJPEG reasoning as a concurrency trade-off rather than a
preference, the in-container path pitfall, and the microphone side effect.

No reference page needed changing: the knobs are deployment environment, not API surface — `POST
/bots` is untouched.

## Security checks (required on the diff)

- **GitGuardian secrets scan**: pass on this PR.
- **`gate:licenses`**: OK — no dependency added or changed. The diff adds no imports and no
  packages; `pnpm-lock.yaml` is untouched.
- **Surface**: no new network call, no new file write, no new privilege. The change adds two
  browser launch flags and reads two environment variables.
- **Worth stating explicitly, since the flags sound permissive**:
  `--use-fake-device-for-media-stream` does not relax any security boundary — it substitutes
  synthetic capture devices. It is gated behind a deployment-set file path, so it cannot be
  triggered by a request body.

Full gate set run locally on the branch, turbo cache cleared so nothing is a replayed log:

```
13 gates            OK   (readme, docs-version, isolation, exports, graph, schema,
                          contract-version, config-contract, db-schema, db-budget,
                          dataflow, calm, licenses)
turbo typecheck     9/9 successful      (--force, cold)
turbo build         17/17 successful    (--force, cold)
turbo test          34/34 successful    (--force, cold; @vexa/join: 19 passed, 0 failed
                                         in the new file)
node --test scripts/*.test.mjs release/*.test.mjs
                    125 pass, 0 fail
```

## Validation request

Any competent non-author. What to watch: send a bot with `BOT_FAKE_VIDEO_FILE` pointing at a
one-frame `.y4m` mounted in the container and `BOT_CAMERA_ENABLED=1`, and check that the card
appears as a video tile and that the bot log reads `Camera turned ON` or `Camera was already ON`.
The negative control matters as much: with both unset, the bot must behave exactly as today —
`fakeVideoTile.test.ts` case 1 asserts that, but seeing it live is the point.

**Deployment validated (D12b):** Lite (`deploy/lite/Dockerfile.lite`), built from a fresh clone at
`v0.12.25` with these four commits applied, image `vexa-lite:dev` plus one derived layer that only
`COPY`s the `.y4m` into the image. Env deltas from stock: `BOT_FAKE_VIDEO_FILE`,
`BOT_CAMERA_ENABLED=1`, `TRANSCRIBE_ENABLED=false`. Guest mode, no authenticated session. Full
compose and k8s: **not run** — honestly unclaimed.

The `pnpm`-level gate set above was additionally re-run on this branch rebased onto current `main`,
which is what the diff targets.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).

Tooling disclosure (optional, welcome, never an attribution): written in an agent session; the
measurements in the bundle are machine-run and reproducible from the commands quoted, and the
rights path below is my own selection.
