### PR TITLE
feat(meeting-api,gateway): import a transcript — a meeting completed from words it already has

### DIFF
--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -117,6 +117,9 @@ ROUTE_SCOPES: Dict[Tuple[str, str], FrozenSet[str]] = {
     # Minting a share is the same power on either address shape — the row id and the (platform,
     # native) pair name the same meeting; only the pair cannot name all of them.
     ("POST", "/meetings/{meeting_id}/share"): TX,
+    # Importing a transcript writes the caller's OWN meeting — the same plane as annotating or
+    # sharing it, addressed by the row id for the same reason (the pair is not an identity).
+    ("POST", "/meetings/{meeting_id}/transcript-import"): TX,
     ("POST", "/meetings/{platform}/{native_meeting_id}/share"): TX,
     ("POST", "/meetings/{platform}/{native_meeting_id}/workspace"): TX,
     # A participants read is meeting DATA, not bot control — same plane as the transcript it is
@@ -667,6 +670,13 @@ def create_app(
     @app.post("/meetings/{meeting_id}/share")
     async def mint_transcript_share_by_id(meeting_id: int, request: Request):
         return await _forward("POST", _meeting(f"/meetings/{meeting_id}/share"), request)
+
+    # Import a transcript into a meeting the caller owns — "this already happened, here are its
+    # words" — and complete it. Row-id addressed like the mint above; same _forward, so the same
+    # key→identity resolution (X-User-Id) the meeting-api route scopes on.
+    @app.post("/meetings/{meeting_id}/transcript-import")
+    async def import_meeting_transcript(meeting_id: int, request: Request):
+        return await _forward("POST", _meeting(f"/meetings/{meeting_id}/transcript-import"), request)
 
     @app.post("/meetings/{platform}/{native_meeting_id}/share")
     async def mint_transcript_share(platform: str, native_meeting_id: str, request: Request):

--- a/core/gateway/services/gateway/tests/test_scope_matrix.py
+++ b/core/gateway/services/gateway/tests/test_scope_matrix.py
@@ -54,6 +54,7 @@ CASES = [
     ("POST", "/meetings/google_meet/abc-defg-hij/annotate",
      "/meetings/{platform}/{native_meeting_id}/annotate"),
     ("POST", "/meetings/42/share", "/meetings/{meeting_id}/share"),
+    ("POST", "/meetings/42/transcript-import", "/meetings/{meeting_id}/transcript-import"),
     ("POST", "/meetings/google_meet/abc-defg-hij/share",
      "/meetings/{platform}/{native_meeting_id}/share"),
     ("POST", "/meetings/google_meet/abc-defg-hij/workspace",

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -250,6 +250,58 @@ def _segment_to_api(seg: dict) -> dict:
     return out
 
 
+# The ONE definition of a durable transcript write. Two callers reach it — the db-writer's flush
+# of a live meeting's redis hash (``upsert_segments``) and the import route's
+# ``complete_transcript_import`` — and a second copy of this statement would be a second place to
+# get the segment identity wrong. Keyed on ``(meeting_id, segment_id)`` (the partial unique index
+# ``ix_transcription_meeting_segment``): a re-write lands as an UPDATE, never a duplicate row.
+_SEGMENT_UPSERT_SQL = """
+    INSERT INTO transcriptions (meeting_id, start_time, end_time, text, speaker, language, session_uid, segment_id, created_at)
+    VALUES (:mid, :start, :end, :text, :speaker, :lang, :uid, :segid, :created)
+    ON CONFLICT (meeting_id, segment_id) WHERE segment_id IS NOT NULL
+    DO UPDATE SET text = EXCLUDED.text, speaker = EXCLUDED.speaker,
+                  start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time,
+                  language = EXCLUDED.language, created_at = EXCLUDED.created_at
+"""
+
+
+def _segment_upsert_rows(meeting_id, segments) -> "list[dict]":
+    """Normalize a batch of segments into the bind-parameter rows ``_SEGMENT_UPSERT_SQL`` takes.
+    A segment with no ``segment_id`` is skipped (0.12 ingest guarantees one; a legacy stray is
+    skipped, not guessed) and an unparseable start/end likewise."""
+    from datetime import datetime as _dt
+
+    rows = []
+    for seg in segments:
+        sid = seg.get("segment_id")
+        if not sid:
+            continue
+        try:
+            start = float(seg.get("start", seg.get("start_time", 0.0)) or 0.0)
+            end = float(seg.get("end", seg.get("end_time", start)) or start)
+        except (TypeError, ValueError):
+            continue
+        if end < start:
+            start, end = end, start
+        rows.append({
+            "mid": int(meeting_id), "start": start, "end": end,
+            "text": seg.get("text") or "", "speaker": seg.get("speaker"),
+            "lang": seg.get("language"), "uid": seg.get("session_uid"),
+            "segid": str(sid), "created": _dt.utcnow(),
+        })
+    return rows
+
+
+async def _write_segment_rows(db, rows) -> None:
+    """Execute the upsert for every row on an ALREADY-OPEN session, committing nothing. The caller
+    owns the transaction — which is how the import writes the segments and completes the row in one."""
+    from sqlalchemy import text as sql_text  # lazy: not needed for the in-memory fakes
+
+    stmt = sql_text(_SEGMENT_UPSERT_SQL)
+    for row in rows:
+        await db.execute(stmt, row)
+
+
 class SqlAlchemyTranscriptStore:
     """``TranscriptStore`` over a SQLAlchemy-async ``session_factory`` (the ``meetings`` /
     ``transcriptions`` tables; recordings/notes live in ``meeting.data`` JSONB — NO separate
@@ -887,44 +939,104 @@ class SqlAlchemyTranscriptStore:
         ``ix_transcription_meeting_segment`` in the admin-api authoritative schema), exactly the
         parent db-writer's ON CONFLICT statement: idempotent, a re-flushed rewrite lands as an
         UPDATE, never a duplicate row."""
-        from datetime import datetime as _dt
-
-        from sqlalchemy import text as sql_text  # lazy: not needed for the in-memory fakes
-
-        rows = []
-        for seg in segments:
-            sid = seg.get("segment_id")
-            if not sid:
-                continue  # 0.12 ingest guarantees segment_id; a legacy stray is skipped, not guessed
-            try:
-                start = float(seg.get("start", seg.get("start_time", 0.0)) or 0.0)
-                end = float(seg.get("end", seg.get("end_time", start)) or start)
-            except (TypeError, ValueError):
-                continue
-            if end < start:
-                start, end = end, start
-            rows.append({
-                "mid": int(meeting_id), "start": start, "end": end,
-                "text": seg.get("text") or "", "speaker": seg.get("speaker"),
-                "lang": seg.get("language"), "uid": seg.get("session_uid"),
-                "segid": str(sid), "created": _dt.utcnow(),
-            })
+        rows = _segment_upsert_rows(meeting_id, segments)
         if not rows:
             return
         async with self._session_factory() as db:
-            for row in rows:
-                await db.execute(
-                    sql_text("""
-                        INSERT INTO transcriptions (meeting_id, start_time, end_time, text, speaker, language, session_uid, segment_id, created_at)
-                        VALUES (:mid, :start, :end, :text, :speaker, :lang, :uid, :segid, :created)
-                        ON CONFLICT (meeting_id, segment_id) WHERE segment_id IS NOT NULL
-                        DO UPDATE SET text = EXCLUDED.text, speaker = EXCLUDED.speaker,
-                                      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time,
-                                      language = EXCLUDED.language, created_at = EXCLUDED.created_at
-                    """),
-                    row,
-                )
+            await _write_segment_rows(db, rows)
             await db.commit()
+
+    async def complete_transcript_import(self, user_id, meeting_id, *, segments, started_at,
+                                        ended_at, source, session_uid) -> "Optional[dict]":
+        """Land an imported transcript on the caller's row and COMPLETE it — see
+        ``ports.complete_transcript_import`` for the contract.
+
+        ONE transaction, under the same per-user advisory lock ``create_planned_meeting`` and
+        ``annotate_meeting`` take, so an import serializes against a concurrent spawn/calendar-sync
+        on the same user rather than racing it. Inside it: the row lock, the idempotency check, the
+        segment upsert, the status/window write. Either the meeting is completed WITH its words or
+        neither happened — a half-import (segments under a `scheduled` row) is exactly the shape
+        that made the founder's walk read "MEETING · UPCOMING" over a finished call.
+
+        ``start_time``/``end_time`` are written NAIVE UTC, matching the columns (an aware datetime is
+        an asyncpg DataError here — see ``bot_spawn.adapters.update_meeting_status``).
+        """
+        from sqlalchemy import bindparam, func, select, text
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from .models import Meeting, Transcription
+        from .transcript_import import IN_FLIGHT_STATUSES
+
+        try:
+            mid = int(meeting_id)
+        except (TypeError, ValueError):
+            return None
+
+        async with self._session_factory() as db:
+            await db.execute(
+                text("SELECT pg_advisory_xact_lock(:uid)").bindparams(bindparam("uid", user_id))
+            )
+            meeting = (await db.execute(
+                select(Meeting).where(Meeting.id == mid, Meeting.user_id == user_id)
+                .with_for_update()
+            )).scalars().first()
+            # Owner-scoped: a row that is not the caller's answers exactly like one that does not
+            # exist, so this route is no existence oracle — the rule the by-id share mint follows.
+            if meeting is None:
+                return None
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            prior = data.get("transcript_import")
+            if isinstance(prior, dict) and prior.get("session_uid") == session_uid:
+                # The SAME import, again. Nothing is written — not the segments, not the window.
+                # A second call is a no-op that reports what the first one did.
+                return {
+                    "meeting_id": mid, "imported": False, "status": meeting.status,
+                    "segments_imported": int(prior.get("segments") or 0),
+                    "start_time": _iso_utc(meeting.start_time),
+                    "end_time": _iso_utc(meeting.end_time),
+                    "session_uid": session_uid, "source": prior.get("source") or source,
+                    "imported_at": prior.get("imported_at"),
+                }
+            if meeting.status in IN_FLIGHT_STATUSES:
+                return {"error": "conflict", "status": meeting.status}
+
+            rows = _segment_upsert_rows(mid, segments)
+            await _write_segment_rows(db, rows)
+
+            meeting.status = "completed"
+            meeting.start_time = started_at.astimezone(timezone.utc).replace(tzinfo=None)
+            meeting.end_time = ended_at.astimezone(timezone.utc).replace(tzinfo=None)
+            # The provenance, not a completion_reason. `completion_reason` is a BOT fact — why a run
+            # ended — and no bot ran here; writing one would be the double claiming to be a
+            # recording. `transcript_import` says what actually happened, and any reader can tell an
+            # imported meeting from a captured one by asking for it.
+            data["transcript_import"] = {
+                "source": source, "session_uid": session_uid, "segments": len(rows),
+                "started_at": _iso_utc(meeting.start_time),
+                "ended_at": _iso_utc(meeting.end_time),
+                "imported_at": _now().isoformat().replace("+00:00", "Z"),
+            }
+            # The same delivery marker a terminal transition writes (#807), counted the same way —
+            # SELECT COUNT over the durable rows, so it reports what is really in the table rather
+            # than what this call believes it wrote.
+            data["segments_captured"] = (await db.execute(
+                select(func.count()).select_from(Transcription).where(Transcription.meeting_id == mid)
+            )).scalar() or 0
+            meeting.data = data
+            flag_modified(meeting, "data")
+            await db.commit()
+            await db.refresh(meeting)
+            return {
+                "meeting_id": mid, "imported": True, "status": meeting.status,
+                "segments_imported": len(rows),
+                "segments_captured": data["segments_captured"],
+                "start_time": _iso_utc(meeting.start_time),
+                "end_time": _iso_utc(meeting.end_time),
+                "platform": meeting.platform,
+                "native_meeting_id": meeting.platform_specific_id,
+                "session_uid": session_uid, "source": source,
+                "imported_at": data["transcript_import"]["imported_at"],
+            }
 
     async def processed_view_cursor(self, meeting_id, view_id) -> Optional[str]:
         """The ``source_cursor`` of the ``view_id`` view inside ``meeting.data['processed']['views']``

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -897,6 +897,115 @@ def build_router(
             int(payload.get("expires_in_sec", 86400) or 86400),
         )
 
+    # --- POST /meetings/{meeting_id}/transcript-import → complete a meeting FROM A TRANSCRIPT.
+    #
+    # The product feature is "import a transcript": a meeting that already happened somewhere we did
+    # not record — a Zoom export, a TSC recording, minutes from a call nobody sent a bot to — becomes
+    # a first-class Vexa meeting. Everything downstream then treats it as one: the canvas, the by-id
+    # transcript read, search, the post-meeting flows.
+    #
+    # It is ALSO the honest capture double. The rehearsal rig used to build this row by hand —
+    # `docker exec … psql` INSERTing `transcriptions` and UPDATEing `meetings` with the DB password
+    # it read out of another container — because meeting-api owned the two things the double needed
+    # and exposed neither: a way to put words on a row, and a way to say WHEN the meeting was (a bot
+    # run stamps start/end from `now()`, so a call that happened last Tuesday was inexpressible).
+    # That shell-out is the audit's V4/N5 — a second writer on a table this service owns, building
+    # SQL by string-interpolating speaker names, and it produced rows the product never makes
+    # (`scheduled`, NULL start/end) which read as "UPCOMING" over a finished meeting. One route
+    # closes the feature gap and the ownership hole at once, which is why `source` is declared
+    # rather than inferred: a reader can always tell a double from a real import.
+    #
+    # ROW ID, not the (platform, native) pair — the same lesson the by-id share mint above records:
+    # the pair is not an identity, and the rows most likely to be imported into are exactly the ones
+    # no pair addresses. Three segments against the pair routes' four, so neither can shadow the
+    # other; registered before them anyway, matching the `by-id` precedent.
+    #
+    # Owner-scoped, and refused (409) while a bot is in flight on the row — the FSM is never fought.
+    @router.post("/meetings/{meeting_id}/transcript-import")
+    async def import_transcript(
+        meeting_id: int,
+        request: Request,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        from .transcript_import import (SOURCES, normalize_segments, occurrence_window,
+                                        session_uid_for)
+
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=422, detail="invalid JSON body")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=422, detail="body must be an object")
+
+        source = str(payload.get("source") or "import").strip()
+        if source not in SOURCES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"'source' must be one of {sorted(SOURCES)} — say where the transcript came from",
+            )
+        session_uid = session_uid_for(source, meeting_id)
+        segments, reason = normalize_segments(payload.get("segments"), session_uid)
+        if reason:
+            raise HTTPException(status_code=422, detail=reason)
+        started_at, ended_at, reason = occurrence_window(
+            segments, payload.get("started_at"), payload.get("ended_at"),
+        )
+        if reason:
+            raise HTTPException(status_code=422, detail=reason)
+
+        result = await store.complete_transcript_import(
+            user_id, meeting_id, segments=segments, started_at=started_at, ended_at=ended_at,
+            source=source, session_uid=session_uid,
+        )
+        if result is None:
+            log_event(
+                "transcript_import_failed", audience="system", level="warning",
+                span="meetings.transcript.import", user_id=user_id, meeting_id=str(meeting_id),
+                fields={"source": source, "reason": "no such meeting for this owner"},
+            )
+            raise HTTPException(status_code=404, detail=f"Meeting {meeting_id} not found")
+        if result.get("error") == "conflict":
+            raise HTTPException(
+                status_code=409,
+                detail=(f"Meeting {meeting_id} is {result.get('status')} — a bot is in flight on it. "
+                        "A live meeting is completed by its bot, not by an import."),
+            )
+
+        if result.get("imported"):
+            # What a real completion emits, emitted here for the same reason: the terminal learns a
+            # meeting's status from the `u:{user}:meetings` frame the gateway `/ws` forwards
+            # (surfaces/gatewayWS.ts), and its live view of a meeting ends on the `session_end`
+            # marker the collector appends to `tc:meeting:{id}` (ingest._transcript_stream). Both are
+            # best-effort, like every other publish on this path — the durable row is the truth.
+            #
+            # What is deliberately NOT emitted: the segments themselves, into the live stream. They
+            # went through it during a real call because the call was happening. Replaying an
+            # already-finished transcript as live frames would be a fake liveness, and the canvas
+            # reads a completed meeting from `GET /transcripts/by-id/{id}` anyway.
+            await _publish_user_meeting_status(
+                redis, user_id=user_id, meeting_id=result.get("meeting_id"),
+                native_id=result.get("native_meeting_id"), status="completed",
+                when=result.get("end_time"), log_event=log_event,
+            )
+            if redis is not None:
+                try:
+                    await redis.xadd(f"tc:meeting:{result['meeting_id']}",
+                                     {"type": "session_end", "uid": session_uid})
+                except Exception as e:  # noqa: BLE001 — best-effort marker; never fail the import
+                    log_event("transcript_import_marker_failed", audience="system", level="warning",
+                              span="meetings.transcript.import", user_id=user_id,
+                              meeting_id=str(meeting_id), fields={"error": str(e)})
+
+        log_event(
+            "transcript_imported", audience="user", span="meetings.transcript.import",
+            user_id=user_id, meeting_id=str(meeting_id),
+            fields={"source": source, "segments": result.get("segments_imported"),
+                    "imported": bool(result.get("imported")),
+                    "start_time": result.get("start_time"), "end_time": result.get("end_time")},
+        )
+        return JSONResponse(content=result)
+
     # --- POST /meetings/{meeting_id}/share → the SAME mint, addressed by the ROW's primary key.
     #
     # Why it exists: the (platform, native) pair is not an identity. A meeting planned from an invite

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -803,6 +803,65 @@ class InMemoryTranscriptStore:
             if sid:
                 m["segments"][sid] = dict(seg)
 
+    async def complete_transcript_import(self, user_id, meeting_id, *, segments, started_at,
+                                        ended_at, source, session_uid):
+        """Mirror of the SqlAlchemy store's import — same owner scope, same idempotency on
+        ``session_uid``, same FSM refusal, same row shape afterwards. Most of the suite drives this
+        fake, so the two must agree on every branch a caller can observe."""
+        from datetime import datetime as _now_dt
+        from datetime import timezone
+
+        from .transcript_import import IN_FLIGHT_STATUSES
+
+        def _iso(dt):
+            return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+        try:
+            mid = int(meeting_id)
+        except (TypeError, ValueError):
+            return None
+        m = self._meetings.get(mid)
+        if m is None or m.get("user_id") != user_id:
+            return None  # owner-scoped: not-yours is indistinguishable from not-there
+        data = m["data"] if isinstance(m.get("data"), dict) else {}
+        prior = data.get("transcript_import")
+        if isinstance(prior, dict) and prior.get("session_uid") == session_uid:
+            return {
+                "meeting_id": mid, "imported": False, "status": m["status"],
+                "segments_imported": int(prior.get("segments") or 0),
+                "start_time": m["start_time"], "end_time": m["end_time"],
+                "session_uid": session_uid, "source": prior.get("source") or source,
+                "imported_at": prior.get("imported_at"),
+            }
+        if m["status"] in IN_FLIGHT_STATUSES:
+            return {"error": "conflict", "status": m["status"]}
+
+        written = 0
+        for seg in segments:
+            sid = seg.get("segment_id")
+            if not sid:
+                continue
+            m["segments"][sid] = dict(seg)
+            written += 1
+        m["status"] = "completed"
+        m["start_time"] = _iso(started_at)
+        m["end_time"] = _iso(ended_at)
+        data["transcript_import"] = {
+            "source": source, "session_uid": session_uid, "segments": written,
+            "started_at": m["start_time"], "ended_at": m["end_time"],
+            "imported_at": _iso(_now_dt.now(timezone.utc)),
+        }
+        data["segments_captured"] = len(m["segments"])
+        m["data"] = data
+        return {
+            "meeting_id": mid, "imported": True, "status": "completed",
+            "segments_imported": written, "segments_captured": data["segments_captured"],
+            "start_time": m["start_time"], "end_time": m["end_time"],
+            "platform": m["platform"], "native_meeting_id": m["native_meeting_id"],
+            "session_uid": session_uid, "source": source,
+            "imported_at": data["transcript_import"]["imported_at"],
+        }
+
     async def processed_view_cursor(self, meeting_id, view_id) -> Optional[str]:
         from .adapters import _find_processed_view
 

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -104,6 +104,29 @@ class TranscriptStore(Protocol):
         same one-time token as the pair-keyed mint; ``None`` when the row is unknown OR not the caller's."""
         ...
 
+    async def complete_transcript_import(
+        self, user_id: int, meeting_id: int, *, segments: list, started_at, ended_at,
+        source: str, session_uid: str,
+    ) -> "Optional[dict]":
+        """OWNER-scoped: land an ALREADY-HAPPENED meeting's transcript on the row and complete it.
+
+        The import route's whole persistence. One transaction: the segments are upserted into
+        ``transcriptions`` through the SAME sink the db-writer flushes with (the ``(meeting_id,
+        segment_id)`` identity), the row's ``status`` becomes ``completed``, ``start_time`` /
+        ``end_time`` become the window the caller states (the ONE thing a bot run cannot express —
+        it derives both from ``now()``), and ``data.transcript_import`` records the provenance.
+
+        IDEMPOTENT on ``session_uid``, which the caller derives from ``(source, meeting_id)``: a
+        second import of the same source onto the same row writes NOTHING and reports
+        ``imported: False``. The segment ids are derived from the same ``session_uid``, so even a
+        write that did land twice would upsert in place rather than duplicate.
+
+        Returns the completed row summary, ``{"error": "conflict", ...}`` when the row is inside the
+        bot FSM (this never fights the FSM — a live meeting is completed by its bot, not by an
+        import), or ``None`` when the caller owns no such row (→ 404, no existence oracle).
+        """
+        ...
+
     async def redeem_transcript_share(
         self, user_id: int, user_email: "Optional[str]", token: str
     ) -> "Optional[dict]":

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/transcript_import.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/transcript_import.py
@@ -1,0 +1,167 @@
+"""Transcript IMPORT — the pure half of "this meeting already happened, here are its words".
+
+The product feature is *bring a transcript Vexa did not record* (a Zoom export, an LFX/TSC
+recording, minutes from a call nobody sent a bot to) into a meeting row, so everything
+downstream — the canvas, ``GET /transcripts/by-id/{id}``, search, the post-meeting flows — sees
+it exactly as it sees a recorded one. The capture double the rehearsal rig runs is the SAME
+feature with ``source='seed'``; that is why there is one route and not two.
+
+Everything here is pure: parse, validate, derive. The persistence lives in the store
+(``TranscriptStore.complete_transcript_import``) — this module is imported by the route, by both
+store implementations, and by the tests, so the identity of an import has ONE definition.
+
+**The identity of an import is ``(source, meeting_id)``.** That derives the ``session_uid``, which
+derives every segment id. A bot run's session uid is a uuid4 minted per spawn — right for a run
+that could happen twice, wrong here: importing the same source into the same meeting a second time
+is the SAME import, not a second one. Deriving rather than minting is what makes the route
+idempotent at the row AND at the segment (a re-write upserts on ``(meeting_id, segment_id)``
+instead of doubling the transcript, which is what a hand-rolled ``INSERT … ON CONFLICT DO
+NOTHING`` with a fresh uuid could never guarantee).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+# The declared origins of an import. ``import`` is a person bringing a transcript from elsewhere;
+# ``seed`` is the rehearsal rig's capture double. They differ ONLY in the provenance recorded on
+# the row — a reader can always tell a double from a real import, which is the whole point of
+# naming the source rather than letting the double pretend to be a recording.
+SOURCES = frozenset({"import", "seed"})
+
+# A cap, refused rather than truncated: silently storing part of what a caller sent is a worse
+# failure than telling them it did not fit (the same rule `annotate_meeting` applies to metadata).
+MAX_SEGMENTS = 20000
+MAX_TEXT = 8000
+
+
+def session_uid_for(source: str, meeting_id: int) -> str:
+    """The import's session identity — DERIVED, never minted. See the module docstring."""
+    return f"import-{source}-{int(meeting_id)}"
+
+
+def segment_id_for(session_uid: str, index: int) -> str:
+    """The segment identity the ``(meeting_id, segment_id)`` upsert keys on. Positional inside the
+    import, so re-importing a corrected transcript UPDATES each segment in place."""
+    return f"{session_uid}-{index:06d}"
+
+
+def parse_instant(raw) -> Optional[datetime]:
+    """ISO-8601 (``Z`` accepted) or epoch seconds → an aware UTC datetime. ``None`` when neither.
+
+    Both shapes because the two callers already speak both: a calendar/export stamp is ISO, a
+    recording tool's is epoch. Refusing one of them would just move the conversion into every
+    caller, where it would be written slightly differently each time.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        try:
+            return datetime.fromtimestamp(float(raw), timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    try:
+        if s.replace(".", "", 1).lstrip("-").isdigit():
+            return datetime.fromtimestamp(float(s), timezone.utc)
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt).astimezone(timezone.utc)
+
+
+def normalize_segments(raw, session_uid: str) -> "tuple[Optional[list], Optional[str]]":
+    """``[{start, end, speaker, text, language?}, …]`` → the store's segment shape, or an error.
+
+    Returns ``(segments, None)`` or ``(None, reason)``. The reason is returned rather than raised
+    so the route decides the status code and the tests can assert the sentence a caller reads.
+
+    Deliberately STRICTER than the live-stream coercion in ``ingest._coerce_segment``: that one
+    drops a malformed segment and keeps the stream flowing, because a live meeting must not stop
+    for one bad frame. An import is a single, whole artifact a person handed us — dropping part of
+    it silently would hand them back a transcript with holes they cannot see. So one bad segment
+    refuses the whole import and names its index.
+    """
+    if not isinstance(raw, list) or not raw:
+        return None, "'segments' must be a non-empty array"
+    if len(raw) > MAX_SEGMENTS:
+        return None, f"'segments' exceeds the {MAX_SEGMENTS}-segment cap ({len(raw)} sent)"
+    out = []
+    for i, seg in enumerate(raw):
+        if not isinstance(seg, dict):
+            return None, f"segment {i}: must be an object"
+        try:
+            start = float(seg.get("start"))
+            end = float(seg.get("end", seg.get("start")))
+        except (TypeError, ValueError):
+            return None, f"segment {i}: 'start' and 'end' must be numbers (seconds from the start)"
+        if start < 0 or end < 0:
+            return None, f"segment {i}: 'start' and 'end' are seconds from the start, never negative"
+        if end < start:
+            start, end = end, start
+        text = seg.get("text")
+        if text is not None and not isinstance(text, str):
+            return None, f"segment {i}: 'text' must be a string"
+        text = (text or "").strip()
+        if len(text) > MAX_TEXT:
+            return None, f"segment {i}: 'text' exceeds {MAX_TEXT} characters"
+        speaker = seg.get("speaker")
+        if speaker is not None and not isinstance(speaker, str):
+            return None, f"segment {i}: 'speaker' must be a string"
+        language = seg.get("language")
+        if language is not None and not isinstance(language, str):
+            return None, f"segment {i}: 'language' must be a string"
+        out.append({
+            "segment_id": segment_id_for(session_uid, i),
+            "session_uid": session_uid,
+            "start": start,
+            "end": end,
+            "text": text,
+            "speaker": (speaker or None),
+            "language": (language or None),
+            "completed": True,
+        })
+    return out, None
+
+
+def occurrence_window(
+    segments: list, started_at, ended_at,
+) -> "tuple[Optional[datetime], Optional[datetime], Optional[str]]":
+    """The meeting's real occurrence window: ``(start, end, None)`` or ``(None, None, reason)``.
+
+    ``started_at`` is REQUIRED and is the single fact an import carries that a bot run cannot: a
+    run's ``start_time``/``end_time`` are stamped from ``now()`` at the FSM's transitions, so a
+    meeting that happened last Tuesday is not expressible through the bot path at all. That is
+    exactly why the rehearsal rig used to reach past the service and ``UPDATE meetings`` by hand.
+
+    ``ended_at`` is optional: absent, the end is the start plus the transcript's own length (the
+    last segment's ``end`` is seconds from the start of the capture, so it IS the duration). An
+    ``ended_at`` BEFORE the start is refused rather than swapped — an inverted window is a caller
+    bug, and silently reordering it would seed the meeting at a time nobody asked for.
+    """
+    start = parse_instant(started_at)
+    if start is None:
+        return None, None, "'started_at' is required — ISO-8601 or epoch seconds"
+    duration = max((float(s["end"]) for s in segments), default=0.0)
+    end = parse_instant(ended_at)
+    if ended_at not in (None, "") and end is None:
+        return None, None, "'ended_at' is neither ISO-8601 nor epoch seconds"
+    if end is None:
+        end = start + timedelta(seconds=duration)
+    if end < start:
+        return None, None, "'ended_at' is before 'started_at'"
+    return start, end, None
+
+
+# The statuses that mean a BOT IS IN FLIGHT on this row. An import is refused on all of them: the
+# FSM is never fought (`update_planned_meeting` refuses for the same reason), and a transcript
+# landing under a running bot would interleave two capture sources on one meeting. Terminal
+# (`completed`/`failed`) is NOT here — a finished row may be re-imported (idempotently), and the
+# intent statuses (`idle`/`scheduled`) are the normal case: a planned row that has now happened.
+IN_FLIGHT_STATUSES = frozenset({
+    "requested", "joining", "awaiting_admission", "needs_help", "active", "stopping",
+})

--- a/core/meetings/services/meeting-api/tests/test_transcript_import.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_import.py
@@ -1,0 +1,193 @@
+"""Transcript IMPORT — a meeting completed from words it already has.
+
+The feature: bring a transcript Vexa did not record (a Zoom export, a TSC recording) into a
+meeting row so the product treats it exactly like a captured one. The same route is the rehearsal
+rig's capture double (`source="seed"`), which is why the audit's V4/N5 shell-out into this
+service's database has somewhere to go.
+
+Offline over the in-memory fake — no docker, no postgres:
+  * import → the row is `completed`, with the occurrence window the CALLER stated (the one fact a
+    bot run cannot express: it stamps start/end from `now()`);
+  * the segments read back through `GET /transcripts/by-id/{id}`, in order;
+  * a second import of the same source is a NO-OP — nothing rewritten, `imported: false`;
+  * a non-owner is refused, and refused identically to an unknown row (no existence oracle);
+  * a row with a bot in flight is refused 409 — the FSM is never fought;
+  * malformed bodies are refused whole (an import is one artifact; a hole a caller cannot see is
+    worse than a rejection they can read).
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+OWNER, STRANGER = 11, 12
+PLAT, NID = "jitsi", "dna-tsc-2026-08-03"
+WHEN = "2026-08-03T14:00:00Z"
+
+SEGS = [
+    {"start": 0.0, "end": 4.5, "speaker": "Larry", "text": "Welcome to the TSC call."},
+    {"start": 4.5, "end": 9.25, "speaker": "Marvin", "text": "Two items on the agenda today."},
+    {"start": 9.25, "end": 15.0, "speaker": "Larry", "text": "Let us start with the first."},
+]
+
+
+def _client(status="scheduled", user_id=OWNER):
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=user_id, platform=PLAT, native_meeting_id=NID,
+                             status=status, start_time=None, end_time=None)
+    return TestClient(create_app(store, redis=None)), store, mid
+
+
+def _import(client, mid, uid=OWNER, **over):
+    body = {"segments": SEGS, "started_at": WHEN, "source": "import"}
+    body.update(over)
+    return client.post(f"/meetings/{mid}/transcript-import", json=body,
+                       headers={"x-user-id": str(uid)})
+
+
+def test_import_completes_the_row_with_the_stated_occurrence_window():
+    client, _store, mid = _client()
+    r = _import(client, mid)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["imported"] is True
+    assert body["status"] == "completed"
+    assert body["segments_imported"] == 3
+    # The window the CALLER stated, not `now()` — a meeting that happened last Tuesday is
+    # expressible, which is the whole reason the rig used to UPDATE the columns by hand.
+    assert body["start_time"].startswith("2026-08-03T14:00:00")
+    # No `ended_at` given → the transcript's own length (last segment's end = 15s).
+    assert body["end_time"].startswith("2026-08-03T14:00:15")
+    assert body["session_uid"] == f"import-import-{mid}"
+
+
+def test_explicit_ended_at_wins_over_the_transcripts_length():
+    client, _store, mid = _client()
+    r = _import(client, mid, ended_at="2026-08-03T15:30:00Z")
+    assert r.status_code == 200
+    assert r.json()["end_time"].startswith("2026-08-03T15:30:00")
+
+
+def test_imported_segments_read_back_through_the_by_id_transcript():
+    """The product read a terminal canvas uses — an imported meeting must look like a recorded one."""
+    client, _store, mid = _client()
+    _import(client, mid)
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)})
+    assert doc.status_code == 200
+    body = doc.json()
+    assert body["status"] == "completed"
+    assert body["start_time"].startswith("2026-08-03T14:00:00")
+    texts = [s["text"] for s in body["segments"]]
+    assert texts == [s["text"] for s in SEGS]           # in order
+    assert body["segments"][1]["speaker"] == "Marvin"   # speakers survive
+
+
+def test_a_second_import_of_the_same_source_writes_nothing():
+    client, store, mid = _client()
+    first = _import(client, mid).json()
+    doc_before = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+
+    again = _import(client, mid)
+    assert again.status_code == 200
+    assert again.json()["imported"] is False
+    assert again.json()["segments_imported"] == first["segments_imported"]
+    assert again.json()["imported_at"] == first["imported_at"]  # the FIRST import's stamp
+
+    doc_after = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert doc_after["segments"] == doc_before["segments"]      # not doubled, not rewritten
+    assert len(doc_after["segments"]) == 3
+
+
+def test_a_changed_transcript_from_the_same_source_is_still_one_import():
+    """Idempotency is on the SOURCE, not on the bytes: re-sending different words for the same
+    (source, meeting) is the same import, and does not silently rewrite the meeting."""
+    client, _store, mid = _client()
+    _import(client, mid)
+    again = _import(client, mid, segments=[{"start": 0.0, "end": 1.0, "speaker": "X", "text": "different"}])
+    assert again.status_code == 200 and again.json()["imported"] is False
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert [s["text"] for s in doc["segments"]] == [s["text"] for s in SEGS]
+
+
+def test_a_different_source_is_a_different_import():
+    """`seed` and `import` derive different session uids, so the double and a real import of the
+    same meeting are distinguishable — and neither is mistaken for the other's replay."""
+    client, _store, mid = _client()
+    assert _import(client, mid, source="seed").json()["session_uid"] == f"import-seed-{mid}"
+    assert _import(client, mid, source="seed").json()["imported"] is False
+
+
+def test_non_owner_is_refused_exactly_like_an_unknown_row():
+    client, _store, mid = _client()
+    mine = _import(client, mid, uid=STRANGER)
+    unknown = _import(client, 987654, uid=STRANGER)
+    assert mine.status_code == 404 and unknown.status_code == 404
+    assert mine.json()["detail"] == f"Meeting {mid} not found"
+    assert unknown.json()["detail"] == "Meeting 987654 not found"
+    # and nothing was written
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert doc["status"] == "scheduled" and doc["segments"] == []
+
+
+def test_a_row_with_a_bot_in_flight_is_refused():
+    for live in ("joining", "active", "awaiting_admission", "stopping"):
+        client, _store, mid = _client(status=live)
+        r = _import(client, mid)
+        assert r.status_code == 409, f"{live} → {r.status_code}"
+        assert live in r.json()["detail"]
+
+
+def test_an_already_completed_row_may_be_imported_into():
+    """A meeting whose bot ran and completed is terminal, not in flight — importing an external
+    transcript onto it is a legitimate act (a better recording of the same call)."""
+    client, _store, mid = _client(status="completed")
+    assert _import(client, mid).status_code == 200
+
+
+def test_malformed_bodies_are_refused_whole():
+    client, _store, mid = _client()
+    cases = [
+        ({"segments": [], "started_at": WHEN}, "non-empty"),
+        ({"segments": SEGS}, "started_at"),
+        ({"segments": SEGS, "started_at": "yesterday"}, "started_at"),
+        ({"segments": SEGS, "started_at": WHEN, "ended_at": "2026-08-03T13:00:00Z"}, "before"),
+        ({"segments": SEGS, "started_at": WHEN, "source": "recording"}, "source"),
+        ({"segments": [{"start": "x", "end": 1}], "started_at": WHEN}, "segment 0"),
+        ({"segments": [{"start": 0, "end": 1, "text": 5}], "started_at": WHEN}, "segment 0"),
+    ]
+    for body, needle in cases:
+        r = client.post(f"/meetings/{mid}/transcript-import", json=body,
+                        headers={"x-user-id": str(OWNER)})
+        assert r.status_code == 422, f"{body} → {r.status_code}"
+        assert needle in r.json()["detail"], f"{body} → {r.json()['detail']}"
+    # the row is untouched by every one of them
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert doc["status"] == "scheduled" and doc["segments"] == []
+
+
+def test_identity_is_required():
+    client, _store, mid = _client()
+    r = client.post(f"/meetings/{mid}/transcript-import",
+                    json={"segments": SEGS, "started_at": WHEN})
+    assert r.status_code == 401
+
+
+def test_the_import_route_does_not_shadow_the_share_pair_route():
+    """Three segments against four — and a non-numeric id is refused by validation here rather than
+    resolved as a platform name. The property the by-id share mint relies on, asserted again."""
+    client, _store, mid = _client()
+    r = client.post("/meetings/google_meet/transcript-import",
+                    json={"segments": SEGS, "started_at": WHEN}, headers={"x-user-id": str(OWNER)})
+    assert r.status_code == 422
+    ok = client.post(f"/meetings/{PLAT}/{NID}/share", json={"mode": "open"},
+                     headers={"x-user-id": str(OWNER)})
+    assert ok.status_code == 200
+
+
+def test_epoch_seconds_are_accepted_for_the_window():
+    client, _store, mid = _client()
+    r = _import(client, mid, started_at=1785765600)   # 2026-08-03T14:00:00Z
+    assert r.status_code == 200
+    assert r.json()["start_time"].startswith("2026-08-03T14:00:00")


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.** No money, no dates promised to anyone, no rights, no published terms. The one precedent worth naming is internal: this is the first route by which a transcript enters Vexa without a bot having produced it.

## Symptom

Two of them, and they are the same hole seen from opposite sides.

**The product side.** A meeting that already happened somewhere we did not record — a Zoom export, a TSC recording, minutes from a call nobody sent a bot to — had no way into Vexa. There is no route that puts words on a meeting, and no route at all that says *when* a meeting was: `start_time`/`end_time` are stamped from `now()` at the FSM's `active` and terminal edges (`bot_spawn/adapters.py` `update_meeting_status`), and `PATCH /meetings/{id}` refuses a row that entered the FSM. A call that happened last Tuesday was inexpressible through the service.

**The seam side.** Because of that, the rehearsal rig's capture double (`meeting_seed`) reached past the service entirely: `docker inspect vexa-dogfood-postgres-1` for `POSTGRES_PASSWORD`, then `docker exec … psql` to INSERT `meeting_sessions` (the row only `bot_spawn` creates, forged so a lifecycle callback would resolve) and `transcriptions` (SQL built by string-interpolating speaker names and transcript text), a climb through the bot FSM over a callback meant for a browser, and finally `UPDATE meetings SET start_time=…, end_time=…` to correct the two columns the service had just filled with `now()`. The architecture audit (`biz` `drafts/2026-09-02-architecture-audit-report.md` §4) names this **V4/N5** — four writers on tables meeting-api owns, from another domain — and prescribes exactly this fix: *"seeding goes through a meeting-api ingest endpoint"*.

The cost was not theoretical. Without a way to complete a row, the double stopped at `POST /meetings`, which mints an **intent** row — `scheduled`, NULL start/end. The terminal reads that shape and says so: `meetingPhase()` buckets `idle`/`scheduled` as `prep`, so the founder opened a finished meeting and was shown **"MEETING · UPCOMING"** with the prep greeting. Twice. And this morning his own meeting could not be completed at all, because the only path was a direct DB write with the DB password, which the permission layer refused.

## Change

**`POST /meetings/{meeting_id}/transcript-import`** — body `{segments:[{start,end,speaker,text,language?}], started_at, ended_at?, source:"import"|"seed"}`.

| | |
|---|---|
| `core/meetings/services/meeting-api/src/meeting_api/collector/transcript_import.py` | new — the pure half: parse, validate, and **derive the identity of an import** |
| `…/collector/app.py:889` | the route |
| `…/collector/adapters.py:253` `:766` `:1041` | `_SEGMENT_UPSERT_SQL` factored to one definition; `complete_transcript_import` |
| `…/collector/fakes.py:806` · `ports.py:100` | the mirror and the contract |
| `core/gateway/services/gateway/src/gateway/app.py:118` `:679` | `ROUTE_SCOPES` (TX) + the passthrough |

Five decisions worth reading:

- **Addressed by ROW ID**, not the `(platform, native)` pair — the same lesson `30bb2dd96` records: the pair is not an identity, and a link-less planned row is exactly the kind most likely to be imported into. Three segments against the pair routes' four, so on segment count alone neither can shadow the other.
- **The identity of an import is `(source, meeting_id)`** — that derives the `session_uid`, which derives every segment id. A bot run's session uid is a `uuid4` per spawn: right for a run that can happen twice, wrong here, because re-importing the same source into the same meeting is the *same* import. So a second call writes nothing at all and reports `imported: false`; and because the ids are derived, a write that did land twice upserts on `(meeting_id, segment_id)` rather than doubling the transcript — which a fresh uuid plus `ON CONFLICT DO NOTHING` could never promise.
- **One transaction**, under the same per-user advisory lock `create_planned_meeting` takes: segments, status flip and occurrence window together. A half-import — segments under a `scheduled` row — *is* the "UPCOMING over a finished call" defect.
- **Provenance, not a `completion_reason`.** `completion_reason` is a bot fact; no bot ran. `data.transcript_import = {source, session_uid, segments, started_at, ended_at, imported_at}` says what happened, and `source` is declared rather than inferred so a reader can always tell a double from a real import.
- **409 while a bot is in flight.** The FSM is never fought. Terminal rows *are* importable — a better recording of a call we did capture is a legitimate import.

It emits what a real completion emits, because the terminal learns from exactly those two: the `meeting.status` frame on `u:{user}:meetings` that the gateway `/ws` forwards, and the `session_end` marker on `tc:meeting:{id}`. Deliberately **not** emitted: the segments as live stream frames. They rode that stream during a real call because the call was happening; replaying a finished transcript as live would be fake liveness, and the canvas reads a completed meeting from `GET /transcripts/by-id/{id}`.

## Proof

**Offline** — 13 tests in `tests/test_transcript_import.py` + 1 gateway scope-matrix case. Full suites: meeting-api **1329 passed / 5 skipped**, gateway **339 passed / 1 xfailed**. Gates `isolation-py`, `graph-py`, `test-isolation`, `dataflow`, `db-budget`, `db-schema`, `schema`, `contract-version` green.

**Live**, on the `vexa-dogfood` stack (`line-544ceb17d-import` = this commit + `30bb2dd96` cherry-picked onto the deployed base `544ceb17d`), as the loop identity (uid 68), importing the DNA TSC 2026-08-03 fixture, 2026-09-02T09:25:44Z:

```
POST /meetings                        201  id=103  status=scheduled  jitsi/dna-tsc-20260803-import-proof
POST /meetings/103/transcript-import  200  imported=true  segments_imported=522  segments_captured=522
                                           status=completed  2026-08-03T20:00:00Z → 21:00:00Z
GET  /transcripts/by-id/103           200  522 segments, first "Hey, Ben, how's it going?" … last "Thanks. Bye-bye."
POST … again                          200  imported=false  (segments still 522 — not doubled, not rewritten)
GET  /meetings/103                    200  completed, window intact, in the caller's list
```

## Rig

`deploy/dogfood/rig/vexa_control_mcp.py` `meeting_seed` is now a thin forward — `POST /meetings` then `POST /meetings/{id}/transcript-import`, both through the gateway on the caller's own key. No docker, no psql, no password read out of another container. Same arguments (`occurred_at` still accepted as the old name for `started_at`), same loud refusals. Pushed on `mcp-rehearsal-rig` as `f894e06a4`; the control MCP has **not** been restarted (the founder is in a live session).

Owning issue: [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449).

<!-- vexa-agent -->
