### PR TITLE
security: close the internal tier at the edge (F95) and stop the rig writing workspaces around agent-api (F96)

### DIFF
--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -2,7 +2,6 @@
   "core/agent/contracts/event.v1": "f154a49d0589274140fb584e680b34a12e47f8cf3b1491cfc077d47e019f71f8",
   "core/agent/contracts/invoke.v1": "9a38b01616a8cb25b8e34db9a4a539f9cdc237a731fb67ebf4f361c081897982",
   "core/agent/contracts/proactive-card.v1": "cb9f8df76cea7667dec8f6ea5fdbc6fe4f6c9ed518fd3369c9f75e6fcf7b8a88",
-  "core/agent/contracts/processed-notes.v1": "cc58ab6c26e68c9b01f326891bfa6d7d384ce4fa57f7ece3c9f13342372350f8",
   "core/agent/contracts/routine.v1": "0ef13353d8d71145fb6190d7f4c17f7aed3db74062b65c5119416bde0b704bd8",
   "core/agent/contracts/task.v1": "12575c8f7e31d3510cddead4fec7a3d5bea93cf8c4b60643fbcf02b3c8b85a26",
   "core/agent/contracts/tool.v1": "a6a19a0539f26adeb2ecfccea6071f6eda99b2185e506eed6f474256810f224e",
@@ -22,6 +21,6 @@
   "core/meetings/contracts/webhook.v1": "7d5b9d674544cf8ce7bdeda85b5156907be7c4d3e9be359366cc2ab1665bafba",
   "core/runtime/contracts/runtime.v1": "9d67b9379e0d34c4d715764a467e7f6e6543a5db8177fc284fb4a7418067bc18",
   "core/runtime/contracts/schedule.v1": "6f2c0277d3d186ca2a9333342930f135ea66bfd931135c451bd12b05ff862648",
-  "deploy/contracts/config.v1": "b8c5c1f6344858eddd6509dcbf0a459a3df73866b467011a774245fb3c9ecb17",
+  "deploy/contracts/config.v1": "90396c2a1e181fcc9fc229359adef8bea9308d3210aba6d3c20b9d76a668410a",
   "deploy/contracts/execution-targets.v1": "0c644571b7823024aa2e7ec6a135a55202233155c6c60eef79f1f4ec063e6375"
 }

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -3593,10 +3593,24 @@ def _build_production_app() -> FastAPI:
     from control_plane.config_preflight import preflight
     from control_plane.workspace_routines import start_workspace_routine_reconciler
 
-    # config.v1 boot preflight (ADR-0026): agent-api has no required-explicit keys today, so this
-    # logs the capability tri-states (bot_gateway · model_inference) — a deploy that cannot add bots
-    # from URL or whose workers will have NO model credentials says so in the boot log and on
-    # /health, instead of failing at first chat with 'Model inference failed: Not logged in'.
+    # ONE NAME for the internal tier (F95). The canonical key is INTERNAL_API_SECRET — the same
+    # name compose, helm, admin-api, gateway and meeting-api use. VEXA_INTERNAL_API_SECRET still
+    # resolves through the settings alias so an operator mid-upgrade is WARNED rather than silently
+    # dropped into an unauthenticated internal tier; it is removed next release.
+    if not (os.environ.get("INTERNAL_API_SECRET") or "").strip() and \
+            (os.environ.get("VEXA_INTERNAL_API_SECRET") or "").strip():
+        logger.warning(
+            "VEXA_INTERNAL_API_SECRET is DEPRECATED — rename it to INTERNAL_API_SECRET, the one "
+            "name the whole internal tier uses (compose/helm secret key, admin-api, gateway, "
+            "meeting-api). The prefixed spelling is honoured this release and removed in the next."
+        )
+
+    # config.v1 boot preflight (ADR-0026): INTERNAL_API_SECRET is required-explicit and must not
+    # hold a published placeholder, so an internal tier that was never configured refuses to boot
+    # rather than believing a secret printed in this repository (F95). The run also logs the
+    # capability tri-states (bot_gateway · model_inference) — a deploy that cannot add bots from URL
+    # or whose workers will have NO model credentials says so in the boot log and on /health,
+    # instead of failing at first chat with 'Model inference failed: Not logged in'.
     preflight()
 
     settings = load_settings()

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -314,12 +314,40 @@
       ]
     },
     {
+      "key": "INTERNAL_API_SECRET",
+      "class": "required-explicit",
+      "secret": true,
+      "description": "THE internal-tier shared secret — one name across every service (the compose/helm secret key). agent-api both PRESENTS it (Lane M: X-Internal-Secret on the admin-api membership-index edge) and BELIEVES it: `_internal_caller` compares this value, and gate 0 of the meeting room is by the code's own statement the trust boundary on who is in the room. Unset it used to mean `_internal_caller` simply returned False; the boot now refuses instead, because a half-configured internal tier is not a degrade an operator can see. Read through an alias so the deprecated VEXA_-prefixed spelling still works for one release (shared/config.py).",
+      "targets": [
+        "compose",
+        "helm",
+        "lite"
+      ],
+      "forbidden_values": [
+        "vexa-internal-secret",
+        "lite-internal-secret",
+        "changeme",
+        "change-me",
+        "CHANGE-ME",
+        "default",
+        "secret"
+      ]
+    },
+    {
       "key": "VEXA_INTERNAL_API_SECRET",
       "class": "defaulted",
-      "default": "(unset)",
-      "description": "Lane M: X-Internal-Secret for the admin-api membership-index internal edge (same value the gateway uses)",
-      "targets": [
-        "compose"
+      "default": "(unset — DEPRECATED alias of INTERNAL_API_SECRET; read only when the canonical name is absent, and the boot logs a deprecation warning)",
+      "secret": true,
+      "description": "DEPRECATED spelling of INTERNAL_API_SECRET. One secret had three names (INTERNAL_API_SECRET in compose/helm and in admin-api/gateway/meeting-api, VEXA_INTERNAL_API_SECRET here and in the terminal, VEXA_INTERNAL_SECRET in flows) and the drift is what let a placeholder survive on one spelling's refusal list and not the others (F95). No deploy surface sets it on agent-api any more; it is still READ so an operator mid-upgrade is warned rather than 401ed. Delete once the terminal reads the canonical name too.",
+      "targets": [],
+      "forbidden_values": [
+        "vexa-internal-secret",
+        "lite-internal-secret",
+        "changeme",
+        "change-me",
+        "CHANGE-ME",
+        "default",
+        "secret"
       ]
     },
     {

--- a/core/agent/control_plane/config_preflight.py
+++ b/core/agent/control_plane/config_preflight.py
@@ -27,6 +27,11 @@ when the cached result is older than the probe's ``ttl_s``. This is what turns t
 token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
 meeting/agent runs.
 
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
 Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
 environment and long-lived processes both observe the truth.
 """
@@ -362,6 +367,20 @@ def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
             f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
             f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
             "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
         )
     rows = capability_health(env, force_probe=True)
     for name, row in sorted(rows.items()):

--- a/core/agent/shared/config.py
+++ b/core/agent/shared/config.py
@@ -6,14 +6,16 @@ never land in a log line, a repr, or a golden. The control plane reads these onc
 """
 from __future__ import annotations
 
-from pydantic import Field, SecretStr
+from pydantic import AliasChoices, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """The agent-api boot config. Every field arrives by ``VEXA_*`` env (12-factor)."""
 
-    model_config = SettingsConfigDict(env_prefix="VEXA_", extra="ignore")
+    # ``populate_by_name`` so a field carrying an explicit ``validation_alias`` (below) is still
+    # constructible by its FIELD name — every test builds Settings that way.
+    model_config = SettingsConfigDict(env_prefix="VEXA_", extra="ignore", populate_by_name=True)
 
     # ── Where this service lives ─────────────────────────────────────────────
     agent_api_port: int = Field(default=8100, ge=1, le=65535)
@@ -121,8 +123,21 @@ class Settings(BaseSettings):
     # The shared key the Identity service signs per-dispatch tokens with (dev tier); every boundary
     # verifies with the same key. k8s replaces this with SPIRE-issued SVIDs behind the same interface.
     dispatch_signing_key: SecretStr = SecretStr("dev-dispatch-signing-key")
-    # Internal-tier shared secret for the admin-api membership-index edge (Lane M).
-    internal_api_secret: SecretStr = SecretStr("")
+    # THE internal-tier shared secret. agent-api both PRESENTS it (Lane M: the admin-api
+    # membership-index edge) and BELIEVES it — ``_internal_caller`` compares this value, and gate 0
+    # of the meeting room is by that code's own statement the trust boundary on who is in the room.
+    #
+    # ONE NAME, and the alias says which. The secret had three spellings across the estate
+    # (``INTERNAL_API_SECRET`` in compose/helm and in admin-api/gateway/meeting-api,
+    # ``VEXA_INTERNAL_API_SECRET`` here and in the terminal, ``VEXA_INTERNAL_SECRET`` in flows), and
+    # that drift is precisely what let the published placeholder ``vexa-internal-secret`` sit on one
+    # refusal list and not the others (F95). The canonical name is the compose/helm secret KEY —
+    # ``INTERNAL_API_SECRET`` — and it wins; the prefixed spelling is read only when the canonical
+    # one is absent, and ``_build_production_app`` logs a deprecation warning when it is.
+    internal_api_secret: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices("INTERNAL_API_SECRET", "VEXA_INTERNAL_API_SECRET"),
+    )
     # admin-api's ADMIN token (``X-Admin-API-Key`` / its ``ADMIN_API_TOKEN``). Needed ONLY to resolve
     # a meeting participant's ADDRESS to a subject for the post-meeting room, because the one route
     # that answers that question — ``GET /admin/users/email/{email}`` — sits behind the admin token

--- a/core/agent/tests/test_config_contract.py
+++ b/core/agent/tests/test_config_contract.py
@@ -38,17 +38,72 @@ def test_declaration_loads_and_is_internally_consistent():
     assert decl["capabilities"]["model_inference"]["mode"] == "any"
 
 
+def _env_names(field_name, field):
+    """Every env var this Settings field actually reads — the VEXA_ prefix by default, or the
+    explicit `validation_alias` choices where a field carries one (F95: `internal_api_secret` reads
+    the canonical `INTERNAL_API_SECRET` first and the prefixed spelling as a deprecated fallback)."""
+    alias = getattr(field, "validation_alias", None)
+    choices = getattr(alias, "choices", None)
+    if choices:
+        return [str(c) for c in choices]
+    if isinstance(alias, str):
+        return [alias]
+    return [f"VEXA_{field_name.upper()}"]
+
+
 def test_every_settings_field_is_declared():
     """pydantic-settings reads env by field name (VEXA_ prefix) — invisible to the gate's literal
     os.getenv scanner, so THIS test holds the sync: a new Settings field must land in the
-    declaration (the SSOT) to pass."""
+    declaration (the SSOT) to pass. A field carrying an explicit alias must have EVERY spelling it
+    accepts declared, or one name of a secret drifts out of the contract while the other stays in —
+    which is precisely the shape F95 arrived in."""
     declared = {k["key"] for k in cp.load_declaration()["keys"]}
-    for field in Settings.model_fields:
-        env_name = f"VEXA_{field.upper()}"
-        assert env_name in declared, (
-            f"Settings.{field} reads {env_name} but config.v1.json does not declare it — "
-            "add it to core/agent/control_plane/config.v1.json"
-        )
+    for field_name, field in Settings.model_fields.items():
+        for env_name in _env_names(field_name, field):
+            assert env_name in declared, (
+                f"Settings.{field_name} reads {env_name} but config.v1.json does not declare it — "
+                "add it to core/agent/control_plane/config.v1.json"
+            )
+
+
+def test_internal_secret_has_one_canonical_name_and_a_deprecated_alias(monkeypatch):
+    """F95 — one secret had three names, and each name grew its own refusal list.
+
+    The canonical name is the compose/helm secret KEY, `INTERNAL_API_SECRET`, the same name
+    admin-api, gateway and meeting-api read. The prefixed spelling still resolves so an operator
+    mid-upgrade is warned rather than silently dropped into an unauthenticated internal tier — but
+    it must never WIN over the canonical one, or a stale export quietly shadows the real value."""
+    monkeypatch.delenv("INTERNAL_API_SECRET", raising=False)
+    monkeypatch.setenv("VEXA_INTERNAL_API_SECRET", "deprecated")
+    assert load_settings().internal_api_secret.get_secret_value() == "deprecated"
+
+    monkeypatch.setenv("INTERNAL_API_SECRET", "canonical")
+    assert load_settings().internal_api_secret.get_secret_value() == "canonical"
+
+    monkeypatch.delenv("VEXA_INTERNAL_API_SECRET", raising=False)
+    assert load_settings().internal_api_secret.get_secret_value() == "canonical"
+
+    # Constructing by FIELD name still works — every other test in this tree builds Settings that
+    # way, and an alias that broke it would have been a silent test-only regression.
+    assert load_settings(internal_api_secret="explicit").internal_api_secret\
+        .get_secret_value() == "explicit"
+
+
+def test_preflight_refuses_a_secretless_or_placeheld_internal_tier():
+    """agent-api both PRESENTS the internal secret and BELIEVES it — `_internal_caller` compares
+    this value, and the meeting room's gate 0 is by that code's own statement the trust boundary on
+    who is in the room. Unset used to mean `_internal_caller` simply returned False, which is a
+    half-configured tier nobody can see; a PUBLISHED placeholder is worse, because it is that tier
+    handed to every reader of the repository (F95)."""
+    with pytest.raises(cp.ConfigError) as ei:
+        cp.preflight({})
+    assert "INTERNAL_API_SECRET" in str(ei.value)
+    for placeholder in ("vexa-internal-secret", "lite-internal-secret", "changeme"):
+        with pytest.raises(cp.ConfigError) as ei:
+            cp.preflight({"INTERNAL_API_SECRET": placeholder})
+        assert "INTERNAL_API_SECRET" in str(ei.value)
+        assert placeholder not in str(ei.value), "a refusal must never echo the value"
+    cp.preflight({"INTERNAL_API_SECRET": "a-real-secret"})
 
 
 def test_capability_tri_states():
@@ -60,9 +115,13 @@ def test_capability_tri_states():
     assert cp.capability_states({"ANTHROPIC_AUTH_TOKEN": "tok"})["model_inference"] == cp.CONFIGURED
 
 
-def test_preflight_has_no_required_keys_and_reports_rows(monkeypatch):
+def test_preflight_reports_capability_rows(monkeypatch):
+    """agent-api used to have NO required-explicit key, and this test was named for that fact. F95
+    gave it one — INTERNAL_API_SECRET, which it both presents and believes — so the environment now
+    has to carry it before the capability rows can be reached at all."""
     for k in ("VEXA_BOT_API_KEY", "HOST_CLAUDE_CREDENTIALS", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"):
         monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("INTERNAL_API_SECRET", "a-real-secret")
     report = cp.preflight()
     assert report["service"] == "agent-api"
     assert report["capabilities"]["bot_gateway"]["state"] == cp.NOT_CONFIGURED

--- a/core/agent/tests/test_lane_a_shared_mounts.py
+++ b/core/agent/tests/test_lane_a_shared_mounts.py
@@ -209,6 +209,22 @@ def test_non_member_is_refused_shared_tree_and_file(tmp_path):
     assert file.status_code == 403          # ...nor read its files by slug
 
 
+def test_non_member_is_refused_a_shared_WRITE_by_slug(tmp_path):
+    """F96 — the write side, stated where the read side already is.
+
+    The rig's `workspace_write` bypassed this entirely: it wrote by `docker exec` into the volume,
+    and a volume has no membership. Now that it forwards here on the caller's identity, THIS is the
+    check that stops a stranger overwriting a shared workspace's files, so it is asserted rather
+    than assumed."""
+    _grant(tmp_path, "wsA", owner="owner1")          # stranger is NOT a member
+    client = _client(tmp_path, index=m.InMemoryMembershipIndex())
+
+    r = client.put("/api/workspace/file", headers=_h("stranger"),
+                   json={"path": "README.md", "content": "mine now", "slug": "wsA"})
+
+    assert r.status_code == 403
+
+
 # ── the full share flow: create shared ws (bootstrap) → mint → accept → appears for the new member ──
 def test_share_flow_create_mint_accept(tmp_path, monkeypatch):
     # a minimal seed template so create_shared_workspace_dir can seed the new ws

--- a/core/agent/tests/test_rig_workspace_write.py
+++ b/core/agent/tests/test_rig_workspace_write.py
@@ -1,0 +1,146 @@
+"""F96 — the rig writes a workspace through the door that authorizes it, not around it.
+
+`workspace_write` used to run
+
+    docker exec -i vexa-dogfood-agent-api-1 sh -c 'mkdir -p "$(dirname TARGET)" && cat > TARGET'
+
+with the caller's `path` and `slug` interpolated unquoted into TARGET. Two failures in one line:
+
+  * **the shell** — `workspace_write(path="x; id > /tmp/p; #")` executed as root inside the
+    container that holds every workspace AND the secret store, reachable by any signed-in user;
+  * **the door** — the write went to the volume, and a volume has no membership check, so any
+    signed-in user could truncate any other person's or group's file. The READ side had gone
+    through agent-api, which confines and authorizes, since the beginning.
+
+Both are the same mistake — reaching around the service that owns the resource — and one fix
+answers both: `PUT /api/workspace/file` on the caller's identity. The route applies the mount rules
+(contributor+ on a shared workspace, the org-admin allowlist on `_global`), confines the path under
+the workspace root, and commits.
+
+Source-level, like `test_rig_stateless.py`: the rig is a standalone server with its own dependency
+set, so these tests read it rather than import it. The path validator IS executed — extracted by
+`ast` so the assertions run against the shipped function and not a copy of it.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import posixpath
+import re
+
+import pytest
+
+RIG = pathlib.Path(__file__).resolve().parents[3] / "deploy/dogfood/rig/vexa_control_mcp.py"
+
+
+def _src() -> str:
+    return RIG.read_text()
+
+
+def _fn(name: str) -> str:
+    """The CODE of one top-level function — docstring excluded.
+
+    Excluded deliberately: these functions explain in prose what they no longer do, and a scan that
+    cannot tell an explanation from an instruction would either fail on the explanation or force the
+    explanation out of the file. The history is the most valuable line in there."""
+    src = _src()
+    tree = ast.parse(src)
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            body = list(node.body)
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                body = body[1:]
+            return "\n".join(ast.get_source_segment(src, n) or "" for n in body)
+    raise AssertionError(f"{name} is gone from the rig — re-read it before trusting this test")
+
+
+def _path_validator():
+    """Execute the SHIPPED `_safe_ws_path` (plus what it needs) without importing the whole rig."""
+    src = _src()
+    tree = ast.parse(src)
+    wanted = {"_BadPath", "_PATH_FORBIDDEN", "_safe_ws_path"}
+    body = []
+    for node in tree.body:
+        if getattr(node, "name", None) in wanted:
+            body.append(node)
+        elif isinstance(node, ast.Assign) and any(
+                getattr(t, "id", None) in wanted for t in node.targets):
+            body.append(node)
+    assert len(body) == 3, f"the path validator moved or changed shape: {[getattr(n, 'name', n) for n in body]}"
+    ns: dict = {"posixpath": posixpath}
+    exec(compile(ast.Module(body=body, type_ignores=[]), str(RIG), "exec"), ns)  # noqa: S102
+    return ns["_safe_ws_path"], ns["_BadPath"]
+
+
+# ── the door ─────────────────────────────────────────────────────────────────────────────────────
+
+def test_no_write_shells_into_the_container_any_more():
+    """The whole class, not the one call site: no `docker exec` may carry a write.
+
+    `docker inspect` on admin-api's env survives — it is a READ of a container's own configuration
+    and belongs to the seam inventory the core-mcp work closes, not to this hotfix."""
+    src = _src()
+    reaches = [ln.strip() for ln in src.splitlines()
+               if '"docker", "exec"' in ln or "docker exec -i" in ln]
+    assert reaches == [], f"a write still shells into the container: {reaches}"
+
+
+def test_workspace_write_goes_through_agent_api_on_the_callers_identity():
+    body = _fn("workspace_write")
+    assert "/api/workspace/file" in body, "the write must use agent-api's own write route"
+    assert re.search(r'_http\(\s*"PUT"', body), "the route is a PUT"
+    assert '"X-User-Id": uid' in body, (
+        "the write must carry the CALLER's identity — that header is what makes the route's "
+        "membership check mean anything")
+    assert "subprocess" not in body and "docker" not in body
+    assert "_safe_ws_path" in body
+
+
+def test_the_resume_queue_writes_through_the_same_door():
+    body = _fn("_write_json")
+    assert "/api/workspace/file" in body and '"X-User-Id": uid' in body
+    assert "subprocess" not in body and "docker" not in body
+
+
+# ── the path ─────────────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", [
+    "../../etc/passwd",
+    "a/../../etc/passwd",
+    "/etc/passwd",
+    "..",
+    "",
+    "   ",
+    ".git/config",
+    "x; id > /tmp/pwned; #",
+    "$(id)",
+    "`id`",
+    "a|b",
+    "a&b",
+    "a\nb",
+    'a"b',
+    "a'b",
+])
+def test_a_path_that_climbs_or_carries_a_shell_metacharacter_is_refused(path):
+    """Refused BEFORE anything runs. The shell is gone, so the metacharacter cases are belt as well
+    as braces — deliberately: a validator that only defends against today's implementation defends
+    against nothing after the next refactor."""
+    safe, bad_path = _path_validator()
+    with pytest.raises(bad_path):
+        safe(path)
+
+
+@pytest.mark.parametrize("path,expected", [
+    ("kg/entities/person/olga.md", "kg/entities/person/olga.md"),
+    ("README.md", "README.md"),
+    ("_pending/claims.json", "_pending/claims.json"),
+    ("./notes/today.md", "notes/today.md"),
+    ("kg/entities/person/José Álvarez.md", "kg/entities/person/José Álvarez.md"),
+    ("..notes.md", "..notes.md"),          # a NAME beginning with dots is not an escape
+    ("a/.gitignore", "a/.gitignore"),      # `.git` is refused as a ROOT segment, not as a prefix
+])
+def test_the_paths_a_workspace_actually_holds_are_accepted(path, expected):
+    safe, _ = _path_validator()
+    assert safe(path) == expected

--- a/core/flows/src/flows_steps/agent.py
+++ b/core/flows/src/flows_steps/agent.py
@@ -42,7 +42,7 @@ def dispatch_turn(uid: str, session: str, prompt: str, room: dict | None = None)
 
     THE INTERNAL-TIER HEADER IS PART OF THE ROOM, NOT AN EXTRA. agent-api refuses a room to any
     caller that cannot present ``X-Internal-Secret``, so it goes on the same post. Its value comes
-    from the environment (``VEXA_INTERNAL_SECRET``, a mode-600 file the lane's start script
+    from the environment (``INTERNAL_API_SECRET``, a mode-600 file the lane's start script
     exports) and never from this repository; both entrypoints refuse to start without it, so by
     the time a turn is dispatched it exists.
 

--- a/core/flows/src/flows_steps/common.py
+++ b/core/flows/src/flows_steps/common.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import urllib.request
 from typing import Optional
 
@@ -14,6 +15,20 @@ AGENT_API = os.environ.get("VEXA_FLOWS_AGENT_API_URL", "http://localhost:18100")
 ADMIN_API = os.environ.get("VEXA_FLOWS_ADMIN_API_URL", "http://localhost:18057")
 ADMIN_KEY = os.environ.get("VEXA_FLOWS_ADMIN_KEY", "changeme")
 FIXTURE_TRANSCRIPT = os.environ.get("VEXA_FLOWS_FIXTURE_TRANSCRIPT", "") == "1"   # declared double
+
+
+#: The ONE name for the internal-tier secret — the compose/helm secret key, the name admin-api,
+#: gateway, meeting-api and agent-api read. Flows had a THIRD spelling of its own, which is exactly
+#: how the published literal `vexa-internal-secret` came to sit on this file's refusal list and on
+#: nobody else's (F95): one secret with three names has three refusal lists and they drift.
+INTERNAL_SECRET_ENV = "INTERNAL_API_SECRET"
+#: Read when the canonical name is absent, with a deprecation warning. Removed next release.
+INTERNAL_SECRET_ENV_DEPRECATED = ("VEXA_INTERNAL_SECRET", "VEXA_INTERNAL_API_SECRET")
+#: Placeholder literals a stock deploy surface once supplied. Every one of these is PUBLISHED in the
+#: OSS repository, so a deployment holding one is not configured — it is open, wearing a configured
+#: face. Same list as the services' config.v1 `forbidden_values`.
+INTERNAL_SECRET_PLACEHOLDERS = ("vexa-internal-secret", "lite-internal-secret", "changeme",
+                                "change-me", "CHANGE-ME", "default", "secret")
 
 
 def require_internal_secret() -> str:
@@ -27,18 +42,33 @@ def require_internal_secret() -> str:
     Deliberately the SAME REFUSAL as `flows_api._require_api_key`, down to the wording: a weak
     default makes an unconfigured deployment look configured and fails no test, so there is no
     default and no fallback. The value lives in a mode-600 file under `~/.storm/`, exported by the
-    lane's start script as `VEXA_INTERNAL_SECRET`; it never appears in this repository, in a log,
-    or in an error message — including the ones below, which name the VARIABLE and never the value.
+    lane's start script; it never appears in this repository, in a log, or in an error message —
+    including the ones below, which name the VARIABLE and never the value.
+
+    TWO things changed with F95. The variable is now `INTERNAL_API_SECRET`, the one name every other
+    service uses (the old spellings still work for one release and say so); and the placeholder list
+    carries the literals the deploy surfaces actually shipped, not four generic ones — the refusal
+    that missed `vexa-internal-secret` was a refusal list written from imagination rather than from
+    the compose file it was defending against.
     """
-    key = (os.environ.get("VEXA_INTERNAL_SECRET") or "").strip()
+    key = (os.environ.get(INTERNAL_SECRET_ENV) or "").strip()
+    if not key:
+        for legacy in INTERNAL_SECRET_ENV_DEPRECATED:
+            key = (os.environ.get(legacy) or "").strip()
+            if key:
+                print(f"WARNING: {legacy} is DEPRECATED — rename it to {INTERNAL_SECRET_ENV}, the "
+                      f"one name the whole internal tier uses. Honoured this release, removed next.",
+                      file=sys.stderr)
+                break
     if not key:
         raise RuntimeError(
-            "VEXA_INTERNAL_SECRET is unset — flows refuses to start rather than run with no "
+            f"{INTERNAL_SECRET_ENV} is unset — flows refuses to start rather than run with no "
             "internal-tier identity. Mint one into a mode-600 file (the ~/.storm/dburl pattern) "
             "and export it from the lane's start script; never put the value in the repo.")
-    if key in ("changeme", "change-me", "default", "secret"):
+    if key in INTERNAL_SECRET_PLACEHOLDERS:
         raise RuntimeError(
-            f"VEXA_INTERNAL_SECRET is the placeholder {key!r} — refusing to start.")
+            f"{INTERNAL_SECRET_ENV} is the placeholder {key!r} — refusing to start. That literal is "
+            "published in this repository, so it authenticates nobody and everybody.")
     return key
 
 # Where a person's own terminal lives. Same env name the control MCP already reads, and the same

--- a/core/flows/tests/test_internal_secret.py
+++ b/core/flows/tests/test_internal_secret.py
@@ -1,0 +1,70 @@
+"""F95 — the internal-tier secret: ONE name, no default, and the placeholders that shipped.
+
+Flows spelled this secret `VEXA_INTERNAL_SECRET` — a third name for a value compose, helm,
+admin-api, gateway and agent-api all called `INTERNAL_API_SECRET`. Three names meant three refusal
+lists, and this file's list refused four generic placeholders (`changeme`, `change-me`, `default`,
+`secret`) while the literal the deploy surfaces ACTUALLY shipped — `vexa-internal-secret`, published
+in the OSS repository and the exact value the internal tier compared against — was on none of them.
+
+A refusal list written from imagination rather than from the compose file it defends against is the
+whole finding, so these tests pin the list to the literals that were really there.
+Offline, stdlib only.
+"""
+from __future__ import annotations
+
+import pytest
+
+from flows_steps import common
+
+
+def _clear(monkeypatch):
+    for name in (common.INTERNAL_SECRET_ENV, *common.INTERNAL_SECRET_ENV_DEPRECATED):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_the_canonical_name_is_the_compose_secret_key():
+    assert common.INTERNAL_SECRET_ENV == "INTERNAL_API_SECRET"
+
+
+def test_it_reads_the_canonical_name(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("INTERNAL_API_SECRET", "a-real-secret")
+    assert common.require_internal_secret() == "a-real-secret"
+
+
+def test_the_old_spellings_still_work_and_say_so(monkeypatch, capsys):
+    """An operator mid-upgrade is WARNED, not 401ed — a rename that silently drops the value would
+    leave flows reading zero desks with nothing looking broken, which is the failure this whole
+    module's refusal exists to prevent."""
+    for legacy in common.INTERNAL_SECRET_ENV_DEPRECATED:
+        _clear(monkeypatch)
+        monkeypatch.setenv(legacy, "a-real-secret")
+        assert common.require_internal_secret() == "a-real-secret"
+        err = capsys.readouterr().err
+        assert legacy in err and "DEPRECATED" in err
+        assert "a-real-secret" not in err, "a warning must never echo the value"
+
+
+def test_the_canonical_name_wins_over_a_stale_legacy_export(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("INTERNAL_API_SECRET", "canonical")
+    monkeypatch.setenv("VEXA_INTERNAL_SECRET", "stale")
+    assert common.require_internal_secret() == "canonical"
+
+
+def test_unset_refuses(monkeypatch):
+    _clear(monkeypatch)
+    with pytest.raises(RuntimeError) as ei:
+        common.require_internal_secret()
+    assert "INTERNAL_API_SECRET" in str(ei.value)
+
+
+def test_the_literals_the_deploy_surfaces_shipped_are_refused(monkeypatch):
+    """The regression, named: every one of these was a real default in a real deploy surface —
+    docker-compose.yml, the helm chart Secret, lite's entrypoint, the dogfood env example."""
+    for placeholder in ("vexa-internal-secret", "lite-internal-secret", "changeme", "CHANGE-ME"):
+        _clear(monkeypatch)
+        monkeypatch.setenv("INTERNAL_API_SECRET", placeholder)
+        with pytest.raises(RuntimeError) as ei:
+            common.require_internal_secret()
+        assert "refusing to start" in str(ei.value)

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -283,6 +283,28 @@ def _required_scopes(request: Request) -> Optional[FrozenSet[str]]:
     return ROUTE_SCOPES.get((request.method.upper(), path))
 
 
+# ── the authority-header strip (F95) ─────────────────────────────────────────────
+# Downstream services trust a small vocabulary of headers as AUTHORITY: ``x-user-*`` is the identity
+# the gateway resolved from the api-key, ``x-internal-secret`` is the internal service tier (agent-api
+# ``_internal_caller``, admin-api ``_check_internal`` — the gate the meeting room calls its own trust
+# boundary), ``x-gateway-verified`` is the marker ``VEXA_REQUIRE_GATEWAY_IDENTITY`` looks for, and
+# ``x-admin-api-key`` is admin-api's privileged surface.
+#
+# NONE of them may arrive from a client. The strip used to be an eight-name list of ``x-user-*``
+# spellings, so ``x-internal-secret`` from the public edge reached agent-api and was believed — and
+# with the shipped compose default (a literal in a public repo) that was the internal tier, open to
+# any api-key holder. A LIST rots the moment a new authority header is added; a PREFIX rule does not,
+# which is why this matches by family and why every new internal header must be spelled into one.
+_AUTHORITY_HEADER_PREFIXES = ("x-user-", "x-internal-", "x-vexa-internal-")
+_AUTHORITY_HEADER_EXACT = frozenset({"x-admin-api-key", "x-gateway-verified"})
+
+
+def _is_authority_header(name: str) -> bool:
+    """True for any header a downstream service reads as AUTHORITY — never forwarded from a client."""
+    name = name.lower()
+    return name in _AUTHORITY_HEADER_EXACT or name.startswith(_AUTHORITY_HEADER_PREFIXES)
+
+
 def _insufficient_scope_response() -> Response:
     return Response(
         content=json.dumps({"detail": "Insufficient scope for this endpoint"}),
@@ -430,12 +452,12 @@ def create_app(
         )
 
         # Inject identity headers + forward the SAME trace_id downstream (main.py:322-326, 365).
-        # Strip any client-supplied identity headers first (anti-spoofing, main.py:294-296).
+        # Strip any client-supplied identity/authority headers first (anti-spoofing, main.py:294-296).
         excluded = {"host", "content-length", "transfer-encoding"}
         headers = {k.lower(): v for k, v in request.headers.items() if k.lower() not in excluded}
-        for h in ("x-user-id", "x-user-email", "x-user-scopes", "x-user-limits", "x-user-workspaces",
-                  "x-user-webhook-url", "x-user-webhook-secret", "x-user-webhook-events"):
-            headers.pop(h, None)
+        for h in list(headers):
+            if _is_authority_header(h):
+                headers.pop(h, None)
         headers["x-api-key"] = client_key
         headers["x-user-id"] = str(user_id)
         # The RESOLVED verified email (never client-declared; /internal/validate returns it). agent-api's

--- a/core/gateway/services/gateway/src/gateway/config.v1.json
+++ b/core/gateway/services/gateway/src/gateway/config.v1.json
@@ -6,7 +6,16 @@
    "key": "INTERNAL_API_SECRET",
    "class": "required-explicit",
    "secret": true,
-   "description": "shared internal secret attached as X-Internal-Secret on the admin-api /internal/validate hop (adapters.py:67-69). Unset, admin-api rejects validation and EVERY API-key check 503s (fail-closed) — so the boot refuses instead of coming up green and 503ing every call (the 2026-04-23 failure shape, #526)."
+   "description": "shared internal secret attached as X-Internal-Secret on the admin-api /internal/validate hop (adapters.py:67-69). Unset, admin-api rejects validation and EVERY API-key check 503s (fail-closed) — so the boot refuses instead of coming up green and 503ing every call (the 2026-04-23 failure shape, #526). It is ALSO the internal-tier authority agent-api's _internal_caller and admin-api's _check_internal compare against, which is why a published placeholder is refused outright (F95).",
+   "forbidden_values": [
+     "vexa-internal-secret",
+     "lite-internal-secret",
+     "changeme",
+     "change-me",
+     "CHANGE-ME",
+     "default",
+     "secret"
+   ]
   },
   {
    "key": "ADMIN_API_URL",

--- a/core/gateway/services/gateway/src/gateway/config_preflight.py
+++ b/core/gateway/services/gateway/src/gateway/config_preflight.py
@@ -27,6 +27,11 @@ when the cached result is older than the probe's ``ttl_s``. This is what turns t
 token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
 meeting/agent runs.
 
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
 Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
 environment and long-lived processes both observe the truth.
 """
@@ -362,6 +367,20 @@ def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
             f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
             f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
             "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
         )
     rows = capability_health(env, force_probe=True)
     for name, row in sorted(rows.items()):

--- a/core/gateway/services/gateway/tests/test_config_contract.py
+++ b/core/gateway/services/gateway/tests/test_config_contract.py
@@ -27,3 +27,19 @@ def test_preflight_refuses_boot_without_internal_api_secret():
 
 def test_preflight_passes_when_required_set():
     cp.preflight({"INTERNAL_API_SECRET": "a-real-secret"})
+
+
+def test_preflight_refuses_the_published_placeholder():
+    """F95 — the failure a required-explicit key does NOT catch.
+
+    `INTERNAL_API_SECRET` was never unset on a stock deploy: compose supplied
+    `${INTERNAL_API_SECRET:-vexa-internal-secret}`, a literal in a public repository and the exact
+    value the internal tier compared against. The boot was green, the preflight was satisfied, and
+    the internal tier was open to anyone who had read the source. A set placeholder is not a
+    configured deployment, so it refuses the same way an unset one does — and the message names the
+    KEY, never the value."""
+    for placeholder in ("vexa-internal-secret", "lite-internal-secret", "changeme"):
+        with pytest.raises(cp.ConfigError) as ei:
+            cp.preflight({**{}, "INTERNAL_API_SECRET": placeholder})
+        assert "INTERNAL_API_SECRET" in str(ei.value)
+        assert placeholder not in str(ei.value), "a refusal must never echo the value"

--- a/core/gateway/services/gateway/tests/test_proxy.py
+++ b/core/gateway/services/gateway/tests/test_proxy.py
@@ -186,6 +186,47 @@ def test_identity_headers_injected_and_spoof_stripped():
     assert fwd["x-api-key"] == VALID_KEY
 
 
+def test_internal_tier_header_is_stripped_from_a_public_request():
+    """F95 — the internal tier is not reachable from the public edge.
+
+    `/agent/{path}` maps to agent-api `/api/{path}`, and agent-api's `_internal_caller` (with
+    admin-api's `_check_internal`, and the meeting room's gate 0, which the code itself calls the
+    trust boundary on who is in the room) is gated SOLELY on `x-internal-secret`. The strip used to
+    be an eight-name list of `x-user-*` spellings, so a request carrying `x-internal-secret` — the
+    compose default was a literal in a public repository, and the exact value the comparison used —
+    arrived at agent-api and was believed.
+
+    The header must not reach the downstream at all, whatever value it carries."""
+    client, downstream = _client()
+    r = client.get("/bots/status", headers={
+        **AUTH,
+        "x-internal-secret": "vexa-internal-secret",   # the value that shipped in docker-compose.yml
+        "x-vexa-internal-api-secret": "vexa-internal-secret",
+        "x-admin-api-key": "changeme",
+        "x-gateway-verified": "1",                     # VEXA_REQUIRE_GATEWAY_IDENTITY's own marker
+    })
+    assert r.status_code == 200
+    fwd = downstream.last["headers"]
+    for spoofed in ("x-internal-secret", "x-vexa-internal-api-secret",
+                    "x-admin-api-key", "x-gateway-verified"):
+        assert spoofed not in fwd, f"{spoofed} reached the downstream from a public request"
+    # The strip is by FAMILY, not by a list that rots: a header nobody has invented yet, spelled
+    # inside one of the internal families, is stripped for free.
+    assert "x-user-id" in fwd and fwd["x-user-id"] == "7"
+
+
+def test_authority_header_families_are_recognised_by_prefix():
+    """The oracle behind the strip, stated directly — a list of eight names is what failed."""
+    from gateway.app import _is_authority_header
+
+    for name in ("x-internal-secret", "X-Internal-Secret", "x-internal-anything-new",
+                 "x-vexa-internal-api-secret", "x-user-id", "x-user-invented-tomorrow",
+                 "x-admin-api-key", "x-gateway-verified"):
+        assert _is_authority_header(name), name
+    for name in ("x-api-key", "content-type", "x-trace-id", "authorization", "mcp-session-id"):
+        assert not _is_authority_header(name), name
+
+
 def test_meeting_intent_put_forwards_to_meeting_api():
     """The Meetings surface's Schedule/Cancel action PUTs the user-owned intent; the gateway must
     forward it verbatim to meeting-api's PUT /meetings/{platform}/{native}/intent. Regression: this

--- a/core/identity/services/admin-api/src/admin_api/config.v1.json
+++ b/core/identity/services/admin-api/src/admin_api/config.v1.json
@@ -6,7 +6,16 @@
    "key": "INTERNAL_API_SECRET",
    "class": "required-explicit",
    "secret": true,
-   "description": "shared internal secret the /internal/validate endpoint requires (fail-closed guard, main.py). Unset, gateway's validation hop 503s and every API-key check fails — so the boot refuses instead of coming up green and rejecting every call (the 2026-04-23 failure shape, #526)."
+   "description": "shared internal secret the /internal/validate endpoint requires (fail-closed guard, main.py). Unset, gateway's validation hop 503s and every API-key check fails — so the boot refuses instead of coming up green and rejecting every call (the 2026-04-23 failure shape, #526). The same value gates /internal/bootstrap-admin and /internal/users/by-email, so a published placeholder is refused outright (F95).",
+   "forbidden_values": [
+     "vexa-internal-secret",
+     "lite-internal-secret",
+     "changeme",
+     "change-me",
+     "CHANGE-ME",
+     "default",
+     "secret"
+   ]
   },
   {
    "key": "ADMIN_API_TOKEN",

--- a/core/identity/services/admin-api/src/admin_api/config_preflight.py
+++ b/core/identity/services/admin-api/src/admin_api/config_preflight.py
@@ -27,6 +27,11 @@ when the cached result is older than the probe's ``ttl_s``. This is what turns t
 token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
 meeting/agent runs.
 
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
 Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
 environment and long-lived processes both observe the truth.
 """
@@ -362,6 +367,20 @@ def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
             f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
             f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
             "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
         )
     rows = capability_health(env, force_probe=True)
     for name, row in sorted(rows.items()):

--- a/core/identity/services/admin-api/tests/test_config_contract.py
+++ b/core/identity/services/admin-api/tests/test_config_contract.py
@@ -40,3 +40,19 @@ def test_db_pool_keys_declared_defaulted():
         assert key in by_key, f"{key} must be declared (it is read in __main__)"
         assert by_key[key]["class"] == "defaulted"
         assert by_key[key]["default"] == default
+
+
+def test_preflight_refuses_the_published_placeholder():
+    """F95 — the failure a required-explicit key does NOT catch.
+
+    `INTERNAL_API_SECRET` was never unset on a stock deploy: compose supplied
+    `${INTERNAL_API_SECRET:-vexa-internal-secret}`, a literal in a public repository and the exact
+    value the internal tier compared against. The boot was green, the preflight was satisfied, and
+    the internal tier was open to anyone who had read the source. A set placeholder is not a
+    configured deployment, so it refuses the same way an unset one does — and the message names the
+    KEY, never the value."""
+    for placeholder in ("vexa-internal-secret", "lite-internal-secret", "changeme"):
+        with pytest.raises(cp.ConfigError) as ei:
+            cp.preflight({**{}, "INTERNAL_API_SECRET": placeholder})
+        assert "INTERNAL_API_SECRET" in str(ei.value)
+        assert placeholder not in str(ei.value), "a refusal must never echo the value"

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -87,7 +87,16 @@
    "class": "defaulted",
    "default": "(unset — the internal lifecycle-callback header is then not attached)",
    "secret": true,
-   "description": "shared secret for internal service-to-service calls (x-internal-secret on the self-driven lifecycle callback)"
+   "description": "shared secret for internal service-to-service calls (x-internal-secret on the self-driven lifecycle callback). Unset is a documented degrade; a PUBLISHED PLACEHOLDER is not — it is the whole internal tier handed to anyone who read the repository (F95), so the boot refuses it.",
+   "forbidden_values": [
+     "vexa-internal-secret",
+     "lite-internal-secret",
+     "changeme",
+     "change-me",
+     "CHANGE-ME",
+     "default",
+     "secret"
+   ]
   },
   {
    "key": "DEFAULT_BOT_NAME",

--- a/core/meetings/services/meeting-api/src/meeting_api/config_preflight.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/config_preflight.py
@@ -27,6 +27,11 @@ when the cached result is older than the probe's ``ttl_s``. This is what turns t
 token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
 meeting/agent runs.
 
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
 Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
 environment and long-lived processes both observe the truth.
 """
@@ -362,6 +367,20 @@ def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
             f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
             f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
             "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
         )
     rows = capability_health(env, force_probe=True)
     for name, row in sorted(rows.items()):

--- a/core/runtime/src/runtime_kernel/config_preflight.py
+++ b/core/runtime/src/runtime_kernel/config_preflight.py
@@ -27,6 +27,11 @@ when the cached result is older than the probe's ``ttl_s``. This is what turns t
 token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
 meeting/agent runs.
 
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
 Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
 environment and long-lived processes both observe the truth.
 """
@@ -362,6 +367,20 @@ def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
             f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
             f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
             "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
         )
     rows = capability_health(env, force_probe=True)
     for name, row in sorted(rows.items()):

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -51,7 +51,11 @@ MINIO_SECURE=false
 # --- stack secrets (CHANGE for any non-local deploy) -------------------------
 # admin-api auth; `make all` mints your API key with this
 ADMIN_TOKEN=dev-admin-token
-INTERNAL_API_SECRET=vexa-internal-secret
+# The INTERNAL TIER: services present it as X-Internal-Secret and agent-api/admin-api believe
+# it as authority (the meeting room's gate 0). It shipped here as a literal, which meant every
+# unconfigured deploy shared one published secret — mint your own, there is no default and the
+# services refuse to boot without it:  openssl rand -hex 32
+INTERNAL_API_SECRET=
 # The bot's display name in the meeting — the terminal omits bot_name on join, so this names every
 # bot it sends. Empty → Vexa. Restart meeting-api after changing; the terminal needs no rebuild.
 DEFAULT_BOT_NAME=

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       - DB_USER=${DB_USER:-postgres}
       - DB_PASSWORD=${DB_PASSWORD:-postgres}
       - ADMIN_API_TOKEN=${ADMIN_TOKEN:-changeme}
-      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       - LOG_LEVEL=${LOG_LEVEL:-info}
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8001/health').status==200 else 1)"]
@@ -176,7 +176,7 @@ services:
       - ANTHROPIC_DEFAULT_OPUS_MODEL=${ANTHROPIC_DEFAULT_OPUS_MODEL:-}
       - ANTHROPIC_DEFAULT_SONNET_MODEL=${ANTHROPIC_DEFAULT_SONNET_MODEL:-}
       - ANTHROPIC_DEFAULT_HAIKU_MODEL=${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}
-      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # Spawn the bot onto THIS compose network so it resolves meeting-api:8080 (lifecycle callback)
       # + redis. Must equal the project-prefixed network name (DockerBackend → HostConfig.NetworkMode).
@@ -262,7 +262,7 @@ services:
       # Lane M: the users.data.memberships[] index mirror over the admin-api internal edge
       # (policy/members.json in the workspace git repo stays authoritative; this is the listing cache).
       - VEXA_ADMIN_API_URL=http://admin-api:8001
-      - VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       # The post-meeting room resolves a participant's email to a subject through admin-api. There
       # is no narrow door yet — the internal-secret tier exposes no by-email lookup, and
       # GET /admin/users/email/{email} sits behind this much broader credential, which can also
@@ -371,7 +371,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-postgres}
       - REDIS_URL=redis://redis:6379/0
       - RUNTIME_API_URL=http://runtime:8090
-      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       # The bot's display name in the meeting. The terminal omits bot_name on join, so this is what
       # participants see; set DEFAULT_BOT_NAME in .env and restart meeting-api (no terminal rebuild).
       - DEFAULT_BOT_NAME=${DEFAULT_BOT_NAME:-Vexa}
@@ -455,7 +455,7 @@ services:
       # dependency cycle. The forward simply 502s until mcp is up, like any other upstream.
       - MCP_URL=http://mcp:8010
       - REDIS_URL=redis://redis:6379/0
-      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # fastapi-guard edge layer (edge_guard.py): per-IP throttle + auto-ban at the edge.
       # ON by default with generous limits (owner ruling — protection that ships dark protects
@@ -588,7 +588,7 @@ services:
       # for everyone. Identity is VERIFIED against admin-api /internal/validate over the internal-tier
       # secret (never trusted from a cookie), and the same secret fronts agent-api's admin overview.
       - VEXA_ADMIN_EMAILS=${VEXA_ADMIN_EMAILS:-}
-      - VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      - VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       # Declared self-hosted Jitsi hostnames — served to the client link parser
       # (/api/meeting/jitsi-hosts) so pasted links on these hosts are recognized in the UI,
       # matching meeting-api's and mcp's parsers (same setting).

--- a/deploy/contracts/config.v1/README.md
+++ b/deploy/contracts/config.v1/README.md
@@ -31,6 +31,16 @@ exposed by any surface, still declared so the undeclared-read scan stays tight),
 `surface_only` list (keys a surface sets that the service does NOT read — documented drift with a
 `reason`, so the check never silently ignores anything).
 
+Extra fields, continued: **`forbidden_values`** — the published placeholder literals a deploy
+surface once supplied for this key. A boot whose env holds one raises `ConfigError` the same way a
+missing required key does. It exists because `required-explicit` cannot catch the commoner failure:
+`INTERNAL_API_SECRET` was never *unset* on a stock deploy, compose supplied
+`${INTERNAL_API_SECRET:-vexa-internal-secret}` — a literal in a public repository, and the exact
+value the internal tier compared against — so every unconfigured deployment booted green sharing one
+published secret. **A key that looks configured and is not is worse than one that is missing**, and
+only the declaration knows which literals were ever shipped. The refusal names the KEY, never the
+value.
+
 ```json
 {
   "contract": "config.v1",

--- a/deploy/contracts/config.v1/config.schema.json
+++ b/deploy/contracts/config.v1/config.schema.json
@@ -64,6 +64,13 @@
           "items": { "$ref": "#/$defs/Target" },
           "uniqueItems": true,
           "description": "Which deploy surfaces plumb this key (default: all three). An EMPTY array = an in-code dial deliberately not exposed by any deploy surface (still declared, so the undeclared-read scan stays tight)."
+        },
+        "forbidden_values": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true,
+          "minItems": 1,
+          "description": "Values this key must NEVER hold in a running deploy — the published placeholder literals a stock compose/helm/lite once supplied. The boot preflight raises ConfigError on a match, so a deployment nobody configured refuses to start instead of coming up green holding a secret every reader of this repository knows (F95: INTERNAL_API_SECRET shipped as `vexa-internal-secret`, the exact value the internal tier compared against). Compared on the stripped value; the refusal names the KEY, never the value."
         }
       },
       "allOf": [

--- a/deploy/contracts/config.v1/preflight.py
+++ b/deploy/contracts/config.v1/preflight.py
@@ -27,6 +27,11 @@ when the cached result is older than the probe's ``ttl_s``. This is what turns t
 token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
 meeting/agent runs.
 
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
 Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
 environment and long-lived processes both observe the truth.
 """
@@ -362,6 +367,20 @@ def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
             f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
             f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
             "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
         )
     rows = capability_health(env, force_probe=True)
     for name, row in sorted(rows.items()):

--- a/deploy/dogfood/rehearse/doors.py
+++ b/deploy/dogfood/rehearse/doors.py
@@ -763,12 +763,16 @@ def _flows_key() -> str:
 
 
 def _internal_secret() -> str:
-    key = (os.environ.get("VEXA_INTERNAL_SECRET")
+    # ONE name (F95): INTERNAL_API_SECRET, the compose/helm secret key. The two prefixed spellings
+    # are read after it so a shell mid-upgrade still works; this file papering over the drift in one
+    # place is what let it survive everywhere else.
+    key = (os.environ.get("INTERNAL_API_SECRET")
+           or os.environ.get("VEXA_INTERNAL_SECRET")
            or os.environ.get("VEXA_INTERNAL_API_SECRET") or "").strip()
     if key:
         return key
     f = pathlib.Path.home() / ".storm/internal-secret"
     if f.is_file():
         return f.read_text().strip()
-    raise DoorRefused("no internal secret: set VEXA_INTERNAL_SECRET or place "
+    raise DoorRefused("no internal secret: set INTERNAL_API_SECRET or place "
                       "~/.storm/internal-secret (mode 600)")

--- a/deploy/dogfood/rig/flows-up.sh
+++ b/deploy/dogfood/rig/flows-up.sh
@@ -39,13 +39,17 @@ export VEXA_FLOWS_ADMIN_KEY="$(docker inspect vexa-dogfood-admin-api-1 \
 # Its own mode-600 file, like the operator key above and for the same reason: the value belongs to
 # the deployment, never to the repo, never to a log, never to an error message. The NAME is
 # documented here; the VALUE lives only in $HOME/.storm/internal-secret.
-# It must equal the agent-api container's VEXA_INTERNAL_API_SECRET — if agent-api is ever recreated
+# It must equal the agent-api container's INTERNAL_API_SECRET — if agent-api is ever recreated
 # with a different one, the room silently stops opening, so re-copy it then.
-export VEXA_INTERNAL_SECRET="$(cat "$HOME/.storm/internal-secret" 2>/dev/null)"
-if [ -z "${VEXA_INTERNAL_SECRET:-}" ]; then
+#
+# The name is INTERNAL_API_SECRET, everywhere (F95). This lane used to export VEXA_INTERNAL_SECRET,
+# a third spelling of one secret, and three spellings meant three refusal lists: the published
+# literal `vexa-internal-secret` was on this one's and on nobody else's.
+export INTERNAL_API_SECRET="$(cat "$HOME/.storm/internal-secret" 2>/dev/null)"
+if [ -z "${INTERNAL_API_SECRET:-}" ]; then
   echo "flows-up: REFUSING to start — no internal-tier secret at $HOME/.storm/internal-secret." >&2
   echo "  Without it agent-api refuses every meeting room and the post-meeting run reads no desks," >&2
-  echo "  silently. Copy agent-api's VEXA_INTERNAL_API_SECRET into that file (chmod 600)." >&2
+  echo "  silently. Copy agent-api's INTERNAL_API_SECRET into that file (chmod 600)." >&2
   exit 1
 fi
 

--- a/deploy/dogfood/rig/rig.sh
+++ b/deploy/dogfood/rig/rig.sh
@@ -23,6 +23,10 @@ set -u
 #                        arrival while looking perfectly well-formed.
 #   VEXA_MCP_DELEGATION_SECRET  the HMAC key agent-api mints delegated tokens with. Read from
 #                        $HOME/.storm/delegation-secret at start; never echoed, never defaulted.
+#   INTERNAL_API_SECRET  the INTERNAL TIER. Read from $HOME/.storm/internal-secret at start; must
+#                        equal agent-api's own. The control server and flows-api both REFUSE TO
+#                        START without it (F95) — deliberately, because without it the rig cannot
+#                        authenticate as a service and nothing about that failure is visible.
 # ONE LINE (2026-09-02): the flows checkout is the LINE worktree. This default is not
 # cosmetic — start_worker passes VEXA_FLOWS_SRC="$FL" into flows-up.sh, which OVERRIDES
 # flows-up.sh's own default, so a later `rig.sh restart` with the old value here would
@@ -71,12 +75,14 @@ start_ctl() {
   tmux new-session -d -s stormctl -c /tmp \
     "VEXA_FLOWS_SRC=\"$FL\" VEXA_PUBLIC_MCP_URL=\"$PUBLIC_MCP_URL\" VEXA_UI_URL=\"$UI_URL\" \
      VEXA_MCP_DELEGATION_SECRET=\"\$(cat \"\$HOME/.storm/delegation-secret\" 2>/dev/null)\" \
+     INTERNAL_API_SECRET=\"\$(cat \"\$HOME/.storm/internal-secret\" 2>/dev/null)\" \
      $V/python -u \"$CTL\" 2>&1 | tee $LOG/control-mcp.log"
 }
 start_api() {
   tmux kill-session -t stormapi 2>/dev/null
   tmux new-session -d -s stormapi -c "$FL" \
     "PYTHONPATH=$FL/src VEXA_FLOWS_DB_URL=$(cat "$HOME/.storm/dburl") \
+     INTERNAL_API_SECRET=\"\$(cat \"\$HOME/.storm/internal-secret\" 2>/dev/null)\" \
      $V/python -m uvicorn flows_integrations.flows_api:app --host 127.0.0.1 --port 18200 \
      2>&1 | tee $LOG/flows-api.log"
 }

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -16,6 +16,7 @@ import hmac
 import json
 import os
 import pathlib
+import posixpath
 import re
 import subprocess
 import time
@@ -129,6 +130,104 @@ def _http(method: str, url: str, headers: dict | None = None, body=None, timeout
             return e.code, raw
     except Exception as e:  # noqa: BLE001
         return 0, f"{type(e).__name__}: {e}"
+
+
+# ── the internal tier: ONE name, and no start without it (F95) ───────────────────────────────────
+#: The compose/helm secret key, and the name admin-api, gateway, meeting-api and agent-api read.
+INTERNAL_SECRET_ENV = "INTERNAL_API_SECRET"
+#: Honoured for one release, with a warning. This file quietly accepting two spellings is part of
+#: how the drift survived: a reader that papers over two names for one secret removes the pressure
+#: to pick one, and each name then grows its own refusal list.
+INTERNAL_SECRET_ENV_DEPRECATED = ("VEXA_INTERNAL_API_SECRET", "VEXA_INTERNAL_SECRET")
+#: Every literal a stock compose/helm/lite once supplied. All of them are PUBLISHED in the OSS
+#: repository, so a deployment holding one is not configured — it is open, wearing a configured face.
+INTERNAL_SECRET_PLACEHOLDERS = ("vexa-internal-secret", "lite-internal-secret", "changeme",
+                                "change-me", "CHANGE-ME", "default", "secret")
+
+
+def _require_internal_secret() -> str:
+    """The internal-tier secret, or this server does not start.
+
+    This process is PUBLIC. It presents the internal tier (`_operator_or_refuse` accepts this value
+    as a service identity) and it forwards to agent-api, whose `_internal_caller` believes the same
+    value — so an unset or placeholder secret here is not a degraded rig, it is a rig that either
+    cannot authenticate at all or authenticates on a string printed in a public repository.
+
+    Refusing at IMPORT is the point: what a weak default produces is silence, and a start-time
+    refusal is how silence becomes a message. The value never enters a log or an error — the
+    messages below name the VARIABLE, never the value."""
+    key = (os.environ.get(INTERNAL_SECRET_ENV) or "").strip()
+    if not key:
+        for legacy in INTERNAL_SECRET_ENV_DEPRECATED:
+            key = (os.environ.get(legacy) or "").strip()
+            if key:
+                print(f"WARNING: {legacy} is DEPRECATED — rename it to {INTERNAL_SECRET_ENV}, the "
+                      f"one name the whole internal tier uses. Honoured this release, removed next.",
+                      flush=True)
+                break
+    if not key:
+        f = pathlib.Path.home() / ".storm/internal-secret"
+        try:
+            if f.is_file():
+                key = f.read_text().strip()
+        except Exception:  # noqa: BLE001
+            key = ""
+    if not key:
+        raise RuntimeError(
+            f"{INTERNAL_SECRET_ENV} is unset — the vexa-control MCP refuses to start rather than "
+            "run with no internal-tier identity. Export it with the SAME value agent-api holds "
+            "(the lane's start script reads $HOME/.storm/internal-secret, mode 600); never put the "
+            "value in the repo.")
+    if key in INTERNAL_SECRET_PLACEHOLDERS:
+        raise RuntimeError(
+            f"{INTERNAL_SECRET_ENV} is the placeholder {key!r} — refusing to start. That literal is "
+            "published in this repository, so it authenticates nobody and everybody.")
+    return key
+
+
+INTERNAL_SECRET = _require_internal_secret()
+
+
+class _BadPath(Exception):
+    """A workspace path this server will not pass on. Carries the reason, in the agent's language."""
+
+
+#: Characters with no business in a workspace path and every business in a shell command. The write
+#: path no longer builds a shell command at all — but a validator that only defends against today's
+#: implementation defends against nothing tomorrow, and the refusal reads the same either way.
+_PATH_FORBIDDEN = frozenset(
+    "\x00\n\r\t"                    # control characters
+    ";|&$`<>*?"                     # shell metacharacters
+    + chr(34) + chr(39) + chr(92)   # " ' \ — spelled by codepoint so the set stays readable
+)
+
+
+def _safe_ws_path(path: str) -> str:
+    """A workspace-relative path, or refuse. RELATIVE, inside the workspace, never `.git/`.
+
+    `..` is checked SEGMENT-wise, not by substring: a file legitimately named `..notes.md` is not an
+    escape, and `a/../../etc` is one though it carries no leading dot-dot. `posixpath.normpath` then
+    has the final word — the segment scan is the readable check, normpath is the real one."""
+    raw = (path or "").strip()
+    if not raw:
+        raise _BadPath("empty path")
+    if raw.startswith("/"):
+        raise _BadPath("an absolute path names the container's filesystem, not a workspace — pass "
+                       "a path relative to the workspace root")
+    bad = sorted(set(raw) & _PATH_FORBIDDEN)
+    if bad:
+        raise _BadPath(f"the path contains {bad!r}, which no workspace file needs")
+    if ".." in raw.split("/"):
+        raise _BadPath("`..` climbs out of the workspace")
+    normalized = posixpath.normpath(raw)
+    if normalized.startswith("/") or normalized == ".." or normalized.startswith("../"):
+        raise _BadPath("that path resolves outside the workspace")
+    if normalized == ".":
+        raise _BadPath("that path names the workspace itself, not a file in it")
+    if normalized.split("/")[0] == ".git":
+        raise _BadPath("`.git/` is the workspace's own history — writing into it corrupts the "
+                       "record every other tool reads")
+    return normalized
 
 
 def _fkey():
@@ -790,8 +889,9 @@ def _operator_or_refuse(verb: str) -> str:
     right door for a producer that is not a person.
     """
     tok = (CALL_TOKEN.get() or "").strip()
-    svc = os.environ.get("VEXA_INTERNAL_API_SECRET", "") or os.environ.get("INTERNAL_API_SECRET", "")
-    if svc and tok and tok == svc:
+    # ONE name, resolved once at import, and a CONSTANT-TIME compare: `==` on a shared service
+    # secret leaks its prefix to anyone who can time this call, and this server is public (F95).
+    if tok and hmac.compare_digest(tok, INTERNAL_SECRET):
         return "service"
     uid = _subject()
     if not uid:
@@ -2130,9 +2230,19 @@ def workspace_read(path: str, slug: str = "", token: str = "") -> str:
 def workspace_write(path: str, content: str, slug: str = "", token: str = "") -> str:
     """Write a file into a workspace.
 
-    NOTE: agent-api exposes no HTTP write — only an agent turn writes knowledge. This goes
-    in through the container's own view of the volume and is a DEV DOUBLE for that missing
-    endpoint; it is the gap to close before workspaces are genuinely agent-controllable."""
+    Goes through agent-api's own write route (`PUT /api/workspace/file`) on the CALLER'S identity,
+    so a write is authorized by the same rules a read is: a shared workspace needs contributor+,
+    `_global` needs the org-admin allowlist, the path is confined under the workspace root, and the
+    change is committed so the history stays honest.
+
+    It used to `docker exec ... sh -c '... cat > /workspaces/<slug>/<path>'` — the caller's `path`
+    and `slug` interpolated unquoted into a shell, as root, in the container that holds every
+    workspace and the secret store, and with no membership check at all because a volume does not
+    have one. Two failures wearing one shape: the shell (any signed-in user could run a command) and
+    the door (any signed-in user could overwrite anyone's file). One fix answers both — stop
+    reaching around the service that owns the resource. The note that said "agent-api exposes no
+    HTTP write" was true when it was written and has been false since the terminal's page editor
+    shipped, which is the other half of how this survived review (F96)."""
     vocab = CONFIG_VOCAB.get(path.strip("/"))
     if vocab:
         unknown = [k for k in _frontmatter_keys(content) if k not in vocab]
@@ -2148,17 +2258,27 @@ def workspace_write(path: str, content: str, slug: str = "", token: str = "") ->
             })
 
     uid = me()
-    target = f"/workspaces/{slug or uid}/{path}"
     try:
-        r = subprocess.run(
-            ["docker", "exec", "-i", "vexa-dogfood-agent-api-1", "sh", "-c",
-             f'mkdir -p "$(dirname {target})" && cat > {target}'],
-            input=content, capture_output=True, text=True, timeout=30)
-        if r.returncode != 0:
-            return json.dumps({"error": (r.stderr or "write failed")[:300]})
-        return json.dumps({"url": _ws_url(path, token or ""), "paste_this_link": "[" + path.rsplit("/", 1)[-1] + "](" + _ws_url(path, token or "") + ")", "written": target, "bytes": len(content)})
-    except Exception as e:  # noqa: BLE001
-        return json.dumps({"error": f"{type(e).__name__}: {e}"})
+        rel = _safe_ws_path(path)
+    except _BadPath as e:
+        return json.dumps({
+            "refused": "invalid_path", "path": path, "why": str(e),
+            "tell_your_person": "plainly, that the file name is not one a workspace can hold — "
+                                "then offer a path inside it.",
+        })
+    body = {"path": rel, "content": content}
+    if slug:
+        body["slug"] = slug
+    st, resp = _http("PUT", f"{AGENT_API}/api/workspace/file", {"X-User-Id": uid}, body)
+    if st != 200:
+        # A 403 here is a real answer, not a fault: this person is not a contributor on that
+        # workspace. Say so; do not retry, and do not describe what is in it.
+        return json.dumps({"refused": "not_written", "status": st, "path": rel,
+                           "workspace": slug or "your own",
+                           "why": resp if isinstance(resp, (str, dict)) else "write refused"})
+    return json.dumps({"url": _ws_url(rel, token or ""),
+                       "paste_this_link": "[" + rel.rsplit("/", 1)[-1] + "](" + _ws_url(rel, token or "") + ")",
+                       "written": rel, "bytes": len(content)})
 
 
 @mcp.tool()
@@ -2883,12 +3003,18 @@ def _read_json(uid: str, path: str, default):
 
 
 def _write_json(uid: str, path: str, obj) -> bool:
-    target = f"/workspaces/{uid}/{path}"
-    r = subprocess.run(
-        ["docker", "exec", "-i", "vexa-dogfood-agent-api-1", "sh", "-c",
-         f'mkdir -p "$(dirname {target})" && cat > {target}'],
-        input=json.dumps(obj, indent=1), capture_output=True, text=True, timeout=30)
-    return r.returncode == 0
+    """Write one JSON doc into `uid`'s own workspace, through the door that authorizes it.
+
+    Same fix as `workspace_write` and for the same reason (F96): this shelled into the agent-api
+    container as root with an interpolated path. `uid` here is always the resolved subject, so the
+    route's own authorization is exactly what this was always meant to have."""
+    try:
+        rel = _safe_ws_path(path)
+    except _BadPath:
+        return False
+    st, _ = _http("PUT", f"{AGENT_API}/api/workspace/file", {"X-User-Id": uid},
+                  {"path": rel, "content": json.dumps(obj, indent=1)})
+    return st == 200
 
 
 @mcp.tool()

--- a/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
@@ -80,6 +80,15 @@ spec:
               value: {{ .Values.agentApi.globalAdminSubjects | default "" | quote }}
             - name: VEXA_REDIS_URL
               value: {{ include "vexa.redisUrl" . | quote }}
+            # The internal tier agent-api both presents (Lane M) and BELIEVES (_internal_caller,
+            # meeting-room gate 0). The chart never set it here at all, so every helm deploy ran
+            # agent-api with an empty secret; it is required-explicit now and the boot refuses
+            # without it (F95).
+            - name: INTERNAL_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: INTERNAL_API_SECRET
             - name: VEXA_DISPATCH_SIGNING_KEY
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/charts/vexa/templates/secret.yaml
+++ b/deploy/helm/charts/vexa/templates/secret.yaml
@@ -8,7 +8,11 @@ metadata:
 type: Opaque
 stringData:
   ADMIN_API_TOKEN: {{ .Values.secrets.adminApiToken | quote }}
-  INTERNAL_API_SECRET: {{ .Values.secrets.internalApiSecret | default "vexa-internal-secret" | quote }}
+  # No default: `vexa-internal-secret` is published in this repository and is the exact value the
+  # internal tier compares against, so a chart default IS an open internal tier (F95). Mint one
+  # (`openssl rand -hex 32`) and pass --set secrets.internalApiSecret=..., or use
+  # secrets.existingSecretName.
+  INTERNAL_API_SECRET: {{ required "secrets.internalApiSecret is required — mint one with `openssl rand -hex 32` (or set secrets.existingSecretName); there is no default, the internal tier is authority" .Values.secrets.internalApiSecret | quote }}
   TRANSCRIPTION_SERVICE_TOKEN: {{ .Values.secrets.transcriptionServiceToken | quote }}
   VEXA_SERVICE_AUTHORITY_SECRET: {{ .Values.secrets.serviceAuthoritySecret | quote }}
   VEXA_SYSTEM_WEBHOOK_SECRET: {{ .Values.secrets.systemWebhookSecret | quote }}

--- a/deploy/helm/charts/vexa/values-test.yaml
+++ b/deploy/helm/charts/vexa/values-test.yaml
@@ -12,7 +12,10 @@ global:
 
 secrets:
   adminApiToken: "test-admin-token"
-  internalApiSecret: "vexa-internal-secret"
+  # A RENDER fixture, never a running value — and deliberately not the old published literal:
+  # `vexa-internal-secret` is on every service's forbidden-values list now (F95) and a boot
+  # holding it refuses to start.
+  internalApiSecret: "helm-render-test-only"
   transcriptionServiceToken: ""
   dispatchSigningKey: "dev-dispatch-signing-key"
 

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -49,7 +49,8 @@ global:
 secrets:
   existingSecretName: ""
   adminApiToken: "CHANGE_ME"        # admin-api auth + MeetingToken signing (== meeting-api ADMIN_TOKEN)
-  internalApiSecret: ""             # gateway↔admin-api↔meeting-api internal calls (default vexa-internal-secret)
+  internalApiSecret: ""             # REQUIRED, no default (F95): the internal tier every service
+                                    # presents AND believes — `openssl rand -hex 32`
   transcriptionServiceToken: ""     # funded STT token threaded into spawned bots
   serviceAuthoritySecret: ""        # exact-byte HMAC secret; required only when meetingApi.serviceAuthorityConfig is set
   systemWebhookSecret: ""           # exact-byte HMAC secret; required only when meetingApi.systemWebhookUrl is set

--- a/deploy/lite/entrypoint.sh
+++ b/deploy/lite/entrypoint.sh
@@ -36,7 +36,13 @@ export DB_PASSWORD="${DB_PASSWORD:-postgres}"
 export LOG_LEVEL="${LOG_LEVEL:-info}"
 export DISPLAY="${DISPLAY:-:99}"
 export ADMIN_API_TOKEN="${ADMIN_API_TOKEN:-${ADMIN_TOKEN:-changeme}}"
-export INTERNAL_API_SECRET="${INTERNAL_API_SECRET:-lite-internal-secret}"
+# The internal tier. lite is ONE container, so every service that shares this secret shares this
+# process's environment — which means the fallback can be MINTED per boot instead of shipped as
+# a literal. `lite-internal-secret` was published in this repository and was the exact value
+# agent-api's _internal_caller compared against, so anyone who could reach the port was the
+# internal tier (F95). A random per-boot value keeps the one-command quickstart working and is
+# nobody's to guess; set INTERNAL_API_SECRET explicitly when something outside talks in.
+export INTERNAL_API_SECRET="${INTERNAL_API_SECRET:-$(python3 -c "import secrets; print(secrets.token_hex(32))")}"
 export DEFAULT_BOT_NAME="${DEFAULT_BOT_NAME:-Vexa}"
 
 # Optional Google Meet speaker-stream tuning. Empty values preserve bot defaults; the runtime

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -105,7 +105,7 @@ redirect this operator callback. Leave all four values unset for the stock OSS b
 | Variable | Default | Purpose |
 |---|---|---|
 | `ADMIN_TOKEN` | `changeme` | Admin API key (`X-Admin-API-Key`) — mints users and tokens. |
-| `INTERNAL_API_SECRET` | `vexa-internal-secret` | Shared secret for service-to-service calls. |
+| `INTERNAL_API_SECRET` | **none — required** | The internal tier. Services present it as `X-Internal-Secret`; agent-api and admin-api believe it as *authority* (it opens the meeting room and admin-api's `/internal/*` surface), so there is no default and the services refuse to boot without it — or on a published placeholder. Mint one: `openssl rand -hex 32`. Lite mints a per-boot value when unset. |
 | `VEXA_DISPATCH_SIGNING_KEY` | `dev-dispatch-signing-key` | Signs dispatch tokens (the identity chain of custody). |
 | `NEXTAUTH_SECRET` | `dev-nextauth-secret` | Session secret for the web UI. |
 | `VEXA_BOT_API_KEY` | — | Pre-shared key a bot uses to call back into the stack. |


### PR DESCRIPTION
Two **live** security findings from the full review of this line vs `main` — `~/dev/biz/drafts/2026-09-02-line-vs-main-full-review.md` §A2, §D1, §E1. Owning issue: [`DmitriyG228/biz#449`](https://github.com/DmitriyG228/biz/issues/449). Both are reachable by any signed-in user.

**COMMITMENTS IN THIS PR — none.** No money, no dates, no rights, no published terms. One precedent worth naming as a change of behaviour rather than a commitment: `INTERNAL_API_SECRET` becomes required-explicit for agent-api, so a deploy that never set it stops booting instead of running a half-configured internal tier.

---

## F95 — the internal tier was open by default, and the gateway forwarded the key

**(a) The gateway now strips authority headers by family.** It copied every client header and stripped an eight-name list of `x-user-*` spellings, so `x-internal-secret` arrived at agent-api from the public edge — and agent-api's `_internal_caller` believes it, as does admin-api's `_check_internal`, and the meeting room calls that gate *in its own words* the trust boundary on who is in the room. The strip is now `x-user-`, `x-internal-`, `x-vexa-internal-` by prefix plus `x-admin-api-key` and `x-gateway-verified` exactly. A list rots the moment somebody adds an authority header; a prefix rule does not.

**(b) A published placeholder now refuses the boot.** New optional `forbidden_values` on the config.v1 key declaration; `preflight()` raises `ConfigError` on a match. This is the case `required-explicit` cannot catch, and it is the one that actually happened: the secret was never *unset* on a stock deploy — compose supplied `${INTERNAL_API_SECRET:-vexa-internal-secret}`, a literal in a public repository and the exact value the comparison used — so every unconfigured deployment came up green sharing one secret anyone could read. **A key that looks configured and is not is worse than one that is missing.** agent-api, admin-api, gateway and meeting-api declare the literals the deploy surfaces really shipped; flows-api and the rig carry the same list in code and refuse the same way. Every refusal names the KEY, never the value.

**(c) One name.** The secret had three — `INTERNAL_API_SECRET` (compose/helm, admin-api, gateway, meeting-api), `VEXA_INTERNAL_API_SECRET` (agent-api, terminal), `VEXA_INTERNAL_SECRET` (flows) — and three names meant three refusal lists, which is precisely why `vexa-internal-secret` was on flows' list and on nobody else's. Canonical is the compose/helm secret key, `INTERNAL_API_SECRET`. The prefixed spellings still resolve for one release and log a deprecation at boot. agent-api reads it through an alias and declares it required-explicit; the helm chart sets it on agent-api **for the first time** (it was set on gateway, admin-api, meeting-api, runtime and terminal, and never on agent-api, so every helm deploy ran agent-api with an empty internal secret).

Defaults removed: compose `${INTERNAL_API_SECRET}` with no fallback · `.env.example` empty with the mint command · the helm chart Secret `required` · lite mints a **random per-boot value** when unset (it is one container, so every service shares this process's env — that keeps the one-command quickstart working while removing the published literal).

## F96 — the rig wrote workspaces by shelling into the container

`workspace_write` ran `docker exec … sh -c 'mkdir -p "$(dirname TARGET)" && cat > TARGET'` with the caller's `path` and `slug` interpolated **unquoted**. Two failures in one line:

- **the shell** — `workspace_write(path="x; id > /tmp/p; #")` executed as root inside the container that holds every workspace *and* the secret store, reachable by any signed-in user;
- **the door** — the write went to the volume, and a volume has no membership check, so any signed-in user could truncate any other person's or group's file. The **read** side had gone through agent-api, which confines and authorizes, since the beginning.

`_write_json` (the resume queue) had the same shape.

Both now `PUT /api/workspace/file` on the **caller's** identity, so a write is authorized by the same rules a read is: contributor+ on a shared workspace, the org-admin allowlist on `_global` (the founder's `setup-global` flow still works — that is the route's own path), confinement under the workspace root, and a commit so history stays honest. A validator refuses `..` **segment-wise**, absolute paths, `.git/` and shell metacharacters before anything runs — belt as well as braces now that the shell is gone, deliberately: a validator that defends only against today's implementation defends against nothing after the next refactor.

The docstring saying *"agent-api exposes no HTTP write"* had been false since the terminal's page editor shipped. That is the other half of how this survived review, so the new docstring says what it does and what it used to do.

**Remaining non-HTTP reach:** `docker inspect` on admin-api's env in `_admin_key()` — a READ of a container's own configuration, not a write. It belongs to the `core-mcp` seam work, not to a hotfix. Rig edits were kept minimal for exactly that reason; `core-mcp` is at the same base commit and this diff touches `vexa_control_mcp.py` in four places (the internal-secret helper + path validator block, `_operator_or_refuse`'s compare, `workspace_write`, `_write_json`).

---

## Proof

| suite | result |
|---|---|
| gateway | **342 passed**, 1 xfailed (+2) |
| agent-api | **1093 passed**, 1 failed (+27) — the failure is the standing `requests_unixsocket` env red, red on the base commit too |
| flows | **243 passed**, 1 failed (+7) — the failure is the standing live-admin-api smoke, red on the base commit too |
| admin-api | **110 passed** (+1) |
| meeting-api | **1322 passed**, 5 skipped (unchanged) |
| 14 pre-push gates | green (pushed **without** `--no-verify`) |
| gate script tests | 123/125 — the same two failures as the base commit (`image-licenses vacuity`, `Lite apt package inventoried`) |
| rig parity | **64 tools, names + signatures IDENTICAL** to the base; the only description that changed is `workspace_write`'s, deliberately |

Fail-closed proved by running it, not by reading it:

```
INTERNAL_API_SECRET is unset — the vexa-control MCP refuses to start …
INTERNAL_API_SECRET is the placeholder 'vexa-internal-secret' — refusing to start. That
literal is published in this repository, so it authenticates nobody and everybody.
```

## ⚠ Needs `lane:contract` review

`deploy/contracts/config.v1` is a **published, sealed** contract. The change is additive and back-compatible (a new optional key field), so `contracts.seal.json` is re-sealed with `pnpm seal:contracts` as `gate:contract-version` prescribes — and that re-seal is a human-reviewed step by design. The re-seal also dropped a **stale** entry for `core/agent/contracts/processed-notes.v1`, a contract this branch had already deleted; that line is the only part of the seal diff not caused by this PR.

## Deploy notes for whoever restarts the stack

Not done here — this branch builds and tests only; the running stack is the stage-1 worker's.

- **Rebuild:** gateway (header strip), agent-api (settings + preflight), admin-api and meeting-api (declarations only — the vendored `config_preflight.py` is inside the image, so they need the rebuild to gain the refusal), the flows lane, and a rig restart.
- **`rig.sh` now exports `INTERNAL_API_SECRET`** into `start_ctl` and `start_api` from `$HOME/.storm/internal-secret`. Without it the control MCP and flows-api **refuse to start** — that is the intended fail-closed behaviour, not a regression.
- **Rotation:** the live compose value is a 64-character random secret, **not** a default literal, so nothing was open in practice on this deployment. Rotating is a judgment call, not a forced step.
