### PR TITLE
attach: a repository field is validated before it is sent, and no error text may carry a credential

### DIFF
--- a/clients/terminal/src/minutes/AttachRepo.tsx
+++ b/clients/terminal/src/minutes/AttachRepo.tsx
@@ -15,6 +15,14 @@
  *  and nothing of theirs ever travels here. The saved PAT stays a fallback for `https://` remotes and
  *  is entered once in the account menu's GitHub token card — never re-asked per repo.
  *
+ *  THE REPOSITORY FIELD IS VALIDATED BEFORE IT IS SENT (2026-09-02). Saying "the credential is not a
+ *  token box" is not the same as making it impossible to put one in the wrong box, and a founder put a
+ *  PAT in THIS field. It was sent, git was told to clone it, and git's answer — `fatal: repository
+ *  '<the token>' does not exist` — came back into the card below. So `checkRepo` runs on every
+ *  keystroke and on submit: a credential-shaped value never leaves the tab, and the card says which
+ *  box it belongs in. The server refuses it too (422, before any git process exists); this is the
+ *  first line, and the point of the first line is that the value does not travel.
+ *
  *  THE RESULT STATES A STATE. `cloned` · `restored` · `already attached` are three different facts
  *  about where a group's data now is, and "done" is not one of them. On failure the server has already
  *  composed the fix — a 502 whose detail carries the public key and the "say `done` when added"
@@ -24,6 +32,8 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties } from "re
 import { Icon } from "../ui-kit";
 import { copyText } from "../ui-kit/ContextMenu";
 import { ApiError, presentError } from "../surfaces/apiClient";
+import { redactSecrets } from "../surfaces/redactSecrets";
+import { checkRepo } from "../surfaces/repoRef";
 import {
   attachSharedWorkspace, ensureDeployKey, listSharedMemberships, readDeployKey, swapWorkspace,
   type DeployKey, type Membership, type SwapResult,
@@ -80,6 +90,7 @@ export function AttachRepo(p: { workspaceId?: string; onClose: () => void; onAtt
   const [targets, setTargets] = useState<AttachTarget[]>([{ value: DESK_TARGET, label: "Personal" }]);
   const [target, setTarget] = useState<string>(p.workspaceId ?? DESK_TARGET);
   const [repo, setRepo] = useState("");
+  const [repoIssue, setRepoIssue] = useState<string | null>(null);
   const [ref, setRef] = useState("main");
   const [key, setKey] = useState<DeployKey | null>(null);
   const [keyNote, setKeyNote] = useState<string | null>(null);
@@ -126,7 +137,11 @@ export function AttachRepo(p: { workspaceId?: string; onClose: () => void; onAtt
   }, [p.onClose]);
 
   const fail = useCallback((e: unknown) => {
-    setError({ headline: presentError(e).headline, verbatim: e instanceof ApiError ? e.detail : "" });
+    // `verbatim` exists to carry the deploy-key answer through unparaphrased; that same channel is
+    // how a credential would reach the screen, so it is scrubbed. The public key survives — it is not
+    // a secret and the scrubber leaves git object ids and key material alone (see redactSecrets).
+    setError({ headline: presentError(e).headline,
+               verbatim: e instanceof ApiError ? redactSecrets(e.detail) : "" });
   }, []);
 
   const makeKey = async () => {
@@ -139,12 +154,21 @@ export function AttachRepo(p: { workspaceId?: string; onClose: () => void; onAtt
 
   const attach = async () => {
     if (busy || !repo.trim()) return;
+    // The value is checked HERE as well as on every keystroke, because a paste that never fires a
+    // change handler, an autofill, or a stale `repoIssue` must not be the thing standing between a
+    // credential and the wire.
+    const checked = checkRepo(repo);
+    if (!checked.ok) {
+      setRepoIssue(checked.sentence);
+      setToken("");
+      return;
+    }
     // P15: a one-off token is read once, handed to the call, and gone from this component before the
     // request is even in flight — it is never re-rendered, never re-sent and never logged.
     const oneOff = token.trim() || undefined;
     setToken(""); setTokenOpen(false);
     setBusy(true); setError(null);
-    const url = repo.trim();
+    const url = checked.url;          // the canonical form, not the raw keystrokes
     const branch = ref.trim() || "main";
     try {
       const state = target
@@ -171,8 +195,8 @@ export function AttachRepo(p: { workspaceId?: string; onClose: () => void; onAtt
           </button>
         </div>
         <div style={{ ...ty.meta, lineHeight: 1.5, marginBottom: 12 }}>
-          Your workspace is already on GitHub. Point one of your workspaces at it — the tree that is
-          there now is parked, not destroyed, so this is reversible.
+          Point a workspace at a repository you have. The tree that is there now is parked, not
+          destroyed.
         </div>
 
         {error && (
@@ -204,7 +228,22 @@ export function AttachRepo(p: { workspaceId?: string; onClose: () => void; onAtt
             <div style={{ marginBottom: 10 }}>
               <label htmlFor="attach-repo" style={labelS}>Repository</label>
               <input id="attach-repo" data-attach="repo" autoFocus value={repo} disabled={busy}
-                onChange={(e) => setRepo(e.target.value)} placeholder="git@github.com:acme/kg.git" style={fieldS} />
+                aria-invalid={repoIssue ? true : undefined}
+                aria-describedby={repoIssue ? "attach-repo-issue" : undefined}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setRepo(v);
+                  // A token is called out the moment it appears, before there is anything to submit.
+                  // Everything else is only judged once the person has typed enough to be judged —
+                  // shouting "not a repository" at `g` is noise that teaches people to ignore it.
+                  const c = checkRepo(v);
+                  setRepoIssue(!v.trim() ? null : c.ok ? null : c.kind === "token" ? c.sentence : null);
+                }}
+                placeholder="git@github.com:acme/kg.git" style={{ ...fieldS, borderColor: repoIssue ? "var(--danger)" : "var(--line)" }} />
+              {repoIssue && (
+                <div id="attach-repo-issue" data-attach="repo-issue" role="alert"
+                  style={{ ...ty.meta, color: "var(--danger)", marginTop: 5, lineHeight: 1.45 }}>{repoIssue}</div>
+              )}
             </div>
 
             <div style={{ marginBottom: 12 }}>
@@ -264,8 +303,8 @@ export function AttachRepo(p: { workspaceId?: string; onClose: () => void; onAtt
               </div>
             </div>
 
-            <button data-attach="submit" onClick={() => void attach()} disabled={busy || !repo.trim()}
-              style={{ ...btnS, background: "var(--accent)", color: "var(--on-accent)", border: "none", opacity: busy || !repo.trim() ? 0.5 : 1 }}>
+            <button data-attach="submit" onClick={() => void attach()} disabled={busy || !repo.trim() || !!repoIssue}
+              style={{ ...btnS, background: "var(--accent)", color: "var(--on-accent)", border: "none", opacity: busy || !repo.trim() || repoIssue ? 0.5 : 1 }}>
               {busy ? "Loading…" : "Attach"}
             </button>
           </>

--- a/clients/terminal/src/minutes/__tests__/attachRepo.test.tsx
+++ b/clients/terminal/src/minutes/__tests__/attachRepo.test.tsx
@@ -211,3 +211,110 @@ describe("the deploy key is the primary credential", () => {
     expect(container.querySelector('[data-attach="addat"]')).toBeNull();
   });
 });
+
+
+/** THE 2026-09-02 INCIDENT. A founder pasted a GitHub PAT into the Repository field of this dialog.
+ *  It was sent; git was asked to clone it; git answered `fatal: repository '<the token>' does not
+ *  exist`, and that string was rendered in the card below and echoed to the browser console.
+ *
+ *  The fix is not a nicer error. It is that the value never leaves the tab — so what these assert is
+ *  the ABSENCE of a request, not the presence of a message. */
+describe("a token pasted into the Repository field", () => {
+  const PAT = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8";
+
+  it("is named as a token the moment it is typed, and Attach is refused", async () => {
+    const { container } = open();
+    await screen.findByRole("option", { name: "acme-kg" });
+    fireEvent.change(screen.getByLabelText("Repository"), { target: { value: PAT } });
+
+    const issue = container.querySelector('[data-attach="repo-issue"]');
+    expect(issue?.textContent).toBe(
+      "That looks like a token, not a repository. Paste the repository URL here; " +
+      "a saved token goes in the token card.");
+    expect((container.querySelector('[data-attach="submit"]') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("is NEVER SENT — no attach call is made, by either lane", async () => {
+    open();
+    await submit(PAT, "acme-kg");
+    expect(api.attachSharedWorkspace).not.toHaveBeenCalled();
+    expect(api.swapWorkspace).not.toHaveBeenCalled();
+
+    cleanup();
+    open();
+    await submit(PAT);                       // the desk lane too
+    expect(api.swapWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("is not left sitting in the DOM after the refusal", async () => {
+    const { container } = open();
+    await submit(PAT, "acme-kg");
+    const field = container.querySelector('[data-attach="repo"]') as HTMLInputElement;
+    // The field keeps what the person typed — clearing it under them would be the wrong lesson, and
+    // they must be able to see what they pasted to know to revoke it. What must not happen is the
+    // value travelling: nothing is sent, and the card never renders it.
+    expect(field.value).toBe(PAT);
+    expect(container.querySelector('[data-attach="result"]')).toBeNull();
+    expect(container.querySelector('[data-attach="detail"]')).toBeNull();
+  });
+
+  it("a repository that is merely malformed is refused on submit without a scolding keystroke", async () => {
+    const { container } = open();
+    await screen.findByRole("option", { name: "acme-kg" });
+    fireEvent.change(screen.getByLabelText("Repository"), { target: { value: "g" } });
+    expect(container.querySelector('[data-attach="repo-issue"]')).toBeNull();  // no shouting at "g"
+
+    fireEvent.click(screen.getByText("Attach"));
+    await waitFor(() => {
+      const el = container.querySelector('[data-attach="repo-issue"]');
+      if (!el) throw new Error("no issue yet");
+      expect(el.textContent).toContain("That is not a repository.");
+    });
+    expect(api.swapWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("normalizes what it does send — the canonical URL, not the raw keystrokes", async () => {
+    vi.mocked(api.swapWorkspace).mockResolvedValue({
+      subject: "u1", active: "seed", repo: "https://github.com/acme/kg.git", ref: "main",
+      swapped: true, cloned: true, parked: "seed-prev", nested: false,
+    });
+    open();
+    await submit("  acme/kg  ");
+    await screen.findByText("Cloned https://github.com/acme/kg.git into Personal");
+    expect(vi.mocked(api.swapWorkspace).mock.calls[0][0]).toBe("https://github.com/acme/kg.git");
+  });
+});
+
+/** P15 in the one place a secret was actually seen. The server scrubs its own text now; the card is
+ *  the second line, because a client cannot know which failure will hand it a string containing one. */
+describe("the error card never renders a credential", () => {
+  it("masks a token inside a clone error while keeping the deploy key intact", async () => {
+    const PAT = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8";
+    vi.mocked(api.attachSharedWorkspace).mockRejectedValue(new ApiError(
+      502,
+      `git clone failed: fatal: could not read Username for 'https://${PAT}@github.com'\n\n${REFUSAL}`,
+      "/api/workspace/shared/acme-kg/attach",
+    ));
+    const { container } = open();
+    await submit("git@github.com:acme/kg.git", "acme-kg");
+    const pre = await waitFor(() => {
+      const el = container.querySelector('[data-attach="detail"]');
+      if (!el) throw new Error("no verbatim block yet");
+      return el;
+    });
+    expect(pre.textContent).not.toContain(PAT);
+    expect(pre.textContent).toContain("«redacted»");
+    expect(pre.textContent).toContain(PUBKEY);            // the answer survives the scrubbing
+    expect(container.innerHTML).not.toContain(PAT);
+  });
+});
+
+/** F80 — the lede. "Your workspace is already on GitHub" told the person a fact about themselves that
+ *  may be false; this says what the control does. */
+describe("the lede", () => {
+  it("describes the action, not an assumption about the person", async () => {
+    open();
+    expect(screen.getByText(/Point a workspace at a repository you have/)).toBeTruthy();
+    expect(screen.queryByText(/Your workspace is already on GitHub/)).toBeNull();
+  });
+});

--- a/clients/terminal/src/surfaces/__tests__/repoRef.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/repoRef.test.ts
@@ -80,3 +80,35 @@ describe("redactSecrets — nothing that reaches a person or the console carries
     expect(redactSecrets(undefined)).toBe("");
   });
 });
+
+/** The answer must survive the scrubbing — else the fix breaks the feature it exists to protect.
+ *  `PLAIN_FP`'s base64 body deliberately contains neither `+` nor `/`: those characters fall outside
+ *  the generic rule's class and split a long run, so a fingerprint containing one survives by
+ *  accident. Roughly one in four does not. This is the one that does not. */
+describe("public key material survives, credentials do not", () => {
+  const PLAIN_FP = "SHA256:" + "aB3dE5gH7jK9mN1pQ3sT5vW7yZ9bD1fH3jL5nP7rT9v";
+  const KEY =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHqZ0mQfZ5xW1kTn2vJ8sQpYbR3cL7dM4eF6gH9iJ0kL vexa-workspace-ws-acme";
+  const PAT = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8";
+
+  it("renders the whole deploy-key card unmasked", () => {
+    const card = `no credential yet (${PLAIN_FP}). Add this public key, then say \`done\` when added:\n${KEY}`;
+    const out = redactSecrets(card);
+    expect(out).toContain(KEY);
+    expect(out).toContain(PLAIN_FP);
+    expect(out).toContain("say `done` when added");
+  });
+
+  it("still masks a PAT sitting in the same message — the allow-list is not a hole", () => {
+    const out = redactSecrets(`could not read Username for 'https://${PAT}@github.com'\n${KEY}\n${PLAIN_FP}`);
+    expect(out).not.toContain(PAT);
+    expect(out).toContain(MASK);
+    expect(out).toContain(KEY);
+    expect(out).toContain(PLAIN_FP);
+  });
+
+  it("keeps an MD5 fingerprint too", () => {
+    const md5 = "MD5:" + new Array(16).fill("ab").join(":");
+    expect(redactSecrets(`key fingerprint ${md5}`)).toContain(md5);
+  });
+});

--- a/clients/terminal/src/surfaces/__tests__/repoRef.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/repoRef.test.ts
@@ -1,0 +1,82 @@
+/** The 2026-09-02 incident, client-side: a GitHub PAT was pasted into the attach dialog's Repository
+ *  field and SENT. The point of these is not that a nicer error is shown — it is that the value never
+ *  leaves the tab, and that nothing which does leave carries a secret. */
+import { describe, expect, it } from "vitest";
+import { checkRepo, looksLikeToken, SHAPE_SENTENCE, TOKEN_SENTENCE } from "../repoRef";
+import { MASK, redactSecrets } from "../redactSecrets";
+
+const PAT = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8";
+const FINE = "github_pat_11ABCDE0aAbBcCdDeEfF_gGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ01";
+
+describe("checkRepo — the whitelist", () => {
+  it.each([
+    ["https://github.com/acme/kg", "https://github.com/acme/kg.git"],
+    ["https://github.com/acme/kg.git", "https://github.com/acme/kg.git"],
+    ["git@github.com:acme/kg.git", "git@github.com:acme/kg.git"],
+    ["git@github.com:acme/kg", "git@github.com:acme/kg.git"],
+    ["ssh://git@github.com/acme/kg.git", "ssh://git@github.com/acme/kg.git"],
+    ["acme/kg", "https://github.com/acme/kg.git"],
+    ["  acme/kg.git ", "https://github.com/acme/kg.git"],
+  ])("accepts %s", (raw, url) => {
+    const r = checkRepo(raw);
+    expect(r).toEqual({ ok: true, url });
+  });
+
+  it.each([PAT, FINE, "glpat-aBcDeFgHiJkLmNoPqRsT"])("refuses the token %s by name", (t) => {
+    const r = checkRepo(t);
+    expect(r).toEqual({ ok: false, kind: "token", sentence: TOKEN_SENTENCE });
+  });
+
+  it("refuses a URL that carries a credential, and keeps ssh://git@ working", () => {
+    expect(checkRepo(`https://${PAT}@github.com/acme/kg.git`)).toMatchObject({ kind: "token" });
+    expect(checkRepo("https://someone:hunter2@github.com/acme/kg.git")).toMatchObject({ kind: "token" });
+    expect(checkRepo("ssh://git@github.com/acme/kg.git")).toMatchObject({ ok: true });
+  });
+
+  it.each(["/workspaces/u_someone_else", "file:///etc", "not a url", "https://github.com/acme", "acme"])(
+    "refuses %s as a shape", (bad) => {
+      expect(checkRepo(bad)).toEqual({ ok: false, kind: "shape", sentence: SHAPE_SENTENCE });
+    });
+
+  it("never echoes the value back in its refusal", () => {
+    expect(JSON.stringify(checkRepo(PAT))).not.toContain(PAT);
+  });
+
+  it("looksLikeToken is narrow enough to be useful", () => {
+    expect(looksLikeToken(PAT)).toBe(true);
+    for (const ok of ["git@github.com:acme/kg.git", "acme/kg", "main", ""]) {
+      expect(looksLikeToken(ok)).toBe(false);
+    }
+  });
+});
+
+describe("redactSecrets — nothing that reaches a person or the console carries one", () => {
+  it("masks the exact string that leaked", () => {
+    const out = redactSecrets(`fatal: repository '${PAT}' does not exist`);
+    expect(out).not.toContain(PAT);
+    expect(out).toContain(MASK);
+  });
+
+  it("masks a URL credential and an unknown long secret", () => {
+    expect(redactSecrets("https://someone:hunter2@github.com/x/y.git")).not.toContain("hunter2");
+    const unknown = "zzQ7rT9wL2mK4nP6vB8xC1dF3gH5jK7lM9nO0p";
+    expect(redactSecrets(`remote: ${unknown}`)).not.toContain(unknown);
+  });
+
+  it("leaves a git object id alone — diagnostics are the reason the string is shown at all", () => {
+    const sha = "a".repeat(40);
+    expect(redactSecrets(`fatal: bad object ${sha}`)).toContain(sha);
+  });
+
+  it("leaves an ssh public key alone — it is the ANSWER, not a secret", () => {
+    const key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHqZ0mQfZ5xW1kTn2vJ8sQpYbR3cL7dM4eF6gH9iJ0kL vexa-workspace-ws-x";
+    expect(redactSecrets(`add this key:\n${key}`)).toContain("ssh-ed25519 ");
+  });
+
+  it("is idempotent and survives odd input", () => {
+    const once = redactSecrets(`a ${PAT} b`);
+    expect(redactSecrets(once)).toBe(once);
+    expect(redactSecrets(null)).toBe("");
+    expect(redactSecrets(undefined)).toBe("");
+  });
+});

--- a/clients/terminal/src/surfaces/apiClient.ts
+++ b/clients/terminal/src/surfaces/apiClient.ts
@@ -12,6 +12,7 @@
  *  — the authoritative cross-caller API-usage signal is the gateway's per-request logs. */
 import { track, endpointLabel } from "@/app/analytics";
 import { noteAuthFailure } from "@/app/session";
+import { redactSecrets } from "./redactSecrets";
 
 export class ApiError extends Error {
   /** `detail` is the FLATTENED operator string (what goes in the message / the console). `body` is
@@ -59,7 +60,12 @@ function isProse(detail: string): boolean {
  *  observable channel keeps the full string — presentation never mutates the error). */
 export function presentError(e: unknown): PresentedError {
   if (e instanceof ApiError) {
-    const detail = e.message;
+    // P15 AT THE PRESENTER. `detail` is rendered by every surface AND echoed to the console, and on
+    // 2026-09-02 it carried a GitHub PAT (git's "repository '<the token>' does not exist", from a
+    // token pasted into the attach dialog's repository field). The server scrubs its own text now;
+    // this is the second line, because a client cannot know which backend, proxy or fetch failure
+    // will hand it a string containing a secret.
+    const detail = redactSecrets(e.message);
     console.warn("api failure", detail);
     if (e.status === 0) return { headline: NETWORK_HEADLINE, detail };
     if (e.status === 502 || e.status === 504) return { headline: "The Vexa server can't reach a backend service right now.", detail };
@@ -72,16 +78,16 @@ export function presentError(e: unknown): PresentedError {
     if (e.status === 429) return { headline: "Rate limit hit — try again in a moment.", detail };
     // Remaining 4xx/5xx: a prose `detail` is the backend's own user-facing reason — pass it
     // through VERBATIM (e.g. a typed transcription 503). A payload-shaped detail stays operator-only.
-    if (isProse(e.detail)) return { headline: e.detail.trim(), detail };
+    if (isProse(e.detail)) return { headline: redactSecrets(e.detail).trim(), detail };
     return { headline: `The request failed (${e.status}).`, detail };
   }
   if (e instanceof Error) {
-    const detail = e.message || String(e);
+    const detail = redactSecrets(e.message || String(e));
     console.warn("api failure", detail);
     if (NETWORK_MESSAGE.test(detail)) return { headline: NETWORK_HEADLINE, detail };
     return isProse(detail) ? { headline: detail.trim(), detail } : { headline: GENERIC_HEADLINE, detail };
   }
-  const detail = String(e);
+  const detail = redactSecrets(e);
   console.warn("api failure", detail);
   return { headline: GENERIC_HEADLINE, detail };
 }

--- a/clients/terminal/src/surfaces/redactSecrets.ts
+++ b/clients/terminal/src/surfaces/redactSecrets.ts
@@ -1,0 +1,36 @@
+/** redactSecrets — the browser-side half of P15.
+ *
+ *  `presentError` echoes every failure to the console and every surface renders its `detail`. On
+ *  2026-09-02 that detail was `fatal: repository '<a GitHub PAT>' does not exist`, so the token was on
+ *  screen AND in the console. The server scrubs its own text now; this is the second line, because a
+ *  client cannot know which backend, proxy or fetch failure will hand it a string containing a secret
+ *  — and because a browser console is a place people paste screenshots from.
+ *
+ *  Shape-based, mirroring `shared/git_redaction.py`: named token families, credentials wearing a URL,
+ *  and a generic long opaque run — minus git object ids, which an operator reading a clone error needs. */
+export const MASK = "«redacted»";
+
+const TOKEN_FAMILIES = /\b(?:gh[pousr]_[A-Za-z0-9_]{4,}|github_pat_[A-Za-z0-9_]{4,}|glpat-[A-Za-z0-9_-]{4,})/g;
+const URL_USERINFO = /(?<=:\/\/)[^/\s:@]+:[^/\s@]+(?=@)/g;
+const URL_BARE_USERINFO = /(?<=:\/\/)[^/\s:@]{16,}(?=@)/g;
+const GENERIC = /[A-Za-z0-9_-]{36,}/g;
+const GIT_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+/** An SSH PUBLIC KEY is a long base64 run the generic rule would eat — and it is the opposite of a
+ *  secret: it is the ANSWER shown when a credential is missing ("add this key to your repository").
+ *  Masking it leaves a message reading "add this: «redacted»". */
+const SSH_PUBKEY =
+  /\b(?:ssh-(?:rsa|dss|ed25519)|ecdsa-sha2-[A-Za-z0-9-]+|sk-ssh-ed25519@openssh\.com)\s+[A-Za-z0-9+/]+=*(?:\s+\S+)?/g;
+
+/** `text` with every credential-shaped run masked. Safe on anything, and safe to run twice. */
+export function redactSecrets(text: unknown): string {
+  let out = text === null || text === undefined ? "" : String(text);
+  out = out.replace(TOKEN_FAMILIES, MASK);
+  out = out.replace(URL_USERINFO, MASK);
+  out = out.replace(URL_BARE_USERINFO, MASK);
+  // Park public keys before the generic sweep and restore them after — the sweep cannot tell a key
+  // from a secret by shape, and here that difference is the whole message.
+  const kept: string[] = [];
+  out = out.replace(SSH_PUBKEY, (m) => `\u0000pub${kept.push(m) - 1}\u0000`);
+  out = out.replace(GENERIC, (m) => (GIT_OID.test(m) ? m : MASK));
+  return kept.reduce((acc, original, i) => acc.replace(`\u0000pub${i}\u0000`, original), out);
+}

--- a/clients/terminal/src/surfaces/redactSecrets.ts
+++ b/clients/terminal/src/surfaces/redactSecrets.ts
@@ -20,6 +20,11 @@ const GIT_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
  *  Masking it leaves a message reading "add this: «redacted»". */
 const SSH_PUBKEY =
   /\b(?:ssh-(?:rsa|dss|ed25519)|ecdsa-sha2-[A-Za-z0-9-]+|sk-ssh-ed25519@openssh\.com)\s+[A-Za-z0-9+/]+=*(?:\s+\S+)?/g;
+/** …and a KEY FINGERPRINT. `SHA256:` + 43 base64 chars only SOMETIMES contains a `+` or `/`, and those
+ *  are outside the generic rule's class — so today a fingerprint survives by accident, and roughly one
+ *  in four would not. An intermittent bug in the message telling someone which key to add is the worst
+ *  place to have one, so the shape is allow-listed rather than left to chance. */
+const KEY_FINGERPRINT = /\b(?:SHA256:[A-Za-z0-9+/]{20,}=*|MD5:(?:[0-9a-f]{2}:){5,}[0-9a-f]{2})/g;
 
 /** `text` with every credential-shaped run masked. Safe on anything, and safe to run twice. */
 export function redactSecrets(text: unknown): string {
@@ -30,7 +35,8 @@ export function redactSecrets(text: unknown): string {
   // Park public keys before the generic sweep and restore them after — the sweep cannot tell a key
   // from a secret by shape, and here that difference is the whole message.
   const kept: string[] = [];
-  out = out.replace(SSH_PUBKEY, (m) => `\u0000pub${kept.push(m) - 1}\u0000`);
+  const park = (m: string) => `\u0000pub${kept.push(m) - 1}\u0000`;
+  out = out.replace(SSH_PUBKEY, park).replace(KEY_FINGERPRINT, park);
   out = out.replace(GENERIC, (m) => (GIT_OID.test(m) ? m : MASK));
   return kept.reduce((acc, original, i) => acc.replace(`\u0000pub${i}\u0000`, original), out);
 }

--- a/clients/terminal/src/surfaces/repoRef.ts
+++ b/clients/terminal/src/surfaces/repoRef.ts
@@ -1,0 +1,69 @@
+/** repoRef — what may be typed into the attach dialog's "Repository" field.
+ *
+ *  The twin of `control_plane/repo_ref.py`, and deliberately a twin rather than a round trip: on
+ *  2026-09-02 a GitHub PAT was pasted into that field and SENT, and git's reply — `fatal: repository
+ *  '<the token>' does not exist` — put the secret in the error card and the browser console. The
+ *  server refuses it now too (422, before any git process exists), but the client must refuse FIRST,
+ *  because the fix is not "show a nicer error": it is that **the value never leaves the tab**.
+ *
+ *  A whitelist, not a blacklist. The set of things that are a repository is small and knowable; the
+ *  set of things that are a secret is neither. */
+
+/** Token families we can name — the prefix check is the cheap half; anything long and opaque that
+ *  isn't a repository shape is refused by the whitelist anyway. */
+const TOKEN_PREFIX = /^(ghp_|gho_|ghu_|ghs_|ghr_|github_pat_|glpat-)/;
+
+/** The one sentence a person sees when they paste a credential where a repository goes. It names what
+ *  they did, what to do instead, and where the other thing lives — a refusal that only says "invalid"
+ *  teaches nothing and gets retried verbatim. Identical to the server's, so a client-side refusal and
+ *  a server-side one are the same experience. */
+export const TOKEN_SENTENCE =
+  "That looks like a token, not a repository. Paste the repository URL here; a saved token goes in the token card.";
+export const SHAPE_SENTENCE =
+  "That is not a repository. Use https://github.com/owner/repo, git@github.com:owner/repo.git, or owner/repo.";
+
+const SEG = "[A-Za-z0-9._-]+";
+const HOST = "[A-Za-z0-9.-]+(?::\\d{1,5})?";
+const HTTP = new RegExp(`^(https?)://(${HOST})/(${SEG})/(${SEG}?)/?$`);
+const SCP = new RegExp(`^([A-Za-z0-9._-]+)@([A-Za-z0-9.-]+):/?(${SEG})/(${SEG}?)/?$`);
+const SSH = new RegExp(`^ssh://(?:([A-Za-z0-9._-]+)@)?(${HOST})/(${SEG})/(${SEG}?)/?$`);
+const BARE = new RegExp(`^(${SEG})/(${SEG})$`);
+const USERINFO = /^[a-z]+:\/\/([^/\s@]+)@/;
+
+const tidy = (name: string) => name.replace(/\.git$/, "");
+
+export type RepoCheck =
+  | { ok: true; url: string }
+  | { ok: false; kind: "token" | "shape"; sentence: string };
+
+/** True when the value is credential-shaped ON ITS OWN — checked before anything else happens to it. */
+export function looksLikeToken(value: string): boolean {
+  return TOKEN_PREFIX.test(value.trim());
+}
+
+/** Validate + canonicalize what the person typed. `""` is not an error — an empty field is simply not
+ *  yet a repository, and the submit button is what gates that. */
+export function checkRepo(raw: string): RepoCheck {
+  const v = (raw ?? "").trim();
+  if (!v) return { ok: false, kind: "shape", sentence: SHAPE_SENTENCE };
+  if (looksLikeToken(v)) return { ok: false, kind: "token", sentence: TOKEN_SENTENCE };
+
+  // git's own "authenticated clone URL" carries a credential as plain USERINFO, which is how a PAT
+  // most often arrives here — pasted inside a URL copied out of a tutorial. `ssh://git@host/…` is the
+  // legitimate case and must survive, so the discriminator is the userinfo itself: a user:password
+  // pair, a token-shaped run, or anything long enough to be opaque. A real ssh user is none of those.
+  const ui = USERINFO.exec(v);
+  if (ui && (ui[1].includes(":") || looksLikeToken(ui[1]) || ui[1].length >= 20)) {
+    return { ok: false, kind: "token", sentence: TOKEN_SENTENCE };
+  }
+
+  let m = HTTP.exec(v);
+  if (m) return { ok: true, url: `${m[1]}://${m[2]}/${m[3]}/${tidy(m[4])}.git` };
+  m = SCP.exec(v);
+  if (m) return { ok: true, url: `${m[1]}@${m[2]}:${m[3]}/${tidy(m[4])}.git` };
+  m = SSH.exec(v);
+  if (m) return { ok: true, url: `ssh://${m[1] ? `${m[1]}@` : ""}${m[2]}/${m[3]}/${tidy(m[4])}.git` };
+  m = BARE.exec(v);
+  if (m) return { ok: true, url: `https://github.com/${m[1]}/${tidy(m[2])}.git` };
+  return { ok: false, kind: "shape", sentence: SHAPE_SENTENCE };
+}

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -75,6 +75,8 @@ from control_plane import git_credentials as git_creds
 from control_plane import dispatch as dispatch_mod
 from control_plane import deploy_keys as deploy_keys_mod
 from control_plane import workspace_credentials as wcreds
+from control_plane import repo_ref
+from shared.git_redaction import redact as redact_secrets
 from control_plane import global_layer
 from control_plane import system_mounts
 from control_plane import scaffolds as scaffolds_mod
@@ -1962,6 +1964,24 @@ def create_app(
             return membership_mod._ws_dir(wsr.root, target)
         raise HTTPException(status_code=404, detail="workspace not found")
 
+    def _repo(raw: "Optional[str]") -> "Optional[str]":
+        """The value a PERSON typed into "Repository", normalized — or a 422 they can act on.
+
+        It runs before a subprocess exists, which is the whole point: on 2026-09-02 a PAT pasted into
+        that field was handed straight to ``git clone``, and git's "repository '<the token>' does not
+        exist" put the secret in the error card, the response body and the browser console. A
+        validator that runs after the clone has not protected anything.
+
+        422 rather than 400 because the field is well-formed JSON and semantically wrong — and the
+        detail is the sentence itself, which the terminal's presenter shows verbatim."""
+        try:
+            return repo_ref.normalize(raw)
+        except repo_ref.RepoRefError as exc:
+            # LOG THE KIND, NEVER THE VALUE. "someone pasted a token" is the operational signal; the
+            # token is the thing we are refusing to have anywhere at all.
+            logger.warning("repository field refused (kind=%s)", exc.kind)
+            raise HTTPException(status_code=422, detail=exc.sentence)
+
     def _require_shared_write(subject: str, slug: Optional[str]) -> None:
         """A no-op for the caller's OWN workspaces; for a SHARED one, refuse anyone below contributor.
         (``_manage_dir`` resolves a workspace a viewer may READ — that is the right gate for status and
@@ -2765,13 +2785,16 @@ def create_app(
         Mounting is by-folder (``<root>/<subject>`` is what the next dispatch mounts), so the swapped
         tree takes effect on the subject's next turn — no dispatch change needed."""
         subject = subject_of(request)
+        repo = _repo(body.repo)      # 422 before any git process exists
         key = deploy_keys_mod.workspace_key(subject=subject)
         try:
-            with wcreds.for_workspace(wsr.root, key=key, repo_url=body.repo or "", subject=subject,
+            with wcreds.for_workspace(wsr.root, key=key, repo_url=repo or "", subject=subject,
                                       explicit_token=body.token) as cred:
-                result = swap_workspace(wsr.root, subject, body.repo, body.ref or "main",
+                result = swap_workspace(wsr.root, subject, repo, body.ref or "main",
                                         slug=body.slug or None, fresh=body.fresh, token=cred.token,
                                         clone=_clone_fn(cred))
+        except repo_ref.RepoRefError as exc:
+            raise HTTPException(status_code=422, detail=exc.sentence)
         except ValueError:
             raise HTTPException(status_code=400, detail="invalid subject")
         except KeyError:
@@ -2779,7 +2802,7 @@ def create_app(
         except CloneError as exc:
             # Already token-redacted (P15). A private repo we hold no credential for lands here — and
             # the answer is the workspace's public key to add, not a prompt for a secret.
-            raise _credential_refusal(f"git clone failed: {exc}", subject, None, body.repo or "")
+            raise _credential_refusal(f"git clone failed: {redact_secrets(exc)}", subject, None, repo or "")
         return {
             "subject": result.subject,
             "active": result.active_slug,
@@ -2827,19 +2850,22 @@ def create_app(
         """ADD a workspace to the active set WITHOUT parking the others (the additive counterpart of swap).
         Clones/restores the target if needed. Idempotent — an already-active workspace is a no-op."""
         subject = subject_of(request)
+        repo = _repo(body.repo)      # 422 before any git process exists
         key = deploy_keys_mod.workspace_key(subject=subject)
         try:
-            with wcreds.for_workspace(wsr.root, key=key, repo_url=body.repo or "", subject=subject,
+            with wcreds.for_workspace(wsr.root, key=key, repo_url=repo or "", subject=subject,
                                       explicit_token=body.token) as cred:
-                result = activate_workspace(wsr.root, subject, body.repo, body.ref or "main",
+                result = activate_workspace(wsr.root, subject, repo, body.ref or "main",
                                             slug=body.slug or None, token=cred.token,
                                             clone=_clone_fn(cred))
+        except repo_ref.RepoRefError as exc:
+            raise HTTPException(status_code=422, detail=exc.sentence)
         except ValueError:
             raise HTTPException(status_code=400, detail="invalid subject")
         except KeyError:
             raise HTTPException(status_code=404, detail="unknown workspace")
         except CloneError as exc:
-            raise _credential_refusal(f"git clone failed: {exc}", subject, None, body.repo or "")
+            raise _credential_refusal(f"git clone failed: {redact_secrets(exc)}", subject, None, repo or "")
         return {"subject": result.subject, "slug": result.slug, "changed": result.changed,
                 "cloned": result.cloned, "nested": result.nested}
 
@@ -2967,7 +2993,7 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
         except RemoteSyncError as exc:
-            raise _credential_refusal(str(exc), subject, body.slug, home.url or "")  # token-redacted (P15)
+            raise _credential_refusal(redact_secrets(exc), subject, body.slug, home.url or "")  # P15
         return {"remote": r.remote, "url": r.url, "branch": r.branch, "head_sha": r.head_sha}
 
     @app.post("/api/workspace/pull")
@@ -2989,7 +3015,7 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
         except RemoteSyncError as exc:
-            raise _credential_refusal(str(exc), subject, body.slug, home.url or "")  # token-redacted (P15)
+            raise _credential_refusal(redact_secrets(exc), subject, body.slug, home.url or "")  # P15
         return {"remote": r.remote, "url": r.url, "branch": r.branch, "head_sha": r.head_sha,
                 "updated": r.updated, "behind_before": r.behind_before}
 
@@ -3252,7 +3278,7 @@ def create_app(
             membership_mod.require_role(wsr.root, workspace_id, subject, "contributor")
         except MembershipError as exc:
             raise _member_error(exc)
-        repo = (body.repo or "").strip() or None
+        repo = _repo(body.repo)      # 422 before any git process exists
         key = deploy_keys_mod.workspace_key(workspace_id=workspace_id)
         try:
             with wcreds.for_workspace(wsr.root, key=key, repo_url=repo or "", subject=subject,
@@ -3260,12 +3286,14 @@ def create_app(
                 clone = _clone_fn(cred)
                 result = attach_shared_workspace(wsr.root, workspace_id, repo, body.ref or "main",
                                                  slug=body.slug or None, token=cred.token, clone=clone)
+        except repo_ref.RepoRefError as exc:
+            raise HTTPException(status_code=422, detail=exc.sentence)
         except ValueError:
             raise HTTPException(status_code=400, detail="invalid workspace id")
         except KeyError:
             raise HTTPException(status_code=404, detail="unknown workspace")
         except CloneError as exc:   # message already token-redacted (P15)
-            raise _credential_refusal(f"git clone failed: {exc}", subject, workspace_id, repo or "")
+            raise _credential_refusal(f"git clone failed: {redact_secrets(exc)}", subject, workspace_id, repo or "")
         return {
             "workspace_id": workspace_id, "active": result.active_slug, "repo": result.repo,
             "ref": result.ref, "attached": result.swapped, "cloned": result.cloned,

--- a/core/agent/control_plane/repo_ref.py
+++ b/core/agent/control_plane/repo_ref.py
@@ -1,0 +1,114 @@
+"""repo_ref.py — what may be typed into a "Repository" field, and what may not.
+
+The dialog that shipped took whatever string it was given and handed it to ``git clone``. On
+2026-09-02 the string it was given was a GitHub personal access token, and git answered
+``fatal: repository '<the token>' does not exist`` — which put the secret on screen, in the browser
+console, and in the response body. Two failures, and this module is the first one: **an input nobody
+validated**. (The second, the error text nobody scrubbed, is ``git_redaction``.)
+
+The gate is a WHITELIST, not a blacklist, because the set of things that are a repository is small and
+knowable while the set of things that are a secret is neither:
+
+* ``https://host/owner/repo`` (``.git`` optional, ``http`` accepted for a self-hosted mirror)
+* ``git@host:owner/repo.git`` — the scp-like form
+* ``ssh://[user@]host[:port]/owner/repo``
+* ``owner/repo`` — the bare shorthand, expanded to ``https://github.com/owner/repo.git``
+
+Anything else is refused **before any git process starts**, which is the part that matters: a
+validator that runs after the subprocess has already been told the secret has not protected anything.
+
+Two consequences worth naming, because both are security properties and neither was intended when the
+list was written down:
+
+* a **local path** (``/workspaces/<someone-else>``) is not a URL shape, so it is refused — closing a
+  hole where any caller could have cloned another user's workspace out of the shared store by naming
+  its path;
+* the token check is duplicated inside ``workspace_attach`` rather than trusted from the route, so a
+  credential cannot reach ``git clone`` through the MCP, a future route, or a test that forgot.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from shared.git_redaction import TOKEN_PREFIXES, looks_like_token
+
+#: The one sentence a person sees when they paste a credential where a repository goes. It says what
+#: they did, what to do instead, and where the other thing lives — a refusal that only says "invalid"
+#: teaches nothing and gets retried verbatim.
+TOKEN_SENTENCE = ("That looks like a token, not a repository. Paste the repository URL here; "
+                  "a saved token goes in the token card.")
+#: …and when it is simply not a repository reference. Saying "that looks like a token" about `foo bar`
+#: would be a guess, and a wrong guess about a secret is how people learn to ignore the warning.
+SHAPE_SENTENCE = ("That is not a repository. Use https://github.com/owner/repo, "
+                  "git@github.com:owner/repo.git, or owner/repo.")
+
+DEFAULT_HOST = "github.com"
+
+_SEG = r"[A-Za-z0-9._-]+"                       # one path segment of an owner or repo name
+_HOST = r"[A-Za-z0-9.-]+(?::\d{1,5})?"
+_HTTP = re.compile(rf"^(https?)://({_HOST})/({_SEG})/({_SEG}?)/?$")
+_SCP = re.compile(rf"^([A-Za-z0-9._-]+)@([A-Za-z0-9.-]+):/?({_SEG})/({_SEG}?)/?$")
+_SSH = re.compile(rf"^ssh://(?:([A-Za-z0-9._-]+)@)?({_HOST})/({_SEG})/({_SEG}?)/?$")
+_BARE = re.compile(rf"^({_SEG})/({_SEG})$")
+
+
+class RepoRefError(ValueError):
+    """A repository field that cannot be one. ``sentence`` is the text a person is shown; the raw
+    value is NEVER carried on the exception, because the whole point may be that it is a secret."""
+
+    def __init__(self, sentence: str, *, kind: str = "shape"):
+        super().__init__(sentence)
+        self.sentence = sentence
+        self.kind = kind        # 'token' | 'shape' — the caller may want to log which, never what
+
+
+def _tidy(name: str) -> str:
+    return re.sub(r"\.git$", "", name)
+
+
+def assert_not_credential(raw: Optional[str]) -> None:
+    """Refuse a credential-shaped repository, wherever the call came from. Deliberately NARROWER than
+    :func:`normalize` so it can sit inside ``workspace_attach`` — which is also reached by tests and
+    fixtures cloning local paths — while still making it impossible for a secret to reach ``git``."""
+    v = (raw or "").strip()
+    if not v:
+        return
+    if looks_like_token(v) or v.startswith(TOKEN_PREFIXES):
+        raise RepoRefError(TOKEN_SENTENCE, kind="token")
+
+
+def normalize(raw: Optional[str]) -> Optional[str]:
+    """The full gate for a value a PERSON typed: return the canonical URL, or raise ``RepoRefError``.
+
+    ``None``/empty passes through as ``None`` — that is "swap back to what was here", not a repository.
+    """
+    v = (raw or "").strip()
+    if not v:
+        return None
+    assert_not_credential(v)
+    # A credential is not always prefix-shaped, and git's own "authenticated clone URL" carries one as
+    # plain USERINFO — which is how a PAT most often arrives in a repository field: pasted into a URL
+    # someone copied out of a tutorial. `ssh://git@host/...` is the legitimate case and must survive,
+    # so the discriminator is the userinfo itself: a `user:password` pair, a token-shaped run, or
+    # anything long enough to be opaque. A real ssh user ("git", "ubuntu") is none of those.
+    m = re.match(r"^[a-z]+://([^/\s@]+)@", v)
+    if m:
+        userinfo = m.group(1)
+        if ":" in userinfo or looks_like_token(userinfo) or len(userinfo) >= 20:
+            raise RepoRefError(TOKEN_SENTENCE, kind="token")
+
+    m = _HTTP.match(v)
+    if m:
+        return f"{m.group(1)}://{m.group(2)}/{m.group(3)}/{_tidy(m.group(4))}.git"
+    m = _SCP.match(v)
+    if m:
+        return f"{m.group(1)}@{m.group(2)}:{m.group(3)}/{_tidy(m.group(4))}.git"
+    m = _SSH.match(v)
+    if m:
+        user = f"{m.group(1)}@" if m.group(1) else ""
+        return f"ssh://{user}{m.group(2)}/{m.group(3)}/{_tidy(m.group(4))}.git"
+    m = _BARE.match(v)
+    if m:
+        return f"https://{DEFAULT_HOST}/{m.group(1)}/{_tidy(m.group(2))}.git"
+    raise RepoRefError(SHAPE_SENTENCE)

--- a/core/agent/control_plane/workspace_attach.py
+++ b/core/agent/control_plane/workspace_attach.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
+from shared.git_redaction import redact
+from control_plane.repo_ref import RepoRefError, assert_not_credential
 from shared.gitenv import scrubbed_git_env
 from shared.seeding import resolve_seed_dir, seed_workspace, validate_seed
 
@@ -165,11 +167,9 @@ def _git_clone(repo_url: str, ref: str, dest: Path, token: Optional[str] = None,
     dest.parent.mkdir(parents=True, exist_ok=True)
     # scrubbed env: a hook-exported GIT_DIR would re-point every op below at the hook's repo
     # (see shared/gitenv.py); prompts stay disabled so a bad credential fails loud.
+    assert_not_credential(repo_url)   # never hand a secret to a subprocess (see repo_ref)
     env = scrubbed_git_env(GIT_ASKPASS="true", GIT_TERMINAL_PROMPT="0", **(ssh_env or {}))
     url = _authenticated_url(repo_url, token)
-
-    def redact(text: str) -> str:
-        return text.replace(token, "***") if token else text
 
     try:
         subprocess.run(["git", "clone", "--quiet", url, str(dest)],
@@ -181,7 +181,10 @@ def _git_clone(repo_url: str, ref: str, dest: Path, token: Optional[str] = None,
             subprocess.run(["git", "-C", str(dest), "checkout", "--quiet", ref],
                            check=True, capture_output=True, text=True, env=env)
     except subprocess.CalledProcessError as exc:
-        raise CloneError(redact((exc.stderr or str(exc)).strip())) from None
+        # SHAPE-BASED redaction, not "replace the token we were given": the credential that leaked on
+        # 2026-09-02 arrived as the repo ARGUMENT, so `token` was None and the old replace() was a no-op
+        # over a message containing the secret. See git_redaction.
+        raise CloneError(redact((exc.stderr or str(exc)).strip(), token)) from None
 
 
 def _safe_subject_dir(root: Path, subject: str) -> Path:
@@ -319,6 +322,7 @@ def swap_workspace(
     ``slug`` targets a parked slot DIRECTLY (overriding the repo→slug derivation) — the way to swap back
     to a slot that carries no repo URL (the seed, or a ``SEED_BACKUP_SLOT`` backup). A parked tree is
     restored (no re-clone); an unknown slug with no repo to clone raises ``KeyError``."""
+    assert_not_credential(repo_url)   # a secret must never reach git (repo_ref)
     rootp = Path(root)
     active_dir = _safe_subject_dir(rootp, subject)
     store = _store(rootp, subject)
@@ -660,6 +664,7 @@ def activate_workspace(
     private baseline is always active and needs no activation — activating its slug is a no-op.
 
     A clone failure raises ``CloneError`` (token-redacted, P15) WITHOUT mutating the active set."""
+    assert_not_credential(repo_url)   # a secret must never reach git (repo_ref)
     rootp = Path(root)
     _safe_subject_dir(rootp, subject)
     store = _store(rootp, subject)
@@ -1032,6 +1037,7 @@ def attach_repo_at(
 
     ``carry`` names a directory to copy from the parked tree into the new one before it goes live —
     the shared lane passes ``policy/`` so a repo attach cannot delete the member list."""
+    assert_not_credential(repo_url)   # a secret must never reach git (repo_ref)
     active_dir = Path(active_dir)
     store = Path(store)
     state = _plain_state(store)

--- a/core/agent/control_plane/workspace_git_sync.py
+++ b/core/agent/control_plane/workspace_git_sync.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from shared.git_redaction import redact
 from shared.adapters import GitPushError, push_with_token
 from shared.gitenv import scrubbed_git_env
 
@@ -67,7 +68,10 @@ class RemoteSyncError(RuntimeError):
 
 
 def _redacted(text: str, token: Optional[str]) -> str:
-    return text.replace(token, "***") if token else text
+    """SHAPE-BASED (git_redaction), with the known token as belt to the braces. The previous version
+    was the replace() alone, which redacts nothing whenever the credential reached us by a route the
+    caller did not classify as a credential — which is precisely when it matters."""
+    return redact(text, token)
 
 
 def _git(ws: Path, *args: str, token: Optional[str] = None, check: bool = True,
@@ -195,9 +199,9 @@ def push_origin(ws: str | Path, *, token: Optional[str] = None, ssh_env: Optiona
         if pushed.returncode != 0:
             err = (pushed.stderr or "").strip()
             if "non-fast-forward" in err or "fetch first" in err or "rejected" in err:
-                raise RemoteSyncError(
-                    f"push rejected — the remote has commits this workspace doesn't. Pull first (no force push): {err}")
-            raise RemoteSyncError(f"git push failed: {err}")
+                raise RemoteSyncError(_redacted(
+                    f"push rejected — the remote has commits this workspace doesn't. Pull first (no force push): {err}", None))
+            raise RemoteSyncError(_redacted(f"git push failed: {err}", None))
         head_sha = _git(wsp, "rev-parse", "HEAD", ssh_env=ssh_env).stdout.strip()
     else:
         head_sha = _push_with_pat(wsp, url, branch, token)

--- a/core/agent/shared/friction.py
+++ b/core/agent/shared/friction.py
@@ -51,6 +51,8 @@ import re
 import time
 from datetime import datetime, timezone
 
+from shared.git_redaction import redact
+
 # ── the vocabulary ───────────────────────────────────────────────────────────────────────────────
 
 #: Who filed it. Two values, and the difference is load-bearing in the dump: an agent's report is
@@ -83,7 +85,12 @@ MAX_ERROR = 600
 
 
 def _clip(v, n: int = MAX_TEXT) -> str:
-    return str(v or "").strip()[:n]
+    """Trim ONE free-text field — and scrub it. Every string a person or an agent writes into a
+    friction report passes through here, and a friction record is DURABLE BY DESIGN (this file's own
+    docstring: "nothing here expires"). A credential pasted into "what went wrong" would therefore
+    outlive the session, the fix and the rotation. Shape-based, so it does not depend on anybody
+    having recognised the value as a secret first — which on 2026-09-02 nobody did."""
+    return redact(str(v or "").strip())[:n]
 
 
 def _one_of(v, allowed, default: str) -> str:

--- a/core/agent/shared/git_redaction.py
+++ b/core/agent/shared/git_redaction.py
@@ -57,6 +57,12 @@ _SSH_PUBKEY = re.compile(
     r"\b(?:ssh-(?:rsa|dss|ed25519)|ecdsa-sha2-[A-Za-z0-9-]+|sk-ssh-ed25519@openssh\.com)"
     r"\s+[A-Za-z0-9+/]+=*(?:\s+\S+)?"
 )
+#: …and a KEY FINGERPRINT, for the same reason and with a nastier failure mode. ``SHA256:`` + 43
+#: base64 chars only SOMETIMES contains a ``+`` or ``/`` — those characters are outside the generic
+#: rule's class, so they split the run and the fingerprint survives by accident. Roughly one in four
+#: fingerprints contains neither and would be masked: an intermittent bug in the message that tells a
+#: person which key to add, which is the worst place to have one. Allow-listed explicitly.
+_KEY_FINGERPRINT = re.compile(r"\b(?:SHA256:[A-Za-z0-9+/]{20,}=*|MD5:(?:[0-9a-f]{2}:){5,}[0-9a-f]{2})")
 
 
 def looks_like_token(value: str) -> bool:
@@ -80,8 +86,9 @@ def redact(text, *known: "str | None") -> str:
     out = _TOKEN_FAMILIES.sub(MASK, out)
     out = _URL_USERINFO.sub(MASK, out)
     out = _URL_BARE_USERINFO.sub(MASK, out)
-    # Park public keys before the generic sweep and put them back after: the sweep cannot tell a key
-    # from a secret by shape, and the difference matters more here than anywhere else in this file.
+    # Park PUBLIC key material before the generic sweep and put it back after: the sweep cannot tell a
+    # key from a secret by shape, and the difference matters more here than anywhere else in this file
+    # — these two shapes are the answer we hand someone whose credential is missing.
     kept: list[str] = []
 
     def _park(m):
@@ -89,6 +96,7 @@ def redact(text, *known: "str | None") -> str:
         return f"\x00pub{len(kept) - 1}\x00"
 
     out = _SSH_PUBKEY.sub(_park, out)
+    out = _KEY_FINGERPRINT.sub(_park, out)
     out = _GENERIC.sub(lambda m: m.group(0) if _GIT_OID.match(m.group(0)) else MASK, out)
     for i, original in enumerate(kept):
         out = out.replace(f"\x00pub{i}\x00", original)

--- a/core/agent/shared/git_redaction.py
+++ b/core/agent/shared/git_redaction.py
@@ -1,0 +1,95 @@
+"""git_redaction.py — the P15 scrubber, and the reason it is no longer a keyword argument.
+
+The old shape was ``text.replace(token, "***")``: redaction only worked when the caller ALREADY HELD
+the secret and remembered to pass it. On 2026-09-02 that assumption broke in the way assumptions like
+this always break — the credential arrived somewhere nobody had classified as a credential. A founder
+pasted a GitHub PAT into the attach dialog's REPOSITORY field; the token was the ``repo`` argument, so
+``token`` was ``None``, so the redactor had nothing to replace, and git's own message —
+``fatal: repository '<the token>' does not exist`` — went to the error card, to the browser console,
+and into every place that error string travels.
+
+So redaction here is **shape-based and unconditional**. It does not need to know what the secret is:
+
+* the token families we can name (GitHub ``ghp_``/``gho_``/``ghu_``/``ghs_``/``ghr_``/``github_pat_``,
+  GitLab ``glpat-``),
+* credentials wearing a URL (``https://user:password@host``),
+* and a **generic** long opaque run — 36+ characters of ``[A-Za-z0-9_-]`` — which is what catches the
+  next provider's token before anyone has heard of it.
+
+Known values are still passed when the caller has them (``redact(text, token)``); that is now belt to
+the braces, not the mechanism.
+
+TWO DELIBERATE HOLES, both so the scrubber does not destroy the diagnostics it exists to protect:
+
+* a bare 40- or 64-character LOWERCASE HEX run is a git object id, not a secret — no token family in
+  this file is hex-only, and masking every sha would make clone errors unreadable;
+* the scrubber is applied AT THE SOURCE of git's text, never to a composed message. The deploy-key
+  answer (``ssh-ed25519 AAAA…``) is a 68-character base64 run that the generic rule would eat, and it
+  is the one part of that message the person actually needs.
+"""
+from __future__ import annotations
+
+import re
+
+MASK = "«redacted»"
+
+#: Prefixes that make a string a credential no matter where it appears. Public so the request
+#: validators (repo_ref) refuse the same shapes rather than keeping a second, drifting list.
+TOKEN_PREFIXES = ("ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_", "glpat-")
+
+_TOKEN_FAMILIES = re.compile(
+    r"\b(?:gh[pousr]_[A-Za-z0-9_]{4,}|github_pat_[A-Za-z0-9_]{4,}|glpat-[A-Za-z0-9_-]{4,})"
+)
+#: ``scheme://user:password@host`` — the credential is the ``user:password`` run.
+_URL_USERINFO = re.compile(r"(?<=://)[^/\s:@]+:[^/\s@]+(?=@)")
+#: ``scheme://token@host`` — a PAT used as the whole userinfo (how git's own clone URL carries one).
+_URL_BARE_USERINFO = re.compile(r"(?<=://)[^/\s:@]{16,}(?=@)")
+#: Anything long and opaque enough to be a secret we have no name for yet.
+_GENERIC = re.compile(r"[A-Za-z0-9_-]{36,}")
+#: …except a git object id, which is exactly what an operator reading a git error needs to keep.
+_GIT_OID = re.compile(r"^[0-9a-f]{40}$|^[0-9a-f]{64}$")
+#: …and except an SSH PUBLIC KEY, which is a long base64 run the generic rule would happily eat — and
+#: which is the OPPOSITE of a secret: it is the answer we hand a person when a credential is missing
+#: ("add this key to your repository"). Masking it would leave a message that says "add this:
+#: «redacted»". Matched as the whole `ssh-ed25519 AAAA… comment` token so only key material inside a
+#: real key line is spared, never a bare base64 blob on its own.
+_SSH_PUBKEY = re.compile(
+    r"\b(?:ssh-(?:rsa|dss|ed25519)|ecdsa-sha2-[A-Za-z0-9-]+|sk-ssh-ed25519@openssh\.com)"
+    r"\s+[A-Za-z0-9+/]+=*(?:\s+\S+)?"
+)
+
+
+def looks_like_token(value: str) -> bool:
+    """True when ``value`` is credential-shaped ON ITS OWN — the check a validator runs on a field a
+    person typed, before anything is done with it."""
+    v = (value or "").strip()
+    return v.startswith(TOKEN_PREFIXES) or bool(_TOKEN_FAMILIES.fullmatch(v))
+
+
+def redact(text, *known: "str | None") -> str:
+    """``text`` with every credential-shaped run replaced by ``«redacted»``.
+
+    Safe to call on anything (``None``, an exception, a dict repr) and safe to call twice — the mask
+    contains no character the patterns match. ``known`` values, when a caller has them, are removed
+    first so a short token that no pattern would catch is still gone."""
+    out = str(text if text is not None else "")
+    for k in known:
+        k = (k or "").strip()
+        if k:
+            out = out.replace(k, MASK)
+    out = _TOKEN_FAMILIES.sub(MASK, out)
+    out = _URL_USERINFO.sub(MASK, out)
+    out = _URL_BARE_USERINFO.sub(MASK, out)
+    # Park public keys before the generic sweep and put them back after: the sweep cannot tell a key
+    # from a secret by shape, and the difference matters more here than anywhere else in this file.
+    kept: list[str] = []
+
+    def _park(m):
+        kept.append(m.group(0))
+        return f"\x00pub{len(kept) - 1}\x00"
+
+    out = _SSH_PUBKEY.sub(_park, out)
+    out = _GENERIC.sub(lambda m: m.group(0) if _GIT_OID.match(m.group(0)) else MASK, out)
+    for i, original in enumerate(kept):
+        out = out.replace(f"\x00pub{i}\x00", original)
+    return out

--- a/core/agent/tests/gitserve.py
+++ b/core/agent/tests/gitserve.py
@@ -1,0 +1,57 @@
+"""gitserve — a LOCAL bare repo served over git's real ssh transport, for tests.
+
+The repository field is validated now (``control_plane.repo_ref``), and a bare filesystem path is not
+a repository URL — deliberately, because accepting one let any caller name another user's workspace
+directory in the shared store and clone it. So a ROUTE test can no longer pass ``str(some_tmp_dir)``.
+
+Rather than weaken the gate for tests, this serves the same local bare repo through the transport a
+real ``ssh://`` URL uses: ``ssh`` is stubbed with a script that drops its options and its host, maps
+the server-side path, and runs ``git-upload-pack`` locally. The clone is real, the URL shape is real,
+git's own ssh code path is exercised, and nothing touches a network.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def bare_repo(tmp_path: Path, name: str = "kg", **files: str) -> Path:
+    """A real bare repo with one commit. ``files`` overrides/adds working-tree files."""
+    work = tmp_path / f"{name}-src"
+    work.mkdir(parents=True)
+    g = lambda *a: subprocess.run(["git", "-C", str(work), *a], check=True, capture_output=True, text=True)
+    g("init", "-q", "-b", "main"); g("config", "user.email", "t@t"); g("config", "user.name", "t")
+    content = {"CLAUDE.md": "# governed workspace\n", "README.md": "the existing repo\n", **files}
+    for rel, body in content.items():
+        f = work / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(body)
+    g("add", "-A"); g("commit", "-q", "-m", "their history")
+    bare = tmp_path / f"{name}.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(work), str(bare)], check=True, capture_output=True)
+    return bare
+
+
+def serve(tmp_path: Path, bare: Path, monkeypatch, *, owner: str = "acme", repo: str = "kg") -> str:
+    """Install the ssh stub and return the ``ssh://`` URL that reaches ``bare``.
+
+    ``GIT_SSH_COMMAND`` is set in the process env: ``shared.gitenv.scrubbed_git_env`` copies the
+    environment (it strips only git's repo-DISCOVERY vars), so this reaches the clone exactly as a
+    deploy key's would — which is also what makes it a faithful stand-in."""
+    script = tmp_path / "fake-ssh"
+    script.write_text(
+        "#!/bin/sh\n"
+        "while [ $# -gt 0 ]; do\n"
+        "  case \"$1\" in\n"
+        "    -i|-o|-p|-l|-F) shift 2 ;;\n"
+        "    -*) shift ;;\n"
+        "    *) break ;;\n"
+        "  esac\n"
+        "done\n"
+        "shift\n"                                    # drop the host
+        f"cmd=$(printf '%s' \"$*\" | sed \"s#/{owner}/{repo}\\\\.git#{bare}#g\")\n"
+        'exec sh -c "$cmd"\n'
+    )
+    script.chmod(0o755)
+    monkeypatch.setenv("GIT_SSH_COMMAND", str(script))
+    return f"ssh://git@fake-host/{owner}/{repo}.git"

--- a/core/agent/tests/test_api.py
+++ b/core/agent/tests/test_api.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from control_plane.api import create_app
+from tests import gitserve
 from shared.config import load_settings
 from control_plane.dispatch import Dispatcher
 
@@ -1057,12 +1058,11 @@ def test_workspace_swap_attaches_custom_repo_and_swaps_back(tmp_path, monkeypatc
     (seed / "CLAUDE.md").write_text("SEED\n")
     monkeypatch.setenv("VEXA_WORKSPACE_SEED_DIR", str(seed))
 
-    origin = tmp_path / "origin"
-    origin.mkdir()
-    run = lambda *a: subprocess.run(["git", *a], cwd=origin, check=True, capture_output=True)
-    run("init", "-q", "-b", "main"); run("config", "user.email", "t@t"); run("config", "user.name", "t")
-    (origin / "MARK").write_text("CUSTOM\n"); (origin / "CLAUDE.md").write_text("CUSTOM ROOT\n")
-    run("add", "-A"); run("commit", "-q", "-m", "x")
+    # A bare filesystem path is NO LONGER a repository reference (control_plane.repo_ref) — that is
+    # what let a caller name another user's directory in the shared store. The same local repo is
+    # served over git's real ssh transport instead, so the URL shape is one a person could type.
+    bare = gitserve.bare_repo(tmp_path, "custom", **{"MARK": "CUSTOM\n", "CLAUDE.md": "CUSTOM ROOT\n"})
+    origin_url = gitserve.serve(tmp_path, bare, monkeypatch, repo="custom")
 
     workspaces = tmp_path / "ws"
     c = TestClient(create_app(
@@ -1072,7 +1072,7 @@ def test_workspace_swap_attaches_custom_repo_and_swaps_back(tmp_path, monkeypatc
     h = {"X-User-Id": "u_jane"}
     c.post("/api/workspace/init", headers=h)                      # seed the active workspace first
 
-    r = c.post("/api/workspace/swap", headers=h, json={"repo": str(origin)})
+    r = c.post("/api/workspace/swap", headers=h, json={"repo": origin_url})
     assert r.status_code == 200
     body = r.json()
     assert body["swapped"] is True and body["cloned"] is True and body["parked"] == "seed"
@@ -1096,10 +1096,10 @@ def test_workspace_activate_adds_without_parking_then_deactivate_parks(tmp_path,
 
     seed = tmp_path / "seed"; seed.mkdir(); (seed / "CLAUDE.md").write_text("SEED\n")
     monkeypatch.setenv("VEXA_WORKSPACE_SEED_DIR", str(seed))
-    origin = tmp_path / "origin"; origin.mkdir()
-    run = lambda *a: subprocess.run(["git", *a], cwd=origin, check=True, capture_output=True)
-    run("init", "-q", "-b", "main"); run("config", "user.email", "t@t"); run("config", "user.name", "t")
-    (origin / "CLAUDE.md").write_text("SHARED ROOT\n"); run("add", "-A"); run("commit", "-q", "-m", "x")
+    # served over ssh rather than named by path — a bare path is no longer a repository (repo_ref)
+    origin_url = gitserve.serve(
+        tmp_path, gitserve.bare_repo(tmp_path, "extra", **{"CLAUDE.md": "SHARED ROOT\n"}),
+        monkeypatch, repo="extra")
 
     workspaces = tmp_path / "ws"
     c = TestClient(create_app(
@@ -1109,7 +1109,7 @@ def test_workspace_activate_adds_without_parking_then_deactivate_parks(tmp_path,
     h = {"X-User-Id": "u_jane"}
     c.post("/api/workspace/init", headers=h)
 
-    r = c.post("/api/workspace/activate", headers=h, json={"repo": str(origin)})
+    r = c.post("/api/workspace/activate", headers=h, json={"repo": origin_url})
     assert r.status_code == 200
     body = r.json()
     assert body["changed"] is True and body["cloned"] is True

--- a/core/agent/tests/test_repo_ref_and_redaction.py
+++ b/core/agent/tests/test_repo_ref_and_redaction.py
@@ -1,0 +1,226 @@
+"""The 2026-09-02 incident, in tests: a PAT was pasted into the attach dialog's REPOSITORY field.
+
+Two independent failures had to line up, so there are two independent fixes and both are held here:
+
+  1. **Nothing validated the field** (``repo_ref``) — the string went straight to ``git clone``.
+  2. **Nothing scrubbed git's answer** (``git_redaction``) — redaction was ``text.replace(token, …)``,
+     which does nothing when the credential arrived as the ``repo`` argument rather than the ``token``
+     one, so ``fatal: repository '<the token>' does not exist`` reached the card, the response body and
+     the browser console.
+
+Either fix alone would have stopped the leak. Both are here because the next credential will arrive
+through a field nobody has classified yet, and only the second one is shape-based.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+from control_plane import repo_ref
+from control_plane.api import create_app
+from control_plane.dispatch import Dispatcher
+from control_plane.workspace_attach import CloneError, _git_clone, swap_workspace
+from control_plane.workspace_reader import WorkspaceReader
+from shared.config import load_settings
+from shared.git_redaction import MASK, looks_like_token, redact
+
+PAT = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"
+FINE = "github_pat_11ABCDE0aAbBcCdDeEfF_gGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ01"
+GLPAT = "glpat-aBcDeFgHiJkLmNoPqRsT"
+
+
+class _FakeRuntime:
+    def spawn(self, workload_id, profile, env): return workload_id
+    def await_done(self, workload_id, timeout_sec=0.0): return "completed"
+
+
+class _FakeIdentity:
+    def mint(self, subject, launcher, workspaces, tools): return "tok"
+
+
+def _client(root):
+    return TestClient(create_app(
+        Dispatcher(load_settings(workspaces_dir=str(root)), _FakeRuntime(), _FakeIdentity()),
+        reader=WorkspaceReader(str(root)),
+    ))
+
+
+# ── F78 · what may be typed into "Repository" ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("raw,expected", [
+    ("https://github.com/acme/kg", "https://github.com/acme/kg.git"),
+    ("https://github.com/acme/kg.git", "https://github.com/acme/kg.git"),
+    ("https://github.com/acme/kg/", "https://github.com/acme/kg.git"),
+    ("http://git.internal:8080/acme/kg.git", "http://git.internal:8080/acme/kg.git"),
+    ("git@github.com:acme/kg.git", "git@github.com:acme/kg.git"),
+    ("git@github.com:acme/kg", "git@github.com:acme/kg.git"),
+    ("ssh://git@github.com/acme/kg.git", "ssh://git@github.com/acme/kg.git"),
+    ("ssh://github.com/acme/kg", "ssh://github.com/acme/kg.git"),
+    ("acme/kg", "https://github.com/acme/kg.git"),        # the bare shorthand expands to GitHub
+    ("  acme/kg.git  ", "https://github.com/acme/kg.git"),
+])
+def test_a_repository_reference_normalizes(raw, expected):
+    assert repo_ref.normalize(raw) == expected
+
+
+def test_empty_means_swap_back_not_a_repository():
+    assert repo_ref.normalize(None) is None
+    assert repo_ref.normalize("   ") is None
+
+
+@pytest.mark.parametrize("token", [PAT, FINE, GLPAT, "gho_aaaaaaaaaaaaaaaaaaaaaaaa",
+                                   "ghs_bbbbbbbbbbbbbbbbbbbbbbbb", "ghu_cccccccccccccccccccccccc",
+                                   "ghr_dddddddddddddddddddddddd"])
+def test_a_token_in_the_repository_field_is_refused_by_name(token):
+    with pytest.raises(repo_ref.RepoRefError) as e:
+        repo_ref.normalize(token)
+    assert e.value.kind == "token"
+    assert e.value.sentence == (
+        "That looks like a token, not a repository. Paste the repository URL here; "
+        "a saved token goes in the token card.")
+    assert token not in str(e.value), "the refusal must never carry the value back"
+
+
+def test_a_url_carrying_a_credential_is_refused_too():
+    with pytest.raises(repo_ref.RepoRefError) as e:
+        repo_ref.normalize(f"https://{PAT}@github.com/acme/kg.git")
+    assert e.value.kind == "token"
+
+
+@pytest.mark.parametrize("bad", [
+    "/workspaces/u_someone_else",          # another user's directory in the shared store
+    "/tmp/anything",
+    "file:///workspaces/u_someone_else",
+    "not a url at all",
+    "ftp://example.com/acme/kg.git",
+    "https://github.com/acme",             # no repo
+    "acme",                                # no owner
+    "https://github.com/a/b/c",            # not owner/repo
+])
+def test_anything_that_is_not_a_repository_is_refused(bad):
+    with pytest.raises(repo_ref.RepoRefError) as e:
+        repo_ref.normalize(bad)
+    assert e.value.kind == "shape"
+
+
+def test_the_route_refuses_before_any_git_process_exists(tmp_path, monkeypatch):
+    """The ordering IS the fix. A validator that runs after ``git clone`` has already been told the
+    secret has protected nothing — git has forked, logged, and put it in its own error text."""
+    started: list = []
+    monkeypatch.setattr(subprocess, "run",
+                        lambda *a, **k: started.append(a) or (_ for _ in ()).throw(AssertionError("git ran")))
+    c = _client(tmp_path)
+    r = c.post("/api/workspace/swap", json={"repo": PAT}, headers={"X-User-Id": "u_jane"})
+    assert r.status_code == 422
+    assert r.json()["detail"] == repo_ref.TOKEN_SENTENCE
+    assert PAT not in r.text, "the response body must not echo the value back"
+    assert started == [], "no subprocess may start for a refused repository"
+
+
+@pytest.mark.parametrize("path,body", [
+    ("/api/workspace/swap", {"repo": PAT}),
+    ("/api/workspace/activate", {"repo": PAT}),
+])
+def test_every_desk_route_that_clones_refuses_a_token(tmp_path, path, body):
+    c = _client(tmp_path)
+    r = c.post(path, json=body, headers={"X-User-Id": "u_jane"})
+    assert r.status_code == 422 and r.json()["detail"] == repo_ref.TOKEN_SENTENCE
+    assert PAT not in r.text
+
+
+def test_the_refusal_log_line_names_the_kind_and_never_the_value(tmp_path, caplog):
+    c = _client(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        c.post("/api/workspace/swap", json={"repo": PAT}, headers={"X-User-Id": "u_jane"})
+    assert any("repository field refused" in r.getMessage() for r in caplog.records)
+    assert PAT not in caplog.text
+
+
+def test_the_mechanic_refuses_a_credential_even_when_the_route_is_bypassed(tmp_path):
+    """Duplicated on purpose: the MCP, a future route, or a test can reach ``workspace_attach``
+    directly, and a secret must not reach ``git`` by any of them."""
+    with pytest.raises(repo_ref.RepoRefError):
+        swap_workspace(tmp_path, "u_jane", PAT)
+    with pytest.raises(repo_ref.RepoRefError):
+        _git_clone(PAT, "main", tmp_path / "dest")
+
+
+# ── F79 · nothing that reaches a person or a log may carry a secret ────────────────────────────────
+
+@pytest.mark.parametrize("secret", [PAT, FINE, GLPAT])
+def test_a_token_is_scrubbed_out_of_any_text(secret):
+    out = redact(f"fatal: repository '{secret}' does not exist")
+    assert secret not in out and MASK in out
+
+
+def test_the_leak_that_happened_is_scrubbed_even_though_nobody_passed_the_token():
+    """The exact 2026-09-02 string, through the exact call the clone path now makes. The old redactor
+    took the token as an argument; here there is no argument to give it, which is the whole point."""
+    out = redact(f"fatal: repository '{PAT}' does not exist")
+    assert PAT not in out
+
+
+def test_a_url_credential_and_an_unknown_long_secret_are_scrubbed():
+    assert "hunter2" not in redact("https://someone:hunter2@github.com/acme/kg.git")
+    unknown = "zz" + "Q7rT9wL2mK4nP6vB8xC1dF3gH5jK7lM9nO0p"      # 38 chars, no known prefix
+    assert unknown not in redact(f"remote: rejected {unknown}")
+
+
+def test_a_git_object_id_survives_because_diagnostics_matter():
+    sha = "a" * 40
+    assert sha in redact(f"fatal: bad object {sha}")
+    assert "b" * 64 in redact("bad object " + "b" * 64)
+
+
+def test_a_deploy_key_is_not_a_secret_and_must_survive():
+    """The answer to a missing credential IS an ssh public key — a long base64 run the generic rule
+    would eat. It survives because the scrubber runs at the SOURCE of git's text, never over the
+    composed message; this asserts the composed message keeps the key."""
+    from control_plane import deploy_keys, workspace_credentials as wc
+    import tempfile
+    with tempfile.TemporaryDirectory() as root:
+        prompt = wc.deploy_key_prompt(root, key="user-u_jane", repo_url="git@github.com:acme/kg.git")
+        assert prompt["public_key"] in wc.prompt_sentence(prompt)
+        assert deploy_keys.public_key(root, "user-u_jane") == prompt["public_key"]
+
+
+def test_redact_is_idempotent_and_survives_odd_input():
+    once = redact(f"a {PAT} b")
+    assert redact(once) == once
+    assert redact(None) == ""
+    assert redact(CloneError(f"boom {PAT}")) .find(PAT) == -1
+
+
+def test_a_clone_failure_carrying_a_token_reaches_the_route_masked(tmp_path, monkeypatch):
+    """End to end through the route: git fails with the secret in its own stderr (the shape of the
+    incident), and neither the response body nor the log carries it."""
+    def _boom(cmd, *a, **k):
+        raise subprocess.CalledProcessError(128, cmd, stderr=f"fatal: could not read Username for 'https://{PAT}@github.com'")
+    monkeypatch.setattr(subprocess, "run", _boom)
+    c = _client(tmp_path)
+    r = c.post("/api/workspace/swap", json={"repo": "https://github.com/acme/private.git"},
+               headers={"X-User-Id": "u_jane"})
+    assert r.status_code == 502
+    assert PAT not in r.text
+    assert MASK in r.json()["detail"]
+
+
+def test_the_friction_ledger_never_stores_a_credential():
+    """A friction record is durable BY DESIGN ("nothing here expires"), so a secret pasted into one
+    outlives the session, the fix and the rotation."""
+    from shared import friction as fr
+    rec = fr.normalize({"what_i_was_doing": f"attaching {PAT}",
+                        "what_went_wrong": f"fatal: repository '{PAT}' does not exist",
+                        "tool": "workspace_attach"})
+    blob = repr(rec)
+    assert PAT not in blob
+    assert MASK in blob
+
+
+def test_looks_like_token_is_narrow_enough_to_be_useful():
+    assert looks_like_token(PAT) and looks_like_token(GLPAT)
+    for ordinary in ("git@github.com:acme/kg.git", "https://github.com/acme/kg", "main", "acme/kg", ""):
+        assert not looks_like_token(ordinary)

--- a/core/agent/tests/test_repo_ref_and_redaction.py
+++ b/core/agent/tests/test_repo_ref_and_redaction.py
@@ -224,3 +224,38 @@ def test_looks_like_token_is_narrow_enough_to_be_useful():
     assert looks_like_token(PAT) and looks_like_token(GLPAT)
     for ordinary in ("git@github.com:acme/kg.git", "https://github.com/acme/kg", "main", "acme/kg", ""):
         assert not looks_like_token(ordinary)
+
+
+# ── the answer must survive the scrubbing (else the fix breaks the feature it protects) ───────────
+
+#: A fingerprint whose base64 body contains NEITHER `+` NOR `/`. Those two characters fall outside the
+#: generic rule's character class, so they split a long run — which means a fingerprint that happens to
+#: contain one survives by accident. Roughly one in four does not. This is the one that does not.
+PLAIN_FP = "SHA256:" + "aB3dE5gH7jK9mN1pQ3sT5vW7yZ9bD1fH3jL5nP7rT9v"
+
+
+def test_a_deploy_key_card_renders_the_whole_public_key_and_its_fingerprint():
+    """The card a person acts on carries an ssh public key and a SHA256 fingerprint — both long,
+    opaque, base64-ish runs that the generic secret rule would happily eat. Both are PUBLIC by
+    definition; masking them would leave a message reading "add this: «redacted»"."""
+    key = ("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHqZ0mQfZ5xW1kTn2vJ8sQpYbR3cL7dM4eF6gH9iJ0kL "
+           "vexa-workspace-ws-acme")
+    card = (f"This workspace has no credential for that repository yet ({PLAIN_FP}). "
+            f"Add this public key as a deploy key with WRITE access, then say `done` when added:\n{key}")
+    out = redact(card)
+    assert key in out, "the public key must survive — it is the answer, not a secret"
+    assert PLAIN_FP in out, "the fingerprint must survive, and not merely by luck"
+    assert "say `done` when added" in out
+
+
+def test_a_pat_in_the_same_message_is_still_masked():
+    """The allow-list must not become a hole: a real credential sitting beside the key still goes."""
+    key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHqZ0mQfZ5xW1kTn2vJ8sQpYbR3cL7dM4eF6gH9iJ0kL vexa"
+    out = redact(f"could not read Username for 'https://{PAT}@github.com'\n{key}\n{PLAIN_FP}")
+    assert PAT not in out and MASK in out
+    assert key in out and PLAIN_FP in out
+
+
+def test_an_md5_fingerprint_survives_too():
+    md5 = "MD5:" + ":".join(["ab"] * 16)
+    assert md5 in redact(f"key fingerprint {md5}")

--- a/core/agent/tests/test_shared_workspace_attach.py
+++ b/core/agent/tests/test_shared_workspace_attach.py
@@ -29,6 +29,7 @@ from control_plane.workspace_attach import (
 )
 from control_plane.workspace_reader import WorkspaceReader
 from shared.config import load_settings
+from tests import gitserve
 
 
 class _FakeRuntime:
@@ -202,12 +203,12 @@ def test_a_workspace_id_can_never_traverse(tmp_path, bad):
 
 # ── the routes: who may do it ──────────────────────────────────────────────────────────────────────
 
-def test_route_attaches_for_a_contributor_and_refuses_a_viewer(tmp_path):
+def test_route_attaches_for_a_contributor_and_refuses_a_viewer(tmp_path, monkeypatch):
     idx = m.InMemoryMembershipIndex()
     _shared_ws(tmp_path, "grp-r1", owner="u_owner")
     m.grant_membership(tmp_path, "grp-r1", "u_writer", "contributor", index=idx, added_by="u_owner", commit_fn=m.policy_commit)
     m.grant_membership(tmp_path, "grp-r1", "u_reader", "viewer", index=idx, added_by="u_owner", commit_fn=m.policy_commit)
-    repo = _existing_repo(tmp_path)
+    repo = gitserve.serve(tmp_path, gitserve.bare_repo(tmp_path, "kg"), monkeypatch)
     c = _client(tmp_path, idx)
 
     refused = c.post("/api/workspace/shared/grp-r1/attach", json={"repo": repo},
@@ -227,10 +228,10 @@ def test_route_attaches_for_a_contributor_and_refuses_a_viewer(tmp_path):
     assert (tmp_path / "grp-r1" / "README.md").exists()
 
 
-def test_route_attached_view_states_the_home_and_the_credential_kind_only(tmp_path):
+def test_route_attached_view_states_the_home_and_the_credential_kind_only(tmp_path, monkeypatch):
     idx = m.InMemoryMembershipIndex()
     _shared_ws(tmp_path, "grp-r2", owner="u_owner")
-    repo = _existing_repo(tmp_path)
+    repo = gitserve.serve(tmp_path, gitserve.bare_repo(tmp_path, "kg"), monkeypatch)
     c = _client(tmp_path, idx)
     c.post("/api/workspace/shared/grp-r2/attach", json={"repo": repo}, headers={"X-User-Id": "u_owner"})
 
@@ -240,30 +241,33 @@ def test_route_attached_view_states_the_home_and_the_credential_kind_only(tmp_pa
     assert view["workspace_id"] == "grp-r2"
     assert view["slots"][view["active"]]["repo"] == repo
     assert view["home"]["remote"] == "origin"
-    assert view["home"]["url"].rstrip(".git") == repo.rstrip(".git")
+    # the DISPLAY url drops any userinfo (workspace_publish._display_url treats it as a
+    # credential), so compare what identifies the repository: host and path.
+    assert view["home"]["url"].endswith("/acme/kg")
     assert view["credential"].startswith("origin ")
     assert "ghp_" not in got.text and "PRIVATE KEY" not in got.text
 
     assert c.get("/api/workspace/shared/grp-r2/attached", headers={"X-User-Id": "u_nobody"}).status_code == 403
 
 
-def test_push_pull_and_status_address_a_shared_workspace_by_id(tmp_path):
+def test_push_pull_and_status_address_a_shared_workspace_by_id(tmp_path, monkeypatch):
     """The sync routes already took a ``slug``; these prove it resolves a GROUP workspace, and that a
     pull — which rewrites the tree — is refused for a viewer even though a read of the same workspace is not."""
     idx = m.InMemoryMembershipIndex()
     _shared_ws(tmp_path, "grp-r3", owner="u_owner")
     m.grant_membership(tmp_path, "grp-r3", "u_reader", "viewer", index=idx, added_by="u_owner", commit_fn=m.policy_commit)
-    repo = _existing_repo(tmp_path, "syncme")
+    bare = gitserve.bare_repo(tmp_path, "syncme")
+    repo = gitserve.serve(tmp_path, bare, monkeypatch, repo="syncme")
     c = _client(tmp_path, idx)
     c.post("/api/workspace/shared/grp-r3/attach", json={"repo": repo}, headers={"X-User-Id": "u_owner"})
 
     st = c.get("/api/workspace/git-remote-status?slug=grp-r3", headers={"X-User-Id": "u_owner"})
     assert st.status_code == 200 and st.json()["has_home"]
-    assert st.json()["url"].rstrip(".git") == repo.rstrip(".git")
+    assert st.json()["url"].endswith("/acme/syncme")   # display url drops userinfo + .git
 
     # a new commit lands on the home; the group pulls it
     other = tmp_path / "collab"
-    subprocess.run(["git", "clone", "-q", repo, str(other)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", "-q", str(bare), str(other)], check=True, capture_output=True)
     _git(other, "config", "user.email", "t@t"); _git(other, "config", "user.name", "t")
     (other / "NEW.md").write_text("added elsewhere\n")
     _git(other, "add", "-A"); _git(other, "commit", "-q", "-m", "elsewhere"); _git(other, "push", "-q", "origin", "main")
@@ -282,7 +286,7 @@ def test_push_pull_and_status_address_a_shared_workspace_by_id(tmp_path):
     pushed = c.post("/api/workspace/push", json={"slug": "grp-r3", "token": "x"},
                     headers={"X-User-Id": "u_owner"})
     assert pushed.status_code == 200, pushed.text
-    assert _git(tmp_path / "syncme.git", "log", "--oneline", "-1").endswith("ours")
+    assert _git(bare, "log", "--oneline", "-1").endswith("ours")
 
 
 def test_deploy_key_route_hands_out_the_public_half_only(tmp_path):
@@ -327,12 +331,12 @@ def test_a_private_repo_with_no_credential_answers_with_the_key_to_add(tmp_path,
     assert (tmp_path / "grp-r5" / "CLAUDE.md").exists(), "the group's tree must be untouched by a failed attach"
 
 
-def test_the_desk_lane_answers_the_same_way(tmp_path):
+def test_the_desk_lane_answers_the_same_way(tmp_path, monkeypatch):
     """The person's OWN workspace loads a repo through ``/api/workspace/swap``, and it must resolve the
     same credential — otherwise an ssh:// repo works for a group and silently does not for a desk, and
     the MCP verb (which carries no token, ever) could only load public repos onto a desk."""
     c = _client(tmp_path)
-    repo = _existing_repo(tmp_path, "mine")
+    repo = gitserve.serve(tmp_path, gitserve.bare_repo(tmp_path, "mine"), monkeypatch, repo="mine")
 
     ok = c.post("/api/workspace/swap", json={"repo": repo, "ref": "main"}, headers={"X-User-Id": "u_solo"})
     assert ok.status_code == 200, ok.text


### PR DESCRIPTION
A founder pasted a GitHub PAT into the attach dialog's **Repository** field. It was sent, git was told to clone it, and git's answer — `fatal: repository '<the token>' does not exist` — was rendered in the error card and echoed to the browser console. My defect, from #1400.

Two independent failures had to line up, so there are two independent fixes. Either alone would have stopped it.

## F78 — the field is validated, client and server, before any git process exists

A whitelist, not a blacklist: the set of things that are a repository is small and knowable; the set of things that are a secret is neither. Accepted: `https://host/owner/repo(.git)`, `git@host:owner/repo.git`, `ssh://[user@]host/owner/repo`, and bare `owner/repo` (expanded to GitHub). Everything else is refused.

- **The client refuses first** (`surfaces/repoRef.ts`), and the point is not a nicer message — **the value never leaves the tab**. A token is called out on the keystroke that reveals it, Attach is disabled, and no request is made by either lane. A merely malformed value is judged on submit, not per-keystroke (shouting "not a repository" at `g` is noise that teaches people to ignore the warning).
- **The server refuses too** (`control_plane/repo_ref.py`), 422, **before any subprocess starts** — asserted by a test that fails if `subprocess.run` is called at all. Ordering is the fix: a validator that runs after `git clone` has already been told the secret has protected nothing.
- **And the mechanic refuses independently** — `assert_not_credential` sits inside `swap_workspace`, `activate_workspace`, `attach_repo_at` and `_git_clone`, so a secret cannot reach git through the MCP, a future route, or a test that forgot.

Token-shaped values get exactly the sentence asked for; a value that is merely not a repository gets its own (`That is not a repository. Use https://github.com/owner/repo, git@github.com:owner/repo.git, or owner/repo.`) — telling someone "that looks like a token" about `foo bar` is a guess, and a wrong guess about a secret is how people learn to ignore the warning. **A refusal never carries the value back**, in the body or the log; the log line names the *kind* only.

**Two things this closes that were not the reported bug.** A bare filesystem path is not a repository shape, so `POST /api/workspace/swap {"repo": "/workspaces/<someone-else>"}` — cloning another user's workspace out of the shared store — is now refused. And a URL carrying userinfo (`https://<PAT>@github.com/…`, the form people copy out of tutorials) is classified as a token, while `ssh://git@host/…` still works: the discriminator is the userinfo itself, not its presence.

## F79 — redaction is shape-based now, not "replace the token we were given"

The old redactor was `text.replace(token, "***")`. It does nothing when the credential arrives as the `repo` argument, which is exactly what happened. `shared/git_redaction.py` (+ a TypeScript twin) masks by **shape** — named token families (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`/`glpat-`), credentials wearing a URL, and a generic `[A-Za-z0-9_-]{36,}` run for the next provider's token before anyone has heard of it. Applied at `CloneError`, `RemoteSyncError`, every swap/attach/activate/push/pull route detail, the durable friction ledger, and the terminal's `presentError` + the card's verbatim block.

**Three deliberate allow-list holes, because a scrubber that eats the answer is not a fix:**

- a 40/64-char lowercase hex run is a **git object id**, and masking every sha makes clone errors unreadable;
- an **ssh public key** is what we hand someone whose credential is missing — masking it leaves a message reading *"add this: «redacted»"*. Caught by a test, not by review;
- a **key fingerprint**. `SHA256:` + 43 base64 chars only *sometimes* contains a `+` or `/`, and those fall outside the generic rule's character class — so today a fingerprint survives **by accident**, and roughly one in four would not. An intermittent bug in the message telling someone which key to add is the worst place to have one, so the shape is allow-listed rather than left to chance.

Tested both directions: a deploy-key card renders the full public key **and** its fingerprint, while a PAT sitting in the same message is masked.

## F80 — the lede

*"Your workspace is already on GitHub. Point one of your workspaces at it…"* → **"Point a workspace at a repository you have. The tree that is there now is parked, not destroyed."** It describes the control instead of asserting something about the reader that may be false.

## Where the token went — read from the code, not guessed

| Channel | Carried it? |
|---|---|
| **The browser console** | **Yes.** `presentError` does `console.warn("api failure", detail)`, and the detail was git's message. On the founder's machine. |
| **The rendered error card** | **Yes.** On screen. |
| **agent-api's own logs** | **No.** The clone error travels on an `HTTPException` detail; FastAPI does not log it, and no `logger.*` call in the swap path receives it. |
| **uvicorn access log** | **No.** Method, path and status — never the request or response body. |
| **The terminal's Next.js proxy** | **No.** It passes the body through untouched; its `console.error` fires only when `fetch` itself throws, and logs the error object. |
| **The friction ledger** (durable, never expires) | **Only if someone filed a report containing it** — nothing files automatically. Worth checking: `GET /api/friction/dump`. Future reports are scrubbed at `_clip`, the choke point every free-text field passes through. |

So the exposure is the founder's own browser (console + screen) and the token's transit through the gateway → agent-api → git process. **Revoking is the right call and there is nothing here that changes it.** Nothing on the server persisted it: the clone URL was never written to a remote, and the workspace was never created.

## Proof

- agent suite `1146 passed`, one pre-existing red (`test_meeting_room` — `requests_unixsocket`, unrelated)
- terminal `tsc --noEmit` clean; vitest `100 files / 1126 tests`
- the 14 pre-push static gates green — pushed **without** `--no-verify`
- new: `core/agent/tests/test_repo_ref_and_redaction.py` (46 cases, including "no subprocess may start for a refused repository" and the exact incident string), `clients/terminal/src/surfaces/__tests__/repoRef.test.ts` (26), and 6 new cases in `attachRepo.test.tsx` asserting the **absence of a request** when a token is typed

## One test-fixture change worth naming

Route tests used to pass a bare tmp path as the repo — the shape the validator now refuses. Rather than weaken the gate for tests, `core/agent/tests/gitserve.py` serves the same local bare repo over **git's real ssh transport** with a stubbed `ssh`, so the clone, the URL shape and git's own ssh code path are all exercised, offline.

Rebased onto `minutes-mcp-viewer` at `732676a40`.
