### PR TITLE
panel: Extend — the open page or a selection, into the open chat (PRD decision 32)

### DIFF
--- a/clients/terminal/src/minutes/ExtendAction.tsx
+++ b/clients/terminal/src/minutes/ExtendAction.tsx
@@ -1,0 +1,141 @@
+"use client";
+/** THE "EXTEND" CONTROLS — two triggers and a landing (PRD decision 32.1).
+ *
+ *  The header action asks about the whole open page; the floating action asks about what the reader
+ *  just highlighted. Both post into the SAME chat and both go through `postIntent`, so there is one
+ *  place that decides what a press means and one place that refuses a press it cannot honour.
+ *
+ *  The panel supplies `workspace` and `path` from THE RESOLVED VIEW SLOT — never from a tab label,
+ *  a crumb, or the document header's rendered name (F63). Those are display strings; two of them
+ *  have already been wrong on this screen (a folder listing renaming the document behind it), and
+ *  an intent built from one sends the agent to work on a file nobody opened.
+ */
+import type { CSSProperties, RefObject } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { WORKSPACE_COMMIT_EVENT } from "../canvas/actions";
+import { Icon } from "../ui-kit";
+import { landPending, postIntent, sourceRange } from "./extend";
+import { type as ty, surface } from "./tokens";
+
+/** THE LANDING (decision 32.3). One listener for the whole panel: when the turn commits, the page
+ *  the intent named becomes the view. Mounted once by the panel — a second mount would navigate
+ *  twice, which is why `landPending` clears before it navigates. */
+export function useIntentLanding(): void {
+  useEffect(() => {
+    const onCommit = () => { landPending(); };
+    window.addEventListener(WORKSPACE_COMMIT_EVENT, onCommit);
+    return () => window.removeEventListener(WORKSPACE_COMMIT_EVENT, onCommit);
+  }, []);
+}
+
+const iconBtn: CSSProperties = {
+  flex: "none", width: 26, height: 24, display: "flex", alignItems: "center", justifyContent: "center",
+  background: "transparent", border: "none", borderRadius: 6, color: "var(--t3)", cursor: "pointer",
+  padding: 0, transition: "color .12s, background .12s",
+};
+const lit = (e: { currentTarget: HTMLElement }) => { e.currentTarget.style.color = "var(--t1)"; e.currentTarget.style.background = surface.raised; };
+const dim = (e: { currentTarget: HTMLElement }) => { e.currentTarget.style.color = "var(--t3)"; e.currentTarget.style.background = "transparent"; };
+
+/** THE HEADER ACTION — the open page, whole. Sits in the document header's utility group with the
+ *  other things that act on what is in front. */
+export function ExtendButton(p: { workspace?: string; path: string }) {
+  return (
+    <button data-doc-act="extend" aria-label="Extend" title="Extend — ask this chat to go further on this page"
+      onClick={() => postIntent({ kind: "extend", workspace: p.workspace, path: p.path })}
+      style={iconBtn} onMouseEnter={lit} onMouseLeave={dim}>
+      <Icon name="spark" size={14} />
+    </button>
+  );
+}
+
+/** THE EMPTY STATE'S ACTION (decision 32.4) — a page that does not exist yet is a thing the chat
+ *  can make. The old empty state named the absence and offered nothing; this is the same sentence
+ *  with the obvious next move attached. */
+export function CreatePageButton(p: { workspace?: string; path: string }) {
+  return (
+    <button data-doc-act="create" title={`Ask this chat to write ${p.path}`}
+      onClick={() => postIntent({ kind: "create", workspace: p.workspace, path: p.path })}
+      style={{
+        ...ty.chip, display: "inline-flex", alignItems: "center", gap: 6, marginTop: 12,
+        color: "var(--t1)", background: surface.raised, border: "1px solid var(--line)",
+        borderRadius: 6, padding: "4px 10px", cursor: "pointer",
+      }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = surface.raisedHi; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = surface.raised; }}>
+      <Icon name="plus" size={13} />
+      Create this page
+    </button>
+  );
+}
+
+interface Hit { text: string; top: number; left: number }
+
+/** THE FLOATING ACTION — appears over a live text selection inside the rendered document, and only
+ *  there.
+ *
+ *  Scoped to the container on purpose: a selection in the conversation, in the rail, or in another
+ *  panel is not a selection in this file, and an action that offered to extend it would name this
+ *  page while quoting something else. The check is containment in the DOM, not a guess from
+ *  coordinates. */
+export function SelectionExtend(p: {
+  containerRef: RefObject<HTMLElement | null>;
+  workspace?: string;
+  path: string;
+  /** the file source, for locating the selection exactly — see `sourceRange` */
+  body: string | null;
+}) {
+  const [hit, setHit] = useState<Hit | null>(null);
+
+  const read = useCallback(() => {
+    const host = p.containerRef.current;
+    const sel = typeof window !== "undefined" ? window.getSelection() : null;
+    if (!host || !sel || sel.isCollapsed || sel.rangeCount === 0) { setHit(null); return; }
+    const text = sel.toString().trim();
+    if (!text) { setHit(null); return; }
+    const range = sel.getRangeAt(0);
+    // BOTH ends inside this document, or it is not this document's selection.
+    if (!host.contains(range.startContainer) || !host.contains(range.endContainer)) { setHit(null); return; }
+    // jsdom has no layout, so every rect is zeroes there. That is not an error state — the action
+    // still belongs on screen, it simply pins to the top-left of the document until a real browser
+    // gives it a rect.
+    const r = range.getBoundingClientRect?.();
+    const hostRect = host.getBoundingClientRect?.();
+    const top = r && hostRect ? r.top - hostRect.top + host.scrollTop - 34 : 0;
+    const left = r && hostRect ? r.left - hostRect.left : 0;
+    setHit({ text, top: Math.max(0, top), left: Math.max(0, left) });
+  }, [p.containerRef]);
+
+  useEffect(() => {
+    // `selectionchange` is the only event that fires for a keyboard selection and for a
+    // drag that ends outside the element; mouseup alone misses both.
+    document.addEventListener("selectionchange", read);
+    return () => document.removeEventListener("selectionchange", read);
+  }, [read]);
+
+  // A new document is a new selection context — never carry the last page's highlight onto it.
+  useEffect(() => { setHit(null); }, [p.path, p.workspace]);
+
+  if (!hit) return null;
+  return (
+    <button data-doc-act="extend-selection" title="Extend — ask this chat to go further on the highlighted text"
+      // mousedown, not click: a click on this button would first collapse the selection it is
+      // about, and the text would be gone by the time the handler read it.
+      onMouseDown={(e) => {
+        e.preventDefault();
+        postIntent({
+          kind: "extend", workspace: p.workspace, path: p.path,
+          selection: hit.text, selection_range: sourceRange(p.body, hit.text),
+        });
+        setHit(null);
+      }}
+      style={{
+        ...ty.chip, position: "absolute", top: hit.top, left: hit.left, zIndex: 4,
+        display: "inline-flex", alignItems: "center", gap: 5, color: "var(--t1)",
+        background: surface.raisedHi, border: "1px solid var(--line)", borderRadius: 6,
+        padding: "3px 8px", cursor: "pointer", boxShadow: "0 2px 8px rgba(0,0,0,.18)",
+      }}>
+      <Icon name="spark" size={12} />
+      Extend
+    </button>
+  );
+}

--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -34,7 +34,7 @@ import { Rail } from "./Rail";
 import { ScaffoldRefusalCard } from "./ScaffoldRefusalCard";
 import { meetingPhase, type MeetingMock } from "../surfaces/meetingModel";
 import { fetchScaffold, localScaffold, scaffoldToChat, type Scaffold, type ScaffoldRefusal } from "./scaffold";
-import { artifactsFromTokens, artifactTabEffect, pageForDocRef, pageForMeetingRef, pagesForPhase, resolveView, VIEW_KEY } from "./roomView";
+import { artifactsFromTokens, artifactTabEffect, pageForDocRef, pageForMeetingRef, pagesForPhase, resolveView, VIEW_KEY, VIEW_NAVIGATE_EVENT, type ViewSlot } from "./roomView";
 import { deskPanelPages } from "./deskPanel";
 import { reportOpened } from "./deskTouch";
 import { applyProposal, proposals, type Proposal } from "./proposals";
@@ -556,6 +556,25 @@ export function MinutesShell() {
     setPages((prev) => prev.some((x) => artifactKey(x) === artifactKey(pg)) ? prev : [...prev, pg]);
     setDocPath(pg.path); setDocSlug(pg.slug); setDocKind(pg.kind === "meeting" ? "meeting" : "doc");
     setListing(null); setDocNonce((n) => n + 1);
+  }, []);
+
+  /** THE VIEW SLOT (decision 28) — a navigation moves what is IN FRONT and mints no tab. Reading
+   *  a workspace by walking it is browsing, and browsing that collects leaves a tab strip nobody
+   *  asked for; a tab is now an explicit act.
+   *
+   *  Until branch `panel-view-slot` puts `view: {workspace, path}` on the chat record, the
+   *  destination lands in the shell's own document state — the very state a focused tab drives —
+   *  so nothing here is panel-local and `artifacts[]` is untouched. */
+  useEffect(() => {
+    const onView = (e: Event) => {
+      const d = (e as CustomEvent<ViewSlot>).detail;
+      if (!d?.path) return;
+      setPagesCollapsed(false); saveCollapsed("right", false);
+      setDocPath(d.path); setDocSlug(d.workspace); setDocKind("doc");
+      setListing(null); setDocNonce((n) => n + 1);
+    };
+    window.addEventListener(VIEW_NAVIGATE_EVENT, onView);
+    return () => window.removeEventListener(VIEW_NAVIGATE_EVENT, onView);
   }, []);
 
   /** Walk the stack without disturbing it. A document closed since it was visited is REOPENED as a

--- a/clients/terminal/src/minutes/PagesPanel.tsx
+++ b/clients/terminal/src/minutes/PagesPanel.tsx
@@ -20,7 +20,7 @@
  *  file management.
  */
 import type { CSSProperties } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Icon } from "../ui-kit";
 import { copyText } from "../ui-kit/ContextMenu";
 import { MdxDoc } from "../ui-kit/MdxDoc";
@@ -28,6 +28,7 @@ import { writeWorkspaceFile } from "../surfaces/workspaceApi";
 import { MarkdownEditor } from "./MarkdownEditor";
 import type { Page } from "./types";
 import { CollapseButton } from "./Collapse";
+import { CreatePageButton, ExtendButton, SelectionExtend, useIntentLanding } from "./ExtendAction";
 import { registry } from "../contributions";
 import { header, surface, type as ty } from "./tokens";
 
@@ -79,6 +80,11 @@ export function PagesPanel(p: {
   // surfaces register, shells render what is registered.
   const canvas = p.docKind === "meeting" && !p.listing;
   const MeetingCanvas = canvas ? registry.tabComponent("meeting") : undefined;
+  // The rendered document's own box — the scope a text selection must be inside to be THIS page's
+  // (see SelectionExtend), and the positioning context the floating action sits in.
+  const docBox = useRef<HTMLDivElement | null>(null);
+  // One listener for the panel: when an Extend/Create turn commits, its page becomes the view.
+  useIntentLanding();
   const [mode, setMode] = useState<"view" | "edit">("view");
   // RAW is a lens on the view, not a third mode: `</>` shows the markdown the renderer was given,
   // which is the question it answers ("what is actually in the file?"). Keeping it orthogonal to
@@ -181,6 +187,9 @@ export function PagesPanel(p: {
                   style={iconBtn(copied)} onMouseEnter={litIcon} onMouseLeave={dimIcon(copied)}>
                   <Icon name={copied ? "check" : "copy"} size={14} />
                 </button>
+                {/* PRD decision 32.1 — the open page, whole. `docSlug`/`docPath` are the RESOLVED
+                    view slot, never the tab label or the crumb (F63). */}
+                <ExtendButton workspace={p.docSlug} path={p.docPath} />
                 <button data-doc-act="edit" onClick={() => { setDraft(p.body ?? ""); setSaveError(null); setMode("edit"); }}
                   title="Edit" aria-label="Edit"
                   style={iconBtn(false)} onMouseEnter={litIcon} onMouseLeave={dimIcon(false)}>
@@ -211,7 +220,7 @@ export function PagesPanel(p: {
           {trail.length > 0 && <span style={{ flex: "none", opacity: 0.6 }}>{SEP}</span>}
           <span style={{ flex: "none", color: "var(--t1)", fontWeight: 600 }}>{leaf}</span>
         </div>}
-        <div style={{ ...ty.body, flex: 1, overflowY: canvas ? "hidden" : "auto", padding: canvas || (mode === "edit" && !listing) ? 0 : "18px 20px 40px", minHeight: 0, lineHeight: 1.6, color: "var(--t1)", display: canvas || (mode === "edit" && !listing) ? "flex" : undefined }}>
+        <div ref={docBox} style={{ ...ty.body, position: "relative", flex: 1, overflowY: canvas ? "hidden" : "auto", padding: canvas || (mode === "edit" && !listing) ? 0 : "18px 20px 40px", minHeight: 0, lineHeight: 1.6, color: "var(--t1)", display: canvas || (mode === "edit" && !listing) ? "flex" : undefined }}>
           {canvas
             // the canvas owns its own scrolling, header and padding — it is a whole surface, not a body
             ? (MeetingCanvas
@@ -220,7 +229,11 @@ export function PagesPanel(p: {
             : listing
               ? <FolderListing listing={listing} onNavigate={p.onNavigate} onOpen={p.onOpen} />
               : p.body === null
-                ? <div style={{ ...ty.body, color: "var(--t3)", lineHeight: 1.6 }}>No page here yet — it appears when the conversation (or a meeting) writes one.</div>
+                ? <div style={{ ...ty.body, color: "var(--t3)", lineHeight: 1.6 }}>
+                    <div>No page here yet — it appears when the conversation (or a meeting) writes one.</div>
+                    {/* …or you ask for it now (decision 32.4). Same resolved slot as the header. */}
+                    <CreatePageButton workspace={p.docSlug} path={p.docPath} />
+                  </div>
                 : mode === "edit"
                   ? <MarkdownEditor value={draft} onChange={setDraft} />
                   : raw
@@ -228,6 +241,11 @@ export function PagesPanel(p: {
                     // so `</>` stays a lens and Edit stays the one way to change a file
                     ? <pre data-doc-raw style={{ margin: 0, fontFamily: "var(--mono)", fontSize: 12.5, lineHeight: 1.65, color: "var(--t1)", whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>{p.body}</pre>
                     : <MdxDoc>{p.body}</MdxDoc>}
+          {/* PRD decision 32.1's second trigger. Only while READING — an editor's selection is
+              being edited, not asked about. */}
+          {doc && p.body !== null && mode === "view" && (
+            <SelectionExtend containerRef={docBox} workspace={p.docSlug} path={p.docPath} body={p.body} />
+          )}
         </div>
       </div>
     </>

--- a/clients/terminal/src/minutes/__tests__/extend.test.ts
+++ b/clients/terminal/src/minutes/__tests__/extend.test.ts
@@ -1,0 +1,161 @@
+/** "EXTEND" — the decisions, without a DOM (PRD decision 32, F63).
+ *
+ *  What has a plausible wrong answer here: an intent built from a display string instead of the
+ *  resolved slot; a bubble that quietly grows into the prompt; a `selection_range` that points
+ *  somewhere with the authority of a number; a landing that fires twice.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ASK_CHAT_EVENT } from "../../canvas/actions";
+import { normalizeIntent, SELECTION_MAX, type ChatIntent } from "../../surfaces/chatIntent";
+import {
+  PREVIEW_MAX, clearPending, compactLabel, fallbackText, landPending, pendingLanding, postIntent, sourceRange,
+} from "../extend";
+import { VIEW_NAVIGATE_EVENT } from "../roomView";
+
+const asks: { prompt?: string; display?: string; intent?: ChatIntent }[] = [];
+const views: unknown[] = [];
+const onAsk = (e: Event) => asks.push((e as CustomEvent).detail);
+const onView = (e: Event) => views.push((e as CustomEvent).detail);
+
+beforeEach(() => {
+  asks.length = 0; views.length = 0; clearPending();
+  window.addEventListener(ASK_CHAT_EVENT, onAsk);
+  window.addEventListener(VIEW_NAVIGATE_EVENT, onView);
+});
+afterEach(() => {
+  window.removeEventListener(ASK_CHAT_EVENT, onAsk);
+  window.removeEventListener(VIEW_NAVIGATE_EVENT, onView);
+});
+
+describe("what an intent may say (F63 — never a guessed path)", () => {
+  it("carries the workspace and the path it was given", () => {
+    expect(normalizeIntent({ kind: "extend", workspace: "acme-kg", path: "kg/plan.md" }))
+      .toEqual({ kind: "extend", workspace: "acme-kg", path: "kg/plan.md" });
+  });
+
+  it("an absent workspace is the reader's own desk, and stays ABSENT — never an empty string", () => {
+    const i = normalizeIntent({ kind: "extend", path: "README.md" })!;
+    expect(i.workspace).toBeUndefined();
+    expect("workspace" in i).toBe(false);
+    expect(normalizeIntent({ kind: "extend", workspace: "   ", path: "README.md" })!.workspace).toBeUndefined();
+  });
+
+  it("refuses a path that is missing, empty, or walks out of its mount", () => {
+    expect(normalizeIntent({ kind: "extend", path: "" })).toBeNull();
+    expect(normalizeIntent({ kind: "extend", path: "   " })).toBeNull();
+    expect(normalizeIntent({ kind: "extend", path: undefined })).toBeNull();
+    expect(normalizeIntent({ kind: "extend", path: "../../etc/passwd" })).toBeNull();
+  });
+
+  it("refuses a kind it does not know", () => {
+    expect(normalizeIntent({ kind: "explode" as "extend", path: "a.md" })).toBeNull();
+  });
+
+  it("trims the selection and caps it at 2000 characters", () => {
+    expect(normalizeIntent({ kind: "extend", path: "a.md", selection: "  hi  " })!.selection).toBe("hi");
+    expect(normalizeIntent({ kind: "extend", path: "a.md", selection: "   " })!.selection).toBeUndefined();
+    const long = "x".repeat(SELECTION_MAX + 500);
+    expect(normalizeIntent({ kind: "extend", path: "a.md", selection: long })!.selection).toHaveLength(SELECTION_MAX);
+  });
+
+  it("drops a range that has no selection, or that does not measure its own selection", () => {
+    expect(normalizeIntent({ kind: "extend", path: "a.md", selection_range: { start: 0, end: 5 } })!.selection_range).toBeUndefined();
+    // "hello" is 5 long; a range claiming 9 is pointing somewhere else with a number's authority
+    expect(normalizeIntent({ kind: "extend", path: "a.md", selection: "hello", selection_range: { start: 3, end: 12 } })!.selection_range).toBeUndefined();
+    expect(normalizeIntent({ kind: "extend", path: "a.md", selection: "hello", selection_range: { start: 3, end: 8 } })!.selection_range).toEqual({ start: 3, end: 8 });
+  });
+});
+
+describe("where a selection sits in the SOURCE", () => {
+  const body = "# Plan\n\nThe pilot ships in March.\n\nThe pilot ships in March again.\n";
+
+  it("locates an unambiguous selection", () => {
+    expect(sourceRange(body, "in March again")).toEqual({ start: 51, end: 65 });
+  });
+
+  it("returns nothing when the text occurs twice — ambiguous is not near-miss", () => {
+    expect(sourceRange(body, "The pilot ships")).toBeNull();
+  });
+
+  it("returns nothing when the rendered selection is not in the source at all", () => {
+    expect(sourceRange(body, "a heading rendered without its hash")).toBeNull();
+    expect(sourceRange(null, "anything")).toBeNull();
+  });
+});
+
+describe("the bubble is the compact form, never the prompt", () => {
+  const page: ChatIntent = { kind: "extend", path: "kg/entities/company/helm.md" };
+
+  it("names the verb and the page", () => {
+    expect(compactLabel(page)).toBe("Extend: kg/entities/company/helm.md");
+    expect(compactLabel({ kind: "create", path: "kg/plan.md" })).toBe("Create: kg/plan.md");
+  });
+
+  it("quotes a short selection, and shortens a long one", () => {
+    expect(compactLabel({ ...page, selection: "the pilot ships in March" }))
+      .toBe('Extend: kg/entities/company/helm.md — “the pilot ships in March”');
+    const long = compactLabel({ ...page, selection: "word ".repeat(60) });
+    expect(long.length).toBeLessThan(page.path.length + PREVIEW_MAX + 20);
+    expect(long.endsWith("…”")).toBe(true);
+  });
+
+  it("flattens a selection dragged across paragraphs — a label is one line", () => {
+    expect(compactLabel({ ...page, selection: "first line\n\nsecond line" }))
+      .toBe('Extend: kg/entities/company/helm.md — “first line second line”');
+  });
+
+  it("the PROMPT keeps the whole selection — it is what the agent reads", () => {
+    const selection = "word ".repeat(60).trim();
+    expect(fallbackText({ ...page, selection })).toContain(selection);
+    expect(fallbackText(page)).toBe("Extend: kg/entities/company/helm.md");
+  });
+});
+
+describe("posting into the open chat", () => {
+  it("sends the intent AND a plain-text fallback, with the compact form as the display", () => {
+    const sent = postIntent({ kind: "extend", workspace: "acme-kg", path: "kg/plan.md" });
+    expect(sent).toEqual({ kind: "extend", workspace: "acme-kg", path: "kg/plan.md" });
+    expect(asks).toHaveLength(1);
+    expect(asks[0].intent).toEqual(sent);
+    expect(asks[0].display).toBe("Extend: kg/plan.md");
+    expect(asks[0].prompt).toBe("Extend: kg/plan.md");
+  });
+
+  it("a selection travels on the intent and inside the fallback sentence", () => {
+    postIntent({ kind: "extend", path: "a.md", selection: "  the pilot ships  " });
+    expect(asks[0].intent?.selection).toBe("the pilot ships");
+    expect(asks[0].prompt).toBe("Extend: a.md — 'the pilot ships'");
+    expect(asks[0].display).toBe('Extend: a.md — “the pilot ships”');
+  });
+
+  it("an intent it cannot honour is not sent at all — no bubble, no turn", () => {
+    expect(postIntent({ kind: "extend", path: "" })).toBeNull();
+    expect(asks).toHaveLength(0);
+    expect(pendingLanding()).toBeNull();
+  });
+});
+
+describe("the landing (decision 32.3)", () => {
+  it("the posted page becomes the view — once", () => {
+    postIntent({ kind: "create", workspace: "acme-kg", path: "kg/new.md" });
+    expect(pendingLanding()).toEqual({ workspace: "acme-kg", path: "kg/new.md" });
+
+    expect(landPending()).toBe(true);
+    expect(views).toEqual([{ workspace: "acme-kg", path: "kg/new.md", label: "new" }]);
+
+    expect(landPending()).toBe(false);      // a second commit does not re-navigate
+    expect(views).toHaveLength(1);
+  });
+
+  it("nothing pending lands nothing", () => {
+    expect(landPending()).toBe(false);
+    expect(views).toEqual([]);
+  });
+
+  it("a second press replaces the first — the newest is what the reader asked for", () => {
+    postIntent({ kind: "extend", path: "one.md" });
+    postIntent({ kind: "extend", path: "two.md" });
+    landPending();
+    expect(views).toEqual([{ workspace: undefined, path: "two.md", label: "two" }]);
+  });
+});

--- a/clients/terminal/src/minutes/__tests__/extendPanel.test.tsx
+++ b/clients/terminal/src/minutes/__tests__/extendPanel.test.tsx
@@ -1,0 +1,193 @@
+/** "EXTEND" AS THE READER PRESSES IT — through the pages panel, which is where both triggers live.
+ *
+ *  Rendered via `PagesPanel` rather than as loose components, because the two claims that matter
+ *  are about the panel: that the intent is built from the RESOLVED VIEW SLOT and not from anything
+ *  on screen (F63), and that pressing it does not mint a tab (decision 28). Neither is observable
+ *  from a button in isolation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { PagesPanel } from "../PagesPanel";
+import { ASK_CHAT_EVENT, WORKSPACE_COMMIT_EVENT } from "../../canvas/actions";
+import { VIEW_NAVIGATE_EVENT } from "../roomView";
+import { clearPending } from "../extend";
+import type { ChatIntent } from "../../surfaces/chatIntent";
+import type { Page } from "../types";
+
+const PATH = "kg/entities/company/helm.md";
+const BODY = "# Helm Bank\n\nThe pilot ships in March, self-hosted.\n";
+// the tab's LABEL is deliberately not the path, and deliberately misleading: an intent built from
+// what is written on a chip would pick this up
+const pages: Page[] = [{ path: PATH, slug: "acme-kg", label: "Some Other Name" }];
+
+const asks: { prompt?: string; display?: string; intent?: ChatIntent }[] = [];
+const views: unknown[] = [];
+const onAsk = (e: Event) => asks.push((e as CustomEvent).detail);
+const onView = (e: Event) => views.push((e as CustomEvent).detail);
+const onOpen = vi.fn();
+
+const panel = (over: Partial<Parameters<typeof PagesPanel>[0]> = {}) =>
+  render(<PagesPanel pages={pages} docPath={PATH} docSlug="acme-kg" onOpen={onOpen} body={BODY} {...over} />);
+
+beforeEach(() => {
+  asks.length = 0; views.length = 0; onOpen.mockClear(); clearPending();
+  window.addEventListener(ASK_CHAT_EVENT, onAsk);
+  window.addEventListener(VIEW_NAVIGATE_EVENT, onView);
+});
+afterEach(() => {
+  window.removeEventListener(ASK_CHAT_EVENT, onAsk);
+  window.removeEventListener(VIEW_NAVIGATE_EVENT, onView);
+  cleanup();
+});
+
+describe("the header action — the open page, whole (decision 32.1)", () => {
+  it("posts the intent for the RESOLVED slot, not for what the tab is called (F63)", () => {
+    const { container } = panel();
+    fireEvent.click(container.querySelector('[data-doc-act="extend"]') as HTMLElement);
+
+    expect(asks).toHaveLength(1);
+    expect(asks[0].intent).toEqual({ kind: "extend", workspace: "acme-kg", path: PATH });
+    expect(JSON.stringify(asks[0])).not.toContain("Some Other Name");
+  });
+
+  it("the bubble is the compact form — the prompt is never what the reader is shown as their words", () => {
+    const { container } = panel();
+    fireEvent.click(container.querySelector('[data-doc-act="extend"]') as HTMLElement);
+    expect(asks[0].display).toBe(`Extend: ${PATH}`);
+    expect(asks[0].display).not.toMatch(/follow the links|research|write back/i);
+  });
+
+  it("the desk's own page carries NO workspace — an absent slug is an answer", () => {
+    const { container } = panel({ docSlug: undefined, docPath: "README.md", pages: [{ path: "README.md", label: "README" }] });
+    fireEvent.click(container.querySelector('[data-doc-act="extend"]') as HTMLElement);
+    expect(asks[0].intent).toEqual({ kind: "extend", path: "README.md" });
+  });
+
+  it("mints no tab (decision 28)", () => {
+    const { container } = panel();
+    fireEvent.click(container.querySelector('[data-doc-act="extend"]') as HTMLElement);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("a meeting canvas has no page to extend, so it has no action", () => {
+    const { container } = render(
+      <PagesPanel pages={[{ kind: "meeting", path: "42", label: "Standup" }]} docPath="42" docKind="meeting" onOpen={onOpen} body={null} />,
+    );
+    expect(container.querySelector('[data-doc-act="extend"]')).toBeNull();
+  });
+});
+
+describe("the empty state's action (decision 32.4)", () => {
+  it("offers to create the page that is not there", () => {
+    const { container } = panel({ body: null });
+    expect(screen.getByText(/No page here yet/)).toBeTruthy();
+    fireEvent.click(container.querySelector('[data-doc-act="create"]') as HTMLElement);
+
+    expect(asks[0].intent).toEqual({ kind: "create", workspace: "acme-kg", path: PATH });
+    expect(asks[0].display).toBe(`Create: ${PATH}`);
+    expect(asks[0].prompt).toBe(`Create: ${PATH}`);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("a page that HAS content is not offered a create button", () => {
+    const { container } = panel();
+    expect(container.querySelector('[data-doc-act="create"]')).toBeNull();
+  });
+});
+
+/** Select `length` characters of the first text node inside `host`, starting at `from`. */
+function highlight(host: HTMLElement, from: number, length: number) {
+  const node = host.firstChild as Text;
+  const range = document.createRange();
+  range.setStart(node, from);
+  range.setEnd(node, from + length);
+  const sel = window.getSelection() as Selection;
+  sel.removeAllRanges();
+  sel.addRange(range);
+  act(() => { document.dispatchEvent(new Event("selectionchange")); });
+}
+
+describe("the floating action on a selection (decision 32.1)", () => {
+  /** the `</>` lens — one text node, so the selection is exact and the test is about the ACTION,
+   *  not about how MDX happens to split a paragraph into elements */
+  const raw = (over: Partial<Parameters<typeof PagesPanel>[0]> = {}) => {
+    const r = panel(over);
+    fireEvent.click(r.container.querySelector('[data-doc-act="raw"]') as HTMLElement);
+    return r.container.querySelector("[data-doc-raw]") as HTMLElement;
+  };
+
+  it("appears only once there is a selection, and carries its text", () => {
+    const pre = raw();
+    expect(document.querySelector('[data-doc-act="extend-selection"]')).toBeNull();
+
+    highlight(pre, 13, 24);            // "The pilot ships in March"
+    const btn = document.querySelector('[data-doc-act="extend-selection"]') as HTMLElement;
+    expect(btn).toBeTruthy();
+
+    fireEvent.mouseDown(btn);
+    expect(asks[0].intent).toMatchObject({ kind: "extend", workspace: "acme-kg", path: PATH, selection: "The pilot ships in March" });
+    expect(asks[0].display).toBe(`Extend: ${PATH} — “The pilot ships in March”`);
+    expect(asks[0].prompt).toBe(`Extend: ${PATH} — 'The pilot ships in March'`);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("locates the selection in the SOURCE when it occurs there exactly once", () => {
+    const pre = raw();
+    highlight(pre, 13, 24);
+    fireEvent.mouseDown(document.querySelector('[data-doc-act="extend-selection"]') as HTMLElement);
+    const r = asks[0].intent?.selection_range;
+    expect(r).toBeTruthy();
+    expect(BODY.slice(r!.start, r!.end)).toBe("The pilot ships in March");
+  });
+
+  it("says nothing about where a selection sits when the text repeats", () => {
+    const body = "one two\n\none two\n";
+    const pre = raw({ body });
+    highlight(pre, 0, 7);              // "one two", twice in the file
+    fireEvent.mouseDown(document.querySelector('[data-doc-act="extend-selection"]') as HTMLElement);
+    expect(asks[0].intent?.selection).toBe("one two");
+    expect(asks[0].intent?.selection_range).toBeUndefined();
+  });
+
+  it("caps a very long selection at 2000 characters", () => {
+    const body = "y".repeat(4000);
+    const pre = raw({ body });
+    highlight(pre, 0, 4000);
+    fireEvent.mouseDown(document.querySelector('[data-doc-act="extend-selection"]') as HTMLElement);
+    expect(asks[0].intent?.selection).toHaveLength(2000);
+  });
+
+  it("a selection OUTSIDE the document is not this page's selection", () => {
+    raw();
+    const stray = document.createElement("p");
+    stray.textContent = "text in some other pane";
+    document.body.appendChild(stray);
+    highlight(stray, 0, 9);
+    expect(document.querySelector('[data-doc-act="extend-selection"]')).toBeNull();
+    stray.remove();
+  });
+
+  it("an editor's selection is being edited, not asked about", () => {
+    const { container } = panel();
+    fireEvent.click(container.querySelector('[data-doc-act="edit"]') as HTMLElement);
+    expect(container.querySelector('[data-doc-act="extend-selection"]')).toBeNull();
+  });
+});
+
+describe("the landing (decision 32.3)", () => {
+  it("the page becomes the view when the turn commits — and no tab is minted", () => {
+    const { container } = panel({ body: null });
+    fireEvent.click(container.querySelector('[data-doc-act="create"]') as HTMLElement);
+    expect(views).toEqual([]);                       // not before the reply
+
+    act(() => { window.dispatchEvent(new CustomEvent(WORKSPACE_COMMIT_EVENT)); });
+    expect(views).toEqual([{ workspace: "acme-kg", path: PATH, label: "helm" }]);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("a commit with nothing pending navigates nowhere", () => {
+    panel();
+    act(() => { window.dispatchEvent(new CustomEvent(WORKSPACE_COMMIT_EVENT)); });
+    expect(views).toEqual([]);
+  });
+});

--- a/clients/terminal/src/minutes/extend.ts
+++ b/clients/terminal/src/minutes/extend.ts
@@ -1,0 +1,109 @@
+/** "EXTEND" — send the open chat to explore the page, or a piece of it (PRD decision 32).
+ *
+ *  Founder: *"an extend button that would request the same chat that is open now — just go explore
+ *  the page in question or a highlighted text from a file, so the agent would go explore that
+ *  further following the logic of the context and the chat and the focus."*
+ *
+ *  THE SAME CHAT, NOT A NEW ONE. It posts a turn into whatever chat is open, through the same
+ *  `ASK_CHAT_EVENT` seam a canvas chip already uses — so the turn inherits that conversation's
+ *  context, focus and mount set by construction rather than by re-composing them here.
+ *
+ *  WHAT THE PERSON SEES IS THE COMPACT FORM. `Extend: kg/plan.md — "…"`, never the prompt. The
+ *  preset text is the agent's business; a bubble that renders it puts words in the person's mouth
+ *  they did not write, and then their next message argues with a paragraph they never said. The ask
+ *  seam has carried a separate `display` since the canvas chips — this is the same rule, and when
+ *  F47's `user_text` lands on the record it is the same rule again, one layer down.
+ *
+ *  UNTIL THE SERVER HALF LANDS, BOTH TRAVEL. The typed `intent` is what the `extend` preset will
+ *  read; the prompt is the plain sentence that works today. A build where the server ignores the
+ *  intent still does the right thing, and a build where it reads it is not confused by the
+ *  sentence — the two say the same thing.
+ */
+import { ASK_CHAT_EVENT } from "../canvas/actions";
+import { normalizeIntent, type ChatIntent, type ChatIntentKind } from "../surfaces/chatIntent";
+import { navigateView } from "./roomView";
+
+/** How much of a selection the BUBBLE shows. The intent carries up to 2000 characters; a bubble is
+ *  a label, and a paragraph rendered as one is the composed-text failure wearing a quotation mark. */
+export const PREVIEW_MAX = 80;
+
+const VERB: Record<ChatIntentKind, string> = { extend: "Extend", create: "Create" };
+
+/** Collapse the whitespace a rendered selection carries — a highlight dragged across a paragraph
+ *  break arrives with newlines in it, and they belong in the intent, never in a one-line label. */
+const oneLine = (s: string) => s.replace(/\s+/g, " ").trim();
+
+/** THE BUBBLE. Compact by construction: a verb, the page, and — when there is one — a short
+ *  quotation of what was highlighted. */
+export function compactLabel(intent: ChatIntent): string {
+  const head = `${VERB[intent.kind]}: ${intent.path}`;
+  if (!intent.selection) return head;
+  const flat = oneLine(intent.selection);
+  const shown = flat.length > PREVIEW_MAX ? `${flat.slice(0, PREVIEW_MAX).trimEnd()}…` : flat;
+  return `${head} — “${shown}”`;
+}
+
+/** THE PROMPT, until the server turns the intent into the `extend` preset. The whole selection,
+ *  not the preview: this is what the agent reads, and truncating it here would lose the half of a
+ *  paragraph the person actually cared about. */
+export function fallbackText(intent: ChatIntent): string {
+  const head = `${VERB[intent.kind]}: ${intent.path}`;
+  return intent.selection ? `${head} — '${intent.selection}'` : head;
+}
+
+/** WHERE A SELECTION SITS IN THE FILE SOURCE — or nothing.
+ *
+ *  The rendered document is not the file: a heading loses its `#`, a link loses its target, and an
+ *  offset into what the reader highlighted is an offset into neither. So the range is established
+ *  by finding the selection in the SOURCE, and only when it occurs there exactly ONCE. Two
+ *  occurrences is not a near-miss, it is an unknown answer (F63), and an unknown answer is omitted.
+ */
+export function sourceRange(body: string | null | undefined, selection: string): { start: number; end: number } | null {
+  const src = body ?? "";
+  const needle = selection.trim();
+  if (!src || !needle) return null;
+  const first = src.indexOf(needle);
+  if (first < 0) return null;
+  if (src.indexOf(needle, first + 1) >= 0) return null;   // ambiguous → no range
+  return { start: first, end: first + needle.length };
+}
+
+// ── posting, and where the reply lands ───────────────────────────────────────────────────────────
+
+/** The page an in-flight intent will bring into view once the turn commits. Module-level because
+ *  the button that posts and the listener that lands are two different components with one fact
+ *  between them — and it is a POINTER, not state: one intent is pending at a time, the newest wins,
+ *  which is exactly what a second press of Extend means. */
+let pending: { workspace?: string; path: string } | null = null;
+
+/** For tests and for a panel that unmounts mid-turn. */
+export const pendingLanding = (): { workspace?: string; path: string } | null => pending;
+export const clearPending = (): void => { pending = null; };
+
+/** Post an intent into the OPEN chat. Returns the intent that went, or `null` when there was
+ *  nothing honest to send (see `normalizeIntent` — an unnamed page is never guessed at). */
+export function postIntent(raw: Parameters<typeof normalizeIntent>[0]): ChatIntent | null {
+  const intent = normalizeIntent(raw);
+  if (!intent) return null;
+  pending = { workspace: intent.workspace, path: intent.path };
+  window.dispatchEvent(new CustomEvent(ASK_CHAT_EVENT, {
+    detail: { prompt: fallbackText(intent), display: compactLabel(intent), intent },
+  }));
+  return intent;
+}
+
+/** THE LANDING (decision 32.3): after the reply, the page the intent named becomes the view.
+ *
+ *  It fires on the turn's COMMIT, not on the last token — for `create` the file does not exist
+ *  until then, and navigating to it a moment early is how the panel ends up saying "no page here
+ *  yet" about a page that was just written. A turn that commits nothing lands nothing, which is
+ *  the honest answer: the page did not change.
+ *
+ *  It NAVIGATES, it does not open a tab (decision 28). */
+export function landPending(): boolean {
+  if (!pending) return false;
+  const { workspace, path } = pending;
+  pending = null;
+  navigateView(workspace, path);
+  return true;
+}

--- a/clients/terminal/src/minutes/roomView.ts
+++ b/clients/terminal/src/minutes/roomView.ts
@@ -265,3 +265,40 @@ export function resolveView(spec: string | null | undefined, phasePages: Page[])
   }
   return { pages, focus };
 }
+
+// ── THE VIEW SLOT — a click NAVIGATES, it does not collect (PRD decision 28) ─────────────────────
+/** A file clicked in the panel's navigator moves the panel's SINGLE view; it never mints a tab.
+ *  Tabs are minted only by an explicit open-in-tab (middle-click, the row's ⧉) or by a scaffold.
+ *
+ *  STUB. Branch `panel-view-slot` owns the real thing — `view: {workspace, path}` on the chat
+ *  record, with back/forward over it. What lives here is only the SEAM, so the navigator can be
+ *  written against the final call and nothing has to be rewritten when the slot lands: the click
+ *  ANNOUNCES a destination, the shell puts it in front, and the navigator keeps no state about
+ *  what is being read. On the rebase this block goes and `navigateView` resolves to theirs.
+ *
+ *  Deliberately an event and not a callback prop: it is the same shape as OPEN_ENTITY_EVENT and
+ *  ARTIFACT_EVENT, which is how every other "something wants to be in front" already reaches the
+ *  shell — one route, not two.
+ */
+export const VIEW_NAVIGATE_EVENT = "vexa:view-navigate";
+
+export interface ViewSlot { workspace?: string; path: string; label: string }
+
+/** The slot a workspace + path address. `workspace` empty ⇒ the reader's own desk (no slug), the
+ *  same "" ⇒ undefined rule `artifactFromDocRef` applies — an absent slug is a resolved answer. */
+export function viewSlotFor(workspace: string | undefined, path: string): ViewSlot {
+  const clean = String(path ?? "").replace(/^\/+/, "");
+  return {
+    workspace: workspace || undefined,
+    path: clean,
+    label: (clean.split("/").pop() ?? clean).replace(/\.md$/i, ""),
+  };
+}
+
+/** Put a file in front. A path that walks out of its mount is refused here rather than at the
+ *  fetch, exactly as `resolveView` refuses one from a link. */
+export function navigateView(workspace: string | undefined, path: string): void {
+  const detail = viewSlotFor(workspace, path);
+  if (!detail.path || detail.path.split("/").includes("..")) return;
+  window.dispatchEvent(new CustomEvent(VIEW_NAVIGATE_EVENT, { detail }));
+}

--- a/clients/terminal/src/surfaces/chat.tsx
+++ b/clients/terminal/src/surfaces/chat.tsx
@@ -20,6 +20,7 @@ import { buildChatContext, focusTarget, readIncludeSchedule, scheduleEligible, w
 import { useLiveMeetings } from "./liveMeetings";
 import { meetingPhase, type MeetingMock, type MeetingPhase } from "./meetingModel";
 import { presentError } from "./apiClient";
+import type { ChatIntent } from "./chatIntent";
 import { ARTIFACT_EVENT, ASK_CHAT_EVENT, CHAT_TOUCHED_EVENT, MACHINERY_MARK, WORKSPACE_COMMIT_EVENT, MACHINERY_NOTE, ONBOARDING_KICKOFF_MARK, MINUTES_ONBOARDING_GREETING, MINUTES_PREP_GREETING, ONBOARDING_REPLY_SEP } from "../canvas/actions";
 
 /** classify a tool name into one of the op icons so the operation line reads at a glance */
@@ -858,7 +859,7 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
     return data.files ?? [];
   };
 
-  const send = async (text: string, prompt = text, referenceSource = text, opts: { hidden?: boolean; ground?: boolean; scaffoldId?: string } = {}) => {
+  const send = async (text: string, prompt = text, referenceSource = text, opts: { hidden?: boolean; ground?: boolean; scaffoldId?: string; intent?: ChatIntent } = {}) => {
     // hidden → no visible user bubble (system kickoffs); ground:false → don't append the active
     // meeting/file context (onboarding must not inherit whatever meeting happens to be focused).
     const { hidden = false, ground = true } = opts;
@@ -938,7 +939,9 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
     try {
       const result = await streamChatTurn(
         // `scaffold_id` on the FIRST turn: dispatch reads the same record the panel rendered from.
-        { prompt: p, session: sessionForSend, active, context, scaffold_id: opts.scaffoldId },
+        // `intent` (PRD decision 32) — an Extend/Create press is an ACT on a named file, not a
+        // sentence; it travels typed so the server can turn it into a preset without parsing prose.
+        { prompt: p, session: sessionForSend, active, context, scaffold_id: opts.scaffoldId, intent: opts.intent },
         {
           onStarting: () => {},  // visual is driven by onStatus (below); the stream still signals cold-start here
           onStatus: (phase) => setStatus(phase),
@@ -1008,7 +1011,7 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
   sendRef.current = send;
   useEffect(() => {
     const onAsk = (e: Event) => {
-      const detail = (e as CustomEvent<{ prompt?: string; display?: string; hidden?: boolean; ground?: boolean; session?: string; scaffoldId?: string }>).detail;
+      const detail = (e as CustomEvent<{ prompt?: string; display?: string; hidden?: boolean; ground?: boolean; session?: string; scaffoldId?: string; intent?: ChatIntent }>).detail;
       const prompt = detail?.prompt;
       if (!prompt) return;
       // A SESSION-TARGETED ask must never land in whichever chat happens to be visible (the
@@ -1021,7 +1024,7 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
       if (layout.store.getState().rightCollapsed) layout.toggleRight();
       // `display` — what the READER sees when it is not what the agent gets: a chip whose label is
       // the user's own sentence renders as their message, and the grounding it carries does not.
-      void sendRef.current(detail?.display || prompt, prompt, prompt, { hidden: detail?.hidden, ground: detail?.ground, scaffoldId: detail?.scaffoldId });
+      void sendRef.current(detail?.display || prompt, prompt, prompt, { hidden: detail?.hidden, ground: detail?.ground, scaffoldId: detail?.scaffoldId, intent: detail?.intent });
     };
     window.addEventListener(ASK_CHAT_EVENT, onAsk);
     return () => window.removeEventListener(ASK_CHAT_EVENT, onAsk);

--- a/clients/terminal/src/surfaces/chatIntent.ts
+++ b/clients/terminal/src/surfaces/chatIntent.ts
@@ -1,0 +1,69 @@
+/** THE INTENT ON A CHAT TURN — what a button pressed on a page asks the agent to do (PRD decision 32).
+ *
+ *  A turn can now carry more than prose. "Extend" and "Create this page" are not sentences the
+ *  person typed; they are ACTS on a named file, and the agent needs the file — not a paraphrase of
+ *  it that it then has to parse back. So the wire carries a small typed record beside the prompt,
+ *  and the server half turns it into the matching preset.
+ *
+ *  It lives in `surfaces/` rather than beside its buttons in `minutes/` because three layers have
+ *  to agree on it — the panel that mints it, the chat that sends it, the stream that puts it on the
+ *  wire — and the dependency direction runs that way (surfaces are below shells, never above).
+ *
+ *  F63 — AN INTENT NEVER CARRIES A GUESSED PATH. Everything below refuses rather than repairs: an
+ *  empty path, a path that walks out of its mount, a range that does not describe its own selection.
+ *  A malformed intent becomes `null` here and the caller sends nothing, because the failure mode
+ *  this exists to prevent is the agent confidently working on a file that was never open.
+ */
+
+/** The most selected text an intent carries. Past this the selection is no longer a quotation, and
+ *  the page itself — which the intent already names — is the better thing to hand the agent. */
+export const SELECTION_MAX = 2000;
+
+export type ChatIntentKind = "extend" | "create";
+
+export interface ChatIntent {
+  kind: ChatIntentKind;
+  /** the workspace slug the page lives in. ABSENT = the reader's own desk (a no-slug read) — an
+   *  absent slug is a RESOLVED answer here, never "we did not look". */
+  workspace?: string;
+  /** the path inside that workspace, from its root */
+  path: string;
+  /** the highlighted text, trimmed and capped. Absent = the whole page. */
+  selection?: string;
+  /** where that selection sits IN THE FILE SOURCE. Only ever present when it could be established
+   *  exactly (see `sourceRange`); a range whose basis is ambiguous is omitted, not approximated. */
+  selection_range?: { start: number; end: number };
+}
+
+const isInt = (n: unknown): n is number => typeof n === "number" && Number.isInteger(n) && n >= 0;
+
+/** The one door an intent comes through. Returns the intent, or `null` when it would be a guess. */
+export function normalizeIntent(raw: {
+  kind: ChatIntentKind;
+  workspace?: string | null;
+  path?: string | null;
+  selection?: string | null;
+  selection_range?: { start: number; end: number } | null;
+}): ChatIntent | null {
+  if (raw.kind !== "extend" && raw.kind !== "create") return null;
+  const path = String(raw.path ?? "").trim().replace(/^\/+/, "");
+  // no path, or one that walks out of its mount → nothing to act on. Same refusal `resolveView`
+  // applies to a link, for the same reason.
+  if (!path || path.split("/").includes("..")) return null;
+
+  const workspace = String(raw.workspace ?? "").trim() || undefined;
+
+  const selRaw = String(raw.selection ?? "").trim();
+  const selection = selRaw ? selRaw.slice(0, SELECTION_MAX) : undefined;
+
+  const r = raw.selection_range;
+  // A RANGE WITHOUT ITS SELECTION IS NOISE, and a range that does not match the length of the text
+  // it claims to locate is worse than none: it points the agent at the wrong lines with the
+  // authority of a number. Both are dropped; the selection itself survives.
+  const selection_range =
+    selection && r && isInt(r.start) && isInt(r.end) && r.end > r.start && r.end - r.start === selRaw.length
+      ? { start: r.start, end: r.end }
+      : undefined;
+
+  return { kind: raw.kind, ...(workspace ? { workspace } : {}), path, ...(selection ? { selection } : {}), ...(selection_range ? { selection_range } : {}) };
+}

--- a/clients/terminal/src/surfaces/chatStream.ts
+++ b/clients/terminal/src/surfaces/chatStream.ts
@@ -11,6 +11,7 @@
  *
  *  Extracted from Chat.send so the robustness logic is unit-testable against a faked fetch/SSE. */
 
+import type { ChatIntent } from "./chatIntent";
 import { noteAuthFailure, isAuthStatus } from "@/app/session";
 import { SESSION_ENDED_HEADLINE } from "./apiClient";
 
@@ -110,6 +111,9 @@ export type ChatStreamRequest = {
    *  thread from then on, and re-sending it would invite the server to re-apply an arrival that
    *  already happened. */
   scaffold_id?: string;
+  /** PRD decision 32 — what a button pressed on a page asks for. Typed, never prose: the server
+   *  half turns it into the matching preset. Omitted when absent, like `scaffold_id`. */
+  intent?: ChatIntent;
 };
 
 /** One nonce per user turn, constant across that turn's reconnect attempts. It lets agent-api tell a
@@ -225,7 +229,8 @@ export async function streamChatTurn(
         // `extra="forbid"`-adjacent about shapes, and an explicit null is a different statement
         // from "this turn did not come from an arrival".
         body: JSON.stringify({ prompt: req.prompt, session: req.session, active: req.active, context: req.context, turn_id: turnId,
-          ...(req.scaffold_id ? { scaffold_id: req.scaffold_id } : {}) }),
+          ...(req.scaffold_id ? { scaffold_id: req.scaffold_id } : {}),
+          ...(req.intent ? { intent: req.intent } : {}) }),
         signal,
       });
     } catch (e) {


### PR DESCRIPTION
**PRD decision 32** — *"an extend button that would request the same chat that is open now — just go explore the page in question or a highlighted text from a file."* Plus **32.4**: "Create this page" on the empty state.

Base `minutes-mcp-viewer`, rebased onto `25b52bfbc` and re-proven there (one conflict, one import line — upstream had dropped `refusalCopy` from the scaffold import; theirs kept, my `roomView` additions kept).

## Three controls, one door

| Trigger | Posts |
|---|---|
| **`[data-doc-act="extend"]`** — the document header's utility group, beside copy/edit | `{kind: "extend", workspace, path}` for the open page |
| **`[data-doc-act="extend-selection"]`** — floats over a live text selection inside the document column | the same, plus `selection` (trimmed, ≤2000) and `selection_range` when it can be established exactly |
| **`[data-doc-act="create"]`** — on the "No page here yet" state (32.4) | `{kind: "create", workspace, path}` |

All three go through one `postIntent`, so there is one place that decides what a press means and one place that refuses a press it cannot honour. None of them mints a tab (decision 28).

## Three rules worth naming

**The bubble is the compact form, never the prompt.** `Extend: kg/plan.md — “…”`. A bubble that renders composed text puts words in the person's mouth they did not write, and their next message then argues with a paragraph they never said. The ask seam has carried a separate `display` since the canvas chips — this is that rule; when **F47's `user_text`** lands on the record it is the same rule one layer down, and this code needs no change to honour it. The *prompt* keeps the whole selection (up to 2000 chars) because that is what the agent reads; only the *label* is previewed at 80.

**An intent never carries a guessed path (F63).** `{workspace, path}` come from the **resolved view slot** (`docSlug`/`docPath`), never the tab label, the crumb, or the header's rendered document name. Those are display strings and one of them has already been wrong on this screen — a folder listing renaming the document behind it. A test renders the panel with a tab labelled `"Some Other Name"` and asserts that string appears nowhere in what was posted. `normalizeIntent` **refuses rather than repairs**: no path, a path containing `..`, an unknown kind → `null`, and nothing is sent at all.

**A range is exact or absent.** The rendered document is not the file — a heading loses its `#`, a link loses its target — so an offset into what the reader highlighted is an offset into neither. `sourceRange` finds the selection in the **source**, and only when it occurs there exactly once. Two occurrences is an *unknown* answer, not a near-miss, and it is omitted: a range that is wrong points the agent at the wrong lines with a number's authority. `normalizeIntent` independently drops any range whose length does not measure its own selection.

## Until the server half lands

**Both travel.** The typed `intent` (what the `extend` preset will read) and the plain sentence `Extend: <path> — '<selection>'` that works today. A build that ignores the intent still does the right thing; a build that reads it is not confused by the sentence — they say the same thing. When stage-1 lands the preset, the fallback prompt is the one string to drop.

**Where the reply lands.** On the turn's `WORKSPACE_COMMIT_EVENT`, not on the last token: for `create` the file does not exist until then, and navigating a moment early is exactly how the panel ends up saying *"no page here yet"* about a page that was just written. A turn that commits nothing lands nothing — the honest answer, since the page did not change. It **navigates** (`navigateView`), it does not open a tab.

**The view slot is still a stub.** `roomView.ts` carries `VIEW_NAVIGATE_EVENT` + `navigateView` + `viewSlotFor`, plus a 15-line listener in `MinutesShell` — **byte-identical to the block on [`#1404`](https://github.com/Vexa-ai/vexa/pull/1404)**, which is not merged yet. If that lands first, the rebase here resolves by keeping one copy; when `panel-view-slot` lands, both blocks go and both branches' imports resolve to theirs unchanged.

## The hook

The intent had to reach the wire, which is three small additive edits and one new file:

- `surfaces/chatIntent.ts` **(new)** — the wire type + `normalizeIntent`. In `surfaces/` because three layers must agree on it and the dependency direction runs that way.
- `surfaces/chatStream.ts` — `intent?: ChatIntent` on the request, spread into the body **only when present** (the same "an explicit null is a different statement" rule `scaffold_id` follows). +7/−2.
- `surfaces/chat.tsx` — `intent` on the ask detail → `send` opts → `streamChatTurn`. +11/−4, all additive; stage-1's F47/F48 edits are elsewhere in the file.
- `minutes/PagesPanel.tsx` — the header button, the create button, the selection container's ref, one landing hook. +24/−4.

## Proof

- `npx tsc --noEmit` — clean, before and after the rebase.
- `npx vitest run` — **950 tests over 91 files green** on the rebased head, **34 of them new** (19 pure + 15 through the panel).
- `docker build --target build --build-arg NEXT_PUBLIC_TERMINAL_MODE=minutes` — green, cold, twice (before and after the rebase). On `bbb`; the running stack, `~/.storm/*`, the lanes and mailpit untouched, no `git stash`, no production image.

What the new tests catch:

| Test | Would otherwise pass with |
|---|---|
| the header intent carries the resolved slot; the misleading tab label appears nowhere in the payload | an intent built from a chip label (F63) |
| the desk's page carries **no** `workspace` key at all | `workspace: ""` sent as a fact |
| empty path / `..` / unknown kind → nothing posted, nothing pending | a turn about a file nobody opened |
| selection trimmed, capped at 2000; the label flattens newlines and elides at 80 while the prompt keeps it whole | a bubble that grows into the prompt |
| `selection_range` present for a unique match, **absent** when the text repeats, absent when it is not in the source | a plausible-looking wrong range |
| a selection outside the document column raises no action | this page's name quoting another pane's text |
| the editor's selection raises no action | asking about text that is being edited |
| the page becomes the view on commit, once; a second commit does not re-navigate | a double navigation |
| `onOpen` never called by any of the three controls | a tab minted per press (decision 28) |

Not asserted by any test, and worth an eye at review: the floating action's placement in a real browser (jsdom has no layout, so the rects are zeroes there and the button pins to the document's top-left).

**COMMITMENTS IN THIS DRAFT — none.**

One item of [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449); closes nothing on its own.
