### PR TITLE
claim: the setup conversation is a server record, not a key in one browser (PRD §5.5 step 5)

### DIFF
--- a/clients/terminal/src/app/AuthGate.tsx
+++ b/clients/terminal/src/app/AuthGate.tsx
@@ -490,9 +490,19 @@ function ClaimInstanceCard({ email, onSignOut }: { email: string | null; onSignO
     try {
       const r = await fetch("/api/auth/claim-admin", { method: "POST" });
       if (r.ok) {
-        // Reload rather than flip a flag: the claim changes what every probe on this page would
-        // answer, and a fresh load is the only way to be sure nothing is left holding the old answer.
-        window.location.reload();
+        // FOLLOW THE URL THE SERVER MINTED. The claim creates the admin-setup scaffold and hands
+        // back `/?s=<id>` — the setup conversation as a server record rather than a key in this
+        // browser's storage, which is what made it vanish when the storage was cleared or a second
+        // browser was used. A full navigation, not a flip: the claim changes what every probe on
+        // this page would answer, so nothing may be left holding the old answer.
+        const body = (await r.json().catch(() => ({}))) as { url?: string; scaffold_error?: string };
+        if (body.scaffold_error) {
+          // The role IS claimed and that is not undone. Only the conversation is missing, so say
+          // exactly that instead of a generic failure the person would answer by re-claiming.
+          setError(body.scaffold_error);
+          return;
+        }
+        window.location.assign(body.url || "/");
         return;
       }
       const body = (await r.json().catch(() => ({}))) as { error?: string; reload?: boolean };

--- a/clients/terminal/src/app/SetupGate.tsx
+++ b/clients/terminal/src/app/SetupGate.tsx
@@ -45,6 +45,7 @@ import {
   type GlobalSetting, type GlobalState,
 } from "../surfaces/settingsApi";
 import { setCompanyLayerHint } from "../minutes/chats";
+import { COMPANY_LAYER_EVENT } from "../canvas/actions";
 
 /** Show the setup surface at all? null = not an admin (probe 404s); completed set = already ran.
  *  Note what does NOT appear here: the company layer's own state. `setup.completed` is written by
@@ -229,6 +230,9 @@ function useGlobalState(stop: boolean): Poll {
       // absent. Being wrong costs a row in a list and nothing else: the server refuses every gated
       // request on its own, so this is presentation, never permission.
       setCompanyLayerHint(state.global_setup === "completed" ? "completed" : "missing");
+      // …and SAY so, because the rail rendered before this answer existed and withheld its
+      // structural rows rather than guess. This is the only dispatcher.
+      window.dispatchEvent(new CustomEvent(COMPANY_LAYER_EVENT));
       if (alive.current) setPoll({ state, error: null });
     } catch (e: unknown) {
       if (alive.current) setPoll((prev) => ({ state: prev.state, error: e instanceof Error ? e.message : String(e) }));

--- a/clients/terminal/src/app/api/auth/__tests__/claimAdmin.test.ts
+++ b/clients/terminal/src/app/api/auth/__tests__/claimAdmin.test.ts
@@ -33,6 +33,8 @@ function stubAdminApi(opts: {
   adminExists?: boolean;
   instanceFails?: boolean;
   bootstrap?: { status: number; body?: unknown };
+  mint?: { status: number; body?: unknown };
+  mintThrows?: boolean;
 }) {
   const calls: string[] = [];
   vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
@@ -50,6 +52,11 @@ function stubAdminApi(opts: {
       const b = opts.bootstrap ?? { status: 200, body: { claimed: true } };
       return new Response(JSON.stringify(b.body ?? {}), { status: b.status });
     }
+    if (u.includes("/internal/scaffolds")) {
+      if (opts.mintThrows) throw new Error("ECONNREFUSED");
+      const m = opts.mint ?? { status: 201, body: { id: "SCAF1", url: "https://app.test/?s=SCAF1" } };
+      return new Response(JSON.stringify(m.body ?? {}), { status: m.status });
+    }
     return new Response("nope", { status: 500 });
   }));
   return calls;
@@ -61,6 +68,7 @@ beforeEach(() => {
   vi.stubEnv("VEXA_ADMIN_API_KEY", "admin-key");
   vi.stubEnv("VEXA_INTERNAL_API_SECRET", "internal-secret");
   vi.stubEnv("VEXA_ADMIN_EMAILS", "");
+  vi.stubEnv("AGENT_API_URL", "http://agent.test");
 });
 
 afterEach(() => {
@@ -78,7 +86,10 @@ describe("the happy path", () => {
 
     const res = await claimAdmin();
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ success: true, claimed: true, email: "dmitry@vexa.ai" });
+    expect(await res.json()).toEqual({
+      success: true, claimed: true, email: "dmitry@vexa.ai",
+      url: "https://app.test/?s=SCAF1", scaffold: "SCAF1",
+    });
 
     expect(calls.some((c) => c.includes("/internal/bootstrap-admin"))).toBe(true);
     const write = spy.mock.calls.find(([u]) => String(u).includes("/internal/bootstrap-admin"));
@@ -146,5 +157,76 @@ describe("it can never transfer the role", () => {
     const res = await claimAdmin();
     expect(res.status).toBe(500);
     expect((await res.json()).error).toContain("Could not claim this instance");
+  });
+});
+
+
+/** THE CONVERSATION, NOT JUST THE ROLE (F26).
+ *
+ *  The hand-off used to live in `localStorage`: clear it, or open the instance in a second browser,
+ *  and the admin landed in a Personal chat on the generic greeting while the setup marker already
+ *  said "handoff", so nothing re-opened the conversation. Verified live 2026-09-02. The claim now
+ *  mints the admin-setup scaffold — the conversation as a SERVER record — and hands back the url. */
+describe("the setup conversation is minted, not stashed", () => {
+  it("mints an admin-setup scaffold for the ORACLE's address, with no prompt text and no mount list", async () => {
+    stubAdminApi({});
+    const spy = vi.mocked(globalThis.fetch);
+    await claimAdmin();
+
+    const mint = spy.mock.calls.find(([u]) => String(u).includes("/internal/scaffolds"));
+    expect(mint).toBeDefined();
+    const body = JSON.parse(String((mint![1] as RequestInit).body));
+    expect(body).toEqual({
+      who: "dmitry@vexa.ai",
+      kind: "admin-setup",
+      opening: "setup-global",
+      provenance: { flow: "admin-claim", step: "claim-admin", minted_by: "11" },
+    });
+    // `workspaces`, `tabs` and `focus` are ABSENT, not empty: the server derives `_global` + this
+    // admin's own desk from the address and takes the tabs from the preset's frontmatter. Sending
+    // them here would be a second spelling of a rule that already has one.
+    expect("workspaces" in body).toBe(false);
+    expect("tabs" in body).toBe(false);
+    // And nothing carries prompt text — the record behind the url is as text-free as the url.
+    expect(JSON.stringify(body)).not.toMatch(/\[setup-global\]/);
+  });
+
+  it("mints on the INTERNAL tier, which a browser can never reach", async () => {
+    stubAdminApi({});
+    const spy = vi.mocked(globalThis.fetch);
+    await claimAdmin();
+    const mint = spy.mock.calls.find(([u]) => String(u).includes("/internal/scaffolds"));
+    const headers = (mint![1] as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Internal-Secret"]).toBe("internal-secret");
+  });
+
+  it("a failed mint still reports the role as claimed — and says the conversation is what is missing", async () => {
+    // The role write already happened and is not undone by this. A caller told only "failed" would
+    // reasonably re-claim; one told only "success" would navigate to a chat that does not exist.
+    stubAdminApi({ mint: { status: 503 } });
+    const res = await claimAdmin();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.claimed).toBe(true);
+    expect(body.url).toBe("/");
+    expect(body.scaffold_error).toMatch(/administrator, but the setup conversation could not be opened/);
+  });
+
+  it("an unreachable agent-api is the same story, not a crash", async () => {
+    stubAdminApi({ mintThrows: true });
+    const res = await claimAdmin();
+    expect(res.status).toBe(200);
+    expect((await res.json()).scaffold_error).toBeTruthy();
+  });
+
+  it("does not mint when the claim itself was refused", async () => {
+    // An instance that already has an admin gets 409 and no scaffold: minting one for somebody who
+    // is not the administrator would compose a stranger's first turn over the company layer.
+    stubAdminApi({ adminExists: true });
+    const spy = vi.mocked(globalThis.fetch);
+    const res = await claimAdmin();
+    expect(res.status).toBe(409);
+    expect(spy.mock.calls.some(([u]) => String(u).includes("/internal/scaffolds"))).toBe(false);
   });
 });

--- a/clients/terminal/src/app/api/auth/adminApi.ts
+++ b/clients/terminal/src/app/api/auth/adminApi.ts
@@ -216,6 +216,65 @@ export async function instanceState(): Promise<InstanceState> {
   };
 }
 
+/** MINT THE ADMIN-SETUP SCAFFOLD — the record that makes the setup conversation reachable.
+ *
+ *  ⚠ WHAT THIS REPLACES, AND WHY IT WAS A HOLE. The hand-off used to live in `localStorage`: the
+ *  wizard stashed a pending preset, the workbench opened a chat from it, and the whole existence of
+ *  that conversation was one key in one browser. Clear it, or open the instance in a second browser,
+ *  and the admin landed in a Personal chat on the generic greeting — "paste a meeting link" — on an
+ *  instance that served nobody, with the setup marker already saying "handoff" so nothing re-opened
+ *  it. Verified live on 2026-09-02. A conversation the product depends on cannot live in the one
+ *  place a person can clear by accident.
+ *
+ *  The scaffold is that conversation as a SERVER record (PRD §5.5): who it is for, which workspaces
+ *  it mounts, which preset opens it, which tabs it shows. The claim mints it and the client follows
+ *  the returned `url` — so a second browser, a cleared browser, and a reload all arrive at the SAME
+ *  chat, because the id is in the URL and the record is on the server.
+ *
+ *  Minting is INTERNAL-TIER on agent-api (a scaffold names mounts and composes an opening, so a
+ *  caller who could mint one for another address could drive that person's agent). This server
+ *  holds that secret; a browser never does. Failure is REPORTED, never swallowed: the caller
+ *  decides what to do with a claim that succeeded and a conversation that could not be made.
+ */
+export interface MintedScaffold { id: string; url: string }
+
+export async function mintAdminSetupScaffold(
+  email: string,
+  userId: string | number,
+): Promise<AdminResult<MintedScaffold>> {
+  const url = (process.env.AGENT_API_URL || "").replace(/\/$/, "");
+  const secret = process.env.VEXA_INTERNAL_API_SECRET || "";
+  if (!url || !secret) {
+    return { ok: false, status: 503, error: "Scaffold minting is not configured (AGENT_API_URL / VEXA_INTERNAL_API_SECRET)" };
+  }
+  try {
+    const res = await fetch(`${url}/internal/scaffolds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Internal-Secret": secret },
+      // `workspaces` is deliberately ABSENT, not `[]`: the server derives `_global` + this admin's
+      // own desk from the address, which is exactly the two-scaffold mount set the setup preset
+      // needs — and deriving it there keeps one rule in one place rather than two that drift.
+      // `tabs`/`focus` likewise come from the preset's own frontmatter.
+      body: JSON.stringify({
+        who: email,
+        kind: "admin-setup",
+        opening: "setup-global",
+        provenance: { flow: "admin-claim", step: "claim-admin", minted_by: String(userId) },
+      }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) {
+      const detail = (await res.text().catch(() => "")).slice(0, 500);
+      return { ok: false, status: res.status, error: detail || `agent-api returned ${res.status}` };
+    }
+    return { ok: true, status: res.status, data: (await res.json()) as MintedScaffold };
+  } catch (err) {
+    const e = err as Error;
+    return { ok: false, status: 0, error: e.name === "TimeoutError" ? "scaffold mint timed out" : e.message };
+  }
+}
+
 /** Does this instance have an admin yet? An allowlist counts as "yes" (those emails ARE admins),
  *  and short-circuits before the probe — those addresses are admins whatever admin-api thinks.
  *  FAIL-SAFE towards true: if the probe can't answer, the login surface shows plain sign-in

--- a/clients/terminal/src/app/api/auth/claim-admin/route.ts
+++ b/clients/terminal/src/app/api/auth/claim-admin/route.ts
@@ -28,7 +28,7 @@
  */
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { AUTH_COOKIE, claimAdminRole, instanceState, validateAuthToken } from "../adminApi";
+import { AUTH_COOKIE, claimAdminRole, instanceState, mintAdminSetupScaffold, validateAuthToken } from "../adminApi";
 
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
@@ -74,8 +74,36 @@ export async function POST() {
   // reload puts them on the correct screen — but it is not the same event, so it is not reported
   // as one.
   console.info(`[terminal-auth] admin claim by user ${who.userId} (${who.email}): claimed=${claimed.claimed}`);
+
+  // THE ROLE IS NOT THE POINT — THE CONVERSATION IS. Claiming admin without a way back into the
+  // setup conversation is what the localStorage hand-off got wrong: the marker said "handed off"
+  // while the chat itself existed only in one browser's storage. So the claim mints the record for
+  // that conversation and hands back the url to follow. Same order as everywhere else in this gate:
+  // the durable thing first, the navigation second.
+  const scaffold = await mintAdminSetupScaffold(who.email, who.userId);
+  if (!scaffold.ok || !scaffold.data?.url) {
+    // The role IS claimed — that write already happened and is not undone by this. Say both facts,
+    // because a caller told only "failed" would reasonably retry the claim, and a caller told only
+    // "success" would navigate to a conversation that does not exist. `/` is the honest fallback:
+    // the corner card is still there and still says what is missing.
+    console.error(`[terminal-auth] admin-setup scaffold mint failed for ${who.email}: ${scaffold.error}`);
+    return NextResponse.json(
+      {
+        success: true,
+        claimed: claimed.claimed,
+        email: who.email,
+        url: "/",
+        scaffold_error: "You are this instance's administrator, but the setup conversation could not be opened. Reload to try again.",
+      },
+      { headers: NO_STORE },
+    );
+  }
+
+  // The url is absolute (agent-api composes it from VEXA_UI_URL). The client follows it as given —
+  // it is the one place the link is built, and rebuilding it here would be the second spelling of a
+  // rule that already exists.
   return NextResponse.json(
-    { success: true, claimed: claimed.claimed, email: who.email },
+    { success: true, claimed: claimed.claimed, email: who.email, url: scaffold.data.url, scaffold: scaffold.data.id },
     { headers: NO_STORE },
   );
 }

--- a/clients/terminal/src/canvas/actions.ts
+++ b/clients/terminal/src/canvas/actions.ts
@@ -99,6 +99,11 @@ export const MACHINERY_NOTE = "\n\n" + MACHINERY_MARK + " This opening was compo
 // Onboarding uses a CACHED first turn (no slow LLM round-trip): the gate seeds this canned agent greeting
 // instantly, then arms the chat so the user's FIRST reply carries the discovery-loop grounding.
 export const ONBOARDING_SEED_EVENT = "vexa:terminal:onboarding-seed";
+/** The company-layer probe answered. SetupGate owns that probe and is the only dispatcher; the
+ *  rail listens so the structural rows it deliberately withheld on first render can appear the
+ *  moment the instance is known to be set up. One writer, one announcement, no polling in the
+ *  rail. */
+export const COMPANY_LAYER_EVENT = "vexa:terminal:company-layer";
 
 /** A chat turn COMMITTED to the workspace — the moment files it wrote became real.
  *

--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -14,7 +14,7 @@
  *  One CSS grid: three columns (rail · conversation · pages), a shared 46px header band. */
 import { WORKSPACE_WORD } from "./vocabulary";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ASK_CHAT_EVENT, CHAT_TOUCHED_EVENT, ONBOARDING_SEED_EVENT, WORKSPACE_COMMIT_EVENT, OPEN_ENTITY_EVENT, OPEN_MEETING_EVENT, setPresetInFlight } from "../canvas/actions";
+import { COMPANY_LAYER_EVENT, ASK_CHAT_EVENT, CHAT_TOUCHED_EVENT, ONBOARDING_SEED_EVENT, WORKSPACE_COMMIT_EVENT, OPEN_ENTITY_EVENT, OPEN_MEETING_EVENT, setPresetInFlight } from "../canvas/actions";
 import { Chat } from "../surfaces/chat";
 import { useLiveMeetings, useLiveMeetingsLoaded } from "../surfaces/liveMeetings";
 import {
@@ -27,8 +27,8 @@ import {
   chatForRow, loadChats, loadCollapsed, loadRailAll, markTouched, meetingChatId, meetingTitle, newChat, railRows,
   readRailOwner, resetChats, writeRailOwner,
   removeChat, saveChats, saveCollapsed, saveRailAll, upsertChat, visibleRows, artifactKey, PERSONAL_CHAT_ID,
-  type Artifact, type Chat as ChatRec, type Row,
-} from "./chats";
+  ensureSeeds,
+  type Artifact, type Chat as ChatRec, type Row } from "./chats";
 import { resolveDocRef } from "../ui-kit/docLinks";
 import { Rail } from "./Rail";
 import { meetingPhase, type MeetingMock } from "../surfaces/meetingModel";
@@ -69,6 +69,15 @@ export function MinutesShell() {
   const meetings = useMemo(() => (mock ? [...MOCK_MEETINGS, ...realMeetings] : realMeetings), [mock, realMeetings]);
   // The stored list. Mock chats are merged for DISPLAY only — they are never written back.
   const [chats, setChats] = useState<ChatRec[]>(() => loadChats());
+  // The structural rows (Personal, Organisation setup) are withheld on first render while the
+  // company layer is unknown — see chats.ts `companyLayerHint`. SetupGate answers that question a
+  // moment later and announces it here, which is when they may appear. Derived, never stored, so
+  // this adds rows and never removes anyone's.
+  useEffect(() => {
+    const on = () => setChats((prev) => ensureSeeds(prev));
+    window.addEventListener(COMPANY_LAYER_EVENT, on);
+    return () => window.removeEventListener(COMPANY_LAYER_EVENT, on);
+  }, []);
   const allChats = useMemo(() => (mock ? [...chats, ...MOCK_CHATS] : chats), [mock, chats]);
   const chatsRef = useRef(allChats);
   useEffect(() => { chatsRef.current = allChats; }, [allChats]);

--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -601,7 +601,14 @@ export function MinutesShell() {
   // states now, in the meeting's own vocabulary.
   const PHASE_WORD = { prep: "upcoming", live: "live", post: "held" } as const;
   const selMeeting = sel.kind === "meeting" ? meetings.find((m) => String(m.id) === sel.meetingId) : undefined;
+  // THE CHAT SAYS WHAT IT IS; the header does not deduce it. This read `workspaces.filter(w => w !==
+  // "_global").length === 0 ? "chat · admin" : "chat"` — mount arithmetic — and it was wrong the
+  // moment the company-setup conversation legitimately mounted the admin's own desk beside
+  // `_global` (the two-scaffold ruling: the first chat writes both layers). The instance's most
+  // consequential conversation then announced itself as an ordinary "chat · personal".
+  const selChat = allChats.find((c) => c.id === sel.chatId);
   const flavor = sel.kind === "meeting" ? `meeting · ${selMeeting ? PHASE_WORD[meetingPhase(selMeeting)] : "held"}`
+    : selChat?.scaffoldKind === "admin-setup" ? "chat · admin"
     : sel.workspaces.filter((w) => w !== "_global").length === 0 ? "chat · admin" : "chat";
 
   // `?ask=<preset>` — the emailed link. App.tsx stashed the name; resolve it to an ADMIN-AUTHORED

--- a/clients/terminal/src/minutes/__tests__/scaffold.test.ts
+++ b/clients/terminal/src/minutes/__tests__/scaffold.test.ts
@@ -171,3 +171,33 @@ describe("refusalCopy — every refusal states a state and a next move", () => {
     expect(refusalCopy({ reason: "forbidden", status: 403, detail: "" }).title).toMatch(/someone else/i);
   });
 });
+
+
+/** F27 — a chat says what it IS; the header does not deduce it from mount arithmetic.
+ *
+ *  The flavour read `workspaces.filter(w => w !== "_global").length === 0 ? "chat · admin" : "chat"`.
+ *  That was true only while the company-setup conversation mounted `_global` alone — and the
+ *  two-scaffold ruling (the first chat writes the company layer AND the admin's own desk) made it
+ *  mount both, at which point the instance's most consequential conversation announced itself as an
+ *  ordinary personal chat. The kind travels on the record instead. */
+describe("the scaffold kind reaches the chat", () => {
+  const base = {
+    id: "S1", kind: "admin-setup", who: "a@b.test", meeting: null, phase: null,
+    workspaces: ["_global", "u_admin"], refs: {}, opening_preset: "setup-global",
+    // a record with no opening text is refused by design — it would open an empty chat
+    opening_text: "[setup-global] …", tabs: [], focus: "", redeemed_at: null,
+  };
+
+  it("carries `admin-setup` even though the chat mounts a desk beside _global", () => {
+    const chat = scaffoldToChat(parseScaffold(base)!);
+    expect(chat.scaffoldKind).toBe("admin-setup");
+    // the arithmetic the old rule used would have called this an ordinary chat
+    expect(chat.workspaces.filter((w) => w !== "_global").length).toBeGreaterThan(0);
+  });
+
+  it("carries the kind for every other arrival too, so nothing has to special-case one", () => {
+    for (const kind of ["post-meeting", "prep", "invite-offer", "catch-up", "group-setup"]) {
+      expect(scaffoldToChat(parseScaffold({ ...base, kind })!).scaffoldKind).toBe(kind);
+    }
+  });
+});

--- a/clients/terminal/src/minutes/chats.ts
+++ b/clients/terminal/src/minutes/chats.ts
@@ -370,8 +370,24 @@ export function setCompanyLayerHint(state: "missing" | "completed"): void {
   try { localStorage.setItem(LAYER_HINT_KEY, state); } catch { /* locked-down storage */ }
 }
 
-export function companyLayerMissing(): boolean {
-  try { return localStorage.getItem(LAYER_HINT_KEY) === "missing"; } catch { return false; }
+/** THREE-valued, and the third value is the whole correction.
+ *
+ *  ⚠ The first version read `=== "missing"` and treated everything else — including an ABSENT
+ *  hint — as "the layer is fine, seed the rows". That defeats itself on the exact case it exists
+ *  for: a first admin on a fresh browser has no hint yet, because the poll that writes it has not
+ *  returned when the rail renders. Verified live on a cleared browser: the admin got the Personal
+ *  row, the generic "paste a meeting link" greeting and the personal README template — the
+ *  founder's original complaint, reproduced by the fix meant to prevent it.
+ *
+ *  So `null` (unknown) is its own answer and it does NOT seed. The rows are restored by the
+ *  re-seed below the moment the probe says "completed", which is under a second later — and they
+ *  are derived, not stored, so nothing has to be un-hidden. Being briefly rowless costs a second;
+ *  guessing wrong the other way costs the first impression this whole gate exists to protect. */
+export function companyLayerHint(): "missing" | "completed" | null {
+  try {
+    const v = localStorage.getItem(LAYER_HINT_KEY);
+    return v === "missing" || v === "completed" ? v : null;
+  } catch { return null; }
 }
 
 /** The two rows that must always be reachable: your own chat, and the `_global` admin setup — which
@@ -388,7 +404,7 @@ export function companyLayerMissing(): boolean {
  *  the only chat, and it is the whole screen. They come back the moment the instance opens — these
  *  rows are derived, not stored, so nothing has to be un-hidden later. */
 export function seedChats(now = Date.now()): Chat[] {
-  if (companyLayerMissing()) return [];
+  if (companyLayerHint() !== "completed") return [];
   return [
     { id: PERSONAL_CHAT_ID, label: "Personal", workspaces: ["personal", "_global"], artifacts: [], touched: true, createdAt: now, lastActivityAt: now },
     { id: ORG_CHAT_ID, label: ORG_CHAT_LABEL, workspaces: ["_global"], artifacts: [], touched: true, createdAt: now - 1, lastActivityAt: now - 1 },

--- a/clients/terminal/src/minutes/chats.ts
+++ b/clients/terminal/src/minutes/chats.ts
@@ -42,6 +42,13 @@ export type Chat = {
   workspaces: string[];       // the mount set — what a PROJECT used to own
   artifacts: Artifact[];      // the open tabs (seeded by the room's phase pages and by `?view=`)
   focus?: string;             // artifactKey() of the tab in front
+  // The SCAFFOLD KIND this chat was opened from (`admin-setup`, `post-meeting`, …), when it came
+  // from one. It is what the chat IS, and things that depend on that — the header's flavour, today —
+  // read it instead of inferring. The old inference was mount arithmetic: "no workspace besides
+  // `_global` means admin", which broke the moment the setup conversation legitimately mounted the
+  // admin's own desk as well (the two-scaffold ruling). A chat's nature is not a function of how
+  // many folders it happens to have open.
+  scaffoldKind?: string;
   touched?: boolean;          // a user wrote in it, or a user made it by hand
   createdAt: number;
   lastActivityAt: number;
@@ -444,6 +451,9 @@ function normalise(raw: unknown, now: number): Chat[] {
             .map((a) => ({ ...a, kind: a.kind === "meeting" ? ("meeting" as const) : undefined }))
         : [],
       focus: typeof r.focus === "string" && r.focus ? r.focus : undefined,
+      // Survives a reload. Without this the flavour would be right on the turn the scaffold opened
+      // the chat and wrong on every load after it — the sort of half-fix that reads as fixed.
+      scaffoldKind: typeof r.scaffoldKind === "string" && r.scaffoldKind ? r.scaffoldKind : undefined,
       touched: !!r.touched,
       createdAt: Number.isFinite(r.createdAt) ? Number(r.createdAt) : now,
       lastActivityAt: Number.isFinite(r.lastActivityAt) ? Number(r.lastActivityAt) : Number(r.createdAt) || now,

--- a/clients/terminal/src/minutes/scaffold.ts
+++ b/clients/terminal/src/minutes/scaffold.ts
@@ -184,7 +184,7 @@ export function refusalCopy(r: ScaffoldRefusal): { title: string; body: string }
  *  same rule that folded "prepare" and "DNA TSC" into one chat. */
 export function scaffoldToChat(s: Scaffold, opts: { native?: string | null } = {}): {
   id: string; label: string; meeting?: string; workspaces: string[];
-  artifacts: Artifact[]; focus?: string;
+  artifacts: Artifact[]; focus?: string; scaffoldKind: string;
 } {
   // `native` is an INPUT, not something this function can know. `meeting:note` resolves to
   // `kg/entities/meeting/<native>.md`, and the scaffold carries the ROW id — the two are different
@@ -201,6 +201,7 @@ export function scaffoldToChat(s: Scaffold, opts: { native?: string | null } = {
   const artifacts = artifactsFromTokens(s.tabs, ctx);
   const focusArt = s.focus ? artifactsFromTokens([s.focus], ctx)[0] : undefined;
   return {
+    scaffoldKind: s.kind,
     id: s.meeting ? meetingChatId(s.meeting) : `scaffold-${s.id}`,
     // A meeting chat carries NO label of its own: the rail names it from the meeting, so the row
     // follows the meeting's title instead of freezing whatever the scaffold called it.

--- a/clients/terminal/src/surfaces/__tests__/railChats.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/railChats.test.ts
@@ -324,7 +324,14 @@ describe("loadChats — migrate exactly once, and never write the old key", () =
     expect(loadChats(T0).map((c) => c.id)).not.toContain("pchat-b");
   });
 
-  it("the two structural rows always exist, and are touched so the filter cannot hide admin", () => {
+  // ── the structural rows are conditional now (founder ruling 2026-09-02) ─────────────────────
+  // They used to be unconditional, and on a fresh instance that put a "Personal" row seeded with
+  // "paste a meeting link" in front of an admin whose instance could not join a meeting or send a
+  // mail. They exist once the company layer is KNOWN to be written, and not before.
+  const layerReady = () => localStorage.setItem("vexa.companyLayer.v1", "completed");
+
+  it("the two structural rows exist once the instance is set up, touched so the filter cannot hide admin", () => {
+    layerReady();
     const out = loadChats(T0);
     const org = out.find((c) => c.label === ORG_CHAT_LABEL);
     expect(out.find((c) => c.id === PERSONAL_CHAT_ID)?.touched).toBe(true);
@@ -332,7 +339,20 @@ describe("loadChats — migrate exactly once, and never write the old key", () =
     expect(org?.workspaces).toEqual(["_global"]);
   });
 
+  it("withholds them while the company layer is missing — the setup conversation is the only chat", () => {
+    localStorage.setItem("vexa.companyLayer.v1", "missing");
+    expect(loadChats(T0)).toEqual([]);
+  });
+
+  it("withholds them while the answer is UNKNOWN, which is the first render of a fresh browser", () => {
+    // The case the first version of this fix got wrong: the hint is written by a poll that has not
+    // returned when the rail first renders, so "absent" must not read as "fine, seed them". Being
+    // briefly rowless costs a second; guessing wrong costs the first impression.
+    expect(loadChats(T0)).toEqual([]);
+  });
+
   it("a corrupt stored list falls back to the seeds instead of throwing", () => {
+    layerReady();
     localStorage.setItem(CHATS_KEY, "{not json");
     expect(loadChats(T0).map((c) => c.id)).toEqual([PERSONAL_CHAT_ID, "org-setup"]);
   });


### PR DESCRIPTION
Step 5 of PRD §5.5, on top of [#1398](https://github.com/Vexa-ai/vexa/pull/1398) (`scaffold`) with the line merged in. **794 tests green (79 files, 9 new), tsc clean. Nothing built, nothing swapped** — the founder is in a session.

## F26 — the setup conversation lived in one browser

**Symptom, verified live on the blank stack.** The hand-off was `localStorage`: the wizard stashed a pending preset, the workbench opened a chat from it, and the entire existence of the instance's most consequential conversation was one key in one browser. Clear it — or open the instance in a second browser — and the admin landed in a **Personal chat on the generic greeting** ("paste a meeting link") on an instance that served nobody. Worse, the `setup` marker already said `handoff`, so nothing re-opened the conversation: the state said the work was under way and there was no way back to it.

**Change.** The claim mints the `admin-setup` scaffold and returns its url; the client follows it.

| | `file:line` |
|---|---|
| the minter, internal tier | `app/api/auth/adminApi.ts` — `mintAdminSetupScaffold` |
| claim → mint → `{url}` | `app/api/auth/claim-admin/route.ts` |
| the client follows it instead of stashing | `app/AuthGate.tsx` — the claim handler |

A second browser, a cleared browser and a reload now arrive at the **same** chat: the id is in the URL and the record is on the server.

### Three decisions worth a look

- **`workspaces`, `tabs` and `focus` are absent from the mint body, not empty.** The server derives `_global` + this admin's own desk from the address — exactly the two-scaffold mount set the preset needs — and takes tabs from the preset's frontmatter. Sending them from here would be a second spelling of a rule that already has one, and the two would drift.
- **A failed mint reports both facts.** The role write already happened and a mint failure does not undo it, so a caller told only "failed" would reasonably re-claim, and one told only "success" would navigate to a chat that does not exist. It answers `200` with the role claimed, `url: "/"`, and a sentence naming the conversation as the thing that is missing.
- **A refused claim mints nothing.** A scaffold for somebody who is not the administrator would compose a stranger's first turn over the company layer.

## F27 — a chat says what it is

The header's flavour read `workspaces.filter(w => w !== "_global").length === 0 ? "chat · admin" : "chat"` — mount arithmetic, true only while the setup conversation mounted `_global` alone. The two-scaffold ruling made it mount the admin's own desk as well, and the instance's most consequential chat began announcing itself as an ordinary `chat · personal`.

The kind travels on the record now: `Chat.scaffoldKind`, set by `scaffoldToChat`, **preserved through `normalise`** so it survives a reload — without that the flavour would be right on the turn the scaffold opened the chat and wrong on every load after, which is the sort of half-fix that reads as fixed.

## Honest limits

- **No real-click proof.** The stack is frozen while the founder is signed in; nothing here is built or deployed. The four proofs — claim lands in the setup chat · a second browser reaches the same chat · a failed mint shows the sentence and keeps the role · the flavour reads `chat · admin` with a desk mounted — run on the next scratch walk.
- **Depends on #1398 being deployed first** (`POST /internal/scaffolds` on agent-api). Until then the mint 404s and the claim degrades to `url: "/"` with the sentence — which is the designed failure, but it is a degradation, not the feature.
- The terminal still needs `AGENT_API_URL` and `VEXA_INTERNAL_API_SECRET`; both are already in its container env on the dogfood stack.

<!-- vexa-agent -->
