### PR TITLE
scaffold(terminal): render the chat from the scaffold record, and collapse to one composition path (PRD §5.5 step 3)

### DIFF
--- a/clients/terminal/src/app/App.tsx
+++ b/clients/terminal/src/app/App.tsx
@@ -41,6 +41,7 @@ function InviteGate({ children }: { children: ReactNode }) {
   const setup = params.get("setup");       // ?setup=global — MINUTES: the admin org-tier conversation
   const view = params.get("view");         // ?view=meeting:<ref>,file:<path>,readme — a COMPOSED layout
   const ask = params.get("ask");           // ?ask=<preset> — MINUTES: open a chat already primed
+  const scaffold = params.get("s");        // ?s=<id> — THE SCAFFOLD: one record per arrival (§5.5)
 
   // MINUTES `?setup=global`: the ADMIN company-layer conversation. It stashes a PRESET — the same
   // `vexa.pendingPreset` every emailed `?ask=` link stashes — so the opening turn comes from
@@ -91,6 +92,19 @@ function InviteGate({ children }: { children: ReactNode }) {
     } catch { /* locked-down storage */ }
     if (!invite && !tshare) window.location.replace(window.location.pathname);
   }, [ask, invite, tshare]);
+
+  // `?s=<id>` — THE SCAFFOLD (PRD §5.5). The link carries an ID and nothing else: no prompt text,
+  // no mount set, no tabs. The terminal fetches the record as the signed-in identity and renders a
+  // chat from it, and the agent is handed the same record — one record, two renderers, so neither
+  // side composes from whatever was there before.
+  //
+  // Same stash-and-clean discipline as `?ask=`: the URL is cleaned on landing so a reload does not
+  // re-open a spent arrival, and the id travels to MinutesShell through storage.
+  useEffect(() => {
+    if (!scaffold) return;
+    try { localStorage.setItem("vexa.pendingScaffold", scaffold); } catch { /* locked-down storage */ }
+    if (!invite && !tshare) window.location.replace(window.location.pathname);
+  }, [scaffold, invite, tshare]);
 
   // A `?meeting=` deep-link: stash the ref for the workbench first-view resolver, then clean the URL
   // (reload so the stash is in place before the grid mounts) — unless an invite/tshare owns the reload.

--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -32,12 +32,13 @@ import {
 import { resolveDocRef } from "../ui-kit/docLinks";
 import { Rail } from "./Rail";
 import { meetingPhase, type MeetingMock } from "../surfaces/meetingModel";
+import { fetchScaffold, localScaffold, refusalCopy, scaffoldToChat, type Scaffold, type ScaffoldRefusal } from "./scaffold";
 import { artifactsFromTokens, pageForDocRef, pageForMeetingRef, pagesForPhase, resolveView, VIEW_KEY } from "./roomView";
 import { applyProposal, proposals, type Proposal } from "./proposals";
 import { ProposalChips } from "./ProposalChips";
 import { EdgeHandle, EDGE_W } from "./Collapse";
 import { MOCK_CHATS, MOCK_MEETINGS, mockBody, mockOn } from "./mockPhases";
-import { T, maxPagesW, surface } from "./tokens";
+import { T, maxPagesW, surface, type as ty } from "./tokens";
 import { useService } from "../platform";
 import { LayoutServiceId } from "../workbench/layout";
 import type { Page, Sel } from "./types";
@@ -49,9 +50,13 @@ const PERSONAL_SEL: Sel = { kind: "chat", chatId: PERSONAL_CHAT_ID, label: "Pers
  *  so it can never land in whichever conversation happens to be visible. `say` is the visible form
  *  for a chip whose words are the user's own; without one the turn arrives hidden, as system kickoffs
  *  always have. */
-const fireKick = (session: string, prompt: string, say?: string) =>
+const fireKick = (session: string, prompt: string, say?: string, scaffoldId?: string) =>
   window.setTimeout(() => window.dispatchEvent(new CustomEvent(ASK_CHAT_EVENT,
-    { detail: { hidden: !say, display: say, session, prompt } })), 1200);
+    // `scaffoldId` rides with the FIRST turn so dispatch can read the same record the panel
+    // rendered from (PRD §5.5: one record, two renderers). Without it the server would have to
+    // re-derive mounts and opening from the session, which is the composed-from-whatever-was-there
+    // problem the scaffold exists to end.
+    { detail: { hidden: !say, display: say, session, prompt, scaffoldId } })), 1200);
 
 export function MinutesShell() {
   const layout = useService(LayoutServiceId);
@@ -293,14 +298,14 @@ export function MinutesShell() {
     return row ? await openRow(row, opts) : null;
   }, [openRow]);
 
-  const addChat = useCallback((label: string, workspaces: string[], opts: { id?: string; kick?: string; say?: string; meeting?: string; artifacts?: Artifact[]; focus?: string } = {}) => {
+  const addChat = useCallback((label: string, workspaces: string[], opts: { id?: string; kick?: string; say?: string; meeting?: string; artifacts?: Artifact[]; focus?: string; scaffoldId?: string } = {}) => {
     const base = newChat(label, workspaces, { id: opts.id, touched: true, meeting: opts.meeting });
     // A preset's declared tabs ARE the chat's opening artifacts — see openRow. A chat born from a
     // link is the one case where the record is written before a human has touched the panel.
     const c = opts.artifacts?.length ? { ...base, artifacts: opts.artifacts, focus: opts.focus } : base;
     persist((prev) => upsertChat(prev, c));
     void openChat(c);
-    if (opts.kick) fireKick(c.id, opts.kick, opts.say);
+    if (opts.kick) fireKick(c.id, opts.kick, opts.say, opts.scaffoldId);
     return c;
   }, [openChat, persist]);
 
@@ -602,6 +607,73 @@ export function MinutesShell() {
   // preset fires anyway after this, naming the meeting less well rather than not at all.
   const [presetWaited, setPresetWaited] = useState(false);
   const presetTimer = useRef(false);
+
+  /** THE ONE PATH from "a link was clicked" to "a chat exists" (PRD §5.5 step 3).
+   *
+   *  Both entry points end here: `?s=<id>` with a server-minted scaffold, and the `?ask=&meeting=`
+   *  hand link with a local one. Before this they were two bodies of composition code that had
+   *  already drifted — only one of them knew about tabs — and that drift is the class of defect the
+   *  scaffold record exists to end. If a third arrival is ever added, it mints a scaffold and calls
+   *  this; it does not grow a third composer. */
+  const openFromScaffold = useCallback((sc: Scaffold, native: string | null) => {
+    const rec = scaffoldToChat(sc, { native });
+    // Decision 18's rule: a chat that already carries tabs belongs to its reader, and a second
+    // arrival must not tidy their desk out from under them.
+    const existing = chatsRef.current.find((c) => c.id === rec.id);
+    const fresh = !existing?.artifacts.length;
+    addChat(rec.label, rec.workspaces, {
+      id: rec.id,
+      meeting: rec.meeting,
+      artifacts: fresh ? rec.artifacts : undefined,
+      focus: fresh ? rec.focus : undefined,
+      kick: sc.openingText,
+      scaffoldId: sc.kind === "hand-link" ? undefined : sc.id,
+    });
+  }, [addChat]);
+
+  // A scaffold that would not open. Held so the reader is TOLD — a person who clicked a real link
+  // and landed on a blank chat cannot tell a spent invitation from a broken product.
+  const [scaffoldRefusal, setScaffoldRefusal] = useState<ScaffoldRefusal | null>(null);
+  const scaffoldFired = useRef(false);
+
+  // `?s=<id>` — THE SCAFFOLD (PRD §5.5 step 3). One record per arrival: the server says which
+  // workspaces, which documents, and what the opening is; the terminal renders a chat from it and
+  // NOTHING here is composed from what was there before. The right panel keeps rendering from the
+  // chat record only — the decision-18 contract — so this effect's whole job is to write that
+  // record correctly and then get out of the way.
+  useEffect(() => {
+    if (scaffoldFired.current) return;
+    let id: string | null = null;
+    try { id = localStorage.getItem("vexa.pendingScaffold"); } catch { /* ignore */ }
+    if (!id) return;
+    // A scaffold ABOUT a meeting needs the meetings list to resolve the note's native id, exactly
+    // as the preset path does. Bounded by the same 8s wait: a list that never answers must not
+    // leave a real click with nothing.
+    if (!meetingsLoaded && !presetWaited) {
+      if (!presetTimer.current) {
+        presetTimer.current = true;
+        window.setTimeout(() => setPresetWaited(true), 8000);
+      }
+      return;
+    }
+    scaffoldFired.current = true;
+    setPresetInFlight(true);        // the scaffold OWNS the opening, like a preset
+    try { localStorage.removeItem("vexa.pendingScaffold"); } catch { /* ignore */ }
+    void (async () => {
+      const got = await fetchScaffold(id);
+      if (!got.ok) {
+        console.error("scaffold " + id + " did not open:", got.refusal.reason, got.refusal.detail);
+        setPresetInFlight(false);
+        setScaffoldRefusal(got.refusal);
+        return;
+      }
+      const sc = got.scaffold;
+      const row = sc.meeting ? meetings.find((x) => String(x.id) === sc.meeting) : undefined;
+      const native = (row as { native_id?: string } | undefined)?.native_id ?? null;
+      openFromScaffold(sc, native);
+    })();
+  }, [addChat, meetings, meetingsLoaded, presetWaited]);
+
   useEffect(() => {
     if (presetFired.current) return;
     let raw: string | null = null;
@@ -716,30 +788,27 @@ export function MinutesShell() {
       const focusArt = focusToken ? artifactsFromTokens([focusToken], tabCtx)[0] : undefined;
       const focusKey = focusArt ? artifactKey(focusArt) : undefined;
 
+      // A HAND LINK MINTS A LOCAL SCAFFOLD and renders through the one path (PRD §5.5 step 3).
+      // `?ask=&meeting=` survives only as this fallback: it composes the SAME record an emailed
+      // `?s=` produces, so there is one composer rather than two that drift. Nothing about the URL
+      // carries prompt text — the body still comes from `_global/asks/<name>.md`, admin-authored.
       if (row) {
         try { localStorage.removeItem("vexa.openMeetingRef"); } catch { /* ignore */ }
         meetingRefSpent.current = true;
-        const chatId = await openMeeting(row, { touched: true, artifacts, focus: focusKey });
-        if (chatId) { fireKick(chatId, prompt); return; }
       }
-      // ONE MEETING IS ONE CHAT, even when its row has not arrived yet. This fallback used to mint
-      // `askchat-<base36>` labelled from the preset name, so a click whose meeting list was still
-      // loading produced a second conversation — the founder got "prepare" AND "DNA TSC" for one
-      // meeting, and a retry produced another. When the ref is a ROW ID we can name the chat the
-      // same thing the meeting's own row will name it (`meet-<id>`), bind `meeting` so the rail
-      // knows what it is, and leave the LABEL EMPTY: railRows falls back to the meeting's title
-      // (`c.label || meetingTitle(m)`), so the row names itself the moment the list lands, and the
-      // meeting's own chat resolves to this very record instead of a second one.
-      const rowRef = /^\d+$/.test(ref) ? ref : "";
-      // same settle delay the other seeded conversations use — the chat must be mounted to hear it
-      addChat(rowRef ? "" : label, mounts, {
-        id: rowRef ? meetingChatId(rowRef) : "askchat-" + Date.now().toString(36),
-        meeting: rowRef || undefined,
-        artifacts, focus: focusKey,
-        kick: prompt,
-      });
+      openFromScaffold(localScaffold({
+        preset: name,
+        openingText: prompt,
+        meeting: row ? String(row.id) : (/^\d+$/.test(ref) ? ref : null),
+        phase,
+        workspaces: mounts,
+        tabs: tabTokens,
+        focus: focusToken,
+        title: row?.title,
+      }), tabCtx.native);
+      return;
     })();
-  }, [addChat, meetings, meetingsLoaded, presetWaited, openMeeting]);
+  }, [openFromScaffold, meetings, meetingsLoaded, presetWaited]);
 
   return (
     <div style={{ position: "relative", display: "grid", gridTemplateColumns: `${railCollapsed ? EDGE_W : T.railW}px minmax(0, 1fr) ${pagesCollapsed ? EDGE_W : pagesW}px`, gridTemplateRows: `${T.headerH}px 1fr`, height: "100%", minHeight: 0, background: surface.rail }}>
@@ -752,8 +821,31 @@ export function MinutesShell() {
       <ContextBar sel={sel} flavor={flavor} memberships={memberships}
         onAddWorkspace={(id) => setWorkspaces((ws) => ws.includes(id) ? ws : [...ws, id])}
         onRemoveWorkspace={(id) => setWorkspaces((ws) => ws.filter((w) => w !== id))} />
-      <main style={{ gridRow: 2, gridColumn: 2, minWidth: 0, minHeight: 0, background: surface.center }}>
-        <Chat params={{ session }} emptyExtra={<ProposalChips items={shownChips} onPick={(p) => void runProposal(p)} />} />
+      <main style={{ gridRow: 2, gridColumn: 2, minWidth: 0, minHeight: 0, background: surface.center, display: "flex", flexDirection: "column" }}>
+        {/* A SCAFFOLD THAT WOULD NOT OPEN STATES ITSELF. Someone who clicked a real link and landed
+            on an empty conversation cannot tell a spent invitation from a broken product — and the
+            second reading is the one they take. So: whose it is, and what to do about it. It sits
+            ABOVE the chat rather than replacing it, because their own conversations are still
+            theirs and hiding them would be a second wrong. */}
+        {scaffoldRefusal && (() => {
+          const c = refusalCopy(scaffoldRefusal);
+          return (
+            <div role="alert" data-scaffold-refusal={scaffoldRefusal.reason}
+              style={{ flex: "none", margin: "12px 14px 0", padding: "12px 14px", borderRadius: 8,
+                border: "1px solid var(--line)", background: "var(--bg2, var(--bg))" }}>
+              <div style={{ ...ty.title, fontSize: 13.5, color: "var(--t1)", marginBottom: 4 }}>{c.title}</div>
+              <div style={{ ...ty.body, color: "var(--t3)", lineHeight: 1.55 }}>{c.body}</div>
+              <button onClick={() => setScaffoldRefusal(null)}
+                style={{ ...ty.chip, marginTop: 10, color: "var(--t3)", background: "transparent",
+                  border: "1px solid var(--line)", borderRadius: 6, padding: "3px 10px", cursor: "pointer" }}>
+                Dismiss
+              </button>
+            </div>
+          );
+        })()}
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <Chat params={{ session }} emptyExtra={<ProposalChips items={shownChips} onPick={(p) => void runProposal(p)} />} />
+        </div>
       </main>
       {/* the pages panel's resize handle — a real separator: 11px hit area, a hairline that
           lights up on hover/focus, and arrow keys for anyone not dragging. A collapsed panel has no

--- a/clients/terminal/src/minutes/__tests__/scaffold.test.ts
+++ b/clients/terminal/src/minutes/__tests__/scaffold.test.ts
@@ -1,0 +1,173 @@
+/** THE SCAFFOLD → the chat record (PRD §5.5 step 3).
+ *
+ *  One record per arrival, rendered by the terminal and consumed by the agent. These tests pin the
+ *  three things that decide what a person sees when they click a link: what the wire is allowed to
+ *  say, what that becomes as a chat, and what happens when it will not open.
+ *
+ *  The wire shape is owned by a separate worker's branch. `parseScaffold` is the ONLY place that
+ *  knows it, so these tests are also the thing that will fail first — loudly and in one file — if
+ *  the real interface differs from the expected one.
+ */
+import { describe, expect, it } from "vitest";
+import { fetchScaffold, localScaffold, parseScaffold, refusalCopy, scaffoldToChat } from "../scaffold";
+
+const WIRE = {
+  id: "sc_abc123",
+  kind: "post-meeting",
+  meeting: 95,
+  phase: "post",
+  workspaces: ["_global", "personal"],
+  refs: {
+    title: "DNA TSC — 3 August",
+    when: "Sep 2, 10:12",
+    organizer: "dmitry@vexa.ai",
+    participants: ["a@x.test", "b@x.test"],
+    participant_names: { "a@x.test": "Ann X", "b@x.test": 7 },
+    state: { desk: "new", group: "warm" },
+  },
+  opening_preset: "minutes-review",
+  opening_text: "[minutes-review] Someone clicked through …",
+  tabs: ["meeting:note", "meeting:transcript"],
+  focus: "meeting:note",
+  provenance: "post_meeting flow",
+  redeemed_at: null,
+};
+
+describe("parseScaffold", () => {
+  it("reads the record, and coerces the ROW id to a string", () => {
+    const s = parseScaffold(WIRE)!;
+    expect(s.id).toBe("sc_abc123");
+    expect(s.meeting).toBe("95");           // number on the wire, string everywhere here
+    expect(s.phase).toBe("post");
+    expect(s.workspaces).toEqual(["_global", "personal"]);
+    expect(s.refs.state).toEqual({ desk: "new", group: "warm" });
+    // a non-string name is dropped rather than rendered as "7"
+    expect(s.refs.participantNames).toEqual({ "a@x.test": "Ann X" });
+  });
+
+  it("refuses a record it cannot open, rather than opening an empty chat", () => {
+    expect(parseScaffold({ ...WIRE, id: "" })).toBeNull();
+    expect(parseScaffold({ ...WIRE, opening_text: "   " })).toBeNull();
+    expect(parseScaffold(null)).toBeNull();
+    expect(parseScaffold("nope")).toBeNull();
+  });
+
+  it("an unknown phase is NULL, never guessed", () => {
+    // §5.5: phase is resolved server-side at OPEN. A client that guessed it would reintroduce the
+    // exact lie the rule exists to stop — a "prep" link clicked after the meeting.
+    expect(parseScaffold({ ...WIRE, phase: "whenever" })!.phase).toBeNull();
+    expect(parseScaffold({ ...WIRE, phase: undefined })!.phase).toBeNull();
+  });
+
+  it("survives a record with everything optional missing", () => {
+    const s = parseScaffold({ id: "x", opening_text: "hi" })!;
+    expect(s.meeting).toBeNull();
+    expect(s.workspaces).toEqual([]);
+    expect(s.refs.participants).toEqual([]);
+    expect(s.tabs).toEqual([]);
+  });
+});
+
+describe("scaffoldToChat", () => {
+  it("a meeting scaffold lands in the MEETING's own chat, with the phase's tab names", () => {
+    const rec = scaffoldToChat(parseScaffold(WIRE)!, { native: "abc-defg-hij" });
+    expect(rec.id).toBe("meet-95");        // not a parallel conversation
+    expect(rec.label).toBe("");            // the rail names it from the meeting
+    expect(rec.meeting).toBe("95");
+    expect(rec.artifacts).toEqual([
+      { path: "kg/entities/meeting/abc-defg-hij.md", label: "Minutes" },  // post → Minutes
+      { kind: "meeting", path: "95", label: "Transcript" },
+    ]);
+    expect(rec.focus).toBe("|kg/entities/meeting/abc-defg-hij.md");
+  });
+
+  it("without the native id the note is DROPPED, not guessed at", () => {
+    // a tab pointing at a guessed path opens a page that can never load — worse than one fewer tab
+    const rec = scaffoldToChat(parseScaffold(WIRE)!, { native: null });
+    expect(rec.artifacts).toEqual([{ kind: "meeting", path: "95", label: "Transcript" }]);
+  });
+
+  it("a scaffold with no meeting opens its own chat over its declared workspaces", () => {
+    const s = parseScaffold({
+      ...WIRE, meeting: null, kind: "admin-setup", opening_preset: "setup-global",
+      workspaces: ["_global"], tabs: ["_global/README.md", "_global/MISSING.md"], focus: "_global/README.md",
+      refs: { ...WIRE.refs, title: "" },
+    })!;
+    const rec = scaffoldToChat(s);
+    expect(rec.id).toBe("scaffold-sc_abc123");
+    expect(rec.label).toBe("setup global");
+    expect(rec.meeting).toBeUndefined();
+    expect(rec.artifacts.map((a) => a.path)).toEqual(["README.md", "MISSING.md"]);
+    expect(rec.focus).toBe("_global|README.md");
+  });
+
+  it("empty workspaces fall back to a real mount set rather than nothing", () => {
+    const rec = scaffoldToChat(parseScaffold({ id: "x", opening_text: "hi" })!);
+    expect(rec.workspaces).toEqual(["_global", "personal"]);
+  });
+});
+
+describe("localScaffold — the hand link composes through the SAME path", () => {
+  it("`?ask=&meeting=` produces a record scaffoldToChat renders identically", () => {
+    const sc = localScaffold({
+      preset: "prep", openingText: "[prep] …", meeting: "95", phase: "prep",
+      workspaces: ["_global", "personal"], tabs: ["meeting:note"], focus: "meeting:note",
+    });
+    expect(sc.kind).toBe("hand-link");
+    const rec = scaffoldToChat(sc, { native: "abc-defg-hij" });
+    expect(rec.id).toBe("meet-95");
+    // prep → the same file under the name the reader needs today
+    expect(rec.artifacts).toEqual([{ path: "kg/entities/meeting/abc-defg-hij.md", label: "Brief" }]);
+  });
+});
+
+describe("fetchScaffold — a refusal is returned, never thrown", () => {
+  const res = (status: number, body: unknown) => ({
+    ok: status >= 200 && status < 300, status, json: async () => body,
+  }) as unknown as Response;
+
+  it("404 is not-found, 403 is forbidden, 500 is unavailable", async () => {
+    const r404 = await fetchScaffold("x", async () => res(404, { detail: "no" }));
+    const r403 = await fetchScaffold("x", async () => res(403, { detail: "not yours" }));
+    const r500 = await fetchScaffold("x", async () => res(500, {}));
+    expect(r404.ok === false && r404.refusal.reason).toBe("not-found");
+    expect(r403.ok === false && r403.refusal.reason).toBe("forbidden");
+    expect(r500.ok === false && r500.refusal.reason).toBe("unavailable");
+  });
+
+  it("a network fault is unavailable, not a crash", async () => {
+    const r = await fetchScaffold("x", async () => { throw new Error("offline"); });
+    expect(r.ok === false && r.refusal.reason).toBe("unavailable");
+    expect(r.ok === false && r.refusal.detail).toBe("offline");
+  });
+
+  it("an id that is not an id never reaches the network", async () => {
+    let called = false;
+    const r = await fetchScaffold("../../etc/passwd", async () => { called = true; return res(200, WIRE); });
+    expect(called).toBe(false);
+    expect(r.ok === false && r.refusal.reason).toBe("malformed");
+  });
+
+  it("a 200 that is not a scaffold is malformed — not an empty chat", async () => {
+    const r = await fetchScaffold("x", async () => res(200, { id: "x" }));   // no opening_text
+    expect(r.ok === false && r.refusal.reason).toBe("malformed");
+  });
+
+  it("a good one parses", async () => {
+    const r = await fetchScaffold("sc_abc123", async () => res(200, WIRE));
+    expect(r.ok && r.scaffold.id).toBe("sc_abc123");
+  });
+});
+
+describe("refusalCopy — every refusal states a state and a next move", () => {
+  it("names whose the link is, and what to do, for each reason", () => {
+    for (const reason of ["not-found", "forbidden", "unavailable", "malformed"] as const) {
+      const c = refusalCopy({ reason, status: 0, detail: "" });
+      expect(c.title.length).toBeGreaterThan(10);
+      expect(c.body.length).toBeGreaterThan(10);
+      // never a stack trace, never a status code in the reader's face
+      expect(c.title + c.body).not.toMatch(/HTTP|undefined|null|\[object/);
+    }
+    expect(refusalCopy({ reason: "forbidden", status: 403, detail: "" }).title).toMatch(/someone else/i);
+  });
+});

--- a/clients/terminal/src/minutes/scaffold.ts
+++ b/clients/terminal/src/minutes/scaffold.ts
@@ -1,0 +1,240 @@
+"use client";
+/** THE SCAFFOLD — one record per arrival (PRD §5.5).
+ *
+ *  A scaffold says, for one moment a person arrives at, what the agent knows and what the UI
+ *  shows. The flow mints it when it creates a touch; the link carries only its **id** (plus the
+ *  share); the terminal and the agent both render from it. Nothing on either side is composed from
+ *  whatever happened to be there before — which is the whole point, because "composed from
+ *  whatever was there" is the shape of every seam failure the founder hit.
+ *
+ *  THIS FILE IS THE ONLY PLACE THAT KNOWS THE WIRE SHAPE. The server half lands on its own branch
+ *  and posts its response shape; everything else in the client consumes `Scaffold`, so reconciling
+ *  with the real interface is an edit to `parseScaffold` and nothing else. That is deliberate: two
+ *  workers building two halves of one contract the same afternoon is exactly how the
+ *  `room_read` / `room_participants` mismatch happened, and it 422'd every dispatch.
+ *
+ *  Two rules the parse enforces, both from §5.5:
+ *    · **phase is resolved at OPEN, never at mint** — so it is read from the response, never
+ *      remembered from the link. A "prep" link clicked after the meeting must not lie.
+ *    · **the opening is a preset NAME plus text the SERVER substituted** — the URL never carries
+ *      prompt text, because a link that could would let anyone who can send mail drive the
+ *      recipient's agent.
+ */
+import type { MeetingPhase } from "../surfaces/meetingModel";
+import { artifactKey, meetingChatId, type Artifact } from "./chats";
+import { artifactsFromTokens } from "./roomView";
+
+/** What a scaffold says about the person and the room, for a preset to branch on. */
+export interface ScaffoldRefs {
+  title?: string;
+  when?: string;
+  organizer?: string;
+  participants: string[];
+  participantNames: Record<string, string>;
+  /** coarse, deliberately: `desk` new|pile|warm · `group` absent|new|warm */
+  state: { desk?: string; group?: string };
+}
+
+export interface Scaffold {
+  id: string;
+  kind: string;
+  /** the meetings-domain ROW id, or null for a scaffold that is not about a meeting */
+  meeting: string | null;
+  /** resolved SERVER-SIDE at open — never at mint, never inferred here */
+  phase: MeetingPhase | null;
+  workspaces: string[];
+  refs: ScaffoldRefs;
+  openingPreset: string;
+  /** already substituted server-side, and machinery: the human never sees it as their own words */
+  openingText: string;
+  tabs: string[];
+  focus: string;
+  provenance: string;
+  redeemedAt: string | null;
+}
+
+/** Why a scaffold could not be opened. Never a blank chat: a person who clicked a real link and
+ *  landed on nothing cannot tell a revoked invitation from a broken product. */
+export interface ScaffoldRefusal {
+  reason: "not-found" | "forbidden" | "unavailable" | "malformed";
+  status: number;
+  detail: string;
+}
+
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+const strArr = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === "string" && !!x.trim()).map((x) => x.trim()) : [];
+
+const PHASES: MeetingPhase[] = ["prep", "live", "post"];
+
+/** The wire → `Scaffold`, or `null` when the body is not one.
+ *
+ *  Tolerant on every optional field and STRICT on exactly two — `id` and `opening_text` — because a
+ *  scaffold without them cannot open a chat, and rendering an empty conversation is worse than
+ *  saying plainly that the link did not resolve. */
+export function parseScaffold(raw: unknown): Scaffold | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const id = str(r.id).trim();
+  const openingText = str(r.opening_text);
+  if (!id || !openingText.trim()) return null;
+
+  const refsRaw = (r.refs && typeof r.refs === "object" ? r.refs : {}) as Record<string, unknown>;
+  const stateRaw = (refsRaw.state && typeof refsRaw.state === "object" ? refsRaw.state : {}) as Record<string, unknown>;
+  const namesRaw = (refsRaw.participant_names && typeof refsRaw.participant_names === "object"
+    ? refsRaw.participant_names : {}) as Record<string, unknown>;
+  const names: Record<string, string> = {};
+  for (const [k, v] of Object.entries(namesRaw)) if (typeof v === "string") names[k] = v;
+
+  const phaseRaw = str(r.phase).trim().toLowerCase() as MeetingPhase;
+  const meeting = r.meeting == null || r.meeting === "" ? null : String(r.meeting);
+
+  return {
+    id,
+    kind: str(r.kind) || "unknown",
+    meeting,
+    phase: PHASES.includes(phaseRaw) ? phaseRaw : null,
+    // `_global` is always mounted by the server's own rule; we do not add it here, because a
+    // client that patches the mount set is a second opinion about context.
+    workspaces: strArr(r.workspaces),
+    refs: {
+      title: str(refsRaw.title) || undefined,
+      when: str(refsRaw.when) || undefined,
+      organizer: str(refsRaw.organizer) || undefined,
+      participants: strArr(refsRaw.participants),
+      participantNames: names,
+      state: { desk: str(stateRaw.desk) || undefined, group: str(stateRaw.group) || undefined },
+    },
+    openingPreset: str(r.opening_preset),
+    openingText,
+    tabs: strArr(r.tabs),
+    focus: str(r.focus),
+    provenance: str(r.provenance),
+    redeemedAt: str(r.redeemed_at) || null,
+  };
+}
+
+/** Fetch one scaffold AS THE SIGNED-IN IDENTITY. The server decides whether it is theirs; the
+ *  client never asserts who it is for. A refusal is returned, never thrown — the caller renders a
+ *  card that states the situation. */
+export async function fetchScaffold(
+  id: string,
+  fetcher: typeof fetch = fetch,
+): Promise<{ ok: true; scaffold: Scaffold } | { ok: false; refusal: ScaffoldRefusal }> {
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(id)) {
+    return { ok: false, refusal: { reason: "malformed", status: 0, detail: "that is not a scaffold id" } };
+  }
+  let res: Response;
+  try {
+    res = await fetcher(`/api/scaffolds/${encodeURIComponent(id)}`, { cache: "no-store" });
+  } catch (e) {
+    return { ok: false, refusal: { reason: "unavailable", status: 0, detail: e instanceof Error ? e.message : String(e) } };
+  }
+  if (!res.ok) {
+    const reason: ScaffoldRefusal["reason"] =
+      res.status === 404 ? "not-found" : res.status === 401 || res.status === 403 ? "forbidden" : "unavailable";
+    let detail = `HTTP ${res.status}`;
+    try {
+      const body = await res.json() as { detail?: string };
+      if (body?.detail) detail = body.detail;
+    } catch { /* a body we cannot read is not worth a second failure */ }
+    return { ok: false, refusal: { reason, status: res.status, detail } };
+  }
+  let body: unknown;
+  try { body = await res.json(); } catch {
+    return { ok: false, refusal: { reason: "malformed", status: res.status, detail: "the response was not JSON" } };
+  }
+  const scaffold = parseScaffold(body);
+  return scaffold
+    ? { ok: true, scaffold }
+    : { ok: false, refusal: { reason: "malformed", status: res.status, detail: "the scaffold carried no id or no opening" } };
+}
+
+/** What the reader is told when a scaffold will not open. One sentence of state, one of what to do
+ *  — never a blank chat, and never a stack trace. */
+export function refusalCopy(r: ScaffoldRefusal): { title: string; body: string } {
+  switch (r.reason) {
+    case "not-found":
+      return { title: "This link has already been used, or it never existed.",
+               body: "Ask whoever sent it for a fresh one — links are minted per person and are not shared." };
+    case "forbidden":
+      return { title: "This link belongs to someone else.",
+               body: "You are signed in as a different person. Sign in with the address the mail was sent to, and it will open." };
+    case "malformed":
+      return { title: "This link is not readable.",
+               body: "Nothing was opened rather than opening the wrong thing. Ask for a fresh link." };
+    default:
+      return { title: "We could not reach the service that holds this link.",
+               body: "Nothing is lost — reload in a moment and it will open." };
+  }
+}
+
+/** THE ONE COMPOSITION PATH (PRD §5.5 step 3). A scaffold → the fields of a chat record.
+ *
+ *  Pure, and separate from the fetch, so the mapping is provable without a server: this is the
+ *  function that decides what the reader sees, and it is the thing most worth pinning.
+ *
+ *  `?ask=&meeting=` hand-links compose through HERE too, by minting a local scaffold — so there is
+ *  exactly one path from "a link was clicked" to "a chat exists", not two that drift. Before this,
+ *  the emailed link and the hand link built the record with different code and only one of them
+ *  knew about tabs.
+ *
+ *  The chat's ID is the meeting's when the scaffold names one (`meet-<row>`), so a scaffold about a
+ *  meeting lands in that meeting's existing conversation instead of minting a parallel one — the
+ *  same rule that folded "prepare" and "DNA TSC" into one chat. */
+export function scaffoldToChat(s: Scaffold, opts: { native?: string | null } = {}): {
+  id: string; label: string; meeting?: string; workspaces: string[];
+  artifacts: Artifact[]; focus?: string;
+} {
+  // `native` is an INPUT, not something this function can know. `meeting:note` resolves to
+  // `kg/entities/meeting/<native>.md`, and the scaffold carries the ROW id — the two are different
+  // identifiers and the row id is the one the canvas binds to. The caller reads the native off the
+  // meetings list it already holds. Absent, the note token resolves to nothing and the chat opens
+  // one document fewer, which is the honest degradation: a tab pointing at a guessed path would
+  // open a page that can never load.
+  const ctx = {
+    native: opts.native ?? null,
+    meetingId: s.meeting,
+    phase: s.phase,
+    mounts: s.workspaces,
+  };
+  const artifacts = artifactsFromTokens(s.tabs, ctx);
+  const focusArt = s.focus ? artifactsFromTokens([s.focus], ctx)[0] : undefined;
+  return {
+    id: s.meeting ? meetingChatId(s.meeting) : `scaffold-${s.id}`,
+    // A meeting chat carries NO label of its own: the rail names it from the meeting, so the row
+    // follows the meeting's title instead of freezing whatever the scaffold called it.
+    label: s.meeting ? "" : (s.refs.title || s.openingPreset.replace(/[-_]/g, " ") || "Chat"),
+    meeting: s.meeting ?? undefined,
+    workspaces: s.workspaces.length ? s.workspaces : ["_global", "personal"],
+    artifacts,
+    focus: focusArt ? artifactKey(focusArt) : undefined,
+  };
+}
+
+/** A hand link (`?ask=&meeting=`) minted into the SAME record shape, so it renders through the one
+ *  composition path above. Not persisted and not a server scaffold — it is the local equivalent,
+ *  which is exactly what keeps the two entry points from drifting apart.
+ *
+ *  `openingText` is the preset body the client substituted; a server-minted scaffold arrives with
+ *  the server's substitution already done. Either way the text is MACHINERY and is marked as such
+ *  by the send path — the human never sees it as their own words. */
+export function localScaffold(input: {
+  preset: string; openingText: string; meeting: string | null; phase: MeetingPhase | null;
+  workspaces: string[]; tabs: string[]; focus: string; title?: string;
+}): Scaffold {
+  return {
+    id: `local-${input.preset}`,
+    kind: "hand-link",
+    meeting: input.meeting,
+    phase: input.phase,
+    workspaces: input.workspaces,
+    refs: { title: input.title, participants: [], participantNames: {}, state: {} },
+    openingPreset: input.preset,
+    openingText: input.openingText,
+    tabs: input.tabs,
+    focus: input.focus,
+    provenance: "hand link (?ask=)",
+    redeemedAt: null,
+  };
+}

--- a/clients/terminal/src/surfaces/chat.tsx
+++ b/clients/terminal/src/surfaces/chat.tsx
@@ -811,7 +811,7 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
     return data.files ?? [];
   };
 
-  const send = async (text: string, prompt = text, referenceSource = text, opts: { hidden?: boolean; ground?: boolean } = {}) => {
+  const send = async (text: string, prompt = text, referenceSource = text, opts: { hidden?: boolean; ground?: boolean; scaffoldId?: string } = {}) => {
     // hidden → no visible user bubble (system kickoffs); ground:false → don't append the active
     // meeting/file context (onboarding must not inherit whatever meeting happens to be focused).
     const { hidden = false, ground = true } = opts;
@@ -886,7 +886,8 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
     });
     try {
       const result = await streamChatTurn(
-        { prompt: p, session: sessionForSend, active, context },
+        // `scaffold_id` on the FIRST turn: dispatch reads the same record the panel rendered from.
+        { prompt: p, session: sessionForSend, active, context, scaffold_id: opts.scaffoldId },
         {
           onStarting: () => {},  // visual is driven by onStatus (below); the stream still signals cold-start here
           onStatus: (phase) => setStatus(phase),
@@ -948,20 +949,20 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
   sendRef.current = send;
   useEffect(() => {
     const onAsk = (e: Event) => {
-      const detail = (e as CustomEvent<{ prompt?: string; display?: string; hidden?: boolean; ground?: boolean; session?: string }>).detail;
+      const detail = (e as CustomEvent<{ prompt?: string; display?: string; hidden?: boolean; ground?: boolean; session?: string; scaffoldId?: string }>).detail;
       const prompt = detail?.prompt;
       if (!prompt) return;
       // A SESSION-TARGETED ask must never land in whichever chat happens to be visible (the
       // workspace-scaffold kickoff once fired into the org-setup thread mid-switch). Not ours →
       // stash it; the target session's Chat consumes it the moment it mounts.
       if (detail?.session && detail.session !== session) {
-        try { localStorage.setItem(`vexa.pendingAsk.${detail.session}`, JSON.stringify({ prompt, display: detail.display, hidden: detail.hidden, ground: detail.ground })); } catch { /* ignore */ }
+        try { localStorage.setItem(`vexa.pendingAsk.${detail.session}`, JSON.stringify({ prompt, display: detail.display, hidden: detail.hidden, ground: detail.ground, scaffoldId: detail.scaffoldId })); } catch { /* ignore */ }
         return;
       }
       if (layout.store.getState().rightCollapsed) layout.toggleRight();
       // `display` — what the READER sees when it is not what the agent gets: a chip whose label is
       // the user's own sentence renders as their message, and the grounding it carries does not.
-      void sendRef.current(detail?.display || prompt, prompt, prompt, { hidden: detail?.hidden, ground: detail?.ground });
+      void sendRef.current(detail?.display || prompt, prompt, prompt, { hidden: detail?.hidden, ground: detail?.ground, scaffoldId: detail?.scaffoldId });
     };
     window.addEventListener(ASK_CHAT_EVENT, onAsk);
     return () => window.removeEventListener(ASK_CHAT_EVENT, onAsk);
@@ -976,8 +977,8 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
     const t = setTimeout(() => {
       try { localStorage.removeItem(key); } catch { /* ignore */ }
       try {
-        const d = JSON.parse(raw as string) as { prompt: string; display?: string; hidden?: boolean; ground?: boolean };
-        if (d.prompt) void sendRef.current(d.display || d.prompt, d.prompt, d.prompt, { hidden: d.hidden, ground: d.ground });
+        const d = JSON.parse(raw as string) as { prompt: string; display?: string; hidden?: boolean; ground?: boolean; scaffoldId?: string };
+        if (d.prompt) void sendRef.current(d.display || d.prompt, d.prompt, d.prompt, { hidden: d.hidden, ground: d.ground, scaffoldId: d.scaffoldId });
       } catch { /* ignore */ }
     }, 600);
     return () => clearTimeout(t);

--- a/clients/terminal/src/surfaces/chatStream.ts
+++ b/clients/terminal/src/surfaces/chatStream.ts
@@ -67,6 +67,13 @@ export type ChatStreamRequest = {
   active: unknown;
   /** the terminal-state context bundle {tz, surface, focus, include}, or undefined */
   context?: unknown;
+  /** THE SCAFFOLD this turn opened from (PRD §5.5), on the FIRST turn only.
+   *
+   *  One record, two renderers: the panel rendered its tabs from this id and dispatch reads its
+   *  mounts and opening from the same one. Absent on every later turn — the session carries the
+   *  thread from then on, and re-sending it would invite the server to re-apply an arrival that
+   *  already happened. */
+  scaffold_id?: string;
 };
 
 /** One nonce per user turn, constant across that turn's reconnect attempts. It lets agent-api tell a
@@ -178,7 +185,11 @@ export async function streamChatTurn(
       r = await fetchImpl("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json", ...(lastEventId ? { "Last-Event-ID": lastEventId } : {}) },
-        body: JSON.stringify({ prompt: req.prompt, session: req.session, active: req.active, context: req.context, turn_id: turnId }),
+        // `scaffold_id` is OMITTED when absent rather than sent as null: agent-api's ChatBody is
+        // `extra="forbid"`-adjacent about shapes, and an explicit null is a different statement
+        // from "this turn did not come from an arrival".
+        body: JSON.stringify({ prompt: req.prompt, session: req.session, active: req.active, context: req.context, turn_id: turnId,
+          ...(req.scaffold_id ? { scaffold_id: req.scaffold_id } : {}) }),
         signal,
       });
     } catch (e) {


### PR DESCRIPTION
The terminal half of the scaffold (PRD §5.5 step 3). The server half is a separate branch (`scaffold`); this was written **before** its interface was posted, which shapes how it is built.

## What a scaffold is, and why this exists

One record per arrival: for one moment a person lands on, what the agent knows and what the UI shows. The flow mints it, the link carries only its id, and the terminal and the agent both render from it. **Nothing on either side is composed from whatever was there before** — that composed-from-whatever is the shape of every seam failure on the founder's walk.

## The interface risk, and how it is contained

`scaffold.ts` is **the only place that knows the wire shape**. Everything else consumes a `Scaffold`. Reconciling with the server's real response is an edit to `parseScaffold` and nothing else.

That is deliberate, and it is the direct lesson from earlier today: two workers built two halves of the meeting-room contract the same afternoon, one sent `room_read` and the other declared `room_participants`, both suites were green, and because `ChatBody` is `extra="forbid"` it would have **422'd every post-meeting dispatch**. The tests here pin the expected shape precisely so that a mismatch fails first, loudly, in one file.

## Changes

| | |
|---|---|
| `minutes/scaffold.ts` **(new)** | `parseScaffold` · `fetchScaffold` · `scaffoldToChat` · `localScaffold` · `refusalCopy` |
| `app/App.tsx:44,~103` | `?s=<id>` → stash + clean URL, same discipline as `?ask=` |
| `minutes/MinutesShell.tsx:618` | `openFromScaffold` — the one composition path |
| `minutes/MinutesShell.tsx:~660` | the `?s=` effect: fetch as the signed-in identity, compose, open |
| `minutes/MinutesShell.tsx:~799` | `?ask=&meeting=` mints a **local** scaffold through the same path; the parallel composer is deleted |
| `minutes/MinutesShell.tsx:~820` | the refusal card (`data-scaffold-refusal`) |
| `surfaces/chat.tsx`, `surfaces/chatStream.ts` | `scaffold_id` on the **first turn only**, omitted rather than nulled |

Decisions worth reviewing rather than skimming:

- **`phase` is read, never inferred.** §5.5 resolves it server-side at open; an unknown phase parses to `null`. A client that guessed would reintroduce exactly the lie the rule exists to stop — a `prep` link clicked after the meeting.
- **`native` is an input to `scaffoldToChat`, not something it can know.** `meeting:note` resolves against the native id; the scaffold carries the **row** id. Different identifiers. Absent, the note tab is **dropped** rather than pointed at a guessed path — one document fewer beats a tab that can never load.
- **A meeting scaffold lands in `meet-<row>`**, so it joins that meeting's existing conversation instead of minting a parallel one — the same fold that merged "prepare" and "DNA TSC".
- **A second arrival does not overwrite a reader's tabs.** Decision 18's rule: a chat that already carries artifacts belongs to whoever opened them.
- **The refusal states a state.** Whose the link is, what to do. It sits *above* the chat rather than replacing it, because the reader's own conversations are still theirs.
- **`?ask=` survives only as a hand link** and composes through the same function. The two composers had already drifted — only one knew about tabs. **No prompt text in any URL**: the body still comes from `_global/asks/<name>.md`.

## Proof

- `docker build --target build` + `npx vitest run` — **770 tests, 78 files, all green**, including 15 new. No regressions from deleting the old composer or touching the send path.
- Cold `docker build` with `--build-arg NEXT_PUBLIC_TERMINAL_MODE=minutes` — green.
- **No real-click proof yet, and no swap by me.** The instance is blank; I have not signed in. These commits go to the stage-1 worker for the joint terminal image, and the four real-click proofs (`?s=` opens the composed room · a refused scaffold shows the card · `?ask=` still works as a hand link · the setup chat's five tabs) run on its next scratch walk.

## Not done

`scaffold_id` is sent; **nothing consumes it yet** — that is step 4 (dispatch) on the server branch. Until then it is an inert field on the first turn, which is the correct order: the client can send it before the server reads it, not after.

Closes nothing on its own — step 3 of five.
