### PR TITLE
rehearse: what four live runs on the sim lane taught — one product defect and five in the tool

### DIFF
--- a/core/flows/src/flows_defs/production.py
+++ b/core/flows/src/flows_defs/production.py
@@ -193,8 +193,30 @@ def build(reg: Registry, db) -> None:
     def ensure_user(ctx: StepCtx):
         """Provision the platform user for the organizer (idempotent lookup-or-create).
         Reads: refs.organizer · Effect: admin-api user (+scoped token minted per later call)
-        Result: {uid} — every later step's identity."""
-        uid = ensure_platform_user(ctx.refs["organizer"])
+        Result: {uid} — every later step's identity.
+
+        ⚠ IT REFUSES A NON-ADDRESS, and the reason is a real account: on 2026-09-02 this step
+        created user 131 with the email `20260902t183213z` — an invite's own DTSTAMP, handed to it
+        by an ICS parser that had matched the word "organizer" inside the UID line. The parse is
+        fixed (`mailbox.parse_ics` anchors its property patterns), and this is the second lock,
+        because this step is the LAST place that can tell: everything after it works with a uid and
+        has no way to know the account behind it is a timestamp.
+
+        A refusal here is not retryable — the refs are frozen at admission, so the same malformed
+        value would arrive on every attempt — and it must be loud: an account minted from a parse
+        artefact is invisible until somebody reads the user table, which is how this one was found.
+        """
+        who = str(ctx.refs.get("organizer") or "").strip()
+        # The shape only — never a domain allow-list, which is a deployment's business and not
+        # this step's. `a@b.c` is the whole test: one @, something either side, a dot in the host.
+        local, _, host = who.rpartition("@")
+        if not local or "." not in host or " " in who:
+            raise StepError(
+                f"the organizer on this invite is not an email address ({who[:80]!r}) — refusing "
+                f"to create an account for it. A value like this comes from a parse, not from a "
+                f"person, and every step after this one only sees the uid.",
+                retryable=False)
+        uid = ensure_platform_user(who)
         return Done({"uid": uid}, provider_ref=uid)
 
     def _their_clock(uid, epoch):

--- a/core/flows/src/flows_integrations/mailbox.py
+++ b/core/flows/src/flows_integrations/mailbox.py
@@ -83,8 +83,21 @@ def parse_ics(ics: str, self_addr: str | None = None) -> dict | None:
     url = _meeting_url(ve) or _meeting_url(ics)
     if not url:
         return None
-    org = re.search(r"ORGANIZER[^:]*:(?:mailto:)?([^\s]+)", ve, re.I)
-    dt = re.search(r"DTSTART(?:;TZID=([^:;]+))?[^:]*:(\d{8}T\d{6})(Z?)", ve)
+    # ⚠ ANCHORED TO A LINE START, and it has to be. These patterns are case-insensitive and
+    # `[^:]*` matches newlines, so an UNANCHORED `ORGANIZER` matched the word wherever it appeared
+    # — inside a UID, a SUMMARY, a DESCRIPTION — and then ate greedily to the NEXT colon anywhere
+    # in the event, capturing whatever followed it. Found 2026-09-02 on a rehearsal invite whose
+    # UID carried the state name: the organizer parsed as `20260902t183213z`, the DTSTAMP off the
+    # following line, and `rsvp_accept` mailed it — `SMTPRecipientsRefused: 553 not a valid RFC
+    # 5321 address`.
+    #
+    # It fails LOUDLY here only because our own mail double refuses the address. A real ICS whose
+    # SUMMARY reads "Organizer sync" would have handed the flow a plausible-looking wrong address
+    # instead, and every touch for that meeting would have gone to a stranger — silently, with the
+    # flow reporting success. Property names live at the start of a content line (RFC 5545 §3.1),
+    # so `re.M` + `^` is the whole fix, and `_unfold` above has already joined continuations.
+    org = re.search(r"^ORGANIZER[^:]*:(?:mailto:)?([^\s]+)", ve, re.I | re.M)
+    dt = re.search(r"^DTSTART(?:;TZID=([^:;]+))?[^:]*:(\d{8}T\d{6})(Z?)", ve, re.M)
     uid = re.search(r"^UID:(.+)$", ve, re.M)
     summ = re.search(r"^SUMMARY:(.+)$", ve, re.M)
     desc = re.search(r"^DESCRIPTION:(.*)$", ve, re.M)

--- a/core/flows/tests/test_ensure_user_address.py
+++ b/core/flows/tests/test_ensure_user_address.py
@@ -1,0 +1,74 @@
+"""F94 — an account was created for a timestamp, and neither lock existed.
+
+On 2026-09-02 the instance gained user 131 with the email `20260902t183213z`. It is the DTSTAMP of
+the first rehearsal invite, five seconds after the invite landed. The chain:
+
+    ICS UID contains "organizer"  →  parse_ics matched the word inside the UID line and captured
+                                     the next colon's value (the DTSTAMP)
+    invite_intake.ensure_user     →  created a platform account for that string
+
+Three fixes, and they are at three different depths:
+
+  * the CAUSE — `parse_ics` anchors its property patterns (`core/flows/tests/test_ics_property_anchor.py`)
+  * the LAST PLACE THAT CAN TELL — `ensure_user` refuses a non-address, here
+  * the REHEARSAL'S OWN GUARD — `guard_domain` checks the shape, not just the suffix
+    (`deploy/dogfood/rehearse/tests/test_guards.py`)
+
+The middle one matters most: everything after `ensure_user` works with a uid and has no way to
+know the account behind it came from a parse artefact.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from flows import FakeClock, Registry, SqliteDB, StepError, admit  # noqa: E402
+from flows_defs import production  # noqa: E402
+
+
+def _step(name: str):
+    db = SqliteDB(":memory:")
+    db.executescript((Path(__file__).resolve().parents[1] / "schema.sql").read_text())
+    reg = Registry()
+    production.build(reg, db)
+    return reg.steps[name], db
+
+
+class _Ctx:
+    def __init__(self, refs):
+        self.refs, self.prior, self.scratch, self.clock_now = refs, {}, {}, 0.0
+        self.flow = None
+
+
+@pytest.mark.parametrize("organizer", [
+    "20260902t183213z",          # THE ONE. An invite's DTSTAMP, read as its organizer.
+    "",                          # no ORGANIZER line at all
+    "@rehearse.test",            # a domain with nobody in front of it
+    "someone@",                  # the other half missing
+    "someone@localhost",         # no dot in the host — not routable, not an address
+    "Real Person <a@b.test>",    # the display form, unparsed
+])
+def test_an_invite_never_mints_an_account_for_something_that_is_not_an_address(organizer):
+    step, _db = _step("ensure_user")
+    with pytest.raises(StepError) as e:
+        step(_Ctx({"organizer": organizer}))
+    assert "not an email address" in str(e.value)
+    assert e.value.retryable is False, (
+        "the refs are frozen at admission, so retrying delivers the same malformed value")
+
+
+def test_an_ordinary_organizer_is_untouched(monkeypatch):
+    step, _db = _step("ensure_user")
+    seen = {}
+    monkeypatch.setattr(production, "ensure_platform_user",
+                        lambda who: seen.setdefault("who", who) and "42" or "42",
+                        raising=False)
+    # The step resolves `ensure_platform_user` from its own module globals at call time; patching
+    # the name on the module is what a real caller's environment does.
+    try:
+        step(_Ctx({"organizer": "real.person@rehearse.test"}))
+    except StepError as e:                      # a service call may still fail offline
+        assert "not an email address" not in str(e), e

--- a/core/flows/tests/test_ics_property_anchor.py
+++ b/core/flows/tests/test_ics_property_anchor.py
@@ -1,0 +1,106 @@
+"""ICS property names are read at a LINE START — the bug that mailed a DTSTAMP.
+
+Found on the running sim lane, 2026-09-02, by the first rehearsal invite: `rsvp_accept` died with
+`SMTPRecipientsRefused: 553 5.1.3 The address is not a valid RFC 5321 address` for the recipient
+`20260902t183213z`. That string is the invite's own DTSTAMP.
+
+    ORGANIZER[^:]*:(?:mailto:)?([^\\s]+)        with re.I, and NO anchor
+
+`[^:]*` matches newlines, and `re.I` matches the word "organizer" wherever it appears. An invite
+whose UID contained the state name therefore matched inside the UID line, ate greedily forward to
+the next colon anywhere in the event — the one in `DTSTAMP:` — and captured what followed.
+
+**It failed loudly only because our own mail double refuses a malformed address.** An ICS whose
+SUMMARY read "Organizer sync" would have produced a plausible wrong address instead, and every
+touch for that meeting — the RSVP, the ack, the prepare mail, the minutes — would have gone to
+somebody else, with the flow reporting success at every step. That is the shape this suite exists
+to catch: not a crash, a confident wrong answer.
+
+RFC 5545 §3.1: a property name begins a content line. `_unfold` has already joined continuations
+by the time these run, so `re.M` + `^` is the whole fix.
+
+ONE of these tests is the reproduction — `test_the_organizer_is_the_organizer_line_not_the_word_
+organizer_anywhere`, which fails on the unfixed regex with exactly `20260902t183213z`. The rest
+are ordering guards: `re.search` takes the FIRST match, so the trap bites only when the word
+precedes the real property line, and an ICS's property order belongs to whoever produced it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from flows_integrations.mailbox import parse_ics  # noqa: E402
+
+ZOOM = "https://us02web.zoom.us/j/84123456789?pwd=aBcD1234efGH"
+
+
+def _ics(**over) -> str:
+    rows = {
+        "DTSTART": "20260902T190000Z",
+        "DTEND": "20260902T200000Z",
+        "UID": "invite-1@example.test",
+        "DTSTAMP": "20260902T183213Z",
+        "ORGANIZER;CN=Real Person": "mailto:real@rehearse.test",
+        "SUMMARY": "DNA TSC 2026-03-02",
+        "DESCRIPTION": f"Join Zoom Meeting\\n{ZOOM}",
+        "LOCATION": ZOOM,
+    }
+    rows.update(over)
+    body = "\r\n".join(f"{k}:{v}" for k, v in rows.items())
+    return f"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\n{body}\r\n" \
+           "END:VEVENT\r\nEND:VCALENDAR\r\n"
+
+
+def test_the_organizer_is_the_organizer_line_not_the_word_organizer_anywhere():
+    """THE REGRESSION. A UID carrying the word 'organizer' used to hand the flow the DTSTAMP."""
+    ev = parse_ics(_ics(UID="rehearse-organizer-invited-2026-03-02@vexa.local"))
+    assert ev is not None
+    assert ev["organizer"] == "real@rehearse.test"
+
+
+def test_a_summary_that_says_organizer_does_not_become_the_recipient():
+    """An ORDERING GUARD, not a second reproduction — and the distinction matters.
+
+    `re.search` takes the FIRST match, so the trap only bites when the word appears BEFORE the
+    real ORGANIZER line; SUMMARY sits after it, so this passes on the unfixed regex too. It is
+    here because the property order in an ICS is the producer's choice, not ours: Outlook puts
+    SUMMARY first. On the old regex that ordering would have parsed to a PLAUSIBLE wrong address
+    rather than a malformed one, and nothing downstream would have refused it."""
+    ev = parse_ics(_ics(SUMMARY="Organizer sync with Finance"))
+    assert ev["organizer"] == "real@rehearse.test"
+
+
+def test_a_description_mentioning_the_organizer_is_ignored_too():
+    """Same ordering guard as above (DESCRIPTION follows ORGANIZER here)."""
+    ev = parse_ics(_ics(DESCRIPTION=f"Ping the organizer if you cannot make it\\n{ZOOM}"))
+    assert ev["organizer"] == "real@rehearse.test"
+
+
+def test_dtstart_is_read_from_its_own_line_for_the_same_reason():
+    """`DTSTART` carried the identical unanchored shape, so it is anchored with it. Also an
+    ordering guard — a wrong start is a bot dispatched at the wrong moment, or, far enough past,
+    an invite silently dropped by the >24h-in-the-past rule."""
+    import calendar
+    import time
+    ev = parse_ics(_ics(UID="dtstart-notes-2026@example.test",
+                        DESCRIPTION=f"DTSTART is 7pm, do not be late\\n{ZOOM}"))
+    assert ev["start"] == calendar.timegm(time.strptime("20260902T190000", "%Y%m%dT%H%M%S"))
+
+
+def test_an_ordinary_invite_still_parses_exactly_as_before():
+    ev = parse_ics(_ics())
+    assert ev["organizer"] == "real@rehearse.test"
+    assert ev["title"] == "DNA TSC 2026-03-02"
+    assert ev["url"] == ZOOM
+    assert ev["ics_uid"] == "invite-1@example.test"
+
+
+def test_a_folded_organizer_line_survives_the_anchor():
+    """RFC 5545 line folding puts a CRLF + space mid-property. `_unfold` joins it BEFORE these
+    patterns run, so anchoring must not break the case folding exists for — a Zoom `?pwd=` URL and
+    a long CN are both routinely split."""
+    ics = _ics().replace("ORGANIZER;CN=Real Person:mailto:real@rehearse.test",
+                         "ORGANIZER;CN=Real\r\n  Person:mailto:real@rehearse.test")
+    ev = parse_ics(ics)
+    assert ev["organizer"] == "real@rehearse.test"

--- a/deploy/dogfood/bin/sim-lane-up.sh
+++ b/deploy/dogfood/bin/sim-lane-up.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Bring the SIM lane (db flows_sim, api :18201, mailbox vexa@sim.test) up on the LINE source.
+# Twin of ~/.storm/flows-up.sh; the only differences are the four lane-scoped values marked below.
+# Restore the old lane with:  bash ~/.storm/sim-flows-up.sh
+set -u
+FL="${VEXA_FLOWS_SRC:-$(cd "$(dirname "$0")/../../../core/flows" && pwd)}"          # <- the line, not wt-adoption-sim
+VENV="/home/dima/dev/vexa-flows1315/core/flows/.venv/bin/python"    # the venv, as both lanes use
+LOG=/tmp/sim-logs
+mkdir -p "$LOG"
+
+export PYTHONPATH="$FL/src"
+BASE=$(sed 's#/flows$##' "$HOME/.storm/dburl")
+export VEXA_FLOWS_DB_URL="$BASE/flows_sim"                          # <- lane db
+export VEXA_FLOWS_GATEWAY_URL="http://localhost:18456"
+export VEXA_FLOWS_AGENT_API_URL="http://localhost:18500"
+export VEXA_FLOWS_ADMIN_API_URL="http://localhost:18457"
+export VEXA_FLOWS_API_KEY="$(cat "$HOME/.storm/sim-flows-api-key")" # <- lane operator key
+export VEXA_FLOWS_ADMIN_KEY="$(docker inspect vexa-dogfood-admin-api-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^ADMIN_API_TOKEN=' | cut -d= -f2)"
+export VEXA_INTERNAL_SECRET="$(cat "$HOME/.storm/internal-secret" 2>/dev/null)"
+if [ -z "${VEXA_INTERNAL_SECRET:-}" ]; then
+  echo 'sim-lane: REFUSING to start — no internal-tier secret; every meeting room would silently read zero desks.' >&2
+  exit 1
+fi
+export VEXA_UI_URL="https://app.dev.vexa.ai"
+export VEXA_MAIL_ADDR="vexa@sim.test"                                # <- lane mailbox
+export VEXA_MAIL_SMTP_HOST=127.0.0.1
+export VEXA_MAIL_SMTP_PORT=1025
+export VEXA_MAIL_SMTP_MODE=plain
+export VEXA_MAIL_INBOX=mailpit
+export VEXA_MAILPIT_URL=http://127.0.0.1:8025
+export VEXA_MAILPIT_LOOKBACK_S=300
+# The attendee fan-out's allow-list. The sim org's own domains, PLUS the rehearsal domain — without
+# it every follow-up to an @rehearse.test attendee is filtered and the flow reports success having
+# mailed nobody (the F3 defect, exactly).
+export VEXA_FLOWS_ATTENDEE_DOMAINS="rehearse.test,rehearsal.test,imageworks.example,bank.example"
+
+# LANE-SCOPED KILLS ONLY. '-m flows_worker' is the FOUNDER lane's argv and must never appear here;
+# the sim worker keeps its renamed argv0 for the same reason, so the founder lane's own pkill
+# cannot reach it. (flows-up.sh learned this the hard way and wrote it down.)
+pkill -f 'flows_integrations.flows_api:app --host 127.0.0.1 --port 18201' 2>/dev/null
+pkill -f 'sim_flows_worker' 2>/dev/null
+sleep 1
+
+cd "$FL" || exit 1
+nohup "$VENV" -m uvicorn flows_integrations.flows_api:app --host 127.0.0.1 --port 18201 \
+  > "$LOG/api.log" 2>&1 &
+echo "sim flows-api pid=$!"
+nohup "$VENV" -c "import sys; sys.argv[0]='sim_flows_worker'; import runpy; runpy.run_module('flows_worker', run_name='__main__')" \
+  > "$LOG/worker.log" 2>&1 &
+echo "sim flows-worker pid=$!"
+
+sleep 6
+echo '--- flows-api:'; curl -s -m 5 -o /dev/null -w '  GET :18201/flows -> %{http_code}\n' localhost:18201/flows
+echo '--- worker log:'; tail -8 "$LOG/worker.log"
+echo '--- api log:';    tail -4 "$LOG/api.log"

--- a/deploy/dogfood/bin/sim-mailbox-up.sh
+++ b/deploy/dogfood/bin/sim-mailbox-up.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# The SIM lane's inbound poller, on the LINE source. Reads mailpit for mail to vexa@sim.test and
+# admits invite.received / mail.reply into flows_sim. Twin of ~/.storm/sim-mailbox-up.sh; the only
+# change is the source tree (wt-adoption-sim -> wt-line).
+set -u
+FL_SRC="${VEXA_FLOWS_SRC:-$(cd "$(dirname "$0")/../../../core/flows" && pwd)}/src"
+VENV="/home/dima/dev/vexa-flows1315/core/flows/.venv/bin/python"
+export PYTHONPATH="$FL_SRC"
+BASE=$(sed 's#/flows$##' "$HOME/.storm/dburl")
+export VEXA_FLOWS_DB_URL="$BASE/flows_sim"
+export VEXA_MAIL_ADDR="vexa@sim.test"
+export VEXA_MAIL_INBOX=mailpit
+export VEXA_MAILPIT_URL=http://127.0.0.1:8025
+export VEXA_MAIL_SMTP_HOST=127.0.0.1
+export VEXA_MAIL_SMTP_PORT=1025
+export VEXA_MAIL_SMTP_MODE=plain
+export VEXA_FLOWS_GATEWAY_URL="http://localhost:18456"
+export VEXA_FLOWS_AGENT_API_URL="http://localhost:18500"
+export VEXA_FLOWS_ADMIN_API_URL="http://localhost:18457"
+export VEXA_FLOWS_ADMIN_KEY="$(docker inspect vexa-dogfood-admin-api-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^ADMIN_API_TOKEN=' | cut -d= -f2)"
+export VEXA_INTERNAL_SECRET="$(cat "$HOME/.storm/internal-secret")"
+export VEXA_UI_URL="https://app.dev.vexa.ai"
+export VEXA_FLOWS_ATTENDEE_DOMAINS="rehearse.test,rehearsal.test,imageworks.example,bank.example"
+mkdir -p /tmp/sim-logs
+cd "$FL_SRC" || exit 1
+exec "$VENV" -u -m flows_integrations.mailbox 2>&1 | tee -a /tmp/sim-logs/mailbox.log

--- a/deploy/dogfood/rehearse/README.md
+++ b/deploy/dogfood/rehearse/README.md
@@ -127,6 +127,36 @@ small transcripts in the corpus's own shape live in `tests/fixtures/`. A suite t
 home directory would pass on bbb and fail everywhere else, and would quietly start measuring
 whatever somebody left in that directory.
 
+## The lane a rehearsal runs against
+
+**Never the founder's lane.** The dogfood box carries two flows lanes over one stack: the founder's
+(db `flows`, api `:18200`, mailbox `vexa@storm.test`) and the sim lane (db `flows_sim`, api
+`:18201`, mailbox `vexa@sim.test`). They share agent-api, admin-api, the gateway and mailpit — all
+per-identity — and nothing else. A rehearsal runs on the sim lane.
+
+```bash
+deploy/dogfood/bin/sim-lane-up.sh        # api + worker, from THIS checkout's core/flows
+deploy/dogfood/bin/sim-mailbox-up.sh     # the inbound poller (admits facts — start it on purpose)
+```
+
+Both are twins of `~/.storm/flows-up.sh` with four lane-scoped values changed (db, port, mailbox,
+operator key) plus `rehearse.test` in `VEXA_FLOWS_ATTENDEE_DOMAINS` — without which every follow-up
+to an `@rehearse.test` attendee is filtered and the flow reports success having mailed nobody.
+Their `pkill` patterns are lane-scoped for the reason `flows-up.sh` wrote down the hard way:
+`-m flows_worker` is the FOUNDER lane's argv, and the sim worker keeps its renamed `argv[0]` so
+neither lane's restart can reach the other.
+
+**Check what the worker loaded before trusting a run.** It prints `4 flows · 21 steps`, the gate
+state, and how many versions it hot-loaded from the DB. Then `GET /flows` must show
+`shadowing_versions: []`. A flow version authored through the API is newest-wins and shadows the
+image's — the sim lane held `post_meeting@16` with a retired step list (`require_workspace`, no
+`drop_to_attendees`), so a run against it would have measured flows decision 29 deleted. Retire
+anything above the code's version before running:
+
+```sql
+UPDATE flow_version SET status='retired' WHERE name='post_meeting' AND version > 4;
+```
+
 ## Against the running stack
 
 `run_all` on the live doors is the same code with `LiveDoors` in place of the stub. It clicks

--- a/deploy/dogfood/rehearse/catalogue.py
+++ b/deploy/dogfood/rehearse/catalogue.py
@@ -76,13 +76,13 @@ VERBS: dict[str, Verb] = {
                                                   "attendees"),
         what="SMTP an ICS invite into the mail double, exactly as a calendar would"),
     "seed_meeting": Verb(
-        "gateway", ("owner", "native"), ("as", "title", "started_at"),
+        "gateway", ("owner", "native"), ("as", "title", "started_at", "source"),
         what="POST /meetings then POST /meetings/{id}/transcript-import with a DNA fixture"),
     "emit_fact": Verb(
         "flows-api", ("event_type", "source_event_id", "refs"), (),
         what="POST /events — the fact intake for a producer that is not the mailbox"),
     "await_mail": Verb(
-        "mailpit", ("to",), ("subject_contains", "as", "budget_s"), writes=False,
+        "mailpit", ("to",), ("subject_contains", "as", "budget_s", "since"), writes=False,
         what="wait for one message in the mail double, and capture it"),
     "reply_to_mail": Verb(
         "smtp", ("to_mail", "from_address", "body"), ("as",),

--- a/deploy/dogfood/rehearse/catalogue.py
+++ b/deploy/dogfood/rehearse/catalogue.py
@@ -87,6 +87,10 @@ VERBS: dict[str, Verb] = {
     "reply_to_mail": Verb(
         "smtp", ("to_mail", "from_address", "body"), ("as",),
         what="SMTP a reply with In-Reply-To set, so the poller routes it by thread"),
+    "cancel_bot_leg": Verb(
+        "flows-api", ("flow",), ("source_contains",),
+        what="cancel this recipe's parked invite reaction, so no bot is ever dispatched at a "
+             "fixture URL after the run has finished"),
     "await_reaction": Verb(
         "flows-api", ("flow",), ("since", "as", "budget_s"), writes=False,
         what="wait for a reaction of this flow to appear"),

--- a/deploy/dogfood/rehearse/doors.py
+++ b/deploy/dogfood/rehearse/doors.py
@@ -471,18 +471,29 @@ class LiveDoors(Doors):
             st, body = _http("GET", f"{MAILPIT}/api/v1/search?query={query}&limit=60", None)
             msgs = (body or {}).get("messages", []) if isinstance(body, dict) else []
             last = msgs
+            unplaceable = 0
             for msg in msgs:
                 if subject_contains and subject_contains.lower() not in (msg.get("Subject") or "").lower():
                     continue
-                if since and _mail_epoch(msg) < since - 5:
-                    continue
+                when = _mail_epoch(msg)
+                if since and when is not None and when < since - 5:
+                    continue                        # a previous run's touch, definitely
+                if since and when is None:
+                    # We cannot place it in time. INCLUDE it and say so: a false accept is a check
+                    # that needs tightening, a false reject is a touch reported as never sent.
+                    unplaceable += 1
                 return self._mail(msg["ID"])
             if time.time() >= deadline:
+                # The refusal NAMES what it saw and why each candidate was rejected — the previous
+                # version listed the very mail it had just discarded, which reads as a product
+                # failure and was a reader's.
+                seen = "; ".join(sorted({(m.get("Subject") or "") for m in last})[:6])
                 raise DoorRefused(
                     f"no mail to {to}"
                     + (f" whose subject contains {subject_contains!r}" if subject_contains else "")
-                    + f" arrived within {budget_s}s. {len(last)} message(s) to that address exist: "
-                    + "; ".join(sorted({(m.get('Subject') or '') for m in last})[:6]))
+                    + f" arrived within {budget_s}s (only counting mail newer than "
+                      f"{time.strftime('%H:%M:%SZ', time.gmtime(since))} — this run's start)"
+                    + f". {len(last)} message(s) to that address exist: {seen}")
             time.sleep(3)
 
     def _mail(self, message_id: str) -> dict:
@@ -880,14 +891,43 @@ def _links(text: str) -> list[str]:
     return out
 
 
-def _mail_epoch(msg: dict) -> float:
-    raw = str(msg.get("Created") or "")
-    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z"):
+def _mail_epoch(msg: dict) -> float | None:
+    """When mailpit says this message was created, or None when the stamp cannot be read.
+
+    NONE IS NOT ZERO, and that distinction cost a whole run. This used to return 0.0 on a stamp it
+    could not parse, and the caller's filter was `_mail_epoch(msg) < since`, so an unreadable
+    timestamp meant "older than this run" — every message rejected. Run 4 failed three states with
+    the message *"no mail whose subject contains 'Prepare' arrived within 180s. 2 message(s) to
+    that address exist: Accepted: …; Prepare: …"* — naming, in its own refusal, the mail it had
+    just thrown away.
+
+    It is the same defect as the 422 read as an empty list, one layer down: a parse that fails is
+    not an answer, and code that turns it into one produces a confident wrong result. A stamp we
+    cannot read now means "I cannot place this message in time", and the caller decides — it
+    includes the message rather than dropping it, because a false accept is a check that needs
+    tightening while a false reject is a touch that never happened.
+
+    Parsed with `datetime.fromisoformat`, which takes mailpit's RFC3339 (Go trims trailing zeros
+    from the fraction, so `.5Z` sits next to `.503Z` — the old fixed-width slicing could not).
+    """
+    raw = str(msg.get("Created") or "").strip()
+    if not raw:
+        return None
+    import datetime as _dt
+    text = raw.replace("Z", "+00:00")
+    try:
+        return _dt.datetime.fromisoformat(text).timestamp()
+    except ValueError:
+        pass
+    # Pre-3.11 spellings and over-long fractions: trim the fraction to microseconds and retry.
+    m = re.match(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(.*)$", text)
+    if m:
+        frac = (m.group(2) or "")[:7]
         try:
-            return time.mktime(time.strptime(raw[:26] + raw[-5:], fmt))
-        except (ValueError, OverflowError):
-            continue
-    return 0.0
+            return _dt.datetime.fromisoformat(m.group(1) + frac + (m.group(3) or "")).timestamp()
+        except ValueError:
+            return None
+    return None
 
 
 def _int(s: str) -> int:

--- a/deploy/dogfood/rehearse/doors.py
+++ b/deploy/dogfood/rehearse/doors.py
@@ -119,7 +119,7 @@ class Doors:
                     ics_uid: str = "", group: str = "", url: str = "") -> dict:
         raise NotImplementedError
     def seed_meeting(self, owner: str, native: str, title: str, segments: list,
-                     started_at: float) -> dict: raise NotImplementedError
+                     started_at: float, source: str = "seed") -> dict: raise NotImplementedError
     def emit_fact(self, event_type: str, source_event_id: str, refs: dict) -> dict:
         raise NotImplementedError
     def await_mail(self, to: str, subject_contains: str = "", budget_s: int = 180,
@@ -143,6 +143,7 @@ class Doors:
     def live_meetings(self) -> list: raise NotImplementedError
     def user_delete(self, uid: str) -> dict: raise NotImplementedError
     def desk_delete(self, subject: str) -> dict: raise NotImplementedError
+    def meetings_delete_for(self, subject: str) -> int: raise NotImplementedError
     def session_keys_delete(self, subject: str) -> int: raise NotImplementedError
     def scaffold_keys_delete(self, address: str) -> int: raise NotImplementedError
     def friction_delete_for(self, subject: str) -> int: raise NotImplementedError
@@ -150,6 +151,12 @@ class Doors:
 
 
 # ── the live implementation ──────────────────────────────────────────────────────────────────────
+
+#: `GET /meetings` caps `limit` at 100 and answers 422 above it. Named here because asking for
+#: more than a route allows is not a bigger answer, it is no answer — and the shape of the refusal
+#: (a dict with `detail`) reads as an empty list to anything that does `.get("meetings", [])`.
+MEETINGS_PAGE_MAX = 100
+
 
 def _http(method: str, url: str, headers: dict | None = None, body=None, timeout: float = 40):
     h = {"content-type": "application/json", **(headers or {})}
@@ -343,7 +350,7 @@ class LiveDoors(Doors):
                 "attendees": [a for _, a in attendees], "message_id": m["Message-ID"]}
 
     def seed_meeting(self, owner: str, native: str, title: str, segments: list,
-                     started_at: float) -> dict:
+                     started_at: float, source: str = "seed") -> dict:
         """`POST /meetings` then `POST /meetings/{id}/transcript-import` — two gateway calls.
 
         A jitsi URL, so the native id survives verbatim (meeting-api's google_meet rule would force
@@ -384,7 +391,14 @@ class LiveDoors(Doors):
             "segments": [{"start": float(s["start"]), "end": float(s["end"]),
                           "speaker": s.get("speaker"), "text": s.get("text") or "",
                           "language": s.get("language") or "en"} for s in segments],
-            "started_at": iso(started), "ended_at": iso(ended), "source": "rehearse"},
+            "started_at": iso(started), "ended_at": iso(ended),
+            # `source` is a CLOSED vocabulary on the route — `import` | `seed` — and it refuses
+            # anything else with the list. It sent "rehearse" and got a 422 on the first live run.
+            # The route is RIGHT and the tool was wrong: these words did not come from a recording,
+            # they were imported from a fixture by a double, which is exactly what `seed` means.
+            # Widening the vocabulary to admit a caller's own name for itself would make the column
+            # unreadable, which is the column's whole job.
+            "source": source or "seed"},
             timeout=180)
         if st != 200 or not isinstance(body, dict):
             raise DoorRefused(f"transcript-import refused on meeting {mid}: {st} {str(body)[:300]}")
@@ -398,9 +412,29 @@ class LiveDoors(Doors):
                 "started_epoch": int(started), "ended_epoch": int(ended),
                 "start_time": m.get("start_time"), "end_time": m.get("end_time")}
 
+    def _meetings_of(self, owner: str) -> list:
+        """This subject's meetings — and a REFUSAL IS NOT AN EMPTY LIST.
+
+        Both callers used to read the response as `(b or {}).get("meetings", [])`, which turns any
+        non-2xx into "this person has no meetings". Found live: the list was requested with
+        `?limit=200`, the route caps it at 100 and answered 422, and `subject_reset` reported
+        `meetings: 0` with a row sitting right there — then the next run of that state was refused
+        with a 409 nobody could explain. The other caller is worse: `seed_meeting` asks this to
+        decide whether a completed row already exists, so a swallowed refusal would have minted a
+        SECOND completed meeting and mailed the whole room twice.
+
+        This is the defect the whole package is written against, in its own code: a call that fails
+        and is read as "nothing to do".
+        """
+        st, b = self._gw(owner, "GET", f"/meetings?limit={MEETINGS_PAGE_MAX}")
+        if st != 200 or not isinstance(b, dict) or "meetings" not in b:
+            raise DoorRefused(
+                f"could not list meetings for {owner}: {st} {str(b)[:200]}. Refusing to read that "
+                f"as 'no meetings' — every caller here decides something destructive from it.")
+        return list(b.get("meetings") or [])
+
     def _find_meeting(self, owner: str, native: str) -> dict | None:
-        st, b = self._gw(owner, "GET", "/meetings?limit=200")
-        rows = (b or {}).get("meetings", []) if isinstance(b, dict) else []
+        rows = self._meetings_of(owner)
         return next((r for r in rows if str(r.get("native_meeting_id")) == str(native)), None)
 
     def emit_fact(self, event_type: str, source_event_id: str, refs: dict) -> dict:
@@ -604,6 +638,30 @@ class LiveDoors(Doors):
                 "The route exists on this branch; the deployment needs the admin-api swap before "
                 "subject_reset can remove a user. Nothing was deleted.")
         raise DoorRefused(f"admin-api refused to delete uid {uid}: {st} {str(b)[:200]}")
+
+    def meetings_delete_for(self, subject: str) -> int:
+        """Every meeting this subject owns, deleted through the product's own `DELETE /meetings/{id}`.
+
+        Needed on its own, not only as part of the user delete: a run that fails BETWEEN
+        `POST /meetings` and the transcript import leaves a non-terminal row, and the next attempt
+        at that state is refused — correctly — with `409 a non-terminal meeting already holds this
+        native id`. Found live on run 2, where three states could not be re-entered for that
+        reason. Without this the only way out was a hand-written call.
+        """
+        rows = self._meetings_of(subject)
+        gone, refused = 0, []
+        for row in rows:
+            dst, body = self._gw(subject, "DELETE", f"/meetings/{row.get('id')}")
+            if dst in (200, 204):
+                gone += 1
+            else:
+                refused.append(f"{row.get('id')}:{dst}")
+        if refused:
+            # A delete that did not happen must not be counted as one. The caller reports this
+            # under `remaining`, and the next run of that state would otherwise meet a 409 it
+            # cannot explain.
+            raise DoorRefused(f"deleted {gone} meeting(s); refused: {', '.join(refused)}")
+        return gone
 
     def desk_delete(self, subject: str) -> dict:
         st, b = _http("DELETE", f"{AGENT_API}/api/workspace/{urllib.parse.quote(str(subject))}",

--- a/deploy/dogfood/rehearse/doors.py
+++ b/deploy/dogfood/rehearse/doors.py
@@ -132,6 +132,8 @@ class Doors:
         raise NotImplementedError
     def await_reaction(self, flow: str, since: float = 0.0, budget_s: int = 300) -> dict:
         raise NotImplementedError
+    def cancel_bot_leg(self, flow: str, source_contains: str = "") -> dict:
+        raise NotImplementedError
 
     # ── the per-subject harness (decisions 37 + 38) ──────────────────────────────────────────
     def bind_runner(self, subject: str, runner: str) -> dict: raise NotImplementedError
@@ -558,6 +560,42 @@ class LiveDoors(Doors):
             raise DoorRefused(f"admin-api refused the runner binding for {subject}: "
                               f"{st} {str(body)[:200]}")
         return {"subject": str(subject), "runner": runner, "config": cfg}
+
+    def cancel_bot_leg(self, flow: str, source_contains: str = "") -> dict:
+        """Cancel this recipe's own parked reaction — `POST /reactions/{id}/cancel`, the product's
+        audited lifecycle verb.
+
+        A REHEARSAL MUST LEAVE NOTHING ARMED. `invite_intake` parks on `await_start` until
+        start−2min and then dispatches a REAL bot at the invite's URL, and the states that use an
+        invite are rehearsing the PREPARE TOUCH — the bot leg is not what they measure. Leaving the
+        reaction parked means the run has armed a live dispatch at a fixture Zoom URL that fires on
+        the clock, long after the state was reported green. It happened: meeting 115 reached
+        `joining` at 19:20Z while the catalogue was still running.
+
+        Scoped by `source_contains` so it can only reach a reaction this recipe's own derived ids
+        name — never another lane user's parked work.
+        """
+        st, body = _http("GET", f"{FLOWS_API}/reactions?limit=100",
+                         {"X-Flows-Admin-Key": self._flows_key})
+        rows = (body or {}).get("reactions", []) if isinstance(body, dict) else []
+        if st != 200 or not isinstance(body, dict):
+            raise DoorRefused(f"could not list reactions to cancel the bot leg: {st}")
+        targets = [r for r in rows
+                   if r.get("flow") == flow
+                   and str(r.get("status")) in ("admitted", "retrying")
+                   and (not source_contains
+                        or source_contains in str(r.get("source_event_id") or ""))]
+        cancelled, refused = [], []
+        for r in targets:
+            rid = r.get("reaction_id") or r.get("id")
+            cst, cb = _http("POST", f"{FLOWS_API}/reactions/{rid}/cancel",
+                            {"X-Flows-Admin-Key": self._flows_key}, {})
+            (cancelled if 200 <= cst < 300 else refused).append(f"{rid}:{cst}")
+        if refused:
+            raise DoorRefused(
+                f"cancelled {len(cancelled)}, REFUSED {refused} — a parked invite reaction left "
+                f"behind will dispatch a real bot at a fixture URL when its clock arrives")
+        return {"flow": flow, "cancelled": len(cancelled), "ids": cancelled}
 
     # ── reads ─────────────────────────────────────────────────────────────────────────────────
     def user_find(self, address: str):

--- a/deploy/dogfood/rehearse/doors.py
+++ b/deploy/dogfood/rehearse/doors.py
@@ -17,8 +17,12 @@ rather than discovered later:
   2. `session_keys_delete()` / `scaffold_keys_delete()` in `subject_reset` clear redis by the
      exact per-subject prefixes `blank-instance.sh` documents, and nothing else. agent-api owns
      those keys and exposes no delete for them.
-  3. `friction_delete_for()` deletes that subject's friction rows from the flows lane. Same
-     shape: the rows are per-subject, and no route removes them.
+  3. `lane_rows_delete_for()` deletes that subject's rows from the flows lanes — the reactions the
+     engine admitted for them, their receipts and signals, their mail threads, and their friction.
+     Same shape as the other two: the rows are per-subject and no route removes them. It is the
+     one that makes a state RE-ENTERABLE — `admit()` dedups on (source_event_id, flow), so a
+     reaction from an earlier run silently swallows the next invite (`admitted 0`, no prepare
+     mail, a step that waits out its budget for a touch nothing will send).
 
 `Doors` is a plain class with no HTTP in it, so `stub_doors.StubDoors` subclasses it and
 `run_all.py --stub` proves every recipe offline. `LiveDoors` is the only thing that talks to the
@@ -147,6 +151,8 @@ class Doors:
     def session_keys_delete(self, subject: str) -> int: raise NotImplementedError
     def scaffold_keys_delete(self, address: str) -> int: raise NotImplementedError
     def friction_delete_for(self, subject: str) -> int: raise NotImplementedError
+    def lane_rows_delete_for(self, subject: str, address: str) -> dict:
+        raise NotImplementedError
     def mail_delete_for(self, address: str) -> int: raise NotImplementedError
 
 
@@ -727,6 +733,69 @@ class LiveDoors(Doors):
         r = subprocess.run(["docker", "exec", f"{self.stack}-redis-1", cli, *args],
                            capture_output=True, text=True, timeout=60)
         return r.stdout or ""
+
+    #: The lane tables that hold ONE PERSON'S rows, in FK order — receipts and signals reference a
+    #: reaction, so the reaction goes last. The same order `blank-instance.sh` documents, and the
+    #: same list minus the lane-wide ones (`mail_cursor` is the poller's watermark and belongs to
+    #: the deployment, not to a subject; deleting it would replay the whole box).
+    LANE_TABLES = ("effect_receipt", "signal", "reaction", "mail_thread", "mail_outbox_sent")
+
+    def lane_rows_delete_for(self, subject: str, address: str) -> dict:
+        """One subject's rows in every flows lane. THIS is what makes a state re-enterable.
+
+        `admit()` dedups on (source_event_id, flow), and a rehearsal's source ids are derived from
+        (state, subject, meeting) precisely so a re-run is idempotent. The other side of that coin:
+        after a reset the SAME ids must be admissible again, and they are not while the earlier
+        reaction is still in the lane. Found live — the poller logged `admitted 0` for a fresh
+        invite, no prepare mail was sent, and the step waited out its whole budget for a touch
+        nothing was ever going to produce.
+
+        MATCHED ON THE SUBJECT, never on a bare number: `"uid": "13"` must not take uid 130 with
+        it. Both JSON spellings, plus the address, which is how the invite lineage names a person.
+        """
+        out: dict = {}
+        for db in self._flow_lanes():
+            for table in self.LANE_TABLES:
+                where = self._lane_where(table, str(subject), address)
+                if not where:
+                    continue
+                r = subprocess.run(
+                    ["docker", "exec", f"{self.stack}-postgres-1", "psql", "-U", "postgres",
+                     "-d", db, "-tAc", f"DELETE FROM {table} WHERE {where};"],
+                    capture_output=True, text=True, timeout=30)
+                if r.returncode != 0:
+                    if "does not exist" in (r.stderr or ""):
+                        continue                     # lanes differ; absent is not a failure
+                    raise DoorRefused(
+                        f"could not clear {db}.{table} for {address}: "
+                        f"{(r.stderr or '').strip()[:200]}. Refusing to report a reset that would "
+                        f"leave this state un-re-enterable.")
+                n = _int((r.stdout or "").replace("DELETE", ""))
+                if n:
+                    out[f"{db}.{table}"] = n
+        return out
+
+    @staticmethod
+    def _lane_where(table: str, subject: str, address: str) -> str:
+        """The per-subject predicate for one lane table, or "" when the table names no person —
+        in which case it is left alone rather than guessed at."""
+        def q(v: str) -> str:
+            return "'" + str(v).replace("'", "''") + "'"
+
+        # MATCHED ON THE SUBJECT, never on a bare number: `%13%` would take uid 130 with it. Both
+        # JSON spellings of the key, plus the address, which is how the invite lineage names a
+        # person before any uid exists.
+        naming = " OR ".join(
+            f"{{col}} LIKE {q('%' + pat + '%')}"
+            for pat in (f'"uid": "{subject}"', f'"uid":"{subject}"', address))
+        if table in ("effect_receipt", "signal"):
+            inner = naming.format(col="r.subject_refs")
+            return f"reaction_id IN (SELECT reaction_id FROM reaction r WHERE {inner})"
+        if table == "reaction":
+            return naming.format(col="subject_refs")
+        if table in ("mail_thread", "mail_outbox_sent"):
+            return f"subject_uid = {q(subject)}"
+        return ""
 
     def friction_delete_for(self, subject: str) -> int:
         n = 0

--- a/deploy/dogfood/rehearse/engine.py
+++ b/deploy/dogfood/rehearse/engine.py
@@ -35,7 +35,16 @@ from . import catalogue as cat
 from .doors import DoorRefused, Doors
 
 DEFAULT_MEETING = "2026-03-02"
-DEFAULT_WHEN = "+30m"
+# FAR ENOUGH OUT THAT A RUN CANNOT OUTLIVE IT. `invite_intake` parks on `await_start` until
+# start−2min and then dispatches a REAL bot at the invite's URL. At +30m a catalogue run — three
+# states with a 677-segment import and an agent turn each — reached start−2min while it was still
+# going, and a bot was dispatched at the fixture Zoom URL (meeting 115, status `joining`, 2026-09-02
+# 19:20Z). +3h is the ledger's own figure, chosen for this exact reason at station 2; not carrying
+# it over is what cost this.
+#
+# The default is a floor, not the fix: `cancel_bot_leg` below is the fix, because a rehearsal must
+# leave nothing armed no matter how long it ran.
+DEFAULT_WHEN = "+3h"
 
 
 class Refused(RuntimeError):
@@ -357,6 +366,8 @@ def _execute(step: cat.Step, args: dict, doors: Doors, bindings: dict, fixture: 
     if v == "await_reaction":
         return doors.await_reaction(args["flow"], float(args.get("since") or 0.0),
                                     int(args.get("budget_s") or 300))
+    if v == "cancel_bot_leg":
+        return doors.cancel_bot_leg(args["flow"], args.get("source_contains") or "")
     raise cat.CatalogueError(f"no executor for verb {v!r} — catalogue.VERBS and engine._execute "
                              f"have drifted apart")
 

--- a/deploy/dogfood/rehearse/engine.py
+++ b/deploy/dogfood/rehearse/engine.py
@@ -463,6 +463,13 @@ def subject_reset(address: str, *, doors: Doors, catalog: cat.Catalogue | None =
             out["removed"]["friction"] = doors.friction_delete_for(uid)
         except DoorRefused as e:
             out["remaining"]["friction"] = str(e)
+        try:
+            # The lane's dedup memory. Without this the subject is gone and the state still
+            # cannot be re-entered: `admit()` swallows the next invite as a duplicate and the
+            # touch that should follow is simply never sent.
+            out["removed"]["lane_rows"] = doors.lane_rows_delete_for(uid, address)
+        except DoorRefused as e:
+            out["remaining"]["lane_rows"] = str(e)
     try:
         out["removed"]["scaffolds"] = doors.scaffold_keys_delete(address)
     except DoorRefused as e:

--- a/deploy/dogfood/rehearse/engine.py
+++ b/deploy/dogfood/rehearse/engine.py
@@ -88,9 +88,24 @@ def guard_domain(addresses, domain: str, mailbox: str = "") -> None:
     `mailbox` is the address the deployment's own mail double answers as (`VEXA_MAIL_ADDR`). It is
     the product's identity, not a person's, and every invite is addressed to it; excluding it here
     is the one exception and it is named rather than pattern-matched.
+
+    IT CHECKS THE SHAPE, NOT ONLY THE SUFFIX. `endswith("@" + domain)` passes anything ending in
+    those characters and says nothing about the rest, so a value that is not an address at all —
+    a timestamp, an empty local part, a whole sentence — is judged only on its tail. That is how
+    a domainless account (`20260902t183213z`) reached the instance on 2026-09-02: not through this
+    guard, which never saw it, but the guard could not have stopped it either, and a safety check
+    that would have waved it through is not one.
     """
-    bad = sorted({a.lower() for a in addresses
-                  if not a.lower().endswith("@" + domain) and a.lower() != mailbox.lower()})
+    def refused(value: str) -> bool:
+        a = value.lower().strip()
+        if a == mailbox.lower().strip() and mailbox:
+            return False
+        local, sep, host = a.rpartition("@")
+        # No whitespace anywhere: `a b@rehearse.test` has the right tail and is not an address,
+        # and the display form `Real Person <a@b.test>` is the shape a header hands you unparsed.
+        return not (sep and local and host == domain and not any(c.isspace() for c in a))
+
+    bad = sorted({a.lower() for a in addresses if refused(a)})
     if bad:
         raise Refused(
             f"refusing: {', '.join(bad)} " + ("is" if len(bad) == 1 else "are") +

--- a/deploy/dogfood/rehearse/engine.py
+++ b/deploy/dogfood/rehearse/engine.py
@@ -222,6 +222,8 @@ def rehearse(state: str, as_: str, meeting: str = DEFAULT_MEETING, when: str = D
         "fixture_attendees": [a for _, a in attendees] + [subject],
         "fixture_attendee_names": {a: n for n, a in attendees},
         "_attendee_pairs": attendees,
+        # The floor every `await_mail` measures against — see `_execute`.
+        "_started": started,
     }
 
     # Everything the recipe will say, resolved as far as it can be, BEFORE anything is done. This
@@ -322,12 +324,19 @@ def _execute(step: cat.Step, args: dict, doors: Doors, bindings: dict, fixture: 
     if v == "seed_meeting":
         return doors.seed_meeting(str(args["owner"]), args["native"],
                                   args.get("title") or fixture["title"], fixture["segments"],
-                                  float(args.get("started_at") or (start_epoch - 3600)))
+                                  float(args.get("started_at") or (start_epoch - 3600)),
+                                  source=str(args.get("source") or "seed"))
     if v == "emit_fact":
         return doors.emit_fact(args["event_type"], args["source_event_id"], args["refs"])
     if v == "await_mail":
+        # `since` IS THE CHECK. Without it the step matched a message a PREVIOUS run had sent —
+        # found live on run 2, where `warm-desk-recurring` "found" run 1's Prepare mail, verified
+        # run 1's scaffold, and reported a state this run had not produced. A touch is evidence
+        # only if it is this run's touch; the floor is when this run started, and a recipe may
+        # raise it but never lower it.
         return doors.await_mail(args["to"], args.get("subject_contains") or "",
-                                int(args.get("budget_s") or 180))
+                                int(args.get("budget_s") or 180),
+                                since=float(args.get("since") or bindings["_started"]))
     if v == "reply_to_mail":
         return doors.reply_to_mail(bindings[args["to_mail"]], args["from_address"], args["body"])
     if v == "await_reaction":
@@ -367,8 +376,12 @@ def _verify(row: dict, bindings: dict, doors: Doors, res: Result) -> dict:
                     out["ok"] = False
                     out["detail"] += f" — expected kind {row['kind']}"
                 if row.get("desk_state"):
-                    got = ((rec.get("refs") or {}).get("state")
-                           or (rec.get("refs") or {}).get("desk"))
+                    # `refs.state` is an OBJECT — `{"desk": "new|pile|warm", "group": …}` — and
+                    # reading it as a string could never match, so the check FAILED on a state that
+                    # had worked. A check that cannot pass is worse than no check: it reports a
+                    # product defect where there is only a reader that guessed a shape.
+                    state = (rec.get("refs") or {}).get("state")
+                    got = state.get("desk") if isinstance(state, dict) else state
                     if got != row["desk_state"]:
                         out["ok"] = False
                         out["detail"] += f" — desk state {got!r}, expected {row['desk_state']!r}"
@@ -434,6 +447,10 @@ def subject_reset(address: str, *, doors: Doors, catalog: cat.Catalogue | None =
 
     # Order matters: the desk and the redis keys are addressed BY uid, so the user goes last.
     if uid:
+        try:
+            out["removed"]["meetings"] = doors.meetings_delete_for(uid)
+        except DoorRefused as e:
+            out["remaining"]["meetings"] = str(e)
         try:
             out["removed"]["desk"] = doors.desk_delete(uid)
         except DoorRefused as e:

--- a/deploy/dogfood/rehearse/run_all.py
+++ b/deploy/dogfood/rehearse/run_all.py
@@ -19,12 +19,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import pathlib
 import sys
 import time
 
 from . import catalogue as cat
 from .doors import Doors, LiveDoors
 from .engine import DEFAULT_MEETING, DEFAULT_WHEN, Refused, rehearse
+
+#: Where a finding goes when the intake cannot take it. Overridable, because a run on a host with
+#: a read-only /tmp still has to be able to keep its findings.
+FRICTION_FALLBACK = pathlib.Path(
+    os.environ.get("VEXA_REHEARSE_FRICTION_LOG", "/tmp/rehearse-friction.jsonl"))
 
 
 def file_friction(doors_kind: str, state: str, res, reporter) -> dict:
@@ -52,11 +59,24 @@ def file_friction(doors_kind: str, state: str, res, reporter) -> dict:
             + f"  ·  failed checks: {', '.join(v['check'] for v in failed) or 'none'}"),
         "error": symptom[:900],
     }
+    # THE FILE FIRST, ALWAYS — the rig's own rule for `report_friction`, and it earned its place
+    # here on the first live run: `POST /api/friction` is not on the deployed agent-api image yet
+    # (#1412), so every record 404'd. A finding that exists only in a 404 is a finding nobody has.
+    # The file is the fallback, never the store: the intake below is still the destination.
+    try:
+        FRICTION_FALLBACK.parent.mkdir(parents=True, exist_ok=True)
+        with FRICTION_FALLBACK.open("a") as f:
+            f.write(json.dumps({"at": time.time(), "state": state, **rec}) + "\n")
+        rec["written_to"] = str(FRICTION_FALLBACK)
+    except OSError as e:
+        rec["written_to"] = f"FAILED: {e}"
     if reporter:
         try:
             reporter(rec)
             rec["filed"] = True
         except Exception as e:                                     # noqa: BLE001
+            # A 404 here is NOT a pass and never becomes one: the record is on disk, the run is
+            # still red, and the report says the intake refused it and where the record went.
             rec["filed"] = False
             rec["file_error"] = f"{type(e).__name__}: {e}"
     return rec
@@ -105,7 +125,13 @@ def render(report: dict) -> str:
     lines.append(f"{report['passed']}/{report['ran']} states green in {report['wall_s']}s"
                  + (f" · failed: {', '.join(report['failed'])}" if report["failed"] else ""))
     if report["friction"]:
-        lines.append(f"{len(report['friction'])} friction record(s) filed (decision 33)")
+        filed = sum(1 for f in report["friction"] if f.get("filed"))
+        unfiled = [f for f in report["friction"] if not f.get("filed")]
+        lines.append(f"{len(report['friction'])} friction record(s): {filed} filed to the intake "
+                     f"(decision 33), {len(unfiled)} written to "
+                     f"{report['friction'][0].get('written_to', FRICTION_FALLBACK)}")
+        if unfiled:
+            lines.append(f"  the intake refused them: {unfiled[0].get('file_error', '?')}")
     return "\n".join(lines)
 
 

--- a/deploy/dogfood/rehearse/states.yaml
+++ b/deploy/dogfood/rehearse/states.yaml
@@ -318,6 +318,21 @@ states:
         facts:
           - "The series met again and the report landed on this desk."
         source: "rehearse:{{state}}"
+      # `desk_state()` is the product's classifier and its vocabulary is not ours: meeting entities
+      # ALONE are a `pile` — "reports landed and nobody wired them", decision 22's economics —
+      # and it takes a NON-meeting entity for a desk to read `warm` ("somebody has worked here").
+      # The first live run failed here, correctly: two prior reports made a pile, not a warm desk.
+      # A warm desk really does carry both, so the recipe now writes both rather than arguing with
+      # the classifier.
+      - do: desk_entity
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+        kind: person
+        name: "{{subject_local}}"
+        summary: "The subject's own page — what makes this desk worked-in rather than a pile."
+        facts:
+          - "Attends the {{title}} series."
+        source: "rehearse:{{state}}"
       - do: drop_invite
         door: smtp
         organizer: "{{subject}}"

--- a/deploy/dogfood/rehearse/states.yaml
+++ b/deploy/dogfood/rehearse/states.yaml
@@ -119,6 +119,15 @@ states:
         to: "{{subject}}"
         subject_contains: "Prepare"
         as: prepare_mail
+      # A REHEARSAL LEAVES NOTHING ARMED. `invite_intake` parks on `await_start` until start−2min
+      # and then dispatches a REAL bot at the invite's URL — and this state rehearses the PREPARE
+      # touch, not the bot leg. Left parked, the run arms a live dispatch at a fixture Zoom URL
+      # that fires on the clock long after the state was reported green: on 2026-09-02 meeting 115
+      # reached `joining` while the catalogue was still running.
+      - do: cancel_bot_leg
+        door: flows-api
+        flow: invite_intake
+        source_contains: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
     artefacts:
       mail: "RSVP (\"Accepted\") and \"Prepare: {{title}}\" to {{subject}}"
       link: the prepare mail's only link is /?s=<scaffold id> (kind `prep`)
@@ -345,6 +354,10 @@ states:
         to: "{{subject}}"
         subject_contains: "Prepare"
         as: prepare_mail
+      - do: cancel_bot_leg          # same reason as organizer-invited: disarm the bot leg
+        door: flows-api
+        flow: invite_intake
+        source_contains: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
     artefacts:
       mail: "\"Prepare: {{title}}\" to {{subject}}"
       link: "/?s=<scaffold id> (kind `prep`) whose refs carry `state: warm`"

--- a/deploy/dogfood/rehearse/stub_doors.py
+++ b/deploy/dogfood/rehearse/stub_doors.py
@@ -12,6 +12,7 @@ good. Those need the stack and, for the last one, a person.
 """
 from __future__ import annotations
 
+import json
 import re
 import time
 
@@ -294,6 +295,16 @@ class StubDoors(Doors):
 
     def friction_delete_for(self, subject: str) -> int:
         return 0
+
+    def lane_rows_delete_for(self, subject: str, address: str) -> dict:
+        """Drop this subject's admitted facts, so the same derived ids are admissible again —
+        the model of `admit()`'s dedup being per-subject-clearable."""
+        gone = [f for f in self.facts
+                if str(subject) in json.dumps(f.get("refs") or {})
+                or address in json.dumps(f.get("refs") or {})]
+        self.facts = [f for f in self.facts if f not in gone]
+        self.reactions = [r for r in self.reactions if r.get("subject") not in (str(subject),)]
+        return {"facts": len(gone)} if gone else {}
 
     def mail_delete_for(self, address: str) -> int:
         before = len(self.mail)

--- a/deploy/dogfood/rehearse/stub_doors.py
+++ b/deploy/dogfood/rehearse/stub_doors.py
@@ -132,6 +132,11 @@ class StubDoors(Doors):
         mid = self._id()
         self.meetings[mid] = {"id": mid, "native_meeting_id": ics_uid or mid, "status": "scheduled",
                               "owner": uid, "title": title}
+        # `invite_intake` PARKS on `await_start` and then dispatches a real bot. Modelled, because
+        # the thing the recipe has to prove is that it leaves nothing armed.
+        self.reactions.append({"flow": "invite_intake", "state": "retrying", "id": self._id("r"),
+                               "created_at": time.time(),
+                               "source_event_id": f"ics-{ics_uid}::invite_intake"})
         self.calls.append(("drop_invite", organizer, title, group))
         return {"ics_uid": ics_uid, "to": "vexa@storm.test", "organizer": organizer,
                 "start": start, "attendees": [a for _, a in attendees]}
@@ -240,6 +245,14 @@ class StubDoors(Doors):
             return "new"
         other = [f for f in files if "/meeting/" not in f and not f.endswith("index.md")]
         return "warm" if other else "pile"
+
+    def cancel_bot_leg(self, flow: str, source_contains: str = "") -> dict:
+        live = [r for r in self.reactions
+                if r["flow"] == flow and r["state"] in ("admitted", "running", "retrying")]
+        for r in live:
+            r["state"] = "cancelled"
+        self.calls.append(("cancel_bot_leg", flow))
+        return {"flow": flow, "cancelled": len(live), "ids": [r["id"] for r in live]}
 
     # -- reads -----------------------------------------------------------------------------------
     def user_find(self, address: str):

--- a/deploy/dogfood/rehearse/stub_doors.py
+++ b/deploy/dogfood/rehearse/stub_doors.py
@@ -57,7 +57,13 @@ class StubDoors(Doors):
     def require_instance_blank(self) -> dict:
         self.calls.append(("require_instance_blank",))
         if not self._blank:
-            raise DoorRefused("the instance is NOT blank: an admin has claimed it")
+            # Word for word the live refusal (`LiveDoors.require_instance_blank`): a double whose
+            # error text differs from the door's teaches a caller to handle a message the stack
+            # never sends.
+            raise DoorRefused(
+                "the instance is NOT blank: an admin has claimed it and the company layer is "
+                "completed. `blank-admin` asserts this state, it never creates it — blanking "
+                "deletes every person on the stack and is `bin/blank-instance.sh`, run on purpose.")
         return {"blank": True}
 
     def require_subject_absent(self, address: str) -> dict:
@@ -119,7 +125,7 @@ class StubDoors(Doors):
         self._send(organizer, f"Accepted: {title}", "Vexa will be there.")
         link = self._scaffold("prep", organizer,
                               {"title": title, "when": start, "organizer": organizer,
-                               "state": "warm" if len(self.desks.get(uid, [])) > 1 else "new"})
+                               "state": {"desk": self._desk_state(uid), "group": "absent"}})
         self._send(organizer, f"Prepare: {title}",
                    f"{title} — I'll be in the room. Open the chat: {link}\n")
         mid = self._id()
@@ -129,8 +135,17 @@ class StubDoors(Doors):
         return {"ics_uid": ics_uid, "to": "vexa@storm.test", "organizer": organizer,
                 "start": start, "attendees": [a for _, a in attendees]}
 
+    #: `transcript-import`'s own vocabulary, from its 422. A double that accepts what the real
+    #: route refuses certifies a broken caller — which is exactly what happened on the first live
+    #: run: three states passed here and 422'd there.
+    IMPORT_SOURCES = ("import", "seed")
+
     def seed_meeting(self, owner: str, native: str, title: str, segments: list,
-                     started_at: float) -> dict:
+                     started_at: float, source: str = "seed") -> dict:
+        if source not in self.IMPORT_SOURCES:
+            raise DoorRefused(
+                f"'source' must be one of {list(self.IMPORT_SOURCES)} — say where the transcript "
+                f"came from (got {source!r})")
         for row in self.meetings.values():            # adopt, exactly as LiveDoors does
             if row["native_meeting_id"] == native and row["status"] == "completed":
                 return {"meeting_id": row["id"], "native_meeting_id": native, "platform": "jitsi",
@@ -186,6 +201,8 @@ class StubDoors(Doors):
                 continue
             if subject_contains and subject_contains.lower() not in msg["subject"].lower():
                 continue
+            if since and msg["at"] < since - 5:
+                continue          # a previous run's touch is not this run's evidence
             return dict(msg)
         raise DoorRefused(f"no mail to {to} containing {subject_contains!r}")
 
@@ -211,6 +228,17 @@ class StubDoors(Doors):
         self.runners[str(subject)] = cfg
         self.calls.append(("bind_runner", subject, runner))
         return {"subject": str(subject), "runner": runner, "config": cfg}
+
+    def _desk_state(self, subject: str) -> str:
+        """`new` | `pile` | `warm`, by the product's rule (`control_plane/scaffolds.desk_state`):
+        meeting entities ALONE are a pile — reports landed and nobody wired them — and it takes a
+        non-meeting entity for somebody to have worked here. Mirrored rather than invented, because
+        the recipe asserts against it and a double with its own opinion proves nothing."""
+        files = [f for f in self.desks.get(str(subject), []) if "kg/entities/" in f]
+        if not files:
+            return "new"
+        other = [f for f in files if "/meeting/" not in f and not f.endswith("index.md")]
+        return "warm" if other else "pile"
 
     # -- reads -----------------------------------------------------------------------------------
     def user_find(self, address: str):
@@ -245,6 +273,12 @@ class StubDoors(Doors):
             if row.get("owner") == str(uid):
                 del self.meetings[mid]
         return {"deleted": True, "via": "admin-api"}
+
+    def meetings_delete_for(self, subject: str) -> int:
+        gone = [m for m, row in self.meetings.items() if row.get("owner") == str(subject)]
+        for m in gone:
+            del self.meetings[m]
+        return len(gone)
 
     def desk_delete(self, subject: str) -> dict:
         return {"deleted": self.desks.pop(str(subject), None) is not None}

--- a/deploy/dogfood/rehearse/tests/test_catalogue.py
+++ b/deploy/dogfood/rehearse/tests/test_catalogue.py
@@ -42,7 +42,7 @@ def test_every_verb_has_a_door_method_and_every_door_method_is_a_verb():
     reads = {"user_find", "meeting_get", "desk_tree", "group_members", "scaffold_get",
              "live_meetings", "user_delete", "desk_delete", "session_keys_delete",
              "scaffold_keys_delete", "friction_delete_for", "mail_delete_for",
-             "bind_runner", "meetings_delete_for"}
+             "bind_runner", "meetings_delete_for", "lane_rows_delete_for"}
     assert set(cat.VERBS) <= methods
     assert methods - reads == set(cat.VERBS)
 

--- a/deploy/dogfood/rehearse/tests/test_catalogue.py
+++ b/deploy/dogfood/rehearse/tests/test_catalogue.py
@@ -42,7 +42,7 @@ def test_every_verb_has_a_door_method_and_every_door_method_is_a_verb():
     reads = {"user_find", "meeting_get", "desk_tree", "group_members", "scaffold_get",
              "live_meetings", "user_delete", "desk_delete", "session_keys_delete",
              "scaffold_keys_delete", "friction_delete_for", "mail_delete_for",
-             "bind_runner"}
+             "bind_runner", "meetings_delete_for"}
     assert set(cat.VERBS) <= methods
     assert methods - reads == set(cat.VERBS)
 

--- a/deploy/dogfood/rehearse/tests/test_guards.py
+++ b/deploy/dogfood/rehearse/tests/test_guards.py
@@ -123,3 +123,33 @@ def test_a_dry_run_resolves_the_whole_plan_and_touches_nothing():
     assert res.ok and len(res.steps) == len(CAT["group-member"].steps)
     assert doors.calls == []
     assert time.time() > 0
+
+
+# ── F94: the guard checks the SHAPE, not only the suffix ─────────────────────────────────────────
+
+@pytest.mark.parametrize("value", [
+    "20260902t183213z",          # the DTSTAMP that became user 131 on the instance
+    "",
+    "@rehearse.test",            # a domain with nobody in front of it
+    "someone@",
+    "someone@evil.test",
+    "rehearse.test",             # the domain as a bare word — `endswith` would have judged only
+    "a b@rehearse.test",         # a space is not part of an address
+])
+def test_a_value_that_is_not_an_address_under_the_domain_is_refused(value):
+    """`endswith("@" + domain)` passes anything ending in those characters and says nothing about
+    the rest. A safety check that would wave a timestamp through is not one."""
+    with pytest.raises(Refused):
+        guard_domain([value], "rehearse.test")
+
+
+@pytest.mark.parametrize("value", ["a@rehearse.test", "rehearse-group-member@rehearse.test",
+                                   "OLGA-AVRAMENKO@REHEARSE.TEST"])
+def test_a_real_address_under_the_domain_still_passes(value):
+    guard_domain([value], "rehearse.test")
+
+
+def test_a_subdomain_is_not_the_domain():
+    """`evil.rehearse.test` ends with the domain and is somebody else's host."""
+    with pytest.raises(Refused):
+        guard_domain(["a@evil.rehearse.test"], "rehearse.test")

--- a/deploy/dogfood/rehearse/tests/test_hot.py
+++ b/deploy/dogfood/rehearse/tests/test_hot.py
@@ -31,6 +31,7 @@ MAY_SHELL_OUT = {
     "live_meetings",        # the fail-closed guard: no instance-wide live-meeting route exists
     "_redis_cli", "_redis", "_redis_del",   # per-subject session/scaffold keys agent-api owns
     "friction_delete_for", "_flow_lanes",   # per-subject friction rows no route removes
+    "lane_rows_delete_for",                 # per-subject reactions/receipts/threads, ditto
     "_admin_key",           # reading this deployment's own admin token, when it is not in the env
 }
 
@@ -84,8 +85,10 @@ def test_nothing_writes_the_database_or_the_workspace_volume():
     src = (PKG / "doors.py").read_text()
     assert "INSERT" not in src and "UPDATE " not in src
     # One DELETE, and it is the per-subject friction rows the docstring names.
-    deletes = re.findall(r"DELETE FROM (\w+)", src)
-    assert deletes == ["friction"], deletes
+    # The per-subject lane tables the reset owns — named, in FK order, and nothing else. The
+    #  `{table}` is `LANE_TABLES`, which the docstring above it lists and bounds.
+    deletes = sorted(set(re.findall(r"DELETE FROM (\{?\w+\}?)", src)))
+    assert deletes == ["friction", "{table}"], deletes
     assert "cat > /workspaces" not in src and "/workspaces/" not in src
 
 

--- a/deploy/dogfood/rehearse/tests/test_live_lessons.py
+++ b/deploy/dogfood/rehearse/tests/test_live_lessons.py
@@ -91,3 +91,51 @@ def test_blank_admin_refuses_on_a_claimed_instance_which_is_the_live_answer(cata
                    catalog=catalog, env=env)
     assert not res.ok
     assert "NOT blank" in res.error and "blank-instance.sh" in res.error
+
+
+# ── run 4's lesson: a rehearsal must leave NOTHING armed ─────────────────────────────────────────
+
+def test_every_state_that_drops_an_invite_disarms_its_bot_leg(catalog):
+    """`invite_intake` parks on `await_start` until start−2min and then dispatches a REAL bot at
+    the invite's URL. These states rehearse the PREPARE TOUCH; the bot leg is not what they
+    measure, and leaving it parked arms a live dispatch at a fixture Zoom URL that fires on the
+    clock long after the state was reported green.
+
+    It happened on 2026-09-02: meeting 115 reached `joining` at 19:20Z while the catalogue was
+    still running, because the run outlived a `+30m` start.
+    """
+    for name, st in catalog.states.items():
+        verbs = [step.do for step in st.steps]
+        if "drop_invite" not in verbs:
+            continue
+        assert "cancel_bot_leg" in verbs, f"{name} drops an invite and never disarms it"
+        assert verbs.index("cancel_bot_leg") > verbs.index("drop_invite"), name
+
+
+def test_the_default_start_cannot_be_reached_by_a_run_s_own_wall_clock():
+    """A floor, not the fix. Three states with a 677-segment import and an agent turn each ran for
+    well over half an hour; `+30m` put start−2min inside that window."""
+    from rehearse.engine import DEFAULT_WHEN, parse_when
+    assert parse_when(DEFAULT_WHEN, 0.0) >= 3 * 3600
+
+
+def test_the_state_actually_cancels_the_parked_reaction(catalog, env):
+    doors = StubDoors()
+    res = rehearse("organizer-invited", "rehearse-organizer-invited@rehearse.test", doors=doors,
+                   catalog=catalog, env=env)
+    assert res.ok, res.error
+    parked = [r for r in doors.reactions
+              if r["flow"] == "invite_intake" and r["state"] != "cancelled"]
+    assert not parked, f"the run left a parked invite reaction: {parked}"
+
+
+def test_a_cancel_that_is_refused_fails_the_state_rather_than_passing_quietly(catalog, env):
+    """The one outcome that must never be silent: a reaction we could not disarm is a bot that
+    will be dispatched."""
+    class NoCancel(StubDoors):
+        def cancel_bot_leg(self, flow, source_contains=""):
+            raise DoorRefused("cancelled 0, REFUSED ['r1:500']")
+    res = rehearse("organizer-invited", "rehearse-organizer-invited@rehearse.test",
+                   doors=NoCancel(), catalog=catalog, env=env)
+    assert not res.ok
+    assert "REFUSED" in res.error

--- a/deploy/dogfood/rehearse/tests/test_live_lessons.py
+++ b/deploy/dogfood/rehearse/tests/test_live_lessons.py
@@ -1,0 +1,93 @@
+"""What the FIRST live run against the sim lane taught, held as tests.
+
+Three of the six states failed on the stack and passed offline, which is the whole reason a stub
+is not enough — each failure was a place where this package had guessed at a shape the product
+defines. None of them was a product defect; all three were this tool being confidently wrong.
+
+    attendee-stranger-minutes   422  'source' must be one of ['import', 'seed']
+    group-member                422  (same)
+    reply-pending               422  (same)
+    warm-desk-recurring         scaffold_resolves FAIL — desk state, read as the wrong TYPE
+
+The stub could not have caught any of them: it answered whatever it was asked. So the stub now
+enforces the product's vocabulary too — a double that accepts what the real door refuses is a
+double that certifies a broken caller.
+"""
+from __future__ import annotations
+
+import pytest
+
+from rehearse.doors import DoorRefused
+from rehearse.engine import rehearse
+from rehearse.stub_doors import StubDoors
+
+# The route's closed vocabulary, from its own 422: "'source' must be one of ['import', 'seed']".
+IMPORT_SOURCES = ("import", "seed")
+
+
+def test_the_transcript_import_declares_a_source_the_route_accepts():
+    """`source: "rehearse"` was refused 422 on three states. These words came from a fixture via a
+    double, which is what `seed` means; the route's vocabulary is right and was not widened."""
+    import inspect
+
+    from rehearse import doors
+    for door in (doors.Doors, doors.LiveDoors):
+        default = inspect.signature(door.seed_meeting).parameters["source"].default
+        assert default in IMPORT_SOURCES, (
+            f"{door.__name__}.seed_meeting defaults `source` to {default!r}; the import route "
+            f"answers 422 with the list {list(IMPORT_SOURCES)} for anything else")
+        assert default == "seed", "a fixture through a double is a seed, not an import"
+
+
+def test_the_stub_refuses_a_source_the_real_route_would_refuse(catalog, env):
+    """The stub's job is to fail where the stack fails. It answered 200 to `source: "rehearse"`
+    and certified three states that could not run."""
+    doors = StubDoors()
+    with pytest.raises(DoorRefused, match="must be one of"):
+        doors.seed_meeting("1", "native-x", "T", [{"start": 0, "end": 1}], 0.0, source="rehearse")
+
+
+def test_the_desk_state_in_a_scaffold_is_an_object_not_a_string(catalog, env):
+    """`refs.state` is `{"desk": …, "group": …}`. Read as a string the check could never pass, so
+    it reported a product defect where the state had actually worked."""
+    doors = StubDoors()
+    res = rehearse("warm-desk-recurring", "rehearse-warm-desk-recurring@rehearse.test",
+                   doors=doors, catalog=catalog, env=env)
+    assert res.ok, [v for v in res.verify if not v["ok"]]
+    sc = next(iter(doors.scaffolds.values()))
+    assert isinstance(sc["refs"]["state"], dict)
+    assert sc["refs"]["state"]["desk"] == "warm"
+
+
+def test_a_wrong_desk_state_still_fails_the_check(catalog, env):
+    """The fix must not have turned the check off: a scaffold whose desk state is not what the
+    recipe declared is still a FAIL."""
+    class Pile(StubDoors):
+        def _desk_state(self, uid):                       # every desk reads as a pile
+            return "pile"
+    res = rehearse("warm-desk-recurring", "rehearse-warm-desk-recurring@rehearse.test",
+                   doors=Pile(), catalog=catalog, env=env)
+    bad = [v for v in res.verify if v["check"] == "scaffold_resolves"]
+    assert bad and not bad[0]["ok"]
+    assert "'pile', expected 'warm'" in bad[0]["detail"]
+
+
+def test_two_meeting_reports_alone_are_a_pile_not_a_warm_desk(catalog, env):
+    """The product's classifier, in its own words: meeting entities alone are a `pile` (decision
+    22's economics — reports landed, nobody wired them); it takes a non-meeting entity to be
+    `warm`. The recipe writes both rather than arguing with the classifier."""
+    doors = StubDoors()
+    rehearse("warm-desk-recurring", "rehearse-warm-desk-recurring@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    kinds = [c[2] for c in doors.calls if c[0] == "desk_entity"]
+    assert kinds.count("meeting") == 2 and "person" in kinds
+
+
+def test_blank_admin_refuses_on_a_claimed_instance_which_is_the_live_answer(catalog, env):
+    """The live run's `blank-admin` failure is this refusal, and it is CORRECT: the dogfood stack
+    has an admin and a committed company layer. The state asserts that precondition; it never
+    creates it, because creating it means deleting every person on the stack."""
+    res = rehearse("blank-admin", "admin@rehearse.test", doors=StubDoors(blank=False),
+                   catalog=catalog, env=env)
+    assert not res.ok
+    assert "NOT blank" in res.error and "blank-instance.sh" in res.error

--- a/deploy/dogfood/rehearse/tests/test_reset.py
+++ b/deploy/dogfood/rehearse/tests/test_reset.py
@@ -90,11 +90,30 @@ def test_the_state_can_be_re_entered_immediately_after_a_reset(catalog, env):
 
 
 def test_fresh_resets_the_organizer_too_or_the_fact_would_dedup_the_touch_away(catalog, env):
+    """The lane's dedup memory is the thing that has to go, and it belongs to BOTH people.
+
+    `admit()` dedups on (source_event_id, flow) and a rehearsal's ids are derived from
+    (state, subject, meeting) — deliberately, so a plain re-run is idempotent. The cost is that a
+    re-entry needs the earlier row cleared, and the meeting the fact names belongs to the ORGANIZER
+    the recipe derives, not to the subject. Reset only the subject and the fact is swallowed as a
+    duplicate: no touch is sent, and the step waits out its budget for a mail nothing will produce.
+    That is what the sim lane logged as `admitted 0`.
+    """
     doors = StubDoors()
     who = "rehearse-attendee-stranger-minutes@rehearse.test"
-    rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env)
+    first = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env)
     organizer = f"organizer-{who.split('@')[0]}@rehearse.test"
-    assert doors.user_find(organizer)
-    rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env, fresh=True)
-    facts = [f["source_event_id"] for f in doors.facts]
-    assert len(set(facts)) == 2, f"the re-entry must mint a new fact id, got {facts}"
+    assert first.ok and doors.user_find(organizer)
+    stale = [f["source_event_id"] for f in doors.facts]
+    assert stale
+
+    again = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env,
+                     fresh=True)
+    assert again.ok, again.error
+    assert again.links, "a re-entered state must produce a touch, not a deduped silence"
+    # ONE fact in the lane, not two: the earlier one went with the organizer's reset, and the
+    # re-entry admitted its own. Its id differs because it names the meeting ROW, which is new —
+    # both halves matter, and either alone would let the touch be swallowed as a duplicate.
+    fresh_ids = [f["source_event_id"] for f in doors.facts]
+    assert len(fresh_ids) == 1, f"the stale fact survived the reset: {fresh_ids}"
+    assert fresh_ids != stale

--- a/deploy/dogfood/rehearse/tests/test_run_all.py
+++ b/deploy/dogfood/rehearse/tests/test_run_all.py
@@ -69,3 +69,47 @@ def test_the_rendered_report_names_every_state_and_the_score(catalog, env):
     for name in catalog.states:
         assert name in text
     assert f"{len(catalog.states)}/{len(catalog.states)} states green" in text
+
+
+# ── a finding must survive an intake that is not there ───────────────────────────────────────────
+
+def test_a_finding_lands_on_disk_even_when_the_intake_is_missing(catalog, env, tmp_path,
+                                                                 monkeypatch):
+    """`POST /api/friction` is not on the deployed agent-api image yet (#1412), so every record
+    404'd on the first live run. A finding that exists only in a 404 is a finding nobody has —
+    and a 404 is never allowed to read as a pass."""
+    import json as _json
+
+    from rehearse import run_all as ra
+    log = tmp_path / "friction.jsonl"
+    monkeypatch.setattr(ra, "FRICTION_FALLBACK", log)
+
+    def intake_404(_rec):
+        raise RuntimeError("friction intake answered 404: {'detail': 'Not Found'}")
+
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains="", budget_s=180, since=0.0):
+            raise DoorRefused("no mail arrived")
+
+    report = ra.run(NoMail(), catalog=catalog, env=env, reporter=intake_404)
+    assert report["failed"], "a refused intake must not turn a red run green"
+    assert all(f["filed"] is False for f in report["friction"])
+    rows = [_json.loads(ln) for ln in log.read_text().splitlines()]
+    assert len(rows) == len(report["friction"])
+    assert {r["state"] for r in rows} == set(report["failed"])
+    assert all("python -m rehearse.run_all --only" in r["what_would_have_helped"] for r in rows)
+
+
+def test_the_rendered_report_says_the_intake_refused_and_where_the_records_went(catalog, env,
+                                                                                tmp_path,
+                                                                                monkeypatch):
+    from rehearse import run_all as ra
+    monkeypatch.setattr(ra, "FRICTION_FALLBACK", tmp_path / "friction.jsonl")
+
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains="", budget_s=180, since=0.0):
+            raise DoorRefused("no mail arrived")
+
+    text = ra.render(ra.run(NoMail(), catalog=catalog, env=env,
+                            reporter=lambda _r: (_ for _ in ()).throw(RuntimeError("404"))))
+    assert "written to" in text and "the intake refused them" in text

--- a/deploy/dogfood/rehearse/tests/test_since.py
+++ b/deploy/dogfood/rehearse/tests/test_since.py
@@ -1,0 +1,142 @@
+"""A touch is evidence only if it is THIS run's touch — run 2's lesson, held as a test.
+
+`await_mail` had no floor, so it matched a message an earlier run had sent. On the sim lane that
+made `warm-desk-recurring` verify run 1's Prepare mail and run 1's scaffold, and report on a state
+run 2 had not produced. It looked like a product defect (`desk state 'pile', expected 'warm'`) and
+it was a reader accepting stale evidence — the same class as a hash comparison that goes stale, and
+the reason the doctrine is *positive evidence*, never inequality against a remembered value.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from rehearse.doors import DoorRefused
+from rehearse.engine import rehearse, subject_reset
+from rehearse.stub_doors import StubDoors
+
+WHO = "rehearse-organizer-invited@rehearse.test"
+
+
+def test_a_previous_run_s_mail_is_not_this_run_s_evidence(catalog, env):
+    """The reproduction. The mail is there, addressed correctly, with the right subject — and it
+    is old, so the step must keep waiting rather than accept it."""
+    class SilentInvite(StubDoors):
+        """The invite lands but the lane sends nothing back — a parked or broken flow. The ONLY
+        candidate for `await_mail` is then the stale message, which is the whole point."""
+        def drop_invite(self, organizer, title, start, attendees=(), ics_uid="", group="",
+                        url=""):
+            return {"ics_uid": ics_uid, "to": "vexa@sim.test", "organizer": organizer,
+                    "start": start, "attendees": [a for _, a in attendees]}
+
+    doors = SilentInvite()
+    doors._send(WHO, "Prepare: DNA TSC 2026-03-02", "an earlier run's touch")
+    doors.mail[-1]["at"] = time.time() - 3600
+    res = rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    assert not res.ok
+    assert "no mail" in res.error
+
+
+def test_a_fresh_touch_in_the_same_run_is_accepted(catalog, env):
+    res = rehearse("organizer-invited", WHO, doors=StubDoors(), catalog=catalog, env=env)
+    assert res.ok, res.error
+
+
+def test_the_floor_is_the_run_s_own_start_not_the_process_s(catalog, env):
+    """Two runs back to back: the second must verify the second's mail, not the first's."""
+    doors = StubDoors()
+    first = rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    second = rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    assert first.ok and second.ok
+    assert first.mails[0]["id"] != second.mails[0]["id"], (
+        "the second run verified the first run's mail — the floor did not move")
+
+
+def test_subject_reset_removes_the_meetings_that_would_block_re_entry(catalog, env):
+    """Run 2's other lesson. A run that fails BETWEEN `POST /meetings` and the import leaves a
+    non-terminal row, and the next attempt is refused — correctly — with a 409. Nothing else on
+    today's stack clears it: `DELETE /admin/users/{id}` is not on the running admin-api image."""
+    doors = StubDoors()
+    rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    assert doors.meetings
+    out = subject_reset("rehearse-reply-pending@rehearse.test", doors=doors, catalog=catalog,
+                        env=env)
+    assert out["removed"]["meetings"] >= 1
+    assert doors.meetings == {}
+
+
+def test_it_only_removes_that_subject_s_meetings(catalog, env):
+    doors = StubDoors()
+    rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    rehearse("group-member", "rehearse-group-member@rehearse.test", doors=doors, catalog=catalog,
+             env=env)
+    before = len(doors.meetings)
+    subject_reset("rehearse-reply-pending@rehearse.test", doors=doors, catalog=catalog, env=env)
+    assert 0 < len(doors.meetings) < before
+
+
+def test_a_meeting_delete_that_refuses_is_reported_not_swallowed(catalog, env):
+    class NoDelete(StubDoors):
+        def meetings_delete_for(self, subject):
+            raise DoorRefused("the gateway refused DELETE /meetings/{id}")
+    doors = NoDelete()
+    rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    out = subject_reset("rehearse-reply-pending@rehearse.test", doors=doors, catalog=catalog,
+                        env=env)
+    assert out["ok"] is False
+    assert "DELETE /meetings" in out["remaining"]["meetings"]
+
+
+# ── run 2's third lesson: a refusal is not an empty list ─────────────────────────────────────────
+
+def test_the_meetings_list_never_reads_a_refusal_as_no_meetings():
+    """`GET /meetings` caps `limit` at 100 and answers 422 above it. The list was requested with
+    `?limit=200`, and both readers did `(b or {}).get("meetings", [])` — so the 422's `{"detail":
+    …}` became "this person has no meetings".
+
+    `subject_reset` then reported `meetings: 0` with a row sitting right there, and the next run of
+    that state was refused with a 409 nobody could explain. The other reader is worse:
+    `seed_meeting` asks it whether a completed row already exists, so a swallowed refusal would
+    have minted a SECOND completed meeting and mailed the whole room twice.
+    """
+    import ast
+    import inspect
+
+    from rehearse import doors
+
+    # Read the CODE, not the prose: the fix's own docstring quotes `?limit=200` as the defect, and
+    # a grep over source text cannot tell an explanation from an instruction.
+    tree = ast.parse(inspect.getsource(doors))
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            first = (node.body or [None])[0]
+            if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+                docstrings.add(id(first.value))
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and id(node) not in docstrings):
+            assert "limit=200" not in node.value, (
+                "a request string still asks for more than the cap")
+    assert doors.MEETINGS_PAGE_MAX == 100, "the route's own cap, not a number we prefer"
+
+    # Exactly one place reads that list, and it RAISES rather than defaulting to empty.
+    assert "raise DoorRefused" in inspect.getsource(doors.LiveDoors._meetings_of)
+    for reader in (doors.LiveDoors._find_meeting, doors.LiveDoors.meetings_delete_for):
+        body = inspect.getsource(reader)
+        assert "_meetings_of" in body
+        assert '.get("meetings", [])' not in body
+
+
+def test_a_meeting_that_refused_deletion_is_not_counted_as_deleted(catalog, env):
+    """`meetings_delete_for` returned a count, and a count cannot say "one of these did not go".
+    A delete that did not happen must reach `remaining`, or the next run meets a 409."""
+    import inspect
+
+    from rehearse import doors
+    src = inspect.getsource(doors.LiveDoors.meetings_delete_for)
+    assert "refused" in src and "raise DoorRefused" in src

--- a/deploy/dogfood/rehearse/tests/test_since.py
+++ b/deploy/dogfood/rehearse/tests/test_since.py
@@ -120,8 +120,8 @@ def test_the_meetings_list_never_reads_a_refusal_as_no_meetings():
     for node in ast.walk(tree):
         if (isinstance(node, ast.Constant) and isinstance(node.value, str)
                 and id(node) not in docstrings):
-            assert "limit=200" not in node.value, (
-                "a request string still asks for more than the cap")
+            assert "/meetings?limit=200" not in node.value, (
+                "a meetings request still asks for more than that route's cap")
     assert doors.MEETINGS_PAGE_MAX == 100, "the route's own cap, not a number we prefer"
 
     # Exactly one place reads that list, and it RAISES rather than defaulting to empty.

--- a/deploy/dogfood/rehearse/tests/test_since.py
+++ b/deploy/dogfood/rehearse/tests/test_since.py
@@ -140,3 +140,51 @@ def test_a_meeting_that_refused_deletion_is_not_counted_as_deleted(catalog, env)
     from rehearse import doors
     src = inspect.getsource(doors.LiveDoors.meetings_delete_for)
     assert "refused" in src and "raise DoorRefused" in src
+
+
+# ── run 4: the filter rejected the mail it then named in its own refusal ─────────────────────────
+
+@pytest.mark.parametrize('created,ok', [
+    ('2026-09-02T18:50:41.503Z', True),
+    ('2026-09-02T18:50:41.5Z', True),        # Go trims trailing zeros — .5Z beside .503Z
+    ('2026-09-02T18:50:41Z', True),
+    ('2026-09-02T18:50:41.503123456Z', True),  # RFC3339Nano, more digits than %f takes
+    ('2026-09-02T18:50:41+02:00', True),
+    ('', False),
+    ('not a timestamp', False),
+])
+def test_mailpit_stamps_parse_and_an_unreadable_one_is_None_not_zero(created, ok):
+    '''NONE IS NOT ZERO. It returned 0.0 on an unparseable stamp and the caller filtered
+    `epoch < since`, so every message read as older than the run — run 4 failed three states
+    while listing, in its own refusal, the mail it had just discarded.'''
+    from rehearse.doors import _mail_epoch
+    got = _mail_epoch({'Created': created})
+    assert (got is not None) is ok
+    if ok:
+        assert got > 1_000_000_000
+
+
+def test_a_message_we_cannot_place_in_time_is_INCLUDED_not_dropped():
+    '''A false accept is a check that needs tightening; a false reject is a touch reported as
+    never sent. The second is the one that wastes a person's afternoon.'''
+    import time as _t
+
+    from rehearse.doors import LiveDoors
+    import rehearse.doors as D
+
+    calls = []
+    def fake_http(method, url, headers=None, body=None, timeout=40):
+        calls.append(url)
+        if '/search' in url:
+            return 200, {'messages': [{'ID': 'm1', 'Subject': 'Prepare: X', 'Created': 'garbage'}]}
+        return 200, {'Subject': 'Prepare: X', 'To': [{'Address': 'a@rehearse.test'}],
+                     'From': {'Address': 'v@sim.test'}, 'MessageID': '<x@y>', 'Text': 'body',
+                     'HTML': ''}
+    old = D._http
+    D._http = fake_http
+    try:
+        d = LiveDoors.__new__(LiveDoors)
+        msg = LiveDoors.await_mail(d, 'a@rehearse.test', 'Prepare', budget_s=5, since=_t.time())
+        assert msg['subject'] == 'Prepare: X'
+    finally:
+        D._http = old


### PR DESCRIPTION
Eight commits on `rehearse-states` after [#1419](https://github.com/Vexa-ai/vexa/pull/1419) merged — everything the **first live runs against the sim lane** taught. Owning issue: [DmitriyG228/biz#449](https://github.com/DmitriyG228/biz/issues/449).

Four runs. The catalogue found six defects, **five of them in this tool** and one in the product. That is the point of running it: every one was invisible offline because the stub answered whatever it was asked.

## The product defect

**`parse_ics` read a property name anywhere in the event.** `ORGANIZER[^:]*:` with `re.I` and no anchor matched the word inside a UID line, ate forward to the next colon, and returned the **DTSTAMP** as the organizer. `invite_intake.ensure_user` then created platform user 131 with the email `20260902t183213z`.

It failed loudly only because our own mail double refuses a malformed address. An invite whose SUMMARY reads "Organizer sync" — Outlook puts SUMMARY first — would have produced a **plausible wrong address**, and the RSVP, the ack, the prepare mail and the minutes would all have gone to a stranger while every step reported success.

Three locks at three depths: the parse is anchored (`cd826126b`); `ensure_user` refuses a non-address `retryable=False` because it is the last place that can tell; and the rehearsal's own guard now checks the **shape**, not `endswith("@" + domain)`.

## Five defects in this tool, each found by the stack

| symptom on the stack | cause | fix |
|---|---|---|
| 422 on three states | `source: "rehearse"` — the import route's vocabulary is closed (`import`\|`seed`) and right | send `seed`; the **stub now enforces the same vocabulary**, because a double that accepts what the door refuses certifies a broken caller |
| `scaffold_resolves` FAIL on a state that worked | read `refs.state` as a string; it is `{desk, group}` — a check that **cannot pass** reports a product defect where there is a reader that guessed | read the object; and the product's answer (`pile`) was right — two meeting reports are a pile, so the recipe writes a non-meeting entity too rather than arguing with the classifier |
| a state verified a **previous run's** mail | `await_mail` had no floor | the floor is the run's own start |
| `subject_reset` reported `meetings: 0` with a row sitting there | `GET /meetings?limit=200` → 422 (cap 100), read as `.get("meetings", [])` | one reader, and it **raises**. `seed_meeting` asks it whether a completed row exists, so a swallowed refusal would have minted a second completed meeting and mailed the room twice |
| a reset subject still could not re-enter its state | the lane's dedup memory (`admit()` on source_event_id) outlived it — the poller logged `admitted 0`, no touch was sent, the step waited out its budget | `lane_rows_delete_for` clears that subject's rows in every lane, FK order, matched on the subject and never a bare number |
| **a real bot was dispatched at a fixture Zoom URL** (meeting 115, `joining` at 19:20Z) | `+30m` default: `await_start` woke mid-run | `+3h`, and — the actual fix — both invite states end with `cancel_bot_leg` through the product's audited `POST /reactions/{id}/cancel`. A longer fuse is still a fuse |
| three states refused **the very mail they listed** | `_mail_epoch` returned `0.0` on an unparseable RFC3339Nano stamp, so the since-filter rejected everything | `fromisoformat`; `None` never `0.0`; an unplaceable message is **included** — a false accept needs tightening, a false reject reports a touch that never happened |

## Also

- `deploy/dogfood/bin/sim-lane-up.sh` / `sim-mailbox-up.sh` — the sim lane started from the checkout's own `core/flows`, with `rehearse.test` in the attendee allow-list and lane-scoped `pkill`. The lane had been running `wt-adoption-sim` with no worker and `post_meeting@16` (`require_workspace`, no `drop_to_attendees`) shadowing the image.
- Friction survives an intake that is not there: every record hits `$VEXA_REHEARSE_FRICTION_LOG` **before** the route is tried, and a 404 never reads as a pass.

**118 offline tests** (was 79), 14/14 gates, pushed without `--no-verify`.

**COMMITMENTS IN THIS PR — none.**
