### PR TITLE
terminal: the tab notices when the deployment underneath it moved (PRD decision 39)

### DIFF
--- a/clients/terminal/Dockerfile
+++ b/clients/terminal/Dockerfile
@@ -38,6 +38,13 @@ ENV NEXT_PUBLIC_TERMINAL_MODE=$NEXT_PUBLIC_TERMINAL_MODE
 # deployment's DEFAULT_BOT_NAME and a rename costs a rebuild.
 ARG NEXT_PUBLIC_DEFAULT_BOT_NAME=""
 ENV NEXT_PUBLIC_DEFAULT_BOT_NAME=$NEXT_PUBLIC_DEFAULT_BOT_NAME
+# The BUILD STAMP the reload bar compares against (PRD decision 39). Inlined into the client bundle
+# like every other NEXT_PUBLIC_*, which is the property that makes it work: a tab running an old
+# bundle carries the old string, the server route serving the new one reports the new string, and
+# that difference IS "a new version is ready". Empty → "unknown", and a deployment of unstamped
+# images simply never offers a reload (no false positives, no silent wrong ones).
+ARG NEXT_PUBLIC_BUILD_ID=""
+ENV NEXT_PUBLIC_BUILD_ID=$NEXT_PUBLIC_BUILD_ID
 # Regular build (not standalone): produces .next served by the custom server in production.
 RUN npm run build
 
@@ -61,10 +68,12 @@ FROM node:22-slim AS runtime
 # The server-side proxy gate reads the mode at REQUEST time (process.env), so the runtime stage must
 # carry the same value the bundle was built with — client gating and edge gating stay in lockstep.
 ARG NEXT_PUBLIC_TERMINAL_MODE=""
+ARG NEXT_PUBLIC_BUILD_ID=""
 ENV NODE_ENV=production \
     PORT=3000 \
     HOST=0.0.0.0 \
-    NEXT_PUBLIC_TERMINAL_MODE=$NEXT_PUBLIC_TERMINAL_MODE
+    NEXT_PUBLIC_TERMINAL_MODE=$NEXT_PUBLIC_TERMINAL_MODE \
+    NEXT_PUBLIC_BUILD_ID=$NEXT_PUBLIC_BUILD_ID
 # F67 — THE VARIANT, AS A FACT ON THE IMAGE. The minutes terminal and the default terminal come out
 # of this one Dockerfile and differ only by the build arg above. Both build, both pass the suite,
 # both start, and the tag is whatever the builder typed — so on 2026-09-02 a `docker compose build`
@@ -77,6 +86,18 @@ ENV NODE_ENV=production \
 # an env var can. "default" is spelled out because an empty string reads as "nobody set this", and
 # the swap guard has to tell the default variant from a broken read.
 LABEL ai.vexa.terminal.mode="${NEXT_PUBLIC_TERMINAL_MODE:-default}"
+# THE PAIRING NUMBER, AS A FACT ON THE IMAGE (F55/F77, PRD decision 39). The terminal and the
+# server have to move together: on 2026-09-02 a terminal built ahead of agent-api shipped a button
+# whose request every running server rejected, and a terminal swapped onto an old server pointed a
+# tab at a note path that server never writes. Both were caught by a human reading a diff.
+#
+# This label is what lets the swap catch them instead. It is the agent-api contract number the
+# BUNDLE was built against (`TERMINAL_AGENT_API` in src/version.ts — a test pins the two together),
+# and `deploy.sh` refuses a terminal whose label is not the `api` the agent-api that is actually
+# serving answers on GET /api/version. A literal rather than a build arg on purpose: a build arg
+# can be forgotten, and the mode label directly above is here because exactly that happened.
+LABEL ai.vexa.terminal.agent_api="1"
+LABEL ai.vexa.terminal.build="${NEXT_PUBLIC_BUILD_ID:-unknown}"
 WORKDIR /app
 COPY package.json package-lock.json ./
 # node_modules from the RUNTIME_DEPS-selected stage (prod = pruned + typescript; dev = full tree).

--- a/clients/terminal/src/app/App.tsx
+++ b/clients/terminal/src/app/App.tsx
@@ -14,6 +14,7 @@ import { registerEngineCommands } from "../workbench/commands";
 import { Workbench } from "../workbench/Workbench";
 import { MinutesShell } from "../minutes/MinutesShell";
 import { minutesOnly } from "./mode";
+import { VersionBar } from "./VersionBar";
 import { registry } from "../contributions";
 import { AuthGate } from "./AuthGate";
 import { OnboardingGate } from "./OnboardingGate";
@@ -227,6 +228,12 @@ export function App() {
   // InviteGate then shows the consent screen for any ?invite= INSIDE the authed subtree, so its preview /
   // redeem calls carry the user's real API key (the fail-closed gateway rejects anonymous calls).
   return (
+    <>
+      {/* The swap is invisible now (PRD decision 39) — so the tab tells the person when the
+          deployment underneath it moved. OUTSIDE AuthGate on purpose: the tab most likely to be
+          running a stale bundle is one sitting on a sign-in screen, and /api/version needs no
+          session. Renders nothing until it has something to say. */}
+      <VersionBar />
     <AuthGate>
       <InviteGate>
         {/* SetupGate: the bootstrap-claimed admin's first-run wizard (models + transcription,
@@ -240,5 +247,6 @@ export function App() {
         </SetupGate>
       </InviteGate>
     </AuthGate>
+    </>
   );
 }

--- a/clients/terminal/src/app/VersionBar.tsx
+++ b/clients/terminal/src/app/VersionBar.tsx
@@ -1,0 +1,68 @@
+"use client";
+/** VersionBar — one line, one button, and it appears only when the tab has gone stale.
+ *
+ *  PRD decision 39: *"a version endpoint; a new server or bundle version shows a one-line 'new
+ *  version, reload' bar; reload only on click."* All three constraints are load-bearing:
+ *
+ *  • ONE LINE, because the alternative that keeps being proposed — a modal, a toast, a full-screen
+ *    "updating" state — interrupts a person who is mid-sentence in a chat. The swap did not
+ *    interrupt them; the notice must not either.
+ *  • RELOAD ONLY ON CLICK. An automatic reload throws away an unsent message and an open canvas
+ *    to fix a problem the person may not have. The tab keeps working on the old bundle; the bar
+ *    just stops the case where they are debugging a fix that is already live and invisible.
+ *  • It never un-shows itself. Once the deployment has moved, no later poll makes the tab fresh
+ *    again, so the bar is sticky and polling stops the moment it appears.
+ */
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { POLL_MS, baselineOf, foldBaseline, readVersion, reloadOffered, type Baseline } from "./versionWatch";
+
+const bar: CSSProperties = {
+  position: "fixed", top: 0, left: 0, right: 0, zIndex: 9999,
+  display: "flex", alignItems: "center", justifyContent: "center", gap: 12,
+  padding: "7px 14px", fontSize: 13, lineHeight: 1.3,
+  background: "var(--panel)", color: "var(--t1)", borderBottom: "1px solid var(--line)",
+};
+const button: CSSProperties = {
+  padding: "3px 12px", borderRadius: 7, fontSize: 12.5, fontWeight: 600, cursor: "pointer",
+  background: "var(--accent)", color: "var(--on-accent)", border: "1px solid var(--accent)",
+};
+
+export function VersionBar({ reload = () => window.location.reload() }: { reload?: () => void }) {
+  const [stale, setStale] = useState(false);
+  const baseline = useRef<Baseline | null>(null);
+
+  const poll = useCallback(async () => {
+    const report = await readVersion();
+    if (!report) return;                       // a failed poll is silence, not a banner
+    if (baseline.current === null) { baseline.current = baselineOf(report); return; }
+    if (reloadOffered(baseline.current, report)) setStale(true);
+    else baseline.current = foldBaseline(baseline.current, report);
+  }, []);
+
+  useEffect(() => {
+    if (stale) return;                         // sticky: stop asking once the answer is known
+    let live = true;
+    const tick = () => { if (live) void poll(); };
+    tick();
+    const timer = setInterval(tick, POLL_MS);
+    // Focus is the trigger that fires in practice: a swap lands far more often while the tab is in
+    // the background than while someone is typing into it.
+    const onFocus = () => { if (document.visibilityState === "visible") tick(); };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    return () => {
+      live = false;
+      clearInterval(timer);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, [poll, stale]);
+
+  if (!stale) return null;
+  return (
+    <div style={bar} role="status">
+      <span>A new version is ready — reload</span>
+      <button style={button} onClick={reload}>Reload</button>
+    </div>
+  );
+}

--- a/clients/terminal/src/app/__tests__/versionBar.test.tsx
+++ b/clients/terminal/src/app/__tests__/versionBar.test.tsx
@@ -1,0 +1,89 @@
+/** The reload bar itself (PRD decision 39): what it shows, when, and what it refuses to do.
+ *
+ *  The refusals are the point. An automatic reload would throw away an unsent chat message to fix
+ *  a staleness the person may not care about, and a bar that appears before there is news is a bar
+ *  nobody reads by the time there is. So: nothing until a second reading disagrees with the first,
+ *  and the page moves only when a human clicks.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { VersionBar } from "../VersionBar";
+import type { VersionReport } from "../versionWatch";
+
+const report = (over: Partial<VersionReport> = {}): VersionReport => ({
+  terminal: { build: "line-aaaa", agent_api: 1 },
+  server: { sha: "line-aaaa", api: 1 },
+  paired: true,
+  ...over,
+});
+
+/** Serve a queue of readings to the component's own /api/version polls; the last one repeats. */
+function serve(readings: (VersionReport | "fail")[]) {
+  let i = 0;
+  const fetchMock = vi.fn(async () => {
+    const r = readings[Math.min(i++, readings.length - 1)];
+    if (r === "fail") throw new Error("fetch failed");
+    return new Response(JSON.stringify(r), { status: 200 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const bar = () => screen.queryByText("A new version is ready — reload");
+
+beforeEach(() => { vi.useFakeTimers({ shouldAdvanceTime: true }); });
+afterEach(() => { cleanup(); vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+describe("VersionBar", () => {
+  it("shows nothing while the deployment has not moved", async () => {
+    serve([report(), report()]);
+    render(<VersionBar />);
+    await vi.advanceTimersByTimeAsync(61_000);
+    expect(bar()).toBeNull();
+  });
+
+  it("appears once the server underneath the tab changed", async () => {
+    serve([report(), report({ server: { sha: "line-bbbb", api: 1 } })]);
+    render(<VersionBar />);
+    await vi.advanceTimersByTimeAsync(61_000);
+    await waitFor(() => expect(bar()).not.toBeNull());
+  });
+
+  it("reloads ONLY on the click", async () => {
+    const reload = vi.fn();
+    serve([report(), report({ terminal: { build: "line-bbbb", agent_api: 1 } })]);
+    render(<VersionBar reload={reload} />);
+    await vi.advanceTimersByTimeAsync(61_000);
+    await waitFor(() => expect(bar()).not.toBeNull());
+    expect(reload).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Reload"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet through a failed poll — a swap's own gap is not news", async () => {
+    serve([report(), "fail", report()]);
+    render(<VersionBar />);
+    await vi.advanceTimersByTimeAsync(121_000);
+    expect(bar()).toBeNull();
+  });
+
+  it("stops polling once it has something to say", async () => {
+    const f = serve([report(), report({ server: { sha: "line-bbbb", api: 1 } })]);
+    render(<VersionBar />);
+    await vi.advanceTimersByTimeAsync(61_000);
+    await waitFor(() => expect(bar()).not.toBeNull());
+    const settled = f.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(f.mock.calls.length).toBe(settled);
+  });
+
+  it("re-checks when the tab regains focus, without waiting out the interval", async () => {
+    const f = serve([report(), report()]);
+    render(<VersionBar />);
+    await waitFor(() => expect(f.mock.calls.length).toBe(1));
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => expect(f.mock.calls.length).toBe(2));
+  });
+});

--- a/clients/terminal/src/app/__tests__/versionPairing.test.ts
+++ b/clients/terminal/src/app/__tests__/versionPairing.test.ts
@@ -1,0 +1,31 @@
+/** The pairing number exists in TWO places and a swap trusts the one it can read without starting
+ *  a container. This test is the only thing keeping them equal.
+ *
+ *  F67 is the precedent: `NEXT_PUBLIC_TERMINAL_MODE` was a property of the bundle that the image
+ *  did not declare, so a `-minutes` tag was a label the builder typed and two wrong-variant images
+ *  passed every test that existed. The fix was to make the image state the fact — and a stated fact
+ *  drifts from its source the first time someone edits one of them.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TERMINAL_AGENT_API } from "../../version";
+
+const dockerfile = readFileSync(resolve(process.cwd(), "Dockerfile"), "utf8");
+
+describe("terminal image labels", () => {
+  it("declares the agent-api pairing number the bundle was built against", () => {
+    const m = dockerfile.match(/^LABEL ai\.vexa\.terminal\.agent_api="(\d+)"$/m);
+    expect(m, "the Dockerfile no longer declares ai.vexa.terminal.agent_api — deploy.sh reads it").not.toBeNull();
+    expect(Number(m![1])).toBe(TERMINAL_AGENT_API);
+  });
+
+  it("still declares the variant (F67) — the other fact the swap refuses on", () => {
+    expect(dockerfile).toMatch(/^LABEL ai\.vexa\.terminal\.mode=/m);
+  });
+
+  it("bakes the build stamp the reload bar compares", () => {
+    expect(dockerfile).toMatch(/ARG NEXT_PUBLIC_BUILD_ID/);
+    expect(dockerfile).toMatch(/^LABEL ai\.vexa\.terminal\.build=/m);
+  });
+});

--- a/clients/terminal/src/app/__tests__/versionWatch.test.ts
+++ b/clients/terminal/src/app/__tests__/versionWatch.test.ts
@@ -1,0 +1,91 @@
+/** The reload bar's decision logic (PRD decision 39).
+ *
+ *  These are the tests that replace a human ritual. Until 2026-09-02 the founder was asked to go
+ *  "out" while containers were recreated and "in" when they were back — a person doing, by hand,
+ *  the job of noticing that the page in front of him was older than the deployment behind it. The
+ *  rules below are that job, written down; the interesting half of them is the NON-events, because
+ *  a bar that fires on every swap-in-progress is one nobody reads by the time it is true.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  baselineOf, foldBaseline, readVersion, reloadOffered,
+  type Baseline, type VersionReport,
+} from "../versionWatch";
+
+const report = (over: Partial<VersionReport> = {}): VersionReport => ({
+  terminal: { build: "line-aaaa", agent_api: 1 },
+  server: { sha: "line-aaaa", api: 1 },
+  paired: true,
+  ...over,
+});
+
+describe("reloadOffered", () => {
+  it("is silent while nothing moved", () => {
+    const b = baselineOf(report());
+    expect(reloadOffered(b, report())).toBe(false);
+  });
+
+  it("fires when the SERVER moved under the tab (F20)", () => {
+    const b = baselineOf(report());
+    expect(reloadOffered(b, report({ server: { sha: "line-bbbb", api: 1 } }))).toBe(true);
+  });
+
+  it("fires when the BUNDLE moved — a terminal-only swap", () => {
+    const b = baselineOf(report());
+    expect(reloadOffered(b, report({ terminal: { build: "line-bbbb", agent_api: 1 } }))).toBe(true);
+  });
+
+  it("fires when the pair broke (F55/F77) even with both stamps unchanged", () => {
+    const b = baselineOf(report());
+    expect(reloadOffered(b, report({ paired: false }))).toBe(true);
+  });
+
+  it("stays silent while the server is unreachable — the swap's own gap", () => {
+    // agent-api is briefly unreachable by construction during a swap. `server: null` is "no
+    // reading", never "a different one"; treating it as news would paint the bar a second before
+    // every successful swap, which is how a notice stops being read.
+    const b = baselineOf(report());
+    expect(reloadOffered(b, report({ server: null }))).toBe(false);
+  });
+
+  it("stays silent when the FIRST reading had no server half and one appears unchanged", () => {
+    const b = baselineOf(report({ server: null }));
+    expect(b.sha).toBeNull();
+    expect(reloadOffered(b, report())).toBe(false);
+  });
+});
+
+describe("foldBaseline", () => {
+  it("fills an unknown server half from the first answer", () => {
+    const b: Baseline = { build: "line-aaaa", sha: null };
+    expect(foldBaseline(b, report()).sha).toBe("line-aaaa");
+  });
+
+  it("never overwrites a known one — that difference is the news", () => {
+    const b: Baseline = { build: "line-aaaa", sha: "line-aaaa" };
+    expect(foldBaseline(b, report({ server: { sha: "line-bbbb", api: 1 } })).sha).toBe("line-aaaa");
+  });
+});
+
+describe("readVersion", () => {
+  it("reads a well-formed report", async () => {
+    const f = vi.fn(async () => new Response(JSON.stringify(report()), { status: 200 }));
+    expect(await readVersion(f as unknown as typeof fetch)).toEqual(report());
+  });
+
+  it("answers null — never throws — on a network error, a non-200, or junk", async () => {
+    const boom = vi.fn(async () => { throw new Error("fetch failed"); });
+    expect(await readVersion(boom as unknown as typeof fetch)).toBeNull();
+    const five = vi.fn(async () => new Response("nope", { status: 502 }));
+    expect(await readVersion(five as unknown as typeof fetch)).toBeNull();
+    const junk = vi.fn(async () => new Response(JSON.stringify({ hello: "world" }), { status: 200 }));
+    expect(await readVersion(junk as unknown as typeof fetch)).toBeNull();
+  });
+
+  it("degrades a malformed server half to null rather than dropping the whole reading", async () => {
+    const f = vi.fn(async () => new Response(JSON.stringify({ ...report(), server: { sha: 7 } }), { status: 200 }));
+    const r = await readVersion(f as unknown as typeof fetch);
+    expect(r?.server).toBeNull();
+    expect(r?.terminal.build).toBe("line-aaaa");
+  });
+});

--- a/clients/terminal/src/app/api/__tests__/version.test.ts
+++ b/clients/terminal/src/app/api/__tests__/version.test.ts
@@ -1,0 +1,66 @@
+/** `GET /api/version` on the terminal — the two halves of the pairing rule, in one answer.
+ *
+ *  It is not a hop through the catch-all proxy on purpose: that route carries a per-user API key to
+ *  the gateway, and the tab most likely to be running a stale bundle is one with no session at all.
+ *  It also has to report the bundle's own build id, which only this process knows.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "../version/route";
+import { TERMINAL_AGENT_API } from "../../../version";
+
+const agentVersion = (body: unknown, status = 200) =>
+  vi.fn(async (url: string) => { void url; return new Response(JSON.stringify(body), { status }); });
+
+beforeEach(() => { vi.stubEnv("AGENT_API_URL", "http://agent.test"); vi.stubEnv("NEXT_PUBLIC_BUILD_ID", "line-aaaa"); });
+afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+async function body() { return (await GET()).json(); }
+
+describe("terminal /api/version", () => {
+  it("reports both halves — this bundle and the agent-api it resolves", async () => {
+    vi.stubGlobal("fetch", agentVersion({ service: "agent-api", sha: "line-bbbb", api: TERMINAL_AGENT_API }));
+    expect(await body()).toEqual({
+      terminal: { build: "line-aaaa", agent_api: TERMINAL_AGENT_API },
+      server: { sha: "line-bbbb", api: TERMINAL_AGENT_API },
+      paired: true,
+    });
+  });
+
+  it("calls agent-api through the network alias the swap moves", async () => {
+    const f = agentVersion({ sha: "x", api: TERMINAL_AGENT_API });
+    vi.stubGlobal("fetch", f);
+    await body();
+    expect(f.mock.calls[0]?.[0]).toBe("http://agent.test/api/version");
+  });
+
+  it("says paired:false when the server answers a contract this bundle was not built for", async () => {
+    vi.stubGlobal("fetch", agentVersion({ sha: "line-bbbb", api: TERMINAL_AGENT_API + 1 }));
+    const b = await body();
+    expect(b.paired).toBe(false);
+    expect(b.server.api).toBe(TERMINAL_AGENT_API + 1);
+  });
+
+  it("answers server:null — not a 500 — when agent-api is unreachable, a non-200, or junk", async () => {
+    // A swap makes agent-api briefly unreachable by construction. A version probe that failed
+    // loudly would paint an error in the client every time a container was a second slow.
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("ECONNREFUSED"); }));
+    expect((await GET()).status).toBe(200);
+    expect((await body()).server).toBeNull();
+    vi.stubGlobal("fetch", agentVersion({ sha: "x", api: 1 }, 503));
+    expect((await body()).server).toBeNull();
+    vi.stubGlobal("fetch", agentVersion({ nothing: true }));
+    expect((await body()).server).toBeNull();
+  });
+
+  it("an unreachable server is PAIRED — unknown is not a mismatch", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("ECONNREFUSED"); }));
+    expect((await body()).paired).toBe(true);
+  });
+
+  it("an unstamped bundle reads as unknown, never as an empty string", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BUILD_ID", "");
+    vi.stubGlobal("fetch", agentVersion({ sha: "x", api: TERMINAL_AGENT_API }));
+    expect((await body()).terminal.build).toBe("unknown");
+  });
+});

--- a/clients/terminal/src/app/api/version/README.md
+++ b/clients/terminal/src/app/api/version/README.md
@@ -1,0 +1,37 @@
+# version
+
+`GET /api/version` — what is serving, so a tab can tell when the deployment underneath it moved.
+
+PRD decision 39 removed the "out / in" ritual: containers are replaced beside the running ones and
+traffic is switched with nobody asked to leave. The ritual's one real product was a person who was
+never looking at a page older than the service behind it, and this route is how that is bought
+back.
+
+It answers both halves in one reading:
+
+```json
+{ "terminal": { "build": "line-6bec34db4", "agent_api": 1 },
+  "server":   { "sha": "line-6bec34db4", "api": 1 },
+  "paired":   true }
+```
+
+- **`terminal.build`** — `NEXT_PUBLIC_BUILD_ID`, inlined into the client bundle at image build. A
+  tab running an older bundle carries the older string; the server route serving the new one
+  reports the new string, and that difference IS "a new version is ready".
+- **`server`** — agent-api's own `GET /api/version`, fetched server-side through `AGENT_API_URL`,
+  i.e. through the compose network alias the blue/green swap moves. The answer therefore changes
+  the instant traffic is switched, with nothing restarted. Unreachable → `null`, never a 500:
+  agent-api is briefly unreachable during every swap by construction, and a probe that failed
+  loudly would paint an error in the client each time a container was a second slow.
+- **`paired`** — `false` when the server answers a contract number this bundle was not built for
+  (F55/F77). `deploy.sh` refuses to create that state; if one is live anyway, the client offers a
+  reload, which is the only move it has.
+
+It is a route of its own rather than a hop through `[...path]`, which carries a per-user API key to
+the gateway — the tab most likely to be running a stale bundle is one with no session at all. It is
+also the only place that knows the bundle's own build id.
+
+Consumers: `src/app/versionWatch.ts` (the decision logic) and `src/app/VersionBar.tsx` (one line, a
+button, and a reload that happens only on the click). The constants both sides compare live in
+`src/version.ts`, and `Dockerfile`'s `ai.vexa.terminal.agent_api` label repeats the pairing number
+so a swap can read it without starting a container — a test pins the two together.

--- a/clients/terminal/src/app/api/version/route.ts
+++ b/clients/terminal/src/app/api/version/route.ts
@@ -1,0 +1,61 @@
+/** `GET /api/version` — what is serving, for a tab that wants to notice it was swapped underneath.
+ *
+ *  PRD decision 39: the founder no longer goes "out" while a container is replaced and "in" when it
+ *  is back. The swap is invisible, which means the ONE thing the ritual bought — a person who knows
+ *  the page in front of them is stale — has to be bought by the page itself.
+ *
+ *  It is a route of its own rather than a hop through the catch-all proxy, for three reasons:
+ *    • the catch-all goes through the gateway with a per-user API key, so an unauthenticated tab
+ *      (a sign-in screen, an expired session) could not poll it — and that is exactly the tab most
+ *      likely to be looking at a stale bundle;
+ *    • it must report BOTH halves. The pairing rule has two sides, and only this process knows the
+ *      bundle's own build id;
+ *    • it resolves `agent-api` through the compose network alias, which is the thing the blue/green
+ *      swap moves. Reading it here means the answer changes the instant traffic is switched, with
+ *      no restart of anything.
+ *
+ *  The server half is best-effort: an unreachable agent-api answers `server: null` rather than a
+ *  500. A version probe that fails loudly would be a poll that paints an error banner every time a
+ *  container is a second slow — the exact opposite of the point.
+ */
+import { NextResponse } from "next/server";
+import { TERMINAL_AGENT_API, terminalBuild } from "../../../version";
+
+export const dynamic = "force-dynamic";
+
+export type ServerVersion = { sha: string; api: number };
+export type VersionReport = {
+  terminal: { build: string; agent_api: number };
+  server: ServerVersion | null;
+  /** false when the server answers a different contract number than this bundle was built for —
+   *  the F55/F77 mismatch. The deploy script refuses to create it; if one is somehow live, the
+   *  client shows the reload bar rather than pretending the pairing holds. */
+  paired: boolean;
+};
+
+async function serverVersion(): Promise<ServerVersion | null> {
+  const base = (process.env.AGENT_API_URL || "").replace(/\/$/, "");
+  if (!base) return null;
+  try {
+    const r = await fetch(`${base}/api/version`, {
+      cache: "no-store",
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!r.ok) return null;
+    const j = (await r.json()) as { sha?: unknown; api?: unknown };
+    if (typeof j?.sha !== "string" || typeof j?.api !== "number") return null;
+    return { sha: j.sha, api: j.api };
+  } catch {
+    return null;
+  }
+}
+
+export async function GET() {
+  const server = await serverVersion();
+  const body: VersionReport = {
+    terminal: { build: terminalBuild(), agent_api: TERMINAL_AGENT_API },
+    server,
+    paired: server === null ? true : server.api === TERMINAL_AGENT_API,
+  };
+  return NextResponse.json(body, { headers: { "Cache-Control": "no-store" } });
+}

--- a/clients/terminal/src/app/versionWatch.ts
+++ b/clients/terminal/src/app/versionWatch.ts
@@ -1,0 +1,78 @@
+/** versionWatch — the decision half of the reload bar, with no React and no timers in it.
+ *
+ *  PRD decision 39 removed the "out / in" ritual: containers are now replaced beside the running
+ *  ones and traffic is switched with nobody asked to leave. What the ritual used to guarantee is
+ *  that the founder never sat in front of a stale tab. This module is that guarantee, restated as a
+ *  comparison a test can drive: hold the FIRST reading as the baseline, and answer whether a later
+ *  reading means the page in front of the person is no longer the deployment behind it.
+ *
+ *  Three rules, and each one is a defect we watched happen:
+ *
+ *  1. **The server moved** — `sha` changed. F20: a container swapped under an open tab, the
+ *     in-flight request said "fetch failed", and the person read it as the product breaking.
+ *  2. **The bundle moved** — the terminal's own build id changed, so a reload would fetch different
+ *     code than the tab is running. This is what makes the bar fire for a terminal-only swap.
+ *  3. **The pair broke** — the server answers a contract number this bundle was not built for
+ *     (F55/F77). The swap refuses to create that state, so seeing it means something else did;
+ *     offering a reload is the only move a client has.
+ *
+ *  What is deliberately NOT a change: a reading with no server half. agent-api is briefly
+ *  unreachable during a swap by construction, and `server: null` means "no reading", never "a
+ *  different one". Treating it as a change would paint the bar every single swap, a second before
+ *  the swap succeeds — a boy-who-cried-wolf bar is worse than none, because the person stops
+ *  reading it exactly when it finally matters.
+ */
+
+export type ServerVersion = { sha: string; api: number };
+export type VersionReport = {
+  terminal: { build: string; agent_api: number };
+  server: ServerVersion | null;
+  paired: boolean;
+};
+
+/** The reading the tab loaded with. `sha` is null until agent-api has answered once. */
+export type Baseline = { build: string; sha: string | null };
+
+export function baselineOf(report: VersionReport): Baseline {
+  return { build: report.terminal.build, sha: report.server?.sha ?? null };
+}
+
+/** Fold a later reading into the baseline: a first server answer FILLS the unknown half; it never
+ *  overwrites a known one (that difference is the news, and losing it would silence the bar). */
+export function foldBaseline(baseline: Baseline, report: VersionReport): Baseline {
+  if (baseline.sha === null && report.server) return { ...baseline, sha: report.server.sha };
+  return baseline;
+}
+
+/** Is the page in front of the person no longer the deployment behind it? */
+export function reloadOffered(baseline: Baseline, report: VersionReport): boolean {
+  if (report.terminal.build !== baseline.build) return true;
+  if (!report.paired) return true;
+  if (baseline.sha !== null && report.server !== null && report.server.sha !== baseline.sha) return true;
+  return false;
+}
+
+/** Fetch one reading. Never throws: a failed poll is silence, not a banner. */
+export async function readVersion(fetcher: typeof fetch = fetch): Promise<VersionReport | null> {
+  try {
+    const r = await fetcher("/api/version", { cache: "no-store" });
+    if (!r.ok) return null;
+    const j = (await r.json()) as Partial<VersionReport>;
+    if (!j || typeof j.terminal?.build !== "string" || typeof j.terminal?.agent_api !== "number") return null;
+    return {
+      terminal: { build: j.terminal.build, agent_api: j.terminal.agent_api },
+      server: j.server && typeof j.server.sha === "string" && typeof j.server.api === "number"
+        ? { sha: j.server.sha, api: j.server.api }
+        : null,
+      paired: j.paired !== false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** How often a tab asks. 60s is the number in decision 39: long enough to be free, short enough
+ *  that a person who walked away for a coffee comes back to a current page. Focus is the other
+ *  trigger, and it is the one that actually fires in practice — a swap happens while the tab is
+ *  in the background far more often than while it is being read. */
+export const POLL_MS = 60_000;

--- a/clients/terminal/src/version.ts
+++ b/clients/terminal/src/version.ts
@@ -1,0 +1,30 @@
+/** version.ts — what THIS bundle is, and which agent-api contract it was built against.
+ *
+ *  Both constants exist for PRD decision 39: swaps on the dogfood stack are invisible now, so the
+ *  two jobs the "out / in" ritual used to do by hand have to be done by machinery.
+ *
+ *  `TERMINAL_AGENT_API` is the pairing number (F55/F77). The failure it prevents was live on
+ *  2026-09-02 twice: a terminal built ahead of the server shipped a button whose request every
+ *  running agent-api rejected, and a terminal swapped onto an old server lost the note tab. The
+ *  deploy script reads this number off the IMAGE (the `ai.vexa.terminal.agent_api` label, which the
+ *  Dockerfile copies from here and a test pins) and refuses to put a terminal in front of a person
+ *  when the agent-api that is actually serving answers a different `api` on `GET /api/version`.
+ *  Bump it only together with agent-api's `API_VERSION` — i.e. on a client-visible break.
+ *
+ *  `terminalBuild()` is the build stamp, read at call time so the server route and the tests see
+ *  the env rather than a value frozen at module load. It is inlined into the client bundle at BUILD
+ *  time like every other NEXT_PUBLIC_*, which is exactly the property the reload bar needs: when a
+ *  new bundle is served under an open tab, the tab's own copy of this string stops matching the one
+ *  the server route reports, and that difference IS the notification.
+ */
+
+/** The agent-api contract this bundle speaks. Keep in lockstep with `API_VERSION` in
+ *  `core/agent/control_plane/version.py` and with the Dockerfile's `ai.vexa.terminal.agent_api`. */
+export const TERMINAL_AGENT_API = 1;
+
+export const UNKNOWN_BUILD = "unknown";
+
+/** The build this bundle came out of — `NEXT_PUBLIC_BUILD_ID`, stamped at image build. */
+export function terminalBuild(): string {
+  return (process.env.NEXT_PUBLIC_BUILD_ID || "").trim() || UNKNOWN_BUILD;
+}

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -77,6 +77,7 @@ from control_plane import workspace_credentials as wcreds
 from control_plane import repo_ref
 from shared.git_redaction import redact as redact_secrets
 from control_plane import global_layer
+from control_plane import version as version_mod
 from control_plane import system_mounts
 from control_plane import scaffolds as scaffolds_mod
 from control_plane import friction as friction_store_mod
@@ -1121,7 +1122,10 @@ def create_app(
     # unreachable probe so a transient fault cannot brick sign-in on a working instance; it can
     # afford to precisely because this middleware holds, so a browser that renders anyway can still
     # do nothing.
-    _GATE_OPEN_PREFIXES = ("/api/global/",)
+    # `/api/version` joins them (decision 39): the swap script and an open browser tab both poll
+    # it to find out what is serving, and neither has a subject. Gating it would answer 403 to
+    # the one question whose whole purpose is answerable from outside, before anyone signs in.
+    _GATE_OPEN_PREFIXES = ("/api/global/", "/api/version")
 
     @app.middleware("http")
     async def _company_layer_gate(request: Request, call_next):
@@ -1291,6 +1295,21 @@ def create_app(
              "capabilities": capability_health()},
             status_code=200 if ok else 503,
         )
+
+    @app.get("/api/version")
+    def version():
+        """What is serving — unauthenticated, cheap, and polled (PRD decision 39).
+
+        No identity gate on purpose: the blue/green swap probes this from the HOST before any
+        traffic is switched onto the container, and an open browser tab polls it to notice that
+        the service underneath it moved. Both are outside a session. What it discloses is a build
+        stamp and a contract integer — the same facts the running image announces in its tag.
+
+        `api` is the pairing number the swap enforces (F55/F77): a terminal image whose baked
+        `ai.vexa.terminal.agent_api` label is not this number is REFUSED before it can be put in
+        front of a person, because that is the failure where the client leads the server and every
+        click 422s."""
+        return version_mod.version_payload()
 
     @app.get("/api/models")
     def models(request: Request):

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -15,6 +15,15 @@
       "description": "app log level"
     },
     {
+      "key": "VEXA_BUILD_SHA",
+      "class": "defaulted",
+      "default": "unknown",
+      "description": "the build this CONTAINER is running, stamped by whoever started it and reported verbatim by GET /api/version. Deliberately NOT derived from the source tree: the answer has to be true of the container, and a container knows nothing about the repo it was built from. The blue/green deploy sets it to the tag it is deploying (PRD decision 39); unset reads as \"unknown\", so an unstamped deployment simply never offers the terminal's reload bar",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
       "key": "VEXA_RUNTIME_API_URL",
       "class": "defaulted",
       "default": "http://runtime-api:8090",

--- a/core/agent/control_plane/version.py
+++ b/core/agent/control_plane/version.py
@@ -1,0 +1,48 @@
+"""version.py — what is serving, as one cheap unauthenticated fact.
+
+Two consumers, and neither of them is a human reading a log:
+
+1. **The deploy script** (`deploy/dogfood/bin/deploy.sh` in the estate line). A blue/green swap
+   starts the new container beside the old and has to decide, from outside, whether the thing now
+   answering is the thing it started. `sha` answers that. It also has to refuse a TERMINAL whose
+   bundle expects a different agent-api contract than the one serving — the F55/F77 pairing rule,
+   which is what `api` is for: a small integer bumped by hand whenever a change to this service
+   would break a client bundle built before it.
+
+2. **The terminal itself.** It polls this endpoint and shows a one-line "a new version is ready —
+   reload" bar when `sha` moves under an open tab. Before decision 39 that was a human ritual
+   ("out" / "in"); the swap is invisible now, so the tab has to notice on its own.
+
+`api` is NOT the build. Two different builds share an `api` whenever neither breaks the client;
+it moves only on a client-visible break, which is why a client can pin it as a constant
+(`clients/terminal/src/version.ts`) and the swap can compare the two numbers.
+
+`sha` is whatever the deployment stamped as `VEXA_BUILD_SHA` — the image tag / commit the operator
+deployed. It is deliberately NOT derived from the source tree: the answer has to be true of the
+CONTAINER, and a container knows nothing about the git repo it was built from.
+"""
+from __future__ import annotations
+
+import os
+
+# ── THE CONTRACT NUMBER ──────────────────────────────────────────────────────────────────────────
+# Bump ONLY when a change here would break a terminal bundle built before it (a removed or
+# renamed response field, a changed status code, a new required request field). Bumping it makes
+# every older terminal image REFUSED by the swap until it is rebuilt — that is the point.
+# Keep in lockstep with TERMINAL_AGENT_API in clients/terminal/src/version.ts.
+API_VERSION = 1
+
+UNKNOWN = "unknown"
+
+
+def build_sha() -> str:
+    """The build the CONTAINER is running, as stamped by whoever started it.
+
+    Empty/unset reads as "unknown" rather than an empty string: a consumer comparing two versions
+    must be able to tell "no answer" from "a build called ''".
+    """
+    return (os.environ.get("VEXA_BUILD_SHA") or "").strip() or UNKNOWN
+
+
+def version_payload() -> dict:
+    return {"service": "agent-api", "sha": build_sha(), "api": API_VERSION}

--- a/core/agent/tests/test_version.py
+++ b/core/agent/tests/test_version.py
@@ -1,0 +1,71 @@
+"""`GET /api/version` — the fact a blue/green swap and an open tab both ask for (PRD decision 39).
+
+The ritual it replaces was a human one: the founder was told to go "out" while containers were
+recreated and "in" when they were back, because a container swapped under an open tab fails one
+request (F20) and because the terminal and the server must move together (F55/F77). Neither reason
+needs a person. This endpoint is what lets the machine do both jobs:
+
+  * the swap script probes it on the NEW container, from the host, before any traffic moves;
+  * the swap script compares its `api` to the terminal image's baked pairing label and REFUSES a
+    terminal that would lead the server;
+  * the terminal polls it and offers a reload when `sha` changes underneath.
+
+So the tests below hold exactly the properties those three uses depend on: it answers without a
+session, it answers before the company layer is written, it reports the CONTAINER's stamp rather
+than anything read off a source tree, and `api` is a stable integer.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from control_plane import global_layer, version
+from control_plane.api import create_app
+from control_plane.dispatch import Dispatcher
+from shared.config import load_settings
+from tests.test_api import _FakeIdentity, _FakeRuntime
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app(Dispatcher(load_settings(), _FakeRuntime(), _FakeIdentity())))
+
+
+def test_version_reports_the_containers_stamp_and_the_contract(client, monkeypatch):
+    monkeypatch.setenv("VEXA_BUILD_SHA", "line-deadbeef")
+    r = client.get("/api/version")
+    assert r.status_code == 200
+    assert r.json() == {"service": "agent-api", "sha": "line-deadbeef", "api": version.API_VERSION}
+
+
+def test_unstamped_build_is_unknown_not_empty(client, monkeypatch):
+    """A consumer comparing two answers must be able to tell "nobody stamped this" from a build
+    whose name is the empty string — otherwise every unstamped container looks identical to every
+    other one and the terminal never offers a reload."""
+    monkeypatch.setenv("VEXA_BUILD_SHA", "   ")
+    assert client.get("/api/version").json()["sha"] == "unknown"
+    monkeypatch.delenv("VEXA_BUILD_SHA", raising=False)
+    assert client.get("/api/version").json()["sha"] == "unknown"
+
+
+def test_api_is_an_integer_contract_number(client):
+    assert isinstance(client.get("/api/version").json()["api"], int)
+
+
+def test_no_session_needed(client):
+    """Probed from the host before any traffic is switched onto the container: there is no user."""
+    r = client.get("/api/version")
+    assert r.status_code == 200
+
+
+def test_answers_through_the_company_layer_gate(client, monkeypatch):
+    """The gate refuses every `/api/*` path to a non-admin on an unwritten instance. That is right
+    for everything a person does and wrong here: a swap probing a brand-new container has no
+    admin, and a tab polling for "did the thing under me move" would be told 403 forever."""
+    monkeypatch.setattr(global_layer, "instance_state",
+                        lambda *_a, **_k: {"admin_exists": True, "global_setup": "missing", "company": None})
+    monkeypatch.setattr(global_layer, "is_admin", lambda *_a, **_k: False)
+    r = client.get("/api/version", headers={"X-User-Id": "u_stranger"})
+    assert r.status_code == 200, "the gate swallowed the one endpoint that must answer from outside"
+    # and the gate is otherwise still closed — this test must not be passing because it is off
+    assert client.get("/api/models", headers={"X-User-Id": "u_stranger"}).status_code == 403

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -26,6 +26,11 @@ MINIO_CONSOLE_HOST_PORT=9001
 
 # --- images ------------------------------------------------------------------
 IMAGE_TAG=v012
+
+# The build stamp agent-api reports on GET /api/version and the terminal's reload bar compares
+# against (PRD decision 39). Empty -> falls back to IMAGE_TAG, which is what a plain `up -d`
+# should say. The blue/green deploy sets it per swap.
+VEXA_BUILD_SHA=
 # v012 tags are the published 0.12-line images. Do NOT fall back to `dev`: the published
 # vexaai/vexa-bot:dev on Docker Hub is the older 0.10 line and is INCOMPATIBLE with this stack's
 # lifecycle.v1 contract (bots reach `joining` then fail). For a source dev loop, build the bot

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -258,6 +258,12 @@ services:
       # How the runtime's scheduler reaches this service's /invocations sink when a routine fires (MVP2).
       - VEXA_AGENT_API_SELF_URL=http://agent-api:8100
       - VEXA_AGENT_PROFILE=agent
+      # What GET /api/version reports, and what the terminal's reload bar compares against. It is a
+      # property of the CONTAINER, not of the source tree — an image knows nothing about the repo it
+      # was built from — so the deployment stamps it. Defaults to the image tag, which is right for a
+      # plain `up -d`; the blue/green deploy sets it explicitly to the tag it is rolling out.
+      # Unset reads as "unknown" and the bar simply never fires (PRD decision 39).
+      - VEXA_BUILD_SHA=${VEXA_BUILD_SHA:-${IMAGE_TAG:-dev}}
       - VEXA_WORKSPACES_DIR=/workspaces
       # Lane M: the users.data.memberships[] index mirror over the admin-api internal edge
       # (policy/members.json in the workspace git repo stays authoritative; this is the listing cache).


### PR DESCRIPTION
## Symptom

Once swaps are invisible (PRD decision 39, sibling PR #1421), the one thing the **"out / in"** ritual actually bought disappears with it: a person who is never looking at a page older than the service behind it. A tab open across a swap keeps running an old bundle against a new server and says nothing — which is F20 with the noise removed rather than the problem.

And the pairing rule (F55/F77) has no machine-readable side. The terminal and the server must move together, and on 2026-09-02 both directions cost a window: a terminal built ahead of agent-api shipped an Extend/Create button whose `intent` field every running server rejected (`extra: "forbid"` → 422), and a terminal swapped onto an old server pointed a tab at a note path that server never writes. Both were caught by a human reading a diff.

## Change

**agent-api — `GET /api/version` → `{service, sha, api}`.** Unauthenticated and exempt from the company-layer gate, because both callers are outside a session by construction: a swap probing a brand-new container before any traffic reaches it, and a tab asking whether it is stale. `sha` is `VEXA_BUILD_SHA`, stamped by whoever started the container — deliberately not derived from the source tree, since the answer has to be true of the *container*. `api` is the contract integer, bumped only on a client-visible break, which is what makes it something a client can pin.

**terminal — `GET /api/version` of its own.** Not a hop through the catch-all: that route carries a per-user API key to the gateway, and the tab most likely to be running a stale bundle is one with no session at all. It reports the bundle's own build id **and** the agent-api it resolves through `AGENT_API_URL` — i.e. through the compose alias the swap moves, so the answer changes the instant traffic is switched, with nothing restarted. An unreachable agent-api is `server: null`, never a 500.

**The bar.** One line, one button, sticky, polling every 60 s and on focus, and it reloads **only on the click** — an automatic reload throws away an unsent message to fix a staleness the person may not have. It fires when the server `sha` moved, when the bundle's build id moved, or when the pair broke. It deliberately does **not** fire on a reading with no server half: agent-api is unreachable for a moment during every swap by construction, and a bar that fires then is one nobody reads by the time it is true.

**The pairing number as a fact on the image.** `ai.vexa.terminal.agent_api` — the same shape F67 gave the variant, and for the same reason: a property of the bundle that the image does not declare is a property nobody can check without starting it. `deploy.sh` reads the label and refuses any terminal whose number is not the `api` the serving agent-api answers. A test pins the label to the source constant, because a stated fact drifts from its source the first time someone edits one of them.

## Proof

- **Terminal: 1133 tests green, `tsc --noEmit` clean.** 26 of them new — the watch logic (including every non-event), the bar's refusals (no auto-reload, quiet through a failed poll, stops polling once it has something to say, re-checks on focus), the route's degradations, and the Dockerfile-label pin.
- **agent-api: 5 new tests** — the stamp, `unknown` rather than empty for an unstamped build, no session needed, and that it answers *through* the company-layer gate while `/api/models` still 403s to the same caller (so the exemption test cannot pass because the gate is off).
- **End to end on the rehearsal rig** (sibling PR): `GUARD 4 — pairing holds: terminal expects api=1, serving agent-api answers api=1`, and a terminal declaring `agent_api=2` against a server answering `api=1` was **refused** with nothing moved.

`VEXA_BUILD_SHA` is declared in `config.v1` (ADR-0026) and stamped in compose with `IMAGE_TAG` as its default, so a plain `up -d` also says what it is running.

Owning issue: DmitriyG228/biz#449 · PRD decision 39 · pairs with #1421.
