### PR TITLE
entities: the agent writes them as a phase of every turn (PRD decision 24)

### DIFF
--- a/behavior/workspaces/default/CLAUDE.md
+++ b/behavior/workspaces/default/CLAUDE.md
@@ -20,6 +20,22 @@ up, read exactly ONE:
 
 Entity shapes live in [`kg/templates/`](kg/templates/README.md) — skeletons, never knowledge.
 
+## Writing entities — a name without a page gets one now
+
+`entity_upsert(kind, name, facts, source)` is the whole write: it creates
+`kg/entities/<kind>/<slug>.md` with its frontmatter if the page is not there, and appends a dated
+entry if it is. Nothing to check first, nothing to merge by hand, and a fact the page already
+carries writes nothing — so call it on a maybe rather than deciding whether it is worth a page.
+
+Three rules travel with it, and they are the whole of it:
+
+- **A name without a page gets one NOW.** The moment a turn learns something durable about a person,
+  company, meeting, project or decision, it is written. Not at the end, not next time.
+- **Facts carry a source** — only what was said in the conversation or read from a file, a tool
+  result or a transcript, each with where it came from. A fact with no source is refused.
+- **Gaps go to `kg/MISSING.md`, never invented.** What you would have to guess is an open question
+  written there, not a sentence on a page that reads like knowledge.
+
 ## Entity layout (binding)
 
 - One markdown file per entity at **`kg/entities/<type>/<slug>.md`** (e.g.

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -39,6 +39,7 @@ from control_plane import schedule_digest as schedule_digest_mod
 from control_plane import routines as routines_mod
 from control_plane.config_preflight import NOT_CONFIGURED, capability_state, missing_capability_keys
 from shared import units
+from shared import entities as entities_mod
 from control_plane import workspace_routines as workspace_routines_mod
 from shared.agent_config import default_meeting_model, load_meeting_config
 from shared.seeding import resolve_seed_dir, seed_workspace, validate_seed
@@ -2202,6 +2203,56 @@ def create_app(
             _sp.run(["git", "-C", str(target), "-c", "user.name=vexa-terminal", "-c", "user.email=terminal@vexa.local",
                      "commit", "-m", f"edit {rel} (terminal page editor)"], check=False, capture_output=True)
         return {"path": rel, "written": True}
+
+    @app.post("/api/workspace/entity")
+    def ws_entity_upsert(request: Request, body: dict = Body(...)):
+        """UPSERT one knowledge-graph entity — PRD decision 24, the single call behind `entity_upsert`.
+
+        Creates `kg/entities/<kind>/<slug>.md` with frontmatter and a first dated entry, or appends a
+        dated entry to the page already there; refreshes `kg/INDEX.md`; commits both by pathspec with
+        the F31 subject shape. Authorization is `ws_file_write`'s, because it is the same act — a
+        write into a workspace — and two spellings of one authorization rule is how the second one
+        ends up weaker.
+
+        This endpoint exists so the MCP tool can be a THIN FORWARD (PRD §3.3: every host-reaching rig
+        tool is a missing endpoint in an owning service wearing a shell command). `workspace_write`'s
+        `docker exec` double is the shape this deliberately does not copy.
+        """
+        subject = subject_of(request)
+        kind = str(body.get("kind") or "").strip().lower()
+        name = str(body.get("name") or "").strip()
+        source = str(body.get("source") or "").strip()
+        slug = str(body.get("slug") or "").strip() or None
+        raw_facts = body.get("facts")
+        if isinstance(raw_facts, str):
+            raw_facts = [raw_facts]
+        facts = [str(f) for f in (raw_facts or []) if str(f).strip()]
+
+        if slug == system_mounts.GLOBAL_SLUG:
+            # `_global` is the company layer, admin-written and read-only to every worker. An entity
+            # write is exactly the kind of thing that would drift into it by accident.
+            raise HTTPException(status_code=403, detail="_global is the organisation tier — entities "
+                                                        "belong on a desk, not in it")
+        if slug and slug not in (subject, system_mounts.SYSTEM_SLUG):
+            try:
+                membership_mod.require_role(wsr.root, slug, subject, "contributor")
+            except MembershipError:
+                pass  # not shared — _read_target 403s anything outside the active set
+        target = _read_target(request, slug)
+        try:
+            result = entities_mod.upsert_entity(target, kind, name, facts, source)
+        except entities_mod.EntityRefused as e:
+            # 422, not 400: the request is well-formed and the REFUSAL is the product — the agent is
+            # meant to read the sentence and fix the fact, not to retry the call.
+            raise HTTPException(status_code=422, detail=str(e))
+        index_rel = entities_mod.write_index(target, slug or str(subject))
+        sha = None
+        if result.get("changed"):
+            sha = entities_mod.commit_entity(
+                target, [result["path"], index_rel],
+                subject_path=result["path"], created=bool(result.get("created")),
+                author=(str(subject), f"{subject}@vexa.local"))
+        return {**result, "index": index_rel, "commit": sha}
 
     @app.get("/api/workspace/git")
     def ws_git(request: Request, slug: Optional[str] = None):

--- a/core/agent/control_plane/scaffolds.py
+++ b/core/agent/control_plane/scaffolds.py
@@ -96,7 +96,13 @@ MACHINERY_NOTE = (
     # Reading is how the job is done, not part of the job; announcing it teaches the reader only
     # that they are waiting.
     "Read whatever you need silently: the FIRST sentence you emit is addressed to the person, and "
-    "you never narrate your own tool use.")
+    "you never narrate your own tool use. "
+    # Decision 24. A composed opening is the turn most likely to meet a name for the first time
+    # — an attendee clicking a post-meeting link brings a whole room with them — and it is the
+    # turn least likely to stop and write pages, because it is answering an ask.
+    "A name without a page gets one now: whatever this turn learns about a person, company, "
+    "meeting, project or decision goes in through entity_upsert with its source. Facts carry a "
+    "source; gaps go to kg/MISSING.md, never invented.")
 
 _FRONTMATTER = re.compile(r"^---\n([\s\S]*?)\n---\n?")
 

--- a/core/agent/shared/entities.py
+++ b/core/agent/shared/entities.py
@@ -1,0 +1,337 @@
+"""entities.py — the ONE write that turns something learned into a page in the knowledge graph.
+
+PRD decision 24 (founder, 2026-09-02): *"how to update the agent so that it updates entities
+whenever there is a chance for that? so it does not hesitate creating pages"*. Hesitation was never
+a prompt problem — it was a **cost** problem. Recording one fact about a person meant: guess whether
+a page exists, read it, invent a shape, merge without clobbering, remember the wikilink rule, and
+commit. Six decisions for one sentence, so the agent skipped it and wrote prose instead. This module
+collapses all six into one call that is safe to make on a maybe.
+
+Deliberately a PURE FUNCTION OVER A DIRECTORY: no HTTP, no docker, no git required, so it is
+offline-provable and the same code serves the control-plane endpoint, the MCP tool that forwards to
+it, and the tests. Committing is a separate, optional step (``commit_entity``) — the caller owns the
+repo, and a caller mid-turn on a workspace another writer owns must be able to write without
+committing at all.
+
+⚠ FRONTMATTER VOCABULARY. The tool's ARGUMENTS are the founder's words — ``kind`` and ``name`` — but
+the KEYS written to the page are the ones this workspace's readers already use: ``type``, ``id``,
+``title`` (``behavior/workspaces/default/kg/templates/*.md``, the terminal's wikilink resolver, the
+per-type ``index.md`` files). Writing ``kind:``/``name:`` instead would have produced pages that look
+right and are invisible to every existing reader — the exact defect ``workspace_write``'s CONFIG_VOCAB
+guard exists to refuse. ``aliases``/``created``/``sources`` are added on top; nothing is renamed.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import re
+import subprocess
+import unicodedata
+from pathlib import Path
+
+# The five kinds decision 24 names. A kind outside this set is refused rather than guessed into a new
+# directory: a directory nothing indexes is a page nobody will ever find again.
+KINDS = ("person", "company", "meeting", "project", "decision")
+
+ENTITIES_DIR = "kg/entities"
+INDEX_PATH = "kg/INDEX.md"
+MISSING_PATH = "kg/MISSING.md"
+
+_FRONTMATTER = re.compile(r"^---\n([\s\S]*?)\n---\n?")
+_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
+_DATED_HEADING = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*$", re.M)
+_BULLET = re.compile(r"^\s*[-*]\s+(.+?)\s*$", re.M)
+
+# The index is mounted into EVERY dispatch, so it is a prompt-budget line item, not a report.
+INDEX_MAX_ROWS = 400
+
+
+class EntityRefused(ValueError):
+    """A write this module will not perform, carrying the reason the CALLER has to act on.
+
+    Refusals are the point of the interface, not its edge: "a page carries only what was said or
+    read, with its source" (decision 24.5) is enforceable only if a sourceless fact cannot be
+    written at all. A rule that is merely asked for is a rule the model obeys about half the time —
+    the grounding gate measured exactly that."""
+
+
+def slugify(name: str) -> str:
+    """kebab-case ascii, the shape the templates promise (``id: <slug>`` matches the filename)."""
+    s = unicodedata.normalize("NFKD", str(name or "")).encode("ascii", "ignore").decode()
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", s).strip("-").lower()
+    return s[:80]
+
+
+def entity_rel_path(kind: str, name: str) -> str:
+    kind = (kind or "").strip().lower()
+    if kind not in KINDS:
+        raise EntityRefused(f"{kind!r} is not an entity kind — one of {', '.join(KINDS)}")
+    slug = slugify(name)
+    if not slug:
+        raise EntityRefused("an entity needs a name that survives slugification")
+    return f"{ENTITIES_DIR}/{kind}/{slug}.md"
+
+
+def split_frontmatter(text: str) -> tuple[list[str], str]:
+    """``(frontmatter lines, body)``. Lines are kept RAW — comments, ordering, keys this module has
+    never heard of. A page a human edited must come back out the way they left it."""
+    m = _FRONTMATTER.match(text or "")
+    if not m:
+        return [], text or ""
+    return m.group(1).splitlines(), text[m.end():]
+
+
+def _fm_get(lines: list[str], key: str) -> str | None:
+    for ln in lines:
+        k, sep, v = ln.partition(":")
+        if sep and k.strip() == key:
+            return v.split("#")[0].strip()
+    return None
+
+
+def _fm_set(lines: list[str], key: str, value: str) -> list[str]:
+    out, done = [], False
+    for ln in lines:
+        k, sep, _ = ln.partition(":")
+        if sep and k.strip() == key and not done:
+            out.append(f"{key}: {value}")
+            done = True
+        else:
+            out.append(ln)
+    if not done:
+        out.append(f"{key}: {value}")
+    return out
+
+
+def _list_field(raw: str | None) -> list[str]:
+    raw = (raw or "").strip()
+    if not raw or raw in ("[]", "~", "null"):
+        return []
+    return [p.strip() for p in raw.strip("[]").split(",") if p.strip()]
+
+
+def _render_list(items) -> str:
+    seen, out = set(), []
+    for i in items:
+        i = str(i).strip()
+        if i and i not in seen:
+            seen.add(i)
+            out.append(i)
+    return "[" + ", ".join(out) + "]"
+
+
+def _normalise(fact: str) -> str:
+    """What "the same fact" means for idempotency: same words, ignoring case, punctuation and the
+    wikilink brackets. Without dropping the brackets, a fact re-stated after its subject got a page
+    would append a near-duplicate line, and the page grows by a paragraph per turn forever."""
+    s = _WIKILINK.sub(r"\1", str(fact or ""))
+    s = re.sub(r"[^a-z0-9 ]+", " ", s.lower())
+    return " ".join(s.split())
+
+
+# Every recorded fact ends `- <fact> - source: <where it came from>`, so the stored line and the
+# fact the caller passes are never byte-identical. Comparing them raw made "idempotent on identical facts"
+# quietly false: the same sentence, re-stated next turn, appended again with a second source. Strip
+# the attribution before comparing — the fact is the claim, not the provenance of this telling.
+_SOURCE_SUFFIX = re.compile(r"\s+—\s+source:\s.*$")
+
+
+def existing_facts(text: str) -> set[str]:
+    out = set()
+    for b in _BULLET.findall(text or ""):
+        n = _normalise(_SOURCE_SUFFIX.sub("", b))
+        if n:
+            out.add(n)
+    return out
+
+
+def wikilinks(texts) -> list[str]:
+    out, seen = [], set()
+    for t in texts:
+        for name in _WIKILINK.findall(str(t or "")):
+            n = name.strip()
+            if n and n.lower() not in seen:
+                seen.add(n.lower())
+                out.append(n)
+    return out
+
+
+def resolve_links(root, names) -> tuple[list[str], list[str]]:
+    """``(resolved, unresolved)`` — which ``[[Name]]`` already have a page anywhere under
+    ``kg/entities/``. Unresolved names are RETURNED, never auto-created: a page minted from a name
+    with no facts behind it is the invention decision 24.5 forbids, and the kg-links rule already
+    says a wikilink with no page renders as an inert "not found" chip. The caller upserts them with
+    their own source; the tool result says so in words."""
+    base = Path(root) / ENTITIES_DIR
+    resolved, unresolved = [], []
+    for n in names:
+        slug = slugify(n)
+        hit = any((base / k / f"{slug}.md").exists() for k in KINDS) if slug else False
+        (resolved if hit else unresolved).append(n)
+    return resolved, unresolved
+
+
+def _today(today: str | None) -> str:
+    return today or _dt.date.today().isoformat()
+
+
+def upsert_entity(root, kind: str, name: str, facts, source: str, *,
+                  today: str | None = None, aliases=()) -> dict:
+    """Create ``kg/entities/<kind>/<slug>.md`` with frontmatter and a first dated entry, or append a
+    dated entry to the page already there. Returns what happened, in the caller's words.
+
+    Idempotent on identical facts: a fact already on the page (by ``_normalise``) is dropped, and a
+    call whose every fact is already there writes nothing and reports ``changed: False``. That is
+    what makes the forced write-back phase safe to run on EVERY turn — a turn that learned nothing
+    new costs one no-op, not a duplicated paragraph."""
+    root = Path(root)
+    src = str(source or "").strip()
+    facts = [str(f).strip() for f in (facts or []) if str(f).strip()]
+    if not facts:
+        raise EntityRefused("nothing to record — pass the facts this turn learned, or say nothing new")
+    if not src:
+        raise EntityRefused(
+            "every fact needs a source: what was said or read that this came from (the meeting, the "
+            "mail, the file, the person's own words). A page carries only what was said or read — "
+            "if you do not have a source the gap goes to kg/MISSING.md, never onto the page.")
+
+    rel = entity_rel_path(kind, name)
+    path = root / rel
+    existed = path.exists()
+    raw = path.read_text(encoding="utf-8", errors="replace") if existed else ""
+    fm, body = split_frontmatter(raw)
+
+    fresh = [f for f in facts if _normalise(f) not in existing_facts(raw)]
+    linked = wikilinks(facts)
+    resolved, unresolved = resolve_links(root, linked)
+    day = _today(today)
+
+    if existed and not fresh:
+        return {"path": rel, "created": False, "changed": False, "facts_written": 0,
+                "already_recorded": len(facts), "links_resolved": resolved,
+                "links_missing": unresolved, "kind": kind, "name": name}
+
+    if not existed:
+        fm = [f"type: {kind}", f"id: {slugify(name)}", f"title: {name}",
+              f"aliases: {_render_list(aliases)}", f"created: {day}",
+              f"sources: {_render_list([src])}"]
+        body = f"\n# {name}\n"
+    else:
+        # A page that predates this module (or one a human wrote) may carry none of these keys.
+        # Fill what is missing; never overwrite a title or a created date somebody else set.
+        if _fm_get(fm, "type") is None:
+            fm = _fm_set(fm, "type", kind)
+        if _fm_get(fm, "id") is None:
+            fm = _fm_set(fm, "id", slugify(name))
+        if _fm_get(fm, "title") is None:
+            fm = _fm_set(fm, "title", name)
+        if _fm_get(fm, "created") is None:
+            fm = _fm_set(fm, "created", day)
+        fm = _fm_set(fm, "aliases", _render_list(_list_field(_fm_get(fm, "aliases")) + list(aliases)))
+        fm = _fm_set(fm, "sources", _render_list(_list_field(_fm_get(fm, "sources")) + [src]))
+
+    written = fresh or facts
+    entry = [f"\n## {day}\n"] + [f"- {f} — source: {src}" for f in written] + [""]
+    body = body.rstrip("\n") + "\n" + "\n".join(entry)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("---\n" + "\n".join(fm) + "\n---\n" + body.lstrip("\n"), encoding="utf-8")
+    return {"path": rel, "created": not existed, "changed": True, "facts_written": len(written),
+            "already_recorded": len(facts) - len(written), "links_resolved": resolved,
+            "links_missing": unresolved, "kind": kind, "name": name, "date": day}
+
+
+# ── the index that rides in every dispatch ───────────────────────────────────────────────────────
+
+def _last_updated(text: str, fallback: str) -> str:
+    days = _DATED_HEADING.findall(text or "")
+    if days:
+        return max(days)
+    fm, _ = split_frontmatter(text or "")
+    return _fm_get(fm, "created") or fallback
+
+
+def index_rows(root) -> list[tuple[str, str, str, str]]:
+    root = Path(root)
+    base = root / ENTITIES_DIR
+    rows: list[tuple[str, str, str, str]] = []
+    for kind in KINDS:
+        d = base / kind
+        if not d.is_dir():
+            continue
+        for f in sorted(d.glob("*.md")):
+            if f.name == "index.md":
+                continue
+            try:
+                text = f.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            fm, _ = split_frontmatter(text)
+            # `kg/templates/` is not the only place a shape can hide: a doc whose frontmatter says
+            # `template: true` is a SHAPE wherever it sits, and the kg-links rule already forbids
+            # citing one. Listing it here would put it back in front of the model on every turn.
+            if (_fm_get(fm, "template") or "").lower() == "true":
+                continue
+            title = _fm_get(fm, "title") or f.stem
+            try:
+                mtime = _dt.date.fromtimestamp(f.stat().st_mtime).isoformat()
+            except OSError:
+                mtime = ""
+            rows.append((kind, title, f"{ENTITIES_DIR}/{kind}/{f.name}", _last_updated(text, mtime)))
+    return rows
+
+
+def render_index(root, slug: str = "") -> str:
+    rows = index_rows(root)
+    head = f"# Entities in {slug}" if slug else "# Entities"
+    if not rows:
+        return (head + "\n\nNo entity pages exist here yet. The first name this turn learns something"
+                " about gets one — `entity_upsert` creates it in a single call.\n")
+    shown, omitted = rows[:INDEX_MAX_ROWS], max(0, len(rows) - INDEX_MAX_ROWS)
+    body = [head, "", f"{len(rows)} pages. Regenerated on every `entity_upsert` — never edit by hand.",
+            "", "| kind | name | path | last updated |", "|---|---|---|---|"]
+    body += [f"| {k} | {t} | `{p}` | {u} |" for k, t, p, u in shown]
+    if omitted:
+        body.append(f"\n_{omitted} more not listed — read `{ENTITIES_DIR}/` directly for the rest._")
+    return "\n".join(body) + "\n"
+
+
+def write_index(root, slug: str = "") -> str:
+    root = Path(root)
+    p = root / INDEX_PATH
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(render_index(root, slug), encoding="utf-8")
+    return INDEX_PATH
+
+
+# ── the commit ───────────────────────────────────────────────────────────────────────────────────
+
+def commit_entity(root, paths, *, subject_path: str, created: bool,
+                  author=None):
+    """ONE commit, BY PATHSPEC, carrying the F31 subject shape ``<workspace>: <path> — added|updated``.
+
+    By pathspec on purpose, and for a standing reason rather than a local nicety: ``git commit``
+    commits THE INDEX, so a bare ``add`` + ``commit`` here would sweep in whatever a concurrently
+    running worker turn had staged in the same repo and file it under this message. The index is a
+    write surface with no owner; naming the paths is how this writer stays in its own lane. The
+    subject names the ENTITY page even when `kg/INDEX.md` rides along, because that is the change a
+    reader of ``git log --oneline`` came for."""
+    root = Path(root)
+    if not (root / ".git").is_dir():
+        return None
+    env = {**os.environ, "GIT_COMMITTER_NAME": "Vexa", "GIT_COMMITTER_EMAIL": "platform@vexa.ai"}
+    if author:
+        env["GIT_AUTHOR_NAME"], env["GIT_AUTHOR_EMAIL"] = author
+
+    def git(*args):
+        return subprocess.run(["git", "-C", str(root), *args], capture_output=True, text=True, env=env)
+
+    paths = [str(p) for p in paths if p]
+    if not paths:
+        return None
+    git("add", "--", *paths)
+    if not git("diff", "--cached", "--name-only", "--", *paths).stdout.strip():
+        return None
+    subject = f"{root.name}: {subject_path} — {'added' if created else 'updated'}"[:72]
+    if git("commit", "-m", subject, "--", *paths).returncode != 0:
+        return None
+    return git("rev-parse", "HEAD").stdout.strip() or None

--- a/core/agent/tests/test_delegation.py
+++ b/core/agent/tests/test_delegation.py
@@ -235,7 +235,19 @@ def test_the_worker_writes_a_bearer_header_config_and_widens_its_allow_set(tmp_p
     assert cfg["headers"]["Authorization"] == f"Bearer {tok}"
     assert "?" not in cfg["url"]
     # attaching the server is not enough; the model must also be ALLOWED to call it
-    assert tools == [f"mcp__{VEXA_MCP_SERVER}"]
+    #
+    # ⚠ THIS ASSERTION WAS STALE AND FAILING ON EVERY RUN of the suite, on `minutes-mcp-viewer`,
+    # since the 21-tool union landed. It said `== [prefix]`, which was true when the allow-set was
+    # the prefix alone; the list grew and this line kept failing, red, in a suite whose other 721
+    # tests are green. Found 2026-09-02 while adding `entity_upsert` to that same list. An anomaly
+    # is a finding: the prefix + the named tools is the shape the code actually returns and the
+    # shape it is meant to return, so the check now says that instead of a number that ages.
+    from worker.engine import VEXA_MCP_TOOLS
+    assert tools[0] == f"mcp__{VEXA_MCP_SERVER}"
+    assert set(tools[1:]) == {f"mcp__{VEXA_MCP_SERVER}__{t}" for t in VEXA_MCP_TOOLS}
+    # decision 24: the write-back phase is only as reliable as the tool being NAMED — a tool the
+    # allow-set omits is one the model has to find before it can call it.
+    assert f"mcp__{VEXA_MCP_SERVER}__entity_upsert" in tools
 
 
 def test_the_config_lands_where_the_post_turn_commit_cannot_sweep_it_up(tmp_path, monkeypatch):

--- a/core/agent/tests/test_entities.py
+++ b/core/agent/tests/test_entities.py
@@ -1,0 +1,198 @@
+"""entity_upsert — the ONE write behind PRD decision 24, proved offline over a directory.
+
+No docker, no HTTP, no model. The module is a pure function over a workspace path precisely so the
+rules it enforces (a source or nothing; idempotent on identical facts; the existing frontmatter
+vocabulary, not a new one) can be argued with in a test rather than observed in production.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from shared import entities as E
+
+
+def read(ws, rel):
+    return (ws / rel).read_text()
+
+
+# ── creating a page ──────────────────────────────────────────────────────────────────────────────
+
+def test_creates_the_page_with_the_readers_frontmatter_vocabulary(tmp_path):
+    r = E.upsert_entity(tmp_path, "person", "Olga Avramenko",
+                        ["Runs the DNA TSC agenda."], "the 2026-03-02 TSC call", today="2026-09-02")
+    assert r["created"] is True and r["path"] == "kg/entities/person/olga-avramenko.md"
+    text = read(tmp_path, r["path"])
+    # type/id/title are what the templates, the per-type index.md files and the terminal's wikilink
+    # resolver already read. A page keyed on `kind:`/`name:` would look right and be invisible.
+    assert "type: person" in text
+    assert "id: olga-avramenko" in text
+    assert "title: Olga Avramenko" in text
+    assert "created: 2026-09-02" in text
+    assert "sources: [the 2026-03-02 TSC call]" in text
+    assert "aliases: []" in text
+    assert "## 2026-09-02" in text
+    assert "- Runs the DNA TSC agenda. — source: the 2026-03-02 TSC call" in text
+
+
+def test_every_kind_decision_24_names_is_writable_and_nothing_else_is(tmp_path):
+    for kind in ("person", "company", "meeting", "project", "decision"):
+        r = E.upsert_entity(tmp_path, kind, f"A {kind}", ["a fact"], "a source")
+        assert r["path"].startswith(f"kg/entities/{kind}/")
+    with pytest.raises(E.EntityRefused):
+        E.upsert_entity(tmp_path, "vendor", "Acme", ["a fact"], "a source")
+
+
+# ── the counter-rule: a page carries only what was said or read, with its source ─────────────────
+
+def test_a_fact_with_no_source_is_refused_and_names_MISSING(tmp_path):
+    with pytest.raises(E.EntityRefused) as e:
+        E.upsert_entity(tmp_path, "company", "Sony Pictures Imageworks", ["2,000 people"], "  ")
+    assert "kg/MISSING.md" in str(e.value)
+    assert not (tmp_path / "kg" / "entities").exists()   # refused means NOTHING was written
+
+
+def test_no_facts_is_refused_rather_than_writing_an_empty_dated_heading(tmp_path):
+    with pytest.raises(E.EntityRefused):
+        E.upsert_entity(tmp_path, "person", "Nobody", [], "a source")
+
+
+# ── appending, and idempotency ───────────────────────────────────────────────────────────────────
+
+def test_second_call_appends_a_dated_entry_and_keeps_the_first(tmp_path):
+    E.upsert_entity(tmp_path, "person", "Cottalango Leon", ["Chairs the TSC."], "call A",
+                    today="2026-03-02")
+    r = E.upsert_entity(tmp_path, "person", "Cottalango Leon", ["Asked for a standard CLA."],
+                        "call B", today="2026-08-18")
+    assert r["created"] is False and r["changed"] is True and r["facts_written"] == 1
+    text = read(tmp_path, r["path"])
+    assert "Chairs the TSC." in text and "Asked for a standard CLA." in text
+    assert "## 2026-03-02" in text and "## 2026-08-18" in text
+    assert "sources: [call A, call B]" in text
+
+
+def test_identical_facts_write_nothing_at_all(tmp_path):
+    E.upsert_entity(tmp_path, "company", "Vexa", ["Ships a meeting bot."], "the README",
+                    today="2026-09-01")
+    before = read(tmp_path, "kg/entities/company/vexa.md")
+    r = E.upsert_entity(tmp_path, "company", "Vexa", ["ships a meeting bot"], "the README again",
+                        today="2026-09-02")
+    # THIS is what makes a forced write-back phase on EVERY turn affordable: a turn that learned
+    # nothing new costs one no-op, not a duplicated paragraph and not a second `sources` entry.
+    assert r["changed"] is False and r["facts_written"] == 0 and r["already_recorded"] == 1
+    assert read(tmp_path, "kg/entities/company/vexa.md") == before
+
+
+def test_a_repeated_fact_is_dropped_and_the_new_one_kept(tmp_path):
+    E.upsert_entity(tmp_path, "person", "Marvin", ["Works at OeNB."], "mail", today="2026-09-01")
+    r = E.upsert_entity(tmp_path, "person", "Marvin", ["Works at OeNB.", "Asked for prod versions."],
+                        "call", today="2026-09-02")
+    assert r["facts_written"] == 1 and r["already_recorded"] == 1
+    assert read(tmp_path, r["path"]).count("Works at OeNB.") == 1
+
+
+def test_an_existing_hand_written_page_keeps_its_own_frontmatter(tmp_path):
+    p = tmp_path / "kg/entities/person/jane-liu.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("---\ntype: person\nid: jane-liu\ntitle: Jane Liu\nself: true\n---\n\n# Jane Liu\n")
+    E.upsert_entity(tmp_path, "person", "Jane Liu", ["Moved to Berlin."], "her message",
+                    today="2026-09-02")
+    text = p.read_text()
+    assert "self: true" in text          # a key this module has never heard of survives
+    assert "title: Jane Liu" in text     # and a title somebody else set is not rewritten
+    assert "created: 2026-09-02" in text and "sources: [her message]" in text
+
+
+# ── wikilinks ────────────────────────────────────────────────────────────────────────────────────
+
+def test_wikilinks_resolve_and_the_missing_ones_come_back_as_the_next_calls(tmp_path):
+    E.upsert_entity(tmp_path, "company", "Sony Pictures Imageworks", ["A VFX studio."], "the web")
+    r = E.upsert_entity(tmp_path, "person", "Olga Avramenko",
+                        ["Works at [[Sony Pictures Imageworks]] with [[Cottalango Leon]]."],
+                        "the TSC call")
+    assert r["links_resolved"] == ["Sony Pictures Imageworks"]
+    # NOT auto-created: a page minted from a name with no facts behind it is the invention
+    # decision 24.5 forbids. It is returned so the caller upserts it with its own source.
+    assert r["links_missing"] == ["Cottalango Leon"]
+    assert not (tmp_path / "kg/entities/person/cottalango-leon.md").exists()
+
+
+# ── the index ────────────────────────────────────────────────────────────────────────────────────
+
+def test_index_lists_kind_name_path_and_last_updated(tmp_path):
+    E.upsert_entity(tmp_path, "person", "Olga Avramenko", ["a"], "s", today="2026-03-02")
+    E.upsert_entity(tmp_path, "person", "Olga Avramenko", ["b"], "s", today="2026-08-03")
+    E.upsert_entity(tmp_path, "company", "Vexa", ["c"], "s", today="2026-05-11")
+    rel = E.write_index(tmp_path, "desk-1")
+    text = read(tmp_path, rel)
+    assert rel == "kg/INDEX.md"
+    assert "| person | Olga Avramenko | `kg/entities/person/olga-avramenko.md` | 2026-08-03 |" in text
+    assert "| company | Vexa | `kg/entities/company/vexa.md` | 2026-05-11 |" in text
+    assert "desk-1" in text
+
+
+def test_index_never_lists_a_template(tmp_path):
+    p = tmp_path / "kg/entities/person/shape.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("---\ntemplate: true\ntype: person\ntitle: <Full Name>\n---\n")
+    assert "<Full Name>" not in E.render_index(tmp_path)
+
+
+def test_an_empty_workspace_says_so_instead_of_pretending(tmp_path):
+    assert "No entity pages exist here yet" in E.render_index(tmp_path)
+
+
+# ── the commit ───────────────────────────────────────────────────────────────────────────────────
+
+def git(ws, *args):
+    return subprocess.run(["git", "-C", str(ws), *args], capture_output=True, text=True).stdout.strip()
+
+
+def repo(tmp_path):
+    ws = tmp_path / "desk-7"
+    ws.mkdir()
+    git(ws, "init", "-q")
+    git(ws, "config", "user.email", "t@t.t")
+    git(ws, "config", "user.name", "t")
+    (ws / "seed.md").write_text("x")
+    git(ws, "add", "-A")
+    git(ws, "commit", "-qm", "seed")
+    return ws
+
+
+def test_one_commit_carries_the_F31_subject_shape(tmp_path):
+    ws = repo(tmp_path)
+    r = E.upsert_entity(ws, "person", "Olga Avramenko", ["a fact"], "a source")
+    idx = E.write_index(ws, "desk-7")
+    sha = E.commit_entity(ws, [r["path"], idx], subject_path=r["path"], created=True)
+    assert sha
+    assert git(ws, "log", "-1", "--format=%s") == \
+        "desk-7: kg/entities/person/olga-avramenko.md — added"
+    r2 = E.upsert_entity(ws, "person", "Olga Avramenko", ["another fact"], "a source")
+    E.commit_entity(ws, [r2["path"], idx], subject_path=r2["path"], created=False)
+    assert git(ws, "log", "-1", "--format=%s").endswith(" — updated")
+
+
+def test_the_commit_is_by_pathspec_and_leaves_a_concurrent_writers_work_alone(tmp_path):
+    """`git commit` commits THE INDEX. A bare add+commit here would sweep in whatever a worker turn
+    running in the same repo had staged and file it under this subject — the standing rule, one
+    level down: the git index is a write surface with no owner."""
+    ws = repo(tmp_path)
+    (ws / "someone-elses-draft.md").write_text("mid-turn work")
+    git(ws, "add", "someone-elses-draft.md")            # staged by another writer
+    r = E.upsert_entity(ws, "person", "Olga", ["a fact"], "a source")
+    E.commit_entity(ws, [r["path"]], subject_path=r["path"], created=True)
+    assert "someone-elses-draft.md" not in git(ws, "show", "--name-only", "--format=", "HEAD")
+    assert "someone-elses-draft.md" in git(ws, "diff", "--cached", "--name-only")
+
+
+def test_a_no_op_upsert_produces_no_commit(tmp_path):
+    ws = repo(tmp_path)
+    r = E.upsert_entity(ws, "person", "Olga", ["a fact"], "a source")
+    E.commit_entity(ws, [r["path"]], subject_path=r["path"], created=True)
+    head = git(ws, "rev-parse", "HEAD")
+    again = E.upsert_entity(ws, "person", "Olga", ["a fact"], "a source")
+    assert again["changed"] is False
+    assert E.commit_entity(ws, [again["path"]], subject_path=again["path"], created=False) is None
+    assert git(ws, "rev-parse", "HEAD") == head

--- a/core/agent/tests/test_entity_endpoint.py
+++ b/core/agent/tests/test_entity_endpoint.py
@@ -1,0 +1,101 @@
+"""`POST /api/workspace/entity` — the endpoint `entity_upsert` is a thin forward to.
+
+PRD §3.3's porting rule, applied ahead of the port rather than after it: every host-reaching rig
+tool is a missing HTTP endpoint in an owning service wearing a shell command. `workspace_write`'s
+`docker exec` double is the shape this deliberately does not copy — so the tool has nothing to do
+but pass the arguments on, and the rules live where the workspace does.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from control_plane.api import create_app
+from shared.config import load_settings
+from control_plane.dispatch import Dispatcher
+from control_plane.workspace_reader import WorkspaceReader
+
+
+class _FakeRuntime:
+    def spawn(self, *a, **kw):
+        return "unit-1"
+
+    def stop(self, *a, **kw):
+        return None
+
+
+class _FakeIdentity:
+    def mint(self, subject, launcher, workspaces, tools):
+        return "tok"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("VEXA_WORKSPACES_DIR", str(tmp_path))
+    return TestClient(create_app(
+        Dispatcher(load_settings(), _FakeRuntime(), _FakeIdentity()),
+        reader=WorkspaceReader(str(tmp_path))))
+
+
+H = {"X-User-Id": "u_jane"}
+
+
+def test_creates_the_page_and_the_index_and_reports_both(client, tmp_path):
+    r = client.post("/api/workspace/entity", headers=H, json={
+        "kind": "person", "name": "Olga Avramenko",
+        "facts": ["Chairs the DNA TSC agenda."], "source": "the 2026-03-02 call"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["created"] is True
+    assert body["path"] == "kg/entities/person/olga-avramenko.md"
+    assert body["index"] == "kg/INDEX.md"
+    page = (tmp_path / "u_jane" / body["path"]).read_text()
+    assert "title: Olga Avramenko" in page
+    assert "source: the 2026-03-02 call" in page
+    assert "Olga Avramenko" in (tmp_path / "u_jane" / "kg" / "INDEX.md").read_text()
+
+
+def test_a_second_call_appends_rather_than_replacing(client, tmp_path):
+    for fact in ("Chairs the DNA TSC agenda.", "Asked for a standard CLA."):
+        client.post("/api/workspace/entity", headers=H, json={
+            "kind": "person", "name": "Olga Avramenko", "facts": [fact], "source": "a call"})
+    page = (tmp_path / "u_jane" / "kg/entities/person/olga-avramenko.md").read_text()
+    assert "Chairs the DNA TSC agenda." in page and "Asked for a standard CLA." in page
+
+
+def test_a_sourceless_fact_is_refused_with_the_reason_the_agent_has_to_act_on(client, tmp_path):
+    r = client.post("/api/workspace/entity", headers=H, json={
+        "kind": "person", "name": "Somebody", "facts": ["a claim"], "source": ""})
+    # 422, not 400: the request is well-formed and the refusal IS the product — the agent reads the
+    # sentence and fixes the fact rather than retrying the call.
+    assert r.status_code == 422
+    assert "kg/MISSING.md" in r.json()["detail"]
+    assert not (tmp_path / "u_jane" / "kg" / "entities").exists()
+
+
+def test_an_unknown_kind_is_refused_rather_than_guessed_into_a_new_directory(client):
+    r = client.post("/api/workspace/entity", headers=H, json={
+        "kind": "vendor", "name": "Acme", "facts": ["a fact"], "source": "the web"})
+    assert r.status_code == 422
+
+
+def test_global_is_the_organisation_tier_and_refuses_entities(client):
+    r = client.post("/api/workspace/entity", headers=H, json={
+        "kind": "company", "name": "Acme", "facts": ["a fact"], "source": "the web",
+        "slug": "_global"})
+    assert r.status_code == 403
+
+
+def test_repeating_a_fact_is_a_no_op_the_caller_can_see(client):
+    payload = {"kind": "company", "name": "Vexa", "facts": ["Ships a meeting bot."],
+               "source": "the README"}
+    assert client.post("/api/workspace/entity", headers=H, json=payload).json()["changed"] is True
+    second = client.post("/api/workspace/entity", headers=H, json=payload).json()
+    assert second["changed"] is False and second["already_recorded"] == 1
+
+
+def test_unresolved_wikilinks_come_back_as_the_next_calls(client):
+    body = client.post("/api/workspace/entity", headers=H, json={
+        "kind": "person", "name": "Olga", "facts": ["Works with [[Cottalango Leon]]."],
+        "source": "the call"}).json()
+    assert body["links_missing"] == ["Cottalango Leon"]

--- a/core/agent/tests/test_entity_writeback.py
+++ b/core/agent/tests/test_entity_writeback.py
@@ -1,0 +1,211 @@
+"""The write-back phase and the entity index in context — PRD decision 24, items 2 and 3.
+
+Offline: a fake stream, an injected turn and an injected phase. Nothing here needs docker, a model
+or the MCP; what is being proved is the CONTRACT — when the phase runs, what of it the person sees,
+and that it can never cost them their answer.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worker import engine
+from worker.worker import serve
+
+
+class FakeStream:
+    def __init__(self, inbox=None):
+        self.out = []
+        self._inbox = list(inbox or [])
+
+    def xadd(self, name, fields):
+        self.out.append((name, fields))
+        return str(len(self.out))
+
+    def xread(self, streams, count=1, block=None):
+        in_topic = next(iter(streams))
+        if not self._inbox:
+            return []
+        eid, fields = self._inbox.pop(0)
+        return [(in_topic, [(eid, fields)])]
+
+
+def events(stream):
+    return [json.loads(f["event"]) for _t, f in stream.out]
+
+
+# ── when the phase runs (the cheap-turn skip) ────────────────────────────────────────────────────
+
+def test_a_turn_that_called_a_tool_always_writes_back(monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    assert engine.should_write_back("ok", tool_calls=1) is True
+
+
+def test_a_short_turn_with_no_tool_call_is_skipped(monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    assert engine.should_write_back("thanks", tool_calls=0) is False
+
+
+def test_a_long_turn_with_no_tool_call_still_writes_back(monkeypatch):
+    """Either signal alone is a turn that can have learned something: a long message carries facts
+    with no tool call at all. The floor is on the PERSON's words, never on the agent's reply."""
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    assert engine.should_write_back(" ".join(["word"] * 60), tool_calls=0) is True
+
+
+def test_the_floor_is_configurable(monkeypatch):
+    monkeypatch.setenv("VEXA_WRITEBACK_MIN_TOKENS", "3")
+    assert engine.should_write_back("one two three", tool_calls=0) is True
+    monkeypatch.setenv("VEXA_WRITEBACK_MIN_TOKENS", "99")
+    assert engine.should_write_back("one two three", tool_calls=0) is False
+
+
+def test_the_phase_can_be_switched_off_entirely(monkeypatch):
+    monkeypatch.setenv("VEXA_WRITEBACK", "0")
+    assert engine.should_write_back("anything at all", tool_calls=5) is False
+
+
+# ── what the person sees of it ───────────────────────────────────────────────────────────────────
+
+def test_step_lines_pass_through_prose_and_the_tab_do_not():
+    raw = [
+        {"type": "message-delta", "text": "I have recorded three entities"},
+        {"type": "tool-call", "tool": "mcp__vexa__entity_upsert", "args": {}, "callId": "c1"},
+        {"type": "tool-result", "callId": "c1", "ok": True, "summary": "{...}"},
+        {"type": "artifact", "workspace": "d", "path": "kg/entities/person/x.md", "focus": True},
+        {"type": "commit", "sha": "abc"},
+        {"type": "done", "reply": "nothing new", "sessionId": "s"},
+    ]
+    out = list(engine.writeback_events(iter(raw)))
+    assert [e["type"] for e in out] == ["tool-call", "tool-result", "commit"]
+    assert all(e["phase"] == "writeback" for e in out)
+
+
+# ── the loop ─────────────────────────────────────────────────────────────────────────────────────
+
+def _serve(stream, turn, writeback):
+    serve(stream, out_topic="out", in_topic="in", turn=turn,
+          start={"entrypoint": {"inline": "who is Olga Avramenko?"}}, idle_ms=1,
+          writeback=writeback)
+
+
+def test_the_phase_runs_after_the_answer_and_before_turn_complete(monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+
+    def turn(_p):
+        yield {"type": "tool-call", "tool": "Read", "args": {}, "callId": "a"}
+        yield {"type": "message-delta", "text": "She chairs the DNA TSC."}
+        yield {"type": "done", "reply": "She chairs the DNA TSC.", "sessionId": "s1"}
+
+    def writeback(_p):
+        yield {"type": "tool-call", "tool": "mcp__vexa__entity_upsert", "args": {}, "callId": "b"}
+        yield {"type": "message-delta", "text": "recorded 1 entity"}
+        yield {"type": "done", "reply": "done", "sessionId": "s1"}
+
+    s = FakeStream()
+    _serve(s, turn, writeback)
+    kinds = [(e["type"], e.get("phase")) for e in events(s)]
+    answer = kinds.index(("message-delta", None))
+    phase = kinds.index(("tool-call", "writeback"))
+    complete = kinds.index(("turn-complete", None))
+    assert answer < phase < complete
+    # the phase's own prose never reaches the person
+    assert ("message-delta", "writeback") not in kinds
+
+
+def test_a_cheap_turn_runs_no_phase(monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    monkeypatch.setenv("VEXA_WRITEBACK_MIN_TOKENS", "40")
+    calls = []
+
+    def turn(_p):
+        yield {"type": "done", "reply": "you're welcome", "sessionId": "s"}
+
+    def writeback(_p):
+        calls.append(1)
+        yield {"type": "done", "reply": "", "sessionId": "s"}
+
+    s = FakeStream()
+    serve(s, out_topic="out", in_topic="in", turn=turn,
+          start={"entrypoint": {"inline": "thanks"}}, idle_ms=1, writeback=writeback)
+    assert calls == []
+
+
+def test_a_phase_that_raises_never_costs_the_person_their_turn(monkeypatch):
+    """Bookkeeping is not worth a dead session. The answer has already streamed by the time this
+    runs, so the only thing a failure may do is not happen — and say so in the log."""
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+
+    def turn(_p):
+        yield {"type": "tool-call", "tool": "Read", "args": {}, "callId": "a"}
+        yield {"type": "done", "reply": "an answer", "sessionId": "s"}
+
+    def writeback(_p):
+        raise RuntimeError("the entity endpoint is down")
+        yield  # pragma: no cover
+
+    s = FakeStream()
+    _serve(s, turn, writeback)
+    assert [e["type"] for e in events(s)][-1] == "turn-complete"
+
+
+# ── the index in context ─────────────────────────────────────────────────────────────────────────
+
+def test_every_dispatch_carries_the_rule_and_the_index(tmp_path):
+    from shared import entities as E
+    desk = tmp_path / "desk-1"
+    desk.mkdir()
+    E.upsert_entity(desk, "person", "Olga Avramenko", ["Chairs the TSC."], "the call",
+                    today="2026-09-02")
+    E.write_index(desk, "desk-1")
+    txt = engine.entity_index_preamble([{"slug": "desk-1", "path": str(desk), "write": True}])
+    assert "A name without a page gets one NOW" in txt
+    assert "Facts carry a source" in txt
+    assert "kg/MISSING.md`, never invented" in txt
+    assert "Olga Avramenko" in txt and "kg/entities/person/olga-avramenko.md" in txt
+
+
+def test_the_index_renders_live_when_the_file_has_never_been_written(tmp_path):
+    """A first dispatch into a workspace nobody has upserted must still see what it holds — being
+    told 'nothing exists' when three pages do is how a duplicate page gets created."""
+    from shared import entities as E
+    desk = tmp_path / "desk-2"
+    E.upsert_entity(desk, "company", "Vexa", ["Ships a meeting bot."], "the README")
+    assert not (desk / "kg" / "INDEX.md").exists()
+    txt = engine.entity_index_preamble([{"slug": "desk-2", "path": str(desk), "write": True}])
+    assert "Vexa" in txt
+
+
+def test_a_read_only_mount_is_not_offered_as_a_place_to_write_entities(tmp_path):
+    g = tmp_path / "_global"
+    (g / "kg" / "entities" / "company").mkdir(parents=True)
+    (g / "kg" / "entities" / "company" / "acme.md").write_text("---\ntype: company\ntitle: Acme\n---\n")
+    assert engine.entity_index_preamble(
+        [{"slug": "_global", "path": str(g), "write": False, "role": "global"}]) == ""
+
+
+def test_the_preamble_ships_on_the_turn_prompt(tmp_path, monkeypatch):
+    """The rule reaches EVERY turn, for the reason kg_links does: a rule that reaches only composed
+    openings is a rule about nothing, and a chat the person opened themselves is where names land."""
+    seen = {}
+
+    def fake_run(work, prompt, harness, **kw):
+        seen["prompt"] = prompt
+        yield {"type": "done", "reply": "ok", "sessionId": "s"}
+
+    monkeypatch.setattr(engine, "run_harness_turn", fake_run)
+    monkeypatch.setattr(engine, "active_mounts",
+                        lambda: [{"slug": "desk-1", "path": str(tmp_path), "write": True,
+                                  "primary": True}])
+    monkeypatch.setattr(engine, "_ensure_repo", lambda w: None)
+
+    class H:
+        def prepare(self, work, chat_root=None):
+            pass
+
+        def transcript_bytes(self, work, sid):
+            return 0
+
+    list(engine.run_turn_over_workspace(tmp_path, "hello", harness=H(), commit=False))
+    assert "A name without a page gets one NOW" in seen["prompt"]

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -404,18 +404,36 @@ _ENTITY_FILE_SHAPE = (
     "append `## <today>` and one `- <fact> — source: <source>` line per fact. Never rewrite what is "
     "already on the page.\n\n")
 
+# ⚠ THE FIRST VERSION OF THIS ASKED FOR JUDGEMENT AND GOT HESITATION — the exact thing the founder
+# named. Told to record "what this turn learned about a person, company, meeting, project or
+# decision", the phase answered `nothing new` on a turn that had just written a note naming six
+# people and three organisations, and explained itself: *"further pages for individual TSC members
+# or companies can be added as the project develops and additional facts about them become
+# relevant beyond their participation in this kickoff."* Every clause of that is a reasonable
+# editorial judgement, and every clause is the reason the graph stays empty.
+#
+# So the phase no longer asks whether a name deserves a page. It asks for the LIST first — a
+# mechanical step with no judgement in it — and then makes the list the work. `nothing new` is
+# narrowed to the one case it is true in: no name was touched at all. And the note is explicitly
+# NOT a substitute for a page, because "it is already in the note" was the reasoning that ran.
 WRITEBACK_PROMPT = (
     MACHINERY_MARK + " Write-back phase — not a message from the person, and nothing you say here "
     "reaches them. Do not address them, do not summarise the turn, do not ask them anything.\n\n"
-    "List what THIS turn learned about a person, company, meeting, project or decision — only what "
-    "was said in the conversation or read from a file, a tool result or a transcript — and record "
-    "each one with `entity_upsert(kind, name, facts, source)`. One call per entity. A name that came "
-    "up and has no page gets one now; a page that exists gets the new facts appended; a fact already "
-    "on the page writes nothing, so call it rather than wondering.\n\n"
+    "FIRST, list every proper name this turn touched: every person who spoke or was named, every "
+    "company or organisation, every meeting, project or decision. Just the names.\n\n"
+    "THEN give each one a page, with `entity_upsert(kind, name, facts, source)` — one call per "
+    "name, in order. A name with no page gets one NOW; a page that exists gets this turn's facts "
+    "appended; a fact already on the page writes nothing, so call it rather than wondering.\n\n"
+    "Do not judge whether a name is important enough, whether it will matter later, or whether it "
+    "is already covered somewhere else. A meeting note is NOT a substitute for a page — it records "
+    "an occasion, a page records a subject, and the whole point is that the next turn can find the "
+    "subject. If a name was touched and you know one true thing about it, it gets a page. One "
+    "sentence of fact is enough to start one.\n\n"
     + _ENTITY_FILE_SHAPE +
-    "Every fact carries its source. Anything you would have to guess goes to `kg/MISSING.md` as an "
-    "open question, never onto a page.\n\n"
-    "If this turn learned nothing durable, reply exactly: nothing new")
+    "Every fact carries its source, and only what was said in this conversation or read from a "
+    "file, a tool result or a transcript counts. Anything you would have to guess goes to "
+    "`kg/MISSING.md` as an open question, never onto a page.\n\n"
+    "Reply exactly `nothing new` ONLY if this turn touched no name at all.")
 
 # Read/Glob/Grep to check what a page already says, Write/Edit for `kg/MISSING.md`, and the entity
 # verb itself. Deliberately NOT the research tools: this phase records what the turn already learned,

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -226,6 +226,59 @@ def kg_links_preamble() -> str:
     )
 
 
+# The rule text of PRD decision 24, and the index it is a rule about. One string, because the rule
+# is unreadable without the list and the list is inert without the rule.
+_ENTITY_INDEX_MAX_CHARS = 12_000
+
+
+def entity_index_preamble(mounts: list[dict]) -> str:
+    """The entity index of every mounted workspace, plus the rule that makes it actionable.
+
+    Decision 24 (founder, 2026-09-02): *"how to update the agent so that it updates entities whenever
+    there is a chance for that? so it does not hesitate creating pages"*. Hesitation had two causes
+    and this preamble removes the first: the agent could not see what already existed, so every
+    mention of a name was a choice between a duplicate page and no page, and it reliably chose no
+    page. `entity_upsert` removes the second (one call, create-or-append).
+
+    Ships on EVERY dispatch for the reason `kg_links_preamble` does — a rule that reaches only some
+    turns is a rule about nothing, and the turns most likely to learn a name (a chat the person
+    opened themselves) are exactly the ones no composed opening covers.
+
+    The list is read from the generated `kg/INDEX.md` when it is there (refreshed by every upsert)
+    and rendered live from the directory when it is not, so a first dispatch into a workspace that
+    has never been upserted still sees what it holds instead of being told nothing exists."""
+    from shared.entities import INDEX_PATH, render_index
+
+    blocks: list[str] = []
+    for m in mounts:
+        if not m.get("write", True):
+            continue                     # `_global` is the org tier — entities belong on a desk
+        root = Path(str(m.get("path") or ""))
+        slug = str(m.get("slug") or root.name)
+        try:
+            f = root / INDEX_PATH
+            listing = f.read_text(encoding="utf-8", errors="replace") if f.exists() else ""
+            if not listing.strip():
+                listing = render_index(root, slug)
+        except OSError:
+            continue
+        blocks.append(f"### `{slug}`\n\n{listing.strip()[:_ENTITY_INDEX_MAX_CHARS]}")
+    if not blocks:
+        return ""
+    return (
+        "## Entities you already hold, and the rule about writing them\n\n"
+        "**A name without a page gets one NOW.** The moment this turn learns something durable about "
+        "a person, company, meeting, project or decision, call `entity_upsert(kind, name, facts, "
+        "source)` — it creates the page if it does not exist and appends a dated entry if it does, "
+        "so there is nothing to check first and nothing to merge by hand. Call it on a maybe: a fact "
+        "the page already carries writes nothing.\n"
+        "- **Facts carry a source.** Only what was said in this conversation or read from a file, a "
+        "tool result or a transcript, each with where it came from. A fact with no source is refused.\n"
+        "- **Gaps go to `kg/MISSING.md`, never invented.** What you would have to guess is written "
+        "there as an open question, not onto the page.\n\n"
+        + "\n\n".join(blocks) + "\n\n")
+
+
 _GLOBAL_CONTEXT_FILES = ("CLAUDE.md", "PURPOSE", "README.md")
 _GLOBAL_CONTEXT_MAX_CHARS = 48_000
 
@@ -319,6 +372,79 @@ def mounts_preamble(mounts: list[dict]) -> str:
         "",
     ]
     return "\n".join(lines)
+
+
+# ── the write-back phase (PRD decision 24.2) ─────────────────────────────────────────────────────
+#
+# "A gate, not advice." The grounding gate is the precedent and the measurement behind it is the
+# argument: asked in a prompt to read the transcript, Haiku did it about half the time; made to
+# prove it, depth went 0.00 → 0.90. Asking the model to record entities *while* it answers competes
+# with answering, and answering wins. So it is asked afterwards, separately, when nothing else is
+# in flight — and the person's answer is never delayed by it, because their answer has already
+# streamed by the time this runs.
+#
+# THE SAME MARK the composed openings carry (control_plane.scaffolds.MACHINERY_MARK, and the
+# terminal's own copy in clients/terminal/src/canvas/actions.ts). Duplicated rather than shared for
+# the same stated reason: the three sides ship in different images, and a rename in one is meant to
+# be a visible regression in the others.
+MACHINERY_MARK = "[vexa-machinery]"
+
+WRITEBACK_PROMPT = (
+    MACHINERY_MARK + " Write-back phase — not a message from the person, and nothing you say here "
+    "reaches them. Do not address them, do not summarise the turn, do not ask them anything.\n\n"
+    "List what THIS turn learned about a person, company, meeting, project or decision — only what "
+    "was said in the conversation or read from a file, a tool result or a transcript — and record "
+    "each one with `entity_upsert(kind, name, facts, source)`. One call per entity. A name that came "
+    "up and has no page gets one now; a page that exists gets the new facts appended; a fact already "
+    "on the page writes nothing, so call it rather than wondering.\n\n"
+    "Every fact carries its source. Anything you would have to guess goes to `kg/MISSING.md` as an "
+    "open question, never onto a page.\n\n"
+    "If this turn learned nothing durable, reply exactly: nothing new")
+
+# Read/Glob/Grep to check what a page already says, Write/Edit for `kg/MISSING.md`, and the entity
+# verb itself. Deliberately NOT the research tools: this phase records what the turn already learned,
+# and a phase that can go and look things up is a second turn wearing a bookkeeping name.
+WRITEBACK_TOOLS = ("Read", "Glob", "Grep", "Write", "Edit")
+
+
+def writeback_enabled() -> bool:
+    return (os.environ.get("VEXA_WRITEBACK") or "1").strip().lower() not in ("0", "false", "off", "no")
+
+
+def writeback_min_tokens() -> int:
+    """The cheap-turn floor, configurable. A bare "thanks" or "yes" with no tool call learned
+    nothing, and a write-back phase on it is a whole model call spent proving that."""
+    try:
+        return int(os.environ.get("VEXA_WRITEBACK_MIN_TOKENS", "40"))
+    except ValueError:
+        return 40
+
+
+def should_write_back(prompt: str, tool_calls: int, *, min_tokens: int | None = None) -> bool:
+    """Skip only a turn that is cheap on BOTH counts: it called no tools AND the person said very
+    little. Either one alone is a turn that can have learned something — a long message carries
+    facts with no tool call, and a short one ("who is Olga?") can pull a whole dossier through a
+    tool. The floor is on the PERSON's words, never on the agent's reply."""
+    if not writeback_enabled():
+        return False
+    if tool_calls > 0:
+        return True
+    floor = writeback_min_tokens() if min_tokens is None else min_tokens
+    return len((prompt or "").split()) >= floor
+
+
+def writeback_events(events: Iterator[dict]) -> Iterator[dict]:
+    """The phase's STEP LINES, never its prose. Tool calls and their results pass through tagged
+    `phase: "writeback"` so the client can show that bookkeeping happened; text, the artifact tab
+    and the terminating `done` are dropped.
+
+    The `artifact` event is dropped for the same reason the text is: it steals the right panel onto
+    an entity page the person did not ask to see, one turn after the document they did."""
+    for ev in events:
+        t = ev.get("type")
+        if t in ("message-delta", "artifact", "done"):
+            continue
+        yield {**ev, "phase": "writeback"}
 
 
 class _Stream(Protocol):
@@ -460,6 +586,10 @@ VEXA_MCP_TOOLS = (
     "workspace_purpose", "mark_scaffolded",
     # the write side, unused only because the volume mount hides it
     "workspace_write",
+    # decision 24: the ONE call that turns something learned into a page. Named here
+    # rather than left to the prefix because the write-back phase is only as reliable
+    # as the tool being present without a search step (see the deferral note above).
+    "entity_upsert",
 )
 
 
@@ -533,7 +663,8 @@ def run_turn_over_workspace(
     author = _principal_author()
     extras = _extra_mount_paths(work)
     turn_prompt = (voice_preamble() + kg_links_preamble() + mounts_preamble(mounts)
-                   + global_context_preamble(mounts) + prompt)
+                   + entity_index_preamble(mounts) + global_context_preamble(mounts)
+                   + prompt)
     gen = run_harness_turn(work, turn_prompt, harness, allowed_tools=allowed, session=resume, model=model,
                            commit=commit, author=author, extra_mounts=extras, mcp_config=mcp_config)
     first = next(gen, None)
@@ -566,7 +697,7 @@ def start_prompt(start: dict) -> str | None:
 # ── the harness loop (redis + the turn injected) ─────────────────────────────────────────────────
 
 def serve(stream: _Stream, *, out_topic: str, in_topic: str, turn: TurnFn, start: dict, idle_ms: int,
-          harness: HarnessPort | None = None) -> None:
+          harness: HarnessPort | None = None, writeback: TurnFn | None = None) -> None:
     """Run the entrypoint turn (if any), then serve interactive messages on ``in_topic`` until idle.
 
     Each turn's UnitEvents are XADD'd to ``out_topic`` (tagged with a turn id), followed by a
@@ -611,10 +742,23 @@ def serve(stream: _Stream, *, out_topic: str, in_topic: str, turn: TurnFn, start
         if nonce:
             ack["nonce"] = nonce
         stream.xadd(out_topic, {"event": json.dumps(ack)})
+        tool_calls = 0
         for ev in turn(prompt):
+            if ev.get("type") == "tool-call":
+                tool_calls += 1
             stream.xadd(out_topic, {"event": json.dumps({**ev, "turn_id": turn_id})})
             if cursor is not None:
                 _drain_inject(cursor)
+        # THE WRITE-BACK PHASE (decision 24.2). It runs AFTER the answer has streamed — the person
+        # is already reading — and before `turn-complete`, so its tool calls land as step lines on
+        # the turn they belong to instead of on nothing. A phase that raises must not lose the
+        # turn: the answer is delivered either way, and bookkeeping is not worth a dead session.
+        if writeback is not None and should_write_back(prompt, tool_calls):
+            try:
+                for ev in writeback_events(writeback(prompt)):
+                    stream.xadd(out_topic, {"event": json.dumps({**ev, "turn_id": turn_id})})
+            except Exception as e:  # noqa: BLE001
+                log.warning("write-back phase failed on %s: %s: %s", turn_id, type(e).__name__, e)
         stream.xadd(out_topic, {"event": json.dumps({"type": "turn-complete", "turn_id": turn_id})})
 
     # Anchor the in-topic cursor at the BOOT-TIME tail, before the entrypoint turn runs. The
@@ -828,6 +972,13 @@ def main() -> None:  # pragma: no cover — the container entrypoint (wired in t
             turn=lambda prompt: run_turn_over_workspace(work, prompt, model=model,
                                                         allowed_tools=chat_tools, session=session,
                                                         mcp_config=mcp_cfg, harness=chat_harness),
+            # SAME session on purpose: the phase has to see what the turn just saw, and a fresh
+            # session would have to be told the whole conversation to ask one bookkeeping question.
+            # Small budget by TOOLSET rather than by a step cap the harness does not expose.
+            writeback=lambda _prompt: run_turn_over_workspace(
+                work, WRITEBACK_PROMPT, model=model,
+                allowed_tools=[*WRITEBACK_TOOLS, *mcp_tools], session=session,
+                mcp_config=mcp_cfg, harness=chat_harness),
             start=json.loads(os.environ.get("VEXA_START", "{}")), idle_ms=idle_ms,
             harness=chat_harness,
         )

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -389,6 +389,21 @@ def mounts_preamble(mounts: list[dict]) -> str:
 # be a visible regression in the others.
 MACHINERY_MARK = "[vexa-machinery]"
 
+# ⚠ THE FALLBACK IS NOT A TEST CONVENIENCE — it is the majority case for some deployments. A
+# dispatch with no delegation token gets NO MCP at all (`mcp_delegation_config` returns `(None,
+# [])`), so a phase whose only instruction names `entity_upsert` would be a wasted model call on
+# every one of those turns. Measured 2026-09-02 on a DNA fixture with the tool absent: the phase
+# ran for 58 seconds and created nothing. The workspace is mounted either way; the file is the
+# floor, the tool is the fast path, and the SHAPE has to be stated because the two paths must
+# produce the same page (`shared/entities.py` is the other spelling of it).
+_ENTITY_FILE_SHAPE = (
+    "If `entity_upsert` is not available to you, write the page yourself — the workspace is "
+    "mounted. `kg/entities/<kind>/<slug>.md`, kind one of person/company/meeting/project/decision, "
+    "slug kebab-case of the name. A new page opens with frontmatter `type`, `id`, `title`, "
+    "`aliases: []`, `created: <today>`, `sources: [<source>]`, then `# <Name>`. New or existing, "
+    "append `## <today>` and one `- <fact> — source: <source>` line per fact. Never rewrite what is "
+    "already on the page.\n\n")
+
 WRITEBACK_PROMPT = (
     MACHINERY_MARK + " Write-back phase — not a message from the person, and nothing you say here "
     "reaches them. Do not address them, do not summarise the turn, do not ask them anything.\n\n"
@@ -397,6 +412,7 @@ WRITEBACK_PROMPT = (
     "each one with `entity_upsert(kind, name, facts, source)`. One call per entity. A name that came "
     "up and has no page gets one now; a page that exists gets the new facts appended; a fact already "
     "on the page writes nothing, so call it rather than wondering.\n\n"
+    + _ENTITY_FILE_SHAPE +
     "Every fact carries its source. Anything you would have to guess goes to `kg/MISSING.md` as an "
     "open question, never onto a page.\n\n"
     "If this turn learned nothing durable, reply exactly: nothing new")

--- a/core/flows/eval/dna/replay.py
+++ b/core/flows/eval/dna/replay.py
@@ -222,6 +222,27 @@ def wait_note(uid: str, shas_before: list, budget_s: int, stamp: str = ""):
     return wait_for(probe, budget_s) or best.get("any")
 
 
+def entity_files_since(uid: str, shas_before: list) -> list:
+    """Every `kg/entities/**` path this run committed, across every new commit.
+
+    Decision 24's measure needs a denominator the harness already has and a numerator nothing else
+    produces. The commits are the numerator: the post_meeting run and the two primed openings each
+    write through the same workspace, and a commit is the only place a write is visible from
+    outside the container. `kg/INDEX.md` is excluded — it is a rendering of the pages, and counting
+    it would score the same write twice."""
+    seen, out = set(shas_before or []), []
+    for c in (workspace_git(uid).get("commits") or []):
+        if c.get("sha") in seen:
+            continue
+        for f in (c.get("files") or []):
+            if f.startswith("kg/entities/") and f not in out and not f.endswith("/index.md"):
+                out.append(f)
+    return sorted(out)
+
+
+ENTITY_PAGES_SAMPLED = 8       # what the judge is shown; the count is measured over all of them
+
+
 def workspace_git(uid: str) -> dict:
     _, g = http("GET", f"{AGENT_API}/api/workspace/git", {"X-User-Id": uid})
     return g if isinstance(g, dict) else {}
@@ -377,6 +398,10 @@ def replay_one(rig: Rig, uid: str, org: str, fx_path: pathlib.Path, rev: int, ru
                scheduled_at=seed.get("scheduled_at"),
                transcript_chars_delivered=len(seed.get("transcript") or ""))
 
+    # Decision 24's measure: the entity write-back is scored over the WHOLE fixture — the
+    # post_meeting run plus both primed openings — so the baseline is taken before any of them.
+    entity_base = [c.get("sha") for c in (workspace_git(uid).get("commits") or [])]
+
     mail_mark = time.time()
     up_id = f"dna-r{rev}-prep-{date}"
     rec["emit_upcoming"] = rig.call(
@@ -409,6 +434,15 @@ def replay_one(rig: Rig, uid: str, org: str, fx_path: pathlib.Path, rev: int, ru
         rec[key] = {"prompt": p,
                     "reply": chat_turn(uid, f"askchat-r{rev}-{name}-{date}", p) if p else None}
         print(f"  {key}={bool(rec[key]['reply'])}", flush=True)
+
+    # THE ENTITY MEASURE (decision 24.4). Three agent turns ran for this fixture: the post_meeting
+    # note and the two primed openings. The meeting note itself is one of the pages, and it is
+    # counted — it always existed, so it is the floor a revolution has to beat, not a free point.
+    ent = entity_files_since(uid, entity_base)
+    rec["entity_files"] = ent
+    rec["entity_turns"] = 3
+    rec["entity_pages"] = {f: (ws_file(uid, f) or "")[:2000] for f in ent[:ENTITY_PAGES_SAMPLED]}
+    print(f"  entities={len(ent)}", flush=True)
     return rec
 
 

--- a/core/flows/eval/dna/score.py
+++ b/core/flows/eval/dna/score.py
@@ -299,19 +299,29 @@ def unlinked_names(note: str) -> list:
     return out
 
 
-def d_entities_touched(rec: dict) -> tuple[float, dict]:
-    """Entity pages written per agent turn. One page per turn scores 1.0.
+ENTITY_TARGET_PER_TURN = 3.0
 
-    The target is deliberately modest. Decision 24 is about a floor — a turn that met a name and
-    created nothing — not about volume, and a dimension that rewards volume would be gamed by an
-    agent writing a page per sentence."""
+def d_entities_touched(rec: dict) -> tuple[float, dict]:
+    """Entity pages written per agent turn, against a target of three.
+
+    ⚠ THE TARGET WAS ONE, AND ONE WAS UNMEASURABLE. A post-meeting turn writes the meeting's own
+    page whatever else it does, so at a target of one BOTH arms of the first A/B scored a flat
+    1.000 — including the arm that wrote nothing but that page. The raw counts in the same run were
+    1 page against 12. A dimension both arms max out is not measuring the change; three is the
+    smallest target with headroom over the page a meeting turn writes anyway.
+
+    It is still capped, and for the original reason: decision 24 is about a floor — a turn that met
+    a name and created nothing — never about volume, and an uncapped dimension would be maxed by an
+    agent writing a page per sentence. The raw `pages` count rides in the evidence either way,
+    because that is the number that cannot be tuned."""
     files = rec.get("entity_files")
     if files is None:
         return -1.0, {"why": "this run predates the entity measure — not scored"}
     turns = max(1, int(rec.get("entity_turns") or 1))
     per_turn = len(files) / turns
-    return round(min(1.0, per_turn), 3), {"entity_files": files[:12], "pages": len(files),
-                                          "turns": turns, "per_turn": round(per_turn, 3)}
+    return round(min(1.0, per_turn / ENTITY_TARGET_PER_TURN), 3), {
+        "entity_files": files[:12], "pages": len(files), "turns": turns,
+        "per_turn": round(per_turn, 3), "target_per_turn": ENTITY_TARGET_PER_TURN}
 
 
 def d_names_linked(rec: dict) -> tuple[float, dict]:

--- a/core/flows/eval/dna/score.py
+++ b/core/flows/eval/dna/score.py
@@ -41,7 +41,8 @@ def note_belongs_to(rec: dict, fx: dict) -> bool:
 
 
 MECHANICAL = ["note_shape", "transcript_depth", "prepare_mail", "minutes_mail",
-              "opening_prep", "opening_minutes", "compounding"]
+              "opening_prep", "opening_minutes", "compounding",
+              "entities_touched", "names_linked"]
 
 
 def frac(hits: list[bool]) -> float:
@@ -233,6 +234,95 @@ def d_compounding(rec: dict, earlier: list[dict]) -> tuple[float, dict]:
         "prior_meetings": len(earlier), "named_earlier_dates": named, "shared_terms": hit[:10]}
 
 
+# ── the entity write-back (PRD decision 24.4) ────────────────────────────────────────────────────
+#
+# Two numbers, because decision 24 has two halves and they fail differently. A run can write plenty
+# of pages and still leave every name in the note dead (`entities_touched` high, `names_linked`
+# low), and it can write beautifully linked prose that created nothing (the reverse). Averaging them
+# into one score would hide exactly the distinction the change is meant to move.
+
+# A capitalised RUN of two or more words — "Sony Pictures Imageworks", "Cottalango Leon". Single
+# capitalised words are deliberately not counted: at the start of a sentence every word is one, and
+# a measure that fires on "The" and "Monday" tells you about English, not about the product.
+# `and` and `the` are NOT intra-name particles, and the first version of this had them: it read
+# "Blue Light Card and Kaar Tech" as ONE name, undercounting by exactly the amount a note listing
+# several dead names does. A measure's own bugs bias in the direction that flatters the product.
+_BARE_NAME = re.compile(r"\b[A-Z][a-zA-Z'’\-]+(?:\s+(?:of|de|del|van|von|da|di)\s+[A-Z][a-zA-Z'’\-]+"
+                        r"|\s+[A-Z][a-zA-Z'’\-]+)+")
+_FENCE = re.compile(r"```[\s\S]*?```")
+# Headings and list labels are formatting, not mentions; a `## Decided` never wanted a wikilink.
+_HEADING = re.compile(r"^#{1,6}\s.*$", re.M)
+_NOT_A_NAME = {"Open Items", "Action Items", "Next Steps", "Open Questions", "Decided Committed"}
+
+# ⚠ MEASURED FALSE POSITIVE, removed after the first baseline run. Over ten real DNA notes the
+# measure flagged "Complete SSO", "Ask ASF", "Co-author TAC", "Lead TAC", "Attend SIGGRAPH",
+# "Escalate GitHub", "Await PR" — every one of them a Committed-section bullet, which by convention
+# opens with an imperative verb and is followed by an acronym. Those are not names anybody failed to
+# link; counting them inflated the deficit by roughly a third and would have made the fix look
+# better than it was. A measure's own bugs bias in whichever direction flatters the change, so they
+# get found before the change is scored, not after.
+_LEADING_VERB = {
+    "add", "address", "agree", "answer", "ask", "assign", "attend", "await", "book", "bring",
+    "build", "check", "circulate", "clarify", "close", "co-author", "complete", "confirm",
+    "consider", "continue", "create", "decide", "define", "deliver", "deploy", "discuss", "draft",
+    "escalate", "explore", "file", "finalize", "finalise", "find", "fix", "follow", "get", "give",
+    "identify", "include", "investigate", "invite", "keep", "land", "lead", "let", "look", "make",
+    "merge", "move", "open", "organise", "organize", "pick", "plan", "post", "prepare", "present",
+    "propose", "provide", "publish", "raise", "reach", "read", "record", "report", "request",
+    "resolve", "review", "revisit", "run", "schedule", "send", "set", "share", "should", "start",
+    "submit", "support", "take", "test", "track", "update", "verify", "wait", "work", "write",
+}
+_POSSESSIVE = re.compile(r"[\u2019']s$")
+
+
+def unlinked_names(note: str) -> list:
+    """Capitalised multi-word names in the note that are NOT inside a `[[wikilink]]` or a markdown
+    link. This is a PROXY and says so: it cannot know that "Technical Steering Committee" deserves
+    a page. It is a good proxy because it is exactly the failure decision 24 names — a name went
+    past and nothing was created — and because it can only be improved by writing the page."""
+    if not note:
+        return []
+    fm = re.match(r"^---\n[\s\S]*?\n---\n", note)
+    body = note[fm.end():] if fm else note
+    body = _FENCE.sub(" ", body)
+    body = _HEADING.sub(" ", body)
+    body = re.sub(r"\[\[[^\]]+\]\]", " ", body)          # already a chip
+    body = re.sub(r"\[[^\]]+\]\([^)]*\)", " ", body)      # already a link
+    out = []
+    for m in _BARE_NAME.finditer(body):
+        n = _POSSESSIVE.sub("", " ".join(m.group(0).split())).strip()
+        if not n or n in _NOT_A_NAME or n in out:
+            continue
+        if n.split()[0].lower() in _LEADING_VERB:
+            continue
+        out.append(n)
+    return out
+
+
+def d_entities_touched(rec: dict) -> tuple[float, dict]:
+    """Entity pages written per agent turn. One page per turn scores 1.0.
+
+    The target is deliberately modest. Decision 24 is about a floor — a turn that met a name and
+    created nothing — not about volume, and a dimension that rewards volume would be gamed by an
+    agent writing a page per sentence."""
+    files = rec.get("entity_files")
+    if files is None:
+        return -1.0, {"why": "this run predates the entity measure — not scored"}
+    turns = max(1, int(rec.get("entity_turns") or 1))
+    per_turn = len(files) / turns
+    return round(min(1.0, per_turn), 3), {"entity_files": files[:12], "pages": len(files),
+                                          "turns": turns, "per_turn": round(per_turn, 3)}
+
+
+def d_names_linked(rec: dict) -> tuple[float, dict]:
+    """Bare capitalised names left unlinked in the note. Five of them scores zero."""
+    note = rec.get("note") or ""
+    if not note:
+        return 0.0, {"why": "no committed note"}
+    bare = unlinked_names(note)
+    return round(max(0.0, 1.0 - len(bare) / 5.0), 3), {"unlinked": bare[:12], "count": len(bare)}
+
+
 # ── the judge ────────────────────────────────────────────────────────────────────────────────────
 
 def ask_json(prompt: str, model: str, timeout: int = 900) -> dict | None:
@@ -268,7 +358,11 @@ def ask_json(prompt: str, model: str, timeout: int = 900) -> dict | None:
 
 SCHEMA = ("Reply with ONLY a JSON object, no prose, no code fence, with exactly these integer keys "
           "(0-100 unless stated): decisions_recalled, decisions_invented (count), decisions_missed "
-          "(count), owners_correct, open_items_correct, attributions_wrong (count), overall.")
+          "(count), owners_correct, open_items_correct, attributions_wrong (count), overall, "
+          # decision 24.4: the entity pages are scored for GROUNDING, never for volume.
+          "and — only when an ENTITY PAGES section is present below — entities_supported (0-100: "
+          "how much of what those pages assert is supported by the truth or the note) and "
+          "entities_invented (count of claims on them that are neither).")
 
 
 def truth_is_empty(truth: str) -> bool:
@@ -287,10 +381,19 @@ def judge(rec: dict, truth: str, model: str) -> dict:
         return {"skipped": "truth sidecar is an empty stub — nothing to judge against",
                 "next": "fill decided/committed/open (a human, or the plan's first-pass LLM "
                         "extraction tagged unvalidated) before this column means anything"}
+    # The entity pages are part of what this turn produced, and they are mailed to nobody — which
+    # is exactly why they need a judge. A fabricated line on a person's page is invisible in a way
+    # a fabricated line in a note is not: nobody reads it until it is quoted back as knowledge.
+    pages = rec.get("entity_pages") or {}
+    pages_block = ""
+    if pages:
+        pages_block = ("\n\n=== ENTITY PAGES THIS TURN WROTE ===\n"
+                       + "\n\n".join(f"--- {p} ---\n{c}" for p, c in pages.items())[:12000])
     prompt = (
         "You are scoring a meeting note against a truth sidecar. Be strict and literal: an item is "
         "recalled only if the truth contains it, invented only if the truth contradicts or omits it.\n\n"
-        f"{SCHEMA}\n\n=== TRUTH SIDECAR ===\n{truth}\n\n=== THE NOTE UNDER TEST ===\n{note[:12000]}\n")
+        f"{SCHEMA}\n\n=== TRUTH SIDECAR ===\n{truth}\n\n=== THE NOTE UNDER TEST ===\n{note[:12000]}\n"
+        + pages_block)
     got = ask_json(prompt, model, timeout=600)
     return got if got is not None else {"error": "judge produced no json file"}
 
@@ -326,6 +429,8 @@ def main() -> int:
         dims["opening_prep"], ev["opening_prep"] = _opening(rec, "opening_prep", None)
         dims["opening_minutes"], ev["opening_minutes"] = _opening(rec, "opening_minutes", 100)
         dims["compounding"], ev["compounding"] = d_compounding(rec, earlier)
+        dims["entities_touched"], ev["entities_touched"] = d_entities_touched(rec)
+        dims["names_linked"], ev["names_linked"] = d_names_linked(rec)
 
         counted = [v for k, v in dims.items() if v >= 0]
         belongs = note_belongs_to(rec, fx)

--- a/core/flows/eval/dna/scoreboard.py
+++ b/core/flows/eval/dna/scoreboard.py
@@ -19,8 +19,9 @@ import pathlib
 import subprocess
 
 HEADER = ("| rev | when | fingerprint | layer | what changed | fixtures | mean | note_shape | "
-          "depth | prep mail | minutes mail | open prep | open min | compounding | judge |\n"
-          "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|")
+          "depth | prep mail | minutes mail | open prep | open min | compounding | "
+          "entities/turn | names linked | judge |\n"
+          "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|")
 
 
 def fingerprint(fixtures: pathlib.Path, line_sha: str, presets: dict, stack: dict) -> str:
@@ -77,7 +78,8 @@ def main() -> int:
            f"{a.changed or '—'} | {scores['fixtures_scored']} | **{scores['mean_score']:.3f}** | "
            + " | ".join(f"{d[k]:.2f}" for k in
                         ["note_shape", "transcript_depth", "prepare_mail", "minutes_mail",
-                         "opening_prep", "opening_minutes", "compounding"])
+                         "opening_prep", "opening_minutes", "compounding",
+                         "entities_touched", "names_linked"])
            + f" | {jcol} |")
 
     if not prior:

--- a/core/flows/tests/test_entity_measure.py
+++ b/core/flows/tests/test_entity_measure.py
@@ -53,12 +53,19 @@ def test_the_dimension_falls_as_names_are_left_dead():
 
 # ── entities touched ─────────────────────────────────────────────────────────────────────────────
 
-def test_one_page_per_turn_scores_one():
-    rec = {"entity_turns": 3, "entity_files": ["kg/entities/person/a.md",
+def test_three_pages_per_turn_scores_one():
+    rec = {"entity_turns": 1, "entity_files": ["kg/entities/person/a.md",
                                                "kg/entities/company/b.md",
                                                "kg/entities/meeting/c.md"]}
     s, ev = S.d_entities_touched(rec)
-    assert s == 1.0 and ev["per_turn"] == 1.0
+    assert s == 1.0 and ev["per_turn"] == 3.0
+
+
+def test_the_meeting_page_a_turn_writes_anyway_does_not_max_the_dimension():
+    """The measured reason the target is not one: at one, the arm that wrote ONLY the meeting note
+    scored the same as the arm that wrote it plus eleven entity pages."""
+    only_the_note = {"entity_turns": 1, "entity_files": ["kg/entities/meeting/c.md"]}
+    assert S.d_entities_touched(only_the_note)[0] < 0.5
 
 
 def test_a_run_that_created_nothing_scores_zero():

--- a/core/flows/tests/test_entity_measure.py
+++ b/core/flows/tests/test_entity_measure.py
@@ -1,0 +1,80 @@
+"""The entity write-back measure in the DNA replay loop — PRD decision 24.4.
+
+Scored offline over recorded replay rows, because that is what the scorer is: a pure function of
+what a revolution collected. If these two dimensions cannot be argued with here, the number they
+put on the scoreboard cannot be argued with anywhere.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "eval" / "dna"))
+
+import score as S  # noqa: E402
+
+
+# ── bare names ───────────────────────────────────────────────────────────────────────────────────
+
+def test_a_bare_multi_word_name_is_counted():
+    assert S.unlinked_names("Cottalango Leon agreed to chair it.") == ["Cottalango Leon"]
+
+
+def test_a_wikilinked_name_is_not():
+    assert S.unlinked_names("[[Cottalango Leon]] agreed to chair it.") == []
+
+
+def test_a_markdown_linked_name_is_not():
+    assert S.unlinked_names("[Cottalango Leon](kg/entities/person/x.md) agreed.") == []
+
+
+def test_sentence_initial_words_do_not_fire():
+    """A measure that counts every capitalised word is measuring English, not the product."""
+    assert S.unlinked_names("The meeting ran long. Monday works for everyone.") == []
+
+
+def test_headings_and_code_fences_are_formatting_not_mentions():
+    note = "## Open Items\n\n```\nSony Pictures Imageworks\n```\n"
+    assert S.unlinked_names(note) == []
+
+
+def test_frontmatter_is_not_prose():
+    assert S.unlinked_names("---\ntitle: Sony Pictures Imageworks\n---\n\nAll agreed.\n") == []
+
+
+def test_the_dimension_falls_as_names_are_left_dead():
+    clean = {"note": "[[Olga Avramenko]] will chair."}
+    dirty = {"note": "Olga Avramenko, Cottalango Leon, Sony Pictures Imageworks, "
+                     "Blue Light Card and Kaar Tech all agreed."}
+    assert S.d_names_linked(clean)[0] == 1.0
+    assert S.d_names_linked(dirty)[0] == 0.0
+    assert S.d_names_linked({"note": ""})[0] == 0.0
+
+
+# ── entities touched ─────────────────────────────────────────────────────────────────────────────
+
+def test_one_page_per_turn_scores_one():
+    rec = {"entity_turns": 3, "entity_files": ["kg/entities/person/a.md",
+                                               "kg/entities/company/b.md",
+                                               "kg/entities/meeting/c.md"]}
+    s, ev = S.d_entities_touched(rec)
+    assert s == 1.0 and ev["per_turn"] == 1.0
+
+
+def test_a_run_that_created_nothing_scores_zero():
+    assert S.d_entities_touched({"entity_turns": 3, "entity_files": []})[0] == 0.0
+
+
+def test_a_run_from_before_the_measure_is_not_scored_rather_than_scored_zero():
+    """-1.0 is the harness's "not scored" and is excluded from the means. Reporting an old
+    revolution as a zero would show this change improving something it never measured."""
+    assert S.d_entities_touched({"note": "x"})[0] == -1.0
+
+
+def test_volume_is_capped_so_a_page_per_sentence_buys_nothing():
+    rec = {"entity_turns": 1, "entity_files": [f"kg/entities/person/{i}.md" for i in range(40)]}
+    assert S.d_entities_touched(rec)[0] == 1.0
+
+
+def test_both_dimensions_are_on_the_mechanical_list():
+    assert "entities_touched" in S.MECHANICAL and "names_linked" in S.MECHANICAL

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -2108,6 +2108,59 @@ def workspace_write(path: str, content: str, slug: str = "", token: str = "") ->
 
 @mcp.tool()
 @_anon_guard
+def entity_upsert(kind: str, name: str, facts: list[str], source: str, slug: str = "",
+                  token: str = "") -> str:
+    """Record what you just learned about a person, company, meeting, project or decision.
+
+    ONE call does the whole thing: it creates `kg/entities/<kind>/<slug>.md` with frontmatter if the
+    page does not exist, or appends a dated entry if it does. You never have to check first, never
+    have to invent the shape, never have to merge by hand. Call it on a maybe — repeating a fact the
+    page already carries writes nothing.
+
+    Use it the moment a turn learns anything durable: a name and who they are, a company and what
+    they do, what a meeting decided, who owns what, a decision and why it went that way. A name
+    without a page gets one NOW.
+
+    - `kind` — person | company | meeting | project | decision
+    - `name` — what the page is about, as a person would say it ("Cottalango Leon", "Sony Pictures
+      Imageworks"). It becomes the title `[[wikilinks]]` resolve to.
+    - `facts` — one short sentence each, only what was SAID or READ. Write other entities inside a
+      fact as `[[Their Name]]`; the result tells you which of those have no page yet, and those are
+      your next calls.
+    - `source` — where it came from, in a few words: the meeting, the mail, the file, the person's
+      own message. REQUIRED. A fact with no source is refused, not written — if you do not have one,
+      the gap belongs in `kg/MISSING.md`, never on the page.
+    - `slug` — a shared workspace, omitted means this person's own desk.
+    """
+    uid = me()
+    if isinstance(facts, str):
+        facts = [facts]
+    st, body = _http("POST", f"{AGENT_API}/api/workspace/entity", {"X-User-Id": uid},
+                     {"kind": kind, "name": name, "facts": list(facts or []),
+                      "source": source, "slug": slug or ""})
+    if st == 422:
+        detail = (body or {}).get("detail") if isinstance(body, dict) else str(body)
+        return json.dumps({"refused": detail,
+                           "do": "fix the fact, do not retry the same call — the refusal is the rule"})
+    if st not in (200, 201):
+        return json.dumps({"error": "the entity could not be written", "status": st,
+                           "detail": str(body)[:300],
+                           "do": "say so plainly in one sentence, and report_friction()"})
+    out = dict(body) if isinstance(body, dict) else {"result": body}
+    path = out.get("path") or ""
+    if path:
+        out["paste_this_link"] = f"[[{name}]]"
+        out["never_show_the_path"] = ("the path is an argument for tools; in your reply write "
+                                      "[[" + str(name) + "]] and nothing slashed")
+    if out.get("links_missing"):
+        out["next"] = ("these names have no page yet and will render as inert 'not found' chips — "
+                       "upsert each one now, with its own source: "
+                       + ", ".join(out["links_missing"]))
+    return json.dumps(out)[:6000]
+
+
+@mcp.tool()
+@_anon_guard
 def workspace_new(name: str, purpose: str = "", token: str = "") -> str:
     """Create a SHARED workspace — a place a team writes into together — and own it.
 


### PR DESCRIPTION
**PRD decision 24** — *"how to update the agent so that it updates entities whenever there is a chance for that? so it does not hesitate creating pages"* (founder, 2026-09-02 11:30Z). Owning issue: [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449). Base: `minutes-mcp-viewer`, never `main`.

Hesitation was never a prompt problem — it was a **cost** problem. Recording one fact about a person meant six decisions: does a page exist, read it, invent a shape, merge without clobbering, remember the wikilink rule, commit. So the agent wrote prose instead. This collapses all six into one call that is safe to make on a maybe, then makes the call happen whether or not the agent felt like it.

**COMMITMENTS IN THIS PR — none.** Nothing deploys, nothing sends, no swap. Build only.

---

## The interface

### 1. `entity_upsert(kind, name, facts, source, slug="")`

One call creates `kg/entities/<kind>/<slug>.md` with frontmatter, or appends a dated entry to the page already there.

- `kind ∈ {person, company, meeting, project, decision}` — anything else is refused rather than guessed into a directory nothing indexes.
- **Refuses a fact with no source**, naming `kg/MISSING.md` in the refusal. Decision 24.5 is only enforceable if a sourceless fact cannot be written at all — the grounding gate is the precedent (a rule merely *asked for* held about half the time).
- **Idempotent on identical facts**: a fact already on the page writes nothing and reports `changed: false`. That is what makes a forced phase on every turn affordable — a turn that learned nothing costs one no-op, not a duplicated paragraph.
- Resolves `[[wikilinks]]` in the facts and returns `links_missing` — the names with no page yet, as the caller's next calls. **Never auto-creates them**: a page minted from a name with no facts behind it is the invention 24.5 forbids.
- **One commit, by pathspec**, carrying the F31 subject shape `<workspace>: <path> — added|updated`.

⚠ **Frontmatter vocabulary.** The tool's *arguments* are the founder's words (`kind`, `name`); the *keys written* are the ones this workspace's readers already use — `type`, `id`, `title` (`behavior/workspaces/default/kg/templates/*.md`, the terminal's wikilink resolver, the per-type `index.md` files) — plus `aliases`, `created`, `sources`. Writing `kind:`/`name:` would have produced pages that look right and are invisible to every existing reader: the exact defect `workspace_write`'s `CONFIG_VOCAB` guard exists to refuse.

**Where it lives.** `core/agent/shared/entities.py` is a pure function over a directory — no HTTP, no docker, no git required. `POST /api/workspace/entity` on agent-api runs it (`ws_file_write`'s authorization, unchanged; `_global` refused — entities belong on a desk). The rig tool is a **thin forward** to that endpoint. This is PRD §3.3's porting rule applied ahead of the port: a host-reaching rig tool is a missing endpoint in an owning service wearing a shell command, and `workspace_write`'s `docker exec` double is the shape this deliberately does not copy.

### 2. The write-back phase

After the answer has streamed and before `turn-complete`, `serve()` runs one bounded follow-up in the **same session**: list every proper name this turn touched, then give each one a page.

- **The person's answer is never delayed** — it has already streamed by the time this runs.
- **Step lines pass through; prose and the artifact tab do not.** `writeback_events()` drops `message-delta`, `artifact` and `done`, tags the rest `phase: "writeback"`. (The tab is dropped for the same reason as the text: it would steal the right panel onto an entity page the person did not ask to see.)
- **Skipped only on a turn cheap on both counts** — no tool call *and* the person's message under `VEXA_WRITEBACK_MIN_TOKENS` words (default 40). Either signal alone is a turn that can have learned something. `VEXA_WRITEBACK=0` switches the phase off entirely.
- **A phase that raises never costs the person their turn** — logged, `turn-complete` still emitted.
- Small budget by *toolset*, not a step cap the harness does not expose: Read/Glob/Grep/Write/Edit plus the entity verb. Deliberately not the research tools — a phase that can go and look things up is a second turn wearing a bookkeeping name.

### 3. The entity index in context

`entity_index_preamble(mounts)` ships on **every** dispatch (the reason `kg_links_preamble` does: a rule reaching only composed openings is a rule about nothing, and a chat the person opened themselves is where names land). Per writable mount it carries the generated `kg/INDEX.md` — kind · name · path · last updated, refreshed by every upsert, rendered live when the file does not exist yet — under the rule:

> **A name without a page gets one NOW.** Facts carry a source. Gaps go to `kg/MISSING.md`, never invented.

Same rule text in `MACHINERY_NOTE` (composed openings — the turn most likely to meet a name for the first time) and in the desk template's `CLAUDE.md`.

### 4. The measure

Two dimensions in `core/flows/eval/dna/score.py`, on `MECHANICAL` and on the scoreboard:

- **`entities_touched`** — entity pages the run committed, per product turn, against a target of three. The raw `pages` count rides in the evidence because it is the number that cannot be tuned.
- **`names_linked`** — bare capitalised multi-word names in the note that are not inside a `[[wikilink]]` or a markdown link. A proxy, and it says so.

The judge now also sees the **entity pages the turn wrote**, and scores `entities_supported` / `entities_invented`. A fabricated line on a person's page is invisible in a way a fabricated line in a note is not — nobody reads it until it is quoted back as knowledge.

---

## The numbers, honestly

### What could not be run, and why

**The full DNA replay could not be run against this branch.** `replay.py` drives the agent turn through the *deployed* agent-api and the *deployed* worker image on the founder's dogfood stack — the adoption README is explicit that the sim lane "shares agent-api" — and the control MCP runs from a symlinked source in tmux the founder is live on. Measuring this branch there means swapping agent-api, the worker image and the rig. **This dispatch is build-only and holds no swap.** A replay run today would have measured the old stack and reported no movement, which is a meaningless number, not an honest one.

### What was run instead

An **offline A/B one level down**: `worker.engine.run_turn_over_workspace` from this branch, the real `ClaudeCodeHarness`, Haiku, a scratch workspace on disk, two real DNA fixtures (`2026-03-02`, `2026-03-16`), a post-meeting-shaped prompt with the transcript. The only difference between arms is this branch's two additions. Nothing running was touched. Runner: `/tmp/ab.py`; artifacts in `~/dna-runs/entity-ab{,2,3}/`.

| | `entities_touched` | pages/fixture | `names_linked` | bare names/note |
|---|---|---|---|---|
| **A — before** | 0.333 | 1.0 | 0.000 | 9.5 |
| **B — after** | **1.000** | **16.5** | 0.100 | 8.5 |

Arm B's 16 and 17 pages are people, companies and a project — `cottalango-leon`, `sony-pictures-imageworks`, `industrial-light-magic`, `dna` — where arm A wrote the meeting note and nothing else.

**The names half did not move**, and I am not going to dress that up as movement: 0.000 → 0.100, 9.5 → 8.5 bare names per note, n=2. The reason is structural — the phase runs *after* the note is written, so it cannot go back and link what the note already said. What should move `names_linked` is decision 24.3, the index in context, over a library that compounds; a fresh two-fixture workspace has an empty index when the first note is written, so this A/B could not test it. **Untested, and it stays untested until the replay can run on a swapped stack.**

**Cost:** the phase adds ~118–136 s on Haiku against a ~31–47 s answer. It does not lengthen the person's wait, but it roughly triples the turn's wall clock and its tokens. `VEXA_WRITEBACK=0` and the cheap-turn floor exist for that reason.

**Baseline on the real product**, read-only over the recorded ten-fixture run `~/dna-runs/r3` (nothing in that directory was written): `names_linked` mean **0.400**, **3.5 bare names left unlinked per note**. `entities_touched` scores `-1` there — not scored, because that revolution predates the field. Reporting an old run as a zero would show this change improving something it never measured.

### Three things the instrument found about itself

Reported because a measure's own bugs bias in whichever direction flatters the change.

1. **The bare-name regex counted `and` as an intra-name particle** and read *"Blue Light Card and Kaar Tech"* as one name — undercounting exactly when a note lists several dead names.
2. **It flagged every `Committed`-section bullet.** *"Complete SSO"*, *"Ask ASF"*, *"Co-author TAC"*, *"Attend SIGGRAPH"* — imperative verb plus acronym. That inflated the deficit by about a third. Fixed with a leading-verb stoplist; the r3 baseline above is post-fix (it was 0.180 / 4.9 before).
3. **`entities_touched` targeted one page per turn, and one was unmeasurable.** A post-meeting turn writes the meeting's own page whatever else it does, so both arms scored a flat 1.000 while the raw counts were 1 against 12. Target is three now — the smallest with headroom over the page that turn writes anyway.

### Two defects the A/B found in the product

Both fixed on the branch, both with the measurement that found them in the commit message.

1. **A dispatch with no delegation token has no MCP at all** (`mcp_delegation_config` → `(None, [])`), so a phase whose only instruction names `entity_upsert` is a wasted model call on every one of those turns. Measured: the phase ran 58 s and created nothing on one fixture, improvised the files on the other — non-deterministic because it was unstated. The workspace is mounted either way: the file is the floor, the tool is the fast path, and the page shape is stated so both paths produce what `shared/entities.py` writes.
2. **Asking for judgement got hesitation — the founder's exact word.** Told to record *"what this turn learned about a person, company…"*, the phase replied `nothing new` on a turn that had just written a note naming six people and three organisations, and explained itself: *"further pages for individual TSC members or companies can be added as the project develops and additional facts about them become relevant beyond their participation in this kickoff."* Every clause is a reasonable editorial judgement; every clause is why the graph stays empty. The phase now asks for the **list first** — mechanical, no judgement in it — then makes the list the work; states that a meeting note is not a substitute for a page (*"it is already in the note"* was the reasoning that ran); and narrows `nothing new` to the one case it is true in.

---

## Tests

`core/agent`: **722 passed**. `core/flows`: **200 passed, 1 skipped**.

- `core/agent/tests/test_entities.py` (15) — frontmatter vocabulary · every kind and no other · sourceless refusal writes nothing · append keeps the first entry · identical facts write nothing at all · a hand-written page keeps its own keys · wikilinks resolve and the missing ones come back · the index and its template exclusion · the F31 subject · **the commit leaves a concurrent writer's staged work alone**.
- `core/agent/tests/test_entity_endpoint.py` (7) — create · append · 422 with the reason · unknown kind · `_global` 403 · the visible no-op · unresolved links.
- `core/agent/tests/test_entity_writeback.py` (13) — when the phase runs and when it is skipped · the floor and the switch · step lines through, prose and tab not · the phase runs after the answer and before `turn-complete` · a raising phase never costs the turn · the rule and the index on every dispatch · the live render when the file has never been written · a read-only mount is never offered.
- `core/flows/tests/test_entity_measure.py` (12) — the proxy's boundaries, and the two dimensions.

**Pre-existing failures, unchanged by this branch** (confirmed by `git stash` at `origin/minutes-mcp-viewer`): `test_meeting_room.py::test_the_runtime_binds_a_room_mount_read_only` (`ModuleNotFoundError: requests_unixsocket` in `core/runtime`) and two `core/flows/tests/test_contract_smokes.py` cases that talk to the live stack's admin-api.

**One stale test repaired.** `test_delegation.py::test_the_worker_writes_a_bearer_header_config_and_widens_its_allow_set` asserted `tools == [prefix]` — true when the allow-set was the prefix alone, **failing on every run of this suite since the 21-tool union landed**, red beside 721 green. An anomaly is a finding: it now asserts the prefix plus the named tools, a shape that does not age.

---

## Not in this PR

No swap, no deploy, no `_global` write. The rule text belongs in `_global` too (decision 24's own note says so) — that is an admin edit on a live instance, not a code change, and it is left for whoever holds the swap.
