### PR TITLE
reads-as-shipped: decision 30 stops reading as shipped, and its tests stop being unable to fail (R-C09, R-C10)

### DIFF
--- a/clients/terminal/src/minutes/MinutesShell.tsx
+++ b/clients/terminal/src/minutes/MinutesShell.tsx
@@ -31,7 +31,7 @@ import {
   forgetHistory, orderHistory, stripForRecord, touchHistory, withHome,
   type Artifact, type Chat as ChatRec, type Row } from "./chats";
 import { resolveDocRef } from "../ui-kit/docLinks";
-import { syncSurface } from "../surfaces/surfaceSync";
+import { SURFACE_RECORD_LIVE, syncSurface } from "../surfaces/surfaceSync";
 import { Rail } from "./Rail";
 import { ScaffoldRefusalCard } from "./ScaffoldRefusalCard";
 import { meetingPhase, type MeetingMock } from "../surfaces/meetingModel";
@@ -850,12 +850,19 @@ export function MinutesShell() {
   const flavor = sel.kind === "meeting" ? `meeting · ${selMeeting ? PHASE_WORD[meetingPhase(selMeeting)] : "held"}`
     : selChat?.scaffold?.kind === "admin-setup" ? "chat · admin" : "chat";
 
-  // PRD DECISION 30 — THE SURFACE IS A FACT THE SERVER HOLDS, not something the prompt re-describes.
-  // Every change to what the human is looking at is written to the session record: which chat, which
-  // meeting and phase, the view, the strip's history and pins, the navigator. Debounced and
-  // fire-and-forget inside `syncSurface`; inert until stage-1's route lands, and the prompt keeps
-  // its "Active context" prefix until the same flag flips.
+  // PRD DECISION 30 — THE SURFACE WOULD BE A FACT THE SERVER HOLDS, not something the prompt
+  // re-describes. Every change to what the human is looking at would be written to the session
+  // record: which chat, which meeting and phase, the view, the strip's history and pins, the
+  // navigator. Debounced and fire-and-forget inside `syncSurface`.
+  //
+  // ⚠ DECISION 30 IS NOT SHIPPED — `PUT /api/sessions/<id>/surface` is served by no service in
+  // this repo — so this reads the gate ITSELF and returns before doing the work. It used to
+  // recompute `orderHistory(pages)` and build the whole body on every change of chat, view, strip
+  // or navigator and hand it to a `syncSurface` that dropped it on the floor: the code read as
+  // wired while the agent was told nothing (2026-09-02 review, R-C09). The prompt keeps its
+  // "Active context" prefix off the same flag; one value flips both halves.
   useEffect(() => {
+    if (!SURFACE_RECORD_LIVE) return;
     const ordered = orderHistory(pages as Artifact[]);
     const ref = (a: Artifact) => ({ workspace: a.slug ?? "", path: a.path, title: a.label });
     syncSurface(sel.chatId, {

--- a/clients/terminal/src/surfaces/__tests__/surfaceSync.test.ts
+++ b/clients/terminal/src/surfaces/__tests__/surfaceSync.test.ts
@@ -2,9 +2,19 @@
  *
  *  What the person is looking at should be a FACT the server holds, not narration the client
  *  staples to the front of their message every turn. These pin the three properties that make that
- *  trade safe, and the flag that keeps both halves in step.
+ *  trade safe, the ONE gate that flips both halves, and — the reason this file was rewritten — what
+ *  the release may claim about the decision.
+ *
+ *  ⚠ THE PREVIOUS VERSION OF THIS FILE COULD NOT FAIL. Three of its seven tests short-circuited on
+ *  `if (!SURFACE_RECORD_LIVE) { …; return; }` and one asserted the implementation against itself
+ *  (`expect(promptCarriesActiveContext()).toBe(!SURFACE_RECORD_LIVE)`), so setting the flag to
+ *  `true` left all seven green — and all 1110 client tests with them — while the PUT went to a
+ *  route that does not exist and the agent lost the only narration it had. The gate is now a
+ *  PARAMETER: every test below names the state it is testing, and both states are tested.
  */
 import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   promptCarriesActiveContext, readSurface, SURFACE_RECORD_LIVE, surfaceBody, syncSurface,
   type Surface,
@@ -20,6 +30,31 @@ const SURFACE: Surface = {
   },
   navigator: { open: true, workspace: "acme" },
 };
+
+describe("what the release may claim about decision 30", () => {
+  it("is NOT shipped — and this flag is the claim, so flipping it is a release decision", () => {
+    // The server half does not exist: agent-api serves `GET /api/sessions` and
+    // `GET /api/sessions/<id>/history`, and nothing under `/api/sessions/<id>/surface`. One line
+    // flips two irreversible things at once — the PUT starts going to a 404, and the prompt DROPS
+    // its "Active context" narration, which is today the agent's only knowledge of the open page.
+    //
+    // Before this may become `true`, in the SAME commit:
+    //   1. `PUT`/`GET /api/sessions/<id>/surface` exists on agent-api and its field names match
+    //      the `Surface` interface (the shape is pinned by "the wire shape" below);
+    //   2. `readSurface` has a load-time caller — it has none today (review R-C17);
+    //   3. this test moves with it, so the code and the claim cannot disagree unnoticed.
+    expect(SURFACE_RECORD_LIVE).toBe(false);
+  });
+
+  it("keeps exactly ONE mechanism live, for either state of the gate", () => {
+    // The narration and the record are two answers to one question. Running both would let the
+    // agent be told two different things about the same screen; running neither is what shipping
+    // the record switched off would have done. Both states are asserted so neither can drift.
+    expect(promptCarriesActiveContext(true)).toBe(false);
+    expect(promptCarriesActiveContext(false)).toBe(true);
+    expect(promptCarriesActiveContext()).toBe(!SURFACE_RECORD_LIVE);   // the default IS the gate
+  });
+});
 
 describe("the wire shape", () => {
   it("carries chat, meeting, view, strip and navigator — the whole surface, not just the strip", () => {
@@ -37,11 +72,11 @@ describe("syncSurface", () => {
     vi.useFakeTimers();
     const fetcher = vi.fn(async () => new Response("{}", { status: 200 }));
     const live = { ...SURFACE, view: { workspace: "", path: "z.md", title: "z" } };
-    syncSurface("s1", SURFACE, { fetcher: fetcher as unknown as typeof fetch, debounceMs: 300 });
-    syncSurface("s1", live, { fetcher: fetcher as unknown as typeof fetch, debounceMs: 300 });
+    const opts = { fetcher: fetcher as unknown as typeof fetch, debounceMs: 300, live: true };
+    syncSurface("s1", SURFACE, opts);
+    syncSurface("s1", live, opts);
     await vi.advanceTimersByTimeAsync(400);
     vi.useRealTimers();
-    if (!SURFACE_RECORD_LIVE) { expect(fetcher).not.toHaveBeenCalled(); return; }
     expect(fetcher).toHaveBeenCalledTimes(1);
     const [url, init] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe("/api/sessions/s1/surface");
@@ -49,36 +84,87 @@ describe("syncSurface", () => {
     expect(JSON.parse(String(init.body)).view.path).toBe("z.md");
   });
 
-  it("is INERT until the route lands — and that is the same flag that keeps the prompt prefix", () => {
-    // dropping the "Active context" narration before the server fact exists would leave the agent
-    // knowing LESS than it does today. One flag flips both halves together.
-    expect(promptCarriesActiveContext()).toBe(!SURFACE_RECORD_LIVE);
+  it("writes NOTHING while the record is off — the inert half of the same gate", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn(async () => new Response("{}", { status: 200 }));
+    syncSurface("s3", SURFACE, { fetcher: fetcher as unknown as typeof fetch, debounceMs: 300, live: false });
+    await vi.advanceTimersByTimeAsync(400);
+    vi.useRealTimers();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("takes the module gate when the caller does not name one", async () => {
+    // The default is not decoration: it is what MinutesShell and chat.tsx get. While the record is
+    // not shipped this must be silent, and it must be silent BECAUSE of the flag, not by accident.
+    vi.useFakeTimers();
+    const fetcher = vi.fn(async () => new Response("{}", { status: 200 }));
+    syncSurface("s4", SURFACE, { fetcher: fetcher as unknown as typeof fetch, debounceMs: 300 });
+    await vi.advanceTimersByTimeAsync(400);
+    vi.useRealTimers();
+    expect(fetcher.mock.calls.length).toBe(SURFACE_RECORD_LIVE ? 1 : 0);
   });
 
   it("never throws when the write fails — a failed record must not reach the reader", async () => {
     vi.useFakeTimers();
     const boom = vi.fn(async () => { throw new Error("offline"); });
-    expect(() => syncSurface("s2", SURFACE, { fetcher: boom as unknown as typeof fetch, debounceMs: 10 })).not.toThrow();
+    expect(() => syncSurface("s2", SURFACE, { fetcher: boom as unknown as typeof fetch, debounceMs: 10, live: true }))
+      .not.toThrow();
     await vi.advanceTimersByTimeAsync(50);
     vi.useRealTimers();
+    expect(boom).toHaveBeenCalledTimes(1);   // it really did try; the throw was swallowed
   });
 });
 
 describe("readSurface — the server wins only when the local strip is empty", () => {
   it("returns null on any refusal rather than a half record", async () => {
     const no = async () => new Response("nope", { status: 404 });
-    expect(await readSurface("s1", no as unknown as typeof fetch)).toBeNull();
+    expect(await readSurface("s1", no as unknown as typeof fetch, true)).toBeNull();
   });
 
   it("returns null for a body that is not a surface", async () => {
     const bad = async () => new Response(JSON.stringify({ chat: { id: "x" } }), { status: 200 });
-    expect(await readSurface("s1", bad as unknown as typeof fetch)).toBeNull();   // no `strip`
+    expect(await readSurface("s1", bad as unknown as typeof fetch, true)).toBeNull();   // no `strip`
   });
 
   it("parses a real one when the record is live", async () => {
     const ok = async () => new Response(JSON.stringify(SURFACE), { status: 200 });
-    const got = await readSurface("s1", ok as unknown as typeof fetch);
-    if (!SURFACE_RECORD_LIVE) { expect(got).toBeNull(); return; }
+    const got = await readSurface("s1", ok as unknown as typeof fetch, true);
     expect(got?.strip.history[0].path).toBe("a.md");
+    expect(got?.strip.pins[0].workspace).toBe("grp-showb");
+  });
+
+  it("does not even ask while the record is off", async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify(SURFACE), { status: 200 }));
+    expect(await readSurface("s1", fetcher as unknown as typeof fetch, false)).toBeNull();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+/** THE SHELL MUST NOT DO THE WORK OF A RECORD NOBODY HOLDS.
+ *
+ *  READ THE SOURCE, on the precedent of `minutes/__tests__/noDefaults.test.ts`. The finding is that
+ *  the effect *reads as wired*: it recomputed `orderHistory(pages)` and built the whole body on
+ *  every change of chat, view, strip and navigator, and handed it to a `syncSurface` that dropped
+ *  it on the floor. Nothing observable changes either way — which is exactly why no behavioural
+ *  test could have caught it, and why it survived into a release review as a decision the PRD
+ *  counted as shipped (R-C09).
+ */
+describe("MinutesShell — decision 30 is gated at the caller, not only inside the module", () => {
+  const shell = readFileSync(join(__dirname, "..", "..", "minutes", "MinutesShell.tsx"), "utf8");
+
+  it("reads the gate itself and returns before building a surface", () => {
+    // ⚠ assembled, never written out as a `from "…"` literal: gate:isolation reads every quoted
+    // specifier in the file as an import, and a regex that spells one out fails the whole push
+    // (the same gate's own header records it doing this to three files' prose on 2026-09-02).
+    const line = shell.split("\n").find((l) => l.startsWith("import ") && l.includes("surfaceSync"));
+    expect(line).toBeDefined();
+    expect(line).toContain("SURFACE_RECORD_LIVE");
+    expect(shell).toContain("if (!SURFACE_RECORD_LIVE) return;");
+  });
+
+  it("keeps ONE spelling of the gate — the shell never re-declares or negates its own copy", () => {
+    // the `RUNNERS`/`HARNESS_RUNNERS` rule one level down: two copies of one switch is how a
+    // half-flipped decision ships.
+    expect(shell).not.toMatch(/SURFACE_RECORD_LIVE\s*=[^=]/);
   });
 });

--- a/clients/terminal/src/surfaces/surfaceSync.ts
+++ b/clients/terminal/src/surfaces/surfaceSync.ts
@@ -1,14 +1,28 @@
 "use client";
-/** THE HUMAN SURFACE, WRITTEN TO THE SESSION RECORD (PRD decision 30).
+/** THE HUMAN SURFACE, WRITTEN TO THE SESSION RECORD (PRD decision 30) — **NOT SHIPPED**.
  *
  *  What the person is looking at is a FACT the server should hold, not something the client
  *  re-describes in every prompt. Today the terminal prefixes "Active context: the user is viewing
  *  the workspace file …" into the user's own message — the agent reads the human's words with our
  *  narration stapled to the front, and the fact exists only for the duration of one turn.
  *
- *  So: the terminal PUTs the whole surface — which chat, which meeting and phase, what is in the
- *  view, the strip's history and pins, the navigator — whenever any of it changes. The server holds
- *  it; the prompt stops carrying it.
+ *  So the design: the terminal PUTs the whole surface — which chat, which meeting and phase, what
+ *  is in the view, the strip's history and pins, the navigator — whenever any of it changes. The
+ *  server holds it; the prompt stops carrying it.
+ *
+ *  ⚠ THE SERVER HALF DOES NOT EXIST. `PUT`/`GET /api/sessions/<id>/surface` is in no service in
+ *  this repo — agent-api serves `GET /api/sessions` and `GET /api/sessions/<id>/history` and
+ *  nothing else under that prefix. So decision 30 is NOT shipped, this module is inert, and the
+ *  prompt's "Active context" narration is the ONLY thing telling the agent what the reader has
+ *  open. This paragraph is the claim; `SURFACE_RECORD_LIVE` is the claim in code; the test file
+ *  pins the two together so they cannot drift apart silently.
+ *
+ *  THE GATE IS A PARAMETER, NOT A MODULE CONSTANT THE CODE READS BEHIND YOUR BACK. Every function
+ *  here takes `live` and defaults it to `SURFACE_RECORD_LIVE`, for one reason: the first version of
+ *  this file read the constant directly, so no test could exercise the live path, and its own tests
+ *  were green for EITHER value of the flag — flipping it to `true` left all 1110 client tests green
+ *  while the PUT went to a 404 and the prompt lost its prefix (2026-09-02 review, R-C09 / R-C10).
+ *  A gate that does nothing is worse than an absent one, because it is counted.
  *
  *  THREE PROPERTIES, each because the alternative is worse:
  *
@@ -17,15 +31,17 @@
  *      gateway close-loop into 519 requests in three minutes this morning.
  *    · FIRE-AND-FORGET. It never blocks the UI and never throws. A surface the server did not
  *      record is a worse agent turn; a surface that *stalled the panel* is a broken product.
- *    · BEHIND A FLAG. The route is another worker's (stage-1 owns it and will confirm the field
- *      names). Until it lands, `syncSurface` is inert and the prompt KEEPS its prefix — because
- *      dropping the narration before the server fact exists would leave the agent knowing less than
- *      it does today. One flag flips both halves together, which is the only safe way to trade one
- *      mechanism for another.
+ *    · BEHIND ONE GATE. The record and the narration are two answers to one question, so one value
+ *      flips both halves together — the only safe way to trade one mechanism for another.
  */
 
-/** Is the server-side surface record live? Flip when stage-1's route lands and the field names are
- *  confirmed. Until then: the PUT is a no-op and the prompt keeps its "Active context" prefix. */
+/** Is the server-side surface record live?
+ *
+ *  **`false`, and flipping it is a release decision, not an edit.** One line does two irreversible
+ *  things: it starts PUTting to a route that answers 404, and it DROPS the "Active context"
+ *  narration, leaving the agent knowing less than it does today. What must be true first is
+ *  written out in `__tests__/surfaceSync.test.ts` — the test that fails the moment this value and
+ *  that claim disagree. */
 export const SURFACE_RECORD_LIVE = false;
 
 export interface SurfaceRef { workspace: string; path: string; title: string }
@@ -62,13 +78,14 @@ async function put(session: string, surface: Surface, fetcher: typeof fetch): Pr
 }
 
 /** Record the surface. Coalesces bursts per session and keeps only the latest — an intermediate
- *  state nobody stopped on is not worth a request. */
+ *  state nobody stopped on is not worth a request. Inert unless `live`. */
 export function syncSurface(
   session: string,
   surface: Surface,
-  opts: { fetcher?: typeof fetch; debounceMs?: number } = {},
+  opts: { fetcher?: typeof fetch; debounceMs?: number; live?: boolean } = {},
 ): void {
-  if (!SURFACE_RECORD_LIVE || !session) return;
+  const live = opts.live ?? SURFACE_RECORD_LIVE;
+  if (!live || !session) return;
   const fetcher = opts.fetcher ?? fetch;
   const wait = opts.debounceMs ?? DEBOUNCE_MS;
   const prev = pending.get(session);
@@ -81,12 +98,19 @@ export function syncSurface(
   pending.set(session, { timer, surface });
 }
 
-/** Read the surface the server holds for a session, or null. Used on load: when the LOCAL strip is
- *  empty and the server has one, the server's wins — that is the case where this record earns its
- *  keep (a new browser, a cleared store, another device). A local strip is never overwritten: the
- *  reader's own machine knows what they were just doing. */
-export async function readSurface(session: string, fetcher: typeof fetch = fetch): Promise<Surface | null> {
-  if (!SURFACE_RECORD_LIVE || !session) return null;
+/** Read the surface the server holds for a session, or null. Designed for load: when the LOCAL
+ *  strip is empty and the server has one, the server's wins — that is the case where this record
+ *  earns its keep (a new browser, a cleared store, another device). A local strip is never
+ *  overwritten: the reader's own machine knows what they were just doing.
+ *
+ *  ⚠ NO PRODUCTION CALLER TODAY (review R-C17): the load-time merge this describes is not
+ *  implemented, and it is one of the things that must land before `SURFACE_RECORD_LIVE` may flip. */
+export async function readSurface(
+  session: string,
+  fetcher: typeof fetch = fetch,
+  live: boolean = SURFACE_RECORD_LIVE,
+): Promise<Surface | null> {
+  if (!live || !session) return null;
   try {
     const r = await fetcher(`/api/sessions/${encodeURIComponent(session)}/surface`, { cache: "no-store" });
     if (!r.ok) return null;
@@ -101,5 +125,6 @@ export async function readSurface(session: string, fetcher: typeof fetch = fetch
 /** Does the prompt still need to narrate what the reader is looking at?
  *
  *  The narration and the record are two answers to one question, and running both would mean the
- *  agent could be told two different things about the same screen. */
-export const promptCarriesActiveContext = (): boolean => !SURFACE_RECORD_LIVE;
+ *  agent could be told two different things about the same screen. Exactly one is live, always —
+ *  which is why this reads the same gate and takes it the same way. */
+export const promptCarriesActiveContext = (live: boolean = SURFACE_RECORD_LIVE): boolean => !live;


### PR DESCRIPTION
Dispatch 11 of the release backlog, `reads-as-shipped` — the silent-failure shapes where something **reads as configured and does nothing**. Rows [R-C09, R-C10](https://github.com/DmitriyG228/biz/issues/452); R-B18 is handed off (below).

## The finding, as a number

`SURFACE_RECORD_LIVE = false` (`surfaceSync.ts:29`) ships PRD decision 30 switched off. Its own test file was **green with the flag `false` and green with the flag `true`** — and so were all 1110 client tests. That flip is not cosmetic: it starts PUTting to `/api/sessions/<id>/surface`, which is served by **no service in this repo** (agent-api has `GET /api/sessions` and `GET /api/sessions/<id>/history`, nothing else under that prefix), and it **drops** the "Active context" narration that is today the agent's only knowledge of what the reader has open.

Three defects, one shape:

| | |
|---|---|
| **the gate was a module constant** | read inside every function, so no test could reach the live path. Three of seven tests short-circuited on `if (!SURFACE_RECORD_LIVE) { …; return; }`; one asserted the implementation against itself — `expect(promptCarriesActiveContext()).toBe(!SURFACE_RECORD_LIVE)` is true for either value. |
| **the shell read as wired** | `MinutesShell` recomputed `orderHistory(pages)` and built the whole body on every change of chat, view, strip and navigator, then handed it to a `syncSurface` that dropped it on the floor. |
| **nothing counted the claim** | the un-shipped state existed only as a literal no test asserted, while the PRD counts decision 30 as delivered. |

Measured on the old file, before touching anything: deleting the debounce's `clearTimeout` — the entire point of the test named *"coalesces a burst into ONE write"* — left it **7/7 green**.

## The fix

**One spelling of the rule, taken as a parameter.** `syncSurface`, `readSurface` and `promptCarriesActiveContext` each take `live`, defaulting to `SURFACE_RECORD_LIVE`. The record and the narration are two answers to one question; one value flips both halves, and now both halves can be tested at both values without editing the module.

**The shell reads the gate itself** and returns before doing the work (`MinutesShell.tsx:865`), so the code no longer reads as wired.

**The claim is pinned by a test.** `expect(SURFACE_RECORD_LIVE).toBe(false)` — with what must be true before it may flip written where the person flipping it will read it: the route exists and its field names match `Surface`; `readSurface` has a load-time caller (it has none — review R-C17); and the test moves in the same commit. Decision 30's server half is unbuilt and is now recorded as such rather than implied by wired-looking code.

## Proven by mutation

Six, each caught by the test that should catch it. The two marked ⚠ are the finding:

| | mutation | new file | old file |
|---|---|---|---|
| M1 | drop the shell's guard | 1 failed | — (nothing observable changes) |
| M2 | `syncSurface` reads the constant, not the arg | 2 failed | — (this *was* the shape) |
| M3 | `readSurface` ignores the injected gate | 1 failed | — |
| M4 ⚠ | flip the flag with no route behind it | 1 failed | **7/7 green** |
| M5 | the narration stops following the gate | 1 failed | — |
| M6 ⚠ | the debounce stops coalescing | 1 failed | **7/7 green** |

The old file caught exactly one of the six (dropping `strip` from the wire body).

## A gate that read a comment as an import

`gate:isolation` failed the first push on a **regex literal inside the new test** — it matches `from "…"` anywhere in a file and read the assertion's own pattern as an undeclared import of `../surfaces/surfaceSync`. Same family as the incident recorded in that checker's own header (three files' English prose, 2026-09-02). The assertion now finds the import line and reads it, and says why in a comment so the next person does not spell one out.

## Proof

**Terminal 1116 passed (95 files)**, up from 1110 · `tsc --noEmit` clean · cold `next build` green · **the 14 static gates green** (pushed without `--no-verify`). Nothing outside `clients/terminal/` is touched, so the agent, flows and rig suites are unaffected.

## Handed off, not dropped

**R-B18** — *the prompt "hot reload" does not exist: `PROCESS_KICKOFF` is read at module import (`flows_defs/production.py:103`) and `prompt_for` (`:94-96`) never touches `_global`, while `_shared_report_rules` (`:572-574`) and the F54 detector (`:548`) both assert a live override* — lives entirely in `core/flows/src/flows_defs/production.py`, which **`flows-delivery` and `flows-authz` are both editing right now** (uncommitted work in both worktrees). It belongs to **`flows-delivery`**, whose rows own that file's post-meeting half. Not touched here.

<!-- vexa-agent -->