### PR TITLE
friction: the rough-edges loop — agents and people file, one dump feeds a fixing agent (PRD decision 33)

### DIFF
--- a/clients/terminal/src/minutes/PagesPanel.tsx
+++ b/clients/terminal/src/minutes/PagesPanel.tsx
@@ -33,6 +33,7 @@ import { isMachineryEntry } from "./machinery";
 import { loadNavOpen, saveNavOpen } from "./navigatorApi";
 import { CreatePageButton, ExtendButton, SelectionExtend, useIntentLanding } from "./ExtendAction";
 import { registry } from "../contributions";
+import { ReportPageButton } from "../surfaces/ReportThis";
 import { header, surface, type as ty } from "./tokens";
 
 /** Breadcrumb separator. Its padding is NBSP *content*, not margin, so it collapses away under
@@ -224,6 +225,11 @@ export function PagesPanel(p: {
                 {/* PRD decision 32.1 — the open page, whole. `docSlug`/`docPath` are the RESOLVED
                     view slot, never the tab label or the crumb (F63). */}
                 <ExtendButton workspace={p.docSlug} path={p.docPath} />
+                {/* PRD decision 33 §2 — this page is wrong, or is not the page I asked for. Same
+                    resolved view slot as Extend, for the same reason (F63): a tab label and a
+                    breadcrumb are display strings, and a report built from one names a file
+                    nobody opened. */}
+                <ReportPageButton workspace={p.docSlug} path={p.docPath} />
                 <button data-doc-act="edit" onClick={() => { setDraft(p.body ?? ""); setSaveError(null); setMode("edit"); }}
                   title="Edit" aria-label="Edit"
                   style={iconBtn(false)} onMouseEnter={litIcon} onMouseLeave={dimIcon(false)}>

--- a/clients/terminal/src/surfaces/ReportThis.tsx
+++ b/clients/terminal/src/surfaces/ReportThis.tsx
@@ -1,0 +1,148 @@
+"use client";
+/** "REPORT THIS" — the person's half of the rough-edges loop (PRD decision 33 §2).
+ *
+ *  Founder: the agent files its own rough edges; *"people file too — a 'report this' action on any
+ *  turn or page in the terminal — one line, the same record with the human surface attached."*
+ *
+ *  ONE LINE, NO DIALOG. The whole control is a text field that appears where the person already is,
+ *  takes a sentence, and confirms in four words. Everything else the record needs — chat, page,
+ *  workspace, meeting — the client already knows and attaches silently (`frictionApi.ts`). A modal
+ *  with a category dropdown and a severity picker is a report nobody files: the cost of reporting
+ *  has to stay below the cost of shrugging, or the channel measures only the most annoyed people.
+ *
+ *  TWO PLACEMENTS, ONE COMPONENT: a chat turn (what the agent just said was wrong) and the panel's
+ *  page header (this page is wrong, or is not the page I asked for). They differ only in what they
+ *  attach, so `ReportField` is shared and the two exports are the affordances that open it.
+ *
+ *  IT NEVER BLOCKS AND NEVER THROWS. A failure to send says "couldn't send that" beside the field
+ *  with the text still in it — an error dialog on top of the thing the person is already unhappy
+ *  about is the product being broken twice.
+ */
+import type { CSSProperties } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "../ui-kit";
+import { ContextMenu } from "../ui-kit/ContextMenu";
+import { confirmation, reportFriction, type FrictionSurface } from "./frictionApi";
+
+/** The two terminal tokens this control needs, spelled out rather than imported.
+ *  `minutes/tokens.ts` is the panel's design system and `minutes/` already imports FROM here — a
+ *  return edge would make the two directories mutually dependent for two style objects. */
+const ty = {
+  chip: { fontFamily: "var(--sans)", fontSize: 12, fontWeight: 500 } as CSSProperties,
+  meta: { fontFamily: "var(--sans)", fontSize: 11, fontWeight: 400, color: "var(--t3)" } as CSSProperties,
+};
+const surf = { raised: "var(--panel)" };
+
+const iconBtn: CSSProperties = {
+  flex: "none", width: 26, height: 24, display: "flex", alignItems: "center", justifyContent: "center",
+  background: "transparent", border: "none", borderRadius: 6, color: "var(--t3)", cursor: "pointer",
+  padding: 0, transition: "color .12s, background .12s, opacity .12s",
+};
+const lit = (e: { currentTarget: HTMLElement }) => { e.currentTarget.style.color = "var(--t1)"; e.currentTarget.style.background = surf.raised; };
+const dim = (e: { currentTarget: HTMLElement }) => { e.currentTarget.style.color = "var(--t3)"; e.currentTarget.style.background = "transparent"; };
+
+export const REPORT_LABEL = "Report this";
+export const REPORT_HINT = "Report this — one line about what did not work";
+
+/** THE FIELD. Open, type, Enter. Escape closes it and keeps nothing — a half-typed complaint is not
+ *  a draft anybody wants restored three days later. */
+function ReportField({ surface, onDone }: { surface: FrictionSurface; onDone: () => void }) {
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [said, setSaid] = useState<string | null>(null);
+  const input = useRef<HTMLInputElement>(null);
+  useEffect(() => { input.current?.focus(); }, []);
+  // The confirmation is the last thing this control does. It stays long enough to read and then the
+  // control removes itself — a report that leaves a permanent artefact on the screen makes the
+  // person feel they have to tidy it up.
+  useEffect(() => {
+    if (said === null) return;
+    const t = setTimeout(onDone, 1800);
+    return () => clearTimeout(t);
+  }, [said, onDone]);
+
+  const send = async () => {
+    if (!text.trim() || busy) return;
+    setBusy(true);
+    setSaid(confirmation(await reportFriction(text, surface)));
+    setBusy(false);
+  };
+
+  if (said !== null) {
+    return <span data-report="said" style={{ ...ty.meta, color: "var(--t3)" }}>{said}</span>;
+  }
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6, minWidth: 0, flex: "1 1 220px" }}>
+      <input ref={input} data-report="field" aria-label={REPORT_HINT} placeholder="What did not work?"
+        value={text} disabled={busy} onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") { e.preventDefault(); void send(); }
+          // consumed, so the panel's own Escape (close-topmost) does not also fire
+          if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); onDone(); }
+        }}
+        style={{
+          ...ty.chip, flex: "1 1 0%", minWidth: 0, padding: "3px 8px", borderRadius: 6,
+          border: "1px solid var(--line2)", background: "var(--bg)", color: "var(--t1)", outline: "none",
+        }} />
+      <button data-report="send" onClick={() => void send()} disabled={busy || !text.trim()}
+        title="Send" aria-label="Send the report"
+        style={{ ...ty.chip, flex: "none", border: "none", borderRadius: 6, padding: "3px 10px", cursor: "pointer",
+                 color: "var(--on-accent)", background: "var(--accent)", opacity: busy || !text.trim() ? 0.55 : 1 }}>
+        {busy ? "…" : "Send"}
+      </button>
+    </span>
+  );
+}
+
+/** THE PANEL HEADER ACTION (decision 33 §2) — this page. Sits in the document header's utility
+ *  group beside Extend, because it acts on the same thing they do: what is in front. */
+export function ReportPageButton(p: { workspace?: string; path: string; chat?: string }) {
+  const [open, setOpen] = useState(false);
+  if (open) {
+    return <ReportField onDone={() => setOpen(false)}
+      surface={{ at: "page", workspace: p.workspace, path: p.path, chat: p.chat }} />;
+  }
+  return (
+    <button data-doc-act="report" aria-label={REPORT_LABEL} title={REPORT_HINT}
+      onClick={() => setOpen(true)} style={iconBtn} onMouseEnter={lit} onMouseLeave={dim}>
+      <Icon name="alert" size={14} />
+    </button>
+  );
+}
+
+/** THE TURN ACTION (decision 33 §2) — what the agent just said, and everything the client knows
+ *  about where it said it.
+ *
+ *  Two ways in, on purpose. The hover button is the discoverable one; the right-click menu is the
+ *  one every other list and tree in this terminal already has, and a surface where right-click does
+ *  nothing reads as unfinished. Both open the same field, which is the point of having one. */
+export function ReportTurn(p: { surface: FrictionSurface; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [hover, setHover] = useState(false);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  return (
+    <div data-report-turn style={{ position: "relative" }}
+      onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}
+      onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); setMenu({ x: e.clientX, y: e.clientY }); }}>
+      {p.children}
+      {!open && (hover || menu) && (
+        <button data-report="open" aria-label={REPORT_LABEL} title={REPORT_HINT}
+          onClick={() => setOpen(true)}
+          style={{ ...iconBtn, position: "absolute", top: -2, right: -2, opacity: 0.85 }}
+          onMouseEnter={lit} onMouseLeave={dim}>
+          <Icon name="alert" size={13} />
+        </button>
+      )}
+      {open && (
+        <div style={{ display: "flex", alignItems: "center", gap: 6, margin: "6px 0 0", minWidth: 0 }}>
+          <ReportField surface={p.surface} onDone={() => setOpen(false)} />
+        </div>
+      )}
+      {menu && (
+        <ContextMenu x={menu.x} y={menu.y} onClose={() => setMenu(null)}
+          items={[{ id: "report", label: REPORT_LABEL, detail: "one line — it goes to the fix queue",
+                    onSelect: () => setOpen(true) }]} />
+      )}
+    </div>
+  );
+}

--- a/clients/terminal/src/surfaces/__tests__/friction.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/friction.test.ts
@@ -1,0 +1,83 @@
+/** "Report this" — the person's half (PRD decision 33 §2).
+ *
+ *  What matters here is not that a POST happens; it is WHAT TRAVELS WITH IT. The whole design claim
+ *  is that a person types one line and the client attaches everything else — so these assert the
+ *  attachment, and that a failure to send is never an exception thrown at somebody who was already
+ *  telling us the product is broken.
+ */
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { confirmation, reportFriction, surfaceOf, type FrictionSurface } from "../frictionApi";
+
+const ok = (body: unknown) => ({ ok: true, json: async () => body }) as unknown as Response;
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+function capture(body: unknown = { id: "fr_1", known: false, recurrence: 1 }) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  vi.stubGlobal("fetch", (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return Promise.resolve(ok(body));
+  });
+  return calls;
+}
+
+describe("surfaceOf", () => {
+  it("reads the tab's params — the resolved view slot, never a label", () => {
+    const s = surfaceOf("meet-104", { kind: "doc", params: { path: "kg/x.md", slug: "dna" } });
+    expect(s).toMatchObject({ chat: "meet-104", chatKind: "doc", path: "kg/x.md", workspace: "dna" });
+  });
+
+  it("omits what it does not know rather than guessing", () => {
+    const s = surfaceOf("main", null);
+    expect(s.path).toBeUndefined();
+    expect(s.workspace).toBeUndefined();
+    expect(s.chat).toBe("main");
+  });
+
+  it("carries a meeting when the tab is one", () => {
+    expect(surfaceOf("meet-104", { kind: "meeting", params: { meetingId: "104" } }).meeting).toBe("104");
+  });
+});
+
+describe("reportFriction", () => {
+  it("sends one line plus the surface the person never had to describe", async () => {
+    const calls = capture();
+    const surface: FrictionSurface = {
+      chat: "meet-104", chatKind: "meeting", workspace: "dna", path: "kg/x.md",
+      meeting: "104", at: "turn", quote: "here is the write-up",
+    };
+    const filed = await reportFriction("  it opened the wrong page  ", surface);
+    expect(filed).toEqual({ id: "fr_1", known: false, occurrences: 1 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("/api/friction");
+    const body = JSON.parse(String(calls[0].init.body));
+    expect(body.reporter).toBe("person");
+    expect(body.happened).toBe("it opened the wrong page");     // trimmed, and it is the report
+    expect(body.session).toBe("meet-104");
+    expect(body.context).toMatchObject({ workspace: "dna", path: "kg/x.md", meeting_id: "104" });
+    expect(body.context.surface).toMatchObject({ chat: "meet-104", at: "turn", quote: "here is the write-up" });
+    // the person is never asked to classify — the server infers `kind` from the words
+    expect(body.kind).toBeUndefined();
+  });
+
+  it("sends nothing for an empty line", async () => {
+    const calls = capture();
+    expect(await reportFriction("   ", { at: "page" })).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("never throws when the report itself cannot be sent", async () => {
+    vi.stubGlobal("fetch", () => Promise.reject(new Error("offline")));
+    await expect(reportFriction("broken", { at: "page" })).resolves.toBeNull();
+    vi.stubGlobal("fetch", () => Promise.resolve({ ok: false, status: 500 } as Response));
+    await expect(reportFriction("broken", { at: "page" })).resolves.toBeNull();
+  });
+});
+
+describe("confirmation", () => {
+  it("says it is known and counted, because that is worth knowing", () => {
+    expect(confirmation({ id: "a", known: true, occurrences: 4 })).toBe("Filed — known, 4 reports.");
+    expect(confirmation({ id: "a", known: false, occurrences: 1 })).toBe("Filed. Thank you.");
+    expect(confirmation(null)).toContain("Couldn't send");
+  });
+});

--- a/clients/terminal/src/surfaces/chat.tsx
+++ b/clients/terminal/src/surfaces/chat.tsx
@@ -11,6 +11,7 @@ import { registerCommand, type TabProps } from "../contributions";
 import { meetingsOnly } from "../app/mode";
 import { AgentWindow, Conversation, opIcon, type Turn, type Op } from "../workbench/agent-window";
 import { Icon } from "../ui-kit";
+import { ReportTurn } from "./ReportThis";
 import { invalidateDocLinkCaches } from "../ui-kit/docLinks";
 import { startStreamingDictation, type StreamingDictation } from "../ui-kit/micDictation";
 import { sessionTitle, type SessionSummary } from "./sessions";
@@ -22,6 +23,7 @@ import { meetingPhase, type MeetingMock, type MeetingPhase } from "./meetingMode
 import { presentError } from "./apiClient";
 import { promptCarriesActiveContext } from "./surfaceSync";
 import type { ChatIntent } from "./chatIntent";
+import { surfaceOf, type FrictionSurface } from "./frictionApi";
 import { ARTIFACT_EVENT, ASK_CHAT_EVENT, CHAT_TOUCHED_EVENT, MACHINERY_MARK, WORKSPACE_COMMIT_EVENT, MACHINERY_NOTE, ONBOARDING_KICKOFF_MARK, MINUTES_ONBOARDING_GREETING, MINUTES_PREP_GREETING, ONBOARDING_REPLY_SEP } from "../canvas/actions";
 
 /** classify a tool name into one of the op icons so the operation line reads at a glance */
@@ -421,13 +423,19 @@ function ChatHeader({ subject, session, onSelectSession, onNewChat, onClose }: {
   );
 }
 
-function ChatConversation({ turns, busy, empty }: { turns: Turn[]; busy?: boolean; empty?: ReactNode }) {
+function ChatConversation({ turns, busy, empty, surface }: { turns: Turn[]; busy?: boolean; empty?: ReactNode; surface?: FrictionSurface }) {
   if (turns.length === 0 && empty) return <>{empty}</>;
   return (
     <>
       {turns.map((t, i) => t.role === "user"
         ? <div key={t.id} style={{ marginBottom: 16 }}><div style={userBubble}><ReferenceText text={t.text} /></div></div>
-        : <Conversation key={t.id} turns={[t]} busy={!!busy && i === turns.length - 1} />)}
+        // "REPORT THIS" ON A TURN (PRD decision 33 §2). Only the AGENT's turns carry it: the person
+        // reporting their own sentence is not a rough edge, and an action on every bubble is twice
+        // the chrome for half the meaning. The surface travels with the report — chat, kind, the open
+        // page — so nobody is asked to describe where they were.
+        : <ReportTurn key={t.id} surface={{ ...(surface ?? {}), at: "turn", quote: t.text }}>
+            <Conversation turns={[t]} busy={!!busy && i === turns.length - 1} />
+          </ReportTurn>)}
     </>
   );
 }
@@ -1332,7 +1340,7 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
           it in a chat he never made — *"I explain this as stale code."*
           What is left renders the meeting greeting when there IS a meeting, and otherwise renders
           nothing but whatever the host put in `emptyExtra`. */}
-      <ChatConversation turns={turns} busy={busy || loading} empty={
+      <ChatConversation turns={turns} busy={busy || loading} surface={surfaceOf(session, activeTab)} empty={
         <div style={{ color: minutesOnly() ? "var(--t2)" : "var(--t3)", fontSize: 13, textAlign: minutesOnly() ? "left" : "center", lineHeight: 1.6, maxWidth: 560, margin: minutesOnly() ? "26px auto 0" : "40px 0 0", padding: minutesOnly() ? "0 22px" : 0 }}>
             {loading ? "Loading conversation…" : (minutesOnly()
               ? minutesEmptyGreeting(session)

--- a/clients/terminal/src/surfaces/frictionApi.ts
+++ b/clients/terminal/src/surfaces/frictionApi.ts
@@ -1,0 +1,97 @@
+/** frictionApi — "Report this" (PRD decision 33 §2).
+ *
+ *  Founder: *"we also need to leverage the mcp tool that should collect rough edges — things that
+ *  did not work as expected — and dump it in a way that we can just dump that to an agent that
+ *  would just fix that."* §1 is the agent filing its own; this is the half only a person can do —
+ *  the agent cannot see that its answer was fine and the page it opened was the wrong one.
+ *
+ *  ONE LINE AND THE SURFACE, and nothing else is asked for. Every field the record needs beyond the
+ *  sentence is something the client already knows: which chat, which page, which workspace, which
+ *  meeting. Asking a person to classify their own complaint is how a report button ends up unused —
+ *  the classifier is on the server (`shared/friction.py` infers `kind` from the words).
+ *
+ *  IT NEVER THROWS. `apiClient.getJson` is fail-loud by design and that is right for a document
+ *  read; it is wrong here. A failure to report that the product is broken must not itself be an
+ *  error dialog on top of the thing the person was already unhappy about — the caller shows
+ *  "couldn't send that" beside the field and the text stays put.
+ */
+
+/** The human surface, decision 30's shape as far as this client actually knows it. `chat` and
+ *  `kind` come from the chat, `workspace`/`path` from the resolved view slot — never from a tab
+ *  label or a breadcrumb (F63: those are display strings and two of them have already been wrong). */
+export type FrictionSurface = {
+  chat?: string;
+  chatKind?: string;
+  workspace?: string;
+  path?: string;
+  meeting?: string;
+  /** what the person was looking at when they pressed it: a chat turn, or the open page */
+  at?: "turn" | "page";
+  /** the turn's own text, trimmed — what "this" refers to when they say "this is wrong" */
+  quote?: string;
+};
+
+export type FrictionFiled = { id: string; known: boolean; occurrences: number };
+
+/** The surface, read off the chat and whatever tab is active.
+ *
+ *  Structurally typed rather than importing `ActiveTab`: this module is data-access and the report
+ *  only needs four strings. It reads the tab's PARAMS, which are the resolved view slot — never a
+ *  label (F63). Unknown params are omitted, never guessed: a report naming the wrong page sends the
+ *  fixing agent to the wrong file, which is worse than one naming no page at all. */
+export function surfaceOf(
+  chat: string,
+  tab: { kind?: string; params?: Record<string, unknown> } | null | undefined,
+): FrictionSurface {
+  const p = (tab?.params ?? {}) as Record<string, unknown>;
+  const str = (k: string) => (typeof p[k] === "string" ? (p[k] as string) : undefined);
+  return { chat, chatKind: tab?.kind, workspace: str("slug"), path: str("path"), meeting: str("meetingId") };
+}
+
+/** How much of a turn travels as the quote. It is CONTEXT, not the report: the person's sentence is
+ *  the report, and a whole agent turn pasted into `happened` would bury it. */
+export const QUOTE_MAX = 600;
+
+export async function reportFriction(line: string, surface: FrictionSurface): Promise<FrictionFiled | null> {
+  const text = (line || "").trim();
+  if (!text) return null;
+  const body = {
+    reporter: "person",
+    session: surface.chat || "",
+    happened: text,
+    tried: surface.at === "turn"
+      ? "read this reply in the chat"
+      : surface.path ? `opened ${surface.path}` : "used the terminal",
+    context: {
+      workspace: surface.workspace || "",
+      path: surface.path || "",
+      meeting_id: surface.meeting || "",
+      surface: {
+        chat: surface.chat || "",
+        chat_kind: surface.chatKind || "",
+        at: surface.at || "",
+        quote: (surface.quote || "").slice(0, QUOTE_MAX),
+      },
+    },
+  };
+  try {
+    const r = await fetch("/api/friction", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) return null;
+    const j = (await r.json()) as { id?: string; known?: boolean; recurrence?: number };
+    return { id: j.id || "", known: !!j.known, occurrences: j.recurrence || 1 };
+  } catch {
+    return null;
+  }
+}
+
+/** The confirmation, in the fewest words that still say something true. "Known, 4th time" is worth
+ *  saying — it tells the person they are not shouting into a void and that the thing is counted. */
+export function confirmation(filed: FrictionFiled | null): string {
+  if (!filed) return "Couldn't send that — try again?";
+  if (filed.known && filed.occurrences > 1) return `Filed — known, ${filed.occurrences} reports.`;
+  return "Filed. Thank you.";
+}

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Callable, Iterator, Optional
 
 from fastapi import Body, FastAPI, File, HTTPException, Request, UploadFile
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from jsonschema.exceptions import ValidationError
 from pydantic import BaseModel
 
@@ -78,6 +78,8 @@ from control_plane import workspace_credentials as wcreds
 from control_plane import global_layer
 from control_plane import system_mounts
 from control_plane import scaffolds as scaffolds_mod
+from control_plane import friction as friction_store_mod
+from shared import friction as friction_mod
 from control_plane.workspace_membership import MembershipError, MembershipIndex, InMemoryMembershipIndex
 from control_plane.dispatch import Dispatcher
 from control_plane.events import event_to_invocation
@@ -1139,6 +1141,17 @@ def create_app(
         scaffolds = scaffolds_mod.ScaffoldStore(_redis_for_scaffolds.from_url(redis_url, decode_responses=True))
     else:
         scaffolds = scaffolds_mod.ScaffoldStore()
+    # THE FRICTION STORE (PRD decision 33). Same redis client, same in-memory fallback, and for
+    # the same reasons as the scaffold store — plus one of its own: `shared/friction.py` states why
+    # this record does NOT live in the flows `friction` table the rig has been writing (the people
+    # half posts HERE, and this service cannot reach the flows lane).
+    if redis_url:
+        import redis as _redis_for_friction
+
+        friction = friction_store_mod.FrictionStore(
+            _redis_for_friction.from_url(redis_url, decode_responses=True))
+    else:
+        friction = friction_store_mod.FrictionStore()
     wsr = reader or WorkspaceReader("/workspaces")
     mindex: MembershipIndex = membership_index if membership_index is not None else InMemoryMembershipIndex()
     # THE WORKSPACE REGISTRY (PRD decision 26.1) — id → where that workspace is NOW. Same redis
@@ -2256,6 +2269,68 @@ def create_app(
                 # One scaffold whose preset an admin deleted must not empty the whole list.
                 logger.warning("scaffold %s is unrenderable (its preset is gone) — omitted", r.get("id"))
         return {"scaffolds": out}
+
+    # ── ROUGH EDGES (PRD decision 33) ───────────────────────────────────────────────────────────
+    def _friction_subject(request: Request) -> str:
+        """Who filed it, BEST-EFFORT — never a refusal.
+
+        Every other read on this service fails closed without `X-User-Id`, and this one must not.
+        The rig's `report_friction` has always been documented NO ACCOUNT NEEDED, the worker that
+        auto-files may have no principal, and the single most valuable report available is the one
+        from a session so broken it has no identity left. **A friction report we cannot attribute is
+        worth more than one that was never filed**, and refusing it would silence exactly the class
+        of failure this loop exists to catch (ledger F70).
+
+        The exposure is a write with no caller. It is bounded by the record itself: every field is
+        length-capped in `shared/friction.py`, and the dedup key folds a flood of identical reports
+        into ONE row with a counter."""
+        return (request.headers.get("x-user-id") or "").strip()
+
+    @app.post("/api/friction", status_code=201)
+    def file_friction(body: dict, request: Request):
+        """File one rough edge — from an agent (`report_friction`), the harness, or a person's
+        "Report this" (decision 33 §§1–2). Returns the stored record; `recurrence > 1` means this
+        edge was already known and this report is another occurrence of it."""
+        rec = friction.file({**(body or {}), "subject": (body or {}).get("subject")
+                             or _friction_subject(request)})
+        logger.info("friction filed id=%s kind=%s status=%s recurrence=%s tool=%s",
+                    rec.get("id"), rec.get("kind"), rec.get("status"), rec.get("recurrence"),
+                    (rec.get("context") or {}).get("tool") or "-")
+        return {"id": rec["id"], "status": rec["status"], "recurrence": rec["recurrence"],
+                "kind": rec["kind"], "known": rec["recurrence"] > 1}
+
+    @app.get("/api/friction/dump")
+    def dump_friction(request: Request, since: str = "", status: str = "open",
+                      format: str = "md"):
+        """THE DUMP (decision 33 §3) — the open rough edges as a brief a fixing agent works off.
+
+        `format=md` (default) returns the markdown; `format=json` returns the same grouping as data,
+        which is what the rig's `friction_so_far` renders. Both come from ONE renderer in
+        `shared/friction.py`: a dump and a tool that disagree about what is open is the two-renderers
+        failure this codebase has already paid for twice."""
+        subject_of(request)          # a read: identified callers only, like every other read here
+        ts = friction_store_mod.parse_since(since)
+        rows = friction.since(ts, status=status)
+        if format == "json":
+            return {"since": since, "status": status, "count": len(rows),
+                    "findings": friction_mod.group(rows), "records": rows}
+        return Response(content=friction_mod.render_markdown(rows, since=since, status=status),
+                        media_type="text/markdown; charset=utf-8")
+
+    @app.post("/api/friction/{friction_id}/fix")
+    def fix_friction(friction_id: str, body: dict, request: Request):
+        """Close one record against the change that addressed it (decision 33 §4).
+
+        A record filed again after this flips itself to `recurring` — which is why closing is cheap
+        and why a fixing agent should close what it addressed rather than waiting to be sure."""
+        subject_of(request)
+        try:
+            rec = friction.fix(friction_id, str((body or {}).get("fix_ref") or ""))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        if rec is None:
+            raise HTTPException(status_code=404, detail="no such friction record")
+        return {"id": rec["id"], "status": rec["status"], "fix_ref": rec["fix_ref"]}
 
     @app.get("/api/workspace/tree")
     def ws_tree(request: Request, hidden: bool = False, slug: Optional[str] = None):

--- a/core/agent/control_plane/friction.py
+++ b/core/agent/control_plane/friction.py
@@ -1,0 +1,166 @@
+"""friction.py (control plane) — WHERE THE ROUGH EDGES LIVE (PRD decision 33).
+
+The record's shape, dedup key and status machine are in `shared/friction.py`; this is only the
+store. Redis when a client is wired (`agent:friction:<id>` holds the JSON record, `agent:friction:
+key:<dedup>` maps a dedup key to the id that owns it, `agent:friction:all` is a sorted set scored by
+report time), in-memory otherwise — the same three-key shape and the same fallback discipline as
+`ScaffoldStore` and `_Sessions`, for the same reason: the unit tests need no redis and the
+deployment needs no second store.
+
+WHY REDIS AND NOT THE FLOWS `friction` TABLE the rig has been writing: `shared/friction.py`'s module
+docstring states the four reasons in full. The short one is that the people half of decision 33
+posts to THIS service, and this service cannot reach the flows lane.
+
+WHY A SORTED SET AND NOT A KEY SCAN. Every read here is "everything since <t>, optionally filtered
+by status" — the dump, `friction_so_far`, and the fixing agent's next pass. That is a range query,
+and `SCAN agent:friction:*` answers it by reading every record on the instance and throwing most of
+them away. The score is the LAST report time, so a defect filed at nine and hit again at five sorts
+where a reader expects it.
+
+RETENTION: none, deliberately. This is a defect ledger; a row is interesting until it is fixed and
+then it is evidence that it was. Nothing here expires, and the blank script must not delete it
+either — the environment being reset is exactly when the record of what broke matters.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import time
+from typing import Optional
+
+from shared import friction as fr
+
+logger = logging.getLogger("agent_api.friction")
+
+ID_BYTES = 8            # short enough to paste into a `friction_fixed([...])` call by hand
+
+
+class FrictionStore:
+    """Durable friction records, keyed by id, deduplicated by `shared.friction.dedup_key`."""
+
+    def __init__(self, redis_client=None) -> None:
+        self._redis = redis_client
+        self._mem: dict[str, dict] = {}
+        self._by_key: dict[str, str] = {}
+
+    # ── keys ──
+    @staticmethod
+    def _key(rid: str) -> str:
+        return f"agent:friction:{rid}"
+
+    @staticmethod
+    def _dedup_key(dk: str) -> str:
+        return f"agent:friction:key:{dk}"
+
+    INDEX = "agent:friction:all"
+
+    # ── writes ──
+    def file(self, raw: dict, *, now: float | None = None) -> dict:
+        """File one report. Returns the stored record — NEW or folded into the one it duplicates.
+
+        The caller is told which by reading `recurrence`: 1 means this is the first time anyone has
+        seen it. That matters to the reporter — an agent that files the same edge for the fourth
+        time should be told the count, not thanked as if it were news."""
+        rec = fr.normalize(raw, now=now)
+        dk = fr.dedup_key(rec)
+        existing = self.get(self._id_for_key(dk)) if self._id_for_key(dk) else None
+        merged = fr.apply_report(existing, rec, now=now)
+        merged["id"] = (existing or {}).get("id") or f"fr_{secrets.token_hex(ID_BYTES)}"
+        merged["dedup_key"] = dk
+        self._put(merged)
+        self._bind_key(dk, merged["id"])
+        return merged
+
+    def fix(self, rid: str, fix_ref: str, *, now: float | None = None) -> Optional[dict]:
+        """Close one record against the change that addressed it. None when the id is unknown."""
+        rec = self.get(rid)
+        if rec is None:
+            return None
+        out = fr.apply_fix(rec, fix_ref, now=now)
+        self._put(out)
+        return out
+
+    # ── reads ──
+    def get(self, rid: str) -> Optional[dict]:
+        if not rid:
+            return None
+        if self._redis is not None:
+            raw = self._redis.get(self._key(rid))
+            if not raw:
+                return None
+            try:
+                return json.loads(raw)
+            except (TypeError, ValueError):
+                logger.warning("friction record %s is unreadable in the store", rid)
+                return None
+        return self._mem.get(rid)
+
+    def since(self, ts: float = 0.0, *, status: str = "", limit: int = 500) -> list[dict]:
+        """Records reported at or after `ts`, newest first, optionally one status.
+
+        `status="open"` means OPEN OR RECURRING, and that is not a shortcut. A fixing agent asking
+        for "what is open" wants the work; a recurring row is the most urgent work there is, and
+        excluding it because its status string differs would hide exactly the rows that say a
+        previous pass was wrong. `status="recurring"` still selects only those."""
+        if self._redis is not None:
+            ids = self._redis.zrevrangebyscore(self.INDEX, "+inf", ts, start=0, num=limit) or []
+        else:
+            ids = [r["id"] for r in sorted(self._mem.values(),
+                                           key=lambda r: float(r.get("at") or 0), reverse=True)
+                   if float(r.get("at") or 0) >= ts][:limit]
+        rows = [r for r in (self.get(i) for i in ids) if r]
+        want = str(status or "").strip().lower()
+        if want == "open":
+            rows = [r for r in rows if r.get("status") in ("open", "recurring")]
+        elif want in fr.STATUSES:
+            rows = [r for r in rows if r.get("status") == want]
+        return rows
+
+    # ── internals ──
+    def _put(self, rec: dict) -> None:
+        if self._redis is not None:
+            self._redis.set(self._key(rec["id"]), json.dumps(rec))
+            self._redis.zadd(self.INDEX, {rec["id"]: float(rec.get("at") or time.time())})
+        else:
+            self._mem[rec["id"]] = rec
+
+    def _bind_key(self, dk: str, rid: str) -> None:
+        if self._redis is not None:
+            self._redis.set(self._dedup_key(dk), rid)
+        else:
+            self._by_key[dk] = rid
+
+    def _id_for_key(self, dk: str) -> str:
+        if self._redis is not None:
+            return self._redis.get(self._dedup_key(dk)) or ""
+        return self._by_key.get(dk, "")
+
+
+def parse_since(since: str, *, now: float | None = None) -> float:
+    """`""` → everything · `900` / `15m` / `2h` / `3d` → that long ago · an ISO instant → itself.
+
+    A dump asked for "since 1h" and given a wall-clock epoch it could not parse would silently
+    return the whole ledger, which reads as "nothing was fixed today". Unparseable input therefore
+    means EVERYTHING and the caller is told so by the dump's own scope line, rather than being
+    handed a plausible wrong window."""
+    s = str(since or "").strip()
+    if not s:
+        return 0.0
+    now = float(now if now is not None else time.time())
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    if s[-1:].lower() in units and s[:-1].replace(".", "", 1).isdigit():
+        return now - float(s[:-1]) * units[s[-1].lower()]
+    if s.replace(".", "", 1).isdigit():
+        v = float(s)
+        # A bare number is an epoch when it looks like one (>= 2001) and a duration otherwise.
+        return v if v > 1_000_000_000 else now - v
+    try:
+        from datetime import datetime, timezone
+        t = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=timezone.utc)
+        return t.timestamp()
+    except ValueError:
+        logger.warning("friction dump: unparseable since=%r — returning everything", s)
+        return 0.0

--- a/core/agent/eval/friction_loop_replay.py
+++ b/core/agent/eval/friction_loop_replay.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+"""Offline replay: does the rough-edges loop actually produce something a fixing agent can work off?
+
+PRD decision 33's proof obligation — *"dump it in a way that we can just dump that to an agent that
+would just fix that (like you are here)"*. This is that end to end with the cost taken out: no
+stack, no docker, no redis, no model. A real FastAPI agent-api over the store's in-memory fallback,
+the real worker-side detectors, the real record module, and the real routes — under a second, and it
+runs in CI (`tests/test_friction_replay.py` imports and asserts it).
+
+WHAT IT PROVES, in the order it does it:
+
+  1. **Three edges arrive by three different doors and land in one shape.** A missing toolbelt filed
+     by the HARNESS at spawn (the model never ran — ledger F70), a no-page filed by a PERSON from
+     the terminal, and a wrong-workspace filed by an AGENT through the rig's own legacy argument
+     names. Nothing here reformats them by hand; each posts what its real caller posts.
+  2. **The dump is fixer-ready.** Symptom, exact context, likely cause, log pointers you can paste,
+     and a repro line — grouped, counted, and carrying the call that closes each one.
+  3. **The loop closes, and a fix that does not hold says so.** One finding is fixed against a
+     reference; then the same edge is filed again and comes back `recurring` with the fix it
+     outlived still named.
+
+Usage:  python core/agent/eval/friction_loop_replay.py [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))   # core/agent — the path pytest uses
+
+
+def _client(root: Path):
+    """agent-api over fakes — the same L2 shape the unit tests use, no redis and no runtime."""
+    from fastapi.testclient import TestClient
+
+    from control_plane.api import create_app
+    from control_plane.dispatch import Dispatcher
+    from control_plane.workspace_reader import WorkspaceReader
+    from shared.config import load_settings
+
+    class _Runtime:
+        def spawn(self, workload_id, profile, env):
+            return workload_id
+
+        def await_done(self, workload_id, timeout_sec=0.0):
+            return "completed"
+
+    class _Identity:
+        def mint(self, subject, launcher, workspaces, tools):
+            return "tok"
+
+    (root / "_global" / "asks").mkdir(parents=True, exist_ok=True)
+    settings = load_settings(workspaces_dir=str(root),
+                             global_system_workspace_path=str(root / "_global"),
+                             redis_url="")
+    return TestClient(create_app(Dispatcher(settings, _Runtime(), _Identity()),
+                                 reader=WorkspaceReader(str(root))))
+
+
+HDR = {"X-User-Id": "126"}
+
+
+def run(out=sys.stdout) -> dict:
+    from worker import friction as wfr
+
+    with tempfile.TemporaryDirectory() as td:
+        c = _client(Path(td) / "workspaces")
+        filed: list[dict] = []
+
+        # ── EDGE 1 · missing-tool, filed by the HARNESS at spawn ────────────────────────────────
+        # The model never ran. This is ledger F70: a session with no toolbelt cannot call
+        # report_friction, so if the harness does not file it, nothing ever does.
+        rec = wfr.spawn_gap(url="https://rig.example/mcp", token="", config_written=False,
+                            session="meet-104", subject="126")
+        assert rec is not None, "the spawn gap must file when a toolbelt was intended and absent"
+        filed.append(c.post("/api/friction", json=rec, headers=HDR).json())
+
+        # ── EDGE 2 · no-page, filed by a PERSON from the terminal ───────────────────────────────
+        # Exactly the body `clients/terminal/src/surfaces/frictionApi.ts` builds: one line, plus the
+        # surface the person was never asked to describe.
+        filed.append(c.post("/api/friction", json={
+            "reporter": "person", "session": "meet-104",
+            "happened": "clicked the DNA link and the panel says there is no page here yet",
+            "tried": "opened kg/entities/companies/ASWF.md",
+            "context": {"workspace": "dna", "path": "kg/entities/companies/ASWF.md",
+                        "meeting_id": "104",
+                        "surface": {"chat": "meet-104", "chat_kind": "meeting", "at": "page"}},
+        }, headers=HDR).json())
+
+        # ── EDGE 3 · wrong-workspace, filed by an AGENT through the rig's LEGACY argument names ──
+        # `report_friction(what_i_was_doing=…, what_went_wrong=…)` — the signature the live
+        # machinery note still names. Backwards compatibility is proven by using it, not by a
+        # comment saying it is kept.
+        for _ in range(2):          # the same edge, twice: dedup must fold it into one row
+            filed.append(c.post("/api/friction", json={
+                "what_i_was_doing": "write the meeting note to the group desk",
+                "what_went_wrong": "workspace_write landed in the wrong workspace — it wrote to "
+                                   "personal although the chat mounts the dna group",
+                "what_would_have_helped": "workspace_write defaulting to the chat's mounted group",
+                "tool": "mcp__vexa__workspace_write", "workspace": "personal",
+                "severity": "blocker", "kind": "wrong-workspace",
+            }, headers=HDR).json())
+
+        dump = c.get("/api/friction/dump?status=open", headers=HDR).text
+
+        # ── the loop closes, and a fix that does not hold says so ────────────────────────────────
+        target = filed[1]["id"]                      # the no-page finding
+        c.post(f"/api/friction/{target}/fix", json={"fix_ref": "PR #1410 · a3742c4"}, headers=HDR)
+        c.post("/api/friction", json={
+            "reporter": "person", "happened": "clicked the DNA link and the panel says there is no "
+                                              "page here yet",
+            "context": {"workspace": "dna", "path": "kg/entities/companies/ASWF.md"},
+        }, headers=HDR)
+        after = c.get("/api/friction/dump?status=open&format=json", headers=HDR).json()
+
+        by_id = {r["id"]: r for r in after["records"]}
+        result = {
+            "filed": len(filed),
+            "rows": after["count"],
+            "findings": len(after["findings"]),
+            "deduped": [f["id"] for f in filed].count(filed[2]["id"]),
+            "recurring": [f["kind"] for f in after["findings"] if f["status"] == "recurring"],
+            "fix_that_did_not_hold": by_id.get(target, {}).get("fix_ref", ""),
+            "dump": dump,
+        }
+
+        # The assertions ARE the proof; a replay that prints a dump nobody checked proves nothing.
+        assert result["deduped"] == 2, "two reports of one edge must be ONE row"
+        assert result["findings"] == 3, f"three edges → three findings, got {result['findings']}"
+        assert result["recurring"] == ["no-page"], "a fix that did not hold must say so"
+        assert result["fix_that_did_not_hold"] == "PR #1410 · a3742c4"
+        for label in ("**Symptom**", "**Exact context**", "**Likely cause**", "**Logs**",
+                      "**Repro**", "docker logs --since", "friction_fixed("):
+            assert label in dump, f"the dump is not fixer-ready: {label} missing"
+        for kind in ("missing-tool", "no-page", "wrong-workspace"):
+            assert kind in dump, f"{kind} never reached the dump"
+        print(f"friction replay: {result['filed']} reports → {result['rows']} rows → "
+              f"{result['findings']} findings · recurring={result['recurring']}", file=out)
+        return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true", help="print the result object, not the brief")
+    a = ap.parse_args()
+    res = run(out=sys.stderr if not a.json else sys.stderr)
+    if a.json:
+        print(json.dumps({k: v for k, v in res.items() if k != "dump"}, indent=2))
+    else:
+        print(res["dump"])
+    return 0
+
+
+if __name__ == "__main__":          # pragma: no cover — the runnable artefact
+    sys.exit(main())

--- a/core/agent/shared/friction.py
+++ b/core/agent/shared/friction.py
@@ -1,0 +1,560 @@
+"""friction.py — THE ROUGH-EDGES RECORD (PRD decision 33).
+
+Founder, 2026-09-02 16:0xZ: *"we also need to leverage the mcp tool that should collect rough edges
+— things that did not work as expected — and dump it in a way that we can just dump that to an
+agent that would just fix that (like you are here)."*
+
+This module is the RECORD and nothing else: the shape, the normalization that lets three very
+different reporters write the same row, the dedup key, the status machine, and the renderer that
+turns a pile of rows into a brief a fixing agent can work straight off. No storage, no HTTP, no
+clock beyond the one it is handed. The store is `control_plane/friction.py`; the agent-side client
+is `worker/friction.py`; the person-side control is the terminal's `ReportThis.tsx`. All four speak
+this shape, and this file is the only place it is written down.
+
+── WHY THE STORE MOVED OFF THE FLOWS DATABASE ───────────────────────────────────────────────────
+`report_friction` already existed on the rig and wrote a `friction` table in the FLOWS Postgres.
+That table is the wrong owner, for four reasons, and the fourth is the one that decides it:
+
+  1. **The people half cannot reach it.** Decision 33 §2 puts a "Report this" action in the
+     terminal, which posts to agent-api. The rig reaches the flows lane by reading
+     `~/.storm/dburl` off the HOST filesystem; agent-api is a container and has no such file and no
+     flows credential. One store with two owners is the shape that produces two stores.
+  2. **The blank script deletes it.** `deploy/dogfood/bin/blank-instance.sh` lists `friction` among
+     the flows lane tables it wipes. Friction is a ledger of what is BROKEN IN THE PRODUCT — it must
+     outlive the lane whose reset it is describing. Wiping the evidence with the environment is how
+     the same defect gets found four times.
+  3. **It exists in one lane and not the other** ("absent in this lane — skipped"), because nothing
+     ever created it in a migration. A table with no DDL in the repository is not a store, it is a
+     thing somebody typed once.
+  4. **It cannot hold this record.** Decision 33 needs a context object, log pointers, a status, a
+     fix reference and a recurrence counter. The existing five columns hold none of them, and adding
+     them means writing the migration the flows lane never had — for a table that is about to be
+     read by a service that cannot connect to it anyway.
+
+So the store is agent-api's redis, beside the scaffold store and the session index, for the reasons
+`control_plane/scaffolds.py` already states about scaffolds and which apply verbatim here: it is
+durable by deployment (valkey with `--appendonly yes` on its own volume), it is not the workspace
+volume, and an in-memory fallback keeps the unit tests store-free. The legacy flows rows are not
+migrated and not deleted; `friction_so_far` still reads them as a last fallback so nothing already
+filed disappears.
+
+── THE FILE IS STILL WRITTEN FIRST ──────────────────────────────────────────────────────────────
+The rig's original code had one rule worth keeping verbatim: the append-only JSONL lands BEFORE the
+durable store, because "losing feedback because a store was briefly down is the worst failure
+available to the one channel that tells us what using this is like." That stays. The store moving
+does not change which write is the fallback.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from datetime import datetime, timezone
+
+# ── the vocabulary ───────────────────────────────────────────────────────────────────────────────
+
+#: Who filed it. Two values, and the difference is load-bearing in the dump: an agent's report is
+#: written by the thing that hit the edge, a person's is written by the thing that SAW it, and a
+#: fixing agent reads them differently.
+REPORTERS = ("agent", "person")
+
+#: What kind of edge it is (decision 33 §1's list, closed). `other` is the honest floor — a reporter
+#: who cannot classify must still be able to file, and a record forced into a wrong bucket is worse
+#: than one in the bucket named "I could not tell".
+KINDS = ("missing-tool", "refusal", "no-page", "wrong-workspace", "unfulfilled", "error", "ux",
+         "other")
+
+#: The status machine. `open` on file; `fixed` when a fixing agent references it; `recurring` when
+#: the same edge is filed AGAIN after a fix — which is the single most valuable state here, because
+#: it is the only one that says a fix did not hold.
+STATUSES = ("open", "fixed", "recurring")
+
+#: The context object's keys, in the order the dump prints them. `surface` carries the decision-30
+#: human-surface block when the client has one; it is optional by design — decision 30's server half
+#: is not on this branch yet, and a record that refuses to exist without it would file nothing today.
+CONTEXT_KEYS = ("workspace", "path", "meeting_id", "scaffold_id", "tool", "error", "surface")
+
+#: Severity is not in decision 33's shape. It is kept because the rig's `report_friction` has always
+#: taken it, dozens of live rows carry it, and dropping an argument is not backwards compatibility.
+SEVERITIES = ("blocker", "annoyance", "papercut", "idea")
+
+MAX_TEXT = 900          # per free-text field; a report is a lead, not a transcript
+MAX_ERROR = 600
+
+
+def _clip(v, n: int = MAX_TEXT) -> str:
+    return str(v or "").strip()[:n]
+
+
+def _one_of(v, allowed, default: str) -> str:
+    v = str(v or "").strip().lower()
+    return v if v in allowed else default
+
+
+# ── normalization ────────────────────────────────────────────────────────────────────────────────
+
+# Today's rig arguments → the record's fields. `report_friction(what_i_was_doing=…,
+# what_went_wrong=…, what_would_have_helped=…)` has been live long enough to have callers in the
+# wild (the machinery note names it by that signature), so the old spelling is not deprecated, it is
+# an ALIAS. A caller that passes both wins with the new one.
+_ALIASES = {
+    "what_i_was_doing": "tried",
+    "doing": "tried",
+    "what_went_wrong": "happened",
+    "wrong": "happened",
+    "what_would_have_helped": "would_help",
+}
+
+
+def normalize(raw: dict, *, now: float | None = None) -> dict:
+    """One record, in the shape of decision 33 §1 — from whatever the reporter managed to say.
+
+    Accepts the legacy rig arguments, the new named fields, a flat context (``tool=``, ``path=`` at
+    the top level, which is what a person's one-line report produces) or a nested one. Everything
+    unknown is DROPPED rather than carried: a context key nobody reads is a key the dump has to
+    decide how to print, and this record is read by an agent that will act on it.
+
+    It never raises. A report that fails validation is a report that never gets filed, and the whole
+    point of this channel is that filing is cheaper than routing around the problem silently."""
+    raw = raw if isinstance(raw, dict) else {}
+    src = dict(raw)
+    for old, new in _ALIASES.items():
+        if src.get(old) and not src.get(new):
+            src[new] = src[old]
+
+    ctx_in = src.get("context")
+    ctx_in = dict(ctx_in) if isinstance(ctx_in, dict) else {}
+    ctx: dict = {}
+    for k in CONTEXT_KEYS:
+        # top level wins only when the nested object is silent — a caller that sent a real context
+        # object meant it, and a stray top-level `path` should not overwrite it.
+        v = ctx_in.get(k) if ctx_in.get(k) not in (None, "") else src.get(k)
+        if v in (None, ""):
+            continue
+        if k == "surface":
+            ctx[k] = v if isinstance(v, dict) else {"note": _clip(v, 400)}
+        elif k == "error":
+            ctx[k] = _clip(v, MAX_ERROR)
+        else:
+            ctx[k] = _clip(v, 200)
+
+    rec = {
+        "at": float(src.get("at") or (now if now is not None else time.time())),
+        "reporter": _one_of(src.get("reporter"), REPORTERS, "agent"),
+        "subject": _clip(src.get("subject") or src.get("uid"), 64),
+        "session": _clip(src.get("session"), 128),
+        "kind": _one_of(src.get("kind"), KINDS, _infer_kind(src, ctx)),
+        "tried": _clip(src.get("tried")),
+        "happened": _clip(src.get("happened")),
+        "would_help": _clip(src.get("would_help")),
+        "severity": _one_of(src.get("severity"), SEVERITIES, "annoyance"),
+        "context": ctx,
+        "log_refs": log_refs(src.get("log_refs"), ctx, src.get("reporter")),
+    }
+    return rec
+
+
+# The words a reporter who did not classify actually uses. This is a GUESS and is treated as one:
+# it only ever fires when `kind` was absent, and `other` is where an unrecognised report lands. It
+# exists because the alternative — every unclassified report in one bucket — makes the dump's
+# grouping useless on exactly the reports written in a hurry, which are most of them.
+_KIND_HINTS = (
+    ("missing-tool", re.compile(r"no (?:such )?tool|tool (?:is )?(?:missing|absent|unavailable)|"
+                                r"don'?t have a .{0,24}tool|no mcp|mcp server (?:absent|missing)|"
+                                r"tools unavailable", re.I)),
+    ("no-page", re.compile(r"\b(?:page|file|doc(?:ument)?) (?:does not|doesn'?t) exist|"
+                           r"no page (?:here|at)|404|not found", re.I)),
+    ("wrong-workspace", re.compile(r"wrong workspace|wrong desk|other (?:workspace|desk)|"
+                                   r"landed in the wrong", re.I)),
+    ("refusal", re.compile(r"\brefus|\bdenied\b|not permitted|forbidden|403", re.I)),
+    ("error", re.compile(r"\b(?:4\d\d|5\d\d)\b|traceback|exception|failed with", re.I)),
+    ("unfulfilled", re.compile(r"could not (?:do|fulfil|fulfill|complete)|no way to|"
+                               r"gave up|worked around", re.I)),
+)
+
+
+def _infer_kind(src: dict, ctx: dict) -> str:
+    hay = " ".join(str(src.get(k) or "") for k in ("happened", "tried", "would_help"))
+    hay = f"{hay} {ctx.get('error', '')}"
+    for kind, rx in _KIND_HINTS:
+        if rx.search(hay):
+            return kind
+    return "other"
+
+
+# ── the dedup key ────────────────────────────────────────────────────────────────────────────────
+
+# Volatile ids inside an error string are what stop dedup from working at all: the same failure
+# carries a different meeting row, uuid or timestamp every time, so ten reports of one defect look
+# like ten defects. They are masked BEFORE hashing — the key answers "is this the same edge?", and
+# a row id is not part of the answer.
+_UUID = re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b", re.I)
+_HEX = re.compile(r"\b[0-9a-f]{12,}\b", re.I)
+# An id is recognised by WHAT IT IS CALLED, not by how long it is. Masking every 3-digit run was
+# the obvious rule and it is wrong in the direction that matters: it eats HTTP status codes, so
+# `404` and `503` from one tool collapse into a single "edge" and a fixing agent is told two
+# different failures are the same one. So a number is masked when a word beside it says it is an
+# identifier, and otherwise only when it is too long to be a status.
+_LABELLED_ID = re.compile(
+    r"\b(meeting|meetings|uid|user|users|row|id|ids|session|scaffold|workspace|desk|chat|"
+    r"reaction|flow|thread)\s*[#:=]?\s*\d+", re.I)
+_NUM = re.compile(r"\b\d{4,}\b")
+_WS = re.compile(r"\s+")
+
+#: How much of the error text takes part in the key. Long enough to separate two different failures
+#: of one tool, short enough that a stack trace's tail does not make every occurrence unique.
+ERROR_PREFIX = 120
+
+
+def _mask(s: str) -> str:
+    s = _UUID.sub("<id>", str(s or ""))
+    s = _HEX.sub("<id>", s)
+    s = _LABELLED_ID.sub(lambda m: f"{m.group(1)} <id>", s)
+    s = _NUM.sub("<n>", s)
+    return _WS.sub(" ", s).strip().lower()
+
+
+def error_prefix(rec: dict) -> str:
+    """The masked head of what went wrong — the third leg of the key.
+
+    `context.error` when the reporter gave one (a machine-readable failure), otherwise `happened`
+    (what a person or an agent wrote in prose). One field would be wrong in both directions: an
+    error-only key cannot dedup a human report, and a prose-only key cannot dedup a 500."""
+    ctx = rec.get("context") or {}
+    return _mask(ctx.get("error") or rec.get("happened") or "")[:ERROR_PREFIX]
+
+
+def dedup_key(rec: dict) -> str:
+    """`(kind, tool|path, error prefix)` — decision 33 §1's key, hashed.
+
+    `tool` before `path` because a tool failure is about the tool wherever it was pointed, while a
+    page failure has no tool and is entirely about the path. A record with neither keys on the error
+    alone, which is right: that is all it told us."""
+    ctx = rec.get("context") or {}
+    subject = _mask(ctx.get("tool") or ctx.get("path") or "")
+    payload = f"{rec.get('kind', 'other')}|{subject}|{error_prefix(rec)}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:24]
+
+
+def group_key(rec: dict) -> tuple[str, str]:
+    """The DUMP's grouping — "same kind + tool/path" (decision 33 §3), one step coarser than dedup.
+
+    Two different 500s from one tool are two rows and one finding: a fixing agent opens that tool's
+    code once. Grouping at the dedup key instead would hand them the same file twice."""
+    ctx = rec.get("context") or {}
+    return (rec.get("kind", "other"), _mask(ctx.get("tool") or ctx.get("path") or ""))
+
+
+# ── log pointers ─────────────────────────────────────────────────────────────────────────────────
+
+# WHERE TO LOOK, per kind of report. This is the difference between a dump an agent can act on and
+# a dump it has to investigate from scratch — and it is derived, never asked for: a reporter who
+# knew which container held the answer would not be reporting friction.
+#
+# It is a HINT and the dump says so. A wrong container costs one `docker logs` call; a missing one
+# costs the fixing agent the whole investigation.
+AGENT_API = "vexa-dogfood-agent-api-1"
+RUNTIME = "vexa-dogfood-runtime-1"
+TERMINAL = "vexa-dogfood-terminal-1"
+GATEWAY = "vexa-dogfood-gateway-1"
+
+_CONTAINERS = {
+    "missing-tool": (AGENT_API,),        # dispatch mints the delegation config the toolbelt rides on
+    "refusal": (AGENT_API,),
+    "no-page": (AGENT_API,),
+    "wrong-workspace": (AGENT_API,),
+    "unfulfilled": (AGENT_API, RUNTIME),
+    "error": (AGENT_API, RUNTIME),
+    "ux": (TERMINAL,),
+    "other": (AGENT_API,),
+}
+# A tool name that says more than the kind does. `bot_*` and `meeting_*` cross the gateway; anything
+# `flow*` is the flows runtime.
+_TOOL_CONTAINERS = (
+    (re.compile(r"^(?:mcp__vexa__)?(?:bot_|meeting_|recordings_|transcript)", re.I), GATEWAY),
+    (re.compile(r"^(?:mcp__vexa__)?(?:flow|propose|whats_waiting)", re.I), RUNTIME),
+    (re.compile(r"^(?:mcp__vexa__)?workspace|^(?:mcp__vexa__)?entity_", re.I), AGENT_API),
+)
+
+#: How far before the report to start reading. A worker turn that ends in an error wrote the cause
+#: minutes earlier, not seconds.
+LOOKBACK_S = 900
+
+
+def _grep_for(ctx: dict, rec: dict) -> str:
+    """What to grep the container's log FOR. The most specific identifier the record carries, and
+    only as a fallback the first few words of the symptom — a grep for a whole sentence matches
+    nothing, because a log line is not a paragraph."""
+    for k in ("tool", "path", "meeting_id", "scaffold_id"):
+        if ctx.get(k):
+            return str(ctx[k])[:80]
+    words = _mask(rec.get("happened") or "").split(" ")[:4]
+    return " ".join(words)[:80]
+
+
+def log_refs(given, ctx: dict | None = None, reporter=None) -> list[dict]:
+    """`[{container, since, grep}]` — supplied by the reporter, or nothing.
+
+    A reporter that names its own pointers is believed and they are kept as-is: a worker knows its
+    own container id and this function does not. Everything else is left EMPTY here and derived at
+    render time by `derived_log_refs`, where the record's kind and time are both known and where a
+    renamed deployment does not make a stored pointer a lie."""
+    if isinstance(given, list) and given:
+        out = []
+        for r in given[:6]:
+            if isinstance(r, dict) and r.get("container"):
+                out.append({"container": _clip(r["container"], 120),
+                            "since": _clip(r.get("since"), 40),
+                            "grep": _clip(r.get("grep"), 120)})
+        if out:
+            return out
+    return []
+
+
+def derived_log_refs(rec: dict) -> list[dict]:
+    """The pointers for a record that carries none — computed from its kind, tool and time.
+
+    Not stored: a stored pointer goes stale the moment the deployment is renamed, and this is
+    cheap to recompute. `since` is an absolute RFC-3339 instant, which is what `docker logs
+    --since` wants and what survives being pasted into a terminal an hour later."""
+    if rec.get("log_refs"):
+        return list(rec["log_refs"])
+    ctx = rec.get("context") or {}
+    since = datetime.fromtimestamp(max(0.0, float(rec.get("at") or 0) - LOOKBACK_S),
+                                   tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    containers: list[str] = []
+    tool = str(ctx.get("tool") or "")
+    for rx, c in _TOOL_CONTAINERS:
+        if tool and rx.search(tool):
+            containers.append(c)
+            break
+    for c in _CONTAINERS.get(rec.get("kind", "other"), (AGENT_API,)):
+        if c not in containers:
+            containers.append(c)
+    grep = _grep_for(ctx, rec)
+    return [{"container": c, "since": since, "grep": grep} for c in containers[:3]]
+
+
+def log_command(ref: dict) -> str:
+    """One pasteable line. `grep -F` because a tool name is a literal, not a pattern, and an
+    `entity_upsert(` in a grep expression is a syntax error the reader has to debug instead of the
+    defect they came for."""
+    cmd = f"docker logs --since {ref.get('since') or '1h'} {ref.get('container')}"
+    g = ref.get("grep")
+    return f"{cmd} 2>&1 | grep -F {g!r}" if g else cmd
+
+
+def repro_line(rec: dict) -> str:
+    """One line a fixing agent can run or replay. Honest about what it does not know: where no
+    reproducible call exists, it names the surface and the ask instead of inventing a command."""
+    ctx = rec.get("context") or {}
+    tool = ctx.get("tool")
+    # A `subsystem:name` tool is not something you can call — `mcp:vexa` is the toolbelt itself, not
+    # a function. Printing `mcp:vexa()` as a repro is the dump inventing a command, which is exactly
+    # the confident-wrong answer a fixing agent will waste a pass on.
+    if tool and ":" in str(tool):
+        return (f"start a worker turn with the `{tool}` attachment in the state the context "
+                f"describes, as subject {rec.get('subject') or '?'} — this is a SPAWN condition, "
+                "not a call")
+    if tool:
+        args = []
+        if ctx.get("workspace"):
+            args.append(f"workspace={ctx['workspace']!r}")
+        if ctx.get("path"):
+            args.append(f"path={ctx['path']!r}")
+        if ctx.get("meeting_id"):
+            args.append(f"meeting={ctx['meeting_id']!r}")
+        return f"call `{tool}({', '.join(args)})` as subject {rec.get('subject') or '?'}"
+    if ctx.get("path"):
+        ws = ctx.get("workspace") or "personal"
+        return f"open `{ws} › {ctx['path']}` in the panel as subject {rec.get('subject') or '?'}"
+    if rec.get("reporter") == "person":
+        surf = (ctx.get("surface") or {})
+        where = surf.get("path") or surf.get("chat") or rec.get("session") or "the terminal"
+        return f"reproduce from the person's seat at {where}"
+    return "no reproducible call was recorded — read the logs below from the report's timestamp"
+
+
+# ── the status machine ───────────────────────────────────────────────────────────────────────────
+
+def apply_report(existing: dict | None, incoming: dict, *, now: float | None = None) -> dict:
+    """Fold a new report into whatever the store already holds for its dedup key.
+
+    Three transitions, and the third is the whole reason status exists:
+
+      * nothing yet → `open`, recurrence 1.
+      * `open` (or `recurring`) again → recurrence + 1, newest wording wins, status unchanged. The
+        wording is REPLACED rather than appended because the last reporter had the most context;
+        the count is what carries "this keeps happening".
+      * `fixed`, then reported again → `recurring`, and `regressed_at` is stamped. `fix_ref` is
+        KEPT: the question a recurring row answers is "which fix did not hold", and dropping the
+        reference destroys exactly that.
+
+    `first_at` never moves. It is the age of the defect, and a dump sorted by it is the difference
+    between "new since the last pass" and "this has been broken all day"."""
+    now = float(now if now is not None else time.time())
+    if existing is None:
+        rec = dict(incoming)
+        rec["status"] = "open"
+        rec["recurrence"] = 1
+        rec["first_at"] = rec.get("at") or now
+        rec["fix_ref"] = ""
+        return rec
+    rec = dict(existing)
+    for k in ("tried", "happened", "would_help", "context", "reporter", "session", "subject",
+              "severity", "log_refs"):
+        if incoming.get(k):
+            rec[k] = incoming[k]
+    rec["at"] = incoming.get("at") or now
+    rec["recurrence"] = int(rec.get("recurrence") or 1) + 1
+    rec.setdefault("first_at", rec["at"])
+    if rec.get("status") == "fixed":
+        rec["status"] = "recurring"
+        rec["regressed_at"] = rec["at"]
+    return rec
+
+
+def apply_fix(rec: dict, fix_ref: str, *, now: float | None = None) -> dict:
+    """Close one record against the thing that fixed it (decision 33 §4).
+
+    `fix_ref` is required and unvalidated on purpose: a commit sha, a PR url, a branch, a sentence.
+    What matters is that a human or an agent reading the row can find the change; what shape that
+    reference takes is not this module's business. An EMPTY one is refused — a record marked fixed
+    with nothing to point at is indistinguishable from a record somebody wanted off the list."""
+    if not str(fix_ref or "").strip():
+        raise ValueError("a fix needs a reference — a commit, a PR, or a sentence naming the change")
+    out = dict(rec)
+    out["status"] = "fixed"
+    out["fix_ref"] = _clip(fix_ref, 300)
+    out["fixed_at"] = float(now if now is not None else time.time())
+    return out
+
+
+# ── the dump ─────────────────────────────────────────────────────────────────────────────────────
+
+def _iso(ts) -> str:
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (TypeError, ValueError, OSError):
+        return "?"
+
+
+def _ctx_line(rec: dict) -> str:
+    ctx = rec.get("context") or {}
+    bits = []
+    for k in CONTEXT_KEYS:
+        v = ctx.get(k)
+        if not v:
+            continue
+        if k == "surface":
+            inner = " · ".join(f"{a}={b}" for a, b in list(v.items())[:6] if b)
+            if inner:
+                bits.append(f"surface({inner})")
+            continue
+        if k == "error":
+            continue                        # the error is the symptom line; not repeated here
+        bits.append(f"{k} `{v}`")
+    bits.append(f"reporter {rec.get('reporter')}" + (f" (uid {rec['subject']})" if rec.get("subject") else ""))
+    if rec.get("session"):
+        bits.append(f"session `{rec['session']}`")
+    bits.append(f"first {_iso(rec.get('first_at') or rec.get('at'))}, last {_iso(rec.get('at'))}")
+    return " · ".join(bits)
+
+
+def group(records: list[dict]) -> list[dict]:
+    """Records → findings, one per likely cause, most-urgent first.
+
+    Order is not by count. `recurring` sorts above everything because a fix that did not hold is the
+    only class of row that says the last pass was WRONG, and a fixing agent that reads it late has
+    already re-fixed something else. Within a status, the loudest (most occurrences) first, then the
+    freshest — a defect nobody has hit since yesterday is genuinely less interesting than one that
+    fired ten minutes ago."""
+    buckets: dict[tuple[str, str], list[dict]] = {}
+    for r in records:
+        buckets.setdefault(group_key(r), []).append(r)
+    out = []
+    for (kind, subject), rows in buckets.items():
+        rows = sorted(rows, key=lambda r: float(r.get("at") or 0), reverse=True)
+        count = sum(int(r.get("recurrence") or 1) for r in rows)
+        statuses = {r.get("status", "open") for r in rows}
+        status = ("recurring" if "recurring" in statuses
+                  else "open" if "open" in statuses else "fixed")
+        out.append({"kind": kind, "subject": subject, "status": status, "count": count,
+                    "rows": rows, "at": max(float(r.get("at") or 0) for r in rows)})
+    rank = {"recurring": 0, "open": 1, "fixed": 2}
+    out.sort(key=lambda g: (rank.get(g["status"], 3), -g["count"], -g["at"]))
+    return out
+
+
+HEADER = """# Rough edges — the friction dump
+
+Every row here was filed by the agent or the person who hit it (PRD decision 33). Each finding
+below is **symptom → exact context → likely cause → log pointers → repro**, deduplicated, grouped by
+likely cause (same kind, same tool or path). The counts are occurrences, not rows.
+
+**What to do with this.** Work the findings top-down; `recurring` first — those are edges a previous
+fix did not hold on, and the `fix that did not hold` line names the change to re-read. Two rules:
+
+* **A likely cause is a candidate, not a diagnosis.** It is what the reports agree on, computed —
+  nobody looked. Read the logs before you believe it.
+* **Close what you addressed, and only that.** `friction_fixed(ids=[…], fix_ref="<commit|PR>")`, or
+  `POST /api/friction/<id>/fix {"fix_ref": …}`. A record filed again after a fix flips to
+  `recurring` by itself, so closing something you did not fix does not hide it — it just costs the
+  next reader a pass.
+"""
+
+
+def render_markdown(records: list[dict], *, since: str = "", status: str = "open",
+                    now: float | None = None) -> str:
+    """The brief, in the ledger's finding shape — handed to a fixing agent verbatim."""
+    now = float(now if now is not None else time.time())
+    groups = group(records)
+    lines = [HEADER, ""]
+    scope = f"status `{status or 'any'}`" + (f", since `{since}`" if since else "")
+    lines.append(f"_{len(records)} record(s) → {len(groups)} finding(s) · {scope} · "
+                 f"generated {_iso(now)}_")
+    lines.append("")
+    if not groups:
+        lines.append("**Nothing filed in this window.** That is a real answer and not an error — "
+                     "but if you have been running the product and this is empty, the reporting "
+                     "path itself is the first thing to check.")
+        return "\n".join(lines) + "\n"
+    for i, g in enumerate(groups, 1):
+        head = g["subject"] or "—"
+        occ = f"{g['count']} occurrence" + ("s" if g["count"] != 1 else "")
+        lines.append(f"## FR-{i} · {g['kind']} · `{head}` — {occ}, {g['status']}")
+        lines.append("")
+        newest = g["rows"][0]
+        lines.append(f"- **Symptom** — {newest.get('happened') or '(not stated)'}")
+        if newest.get("tried"):
+            lines.append(f"- **Tried** — {newest['tried']}")
+        err = (newest.get("context") or {}).get("error")
+        if err:
+            lines.append(f"- **Error** — `{err}`")
+        lines.append(f"- **Exact context** — {_ctx_line(newest)}")
+        target = f" on `{head}`" if g["subject"] else ""
+        agree = (f"{g['count']} reports agree on kind `{g['kind']}`{target}"
+                 if g["count"] > 1 else f"one report so far: kind `{g['kind']}`{target}")
+        lines.append(f"- **Likely cause** — {agree}, error text "
+                     f"`{error_prefix(newest) or '(none)'}`. "
+                     "Candidate, computed from the reports — not a diagnosis.")
+        for ref in derived_log_refs(newest):
+            lines.append(f"- **Logs** — `{log_command(ref)}`")
+        lines.append(f"- **Repro** — {repro_line(newest)}")
+        if newest.get("would_help"):
+            lines.append(f"- **Reporter's ask** — {newest['would_help']}")
+        if g["status"] == "recurring":
+            fixes = [r.get("fix_ref") for r in g["rows"] if r.get("fix_ref")]
+            lines.append(f"- **Fix that did not hold** — {fixes[0] if fixes else '(unrecorded)'}")
+        elif g["status"] == "fixed":
+            fixes = [r.get("fix_ref") for r in g["rows"] if r.get("fix_ref")]
+            lines.append(f"- **Fixed by** — {fixes[0] if fixes else '(unrecorded)'}")
+        ids = [r["id"] for r in g["rows"] if r.get("id")]
+        if ids:
+            arg = ", ".join(f'"{i}"' for i in ids)
+            lines.append(f'- **Close with** — `friction_fixed([{arg}], "<commit|PR>")`')
+        if len(g["rows"]) > 1:
+            lines.append(f"- **Also in this finding** — {len(g['rows']) - 1} other record(s) with "
+                         "the same kind and target, different error text")
+        lines.append("")
+    return "\n".join(lines) + "\n"

--- a/core/agent/tests/test_friction.py
+++ b/core/agent/tests/test_friction.py
@@ -1,0 +1,354 @@
+"""The rough-edges loop (PRD decision 33) — shape, dedup, status, the dump, and the two hooks.
+
+Every test here is offline: the record module is pure, the store's in-memory fallback needs no
+redis, and the API tests drive the FastAPI app directly. The one thing that is NOT asserted is the
+network — `worker.friction.report` is proven not to raise, which is the only property a `finally`
+block around somebody's turn can depend on.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from control_plane import friction as store_mod
+from control_plane.api import create_app
+from control_plane.dispatch import Dispatcher
+from control_plane.workspace_reader import WorkspaceReader
+from shared.config import load_settings
+from shared import friction as fr
+from worker import friction as wfr
+
+T0 = 1_788_400_000.0          # a fixed clock: every `at` in here is derived from it
+
+
+# ── the record shape ─────────────────────────────────────────────────────────────────────────────
+
+def test_normalize_accepts_todays_rig_arguments():
+    """Backwards compatibility is not optional: the live machinery note names the old signature."""
+    rec = fr.normalize({"what_i_was_doing": "reading the queue",
+                        "what_went_wrong": "bot_say returned 404",
+                        "what_would_have_helped": "a working bot_say",
+                        "tool": "bot_say", "severity": "blocker", "uid": "126"}, now=T0)
+    assert rec["tried"] == "reading the queue"
+    assert rec["happened"] == "bot_say returned 404"
+    assert rec["would_help"] == "a working bot_say"
+    assert rec["context"]["tool"] == "bot_say"
+    assert rec["severity"] == "blocker"
+    assert rec["subject"] == "126"
+    assert rec["reporter"] == "agent"
+
+
+def test_normalize_carries_the_decision_33_shape():
+    rec = fr.normalize({
+        "reporter": "person", "subject": "126", "session": "meet-104", "kind": "no-page",
+        "tried": "opened the desk README", "happened": "the panel says no page here yet",
+        "context": {"workspace": "personal", "path": "README.md", "meeting_id": "104",
+                    "scaffold_id": "sc1", "tool": "", "error": "404",
+                    "surface": {"chat": "meet-104", "view": "README.md"}},
+        "log_refs": [{"container": "c", "since": "2026-09-02T10:00:00", "grep": "README"}],
+    }, now=T0)
+    assert rec["reporter"] == "person" and rec["kind"] == "no-page"
+    assert rec["context"]["surface"] == {"chat": "meet-104", "view": "README.md"}
+    assert rec["log_refs"][0]["container"] == "c"
+
+
+def test_an_unknown_kind_falls_back_and_is_never_a_refusal():
+    """A reporter that cannot classify must still be able to file. Nothing here raises."""
+    rec = fr.normalize({"kind": "catastrophe", "happened": "hmm"}, now=T0)
+    assert rec["kind"] in fr.KINDS
+    assert fr.normalize(None, now=T0)["kind"] == "other"
+    assert fr.normalize({"happened": "no such tool as bot_teleport"}, now=T0)["kind"] == "missing-tool"
+
+
+def test_unknown_context_keys_are_dropped():
+    rec = fr.normalize({"context": {"path": "a.md", "api_key": "sk-secret"}}, now=T0)
+    assert rec["context"] == {"path": "a.md"}
+    assert "sk-secret" not in json.dumps(rec)
+
+
+# ── dedup ────────────────────────────────────────────────────────────────────────────────────────
+
+def test_dedup_ignores_volatile_ids_inside_the_error():
+    """The same failure carrying a different meeting row is ONE edge, not two."""
+    a = fr.normalize({"kind": "error", "tool": "meeting_transcript",
+                      "context": {"tool": "meeting_transcript",
+                                  "error": "500 while reading meeting 104"}}, now=T0)
+    b = fr.normalize({"kind": "error", "tool": "meeting_transcript",
+                      "context": {"tool": "meeting_transcript",
+                                  "error": "500 while reading meeting 991"}}, now=T0)
+    assert fr.dedup_key(a) == fr.dedup_key(b)
+
+
+def test_dedup_separates_a_different_tool_and_a_different_failure():
+    base = {"kind": "error", "context": {"tool": "bot_say", "error": "404 Not Found"}}
+    other_tool = {"kind": "error", "context": {"tool": "bot_send", "error": "404 Not Found"}}
+    other_err = {"kind": "error", "context": {"tool": "bot_say", "error": "503 upstream down"}}
+    k = fr.dedup_key(fr.normalize(base, now=T0))
+    assert k != fr.dedup_key(fr.normalize(other_tool, now=T0))
+    assert k != fr.dedup_key(fr.normalize(other_err, now=T0))
+
+
+def test_grouping_is_coarser_than_dedup():
+    """Two different failures of one tool are two rows and ONE finding — a fixing agent opens that
+    tool's code once."""
+    rows = [fr.normalize({"kind": "error", "context": {"tool": "bot_say", "error": "404"}}, now=T0),
+            fr.normalize({"kind": "error", "context": {"tool": "bot_say", "error": "503"}}, now=T0)]
+    assert fr.dedup_key(rows[0]) != fr.dedup_key(rows[1])
+    assert fr.group_key(rows[0]) == fr.group_key(rows[1])
+
+
+# ── the status machine ───────────────────────────────────────────────────────────────────────────
+
+def test_a_new_report_is_open_with_a_recurrence_of_one():
+    rec = fr.apply_report(None, fr.normalize({"happened": "x"}, now=T0), now=T0)
+    assert rec["status"] == "open" and rec["recurrence"] == 1 and rec["fix_ref"] == ""
+    assert rec["first_at"] == T0
+
+
+def test_a_repeat_counts_and_keeps_the_first_timestamp():
+    first = fr.apply_report(None, fr.normalize({"happened": "x"}, now=T0), now=T0)
+    again = fr.apply_report(first, fr.normalize({"happened": "x, and now also y"}, now=T0 + 60),
+                            now=T0 + 60)
+    assert again["recurrence"] == 2 and again["status"] == "open"
+    assert again["first_at"] == T0 and again["at"] == T0 + 60
+    assert again["happened"] == "x, and now also y"      # newest wording wins
+
+
+def test_a_report_after_a_fix_flips_to_recurring_and_keeps_the_fix_reference():
+    """The whole reason status exists: a fix that did not hold, and WHICH fix it was."""
+    rec = fr.apply_report(None, fr.normalize({"happened": "x"}, now=T0), now=T0)
+    rec = fr.apply_fix(rec, "abc1234", now=T0 + 10)
+    assert rec["status"] == "fixed" and rec["fix_ref"] == "abc1234"
+    rec = fr.apply_report(rec, fr.normalize({"happened": "x again"}, now=T0 + 20), now=T0 + 20)
+    assert rec["status"] == "recurring"
+    assert rec["fix_ref"] == "abc1234"
+    assert rec["regressed_at"] == T0 + 20
+
+
+def test_a_fix_without_a_reference_is_refused():
+    rec = fr.apply_report(None, fr.normalize({"happened": "x"}, now=T0), now=T0)
+    with pytest.raises(ValueError):
+        fr.apply_fix(rec, "  ")
+
+
+# ── log pointers and the dump ────────────────────────────────────────────────────────────────────
+
+def test_log_pointers_are_derived_and_pasteable():
+    rec = fr.apply_report(None, fr.normalize(
+        {"kind": "error", "context": {"tool": "bot_say", "error": "404"}}, now=T0), now=T0)
+    refs = fr.derived_log_refs(rec)
+    assert refs and refs[0]["container"] == fr.GATEWAY      # bot_* crosses the gateway
+    cmd = fr.log_command(refs[0])
+    assert cmd.startswith("docker logs --since 2026-") and "grep -F 'bot_say'" in cmd
+
+
+def test_a_reporter_supplied_pointer_is_believed():
+    rec = fr.normalize({"log_refs": [{"container": "worker-abc", "since": "1h", "grep": "boom"}]},
+                       now=T0)
+    assert fr.derived_log_refs(rec)[0]["container"] == "worker-abc"
+
+
+def test_the_dump_is_in_the_ledgers_finding_shape_and_names_how_to_close():
+    rows = []
+    for err in ("404 Not Found", "404 Not Found", "503 upstream"):
+        rec = fr.apply_report(None, fr.normalize(
+            {"kind": "error", "tried": "speak into the meeting", "happened": f"bot_say → {err}",
+             "context": {"tool": "bot_say", "error": err, "meeting_id": "104"}}, now=T0), now=T0)
+        rec["id"] = f"fr_{len(rows)}"
+        rows.append(rec)
+    md = fr.render_markdown(rows, since="2h", status="open", now=T0)
+    assert "## FR-1 · error · `bot_say`" in md
+    for label in ("**Symptom**", "**Tried**", "**Exact context**", "**Likely cause**",
+                  "**Logs**", "**Repro**"):
+        assert label in md
+    assert "docker logs --since" in md and "grep -F 'bot_say'" in md
+    assert 'friction_fixed(["fr_0"' in md or 'friction_fixed(["fr_2"' in md
+    assert "not a diagnosis" in md          # a likely cause is a candidate, and the dump says so
+
+
+def test_the_dump_sorts_recurring_first():
+    old = fr.apply_report(None, fr.normalize(
+        {"kind": "error", "context": {"tool": "a", "error": "x"}}, now=T0 + 100), now=T0 + 100)
+    old["recurrence"] = 9
+    regressed = fr.apply_report(None, fr.normalize(
+        {"kind": "error", "context": {"tool": "b", "error": "y"}}, now=T0), now=T0)
+    regressed = fr.apply_fix(regressed, "sha", now=T0)
+    regressed = fr.apply_report(regressed, fr.normalize({"happened": "y"}, now=T0 + 1), now=T0 + 1)
+    groups = fr.group([old, regressed])
+    assert groups[0]["status"] == "recurring"
+    md = fr.render_markdown([old, regressed], now=T0 + 200)
+    assert "**Fix that did not hold** — sha" in md
+
+
+def test_an_empty_dump_says_so_without_pretending_it_is_an_error():
+    md = fr.render_markdown([], since="1h", now=T0)
+    assert "Nothing filed in this window" in md
+
+
+# ── the store ────────────────────────────────────────────────────────────────────────────────────
+
+def test_the_store_folds_a_duplicate_into_one_row():
+    st = store_mod.FrictionStore()
+    a = st.file({"kind": "error", "tool": "bot_say", "context": {"error": "404"}}, now=T0)
+    b = st.file({"kind": "error", "tool": "bot_say", "context": {"error": "404"}}, now=T0 + 5)
+    assert a["id"] == b["id"] and b["recurrence"] == 2
+    assert len(st.since(0)) == 1
+
+
+def test_open_includes_recurring_because_that_is_the_most_urgent_work():
+    st = store_mod.FrictionStore()
+    rec = st.file({"kind": "error", "tool": "t", "context": {"error": "e"}}, now=T0)
+    st.fix(rec["id"], "sha", now=T0)
+    assert st.since(0, status="open") == []
+    st.file({"kind": "error", "tool": "t", "context": {"error": "e"}}, now=T0 + 1)
+    rows = st.since(0, status="open")
+    assert len(rows) == 1 and rows[0]["status"] == "recurring"
+    assert st.since(0, status="fixed") == []
+
+
+def test_since_is_forgiving_and_never_silently_narrows():
+    assert store_mod.parse_since("", now=T0) == 0.0
+    assert store_mod.parse_since("2h", now=T0) == T0 - 7200
+    assert store_mod.parse_since("900", now=T0) == T0 - 900
+    assert store_mod.parse_since("not a time", now=T0) == 0.0        # everything, never a guess
+    assert store_mod.parse_since("2026-09-02T00:00:00Z", now=T0) > 0
+
+
+# ── the routes ───────────────────────────────────────────────────────────────────────────────────
+
+class _FakeRuntime:
+    def spawn(self, workload_id, profile, env):
+        return workload_id
+
+    def await_done(self, workload_id, timeout_sec=0.0):
+        return "completed"
+
+
+class _FakeIdentity:
+    def mint(self, subject, launcher, workspaces, tools):
+        return "tok"
+
+
+def _app_client(tmp_path):
+    """agent-api over fakes, no redis — the store's in-memory fallback is the point."""
+    root = tmp_path / "workspaces"
+    (root / "_global" / "asks").mkdir(parents=True)
+    settings = load_settings(workspaces_dir=str(root),
+                             global_system_workspace_path=str(root / "_global"),
+                             redis_url="")
+    app = create_app(Dispatcher(settings, _FakeRuntime(), _FakeIdentity()),
+                     reader=WorkspaceReader(str(root)))
+    return TestClient(app)
+
+
+def test_a_person_can_file_without_being_identified(tmp_path):
+    """The most valuable report available is the one from a session too broken to have an identity."""
+    c = _app_client(tmp_path)
+    r = c.post("/api/friction", json={"reporter": "person", "kind": "ux",
+                                      "happened": "the panel looked stale"})
+    assert r.status_code == 201
+    assert r.json()["status"] == "open" and r.json()["known"] is False
+
+
+def test_filing_the_same_edge_twice_says_it_is_known(tmp_path):
+    c = _app_client(tmp_path)
+    body = {"kind": "error", "tool": "bot_say", "context": {"error": "404"}}
+    first = c.post("/api/friction", json=body).json()
+    second = c.post("/api/friction", json=body).json()
+    assert first["id"] == second["id"]
+    assert second["known"] is True and second["recurrence"] == 2
+
+
+def test_the_dump_route_returns_markdown_and_the_fix_route_closes(tmp_path):
+    c = _app_client(tmp_path)
+    hdr = {"X-User-Id": "126"}
+    rid = c.post("/api/friction", json={"kind": "no-page", "path": "kg/x.md",
+                                        "happened": "no page here yet"}).json()["id"]
+    md = c.get("/api/friction/dump", headers=hdr)
+    assert md.status_code == 200 and md.headers["content-type"].startswith("text/markdown")
+    assert "FR-1 · no-page" in md.text and rid in md.text
+
+    assert c.post(f"/api/friction/{rid}/fix", json={}, headers=hdr).status_code == 400
+    fixed = c.post(f"/api/friction/{rid}/fix", json={"fix_ref": "PR #1409"}, headers=hdr)
+    assert fixed.status_code == 200 and fixed.json()["status"] == "fixed"
+    assert c.post("/api/friction/nope/fix", json={"fix_ref": "x"}, headers=hdr).status_code == 404
+
+    assert "Nothing filed" in c.get("/api/friction/dump", headers=hdr).text
+    assert c.get("/api/friction/dump?status=fixed", headers=hdr).text.count("FR-1") == 1
+
+
+def test_the_dump_json_format_carries_the_same_grouping(tmp_path):
+    c = _app_client(tmp_path)
+    c.post("/api/friction", json={"kind": "error", "tool": "t", "context": {"error": "e"}})
+    body = c.get("/api/friction/dump?format=json", headers={"X-User-Id": "126"}).json()
+    assert body["count"] == 1 and body["findings"][0]["kind"] == "error"
+
+
+def test_reading_the_dump_needs_an_identity_even_though_filing_does_not(tmp_path, monkeypatch):
+    # the L2 harness sets a fallback subject (conftest `_default_subject`); clear it, or every
+    # request is identified and this proves nothing.
+    monkeypatch.setenv("VEXA_AGENT_DEFAULT_SUBJECT", "")
+    c = _app_client(tmp_path)
+    assert c.post("/api/friction", json={"happened": "x"}).status_code == 201
+    assert c.get("/api/friction/dump").status_code == 401
+
+
+# ── the agent side ───────────────────────────────────────────────────────────────────────────────
+
+def test_the_rule_ships_and_names_the_silent_workaround():
+    text = wfr.friction_preamble()
+    assert "report_friction" in text
+    assert "silent workaround is the defect" in text.lower()
+    for word in ("tried", "happened", "session"):
+        assert word in text.lower()
+
+
+def test_a_turn_that_ends_on_a_tool_error_files_by_itself():
+    recs = wfr.scan_turn([
+        {"type": "tool-call", "tool": "Read", "args": {"path": "a.md"}, "callId": "1"},
+        {"type": "tool-result", "callId": "1", "ok": True, "summary": "ok"},
+        {"type": "tool-call", "tool": "Write", "args": {"path": "b.md"}, "callId": "2"},
+        {"type": "tool-result", "callId": "2", "ok": False, "summary": "no such file or directory"},
+    ], session="meet-104", subject="126")
+    assert len(recs) == 1
+    assert recs[0]["kind"] == "no-page" and recs[0]["context"]["tool"] == "Write"
+    assert recs[0]["session"] == "meet-104" and recs[0]["auto"] is True
+
+
+def test_a_4xx_from_a_vexa_tool_files_even_when_the_turn_recovered():
+    """A workaround is invisible from outside — which is exactly why this does not wait for one."""
+    recs = wfr.scan_turn([
+        {"type": "tool-call", "tool": "mcp__vexa__bot_say", "args": {}, "callId": "1"},
+        {"type": "tool-result", "callId": "1", "ok": False, "summary": "404 {'detail':'Not Found'}"},
+        {"type": "tool-call", "tool": "Read", "args": {}, "callId": "2"},
+        {"type": "tool-result", "callId": "2", "ok": True, "summary": "ok"},
+    ])
+    assert len(recs) == 1 and recs[0]["context"]["tool"] == "mcp__vexa__bot_say"
+
+
+def test_a_clean_turn_files_nothing():
+    assert wfr.scan_turn([
+        {"type": "tool-call", "tool": "Read", "args": {}, "callId": "1"},
+        {"type": "tool-result", "callId": "1", "ok": True, "summary": "ok"},
+    ]) == []
+    assert wfr.scan_turn([]) == []
+
+
+def test_a_missing_toolbelt_files_at_spawn_because_the_model_could_not():
+    """Ledger F70: the one failure that silences the reporting channel is the one it cannot report."""
+    rec = wfr.spawn_gap(url="https://rig/mcp", token="", config_written=False, subject="126")
+    assert rec and rec["kind"] == "missing-tool" and rec["severity"] == "blocker"
+    assert "VEXA_MCP_DELEGATION_TOKEN" in rec["happened"]
+    # a turn that was never meant to have a toolbelt is not a defect
+    assert wfr.spawn_gap(url="", token="", config_written=False) is None
+    # nor is one that got it
+    assert wfr.spawn_gap(url="u", token="t", config_written=True) is None
+
+
+def test_reporting_never_raises_into_a_turn(monkeypatch, tmp_path):
+    monkeypatch.setattr(wfr, "FALLBACK_LOG", tmp_path / "f.jsonl")
+    monkeypatch.setenv("VEXA_AGENT_API_SELF_URL", "http://127.0.0.1:1")   # nothing listens
+    assert wfr.report({"happened": "boom"}, subject="126", timeout=0.05) is None
+    assert "boom" in (tmp_path / "f.jsonl").read_text()      # the file is written FIRST, always

--- a/core/agent/tests/test_friction_replay.py
+++ b/core/agent/tests/test_friction_replay.py
@@ -1,0 +1,33 @@
+"""The rough-edges replay, as a test — so decision 33's proof obligation runs on every push.
+
+`eval/friction_loop_replay.py` is the runnable artefact (it prints the brief a human reads). This
+runs the same function and asserts the same claims. It needs no fixtures and no stack, so unlike the
+DNA replay beside it there is nothing here to skip: if this ever cannot run, the loop is broken.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import pathlib
+
+REPLAY = pathlib.Path(__file__).resolve().parents[1] / "eval" / "friction_loop_replay.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("friction_loop_replay", REPLAY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_three_synthetic_edges_produce_a_dump_a_fixing_agent_can_work_off(monkeypatch):
+    monkeypatch.setenv("VEXA_AGENT_DEFAULT_SUBJECT", "u_jane")
+    res = _load().run(out=io.StringIO())
+    assert res["filed"] == 4 and res["rows"] == 3 and res["findings"] == 3
+    assert res["deduped"] == 2                       # one edge reported twice is ONE row
+    assert res["recurring"] == ["no-page"]           # and a fix that did not hold says so
+    assert res["fix_that_did_not_hold"] == "PR #1410 · a3742c4"
+    # The dump is the deliverable. These are the parts that make it usable WITHOUT this session.
+    for part in ("**Symptom**", "**Exact context**", "**Likely cause**", "**Logs**", "**Repro**",
+                 "docker logs --since", "friction_fixed(", "not a diagnosis"):
+        assert part in res["dump"], part

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -50,6 +50,7 @@ from shared.seeding import resolve_seed_dir, seed_workspace, validate_seed
 # and one surface with two writers is the failure `graph/sg/Operating-Loops.md` names in a line.
 # Whoever composes that block appends what this returns.
 from shared.timeline import timeline_preamble  # noqa: F401 — re-exported for the turn prompt
+from worker.friction import friction_preamble, report as report_friction, scan_turn, spawn_gap
 
 log = logging.getLogger("agent_api.worker")
 
@@ -970,6 +971,22 @@ def _delegation_dir(work: Path) -> "Path | None":
     return None
 
 
+def _file_spawn_gap(url: str, token: str) -> None:
+    """A toolbelt the dispatch INTENDED and did not get, filed at spawn (ledger F70).
+
+    It is filed here, and not left to the model, for the reason F70 exists: a session with no tools
+    cannot call `report_friction`, so the one failure that silences the reporting channel is the one
+    it can never report. `spawn_gap` returns None for a turn that was never meant to have a toolbelt,
+    so the ordinary un-delegated dispatch files nothing."""
+    try:
+        rec = spawn_gap(url=url, token=token, config_written=False,
+                        subject=os.environ.get("VEXA_OWNER", ""))
+        if rec:
+            report_friction(rec, subject=os.environ.get("VEXA_OWNER", ""))
+    except Exception as e:  # noqa: BLE001 — never worth a turn
+        log.warning("friction: could not file the spawn gap (%s)", e)
+
+
 def mcp_delegation_config(work: Path) -> "tuple[str | None, list[str]]":
     """Materialize the worker's AUTHENTICATED vexa MCP attachment → (mcp-config path, extra allow-set).
 
@@ -997,6 +1014,7 @@ def mcp_delegation_config(work: Path) -> "tuple[str | None, list[str]]":
     url = (os.environ.get("VEXA_MCP_URL") or "").strip()
     token = (os.environ.get("VEXA_MCP_DELEGATION_TOKEN") or "").strip()
     if not url or not token:
+        _file_spawn_gap(url, token)
         return None, []
     cfg = {"mcpServers": {VEXA_MCP_SERVER: {
         "type": "http", "url": url, "headers": {"Authorization": f"Bearer {token}"},
@@ -1005,6 +1023,7 @@ def mcp_delegation_config(work: Path) -> "tuple[str | None, list[str]]":
     if d is None:
         log.warning("no writable directory for the vexa MCP delegation config — running this turn "
                     "WITHOUT the toolbelt rather than not at all")
+        _file_spawn_gap(url, token)
         return None, []
     path = d / "mcp.json"
     path.write_text(json.dumps(cfg))
@@ -1049,7 +1068,8 @@ def run_turn_over_workspace(
     mounts = active_mounts()
     author = _principal_author()
     extras = _extra_mount_paths(work)
-    turn_prompt = (voice_preamble() + kg_links_preamble(mounts) + mounts_preamble(mounts)
+    turn_prompt = (voice_preamble() + friction_preamble() + kg_links_preamble(mounts)
+                   + mounts_preamble(mounts)
                    + entity_index_preamble(mounts) + timeline_preamble()
                    + global_context_preamble(mounts)
                    + prompt)
@@ -1071,10 +1091,23 @@ def run_turn_over_workspace(
                                commit=commit, author=author, extra_mounts=extras, mcp_config=mcp_config)
         first = next(gen, None)
     captured: str | None = None
+    # THE TURN'S OWN ROUGH EDGES (PRD decision 33 §1). Only the two event types the scan reads are
+    # kept — a turn's full stream is unbounded and this is a footnote, not a recorder.
+    tool_events: list[dict] = []
     for ev in (gen if first is None else itertools.chain([first], gen)):
+        if ev.get("type") in ("tool-call", "tool-result"):
+            tool_events.append(ev)
         if ev.get("type") == "done" and ev.get("sessionId"):
             captured = ev["sessionId"]
         yield ev
+    # AFTER the stream, never inside it: a report is a footnote to a turn, and a turn must not
+    # stall on one. `report` never raises (see worker/friction.py) — this try is the belt.
+    try:
+        for rec in scan_turn(tool_events, session=session,
+                             subject=os.environ.get("VEXA_OWNER", ""), workspace=work.name):
+            report_friction(rec, subject=os.environ.get("VEXA_OWNER", ""))
+    except Exception as e:  # noqa: BLE001 — a friction report is never worth a turn
+        log.warning("friction: the auto-file scan failed (%s)", e)
     if captured and session_continuity:
         sess_file.parent.mkdir(parents=True, exist_ok=True)
         sess_file.write_text(captured)

--- a/core/agent/worker/friction.py
+++ b/core/agent/worker/friction.py
@@ -1,0 +1,230 @@
+"""friction.py (worker) — THE AGENT SIDE OF THE ROUGH-EDGES LOOP (PRD decision 33 §1).
+
+Three things, and the third is the one that matters:
+
+  1. **The rule, in every turn's context.** `friction_preamble()` — "when something did not work as
+     expected, call `report_friction` with what you tried, what happened and the ids; a silent
+     workaround is the defect."
+  2. **A client.** `report()` posts one record to agent-api, best-effort, never raising into a turn.
+  3. **THE HARNESS FILES WITHOUT THE MODEL'S HELP.** A turn that ends on a tool error, an MCP server
+     that was not attached at spawn, a 4xx/5xx from a vexa tool — each files a record whether or not
+     the model noticed, remembered the rule, or was still able to make a call at all.
+
+The third exists because the first two cannot be relied on, and we have the measurement: on
+2026-09-02 a whole session ran with no MCP tools attached (ledger F70) and reported nothing —
+because reporting requires a tool and there were none. **A reporting channel that only works while
+the product works is not a reporting channel.** Every rule that asks a model to remember something
+mid-failure is a rule with a failure rate; the auto-filed record has none, and its cost is a
+duplicate row that the dedup key folds into the model's own report anyway.
+
+WHAT IT DOES NOT DO: it does not judge. A tool error that the agent recovered from is still filed —
+the whole point of §1's "a silent workaround is the defect" is that the workaround is invisible from
+the outside, and a heuristic that files only unrecovered errors reproduces the blindness it exists
+to cure. Deduplication makes the noise cheap; silence is what is expensive.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+#: Where the report goes. `VEXA_AGENT_API_SELF_URL` is an already-declared agent-api config key
+#: (config.v1.json, class `defaulted`, no deploy target) — the worker reads the same name the
+#: control plane does rather than inventing a second one for the same address.
+TIMEOUT_S = 3.0
+
+#: THE FILE FIRST, ALWAYS — the rule the rig's original `report_friction` was written around, kept
+#: verbatim: "losing feedback because a store was briefly down is the worst failure available to the
+#: one channel that tells us what using this is like." A worker container is ephemeral, so this is
+#: a weaker fallback here than on the rig host; it is still the difference between a lost report and
+#: a report somebody can find in `docker logs`.
+FALLBACK_LOG = Path(os.environ.get("TMPDIR", "/tmp")) / "vexa-friction.jsonl"
+
+
+def _api() -> str:
+    return (os.environ.get("VEXA_AGENT_API_SELF_URL") or "http://agent-api:8100").rstrip("/")
+
+
+# ── the rule that rides every turn ───────────────────────────────────────────────────────────────
+
+def friction_preamble() -> str:
+    """READ SILENTLY. Ships on EVERY turn, for the same reason `voice_preamble` does.
+
+    It was NOT put in the composed-opening machinery note, and that is deliberate — the note reaches
+    only turns a link composed, and the founder has already watched one rule fail exactly that way
+    (see `voice_preamble`'s own warning: a `+` chat is not a composed opening and never saw it). An
+    edge is hit in whatever turn hits it.
+
+    The wording carries decision 33 §1's four demands and nothing else: what you tried, what
+    happened, the ids, and that routing around it silently is itself the defect."""
+    return (
+        "## When something does not work\n\n"
+        "Call `report_friction` — a missing tool, a refusal you could not act on, a page that did "
+        "not exist, a link that landed in the wrong workspace, a request you could not fulfil, an "
+        "error, or a step that took five calls when it should have taken one. Say what you TRIED, "
+        "what HAPPENED, and the ids you had (session · workspace · page · meeting · tool · the "
+        "error text). Half-formed is fine.\n\n"
+        "**A silent workaround is the defect.** Routing around a rough edge and saying nothing is "
+        "the only outcome that guarantees it is still there tomorrow — you are the only one who "
+        "knows what you expected. Report it and carry on: it does not interrupt the work, and it "
+        "never goes to the person you are talking to.\n\n"
+    )
+
+
+# ── the client ───────────────────────────────────────────────────────────────────────────────────
+
+def report(record: dict, *, subject: str = "", timeout: float = TIMEOUT_S) -> dict | None:
+    """File one record. Returns the stored record, or None — and NEVER raises.
+
+    A failure to report friction must not become a failure of the turn: the caller is a `finally`
+    block around somebody's actual work. The failure is logged and the record is appended to the
+    fallback file, so it is recoverable from the container's own log even when agent-api is the
+    thing that is broken — which, given what this channel reports on, is a case that will happen."""
+    body = dict(record)
+    body.setdefault("reporter", "agent")
+    if subject and not body.get("subject"):
+        body["subject"] = str(subject)
+    try:
+        FALLBACK_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with FALLBACK_LOG.open("a") as f:
+            f.write(json.dumps({"at": time.time(), **body}) + "\n")
+    except OSError as e:
+        log.warning("friction: could not write the fallback log (%s)", e)
+    req = urllib.request.Request(
+        f"{_api()}/api/friction", method="POST", data=json.dumps(body).encode(),
+        headers={"content-type": "application/json",
+                 **({"x-user-id": str(subject)} if subject else {})})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read().decode())
+    except (urllib.error.URLError, OSError, ValueError, TimeoutError) as e:
+        log.warning("friction: could not file %r (%s) — it is in %s",
+                    (body.get("happened") or "")[:80], e, FALLBACK_LOG)
+        return None
+
+
+# ── what the harness files by itself ─────────────────────────────────────────────────────────────
+
+#: An HTTP status in a tool's own error text. The rig returns its failures as prose carrying the
+#: code (`bot_say returned 404 {'detail': 'Not Found'}`), so this is how a 4xx/5xx from a vexa tool
+#: is recognised without the tool having to cooperate.
+_STATUS = re.compile(r"\b([45]\d{2})\b")
+
+#: Which tool names belong to the product's own surface. A `Read` that failed is the agent reading a
+#: file that is not there; a `mcp__vexa__*` that failed is OUR TOOL failing, which is a different
+#: report with a different reader.
+VEXA_TOOL = re.compile(r"^mcp__vexa__", re.I)
+
+
+def _kind_for(tool: str, summary: str) -> str:
+    if VEXA_TOOL.search(tool or "") and _STATUS.search(summary or ""):
+        return "error"
+    if re.search(r"no such file|does not exist|not found", summary or "", re.I):
+        return "no-page"
+    return "error"
+
+
+def scan_turn(events: list[dict], *, session: str = "", subject: str = "",
+              workspace: str = "") -> list[dict]:
+    """The records a finished turn's event stream earned, if any.
+
+    Two triggers, per decision 33 §2 and the ledger:
+
+      * **the turn ENDED on a tool error** — the last `tool-result` in the stream came back
+        `ok=False`. The turn stopping there is what makes it worth a record: whatever the model said
+        afterwards, its last action did not work.
+      * **any vexa tool answered 4xx/5xx** — anywhere in the turn, recovered or not. This is OUR
+        surface failing and it is filed on sight (F71's neighbour: an agent that works around our
+        own 404 and tells nobody is the case this loop exists for).
+
+    Pure: it reads events and returns records. Filing is the caller's, so a test can assert the
+    decision without a network."""
+    calls: dict[str, dict] = {}
+    results: list[tuple[str, dict]] = []
+    for ev in events or []:
+        t = ev.get("type")
+        if t == "tool-call":
+            calls[str(ev.get("callId") or "")] = ev
+        elif t == "tool-result":
+            results.append((str(ev.get("callId") or ""), ev))
+    if not results:
+        return []
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    def add(call: dict, res: dict, why: str) -> None:
+        tool = str(call.get("tool") or "")
+        cid = str(res.get("callId") or f"{tool}:{len(out)}")
+        if cid in seen:
+            return
+        seen.add(cid)
+        summary = str(res.get("summary") or "")
+        args = call.get("args") if isinstance(call.get("args"), dict) else {}
+        out.append({
+            "reporter": "agent", "subject": subject, "session": session,
+            "kind": _kind_for(tool, summary),
+            "tried": f"{why}: `{tool}`" + (f" with {json.dumps(args)[:200]}" if args else ""),
+            "happened": summary[:900] or "the call failed with no message",
+            "severity": "annoyance",
+            "context": {"tool": tool, "error": summary[:600],
+                        "workspace": str(args.get("workspace") or workspace or ""),
+                        "path": str(args.get("path") or ""),
+                        "meeting_id": str(args.get("meeting_id") or args.get("meeting") or "")},
+            "auto": True,
+        })
+
+    # a vexa tool that answered 4xx/5xx, anywhere in the turn
+    for cid, res in results:
+        if res.get("ok"):
+            continue
+        call = calls.get(cid, {})
+        if VEXA_TOOL.search(str(call.get("tool") or "")) and _STATUS.search(str(res.get("summary") or "")):
+            add(call, res, "a vexa tool answered an HTTP error")
+    # the turn ended on a tool error
+    last_cid, last = results[-1]
+    if not last.get("ok"):
+        add(calls.get(last_cid, {}), last, "the turn ended on a failed tool call")
+    return out
+
+
+def spawn_gap(*, url: str, token: str, config_written: bool, session: str = "",
+              subject: str = "") -> dict | None:
+    """The record for an MCP server that was NOT attached at spawn — ledger F70, or None.
+
+    F70 in one line: a session ran with no vexa tools at all, told the founder to `curl` a public
+    API, and filed nothing, *because filing requires a tool*. So this is checked by the code that
+    builds the attachment, before the model exists to notice, and it is deliberately narrow — it
+    reports only the case the spawn can PROVE:
+
+      * the dispatch intended a toolbelt (a url, or a token, was handed over) and
+      * the attachment was not written.
+
+    **What it cannot see, stated rather than implied:** the F70 session's config file *was* written
+    and the server *was* reachable — the harness dropped the server after init. That is invisible
+    from here and remains open; a `tools unavailable` guard belongs in the harness adapter, not in
+    this function pretending to have caught it."""
+    intended = bool((url or "").strip() or (token or "").strip())
+    if not intended or config_written:
+        return None
+    missing = [n for n, v in (("VEXA_MCP_URL", url), ("VEXA_MCP_DELEGATION_TOKEN", token))
+               if not (v or "").strip()]
+    detail = (f"half-configured spawn: {', '.join(missing)} absent" if missing
+              else "no writable directory for the delegation config")
+    return {
+        "reporter": "agent", "subject": subject, "session": session, "kind": "missing-tool",
+        "tried": "attach the vexa MCP toolbelt to this worker at spawn",
+        "happened": f"the toolbelt was NOT attached — {detail}. This turn runs with no vexa tools; "
+                    "anything it says about meetings, workspaces or bots is unsourced.",
+        "would_help": "a spawn that fails loudly when the toolbelt it was told to attach cannot be "
+                      "attached, rather than a turn that runs as a text-only agent",
+        "severity": "blocker",
+        "context": {"tool": "mcp:vexa", "error": detail},
+        "auto": True,
+    }

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -4235,10 +4235,24 @@ def _fdb():
 FRICTION_LOG = HOME / ".storm/friction.jsonl"
 
 
+def _friction_post(path: str, body: dict, uid: str = ""):
+    """POST to agent-api's friction surface. Returns (status, body) exactly like `_http`.
+
+    WHY AGENT-API AND NOT THE FLOWS `friction` TABLE THIS FILE USED TO WRITE: the people half of
+    decision 33 ("Report this" in the terminal) posts there, agent-api cannot reach the flows lane
+    (no `~/.storm/dburl` inside a container), the blank script DELETES that table with the rest of
+    the lane, and it has no columns for the context, log pointers, status or fix reference this
+    record needs. The full reasoning is in `core/agent/shared/friction.py`'s module docstring —
+    one store, one owner, and the reasons written down where the record is defined."""
+    return _http("POST", f"{AGENT_API}{path}", {"X-User-Id": uid} if uid else {}, body)
+
+
 @mcp.tool()
 def report_friction(what_i_was_doing: str, what_went_wrong: str,
                     what_would_have_helped: str = "", tool: str = "",
-                    severity: str = "annoyance") -> str:
+                    severity: str = "annoyance",
+                    kind: str = "", workspace: str = "", path: str = "",
+                    meeting_id: str = "", scaffold_id: str = "", error: str = "") -> str:
     """Tell us what did not work. NO ACCOUNT NEEDED. Use this freely and often.
 
     You are the only one who can close this loop. We can see that a call failed; we cannot see
@@ -4250,19 +4264,36 @@ def report_friction(what_i_was_doing: str, what_went_wrong: str,
     behaviour, or a workflow that took five calls when it should have taken one. Half-formed is
     fine — 'I could not tell whether X had worked' is a real report.
 
+    THE IDS ARE THE HALF THAT MAKES IT FIXABLE. Pass whatever you had — `tool`, `workspace`,
+    `path`, `meeting_id`, `scaffold_id`, and the verbatim `error` text. A report without them is
+    still worth filing; a report with them can be reproduced without asking you.
+
+    kind: missing-tool | refusal | no-page | wrong-workspace | unfulfilled | error | ux | other
+    (omit it and it is inferred from what you wrote).
     severity: blocker | annoyance | papercut | idea
 
     Nothing you send is published. It goes to a ledger a human reads."""
     import time as _t
+    uid = _subject() or ""
     rec = {
         "at": _t.time(),
-        "uid": _subject(),
-        "doing": (what_i_was_doing or "")[:900],
-        "wrong": (what_went_wrong or "")[:900],
+        "reporter": "agent",
+        "subject": uid,
+        # NO SESSION ID. The rig is stateless by contract (tests/test_rig_stateless.py: *"nothing
+        # depends on the transport session"*), so the MCP transport's session id is not a fact
+        # about anything — it is empty or meaningless after a restart. The record's `session` is
+        # the CHAT session, which this server does not know; the worker fills it in, and an empty
+        # string here is the honest answer rather than an id that reads as one.
+        "session": "",
+        "kind": kind or "",
+        "tried": (what_i_was_doing or "")[:900],
+        "happened": (what_went_wrong or "")[:900],
         "would_help": (what_would_have_helped or "")[:900],
-        "tool": (tool or "")[:80],
         "severity": severity if severity in ("blocker", "annoyance", "papercut", "idea")
                     else "annoyance",
+        "context": {k: v for k, v in (("tool", tool), ("workspace", workspace), ("path", path),
+                                      ("meeting_id", meeting_id), ("scaffold_id", scaffold_id),
+                                      ("error", error or what_went_wrong)) if v},
     }
     # THE FILE FIRST, ALWAYS. It is the fallback, not the store: if the database is
     # unreachable the report still lands somewhere, and losing feedback because a store was
@@ -4275,24 +4306,17 @@ def report_friction(what_i_was_doing: str, what_went_wrong: str,
     except Exception:  # noqa: BLE001
         ok = False
 
-    # then the durable store, deduped: the same edge reported twice is one row carrying the
-    # newest wording, not two rows nobody can count.
-    try:
-        import hashlib
-        fp = hashlib.sha256(
-            f"{rec.get('tool','')}|{(rec.get('wrong') or '')[:300]}".encode()).hexdigest()[:32]
-        _fdb().execute(
-            "INSERT INTO friction (at,uid,doing,wrong,would_help,tool,severity,fingerprint) "
-            "VALUES (%s,%s,%s,%s,%s,%s,%s,%s) "
-            "ON CONFLICT (fingerprint) DO UPDATE SET at=EXCLUDED.at, doing=EXCLUDED.doing, "
-            "would_help=EXCLUDED.would_help, severity=EXCLUDED.severity",
-            (rec["at"], rec["uid"], rec["doing"], rec["wrong"], rec["would_help"],
-             rec["tool"], rec["severity"], fp))
-        ok = True
-    except Exception:  # noqa: BLE001
-        pass
+    # then the durable store, deduped SERVER-SIDE: the same edge reported twice is one row
+    # carrying the newest wording and a count, not two rows nobody can total.
+    st, body = _friction_post("/api/friction", rec, uid)
+    known, out = False, {}
+    if 200 <= st < 300 and isinstance(body, dict):
+        ok, known, out = True, bool(body.get("known")), body
     return json.dumps({
         "recorded": ok,
+        "id": out.get("id", ""),
+        "already_known": known,
+        "occurrences": out.get("recurrence", 1),
         "thank_you": "This is the only signal we get about what it is actually like to use "
                      "this. Keep going — do not let it interrupt what you were doing.",
     })
@@ -4305,22 +4329,78 @@ def friction_so_far(token: str = "") -> str:
 
     Useful before reporting: if the thing you hit is already here, add what is different about
     your case rather than filing it again."""
-    me()   # account-scoped: this touches shared state
+    uid = me()   # account-scoped: this touches shared state
+    st, body = _http("GET", f"{AGENT_API}/api/friction/dump?status=&format=json",
+                     {"X-User-Id": uid})
+    if 200 <= st < 300 and isinstance(body, dict):
+        return _capped({"count": body.get("count", 0), "reports": body.get("records", [])[:40]},
+                       12000)
+    # FALLBACKS, in the order that loses least. The legacy flows table still holds everything
+    # filed before the store moved (see `_friction_post`) — it is read, never written — and the
+    # append-only file is the floor, exactly as it is on the write side.
     rows = []
     try:
         for at, uid_, doing, wrong, help_, tool_, sev, filed in _fdb().execute(
                 "SELECT at,uid,doing,wrong,would_help,tool,severity,filed_as "
                 "FROM friction ORDER BY at DESC LIMIT 60").fetchall():
-            rows.append({"at": at, "uid": uid_, "doing": doing, "wrong": wrong,
-                         "would_help": help_, "tool": tool_, "severity": sev,
-                         "already_filed": filed})
+            rows.append({"at": at, "subject": uid_, "tried": doing, "happened": wrong,
+                         "would_help": help_, "context": {"tool": tool_}, "severity": sev,
+                         "already_filed": filed, "legacy": True})
     except Exception:  # noqa: BLE001
         try:
             rows = [json.loads(x) for x in FRICTION_LOG.read_text().splitlines() if x.strip()]
             rows.reverse()
         except Exception:  # noqa: BLE001
             rows = []
-    return _capped({"count": len(rows), "reports": rows[:40]}, 12000)
+    return _capped({"count": len(rows), "reports": rows[:40],
+                    "note": f"agent-api answered {st} — these are the legacy/fallback rows"}, 12000)
+
+
+@mcp.tool()
+@_anon_guard
+def friction_dump(since: str = "", status: str = "open", token: str = "") -> str:
+    """THE FIXER'S BRIEF: every open rough edge, grouped by likely cause, ready to work.
+
+    This is decision 33 §3 — the thing the whole loop exists to produce. It returns MARKDOWN, in
+    the alpha ledger's finding shape (symptom · exact context · likely cause · log pointers ·
+    repro), deduplicated with occurrence counts, `recurring` first. Hand it to a fixing agent
+    verbatim; it needs no other briefing.
+
+    since: "" (everything) · "2h" · "3d" · an ISO instant.
+    status: "open" (the default — includes `recurring`, which is the most urgent work there is) ·
+            "fixed" · "recurring" · "" for all.
+
+    When you fix something from it, close it: `friction_fixed([ids], "<commit or PR>")`."""
+    uid = me()
+    q = f"?since={urllib.parse.quote(since)}&status={urllib.parse.quote(status)}&format=md"
+    st, body = _http("GET", f"{AGENT_API}/api/friction/dump{q}", {"X-User-Id": uid})
+    if not (200 <= st < 300):
+        return json.dumps({"error": f"agent-api answered {st}", "detail": str(body)[:300],
+                           "do": "the dump is unreadable — say so plainly; do not invent one"})
+    return str(body)[:60000]
+
+
+@mcp.tool()
+@_anon_guard
+def friction_fixed(ids: list[str], fix_ref: str, token: str = "") -> str:
+    """Close the rough edges a change addressed (decision 33 §4).
+
+    `fix_ref` is whatever lets the next reader find the change — a commit sha, a PR url, a branch,
+    or one sentence. Closing is CHEAP and meant to be: a record filed again after a fix flips itself
+    to `recurring`, so a fix that did not hold announces itself instead of hiding. Close what you
+    addressed; do not close what you merely looked at."""
+    uid = me()
+    if not str(fix_ref or "").strip():
+        return json.dumps({"error": "fix_ref is required",
+                           "why": "a record marked fixed with nothing to point at is "
+                                  "indistinguishable from one somebody wanted off the list"})
+    out = []
+    for rid in list(ids or [])[:100]:
+        st, body = _friction_post(f"/api/friction/{urllib.parse.quote(str(rid))}/fix",
+                                  {"fix_ref": fix_ref}, uid)
+        out.append({"id": rid, "ok": 200 <= st < 300,
+                    "status": (body or {}).get("status") if isinstance(body, dict) else str(body)[:120]})
+    return json.dumps({"closed": sum(1 for r in out if r["ok"]), "results": out})
 
 
 # ---------------------------------------------------------------- visible affordances


### PR DESCRIPTION
**PRD decision 33** — *"we also need to leverage the mcp tool that should collect rough edges —
things that did not work as expected — and dump it in a way that we can just dump that to an agent
that would just fix that (like you are here)."* Owning issue: [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449).

## The record

`shared/friction.py` — one shape, four writers:

```
{id, at, reporter: agent|person, subject, session,
 kind: missing-tool|refusal|no-page|wrong-workspace|unfulfilled|error|ux|other,
 tried, happened,
 context: {workspace, path, meeting_id, scaffold_id, tool, error, surface},
 log_refs: [{container, since, grep}], status: open|fixed|recurring, fix_ref}
```

Dedup key = `(kind, tool|path, error prefix)` with a recurrence counter. Ids inside the error text
are masked before hashing — **by what they are called, not by how long they are**: masking every
3-digit run was the obvious rule and it collapsed `404` and `503` from one tool into one "edge",
which tells a fixing agent two different failures are the same one.

The dump groups one step coarser than dedup (same kind + tool/path): two different failures of one
tool are two rows and **one finding**, because a fixing agent opens that tool's code once.

## Where the store lives, and why it moved

`report_friction` already wrote a `friction` table in the **flows** Postgres. That table is the
wrong owner, and the fourth reason decides it:

1. **The people half cannot reach it.** §2's "Report this" posts to agent-api; the rig reaches the
   flows lane by reading `~/.storm/dburl` off the host, which a container has not got.
2. **`deploy/dogfood/bin/blank-instance.sh` DELETES it** with the rest of the lane. Friction is a
   record of what is broken in the product — wiping it with the environment is how the same defect
   gets found four times.
3. **It exists in one lane and not the other** ("absent in this lane — skipped") because nothing
   ever created it in a migration.
4. **It cannot hold this record** — no context, no log pointers, no status, no fix reference,
   no counter; adding them means writing the migration that lane never had, for a table the service
   that needs to read it cannot connect to.

So: **agent-api redis**, beside the scaffold store and the session index, same client, same
in-memory fallback (the unit tests need no redis). Legacy flows rows are **read, never written,
never deleted** — `friction_so_far` still falls back to them so nothing already filed disappears.

## What changed

| Symptom | Change | Proof |
|---|---|---|
| Two reports of one edge were two rows nobody could total; a fix that stopped holding looked like a new defect | `core/agent/shared/friction.py` (new) — shape · dedup · status machine · the dump renderer | `test_friction.py` shape/dedup/status/dump (17 tests) |
| No store the people half could reach; the one that existed gets wiped by the blank script | `core/agent/control_plane/friction.py` (new) `FrictionStore`; wired in `api.py:1145-1154` | `test_the_store_folds_a_duplicate_into_one_row`, `test_open_includes_recurring_because_that_is_the_most_urgent_work` |
| No way for a person or a worker to file at all | `api.py:2273` — `POST /api/friction`, `GET /api/friction/dump`, `POST /api/friction/{id}/fix` | 6 route tests |
| The rule reached only turns a link composed | `worker/engine.py:1071` — `friction_preamble()` beside `voice_preamble()`, so it ships on EVERY turn | `test_the_rule_ships_and_names_the_silent_workaround` |
| **F70: a session with no toolbelt cannot call `report_friction`, so the one failure that silences the channel is the one it can never report** | `worker/engine.py:974 / :1017 / :1026` `_file_spawn_gap` + `worker/friction.py:spawn_gap` — filed by the spawn, before the model exists to notice | `test_a_missing_toolbelt_files_at_spawn_because_the_model_could_not` |
| A silent workaround is invisible from outside — the model has to remember, mid-failure, to report | `worker/engine.py:1101-1109` — the turn's own events are scanned; a turn ending on a tool error and any 4xx/5xx from a vexa tool file with no help from the model | `test_a_turn_that_ends_on_a_tool_error_files_by_itself`, `test_a_4xx_from_a_vexa_tool_files_even_when_the_turn_recovered` |
| `report_friction` took five columns and no ids | `deploy/dogfood/rig/vexa_control_mcp.py:4251` — the decision-33 shape, **every old argument still accepted**; `friction_so_far` reads the one store | the replay files edge 3 through the legacy signature |
| Nothing turned the pile into work | rig `friction_dump(since, status)` + `friction_fixed(ids, fix_ref)` (`vexa_control_mcp.py:4361 / :4385`) | `test_the_dump_route_returns_markdown_and_the_fix_route_closes` |
| People could not file at all | `clients/terminal/src/surfaces/frictionApi.ts` + `ReportThis.tsx` (new); one hook each in `surfaces/chat.tsx:436 + :1343` and `minutes/PagesPanel.tsx:232` | `surfaces/__tests__/friction.test.ts` (7 tests) |

**One line and no dialog, deliberately.** Everything else the record needs — chat, page, workspace,
meeting — the client already knows and attaches silently; the server infers `kind` from the words.
Asking a person to classify their own complaint is how a report button ends up unused.

Two notes for the reader:

- **`CURRENT_SID` is not read.** The first draft put the MCP transport session id into the record;
  `tests/test_rig_stateless.py` refuses it, and it is right — a stateless rig's transport session is
  not a fact about anything. The record's `session` is the chat session, which the worker fills in.
- **`worker/friction.py` reads `VEXA_AGENT_API_SELF_URL`**, an already-declared agent-api config key
  with no deploy target, rather than inventing a second name for the same address. No surface change,
  `gate:config-contract` green.

## Proof

`core/agent/eval/friction_loop_replay.py` — offline, no stack, no redis, no model, under a second,
asserted in `tests/test_friction_replay.py` so it runs on every push. It files three synthetic edges
**through three real doors**: a missing toolbelt filed by the harness at spawn, a no-page filed by a
person with the exact body `frictionApi.ts` builds, a wrong-workspace filed by an agent through the
rig's legacy argument names (twice, so dedup has to fold it). Then it fixes one and files it again.

```
friction replay: 4 reports → 3 rows → 3 findings · recurring=['no-page']
```

Gates: the pre-push static set is green (pushed **without** `--no-verify`); `gate:node`
(18 packages, build + test), `gate:eval`, the full terminal suite (1045 tests) and the agent suite
(1038 passed) are green. One pre-existing failure is unrelated and reproduces on the base branch
`minutes-mcp-viewer` untouched: `test_meeting_room.py::test_the_runtime_binds_a_room_mount_read_only`
→ `ModuleNotFoundError: requests_unixsocket` in this host's ambient interpreter.

## The dump this produces — pasted verbatim, which is the deliverable

Everything below is generated. Nothing was written by hand for this PR: this is what a fixing agent
is handed.

<details open>
<summary><code>python core/agent/eval/friction_loop_replay.py</code></summary>

```markdown
# Rough edges — the friction dump

Every row here was filed by the agent or the person who hit it (PRD decision 33). Each finding
below is **symptom → exact context → likely cause → log pointers → repro**, deduplicated, grouped by
likely cause (same kind, same tool or path). The counts are occurrences, not rows.

**What to do with this.** Work the findings top-down; `recurring` first — those are edges a previous
fix did not hold on, and the `fix that did not hold` line names the change to re-read. Two rules:

* **A likely cause is a candidate, not a diagnosis.** It is what the reports agree on, computed —
  nobody looked. Read the logs before you believe it.
* **Close what you addressed, and only that.** `friction_fixed(ids=[…], fix_ref="<commit|PR>")`, or
  `POST /api/friction/<id>/fix {"fix_ref": …}`. A record filed again after a fix flips to
  `recurring` by itself, so closing something you did not fix does not hide it — it just costs the
  next reader a pass.


_3 record(s) → 3 finding(s) · status `open` · generated 2026-09-02T16:31:13Z_

## FR-1 · wrong-workspace · `mcp__vexa__workspace_write` — 2 occurrences, open

- **Symptom** — workspace_write landed in the wrong workspace — it wrote to personal although the chat mounts the dna group
- **Tried** — write the meeting note to the group desk
- **Exact context** — workspace `personal` · tool `mcp__vexa__workspace_write` · reporter agent (uid 126) · first 2026-09-02T16:31:13Z, last 2026-09-02T16:31:13Z
- **Likely cause** — 2 reports agree on kind `wrong-workspace` on `mcp__vexa__workspace_write`, error text `workspace_write landed in the wrong workspace — it wrote to personal although the chat mounts the dna group`. Candidate, computed from the reports — not a diagnosis.
- **Logs** — `docker logs --since 2026-09-02T16:16:13 vexa-dogfood-agent-api-1 2>&1 | grep -F 'mcp__vexa__workspace_write'`
- **Repro** — call `mcp__vexa__workspace_write(workspace='personal')` as subject 126
- **Reporter's ask** — workspace_write defaulting to the chat's mounted group
- **Close with** — `friction_fixed(["fr_145ddb40b180540a"], "<commit|PR>")`

## FR-2 · no-page · `kg/entities/companies/aswf.md` — 1 occurrence, open

- **Symptom** — clicked the DNA link and the panel says there is no page here yet
- **Tried** — opened kg/entities/companies/ASWF.md
- **Exact context** — workspace `dna` · path `kg/entities/companies/ASWF.md` · meeting_id `104` · surface(chat=meet-104 · chat_kind=meeting · at=page) · reporter person (uid 126) · session `meet-104` · first 2026-09-02T16:31:13Z, last 2026-09-02T16:31:13Z
- **Likely cause** — one report so far: kind `no-page` on `kg/entities/companies/aswf.md`, error text `clicked the dna link and the panel says there is no page here yet`. Candidate, computed from the reports — not a diagnosis.
- **Logs** — `docker logs --since 2026-09-02T16:16:13 vexa-dogfood-agent-api-1 2>&1 | grep -F 'kg/entities/companies/ASWF.md'`
- **Repro** — open `dna › kg/entities/companies/ASWF.md` in the panel as subject 126
- **Close with** — `friction_fixed(["fr_de09520fa11594e5"], "<commit|PR>")`

## FR-3 · missing-tool · `mcp:vexa` — 1 occurrence, open

- **Symptom** — the toolbelt was NOT attached — half-configured spawn: VEXA_MCP_DELEGATION_TOKEN absent. This turn runs with no vexa tools; anything it says about meetings, workspaces or bots is unsourced.
- **Tried** — attach the vexa MCP toolbelt to this worker at spawn
- **Error** — `half-configured spawn: VEXA_MCP_DELEGATION_TOKEN absent`
- **Exact context** — tool `mcp:vexa` · reporter agent (uid 126) · session `meet-104` · first 2026-09-02T16:31:13Z, last 2026-09-02T16:31:13Z
- **Likely cause** — one report so far: kind `missing-tool` on `mcp:vexa`, error text `half-configured spawn: vexa_mcp_delegation_token absent`. Candidate, computed from the reports — not a diagnosis.
- **Logs** — `docker logs --since 2026-09-02T16:16:13 vexa-dogfood-agent-api-1 2>&1 | grep -F 'mcp:vexa'`
- **Repro** — start a worker turn with the `mcp:vexa` attachment in the state the context describes, as subject 126 — this is a SPAWN condition, not a call
- **Reporter's ask** — a spawn that fails loudly when the toolbelt it was told to attach cannot be attached, rather than a turn that runs as a text-only agent
- **Close with** — `friction_fixed(["fr_518afcc08d564321"], "<commit|PR>")`


```

</details>

COMMITMENTS IN THIS DRAFT — none.


---

## CI, honestly

**Nothing in this branch's red set is new.** The base tip `b1ac021f0` carries the identical failures
(`gh api repos/Vexa-ai/vexa/commits/b1ac021f0/check-runs`): `contribution-rights`, `DCO`,
`docs-current`, `evaluate`, `python`, `static`. The delta this PR is responsible for:

- **`node` — pass** (2m29s). This is the check the terminal half moves, and it is green.
- **`python` — the same two failures as the base**, and neither is friction:
  `test_meeting_room.py::test_the_runtime_binds_a_room_mount_read_only` →
  `ModuleNotFoundError: requests_unixsocket`, and
  `test_entity_writeback_trim.py::test_a_phase_over_budget_leaves_no_child_process` (a
  child-process timing assertion — it passes locally on this branch, 1038/1039). The 31 friction
  tests pass in the same run.
- **`static`** is the line's standing set: an undeclared `litellm/litellm` image, the redis SSPL /
  XAUTOCLAIM parity items, and the db-budget self-test rows. This PR adds no image, no pool and no
  contract.

The **pre-push static subset** — the bar this repo's hook enforces — is green on this branch and the
push went through **without** `--no-verify`.
