### PR TITLE
fix(dashboard): fetch transcript by exact meeting row (hotfix on the deployed base)

### DIFF
--- a/services/dashboard/src/lib/api.ts
+++ b/services/dashboard/src/lib/api.ts
@@ -103,8 +103,10 @@ export const vexaAPI = {
     nativeId: string,
     meetingId?: string
   ): Promise<{ meeting: Meeting; segments: TranscriptSegment[]; recordings: RecordingData[] }> {
-    const params = meetingId ? `?meeting_id=${meetingId}` : "";
-    const response = await fetch(withBasePath(`/api/vexa/transcripts/${platform}/${nativeId}${params}`));
+    const transcriptPath = meetingId
+      ? `/api/vexa/transcripts/by-id/${encodeURIComponent(meetingId)}`
+      : `/api/vexa/transcripts/${platform}/${nativeId}`;
+    const response = await fetch(withBasePath(transcriptPath));
     interface RawSegment {
       start: number;
       end: number;

--- a/services/dashboard/tests/test_transcript_meeting_id_api.test.ts
+++ b/services/dashboard/tests/test_transcript_meeting_id_api.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { vexaAPI } from "@/lib/api";
+
+function transcriptResponse(id: number) {
+  return {
+    ok: true,
+    json: async () => ({
+      id,
+      platform: "zoom",
+      native_meeting_id: "89237402037",
+      status: "active",
+      start_time: "2026-07-23T19:31:00Z",
+      end_time: null,
+      segments: [],
+    }),
+  };
+}
+
+describe("vexaAPI.getMeetingWithTranscripts", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the exact meeting-row endpoint when an internal meeting id is supplied", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(transcriptResponse(13614)));
+
+    const result = await vexaAPI.getMeetingWithTranscripts(
+      "zoom",
+      "89237402037",
+      "13614"
+    );
+
+    expect(fetch).toHaveBeenCalledWith("/api/vexa/transcripts/by-id/13614");
+    expect(result.meeting.id).toBe("13614");
+  });
+
+  it("retains native-id lookup when no internal meeting id is supplied", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(transcriptResponse(13616)));
+
+    await vexaAPI.getMeetingWithTranscripts("zoom", "89237402037");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/vexa/transcripts/zoom/89237402037"
+    );
+  });
+});


### PR DESCRIPTION
Closes #1386.

The meeting page fetched the transcript by `platform/native_meeting_id`, which resolves the **newest** row for that native id. For a recurring meeting, calendar auto-join creates the next occurrence's `scheduled` row minutes after a call ends, and the completed meeting's page then rendered that empty newer row (prod 27493 → 27499, 271 segments hidden).

When the internal id is known, fetch `/transcripts/by-id/{id}` (owner-scoped, live in prod meeting-api + gateway). Falls back to the native route otherwise. Cherry-pick of `eecd9acf` (July 23) onto **`fa667cd1`, the commit prod's dashboard image is built from** — deliberately not onto this branch's head, so the shipped image carries only this change. Two vitest cases.

Rung: image built from this commit (`org.opencontainers.image.revision` label); prod delivery via channel entry seq-13, adoption in Vexa-ai/vexa-platform#392.

### Contribution Rights

- [ ] I am the sole rights holder for my contribution. (Independent path.) <!-- rights:independent -->

<!-- vexa-agent -->