### PR TITLE
openai-agent: a provider-agnostic agent harness — the service runs on Qwen served by CCC (PRD decision 37)

### DIFF
--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -170,7 +170,7 @@
       "key": "VEXA_RUNNER",
       "class": "defaulted",
       "default": "claude-code",
-      "description": "agent harness stamped onto dispatched workspace turns; codex selects Codex app-server",
+      "description": "agent harness stamped onto dispatched workspace turns; codex selects the Codex app-server, openai-agent selects this repo\u2019s own loop over any OpenAI-compatible endpoint (VEXA_LLM_BASE_URL/_MODEL/_EXTRA_BODY, already forwarded)",
       "targets": [
         "compose"
       ]

--- a/core/agent/eval/harness_bench.py
+++ b/core/agent/eval/harness_bench.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""harness_bench.py — measure ANY harness runner on real DNA fixtures, offline.
+
+PRD decision 37's order: *build → measure on the DNA replay against the Haiku baseline → switch the
+scratch/sim lane at a window*. This is the measuring half, and it is committed rather than left in
+`/tmp` (where the write-back A/B that produced the ledger's baseline actually lived) for one reason:
+a number nobody can reproduce is a number nobody can argue with.
+
+It runs the REAL turn engine — `worker.engine.run_turn_over_workspace`, the real preambles, the real
+write-back phase with its real budget — over a scratch workspace seeded from `behavior/workspaces/
+default`, with the entity tool served by `eval/entity_mcp_stub.py` over stdio. Nothing running is
+touched: no rig, no docker, no stack, no mailpit.
+
+    python3 core/agent/eval/harness_bench.py --fixtures ~/dna-fixtures --out ~/dna-runs/oa \\
+        --dates 2026-03-02 2026-03-16 --runner openai-agent --model qwen3.8-27b
+
+    # the Haiku baseline the ledger carries
+    python3 core/agent/eval/harness_bench.py ... --runner claude-code --model haiku
+
+Per fixture it reports what the ledger reports, plus the two dimensions a NEW runner has to earn:
+
+    entities_touched  the DNA scorer's own dimension (`core/flows/eval/dna/score.py`)
+    pages             entity pages on disk after the turn + the phase
+    names_linked      the scorer's wikilink discipline measure (and `bare`, its denominator)
+    answer_s/phase_s  wall clock, the bottleneck the trimmed phase was built for
+    tool_ok           share of tool calls that returned ok — a loop that cannot call is not an agent
+    json_valid        share of tool calls whose ARGUMENTS parsed — the Qwen thinking-mode failure
+                      mode, visible as unparsable function arguments rather than as a bad answer
+
+A rate-limited or refusing model is a VOID row, never a low score (the ledger's own lesson).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve()
+REPO = HERE.parents[3]                                   # …/core/agent/eval/x.py → repo root
+sys.path.insert(0, str(REPO / "core/agent"))
+sys.path.insert(0, str(REPO / "core/flows/eval/dna"))
+
+TRANSCRIPT_CAP = 40_000
+_LIMIT = ("hit your limit", "rate limit", "usage limit", "credit balance", "quota")
+
+KICK = """A meeting you were in has finished. Write it up.
+
+Meeting: {title}
+Date: {date}
+
+Write the meeting note to `kg/entities/meeting/{date}-dna-tsc.md` — frontmatter (type, id, title),
+then `## Decided`, `## Committed` (each item with its owner), `## Open`. Every item attributed.
+Write only what the transcript says.
+
+Then reply to me with the report itself — the same words everyone in the room will read.
+
+=== TRANSCRIPT ===
+{transcript}
+"""
+
+
+def _void(text: str) -> bool:
+    t = (text or "").lower()
+    return any(m in t for m in _LIMIT)
+
+
+def workspace(out: Path, tag: str, seed: Path) -> Path:
+    ws = out / tag
+    if ws.exists():
+        shutil.rmtree(ws)
+    shutil.copytree(seed, ws)
+    subprocess.run(["git", "-C", str(ws), "init", "-q"], check=True)
+    for k, v in (("user.email", "bench@rehearsal.test"), ("user.name", "bench")):
+        subprocess.run(["git", "-C", str(ws), "config", k, v], check=True)
+    subprocess.run(["git", "-C", str(ws), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(ws), "commit", "-qm", "seed"], check=True)
+    return ws
+
+
+def transcript_of(fx: dict) -> str:
+    return "\n".join(f"{s.get('speaker', '?')}: {s.get('text', '')}"
+                     for s in fx["segments"])[:TRANSCRIPT_CAP]
+
+
+def entity_files(ws: Path) -> list[str]:
+    base = ws / "kg" / "entities"
+    return sorted(str(f.relative_to(ws)) for f in base.rglob("*.md") if f.name != "index.md")
+
+
+def note_of(ws: Path) -> str:
+    d = ws / "kg" / "entities" / "meeting"
+    files = [f for f in sorted(d.glob("*.md")) if f.name != "index.md"] if d.is_dir() else []
+    return files[0].read_text() if files else ""
+
+
+def _last_assistant_text(ws: Path) -> str:
+    out = ""
+    for f in sorted((ws / ".claude" / "projects").rglob("*.jsonl")):
+        for line in f.read_text().splitlines():
+            try:
+                e = json.loads(line)
+            except ValueError:
+                continue
+            if e.get("type") != "assistant":
+                continue
+            for b in (e.get("message", {}) or {}).get("content", []) or []:
+                if b.get("type") == "text" and b.get("text"):
+                    out = b["text"]
+    return out
+
+
+class _Tally:
+    """Tool-call health, read off the event stream: how many calls, how many returned ok, and how
+    many arrived with parsable arguments. The third is the one that separates a model that can drive
+    a loop from one that only looks like it can."""
+
+    def __init__(self) -> None:
+        self.calls = self.ok = self.parsed = 0
+
+    def call(self, ev: dict) -> None:
+        self.calls += 1
+        args = ev.get("args")
+        if isinstance(args, dict) and "__unparsed_arguments__" not in args:
+            self.parsed += 1
+
+    def result(self, ev: dict) -> None:
+        self.ok += 1 if ev.get("ok") else 0
+
+    def as_dict(self, prefix: str = "") -> dict:
+        n = max(1, self.calls)
+        return {f"{prefix}calls": self.calls,
+                f"{prefix}tool_ok": round(self.ok / n, 3) if self.calls else None,
+                f"{prefix}json_valid": round(self.parsed / n, 3) if self.calls else None}
+
+
+def run_fixture(ws: Path, prompt: str, *, harness, model: str, engine, stub: Path) -> dict:
+    mounts = [{"slug": ws.name, "path": str(ws), "write": True, "primary": True, "role": "private"}]
+    engine.active_mounts = lambda: mounts
+    os.environ["VEXA_MOUNTS"] = json.dumps(mounts)
+
+    answer, phase = _Tally(), _Tally()
+    t0 = time.time()
+    said, upserts, reply = [prompt], 0, ""
+    for ev in engine.run_turn_over_workspace(
+            ws, prompt, model=model, allowed_tools=["Read", "Write", "Edit", "Glob", "Grep"],
+            commit=False, session="bench", harness=harness):
+        t = ev.get("type")
+        if t == "tool-call":
+            answer.call(ev)
+            if str(ev.get("tool") or "").endswith("entity_upsert"):
+                upserts += 1
+        elif t == "tool-result":
+            answer.result(ev)
+            if ev.get("summary"):
+                said.append(str(ev["summary"]))
+        elif t == "message-delta" and ev.get("text"):
+            said.append(ev["text"])
+        elif t == "done":
+            reply = ev.get("reply") or ""
+    out = {"answer_s": round(time.time() - t0, 1), "prepass_s": 0.0, "phase_s": 0.0,
+           "model_call": False, "candidates": [], "truncated": None, "phase_reply": "",
+           "void": _void(reply), "reply": reply, **answer.as_dict()}
+
+    t1 = time.time()
+    cands = (engine.writeback_candidates(said, mounts)
+             if engine.should_write_back(prompt, answer.calls, upserts=upserts) else [])
+    out["prepass_s"] = round(time.time() - t1, 2)
+    out["candidates"] = cands
+    if not engine.should_write_back(prompt, answer.calls, upserts=upserts, candidates=cands):
+        out["phase_s"] = out["prepass_s"]
+        return out
+
+    # THE TOOL PATH, which is what production takes. Without it the phase hand-writes each card as
+    # markdown — about four times the tokens — and the measurement reports the cost of a path only a
+    # dispatch with no delegation token ever takes.
+    cfg = ws / ".claude" / "entities-mcp.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(json.dumps({"mcpServers": {"entities": {
+        "type": "stdio", "command": sys.executable, "args": [str(stub), str(ws)]}}}))
+    tools = [*engine.WRITEBACK_TOOLS, "mcp__entities", "mcp__entities__entity_upsert"]
+    max_calls, max_s = engine.writeback_budget()
+    out["model_call"] = True
+    for ev in engine.writeback_events(engine.bounded(
+            engine.run_turn_over_workspace(
+                ws, engine.writeback_prompt(cands), model=model, allowed_tools=tools,
+                mcp_config=str(cfg), commit=False, session="bench", harness=harness),
+            max_tool_calls=max_calls, max_seconds=max_s)):
+        if ev.get("type") == "tool-call":
+            phase.call(ev)
+        elif ev.get("type") == "tool-result":
+            phase.result(ev)
+        elif ev.get("type") == "writeback-truncated":
+            out["truncated"] = ev.get("reason")
+    reply2 = _last_assistant_text(ws)
+    out["phase_reply"] = reply2[:400]
+    out["void"] = out["void"] or _void(reply2)
+    out["phase_s"] = round(time.time() - t1, 1)
+    out.update(phase.as_dict("phase_"))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--fixtures", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--dates", nargs="+", required=True)
+    ap.add_argument("--runner", default=os.environ.get("VEXA_RUNNER") or "claude-code")
+    ap.add_argument("--model", default=os.environ.get("VEXA_LLM_MODEL") or "haiku")
+    ap.add_argument("--seed", type=Path, default=REPO / "behavior/workspaces/default")
+    args = ap.parse_args()
+
+    os.environ["VEXA_RUNNER"] = args.runner
+    from llm.registry import HARNESS_RUNNERS                       # noqa: E402
+    from worker import engine                                      # noqa: E402
+    import score as S                                              # noqa: E402
+
+    if args.runner not in HARNESS_RUNNERS:
+        print(f"unknown runner {args.runner!r} — known: {sorted(HARNESS_RUNNERS)}")
+        return 2
+    harness = HARNESS_RUNNERS[args.runner]()
+    stub = HERE.parent / "entity_mcp_stub.py"
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for date in args.dates:
+        fx = json.loads((args.fixtures / f"{date}.transcript.json").read_text())
+        prompt = KICK.format(title=fx["meeting"]["title"], date=date, transcript=transcript_of(fx))
+        ws = workspace(args.out, f"{date}-{args.runner}", args.seed)
+        print(f"\n=== {date} · {args.runner} · {args.model} ===", flush=True)
+        res = run_fixture(ws, prompt, harness=harness, model=args.model, engine=engine, stub=stub)
+        files = entity_files(ws)
+        rec = {"note": note_of(ws), "entity_files": files, "entity_turns": 1}
+        ent, _ = S.d_entities_touched(rec)
+        nm, ev_n = S.d_names_linked(rec)
+        row = {"date": date, "runner": args.runner, "model": args.model,
+               "entities_touched": ent, "pages": len(files), "names_linked": nm,
+               "bare": ev_n.get("count"), "files": files,
+               **{k: v for k, v in res.items() if k != "reply"}}
+        print(json.dumps({k: v for k, v in row.items()
+                          if k not in ("files", "candidates", "phase_reply")}, indent=1), flush=True)
+        rows.append(row)
+        (args.out / f"{date}-{args.runner}.json").write_text(
+            json.dumps({**row, "reply": res["reply"]}, indent=1))
+        if row["void"]:
+            (args.out / "bench.json").write_text(json.dumps(rows, indent=1))
+            print("\nVOID — the model refused or was throttled; every number after this point would "
+                  "measure the limiter. Stopping.", flush=True)
+            return 2
+    (args.out / "bench.json").write_text(json.dumps(rows, indent=1))
+
+    n = max(1, len(rows))
+    def avg(k):
+        vals = [r[k] for r in rows if isinstance(r.get(k), (int, float))]
+        return sum(vals) / len(vals) if vals else float("nan")
+    print("\n" + "=" * 92)
+    print(f"{args.runner}/{args.model}: entities_touched {avg('entities_touched'):.3f} · "
+          f"pages/fixture {avg('pages'):.1f} · names_linked {avg('names_linked'):.3f} · "
+          f"answer_s {avg('answer_s'):.1f} · phase_s {avg('phase_s'):.1f} · "
+          f"tool_ok {avg('tool_ok'):.3f} · json_valid {avg('json_valid'):.3f} · n={n}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/agent/llm/README.md
+++ b/core/agent/llm/README.md
@@ -23,8 +23,25 @@ fakes.
   `claude_cli.py` (beats via the claude CLI on mounted SUBSCRIPTION credentials — no API key;
   slower per beat; for subscription-only deployments).
 - **Harnesses**: `claude_code.py` (the `claude` CLI — stream-json + open-stdin steering) · `codex.py`
-  (Codex app-server JSON-RPC — durable threads + `turn/steer`). Both normalize into the same frozen
-  UnitEvents; Claude remains the deployment default.
+  (Codex app-server JSON-RPC — durable threads + `turn/steer`) · `openai_agent.py` (**ours** — an
+  agent loop over any OpenAI-compatible `chat/completions` with function calling, no CLI and no
+  vendor SDK). All three normalize into the same frozen UnitEvents; Claude remains the deployment
+  default.
+
+### The runner matrix
+
+| `VEXA_RUNNER` | What drives the turn | Tools the model gets | Sessions | Steering |
+|---|---|---|---|---|
+| `claude-code` (default) | the `claude` CLI, `--output-format stream-json` | the CLI's own (Read/Write/Edit/Bash/Web...) + MCP via `--mcp-config` | CLI transcripts under `.claude/projects` | mid-turn stdin injection |
+| `codex` | Codex app-server over JSON-RPC | Codex's own + MCP | durable threads | `turn/steer` |
+| `openai-agent` | **this repo's loop**, raw httpx to `POST {base}/chat/completions` | `Read`/`Write`/`Edit`/`Glob`/`Grep` implemented here, sandboxed to the mounts, plus every MCP tool in the same `mcp.json` (http **and** stdio) | JSONL written in the CLI's on-disk shape, so `workspace_reader.history` reads it unchanged | none (one request at a time) |
+
+`openai-agent` exists for PRD decision 37: run the service on a model we host. It has **no `Bash`,
+no `WebSearch`/`WebFetch` and no skills discovery** — a name in the allow-set it does not implement
+is simply not attached. It carries a hard per-turn budget (tool calls + wall clock) and trims
+context oldest-tool-result-first, because the box it was built for holds ~29 requests at 24k
+context. Qwen on that box needs `VEXA_LLM_EXTRA_BODY={"chat_template_kwargs":{"enable_thinking":false}}`
+or it spends the whole budget reasoning.
 
 Raw `httpx`, no vendor SDKs — the protocols are ~10 lines each and a pinned SDK is a heavier
 supply-chain surface than the dialect itself.
@@ -38,7 +55,11 @@ supply-chain surface than the dialect itself.
 | `VEXA_LLM_API_KEY` | credential (optional for local runtimes) | falls back `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` |
 | `VEXA_LLM_MODEL` | deployment-default model (free string) | empty → fail-loud at completion call |
 | `VEXA_LLM_MAX_TOKENS` | Messages-API max_tokens | 4096 |
-| `VEXA_RUNNER` | harness adapter key: `claude-code` \| `codex` | `claude-code` |
+| `VEXA_RUNNER` | harness adapter key: `claude-code` \| `codex` \| `openai-agent` | `claude-code` |
+| `VEXA_LLM_EXTRA_BODY` | JSON object merged into EVERY request (openai-compat + openai-agent) | `{}` |
+| `VEXA_AGENT_MAX_TOOL_CALLS` / `VEXA_AGENT_MAX_TURN_SEC` | openai-agent per-turn budget | 40 / 900 |
+| `VEXA_AGENT_CONTEXT_TOKENS` | openai-agent context ceiling (trims oldest tool results first) | 24000 |
+| `VEXA_AGENT_STREAM` | openai-agent SSE streaming (`0` = one blocking request) | `1` |
 | `ANTHROPIC_*`, `HOST_CLAUDE_CREDENTIALS` | claude-code adapter ONLY | — |
 | `HOST_CODEX_CREDENTIALS`, `OPENAI_API_KEY` | codex adapter subscription-file / API-key auth | — |
 

--- a/core/agent/llm/openai_agent.py
+++ b/core/agent/llm/openai_agent.py
@@ -1,0 +1,917 @@
+"""openai_agent.py — OUR OWN agent loop over any OpenAI-compatible endpoint (``HarnessPort``).
+
+PRD decision 37. The two harnesses that existed both drive a VENDOR CLI (`claude`, `codex`), so a
+deployment that wants to run on a model we host ourselves — the CCC box serving Qwen3.8-27B over
+vLLM — had nowhere to go: `openai_compat.py` is a COMPLETION port (prompt→text, no tools), and a
+completion port cannot run this product's turns, which are tool loops from end to end.
+
+This file is the missing third: the loop itself, in ~600 lines of raw httpx, no vendor SDK.
+
+    POST {base}/chat/completions  with `tools` + `tool_choice: auto`
+      → assistant text            → `message-delta`
+      → assistant tool_calls      → `tool-call`, executed here, `tool-result`, fed back
+      → no tool_calls             → `done`
+
+Everything the rest of the system sees is the FROZEN UnitEvent stream of ``ports.py``, so the
+terminal reducer, the SSE relay and the history reader cannot tell which harness produced a turn.
+Three seams make that true and each one is load-bearing:
+
+* **The transcript is written in the Claude Code shape** (`<chat_root>/.claude/projects/<slug>/
+  <session>.jsonl`), because ``control_plane.workspace_reader.history`` reads that file — and the
+  user turn is stored VERBATIM, the exact composed string the model was handed. That is what makes
+  ``engine._prompt_key`` (a sha256 of those bytes) find the person's own words, and what makes the
+  F51 phase mark and the machinery mark work: the reader tests for `[vexa-phase:writeback]` IN THE
+  STORED PROMPT, so a harness that stored a paraphrase would silently un-hide every write-back
+  exchange. This adapter therefore never rewrites, prefixes or trims the prompt on its way to disk.
+* **The panel conventions are IMPORTED, not re-implemented** — the writer-tool tab, the
+  `transcript_terms` chips (decision 35) and the `bot_send` transcript open (decision 30.4) come
+  from ``llm.claude_code`` itself. A second spelling of those vocabularies is a second thing that
+  can go stale; there is one.
+* **MCP is attached from the SAME `mcp.json`** ``worker.engine.mcp_delegation_config`` already
+  writes (the rig over streamable-http with `Authorization: Bearer <delegation token>`). Both
+  transports of that file are supported — http for the rig, stdio for the offline eval stub — and
+  the tools are exposed to the model under the same `mcp__<server>__<tool>` names the allow-set and
+  the event conventions are written against.
+
+WHAT IT DELIBERATELY DOES NOT HAVE. No `Bash`, no `WebSearch`/`WebFetch`, no skills discovery, no
+mid-turn injection. The file tools are ours (`Read`/`Write`/`Edit`/`Glob`/`Grep`), minimal, and
+sandboxed to the mount roots — a path outside them is refused rather than clamped, because a write
+that silently lands somewhere else is worse than a failed call. Names in the allow-set that this
+harness does not implement are simply not attached, and the turn says so through the tools it has.
+
+SIZING (CCC-Inference-Deployment): the KV cache holds ~29 requests at 24k context, so the loop
+carries a HARD per-turn budget — max tool calls, max wall seconds — and trims context (oldest tool
+results first) to stay under ``VEXA_AGENT_CONTEXT_TOKENS``. A shared box is a shared box.
+
+Config: ``VEXA_LLM_BASE_URL`` · ``VEXA_LLM_API_KEY`` (optional — CCC has no auth) ·
+``VEXA_LLM_MODEL`` / ``VEXA_AGENT_MODEL`` · ``VEXA_LLM_EXTRA_BODY`` (merged into EVERY request —
+Qwen needs `{"chat_template_kwargs":{"enable_thinking":false}}` or it reasons its whole budget away
+and returns nothing parseable) · ``VEXA_AGENT_MAX_TOOL_CALLS`` · ``VEXA_AGENT_MAX_TURN_SEC`` ·
+``VEXA_AGENT_CONTEXT_TOKENS`` · ``VEXA_AGENT_STREAM``.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+import httpx
+
+from llm.errors import LLMAuthError, LLMConfigError, LLMError
+# The panel/chip/transcript vocabularies are the CLAUDE adapter's, imported rather than copied: the
+# terminal must render an openai-agent turn identically, and two copies of a closed vocabulary drift.
+from llm.claude_code import (_BOT_TOOLS, _TERMS_TOOLS, _WRITER_TOOLS, _bot_artifact,
+                             _published_terms, _short, _written_artifact)
+from llm.openai_compat import _parse_extra_body
+from llm.ports import harness_subprocess_env
+
+log = logging.getLogger(__name__)
+
+# ── budgets ──────────────────────────────────────────────────────────────────────────────────────
+# Defaults chosen against the CCC node's sizing table: ~29 concurrent requests at 24k context, and
+# this product's turns are prefill-dominated (input is ~95% of the tokens moved). A turn that grows
+# its own context without a ceiling is a turn that evicts everybody else's.
+_DEFAULT_CONTEXT_TOKENS = 24_000
+_DEFAULT_MAX_TOOL_CALLS = 40
+_DEFAULT_MAX_TURN_SEC = 900.0
+# A tool result is the one part of a turn that is both large and, once acted on, mostly spent — so
+# it is what the trimmer eats first, and a stub is left in its place so the model can see that it
+# read something rather than believing it never did.
+_TRIM_STUB = "[trimmed: this tool result was dropped to stay inside the turn's context budget]"
+_TOOL_RESULT_MAX_CHARS = 24_000     # one result can never be more than a third of a 24k budget
+
+
+def _int_env(key: str, default: int) -> int:
+    try:
+        return int(os.environ.get(key, "") or default)
+    except ValueError:
+        return default
+
+
+def _float_env(key: str, default: float) -> float:
+    try:
+        return float(os.environ.get(key, "") or default)
+    except ValueError:
+        return default
+
+
+def _est_tokens(obj: object) -> int:
+    """A chars/4 estimate. Deliberately crude and deliberately LOCAL: a tokenizer would be a model
+    dependency in a module that must stay liftable, and the budget it guards is a safety margin on a
+    shared box, not an accounting figure."""
+    try:
+        return max(1, len(json.dumps(obj, default=str)) // 4)
+    except (TypeError, ValueError):
+        return 1
+
+
+# ── the MCP client (stdio + streamable-http), stdlib-shaped ─────────────────────────────────────
+
+class _MCPServer:
+    """One MCP server from the harness's `mcp.json`, in whichever transport it declares.
+
+    Two transports because the two consumers need different ones and the file already expresses
+    both: the worker writes `{"type":"http","url":…,"headers":{"Authorization":"Bearer …"}}` for the
+    rig, and the offline eval attaches `{"type":"stdio","command":…,"args":[…]}` for the entity stub
+    (#1414). Anything else is skipped with a warning — an unattachable server must not take the turn
+    down, it must cost the turn that server's tools and say so in the log.
+    """
+
+    def __init__(self, name: str, spec: dict, *, timeout: float = 120.0,
+                 client: Optional[httpx.Client] = None) -> None:
+        self.name = name
+        self._spec = spec or {}
+        self._timeout = timeout
+        self._id = 0
+        self._proc: Optional[subprocess.Popen] = None
+        self._http: Optional[httpx.Client] = client
+        self._owns_http = client is None
+        self._session_header: dict[str, str] = {}
+        self.tools: list[dict] = []
+
+    # -- transport --------------------------------------------------------------------------
+    def _kind(self) -> str:
+        t = str(self._spec.get("type") or "").strip().lower()
+        if t:
+            return t
+        return "stdio" if self._spec.get("command") else ("http" if self._spec.get("url") else "")
+
+    def _next_id(self) -> int:
+        self._id += 1
+        return self._id
+
+    def _rpc(self, method: str, params: Optional[dict] = None, *, notify: bool = False) -> dict:
+        body: dict = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            body["params"] = params
+        if not notify:
+            body["id"] = self._next_id()
+        kind = self._kind()
+        if kind == "stdio":
+            return self._rpc_stdio(body, notify=notify)
+        return self._rpc_http(body, notify=notify)
+
+    def _rpc_stdio(self, body: dict, *, notify: bool) -> dict:
+        proc = self._proc
+        if proc is None or proc.stdin is None or proc.stdout is None:
+            raise LLMError(f"mcp {self.name}: stdio server is not running")
+        proc.stdin.write(json.dumps(body) + "\n")
+        proc.stdin.flush()
+        if notify:
+            return {}
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                raise LLMError(f"mcp {self.name}: stdio server closed while awaiting {body['method']}")
+            try:
+                msg = json.loads(line)
+            except ValueError:
+                continue                       # a server logging to stdout — skip, keep reading
+            if msg.get("id") != body.get("id"):
+                continue                       # a notification or an out-of-band message
+            if msg.get("error"):
+                raise LLMError(f"mcp {self.name}: {msg['error']}")
+            return msg.get("result") or {}
+
+    def _rpc_http(self, body: dict, *, notify: bool) -> dict:
+        assert self._http is not None
+        url = str(self._spec.get("url") or "")
+        headers = {"Content-Type": "application/json",
+                   # streamable-http may answer either way; both are handled below
+                   "Accept": "application/json, text/event-stream"}
+        headers.update({str(k): str(v) for k, v in (self._spec.get("headers") or {}).items()})
+        headers.update(self._session_header)
+        r = self._http.post(url, json=body, headers=headers)
+        # The server's session id rides a RESPONSE header on initialize and must be echoed after.
+        sid = r.headers.get("mcp-session-id") or r.headers.get("Mcp-Session-Id")
+        if sid:
+            self._session_header["Mcp-Session-Id"] = sid
+        if r.status_code in (401, 403):
+            raise LLMAuthError(f"mcp {self.name}: {r.status_code} from {url}: {r.text[:200]}")
+        if r.status_code >= 400:
+            raise LLMError(f"mcp {self.name}: {r.status_code} from {url}: {r.text[:200]}")
+        if notify or r.status_code == 202 or not (r.content or b"").strip():
+            return {}
+        payload = self._decode_http(r, body.get("id"))
+        if payload.get("error"):
+            raise LLMError(f"mcp {self.name}: {payload['error']}")
+        return payload.get("result") or {}
+
+    @staticmethod
+    def _decode_http(r: httpx.Response, want_id: object) -> dict:
+        ctype = (r.headers.get("content-type") or "").lower()
+        if "text/event-stream" in ctype:
+            out: dict = {}
+            for line in r.text.splitlines():
+                line = line.strip()
+                if not line.startswith("data:"):
+                    continue
+                try:
+                    msg = json.loads(line[5:].strip())
+                except ValueError:
+                    continue
+                if isinstance(msg, dict) and (msg.get("id") == want_id or "result" in msg):
+                    out = msg
+            return out
+        try:
+            return r.json()
+        except ValueError as exc:
+            raise LLMError(f"mcp: malformed response: {exc}") from exc
+
+    # -- lifecycle --------------------------------------------------------------------------
+    def start(self) -> list[dict]:
+        kind = self._kind()
+        if kind == "stdio":
+            argv = [str(self._spec.get("command") or ""), *[str(a) for a in (self._spec.get("args") or [])]]
+            env = harness_subprocess_env()
+            env.update({str(k): str(v) for k, v in (self._spec.get("env") or {}).items()})
+            self._proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                          stderr=subprocess.DEVNULL, text=True, bufsize=1, env=env)
+        elif kind in ("http", "streamable-http", "sse"):
+            if self._http is None:
+                self._http = httpx.Client(timeout=self._timeout)
+        else:
+            raise LLMConfigError(f"mcp {self.name}: unsupported transport {kind!r}")
+        self._rpc("initialize", {"protocolVersion": "2025-03-26",
+                                 "capabilities": {},
+                                 "clientInfo": {"name": "vexa-openai-agent", "version": "1"}})
+        try:
+            self._rpc("notifications/initialized", {}, notify=True)
+        except LLMError:
+            pass                                # a server that does not want the notification
+        listed = self._rpc("tools/list", {})
+        self.tools = [t for t in (listed.get("tools") or []) if isinstance(t, dict) and t.get("name")]
+        return self.tools
+
+    def call(self, tool: str, args: dict) -> tuple[bool, str]:
+        """``(ok, text)`` for one `tools/call`. A transport failure is a FAILED TOOL, never an
+        exception out of the loop: the model is told the call failed and can choose again, which is
+        the whole point of running a loop rather than a pipeline."""
+        try:
+            res = self._rpc("tools/call", {"name": tool, "arguments": args})
+        except (LLMError, OSError, ValueError) as exc:
+            return False, f"{type(exc).__name__}: {exc}"
+        text = "".join(b.get("text", "") for b in (res.get("content") or [])
+                       if isinstance(b, dict) and b.get("type") == "text")
+        if not text:
+            text = json.dumps(res.get("structuredContent") or res, default=str)
+        return (not res.get("isError")), text
+
+    def close(self) -> None:
+        if self._proc is not None:
+            for stream in (self._proc.stdin, self._proc.stdout):
+                try:
+                    if stream is not None:
+                        stream.close()
+                except OSError:
+                    pass
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait()
+            self._proc = None
+        if self._http is not None and self._owns_http:
+            self._http.close()
+            self._http = None
+
+
+def _load_mcp(mcp_config: Optional[str], *, http_client: Optional[httpx.Client] = None
+              ) -> tuple[list[_MCPServer], dict[str, tuple[_MCPServer, str]]]:
+    """Attach every server in the Claude-shaped `mcp.json` → (servers, function-name → (server, tool)).
+
+    The exposed function name is `mcp__<server>__<tool>` — the SAME name claude-code gives it, which
+    is what the allow-set (`worker.engine.VEXA_MCP_TOOLS`) and the panel conventions above are
+    written against. OpenAI function names are capped at 64 chars; a longer one is truncated with a
+    short digest so it stays unique and still callable."""
+    servers: list[_MCPServer] = []
+    index: dict[str, tuple[_MCPServer, str]] = {}
+    if not mcp_config:
+        return servers, index
+    try:
+        cfg = json.loads(Path(mcp_config).read_text())
+    except (OSError, ValueError) as exc:
+        log.warning("mcp config unreadable (%s) — running this turn without the toolbelt", exc)
+        return servers, index
+    for name, spec in (cfg.get("mcpServers") or {}).items():
+        srv = _MCPServer(str(name), spec if isinstance(spec, dict) else {}, client=http_client)
+        try:
+            tools = srv.start()
+        except (LLMError, LLMConfigError, LLMAuthError, OSError) as exc:
+            log.warning("mcp %s: could not attach (%s) — the turn runs without its tools", name, exc)
+            srv.close()
+            continue
+        servers.append(srv)
+        for t in tools:
+            index[_fn_name(str(name), str(t["name"]))] = (srv, str(t["name"]))
+    return servers, index
+
+
+def _fn_name(server: str, tool: str) -> str:
+    name = f"mcp__{server}__{tool}"
+    if len(name) <= 64:
+        return name
+    import hashlib
+    return name[:56] + "_" + hashlib.sha256(name.encode()).hexdigest()[:7]
+
+
+def _mcp_specs(index: dict[str, tuple[_MCPServer, str]]) -> list[dict]:
+    specs = []
+    for fn, (srv, tool) in index.items():
+        schema = next((t.get("inputSchema") for t in srv.tools if t.get("name") == tool), None)
+        desc = next((t.get("description") for t in srv.tools if t.get("name") == tool), "") or ""
+        specs.append({"type": "function", "function": {
+            "name": fn, "description": desc[:1024],
+            "parameters": schema if isinstance(schema, dict) else {"type": "object", "properties": {}},
+        }})
+    return specs
+
+
+# ── the built-in file tools (sandboxed to the mount roots) ──────────────────────────────────────
+
+BUILTIN_SPECS: dict[str, dict] = {
+    "Read": {"description": "Read a file from the mounted workspace. Absolute path under a mount.",
+             "parameters": {"type": "object", "properties": {
+                 "file_path": {"type": "string"},
+                 "offset": {"type": "integer", "description": "1-based first line"},
+                 "limit": {"type": "integer"}}, "required": ["file_path"]}},
+    "Write": {"description": "Write a file in the mounted workspace, creating parent directories. "
+                             "Overwrites. Absolute path under a mount.",
+              "parameters": {"type": "object", "properties": {
+                  "file_path": {"type": "string"}, "content": {"type": "string"}},
+                  "required": ["file_path", "content"]}},
+    "Edit": {"description": "Replace an exact string in a file. Fails if old_string is absent or "
+                            "appears more than once and replace_all is false.",
+             "parameters": {"type": "object", "properties": {
+                 "file_path": {"type": "string"}, "old_string": {"type": "string"},
+                 "new_string": {"type": "string"}, "replace_all": {"type": "boolean"}},
+                 "required": ["file_path", "old_string", "new_string"]}},
+    "Glob": {"description": "List files matching a glob pattern (** supported) under a directory.",
+             "parameters": {"type": "object", "properties": {
+                 "pattern": {"type": "string"}, "path": {"type": "string"}},
+                 "required": ["pattern"]}},
+    "Grep": {"description": "Search file contents for a regular expression under a directory.",
+             "parameters": {"type": "object", "properties": {
+                 "pattern": {"type": "string"}, "path": {"type": "string"},
+                 "glob": {"type": "string"}, "case_insensitive": {"type": "boolean"}},
+                 "required": ["pattern"]}},
+}
+
+_GREP_MAX_HITS = 200
+_READ_MAX_CHARS = 100_000
+_GLOB_MAX = 400
+
+
+def mount_roots(work: Path) -> list[Path]:
+    """Every directory this harness's file tools may touch: the turn's cwd plus each declared mount.
+
+    Read from ``VEXA_MOUNTS`` the same way ``worker.engine.active_mounts`` does — by ENV, not by
+    import, because this module owns no product imports. A malformed value costs the extra mounts,
+    never the turn."""
+    roots = [work.resolve()]
+    raw = os.environ.get("VEXA_MOUNTS") or ""
+    if raw:
+        try:
+            for m in json.loads(raw):
+                if isinstance(m, dict) and m.get("path"):
+                    roots.append(Path(str(m["path"])).resolve())
+        except (ValueError, TypeError, OSError):
+            log.warning("VEXA_MOUNTS is not valid JSON — file tools are scoped to the cwd only")
+    out: list[Path] = []
+    for r in roots:
+        if r not in out:
+            out.append(r)
+    return out
+
+
+class _Sandbox:
+    """Path resolution that REFUSES rather than clamps. A tool call aimed outside the mounts is a
+    mistake worth telling the model about — a silently rewritten path writes the right bytes to the
+    wrong workspace, which is the one failure nobody can see afterwards."""
+
+    def __init__(self, roots: list[Path]) -> None:
+        self._roots = roots
+
+    def resolve(self, raw: str) -> Path:
+        if not raw:
+            raise ValueError("no path given")
+        p = Path(raw)
+        if not p.is_absolute():
+            p = self._roots[0] / p
+        # resolve() without strict so a not-yet-existing file still normalises (Write creates it)
+        p = Path(os.path.normpath(str(p)))
+        try:
+            real = p.resolve()
+        except OSError:
+            real = p
+        for root in self._roots:
+            if real == root or root in real.parents:
+                return real
+        raise ValueError(f"path {raw} is outside the mounted workspaces "
+                         f"({', '.join(str(r) for r in self._roots)})")
+
+
+def run_builtin(tool: str, args: dict, sandbox: _Sandbox) -> tuple[bool, str]:
+    """One built-in file tool → ``(ok, text)``. Never raises: a bad call is a failed tool result."""
+    try:
+        if tool == "Read":
+            path = sandbox.resolve(str(args.get("file_path") or ""))
+            text = path.read_text(encoding="utf-8", errors="replace")
+            lines = text.splitlines()
+            start = max(0, int(args.get("offset") or 1) - 1)
+            limit = int(args.get("limit") or 2000)
+            chunk = "\n".join(lines[start:start + limit])
+            return True, chunk[:_READ_MAX_CHARS]
+        if tool == "Write":
+            path = sandbox.resolve(str(args.get("file_path") or ""))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            content = args.get("content")
+            path.write_text("" if content is None else str(content), encoding="utf-8")
+            return True, f"wrote {path}"
+        if tool == "Edit":
+            path = sandbox.resolve(str(args.get("file_path") or ""))
+            old, new = str(args.get("old_string") or ""), str(args.get("new_string") or "")
+            text = path.read_text(encoding="utf-8")
+            hits = text.count(old)
+            if not old or hits == 0:
+                return False, "old_string not found in the file"
+            if hits > 1 and not args.get("replace_all"):
+                return False, f"old_string appears {hits} times — pass replace_all or extend it"
+            path.write_text(text.replace(old, new) if args.get("replace_all")
+                            else text.replace(old, new, 1), encoding="utf-8")
+            return True, f"edited {path}"
+        if tool == "Glob":
+            base = sandbox.resolve(str(args.get("path") or "")) if args.get("path") else sandbox.resolve(".")
+            pattern = str(args.get("pattern") or "*")
+            hits = sorted(str(p) for p in base.glob(pattern) if p.is_file())[:_GLOB_MAX]
+            return True, "\n".join(hits) if hits else "(no matches)"
+        if tool == "Grep":
+            base = sandbox.resolve(str(args.get("path") or "")) if args.get("path") else sandbox.resolve(".")
+            flags = re.IGNORECASE if args.get("case_insensitive") else 0
+            rx = re.compile(str(args.get("pattern") or ""), flags)
+            keep = str(args.get("glob") or "")
+            out: list[str] = []
+            for f in sorted(base.rglob("*")):
+                if len(out) >= _GREP_MAX_HITS:
+                    break
+                if not f.is_file() or ".git" in f.parts:
+                    continue
+                if keep and not fnmatch.fnmatch(f.name, keep):
+                    continue
+                try:
+                    for n, line in enumerate(f.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
+                        if rx.search(line):
+                            out.append(f"{f}:{n}:{line.strip()[:200]}")
+                            if len(out) >= _GREP_MAX_HITS:
+                                break
+                except OSError:
+                    continue
+            return True, "\n".join(out) if out else "(no matches)"
+    except (OSError, ValueError, re.error) as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    return False, f"unknown tool {tool}"
+
+
+def _allowed(name: str, allow: set[str]) -> bool:
+    """The allow-set semantics claude-code's ``--allowedTools`` has: an exact name, or the MCP
+    server prefix (`mcp__vexa`) standing for all of its tools. An EMPTY set means unrestricted —
+    the same as passing no flag."""
+    if not allow:
+        return True
+    if name in allow:
+        return True
+    if name.startswith("mcp__"):
+        server = name.split("__")[1] if len(name.split("__")) > 2 else ""
+        return f"mcp__{server}" in allow
+    return False
+
+
+# ── the transcript (Claude Code's on-disk shape, so history keeps working) ──────────────────────
+
+class _Transcript:
+    """The session store: one JSONL per session under ``.claude/projects/<cwd-slug>/<sid>.jsonl``.
+
+    The SHAPE is Claude Code's, because ``workspace_reader.history`` is the reader on the other end
+    and its parser is the frozen contract, not this file's convenience. Each record additionally
+    carries an ``oa`` field — the raw OpenAI-dialect message — so a resume rebuilds the conversation
+    losslessly instead of re-deriving it from a rendering. The reader ignores fields it does not
+    know; that is the whole trick."""
+
+    def __init__(self, chat_root: Path, work: Path, session_id: str) -> None:
+        slug = str(work.resolve()).replace("/", "-")
+        self.dir = chat_root / ".claude" / "projects" / slug
+        self.session_id = session_id
+        self.path = self.dir / f"{session_id}.jsonl"
+
+    def exists(self) -> bool:
+        if self.path.exists():
+            return True
+        # the sid may have been written under another cwd-slug (a mount that moved) — accept it
+        parent = self.dir.parent
+        return parent.exists() and any(parent.glob(f"*/{self.session_id}.jsonl"))
+
+    def _resolved(self) -> Path:
+        if self.path.exists():
+            return self.path
+        for cand in self.dir.parent.glob(f"*/{self.session_id}.jsonl"):
+            return cand
+        return self.path
+
+    def append(self, record: dict) -> None:
+        try:
+            self.dir.mkdir(parents=True, exist_ok=True)
+            with self._resolved().open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+        except OSError as exc:
+            log.warning("could not append to the session transcript (%s) — history will be short", exc)
+
+    def messages(self) -> list[dict]:
+        """The prior conversation as OpenAI messages (from the ``oa`` field), or [] if unreadable."""
+        out: list[dict] = []
+        try:
+            raw = self._resolved().read_text(encoding="utf-8")
+        except OSError:
+            return out
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            msg = rec.get("oa")
+            if isinstance(msg, dict) and msg.get("role"):
+                out.append(msg)
+        return out
+
+    def record_user(self, text: str) -> None:
+        """VERBATIM. See the module docstring: the phase mark, the machinery mark and
+        ``engine._prompt_key`` all read THIS string."""
+        self.append({"type": "user", "sessionId": self.session_id,
+                     "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+                     "oa": {"role": "user", "content": text}})
+
+    def record_assistant(self, text: str, calls: list[dict], oa: dict) -> None:
+        blocks: list[dict] = []
+        if text:
+            blocks.append({"type": "text", "text": text})
+        for c in calls:
+            blocks.append({"type": "tool_use", "id": c["id"], "name": c["name"],
+                           "input": c["args"]})
+        self.append({"type": "assistant", "sessionId": self.session_id,
+                     "message": {"role": "assistant", "content": blocks}, "oa": oa})
+
+    def record_tool_result(self, call_id: str, ok: bool, text: str) -> None:
+        self.append({"type": "user", "sessionId": self.session_id,
+                     "message": {"role": "user", "content": [
+                         {"type": "tool_result", "tool_use_id": call_id,
+                          "content": text, "is_error": not ok}]},
+                     "oa": {"role": "tool", "tool_call_id": call_id, "content": text}})
+
+
+# ── context trimming ────────────────────────────────────────────────────────────────────────────
+
+def trim_messages(messages: list[dict], budget: int) -> tuple[list[dict], int]:
+    """Fit ``messages`` under ``budget`` estimated tokens. Returns (messages, trimmed_count).
+
+    Order of sacrifice, oldest first: tool RESULTS (replaced by a stub, so the model still sees that
+    the call happened), then whole oldest exchanges, and only then the head of the first user
+    message. The LAST user message is never touched — it is the ask, and a turn that trims the ask
+    answers a question nobody put."""
+    msgs = [dict(m) for m in messages]
+    if _est_tokens(msgs) <= budget:
+        return msgs, 0
+    trimmed = 0
+    for m in msgs:                                     # 1) oldest tool results → stub
+        if _est_tokens(msgs) <= budget:
+            break
+        if m.get("role") == "tool" and m.get("content") != _TRIM_STUB:
+            m["content"] = _TRIM_STUB
+            trimmed += 1
+    last_user = max((i for i, m in enumerate(msgs) if m.get("role") == "user"), default=0)
+    while _est_tokens(msgs) > budget:                  # 2) drop oldest non-final messages
+        drop = next((i for i, m in enumerate(msgs)
+                     if i != last_user and i != 0 and m.get("role") != "system"), None)
+        if drop is None:
+            break
+        msgs.pop(drop)
+        last_user = max((i for i, m in enumerate(msgs) if m.get("role") == "user"), default=0)
+        trimmed += 1
+    if _est_tokens(msgs) > budget and len(msgs) > 1:   # 3) last resort: head-truncate the opener
+        head = msgs[0]
+        content = str(head.get("content") or "")
+        keep = max(1000, budget * 2)
+        if len(content) > keep:
+            head["content"] = content[:keep] + "\n\n[…trimmed to fit the turn's context budget]"
+            trimmed += 1
+    return msgs, trimmed
+
+
+# ── the harness ─────────────────────────────────────────────────────────────────────────────────
+
+class OpenAIAgentHarness:
+    """``HarnessPort`` adapter: our own agent loop over an OpenAI-compatible endpoint."""
+
+    name = "openai-agent"
+
+    def __init__(self, *, base_url: Optional[str] = None, api_key: Optional[str] = None,
+                 model: Optional[str] = None, extra_body: Optional[dict] = None,
+                 timeout: float = 300.0, transport: Optional[httpx.BaseTransport] = None,
+                 mcp_http_client: Optional[httpx.Client] = None) -> None:
+        self._base = (base_url or os.environ.get("VEXA_LLM_BASE_URL")
+                      or os.environ.get("ANTHROPIC_BASE_URL") or "").rstrip("/")
+        self._key = (api_key or os.environ.get("VEXA_LLM_API_KEY")
+                     or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+                     or os.environ.get("ANTHROPIC_API_KEY") or "")
+        self._model = model or os.environ.get("VEXA_LLM_MODEL") or ""
+        self._extra = _parse_extra_body(extra_body if extra_body is not None
+                                        else os.environ.get("VEXA_LLM_EXTRA_BODY"))
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+        self._mcp_http = mcp_http_client
+        self._chat_root: Optional[Path] = None
+
+    # -- port surface -----------------------------------------------------------------------
+    def prepare(self, work: Path, chat_root: Optional[Path] = None) -> None:
+        """Remember where continuity lives. claude-code does this with a `~/.claude/projects`
+        symlink because the CLI decides where to write; we write the file ourselves, so the whole
+        of `prepare` is holding on to the root the engine already computed (`_system` when the
+        dispatch declares one — chats are private and must not land on a shared mount)."""
+        self._chat_root = Path(chat_root or work)
+        try:
+            (self._chat_root / ".claude" / "projects").mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass                                  # a read-only mount: the turn still runs
+
+    def transcript_bytes(self, work: Path, session_id: str) -> int:
+        total = 0
+        for path in (work / ".claude" / "projects").glob(f"*/{session_id}.jsonl"):
+            try:
+                total += path.stat().st_size
+            except OSError:
+                continue
+        return total
+
+    def preflight(self) -> Optional[str]:
+        if not self._base:
+            return ("openai-agent: no VEXA_LLM_BASE_URL — every workspace turn will fail until an "
+                    "OpenAI-compatible endpoint is set")
+        if not (self._model or os.environ.get("VEXA_AGENT_MODEL")):
+            return "openai-agent: no VEXA_LLM_MODEL — the endpoint will be asked for an empty model"
+        return None
+
+    def midturn_enabled(self) -> bool:
+        return False                              # one request at a time; nothing to inject into
+
+    def inject_user_message(self, text: str) -> bool:
+        return False
+
+    def run_turn(self, work: Path, prompt: str, *, allowed_tools: Iterable[str] = (),
+                 session: Optional[str] = None, model: Optional[str] = None,
+                 mcp_config: Optional[str] = None) -> Iterator[dict]:
+        sid = session or uuid.uuid4().hex
+        try:
+            yield from self._loop(Path(work), prompt, set(allowed_tools), session, sid, model,
+                                  mcp_config)
+        except (LLMConfigError, LLMAuthError) as exc:
+            yield {"type": "done", "reply": str(exc), "sessionId": sid, "ok": False}
+        except LLMError as exc:
+            yield {"type": "done", "reply": f"Model inference failed: {exc}", "sessionId": sid,
+                   "ok": False}
+
+    # -- the loop ---------------------------------------------------------------------------
+    def _loop(self, work: Path, prompt: str, allow: set[str], resume: Optional[str], sid: str,
+              model: Optional[str], mcp_config: Optional[str]) -> Iterator[dict]:
+        target = (model or "").strip() or self._model or os.environ.get("VEXA_AGENT_MODEL") or ""
+        if not self._base:
+            raise LLMConfigError(
+                "no agent endpoint: set VEXA_LLM_BASE_URL (e.g. http://192.168.1.6:8001/v1) — the "
+                "openai-agent runner has no default host")
+        if not target:
+            raise LLMConfigError("no model: set VEXA_LLM_MODEL (or VEXA_AGENT_MODEL)")
+
+        chat_root = self._chat_root or work
+        store = _Transcript(chat_root, work, sid)
+        if resume and not store.exists():
+            # An alien/stale id must yield done.ok=False — the engine's stale-resume retry heals it
+            # by calling again with session=None. Anything else forks the conversation silently.
+            yield {"type": "done", "reply": "unknown session", "sessionId": sid, "ok": False}
+            return
+        messages: list[dict] = store.messages() if resume else []
+        messages.append({"role": "user", "content": prompt})
+        store.record_user(prompt)
+
+        servers, mcp_index = _load_mcp(mcp_config, http_client=self._mcp_http)
+        try:
+            specs = [{"type": "function", "function": {"name": n, **BUILTIN_SPECS[n]}}
+                     for n in BUILTIN_SPECS if _allowed(n, allow)]
+            specs += [s for s in _mcp_specs(mcp_index) if _allowed(s["function"]["name"], allow)]
+
+            budget_calls = _int_env("VEXA_AGENT_MAX_TOOL_CALLS", _DEFAULT_MAX_TOOL_CALLS)
+            budget_secs = _float_env("VEXA_AGENT_MAX_TURN_SEC", _DEFAULT_MAX_TURN_SEC)
+            ctx_budget = _int_env("VEXA_AGENT_CONTEXT_TOKENS", _DEFAULT_CONTEXT_TOKENS)
+            started, calls_made, reply = time.monotonic(), 0, ""
+            sandbox = _Sandbox(mount_roots(work))
+
+            while True:
+                sent, trimmed = trim_messages(messages, ctx_budget)
+                if trimmed:
+                    yield {"type": "context-trimmed", "dropped": trimmed,
+                           "tokens": _est_tokens(sent), "budget": ctx_budget}
+                    messages = sent
+                text = ""
+                calls: list[dict] = []
+                oa: dict = {}
+                for ev in self._complete(sent, specs, target):
+                    if "__final__" in ev:
+                        oa = ev["__final__"]
+                        text = str(oa.get("content") or "")
+                        calls = _tool_calls_of(oa)
+                        break
+                    yield ev
+                    if ev.get("type") == "message-delta":
+                        text += ev.get("text", "")
+                if not calls:
+                    store.record_assistant(text, [], oa or {"role": "assistant", "content": text})
+                    reply = text
+                    break
+                store.record_assistant(text, calls, oa)
+                messages.append(oa)
+                over_budget = False
+                for i, call in enumerate(calls):
+                    if calls_made >= budget_calls or (time.monotonic() - started) > budget_secs:
+                        over_budget = True
+                        reason = "tool-call budget" if calls_made >= budget_calls else "time budget"
+                        yield {"type": "turn-truncated", "reason": reason,
+                               "calls": calls_made, "seconds": round(time.monotonic() - started, 1)}
+                        # EVERY call the model made is answered, refusals included. An assistant
+                        # message whose tool_calls have no matching tool message is a MALFORMED
+                        # request to the next round trip, and on a resumed session that malformation
+                        # outlives the turn that made it.
+                        for skipped in calls[i:]:
+                            refusal = f"not run: the turn hit its {reason}"
+                            yield {"type": "tool-result", "callId": skipped["id"], "ok": False,
+                                   "summary": refusal}
+                            store.record_tool_result(skipped["id"], False, refusal)
+                            messages.append({"role": "tool", "tool_call_id": skipped["id"],
+                                             "content": refusal})
+                        break
+                    calls_made += 1
+                    yield {"type": "tool-call", "tool": call["name"], "args": call["args"],
+                           "callId": call["id"]}
+                    ok, out = self._exec_tool(call, mcp_index, sandbox)
+                    out = out[:_TOOL_RESULT_MAX_CHARS]
+                    yield {"type": "tool-result", "callId": call["id"], "ok": ok,
+                           "summary": _short(out)}
+                    for extra in _panel_events(call, ok, out):
+                        yield extra
+                    store.record_tool_result(call["id"], ok, out)
+                    messages.append({"role": "tool", "tool_call_id": call["id"], "content": out})
+                if over_budget:
+                    reply = text
+                    break
+            yield {"type": "done", "reply": reply, "sessionId": sid, "ok": True}
+        finally:
+            for srv in servers:
+                srv.close()
+
+    def _exec_tool(self, call: dict, mcp_index: dict, sandbox: _Sandbox) -> tuple[bool, str]:
+        name, args = call["name"], call["args"]
+        if name in mcp_index:
+            srv, tool = mcp_index[name]
+            return srv.call(tool, args if isinstance(args, dict) else {})
+        if name in BUILTIN_SPECS:
+            return run_builtin(name, args if isinstance(args, dict) else {}, sandbox)
+        return False, (f"no tool named {name} is attached to this turn — the attached tools are "
+                       f"{sorted(set(BUILTIN_SPECS) | set(mcp_index))}")
+
+    def _complete(self, messages: list[dict], specs: list[dict], model: str) -> Iterator[dict]:
+        """One `chat/completions` round trip. Yields ``message-delta`` events while the text
+        streams, then a single ``{"__final__": <assistant message>}``."""
+        body = {**self._extra, "model": model, "messages": messages}   # reserved keys always win
+        if specs:
+            body["tools"] = specs
+            body["tool_choice"] = "auto"
+        headers = {"Authorization": f"Bearer {self._key}"} if self._key else {}
+        stream = (os.environ.get("VEXA_AGENT_STREAM", "1") or "1").strip() not in ("0", "false", "no")
+        if not stream:
+            yield from self._complete_blocking(body, headers)
+            return
+        body = {**body, "stream": True}
+        acc_text, acc_calls = "", {}
+        try:
+            with self._client.stream("POST", f"{self._base}/chat/completions", json=body,
+                                     headers=headers) as r:
+                if r.status_code >= 400:
+                    r.read()
+                    self._raise_http(r)
+                for line in r.iter_lines():
+                    line = (line or "").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(data)
+                    except ValueError:
+                        continue
+                    delta = ((chunk.get("choices") or [{}])[0] or {}).get("delta") or {}
+                    if delta.get("content"):
+                        acc_text += delta["content"]
+                        yield {"type": "message-delta", "text": delta["content"]}
+                    for tc in delta.get("tool_calls") or []:
+                        idx = tc.get("index", 0)
+                        slot = acc_calls.setdefault(idx, {"id": "", "type": "function",
+                                                          "function": {"name": "", "arguments": ""}})
+                        if tc.get("id"):
+                            slot["id"] = tc["id"]
+                        fn = tc.get("function") or {}
+                        if fn.get("name"):
+                            slot["function"]["name"] = fn["name"]
+                        if fn.get("arguments"):
+                            slot["function"]["arguments"] += fn["arguments"]
+        except httpx.HTTPError as exc:
+            raise LLMError(f"agent transport failure against {self._base}: {exc}") from exc
+        msg: dict = {"role": "assistant", "content": acc_text}
+        if acc_calls:
+            msg["tool_calls"] = [acc_calls[k] for k in sorted(acc_calls)]
+        yield {"__final__": msg}
+
+    def _complete_blocking(self, body: dict, headers: dict) -> Iterator[dict]:
+        try:
+            r = self._client.post(f"{self._base}/chat/completions", json=body, headers=headers)
+        except httpx.HTTPError as exc:
+            raise LLMError(f"agent transport failure against {self._base}: {exc}") from exc
+        if r.status_code >= 400:
+            self._raise_http(r)
+        try:
+            msg = ((r.json().get("choices") or [{}])[0] or {}).get("message") or {}
+        except (ValueError, AttributeError, TypeError) as exc:
+            raise LLMError(f"malformed completion payload from {self._base}: {exc}") from exc
+        text = str(msg.get("content") or "")
+        if text:
+            yield {"type": "message-delta", "text": text}
+        yield {"__final__": {"role": "assistant", "content": text,
+                             **({"tool_calls": msg["tool_calls"]} if msg.get("tool_calls") else {})}}
+
+    def _raise_http(self, r: httpx.Response) -> None:
+        detail = (r.text or "")[:300]
+        if r.status_code in (401, 403):
+            raise LLMAuthError(
+                f"{r.status_code} from {self._base}: {detail} — set VEXA_LLM_API_KEY for this "
+                f"endpoint, or point VEXA_LLM_BASE_URL at one that needs no credential")
+        raise LLMError(f"{r.status_code} from {self._base}: {detail}")
+
+
+def _tool_calls_of(msg: dict) -> list[dict]:
+    """The assistant message's tool calls as ``{id, name, args}``.
+
+    A model that returns unparseable arguments is COMMON on smaller models and must not take the
+    turn down: the call is kept with `{}` arguments plus the raw text, so the tool fails loudly and
+    the model gets a chance to correct itself — which is exactly what a loop is for."""
+    out: list[dict] = []
+    for i, tc in enumerate(msg.get("tool_calls") or []):
+        fn = (tc.get("function") or {}) if isinstance(tc, dict) else {}
+        raw = fn.get("arguments")
+        if isinstance(raw, dict):
+            args = raw
+        else:
+            try:
+                args = json.loads(raw or "{}")
+            except ValueError:
+                args = {"__unparsed_arguments__": str(raw)[:500]}
+        if not isinstance(args, dict):
+            args = {"__unparsed_arguments__": str(args)[:500]}
+        out.append({"id": str(tc.get("id") or f"call_{i}"), "name": str(fn.get("name") or ""),
+                    "args": args})
+    return out
+
+
+def _panel_events(call: dict, ok: bool, out: str) -> list[dict]:
+    """The panel moves a successful call earns — the SAME three conventions ``claude_code`` applies,
+    through its own helpers: the writer's tab, decision 35's chips, decision 30.4's transcript."""
+    if not ok:
+        return []                                  # success only: a failed call must move nothing
+    name = call["name"]
+    events: list[dict] = []
+    if name in _WRITER_TOOLS:
+        target = _written_artifact(name, call["args"])
+        if target:
+            events.append({"type": "artifact", "workspace": target[0], "path": target[1],
+                           "focus": True})
+    elif name in _TERMS_TOOLS:
+        ev = _published_terms(out)
+        if ev:
+            events.append(ev)
+    elif name in _BOT_TOOLS:
+        ev = _bot_artifact(out)
+        if ev:
+            events.append(ev)
+    return events

--- a/core/agent/llm/registry.py
+++ b/core/agent/llm/registry.py
@@ -17,6 +17,7 @@ from llm.claude_cli import ClaudeCliCompletion
 from llm.claude_code import ClaudeCodeHarness
 from llm.codex import CodexHarness
 from llm.errors import LLMConfigError
+from llm.openai_agent import OpenAIAgentHarness
 from llm.openai_compat import OpenAICompatCompletion
 from llm.ports import CompletionPort, HarnessPort
 
@@ -30,6 +31,9 @@ COMPLETION_PROVIDERS: dict[str, type] = {
 HARNESS_RUNNERS: dict[str, type] = {
     "claude-code": ClaudeCodeHarness,
     "codex": CodexHarness,
+    # PRD decision 37 — OURS, not a vendor CLI: an agent loop over any OpenAI-compatible endpoint,
+    # so a deployment can run the service on a model it hosts itself (the CCC box serving Qwen).
+    "openai-agent": OpenAIAgentHarness,
 }
 
 

--- a/core/agent/tests/test_llm_openai_agent.py
+++ b/core/agent/tests/test_llm_openai_agent.py
@@ -1,0 +1,447 @@
+"""L2: the openai-agent harness — the loop, offline. A scripted stub server over
+``httpx.MockTransport`` plays the model; a stdlib stdio MCP server (written to a temp file) plays
+the toolbelt. No network, no CLI, no rig.
+
+What each test is defending, because a harness's failures are all silent ones:
+
+* the tool loop actually loops — call, execute, feed back, answer — and emits the FROZEN UnitEvents
+  the terminal reducer consumes;
+* the transcript is written in Claude Code's on-disk shape with the prompt VERBATIM, because
+  ``control_plane.workspace_reader.history`` parses that file and ``engine._prompt_key`` hashes
+  those exact bytes (the phase mark and the machinery mark ride on it);
+* a resumed session carries the conversation, and an ALIEN session id yields ``done.ok=False`` so
+  the engine's stale-resume retry can heal it;
+* ``VEXA_LLM_EXTRA_BODY`` reaches EVERY request — the Qwen thinking switch is the worked case, and
+  a deployment that believes it disabled thinking and did not fails far from the cause;
+* the file tools refuse a path outside the mounts rather than clamping it;
+* the per-turn budget stops the loop AND answers every outstanding tool call;
+* MCP tools are attached from the same `mcp.json` the worker writes, over both transports.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import httpx
+import pytest
+
+from llm.openai_agent import (OpenAIAgentHarness, _Sandbox, mount_roots, run_builtin,
+                              trim_messages)
+
+
+# ── the scripted model ──────────────────────────────────────────────────────────────────────────
+
+def _msg(content="", calls=None):
+    m = {"role": "assistant", "content": content}
+    if calls:
+        m["tool_calls"] = [{"id": c[0], "type": "function",
+                            "function": {"name": c[1], "arguments": json.dumps(c[2])}}
+                           for c in calls]
+    return m
+
+
+def _server(script, seen=None):
+    """A handler that plays ``script`` (one assistant message per request), recording bodies."""
+    state = {"i": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if seen is not None:
+            seen.append(body)
+        msg = script[min(state["i"], len(script) - 1)]
+        state["i"] += 1
+        return httpx.Response(200, json={"choices": [{"message": msg, "finish_reason":
+                                                      "tool_calls" if msg.get("tool_calls") else "stop"}]})
+    return handler
+
+
+@pytest.fixture(autouse=True)
+def _blocking(monkeypatch):
+    # The loop streams by default; these tests script whole messages, so they run the blocking path.
+    # Streaming has its own test below.
+    monkeypatch.setenv("VEXA_AGENT_STREAM", "0")
+    monkeypatch.delenv("VEXA_MOUNTS", raising=False)
+
+
+def _harness(handler, **kw):
+    kw.setdefault("base_url", "http://ccc.local/v1")
+    kw.setdefault("model", "qwen3.8-27b")
+    return OpenAIAgentHarness(transport=httpx.MockTransport(handler), **kw)
+
+
+def _events(harness, work, prompt, **kw):
+    return list(harness.run_turn(Path(work), prompt, **kw))
+
+
+# ── the loop ────────────────────────────────────────────────────────────────────────────────────
+
+def test_tool_loop_reads_a_file_then_answers(tmp_path):
+    (tmp_path / "note.md").write_text("the DNA TSC met on Monday")
+    seen = []
+    h = _harness(_server([
+        _msg("", [("call_1", "Read", {"file_path": str(tmp_path / "note.md")})]),
+        _msg("They met on Monday."),
+    ], seen))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "what happened?", allowed_tools=["Read", "Write"])
+
+    kinds = [e["type"] for e in evs]
+    assert kinds == ["tool-call", "tool-result", "message-delta", "done"]
+    assert evs[0]["tool"] == "Read" and evs[0]["callId"] == "call_1"
+    assert evs[1]["ok"] is True and "Monday" in evs[1]["summary"]
+    assert evs[-1]["reply"] == "They met on Monday." and evs[-1]["ok"] is True
+    # the second request carries the assistant's tool_calls AND the tool result, in order
+    roles = [m["role"] for m in seen[1]["messages"]]
+    assert roles == ["user", "assistant", "tool"]
+    assert seen[1]["messages"][2]["tool_call_id"] == "call_1"
+    # only the allowed built-ins were offered
+    offered = {t["function"]["name"] for t in seen[0]["tools"]}
+    assert offered == {"Read", "Write"}
+    assert seen[0]["tool_choice"] == "auto"
+
+
+def test_unknown_tool_is_a_failed_result_not_a_crash(tmp_path):
+    h = _harness(_server([_msg("", [("c1", "Bash", {"command": "rm -rf /"})]), _msg("ok")]))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "go", allowed_tools=["Read"])
+    result = next(e for e in evs if e["type"] == "tool-result")
+    assert result["ok"] is False and "no tool named Bash" in result["summary"]
+    assert evs[-1]["ok"] is True          # the loop recovers; the model gets to choose again
+
+
+def test_extra_body_is_merged_into_every_request(tmp_path):
+    seen = []
+    h = _harness(_server([_msg("", [("c1", "Glob", {"pattern": "*.md"})]), _msg("done")], seen),
+                 extra_body={"chat_template_kwargs": {"enable_thinking": False}})
+    h.prepare(tmp_path)
+    _events(h, tmp_path, "list", allowed_tools=["Glob"])
+    assert len(seen) == 2
+    for body in seen:
+        assert body["chat_template_kwargs"] == {"enable_thinking": False}
+        assert body["model"] == "qwen3.8-27b"     # reserved keys always win
+
+
+def test_extra_body_cannot_override_reserved_keys(tmp_path):
+    seen = []
+    h = _harness(_server([_msg("hi")], seen), extra_body={"model": "smuggled", "messages": []})
+    h.prepare(tmp_path)
+    _events(h, tmp_path, "hi")
+    assert seen[0]["model"] == "qwen3.8-27b" and seen[0]["messages"][0]["content"] == "hi"
+
+
+# ── sessions + the transcript contract ──────────────────────────────────────────────────────────
+
+def _transcript(root: Path) -> list[dict]:
+    files = list((root / ".claude" / "projects").glob("*/*.jsonl"))
+    assert len(files) == 1, files
+    return [json.loads(l) for l in files[0].read_text().splitlines() if l.strip()]
+
+
+def test_transcript_is_claude_shaped_and_stores_the_prompt_verbatim(tmp_path):
+    work, chat = tmp_path / "ws", tmp_path / "sys"
+    work.mkdir(); chat.mkdir()
+    h = _harness(_server([_msg("", [("c1", "Glob", {"pattern": "*"})]), _msg("nothing here")]))
+    h.prepare(work, chat_root=chat)
+    prompt = "[vexa-machinery] [vexa-phase:writeback] Write-back phase — give each name a page."
+    evs = _events(h, work, prompt, allowed_tools=["Glob"])
+    sid = evs[-1]["sessionId"]
+
+    recs = _transcript(chat)
+    assert not (work / ".claude" / "projects").exists()      # chats stay off a shared mount
+    assert recs[0]["type"] == "user"
+    # VERBATIM: the phase mark and engine._prompt_key both read this string
+    assert recs[0]["message"]["content"][0]["text"] == prompt
+    assert recs[1]["type"] == "assistant"
+    assert [b["type"] for b in recs[1]["message"]["content"]] == ["tool_use"]
+    assert recs[1]["message"]["content"][0]["name"] == "Glob"
+    assert recs[2]["type"] == "user"
+    assert recs[2]["message"]["content"][0]["type"] == "tool_result"      # history skips these
+    assert recs[3]["message"]["content"][0]["text"] == "nothing here"
+    assert h.transcript_bytes(chat, sid) > 0
+
+
+def test_history_reader_parses_our_transcript(tmp_path):
+    """The seam that matters most: the REAL reader, on a file this harness wrote."""
+    from control_plane.workspace_reader import WorkspaceReader
+
+    root = tmp_path / "store"
+    ws = root / "126"
+    ws.mkdir(parents=True)
+    h = _harness(_server([_msg("", [("c1", "Glob", {"pattern": "*"})]), _msg("I found nothing.")]))
+    h.prepare(ws)
+    evs = _events(h, ws, "what do we have?", allowed_tools=["Glob"])
+    sid = evs[-1]["sessionId"]
+    sess = ws / ".claude" / "sessions"
+    sess.mkdir(parents=True, exist_ok=True)
+    (sess / "main.session").write_text(sid)
+
+    turns = WorkspaceReader(root).history("126", "main")
+    assert [t["role"] for t in turns] == ["user", "agent"]
+    assert turns[0]["text"] == "what do we have?"
+    assert turns[1]["text"] == "I found nothing."
+    assert turns[1]["ops"], "the Glob call should render as an op"
+
+
+def test_resume_carries_the_conversation(tmp_path):
+    h = _harness(_server([_msg("first")]))
+    h.prepare(tmp_path)
+    sid = _events(h, tmp_path, "one")[-1]["sessionId"]
+
+    seen = []
+    h2 = _harness(_server([_msg("second")], seen))
+    h2.prepare(tmp_path)
+    evs = _events(h2, tmp_path, "two", session=sid)
+    assert evs[-1]["sessionId"] == sid and evs[-1]["ok"] is True
+    assert [m["content"] for m in seen[0]["messages"]] == ["one", "first", "two"]
+
+
+def test_alien_session_yields_not_ok_so_the_engine_can_retry(tmp_path):
+    h = _harness(_server([_msg("never reached")]))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "hello", session="deadbeef")
+    assert len(evs) == 1 and evs[0]["type"] == "done" and evs[0]["ok"] is False
+
+
+# ── budgets, trimming, sandbox ──────────────────────────────────────────────────────────────────
+
+def test_tool_call_budget_stops_the_turn_and_answers_every_call(tmp_path, monkeypatch):
+    monkeypatch.setenv("VEXA_AGENT_MAX_TOOL_CALLS", "1")
+    h = _harness(_server([_msg("", [("a", "Glob", {"pattern": "*"}),
+                                    ("b", "Glob", {"pattern": "*"})]), _msg("late")]))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "go", allowed_tools=["Glob"])
+    trunc = [e for e in evs if e["type"] == "turn-truncated"]
+    assert trunc and trunc[0]["reason"] == "tool-call budget"
+    # both calls answered — an unanswered tool_call is a malformed next request
+    answered = {e["callId"] for e in evs if e["type"] == "tool-result"}
+    assert answered == {"a", "b"}
+    assert evs[-1]["type"] == "done" and evs[-1]["ok"] is True
+
+
+def test_trim_eats_the_oldest_tool_results_first():
+    msgs = [{"role": "user", "content": "ask"},
+            {"role": "assistant", "content": "x"},
+            {"role": "tool", "tool_call_id": "1", "content": "H" * 20000},
+            {"role": "tool", "tool_call_id": "2", "content": "T" * 20000},
+            {"role": "user", "content": "the real question"}]
+    out, trimmed = trim_messages(msgs, 2000)
+    assert trimmed >= 1
+    assert out[-1]["content"] == "the real question"          # the ask is never trimmed
+    assert "trimmed" in out[2]["content"]
+
+
+def test_context_budget_emits_an_event_and_shrinks_the_request(tmp_path, monkeypatch):
+    monkeypatch.setenv("VEXA_AGENT_CONTEXT_TOKENS", "300")
+    seen = []
+    h = _harness(_server([_msg("", [("c1", "Read", {"file_path": str(tmp_path / "big.md")})]),
+                          _msg("ok")], seen))
+    (tmp_path / "big.md").write_text("x" * 40000)
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "read it", allowed_tools=["Read"])
+    assert any(e["type"] == "context-trimmed" for e in evs)
+    assert len(json.dumps(seen[1]["messages"])) < 40000
+
+
+def test_file_tools_refuse_a_path_outside_the_mounts(tmp_path):
+    sandbox = _Sandbox([tmp_path.resolve()])
+    ok, out = run_builtin("Write", {"file_path": "/etc/passwd", "content": "x"}, sandbox)
+    assert ok is False and "outside the mounted workspaces" in out
+    ok, out = run_builtin("Write", {"file_path": str(tmp_path / "a/b.md"), "content": "hi"}, sandbox)
+    assert ok is True and (tmp_path / "a/b.md").read_text() == "hi"
+    ok, out = run_builtin("Edit", {"file_path": str(tmp_path / "a/b.md"),
+                                   "old_string": "hi", "new_string": "yo"}, sandbox)
+    assert ok is True and (tmp_path / "a/b.md").read_text() == "yo"
+    ok, out = run_builtin("Grep", {"pattern": "yo", "path": str(tmp_path)}, sandbox)
+    assert ok is True and "b.md" in out
+
+
+def test_mount_roots_reads_vexa_mounts(tmp_path, monkeypatch):
+    other = tmp_path / "global"
+    other.mkdir()
+    monkeypatch.setenv("VEXA_MOUNTS", json.dumps([{"path": str(other), "role": "global"}]))
+    roots = mount_roots(tmp_path / "ws")
+    assert other.resolve() in roots
+
+
+# ── MCP ─────────────────────────────────────────────────────────────────────────────────────────
+
+_STDIO_SERVER = textwrap.dedent('''
+    import json, sys
+    TOOL = {"name": "entity_upsert", "description": "record a page",
+            "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}},
+                            "required": ["name"]}}
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        msg = json.loads(raw)
+        mid = msg.get("id")
+        if mid is None:
+            continue
+        m = msg.get("method")
+        if m == "initialize":
+            res = {"protocolVersion": "2025-03-26", "capabilities": {"tools": {}}}
+        elif m == "tools/list":
+            res = {"tools": [TOOL]}
+        else:
+            args = (msg.get("params") or {}).get("arguments") or {}
+            res = {"content": [{"type": "text", "text": json.dumps({"created": args.get("name")})}]}
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": mid, "result": res}) + "\\n")
+        sys.stdout.flush()
+''')
+
+
+def test_mcp_stdio_tools_are_attached_and_callable(tmp_path):
+    server = tmp_path / "stub.py"
+    server.write_text(_STDIO_SERVER)
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {"entities": {
+        "type": "stdio", "command": sys.executable, "args": [str(server)]}}}))
+    seen = []
+    h = _harness(_server([_msg("", [("c1", "mcp__entities__entity_upsert", {"name": "Sam"})]),
+                          _msg("filed")], seen))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "record it",
+                  allowed_tools=["Read", "mcp__entities__entity_upsert"], mcp_config=str(cfg))
+    offered = {t["function"]["name"] for t in seen[0]["tools"]}
+    assert "mcp__entities__entity_upsert" in offered and "Write" not in offered
+    result = next(e for e in evs if e["type"] == "tool-result")
+    assert result["ok"] is True and "Sam" in result["summary"]
+
+
+def test_mcp_http_carries_the_delegation_token(tmp_path):
+    """The worker's own `mcp.json` shape: the rig over http, the token in a HEADER."""
+    calls = []
+
+    def mcp_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        calls.append((body.get("method"), request.headers.get("authorization")))
+        if body.get("method") == "initialize":
+            res = {"protocolVersion": "2025-03-26", "capabilities": {}}
+        elif body.get("method") == "tools/list":
+            res = {"tools": [{"name": "whats_waiting", "description": "the queue",
+                              "inputSchema": {"type": "object", "properties": {}}}]}
+        else:
+            res = {"content": [{"type": "text", "text": "nothing waiting"}]}
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": body.get("id"), "result": res})
+
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {"vexa": {
+        "type": "http", "url": "https://rig.example/mcp",
+        "headers": {"Authorization": "Bearer delegated-token"}}}}))
+    h = _harness(_server([_msg("", [("c1", "mcp__vexa__whats_waiting", {})]), _msg("all clear")]),
+                 mcp_http_client=httpx.Client(transport=httpx.MockTransport(mcp_handler)))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "anything?", allowed_tools=["mcp__vexa"], mcp_config=str(cfg))
+    assert ("tools/call", "Bearer delegated-token") in calls
+    assert next(e for e in evs if e["type"] == "tool-result")["ok"] is True
+
+
+def test_an_unreachable_mcp_server_costs_its_tools_not_the_turn(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {"gone": {"type": "stdio",
+                                                       "command": "/nonexistent/binary"}}}))
+    h = _harness(_server([_msg("answered anyway")]))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "go", mcp_config=str(cfg))
+    assert evs[-1]["ok"] is True and evs[-1]["reply"] == "answered anyway"
+
+
+# ── streaming + errors ──────────────────────────────────────────────────────────────────────────
+
+def test_streaming_emits_incremental_deltas_and_assembles_tool_calls(tmp_path, monkeypatch):
+    monkeypatch.setenv("VEXA_AGENT_STREAM", "1")
+    chunks = [
+        {"choices": [{"delta": {"content": "Look"}}]},
+        {"choices": [{"delta": {"content": "ing."}}]},
+        {"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "id": "c1", "function": {"name": "Glob", "arguments": '{"pat'}}]}}]},
+        {"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "function": {"arguments": 'tern": "*.md"}'}}]}}]},
+    ]
+    state = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        state["n"] += 1
+        if state["n"] == 1:
+            payload = "".join(f"data: {json.dumps(c)}\n\n" for c in chunks) + "data: [DONE]\n\n"
+            return httpx.Response(200, text=payload,
+                                  headers={"content-type": "text/event-stream"})
+        payload = ("data: " + json.dumps({"choices": [{"delta": {"content": "Two files."}}]})
+                   + "\n\ndata: [DONE]\n\n")
+        return httpx.Response(200, text=payload, headers={"content-type": "text/event-stream"})
+
+    h = _harness(handler)
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "list", allowed_tools=["Glob"])
+    deltas = [e["text"] for e in evs if e["type"] == "message-delta"]
+    assert deltas[:2] == ["Look", "ing."]
+    call = next(e for e in evs if e["type"] == "tool-call")
+    assert call["tool"] == "Glob" and call["args"] == {"pattern": "*.md"}
+    assert evs[-1]["reply"] == "Two files."
+
+
+def test_auth_failure_is_a_done_not_an_exception(tmp_path):
+    h = _harness(lambda request: httpx.Response(401, text="no key"))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "hi")
+    assert evs[-1]["type"] == "done" and evs[-1]["ok"] is False
+    assert "VEXA_LLM_API_KEY" in evs[-1]["reply"]
+
+
+def test_missing_endpoint_is_a_config_error_on_the_done_event(tmp_path, monkeypatch):
+    monkeypatch.delenv("VEXA_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    h = OpenAIAgentHarness(base_url="", model="m")
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "hi")
+    assert evs[-1]["ok"] is False and "VEXA_LLM_BASE_URL" in evs[-1]["reply"]
+
+
+def test_unparsable_tool_arguments_fail_the_call_not_the_turn(tmp_path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if len(body["messages"]) == 1:
+            return httpx.Response(200, json={"choices": [{"message": {
+                "role": "assistant", "content": "",
+                "tool_calls": [{"id": "c1", "type": "function",
+                                "function": {"name": "Read", "arguments": "{not json"}}]}}]})
+        return httpx.Response(200, json={"choices": [{"message": {"role": "assistant",
+                                                                  "content": "recovered"}}]})
+    h = _harness(handler)
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "go", allowed_tools=["Read"])
+    assert next(e for e in evs if e["type"] == "tool-result")["ok"] is False
+    assert evs[-1]["reply"] == "recovered"
+
+
+# ── the panel conventions (imported from claude_code, so they must behave identically) ──────────
+
+def test_a_successful_workspace_write_opens_the_tab(tmp_path):
+    """decision 18 / the writer-tool tab: the SAME `_WRITER_TOOLS` + `_written_artifact` the claude
+    adapter uses, so an openai-agent turn paints the panel identically."""
+    server = tmp_path / "stub.py"
+    server.write_text(_STDIO_SERVER.replace("entity_upsert", "workspace_write"))
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {"vexa": {
+        "type": "stdio", "command": sys.executable, "args": [str(server)]}}}))
+    h = _harness(_server([_msg("", [("c1", "mcp__vexa__workspace_write",
+                                    {"path": "kg/note.md", "slug": "126", "name": "n"})]),
+                          _msg("written")]))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "write it", allowed_tools=["mcp__vexa"], mcp_config=str(cfg))
+    art = [e for e in evs if e["type"] == "artifact"]
+    assert art and art[0]["workspace"] == "126" and art[0]["path"] == "kg/note.md"
+    assert art[0]["focus"] is True
+
+
+def test_a_failed_write_opens_nothing(tmp_path):
+    h = _harness(_server([_msg("", [("c1", "mcp__vexa__workspace_write",
+                                    {"path": "kg/note.md", "slug": "126"})]), _msg("sorry")]))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "write it", allowed_tools=["mcp__vexa"])  # no MCP attached
+    assert next(e for e in evs if e["type"] == "tool-result")["ok"] is False
+    assert not [e for e in evs if e["type"] == "artifact"]

--- a/core/agent/tests/test_llm_registry.py
+++ b/core/agent/tests/test_llm_registry.py
@@ -6,6 +6,7 @@ from llm import LLMConfigError, completion_from_env, harness_from_env
 from llm.anthropic_api import AnthropicCompletion
 from llm.claude_code import ClaudeCodeHarness
 from llm.codex import CodexHarness
+from llm.openai_agent import OpenAIAgentHarness
 from llm.openai_compat import OpenAICompatCompletion
 
 
@@ -36,11 +37,22 @@ def test_harness_env_selects_codex(monkeypatch):
     assert isinstance(harness_from_env(), CodexHarness)
 
 
+def test_harness_env_selects_openai_agent(monkeypatch):
+    """PRD decision 37 — the runner that needs no vendor CLI at all."""
+    monkeypatch.setenv("VEXA_RUNNER", "openai-agent")
+    monkeypatch.setenv("VEXA_LLM_BASE_URL", "http://192.168.1.6:8001/v1")
+    monkeypatch.setenv("VEXA_LLM_MODEL", "qwen3.8-27b")
+    h = harness_from_env()
+    assert isinstance(h, OpenAIAgentHarness) and h.name == "openai-agent"
+    assert h.preflight() is None
+
+
 def test_harness_unknown_runner_fails_loud(monkeypatch):
     monkeypatch.setenv("VEXA_RUNNER", "hal9000")
     with pytest.raises(LLMConfigError) as exc:
         harness_from_env()
     assert "hal9000" in str(exc.value) and "claude-code" in str(exc.value) and "codex" in str(exc.value)
+    assert "openai-agent" in str(exc.value)
 
 
 def test_blank_env_values_mean_default(monkeypatch):

--- a/core/runtime/src/runtime_kernel/docker_backend.py
+++ b/core/runtime/src/runtime_kernel/docker_backend.py
@@ -274,10 +274,20 @@ class DockerBackend:
             "VEXA_LLM_API_KEY",
             "VEXA_LLM_MODEL",
             "VEXA_LLM_MAX_TOKENS",
+            # Server-specific request fields the OpenAI dialect cannot express. LOAD-BEARING for a
+            # self-hosted Qwen ({"chat_template_kwargs":{"enable_thinking":false}}): without it the
+            # model reasons its whole budget away and returns nothing parseable — a failure that
+            # looks like a bad model, not like a missing variable.
+            "VEXA_LLM_EXTRA_BODY",
             "VEXA_MODEL_ALLOWLIST",
             "VEXA_RUNNER",
             "VEXA_MIDTURN_INJECT",
             "VEXA_CODEX_MODEL",
+            # openai-agent harness budget dials (per-turn ceiling + context trim + streaming)
+            "VEXA_AGENT_MAX_TOOL_CALLS",
+            "VEXA_AGENT_MAX_TURN_SEC",
+            "VEXA_AGENT_CONTEXT_TOKENS",
+            "VEXA_AGENT_STREAM",
             # codex harness API-key auth (subscription auth is the read-only bind above)
             "OPENAI_API_KEY",
             "CODEX_API_KEY",

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -140,11 +140,26 @@ VEXA_LLM_BASE_URL=
 VEXA_LLM_API_KEY=
 VEXA_LLM_MODEL=
 VEXA_LLM_MAX_TOKENS=
+# A JSON object merged into EVERY chat/completions request — the escape hatch for server-specific
+# parameters the OpenAI dialect has no field for. A self-hosted Qwen NEEDS this one or it spends its
+# whole token budget reasoning and returns no valid JSON:
+#   VEXA_LLM_EXTRA_BODY={"chat_template_kwargs":{"enable_thinking":false}}
+VEXA_LLM_EXTRA_BODY=
 # Optional operator gate on workspace-pinned models (comma-separated; empty = allow any route).
 VEXA_MODEL_ALLOWLIST=
 # The agent HARNESS for workspace turns (chat / routines / post-meeting docs) — a CLI coding agent.
-# Harness runner: claude-code (default) | codex (Codex app-server).
+# Harness runner: claude-code (default) | codex (Codex app-server) | openai-agent (this repo's
+# own agent loop over any OpenAI-compatible endpoint — no CLI, no vendor; pair it with
+# VEXA_LLM_BASE_URL + VEXA_LLM_MODEL + VEXA_LLM_EXTRA_BODY above).
 VEXA_RUNNER=
+# openai-agent per-turn budget and context ceiling (defaults 40 / 900 / 24000). The context ceiling
+# is a SIZING rule on a shared inference box, not a nicety: a 24k-context request is ~1/29th of the
+# KV cache, and a turn that grows unbounded evicts everybody else's.
+VEXA_AGENT_MAX_TOOL_CALLS=
+VEXA_AGENT_MAX_TURN_SEC=
+VEXA_AGENT_CONTEXT_TOKENS=
+# openai-agent SSE streaming (default on; 0 = one blocking request per step).
+VEXA_AGENT_STREAM=
 # Optional Codex-specific model. Empty uses the signed-in subscription account's default and avoids
 # inheriting an existing Claude model pin from Settings → Models.
 VEXA_CODEX_MODEL=


### PR DESCRIPTION
PRD decision 37 — *"we have CCC computer that is hosting qwen — let's move there — we want to test it out."*

**COMMITMENTS IN THIS DRAFT — none.** No money, no date, no right, no published term, no work promised to anyone outside this repo. The live service stays on Sonnet (decision 36); this PR ships a third runner and the numbers to judge it by. The scratch/sim-lane switch below is a proposal for the stage-1 worker's window, not a change made here.

## Symptom → change → proof

| Symptom | Change | Proof |
|---|---|---|
| `VEXA_RUNNER` knew only `claude-code` and `codex`, both of which drive a VENDOR CLI. A deployment that wants to run on a model we host had nowhere to go — `openai_compat.py` is a completion port (prompt→text, no tools) and this product's turns are tool loops end to end. | **`core/agent/llm/openai_agent.py`** (new, 917 lines) — `OpenAIAgentHarness` at `openai_agent.py:619`, the loop at `:689`, the request at `:794`. Raw httpx to `POST {base}/chat/completions` with `tools` + `tool_choice: auto`; no vendor SDK. | `core/agent/tests/test_llm_openai_agent.py` — 23 tests, all offline (a scripted endpoint over `httpx.MockTransport`, a stdlib stdio MCP server, no network). Full agent suite **1146 passed**, 1 pre-existing failure (`test_meeting_room.py::test_the_runtime_binds_a_room_mount_read_only`, missing `requests_unixsocket` — fails identically on `~/dev/wt-line`). Runtime suite **187 passed**. |
| The rig's toolbelt is attached through a Claude-shaped `mcp.json`; nothing else could read it. | `_MCPServer` at `openai_agent.py:117` — a minimal MCP client over **both** transports the file expresses: streamable-http (the rig, `Authorization: Bearer <delegation token>` in a HEADER, `Mcp-Session-Id` echoed) and stdio (the offline entity stub from #1414). Tools convert to OpenAI function specs under the same `mcp__<server>__<tool>` names the allow-set and the panel conventions are written against. | `test_mcp_http_carries_the_delegation_token`, `test_mcp_stdio_tools_are_attached_and_callable`, `test_an_unreachable_mcp_server_costs_its_tools_not_the_turn`. |
| The harness needs file tools the way the CLI has them. | `run_builtin` at `openai_agent.py:421` — `Read`/`Write`/`Edit`/`Glob`/`Grep`, sandboxed by `_Sandbox` to the mount roots read from `VEXA_MOUNTS`. A path outside them is **refused, never clamped**: a write that silently lands in another workspace is the one failure nobody can see afterwards. | `test_file_tools_refuse_a_path_outside_the_mounts`, `test_mount_roots_reads_vexa_mounts`. And observed live on the bench — Qwen guessed the production mount path, was refused with the real roots named, and corrected itself on the next call. |
| Chat history is read out of the harness transcript; a new harness could have broken every chat in the product silently. | `_Transcript` at `openai_agent.py:498` writes Claude Code's on-disk shape at `<chat_root>/.claude/projects/<cwd-slug>/<sid>.jsonl`, with the composed prompt stored **verbatim** (`record_user`, `:554`). That is what makes `engine._prompt_key`'s sha256 find the person's own words and what makes the F51 phase mark and the machinery mark work — the reader tests for `[vexa-phase:writeback]` **in the stored prompt**, so a harness storing a paraphrase would silently un-hide every write-back exchange. Each record also carries an `oa` field (the raw OpenAI message) so a resume is lossless; the reader ignores fields it does not know. | `test_history_reader_parses_our_transcript` runs the **real** `control_plane.workspace_reader.WorkspaceReader` over a file this harness wrote. Plus `test_transcript_is_claude_shaped_and_stores_the_prompt_verbatim`, `test_resume_carries_the_conversation`, `test_alien_session_yields_not_ok_so_the_engine_can_retry` (the contract that lets the engine's stale-resume retry heal an alien id). |
| The panel conventions (writer tab, decision 35 chips, decision 30.4 transcript-on-send) live in `claude_code.py`. | `_panel_events` at `openai_agent.py:897` **imports** `_WRITER_TOOLS` / `_TERMS_TOOLS` / `_BOT_TOOLS` and their helpers rather than restating them — one spelling of a closed vocabulary, so the terminal renders an openai-agent turn identically. | `test_a_successful_workspace_write_opens_the_tab`, `test_a_failed_write_opens_nothing`. |
| CCC holds ~29 requests at 24k context and is a shared internal box. | A hard per-turn budget (`VEXA_AGENT_MAX_TOOL_CALLS` 40 / `VEXA_AGENT_MAX_TURN_SEC` 900) and context trimming, `trim_messages` at `:581` — oldest tool RESULTS first (stubbed, so the model still sees the call happened), then oldest exchanges, and the last user message never. Over budget, **every outstanding tool call is still answered** with a refusal: an assistant `tool_calls` with no matching `tool` message is a malformed next request, and on a resumed session that malformation outlives the turn that made it. | `test_tool_call_budget_stops_the_turn_and_answers_every_call`, `test_trim_eats_the_oldest_tool_results_first`, `test_context_budget_emits_an_event_and_shrinks_the_request`. |
| Qwen returns 0% valid JSON in thinking mode. | `VEXA_LLM_EXTRA_BODY` is merged into **every** request, reserved keys (`model`, `messages`) always winning — parsed by `openai_compat._parse_extra_body`, the same function, so a malformed value is one config error and not two dialects of one. | `test_extra_body_is_merged_into_every_request`, `test_extra_body_cannot_override_reserved_keys`. |
| **Found on the way:** `VEXA_LLM_EXTRA_BODY` was missing from the runtime's spawn-env copy list (`core/runtime/src/runtime_kernel/docker_backend.py:281`) — dispatch's own allowlist carries it, so the live path works, but a deployment that sets it only on the runtime service loses exactly the field a self-hosted Qwen cannot run without, and loses it **as bad output**, far from the cause. | Added, with the four `VEXA_AGENT_*` dials beside it, and `deploy/compose/.env.example` now documents the runner and every dial. | Runtime suite 187 passed; `gate:config-contract` green. |

**Registry + config.** One line: `registry.py:36`. `config.v1.json` declares **nothing new** — the runner rides `VEXA_RUNNER` (already declared; its description now names `openai-agent`) and reads only `VEXA_LLM_BASE_URL` / `VEXA_LLM_API_KEY` / `VEXA_LLM_MODEL` / `VEXA_LLM_EXTRA_BODY`, all already declared and already forwarded into workers by `dispatch.MODEL_AUTH_ENV_ALLOWLIST`. The four `VEXA_AGENT_*` budget dials are optional operator knobs with working defaults; they are in `.env.example` and the runtime copy list, deliberately not in the config contract (which is the CAPABILITY surface, and a tool-call ceiling is not a capability).

## The numbers — same instrument, same two DNA fixtures, same afternoon

`core/agent/eval/harness_bench.py` (new, committed rather than left in `/tmp`, which is where the write-back A/B that produced the ledger's baseline actually lived — a number nobody can reproduce is a number nobody can argue with). It drives the **real** engine: real preambles, real write-back phase, real budget, the entity tool served over stdio by `eval/entity_mcp_stub.py`. No stack, no docker, no rig, nothing running touched.

```
uv run python core/agent/eval/harness_bench.py --fixtures ~/dna-fixtures --out ~/dna-runs/oa2 \
  --dates 2026-03-02 2026-03-16 --runner openai-agent --model qwen3.8-27b
```

| dimension | `claude-code` / Haiku | `openai-agent` / `qwen3.8-27b` |
|---|---|---|
| entities_touched | **1.000** | **1.000** |
| pages / fixture | 5.5 (6, 5) | **7.0** (6, 8) |
| names_linked | 0.000 | 0.000 |
| bare names left | 11, 11 | 13, 16 |
| answer seconds | 35.2 (37.8, 32.6) | **26.1** (34.7, 17.5) |
| phase seconds | 41.0 (27.5, 54.4) | **17.6** (19.2, 16.1) |
| tool-call JSON validity | 1.000 | **1.000** |
| answer tool calls | 1, 1 | 10, 6 |
| tool-call success (answer) | 1.000 | 0.784 |

Ledger cross-check: the Haiku baseline recorded on 2026-09-02 was entities 1.000, pages/fixture 10.5, phase median 28.95 s. This run reproduces the first and the third and lands lower on pages — the fixtures and the trimmed phase's time budget are the same, so pages/fixture is the noisy dimension of the three and should not be read to two significant figures.

**Where Qwen actually is, honestly.**

* **Multi-step tool use: yes.** It drove 6–10 calls per answer where Haiku drove 1, followed the write with the phase's `entity_upsert` calls, and produced more pages, faster. Native tool calling streamed correctly (id on the first chunk, arguments across four chunks) — `json_valid 1.000`, zero unparsable argument blobs across 32 calls, with thinking off.
* **`tool_ok 0.784` overstates the failures.** Four of the five failed calls in the two runs are: (a) Qwen guessing the production mount path `/workspaces/<slug>/…` that the preambles state, which the bench's scratch workspace does not have — the sandbox refused, named the real roots, and the model corrected itself on the next call (under real mounts that path is right and the call succeeds); (b) two `entity_upsert` refusals for sourceless facts, which is **the counter-rule working**, not a model defect. `phase_tool_ok` is noisy under truncation on both runners (a call whose result arrives after `bounded()` closes the generator counts as unanswered) and should not be read as a comparison.
* **Wikilink discipline: no movement, and no regression either.** `names_linked 0.000` on both runners, with Qwen leaving somewhat more bare names (13/16 vs 11/11). The ledger already records this dimension as one that structurally cannot move in-phase; the entity index over a compounding library is the untested lever. **This is the class to watch on a real lane** — more pages plus more bare names is exactly the shape of a model that writes eagerly and links carelessly.
* **Not measured here:** the judge column, transcript depth, the note's shape, and anything about a multi-turn chat with a person in it. This bench measures the write-up turn and the write-back phase, which is what the ledger's baseline measured.

Probes stayed light: sequential single requests against CCC, ≤24k context each, never more than one in flight.

## The scratch / sim-lane switch — for the stage-1 worker, not done here

Windows belong to the stage-1 worker. The exact block, for the scratch/sim lane's `deploy/compose/.env` (both `agent-api` and `runtime` `env_file` it, so one place covers both):

```dotenv
VEXA_RUNNER=openai-agent
VEXA_LLM_BASE_URL=http://192.168.1.6:8001/v1
VEXA_LLM_MODEL=qwen3.8-27b
VEXA_LLM_API_KEY=
VEXA_LLM_EXTRA_BODY={"chat_template_kwargs":{"enable_thinking":false}}
VEXA_AGENT_CONTEXT_TOKENS=24000
VEXA_AGENT_MAX_TOOL_CALLS=40
VEXA_AGENT_MAX_TURN_SEC=900
```

Three things the switch needs, and each of them bites quietly if missed:

1. **`VEXA_RUNNER` is read at import time** (`shared/units.py:19`), so agent-api must be **recreated**, not reloaded, or every dispatch keeps carrying `claude-code`.
2. **`VEXA_AGENT_MODEL` must be cleared or ignored on that lane** — decision 36's Sonnet pin is a claude model name and it would be passed straight to vLLM as `model`. The bench passes the model explicitly; a lane that leaves `VEXA_AGENT_MODEL` set will send `claude-sonnet-…` to CCC and get a 404.
3. **The runtime image carries the new copy list.** Until it is rebuilt, `VEXA_LLM_EXTRA_BODY` reaches workers only through agent-api's dispatch allowlist — which is enough on this compose stack, and is not enough on a lane whose runtime is the only thing setting it.

Not switched, not deployed, no image built, no running stack touched. Live stays on Sonnet until the founder's call (decision 37.2).

Closes nothing on its own — decision 37 step 1 of 3 (build → measure → switch a lane).
