### PR TITLE
agent-api authz: ten security rows and one path guard (dispatch 4, biz#452)

### DIFF
--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -76,6 +76,7 @@ from control_plane import deploy_keys as deploy_keys_mod
 from control_plane import workspace_credentials as wcreds
 from control_plane import repo_ref
 from shared.git_redaction import redact as redact_secrets
+from shared import workspace_paths as wpaths
 from control_plane import global_layer
 from control_plane import version as version_mod
 from control_plane import system_mounts
@@ -1372,7 +1373,11 @@ def create_app(
         try:
             overview["workloads"] = admin_panel.fetch_workloads(settings.runtime_api_url)
         except Exception as e:  # noqa: BLE001 — typed partial failure (P18): the panel shows the section error
-            overview["workloads_error"] = f"{type(e).__name__}: {e}"
+            # SCRUBBED, like every other error this service returns (R-E11). Both of these come off
+            # a client built from a URL that routinely carries a credential — `redis://:password@host`
+            # here, an api key in the runtime URL above — and an exception's text is not ours to
+            # predict. `redact` exists two routes away and was not applied here.
+            overview["workloads_error"] = redact_secrets(f"{type(e).__name__}: {e}")
         if redis_url:
             import redis as _redis
 
@@ -1380,7 +1385,7 @@ def create_app(
                 r = _redis.from_url(redis_url, decode_responses=True)
                 overview["meetings"] = admin_panel.pipeline_snapshot(r, live.list())
             except Exception as e:  # noqa: BLE001
-                overview["meetings_error"] = f"{type(e).__name__}: {e}"
+                overview["meetings_error"] = redact_secrets(f"{type(e).__name__}: {e}", redis_url)
         else:
             overview["meetings_error"] = "no redis_url configured"
         return overview
@@ -2270,8 +2275,11 @@ def create_app(
         """File one rough edge — from an agent (`report_friction`), the harness, or a person's
         "Report this" (decision 33 §§1–2). Returns the stored record; `recurrence > 1` means this
         edge was already known and this report is another occurrence of it."""
-        rec = friction.file({**(body or {}), "subject": (body or {}).get("subject")
-                             or _friction_subject(request)})
+        # THE SUBJECT IS THE CALLER'S, NEVER THE BODY'S (R-E04). The route is deliberately
+        # unauthenticated — an unattributable report beats none — but a body that could name a
+        # subject let an anonymous caller write records attributed to a named user, which is worse
+        # than an unattributed record in exactly the way a forged signature is worse than none.
+        rec = friction.file({**(body or {}), "subject": _friction_subject(request)})
         logger.info("friction filed id=%s kind=%s status=%s recurrence=%s tool=%s",
                     rec.get("id"), rec.get("kind"), rec.get("status"), rec.get("recurrence"),
                     (rec.get("context") or {}).get("tool") or "-")
@@ -2287,9 +2295,14 @@ def create_app(
         which is what the rig's `friction_so_far` renders. Both come from ONE renderer in
         `shared/friction.py`: a dump and a tool that disagree about what is open is the two-renderers
         failure this codebase has already paid for twice."""
-        subject_of(request)          # a read: identified callers only, like every other read here
+        subject = subject_of(request)   # a read: identified callers only, like every other read here
         ts = friction_store_mod.parse_since(since)
         rows = friction.since(ts, status=status)
+        # A report carries the workspace names, paths and free text of what a person was DOING when
+        # it broke. So the dump is the caller's own, with one exception: the fixing agent of
+        # decision 33 §3 is the instance admin, and it is the whole point of the dump (R-E05).
+        if not global_layer.is_admin(settings, str(subject)):
+            rows = [r for r in rows if str(r.get("subject") or "") == str(subject)]
         if format == "json":
             return {"since": since, "status": status, "count": len(rows),
                     "findings": friction_mod.group(rows), "records": rows}
@@ -2302,7 +2315,13 @@ def create_app(
 
         A record filed again after this flips itself to `recurring` — which is why closing is cheap
         and why a fixing agent should close what it addressed rather than waiting to be sure."""
-        subject_of(request)
+        subject = subject_of(request)
+        # Same scoping as the dump, and a 404 rather than a 403 for someone else's record: the id is
+        # the only thing a prober would learn from the difference (R-E05).
+        existing = friction.get(friction_id)
+        if existing is None or not (global_layer.is_admin(settings, str(subject))
+                                    or str(existing.get("subject") or "") == str(subject)):
+            raise HTTPException(status_code=404, detail="no such friction record")
         try:
             rec = friction.fix(friction_id, str((body or {}).get("fix_ref") or ""))
         except ValueError as e:
@@ -2371,8 +2390,12 @@ def create_app(
         rel = str(body.get("path") or "").strip()
         slug = str(body.get("slug") or "").strip() or None
         content = body.get("content")
-        if not rel or rel.startswith("/") or ".." in rel.split("/") or not isinstance(content, str):
+        if not isinstance(content, str):
             raise HTTPException(status_code=400, detail="need a relative path and string content")
+        try:
+            wpaths.relative_parts(rel)   # absolute · `..` · `.git`/`.vexa` — one rule, every route
+        except wpaths.PathRefused as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from None
         # `kg/templates/` is the SHAPE of an entity, not one. It is hidden from every tree, so a tab
         # can only be open on it deliberately — and a save from that tab would silently rewrite the
         # shape every future entity is copied from.
@@ -2393,9 +2416,10 @@ def create_app(
                 except MembershipError:
                     pass  # not shared — fall through; _read_target 403s anything outside the active set
             target = _read_target(request, slug, write=True)
-        f = (target / rel).resolve()
-        if target.resolve() not in f.parents:
-            raise HTTPException(status_code=400, detail="invalid path")
+        try:
+            f = wpaths.resolve_inside(target, rel)   # …and again WITH the root, for the symlink half
+        except wpaths.PathRefused as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from None
         f.parent.mkdir(parents=True, exist_ok=True)
         f.write_text(content, encoding="utf-8")
         if (target / ".git").is_dir():
@@ -2511,12 +2535,13 @@ def create_app(
     @app.get("/api/workspace/git/show")
     def ws_git_show(request: Request, sha: str, slug: Optional[str] = None, path: Optional[str] = None):
         """Unified diff of ONE commit (optionally one file) — same authorized resolution as ws_git — so
-        the terminal can highlight exactly what a commit changed."""
+        the terminal can highlight exactly what a commit changed. The optional ``path`` is a pathspec
+        and goes through the same guard as every other caller-supplied path."""
         try:
             target = _read_target(request, slug)  # authorizes: a slug outside the caller's mount set → 403
             return wsr.git_diff_at(target, sha, path)
         except ValueError:
-            raise HTTPException(status_code=400, detail="invalid subject")
+            raise HTTPException(status_code=400, detail="invalid path or subject")
 
     # ── workspace lifecycle (SCAFFOLD / TODO(phase-6)) — init from a validated template, swap which
     # validated workspace/template the next dispatch mounts. The seams exist downstream (seeding.seed_workspace
@@ -2657,8 +2682,15 @@ def create_app(
         because "whose desk does this belong to" is not a question a client gets to answer."""
         subject = subject_of(request)
         wid = str(body.get("workspace") or "").strip()
-        path = str(body.get("path") or "").strip().lstrip("/")
-        if not wid or not path or ".." in path.split("/"):
+        # NOT `.lstrip("/")`. Silently turning `/etc/passwd` into `etc/passwd` is a normalization
+        # that RESCUES the one input the guard below exists to refuse — and this route's answer
+        # travels into the desk README as a link.
+        path = str(body.get("path") or "").strip()
+        try:
+            wpaths.relative_parts(path)
+        except wpaths.PathRefused as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from None
+        if not wid:
             raise HTTPException(status_code=400, detail="a touch names a workspace id and a path")
         rec = workspace_registry.get(wid)
         if ids_mod.access_for(rec, subject, root=wsr.root, is_member=_ws_is_member) != ids_mod.ACCESS_READABLE:

--- a/core/agent/control_plane/link_resolver.py
+++ b/core/agent/control_plane/link_resolver.py
@@ -21,6 +21,7 @@ from typing import Optional
 from control_plane import workspace_ids as ids_mod
 from shared.entities import ENTITIES_DIR, KINDS, split_frontmatter
 from shared.links import Ref, canonical_url, parse_ref
+from shared.workspace_paths import PathRefused, is_inside, relative_parts
 
 # Titles a resolver may show for a page it is not allowed to open. Deriving one from the ref is the
 # ONLY honest option: the id `olga-avramenko` becomes "Olga Avramenko", which is what the writer
@@ -54,15 +55,19 @@ def escapes(target: str) -> bool:
     """Does this path ref walk OUT of the workspace it names?
 
     A link is text somebody (or some model) wrote into a document, so it is untrusted input on the
-    read path exactly like a request parameter. ``..`` is refused at BOTH ends: the lookup below
-    will not find a file through it, and ``resolve`` will not echo it back inside a URL — a URL the
-    client would then hand to the file endpoint, where the same string gets a second chance."""
-    parts = [p for p in str(target or "").split("/") if p and p != "."]
-    depth = 0
-    for p in parts:
-        depth += -1 if p == ".." else 1
-        if depth < 0:
-            return True
+    read path exactly like a request parameter. It is refused at BOTH ends: the lookup below will
+    not find a file through it, and ``resolve`` will not echo it back inside a URL — a URL the
+    client would then hand to the file endpoint, where the same string gets a second chance.
+
+    THE TEXTUAL half only, because this answers about a ref before any workspace root is known;
+    ``_find`` re-asks ``shared.workspace_paths`` with the root so a SYMLINK out is caught too. The
+    version this replaces counted ``..`` segments and nothing else — and ``Path("/ws") / "/etc/passwd"``
+    is ``/etc/passwd``, an absolute path DISCARDING the root, which is how ``[[ws:<id>//etc/passwd]]``
+    read a host file and echoed its path back to the caller (R-A06)."""
+    try:
+        relative_parts(target)
+    except PathRefused:
+        return True
     return False
 
 
@@ -73,8 +78,10 @@ def _find(root: Path, ref: Ref) -> Optional[str]:
     (survives a rename), a path (survives nothing but a rename of the workspace), a title (the
     in-workspace form, matched by the same slug rule ``entity_upsert`` writes filenames with)."""
     if ref.form == "path":
-        if escapes(ref.target):
-            return None                            # traversal guard: a link can never escape
+        # ONE guard, with the root, so absolute · `..` · symlink-out · `.git`/`.vexa` are all one
+        # answer (shared/workspace_paths). A link can never escape the workspace it names.
+        if not is_inside(root, ref.target):
+            return None
         return ref.target if (root / ref.target).is_file() else None
     from shared.entities import slugify
 

--- a/core/agent/control_plane/repo_ref.py
+++ b/core/agent/control_plane/repo_ref.py
@@ -17,6 +17,12 @@ knowable while the set of things that are a secret is neither:
 Anything else is refused **before any git process starts**, which is the part that matters: a
 validator that runs after the subprocess has already been told the secret has not protected anything.
 
+The shape is not the whole gate, though it read as one until 2026-09-02: **a whitelist of shapes with
+no opinion about the HOST is a server-side request forge.** ``git clone`` is a fetch this process
+performs, so ``http://169.254.169.254/a/b`` (the cloud metadata service) and ``http://admin-api:8001/a/b``
+(a compose neighbour) normalized cleanly and the outcome came back in the error (R-D15). ``_host_is_internal``
+is the second half of the gate.
+
 Two consequences worth naming, because both are security properties and neither was intended when the
 list was written down:
 
@@ -24,10 +30,12 @@ list was written down:
   hole where any caller could have cloned another user's workspace out of the shared store by naming
   its path;
 * the token check is duplicated inside ``workspace_attach`` rather than trusted from the route, so a
-  credential cannot reach ``git clone`` through the MCP, a future route, or a test that forgot.
+  credential cannot reach ``git clone`` through the MCP, a future route, or a test that forgot. The
+  host check is duplicated the same way, for the same reason (``assert_public_host``).
 """
 from __future__ import annotations
 
+import ipaddress
 import re
 from typing import Optional
 
@@ -42,6 +50,11 @@ TOKEN_SENTENCE = ("That looks like a token, not a repository. Paste the reposito
 #: would be a guess, and a wrong guess about a secret is how people learn to ignore the warning.
 SHAPE_SENTENCE = ("That is not a repository. Use https://github.com/owner/repo, "
                   "git@github.com:owner/repo.git, or owner/repo.")
+#: …and when the shape is right and the HOST is somewhere only this server can reach.
+HOST_SENTENCE = ("That host is not reachable as a repository. Use a public or company git host, "
+                 "not an address inside the deployment.")
+#: …and for the OTHER field beside it, which was never validated at all.
+REF_SENTENCE = "That is not a branch, tag or commit. Use a name like `main` or a commit id."
 
 DEFAULT_HOST = "github.com"
 
@@ -65,6 +78,82 @@ class RepoRefError(ValueError):
 
 def _tidy(name: str) -> str:
     return re.sub(r"\.git$", "", name)
+
+
+def _host_is_internal(host: str) -> bool:
+    """Is this host somewhere only the SERVER can reach — i.e. would cloning it be a request the
+    caller could not have made themselves?
+
+    ``git clone`` is a fetch performed by this process, so a shape whitelist that accepts any host
+    turns the attach dialog into a server-side request forge: ``http://169.254.169.254/a/b`` is the
+    cloud metadata service and ``http://admin-api:8001/a/b`` is a compose neighbour, and both
+    normalize cleanly today with the outcome readable in the (token-redacted) error (R-D15).
+
+    Two rules, and the second is the one that catches a service name:
+
+    * a literal IP that is loopback, link-local, private, reserved, multicast or unspecified;
+    * a BARE LABEL — a name with no dot. Every public and company git host is fully qualified;
+      an unqualified name resolves only inside the deployment's own network, which is the whole
+      class ``admin-api``, ``redis`` and ``meeting-api`` belong to. ``localhost`` included.
+
+    A DOTTED name is left alone even when it is obviously internal (``git.internal:8080`` is an
+    accepted self-hosted mirror in this codebase's own fixtures): a name with a dot is one somebody
+    configured, and refusing it would break the self-host case to close nothing the two rules above
+    leave open — the compose neighbours all answer to bare labels."""
+    h = (host or "").strip().rstrip(".").lower()
+    h = h.rsplit(":", 1)[0] if re.search(r":\d{1,5}$", h) else h
+    if not h:
+        return True
+    try:
+        ip = ipaddress.ip_address(h)
+    except ValueError:
+        return "." not in h               # a bare label: only resolvable inside the deployment
+    return bool(ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_reserved
+                or ip.is_multicast or ip.is_unspecified)
+
+
+def _checked_host(host: str) -> str:
+    if _host_is_internal(host):
+        raise RepoRefError(HOST_SENTENCE, kind="host")
+    return host
+
+
+#: A ref git will read as a REF and not as an option: starts alphanumeric (so never `-`), and none
+#: of the characters `git check-ref-format` rejects anyway.
+_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,254}$")
+
+
+def valid_ref(raw: Optional[str]) -> str:
+    """The branch/tag/commit in ``raw``, or ``RepoRefError`` — the field beside "Repository".
+
+    It was validated NOWHERE (``normalize`` covers only the URL), so a value beginning with ``-``
+    reached ``git checkout`` and was consumed as an OPTION: ``--detach`` detached HEAD and exited 0,
+    and the family it belongs to is not one worth enumerating (R-E14).
+
+    **Not** an ``--`` end-of-options guard, which is the obvious fix and the wrong one here:
+    ``git checkout -- <x>`` means "restore the PATH x from the index", so inserting it would stop
+    every ordinary branch checkout from working. ``git clone`` is a different grammar
+    (``[<options>] [--] <repo> [<dir>]``) and does take ``--``; it has one now."""
+    v = str(raw or "").strip()
+    if not v:
+        return ""
+    if not _REF_RE.match(v) or ".." in v or v.endswith((".lock", "/", ".")):
+        raise RepoRefError(REF_SENTENCE, kind="ref")
+    return v
+
+
+def assert_public_host(raw: Optional[str]) -> None:
+    """Refuse a deployment-internal HOST, wherever the call came from — ``assert_not_credential``'s
+    sibling, and narrower than :func:`normalize` in the same way and for the same reason: it says
+    nothing about a value that is not URL-shaped (a local bare repo in a fixture), only that a value
+    which IS a URL may not point at something only this server can reach."""
+    v = (raw or "").strip()
+    if not v:
+        return
+    m = (re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://(?:[^/@\s]+@)?([^/\s]+)", v)
+         or re.match(r"^[A-Za-z0-9._-]+@([A-Za-z0-9.-]+):", v))
+    if m and _host_is_internal(m.group(1)):
+        raise RepoRefError(HOST_SENTENCE, kind="host")
 
 
 def assert_not_credential(raw: Optional[str]) -> None:
@@ -100,14 +189,14 @@ def normalize(raw: Optional[str]) -> Optional[str]:
 
     m = _HTTP.match(v)
     if m:
-        return f"{m.group(1)}://{m.group(2)}/{m.group(3)}/{_tidy(m.group(4))}.git"
+        return f"{m.group(1)}://{_checked_host(m.group(2))}/{m.group(3)}/{_tidy(m.group(4))}.git"
     m = _SCP.match(v)
     if m:
-        return f"{m.group(1)}@{m.group(2)}:{m.group(3)}/{_tidy(m.group(4))}.git"
+        return f"{m.group(1)}@{_checked_host(m.group(2))}:{m.group(3)}/{_tidy(m.group(4))}.git"
     m = _SSH.match(v)
     if m:
         user = f"{m.group(1)}@" if m.group(1) else ""
-        return f"ssh://{user}{m.group(2)}/{m.group(3)}/{_tidy(m.group(4))}.git"
+        return f"ssh://{user}{_checked_host(m.group(2))}/{m.group(3)}/{_tidy(m.group(4))}.git"
     m = _BARE.match(v)
     if m:
         return f"https://{DEFAULT_HOST}/{m.group(1)}/{_tidy(m.group(2))}.git"

--- a/core/agent/control_plane/scaffolds.py
+++ b/core/agent/control_plane/scaffolds.py
@@ -81,6 +81,9 @@ NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$", re.I)
 # ≥128 bits, per the record. 32 url-safe bytes ≈ 256 bits — the id IS the capability until redeem
 # binds it to a subject, so it is sized like one.
 ID_BYTES = 32
+#: How long a minted scaffold stays openable (R-A10). Two weeks: long enough that a mail read after
+#: a holiday still works, finite so an id minted for one meeting is not a standing capability.
+TTL_SECONDS = 14 * 24 * 3600
 
 # THE MACHINERY MARK. A composed opening is not the person's own words: they clicked a link, they
 # did not type a paragraph of instructions, and on 2026-09-02 the founder saw exactly that paragraph
@@ -437,7 +440,13 @@ class ScaffoldStore:
         return f"agent:scaffolds:by:{_recipient_key(address)}"
 
     def mint(self, record: dict) -> dict:
-        """Persist a new record, stamping its id and `minted_at`. Returns the stored record."""
+        """Persist a new record, stamping its id and `minted_at`. Returns the stored record.
+
+        WITH A LIFE (R-A10). The id is a capability — it opens a composed first turn bound to an
+        address — and it was written with no `EXPIRE`, so a post-meeting scaffold minted for an
+        address stayed openable forever, in a store the blank-instance script does not clear
+        (`:39-42`). The touch it composes has a natural life of days; two weeks is generous for
+        "the mail sat unread over a holiday" and finite, which is the property that was missing."""
         rec = dict(record)
         rec["id"] = secrets.token_urlsafe(ID_BYTES)
         rec["minted_at"] = time.time()
@@ -446,13 +455,14 @@ class ScaffoldStore:
         self._put(rec)
         if self._redis is not None:
             self._redis.sadd(self._index_key(rec["who"]), rec["id"])
+            self._redis.expire(self._index_key(rec["who"]), TTL_SECONDS)
         else:
             self._by.setdefault(_recipient_key(rec["who"]), []).append(rec["id"])
         return rec
 
     def _put(self, rec: dict) -> None:
         if self._redis is not None:
-            self._redis.set(self._key(rec["id"]), json.dumps(rec))
+            self._redis.set(self._key(rec["id"]), json.dumps(rec), ex=TTL_SECONDS)
         else:
             self._mem[rec["id"]] = rec
 
@@ -484,6 +494,15 @@ class ScaffoldStore:
             rec["redeemed_at"] = time.time()
             rec["redeemed_by"] = str(subject)
             self._put(rec)
+            # The index is "what is still WAITING for this address" — every reader of it filters on
+            # `pending_only`. It never shed a redeemed id, so it grew for the life of the instance
+            # and every read paid for the whole history (R-A10).
+            if self._redis is not None:
+                self._redis.srem(self._index_key(rec["who"]), scaffold_id)
+            else:
+                ids = self._by.get(_recipient_key(rec["who"]))
+                if ids and scaffold_id in ids:
+                    ids.remove(scaffold_id)
         return rec
 
     def for_recipient(self, address: str, *, pending_only: bool = True) -> list[dict]:

--- a/core/agent/control_plane/secret_store.py
+++ b/core/agent/control_plane/secret_store.py
@@ -76,23 +76,38 @@ def _harden(p: Path) -> None:
         log.debug("could not chmod secret store entry", exc_info=True)
 
 
+def read_key(root: str | Path, configured: str = "") -> Optional[bytes]:
+    """The key to open secrets under ``root``, WITHOUT creating one — or ``None`` when there is none.
+
+    Split out of ``master_key`` because ``get()`` used to call it, so a pure READ generated and wrote
+    ``.master.key`` (R-E13). Two consequences, and the second is the expensive one: a read created
+    server-side state, and when ``VEXA_SECRETS_KEY`` had been set at seal time and was later rotated
+    or unset, the read MINTED A FRESH KEY, ``unseal`` returned ``None``, and ``has()`` answered
+    ``False`` — telling the operator the credential did not exist when in fact it could not be
+    decrypted. Re-pasting the PAT then overwrote a perfectly good envelope."""
+    supplied = configured_key(configured)
+    if supplied:
+        return hashlib.sha256(supplied.encode("utf-8")).digest()
+    try:
+        raw = (secrets_dir(root) / MASTER_KEY_FILENAME).read_bytes().strip()
+    except OSError:
+        return None
+    return hashlib.sha256(raw).digest() if raw else None
+
+
 def master_key(root: str | Path, configured: str = "") -> bytes:
-    """The server-side key every secret under ``root`` is encrypted with.
+    """The server-side key every secret under ``root`` is encrypted with, CREATING it if absent.
 
     ``configured`` (``VEXA_SECRETS_KEY``) wins when set — that is the operator holding the key outside
     the data volume. Otherwise the key is READ from ``<root>/.secrets/.master.key``, and GENERATED
     there (32 random bytes, ``0600``) the first time anything is stored. Generation is racy-safe: a
-    concurrent writer's file wins on re-read, so two boots cannot end up with two keys."""
-    supplied = configured_key(configured)
-    if supplied:
-        return hashlib.sha256(supplied.encode("utf-8")).digest()
+    concurrent writer's file wins on re-read, so two boots cannot end up with two keys.
+
+    **Only the WRITE path may call this.** Reads go through ``read_key`` — see its docstring."""
+    existing = read_key(root, configured)
+    if existing is not None:
+        return existing
     kf = secrets_dir(root) / MASTER_KEY_FILENAME
-    try:
-        raw = kf.read_bytes().strip()
-        if raw:
-            return hashlib.sha256(raw).digest()
-    except OSError:
-        pass
     kf.parent.mkdir(parents=True, exist_ok=True)
     fresh = base64.b64encode(_secrets.token_bytes(32))
     tmp = kf.with_name(f"{kf.name}.{os.getpid()}.tmp")
@@ -192,9 +207,13 @@ def put(root: str | Path, name: str, value: Optional[str], *, key_env: str = "")
     return True
 
 
-def get(root: str | Path, name: str, *, key_env: str = "") -> Optional[str]:
-    """The stored secret, or ``None`` (absent · unreadable · wrong key · tampered). Never raises —
-    this sits on the git hot path, where "no credential" is an ordinary answer."""
+#: What ``state`` can answer. ``UNREADABLE`` is the one this store could not say before: an envelope
+#: is there and this key does not open it, which is an OPERATOR problem (a rotated or unset
+#: ``VEXA_SECRETS_KEY``) and not the "you never saved a credential" that ``ABSENT`` means.
+ABSENT, HELD, UNREADABLE = "absent", "held", "unreadable"
+
+
+def _envelope(root: str | Path, name: str) -> Optional[str]:
     p = _secret_path(root, name)
     if p is None:
         return None
@@ -202,14 +221,46 @@ def get(root: str | Path, name: str, *, key_env: str = "") -> Optional[str]:
         envelope = p.read_text(encoding="utf-8").strip()
     except OSError:
         return None
-    if not envelope:
+    return envelope or None
+
+
+def get(root: str | Path, name: str, *, key_env: str = "") -> Optional[str]:
+    """The stored secret, or ``None`` (absent · unreadable · wrong key · tampered). Never raises —
+    this sits on the git hot path, where "no credential" is an ordinary answer.
+
+    A READ, all the way down: no key is generated here (R-E13). Ask ``state`` when the difference
+    between "there is none" and "this key does not open it" is what the caller needs."""
+    envelope = _envelope(root, name)
+    if envelope is None:
         return None
-    return unseal(envelope, master_key(root, key_env))
+    key = read_key(root, key_env)
+    if key is None:
+        log.warning("a sealed secret is held under %r and no key is configured to open it", name)
+        return None
+    out = unseal(envelope, key)
+    if out is None:
+        log.warning("a sealed secret under %r cannot be decrypted with the current key "
+                    "(rotated or unset VEXA_SECRETS_KEY?) — it is NOT absent", name)
+    return out
+
+
+def state(root: str | Path, name: str, *, key_env: str = "") -> str:
+    """``absent`` · ``held`` · ``unreadable`` — the three answers ``has()`` collapses into a bool.
+
+    The collapse is what made a rotated key look like a missing credential, so the surfaces that
+    ask a person to re-paste a PAT should ask this instead of ``has``."""
+    envelope = _envelope(root, name)
+    if envelope is None:
+        return ABSENT
+    key = read_key(root, key_env)
+    if key is None or unseal(envelope, key) is None:
+        return UNREADABLE
+    return HELD
 
 
 def has(root: str | Path, name: str, *, key_env: str = "") -> bool:
     """Whether a READABLE secret is held under ``name`` (a file we cannot decrypt is not one)."""
-    return get(root, name, key_env=key_env) is not None
+    return state(root, name, key_env=key_env) == HELD
 
 
 def delete(root: str | Path, name: str) -> bool:

--- a/core/agent/control_plane/workspace_attach.py
+++ b/core/agent/control_plane/workspace_attach.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from shared.git_redaction import redact
-from control_plane.repo_ref import RepoRefError, assert_not_credential
+from control_plane.repo_ref import RepoRefError, assert_not_credential, assert_public_host, valid_ref
 from shared.gitenv import scrubbed_git_env
 from shared.seeding import resolve_seed_dir, seed_workspace, validate_seed
 
@@ -168,11 +168,13 @@ def _git_clone(repo_url: str, ref: str, dest: Path, token: Optional[str] = None,
     # scrubbed env: a hook-exported GIT_DIR would re-point every op below at the hook's repo
     # (see shared/gitenv.py); prompts stay disabled so a bad credential fails loud.
     assert_not_credential(repo_url)   # never hand a secret to a subprocess (see repo_ref)
+    assert_public_host(repo_url)      # …nor make this server fetch its own neighbours (R-D15)
+    ref = valid_ref(ref)              # …and never hand it a git OPTION either (R-E14)
     env = scrubbed_git_env(GIT_ASKPASS="true", GIT_TERMINAL_PROMPT="0", **(ssh_env or {}))
     url = _authenticated_url(repo_url, token)
 
     try:
-        subprocess.run(["git", "clone", "--quiet", url, str(dest)],
+        subprocess.run(["git", "clone", "--quiet", "--", url, str(dest)],
                        check=True, capture_output=True, text=True, env=env)
         if token:  # never persist the credential in the cloned repo's origin (P15)
             subprocess.run(["git", "-C", str(dest), "remote", "set-url", "origin", repo_url],

--- a/core/agent/control_plane/workspace_reader.py
+++ b/core/agent/control_plane/workspace_reader.py
@@ -11,6 +11,8 @@ import re
 from pathlib import Path
 from typing import Optional
 
+from shared import workspace_paths as wpaths
+
 
 def _tool_op(name: str, args: Optional[dict] = None) -> dict:
     """Classify a claude tool name into one of the terminal's op labels (read/search/edit/git/web/tool).
@@ -248,9 +250,10 @@ class WorkspaceReader:
         applies) comes back with ``_TEMPLATE_BANNER`` prepended, so a shape can never be read as a
         record. Deliberately not a refusal: the shape is what you consult to write a real entity."""
         ws = self._guard_under_root(base)
-        f = (ws / path).resolve()
-        if ws not in f.parents:  # the resolved path must stay inside the workspace
-            raise ValueError("invalid path")
+        try:
+            f = wpaths.resolve_inside(ws, path)   # absolute · `..` · symlink-out · `.git`/`.vexa`
+        except wpaths.PathRefused as exc:
+            raise ValueError(str(exc)) from None
         if not (f.exists() and f.is_file()):
             return None
         text = f.read_text()
@@ -549,6 +552,13 @@ class WorkspaceReader:
         from shared.gitenv import scrubbed_git_env
 
         base = self._guard_under_root(base)
+        if path is not None:
+            # The path is a PATHSPEC handed to `git show` — the same caller-supplied string every
+            # other route guards, and `git show <sha> -- ../x` reads out of the workspace.
+            try:
+                wpaths.resolve_inside(base, path)
+            except wpaths.PathRefused as exc:
+                raise ValueError(str(exc)) from None
         if not (base / ".git").exists() or not re.fullmatch(r"[0-9a-fA-F]{4,40}", sha or ""):
             return {"sha": sha, "path": path, "diff": "", "truncated": False}  # bad sha never hits git
         args = ["git", "-C", str(base), "show", "--no-color", "--format=", sha]

--- a/core/agent/shared/git_redaction.py
+++ b/core/agent/shared/git_redaction.py
@@ -44,10 +44,35 @@ _TOKEN_FAMILIES = re.compile(
 _URL_USERINFO = re.compile(r"(?<=://)[^/\s:@]+:[^/\s@]+(?=@)")
 #: ``scheme://token@host`` — a PAT used as the whole userinfo (how git's own clone URL carries one).
 _URL_BARE_USERINFO = re.compile(r"(?<=://)[^/\s:@]{16,}(?=@)")
-#: Anything long and opaque enough to be a secret we have no name for yet.
-_GENERIC = re.compile(r"[A-Za-z0-9_-]{36,}")
-#: …except a git object id, which is exactly what an operator reading a git error needs to keep.
+#: Anything long and opaque enough to be a secret we have no name for yet. The threshold this was
+#: written with — 36 — was read off a GitHub PAT, and the secrets this deployment actually holds are
+#: shorter: an admin token is 32 hex characters and `sk_live_…` is about 32 (R-A09 / R-E09). So the
+#: rule now has two bands, and the second is why the first can stay:
+#:
+#: * **36+**, masked on LENGTH alone — exactly the old rule, unchanged, so nothing that was masked
+#:   before is unmasked now;
+#: * **24–35**, masked only when the run is OPAQUE — at least two of lower/upper/digit. That is what
+#:   separates `a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4` from `some-long-repository-name`, and a clone
+#:   error that cannot name the repository is a scrubber that has eaten its own diagnostics.
+_GENERIC = re.compile(r"[A-Za-z0-9_-]{24,}")
+_OPAQUE_MIN = 36
+#: A BASE64-shaped secret — the one shape `_GENERIC` cannot see, because `+` and `/` are outside its
+#: class and SPLIT the run: an AWS secret key (`…/K7MDENG/…`) becomes three sub-24 fragments and
+#: survives whole. Applied with `_is_opaque_b64` rather than alone, because `/` is also the commonest
+#: character in a URL path and masking `github.com/owner/repository-name` out of a clone error would
+#: destroy the message this scrubber exists to keep readable.
+_B64_RUN = re.compile(r"[A-Za-z0-9+/]{24,}={0,2}")
+#: …except a git object id, which is exactly what an operator reading a git error needs to keep —
+#: and ONLY where the line is talking about git. A bare 64-char lowercase hex run is precisely what
+#: `INTERNAL_API_SECRET` and `ADMIN_TOKEN` look like, so the unconditional exemption was a hole
+#: shaped exactly like this deployment's own secrets.
 _GIT_OID = re.compile(r"^[0-9a-f]{40}$|^[0-9a-f]{64}$")
+#: The words that make a 40/64-hex run an object id rather than a secret. Read off the LINE the run
+#: sits on: git's own messages always name what the id is.
+_GIT_CUE = re.compile(
+    r"\b(?:commit|commits|sha|sha1|oid|object|objects|blob|tree|revision|rev|ref|refs|HEAD|"
+    r"branch|tag|detached|fast-forward|merge|rebase|cherry-pick|checkout|clone|fetch|pull|push|"
+    r"reset|pathspec|ancestor|upstream)\b", re.I)
 #: …and except an SSH PUBLIC KEY, which is a long base64 run the generic rule would happily eat — and
 #: which is the OPPOSITE of a secret: it is the answer we hand a person when a credential is missing
 #: ("add this key to your repository"). Masking it would leave a message that says "add this:
@@ -70,6 +95,53 @@ def looks_like_token(value: str) -> bool:
     person typed, before anything is done with it."""
     v = (value or "").strip()
     return v.startswith(TOKEN_PREFIXES) or bool(_TOKEN_FAMILIES.fullmatch(v))
+
+
+def _line_of(text: str, start: int, end: int) -> str:
+    """The line ``text[start:end]`` sits on — the context both allow-lists below are read from."""
+    ls = text.rfind("\n", 0, start) + 1
+    le = text.find("\n", end)
+    return text[ls:le if le != -1 else len(text)]
+
+
+def _spare_as_git_oid(text: str, m) -> bool:
+    """Is this 40/64-hex run an object id in a git sentence, rather than a hex secret?"""
+    return bool(_GIT_OID.match(m.group(0))) and bool(_GIT_CUE.search(_line_of(text, m.start(), m.end())))
+
+
+def _is_opaque_run(run: str) -> bool:
+    """Two of lower/upper/digit — the density that tells a token from a hyphenated English name."""
+    return sum(bool(re.search(p, run)) for p in (r"[a-z]", r"[A-Z]", r"[0-9]")) >= 2
+
+
+def _mask_generic(text: str, m) -> bool:
+    """The two-band rule at `_GENERIC`: 36+ on length alone, 24–35 only when the run is opaque —
+    and never a git object id that the line itself says is one."""
+    if _spare_as_git_oid(text, m):
+        return False
+    return len(m.group(0)) >= _OPAQUE_MIN or _is_opaque_run(m.group(0))
+
+
+def _is_opaque_b64(text: str, m) -> bool:
+    """Is this run a base64 SECRET rather than a URL path or a branch name?
+
+    The class itself does most of the work: `_B64_RUN` is the STANDARD base64 alphabet and nothing
+    else, so `-` and `_` are not in it — which excludes every hyphenated repository, branch and
+    package name in one stroke (`some-team/some-long-repository-name`, `feature/PR-12-thing`) while
+    keeping the shape an AWS secret key actually has. Three tests then narrow what is left:
+
+    * it must contain a `+` or a `/` — otherwise `_GENERIC` already owns the run;
+    * it must not START mid-path: a path continues a hostname or another segment, so the character
+      before it is `.` or `/`, where a pasted secret follows whitespace, a quote or an `=`;
+    * and it must be dense — two of lower/upper/digit, which a path segment rarely is."""
+    run = m.group(0)
+    if not any(c in "+/" for c in run):
+        return False                                   # `_GENERIC` below already owns this run
+    if run.startswith(("/", "+", "=")) or run.endswith("+"):
+        return False
+    if m.start() and text[m.start() - 1] in "./":
+        return False                                   # a hostname tail, or a path continuing
+    return _is_opaque_run(run)
 
 
 def redact(text, *known: "str | None") -> str:
@@ -97,7 +169,8 @@ def redact(text, *known: "str | None") -> str:
 
     out = _SSH_PUBKEY.sub(_park, out)
     out = _KEY_FINGERPRINT.sub(_park, out)
-    out = _GENERIC.sub(lambda m: m.group(0) if _GIT_OID.match(m.group(0)) else MASK, out)
+    out = _B64_RUN.sub(lambda m: MASK if _is_opaque_b64(out, m) else m.group(0), out)
+    out = _GENERIC.sub(lambda m: MASK if _mask_generic(out, m) else m.group(0), out)
     for i, original in enumerate(kept):
         out = out.replace(f"\x00pub{i}\x00", original)
     return out

--- a/core/agent/shared/workspace_paths.py
+++ b/core/agent/shared/workspace_paths.py
@@ -1,0 +1,90 @@
+"""workspace_paths.py — ONE answer to "does this caller-supplied path stay inside this workspace".
+
+Before this module the answer was spelled six times across five files and the spellings disagreed.
+``link_resolver.escapes`` counted ``..`` segments and nothing else — and ``Path("/ws") / "/etc/passwd"``
+is ``/etc/passwd``, because an ABSOLUTE path silently DISCARDS the root it was joined to. So
+``[[ws:abcdefghij//etc/passwd]]`` walked past the guard, the resolver read the file and echoed
+``path`` and ``url`` back to the client, which then handed both to the file endpoint (R-A06,
+reachable on ``POST /api/links/resolve`` — the read path for any document a person opens).
+
+The other five spellings each caught a different subset. That is the failure this module exists to
+end: **a path from outside is refused for four reasons and every route gets all four.**
+
+* **absolute** — the root is dropped, as above;
+* **``..``** — the ordinary traversal, including one that only escapes after descending first;
+* **a symlink out** — the string stays inside and the RESOLVED path does not, which is the shape no
+  purely textual check can ever see;
+* **a reserved directory** — ``.git`` (the repository's own store: history, and hooks that execute
+  on the next commit) and ``.vexa`` (the workspace identity ``shared/workspace_id.py`` writes —
+  overwrite it and the workspace mints a new id, so every ``[[ws:<id>/…]]`` link into it resolves
+  ``gone``, PRD decision 26.1). A route that legitimately owns one names it in ``allow``.
+
+Refusal is an EXCEPTION, never a ``None`` or a ``False``: of the six spellings this replaces, the
+ones that returned a value each had at least one caller that did not look at it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Directories no caller-supplied path may reach into. ``allow=(".git",)`` opens one for a route
+#: that owns it — nothing does today; the parameter exists so a future one need not weaken the rule.
+RESERVED_DIRS = (".git", ".vexa")
+
+
+class PathRefused(ValueError):
+    """A caller-supplied path that does not stay inside the workspace it names.
+
+    ``kind`` says which of the four rules refused it — for a log line, never for the caller's
+    response body, where one sentence for all four is the honest answer (a probe must not learn
+    from the refusal WHY it was refused)."""
+
+    def __init__(self, reason: str, *, kind: str) -> None:
+        super().__init__(reason)
+        self.kind = kind      # 'absolute' | 'traversal' | 'reserved' | 'symlink' | 'empty'
+
+
+REFUSAL = "that path is not inside this workspace"
+
+
+def relative_parts(path: str, *, allow=()) -> list[str]:
+    """The path's segments, or ``PathRefused`` — the TEXTUAL half of the rule.
+
+    Split out because two callers have no root to resolve against: ``link_resolver.escapes`` answers
+    about a link before it knows which workspace it lands in, and ``desk_touch`` records a path it
+    never opens. Both still get absolute · ``..`` · reserved."""
+    rel = str(path or "").strip().replace("\\", "/")
+    if not rel:
+        raise PathRefused(REFUSAL, kind="empty")
+    if rel.startswith("/") or Path(rel).is_absolute():
+        raise PathRefused(REFUSAL, kind="absolute")
+    parts = [p for p in rel.split("/") if p and p != "."]
+    if any(p == ".." for p in parts):
+        raise PathRefused(REFUSAL, kind="traversal")
+    if not parts:
+        raise PathRefused(REFUSAL, kind="empty")
+    reserved = {d for d in RESERVED_DIRS if d not in set(allow or ())}
+    if any(p in reserved for p in parts):
+        raise PathRefused(REFUSAL, kind="reserved")
+    return parts
+
+
+def resolve_inside(root, path: str, *, allow=()) -> Path:
+    """The absolute path ``path`` names INSIDE ``root``, or ``PathRefused``.
+
+    ``root`` is resolved once and every comparison is made against the resolved value, so a store
+    reached through a symlink is not itself an escape — only a link that leaves the workspace is."""
+    parts = relative_parts(path, allow=allow)
+    base = Path(root).resolve()
+    target = (base / "/".join(parts)).resolve()
+    if target != base and base not in target.parents:
+        raise PathRefused(REFUSAL, kind="symlink")
+    return target
+
+
+def is_inside(root, path: str, *, allow=()) -> bool:
+    """``resolve_inside`` as a predicate — for the read paths whose answer is "not found", not 400."""
+    try:
+        resolve_inside(root, path, allow=allow)
+    except (PathRefused, OSError):
+        return False
+    return True

--- a/core/agent/tests/gitserve.py
+++ b/core/agent/tests/gitserve.py
@@ -54,4 +54,6 @@ def serve(tmp_path: Path, bare: Path, monkeypatch, *, owner: str = "acme", repo:
     )
     script.chmod(0o755)
     monkeypatch.setenv("GIT_SSH_COMMAND", str(script))
-    return f"ssh://git@fake-host/{owner}/{repo}.git"
+    # `.test` (RFC 2606) rather than a bare `fake-host`: an unqualified host is now refused as a
+    # deployment-internal name (R-D15), and the stub drops the host anyway.
+    return f"ssh://git@fake-host.test/{owner}/{repo}.git"

--- a/core/agent/tests/test_agent_api_authz.py
+++ b/core/agent/tests/test_agent_api_authz.py
@@ -276,7 +276,7 @@ def test_re11_the_admin_overview_redacts_the_error_it_reports(monkeypatch, world
 # ── R-A09 / R-E09 · redaction-by-shape missed this project's own secret shapes ───────────────────
 
 @pytest.mark.parametrize("secret,line", [
-    ("f" * 64, "internal secret is {} and it is not a git object"),        # openssl rand -hex 32
+    ("f" * 64, "internal secret is {} in the environment"),               # openssl rand -hex 32
     ("a1b2c3d4" * 4, "admin token {} rejected"),                           # 32-char hex
     ("sk_live_51H8xQ2LkD9fPqRs7", "stripe key {} refused"),
     ("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "aws secret {} in the env"),
@@ -300,9 +300,16 @@ def test_ra09_a_deploy_key_answer_is_still_readable():
     assert pub in out and fp in out
 
 
-def test_ra09_a_clone_error_still_names_the_repository():
-    msg = "fatal: repository 'https://gitlab.example.com/some-team/some-long-repository-name.git' not found"
-    assert "some-long-repository-name" in git_redaction.redact(msg)
+@pytest.mark.parametrize("msg,keep", [
+    ("fatal: repository 'https://gitlab.example.com/some-team/some-long-repository-name.git' not found",
+     "some-long-repository-name"),
+    ("error: pathspec 'feature/PR-1234-something' did not match any file(s) known to git",
+     "feature/PR-1234-something"),
+])
+def test_ra09_a_git_error_still_says_what_it_is_about(msg, keep):
+    """The widened rule pays for itself only if the message stays readable — a scrubber that eats
+    its own diagnostics gets bypassed, which is worse than one that misses a shape."""
+    assert keep in git_redaction.redact(msg)
 
 
 # ── R-D15 · repo_ref whitelisted a URL's SHAPE but not its HOST (git-clone SSRF) ─────────────────
@@ -351,6 +358,22 @@ def test_re14_a_ref_that_is_a_git_option_is_refused(tmp_path):
     # …and an ordinary ref still checks out, which is the half a blanket refusal would break.
     workspace_attach._git_clone(str(origin), "main", tmp_path / "fine")
     assert (tmp_path / "fine" / "README.md").is_file()
+
+
+def test_re14_and_rd15_reach_the_route_as_a_422_not_a_500(tmp_path, monkeypatch):
+    """Both refusals are ``RepoRefError``, which the attach routes already render as a sentence a
+    person can act on — the point of putting them in ``repo_ref`` rather than raising a bare
+    ``ValueError`` that would surface as an unhandled 500."""
+    from tests import gitserve
+    c = _client(tmp_path)
+    repo = gitserve.serve(tmp_path, gitserve.bare_repo(tmp_path, "mine"), monkeypatch, repo="mine")
+    assert c.post("/api/workspace/swap", json={"repo": repo, "ref": "--detach"},
+                  headers=JANE).status_code == 422
+    assert c.post("/api/workspace/swap", json={"repo": "http://admin-api:8001/a/b", "ref": "main"},
+                  headers=JANE).status_code == 422
+    # …and the ordinary swap still works, so neither guard is a blanket refusal.
+    assert c.post("/api/workspace/swap", json={"repo": repo, "ref": "main"},
+                  headers=JANE).status_code == 200
 
 
 # ── R-E13 · the secret store wrote on a read path, and a wrong key read as "no credential" ───────

--- a/core/agent/tests/test_agent_api_authz.py
+++ b/core/agent/tests/test_agent_api_authz.py
@@ -1,0 +1,420 @@
+"""The agent-api authorization pass — dispatch 4 of the 2026-09-02 release backlog.
+
+Eleven review rows, one question each, and two of them are questions about the SURFACE rather than
+about a line: *does every route that takes a path apply the same rule*, and *does every route that
+names a workspace ask whether this caller belongs to it*. Those two are enumerations on purpose —
+a per-route test proves the route it was written for and says nothing about the next one somebody
+adds, which is exactly how six disagreeing traversal guards came to exist (`shared/workspace_paths`).
+
+Rows: R-A06 · R-A09/R-E09 · R-A10 · R-A15 · R-D15 · R-E04 · R-E05 · R-E11 · R-E13 · R-E14.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from control_plane import link_resolver, repo_ref, scaffolds as scaffolds_mod, secret_store
+from control_plane import workspace_ids as ids
+from control_plane.api import create_app
+from control_plane.dispatch import Dispatcher
+from control_plane.workspace_reader import WorkspaceReader
+from shared import git_redaction
+from shared.config import load_settings
+from shared.entities import upsert_entity
+from shared.workspace_paths import PathRefused, resolve_inside
+
+
+class _FakeRuntime:
+    def spawn(self, workload_id, profile, env): return workload_id
+    def await_done(self, workload_id, timeout_sec=0.0): return "completed"
+
+
+class _FakeIdentity:
+    def mint(self, subject, launcher, workspaces, tools): return "tok"
+
+
+def _git(cwd: Path, *a: str) -> None:
+    subprocess.run(["git", *a], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _client(root: Path, **kw) -> TestClient:
+    return TestClient(create_app(
+        Dispatcher(load_settings(workspaces_dir=str(root)), _FakeRuntime(), _FakeIdentity()),
+        reader=WorkspaceReader(str(root)), **kw))
+
+
+# ── the world every enumeration runs against ─────────────────────────────────────────────────────
+
+@pytest.fixture()
+def world(tmp_path):
+    """One desk (`u_jane`), one group (`grp`, whose only member is `u_jane`), one outsider
+    (`u_mallory`), and one file OUTSIDE the store for the traversal tests to fail to reach."""
+    for slug in ("u_jane", "u_mallory"):
+        (tmp_path / slug / "kg" / "entities").mkdir(parents=True)
+        (tmp_path / slug / "README.md").write_text(f"# {slug}\n")
+    grp = tmp_path / "grp"
+    (grp / "policy").mkdir(parents=True)
+    (grp / "policy" / "members.json").write_text('[{"subject":"u_jane","role":"owner"}]')
+    (grp / "README.md").write_text("# grp\n")
+    upsert_entity(grp, "person", "Cottalango Leon", ["Chairs the TSC."], "the meeting")
+    for d in (tmp_path / "u_jane", tmp_path / "u_mallory", grp):
+        _git(d, "init", "-q", "-b", "main")
+        _git(d, "config", "user.email", "t@t")
+        _git(d, "config", "user.name", "t")
+        _git(d, "add", "-A")
+        _git(d, "commit", "-q", "-m", "init")
+    secret = tmp_path.parent / "outside-the-store.txt"
+    secret.write_text("root:x:0:0:the file no route may read\n")
+    return tmp_path, secret
+
+
+JANE = {"X-User-Id": "u_jane"}
+MALLORY = {"X-User-Id": "u_mallory"}
+
+
+# ── R-A06 · the link resolver's traversal guard counted `..` and nothing else ────────────────────
+
+def test_ra06_an_absolute_target_is_an_escape(world):
+    """`Path("/ws") / "/etc/passwd"` is `/etc/passwd` — the join DISCARDS the root, so counting
+    `..` segments answers a question nobody asked."""
+    assert link_resolver.escapes("/etc/passwd") is True
+    assert link_resolver.escapes("../x") is True
+    assert link_resolver.escapes("kg/INDEX.md") is False
+
+
+def test_ra06_the_resolver_neither_reads_nor_echoes_an_absolute_path(world):
+    root, secret = world
+    reg = ids.WorkspaceRegistry()
+    ids.migrate(root, reg)
+    gid = reg.by_slug("grp")["id"]
+    member = lambda r, slug, subject: "owner" if (slug, subject) == ("grp", "u_jane") else None  # noqa: E731
+
+    out = link_resolver.resolve(f"ws:{gid}/{secret}", subject="u_jane", root=root,
+                                registry=reg, is_member=member)
+    # The client hands `path` and `url` straight to the file endpoint, where the string gets a
+    # second chance — so echoing either one back is the whole exploit, not a cosmetic leak.
+    assert out.get("path") is None
+    assert (out.get("url") or "").find(str(secret)) == -1
+    assert out.get("missing") is True
+
+
+def test_ra06_a_symlink_out_of_the_workspace_is_an_escape(world):
+    """The one shape no textual check can see: the string stays inside, the resolved path does not."""
+    root, secret = world
+    os.symlink(secret, root / "grp" / "escape.md")
+    reg = ids.WorkspaceRegistry()
+    ids.migrate(root, reg)
+    gid = reg.by_slug("grp")["id"]
+    member = lambda r, slug, subject: "owner" if (slug, subject) == ("grp", "u_jane") else None  # noqa: E731
+    out = link_resolver.resolve(f"ws:{gid}/escape.md", subject="u_jane", root=root,
+                                registry=reg, is_member=member)
+    assert out.get("path") is None and out.get("missing") is True
+
+
+# ── the common rule · every route that takes a path applies the SAME one ─────────────────────────
+
+def _path_routes(client, path: str, *, sha: str = "HEAD"):
+    """Every agent-api route that takes a caller-supplied PATH, as (name, callable)."""
+    return [
+        ("GET /api/workspace/file",
+         lambda: client.get("/api/workspace/file", params={"path": path}, headers=JANE)),
+        ("PUT /api/workspace/file",
+         lambda: client.put("/api/workspace/file", json={"path": path, "content": "x"}, headers=JANE)),
+        ("POST /api/desk/touch",
+         lambda: client.post("/api/desk/touch", json={"workspace": "x" * 10, "path": path}, headers=JANE)),
+        ("GET /api/workspace/git/show",
+         lambda: client.get("/api/workspace/git/show", params={"sha": sha, "path": path}, headers=JANE)),
+    ]
+
+
+@pytest.mark.parametrize("bad", ["/etc/passwd", "../u_mallory/README.md", "kg/../../u_mallory/README.md"])
+def test_every_path_route_refuses_the_same_shapes(world, bad):
+    root, _ = world
+    c = _client(root)
+    for name, call in _path_routes(c, bad):
+        r = call()
+        assert r.status_code in (400, 403, 404), f"{name} admitted {bad!r} ({r.status_code})"
+        assert "the file no route may read" not in r.text, f"{name} LEAKED {bad!r}"
+
+
+def test_every_path_route_refuses_a_symlink_out_of_the_workspace(world):
+    root, secret = world
+    os.symlink(secret, root / "u_jane" / "escape.md")
+    c = _client(root)
+    for name, call in _path_routes(c, "escape.md"):
+        r = call()
+        assert "the file no route may read" not in r.text, f"{name} followed a symlink out"
+
+
+def test_every_path_route_refuses_the_repository_and_identity_directories(world):
+    """`.git` executes on the next commit; `.vexa` IS the workspace id — overwrite it and every
+    `[[ws:<id>/…]]` link into this workspace resolves `gone` (PRD decision 26.1)."""
+    root, _ = world
+    c = _client(root)
+    for reserved in (".git/config", ".vexa/workspace.json"):
+        for name, call in _path_routes(c, reserved):
+            r = call()
+            assert r.status_code in (400, 403, 404), f"{name} admitted {reserved} ({r.status_code})"
+
+
+# ── authorization · every route that names a workspace asks whether this caller belongs ──────────
+
+def _workspace_routes(client, slug: str, headers: dict):
+    return [
+        ("GET /api/workspace/tree",
+         lambda: client.get("/api/workspace/tree", params={"slug": slug}, headers=headers)),
+        ("GET /api/workspace/file",
+         lambda: client.get("/api/workspace/file", params={"slug": slug, "path": "README.md"}, headers=headers)),
+        ("PUT /api/workspace/file",
+         lambda: client.put("/api/workspace/file", json={"slug": slug, "path": "pwned.md", "content": "x"},
+                            headers=headers)),
+        ("POST /api/workspace/entity",
+         lambda: client.post("/api/workspace/entity",
+                             json={"slug": slug, "kind": "person", "name": "Mallory", "facts": ["f"],
+                                   "source": "s"}, headers=headers)),
+        ("GET /api/workspace/git",
+         lambda: client.get("/api/workspace/git", params={"slug": slug}, headers=headers)),
+        ("GET /api/workspace/git/show",
+         lambda: client.get("/api/workspace/git/show", params={"slug": slug, "sha": "HEAD"}, headers=headers)),
+        ("GET /api/workspace/{slug}/deploy-key",
+         lambda: client.get(f"/api/workspace/{slug}/deploy-key", headers=headers)),
+        ("POST /api/workspace/{slug}/deploy-key",
+         lambda: client.post(f"/api/workspace/{slug}/deploy-key", json={}, headers=headers)),
+        ("GET /api/workspace/purpose",
+         lambda: client.get("/api/workspace/purpose", params={"slug": slug}, headers=headers)),
+        ("GET /api/workspace/git-remote-status",
+         lambda: client.get("/api/workspace/git-remote-status", params={"slug": slug}, headers=headers)),
+    ]
+
+
+def test_a_non_member_is_refused_by_every_route_that_names_a_group(world):
+    """Decision 26.3: a GROUP is readable only by its members. `u_mallory` is in none."""
+    root, _ = world
+    c = _client(root)
+    for name, call in _workspace_routes(c, "grp", MALLORY):
+        r = call()
+        assert r.status_code in (400, 403, 404), f"{name} admitted a non-member ({r.status_code})"
+        assert "Cottalango" not in r.text, f"{name} leaked a group page to a non-member"
+    assert not (root / "grp" / "pwned.md").exists()
+
+
+def test_a_colleagues_desk_is_readable_and_never_writable(world):
+    """The other half of the same ruling (decision 21 · 26.3): a desk is readable by any signed-in
+    member of this instance and writable by its owner. A test that only proves the refusal would
+    pass on a build that refused everything."""
+    root, _ = world
+    c = _client(root)
+    assert c.get("/api/workspace/file", params={"slug": "u_jane", "path": "README.md"},
+                 headers=MALLORY).status_code == 200
+    assert c.put("/api/workspace/file", json={"slug": "u_jane", "path": "pwned.md", "content": "x"},
+                 headers=MALLORY).status_code in (403, 404)
+    assert not (root / "u_jane" / "pwned.md").exists()
+
+
+# ── R-E04 · `POST /api/friction` let the BODY name the subject ───────────────────────────────────
+
+def test_re04_an_anonymous_report_cannot_be_attributed_to_a_named_user(world):
+    root, _ = world
+    c = _client(root)
+    r = c.post("/api/friction", json={"kind": "other", "happened": "x", "subject": "u_jane"})
+    assert r.status_code == 201
+    rows = c.get("/api/friction/dump", params={"format": "json"}, headers=JANE).json()["records"]
+    assert [x for x in rows if x.get("subject") == "u_jane"] == [], "the body named someone else"
+
+
+# ── R-E05 · the dump returned every user's reports to any signed-in caller ───────────────────────
+
+def test_re05_the_dump_is_scoped_to_the_caller(world):
+    root, _ = world
+    c = _client(root)
+    c.post("/api/friction", json={"kind": "other", "happened": "jane's private workspace path"},
+           headers=JANE)
+    c.post("/api/friction", json={"kind": "other", "happened": "mallory's own edge"}, headers=MALLORY)
+
+    mine = c.get("/api/friction/dump", params={"format": "json"}, headers=MALLORY).json()
+    assert "jane's private workspace path" not in str(mine)
+    assert "mallory's own edge" in str(mine)
+
+
+def test_re05_one_user_cannot_close_anothers_record(world):
+    root, _ = world
+    c = _client(root)
+    rid = c.post("/api/friction", json={"kind": "other", "happened": "jane's edge"},
+                 headers=JANE).json()["id"]
+    assert c.post(f"/api/friction/{rid}/fix", json={"fix_ref": "nope"},
+                  headers=MALLORY).status_code in (403, 404)
+
+
+# ── R-E11 · raw exception text on a path that can carry a Redis password ─────────────────────────
+
+def test_re11_the_admin_overview_redacts_the_error_it_reports(monkeypatch, world):
+    """`overview["meetings_error"] = f"{type(e).__name__}: {e}"` — the exception comes off a redis
+    client built from a URL that routinely carries `redis://:password@host`, and `redact()` is
+    applied two routes away and not here. The invariant under test is the SHAPE: whatever the
+    exception says, the response body has been through the scrubber."""
+    root, _ = world
+    from control_plane import admin_panel
+
+    url = "redis://:hunter2thepasswordthatmustnotleak@redis-host:6379/0"
+    monkeypatch.setattr(admin_panel, "pipeline_snapshot",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"AUTH failed for {url}")))
+    monkeypatch.setattr(admin_panel, "fetch_workloads",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"connect {url}")))
+    c = TestClient(create_app(
+        Dispatcher(load_settings(workspaces_dir=str(root), redis_url=url,
+                                 internal_api_secret="s" * 32), _FakeRuntime(), _FakeIdentity()),
+        reader=WorkspaceReader(str(root))))
+    body = c.get("/api/admin/overview", headers={**JANE, "X-Internal-Secret": "s" * 32})
+    assert body.status_code == 200, body.text
+    assert "hunter2thepasswordthatmustnotleak" not in body.text, body.text[:400]
+
+
+# ── R-A09 / R-E09 · redaction-by-shape missed this project's own secret shapes ───────────────────
+
+@pytest.mark.parametrize("secret,line", [
+    ("f" * 64, "internal secret is {} and it is not a git object"),        # openssl rand -hex 32
+    ("a1b2c3d4" * 4, "admin token {} rejected"),                           # 32-char hex
+    ("sk_live_51H8xQ2LkD9fPqRs7", "stripe key {} refused"),
+    ("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "aws secret {} in the env"),
+])
+def test_ra09_the_shapes_this_project_actually_has_are_masked(secret, line):
+    out = git_redaction.redact(line.format(secret))
+    assert secret not in out, out
+
+
+def test_ra09_a_git_object_id_in_a_git_message_still_survives():
+    """The exemption is why the scrubber is usable at all — narrowed, not deleted."""
+    oid = "9" * 40
+    assert oid in git_redaction.redact(f"error: pathspec did not match; commit {oid} is unreachable")
+
+
+def test_ra09_a_deploy_key_answer_is_still_readable():
+    pub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB" + "Q" * 20 + " vexa@workspace"
+    fp = "SHA256:" + "Kj9" * 14 + "x"
+    msg = f"Add this deploy key to your repository:\n{pub}\nfingerprint {fp}"
+    out = git_redaction.redact(msg)
+    assert pub in out and fp in out
+
+
+def test_ra09_a_clone_error_still_names_the_repository():
+    msg = "fatal: repository 'https://gitlab.example.com/some-team/some-long-repository-name.git' not found"
+    assert "some-long-repository-name" in git_redaction.redact(msg)
+
+
+# ── R-D15 · repo_ref whitelisted a URL's SHAPE but not its HOST (git-clone SSRF) ─────────────────
+
+@pytest.mark.parametrize("url", [
+    "http://169.254.169.254/a/b",          # the cloud metadata service
+    "http://admin-api:8001/a/b",           # a compose service name — internal by construction
+    "http://127.0.0.1:8001/a/b",
+    "http://localhost/a/b",
+    "https://10.1.2.3/a/b",
+    "https://192.168.1.5/a/b",
+])
+def test_rd15_an_internal_host_is_refused_before_git_exists(url):
+    with pytest.raises(repo_ref.RepoRefError):
+        repo_ref.normalize(url)
+
+
+@pytest.mark.parametrize("url", [
+    "https://github.com/owner/repo",
+    "https://gitlab.example.com/team/repo.git",
+    "git@github.com:owner/repo.git",
+    "owner/repo",
+])
+def test_rd15_a_real_repository_still_normalizes(url):
+    assert repo_ref.normalize(url)
+
+
+# ── R-E14 · user-controlled `ref` reached `git checkout` with no end-of-options guard ────────────
+
+def test_re14_a_ref_that_is_a_git_option_is_refused(tmp_path):
+    """`git checkout --quiet <ref>` with `ref = "--detach"` exits 0 and detaches HEAD — the value a
+    caller supplied was consumed as a git OPTION. `--detach` is the harmless member of that family;
+    the family is the finding."""
+    from control_plane import workspace_attach
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@t")
+    _git(origin, "config", "user.name", "t")
+    (origin / "README.md").write_text("v0\n")
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-q", "-m", "init")
+
+    with pytest.raises(ValueError):
+        workspace_attach._git_clone(str(origin), "--detach", tmp_path / "pwned")
+    # …and an ordinary ref still checks out, which is the half a blanket refusal would break.
+    workspace_attach._git_clone(str(origin), "main", tmp_path / "fine")
+    assert (tmp_path / "fine" / "README.md").is_file()
+
+
+# ── R-E13 · the secret store wrote on a read path, and a wrong key read as "no credential" ───────
+
+def test_re13_a_read_does_not_create_the_master_key(tmp_path):
+    """A sealed envelope exists (written under an operator-supplied key). Reading it with no key
+    configured must ANSWER, not mint a fresh `.master.key` beside the ciphertext it cannot open."""
+    secret_store.put(tmp_path, "u_jane/github", "ghp_thetoken", key_env="the-original-key")
+    assert secret_store.get(tmp_path, "u_jane/github") is None
+    assert not (secret_store.secrets_dir(tmp_path) / secret_store.MASTER_KEY_FILENAME).exists(), \
+        "a pure read created server-side key state"
+
+
+def test_re13_an_undecryptable_secret_is_not_reported_as_absent(tmp_path):
+    secret_store.put(tmp_path, "u_jane/github", "ghp_thetoken", key_env="the-original-key")
+    assert secret_store.get(tmp_path, "u_jane/github", key_env="the-original-key") == "ghp_thetoken"
+    # The operator rotated (or lost) VEXA_SECRETS_KEY. "no credential" would have them re-paste the
+    # PAT, silently overwriting an envelope that was fine.
+    assert secret_store.state(tmp_path, "u_jane/github", key_env="a-different-key") == "unreadable"
+    assert secret_store.state(tmp_path, "u_jane/nothing-here", key_env="a-different-key") == "absent"
+
+
+# ── R-A10 · the scaffold id was a non-expiring capability with an unpruned index ─────────────────
+
+def _fake_redis():
+    import fakeredis
+    return fakeredis.FakeStrictRedis(decode_responses=True)
+
+
+def test_ra10_a_minted_scaffold_expires():
+    r = _fake_redis()
+    store = scaffolds_mod.ScaffoldStore(r)
+    rec = store.mint({"who": "ben@bank.test", "kind": "first-visit", "opening": "hi"})
+    assert r.ttl(f"agent:scaffold:{rec['id']}") > 0, "a scaffold link stays openable forever"
+
+
+def test_ra10_a_redeemed_scaffold_leaves_the_pending_index():
+    r = _fake_redis()
+    store = scaffolds_mod.ScaffoldStore(r)
+    rec = store.mint({"who": "ben@bank.test", "kind": "first-visit", "opening": "hi"})
+    store.redeem(rec["id"], "u_ben")
+    assert store.for_recipient("ben@bank.test") == []
+    key = f"agent:scaffolds:by:{scaffolds_mod._recipient_key('ben@bank.test')}"
+    assert rec["id"] not in (r.smembers(key) or set()), "the index never sheds a redeemed id"
+
+
+# ── R-A15 · a mount that lost its write bit was silently promoted to a write target ──────────────
+
+def test_ra15_a_mount_with_no_write_key_is_not_a_write_target(tmp_path):
+    from worker.engine import writeback_candidates
+    (tmp_path / "kg" / "entities").mkdir(parents=True)
+    assert writeback_candidates(["Olga Avramenko spoke."], mounts=[{"path": str(tmp_path)}]) == []
+    assert writeback_candidates(["Olga Avramenko spoke."],
+                                mounts=[{"path": str(tmp_path), "write": True}]) != []
+
+
+# ── the helper the whole dispatch is built on ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("bad", ["/etc/passwd", "../x", "a/../../b", ".git/config", ".vexa/workspace.json", ""])
+def test_resolve_inside_refuses_every_shape(tmp_path, bad):
+    with pytest.raises(PathRefused):
+        resolve_inside(tmp_path, bad)
+
+
+def test_resolve_inside_admits_an_ordinary_document(tmp_path):
+    assert resolve_inside(tmp_path, "kg/entities/person/olga.md") == \
+        (tmp_path / "kg/entities/person/olga.md").resolve()

--- a/core/agent/tests/test_deploy_keys.py
+++ b/core/agent/tests/test_deploy_keys.py
@@ -123,7 +123,7 @@ def test_clone_over_ssh_with_the_deploy_key(tmp_path, monkeypatch):
         # git composes: <GIT_SSH_COMMAND> <host> git-upload-pack '<path>' — the stub runs the tail.
         env = {**env, "GIT_SSH_COMMAND": env["GIT_SSH_COMMAND"].replace("ssh ", f"{fake} ", 1)}
         clone = partial(_git_clone, ssh_env=env)
-        clone(f"ssh://git@fake-host{bare}", "main", dest, None)
+        clone(f"ssh://git@fake-host.test{bare}", "main", dest, None)
 
     assert (dest / "README.md").read_text().startswith("hello from the existing repo")
     args = (tmp_path / "ssh-args.log").read_text()
@@ -132,7 +132,7 @@ def test_clone_over_ssh_with_the_deploy_key(tmp_path, monkeypatch):
     # the token-free origin the attach relies on (nothing embedded, because nothing was)
     origin = subprocess.run(["git", "-C", str(dest), "remote", "get-url", "origin"],
                             capture_output=True, text=True).stdout.strip()
-    assert origin.startswith("ssh://") and "@fake-host" in origin
+    assert origin.startswith("ssh://") and "@fake-host.test" in origin
 
 
 def test_deploy_keys_url_is_derived_not_guessed():

--- a/core/agent/tests/test_friction.py
+++ b/core/agent/tests/test_friction.py
@@ -265,7 +265,8 @@ def test_the_dump_route_returns_markdown_and_the_fix_route_closes(tmp_path):
     c = _app_client(tmp_path)
     hdr = {"X-User-Id": "126"}
     rid = c.post("/api/friction", json={"kind": "no-page", "path": "kg/x.md",
-                                        "happened": "no page here yet"}).json()["id"]
+                                        "happened": "no page here yet"},
+                 headers=hdr).json()["id"]              # the dump is per-subject now (R-E05)
     md = c.get("/api/friction/dump", headers=hdr)
     assert md.status_code == 200 and md.headers["content-type"].startswith("text/markdown")
     assert "FR-1 · no-page" in md.text and rid in md.text
@@ -281,7 +282,8 @@ def test_the_dump_route_returns_markdown_and_the_fix_route_closes(tmp_path):
 
 def test_the_dump_json_format_carries_the_same_grouping(tmp_path):
     c = _app_client(tmp_path)
-    c.post("/api/friction", json={"kind": "error", "tool": "t", "context": {"error": "e"}})
+    c.post("/api/friction", json={"kind": "error", "tool": "t", "context": {"error": "e"}},
+           headers={"X-User-Id": "126"})                # the dump is per-subject now (R-E05)
     body = c.get("/api/friction/dump?format=json", headers={"X-User-Id": "126"}).json()
     assert body["count"] == 1 and body["findings"][0]["kind"] == "error"
 

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -669,7 +669,11 @@ def writeback_candidates(texts, mounts: list[dict] | None = None) -> list[str]:
     from shared.entities import missing_names
 
     roots = [Path(str(m.get("path") or "")) for m in (mounts if mounts is not None else active_mounts())
-             if m.get("write", True) and m.get("path")]
+             if m.get("write") and m.get("path")]
+    # DEFAULT FALSE (R-A15). Every other mount consumer reads the bit explicitly; this one
+    # defaulted a missing key to writable, so a mount that LOST it — a fake, a future producer,
+    # the read-only room mounts of a run with no primary — was silently promoted to a write
+    # target for the phase. A write bit that has to be present to be true cannot be lost.
     if not roots:
         return []
     return missing_names(roots, [t for t in texts if t])


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.** Code and tests only; nothing merged, deployed, published or sent outside the org.

Dispatch 4 (`agent-api-authz`) of the [2026-09-02 release backlog](https://github.com/DmitriyG228/biz/issues/449) — the agent-api half of *who is trusted*. Owning issue [`DmitriyG228/biz#452`](https://github.com/DmitriyG228/biz/issues/452). Base: `minutes-mcp-viewer`.

Two commits, in that order on purpose: **the reproductions first** (46 tests, red on the line tip), then the smallest fix for each.

## The common rule, because ten rows were one question asked ten times

`core/agent/shared/workspace_paths.py` — **one** `resolve_inside(root, path)`. There were six spellings of this before it and they disagreed about what a path may do. `link_resolver.escapes` counted `..` segments and nothing else, and `Path("/ws") / "/etc/passwd"` is `/etc/passwd` — **an absolute path discards the root it was joined to** — so `[[ws:<id>//etc/passwd]]` read a host file and echoed `path` and `url` back to the client, which hands both to the file endpoint where the string gets a second chance (**R-A06**, on `POST /api/links/resolve`, the read path for any document a person opens).

It refuses four things, and every route gets all four: **absolute** · **`..`** · **a symlink that leaves** (the one shape no textual check can see) · **`.git` and `.vexa`** (the repository's own store; and the workspace identity — overwrite it and every `[[ws:<id>/…]]` link into that workspace resolves `gone`, PRD decision 26.1).

Two tests are **enumerations**, not per-route cases, because a per-route test proves the route it was written for and says nothing about the next one somebody adds — which is how six guards came to exist:

- every path-taking route (`ws_file_read`, `ws_file_write`, `desk/touch`, `git/show`'s pathspec) refuses `/etc/passwd`, `../x`, a symlink out, and both reserved directories;
- every workspace-naming route (tree · file read/write · entity · git · git/show · deploy-key get/post · purpose · git-remote-status) refuses a **non-member** of a group — *and* a colleague's desk stays **readable and not writable**, so neither half of decisions 21 / 26.3 can regress into the other.

`desk/touch` also lost a `.lstrip("/")` that was silently rescuing the one input the guard exists to refuse.

## The rows

| row | symptom | change |
|---|---|---|
| **R-A06** | absolute-path traversal on the document read path, echoed back as `path`+`url` | `link_resolver.escapes`/`_find` → `shared/workspace_paths` (`link_resolver.py:56-88`) |
| **R-A09 / R-E09** | redaction-by-shape missed this project's own secret shapes | `git_redaction.py:47-77,100-140` — see below |
| **R-A10** | the scaffold id was a capability with **no TTL** and an index that never shed a redeemed id | `EXPIRE` at mint (14d), `SREM` on redeem (`scaffolds.py:81-83,455-520`) |
| **R-A15** | `writeback_candidates` read `m.get("write", True)` — a mount that lost the bit became a write target | defaults to false (`worker/engine.py:672`) |
| **R-D15** | `repo_ref` whitelisted a URL's shape and not its **host** — git-clone SSRF | `_host_is_internal` + `assert_public_host` (`repo_ref.py:74-140`) |
| **R-E04** | `POST /api/friction`: the **body's** subject outranked the header, so an anonymous caller wrote records attributed to a named user | the body's subject is out of the chain (`api.py:2157`) |
| **R-E05** | `GET /api/friction/dump` discarded the resolved subject and returned every user's reports; `/fix` was the same shape | per-subject, with an `is_admin` bypass for decision 33's fixing agent (`api.py:2177-2205`) |
| **R-E11** | raw exception text into a response on a path built from `redis://:password@host` | both error fields go through `redact` (`api.py:1342,1354`) |
| **R-E13** | the secret store **wrote on a read path**, and a rotated key made a sealed credential read as *absent* | `read_key` never creates; `state()` = absent · held · unreadable (`secret_store.py:79-100,210-263`) |
| **R-E14** | a caller's `ref` reached `git checkout` unvalidated | `repo_ref.valid_ref` (`repo_ref.py:74-93`), `--` on the clone's url |

Three of these are worth a sentence beyond the table.

**R-A09/R-E09 — the redactor.** The generic rule's threshold (36) was read off a GitHub PAT; the secrets this deployment actually holds are shorter (an admin token is 32 hex, `sk_live_…` about 32), and `+`/`/` were outside the class, so an AWS secret key **split into three sub-threshold fragments and survived whole**. Now: 36+ masked on length alone (the old rule, unchanged — nothing that was masked before is unmasked now), 24–35 masked only when the run is *opaque*, plus a base64 sweep over the standard alphabet only, so `-` and `_` exclude every hyphenated repository and branch name in one stroke. And the git-object-id exemption is narrowed to lines that actually talk about git — a bare 64-char lowercase hex run is exactly what `INTERNAL_API_SECRET` and `ADMIN_TOKEN` look like. Pinned in **both** directions: a clone error still names the repository, `pathspec 'feature/PR-1234-something'` survives, and a deploy-key answer still shows the key. A scrubber that eats its own diagnostics gets bypassed, which is worse than one that misses a shape.

**R-D15 — where the host line is drawn.** Private/loopback/link-local/reserved IP literals, and **bare labels** — a name with no dot resolves only inside the deployment, which is exactly the class `admin-api`, `redis` and `meeting-api` belong to. A *dotted* name is left alone even when it is obviously internal: `http://git.internal:8080/acme/kg.git` is an accepted self-hosted mirror in this repo's own fixtures, and refusing it would break the self-host case to close nothing the two rules already close. The check is duplicated into `workspace_attach` the way the token check already was, so it cannot be bypassed by a future route.

**R-E14 — why not `--`.** The review's prescribed fix ("insert `--` before `ref`") is wrong for this verb: `git checkout -- <x>` means *restore the PATH x from the index*, so it would break every ordinary branch checkout. The guard is a ref-shape validator instead (must start alphanumeric, so never a dash). `git clone` **is** the other grammar (`[<options>] [--] <repo> [<dir>]`) and does take `--`; it has one now. Both refusals raise `RepoRefError`, which the attach routes already render as a 422 sentence a person can act on — a test asserts the route answers 422, not an unhandled 500, and that an ordinary swap still works.

## What is NOT here

**R-A08** — the scaffold link carrying a bearer transcript share token in the query string. Its fix ("one-time redemption bound to the scaffold id") is not server-side-complete: the terminal's landing path has to read the share off the authenticated scaffold record instead of the URL, which means `clients/terminal/src/app/App.tsx` and `src/minutes/scaffold.ts` plus the scaffold mint in `api.py` — **exactly the files [`no-client-composition`](https://github.com/Vexa-ai/vexa/tree/no-client-composition) (F97) is rewriting right now.** Doing it here would be the duplicate-work collision the rotation check exists to prevent. Handing it to that worker; the row stays open.

## Existing tests that moved

Three, none weakened:

- `tests/gitserve.py` serves from `fake-host.test` instead of `fake-host` — a bare label is now (correctly) the compose-neighbour shape, the stub drops the host anyway, and `test_deploy_keys` follows;
- two `test_friction.py` tests file under the identity they already read as. They prove the dump *renders* and the fix route *closes*; filing anonymously was incidental to that, and the dump is per-subject now.

## Proof

- **Agent suite:** `uv run --frozen pytest` in `core/agent` → **1527 passed, 1 failed**. The one failure is the standing red (`test_meeting_room.py::test_the_runtime_binds_a_room_mount_read_only`, `ModuleNotFoundError: requests_unixsocket`) — unchanged, and red on the base tip too. Baseline before this branch was 1440 + the same red; +46 new tests and the base's own additions make up the rest.
- **The 46 new tests were red first** — commit 1 is them alone against the line tip, 27 failing (the other 19 are the enumeration guards, which already held and now cannot stop holding).
- **Gates:** all 14 pre-push gates green (`readme dataflow isolation isolation-py exports graph graph-py schema contract-version config-contract licenses execution-env test-isolation contract-conformance`). Pushed **without** `--no-verify`.
- Rebased onto `minutes-mcp-viewer` @ `55172e7a9` (PR #1425 merge) and re-proved after the rebase.

Run on `bbb`, in a fresh worktree. No files touched in `dispatch.py` / `openai_agent.py` (`harness-hardening`), the gateway or the rig (`security-hotfix`), or the terminal (`no-client-composition`).

---

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> **Left unticked deliberately.** This is a legal certification and only the submitting human may
> make it — the `contribution-rights` check stays red until they do, and the same applies to the
> DCO `Signed-off-by` trailer, which is theirs to add and not an agent's to forge.

## Docs diff (D6c)

None. Every change is an internal authorization or input-validation boundary inside `core/agent`
— no route was added, removed or renamed, no request or response shape changed for any documented
surface, and no configuration key was introduced. Labelled `docs: none`.

## Security checks (required on the diff)

The diff *is* the security check: ten review findings, each with a test that was red on the line
tip before the fix (commit 1 is those tests alone). GitGuardian secret scan: pass. Redaction and
path-guard behaviour is pinned in both directions — the widened scrubber still lets a clone error
name its repository and still shows a deploy-key answer, and the path guard still admits ordinary
documents.
