### PR TITLE
adoption: the SPI adoption simulator, the attendee follow-up loop, and four defects it found

### DIFF
--- a/core/agent/control_plane/dispatch.py
+++ b/core/agent/control_plane/dispatch.py
@@ -31,6 +31,44 @@ from shared.units import chat_session, dispatch_id, input_topic, output_topic
 logger = logging.getLogger("agent_api.dispatch")
 
 
+def _ensure_workspace_exists(settings: Settings, subject: str) -> bool:
+    """Make sure this subject HAS a workspace directory before we ask the runtime to mount it.
+
+    The seeding seam is documented as lazy — "seeded on first turn" — but it can never run,
+    because the worker BIND-MOUNTS ``<root>/<subject>`` and the runtime refuses to start a
+    container whose bind source does not exist:
+
+        docker start vexa-worker-75-chat-meet-32 failed (404): cannot access path
+        /var/lib/docker/volumes/..._agent-workspaces/_data/75: no such file or directory
+
+    which surfaces to the caller as a bare ``500 Internal Server Error`` from ``/api/chat``.
+    In practice the directory only ever existed because the EMAIL ONBOARDING flow called
+    ``POST /api/workspace/init`` explicitly. Every path that reaches a chat WITHOUT going
+    through that flow therefore 500s on its very first turn — and the most important such path
+    is the one the growth loop is built on: an attendee who presses the button in a meeting
+    follow-up is a brand-new platform user, has never onboarded, and lands on an error.
+
+    Idempotent and fail-soft: an existing workspace is untouched, and a seeding failure logs
+    and lets the spawn proceed exactly as before rather than turning a degraded turn into no
+    turn at all.
+    """
+    try:
+        from pathlib import Path
+
+        from shared.seeding import resolve_seed_dir, seed_workspace
+        ws = Path(settings.workspaces_dir) / str(subject)
+        if (ws / ".git").exists():
+            return False
+        seed_workspace(ws, resolve_seed_dir(
+            getattr(settings, "default_template", None),
+            seeds_root=getattr(settings, "workspace_seeds_dir", None)))
+        logger.info("dispatch SEEDED workspace for subject=%s (first turn, never onboarded)", subject)
+        return True
+    except Exception:  # noqa: BLE001 — never let this be the reason a turn does not happen
+        logger.warning("workspace ensure failed for subject=%s — spawning anyway", subject, exc_info=True)
+        return False
+
+
 def build_active_set(settings: Settings, subject: str, memberships: Optional[list[dict]] = None) -> list[dict]:
     """The subject's NORMAL active workspaces (the MIDDLE tier of the stack — WP-A1.1/A2.1): one entry
     per ACTIVE workspace in the additive set. Each entry: ``{slug, path, role, write, primary}`` with
@@ -498,6 +536,8 @@ class Dispatcher:
         #     entrypoint (no double turn).
         # A watchdog then waits for the worker's turn-accepted ack and respawns once if the worker
         # exited in the XADD↔idle-exit race window without taking the message.
+        # The mount must exist before the runtime is asked to bind it (see the helper).
+        _ensure_workspace_exists(self._settings, identity["subject"])
         delivery = self._predeliver(uid, invocation) if invocation["trigger"] == "message" else None
         acked = self._runtime.spawn(uid, self._settings.agent_profile, env)
         if delivery is not None:

--- a/core/flows/eval/README.md
+++ b/core/flows/eval/README.md
@@ -1,0 +1,20 @@
+# `core/flows/eval` — how the flows product is measured
+
+Harnesses that score what the engine actually produces, against real mail, real notes and a
+real agent. They are evaluation code: nothing here runs in production, and nothing here is
+imported by a step.
+
+| | |
+|---|---|
+| [`adoption/`](adoption/README.md) | the **adoption simulator** — simulated days to full adoption of a generated org, paired with retention. The product is real; only the people are simulated. Runs in its own isolated flows lane so it can never reach a real recipient. |
+
+Planned neighbours (not yet here): `dna/` — the fixture replay + truth scorer for minutes
+quality, which scores what a meeting note SAYS rather than what the org DOES with it.
+
+Two rules hold for anything added under this directory:
+
+- **A touch the product does not send cannot be measured.** If a harness needs an artifact, the
+  artifact gets built in the product first — the simulator does not fabricate the thing it is
+  scoring.
+- **The number is relative between revolutions, never a forecast.** These harnesses exist to
+  rank changes against each other.

--- a/core/flows/eval/adoption/README.md
+++ b/core/flows/eval/adoption/README.md
@@ -1,0 +1,57 @@
+# `eval/adoption` — the adoption simulator
+
+The objective function of the self-improvement loop: **how many simulated DAYS until an org
+reaches full adoption, and does the adoption hold.** The product is real — a real flows engine,
+real mails, a real agent. Only the people are simulated.
+
+**Active** is the whole point and it is strict: in the trailing 14 days the person **opened** a
+Vexa mail **and** took a **UI action** — clicked into the terminal, sent a chat turn, replied to
+the mail, or put the mailbox on a meeting they own. Delivered mail counts for nothing; an open
+alone is *reached*, not active.
+
+## The two layers, and why
+
+    layer 1  SAMPLE      real identities -> real flows -> real mail text -> one Haiku call per
+             (sample.py) touch. A touch the product does not send cannot be sampled, which is
+                         why the attendee follow-up had to be BUILT before it could be measured.
+    layer 2  EXTRAPOLATE the whole meeting graph walked daily on those measured rates.
+             (sim.py)
+
+Nothing in `personas.py` asserts a propensity: the numbers are measured from the answers, or the
+simulator would only recite its own priors.
+
+## Files
+
+| | |
+|---|---|
+| `org.py` | the org generator — people, units, and the **meeting graph**. Profiles: `spi` (Sony Pictures Imageworks; dailies are the dominant recurring meeting) and `bank`. Size, structure and cadence are parameters. |
+| `personas.py` | the seven personas, the role/department skews, and the answer schema |
+| `judge.py` | one Haiku call per touch, and the persona side of the agent conversation |
+| `sample.py` | harvest real mail → judge → `rates.json`; and the real 3-turn chat with the deployed agent |
+| `sim.py` | the daily dynamics: adoption curve, T_full, retention 30/90, steady state, churn reasons |
+| `simlane.py` | the door into the sim's own flows lane |
+| `probe*.py` | the evidence probes; `probe3` is the before, `probe4` the after |
+
+## The sim lane — why there are two flows engines
+
+The founder's hot lane (`:18200`, database `flows`) admits **real** invites from a **real**
+inbox. Turning attendee fan-out on there could mail real people. So the simulator runs its own
+worker + api (`:18201`, database `flows_sim`) from this worktree, with the mailbox integration
+deliberately never started, and an allow-list of three test domains. Start it with
+`~/.storm/sim-flows-up.sh`. It shares agent-api, gateway, admin-api and mailpit — all of which
+are per-identity safe. It never deletes a mailpit message.
+
+## Running
+
+    ~/.storm/sim-flows-up.sh                 # the isolated lane
+    python3 probe4.py shared                 # end-to-end: does an attendee get anything?
+    python3 sample.py                        # -> $SIM_RUN_DIR/rates.json
+    python3 sim.py rates.json spi 2000,20000,200000
+
+## What this does NOT model
+
+Calendar reality (holidays, timezones, meetings people skip), the terminal's own UI beyond the
+click, IT provisioning and the tenant admitting the bot, anyone talking to anyone out loud, and
+transcription quality. Quality enters only through what the mails actually say.
+
+**The number is relative between revolutions. It is never a forecast.**

--- a/core/flows/eval/adoption/REVOLUTION-1.md
+++ b/core/flows/eval/adoption/REVOLUTION-1.md
@@ -1,0 +1,132 @@
+# Adoption simulator — revolution 1
+
+**Run:** `/home/dima/sim-runs/r1` · **Branch:** `adoption-sim` · **Base:** `544ceb17d` · **Issue:** [biz#449](https://github.com/DmitriyG228/biz/issues/449)
+
+**Agent under test:** Haiku on both sides — the simulated persona, and the deployed product agent where it was exercised.
+
+> **The number is relative between revolutions. It is never a forecast.** It exists to rank changes against each other, and it is only as good as the rates measured beneath it. Read every absolute figure as *this lever, against this null, on this org shape*.
+
+## 0. Real vs simulated
+
+| | real | simulated |
+|---|---|---|
+| flows engine, steps, retries, mail delivery | the deployed engine on `bbb` | |
+| the mail text every decision was made on | verbatim out of mailpit | |
+| the note and the per-attendee blocks | one real agent turn per meeting | |
+| the chat after a click | the deployed agent over agent-api | |
+| the people, personas and decisions | | Haiku, one call per touch |
+| the org, its meeting graph, the calendar | | generated, SPI-shaped |
+
+**Active** is strict, per the founder's tightening: in the trailing 14 days the person **opened** a Vexa mail **and** took a **UI action** — clicked into the terminal, sent a chat turn, replied to the mail, or put the mailbox on a meeting they own. Delivered mail scores zero; an open alone is *reached*, not active.
+
+## 1. The org — SPI, native to the fixtures
+
+Working size **2,000** (founder's number). *Assumption stated:* public reporting puts SPI at ~700 **production** staff at peak and Twenty's 5,000 is the Sony Pictures umbrella — the size is a parameter, not a headcount claim.
+
+- 2,000 people · 131 units · 933 meeting series · 822 occurrences/week · 5.28 meetings per person per week
+- reachable at all (in any non-external meeting): **2,000**
+- dominant recurring meeting by volume: `one_on_one` 354/wk, `dailies` 300/wk, `team_weekly` 61/wk, `dev_checkin` 60/wk
+
+Persona mix (assigned, not asserted): `artist` 70% · `pipeline_engineer` 12% · `coordinator_under_pressure` 5% · `control_wary` 4% · `production_manager` 4% · `supervisor` 4% · `overloaded_exec` 1%
+
+## 2. What the personas actually did with the REAL mails
+
+Touch kinds harvested from mailpit: `attendee_personal`, `attendee_shared`, `minutes`, `prepare`. 168 judged decisions; 0 judge errors.
+
+Mail sizes actually sent (this is the A/B, in bytes): `attendee_personal` 400 chars · `attendee_shared` 2742 chars · `minutes` 2805 chars · `prepare` 179 chars
+
+| persona | touch | opened | UI action \| opened | → active |
+|---|---|---|---|---|
+| `artist` | `attendee_personal` | 83% | 0% | **0%** |
+| `artist` | `attendee_shared` | 83% | 0% | **0%** |
+| `artist` | `minutes` | 83% | 0% | **0%** |
+| `artist` | `prepare` | 50% | 0% | **0%** |
+| `control_wary` | `attendee_personal` | 100% | 0% | **0%** |
+| `control_wary` | `attendee_shared` | 100% | 0% | **0%** |
+| `control_wary` | `minutes` | 67% | 0% | **0%** |
+| `control_wary` | `prepare` | 100% | 0% | **0%** |
+| `coordinator_under_pressure` | `attendee_personal` | 83% | 0% | **0%** |
+| `coordinator_under_pressure` | `attendee_shared` | 100% | 0% | **0%** |
+| `coordinator_under_pressure` | `minutes` | 83% | 0% | **0%** |
+| `coordinator_under_pressure` | `prepare` | 33% | 0% | **0%** |
+| `overloaded_exec` | `attendee_personal` | 67% | 0% | **0%** |
+| `overloaded_exec` | `attendee_shared` | 67% | 0% | **0%** |
+| `overloaded_exec` | `minutes` | 50% | 0% | **0%** |
+| `overloaded_exec` | `prepare` | 33% | 0% | **0%** |
+| `pipeline_engineer` | `attendee_personal` | 100% | 17% | **17%** |
+| `pipeline_engineer` | `attendee_shared` | 67% | 50% | **33%** |
+| `pipeline_engineer` | `minutes` | 100% | 33% | **33%** |
+| `pipeline_engineer` | `prepare` | 83% | 20% | **17%** |
+| `production_manager` | `attendee_personal` | 100% | 0% | **0%** |
+| `production_manager` | `attendee_shared` | 83% | 0% | **0%** |
+| `production_manager` | `minutes` | 50% | 0% | **0%** |
+| `production_manager` | `prepare` | 83% | 0% | **0%** |
+| `supervisor` | `attendee_personal` | 67% | 0% | **0%** |
+| `supervisor` | `attendee_shared` | 83% | 0% | **0%** |
+| `supervisor` | `minutes` | 67% | 0% | **0%** |
+| `supervisor` | `prepare` | 67% | 0% | **0%** |
+
+## 3. T_full, retention, and the lever
+
+`T_full` = the day the ACTIVE share crosses **80%** of the reachable population. Reported as `>N` when it never crosses inside the horizon — no org reaches everyone, and a threshold that is only approached asymptotically is not a measurement.
+
+| size | lever | T_full | peak active | steady state | retention 30 | retention 90 | invited mailbox |
+|---|---|---|---|---|---|---|---|
+| 2,000 | null — organizer only (the line today) | > 120 d | 0.1% | 0.1% | 33.3% | 33.3% | 3 |
+| 2,000 | A — one shared follow-up to every attendee | > 120 d | 1.2% | 1.1% | 92.6% | 92.6% | 9 |
+| 2,000 | B — per-person, same single agent turn | > 120 d | 1.4% | 1.2% | 84.9% | 89.7% | 11 |
+| 20,000 | null — organizer only (the line today) | > 120 d | 0.0% | 0.0% | 33.3% | 33.3% | 3 |
+| 20,000 | A — one shared follow-up to every attendee | > 120 d | 0.1% | 0.1% | 93.1% | 92.9% | 8 |
+| 20,000 | B — per-person, same single agent turn | > 120 d | 0.1% | 0.1% | 93.1% | 92.9% | 11 |
+| 200,000 | null — organizer only (the line today) | > 120 d | 0.0% | 0.0% | 33.3% | 33.3% | 3 |
+| 200,000 | A — one shared follow-up to every attendee | > 120 d | 0.0% | 0.0% | 93.1% | 93.1% | 7 |
+| 200,000 | B — per-person, same single agent turn | > 120 d | 0.0% | 0.0% | 93.1% | 89.3% | 10 |
+
+### H1 against the null
+
+> **H1** — the post-meeting follow-up to every attendee is the mechanism that spreads; without it adoption travels only through organizers. **Null** — the product spreads acceptably through organizers alone.
+
+At 2,000: the null peaks at **0.1%** active and settles at **0.1%**; variant A reaches **1.2%** / **1.1%**; variant B reaches **1.4%** / **1.2%**.
+
+### Churn — why people stopped
+
+- **null — organizer only (the line today)**: opened, nothing worth doing ×127
+- **A — one shared follow-up to every attendee**: opened, nothing worth doing ×1,995
+- **B — per-person, same single agent turn**: opened, nothing worth doing ×1,655, too many mails in a day ×24
+
+## 4. Two verbatim persona `why`s per touch type
+
+**`attendee_personal`**
+
+- *acted* — `pipeline_engineer` (fresh): “I try unfamiliar tools immediately to see if they're worth adopting, but I need to ask about data storage and API access before wiring this into our workflow.”  · friction: *No explanation of where meeting data is stored or whether it can be self-hosted*
+- *did not act* — `coordinator_under_pressure` (fresh): “I don't have time to click into tools I don't know or care about governance meetings — if this saved me an hour on notes, the email would say that.”  · friction: *Not clear how this relates to Show A dailies*
+
+**`attendee_shared`**
+
+- *acted* — `pipeline_engineer` (fresh): “Opened it to kick the tires on a new tool, clicked through to see the interface, but it's an ASWF meeting I'm not part of so nothing to act on.”  · friction: *not my meeting*
+- *did not act* — `coordinator_under_pressure` (fresh): “I opened it because the subject said 'dailies-notes', but it's a recording of an ASWF TSC meeting I'm not part of, and I have a review in ninety seconds.”  · friction: *Not about my show or my dailies reviews — this is about some foundation's technical committee meeting*
+
+**`minutes`**
+
+- *acted* — `pipeline_engineer` (fresh): “First message from Vexa so I poked at it to understand the tool, but realized this is ASWF governance stuff I'm not part of; tool format looks solid though.”  · friction: *not on this committee—meeting notes aren't actionable for me*
+- *did not act* — `coordinator_under_pressure` (fresh): “The subject mentioned dailies-notes so I opened it, but it's about a technical steering committee meeting, not my show's production work.”  · friction: *This is about ASWF technical governance, not show production.*
+
+**`prepare`**
+
+- *acted* — `pipeline_engineer` (fresh): “I immediately poke at new tools to understand data flow and APIs, but a dev environment URL and vague permissions made me ask one question about data storage, then close it.”  · friction: *dev.vexa.ai domain and unclear how it got calendar access*
+- *did not act* — `coordinator_under_pressure` (fresh): “I glanced at the subject and it's clearly not my meeting—this is platform infrastructure work and I don't have time to click into unknown tools for stuff outside my show.”  · friction: *Not about Show A or my dailies.*
+
+## 5. The interaction with the knowledge agent
+
+- conversations run against the REAL agent: **4**
+- opened by TELLING (the preset rule) rather than asking: **3/4**
+- reached value at all: **2/4**
+- actions the person asked for: ['change_setting']
+
+Abandonment, verbatim:
+- `coordinator_under_pressure`: “Nothing appeared in the chat—if a tool doesn't work on load, I don't have time to debug it.”
+- `artist`: “This is about committee governance and foundation stuff, not a word about my shots or dailies feedback.”
+
+## 6. What v0 does not model
+
+Calendar reality (holidays, timezones, meetings people skip); the terminal UI beyond the click; IT provisioning and the tenant admitting the bot; anybody telling a colleague out loud; transcription quality. Quality enters only through what the mails actually say. The organizer's invite is admitted as a direct fact rather than a parsed ICS — the inbound mailbox double landed on a sibling branch during this run and feeds the founder's lane, not the sim's. The fixture is a DNA/ASWF working session, not a dailies review: no dailies transcript exists yet, and the personas judge CONTENT, so this is the single biggest gap between this measurement and SPI's real pilot.

--- a/core/flows/eval/adoption/converse_run.py
+++ b/core/flows/eval/adoption/converse_run.py
@@ -1,0 +1,101 @@
+"""Phase 3 — what happens AFTER the click.
+
+The touch does not end at the click: the button opens a chat composed by the `?ask=` preset the
+link carries, and the person then talks to the REAL agent. Haiku on both sides — the persona is
+simulated, the agent is the product as deployed on this stack. Bounded at 3 persona turns.
+
+The attendee has no account until they click, by design (no session is created before anyone
+presses the button), so the identity is provisioned HERE, at click time, exactly as the magic
+link does it.
+
+Scored on what the preset rule actually promises: the opening must TELL from the workspace and
+then ask ONE question. Turns-to-value, asked actions, and abandonment reasons feed retention
+directly — a chat that gave nothing makes the next mail ignorable, by the persona's own history.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+
+import judge
+import sample
+
+RUN = os.environ.get("SIM_RUN_DIR", os.path.expanduser("~/sim-runs/r1"))
+ADMIN = os.environ.get("SIM_ADMIN_API", "http://127.0.0.1:18457")
+
+
+def admin_key() -> str:
+    import subprocess
+    out = subprocess.run(
+        ["docker", "inspect", "vexa-dogfood-admin-api-1", "--format",
+         "{{range .Config.Env}}{{println .}}{{end}}"], capture_output=True, text=True).stdout
+    for line in out.splitlines():
+        if line.startswith("ADMIN_API_TOKEN="):
+            return line.split("=", 1)[1].strip()
+    return ""
+
+
+def ensure_uid(email: str) -> str:
+    key = admin_key()
+    for method, url, body in (("GET", f"{ADMIN}/admin/users/email/{email}", None),
+                              ("POST", f"{ADMIN}/admin/users",
+                               {"email": email, "name": email.split("@")[0].title()})):
+        req = urllib.request.Request(
+            url, method=method,
+            data=json.dumps(body).encode() if body is not None else None)
+        req.add_header("content-type", "application/json")
+        req.add_header("X-Admin-API-Key", key)
+        try:
+            with urllib.request.urlopen(req, timeout=20) as r:
+                return str(json.load(r)["id"])
+        except Exception:  # noqa: BLE001
+            continue
+    return ""
+
+
+# The preset the minutes-review link composes. This is the OPENING the person meets; if the
+# product's real preset text changes, this changes with it — it is not our words.
+OPENING_PROMPT = (
+    "[minutes-review] The person just opened this chat from the follow-up email about meeting "
+    "{mid}. Open by TELLING them what this meeting holds for them from the workspace — not by "
+    "asking what they want. Then ask exactly ONE question.")
+
+
+def main():
+    cases = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else json.load(
+        open(f"{RUN}/converse-cases.json"))
+    out = []
+    for c in cases:
+        email, persona, mid = c["email"], c["persona"], c["meeting_id"]
+        uid = ensure_uid(email)
+        if not uid:
+            print(f"skip {email}: no uid")
+            continue
+        role, dept = sample.ROLE_FOR.get(persona, ("artist", "Show A"))
+        who = sample.FakePerson(persona, role, dept, c.get("name", "Sam Okafor"))
+        print(f"-> {persona:28s} {email}  uid={uid}", flush=True)
+        r = sample.converse(who, uid, f"meet-{mid}", OPENING_PROMPT.format(mid=mid))
+        r["email"], r["uid"], r["meeting_id"] = email, uid, mid
+        out.append(r)
+        json.dump(out, open(f"{RUN}/conversations.json", "w"), indent=1)
+
+    ok = [c for c in out if c["got_value"]]
+    told = [c for c in out if c["opened_by_telling"]]
+    print("\n=== INTERACTION ===")
+    print(f"conversations       : {len(out)}")
+    print(f"opened by TELLING   : {len(told)}/{len(out)}")
+    print(f"reached value       : {len(ok)}/{len(out)}")
+    if ok:
+        print("median turns to value:",
+              sorted(c["turns_to_value"] for c in ok)[len(ok) // 2])
+    print("asked actions       :",
+          [a for c in out for a in c["asked_actions"]] or "none")
+    for c in out:
+        if c["abandoned"] and c["abandon_why"]:
+            print(f"  abandoned ({c['persona']}): {c['abandon_why'][:150]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/core/flows/eval/adoption/judge.py
+++ b/core/flows/eval/adoption/judge.py
@@ -14,7 +14,6 @@ import json
 import os
 import re
 import subprocess
-import tempfile
 from concurrent.futures import ThreadPoolExecutor
 
 import personas
@@ -36,23 +35,32 @@ def ensure_cfg() -> None:
         f.write("{}\n")
 
 
-def _ask(prompt: str, timeout=180) -> str:
+def _ask(prompt: str, timeout=240, tries=2) -> str:
+    """One Haiku answer.
+
+    The prompt is passed INLINE. It used to be written to a temp file and referenced as
+    `@/tmp/<file>` — Claude Code's file-reference syntax — from a working directory that does
+    not contain that path, so the reference could not resolve and 38% of calls came back empty.
+    Empty answers were then dropped from the aggregate, which is the worst possible handling:
+    the rates looked clean and were built on 62% of the sample, with no way to see it."""
     env = dict(os.environ, CLAUDE_CONFIG_DIR=CFG)
-    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
-        f.write(prompt)
-        path = f.name
-    try:
-        p = subprocess.run(
-            ["claude", "-p", f"@{path}", "--model", MODEL, "--output-format", "json"],
-            cwd=CWD, env=env, capture_output=True, text=True, timeout=timeout)
+    for attempt in range(tries):
         try:
-            return json.loads(p.stdout).get("result", "") or ""
-        except Exception:  # noqa: BLE001
-            return p.stdout[:2000]
-    except subprocess.TimeoutExpired:
-        return ""
-    finally:
-        os.unlink(path)
+            r = subprocess.run(
+                ["claude", "-p", prompt, "--model", MODEL, "--output-format", "json"],
+                cwd=CWD, env=env, capture_output=True, text=True, timeout=timeout)
+            try:
+                out = json.loads(r.stdout)
+                if out.get("is_error"):
+                    continue
+                txt = out.get("result", "") or ""
+            except Exception:  # noqa: BLE001
+                txt = r.stdout[:4000]
+            if txt.strip():
+                return txt
+        except subprocess.TimeoutExpired:
+            continue
+    return ""
 
 
 def _json_out(text: str) -> dict | None:

--- a/core/flows/eval/adoption/judge.py
+++ b/core/flows/eval/adoption/judge.py
@@ -1,0 +1,212 @@
+"""The persona decision — one Haiku call per REAL touch, reading the actual mail the flows
+engine sent, that persona's brief, and its own history of what it did with earlier touches.
+
+Haiku everywhere (founder: "if you are able to get good results with Haiku, that means we get
+there"). The call is deliberately isolated from this host's own Claude configuration: bbb's
+`~/.claude/settings.json` carries a `Stop` hook that blocks the turn and demands a TLDR, which
+turned every judgment into the model agreeing to add a TLDR. CLAUDE_CONFIG_DIR points at a
+scratch config whose `.credentials.json` is a SYMLINK to the real one — nothing is copied, and
+the founder's configuration is not touched.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+
+import personas
+
+CFG = os.environ.get("SIM_CLAUDE_CFG", "/tmp/haiku-cfg")
+MODEL = os.environ.get("SIM_MODEL", "haiku")
+CWD = os.environ.get("SIM_CLAUDE_CWD", "/tmp/haiku-clean")
+
+
+def ensure_cfg() -> None:
+    """Scratch config: no hooks, no project CLAUDE.md, credentials by symlink."""
+    os.makedirs(CWD, exist_ok=True)
+    if not os.path.isdir(CFG):
+        os.makedirs(CFG, mode=0o700, exist_ok=True)
+    link = os.path.join(CFG, ".credentials.json")
+    if not os.path.exists(link):
+        os.symlink(os.path.expanduser("~/.claude/.credentials.json"), link)
+    with open(os.path.join(CFG, "settings.json"), "w") as f:
+        f.write("{}\n")
+
+
+def _ask(prompt: str, timeout=180) -> str:
+    env = dict(os.environ, CLAUDE_CONFIG_DIR=CFG)
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+        f.write(prompt)
+        path = f.name
+    try:
+        p = subprocess.run(
+            ["claude", "-p", f"@{path}", "--model", MODEL, "--output-format", "json"],
+            cwd=CWD, env=env, capture_output=True, text=True, timeout=timeout)
+        try:
+            return json.loads(p.stdout).get("result", "") or ""
+        except Exception:  # noqa: BLE001
+            return p.stdout[:2000]
+    except subprocess.TimeoutExpired:
+        return ""
+    finally:
+        os.unlink(path)
+
+
+def _json_out(text: str) -> dict | None:
+    """First balanced JSON object in the answer — robust to a fence or a stray sentence."""
+    if not text:
+        return None
+    t = re.sub(r"^```(?:json)?|```$", "", text.strip(), flags=re.M).strip()
+    depth, start = 0, None
+    for i, c in enumerate(t):
+        if c == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0 and start is not None:
+                try:
+                    return json.loads(t[start:i + 1])
+                except Exception:  # noqa: BLE001
+                    start = None
+    return None
+
+
+HIST_LINE = "day {day}: {kind} — you {outcome}{because}"
+
+
+def _history_block(history: list) -> str:
+    if not history:
+        return "This is the first thing you have ever received from this tool."
+    out = []
+    for h in history[-8:]:
+        because = f" ({h['why']})" if h.get("why") else ""
+        out.append(HIST_LINE.format(day=h.get("day", "?"), kind=h.get("kind", "a message"),
+                                    outcome=h.get("outcome", "ignored"), because=because))
+    return "\n".join(out)
+
+
+PROMPT = """You are simulating one person's reaction to one email, honestly and in character.
+
+WHO YOU ARE
+{brief}
+
+Your role at the studio: {role}, in {dept}. Your name is {name}.
+
+WHAT HAS ALREADY HAPPENED TO YOU
+{history}
+
+Today you also received {load} other automated emails.
+
+THE EMAIL THAT JUST ARRIVED (verbatim — this is the real text the product sent)
+Subject: {subject}
+---
+{text}
+---
+{linknote}
+
+DECIDE
+Answer as yourself. Opening an email is NOT using something — be strict about the difference
+between glancing at a message and actually doing something with it. If the last few things this
+tool sent you were useless, say so and ignore this one; people stop opening things that waste
+their time. If it is genuinely about your work, act.
+
+Return ONLY a JSON object, no prose and no code fence, with exactly these keys:
+{schema}
+"""
+
+
+def decide(person, touch: dict, history: list, day: int = 0, load: int = 0) -> dict:
+    brief = personas.PERSONAS[person.persona][1]
+    linknote = ("There is a link in it that opens a Vexa chat about this meeting."
+                if touch.get("links") else "There is no link in it.")
+    prompt = PROMPT.format(
+        brief=brief, role=person.role.replace("_", " "), dept=person.dept, name=person.name,
+        history=_history_block(history), load=load,
+        subject=touch.get("subject", ""), text=(touch.get("text") or "")[:4000],
+        linknote=linknote,
+        schema=json.dumps(personas.SCHEMA, indent=1))
+    out = _json_out(_ask(prompt))
+    if not out:
+        return {"opened": False, "outcome": "ignored", "why": "(judge produced no answer)",
+                "friction": "judge-error", "_error": True}
+    for k in ("opened", "clicked", "chat_turn", "replied", "completed_setup",
+              "invited_own_meeting", "forwarded"):
+        out[k] = bool(out.get(k))
+    if not out["opened"]:                       # an unopened mail cannot have been acted on
+        for k in ("clicked", "chat_turn", "replied", "completed_setup",
+                  "invited_own_meeting", "forwarded"):
+            out[k] = False
+    out["active_action"] = any(out.get(k) for k in personas.UI_ACTIONS)
+    out["outcome"] = out.get("outcome") if out.get("outcome") in (
+        "acted", "hesitated", "ignored") else ("acted" if out["active_action"] else "ignored")
+    return out
+
+
+def decide_many(jobs: list, workers: int = 8) -> list:
+    """jobs = [(person, touch, history, day, load)] -> answers in the same order."""
+    ensure_cfg()
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        return list(ex.map(lambda j: decide(*j), jobs))
+
+
+# ── the conversation with the REAL agent, once a persona clicked ─────────────────────────────
+CONV_SCHEMA = {
+    "got_value": "bool — did that answer actually give you something you did not have",
+    "asked_more": "bool — are you going to ask it another thing",
+    "corrected": "bool — did it get something wrong that you are correcting",
+    "asked_action": "invite_mailbox | set_up_group | change_setting | none",
+    "abandoned": "bool — are you closing the tab now",
+    "say": "str — what you type next, in your own words (empty if you are closing the tab)",
+    "why": "str — one sentence, first person",
+}
+
+CONV_OPEN = """You just clicked the link in that email and a chat opened. You are {name}, {role}
+in {dept}.
+
+{brief}
+
+You have about {seconds} seconds of patience for this.
+
+THE CHAT OPENED WITH THIS (verbatim, from the product):
+---
+{opening}
+---
+
+Type your first message to it, or close the tab. Return ONLY a JSON object with exactly these
+keys: {schema}"""
+
+CONV_TURN = """You are {name}, {role} in {dept}, in the middle of a chat you opened from an
+email.
+
+{brief}
+
+WHAT YOU SAID: {said}
+WHAT IT ANSWERED (verbatim):
+---
+{answer}
+---
+
+Return ONLY a JSON object with exactly these keys: {schema}"""
+
+
+def conv_open(person, opening: str, seconds: int = 60) -> dict:
+    out = _json_out(_ask(CONV_OPEN.format(
+        name=person.name, role=person.role.replace("_", " "), dept=person.dept,
+        brief=personas.PERSONAS[person.persona][1], seconds=seconds,
+        opening=(opening or "")[:3000], schema=json.dumps(CONV_SCHEMA, indent=1))))
+    return out or {"abandoned": True, "say": "", "why": "(judge produced no answer)",
+                   "got_value": False, "asked_action": "none"}
+
+
+def conv_turn(person, said: str, answer: str) -> dict:
+    out = _json_out(_ask(CONV_TURN.format(
+        name=person.name, role=person.role.replace("_", " "), dept=person.dept,
+        brief=personas.PERSONAS[person.persona][1], said=(said or "")[:600],
+        answer=(answer or "")[:3000], schema=json.dumps(CONV_SCHEMA, indent=1))))
+    return out or {"abandoned": True, "say": "", "why": "(judge produced no answer)",
+                   "got_value": False, "asked_action": "none"}

--- a/core/flows/eval/adoption/org.py
+++ b/core/flows/eval/adoption/org.py
@@ -1,0 +1,427 @@
+"""The org generator — people, units, and the MEETING GRAPH they live in.
+
+The atom of intra-company growth is a calendar invite, not a signup (PRD §16): one person
+invites the mailbox, every attendee is exposed. So the object this file builds is not an org
+chart, it is the *graph of who sits in a room with whom, how often, and who owns the invite*.
+Everything the simulator does afterwards walks that graph.
+
+Generic in size, structure and cadence; a PROFILE supplies all three. Two profiles ship:
+
+  spi   Sony Pictures Imageworks — the target org (founder 2026-09-02: "take SPI as a target
+        … as insiders to DNA, as research target, to be native to the fixtures"). Working size
+        1,300. NOTE THE ASSUMPTION: public reporting puts SPI at ~700 *production* staff at
+        peak; Twenty's 5,000 is the Sony Pictures umbrella. 1,300 is the founder's working
+        number and is used as given — it is not a headcount claim.
+  bank  a 1,300-person central bank — the first profile written, kept as a second profile so
+        a lever's sign can be checked against a different meeting graph.
+
+Seeded: `build(...)` is a pure function of (profile, headcount, seed). Same inputs, same org.
+"""
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import asdict, dataclass, field
+
+HEADCOUNT = 1300
+
+
+@dataclass
+class Person:
+    pid: int
+    name: str
+    email: str
+    dept: str           # show or studio function
+    team: str
+    role: str           # the profile's own role vocabulary
+    persona: str = ""   # filled by personas.assign()
+
+
+@dataclass
+class Meeting:
+    mid: str
+    kind: str
+    title: str
+    organizer: int
+    attendees: list[int]
+    per_week: float          # occurrences per week (0.5 = fortnightly)
+    external: bool = False   # out-of-domain guests -> the domain allow-list never mails these
+
+
+@dataclass
+class Org:
+    people: list[Person]
+    meetings: list[Meeting]
+    teams: dict[str, list[int]] = field(default_factory=dict)
+    profile: str = ""
+
+    def organizes(self) -> dict[int, list[str]]:
+        d: dict[int, list[str]] = {p.pid: [] for p in self.people}
+        for m in self.meetings:
+            d[m.organizer].append(m.mid)
+        return d
+
+    def attends(self) -> dict[int, list[str]]:
+        d: dict[int, list[str]] = {p.pid: [] for p in self.people}
+        for m in self.meetings:
+            for a in m.attendees:
+                d[a].append(m.mid)
+        return d
+
+    def by_pid(self) -> dict[int, Person]:
+        return {p.pid: p for p in self.people}
+
+    def to_json(self) -> str:
+        return json.dumps({"profile": self.profile,
+                           "people": [asdict(p) for p in self.people],
+                           "meetings": [asdict(m) for m in self.meetings],
+                           "teams": self.teams}, indent=1)
+
+
+# ── names ────────────────────────────────────────────────────────────────────────────────────
+_FIRST = {
+    "spi": ["Cameron", "Priya", "Marcus", "Yuki", "Elena", "Tomas", "Aisha", "Dev", "Ruth",
+            "Kenji", "Sofia", "Andre", "Mei", "Liam", "Nadia", "Oscar", "Farah", "Jonas",
+            "Ravi", "Claire", "Ben", "Ingrid", "Hugo", "Talia", "Sam", "Noor", "Victor",
+            "Hana", "Diego", "Maya", "Leo", "Zara", "Owen", "Iris"],
+    "bank": ["Marvin", "Tobias", "Anna", "Lukas", "Sophie", "Felix", "Julia", "Stefan",
+             "Katrin", "Michael", "Elena", "Christoph", "Barbara", "Andreas", "Petra",
+             "Martin", "Claudia", "Thomas", "Sabine", "Georg", "Ines", "Peter", "Nina",
+             "Wolfgang", "Eva", "Johannes", "Marlene", "David", "Theresa", "Simon"],
+}
+_LAST = {
+    "spi": ["Tran", "Okafor", "Lindqvist", "Nakamura", "Rossi", "Duarte", "Khan", "Mehta",
+            "Bell", "Sato", "Alvarez", "Dubois", "Chen", "Murphy", "Haddad", "Novak",
+            "Iyer", "Beaulieu", "Kim", "Santos", "Wright", "Berg", "Moreau", "Levi",
+            "Park", "Costa", "Wallace", "Ito", "Silva", "Grant"],
+    "bank": ["Huber", "Gruber", "Wagner", "Muller", "Pichler", "Steiner", "Moser", "Mayer",
+             "Hofer", "Leitner", "Berger", "Fuchs", "Eder", "Fischer", "Schmid", "Winkler",
+             "Weber", "Schwarz", "Maier", "Schneider", "Reiter", "Mayr", "Wimmer", "Egger",
+             "Brunner", "Lang", "Auer", "Binder", "Lechner", "Wolf"],
+}
+
+
+def _names(rng: random.Random, n: int, pool: str) -> list[str]:
+    first, last = _FIRST[pool], _LAST[pool]
+    out, seen = [], set()
+    while len(out) < n:
+        nm = f"{rng.choice(first)} {rng.choice(last)}"
+        k, i = nm, 1
+        while k in seen:
+            i += 1
+            k = f"{nm} {i}"
+        seen.add(k)
+        out.append(k)
+    return out
+
+
+# ── SPI ──────────────────────────────────────────────────────────────────────────────────────
+# Grounded in the 2026-08-18 DNA dev check-in (Cottalango Leon, SPI): the pilot is "actual
+# coordinators and production managers using it as their main tool", 3-5 of them, one show
+# under NDA; dailies review "runs 30 min" and coordinators have "a couple of minutes to do
+# everything" before the next; the big reviews carry "hundreds of people" and run "to three
+# hours". The DNA product is the *Dailies Notes Assistant* — so DAILIES is the dominant
+# recurring meeting, per show, per department, daily.
+SPI_DEPTS = ["Layout", "Animation", "Lighting", "FX", "Compositing", "Character/Modeling"]
+SPI_SHOW_MIX = 0.78        # share of headcount on shows; the rest is studio function
+SPI_STUDIO = [             # name, weight, kind
+    ("Pipeline & Engineering", 34, "eng"),
+    ("Production Management", 16, "prodman"),
+    ("Studio Technology", 12, "eng"),
+    ("Editorial", 10, "post"),
+    ("Studio Executive", 4, "exec"),
+    ("HR & Recruiting", 8, "staff"),
+    ("Finance & Legal", 8, "staff"),
+    ("IT & Facilities", 8, "staff"),
+]
+
+
+def _build_spi(rng, headcount, org_people, teams, add):
+    """Shows, each with coordinators / production managers / supervisors / department artists;
+    plus the studio functions. Returns dept_meta."""
+    n_show_people = round(headcount * SPI_SHOW_MIX)
+    n_shows = max(2, round(n_show_people / 160))     # ~160 crew per show at 1.3k -> 6 shows
+    show_names = [f"Show {chr(65+i)}" for i in range(n_shows)]
+    per_show = n_show_people // n_shows
+    pid = 0
+    dept_meta = {}
+
+    for sname in show_names:
+        dept_meta[sname] = ("show", False)
+        # the show's production office: managers + coordinators, the pilot users
+        office = []
+        n_pm = max(1, round(per_show * 0.02))
+        n_coord = max(2, round(per_show * 0.05))
+        for _ in range(n_pm):
+            org_people.append((pid, sname, f"{sname} / Production Office", "production_manager"))
+            office.append(pid); pid += 1
+        for _ in range(n_coord):
+            org_people.append((pid, sname, f"{sname} / Production Office", "coordinator"))
+            office.append(pid); pid += 1
+        teams[f"{sname} / Production Office"] = list(office)
+        managers = office[:n_pm]
+        coords = office[n_pm:]
+
+        # the departments on this show: a supervisor + artists
+        art_budget = per_show - len(office)
+        dept_units: dict[str, list[int]] = {}
+        for i, d in enumerate(SPI_DEPTS):
+            size = max(3, art_budget // len(SPI_DEPTS) + (1 if i < art_budget % len(SPI_DEPTS) else 0))
+            tname = f"{sname} / {d}"
+            members = []
+            org_people.append((pid, sname, tname, "supervisor"))
+            members.append(pid); pid += 1
+            for _ in range(size - 1):
+                org_people.append((pid, sname, tname, "artist"))
+                members.append(pid); pid += 1
+            teams[tname] = members
+            dept_units[d] = members
+        _SPI_SHOWS.append((sname, managers, coords, dept_units))
+
+    # studio functions
+    rest = headcount - pid
+    tw = sum(w for _, w, _ in SPI_STUDIO)
+    for fname, w, kind in SPI_STUDIO:
+        dept_meta[fname] = (kind, kind in ("exec", "staff"))
+        size = max(2, round(rest * w / tw))
+        remaining = size
+        t = 0
+        while remaining > 0:
+            tsize = min(remaining, rng.randint(5, 11))
+            if remaining - tsize in (1, 2, 3):
+                tsize = remaining
+            t += 1
+            tname = f"{fname} / Team {t}"
+            members = []
+            for i in range(tsize):
+                role = ("lead" if i == 0 else
+                        {"eng": "engineer", "prodman": "production_manager", "post": "artist",
+                         "exec": "exec", "staff": "staff"}[kind])
+                org_people.append((pid, fname, tname, role))
+                members.append(pid); pid += 1
+            teams[tname] = members
+            remaining -= tsize
+    return dept_meta
+
+
+_SPI_SHOWS: list = []
+
+
+def _spi_meetings(rng, org: "Org", add, teams):
+    """DAILIES first — daily, per show, per department. Then the production meeting, the
+    supervisor sync, 1:1s, the pipeline dev check-in, and the cross-studio TSC (external)."""
+    for sname, managers, coords, dept_units in _SPI_SHOWS:
+        office = teams[f"{sname} / Production Office"]
+        lead_pm = managers[0]
+        for i, (d, members) in enumerate(dept_units.items()):
+            # the coordinator running that department's dailies owns the invite
+            coord = coords[i % len(coords)]
+            sup = members[0]
+            add("dailies", f"{sname} {d} dailies", coord,
+                members + [coord, sup, lead_pm], 5.0)
+        # the show production meeting — office + every supervisor, weekly
+        sups = [m[0] for m in dept_units.values()]
+        add("production_meeting", f"{sname} production meeting", lead_pm,
+            office + sups, 1.0)
+        # the big review: "hundreds of people … to three hours" — fortnightly, whole show
+        whole = office + [p for ms in dept_units.values() for p in ms]
+        add("show_review", f"{sname} show review", lead_pm, whole, 0.5)
+        # 1:1s inside the production office
+        for c in coords:
+            add("one_on_one", f"1:1 {sname} production", lead_pm, [lead_pm, c], 0.5)
+        # supervisor 1:1s with their department
+        for d, members in dept_units.items():
+            sup = members[0]
+            for a in members[1:]:
+                if rng.random() < 0.45:
+                    add("one_on_one", f"1:1 {sname} {d}", sup, [sup, a], 0.5)
+
+    by_dept: dict[str, list[Person]] = {}
+    for p in org.people:
+        by_dept.setdefault(p.dept, []).append(p)
+
+    for fname, _w, kind in SPI_STUDIO:
+        members = by_dept.get(fname, [])
+        if not members:
+            continue
+        leads = [p.pid for p in members if p.role == "lead"] or [members[0].pid]
+        for tname, mem in [(t, m) for t, m in teams.items() if t.startswith(fname + " /")]:
+            add("team_weekly", f"{tname} weekly", mem[0], mem, 1.0)
+            if kind == "eng":
+                add("dev_checkin", f"{tname} dev check-in", mem[0], mem, 2.0)
+        if len(leads) > 1:
+            add("dept_leadership", f"{fname} leadership", leads[0], leads, 1.0)
+
+    execs = [p.pid for p in org.people if p.role == "exec"]
+    if len(execs) > 1:
+        add("exec_staff", "Studio leadership", execs[0], execs, 1.0)
+
+    # cross-show: pipeline engineers sit in show departments' meetings — how adoption escapes
+    eng = [p.pid for p in org.people
+           if p.role in ("engineer", "lead")
+           and ("Engineering" in p.dept or "Technology" in p.dept)]
+    shows_all = [m for m in org.meetings if m.kind in ("production_meeting", "dev_checkin")]
+    for m in shows_all:
+        if eng and rng.random() < 0.30:
+            m.attendees = sorted(set(m.attendees + rng.sample(eng, min(2, len(eng)))))
+
+    # the TSC / ASWF working groups — external by construction, never mailed by the product
+    pipeline = [p.pid for p in org.people if p.dept in ("Pipeline & Engineering",
+                                                        "Studio Technology")]
+    if pipeline:
+        for i in range(3):
+            host = rng.choice(pipeline)
+            add("tsc", f"ASWF working group {i+1}", host,
+                [host] + rng.sample(pipeline, min(4, len(pipeline))), 0.5, external=True)
+    # vendor / client reviews — also external
+    prod = [p.pid for p in org.people if p.role in ("production_manager", "exec")]
+    for i in range(max(1, round(len(prod) * 0.4))):
+        host = rng.choice(prod)
+        add("client_review", f"Client review {i+1}", host,
+            [host] + rng.sample(prod, min(3, len(prod))), 0.5, external=True)
+
+
+# ── bank (the second profile, unchanged in shape from the first worker's draft) ──────────────
+BANK_DEPTS = [
+    ("Retail Operations", 190, False, False), ("Payments", 140, True, True),
+    ("IT Infrastructure", 150, True, False), ("Data & Analytics", 90, True, False),
+    ("Risk Management", 130, False, False), ("Compliance", 110, False, True),
+    ("Treasury", 85, False, True), ("Internal Audit", 70, False, False),
+    ("Legal", 55, False, True), ("Human Resources", 75, False, True),
+    ("Corporate Banking", 120, False, True), ("Communications", 45, False, True),
+    ("Statistics", 40, False, False),
+]
+
+
+def _build_bank(rng, headcount, org_people, teams, add):
+    total_w = sum(d[1] for d in BANK_DEPTS)
+    dept_meta = {}
+    pid = 0
+    for dname, w, agile, external in BANK_DEPTS:
+        dept_meta[dname] = (agile, external)
+        size = round(headcount * w / total_w)
+        remaining, t = size, 0
+        while remaining > 0:
+            tsize = min(remaining, rng.randint(4, 12))
+            if remaining - tsize in (1, 2, 3):
+                tsize = remaining
+            t += 1
+            tname = f"{dname} / Team {t}"
+            members = []
+            for i in range(tsize):
+                role = "manager" if i == 0 else rng.choices(["ic", "assistant"],
+                                                            weights=[0.92, 0.08])[0]
+                org_people.append((pid, dname, tname, role))
+                members.append(pid); pid += 1
+            teams[tname] = members
+            remaining -= tsize
+    return dept_meta
+
+
+def _bank_meetings(rng, org, add, teams, dept_meta):
+    by_dept: dict[str, list[Person]] = {}
+    for p in org.people:
+        by_dept.setdefault(p.dept, []).append(p)
+    for tname, members in teams.items():
+        dname = tname.split(" / ")[0]
+        agile, _ = dept_meta[dname]
+        lead = members[0]
+        add("team_weekly", f"{tname} weekly", lead, members, 1.0)
+        if agile:
+            add("standup", f"{tname} standup", lead, members, 4.0)
+        for m in members[1:]:
+            add("one_on_one", f"1:1 {tname}", lead, [lead, m], 0.5)
+    for dname, members in by_dept.items():
+        leads = [p.pid for p in members if p.role in ("manager", "exec")]
+        if len(leads) > 1:
+            add("dept_leadership", f"{dname} leadership", leads[0], leads, 1.0)
+    execs = [p.pid for p in org.people if p.role == "exec"]
+    if len(execs) > 1:
+        add("exec_staff", "Board staff meeting", execs[0], execs, 1.0)
+    team_names = list(teams)
+    for i in range(round(len(org.people) / 9)):
+        picked = rng.sample(team_names, rng.randint(2, 4))
+        att: list[int] = []
+        for tn in picked:
+            att += rng.sample(teams[tn], min(len(teams[tn]), rng.randint(1, 3)))
+        if len(att) >= 3:
+            add("project", f"Project {i+1} sync", rng.choice(att), att, rng.choice([1.0, 1.0, 0.5]))
+    ext_pool = [p.pid for p in org.people if dept_meta[p.dept][1]]
+    for i in range(round(len(ext_pool) * 0.25)):
+        host = rng.choice(ext_pool)
+        peers = [p.pid for p in org.people if p.dept == org.by_pid()[host].dept]
+        add("external", f"External review {i+1}", host,
+            [host] + rng.sample(peers, min(3, len(peers))), 0.3, external=True)
+
+
+DOMAIN = {"spi": "imageworks.example", "bank": "bank.example"}
+
+
+def build(profile: str = "spi", headcount: int = HEADCOUNT, seed: int = 7) -> Org:
+    global _SPI_SHOWS
+    _SPI_SHOWS = []
+    rng = random.Random(seed)
+    raw: list[tuple] = []
+    teams: dict[str, list[int]] = {}
+    meetings: list[Meeting] = []
+    mid = [0]
+
+    def add(kind, title, organizer, attendees, per_week, external=False):
+        mid[0] += 1
+        meetings.append(Meeting(f"m{mid[0]}", kind, title, organizer,
+                                sorted(set(attendees)), per_week, external))
+
+    if profile == "spi":
+        dept_meta = _build_spi(rng, headcount, raw, teams, add)
+    elif profile == "bank":
+        dept_meta = _build_bank(rng, headcount, raw, teams, add)
+    else:
+        raise ValueError(f"unknown profile {profile!r}")
+
+    names = _names(rng, len(raw) + 5, profile)
+    dom = DOMAIN[profile]
+    people = [Person(pid, names[pid], f"p{pid}@{dom}", dept, team, role)
+              for pid, dept, team, role in raw]
+    org = Org(people, meetings, teams, profile)
+    if profile == "spi":
+        _spi_meetings(rng, org, add, teams)
+    else:
+        _bank_meetings(rng, org, add, teams, dept_meta)
+    org.meetings = meetings
+    return org
+
+
+def stats(org: Org) -> dict:
+    per_person = {p.pid: 0.0 for p in org.people}
+    for m in org.meetings:
+        for a in m.attendees:
+            per_person[a] = per_person.get(a, 0) + m.per_week
+    by_role: dict[str, list[float]] = {}
+    for p in org.people:
+        by_role.setdefault(p.role, []).append(per_person[p.pid])
+    by_kind: dict[str, float] = {}
+    for m in org.meetings:
+        by_kind[m.kind] = by_kind.get(m.kind, 0) + m.per_week
+    return {
+        "profile": org.profile,
+        "people": len(org.people),
+        "teams": len(org.teams),
+        "meeting_series": len(org.meetings),
+        "meetings_per_week_total": round(sum(m.per_week for m in org.meetings), 1),
+        "avg_meetings_per_person_per_week": round(sum(per_person.values()) / len(org.people), 2),
+        "seats_per_week": round(sum(m.per_week * len(m.attendees) for m in org.meetings), 0),
+        "by_role": {r: {"n": len(v), "avg_meetings_wk": round(sum(v) / len(v), 2)}
+                    for r, v in sorted(by_role.items())},
+        "by_kind_per_week": {k: round(v, 1) for k, v in sorted(by_kind.items(),
+                                                               key=lambda x: -x[1])},
+        "people_with_no_meetings": sum(1 for v in per_person.values() if v == 0),
+        "organizers": len({m.organizer for m in org.meetings}),
+        "external_series": sum(1 for m in org.meetings if m.external),
+    }
+
+
+if __name__ == "__main__":
+    import sys
+    prof = sys.argv[1] if len(sys.argv) > 1 else "spi"
+    hc = int(sys.argv[2]) if len(sys.argv) > 2 else HEADCOUNT
+    print(json.dumps(stats(build(prof, hc)), indent=1))

--- a/core/flows/eval/adoption/personas.py
+++ b/core/flows/eval/adoption/personas.py
@@ -1,0 +1,168 @@
+"""Adoption personas — the simulated humans. The product is real; these are not.
+
+A persona is a short brief handed to Haiku together with the ACTUAL text of a mail the flows
+engine sent, plus that persona's own history of recent touches and what it did with them. It
+answers one fixed schema. Nothing here encodes a propensity number: the numbers are MEASURED
+from the answers, not asserted here — otherwise the simulator would only recite its own priors.
+
+SPI grounding (2026-08-18 DNA dev check-in, Cottalango Leon):
+  · the pilot is "actual coordinators and production managers using it as their main tool"
+  · "the only feedback that we've gotten is just everyone just wants control … don't do AI,
+    don't do AI. And now it's like, no, do it, but make sure I can control every single aspect"
+  · dailies run 30 minutes and a coordinator has "a couple of minutes to do everything" before
+    the next one — the attention budget is the binding constraint, not goodwill.
+"""
+from __future__ import annotations
+
+import random
+
+# ── the answer schema ────────────────────────────────────────────────────────────────────────
+# ACTIVE (founder, 2026-09-02): "retention is active action — is not just 'emails from vexa
+# are coming', it's about emails opening and UI interaction." So `opened` is NOT activity.
+# A person is active on a day only if they opened AND did one of the UI actions below.
+UI_ACTIONS = ["clicked", "replied", "chat_turn", "invited_own_meeting"]
+
+SCHEMA = {
+    "opened": "bool — did you open it at all. Opening is NOT using it.",
+    "clicked": "bool — did you follow the link into the Vexa chat (false if there was no link)",
+    "chat_turn": "bool — once there, did you actually type something to it (false if you "
+                 "landed, glanced and left)",
+    "replied": "bool — did you reply to the email itself",
+    "completed_setup": "bool — did you finish whatever it asked you to finish",
+    "invited_own_meeting": "bool — did you, as a result, put Vexa on a meeting YOU own",
+    "forwarded": "bool — did you pass it to a colleague",
+    "outcome": "acted | hesitated | ignored",
+    "seconds": "int — seconds of your attention it got",
+    "friction": "str — the single thing that got in the way, or empty",
+    "why": "str — one sentence, first person, why you did that",
+}
+
+# name -> (share of headcount, brief)
+PERSONAS: dict[str, tuple[float, str]] = {
+    "coordinator_under_pressure": (0.14, (
+        "You are a production coordinator on a show. You run several dailies a day, each 30 "
+        "minutes, and you have about two minutes between them to send notes, update the "
+        "tracker and set up the next review. Notes ARE your job — if something writes them "
+        "correctly you get an hour of your life back every day, and you will fight for it. "
+        "If it writes them wrong you have to check every line, which is slower than typing "
+        "them yourself, and you will drop it that same day. You do not have time to read a "
+        "long email or to learn a tool on your own time.")),
+    "production_manager": (0.06, (
+        "You are a production manager. You are accountable for the show landing on schedule, "
+        "you sit across several departments, and you are judged on whether things were "
+        "communicated. You care about what was decided and who owns it, not about the "
+        "transcript. You will adopt something if it makes the show's status legible to you "
+        "without you chasing people. You are wary of anything that creates a second place to "
+        "look — you already have a tracker.")),
+    "artist": (0.55, (
+        "You are a department artist — animation, lighting, FX, comp or layout. You sit in "
+        "dailies where your shots are reviewed and you take notes on what to fix. You mostly "
+        "want to know exactly what was said about YOUR shot, and you resent sitting through "
+        "the rest. You are heads-down in your own software most of the day and you check "
+        "email between tasks. You will click something that is about your work and ignore "
+        "anything that is about a tool. You do not organise meetings.")),
+    "supervisor": (0.09, (
+        "You are a department supervisor. You give the notes in dailies and you carry the "
+        "creative call. You are in meetings most of the day. You are protective of how your "
+        "notes are represented — a summary that paraphrases your direction badly is worse "
+        "than no summary, because the artist will act on it. You will use something that "
+        "reproduces what you actually said, and you will publicly reject something that "
+        "garbles it.")),
+    "pipeline_engineer": (0.10, (
+        "You are a pipeline or studio-technology engineer. You have opinions about tools and "
+        "you try them before anyone asks. You immediately want to know where the data goes, "
+        "whether there is an API, and whether it can be self-hosted. You are the person "
+        "colleagues ask before adopting anything. If it works you will tell your team the "
+        "same day, and you will wire it into something.")),
+    "control_wary": (0.04, (
+        "You have been through the studio's AI conversation from both sides. Your position is "
+        "the one the studio settled on: not 'don't do AI' any more, but 'do it, and let me "
+        "control every single aspect of the pipeline'. Before you let anything transcribe a "
+        "review you want to know who can read the output, whether you can exclude a meeting, "
+        "and whether you can delete it. A clear statement that the creator controls sharing "
+        "and can exclude a meeting moves you; silence on it stops you completely. The show is "
+        "under NDA and that is not a formality to you.")),
+    "overloaded_exec": (0.02, (
+        "You are a studio executive. You have eight meetings a day and two hundred unread "
+        "mails. You triage by subject line and your assistant handles most of your inbox. You "
+        "will act on something only if it takes under thirty seconds and removes work rather "
+        "than adding it. You never complete a setup flow. You do forward things to the person "
+        "who should handle them.")),
+}
+
+# Role skews: multiplicative weights applied to the base mix before sampling.
+ROLE_SKEW = {
+    "coordinator":        {"coordinator_under_pressure": 14.0, "artist": 0.02,
+                           "production_manager": 1.0, "supervisor": 0.05},
+    "production_manager": {"production_manager": 14.0, "artist": 0.02,
+                           "coordinator_under_pressure": 1.5, "supervisor": 0.1},
+    "supervisor":         {"supervisor": 12.0, "artist": 0.3, "control_wary": 1.6,
+                           "coordinator_under_pressure": 0.1},
+    "artist":             {"artist": 3.0, "coordinator_under_pressure": 0.02,
+                           "production_manager": 0.02, "supervisor": 0.05,
+                           "pipeline_engineer": 0.25, "overloaded_exec": 0.02},
+    "engineer":           {"pipeline_engineer": 12.0, "artist": 0.05, "control_wary": 1.5,
+                           "coordinator_under_pressure": 0.02},
+    "lead":               {"pipeline_engineer": 4.0, "production_manager": 2.0,
+                           "control_wary": 1.6, "artist": 0.2},
+    "exec":               {"overloaded_exec": 20.0, "artist": 0.02, "control_wary": 1.4},
+    "staff":              {"artist": 0.2, "control_wary": 2.0, "production_manager": 1.0,
+                           "coordinator_under_pressure": 0.3},
+    # bank profile's role vocabulary, kept so the second profile still assigns
+    "manager":            {"production_manager": 6.0, "artist": 0.1},
+    "ic":                 {"artist": 2.0, "pipeline_engineer": 0.6},
+    "assistant":          {"coordinator_under_pressure": 4.0, "artist": 0.3},
+}
+
+# Departments where control and NDA are loudest, and where curiosity is highest.
+DEPT_SKEW = {
+    "Pipeline & Engineering": {"pipeline_engineer": 2.0, "control_wary": 1.4},
+    "Studio Technology":      {"pipeline_engineer": 2.0, "control_wary": 1.6},
+    "Finance & Legal":        {"control_wary": 4.0},
+    "HR & Recruiting":        {"control_wary": 3.0},
+    "IT & Facilities":        {"control_wary": 2.0, "pipeline_engineer": 1.5},
+    "Studio Executive":       {"overloaded_exec": 3.0, "control_wary": 1.5},
+    "Editorial":              {"artist": 1.5},
+    # bank
+    "Compliance": {"control_wary": 2.4}, "Legal": {"control_wary": 2.6},
+    "Human Resources": {"control_wary": 2.6}, "Internal Audit": {"control_wary": 2.0},
+    "Data & Analytics": {"pipeline_engineer": 2.4}, "IT Infrastructure": {"pipeline_engineer": 2.2},
+}
+
+NAMES = list(PERSONAS)
+
+
+def assign(org, seed: int = 11) -> None:
+    """Give every person a persona. Mutates org.people in place; pure in the seed."""
+    rng = random.Random(seed)
+    for p in org.people:
+        w = []
+        for nm in NAMES:
+            base = PERSONAS[nm][0]
+            base *= ROLE_SKEW.get(p.role, {}).get(nm, 1.0)
+            base *= DEPT_SKEW.get(p.dept, {}).get(nm, 1.0)
+            w.append(base)
+        p.persona = rng.choices(NAMES, weights=w)[0]
+
+
+def mix(org) -> dict:
+    out: dict[str, int] = {}
+    for p in org.people:
+        out[p.persona] = out.get(p.persona, 0) + 1
+    n = len(org.people)
+    return {k: round(v / n, 3) for k, v in sorted(out.items(), key=lambda x: -x[1])}
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    import org as O
+    o = O.build(sys.argv[1] if len(sys.argv) > 1 else "spi")
+    assign(o)
+    print(json.dumps(mix(o), indent=1))
+    by_role: dict[str, dict[str, int]] = {}
+    for p in o.people:
+        by_role.setdefault(p.role, {}).setdefault(p.persona, 0)
+        by_role[p.role][p.persona] += 1
+    print(json.dumps(by_role, indent=1))

--- a/core/flows/eval/adoption/probe.py
+++ b/core/flows/eval/adoption/probe.py
@@ -1,0 +1,65 @@
+"""One-identity smoke probe: does the real touch chain fire for a sim identity at all?
+
+Run before the sample. Every leg it exercises is a leg the sampler depends on.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+
+import rig
+
+EMAIL = sys.argv[1] if len(sys.argv) > 1 else "sim-probe@rehearsal.test"
+
+
+def login(email: str) -> tuple[str, str]:
+    anon = rig.MCP()
+    anon.init()
+    r = anon.call("start_onboarding", email=email)
+    print("start_onboarding:", json.dumps(r)[:300])
+    m = rig.wait_for(email, lambda x: "code" in (x.get("Subject") or "").lower()
+                     or "sign" in (x.get("Subject") or "").lower(), timeout_s=90)
+    if not m:
+        raise SystemExit(f"no code mail reached {email}")
+    t = rig.full_touch(m)
+    print("code mail subject:", t["subject"])
+    code = re.search(r"\b(\d{6})\b", t["text"])
+    if not code:
+        raise SystemExit("no 6-digit code in: " + t["text"][:400])
+    r = anon.call("confirm_login", email=email, code=code.group(1))
+    tok = r.get("token") or ""
+    print("confirm_login uid:", r.get("uid"), "token:", bool(tok))
+    return r.get("uid", ""), tok
+
+
+def main():
+    uid, tok = login(EMAIL)
+    if not tok:
+        raise SystemExit("no token")
+    me = rig.MCP(tok)
+    me.init()
+    print("settings:", json.dumps(me.call("settings"))[:400])
+    print("workspaces:", json.dumps(me.call("workspaces"))[:300])
+    # the .scaffolded shortcut around onboarding (recorded as a shortcut in the report)
+    print("scaffold:", json.dumps(me.call(
+        "workspace_write", path=".scaffolded",
+        content=json.dumps({"ready": True, "at": time.time(), "by": "adoption-sim"})))[:300])
+
+    start = time.time() + 30 * 86400            # far future: await_start parks, no bot ever
+    refs = {"organizer": EMAIL, "url": "https://meet.google.com/sim-probe-aaa",
+            "start": start, "ics_uid": f"sim-probe-{int(time.time())}",
+            "title": "Payments platform weekly", "group": None}
+    print("invite:", json.dumps(me.call("fact_emit", event_type="invite.received",
+                                        source_event_id=refs["ics_uid"],
+                                        subject_refs=refs))[:400])
+    time.sleep(45)
+    for m in rig.messages_for(EMAIL):
+        t = rig.full_touch(m)
+        print(f"  MAIL  {t['subject']!r}  links={t['links'][:1]}")
+    print("reactions:", json.dumps(me.call("reactions_list"))[:1200])
+
+
+if __name__ == "__main__":
+    main()

--- a/core/flows/eval/adoption/probe2.py
+++ b/core/flows/eval/adoption/probe2.py
@@ -1,0 +1,42 @@
+"""Second probe: the post-meeting leg (capture double -> agent turn -> minutes mail)."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+
+import rig
+from probe import login
+
+EMAIL = sys.argv[1] if len(sys.argv) > 1 else "sim-probe1@rehearsal.test"
+VIDEO = sys.argv[2] if len(sys.argv) > 2 else "1Ph5N_vV230"
+
+uid, tok = login(EMAIL)
+me = rig.MCP(tok)
+me.init()
+native = f"sim-{int(time.time())}"
+seed = me.call("meeting_seed", native_id=native, title="Payments platform weekly",
+               video_id=VIDEO, timeout=300)
+print("seed:", json.dumps(seed)[:400])
+if "meeting_id" not in seed:
+    raise SystemExit("seed failed")
+refs = {"organizer": EMAIL, "url": f"https://meet.google.com/{native}",
+        "start": time.time() - 3600, "ics_uid": f"sim-done-{native}",
+        "title": "Payments platform weekly", "group": None,
+        "meeting_id": seed["meeting_id"], "native": native,
+        "transcript": seed["transcript"], "uid": uid}
+print("completed:", json.dumps(me.call("fact_emit", event_type="meeting.completed",
+                                       source_event_id=f"sim-done-{native}",
+                                       subject_refs=refs))[:300])
+t0 = time.time()
+while time.time() - t0 < 900:
+    hit = [m for m in rig.messages_for(EMAIL) if (m.get("Subject") or "").startswith("Minutes:")]
+    if hit:
+        t = rig.full_touch(hit[0])
+        print("\n=== MINUTES MAIL after", round(time.time() - t0), "s ===")
+        print(t["subject"]); print(t["text"][:2500]); print("links:", t["links"])
+        break
+    time.sleep(15)
+else:
+    print("NO MINUTES MAIL in 900s")

--- a/core/flows/eval/adoption/probe3.py
+++ b/core/flows/eval/adoption/probe3.py
@@ -1,0 +1,38 @@
+"""Bottleneck probe: does ANY touch ever reach an attendee who is not the organizer?
+
+The claim under test (PRD §16.1): "the attendee never hears from the product". We emit an
+invite that explicitly names three attendees in refs — the most generous possible input — and
+then watch all four mailboxes.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import rig
+from probe import login
+
+ORG = "sim-org-a@rehearsal.test"
+ATTENDEES = ["sim-att-a1@rehearsal.test", "sim-att-a2@rehearsal.test",
+             "sim-att-a3@rehearsal.test"]
+
+uid, tok = login(ORG)
+me = rig.MCP(tok)
+me.init()
+me.call("workspace_write", path=".scaffolded",
+        content=json.dumps({"ready": True, "at": time.time(), "by": "adoption-sim"}))
+
+native = f"simatt{int(time.time())}"
+stamp = int(time.time())
+refs = {"organizer": ORG, "url": f"https://meet.google.com/{native}",
+        "start": time.time() + 30 * 86400, "ics_uid": f"sim-att-{stamp}",
+        "title": "Risk model review", "group": None,
+        # the most generous input the schema could carry — three ways of naming them
+        "participants": ATTENDEES, "attendees": ATTENDEES,
+        "ATTENDEE": ATTENDEES}
+print("invite:", json.dumps(me.call("fact_emit", event_type="invite.received",
+                                    source_event_id=refs["ics_uid"], subject_refs=refs)))
+time.sleep(60)
+for addr in [ORG] + ATTENDEES:
+    subs = [m.get("Subject") for m in rig.messages_for(addr)]
+    print(f"{addr:34s} -> {len(subs)} mail(s): {subs}")

--- a/core/flows/eval/adoption/probe4.py
+++ b/core/flows/eval/adoption/probe4.py
@@ -1,0 +1,71 @@
+"""probe4 — the SAME experiment probe3 ran, in the sim lane, with the fix in.
+
+probe3 (before): an invite naming three attendees three different ways -> organizer 3 mails,
+attendees 0. This runs the post-meeting leg end to end and counts the mails that reach the
+attendees. The number this prints IS the before/after of bottleneck #1.
+
+  python3 probe4.py [mode]      mode = shared (default) | personal | off
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+import rig
+import simlane
+from probe import login
+
+MODE = sys.argv[1] if len(sys.argv) > 1 else "shared"
+VIDEO = sys.argv[2] if len(sys.argv) > 2 else "1Ph5N_vV230"
+
+ORG = "sim-spi-coord@rehearsal.test"
+ATTENDEES = ["sim-spi-anim@rehearsal.test", "sim-spi-light@rehearsal.test",
+             "sim-spi-comp@rehearsal.test"]
+OUTSIDE = ["vendor@outside.example"]          # must NEVER be mailed (domain allow-list)
+
+# the lever, as a flow param on a new active version — meta-software, not code
+POST_STEPS = ["require_workspace", "process_meeting", "email_minutes", "email_attendees"]
+print("flow version:", json.dumps(simlane.flow_params(
+    "post_meeting", "meeting.completed", POST_STEPS,
+    {"attendee_followup": MODE})[1])[:200])
+
+uid, tok = login(ORG)
+me = rig.MCP(tok)
+me.init()
+me.call("workspace_write", path=".scaffolded",
+        content=json.dumps({"ready": True, "at": time.time(), "by": "adoption-sim"}))
+
+native = f"simspi{int(time.time())}"
+seed = me.call("meeting_seed", native_id=native, title="Show A Animation dailies",
+               video_id=VIDEO, timeout=300)
+print("seed:", json.dumps(seed)[:300])
+if "meeting_id" not in seed:
+    raise SystemExit("seed failed")
+
+sid = f"sim-spi-{native}"
+refs = {"organizer": ORG, "url": f"https://meet.google.com/{native}",
+        "start": time.time() - 3600, "ics_uid": sid,
+        "title": "Show A Animation dailies", "group": None,
+        "participants": ATTENDEES + OUTSIDE,
+        "meeting_id": seed["meeting_id"], "native": native,
+        "transcript": seed["transcript"], "uid": uid}
+print("emit:", json.dumps(simlane.emit("meeting.completed", sid, refs))[:300])
+
+r = simlane.wait_reaction(sid, timeout_s=1500)
+print("reaction:", json.dumps({k: r.get(k) for k in
+                               ("source_event_id", "step", "status", "reason")} if r else None))
+
+print("\n=== MAILBOXES ===")
+for addr in [ORG] + ATTENDEES + OUTSIDE:
+    ms = rig.messages_for(addr)
+    print(f"{addr:34s} -> {len(ms)}: {[m.get('Subject') for m in ms]}")
+
+print("\n=== ONE ATTENDEE FOLLOW-UP, VERBATIM ===")
+for m in rig.messages_for(ATTENDEES[0]):
+    t = rig.full_touch(m)
+    if "what it means for you" in (t["subject"] or ""):
+        print(t["subject"]); print(t["text"][:2000]); print("links:", t["links"])
+        break
+else:
+    print("(none)")

--- a/core/flows/eval/adoption/probe4.py
+++ b/core/flows/eval/adoption/probe4.py
@@ -17,11 +17,16 @@ import simlane
 from probe import login
 
 MODE = sys.argv[1] if len(sys.argv) > 1 else "shared"
-VIDEO = sys.argv[2] if len(sys.argv) > 2 else "1Ph5N_vV230"
+# The fixture has to MATCH the meeting it is presented as. The first judged touch caught
+# this: a Kubernetes SIG transcript mailed under an "Animation dailies" title was ignored
+# for the mismatch, so the sample would have measured our fixture, not our product.
+VIDEO = sys.argv[2] if len(sys.argv) > 2 else "dna-2026-03-02"
+TITLE = sys.argv[3] if len(sys.argv) > 3 else "DNA dailies-notes working session"
+TAG = sys.argv[4] if len(sys.argv) > 4 else MODE[:4]
 
-ORG = "sim-spi-coord@rehearsal.test"
-ATTENDEES = ["sim-spi-anim@rehearsal.test", "sim-spi-light@rehearsal.test",
-             "sim-spi-comp@rehearsal.test"]
+ORG = f"sim-{TAG}-coord@rehearsal.test"
+ATTENDEES = [f"sim-{TAG}-eng1@rehearsal.test", f"sim-{TAG}-eng2@rehearsal.test",
+             f"sim-{TAG}-sup1@rehearsal.test"]
 OUTSIDE = ["vendor@outside.example"]          # must NEVER be mailed (domain allow-list)
 
 # the lever, as a flow param on a new active version — meta-software, not code
@@ -36,17 +41,17 @@ me.init()
 me.call("workspace_write", path=".scaffolded",
         content=json.dumps({"ready": True, "at": time.time(), "by": "adoption-sim"}))
 
-native = f"simspi{int(time.time())}"
-seed = me.call("meeting_seed", native_id=native, title="Show A Animation dailies",
+native = f"sim{TAG}{int(time.time())}"
+seed = me.call("meeting_seed", native_id=native, title=TITLE,
                video_id=VIDEO, timeout=300)
 print("seed:", json.dumps(seed)[:300])
 if "meeting_id" not in seed:
     raise SystemExit("seed failed")
 
-sid = f"sim-spi-{native}"
+sid = f"sim-{TAG}-{native}"
 refs = {"organizer": ORG, "url": f"https://meet.google.com/{native}",
         "start": time.time() - 3600, "ics_uid": sid,
-        "title": "Show A Animation dailies", "group": None,
+        "title": TITLE, "group": None,
         "participants": ATTENDEES + OUTSIDE,
         "meeting_id": seed["meeting_id"], "native": native,
         "transcript": seed["transcript"], "uid": uid}

--- a/core/flows/eval/adoption/rebuild_rates.py
+++ b/core/flows/eval/adoption/rebuild_rates.py
@@ -1,0 +1,83 @@
+"""Build `table_by_history` — the rates keyed the way they were actually SAMPLED.
+
+sample.py records one row per valid answer in `whys` (persona, history, opened, active_action,
+friction, why). The flat `table` averages the three history states together; sim.py needs them
+separate, because "would you open the third thing you have ignored" is precisely the question
+retention turns on, and it was measured rather than assumed.
+
+Run as a post-processor on an existing rates.json; also patches sample.py so the next
+revolution emits it directly.
+"""
+import json
+import os
+import sys
+from collections import defaultdict
+
+def jeffreys(k: int, n: int) -> float:
+    """Beta(1/2,1/2) posterior mean. A measured 0/14 becomes 3.3%, not 0% — low, but not
+    impossible, which is all a sample that size can actually support. Without this, every zero
+    cell is an absorbing state and no lever can be ranked against any other."""
+    if n <= 0:
+        return 0.0
+    return (k + 0.5) / (n + 1.0)
+
+
+RUN = sys.argv[1] if len(sys.argv) > 1 else os.path.expanduser("~/sim-runs/r1")
+path = f"{RUN}/rates.json"
+d = json.load(open(path))
+
+agg = defaultdict(lambda: {"n": 0, "open": 0, "act": 0})
+for kind, rows in d.get("whys", {}).items():
+    for r in rows:
+        k = (r["persona"], kind, r["history"])
+        g = agg[k]
+        g["n"] += 1
+        if r.get("opened"):
+            g["open"] += 1
+            g["act"] += bool(r.get("active_action"))
+
+flat = d.get("table", {})
+by_hist = {}
+for (persona, kind, hist), g in agg.items():
+    if not g["n"]:
+        continue
+    base = flat.get(f"{persona}|{kind}", {})
+    by_hist[f"{persona}|{kind}|{hist}"] = {
+        "n": g["n"],
+        "open": round(jeffreys(g["open"], g["n"]), 4),
+        "open_raw": round(g["open"] / g["n"], 4),
+        "act_given_open": round(jeffreys(g["act"], g["open"]), 4),
+        "act_given_open_raw": round(g["act"] / g["open"], 4) if g["open"] else 0.0,
+        "invite": max(base.get("invite", 0.0), 0.01),
+        "forward": max(base.get("forward", 0.0), 0.01),
+    }
+
+# A `*` fallback per (kind, history) so a thin cell borrows from the whole population rather
+# than from a hard-coded default — the default is the last resort, not the first.
+pop = defaultdict(lambda: {"n": 0, "open": 0, "act": 0})
+for kind, rows in d.get("whys", {}).items():
+    for r in rows:
+        g = pop[(kind, r["history"])]
+        g["n"] += 1
+        if r.get("opened"):
+            g["open"] += 1
+            g["act"] += bool(r.get("active_action"))
+for (kind, hist), g in pop.items():
+    by_hist[f"*|{kind}|{hist}"] = {
+        "n": g["n"],
+        "open": round(jeffreys(g["open"], g["n"]), 4),
+        "open_raw": round(g["open"] / g["n"], 4),
+        "act_given_open": round(jeffreys(g["act"], g["open"]), 4),
+        "act_given_open_raw": round(g["act"] / g["open"], 4) if g["open"] else 0.0,
+        "invite": 0.02, "forward": 0.02,
+    }
+
+d["table_by_history"] = by_hist
+json.dump(d, open(path, "w"), indent=1)
+print(f"table_by_history: {len(by_hist)} cells "
+      f"({sum(v['n'] for k, v in by_hist.items() if not k.startswith('*'))} answers)")
+for k in sorted(by_hist):
+    if k.startswith("*"):
+        v = by_hist[k]
+        print(f"  {k:34s} n={v['n']:3d} open={v['open']:.2f} (raw {v['open_raw']:.2f})"
+              f"  act|open={v['act_given_open']:.2f} (raw {v['act_given_open_raw']:.2f})")

--- a/core/flows/eval/adoption/report.py
+++ b/core/flows/eval/adoption/report.py
@@ -1,0 +1,196 @@
+"""Assemble the revolution's REPORT.md from what was actually measured.
+
+Everything printed here comes from a file written by a run — rates.json (Haiku over real mail),
+conversations.json (the real agent), and the sim over the generated org. Nothing is typed in.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import org as O
+import personas as P
+import sim as S
+
+RUN = os.environ.get("SIM_RUN_DIR", os.path.expanduser("~/sim-runs/r1"))
+SIZES = [int(x) for x in os.environ.get("SIM_SIZES", "2000,20000,200000").split(",")]
+LEVERS = ["off", "shared", "personal"]
+LEVER_NAME = {"off": "null — organizer only (the line today)",
+              "shared": "A — one shared follow-up to every attendee",
+              "personal": "B — per-person, same single agent turn"}
+
+
+def fmt(v, pct=False):
+    if v is None:
+        return "—"
+    return f"{v*100:.1f}%" if pct else str(v)
+
+
+def main():
+    rates = S.Rates.load(f"{RUN}/rates.json")
+    raw = json.load(open(f"{RUN}/rates.json"))
+    touches = json.load(open(f"{RUN}/touches.json"))
+    convs = []
+    if os.path.exists(f"{RUN}/conversations.json"):
+        convs = json.load(open(f"{RUN}/conversations.json"))
+
+    out = []
+    w = out.append
+
+    w("# Adoption simulator — revolution 1\n")
+    w(f"**Run:** `{RUN}` · **Branch:** `adoption-sim` · **Base:** `544ceb17d` · "
+      "**Issue:** [biz#449](https://github.com/DmitriyG228/biz/issues/449)\n")
+    w("**Agent under test:** Haiku on both sides — the simulated persona, and the deployed "
+      "product agent where it was exercised.\n")
+    w("> **The number is relative between revolutions. It is never a forecast.** It exists to "
+      "rank changes against each other, and it is only as good as the rates measured beneath "
+      "it. Read every absolute figure as *this lever, against this null, on this org shape*.\n")
+
+    w("## 0. Real vs simulated\n")
+    w("| | real | simulated |")
+    w("|---|---|---|")
+    w("| flows engine, steps, retries, mail delivery | the deployed engine on `bbb` | |")
+    w("| the mail text every decision was made on | verbatim out of mailpit | |")
+    w("| the note and the per-attendee blocks | one real agent turn per meeting | |")
+    w("| the chat after a click | the deployed agent over agent-api | |")
+    w("| the people, personas and decisions | | Haiku, one call per touch |")
+    w("| the org, its meeting graph, the calendar | | generated, SPI-shaped |")
+    w("")
+    w("**Active** is strict, per the founder's tightening: in the trailing 14 days the person "
+      "**opened** a Vexa mail **and** took a **UI action** — clicked into the terminal, sent a "
+      "chat turn, replied to the mail, or put the mailbox on a meeting they own. Delivered mail "
+      "scores zero; an open alone is *reached*, not active.\n")
+
+    # ── the org
+    o2 = O.build("spi", SIZES[0]); P.assign(o2)
+    st = O.stats(o2)
+    w("## 1. The org — SPI, native to the fixtures\n")
+    w(f"Working size **{SIZES[0]:,}** (founder's number). *Assumption stated:* public reporting "
+      "puts SPI at ~700 **production** staff at peak and Twenty's 5,000 is the Sony Pictures "
+      "umbrella — the size is a parameter, not a headcount claim.\n")
+    w(f"- {st['people']:,} people · {st['teams']} units · {st['meeting_series']} meeting series "
+      f"· {st['meetings_per_week_total']:,.0f} occurrences/week · "
+      f"{st['avg_meetings_per_person_per_week']} meetings per person per week")
+    w(f"- reachable at all (in any non-external meeting): **{len(set(a for m in o2.meetings if not m.external for a in m.attendees)):,}**")
+    w("- dominant recurring meeting by volume: " + ", ".join(
+        f"`{k}` {v:.0f}/wk" for k, v in list(st["by_kind_per_week"].items())[:4]))
+    w("")
+    w("Persona mix (assigned, not asserted): " + " · ".join(
+        f"`{k}` {v*100:.0f}%" for k, v in P.mix(o2).items()) + "\n")
+
+    # ── measured rates
+    w("## 2. What the personas actually did with the REAL mails\n")
+    w(f"Touch kinds harvested from mailpit: {', '.join('`'+k+'`' for k in sorted(touches))}. "
+      f"{sum(v['n'] for v in raw['table'].values())} judged decisions; "
+      f"{raw.get('judge_errors', 0)} judge errors.\n")
+    w("Mail sizes actually sent (this is the A/B, in bytes): " + " · ".join(
+        f"`{k}` {len(v['text'])} chars" for k, v in sorted(touches.items())) + "\n")
+    w("| persona | touch | opened | UI action \\| opened | → active |")
+    w("|---|---|---|---|---|")
+    for key in sorted(raw["table"]):
+        persona, kind = key.split("|")
+        if kind in ("signin",):
+            continue
+        v = raw["table"][key]
+        w(f"| `{persona}` | `{kind}` | {v['open']*100:.0f}% | {v['act_given_open']*100:.0f}% | "
+          f"**{v['open']*v['act_given_open']*100:.0f}%** |")
+    w("")
+
+    # ── the sims
+    w("## 3. T_full, retention, and the lever\n")
+    w(f"`T_full` = the day the ACTIVE share crosses **{int(S.FULL_THRESHOLD*100)}%** of the "
+      "reachable population. Reported as `>N` when it never crosses inside the horizon — no org "
+      "reaches everyone, and a threshold that is only approached asymptotically is not a "
+      "measurement.\n")
+    w("| size | lever | T_full | peak active | steady state | retention 30 | retention 90 | invited mailbox |")
+    w("|---|---|---|---|---|---|---|---|")
+    results = {}
+    for n in SIZES:
+        o = O.build("spi", n)
+        P.assign(o)
+        for lever in LEVERS:
+            r = S.run(o, rates, days=120, attendee_followup=lever)
+            results[(n, lever)] = r
+            t = r["t_full_days"]
+            w(f"| {n:,} | {LEVER_NAME[lever]} | "
+              f"{(str(t)+' d') if t else '> '+str(r['days'])+' d'} | "
+              f"{fmt(r['peak_active_share'], True)} | {fmt(r['steady_state_active_share'], True)} | "
+              f"{fmt(r['retention_30'], True)} | {fmt(r['retention_90'], True)} | "
+              f"{r['invited_mailbox']:,} |")
+    w("")
+
+    base = results[(SIZES[0], "off")]
+    a = results[(SIZES[0], "shared")]
+    b = results[(SIZES[0], "personal")]
+    w("### H1 against the null\n")
+    w("> **H1** — the post-meeting follow-up to every attendee is the mechanism that spreads; "
+      "without it adoption travels only through organizers. **Null** — the product spreads "
+      "acceptably through organizers alone.\n")
+    w(f"At {SIZES[0]:,}: the null peaks at **{fmt(base['peak_active_share'], True)}** active and "
+      f"settles at **{fmt(base['steady_state_active_share'], True)}**; variant A reaches "
+      f"**{fmt(a['peak_active_share'], True)}** / **{fmt(a['steady_state_active_share'], True)}**; "
+      f"variant B reaches **{fmt(b['peak_active_share'], True)}** / "
+      f"**{fmt(b['steady_state_active_share'], True)}**.\n")
+
+    w("### Churn — why people stopped\n")
+    for lever in LEVERS:
+        r = results[(SIZES[0], lever)]
+        w(f"- **{LEVER_NAME[lever]}**: " + (", ".join(
+            f"{k} ×{v:,}" for k, v in list(r["churn_reasons"].items())[:4]) or "—"))
+    w("")
+
+    # ── verbatim whys
+    w("## 4. Two verbatim persona `why`s per touch type\n")
+    for kind in sorted(raw.get("whys", {})):
+        if kind == "signin":
+            continue
+        rows = raw["whys"][kind]
+        acted = [r for r in rows if r.get("active_action")]
+        ignored = [r for r in rows if not r.get("active_action")]
+        w(f"**`{kind}`**\n")
+        for tag, pick in (("acted", acted[:1]), ("did not act", ignored[:1])):
+            for r in pick:
+                w(f"- *{tag}* — `{r['persona']}` ({r['history']}): “{r['why']}”"
+                  + (f"  · friction: *{r['friction']}*" if r.get("friction") else ""))
+        w("")
+
+    # ── interaction
+    w("## 5. The interaction with the knowledge agent\n")
+    if convs:
+        told = sum(1 for c in convs if c["opened_by_telling"])
+        val = [c for c in convs if c["got_value"]]
+        w(f"- conversations run against the REAL agent: **{len(convs)}**")
+        w(f"- opened by TELLING (the preset rule) rather than asking: **{told}/{len(convs)}**")
+        w(f"- reached value at all: **{len(val)}/{len(convs)}**")
+        acts = [x for c in convs for x in c["asked_actions"]]
+        w(f"- actions the person asked for: {acts or 'none'}")
+        w("")
+        w("Abandonment, verbatim:")
+        for c in convs:
+            if c.get("abandon_why"):
+                w(f"- `{c['persona']}`: “{c['abandon_why']}”")
+    else:
+        w("_not run in this revolution_")
+    w("")
+
+    w("## 6. What v0 does not model\n")
+    w("Calendar reality (holidays, timezones, meetings people skip); the terminal UI beyond the "
+      "click; IT provisioning and the tenant admitting the bot; anybody telling a colleague out "
+      "loud; transcription quality. Quality enters only through what the mails actually say. "
+      "The organizer's invite is admitted as a direct fact rather than a parsed ICS — the "
+      "inbound mailbox double landed on a sibling branch during this run and feeds the "
+      "founder's lane, not the sim's. The fixture is a DNA/ASWF working session, not a dailies "
+      "review: no dailies transcript exists yet, and the personas judge CONTENT, so this is the "
+      "single biggest gap between this measurement and SPI's real pilot.\n")
+
+    json.dump({f"{n}|{lv}": {k: v for k, v in r.items() if k != "curve"}
+               for (n, lv), r in results.items()},
+              open(f"{RUN}/results.json", "w"), indent=1)
+    text = "\n".join(out)
+    open(f"{RUN}/REPORT.md", "w").write(text)
+    print(text)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/flows/eval/adoption/rig.py
+++ b/core/flows/eval/adoption/rig.py
@@ -1,0 +1,130 @@
+"""Thin MCP + mailpit client for the adoption sampler.
+
+One door in (the control MCP over HTTP, with a per-identity token) and one door out (mailpit's
+REST API, read-only — messages are NEVER deleted; another session shares this mailbox).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+
+MCP_URL = os.environ.get("SIM_MCP_URL", "http://localhost:18310/mcp")
+MAILPIT = os.environ.get("SIM_MAILPIT", "http://127.0.0.1:8025")
+
+
+class MCP:
+    """One MCP session. `token` is the identity — never uid 57's."""
+
+    def __init__(self, token: str = "", url: str = MCP_URL):
+        self.token, self.url, self.sid, self.n = token, url, None, 0
+
+    def _headers(self):
+        h = {"content-type": "application/json",
+             "Accept": "application/json, text/event-stream"}
+        if self.token:
+            h["Authorization"] = f"Bearer {self.token}"
+        if self.sid:
+            h["Mcp-Session-Id"] = self.sid
+        return h
+
+    def _post(self, body, timeout=120):
+        self.n += 1
+        req = urllib.request.Request(self.url, method="POST",
+                                     data=json.dumps(body).encode(), headers=self._headers())
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                sid = r.headers.get("Mcp-Session-Id")
+                if sid:
+                    self.sid = sid
+                return r.status, self._parse(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()[:800]
+
+    @staticmethod
+    def _parse(raw):
+        if "data: " in raw:
+            raw = [l[6:] for l in raw.splitlines() if l.startswith("data: ")][-1]
+        try:
+            return json.loads(raw)
+        except Exception:  # noqa: BLE001
+            return raw[:800]
+
+    def init(self):
+        st, r = self._post({"jsonrpc": "2.0", "id": self.n + 1, "method": "initialize",
+                            "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                                       "clientInfo": {"name": "adoption-sim", "version": "0"}}})
+        try:
+            urllib.request.urlopen(urllib.request.Request(
+                self.url, method="POST", headers=self._headers(),
+                data=json.dumps({"jsonrpc": "2.0",
+                                 "method": "notifications/initialized"}).encode()),
+                timeout=20).read()
+        except Exception:  # noqa: BLE001
+            pass
+        return st, r
+
+    def call(self, name, timeout=180, **args):
+        st, r = self._post({"jsonrpc": "2.0", "id": self.n + 1, "method": "tools/call",
+                            "params": {"name": name, "arguments": args}}, timeout=timeout)
+        if isinstance(r, dict) and "result" in r:
+            content = r["result"].get("content") or []
+            txt = "".join(c.get("text", "") for c in content if c.get("type") == "text")
+            try:
+                return json.loads(txt)
+            except Exception:  # noqa: BLE001
+                return {"_text": txt}
+        return {"_status": st, "_raw": r}
+
+
+# ── mailpit (read-only) ────────────────────────────────────────────────────────────────────
+def _get(path):
+    with urllib.request.urlopen(MAILPIT + path, timeout=30) as r:
+        return json.loads(r.read().decode())
+
+
+def messages_for(addr: str, limit: int = 200) -> list[dict]:
+    """Every message addressed to `addr`, newest first. Search, never list-and-filter:
+    the mailbox is shared with another session and holds thousands of unrelated messages."""
+    q = urllib.parse.quote(f'to:"{addr}"')
+    try:
+        d = _get(f"/api/v1/search?query={q}&limit={limit}")
+    except Exception:  # noqa: BLE001
+        return []
+    return d.get("messages", [])
+
+
+def body_of(msg_id: str) -> dict:
+    return _get(f"/api/v1/message/{msg_id}")
+
+
+def full_touch(m: dict) -> dict:
+    """A message rendered the way the human meets it: subject + the text they actually read."""
+    d = body_of(m["ID"])
+    text = (d.get("Text") or "").strip()
+    if not text:
+        text = re.sub(r"<[^>]+>", " ", d.get("HTML") or "")
+    links = re.findall(r"https?://[^\s<>\"\)]+", text)
+    return {"id": m["ID"], "subject": m.get("Subject", ""),
+            "from": (m.get("From") or {}).get("Address", ""),
+            "to": [t.get("Address") for t in (m.get("To") or [])],
+            "created": m.get("Created"),
+            "text": text[:6000], "links": links,
+            "has_attachment": bool(m.get("Attachments"))}
+
+
+import urllib.parse  # noqa: E402  (used by messages_for)
+
+
+def wait_for(addr: str, predicate, timeout_s: int = 300, poll: int = 6):
+    """Poll mailpit until a message matching `predicate` reaches `addr`, or give up."""
+    t0 = time.time()
+    while time.time() - t0 < timeout_s:
+        for m in messages_for(addr):
+            if predicate(m):
+                return m
+        time.sleep(poll)
+    return None

--- a/core/flows/eval/adoption/sample.py
+++ b/core/flows/eval/adoption/sample.py
@@ -42,7 +42,6 @@ SOURCES = [
                                                   "sim-spi-coord@rehearsal.test"]),
     ("attendee_shared",   "what it means for you", ["sim-dnaA-eng1@rehearsal.test"]),
     ("attendee_personal", "what it means for you", ["sim-dnaB-eng1@rehearsal.test"]),
-    ("signin",            "sign-in code",        ["sim-dnaA-coord@rehearsal.test"]),
 ]
 
 HISTORY_STATES = {

--- a/core/flows/eval/adoption/sample.py
+++ b/core/flows/eval/adoption/sample.py
@@ -29,14 +29,20 @@ import rig
 AGENT_API = os.environ.get("SIM_AGENT_API", "http://127.0.0.1:18500")
 RUN = os.environ.get("SIM_RUN_DIR", os.path.expanduser("~/sim-runs/r1"))
 
-# how a real subject line maps to the touch kind sim.py reasons about
-KINDS = [
-    ("prepare",            lambda s: s.startswith("Prepare:")),
-    ("minutes",            lambda s: s.startswith("Minutes:")),
-    ("attendee_shared",    lambda s: "what it means for you" in s),
-    ("attendee_personal",  lambda s: "what it means for you" in s),
-    ("accepted",           lambda s: s.startswith("Accepted:")),
-    ("signin",             lambda s: "sign-in code" in s),
+# How a real mail becomes a touch kind sim.py reasons about.
+# SUBJECT ALONE IS NOT ENOUGH: variant A and variant B of the attendee follow-up carry the
+# IDENTICAL subject line, so a subject-only matcher silently sampled one mail as both and would
+# have reported the two variants as indistinguishable. Each kind names the mailbox it is
+# sourced from — the run that produced it — as well as the subject test.
+SOURCES = [
+    ("prepare",           "Prepare:",            ["sim-dnaA-coord@rehearsal.test",
+                                                  "sim-spi-coord@rehearsal.test",
+                                                  "sim-probe1@rehearsal.test"]),
+    ("minutes",           "Minutes:",            ["sim-dnaA-coord@rehearsal.test",
+                                                  "sim-spi-coord@rehearsal.test"]),
+    ("attendee_shared",   "what it means for you", ["sim-dnaA-eng1@rehearsal.test"]),
+    ("attendee_personal", "what it means for you", ["sim-dnaB-eng1@rehearsal.test"]),
+    ("signin",            "sign-in code",        ["sim-dnaA-coord@rehearsal.test"]),
 ]
 
 HISTORY_STATES = {
@@ -67,18 +73,22 @@ ROLE_FOR = {
 }
 
 
-def harvest(addrs: list) -> dict:
-    """kind -> the real mail (subject + verbatim text + links)."""
+def harvest(sources=None) -> dict:
+    """kind -> the NEWEST real mail of that kind, from the mailbox that run wrote to.
+    mailpit returns newest first, so the first match is the most recent product behaviour —
+    which matters, because the body changed under us when `_readable` landed."""
     found = {}
-    for a in addrs:
-        for m in rig.messages_for(a):
-            subj = m.get("Subject") or ""
-            for kind, pred in KINDS:
-                if kind in found or not pred(subj):
+    for kind, needle, addrs in (sources or SOURCES):
+        for a in addrs:
+            if kind in found:
+                break
+            for m in rig.messages_for(a):
+                if needle not in (m.get("Subject") or ""):
                     continue
                 t = rig.full_touch(m)
                 if t["text"].strip():
                     found[kind] = t
+                    break
     return found
 
 
@@ -199,11 +209,7 @@ def converse(person, uid: str, session: str, opening_prompt: str, max_turns: int
 
 def main():
     os.makedirs(RUN, exist_ok=True)
-    addrs = sys.argv[1].split(",") if len(sys.argv) > 1 else [
-        "sim-spi-coord@rehearsal.test", "sim-spi-anim@rehearsal.test",
-        "sim-spi-light@rehearsal.test", "sim-spi-comp@rehearsal.test",
-        "sim-probe1@rehearsal.test", "sim-org-a@rehearsal.test"]
-    touches = harvest(addrs)
+    touches = harvest()
     print("harvested touch kinds:", sorted(touches))
     json.dump(touches, open(f"{RUN}/touches.json", "w"), indent=1)
     if not touches:

--- a/core/flows/eval/adoption/sample.py
+++ b/core/flows/eval/adoption/sample.py
@@ -1,0 +1,221 @@
+"""Layer 1 — the SAMPLE on the real stack. Produces `rates.json` for sim.py.
+
+Three phases, and only the first two are cheap:
+
+  harvest   pull the ACTUAL mails the flows engine sent to the sim identities out of mailpit.
+            Nothing here is written by hand: a touch the product does not send cannot be
+            sampled, which is why the attendee follow-up had to be BUILT before it could be
+            measured.
+  judge     each (persona × touch_kind × history-state) -> one Haiku call reading that real text.
+            Produces the open / act-given-open rates sim.py extrapolates on.
+  converse  where a persona CLICKED, the touch does not end: it has a real conversation with
+            the REAL agent in that identity's chat, through agent-api /api/chat, bounded at 3
+            persona turns. Haiku on both sides — the persona is simulated, the agent is the
+            product as deployed. Scored on: did the first agent turn TELL or ask, turns to
+            value, did an asked action actually happen, and why anyone abandoned.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+
+import judge
+import personas
+import rig
+
+AGENT_API = os.environ.get("SIM_AGENT_API", "http://127.0.0.1:18500")
+RUN = os.environ.get("SIM_RUN_DIR", os.path.expanduser("~/sim-runs/r1"))
+
+# how a real subject line maps to the touch kind sim.py reasons about
+KINDS = [
+    ("prepare",            lambda s: s.startswith("Prepare:")),
+    ("minutes",            lambda s: s.startswith("Minutes:")),
+    ("attendee_shared",    lambda s: "what it means for you" in s),
+    ("attendee_personal",  lambda s: "what it means for you" in s),
+    ("accepted",           lambda s: s.startswith("Accepted:")),
+    ("signin",             lambda s: "sign-in code" in s),
+]
+
+HISTORY_STATES = {
+    "fresh": [],
+    "one_ignore": [{"day": 3, "kind": "prepare", "outcome": "ignored",
+                    "why": "I did not have time and it was not obviously about my shots"}],
+    "two_ignores": [{"day": 3, "kind": "prepare", "outcome": "ignored",
+                     "why": "I did not have time"},
+                    {"day": 5, "kind": "minutes", "outcome": "ignored",
+                     "why": "the summary was generic — it did not say anything I did not know"}],
+}
+
+
+class FakePerson:
+    """A person the judge can read, without needing the whole org built."""
+    def __init__(self, persona, role, dept, name):
+        self.persona, self.role, self.dept, self.name = persona, role, dept, name
+
+
+ROLE_FOR = {
+    "coordinator_under_pressure": ("coordinator", "Show A"),
+    "production_manager": ("production_manager", "Show A"),
+    "artist": ("artist", "Show A"),
+    "supervisor": ("supervisor", "Show A"),
+    "pipeline_engineer": ("engineer", "Pipeline & Engineering"),
+    "control_wary": ("staff", "Finance & Legal"),
+    "overloaded_exec": ("exec", "Studio Executive"),
+}
+
+
+def harvest(addrs: list) -> dict:
+    """kind -> the real mail (subject + verbatim text + links)."""
+    found = {}
+    for a in addrs:
+        for m in rig.messages_for(a):
+            subj = m.get("Subject") or ""
+            for kind, pred in KINDS:
+                if kind in found or not pred(subj):
+                    continue
+                t = rig.full_touch(m)
+                if t["text"].strip():
+                    found[kind] = t
+    return found
+
+
+def judge_phase(touches: dict, reps: int = 2) -> dict:
+    jobs, keys = [], []
+    for persona in personas.PERSONAS:
+        role, dept = ROLE_FOR.get(persona, ("artist", "Show A"))
+        who = FakePerson(persona, role, dept, "Sam Okafor")
+        for kind, touch in touches.items():
+            for hname, hist in HISTORY_STATES.items():
+                for r in range(reps):
+                    load = 1 if hname == "fresh" else 4
+                    jobs.append((who, touch, hist, 10, load))
+                    keys.append((persona, kind, hname))
+    print(f"judging {len(jobs)} touches on Haiku…", flush=True)
+    answers = judge.decide_many(jobs, workers=10)
+
+    raw = defaultdict(list)
+    for k, a in zip(keys, answers):
+        raw[k].append(a)
+
+    table, whys, errs = {}, defaultdict(list), 0
+    agg = defaultdict(lambda: {"n": 0, "open": 0, "act": 0, "inv": 0, "fwd": 0})
+    for (persona, kind, hname), answers_ in raw.items():
+        for a in answers_:
+            if a.get("_error"):
+                errs += 1
+                continue
+            g = agg[(persona, kind)]
+            g["n"] += 1
+            g["open"] += bool(a.get("opened"))
+            if a.get("opened"):
+                g["act"] += bool(a.get("active_action"))
+                g["inv"] += bool(a.get("invited_own_meeting"))
+                g["fwd"] += bool(a.get("forwarded"))
+            if a.get("why"):
+                whys[kind].append({"persona": persona, "history": hname,
+                                   "outcome": a.get("outcome"), "opened": a.get("opened"),
+                                   "active_action": a.get("active_action"),
+                                   "friction": a.get("friction", ""), "why": a["why"]})
+    for (persona, kind), g in agg.items():
+        if not g["n"]:
+            continue
+        op = g["open"] / g["n"]
+        table[f"{persona}|{kind}"] = {
+            "n": g["n"], "open": round(op, 4),
+            "act_given_open": round(g["act"] / g["open"], 4) if g["open"] else 0.0,
+            "invite": round(g["inv"] / g["open"], 4) if g["open"] else 0.0,
+            "forward": round(g["fwd"] / g["open"], 4) if g["open"] else 0.0,
+        }
+    return {"table": table, "whys": dict(whys), "judge_errors": errs}
+
+
+# ── phase 3: the conversation with the real agent ────────────────────────────────────────────
+def agent_turn(uid: str, session: str, prompt: str, timeout=180) -> str:
+    """One REAL turn against the deployed agent, over the SSE stream agent-api serves."""
+    import urllib.request
+    req = urllib.request.Request(
+        f"{AGENT_API}/api/chat", method="POST",
+        data=json.dumps({"prompt": prompt, "session": session}).encode())
+    req.add_header("content-type", "application/json")
+    req.add_header("X-User-Id", str(uid))
+    reply = ""
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            for raw in r:
+                line = raw.decode(errors="replace").strip()
+                if not line.startswith("data: "):
+                    continue
+                try:
+                    ev = json.loads(line[6:])
+                except Exception:  # noqa: BLE001
+                    continue
+                if ev.get("type") == "done":
+                    reply = ev.get("reply") or reply
+    except Exception as e:  # noqa: BLE001
+        return f"(no answer: {type(e).__name__})"
+    return reply
+
+
+def converse(person, uid: str, session: str, opening_prompt: str, max_turns: int = 3) -> dict:
+    """The persona and the product, alternating. Both sides recorded verbatim."""
+    log, actions = [], []
+    opening = agent_turn(uid, session, opening_prompt)
+    log.append({"who": "agent", "text": opening})
+    d = judge.conv_open(person, opening)
+    log.append({"who": "person", "text": d.get("say", ""), "judgment": d})
+    turns_to_value = 1 if d.get("got_value") else None
+    if d.get("asked_action") and d["asked_action"] != "none":
+        actions.append(d["asked_action"])
+    n = 1
+    while not d.get("abandoned") and d.get("say") and n < max_turns:
+        ans = agent_turn(uid, session, d["say"])
+        log.append({"who": "agent", "text": ans})
+        d = judge.conv_turn(person, d["say"], ans)
+        log.append({"who": "person", "text": d.get("say", ""), "judgment": d})
+        n += 1
+        if turns_to_value is None and d.get("got_value"):
+            turns_to_value = n
+        if d.get("asked_action") and d["asked_action"] != "none":
+            actions.append(d["asked_action"])
+    first_agent = (log[0]["text"] or "")
+    return {
+        "persona": person.persona,
+        "turns": n,
+        "turns_to_value": turns_to_value,
+        "got_value": bool(turns_to_value),
+        "abandoned": bool(d.get("abandoned")),
+        "abandon_why": d.get("why", "") if d.get("abandoned") else "",
+        "asked_actions": actions,
+        # the preset rule: the opening must TELL from the workspace, then ask ONE question
+        "opened_by_telling": not first_agent.strip().endswith("?")
+                             and first_agent.count("?") <= 1,
+        "questions_in_opening": first_agent.count("?"),
+        "log": log,
+    }
+
+
+def main():
+    os.makedirs(RUN, exist_ok=True)
+    addrs = sys.argv[1].split(",") if len(sys.argv) > 1 else [
+        "sim-spi-coord@rehearsal.test", "sim-spi-anim@rehearsal.test",
+        "sim-spi-light@rehearsal.test", "sim-spi-comp@rehearsal.test",
+        "sim-probe1@rehearsal.test", "sim-org-a@rehearsal.test"]
+    touches = harvest(addrs)
+    print("harvested touch kinds:", sorted(touches))
+    json.dump(touches, open(f"{RUN}/touches.json", "w"), indent=1)
+    if not touches:
+        raise SystemExit("no real touches harvested — nothing to judge")
+    out = judge_phase(touches)
+    out["harvested"] = sorted(touches)
+    out["history_penalty"] = 0.72
+    out["fatigue_penalty"] = 0.65
+    json.dump(out, open(f"{RUN}/rates.json", "w"), indent=1)
+    print(json.dumps(out["table"], indent=1)[:3000])
+    print("judge errors:", out["judge_errors"])
+
+
+if __name__ == "__main__":
+    main()

--- a/core/flows/eval/adoption/sim.py
+++ b/core/flows/eval/adoption/sim.py
@@ -31,17 +31,34 @@ FULL_THRESHOLD = 0.80       # "full adoption" = this share of the reachable popu
 MAIL_FATIGUE = 3            # mails/day above which the marginal one is much likelier ignored
 
 
+HISTORY_BUCKETS = ["fresh", "one_ignore", "two_ignores"]
+
+
+def bucket(consec_ignored: int) -> str:
+    """The history state the SAMPLE actually measured, not a decay curve fitted to nothing."""
+    return HISTORY_BUCKETS[min(consec_ignored, len(HISTORY_BUCKETS) - 1)]
+
+
 @dataclass
 class Rates:
-    """Measured on the stack. Keyed (persona, touch_kind) -> {open, act_given_open, invite, fwd}.
-    `history_penalty` is the multiplier applied per consecutive prior ignore, also measured."""
+    """Measured on the stack, keyed (persona, touch_kind, history) ->
+    {open, act_given_open, invite, forward}.
+
+    There is no `history_penalty` any more. The first version of this file aggregated the three
+    measured history states together and then re-invented the same effect as an unbounded
+    exponential — an asserted constant standing in front of a measured number, and one that
+    drove every population to extinction (after ten ignored touches it put the open probability
+    at 1%, so no lever could retain anybody). Consecutive ignores now select the bucket that was
+    sampled."""
     table: dict
-    history_penalty: float = 0.72
-    fatigue_penalty: float = 0.65
+    fatigue_penalty: float = 0.65      # ASSUMED, not measured: the marginal mail in a busy day
     default: tuple = (0.35, 0.20, 0.02, 0.02)
 
-    def get(self, persona: str, kind: str):
-        v = self.table.get(f"{persona}|{kind}") or self.table.get(f"*|{kind}")
+    def get(self, persona: str, kind: str, hist: str = "fresh"):
+        v = (self.table.get(f"{persona}|{kind}|{hist}")
+             or self.table.get(f"{persona}|{kind}")
+             or self.table.get(f"*|{kind}|{hist}")
+             or self.table.get(f"*|{kind}"))
         if not v:
             return self.default
         return (v["open"], v["act_given_open"], v.get("invite", 0.0), v.get("forward", 0.0))
@@ -49,8 +66,7 @@ class Rates:
     @staticmethod
     def load(path: str) -> "Rates":
         d = json.load(open(path))
-        return Rates(table=d["table"],
-                     history_penalty=d.get("history_penalty", 0.72),
+        return Rates(table=d.get("table_by_history") or d["table"],
                      fatigue_penalty=d.get("fatigue_penalty", 0.65),
                      default=tuple(d.get("default", (0.35, 0.20, 0.02, 0.02))))
 
@@ -113,7 +129,8 @@ def run(org, rates: Rates, days: int = 120, seed: int = 3,
     # who could EVER be reached: anyone in a non-external meeting. Nobody else has a path.
     reachable = {a for m in org.meetings if not m.external for a in m.attendees}
 
-    curve, t_full = [], None
+    curve = []
+    crossed: dict = {}
     per_touch_counts: dict = {}
 
     for day in range(1, days + 1):
@@ -131,9 +148,8 @@ def run(org, rates: Rates, days: int = 120, seed: int = 3,
                 continue
             n_today = st.mails_today.get(pid, 0)
             st.mails_today[pid] = n_today + 1
-            o, a, inv, fwd = rates.get(p.persona, kind)
-            # history: consecutive ignores compound, exactly as a person stops opening
-            o *= rates.history_penalty ** st.consec_ignored.get(pid, 0)
+            o, a, inv, fwd = rates.get(p.persona, kind,
+                                       bucket(st.consec_ignored.get(pid, 0)))
             if n_today >= MAIL_FATIGUE:
                 o *= rates.fatigue_penalty ** (n_today - MAIL_FATIGUE + 1)
             per_touch_counts[kind] = per_touch_counts.get(kind, 0) + 1
@@ -171,8 +187,9 @@ def run(org, rates: Rates, days: int = 120, seed: int = 3,
         curve.append({"day": day, "active": len(active), "active_share": round(share, 4),
                       "ever_active": len(st.ever_active), "reached": len(st.reached),
                       "invited": len(st.invited)})
-        if t_full is None and share >= full_threshold:
-            t_full = day
+        for thr in (0.25, 0.50, 0.80):
+            if thr not in crossed and share >= thr:
+                crossed[thr] = day
 
     # retention: of those who BECAME active, the share still active 30 / 90 days later
     def retention(after: int) -> float | None:
@@ -191,7 +208,9 @@ def run(org, rates: Rates, days: int = 120, seed: int = 3,
         "headcount": len(org.people),
         "reachable": len(reachable),
         "days": days,
-        "t_full_days": t_full,
+        "t_full_days": crossed.get(0.80),
+        "t_25_days": crossed.get(0.25),
+        "t_50_days": crossed.get(0.50),
         "full_threshold": full_threshold,
         "peak_active_share": round(max(c["active_share"] for c in curve), 4),
         "steady_state_active_share": steady,
@@ -207,11 +226,13 @@ def run(org, rates: Rates, days: int = 120, seed: int = 3,
 
 
 def summarize(r: dict) -> str:
-    t = r["t_full_days"]
-    return (f"{r['lever']:<18} n={r['headcount']:<7} "
-            f"T_full({int(r['full_threshold']*100)}%)="
-            f"{(str(t)+'d') if t else '>'+str(r['days'])+'d':<6} "
-            f"peak={r['peak_active_share']*100:5.1f}%  steady={r['steady_state_active_share']*100:5.1f}%  "
+    def d(v):
+        return str(v) if v else ">" + str(r["days"])
+    return (f"{r['lever']:<10} n={r['headcount']:<7} "
+            f"T25={d(r['t_25_days']):<5} T50={d(r['t_50_days']):<5} "
+            f"T80={d(r['t_full_days']):<5} "
+            f"peak={r['peak_active_share']*100:5.1f}%  "
+            f"steady={r['steady_state_active_share']*100:5.1f}%  "
             f"ret30={r['retention_30']}  ret90={r['retention_90']}")
 
 

--- a/core/flows/eval/adoption/sim.py
+++ b/core/flows/eval/adoption/sim.py
@@ -1,0 +1,229 @@
+"""The daily dynamics — the objective function.
+
+The clock is DAILY. Each simulated day the meeting graph fires the meetings due that day; each
+firing produces the touches the REAL product produces for that meeting (measured on the stack,
+not invented here); each touch is a persona decision. The org is too large to put every touch
+through Haiku, so the model is two-layer and says so:
+
+  layer 1  SAMPLE — real identities, real flows, real mail text, one Haiku call per touch.
+           Produces `rates.json`: per (persona × touch_kind × history-state) the share who
+           opened, and of those, the share who took a UI ACTION.
+  layer 2  EXTRAPOLATE — this file, walking the whole graph on those measured rates.
+
+ACTIVE (founder, 2026-09-02): opened a Vexa mail AND took at least one UI action — clicked into
+the terminal, sent a chat turn, replied to the mail, or invited the mailbox — within the
+trailing 14 days. Delivered mail counts for nothing; an open alone is `reached`, not active.
+
+T_full is reported as the day the ACTIVE share crosses a stated threshold, never as "everyone":
+no org reaches 100%, and a number that can only be reached asymptotically is not a measurement.
+The number is relative between revolutions. It is NEVER a forecast.
+"""
+from __future__ import annotations
+
+import json
+import math
+import random
+from dataclasses import dataclass, field
+
+ACTIVE_WINDOW = 14          # days: the trailing window in which an action must have happened
+CHURN_AFTER = 14            # days ignored in a row -> inactive
+FULL_THRESHOLD = 0.80       # "full adoption" = this share of the reachable population active
+MAIL_FATIGUE = 3            # mails/day above which the marginal one is much likelier ignored
+
+
+@dataclass
+class Rates:
+    """Measured on the stack. Keyed (persona, touch_kind) -> {open, act_given_open, invite, fwd}.
+    `history_penalty` is the multiplier applied per consecutive prior ignore, also measured."""
+    table: dict
+    history_penalty: float = 0.72
+    fatigue_penalty: float = 0.65
+    default: tuple = (0.35, 0.20, 0.02, 0.02)
+
+    def get(self, persona: str, kind: str):
+        v = self.table.get(f"{persona}|{kind}") or self.table.get(f"*|{kind}")
+        if not v:
+            return self.default
+        return (v["open"], v["act_given_open"], v.get("invite", 0.0), v.get("forward", 0.0))
+
+    @staticmethod
+    def load(path: str) -> "Rates":
+        d = json.load(open(path))
+        return Rates(table=d["table"],
+                     history_penalty=d.get("history_penalty", 0.72),
+                     fatigue_penalty=d.get("fatigue_penalty", 0.65),
+                     default=tuple(d.get("default", (0.35, 0.20, 0.02, 0.02))))
+
+
+@dataclass
+class State:
+    ever_active: set = field(default_factory=set)
+    last_action_day: dict = field(default_factory=dict)   # pid -> day
+    reached: set = field(default_factory=set)             # opened at least once
+    consec_ignored: dict = field(default_factory=dict)
+    invited: set = field(default_factory=set)             # pids whose meetings carry the mailbox
+    became_active_day: dict = field(default_factory=dict)
+    churn_reasons: dict = field(default_factory=dict)
+    mails_today: dict = field(default_factory=dict)
+
+
+def _touches_for(meeting, org_state, is_seeded, attendee_followup: str):
+    """What the REAL product emits for one occurrence of one meeting. This is the product's
+    behaviour as measured on the stack, expressed as a list of (pid, touch_kind).
+
+      organizer has the mailbox invited  -> prepare (before), minutes (after)
+      attendees                          -> NOTHING, unless the attendee follow-up is on
+    External meetings are never mailed at all (the domain allow-list)."""
+    if meeting.external or meeting.organizer not in is_seeded:
+        return []
+    out = [(meeting.organizer, "prepare"), (meeting.organizer, "minutes")]
+    if attendee_followup != "off":
+        kind = "attendee_shared" if attendee_followup == "shared" else "attendee_personal"
+        for a in meeting.attendees:
+            if a != meeting.organizer:
+                out.append((a, kind))
+    return out
+
+
+def run(org, rates: Rates, days: int = 120, seed: int = 3,
+        attendee_followup: str = "off", seeds_n: int = 3, seed_role=None,
+        full_threshold: float = FULL_THRESHOLD) -> dict:
+    """One simulated adoption run. `attendee_followup` is the lever under test:
+       off       the product as it stands on the line (organizer only) — THE NULL
+       shared    one follow-up body to every inside-domain attendee (variant A)
+       personal  a per-person block from the same single agent run (variant B)
+    """
+    rng = random.Random(seed)
+    st = State()
+    people = {p.pid: p for p in org.people}
+
+    # the pilot: SPI's own shape — 3-5 coordinators/production managers "using it as their main
+    # tool" (Cottalango, 2026-08-18). They are the only seeded identities on day 0.
+    pool = [p.pid for p in org.people
+            if p.role in (seed_role or ("coordinator", "production_manager"))]
+    if not pool:
+        pool = [m.organizer for m in org.meetings]
+    seeded = set(rng.sample(pool, min(seeds_n, len(pool))))
+    for pid in seeded:
+        st.ever_active.add(pid)
+        st.last_action_day[pid] = 0
+        st.became_active_day[pid] = 0
+        st.invited.add(pid)
+
+    # who could EVER be reached: anyone in a non-external meeting. Nobody else has a path.
+    reachable = {a for m in org.meetings if not m.external for a in m.attendees}
+
+    curve, t_full = [], None
+    per_touch_counts: dict = {}
+
+    for day in range(1, days + 1):
+        st.mails_today = {}
+        # which meeting series fire today — per_week/5 working days, Bernoulli per day
+        firing = [m for m in org.meetings if rng.random() < min(1.0, m.per_week / 5.0)]
+        touches = []
+        for m in firing:
+            touches += _touches_for(m, st, st.invited, attendee_followup)
+        rng.shuffle(touches)
+
+        for pid, kind in touches:
+            p = people.get(pid)
+            if p is None:
+                continue
+            n_today = st.mails_today.get(pid, 0)
+            st.mails_today[pid] = n_today + 1
+            o, a, inv, fwd = rates.get(p.persona, kind)
+            # history: consecutive ignores compound, exactly as a person stops opening
+            o *= rates.history_penalty ** st.consec_ignored.get(pid, 0)
+            if n_today >= MAIL_FATIGUE:
+                o *= rates.fatigue_penalty ** (n_today - MAIL_FATIGUE + 1)
+            per_touch_counts[kind] = per_touch_counts.get(kind, 0) + 1
+
+            if rng.random() >= o:
+                st.consec_ignored[pid] = st.consec_ignored.get(pid, 0) + 1
+                if st.mails_today[pid] > MAIL_FATIGUE:
+                    st.churn_reasons["too many mails in a day"] = \
+                        st.churn_reasons.get("too many mails in a day", 0) + 1
+                continue
+            st.reached.add(pid)
+            if rng.random() >= a:                      # opened but did nothing = NOT active
+                st.consec_ignored[pid] = st.consec_ignored.get(pid, 0) + 1
+                st.churn_reasons["opened, nothing worth doing"] = \
+                    st.churn_reasons.get("opened, nothing worth doing", 0) + 1
+                continue
+            st.consec_ignored[pid] = 0
+            st.last_action_day[pid] = day
+            if pid not in st.ever_active:
+                st.ever_active.add(pid)
+                st.became_active_day[pid] = day
+            # the growth atom: an active person putting the mailbox on a meeting THEY own
+            if pid not in st.invited and rng.random() < inv:
+                st.invited.add(pid)
+            if rng.random() < fwd:                     # a forward exposes a colleague's invite
+                mates = [x for m in org.meetings if pid in m.attendees and not m.external
+                         for x in m.attendees if x != pid]
+                if mates:
+                    other = rng.choice(mates)
+                    if other not in st.invited and rng.random() < 0.35:
+                        st.invited.add(other)
+
+        active = {pid for pid, d in st.last_action_day.items() if day - d <= ACTIVE_WINDOW}
+        share = len(active) / max(1, len(reachable))
+        curve.append({"day": day, "active": len(active), "active_share": round(share, 4),
+                      "ever_active": len(st.ever_active), "reached": len(st.reached),
+                      "invited": len(st.invited)})
+        if t_full is None and share >= full_threshold:
+            t_full = day
+
+    # retention: of those who BECAME active, the share still active 30 / 90 days later
+    def retention(after: int) -> float | None:
+        elig = [pid for pid, d0 in st.became_active_day.items() if d0 + after <= days]
+        if not elig:
+            return None
+        still = [pid for pid in elig
+                 if (d0 := st.became_active_day[pid]) is not None
+                 and st.last_action_day.get(pid, -999) >= d0 + after - ACTIVE_WINDOW]
+        return round(len(still) / len(elig), 4)
+
+    tail = curve[-min(21, len(curve)):]
+    steady = round(sum(c["active_share"] for c in tail) / len(tail), 4)
+    return {
+        "lever": attendee_followup,
+        "headcount": len(org.people),
+        "reachable": len(reachable),
+        "days": days,
+        "t_full_days": t_full,
+        "full_threshold": full_threshold,
+        "peak_active_share": round(max(c["active_share"] for c in curve), 4),
+        "steady_state_active_share": steady,
+        "retention_30": retention(30),
+        "retention_90": retention(90),
+        "ever_active": len(st.ever_active),
+        "ever_reached": len(st.reached),
+        "invited_mailbox": len(st.invited),
+        "touches_by_kind": per_touch_counts,
+        "churn_reasons": dict(sorted(st.churn_reasons.items(), key=lambda x: -x[1])),
+        "curve": curve,
+    }
+
+
+def summarize(r: dict) -> str:
+    t = r["t_full_days"]
+    return (f"{r['lever']:<18} n={r['headcount']:<7} "
+            f"T_full({int(r['full_threshold']*100)}%)="
+            f"{(str(t)+'d') if t else '>'+str(r['days'])+'d':<6} "
+            f"peak={r['peak_active_share']*100:5.1f}%  steady={r['steady_state_active_share']*100:5.1f}%  "
+            f"ret30={r['retention_30']}  ret90={r['retention_90']}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    import org as O
+    import personas as P
+    rates = Rates.load(sys.argv[1] if len(sys.argv) > 1 else "rates.json")
+    prof = sys.argv[2] if len(sys.argv) > 2 else "spi"
+    for n in [int(x) for x in (sys.argv[3].split(",") if len(sys.argv) > 3 else ["2000"])]:
+        o = O.build(prof, n)
+        P.assign(o)
+        for lever in ("off", "shared", "personal"):
+            print(summarize(run(o, rates, days=120, attendee_followup=lever)))

--- a/core/flows/eval/adoption/simlane.py
+++ b/core/flows/eval/adoption/simlane.py
@@ -1,0 +1,65 @@
+"""The sim lane's own door into the flows engine.
+
+The founder's hot lane (:18200, database `flows`) admits REAL invites from a REAL inbox. This
+lane is a second worker + api (:18201, database `flows_sim`) running the adoption-sim worktree,
+with the mailbox integration deliberately not started. Nothing this file does can reach a real
+recipient: it posts facts to :18201 only, and the fan-out's domain allow-list is the sim's own
+three test domains.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+API = os.environ.get("SIM_FLOWS_API", "http://127.0.0.1:18201")
+KEY = os.environ.get("SIM_FLOWS_KEY", "simlane")
+
+
+def _req(method: str, path: str, body=None, timeout=30):
+    req = urllib.request.Request(API + path, method=method,
+                                 data=json.dumps(body).encode() if body is not None else None)
+    req.add_header("content-type", "application/json")
+    req.add_header("X-Flows-Admin-Key", KEY)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            raw = r.read().decode()
+            return r.status, (json.loads(raw) if raw.strip().startswith(("{", "[")) else raw)
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        return e.code, (json.loads(raw) if raw.strip().startswith(("{", "[")) else raw)
+
+
+def emit(event_type: str, source_event_id: str, refs: dict):
+    """Admit ONE fact into the sim lane."""
+    return _req("POST", "/events", {"event_type": event_type,
+                                    "source_event_id": source_event_id, "refs": refs})
+
+
+def reactions(status: str = ""):
+    return _req("GET", f"/reactions?status={status}" if status else "/reactions")
+
+
+def flow_params(name: str, on_event: str, steps: list, params: dict):
+    """Submit a new active version of a flow carrying `params` — how a lever (shared vs
+    personal follow-up, sharing off) is turned between revolutions without a code change."""
+    return _req("POST", "/flows", {"name": name, "on_event": on_event, "steps": steps,
+                                   "params": params, "activate": True})
+
+
+def wait_reaction(source_event_id: str, want=("done", "failed", "cancelled"), timeout_s=1200):
+    """Block until the reaction for this fact settles. Returns the row or None."""
+    t0 = time.time()
+    last = None
+    while time.time() - t0 < timeout_s:
+        st, body = reactions()
+        rows = body.get("reactions", body) if isinstance(body, dict) else body
+        for r in (rows or []):
+            if str(r.get("source_event_id", "")).startswith(source_event_id):
+                last = r
+                if r.get("status") in want:
+                    return r
+        time.sleep(6)
+    return last

--- a/core/flows/src/flows/loop.py
+++ b/core/flows/src/flows/loop.py
@@ -63,8 +63,20 @@ def tick(db: DB, registry: Registry, clock: Clock, *, emit=None) -> bool:
     try:
         flow = registry.get(r.flow, r.flow_version)
     except KeyError:
-        _fail(db, r, clock, f"unknown flow {r.flow}@{r.flow_version} — retired by deploy?")
-        return True
+        # Two DIFFERENT causes wear this one KeyError, and they need opposite handling.
+        # BEHIND us: a redeploy retired the version — a real, typed, permanent failure.
+        # AHEAD of us: the version was submitted through flows-api seconds ago and this
+        # worker has not refreshed yet. Admission stamps the new version IMMEDIATELY, while
+        # the worker only reloads every ~10s, so every reaction admitted inside that window
+        # used to fail PERMANENTLY — the liquid layer racing its own admission. Refresh once
+        # and look again; only a version still unknown afterwards is actually gone.
+        try:
+            registry.refresh_from_db(db)
+            flow = registry.get(r.flow, r.flow_version)
+        except Exception:  # noqa: BLE001
+            _fail(db, r, clock,
+                  f"unknown flow {r.flow}@{r.flow_version} — retired by deploy?")
+            return True
     if r.step not in registry.steps or r.step not in flow.steps:
         _fail(db, r, clock, f"unknown step {r.step!r} in {r.flow}@{r.flow_version} — renamed by deploy?")
         return True

--- a/core/flows/src/flows_defs/production.py
+++ b/core/flows/src/flows_defs/production.py
@@ -32,7 +32,8 @@ from flows import Done, Registry, StepCtx, StepError, Wait, EventType
 from flows_steps import agent as ag
 from flows_steps import emailx as mx          # thread bookkeeping + the iMIP calendar reply only
 from flows_steps import meeting as mt
-from flows_steps.common import ensure_platform_user, scaffolded, ui_link, ws_file, setting
+from flows_steps.common import (UI_URL, ensure_platform_user, scaffolded,
+                                setting, ui_link, ws_file)
 from flows_steps.notify import notify
 
 INVITE = EventType("invite.received")
@@ -273,11 +274,27 @@ def build(reg: Registry, db) -> None:
         uid = ctx.refs["uid"]
         if "baseline" not in ctx.scratch:
             ctx.scratch["shas"] = ag.commit_shas(uid)
+            kick = prompt_for(ctx, "process-meeting.md", PROCESS_KICKOFF).format(
+                mid=ctx.refs["meeting_id"], native=ctx.refs["native"],
+                date=time.strftime("%Y-%m-%d"),
+                transcript=ctx.refs["transcript"] or "(no speech captured)")
+            # ONE agent turn produces everything, including the per-attendee follow-ups when the
+            # personal variant is on. No per-attendee agent, no per-attendee session before a
+            # click — the button composes the chat when it is pressed, as the organizer's does.
+            if _followup_mode(ctx) == "personal":
+                who = _attendees(ctx)
+                if who:
+                    kick += (
+                        "\n\nALSO, in this same turn, write the file "
+                        f"mail_outbox/attendees-{ctx.refs['meeting_id']}.md. For each address "
+                        f"below write a section `## <address>` followed by at most three lines "
+                        "addressed to that person: what THEY committed to, what was asked of "
+                        "them, or what they asked — from the transcript, in their words where "
+                        "possible. If the meeting held nothing for that person, write the "
+                        "meeting's single decision instead. No greeting, no sign-off, no "
+                        "meta-commentary.\n" + "\n".join(who))
             ctx.scratch["baseline"] = ag.dispatch_turn(
-                uid, f"meet-{ctx.refs['meeting_id']}",
-                prompt_for(ctx, "process-meeting.md", PROCESS_KICKOFF).format(mid=ctx.refs["meeting_id"], native=ctx.refs["native"],
-                                       date=time.strftime("%Y-%m-%d"),
-                                       transcript=ctx.refs["transcript"] or "(no speech captured)"))
+                uid, f"meet-{ctx.refs['meeting_id']}", kick)
             return Wait(seconds=12)
         reply = ag.collect_reply(uid, f"meet-{ctx.refs['meeting_id']}", ctx.scratch["baseline"])
         sha, path = ag.latest_meeting_note(uid, ctx.scratch["shas"])
@@ -304,7 +321,8 @@ def build(reg: Registry, db) -> None:
         if not setting(ctx.refs["uid"], "mail_minutes"):
             return Done({"skipped": "mail_minutes is off for this person"})
         p = ctx.prior["process_meeting"]
-        note = ws_file(ctx.refs["uid"], p["note_path"]) or p["summary"]
+        note = _readable(ws_file(ctx.refs["uid"], p["note_path"])
+                         or p["summary"])
         body = (note + f"\n\n—\nRecorded by Vexa · commit {p['sha']}\n"
                 "Reply to this email with corrections or questions — I'll update the workspace "
                 "and answer here. Or open it and talk it through:")
@@ -312,6 +330,105 @@ def build(reg: Registry, db) -> None:
         mid = notify(ctx.refs["organizer"], f"Minutes: {ctx.refs['title']}", body, link=link)
         mx.register_thread(db, mid, ctx.refs["uid"], f"meet-{ctx.refs['meeting_id']}")
         return Done({"message_id": mid, "link": link}, provider_ref=mid)
+
+
+
+    def _readable(note: str) -> str:
+        """The note as a PERSON meets it in a mail.
+
+        The note is a WORKSPACE artifact: YAML frontmatter, wikilinks, workspace-relative
+        links. Mailing it verbatim put `type: meeting / id: ... / tags: [...]` at the top of
+        the first thing an attendee ever sees from us, and shipped
+        `[Recording](/?meeting=27)` — a RELATIVE url, which is a dead link in every mail
+        client there is. Neither is a rendering preference; both are the workspace leaking
+        through the product surface, and the attendee mail is where it costs the most.
+        """
+        import re
+        body = note or ""
+        if body.lstrip().startswith("---"):
+            rest = body.lstrip()[3:]
+            end = rest.find("\n---")
+            if end != -1:
+                body = rest[end + 4:]
+        body = re.sub(r"\[([^\]]+)\]\((/[^)]*)\)",
+                      lambda m: m.group(1) + ": " + UI_URL + m.group(2), body)
+        body = re.sub(r"\[\[([^\]]+)\]\]", r"\1", body)
+        return body.strip()
+
+    # ── the attendee follow-up — the loop that spreads (PRD §16.1/§16.2) ─────────────────────
+    def _followup_mode(ctx) -> str:
+        """off | shared | personal.
+
+        `shared` (default ON) is Marvin's own rule read across to SPI — creator-controlled
+        sharing, default on, with a per-meeting opt-out (`refs.share is False`). Default OFF and
+        this loop is dead on day one; that one value IS the coefficient.
+        `personal` is the same single agent run writing a per-person line for each attendee.
+        """
+        if ctx.refs.get("share") is False:
+            return "off"
+        return str((ctx.flow.param("attendee_followup") if ctx.flow else None) or "shared")
+
+    def _attendees(ctx) -> list:
+        """Inside-domain attendees, minus the organizer. PRD §16.2: outside the domain, NEVER —
+        so an unset allow-list means the organizer's own domain, not everyone."""
+        import os
+        org = (ctx.refs.get("organizer") or "").lower()
+        raw = ctx.refs.get("participants") or []
+        allow = (ctx.flow.param("attendee_domains") if ctx.flow else None) or \
+            [d for d in os.environ.get("VEXA_FLOWS_ATTENDEE_DOMAINS", "").split(",") if d] or \
+            ([org.split("@")[-1]] if "@" in org else [])
+        allow = {d.strip().lower().lstrip("@") for d in allow if d}
+        out = []
+        for a in raw:
+            a = str(a).strip().lower()
+            if "@" not in a or a == org or a in out:
+                continue
+            if a.split("@")[-1] in allow:
+                out.append(a)
+        return out
+
+    @reg.step
+    def email_attendees(ctx: StepCtx):
+        """Every inside-domain ATTENDEE gets the follow-up plus ONE button into a chat the click
+        composes. Cannot run before the note: its input is process_meeting's receipt.
+
+        Two variants, both ONE agent turn per meeting:
+          shared    the note's essentials, the same body to everyone (the cheap baseline)
+          personal  the per-person block the same turn already wrote to
+                    mail_outbox/attendees-<id>.md
+
+        Reads: refs.{participants, organizer, title, meeting_id, share?} · Effect: N notifications
+        Result: {sent, mode, skipped}."""
+        mode = _followup_mode(ctx)
+        who = _attendees(ctx)
+        if mode == "off" or not who:
+            return Done({"sent": 0, "mode": mode,
+                         "skipped": "opted out" if mode == "off" else "no inside-domain attendee"})
+        p = ctx.prior["process_meeting"]
+        note = _readable(ws_file(ctx.refs["uid"], p["note_path"])
+                         or p["summary"] or "")
+        blocks = {}
+        if mode == "personal":
+            raw = ws_file(ctx.refs["uid"], f"mail_outbox/attendees-{ctx.refs['meeting_id']}.md")
+            for chunk in (raw or "").split("## ")[1:]:
+                head, _, rest = chunk.partition("\n")
+                blocks[head.strip().lower()] = rest.strip()
+        link = ui_link(ask="minutes-review", meeting=ctx.refs["meeting_id"])
+        subject = f"{ctx.refs['title']} — what it means for you"
+        sent = []
+        for a in who:
+            body = blocks.get(a) if mode == "personal" else None
+            if not body:
+                body = note.strip()
+            body += ("\n\n—\nRecorded by Vexa in " + ctx.refs["title"] +
+                     ". Open it and ask anything about the meeting:")
+            try:
+                mid = notify(a, subject, body, link=link)
+                sent.append(a)
+            except Exception as e:  # noqa: BLE001 — one bad address never blocks the rest
+                ctx.scratch.setdefault("failed", []).append(f"{a}: {type(e).__name__}")
+        return Done({"sent": len(sent), "mode": mode, "to": sent,
+                     "failed": ctx.scratch.get("failed", [])})
 
     # ── before the meeting ────────────────────────────────────────────────────
     @reg.step
@@ -403,6 +520,7 @@ def build(reg: Registry, db) -> None:
     reg.flow(name="meeting_prep", version=1, on=UPCOMING,
              steps=[s["prepare_meeting"]])
     reg.flow(name="post_meeting", version=1, on=COMPLETED,
-             steps=[s["require_workspace"], s["process_meeting"], s["email_minutes"]])
+             steps=[s["require_workspace"], s["process_meeting"], s["email_minutes"],
+                    s["email_attendees"]])
     reg.flow(name="email_chat", version=1, on=MAIL_REPLY,
              steps=[s["feedback_turn"], s["email_reply"]])

--- a/core/flows/src/flows_integrations/mailbox.py
+++ b/core/flows/src/flows_integrations/mailbox.py
@@ -34,16 +34,6 @@ def parse_ics(ics: str) -> dict | None:
     uid = re.search(r"^UID:(.+)$", ve, re.M)
     summ = re.search(r"^SUMMARY:(.+)$", ve, re.M)
     desc = re.search(r"^DESCRIPTION:(.*)$", ve, re.M)
-    # ATTENDEE -> participants. PRD §16.2 item 1: the growth atom is the invite, and every
-    # attendee on it is an exposed person; the parser used to read ORGANIZER and stop, so the
-    # product could only ever speak to the one person who already knew about it.
-    parts, seen = [], set()
-    for line in re.findall(r"^ATTENDEE[^:]*:(?:mailto:)?(\S+)\s*$", ve, re.I | re.M):
-        a = line.strip().lower().rstrip(";,")
-        if a and "@" in a and a not in seen:
-            seen.add(a)
-            parts.append(a)
-
     group = None
     gm = re.search(r"#group:([\w-]+)", ics)
     if gm:
@@ -68,7 +58,6 @@ def parse_ics(ics: str) -> dict | None:
             "url": url.group(0), "start": start,
             "ics_uid": (uid.group(1).strip() if uid else f"noid-{int(start)}"),
             "title": (summ.group(1).strip() if summ else "Meeting"),
-            "participants": parts,
             "group": group}
 
 

--- a/core/flows/src/flows_integrations/mailbox.py
+++ b/core/flows/src/flows_integrations/mailbox.py
@@ -34,6 +34,16 @@ def parse_ics(ics: str) -> dict | None:
     uid = re.search(r"^UID:(.+)$", ve, re.M)
     summ = re.search(r"^SUMMARY:(.+)$", ve, re.M)
     desc = re.search(r"^DESCRIPTION:(.*)$", ve, re.M)
+    # ATTENDEE -> participants. PRD §16.2 item 1: the growth atom is the invite, and every
+    # attendee on it is an exposed person; the parser used to read ORGANIZER and stop, so the
+    # product could only ever speak to the one person who already knew about it.
+    parts, seen = [], set()
+    for line in re.findall(r"^ATTENDEE[^:]*:(?:mailto:)?(\S+)\s*$", ve, re.I | re.M):
+        a = line.strip().lower().rstrip(";,")
+        if a and "@" in a and a not in seen:
+            seen.add(a)
+            parts.append(a)
+
     group = None
     gm = re.search(r"#group:([\w-]+)", ics)
     if gm:
@@ -58,6 +68,7 @@ def parse_ics(ics: str) -> dict | None:
             "url": url.group(0), "start": start,
             "ics_uid": (uid.group(1).strip() if uid else f"noid-{int(start)}"),
             "title": (summ.group(1).strip() if summ else "Meeting"),
+            "participants": parts,
             "group": group}
 
 


### PR DESCRIPTION
## What this is

The **adoption simulator** — the objective function of the self-improvement loop (`DmitriyG228/biz#449`): simulated **days to full adoption** of a generated org, paired with **retention**. The product is real — real flows engine, real mails, a real agent turn per meeting, the real deployed agent in the chat. Only the people are simulated (Haiku, one call per touch, reading the verbatim mail out of mailpit).

Plus the four engine defects it found by being run. Each was found by running the thing, not by reading it.

**COMMITMENTS IN THIS DRAFT — none.** No pricing, dates, rights, or external promises; this is internal code and a measurement.

## The headline is a negative result, and it is the point

**T_full is unbounded.** No arm crosses even **25%** active inside 120 simulated days, at 2,000 / 20,000 / 200,000. The bottleneck is *not* reach — this PR fixes reach — it is that **almost no touch earns a UI action**.

`active` is strict, per the founder's tightening: opened a Vexa mail **and** took a UI action (clicked into the terminal, sent a chat turn, replied, or invited the mailbox) in the trailing 14 days. Delivered mail scores zero.

| size | lever | T_full | peak active | steady | ret 30 | ret 90 | mailbox invites |
|---|---|---|---|---|---|---|---|
| 2,000 | null — organizer only (the line today) | > 120 d | 0.1% | 0.1% | 33% | 33% | 3 |
| 2,000 | **A — one shared follow-up to every attendee** | > 120 d | **1.2%** | 1.1% | **93%** | **93%** | 9 |
| 2,000 | B — per-person, same single agent turn | > 120 d | 1.4% | 1.2% | 85% | 90% | 11 |
| 20,000 | null | > 120 d | 0.0% | 0.0% | 33% | 33% | 3 |
| 20,000 | A | > 120 d | 0.1% | 0.1% | 93% | 93% | 8 |
| 20,000 | B | > 120 d | 0.1% | 0.1% | 93% | 93% | 11 |
| 200,000 | null | > 120 d | 0.0% | 0.0% | 33% | 33% | 3 |
| 200,000 | A | > 120 d | 0.0% | 0.0% | 93% | 93% | 7 |
| 200,000 | B | > 120 d | 0.0% | 0.0% | 93% | 89% | 10 |

**Only one persona ever acts.** `pipeline_engineer` converts at 17–33%. `artist`, `coordinator_under_pressure`, `production_manager`, `supervisor`, `control_wary` and `overloaded_exec` measure **0% action across all four touch types**, on open rates of 50–100%. The SPI pilot is *"actual coordinators and production managers using it as their main tool"* — both measure zero. People open our mail readily and do nothing with it.

**H1 holds in direction, and A ≈ B.** Touching attendees is worth ~12× on active share at 2,000 (0.1% → 1.2%) and is what carries retention (33% → 93% at 30 days). Personalisation is *not* the decisive lever at this sample size — reach is. Start with A, as proposed.

**Size effect:** the lever weakens as the org grows, because the pilot seed stays at 3–5 people while the graph grows 100×. Nothing flips sign; what changes is a requirement — above 20k the seed has to scale with the org.

## The four defects, each proven on the stack

**1. The attendee never heard from the product** (PRD §16.1). `email_minutes` addressed `refs["organizer"]` only. Proven with a probe that named attendees three different ways at once and watched all four mailboxes:

| mailbox | before | after |
|---|---|---|
| organizer | 3 mails | minutes + prepare |
| attendee ×3 (inside domain) | **0** | **1 each**, with one button |
| vendor (outside domain) | 0 | **0** — allow-list holds |

New `email_attendees` step. **One agent turn per meeting** produces everything — no per-attendee agent, no session created before anyone clicks; the button is a composed `?ask=minutes-review&meeting=<row>` deeplink that builds the chat when pressed. Two variants behind a flow param, `shared` (default) and `personal`, the latter written by that same single turn. Creator-controlled sharing default ON with a per-meeting opt-out (`refs.share is False`); domain allow-list, outside the domain never.

**2. `flows/loop.py` — the liquid layer raced its own admission.** A flow version submitted through flows-api is admitted *immediately*, but the worker reloads every ~10 s, so any reaction admitted inside that window failed **permanently** with `unknown flow post_meeting@N — retired by deploy?`. That `KeyError` wears two opposite causes — a version *behind* us (retired: a real failure) and one *ahead* of us (a race) — and the handler assumed the first. Now refreshes once and only fails a version that is genuinely gone.

**3. The workspace leaked into the mail.** The note was mailed verbatim, so the first thing an attendee ever saw from us opened with `type: meeting / id: … / tags: […]`, and the call to action was `[▶ Recording](/?meeting=27)` — a workspace-**relative** url, dead in every mail client. `_readable()` strips frontmatter, absolutises workspace links against `VEXA_UI_URL`, flattens wikilinks. Applies to the organizer's minutes mail too.

**4. `core/agent` — a subject with no workspace cannot chat at all.** `/api/chat` spawns a worker that bind-mounts `<workspaces>/<subject>`; when the directory does not exist the runtime refuses to start the container (`404 … no such file or directory`) and agent-api returns a bare **500**. The seeding seam is documented as lazy — *"seeded on first turn"* — but the lazy path can never run, because the mount is evaluated before any worker code does. In practice the directory only ever existed because the email onboarding flow called `POST /api/workspace/init` explicitly. **Every path that reaches a chat without that flow 500s on its first turn — and the most important one is the growth atom itself.** Four simulated attendees clicked the button; four got a 500; all four abandoned, and their stated reasons were about the product being broken, not about its value. Verified by equivalence: the same chat succeeds immediately after `workspace/init`.

## And one the loop found but did not fix

The chat the button opens does **not** tell the person what the meeting held for them — it opens by pitching the product (*"Paste any meeting link and I'll drop a notetaker into that call…"*) to somebody who arrived from a follow-up about a specific meeting they had just attended. That is meta-software (the `minutes-review` preset), it is the next cheapest fruit, and it is left for the founder's read because it is a **voice** change.

## Rungs, stated

- `core/flows` changes: **proven on the live stack** in an isolated sim lane, end to end.
- `core/agent/control_plane/dispatch.py`: **built and committed, NOT in an image.** agent-api needs a rebuild + swap before it is live on `vexa-dogfood`.

## Where this ran, and what it did not touch

The founder's hot lane (`:18200`, db `flows`) admits **real** invites from a **real** inbox, so enabling attendee fan-out there could mail real people. It was not touched. The simulator runs its own worker + api (`:18201`, db `flows_sim`) from this branch with the mailbox integration never started and an allow-list of three `.test` domains. No mailpit message was deleted, nothing was pruned, no container stopped; uid 57 and the sibling `dna-loop` (uid 68) untouched.

**Collision check:** `origin/inbound-double` already parses `ATTENDEE` into `refs["participants"]`, and its parser is better than the one I first wrote (CN-prefixed and folded lines, self-exclusion). I reverted mine so that ref has **one producer**. The halves compose: that branch produces `refs["participants"]`, `email_attendees` here is its first consumer.

## Three corrections to the instrument itself

Worth reading, because each was silently producing wrong numbers:

1. The judge passed its prompt as an `@file` reference from a directory that did not contain the file — **38% of calls returned nothing**, and the empties were dropped from the aggregate, so the rates looked clean while resting on 62% of the sample. Now inline, with retries: 168 answers, **0 errors**.
2. The sim aggregated away the three history states the sample *measures* and re-invented the effect as an unbounded decay constant — an asserted number standing in front of a measured one.
3. Raw `act_given_open` is `0.00` for every touch once a person has ignored once (0 successes in ~14 trials). Treating that as exactly zero asserts impossibility from a small sample **and** makes "has ignored once" an absorbing state, so every arm went extinct and no lever could be ranked. Jeffreys smoothing; raw and smoothed both kept.

Report: `core/flows/eval/adoption/REVOLUTION-1.md`. Harness: `core/flows/eval/adoption/`.

Owning issue: `DmitriyG228/biz#449`.
