### PR TITLE
transcript terms: the live transcript is a clickable surface (PRD decision 35)

### DIFF
--- a/clients/terminal/src/canvas/LiveTranscriptEngine.tsx
+++ b/clients/terminal/src/canvas/LiveTranscriptEngine.tsx
@@ -119,9 +119,17 @@ function ContestedText({ text }: { text: string }): React.ReactElement | null {
   return <>{parts}</>;
 }
 
-/** Render a block's text. With `entities` → inline highlights; without → plain text (raw mode). */
-function BlockText({ text, entities, actions }: { text: string; entities?: EngineEntity[]; actions?: EngineActions }) {
+/** Render a block's text. With `renderText` → whatever that layer draws; with `entities` → inline
+ *  highlights; with neither → plain text (raw mode).
+ *
+ *  `renderText` is a SEAM, not a feature: the transcript-terms layer (PRD decision 35) draws chips
+ *  over the same words, and it is a separate component so that this engine stays one renderer and
+ *  the in-product inference pipeline can be removed from underneath it (decision 34) without the
+ *  chips going with it. It wins over `entities` because a caller that supplies both has said which
+ *  layer it wants on top, and two highlight layers over one string would fight for the same spans. */
+function BlockText({ text, entities, actions, renderText }: { text: string; entities?: EngineEntity[]; actions?: EngineActions; renderText?: (text: string) => React.ReactNode }) {
   if (/⟦[^⟧]+⟧\{[^}]+\}/.test(text)) return <ContestedText text={text} />;
+  if (renderText) return <>{renderText(text)}</>;
   if (!entities || !entities.length) return <>{text}</>;
   const spans = splitTextIntoSpans(text, entities);
   return (
@@ -141,12 +149,15 @@ export function LiveTranscriptEngine({
   entities,
   signals,
   actions,
+  renderText,
 }: {
   segments: EngineSegment[];
   emptyLabel?: string;
   entities?: EngineEntity[];
   signals?: EngineSignal[];
   actions?: EngineActions;
+  /** an outer layer's per-block renderer (decision 35's term chips). See `BlockText`. */
+  renderText?: (text: string) => React.ReactNode;
 }) {
   // Confirmed (completed !== false) = stable. Merge consecutive same-speaker confirmed segments into
   // flowing blocks; keyword tags accumulate per block. Pending (completed === false) = the live edge.
@@ -232,7 +243,7 @@ export function LiveTranscriptEngine({
           <div key={b.key}>
             {head(b.speaker, b.tsMs)}
             <div style={{ fontSize: 13.5, color: "var(--t1)", lineHeight: 1.6 }}>
-              <BlockText text={b.text} entities={entities} actions={actions} />
+              <BlockText text={b.text} entities={entities} actions={actions} renderText={renderText} />
               {isLast && liveJoinsLast && (
                 <span style={{ color: "var(--t3)", fontStyle: "italic" }}> {live} …</span>
               )}

--- a/clients/terminal/src/canvas/MeetingCanvasView.tsx
+++ b/clients/terminal/src/canvas/MeetingCanvasView.tsx
@@ -7,15 +7,24 @@ import { MeetingHealthBanner } from "./MeetingHealthBanner";
 import { LiveTranscriptEngine, type EngineActions, type EngineEntity, type EngineSignal } from "./LiveTranscriptEngine";
 import { useMeetingNotes } from "./notes";
 import { deriveProcessingView } from "./processingView";
+import { HighlightButton, useTermRenderer } from "./TranscriptTerms";
 import { MeetingScopeProvider, MeetingSourceProvider, useEntities, useMeeting, useSignals } from "./useMeeting";
 
 export const MEETING_CANVAS_CONTENT_INSET = 18;
 
 /** ONE render engine for both modes (P23: the terminal RENDERS, it does not re-derive). The toggle picks
  *  the SOURCE — raw segments vs the cleaned processed mirror — not a different renderer. */
-function RawTranscript() {
+function RawTranscript({ meetingId }: { meetingId?: string }) {
   const { transcript } = useMeeting();
-  return <LiveTranscriptEngine segments={transcript.segments} />;
+  // THE TERM CHIPS (PRD decision 35), as a layer over the same words. `useTermRenderer` returns
+  // undefined until a Highlight has published something, so an un-highlighted meeting renders
+  // exactly the plain text it did before — this costs nothing until somebody asks for it.
+  //
+  // It hangs on the RAW view deliberately: the raw transcript is the one that survives decision 34,
+  // and it is the same component for a live meeting and a finished one, so chips work on both
+  // without a second wiring.
+  const renderText = useTermRenderer(meetingId ?? "");
+  return <LiveTranscriptEngine segments={transcript.segments} renderText={renderText} />;
 }
 
 // Map a copilot signal's loose context/kind onto the badge taxonomy (decision / action-item /
@@ -134,11 +143,17 @@ function MeetingCanvasBody({ meetingId }: { meetingId?: string }) {
           {label}
         </button>
         <span style={{ fontSize: 11.5, color: "var(--t3)" }}>{processing ? "cleaned + copilot" : "raw transcript"}</span>
+        {/* the spacer keeps Highlight on the right of this row and collapses when the row is narrow */}
+        <div style={{ flex: "1 0 0", minWidth: 0 }} />
+        {/* HIGHLIGHT (decision 35.2). Deliberately NOT gated on `effectiveLive`: the founder asked
+            for "a button on transcripts", and a finished transcript is the one people actually read
+            back. It needs the ROW id, which is what `meetingId` is here and what the tool takes. */}
+        {meetingId && <HighlightButton meeting={meetingId} live={effectiveLive} />}
       </div>
       <MeetingHealthBanner />
       <main style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
         <div style={{ padding: MEETING_CANVAS_CONTENT_INSET }}>
-          {processing ? <ProcessedTranscript /> : <RawTranscript />}
+          {processing ? <ProcessedTranscript /> : <RawTranscript meetingId={meetingId} />}
         </div>
       </main>
     </div>

--- a/clients/terminal/src/canvas/TranscriptTerms.tsx
+++ b/clients/terminal/src/canvas/TranscriptTerms.tsx
@@ -1,0 +1,132 @@
+"use client";
+/** THE TRANSCRIPT AS A CLICKABLE SURFACE — chips over the words, and the button that asks for them.
+ *
+ *  PRD decision 35 (founder, 2026-09-02): the live transcript renders terms as chips, *"solid = has
+ *  a page (opens it in the view), dashed = no page yet"*, and a click drops an `explore` into the
+ *  open chat — *"just to find out what that is"*.
+ *
+ *  A SEPARATE LAYER, ON PURPOSE. It renders through the engine's `renderText` seam rather than
+ *  inside it, so the transcript stays one renderer with or without terms and the in-product
+ *  inference pipeline can be removed from underneath it (decision 34) without touching this.
+ *
+ *  IT NEVER ASKS FOR ANYTHING BY ITSELF. The terms come off the chat record (`transcriptTerms.ts`);
+ *  the only thing here that talks to anyone is the button, and it talks by posting an intent into
+ *  the chat the person already has open. There is no timer, no poll, and no fetch — the founder's
+ *  correction was explicit that this "does not require any 'processing on'", and a background loop
+ *  that highlights unasked is that feature under a different name.
+ */
+import React, { useMemo } from "react";
+import { OPEN_ENTITY_EVENT } from "./actions";
+import { splitTextIntoSpans } from "./inlineSpans";
+import { postIntent } from "../minutes/extend";
+import { termSpans, termsCursor, useTranscriptTerms, type TranscriptTerm } from "./transcriptTerms";
+
+/** SOLID vs DASHED is the whole visual vocabulary (decision 35.2), so it is one object and not a
+ *  scattering of inline conditionals: the two states have to stay legibly different, and the next
+ *  person to touch this should have to change one place to change that. */
+const chip = (known: boolean): React.CSSProperties => ({
+  display: "inline", padding: "0 3px", margin: "0 -1px", borderRadius: 4,
+  font: "inherit", lineHeight: "inherit", cursor: "pointer",
+  background: known ? "var(--accentbg)" : "transparent",
+  color: known ? "var(--accent)" : "var(--t1)",
+  border: known ? "1px solid transparent" : "1px dashed var(--line2)",
+  borderBottom: known ? "1px solid var(--accent)" : "1px dashed var(--t3)",
+});
+
+function open(path: string): void {
+  if (typeof window === "undefined") return;
+  // THE RESOLVER, not a tab (decisions 26.3 and 28.1): the shell's open-entity listener asks the
+  // server what this link points at NOW and navigates the view slot. A chip must never mint a tab —
+  // the founder counted seven of them after a few clicks.
+  window.dispatchEvent(new CustomEvent(OPEN_ENTITY_EVENT, { detail: { path } }));
+}
+
+/** One chip. A real `<button>`, so Enter and Space work, focus is visible, and a screen reader is
+ *  told what it does — the alternative (a styled `<span onClick>`) is a click target that only a
+ *  mouse can reach, inside a live region a keyboard user is otherwise reading fine. */
+const TermChip = React.memo(function TermChip(
+  p: { term: TranscriptTerm; text: string; meeting: string; segment?: string },
+) {
+  const known = !!p.term.known;
+  const what = p.term.kind ? `${p.term.kind} · ` : "";
+  return (
+    <button
+      type="button"
+      data-term={p.term.term}
+      data-known={known ? "1" : "0"}
+      aria-label={known ? `Open the page for ${p.term.term}` : `Find out what ${p.term.term} is`}
+      title={known ? `${what}open its page` : `${what}no page yet — ask this chat what it is`}
+      onClick={() => {
+        if (known && p.term.known?.path) { open(p.term.known.path); return; }
+        postIntent({ kind: "explore", term: p.term.term, meeting: p.meeting, segment: p.segment });
+      }}
+      style={chip(known)}
+    >{p.text}</button>
+  );
+});
+
+/** A segment's text with its terms chipped. Memoised on (text, terms, segment): a live transcript
+ *  re-renders on every arriving line, and without this every chip in the room would be rebuilt —
+ *  which is visible, because rebuilding a focused chip drops the keyboard focus off it. */
+export const TermText = React.memo(function TermText(
+  p: { text: string; terms: TranscriptTerm[]; meeting: string; segment?: string },
+) {
+  const spans = useMemo(() => splitTextIntoSpans(p.text, termSpans(p.terms)), [p.text, p.terms]);
+  const byLabel = useMemo(() => {
+    const m = new Map<string, TranscriptTerm>();
+    for (const t of p.terms) m.set(t.term.toLowerCase(), t);
+    return m;
+  }, [p.terms]);
+  return (
+    <>
+      {spans.map((s, i) => {
+        const t = s.entity ? byLabel.get(s.entity.label.toLowerCase()) : undefined;
+        return t
+          ? <TermChip key={`${t.term}-${i}`} term={t} text={s.text} meeting={p.meeting} segment={p.segment} />
+          : <React.Fragment key={i}>{s.text}</React.Fragment>;
+      })}
+    </>
+  );
+});
+
+/** The `renderText` the transcript engine calls per block. A hook, because the terms are a
+ *  subscription and the transcript is the only subscriber that matters. Returns `undefined` when
+ *  nothing is published, so the engine falls straight through to plain text and a meeting nobody
+ *  highlighted costs exactly nothing. */
+export function useTermRenderer(meeting: string): ((text: string) => React.ReactNode) | undefined {
+  const terms = useTranscriptTerms(meeting);
+  return useMemo(
+    () => (terms.length ? (text: string) => <TermText text={text} terms={terms} meeting={meeting} /> : undefined),
+    [terms, meeting],
+  );
+}
+
+/** THE HIGHLIGHT BUTTON (founder correction, 2026-09-02): *"we will have a button on transcripts
+ *  that will silently request our open chat to deliver the important and new terms to highlight."*
+ *
+ *  SILENT means the person sees no bubble and gets no reply — `postIntent` marks the turn machinery
+ *  and the `highlight` preset tells the agent to say nothing. What they see is chips appearing.
+ *
+ *  ADDITIVE means it sends the cursor the LAST publish returned, so a second press adds what has
+ *  been said since instead of re-listing the room. The client never invents that cursor; it echoes
+ *  the server's. */
+export function HighlightButton(p: { meeting: string; live?: boolean }) {
+  const terms = useTranscriptTerms(p.meeting);
+  const n = terms.length;
+  return (
+    <button
+      type="button"
+      data-act="highlight"
+      title={n ? `Highlight what has been said since — ${n} term${n === 1 ? "" : "s"} already on this transcript`
+               : "Highlight the people, companies and projects this meeting has named"}
+      onClick={() => postIntent({ kind: "highlight", meeting: p.meeting, since: termsCursor(p.meeting) })}
+      style={{
+        flex: "none", display: "inline-flex", alignItems: "center", gap: 6, cursor: "pointer",
+        fontSize: 11.5, lineHeight: 1.2, padding: "3px 9px", borderRadius: 999,
+        border: "1px solid var(--line2)", background: "var(--panel2)", color: "var(--t2)",
+      }}
+    >
+      Highlight{n ? ` · ${n}` : ""}
+    </button>
+  );
+}

--- a/clients/terminal/src/canvas/__tests__/transcriptTerms.test.tsx
+++ b/clients/terminal/src/canvas/__tests__/transcriptTerms.test.tsx
@@ -1,0 +1,260 @@
+/** PRD decision 35, client half — chips over the transcript, and the two clicks they carry.
+ *
+ *  Founder: *"click on a thing and it's dropped into the chat as a research drop… just to find out
+ *  what that is"*, and the correction that made the trigger a button: *"we will have a button on
+ *  transcripts that will silently request our open chat to deliver the important and new terms."*
+ *
+ *  The behaviours worth a test are the ones that fail SILENTLY: a merge that replaces instead of
+ *  adding (chips vanish on the second press), a cursor the client invents (the whole room is
+ *  re-scanned every time), a chip that mints a tab (seven tabs after a few clicks), and a Highlight
+ *  that reaches the person as a bubble.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { ASK_CHAT_EVENT, OPEN_ENTITY_EVENT } from "../actions";
+import { LiveTranscriptEngine } from "../LiveTranscriptEngine";
+import { HighlightButton, TermText, useTermRenderer } from "../TranscriptTerms";
+import {
+  mergeTerms, notePageWritten, promoteWritten, recordTerms, resetTerms, TERMS_EVENT,
+  termsCursor, termsFor, termSpans, type TranscriptTerm,
+} from "../transcriptTerms";
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => { root.render(ui); });
+  return { container, unmount: () => { act(() => root.unmount()); container.remove(); } };
+}
+
+const known = (term: string): TranscriptTerm =>
+  ({ term, kind: "company", known: { workspace_id: "w1", entity_id: term.toLowerCase().replace(/\s+/g, "-"), path: `kg/entities/company/${term.toLowerCase().replace(/\s+/g, "-")}.md` } });
+const unknown = (term: string): TranscriptTerm => ({ term, known: null });
+
+let asks: { display?: string; prompt?: string; hidden?: boolean; intent?: unknown }[] = [];
+let opened: { path?: string }[] = [];
+const onAsk = (e: Event) => { asks.push((e as CustomEvent).detail); };
+const onOpen = (e: Event) => { opened.push((e as CustomEvent).detail); };
+
+beforeEach(() => {
+  resetTerms(); asks = []; opened = [];
+  window.addEventListener(ASK_CHAT_EVENT, onAsk);
+  window.addEventListener(OPEN_ENTITY_EVENT, onOpen);
+});
+afterEach(() => {
+  window.removeEventListener(ASK_CHAT_EVENT, onAsk);
+  window.removeEventListener(OPEN_ENTITY_EVENT, onOpen);
+});
+
+// ── the record ───────────────────────────────────────────────────────────────────────────────────
+
+describe("the terms are the chat's record, and a second Highlight ADDS to it", () => {
+  it("merges rather than replaces — nothing already chipped disappears on the next press", () => {
+    const out = mergeTerms([unknown("Kaar Tech")], [unknown("Blue Light Card")]);
+    expect(out.map((t) => t.term)).toEqual(["Kaar Tech", "Blue Light Card"]);
+  });
+
+  it("a later answer about `known` wins, including a later null", () => {
+    expect(mergeTerms([unknown("Kaar Tech")], [known("Kaar Tech")])[0].known).toBeTruthy();
+    // the page could have been deleted; a chip that stays solid over a page that is gone is the
+    // "opens nothing" failure the link resolver already refuses
+    expect(mergeTerms([known("Kaar Tech")], [unknown("Kaar Tech")])[0].known).toBeNull();
+    expect(mergeTerms([unknown("Kaar Tech")], [known("kaar tech")])).toHaveLength(1);
+  });
+
+  it("the cursor only ever moves forward to what the SERVER issued", () => {
+    recordTerms({ meeting: "41", cursor: "c9", terms: [unknown("Kaar Tech")] });
+    expect(termsCursor("41")).toBe("c9");
+    // an event without a cursor must not reset it — the next Highlight would re-scan the whole room
+    recordTerms({ meeting: "41", terms: [unknown("Blue Light Card")] });
+    expect(termsCursor("41")).toBe("c9");
+    expect(termsFor("41")).toHaveLength(2);
+  });
+
+  it("an empty publish is a NON-event — it never clears what is on screen", () => {
+    recordTerms({ meeting: "41", cursor: "c9", terms: [unknown("Kaar Tech")] });
+    recordTerms({ meeting: "41", cursor: "c12", terms: [] });
+    expect(termsFor("41")).toHaveLength(1);
+    expect(termsCursor("41")).toBe("c9");
+  });
+
+  it("terms belong to their own meeting", () => {
+    recordTerms({ meeting: "41", cursor: "a", terms: [unknown("Kaar Tech")] });
+    expect(termsFor("42")).toEqual([]);
+  });
+});
+
+describe("a page the turn just wrote turns its chip solid, without asking anybody", () => {
+  it("promotes on the entity path the agent wrote", () => {
+    const out = promoteWritten([unknown("Kaar Tech")], "w1", "kg/entities/company/kaar-tech.md");
+    expect(out[0].known).toEqual({ workspace_id: "w1", entity_id: "kaar-tech", path: "kg/entities/company/kaar-tech.md" });
+    expect(out[0].kind).toBe("company");
+  });
+
+  it("returns the SAME array when nothing matched — a commit elsewhere must not churn the transcript", () => {
+    const before = [unknown("Kaar Tech")];
+    expect(promoteWritten(before, "w1", "README.md")).toBe(before);
+    expect(promoteWritten(before, "w1", "kg/entities/company/other.md")).toBe(before);
+  });
+
+  it("the artifact event drives it across every meeting on screen", () => {
+    recordTerms({ meeting: "41", cursor: "a", terms: [unknown("Kaar Tech")] });
+    notePageWritten("w1", "kg/entities/company/kaar-tech.md");
+    expect(termsFor("41")[0].known?.entity_id).toBe("kaar-tech");
+  });
+});
+
+// ── the chips ────────────────────────────────────────────────────────────────────────────────────
+
+describe("the chips", () => {
+  it("solid for a term with a page, dashed for one without — and the words are never altered", () => {
+    const { container, unmount } = render(
+      <TermText text="Kaar Tech met Blue Light Card today." meeting="41"
+                terms={[known("Kaar Tech"), unknown("Blue Light Card")]} />);
+    expect(container.textContent).toBe("Kaar Tech met Blue Light Card today.");
+    const chips = [...container.querySelectorAll("[data-term]")] as HTMLElement[];
+    expect(chips.map((c) => c.dataset.term)).toEqual(["Kaar Tech", "Blue Light Card"]);
+    expect(chips[0].dataset.known).toBe("1");
+    expect(chips[1].dataset.known).toBe("0");
+    expect(chips[1].style.borderBottom).toContain("dashed");
+    unmount();
+  });
+
+  it("is a real button, so a keyboard reaches it and a screen reader is told what it does", () => {
+    const { container, unmount } = render(
+      <TermText text="Kaar Tech asked." meeting="41" terms={[unknown("Kaar Tech")]} />);
+    const chip = container.querySelector("[data-term]") as HTMLButtonElement;
+    expect(chip.tagName).toBe("BUTTON");
+    expect(chip.type).toBe("button");
+    expect(chip.getAttribute("aria-label")).toBe("Find out what Kaar Tech is");
+    unmount();
+  });
+
+  it("a SOLID chip navigates the view slot through the resolver — it never mints a tab", () => {
+    const { container, unmount } = render(
+      <TermText text="Kaar Tech asked." meeting="41" terms={[known("Kaar Tech")]} />);
+    act(() => { (container.querySelector("[data-term]") as HTMLElement).click(); });
+    expect(opened).toEqual([{ path: "kg/entities/company/kaar-tech.md" }]);
+    expect(asks).toHaveLength(0);
+    unmount();
+  });
+
+  it("a DASHED chip drops an `explore` into the open chat, as a compact bubble", () => {
+    const { container, unmount } = render(
+      <TermText text="Kaar Tech asked." meeting="41" segment="s7" terms={[unknown("Kaar Tech")]} />);
+    act(() => { (container.querySelector("[data-term]") as HTMLElement).click(); });
+    expect(asks).toHaveLength(1);
+    expect(asks[0].display).toBe("Explore: Kaar Tech");
+    expect(asks[0].intent).toEqual({ kind: "explore", term: "Kaar Tech", meeting: "41", segment: "s7" });
+    // the fallback sentence carries the whole ask, so a deployment whose preset library is behind
+    // the client still does the right thing in plainer words
+    expect(asks[0].prompt).toContain("Explore `Kaar Tech`");
+    expect(asks[0].prompt).toContain("segment s7");
+    expect(asks[0].hidden).toBeUndefined();
+    expect(opened).toHaveLength(0);
+    unmount();
+  });
+
+  it("the longest term wins where two overlap", () => {
+    const { container, unmount } = render(
+      <TermText text="Blue Light Card called." meeting="41"
+                terms={[unknown("Blue Light"), known("Blue Light Card")]} />);
+    const chips = [...container.querySelectorAll("[data-term]")] as HTMLElement[];
+    expect(chips.map((c) => c.dataset.term)).toEqual(["Blue Light Card"]);
+    unmount();
+  });
+
+  it("a chip is not rebuilt when an unrelated line arrives — a rebuild drops keyboard focus off it", () => {
+    const terms = [unknown("Kaar Tech")];
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const view = () => <TermText text="Kaar Tech asked." meeting="41" terms={terms} />;
+    act(() => { root.render(view()); });
+    const first = container.querySelector("[data-term]");
+    act(() => { root.render(view()); });
+    expect(container.querySelector("[data-term]")).toBe(first);
+    act(() => { root.unmount(); });
+    container.remove();
+  });
+});
+
+// ── the engine seam ──────────────────────────────────────────────────────────────────────────────
+
+describe("the transcript renders the layer without knowing anything about it", () => {
+  const segments = [{ id: "s0", speaker: "Jane", text: "Kaar Tech asked about pricing.", completed: true }];
+
+  function Live({ meeting }: { meeting: string }) {
+    return <LiveTranscriptEngine segments={segments} renderText={useTermRenderer(meeting)} />;
+  }
+
+  it("plain text until something is published — an un-highlighted meeting costs nothing", () => {
+    const { container, unmount } = render(<Live meeting="41" />);
+    expect(container.textContent).toContain("Kaar Tech asked about pricing.");
+    expect(container.querySelector("[data-term]")).toBeNull();
+    unmount();
+  });
+
+  it("a `terms` event on the window paints the chips, live and completed alike", () => {
+    const { container, unmount } = render(<Live meeting="41" />);
+    act(() => {
+      window.dispatchEvent(new CustomEvent(TERMS_EVENT, {
+        detail: { meeting: "41", cursor: "c9", terms: [known("Kaar Tech")] },
+      }));
+    });
+    expect((container.querySelector("[data-term]") as HTMLElement).dataset.term).toBe("Kaar Tech");
+    expect(container.textContent).toContain("Kaar Tech asked about pricing.");
+    unmount();
+  });
+
+  it("an event for ANOTHER meeting never reaches this transcript", () => {
+    const { container, unmount } = render(<Live meeting="41" />);
+    act(() => {
+      window.dispatchEvent(new CustomEvent(TERMS_EVENT, {
+        detail: { meeting: "99", cursor: "c9", terms: [known("Kaar Tech")] },
+      }));
+    });
+    expect(container.querySelector("[data-term]")).toBeNull();
+    unmount();
+  });
+});
+
+// ── the button ───────────────────────────────────────────────────────────────────────────────────
+
+describe("the Highlight button", () => {
+  it("posts a SILENT intent — no bubble, no words the person did not type", () => {
+    const { container, unmount } = render(<HighlightButton meeting="41" />);
+    act(() => { (container.querySelector('[data-act="highlight"]') as HTMLElement).click(); });
+    expect(asks).toHaveLength(1);
+    expect(asks[0].hidden).toBe(true);
+    expect(asks[0].intent).toEqual({ kind: "highlight", meeting: "41" });
+    unmount();
+  });
+
+  it("sends back the cursor the last publish issued, so a second press adds only what is new", () => {
+    recordTerms({ meeting: "41", cursor: "c9", terms: [known("Kaar Tech")] });
+    const { container, unmount } = render(<HighlightButton meeting="41" />);
+    act(() => { (container.querySelector('[data-act="highlight"]') as HTMLElement).click(); });
+    expect(asks[0].intent).toEqual({ kind: "highlight", meeting: "41", since: "c9" });
+    unmount();
+  });
+
+  it("says how many terms this transcript already carries", () => {
+    recordTerms({ meeting: "41", cursor: "c9", terms: [known("Kaar Tech"), unknown("Blue Light Card")] });
+    const { container, unmount } = render(<HighlightButton meeting="41" />);
+    expect(container.textContent).toContain("Highlight · 2");
+    unmount();
+  });
+});
+
+describe("termSpans", () => {
+  it("carries the chip STATE as the span kind, which is the only thing painted differently", () => {
+    expect(termSpans([known("Kaar Tech"), unknown("Blue Light Card")]).map((s) => s.kind))
+      .toEqual(["known", "unknown"]);
+  });
+
+  it("drops a one-character term — a span that short is a false match, not a name", () => {
+    expect(termSpans([unknown("A")])).toHaveLength(0);
+  });
+});

--- a/clients/terminal/src/canvas/transcriptTerms.ts
+++ b/clients/terminal/src/canvas/transcriptTerms.ts
@@ -1,0 +1,157 @@
+"use client";
+/** THE TRANSCRIPT'S TERMS — what the chat published for this meeting, and how it stays true (PRD decision 35).
+ *
+ *  Founder: *"an mcp tool that will take the current transcript and list words that should be
+ *  highlighted and clickable like all the things we have in the docs and chat… click on a thing and
+ *  it's dropped into the chat as a research drop."*
+ *
+ *  RECORD-DRIVEN, NEVER FETCHED (decision 18). This module holds no opinion about what should be
+ *  highlighted and never asks anyone: terms arrive as `terms` EVENTS on the chat stream — the
+ *  harness emits one when the agent's `transcript_terms` call publishes — and this is the store they
+ *  land in. The transcript renders the store. A second reader that fetched its own list would be a
+ *  second writer of the same surface, which is the one invariant this codebase keeps repeating.
+ *
+ *  ADDITIVE BY CONSTRUCTION. Pressing Highlight again sends the CURSOR from last time, so the turn
+ *  sees only what has been said since and publishes only what is new. A second event therefore
+ *  MERGES: nothing already on screen is removed by a later press, and a term that arrives twice
+ *  keeps the newer answer about whether it has a page. This is why an empty publish is a non-event
+ *  server-side — an empty event would read as "and now there are none".
+ */
+import { useEffect, useSyncExternalStore } from "react";
+import { entitySlug } from "../ui-kit/docLinks";
+import type { SpanEntity } from "./inlineSpans";
+
+/** The chat published this. `known` non-null ⇒ a page exists that THIS reader can open. */
+export interface TranscriptTerm {
+  term: string;
+  /** the entity kind, when the matched page says one. Absent for an unknown term — the mechanical
+   *  extractor cannot know what a name IS, and guessing would colour the chip a lie. */
+  kind?: string;
+  known: { workspace_id?: string; entity_id?: string; path?: string } | null;
+  /** where it was said, in the PUBLISHER's id vocabulary. Provenance for the agent; the renderer
+   *  re-finds the term in the text it is drawing (the `splitTextIntoSpans` precedent) rather than
+   *  joining on these — the gateway's rows and the live SSE do not share an id space. */
+  segments?: (string | number)[];
+  first_at?: string | number | null;
+}
+
+export interface TermsEvent { meeting: string; cursor?: string; terms: TranscriptTerm[] }
+
+/** A `terms` event, re-emitted onto the window by the chat surface — the same seam, and for the
+ *  same reason, as ARTIFACT_EVENT: the stream reader owns no state and the shell owns no parsing. */
+export const TERMS_EVENT = "vexa:terminal:terms";
+
+interface Entry { terms: TranscriptTerm[]; cursor: string }
+const EMPTY: Entry = { terms: [], cursor: "" };
+
+const store = new Map<string, Entry>();
+const subs = new Set<() => void>();
+const notify = () => subs.forEach((f) => f());
+
+const key = (t: { term: string }) => t.term.trim().toLowerCase();
+
+/** MERGE, never replace (see the header). Pure and exported: the whole additive promise of the
+ *  Highlight button is this one function, and it is the kind of thing that is invisible when wrong. */
+export function mergeTerms(prev: TranscriptTerm[], next: TranscriptTerm[]): TranscriptTerm[] {
+  const out = [...prev];
+  const at = new Map(out.map((t, i) => [key(t), i]));
+  for (const t of next) {
+    const term = String(t?.term ?? "").trim();
+    if (!term) continue;
+    const row: TranscriptTerm = { ...t, term };
+    const i = at.get(key(row));
+    if (i == null) { at.set(key(row), out.length); out.push(row); continue; }
+    // A LATER ANSWER ABOUT `known` WINS, including a later null: the page could have been deleted,
+    // and a chip that stays solid over a page that is gone is the "opens nothing" failure the
+    // resolver already refuses. Everything else merges, so a re-publish cannot lose provenance.
+    out[i] = { ...out[i], ...row, segments: row.segments ?? out[i].segments };
+  }
+  return out;
+}
+
+/** A page the agent just wrote, offered to every term that is waiting for one.
+ *
+ *  THE CHIP TURNS SOLID WITHOUT ASKING ANYBODY (decision 35.3). The alternative — re-running the
+ *  Highlight turn to re-ask "does it have a page now" — spends a model call to learn something the
+ *  artifact event already said. The match is the slug, which is what `entity_upsert` names the file
+ *  after and what the term would have matched had the page existed at publish time.
+ *
+ *  Pure, so the promotion rule is readable in one place. Returns the SAME array when nothing
+ *  changed, so a commit elsewhere in the workspace cannot churn the transcript. */
+export function promoteWritten(terms: TranscriptTerm[], workspace: string, path: string): TranscriptTerm[] {
+  const m = /^kg\/entities\/([^/]+)\/([^/]+)\.md$/.exec(String(path ?? "").trim().replace(/^\/+/, ""));
+  if (!m) return terms;
+  const [, kind, slug] = m;
+  let hit = false;
+  const out = terms.map((t) => {
+    if (t.known || entitySlug(t.term) !== slug) return t;
+    hit = true;
+    return { ...t, kind: t.kind ?? kind, known: { workspace_id: workspace || undefined, entity_id: slug, path: `kg/entities/${kind}/${slug}.md` } };
+  });
+  return hit ? out : terms;
+}
+
+export function recordTerms(ev: TermsEvent): void {
+  const meeting = String(ev?.meeting ?? "").trim();
+  if (!meeting || !Array.isArray(ev?.terms) || !ev.terms.length) return;
+  const cur = store.get(meeting) ?? EMPTY;
+  store.set(meeting, {
+    terms: mergeTerms(cur.terms, ev.terms),
+    // The cursor only ever moves FORWARD to whatever the server last issued; an event without one
+    // leaves it where it was, so the next Highlight does not silently re-scan the whole room.
+    cursor: String(ev.cursor ?? "") || cur.cursor,
+  });
+  notify();
+}
+
+/** A page landed — promote every term it answers, across every meeting on screen. */
+export function notePageWritten(workspace: string, path: string): void {
+  let changed = false;
+  for (const [meeting, entry] of store) {
+    const next = promoteWritten(entry.terms, workspace, path);
+    if (next !== entry.terms) { store.set(meeting, { ...entry, terms: next }); changed = true; }
+  }
+  if (changed) notify();
+}
+
+/** For tests, and for a signed-out reload: the store is per-tab and deliberately not persisted —
+ *  it is a view of the chat record, and the record is on the server. */
+export function resetTerms(): void { store.clear(); notify(); }
+
+export const termsFor = (meeting: string): TranscriptTerm[] => (store.get(meeting) ?? EMPTY).terms;
+/** The `since` the NEXT Highlight sends. Always a value the server issued (decision 35.2). */
+export const termsCursor = (meeting: string): string => (store.get(meeting) ?? EMPTY).cursor;
+
+const entryFor = (meeting: string): Entry => store.get(meeting) ?? EMPTY;
+
+/** Subscribe a component to one meeting's published terms. */
+export function useTranscriptTerms(meeting: string): TranscriptTerm[] {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onTerms = (e: Event) => recordTerms((e as CustomEvent<TermsEvent>).detail);
+    const onArtifact = (e: Event) => {
+      const d = (e as CustomEvent<{ workspace?: string; path?: string }>).detail;
+      if (d?.path) notePageWritten(d.workspace ?? "", d.path);
+    };
+    window.addEventListener(TERMS_EVENT, onTerms);
+    window.addEventListener("vexa:terminal:artifact", onArtifact);
+    return () => {
+      window.removeEventListener(TERMS_EVENT, onTerms);
+      window.removeEventListener("vexa:terminal:artifact", onArtifact);
+    };
+  }, []);
+  return useSyncExternalStore(
+    (cb) => { subs.add(cb); return () => subs.delete(cb); },
+    () => entryFor(meeting).terms,
+    () => entryFor(meeting).terms,
+  );
+}
+
+/** The terms as the span splitter's vocabulary. `kind` carries the CHIP STATE rather than the
+ *  taxonomy — `known` vs `unknown` — because that is the only thing the renderer paints differently
+ *  and the entity's own kind is already on the term for the tooltip. */
+export function termSpans(terms: TranscriptTerm[]): SpanEntity[] {
+  return terms
+    .filter((t) => t.term && t.term.trim().length >= 2)
+    .map((t) => ({ id: t.term, label: t.term, kind: t.known ? "known" : "unknown", docPath: t.known?.path }));
+}

--- a/clients/terminal/src/minutes/__tests__/extend.test.ts
+++ b/clients/terminal/src/minutes/__tests__/extend.test.ts
@@ -6,13 +6,14 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ASK_CHAT_EVENT } from "../../canvas/actions";
-import { normalizeIntent, SELECTION_MAX, type ChatIntent } from "../../surfaces/chatIntent";
+import { normalizeIntent, SELECTION_MAX, type ChatIntent, type PageIntent } from "../../surfaces/chatIntent";
 import {
   PREVIEW_MAX, clearPending, compactLabel, fallbackText, landPending, pendingLanding, postIntent, sourceRange,
 } from "../extend";
 import { VIEW_NAVIGATE_EVENT } from "../roomView";
 
-const asks: { prompt?: string; display?: string; intent?: ChatIntent }[] = [];
+// these suites are about PAGE intents (extend/create); narrowing here is the assertion, not a cast
+const asks: { prompt?: string; display?: string; intent?: PageIntent }[] = [];
 const views: unknown[] = [];
 const onAsk = (e: Event) => asks.push((e as CustomEvent).detail);
 const onView = (e: Event) => views.push((e as CustomEvent).detail);

--- a/clients/terminal/src/minutes/__tests__/extendPanel.test.tsx
+++ b/clients/terminal/src/minutes/__tests__/extendPanel.test.tsx
@@ -11,7 +11,7 @@ import { PagesPanel } from "../PagesPanel";
 import { ASK_CHAT_EVENT, WORKSPACE_COMMIT_EVENT } from "../../canvas/actions";
 import { VIEW_NAVIGATE_EVENT } from "../roomView";
 import { clearPending } from "../extend";
-import type { ChatIntent } from "../../surfaces/chatIntent";
+import type { PageIntent } from "../../surfaces/chatIntent";
 import type { Page } from "../types";
 
 const PATH = "kg/entities/company/helm.md";
@@ -20,7 +20,8 @@ const BODY = "# Helm Bank\n\nThe pilot ships in March, self-hosted.\n";
 // what is written on a chip would pick this up
 const pages: Page[] = [{ path: PATH, slug: "acme-kg", label: "Some Other Name" }];
 
-const asks: { prompt?: string; display?: string; intent?: ChatIntent }[] = [];
+// this suite is about PAGE intents (extend/create); narrowing here is the assertion, not a cast
+const asks: { prompt?: string; display?: string; intent?: PageIntent }[] = [];
 const views: unknown[] = [];
 const onAsk = (e: Event) => asks.push((e as CustomEvent).detail);
 const onView = (e: Event) => views.push((e as CustomEvent).detail);

--- a/clients/terminal/src/minutes/extend.ts
+++ b/clients/terminal/src/minutes/extend.ts
@@ -20,14 +20,14 @@
  *  sentence — the two say the same thing.
  */
 import { ASK_CHAT_EVENT } from "../canvas/actions";
-import { normalizeIntent, type ChatIntent, type ChatIntentKind } from "../surfaces/chatIntent";
+import { isPageIntent, isSilent, normalizeIntent, type ChatIntent, type ChatIntentKind, type IntentOf, type RawIntent } from "../surfaces/chatIntent";
 import { navigateView } from "./roomView";
 
 /** How much of a selection the BUBBLE shows. The intent carries up to 2000 characters; a bubble is
  *  a label, and a paragraph rendered as one is the composed-text failure wearing a quotation mark. */
 export const PREVIEW_MAX = 80;
 
-const VERB: Record<ChatIntentKind, string> = { extend: "Extend", create: "Create" };
+const VERB: Record<ChatIntentKind, string> = { extend: "Extend", create: "Create", explore: "Explore", highlight: "Highlight" };
 
 /** Collapse the whitespace a rendered selection carries — a highlight dragged across a paragraph
  *  break arrives with newlines in it, and they belong in the intent, never in a one-line label. */
@@ -36,6 +36,13 @@ const oneLine = (s: string) => s.replace(/\s+/g, " ").trim();
 /** THE BUBBLE. Compact by construction: a verb, the page, and — when there is one — a short
  *  quotation of what was highlighted. */
 export function compactLabel(intent: ChatIntent): string {
+  // A CHIP CLICKED IN A TRANSCRIPT SHOWS THE WORDS, not the meeting it was said in: the person is
+  // looking at the room already, and "Explore: Kaar Tech (meeting 41, segment …)" spends the whole
+  // label on the two facts they can see.
+  if (intent.kind === "explore") return `Explore: ${intent.term}`;
+  // Highlight is silent (decision 35.2) and never reaches a bubble; the label exists only so a
+  // caller that logs one has something honest to log.
+  if (intent.kind === "highlight") return "Highlight";
   const head = `${VERB[intent.kind]}: ${intent.path}`;
   if (!intent.selection) return head;
   const flat = oneLine(intent.selection);
@@ -47,6 +54,17 @@ export function compactLabel(intent: ChatIntent): string {
  *  not the preview: this is what the agent reads, and truncating it here would lose the half of a
  *  paragraph the person actually cared about. */
 export function fallbackText(intent: ChatIntent): string {
+  if (intent.kind === "explore") {
+    return `Explore \`${intent.term}\` (said in meeting ${intent.meeting}` +
+      (intent.segment ? `, segment ${intent.segment}` : "") +
+      `): find out what it is in the logic of this chat and this meeting — workspace first, ` +
+      `research where it runs out — write its page with sources, then two lines on what it is.`;
+  }
+  if (intent.kind === "highlight") {
+    return `Call transcript_terms(meeting_id="${intent.meeting}", since="${intent.since ?? ""}"), ` +
+      `pick the terms that matter to this person in this meeting, then call it again with ` +
+      `keep="<those terms>" to publish them as chips. Say nothing back — this is machinery.`;
+  }
   const head = `${VERB[intent.kind]}: ${intent.path}`;
   return intent.selection ? `${head} — '${intent.selection}'` : head;
 }
@@ -82,12 +100,25 @@ export const clearPending = (): void => { pending = null; };
 
 /** Post an intent into the OPEN chat. Returns the intent that went, or `null` when there was
  *  nothing honest to send (see `normalizeIntent` — an unnamed page is never guessed at). */
-export function postIntent(raw: Parameters<typeof normalizeIntent>[0]): ChatIntent | null {
+export function postIntent<K extends ChatIntentKind>(raw: Omit<RawIntent, "kind"> & { kind: K }): IntentOf<K> | null;
+export function postIntent(raw: RawIntent): ChatIntent | null;
+export function postIntent(raw: RawIntent): ChatIntent | null {
   const intent = normalizeIntent(raw);
   if (!intent) return null;
-  pending = { workspace: intent.workspace, path: intent.path };
+  // ONLY A PAGE INTENT HAS A LANDING. `explore` writes a page whose path nobody can predict — the
+  // agent picks the kind and the slug — so navigating on its commit would land the panel on a
+  // guess. Its visible result is the chip going solid, which the terms layer does on the same
+  // commit event. `highlight` writes nothing at all.
+  pending = isPageIntent(intent) ? { workspace: intent.workspace, path: intent.path } : null;
   window.dispatchEvent(new CustomEvent(ASK_CHAT_EVENT, {
-    detail: { prompt: fallbackText(intent), display: compactLabel(intent), intent },
+    detail: {
+      prompt: fallbackText(intent),
+      display: compactLabel(intent),
+      intent,
+      // `hidden` suppresses the user bubble for a machinery turn. The chat's own MACHINERY_MARK
+      // keeps it hidden on RELOAD too, which is the half `hidden` alone has never covered.
+      ...(isSilent(intent) ? { hidden: true } : {}),
+    },
   }));
   return intent;
 }

--- a/clients/terminal/src/surfaces/__tests__/chatStream.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/chatStream.test.ts
@@ -356,3 +356,61 @@ describe("streamChatTurn — turn-accepted liveness ack", () => {
     expect(result.terminal).toBe(true);
   });
 });
+
+/** PRD decision 35 — the `terms` event: what the transcript's chips are made of.
+ *
+ *  It rides the CHAT stream and not the meeting stream on purpose (decision 18: the chips are part
+ *  of the chat's record), and it is forwarded here rather than stored, exactly like `artifact`. */
+describe("streamChatTurn — the transcript's terms", () => {
+  const terms = [{ term: "Kaar Tech", known: null }];
+
+  it("forwards a publish with its meeting and its cursor", async () => {
+    const seen: unknown[] = [];
+    const { cb } = recorder();
+    const fetchImpl = vi.fn().mockResolvedValueOnce(sseResponse([
+      ev({ type: "terms", meeting: "41", cursor: "c9", terms }, "1-0"),
+      ev({ type: "turn-complete" }, "2-0"),
+    ]));
+    await streamChatTurn({ prompt: "x", session: "s", active: undefined },
+      { ...cb, onTerms: (t) => seen.push(t) },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, signal: new AbortController().signal, ...noWait });
+    expect(seen).toEqual([{ meeting: "41", cursor: "c9", terms }]);
+  });
+
+  it("an empty or unaddressed publish is dropped — an empty event would CLEAR the chips on screen", async () => {
+    const seen: unknown[] = [];
+    const { cb } = recorder();
+    const fetchImpl = vi.fn().mockResolvedValueOnce(sseResponse([
+      ev({ type: "terms", meeting: "41", cursor: "c9", terms: [] }, "1-0"),
+      ev({ type: "terms", cursor: "c9", terms }, "2-0"),
+      ev({ type: "turn-complete" }, "3-0"),
+    ]));
+    await streamChatTurn({ prompt: "x", session: "s", active: undefined },
+      { ...cb, onTerms: (t) => seen.push(t) },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, signal: new AbortController().signal, ...noWait });
+    expect(seen).toEqual([]);
+  });
+
+  it("is not visible output — a silent Highlight turn produces prose for nobody", async () => {
+    const { cb } = recorder();
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(sseResponse([ev({ type: "terms", meeting: "41", cursor: "c9", terms }, "1-0")]))
+      .mockResolvedValueOnce(sseResponse([ev({ type: "turn-complete" }, "2-0")]));
+    const result = await streamChatTurn({ prompt: "x", session: "s", active: undefined },
+      { ...cb, onTerms: () => {} },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, signal: new AbortController().signal, ...noWait });
+    expect(result.sawVisibleOutput).toBe(false);
+  });
+
+  it("a client with no onTerms handler is not a crash — the callback is optional", async () => {
+    const { cb } = recorder();
+    const fetchImpl = vi.fn().mockResolvedValueOnce(sseResponse([
+      ev({ type: "terms", meeting: "41", cursor: "c9", terms }, "1-0"),
+      ev({ type: "turn-complete" }, "2-0"),
+    ]));
+    const result = await streamChatTurn({ prompt: "x", session: "s", active: undefined }, cb,
+      { fetchImpl: fetchImpl as unknown as typeof fetch, signal: new AbortController().signal, ...noWait });
+    expect(result.terminal).toBe(true);
+  });
+});
+

--- a/clients/terminal/src/surfaces/__tests__/intentTerms.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/intentTerms.test.ts
@@ -1,0 +1,70 @@
+/** PRD decision 35 — the two intents a transcript mints, and what each refuses.
+ *
+ *  `explore` is a research drop about ONE thing somebody clicked; `highlight` is machinery with no
+ *  words in it at all. Both go through the same door as `extend`/`create` (F63): a malformed intent
+ *  becomes null and the caller sends nothing, because the failure this exists to prevent is the
+ *  agent confidently working on a thing that was never in front of anybody.
+ */
+import { describe, expect, it } from "vitest";
+import { isPageIntent, isSilent, normalizeIntent, TERM_MAX } from "../chatIntent";
+
+describe("explore — a term clicked in a transcript", () => {
+  it("carries the term, the meeting and the segment it was said in", () => {
+    expect(normalizeIntent({ kind: "explore", term: " Kaar Tech ", meeting: "41", segment: "s7" }))
+      .toEqual({ kind: "explore", term: "Kaar Tech", meeting: "41", segment: "s7" });
+  });
+
+  it("an absent segment stays ABSENT — provenance we do not have is not invented", () => {
+    const i = normalizeIntent({ kind: "explore", term: "Kaar Tech", meeting: "41" })!;
+    expect("segment" in i).toBe(false);
+  });
+
+  it("refuses a term with no meeting, and a meeting with no term", () => {
+    expect(normalizeIntent({ kind: "explore", term: "Kaar Tech" })).toBeNull();
+    expect(normalizeIntent({ kind: "explore", meeting: "41" })).toBeNull();
+    expect(normalizeIntent({ kind: "explore", term: "   ", meeting: "41" })).toBeNull();
+  });
+
+  it("refuses a paragraph — a 'term' that long is a mis-click, and truncating it would ask the agent to research half a sentence", () => {
+    expect(normalizeIntent({ kind: "explore", term: "x".repeat(TERM_MAX), meeting: "41" })).toBeTruthy();
+    expect(normalizeIntent({ kind: "explore", term: "x".repeat(TERM_MAX + 1), meeting: "41" })).toBeNull();
+  });
+
+  it("is not a page intent — there is no path to land the panel on", () => {
+    expect(isPageIntent(normalizeIntent({ kind: "explore", term: "a b", meeting: "41" })!)).toBe(false);
+  });
+
+  it("is NOT silent — the person clicked something and expects an answer about it", () => {
+    expect(isSilent(normalizeIntent({ kind: "explore", term: "a b", meeting: "41" })!)).toBe(false);
+  });
+});
+
+describe("highlight — the transcript's own button", () => {
+  it("carries the meeting and the cursor the last publish issued", () => {
+    expect(normalizeIntent({ kind: "highlight", meeting: "41", since: "c9" }))
+      .toEqual({ kind: "highlight", meeting: "41", since: "c9" });
+  });
+
+  it("a first press has no cursor, and sends none", () => {
+    expect(normalizeIntent({ kind: "highlight", meeting: "41" })).toEqual({ kind: "highlight", meeting: "41" });
+  });
+
+  it("refuses a press with no meeting", () => {
+    expect(normalizeIntent({ kind: "highlight" })).toBeNull();
+  });
+
+  it("is silent — the person sees chips appear, never a bubble they did not type", () => {
+    expect(isSilent(normalizeIntent({ kind: "highlight", meeting: "41" })!)).toBe(true);
+  });
+});
+
+describe("the door is still closed to everything else", () => {
+  it("an unknown kind is null, not a guess", () => {
+    // @ts-expect-error — the point of the test is what happens when the type is bypassed
+    expect(normalizeIntent({ kind: "explore-everything", term: "a b", meeting: "41" })).toBeNull();
+  });
+
+  it("a page intent still refuses a path that walks out of its mount", () => {
+    expect(normalizeIntent({ kind: "extend", path: "../../etc/passwd" })).toBeNull();
+  });
+});

--- a/clients/terminal/src/surfaces/chat.tsx
+++ b/clients/terminal/src/surfaces/chat.tsx
@@ -23,6 +23,7 @@ import { presentError } from "./apiClient";
 import { promptCarriesActiveContext } from "./surfaceSync";
 import type { ChatIntent } from "./chatIntent";
 import { ARTIFACT_EVENT, ASK_CHAT_EVENT, CHAT_TOUCHED_EVENT, MACHINERY_MARK, WORKSPACE_COMMIT_EVENT, MACHINERY_NOTE, ONBOARDING_KICKOFF_MARK, MINUTES_ONBOARDING_GREETING, MINUTES_PREP_GREETING, ONBOARDING_REPLY_SEP } from "../canvas/actions";
+import { TERMS_EVENT } from "../canvas/transcriptTerms";
 
 /** classify a tool name into one of the op icons so the operation line reads at a glance */
 function toolOp(tool: string, args?: Record<string, unknown>): Op {
@@ -974,6 +975,10 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
           // A FILE THIS TURN WROTE. Re-emitted for the shell, which owns the chat record's tabs —
           // this surface never opens a document itself (F41).
           onArtifact: (a) => window.dispatchEvent(new CustomEvent(ARTIFACT_EVENT, { detail: a })),
+          // TERMS THIS TURN PUBLISHED for a meeting's transcript (PRD decision 35). Same seam and
+          // same reason as the artifact above: the chips are part of the chat's record and the
+          // transcript renders that record — this surface forwards and stores nothing.
+          onTerms: (t) => window.dispatchEvent(new CustomEvent(TERMS_EVENT, { detail: t })),
           onTool: (tool, args) => {
             breakBeforeNextDelta = true;      // F40 — the assistant message ended here
             const op = toolOp(tool, args);

--- a/clients/terminal/src/surfaces/chatIntent.ts
+++ b/clients/terminal/src/surfaces/chatIntent.ts
@@ -1,28 +1,42 @@
-/** THE INTENT ON A CHAT TURN — what a button pressed on a page asks the agent to do (PRD decision 32).
+/** THE INTENT ON A CHAT TURN — what a button pressed on a page asks the agent to do (PRD decisions 32, 35).
  *
- *  A turn can now carry more than prose. "Extend" and "Create this page" are not sentences the
- *  person typed; they are ACTS on a named file, and the agent needs the file — not a paraphrase of
- *  it that it then has to parse back. So the wire carries a small typed record beside the prompt,
- *  and the server half turns it into the matching preset.
+ *  A turn can now carry more than prose. "Extend", "Create this page", a term clicked in a
+ *  transcript and the transcript's own "Highlight" are not sentences the person typed; they are
+ *  ACTS on a named thing, and the agent needs the thing — not a paraphrase of it that it then has
+ *  to parse back. So the wire carries a small typed record beside the prompt, and the server half
+ *  (`control_plane/chat_intents.py`) turns it into the matching preset.
  *
  *  It lives in `surfaces/` rather than beside its buttons in `minutes/` because three layers have
  *  to agree on it — the panel that mints it, the chat that sends it, the stream that puts it on the
  *  wire — and the dependency direction runs that way (surfaces are below shells, never above).
  *
- *  F63 — AN INTENT NEVER CARRIES A GUESSED PATH. Everything below refuses rather than repairs: an
- *  empty path, a path that walks out of its mount, a range that does not describe its own selection.
- *  A malformed intent becomes `null` here and the caller sends nothing, because the failure mode
- *  this exists to prevent is the agent confidently working on a file that was never open.
+ *  F63 — AN INTENT NEVER CARRIES A GUESSED ANYTHING. Everything below refuses rather than repairs:
+ *  an empty path, a path that walks out of its mount, a range that does not describe its own
+ *  selection, a term nobody clicked, a meeting with no id. A malformed intent becomes `null` here
+ *  and the caller sends nothing, because the failure mode this exists to prevent is the agent
+ *  confidently working on a thing that was never in front of anybody.
+ *
+ *  TWO FAMILIES, ONE DOOR. Page intents (`extend` · `create`) name a FILE; meeting intents
+ *  (`explore` · `highlight`) name a MEETING. They are a union rather than one wide optional-
+ *  everything record so that "an explore with no term" cannot type-check — the shape is the
+ *  validation, and the runtime check below only has to enforce what a type cannot.
  */
 
 /** The most selected text an intent carries. Past this the selection is no longer a quotation, and
  *  the page itself — which the intent already names — is the better thing to hand the agent. */
 export const SELECTION_MAX = 2000;
 
-export type ChatIntentKind = "extend" | "create";
+/** A term is a phrase said in a room, not a document. Anything past this is a mis-click on a
+ *  paragraph, and sending it would ask the agent to research a sentence. */
+export const TERM_MAX = 120;
 
-export interface ChatIntent {
-  kind: ChatIntentKind;
+export type ChatIntentKind = "extend" | "create" | "explore" | "highlight";
+
+/** An act on a FILE (decision 32). Split into one interface per kind — rather than one carrying
+ *  `kind: "extend" | "create"` — so the union is DISCRIMINATED all the way down and `IntentOf<K>`
+ *  can narrow it. A member whose own `kind` is a union is not extractable by kind, and the symptom
+ *  is a call site silently typed `never`. */
+export interface PageIntentFields {
   /** the workspace slug the page lives in. ABSENT = the reader's own desk (a no-slug read) — an
    *  absent slug is a RESOLVED answer here, never "we did not look". */
   workspace?: string;
@@ -35,25 +49,96 @@ export interface ChatIntent {
   selection_range?: { start: number; end: number };
 }
 
-const isInt = (n: unknown): n is number => typeof n === "number" && Number.isInteger(n) && n >= 0;
+export interface ExtendIntent extends PageIntentFields { kind: "extend" }
+export interface CreateIntent extends PageIntentFields { kind: "create" }
+export type PageIntent = ExtendIntent | CreateIntent;
 
-/** The one door an intent comes through. Returns the intent, or `null` when it would be a guess. */
-export function normalizeIntent(raw: {
+/** A term clicked in a transcript (decision 35.3) — "find out what this is". */
+export interface ExploreIntent {
+  kind: "explore";
+  /** the words on the chip, exactly as they were said */
+  term: string;
+  /** the meeting ROW id the transcript belongs to */
+  meeting: string;
+  /** the segment the click landed in, when the renderer knows it. Provenance for the agent, never a
+   *  join key: the gateway's rows and the live SSE do not share an id space. */
+  segment?: string;
+}
+
+/** The transcript's own Highlight button (decision 35.2). Carries no words at all — it asks the
+ *  chat to go and find what is worth chipping, and the person never sees the asking. */
+export interface HighlightIntent {
+  kind: "highlight";
+  meeting: string;
+  /** the cursor the LAST highlight on this meeting returned. Absent = highlight from the top.
+   *  Always a value the server issued; the client never invents one. */
+  since?: string;
+}
+
+export type ChatIntent = ExtendIntent | CreateIntent | ExploreIntent | HighlightIntent;
+
+/** The intents the person must NOT see as a bubble in their conversation. Mirrors
+ *  `chat_intents.SILENT_KINDS` server-side — the founder's correction on Highlight is that it is
+ *  silent, and a "Highlight: …" bubble would be the product narrating its own plumbing. */
+export const SILENT_KINDS: ReadonlySet<ChatIntentKind> = new Set<ChatIntentKind>(["highlight"]);
+
+export const isPageIntent = (i: ChatIntent): i is PageIntent => i.kind === "extend" || i.kind === "create";
+export const isSilent = (i: ChatIntent): boolean => SILENT_KINDS.has(i.kind);
+
+/** The loose record a caller hands in — every field optional, because a button knows only its own. */
+export type RawIntent = {
   kind: ChatIntentKind;
   workspace?: string | null;
   path?: string | null;
   selection?: string | null;
   selection_range?: { start: number; end: number } | null;
-}): ChatIntent | null {
-  if (raw.kind !== "extend" && raw.kind !== "create") return null;
+  term?: string | null;
+  meeting?: string | null;
+  segment?: string | null;
+  since?: string | null;
+};
+
+const isInt = (n: unknown): n is number => typeof n === "number" && Number.isInteger(n) && n >= 0;
+const str = (v: unknown): string => String(v ?? "").trim();
+
+/** The intent a given kind produces — so a caller that writes `kind: "extend"` gets a `PageIntent`
+ *  back and can read `.path` off it without a cast. The union is the validation (see the header);
+ *  this keeps that usable at the call site instead of pushing an `as` into every button. */
+export type IntentOf<K extends ChatIntentKind> = Extract<ChatIntent, { kind: K }>;
+
+/** The one door an intent comes through. Returns the intent, or `null` when it would be a guess. */
+export function normalizeIntent<K extends ChatIntentKind>(raw: Omit<RawIntent, "kind"> & { kind: K }): IntentOf<K> | null;
+export function normalizeIntent(raw: RawIntent): ChatIntent | null;
+export function normalizeIntent(raw: RawIntent): ChatIntent | null {
+  const kind = raw?.kind;
+
+  if (kind === "explore") {
+    // A term is capped, never truncated-and-sent: a 300-character "term" is a mis-click, and
+    // trimming it to 120 would hand the agent half a sentence to research as if it were a name.
+    const term = str(raw.term);
+    const meeting = str(raw.meeting);
+    if (!term || term.length > TERM_MAX || !meeting) return null;
+    const segment = str(raw.segment);
+    return { kind, term, meeting, ...(segment ? { segment } : {}) };
+  }
+
+  if (kind === "highlight") {
+    const meeting = str(raw.meeting);
+    if (!meeting) return null;
+    const since = str(raw.since);
+    return { kind, meeting, ...(since ? { since } : {}) };
+  }
+
+  if (kind !== "extend" && kind !== "create") return null;
+
   const path = String(raw.path ?? "").trim().replace(/^\/+/, "");
   // no path, or one that walks out of its mount → nothing to act on. Same refusal `resolveView`
   // applies to a link, for the same reason.
   if (!path || path.split("/").includes("..")) return null;
 
-  const workspace = String(raw.workspace ?? "").trim() || undefined;
+  const workspace = str(raw.workspace) || undefined;
 
-  const selRaw = String(raw.selection ?? "").trim();
+  const selRaw = str(raw.selection);
   const selection = selRaw ? selRaw.slice(0, SELECTION_MAX) : undefined;
 
   const r = raw.selection_range;
@@ -65,5 +150,5 @@ export function normalizeIntent(raw: {
       ? { start: r.start, end: r.end }
       : undefined;
 
-  return { kind: raw.kind, ...(workspace ? { workspace } : {}), path, ...(selection ? { selection } : {}), ...(selection_range ? { selection_range } : {}) };
+  return { kind, ...(workspace ? { workspace } : {}), path, ...(selection ? { selection } : {}), ...(selection_range ? { selection_range } : {}) };
 }

--- a/clients/terminal/src/surfaces/chatStream.ts
+++ b/clients/terminal/src/surfaces/chatStream.ts
@@ -39,6 +39,11 @@ export type ChatStreamEvent = {
    *  scaffold-declared pinned tab does. Orthogonal to `focus`: pinning is about what stays,
    *  focusing is about what is in front, and a turn may ask for either, both, or neither. */
   pin?: boolean;
+  /** `terms` events only (PRD decision 35) — the meeting ROW the chips belong to, the cursor the
+   *  next Highlight should send back, and the published terms themselves. */
+  meeting?: string;
+  cursor?: string;
+  terms?: unknown[];
 };
 
 /** HOW ONE INTERIM TEXT JOINS THE LAST (F40, founder ruling 2026-09-02).
@@ -97,6 +102,10 @@ export type ChatStreamCallbacks = {
    *  success — a failed write says nothing. Optional so existing callers/tests need not implement
    *  it. */
   onArtifact?: (a: { workspace: string; path: string; focus: boolean; pin: boolean }) => void;
+  /** TERMS THE TURN PUBLISHED for a meeting's transcript (decision 35.2). Forwarded, never stored:
+   *  the chips belong to the CHAT RECORD and this reader owns no state, exactly as with
+   *  `onArtifact`. Optional so existing callers/tests need not implement it. */
+  onTerms?: (t: { meeting: string; cursor: string; terms: unknown[] }) => void;
 };
 
 export type ChatStreamRequest = {
@@ -308,6 +317,19 @@ export async function streamChatTurn(
           // belongs to the CHAT RECORD (decision 18) and this file owns no state at all.
           case "artifact":
             if (ev.path) cb.onArtifact?.({ workspace: ev.workspace ?? "", path: ev.path, focus: ev.focus === true, pin: ev.pin === true });
+            break;
+          // THE TRANSCRIPT'S CHIPS (decision 35). Emitted by the harness off a successful
+          // `transcript_terms` PUBLISH — the agent's second call, the one carrying `keep`. A bare
+          // look-up emits nothing, so a turn that read the room without choosing anything paints
+          // nothing on the person's screen.
+          //
+          // NOT counted as visible output: a Highlight turn is machinery and produces no prose, and
+          // treating this as "the agent said something" would keep the "starting agent…" affordance
+          // honest for the wrong turn.
+          case "terms":
+            if (ev.meeting && Array.isArray(ev.terms) && ev.terms.length) {
+              cb.onTerms?.({ meeting: ev.meeting, cursor: ev.cursor ?? "", terms: ev.terms });
+            }
             break;
           case "commit":
             terminal = true; cb.onCommit(ev.sha);

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -78,6 +78,7 @@ from control_plane import workspace_credentials as wcreds
 from control_plane import global_layer
 from control_plane import system_mounts
 from control_plane import scaffolds as scaffolds_mod
+from control_plane import chat_intents
 from control_plane.workspace_membership import MembershipError, MembershipIndex, InMemoryMembershipIndex
 from control_plane.dispatch import Dispatcher
 from control_plane.events import event_to_invocation
@@ -382,6 +383,13 @@ class ChatBody(BaseModel):
     # store. A scaffold that is not this subject's is ignored (never an error) — a stale or
     # forwarded id must not be able to widen anybody's mounts, and must not break their turn either.
     scaffold_id: Optional[str] = None
+    # THE INTENT (PRD decision 32/35). A button pressed on a page — Extend, Create this page,
+    # Explore a term in a transcript, Highlight the transcript — is an ACT on a named thing, not a
+    # sentence somebody typed. The terminal has sent this since decision 32 landed client-side; with
+    # `extra="forbid"` above and no field here, every one of those presses 422'd. It is a plain dict
+    # rather than a model on purpose: the CLOSED vocabulary is `chat_intents.INTENT_PRESETS`, an
+    # unknown kind is ignored, and a client one release ahead must not be refused at the door.
+    intent: Optional[dict] = None
 
 
 class ScaffoldMintBody(BaseModel):
@@ -1603,6 +1611,24 @@ def create_app(
             # fetching anything, and the whole block is machinery-marked so the human never
             # sees it as their own message (ledger F7).
             body = body.model_copy(update={"prompt": scaffolds_mod.turn_prompt(scaffold_view)})
+        # THE INTENT'S PRESET (decision 32.2 / 35.3). Same rule as the scaffold above and for the
+        # same reason: the words are admin-owned content in `_global/asks/`, the wire carries a kind
+        # and its arguments, and the server is the only thing that puts the two together.
+        #
+        # DEGRADES, NEVER REFUSES. `preset_for` returns None for a kind this deployment does not
+        # know and `read_preset` raises when the file is not there; both leave `body.prompt` — the
+        # client's plain fallback sentence — exactly as it arrived. A preset library that is one
+        # release behind the terminal costs the turn its phrasing, not its meaning.
+        elif body.intent:
+            _preset = chat_intents.preset_for(body.intent)
+            if _preset:
+                try:
+                    _fm, _ask = scaffolds_mod.read_preset(_global_root(), _preset)
+                    body = body.model_copy(update={
+                        "prompt": scaffolds_mod.substitute(_ask, chat_intents.tokens_for(body.intent))})
+                except scaffolds_mod.ScaffoldError as e:
+                    logger.warning("intent %s has no preset here (%s) — the turn runs on the "
+                                   "client's fallback sentence", _preset, e)
         # A reconnect carries Last-Event-ID (the last Stream cursor the client rendered). On resume we
         # DON'T re-dispatch — we re-attach to the existing warm unit and read from the cursor onward.
         resume = request.headers.get("last-event-id") or None

--- a/core/agent/control_plane/chat_intents.py
+++ b/core/agent/control_plane/chat_intents.py
@@ -1,0 +1,65 @@
+"""chat_intents.py — a button pressed on a page → the preset that turn runs (PRD decision 32/35).
+
+The terminal sends a small typed record beside the prompt (`surfaces/chatIntent.ts`); this is the
+server half. It maps the intent's KIND to a preset name in `_global/asks/` and supplies the tokens
+that preset substitutes. Nothing here composes text: the words live in the admin-owned preset file,
+for the same reason a scaffold's opening is a NAME and never a string — anyone able to make the
+client send an intent would otherwise be able to drive the recipient's agent.
+
+Pure, and its own module, because the mapping is the part worth testing and the route it is called
+from needs a running app to exercise.
+
+⚠ THE CLIENT'S FALLBACK SENTENCE ALWAYS TRAVELS TOO (`minutes/extend.ts` — `fallbackText`). When a
+preset is missing this returns None, the route leaves `prompt` alone, and the turn still does the
+right thing in plainer words. A missing preset must degrade, never 500: the preset library is admin
+content and a deployment can legitimately be behind the client.
+"""
+from __future__ import annotations
+
+# The closed set. A kind outside it is ignored rather than guessed into a preset name — an intent is
+# attacker-reachable in exactly the way a scaffold's `opening` is, and `read_preset` refuses a path
+# only because nothing ever hands it one.
+INTENT_PRESETS: dict[str, str] = {
+    "extend": "extend",        # decision 32.2 — go further on the open page / a selection
+    "create": "create",        # decision 32.4 — write the page that is not there yet
+    "explore": "explore",      # decision 35.3 — a chip in a transcript: find out what this is
+    "highlight": "highlight",  # decision 35.2 — publish the terms worth chipping, silently
+}
+
+# Kinds whose turn the person must NOT see as a bubble. `highlight` is machinery end to end: the
+# founder's correction is that pressing the button "silently" requests the terms — a visible
+# "Highlight: …" bubble in the conversation would be the product narrating its own plumbing, which
+# is the failure MACHINERY_MARK exists to stop one layer up.
+SILENT_KINDS = frozenset({"highlight"})
+
+
+def preset_for(intent) -> str | None:
+    """The preset name this intent runs, or None when there is nothing safe to run."""
+    if not isinstance(intent, dict):
+        return None
+    return INTENT_PRESETS.get(str(intent.get("kind") or "").strip().lower())
+
+
+def tokens_for(intent) -> dict:
+    """`{{token}}` values for the preset body.
+
+    Every value is a plain string and every absent one is "" rather than the word None — an unknown
+    token is left standing by `substitute` so an admin sees their typo, but a token that IS known
+    and empty must render as nothing, not as the literal `None` the founder would then read in his
+    own chat."""
+    d = intent if isinstance(intent, dict) else {}
+
+    def s(key: str) -> str:
+        v = d.get(key)
+        return "" if v is None else str(v)
+
+    return {
+        "kind": s("kind"),
+        "path": s("path"),
+        "workspace": s("workspace"),
+        "selection": s("selection"),
+        "term": s("term"),
+        "meeting": s("meeting"),
+        "segment": s("segment"),
+        "since": s("since"),
+    }

--- a/core/agent/eval/terms_fixture.py
+++ b/core/agent/eval/terms_fixture.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""terms_fixture.py — run decision 35's term extractor over a whole real transcript, offline.
+
+    uv run python eval/terms_fixture.py ~/dna-fixtures/2026-03-02.transcript.json [<workspace dir>…]
+
+WHY AN OFFLINE RUNNER AND NOT ONLY UNIT TESTS. The unit tests prove the rules on three-segment
+inputs; they cannot tell you whether the thing is USABLE on a 677-segment meeting — whether it
+returns forty terms or four hundred, whether it takes a millisecond or a second (it runs on every
+Highlight press, inside a turn a person is waiting on), and how many of what it finds already have
+pages. Those are product questions and only a real transcript answers them.
+
+Reads a fixture and workspace directories; writes nothing, calls nothing, needs no stack. Fixtures
+are private and live outside the repo, so the path is an argument and there is no default.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from shared.terms import extract_terms, index_entries, match_known  # noqa: E402
+
+
+def load(path: Path) -> list[dict]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    segs = raw.get("segments", raw) if isinstance(raw, dict) else raw
+    return [{"id": i, "at": s.get("t"), "text": s.get("text") or ""} for i, s in enumerate(segs)]
+
+
+def index_for(dirs: list[Path]) -> list[dict]:
+    out: list[dict] = []
+    for d in dirs:
+        files = [str(f.relative_to(d)) for f in d.rglob("*.md")]
+        out += index_entries(d.name, d.name, files)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__.strip())
+        return 2
+    fixture = Path(argv[1]).expanduser()
+    segments = load(fixture)
+    index = index_for([Path(p).expanduser() for p in argv[2:]])
+
+    t0 = time.perf_counter()
+    rows = match_known(extract_terms(segments), index)
+    ms = (time.perf_counter() - t0) * 1000
+
+    known = [r for r in rows if r["known"]]
+    print(f"fixture        {fixture.name}")
+    print(f"segments       {len(segments)}")
+    print(f"index          {len(index)} entity pages across {len(argv) - 2} workspace(s)")
+    print(f"terms          {len(rows)}")
+    print(f"  known        {len(known)}")
+    print(f"  unknown      {len(rows) - len(known)}")
+    print(f"time           {ms:.1f} ms")
+    print()
+    for r in rows[:25]:
+        mark = "●" if r["known"] else "○"
+        print(f"  {mark} {r['term']}  ({len(r['segments'])} segment(s), first at {r['first_at']})")
+    if len(rows) > 25:
+        print(f"  … {len(rows) - 25} more")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/core/agent/llm/claude_code.py
+++ b/core/agent/llm/claude_code.py
@@ -34,6 +34,50 @@ _WRITER_TOOLS = frozenset({
 })
 
 
+# THE TRANSCRIPT-TERM PUBLISH (PRD decision 35). `transcript_terms` is the only tool whose SUCCESS
+# is meant to paint something on the meeting view, so it is the only one whose RESULT BODY is read
+# here rather than summarised. A closed vocabulary for the same reason `_WRITER_TOOLS` is one: a
+# prefix match would let any future tool ending in `_terms` drive somebody's transcript.
+_TERMS_TOOLS = frozenset({
+    "mcp__vexa__transcript_terms",
+    "transcript_terms",
+})
+
+
+def _tool_result_text(content: object) -> str:
+    """The tool result as one string, whichever shape the harness handed it in.
+
+    Claude Code emits a tool result either as a bare string or as a list of content blocks; both
+    reach here, and a reader that handles only one of them fails SILENTLY on the other — which for
+    this seam means chips that simply never appear and nothing anywhere saying why."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(b.get("text", "") for b in content
+                       if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+
+
+def _published_terms(content: object) -> "dict | None":
+    """The `terms` event a `transcript_terms` result asks for, or None.
+
+    ONLY WHEN THE AGENT PUBLISHED. The tool answers a bare look-up call with ``emit: []`` — that
+    call was the agent reading the room, and painting its raw output would put every capitalised
+    word in the meeting on the person's screen. An empty publish is a NON-EVENT rather than an empty
+    event: an empty event would clear the chips the previous Highlight put there."""
+    try:
+        obj = json.loads(_tool_result_text(content))
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    emit = obj.get("emit")
+    if not isinstance(emit, list) or not emit:
+        return None
+    return {"type": "terms", "meeting": str(obj.get("meeting") or ""),
+            "cursor": str(obj.get("cursor") or ""), "terms": emit}
+
+
 def _written_artifact(tool: str, args: dict) -> "tuple[str, str] | None":
     """`(workspace, path)` the call is about to write, or None. Read off the ARGUMENTS, at tool-use
     time, because the result carries only a summary string.
@@ -79,6 +123,10 @@ def parse_stream_json(lines: Iterable[str]) -> Iterator[dict]:
     # callId -> (workspace, path) for writes still in flight. Per-stream, so a call id can never
     # collide across turns, and popped on the matching result so nothing accumulates.
     pending_writes: dict[str, tuple[str, str]] = {}
+    # callIds of `transcript_terms` calls still in flight — the same per-stream,
+    # popped-on-result discipline as `pending_writes`, so one turn's result can never be
+    # matched to another call's id.
+    pending_terms: set[str] = set()
     for raw in lines:
         raw = raw.strip()
         if not raw:
@@ -115,6 +163,8 @@ def parse_stream_json(lines: Iterable[str]) -> Iterator[dict]:
                         target = _written_artifact(tool_name, block.get("input", {}) or {})
                         if target:
                             pending_writes[call_id] = target
+                    elif tool_name in _TERMS_TOOLS:
+                        pending_terms.add(call_id)
                     yield {
                         "type": "tool-call",
                         "tool": tool_name,
@@ -136,6 +186,14 @@ def parse_stream_json(lines: Iterable[str]) -> Iterator[dict]:
                     # and a tab on a path that does not exist is exactly the "page that can never
                     # load" this stream is careful about elsewhere. `pop` either way, so a failed
                     # call cannot leave an entry that a later, unrelated result matches.
+                    # THE CHIPS (decision 35). Same success-only rule as the artifact below:
+                    # a failed read must not paint a transcript.
+                    was_terms = call_id in pending_terms
+                    pending_terms.discard(call_id)
+                    if was_terms and ok:
+                        ev = _published_terms(block.get("content"))
+                        if ev:
+                            yield ev
                     target = pending_writes.pop(call_id, None)
                     if target and ok:
                         workspace, path = target

--- a/core/agent/shared/terms.py
+++ b/core/agent/shared/terms.py
@@ -1,0 +1,203 @@
+"""terms.py — the words a meeting said that are worth a chip, and which of them already have a page.
+
+PRD decision 35 (founder, 2026-09-02): *"an mcp tool that will take the current transcript and list
+words that should be highlighted and clickable like all the things we have in the docs and chat…
+click on a thing and it's dropped into the chat as a research drop — similar to deepen etc — just to
+find out what that is."*
+
+MECHANICAL, AND THAT IS THE WHOLE DESIGN. No model call happens in here. The extractor is
+``entities.candidate_names`` — the SAME proxy the write-back phase already uses to decide "a name
+went past and nothing was created" (decision 24.3) — so a term a chip offers and a page the
+write-back phase would write are the same population by construction. Two extractors would have
+drifted the first time either was tuned, and the drift would have shown up as a chip that opens
+nothing.
+
+``known`` is answered by the ENTITY INDEX of the reader's mounted workspaces, not by a search: the
+question is "does a page for this exist where this reader can read it", and the index is exactly
+that set. A term matched against someone else's workspace would render a solid chip that 404s for
+the person looking at it.
+
+Deliberately a PURE FUNCTION OVER PLAIN DICTS — no HTTP, no redis, no filesystem — for the same
+reason ``entities.py`` is: the control-MCP tool composes it out of reads it already makes, agent-api
+can mount it unchanged if a route is ever wanted, and the whole thing is offline-provable against a
+transcript fixture.
+
+⚠ SEGMENT IDS ARE THE CALLER'S VOCABULARY. Whatever the caller puts in ``id`` comes back in
+``segments`` untouched. The gateway's transcript rows and the terminal's live SSE segments do NOT
+share an id space, so nothing here may assume one: the client re-finds a term in the text it is
+rendering (the ``splitTextIntoSpans`` precedent) and uses its own ids. These are provenance for the
+agent, and a cursor for the next call — never a join key across two readers.
+"""
+from __future__ import annotations
+
+from shared.entities import KINDS, candidate_names, slugify
+
+# `kg/entities/<kind>/<stem>.md` — the one shape `entity_upsert` writes and the one shape this
+# reads. Anything else in the tree is not an entity page, however much it looks like one.
+ENTITIES_PREFIX = "kg/entities/"
+
+# ⚠ MEASURED ON A REAL MEETING, and the reason this layer exists at all.
+#
+# `candidate_names` was tuned on written NOTES and is right there. Run over the 677 segments of the
+# DNA TSC transcript of 2026-03-02 it returned 28 candidates, of which EIGHT were artefacts of
+# SPEECH rather than names: "But I'll", "So I'm", "Like I've", "So Cameron", "That's John",
+# "And Tommy", "On DNA", "Our TAC". Every one is the same shape — a sentence opens with a
+# capitalised function word, the next word is also capitalised, and two capitalised words in a row
+# is exactly what the extractor is looking for. Prose does not begin sentences that way; people do,
+# constantly, and a transcript is nothing but sentence openings.
+#
+# So the lead is stripped HERE and not in `candidate_names`: that function's behaviour is measured
+# against the write-back phase's own numbers (decision 24.4), and quietly changing it to suit a
+# different corpus would move a metric nobody was watching. This is the transcript's own correction,
+# named as such.
+#
+# THE TRADE, STATED: "On Semiconductor" and "Our World in Data" lose their first word and then fall
+# to the two-word floor, so they never become chips. That is one chip missed against eight junk
+# chips on a single meeting — and a junk chip is not neutral, it is an invitation to research
+# "But I'll".
+_LEADING_NOISE = frozenset({
+    # sentence openers
+    "so", "but", "and", "also", "then", "now", "well", "actually", "just", "right", "okay", "ok",
+    "yeah", "yes", "no", "oh", "plus", "or", "if", "when", "while", "because", "though", "although",
+    "like", "maybe", "anyway", "basically", "honestly", "obviously",
+    # demonstratives and possessives that read as part of a name
+    "that", "that's", "this", "these", "those", "the", "a", "an",
+    "our", "your", "their", "his", "her", "its", "my",
+    # pronouns and their contractions — "But I'll" survives the opener strip as "I'll"
+    "i", "i'll", "i'm", "i've", "i'd", "we", "we'll", "we're", "we've", "they", "they'll",
+    "they're", "they've", "he", "he's", "she", "she's", "it", "it's", "you", "you'll", "you're",
+    "you've",
+    # prepositions that open a clause
+    "on", "in", "at", "for", "to", "with", "from", "by", "as", "of", "about", "into", "over",
+})
+
+
+def _strip_lead(name: str) -> str:
+    """Drop leading noise words until the first real one, then hold the two-word floor.
+
+    Repeated rather than single-pass: "And so Cameron" is one utterance and two noise words. What is
+    left has to still be a NAME — one word is not, by the extractor's own rule (see the header of
+    `extract_terms`) — so a stripped candidate that shrinks to a single word is dropped entirely
+    rather than admitted through a back door the two-word floor was closed against."""
+    parts = name.split()
+    while parts and parts[0].lower() in _LEADING_NOISE:
+        parts = parts[1:]
+    return " ".join(parts) if len(parts) >= 2 else ""
+
+
+def extract_terms(segments) -> list[dict]:
+    """The proper names these segments said, in order of first appearance, each with where it was said.
+
+    ``segments`` is any iterable of ``{"id": …, "text": …, "at": …}`` — ``id`` and ``at`` are opaque
+    and echoed back; only ``text`` is read.
+
+    A name that is a PREFIX of a longer one MERGES INTO IT rather than being dropped. ``entities``
+    drops it, and is right to for its purpose (it is choosing which page to write, and the longer
+    spelling is the page). Here the short spelling is a real occurrence in a real line: "James" at
+    minute two and "James Spadafora" at minute nine are one chip and BOTH lines. Dropping the early
+    segment would silently make the chip's provenance start nine minutes after the person did.
+    """
+    order: list[str] = []
+    seen: dict[str, dict] = {}
+    for seg in segments or []:
+        text = str((seg or {}).get("text") or "")
+        if not text.strip():
+            continue
+        sid = (seg or {}).get("id")
+        at = (seg or {}).get("at")
+        for raw in candidate_names(text, mask_linked=False):
+            name = _strip_lead(raw)
+            if not name:
+                continue
+            row = seen.get(name)
+            if row is None:
+                row = {"term": name, "segments": [], "first_at": at}
+                seen[name] = row
+                order.append(name)
+            if sid is not None and sid not in row["segments"]:
+                row["segments"].append(sid)
+    return _merge_prefixes([seen[n] for n in order])
+
+
+def _merge_prefixes(rows: list[dict]) -> list[dict]:
+    """Fold each row whose term is a strict prefix of another row's term into that longer row.
+
+    The trade `entities._drop_prefixes` states holds here too — "John Smith" beside "John Smithson"
+    is folded wrongly and no lexical rule can tell those apart. It costs one chip; the alternative
+    is two chips for one person, one of which opens a page that will never exist."""
+    terms = [r["term"] for r in rows]
+    out: list[dict] = []
+    for row in rows:
+        # The LONGEST match, not the first: with "James" ⊂ "James Spad" ⊂ "James Spadafora" a
+        # first-match fold would put "James" onto a row that is itself folded away, and its
+        # sightings would vanish with it. Folding straight onto the longest spelling makes the
+        # chain flat and the operation order-independent.
+        cands = [t for t in terms if t != row["term"] and t.startswith(row["term"])]
+        longer = max(cands, key=len) if cands else None
+        if longer is None:
+            out.append(row)
+            continue
+        host = next(r for r in rows if r["term"] == longer)
+        for sid in row["segments"]:
+            if sid not in host["segments"]:
+                host["segments"].append(sid)
+        # The host inherits the EARLIER first sighting — it is the same thing, first said then.
+        if host["first_at"] is None or (row["first_at"] is not None and str(row["first_at"]) < str(host["first_at"])):
+            host["first_at"] = row["first_at"]
+    # `segments` may now be out of the order they were said in (a fold appends). Sorting is not
+    # possible — the ids are opaque — so re-derive order from the ROWS' own order instead: the host
+    # keeps its own sightings first, which is the order it saw them.
+    return out
+
+
+def index_entries(workspace_id: str, slug: str, files) -> list[dict]:
+    """Every entity page in one workspace's file list, as index rows.
+
+    Reads the TREE, never `kg/INDEX.md`: the index is regenerated after a write and can be one write
+    behind, and a stale index means a chip that says "no page yet" about a page the agent wrote
+    thirty seconds ago — the exact failure `entities.known_slugs` refuses for the same reason."""
+    out: list[dict] = []
+    for raw in files or []:
+        rel = str(raw or "").strip().lstrip("/")
+        if not rel.startswith(ENTITIES_PREFIX) or not rel.endswith(".md"):
+            continue
+        rest = rel[len(ENTITIES_PREFIX):]
+        parts = rest.split("/")
+        if len(parts) != 2:
+            continue
+        kind, fname = parts
+        if kind not in KINDS:
+            continue
+        stem = fname[:-3]
+        if not stem or stem == "index":
+            continue
+        out.append({"workspace_id": workspace_id, "slug": slug, "entity_id": stem,
+                    "kind": kind, "path": rel})
+    return out
+
+
+def match_known(terms, index) -> list[dict]:
+    """Attach ``known`` (and ``kind`` when the page says one) to each term. Order of ``index`` IS the
+    precedence: the caller lists the desk first, then `_global`, then groups, so a name a person has
+    written about on their own desk resolves to THEIR page rather than to a namesake in a group."""
+    by_slug: dict[str, dict] = {}
+    for entry in index or []:
+        key = str(entry.get("entity_id") or "")
+        if key and key not in by_slug:
+            by_slug[key] = entry
+    out: list[dict] = []
+    for row in terms or []:
+        hit = by_slug.get(slugify(row.get("term", "")))
+        item = {"term": row.get("term"), "segments": list(row.get("segments") or []),
+                "first_at": row.get("first_at"),
+                "known": ({"workspace_id": hit.get("workspace_id"), "entity_id": hit.get("entity_id"),
+                           "path": hit.get("path")} if hit else None)}
+        if hit and hit.get("kind"):
+            item["kind"] = hit["kind"]
+        out.append(item)
+    return out
+
+
+def terms_for(segments, index) -> list[dict]:
+    """The whole thing: what was said → what has a page. The one entry point a caller needs."""
+    return match_known(extract_terms(segments), index)

--- a/core/agent/tests/test_chat_intents.py
+++ b/core/agent/tests/test_chat_intents.py
@@ -1,0 +1,45 @@
+"""PRD decisions 32/35, server half — a button press becomes an admin-owned preset, or nothing.
+
+The rule under test is the same one scaffolds enforce: the WIRE carries a kind and its arguments,
+the WORDS live in `_global/asks/`. Anything else means whoever can make a client send an intent can
+drive the recipient's agent.
+"""
+from __future__ import annotations
+
+from control_plane.chat_intents import INTENT_PRESETS, SILENT_KINDS, preset_for, tokens_for
+
+
+def test_every_known_kind_maps_to_a_preset_name_and_nothing_else_does():
+    for kind, name in INTENT_PRESETS.items():
+        assert preset_for({"kind": kind}) == name
+    assert preset_for({"kind": "rm -rf"}) is None
+    assert preset_for({"kind": "../../etc/passwd"}) is None
+    assert preset_for({"kind": ""}) is None
+    assert preset_for({}) is None
+    assert preset_for(None) is None
+    assert preset_for("explore") is None
+
+
+def test_a_kind_is_matched_case_and_space_insensitively():
+    assert preset_for({"kind": " Explore "}) == "explore"
+
+
+def test_highlight_is_the_silent_one():
+    """The founder's correction: pressing Highlight "silently" requests the terms. A visible bubble
+    would be the product narrating its own plumbing to somebody who pressed a button."""
+    assert SILENT_KINDS == frozenset({"highlight"})
+    assert "explore" not in SILENT_KINDS
+
+
+def test_the_tokens_are_the_intents_own_fields_as_plain_strings():
+    t = tokens_for({"kind": "explore", "term": "Kaar Tech", "meeting": "41", "segment": "s7"})
+    assert t["term"] == "Kaar Tech" and t["meeting"] == "41" and t["segment"] == "s7"
+
+
+def test_an_absent_value_renders_as_nothing_never_as_the_word_None():
+    """`substitute` leaves an UNKNOWN token standing so an admin sees their typo. A token that is
+    known and empty must render as nothing — otherwise the founder reads the literal `None` in his
+    own chat, which is the placeholder-spoken-with-confidence failure one layer down."""
+    t = tokens_for({"kind": "highlight", "meeting": "41"})
+    assert t["since"] == "" and t["term"] == "" and t["path"] == ""
+    assert "None" not in "".join(t.values())

--- a/core/agent/tests/test_transcript_terms.py
+++ b/core/agent/tests/test_transcript_terms.py
@@ -1,0 +1,205 @@
+"""PRD decision 35 — the live transcript is a surface: terms highlighted, clickable, explorable.
+
+Three things are proven here and they are the three things that can silently be wrong:
+
+  * the EXTRACTOR finds the names a room said, folds the short spellings into the long ones without
+    losing where the short one was said, and stays the same population `entity_upsert` writes;
+  * the INDEX MATCH answers `known` from the workspaces THIS reader can open, desk first — a chip
+    that resolves to a namesake in someone else's group is a chip that 404s for the person clicking;
+  * the PUBLISH is the agent's second call, so a bare look-up paints nothing on anybody's screen.
+"""
+from __future__ import annotations
+
+import json
+
+from llm.claude_code import _published_terms, _TERMS_TOOLS, parse_stream_json
+from shared.terms import extract_terms, index_entries, match_known, terms_for
+
+
+def seg(i, text, at=None):
+    return {"id": i, "text": text, "at": at if at is not None else f"2026-09-02T10:0{i}:00Z"}
+
+
+# ── the extractor ────────────────────────────────────────────────────────────────────────────────
+
+def test_it_finds_the_names_a_room_said_in_the_order_they_were_said():
+    rows = extract_terms([
+        seg(1, "Kaar Tech came back on the pricing."),
+        seg(2, "Cottalango Leon is the one who signs it."),
+    ])
+    assert [r["term"] for r in rows] == ["Kaar Tech", "Cottalango Leon"]
+    assert rows[0]["segments"] == [1]
+    assert rows[0]["first_at"] == "2026-09-02T10:01:00Z"
+
+
+def test_one_name_said_twice_is_one_term_carrying_both_lines():
+    rows = extract_terms([seg(1, "Kaar Tech asked."), seg(2, "I told Kaar Tech no.")])
+    assert len(rows) == 1
+    assert rows[0]["segments"] == [1, 2]
+
+
+def test_a_single_word_name_is_not_a_term_and_that_is_the_extractor_we_chose():
+    """⚠ A REAL LIMIT, stated rather than worked around. `candidate_names` requires two capitalised
+    words — measured, over ten real DNA notes, as the rule that stops "Complete SSO" and "Await PR"
+    becoming pages. So "Anthropic" or "Helm", said alone, never becomes a chip.
+
+    We take that deliberately: the chips are the SAME population decision 24 writes pages for, and a
+    second extractor tuned for chips would drift from the one tuned for pages the first time either
+    moved — and the drift would show as a chip that opens a page nothing will ever write."""
+    assert extract_terms([seg(1, "Helm shipped on Monday.")]) == []
+
+
+def test_a_short_spelling_folds_into_the_long_one_and_keeps_its_line():
+    """`entities._drop_prefixes` DROPS the short spelling — right for choosing which page to write,
+    wrong here: the short one is a real occurrence in a real line, and dropping the segment would
+    make the chip's provenance start after the person did."""
+    rows = extract_terms([seg(1, "James Spad said so."), seg(2, "James Spadafora confirmed it.")])
+    assert [r["term"] for r in rows] == ["James Spadafora"]
+    assert rows[0]["segments"] == [2, 1]
+    # the earlier sighting wins the timestamp — it IS when the thing was first named
+    assert rows[0]["first_at"] == "2026-09-02T10:01:00Z"
+
+
+def test_a_chain_of_prefixes_folds_onto_the_longest_not_onto_the_next_one_up():
+    """A first-match fold would put "James" onto "James Spad", which is itself folded away — and its
+    line would vanish with it. The bug is invisible from the output shape; only the count shows it."""
+    rows = extract_terms([seg(1, "James Spa is here."), seg(2, "James Spad is here."),
+                          seg(3, "James Spadafora is here.")])
+    assert [r["term"] for r in rows] == ["James Spadafora"]
+    assert sorted(rows[0]["segments"]) == [1, 2, 3]
+
+
+def test_an_empty_room_is_no_terms_not_an_error():
+    assert extract_terms([]) == []
+    assert extract_terms([seg(1, "   "), {"id": 2}]) == []
+
+
+def test_a_sentence_opener_is_not_part_of_a_name():
+    """⚠ THE MEASURED ONE. Over the 677 segments of the DNA TSC transcript of 2026-03-02 the
+    notes-tuned extractor returned 28 candidates and EIGHT were speech, not names: "But I'll",
+    "So I'm", "Like I've", "So Cameron", "That's John", "And Tommy", "On DNA", "Our TAC". Prose does
+    not open sentences with a capitalised function word; a transcript is nothing but sentence
+    openings. Stripping the lead took the same meeting to 18 candidates, none of that shape."""
+    said = ["But I'll take it.", "So I'm on it.", "Like I've said.", "So Cameron agreed.",
+            "That's John's call.", "And Tommy will do it.", "On DNA we agreed.", "Our TAC met."]
+    assert extract_terms([seg(i, t) for i, t in enumerate(said)]) == []
+
+
+def test_stripping_the_lead_still_finds_the_name_behind_it():
+    rows = extract_terms([seg(1, "So Academy Software Foundation agreed.")])
+    assert [r["term"] for r in rows] == ["Academy Software Foundation"]
+
+
+def test_the_two_word_floor_holds_after_a_strip():
+    """A stripped candidate that shrinks to one word is DROPPED, not admitted: the floor is the
+    extractor's own rule and a back door through this path would be the same defect twice."""
+    assert extract_terms([seg(1, "So Cameron agreed.")]) == []
+
+
+# ── the index ────────────────────────────────────────────────────────────────────────────────────
+
+def test_the_index_reads_entity_pages_and_nothing_else():
+    rows = index_entries("w-desk", "", [
+        "kg/entities/company/kaar-tech.md",
+        "kg/entities/person/cottalango-leon.md",
+        "kg/entities/company/index.md",          # the generated listing is not an entity
+        "kg/templates/person.md",                # a SHAPE is not a record
+        "kg/entities/spaceship/x.md",            # not one of the five kinds
+        "kg/entities/company/nested/deep.md",    # not the one shape entity_upsert writes
+        "README.md",
+    ])
+    assert [(r["entity_id"], r["kind"]) for r in rows] == [
+        ("kaar-tech", "company"), ("cottalango-leon", "person")]
+    assert rows[0]["workspace_id"] == "w-desk"
+    assert rows[0]["path"] == "kg/entities/company/kaar-tech.md"
+
+
+def test_a_term_with_a_page_is_known_and_carries_its_kind():
+    index = index_entries("w-desk", "", ["kg/entities/company/kaar-tech.md"])
+    rows = match_known(extract_terms([seg(1, "Kaar Tech came back.")]), index)
+    assert rows[0]["known"] == {"workspace_id": "w-desk", "entity_id": "kaar-tech",
+                                "path": "kg/entities/company/kaar-tech.md"}
+    assert rows[0]["kind"] == "company"
+
+
+def test_a_term_with_no_page_anywhere_is_known_null_and_carries_no_kind():
+    rows = match_known(extract_terms([seg(1, "Kaar Tech came back.")]), [])
+    assert rows[0]["known"] is None
+    assert "kind" not in rows[0]
+
+
+def test_the_desk_wins_a_namesake_in_a_group_because_the_caller_lists_it_first():
+    """Order of the index IS precedence, and the tool builds it desk → `_global` → groups. A person
+    who has written about Helm on their own desk must open THEIR page, not a group's."""
+    index = (index_entries("w-desk", "", ["kg/entities/company/helm-deploy.md"])
+             + index_entries("w-group", "acme", ["kg/entities/project/helm-deploy.md"]))
+    rows = terms_for([seg(1, "Helm Deploy shipped.")], index)
+    assert rows[0]["known"]["workspace_id"] == "w-desk"
+    assert rows[0]["kind"] == "company"
+
+
+def test_a_page_in_a_workspace_this_reader_cannot_open_is_simply_not_in_the_index():
+    """Decision 26.3 — "not yours" is an ANSWER, not an error. The tool skips a mount it cannot
+    list, so the term comes back unknown and the chip offers to find out. Nothing 404s."""
+    assert terms_for([seg(1, "Helm Deploy shipped.")], [])[0]["known"] is None
+
+
+# ── the publish (the harness seam) ───────────────────────────────────────────────────────────────
+
+def _use(tool, cid="c1"):
+    return json.dumps({"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": tool, "input": {}, "id": cid}]}})
+
+
+def _result(payload, cid="c1", err=False, as_blocks=True):
+    body = json.dumps(payload) if not isinstance(payload, str) else payload
+    content = [{"type": "text", "text": body}] if as_blocks else body
+    return json.dumps({"type": "user", "message": {"content": [
+        {"type": "tool_result", "tool_use_id": cid, "is_error": err, "content": content}]}})
+
+
+LOOKED = {"meeting": "41", "cursor": "c9", "terms": [{"term": "Kaar Tech", "known": None}], "emit": []}
+PUBLISHED = {"meeting": "41", "cursor": "c9", "emit": [{"term": "Kaar Tech", "known": None}]}
+
+
+def test_a_bare_lookup_publishes_nothing():
+    """The agent's FIRST call reads the room. Painting its raw output would put every capitalised
+    word in the meeting on the person's screen — which is the whole reason `keep` exists."""
+    evs = list(parse_stream_json(iter([_use("mcp__vexa__transcript_terms"), _result(LOOKED)])))
+    assert not [e for e in evs if e["type"] == "terms"]
+
+
+def test_the_publish_emits_the_terms_event_after_its_result():
+    evs = list(parse_stream_json(iter([_use("mcp__vexa__transcript_terms"), _result(PUBLISHED)])))
+    terms = [e for e in evs if e["type"] == "terms"]
+    assert terms == [{"type": "terms", "meeting": "41", "cursor": "c9",
+                      "terms": [{"term": "Kaar Tech", "known": None}]}]
+    kinds = [e["type"] for e in evs]
+    assert kinds.index("tool-result") < kinds.index("terms")
+
+
+def test_a_failed_call_paints_nothing():
+    evs = list(parse_stream_json(iter([_use("mcp__vexa__transcript_terms"),
+                                       _result(PUBLISHED, err=True)])))
+    assert not [e for e in evs if e["type"] == "terms"]
+
+
+def test_the_result_is_read_whether_it_arrives_as_a_string_or_as_blocks():
+    """Claude Code emits a tool result in both shapes. A reader that handles one fails SILENTLY on
+    the other, and the symptom is chips that never appear with nothing anywhere saying why."""
+    for as_blocks in (True, False):
+        evs = list(parse_stream_json(iter([_use("transcript_terms"),
+                                           _result(PUBLISHED, as_blocks=as_blocks)])))
+        assert [e["type"] for e in evs].count("terms") == 1, as_blocks
+
+
+def test_another_tools_result_is_never_read_as_a_publish():
+    evs = list(parse_stream_json(iter([_use("mcp__vexa__meeting_transcript"), _result(PUBLISHED)])))
+    assert not [e for e in evs if e["type"] == "terms"]
+    assert "mcp__vexa__meeting_transcript" not in _TERMS_TOOLS
+
+
+def test_a_result_that_is_not_json_is_not_a_crash():
+    assert _published_terms("could not read the transcript") is None
+    assert _published_terms(None) is None
+    assert _published_terms(json.dumps({"emit": "everything"})) is None

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -933,6 +933,10 @@ VEXA_MCP_TOOLS = (
     # rather than left to the prefix because the write-back phase is only as reliable
     # as the tool being present without a search step (see the deferral note above).
     "entity_upsert",
+    # decision 35: the transcript's chips. Named for the same reason `entity_upsert` is — the
+    # `highlight` preset's whole turn is two calls to this one tool, and a turn that has to search
+    # for its only verb is a turn that answers with an apology.
+    "transcript_terms",
 )
 
 

--- a/deploy/dogfood/asks/explore.md
+++ b/deploy/dogfood/asks/explore.md
@@ -1,0 +1,22 @@
+---
+label: explore
+mounts: personal, _global
+---
+[explore] They clicked **{{term}}** in the transcript of meeting {{meeting}} (segment {{segment}}).
+They want to know what it is. Nothing else.
+
+Find out, in the logic of THIS chat and THIS meeting — not in general. The workspace first: read what
+it already holds about it (`kg/entities/`, the meeting's own page, anything that links to it). Only
+where the workspace runs out do you go to the web, and then for this specific thing, not for a
+survey of the topic.
+
+Write its page with `entity_upsert` — kind, name, what you found, each fact with its source. That
+page is the deliverable; the chip in the transcript turns solid the moment it exists. If the meeting
+gave you the meaning and the web adds nothing, the page is short and that is correct.
+
+Then say what it is in TWO LINES. Not a summary of your research and not what you did — what the
+thing is, and why it came up here. If you genuinely could not tell, say that in one line instead and
+leave the page unwritten rather than filling it with a guess: a page carries only what was said or
+read, with its source.
+
+No preamble, no "I looked into it", no offer to dig further.

--- a/deploy/dogfood/asks/highlight.md
+++ b/deploy/dogfood/asks/highlight.md
@@ -1,0 +1,19 @@
+---
+label: highlight
+mounts: personal, _global
+---
+[highlight] They pressed Highlight on the transcript of meeting {{meeting}}. This is MACHINERY: they
+are not asking you a question and they will not see a reply. Do not write to them.
+
+1. Call `transcript_terms(meeting_id="{{meeting}}", since="{{since}}")`. It returns every proper name
+   the room has said since that cursor, each with whether a page for it already exists.
+2. Decide which of them are worth putting on the person's screen — the ones that matter to THIS
+   person in THIS meeting. A company in the deal, a person nobody holds a page on, a product or a
+   project that was named as a thing to do. Not every capitalised word: not a greeting, not a day of
+   the week, not a place mentioned in passing, not a term already chipped before this cursor.
+3. Publish exactly those: call it again with `keep="<term>, <term>"`. That call is what paints them.
+   Use `keep="*"` only when genuinely all of them matter.
+4. If none of them do, publish nothing and stop. An empty Highlight is a correct answer.
+
+Then stop. No message, no summary, no "I've highlighted five terms". The chips ARE the output, and a
+sentence about them is the product narrating its own plumbing to somebody who pressed a button.

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -3538,6 +3538,168 @@ def meeting_transcript(meeting_url: str = "", tail: int = 80, since: str = "",
                        "transcript": lines})
 
 
+
+
+# ── the transcript as a clickable surface (PRD decision 35) ───────────────────────────────────────
+#
+# `shared/terms.py` + `shared/entities.py` are PURE and stdlib-only, so the rig imports them from the
+# checkout it is served out of rather than re-implementing the extractor here. Two extractors would
+# drift the first time either was tuned, and the drift would show up as a chip that opens nothing.
+# `VEXA_AGENT_SRC` names the tree, the same way `VEXA_FLOWS_SRC` names the flows engine; the default
+# is this file's own repo, so an unconfigured rig works.
+AGENT_SRC = os.environ.get("VEXA_AGENT_SRC") or str(pathlib.Path(__file__).resolve().parents[3] / "core" / "agent")
+
+
+def _terms_mod():
+    import sys
+    if AGENT_SRC not in sys.path:
+        sys.path.insert(0, AGENT_SRC)
+    from shared import terms as _t  # noqa: PLC0415 — a deployment input, not an import-time dep
+    return _t
+
+
+# The index is several HTTP reads (the active set, then one tree per mount); the terms themselves are
+# a regex pass. Both are cached, separately, because they go stale at completely different rates: a
+# workspace grows a page every few minutes, a live transcript grows a line every few seconds.
+_TERMS_CACHE: dict = {}
+_INDEX_CACHE: dict = {}
+_TERMS_TTL = 5.0
+_INDEX_TTL = 20.0
+
+
+def _cached(store: dict, key, ttl: float):
+    hit = store.get(key)
+    if hit and (time.time() - hit[0]) < ttl:
+        return hit[1]
+    return None
+
+
+def _entity_index(uid: str) -> list:
+    """Every entity page the CALLER can read, desk first, then `_global`, then their groups.
+
+    ORDER IS PRECEDENCE (`match_known` takes the first hit): a name this person has written about on
+    their own desk resolves to THEIR page, never to a namesake in a group they happen to be in."""
+    cached = _cached(_INDEX_CACHE, uid, _INDEX_TTL)
+    if cached is not None:
+        return cached
+    mod = _terms_mod()
+    slugs: list = [""]                      # "" = their own desk (a no-slug read)
+    st, act = _http("GET", f"{AGENT_API}/api/workspace/active", {"X-User-Id": uid})
+    if st == 200:
+        for m in (act or {}).get("active") or []:
+            s = str(m.get("slug") or "").strip()
+            if s and s not in slugs:
+                slugs.append(s)
+    if "_global" not in slugs:
+        slugs.append("_global")             # the company layer is mounted on every dispatch
+    index: list = []
+    for slug in slugs:
+        q = f"?slug={urllib.parse.quote(slug)}" if slug else ""
+        st, body = _http("GET", f"{AGENT_API}/api/workspace/tree{q}", {"X-User-Id": uid})
+        if st != 200:
+            continue                        # a mount this reader cannot list is not an error (decision 26.3)
+        files = (body or {}).get("files") or []
+        wsid = slug
+        ist, ib = _http("GET", f"{AGENT_API}/api/workspaces/by-slug/{urllib.parse.quote(slug or uid)}",
+                        {"X-User-Id": uid})
+        if ist == 200 and isinstance(ib, dict) and ib.get("id"):
+            wsid = str(ib["id"])
+        index += mod.index_entries(wsid, slug, files)
+    _INDEX_CACHE[uid] = (time.time(), index)
+    return index
+
+
+@mcp.tool()
+@_anon_guard
+def transcript_terms(meeting_id: str = "", since: str = "", keep: str = "",
+                     meeting_url: str = "", token: str = "") -> str:
+    """The things a meeting has NAMED so far — people, companies, projects, products, topics — each
+    with where it was said and whether a page for it already exists.
+
+    THIS IS THE HIGHLIGHT LAYER (PRD decision 35). The transcript view has a Highlight button; it
+    posts a silent turn that calls this, decides which terms matter for THIS person and this chat,
+    and publishes them. The reader then sees them as chips in the transcript: solid where a page
+    exists (clicking opens it), dashed where none does (clicking asks you what it is).
+
+    MECHANICAL — no model runs inside this tool. It is the same name extractor the write-back phase
+    uses, matched against the entity index of the workspaces YOU can read. So a term it calls
+    `known` is a page you can actually open, and one it calls unknown is a page decision 24 says you
+    should be writing.
+
+    TWO CALLS, AND THE SECOND ONE IS THE PUBLISH:
+
+      1. `transcript_terms(meeting_id, since)` — LOOK. Returns every candidate. Nothing is shown to
+         anyone yet. Read the list and pick the ones that matter here: a company in the deal, a
+         person nobody has a page for, a product name that was decided on. Drop the ones that are
+         just capitalised words.
+      2. `transcript_terms(meeting_id, since, keep="Acme, Cottalango Leon")` — PUBLISH. Exactly those
+         become chips in the transcript. `keep="*"` publishes everything, which is right only when
+         everything genuinely matters.
+
+    A first call publishes NOTHING on purpose: chips are on the person's screen, and a list nobody
+    judged is a screen full of every capitalised word in the room.
+
+    `since` is the CURSOR from your last call on this meeting — pass it back and you get only what
+    has been said since, so pressing Highlight again adds new terms instead of re-listing the room.
+    Omit it the first time.
+    """
+    uid = me()
+    row, err = _resolve_meeting(uid, meeting_url, meeting_id)
+    if not row:
+        return json.dumps({"error": err or "give meeting_id=<row id> or meeting_url=<link>"})
+    mod = _terms_mod()
+    st, r = _gw_http(uid, "GET", f"/transcripts/by-id/{row}")
+    if st != 200:
+        return json.dumps({"error": "could not read the transcript", "read_ok": False, "status": st,
+                           "tell_your_person": "Say the READ failed — never that nothing was said.",
+                           "do": "try again in ~20 seconds; if it repeats, report_friction()"})
+    raw = (r or {}).get("segments") or []
+
+    def _at(g):
+        return g.get("absolute_start_time") or g.get("start")
+
+    fresh = [g for g in raw if str(_at(g) or "") > str(since)] if since else raw
+    segments = [{"id": _at(g), "at": _at(g), "text": (g.get("text") or "").strip()}
+                for g in fresh if (g.get("text") or "").strip()]
+    cursor = str(_at(raw[-1])) if raw else (since or "")
+
+    cache_key = (uid, row, str(since), cursor)
+    found = _cached(_TERMS_CACHE, cache_key, _TERMS_TTL)
+    if found is None:
+        found = mod.terms_for(segments, _entity_index(uid))
+        _TERMS_CACHE[cache_key] = (time.time(), found)
+
+    wanted = [w.strip().lower() for w in str(keep or "").split(",") if w.strip()]
+    publish_all = any(w in ("*", "all") for w in wanted)
+    emit = found if publish_all else [t for t in found if str(t.get("term", "")).lower() in wanted] if wanted else []
+    unmatched = [] if publish_all else [w for w in wanted
+                                        if not any(str(t.get("term", "")).lower() == w for t in found)]
+    known = [t for t in found if t.get("known")]
+    return _capped({
+        "meeting": row,
+        "read_ok": True,
+        "cursor": cursor,
+        "since": since or "",
+        "scanned_segments": len(segments),
+        "terms": found,
+        "known_count": len(known),
+        "unknown_count": len(found) - len(known),
+        # THE PUBLISHED SET. Non-empty ⇒ the harness turns this result into the chat's `terms` event
+        # and the transcript paints these, and only these.
+        "emit": emit,
+        "published": len(emit),
+        "keep_not_found": unmatched,
+        "next": ("Nothing is on the person's screen yet. Call me again with keep=\"<the terms that "
+                 "matter here, comma separated>\" to publish them as chips — or keep=\"*\" only if "
+                 "genuinely all of them do."
+                 if not emit else
+                 "Published. Say nothing to your person about it — the chips are the answer. Keep "
+                 f"cursor={cursor} for the next Highlight on this meeting."),
+        "a_term_with_known_null": ("has no page anywhere you can read. That is decision 24's cue, "
+                                   "not a gap to narrate: entity_upsert it when you know what it is."),
+    }, 12000)
+
+
 @mcp.tool()
 @_anon_guard
 def bot_stop(meeting_url: str, token: str = "") -> str:


### PR DESCRIPTION
**PRD decision 35 — the live transcript is a surface: terms highlighted, clickable, explorable.**
Base: `minutes-mcp-viewer`. Owning issue: [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449).

> *"an mcp tool that will take the current transcript and list words that should be highlighted and clickable like all the things we have in the docs and chat… click on a thing and it's dropped into the chat as a research drop — similar to deepen etc — just to find out what that is."* — founder, 2026-09-02
>
> *"it does not require any 'processing on'. We will have a button on transcripts that will silently request our open chat to deliver the important and new terms to highlight."* — founder correction, same day

## What ships

**One implementation, over MCP.** `transcript_terms(meeting_id, since="", keep="")` in `deploy/dogfood/rig/vexa_control_mcp.py` is the whole server side — no `GET /api/meetings/{row}/terms`, no harness polling loop, and no read of the `tc:meeting:*` copilot tail or `VEXA_LLM_*` plumbing being removed on `one-intelligence`. It reads raw segments through the gateway on the caller's identity, runs the **same** name extractor the write-back phase uses (`shared/entities.candidate_names`), and matches against the entity index of the workspaces that reader can open — desk, `_global`, then their groups, **in that order, because order is precedence**. No model call.

**Two calls, and the second one is the publish.** A bare look-up returns candidates and paints nothing; only a call carrying `keep="Acme, Cottalango Leon"` (or `keep="*"`) sets `emit`, and the harness turns that result into a `terms` event. The model's judgment about what matters sits between the regex and the person's screen — which is the only thing standing between them and every capitalised word in the room.

**Delivery is the chat record** (decision 18). The terminal renders chips from `terms` events, remembers the server's cursor per meeting, and never fetches. Pressing **Highlight** again sends that cursor back, so it ADDS rather than re-lists; an empty publish is a non-event server-side, because an empty event would clear the chips already on screen.

**The clicks.** A solid chip navigates the view slot through the resolver (26.3 / 28.1 — never a tab). A dashed one posts `{kind: "explore", term, meeting, segment}` into the open chat as a compact `Explore: <term>` bubble, and turns solid on the artifact event when the agent writes the page — mechanically, on the slug, with no second model turn.

## Files

| | |
|---|---|
| `core/agent/shared/terms.py` | new — pure extractor + index match + the speech-lead correction |
| `deploy/dogfood/rig/vexa_control_mcp.py` | new tool `transcript_terms` (+ a cached entity index) |
| `core/agent/llm/claude_code.py` | the publish seam: a successful `keep=` result → a `terms` event, after its `tool-result` |
| `core/agent/control_plane/chat_intents.py` | new — kind → preset name, a closed vocabulary |
| `core/agent/control_plane/api.py` | `ChatBody.intent` + the mapping (see the defect below) |
| `deploy/dogfood/asks/{explore,highlight}.md` | the two presets |
| `core/agent/worker/engine.py` | `transcript_terms` named in `VEXA_MCP_TOOLS` |
| `clients/terminal/src/canvas/{transcriptTerms.ts,TranscriptTerms.tsx}` | new — the record store and the chip layer + button |
| `clients/terminal/src/canvas/LiveTranscriptEngine.tsx` | one optional `renderText` prop — the seam, so the layer is separable |
| `clients/terminal/src/canvas/MeetingCanvasView.tsx` | the raw transcript renders the layer; Highlight in the header |
| `clients/terminal/src/surfaces/{chatIntent.ts,chatStream.ts,chat.tsx}` | `explore`/`highlight` kinds; the `terms` event forwarded, never stored |
| `clients/terminal/src/minutes/extend.ts` | labels, fallback sentences, silent posting |
| `core/agent/eval/terms_fixture.py` | new — the offline fixture runner |

## A defect this uncovered, and fixes

`ChatBody` carries `model_config = {"extra": "forbid"}` and had **no `intent` field**. The terminal has sent `intent` on every Extend / Create press since decision 32 landed client-side (`chatStream.ts:237`), so **every one of those presses was a 422** — while `minutes/extend.ts`'s own docstring says *"a build where the server ignores the intent still does the right thing"*. It did not ignore it; it refused the turn. `chat_intents.py` is the minimal mapping asked for, and it degrades rather than refuses: an unknown kind or an absent preset leaves the client's plain fallback sentence exactly as it arrived.

## Proof

**Offline, on the DNA fixture** (`~/dna-fixtures/2026-03-02.transcript.json`, 677 segments):

```
segments 677 · index 5 entity pages · terms 18 · known 5 · unknown 13 · 2.4 ms
```

**And it changed the code.** The first run returned **28** candidates, of which **eight were speech rather than names** — `But I'll`, `So I'm`, `Like I've`, `So Cameron`, `That's John`, `And Tommy`, `On DNA`, `Our TAC`. All one shape: a sentence opens with a capitalised function word and the next word is capitalised too, which is exactly what a two-capitalised-words extractor is looking for. Prose does not open sentences that way; a transcript is nothing but sentence openings. The lead is stripped in **the transcript layer, not in `candidate_names`** — that function's behaviour is measured against decision 24's own numbers, and quietly retuning it for a different corpus would move a metric nobody is watching. 28 → 18, in the same 2.4 ms. The trade is stated in the code: `On Semiconductor` loses its first word and falls to the two-word floor. One chip missed against eight junk chips on one meeting, and a junk chip is an invitation to research `But I'll`.

**A known limit, stated rather than worked around:** `candidate_names` requires two capitalised words, so a single-word name (`Anthropic`, `Helm`) never becomes a chip. Taken deliberately — the chips are the same population decision 24 writes pages for, and a second extractor tuned for chips would drift from the one tuned for pages the first time either moved.

**Also visible in the fixture, and not ours to fix here:** `Berner Foundation` and `Blenem Foundation` beside `Blender Foundation` are ASR mis-hearings, and the prefix fold cannot reach them (they are not prefixes). The `highlight` preset's step 2 — the model choosing what to publish — is where they die.

**Suites**

- python: `1032 passed`, plus 25 new across `tests/test_transcript_terms.py` and `tests/test_chat_intents.py`. One pre-existing failure, `test_meeting_room.py::test_the_runtime_binds_a_room_mount_read_only` (`ModuleNotFoundError: requests_unixsocket` in the local env) — reproduced identically on the base branch in `~/dev/wt-desknow`.
- terminal: `98 files, 1086 tests, all passing`; `tsc --noEmit` clean.
- the 14 fast gates: green, via `pre-push` (pushed **without** `--no-verify`).

## Coordination

- **`one-intelligence`** (decision 34) has no commits yet at time of writing. The chip layer is deliberately separable — a new component plus one optional `renderText` prop — and hangs off the **raw** transcript, which is the view that survives that removal. **Rebase onto its branch, or onto the line, before merge.**
- **Stage-1 / dispatch intents** (decision 32 server half): `chat_intents.INTENT_PRESETS` already carries `extend` and `create` and reads their presets from the same `_global/asks/` directory, so that worker adds two files and nothing else. If it lands its own mapping first, delete this one and keep the `explore`/`highlight` rows.

## COMMITMENTS IN THIS PR — none.

<!-- vexa-agent -->
