### PR TITLE
timeline: the agent knows what time it is — a person-scoped timeline (PRD decision 31)

### DIFF
--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -2411,8 +2411,12 @@ def create_app(
             # workspace is stored as `[[ws:<id>/<entity-id>]]` (PRD decision 26.3). Without it the
             # link resolves by TITLE in whichever mount the reader searches first, and dies the
             # moment either workspace is renamed — which is the ordinary case, not the edge.
+            # `dates` (decision 31 §3): the whitelisted temporal frontmatter — `scheduled_at`,
+            # `held_at`, `report_delivered_at`. Filtered and normalised in `upsert_entity`, so a
+            # caller cannot write an arbitrary key by naming it here.
             result = entities_mod.upsert_entity(target, kind, name, facts, source,
-                                                mounts=_entity_mounts(subject))
+                                                mounts=_entity_mounts(subject),
+                                                dates=body.get("dates"))
         except entities_mod.EntityRefused as e:
             # 422, not 400: the request is well-formed and the REFUSAL is the product — the agent is
             # meant to read the sentence and fix the fact, not to retry the call.

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -467,6 +467,64 @@
       "default": "(unset \u2014 derived per dispatch: minted by the dispatcher, never configured)",
       "description": "the short-lived scoped delegation token the dispatcher stamps into the WORKER's env (subject + regime + workspace scope + exp + jti); the worker writes it into its gitignored .claude/mcp.json as an Authorization header. Runtime-injected per dispatch, never a deploy surface",
       "targets": []
+    },
+    {
+      "key": "VEXA_OWNER",
+      "class": "defaulted",
+      "default": "(unset \u2014 derived per dispatch: the subject the dispatch acts for)",
+      "description": "the PERSON this dispatch acts for \u2014 the quota and credential-brokerage axis, and the subject the worker's timeline preamble is scoped to (PRD decision 31). Runtime-injected per dispatch, never a deploy surface",
+      "targets": []
+    },
+    {
+      "key": "VEXA_FLOWS_API_URL",
+      "class": "defaulted",
+      "default": "(unset \u2014 no timeline block)",
+      "description": "flows-api's base url, for the WORKER's read-only timeline route (GET /timeline?format=preamble). Unset \u21d2 the dispatch carries no temporal block and the turn behaves exactly as it did before decision 31",
+      "targets": []
+    },
+    {
+      "key": "VEXA_FLOWS_TIMELINE_KEY",
+      "class": "defaulted",
+      "default": "(unset \u2014 no timeline block)",
+      "secret": true,
+      "description": "the READ-ONLY key that opens flows-api's GET /timeline and nothing else (flows_api._timeline_key). This is the one to set: VEXA_FLOWS_API_KEY is the OPERATOR key and would let every worker container submit and activate flows",
+      "targets": []
+    },
+    {
+      "key": "VEXA_FLOWS_API_KEY",
+      "class": "defaulted",
+      "default": "(unset)",
+      "secret": true,
+      "description": "flows-api's OPERATOR key. Read here only as a fallback credential for the timeline preamble; prefer VEXA_FLOWS_TIMELINE_KEY, which cannot configure the machine",
+      "targets": []
+    },
+    {
+      "key": "VEXA_TIMELINE_CACHE_S",
+      "class": "defaulted",
+      "default": "60",
+      "description": "how long a subject's rendered timeline block is reused across dispatches \u2014 fresh enough that a meeting that just ended is in the next turn, cheap enough that three messages in a row cost one round-trip",
+      "targets": []
+    },
+    {
+      "key": "VEXA_TIMELINE_TIMEOUT_S",
+      "class": "defaulted",
+      "default": "3",
+      "description": "how long the worker waits for the timeline route before giving up on the block for this turn (a failure is cached like an answer)",
+      "targets": []
+    },
+    {
+      "key": "VEXA_TIMELINE_BACK",
+      "class": "defaulted",
+      "default": "5",
+      "description": "how many past events the per-dispatch timeline block states (decision 31 \u00a71: a handful of lines)",
+      "targets": []
+    },
+    {
+      "key": "VEXA_TIMELINE_AHEAD",
+      "class": "defaulted",
+      "default": "5",
+      "description": "how many scheduled meetings the per-dispatch timeline block states",
+      "targets": []
     }
   ],
   "capabilities": {

--- a/core/agent/control_plane/dispatch.py
+++ b/core/agent/control_plane/dispatch.py
@@ -520,6 +520,16 @@ def build_unit_env(settings: Settings, invocation: dict, *, unit_id: str, token:
             env.pop("VEXA_MCP_URL", None)
             logger.exception("mcp delegation mint refused for subject=%s regime=%s — worker runs "
                              "WITHOUT the vexa MCP", subject, regime)
+    # Temporal awareness (PRD decision 31 §1): the worker builds its own `now / last / next` block
+    # from flows-api's read-only timeline route, so it needs that route's address and a key. Passed
+    # through from THIS process's environment rather than from settings, and only when it is there:
+    # a deployment that has minted no timeline key gets no block, which is the correct default —
+    # `VEXA_FLOWS_API_KEY` is the OPERATOR key (it submits and activates flows), and putting it in
+    # a worker container to read a list of times would widen its reach by one container per turn.
+    # Mint `VEXA_FLOWS_TIMELINE_KEY` instead; `flows_api._timeline_key` accepts only that route.
+    for _var in ("VEXA_FLOWS_API_URL", "VEXA_FLOWS_TIMELINE_KEY"):
+        if os.environ.get(_var):
+            env[_var] = os.environ[_var]
     if settings.agent_model:
         env["VEXA_AGENT_MODEL"] = settings.agent_model
     if settings.meeting_model:

--- a/core/agent/shared/desk_now.py
+++ b/core/agent/shared/desk_now.py
@@ -1,0 +1,152 @@
+"""THE DESK README'S `Now` SECTION, built from the same dated facts the timeline reads.
+
+PRD decision 26.4 (founder, 2026-09-02 14:0xZ): the desk README *is* the desk, *"mostly links to
+the other cards in different workspaces"*, and one of its sections is `Now` — next meetings, open
+commitments. Decision 31 §3: *"the write-back phase files dated facts so the desk README's `Now`
+and the timeline agree"*.
+
+AGREE is the requirement, and it is why this module exists instead of a second query. The timeline
+reads the flows engine; the desk README reads the workspace. If the README derived its `Now` from
+its own prose — "the meeting is Thursday", written by a model that read a note — the two would
+drift silently the first time a meeting moved, and the person would be told two different things by
+one product on one screen. So the meeting PAGE carries the dates, `entity_upsert` is the only thing
+that writes them (`shared/entities.py`, the `dates` argument), and both readers read facts rather
+than sentences.
+
+Three frontmatter keys, all ISO-8601 UTC, all optional:
+
+    scheduled_at:        when it is meant to happen        → a next meeting
+    held_at:             when it actually ran              → it happened
+    report_delivered_at: when the write-up reached them    → the commitment is closed
+
+An OPEN COMMITMENT is exactly `held_at` set and `report_delivered_at` absent: the meeting happened
+and nothing has been delivered about it. That is a fact with a shape, not a judgement, which is the
+only kind of thing a section like this can be built out of.
+
+This module does NOT write the README. Whoever owns that file calls `render_now(root)` and drops
+the result between its markers — one loop, one write surface.
+"""
+from __future__ import annotations
+
+import datetime
+import re
+from pathlib import Path
+from typing import Optional
+
+from shared.entities import split_frontmatter
+
+MEETING_KIND = "meeting"
+DATE_FIELDS = ("scheduled_at", "held_at", "report_delivered_at")
+
+UTC = datetime.timezone.utc
+_FM_LINE = re.compile(r"^([A-Za-z_][A-Za-z0-9_\-]*)\s*:\s*(.*)$")
+
+# How far back a meeting whose write-up never arrived keeps asking. Beyond this it is history, not
+# a commitment — a `Now` section that still lists last month is a section people stop reading.
+OPEN_WINDOW_DAYS = 14
+
+
+def _epoch(value: str) -> Optional[float]:
+    text = str(value or "").strip().strip("'\"")
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        dt = datetime.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (dt if dt.tzinfo else dt.replace(tzinfo=UTC)).timestamp()
+
+
+def read_page(path: Path) -> dict:
+    """`{title, path, scheduled_at, held_at, report_delivered_at}` — epochs, absent keys omitted."""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    fm, _body = split_frontmatter(raw)
+    out: dict = {"path": str(path), "title": path.stem}
+    for line in fm:
+        m = _FM_LINE.match(line.strip())
+        if not m:
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        if key == "title" and value:
+            out["title"] = value.strip("'\"")
+        elif key == "template" and value.lower() in ("true", "yes"):
+            return {}                  # a shape is not a meeting (the entity-index rule, same list)
+        elif key in DATE_FIELDS:
+            at = _epoch(value)
+            if at is not None:
+                out[key] = at
+    return out
+
+
+def meetings(root) -> list[dict]:
+    """Every meeting page on this desk that carries at least one date. Order is not decided here."""
+    folder = Path(root) / "kg" / "entities" / MEETING_KIND
+    if not folder.is_dir():
+        return []
+    out = []
+    for f in sorted(folder.glob("*.md")):
+        page = read_page(f)
+        if page and any(k in page for k in DATE_FIELDS):
+            out.append(page)
+    return out
+
+
+def now_rows(root, *, now: Optional[float] = None, ahead: int = 5,
+             open_window_days: int = OPEN_WINDOW_DAYS) -> dict:
+    """`{"next": [...], "open": [...]}` — the two lists decision 26.4 names, from the pages.
+
+    `next`  — `scheduled_at` still ahead, soonest first, and never one that already has a
+              `held_at`: a meeting that ran is not still coming, whatever its calendar row says.
+    `open`  — `held_at` inside the window with no `report_delivered_at`. Most recent first, because
+              the write-up nobody has seen yet is the one most likely to still be wanted.
+    """
+    now = datetime.datetime.now(UTC).timestamp() if now is None else float(now)
+    floor = now - open_window_days * 86400
+    pages = meetings(root)
+    nxt = sorted((p for p in pages
+                  if p.get("scheduled_at", 0) > now and "held_at" not in p),
+                 key=lambda p: p["scheduled_at"])[:ahead]
+    opn = sorted((p for p in pages
+                  if floor <= p.get("held_at", 0) <= now and "report_delivered_at" not in p),
+                 key=lambda p: p["held_at"], reverse=True)
+    return {"next": nxt, "open": opn}
+
+
+def _stamp(epoch: float, tz: str = "") -> str:
+    z = UTC
+    if tz:
+        try:
+            import zoneinfo
+            z = zoneinfo.ZoneInfo(tz)
+        except Exception:  # noqa: BLE001
+            z = UTC
+    t = datetime.datetime.fromtimestamp(float(epoch), z)
+    return t.strftime("%a %d %b %H:%M ") + (t.tzname() or "UTC")
+
+
+def render_now(root, *, now: Optional[float] = None, tz: str = "", ahead: int = 5) -> str:
+    """The `Now` section body — LINKS, per decision 26.4, never prose about the links.
+
+    Returned without its heading and without the markers: the README's owner puts it where it goes.
+    Empty lists are stated, not hidden. "Nothing scheduled" is information; a section that silently
+    disappears when it has nothing to say reads as a bug the first time someone looks for it.
+    """
+    rows = now_rows(root, now=now, ahead=ahead)
+    out: list[str] = []
+    if rows["next"]:
+        for p in rows["next"]:
+            out.append(f"- {_stamp(p['scheduled_at'], tz)} — [[{p['title']}]]")
+    else:
+        out.append("- Nothing scheduled.")
+    if rows["open"]:
+        out.append("")
+        for p in rows["open"]:
+            out.append(f"- [[{p['title']}]] — held {_stamp(p['held_at'], tz)}, no write-up yet")
+    return "\n".join(out) + "\n"

--- a/core/agent/shared/entities.py
+++ b/core/agent/shared/entities.py
@@ -230,8 +230,54 @@ def _rewrite_links(root, facts, *, name: str, mounts) -> tuple[list, list]:
     return out, all_rewrites
 
 
+# ── dated facts (PRD decision 31 §3) ─────────────────────────────────────────────────────────────
+#
+# A meeting page carries WHEN, in frontmatter, so that the desk README's `Now` section and the
+# timeline read the same fact instead of two descriptions of it (`shared/desk_now.py` is the
+# reader). Three keys, closed set, ISO-8601 UTC. A closed set on purpose: an open one turns
+# frontmatter into a scratchpad, and the value of these is that a reader knows what it will find.
+DATE_FIELDS = ("scheduled_at", "held_at", "report_delivered_at")
+
+
+def _as_iso(value) -> str:
+    """ISO-8601 `Z` from an epoch or an ISO string; "" for anything else.
+
+    Naive strings are UTC: every timestamp this system writes is UTC, and guessing local would move
+    a meeting by hours on a host whose clock is not the deployment's, silently.
+    """
+    import datetime as _dt
+    if value in (None, "", []):
+        return ""
+    if isinstance(value, (int, float)):
+        dt = _dt.datetime.fromtimestamp(float(value), _dt.timezone.utc)
+    else:
+        text = str(value).strip()
+        try:
+            dt = _dt.datetime.fromtimestamp(float(text), _dt.timezone.utc)
+        except ValueError:
+            try:
+                dt = _dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+            except ValueError:
+                return ""
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=_dt.timezone.utc)
+    return dt.astimezone(_dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _dated(dates) -> dict:
+    """The whitelisted, normalised subset of what a caller passed. Anything else is dropped."""
+    if not isinstance(dates, dict):
+        return {}
+    out = {}
+    for key in DATE_FIELDS:
+        iso = _as_iso(dates.get(key))
+        if iso:
+            out[key] = iso
+    return out
+
+
 def upsert_entity(root, kind: str, name: str, facts, source: str, *,
-                  today: str | None = None, aliases=(), mounts=None) -> dict:
+                  today: str | None = None, aliases=(), mounts=None, dates=None) -> dict:
     """Create ``kg/entities/<kind>/<slug>.md`` with frontmatter and a first dated entry, or append a
     dated entry to the page already there. Returns what happened, in the caller's words.
 
@@ -245,13 +291,21 @@ def upsert_entity(root, kind: str, name: str, facts, source: str, *,
     id form ``[[ws:<workspace-id>/<entity-id>]]`` before it is stored, so the link survives that
     workspace being renamed. The home workspace always wins — a name with a page HERE is left alone,
     because the reader's own desk is the page they meant. Omitting ``mounts`` is the single-workspace
-    behaviour, byte-identical to before."""
+    behaviour, byte-identical to before.
+
+    ``dates`` records WHEN, in frontmatter, for the keys in ``DATE_FIELDS`` — `scheduled_at`,
+    `held_at`, `report_delivered_at`. It is how the desk README's `Now` section and the timeline
+    stay in agreement (decision 31 §3): both read these fields, neither parses prose. A dates-only
+    call is a real change and is reported as one, but it appends NO dated entry — the page's body
+    is the record of what was learned, and "the report went out" is not a new fact about the
+    meeting, it is a property of it."""
     root = Path(root)
     src = str(source or "").strip()
     facts = [str(f).strip() for f in (facts or []) if str(f).strip()]
-    if not facts:
+    stamps = _dated(dates)
+    if not facts and not stamps:
         raise EntityRefused("nothing to record — pass the facts this turn learned, or say nothing new")
-    if not src:
+    if not src and facts:
         raise EntityRefused(
             "every fact needs a source: what was said or read that this came from (the meeting, the "
             "mail, the file, the person's own words). A page carries only what was said or read — "
@@ -279,15 +333,17 @@ def upsert_entity(root, kind: str, name: str, facts, source: str, *,
         unresolved = [n for n in unresolved if n not in crossed]
     day = _today(today)
 
-    if existed and not fresh:
+    new_stamps = {k: v for k, v in stamps.items() if _fm_get(fm, k) != v}
+    if existed and not fresh and not new_stamps:
         return {"path": rel, "created": False, "changed": False, "facts_written": 0,
                 "already_recorded": len(facts), "links_resolved": resolved,
-                "links_missing": unresolved, "links_rewritten": rewritten, "kind": kind, "name": name}
+                "links_missing": unresolved, "links_rewritten": rewritten,
+                "kind": kind, "name": name, "dates": {}}
 
     if not existed:
         fm = [f"type: {kind}", f"id: {slugify(name)}", f"title: {name}",
               f"aliases: {_render_list(aliases)}", f"created: {day}",
-              f"sources: {_render_list([src])}"]
+              f"sources: {_render_list([s_ for s_ in [src] if s_])}"]
         body = f"\n# {name}\n"
     else:
         # A page that predates this module (or one a human wrote) may carry none of these keys.
@@ -301,17 +357,21 @@ def upsert_entity(root, kind: str, name: str, facts, source: str, *,
         if _fm_get(fm, "created") is None:
             fm = _fm_set(fm, "created", day)
         fm = _fm_set(fm, "aliases", _render_list(_list_field(_fm_get(fm, "aliases")) + list(aliases)))
-        fm = _fm_set(fm, "sources", _render_list(_list_field(_fm_get(fm, "sources")) + [src]))
+        if src:
+            fm = _fm_set(fm, "sources", _render_list(_list_field(_fm_get(fm, "sources")) + [src]))
 
-    written = fresh or facts
-    entry = [f"\n## {day}\n"] + [f"- {f} — source: {src}" for f in written] + [""]
-    body = body.rstrip("\n") + "\n" + "\n".join(entry)
+    for key, value in new_stamps.items():
+        fm = _fm_set(fm, key, value)
+    written = fresh if existed else facts
+    if written:
+        entry = [f"\n## {day}\n"] + [f"- {f} — source: {src}" for f in written] + [""]
+        body = body.rstrip("\n") + "\n" + "\n".join(entry)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("---\n" + "\n".join(fm) + "\n---\n" + body.lstrip("\n"), encoding="utf-8")
     return {"path": rel, "created": not existed, "changed": True, "facts_written": len(written),
             "already_recorded": len(facts) - len(written), "links_resolved": resolved,
-            "links_missing": unresolved, "links_rewritten": rewritten, "kind": kind, "name": name,
-            "date": day}
+            "links_missing": unresolved, "links_rewritten": rewritten, "kind": kind,
+            "name": name, "date": day, "dates": new_stamps}
 
 
 # ── candidate names, mechanically (the phase's pre-pass) ─────────────────────────────────────────

--- a/core/agent/shared/timeline.py
+++ b/core/agent/shared/timeline.py
@@ -1,0 +1,110 @@
+"""TEMPORAL AWARENESS IN CONTEXT, every turn — PRD decision 31 §1.
+
+Founder, 2026-09-02 15:5xZ: *"does the agent have temporal awareness of the last events and future
+events? scheduled meetings, the things that actually get logged in the flows data"*. It did not: it
+could look things up when asked, and had no sense of now, of recent, or of next. An agent with no
+now answers "this morning" out of the training data.
+
+This is the TEMPORAL half of the per-dispatch fact block, kept as its own function on purpose. The
+other half — which chat, which meeting, which page is open (decision 30 §2) — is composed
+elsewhere and by someone else; a block with two authors is a block that loses one author's edits,
+which is the one invariant `graph/sg/Operating-Loops.md` states in a single line. Whoever composes
+the human-surface block calls `timeline_preamble()` and appends what it returns.
+
+WHERE THE WORK HAPPENS. Nothing here reads a database, and nothing here formats a time. The route
+(`flows-api GET /timeline?format=preamble`) does both, because the person's zone lives in their
+`.settings.json` — which flows already reads — and because the control-MCP `timeline` tool renders
+the same payload through the same function. Two renderers is how a chat and a machinery note end up
+disagreeing about when a meeting was.
+
+COST. One HTTP call per subject per minute, three-second timeout, and a FAILURE IS CACHED TOO: a
+flows-api that is down must cost this worker three seconds an hour, not three seconds a turn.
+
+CREDENTIAL. `VEXA_FLOWS_TIMELINE_KEY` is a read-only key that opens exactly this route (see
+`flows_api._timeline_key`). The operator key also works, and a deployment that puts THAT in a
+worker container has handed every worker the ability to submit flows — so the narrow one is the one
+to set. No key ⇒ no block, silently: a worker that cannot see the timeline behaves exactly as it
+did before the timeline existed.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+log = logging.getLogger(__name__)
+
+CACHE_TTL_S = float(os.environ.get("VEXA_TIMELINE_CACHE_S", "60"))
+TIMEOUT_S = float(os.environ.get("VEXA_TIMELINE_TIMEOUT_S", "3"))
+BACK = int(os.environ.get("VEXA_TIMELINE_BACK", "5"))
+AHEAD = int(os.environ.get("VEXA_TIMELINE_AHEAD", "5"))
+
+# subject -> (expires_at, rendered block). "" is a legitimate cached value: see COST above.
+_CACHE: dict[str, tuple[float, str]] = {}
+
+
+def _api() -> str:
+    return (os.environ.get("VEXA_FLOWS_API_URL") or "").rstrip("/")
+
+
+def _key() -> str:
+    return ((os.environ.get("VEXA_FLOWS_TIMELINE_KEY") or "").strip()
+            or (os.environ.get("VEXA_FLOWS_API_KEY") or "").strip())
+
+
+def subject() -> str:
+    """WHO this dispatch acts for. `VEXA_OWNER` is the dispatcher's own word for it (dispatch.py:
+    *"Quota keys on the PERSON (VEXA_OWNER = subject)"*); the principal's address is the fallback
+    for a dispatch that predates it, and the route accepts either form."""
+    return ((os.environ.get("VEXA_OWNER") or "").strip()
+            or (os.environ.get("VEXA_PRINCIPAL_EMAIL") or "").strip())
+
+
+def fetch(uid: str, *, back: int = BACK, ahead: int = AHEAD, timeout: float = TIMEOUT_S) -> str:
+    """The rendered block for one person, or "". NEVER raises — see the module docstring."""
+    api, key = _api(), _key()
+    if not api or not key or not uid:
+        return ""
+    # The window is the route's default (14 back, 30 forward); `limit` is what the block can hold.
+    url = f"{api}/timeline?subject={urllib.parse.quote(str(uid))}&format=preamble&limit={back + ahead}"
+    req = urllib.request.Request(url, method="GET", headers={"X-Flows-Admin-Key": key})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            body = json.loads(r.read().decode() or "{}")
+    except Exception as e:  # noqa: BLE001 — a missing timeline degrades the turn, never fails it
+        log.debug("timeline unavailable for %s: %s: %s", uid, type(e).__name__, e)
+        return ""
+    text = body.get("text") if isinstance(body, dict) else None
+    return text if isinstance(text, str) else ""
+
+
+def timeline_preamble(uid: str = "", *, now: float | None = None) -> str:
+    """`now` in the person's zone, their last few events and their next few — for the turn prompt.
+
+    Cached per subject for `CACHE_TTL_S` (60 s): the block is refreshed often enough that a meeting
+    that just ended is in the next turn's context, and rarely enough that a person typing three
+    messages in a row does not pay for three round-trips.
+    """
+    uid = str(uid or subject() or "").strip()
+    if not uid:
+        return ""
+    now = time.time() if now is None else float(now)
+    hit = _CACHE.get(uid)
+    if hit and hit[0] > now:
+        return hit[1]
+    block = fetch(uid)
+    _CACHE[uid] = (now + CACHE_TTL_S, block)
+    return block
+
+
+def invalidate(uid: str = "") -> None:
+    """Forget one subject's cached block, or all of them. For tests and for a caller that has just
+    made the timeline wrong (a meeting booked, a report sent) and wants the next turn to see it."""
+    if uid:
+        _CACHE.pop(str(uid), None)
+    else:
+        _CACHE.clear()

--- a/core/agent/tests/test_desk_now.py
+++ b/core/agent/tests/test_desk_now.py
@@ -1,0 +1,158 @@
+"""Dated facts on a meeting page, and the desk README's `Now` read from them.
+
+PRD decision 26.4 (`Now` = next meetings, open commitments) and decision 31 §3 (*"the write-back
+phase files dated facts so the desk README's `Now` and the timeline agree"*). AGREE is the whole
+requirement: both readers read the same three frontmatter keys, and neither parses a sentence.
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from shared import desk_now
+from shared.entities import EntityRefused, upsert_entity
+
+UTC = datetime.timezone.utc
+NOW = 1_788_362_400.0                       # 2026-09-02 15:20Z
+HOUR = 3600.0
+
+
+def _iso(epoch):
+    return (datetime.datetime.fromtimestamp(epoch, UTC)
+            .isoformat(timespec="seconds").replace("+00:00", "Z"))
+
+
+# ── the write ────────────────────────────────────────────────────────────────────────────────────
+
+def test_a_meeting_page_carries_when_it_happened(tmp_path):
+    out = upsert_entity(tmp_path, "meeting", "ASWF DNA TSC", ["The TSC met for the first time."],
+                        "the transcript", today="2026-09-02",
+                        dates={"held_at": NOW - HOUR, "report_delivered_at": _iso(NOW)})
+    text = (tmp_path / out["path"]).read_text()
+    assert f"held_at: {_iso(NOW - HOUR)}" in text
+    assert f"report_delivered_at: {_iso(NOW)}" in text
+    assert out["dates"] == {"held_at": _iso(NOW - HOUR), "report_delivered_at": _iso(NOW)}
+
+
+def test_an_epoch_and_an_iso_string_land_identically(tmp_path):
+    a = upsert_entity(tmp_path / "a", "meeting", "M", ["x"], "s", dates={"held_at": NOW})
+    b = upsert_entity(tmp_path / "b", "meeting", "M", ["x"], "s", dates={"held_at": _iso(NOW)})
+    assert a["dates"] == b["dates"] == {"held_at": _iso(NOW)}
+
+
+def test_a_naive_timestamp_is_read_as_utc(tmp_path):
+    out = upsert_entity(tmp_path, "meeting", "M", ["x"], "s",
+                        dates={"held_at": "2026-09-02T15:20:00"})
+    assert out["dates"]["held_at"] == "2026-09-02T15:20:00Z"
+
+
+def test_a_key_outside_the_closed_set_is_dropped(tmp_path):
+    """Frontmatter is a contract, not a scratchpad: `Now` can only be built on keys it knows."""
+    out = upsert_entity(tmp_path, "meeting", "M", ["x"], "s",
+                        dates={"held_at": NOW, "cancelled_at": NOW, "notes": "whatever"})
+    assert out["dates"] == {"held_at": _iso(NOW)}
+    assert "cancelled_at" not in (tmp_path / out["path"]).read_text()
+
+
+def test_an_unparseable_date_is_dropped_not_written(tmp_path):
+    out = upsert_entity(tmp_path, "meeting", "M", ["x"], "s", dates={"held_at": "thursday-ish"})
+    assert out["dates"] == {}
+
+
+def test_a_dates_only_call_changes_the_page_without_a_new_entry(tmp_path):
+    """*The report went out* is a property of the meeting, not a new fact about it — the body is
+    the record of what was LEARNED, and stamping it would grow the page on every delivery."""
+    first = upsert_entity(tmp_path, "meeting", "M", ["The TSC met."], "the transcript",
+                          today="2026-09-02", dates={"held_at": NOW - HOUR})
+    before = (tmp_path / first["path"]).read_text()
+    second = upsert_entity(tmp_path, "meeting", "M", [], "", dates={"report_delivered_at": NOW})
+    after = (tmp_path / second["path"]).read_text()
+    assert second["changed"] is True and second["facts_written"] == 0
+    assert after.count("## 2026-09-02") == before.count("## 2026-09-02")
+    assert f"report_delivered_at: {_iso(NOW)}" in after
+    assert "The TSC met." in after
+
+
+def test_the_same_date_twice_writes_nothing(tmp_path):
+    """The write-back phase runs every turn; a no-op has to stay a no-op."""
+    upsert_entity(tmp_path, "meeting", "M", ["x"], "s", dates={"held_at": NOW})
+    again = upsert_entity(tmp_path, "meeting", "M", ["x"], "s", dates={"held_at": NOW})
+    assert again["changed"] is False and again["dates"] == {}
+
+
+def test_nothing_at_all_is_still_refused(tmp_path):
+    with pytest.raises(EntityRefused):
+        upsert_entity(tmp_path, "meeting", "M", [], "", dates={})
+
+
+def test_a_fact_still_needs_a_source(tmp_path):
+    with pytest.raises(EntityRefused):
+        upsert_entity(tmp_path, "meeting", "M", ["The TSC met."], "", dates={"held_at": NOW})
+
+
+# ── the read ─────────────────────────────────────────────────────────────────────────────────────
+
+def _desk(tmp_path):
+    upsert_entity(tmp_path, "meeting", "DNA TSC", ["It met."], "the transcript",
+                  dates={"held_at": NOW - 2 * HOUR, "report_delivered_at": NOW - HOUR})
+    upsert_entity(tmp_path, "meeting", "Weekly sync", ["It met."], "the transcript",
+                  dates={"held_at": NOW - 3 * HOUR})
+    upsert_entity(tmp_path, "meeting", "Board review", ["It is booked."], "the invite",
+                  dates={"scheduled_at": NOW + 26 * HOUR})
+    upsert_entity(tmp_path, "meeting", "Standup", ["It is booked."], "the invite",
+                  dates={"scheduled_at": NOW + 2 * HOUR})
+    return tmp_path
+
+
+def test_now_reads_the_dates_the_phase_wrote(tmp_path):
+    rows = desk_now.now_rows(_desk(tmp_path), now=NOW)
+    assert [p["title"] for p in rows["next"]] == ["Standup", "Board review"]
+    assert [p["title"] for p in rows["open"]] == ["Weekly sync"]
+
+
+def test_a_delivered_write_up_closes_the_commitment(tmp_path):
+    desk = _desk(tmp_path)
+    assert "Weekly sync" in [p["title"] for p in desk_now.now_rows(desk, now=NOW)["open"]]
+    upsert_entity(desk, "meeting", "Weekly sync", [], "", dates={"report_delivered_at": NOW})
+    assert desk_now.now_rows(desk, now=NOW)["open"] == []
+
+
+def test_a_meeting_that_ran_is_not_still_coming(tmp_path):
+    """A calendar row can keep a future `scheduled_at` after the fact. `held_at` settles it."""
+    upsert_entity(tmp_path, "meeting", "Moved", ["It ran early."], "the transcript",
+                  dates={"scheduled_at": NOW + 5 * HOUR, "held_at": NOW - HOUR,
+                         "report_delivered_at": NOW})
+    assert desk_now.now_rows(tmp_path, now=NOW)["next"] == []
+
+
+def test_an_old_undelivered_meeting_stops_asking(tmp_path):
+    upsert_entity(tmp_path, "meeting", "Ancient", ["It met."], "the transcript",
+                  dates={"held_at": NOW - 40 * 86400})
+    assert desk_now.now_rows(tmp_path, now=NOW)["open"] == []
+
+
+def test_pages_with_no_dates_and_templates_are_not_meetings(tmp_path):
+    upsert_entity(tmp_path, "meeting", "Undated", ["It happened sometime."], "a note")
+    folder = tmp_path / "kg" / "entities" / "meeting"
+    (folder / "shape.md").write_text("---\ntype: meeting\ntitle: Shape\ntemplate: true\n"
+                                     f"held_at: {_iso(NOW - HOUR)}\n---\n")
+    assert desk_now.meetings(tmp_path) == []
+
+
+def test_a_desk_with_no_meeting_pages_answers_empty(tmp_path):
+    assert desk_now.meetings(tmp_path) == []
+    assert desk_now.now_rows(tmp_path, now=NOW) == {"next": [], "open": []}
+
+
+def test_now_renders_links_not_prose(tmp_path):
+    """Decision 26.4: the desk README is *a hub of links, not prose*."""
+    out = desk_now.render_now(_desk(tmp_path), now=NOW, tz="Europe/Lisbon")
+    assert "[[Standup]]" in out and "[[Weekly sync]]" in out
+    assert "WEST" in out                                    # a time always carries its zone
+    assert out.index("[[Standup]]") < out.index("[[Board review]]")
+    assert "no write-up yet" in out
+
+
+def test_an_empty_now_says_so_rather_than_vanishing(tmp_path):
+    assert desk_now.render_now(tmp_path, now=NOW).strip() == "- Nothing scheduled."

--- a/core/agent/tests/test_timeline_preamble.py
+++ b/core/agent/tests/test_timeline_preamble.py
@@ -1,0 +1,180 @@
+"""Temporal awareness in context, every turn — PRD decision 31 §1 (the agent half).
+
+What the flows route renders is proven in `core/flows/tests/test_timeline_render.py`. What is
+proven here is the part this service owns: that the block reaches the turn prompt, that it costs
+one call a minute, and that nothing about it can fail a turn.
+"""
+from __future__ import annotations
+
+import pytest
+
+from shared import timeline as T
+from worker import engine
+
+BLOCK = ("## Where this person is in time\n\n**Now: Wednesday 02 September 2026, 16:20 WEST.** "
+         "State times in this zone.\n\nLast events concerning them:\n"
+         "  12:23 WEST  invite.received  ASWF DNA TSC\n")
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    T.invalidate()
+    yield
+    T.invalidate()
+
+
+def _configured(monkeypatch):
+    monkeypatch.setenv("VEXA_FLOWS_API_URL", "http://flows:18200")
+    monkeypatch.setenv("VEXA_FLOWS_TIMELINE_KEY", "a-read-only-key")
+    monkeypatch.setenv("VEXA_OWNER", "126")
+
+
+# ── the subject ──────────────────────────────────────────────────────────────────────────────────
+
+def test_the_subject_is_the_dispatch_owner(monkeypatch):
+    monkeypatch.setenv("VEXA_OWNER", "126")
+    monkeypatch.setenv("VEXA_PRINCIPAL_EMAIL", "admin@vexa.ai")
+    assert T.subject() == "126"
+
+
+def test_the_principal_address_is_the_fallback(monkeypatch):
+    monkeypatch.delenv("VEXA_OWNER", raising=False)
+    monkeypatch.setenv("VEXA_PRINCIPAL_EMAIL", "admin@vexa.ai")
+    assert T.subject() == "admin@vexa.ai"
+
+
+# ── the degrade path — every branch of it returns "" and none of them raises ─────────────────────
+
+def test_no_route_configured_means_no_block(monkeypatch):
+    monkeypatch.delenv("VEXA_FLOWS_API_URL", raising=False)
+    monkeypatch.setenv("VEXA_FLOWS_TIMELINE_KEY", "k")
+    assert T.fetch("126") == ""
+
+
+def test_no_key_means_no_block(monkeypatch):
+    """A worker with no credential behaves exactly as it did before the timeline existed."""
+    monkeypatch.setenv("VEXA_FLOWS_API_URL", "http://flows:18200")
+    monkeypatch.delenv("VEXA_FLOWS_TIMELINE_KEY", raising=False)
+    monkeypatch.delenv("VEXA_FLOWS_API_KEY", raising=False)
+    assert T.fetch("126") == ""
+
+
+def test_no_subject_means_no_block(monkeypatch):
+    monkeypatch.delenv("VEXA_OWNER", raising=False)
+    monkeypatch.delenv("VEXA_PRINCIPAL_EMAIL", raising=False)
+    assert T.timeline_preamble() == ""
+
+
+def test_a_route_that_is_down_costs_the_turn_nothing(monkeypatch):
+    _configured(monkeypatch)
+    monkeypatch.setattr(T.urllib.request, "urlopen",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("connection refused")))
+    assert T.timeline_preamble() == ""
+
+
+def test_a_route_that_answers_nonsense_is_ignored_not_pasted(monkeypatch):
+    _configured(monkeypatch)
+    monkeypatch.setattr(T, "fetch", lambda uid, **kw: "")
+    assert T.timeline_preamble("126") == ""
+
+
+# ── the cache ────────────────────────────────────────────────────────────────────────────────────
+
+def test_one_call_a_minute_however_many_turns(monkeypatch):
+    _configured(monkeypatch)
+    calls = []
+    monkeypatch.setattr(T, "fetch", lambda uid, **kw: calls.append(uid) or BLOCK)
+    assert T.timeline_preamble("126", now=1000.0) == BLOCK
+    assert T.timeline_preamble("126", now=1030.0) == BLOCK
+    assert calls == ["126"]
+
+
+def test_the_block_refreshes_after_the_ttl(monkeypatch):
+    _configured(monkeypatch)
+    calls = []
+    monkeypatch.setattr(T, "fetch", lambda uid, **kw: calls.append(uid) or BLOCK)
+    T.timeline_preamble("126", now=1000.0)
+    T.timeline_preamble("126", now=1000.0 + T.CACHE_TTL_S + 1)
+    assert len(calls) == 2
+
+
+def test_a_failure_is_cached_too(monkeypatch):
+    """A flows-api that is down must cost this worker one timeout a minute, not one a turn."""
+    _configured(monkeypatch)
+    calls = []
+    monkeypatch.setattr(T, "fetch", lambda uid, **kw: calls.append(uid) or "")
+    assert T.timeline_preamble("126", now=1000.0) == ""
+    assert T.timeline_preamble("126", now=1030.0) == ""
+    assert calls == ["126"]
+
+
+def test_two_people_do_not_share_a_block(monkeypatch):
+    _configured(monkeypatch)
+    monkeypatch.setattr(T, "fetch", lambda uid, **kw: f"block for {uid}")
+    assert T.timeline_preamble("126", now=1000.0) == "block for 126"
+    assert T.timeline_preamble("204", now=1000.0) == "block for 204"
+
+
+def test_invalidate_forgets_one_or_all(monkeypatch):
+    _configured(monkeypatch)
+    seen = []
+    monkeypatch.setattr(T, "fetch", lambda uid, **kw: seen.append(uid) or BLOCK)
+    T.timeline_preamble("126", now=1000.0)
+    T.invalidate("126")
+    T.timeline_preamble("126", now=1000.0)
+    assert len(seen) == 2
+
+
+# ── it reaches the turn ──────────────────────────────────────────────────────────────────────────
+
+def test_the_block_ships_on_the_turn_prompt(tmp_path, monkeypatch):
+    """Decision 31 §1 is *in context every turn*. A sense of now that arrives only when asked for
+    is the lookup the decision replaced."""
+    seen = {}
+
+    def fake_run(work, prompt, harness, **kw):
+        seen["prompt"] = prompt
+        yield {"type": "done", "reply": "ok", "sessionId": "s"}
+
+    monkeypatch.setattr(engine, "run_harness_turn", fake_run)
+    monkeypatch.setattr(engine, "active_mounts",
+                        lambda: [{"slug": "desk-1", "path": str(tmp_path), "write": True,
+                                  "primary": True}])
+    monkeypatch.setattr(engine, "_ensure_repo", lambda w: None)
+    monkeypatch.setattr(engine, "timeline_preamble", lambda: BLOCK)
+
+    class H:
+        def prepare(self, work, chat_root=None):
+            pass
+
+        def transcript_bytes(self, work, sid):
+            return 0
+
+    list(engine.run_turn_over_workspace(tmp_path, "hello", harness=H(), commit=False))
+    assert "Where this person is in time" in seen["prompt"]
+    assert "16:20 WEST" in seen["prompt"]
+
+
+def test_a_turn_with_no_timeline_is_still_a_turn(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_run(work, prompt, harness, **kw):
+        seen["prompt"] = prompt
+        yield {"type": "done", "reply": "ok", "sessionId": "s"}
+
+    monkeypatch.setattr(engine, "run_harness_turn", fake_run)
+    monkeypatch.setattr(engine, "active_mounts",
+                        lambda: [{"slug": "desk-1", "path": str(tmp_path), "write": True,
+                                  "primary": True}])
+    monkeypatch.setattr(engine, "_ensure_repo", lambda w: None)
+    monkeypatch.setattr(engine, "timeline_preamble", lambda: "")
+
+    class H:
+        def prepare(self, work, chat_root=None):
+            pass
+
+        def transcript_bytes(self, work, sid):
+            return 0
+
+    list(engine.run_turn_over_workspace(tmp_path, "hello", harness=H(), commit=False))
+    assert "hello" in seen["prompt"] and "Where this person is in time" not in seen["prompt"]

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -39,6 +39,17 @@ from llm import (
 )
 from llm.errors import _AUTH_SIGNATURE_RE  # noqa: F401 — re-exported for the worker.worker shim
 from shared.seeding import resolve_seed_dir, seed_workspace, validate_seed
+# PRD decision 31 §1 — WHERE THIS PERSON IS IN TIME, on every dispatch (used in the preamble list
+# in `run_turn_over_workspace`). Imported rather than written here: the work is an HTTP read and a
+# cache, not prompt text, and what it returns is rendered by the flows route — the same rendering
+# the control-MCP `timeline` tool gets, so a chat and a machinery note cannot disagree about when
+# a meeting was.
+#
+# It stays its OWN call rather than a section of somebody else’s block: decision 30 §2’s
+# human-surface block (which chat, which meeting, which page is open) is composed by another hand,
+# and one surface with two writers is the failure `graph/sg/Operating-Loops.md` names in a line.
+# Whoever composes that block appends what this returns.
+from shared.timeline import timeline_preamble  # noqa: F401 — re-exported for the turn prompt
 
 log = logging.getLogger("agent_api.worker")
 
@@ -242,7 +253,6 @@ def kg_links_preamble(mounts: "list[dict] | None" = None) -> str:
         " them in a brief and never count them as prior context. If you hold nothing on a subject,"
         " say so — a shape is not a substitute for knowledge you do not have.\n\n"
     )
-
 
 # The rule text of PRD decision 24, and the index it is a rule about. One string, because the rule
 # is unreadable without the list and the list is inert without the rule.
@@ -480,6 +490,12 @@ def writeback_prompt(candidates: list[str]) -> str:
         "Do not judge whether a name is important enough or whether it is covered somewhere else. A "
         "meeting note is NOT a substitute for a page — it records an occasion, a page records a "
         "subject, and the point is that the next turn can find the subject.\n\n"
+        "For a MEETING, pass `dates` as well — `held_at` when you know it ran, "
+        "`report_delivered_at` when you know its write-up reached them, `scheduled_at` when it is "
+        "still ahead (ISO-8601 or epoch, any subset, only what this turn actually knows). Those "
+        "three fields are what the desk's `Now` section and `timeline` both read, so a meeting "
+        "that ran with no write-up shows as an open commitment without anyone writing a sentence "
+        "about it. A meeting page with no `dates` is a page nothing can order.\n\n"
         + _ENTITY_FILE_SHAPE +
         "A name you cannot say one sourced thing about does NOT get a page: append it to "
         "`kg/MISSING.md` as one line — the name and what you would need to know — in a single "
@@ -1034,7 +1050,8 @@ def run_turn_over_workspace(
     author = _principal_author()
     extras = _extra_mount_paths(work)
     turn_prompt = (voice_preamble() + kg_links_preamble(mounts) + mounts_preamble(mounts)
-                   + entity_index_preamble(mounts) + global_context_preamble(mounts)
+                   + entity_index_preamble(mounts) + timeline_preamble()
+                   + global_context_preamble(mounts)
                    + prompt)
     # THE PERSON'S HALF, WRITTEN DOWN SEPARATELY (F47) — see `record_user_text` for why the history
     # reader must never have to find it again by parsing the composed prompt above. Recorded BEFORE

--- a/core/flows/scripts/proof_timeline.py
+++ b/core/flows/scripts/proof_timeline.py
@@ -1,0 +1,135 @@
+"""OFFLINE PROOF of GET /timeline against a REAL lane database — read-only, no service running.
+
+Tries the sim lane's `flows_sim` first (the instruction's preference) and falls back to the founder
+lane's `flows`, saying which it used. Both are opened through the container's psql with the SERVER
+enforcing read-only (`default_transaction_read_only=on`), so the proof cannot write even by mistake;
+the only statements it issues are the two SELECTs `flows_timeline.service` issues in production.
+
+The meetings half is read the same way, straight from the `vexa` database, instead of over the
+gateway: the point of the check is the merge, the scoping and the order, and a live HTTP hop would
+add a moving part that proves nothing about any of them.
+
+Usage: python3 proof_timeline.py <uid> [YYYY-MM-DD]
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import datetime
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC))
+
+from flows_timeline import build_timeline           # noqa: E402
+from flows_timeline.model import event_from_meeting  # noqa: E402
+
+CONTAINER = "vexa-dogfood-postgres-1"
+UNIT, RECORD = "\x1f", "\x1e"
+
+
+class PsqlDB:
+    """A READ-ONLY `DB` — the same `execute(sql, params)` seam the engine speaks, over psql."""
+
+    dialect = "postgres"
+
+    def __init__(self, database: str) -> None:
+        self.database = database
+
+    def _quote(self, v) -> str:
+        if v is None:
+            return "NULL"
+        if isinstance(v, (int, float)):
+            return repr(float(v))
+        return "'" + str(v).replace("'", "''") + "'"
+
+    def execute(self, sql: str, params: dict | None = None) -> list[tuple]:
+        for key in sorted((params or {}), key=len, reverse=True):
+            sql = sql.replace(f":{key}", self._quote(params[key]))
+        out = subprocess.run(
+            ["docker", "exec", "-e", "PGOPTIONS=-c default_transaction_read_only=on", CONTAINER,
+             "psql", "-U", "postgres", "-d", self.database, "-At", "-F", UNIT, "-R", RECORD,
+             "-c", sql],
+            capture_output=True, text=True, check=True).stdout
+        rows = [r for r in out.split(RECORD) if r.strip()]
+        return [tuple(f if f != "" else None for f in r.split(UNIT)) for r in rows]
+
+    def executescript(self, sql: str) -> None:  # pragma: no cover — never called by a read
+        raise RuntimeError("read-only")
+
+
+def meetings_for(uid: str) -> list[dict]:
+    rows = PsqlDB("vexa").execute(
+        "SELECT id, status, start_time, end_time, created_at, data::text FROM meetings "
+        f"WHERE user_id = {int(uid)} ORDER BY id")
+    out = []
+    for mid, status, start, end, created, data in rows:
+        try:
+            blob = json.loads(data) if data else {}
+        except ValueError:
+            blob = {}
+        out.append({"id": mid, "status": status, "start_time": start, "end_time": end,
+                    "created_at": created, "data": blob})
+    return out
+
+
+def has_rows(database: str) -> bool:
+    try:
+        n = PsqlDB(database).execute("SELECT count(*) FROM reaction")[0][0]
+        return int(n or 0) > 0
+    except subprocess.CalledProcessError:
+        return False
+
+
+def main() -> int:
+    uid = sys.argv[1] if len(sys.argv) > 1 else "126"
+    day = sys.argv[2] if len(sys.argv) > 2 else datetime.date.today().isoformat()
+    start = datetime.datetime.fromisoformat(day + "T00:00:00+00:00").timestamp()
+
+    lane = "flows_sim" if has_rows("flows_sim") else "flows"
+    if lane == "flows":
+        print("the sim lane's flows_sim holds no reactions — reading the FOUNDER lane `flows`, "
+              "READ-ONLY through the container's psql (default_transaction_read_only=on)")
+    db = PsqlDB(lane)
+
+    # The identity: resolved from the same database the product resolves it from, read-only.
+    email = ""
+    for (addr,) in PsqlDB("vexa").execute(f"SELECT email FROM users WHERE id = {int(uid)}"):
+        email = str(addr or "").lower()
+    print(f"lane={lane}  uid={uid}  email={email or '(none)'}  day={day}\n")
+
+    out = build_timeline(db, uid, since=start, until=start + 86400, limit=100,
+                         now=start + 86400, meetings=meetings_for,
+                         identity=lambda _s: (uid, email))
+    for e in out["events"]:
+        produced = " ".join(f"{k}={v}" for k, v in sorted(e["produced"].items()))
+        print(f"  {e['at']}  {e['kind']:<20} {e['status']:<10} "
+              f"m={e.get('meeting_id') or '-':<5} {e['title'][:38]:<38} {produced[:90]}")
+
+    # The same payload, rendered the two ways the product renders it — the control-MCP tool
+    # (`format=text`) and the per-dispatch block (`format=preamble`), both in the person's zone.
+    from flows_timeline import render_preamble
+    tz = "Europe/Lisbon"
+    print("\n  --- format=preamble, tz=" + tz + " " + "-" * 40)
+    for row in render_preamble(out, tz).splitlines():
+        print("  " + row)
+
+    kinds = [e["kind"] for e in out["events"]]
+    want = ["invite.received", "mail.sent", "meeting.held", "report.delivered"]
+    pos, at = [], -1
+    for k in want:
+        try:
+            at = kinds.index(k, at + 1)
+        except ValueError:
+            at = -1
+            break
+        pos.append(at)
+    ats = [e["at_epoch"] for e in out["events"]]
+    print(f"\n  events: {len(kinds)}   ascending: {ats == sorted(ats)}")
+    print(f"  the DNA sequence {want} in order: {'YES at ' + str(pos) if at >= 0 else 'NO'}")
+    return 0 if at >= 0 and ats == sorted(ats) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -10,6 +10,10 @@
   POST /flows/{name}/{v}/activate   · POST /flows/{name}/{v}/retire
   GET  /reactions[?status=…]        the operator projection
   POST /reactions/{id}/{retry|resume|cancel}    the signal verbs (audited rows)
+  GET  /timeline?subject=…          ONE PERSON'S DAY, in order — facts, receipts and the
+                                    meetings table merged and scoped to them (PRD decision 31).
+                                    Read-only, and it takes the operator key OR the narrower
+                                    VEXA_FLOWS_TIMELINE_KEY (see `_timeline_key`).
 
 Auth: X-Flows-Admin-Key (env VEXA_FLOWS_API_KEY). NEVER accepts code — steps are reviewed Python
 in the image; this API composes them (the n8n line we do not cross).
@@ -42,7 +46,8 @@ from pydantic import BaseModel, Field  # noqa: E402
 from flows import Registry, SystemClock, admit, cancel, postgres_db, resume, retry, wake  # noqa: E402
 from flows_defs import production  # noqa: E402
 from flows_integrations import instance_gate  # noqa: E402
-from flows_steps.common import db_url, require_internal_secret  # noqa: E402
+from flows_steps.common import db_url, require_internal_secret, setting  # noqa: E402
+from flows_timeline import build_timeline, fetch_meetings, render_preamble, render_text  # noqa: E402
 
 def _require_api_key() -> str:
     """The operator key, or the process refuses to start.
@@ -71,6 +76,25 @@ def _require_api_key() -> str:
 
 
 API_KEY = _require_api_key()
+
+
+def _timeline_key() -> str:
+    """A SECOND key, for `GET /timeline` alone — or "" when the deployment has not minted one.
+
+    The timeline is read-only and the agent worker asks for it on EVERY dispatch (decision 31 §1),
+    so it needs a credential in every worker container. Handing those containers the OPERATOR key —
+    the one that submits and activates flows — to read a list of times would widen the operator
+    key's blast radius by one container per person per turn, which is the opposite of what the
+    key-hardening above was for. This is a key that can do exactly one thing.
+
+    Unset ⇒ only the operator key opens the route. That is the right default: a deployment that has
+    not thought about this gets the narrower reach (nobody but the operator), never the wider one.
+    """
+    key = (os.environ.get("VEXA_FLOWS_TIMELINE_KEY") or "").strip()
+    return "" if key in ("changeme", "change-me", "default", "secret") else key
+
+
+TIMELINE_KEY = _timeline_key()
 # The internal-tier identity, refused the same way and for the same reason. Read at import so an
 # unconfigured deployment stops HERE rather than at the first post-meeting run.
 INTERNAL_SECRET = require_internal_secret()
@@ -87,6 +111,13 @@ app = FastAPI(title="flows-api", version="0.1.0",
 def auth(x_flows_admin_key: str = Header(default="")) -> None:
     if x_flows_admin_key != API_KEY:
         raise HTTPException(status_code=401, detail="X-Flows-Admin-Key required")
+
+
+def timeline_auth(x_flows_admin_key: str = Header(default="")) -> None:
+    """The operator key opens everything, including this. The timeline key opens only this."""
+    if x_flows_admin_key == API_KEY or (TIMELINE_KEY and x_flows_admin_key == TIMELINE_KEY):
+        return
+    raise HTTPException(status_code=401, detail="X-Flows-Admin-Key required")
 
 
 def _refuse_if_gated(verb: str) -> None:
@@ -323,6 +354,67 @@ def signal_reaction(reaction_id: str, verb: str, x_actor: str = Header(default="
     if not ok:
         raise HTTPException(status_code=409, detail=f"{verb} not applicable in current status")
     return {verb: True}
+
+
+@app.get("/timeline", dependencies=[Depends(timeline_auth)])
+def timeline(subject: str = "", since: str = "", until: str = "", limit: int = 20,
+             meetings: bool = True, format: str = "json"):
+    """ONE PERSON'S DAY, IN ORDER — PRD decision 31.
+
+    Founder, 2026-09-02: *"does the agent have temporal awareness of the last events and future
+    events? scheduled meetings, the things that actually get logged in the flows data"*. It did
+    not, and the reason was not that the data was missing: every one of those moments is already a
+    reaction row or an effect receipt in this database. What was missing was a read along the axis
+    a person thinks in. This is that read.
+
+    `subject` is a platform uid or an email address, and the route resolves the OTHER one before it
+    scopes, because the invite lineage carries an organizer and no uid while the completed lineage
+    carries a uid and, without the resolution, nothing to match an address on. Scoping on one of
+    them silently returns half a day — see `flows_timeline.model.concerns`.
+
+    `since` / `until` take epoch seconds or ISO-8601; the default window straddles NOW (14 days
+    back, 30 forward) because half of what decision 31 asks for is in the future. `limit` keeps the
+    events NEAREST NOW, not the oldest rows the engine still holds.
+
+    Read-only: it admits nothing, signals nothing and writes nothing. It therefore stays open while
+    the instance gate is up, exactly like `GET /flows` and `GET /reactions` — an admin must be able
+    to see what the machine has done.
+
+    `meetings=false` drops the gateway hop and answers from this database alone — the offline shape,
+    used by the proof and by any caller that cannot reach the gateway.
+
+    `format=text` (a person asking, through the control MCP) and `format=preamble` (the same
+    person's agent, told unasked on every dispatch) add a rendered `text`, in THE SUBJECT'S OWN
+    ZONE — read here, from `setting(uid, "timezone")`, and not by the caller. That is deliberate:
+    two readers rendering the same payload is how a chat and a machinery note end up disagreeing
+    about one meeting, and the zone is a fact about the person, which this service can read and a
+    worker container cannot.
+    """
+    subj = (subject or "").strip()
+    if not subj:
+        raise HTTPException(status_code=400,
+                            detail="subject is required: a platform uid, or an email address")
+    if not (subj.isdigit() or "@" in subj):
+        raise HTTPException(status_code=400, detail={
+            "not_a_subject": subj,
+            "expected": "a platform uid (digits) or an email address"})
+    out = build_timeline(db, subj, since=since or None, until=until or None,
+                         limit=max(1, min(int(limit or 20), 200)),
+                         meetings=fetch_meetings if meetings else None)
+    if out.get("unresolved"):
+        raise HTTPException(status_code=404, detail=f"nobody answers to {subj!r}")
+    shape = (format or "json").strip().lower()
+    if shape in ("text", "preamble"):
+        # A zone we cannot read is UTC, stated as UTC — never the server's local time wearing the
+        # person's name. `setting` never raises; a missing file means defaults.
+        try:
+            tz = str(setting(out.get("uid") or subj, "timezone") or "")
+        except Exception:  # noqa: BLE001 — a preference lookup must not cost the timeline
+            tz = ""
+        out = {**out, "timezone": tz or "UTC",
+               "text": (render_preamble(out, tz) if shape == "preamble"
+                        else render_text(out, tz))}
+    return out
 
 
 def main() -> int:  # pragma: no cover — process entrypoint

--- a/core/flows/src/flows_timeline/README.md
+++ b/core/flows/src/flows_timeline/README.md
@@ -1,0 +1,33 @@
+# `flows_timeline` — one person's day, in order
+
+PRD decision 31. Founder, 2026-09-02: *"does the agent have temporal awareness of the last events
+and future events? scheduled meetings, the things that actually get logged in the flows data"*.
+
+The engine already writes every one of those moments down — a **reaction** is a fact that arrived,
+an **effect receipt** is what we did about it — and nothing ever read them back along the one axis a
+person thinks in. This package is that read, and it is only a read: it admits nothing, claims
+nothing, runs nothing, and writes nothing.
+
+| module | what it is |
+|---|---|
+| `model.py` | pure. Rows in, `Event`s out: the three mappers, the scoping rule, the merge. Everything that can be wrong in a way a test can catch. |
+| `service.py` | the I/O: which rows to scan, who the subject is, and the meetings half over HTTP. |
+| `render.py` | pure. The timeline as text, in the person's own zone — for the control-MCP `timeline` tool and for the per-dispatch preamble, which must not disagree. |
+
+Served by `flows_integrations.flows_api` as `GET /timeline?subject=<uid|email>&since=&until=&limit=`
+(`format=text|preamble` adds a rendered `text`). Read-only, and open to the operator key or to the
+narrower `VEXA_FLOWS_TIMELINE_KEY`.
+
+## Three things worth knowing before you change it
+
+1. **Scoping needs BOTH identifiers.** The invite lineage carries an organizer address and no uid;
+   the completed lineage carries a uid. Scoping on one silently returns half a day.
+2. **Machinery is not an event.** Receipt steps become events only through `STEP_KINDS` — a
+   whitelist, because the failure mode of a blacklist is a timeline that fills with `ensure_user`
+   and still looks like a timeline. A **failed** receipt is always an event, whatever its step.
+3. **One renderer.** The zone lookup and the formatting happen here, once, server-side. Two
+   spellings of "half past two, their time" is how a chat and a machinery note end up disagreeing
+   about one meeting.
+
+`scripts/proof_timeline.py` runs the whole thing against a real lane database, read-only, with no
+service up.

--- a/core/flows/src/flows_timeline/__init__.py
+++ b/core/flows/src/flows_timeline/__init__.py
@@ -1,0 +1,20 @@
+"""flows_timeline — one person's day, in order (PRD decision 31).
+
+`model` is pure and takes rows; `service` reads the flows database and the meetings table. Kept
+out of `flows/` because it is not the engine (it never admits, claims or runs anything) and out of
+`flows_steps/` because it is not a step (nothing in a flow calls it) — it is a READ over what those
+two already wrote.
+"""
+from __future__ import annotations
+
+from flows_timeline.model import (EVENT_KINDS, STEP_KINDS, Event, concerns, event_from_meeting,
+                                  event_from_receipt, events_from_reaction, iso, merge,
+                                  split_around, to_epoch)
+from flows_timeline.render import render_preamble, render_text
+from flows_timeline.service import (build_timeline, fetch_meetings, read_flows, resolve_identity,
+                                    window)
+
+__all__ = ["EVENT_KINDS", "STEP_KINDS", "Event", "concerns", "event_from_meeting",
+           "event_from_receipt", "events_from_reaction", "iso", "merge", "split_around",
+           "to_epoch", "build_timeline", "fetch_meetings", "read_flows", "resolve_identity",
+           "window", "render_preamble", "render_text"]

--- a/core/flows/src/flows_timeline/model.py
+++ b/core/flows/src/flows_timeline/model.py
@@ -1,0 +1,359 @@
+"""WHAT HAPPENED TO ONE PERSON, IN ORDER — the pure half of the timeline (PRD decision 31).
+
+Founder, 2026-09-02 15:5xZ: *"does the agent have temporal awareness of the last events and future
+events? scheduled meetings, the things that actually get logged in the flows data"*. It did not.
+The engine already writes every one of those moments down — a reaction is a fact that arrived, a
+receipt is an effect that landed — but nothing ever read them back along the ONE axis a person
+thinks in, which is time, and nothing ever scoped them to the person they happened to.
+
+Everything here is stdlib-only and takes ROWS, not a database: the merge, the scoping and the
+ordering are the part that can be wrong in a way tests can catch, so they are kept away from the
+I/O that cannot be. `service.py` does the reading.
+
+Three sources, one list:
+
+  * a REACTION is the fact itself — an invite arrived, a meeting finished, a reply came back.
+  * an EFFECT RECEIPT is what we did about it — the prepare mail, the minutes mail, the desk drop.
+    Only the steps a PERSON would recognise become events; `ensure_user` and `require_workspace`
+    are machinery, and a timeline that lists machinery is a log, not an awareness.
+  * a MEETING ROW is the calendar half — what is scheduled and has not happened yet, which no fact
+    can carry because the fact for it has not been admitted.
+
+A failure is never machinery: any receipt in state `failed` becomes a `reaction.failed` event
+whatever its step, because the one thing an agent must not do is talk about a report it never
+delivered.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# ── the vocabulary ───────────────────────────────────────────────────────────────────────────────
+# Deliberately SMALL and stated once. Each key is what the engine calls the thing; each value is
+# what a person calls it. An event type with no entry keeps its own name rather than being dropped:
+# a flow submitted over the API reacts to event types this file has never heard of, and silence
+# about them would make the timeline lie by omission.
+EVENT_KINDS = {
+    "invite.received": "invite.received",
+    "meeting.upcoming": "meeting.scheduled",
+    "meeting.completed": "meeting.held",
+    "mail.reply": "reply.handled",
+    "onboarding.person.needed": "onboarding.started",
+    "onboarding.group.needed": "onboarding.started",
+}
+
+# A step ABSENT from this map is machinery and produces no event. That is a whitelist on purpose:
+# the failure mode of a blacklist here is a timeline that fills with `ensure_user` the first time
+# somebody adds a step, and nobody notices because it still looks like a timeline.
+STEP_KINDS = {
+    "rsvp_accept": "invite.accepted",
+    "ack_by_email": "mail.sent",
+    "prepare_meeting": "mail.sent",
+    "email_minutes": "report.delivered",
+    "email_attendees": "report.delivered",
+    "drop_to_attendees": "report.delivered",
+    "email_reply": "mail.sent",
+    "drive_person": "mail.sent",
+    "drive_group": "mail.sent",
+    "process_meeting": "report.written",
+    "dispatch_bot": "meeting.joined",
+}
+
+# The kinds that describe a MEETING rather than a message. One meeting produces at most one of each
+# of these, whichever source saw it first — see `merge`.
+_MEETING_KINDS = ("meeting.scheduled", "meeting.held", "meeting.joined")
+
+_RECEIPT_STATUS = {"confirmed": "done", "reserved": "in_flight", "failed": "failed"}
+
+
+@dataclass
+class Event:
+    """One moment on one person's timeline."""
+    at: float                                   # epoch seconds — the ONE sort key
+    kind: str
+    title: str
+    status: str
+    meeting_id: Optional[str] = None
+    produced: dict = field(default_factory=dict)
+    flow: Optional[str] = None
+    source: str = ""                            # reaction | receipt | meeting — provenance, not UI
+    detail: Optional[str] = None                # a reason, when there is one
+
+    def as_dict(self) -> dict:
+        out = {
+            "at": iso(self.at),
+            "at_epoch": round(self.at, 3),
+            "kind": self.kind,
+            "title": self.title,
+            "status": self.status,
+            "produced": self.produced,
+            "source": self.source,
+        }
+        if self.meeting_id:
+            out["meeting_id"] = str(self.meeting_id)
+        if self.flow:
+            out["flow"] = self.flow
+        if self.detail:
+            out["detail"] = self.detail
+        return out
+
+
+# ── small conversions ────────────────────────────────────────────────────────────────────────────
+
+def iso(epoch: float) -> str:
+    """UTC, ISO-8601, `Z`. The wire format: one zone on the wire, the person's zone at the edge."""
+    return (datetime.datetime.fromtimestamp(float(epoch), datetime.timezone.utc)
+            .isoformat(timespec="seconds").replace("+00:00", "Z"))
+
+
+def to_epoch(value: Any) -> Optional[float]:
+    """Epoch seconds from an epoch, an ISO-8601 string (with or without `Z`), or None.
+
+    Naive strings are read as UTC — every timestamp this system writes is UTC, and guessing local
+    would silently move a meeting by hours on a machine whose clock is not the deployment's.
+    """
+    if value in (None, "", []):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        dt = datetime.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.timestamp()
+
+
+def loads(raw: Any) -> dict:
+    """A JSON column, defensively. A row we cannot parse must never take the timeline down."""
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        out = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return out if isinstance(out, dict) else {}
+
+
+# ── scoping: is this the person's? ───────────────────────────────────────────────────────────────
+
+def _emails(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value.strip().lower()] if value.strip() else []
+    if isinstance(value, (list, tuple)):
+        return [str(v).strip().lower() for v in value if str(v).strip()]
+    return []
+
+
+def concerns(refs: dict, uid: str = "", email: str = "") -> bool:
+    """Is this fact ABOUT this person — as its subject, its organizer, or one of its attendees?
+
+    Both identifiers are needed and neither is sufficient. The facts the mailbox admits
+    (`invite.received`, `meeting.upcoming`) carry an ORGANIZER and a participant list and no uid at
+    all, because at that moment the person may not be a platform user yet; the facts the engine
+    emits (`meeting.completed`, `mail.reply`) carry a uid and, in the invite lineage, the emails
+    too. Scoping on one of them alone silently drops half of the person's own day — which is
+    exactly the shape of the bug this function exists to not have.
+    """
+    uid = str(uid or "").strip()
+    email = str(email or "").strip().lower()
+    if not uid and not email:
+        return False
+    if uid:
+        for key in ("uid", "user_id", "subject", "owner"):
+            if str(refs.get(key) or "").strip() == uid:
+                return True
+    if email:
+        for key in ("organizer", "inviter", "from", "to", "recipient", "email"):
+            if email in _emails(refs.get(key)):
+                return True
+        for key in ("participants", "attendees", "recipients"):
+            if email in _emails(refs.get(key)):
+                return True
+    return False
+
+
+# ── the three mappers ────────────────────────────────────────────────────────────────────────────
+
+def _title(refs: dict, fallback: str) -> str:
+    for key in ("title", "subject", "summary", "name"):
+        v = str(refs.get(key) or "").strip()
+        if v:
+            return v
+    return fallback
+
+
+def _meeting_id(refs: dict, result: dict | None = None) -> Optional[str]:
+    for src in (result or {}, refs):
+        for key in ("meeting_id", "meeting_ref", "meeting"):
+            v = src.get(key)
+            if v not in (None, "", []):
+                return str(v)
+    return None
+
+
+def _produced(result: dict, provider_ref: str = "") -> dict:
+    """What the effect left behind, in the three words the founder used: a link, a mail, a note."""
+    out: dict = {}
+    for key in ("link", "url"):
+        v = str(result.get(key) or "").strip()
+        if v:
+            out["link"] = v
+            break
+    for key in ("subject", "mail_subject"):
+        v = str(result.get(key) or "").strip()
+        if v:
+            out["mail_subject"] = v
+            break
+    for key in ("entity", "note_path", "note", "path"):
+        v = str(result.get(key) or "").strip()
+        if v:
+            out["note_path"] = v
+            break
+    mid = str(result.get("message_id") or "").strip() or str(provider_ref or "").strip()
+    if mid.startswith("<"):
+        out["message_id"] = mid
+    return out
+
+
+def events_from_reaction(row: dict) -> list[Event]:
+    """The FACT itself, plus its failure if it has one.
+
+    Two events out of one row is deliberate: a reaction that failed happened TWICE as far as the
+    person is concerned — the invite did arrive at 11:23, and the thing we were going to do about
+    it died at 11:41 — and collapsing them into a single "failed invite" loses the first half.
+    """
+    refs = loads(row.get("subject_refs"))
+    created = to_epoch(row.get("created_at"))
+    if created is None:
+        return []
+    kind = EVENT_KINDS.get(str(row.get("event_type") or ""), str(row.get("event_type") or "event"))
+    status = str(row.get("status") or "")
+    out = [Event(at=created, kind=kind, title=_title(refs, kind), status=status,
+                 meeting_id=_meeting_id(refs), flow=str(row.get("flow") or "") or None,
+                 source="reaction")]
+    if status == "failed":
+        at = to_epoch(row.get("updated_at")) or created
+        out.append(Event(at=at, kind="reaction.failed",
+                         title=_title(refs, kind), status="failed",
+                         meeting_id=_meeting_id(refs), flow=str(row.get("flow") or "") or None,
+                         source="reaction", detail=(str(row.get("reason") or "") or None)[:300]
+                         if row.get("reason") else None))
+    return out
+
+
+def event_from_receipt(row: dict, refs: dict, flow: str = "") -> Optional[Event]:
+    """What we DID, when the step is one a person would recognise — or a failure, always."""
+    at = to_epoch(row.get("attempted_at"))
+    if at is None:
+        return None
+    confirmed = to_epoch(row.get("confirmed_at"))
+    step = str(row.get("step") or "")
+    state = str(row.get("state") or "")
+    result = loads(row.get("result"))
+    kind = STEP_KINDS.get(step)
+    if state == "failed":
+        kind = "reaction.failed"
+    if not kind:
+        return None
+    if result.get("skipped"):
+        status = "skipped"
+    elif result.get("coalesced"):
+        status = "coalesced"
+    else:
+        status = _RECEIPT_STATUS.get(state, state or "unknown")
+    return Event(at=confirmed if (confirmed and state == "confirmed") else at,
+                 kind=kind, title=_title(refs, step), status=status,
+                 meeting_id=_meeting_id(refs, result),
+                 produced=_produced(result, str(row.get("provider_ref") or "")),
+                 flow=flow or None, source="receipt",
+                 detail=(str(result.get("skipped") or "")[:300] or None))
+
+
+# A meeting row is HELD once it can no longer happen again — the platform's own terminal statuses.
+_TERMINAL = {"completed", "failed"}
+
+
+def event_from_meeting(row: dict) -> Optional[Event]:
+    """The calendar half: one row, one event — scheduled until it is terminal, then held.
+
+    Never both. A completed meeting's `scheduled_at` is not news; the person lived through it, and
+    the invite that created it is already on the timeline from the facts.
+    """
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    status = str(row.get("status") or "").strip().lower()
+    held = status in _TERMINAL
+    if held:
+        at = (to_epoch(row.get("end_time")) or to_epoch(row.get("start_time"))
+              or to_epoch(data.get("scheduled_at")) or to_epoch(row.get("created_at")))
+        kind = "meeting.held"
+    else:
+        at = (to_epoch(row.get("scheduled_at")) or to_epoch(data.get("scheduled_at"))
+              or to_epoch(row.get("start_time")) or to_epoch(row.get("created_at")))
+        kind = "meeting.scheduled"
+    if at is None:
+        return None
+    title = (str(row.get("title") or "").strip() or str(data.get("title") or "").strip()
+             or str(row.get("native_meeting_id") or "").strip() or "meeting")
+    mid = row.get("id")
+    return Event(at=at, kind=kind, title=title, status=status or "scheduled",
+                 meeting_id=str(mid) if mid not in (None, "") else None,
+                 source="meeting")
+
+
+# ── the merge ────────────────────────────────────────────────────────────────────────────────────
+
+def _key(e: Event) -> tuple:
+    """The identity a duplicate would share. Two sources see one meeting; the person sees one."""
+    if e.kind in _MEETING_KINDS and e.meeting_id:
+        return (e.kind, e.meeting_id)
+    return (e.kind, e.source, round(e.at, 3), e.title, e.meeting_id or "")
+
+
+def merge(events, *, since: Optional[float] = None, until: Optional[float] = None,
+          limit: int = 20) -> list[Event]:
+    """Window, de-duplicate, order oldest-first, and keep the LAST `limit`.
+
+    Keeping the last rather than the first is the whole point of a limit on a timeline: a person
+    asking for twenty events wants the twenty nearest to now, not the twenty oldest rows the engine
+    still holds. The result stays ascending so "in order" means the same thing to every reader.
+
+    The duplicate rule keeps the EARLIER sighting of a meeting, because the earlier one is the one
+    that came from a fact — the moment the system learned it — and the meetings table is a mirror
+    of state, not of when that state was reached.
+    """
+    picked: dict[tuple, Event] = {}
+    for e in events:
+        if e is None:
+            continue
+        if since is not None and e.at < since:
+            continue
+        if until is not None and e.at > until:
+            continue
+        k = _key(e)
+        prior = picked.get(k)
+        if prior is None or e.at < prior.at:
+            picked[k] = e
+    ordered = sorted(picked.values(), key=lambda e: (e.at, e.kind, e.title))
+    if limit and limit > 0 and len(ordered) > limit:
+        ordered = ordered[-limit:]
+    return ordered
+
+
+def split_around(events, now: float, *, back: int = 5, ahead: int = 5) -> tuple[list, list]:
+    """`(the last `back`, the next `ahead`)` — the two halves the preamble states, in one pass."""
+    past = [e for e in events if e.at <= now]
+    future = [e for e in events if e.at > now]
+    return past[-back:] if back else [], future[:ahead] if ahead else []

--- a/core/flows/src/flows_timeline/render.py
+++ b/core/flows/src/flows_timeline/render.py
@@ -1,0 +1,134 @@
+"""THE TIMELINE AS TEXT, in the person's own zone — pure, stdlib, and therefore testable.
+
+Two readers use exactly this rendering and they must not disagree: the control-MCP `timeline` tool
+(a person asking) and the dispatch preamble (the same person's agent being told, unasked). Two
+spellings of "half past two, their time" is how a chat ends up saying one thing and the machinery
+note another about the same meeting.
+
+Three rules, all of them lessons already paid for elsewhere in this codebase:
+
+  * NEVER a bare `HH:MM`. Times were once rendered on the server's clock and a Lisbon person was
+    told their standup joined at 19:15 when it was 17:15 where they stood (`_person_tz`). Every
+    stamp here carries its zone.
+  * NEVER a bare `HH:MM` for a day that is not today either — "11:23" for something that happened
+    on Monday is what makes an agent talk about last week as if it were this morning.
+  * `now` FIRST. A timeline without a now is a list; the whole ask in decision 31 was a SENSE of
+    now, and "in an hour" has nothing to be relative to without it.
+"""
+from __future__ import annotations
+
+import datetime
+from typing import Optional
+
+UTC = datetime.timezone.utc
+
+
+def zone(tz: str):
+    """The person's `tzinfo`, or UTC. An unknown zone degrades; it never raises."""
+    if tz:
+        try:
+            import zoneinfo
+            return zoneinfo.ZoneInfo(tz)
+        except Exception:  # noqa: BLE001 — a bad zone is a setting, not a crash
+            pass
+    return UTC
+
+
+def clock(epoch: float, tz: str) -> str:
+    """`HH:MM ZONE` — the house format, zone always attached."""
+    z = zone(tz)
+    t = datetime.datetime.fromtimestamp(float(epoch), z)
+    return t.strftime("%H:%M ") + (t.tzname() or (tz or "UTC"))
+
+
+def when(epoch: float, tz: str, today: str) -> str:
+    """`HH:MM ZONE` when it is today for THEM, `Wed 03 Sep HH:MM ZONE` when it is not."""
+    t = datetime.datetime.fromtimestamp(float(epoch), zone(tz))
+    stamp = clock(epoch, tz)
+    return stamp if t.strftime("%Y-%m-%d") == today else t.strftime("%a %d %b ") + stamp
+
+
+def _tail(event: dict) -> str:
+    produced = event.get("produced") or {}
+    return str(produced.get("link") or produced.get("note_path")
+               or produced.get("mail_subject") or "")
+
+
+def line(event: dict, tz: str, today: str) -> str:
+    """One event, one line. A status is shown only when it is NOT the boring one — a line that
+    says `done` on every row trains the reader to stop reading the column that matters."""
+    bits = [f"{when(event.get('at_epoch') or 0, tz, today):>22}",
+            f"{str(event.get('kind') or ''):<18}",
+            str(event.get("title") or "")[:48]]
+    status = str(event.get("status") or "")
+    if status and status not in ("done", "confirmed", "completed"):
+        bits.append(f"[{status}]")
+    tail = _tail(event)
+    if tail:
+        bits.append(tail[:100])
+    return "  " + "  ".join(b for b in bits if b.strip())
+
+
+def _split(events, now: float, *, back: int, ahead: int):
+    past = [e for e in events if (e.get("at_epoch") or 0) <= now]
+    future = [e for e in events if (e.get("at_epoch") or 0) > now]
+    return (past[-back:] if back else past), (future[:ahead] if ahead else future)
+
+
+def render_text(payload: dict, tz: str = "", *, back: int = 0, ahead: int = 0,
+                now: Optional[float] = None) -> str:
+    """The `timeline` tool's answer: now, then what happened, then what is coming.
+
+    `back`/`ahead` of 0 mean "everything the payload holds" — the tool shows what was asked for.
+    The preamble passes 5 and 5 (decision 31 §1: *a handful of lines*).
+    """
+    events = payload.get("events") or []
+    now = float(now if now is not None else (payload.get("now_epoch") or 0))
+    z = zone(tz)
+    head = datetime.datetime.fromtimestamp(now, z)
+    today = head.strftime("%Y-%m-%d")
+    past, future = _split(events, now, back=back, ahead=ahead)
+    out = [f"now  {head.strftime('%a %d %b')}  {clock(now, tz)}"
+           + ("" if tz else "   (no timezone set — say your IANA zone and it will be remembered)")]
+    out.append("")
+    out.append(f"already happened ({len(past)}):" if past
+               else "already happened: nothing in this window")
+    out += [line(e, tz, today) for e in past]
+    out.append("")
+    out.append(f"still ahead ({len(future)}):" if future else "still ahead: nothing scheduled")
+    out += [line(e, tz, today) for e in future]
+    return "\n".join(out)
+
+
+def render_preamble(payload: dict, tz: str = "", *, back: int = 5, ahead: int = 5) -> str:
+    """The compact block that ships on EVERY dispatch (decision 31 §1) — a heading, `now`, the last
+    few events concerning this person and the next few scheduled, and nothing else.
+
+    Returns "" when there is nothing to say — no payload, no now. A preamble that renders a heading
+    over an empty list teaches the model that the section is noise, and it will then skip the turn
+    where the section is not.
+    """
+    if not payload or not payload.get("now_epoch"):
+        return ""
+    events = payload.get("events") or []
+    now = float(payload["now_epoch"])
+    z = zone(tz)
+    head = datetime.datetime.fromtimestamp(now, z)
+    today = head.strftime("%Y-%m-%d")
+    past, future = _split(events, now, back=back, ahead=ahead)
+    out = ["## Where this person is in time\n",
+           f"**Now: {head.strftime('%A %d %B %Y')}, {clock(now, tz)}.** "
+           "State times in this zone; never a bare clock time from another one. "
+           "`timeline(since, until)` reaches further back or further forward than this block.\n"]
+    if past:
+        out.append("Last events concerning them:")
+        out += [line(e, tz, today) for e in past]
+        out.append("")
+    if future:
+        out.append("Next, scheduled:")
+        out += [line(e, tz, today) for e in future]
+        out.append("")
+    if not past and not future:
+        out.append("Nothing recorded for them in the last two weeks and nothing scheduled ahead — "
+                   "say so if it comes up rather than implying a history you cannot see.\n")
+    return "\n".join(out) + "\n"

--- a/core/flows/src/flows_timeline/service.py
+++ b/core/flows/src/flows_timeline/service.py
@@ -1,0 +1,191 @@
+"""THE READING half of the timeline (PRD decision 31) — rows in, `model.Event`s out.
+
+Everything that can only be wrong at runtime lives here: which rows to scan, who the subject is,
+and where the meetings table is. `model.py` holds the part the tests can pin.
+
+Two scoping identifiers, always. See `model.concerns` for why one is never enough; this module is
+what turns the single `subject` a caller passes into the pair.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Callable, Optional
+
+from flows_timeline.model import (Event, concerns, event_from_meeting, event_from_receipt,
+                                  events_from_reaction, loads, merge, to_epoch)
+
+# How many reaction rows one call may look at. A person's own share of them is small, but the table
+# is org-wide, so the scan is bounded rather than the result: an unbounded ORDER BY over a table a
+# simulator can fill with a hundred thousand rows is the shape of a route that works until the day
+# it matters. Raise it with the window, never with the limit.
+SCAN_ROWS = int(os.environ.get("VEXA_TIMELINE_SCAN_ROWS", "2000"))
+
+DEFAULT_BACK_S = 14 * 86400
+DEFAULT_AHEAD_S = 30 * 86400
+
+_REACTION_COLS = ("reaction_id", "source_event_id", "event_type", "subject_refs", "flow",
+                  "flow_version", "step", "status", "reason", "created_at", "updated_at")
+_RECEIPT_COLS = ("effect_key", "reaction_id", "step", "state", "provider_ref", "result",
+                 "attempted_at", "confirmed_at")
+
+
+def _rows(db, sql: str, params: dict, cols: tuple) -> list[dict]:
+    return [dict(zip(cols, r)) for r in db.execute(sql, params)]
+
+
+def window(since=None, until=None, now: Optional[float] = None) -> tuple[float, float]:
+    """The `[since, until]` a caller asked for, or the default one that straddles now.
+
+    Straddling is the point: a timeline whose default window ends at `now` cannot answer the half
+    of decision 31 that says *the next scheduled meetings with times*, and that half is the one the
+    person cannot get from anywhere else.
+    """
+    now = time.time() if now is None else float(now)
+    s = to_epoch(since)
+    u = to_epoch(until)
+    return (now - DEFAULT_BACK_S if s is None else s,
+            now + DEFAULT_AHEAD_S if u is None else u)
+
+
+def read_flows(db, *, uid: str = "", email: str = "", since: float, until: float,
+               scan: int = SCAN_ROWS) -> list[Event]:
+    """Every reaction and receipt in the window that CONCERNS this person.
+
+    The reaction scan filters on `updated_at`, not `created_at`, and that is load-bearing: a
+    reaction admitted a week ago whose minutes mail went out an hour ago has an old `created_at`
+    and a fresh `updated_at`, and scanning on the former would drop the one event the person is
+    most likely to be asking about. Every step run touches `updated_at`, so it is an upper bound on
+    the receipts that hang off the row.
+    """
+    reactions = _rows(db, f"""SELECT {", ".join(_REACTION_COLS)} FROM reaction
+                              WHERE updated_at >= :since AND created_at <= :until
+                              ORDER BY updated_at DESC LIMIT {int(scan)}""",
+                      {"since": since, "until": until}, _REACTION_COLS)
+    mine = [r for r in reactions if concerns(loads(r["subject_refs"]), uid, email)]
+    out: list[Event] = []
+    for r in mine:
+        out.extend(events_from_reaction(r))
+    if not mine:
+        return out
+    ids = {r["reaction_id"]: r for r in mine}
+    keys = {f"r{i}": rid for i, rid in enumerate(ids)}
+    placeholders = ", ".join(f":{k}" for k in keys)
+    receipts = _rows(db, f"""SELECT {", ".join(_RECEIPT_COLS)} FROM effect_receipt
+                             WHERE reaction_id IN ({placeholders})""",
+                     {k: v for k, v in keys.items()}, _RECEIPT_COLS)
+    for rc in receipts:
+        parent = ids.get(rc["reaction_id"]) or {}
+        ev = event_from_receipt(rc, loads(parent.get("subject_refs")),
+                                flow=str(parent.get("flow") or ""))
+        if ev is not None:
+            out.append(ev)
+    return out
+
+
+# ── the meetings half ────────────────────────────────────────────────────────────────────────────
+#
+# The meetings table lives in another service's database, so it is reached the way every step
+# reaches it: over HTTP, with the person's own key. The key is CACHED per process — the preamble
+# asks for a timeline on every dispatch (behind its own 60 s cache) and minting a fresh API token
+# per ask would leave a token per person per minute in the identity database forever.
+
+_KEY_CACHE: dict[str, str] = {}
+
+
+def _user_key(uid: str) -> str:
+    if uid not in _KEY_CACHE:
+        from flows_steps.common import user_api_key
+        _KEY_CACHE[uid] = user_api_key(str(uid))
+    return _KEY_CACHE[uid]
+
+
+def fetch_meetings(uid: str) -> list[dict]:
+    """This person's meeting rows, or `[]`. NEVER raises: the flows half is the half that matters,
+    and a gateway hiccup must degrade the timeline, not empty it."""
+    uid = str(uid or "").strip()
+    if not uid:
+        return []
+    try:
+        from flows_steps.common import GATEWAY, http
+        _st, body = http("GET", f"{GATEWAY}/meetings", {"X-API-Key": _user_key(uid)})
+    except Exception:  # noqa: BLE001 — see docstring
+        _KEY_CACHE.pop(uid, None)          # a rejected key is the likeliest cause; re-mint next call
+        return []
+    if isinstance(body, dict):
+        rows = body.get("meetings", [])
+    elif isinstance(body, list):
+        rows = body
+    else:
+        rows = []
+    return [m for m in rows if isinstance(m, dict)]
+
+
+# ── identity ─────────────────────────────────────────────────────────────────────────────────────
+
+def resolve_identity(subject: str, lookup: Optional[Callable[[str], dict]] = None) -> tuple[str, str]:
+    """`(uid, email)` from either one. Fails SOFT: what could not be resolved comes back empty.
+
+    A subject of all digits is a platform id; anything with an `@` is an address; anything else is
+    refused by the caller. When admin-api cannot be reached the caller still gets the identifier it
+    was given, so a timeline scoped by email keeps working while identity is down — half a scope is
+    a smaller lie than no timeline.
+    """
+    subject = str(subject or "").strip()
+    if not subject:
+        return "", ""
+    uid = subject if subject.isdigit() else ""
+    email = subject.lower() if "@" in subject else ""
+    if lookup is None:
+        def lookup(path: str) -> dict:
+            from flows_steps.common import ADMIN_API, ADMIN_KEY, http
+            _st, body = http("GET", f"{ADMIN_API}{path}", {"X-Admin-API-Key": ADMIN_KEY})
+            return body if isinstance(body, dict) else {}
+    try:
+        if uid and not email:
+            email = str((lookup(f"/admin/users/{uid}") or {}).get("email") or "").lower()
+        elif email and not uid:
+            got = (lookup(f"/admin/users/email/{email}") or {}).get("id")
+            uid = str(got) if got not in (None, "") else ""
+    except Exception:  # noqa: BLE001 — see docstring
+        pass
+    return uid, email
+
+
+# ── the whole thing ──────────────────────────────────────────────────────────────────────────────
+
+def build_timeline(db, subject: str, *, since=None, until=None, limit: int = 20,
+                   now: Optional[float] = None,
+                   meetings: Optional[Callable[[str], list]] = fetch_meetings,
+                   identity: Optional[Callable[[str], tuple]] = None) -> dict:
+    """The route's answer: `now`, the resolved subject, and the merged events oldest-first.
+
+    `meetings` and `identity` are injected so the whole thing can be exercised — and PROVEN against
+    a real database — without a gateway, an identity service or a network. Pass `meetings=None` for
+    the flows half alone.
+    """
+    now = time.time() if now is None else float(now)
+    s, u = window(since, until, now=now)
+    uid, email = (identity or resolve_identity)(subject)
+    if not uid and not email:
+        return {"now": None, "subject": subject, "uid": "", "email": "", "events": [],
+                "unresolved": True}
+    events = read_flows(db, uid=uid, email=email, since=s, until=u)
+    if meetings is not None and uid:
+        for row in meetings(uid):
+            ev = event_from_meeting(row)
+            if ev is not None:
+                events.append(ev)
+    ordered = merge(events, since=s, until=u, limit=limit)
+    from flows_timeline.model import iso
+    return {
+        "now": iso(now),
+        "now_epoch": round(now, 3),
+        "subject": subject,
+        "uid": uid,
+        "email": email,
+        "since": iso(s),
+        "until": iso(u),
+        "count": len(ordered),
+        "events": [e.as_dict() for e in ordered],
+    }

--- a/core/flows/tests/test_timeline.py
+++ b/core/flows/tests/test_timeline.py
@@ -1,0 +1,258 @@
+"""The timeline: scoping · merge · ordering (PRD decision 31).
+
+Offline and stdlib-pure like the rest of the suite — a real sqlite schema, real rows written the
+way the engine writes them, and no gateway. The meetings half is injected.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from flows import SqliteDB
+from flows_timeline import (build_timeline, concerns, event_from_meeting, events_from_reaction,
+                            iso, merge, read_flows, resolve_identity, split_around, to_epoch)
+from flows_timeline.model import Event, event_from_receipt
+
+T0 = 1_788_000_000.0          # a fixed "now"; every offset below is relative to it
+HOUR = 3600.0
+
+REFS_INVITE = {"ics_uid": "dna@zoom.us", "organizer": "admin@vexa.ai", "title": "ASWF DNA TSC",
+               "participants": ["sam.richards@dna.test", "tommy.snyder@dna.test"],
+               "start": T0 + 3 * HOUR}
+REFS_DONE = {**REFS_INVITE, "uid": "126", "meeting_id": 104}
+
+
+def _reaction(db, rid, event_type, refs, *, flow="invite_intake", step="await_start",
+              status="done", created=T0, updated=None, reason=None):
+    db.execute("""INSERT INTO reaction (reaction_id, source_event_id, event_type, subject_refs,
+                                        flow, flow_version, step, status, attempt, next_run_at,
+                                        reason, created_at, updated_at)
+                  VALUES (:rid,:sid,:et,:refs,:flow,1,:step,:st,0,0,:why,:c,:u)""",
+               {"rid": rid, "sid": f"{rid}::{flow}", "et": event_type,
+                "refs": json.dumps(refs), "flow": flow, "step": step, "st": status,
+                "why": reason, "c": created, "u": updated if updated is not None else created})
+
+
+def _receipt(db, rid, step, *, state="confirmed", result=None, at=T0, confirmed=None,
+             provider_ref=None):
+    db.execute("""INSERT INTO effect_receipt (effect_key, reaction_id, step, state, provider_ref,
+                                              result, attempted_at, confirmed_at)
+                  VALUES (:k,:r,:s,:st,:p,:res,:a,:c)""",
+               {"k": f"{rid}:{step}", "r": rid, "s": step, "st": state, "p": provider_ref,
+                "res": json.dumps(result) if result is not None else None,
+                "a": at, "c": confirmed if confirmed is not None else (at if state == "confirmed" else None)})
+
+
+def _lane():
+    """The DNA day, exactly as the founder lane wrote it: invite → prepare mail → completed →
+    minutes mail. Two reactions, four receipts that matter and three that are machinery."""
+    db = SqliteDB()
+    _reaction(db, "r-invite", "invite.received", REFS_INVITE, flow="invite_intake",
+              created=T0, updated=T0 + 60)
+    _receipt(db, "r-invite", "ensure_user", result={"uid": "126"}, at=T0 + 1)
+    _receipt(db, "r-invite", "rsvp_accept", result={"message_id": "<rsvp@vexa.ai>"}, at=T0 + 2)
+    _reaction(db, "r-prep", "meeting.upcoming", REFS_INVITE, flow="meeting_prep",
+              step="prepare_meeting", created=T0 + 3, updated=T0 + 4)
+    _receipt(db, "r-prep", "prepare_meeting", at=T0 + 4,
+             result={"message_id": "<prep@vexa.ai>", "meeting_ref": "104"},
+             provider_ref="<prep@vexa.ai>")
+    _reaction(db, "r-done", "meeting.completed", REFS_DONE, flow="post_meeting",
+              step="email_attendees", created=T0 + 2 * HOUR, updated=T0 + 2 * HOUR + 200)
+    _receipt(db, "r-done", "require_workspace", result={"ready": True}, at=T0 + 2 * HOUR + 1)
+    _receipt(db, "r-done", "email_minutes", at=T0 + 2 * HOUR + 160,
+             result={"message_id": "<min@vexa.ai>", "link": "https://app.dev.vexa.ai/?s=tok"})
+    return db
+
+
+def _ident(subject):
+    return ("126", "admin@vexa.ai")
+
+
+# ── scoping ──────────────────────────────────────────────────────────────────────────────────────
+
+def test_scoping_matches_organizer_attendee_and_uid():
+    assert concerns({"organizer": "Admin@Vexa.ai"}, email="admin@vexa.ai")
+    assert concerns({"participants": ["a@x.io", "sam.richards@dna.test"]},
+                    email="Sam.Richards@DNA.test")
+    assert concerns({"uid": "126"}, uid="126")
+    assert concerns({"user_id": 126}, uid="126")   # an int column compares as its string
+    assert not concerns({"organizer": "someone@else.io"}, uid="126", email="admin@vexa.ai")
+    assert not concerns({"uid": "126"}, uid="", email="")   # no identity ⇒ nothing is yours
+
+
+def test_scoping_needs_both_identifiers():
+    """The invite lineage carries no uid and the completed lineage carries no address of ours —
+    scoping on either alone drops half the day. This is the regression that rule exists for."""
+    db = _lane()
+    by_email = read_flows(db, email="admin@vexa.ai", since=T0 - HOUR, until=T0 + 4 * HOUR)
+    by_uid = read_flows(db, uid="126", since=T0 - HOUR, until=T0 + 4 * HOUR)
+    both = read_flows(db, uid="126", email="admin@vexa.ai", since=T0 - HOUR, until=T0 + 4 * HOUR)
+    assert {e.kind for e in by_uid} == {"meeting.held", "report.delivered"}
+    assert "invite.received" in {e.kind for e in by_email}
+    assert len(both) > len(by_uid)
+
+
+def test_a_stranger_sees_nothing():
+    db = _lane()
+    assert read_flows(db, uid="999", email="nobody@else.io",
+                      since=T0 - HOUR, until=T0 + 4 * HOUR) == []
+
+
+# ── mapping ──────────────────────────────────────────────────────────────────────────────────────
+
+def test_machinery_steps_produce_no_events():
+    """`ensure_user` and `require_workspace` happened; a person does not care. A timeline that
+    lists them is a log."""
+    db = _lane()
+    kinds = [e.kind for e in read_flows(db, uid="126", email="admin@vexa.ai",
+                                        since=T0 - HOUR, until=T0 + 4 * HOUR)]
+    assert "ensure_user" not in kinds and "require_workspace" not in kinds
+
+
+def test_a_failed_receipt_is_an_event_whatever_its_step():
+    refs = {"uid": "126", "title": "ASWF DNA TSC"}
+    ev = event_from_receipt({"step": "ensure_user", "state": "failed", "attempted_at": T0,
+                             "result": json.dumps({})}, refs)
+    assert ev is not None and ev.kind == "reaction.failed" and ev.status == "failed"
+
+
+def test_a_failed_reaction_keeps_the_fact_that_arrived():
+    evs = events_from_reaction({"event_type": "invite.received", "subject_refs": json.dumps(REFS_INVITE),
+                                "flow": "invite_intake", "status": "failed", "reason": "smtp said no",
+                                "created_at": T0, "updated_at": T0 + 900})
+    assert [e.kind for e in evs] == ["invite.received", "reaction.failed"]
+    assert [e.at for e in evs] == [T0, T0 + 900]
+    assert evs[1].detail == "smtp said no"
+
+
+def test_a_skipped_send_says_skipped_not_done():
+    ev = event_from_receipt({"step": "email_attendees", "state": "confirmed", "attempted_at": T0,
+                             "result": json.dumps({"sent": 0, "skipped": "no inside-domain attendee"})},
+                            REFS_DONE)
+    assert ev.status == "skipped" and ev.detail == "no inside-domain attendee"
+
+
+def test_produced_carries_the_link_the_note_and_the_message():
+    ev = event_from_receipt({"step": "drop_to_attendees", "state": "confirmed", "attempted_at": T0,
+                             "provider_ref": "<m@vexa.ai>",
+                             "result": json.dumps({"entity": "kg/entities/meeting/dna.md",
+                                                   "link": "https://app/x", "dropped": 2})},
+                            REFS_DONE)
+    assert ev.produced == {"link": "https://app/x", "note_path": "kg/entities/meeting/dna.md",
+                           "message_id": "<m@vexa.ai>"}
+
+
+def test_a_meeting_row_is_scheduled_until_it_is_terminal():
+    upcoming = event_from_meeting({"id": 200, "status": "scheduled", "data": {"title": "Standup",
+                                   "scheduled_at": "2026-09-03T09:00:00Z"}})
+    held = event_from_meeting({"id": 104, "status": "completed", "data": {"title": "ASWF DNA TSC"},
+                               "start_time": "2026-09-02T14:23:00", "end_time": "2026-09-02T15:36:10"})
+    assert (upcoming.kind, upcoming.title) == ("meeting.scheduled", "Standup")
+    assert held.kind == "meeting.held" and held.at == to_epoch("2026-09-02T15:36:10Z")
+
+
+def test_a_naive_timestamp_is_read_as_utc():
+    """meeting-api stores naive UTC. Reading it as local would move a meeting by hours on any host
+    whose clock is not the deployment's, and nothing would say so."""
+    assert to_epoch("2026-09-02T14:23:00") == to_epoch("2026-09-02T14:23:00Z")
+
+
+# ── merge + ordering ─────────────────────────────────────────────────────────────────────────────
+
+def test_ordering_is_ascending_and_the_limit_keeps_the_most_recent():
+    evs = [Event(at=T0 + i, kind="mail.sent", title=f"m{i}", status="done") for i in range(10)]
+    got = merge(evs, limit=3)
+    assert [e.title for e in got] == ["m7", "m8", "m9"]
+
+
+def test_the_window_excludes_what_is_outside_it():
+    evs = [Event(at=T0 - HOUR, kind="mail.sent", title="old", status="done"),
+           Event(at=T0 + HOUR, kind="mail.sent", title="in", status="done"),
+           Event(at=T0 + 10 * HOUR, kind="mail.sent", title="far", status="done")]
+    assert [e.title for e in merge(evs, since=T0, until=T0 + 2 * HOUR)] == ["in"]
+
+
+def test_one_meeting_seen_twice_is_one_row_and_the_earlier_sighting_wins():
+    """The fact said the meeting finished at 13:52; the meetings table says its row ended at 15:36.
+    Both are true and the person had one meeting — keep the moment the system LEARNED it."""
+    evs = [Event(at=T0 + 100, kind="meeting.held", title="DNA", status="done", meeting_id="104",
+                 source="reaction"),
+           Event(at=T0 + 6000, kind="meeting.held", title="DNA", status="completed",
+                 meeting_id="104", source="meeting")]
+    got = merge(evs)
+    assert len(got) == 1 and got[0].source == "reaction"
+
+
+def test_scheduled_and_held_for_one_meeting_both_survive():
+    evs = [Event(at=T0, kind="meeting.scheduled", title="DNA", status="scheduled", meeting_id="104"),
+           Event(at=T0 + 100, kind="meeting.held", title="DNA", status="done", meeting_id="104")]
+    assert [e.kind for e in merge(evs)] == ["meeting.scheduled", "meeting.held"]
+
+
+def test_split_around_gives_the_last_few_and_the_next_few():
+    evs = [Event(at=T0 - i * HOUR, kind="mail.sent", title=f"p{i}", status="done") for i in range(8, 0, -1)]
+    evs += [Event(at=T0 + i * HOUR, kind="meeting.scheduled", title=f"n{i}", status="scheduled")
+            for i in range(1, 8)]
+    past, future = split_around(merge(evs, limit=100), T0, back=5, ahead=5)
+    assert [e.title for e in past] == ["p5", "p4", "p3", "p2", "p1"]
+    assert [e.title for e in future] == ["n1", "n2", "n3", "n4", "n5"]
+
+
+# ── the whole route answer ───────────────────────────────────────────────────────────────────────
+
+def test_the_dna_day_comes_back_in_order():
+    db = _lane()
+    out = build_timeline(db, "126", since=T0 - HOUR, until=T0 + 4 * HOUR, limit=50,
+                         now=T0 + 3 * HOUR, meetings=None, identity=_ident)
+    kinds = [e["kind"] for e in out["events"]]
+    assert kinds[:2] == ["invite.received", "invite.accepted"]
+    assert kinds.index("meeting.scheduled") < kinds.index("meeting.held")
+    assert kinds.index("meeting.held") < kinds.index("report.delivered")
+    ats = [e["at_epoch"] for e in out["events"]]
+    assert ats == sorted(ats)
+    assert out["now"] == iso(T0 + 3 * HOUR)
+
+
+def test_the_meetings_half_merges_in():
+    db = _lane()
+    rows = [{"id": 300, "status": "scheduled", "data": {"title": "Next standup",
+                                                        "scheduled_at": T0 + 3 * HOUR}}]
+    out = build_timeline(db, "126", since=T0 - HOUR, until=T0 + 4 * HOUR, limit=50,
+                         now=T0 + 2.5 * HOUR, meetings=lambda uid: rows, identity=_ident)
+    scheduled = [e for e in out["events"] if e["kind"] == "meeting.scheduled"]
+    assert "Next standup" in [e["title"] for e in scheduled]
+    assert out["events"][-1]["title"] == "Next standup"      # the future sorts last
+
+
+def test_an_unresolvable_subject_is_said_so_not_answered_with_everything():
+    db = _lane()
+    out = build_timeline(db, "", meetings=None, identity=lambda s: ("", ""))
+    assert out["unresolved"] is True and out["events"] == []
+
+
+def test_identity_resolution_asks_admin_api_for_the_half_it_lacks():
+    seen = []
+
+    def lookup(path):
+        seen.append(path)
+        return {"email": "admin@vexa.ai"} if path.endswith("/126") else {"id": 126}
+
+    assert resolve_identity("126", lookup) == ("126", "admin@vexa.ai")
+    assert resolve_identity("Admin@Vexa.ai", lookup) == ("126", "admin@vexa.ai")
+    assert seen == ["/admin/users/126", "/admin/users/email/admin@vexa.ai"]
+
+
+def test_identity_failure_degrades_to_the_half_we_were_given():
+    def lookup(path):
+        raise RuntimeError("identity is down")
+
+    assert resolve_identity("126", lookup) == ("126", "")
+
+
+@pytest.mark.parametrize("subject", ["126", "admin@vexa.ai"])
+def test_either_identifier_reaches_the_same_day(subject):
+    db = _lane()
+    out = build_timeline(db, subject, since=T0 - HOUR, until=T0 + 4 * HOUR, limit=50,
+                         now=T0 + 3 * HOUR, meetings=None, identity=_ident)
+    assert [e["kind"] for e in out["events"]].count("invite.received") == 1

--- a/core/flows/tests/test_timeline_render.py
+++ b/core/flows/tests/test_timeline_render.py
@@ -1,0 +1,103 @@
+"""The timeline in a person's own zone — the rendering both readers share (PRD decision 31).
+
+The control-MCP tool and the dispatch preamble render the SAME payload through these functions, so
+what is pinned here is pinned for both.
+"""
+from __future__ import annotations
+
+from flows_timeline.render import clock, line, render_preamble, render_text, when
+
+# 2026-09-02 11:23:05Z — the DNA invite. Lisbon is UTC+1 in September, so the two zones disagree,
+# which is the point: a stamp that reads the same in both proves nothing.
+INVITE = 1_788_348_185.0
+NOW = 1_788_362_400.0                  # same day, 15:20Z / 16:20 in Lisbon
+TOMORROW = NOW + 86_400
+LISBON = "Europe/Lisbon"
+
+
+def _payload(events):
+    return {"now": "2026-09-02T15:20:00Z", "now_epoch": NOW, "events": events}
+
+
+def _ev(at, kind, title, status="done", produced=None, meeting_id=None):
+    e = {"at_epoch": at, "kind": kind, "title": title, "status": status,
+         "produced": produced or {}}
+    if meeting_id:
+        e["meeting_id"] = meeting_id
+    return e
+
+
+def test_a_time_always_carries_its_zone():
+    """Never a bare HH:MM — the Lisbon standup that joined at '19:15' when it was 17:15."""
+    assert clock(INVITE, LISBON) == "12:23 WEST"
+    assert clock(INVITE, "") == "11:23 UTC"
+    assert clock(INVITE, "Not/AZone") == "11:23 UTC"     # a bad setting degrades, never raises
+
+
+def test_another_day_is_dated_not_just_clocked():
+    today = "2026-09-02"
+    assert when(INVITE, LISBON, today) == "12:23 WEST"
+    assert when(TOMORROW, LISBON, today).startswith("Thu 03 Sep ")
+
+
+def test_today_is_the_persons_today_not_the_servers():
+    """23:30 UTC is already tomorrow in Lisbon. The day boundary that matters is theirs."""
+    late = 1_788_391_800.0                                # 2026-09-02 23:30Z → 00:30 on the 3rd
+    assert when(late, LISBON, "2026-09-02").startswith("Thu 03 Sep ")
+    assert when(late, "", "2026-09-02") == "23:30 UTC"
+
+
+def test_a_line_hides_the_boring_status_and_shows_the_interesting_one():
+    ok = line(_ev(INVITE, "report.delivered", "ASWF DNA TSC"), LISBON, "2026-09-02")
+    skipped = line(_ev(INVITE, "report.delivered", "ASWF DNA TSC", status="skipped"),
+                   LISBON, "2026-09-02")
+    assert "[done]" not in ok and "[skipped]" in skipped
+
+
+def test_a_line_shows_what_the_event_produced():
+    got = line(_ev(INVITE, "report.delivered", "DNA", produced={"link": "https://app/x"}),
+               LISBON, "2026-09-02")
+    assert "https://app/x" in got
+
+
+def test_render_text_states_now_first_and_splits_at_it():
+    out = render_text(_payload([_ev(INVITE, "invite.received", "ASWF DNA TSC"),
+                                _ev(NOW + 3600, "meeting.scheduled", "Standup", "scheduled")]),
+                      LISBON)
+    lines = out.splitlines()
+    assert lines[0].startswith("now  Wed 02 Sep  16:20 WEST")
+    assert out.index("already happened") < out.index("still ahead")
+    assert out.index("ASWF DNA TSC") < out.index("Standup")
+
+
+def test_render_text_says_the_zone_is_unset_rather_than_pretending_utc_is_theirs():
+    out = render_text(_payload([]), "")
+    assert "no timezone set" in out.splitlines()[0]
+    assert "nothing in this window" in out and "nothing scheduled" in out
+
+
+def test_the_preamble_is_a_handful_of_lines_capped_both_ways():
+    events = [_ev(NOW - i * 600, "mail.sent", f"past-{i}") for i in range(9, 0, -1)]
+    events += [_ev(NOW + i * 600, "meeting.scheduled", f"next-{i}", "scheduled")
+               for i in range(1, 10)]
+    out = render_preamble(_payload(events), LISBON)
+    assert "past-5" in out and "past-1" in out and "past-6" not in out
+    assert "next-1" in out and "next-5" in out and "next-6" not in out
+
+
+def test_the_preamble_states_now_and_the_zone_rule():
+    out = render_preamble(_payload([_ev(INVITE, "invite.received", "ASWF DNA TSC")]), LISBON)
+    assert "**Now: Wednesday 02 September 2026, 16:20 WEST.**" in out
+    assert "timeline(since, until)" in out                  # the deeper read is named
+    assert "12:23 WEST" in out                              # the event, in THEIR zone
+
+
+def test_an_empty_preamble_says_so_rather_than_implying_a_history():
+    out = render_preamble(_payload([]), LISBON)
+    assert "Nothing recorded" in out
+
+
+def test_no_payload_renders_nothing_at_all():
+    """A heading over an empty list teaches the model the section is noise."""
+    assert render_preamble({}, LISBON) == ""
+    assert render_preamble({"events": []}, LISBON) == ""

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -1987,6 +1987,41 @@ def reactions_list(status: str = "", token: str = "") -> str:
 
 @mcp.tool()
 @_anon_guard
+def timeline(since: str = "", until: str = "", limit: int = 20, token: str = "") -> str:
+    """WHAT HAS HAPPENED TO YOU AND WHAT IS COMING — your own events, in order (PRD decision 31).
+
+    Invites that arrived, meetings scheduled and held, reports delivered, mail sent, replies
+    handled, and anything that failed — merged from the flows engine's own facts and receipts with
+    your meetings table, scoped to you as organizer or attendee. Every time is in YOUR zone, and
+    `now` is stated first so a relative answer ("this morning", "in an hour") has something to be
+    relative to.
+
+    since / until: epoch seconds or ISO-8601. Empty means 14 days back and 30 days forward, so the
+    answer covers both halves of the question — what just happened, and what is next.
+
+    Read-only. It never sends, schedules or cancels anything.\n\n    If you have not called whats_waiting() yet this session, call it first."""
+    uid = me()
+    q = urllib.parse.urlencode({k: v for k, v in
+                                {"subject": uid, "since": since, "until": until,
+                                 "limit": max(1, min(int(limit or 20), 200)),
+                                 "format": "text"}.items() if v != ""})
+    st, body = _http("GET", f"{FLOWS_API}/timeline?{q}", _fkey())
+    if st != 200 or not isinstance(body, dict):
+        return json.dumps({"error": "the timeline is not available", "status": st,
+                           "detail": str(body)[:300],
+                           "note": "the flows route answers this; every other tool is unaffected"})
+    # A THIN FORWARD, on purpose (PRD §3.3). The zone lookup and the rendering happen in the owning
+    # service, where the person's `.settings.json` is already read — not here, and not a second
+    # time in the dispatch preamble, which asks the same route for `format=preamble`. One renderer
+    # is why a chat and a machinery note cannot disagree about when a meeting was.
+    text = body.get("text")
+    if isinstance(text, str) and text.strip():
+        return text[:12000]
+    return _capped({"status": st, "result": body}, 12000)
+
+
+@mcp.tool()
+@_anon_guard
 def reaction_signal(reaction_id: str, verb: str, token: str = "") -> str:
     """Steer one reaction. Every signal is an audited row, never shell surgery on the table.
 
@@ -2129,7 +2164,7 @@ def workspace_write(path: str, content: str, slug: str = "", token: str = "") ->
 @mcp.tool()
 @_anon_guard
 def entity_upsert(kind: str, name: str, facts: list[str], source: str, slug: str = "",
-                  token: str = "") -> str:
+                  dates: dict | None = None, token: str = "") -> str:
     """Record what you just learned about a person, company, meeting, project or decision.
 
     ONE call does the whole thing: it creates `kg/entities/<kind>/<slug>.md` with frontmatter if the
@@ -2151,13 +2186,19 @@ def entity_upsert(kind: str, name: str, facts: list[str], source: str, slug: str
       own message. REQUIRED. A fact with no source is refused, not written — if you do not have one,
       the gap belongs in `kg/MISSING.md`, never on the page.
     - `slug` — a shared workspace, omitted means this person's own desk.
+    - `dates` — WHEN, for a meeting: `{"scheduled_at": ..., "held_at": ..., "report_delivered_at":
+      ...}`, ISO-8601 or epoch, any subset. Record `held_at` the moment you know a meeting ran and
+      `report_delivered_at` the moment its write-up reached them. These are the fields the desk
+      README's `Now` section and `timeline` both read, so a meeting that ran and has no write-up
+      shows up as an open commitment without anyone writing a sentence about it. Any other key is
+      dropped. A call with only `dates` is legal and needs no facts.
     """
     uid = me()
     if isinstance(facts, str):
         facts = [facts]
     st, body = _http("POST", f"{AGENT_API}/api/workspace/entity", {"X-User-Id": uid},
                      {"kind": kind, "name": name, "facts": list(facts or []),
-                      "source": source, "slug": slug or ""})
+                      "source": source, "slug": slug or "", "dates": dates or {}})
     if st == 422:
         detail = (body or {}).get("detail") if isinstance(body, dict) else str(body)
         return json.dumps({"refused": detail,


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.** No money in or out, no dates promised, no rights granted, no published terms, no precedent set.

PRD decision 31 (founder, 2026-09-02 15:5xZ): *"does the agent have temporal awareness of the last events and future events? scheduled meetings, the things that actually get logged in the flows data"* — **it did not.** Lookups on request, no sense of now, recent, or next.

The data was never missing. Every one of those moments is already a row: a **reaction** is a fact that arrived, an **effect receipt** is what we did about it. What was missing was a read along the one axis a person thinks in.

---

## What is here

### 1. `GET /timeline` on flows-api

`?subject=<uid|email>&since=&until=&limit=&meetings=&format=` — reactions, effect receipts and the meetings table, merged, scoped to the person as organizer or attendee, oldest-first. Each item is `{at, at_epoch, kind, title, meeting_id?, produced: {link? mail_subject? note_path? message_id?}, status}`.

Read-only, so it stays open while the instance gate is up — the same rule `GET /flows` and `GET /reactions` already follow.

Auth: the operator key, **or** the narrower `VEXA_FLOWS_TIMELINE_KEY`, which opens this route and nothing else. That second key exists because §1 below needs a credential in every worker container, and handing those containers the operator key — the one that submits and activates flows — to read a list of times would widen its blast radius by one container per person per turn. Unset ⇒ only the operator key works, which is the right default for a deployment that has not thought about it.

### 2. `timeline(since, until, limit)` on the control MCP

A thin forward on the caller's own identity: `me()` is the subject, and the route does the scoping, the zone lookup and the rendering. `now` first, then what already happened, then what is still ahead — every time in the person's zone, from `setting(uid, "timezone")`, never a bare `HH:MM`.

### 3. The block in context, every turn

`shared/timeline.py::timeline_preamble()`, hooked in `worker/engine.py` beside `entity_index_preamble`: now in the person's zone, their last five events, their next five scheduled.

It is **its own function on purpose**, not a section of the human-surface block decision 30 §2 asks for. One surface with two writers loses one writer's intent silently — that is the single line `graph/sg/Operating-Loops.md` exists to state. Whoever composes that block calls this and appends what it returns; this half never writes into theirs.

Cost: one HTTP read per subject per minute, three-second timeout, and **a failure is cached like an answer** — a flows-api that is down costs a worker one timeout an hour, not one a turn. No route or key ⇒ no block, and the turn is byte-identical to what it was before this existed.

### 4. Write-back: a meeting page knows when it happened

`entity_upsert` takes `dates` — `scheduled_at`, `held_at`, `report_delivered_at`, a closed set, normalised to ISO-8601 UTC. `shared/desk_now.py` reads exactly those three keys into the desk README's `Now` section (decision 26.4): next meetings, and open commitments — which is precisely `held_at` set with no `report_delivered_at`, a fact with a shape rather than a judgement.

**It does not write the README.** Whoever owns that file calls `render_now(root)` and drops the result between its markers. Both readers read facts, so `Now` and the timeline cannot drift into two stories about one meeting (decision 31 §3).

A dates-only call is a real change and appends **no** dated entry: the report going out is a property of the meeting, not a new fact about it.

---

## Three things the tests pin, because each is silent when wrong

**Scoping needs BOTH identifiers.** The invite lineage carries an organizer address and no uid; the completed lineage carries a uid. Scoping on either alone returns half the person's day and looks entirely correct. `test_scoping_needs_both_identifiers`.

**Machinery is not an event.** Receipt steps become events through a whitelist (`STEP_KINDS`), so adding a step cannot quietly fill timelines with `ensure_user`. A **failed** receipt is always an event, whatever its step — the one thing an agent must not do is talk about a report it never delivered.

**One renderer.** `format=text` (a person asking) and `format=preamble` (their agent, told unasked) are rendered by the same functions, server-side, in the subject's own zone. Two renderers is how a chat and a machinery note end up disagreeing about one meeting.

---

## Proof

**Unit — 64 tests, all offline, zero dependencies.** `core/flows/tests/test_timeline.py` (22: scoping · mapping · merge · ordering · identity), `core/flows/tests/test_timeline_render.py` (11: the zone rules, including that *today* is the person's today, not the server's), `core/agent/tests/test_timeline_preamble.py` (14: the block reaches the turn prompt; every degrade path returns `""`; one call a minute), `core/agent/tests/test_desk_now.py` (17: the dated facts, and `Now` reading them).

**Offline, against a real lane database.** `core/flows/scripts/proof_timeline.py` opens the lane through the container's psql with the **server** enforcing `default_transaction_read_only=on`, and issues only the two SELECTs the service issues. The sim lane's `flows_sim` holds no reactions, so it read the founder lane's `flows`, read-only, and replayed today's DNA day:

```
lane=flows  uid=126  email=admin@vexa.ai  day=2026-09-02

  2026-09-02T11:23:05Z  invite.received    cancelled  m=-     ASWF DNA TSC
  2026-09-02T11:23:06Z  invite.accepted    done       m=-     ASWF DNA TSC     message_id=<1788348186…>
  2026-09-02T11:23:06Z  mail.sent          skipped    m=-     ASWF DNA TSC
  2026-09-02T11:23:06Z  meeting.scheduled  done       m=-     ASWF DNA TSC
  2026-09-02T11:23:07Z  mail.sent          done       m=104   ASWF DNA TSC     message_id=<1788348187…>
  2026-09-02T11:34:40Z  meeting.held       completed  m=105   meeting
  2026-09-02T13:52:35Z  meeting.held       done       m=104   ASWF DNA TSC
  2026-09-02T13:55:12Z  report.written     done       m=104   ASWF DNA TSC
  2026-09-02T13:55:12Z  report.delivered   done       m=104   ASWF DNA TSC     link=https://app.dev.vexa.ai/?s=…
  2026-09-02T13:55:12Z  report.delivered   skipped    m=104   ASWF DNA TSC

  events: 10   ascending: True
  the DNA sequence [invite.received, mail.sent, meeting.held, report.delivered] in order: YES at [0, 2, 5, 8]
```

and the same payload through `format=preamble`, in a person's zone:

```
## Where this person is in time

**Now: Thursday 03 September 2026, 01:00 WEST.** State times in this zone; never a bare clock
time from another one. `timeline(since, until)` reaches further back or further forward.

Last events concerning them:
   Wed 02 Sep 14:52 WEST  meeting.held      ASWF DNA TSC
   Wed 02 Sep 14:55 WEST  report.written    ASWF DNA TSC
   Wed 02 Sep 14:55 WEST  report.delivered  ASWF DNA TSC  https://app.dev.vexa.ai/?s=…
```

**Gates.** All fourteen pre-push static gates green (pushed without `--no-verify`). Suites: flows 235 passed, agent 997 passed. Three failures are pre-existing and environmental, verified against the untouched base: two `test_contract_smokes` cases hitting live services with the retired `changeme` key, and `test_meeting_room` importing `requests_unixsocket`, a `core/runtime` dependency absent from the agent test venv.

---

## What this does not do

- **The route is not wired into a running lane.** Nothing here changes the running stack; `VEXA_FLOWS_TIMELINE_KEY` and `VEXA_FLOWS_API_URL` are unset, so the per-dispatch block is absent until an operator mints the key. That is the deliberate default.
- **`shared/desk_readme.py` does not exist on this line yet.** Decision 26.4's README owner is somebody else's work; this adds the field and the reader (`shared/desk_now.py::render_now`) so that when it lands, `Now` is one call away and reads the same facts the timeline does.
- **The meetings half costs one API token per person per process.** `fetch_meetings` mints a gateway key through `user_api_key` and caches it for the process's life, so a preamble every 60 s does not leave a token per person per minute in the identity database. A read-only internal route for another user's meetings would remove the mint entirely; it does not exist today.

Owning issue: [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449).

<!-- vexa-agent -->
