### PR TITLE
panel: the file navigator — workspaces, trees, filter (PRD decision 27)

### DIFF
--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -33,7 +33,7 @@ import { resolveDocRef } from "../ui-kit/docLinks";
 import { Rail } from "./Rail";
 import { meetingPhase, type MeetingMock } from "../surfaces/meetingModel";
 import { fetchScaffold, localScaffold, refusalCopy, scaffoldToChat, type Scaffold, type ScaffoldRefusal } from "./scaffold";
-import { artifactsFromTokens, artifactTabEffect, pageForDocRef, pageForMeetingRef, pagesForPhase, resolveView, VIEW_KEY } from "./roomView";
+import { artifactsFromTokens, artifactTabEffect, pageForDocRef, pageForMeetingRef, pagesForPhase, resolveView, VIEW_KEY, VIEW_NAVIGATE_EVENT, type ViewSlot } from "./roomView";
 import { applyProposal, proposals, type Proposal } from "./proposals";
 import { ProposalChips } from "./ProposalChips";
 import { EdgeHandle, EDGE_W } from "./Collapse";
@@ -555,6 +555,25 @@ export function MinutesShell() {
     setPages((prev) => prev.some((x) => artifactKey(x) === artifactKey(pg)) ? prev : [...prev, pg]);
     setDocPath(pg.path); setDocSlug(pg.slug); setDocKind(pg.kind === "meeting" ? "meeting" : "doc");
     setListing(null); setDocNonce((n) => n + 1);
+  }, []);
+
+  /** THE VIEW SLOT (decision 28) — the navigator moves what is IN FRONT and mints no tab. Reading
+   *  a workspace by walking it is browsing, and browsing that collects leaves a tab strip nobody
+   *  asked for; a tab is now an explicit act.
+   *
+   *  Until branch `panel-view-slot` puts `view: {workspace, path}` on the chat record, the
+   *  destination lands in the shell's own document state — the very state a focused tab drives —
+   *  so nothing here is panel-local and `artifacts[]` is untouched. */
+  useEffect(() => {
+    const onView = (e: Event) => {
+      const d = (e as CustomEvent<ViewSlot>).detail;
+      if (!d?.path) return;
+      setPagesCollapsed(false); saveCollapsed("right", false);
+      setDocPath(d.path); setDocSlug(d.workspace); setDocKind("doc");
+      setListing(null); setDocNonce((n) => n + 1);
+    };
+    window.addEventListener(VIEW_NAVIGATE_EVENT, onView);
+    return () => window.removeEventListener(VIEW_NAVIGATE_EVENT, onView);
   }, []);
 
   /** Walk the stack without disturbing it. A document closed since it was visited is REOPENED as a

--- a/clients/terminal/src/minutes/Navigator.tsx
+++ b/clients/terminal/src/minutes/Navigator.tsx
@@ -1,0 +1,258 @@
+"use client";
+/** THE NAVIGATOR — the right panel's own left rail (PRD decision 27).
+ *
+ *  Founder: *"we need this workspaces view — default hidden left-side bar of the right sidebar,
+ *  that will have collapsed workspaces and filter search."* A file tree beside the open file, and
+ *  nothing more: open, filter, read. No rename, no delete, no drag — decision 27.6, "not an IDE".
+ *
+ *  DEFAULT HIDDEN, remembered per browser (27.4). It is a way to go looking, not a thing to look at:
+ *  the panel still opens on the desk README (decision 26.4) and the rail stays folded until asked.
+ *
+ *  A CLICK NAVIGATES, IT DOES NOT COLLECT (decision 28). Walking a tree is browsing, and browsing
+ *  that mints a tab per curiosity leaves a strip nobody asked for; so a row moves the panel's single
+ *  view slot, and a TAB is minted only when the reader says so — middle-click, or the ⧉ on the row.
+ *  Either way the write goes through `minutes/roomView`'s seam and the panel's own `onOpen`, never
+ *  into state this component keeps: what is in front belongs to the chat record.
+ *
+ *  WHAT IS NOT LISTED: machinery and dotfiles, from the one list in `./machinery` that the panel's
+ *  folder listing reads too. WHAT IS LISTED GREY: a workspace this reader cannot open — named, not
+ *  hidden, and it does not expand (decision 26.3, "if a workspace is not available, it's okay — by
+ *  design"). */
+import type { CSSProperties, ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "../ui-kit";
+import type { Page } from "./types";
+import { navigateView } from "./roomView";
+import {
+  MAX_HITS, filterByName, loadNavTree, loadNavWorkspaces, parseQuery, treeFrom,
+  type NavWorkspace, type TreeNode,
+} from "./navigatorApi";
+import { surface, type as ty } from "./tokens";
+
+/** FIXED (founder: a "left-side bar", not a second resizable pane). The pages panel's own drag is
+ *  the one width the reader sets here; a rail with its own handle would put two grips on one edge. */
+export const NAV_W = 236;
+
+const wsRow = (readable: boolean): CSSProperties => ({
+  ...ty.body, display: "flex", alignItems: "center", gap: 6, width: "100%", textAlign: "left",
+  padding: "4px 6px", borderRadius: 6, border: "none", background: "transparent",
+  color: readable ? "var(--t1)" : "var(--t3)", cursor: readable ? "pointer" : "default",
+  fontWeight: 600, fontSize: 12, minWidth: 0,
+});
+const entry: CSSProperties = {
+  display: "flex", alignItems: "center", width: "100%", textAlign: "left", background: "transparent",
+  border: "none", padding: "3px 6px", borderRadius: 6, cursor: "pointer",
+  fontFamily: "var(--mono)", fontSize: 11.5, minWidth: 0,
+};
+const nameS: CSSProperties = { flex: "1 1 0%", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" };
+const caret = (open: boolean): CSSProperties => ({ flex: "none", width: 10, color: "var(--t3)", fontFamily: "var(--sans)", fontSize: 9, lineHeight: 1, transform: open ? "rotate(90deg)" : "none", transition: "transform .1s" });
+const hoverOn = (e: { currentTarget: HTMLElement }) => { e.currentTarget.style.background = surface.raised; };
+const hoverOff = (e: { currentTarget: HTMLElement }) => { e.currentTarget.style.background = "transparent"; };
+
+const named = (path: string) => (path.split("/").pop() ?? path).replace(/\.md$/i, "");
+const pageFor = (ws: NavWorkspace, path: string): Page => ({ path, slug: ws.slug, label: named(path) });
+
+export function Navigator(p: {
+  /** the panel's own tab route — the chat record's `artifacts[]`. Used ONLY on an explicit
+   *  open-in-tab, never on a plain click (decision 28). */
+  onOpenTab: (pg: Page) => void;
+  onClose: () => void;
+  /** test seam: the workspaces, already resolved. Absent → fetched on mount. */
+  workspaces?: NavWorkspace[];
+  /** test seam: file lists by workspace key. A key present here is never fetched. */
+  trees?: Record<string, string[]>;
+}) {
+  const [workspaces, setWorkspaces] = useState<NavWorkspace[] | null>(p.workspaces ?? null);
+  const [trees, setTrees] = useState<Record<string, string[]>>(p.trees ?? {});
+  const [openWs, setOpenWs] = useState<Set<string>>(() => new Set());
+  const [openDirs, setOpenDirs] = useState<Set<string>>(() => new Set());
+  const [q, setQ] = useState("");
+  const box = useRef<HTMLInputElement>(null);
+  const seeded = useRef(!!p.workspaces);
+  /** workspace keys whose file list has been read (or handed in) — never read back from state */
+  const fetched = useRef<Set<string>>(new Set(Object.keys(p.trees ?? {})));
+
+  useEffect(() => {
+    if (seeded.current) return;
+    let live = true;
+    // A failure here is an EMPTY rail, never a missing one: `loadNavWorkspaces` already degrades to
+    // the desk alone, so the only way to land on [] is a browser with no session at all.
+    void loadNavWorkspaces().then((ws) => { if (live) setWorkspaces(ws); }).catch(() => { if (live) setWorkspaces([]); });
+    return () => { live = false; };
+  }, []);
+
+  /** Read a workspace's files ONCE, when something needs them (an expand, or a filter that must
+   *  search everywhere). Lazy per decision 27.2's spirit — the tree endpoint walks a whole
+   *  workspace, and a rail that opens should not walk five. */
+  const ensureTree = useCallback(async (ws: NavWorkspace) => {
+    // "have we read this one?" is asked OUTSIDE React state on purpose: a state updater is not a
+    // place to read from — it may run later, or twice — and a wrong answer here is either a
+    // duplicated walk of a whole workspace or a tree that never arrives.
+    if (!ws.readable || fetched.current.has(ws.key)) return;
+    fetched.current.add(ws.key);
+    const files = await loadNavTree(ws);
+    setTrees((prev) => ({ ...prev, [ws.key]: files }));
+  }, []);
+
+  const parsed = useMemo(() => parseQuery(q), [q]);
+  const filtering = parsed.text.length > 0;
+
+  // A filter reaches ACROSS the listed workspaces (27.3), so it needs their file lists — including
+  // the ones nobody expanded. Typing is what pays for that walk, and it is paid once.
+  useEffect(() => {
+    if (!filtering || !workspaces) return;
+    for (const ws of workspaces) if (ws.readable) void ensureTree(ws);
+  }, [filtering, workspaces, ensureTree]);
+
+  // The close handler as a REF: the key listener is registered once, and a parent that re-renders
+  // (every keystroke in the filter does) must not cost a listener churn.
+  const onCloseRef = useRef(p.onClose);
+  onCloseRef.current = p.onClose;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { onCloseRef.current(); return; }
+      if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      const tag = t?.tagName;
+      // `/` is a character before it is a shortcut — never steal it out of a composer.
+      if (tag === "INPUT" || tag === "TEXTAREA" || t?.isContentEditable) return;
+      e.preventDefault();
+      box.current?.focus();
+      box.current?.select();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const toggleWs = (ws: NavWorkspace) => {
+    if (!ws.readable) return;   // greyed rows do not expand — there is nothing behind them to show
+    const next = new Set(openWs);
+    if (next.has(ws.key)) next.delete(ws.key); else { next.add(ws.key); void ensureTree(ws); }
+    setOpenWs(next);
+  };
+  const toggleDir = (key: string) => setOpenDirs((prev) => {
+    const next = new Set(prev);
+    if (next.has(key)) next.delete(key); else next.add(key);
+    return next;
+  });
+
+  /** THE CLICK. It moves the panel's view slot and mints nothing (decision 28). */
+  const go = (ws: NavWorkspace, path: string) => navigateView(ws.slug, path);
+  /** THE EXPLICIT KEEP. Middle-click, or the ⧉ — a tab through the panel's own route. */
+  const keep = (ws: NavWorkspace, path: string) => p.onOpenTab(pageFor(ws, path));
+
+  const fileRow = (ws: NavWorkspace, path: string, label: string, depth: number) => (
+    <div key={`${ws.key}|${path}`} style={{ position: "relative", display: "flex" }}
+      onMouseEnter={(e) => { const b = e.currentTarget.querySelector("[data-nav-tab]") as HTMLElement | null; if (b) b.style.opacity = "1"; }}
+      onMouseLeave={(e) => { const b = e.currentTarget.querySelector("[data-nav-tab]") as HTMLElement | null; if (b) b.style.opacity = "0"; }}>
+      <button data-nav-file={`${ws.key}|${path}`} title={ws.slug ? `${ws.slug} › ${path}` : path}
+        onClick={() => go(ws, path)}
+        onAuxClick={(e) => { if (e.button === 1) { e.preventDefault(); keep(ws, path); } }}
+        style={{ ...entry, color: "var(--t1)", paddingLeft: 6 + depth * 11, paddingRight: 22 }}
+        onMouseEnter={hoverOn} onMouseLeave={hoverOff}>
+        <span style={nameS}>{label}</span>
+      </button>
+      <button data-nav-tab={`${ws.key}|${path}`} aria-label={`Open ${label} in a tab`} title="Open in a tab"
+        onClick={(e) => { e.stopPropagation(); keep(ws, path); }}
+        style={{ position: "absolute", right: 2, top: "50%", transform: "translateY(-50%)", opacity: 0, transition: "opacity .12s", background: "transparent", border: "none", color: "var(--t3)", cursor: "pointer", fontSize: 11, lineHeight: 1, padding: "2px 4px", fontFamily: "var(--sans)" }}>⧉</button>
+    </div>
+  );
+
+  const nodes = (ws: NavWorkspace, list: TreeNode[], depth: number): ReactNode[] =>
+    list.flatMap((n) => {
+      if (!n.dir) return [fileRow(ws, n.path, n.name, depth)];
+      const key = `${ws.key}|${n.path}`;
+      const open = openDirs.has(key);
+      return [
+        <button key={`d:${key}`} data-nav-dir={key} onClick={() => toggleDir(key)}
+          style={{ ...entry, color: "var(--t2)", paddingLeft: 6 + depth * 11 }}
+          onMouseEnter={hoverOn} onMouseLeave={hoverOff}>
+          <span style={caret(open)} aria-hidden>▶</span>
+          <span style={{ ...nameS, paddingLeft: 4 }}>{n.name}</span>
+        </button>,
+        ...(open ? nodes(ws, n.children, depth + 1) : []),
+      ];
+    });
+
+  const result = useMemo(
+    () => (filtering && workspaces ? filterByName(q, workspaces, trees) : null),
+    [filtering, workspaces, trees, q],
+  );
+
+  return (
+    <div data-navigator style={{
+      flex: "none", width: NAV_W, display: "flex", flexDirection: "column", minHeight: 0,
+      background: surface.rail, borderRight: "1px solid var(--line)",
+    }}>
+      <div style={{ flex: "none", display: "flex", alignItems: "center", gap: 6, padding: "8px 8px 6px" }}>
+        <Icon name="search" size={12} style={{ flex: "none", color: "var(--t3)" }} />
+        <input ref={box} data-nav-filter value={q} onChange={(e) => setQ(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Escape") { e.stopPropagation(); if (q) setQ(""); else p.onClose(); } }}
+          placeholder="Filter files  (> content)" aria-label="Filter files"
+          style={{
+            ...ty.body, flex: "1 1 0%", minWidth: 0, fontSize: 12, background: surface.raised,
+            border: "1px solid var(--line)", borderRadius: 6, padding: "3px 7px", color: "var(--t1)", outline: "none",
+          }} />
+      </div>
+      {/* CONTENT SEARCH IS NOT ON THIS BUILD. There is no workspace-content route to call, so the
+          `>` is honoured as far as it can be — the names are still matched — and the reader is TOLD,
+          rather than shown an empty result that reads as "no such text anywhere". */}
+      {parsed.content && (
+        <div data-nav-note style={{ ...ty.meta, padding: "0 10px 6px", lineHeight: 1.45 }}>
+          Content search is not available yet — matching names.
+        </div>
+      )}
+      <div style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: "0 6px 12px" }}>
+        {workspaces === null
+          ? null   /* nothing until the state is known — never a placeholder row (decision 23.1) */
+          : result
+            ? (result.groups.length === 0
+                ? <div data-nav-empty style={{ ...ty.meta, padding: "6px 8px" }}>No file matches that.</div>
+                : <>
+                    {result.groups.map((g) => {
+                      const ws = workspaces.find((w) => w.key === g.key);
+                      if (!ws) return null;
+                      return (
+                        <div key={g.key} data-nav-group={g.key} style={{ paddingBottom: 4 }}>
+                          <div style={{ ...ty.lens, fontSize: 9.5, padding: "8px 6px 3px" }}>{g.name}</div>
+                          {g.paths.map((path) => fileRow(ws, path, path, 0))}
+                        </div>
+                      );
+                    })}
+                    {result.truncated && (
+                      <div data-nav-truncated style={{ ...ty.meta, padding: "6px 8px" }}>
+                        First {MAX_HITS} matches — keep typing.
+                      </div>
+                    )}
+                  </>)
+            : workspaces.map((ws) => {
+                const open = openWs.has(ws.key);
+                return (
+                  <div key={ws.key}>
+                    <button data-nav-ws={ws.key} data-nav-readable={ws.readable ? "1" : "0"}
+                      aria-expanded={ws.readable ? open : undefined}
+                      disabled={!ws.readable}
+                      title={ws.readable ? ws.name : `${ws.name} — not available to you`}
+                      onClick={() => toggleWs(ws)} style={wsRow(ws.readable)}
+                      onMouseEnter={(e) => { if (ws.readable) hoverOn(e); }} onMouseLeave={hoverOff}>
+                      <span style={caret(open && ws.readable)} aria-hidden>{ws.readable ? "▶" : "·"}</span>
+                      <span style={{ ...nameS, paddingLeft: 2 }}>{ws.name}</span>
+                      {!ws.readable && (
+                        <span data-nav-unavailable={ws.key} style={{ ...ty.meta, flex: "none", fontSize: 10 }}>
+                          not available to you
+                        </span>
+                      )}
+                    </button>
+                    {ws.readable && open && (
+                      trees[ws.key]
+                        ? nodes(ws, treeFrom(trees[ws.key]), 1)
+                        : <div style={{ ...ty.meta, padding: "3px 6px 3px 17px" }}>…</div>
+                    )}
+                  </div>
+                );
+              })}
+      </div>
+    </div>
+  );
+}

--- a/clients/terminal/src/minutes/PagesPanel.tsx
+++ b/clients/terminal/src/minutes/PagesPanel.tsx
@@ -28,6 +28,9 @@ import { writeWorkspaceFile } from "../surfaces/workspaceApi";
 import { MarkdownEditor } from "./MarkdownEditor";
 import type { Page } from "./types";
 import { CollapseButton } from "./Collapse";
+import { Navigator } from "./Navigator";
+import { isMachineryEntry } from "./machinery";
+import { loadNavOpen, saveNavOpen } from "./navigatorApi";
 import { registry } from "../contributions";
 import { header, surface, type as ty } from "./tokens";
 
@@ -79,6 +82,11 @@ export function PagesPanel(p: {
   // surfaces register, shells render what is registered.
   const canvas = p.docKind === "meeting" && !p.listing;
   const MeetingCanvas = canvas ? registry.tabComponent("meeting") : undefined;
+  // THE NAVIGATOR'S DOOR (PRD decision 27.4). Default hidden, remembered per browser — the boolean
+  // lives here rather than in the shell because the rail is part of this panel, and the panel is
+  // already the thing that knows whether it is folded away at all.
+  const [navOpen, setNavOpen] = useState<boolean>(() => loadNavOpen());
+  const showNav = (v: boolean) => { setNavOpen(v); saveNavOpen(v); };
   const [mode, setMode] = useState<"view" | "edit">("view");
   // RAW is a lens on the view, not a third mode: `</>` shows the markdown the renderer was given,
   // which is the question it answers ("what is actually in the file?"). Keeping it orthogonal to
@@ -130,6 +138,14 @@ export function PagesPanel(p: {
       <div style={{ ...header, gridRow: 1, gridColumn: 3, gap: 6, flexWrap: "nowrap", minWidth: 0, overflowX: "auto", borderLeft: "1px solid var(--line)" }}>
         {/* where you have BEEN, at the panel's left edge — the reading order of a document surface
             starts here (Obsidian, and the old terminal, both put them exactly there). */}
+        {/* the navigator's toggle — the panel's leftmost control, because the rail it opens is the
+            panel's leftmost column. One button, no other chrome (decision 27.4). */}
+        <button data-nav-toggle aria-pressed={navOpen} aria-label={navOpen ? "Hide the file navigator" : "Show the file navigator"}
+          title={navOpen ? "Hide the file navigator" : "Show the file navigator (Esc closes, / filters)"}
+          onClick={() => showNav(!navOpen)} style={iconBtn(navOpen)}
+          onMouseEnter={litIcon} onMouseLeave={dimIcon(navOpen)}>
+          <Icon name="folder" size={13} />
+        </button>
         <button data-nav="back" aria-label="Back" title="Back (⌘/Ctrl + [)" disabled={!p.canBack} onClick={p.onBack} style={navBtn(!!p.canBack)}>‹</button>
         <button data-nav="forward" aria-label="Forward" title="Forward (⌘/Ctrl + ])" disabled={!p.canForward} onClick={p.onForward} style={navBtn(!!p.canForward)}>›</button>
         <div style={{ flex: "1 1 0%", minWidth: 0, display: "flex", alignItems: "center", gap: 6, overflowX: "auto", overflowY: "hidden", paddingLeft: 2 }}>
@@ -155,7 +171,13 @@ export function PagesPanel(p: {
         {/* outside the tab scroller (`flex: none`), so it never scrolls out of reach */}
         {p.onCollapse && <CollapseButton side="right" onClick={p.onCollapse} />}
       </div>
-      <div style={{ gridRow: 2, gridColumn: 3, display: "flex", flexDirection: "column", minHeight: 0, background: surface.pages, borderLeft: "1px solid var(--line)" }}>
+      <div style={{ gridRow: 2, gridColumn: 3, display: "flex", minHeight: 0, minWidth: 0, background: surface.pages, borderLeft: "1px solid var(--line)" }}>
+        {/* The rail sits INSIDE the panel, under the shared header band — beside the open file, the
+            way the founder's reference has it. `onOpenTab` is this panel's own open route, so an
+            explicit open-in-tab lands on the chat record exactly like a link click does; a plain
+            click never comes through here at all (decision 28). */}
+        {navOpen && <Navigator onOpenTab={p.onOpen} onClose={() => showNav(false)} />}
+        <div style={{ flex: "1 1 0%", display: "flex", flexDirection: "column", minHeight: 0, minWidth: 0 }}>
         {/* WHAT is in front, and what can be done to it — the document's own header row.
             Filename prominent, location subdued beside it, every utility grouped hard right
             (founder reference, the desktop app's doc panel). Three rows now stack above the body
@@ -229,6 +251,7 @@ export function PagesPanel(p: {
                     ? <pre data-doc-raw style={{ margin: 0, fontFamily: "var(--mono)", fontSize: 12.5, lineHeight: 1.65, color: "var(--t1)", whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>{p.body}</pre>
                     : <MdxDoc>{p.body}</MdxDoc>}
         </div>
+        </div>
       </div>
     </>
   );
@@ -242,8 +265,12 @@ const entryS: CSSProperties = {
 /** A folder, as a list of names. Directories first, then files; clicking a directory goes deeper,
  *  clicking a file opens it as a tab. Deliberately plain — this is orientation, not a file manager. */
 function FolderListing(p: { listing: Listing; onNavigate?: (slug: string | undefined, prefix: string) => void; onOpen: (pg: Page) => void }) {
-  const { slug, prefix, dirs, files } = p.listing;
+  const { slug, prefix } = p.listing;
   const at = (name: string) => (prefix ? `${prefix}/${name}` : name);
+  // HUMAN FILES ONLY (decision 27.2) — and from the same list `./machinery` gives the navigator,
+  // so a folder walked here and the same folder expanded there can never disagree.
+  const dirs = p.listing.dirs.filter((d) => !isMachineryEntry(prefix, d));
+  const files = p.listing.files.filter((f) => !isMachineryEntry(prefix, f));
   if (!dirs.length && !files.length) {
     return <div style={{ ...ty.body, color: "var(--t3)" }}>Nothing in this folder.</div>;
   }

--- a/clients/terminal/src/minutes/__tests__/navigator.test.ts
+++ b/clients/terminal/src/minutes/__tests__/navigator.test.ts
@@ -1,0 +1,248 @@
+/** THE NAVIGATOR'S DECISIONS — the ones with a plausible wrong answer.
+ *
+ *  Every claim here is about a rule that would look fine on screen if it were broken: a hide list
+ *  that hides one folder too many or one too few; an order that is alphabetical because nobody
+ *  said otherwise; a cap that counts groups instead of hits and so starves the second workspace;
+ *  a filter that matches paths and returns a workspace when someone typed a filename.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  frontmatterSaysTemplate, humanPaths, isMachinery, isMachineryEntry,
+} from "../machinery";
+import {
+  MAX_HITS, NAV_OPEN_KEY, buildWorkspaces, filterByName, loadNavOpen, parseQuery,
+  referencedWorkspaceIds, saveNavOpen, treeFrom, type NavWorkspace,
+} from "../navigatorApi";
+import { VIEW_NAVIGATE_EVENT, navigateView, viewSlotFor } from "../roomView";
+import type { ActiveMount } from "../../surfaces/workspaceApi";
+
+const mount = (over: Partial<ActiveMount> & { slug: string }): ActiveMount => ({
+  repo: null, ref: null, role: "shared", path: `/workspaces/${over.slug}`, write: true, primary: false,
+  ...over,
+});
+
+describe("the hide list — human files only (decision 27.2)", () => {
+  it("hides the agent's instructions, the liquid layer, and the templates", () => {
+    for (const p of ["CLAUDE.md", "flows", "flows/personal.md", "skills/sell/SKILL.md",
+                     "routines/daily.md", "views/board.md", "policy/members.json",
+                     "kg/templates", "kg/templates/person.md"]) {
+      expect(isMachinery(p), p).toBe(true);
+    }
+  });
+
+  it("hides dotfiles and anything under a dot-directory", () => {
+    expect(isMachinery(".scaffolded")).toBe(true);
+    expect(isMachinery(".claude/settings.json")).toBe(true);
+    expect(isMachinery("kg/.obsidian/workspace.json")).toBe(true);
+  });
+
+  it("hides nothing else — a hide list that guesses hides tomorrow's write-back", () => {
+    for (const p of ["README.md", "kg/entities/person/dmitry.md", "drafts/2026-09-01-prd.md",
+                     "kg", "kg/entities", "notes/policy-notes.md", "meetings/2026-09-02.md"]) {
+      expect(isMachinery(p), p).toBe(false);
+    }
+  });
+
+  it("`CLAUDE.md` is machinery at the ROOT — a draft ABOUT it is a draft", () => {
+    expect(isMachinery("CLAUDE.md")).toBe(true);
+    expect(isMachinery("drafts/CLAUDE.md")).toBe(false);
+  });
+
+  it("a folder listing asks about prefix + name, and gets the same answer", () => {
+    expect(isMachineryEntry("", "flows")).toBe(true);
+    expect(isMachineryEntry("kg", "templates")).toBe(true);
+    expect(isMachineryEntry("kg", "entities")).toBe(false);
+    expect(isMachineryEntry("drafts", "CLAUDE.md")).toBe(false);
+  });
+
+  it("humanPaths keeps order and drops the rest", () => {
+    expect(humanPaths(["README.md", "flows/a.md", "kg/x.md", ".git/HEAD"]))
+      .toEqual(["README.md", "kg/x.md"]);
+  });
+
+  it("`template: true` in frontmatter is a template; the word in prose is not", () => {
+    expect(frontmatterSaysTemplate("---\ntemplate: true\n---\n# Person\n")).toBe(true);
+    expect(frontmatterSaysTemplate("---\nid: p1\ntemplate: false\n---\n")).toBe(false);
+    expect(frontmatterSaysTemplate("# Notes\n\ntemplate: true is a line of prose\n")).toBe(false);
+    expect(frontmatterSaysTemplate(null)).toBe(false);
+  });
+});
+
+describe("which workspaces are listed, and in what order (decisions 26–27)", () => {
+  const active: ActiveMount[] = [
+    mount({ slug: "seed", role: "primary", primary: true, name: "Dmitry's desk", path: "/workspaces/u-7" }),
+    mount({ slug: "_global", name: "Helm Bank" }),
+    mount({ slug: "zebra-team" }),
+    mount({ slug: "acme-kg", name: "Acme" }),
+    mount({ slug: "_system" }),
+  ];
+
+  it("desk first, then `_global`, then the groups by name", () => {
+    const ws = buildWorkspaces({ active, subject: "u-7" });
+    expect(ws.map((w) => w.name)).toEqual(["Dmitry's desk", "Helm Bank", "Acme", "zebra-team"]);
+    expect(ws.map((w) => w.kind)).toEqual(["desk", "global", "group", "group"]);
+  });
+
+  it("the desk is the NO-SLUG read — every other row carries its slug", () => {
+    const ws = buildWorkspaces({ active, subject: "u-7" });
+    expect(ws[0]).toMatchObject({ key: "desk", slug: undefined, readable: true });
+    expect(ws[1].slug).toBe("_global");
+  });
+
+  it("`_global` wears the company name when the mount knows one, its slug when it does not", () => {
+    expect(buildWorkspaces({ active, subject: "u-7" })[1].name).toBe("Helm Bank");
+    const anon = active.map((m) => (m.slug === "_global" ? { ...m, name: null } : m));
+    expect(buildWorkspaces({ active: anon, subject: "u-7" })[1].name).toBe("_global");
+  });
+
+  it("`_system` is never listed — always mounted, never a place to read files", () => {
+    expect(buildWorkspaces({ active, subject: "u-7" }).some((w) => w.key === "_system")).toBe(false);
+  });
+
+  it("a membership that is not mounted is still the reader's to open", () => {
+    const ws = buildWorkspaces({ active, subject: "u-7", memberships: [{ workspace_id: "parked-team", role: "viewer" }] });
+    expect(ws.find((w) => w.key === "parked-team")).toMatchObject({ readable: true, kind: "group" });
+  });
+
+  it("a workspace the reader is not in is LISTED, greyed — never hidden, never an error", () => {
+    const ws = buildWorkspaces({
+      active, subject: "u-7",
+      registry: [{ id: "legal-room", name: "Legal" }, { id: "acme-kg", name: "Acme" }],
+    });
+    const legal = ws.find((w) => w.key === "legal-room");
+    expect(legal).toMatchObject({ readable: false, name: "Legal" });
+    // a registry row the reader DOES have stays readable — the registry never demotes a membership
+    expect(ws.find((w) => w.key === "acme-kg")?.readable).toBe(true);
+    // and the greyed rows sit after the readable ones
+    expect(ws[ws.length - 1].key).toBe("legal-room");
+  });
+
+  it("with nothing at all there is still a desk — it is the workspace that always exists", () => {
+    expect(buildWorkspaces({})).toEqual([{ key: "desk", slug: undefined, kind: "desk", readable: true, name: "Desk" }]);
+  });
+
+  it("reads decision 26.2's two cross-workspace link forms out of the desk", () => {
+    const desk = "See [[ws:legal-room/e-12]] and [the plan](/w/deal-room/kg/plan.md) and [[Local]].";
+    expect(referencedWorkspaceIds(desk)).toEqual(["legal-room", "deal-room"]);
+    expect(referencedWorkspaceIds(null)).toEqual([]);
+  });
+});
+
+describe("the tree", () => {
+  const paths = ["README.md", "kg/entities/person/dmitry.md", "kg/entities/company/helm.md",
+                 "kg/templates/person.md", "flows/personal.md", ".git/HEAD", "drafts/a.md"];
+
+  it("nests, drops machinery, and puts directories before files", () => {
+    const t = treeFrom(paths);
+    expect(t.map((n) => n.name)).toEqual(["drafts", "kg", "README.md"]);
+    const kg = t.find((n) => n.name === "kg")!;
+    expect(kg.children.map((n) => n.name)).toEqual(["entities"]);          // templates/ is gone
+    const ent = kg.children[0];
+    expect(ent.children.map((n) => n.name)).toEqual(["company", "person"]);
+    expect(ent.children[0].children[0]).toMatchObject({ name: "helm.md", path: "kg/entities/company/helm.md", dir: false });
+  });
+
+  it("an empty workspace is an empty tree, not a crash", () => {
+    expect(treeFrom([])).toEqual([]);
+    expect(treeFrom(["flows/only.md"])).toEqual([]);
+  });
+});
+
+describe("the filter (decision 27.3)", () => {
+  const ws: NavWorkspace[] = [
+    { key: "desk", slug: undefined, name: "Desk", kind: "desk", readable: true },
+    { key: "acme-kg", slug: "acme-kg", name: "Acme", kind: "group", readable: true },
+    { key: "legal-room", slug: "legal-room", name: "Legal", kind: "group", readable: false },
+  ];
+  const trees = {
+    desk: ["README.md", "kg/entities/person/brief-writer.md", "drafts/BRIEF.md", "flows/brief.md"],
+    "acme-kg": ["kg/brief-2026.md", "kg/other.md"],
+    "legal-room": ["kg/secret-brief.md"],
+  };
+
+  it("matches names case-insensitively and groups the hits by workspace", () => {
+    const r = filterByName("brief", ws, trees);
+    expect(r.groups.map((g) => g.key)).toEqual(["desk", "acme-kg"]);
+    expect(r.groups[0].paths).toEqual(["drafts/BRIEF.md", "kg/entities/person/brief-writer.md"]);
+    expect(r.groups[1].paths).toEqual(["kg/brief-2026.md"]);
+  });
+
+  it("never reaches into a workspace the reader cannot open", () => {
+    expect(filterByName("brief", ws, trees).groups.some((g) => g.key === "legal-room")).toBe(false);
+  });
+
+  it("machinery stays hidden under the filter too", () => {
+    expect(filterByName("brief", ws, trees).groups[0].paths).not.toContain("flows/brief.md");
+  });
+
+  it("matches the NAME, not the path — typing a folder is not a search for its files", () => {
+    expect(filterByName("drafts", ws, trees).groups).toEqual([]);
+  });
+
+  it("caps at 50 HITS across the list, and says so", () => {
+    const many = { desk: Array.from({ length: 60 }, (_, i) => `kg/note-${String(i).padStart(2, "0")}.md`), "acme-kg": ["kg/note-x.md"] };
+    const r = filterByName("note", ws, many);
+    expect(r.shown).toBe(MAX_HITS);
+    expect(r.truncated).toBe(true);
+    expect(r.groups[0].paths).toHaveLength(MAX_HITS);
+  });
+
+  it("an empty query is not a search — it is the tree", () => {
+    expect(filterByName("   ", ws, trees)).toEqual({ groups: [], shown: 0, truncated: false });
+  });
+
+  it("`>` asks for CONTENT and is stripped from what is matched", () => {
+    expect(parseQuery("> brief")).toEqual({ text: "brief", content: true });
+    expect(parseQuery("brief")).toEqual({ text: "brief", content: false });
+    // no content route on this build: the names still answer, so the box is never dead
+    expect(filterByName("> brief", ws, trees).groups.map((g) => g.key)).toEqual(["desk", "acme-kg"]);
+  });
+});
+
+describe("remembered per browser (decision 27.4)", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults to HIDDEN when nothing is stored", () => {
+    expect(loadNavOpen()).toBe(false);
+  });
+
+  it("round-trips the choice", () => {
+    saveNavOpen(true);
+    expect(localStorage.getItem(NAV_OPEN_KEY)).toBe("1");
+    expect(loadNavOpen()).toBe(true);
+    saveNavOpen(false);
+    expect(loadNavOpen()).toBe(false);
+  });
+
+  it("a storage that throws means HIDDEN, never a crash", () => {
+    const get = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => { throw new Error("denied"); });
+    const set = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => { throw new Error("denied"); });
+    expect(loadNavOpen()).toBe(false);
+    expect(() => saveNavOpen(true)).not.toThrow();
+    get.mockRestore(); set.mockRestore();
+  });
+});
+
+describe("the view slot — a click navigates, it does not collect (decision 28)", () => {
+  const seen: unknown[] = [];
+  const spy = (e: Event) => seen.push((e as CustomEvent).detail);
+  beforeEach(() => { seen.length = 0; window.addEventListener(VIEW_NAVIGATE_EVENT, spy); });
+  afterEach(() => window.removeEventListener(VIEW_NAVIGATE_EVENT, spy));
+
+  it("addresses a workspace file, and the desk with NO workspace", () => {
+    expect(viewSlotFor("acme-kg", "kg/brief.md")).toEqual({ workspace: "acme-kg", path: "kg/brief.md", label: "brief" });
+    expect(viewSlotFor(undefined, "README.md")).toEqual({ workspace: undefined, path: "README.md", label: "README" });
+    expect(viewSlotFor("", "a/b.md").workspace).toBeUndefined();
+  });
+
+  it("announces the destination", () => {
+    navigateView("acme-kg", "kg/brief.md");
+    expect(seen).toEqual([{ workspace: "acme-kg", path: "kg/brief.md", label: "brief" }]);
+  });
+
+  it("refuses a path that walks out of its mount", () => {
+    navigateView(undefined, "../../etc/passwd");
+    navigateView(undefined, "");
+    expect(seen).toEqual([]);
+  });
+});

--- a/clients/terminal/src/minutes/__tests__/navigatorRail.test.tsx
+++ b/clients/terminal/src/minutes/__tests__/navigatorRail.test.tsx
@@ -1,0 +1,258 @@
+/** THE RAIL, AS THE READER MEETS IT — inside the pages panel, through the panel's own props.
+ *
+ *  Rendered via `PagesPanel` on purpose. The rail is not a component someone drops on a page: it is
+ *  a column of that panel, its toggle is that panel's leftmost control, and the one thing a click
+ *  must never do — mint a tab — is only observable where the panel's tab route is. Testing the
+ *  Navigator alone would prove the rail draws and prove nothing about the seam.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+import { PagesPanel } from "../PagesPanel";
+import { NAV_OPEN_KEY } from "../navigatorApi";
+import { VIEW_NAVIGATE_EVENT } from "../roomView";
+import type { Page } from "../types";
+import * as nav from "../navigatorApi";
+
+vi.mock("../navigatorApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../navigatorApi")>()),
+  loadNavWorkspaces: vi.fn(),
+  loadNavTree: vi.fn(),
+}));
+
+const WORKSPACES: nav.NavWorkspace[] = [
+  { key: "desk", slug: undefined, name: "Dmitry's desk", kind: "desk", readable: true },
+  { key: "_global", slug: "_global", name: "Helm Bank", kind: "global", readable: true },
+  { key: "acme-kg", slug: "acme-kg", name: "Acme", kind: "group", readable: true },
+  { key: "legal-room", slug: "legal-room", name: "Legal", kind: "group", readable: false },
+];
+const TREES: Record<string, string[]> = {
+  desk: ["README.md", "drafts/brief.md", "CLAUDE.md", "flows/personal.md", ".scaffolded"],
+  _global: ["PRINCIPLES.md"],
+  "acme-kg": ["kg/brief-2026.md"],
+};
+
+const PATH = "README.md";
+const pages: Page[] = [{ path: PATH, label: "README" }];
+const onOpen = vi.fn();
+
+const panel = () => render(<PagesPanel pages={pages} docPath={PATH} onOpen={onOpen} body={"# Desk"} />);
+const toggle = (c: HTMLElement) => c.querySelector("[data-nav-toggle]") as HTMLElement;
+
+beforeEach(() => {
+  localStorage.clear();
+  onOpen.mockClear();
+  vi.mocked(nav.loadNavWorkspaces).mockReset().mockResolvedValue(WORKSPACES);
+  vi.mocked(nav.loadNavTree).mockReset().mockImplementation(async (ws: nav.NavWorkspace) => TREES[ws.key] ?? []);
+});
+afterEach(cleanup);
+
+/** open the rail and wait for the workspace rows to land */
+async function openRail() {
+  const { container } = panel();
+  fireEvent.click(toggle(container));
+  await screen.findByText("Dmitry's desk");
+  return container;
+}
+
+/** A rail row, waited for. Never `findByText` for a filename: the panel's own doc header prints
+ *  the open document's name too, so "README.md" is genuinely ambiguous on this screen — and a test
+ *  that matches the header instead of the row would pass with the rail rendering nothing. */
+const rowOf = (c: HTMLElement, key: string) => c.querySelector(`[data-nav-file="${key}"]`) as HTMLElement | null;
+const waitRow = async (c: HTMLElement, key: string) => {
+  await waitFor(() => expect(rowOf(c, key)).toBeTruthy());
+  return rowOf(c, key) as HTMLElement;
+};
+
+describe("default hidden, one toggle, remembered (decision 27.4)", () => {
+  it("is not there until it is asked for", () => {
+    const { container } = panel();
+    expect(container.querySelector("[data-navigator]")).toBeNull();
+    expect(toggle(container)).toBeTruthy();
+    expect(toggle(container).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("the toggle opens it, and the choice survives a remount", async () => {
+    const container = await openRail();
+    expect(container.querySelector("[data-navigator]")).toBeTruthy();
+    expect(localStorage.getItem(NAV_OPEN_KEY)).toBe("1");
+
+    cleanup();
+    const again = panel();
+    expect(again.container.querySelector("[data-navigator]")).toBeTruthy();   // remembered
+
+    fireEvent.click(toggle(again.container));
+    expect(again.container.querySelector("[data-navigator]")).toBeNull();
+    expect(localStorage.getItem(NAV_OPEN_KEY)).toBe("0");
+  });
+
+  it("nothing is fetched while it is closed", () => {
+    panel();
+    expect(nav.loadNavWorkspaces).not.toHaveBeenCalled();
+  });
+});
+
+describe("the workspaces (decisions 26–27.1)", () => {
+  it("lists them in registry order, desk first", async () => {
+    const container = await openRail();
+    const rows = [...container.querySelectorAll("[data-nav-ws]")].map((b) => b.getAttribute("data-nav-ws"));
+    expect(rows).toEqual(["desk", "_global", "acme-kg", "legal-room"]);
+    expect(screen.getByText("Helm Bank")).toBeTruthy();      // `_global` under the company's name
+  });
+
+  it("a workspace the reader cannot open says so and DOES NOT expand", async () => {
+    const container = await openRail();
+    const row = container.querySelector('[data-nav-ws="legal-room"]') as HTMLButtonElement;
+    expect(row.getAttribute("data-nav-readable")).toBe("0");
+    expect(screen.getByText("not available to you")).toBeTruthy();
+
+    fireEvent.click(row);
+    await Promise.resolve();
+    expect(container.querySelectorAll("[data-nav-file]").length).toBe(0);
+    expect(nav.loadNavTree).not.toHaveBeenCalled();
+    expect(row.getAttribute("aria-expanded")).toBeNull();
+  });
+
+  it("expands lazily — a tree is read when it is asked for, and once", async () => {
+    const container = await openRail();
+    expect(nav.loadNavTree).not.toHaveBeenCalled();
+
+    fireEvent.click(container.querySelector('[data-nav-ws="desk"]') as HTMLElement);
+    await waitRow(container, "desk|README.md");
+    expect(nav.loadNavTree).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(container.querySelector('[data-nav-ws="desk"]') as HTMLElement);   // collapse
+    expect(rowOf(container, "desk|README.md")).toBeNull();
+    fireEvent.click(container.querySelector('[data-nav-ws="desk"]') as HTMLElement);   // and back
+    await waitRow(container, "desk|README.md");
+    expect(nav.loadNavTree).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows human files only — no machinery, no dotfiles (decision 27.2)", async () => {
+    const container = await openRail();
+    fireEvent.click(container.querySelector('[data-nav-ws="desk"]') as HTMLElement);
+    await waitRow(container, "desk|README.md");
+
+    expect(screen.getByText("drafts")).toBeTruthy();
+    expect(screen.queryByText("CLAUDE.md")).toBeNull();
+    expect(screen.queryByText("flows")).toBeNull();
+    expect(screen.queryByText(".scaffolded")).toBeNull();
+    expect(container.querySelector('[data-nav-file="desk|CLAUDE.md"]')).toBeNull();
+  });
+});
+
+describe("opening a file (decision 28)", () => {
+  const seen: unknown[] = [];
+  const spy = (e: Event) => seen.push((e as CustomEvent).detail);
+  beforeEach(() => { seen.length = 0; window.addEventListener(VIEW_NAVIGATE_EVENT, spy); });
+  afterEach(() => window.removeEventListener(VIEW_NAVIGATE_EVENT, spy));
+
+  async function deskOpen() {
+    const container = await openRail();
+    fireEvent.click(container.querySelector('[data-nav-ws="desk"]') as HTMLElement);
+    await waitRow(container, "desk|README.md");
+    return container;
+  }
+
+  it("a click NAVIGATES the view slot and mints no tab", async () => {
+    const container = await deskOpen();
+    fireEvent.click(container.querySelector('[data-nav-file="desk|README.md"]') as HTMLElement);
+    expect(seen).toEqual([{ workspace: undefined, path: "README.md", label: "README" }]);
+    expect(onOpen).not.toHaveBeenCalled();          // the tab route is untouched
+  });
+
+  it("the destination carries the workspace it came from — through the folders it lives in", async () => {
+    const container = await openRail();
+    fireEvent.click(container.querySelector('[data-nav-ws="acme-kg"]') as HTMLElement);
+    // the tree NESTS: the file is inside `kg/`, and the folder opens before the file exists on screen
+    await waitFor(() => expect(container.querySelector('[data-nav-dir="acme-kg|kg"]')).toBeTruthy());
+    expect(rowOf(container, "acme-kg|kg/brief-2026.md")).toBeNull();
+    fireEvent.click(container.querySelector('[data-nav-dir="acme-kg|kg"]') as HTMLElement);
+
+    fireEvent.click(await waitRow(container, "acme-kg|kg/brief-2026.md"));
+    expect(seen).toEqual([{ workspace: "acme-kg", path: "kg/brief-2026.md", label: "brief-2026" }]);
+  });
+
+  it("a TAB is minted only when the reader says so — and through the panel's own route", async () => {
+    const container = await deskOpen();
+    fireEvent.click(container.querySelector('[data-nav-tab="desk|README.md"]') as HTMLElement);
+    expect(onOpen).toHaveBeenCalledWith({ path: "README.md", slug: undefined, label: "README" });
+    expect(seen).toEqual([]);                       // and it did not ALSO navigate
+  });
+
+  it("middle-click is the same explicit act", async () => {
+    const container = await deskOpen();
+    // no `fireEvent.auxClick` in this DOM-testing-library — so the event itself, which is what the
+    // browser sends anyway
+    fireEvent(rowOf(container, "desk|README.md") as HTMLElement,
+      new MouseEvent("auxclick", { bubbles: true, cancelable: true, button: 1 }));
+    expect(onOpen).toHaveBeenCalledWith({ path: "README.md", slug: undefined, label: "README" });
+  });
+});
+
+describe("the filter (decision 27.3)", () => {
+  it("searches every listed workspace and groups the hits by workspace", async () => {
+    const container = await openRail();
+    const box = container.querySelector("[data-nav-filter]") as HTMLInputElement;
+    fireEvent.change(box, { target: { value: "brief" } });
+
+    await waitFor(() => expect(container.querySelectorAll("[data-nav-group]").length).toBe(2));
+    const groups = [...container.querySelectorAll("[data-nav-group]")].map((g) => g.getAttribute("data-nav-group"));
+    expect(groups).toEqual(["desk", "acme-kg"]);    // list order, and never `legal-room`
+    expect(screen.getByText("drafts/brief.md")).toBeTruthy();
+    expect(screen.getByText("kg/brief-2026.md")).toBeTruthy();
+  });
+
+  it("`>` says out loud that content search is not on this build, and still matches names", async () => {
+    const container = await openRail();
+    fireEvent.change(container.querySelector("[data-nav-filter]") as HTMLInputElement, { target: { value: "> brief" } });
+    await waitFor(() => expect(container.querySelector("[data-nav-note]")).toBeTruthy());
+    expect(container.querySelector("[data-nav-note]")?.textContent).toContain("not available yet");
+    expect(container.querySelectorAll("[data-nav-group]").length).toBe(2);
+  });
+
+  it("a filter that matches nothing says nothing matched", async () => {
+    const container = await openRail();
+    fireEvent.change(container.querySelector("[data-nav-filter]") as HTMLInputElement, { target: { value: "zzz" } });
+    await waitFor(() => expect(container.querySelector("[data-nav-empty]")).toBeTruthy());
+  });
+});
+
+describe("the keyboard", () => {
+  it("`/` focuses the filter while the rail is open", async () => {
+    const container = await openRail();
+    const box = container.querySelector("[data-nav-filter]") as HTMLInputElement;
+    expect(document.activeElement).not.toBe(box);
+    act(() => { fireEvent.keyDown(document.body, { key: "/" }); });
+    expect(document.activeElement).toBe(box);
+  });
+
+  it("`/` typed INTO a field is a character, not a shortcut", async () => {
+    const container = await openRail();
+    const box = container.querySelector("[data-nav-filter]") as HTMLInputElement;
+    const other = document.createElement("input");
+    document.body.appendChild(other);
+    other.focus();
+    act(() => { fireEvent.keyDown(other, { key: "/" }); });
+    expect(document.activeElement).toBe(other);
+    expect(document.activeElement).not.toBe(box);
+    other.remove();
+  });
+
+  it("Escape closes the rail", async () => {
+    const container = await openRail();
+    act(() => { fireEvent.keyDown(document.body, { key: "Escape" }); });
+    await waitFor(() => expect(container.querySelector("[data-navigator]")).toBeNull());
+    expect(localStorage.getItem(NAV_OPEN_KEY)).toBe("0");
+  });
+});
+
+describe("the folder listing reads the same hide list", () => {
+  it("machinery the breadcrumb walked into is not offered either", () => {
+    const { container } = render(
+      <PagesPanel pages={pages} docPath={PATH} onOpen={onOpen} body={"# Desk"}
+        listing={{ prefix: "", dirs: ["drafts", "flows", "skills"], files: ["README.md", "CLAUDE.md"] }} />,
+    );
+    const names = [...container.querySelectorAll("[data-entry]")].map((b) => b.textContent);
+    expect(names).toEqual(["drafts/", "README.md"]);
+  });
+});

--- a/clients/terminal/src/minutes/machinery.ts
+++ b/clients/terminal/src/minutes/machinery.ts
@@ -1,0 +1,72 @@
+/** THE HIDE LIST — what a workspace shows a READER when it is shown as files (PRD decision 27.2,
+ *  "human files only: no dot-directories, no machinery, no templates as pages").
+ *
+ *  ONE list, two consumers. The panel's breadcrumb listing and the navigator's tree are two views
+ *  of the same question — "what is in this folder?" — and answering it twice is how they drift:
+ *  a file hidden in the tree and shown in the listing is not a cosmetic difference, it is the
+ *  reader learning that the rule is arbitrary. So both call `isMachinery` and neither carries a
+ *  list of its own.
+ *
+ *  What is machinery: the agent's own instructions (`CLAUDE.md`), the liquid layer it runs on
+ *  (`flows/`, `skills/`, `routines/`, `views/`, `policy/`) and the shapes pages are cut from
+ *  (`kg/templates/`). None of it is a page a person reads; all of it is edited through the MCP
+ *  verbs and the conversation.
+ *
+ *  What is NOT hidden: everything else, including files this build has never seen. A hide list that
+ *  guesses ("looks generated") would hide the agent's own write-back the day it invents a folder.
+ */
+
+/** Root-level files that are machinery. Root-level ONLY — a `CLAUDE.md` a person wrote inside
+ *  `drafts/` is a draft about CLAUDE.md, not the agent's instruction file. */
+export const MACHINERY_FILES: readonly string[] = ["CLAUDE.md"];
+
+/** Directories that are machinery, with everything under them. Written as paths from the workspace
+ *  root, so `kg/templates` hides the templates without hiding `kg`. */
+export const MACHINERY_DIRS: readonly string[] = [
+  "flows",
+  "skills",
+  "routines",
+  "views",
+  "policy",
+  "kg/templates",
+];
+
+/** A dot-file or anything under a dot-directory — `.git`, `.scaffolded`, `.claude/…`. */
+export const isDotted = (path: string): boolean =>
+  path.split("/").some((seg) => seg.startsWith("."));
+
+/** Is this path — a file OR a directory, addressed from the workspace root — machinery?
+ *
+ *  Directories answer for themselves (`flows` is machinery) and for their contents
+ *  (`flows/personal.md` is too), which is what lets one predicate serve a flat tree listing and a
+ *  one-level folder listing without either translating for the other. */
+export function isMachinery(path: string): boolean {
+  const p = String(path ?? "").replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!p) return true;
+  if (isDotted(p)) return true;
+  if (MACHINERY_FILES.includes(p)) return true;
+  return MACHINERY_DIRS.some((d) => p === d || p.startsWith(`${d}/`));
+}
+
+/** The paths a reader is shown, in the order they came. */
+export const humanPaths = (paths: readonly string[]): string[] => paths.filter((p) => !isMachinery(p));
+
+/** One entry of a folder listing: the breadcrumb holds a prefix and a bare name, and the rule is
+ *  about the whole path, so this is where the two are joined. */
+export const isMachineryEntry = (prefix: string, name: string): boolean =>
+  isMachinery(prefix ? `${prefix}/${name}` : name);
+
+/** `template: true` in a page's own frontmatter — the third clause of decision 27.2, and the only
+ *  one that cannot be answered from a path.
+ *
+ *  `GET /api/workspace/tree` returns paths and nothing else, so the tree and the breadcrumb listing
+ *  apply the path rules above and this predicate stays available for any caller that HOLDS a body
+ *  (the panel does, once a document is open). It lives here rather than beside its one caller so
+ *  that the hide list is one file, not one file plus a rule someone else keeps.
+ */
+export function frontmatterSaysTemplate(body: string | null | undefined): boolean {
+  if (!body) return false;
+  const m = /^﻿?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(body);
+  if (!m) return false;
+  return /^[ \t]*template[ \t]*:[ \t]*(?:true|yes)[ \t]*$/im.test(m[1]);
+}

--- a/clients/terminal/src/minutes/navigatorApi.ts
+++ b/clients/terminal/src/minutes/navigatorApi.ts
@@ -1,0 +1,250 @@
+/** THE NAVIGATOR'S DATA — which workspaces exist, what is in one, and what a filter matches.
+ *
+ *  Every function that decides something is PURE and exported: the component fetches, these decide.
+ *  That split is why the ordering rule, the greying rule and the 50-hit cap are testable without a
+ *  DOM, and why swapping the SOURCE of workspace names later changes one call rather than a screen.
+ *
+ *  THE REGISTRY IS NOT ON THE LINE YET (decision 26.1: an immutable short id per workspace, a
+ *  server registry of id · name · kind · owner, `GET /api/workspaces/{id}`). Until it lands, the
+ *  readable set comes from the mount table + the shared-membership index, and the workspaces the
+ *  reader CANNOT open come from the ids their own desk links to (`[[ws:<id>/…]]`, `/w/<id>/…`) that
+ *  they are not a member of — decision 26.3's "not yours → greyed chip", applied to a list instead
+ *  of a chip. `buildWorkspaces` already takes those rows as `registry`, so the swap is one line at
+ *  the call site: hand it the registry listing instead of `referencedWorkspaceIds(desk)`.
+ */
+import type { ActiveMount, Membership } from "../surfaces/workspaceApi";
+import { listSharedMemberships, listWorkspaceTree, readActiveSet, readWorkspaceFile } from "../surfaces/workspaceApi";
+import { humanPaths } from "./machinery";
+
+/** Desk first, then `_global`, then the groups — decision 27.1's order, and it is not alphabetical
+ *  by accident: the reader's own desk is where they write, `_global` is what the company shares. */
+export type NavKind = "desk" | "global" | "group";
+
+export interface NavWorkspace {
+  /** stable list key — the slug, or `desk` for the reader's own (which is addressed with NO slug) */
+  key: string;
+  /** what `listWorkspaceTree`/`readWorkspaceFile` take; `undefined` = the caller's own workspace */
+  slug?: string;
+  name: string;
+  kind: NavKind;
+  /** false → listed, greyed, does not expand (decision 26.3 — "by design, no error") */
+  readable: boolean;
+}
+
+/** A registry row as decision 26.1 will serve it. `name` absent → the id is the name we have. */
+export interface RegistryRow { id: string; name?: string | null; kind?: string | null }
+
+export const GLOBAL_SLUG = "_global";
+/** Always mounted, never listed as a place to read files (PRD §7: per-user private machinery). */
+const SYSTEM_SLUG = "_system";
+
+/** The mount a no-slug read reaches — the reader's own desk. It does not announce itself by name
+ *  (the server calls it `seed`), so the marks are `primary`, the subject, and the mount path.
+ *  Same test `ui-kit/docLinks` applies; duplicated deliberately rather than exported across a
+ *  layer boundary that has no other reason to exist. */
+const isHomeMount = (m: ActiveMount, subject?: string): boolean =>
+  m.primary || m.slug === subject || (!!subject && m.path.endsWith(`/${subject}`));
+
+const byName = (a: NavWorkspace, b: NavWorkspace) =>
+  a.name.toLowerCase().localeCompare(b.name.toLowerCase()) || a.key.localeCompare(b.key);
+
+/** THE LIST, in the order it is shown.
+ *
+ *  A workspace is READABLE when this reader mounts it or is a member of it. Anything the registry
+ *  (today: their own desk's links) names that is neither is listed greyed — the reader learns the
+ *  place exists and that it is not theirs, which is the whole of decision 26.3. */
+export function buildWorkspaces(src: {
+  active?: readonly ActiveMount[];
+  subject?: string;
+  memberships?: readonly Membership[];
+  registry?: readonly RegistryRow[];
+}): NavWorkspace[] {
+  const active = src.active ?? [];
+  const home = active.find((m) => isHomeMount(m, src.subject));
+  const desk: NavWorkspace = {
+    key: "desk", slug: undefined, kind: "desk", readable: true,
+    name: home?.name?.trim() || "Desk",
+  };
+
+  const globalMount = active.find((m) => m.slug === GLOBAL_SLUG);
+  // "shown as the company name when known" — known means the mount carries a display name. With no
+  // name we say `_global` rather than invent an org: a guessed company name is worse than a slug.
+  const global: NavWorkspace | null = globalMount
+    ? { key: GLOBAL_SLUG, slug: GLOBAL_SLUG, kind: "global", readable: true, name: globalMount.name?.trim() || GLOBAL_SLUG }
+    : null;
+
+  const groups = new Map<string, NavWorkspace>();
+  for (const m of active) {
+    if (isHomeMount(m, src.subject) || m.slug === GLOBAL_SLUG || m.slug === SYSTEM_SLUG) continue;
+    groups.set(m.slug, { key: m.slug, slug: m.slug, kind: "group", readable: true, name: m.name?.trim() || m.slug });
+  }
+  // A membership whose workspace is not mounted right now is still the reader's to open — parking
+  // is a focus choice, not a permission (PRD §5.2: the mount set is soft).
+  for (const ms of src.memberships ?? []) {
+    const id = ms.workspace_id;
+    if (!id || id === GLOBAL_SLUG || id === SYSTEM_SLUG || groups.has(id)) continue;
+    groups.set(id, { key: id, slug: id, kind: "group", readable: true, name: id });
+  }
+
+  const unreadable: NavWorkspace[] = [];
+  for (const row of src.registry ?? []) {
+    const id = row.id;
+    if (!id || id === GLOBAL_SLUG || id === SYSTEM_SLUG || groups.has(id)) continue;
+    if (home && (id === home.slug || id === src.subject)) continue;
+    if (unreadable.some((w) => w.key === id)) continue;
+    unreadable.push({ key: id, slug: id, kind: "group", readable: false, name: row.name?.trim() || id });
+  }
+
+  return [desk, ...(global ? [global] : []), ...[...groups.values()].sort(byName), ...unreadable.sort(byName)];
+}
+
+/** The workspace ids a page LINKS to, in decision 26.2's two cross-workspace forms:
+ *  `[[ws:<workspace-id>/<entity-id>]]` and the canonical URL `/w/<workspace-id>/<path>`. */
+export function referencedWorkspaceIds(text: string | null | undefined): string[] {
+  const out: string[] = [];
+  const add = (id?: string) => { const t = (id ?? "").trim(); if (t && !out.includes(t)) out.push(t); };
+  const body = text ?? "";
+  for (const m of body.matchAll(/\[\[\s*ws:([A-Za-z0-9._-]+)\s*\//g)) add(m[1]);
+  for (const m of body.matchAll(/\/w\/([A-Za-z0-9._-]+)\//g)) add(m[1]);
+  return out;
+}
+
+// ── the tree ─────────────────────────────────────────────────────────────────────────────────────
+
+export interface TreeNode {
+  name: string;
+  /** the path from the workspace root — a directory's has no trailing slash */
+  path: string;
+  dir: boolean;
+  children: TreeNode[];
+}
+
+/** A flat path list → a tree, machinery dropped. Directories before files, each alphabetical:
+ *  the same order the panel's folder listing already uses, so walking one and reading the other
+ *  never re-sorts under the reader. */
+export function treeFrom(paths: readonly string[]): TreeNode[] {
+  const roots: TreeNode[] = [];
+  const dirs = new Map<string, TreeNode>();
+  for (const path of humanPaths(paths)) {
+    const segs = path.split("/").filter(Boolean);
+    if (!segs.length) continue;
+    let parent: TreeNode[] = roots;
+    let here = "";
+    for (let i = 0; i < segs.length; i++) {
+      here = here ? `${here}/${segs[i]}` : segs[i];
+      const leaf = i === segs.length - 1;
+      if (leaf) {
+        if (!parent.some((n) => !n.dir && n.name === segs[i])) parent.push({ name: segs[i], path: here, dir: false, children: [] });
+        break;
+      }
+      let node = dirs.get(here);
+      if (!node) {
+        node = { name: segs[i], path: here, dir: true, children: [] };
+        dirs.set(here, node);
+        parent.push(node);
+      }
+      parent = node.children;
+    }
+  }
+  const sort = (nodes: TreeNode[]): TreeNode[] => {
+    nodes.sort((a, b) => (a.dir === b.dir ? a.name.toLowerCase().localeCompare(b.name.toLowerCase()) : a.dir ? -1 : 1));
+    for (const n of nodes) if (n.dir) sort(n.children);
+    return nodes;
+  };
+  return sort(roots);
+}
+
+// ── the filter ───────────────────────────────────────────────────────────────────────────────────
+
+/** Enough to answer "where is that file?" without becoming a result page. */
+export const MAX_HITS = 50;
+
+export interface ParsedQuery {
+  /** what to match — the `>` is not part of it */
+  text: string;
+  /** the reader asked for CONTENT search (`>` prefix) */
+  content: boolean;
+}
+
+/** `>` = content, anything else = names (decision 27.3). The prefix is stripped either way, so a
+ *  build with no content-search route still answers the question the reader typed. */
+export function parseQuery(raw: string): ParsedQuery {
+  const s = String(raw ?? "");
+  const content = s.trimStart().startsWith(">");
+  return { text: (content ? s.trimStart().slice(1) : s).trim(), content };
+}
+
+export interface FilterGroup { key: string; name: string; slug?: string; paths: string[] }
+export interface FilterResult { groups: FilterGroup[]; shown: number; truncated: boolean }
+
+/** Name match, case-insensitive substring, across every listed workspace, grouped by workspace and
+ *  capped — the cap counts HITS, not groups, so one enormous workspace cannot starve the next one
+ *  of a row: the groups are filled in list order and the cap stops mid-list, visibly.
+ *
+ *  Matching is on the file's NAME, which is what the box says it does. A path substring would make
+ *  `kg` return a workspace and read as broken to anyone who typed a filename. */
+export function filterByName(
+  query: string,
+  workspaces: readonly NavWorkspace[],
+  trees: Readonly<Record<string, readonly string[] | undefined>>,
+  limit: number = MAX_HITS,
+): FilterResult {
+  const { text } = parseQuery(query);
+  const needle = text.toLowerCase();
+  if (!needle) return { groups: [], shown: 0, truncated: false };
+  const groups: FilterGroup[] = [];
+  let shown = 0;
+  let truncated = false;
+  for (const ws of workspaces) {
+    if (!ws.readable) continue;
+    const paths = humanPaths(trees[ws.key] ?? []);
+    const hits = paths
+      .filter((p) => (p.split("/").pop() ?? p).toLowerCase().includes(needle))
+      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    if (!hits.length) continue;
+    const room = limit - shown;
+    if (room <= 0) { truncated = true; break; }
+    if (hits.length > room) truncated = true;
+    const take = hits.slice(0, room);
+    shown += take.length;
+    groups.push({ key: ws.key, name: ws.name, slug: ws.slug, paths: take });
+  }
+  return { groups, shown, truncated };
+}
+
+// ── the browser's memory ─────────────────────────────────────────────────────────────────────────
+
+/** Remembered per browser (decision 27.4), and DEFAULT HIDDEN: absent storage, locked-down storage
+ *  and a storage that throws all mean the same thing — the rail is not shown. */
+export const NAV_OPEN_KEY = "vexa.minutes.navigator";
+
+export function loadNavOpen(): boolean {
+  try { return localStorage.getItem(NAV_OPEN_KEY) === "1"; } catch { return false; }
+}
+export function saveNavOpen(open: boolean): void {
+  try { localStorage.setItem(NAV_OPEN_KEY, open ? "1" : "0"); } catch { /* locked-down storage */ }
+}
+
+// ── the fetches (thin: every decision above is pure) ──────────────────────────────────────────────
+
+/** The workspaces this reader is shown. Best-effort by design — a dead membership index must not
+ *  cost the reader their own desk, which is the one workspace that always exists. */
+export async function loadNavWorkspaces(): Promise<NavWorkspace[]> {
+  const [set, memberships] = await Promise.all([
+    readActiveSet().catch(() => null),
+    listSharedMemberships().catch(() => [] as Membership[]),
+  ]);
+  const active = set?.active ?? [];
+  const subject = set?.subject;
+  // TODAY: the greyed rows come from the desk's own cross-workspace links (decision 26.2).
+  // WITH THE REGISTRY: replace this one line with the registry listing.
+  const desk = await readWorkspaceFile("README.md").catch(() => null);
+  const referenced = referencedWorkspaceIds(desk).map((id) => ({ id }));
+  return buildWorkspaces({ active, subject, memberships, registry: referenced });
+}
+
+/** One workspace's file list. `slug: undefined` reads the caller's own desk. */
+export async function loadNavTree(ws: NavWorkspace): Promise<string[]> {
+  if (!ws.readable) return [];
+  return listWorkspaceTree(ws.slug ? { slug: ws.slug } : undefined).catch(() => [] as string[]);
+}

--- a/clients/terminal/src/minutes/roomView.ts
+++ b/clients/terminal/src/minutes/roomView.ts
@@ -251,3 +251,40 @@ export function resolveView(spec: string | null | undefined, phasePages: Page[])
   }
   return { pages, focus };
 }
+
+// ── THE VIEW SLOT — a click NAVIGATES, it does not collect (PRD decision 28) ─────────────────────
+/** A file clicked in the panel's navigator moves the panel's SINGLE view; it never mints a tab.
+ *  Tabs are minted only by an explicit open-in-tab (middle-click, the row's ⧉) or by a scaffold.
+ *
+ *  STUB. Branch `panel-view-slot` owns the real thing — `view: {workspace, path}` on the chat
+ *  record, with back/forward over it. What lives here is only the SEAM, so the navigator can be
+ *  written against the final call and nothing has to be rewritten when the slot lands: the click
+ *  ANNOUNCES a destination, the shell puts it in front, and the navigator keeps no state about
+ *  what is being read. On the rebase this block goes and `navigateView` resolves to theirs.
+ *
+ *  Deliberately an event and not a callback prop: it is the same shape as OPEN_ENTITY_EVENT and
+ *  ARTIFACT_EVENT, which is how every other "something wants to be in front" already reaches the
+ *  shell — one route, not two.
+ */
+export const VIEW_NAVIGATE_EVENT = "vexa:view-navigate";
+
+export interface ViewSlot { workspace?: string; path: string; label: string }
+
+/** The slot a workspace + path address. `workspace` empty ⇒ the reader's own desk (no slug), the
+ *  same "" ⇒ undefined rule `artifactFromDocRef` applies — an absent slug is a resolved answer. */
+export function viewSlotFor(workspace: string | undefined, path: string): ViewSlot {
+  const clean = String(path ?? "").replace(/^\/+/, "");
+  return {
+    workspace: workspace || undefined,
+    path: clean,
+    label: (clean.split("/").pop() ?? clean).replace(/\.md$/i, ""),
+  };
+}
+
+/** Put a file in front. A path that walks out of its mount is refused here rather than at the
+ *  fetch, exactly as `resolveView` refuses one from a link. */
+export function navigateView(workspace: string | undefined, path: string): void {
+  const detail = viewSlotFor(workspace, path);
+  if (!detail.path || detail.path.split("/").includes("..")) return;
+  window.dispatchEvent(new CustomEvent(VIEW_NAVIGATE_EVENT, { detail }));
+}


### PR DESCRIPTION
**PRD decision 27** — the right panel's file navigator. Founder: *"we need this workspaces view — default hidden left-side bar of the right sidebar, that will have collapsed workspaces and filter search."*

Base: `minutes-mcp-viewer` (never `main`). Built in new files; the only edits to shared files are one toggle in the panel header, one hide-list call in the folder listing, and one event listener in the shell.

## What it does

| | |
|---|---|
| **Default hidden** | one toggle in the panel header (`[data-nav-toggle]`, the leftmost control), remembered per browser in `localStorage` under `vexa.minutes.navigator`, every read and write in a try/catch — locked-down storage means *hidden*, never a crash. Nothing is fetched while it is closed. |
| **The rail** | fixed 236px inside the panel, under the shared 46px header band, beside the open file. Not resizable: the panel already has one drag handle on that edge and two grips on one edge is a worse answer than one. |
| **The workspaces** | collapsed, by name — desk first, then `_global` **shown as the company name when the mount carries one** (and as `_global` when it does not: a guessed org name is worse than a slug), then the groups by name. `_system` is never listed. |
| **Not yours** | a workspace the reader cannot open is **listed, greyed, says "not available to you", and does not expand** — decision 26.3, by design, never an error and never a hole in the list. |
| **The tree** | lazy per expand from the existing `GET /api/workspace/tree` (slug-scoped), read once per workspace, nested, directories before files. |
| **Human files only** | dotfiles, dot-directories, `CLAUDE.md`, `flows/`, `skills/`, `routines/`, `views/`, `policy/`, `kg/templates/` — hidden. |
| **Filter** | names by default (case-insensitive substring on the **file name**), across every listed workspace, grouped by workspace, capped at 50 hits with the cap said out loud. |
| **Opening** | a click **navigates**; a tab is minted only on an explicit act. |
| **Not an IDE** | no rename, no delete, no drag. The existing edit icon keeps working on whatever is in front. |
| **Keyboard** | `/` focuses the filter while the rail is open (and is left alone when a field has focus — it is a character before it is a shortcut); Escape clears the filter, then closes the rail. |

No new dependencies. Visual language is `minutes/tokens.ts` throughout — no literal size, weight or surface.

## Three rules worth naming

Each has a wrong answer that looks right on screen.

**One hide list, two consumers.** `minutes/machinery.ts` is the single list, and both the navigator tree *and* the panel's breadcrumb folder listing read it. There was no hide list on the line, so this creates one rather than growing a second. Answering *"what is in this folder?"* twice is how two views drift, and a file hidden in one and shown in the other teaches the reader that the rule is arbitrary.

**A workspace you cannot open is listed, not hidden.** Decision 26.3's greyed chip, applied to a list. It is named, it says why, and it does not expand.

**A click navigates, it does not collect (decision 28).** Walking a tree is browsing, and browsing that mints a tab per curiosity leaves a strip nobody asked for. A row moves the panel's single view slot; a **tab** is minted only when the reader says so — middle-click, or the row's `⧉` — and then through the panel's own `onOpen`, i.e. onto the chat record, exactly like a link click in the conversation. Nothing about what is being read is kept in this component.

## Two seams, and what replaces them

**The view slot is a stub.** `minutes/roomView.ts` carries only `VIEW_NAVIGATE_EVENT` + `navigateView(workspace, path)` + `viewSlotFor`, plus a six-line listener in `MinutesShell` that puts the destination in front through the shell's own document state without touching `artifacts[]`. Branch **`panel-view-slot`** owns the real thing — `view: {workspace, path}` on the chat record with back/forward over it. It was **not on the line at the time of writing** (`git ls-remote --heads origin` found no such branch, and `minutes-mcp-viewer` was still `f1f4adb0a`), so there was nothing to rebase onto. **On the rebase the whole stubbed block in `roomView.ts` is deleted and `Navigator.tsx`'s import resolves to theirs unchanged** — that is the point of the seam being an event and a call rather than a prop.

**The registry is not on the line either.** Decision 26.1's `GET /api/workspaces/{id}` (id · name · kind · owner) does not exist yet, so names come from `GET /api/workspace/active` + `GET /api/workspace/shared`, and the workspaces the reader *cannot* open come from the ids their own desk links to (`[[ws:<id>/…]]`, `/w/<id>/…`) that they are not a member of. `buildWorkspaces` already takes those rows as its `registry` argument, so **the swap is one line** in `loadNavWorkspaces` — hand it the registry listing instead of `referencedWorkspaceIds(desk)`.

## What is NOT in this PR

- **Content search (`>`).** There is no workspace-content route on the line — `core/agent/control_plane/api.py` serves `tree`, `file`, `git`, `active`, `shared` and no search — and `transcript_search` searches transcripts, not workspace files. So `>` is parsed, the names are still matched (the box is never dead), and the rail **says out loud** that content search is not available yet rather than showing an empty result that reads as *"no such text anywhere"*. Wiring it later is one call inside `filterByName`'s caller.
- **`template: true` in frontmatter.** `GET /api/workspace/tree` returns paths and nothing else, so this clause of 27.2 cannot be answered from a listing. `frontmatterSaysTemplate()` is implemented and tested in `machinery.ts` for any caller that holds a body; hiding template *pages* from the tree needs the tree endpoint to say which files carry the flag. **Flagged, not silently dropped.** The path rules already hide `kg/templates/`, which is where templates live today.

## Files

New — `minutes/machinery.ts` · `minutes/navigatorApi.ts` · `minutes/Navigator.tsx` · `minutes/__tests__/navigator.test.ts` · `minutes/__tests__/navigatorRail.test.tsx`.
Touched — `minutes/PagesPanel.tsx` (the header toggle, the rail in the body row, the folder listing reading the hide list), `minutes/roomView.ts` (the view-slot seam, appended), `minutes/MinutesShell.tsx` (one listener, +21/−1).

Chosen to stay out of the other two workers' way: **stage-1** (F47/F48) has `MinutesShell.tsx`, `surfaces/chat.tsx`, `minutes/scaffold.ts` — the only overlap is a 15-line additive effect in `MinutesShell`; **workspace-ids** (decision 26) has `ui-kit/docLinks`, the registry route and `/w/<id>/<path>` — no file in common.

## Proof

- `npx tsc --noEmit` — clean.
- `npx vitest run` — **919 tests over 86 files green**, 48 of them new (30 pure + 18 through the panel). Also green inside the build image with `src` mounted: 206 tests over the 13 `minutes` files.
- `docker build --target build --build-arg NEXT_PUBLIC_TERMINAL_MODE=minutes` — **green, cold** (on `bbb`; nothing in the running stack, `~/.storm/*`, the lanes or mailpit was touched, no production image was built).

The new tests, and the wrong answer each one catches:

| Test | Would otherwise pass with |
|---|---|
| rail absent until toggled; nothing fetched while closed | a rail that opens by default, or walks five workspaces on mount |
| the toggle persists across a remount, and a throwing storage means hidden | a choice that resets, or a crash in a private window |
| desk → `_global` → groups; `_global` wears the company name; `_system` never listed | an alphabetical order nobody asked for |
| a greyed workspace does not expand and its tree is never fetched | a row that looks disabled and still calls the API |
| lazy expand reads a tree once across collapse/re-expand | a walk per click |
| machinery + dotfiles hidden in the tree **and** in the breadcrumb listing | the two views disagreeing |
| a click dispatches the view slot and `onOpen` is **not** called; `⧉` and middle-click call `onOpen` and do **not** navigate | a click that quietly mints a tab (decision 28) |
| the filter groups by workspace, in list order, skipping the unreadable one, hiding machinery, matching names not paths, capping at 50 **hits** | a cap that counts groups and starves the second workspace; `drafts` returning every file under `drafts/` |
| `/` focuses the filter, and is left alone inside a field; Escape closes | a shortcut that eats a character in the composer |
| `navigateView` refuses `..` | a path that walks out of its mount |

Not asserted by any test, and worth an eye at review: how the 236px rail reads beside a narrow panel at `pagesMin` (240px).

**COMMITMENTS IN THIS DRAFT — none.**

Closes nothing on its own — decision 27 is one item of [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449).
