### PR TITLE
artifact events may pin, and meeting:<row> opens the live transcript canvas

### DIFF
--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -783,8 +783,17 @@ export function MinutesShell() {
     const onArtifact = (e: Event) => {
       const detail = (e as CustomEvent<{ workspace?: string; path?: string; focus?: boolean }>).detail || {};
       const eff = artifactViewEffect(detail, readerChoseFocus.current);
-      if (!eff) return;              // `focus: false` is now NOTHING VISIBLE, not a quiet tab
-      openPage(eff.view);
+      if (!eff) return;              // neither pinned nor focused ⇒ NOTHING VISIBLE, not a quiet tab
+      // PIN FIRST, then focus. `touchHistory` (inside openPage) carries a prior entry's `pinned`
+      // forward, so pinning before navigating keeps the pin; the other order would move the page
+      // into the strip unpinned and then pin a second copy of the same identity.
+      if (eff.pin) {
+        const a = { kind: eff.pin.kind, path: eff.pin.path, slug: eff.pin.slug, label: eff.pin.label };
+        setPages((prev) => prev.some((x) => artifactKey(x) === artifactKey(a))
+          ? prev.map((x) => (artifactKey(x) === artifactKey(a) ? { ...x, pinned: true } : x))
+          : touchHistory(prev, { ...a, pinned: true }, Date.now()));
+      }
+      if (eff.view) openPage(eff.view);
     };
     window.addEventListener(ARTIFACT_EVENT, onArtifact);
     return () => window.removeEventListener(ARTIFACT_EVENT, onArtifact);

--- a/clients/terminal/src/minutes/__tests__/artifactTab.test.ts
+++ b/clients/terminal/src/minutes/__tests__/artifactTab.test.ts
@@ -10,7 +10,8 @@
  *  does NOTHING VISIBLE when it does not — where it used to append a tab "quietly behind the
  *  reader". Seven quiet tabs are not quiet. */
 import { describe, expect, it } from "vitest";
-import { artifactViewEffect, pageForArtifact } from "../roomView";
+import { artifactFromToken, artifactViewEffect, pageForArtifact } from "../roomView";
+import { artifactKey, touchHistory } from "../chats";
 
 const ev = (over: Partial<{ workspace: string; path: string; focus: boolean }> = {}) =>
   ({ workspace: "daily", path: "README.md", focus: true, ...over });
@@ -60,5 +61,81 @@ describe("artifactViewEffect — the view moves, a tab is never minted", () => {
   it("an unresolvable write moves nothing", () => {
     expect(artifactViewEffect({ workspace: "daily", path: "../../etc/passwd", focus: true }, false)).toBeNull();
     expect(artifactViewEffect({ focus: true }, false)).toBeNull();
+  });
+});
+
+describe("`pin: true` — the write ENTERS the strip, pinned (coordinator, 2026-09-02)", () => {
+  const at = (over: Partial<{ workspace: string; path: string; focus: boolean; pin: boolean }> = {}) =>
+    ({ workspace: "daily", path: "README.md", ...over });
+
+  it("pin without focus: the page is kept, and NOTHING moves", () => {
+    // pinning and focusing are separate asks — a turn may want a page kept without interrupting
+    // what the reader is looking at
+    const eff = artifactViewEffect(at({ pin: true }), false)!;
+    expect(eff.pin).toEqual({ path: "README.md", slug: "daily", label: "README" });
+    expect(eff.view).toBeUndefined();
+  });
+
+  it("pin AND focus: kept and brought to the front", () => {
+    const eff = artifactViewEffect(at({ pin: true, focus: true }), false)!;
+    expect(eff.pin).toBeTruthy();
+    expect(eff.view).toEqual(eff.pin);
+  });
+
+  it("focus without pin: moves the view and keeps nothing — today's behaviour, unchanged", () => {
+    const eff = artifactViewEffect(at({ focus: true }), false)!;
+    expect(eff.view).toBeTruthy();
+    expect(eff.pin).toBeUndefined();
+  });
+
+  it("neither: still NOTHING VISIBLE", () => {
+    expect(artifactViewEffect(at({}), false)).toBeNull();
+    expect(artifactViewEffect(at({ focus: false, pin: false }), false)).toBeNull();
+  });
+
+  it("a reader's own focus is still never overridden — but the pin STILL lands", () => {
+    // their attention beats our suggestion; keeping a page does not interrupt them, so it is not
+    // suppressed by the same rule
+    const eff = artifactViewEffect(at({ pin: true, focus: true }), true)!;
+    expect(eff.view).toBeUndefined();
+    expect(eff.pin).toBeTruthy();
+  });
+
+  it("a pinned entry is the SAME kind of thing a scaffold pins — one identity, one strip entry", () => {
+    const eff = artifactViewEffect(at({ pin: true }), false)!;
+    const a = { path: eff.pin!.path, slug: eff.pin!.slug, label: eff.pin!.label, pinned: true };
+    // arriving twice in a turn is one entry, still pinned
+    const once = touchHistory([], a, 1);
+    const twice = touchHistory(once, a, 2);
+    expect(twice).toHaveLength(1);
+    expect(twice[0].pinned).toBe(true);
+  });
+});
+
+describe("a LIVE meeting's transcript, opened by an artifact event", () => {
+  it("`meeting:<row id>` resolves to the CANVAS, not a document at a path", () => {
+    // The canvas is what streams: it binds to the row id and renders segments as they are
+    // captured, with the Live header. A doc page cannot do that — and until this, EVERY artifact
+    // event produced a doc page, so the canvas was unreachable from a turn.
+    expect(pageForArtifact({ path: "meeting:97" }))
+      .toEqual({ kind: "meeting", path: "97", label: "Transcript" });
+  });
+
+  it("is the SAME slot the `meeting:transcript` preset token produces", () => {
+    // one identity for the transcript however it is reached — a preset-declared tab and a
+    // mid-turn artifact event must not become two entries for one meeting
+    const fromToken = artifactFromToken("meeting:transcript", { meetingId: "97" })!;
+    const fromEvent = pageForArtifact({ path: "meeting:97" })!;
+    expect(artifactKey(fromEvent)).toBe(artifactKey(fromToken));
+  });
+
+  it("refuses a malformed meeting ref rather than opening an empty canvas", () => {
+    expect(pageForArtifact({ path: "meeting:" })).toBeNull();
+    expect(pageForArtifact({ path: "meeting:a/b" })).toBeNull();
+  });
+
+  it("a path that merely CONTAINS the word meeting is still a document", () => {
+    expect(pageForArtifact({ path: "kg/entities/meeting/x.md" }))
+      .toEqual({ path: "kg/entities/meeting/x.md", slug: undefined, label: "x" });
   });
 });

--- a/clients/terminal/src/minutes/chats.ts
+++ b/clients/terminal/src/minutes/chats.ts
@@ -564,7 +564,12 @@ export function touchHistory(list: Artifact[], art: Artifact, now: number, cap =
   const prev = list.find((a) => artifactKey(a) === key);
   // a pin that is navigated to STAYS pinned and stays at the left edge — its `at` still moves, so
   // unpinning it later drops it into history in the right place rather than at the far left.
-  const next: Artifact = { ...(prev ?? art), ...art, pinned: prev?.pinned, desk: prev?.desk, at: now };
+  // `prev?.pinned ?? art.pinned` — a page ALREADY in the strip keeps whatever pin state it has (so
+  // navigating to a pin does not unpin it, and navigating to an ordinary page does not pin it),
+  // and a page arriving for the FIRST TIME keeps the pin it arrived with. Taking it from `prev`
+  // alone silently dropped the pin on an entry that had never been touched — which is every
+  // artifact event carrying `pin: true`.
+  const next: Artifact = { ...(prev ?? art), ...art, pinned: prev?.pinned ?? art.pinned, desk: prev?.desk ?? art.desk, at: now };
   const kept = list.filter((a) => artifactKey(a) !== key);
   const out = orderHistory([...kept, next]);
   const unpinned = out.filter((a) => !a.pinned && !a.desk);

--- a/clients/terminal/src/minutes/roomView.ts
+++ b/clients/terminal/src/minutes/roomView.ts
@@ -146,6 +146,20 @@ export function artifactsFromTokens(
  *  what a path means is a contract with the server, and a contract is worth a test. */
 export function pageForArtifact(ev: { workspace?: string; path?: string }): Page | null {
   const path = (ev.path ?? "").trim();
+  // A MEETING, NOT A FILE. `meeting:<row id>` opens the meeting CANVAS — the live transcript that
+  // streams segments as they are captured — rather than a document at a path. It reuses the
+  // `meeting:` vocabulary the preset tokens already speak, so nothing new goes on the wire.
+  //
+  // Without this an artifact event could never reach the canvas at all: every event produced a
+  // plain doc page, so `openPage` set `docKind: "doc"` and PagesPanel's canvas branch never fired.
+  // A harness opening the transcript on bot admission would have rendered a document view of a
+  // path that is not a document.
+  // The PREFIX claims the ref, not the match: `meeting:` with nothing after it must open NOTHING,
+  // not fall through and render a document at the literal path "meeting:".
+  if (/^meeting:/.test(path)) {
+    const id = path.slice("meeting:".length).trim();
+    return id && !id.includes("/") ? { kind: "meeting", path: id, label: "Transcript" } : null;
+  }
   // A path that walks out of the mount is refused, as everywhere else here — a write we cannot
   // name honestly opens no tab rather than a tab pointing somewhere it should not.
   if (!path || path.split("/").includes("..")) return null;
@@ -170,13 +184,18 @@ export function pageForArtifact(ev: { workspace?: string; path?: string }): Page
  *  `readerChoseFocus` still wins over `focus: true`: a reader who has deliberately opened something
  *  during the turn is not interrupted by the agent's write. Their attention beats our suggestion. */
 export function artifactViewEffect(
-  ev: { workspace?: string; path?: string; focus?: boolean },
+  ev: { workspace?: string; path?: string; focus?: boolean; pin?: boolean },
   readerChoseFocus: boolean,
-): { view: Page } | null {
+): { view?: Page; pin?: Page } | null {
   const pg = pageForArtifact(ev);
   if (!pg) return null;
-  if (ev.focus !== true || readerChoseFocus) return null;
-  return { view: pg };
+  // TWO INDEPENDENT ASKS. `pin` is about what STAYS in the strip; `focus` is about what is IN
+  // FRONT. A turn may want either, both or neither, so they are decided separately rather than one
+  // implying the other — a page pinned without focus is the whole point of pinning without
+  // interrupting, and a page focused without a pin is an ordinary navigation.
+  const view = ev.focus === true && !readerChoseFocus ? pg : undefined;
+  const pin = ev.pin === true ? pg : undefined;
+  return view || pin ? { view, pin } : null;
 }
 
 /** Where App.tsx stashes a `?view=` spec — the URL is cleaned on landing, so the value travels here.

--- a/clients/terminal/src/surfaces/chatStream.ts
+++ b/clients/terminal/src/surfaces/chatStream.ts
@@ -35,6 +35,10 @@ export type ChatStreamEvent = {
   workspace?: string;
   path?: string;
   focus?: boolean;
+  /** `artifact` events only — KEEP this page in the chat's strip, as a pinned entry, exactly as a
+   *  scaffold-declared pinned tab does. Orthogonal to `focus`: pinning is about what stays,
+   *  focusing is about what is in front, and a turn may ask for either, both, or neither. */
+  pin?: boolean;
 };
 
 /** HOW ONE INTERIM TEXT JOINS THE LAST (F40, founder ruling 2026-09-02).
@@ -92,7 +96,7 @@ export type ChatStreamCallbacks = {
   /** A FILE THE TURN JUST WROTE (F41). Emitted after the matching `tool-result` and only on
    *  success — a failed write says nothing. Optional so existing callers/tests need not implement
    *  it. */
-  onArtifact?: (a: { workspace: string; path: string; focus: boolean }) => void;
+  onArtifact?: (a: { workspace: string; path: string; focus: boolean; pin: boolean }) => void;
 };
 
 export type ChatStreamRequest = {
@@ -303,7 +307,7 @@ export async function streamChatTurn(
           // advisory-only here: this reader forwards it and the shell decides, because the tab set
           // belongs to the CHAT RECORD (decision 18) and this file owns no state at all.
           case "artifact":
-            if (ev.path) cb.onArtifact?.({ workspace: ev.workspace ?? "", path: ev.path, focus: ev.focus === true });
+            if (ev.path) cb.onArtifact?.({ workspace: ev.workspace ?? "", path: ev.path, focus: ev.focus === true, pin: ev.pin === true });
             break;
           case "commit":
             terminal = true; cb.onCommit(ev.sha);


### PR DESCRIPTION
Two small asks; each turned up a real defect on the way.

## 1 · `pin: true` keeps the page

Pinning and focusing are **separate asks**, now decided separately: `pin` is about what *stays* in the strip, `focus` is about what is *in front*. A turn may want either, both, or neither.

| event | effect |
|---|---|
| `pin: true` only | enters the strip as a pinned entry — same as a scaffold-declared pinned tab. **Nothing moves.** |
| `pin` + `focus` | kept, and brought to the front |
| `focus` only | moves the view, keeps nothing — **today's behaviour, unchanged** |
| neither | nothing visible |

A reader's own focus is still never overridden — but in that case **the pin still lands**. Keeping a page does not interrupt anyone, so it is not suppressed by the rule that protects their attention.

Order matters and is commented at the call site: **pin first, then focus.** `touchHistory` carries a prior entry's pin forward, so pinning before navigating keeps it; the other order would insert the page unpinned and then pin a second copy of one identity.

## 2 · The live transcript — verified first, and it could not work

`pageForArtifact` produced a plain doc page for **every** event, so `openPage` set `docKind: "doc"` and PagesPanel's canvas branch never fired. A harness opening the transcript on bot admission would have rendered *a document view of a path that is not a document*.

The canvas itself was fine — `MeetingTab` already has the Live header, the reconnecting state and the participant count, and binds to the row id. It was simply **unreachable from an artifact event**.

`meeting:<row id>` now resolves to the canvas. It reuses the `meeting:` vocabulary the preset tokens already speak, so **nothing new goes on the wire**, and it produces the same `artifactKey` as the `meeting:transcript` token — one identity for the transcript however it is reached, rather than a preset-declared tab and a mid-turn event becoming two entries for one meeting.

## Two bugs the tests caught

- **`touchHistory` dropped an incoming pin.** It took `pinned` from a *prior* entry only, so a page arriving pinned lost its pin on the very first touch — which is every artifact event carrying `pin: true`. Mine, from the panel branch, where nothing yet arrived pre-pinned so it could not show. Now `prev?.pinned ?? art.pinned`.
- **`meeting:` with no id fell through** to the document branch and opened a doc at the literal path `"meeting:"`. The prefix claims the ref, not the match.

## ⚠️ One thing to confirm before the harness ships

**The wire shape for the transcript is my choice, not an agreed one.** I picked `path: "meeting:<row id>"` because it adds no field and reuses an existing vocabulary — but the harness must send exactly that. This is the same seam that produced the `room_read` / `room_participants` mismatch; the test here is what will fail first if it differs.

## Proof

**1048 tests, 96 files, all green. Cold minutes build green. No swap.**
