### PR TITLE
desk `Now`: one implementation, one renderer — filed dates, never prose

### DIFF
--- a/core/agent/eval/workspace_links_replay.py
+++ b/core/agent/eval/workspace_links_replay.py
@@ -21,12 +21,19 @@ WHAT IT PROVES, and why the shape is what it is:
   6. A DESK, though, is a different answer (founder ruling, 2026-09-02): readable by any signed-in
      member of this instance, writable only by its owner, and `not-yours` only from outside the
      instance. Groups gate on membership; desks gate on writing.
+  7. The README's `## Now` is built from FILED DATES and nothing else (coordinator ruling,
+     2026-09-02). The replay files them the way the write-back phase does — `held_at` when a
+     meeting ran, `report_delivered_at` when its write-up went out, `scheduled_at` for the next
+     one, `due_at` for a commitment — and then asserts that all three of `Now`'s lists say what
+     those fields say. A page here also carries a date in PROSE, under the heading the old scraper
+     matched, and `Now` must not show it.
 
 Usage:  python core/agent/eval/workspace_links_replay.py --fixtures ~/dna-fixtures
 """
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import pathlib
 import re
@@ -137,7 +144,13 @@ def main() -> int:
         mounts = [{"path": str(desk)}, {"path": str(group)}]
         written = 0
 
-        def play(truth: dict) -> None:
+        def at(day: str, hour: int = 15) -> float:
+            """An instant on a fixture's day, UTC — what `entity_upsert(dates=)` files."""
+            d = datetime.date.fromisoformat(day)
+            return datetime.datetime(d.year, d.month, d.day, hour,
+                                     tzinfo=datetime.timezone.utc).timestamp()
+
+        def play(truth: dict, *, delivered: bool) -> None:
             """One meeting, the way decision 22 says a group meeting lands: the PEOPLE and the
             COMPANIES go on the GROUP desk (the run actively maintains it), and the person's own
             desk gets the meeting entity — whose links therefore point across."""
@@ -152,15 +165,26 @@ def main() -> int:
                               f"the {truth['date']} transcript", today=truth["date"])
             facts = [f"Present: " + ", ".join(f"[[{p}]]" for p in truth["people"]) + "."]
             facts += [f"Decided: {d}" for d in truth.get("decided", [])[:3]]
+            # THE DATES ARE FILED, NOT WRITTEN. `held_at` says it ran; `report_delivered_at`
+            # says the write-up reached them, which is what closes the open commitment. A meeting
+            # with the first and not the second is exactly what `Now` calls open.
+            stamps = {"held_at": at(truth["date"])}
+            if delivered:
+                stamps["report_delivered_at"] = at(truth["date"], 18)
             out = upsert_entity(desk, "meeting", f"DNA TSC {truth['date']}", facts,
                                 f"the {truth['date']} transcript", today=truth["date"],
-                                mounts=mounts)
+                                mounts=mounts, dates=stamps)
+            # …and one date in PROSE, under the heading the retired scraper matched. `Now` must not
+            # show it: nothing filed it, so nothing could ever move it or close it either.
+            page = desk / out["path"]
+            page.write_text(page.read_text()
+                            + f"\n## Committed\n\n- Circulate the charter by {truth['date']}\n")
             written += len(out.get("links_rewritten") or [])
             report["steps"].append({"meeting": truth["date"], "page": out["path"],
                                     "links_rewritten": len(out.get("links_rewritten") or [])})
 
         first, second = read_truth(truths[0]), read_truth(truths[1])
-        play(first)
+        play(first, delivered=True)
 
         # ── THE RENAME, and the move with it ────────────────────────────────────────────────────
         renamed_slug = "digital-naming-authority"
@@ -172,7 +196,17 @@ def main() -> int:
         report["rename"] = {"from": GROUP, "to": renamed_slug,
                             "id_unchanged": registry.by_slug(renamed_slug)["id"] == group_id}
 
-        play(second)
+        play(second, delivered=False)          # its write-up never went out — an OPEN commitment
+
+        # The two facts a desk holds about what is ahead, both FILED: the next meeting, and one
+        # thing owed by a date.
+        when_next = at(second["date"]) + 14 * 86400
+        upsert_entity(desk, "meeting", "DNA TSC next", ["Booked in the series."], "the invite",
+                      today=second["date"], dates={"scheduled_at": when_next})
+        upsert_entity(desk, "decision", "Sign the ASWF CLA",
+                      ["SPI asked for the standard shape rather than an authorisation letter."],
+                      f"the {second['date']} transcript", today=second["date"],
+                      dates={"due_at": at(second["date"]) + 7 * 86400})
 
         # ── the desk README, which is the desk: a HUB OF LINKS (founder refinement 2026-09-02) ──
         # Fed every mount, so the group's own cards appear on the desk in `ws:` id form — the whole
@@ -182,13 +216,23 @@ def main() -> int:
             workspaces=[{"id": group_id, "name": "Digital Naming Authority"}],
             touches=[{"workspace": group_id,
                       "path": "kg/entities/person/cottalango-leon.md", "at": 9e9}],
-            home_id=desk_id, name="olga@spi.com", today=second["date"])
+            home_id=desk_id, name="olga@spi.com", now=at(second["date"], 18))
         readme = (desk / desk_readme.README).read_text()
+        now_block = readme.split("## Now", 1)[1].split("<!-- desk:now:end -->", 1)[0]
         report["readme"] = {
             "links_to_group_cards": readme.count(f"[[ws:{group_id}/"),
             "pinned_is_untouched": desk_readme.PINNED_HINT in readme,
             "most_used_card_is_first": (readme.split("## People")[1].strip().splitlines() or [""])[0]
                                        == f"- [[ws:{group_id}/cottalango-leon]]",
+        }
+        report["now"] = {
+            "next_meeting": "[[DNA TSC next]]" in now_block,
+            "dated_commitment": "[[Sign the ASWF CLA]]" in now_block,
+            "open_commitment": (f"[[DNA TSC {second['date']}]]" in now_block
+                                and "no write-up yet" in now_block),
+            "delivered_meeting_is_closed": f"[[DNA TSC {first['date']}]]" not in now_block,
+            "a_date_in_prose_is_ignored": "Circulate the charter" not in now_block,
+            "lines": [ln for ln in now_block.strip().splitlines() if ln.startswith("- ")],
         }
 
         # ── RESOLVE EVERYTHING THE DESK NOW HOLDS, as both readers ──────────────────────────────
@@ -239,6 +283,13 @@ def main() -> int:
             "the card the person opened is at the top of its section":
                 report["readme"]["most_used_card_is_first"],
             "Pinned is left to the person": report["readme"]["pinned_is_untouched"],
+            "`Now` shows the next meeting, from `scheduled_at`": report["now"]["next_meeting"],
+            "`Now` shows a commitment, from `due_at`": report["now"]["dated_commitment"],
+            "`Now` shows the meeting whose write-up never went out":
+                report["now"]["open_commitment"],
+            "`Now` drops the meeting whose write-up did":
+                report["now"]["delivered_meeting_is_closed"],
+            "`Now` ignores a date written in prose": report["now"]["a_date_in_prose_is_ignored"],
             "the desk is readable by its owner, and writable":
                 report["a_link_into_the_desk"]["its_owner"] == {"access": "readable", "writable": True},
             "the desk is readable by a colleague, and NOT writable":

--- a/core/agent/shared/desk_now.py
+++ b/core/agent/shared/desk_now.py
@@ -1,4 +1,4 @@
-"""THE DESK README'S `Now` SECTION, built from the same dated facts the timeline reads.
+"""THE DESK README'S `Now` SECTION, built from dated FACTS — the one implementation, the one renderer.
 
 PRD decision 26.4 (founder, 2026-09-02 14:0xZ): the desk README *is* the desk, *"mostly links to
 the other cards in different workspaces"*, and one of its sections is `Now` — next meetings, open
@@ -9,34 +9,50 @@ AGREE is the requirement, and it is why this module exists instead of a second q
 reads the flows engine; the desk README reads the workspace. If the README derived its `Now` from
 its own prose — "the meeting is Thursday", written by a model that read a note — the two would
 drift silently the first time a meeting moved, and the person would be told two different things by
-one product on one screen. So the meeting PAGE carries the dates, `entity_upsert` is the only thing
-that writes them (`shared/entities.py`, the `dates` argument), and both readers read facts rather
-than sentences.
+one product on one screen. So the PAGE carries the dates, `entity_upsert` is the only thing that
+writes them (`shared/entities.py`, the `dates` argument), and both readers read facts rather than
+sentences.
 
-Three frontmatter keys, all ISO-8601 UTC, all optional:
+⚠ THERE WERE TWO OF THESE, AND THE OTHER ONE SCRAPED PROSE. `desk_readme._now_rows` shipped first
+and found a meeting's date by looking for an ISO string in its title or body, and a commitment by
+matching `## Committed`-shaped headings and pulling dates out of their bullets. It worked on the
+notes the fixtures happen to contain and it is the exact drift this docstring was written to warn
+about: a date is whatever a model last typed, a commitment is whatever a heading was called, and
+nothing that moves a meeting can move the README. It is gone. This module is now the only answer to
+"what is Now", and `desk_readme` is the only thing that writes the file it lands in — one writer,
+one renderer (coordinator ruling, 2026-09-02).
+
+Four frontmatter keys, all ISO-8601 UTC, all optional, all written ONLY by `entity_upsert(dates=)`:
 
     scheduled_at:        when it is meant to happen        → a next meeting
     held_at:             when it actually ran              → it happened
     report_delivered_at: when the write-up reached them    → the commitment is closed
+    due_at:              when something is owed BY         → a dated commitment
 
 An OPEN COMMITMENT is exactly `held_at` set and `report_delivered_at` absent: the meeting happened
 and nothing has been delivered about it. That is a fact with a shape, not a judgement, which is the
-only kind of thing a section like this can be built out of.
+only kind of thing a section like this can be built out of. A DATED COMMITMENT is `due_at` still
+ahead — and it is a field precisely so that "circulate the charter by the 20th" reaches `Now`
+because the write-back phase FILED it with a source, never because a regex found a date in a
+sentence somebody wrote.
 
-This module does NOT write the README. Whoever owns that file calls `render_now(root)` and drops
-the result between its markers — one loop, one write surface.
+Nothing here writes the README. Whoever owns that file calls `render_now(...)` and drops the result
+between its markers.
 """
 from __future__ import annotations
 
 import datetime
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
-from shared.entities import split_frontmatter
+# ONE closed set, defined where it is written and imported where it is read. Two copies of a
+# frontmatter contract is the same drift in miniature: the writer gains a key, the reader never
+# hears about it, and the section quietly stops showing a whole class of fact.
+from shared.entities import DATE_FIELDS, ENTITIES_DIR, KINDS, split_frontmatter
+from shared.links import format_ref
 
 MEETING_KIND = "meeting"
-DATE_FIELDS = ("scheduled_at", "held_at", "report_delivered_at")
 
 UTC = datetime.timezone.utc
 _FM_LINE = re.compile(r"^([A-Za-z_][A-Za-z0-9_\-]*)\s*:\s*(.*)$")
@@ -44,6 +60,12 @@ _FM_LINE = re.compile(r"^([A-Za-z_][A-Za-z0-9_\-]*)\s*:\s*(.*)$")
 # How far back a meeting whose write-up never arrived keeps asking. Beyond this it is history, not
 # a commitment — a `Now` section that still lists last month is a section people stop reading.
 OPEN_WINDOW_DAYS = 14
+
+# The caps. `Now` is the top of the page a person opens without asking for it; past about a dozen
+# rows it stops being "what is now" and becomes a list they scroll past.
+AHEAD_MAX = 5        # next meetings
+OPEN_MAX = 5         # meetings held with no write-up delivered
+DUE_MAX = 10         # things owed by a date
 
 
 def _epoch(value: str) -> Optional[float]:
@@ -61,14 +83,19 @@ def _epoch(value: str) -> Optional[float]:
     return (dt if dt.tzinfo else dt.replace(tzinfo=UTC)).timestamp()
 
 
-def read_page(path: Path) -> dict:
-    """`{title, path, scheduled_at, held_at, report_delivered_at}` — epochs, absent keys omitted."""
+def read_page(path: Path, *, workspace: str = "", home: bool = True) -> dict:
+    """`{title, slug, path, workspace, home, <date fields>}` — epochs, absent keys omitted.
+
+    `workspace`/`home` ride along so the renderer can form the right link without a second read:
+    a card on this desk is `[[Title]]`, a card in another mounted workspace is
+    `[[ws:<workspace-id>/<entity-id>]]` (PRD decision 26.2)."""
     try:
         raw = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return {}
     fm, _body = split_frontmatter(raw)
-    out: dict = {"path": str(path), "title": path.stem}
+    out: dict = {"path": str(path), "title": path.stem, "slug": path.stem,
+                 "workspace": workspace, "home": home}
     for line in fm:
         m = _FM_LINE.match(line.strip())
         if not m:
@@ -76,6 +103,8 @@ def read_page(path: Path) -> dict:
         key, value = m.group(1), m.group(2).strip()
         if key == "title" and value:
             out["title"] = value.strip("'\"")
+        elif key == "id" and value:
+            out["slug"] = value.strip("'\"")
         elif key == "template" and value.lower() in ("true", "yes"):
             return {}                  # a shape is not a meeting (the entity-index rule, same list)
         elif key in DATE_FIELDS:
@@ -85,38 +114,78 @@ def read_page(path: Path) -> dict:
     return out
 
 
-def meetings(root) -> list[dict]:
-    """Every meeting page on this desk that carries at least one date. Order is not decided here."""
-    folder = Path(root) / "kg" / "entities" / MEETING_KIND
-    if not folder.is_dir():
-        return []
-    out = []
-    for f in sorted(folder.glob("*.md")):
-        page = read_page(f)
-        if page and any(k in page for k in DATE_FIELDS):
-            out.append(page)
+def _roots(where) -> list[dict]:
+    """Accept a single workspace path OR the mount set. One function, two call shapes.
+
+    A bare path is the single-desk case (and the shape every caller had before `Now` learned about
+    other workspaces); a list of `{path, id}` is the mount set, where exactly the entry whose id
+    matches `home_id` is rendered with the in-workspace link form."""
+    if isinstance(where, (str, Path)):
+        return [{"path": str(where), "id": "", "home": True}]
+    return [{"path": str(m.get("path") or ""), "id": str(m.get("id") or ""),
+             "home": bool(m.get("home"))}
+            for m in (where or []) if isinstance(m, dict) and m.get("path")]
+
+
+def dated_pages(where, *, kinds: Iterable[str] = KINDS, home_id: str = "") -> list[dict]:
+    """Every entity page carrying at least one date field, across every workspace given.
+
+    All kinds, not only `meeting`: a `due_at` belongs wherever the thing that is owed lives, and
+    restricting the scan to meetings would silently drop every commitment filed on a project or a
+    decision page. Order is not decided here."""
+    out: list[dict] = []
+    for mount in _roots(where):
+        base = Path(mount["path"]) / ENTITIES_DIR
+        if not base.is_dir():
+            continue
+        home = mount["home"] or (bool(home_id) and mount["id"] == home_id) or not mount["id"]
+        for kind in kinds:
+            folder = base / kind
+            if not folder.is_dir():
+                continue
+            for f in sorted(folder.glob("*.md")):
+                if f.name == "index.md":
+                    continue
+                page = read_page(f, workspace=mount["id"], home=home)
+                if page and any(k in page for k in DATE_FIELDS):
+                    page["kind"] = kind
+                    out.append(page)
     return out
 
 
-def now_rows(root, *, now: Optional[float] = None, ahead: int = 5,
-             open_window_days: int = OPEN_WINDOW_DAYS) -> dict:
-    """`{"next": [...], "open": [...]}` — the two lists decision 26.4 names, from the pages.
+def meetings(where, *, home_id: str = "") -> list[dict]:
+    """Every MEETING page carrying at least one date. Kept as its own name because that is what the
+    timeline and the tests ask for; `dated_pages` is the general case."""
+    return dated_pages(where, kinds=(MEETING_KIND,), home_id=home_id)
 
-    `next`  — `scheduled_at` still ahead, soonest first, and never one that already has a
-              `held_at`: a meeting that ran is not still coming, whatever its calendar row says.
-    `open`  — `held_at` inside the window with no `report_delivered_at`. Most recent first, because
-              the write-up nobody has seen yet is the one most likely to still be wanted.
+
+def now_rows(where, *, now: Optional[float] = None, ahead: int = AHEAD_MAX,
+             open_window_days: int = OPEN_WINDOW_DAYS, home_id: str = "") -> dict:
+    """`{"next": [...], "open": [...], "due": [...]}` — decision 26.4's section, from the pages.
+
+    `next`  — a MEETING whose `scheduled_at` is still ahead, soonest first, and never one that
+              already has a `held_at`: a meeting that ran is not still coming, whatever its calendar
+              row says.
+    `open`  — a MEETING whose `held_at` is inside the window with no `report_delivered_at`. Most
+              recent first, because the write-up nobody has seen yet is the one most likely to still
+              be wanted.
+    `due`   — ANY page whose `due_at` is still ahead, soonest first. A field, never a sentence: the
+              write-back phase files it with a source, and nothing else can put a commitment here.
     """
     now = datetime.datetime.now(UTC).timestamp() if now is None else float(now)
     floor = now - open_window_days * 86400
-    pages = meetings(root)
-    nxt = sorted((p for p in pages
-                  if p.get("scheduled_at", 0) > now and "held_at" not in p),
-                 key=lambda p: p["scheduled_at"])[:ahead]
-    opn = sorted((p for p in pages
-                  if floor <= p.get("held_at", 0) <= now and "report_delivered_at" not in p),
-                 key=lambda p: p["held_at"], reverse=True)
-    return {"next": nxt, "open": opn}
+    pages = dated_pages(where, home_id=home_id)
+    mtgs = [p for p in pages if p.get("kind") == MEETING_KIND]
+    return {
+        "next": sorted((p for p in mtgs
+                        if p.get("scheduled_at", 0) > now and "held_at" not in p),
+                       key=lambda p: p["scheduled_at"])[:ahead],
+        "open": sorted((p for p in mtgs
+                        if floor <= p.get("held_at", 0) <= now and "report_delivered_at" not in p),
+                       key=lambda p: p["held_at"], reverse=True)[:OPEN_MAX],
+        "due": sorted((p for p in pages if p.get("due_at", 0) > now),
+                      key=lambda p: p["due_at"])[:DUE_MAX],
+    }
 
 
 def _stamp(epoch: float, tz: str = "") -> str:
@@ -131,22 +200,33 @@ def _stamp(epoch: float, tz: str = "") -> str:
     return t.strftime("%a %d %b %H:%M ") + (t.tzname() or "UTC")
 
 
-def render_now(root, *, now: Optional[float] = None, tz: str = "", ahead: int = 5) -> str:
+def link_to(page: dict) -> str:
+    """`[[Title]]` on this desk; `[[ws:<workspace-id>/<entity-id>]]` anywhere else (decision 26.2)."""
+    return (f"[[{page.get('title')}]]" if page.get("home") or not page.get("workspace")
+            else format_ref(str(page["workspace"]), str(page.get("slug") or "")))
+
+
+def render_now(where, *, now: Optional[float] = None, tz: str = "", ahead: int = AHEAD_MAX,
+               home_id: str = "") -> str:
     """The `Now` section body — LINKS, per decision 26.4, never prose about the links.
 
     Returned without its heading and without the markers: the README's owner puts it where it goes.
     Empty lists are stated, not hidden. "Nothing scheduled" is information; a section that silently
     disappears when it has nothing to say reads as a bug the first time someone looks for it.
     """
-    rows = now_rows(root, now=now, ahead=ahead)
+    rows = now_rows(where, now=now, ahead=ahead, home_id=home_id)
     out: list[str] = []
     if rows["next"]:
         for p in rows["next"]:
-            out.append(f"- {_stamp(p['scheduled_at'], tz)} — [[{p['title']}]]")
+            out.append(f"- {_stamp(p['scheduled_at'], tz)} — {link_to(p)}")
     else:
         out.append("- Nothing scheduled.")
+    if rows["due"]:
+        out.append("")
+        for p in rows["due"]:
+            out.append(f"- due {_stamp(p['due_at'], tz)} — {link_to(p)}")
     if rows["open"]:
         out.append("")
         for p in rows["open"]:
-            out.append(f"- [[{p['title']}]] — held {_stamp(p['held_at'], tz)}, no write-up yet")
+            out.append(f"- {link_to(p)} — held {_stamp(p['held_at'], tz)}, no write-up yet")
     return "\n".join(out) + "\n"

--- a/core/agent/shared/desk_readme.py
+++ b/core/agent/shared/desk_readme.py
@@ -14,7 +14,7 @@ The page, in order:
 
     # <name> — desk                  two lines of prose, written once, never regenerated
     ## Pinned                        THEIRS. Hand-edited, never touched by this module.
-    ## Now                           next meetings (<=5) + dated open commitments (<=10)
+    ## Now                           next meetings + what is owed — see `shared/desk_now.py`
     ## People / Companies / Projects most-used first, <=12 each, across workspaces
     ## Workspaces                    the groups they are in, id-linked
     ## Recently opened               the last 10 pages they actually opened
@@ -37,6 +37,15 @@ LINK FORM. A card in ANOTHER mounted workspace is `[[ws:<workspace-id>/<entity-i
 survives that workspace being renamed and renders its title at read time (PRD decision 26.2). A card
 on THIS desk stays `[[Title]]` — the in-workspace form, unchanged, and writing an id form for the
 workspace the file is already in would be a redirection through an id for no gain.
+
+⚠ `## Now` IS NOT BUILT HERE. This module writes the file; `shared/desk_now.py` decides what `Now`
+says and renders it (coordinator ruling, 2026-09-02: one writer, one renderer). There were briefly
+two implementations — this one scraped dates out of a card's title and prose and matched
+`## Committed`-shaped headings for commitments — and the other is right for a reason worth keeping
+in front of whoever edits this file next: a date found in a sentence is whatever a model last typed,
+so moving a meeting cannot move the README, and the timeline and the desk end up telling one person
+two different things on one screen. Every date in `Now` is now a frontmatter field that
+`entity_upsert(dates=)` filed, with a source.
 """
 from __future__ import annotations
 
@@ -45,6 +54,7 @@ import re
 from pathlib import Path
 from typing import Iterable, Optional
 
+from shared import desk_now
 from shared.entities import ENTITIES_DIR, KINDS, split_frontmatter
 from shared.links import format_ref
 
@@ -72,8 +82,6 @@ RETIRED_SECTIONS = ("meetings", "commitments", "dates", "purpose", "objective", 
 
 _MARKER = "<!-- desk:{key}:{edge} -->"
 
-MEETINGS_MAX = 5
-COMMITMENTS_MAX = 10
 CARDS_MAX = 12
 RECENT_MAX = 10
 
@@ -81,14 +89,10 @@ RECENT_MAX = 10
 # own: a meeting is in `## Now` while it is ahead and in the card it belongs to afterwards.
 CARD_KINDS = {"people": "person", "companies": "company", "projects": "project"}
 
-_COMMIT_HEADING = re.compile(r"^#{1,6}\s*(committed|commitments|open items?|action items?|next steps?)\b",
-                             re.I | re.M)
-_HEADING = re.compile(r"^#{1,6}\s", re.M)
-_BULLET = re.compile(r"^\s*[-*]\s+(.+?)\s*$", re.M)
-_ISO_DATE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
+# The one regex left in this module, and it is not about dates in prose: it finds the dated ENTRY
+# HEADINGS `entity_upsert` writes (`## 2026-09-02`), which is how "when was this page last written"
+# is answered for the usage ranking. Nothing here reads a date out of a sentence any more.
 _DATED_HEADING = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*$", re.M)
-_SOURCE_SUFFIX = re.compile(r"\s+—\s+source:\s.*$")
-_FM_DATE_KEYS = ("date", "when", "scheduled", "starts", "start")
 
 
 def _marker(key: str, edge: str) -> str:
@@ -100,12 +104,12 @@ def _marker(key: str, edge: str) -> str:
 class Card:
     """One entity page, wherever it lives. The unit every section is made of."""
 
-    __slots__ = ("kind", "title", "slug", "path", "workspace", "home", "text", "when", "modified")
+    __slots__ = ("kind", "title", "slug", "path", "workspace", "home", "text", "modified")
 
-    def __init__(self, *, kind, title, slug, path, workspace, home, text, when, modified):
+    def __init__(self, *, kind, title, slug, path, workspace, home, text, modified):
         self.kind, self.title, self.slug, self.path = kind, title, slug, path
         self.workspace, self.home, self.text = workspace, home, text
-        self.when, self.modified = when, modified
+        self.modified = modified
 
     @property
     def link(self) -> str:
@@ -124,24 +128,6 @@ def _fm(lines: list[str], key: str) -> Optional[str]:
         if sep and k.strip() == key:
             return v.split("#")[0].strip()
     return None
-
-
-def _card_when(fm: list[str], text: str, title: str) -> Optional[str]:
-    """The date this card is ABOUT — a meeting's own date, not when it was written.
-
-    Frontmatter first (`date`/`when`/`scheduled`), then the title (meeting pages are named
-    `DNA TSC 2026-03-16`), then the earliest ISO date in the body. Dated entry headings are
-    excluded: those are when somebody wrote, which is the signal this deliberately is not."""
-    for key in _FM_DATE_KEYS:
-        v = _fm(fm, key)
-        if v and _ISO_DATE.search(v):
-            return _ISO_DATE.search(v).group(1)
-    m = _ISO_DATE.search(title or "")
-    if m:
-        return m.group(1)
-    body = _DATED_HEADING.sub(" ", text or "")
-    found = sorted(set(_ISO_DATE.findall(body)))
-    return found[0] if found else None
 
 
 def cards(mounts: Iterable[dict], home_id: str) -> list[Card]:
@@ -174,10 +160,9 @@ def cards(mounts: Iterable[dict], home_id: str) -> list[Card]:
                 if (_fm(fm, "template") or "").lower() == "true":
                     continue          # a SHAPE is never a card
                 title = _fm(fm, "title") or f.stem
-                out.append(Card(kind=kind, title=title, slug=f.stem,
+                out.append(Card(kind=kind, title=title, slug=_fm(fm, "id") or f.stem,
                                 path=f"{ENTITIES_DIR}/{kind}/{f.name}", workspace=wid,
-                                home=(wid == home_id), text=text,
-                                when=_card_when(fm, text, title), modified=modified))
+                                home=(wid == home_id), text=text, modified=modified))
     return out
 
 
@@ -202,25 +187,6 @@ def _rank(card: Card, touched: dict) -> float:
 
 
 # ── the sections ─────────────────────────────────────────────────────────────────────────────────
-
-def _now_rows(cards_: list[Card], today: str) -> list[str]:
-    """What is ahead: meetings, then dated commitments. One line per link, date first."""
-    ahead = sorted((c for c in cards_ if c.kind == "meeting" and c.when and c.when >= today),
-                   key=lambda c: c.when)[:MEETINGS_MAX]
-    rows = [f"- {c.when} — {c.link}" for c in ahead]
-
-    dated: list[tuple[str, str]] = []
-    for c in cards_:
-        for m in _COMMIT_HEADING.finditer(c.text):
-            nxt = _HEADING.search(c.text, m.end())
-            for b in _BULLET.findall(c.text[m.end(): nxt.start() if nxt else len(c.text)]):
-                line = _SOURCE_SUFFIX.sub("", b).strip()
-                day = next((d for d in sorted(_ISO_DATE.findall(line)) if d >= today), None)
-                if day and line:
-                    dated.append((day, f"- {day} — {line} — {c.link}"))
-    rows += [row for _d, row in sorted(dated)[:COMMITMENTS_MAX]]
-    return rows
-
 
 def _card_rows(cards_: list[Card], kind: str, touched: dict) -> list[str]:
     picked = sorted((c for c in cards_ if c.kind == kind), key=lambda c: _rank(c, touched), reverse=True)
@@ -262,11 +228,24 @@ PINNED_HINT = ("<!-- Yours. Put the links you want at the top of your desk here 
                "this section is hand-edited, and nothing in it is ever regenerated. -->")
 
 
+def _now_epoch(now: Optional[float], today: Optional[str]) -> Optional[float]:
+    """The instant `Now` is evaluated at. `now` wins; `today` means the START of that day, so a
+    caller that only knows a date still gets everything scheduled during it."""
+    if now is not None:
+        return float(now)
+    if not today:
+        return None
+    try:
+        return _dt.datetime.fromisoformat(str(today)).replace(tzinfo=_dt.timezone.utc).timestamp()
+    except ValueError:
+        return None
+
+
 def render_sections(root, *, mounts: Iterable[dict] = (), workspaces: Iterable[dict] = (),
                     touches: Optional[list] = None, home_id: str = "",
-                    today: Optional[str] = None) -> dict:
+                    today: Optional[str] = None, now: Optional[float] = None,
+                    tz: str = "") -> dict:
     """`{key: body}` — the generated body of every section, headings included."""
-    day = today or _dt.date.today().isoformat()
     mounts = list(mounts or [])
     if not mounts:
         mounts = [{"path": str(root), "id": home_id}]
@@ -280,10 +259,14 @@ def render_sections(root, *, mounts: Iterable[dict] = (), workspaces: Iterable[d
             return head + f"\n_{empty}_\n"
         return head + "\n" + "\n".join(rows) + "\n"
 
+    # `Now` is `desk_now`'s answer, verbatim. It is the one section whose CONTENT this module does
+    # not decide — it renders itself, from the same frontmatter facts the timeline reads, so the two
+    # cannot disagree (decision 31 §3).
+    now_body = desk_now.render_now(mounts, now=_now_epoch(now, today), tz=tz,
+                                   home_id=home_id).rstrip("\n")
     return {
         "pinned": f"## Pinned\n\n{PINNED_HINT}\n",
-        "now": block("Now", _now_rows(all_cards, day),
-                     f"Nothing scheduled or committed on or after {day}."),
+        "now": "## Now\n\n" + now_body + "\n",
         "people": block("People", _card_rows(all_cards, "person", touched),
                         "No people on this desk yet."),
         "companies": block("Companies", _card_rows(all_cards, "company", touched),
@@ -328,7 +311,8 @@ def header_for(name: str = "") -> str:
 
 def update_readme(root, *, mounts: Iterable[dict] = (), workspaces: Iterable[dict] = (),
                   touches: Optional[list] = None, home_id: str = "", name: str = "",
-                  today: Optional[str] = None) -> dict:
+                  today: Optional[str] = None, now: Optional[float] = None,
+                  tz: str = "") -> dict:
     """Regenerate the desk README's marked sections. Returns `{path, changed, sections}`.
 
     Idempotent: a desk whose cards and touches have not moved rewrites byte-identical content and
@@ -342,7 +326,7 @@ def update_readme(root, *, mounts: Iterable[dict] = (), workspaces: Iterable[dic
     for key in RETIRED_SECTIONS:
         text = _drop_marked(text, key)
     sections = render_sections(root, mounts=mounts, workspaces=workspaces, touches=touches,
-                               home_id=home_id, today=today)
+                               home_id=home_id, today=today, now=now, tz=tz)
     appended: list[str] = []
     for key, _heading in SECTIONS:
         found = _marker(key, "start") in text and _marker(key, "end") in text

--- a/core/agent/shared/entities.py
+++ b/core/agent/shared/entities.py
@@ -236,7 +236,7 @@ def _rewrite_links(root, facts, *, name: str, mounts) -> tuple[list, list]:
 # timeline read the same fact instead of two descriptions of it (`shared/desk_now.py` is the
 # reader). Three keys, closed set, ISO-8601 UTC. A closed set on purpose: an open one turns
 # frontmatter into a scratchpad, and the value of these is that a reader knows what it will find.
-DATE_FIELDS = ("scheduled_at", "held_at", "report_delivered_at")
+DATE_FIELDS = ("scheduled_at", "held_at", "report_delivered_at", "due_at")
 
 
 def _as_iso(value) -> str:
@@ -294,11 +294,18 @@ def upsert_entity(root, kind: str, name: str, facts, source: str, *,
     behaviour, byte-identical to before.
 
     ``dates`` records WHEN, in frontmatter, for the keys in ``DATE_FIELDS`` — `scheduled_at`,
-    `held_at`, `report_delivered_at`. It is how the desk README's `Now` section and the timeline
-    stay in agreement (decision 31 §3): both read these fields, neither parses prose. A dates-only
-    call is a real change and is reported as one, but it appends NO dated entry — the page's body
-    is the record of what was learned, and "the report went out" is not a new fact about the
-    meeting, it is a property of it."""
+    `held_at`, `report_delivered_at`, `due_at`. It is how the desk README's `Now` section and the
+    timeline stay in agreement (decision 31 §3): both read these fields, neither parses prose. A
+    dates-only call is a real change and is reported as one, but it appends NO dated entry — the
+    page's body is the record of what was learned, and "the report went out" is not a new fact
+    about the meeting, it is a property of it.
+
+    ``due_at`` is the newest of the four and it exists to close the last prose seam (coordinator
+    ruling, 2026-09-02). A dated commitment — "circulate the charter by the 20th" — used to reach
+    the desk README because a regex found an ISO string under a heading that happened to be called
+    `## Committed`. It now reaches it because THIS call filed it, with a source. The difference is
+    not tidiness: a scraped date cannot be corrected (rewriting the sentence does not move it, and
+    nothing knows the commitment was met), while a filed one is a field the next turn can set."""
     root = Path(root)
     src = str(source or "").strip()
     facts = [str(f).strip() for f in (facts or []) if str(f).strip()]

--- a/core/agent/tests/test_desk_now.py
+++ b/core/agent/tests/test_desk_now.py
@@ -142,7 +142,7 @@ def test_pages_with_no_dates_and_templates_are_not_meetings(tmp_path):
 
 def test_a_desk_with_no_meeting_pages_answers_empty(tmp_path):
     assert desk_now.meetings(tmp_path) == []
-    assert desk_now.now_rows(tmp_path, now=NOW) == {"next": [], "open": []}
+    assert desk_now.now_rows(tmp_path, now=NOW) == {"next": [], "open": [], "due": []}
 
 
 def test_now_renders_links_not_prose(tmp_path):
@@ -156,3 +156,79 @@ def test_now_renders_links_not_prose(tmp_path):
 
 def test_an_empty_now_says_so_rather_than_vanishing(tmp_path):
     assert desk_now.render_now(tmp_path, now=NOW).strip() == "- Nothing scheduled."
+
+
+# ── `due_at`: the last prose seam, closed (coordinator ruling, 2026-09-02) ───────────────────────
+#
+# A dated commitment used to reach the desk README because a regex found an ISO string in a bullet
+# under a heading that happened to be called `## Committed`. It reaches it now because the
+# write-back phase FILED it. The tests below are the difference stated twice: what a filed date can
+# do, and what a written one no longer can.
+
+def test_a_dated_commitment_is_a_field_the_phase_filed(tmp_path):
+    upsert_entity(tmp_path, "decision", "Circulate the charter",
+                  ["Cottalango asked for it before the next TSC."], "the 2026-09-02 transcript",
+                  dates={"due_at": NOW + 18 * 24 * HOUR})
+    rows = desk_now.now_rows(tmp_path, now=NOW)
+    assert [p["title"] for p in rows["due"]] == ["Circulate the charter"]
+    assert "[[Circulate the charter]]" in desk_now.render_now(tmp_path, now=NOW)
+
+
+def test_a_date_written_in_PROSE_is_not_a_commitment(tmp_path):
+    """The whole point. This page says a date, under the heading the old scraper matched, and `Now`
+    does not show it — because nothing filed it, so nothing can move it or close it either."""
+    out = upsert_entity(tmp_path, "meeting", "DNA TSC kickoff", ["It met."], "the transcript",
+                        dates={"held_at": NOW - HOUR, "report_delivered_at": NOW})
+    page = tmp_path / out["path"]
+    page.write_text(page.read_text() + "\n## Committed\n\n- Circulate the charter by 2026-09-20\n")
+    assert desk_now.now_rows(tmp_path, now=NOW)["due"] == []
+    assert "Circulate the charter" not in desk_now.render_now(tmp_path, now=NOW)
+
+
+def test_a_due_date_that_has_passed_is_not_Now(tmp_path):
+    upsert_entity(tmp_path, "decision", "Overdue", ["x"], "s", dates={"due_at": NOW - HOUR})
+    assert desk_now.now_rows(tmp_path, now=NOW)["due"] == []
+
+
+def test_a_commitment_lives_on_whatever_page_owns_it(tmp_path):
+    """All kinds, not only `meeting`: restricting the scan would silently drop every commitment
+    filed on a project or a person."""
+    for kind in ("project", "person", "company", "meeting"):
+        upsert_entity(tmp_path, kind, f"Owner {kind}", ["x"], "s", dates={"due_at": NOW + HOUR})
+    assert len(desk_now.now_rows(tmp_path, now=NOW)["due"]) == 4
+
+
+def test_the_due_cap_holds(tmp_path):
+    for i in range(desk_now.DUE_MAX + 4):
+        upsert_entity(tmp_path, "decision", f"Item {i:02d}", ["x"], "s",
+                      dates={"due_at": NOW + (i + 1) * HOUR})
+    assert len(desk_now.now_rows(tmp_path, now=NOW)["due"]) == desk_now.DUE_MAX
+
+
+def test_the_open_cap_holds(tmp_path):
+    for i in range(desk_now.OPEN_MAX + 3):
+        upsert_entity(tmp_path, "meeting", f"Held {i:02d}", ["x"], "s",
+                      dates={"held_at": NOW - (i + 1) * HOUR})
+    assert len(desk_now.now_rows(tmp_path, now=NOW)["open"]) == desk_now.OPEN_MAX
+
+
+# ── across workspaces (PRD decision 26.2) ────────────────────────────────────────────────────────
+
+def test_a_card_in_another_workspace_is_linked_by_id(tmp_path):
+    """`Now` is part of a hub of links, so it obeys the same link rule as every other section: a
+    card here is `[[Title]]`, a card in a group is `[[ws:<id>/<entity-id>]]` — which survives that
+    group being renamed."""
+    desk, grp = tmp_path / "desk", tmp_path / "grp"
+    upsert_entity(desk, "meeting", "Mine", ["x"], "s", dates={"scheduled_at": NOW + HOUR})
+    upsert_entity(grp, "meeting", "Theirs", ["x"], "s", dates={"scheduled_at": NOW + 2 * HOUR})
+    mounts = [{"path": str(desk), "id": "aaaaaaaaaa"}, {"path": str(grp), "id": "bbbbbbbbbb"}]
+    out = desk_now.render_now(mounts, now=NOW, home_id="aaaaaaaaaa")
+    assert "[[Mine]]" in out
+    assert "[[ws:bbbbbbbbbb/theirs]]" in out
+    assert "[[Theirs]]" not in out
+
+
+def test_a_single_root_still_works_unchanged(tmp_path):
+    """The call shape every existing caller uses: a bare path, and every card is `[[Title]]`."""
+    upsert_entity(tmp_path, "meeting", "Solo", ["x"], "s", dates={"scheduled_at": NOW + HOUR})
+    assert "[[Solo]]" in desk_now.render_now(tmp_path, now=NOW)

--- a/core/agent/tests/test_desk_readme.py
+++ b/core/agent/tests/test_desk_readme.py
@@ -12,14 +12,17 @@ Four claims, and the second matters most:
 """
 from __future__ import annotations
 
+import datetime
 import time
 
-from shared import desk_readme
+from shared import desk_now, desk_readme
 from shared.entities import upsert_entity
 from shared.workspace_id import write_workspace_json
 
 DESK_ID = "aaaaaaaaaa"
 GROUP_ID = "bbbbbbbbbb"
+NOW = 1_788_362_400.0                       # 2026-09-02 15:20Z — the same instant test_desk_now uses
+HOUR = 3600.0
 
 
 def _ws(tmp_path, name, wid, kind="desk"):
@@ -42,10 +45,10 @@ def _sections(text: str) -> dict:
     return out
 
 
-def _write(d, mounts=(), workspaces=(), touches=None, today="2026-09-02", name=""):
+def _write(d, mounts=(), workspaces=(), touches=None, today="2026-09-02", name="", now=None):
     return desk_readme.update_readme(d, mounts=mounts or [{"path": str(d), "id": DESK_ID}],
                                      workspaces=workspaces, touches=touches, home_id=DESK_ID,
-                                     name=name, today=today)
+                                     name=name, today=today, now=now)
 
 
 # ── the shape ────────────────────────────────────────────────────────────────────────────────────
@@ -131,8 +134,8 @@ def test_regeneration_replaces_only_between_the_markers(tmp_path):
 def test_it_is_idempotent(tmp_path):
     d = _desk(tmp_path)
     upsert_entity(d, "person", "Olga Avramenko", ["Attends."], "the meeting", today="2026-09-02")
-    assert _write(d)["changed"] is True
-    assert _write(d)["changed"] is False
+    assert _write(d, now=NOW)["changed"] is True
+    assert _write(d, now=NOW)["changed"] is False
 
 
 # ── across workspaces ────────────────────────────────────────────────────────────────────────────
@@ -168,35 +171,65 @@ def test_workspaces_are_listed_by_id_link(tmp_path):
     assert "ASWF DNA Project" not in got["workspaces"]     # the name is resolved at read time
 
 
-# ── Now ──────────────────────────────────────────────────────────────────────────────────────────
+# ── Now — ONE implementation, and it is `shared/desk_now.py` ─────────────────────────────────────
+#
+# Coordinator ruling, 2026-09-02: there were two. This module's version scraped a meeting's date out
+# of its title or body and matched `## Committed`-shaped headings for commitments; `desk_now` reads
+# frontmatter facts that `entity_upsert(dates=)` filed. The second is right — a date found in a
+# sentence is whatever a model last typed, so moving a meeting could not move the README — and the
+# first is gone. These tests assert through the seam that survived.
 
 def test_now_leads_with_the_next_meetings_soonest_first(tmp_path):
     d = _desk(tmp_path)
-    for day in ("2026-10-01", "2026-09-15", "2026-01-05"):
-        upsert_entity(d, "meeting", f"DNA TSC {day}", ["Held."], "s", today="2026-09-02")
-    got = _sections(_write(d) and (d / "README.md").read_text())["now"]
-    assert got.index("2026-09-15") < got.index("2026-10-01")
-    assert "2026-01-05" not in got                          # behind us — not "Now"
+    for offset in (30 * 24, 13 * 24, -200 * 24):
+        upsert_entity(d, "meeting", f"DNA TSC {offset}", ["Booked."], "s",
+                      dates={"scheduled_at": NOW + offset * HOUR})
+    got = _sections(_write(d, now=NOW) and (d / "README.md").read_text())["now"]
+    assert got.index("[[DNA TSC 312]]") < got.index("[[DNA TSC 720]]")
+    assert "[[DNA TSC -4800]]" not in got                   # behind us — not "Now"
 
 
-def test_now_carries_dated_commitments_and_names_the_card_they_came_from(tmp_path):
+def test_now_carries_a_commitment_only_when_a_FIELD_carries_its_date(tmp_path):
+    """The seam the ruling closed. The page below says a date under the heading the old scraper
+    matched, and it does not reach `Now`; the one beside it filed `due_at` and does."""
     d = _desk(tmp_path)
-    upsert_entity(d, "meeting", "DNA TSC kickoff", ["Held."], "s", today="2026-09-02")
-    page = d / "kg/entities/meeting/dna-tsc-kickoff.md"
-    page.write_text(page.read_text() + "\n## Committed\n\n- Circulate the charter by 2026-09-20\n"
-                                       "- Something with no date\n")
-    _write(d)
+    out = upsert_entity(d, "meeting", "DNA TSC kickoff", ["Held."], "s",
+                        dates={"held_at": NOW - HOUR, "report_delivered_at": NOW})
+    page = d / out["path"]
+    page.write_text(page.read_text() + "\n## Committed\n\n- Circulate the charter by 2026-09-20\n")
+    upsert_entity(d, "decision", "Sign the CLA", ["SPI asked for the standard shape."], "the call",
+                  dates={"due_at": NOW + 5 * 24 * HOUR})
+    _write(d, now=NOW)
     got = _sections((d / "README.md").read_text())["now"]
-    assert "2026-09-20 — Circulate the charter by 2026-09-20 — [[DNA TSC kickoff]]" in got
-    assert "Something with no date" not in got              # "with dates" is the rule
+    assert "[[Sign the CLA]]" in got and "due " in got
+    assert "Circulate the charter" not in got
+
+
+def test_a_held_meeting_with_no_write_up_is_an_open_commitment(tmp_path):
+    d = _desk(tmp_path)
+    upsert_entity(d, "meeting", "Weekly sync", ["It met."], "the transcript",
+                  dates={"held_at": NOW - 2 * HOUR})
+    got = _sections(_write(d, now=NOW) and (d / "README.md").read_text())["now"]
+    assert "[[Weekly sync]]" in got and "no write-up yet" in got
 
 
 def test_the_meeting_cap_holds(tmp_path):
     d = _desk(tmp_path)
-    for i in range(desk_readme.MEETINGS_MAX + 4):
-        upsert_entity(d, "meeting", f"Sync 2026-10-{i + 1:02d}", ["x"], "s", today="2026-09-02")
-    got = _sections(_write(d) and (d / "README.md").read_text())["now"]
-    assert len([ln for ln in got.splitlines() if ln.startswith("- 2026-10-")]) == desk_readme.MEETINGS_MAX
+    for i in range(desk_now.AHEAD_MAX + 4):
+        upsert_entity(d, "meeting", f"Sync {i:02d}", ["x"], "s",
+                      dates={"scheduled_at": NOW + (i + 1) * 24 * HOUR})
+    got = _sections(_write(d, now=NOW) and (d / "README.md").read_text())["now"]
+    assert len([ln for ln in got.splitlines() if ln.startswith("- ") and " — [[Sync" in ln]) \
+        == desk_now.AHEAD_MAX
+
+
+def test_a_meeting_in_the_group_appears_in_Now_by_id(tmp_path):
+    """`Now` obeys the hub's link rule like every other section."""
+    d, g = _desk(tmp_path), _ws(tmp_path, "grp", GROUP_ID, kind="group")
+    upsert_entity(g, "meeting", "Group standup", ["Booked."], "s",
+                  dates={"scheduled_at": NOW + 2 * HOUR})
+    _write(d, mounts=[{"path": str(d), "id": DESK_ID}, {"path": str(g), "id": GROUP_ID}], now=NOW)
+    assert f"[[ws:{GROUP_ID}/group-standup]]" in _sections((d / "README.md").read_text())["now"]
 
 
 # ── ordering by USE, and the caps ────────────────────────────────────────────────────────────────
@@ -277,4 +310,4 @@ def test_empty_is_said_never_omitted(tmp_path):
     assert "No projects on this desk yet" in got["projects"]
     assert "belongs to no group workspace yet" in got["workspaces"]
     assert "Nothing opened from here yet" in got["recent"]
-    assert "Nothing scheduled or committed" in got["now"]
+    assert "Nothing scheduled." in got["now"]         # `desk_now`'s words, because it is the renderer

--- a/core/agent/tests/test_workspace_links_replay.py
+++ b/core/agent/tests/test_workspace_links_replay.py
@@ -47,6 +47,14 @@ def test_links_between_a_desk_and_a_group_survive_the_group_being_renamed(capsys
     assert report["readme"]["links_to_group_cards"] > 1
     assert report["readme"]["most_used_card_is_first"] is True
     assert report["readme"]["pinned_is_untouched"] is True
+    # `Now` is built from FILED dates and nothing else (coordinator ruling, 2026-09-02). All three
+    # of its lists, and the one thing it must refuse.
+    assert report["now"]["next_meeting"] is True
+    assert report["now"]["dated_commitment"] is True
+    assert report["now"]["open_commitment"] is True
+    assert report["now"]["delivered_meeting_is_closed"] is True
+    assert report["now"]["a_date_in_prose_is_ignored"] is True
+    assert len(report["now"]["lines"]) == 3
 
 
 def test_the_replay_reads_a_truth_sidecar_without_a_yaml_dependency(tmp_path):


### PR DESCRIPTION
Coordinator ruling, 2026-09-02. Two `## Now` implementations existed on the line after [#1408](https://github.com/Vexa-ai/vexa/pull/1408) merged, and they disagreed about what a date *is*.

| | | |
|---|---|---|
| `desk_readme._now_rows` | **live** | Found a meeting's date by looking for an ISO string in its title or body; found a commitment by matching `## Committed`-shaped headings and pulling dates out of their bullets. |
| `desk_now.now_rows` | **unwired** | Frontmatter fields — `scheduled_at`, `held_at`, `report_delivered_at` — written only by `entity_upsert(dates=)`. |

## Why the second one is right

Its own docstring says it: the timeline reads the flows engine and the desk README reads the workspace, so if the README derives its dates from prose the two **drift silently the first time a meeting moves**, and one product tells one person two different things on one screen. A scraped date also cannot be corrected — rewriting the sentence does not move it, and nothing knows a commitment was met.

## Change

`desk_readme` builds `Now` by calling `desk_now.render_now(mounts, …)`. The prose machinery is **deleted**: `_now_rows`, `_card_when`, `_COMMIT_HEADING`, `_BULLET`, `_SOURCE_SUFFIX`, `_ISO_DATE`, `_FM_DATE_KEYS`, `Card.when`, `MEETINGS_MAX`, `COMMITMENTS_MAX`. One regex survives in that module and it reads the dated *entry headings* `entity_upsert` writes (`## 2026-09-02`), for the usage ranking — not a date in a sentence.

**One writer** (`desk_readme` owns the file), **one renderer** (`desk_now` owns what `Now` says).

`due_at` is the fourth date field, and it is what the ruling's *"keep dated commitments only if they come from an entity field"* needed: a dated commitment reaches `Now` because the write-back phase **filed** it with a source, never because a regex found `2026-09-20` under a heading. It is available on any entity kind, not just `meeting` — a commitment belongs on the page that owns it, and scanning only meetings would silently drop every one filed on a project or a decision.

`desk_now` grew the two things it needed to be the only implementation:
- it takes the **mount set** as well as a single root, so `Now` obeys the hub's link rule like every other section — a card here is `[[Title]]`, a card in a group is `[[ws:<id>/<entity-id>]]`;
- it imports `DATE_FIELDS` from `shared/entities` instead of keeping its own copy. Two spellings of one frontmatter contract is the same drift in miniature: the writer gains a key, the reader never hears about it.

Caps stated rather than implied: 5 next meetings, 5 held-with-no-write-up, 10 due.

## Proof

Both suites converge on one answer. `test_desk_readme`'s three `Now` tests file dates instead of writing sentences, and one asserts the seam directly: a page carrying `- Circulate the charter by 2026-09-20` under `## Committed` does **not** reach `Now`, while a `decision` page with `due_at` does. `test_desk_now` gains `due_at` coverage, the cross-workspace link form, the caps, and the same prose-is-not-a-commitment control.

The replay is **better, not merely unchanged**. It now files what the phase files — `held_at` on both meetings, `report_delivered_at` on the first only, a `scheduled_at` for the next one, a `due_at` for a commitment — and carries a prose date under the old heading as a control:

```
## Now
- Mon 30 Mar 15:00 UTC — [[DNA TSC next]]
- due Mon 23 Mar 15:00 UTC — [[Sign the ASWF CLA]]
- [[DNA TSC 2026-03-16]] — held Mon 16 Mar 15:00 UTC, no write-up yet
```

Three lists where there was one title-scraped line; the delivered meeting is closed, and the prose date is ignored. Five new replay checks assert exactly that. Link numbers unchanged: **14** written in id form, **15** distinct refs, **16** id-form links into the group's cards.

`core/agent`: **1007 passed**, 1 pre-existing failure (`test_meeting_room.py` — `ModuleNotFoundError: requests_unixsocket`, a local venv gap that fails identically on a clean baseline worktree). All 14 pre-push gates green; pushed without `--no-verify`. No stack, no images.

Branch cut from `1a6198c5b` (the line tip); rebased on `origin/minutes-mcp-viewer` immediately before opening.

<!-- vexa-agent -->
