### PR TITLE
harness hardening: F84-F93 from the openai-agent / dispatch / config-contract sub-review

### DIFF
--- a/clients/terminal/src/surfaces/__tests__/chatStream.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/chatStream.test.ts
@@ -44,7 +44,7 @@ function ev(o: Record<string, unknown>, id?: string): string {
 
 /** Collect the callback effects into a simple record for assertions. */
 function recorder() {
-  const state = { text: "", tools: [] as string[], commit: undefined as string | undefined, rejected: false, error: "", modelFailure: 0, starting: 0 };
+  const state = { text: "", tools: [] as string[], commit: undefined as string | undefined, rejected: false, error: "", modelFailure: 0, starting: 0, truncated: "" };
   const cb: ChatStreamCallbacks = {
     onStarting: () => { state.starting += 1; },
     onDelta: (t) => { state.text += t; },
@@ -53,6 +53,7 @@ function recorder() {
     onRejected: () => { state.rejected = true; },
     onModelFailure: () => { state.modelFailure += 1; },
     onError: (m) => { state.error += m; },
+    onTruncated: (reason) => { state.truncated = reason; },
   };
   return { state, cb };
 }
@@ -414,3 +415,44 @@ describe("streamChatTurn — the transcript's terms", () => {
   });
 });
 
+/** F89 — `done.reason`: the harness's `turn-truncated` / `context-trimmed` events had NO consumer
+ *  anywhere, so a turn that stopped on its budget was rendered exactly like one that finished. The
+ *  reason now rides on `done`, which this reducer reads, and it is NOT reported as a model failure:
+ *  the model worked, the budget ran out, and saying "Model inference failed" sends the person
+ *  looking at the wrong thing. */
+describe("streamChatTurn — a turn that stopped early (F89)", () => {
+  it("reports done.reason through onTruncated, not as a model failure", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(sseResponse([
+      ev({ type: "message-delta", text: "half an " }),
+      ev({ type: "done", ok: false, reply: "half an answer", reason: "the turn stopped early: tool-call budget" }),
+    ]));
+    const { state, cb } = recorder();
+
+    const result = await streamChatTurn(
+      { prompt: "go", session: "s1", active: undefined },
+      cb,
+      { fetchImpl: fetchImpl as unknown as typeof fetch, signal: new AbortController().signal, ...noWait },
+    );
+
+    expect(state.truncated).toContain("tool-call budget");
+    expect(state.modelFailure).toBe(0);
+    expect(result.terminal).toBe(true);
+    expect(result.sawVisibleOutput).toBe(true);
+  });
+
+  it("still reports a genuine ok=false with no reason as a model failure", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(sseResponse([
+      ev({ type: "done", ok: false, reply: "Not logged in" }),
+    ]));
+    const { state, cb } = recorder();
+
+    await streamChatTurn(
+      { prompt: "go", session: "s1", active: undefined },
+      cb,
+      { fetchImpl: fetchImpl as unknown as typeof fetch, signal: new AbortController().signal, ...noWait },
+    );
+
+    expect(state.modelFailure).toBe(1);
+    expect(state.truncated).toBe("");
+  });
+});

--- a/clients/terminal/src/surfaces/chat.tsx
+++ b/clients/terminal/src/surfaces/chat.tsx
@@ -1012,6 +1012,13 @@ export function Chat({ params = {}, emptyExtra }: ChatProps) {
           },
           onRejected: () => patchAgentTurn(key, agentId, (t) => ({ ...t, status: null, rejected: "workspace.v1 violation — reverted" })),
           onModelFailure: (reply) => patchAgentTurn(key, agentId, (t) => ({ ...t, status: null, text: (t.text ?? "") + (t.text ? "\n\n" : "") + `Model inference failed${reply ? `: ${reply}` : "."}` })),
+          // THE TURN STOPPED EARLY (F89) — not the same thing as the model failing. Keep whatever
+          // the turn did produce and say plainly that it is partial, so the person knows to ask
+          // again rather than reading half an answer as the whole one.
+          onTruncated: (reason, partial) => patchAgentTurn(key, agentId, (t) => {
+            const body = t.text ?? partial ?? "";
+            return { ...t, status: null, text: body + (body ? "\n\n" : "") + `_${reason}_` };
+          }),
           onError: (msg) => patchAgentTurn(key, agentId, (t) => ({ ...t, status: null, text: (t.text ?? "") + (t.text ? "\n\n" : "") + presentError(new Error(msg)).headline })),
           onProgress: () => { if (stickToBottomRef.current) scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight }); },
         },

--- a/clients/terminal/src/surfaces/chatStream.ts
+++ b/clients/terminal/src/surfaces/chatStream.ts
@@ -23,6 +23,9 @@ export type ChatStreamEvent = {
   sha?: string;
   ok?: boolean;
   reply?: string;
+  /** `done` events only — WHAT THE TURN GAVE UP (F89): its tool-call or wall-clock budget ran out,
+   *  or its context was trimmed to fit. Absent on a turn that finished under its own budgets. */
+  reason?: string;
   message?: string;
   /** `error` events only — the upstream HTTP status the proxy folded into the stream. /api/chat
    *  answers 200 with an `error` event even when the gateway refused with a 401, so this field is
@@ -89,6 +92,13 @@ export type ChatStreamCallbacks = {
   onRejected: () => void;
   /** a done event with ok=false — model inference failed (terminal, surfaced) */
   onModelFailure: (reply: string | undefined) => void;
+  /** THE TURN GAVE SOMETHING UP (F89): `done.reason` — it hit its tool-call or wall-clock budget,
+   *  or answered from a context it had trimmed. The harness emitted `turn-truncated` /
+   *  `context-trimmed` for this and NOTHING consumed them, so a half-finished turn was rendered as
+   *  a finished one. `partial` is whatever reply the turn did produce; it is still worth showing.
+   *  Optional so existing callers/tests need not implement it — when it is absent an `ok=false`
+   *  done still falls through to `onModelFailure`. */
+  onTruncated?: (reason: string, partial: string | undefined) => void;
   /** a hard upstream error the proxy folded into the stream (terminal, surfaced) */
   onError: (message: string) => void;
   /** we are (re)connecting and no output has shown yet — show/keep a "starting agent…" affordance */
@@ -340,10 +350,17 @@ export async function streamChatTurn(
           case "turn-complete":
             terminal = true;
             break;
-          case "done":
+          case "done": {
             terminal = true;
-            if (ev.ok === false) { sawVisibleOutput = true; cb.onModelFailure(ev.reply); }
+            // `reason` distinguishes "the model failed" from "the turn stopped early" (F89). They
+            // read identically in the old shape — both arrive as ok=false — and telling a person
+            // "Model inference failed" when the model worked and the BUDGET ran out sends them
+            // looking at the wrong thing.
+            const reason = typeof ev.reason === "string" ? ev.reason : "";
+            if (reason && cb.onTruncated) { sawVisibleOutput = true; cb.onTruncated(reason, ev.reply); }
+            else if (ev.ok === false) { sawVisibleOutput = true; cb.onModelFailure(ev.reply); }
             break;
+          }
           // A hard upstream error the proxy folded into the stream: the turn genuinely failed — surface
           // it (do NOT treat as a cold-start close to resume).
           //

--- a/contracts.seal.json
+++ b/contracts.seal.json
@@ -2,7 +2,6 @@
   "core/agent/contracts/event.v1": "f154a49d0589274140fb584e680b34a12e47f8cf3b1491cfc077d47e019f71f8",
   "core/agent/contracts/invoke.v1": "9a38b01616a8cb25b8e34db9a4a539f9cdc237a731fb67ebf4f361c081897982",
   "core/agent/contracts/proactive-card.v1": "cb9f8df76cea7667dec8f6ea5fdbc6fe4f6c9ed518fd3369c9f75e6fcf7b8a88",
-  "core/agent/contracts/processed-notes.v1": "cc58ab6c26e68c9b01f326891bfa6d7d384ce4fa57f7ece3c9f13342372350f8",
   "core/agent/contracts/routine.v1": "0ef13353d8d71145fb6190d7f4c17f7aed3db74062b65c5119416bde0b704bd8",
   "core/agent/contracts/task.v1": "12575c8f7e31d3510cddead4fec7a3d5bea93cf8c4b60643fbcf02b3c8b85a26",
   "core/agent/contracts/tool.v1": "a6a19a0539f26adeb2ecfccea6071f6eda99b2185e506eed6f474256810f224e",

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -80,6 +80,7 @@ from control_plane import global_layer
 from control_plane import system_mounts
 from control_plane import scaffolds as scaffolds_mod
 from control_plane import friction as friction_store_mod
+from control_plane import model_endpoint
 from shared import friction as friction_mod
 from control_plane import chat_intents
 from control_plane.workspace_membership import MembershipError, MembershipIndex, InMemoryMembershipIndex
@@ -621,9 +622,12 @@ def _sse(events) -> Iterator[str]:
 
 def _has_custom_model_endpoint(cfg: dict) -> bool:
     """True iff a per-user Settings → Models config actually delivers a credential to the worker.
-    Mirrors overlay_model_config's inertness rule (dispatch.py): only ``mode=custom`` WITH a
-    ``base_url`` stamps auth env; ``api_key`` is optional (a keyless local gateway is legitimate)."""
-    return (cfg.get("mode") or "").strip() == "custom" and bool((cfg.get("base_url") or "").strip())
+
+    ONE spelling, shared with the dispatch overlay and the Test button (F93): this used to be a
+    third hand-written copy of "is this custom", and the three disagreed — the Test button certified
+    a configuration the turn would not use. It now delegates to `model_endpoint.has_custom_endpoint`
+    so the pre-flight gate and the dispatch cannot answer differently."""
+    return model_endpoint.has_custom_endpoint(cfg)
 
 
 def _model_creds_error_message() -> str:
@@ -1066,6 +1070,10 @@ def create_app(
             _redis_for_friction.from_url(redis_url, decode_responses=True))
     else:
         friction = friction_store_mod.FrictionStore()
+    # A REFUSED model endpoint is friction, not a log line (F84). The dispatcher is built before the
+    # store, so the sink is attached here; a fake dispatcher in a test simply has no such method.
+    if hasattr(dispatcher, "attach_friction"):
+        dispatcher.attach_friction(friction.file)
     wsr = reader or WorkspaceReader("/workspaces")
     mindex: MembershipIndex = membership_index if membership_index is not None else InMemoryMembershipIndex()
     # THE WORKSPACE REGISTRY (PRD decision 26.1) — id → where that workspace is NOW. Same redis

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -480,6 +480,181 @@
       "default": "5",
       "description": "how many scheduled meetings the per-dispatch timeline block states",
       "targets": []
+    },
+    {
+      "key": "VEXA_LLM_BASE_URL",
+      "class": "defaulted",
+      "default": "(unset \u2014 falls back to ANTHROPIC_BASE_URL)",
+      "description": "openai-agent harness: the OpenAI-compatible endpoint the turn's chat/completions run against. Falls back to ANTHROPIC_BASE_URL, which is what a per-subject Settings \u2192 Models gateway arrives as \u2014 there is ONE endpoint pair and this is its second spelling, kept because the harness predates the collapse",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_LLM_API_KEY",
+      "class": "capability",
+      "capability": "model_inference",
+      "secret": true,
+      "description": "openai-agent harness: the bearer token for VEXA_LLM_BASE_URL. Optional \u2014 a self-hosted vLLM behind the deployment's own network needs none. Falls back to ANTHROPIC_AUTH_TOKEN then ANTHROPIC_API_KEY",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_LLM_MODEL",
+      "class": "defaulted",
+      "default": "(unset \u2014 VEXA_AGENT_MODEL applies)",
+      "description": "openai-agent harness: the model id, when it differs from the product-wide VEXA_AGENT_MODEL. VEXA_AGENT_MODEL is the one Settings \u2192 Models writes and the one the dispatch stamps, so this is an override and not the main dial",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_LLM_EXTRA_BODY",
+      "class": "defaulted",
+      "default": "(unset \u2014 no extra fields)",
+      "description": "openai-agent harness: a JSON object merged into EVERY chat/completions request \u2014 the escape hatch for server-specific fields the OpenAI dialect cannot express. THE ONE DIAL WITH NO ANTHROPIC-DIALECT EQUIVALENT, and load-bearing: a self-hosted Qwen returns nothing parseable without {\"chat_template_kwargs\":{\"enable_thinking\":false}}, and a mis-stamped value fails SILENTLY (the turn runs with thinking on). Also settable per subject under Settings \u2192 Models",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_AGENT_STREAM",
+      "class": "defaulted",
+      "default": "1",
+      "description": "openai-agent harness: stream the completion (SSE). 0/false/no sends one blocking request per step instead \u2014 for an endpoint whose SSE is unreliable",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_AGENT_MAX_TOOL_CALLS",
+      "class": "defaulted",
+      "default": "40",
+      "description": "openai-agent harness: hard per-turn ceiling on tool calls. A turn that reaches it stops and reports the truncation on its done event",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_AGENT_MAX_TURN_SEC",
+      "class": "defaulted",
+      "default": "900",
+      "description": "openai-agent harness: hard per-turn wall-clock ceiling in seconds, reported the same way as the tool-call budget",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_AGENT_CONTEXT_TOKENS",
+      "class": "defaulted",
+      "default": "24000",
+      "description": "openai-agent harness: estimated-token ceiling on the request. A SIZING RULE on a shared inference box rather than a nicety \u2014 a 24k-context request is about 1/29th of the CCC KV cache and an unbounded turn evicts everybody else",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_AGENT_EFFORT",
+      "class": "defaulted",
+      "default": "(unset \u2014 the CLI's own default)",
+      "description": "reasoning-effort pin passed to the claude-code CLI as --effort. Stamped per subject by the dispatch overlay (Settings \u2192 Models \"effort\"); empty leaves the CLI's own default, which OpenAI-compatible backends that validate reasoning_effort reject",
+      "targets": []
+    },
+    {
+      "key": "VEXA_CODEX_MODEL",
+      "class": "defaulted",
+      "default": "(unset \u2014 the Codex account default)",
+      "description": "codex harness: the model for the Codex app-server, when it differs from VEXA_AGENT_MODEL. Empty lets the signed-in subscription account choose, which is what stops a claude-* pin in Settings \u2192 Models from being fed to Codex",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MIDTURN_INJECT",
+      "class": "defaulted",
+      "default": "(unset \u2014 off)",
+      "description": "1 enables mid-turn user-message injection into a running harness turn (claude-code stream-json input, codex turn/steer). Off by default: an injection the harness drops is a message the person believes they sent",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_HARNESS_REAP_GRACE_SEC",
+      "class": "defaulted",
+      "default": "5",
+      "description": "seconds a harness CLI subprocess is given to exit after its stream ends before it is killed",
+      "targets": []
+    },
+    {
+      "key": "VEXA_WRITEBACK",
+      "class": "defaulted",
+      "default": "1",
+      "description": "run the post-turn write-back phase (the entity/timeline bookkeeping that follows a chat turn). 0/false/off/no disables it",
+      "targets": []
+    },
+    {
+      "key": "VEXA_WRITEBACK_MIN_TOKENS",
+      "class": "defaulted",
+      "default": "40",
+      "description": "shortest turn worth a write-back phase, in estimated tokens \u2014 below it the bookkeeping costs more than it records",
+      "targets": []
+    },
+    {
+      "key": "VEXA_CHAT_RESUME_MAX_BYTES",
+      "class": "defaulted",
+      "default": "1000000",
+      "description": "largest session transcript the worker will resume from; past it the thread starts a fresh harness session rather than re-sending an unaffordable history",
+      "targets": []
+    },
+    {
+      "key": "VEXA_IDLE_TIMEOUT_SEC",
+      "class": "defaulted",
+      "default": "120",
+      "description": "the WORKER's warm-serve window: how long it keeps serving unit:<id>:in after its last turn. Dispatch-stamped per chat turn from VEXA_CHAT_IDLE_TIMEOUT_SEC; the engine's own default is deliberately tighter",
+      "targets": []
+    },
+    {
+      "key": "VEXA_CHAT_TOOLS",
+      "class": "defaulted",
+      "default": "(unset \u2014 the engine's chat default set)",
+      "description": "the allow-set a chat turn's harness is given (comma-separated). Runtime-injected per dispatch; the harness enforces it at EXECUTION, not only on the tool list it advertises",
+      "targets": []
+    },
+    {
+      "key": "VEXA_CHAT_SESSION",
+      "class": "defaulted",
+      "default": "main",
+      "description": "the conversation THREAD this dispatch belongs to \u2014 the worker namespaces its continuity session file by it, so several threads coexist in one user workspace. Runtime-injected per dispatch",
+      "targets": []
+    },
+    {
+      "key": "VEXA_START",
+      "class": "defaulted",
+      "default": "{}",
+      "description": "the dispatch's ``start`` object as JSON (the entrypoint ask or the session ref). Runtime-injected per dispatch, never a deploy surface",
+      "targets": []
+    },
+    {
+      "key": "VEXA_UNIT_OUT_TOPIC",
+      "class": "defaulted",
+      "default": "(unset in agent-api \u2014 the runtime injects unit:<id>:out per dispatch)",
+      "description": "the per-dispatch output Stream (unit:<id>:out) the worker writes its UnitEvents to. Runtime-injected per dispatch; a worker without it cannot report anything and refuses to boot (mandatory in the WORKER, which refuses to run without it; agent-api stamps it and never reads it)",
+      "targets": []
+    },
+    {
+      "key": "VEXA_UNIT_IN_TOPIC",
+      "class": "defaulted",
+      "default": "(unset in agent-api \u2014 the runtime injects unit:<id>:in per dispatch)",
+      "description": "the per-dispatch input Stream (unit:<id>:in) the worker's serve loop reads interactive messages from. Runtime-injected per dispatch (mandatory in the WORKER, which refuses to run without it; agent-api stamps it and never reads it)",
+      "targets": []
+    },
+    {
+      "key": "REDIS_URL",
+      "class": "defaulted",
+      "default": "(unset in agent-api \u2014 the runtime injects the worker's connection per dispatch)",
+      "description": "the WORKER's redis connection (its unit:<id>:in/out Streams). Runtime-injected per dispatch and deliberately withheld from the model's own subprocess (llm/ports._HARNESS_SUBPROCESS_DENY_VARS) \u2014 a Bash tool holding it reaches another tenant's keys (mandatory in the WORKER, which refuses to run without it; agent-api stamps it and never reads it)",
+      "targets": []
     }
   ],
   "capabilities": {

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -188,6 +188,15 @@
       ]
     },
     {
+      "key": "VEXA_MODEL_BASE_URL_ALLOW",
+      "class": "defaulted",
+      "default": "(empty \u2014 the deployment\u2019s own gateway host(s) plus api.anthropic.com, openrouter.ai and the CCC box)",
+      "description": "operator allow-list for the base_url a SUBJECT may pin under Settings \u2192 Models (comma-separated host globs). A subject-chosen endpoint is an outbound destination picked by a non-operator and the worker carries a model credential to it, so anything unmatched is refused at dispatch with a friction record. Loopback/link-local/private addresses and single-label docker service names (redis, admin-api) need an EXACT literal entry \u2014 a wildcard never reaches the deployment\u2019s own network",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
       "key": "VEXA_CHAT_IDLE_TIMEOUT_SEC",
       "class": "defaulted",
       "default": "900",

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -164,7 +164,7 @@
       "key": "VEXA_AGENT_MODEL",
       "class": "defaulted",
       "default": "(harness CLI default)",
-      "description": "the model id every agent turn runs on \u2014 the chat turn and the write-back phase alike; empty means the harness CLI's own default",
+      "description": "the model id every agent turn runs on \u2014 the chat turn and the write-back phase alike; the key Settings \u2192 Models writes and the dispatch stamps into every worker. Empty means the harness's own default, which exists only for the CLI harnesses: the openai-agent harness has no default host and no default model and refuses the turn with a named-key error rather than asking an endpoint for an empty model",
       "targets": [
         "compose"
       ]
@@ -173,7 +173,7 @@
       "key": "VEXA_RUNNER",
       "class": "defaulted",
       "default": "claude-code",
-      "description": "agent harness stamped onto dispatched workspace turns; codex selects the Codex app-server, openai-agent selects this repo\u2019s own loop over any OpenAI-compatible endpoint (VEXA_LLM_BASE_URL/_MODEL/_EXTRA_BODY, already forwarded)",
+      "description": "agent harness stamped onto dispatched workspace turns: claude-code (default) | codex (the Codex app-server) | openai-agent (this repo's own loop over any OpenAI-compatible endpoint). The deployment FLOOR only \u2014 Settings \u2192 Models pins a harness per subject and the dispatch overlay wins. The openai-agent lane is configured by VEXA_LLM_BASE_URL / _API_KEY / _MODEL / _EXTRA_BODY, which the WORKER reads from its dispatch-stamped env: #1415 removed them from the runtime's forward list, so they travel by stamp and never by forwarding",
       "targets": [
         "compose"
       ]

--- a/core/agent/control_plane/config_test.py
+++ b/core/agent/control_plane/config_test.py
@@ -23,6 +23,7 @@ import urllib.error
 import urllib.request
 from typing import Callable, Optional
 
+from control_plane import model_endpoint
 from shared.host_claude import LEGACY_CREDENTIALS_MOUNT, credentials_path
 
 # The compose-mounted subscription credential (same mounts the runtime probes; the docker backend
@@ -125,6 +126,12 @@ def test_custom_endpoint(base_url: str, api_key: str, model: str = "",
     base = base_url.rstrip("/")
     if not base:
         return _result(False, "Custom mode but no Base URL set.")
+    # THE SAME GATE THE DISPATCH APPLIES (F84 · F93). A Test button that greens an endpoint the
+    # dispatch will refuse is worse than no button: it tells the operator the configuration works
+    # and the turn then silently runs on the deployment's own model. One predicate, both surfaces.
+    refusal = model_endpoint.refuse_reason(base)
+    if refusal:
+        return _result(False, f"Refused before any request was made: {refusal}")
     # A base URL may or may not already carry the /v1 suffix — both spellings are common and the
     # completion adapter accepts either (it posts {base}/chat/completions). Appending a second /v1
     # produced /v1/v1/... against a real vLLM: a 404 that reads as "endpoint broken" when the
@@ -171,9 +178,21 @@ def run_models_test(config: dict, env: Optional[dict] = None,
     (Settings user > global config already collapsed by admin-api; env is the floor)."""
     env = env if env is not None else dict(os.environ)
     mode = (config.get("mode") or "").strip()
-    base_url = (config.get("base_url") or "").strip() or env.get("ANTHROPIC_BASE_URL", "")
-    api_key = (config.get("api_key") or "").strip() or env.get("ANTHROPIC_AUTH_TOKEN", "") \
-        or env.get("ANTHROPIC_API_KEY", "")
+    # `custom_base_url` is the dispatch overlay's OWN inertness rule, imported rather than restated
+    # (F93): `mode=custom` with no base_url is inert, and such a turn really does run on the
+    # deployment's endpoint — so that is what this button must probe.
+    cfg_url = model_endpoint.custom_base_url(config)
+    base_url = cfg_url or env.get("ANTHROPIC_BASE_URL", "")
+    if cfg_url:
+        # A CUSTOM ENDPOINT CARRIES THE SUBJECT'S OWN KEY AND NOTHING ELSE (F84). The dispatch now
+        # stamps the empty string rather than letting the deployment's brokered token be backfilled
+        # onto a foreign host — so falling back to that token here would green an endpoint the turn
+        # reaches unauthenticated, which is precisely the "certifies a config the turn will not
+        # use" failure.
+        api_key = (config.get("api_key") or "").strip()
+    else:
+        api_key = (config.get("api_key") or "").strip() or env.get("ANTHROPIC_AUTH_TOKEN", "") \
+            or env.get("ANTHROPIC_API_KEY", "")
     if mode == "custom" or (not mode and base_url and api_key):
         out = test_custom_endpoint(
             base_url, api_key, (config.get("model") or "").strip(), post=post,

--- a/core/agent/control_plane/dispatch.py
+++ b/core/agent/control_plane/dispatch.py
@@ -23,6 +23,7 @@ from control_plane.workspace_attach import SEED_SLOT, active_workspaces, shared_
 from control_plane.workspace_membership import reconciled_memberships
 from control_plane.workspace_purpose import read_purpose
 from control_plane import global_layer
+from control_plane import model_endpoint
 from control_plane.meeting_room import group_desk_mount, resolve_desks
 from control_plane.system_mounts import GLOBAL_SLUG, SYSTEM_SLUG, global_mount, system_mount
 from shared.config import Settings
@@ -350,7 +351,8 @@ def _allowlisted(model: str, allowlist: str) -> bool:
     return not allowed or model in allowed
 
 
-def overlay_model_config(env: dict[str, str], config: dict, *, allowlist: str = "") -> None:
+def overlay_model_config(env: dict[str, str], config: dict, *, allowlist: str = "",
+                         friction=None, subject: str = "") -> None:
     """Overlay the subject's effective model config (Settings → Models: user pref > platform
     setting, resolved by admin-api) onto the dispatch env — field-by-field over the deployment
     env defaults, which stay the bottom fallback for anything unset.
@@ -396,15 +398,34 @@ def overlay_model_config(env: dict[str, str], config: dict, *, allowlist: str = 
     elif runner:
         logger.warning("runner %r is not a known harness (%s) — using the deployment default",
                        runner, sorted(units.RUNNERS))
-    if (config.get("mode") or "").strip() != "custom":
-        return
-    base_url = (config.get("base_url") or "").strip()
+    base_url = model_endpoint.custom_base_url(config)
     api_key = (config.get("api_key") or "").strip()
     if not base_url:
-        return  # custom mode without an endpoint is inert — deployment credentials still apply
+        # Not custom, or custom with no endpoint — inert either way; deployment credentials apply.
+        return
+    # THE OPERATOR GATE (F84). A subject-supplied URL is an outbound destination chosen by a
+    # non-operator, so it is refused unless the deployment allow-lists its host. The refusal is
+    # LOUD — a log line and a friction record — because a silently-ignored endpoint runs the turn on
+    # the deployment's own model and looks like it worked.
+    refusal = model_endpoint.refuse_reason(base_url)
+    if refusal:
+        logger.warning("model endpoint REFUSED for subject=%s: %s", subject or "?", refusal)
+        if friction is not None:
+            try:
+                friction(model_endpoint.refusal_friction(base_url, refusal, subject=subject))
+            except Exception:  # noqa: BLE001 — a report is never worth a dispatch
+                logger.warning("model endpoint refusal could not be filed as friction")
+        return
     env["ANTHROPIC_BASE_URL"] = base_url
-    if api_key:
-        env["ANTHROPIC_AUTH_TOKEN"] = api_key
+    # ALWAYS THE SUBJECT'S OWN CREDENTIAL — the empty string included (F84, SECURITY). The backfill
+    # at the end of `build_unit_env` fills every MODEL_AUTH_ENV_ALLOWLIST key that is still ABSENT
+    # from agent-api's own environment; an explicit "" is not absent. Stamping only a non-empty key
+    # therefore paired the DEPLOYMENT's brokered token with the SUBJECT's endpoint whenever the
+    # subject supplied a URL and no key. Every credential the harness or the claude CLI would put on
+    # that request is pinned here, so a custom endpoint can only ever receive what its own owner set.
+    env["ANTHROPIC_AUTH_TOKEN"] = api_key
+    env["ANTHROPIC_API_KEY"] = api_key
+    env["CLAUDE_CODE_OAUTH_TOKEN"] = ""    # the subscription token has ONE legitimate destination
     # THE ONE DIAL WITH NO ANTHROPIC-DIALECT EQUIVALENT. Endpoint, credential and model all reach
     # the openai-agent harness through the ANTHROPIC_*/VEXA_AGENT_MODEL keys above (see
     # `llm/openai_agent.py` — `VEXA_LLM_BASE_URL or ANTHROPIC_BASE_URL`, and so on). `extra_body`
@@ -451,7 +472,7 @@ def build_unit_env(settings: Settings, invocation: dict, *, unit_id: str, token:
                    model_config: Optional[dict] = None,
                    room: Optional[dict] = None,
                    scaffold_workspaces: Optional[list[str]] = None,
-                   entry_nonce: str = "") -> dict[str, str]:
+                   entry_nonce: str = "", friction=None) -> dict[str, str]:
     """Map a ``unit.v1`` dispatch to the worker's ``runtime.v1`` env (12-factor, P7). The minted token +
     the workspace LIST + the per-dispatch Stream topics travel here; the runtime injects them opaquely."""
     identity = invocation["identity"]
@@ -554,7 +575,8 @@ def build_unit_env(settings: Settings, invocation: dict, *, unit_id: str, token:
     # Settings → Models (per-user/platform config from admin-api) beats the deployment env
     # defaults stamped above, field-by-field; anything it leaves unset falls through unchanged.
     if model_config:
-        overlay_model_config(env, model_config, allowlist=settings.model_allowlist)
+        overlay_model_config(env, model_config, allowlist=settings.model_allowlist,
+                             friction=friction, subject=subject)
     # The chat conversation thread (default "main") — the worker namespaces its continuity session file
     # by this so multiple threads coexist in the one user workspace. Meeting/digest paths ignore it.
     if invocation["trigger"] == "message":
@@ -661,11 +683,21 @@ class Dispatcher:
         # AdminApiModelConfig — user pref > platform setting over the admin-api internal edge).
         # None → deployment env defaults only, exactly as before.
         self._model_config = model_config
+        # PRD decision 33: where a REFUSED model endpoint is filed (F84). A callable taking the raw
+        # friction record — `create_app` attaches the store's `file` once it has built it. None (a
+        # test, a dispatcher built without an app) logs the refusal and files nothing; the refusal
+        # itself never depends on the sink.
+        self._friction = None
         self.dispatched: list[dict] = []  # observability — the dispatches that fired
 
     @property
     def settings(self) -> Settings:
         return self._settings
+
+    def attach_friction(self, file_record) -> None:
+        """Wire the friction sink (``FrictionStore.file``) after construction — the store is built
+        inside ``create_app``, which already holds the dispatcher."""
+        self._friction = file_record
 
     def resolve_model_config(self, subject: str) -> Optional[dict]:
         """The subject's effective Settings → Models config (user pref > platform setting).
@@ -724,7 +756,8 @@ class Dispatcher:
         env = build_unit_env(self._settings, invocation, unit_id=uid, token=token, memberships=memberships,
                              entry_nonce=entry_nonce,
                              model_config=model_config, room=room,
-                             scaffold_workspaces=scaffold_workspaces)
+                             scaffold_workspaces=scaffold_workspaces,
+                             friction=self._friction)
         # WARM DELIVERY (the lost-turn fix). The runtime's create is an IDEMPOTENT TOUCH for a
         # workload that is still starting/running (ADR-0027) — it returns the live status and
         # DISCARDS the spec env, where a chat message's prompt rides. So a message sent while the

--- a/core/agent/control_plane/dispatch.py
+++ b/core/agent/control_plane/dispatch.py
@@ -435,12 +435,6 @@ def overlay_model_config(env: dict[str, str], config: dict, *, allowlist: str = 
     extra_body = (config.get("extra_body") or "").strip()
     if extra_body:
         env["VEXA_LLM_EXTRA_BODY"] = extra_body
-    # Server-specific request fields the OpenAI dialect cannot express. LOAD-BEARING for a
-    # self-hosted Qwen ({"chat_template_kwargs":{"enable_thinking":false}}): without it the model
-    # reasons its whole budget away and returns nothing parseable.
-    extra_body = (config.get("extra_body") or "").strip()
-    if extra_body:
-        env["VEXA_LLM_EXTRA_BODY"] = extra_body
 
 
 def _worker_cwd(root: str, subject: str, mounts: list[dict]) -> str:

--- a/core/agent/control_plane/model_endpoint.py
+++ b/core/agent/control_plane/model_endpoint.py
@@ -1,0 +1,158 @@
+"""model_endpoint.py — ONE predicate for "this subject's model config points somewhere else", and
+the operator gate on where "somewhere else" is allowed to be.
+
+TWO DEFECTS LIVE HERE, and they are the same defect seen from two sides (F84 · F93).
+
+**The credential could ride to a foreign host.** ``overlay_model_config`` stamped
+``ANTHROPIC_BASE_URL`` from a subject's Settings → Models config but set ``ANTHROPIC_AUTH_TOKEN``
+only when that subject had *also* supplied a key. ``build_unit_env`` then backfills the
+MODEL_AUTH_ENV_ALLOWLIST from agent-api's OWN environment for every key still absent — so
+``mode=custom`` + a base_url + an EMPTY key handed the deployment's brokered credential to whatever
+endpoint the subject named. There was no scheme or host check either, so that endpoint could be
+``http://admin-api:8001``, ``http://redis:6379`` or ``http://169.254.169.254/`` — SSRF from inside
+the control plane, with a live token attached.
+
+The fix is two rules, and both are enforced here rather than at the call sites:
+
+  1. **A custom endpoint always carries the subject's OWN credential — empty string included.**
+     Absence is what the backfill fills; an explicit empty string is not absence. So a keyless
+     gateway gets an empty key and the deployment's token stays home.
+  2. **The endpoint must be allow-listed** (``VEXA_MODEL_BASE_URL_ALLOW``, comma-separated host
+     globs). Unset, the default is the deployment's own configured gateway host(s) plus
+     ``api.anthropic.com``, ``openrouter.ai`` and the CCC box. Loopback, link-local and private
+     addresses — and single-label docker service names like ``redis`` — need an EXACT literal entry;
+     a wildcard never reaches them, because ``*`` is a statement about the public internet and not
+     a decision to expose the deployment's own network.
+
+**"Is this a custom endpoint" was spelled three times and the spellings disagreed** — the dispatch
+overlay's inertness rule, ``api._has_custom_model_endpoint``'s pre-flight gate, and
+``config_test.run_models_test``'s mode sniff. The Test button certified a configuration the turn
+would not use. There is now one function (`has_custom_endpoint`) and all three import it.
+"""
+from __future__ import annotations
+
+import fnmatch
+import ipaddress
+import os
+from typing import Mapping, Optional
+from urllib.parse import urlsplit
+
+#: The operator's gate. Comma-separated host globs (``fnmatch``: ``*.example.com``, ``vllm-*``).
+ALLOW_ENV = "VEXA_MODEL_BASE_URL_ALLOW"
+
+#: The default allow-list when the operator has set none: the two hosted gateways a custom endpoint
+#: legitimately points at, and the CCC inference box this deployment's openai-agent lane runs on.
+DEFAULT_ALLOW = ("api.anthropic.com", "openrouter.ai", "192.168.1.6")
+
+#: The deployment's OWN endpoints, always allowed regardless of the operator list: a subject naming
+#: the host this deployment already sends its credential to adds exactly zero exposure, and refusing
+#: it would be a rule with no threat behind it.
+_DEPLOYMENT_ENDPOINT_KEYS = ("ANTHROPIC_BASE_URL", "VEXA_LLM_BASE_URL")
+
+_SCHEMES = ("http", "https")
+
+
+def custom_base_url(config: Optional[dict]) -> str:
+    """The subject's custom gateway URL, or ``""`` when this config delivers none.
+
+    ``mode: custom`` WITHOUT a base_url is INERT — the deployment's own credentials still apply and
+    nothing is overlaid — which is the rule ``overlay_model_config`` implements and the other two
+    spellings of this question used to restate by hand."""
+    cfg = config if isinstance(config, dict) else {}
+    if (cfg.get("mode") or "").strip() != "custom":
+        return ""
+    return (cfg.get("base_url") or "").strip()
+
+
+def has_custom_endpoint(config: Optional[dict]) -> bool:
+    """True iff this Settings → Models config actually points the worker at another endpoint.
+
+    THE one predicate: the dispatch overlay, ``api``'s credential pre-flight and the Test button all
+    call this, so a config cannot be custom for one of them and subscription for another."""
+    return bool(custom_base_url(config))
+
+
+def host_of(url: str) -> str:
+    """The lowercased hostname of ``url``, or ``""`` when it has none we can read."""
+    try:
+        parts = urlsplit((url or "").strip())
+    except ValueError:
+        return ""
+    return (parts.hostname or "").lower()
+
+
+def allowed_patterns(env: Optional[Mapping[str, str]] = None) -> list[str]:
+    """The effective allow-list: the deployment's own gateway host(s) first (always), then either
+    the operator's ``VEXA_MODEL_BASE_URL_ALLOW`` or ``DEFAULT_ALLOW``."""
+    env = env if env is not None else os.environ
+    out: list[str] = []
+    for key in _DEPLOYMENT_ENDPOINT_KEYS:
+        host = host_of(env.get(key) or "")
+        if host and host not in out:
+            out.append(host)
+    raw = (env.get(ALLOW_ENV) or "").strip()
+    configured = [p.strip().lower() for p in raw.split(",") if p.strip()] if raw else list(DEFAULT_ALLOW)
+    for pattern in configured:
+        if pattern not in out:
+            out.append(pattern)
+    return out
+
+
+def _needs_literal(host: str) -> bool:
+    """Hosts a wildcard must never reach: loopback, link-local (cloud metadata), private and
+    reserved ranges, and single-label names — which is what every docker service on our own compose
+    network is called (``redis``, ``admin-api``, ``runtime``)."""
+    if host in ("localhost",) or host.endswith(".localhost"):
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return "." not in host          # a bare service name, not a public FQDN
+    return bool(ip.is_loopback or ip.is_link_local or ip.is_private
+                or ip.is_reserved or ip.is_unspecified or ip.is_multicast)
+
+
+def refuse_reason(base_url: str, env: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    """``None`` when this URL may be dispatched, else the operator-facing reason it may not.
+
+    The message names the key to change, because a refusal nobody can act on is an outage with a
+    log line."""
+    raw = (base_url or "").strip()
+    if not raw:
+        return None                     # inert: no endpoint, nothing to gate
+    try:
+        parts = urlsplit(raw)
+    except ValueError:
+        return f"model base_url {raw!r} is not a URL"
+    if parts.scheme.lower() not in _SCHEMES:
+        return (f"model base_url {raw!r} is not http(s) — only {'/'.join(_SCHEMES)} endpoints may "
+                "be dispatched")
+    host = (parts.hostname or "").lower()
+    if not host:
+        return f"model base_url {raw!r} names no host"
+    patterns = allowed_patterns(env)
+    literal = host in patterns
+    if not (literal or any(fnmatch.fnmatchcase(host, p) for p in patterns)):
+        return (f"model endpoint host {host!r} is not allow-listed — add it to {ALLOW_ENV} "
+                f"(currently: {', '.join(patterns)})")
+    if _needs_literal(host) and not literal:
+        return (f"model endpoint host {host!r} is loopback/private/internal and matched only a "
+                f"wildcard — name it EXACTLY in {ALLOW_ENV} to allow it")
+    return None
+
+
+def refusal_friction(base_url: str, reason: str, *, subject: str = "") -> dict:
+    """The friction record a refused endpoint files (PRD decision 33). A refusal the person cannot
+    see is a turn that silently runs on the wrong model, which is the failure this whole gate is
+    about."""
+    return {
+        "reporter": "agent",
+        "kind": "refusal",
+        "severity": "blocker",
+        "subject": subject,
+        "tried": "dispatch a workspace turn against the endpoint set in Settings → Models",
+        "happened": reason,
+        "would_help": (f"either allow-list the host in {ALLOW_ENV} on the deployment, or point "
+                       "Settings → Models at an allowed endpoint"),
+        "context": {"tool": "settings-models", "error": f"{reason} (base_url={base_url})"},
+    }

--- a/core/agent/llm/codex.py
+++ b/core/agent/llm/codex.py
@@ -14,6 +14,12 @@ import threading
 from pathlib import Path
 from typing import Callable, Iterable, Iterator, Optional
 
+# THE PANEL CONVENTIONS ARE THE CLAUDE ADAPTER'S, IMPORTED (F92) — the writer's tab, decision 35's
+# transcript chips and decision 30.4's bot-send open. This adapter emitted NONE of them, so the same
+# turn painted the person's screen or did not depending on which harness the deployment ran, which
+# is exactly the thing `openai_agent` imports these to avoid. One vocabulary, three harnesses.
+from llm.claude_code import (_BOT_TOOLS, _TERMS_TOOLS, _WRITER_TOOLS, _bot_artifact,
+                             _published_terms, _written_artifact)
 from llm.ports import harness_subprocess_env
 
 
@@ -47,6 +53,54 @@ def _tool_started(item: dict) -> Optional[dict]:
     return None
 
 
+def _result_content(item: dict) -> object:
+    """The item's result in a shape the shared panel helpers read: a string, or Claude's list of
+    content blocks. Codex hands MCP results back as ``{"content": [{"type": "text", ...}]}``, which
+    IS that list one level down; anything else is serialised so a JSON body still survives."""
+    result = item.get("result")
+    if isinstance(result, (str, list)):
+        return result
+    if isinstance(result, dict):
+        if isinstance(result.get("content"), list):
+            return result["content"]
+        return json.dumps(result, default=str)
+    return item.get("aggregatedOutput") or ""
+
+
+def _panel_events(item: dict) -> list[dict]:
+    """The panel moves a SUCCESSFUL codex item earns — the same three conventions `claude_code` and
+    `openai_agent` apply, through the same helpers. A failed item moves nothing."""
+    kind = item.get("type")
+    events: list[dict] = []
+    if kind == "fileChange":
+        # Codex reports one item per edit batch; each changed path is its own artifact, and the
+        # LAST one is the document the person should be looking at, so only it takes focus.
+        targets = [_written_artifact("Write", {"file_path": change.get("path")})
+                   for change in item.get("changes", []) if change.get("path")]
+        found = [t for t in targets if t]
+        for i, (slug, rel) in enumerate(found):
+            events.append({"type": "artifact", "workspace": slug, "path": rel,
+                           "focus": i == len(found) - 1})
+        return events
+    if kind != "mcpToolCall":
+        return events
+    name = f"mcp__{item.get('server', '')}__{item.get('tool', '')}"
+    if name in _WRITER_TOOLS:
+        target = _written_artifact(name, item.get("arguments") or {})
+        if target:
+            events.append({"type": "artifact", "workspace": target[0], "path": target[1],
+                           "focus": True})
+    elif name in _TERMS_TOOLS:
+        ev = _published_terms(_result_content(item))
+        if ev:
+            events.append(ev)
+    elif name in _BOT_TOOLS:
+        ev = _bot_artifact(_result_content(item))
+        if ev:
+            events.append(ev)
+    return events
+
+
 def _tool_completed(item: dict) -> Optional[dict]:
     kind = item.get("type")
     if kind not in {"commandExecution", "fileChange", "mcpToolCall", "webSearch", "imageView"}:
@@ -73,8 +127,13 @@ def normalize_notification(message: dict, reply_parts: list[str]) -> list[dict]:
         event = _tool_started(params.get("item") or {})
         return [event] if event else []
     if method == "item/completed":
-        event = _tool_completed(params.get("item") or {})
-        return [event] if event else []
+        item = params.get("item") or {}
+        event = _tool_completed(item)
+        if not event:
+            return []
+        # Panel moves ride AFTER the tool-result, and only on success — the same ordering and the
+        # same success-only rule the other two harnesses apply.
+        return [event] + (_panel_events(item) if event.get("ok") else [])
     return []
 
 

--- a/core/agent/llm/openai_agent.py
+++ b/core/agent/llm/openai_agent.py
@@ -59,7 +59,7 @@ import re
 import subprocess
 import time
 import uuid
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterable, Iterator, Optional
 
 import httpx
@@ -390,19 +390,29 @@ _READ_MAX_CHARS = 100_000
 _GLOB_MAX = 400
 
 
-def mount_roots(work: Path) -> list[Path]:
+def mount_roots(work: Path, *, writable_only: bool = False) -> list[Path]:
     """Every directory this harness's file tools may touch: the turn's cwd plus each declared mount.
 
     Read from ``VEXA_MOUNTS`` the same way ``worker.engine.active_mounts`` does — by ENV, not by
     import, because this module owns no product imports. A malformed value costs the extra mounts,
-    never the turn."""
+    never the turn.
+
+    ``writable_only`` HONOURS THE MOUNT'S ``write`` FLAG (F87). The set carries read-only mounts —
+    ``_global`` (the org tier, platform-write-only) and every desk in a post-meeting room — and this
+    function used to drop the flag, so ``Write``/``Edit`` were rooted in workspaces the dispatch had
+    declared read-only. Only the docker ``:ro`` bind stood between the model and somebody else's
+    desk, and the process backend has no such bind at all. The turn's cwd stays in BOTH sets: it is
+    the primary mount, which ``dispatch._worker_cwd`` picks precisely because it is writable."""
     roots = [work.resolve()]
     raw = os.environ.get("VEXA_MOUNTS") or ""
     if raw:
         try:
             for m in json.loads(raw):
-                if isinstance(m, dict) and m.get("path"):
-                    roots.append(Path(str(m["path"])).resolve())
+                if not (isinstance(m, dict) and m.get("path")):
+                    continue
+                if writable_only and not m.get("write"):
+                    continue
+                roots.append(Path(str(m["path"])).resolve())
         except (ValueError, TypeError, OSError):
             log.warning("VEXA_MOUNTS is not valid JSON — file tools are scoped to the cwd only")
     out: list[Path] = []
@@ -417,26 +427,48 @@ class _Sandbox:
     mistake worth telling the model about — a silently rewritten path writes the right bytes to the
     wrong workspace, which is the one failure nobody can see afterwards."""
 
-    def __init__(self, roots: list[Path]) -> None:
+    def __init__(self, roots: list[Path], write_roots: Optional[list[Path]] = None) -> None:
         self._roots = roots
+        # F87: the WRITABLE subset. Defaults to the read set so a caller that knows of only one
+        # scope (a test, the eval stub) behaves exactly as before.
+        self._write_roots = roots if write_roots is None else write_roots
 
     def resolve(self, raw: str) -> Path:
+        """A path a READ tool may touch — anywhere in the mount set."""
+        return self._within(raw, self._roots, "mounted workspaces")
+
+    def resolve_write(self, raw: str) -> Path:
+        """A path a WRITE tool may touch — the WRITABLE mounts only (F87). A read-only mount is a
+        governance decision the dispatch already made; asking the model nicely is not enforcement."""
+        return self._within(raw, self._write_roots, "WRITABLE mounted workspaces")
+
+    def contains(self, raw: str) -> bool:
+        """True when ``raw`` is inside the read set — for filtering hits rather than refusing a call."""
+        try:
+            self.resolve(raw)
+        except (ValueError, OSError):
+            return False
+        return True
+
+    def _within(self, raw: str, roots: list[Path], what: str) -> Path:
         if not raw:
             raise ValueError("no path given")
+        if not roots:
+            raise ValueError(f"this turn has no {what}")
         p = Path(raw)
         if not p.is_absolute():
-            p = self._roots[0] / p
+            p = roots[0] / p
         # resolve() without strict so a not-yet-existing file still normalises (Write creates it)
         p = Path(os.path.normpath(str(p)))
         try:
             real = p.resolve()
         except OSError:
             real = p
-        for root in self._roots:
+        for root in roots:
             if real == root or root in real.parents:
                 return real
-        raise ValueError(f"path {raw} is outside the mounted workspaces "
-                         f"({', '.join(str(r) for r in self._roots)})")
+        raise ValueError(f"path {raw} is outside the {what} "
+                         f"({', '.join(str(r) for r in roots)})")
 
 
 def run_builtin(tool: str, args: dict, sandbox: _Sandbox) -> tuple[bool, str]:
@@ -451,13 +483,13 @@ def run_builtin(tool: str, args: dict, sandbox: _Sandbox) -> tuple[bool, str]:
             chunk = "\n".join(lines[start:start + limit])
             return True, chunk[:_READ_MAX_CHARS]
         if tool == "Write":
-            path = sandbox.resolve(str(args.get("file_path") or ""))
+            path = sandbox.resolve_write(str(args.get("file_path") or ""))
             path.parent.mkdir(parents=True, exist_ok=True)
             content = args.get("content")
             path.write_text("" if content is None else str(content), encoding="utf-8")
             return True, f"wrote {path}"
         if tool == "Edit":
-            path = sandbox.resolve(str(args.get("file_path") or ""))
+            path = sandbox.resolve_write(str(args.get("file_path") or ""))
             old, new = str(args.get("old_string") or ""), str(args.get("new_string") or "")
             text = path.read_text(encoding="utf-8")
             hits = text.count(old)
@@ -471,7 +503,24 @@ def run_builtin(tool: str, args: dict, sandbox: _Sandbox) -> tuple[bool, str]:
         if tool == "Glob":
             base = sandbox.resolve(str(args.get("path") or "")) if args.get("path") else sandbox.resolve(".")
             pattern = str(args.get("pattern") or "*")
-            hits = sorted(str(p) for p in base.glob(pattern) if p.is_file())[:_GLOB_MAX]
+            # F86: THE PATTERN IS A PATH TOO. `Read` resolved its argument through the sandbox and
+            # `Glob` did not, so `{"pattern": "../../../etc/*"}` enumerated the container's whole
+            # filesystem from inside a workspace turn — the sandbox refused the read that followed,
+            # but the listing itself is the disclosure. Refuse the two escapes a pattern can spell,
+            # then resolve every HIT as well: a symlink inside the mount is the same escape wearing
+            # a legal-looking pattern.
+            if pattern.startswith("/") or ".." in PurePosixPath(pattern).parts:
+                return False, ("pattern must be relative to the search path and may not contain "
+                               "'..' — name a `path` under a mounted workspace instead")
+            hits: list[str] = []
+            for p in base.glob(pattern):
+                try:
+                    real = sandbox.resolve(str(p))
+                except (ValueError, OSError):
+                    continue                      # a symlink out of the mounts is not a hit
+                if real.is_file():
+                    hits.append(str(real))
+            hits = sorted(set(hits))[:_GLOB_MAX]
             return True, "\n".join(hits) if hits else "(no matches)"
         if tool == "Grep":
             base = sandbox.resolve(str(args.get("path") or "")) if args.get("path") else sandbox.resolve(".")
@@ -484,6 +533,8 @@ def run_builtin(tool: str, args: dict, sandbox: _Sandbox) -> tuple[bool, str]:
                     break
                 if not f.is_file() or ".git" in f.parts:
                     continue
+                if not sandbox.contains(str(f)):
+                    continue                      # same escape as F86, reached through a symlink
                 if keep and not fnmatch.fnmatch(f.name, keep):
                     continue
                 try:
@@ -738,7 +789,7 @@ class OpenAIAgentHarness:
             budget_secs = _float_env("VEXA_AGENT_MAX_TURN_SEC", _DEFAULT_MAX_TURN_SEC)
             ctx_budget = _int_env("VEXA_AGENT_CONTEXT_TOKENS", _DEFAULT_CONTEXT_TOKENS)
             started, calls_made, reply = time.monotonic(), 0, ""
-            sandbox = _Sandbox(mount_roots(work))
+            sandbox = _Sandbox(mount_roots(work), mount_roots(work, writable_only=True))
 
             while True:
                 sent, trimmed = trim_messages(messages, ctx_budget)
@@ -786,7 +837,7 @@ class OpenAIAgentHarness:
                     calls_made += 1
                     yield {"type": "tool-call", "tool": call["name"], "args": call["args"],
                            "callId": call["id"]}
-                    ok, out = self._exec_tool(call, mcp_index, sandbox)
+                    ok, out = self._exec_tool(call, mcp_index, sandbox, allow)
                     out = out[:_TOOL_RESULT_MAX_CHARS]
                     yield {"type": "tool-result", "callId": call["id"], "ok": ok,
                            "summary": _short(out)}
@@ -802,8 +853,17 @@ class OpenAIAgentHarness:
             for srv in servers:
                 srv.close()
 
-    def _exec_tool(self, call: dict, mcp_index: dict, sandbox: _Sandbox) -> tuple[bool, str]:
+    def _exec_tool(self, call: dict, mcp_index: dict, sandbox: _Sandbox,
+                   allow: set[str]) -> tuple[bool, str]:
         name, args = call["name"], call["args"]
+        # F85 (SECURITY): THE ALLOW-SET IS ENFORCED HERE, not only where tools are advertised.
+        # `specs` filters what the model is TOLD about, and a model that names a tool it was never
+        # offered — smaller models do this constantly, and a resumed transcript carries the names of
+        # tools an earlier turn had — was executed anyway. `allowed_tools=["Read"]` ran `Write`.
+        # A refusal is a normal tool result: the model sees it and corrects itself.
+        if not _allowed(name, allow):
+            return False, (f"{name} is not allowed on this turn — the allowed tools are "
+                           f"{sorted(allow)}")
         if name in mcp_index:
             srv, tool = mcp_index[name]
             return srv.call(tool, args if isinstance(args, dict) else {})

--- a/core/agent/llm/openai_agent.py
+++ b/core/agent/llm/openai_agent.py
@@ -801,7 +801,12 @@ class OpenAIAgentHarness:
             return ("openai-agent: no VEXA_LLM_BASE_URL — every workspace turn will fail until an "
                     "OpenAI-compatible endpoint is set")
         if not (self._model or os.environ.get("VEXA_AGENT_MODEL")):
-            return "openai-agent: no VEXA_LLM_MODEL — the endpoint will be asked for an empty model"
+            # NAME THE KEY THE OPERATOR ACTUALLY SETS (F91). `VEXA_AGENT_MODEL` is what Settings →
+            # Models writes and what the dispatch stamps into every worker; `VEXA_LLM_MODEL` is only
+            # this harness's override, so sending the operator to it sent them to the dial that
+            # would not be read.
+            return ("openai-agent: no VEXA_AGENT_MODEL (nor the VEXA_LLM_MODEL override) — the "
+                    "endpoint will be asked for an empty model")
         return None
 
     def midturn_enabled(self) -> bool:
@@ -832,7 +837,8 @@ class OpenAIAgentHarness:
                 "no agent endpoint: set VEXA_LLM_BASE_URL (e.g. http://192.168.1.6:8001/v1) — the "
                 "openai-agent runner has no default host")
         if not target:
-            raise LLMConfigError("no model: set VEXA_LLM_MODEL (or VEXA_AGENT_MODEL)")
+            raise LLMConfigError("no model: set VEXA_AGENT_MODEL (Settings → Models writes this "
+                                 "one), or the VEXA_LLM_MODEL override for this harness")
 
         chat_root = self._chat_root or work
         store = _Transcript(chat_root, work, sid)

--- a/core/agent/llm/openai_agent.py
+++ b/core/agent/llm/openai_agent.py
@@ -650,14 +650,72 @@ class _Transcript:
 
 # ── context trimming ────────────────────────────────────────────────────────────────────────────
 
+def _call_ids(msg: dict) -> set[str]:
+    """The ids of the tool calls THIS assistant message made."""
+    return {str(tc.get("id")) for tc in (msg.get("tool_calls") or [])
+            if isinstance(tc, dict) and tc.get("id")}
+
+
+def _exchange(msgs: list[dict], i: int) -> set[int]:
+    """The indices that must leave TOGETHER if index ``i`` leaves — an assistant's tool_calls and
+    every ``tool`` message answering them (F88).
+
+    The OpenAI dialect is strict in both directions: an assistant message whose ``tool_calls`` have
+    no answering ``tool`` message is a 400, and so is a ``tool`` message whose caller is gone. The
+    old trimmer dropped one message at a time and hit both."""
+    msg = msgs[i]
+    ids = _call_ids(msg)
+    if ids:
+        return {i} | {j for j, m in enumerate(msgs)
+                      if m.get("role") == "tool" and str(m.get("tool_call_id")) in ids}
+    if msg.get("role") == "tool":
+        cid = str(msg.get("tool_call_id") or "")
+        caller = next((j for j, m in enumerate(msgs) if cid and cid in _call_ids(m)), None)
+        return {i} if caller is None else _exchange(msgs, caller)
+    return {i}
+
+
+def prune_orphans(messages: list[dict]) -> tuple[list[dict], int]:
+    """Remove tool/assistant messages that cannot be sent because their counterpart is missing.
+
+    This is a REPAIR, not a sacrifice: such a message is unsendable, so keeping it costs the whole
+    turn. It matters most on a RESUMED session — a transcript written by the old trimmer carries the
+    orphan for good, so every subsequent turn of that conversation 400s until somebody starts a new
+    one, which is exactly how the defect reproduced."""
+    msgs = list(messages)
+    removed = 0
+    while True:
+        answered = {str(m.get("tool_call_id")) for m in msgs if m.get("role") == "tool"}
+        called: set[str] = set()
+        for m in msgs:
+            called |= _call_ids(m)
+        drop = {i for i, m in enumerate(msgs)
+                if (m.get("role") == "tool" and str(m.get("tool_call_id")) not in called)
+                or (_call_ids(m) and not (_call_ids(m) & answered))}
+        if not drop:
+            return msgs, removed
+        msgs = [m for i, m in enumerate(msgs) if i not in drop]
+        removed += len(drop)
+
+
 def trim_messages(messages: list[dict], budget: int) -> tuple[list[dict], int]:
     """Fit ``messages`` under ``budget`` estimated tokens. Returns (messages, trimmed_count).
 
     Order of sacrifice, oldest first: tool RESULTS (replaced by a stub, so the model still sees that
-    the call happened), then whole oldest exchanges, and only then the head of the first user
+    the call happened), then whole oldest EXCHANGES, and only then the head of the first user
     message. The LAST user message is never touched — it is the ask, and a turn that trims the ask
-    answers a question nobody put."""
-    msgs = [dict(m) for m in messages]
+    answers a question nobody put.
+
+    "Exchange", not "message" (F88): dropping an assistant turn without the ``tool`` messages that
+    answered it — or a ``tool`` message without its caller — produces a request every
+    OpenAI-compatible server rejects with a 400, and the malformation is WRITTEN TO THE TRANSCRIPT,
+    so a resumed session reproduced it on every later turn. `prune_orphans` runs first and
+    unconditionally, healing transcripts the old trimmer already broke; its removals are not counted
+    as trimming because they buy no context, they only make the request sendable."""
+    msgs, healed = prune_orphans([dict(m) for m in messages])
+    if healed:
+        log.warning("dropped %d orphaned tool message(s) from the session transcript — an "
+                    "assistant turn and its tool results must leave together", healed)
     if _est_tokens(msgs) <= budget:
         return msgs, 0
     trimmed = 0
@@ -668,14 +726,22 @@ def trim_messages(messages: list[dict], budget: int) -> tuple[list[dict], int]:
             m["content"] = _TRIM_STUB
             trimmed += 1
     last_user = max((i for i, m in enumerate(msgs) if m.get("role") == "user"), default=0)
-    while _est_tokens(msgs) > budget:                  # 2) drop oldest non-final messages
-        drop = next((i for i, m in enumerate(msgs)
-                     if i != last_user and i != 0 and m.get("role") != "system"), None)
-        if drop is None:
+    while _est_tokens(msgs) > budget:                  # 2) drop oldest non-final EXCHANGES
+        drop: Optional[set[int]] = None
+        for i, m in enumerate(msgs):
+            if i == 0 or i == last_user or m.get("role") == "system":
+                continue
+            group = _exchange(msgs, i)
+            if 0 in group or last_user in group or any(msgs[j].get("role") == "system"
+                                                       for j in group):
+                continue                               # the group is anchored — try the next one
+            drop = group
             break
-        msgs.pop(drop)
+        if not drop:
+            break
+        msgs = [m for i, m in enumerate(msgs) if i not in drop]
+        trimmed += len(drop)
         last_user = max((i for i, m in enumerate(msgs) if m.get("role") == "user"), default=0)
-        trimmed += 1
     if _est_tokens(msgs) > budget and len(msgs) > 1:   # 3) last resort: head-truncate the opener
         head = msgs[0]
         content = str(head.get("content") or "")
@@ -790,10 +856,20 @@ class OpenAIAgentHarness:
             ctx_budget = _int_env("VEXA_AGENT_CONTEXT_TOKENS", _DEFAULT_CONTEXT_TOKENS)
             started, calls_made, reply = time.monotonic(), 0, ""
             sandbox = _Sandbox(mount_roots(work), mount_roots(work, writable_only=True))
+            # F89: WHAT THE TURN GAVE UP, carried to the `done` event. `turn-truncated` and
+            # `context-trimmed` are emitted for the log and the panel, but neither had a consumer —
+            # the terminal reducer's switch has no case for them and the engine drops them — so a
+            # turn that ran out of tool calls, ran out of wall clock, or answered from a context it
+            # had sacrificed reported `done.ok=True` with a partial reply and looked complete.
+            # `done` is one of the five FROZEN types, so this rides as an optional field on it
+            # rather than as a sixth type.
+            truncation = ""
+            trimmed_total = 0
 
             while True:
                 sent, trimmed = trim_messages(messages, ctx_budget)
                 if trimmed:
+                    trimmed_total += trimmed
                     yield {"type": "context-trimmed", "dropped": trimmed,
                            "tokens": _est_tokens(sent), "budget": ctx_budget}
                     messages = sent
@@ -820,6 +896,7 @@ class OpenAIAgentHarness:
                     if calls_made >= budget_calls or (time.monotonic() - started) > budget_secs:
                         over_budget = True
                         reason = "tool-call budget" if calls_made >= budget_calls else "time budget"
+                        truncation = reason
                         yield {"type": "turn-truncated", "reason": reason,
                                "calls": calls_made, "seconds": round(time.monotonic() - started, 1)}
                         # EVERY call the model made is answered, refusals included. An assistant
@@ -848,7 +925,18 @@ class OpenAIAgentHarness:
                 if over_budget:
                     reply = text
                     break
-            yield {"type": "done", "reply": reply, "sessionId": sid, "ok": True}
+            # THE TURN'S OWN VERDICT. `ok` is False only when the turn did not finish its own
+            # reasoning — it hit a budget — because that reply is partial and acting on it as if it
+            # were an answer is the failure. A context trim leaves a COMPLETE answer built on less,
+            # so it stays ok=True and says so in `reason`; the consumer decides how loud that is.
+            done: dict = {"type": "done", "reply": reply, "sessionId": sid,
+                          "ok": not truncation}
+            if truncation:
+                done["reason"] = f"the turn stopped early: {truncation}"
+            elif trimmed_total:
+                done["reason"] = (f"context-trimmed: {trimmed_total} message(s) dropped to stay "
+                                  f"inside the turn's {ctx_budget}-token budget")
+            yield done
         finally:
             for srv in servers:
                 srv.close()
@@ -903,6 +991,16 @@ class OpenAIAgentHarness:
                         chunk = json.loads(data)
                     except ValueError:
                         continue
+                    # F90: AN ERROR FRAME ON A 200 RESPONSE. vLLM, LiteLLM and OpenRouter all
+                    # answer 200 and then put the failure INSIDE the stream (a rate limit, a
+                    # context overflow, an upstream 5xx). The old loop looked only for `delta`, so
+                    # such a frame was skipped and the turn ended with an empty successful reply —
+                    # the person saw the agent say nothing and nothing anywhere said why.
+                    err = chunk.get("error")
+                    if err:
+                        detail = err.get("message") if isinstance(err, dict) else str(err)
+                        raise LLMError(f"{self._base} streamed an error frame: "
+                                       f"{_short(detail or err, 300)}")
                     delta = ((chunk.get("choices") or [{}])[0] or {}).get("delta") or {}
                     if delta.get("content"):
                         acc_text += delta["content"]
@@ -920,6 +1018,14 @@ class OpenAIAgentHarness:
                             slot["function"]["arguments"] += fn["arguments"]
         except httpx.HTTPError as exc:
             raise LLMError(f"agent transport failure against {self._base}: {exc}") from exc
+        # F90: A STREAM THAT SAID NOTHING is a failure, not an empty answer. A truncated connection,
+        # a model that emitted only reasoning tokens (the Qwen thinking case VEXA_LLM_EXTRA_BODY
+        # exists to switch off), a `[DONE]` with no content — all reached `done.ok=True` with an
+        # empty reply, which the chat renders as the agent having nothing to say.
+        if not acc_text and not acc_calls:
+            raise LLMError(f"{self._base} streamed no content and no tool calls — the endpoint "
+                           "answered 200 with an empty completion (a truncated stream, or a model "
+                           "spending its whole budget on reasoning tokens)")
         msg: dict = {"role": "assistant", "content": acc_text}
         if acc_calls:
             msg["tool_calls"] = [acc_calls[k] for k in sorted(acc_calls)]

--- a/core/agent/shared/units.py
+++ b/core/agent/shared/units.py
@@ -16,7 +16,19 @@ import hashlib
 import json
 import os
 
-RUNNER = (os.environ.get("VEXA_RUNNER") or "").strip() or "claude-code"
+DEFAULT_RUNNER = "claude-code"
+
+
+def deployment_runner() -> str:
+    """The deployment's default harness, resolved AT CALL TIME (F92).
+
+    This used to be a module constant frozen into ``make_dispatch``'s default argument, which is the
+    exact pattern ``control_plane/config_test.py`` documents at length as a 32-hour outage: a value
+    decided ONCE at import cannot follow the environment, so an operator who changes ``VEXA_RUNNER``
+    sees nothing happen until the container is recreated, and every test that sets the variable is
+    reading whatever the interpreter saw first. The per-subject overlay (Settings → Models) stamps
+    the runner into the worker env; this is only the floor under it."""
+    return (os.environ.get("VEXA_RUNNER") or "").strip() or DEFAULT_RUNNER
 
 # The harness names a dispatch may carry. `llm/registry.HARNESS_RUNNERS` is the AUTHORITY — it maps
 # each name to the class that implements it — but `llm/` ships only in the WORKER image: the
@@ -70,7 +82,7 @@ def make_dispatch(
     tools: list[str] | tuple[str, ...] = (),
     context: dict | None = None,
     launcher: str | None = None,
-    runner: str = RUNNER,
+    runner: str = "",
     token: str | None = None,
     principal: dict | None = None,
 ) -> dict:
@@ -80,7 +92,7 @@ def make_dispatch(
     dispatch stamps it as the git author (see dispatch.py D4)."""
     inv: dict = {
         "identity": {"subject": subject, "launcher": launcher or launcher_for(trigger, subject)},
-        "runner": runner,
+        "runner": runner or deployment_runner(),
         "workspaces": workspaces or [{"id": subject, "mode": mode_for(trigger)}],
         "trigger": trigger,
         "start": start,

--- a/core/agent/tests/test_config_contract.py
+++ b/core/agent/tests/test_config_contract.py
@@ -5,6 +5,9 @@ model_inference), and the ADDITIVE /health rows next to the existing dispatcher 
 """
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -92,3 +95,68 @@ def test_health_degraded_path_still_carries_rows():
     body = r.json()
     assert body["status"] == "degraded"
     assert "capabilities" in body
+
+
+# ── the WORKER and the HARNESS are part of this service's config surface (F91 · F93) ─────────────
+
+_ENV_READ = re.compile(r"""os\.(?:getenv|environ\.get|environ\.setdefault)\(\s*["']([A-Z][A-Z0-9_]*)["']"""
+                       r"""|os\.environ\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]""")
+
+#: Process plumbing a module may read without a declaration — the same tight list gate:config-contract
+#: keeps (CONFIG_SURFACE_ALLOW). Interpreter/runtime wiring only, never product config.
+_PLUMBING = {"PYTHONUNBUFFERED", "PYTHONPATH", "DISPLAY", "NODE_ENV", "HOSTNAME", "TZ", "PGTZ",
+             "HOME", "TMPDIR"}
+
+
+def _env_reads(*dirs: str) -> dict[str, str]:
+    root = Path(__file__).resolve().parents[1]
+    found: dict[str, str] = {}
+    for d in dirs:
+        for path in sorted((root / d).rglob("*.py")):
+            if "tests" in path.parts or "__pycache__" in path.parts:
+                continue
+            for m in _ENV_READ.finditer(path.read_text(encoding="utf-8")):
+                found.setdefault(m.group(1) or m.group(2), str(path.relative_to(root)))
+    return found
+
+
+def test_every_env_read_in_the_harness_and_the_worker_is_declared():
+    """F91. gate:config-contract scanned only `control_plane` + `shared`, so every dial the TURN
+    actually runs on was invisible to the contract — `VEXA_LLM_EXTRA_BODY`, whose absence fails
+    silently (the turn runs with thinking on), was declared nowhere at all. agent-api does not read
+    these itself; it STAMPS them into every worker spec env, which is exactly why they are its
+    config surface. This is the Python-side twin of the widened gate scan: either alone can be
+    edited away, both cannot be by accident."""
+    declared = {k["key"] for k in cp.load_declaration()["keys"]}
+    for key, where in sorted(_env_reads("llm", "worker").items()):
+        assert key in declared or key in _PLUMBING, (
+            f"{where} reads {key} but config.v1.json does not declare it — add it to "
+            "core/agent/control_plane/config.v1.json"
+        )
+
+
+def test_the_qwen_lane_dials_are_declared():
+    """Named one by one because these are the keys whose absence is SILENT: a mis-stamped
+    extra_body leaves thinking on and the turn merely returns nothing parseable."""
+    declared = {k["key"] for k in cp.load_declaration()["keys"]}
+    assert {"VEXA_LLM_BASE_URL", "VEXA_LLM_API_KEY", "VEXA_LLM_MODEL", "VEXA_LLM_EXTRA_BODY",
+            "VEXA_AGENT_MODEL", "VEXA_AGENT_STREAM", "VEXA_AGENT_MAX_TOOL_CALLS",
+            "VEXA_AGENT_MAX_TURN_SEC", "VEXA_AGENT_CONTEXT_TOKENS", "VEXA_MOUNTS",
+            "VEXA_RUNNER"} <= declared
+
+
+#: The number gate:config-contract PRINTS. It used to be compared to nothing, so it could move by
+#: any amount — a key silently dropped from the declaration reads as a smaller, equally green line
+#: (F93). Bump this deliberately, in the same commit that adds or removes a key.
+EXPECTED_DECLARED_KEYS = 84
+
+
+def test_the_declared_key_count_is_asserted_not_merely_printed():
+    decl = cp.load_declaration()
+    assert len(decl["keys"]) == EXPECTED_DECLARED_KEYS, (
+        f"agent-api declares {len(decl['keys'])} keys, this tripwire expects "
+        f"{EXPECTED_DECLARED_KEYS}. If the change is intended, update EXPECTED_DECLARED_KEYS here "
+        "in the same commit — the gate prints this number and comparing it to nothing is how a "
+        "dropped declaration stays green."
+    )
+    assert len({k["key"] for k in decl["keys"]}) == len(decl["keys"]), "a key is declared twice"

--- a/core/agent/tests/test_config_test.py
+++ b/core/agent/tests/test_config_test.py
@@ -6,7 +6,19 @@ token, unreachable backend, and the happy paths.
 """
 import json
 
+import pytest
+
 from control_plane import config_test as ct
+
+
+@pytest.fixture(autouse=True)
+def _allow_the_fixture_gateways(monkeypatch):
+    """The endpoint the Test button probes now passes the SAME operator allow-list the dispatch
+    applies (F84) — a button that greens a host the turn refuses is the "certifies a config the
+    turn will not use" defect. These fixtures' hosts are allow-listed explicitly, which is also how
+    an operator enables their own gateway."""
+    monkeypatch.setenv("VEXA_MODEL_BASE_URL_ALLOW",
+                       "gw.example,gw,transcription.vexa.ai,api.openai.com,t.vexa.ai,t,x")
 
 
 # ── subscription file ─────────────────────────────────────────────────────────────────────────

--- a/core/agent/tests/test_llm_codex.py
+++ b/core/agent/tests/test_llm_codex.py
@@ -5,7 +5,8 @@ import json
 import os
 from pathlib import Path
 
-from llm.codex import CodexHarness, _link_sessions_into_workspace, _mcp_config
+from llm.codex import (CodexHarness, _link_sessions_into_workspace, _mcp_config,
+                       normalize_notification)
 
 
 class _Input:
@@ -151,3 +152,54 @@ def test_codex_ignores_inherited_claude_model_pin(tmp_path: Path):
     start = next(json.loads(line) for line in proc.stdin.lines
                  if json.loads(line).get("method") == "thread/start")
     assert "model" not in start["params"]
+
+
+# ── the panel conventions, shared with the other two harnesses (F92) ────────────────────────────
+
+def _completed(item):
+    return normalize_notification({"method": "item/completed", "params": {"item": item}}, [])
+
+
+def test_a_codex_file_change_opens_the_writers_tab():
+    """F92 REPRODUCTION. This adapter emitted none of the three panel conventions, so the SAME turn
+    painted the person's screen or did not depending on which harness the deployment ran."""
+    evs = _completed({"type": "fileChange", "id": "i1", "status": "completed",
+                      "changes": [{"path": "/workspaces/u_1/notes/a.md"},
+                                  {"path": "/workspaces/u_1/notes/b.md"}]})
+    arts = [e for e in evs if e["type"] == "artifact"]
+    assert [(a["workspace"], a["path"]) for a in arts] == [("u_1", "notes/a.md"), ("u_1", "notes/b.md")]
+    assert [a["focus"] for a in arts] == [False, True]   # the last write is the one to look at
+
+
+def test_a_codex_workspace_write_opens_the_writers_tab():
+    evs = _completed({"type": "mcpToolCall", "id": "i2", "status": "completed",
+                      "server": "vexa", "tool": "workspace_write",
+                      "arguments": {"slug": "_global", "path": "README.md"},
+                      "result": {"content": [{"type": "text", "text": "ok"}]}})
+    art = next(e for e in evs if e["type"] == "artifact")
+    assert (art["workspace"], art["path"], art["focus"]) == ("_global", "README.md", True)
+
+
+def test_a_codex_transcript_terms_publish_paints_the_chips():
+    body = json.dumps({"meeting": "42", "cursor": "c1", "emit": [{"term": "TSC"}]})
+    evs = _completed({"type": "mcpToolCall", "id": "i3", "status": "completed",
+                      "server": "vexa", "tool": "transcript_terms",
+                      "arguments": {}, "result": {"content": [{"type": "text", "text": body}]}})
+    terms = next(e for e in evs if e["type"] == "terms")
+    assert terms["meeting"] == "42" and terms["terms"] == [{"term": "TSC"}]
+
+
+def test_a_codex_bot_send_opens_the_live_transcript():
+    body = json.dumps({"sent": True, "meeting_row": "77"})
+    evs = _completed({"type": "mcpToolCall", "id": "i4", "status": "completed",
+                      "server": "vexa", "tool": "bot_send",
+                      "arguments": {}, "result": body})
+    art = next(e for e in evs if e["type"] == "artifact")
+    assert art["path"] == "meeting:77" and art["pin"] is True
+
+
+def test_a_failed_codex_item_moves_nothing():
+    """Success only — a failed call must move no panel, exactly as in the other two harnesses."""
+    evs = _completed({"type": "fileChange", "id": "i5", "status": "failed",
+                      "changes": [{"path": "/workspaces/u_1/notes/a.md"}]})
+    assert [e["type"] for e in evs] == ["tool-result"]

--- a/core/agent/tests/test_llm_openai_agent.py
+++ b/core/agent/tests/test_llm_openai_agent.py
@@ -104,9 +104,12 @@ def test_tool_loop_reads_a_file_then_answers(tmp_path):
 
 
 def test_unknown_tool_is_a_failed_result_not_a_crash(tmp_path):
+    # No allow-set (unrestricted, the claude-code `--allowedTools` semantics) so the call reaches
+    # the "this harness does not implement it" branch rather than the F85 allow-set refusal — the
+    # two are different answers to different questions and both must stay non-fatal.
     h = _harness(_server([_msg("", [("c1", "Bash", {"command": "rm -rf /"})]), _msg("ok")]))
     h.prepare(tmp_path)
-    evs = _events(h, tmp_path, "go", allowed_tools=["Read"])
+    evs = _events(h, tmp_path, "go")
     result = next(e for e in evs if e["type"] == "tool-result")
     assert result["ok"] is False and "no tool named Bash" in result["summary"]
     assert evs[-1]["ok"] is True          # the loop recovers; the model gets to choose again
@@ -248,6 +251,8 @@ def test_context_budget_emits_an_event_and_shrinks_the_request(tmp_path, monkeyp
 def test_file_tools_refuse_a_path_outside_the_mounts(tmp_path):
     sandbox = _Sandbox([tmp_path.resolve()])
     ok, out = run_builtin("Write", {"file_path": "/etc/passwd", "content": "x"}, sandbox)
+    assert ok is False and "outside the WRITABLE mounted workspaces" in out
+    ok, out = run_builtin("Read", {"file_path": "/etc/passwd"}, sandbox)
     assert ok is False and "outside the mounted workspaces" in out
     ok, out = run_builtin("Write", {"file_path": str(tmp_path / "a/b.md"), "content": "hi"}, sandbox)
     assert ok is True and (tmp_path / "a/b.md").read_text() == "hi"
@@ -445,3 +450,95 @@ def test_a_failed_write_opens_nothing(tmp_path):
     evs = _events(h, tmp_path, "write it", allowed_tools=["mcp__vexa"])  # no MCP attached
     assert next(e for e in evs if e["type"] == "tool-result")["ok"] is False
     assert not [e for e in evs if e["type"] == "artifact"]
+
+
+# ── the sandbox and the allow-set (F85 · F86 · F87) ─────────────────────────────────────────────
+
+def test_the_allow_set_is_enforced_at_EXECUTION_not_only_at_advertisement(tmp_path):
+    """F85 REPRODUCTION. `allowed_tools=["Read"]` filters the `tools` array the model is handed —
+    and nothing else. A model that names `Write` anyway (small models do, constantly, and a resumed
+    transcript carries names an earlier turn had) had its write performed."""
+    target = tmp_path / "written-anyway.md"
+    h = _harness(_server([
+        _msg("", [("c1", "Write", {"file_path": str(target), "content": "escaped"})]),
+        _msg("done"),
+    ]))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "write it", allowed_tools=["Read"])
+    result = next(e for e in evs if e["type"] == "tool-result")
+    assert result["ok"] is False
+    assert "not allowed on this turn" in result["summary"]
+    assert not target.exists(), "the refused tool must not have run"
+
+
+def test_an_empty_allow_set_still_means_unrestricted(tmp_path):
+    """The claude-code `--allowedTools` semantics `_allowed` documents: no flag = every tool."""
+    target = tmp_path / "ok.md"
+    h = _harness(_server([
+        _msg("", [("c1", "Write", {"file_path": str(target), "content": "hi"})]),
+        _msg("done"),
+    ]))
+    h.prepare(tmp_path)
+    _events(h, tmp_path, "write it")
+    assert target.read_text() == "hi"
+
+
+def test_glob_cannot_enumerate_outside_the_mounts(tmp_path):
+    """F86 REPRODUCTION. `Read` resolved its argument through the sandbox; `Glob` passed the pattern
+    to `Path.glob` raw, so `../../../etc/*` listed a directory no mount contains. The listing IS the
+    disclosure — refusing the read that follows is too late."""
+    work = tmp_path / "ws"
+    work.mkdir()
+    (tmp_path / "secret.txt").write_text("outside")
+    (work / "inside.md").write_text("inside")
+    sandbox = _Sandbox([work.resolve()])
+    ok, out = run_builtin("Glob", {"pattern": "../*.txt"}, sandbox)
+    assert ok is False and ".." in out
+    ok, out = run_builtin("Glob", {"pattern": "/etc/*"}, sandbox)
+    assert ok is False
+    ok, out = run_builtin("Glob", {"pattern": "*.md"}, sandbox)
+    assert ok is True and "inside.md" in out
+
+
+def test_glob_drops_hits_that_leave_the_mounts_by_symlink(tmp_path):
+    """The same escape wearing a legal-looking pattern: a symlink inside the mount. `**` does not
+    follow one, but an explicit component does — `link/*.md` walks straight out of the workspace,
+    which is why every HIT is resolved and not merely the pattern checked."""
+    work = tmp_path / "ws"
+    work.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("classified")
+    (work / "link").symlink_to(outside)
+    sandbox = _Sandbox([work.resolve()])
+    ok, out = run_builtin("Glob", {"pattern": "link/*.md"}, sandbox)
+    assert ok is True and "secret.md" not in out, out
+
+
+def test_write_roots_are_the_WRITABLE_mounts_only(tmp_path, monkeypatch):
+    """F87 REPRODUCTION. `mount_roots` dropped each mount's `write` flag, so `_global` and every
+    read-only desk in a post-meeting room became a writable root for `Write`/`Edit`. Only the docker
+    `:ro` bind stood in the way, and the process backend has no such bind."""
+    work = tmp_path / "ws"
+    work.mkdir()
+    ro = tmp_path / "_global"
+    ro.mkdir()
+    (ro / "README.md").write_text("org tier")
+    monkeypatch.setenv("VEXA_MOUNTS", json.dumps([
+        {"slug": "ws", "path": str(work), "role": "private", "write": True, "primary": True},
+        {"slug": "_global", "path": str(ro), "role": "global", "write": False},
+    ]))
+    assert ro.resolve() in mount_roots(work)
+    assert ro.resolve() not in mount_roots(work, writable_only=True)
+
+    sandbox = _Sandbox(mount_roots(work), mount_roots(work, writable_only=True))
+    ok, out = run_builtin("Read", {"file_path": str(ro / "README.md")}, sandbox)
+    assert ok is True and "org tier" in out          # readable: it IS in the mount set
+    ok, out = run_builtin("Write", {"file_path": str(ro / "hijack.md"), "content": "x"}, sandbox)
+    assert ok is False and "WRITABLE" in out
+    assert not (ro / "hijack.md").exists()
+    ok, out = run_builtin("Edit", {"file_path": str(ro / "README.md"),
+                                   "old_string": "org tier", "new_string": "mine"}, sandbox)
+    assert ok is False and (ro / "README.md").read_text() == "org tier"
+    ok, _ = run_builtin("Write", {"file_path": str(work / "fine.md"), "content": "x"}, sandbox)
+    assert ok is True

--- a/core/agent/tests/test_llm_openai_agent.py
+++ b/core/agent/tests/test_llm_openai_agent.py
@@ -221,12 +221,19 @@ def test_tool_call_budget_stops_the_turn_and_answers_every_call(tmp_path, monkey
     # both calls answered — an unanswered tool_call is a malformed next request
     answered = {e["callId"] for e in evs if e["type"] == "tool-result"}
     assert answered == {"a", "b"}
-    assert evs[-1]["type"] == "done" and evs[-1]["ok"] is True
+    # F89: the truncation reaches the `done` event, which is the only one anything downstream reads
+    assert evs[-1]["type"] == "done" and evs[-1]["ok"] is False
+    assert "tool-call budget" in evs[-1]["reason"]
+
+
+def _calls(*ids):
+    return [{"id": i, "type": "function", "function": {"name": "Read", "arguments": "{}"}}
+            for i in ids]
 
 
 def test_trim_eats_the_oldest_tool_results_first():
     msgs = [{"role": "user", "content": "ask"},
-            {"role": "assistant", "content": "x"},
+            {"role": "assistant", "content": "x", "tool_calls": _calls("1", "2")},
             {"role": "tool", "tool_call_id": "1", "content": "H" * 20000},
             {"role": "tool", "tool_call_id": "2", "content": "T" * 20000},
             {"role": "user", "content": "the real question"}]
@@ -542,3 +549,139 @@ def test_write_roots_are_the_WRITABLE_mounts_only(tmp_path, monkeypatch):
     assert ok is False and (ro / "README.md").read_text() == "org tier"
     ok, _ = run_builtin("Write", {"file_path": str(work / "fine.md"), "content": "x"}, sandbox)
     assert ok is True
+
+
+# ── trimming never orphans a tool reply (F88) ───────────────────────────────────────────────────
+
+def _orphans(msgs):
+    """Every unsendable pairing an OpenAI-compatible server 400s on."""
+    called = {tc["id"] for m in msgs for tc in (m.get("tool_calls") or [])}
+    answered = {m.get("tool_call_id") for m in msgs if m.get("role") == "tool"}
+    return (called - answered) | (answered - called)
+
+
+def test_trim_drops_an_assistant_turn_together_with_its_tool_replies(tmp_path):
+    """F88 REPRODUCTION. Step 2 dropped ONE message at a time, so the assistant turn that made the
+    calls went and its `tool` answers stayed — a 400 from every OpenAI-compatible server, written
+    into the transcript, reproduced on every later turn of a resumed session."""
+    # The budget is met the moment the ASSISTANT turn goes — so the old loop stopped right there,
+    # leaving its `tool` answer behind with nobody to answer.
+    msgs = [{"role": "user", "content": "ask"},
+            {"role": "assistant", "content": "X" * 8000, "tool_calls": _calls("c0")},
+            {"role": "tool", "tool_call_id": "c0", "content": "small"},
+            {"role": "user", "content": "the real question"}]
+    out, trimmed = trim_messages(msgs, 200)
+    assert trimmed >= 1
+    assert _orphans(out) == set(), out
+    assert out[-1]["content"] == "the real question"
+
+
+def test_a_transcript_the_old_trimmer_already_broke_is_healed(tmp_path):
+    """The resumed-session half: an orphan already ON DISK must not be sent either. It costs the
+    whole turn, so it is repaired rather than counted as trimming."""
+    msgs = [{"role": "user", "content": "ask"},
+            {"role": "tool", "tool_call_id": "gone", "content": "an answer to nobody"},
+            {"role": "assistant", "content": "", "tool_calls": _calls("never-answered")},
+            {"role": "user", "content": "now what"}]
+    out, trimmed = trim_messages(msgs, 10_000)
+    assert trimmed == 0                       # nothing was sacrificed — it was unsendable
+    assert _orphans(out) == set()
+    assert [m["role"] for m in out] == ["user", "user"]
+
+
+def test_trim_never_orphans_under_a_brutal_budget():
+    msgs = [{"role": "system", "content": "rules"}, {"role": "user", "content": "ask"}]
+    for n in range(4):
+        msgs.append({"role": "assistant", "content": "", "tool_calls": _calls(f"a{n}", f"b{n}")})
+        msgs.append({"role": "tool", "tool_call_id": f"a{n}", "content": "R" * 9000})
+        msgs.append({"role": "tool", "tool_call_id": f"b{n}", "content": "S" * 9000})
+    msgs.append({"role": "user", "content": "the real question"})
+    out, _ = trim_messages(msgs, 50)
+    assert _orphans(out) == set(), out
+
+
+# ── the streaming path (F89 · F90) ──────────────────────────────────────────────────────────────
+
+def _sse(*frames):
+    """An SSE handler: each frame is a dict written as one `data:` line, then `[DONE]`."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = "".join(f"data: {json.dumps(f)}\n\n" for f in frames) + "data: [DONE]\n\n"
+        return httpx.Response(200, text=body,
+                              headers={"Content-Type": "text/event-stream"})
+    return handler
+
+
+def _delta(text):
+    return {"choices": [{"delta": {"content": text}}]}
+
+
+def test_streaming_is_the_default_and_streams_deltas(tmp_path, monkeypatch):
+    monkeypatch.delenv("VEXA_AGENT_STREAM", raising=False)
+    h = _harness(_sse(_delta("Hel"), _delta("lo")))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "hi")
+    assert [e["text"] for e in evs if e["type"] == "message-delta"] == ["Hel", "lo"]
+    assert evs[-1]["type"] == "done" and evs[-1]["ok"] is True and evs[-1]["reply"] == "Hello"
+
+
+def test_a_mid_stream_error_frame_on_a_200_is_a_failure(tmp_path, monkeypatch):
+    """F90 REPRODUCTION. vLLM/LiteLLM/OpenRouter answer 200 and put the failure inside the stream.
+    The old loop looked only for `delta`, so the frame was skipped and the turn ended
+    `done.ok=True` with an empty reply — the agent said nothing and nothing said why."""
+    monkeypatch.delenv("VEXA_AGENT_STREAM", raising=False)
+    h = _harness(_sse(_delta("part"), {"error": {"message": "context length exceeded"}}))
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "hi")
+    assert evs[-1]["type"] == "done" and evs[-1]["ok"] is False
+    assert "context length exceeded" in evs[-1]["reply"]
+
+
+def test_a_stream_with_no_text_and_no_tool_calls_is_a_failure(tmp_path, monkeypatch):
+    """F90 REPRODUCTION, second half: a truncated stream, or a model that spent its whole budget on
+    reasoning tokens (the case VEXA_LLM_EXTRA_BODY exists to switch off), reached done.ok=True with
+    an empty reply."""
+    monkeypatch.delenv("VEXA_AGENT_STREAM", raising=False)
+    h = _harness(_sse())
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "hi")
+    assert evs[-1]["type"] == "done" and evs[-1]["ok"] is False
+    assert "no content and no tool calls" in evs[-1]["reply"]
+
+
+def test_a_streamed_tool_call_still_answers_the_turn(tmp_path, monkeypatch):
+    """A stream carrying only tool_calls (no text) is NOT the empty case."""
+    monkeypatch.delenv("VEXA_AGENT_STREAM", raising=False)
+    (tmp_path / "n.md").write_text("body")
+    state = {"i": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        state["i"] += 1
+        if state["i"] == 1:
+            frames = [{"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "id": "c1", "function": {"name": "Read",
+                                                      "arguments": json.dumps(
+                                                          {"file_path": str(tmp_path / "n.md")})}}]}}]}]
+        else:
+            frames = [_delta("read it")]
+        body = "".join(f"data: {json.dumps(f)}\n\n" for f in frames) + "data: [DONE]\n\n"
+        return httpx.Response(200, text=body, headers={"Content-Type": "text/event-stream"})
+
+    h = _harness(handler)
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "read", allowed_tools=["Read"])
+    assert any(e["type"] == "tool-call" for e in evs)
+    assert evs[-1]["ok"] is True and evs[-1]["reply"] == "read it"
+
+
+def test_a_trimmed_turn_says_so_on_done(tmp_path, monkeypatch):
+    """F89: `context-trimmed` had no consumer anywhere. The turn is COMPLETE — it just answered from
+    less — so it stays ok=True and reports what it gave up."""
+    monkeypatch.setenv("VEXA_AGENT_CONTEXT_TOKENS", "300")
+    h = _harness(_server([_msg("", [("c1", "Read", {"file_path": str(tmp_path / "big.md")})]),
+                          _msg("ok")]))
+    (tmp_path / "big.md").write_text("x" * 40000)
+    h.prepare(tmp_path)
+    evs = _events(h, tmp_path, "read it", allowed_tools=["Read"])
+    done = evs[-1]
+    assert done["type"] == "done" and done["ok"] is True
+    assert "context-trimmed" in done["reason"]

--- a/core/agent/tests/test_meeting_room.py
+++ b/core/agent/tests/test_meeting_room.py
@@ -307,9 +307,23 @@ def test_a_broken_room_never_kills_the_dispatch(tmp_path, monkeypatch):
 def test_the_runtime_binds_a_room_mount_read_only(tmp_path):
     """The write flag is not decoration: the shared runtime mount plumbing turns it into a :ro bind,
     so read-only is enforced by the container's mount table rather than by asking the model nicely."""
+    # IMPORT THE MODULE, NOT THE PACKAGE (F92). `from runtime_kernel.mounts import …` executes
+    # `runtime_kernel/__init__.py`, which eagerly imports all three backends — including
+    # `docker_backend`, whose `requests_unixsocket` is a RUNTIME-image dependency the agent test env
+    # has no reason to hold. That import is why this test has been the suite's one standing red, and
+    # the red says nothing about mounts: `mounts.py` itself imports only the stdlib. Load it by path
+    # so the assertion runs against the real shared plumbing without dragging the package in.
+    import importlib.util
     import sys
-    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "runtime" / "src"))
-    from runtime_kernel.mounts import workspace_binds
+
+    mounts_py = Path(__file__).resolve().parents[2] / "runtime" / "src" / "runtime_kernel" / "mounts.py"
+    name = "runtime_kernel_mounts_under_test"
+    spec = importlib.util.spec_from_file_location(name, mounts_py)
+    assert spec and spec.loader, mounts_py
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module      # @dataclass resolves its own module through sys.modules
+    spec.loader.exec_module(module)
+    workspace_binds = module.workspace_binds
 
     env = {"VEXA_WORKSPACE_MOUNT_SOURCE": "/host/store", "VEXA_WORKSPACE_MOUNT_TARGET": "/workspaces",
            "VEXA_MOUNTS": json.dumps([

--- a/core/agent/tests/test_model_endpoint.py
+++ b/core/agent/tests/test_model_endpoint.py
@@ -1,0 +1,177 @@
+"""The model-endpoint gate (F84 · F93) — the credential must never ride to a foreign host.
+
+The reproduction the sub-review recorded is `test_a_custom_endpoint_never_inherits_the_deployment_token`:
+before the fix, `mode=custom` + a subject base_url + an EMPTY api_key left ANTHROPIC_AUTH_TOKEN
+absent from the dispatch env, and `build_unit_env`'s MODEL_AUTH_ENV_ALLOWLIST backfill then copied
+agent-api's OWN token in beside the subject's URL.
+"""
+from __future__ import annotations
+
+import pytest
+
+from control_plane import model_endpoint
+from control_plane.api import _has_custom_model_endpoint
+from control_plane.config_test import run_models_test
+from control_plane.dispatch import overlay_model_config
+
+ALLOWED = "https://api.anthropic.com"
+
+
+def _overlay(config, env=None, **kw):
+    out = dict(env or {})
+    overlay_model_config(out, config, **kw)
+    return out
+
+
+# ── F84: the credential pairing ───────────────────────────────────────────────────────────────────
+
+def test_a_custom_endpoint_never_inherits_the_deployment_token(monkeypatch):
+    """THE REPRODUCTION. A subject supplies a URL and NO key; the deployment holds one. Every
+    credential the worker would put on a request to that URL must be stamped EMPTY, because the
+    backfill fills only what is absent — and an explicit "" is not absent."""
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "deployment-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "deployment-api-key")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "deployment-oauth")
+    env = _overlay({"mode": "custom", "base_url": ALLOWED, "api_key": ""})
+    assert env["ANTHROPIC_BASE_URL"] == ALLOWED
+    for key in ("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
+        assert key in env, f"{key} must be stamped (absence is what the backfill fills)"
+        assert env[key] == ""
+
+
+def test_the_backfill_cannot_reach_a_custom_endpoints_slot(monkeypatch):
+    """End to end through the backfill itself: the deployment's token is present in agent-api's
+    environment and still does not reach a dispatch whose endpoint is the subject's."""
+    from shared.config import Settings
+
+    from control_plane.dispatch import build_unit_env
+
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "deployment-secret")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "deployment-oauth")
+    settings = Settings()
+    inv = {"identity": {"subject": "u_1", "launcher": "user:u_1"}, "runner": "claude-code",
+           "workspaces": [{"id": "u_1", "mode": "rw"}], "trigger": "message",
+           "start": {"entrypoint": {"inline": "hi"}}}
+    env = build_unit_env(settings, inv, unit_id="unit-1", token="tok",
+                         model_config={"mode": "custom", "base_url": ALLOWED, "api_key": ""})
+    assert env["ANTHROPIC_BASE_URL"] == ALLOWED
+    assert env["ANTHROPIC_AUTH_TOKEN"] == ""
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == ""
+
+
+def test_a_subject_supplied_key_still_wins():
+    env = _overlay({"mode": "custom", "base_url": ALLOWED, "api_key": "sk-subject"})
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-subject"
+    assert env["ANTHROPIC_API_KEY"] == "sk-subject"
+
+
+def test_custom_mode_without_an_endpoint_stays_inert():
+    env = _overlay({"mode": "custom", "base_url": "", "api_key": "sk-subject"})
+    assert "ANTHROPIC_BASE_URL" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+
+# ── F84: the allow-list ───────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("url", [
+    "http://admin-api:8001",             # our own control plane
+    "http://redis:6379",                 # our own data plane
+    "http://169.254.169.254/latest",     # cloud metadata
+    "http://127.0.0.1:8001",
+    "http://localhost:8001",
+    "http://10.0.0.5:8000",
+    "file:///etc/passwd",
+    "gopher://evil.example.com",
+    "https://evil.example.com/v1",
+])
+def test_a_non_allowlisted_endpoint_is_refused(url):
+    assert model_endpoint.refuse_reason(url, env={}) is not None
+    env = _overlay({"mode": "custom", "base_url": url, "api_key": "sk"})
+    assert "ANTHROPIC_BASE_URL" not in env, f"{url} must never be stamped"
+
+
+@pytest.mark.parametrize("url", ["https://api.anthropic.com", "https://openrouter.ai/api/v1",
+                                 "http://192.168.1.6:8001/v1"])
+def test_the_default_allow_list_admits_the_three_known_gateways(url):
+    assert model_endpoint.refuse_reason(url, env={}) is None
+
+
+def test_the_deployments_own_gateway_is_always_allowed():
+    env = {"ANTHROPIC_BASE_URL": "https://gw.example.test/v1"}
+    assert model_endpoint.refuse_reason("https://gw.example.test/v1", env=env) is None
+
+
+def test_an_operator_allow_list_replaces_the_defaults():
+    env = {model_endpoint.ALLOW_ENV: "*.vllm.example.test"}
+    assert model_endpoint.refuse_reason("https://a.vllm.example.test/v1", env=env) is None
+    assert model_endpoint.refuse_reason("https://api.anthropic.com", env=env) is not None
+
+
+def test_a_wildcard_never_reaches_the_deployments_own_network():
+    """`*` is a statement about the public internet. Reaching `redis` or a private address takes an
+    exact literal entry, so a lazy allow-list cannot re-open the SSRF."""
+    wide = {model_endpoint.ALLOW_ENV: "*"}
+    assert model_endpoint.refuse_reason("http://redis:6379", env=wide) is not None
+    assert model_endpoint.refuse_reason("http://169.254.169.254/", env=wide) is not None
+    exact = {model_endpoint.ALLOW_ENV: "*,192.168.1.9"}
+    assert model_endpoint.refuse_reason("http://192.168.1.9:8000", env=exact) is None
+
+
+def test_a_refusal_files_friction():
+    filed: list[dict] = []
+    env = _overlay({"mode": "custom", "base_url": "http://redis:6379", "api_key": "sk"},
+                   friction=filed.append, subject="u_7")
+    assert "ANTHROPIC_BASE_URL" not in env
+    assert len(filed) == 1
+    assert filed[0]["kind"] == "refusal" and filed[0]["subject"] == "u_7"
+    assert "redis" in filed[0]["context"]["error"]
+
+
+def test_a_broken_friction_sink_never_breaks_a_dispatch():
+    def boom(_rec):
+        raise RuntimeError("store down")
+
+    env = _overlay({"mode": "custom", "base_url": "http://redis:6379", "api_key": "sk"},
+                   friction=boom)
+    assert "ANTHROPIC_BASE_URL" not in env
+
+
+# ── F93: one predicate, three call sites ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("cfg,expected", [
+    ({"mode": "custom", "base_url": ALLOWED}, True),
+    ({"mode": "custom", "base_url": "  "}, False),
+    ({"mode": "subscription", "base_url": ALLOWED}, False),
+    ({}, False),
+])
+def test_the_three_spellings_are_one(cfg, expected):
+    assert model_endpoint.has_custom_endpoint(cfg) is expected
+    assert _has_custom_model_endpoint(cfg) is expected
+
+
+def test_the_test_button_refuses_what_the_dispatch_would_refuse():
+    """The Test button must not green an endpoint the turn cannot use."""
+    calls = []
+
+    def post(url, payload, headers):
+        calls.append(url)
+        return 200, "{}"
+
+    out = run_models_test({"mode": "custom", "base_url": "http://admin-api:8001", "model": "m"},
+                          env={}, post=post)
+    assert out["ok"] is False and calls == []
+    assert "not allow-listed" in out["summary"]
+
+
+def test_the_test_button_probes_a_custom_endpoint_with_the_subjects_own_key():
+    """No key on the config means no key on the request — because that is what the turn sends."""
+    seen = {}
+
+    def post(url, payload, headers):
+        seen["auth"] = headers.get("Authorization")
+        return 200, "{}"
+
+    out = run_models_test({"mode": "custom", "base_url": ALLOWED, "model": "m", "api_key": ""},
+                          env={"ANTHROPIC_AUTH_TOKEN": "deployment-secret"}, post=post)
+    assert out["ok"] is True
+    assert seen["auth"] == "Bearer "

--- a/core/agent/tests/test_model_endpoint.py
+++ b/core/agent/tests/test_model_endpoint.py
@@ -175,3 +175,21 @@ def test_the_test_button_probes_a_custom_endpoint_with_the_subjects_own_key():
                           env={"ANTHROPIC_AUTH_TOKEN": "deployment-secret"}, post=post)
     assert out["ok"] is True
     assert seen["auth"] == "Bearer "
+
+
+# ── F93: the extra_body stamp exists once ───────────────────────────────────────────────────────
+
+def test_extra_body_is_stamped_exactly_once(monkeypatch):
+    """The block was written twice, verbatim, in one function. Harmless today — the second
+    assignment writes the same value — and precisely the shape that stops being harmless the moment
+    one copy is edited."""
+    import inspect
+
+    from control_plane import dispatch as d
+
+    src = inspect.getsource(d.overlay_model_config)
+    assert src.count('env["VEXA_LLM_EXTRA_BODY"]') == 1, src
+
+    env = _overlay({"mode": "custom", "base_url": ALLOWED, "api_key": "k",
+                    "extra_body": '{"chat_template_kwargs": {"enable_thinking": false}}'})
+    assert env["VEXA_LLM_EXTRA_BODY"] == '{"chat_template_kwargs": {"enable_thinking": false}}'

--- a/core/agent/tests/test_unit_foundation.py
+++ b/core/agent/tests/test_unit_foundation.py
@@ -521,3 +521,24 @@ def test_message_dispatch_stamps_the_chat_idle_window():
     d.dispatch(VALID_INV)
     _, _profile, env = rt.spawned[0]
     assert env["VEXA_IDLE_TIMEOUT_SEC"] == str(settings.chat_idle_timeout_sec)
+
+
+# ── the deployment runner is resolved per call, never frozen at import (F92) ─────────────────────
+
+def test_vexa_runner_is_read_when_the_dispatch_is_built(monkeypatch):
+    """F92 REPRODUCTION. `RUNNER` was a module constant bound into `make_dispatch`'s DEFAULT
+    ARGUMENT, so it was decided once when `shared.units` was first imported — the exact pattern
+    `control_plane/config_test.py` documents at length as a 32-hour outage. An operator who changed
+    VEXA_RUNNER saw nothing happen; a test that set it read whatever the interpreter saw first."""
+    from shared import units as u
+
+    monkeypatch.delenv("VEXA_RUNNER", raising=False)
+    start = u.entrypoint(inline="hi")
+    assert u.make_dispatch(subject="u1", trigger="message", start=start)["runner"] == "claude-code"
+
+    monkeypatch.setenv("VEXA_RUNNER", "openai-agent")
+    assert u.make_dispatch(subject="u1", trigger="message", start=start)["runner"] == "openai-agent"
+
+    # an explicit argument still wins over the deployment floor
+    assert u.make_dispatch(subject="u1", trigger="message", start=start,
+                           runner="codex")["runner"] == "codex"

--- a/core/agent/tests/test_unit_foundation.py
+++ b/core/agent/tests/test_unit_foundation.py
@@ -370,11 +370,12 @@ def test_dispatcher_model_config_stamps_reasoning_effort():
     assert "VEXA_AGENT_EFFORT" not in env2
 
 
-def test_dispatcher_model_config_custom_mode_stamps_the_one_call_shape():
+def test_dispatcher_model_config_custom_mode_stamps_the_one_call_shape(monkeypatch):
     """mode:custom points the agent harness (ANTHROPIC_*) at the supplied gateway. Dispatch-stamped
     keys WIN downstream (docker_backend copies its own env only for keys absent here). It used to
     stamp a SECOND pair (VEXA_LLM_PROVIDER/_BASE_URL/_API_KEY) for the completion adapters — one
     endpoint, configured twice, in two dialects; PRD decision 34 removed the second consumer."""
+    monkeypatch.setenv("VEXA_MODEL_BASE_URL_ALLOW", "gw.example.com")   # F84: the operator gate
     rt = _FakeRuntime()
     mc = _FakeModelConfig({"mode": "custom", "base_url": "https://gw.example.com",
                            "api_key": "sk-user", "model": "qwen3"})
@@ -402,9 +403,10 @@ def test_dispatcher_model_config_subscription_mode_keeps_deployment_credentials(
     assert "ANTHROPIC_BASE_URL" not in env
 
 
-def test_dispatcher_model_config_allowlist_gates_models_not_endpoint():
+def test_dispatcher_model_config_allowlist_gates_models_not_endpoint(monkeypatch):
     """A non-allowlisted model is DROPPED (deployment default applies) — never an error; the
     custom endpoint itself is not the allowlist's business."""
+    monkeypatch.setenv("VEXA_MODEL_BASE_URL_ALLOW", "gw.example.com")   # the ENDPOINT gate is separate
     settings = load_settings(agent_model="deployment-default", model_allowlist="sonnet,haiku")
     rt = _FakeRuntime()
     mc = _FakeModelConfig({"mode": "custom", "base_url": "https://gw.example.com",

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -1129,7 +1129,12 @@ def run_turn_over_workspace(
     gen = run_harness_turn(work, turn_prompt, harness, allowed_tools=allowed, session=resume, model=model,
                            commit=commit, author=author, extra_mounts=extras, mcp_config=mcp_config)
     first = next(gen, None)
-    if resume and first is not None and first.get("type") == "done" and not first.get("ok", True):
+    # A FIRST EVENT THAT IS ALREADY `done.ok=False` means the harness refused the RESUME (an alien or
+    # stale session id) — heal it by running the same prompt with no session. `reason` is what says
+    # this is NOT that case (F89): a turn that stopped on its own budget also reports ok=False, and
+    # re-running it from scratch would burn the budget again and answer no better.
+    if (resume and first is not None and first.get("type") == "done"
+            and not first.get("ok", True) and not first.get("reason")):
         if sess_file.exists():
             sess_file.unlink()
         gen = run_harness_turn(work, turn_prompt, harness, allowed_tools=allowed, session=None, model=model,
@@ -1144,6 +1149,10 @@ def run_turn_over_workspace(
             tool_events.append(ev)
         if ev.get("type") == "done" and ev.get("sessionId"):
             captured = ev["sessionId"]
+        if ev.get("type") == "done" and ev.get("reason"):
+            # WHAT THE TURN GAVE UP (F89). Before this the budget/trim events had no consumer at
+            # all, so a turn that stopped halfway looked in every log exactly like one that finished.
+            log.warning("turn incomplete for session=%s: %s", session or "-", ev["reason"])
         yield ev
     # AFTER the stream, never inside it: a report is a footnote to a turn, and a turn must not
     # stall on one. `report` never raises (see worker/friction.py) — this try is the belt.

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -147,6 +147,13 @@ VEXA_LLM_MODEL=
 VEXA_LLM_EXTRA_BODY=
 # Optional operator gate on workspace-pinned models (comma-separated; empty = allow any route).
 VEXA_MODEL_ALLOWLIST=
+# Operator allow-list for the ENDPOINT a subject may pin under Settings → Models (comma-separated
+# host globs, e.g. `api.anthropic.com,*.internal.example.com`). A subject-chosen base_url is an
+# outbound destination picked by a non-operator and the worker carries a model credential to it, so
+# anything unmatched is refused at dispatch. Empty = the deployment's own gateway host(s) plus
+# api.anthropic.com, openrouter.ai and 192.168.1.6. Loopback / private / single-label docker names
+# (redis, admin-api) must be named EXACTLY — a wildcard never reaches the deployment's own network.
+VEXA_MODEL_BASE_URL_ALLOW=
 # The agent HARNESS for workspace turns (chat / routines / post-meeting docs) — a CLI coding agent.
 # Harness runner: claude-code (default) | codex (Codex app-server) | openai-agent (this repo's
 # own agent loop over any OpenAI-compatible endpoint — no CLI, no vendor; pair it with

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -278,6 +278,15 @@ function gateContractVersion() {
   if (changed.length) return fail(changed.map((k) =>
     `sealed contract changed: ${k} — a published .vN is frozen. BREAKING change → add the next version (vN+1); ` +
     `BACK-COMPATIBLE change → re-seal with \`pnpm seal:contracts\` in a lane:contract human-reviewed PR.`));
+  // A SEAL ENTRY WITH NO CONTRACT BEHIND IT (F93). The loop above walks the DIRS, so an entry for a
+  // deleted contract is never read and never fails — `processed-notes.v1` stayed sealed long after
+  // PRD decision 34 removed the pipeline that produced it. A stale pin is not harmless: it is the
+  // seal file asserting that something is frozen when nothing is.
+  const sealedDirs = new Set(dirs.map((d) => rel(d).replace(/\\/g, "/")));
+  const orphaned = Object.keys(seal).filter((k) => !sealedDirs.has(k));
+  if (orphaned.length) return fail(orphaned.map((k) =>
+    `sealed contract no longer exists: ${k} — remove it from contracts.seal.json (or restore the ` +
+    `contract). A pin with nothing behind it freezes nothing.`));
   const note = unsealed.length ? `; ${unsealed.length} unsealed (in development): ${unsealed.join(", ")}` : "";
   console.log(`  ✓ gate:contract-version — ${dirs.length - unsealed.length} sealed contract(s) frozen${note}`);
   return true;

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -924,7 +924,7 @@ function gateDataflow() {
 const CONFIG_CONTRACT_DIR = join(ROOT, "deploy", "contracts", "config.v1");
 // process-plumbing vars a surface may set without a declaration entry (kept TIGHT + documented):
 // interpreter/runtime wiring only, never product config.
-const CONFIG_SURFACE_ALLOW = new Set(["PYTHONUNBUFFERED", "PYTHONPATH", "DISPLAY", "NODE_ENV", "HOSTNAME", "TZ", "PGTZ"]);
+const CONFIG_SURFACE_ALLOW = new Set(["PYTHONUNBUFFERED", "PYTHONPATH", "DISPLAY", "NODE_ENV", "HOSTNAME", "TZ", "PGTZ", "HOME", "TMPDIR"]);
 // literal env-read spellings the scanner recognizes (Python; `_os` aliases included by substring match)
 const CONFIG_READ_RES = [
   /os\.getenv\(\s*["']([A-Z][A-Z0-9_]*)["']/g,
@@ -951,7 +951,11 @@ const CONFIG_ADOPTED = [
     service: "agent-api",
     decl: "core/agent/control_plane/config.v1.json",
     preflight: "core/agent/control_plane/config_preflight.py",
-    scan: ["core/agent/control_plane", "core/agent/shared"],
+    // F91: the WORKER and the HARNESS adapters are part of this service's config surface. agent-api
+    // does not read their keys itself - it STAMPS them into every worker spec env (build_unit_env)
+    // - so scanning only the control plane made every dial the turn actually runs on invisible to
+    // the contract, and VEXA_LLM_EXTRA_BODY was declared nowhere at all.
+    scan: ["core/agent/control_plane", "core/agent/shared", "core/agent/llm", "core/agent/worker"],
     compose: "agent-api", helm: ["deployment-agent-api.yaml"], lite: "agent-api",
   },
   {


### PR DESCRIPTION
Fixes **F84–F93** from the read-only sub-review of `llm/openai_agent.py` + dispatch + the config
contract, recorded in `drafts/2026-09-02-alpha-ledger.md § 19:1xZ`. One commit per finding group,
each with a test that reproduces the finding and fails on the parent commit.

## What was wrong, and what changed

| | Symptom | Change |
|---|---|---|
| **F84** security | `mode=custom` + a subject `base_url` + an EMPTY `api_key` ⇒ `build_unit_env`'s backfill paired the **deployment's** brokered token with the **subject's** endpoint. No scheme/host check, so `http://admin-api:8001`, `http://redis:6379` and `http://169.254.169.254/` were dispatchable — SSRF with a live credential attached. | New `control_plane/model_endpoint.py`. A custom endpoint always carries the subject's own credential, **empty string included** (absence is what the backfill fills), and its host must pass `VEXA_MODEL_BASE_URL_ALLOW`. Refusals log **and file friction**. |
| **F85** security | The allow-set was enforced on **advertisement** only: `allowed_tools=["Read"]` executed `Write`. | `_exec_tool` takes the allow-set and refuses, as a normal failed tool result. |
| **F86** security | `Glob` passed its pattern to `Path.glob` raw — `../../../etc/*` enumerated outside the mounts. | Pattern refuses `/` and `..`; every **hit** resolves through the sandbox (an explicit symlink component walks out where `**` does not). `Grep` filters the same way. |
| **F87** security | `mount_roots` dropped each mount's `write` flag, so `_global` and every read-only room desk were writable roots. Only the docker `:ro` bind stood in the way; the process backend has none. | `Write`/`Edit` root in `mount_roots(work, writable_only=True)`; `Read`/`Glob`/`Grep` keep the whole set. |
| **F88** correctness | `trim_messages` dropped one message at a time, orphaning `tool` replies from their caller — a 400 from every OpenAI-compatible server, **written into the transcript**, so a resumed session reproduced it every turn. | Trimming moves whole **exchanges**; `prune_orphans` runs first and unconditionally, healing transcripts the old trimmer already broke. |
| **F89** correctness | `turn-truncated` / `context-trimmed` had **no consumer anywhere**; a budget-truncated turn reported `done.ok=True` with a partial reply. | The reason rides on `done` (an optional field on one of the five frozen types). `ok=False` for a budget truncation; `ok=True` + reason for a context trim. Read by `worker/engine` (which no longer mistakes it for a stale resume) and by the terminal reducer's new `onTruncated`. |
| **F90** silent | A mid-stream `{"error"}` frame on HTTP 200, and a stream with no text and no tool calls, both ended as an empty **successful** reply. Streaming is the default and the tests pinned it off. | Both raise `LLMError`. Streaming-on tests added. |
| **F91** silent | `gate:config-contract` scanned only `control_plane` + `shared`, so every dial the turn runs on was invisible; `VEXA_LLM_EXTRA_BODY` was declared nowhere. Two operator messages named `VEXA_LLM_MODEL`, the override, not `VEXA_AGENT_MODEL`, the key operators set. | Scan covers `core/agent/llm` + `core/agent/worker`; the 22 keys it finds are declared; `HOME`/`TMPDIR` join the plumbing allow-list; both messages corrected. |
| **F92** silent | `VEXA_RUNNER` frozen into a default argument at import — the pattern `config_test.py` documents as a 32-hour outage. The codex harness emitted none of the panel conventions. `test_meeting_room` imported through `runtime_kernel.__init__` (⇒ `requests_unixsocket`), which was the suite's one standing red. | `deployment_runner()` resolves per call; codex calls the SAME `_written_artifact` / `_published_terms` / `_bot_artifact` helpers, imported from `llm.claude_code` exactly as `openai_agent` does; the bind assertion loads `mounts.py` by path. |
| **F93** duplication/dead | `VEXA_LLM_EXTRA_BODY` stamped twice verbatim; "is this a custom endpoint" spelled three times and disagreeing; `contracts.seal.json` sealed the deleted `processed-notes.v1`; two false config descriptions; a printed key count compared to nothing. | One stamp, one predicate (closed with F84), seal entry dropped **and** `gate:contract-version` now fails on an orphaned pin, both descriptions rewritten, and the key count is an asserted tripwire. |

## Why `codex` was fixed rather than refused

The review offered "or registry refuses `codex`". Codex stays: it is in `shared.units.RUNNERS`, the
registry implements it, `test_llm_codex.py` exercises it, and `HOST_CODEX_CREDENTIALS` is a declared
deploy surface. Removing a working harness is a product decision; giving it the panel vocabulary the
other two already share is the smallest fix that makes the same turn look the same on any harness.

## Two changes beyond the letter of the review, both same-class

* `CLAUDE_CODE_OAUTH_TOKEN` is pinned empty alongside the two `ANTHROPIC_*` keys — it is on the same
  `MODEL_AUTH_ENV_ALLOWLIST` and the claude CLI sends it to `ANTHROPIC_BASE_URL`, so leaving it out
  would have left the same hole half open.
* `gate:contract-version` fails on a seal entry whose contract directory is gone — the reason
  `processed-notes.v1` could sit there unnoticed.

## Proof

* agent suite **1117 passed** (baseline 1066 + the standing `test_meeting_room` red, which is **gone**)
* `core/runtime` **187 passed**, 1 skipped; `gate:python` green across all 13 packages
* terminal vitest **1103 passed** (95 files)
* the 14 pre-push gates green — pushed **without** `--no-verify`
* every reproduction re-run against the parent commit `43d824f20` in a separate worktree:
  16/27 fail for F84, 11 for F85–F90 (plus 1 in the terminal's `chatStream.test.ts`), 8 for F91–F93

## Operator note

`VEXA_MODEL_BASE_URL_ALLOW` is new and defaults to the deployment's own configured gateway host(s)
plus `api.anthropic.com`, `openrouter.ai` and `192.168.1.6`. A deployment whose subjects point
Settings → Models at some other gateway must name it here or those turns are refused (loudly, with
a friction record) instead of silently running on the deployment's own model.

COMMITMENTS IN THIS PR — none.

Owning issue: DmitriyG228/biz#449.

<!-- vexa-agent -->
