### PR TITLE
[BUSINESS] flows: an inbound mail double — mailpit as a second inbox source, ATTENDEEs and Zoom in the ICS

### DIFF
--- a/core/flows/schema.sql
+++ b/core/flows/schema.sql
@@ -37,9 +37,20 @@ CREATE TABLE IF NOT EXISTS mail_thread (
 CREATE TABLE IF NOT EXISTS mail_cursor (
 	id SERIAL NOT NULL, 
 	uid INTEGER NOT NULL, 
+	token TEXT, 
 	PRIMARY KEY (id), 
 	CONSTRAINT cursor_singleton CHECK (id = 1)
 );
+
+CREATE TABLE IF NOT EXISTS mail_seen (
+	source TEXT NOT NULL, 
+	ext_id TEXT NOT NULL, 
+	created TEXT NOT NULL, 
+	seen_at DOUBLE PRECISION NOT NULL, 
+	PRIMARY KEY (source, ext_id)
+);
+
+CREATE INDEX IF NOT EXISTS mail_seen_window ON mail_seen (source, created);
 
 CREATE TABLE IF NOT EXISTS mail_outbox_sent (
 	subject_uid TEXT NOT NULL, 

--- a/core/flows/src/flows_integrations/README.md
+++ b/core/flows/src/flows_integrations/README.md
@@ -1,5 +1,12 @@
 # flows_integrations
 
 The edge: processes that turn the outside world into FACTS. `mailbox.py` — the real inbox:
-ICS → invite.received; thread-matched replies → mail.reply; durable IMAP cursor (mail_cursor row)
+ICS → invite.received; thread-matched replies → mail.reply; durable cursor (mail_cursor row)
 so restarts resume, never re-admit.
+
+`inbox.py` is the source seam underneath it: `VEXA_MAIL_INBOX=imap` (default) polls
+imap.gmail.com exactly as before, `=mailpit` polls the dev stack's mail double over REST
+(`VEXA_MAILPIT_URL`, filtered on `VEXA_MAIL_ADDR`, no mail password needed). Both fetch the raw
+RFC822 source and share one parse, so the two produce identical facts. Mailpit ids are random
+rather than monotonic, so its position is a `Created` watermark (`mail_cursor.token`) plus a
+seen-id set (`mail_seen`) — see the contracts at the top of `inbox.py`.

--- a/core/flows/src/flows_integrations/inbox.py
+++ b/core/flows/src/flows_integrations/inbox.py
@@ -1,0 +1,344 @@
+"""The INBOX SEAM — one poller, two sources, one set of facts.
+
+`mailbox.py` polls an INBOX. Which inbox technology that is must not reach the parser, the
+routing decision, the admission or the flows: both sources fetch the RAW RFC822 source and hand
+back the same `InboundMessage`, so a Gmail invite and a mailpit invite produce byte-identical
+facts.
+
+    VEXA_MAIL_INBOX = imap     (default) — IMAP against imap.gmail.com, exactly as before
+                    = mailpit           — the dev stack's mail double, REST only (no IMAP/POP3)
+    VEXA_MAILPIT_URL           — mailpit's HTTP base (default http://127.0.0.1:8025)
+    VEXA_MAIL_ADDR             — the address this inbox answers as; mailpit filters on it
+    VEXA_MAILPIT_LOOKBACK_S    — re-scan window behind the watermark (default 300)
+
+Contracts both sources keep — they are the ones the live witness paid for, so a source that
+breaks any of them is a regression, not a variant:
+
+  C1  **durable cursor** — a restart resumes where it stopped and NEVER re-admits; on first boot
+      the cursor anchors at the CURRENT tail, so an existing mailbox is not replayed.
+  C2  **threading** — inbound In-Reply-To/References are surfaced verbatim, so a reply routes by
+      THREAD (the `mail_thread` row), never by sender.
+  C3  **ICS attachments** are read and decoded — the invite is an attachment, not a body.
+  C4  **no sleeping, no internal polling** — `fetch()` returns what is there and stops.
+
+Why mailpit needs more than an integer: IMAP UIDs are monotonic, so one number is a complete
+position. Mailpit IDs are random base62 (`6bdn12ZorjbbiXdRJuW3xR`) and carry no order at all, so
+the position is a **`Created` watermark plus a seen-ID set**, both persisted — the watermark bounds
+the scan, the set makes the re-scan window idempotent. Both live next to the IMAP cursor:
+`mail_cursor.token` holds the watermark (the same nullable TEXT column the Exchange/Graph seam in
+Vexa-ai/vexa#1318 adds, deliberately — the two converge on merge) and `mail_seen` holds the ids.
+
+Stdlib only (imaplib/urllib), matching `flows_steps/common.py`'s `http()` idiom.
+"""
+from __future__ import annotations
+
+import calendar
+import email as email_mod
+import email.utils
+import imaplib
+import json
+import math
+import os
+import re
+import time
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Callable, Iterator
+
+# Exactly the two content types and the exact suffix test the IMAP poller has always used — a
+# widened match here would change the facts the Gmail path produces, which is the one thing this
+# seam may not do.
+ICS_TYPES = ("text/calendar", "application/ics")
+
+PAGE = 200          # mailpit list page size
+MAX_SCAN = 2000     # never walk further back than this many messages in one poll
+
+
+@dataclass(frozen=True)
+class InboundMessage:
+    """One inbound mail, source-independent.
+
+    `cursor` is the source-native position AFTER this message; the poller persists it once the
+    message has been routed (C1). `ext_id` is the source-native id — IMAP UID or mailpit ID —
+    and is only ever a fallback dedup key for a message with no Message-ID."""
+    cursor: str
+    ext_id: str
+    message_id: str
+    frm: str
+    subject: str
+    headers: dict = field(default_factory=dict)
+    body: str = ""
+    ics: str | None = None
+
+
+def from_rfc822(raw: bytes, *, cursor: str, ext_id: str) -> InboundMessage:
+    """RFC822 bytes → InboundMessage. THE shared parse: both sources go through this function and
+    nothing else, which is what makes the two paths produce identical facts."""
+    msg = email_mod.message_from_bytes(raw)
+    body, ics = "", None
+    for part in msg.walk():
+        ct = part.get_content_type()
+        if ct == "text/plain" and not body:
+            body = (part.get_payload(decode=True) or b"").decode(errors="replace")
+        if ct in ICS_TYPES or (part.get_filename() or "").endswith(".ics"):
+            ics = (part.get_payload(decode=True) or b"").decode(errors="replace")
+    return InboundMessage(
+        cursor=cursor, ext_id=ext_id,
+        message_id=(msg.get("Message-ID", "") or "").strip(),
+        frm=email_mod.utils.parseaddr(msg.get("From", ""))[1].lower(),
+        subject=msg.get("Subject", "") or "",
+        headers=dict(msg.items()), body=body, ics=ics)
+
+
+# ---------------------------------------------------------------------------------------------
+# Timestamps. Mailpit renders `Created` as Go's RFC3339Nano, which TRIMS trailing zeros — `.5Z`
+# and `.503Z` are both possible, and comparing those as strings orders them wrongly. So every
+# comparison goes through epochs, and every stored watermark is normalised to fixed-width
+# microseconds, which then IS safely string-ordered (the pruning DELETE relies on that).
+# ---------------------------------------------------------------------------------------------
+_ISO = re.compile(r"^(\d{4})-(\d{2})-(\d{2})[Tt ](\d{2}):(\d{2}):(\d{2})"
+                  r"(?:\.(\d+))?(Z|z|[+-]\d{2}:?\d{2})?$")
+
+
+def iso_epoch(s: str) -> float:
+    m = _ISO.match((s or "").strip())
+    if not m:
+        return 0.0
+    y, mo, d, h, mi, sec, frac, tz = m.groups()
+    ep = float(calendar.timegm((int(y), int(mo), int(d), int(h), int(mi), int(sec), 0, 1, -1)))
+    if frac:
+        ep += float("0." + frac)
+    if tz and tz not in ("Z", "z"):
+        off = tz[1:].replace(":", "")
+        delta = int(off[:2]) * 3600 + int(off[2:4] or 0) * 60
+        ep -= delta if tz[0] == "+" else -delta
+    return ep
+
+
+def iso_norm(value) -> str:
+    """Any accepted timestamp (or epoch) → `YYYY-MM-DDTHH:MM:SS.ffffffZ`, fixed width."""
+    ep = float(value) if isinstance(value, (int, float)) else iso_epoch(value)
+    whole = math.floor(ep)
+    micro = int(round((ep - whole) * 1_000_000))
+    if micro >= 1_000_000:
+        whole, micro = whole + 1, 0
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(whole)) + f".{micro:06d}Z"
+
+
+class Inbox:
+    """The seam. Five methods; nothing else may vary between sources."""
+
+    name = "abstract"
+
+    def address(self) -> str:
+        raise NotImplementedError
+
+    def restore(self, db) -> str | None:
+        """The persisted position, or None on first boot."""
+        raise NotImplementedError
+
+    def anchor(self, db, cursor: str) -> None:
+        """Persist the first-boot position (C1: history is never replayed)."""
+        raise NotImplementedError
+
+    def tail_cursor(self) -> str:
+        raise NotImplementedError
+
+    def fetch(self, cursor: str) -> Iterator[InboundMessage]:
+        raise NotImplementedError
+
+    def commit(self, db, msg: InboundMessage) -> None:
+        """Persist the position AFTER this message has been routed."""
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------------------------
+# IMAP — the original wiring, moved behind the seam and otherwise untouched: same host, same
+# UID search, same `n:*` guard, same single-integer cursor row.
+# ---------------------------------------------------------------------------------------------
+class ImapInbox(Inbox):
+    name = "imap"
+    host = "imap.gmail.com"
+    folder = "INBOX"
+
+    def _creds(self):
+        from flows_steps import emailx as mx
+        return mx.creds()
+
+    def address(self) -> str:
+        return self._creds()[0]
+
+    def restore(self, db) -> str | None:
+        row = db.execute("SELECT uid FROM mail_cursor WHERE id = 1")
+        return str(row[0][0]) if row else None
+
+    def anchor(self, db, cursor: str) -> None:
+        db.execute("INSERT INTO mail_cursor (id, uid) VALUES (1, :u) ON CONFLICT (id) DO NOTHING",
+                   {"u": int(cursor)})
+
+    def _open(self):
+        addr, pw = self._creds()
+        im = imaplib.IMAP4_SSL(self.host)
+        im.login(addr, pw)
+        im.select(self.folder)
+        return im
+
+    def tail_cursor(self) -> str:
+        with self._open() as im:
+            _, d = im.uid("search", None, "ALL")
+            uids = d[0].split() if d and d[0] else []
+            return str(int(uids[-1])) if uids else "0"
+
+    def fetch(self, cursor: str) -> Iterator[InboundMessage]:
+        low = int(cursor or 0)
+        with self._open() as im:
+            _, d = im.uid("search", None, f"UID {low + 1}:*")
+            for raw in (d[0].split() if d and d[0] else []):
+                uid = int(raw)
+                if uid <= low:
+                    continue          # IMAP's `n:*` returns the last UID even when the range is empty
+                _, md = im.uid("fetch", raw, "(RFC822)")
+                yield from_rfc822(md[0][1], cursor=str(uid), ext_id=str(uid))
+
+    def commit(self, db, msg: InboundMessage) -> None:
+        db.execute("UPDATE mail_cursor SET uid = :u WHERE id = 1", {"u": int(msg.cursor)})
+
+
+# ---------------------------------------------------------------------------------------------
+# Mailpit — the dev stack's mail double. REST only: no IMAP, no POP3 on this deployment.
+# ---------------------------------------------------------------------------------------------
+class MailpitInbox(Inbox):
+    name = "mailpit"
+
+    def __init__(self, base_url: str | None = None, addr: str | None = None,
+                 opener: Callable[[str], bytes] | None = None,
+                 lookback_s: float | None = None) -> None:
+        self.base = (base_url or os.environ.get("VEXA_MAILPIT_URL")
+                     or "http://127.0.0.1:8025").rstrip("/")
+        self.addr = (addr or os.environ.get("VEXA_MAIL_ADDR") or "").strip().lower()
+        if not self.addr:
+            raise ValueError("VEXA_MAIL_ADDR is required for VEXA_MAIL_INBOX=mailpit — it is the "
+                             "recipient this inbox answers as, and mailpit accepts every address")
+        self._open = opener or self._urlopen
+        self.lookback = float(lookback_s if lookback_s is not None
+                              else os.environ.get("VEXA_MAILPIT_LOOKBACK_S", "300"))
+        self._seen: set[str] = set()
+
+    # --- transport ---------------------------------------------------------------------------
+    def _urlopen(self, path: str) -> bytes:  # pragma: no cover — exercised against live mailpit
+        req = urllib.request.Request(self.base + path, method="GET")
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.read()
+
+    def _json(self, path: str) -> dict:
+        raw = self._open(path)
+        return json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+
+    def address(self) -> str:
+        return self.addr
+
+    # --- cursor ------------------------------------------------------------------------------
+    @staticmethod
+    def ensure_schema(db) -> None:
+        """`schema.sql` is CREATE TABLE IF NOT EXISTS with no migration runner, so a database that
+        was deployed before this seam has a `mail_cursor` with no `token` column. Add it — one
+        idempotent ALTER, run only on the mailpit path, so an IMAP deployment is never touched."""
+        try:
+            db.execute("SELECT token FROM mail_cursor WHERE id = 1")
+        except Exception:  # noqa: BLE001 — "column does not exist" is a schema fact, not a failure
+            db.execute("ALTER TABLE mail_cursor ADD COLUMN token TEXT")
+
+    def restore(self, db) -> str | None:
+        self.ensure_schema(db)
+        row = db.execute("SELECT token FROM mail_cursor WHERE id = 1")
+        token = (row[0][0] if row else None) or None
+        if token:
+            floor = iso_norm(iso_epoch(token) - self.lookback)
+            self._seen = {r[0] for r in db.execute(
+                "SELECT ext_id FROM mail_seen WHERE source = :s AND created >= :f",
+                {"s": self.name, "f": floor})}
+        return token
+
+    def anchor(self, db, cursor: str) -> None:
+        """Anchoring is not just a watermark here: everything already in the box AT OR BEFORE the
+        anchor is marked seen. That makes the two boot cases one rule — anchoring at the tail
+        skips the double's whole rehearsal history (C1), while anchoring at an operator-supplied
+        earlier position still admits everything after it."""
+        self.ensure_schema(db)
+        at = iso_norm(cursor)
+        db.execute("INSERT INTO mail_cursor (id, uid, token) VALUES (1, 0, :t) "
+                   "ON CONFLICT (id) DO UPDATE SET token = :t", {"t": at})
+        for created, m in self._scan(iso_epoch(at) - self.lookback):
+            if created <= at:
+                self._mark_seen(db, m.get("ID") or "", created)
+
+    def tail_cursor(self) -> str:
+        """The newest message's timestamp, or now — first boot never replays the double's history
+        (a rig mailbox holds every rehearsal that came before)."""
+        msgs = (self._json(f"/api/v1/messages?limit=1&start=0").get("messages") or [])
+        return iso_norm(msgs[0].get("Created", "")) if msgs else iso_norm(time.time())
+
+    def _mark_seen(self, db, ext_id: str, created: str) -> None:
+        db.execute("INSERT INTO mail_seen (source, ext_id, created, seen_at) "
+                   "VALUES (:s, :e, :c, :t) ON CONFLICT (source, ext_id) DO NOTHING",
+                   {"s": self.name, "e": ext_id, "c": created, "t": time.time()})
+        self._seen.add(ext_id)
+
+    def commit(self, db, msg: InboundMessage) -> None:
+        created = msg.cursor
+        self._mark_seen(db, msg.ext_id, created)
+        row = db.execute("SELECT token FROM mail_cursor WHERE id = 1")
+        held = (row[0][0] if row else None) or ""
+        if iso_epoch(created) >= iso_epoch(held):
+            db.execute("UPDATE mail_cursor SET token = :t WHERE id = 1", {"t": created})
+            # anything older than the re-scan window can never be fetched again
+            db.execute("DELETE FROM mail_seen WHERE source = :s AND created < :f",
+                       {"s": self.name, "f": iso_norm(iso_epoch(created) - self.lookback - 86400)})
+
+    # --- fetch -------------------------------------------------------------------------------
+    def _for_us(self, m: dict) -> bool:
+        for field_name in ("To", "Cc", "Bcc"):
+            for who in (m.get(field_name) or []):
+                if (who.get("Address") or "").strip().lower() == self.addr:
+                    return True
+        return False
+
+    def _scan(self, floor: float) -> list[tuple[str, dict]]:
+        """Every listed message at or after `floor`, oldest first. Mailpit lists newest first, so
+        the walk stops at the first message that falls out of the window."""
+        picked: list[tuple[str, dict]] = []
+        start = 0
+        while start < MAX_SCAN:
+            msgs = self._json(f"/api/v1/messages?limit={PAGE}&start={start}").get("messages") or []
+            if not msgs:
+                break
+            done = False
+            for m in msgs:
+                created = iso_norm(m.get("Created", ""))
+                if iso_epoch(created) < floor:
+                    done = True
+                    break
+                picked.append((created, m))
+            if done or len(msgs) < PAGE:
+                break
+            start += PAGE
+        picked.sort(key=lambda t: (t[0], t[1].get("ID", "")))
+        return picked
+
+    def fetch(self, cursor: str) -> Iterator[InboundMessage]:
+        for created, m in self._scan(iso_epoch(cursor) - self.lookback):
+            mid = m.get("ID") or ""
+            if mid in self._seen or not self._for_us(m):
+                continue
+            raw = self._open(f"/api/v1/message/{mid}/raw")
+            yield from_rfc822(raw if isinstance(raw, bytes) else raw.encode(),
+                              cursor=created, ext_id=mid)
+
+
+def get_inbox() -> Inbox:
+    kind = (os.environ.get("VEXA_MAIL_INBOX") or "imap").strip().lower()
+    if kind in ("", "imap", "gmail"):
+        return ImapInbox()
+    if kind == "mailpit":
+        return MailpitInbox()
+    raise ValueError(f"VEXA_MAIL_INBOX={kind!r} — expected 'imap' (default) or 'mailpit'")

--- a/core/flows/src/flows_integrations/mailbox.py
+++ b/core/flows/src/flows_integrations/mailbox.py
@@ -1,13 +1,27 @@
 """mailbox integration — its own process: the REAL inbox becomes facts.
 
-  ICS attachment (with a Meet link)      → invite.received   (dedup: the ICS UID)
+  ICS attachment (with a meeting link)   → invite.received   (dedup: the ICS UID)
   reply on a registered thread           → mail.reply        (dedup: inbound Message-ID)
   anything else                          → logged, ignored
 
 Threading is the law here: a reply routes by In-Reply-To/References looked up in mail_thread —
-never by sender. Cursor is durable (mail_cursor row) — restarts resume, never re-admit."""
+never by sender. Cursor is durable (mail_cursor row) — restarts resume, never re-admit.
+
+WHICH inbox this is stops at `inbox.get_inbox()` — routing, admission and dedup below are
+source-blind by design:
+
+    VEXA_MAIL_INBOX = imap     (default) — IMAP against imap.gmail.com, behaviour unchanged
+                    = mailpit           — the dev stack's mail double (REST only, no IMAP)
+    VEXA_MAILPIT_URL           — mailpit's HTTP base (default http://127.0.0.1:8025)
+    VEXA_MAIL_ADDR             — the address this inbox answers as; mailpit filters on it
+    VEXA_MAILPIT_LOOKBACK_S    — re-scan window behind the watermark (default 300)
+
+Both sources fetch the raw RFC822 source and go through the same parse, so a Gmail invite and a
+mailpit invite produce byte-identical facts. See `flows_integrations/inbox.py` for the contracts.
+"""
 from __future__ import annotations
 
+import os
 import re
 import sys
 import time
@@ -17,16 +31,35 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from flows import Registry, SystemClock, admit, postgres_db
 from flows_defs import production
-from flows_steps import emailx as mx
+from flows_integrations.inbox import get_inbox
 from flows_steps.common import db_url
 
+POLL_SECONDS = 12
 
-def parse_ics(ics: str) -> dict | None:
+# A meeting link is Meet or Zoom. Meet stays byte-for-byte the pattern it always was (case
+# sensitive, lowercase code); Zoom is the DNA corpus's platform — those invites are zoom.us.
+MEET_URL = re.compile(r"https://meet\.google\.com/[a-z-]+")
+ZOOM_URL = re.compile(r"https://(?:[A-Za-z0-9-]+\.)*zoom\.us/j/\d+(?:\?pwd=[A-Za-z0-9._%~-]+)?")
+
+
+def _meeting_url(text: str) -> str | None:
+    m = MEET_URL.search(text) or ZOOM_URL.search(text)
+    return m.group(0) if m else None
+
+
+def _unfold(ics: str) -> str:
+    """RFC 5545 line folding: a CRLF followed by one space or tab continues the line. Real
+    invites fold — a Zoom URL with a `?pwd=` is long enough to be split mid-token, and an
+    ATTENDEE line with a CN and a mailto is longer still."""
+    return re.sub(r"\r?\n[ \t]", "", ics)
+
+
+def parse_ics(ics: str, self_addr: str | None = None) -> dict | None:
+    ics = _unfold(ics)
     if "BEGIN:VEVENT" not in ics:
         return None                       # no event block — never fall back to scanning VTIMEZONE
     ve = ics.split("BEGIN:VEVENT", 1)[-1].split("END:VEVENT", 1)[0]
-    url = re.search(r"https://meet\.google\.com/[a-z-]+", ve) or \
-        re.search(r"https://meet\.google\.com/[a-z-]+", ics)
+    url = _meeting_url(ve) or _meeting_url(ics)
     if not url:
         return None
     org = re.search(r"ORGANIZER[^:]*:(?:mailto:)?([^\s]+)", ve, re.I)
@@ -38,6 +71,15 @@ def parse_ics(ics: str) -> dict | None:
     gm = re.search(r"#group:([\w-]+)", ics)
     if gm:
         group = gm.group(1)
+    # Who else is in the room. The organizer stays exactly what it was — this is an ADDITIONAL
+    # ref, and every existing consumer of refs is untouched. Our own address is never a
+    # participant: we are the notetaker, and an onboarding aimed at ourselves is an echo loop.
+    me = (self_addr if self_addr is not None else os.environ.get("VEXA_MAIL_ADDR", "")).strip().lower()
+    participants: list[str] = []
+    for a in re.finditer(r"ATTENDEE[^\n]*?mailto:([^\s;,>\"]+)", ve, re.I):
+        who = a.group(1).strip().lower()
+        if who and who != me and who not in participants:
+            participants.append(who)
     start = time.time() + 150
     if dt:
         import calendar as cal
@@ -55,10 +97,11 @@ def parse_ics(ics: str) -> dict | None:
                                           # class) or a stale event — never admit it (a bot would
                                           # dispatch IMMEDIATELY on an ancient start)
     return {"organizer": (org.group(1).strip().lower() if org else ""),
-            "url": url.group(0), "start": start,
+            "url": url, "start": start,
             "ics_uid": (uid.group(1).strip() if uid else f"noid-{int(start)}"),
             "title": (summ.group(1).strip() if summ else "Meeting"),
-            "group": group}
+            "group": group,
+            "participants": participants}
 
 
 def route(db, self_addr: str, frm: str, headers: dict, ics: str | None,
@@ -74,7 +117,7 @@ def route(db, self_addr: str, frm: str, headers: dict, ics: str | None,
             return None               # calendar machinery (our own RSVP echoes!) — never a
                                       # conversation, never a provisioning trigger (storm catch:
                                       # we nearly onboarded calendar-notification@google.com)
-        ev = parse_ics(ics)
+        ev = parse_ics(ics, self_addr)
         if ev and ev["organizer"]:
             return ("invite", ev)
         return None
@@ -100,88 +143,68 @@ def strip_quotes(body: str) -> str:
     return "\n".join(l for l in body.strip().splitlines() if not l.strip().startswith(">"))[:2000]
 
 
+def handle(db, reg, clock, self_addr: str, msg, known_uid, is_scaffolded,
+           provision) -> tuple[str, int] | None:
+    """One inbound message → at most one admission. Source-blind and service-blind: every reach
+    outside is injected, so the whole intake is drivable offline."""
+    decision = route(db, self_addr, msg.frm, msg.headers, msg.ics, known_uid, is_scaffolded)
+    if decision is None:
+        return None
+    kind, payload = decision
+    if kind == "invite":
+        n = admit(db, reg, clock, source_event_id=f"ics-{payload['ics_uid']}",
+                  event_type="invite.received", subject_refs=payload)
+        return ("invite", n)
+    if kind == "new_sender_mail":
+        payload["uid"] = provision(msg.frm)
+    n = admit(db, reg, clock,
+              source_event_id=f"mail-{msg.message_id or msg.ext_id}",
+              event_type="mail.reply",
+              subject_refs={"uid": str(payload["uid"]), "session": payload["session"],
+                            "from_addr": msg.frm, "text": strip_quotes(msg.body),
+                            "subject": msg.subject, "orig_msgid": msg.message_id,
+                            "organizer": msg.frm})
+    return (kind, n)
+
+
 def main() -> int:
     db = postgres_db(db_url())
     clock = SystemClock()
     reg = Registry()
     production.build(reg, db)     # the matcher needs the flow triggers; steps unused here
+    inbox = get_inbox()
 
-    row = db.execute("SELECT uid FROM mail_cursor WHERE id = 1")
-    if row:
-        cursor = row[0][0]
-    else:
+    cursor = inbox.restore(db)
+    if cursor is None:
         # first boot: anchor at the CURRENT inbox tail — history is never replayed
-        tail = 0
-        import imaplib
-        addr, pw = mx.creds()
-        with imaplib.IMAP4_SSL("imap.gmail.com") as im:
-            im.login(addr, pw); im.select("INBOX")
-            _, d = im.uid("search", None, "ALL")
-            uids = d[0].split() if d and d[0] else []
-            tail = int(uids[-1]) if uids else 0
-        cursor = int(sys.argv[1]) if len(sys.argv) > 1 else tail
-        db.execute("INSERT INTO mail_cursor (id, uid) VALUES (1, :u) ON CONFLICT (id) DO NOTHING",
-                   {"u": cursor})
-    print(f"mailbox integration up · cursor uid {cursor}", flush=True)
+        cursor = sys.argv[1] if len(sys.argv) > 1 else inbox.tail_cursor()
+        inbox.anchor(db, cursor)
+    print(f"mailbox integration up · inbox {inbox.name} · cursor {cursor!r}", flush=True)
 
-    import email as email_mod
-    import imaplib
+    from flows_steps.common import ADMIN_API, ADMIN_KEY, ensure_platform_user
+    from flows_steps.common import http as _http
+    from flows_steps.common import scaffolded as _scaff
+
+    def _known_uid(e: str):
+        code, u = _http("GET", f"{ADMIN_API}/admin/users/email/{e}", {"X-Admin-API-Key": ADMIN_KEY})
+        return u.get("id") if code == 200 else None
+
     while True:
         try:
-            addr, pw = mx.creds()
-            with imaplib.IMAP4_SSL("imap.gmail.com") as im:
-                im.login(addr, pw); im.select("INBOX")
-                _, d = im.uid("search", None, f"UID {cursor + 1}:*")
-                for raw in (d[0].split() if d and d[0] else []):
-                    uid = int(raw)
-                    if uid <= cursor:
-                        continue
-                    _, md = im.uid("fetch", raw, "(RFC822)")
-                    msg = email_mod.message_from_bytes(md[0][1])
-                    frm = email_mod.utils.parseaddr(msg.get("From", ""))[1].lower()
-                    body, ics = "", None
-                    for part in msg.walk():
-                        ct = part.get_content_type()
-                        if ct == "text/plain" and not body:
-                            body = part.get_payload(decode=True).decode(errors="replace")
-                        if ct in ("text/calendar", "application/ics") or \
-                                (part.get_filename() or "").endswith(".ics"):
-                            ics = part.get_payload(decode=True).decode(errors="replace")
-                    from flows_steps.common import ADMIN_API, ADMIN_KEY, http as _http, scaffolded as _scaff
-
-                    def _known_uid(e: str):
-                        code, u = _http("GET", f"{ADMIN_API}/admin/users/email/{e}",
-                                        {"X-Admin-API-Key": ADMIN_KEY})
-                        return u.get("id") if code == 200 else None
-
-                    decision = route(db, addr, frm, dict(msg.items()), ics, _known_uid, _scaff)
-                    if decision is None:
-                        print(f"ignored mail from {frm} ({msg.get('Subject','')[:40]!r})", flush=True)
-                    else:
-                        kind, payload = decision
-                        if kind == "invite":
-                            n = admit(db, reg, clock, source_event_id=f"ics-{payload['ics_uid']}",
-                                      event_type="invite.received", subject_refs=payload)
-                            print(f"ICS '{payload['title']}' {payload['organizer']} group={payload['group']} → admitted {n}", flush=True)
-                        else:
-                            if kind == "new_sender_mail":
-                                from flows_steps.common import ensure_platform_user
-                                payload["uid"] = ensure_platform_user(frm)
-                                print(f"NEW sender {frm} provisioned (uid {payload['uid']})", flush=True)
-                            n = admit(db, reg, clock,
-                                      source_event_id=f"mail-{msg.get('Message-ID','').strip() or uid}",
-                                      event_type="mail.reply",
-                                      subject_refs={"uid": str(payload["uid"]), "session": payload["session"],
-                                                    "from_addr": frm, "text": strip_quotes(body),
-                                                    "subject": msg.get("Subject", ""),
-                                                    "orig_msgid": msg.get("Message-ID", "").strip(),
-                                                    "organizer": frm})
-                            print(f"{kind} {frm} → {payload['session']} → admitted {n}", flush=True)
-                    cursor = uid
-                    db.execute("UPDATE mail_cursor SET uid = :u WHERE id = 1", {"u": cursor})
+            self_addr = inbox.address().lower()
+            for msg in inbox.fetch(cursor):
+                out = handle(db, reg, clock, self_addr, msg, _known_uid, _scaff,
+                             ensure_platform_user)
+                if out is None:
+                    print(f"ignored mail from {msg.frm} ({msg.subject[:40]!r})", flush=True)
+                else:
+                    kind, n = out
+                    print(f"{kind} {msg.frm} {msg.subject[:40]!r} → admitted {n}", flush=True)
+                cursor = msg.cursor
+                inbox.commit(db, msg)
         except Exception as e:  # noqa: BLE001
             print(f"poll hiccup: {type(e).__name__}: {e}", flush=True)
-        time.sleep(12)
+        time.sleep(POLL_SECONDS)
 
 
 if __name__ == "__main__":

--- a/core/flows/src/flows_schema/models.py
+++ b/core/flows/src/flows_schema/models.py
@@ -82,10 +82,31 @@ class MailThread(Base):
 
 
 class MailCursor(Base):
+    """One row: where the inbox poller stopped.
+
+    'uid' is the IMAP UID — monotonic, so one integer is a complete position. 'token' is for
+    sources whose ids are not ordered at all (mailpit's are random base62): it holds an opaque
+    source-native watermark, and the 'mail_seen' table holds the ids it cannot separate."""
     __tablename__ = "mail_cursor"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     uid: Mapped[int] = mapped_column(Integer, nullable=False)
+    token: Mapped[str | None] = mapped_column(Text)
     __table_args__ = (CheckConstraint("id = 1", name="cursor_singleton"),)
+
+
+class MailSeen(Base):
+    """Ids already routed, per inbox source — the never-re-admit half of a non-monotonic cursor.
+
+    A watermark alone cannot make a re-scan idempotent when the source orders by a timestamp that
+    several messages can share, so the poller re-scans a small window behind the watermark and
+    this table decides what inside it has already been answered. Rows older than the window are
+    pruned on every commit; they can never be fetched again."""
+    __tablename__ = "mail_seen"
+    source: Mapped[str] = mapped_column(Text, primary_key=True)
+    ext_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    created: Mapped[str] = mapped_column(Text, nullable=False)
+    seen_at: Mapped[float] = mapped_column(Double, nullable=False)
+    __table_args__ = (Index("mail_seen_window", "source", "created"),)
 
 
 class MailOutboxSent(Base):

--- a/core/flows/tests/mailpit/README.md
+++ b/core/flows/tests/mailpit/README.md
@@ -1,0 +1,18 @@
+# tests/mailpit — the recorded inbound double
+
+`messages.json` is the shape mailpit **1.30.7** actually returns from `GET /api/v1/messages`
+(recorded off the dogfood rig): newest first, `ID` a random base62 string with no order in it,
+`Created` in Go's RFC3339Nano — which trims trailing zeros, so `.5Z` sits next to `.503Z` and
+string comparison would order the two wrongly. That trap is deliberate; `test_inbound_double.py`
+pins it.
+
+The three `.eml` files are what `GET /api/v1/message/<ID>/raw` returns for those rows:
+
+| file | what it proves |
+|---|---|
+| `invite-dna-tsc.eml` | an ICS invite the DNA corpus shape: a **Zoom** URL, two real ATTENDEEs plus our own address, a `#group:` tag, and folded lines (RFC 5545) through the ATTENDEE and DESCRIPTION properties |
+| `reply-minutes.eml` | a reply carrying `In-Reply-To` — routed by the thread row, never by the sender |
+| `not-for-us.eml` | mailpit accepts every address, so a poller that does not filter on `VEXA_MAIL_ADDR` answers another tenant's mail |
+
+Re-record with `curl -s "$VEXA_MAILPIT_URL/api/v1/messages?limit=200"` and
+`curl -s "$VEXA_MAILPIT_URL/api/v1/message/<ID>/raw"`.

--- a/core/flows/tests/mailpit/invite-dna-tsc.eml
+++ b/core/flows/tests/mailpit/invite-dna-tsc.eml
@@ -1,0 +1,39 @@
+From: Marvin Nolan <Organizer@DNA.test>
+To: vexa@oenb.at
+Subject: Invitation: DNA TSC weekly @ Sat Mar 2, 2030 2pm (UTC)
+Message-ID: <invite-dna-tsc-1@dna.test>
+Date: Tue, 01 Sep 2026 21:14:02 +0000
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="b1"
+
+--b1
+Content-Type: text/plain; charset="utf-8"
+
+You have been invited to DNA TSC weekly.
+
+--b1
+Content-Type: text/calendar; charset="utf-8"; method=REQUEST; name="invite.ics"
+Content-Disposition: attachment; filename="invite.ics"
+
+BEGIN:VCALENDAR
+PRODID:-//Zoom//Zoom Calendar//EN
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VEVENT
+DTSTART:20300302T140000Z
+DTEND:20300302T150000Z
+UID:dna-tsc-20300302@zoom.us
+ORGANIZER;CN=Marvin Nolan:mailto:Organizer@DNA.test
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;CN=Ame
+ lia Chen:mailto:Amelia@DNA.test
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;CN=Priya Raman:mailto:priya@
+ dna.test
+ATTENDEE;CN=Vexa;PARTSTAT=NEEDS-ACTION:mailto:VEXA@oenb.at
+SUMMARY:DNA TSC weekly
+DESCRIPTION:Join Zoom Meeting #group:dna-tsc\nhttps://us02web.zoom.us/j/8412
+ 3456789?pwd=aBcD1234efGH
+LOCATION:https://us02web.zoom.us/j/84123456789?pwd=aBcD1234efGH
+END:VEVENT
+END:VCALENDAR
+
+--b1--

--- a/core/flows/tests/mailpit/messages.json
+++ b/core/flows/tests/mailpit/messages.json
@@ -1,0 +1,58 @@
+{
+  "total": 3,
+  "unread": 0,
+  "count": 3,
+  "messages_count": 3,
+  "start": 0,
+  "tags": [],
+  "messages": [
+    {
+      "ID": "3ReplyAmeliaXXXXXXXXXX",
+      "MessageID": "reply-amelia-1@dna.test",
+      "Read": false,
+      "From": {"Name": "Amelia Chen", "Address": "amelia@dna.test"},
+      "To": [{"Name": "", "Address": "vexa@oenb.at"}],
+      "Cc": null,
+      "Bcc": null,
+      "ReplyTo": [],
+      "Subject": "Re: Minutes: DNA TSC weekly",
+      "Created": "2026-09-01T21:20:11.5Z",
+      "Tags": [],
+      "Size": 512,
+      "Attachments": 0,
+      "Snippet": "Point 3 is wrong - the vote was deferred, not carried."
+    },
+    {
+      "ID": "2StrangerYYYYYYYYYYYYY",
+      "MessageID": "stranger-1@rehearsal.test",
+      "Read": false,
+      "From": {"Name": "Someone Else", "Address": "someone@rehearsal.test"},
+      "To": [{"Name": "", "Address": "other-tenant@rehearsal.test"}],
+      "Cc": null,
+      "Bcc": null,
+      "ReplyTo": [],
+      "Subject": "not addressed to this mailbox",
+      "Created": "2026-09-01T21:16:00Z",
+      "Tags": [],
+      "Size": 301,
+      "Attachments": 0,
+      "Snippet": "This mailbox is a shared double"
+    },
+    {
+      "ID": "1InviteDnaTscZZZZZZZZZ",
+      "MessageID": "invite-dna-tsc-1@dna.test",
+      "Read": false,
+      "From": {"Name": "Marvin Nolan", "Address": "organizer@dna.test"},
+      "To": [{"Name": "", "Address": "vexa@oenb.at"}],
+      "Cc": null,
+      "Bcc": null,
+      "ReplyTo": [],
+      "Subject": "Invitation: DNA TSC weekly @ Sat Mar 2, 2030 2pm (UTC)",
+      "Created": "2026-09-01T21:14:02.503Z",
+      "Tags": [],
+      "Size": 1204,
+      "Attachments": 1,
+      "Snippet": "You have been invited to DNA TSC weekly."
+    }
+  ]
+}

--- a/core/flows/tests/mailpit/not-for-us.eml
+++ b/core/flows/tests/mailpit/not-for-us.eml
@@ -1,0 +1,10 @@
+From: Someone Else <someone@rehearsal.test>
+To: other-tenant@rehearsal.test
+Subject: not addressed to this mailbox
+Message-ID: <stranger-1@rehearsal.test>
+Date: Tue, 01 Sep 2026 21:16:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+This mailbox is a shared double: mailpit accepts every address, so the poller
+must filter on VEXA_MAIL_ADDR or it answers other people's mail.

--- a/core/flows/tests/mailpit/reply-minutes.eml
+++ b/core/flows/tests/mailpit/reply-minutes.eml
@@ -1,0 +1,14 @@
+From: Amelia Chen <Amelia@DNA.test>
+To: vexa@oenb.at
+Subject: Re: Minutes: DNA TSC weekly
+Message-ID: <reply-amelia-1@dna.test>
+In-Reply-To: <minutes-thread-1@vexa.ai>
+References: <ack-1@vexa.ai> <minutes-thread-1@vexa.ai>
+Date: Tue, 01 Sep 2026 21:20:11 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Point 3 is wrong - the vote was deferred, not carried.
+
+> Minutes: DNA TSC weekly
+> 3. The licence vote carried.

--- a/core/flows/tests/test_inbound_double.py
+++ b/core/flows/tests/test_inbound_double.py
@@ -1,0 +1,250 @@
+"""The INBOUND DOUBLE — mailpit as a second inbox source, driven from recorded fixtures.
+
+The dev stack's mail double is mailpit: REST only, no IMAP and no POP3, so the Gmail-hardcoded
+poller could not receive anything there and an invite or a reply had to be injected as a fact.
+These tests hold the four properties that make the second source usable as a rehearsal surface:
+
+  1. an ICS invite (Zoom link, two ATTENDEEs) becomes exactly the `invite.received` refs
+  2. a reply carrying In-Reply-To routes by THREAD into `mail.reply`
+  3. the cursor never re-admits across a restart, even with the whole history back in the window
+  4. the IMAP path is untouched — the same bytes through either source yield identical facts
+
+`tests/mailpit/messages.json` is the shape mailpit 1.30.7 actually returns (recorded off the rig,
+including Go's RFC3339Nano trailing-zero trim: `.5Z` next to `.503Z`).
+"""
+from __future__ import annotations
+
+import calendar
+import json
+import sys
+import time
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from flows import EventType, FakeClock, Registry, SqliteDB  # noqa: E402
+from flows_integrations.inbox import (  # noqa: E402
+    ImapInbox,
+    MailpitInbox,
+    from_rfc822,
+    get_inbox,
+    iso_epoch,
+    iso_norm,
+)
+from flows_integrations.mailbox import handle, parse_ics  # noqa: E402
+from flows_steps.emailx import register_thread  # noqa: E402
+
+FIX = Path(__file__).resolve().parent / "mailpit"
+SELF = "vexa@oenb.at"
+BEFORE_ALL = "2026-09-01T21:00:00.000000Z"
+EML = {"1InviteDnaTscZZZZZZZZZ": "invite-dna-tsc.eml",
+       "2StrangerYYYYYYYYYYYYY": "not-for-us.eml",
+       "3ReplyAmeliaXXXXXXXXXX": "reply-minutes.eml"}
+
+
+def recorded_mailpit(path: str) -> bytes:
+    """The recorded mailpit API: the list endpoint (paged) and the raw-source endpoint."""
+    u = urlparse(path)
+    if u.path == "/api/v1/messages":
+        q = parse_qs(u.query)
+        start = int(q.get("start", ["0"])[0])
+        limit = int(q.get("limit", ["50"])[0])
+        doc = json.loads((FIX / "messages.json").read_text())
+        doc["messages"] = doc["messages"][start:start + limit]
+        doc["count"] = len(doc["messages"])
+        return json.dumps(doc).encode()
+    if u.path.startswith("/api/v1/message/") and u.path.endswith("/raw"):
+        return (FIX / EML[u.path.split("/")[4]]).read_bytes()
+    raise AssertionError(f"mailpit fixture has no recording for {path}")
+
+
+def rig(lookback_s: float = 86_400.0):
+    """A db with both flows registered, and a mailpit inbox positioned before the whole fixture."""
+    db, clock, reg = SqliteDB(), FakeClock(), Registry()
+
+    @reg.step
+    def noop(ctx):
+        from flows import Done
+        return Done()
+
+    reg.flow(name="invite_intake", version=1, on=EventType("invite.received"), steps=[noop])
+    reg.flow(name="email_chat", version=1, on=EventType("mail.reply"), steps=[noop])
+
+    # the minutes mail that this fixture's reply answers — the thread row is what routes it
+    register_thread(db, "<minutes-thread-1@vexa.ai>", "7", "main")
+
+    inbox = MailpitInbox(base_url="http://recorded", addr=SELF, opener=recorded_mailpit,
+                         lookback_s=lookback_s)
+    assert inbox.restore(db) is None, "a virgin db has no position"
+    inbox.anchor(db, BEFORE_ALL)
+    return db, reg, clock, inbox
+
+
+def drive(db, reg, clock, inbox, cursor: str):
+    """One poll: exactly what mailbox.main()'s loop body does, with the services injected."""
+    out = []
+    for msg in inbox.fetch(cursor):
+        out.append((msg, handle(db, reg, clock, SELF, msg,
+                                known_uid=lambda e: None,
+                                is_scaffolded=lambda u: False,
+                                provision=lambda e: "99")))
+        cursor = msg.cursor
+        inbox.commit(db, msg)
+    return cursor, out
+
+
+def refs_of(db, event_type: str) -> list[dict]:
+    return [json.loads(r[0]) for r in db.execute(
+        "SELECT subject_refs FROM reaction WHERE event_type = :e ORDER BY created_at",
+        {"e": event_type})]
+
+
+# ---------------------------------------------------------------------------------------------
+# 1 · the invite
+# ---------------------------------------------------------------------------------------------
+def test_zoom_invite_becomes_the_exact_invite_received_refs():
+    db, reg, clock, inbox = rig()
+    _, out = drive(db, reg, clock, inbox, BEFORE_ALL)
+
+    kinds = [o[1][0] for o in out]
+    assert kinds == ["invite", "thread_reply"], "oldest first, stranger filtered out"
+
+    ev = refs_of(db, "invite.received")[0]
+    assert ev == {
+        "organizer": "organizer@dna.test",
+        "url": "https://us02web.zoom.us/j/84123456789?pwd=aBcD1234efGH",
+        "start": float(calendar.timegm(time.strptime("20300302T140000", "%Y%m%dT%H%M%S"))),
+        "ics_uid": "dna-tsc-20300302@zoom.us",
+        "title": "DNA TSC weekly",
+        "group": "dna-tsc",
+        "participants": ["amelia@dna.test", "priya@dna.test"],
+    }
+
+
+def test_participants_exclude_us_case_insensitively_and_organizer_is_unchanged():
+    ics = (FIX / "invite-dna-tsc.eml").read_text().split("BEGIN:VCALENDAR", 1)[1]
+    ev = parse_ics("BEGIN:VCALENDAR" + ics, "VeXa@OeNB.at")
+    assert SELF not in ev["participants"] and ev["participants"] == ["amelia@dna.test",
+                                                                    "priya@dna.test"]
+    assert ev["organizer"] == "organizer@dna.test"        # exactly as before this change
+
+
+def test_meet_invites_still_parse_and_now_carry_participants():
+    meet = ("BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:u-1\nDTSTART:20300302T140000Z\n"
+            "ORGANIZER:mailto:anna@bank.com\nATTENDEE:mailto:ben@bank.com\n"
+            "ATTENDEE:mailto:vexa@oenb.at\nSUMMARY:Pilot sync\n"
+            "LOCATION:https://meet.google.com/jrn-qwko-mqp\nEND:VEVENT\nEND:VCALENDAR\n")
+    ev = parse_ics(meet, SELF)
+    assert ev["url"] == "https://meet.google.com/jrn-qwko-mqp"
+    assert ev["participants"] == ["ben@bank.com"]
+    assert ev["group"] is None and ev["title"] == "Pilot sync"
+
+
+# ---------------------------------------------------------------------------------------------
+# 2 · the reply
+# ---------------------------------------------------------------------------------------------
+def test_reply_routes_by_thread_not_by_sender():
+    db, reg, clock, inbox = rig()
+    drive(db, reg, clock, inbox, BEFORE_ALL)
+
+    r = refs_of(db, "mail.reply")[0]
+    assert r["uid"] == "7" and r["session"] == "main", "the thread row decides, never the sender"
+    assert r["from_addr"] == "amelia@dna.test"
+    assert r["orig_msgid"] == "<reply-amelia-1@dna.test>"
+    assert r["text"].strip() == "Point 3 is wrong - the vote was deferred, not carried."
+    assert ">" not in r["text"], "quoted history is stripped"
+
+
+def test_mail_addressed_to_another_tenant_is_never_fetched():
+    db, reg, clock, inbox = rig()
+    _, out = drive(db, reg, clock, inbox, BEFORE_ALL)
+    assert all(m.frm != "someone@rehearsal.test" for m, _ in out)
+    assert "2StrangerYYYYYYYYYYYYY" not in {r[0] for r in db.execute(
+        "SELECT ext_id FROM mail_seen")}
+
+
+# ---------------------------------------------------------------------------------------------
+# 3 · the cursor
+# ---------------------------------------------------------------------------------------------
+def test_cursor_never_re_admits_across_a_restart():
+    db, reg, clock, inbox = rig()
+    cursor, out = drive(db, reg, clock, inbox, BEFORE_ALL)
+    assert len(out) == 2
+    before = db.execute("SELECT COUNT(*) FROM reaction")[0][0]
+
+    # the process dies. A NEW inbox object (empty in-memory seen set) on the SAME database, with
+    # a re-scan window wide enough that the watermark alone cannot suppress anything: only the
+    # persisted seen set can, which is the property under test.
+    restarted = MailpitInbox(base_url="http://recorded", addr=SELF, opener=recorded_mailpit,
+                             lookback_s=86_400.0)
+    resumed = restarted.restore(db)
+    assert resumed == cursor, "the position survived the restart"
+    assert iso_epoch(resumed) > iso_epoch(BEFORE_ALL)
+
+    cursor2, out2 = drive(db, reg, clock, restarted, resumed)
+    assert out2 == [], "a restart re-admitted mail it had already routed"
+    assert db.execute("SELECT COUNT(*) FROM reaction")[0][0] == before
+
+
+def test_first_boot_anchors_at_the_tail_and_never_replays_history():
+    db, reg, clock = SqliteDB(), FakeClock(), Registry()
+    inbox = MailpitInbox(base_url="http://recorded", addr=SELF, opener=recorded_mailpit)
+    assert inbox.restore(db) is None
+    tail = inbox.tail_cursor()
+    assert tail == iso_norm("2026-09-01T21:20:11.5Z"), "the newest message IS the tail"
+    inbox.anchor(db, tail)
+    assert list(inbox.fetch(tail)) == [], "the double's whole rehearsal history was replayed"
+
+
+def test_go_trimmed_fractions_order_correctly():
+    # `.5Z` sorts AFTER `.503Z` as a string and BEFORE it in time — mailpit emits both shapes,
+    # so every comparison goes through epochs and every stored watermark is fixed width.
+    assert "2026-09-01T21:14:02.5Z" > "2026-09-01T21:14:02.503Z"
+    assert iso_epoch("2026-09-01T21:14:02.5Z") < iso_epoch("2026-09-01T21:14:02.503Z")
+    assert iso_norm("2026-09-01T21:14:02.5Z") < iso_norm("2026-09-01T21:14:02.503Z")
+    assert iso_norm("2026-09-01T21:14:02Z") == "2026-09-01T21:14:02.000000Z"
+    assert iso_epoch("2026-09-01T23:14:02+02:00") == iso_epoch("2026-09-01T21:14:02Z")
+
+
+# ---------------------------------------------------------------------------------------------
+# 4 · the IMAP path
+# ---------------------------------------------------------------------------------------------
+def test_the_two_sources_yield_identical_facts_from_identical_bytes():
+    raw = (FIX / "invite-dna-tsc.eml").read_bytes()
+    as_imap = from_rfc822(raw, cursor="4711", ext_id="4711")        # an IMAP UID
+    as_mailpit = from_rfc822(raw, cursor=iso_norm("2026-09-01T21:14:02.503Z"),
+                             ext_id="1InviteDnaTscZZZZZZZZZ")
+    for f in ("message_id", "frm", "subject", "headers", "body", "ics"):
+        assert getattr(as_imap, f) == getattr(as_mailpit, f), f
+    assert parse_ics(as_imap.ics, SELF) == parse_ics(as_mailpit.ics, SELF)
+
+
+def test_imap_stays_the_default_and_still_points_at_gmail(monkeypatch):
+    monkeypatch.delenv("VEXA_MAIL_INBOX", raising=False)
+    box = get_inbox()
+    assert isinstance(box, ImapInbox) and box.name == "imap"
+    assert box.host == "imap.gmail.com" and box.folder == "INBOX"
+
+    monkeypatch.setenv("VEXA_MAIL_INBOX", "mailpit")
+    monkeypatch.setenv("VEXA_MAIL_ADDR", SELF)
+    monkeypatch.setenv("VEXA_MAILPIT_URL", "http://127.0.0.1:8025")
+    assert get_inbox().name == "mailpit"
+
+    monkeypatch.setenv("VEXA_MAIL_INBOX", "pigeon")
+    try:
+        get_inbox()
+        raise AssertionError("an unknown inbox name must fail loudly at boot")
+    except ValueError:
+        pass
+
+
+def test_imap_cursor_row_is_the_integer_it_always_was():
+    db = SqliteDB()
+    box = ImapInbox()
+    assert box.restore(db) is None
+    box.anchor(db, "4711")
+    assert box.restore(db) == "4711"
+    box.commit(db, from_rfc822((FIX / "reply-minutes.eml").read_bytes(),
+                               cursor="4712", ext_id="4712"))
+    assert db.execute("SELECT uid, token FROM mail_cursor WHERE id = 1")[0] == (4712, None)
+    assert db.execute("SELECT COUNT(*) FROM mail_seen")[0][0] == 0, "IMAP writes no seen rows"

--- a/deploy/dogfood/rig/flows-up.sh
+++ b/deploy/dogfood/rig/flows-up.sh
@@ -20,6 +20,14 @@ export VEXA_MAIL_SMTP_HOST=127.0.0.1
 export VEXA_MAIL_SMTP_PORT=1025
 export VEXA_MAIL_SMTP_MODE=plain
 
+# ...and its INBOUND half. Mailpit speaks no IMAP and no POP3, so the mailbox poller reads its
+# REST API instead: VEXA_MAIL_INBOX selects the source, VEXA_MAIL_ADDR (above) is the recipient
+# it answers as, and no mail password is needed on this path at all.
+#   imap (default) -> imap.gmail.com, unchanged   |   mailpit -> the double
+export VEXA_MAIL_INBOX=mailpit
+export VEXA_MAILPIT_URL=http://127.0.0.1:8025
+export VEXA_MAILPIT_LOOKBACK_S=300         # re-scan window behind the Created watermark
+
 PY="$FL/.venv/bin/python"
 
 pkill -f 'flows_integrations.flows_api' 2>/dev/null
@@ -33,6 +41,12 @@ echo "flows-api pid=$!"
 
 nohup "$PY" -m flows_worker > "$LOG/flows-worker.log" 2>&1 &
 echo "flows-worker pid=$!"
+
+# The inbound poller is NOT started here: it ADMITS FACTS, so it goes up deliberately, once the
+# rehearsal actually wants the box read. Start it by hand with the env this script exported:
+#   cd "$FL/src" && nohup "$PY" -m flows_integrations.mailbox > "$LOG/flows-mailbox.log" 2>&1 &
+# First boot anchors at the CURRENT tail, so the double's rehearsal history is never replayed;
+# pass an ISO timestamp as argv[1] to rewind deliberately.
 
 sleep 5
 echo "--- flows-api:"


### PR DESCRIPTION
## What

The dev stack's mail double is **mailpit** — REST API only, no IMAP and no POP3 — while
`core/flows/src/flows_integrations/mailbox.py` was hardcoded to `imap.gmail.com`. Nothing on the
rig could **receive** an invite or a reply, so both had to be injected as facts and the invite
leg of the rehearsal was never exercised end to end. This adds a second inbox source behind a
seam, and teaches the ICS parser the two things the DNA corpus needs.

| | |
|---|---|
| `core/flows/src/flows_integrations/inbox.py` (new, 344 lines) | The source seam: `InboundMessage`, the shared `from_rfc822()` parse, `ImapInbox`, `MailpitInbox`, `get_inbox()`. Contracts (durable cursor · threading · ICS attachments · no sleeping) documented at the top. |
| `mailbox.py:1-22` | Docstring names the env. |
| `mailbox.py:38-49` | `MEET_URL` / `ZOOM_URL` and RFC 5545 line unfolding. |
| `mailbox.py:52-105` | `parse_ics(ics, self_addr=None)` — adds `refs["participants"]`, accepts Zoom. |
| `mailbox.py:120` | `route()` passes `self_addr` into `parse_ics`. |
| `mailbox.py:146-168` | `handle()` — one message → at most one admission, every outside reach injected. |
| `mailbox.py:171-211` | `main()` polls `get_inbox()` instead of imaplib inline. |
| `src/flows_schema/models.py:84-112` | `mail_cursor.token` (nullable TEXT) + new `mail_seen` table; `schema.sql` regenerated by `scripts/gen_schema.py` (the drift gate passes). |
| `tests/test_inbound_double.py`, `tests/mailpit/` | 11 tests off recorded mailpit-1.30.7 fixtures. |
| `deploy/dogfood/rig/flows-up.sh` | The env, and the start line — commented, not started. |

**Facts are identical across sources.** Both fetch the raw RFC822 source and go through one
parse function; `test_the_two_sources_yield_identical_facts_from_identical_bytes` pins it.

**The cursor.** IMAP UIDs are monotonic, so one integer is a complete position. Mailpit ids are
random base62 (`6bdn12ZorjbbiXdRJuW3xR`) with no order in them, so the position is a `Created`
watermark (`mail_cursor.token`) **plus** a persisted seen-id set (`mail_seen`), re-scanned over a
small window (`VEXA_MAILPIT_LOOKBACK_S`, default 300s). First boot anchors at the current tail
*and* marks what is already in the box as seen — the double's whole rehearsal history is never
replayed — while an operator-supplied earlier cursor (`argv[1]`) still admits everything after
it. Mailpit renders `Created` as Go's RFC3339Nano, which **trims trailing zeros** (`.5Z` next to
`.503Z`), so string comparison orders them wrongly: every comparison goes through epochs and
every stored watermark is fixed width. That trap is in the fixtures and pinned by a test.

**Migration.** `schema.sql` is `CREATE TABLE IF NOT EXISTS` with no migration runner, so
`mail_seen` appears on its own for any database `postgres_db()` opens, and the one added column
is handled by an idempotent `ALTER TABLE mail_cursor ADD COLUMN token TEXT` run **only on the
mailpit path** (`MailpitInbox.ensure_schema`). An IMAP deployment is never touched.

**`parse_ics` additions.** `refs["participants"]` = every `ATTENDEE…mailto:` except our own
address (case-insensitive) — the thing `core/flows/witness/run_real.py:40-46` already parsed by
hand, and PRD §16.2 item 1. `organizer` and every other ref are byte-for-byte what they were, so
**no consumer of refs changes**. Zoom URLs are accepted alongside Meet (the DNA fixtures are Zoom
meetings), and folded lines are unfolded first — a `?pwd=` link and a `CN`'d ATTENDEE both fold
in real invites.

## Related work — please read before merging

`#1318` (Exchange/M365 mail edge) adds `mail_transport.py`, a *send+receive* transport seam over
`gmail|imap|graph` on the `codex/1315-group-meeting-flow` base, and `#1319` adds a
`meeting_link.py` with Teams/Zoom link extraction. **This PR is on `minutes-mcp-viewer` and does
not contain either.** The overlap was deliberate-checked, not stumbled into:

* `mail_cursor.token` here is **the same nullable TEXT column with the same opaque-position
  semantics** as #1318's, so the schema converges rather than conflicting.
* `InboundMessage` mirrors #1318's field names, and `handle()` mirrors its signature, so folding
  `MailpitInbox` into `mail_transport.MailTransport` later is a rename, not a rewrite.
* Whoever merges second should keep one seam file. Mine is inbox-only and selected by
  `VEXA_MAIL_INBOX`; #1318's also sends and is selected by `VEXA_MAIL_TRANSPORT`.

## How to enable

```
VEXA_MAIL_INBOX=mailpit          # default `imap` — behaviour unchanged, imap.gmail.com
VEXA_MAILPIT_URL=http://127.0.0.1:8025
VEXA_MAIL_ADDR=vexa@oenb.at      # the recipient this inbox answers as; mailpit accepts every
                                 # address, so without the filter it answers other tenants' mail
VEXA_MAILPIT_LOOKBACK_S=300      # re-scan window behind the watermark
```

No mail password is used on this path at all — `MailpitInbox` never calls `emailx.creds()`.

## The exact command to start the poller against mailpit

Not run by me — it admits facts into the live flows database, so it goes up deliberately.

```bash
ssh bbb
cd ~/dev/wt-inbound-double/core/flows/src
VEXA_MAIL_INBOX=mailpit \
VEXA_MAILPIT_URL=http://127.0.0.1:8025 \
VEXA_MAIL_ADDR=vexa@oenb.at \
VEXA_FLOWS_DB_URL="$(cat ~/.storm/dburl)" \
VEXA_FLOWS_GATEWAY_URL=http://localhost:18456 \
VEXA_FLOWS_AGENT_API_URL=http://localhost:18500 \
VEXA_FLOWS_ADMIN_API_URL=http://localhost:18457 \
VEXA_FLOWS_ADMIN_KEY="$(docker inspect vexa-dogfood-admin-api-1 \
  --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^ADMIN_API_TOKEN=' | cut -d= -f2)" \
PYTHONPATH=. nohup ../.venv/bin/python -m flows_integrations.mailbox \
  > /tmp/storm-logs/flows-mailbox.log 2>&1 &
```

First line of the log states the source and the position:
`mailbox integration up · inbox mailpit · cursor '2026-09-01T23:18:17.697000Z'`.
Append an ISO timestamp as `argv[1]` to rewind deliberately.

## Test results

`.venv/bin/python -m pytest tests -q` in `core/flows`, on bbb:

* **65 passed, 1 failed** — the failure is `tests/test_contract_smokes.py::test_admin_user_lookup_shapes`
  (`assert 403 == 404`), **pre-existing on the base commit** `544ceb17d` (baseline before any of
  my edits: 54 passed, same 1 failed). It is a live-stack smoke that wants a running admin-api
  with a matching key.
* 11 of the 65 are new. `make gates` equivalents also green: `node scripts/check-isolation.js` ✅,
  `tests/test_schema_drift.py` ✅ (schema.sql regenerated from the models, not hand-edited).
* Storms re-run against the changed parser: `test_storm` + `test_ics_storm` +
  `test_mail_routing_storm`, 10 passed (the ICS mutation fuzz covers the unfolding change).
* **These tests do not run in the repo's push gates** — the pre-push hook runs isolation and
  contract-conformance only, so `core/flows` regressions here are caught by whoever runs the
  suite, not by CI.

Also smoked **read-only** against the live mailpit on the rig (86 messages): anchor-at-tail
admits nothing, a deliberate rewind picks up exactly the 4 messages addressed to that recipient,
and a restart on the same database re-admits none. No process was started, stopped or restarted.

## Unsettled

* The recipient filter is exact-match on `VEXA_MAIL_ADDR`. A rehearsal that wants several vexa
  addresses in one mailpit needs a list; say so and it is one line.
* `ZOOM_URL` accepts `?pwd=` and nothing else after the meeting id. Teams links are #1319's.
* `refs["participants"]` is produced but nothing downstream consumes it yet — `spawn_onboardings`
  still works off the organizer. That is the next build item, not this one.
