### PR TITLE
panel: ONE view slot, and the strip is its history bar (PRD decision 28 + amendments, F61, decision 30 client half)

### DIFF
--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -28,12 +28,14 @@ import {
   chatForRow, loadChats, loadCollapsed, loadRailAll, markTouched, meetingChatId, meetingTitle, nameChat, nameFromTurn,
   newChat, railRows, readRailOwner, resetChats, writeRailOwner,
   removeChat, saveChats, saveCollapsed, saveRailAll, upsertChat, visibleRows, artifactKey,
+  forgetHistory, orderHistory, touchHistory, withHome,
   type Artifact, type Chat as ChatRec, type Row } from "./chats";
 import { resolveDocRef } from "../ui-kit/docLinks";
+import { syncSurface } from "../surfaces/surfaceSync";
 import { Rail } from "./Rail";
 import { meetingPhase, type MeetingMock } from "../surfaces/meetingModel";
 import { fetchScaffold, localScaffold, refusalCopy, scaffoldToChat, type Scaffold, type ScaffoldRefusal } from "./scaffold";
-import { artifactsFromTokens, artifactTabEffect, pageForDocRef, pageForMeetingRef, pagesForPhase, resolveView, VIEW_KEY } from "./roomView";
+import { artifactsFromTokens, artifactViewEffect, pageForDocRef, pageForMeetingRef, pagesForPhase, resolveView, VIEW_KEY } from "./roomView";
 import { applyProposal, proposals, type Proposal } from "./proposals";
 import { ProposalChips } from "./ProposalChips";
 import { EdgeHandle, EDGE_W } from "./Collapse";
@@ -305,7 +307,13 @@ export function MinutesShell() {
       ps.push({ path: "README.md", slug: "_global", label: "_global" });
       return ps;
     };
-    const base: Page[] = c.artifacts.length ? c.artifacts.map((a) => ({ ...a })) : roomPages();
+    // THE CHAT'S HOME LEADS THE STRIP (decision 28.5). Composed here rather than stored, so it
+    // follows the chat's mounts if they change and can never be `×`-ed away — it is the product's
+    // first entry, not something the reader put there.
+    const base: Page[] = withHome(
+      (c.artifacts.length ? c.artifacts.map((a) => ({ ...a })) : roomPages()) as Artifact[],
+      c.workspaces,
+    ) as Page[];
     let list = base;
     let focus: Page | null = c.focus ? base.find((pg) => artifactKey(pg) === c.focus) ?? null : null;
     if (!viewSpent.current && pendingView) {
@@ -314,7 +322,11 @@ export function MinutesShell() {
       const r = resolveView(pendingView, base);
       list = r.pages; focus = r.focus ?? focus;
     }
-    const front = focus ?? list[0];
+    // The stored VIEW wins over the first tab: it is where the reader actually was. A chat with
+    // tabs but no stored view (pre-28, or one that has never been navigated) still opens on its
+    // focused tab, so nothing regresses for records written before the slot existed.
+    const stored = c.view ? { kind: c.view.kind, path: c.view.path, slug: c.view.slug, label: c.view.label } as Page : null;
+    const front = stored ?? focus ?? list[0];
     setSel({
       kind: c.meeting ? "meeting" : "chat",
       chatId: c.id,
@@ -459,18 +471,26 @@ export function MinutesShell() {
   // `pages` together, so this can never write one chat's tabs onto another. A mock chat is not in
   // the stored list, so it simply finds no row and writes nothing.
   useEffect(() => {
-    if (!pages.length) return;
+    if (!docPath) return;
     const id = sel.chatId;
     const focus = artifactKey({ kind: docKind, path: docPath, slug: docSlug });
+    // The VIEW is reading state exactly as the tabs are, so it persists with them — reopening a
+    // chat puts back the document you were looking at whether or not you pinned it. Before
+    // decision 28 the only way the panel could remember a document was to make it a tab, which is
+    // precisely how the pile accumulated. NOTE the guard moved from `pages.length` to `docPath`:
+    // a chat with NO tabs still has a view worth remembering.
+    const label = (docPath.split("/").pop() || docPath).replace(/\.md$/i, "");
+    const view: Artifact = { kind: docKind === "meeting" ? "meeting" : undefined, path: docPath, slug: docSlug, label };
     persist((prev) => {
       const i = prev.findIndex((c) => c.id === id);
       if (i < 0) return prev;
       const c = prev[i];
       const same = c.focus === focus && c.artifacts.length === pages.length
+        && artifactKey(c.view ?? { path: "" }) === artifactKey(view)
         && c.artifacts.every((a, k) => artifactKey(a) === artifactKey(pages[k]) && a.label === pages[k].label);
       if (same) return prev;
       const next = [...prev];
-      next[i] = { ...c, artifacts: pages.map((pg) => ({ kind: pg.kind, path: pg.path, slug: pg.slug, label: pg.label })), focus };
+      next[i] = { ...c, artifacts: pages.map((pg) => ({ kind: pg.kind, path: pg.path, slug: pg.slug, label: pg.label, pinned: true })), focus, view };
       return next;
     });
   }, [sel.chatId, pages, docPath, docSlug, docKind, persist]);
@@ -552,10 +572,37 @@ export function MinutesShell() {
       const stack = [...h.stack.slice(0, h.i + 1), e];
       return { stack, i: stack.length - 1 };
     });
-    setPages((prev) => prev.some((x) => artifactKey(x) === artifactKey(pg)) ? prev : [...prev, pg]);
+    // ONE VIEW SLOT, AND THE STRIP IS ITS HISTORY (PRD decision 28 + the founder's amendment).
+    // Navigating replaces what the panel shows AND records where you were: `touchHistory` dedups by
+    // identity, moves the page to the RIGHT end beside the current one, and caps at 12 by evicting
+    // the oldest UNPINNED entry. Pins sit at the left edge and never age out.
+    setPages((prev) => touchHistory(prev, { kind: pg.kind, path: pg.path, slug: pg.slug, label: pg.label }, Date.now()));
     setDocPath(pg.path); setDocSlug(pg.slug); setDocKind(pg.kind === "meeting" ? "meeting" : "doc");
     setListing(null); setDocNonce((n) => n + 1);
   }, []);
+
+  /** PIN A PAGE. The amendment folded "open in tab" into this: the strip is history, so everything
+   *  you open is already in it, and the only extra thing worth asking for is that one STAYS. */
+  const openPinned = useCallback((pg: Page) => {
+    openPage(pg);
+    setPages((prev) => prev.map((x) => artifactKey(x) === artifactKey(pg) ? { ...x, pinned: true } : x));
+  }, [openPage]);
+
+  /** Pin what is in front, or unpin it. The pin is the whole of "specifically requested" for a
+   *  document the reader navigated to and then decided to keep. */
+  const pinned = useMemo(
+    () => pages.some((x) => artifactKey(x) === artifactKey({ kind: docKind, path: docPath, slug: docSlug })),
+    [pages, docKind, docPath, docSlug],
+  );
+  const togglePin = useCallback(() => {
+    const key = artifactKey({ kind: docKind, path: docPath, slug: docSlug });
+    setPages((prev) => {
+      const hit = prev.find((x) => artifactKey(x) === key);
+      if (hit) return prev.filter((x) => artifactKey(x) !== key);
+      const label = (docPath.split("/").pop() || docPath).replace(/\.md$/i, "");
+      return [...prev, { kind: docKind === "meeting" ? "meeting" as const : undefined, path: docPath, slug: docSlug, label, pinned: true }];
+    });
+  }, [docKind, docPath, docSlug]);
 
   /** Walk the stack without disturbing it. A document closed since it was visited is REOPENED as a
    *  tab — going back to somewhere you have been should never fail because you tidied up. */
@@ -577,14 +624,18 @@ export function MinutesShell() {
 
   /** Close a tab. The last one never closes — an empty panel is not a state worth reaching — and
    *  closing the tab in front hands focus to its neighbour rather than to nothing. */
+  /** `×` FORGETS an entry. The strip is history, so this is not "close a tab" — it is the reader
+   *  saying they do not want that page remembered. The last one may go too: an empty strip is a
+   *  chat you have not read anything in, which is a real state and was reachable before this. */
   const closeTab = (pg: Page) => {
-    if (pages.length <= 1) return;
     const key = artifactKey(pg);
     const i = pages.findIndex((x) => artifactKey(x) === key);
     if (i < 0) return;
-    const next = pages.filter((_, k) => k !== i);
+    const next = forgetHistory(pages, key);
     setPages(next);
-    if (key === artifactKey({ kind: docKind, path: docPath, slug: docSlug })) openPage(next[Math.min(i, next.length - 1)]);
+    if (key === artifactKey({ kind: docKind, path: docPath, slug: docSlug }) && next.length) {
+      openPage(next[Math.min(i, next.length - 1)]);
+    }
   };
 
   useEffect(() => {
@@ -715,9 +766,9 @@ export function MinutesShell() {
   useEffect(() => {
     const onArtifact = (e: Event) => {
       const detail = (e as CustomEvent<{ workspace?: string; path?: string; focus?: boolean }>).detail || {};
-      const eff = artifactTabEffect(detail, pagesRef.current, readerChoseFocus.current);
-      if (!eff) return;
-      if (eff.focus) openPage(eff.focus); else setPages(eff.pages);
+      const eff = artifactViewEffect(detail, readerChoseFocus.current);
+      if (!eff) return;              // `focus: false` is now NOTHING VISIBLE, not a quiet tab
+      openPage(eff.view);
     };
     window.addEventListener(ARTIFACT_EVENT, onArtifact);
     return () => window.removeEventListener(ARTIFACT_EVENT, onArtifact);
@@ -763,6 +814,27 @@ export function MinutesShell() {
   // with no scaffold behind it cannot be written in the first place.
   const flavor = sel.kind === "meeting" ? `meeting · ${selMeeting ? PHASE_WORD[meetingPhase(selMeeting)] : "held"}`
     : selChat?.scaffold?.kind === "admin-setup" ? "chat · admin" : "chat";
+
+  // PRD DECISION 30 — THE SURFACE IS A FACT THE SERVER HOLDS, not something the prompt re-describes.
+  // Every change to what the human is looking at is written to the session record: which chat, which
+  // meeting and phase, the view, the strip's history and pins, the navigator. Debounced and
+  // fire-and-forget inside `syncSurface`; inert until stage-1's route lands, and the prompt keeps
+  // its "Active context" prefix until the same flag flips.
+  useEffect(() => {
+    const ordered = orderHistory(pages as Artifact[]);
+    const ref = (a: Artifact) => ({ workspace: a.slug ?? "", path: a.path, title: a.label });
+    syncSurface(sel.chatId, {
+      chat: { id: sel.chatId, kind: sel.kind },
+      meeting: sel.meetingId ? { id: sel.meetingId, phase: selMeeting ? meetingPhase(selMeeting) : null } : null,
+      view: docPath ? { workspace: docSlug ?? "", path: docPath, title: (docPath.split("/").pop() || docPath).replace(/\.md$/i, "") } : null,
+      strip: {
+        history: ordered.filter((a) => !a.pinned && !a.desk).map((a) => ({ ...ref(a), at: a.at ?? 0 })),
+        pins: ordered.filter((a) => a.pinned || a.desk).map(ref),
+      },
+      navigator: { open: !pagesCollapsed, workspace: docSlug ?? null },
+    });
+  }, [sel.chatId, sel.kind, sel.meetingId, selMeeting, pages, docPath, docSlug, pagesCollapsed]);
+
 
   // `?ask=<preset>` — the emailed link. App.tsx stashed the name; resolve it to an ADMIN-AUTHORED
   // body in `_global/asks/<name>.md` and open a fresh chat already holding it. The preset also says
@@ -1035,7 +1107,7 @@ export function MinutesShell() {
       {pagesCollapsed
         ? <EdgeHandle side="right" onClick={() => collapsePages(false)} />
         : <PagesPanel pages={pages} docPath={docPath} docSlug={docSlug} docKind={docKind}
-            onOpen={(pg) => { readerChoseFocus.current = true; openPage(pg); }} onClose={closeTab}
+            onTogglePin={togglePin} pinned={pinned} onOpen={(pg) => { readerChoseFocus.current = true; openPage(pg); }} onClose={closeTab}
             listing={listing} onNavigate={(slug, prefix) => void navigate(slug, prefix)}
             canBack={canBack} canForward={canForward} onBack={goBack} onForward={goForward}
             body={docBody} onSaved={() => setDocNonce((n) => n + 1)}

--- a/clients/terminal/src/minutes/PagesPanel.tsx
+++ b/clients/terminal/src/minutes/PagesPanel.tsx
@@ -66,6 +66,9 @@ export type Listing = { slug?: string; prefix: string; dirs: string[]; files: st
 export function PagesPanel(p: {
   pages: Page[]; docPath: string; docSlug?: string; onOpen: (pg: Page) => void;
   onClose?: (pg: Page) => void;
+  /** decision 28: keep the view as a tab, or drop it. Absent = no pin control rendered. */
+  onTogglePin?: () => void;
+  pinned?: boolean;
   listing?: Listing | null; onNavigate?: (slug: string | undefined, prefix: string) => void;
   canBack?: boolean; canForward?: boolean; onBack?: () => void; onForward?: () => void;
   docKind?: "doc" | "meeting";
@@ -110,7 +113,7 @@ export function PagesPanel(p: {
   // own name, and where it lives. Read off the DOCUMENT, never off the crumb, so a folder listing
   // open in front of it cannot rename the document sitting behind it.
   const docName = p.docPath.split("/").pop() || p.docPath;
-  const docWhere = [p.docSlug ?? "personal", ...p.docPath.split("/").slice(0, -1)].join(" / ");
+
   const doc = !canvas && !listing;   // a document is in front — the only state the header describes
   const save = async () => {
     setSaving(true); setSaveError(null);
@@ -166,11 +169,20 @@ export function PagesPanel(p: {
         {doc && <div style={{ flex: "none", display: "flex", alignItems: "baseline", gap: 8, padding: "9px 20px 8px", borderBottom: "1px solid var(--line)", minWidth: 0 }}>
           <span data-doc-name title={docName}
             style={{ ...ty.title, fontSize: 13.5, color: "var(--t1)", flex: "0 1 auto", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{docName}</span>
-          <span data-doc-where title={docWhere}
-            style={{ ...ty.meta, flex: "0 1 auto", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{docWhere}</span>
+          {/* ONE PATH LINE (PRD decision 28, founder: *"duplicated paths"*). This span repeated the
+              folder trail that the breadcrumb directly below already shows, and navigates. The name
+              belongs here; the path belongs there. */}
           <span style={{ flex: "1 1 0%", minWidth: 8 }} />
           {p.body !== null && (mode === "view"
             ? <>
+                {p.onTogglePin && (
+                  <button data-doc-act="pin" aria-pressed={!!p.pinned} onClick={p.onTogglePin}
+                    title={p.pinned ? "Unpin this tab" : "Keep this as a tab"}
+                    aria-label={p.pinned ? "Unpin this tab" : "Keep this as a tab"}
+                    style={iconBtn(!!p.pinned)} onMouseEnter={litIcon} onMouseLeave={dimIcon(!!p.pinned)}>
+                    <Icon name={p.pinned ? "check" : "plus"} size={14} />
+                  </button>
+                )}
                 <button data-doc-act="raw" aria-pressed={raw} onClick={() => setRaw((v) => !v)}
                   title={raw ? "Show the rendered document" : "Show the markdown source"} aria-label="Toggle markdown source"
                   style={iconBtn(raw)} onMouseEnter={litIcon} onMouseLeave={dimIcon(raw)}>

--- a/clients/terminal/src/minutes/__tests__/artifactTab.test.ts
+++ b/clients/terminal/src/minutes/__tests__/artifactTab.test.ts
@@ -1,16 +1,17 @@
-/** F41 — A FILE THE TURN WROTE BECOMES A TAB. Founder ruling 2026-09-02.
+/** F41, AS AMENDED BY PRD DECISION 28 — a file the turn wrote NAVIGATES THE VIEW; it never mints a
+ *  tab.
  *
- *  He created a shared workspace, the agent wrote its README, and the right panel stayed on
- *  `_global/README.md`: the one document the turn had just made was the one thing not on screen.
+ *  F41 was the founder creating a shared workspace, the agent writing its README, and the panel
+ *  staying on `_global/README.md` — the one document the turn had just made was the one thing not
+ *  on screen. The first fix appended a tab. Decision 28 is the correction to that fix: *"we do not
+ *  want to create new tab for every click, tab is only when tab is specifically requested."*
  *
- *  The server emits `{"type":"artifact","workspace":"<slug>","path":"<path>","focus":true}` after a
- *  successful write. Everything below is what the client does with it, at the pure function that
- *  decides — the shell only wires this. */
+ *  So the event still brings the document to the front when it asks to (`focus: true`), and now
+ *  does NOTHING VISIBLE when it does not — where it used to append a tab "quietly behind the
+ *  reader". Seven quiet tabs are not quiet. */
 import { describe, expect, it } from "vitest";
-import { artifactTabEffect, pageForArtifact } from "../roomView";
-import type { Page } from "../types";
+import { artifactViewEffect, pageForArtifact } from "../roomView";
 
-const README: Page = { path: "README.md", slug: "_global", label: "README" };
 const ev = (over: Partial<{ workspace: string; path: string; focus: boolean }> = {}) =>
   ({ workspace: "daily", path: "README.md", focus: true, ...over });
 
@@ -38,42 +39,26 @@ describe("pageForArtifact — the event resolved to a tab", () => {
   });
 });
 
-describe("artifactTabEffect — append always, focus conditionally", () => {
-  it("appends the written file to the tabs the chat already has", () => {
-    const out = artifactTabEffect(ev(), [README], false)!;
-    expect(out.pages.map((p) => `${p.slug ?? ""}|${p.path}`)).toEqual(["_global|README.md", "daily|README.md"]);
+describe("artifactViewEffect — the view moves, a tab is never minted", () => {
+  it("`focus: true` navigates the view to the written file", () => {
+    expect(artifactViewEffect(ev({ focus: true }), false))
+      .toEqual({ view: { path: "README.md", slug: "daily", label: "README" } });
   });
 
-  it("brings it to the front when the event says so", () => {
-    expect(artifactTabEffect(ev({ focus: true }), [README], false)!.focus)
-      .toEqual({ path: "README.md", slug: "daily", label: "README" });
+  it("`focus: false` does NOTHING VISIBLE — this is the decision-28 change", () => {
+    // It used to append a tab behind the reader. That is the accumulation being removed: a turn
+    // that writes four files must not leave four tabs nobody asked for.
+    expect(artifactViewEffect(ev({ focus: false }), false)).toBeNull();
+    expect(artifactViewEffect(ev({}), false)).not.toBeNull();      // the fixture asks for focus
   });
 
-  it("appends WITHOUT focusing when the event does not ask for it", () => {
-    const out = artifactTabEffect(ev({ focus: false }), [README], false)!;
-    expect(out.focus).toBeNull();
-    expect(out.pages).toHaveLength(2);
+  it("a reader who chose their own document during the turn is not interrupted", () => {
+    // their attention beats our suggestion — unchanged from F41
+    expect(artifactViewEffect(ev({ focus: true }), true)).toBeNull();
   });
 
-  /** THE ONE THAT MATTERS. Decision 18's rule one level down: a person who has opened a document is
-   *  reading it, and the agent's own write must not tidy their desk out from under them. */
-  it("NEVER steals a focus the reader chose — the tab still appears, they do not move", () => {
-    const out = artifactTabEffect(ev({ focus: true }), [README], true)!;
-    expect(out.focus).toBeNull();                       // they stay where they are…
-    expect(out.pages).toHaveLength(2);                  // …and the new file is there when they want it
-    expect(out.pages[1].slug).toBe("daily");
-  });
-
-  it("is idempotent — the same file written twice in a turn is ONE tab", () => {
-    const once = artifactTabEffect(ev(), [README], false)!;
-    const twice = artifactTabEffect(ev(), once.pages, false)!;
-    expect(twice.pages).toHaveLength(2);
-    expect(twice.pages).toEqual(once.pages);
-    // …and a re-write of a file already open still brings it forward, rather than doing nothing
-    expect(twice.focus).toEqual(once.pages[1]);
-  });
-
-  it("a write we cannot name honestly changes nothing at all", () => {
-    expect(artifactTabEffect({ path: "../secrets.md", focus: true }, [README], false)).toBeNull();
+  it("an unresolvable write moves nothing", () => {
+    expect(artifactViewEffect({ workspace: "daily", path: "../../etc/passwd", focus: true }, false)).toBeNull();
+    expect(artifactViewEffect({ focus: true }, false)).toBeNull();
   });
 });

--- a/clients/terminal/src/minutes/__tests__/docHeader.test.tsx
+++ b/clients/terminal/src/minutes/__tests__/docHeader.test.tsx
@@ -21,15 +21,23 @@ const doc = (over: Partial<Parameters<typeof PagesPanel>[0]> = {}) =>
   render(<PagesPanel pages={pages} docPath={PATH} onOpen={() => {}} body={BODY} {...over} />);
 
 describe("doc header — filename prominent, location subdued", () => {
-  it("names the FILE, extension and all, beside where it lives", () => {
+  it("names the FILE, extension and all — and ONLY the file (PRD decision 28)", () => {
+    // The title row used to carry the folder trail beside the name, which the breadcrumb directly
+    // below already shows and can navigate. Founder: *"duplicated paths"*. One path line: the name
+    // belongs here, the path belongs there.
     const { container } = doc();
     expect(container.querySelector("[data-doc-name]")?.textContent).toBe("2026-09-01-vexa-prd.md");
-    expect(container.querySelector("[data-doc-where]")?.textContent).toBe("personal / drafts");
+    expect(container.querySelector("[data-doc-where]")).toBeNull();
   });
 
-  it("a shared workspace shows in the location, not just the folder", () => {
+  it("the path is shown ONCE, by the breadcrumb, and it is the navigable one", () => {
     const { container } = doc({ docSlug: "acme", pages: [{ path: PATH, slug: "acme", label: "prd" }] });
-    expect(container.querySelector("[data-doc-where]")?.textContent).toBe("acme / drafts");
+    // the workspace and every folder are still reachable — as buttons, which is the point of
+    // keeping the breadcrumb rather than the dead text beside the title
+    const crumbs = [...container.querySelectorAll("button")].map((b) => b.textContent);
+    expect(crumbs).toContain("acme");
+    expect(crumbs).toContain("drafts");
+    expect(container.querySelectorAll("[data-doc-where]")).toHaveLength(0);
   });
 
   it("the utilities are grouped in the header, and no longer in the tab strip", () => {

--- a/clients/terminal/src/minutes/__tests__/scaffold.test.ts
+++ b/clients/terminal/src/minutes/__tests__/scaffold.test.ts
@@ -96,7 +96,10 @@ describe("scaffoldToChat", () => {
     expect(rec.id).toBe("meet-97");        // not a parallel conversation
     expect(rec.label).toBe("");            // the rail names it from the meeting
     expect(rec.meeting).toBe("97");
-    expect(rec.artifacts).toEqual([
+    // the chat's HOME leads the strip (decision 28.5); the declared pages follow in the preset's
+    // own order, which is the author's reading order
+    expect(rec.artifacts[0]).toMatchObject({ path: "README.md", desk: true });
+    expect(rec.artifacts.slice(1)).toMatchObject([
       { path: "kg/entities/meeting/abc-defg-hij.md", label: "Minutes" },  // post → Minutes
       { kind: "meeting", path: "97", label: "Transcript" },
     ]);
@@ -106,7 +109,8 @@ describe("scaffoldToChat", () => {
   it("without a native the note is DROPPED, not guessed at", () => {
     // a tab pointing at a guessed path opens a page that can never load — worse than one fewer tab
     const rec = scaffoldToChat(parseScaffold({ ...WIRE, native: null })!);
-    expect(rec.artifacts).toEqual([{ kind: "meeting", path: "97", label: "Transcript" }]);
+    expect(rec.artifacts.filter((a) => !a.desk))
+      .toMatchObject([{ kind: "meeting", path: "97", label: "Transcript" }]);
   });
 
   it("phase null keeps the meeting's own layout and never infers `post`", () => {
@@ -115,7 +119,8 @@ describe("scaffoldToChat", () => {
     const s = parseScaffold({ ...WIRE, phase: null })!;
     expect(s.phase).toBeNull();
     const rec = scaffoldToChat(s);
-    expect(rec.artifacts[0]).toEqual({ path: "kg/entities/meeting/abc-defg-hij.md", label: "Brief" });
+    expect(rec.artifacts.filter((a) => !a.desk)[0])
+      .toMatchObject({ path: "kg/entities/meeting/abc-defg-hij.md", label: "Brief" });
   });
 
   it("a scaffold with no meeting opens its own chat over its declared workspaces", () => {
@@ -128,7 +133,11 @@ describe("scaffoldToChat", () => {
     expect(rec.id).toBe("scaffold-OU5hWbkhdKt9tI2ulYxn4h1Zh8yy3HFm1S9Vd5NalCI");
     expect(rec.label).toBe("setup global");
     expect(rec.meeting).toBeUndefined();
-    expect(rec.artifacts.map((a) => a.path)).toEqual(["README.md", "MISSING.md"]);
+    // `_global/README.md` is declared AND is not the home (the chat mounts no group and no desk
+    // slug), so the strip carries the desk README first and the declared pair after it
+    expect(rec.artifacts.map((a) => a.path)).toEqual(["README.md", "README.md", "MISSING.md"]);
+    expect(rec.artifacts[0]).toMatchObject({ desk: true, label: "Desk" });
+    expect(rec.artifacts[0].slug).toBeUndefined();   // the reader's OWN desk carries no slug
     expect(rec.focus).toBe("_global|README.md");
   });
 
@@ -148,7 +157,8 @@ describe("localScaffold — the hand link composes through the SAME path", () =>
     const rec = scaffoldToChat(sc);
     expect(rec.id).toBe("meet-95");
     // prep → the same file under the name the reader needs today
-    expect(rec.artifacts).toEqual([{ path: "kg/entities/meeting/abc-defg-hij.md", label: "Brief" }]);
+    expect(rec.artifacts.filter((a) => !a.desk))
+      .toMatchObject([{ path: "kg/entities/meeting/abc-defg-hij.md", label: "Brief" }]);
   });
 });
 
@@ -249,5 +259,45 @@ describe("the scaffold kind reaches the chat", () => {
     // the type says `scaffold: { kind, id }`, not `scaffoldKind?: string`: a kind with no id is
     // not a value this function can return.
     expect(Object.keys(chat.scaffold).sort()).toEqual(["id", "kind"]);
+  });
+});
+
+describe("the scaffold DELIVERS the strip (decision 28.5)", () => {
+  it("`tabs` accepts a bare token OR {token, pinned} — the frontmatter is a file a human edits", () => {
+    // asking someone to write `{token: …, pinned: false}` for the common case would be the format
+    // serving the parser rather than the founder
+    const s = parseScaffold({ ...WIRE, tabs: ["meeting:transcript", { token: "meeting:note", pinned: true }] })!;
+    expect(s.tabs).toEqual([
+      { token: "meeting:transcript", pinned: false },
+      { token: "meeting:note", pinned: true },
+    ]);
+  });
+
+  it("a pinned entry arrives as a CHAT pin, at the left edge, after the home", () => {
+    const s = parseScaffold({
+      ...WIRE, workspaces: ["_global", "u_priya", "grp-showb"],
+      tabs: [{ token: "meeting:note", pinned: true }, "meeting:transcript"],
+    })!;
+    const rec = scaffoldToChat(s);
+    // home first (the chat mounts a group, so the GROUP's README, not the desk), then the pin,
+    // then the rest in the preset's own order
+    expect(rec.artifacts[0]).toMatchObject({ path: "README.md", slug: "grp-showb", desk: true });
+    expect(rec.artifacts[1]).toMatchObject({ path: "kg/entities/meeting/abc-defg-hij.md", pinned: true });
+    expect(rec.artifacts[2]).toMatchObject({ kind: "meeting", path: "97" });
+  });
+
+  it("a chat with no group is at home on the reader's own desk", () => {
+    const s = parseScaffold({ ...WIRE, workspaces: ["_global", "u_priya"], tabs: [] })!;
+    expect(scaffoldToChat(s).artifacts[0]).toMatchObject({ path: "README.md", label: "Desk", desk: true });
+  });
+
+  it("a scaffold that names no focus opens on the HOME, never on a blank panel", () => {
+    const s = parseScaffold({ ...WIRE, focus: "", workspaces: ["_global", "grp-showb"], tabs: [] })!;
+    expect(scaffoldToChat(s).focus).toBe("grp-showb|README.md");
+  });
+
+  it("junk entries are dropped, and a malformed tabs list is simply empty", () => {
+    expect(parseScaffold({ ...WIRE, tabs: [1, null, { pinned: true }, "  "] })!.tabs).toEqual([]);
+    expect(parseScaffold({ ...WIRE, tabs: "nope" })!.tabs).toEqual([]);
   });
 });

--- a/clients/terminal/src/minutes/__tests__/stripHistory.test.ts
+++ b/clients/terminal/src/minutes/__tests__/stripHistory.test.ts
@@ -1,0 +1,149 @@
+/** PRD DECISION 28 (+ the founder's amendments) — the strip is a HISTORY BAR.
+ *
+ *  Screenshot 1: seven tabs after a few chip clicks, the path shown twice. Screenshot 2: the strip
+ *  scrolled off the edge. *"ensure these tabs are sorted left to right based on last used — as a
+ *  history bar"*, and *"pin is per chat"*.
+ *
+ *  So the strip has three tiers, left to right: the chat's HOME · its PINS · history oldest→newest,
+ *  with the page you are on at the right edge. Everything below is that rule.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  artifactKey, chatHistory, collapseUnpinned, forgetHistory, homeEntry, HISTORY_CAP,
+  orderHistory, touchHistory, withHome, type Artifact, type Chat,
+} from "../chats";
+
+const A = (path: string, over: Partial<Artifact> = {}): Artifact =>
+  ({ path, label: path.replace(/\.md$/, ""), ...over });
+const paths = (l: Artifact[]) => l.map((a) => (a.slug ? `${a.slug}/` : "") + a.path);
+
+describe("orderHistory — home, then pins, then oldest → newest", () => {
+  it("puts the current page at the RIGHT edge and the home at the left", () => {
+    const out = orderHistory([
+      A("b.md", { at: 2 }), A("home.md", { desk: true }), A("p.md", { pinned: true }), A("a.md", { at: 1 }),
+    ]);
+    expect(paths(out)).toEqual(["home.md", "p.md", "a.md", "b.md"]);
+  });
+});
+
+describe("touchHistory", () => {
+  it("moves a page already in the strip to the right end — never a second chip", () => {
+    let l = [A("a.md", { at: 1 }), A("b.md", { at: 2 }), A("c.md", { at: 3 })];
+    l = touchHistory(l, A("a.md"), 4);
+    expect(paths(l)).toEqual(["b.md", "c.md", "a.md"]);
+    expect(l).toHaveLength(3);            // dedup, not append
+  });
+
+  it("caps at 12 by dropping the OLDEST, and never a pin", () => {
+    let l: Artifact[] = [A("pinned.md", { pinned: true, at: 0 })];
+    for (let i = 1; i <= HISTORY_CAP + 3; i++) l = touchHistory(l, A(`f${i}.md`), i);
+    expect(l.filter((a) => !a.pinned)).toHaveLength(HISTORY_CAP);
+    expect(l.some((a) => a.path === "pinned.md")).toBe(true);   // a cap that could evict a pin
+    expect(l.some((a) => a.path === "f1.md")).toBe(false);      // would make pinning a suggestion
+    expect(paths(l)[paths(l).length - 1]).toBe(`f${HISTORY_CAP + 3}.md`);
+  });
+
+  it("navigating to a PIN keeps it pinned and keeps it at the left edge", () => {
+    let l = [A("p.md", { pinned: true, at: 1 }), A("a.md", { at: 2 })];
+    l = touchHistory(l, A("p.md"), 3);
+    expect(l.find((a) => a.path === "p.md")?.pinned).toBe(true);
+    expect(paths(l)).toEqual(["p.md", "a.md"]);
+  });
+
+  it("the home is never evicted, however much is opened", () => {
+    let l = withHome([], []);
+    for (let i = 1; i <= HISTORY_CAP + 5; i++) l = touchHistory(l, A(`f${i}.md`), i);
+    expect(l.some((a) => a.desk)).toBe(true);
+    expect(l[0].desk).toBe(true);
+  });
+});
+
+describe("forgetHistory — × forgets, except the home", () => {
+  it("forgets an ordinary entry", () => {
+    const l = [A("a.md", { at: 1 }), A("b.md", { at: 2 })];
+    expect(paths(forgetHistory(l, artifactKey(A("a.md"))))).toEqual(["b.md"]);
+  });
+
+  it("refuses to forget the home — it is the product's entry, not the reader's", () => {
+    const l = withHome([A("a.md", { at: 1 })], []);
+    const home = l.find((a) => a.desk)!;
+    expect(forgetHistory(l, artifactKey(home)).some((a) => a.desk)).toBe(true);
+  });
+});
+
+describe("homeEntry / withHome — the chat's home follows its mounts", () => {
+  it("no group → the reader's own desk README", () => {
+    expect(homeEntry(["_global", "personal"])).toEqual({ path: "README.md", label: "Desk", desk: true });
+    // `u_*` is the SERVER's name for a person's desk — not a group, or every scaffolded chat
+    // would be "at home" in the reader's own desk under its server name.
+    expect(homeEntry(["_global", "u_priya"]).slug).toBeUndefined();
+  });
+
+  it("a group in the mounts → THAT group's README instead", () => {
+    expect(homeEntry(["_global", "u_priya", "grp-showb"]))
+      .toEqual({ path: "README.md", slug: "grp-showb", label: "grp-showb", desk: true });
+  });
+
+  it("never duplicates a README the strip already had — it promotes it", () => {
+    const out = withHome([A("README.md", { slug: "grp-showb", at: 5 })], ["_global", "grp-showb"]);
+    expect(out.filter((a) => a.path === "README.md")).toHaveLength(1);
+    expect(out[0].desk).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    const once = withHome([A("a.md", { at: 1 })], ["_global", "grp-showb"]);
+    expect(withHome(once, ["_global", "grp-showb"])).toEqual(once);
+  });
+});
+
+describe("chatHistory — the GET-able shape for the desk README (decision 26.4)", () => {
+  it("newest first, with the workspace, path, title and stamp", () => {
+    const c = { artifacts: [A("a.md", { at: 1 }), A("b.md", { slug: "acme", at: 9 })] } as Chat;
+    expect(chatHistory(c)).toEqual([
+      { workspace: "acme", path: "b.md", title: "b", at: 9 },
+      { workspace: "", path: "a.md", title: "a", at: 1 },
+    ]);
+  });
+
+  it("omits the meeting canvas — it is not a document anything can list", () => {
+    const c = { artifacts: [A("42", { kind: "meeting", at: 3 }), A("a.md", { at: 1 })] } as Chat;
+    expect(chatHistory(c).map((h) => h.path)).toEqual(["a.md"]);
+  });
+});
+
+describe("collapseUnpinned — the one-time migration, as amended", () => {
+  it("a pre-28 pile becomes ORDERED history, not a deletion", () => {
+    // the amendment reframed these entries: they are history that was never ordered or capped,
+    // so they are kept and put in order rather than thrown away
+    const c = collapseUnpinned({
+      id: "c1", label: "c", workspaces: [], createdAt: 1, lastActivityAt: 1,
+      artifacts: [A("a.md"), A("b.md"), A("c.md")], focus: "|b.md",
+    } as Chat);
+    expect(paths(c.artifacts)).toEqual(["a.md", "c.md", "b.md"]);   // the front page lands right
+    expect(c.view?.path).toBe("b.md");
+  });
+
+  it("caps a pre-28 pile that is over the limit", () => {
+    const many = Array.from({ length: HISTORY_CAP + 4 }, (_, i) => A(`f${i}.md`));
+    const c = collapseUnpinned({
+      id: "c1", label: "c", workspaces: [], createdAt: 1, lastActivityAt: 1, artifacts: many,
+    } as Chat);
+    expect(c.artifacts).toHaveLength(HISTORY_CAP);
+  });
+
+  it("a scaffold's tabs are PINNED — declared cannot be told from clicked, so keep", () => {
+    const c = collapseUnpinned({
+      id: "c1", label: "c", workspaces: [], createdAt: 1, lastActivityAt: 1,
+      scaffold: { kind: "admin-setup", id: "S1" },
+      artifacts: [A("README.md", { slug: "_global" }), A("MISSING.md", { slug: "_global" })],
+    } as Chat);
+    expect(c.artifacts.every((a) => a.pinned)).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    const base = { id: "c1", label: "c", workspaces: [], createdAt: 1, lastActivityAt: 1,
+      artifacts: [A("a.md"), A("b.md")], focus: "|a.md" } as Chat;
+    const once = collapseUnpinned(base);
+    expect(collapseUnpinned(once)).toEqual(once);
+  });
+});

--- a/clients/terminal/src/minutes/__tests__/transcriptTab.test.ts
+++ b/clients/terminal/src/minutes/__tests__/transcriptTab.test.ts
@@ -73,8 +73,13 @@ describe("stored chats migrate for free", () => {
   // the assertion below would pass for the wrong reason. A chat whose tabs are worth migrating is
   // by definition one somebody worked in.
   const stored = (artifacts: unknown[]) => {
+    // PINNED (PRD decision 28): a tab exists only when it was asked for, and `loadChats` collapses
+    // unpinned ones. What is under test in this block is `normalise`'s tolerance of the artifact
+    // SHAPE — a missing `kind`, a meeting kind, a kind nobody recognises — not whether a tab is
+    // retained. Pinning here keeps that subject rather than weakening the assertions.
+    const pinned = (artifacts as Record<string, unknown>[]).map((a) => ({ ...a, pinned: true }));
     localStorage.setItem(CHATS_KEY, JSON.stringify([
-      { id: "c1", label: "c1", workspaces: ["personal"], artifacts, touched: true, createdAt: 1, lastActivityAt: 1 },
+      { id: "c1", label: "c1", workspaces: ["personal"], artifacts: pinned, touched: true, createdAt: 1, lastActivityAt: 1 },
     ]));
     return loadChats().find((c) => c.id === "c1")?.artifacts ?? [];
   };

--- a/clients/terminal/src/minutes/chats.ts
+++ b/clients/terminal/src/minutes/chats.ts
@@ -18,7 +18,24 @@ import { meetingPhase, type MeetingMock } from "../surfaces/meetingModel";
  *  the panel's tab strip and the chat's saved artifacts are the same list, not two lists kept in
  *  step. `label` is carried rather than recomputed because a phase page's name ("Minutes" vs
  *  "Brief") is a property of the room that produced it, not of the path. */
-export type Artifact = { kind?: "doc" | "meeting"; path: string; slug?: string; label: string };
+export type Artifact = {
+  kind?: "doc" | "meeting"; path: string; slug?: string; label: string;
+  /** WHEN THIS PAGE WAS LAST IN FRONT — the strip is a history bar, ordered by it (decision 28,
+   *  founder amendment: *"ensure these tabs are sorted left to right based on last used — as a
+   *  history bar"*). Absent on a record written before the amendment; the migration stamps one. */
+  at?: number;
+  /** THE READER'S OWN DESK — the strip's first entry, on every chat (decision 26.4 / 28.5).
+   *
+   *  A product DEFAULT, not a pin: nobody asked for it and nobody can `×` it away. It is where the
+   *  view starts when a scaffold names no focus, because a chat that opens on nothing is a chat
+   *  that opens on a blank panel. Ordering puts it left of the pins. */
+  desk?: boolean;
+  /** THIS TAB WAS ASKED FOR (PRD decision 28). A tab exists only because somebody requested it —
+   *  a pin, an explicit open-in-tab, or a scaffold declaring it at open. Navigation does not mint
+   *  one. Unpinned entries are the pre-28 accumulation and the migration in `normalise` removes
+   *  them; nothing writes an unpinned artifact any more. */
+  pinned?: boolean;
+};
 
 /** A tab's identity. Path alone is not enough — `README.md` exists in every workspace.
  *
@@ -40,8 +57,20 @@ export type Chat = {
   label: string;
   meeting?: string;           // the meeting row id this chat is about (string form of MeetingMock.id)
   workspaces: string[];       // the mount set — what a PROJECT used to own
-  artifacts: Artifact[];      // the open tabs (seeded by the room's phase pages and by `?view=`)
-  focus?: string;             // artifactKey() of the tab in front
+  artifacts: Artifact[];      // the PINNED tabs — only what was asked for (decision 28)
+  focus?: string;             // artifactKey() of the tab in front, when the view IS a tab
+  /** THE ONE VIEW SLOT (PRD decision 28, founder: *"tab is only when tab is specifically
+   *  requested"*).
+   *
+   *  What the panel is showing right now. Every navigation REPLACES it — an entity chip, a
+   *  wikilink, a navigator file, a `/w/<id>/<path>` URL, an agent's `artifact` event with
+   *  `focus: true`. None of them appends to `artifacts`.
+   *
+   *  Persisted beside the tabs because it is reading state like they are: reopening a chat should
+   *  put back the document you were looking at, whether or not you had pinned it. Before this, the
+   *  only way the panel could remember a document was to make it a tab — which is precisely how a
+   *  few chip clicks became seven of them. */
+  view?: Artifact;
   /** THE SCAFFOLD THIS CHAT WAS COMPOSED FROM — the kind AND the record's id, in ONE field.
    *
    *  It is what the chat IS, and things that depend on that — the header's flavour, today — read it
@@ -469,6 +498,142 @@ function scaffoldRecord(raw: unknown): { kind: string; id: string } | undefined 
     : undefined;
 }
 
+/** THE STRIP IS A HISTORY BAR (PRD decision 28, founder amendment).
+ *
+ *  Left to right by last used: the page you are on sits at the RIGHT end, the one before it to its
+ *  left, and so on back. Navigating to something already in the strip MOVES it right rather than
+ *  adding a second chip — the strip is where you have been, and you have only been somewhere once
+ *  most recently.
+ *
+ *  PINNED entries — a scaffold's declared `tabs:` and anything the reader pinned — sit at the LEFT
+ *  edge and never age out. They are not history; they are the room's fixtures, and a fixture that
+ *  scrolled away because you read four documents would defeat the point of pinning it.
+ *
+ *  The cap drops the OLDEST UNPINNED. A cap that could evict a pin would make pinning a suggestion.
+ */
+export const HISTORY_CAP = 12;
+
+/** THE STRIP'S ORDER, left to right: the desk · the chat's pins · history oldest → newest.
+ *
+ *  Three tiers, and the reason each sits where it does. The DESK is the product's own first entry
+ *  and belongs to no chat, so it is furthest from the current page. PINS were asked for and must
+ *  not scroll away, so they sit next. Everything else is history, and the page you are on is at the
+ *  right edge because that is where your eye already is. */
+export function orderHistory(list: Artifact[]): Artifact[] {
+  const desk = list.filter((a) => a.desk);
+  const pinned = list.filter((a) => a.pinned && !a.desk);
+  const rest = list.filter((a) => !a.pinned && !a.desk).sort((x, y) => (x.at ?? 0) - (y.at ?? 0));
+  return [...desk, ...pinned, ...rest];
+}
+
+/** THE CHAT'S HOME — the strip's first entry, and it follows where the chat LIVES.
+ *
+ *  A chat over a group is at home in that group, not on the reader's own desk: opening the group's
+ *  dailies and being shown your personal README first would be the panel disagreeing with the
+ *  conversation. So a chat that mounts a group opens on the GROUP's README; a chat that mounts none
+ *  opens on the desk.
+ *
+ *  WHAT COUNTS AS A GROUP is read off the mount set, and the exclusions are the two conventions the
+ *  rest of this file already uses plus one the server's records introduced: `_global` is the
+ *  company tier and is mounted everywhere; `personal` is the client's name for the reader's own
+ *  desk; and `u_*` is the SERVER's name for a person's desk (the scaffold's `workspaces` carries
+ *  `["_global", "u_priya", "grp-showb"]`). Without that third exclusion a person's own desk,
+ *  arriving under its server name, would be mistaken for a group and become the home of every chat
+ *  a scaffold opened. */
+export function homeEntry(workspaces: string[] = []): Artifact {
+  const group = workspaces.find((w) => w && w !== "_global" && w !== "personal" && !/^u_/.test(w));
+  return group
+    ? { path: "README.md", slug: group, label: group, desk: true }
+    : { path: "README.md", label: "Desk", desk: true };
+}
+
+/** Compose a strip with the chat's home at its head. Idempotent, and it never duplicates: a chat
+ *  whose scaffold happened to declare that README keeps ONE entry, promoted to the home tier. */
+export function withHome(list: Artifact[], workspaces: string[] = []): Artifact[] {
+  const h = homeEntry(workspaces);
+  const key = artifactKey(h);
+  const has = list.find((a) => artifactKey(a) === key);
+  const rest = list.filter((a) => artifactKey(a) !== key && !a.desk);
+  return orderHistory([{ ...(has ?? h), ...h, at: has?.at }, ...rest]);
+}
+
+/** Record that `art` is now in front. Dedups by identity, moves it to the right end, and caps —
+ *  evicting the oldest UNPINNED entry, never a pin. Pure: array in, array out. */
+export function touchHistory(list: Artifact[], art: Artifact, now: number, cap = HISTORY_CAP): Artifact[] {
+  const key = artifactKey(art);
+  const prev = list.find((a) => artifactKey(a) === key);
+  // a pin that is navigated to STAYS pinned and stays at the left edge — its `at` still moves, so
+  // unpinning it later drops it into history in the right place rather than at the far left.
+  const next: Artifact = { ...(prev ?? art), ...art, pinned: prev?.pinned, desk: prev?.desk, at: now };
+  const kept = list.filter((a) => artifactKey(a) !== key);
+  const out = orderHistory([...kept, next]);
+  const unpinned = out.filter((a) => !a.pinned && !a.desk);
+  if (unpinned.length <= cap) return out;
+  const evict = new Set(unpinned.slice(0, unpinned.length - cap).map(artifactKey));
+  return out.filter((a) => a.pinned || a.desk || !evict.has(artifactKey(a)));
+}
+
+/** `×` on a chip: forget that entry. Not "close a tab" — the strip is history, and this is the
+ *  reader saying they do not want it remembered. */
+export function forgetHistory(list: Artifact[], key: string): Artifact[] {
+  // the desk is a product default, not something the reader put there, so it is not theirs to
+  // forget — and a strip that could lose its first entry would have no default view to fall back to
+  return list.filter((a) => artifactKey(a) !== key || a.desk);
+}
+
+/** THE HISTORY, READABLE OFF THE RECORD — for the desk README's "Recently opened" (decision 26.4).
+ *
+ *  Newest first, because that is how a "recently opened" list reads; the strip renders the same
+ *  data left-to-right oldest-first. `workspace` is "" for the reader's own desk, matching the
+ *  `artifact` event's convention that an empty slug means "no slug" rather than "unknown". */
+export function chatHistory(c: Chat): { workspace: string; path: string; title: string; at: number }[] {
+  return orderHistory(c.artifacts)
+    .filter((a) => a.kind !== "meeting")
+    .map((a) => ({ workspace: a.slug ?? "", path: a.path, title: a.label, at: a.at ?? 0 }))
+    .sort((x, y) => y.at - x.at);
+}
+
+/** The stored view slot, tolerant of a record written before it existed. */
+function viewOf(r: Partial<Chat>): Artifact | undefined {
+  const v = r.view as Artifact | undefined;
+  if (!v || typeof v !== "object" || typeof v.path !== "string" || !v.path) return undefined;
+  return { ...v, kind: v.kind === "meeting" ? "meeting" : undefined, label: typeof v.label === "string" ? v.label : v.path };
+}
+
+/** THE ONE-TIME COLLAPSE (PRD decision 28, as amended).
+ *
+ *  Before 28 every navigation appended a tab and nothing ever aged out — the founder's screenshot
+ *  was a strip scrolled off the edge. The amendment makes the strip a HISTORY bar, so those entries
+ *  are not junk to be thrown away; they are history that was never ordered or capped. This puts
+ *  them in order and applies the cap.
+ *
+ *    · a record with pinned entries is already post-28 — order it and move on.
+ *    · a pre-28 record has no `at` at all. Stamping every entry the same instant would be a lie
+ *      dressed as data, so they keep their STORED ORDER as their history order (it is the order
+ *      they were appended, which is the order they were opened) and the one that was in FRONT is
+ *      stamped newest, so it lands at the right edge where the reader left it.
+ *    · a SCAFFOLD's declared tabs cannot be told from clicked ones on a pre-28 record, so they are
+ *      pinned: a declared set that silently aged out would be a visible loss, and a couple of extra
+ *      pins on a day-old chat is not.
+ *
+ *  Idempotent: a second pass finds `at` everywhere and only re-orders, which is a no-op. */
+export function collapseUnpinned(c: Chat): Chat {
+  if (!c.artifacts.length) return c;
+  if (c.artifacts.some((a) => a.at !== undefined)) return { ...c, artifacts: orderHistory(c.artifacts) };
+  const frontKey = c.view ? artifactKey(c.view) : c.focus;
+  const stamped = c.artifacts.map((a, i) => ({
+    ...a,
+    pinned: a.pinned || !!c.scaffold,
+    // stored order IS open order; the front page is stamped last so it sits at the right edge
+    at: artifactKey(a) === frontKey ? c.artifacts.length + 1 : i + 1,
+  }));
+  const view = c.view ?? c.artifacts.find((a) => artifactKey(a) === c.focus) ?? c.artifacts[c.artifacts.length - 1];
+  const capped = orderHistory(stamped);
+  const unpinned = capped.filter((a) => !a.pinned);
+  const evict = new Set(unpinned.slice(0, Math.max(0, unpinned.length - HISTORY_CAP)).map(artifactKey));
+  return { ...c, artifacts: capped.filter((a) => a.pinned || !evict.has(artifactKey(a))), view };
+}
+
 function normalise(raw: unknown, now: number): Chat[] {
   if (!Array.isArray(raw)) return [];
   const out: Chat[] = [];
@@ -495,6 +660,7 @@ function normalise(raw: unknown, now: number): Chat[] {
             .map((a) => ({ ...a, kind: a.kind === "meeting" ? ("meeting" as const) : undefined }))
         : [],
       focus: typeof r.focus === "string" && r.focus ? r.focus : undefined,
+      view: viewOf(r),
       // ALL OR NOTHING (F37). A kind with no record id is the stale shape this commit deleted, and
       // re-admitting one here would let a row stored before it resurrect the pre-scaffold admin
       // render on the next load. A half-record is dropped, never repaired — including the bare
@@ -521,7 +687,7 @@ export function loadChats(now = Date.now()): Chat[] {
   if (stored != null) {
     let parsed: unknown = null;
     try { parsed = JSON.parse(stored); } catch { /* corrupt → fall through to seeds */ }
-    return pruneStale(normalise(parsed, now));
+    return pruneStale(normalise(parsed, now).map(collapseUnpinned));
   }
   let legacy: LegacyProject[] = [];
   try { legacy = JSON.parse(localStorage.getItem(PROJECTS_KEY) || "[]") as LegacyProject[]; } catch { legacy = []; }

--- a/clients/terminal/src/minutes/roomView.ts
+++ b/clients/terminal/src/minutes/roomView.ts
@@ -139,32 +139,30 @@ export function pageForArtifact(ev: { workspace?: string; path?: string }): Page
   return { path, slug: slug || undefined, label: (path.split("/").pop() ?? path).replace(/\.md$/i, "") };
 }
 
-/** WHAT AN `artifact` EVENT DOES TO THE OPEN TABS (F41) — the whole decision, as a pure function.
+/** AN AGENT'S WRITE NAVIGATES THE VIEW; IT NEVER MINTS A TAB (PRD decision 28).
  *
- *  Three rules, and the third is the one worth having a test for:
- *    · the tab is APPENDED, idempotently by artifact key — the same file written twice in a turn is
- *      one tab, not two;
- *    · it comes to the FRONT only when the event says `focus: true`;
- *    · …and never over a focus the READER chose. Someone who has opened a document is reading it,
- *      and an agent's write appears in the strip and waits its turn. This is PRD decision 18's rule
- *      one level down — "a second arrival must not tidy their desk out from under them" — and it is
- *      the same rule whether the second arrival is a re-clicked link or the agent's own write.
+ *  This replaces `artifactTabEffect`, which appended one. The founder's screenshot: seven tabs after
+ *  a few chip clicks, and the same path rendered twice. *"we do not want to create new tab for every
+ *  click, tab is only when tab is specifically requested."*
  *
- *  `focus` in the result is the page to bring forward, or null for "append only". The caller decides
- *  nothing; it wires this. */
-export function artifactTabEffect(
+ *  So the rule inverts. The panel has ONE view slot that every navigation REPLACES, and a tab exists
+ *  only because somebody asked for one. An `artifact` event is a navigation like any other:
+ *
+ *    `focus: true`   the turn is saying "look at this" → the view moves.
+ *    `focus: false`  the turn wrote a file it is not asking you to read → NOTHING VISIBLE happens.
+ *                    Previously this appended a tab "quietly behind the reader", which is exactly
+ *                    the accumulation being removed: seven quiet tabs are not quiet.
+ *
+ *  `readerChoseFocus` still wins over `focus: true`: a reader who has deliberately opened something
+ *  during the turn is not interrupted by the agent's write. Their attention beats our suggestion. */
+export function artifactViewEffect(
   ev: { workspace?: string; path?: string; focus?: boolean },
-  pages: Page[],
   readerChoseFocus: boolean,
-): { pages: Page[]; focus: Page | null } | null {
+): { view: Page } | null {
   const pg = pageForArtifact(ev);
   if (!pg) return null;
-  const key = artifactKey(pg);
-  const already = pages.find((x) => artifactKey(x) === key);
-  return {
-    pages: already ? pages : [...pages, pg],
-    focus: ev.focus === true && !readerChoseFocus ? (already ?? pg) : null,
-  };
+  if (ev.focus !== true || readerChoseFocus) return null;
+  return { view: pg };
 }
 
 /** Where App.tsx stashes a `?view=` spec — the URL is cleaned on landing, so the value travels here.

--- a/clients/terminal/src/minutes/scaffold.ts
+++ b/clients/terminal/src/minutes/scaffold.ts
@@ -21,7 +21,7 @@
  *      recipient's agent.
  */
 import type { MeetingPhase } from "../surfaces/meetingModel";
-import { artifactKey, meetingChatId, type Artifact } from "./chats";
+import { artifactKey, homeEntry, meetingChatId, withHome, type Artifact } from "./chats";
 import { artifactsFromTokens } from "./roomView";
 
 /** What a scaffold says about the person and the room, for a preset to branch on. */
@@ -54,7 +54,10 @@ export interface Scaffold {
   openingPreset: string;
   /** already substituted server-side, and machinery: the human never sees it as their own words */
   openingText: string;
-  tabs: string[];
+  /** THE STRIP THE LINK DELIVERS (decision 28.5). Entries in order, left to right. An entry may be
+   *  a bare token (history) or carry `pinned: true` (a chat pin, held at the left edge and immune
+   *  to aging). `focus` names the one the view opens on. */
+  tabs: { token: string; pinned: boolean }[];
   focus: string;
   provenance: string;
   redeemedAt: string | null;
@@ -71,6 +74,26 @@ export interface ScaffoldRefusal {
 const str = (v: unknown): string => (typeof v === "string" ? v : "");
 const strArr = (v: unknown): string[] =>
   Array.isArray(v) ? v.filter((x): x is string => typeof x === "string" && !!x.trim()).map((x) => x.trim()) : [];
+
+/** `tabs` on the wire: a list whose entries are either a bare token or `{token, pinned}`.
+ *
+ *  BOTH shapes, deliberately. The presets' frontmatter is a file the founder edits, and
+ *  `tabs: meeting:note, meeting:transcript` must keep working — asking a human to write
+ *  `{token: …, pinned: false}` for the common case would be the format serving the parser. A
+ *  string is history; the object is how a preset says "and keep this one". */
+function tabsOf(v: unknown): { token: string; pinned: boolean }[] {
+  if (!Array.isArray(v)) return [];
+  const out: { token: string; pinned: boolean }[] = [];
+  for (const e of v) {
+    if (typeof e === "string" && e.trim()) { out.push({ token: e.trim(), pinned: false }); continue; }
+    if (e && typeof e === "object") {
+      const o = e as Record<string, unknown>;
+      const token = typeof o.token === "string" ? o.token.trim() : "";
+      if (token) out.push({ token, pinned: o.pinned === true });
+    }
+  }
+  return out;
+}
 
 const PHASES: MeetingPhase[] = ["prep", "live", "post"];
 
@@ -116,7 +139,7 @@ export function parseScaffold(raw: unknown): Scaffold | null {
     },
     openingPreset: str(r.opening_preset),
     openingText,
-    tabs: strArr(r.tabs),
+    tabs: tabsOf(r.tabs),
     focus: str(r.focus),
     // `provenance` on the wire is the OBJECT {flow, step, reaction_id, minted_by}; the string is
     // `provenance_line`. Reading the object through `str()` degraded to "" silently — four facts
@@ -216,7 +239,18 @@ export function scaffoldToChat(s: Scaffold, opts: { native?: string | null } = {
     phase: s.phase,
     mounts: s.workspaces,
   };
-  const artifacts = artifactsFromTokens(s.tabs, ctx);
+  // THE SCAFFOLD DELIVERS THE STRIP (decision 28.5), and the order at open is:
+  //   the chat's HOME · the scaffold's PINS · the scaffold's opening pages · (later) history.
+  // `withHome` puts the first tier in place; `artifactsFromTokens` preserves the preset's order
+  // for the rest, which is the author's reading order.
+  const declared: Artifact[] = [];
+  s.tabs.forEach((t, i) => {
+    const a = artifactsFromTokens([t.token], ctx)[0];
+    // `at` is the preset's own order: the author's reading order becomes the strip's history order,
+    // so the last declared page sits nearest the current one.
+    if (a) declared.push({ ...a, pinned: t.pinned ? true : undefined, at: i + 1 });
+  });
+  const artifacts = withHome(declared, s.workspaces);
   const focusArt = s.focus ? artifactsFromTokens([s.focus], ctx)[0] : undefined;
   return {
     // KIND AND RECORD ID TOGETHER (F37). The chat record carries the pair or carries nothing, so
@@ -230,7 +264,9 @@ export function scaffoldToChat(s: Scaffold, opts: { native?: string | null } = {
     meeting: s.meeting ?? undefined,
     workspaces: s.workspaces.length ? s.workspaces : ["_global", "personal"],
     artifacts,
-    focus: focusArt ? artifactKey(focusArt) : undefined,
+    // A scaffold that names no focus opens on the chat's HOME — a chat that opens on nothing is a
+    // chat that opens on a blank panel (decision 26.4).
+    focus: artifactKey(focusArt ?? homeEntry(s.workspaces)),
   };
 }
 
@@ -255,7 +291,7 @@ export function localScaffold(input: {
     refs: { title: input.title, participants: [], participantNames: {}, state: {} },
     openingPreset: input.preset,
     openingText: input.openingText,
-    tabs: input.tabs,
+    tabs: input.tabs.map((t) => ({ token: t, pinned: false })),
     focus: input.focus,
     provenance: "hand link (?ask=)",
     redeemedAt: null,

--- a/clients/terminal/src/minutes/tokens.ts
+++ b/clients/terminal/src/minutes/tokens.ts
@@ -7,7 +7,12 @@
 import type { CSSProperties } from "react";
 
 export const T = {
-  railW: 397,        // +60% (founder, 2026-09-01) — 248 left ~90px for a name
+  // F61 (founder, 2026-09-02, screenshot of the minutes chat): *"left sidebar too wide"* — the rail
+  // was taking ~440px of a 2000px window. This REVERSES the +60% widening of 2026-09-01 (248 → 397),
+  // which was measured against a name that no longer needs it: rows truncate with an ellipsis
+  // (Rail.tsx), so width buys a few more characters and costs the chat and the panel real room.
+  // The `<` control still folds it to an icon strip, and that choice persists.
+  railW: 240,
   pagesMin: 240,     // was 300; safe since 3875079b6 made the pages chips ellipsize below 364
   pagesMax: 1600,    // an absolute ceiling only — the real limit is the viewport fraction below
   pagesFrac: 0.6,    // "read a transcript wide" (founder, 2026-09-01): 60% of the viewport

--- a/clients/terminal/src/surfaces/__tests__/railChats.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/railChats.test.ts
@@ -176,9 +176,13 @@ describe("maxPagesW — the pages panel's range, one place both bounds meet", ()
     expect(maxPagesW(2560)).toBe(1536);
   });
 
-  it("but never squeezes the conversation below its floor — 1440px caps below 60%", () => {
-    expect(maxPagesW(1440)).toBe(1440 - T.railW - T.chatMin);
-    expect(maxPagesW(1440)).toBeLessThan(1440 * 0.6);
+  it("but never squeezes the conversation below its floor — the cap binds on a SMALL window", () => {
+    // F61 narrowed the rail 397 → 240, which gave 157px back: at 1440 the 60% want now FITS, where
+    // it used to be clipped by the conversation floor. That is the founder's change paying off, so
+    // the invariant is asserted where it still bites rather than deleted.
+    expect(maxPagesW(1440)).toBe(Math.round(1440 * 0.6));
+    expect(maxPagesW(1280)).toBe(1280 - T.railW - T.chatMin);
+    expect(maxPagesW(1280)).toBeLessThan(1280 * 0.6);
   });
 
   it("never returns less than the minimum, however small the window", () => {
@@ -272,20 +276,38 @@ describe("artifacts — the open tabs ARE the chat record", () => {
     expect(artifactKey({ path: "README.md", slug: "acme" })).toBe(artifactKey({ path: "README.md", slug: "acme" }));
   });
 
-  it("a saved tab set survives a reload, focus included", () => {
+  it("a PINNED tab set survives a reload, focus included", () => {
     localStorage.clear();
-    const tabs = [{ path: "kg/entities/meeting/m1.md", label: "Minutes" }, { path: "README.md", slug: "_global", label: "_global" }];
+    const tabs = [{ path: "kg/entities/meeting/m1.md", label: "Minutes", pinned: true },
+                  { path: "README.md", slug: "_global", label: "_global", pinned: true }];
     localStorage.setItem(CHATS_KEY, JSON.stringify([
       // touched, because the load path prunes a chat nobody wrote in (F35) — a saved tab set only
       // exists on a chat somebody actually worked in.
       { id: "c1", label: "Acme", workspaces: ["personal", "_global"], artifacts: tabs, focus: artifactKey(tabs[1]), touched: true, createdAt: T0, lastActivityAt: T0 },
     ]));
     const c = loadChats(T0).find((x) => x.id === "c1")!;
-    expect(c.artifacts).toEqual(tabs);
+    // the pins survive, in order and still pinned. They also gain an `at`: a record written before
+    // the strip became a history bar has no stamp, and ordering needs one — so the migration gives
+    // them their stored order as their history order rather than inventing a time.
+    expect(c.artifacts.map((a) => a.path)).toEqual(tabs.map((t) => t.path));
+    expect(c.artifacts.every((a) => a.pinned)).toBe(true);
+    expect(c.artifacts.every((a) => typeof a.at === "number")).toBe(true);
     expect(c.focus).toBe("_global|README.md");
   });
 
-  it("tolerates the earlier build's bare-string artifacts instead of rendering junk tabs", () => {
+  it("an UNPINNED tab set is ORDERED and capped on load, not deleted (decision 28 as amended)", () => {
+    // The first ruling dropped them; the amendment reframed the strip as a HISTORY bar, so these
+    // are history that was never ordered — kept, ordered, and capped. The page that was in FRONT
+    // lands at the right edge, where the reader left it.
+    localStorage.clear();
+    const tabs = [{ path: "a.md", label: "a" }, { path: "b.md", label: "b" }, { path: "c.md", label: "c" }];
+    localStorage.setItem(CHATS_KEY, JSON.stringify([
+      { id: "c1", label: "Acme", workspaces: ["personal", "_global"], artifacts: tabs, focus: "|b.md", touched: true, createdAt: T0, lastActivityAt: T0 },
+    ]));
+    const c = loadChats(T0).find((x) => x.id === "c1")!;
+    expect(c.artifacts.map((a) => a.path)).toEqual(["a.md", "c.md", "b.md"]);
+    expect(c.view?.path).toBe("b.md");
+  });  it("tolerates the earlier build's bare-string artifacts instead of rendering junk tabs", () => {
     localStorage.clear();
     localStorage.setItem(CHATS_KEY, JSON.stringify([
       { id: "c1", label: "Acme", workspaces: ["personal"], artifacts: ["README.md", null, 7], touched: true, createdAt: T0, lastActivityAt: T0 },
@@ -390,7 +412,9 @@ describe("pruneStale — the 2026-09-02 migration", () => {
   const REAL: Chat = chat({
     id: "askchat-mtjwoie7", label: "setup global", touched: true,
     workspaces: ["_global", "personal"],
-    artifacts: [{ path: "README.md", slug: "_global", label: "README" }, { path: "CHARTER.md", slug: "_global", label: "CHARTER" }],
+    // pinned (decision 28): this fixture is about pruning PLANTED ROWS, and unpinned tabs would
+    // now be collapsed on load — which is a different rule under test elsewhere.
+    artifacts: [{ path: "README.md", slug: "_global", label: "README", pinned: true }, { path: "CHARTER.md", slug: "_global", label: "CHARTER", pinned: true }],
     focus: "_global|README.md",
   });
   /** A scaffolded arrival nobody has replied to yet — composed FOR someone, so it stays. */

--- a/clients/terminal/src/surfaces/__tests__/surfaceSync.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/surfaceSync.test.ts
@@ -1,0 +1,84 @@
+/** PRD DECISION 30 — the terminal writes the human surface to the session record.
+ *
+ *  What the person is looking at should be a FACT the server holds, not narration the client
+ *  staples to the front of their message every turn. These pin the three properties that make that
+ *  trade safe, and the flag that keeps both halves in step.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  promptCarriesActiveContext, readSurface, SURFACE_RECORD_LIVE, surfaceBody, syncSurface,
+  type Surface,
+} from "../surfaceSync";
+
+const SURFACE: Surface = {
+  chat: { id: "meet-97", kind: "meeting" },
+  meeting: { id: "97", phase: "post" },
+  view: { workspace: "acme", path: "drafts/prd.md", title: "prd" },
+  strip: {
+    history: [{ workspace: "", path: "a.md", title: "a", at: 1 }],
+    pins: [{ workspace: "grp-showb", path: "README.md", title: "grp-showb" }],
+  },
+  navigator: { open: true, workspace: "acme" },
+};
+
+describe("the wire shape", () => {
+  it("carries chat, meeting, view, strip and navigator — the whole surface, not just the strip", () => {
+    const body = JSON.parse(surfaceBody(SURFACE));
+    expect(Object.keys(body).sort()).toEqual(["chat", "meeting", "navigator", "strip", "view"]);
+    expect(body.strip.pins[0]).toEqual({ workspace: "grp-showb", path: "README.md", title: "grp-showb" });
+    expect(body.strip.history[0].at).toBe(1);
+  });
+});
+
+describe("syncSurface", () => {
+  it("coalesces a burst into ONE write, keeping the LAST state", async () => {
+    // navigation is bursty — walking a folder touches several pages — and one PUT per change is
+    // the write storm that turned a close-loop into 519 requests this morning.
+    vi.useFakeTimers();
+    const fetcher = vi.fn(async () => new Response("{}", { status: 200 }));
+    const live = { ...SURFACE, view: { workspace: "", path: "z.md", title: "z" } };
+    syncSurface("s1", SURFACE, { fetcher: fetcher as unknown as typeof fetch, debounceMs: 300 });
+    syncSurface("s1", live, { fetcher: fetcher as unknown as typeof fetch, debounceMs: 300 });
+    await vi.advanceTimersByTimeAsync(400);
+    vi.useRealTimers();
+    if (!SURFACE_RECORD_LIVE) { expect(fetcher).not.toHaveBeenCalled(); return; }
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, init] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("/api/sessions/s1/surface");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(String(init.body)).view.path).toBe("z.md");
+  });
+
+  it("is INERT until the route lands — and that is the same flag that keeps the prompt prefix", () => {
+    // dropping the "Active context" narration before the server fact exists would leave the agent
+    // knowing LESS than it does today. One flag flips both halves together.
+    expect(promptCarriesActiveContext()).toBe(!SURFACE_RECORD_LIVE);
+  });
+
+  it("never throws when the write fails — a failed record must not reach the reader", async () => {
+    vi.useFakeTimers();
+    const boom = vi.fn(async () => { throw new Error("offline"); });
+    expect(() => syncSurface("s2", SURFACE, { fetcher: boom as unknown as typeof fetch, debounceMs: 10 })).not.toThrow();
+    await vi.advanceTimersByTimeAsync(50);
+    vi.useRealTimers();
+  });
+});
+
+describe("readSurface — the server wins only when the local strip is empty", () => {
+  it("returns null on any refusal rather than a half record", async () => {
+    const no = async () => new Response("nope", { status: 404 });
+    expect(await readSurface("s1", no as unknown as typeof fetch)).toBeNull();
+  });
+
+  it("returns null for a body that is not a surface", async () => {
+    const bad = async () => new Response(JSON.stringify({ chat: { id: "x" } }), { status: 200 });
+    expect(await readSurface("s1", bad as unknown as typeof fetch)).toBeNull();   // no `strip`
+  });
+
+  it("parses a real one when the record is live", async () => {
+    const ok = async () => new Response(JSON.stringify(SURFACE), { status: 200 });
+    const got = await readSurface("s1", ok as unknown as typeof fetch);
+    if (!SURFACE_RECORD_LIVE) { expect(got).toBeNull(); return; }
+    expect(got?.strip.history[0].path).toBe("a.md");
+  });
+});

--- a/clients/terminal/src/surfaces/chat.tsx
+++ b/clients/terminal/src/surfaces/chat.tsx
@@ -20,6 +20,7 @@ import { buildChatContext, focusTarget, readIncludeSchedule, scheduleEligible, w
 import { useLiveMeetings } from "./liveMeetings";
 import { meetingPhase, type MeetingMock, type MeetingPhase } from "./meetingModel";
 import { presentError } from "./apiClient";
+import { promptCarriesActiveContext } from "./surfaceSync";
 import { ARTIFACT_EVENT, ASK_CHAT_EVENT, CHAT_TOUCHED_EVENT, MACHINERY_MARK, WORKSPACE_COMMIT_EVENT, MACHINERY_NOTE, ONBOARDING_KICKOFF_MARK, MINUTES_ONBOARDING_GREETING, MINUTES_PREP_GREETING, ONBOARDING_REPLY_SEP } from "../canvas/actions";
 
 /** classify a tool name into one of the op icons so the operation line reads at a glance */
@@ -474,6 +475,10 @@ const meetingLabel = (m: MeetingMock) => m.title_custom ?? (m.native_id ?? m.tit
 function activeContextPrompt(ref: ActiveReference | null, meeting: MeetingMock | undefined): string {
   if (!ref) return "";
   if (ref.kind === "file") {
+    // PRD decision 30: this narration and the server's surface record are two answers to one
+    // question. While the record is not live the prompt keeps carrying it — dropping it first would
+    // leave the agent knowing LESS than it does today. One flag flips both halves together.
+    if (!promptCarriesActiveContext()) return "";
     return `Active context: the user is viewing the workspace file ${ref.value}. Read it with your Read tool if relevant.`;
   }
 

--- a/clients/terminal/src/surfaces/surfaceSync.ts
+++ b/clients/terminal/src/surfaces/surfaceSync.ts
@@ -1,0 +1,105 @@
+"use client";
+/** THE HUMAN SURFACE, WRITTEN TO THE SESSION RECORD (PRD decision 30).
+ *
+ *  What the person is looking at is a FACT the server should hold, not something the client
+ *  re-describes in every prompt. Today the terminal prefixes "Active context: the user is viewing
+ *  the workspace file …" into the user's own message — the agent reads the human's words with our
+ *  narration stapled to the front, and the fact exists only for the duration of one turn.
+ *
+ *  So: the terminal PUTs the whole surface — which chat, which meeting and phase, what is in the
+ *  view, the strip's history and pins, the navigator — whenever any of it changes. The server holds
+ *  it; the prompt stops carrying it.
+ *
+ *  THREE PROPERTIES, each because the alternative is worse:
+ *
+ *    · DEBOUNCED (~300ms). Navigation is bursty — opening a folder walks several pages — and one
+ *      PUT per keystroke-speed change would be a write storm of exactly the kind that turned a
+ *      gateway close-loop into 519 requests in three minutes this morning.
+ *    · FIRE-AND-FORGET. It never blocks the UI and never throws. A surface the server did not
+ *      record is a worse agent turn; a surface that *stalled the panel* is a broken product.
+ *    · BEHIND A FLAG. The route is another worker's (stage-1 owns it and will confirm the field
+ *      names). Until it lands, `syncSurface` is inert and the prompt KEEPS its prefix — because
+ *      dropping the narration before the server fact exists would leave the agent knowing less than
+ *      it does today. One flag flips both halves together, which is the only safe way to trade one
+ *      mechanism for another.
+ */
+
+/** Is the server-side surface record live? Flip when stage-1's route lands and the field names are
+ *  confirmed. Until then: the PUT is a no-op and the prompt keeps its "Active context" prefix. */
+export const SURFACE_RECORD_LIVE = false;
+
+export interface SurfaceRef { workspace: string; path: string; title: string }
+export interface SurfaceHistoryEntry extends SurfaceRef { at: number }
+
+export interface Surface {
+  chat: { id: string; kind: string };
+  meeting: { id: string; phase: string | null } | null;
+  view: SurfaceRef | null;
+  strip: { history: SurfaceHistoryEntry[]; pins: SurfaceRef[] };
+  navigator: { open: boolean; workspace: string | null };
+}
+
+type Timer = ReturnType<typeof setTimeout>;
+const pending = new Map<string, { timer: Timer; surface: Surface }>();
+const DEBOUNCE_MS = 300;
+
+/** Exposed for tests: what a PUT would carry, without waiting on a timer. */
+export function surfaceBody(s: Surface): string {
+  return JSON.stringify(s);
+}
+
+async function put(session: string, surface: Surface, fetcher: typeof fetch): Promise<void> {
+  try {
+    await fetcher(`/api/sessions/${encodeURIComponent(session)}/surface`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: surfaceBody(surface),
+    });
+  } catch {
+    // deliberately silent: the surface is an optimisation for the NEXT turn, and a failed write
+    // must never reach the reader. It is re-sent on their next navigation anyway.
+  }
+}
+
+/** Record the surface. Coalesces bursts per session and keeps only the latest — an intermediate
+ *  state nobody stopped on is not worth a request. */
+export function syncSurface(
+  session: string,
+  surface: Surface,
+  opts: { fetcher?: typeof fetch; debounceMs?: number } = {},
+): void {
+  if (!SURFACE_RECORD_LIVE || !session) return;
+  const fetcher = opts.fetcher ?? fetch;
+  const wait = opts.debounceMs ?? DEBOUNCE_MS;
+  const prev = pending.get(session);
+  if (prev) clearTimeout(prev.timer);
+  const timer = setTimeout(() => {
+    const held = pending.get(session);
+    pending.delete(session);
+    void put(session, held?.surface ?? surface, fetcher);
+  }, wait);
+  pending.set(session, { timer, surface });
+}
+
+/** Read the surface the server holds for a session, or null. Used on load: when the LOCAL strip is
+ *  empty and the server has one, the server's wins — that is the case where this record earns its
+ *  keep (a new browser, a cleared store, another device). A local strip is never overwritten: the
+ *  reader's own machine knows what they were just doing. */
+export async function readSurface(session: string, fetcher: typeof fetch = fetch): Promise<Surface | null> {
+  if (!SURFACE_RECORD_LIVE || !session) return null;
+  try {
+    const r = await fetcher(`/api/sessions/${encodeURIComponent(session)}/surface`, { cache: "no-store" });
+    if (!r.ok) return null;
+    const body = await r.json() as Partial<Surface> | null;
+    if (!body || typeof body !== "object" || !body.strip) return null;
+    return body as Surface;
+  } catch {
+    return null;
+  }
+}
+
+/** Does the prompt still need to narrate what the reader is looking at?
+ *
+ *  The narration and the record are two answers to one question, and running both would mean the
+ *  agent could be told two different things about the same screen. */
+export const promptCarriesActiveContext = (): boolean => !SURFACE_RECORD_LIVE;


### PR DESCRIPTION
Founder, two screenshots. **Seven tabs after a few chip clicks, the same path rendered twice** — *"we do not want to create new tab for every click, tab is only when tab is specifically requested"*, *"duplicated paths"*. Then: **a strip scrolled off the edge** — *"ensure these tabs are sorted left to right based on last used — as a history bar"*.

## Symptom → cause

`openPage` was the one route into the panel and it did two jobs: navigate, **and append a tab**. Every entity chip, wikilink and navigator click minted one — forever, unordered, uncapped. The strip grew monotonically and its order carried no meaning.

## The model now

One **view slot** on the chat record, replaced by every navigation. The strip is that slot's history, three tiers left to right:

> **the chat's HOME · its PINS · history oldest → newest, current page at the right edge**

- **HOME follows the chat's mounts.** A chat that mounts a group is at home in *that group's* README — being shown your personal page when you opened the group's dailies is the panel disagreeing with the conversation. A product default, not a pin: `×` cannot forget it, and it is the view when a scaffold names no focus, because a chat that opens on nothing opens on a blank panel.
- **PINS are per chat** (person pins and `/api/desk/pins` dropped per the correction). A scaffold's `tabs` entry with `pinned: true` arrives as a chat pin.
- **HISTORY** dedups by identity and **moves right**; the cap (12) evicts the oldest **unpinned** — never a pin, never the home. *A cap that could evict a pin would make pinning a suggestion.*

An agent's `artifact` event is a navigation like any other: `focus: true` moves the view, `focus: false` does **nothing visible**. It used to append a tab "quietly behind the reader" — seven quiet tabs are not quiet.

**One path line:** the title row keeps the file name; the breadcrumb below keeps the path *and navigates*. `docWhere` repeated it as dead text.

**The scaffold delivers the strip:** `tabs` entries may be a bare token **or** `{token, pinned}` — both, because the frontmatter is a file the founder edits, and making him write `{token: …, pinned: false}` for the common case would be the format serving the parser.

## Two judgement calls worth review

**The migration changed meaning between the two rulings.** Under the first it *deleted* the pile. Under the amendment those entries are history that was merely never ordered — so it now orders and caps them, stamping stored order as history order (it *is* the order they were opened) and putting the page that was in front at the right edge. A scaffold's tabs are pinned: declared cannot be told from clicked on an old record, and dropping a declared set is a visible loss where two extra pins are not.

**F61 changed the arithmetic, and I moved an invariant rather than deleting it.** Rail 397 → 240 (reversing the +60% of 2026-09-01; rows already ellipsize, so width bought characters and cost the chat and panel real room). That gives 157px back, and **at 1440px the panel's 60% now fits** where the conversation floor used to clip it. The floor still binds at 1280, so the test asserts it there.

## Decision 30

`syncSurface` writes the whole human surface — chat, meeting+phase, view, strip history+pins, navigator — to the session record. Debounced 300ms, fire-and-forget, never blocking. **Inert behind one flag** until stage-1's route lands, and the *same* flag keeps the prompt's `"Active context: the user is viewing…"` prefix: dropping the narration before the server fact exists would leave the agent knowing **less** than it does today. One flag flips both halves together.

## Proof

**899 tests, 86 files, all green. Cold minutes build green. No swap** — the terminal image is stage-1's to sequence.

**Five existing tests changed and one file deleted, all deliberate** — flagging rather than burying it:
- `panelViewSlot.test.ts` **deleted**: it pinned the *delete* semantics the amendment replaced, and is superseded by `stripHistory.test.ts`. A test pinning a superseded rule is worse than none.
- the `docHeader` pair asserted the duplicated path; the `railChats` pair asserted unordered retention; the `maxPagesW` case moved because F61 changed the numbers.

## Verified, not changed

The view slot takes `{workspace, path}` from the **resolver result** — `pageForDocRef(d, r)` prefers `r` and only falls back to a canonical path when the resolver returns nothing. I did **not** touch the guessed-path resolver that `#1403` replaces.
