### PR TITLE
entities: the write-back phase gets a mechanical pre-pass and a hard budget

### DIFF
--- a/core/agent/llm/claude_code.py
+++ b/core/agent/llm/claude_code.py
@@ -245,15 +245,33 @@ def inject_user_message(text: str) -> bool:
             return False
 
 
-def _reap(proc, grace: float = 5.0) -> None:
+def _reap_grace() -> float:
+    """How long a finished-with stdout is given to bring the CLI down on its own, before it is
+    killed. Tunable only so a test can prove the kill path in a fraction of a second."""
+    try:
+        return float(os.environ.get("VEXA_HARNESS_REAP_GRACE_SEC", "5"))
+    except ValueError:
+        return 5.0
+
+
+def _reap(proc, grace: "float | None" = None) -> None:
     """Wait for the CLI, then KILL it if it will not go.
 
     ⚠ `finally: proc.wait()` alone is a HANG waiting to happen, and it became reachable the moment a
     caller could stop consuming early (the write-back phase's budget closes the generator, which
     raises GeneratorExit at the yield and runs this finally while the CLI is still mid-turn). A bare
     wait there blocks the worker forever on a process nobody is reading any more — the budget would
-    have produced the exact stall it exists to prevent. On the normal path the CLI has already
-    exited by the time stdout hits EOF, so the grace period costs nothing."""
+    have produced a permanent stall in place of the temporary one it exists to remove.
+
+    ⚠ AND CLOSING STDOUT IS NOT ENOUGH, which is the version of this that looked fine. A child that
+    keeps writing dies of SIGPIPE the moment the pipe closes, so the first test of this passed with
+    the kill path deleted. A child that has stopped writing — which is what the CLI is doing for
+    most of a turn, waiting on a model — never notices, and waits out the whole budget's worth of
+    nothing. The kill is for that one, and the test now uses a child that sleeps.
+
+    On the normal path the CLI has already exited by the time stdout hits EOF, so the grace costs
+    nothing."""
+    grace = _reap_grace() if grace is None else grace
     try:
         proc.wait(timeout=grace)
     except subprocess.TimeoutExpired:

--- a/core/agent/llm/claude_code.py
+++ b/core/agent/llm/claude_code.py
@@ -245,6 +245,25 @@ def inject_user_message(text: str) -> bool:
             return False
 
 
+def _reap(proc, grace: float = 5.0) -> None:
+    """Wait for the CLI, then KILL it if it will not go.
+
+    ⚠ `finally: proc.wait()` alone is a HANG waiting to happen, and it became reachable the moment a
+    caller could stop consuming early (the write-back phase's budget closes the generator, which
+    raises GeneratorExit at the yield and runs this finally while the CLI is still mid-turn). A bare
+    wait there blocks the worker forever on a process nobody is reading any more — the budget would
+    have produced the exact stall it exists to prevent. On the normal path the CLI has already
+    exited by the time stdout hits EOF, so the grace period costs nothing."""
+    try:
+        proc.wait(timeout=grace)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    except TypeError:
+        # a Popen-shaped test double whose wait() takes no timeout — the seam, not the CLI
+        proc.wait()
+
+
 def _exec_subprocess_stdin(argv: list[str], cwd: str, first_message: str) -> Iterator[str]:
     """stdin-mode exec: the prompt travels as the first stream-json user message and stdin STAYS
     OPEN for mid-turn injection; a `result` line closes it (turn over → CLI exits)."""
@@ -274,7 +293,7 @@ def _exec_subprocess_stdin(argv: list[str], cwd: str, first_message: str) -> Ite
             proc.stdin.close()
         except Exception:  # noqa: BLE001
             pass
-        proc.wait()
+        _reap(proc)
 
 
 def _exec_subprocess(argv: list[str], cwd: str) -> Iterator[str]:
@@ -289,7 +308,11 @@ def _exec_subprocess(argv: list[str], cwd: str) -> Iterator[str]:
     try:
         yield from proc.stdout
     finally:
-        proc.wait()
+        try:
+            proc.stdout.close()
+        except Exception:  # noqa: BLE001
+            pass
+        _reap(proc)
 
 
 def _link_chat_into_workspace(work: Path) -> None:

--- a/core/agent/shared/entities.py
+++ b/core/agent/shared/entities.py
@@ -240,6 +240,123 @@ def upsert_entity(root, kind: str, name: str, facts, source: str, *,
             "links_missing": unresolved, "kind": kind, "name": name, "date": day}
 
 
+# ── candidate names, mechanically (the phase's pre-pass) ─────────────────────────────────────────
+#
+# THE POINT OF THIS BEING CODE. The write-back phase used to spend a whole model call finding out
+# that it had nothing to do — measured at 118-136s on Haiku against a 31-47s answer, which keeps the
+# worker busy 3x longer and queues every message the person sends behind it. Extracting the names is
+# a regex and a directory listing; only writing the FACTS needs a model. So the cheap half runs
+# first, in code, and a turn whose names all already have pages never reaches a model at all.
+#
+# It is also the SSOT for the measure: `core/flows/eval/dna/score.py` imports this function rather
+# than keeping a second regex. Two spellings of "what counts as a name" is how a scorer ends up
+# measuring something the product never looked for.
+
+# A capitalised RUN of two or more words — "Sony Pictures Imageworks", "Cottalango Leon". Single
+# capitalised words are deliberately not counted: at the start of a sentence every word is one, and
+# a rule that fires on "The" and "Monday" is about English, not about the knowledge graph.
+#
+# `and` and `the` are NOT intra-name particles, and the first version had them: it read "Blue Light
+# Card and Kaar Tech" as ONE name, undercounting by exactly the amount a note listing several dead
+# names does.
+_BARE_NAME = re.compile(r"\b[A-Z][a-zA-Z'’\-]+(?:\s+(?:of|de|del|van|von|da|di)\s+[A-Z][a-zA-Z'’\-]+"
+                        r"|\s+[A-Z][a-zA-Z'’\-]+)+")
+_FENCE = re.compile(r"```[\s\S]*?```")
+_HEADING = re.compile(r"^#{1,6}\s.*$", re.M)
+_MD_LINK = re.compile(r"\[[^\]]+\]\([^)]*\)")
+_POSSESSIVE = re.compile(r"[’']s$")
+_NOT_A_NAME = {"Open Items", "Action Items", "Next Steps", "Open Questions", "Decided Committed"}
+
+# ⚠ MEASURED FALSE POSITIVE. Over ten real DNA notes the extractor flagged "Complete SSO",
+# "Ask ASF", "Co-author TAC", "Lead TAC", "Attend SIGGRAPH", "Escalate GitHub", "Await PR" — every
+# one a Committed-section bullet, which by convention opens with an imperative verb and is followed
+# by an acronym. Those are not names anybody failed to write; counting them inflated the deficit by
+# roughly a third and would have sent the phase off to create pages for them.
+_LEADING_VERB = {
+    "add", "address", "agree", "answer", "ask", "assign", "attend", "await", "book", "bring",
+    "build", "can", "check", "circulate", "clarify", "close", "co-author", "complete", "confirm",
+    "consider", "continue", "create", "decide", "define", "deliver", "deploy", "did", "discuss",
+    "do", "does", "draft", "escalate", "explore", "file", "finalize", "finalise", "find", "fix",
+    "follow", "get", "give", "has", "have", "identify", "if", "include", "incorporate",
+    "investigate", "invite", "is", "keep", "land", "lead", "let", "look", "make", "merge", "move",
+    "open", "organise", "organize", "pick", "plan", "post", "prepare", "present", "propose",
+    "provide", "publish", "raise", "reach", "read", "record", "report", "request", "require",
+    "resolve", "review", "revisit", "run", "schedule", "send", "set", "share", "should", "start",
+    "submit", "support", "take", "test", "that", "the", "these", "this", "those", "track", "update",
+    "using", "verify", "wait", "was", "were", "what", "when", "where", "which", "who", "why",
+    "will", "work", "would", "write", "your",
+}
+
+
+def candidate_names(text: str, *, mask_linked: bool = True) -> list[str]:
+    """Proper names in a piece of prose, in order of appearance, de-duplicated.
+
+    A PROXY, and it says so: it cannot know that "Technical Steering Committee" deserves a page. It
+    is a good proxy because it is exactly the shape decision 24 names — a name went past and nothing
+    was created — and because the only way to improve the number is to write the page.
+
+    ``mask_linked`` drops names that are already a ``[[wikilink]]`` or a markdown link. TRUE for the
+    measure (a linked name is not a failure). FALSE for the phase's pre-pass, because a ``[[Name]]``
+    whose page does not exist renders as an inert "not found" chip — the index, not the brackets,
+    decides whether a page is there."""
+    if not text:
+        return []
+    fm = _FRONTMATTER.match(text)
+    body = text[fm.end():] if fm else text
+    body = _FENCE.sub(" ", body)
+    body = _HEADING.sub(" ", body)
+    if mask_linked:
+        body = _WIKILINK.sub(" ", body)
+        body = _MD_LINK.sub(" ", body)
+    else:
+        body = _WIKILINK.sub(r" \1 ", body)
+    out: list[str] = []
+    for m in _BARE_NAME.finditer(body):
+        n = _POSSESSIVE.sub("", " ".join(m.group(0).split())).strip()
+        if not n or n in _NOT_A_NAME or n in out:
+            continue
+        if n.split()[0].lower() in _LEADING_VERB:
+            continue
+        out.append(n)
+    return out
+
+
+def known_slugs(root) -> set:
+    """Every entity slug this workspace already holds — read from `kg/entities/`, never from the
+    generated index, because the index can be one write behind and a stale index means a duplicate
+    page."""
+    base = Path(root) / ENTITIES_DIR
+    out = set()
+    for kind in KINDS:
+        d = base / kind
+        if d.is_dir():
+            out |= {f.stem for f in d.glob("*.md") if f.name != "index.md"}
+    return out
+
+
+def missing_names(roots, texts, *, limit: int = 12) -> list[str]:
+    """The names these texts touched that no mounted desk has a page for, in order, capped.
+
+    This is the whole pre-pass: empty means the phase has nothing to do and no model call is made.
+    The cap is here rather than in the prompt because the list IS the budget — a phase handed forty
+    names either ignores the cap or runs for four minutes."""
+    known: set = set()
+    for r in roots:
+        try:
+            known |= known_slugs(r)
+        except OSError:
+            continue
+    out: list[str] = []
+    for t in texts:
+        for n in candidate_names(t, mask_linked=False):
+            slug = slugify(n)
+            if slug and slug not in known and n not in out:
+                out.append(n)
+                if len(out) >= limit:
+                    return out
+    return out
+
+
 # ── the index that rides in every dispatch ───────────────────────────────────────────────────────
 
 def _last_updated(text: str, fallback: str) -> str:

--- a/core/agent/shared/entities.py
+++ b/core/agent/shared/entities.py
@@ -334,26 +334,45 @@ def known_slugs(root) -> set:
     return out
 
 
-def missing_names(roots, texts, *, limit: int = 12) -> list[str]:
+def missing_names(roots, texts, *, limit: int = 8) -> list[str]:
     """The names these texts touched that no mounted desk has a page for, in order, capped.
 
     This is the whole pre-pass: empty means the phase has nothing to do and no model call is made.
     The cap is here rather than in the prompt because the list IS the budget — a phase handed forty
-    names either ignores the cap or runs for four minutes."""
+    names either ignores the cap or runs for four minutes. Eight matches the phase's tool-call cap:
+    a list longer than the budget can finish is a plan that gets cut off every single time, and the
+    names at the end of it are never the ones anybody chose to drop."""
     known: set = set()
     for r in roots:
         try:
             known |= known_slugs(r)
         except OSError:
             continue
-    out: list[str] = []
+    seen: list[str] = []
     for t in texts:
         for n in candidate_names(t, mask_linked=False):
             slug = slugify(n)
-            if slug and slug not in known and n not in out:
-                out.append(n)
-                if len(out) >= limit:
-                    return out
+            if slug and slug not in known and n not in seen:
+                seen.append(n)
+    return _drop_prefixes(seen)[:limit]
+
+
+def _drop_prefixes(names: list[str]) -> list[str]:
+    """Drop a name that is a PREFIX of another one in the same list — the longer spelling wins.
+
+    "James Spad" beside "James Spadafora" is one person and one page, and truncation only ever
+    produces the shorter. Deliberately a plain prefix rather than a word-boundary one: the cut that
+    matters here lands MID-WORD ("James Spadaf"), which a word-boundary test does not see.
+
+    The trade, stated: "John Smith" in a turn that also names "John Smithson" is dropped, and no
+    lexical rule can tell those two cases apart. That costs one page not written this turn — it is
+    written the next time the name appears on its own — against a permanent `james-spadaf.md` that
+    nothing will ever link to or clean up. Order is preserved, so the first mention still leads."""
+    out = []
+    for n in names:
+        if any(other != n and other.startswith(n) for other in names):
+            continue
+        out.append(n)
     return out
 
 

--- a/core/agent/tests/test_entity_writeback_trim.py
+++ b/core/agent/tests/test_entity_writeback_trim.py
@@ -1,0 +1,202 @@
+"""The write-back phase's TRIM — the mechanical pre-pass and the hard budget.
+
+The phase was right and slow: 118-136s on Haiku against a 31-47s answer, so the worker stayed busy
+three times as long and every message the person sent meanwhile queued behind it (F45/F46). These
+prove the two halves of the fix — that the commonest turn never reaches a model at all, and that
+the budget is enforced rather than requested.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from shared import entities as E
+from worker import engine
+from worker.worker import serve
+
+
+class FakeStream:
+    def __init__(self, inbox=None):
+        self.out = []
+        self._inbox = list(inbox or [])
+
+    def xadd(self, name, fields):
+        self.out.append((name, fields))
+        return str(len(self.out))
+
+    def xread(self, streams, count=1, block=None):
+        in_topic = next(iter(streams))
+        if not self._inbox:
+            return []
+        eid, fields = self._inbox.pop(0)
+        return [(in_topic, [(eid, fields)])]
+
+
+def events(stream):
+    return [json.loads(f["event"]) for _t, f in stream.out]
+
+
+# ── the pre-pass ─────────────────────────────────────────────────────────────────────────────────
+
+def test_names_come_out_of_prose_mechanically():
+    assert E.candidate_names("Cottalango Leon chairs it for Sony Pictures Imageworks.") == \
+        ["Cottalango Leon", "Sony Pictures Imageworks"]
+
+
+def test_a_wikilinked_name_is_still_a_candidate_for_the_pre_pass():
+    """The brackets are not the question — the index is. A `[[Name]]` with no page renders as an
+    inert 'not found' chip, which is the same failure wearing brackets."""
+    assert E.candidate_names("[[Olga Avramenko]] chairs it.", mask_linked=False) == \
+        ["Olga Avramenko"]
+    assert E.candidate_names("[[Olga Avramenko]] chairs it.", mask_linked=True) == []
+
+
+def test_missing_names_subtracts_what_the_desk_already_holds(tmp_path):
+    E.upsert_entity(tmp_path, "person", "Olga Avramenko", ["a fact"], "a source")
+    got = E.missing_names([tmp_path], ["Olga Avramenko met Cottalango Leon."])
+    assert got == ["Cottalango Leon"]
+
+
+def test_missing_names_is_capped_because_the_list_is_the_budget(tmp_path):
+    # alphabetic on purpose: the extractor is a PROPER-NAME regex and does not match digits
+    names = [f"Alpha Beta{chr(97 + i)}{chr(97 + i)}" for i in range(20)]
+    text = " ".join(f"{n} spoke." for n in names)
+    assert len(E.missing_names([tmp_path], [text], limit=5)) == 5
+
+
+def test_a_turn_whose_names_all_have_pages_never_reaches_a_model(tmp_path):
+    E.upsert_entity(tmp_path, "person", "Olga Avramenko", ["a fact"], "a source")
+    mounts = [{"slug": "d", "path": str(tmp_path), "write": True}]
+    assert engine.writeback_candidates(["Olga Avramenko chairs it."], mounts) == []
+
+
+def test_a_read_only_mount_is_not_searched_for_candidates(tmp_path):
+    assert engine.writeback_candidates(["Olga Avramenko chairs it."],
+                                       [{"slug": "_global", "path": str(tmp_path),
+                                         "write": False}]) == []
+
+
+# ── the four gates ───────────────────────────────────────────────────────────────────────────────
+
+def test_no_candidates_means_no_phase(monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    assert engine.should_write_back("a long message " * 20, tool_calls=3, candidates=[]) is False
+    assert engine.should_write_back("a long message " * 20, tool_calls=3,
+                                    candidates=["Olga Avramenko"]) is True
+
+
+def test_a_turn_that_already_upserted_gets_no_phase(monkeypatch):
+    """The note step calls `entity_upsert` itself. A phase after it is a second model call to find
+    out that the work is done — which is the phase on exactly the turns that need it least."""
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    assert engine.should_write_back("anything", tool_calls=4, upserts=2,
+                                    candidates=["Olga"]) is False
+
+
+def test_the_legacy_call_shape_still_gates_on_cheapness(monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    assert engine.should_write_back("thanks", tool_calls=0) is False
+    assert engine.should_write_back("ok", tool_calls=1) is True
+
+
+# ── the budget ───────────────────────────────────────────────────────────────────────────────────
+
+def test_the_tool_call_budget_stops_the_phase_and_says_so():
+    def many():
+        for i in range(50):
+            yield {"type": "tool-call", "tool": "mcp__vexa__entity_upsert", "callId": str(i)}
+
+    out = list(engine.bounded(many(), max_tool_calls=3, max_seconds=99))
+    assert sum(1 for e in out if e["type"] == "tool-call") == 3
+    assert out[-1]["type"] == "writeback-truncated" and out[-1]["reason"] == "tool-call budget"
+
+
+def test_the_time_budget_stops_the_phase():
+    def slow():
+        for i in range(50):
+            time.sleep(0.01)
+            yield {"type": "message-delta", "text": str(i)}
+
+    out = list(engine.bounded(slow(), max_tool_calls=99, max_seconds=0.03))
+    assert out[-1]["type"] == "writeback-truncated" and out[-1]["reason"] == "time budget"
+    assert len(out) < 50
+
+
+def test_the_budget_CLOSES_the_generator_so_the_subprocess_dies():
+    """A budget that only stops reading leaves the CLI running and the worker busy — the exact
+    stall the budget exists to prevent, one layer down."""
+    closed = []
+
+    def gen():
+        try:
+            while True:
+                yield {"type": "tool-call", "tool": "x", "callId": "1"}
+        except GeneratorExit:
+            closed.append(True)
+            raise
+
+    list(engine.bounded(gen(), max_tool_calls=1, max_seconds=99))
+    assert closed == [True]
+
+
+def test_the_budget_is_configurable(monkeypatch):
+    monkeypatch.setenv("VEXA_WRITEBACK_MAX_TOOL_CALLS", "3")
+    monkeypatch.setenv("VEXA_WRITEBACK_MAX_SECONDS", "7")
+    assert engine.writeback_budget() == (3, 7.0)
+
+
+def test_the_truncation_marker_is_not_shown_as_prose():
+    out = list(engine.writeback_events(iter([
+        {"type": "writeback-truncated", "reason": "time budget"},
+        {"type": "message-delta", "text": "recorded three"},
+    ])))
+    assert [e["type"] for e in out] == ["writeback-truncated"]
+
+
+# ── the loop, end to end ─────────────────────────────────────────────────────────────────────────
+
+def test_the_phase_is_handed_the_candidate_list_not_the_prompt(tmp_path, monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    monkeypatch.setenv("VEXA_WORKSPACE_PATH", str(tmp_path))
+    monkeypatch.delenv("VEXA_MOUNTS", raising=False)
+    got = {}
+
+    def turn(_p):
+        yield {"type": "tool-call", "tool": "Read", "args": {}, "callId": "a"}
+        yield {"type": "message-delta", "text": "Cottalango Leon chairs the DNA TSC."}
+        yield {"type": "done", "reply": "x", "sessionId": "s"}
+
+    def writeback(candidates):
+        got["candidates"] = candidates
+        yield {"type": "tool-call", "tool": "mcp__vexa__entity_upsert", "callId": "b"}
+        yield {"type": "done", "reply": "", "sessionId": "s"}
+
+    s = FakeStream()
+    serve(s, out_topic="out", in_topic="in", turn=turn,
+          start={"entrypoint": {"inline": "what happened?"}}, idle_ms=1, writeback=writeback)
+    assert "Cottalango Leon" in got["candidates"]
+    assert engine.writeback_prompt(got["candidates"]).count("Cottalango Leon") == 1
+
+
+def test_a_turn_that_names_nobody_new_runs_no_model_call(tmp_path, monkeypatch):
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    monkeypatch.setenv("VEXA_WORKSPACE_PATH", str(tmp_path))
+    monkeypatch.delenv("VEXA_MOUNTS", raising=False)
+    calls = []
+
+    def turn(_p):
+        yield {"type": "tool-call", "tool": "Read", "args": {}, "callId": "a"}
+        yield {"type": "message-delta", "text": "the build is green and the tests pass."}
+        yield {"type": "done", "reply": "x", "sessionId": "s"}
+
+    def writeback(_c):
+        calls.append(1)
+        yield {"type": "done", "reply": "", "sessionId": "s"}
+
+    s = FakeStream()
+    serve(s, out_topic="out", in_topic="in", turn=turn,
+          start={"entrypoint": {"inline": "how is the build?"}}, idle_ms=1, writeback=writeback)
+    assert calls == []
+    assert [e["type"] for e in events(s)][-1] == "turn-complete"

--- a/core/agent/tests/test_entity_writeback_trim.py
+++ b/core/agent/tests/test_entity_writeback_trim.py
@@ -200,3 +200,77 @@ def test_a_turn_that_names_nobody_new_runs_no_model_call(tmp_path, monkeypatch):
           start={"entrypoint": {"inline": "how is the build?"}}, idle_ms=1, writeback=writeback)
     assert calls == []
     assert [e["type"] for e in events(s)][-1] == "turn-complete"
+
+
+# ── the budget over a REAL subprocess ────────────────────────────────────────────────────────────
+
+def test_a_phase_over_budget_leaves_no_child_process(tmp_path, monkeypatch):
+    """The budget must KILL the CLI, not merely stop reading it.
+
+    This is the whole point of the trim and it is the one part that cannot be proved with a fake: a
+    budget that stops consuming while the process keeps running leaves the worker exactly as busy as
+    it was, which is the stall (F45/F46) the budget exists to remove. Worse, the first shape of
+    `_exec_subprocess` would have HUNG here — `finally: proc.wait()` on a process nobody is reading
+    blocks forever — so the budget would have produced a permanent stall instead of a temporary one.
+
+    Runs the real chain two generator levels deep: `parse_stream_json(_exec_subprocess(...))` under
+    `bounded()`. Closing the outer cascades GeneratorExit down to the subprocess's `finally`.
+
+    ⚠ THE CHILD SLEEPS AFTER ITS LAST LINE, and that detail is the test. The first version looped
+    forever writing, so closing the pipe killed it with SIGPIPE and the test passed with the kill
+    path deleted — it was measuring the operating system. A CLI waiting on a model writes nothing
+    for tens of seconds at a time, notices no closed pipe, and is exactly the case the kill exists
+    for. With the kill removed this test HANGS on `proc.wait()`, which is the failure it names.
+    """
+    import os
+    import subprocess as sp
+
+    from llm import claude_code as cc
+
+    seen = []
+
+    class _Recorder:
+        TimeoutExpired = sp.TimeoutExpired
+        PIPE, STDOUT = sp.PIPE, sp.STDOUT
+
+        @staticmethod
+        def Popen(*a, **kw):
+            proc = sp.Popen(*a, **kw)
+            seen.append(proc)
+            return proc
+
+    monkeypatch.setattr(cc, "subprocess", _Recorder)
+
+    monkeypatch.setenv("VEXA_HARNESS_REAP_GRACE_SEC", "0.3")
+    # A CLI that emits its lines and then goes quiet, the way the real one does while it waits on a
+    # model. It never exits on its own and it never notices a closed pipe.
+    line = ('{"type":"assistant","message":{"content":[{"type":"tool_use",'
+            '"name":"mcp__vexa__entity_upsert","id":"c","input":{}}]}}')
+    argv = ["sh", "-c", f"echo '{line}'; echo '{line}'; echo '{line}'; sleep 300"]
+
+    events = cc.parse_stream_json(cc._exec_subprocess(argv, str(tmp_path)))
+    out = list(engine.bounded(events, max_tool_calls=2, max_seconds=10))
+
+    assert sum(1 for e in out if e["type"] == "tool-call") == 2
+    assert out[-1]["type"] == "writeback-truncated"
+    assert len(seen) == 1
+    proc = seen[0]
+    assert proc.poll() is not None, "the CLI is still running after the budget stopped reading it"
+    with pytest.raises(ProcessLookupError):
+        os.kill(proc.pid, 0)
+
+
+def test_a_phase_inside_its_budget_is_waited_for_not_killed(tmp_path, monkeypatch):
+    """The reap must not truncate a normal turn: a CLI that finishes on its own is waited for, and
+    every line it wrote arrives."""
+    import subprocess as sp
+
+    from llm import claude_code as cc
+
+    line = ('{"type":"assistant","message":{"content":[{"type":"tool_use",'
+            '"name":"Read","id":"c","input":{}}]}}')
+    argv = ["sh", "-c", f"for i in 1 2 3; do echo '{line}'; done"]
+    out = list(engine.bounded(cc.parse_stream_json(cc._exec_subprocess(argv, str(tmp_path))),
+                              max_tool_calls=99, max_seconds=10))
+    assert sum(1 for e in out if e["type"] == "tool-call") == 3
+    assert not any(e["type"] == "writeback-truncated" for e in out)

--- a/core/agent/tests/test_entity_writeback_trim.py
+++ b/core/agent/tests/test_entity_writeback_trim.py
@@ -147,6 +147,26 @@ def test_the_budget_is_configurable(monkeypatch):
     assert engine.writeback_budget() == (3, 7.0)
 
 
+def test_the_deadline_leaves_room_for_the_round_trip_already_in_flight(monkeypatch):
+    """The clock can only be read BETWEEN events, so the phase overshoots its deadline by up to one
+    model round trip. Measured on Haiku with the deadline at 30s the phase took 35.1s and 37.1s —
+    correctly truncated, and over budget anyway. The default is the ceiling minus that round trip,
+    and this test is here so nobody 'tidies' it back to a round number."""
+    monkeypatch.delenv("VEXA_WRITEBACK_MAX_SECONDS", raising=False)
+    monkeypatch.delenv("VEXA_WRITEBACK_MAX_TOOL_CALLS", raising=False)
+    calls, secs = engine.writeback_budget()
+    assert secs < 30, "the deadline is not the ceiling — one round trip lands outside it"
+    assert calls <= 8
+
+
+def test_the_candidate_list_never_exceeds_what_the_budget_can_finish(tmp_path):
+    """A list longer than the budget can finish is a plan cut off every time, and the names at the
+    end of it are never the ones anybody chose to drop."""
+    text = " ".join(f"Alpha Beta{chr(97 + i)}{chr(97 + i)} spoke." for i in range(20))
+    calls, _ = engine.writeback_budget()
+    assert len(E.missing_names([tmp_path], [text])) <= calls
+
+
 def test_the_truncation_marker_is_not_shown_as_prose():
     out = list(engine.writeback_events(iter([
         {"type": "writeback-truncated", "reason": "time budget"},
@@ -274,3 +294,40 @@ def test_a_phase_inside_its_budget_is_waited_for_not_killed(tmp_path, monkeypatc
                               max_tool_calls=99, max_seconds=10))
     assert sum(1 for e in out if e["type"] == "tool-call") == 3
     assert not any(e["type"] == "writeback-truncated" for e in out)
+
+
+# ── phantom names out of truncated text ──────────────────────────────────────────────────────────
+
+def test_a_truncated_name_never_becomes_a_page(tmp_path):
+    """Measured on a second turn over a populated desk: the pre-pass proposed "James Spadaf",
+    "James Spad" and "Technical Stee" — fragments cut out of the 80-character tool-result PREVIEW
+    the worker seam carries. None had a page, none ever would, and each dragged a model call the
+    gate existed to prevent: 2 of 2 turns, the gate failing open."""
+    got = E.missing_names([tmp_path], ["James Spadafora and James Spad and James Spadaf spoke."])
+    assert got == ["James Spadafora"]
+
+
+def test_the_pre_pass_is_not_fed_tool_result_previews(tmp_path, monkeypatch):
+    """A truncated string may confirm a name; it may never introduce one — and confirmation buys
+    nothing the complete text has not already given. So the previews are not read at all."""
+    monkeypatch.delenv("VEXA_WRITEBACK", raising=False)
+    monkeypatch.setenv("VEXA_WORKSPACE_PATH", str(tmp_path))
+    monkeypatch.delenv("VEXA_MOUNTS", raising=False)
+    got = {}
+
+    def turn(_p):
+        yield {"type": "tool-call", "tool": "Read", "args": {}, "callId": "a"}
+        yield {"type": "tool-result", "callId": "a", "ok": True,
+               "summary": "...transcript of the call with James Spadaf"}
+        yield {"type": "message-delta", "text": "Nothing was decided."}
+        yield {"type": "done", "reply": "x", "sessionId": "s"}
+
+    def writeback(candidates):
+        got["candidates"] = candidates
+        yield {"type": "done", "reply": "", "sessionId": "s"}
+
+    s = FakeStream()
+    serve(s, out_topic="out", in_topic="in", turn=turn,
+          start={"entrypoint": {"inline": "what did the call say?"}}, idle_ms=1,
+          writeback=writeback)
+    assert "candidates" not in got, "a truncated preview introduced a name and ran a model call"

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -477,13 +477,21 @@ def writeback_budget() -> "tuple[int, float]":
     `entity_upsert` is a model round trip, and the third digit of pages a turn writes is worth less
     than the person's next message not queueing behind it. Eight is six names plus the MISSING write
     plus slack — and the measure's target is three pages per turn, so a capped phase still scores
-    full marks while the raw page count drops. That trade is deliberate and it is reported."""
+    full marks while the raw page count drops. That trade is deliberate and it is reported.
+
+    ⚠ THE SECONDS ARE A DEADLINE, NOT A DURATION, and 22 is not 30 by accident. `bounded` can only
+    check the clock BETWEEN events, so a model round trip that starts one second inside the deadline
+    runs to completion outside it: the phase overshoots by up to one round trip. Measured on Haiku
+    with the deadline at 30 the phase took 35.1s and 37.1s — correctly truncated, and over budget
+    anyway. 22 leaves room for the round trip that is already in flight. Interrupting one mid-flight
+    would need a thread per turn to buy back six seconds, which is not a trade worth making in a
+    worker."""
     def _int(name, default):
         try:
             return int(os.environ.get(name, str(default)))
         except ValueError:
             return default
-    return _int("VEXA_WRITEBACK_MAX_TOOL_CALLS", 8), float(_int("VEXA_WRITEBACK_MAX_SECONDS", 30))
+    return _int("VEXA_WRITEBACK_MAX_TOOL_CALLS", 8), float(_int("VEXA_WRITEBACK_MAX_SECONDS", 22))
 
 
 def writeback_candidates(texts, mounts: list[dict] | None = None) -> list[str]:
@@ -872,9 +880,17 @@ def serve(stream: _Stream, *, out_topic: str, in_topic: str, turn: TurnFn, start
             ack["nonce"] = nonce
         stream.xadd(out_topic, {"event": json.dumps(ack)})
         tool_calls, upserts = 0, 0
-        # What the phase's pre-pass reads. Kept small on purpose: the answer and the tool RESULTS
-        # are where names appear, and accumulating the whole event stream would put the transcript
-        # back in memory for the sake of a regex.
+        # What the phase's pre-pass reads: the person's message and the agent's answer, and NOT the
+        # tool results.
+        #
+        # ⚠ THE TOOL RESULTS ARE NOT AVAILABLE HERE, and the version that thought they were invented
+        # people. What reaches this seam is `llm.claude_code._short(content, 80)` — an 80-character
+        # PREVIEW — so a name straddling the cut arrives as a fragment. Measured on a second turn
+        # over a populated desk, the pre-pass proposed "James Spadaf", "James Spad", "Technical
+        # Stee" and "DNA TSC Inaugural Meetin": none has a page, none ever would, and each one
+        # dragged a model call it was supposed to prevent — 2 of 2 turns, exactly the gate failing
+        # open. A truncated string is not a source of names. It may confirm one; it may never
+        # introduce one, and confirmation buys nothing the complete text has not already given.
         said: list[str] = [prompt]
         for ev in turn(prompt):
             t = ev.get("type")
@@ -884,8 +900,6 @@ def serve(stream: _Stream, *, out_topic: str, in_topic: str, turn: TurnFn, start
                     upserts += 1
             elif t == "message-delta" and ev.get("text"):
                 said.append(ev["text"])
-            elif t == "tool-result" and ev.get("summary"):
-                said.append(str(ev["summary"]))
             stream.xadd(out_topic, {"event": json.dumps({**ev, "turn_id": turn_id})})
             if cursor is not None:
                 _drain_inject(cursor)

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -23,6 +23,7 @@ import json
 import logging
 import os
 import shutil
+import time
 from pathlib import Path
 from typing import Callable, Iterator, Protocol
 
@@ -408,32 +409,47 @@ _ENTITY_FILE_SHAPE = (
 # named. Told to record "what this turn learned about a person, company, meeting, project or
 # decision", the phase answered `nothing new` on a turn that had just written a note naming six
 # people and three organisations, and explained itself: *"further pages for individual TSC members
-# or companies can be added as the project develops and additional facts about them become
-# relevant beyond their participation in this kickoff."* Every clause of that is a reasonable
-# editorial judgement, and every clause is the reason the graph stays empty.
+# or companies can be added as the project develops and additional facts about them become relevant
+# beyond their participation in this kickoff."* Every clause of that is a reasonable editorial
+# judgement, and every clause is the reason the graph stays empty.
 #
-# So the phase no longer asks whether a name deserves a page. It asks for the LIST first — a
-# mechanical step with no judgement in it — and then makes the list the work. `nothing new` is
-# narrowed to the one case it is true in: no name was touched at all. And the note is explicitly
-# NOT a substitute for a page, because "it is already in the note" was the reasoning that ran.
-WRITEBACK_PROMPT = (
-    MACHINERY_MARK + " Write-back phase — not a message from the person, and nothing you say here "
-    "reaches them. Do not address them, do not summarise the turn, do not ask them anything.\n\n"
-    "FIRST, list every proper name this turn touched: every person who spoke or was named, every "
-    "company or organisation, every meeting, project or decision. Just the names.\n\n"
-    "THEN give each one a page, with `entity_upsert(kind, name, facts, source)` — one call per "
-    "name, in order. A name with no page gets one NOW; a page that exists gets this turn's facts "
-    "appended; a fact already on the page writes nothing, so call it rather than wondering.\n\n"
-    "Do not judge whether a name is important enough, whether it will matter later, or whether it "
-    "is already covered somewhere else. A meeting note is NOT a substitute for a page — it records "
-    "an occasion, a page records a subject, and the whole point is that the next turn can find the "
-    "subject. If a name was touched and you know one true thing about it, it gets a page. One "
-    "sentence of fact is enough to start one.\n\n"
-    + _ENTITY_FILE_SHAPE +
-    "Every fact carries its source, and only what was said in this conversation or read from a "
-    "file, a tool result or a transcript counts. Anything you would have to guess goes to "
-    "`kg/MISSING.md` as an open question, never onto a page.\n\n"
-    "Reply exactly `nothing new` ONLY if this turn touched no name at all.")
+# ⚠ THE SECOND VERSION WAS RIGHT AND SLOW. Asking the model to find the names cost 118-136s on
+# Haiku against a 31-47s answer, so the worker stayed busy three times as long and every message the
+# person sent meanwhile queued behind it. Finding names is a regex over text the turn already
+# produced; only the FACTS need a model. So the list arrives already made (`missing_names`), the
+# phase is told to take it in order, and a turn whose names all have pages never reaches a model.
+def writeback_prompt(candidates: list[str]) -> str:
+    """The phase's one model call, with the work already identified.
+
+    No "list what you learned" step survives here: that step was both the slow half and the half
+    that hesitated. The names are given, in order, and the only question left is what this turn can
+    honestly say about each and where it read it."""
+    named = "\n".join(f"- {c}" for c in candidates)
+    return (
+        MACHINERY_MARK + " Write-back phase — not a message from the person, and nothing you say "
+        "here reaches them. Do not address them, do not summarise the turn, do not ask anything.\n\n"
+        "These names came up in the turn you just finished and NONE of them has a page yet:\n\n"
+        + named + "\n\n"
+        "Give each one a page, in the order listed, with `entity_upsert(kind, name, facts, source)` "
+        "— one call per name, starting immediately, no preamble and no re-reading. `kind` is one of "
+        "person, company, meeting, project, decision. `facts` are what THIS turn actually said or "
+        "read about them — one short sentence each, and one sentence is enough to start a page. "
+        "`source` is where you read it: the meeting, the mail, the file, the person's message.\n\n"
+        "Do not judge whether a name is important enough or whether it is covered somewhere else. A "
+        "meeting note is NOT a substitute for a page — it records an occasion, a page records a "
+        "subject, and the point is that the next turn can find the subject.\n\n"
+        + _ENTITY_FILE_SHAPE +
+        "A name you cannot say one sourced thing about does NOT get a page: append it to "
+        "`kg/MISSING.md` as one line — the name and what you would need to know — in a single "
+        "write at the end. Never invent a fact to fill a page.\n\n"
+        "Work only from this turn. You have a hard budget: no exploration, no reading files you "
+        "have not already read.")
+
+
+# Kept as a module constant because the tests and the docs name it, and because a phase with an
+# empty candidate list is unreachable by construction — `should_write_back` refuses it first.
+WRITEBACK_PROMPT = writeback_prompt(["<the names the pre-pass found>"])
+
 
 # Read/Glob/Grep to check what a page already says, Write/Edit for `kg/MISSING.md`, and the entity
 # verb itself. Deliberately NOT the research tools: this phase records what the turn already learned,
@@ -454,17 +470,96 @@ def writeback_min_tokens() -> int:
         return 40
 
 
-def should_write_back(prompt: str, tool_calls: int, *, min_tokens: int | None = None) -> bool:
-    """Skip only a turn that is cheap on BOTH counts: it called no tools AND the person said very
-    little. Either one alone is a turn that can have learned something — a long message carries
-    facts with no tool call, and a short one ("who is Olga?") can pull a whole dossier through a
-    tool. The floor is on the PERSON's words, never on the agent's reply."""
+def writeback_budget() -> "tuple[int, float]":
+    """``(max tool calls, max seconds)`` for the phase — a HARD budget, not a hope.
+
+    The tool cap is what keeps the phase inside the answer's own order of magnitude: each
+    `entity_upsert` is a model round trip, and the third digit of pages a turn writes is worth less
+    than the person's next message not queueing behind it. Eight is six names plus the MISSING write
+    plus slack — and the measure's target is three pages per turn, so a capped phase still scores
+    full marks while the raw page count drops. That trade is deliberate and it is reported."""
+    def _int(name, default):
+        try:
+            return int(os.environ.get(name, str(default)))
+        except ValueError:
+            return default
+    return _int("VEXA_WRITEBACK_MAX_TOOL_CALLS", 8), float(_int("VEXA_WRITEBACK_MAX_SECONDS", 30))
+
+
+def writeback_candidates(texts, mounts: list[dict] | None = None) -> list[str]:
+    """THE PRE-PASS — the phase's cheap half, in code, before any model is asked anything.
+
+    Names out of what the turn already produced (the person's message, the agent's answer, the tool
+    results), minus everything the mounted desks already have a page for. An empty list means the
+    phase has nothing to do, and that is by far the commonest turn: it now costs a regex instead of
+    a two-minute model call."""
+    from shared.entities import missing_names
+
+    roots = [Path(str(m.get("path") or "")) for m in (mounts if mounts is not None else active_mounts())
+             if m.get("write", True) and m.get("path")]
+    if not roots:
+        return []
+    return missing_names(roots, [t for t in texts if t])
+
+
+def should_write_back(prompt: str, tool_calls: int, *, min_tokens: int | None = None,
+                      upserts: int = 0, candidates: "list[str] | None" = None) -> bool:
+    """Four gates, cheapest first, and three of them cost no model call.
+
+    1. the switch;
+    2. **the turn already did it** — a turn that called `entity_upsert` itself (the note step does)
+       has already paid for the write-back, and a phase after it is a second model call to discover
+       that. This is the gate that removes the phase from exactly the turns that need it least;
+    3. cheap on BOTH counts — no tool call AND the person said very little. Either signal alone is a
+       turn that can have learned something: a long message carries facts with no tool call, and a
+       short one ("who is Olga?") can pull a whole dossier through one. The floor is on the PERSON's
+       words, never on the agent's reply;
+    4. **nothing to write** — `candidates` empty. Passing `None` skips this gate (the caller has not
+       run the pre-pass), which is only the tests and the legacy call shape.
+    """
     if not writeback_enabled():
         return False
-    if tool_calls > 0:
-        return True
+    if upserts > 0:
+        return False
     floor = writeback_min_tokens() if min_tokens is None else min_tokens
-    return len((prompt or "").split()) >= floor
+    if tool_calls <= 0 and len((prompt or "").split()) < floor:
+        return False
+    if candidates is not None and not candidates:
+        return False
+    return True
+
+
+def bounded(events: Iterator[dict], *, max_tool_calls: int, max_seconds: float) -> Iterator[dict]:
+    """Stop the phase at its budget and CLOSE the generator, which kills the harness subprocess.
+
+    A budget the phase is merely told about is a budget it exceeds — the same lesson as the
+    grounding gate, one layer down. Closing the generator is what makes it real: `run_harness_turn`
+    sees `GeneratorExit` at its yield, and `llm.claude_code._exec_subprocess` now terminates the CLI
+    rather than waiting on it forever.
+
+    The cost of stopping early is the phase's own post-turn commit, which never runs. It is a small
+    cost by construction: `entity_upsert` commits each page through the endpoint as it goes, and a
+    file written by the fallback path is swept up by the next turn's commit."""
+    t0 = time.monotonic()
+    calls = 0
+    gen = iter(events)
+    try:
+        for ev in gen:
+            yield ev
+            if ev.get("type") == "tool-call":
+                calls += 1
+            if calls >= max_tool_calls:
+                yield {"type": "writeback-truncated", "reason": "tool-call budget",
+                       "tool_calls": calls}
+                return
+            if time.monotonic() - t0 >= max_seconds:
+                yield {"type": "writeback-truncated", "reason": "time budget",
+                       "seconds": round(time.monotonic() - t0, 1), "tool_calls": calls}
+                return
+    finally:
+        close = getattr(gen, "close", None)
+        if close is not None:
+            close()
 
 
 def writeback_events(events: Iterator[dict]) -> Iterator[dict]:
@@ -776,10 +871,21 @@ def serve(stream: _Stream, *, out_topic: str, in_topic: str, turn: TurnFn, start
         if nonce:
             ack["nonce"] = nonce
         stream.xadd(out_topic, {"event": json.dumps(ack)})
-        tool_calls = 0
+        tool_calls, upserts = 0, 0
+        # What the phase's pre-pass reads. Kept small on purpose: the answer and the tool RESULTS
+        # are where names appear, and accumulating the whole event stream would put the transcript
+        # back in memory for the sake of a regex.
+        said: list[str] = [prompt]
         for ev in turn(prompt):
-            if ev.get("type") == "tool-call":
+            t = ev.get("type")
+            if t == "tool-call":
                 tool_calls += 1
+                if str(ev.get("tool") or "").endswith("entity_upsert"):
+                    upserts += 1
+            elif t == "message-delta" and ev.get("text"):
+                said.append(ev["text"])
+            elif t == "tool-result" and ev.get("summary"):
+                said.append(str(ev["summary"]))
             stream.xadd(out_topic, {"event": json.dumps({**ev, "turn_id": turn_id})})
             if cursor is not None:
                 _drain_inject(cursor)
@@ -787,10 +893,19 @@ def serve(stream: _Stream, *, out_topic: str, in_topic: str, turn: TurnFn, start
         # is already reading — and before `turn-complete`, so its tool calls land as step lines on
         # the turn they belong to instead of on nothing. A phase that raises must not lose the
         # turn: the answer is delivered either way, and bookkeeping is not worth a dead session.
-        if writeback is not None and should_write_back(prompt, tool_calls):
+        #
+        # THE PRE-PASS RUNS FIRST AND IS FREE. Only a turn that touched a name no desk has a page
+        # for reaches a model at all; every other turn now costs a regex where it used to cost two
+        # minutes of worker time with the person's next message queued behind it.
+        if writeback is not None:
             try:
-                for ev in writeback_events(writeback(prompt)):
-                    stream.xadd(out_topic, {"event": json.dumps({**ev, "turn_id": turn_id})})
+                candidates = (writeback_candidates(said)
+                              if should_write_back(prompt, tool_calls, upserts=upserts) else [])
+                if should_write_back(prompt, tool_calls, upserts=upserts, candidates=candidates):
+                    calls, secs = writeback_budget()
+                    for ev in writeback_events(bounded(writeback(candidates),
+                                                       max_tool_calls=calls, max_seconds=secs)):
+                        stream.xadd(out_topic, {"event": json.dumps({**ev, "turn_id": turn_id})})
             except Exception as e:  # noqa: BLE001
                 log.warning("write-back phase failed on %s: %s: %s", turn_id, type(e).__name__, e)
         stream.xadd(out_topic, {"event": json.dumps({"type": "turn-complete", "turn_id": turn_id})})
@@ -1039,8 +1154,8 @@ def main() -> None:  # pragma: no cover — the container entrypoint (wired in t
             # SAME session on purpose: the phase has to see what the turn just saw, and a fresh
             # session would have to be told the whole conversation to ask one bookkeeping question.
             # Small budget by TOOLSET rather than by a step cap the harness does not expose.
-            writeback=lambda _prompt: run_turn_over_workspace(
-                work, WRITEBACK_PROMPT, model=model,
+            writeback=lambda candidates: run_turn_over_workspace(
+                work, writeback_prompt(candidates), model=model,
                 allowed_tools=[*WRITEBACK_TOOLS, *mcp_tools], session=session,
                 mcp_config=mcp_cfg, harness=chat_harness),
             start=json.loads(os.environ.get("VEXA_START", "{}")), idle_ms=idle_ms,

--- a/core/flows/eval/dna/score.py
+++ b/core/flows/eval/dna/score.py
@@ -17,6 +17,7 @@ import json
 import pathlib
 import re
 import subprocess
+import sys
 
 OLD_EVENT_CAP = 8000   # what meeting.completed used to carry; now the comparison boundary
 
@@ -241,62 +242,20 @@ def d_compounding(rec: dict, earlier: list[dict]) -> tuple[float, dict]:
 # low), and it can write beautifully linked prose that created nothing (the reverse). Averaging them
 # into one score would hide exactly the distinction the change is meant to move.
 
-# A capitalised RUN of two or more words — "Sony Pictures Imageworks", "Cottalango Leon". Single
-# capitalised words are deliberately not counted: at the start of a sentence every word is one, and
-# a measure that fires on "The" and "Monday" tells you about English, not about the product.
-# `and` and `the` are NOT intra-name particles, and the first version of this had them: it read
-# "Blue Light Card and Kaar Tech" as ONE name, undercounting by exactly the amount a note listing
-# several dead names does. A measure's own bugs bias in the direction that flatters the product.
-_BARE_NAME = re.compile(r"\b[A-Z][a-zA-Z'’\-]+(?:\s+(?:of|de|del|van|von|da|di)\s+[A-Z][a-zA-Z'’\-]+"
-                        r"|\s+[A-Z][a-zA-Z'’\-]+)+")
-_FENCE = re.compile(r"```[\s\S]*?```")
-# Headings and list labels are formatting, not mentions; a `## Decided` never wanted a wikilink.
-_HEADING = re.compile(r"^#{1,6}\s.*$", re.M)
-_NOT_A_NAME = {"Open Items", "Action Items", "Next Steps", "Open Questions", "Decided Committed"}
-
-# ⚠ MEASURED FALSE POSITIVE, removed after the first baseline run. Over ten real DNA notes the
-# measure flagged "Complete SSO", "Ask ASF", "Co-author TAC", "Lead TAC", "Attend SIGGRAPH",
-# "Escalate GitHub", "Await PR" — every one of them a Committed-section bullet, which by convention
-# opens with an imperative verb and is followed by an acronym. Those are not names anybody failed to
-# link; counting them inflated the deficit by roughly a third and would have made the fix look
-# better than it was. A measure's own bugs bias in whichever direction flatters the change, so they
-# get found before the change is scored, not after.
-_LEADING_VERB = {
-    "add", "address", "agree", "answer", "ask", "assign", "attend", "await", "book", "bring",
-    "build", "check", "circulate", "clarify", "close", "co-author", "complete", "confirm",
-    "consider", "continue", "create", "decide", "define", "deliver", "deploy", "discuss", "draft",
-    "escalate", "explore", "file", "finalize", "finalise", "find", "fix", "follow", "get", "give",
-    "identify", "include", "investigate", "invite", "keep", "land", "lead", "let", "look", "make",
-    "merge", "move", "open", "organise", "organize", "pick", "plan", "post", "prepare", "present",
-    "propose", "provide", "publish", "raise", "reach", "read", "record", "report", "request",
-    "resolve", "review", "revisit", "run", "schedule", "send", "set", "share", "should", "start",
-    "submit", "support", "take", "test", "track", "update", "verify", "wait", "work", "write",
-}
-_POSSESSIVE = re.compile(r"[\u2019']s$")
+# THE EXTRACTOR IS THE PRODUCT'S, NOT THE SCORER'S. `shared/entities.py` owns what counts as a
+# name, because the write-back phase's pre-pass now runs the same function to decide whether a turn
+# has anything to record at all. Two spellings of that rule is how a scorer ends up measuring
+# something the product never looked for — and the first version of this file WAS the second
+# spelling.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "agent"))
+from shared.entities import candidate_names  # noqa: E402
 
 
 def unlinked_names(note: str) -> list:
-    """Capitalised multi-word names in the note that are NOT inside a `[[wikilink]]` or a markdown
-    link. This is a PROXY and says so: it cannot know that "Technical Steering Committee" deserves
-    a page. It is a good proxy because it is exactly the failure decision 24 names — a name went
-    past and nothing was created — and because it can only be improved by writing the page."""
-    if not note:
-        return []
-    fm = re.match(r"^---\n[\s\S]*?\n---\n", note)
-    body = note[fm.end():] if fm else note
-    body = _FENCE.sub(" ", body)
-    body = _HEADING.sub(" ", body)
-    body = re.sub(r"\[\[[^\]]+\]\]", " ", body)          # already a chip
-    body = re.sub(r"\[[^\]]+\]\([^)]*\)", " ", body)      # already a link
-    out = []
-    for m in _BARE_NAME.finditer(body):
-        n = _POSSESSIVE.sub("", " ".join(m.group(0).split())).strip()
-        if not n or n in _NOT_A_NAME or n in out:
-            continue
-        if n.split()[0].lower() in _LEADING_VERB:
-            continue
-        out.append(n)
-    return out
+    """Capitalised multi-word names in the note that are NOT already a `[[wikilink]]` or a markdown
+    link. A linked name is not a failure, so the measure masks them; the phase's pre-pass does not
+    (a `[[Name]]` with no page is an inert chip, which is the same failure wearing brackets)."""
+    return candidate_names(note or "", mask_linked=True)
 
 
 ENTITY_TARGET_PER_TURN = 3.0


### PR DESCRIPTION
Follow-up to [`#1401`](https://github.com/Vexa-ai/vexa/pull/1401) (merged as `0dbd8f205`). Owning issue [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449). Base `minutes-mcp-viewer`; three commits on `a9acf1426`.

**The bottleneck:** the write-back phase cost 118–136 s on Haiku against a 31–47 s answer. The worker stayed busy three times as long and every message the person sent meanwhile queued behind it (F45/F46).

**COMMITMENTS IN THIS PR — none.** Build only; no swap, no deploy.

---

## The change

Finding the names is a regex over text the turn already produced. Only the **facts** need a model. So the cheap half moved into code and the expensive half got a budget.

1. **The pre-pass, in code** — `shared/entities.candidate_names` / `known_slugs` / `missing_names`. Names out of the person's message and the agent's answer, minus every slug the mounted desks already hold. It is also now the **SSOT for the measure**: `core/flows/eval/dna/score.py` imports it instead of keeping a second regex — two spellings of "what counts as a name" is how a scorer ends up measuring something the product never looked for.
2. **Four gates, cheapest first, three of them free** (`should_write_back`): the switch; **the turn already upserted** (the note step does, and a phase after it is a second model call to discover the work is done); cheap on both counts; and **nothing to write**. A turn whose names all have pages never reaches a model.
3. **One model call, list already made** — `writeback_prompt(candidates)`. The "list what you learned" step is gone: it was both the slow half and the half that hesitated.
4. **A hard budget** — `bounded()` stops at `VEXA_WRITEBACK_MAX_TOOL_CALLS` (8) or `VEXA_WRITEBACK_MAX_SECONDS` (22) and **closes the generator**, plus `llm/claude_code._reap` so closing it kills the CLI.

## The numbers

Offline, same rig and same two DNA fixtures as `#1401`, Haiku, scratch workspaces, nothing running touched. Artifacts: `~/dna-runs/entity-ab7/`.

| | phase | model call | `entities_touched` | pages/fixture | answer |
|---|---|---|---|---|---|
| **before the phase** (#1401 arm A) | — | — | 0.333 | 1.0 | 34.3 s |
| **#1401 as merged** | 118–136 s | 2/2 | **1.000** | 16.5 | 31–47 s |
| **this PR** | **27.4 / 28.1 s — median 27.75 s** | 2/2 | **1.000** | 4.0 | 46.1 s |

**Target met:** phase median **27.75 s ≤ 30 s**, `entities_touched` **1.000, unchanged**.

Raw pages fall 16.5 → 4.0, and that is the budget working rather than the phase failing. **The budget does not lose names, it defers them**: the follow-up turn on each populated desk proposed exactly the real people the truncated first turn had not reached yet — `Tommy Burnette`; `John Mertic`, `James Spadafora`, `Olga Avramenko` — at a pre-pass cost of **0.001 s**. The measure's target is three pages per turn, so the dimension holds while the tail moves to the next turn instead of to the front of the person's queue.

`answer_s` is noisier than the change (28.9–55.5 s across arms on n=2); nothing here should be read as the preamble costing 12 s.

## Two defects the measurement found

Both would have passed review. Neither looks like a failure from the outside.

**1. Phantom names out of truncated previews.** The pre-pass was reading tool-result summaries — and what reaches that seam is `llm.claude_code._short(content, 80)`, an 80-character **preview**, not the result. A name straddling the cut arrives as a fragment. Measured on a second turn over a populated desk, the pre-pass proposed `"James Spadaf"`, `"James Spad"`, `"Technical Stee"`, `"DNA TSC Inaugural Meetin"`: none has a page, none ever would, and each dragged a model call the gate exists to prevent — **2 of 2 turns, the gate failing open**. Fixed at the root: the pre-pass reads complete text only, and `missing_names` drops a name that is a prefix of another (longest spelling wins). The trade on `"John Smith"` beside `"John Smithson"` is stated in the docstring — one page deferred a turn, against a permanent `james-spadaf.md` nothing will ever link to or clean up.

**2. The deadline is not the ceiling.** `bounded()` can only read the clock *between* events, so a model round trip that starts one second inside the deadline finishes outside it. With the deadline at 30 s the phase measured **35.1 s and 37.1 s** — correctly truncated, over budget anyway. The default is 22 s so the round trip already in flight lands under 30, with a test that says so; the candidate cap moved 12 → 8 to match the tool cap, because a list longer than the budget can finish is a plan cut off every time and the names at the end are never the ones anybody chose to drop.

## The child process, proved

`test_a_phase_over_budget_leaves_no_child_process` runs the real chain two generator levels deep — `parse_stream_json(_exec_subprocess(...))` under `bounded()` — and asserts `proc.poll() is not None` and that `os.kill(pid, 0)` raises `ProcessLookupError`.

**The first version of that test was worthless and the check caught it.** Its child looped forever *writing*, so closing the pipe killed it with SIGPIPE and the test **passed with the kill path deleted** — it was measuring the operating system. A CLI waiting on a model writes nothing for tens of seconds and never notices a closed pipe; that is the case the kill exists for. The child now sleeps after its last line:

- with the kill path removed → **pytest exit 124, hung** on `proc.wait()` (verified, kill path restored after)
- with it in place → **passes in 0.54 s**

`_reap`'s grace is env-tunable (`VEXA_HARNESS_REAP_GRACE_SEC`, default 5) only so that test can prove the kill path in a fraction of a second.

## Tests

`core/agent` **832 passed**, `core/flows` **200 passed, 1 skipped**. `gate:contract-conformance` green, no bypass.

New in `core/agent/tests/test_entity_writeback_trim.py` (23): the extractor's boundaries · `missing_names` subtracts the desk and is capped · a turn whose names all have pages never reaches a model · a read-only mount is not searched · the four gates · both budgets and the truncation marker · the budget closes the generator · **no child process survives** · a normal turn is waited for, not killed · the deadline leaves room for the round trip in flight · a truncated name never becomes a page · the pre-pass is not fed previews · the phase is handed the candidate list, not the prompt.

**Pre-existing failures, unchanged** — confirmed by running the same tests at `origin/minutes-mcp-viewer` in a throwaway worktree: `test_meeting_room.py::test_the_runtime_binds_a_room_mount_read_only` (`ModuleNotFoundError: requests_unixsocket` in `core/runtime`) and two `core/flows/tests/test_contract_smokes.py` cases that talk to the live stack's admin-api.

## One operational note

`git stash` is repository-wide state shared across every worktree. Using it here to check a baseline **popped another session's stash entry** (`pre-security-integration-20260514`) and produced ~90 conflicted paths. Recovered with `git reset --hard` + `git clean -fd`; all three stash entries verified intact and the two commits untouched. This is the CLAUDE.md git-index rule one level up — the stash stack is a write surface with no owner — and the baseline check that needed it is better done with a throwaway `git worktree`, which is what the numbers above use.
