### PR TITLE
F66: a running turn looks like one — and the navigator shares the one view route

### DIFF
--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -605,24 +605,24 @@ export function MinutesShell() {
     });
   }, [docKind, docPath, docSlug]);
 
-  /** THE VIEW SLOT (decision 28) — the navigator moves what is IN FRONT and mints no tab. Reading
-   *  a workspace by walking it is browsing, and browsing that collects leaves a tab strip nobody
-   *  asked for; a tab is now an explicit act.
+  /** THE VIEW SLOT (decision 28) — the navigator moves what is IN FRONT and mints no tab. Reading a
+   *  workspace by walking it is browsing, and browsing that collects leaves a strip nobody asked for.
    *
-   *  Until branch `panel-view-slot` puts `view: {workspace, path}` on the chat record, the
-   *  destination lands in the shell's own document state — the very state a focused tab drives —
-   *  so nothing here is panel-local and `artifacts[]` is untouched. */
+   *  THE LISTENER IS THE SEAM; `openPage` IS THE MECHANISM. It used to set the document state
+   *  directly, which was correct while the view slot did not exist yet and wrong the moment it did:
+   *  a navigator click skipped the back/forward stack and the strip's history, so it and a chip
+   *  click for the same file landed in two different places. Routing it through `openPage` — the
+   *  one route an entity chip, a wikilink and an `artifact` event already take — is what makes
+   *  "the panel has one view slot" true of every way of reaching it rather than of most of them. */
   useEffect(() => {
     const onView = (e: Event) => {
       const d = (e as CustomEvent<ViewSlot>).detail;
       if (!d?.path) return;
-      setPagesCollapsed(false); saveCollapsed("right", false);
-      setDocPath(d.path); setDocSlug(d.workspace); setDocKind("doc");
-      setListing(null); setDocNonce((n) => n + 1);
+      openPage({ path: d.path, slug: d.workspace, label: d.label });
     };
     window.addEventListener(VIEW_NAVIGATE_EVENT, onView);
     return () => window.removeEventListener(VIEW_NAVIGATE_EVENT, onView);
-  }, []);
+  }, [openPage]);
 
   /** Walk the stack without disturbing it. A document closed since it was visited is REOPENED as a
    *  tab — going back to somewhere you have been should never fail because you tidied up. */

--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -762,27 +762,23 @@ export function MinutesShell() {
     return () => { window.removeEventListener(OPEN_ENTITY_EVENT, onEntityClick); window.removeEventListener(OPEN_MEETING_EVENT, onMeetingClick); };
   }, [meetings, openMeeting, openPage]);
 
-  // ── F41: A FILE THE TURN WROTE BECOMES A TAB ────────────────────────────────────────────────
+  // ── F41, AS AMENDED BY DECISION 28: A FILE THE TURN WROTE NAVIGATES THE VIEW ────────────────
   //
-  //  The founder created a shared workspace, the agent wrote its README, and the right panel stayed
-  //  on `_global/README.md` — the one document the turn had just made was the one thing not on
-  //  screen.
+  //  F41 was the founder creating a shared workspace, the agent writing its README, and the right
+  //  panel staying on `_global/README.md` — the one document the turn had just made was the one
+  //  thing not on screen. That fix appended a tab. Decision 28 is the correction TO that fix: a tab
+  //  exists only when one is asked for, so the write moves the view instead.
   //
-  //  Three rules, and the third is the one worth stating:
-  //    · the tab goes on the CHAT RECORD, not on panel-local state. Layout is a function of the
-  //      chat's state (decision 18), so a reload shows the same tabs — which is why this appends to
-  //      `pages` and lets the artifacts effect, the record's ONE writer, persist it.
-  //    · it comes to the FRONT only when the event says `focus: true`.
+  //  Two rules, and the second is the one worth stating:
+  //    · `focus: true` moves the view; `focus: false` does NOTHING VISIBLE. It used to append a tab
+  //      "quietly behind the reader", which is exactly the accumulation 28 removes — a turn that
+  //      writes four files must not leave four tabs nobody asked for.
   //    · …and never over a focus the READER chose. A person who has opened something is reading it;
-  //      an agent's write appears in the strip and waits. The tab still appears — being appended is
-  //      not conditional on anything.
-  //  Appending is idempotent by artifact key, so the same file written twice in a turn is one tab.
-  //  The decision itself is `artifactTabEffect` — pure, in roomView.ts, tested there. This is the
-  //  wiring: read the tabs in hand, apply it, and either bring the page forward through the ONE
-  //  route into the panel (`openPage`, which also unfolds a collapsed column and pushes history) or
-  //  append it quietly behind the reader.
-  const pagesRef = useRef(pages);
-  useEffect(() => { pagesRef.current = pages; }, [pages]);
+  //      their attention beats our suggestion.
+  //
+  //  The decision itself is `artifactViewEffect` — pure, in roomView.ts, tested there. This is the
+  //  wiring, and it is now one line: hand it to `openPage`, the ONE route into the panel, which
+  //  unfolds a collapsed column, pushes back/forward history and records the visit in the strip.
   useEffect(() => {
     const onArtifact = (e: Event) => {
       const detail = (e as CustomEvent<{ workspace?: string; path?: string; focus?: boolean }>).detail || {};

--- a/clients/terminal/src/minutes/__tests__/navigator.test.ts
+++ b/clients/terminal/src/minutes/__tests__/navigator.test.ts
@@ -13,7 +13,8 @@ import {
   MAX_HITS, NAV_OPEN_KEY, buildWorkspaces, filterByName, loadNavOpen, parseQuery,
   referencedWorkspaceIds, saveNavOpen, treeFrom, type NavWorkspace,
 } from "../navigatorApi";
-import { VIEW_NAVIGATE_EVENT, navigateView, viewSlotFor } from "../roomView";
+import { VIEW_NAVIGATE_EVENT, navigateView, pageForDocRef, viewSlotFor } from "../roomView";
+import { artifactKey, touchHistory } from "../chats";
 import type { ActiveMount } from "../../surfaces/workspaceApi";
 
 const mount = (over: Partial<ActiveMount> & { slug: string }): ActiveMount => ({
@@ -244,5 +245,42 @@ describe("the view slot — a click navigates, it does not collect (decision 28)
     navigateView(undefined, "../../etc/passwd");
     navigateView(undefined, "");
     expect(seen).toEqual([]);
+  });
+});
+
+describe("one mechanism: a navigator click and a chip click land in the same history", () => {
+  // The navigator was written against a STUB seam while the view slot was still on a branch, and
+  // the branch shipped the slot as an in-shell effect with no event. For a while the placeholder
+  // was the only definition, and its listener set the document state directly — so a navigator
+  // click skipped the back/forward stack and the strip, and the same file reached by two routes
+  // landed in two different places. This pins that they are one route.
+  it("both routes produce the SAME view slot for the same file", () => {
+    // what the navigator announces
+    const fromNavigator = viewSlotFor("acme-kg", "kg/brief.md");
+    // what a chip/link click resolves to (pageForDocRef, given a resolver answer)
+    const fromChip = pageForDocRef({ path: "kg/brief.md", slug: "acme-kg" },
+      { path: "kg/brief.md", slug: "acme-kg" })!;
+    expect(fromNavigator.path).toBe(fromChip.path);
+    expect(fromNavigator.workspace).toBe(fromChip.slug);
+    // and therefore the same identity in the strip — which is what "same history" means: one entry,
+    // moved, rather than two chips for one document
+    expect(artifactKey({ path: fromNavigator.path, slug: fromNavigator.workspace }))
+      .toBe(artifactKey({ path: fromChip.path, slug: fromChip.slug }));
+  });
+
+  it("a navigator click DEDUPES against a chip click in the strip, it does not add a second entry", () => {
+    const slot = viewSlotFor("acme-kg", "kg/brief.md");
+    const asArtifact = { path: slot.path, slug: slot.workspace, label: slot.label };
+    // chip first, navigator second — one entry, moved to the right edge
+    const afterChip = touchHistory([], asArtifact, 1);
+    const afterNav = touchHistory(afterChip, asArtifact, 2);
+    expect(afterNav).toHaveLength(1);
+    expect(afterNav[0].at).toBe(2);
+  });
+
+  it("the desk (no workspace) is the same slot either way", () => {
+    const nav = viewSlotFor("", "README.md");
+    expect(nav.workspace).toBeUndefined();
+    expect(artifactKey({ path: nav.path, slug: nav.workspace })).toBe("|README.md");
   });
 });

--- a/clients/terminal/src/minutes/roomView.ts
+++ b/clients/terminal/src/minutes/roomView.ts
@@ -155,7 +155,7 @@ export function pageForArtifact(ev: { workspace?: string; path?: string }): Page
 
 /** AN AGENT'S WRITE NAVIGATES THE VIEW; IT NEVER MINTS A TAB (PRD decision 28).
  *
- *  This replaces `artifactTabEffect`, which appended one. The founder's screenshot: seven tabs after
+ *  This replaces the REMOVED `artifactTabEffect`, which appended one. The founder's screenshot: seven tabs after
  *  a few chip clicks, and the same path rendered twice. *"we do not want to create new tab for every
  *  click, tab is only when tab is specifically requested."*
  *

--- a/clients/terminal/src/minutes/roomView.ts
+++ b/clients/terminal/src/minutes/roomView.ts
@@ -268,11 +268,16 @@ export function resolveView(spec: string | null | undefined, phasePages: Page[])
 /** A file clicked in the panel's navigator moves the panel's SINGLE view; it never mints a tab.
  *  Tabs are minted only by an explicit open-in-tab (middle-click, the row's ⧉) or by a scaffold.
  *
- *  STUB. Branch `panel-view-slot` owns the real thing — `view: {workspace, path}` on the chat
- *  record, with back/forward over it. What lives here is only the SEAM, so the navigator can be
- *  written against the final call and nothing has to be rewritten when the slot lands: the click
- *  ANNOUNCES a destination, the shell puts it in front, and the navigator keeps no state about
- *  what is being read. On the rebase this block goes and `navigateView` resolves to theirs.
+ *  This is THE seam, not a placeholder for one. The click ANNOUNCES a destination and the shell
+ *  puts it in front through `openPage` — the single route every other navigation already takes, so
+ *  a navigator click, an entity chip, a wikilink and an agent's `artifact` event all land in the
+ *  same view slot, the same back/forward stack and the same strip history. The navigator itself
+ *  keeps no state about what is being read.
+ *
+ *  It was written as a stub against a branch that had not landed, and that branch implemented the
+ *  slot as an in-shell effect with no event seam — so for a while the placeholder WAS the only
+ *  definition, and its listener set the document state directly, bypassing the history and the
+ *  strip. A navigator click and a chip click went to two different places. One mechanism now.
  *
  *  Deliberately an event and not a callback prop: it is the same shape as OPEN_ENTITY_EVENT and
  *  ARTIFACT_EVENT, which is how every other "something wants to be in front" already reaches the

--- a/clients/terminal/src/surfaces/__tests__/liveTurn.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/liveTurn.test.ts
@@ -1,0 +1,164 @@
+/** F66 — A RUNNING TURN MUST LOOK LIKE ONE.
+ *
+ *  Founder, watching an 18-step `entity_upsert` turn: *"i know it's working now, but it just stays
+ *  like it's stale — need to update animations or work etc."*
+ *
+ *  The cause was one word. Every op was appended with `status: "done"`, so the step line rendered a
+ *  green TICK from the first tool call and never moved again — an eighteen-step turn looked
+ *  finished eighteen times. These pin the corrected reducer end to end against a scripted stream:
+ *  what the ops look like WHILE it runs, and what they look like when it stops.
+ */
+import { describe, it, expect } from "vitest";
+import { joinInterim, streamChatTurn, type ChatStreamCallbacks } from "../chatStream";
+import type { Op } from "../../workbench/agent-window";
+
+function sseResponse(chunks: string[]): Response {
+  const enc = new TextEncoder();
+  let i = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(c) { if (i < chunks.length) c.enqueue(enc.encode(chunks[i++])); else c.close(); },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+const ev = (o: Record<string, unknown>) => `data: ${JSON.stringify(o)}\n\n`;
+
+/** The reducer the chat surface applies, in the order the stream delivers events. Mirrors
+ *  chat.tsx: a new tool closes the previous step, the turn's end closes the last one. */
+function runTurn(chunks: string[]) {
+  const seen: { ops: Op[][]; text: string[]; artifactsAt: number[] } = { ops: [], text: [], artifactsAt: [] };
+  let ops: Op[] = [];
+  let text = "";
+  let afterTool = false;
+  let events = 0;
+
+  const toolOp = (tool: string): Op => {
+    const name = tool.replace(/^mcp__[^_]+(?:_[^_]+)*?__/, "");
+    return { icon: "zap", label: name, status: "running" };
+  };
+  const settle = (l: Op[]) => l.map((o) => (o.status === "running" ? { ...o, status: "done" as const } : o));
+
+  const cb: ChatStreamCallbacks = {
+    onStarting: () => {},
+    onStatus: () => {},
+    onDelta: (t) => { events += 1; text = joinInterim(text, t, afterTool); afterTool = false; seen.text.push(text); },
+    onTool: (tool) => {
+      events += 1; afterTool = true;
+      ops = [...settle(ops), toolOp(tool)];
+      seen.ops.push(ops);
+    },
+    onArtifact: () => { seen.artifactsAt.push(events); },
+    onCommit: () => {},
+    onRejected: () => {},
+    onModelFailure: () => {},
+    onError: () => {},
+    onProgress: () => {},
+  };
+  return streamChatTurn(
+    { prompt: "p", session: "s", active: undefined },
+    cb,
+    { fetchImpl: (async () => sseResponse(chunks)) as unknown as typeof fetch, hardTimeoutMs: 2000,
+      signal: new AbortController().signal },
+  // NOTE: `renders` is the array of successive texts; `final` is the last one. Spreading a
+  // `text` key over `seen.text` is how the first version of this test silently compared a
+  // character count to a render count.
+  ).then(() => ({ renders: seen.text, ops: seen.ops, artifactsAt: seen.artifactsAt, finalOps: settle(ops), final: text }));
+}
+
+describe("the step line while a turn runs", () => {
+  it("every step is RUNNING as it arrives — never a tick mid-turn", async () => {
+    const out = await runTurn([
+      ev({ type: "tool-call", tool: "Read" }),
+      ev({ type: "tool-call", tool: "mcp__vexa__entity_upsert" }),
+      ev({ type: "tool-call", tool: "Bash" }),
+      ev({ type: "turn-complete" }), ev({ type: "done", ok: true }),
+    ]);
+    // at each moment the LAST op — the one the step line renders — is running
+    for (const snapshot of out.ops) {
+      expect(snapshot[snapshot.length - 1].status).toBe("running");
+    }
+    // and the ones before it have settled, so the line reads as progress rather than a pile
+    expect(out.ops[2].map((o) => o.status)).toEqual(["done", "done", "running"]);
+  });
+
+  it("the count ticks up, one per tool call", async () => {
+    const out = await runTurn([
+      ev({ type: "tool-call", tool: "Read" }),
+      ev({ type: "tool-call", tool: "Edit" }),
+      ev({ type: "tool-call", tool: "Bash" }),
+      ev({ type: "done", ok: true }),
+    ]);
+    expect(out.ops.map((o) => o.length)).toEqual([1, 2, 3]);
+  });
+
+  it("the tick comes ONLY at the end, and then for every step", async () => {
+    const out = await runTurn([
+      ev({ type: "tool-call", tool: "Read" }),
+      ev({ type: "tool-call", tool: "Bash" }),
+      ev({ type: "turn-complete" }), ev({ type: "done", ok: true }),
+    ]);
+    expect(out.finalOps.every((o) => o.status === "done")).toBe(true);
+    expect(out.finalOps).toHaveLength(2);
+  });
+
+  it("an MCP tool reads as its verb — `entity_upsert`, not `mcp__vexa__entity_upsert`", async () => {
+    const out = await runTurn([ev({ type: "tool-call", tool: "mcp__vexa__entity_upsert" }), ev({ type: "done", ok: true })]);
+    expect(out.finalOps[0].label).toBe("entity_upsert");
+  });
+});
+
+describe("interim text streams as it arrives", () => {
+  it("appears paragraph by paragraph, not in one block at the end (F40's separator)", async () => {
+    const out = await runTurn([
+      ev({ type: "message-delta", text: "First thought." }),
+      ev({ type: "tool-call", tool: "Read" }),
+      ev({ type: "message-delta", text: "Second thought." }),
+      ev({ type: "done", ok: true }),
+    ]);
+    // the reader saw text BEFORE the turn ended — two renders, growing
+    expect(out.renders.length).toBe(2);
+    expect(out.renders[0]).toBe("First thought.");
+    // and the tool call between them became a paragraph break, not a run-on
+    expect(out.renders[1]).toBe("First thought.\n\nSecond thought.");
+    expect(out.final).toBe("First thought.\n\nSecond thought.");
+  });
+});
+
+describe("an artifact navigates DURING the turn", () => {
+  it("fires as it arrives, not buffered until completion", async () => {
+    const out = await runTurn([
+      ev({ type: "message-delta", text: "a" }),
+      ev({ type: "artifact", workspace: "acme", path: "README.md", focus: true }),
+      ev({ type: "message-delta", text: "b" }),
+      ev({ type: "message-delta", text: "c" }),
+      ev({ type: "done", ok: true }),
+    ]);
+    // recorded after the 1st event and before the last two — i.e. mid-turn
+    expect(out.artifactsAt).toEqual([1]);
+  });
+});
+
+describe("the composer's state line", () => {
+  // the exact string the founder will read beside the stop button
+  const line = (busy: boolean, ops: Op[]) => {
+    const step = ops.length ? ops[ops.length - 1] : null;
+    const label = step ? (step.label.split(" · ").pop() ?? step.label) : "";
+    return busy
+      ? ["working", ops.length ? `${ops.length} step${ops.length === 1 ? "" : "s"}` : "", label].filter(Boolean).join(" · ")
+      : "";
+  };
+
+  it("reads `working · 18 steps · entity_upsert`", () => {
+    const ops = Array.from({ length: 18 }, (_, i) =>
+      ({ icon: "zap", label: i === 17 ? "entity_upsert" : "Read · x.md", status: "done" }) as Op);
+    expect(line(true, ops)).toBe("working · 18 steps · entity_upsert");
+  });
+
+  it("says `working` before any tool has run, and one STEP is singular", () => {
+    expect(line(true, [])).toBe("working");
+    expect(line(true, [{ icon: "zap", label: "Read · x.md", status: "running" }])).toBe("working · 1 step · x.md");
+  });
+
+  it("is CLEARED the moment the turn completes", () => {
+    expect(line(false, [{ icon: "zap", label: "entity_upsert", status: "done" }])).toBe("");
+  });
+});

--- a/clients/terminal/src/surfaces/chat.tsx
+++ b/clients/terminal/src/surfaces/chat.tsx
@@ -25,6 +25,9 @@ import { ARTIFACT_EVENT, ASK_CHAT_EVENT, CHAT_TOUCHED_EVENT, MACHINERY_MARK, WOR
 
 /** classify a tool name into one of the op icons so the operation line reads at a glance */
 function toolOp(tool: string, args?: Record<string, unknown>): Op {
+  // `mcp__vexa__entity_upsert` → `entity_upsert`. The namespace is ours, not the reader's, and the
+  // founder's own words for what he was watching were "entity_upsert".
+  tool = tool.replace(/^mcp__[^_]+(?:_[^_]+)*?__/, "");
   const t = tool.toLowerCase();
   // verb-first labels: the op line reads as what the agent is DOING, not an internal tool name
   const [icon, verb] = /read|cat|open/.test(t) ? [opIcon.read, "Reading"]
@@ -38,7 +41,20 @@ function toolOp(tool: string, args?: Record<string, unknown>): Op {
   const file = typeof args?.file_path === "string" ? (args.file_path as string) : undefined;
   const wrote = !!file && /edit|write|append|notebook/.test(t);
   const name = file ? file.split("/").filter(Boolean).pop() : undefined;
-  return { icon, label: name ? `${verb} · ${name}` : (verb === tool ? tool : `${verb} · ${tool}`), status: "done", file, wrote };
+  // RUNNING, not done (F66). Every op was appended with `status: "done"`, so the step line rendered
+  // a green TICK from the first tool call — an 18-step turn showed a finished-looking line that
+  // never moved. Founder: *"i know it's working now, but it just stays like it's stale."* The op
+  // that just started IS the one in progress; `onTool` marks the previous one done as it arrives,
+  // and the turn's end marks the last one.
+  return { icon, label: name ? `${verb} · ${name}` : (verb === tool ? tool : `${verb} · ${tool}`), status: "running", file, wrote };
+}
+
+/** Close any step still marked running — the turn is over, so nothing in it is in progress. Errors
+ *  keep their own status: a step that FAILED did not succeed because the turn ended. */
+function settleOps(ops: Op[]): Op[] {
+  return ops.some((o) => o.status === "running")
+    ? ops.map((o) => (o.status === "running" ? { ...o, status: "done" as const } : o))
+    : ops;
 }
 
 /** the backend history turn shape (GET /api/sessions/:session/history).
@@ -962,7 +978,11 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
             // chip in the reply that names this new file resolves to "not found" — which is the
             // whole reason a turn's own chips were dead on arrival.
             if (op.wrote) invalidateDocLinkCaches();
-            patchAgentTurn(key, agentId, (t) => ({ ...t, status: null, ops: [...t.ops, op] }));
+            // the step that was running has finished — the arrival of the next one IS its completion
+            patchAgentTurn(key, agentId, (t) => ({
+              ...t, status: null,
+              ops: [...t.ops.map((o) => (o.status === "running" ? { ...o, status: "done" as const } : o)), op],
+            }));
           },
           onCommit: (sha) => {
             invalidateDocLinkCaches();
@@ -992,12 +1012,16 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
             : "The agent didn't respond before timing out. Reopen the chat to see the reply if it lands." };
         });
       } else {
-        patchAgentTurn(key, agentId, (t) => ({ ...t, status: null }));  // clean end — drop any lingering status line
+        // THE TICK ONLY AT THE END (F66): the last step settles when the turn does, never before.
+        patchAgentTurn(key, agentId, (t) => ({ ...t, status: null, ops: settleOps(t.ops) }));
       }
     } catch (e) {
       if ((e as Error)?.name === "AbortError") patchAgentTurn(key, agentId, (t) => ({ ...t, status: null, text: (t.text ?? "") + (t.text ? "\n\n" : "") + "_stopped_" }));
       else patchAgentTurn(key, agentId, (t) => ({ ...t, status: null, text: (t.text ?? "") + (t.text ? "\n\n" : "") + presentError(e).headline }));
     } finally {
+      // whatever happened — abort, error, timeout — no step is left spinning. A spinner that
+      // outlives its turn is the same lie as a tick that precedes it.
+      patchAgentTurn(key, agentId, (t) => ({ ...t, ops: settleOps(t.ops) }));
       updateChatState(key, (s) => ({ ...s, busy: false, abort: null }));
     }
   };
@@ -1153,6 +1177,17 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
   const slash = value.startsWith("/");
   const skills = slash ? commands.querySkills(value) : [];
 
+  // F66 · THE COMPOSER SAYS WHAT IS HAPPENING. The step line lives up in the transcript, which
+  // scrolls away on a long turn — so the state also sits beside the stop button, where the reader's
+  // hand already is: "working · 18 steps · entity_upsert". Cleared the moment the turn completes.
+  const liveOps = busy ? (turns[turns.length - 1] as AgentTurn | undefined)?.ops ?? [] : [];
+  const liveStep = liveOps.length ? liveOps[liveOps.length - 1] : null;
+  const liveLabel = liveStep ? (liveStep.label.split(" · ").pop() ?? liveStep.label) : "";
+  const liveState = busy
+    ? ["working", liveOps.length ? `${liveOps.length} step${liveOps.length === 1 ? "" : "s"}` : "", liveLabel]
+        .filter(Boolean).join(" · ")
+    : "";
+
   const composer = (
     <>
       {slash && skills.length > 0 && (
@@ -1271,7 +1306,14 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
               : <Icon name="mic" size={15} />}
           </button>
           {busy
-            ? <button aria-label="Stop" title="Stop" onClick={stop} style={{ background: "var(--panel2)", color: "var(--t1)", border: "1px solid var(--line2)", width: 30, height: 30, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flex: "none" }}><span style={{ width: 10, height: 10, background: "var(--t1)", borderRadius: 2, display: "block" }} /></button>
+            ? <>
+              <span data-live-state title={liveState}
+                style={{ flex: "0 1 auto", minWidth: 0, marginRight: 8, fontFamily: "var(--mono)", fontSize: 11,
+                  color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {liveState}
+              </span>
+              <button aria-label="Stop" title="Stop" onClick={stop} style={{ background: "var(--panel2)", color: "var(--t1)", border: "1px solid var(--line2)", width: 30, height: 30, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flex: "none" }}><span style={{ width: 10, height: 10, background: "var(--t1)", borderRadius: 2, display: "block" }} /></button>
+            </>
             : <button aria-label="Send" disabled={uploading} onClick={() => void onSubmit()} style={{ background: "var(--accent)", color: "var(--on-accent)", border: "none", width: 30, height: 30, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", cursor: uploading ? "default" : "pointer", flex: "none", opacity: uploading ? 0.7 : 1 }}><Icon name="send" size={16} /></button>}
         </div>
       </div>

--- a/clients/terminal/src/workbench/agent-window.tsx
+++ b/clients/terminal/src/workbench/agent-window.tsx
@@ -36,11 +36,15 @@ function StatusLine({ status }: { status: TurnStatus }) {
   useEffect(() => { const t = setInterval(() => force((n) => n + 1), 1000); return () => clearInterval(t); }, []);
   const secs = Math.max(0, Math.floor((Date.now() - status.since) / 1000));
   const alert = status.phase === "reconnecting" || status.phase === "stalled";
+  // F66 (5): a turn can genuinely think for a long time. Past 30s of one phase the line says so in
+  // words — a spinner alone reads as hung, and "still working" is the difference between a product
+  // that is slow and a product that is broken.
+  const quiet = !alert && secs >= 30;
   const color = alert ? "var(--accent)" : "var(--t3)";
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4, fontSize: 12, color, fontFamily: "var(--mono)" }}>
       <span className="vx-op-spin" style={{ width: 11, height: 11, borderRadius: "50%", border: "1.5px solid var(--line2)", borderTopColor: color, flex: "none" }} />
-      <span>{PHASE_LABEL[status.phase]}{secs >= 2 ? ` · ${secs}s` : ""}{alert ? "" : "…"}</span>
+      <span data-turn-status>{quiet ? "still working" : PHASE_LABEL[status.phase]}{secs >= 2 ? ` · ${secs}s` : ""}{alert ? "" : "…"}</span>
     </div>
   );
 }
@@ -111,9 +115,12 @@ export function Conversation({ turns, busy, empty }: { turns: Turn[]; busy?: boo
               // must not grow the transcript vertically (founder ruling 2026-08-22).
               <div style={{ display: "flex", alignItems: "center", gap: 8, margin: "0 0 10px 5px" }}>
                 <OpRow op={t.ops[t.ops.length - 1]} />
-                {t.ops.length > 1 && (
-                  <span style={{ fontFamily: "var(--mono)", fontSize: 11, color: "var(--t3)", flex: "none" }}>· {t.ops.length} steps</span>
-                )}
+                {/* F66: the count ticks from the FIRST step. It used to appear only at two, so the
+                    one number that proves a long turn is moving was hidden exactly when the reader
+                    starts looking for it. */}
+                <span style={{ fontFamily: "var(--mono)", fontSize: 11, color: "var(--t3)", flex: "none" }}>
+                  · {t.ops.length} step{t.ops.length === 1 ? "" : "s"}
+                </span>
               </div>
             )}
             {t.text && <div style={{ fontSize: 13.5, color: "var(--t1)", lineHeight: 1.6, maxWidth: 680 }}>


### PR DESCRIPTION
Two commits: **F66** (a running turn must look like one) and the **navigator view seam** you flagged.

---

## F66 — the cause was one word

Founder, on an 18-step `entity_upsert` turn: *"i know it's working now, but it just stays like it's stale — need to update animations or work etc."*

`toolOp` returned **`status: "done"`**. Every step was appended already ticked, so the step line rendered a green check from the **first** tool call and never moved again — an eighteen-step turn looked finished eighteen times. `onTool` also cleared `status`, which removed the StatusLine, so after the first tool call the pane had nothing live on it at all: a tick, a frozen count, no spinner.

| | |
|---|---|
| a step is **running** while it runs | the arrival of the next tool call completes the previous one; the turn's end completes the last — so a tick means *finished*, which is what a tick has to mean or it means nothing |
| every exit path settles | `settleOps` in the `finally` — a spinner that outlives its turn is the same lie as a tick that precedes it. An op that **errored** keeps its status: it did not succeed because the turn ended |
| the count ticks from **step 1** | it appeared only at two, so the one number proving a long turn is moving was hidden exactly when the reader starts looking |
| `mcp__vexa__entity_upsert` → `entity_upsert` | the namespace is ours, not the reader's — and that is the founder's own word for what he was watching |
| the composer says it too | `working · 18 steps · entity_upsert` beside the stop button, cleared on completion. The step line scrolls away on a long turn; the state belongs where the reader's hand already is |
| past 30s in one phase | the line says **"still working"** in words. A spinner alone reads as hung — that is the difference between slow and broken |

**Verified, not changed** (you asked me to check, not assume): interim text already streams per event and `joinInterim` turns a tool call into a paragraph break; the `artifact` event is already forwarded the instant it arrives, not buffered. Both are now **pinned by tests** so they cannot regress quietly.

The tests drive the real `streamChatTurn` over a scripted SSE, and I checked they fail on the **original** bug — reverting that one word fails *"every step is RUNNING as it arrives"*.

> One test bug found and fixed in the writing, worth naming because it nearly passed silently: the harness returned `{...seen, text}`, so the spread overwrote the array of renders with the final string, and the assertion compared a **character count** to a render count.

---

## The navigator view seam — two mechanisms wearing one name

`navigateView` / `viewSlotFor` / `VIEW_NAVIGATE_EVENT` were written in `#1404` as a **stub**, against the view slot `#1405` was building. `#1405` then implemented the slot as an in-shell effect with **no event seam** — so the placeholder was never replaced. It became the only definition, and its listener set `docPath`/`docSlug` **directly**.

That bypassed `openPage`, which is the one route that unfolds the panel, pushes the back/forward stack, and records the visit in the strip. **A file reached from the navigator and the same file reached from an entity chip landed in two different places** — no history entry, no strip entry, and back/forward silently skipping everything the navigator had shown.

The seam **stays** — it is the right shape, and the same one `OPEN_ENTITY_EVENT` and `ARTIFACT_EVENT` already use. What changed is what sits behind it: the listener now calls `openPage`, so every way of putting a document in front is one route. The stub's comment went with it — *a placeholder that has become the definition is worse than either, because the next reader believes the real one is elsewhere.*

**Test:** both routes resolve the same file to the same slot and therefore the same `artifactKey`, and a navigator click after a chip click **dedupes** in the strip — one entry moved, not a second chip.

---

## Proof

**1004 tests, 94 files, all green. Cold minutes build green. No swap** — the terminal image is stage-1's to sequence. Rebased onto `6df487e64`.
