### PR TITLE
[DEV] rig-authz: seal the credential stores, gate the operator verbs, scope the reads (13 security rows + 14 gates)

### DIFF
--- a/clients/terminal/src/app/api/__tests__/minutesSeed.test.ts
+++ b/clients/terminal/src/app/api/__tests__/minutesSeed.test.ts
@@ -1,0 +1,79 @@
+/** GATE 13 (R-E12) — the minutes seed route no longer splices caller text into a shell.
+ *
+ *  What it did: `echo '${f.b64}' | base64 -d > ${dest}` inside `sh -c`, with `f.b64` validated
+ *  nowhere. One apostrophe in the body closed the quote and the rest ran as root inside the
+ *  agent-api container. The route has no identity check at all — it gates on NODE_ENV and the
+ *  terminal mode — so the only thing bounding it was that the server is a developer's laptop.
+ *
+ *  Two properties are asserted, and they are separate defences: the payload is validated against
+ *  the base64 alphabet, and it travels on STDIN, so no validation bug can reach argv either way.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ runs: [] as { container: string; script: string; args: string[]; stdin: string }[] }));
+
+vi.mock("../minutes/seed/dockerSh", () => ({
+  dockerSh: async (container: string, script: string, args: string[], stdin: string) => {
+    h.runs.push({ container, script, args, stdin });
+  },
+}));
+
+import { POST } from "../minutes/seed/route";
+
+function req(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof POST>[0];
+}
+
+describe("minutes seed route", () => {
+  beforeEach(() => {
+    h.runs.length = 0;
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXT_PUBLIC_TERMINAL_MODE", "minutes");
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("refuses a payload that is not base64", async () => {
+    const hostile = "aGk='; id > /tmp/pwned; echo '";
+    const res = await POST(req({ wsId: "room1", files: [{ path: "a.md", b64: hostile }] }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "bad b64" });
+    expect(h.runs).toHaveLength(0);
+  });
+
+  it("passes the payload on stdin and every path as an argv parameter", async () => {
+    const b64 = Buffer.from("# hello", "utf-8").toString("base64");
+    const res = await POST(req({ wsId: "room1", files: [{ path: "notes/a.md", b64 }] }));
+
+    expect(res.status).toBe(200);
+    expect(h.runs).toHaveLength(1);
+    const { script, args, stdin } = h.runs[0];
+
+    expect(stdin).toBe(b64);
+    // Nothing caller-controlled is inside the script text — that is where the injection lived.
+    expect(script).not.toContain(b64);
+    expect(script).not.toContain("notes/a.md");
+    expect(script).not.toContain("room1");
+    expect(args).toEqual(["/workspaces/room1", "notes/a.md"]);
+  });
+
+  it("still refuses a traversing path", async () => {
+    const b64 = Buffer.from("x", "utf-8").toString("base64");
+    const res = await POST(req({ wsId: "room1", files: [{ path: "../../etc/x", b64 }] }));
+    expect(res.status).toBe(400);
+    expect(h.runs).toHaveLength(0);
+  });
+
+  it("sends the README on stdin too, and 404s outside a development minutes build", async () => {
+    const ok = await POST(req({ wsId: "room1", name: "Room One" }));
+    expect(ok.status).toBe(200);
+    expect(h.runs).toHaveLength(1);
+    expect(h.runs[0].script).not.toContain(h.runs[0].stdin);
+    expect(h.runs[0].args).toEqual(["/workspaces/room1"]);
+
+    vi.stubEnv("NODE_ENV", "production");
+    const gone = await POST(req({ wsId: "room1" }));
+    expect(gone.status).toBe(404);
+    expect(h.runs).toHaveLength(1);
+  });
+});

--- a/clients/terminal/src/app/api/minutes/seed/dockerSh.ts
+++ b/clients/terminal/src/app/api/minutes/seed/dockerSh.ts
@@ -1,0 +1,24 @@
+/** Run `sh -c <script> _ <args…>` inside a container, feeding `stdin` to it — R-E12's seam.
+ *
+ *  A separate module for one reason: it is what the seed route's test replaces. Keeping the
+ *  process spawn inside the route made the only proof available a source grep, which is exactly
+ *  the class of test that let the injection this fixes ship in the first place.
+ *
+ *  Nothing caller-controlled goes into `script`. Paths are `args` — `"$1"`, `"$2"` inside the
+ *  script — and file content is `stdin`, so neither can be read as shell syntax.
+ */
+import { spawn } from "child_process";
+
+export function dockerSh(container: string, script: string, args: string[], stdin: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const p = spawn("docker", ["exec", "-i", container, "sh", "-c", script, "_", ...args], {
+      timeout: 15000,
+    });
+    let err = "";
+    p.stderr?.on("data", (d) => { err += String(d); });
+    p.on("error", reject);
+    p.on("close", (code) => (code === 0 ? resolve() : reject(new Error(err.slice(0, 300) || `exit ${code}`))));
+    p.stdin?.on("error", () => { /* the child may exit before we finish writing */ });
+    p.stdin?.end(stdin);
+  });
+}

--- a/clients/terminal/src/app/api/minutes/seed/route.ts
+++ b/clients/terminal/src/app/api/minutes/seed/route.ts
@@ -4,14 +4,23 @@
  *  model credential yet (BYOT is the open decision), so this route writes the seed README
  *  directly into the shared workspace's directory inside the agent-api container and commits it.
  *  Guarded to development + minutes mode; returns 404 otherwise so it cannot exist in prod.
+ *
+ *  SHELL INJECTION, FIXED (R-E12). `f.b64` was interpolated into a `sh -c` string inside single
+ *  quotes and validated nowhere, so one apostrophe in the payload closed the quote and the rest
+ *  ran as root in the agent-api container. It is a developer's own laptop, which bounds the blast
+ *  radius and does not make it safe: the body arrives over HTTP and this route has no identity
+ *  check at all. Two changes: base64 is validated against its own alphabet and travels on STDIN,
+ *  never through argv; and every path is passed as a positional parameter to the shell rather
+ *  than spliced into its text.
  */
 import { NextResponse, type NextRequest } from "next/server";
-import { execFile } from "child_process";
-import { promisify } from "util";
-const run = promisify(execFile);
+import { dockerSh } from "./dockerSh";
 
 export const dynamic = "force-dynamic";
 const CONTAINER = process.env.MINUTES_SEED_CONTAINER || "vexa-v012-agent-api-1";
+
+/** Strict base64 — the only characters the payload may contain, so nothing can leave stdin. */
+const B64 = /^[A-Za-z0-9+/=]+$/;
 
 export async function POST(req: NextRequest) {
   if (process.env.NODE_ENV !== "development" || process.env.NEXT_PUBLIC_TERMINAL_MODE !== "minutes") {
@@ -27,11 +36,12 @@ export async function POST(req: NextRequest) {
   if (Array.isArray(body.files) && body.files.length) {
     for (const f of body.files) {
       if (!/^[A-Za-z0-9._/-]+$/.test(f.path) || f.path.includes("..")) return NextResponse.json({ error: "bad path" }, { status: 400 });
-      const dest = `/workspaces/${wsId}/${f.path}`;
+      if (typeof f.b64 !== "string" || !B64.test(f.b64)) return NextResponse.json({ error: "bad b64" }, { status: 400 });
       try {
-        await run("docker", ["exec", CONTAINER, "sh", "-c",
-          `mkdir -p "$(dirname ${dest})" && echo '${f.b64}' | base64 -d > ${dest} && cd /workspaces/${wsId} && git add ${f.path} && git -c user.email=minutes@local -c user.name="Minutes seed" commit -q -m "minutes seed: ${f.path}" || true`,
-        ], { timeout: 15000, maxBuffer: 1 << 20 });
+        await dockerSh(CONTAINER,
+          'mkdir -p "$(dirname "$1/$2")" && base64 -d > "$1/$2" && cd "$1" && git add "$2" && ' +
+          'git -c user.email=minutes@local -c user.name="Minutes seed" commit -q -m "minutes seed: $2" || true',
+          [`/workspaces/${wsId}`, f.path], f.b64);
       } catch (e) { return NextResponse.json({ error: String((e as Error).message).slice(0, 300) }, { status: 502 }); }
     }
     return NextResponse.json({ ok: true, wrote: body.files.map((f) => f.path) });
@@ -62,14 +72,14 @@ export async function POST(req: NextRequest) {
     "",
   ].join("\n");
 
-  const dir = `/workspaces/${wsId}`;
-  // Content travels as base64 in argv — promisified execFile has no stdin, and base64 sidesteps
-  // every shell-quoting hazard in user-authored text.
+  // Content travels as base64 on STDIN. It is ours, not the caller's, so it cannot be hostile —
+  // but the route that WAS hostile used the identical splice, so there is one way to do this here.
   const b64 = Buffer.from(readme, "utf-8").toString("base64");
   try {
-    await run("docker", ["exec", CONTAINER, "sh", "-c",
-      `echo '${b64}' | base64 -d > ${dir}/README.md && cd ${dir} && git add README.md && git -c user.email=minutes@local -c user.name="Minutes seed" commit -q -m "room seed: name, purpose, attention list" || true`,
-    ], { timeout: 15000, maxBuffer: 1 << 20 });
+    await dockerSh(CONTAINER,
+      'base64 -d > "$1/README.md" && cd "$1" && git add README.md && ' +
+      'git -c user.email=minutes@local -c user.name="Minutes seed" commit -q -m "room seed: name, purpose, attention list" || true',
+      [`/workspaces/${wsId}`], b64);
   } catch (e) {
     return NextResponse.json({ error: String((e as Error).message).slice(0, 300) }, { status: 502 });
   }

--- a/core/agent/tests/test_workspace_credentials.py
+++ b/core/agent/tests/test_workspace_credentials.py
@@ -159,20 +159,35 @@ def test_the_rig_refuses_a_credential_smuggled_into_an_argument():
     from the deployed code) — a PAT typed into the repo URL is refused with a sentence that points at
     the key instead of asking again."""
     tree = ast.parse(RIG.read_text(encoding="utf-8"))
-    wanted = ("_CREDENTIAL_REFUSAL", "_refuse_credentials")
+    wanted = ("_CREDENTIAL_REFUSAL", "_refuse_credentials", "_OUR_CREDENTIAL_PREFIXES")
     picked = [n for n in tree.body
               if (isinstance(n, ast.FunctionDef) and n.name in wanted)
               or (isinstance(n, ast.Assign) and any(getattr(t, "id", "") in wanted for t in n.targets))]
-    assert len(picked) == 2, "the rig's refusal helper moved — this test must follow it"
-    ns: dict = {}
+    assert len(picked) == 3, "the rig's refusal helper moved — this test must follow it"
+    # The detector now IMPORTS the scrubber instead of re-implementing it (R-D14: the copy had
+    # drifted past `glpat-`, the generic run, and bare-userinfo URLs). `rig_secrets` re-exports
+    # `shared.git_redaction`, so the lifted-out copy needs it in its namespace.
+    ns: dict = {"rig_secrets": _rig_secrets()}
     exec(compile(ast.Module(body=picked, type_ignores=[]), str(RIG), "exec"), ns)  # noqa: S102
 
     refuse = ns["_refuse_credentials"]
     assert refuse("https://ghp_AAAAAAAAAAAAAAAAAAAA@github.com/acme/kg.git")
     assert refuse("git@github.com:acme/kg.git", "main", "", "ghp_BBBBBBBBBBBBBBBBBBBB")
     assert refuse("https://user:secret@github.com/acme/kg.git")
+    assert refuse("https://glpat-AAAAAAAAAAAAAAAAAAAA@gitlab.com/acme/kg.git"), \
+        "the drifted six-prefix copy is back — a GitLab PAT in a remote URL walked through it"
     assert refuse("git@github.com:acme/kg.git", "main", "grp-a1b2c3", "") == ""
     assert "will not take a token in chat" in ns["_CREDENTIAL_REFUSAL"]
+
+
+def _rig_secrets():
+    """The rig's own module, imported the way the rig imports it."""
+    import importlib
+    import sys
+    rig_dir = str(RIG.parent)
+    if rig_dir not in sys.path:
+        sys.path.insert(0, rig_dir)
+    return importlib.import_module("rig_secrets")
 
 
 def test_the_rig_calls_that_refusal_before_it_does_anything():

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -47,7 +47,8 @@ from flows import Registry, SystemClock, admit, cancel, postgres_db, resume, ret
 from flows_defs import production  # noqa: E402
 from flows_integrations import instance_gate  # noqa: E402
 from flows_steps.common import db_url, require_internal_secret, setting  # noqa: E402
-from flows_timeline import (build_timeline, fetch_meetings, list_reactions,  # noqa: E402
+from flows_timeline import (REACTION_FOUND, REACTION_MISSING,  # noqa: E402
+                            build_timeline, fetch_meetings, list_reactions, reaction_concerns,
                             render_preamble, render_text)
 
 def _require_api_key() -> str:
@@ -359,11 +360,30 @@ def list_reactions(status: Optional[str] = None, subject: str = ""):
 
 
 @app.post("/reactions/{reaction_id}/{verb}", dependencies=[Depends(auth)])
-def signal_reaction(reaction_id: str, verb: str, x_actor: str = Header(default="api"),
-                    body: dict = Body(default={})):
+def signal_reaction(reaction_id: str, verb: str, subject: str = "",
+                    x_actor: str = Header(default="api"), body: dict = Body(default={})):
+    """Steer one reaction — and, with `subject`, only if it is THAT PERSON'S (R-D07).
+
+    The verbs post with the lane's admin key, so before `subject` existed the caller's identity
+    never reached this decision: the control MCP handed every signed-in user every reaction id and
+    then let them `cancel` any of it. Ownership is the right question here rather than operator
+    authority — a person stopping the join they scheduled with `bot_schedule` is the ordinary path,
+    and an admin-only gate would close it to fix an unusual one.
+
+    Omitting `subject` keeps the unscoped operator behaviour this route has always had: it is
+    already behind the operator key, and the admin console steers reactions it does not own.
+    """
     fns = {"retry": retry, "resume": resume, "cancel": cancel, "wake": wake}
     if verb not in fns:
         raise HTTPException(status_code=404, detail="retry | resume | cancel | wake")
+    if str(subject or "").strip():
+        owns = reaction_concerns(db, reaction_id, subject=subject.strip())
+        if owns == REACTION_MISSING:
+            raise HTTPException(status_code=404, detail="no such reaction")
+        if owns != REACTION_FOUND:
+            # Deliberately NOT 404: the caller named a real id and a real account, and telling them
+            # "no such reaction" for something that exists sends them off to re-derive it.
+            raise HTTPException(status_code=403, detail="that reaction is not yours")
     ok = fns[verb](db, reaction_id, actor=x_actor, clock=clock, reason=body.get("reason"))
     if not ok:
         raise HTTPException(status_code=409, detail=f"{verb} not applicable in current status")

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -47,7 +47,8 @@ from flows import Registry, SystemClock, admit, cancel, postgres_db, resume, ret
 from flows_defs import production  # noqa: E402
 from flows_integrations import instance_gate  # noqa: E402
 from flows_steps.common import db_url, require_internal_secret, setting  # noqa: E402
-from flows_timeline import build_timeline, fetch_meetings, render_preamble, render_text  # noqa: E402
+from flows_timeline import (build_timeline, fetch_meetings, list_reactions,  # noqa: E402
+                            render_preamble, render_text)
 
 def _require_api_key() -> str:
     """The operator key, or the process refuses to start.
@@ -332,16 +333,29 @@ def set_flow_status(name: str, version: int, action: str):
 
 
 @app.get("/reactions", dependencies=[Depends(auth)])
-def list_reactions(status: Optional[str] = None):
-    q, params = "", {}
-    if status and status.isalpha():
-        q, params = " WHERE status = :st", {"st": status}
-    rows = db.execute("SELECT reaction_id, flow, flow_version, step, status, attempt, reason, "
-                      f"next_run_at FROM reaction{q} ORDER BY created_at DESC LIMIT 100", params)
+def list_reactions(status: Optional[str] = None, subject: str = ""):
+    """The operator projection — and, with ``subject``, ONE PERSON'S share of it.
+
+    ``subject`` (a platform uid or an email address) is what makes this route usable by a
+    per-person surface. Without it the control MCP was fanning the whole instance's reactions into
+    every signed-in user's queue: `whats_waiting` reported other tenants' flow names, step names
+    and failure reasons as this person's work, and `reactions_list` handed out every reaction id
+    instance-wide — which is also how `reaction_signal` could cancel a stranger's pending join
+    (R-D07, R-D12).
+
+    Scoping reuses `flows_timeline`'s pair — the uid AND the email — for the reason that module
+    documents: the invite lineage carries an organizer address and no uid, the completed lineage
+    carries a uid and no address, and matching on one of them silently returns half the rows.
+    """
+    subj = (subject or "").strip()
+    rows = list_reactions(db, subject=subj, status=status or "")
+    if rows is None:
+        return {"reactions": [], "subject": subj, "unresolved": True}
     return {"reactions": [
-        {"id": r, "flow": f"{fl}@{v}", "step": st, "status": s_, "attempt": a,
-         "reason": why, "next_run_at": nra}
-        for r, fl, v, st, s_, a, why, nra in rows]}
+        {"id": r["reaction_id"], "flow": f"{r['flow']}@{r['flow_version']}", "step": r["step"],
+         "status": r["status"], "attempt": r["attempt"], "reason": r["reason"],
+         "next_run_at": r["next_run_at"]}
+        for r in rows]}
 
 
 @app.post("/reactions/{reaction_id}/{verb}", dependencies=[Depends(auth)])

--- a/core/flows/src/flows_timeline/__init__.py
+++ b/core/flows/src/flows_timeline/__init__.py
@@ -11,11 +11,13 @@ from flows_timeline.model import (EVENT_KINDS, STEP_KINDS, Event, concerns, even
                                   event_from_receipt, events_from_reaction, iso, merge,
                                   split_around, to_epoch)
 from flows_timeline.render import render_preamble, render_text
-from flows_timeline.service import (build_timeline, fetch_meetings, list_reactions,
-                                    read_flows, resolve_identity, window)
+from flows_timeline.service import (REACTION_FOUND, REACTION_MISSING, REACTION_NOT_YOURS,
+                                    build_timeline, fetch_meetings, list_reactions, read_flows,
+                                    reaction_concerns, resolve_identity, window)
 
 __all__ = ["EVENT_KINDS", "STEP_KINDS", "Event", "concerns", "event_from_meeting",
            "event_from_receipt", "events_from_reaction", "iso", "merge", "split_around",
            "to_epoch", "build_timeline", "fetch_meetings", "list_reactions", "read_flows",
+           "reaction_concerns", "REACTION_FOUND", "REACTION_MISSING", "REACTION_NOT_YOURS",
            "resolve_identity",
            "window", "render_preamble", "render_text"]

--- a/core/flows/src/flows_timeline/__init__.py
+++ b/core/flows/src/flows_timeline/__init__.py
@@ -11,10 +11,11 @@ from flows_timeline.model import (EVENT_KINDS, STEP_KINDS, Event, concerns, even
                                   event_from_receipt, events_from_reaction, iso, merge,
                                   split_around, to_epoch)
 from flows_timeline.render import render_preamble, render_text
-from flows_timeline.service import (build_timeline, fetch_meetings, read_flows, resolve_identity,
-                                    window)
+from flows_timeline.service import (build_timeline, fetch_meetings, list_reactions,
+                                    read_flows, resolve_identity, window)
 
 __all__ = ["EVENT_KINDS", "STEP_KINDS", "Event", "concerns", "event_from_meeting",
            "event_from_receipt", "events_from_reaction", "iso", "merge", "split_around",
-           "to_epoch", "build_timeline", "fetch_meetings", "read_flows", "resolve_identity",
+           "to_epoch", "build_timeline", "fetch_meetings", "list_reactions", "read_flows",
+           "resolve_identity",
            "window", "render_preamble", "render_text"]

--- a/core/flows/src/flows_timeline/service.py
+++ b/core/flows/src/flows_timeline/service.py
@@ -48,6 +48,43 @@ def window(since=None, until=None, now: Optional[float] = None) -> tuple[float, 
             now + DEFAULT_AHEAD_S if u is None else u)
 
 
+#: The operator projection's columns — what `GET /reactions` has always returned.
+LIST_COLS = ("reaction_id", "flow", "flow_version", "step", "status", "attempt", "reason",
+             "next_run_at")
+
+
+def list_reactions(db, *, subject: str = "", status: str = "", limit: int = 100,
+                   scan: int = SCAN_ROWS, identity: Optional[Callable] = None):
+    """The operator projection, optionally SCOPED TO ONE PERSON. ``None`` when nobody answers to
+    ``subject``.
+
+    Scoping lives here rather than in the route because it is the part that can be wrong: the
+    control MCP's `whats_waiting` and `reactions_list` were reading this table unscoped and
+    reporting the whole instance's reactions — flow names, step names and failure reasons — as one
+    person's queue, and handing out every reaction id along with them (R-D07, R-D12).
+
+    It scopes on the uid AND the email, for the reason `model.concerns` documents: the invite
+    lineage carries an organizer address and no uid, the completed lineage carries a uid and no
+    address, and matching on one of them silently returns half the rows. `subject_refs` is a JSON
+    blob with no index to push the predicate into, so the SCAN is bounded and the result is
+    filtered — the same shape `read_flows` uses, and for the same reason.
+    """
+    where, params = "", {}
+    if status and status.isalpha():
+        where, params = " WHERE status = :st", {"st": status}
+    if not str(subject or "").strip():
+        return _rows(db, f"SELECT {', '.join(LIST_COLS)} FROM reaction{where} "
+                         f"ORDER BY created_at DESC LIMIT {int(limit)}", params, LIST_COLS)
+    uid, email = (identity or resolve_identity)(subject)
+    if not uid and not email:
+        return None
+    cols = LIST_COLS + ("subject_refs",)
+    rows = _rows(db, f"SELECT {', '.join(cols)} FROM reaction{where} "
+                     f"ORDER BY created_at DESC LIMIT {int(scan)}", params, cols)
+    mine = [r for r in rows if concerns(loads(r["subject_refs"]), uid, email)]
+    return [{k: r[k] for k in LIST_COLS} for r in mine[:limit]]
+
+
 def read_flows(db, *, uid: str = "", email: str = "", since: float, until: float,
                scan: int = SCAN_ROWS) -> list[Event]:
     """Every reaction and receipt in the window that CONCERNS this person.

--- a/core/flows/src/flows_timeline/service.py
+++ b/core/flows/src/flows_timeline/service.py
@@ -85,6 +85,39 @@ def list_reactions(db, *, subject: str = "", status: str = "", limit: int = 100,
     return [{k: r[k] for k in LIST_COLS} for r in mine[:limit]]
 
 
+#: What `reaction_concerns` answers. Three outcomes, not two: "there is no such reaction" and
+#: "that one is not yours" have different fixes for the caller, and collapsing them into one
+#: refusal is how a person retries forever against an id that never existed.
+REACTION_FOUND, REACTION_MISSING, REACTION_NOT_YOURS = "ok", "not_found", "not_yours"
+
+
+def reaction_concerns(db, reaction_id: str, *, subject: str,
+                      identity: Optional[Callable] = None) -> str:
+    """Does this ONE reaction concern ``subject``? — the ownership check behind the signal verbs.
+
+    R-D07 was two holes, and only one of them is a read: `reactions_list` handed every id out
+    instance-wide, and `reaction_signal` then posted with the lane's admin key without ever asking
+    whether the reaction was the caller's. `cancel` on a stranger's scheduled join destroyed their
+    pending work.
+
+    The answer is OWNERSHIP, not authority. A person cancelling the join THEY scheduled is the
+    product — `bot_schedule` mints that reaction and the same person has to be able to stop it — so
+    an operator gate here would break the ordinary path to close an unusual one. This asks the
+    narrower question instead, on the same `concerns` predicate `list_reactions` uses, and it is a
+    DIRECT lookup rather than a scan: an old reaction outside the projection's window is still
+    yours, and a scoping check with a horizon would start refusing it.
+    """
+    rows = _rows(db, "SELECT reaction_id, subject_refs FROM reaction WHERE reaction_id = :rid",
+                 {"rid": str(reaction_id)}, ("reaction_id", "subject_refs"))
+    if not rows:
+        return REACTION_MISSING
+    uid, email = (identity or resolve_identity)(subject)
+    if not uid and not email:
+        return REACTION_NOT_YOURS          # FAIL CLOSED: a subject nobody answers to owns nothing
+    return (REACTION_FOUND if concerns(loads(rows[0]["subject_refs"]), uid, email)
+            else REACTION_NOT_YOURS)
+
+
 def read_flows(db, *, uid: str = "", email: str = "", since: float, until: float,
                scan: int = SCAN_ROWS) -> list[Event]:
     """Every reaction and receipt in the window that CONCERNS this person.

--- a/core/flows/tests/test_reactions_scope.py
+++ b/core/flows/tests/test_reactions_scope.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import json
 
 from flows import SqliteDB
-from flows_timeline import list_reactions
+from flows_timeline import (REACTION_FOUND, REACTION_MISSING, REACTION_NOT_YOURS,
+                            list_reactions, reaction_concerns)
 
 T0 = 1_788_000_000.0
 
@@ -75,3 +76,53 @@ def test_an_unresolvable_subject_is_none_not_everything():
     how a scoping bug turns into the leak it was added to close."""
     assert list_reactions(_db(), subject="nobody@nowhere.test",
                           identity=lambda s: ("", "")) is None
+
+
+# ── the signal verbs' ownership check ────────────────────────────────────────────────────────────
+#
+# The read half above stops a stranger's reaction id being HANDED OUT. This half stops one being
+# ACTED ON, which is the destructive one: `cancel` on somebody else's scheduled join destroys work
+# they are waiting for.
+
+def test_a_reaction_you_own_is_yours_to_steer():
+    """The ordinary path, and the reason this is ownership rather than operator authority:
+    `bot_schedule` mints the reaction, and the same person has to be able to cancel it."""
+    assert reaction_concerns(_db(), "r-mine-uid", subject="126",
+                             identity=_identity) == REACTION_FOUND
+    assert reaction_concerns(_db(), "r-mine-email", subject="126",
+                             identity=_identity) == REACTION_FOUND
+
+
+def test_a_colleagues_reaction_is_refused():
+    assert reaction_concerns(_db(), "r-theirs", subject="126",
+                             identity=_identity) == REACTION_NOT_YOURS
+
+
+def test_a_reaction_that_does_not_exist_says_so():
+    """Three outcomes, not two. "not yours" for an id nobody has sends the caller off to
+    re-derive it; "no such reaction" tells them to ask for a real one."""
+    assert reaction_concerns(_db(), "r-nope", subject="126",
+                             identity=_identity) == REACTION_MISSING
+
+
+def test_an_unresolvable_subject_owns_nothing():
+    """FAIL CLOSED, the same direction as the read half."""
+    assert reaction_concerns(_db(), "r-mine-uid", subject="ghost@nowhere.test",
+                             identity=lambda s: ("", "")) == REACTION_NOT_YOURS
+
+
+def test_ownership_is_a_direct_lookup_not_a_windowed_scan():
+    """An OLD reaction — outside any projection window or `LIMIT 100` — is still yours.
+
+    Reusing `list_reactions` for this check would have been the shorter edit and would have
+    started refusing exactly the reactions a person is most likely to be cancelling: the ones that
+    have been sitting scheduled for a while."""
+    db = _db()
+    for i in range(150):
+        _reaction(db, f"r-filler-{i}", THEIRS, created=T0 + 1 + i)
+    _reaction(db, "r-old-mine", MINE_BY_UID, created=T0 - 90 * 86400)
+
+    assert reaction_concerns(db, "r-old-mine", subject="126", identity=_identity) == REACTION_FOUND
+    listed = list_reactions(db, subject="126", identity=_identity)
+    assert "r-old-mine" in {r["reaction_id"] for r in listed}, \
+        "the projection can lose it and the ownership check still must not"

--- a/core/flows/tests/test_reactions_scope.py
+++ b/core/flows/tests/test_reactions_scope.py
@@ -1,0 +1,77 @@
+"""GATE 4c — `GET /reactions?subject=`: the operator projection, scoped to one person
+(R-D07 · R-D12), on the service side of the same two rows.
+
+Offline like the rest of the suite: a real sqlite schema and rows written the way the engine writes
+them. What is under test is the SCOPING, which is the part that can be wrong; the route above it is
+a thin forward.
+"""
+from __future__ import annotations
+
+import json
+
+from flows import SqliteDB
+from flows_timeline import list_reactions
+
+T0 = 1_788_000_000.0
+
+MINE_BY_UID = {"uid": "126", "meeting_id": 104, "title": "ours"}
+MINE_BY_EMAIL = {"organizer": "dima@vexa.ai", "ics_uid": "a@b", "title": "ours, from the invite"}
+THEIRS = {"uid": "999", "organizer": "someone@else.test", "meeting_id": 7,
+          "title": "another tenant's meeting"}
+
+
+def _reaction(db, rid, refs, *, status="failed", reason=None, created=T0):
+    db.execute("""INSERT INTO reaction (reaction_id, source_event_id, event_type, subject_refs,
+                                        flow, flow_version, step, status, attempt, next_run_at,
+                                        reason, created_at, updated_at)
+                  VALUES (:rid,:sid,'meeting.completed',:refs,'post_meeting',1,'email_minutes',
+                          :st,0,0,:why,:c,:c)""",
+               {"rid": rid, "sid": f"{rid}::post_meeting", "refs": json.dumps(refs),
+                "st": status, "why": reason, "c": created})
+
+
+def _db():
+    db = SqliteDB()
+    _reaction(db, "r-mine-uid", MINE_BY_UID)
+    _reaction(db, "r-mine-email", MINE_BY_EMAIL)
+    _reaction(db, "r-theirs", THEIRS, reason="smtp 535 on their mailbox")
+    return db
+
+
+def _identity(_subject):
+    return ("126", "dima@vexa.ai")
+
+
+def test_a_subject_sees_only_their_own_reactions():
+    """The defect, exactly: an unscoped read returned all three rows, and the control MCP reported
+    the third — another tenant's flow, step and failure reason — as this person's queue."""
+    everything = list_reactions(_db())
+    assert {r["reaction_id"] for r in everything} == {"r-mine-uid", "r-mine-email", "r-theirs"}
+
+    mine = list_reactions(_db(), subject="126", identity=_identity)
+    assert {r["reaction_id"] for r in mine} == {"r-mine-uid", "r-mine-email"}
+    assert all("smtp" not in str(r["reason"] or "") for r in mine)
+
+
+def test_scoping_uses_both_identifiers():
+    """Half a scope is the failure mode `model.concerns` exists to prevent: the invite lineage
+    carries an organizer address and no uid, the completed lineage a uid and no address."""
+    uid_only = list_reactions(_db(), subject="126", identity=lambda s: ("126", ""))
+    email_only = list_reactions(_db(), subject="x", identity=lambda s: ("", "dima@vexa.ai"))
+
+    assert {r["reaction_id"] for r in uid_only} == {"r-mine-uid"}
+    assert {r["reaction_id"] for r in email_only} == {"r-mine-email"}
+
+
+def test_status_still_filters_under_a_subject():
+    _db_ = _db()
+    _reaction(_db_, "r-mine-done", MINE_BY_UID, status="done")
+    got = list_reactions(_db_, subject="126", status="done", identity=_identity)
+    assert {r["reaction_id"] for r in got} == {"r-mine-done"}
+
+
+def test_an_unresolvable_subject_is_none_not_everything():
+    """FAIL CLOSED. A subject nobody answers to must not fall back to the unscoped read — that is
+    how a scoping bug turns into the leak it was added to close."""
+    assert list_reactions(_db(), subject="nobody@nowhere.test",
+                          identity=lambda s: ("", "")) is None

--- a/deploy/dogfood/rig/rig_secrets.py
+++ b/deploy/dogfood/rig/rig_secrets.py
@@ -1,0 +1,203 @@
+"""rig_secrets.py — the rig's ONE credential store, and its one redactor.
+
+Two defects in the 2026-09-02 line review live here, and they are the same defect twice: the rig
+kept credentials in plaintext JSON at the default umask (R-D05) and every store was an unlocked
+read-modify-write with a truncating save (R-D09). On the live host that produced
+``-rw-rw-r-- ~/.storm/user-api-keys.json`` — every user's gateway key, group- and world-readable —
+beside an encrypted store (``control_plane/secret_store.py``) that decision 25 declared and the rig
+used for nothing.
+
+What this module is:
+
+* **The store is sealed.** One logical map = one encrypt-then-MAC envelope written through
+  ``secret_store`` (``<state>/.secrets/<name>.enc``, ``0600`` in a ``0700`` directory, atomic
+  write-temp-and-replace). Nothing here writes a credential a reader could use.
+* **The store is locked.** ``update()`` holds an exclusive ``flock`` across read-modify-write, so
+  two concurrent sign-ins cannot lose a token, and the write underneath it is atomic, so a crash
+  mid-write cannot empty the store and log everybody out.
+* **Legacy plaintext is migrated, then removed.** A ``~/.storm/<name>.json`` written by an older
+  rig is read once, sealed, verified by reading it back, and only then unlinked. A migration that
+  deletes before it verifies is a data-loss bug wearing a security fix.
+* **One redactor, imported not copied.** ``redact``/``looks_like_token`` come from
+  ``shared/git_redaction.py`` — the same detector agent-api uses — because the rig's hand-rolled
+  six-prefix copy had already drifted past ``glpat-`` and bare userinfo URLs (R-D14).
+
+Both imports are HARD. A rig that cannot reach ``core/agent`` has no encryption and no redactor,
+and a security control that disappears when a path is wrong is worse than an absent one: it is an
+absent one that reads as present. ``VEXA_AGENT_SRC`` names the tree when the default cannot find it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+
+HOME = pathlib.Path.home()
+
+#: Where the rig keeps its state. One variable so a test never touches a live store.
+STATE_DIR = pathlib.Path(os.environ.get("VEXA_RIG_STATE_DIR") or (HOME / ".storm"))
+
+
+def agent_src() -> str:
+    """The importable ``core/agent`` tree — ``VEXA_AGENT_SRC``, else the nearest one above us.
+
+    Searched rather than counted in ``parents[n]``: this file is scheduled to move into
+    ``core/mcp`` (seam item B1) and a hardcoded depth would break silently on the day it does.
+    """
+    named = (os.environ.get("VEXA_AGENT_SRC") or "").strip()
+    if named:
+        return named
+    here = pathlib.Path(__file__).resolve()
+    for parent in here.parents:
+        cand = parent / "core" / "agent"
+        if (cand / "shared" / "git_redaction.py").is_file():
+            return str(cand)
+    return str(here.parents[3] / "core" / "agent") if len(here.parents) > 3 else ""
+
+
+def _import_agent(module: str):
+    src = agent_src()
+    if src and src not in sys.path:
+        sys.path.insert(0, src)
+    try:
+        return __import__(module, fromlist=["*"])
+    except ImportError as exc:  # pragma: no cover — a deployment input, named in the message
+        raise RuntimeError(
+            f"the rig cannot import {module} from {src or '<unset>'}: {exc}. "
+            "Point VEXA_AGENT_SRC at the checkout's core/agent directory. This is not optional — "
+            "it carries the credential encryption and the redactor."
+        ) from exc
+
+
+_git_redaction = _import_agent("shared.git_redaction")
+_secret_store = _import_agent("control_plane.secret_store")
+
+redact = _git_redaction.redact
+looks_like_token = _git_redaction.looks_like_token
+TOKEN_PREFIXES = _git_redaction.TOKEN_PREFIXES
+MASK = _git_redaction.MASK
+
+
+def harden(p: pathlib.Path) -> None:
+    """Owner-only on the file and its directory. Best-effort: a filesystem may not honor modes."""
+    try:
+        if p.is_dir():
+            p.chmod(0o700)
+        else:
+            p.chmod(0o600)
+            p.parent.chmod(0o700)
+    except OSError:
+        pass
+
+
+def _legacy_path(name: str) -> pathlib.Path:
+    """Where an older rig wrote this map in plaintext (``mcp-tokens`` → ``mcp-tokens.json``)."""
+    return STATE_DIR / f"{name}.json"
+
+
+def _migrate(name: str) -> dict:
+    """Seal a legacy plaintext map, VERIFY the readback, then remove the plaintext. Returns it."""
+    legacy = _legacy_path(name)
+    try:
+        raw = legacy.read_text()
+    except OSError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return {}
+    if not isinstance(data, dict) or not data:
+        return data if isinstance(data, dict) else {}
+    _seal(name, data)
+    if _unseal(name) != data:          # never delete a plaintext store we could not re-read
+        harden(legacy)
+        return data
+    try:
+        legacy.unlink()
+    except OSError:
+        harden(legacy)
+    return data
+
+
+def _seal(name: str, data: dict) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    harden(STATE_DIR)
+    _secret_store.put(STATE_DIR, name, json.dumps(data))
+
+
+def _unseal(name: str):
+    raw = _secret_store.get(STATE_DIR, name)
+    if raw is None:
+        return None
+    try:
+        out = json.loads(raw)
+    except ValueError:
+        return None
+    return out if isinstance(out, dict) else None
+
+
+def read(name: str) -> dict:
+    """The sealed map under ``name`` — ``{}`` when absent, unreadable, or sealed under another key.
+
+    Never raises: every caller here is on a request path where "no credentials" is an ordinary
+    answer and an exception would be an outage.
+    """
+    got = _unseal(name)
+    if got is not None:
+        return got
+    return _migrate(name)
+
+
+def _lock_path(name: str) -> pathlib.Path:
+    return _secret_store.secrets_dir(STATE_DIR) / f"{name.replace('/', '_')}.lock"
+
+
+def update(name: str, fn):
+    """Locked read-modify-write. ``fn(map)`` mutates in place (or returns a replacement map).
+
+    The lock is an exclusive ``flock`` on a sibling file, held across BOTH halves. Without it the
+    store was last-writer-wins over a whole map: two sign-ins in the same second lost one token,
+    which is what ``mcp-tokens.json``'s three independent writers were doing.
+    """
+    lock = _lock_path(name)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    harden(lock.parent)
+    fd = os.open(lock, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        try:
+            import fcntl
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except (ImportError, OSError):   # pragma: no cover — platforms without flock
+            pass
+        cur = read(name)
+        out = fn(cur)
+        new = out if isinstance(out, dict) else cur
+        _seal(name, new)
+        return new
+    finally:
+        os.close(fd)
+
+
+def write(name: str, data: dict) -> dict:
+    """Replace the whole map. Still locked — a replace races a read-modify-write just as badly."""
+    return update(name, lambda _cur: data)
+
+
+def signing_key(name: str, env: str = "") -> bytes:
+    """A stable server-side signing key, from ``env`` when the operator sets one, else generated
+    once into the sealed store. Used for the short-lived view tokens that replaced the durable
+    bearer tokens the rig used to mint into URLs (R-D04)."""
+    supplied = (os.environ.get(env, "") if env else "").strip()
+    if supplied:
+        return supplied.encode("utf-8")
+    held = read(f"keys/{name}").get("k")
+    if not held:
+        import secrets as _s
+
+        def _mint(d: dict) -> dict:
+            d.setdefault("k", _s.token_urlsafe(32))     # under the lock: first writer wins
+            return d
+
+        held = update(f"keys/{name}", _mint).get("k", "")
+    return str(held).encode("utf-8")

--- a/deploy/dogfood/rig/tests/README.md
+++ b/deploy/dogfood/rig/tests/README.md
@@ -1,0 +1,54 @@
+# `deploy/dogfood/rig/tests` — the rig's behavioural tests
+
+Until 2026-09-03 this directory did not exist. `vexa_control_mcp.py` is 5,033 lines and 53 verbs —
+the whole agent-facing surface — and **nothing called one of them**: the only file that touched it,
+[`core/agent/tests/test_rig_stateless.py`](../../../../core/agent/tests/test_rig_stateless.py),
+greps the source text. That is why the shell injection, the missing membership check, the
+world-readable credential stores and an operator gate that broke `bot_schedule` were all invisible
+to a green suite (review row R-D20).
+
+## Run them
+
+```bash
+cd deploy/dogfood/rig && python3 -m pytest tests -q
+```
+
+Offline and stdlib-only. `conftest.py` does two things so no test has to:
+
+* **Stubs the MCP SDK** when `mcp.server.mcpserver` is not importable, registering tools in the
+  same place the module reads them back (`mcp._tool_manager._tools`) — so a run does not depend on
+  an SDK generation being installed.
+* **Points every credential store at a tmp directory** (`VEXA_RIG_STATE_DIR`) and supplies the
+  keys the module now demands at import. **Nothing here reads or writes a real `~/.storm` file.**
+
+`as_user()` signs a test in and swaps `_http` for a recorder, because what a tool ASKED FOR — the
+subject on a query string, the header a secret travels in — is where authorization actually lives.
+
+## What is pinned here
+
+Fourteen gates, one per row of the `rig-authz` / `rig-write-guard` dispatch. Each test names its
+row and states the defect it replaces, so a future reader can tell what the assertion is worth.
+
+| gate | row | holds |
+|---|---|---|
+| 1a·1b | R-D04 | a workspace link carries a short-lived, path-scoped view token, never a durable bearer |
+| 2a·2b | R-D05 | credential stores are sealed, `0600` in a `0700` dir; legacy plaintext migrates then goes |
+| 3 | R-D06 | the autonomous delegation regime may not `bot_say` or `meeting_delete` |
+| 4a·4b | R-D07 | `reaction_signal` is operator-only; `reactions_list` is scoped to the caller |
+| 5 | R-D09 | concurrent sign-ins do not lose a token |
+| 6 | R-D10 | the transcript converters cannot read or write outside their directories |
+| 7a·7b | R-D11 | no account before the code is proven; identical answer either way; single-use codes |
+| 8 | R-D12 | `whats_waiting` asks only for this subject |
+| 9 | R-D13 | the `/do` bridge never echoes a credential |
+| 10 | R-D14 | the credential detector is the one the API uses, imported not copied |
+| 11 | R-D19 | `whats_waiting` is `@_anon_guard`-wrapped |
+| 12 | R-D21 | the instance-wide friction routes are operator-only |
+| 14 | — | **AST**: no tool writes a plaintext credential (the standing check) |
+
+Gate 4c lives with the service that owns the scoping
+([`core/flows/tests/test_reactions_scope.py`](../../../../core/flows/tests/test_reactions_scope.py))
+and gate 13 with the route it guards
+([`clients/terminal/src/app/api/__tests__/minutesSeed.test.ts`](../../../../clients/terminal/src/app/api/__tests__/minutesSeed.test.ts)).
+
+**Assert on the tool, not on the file.** The verbs are being split by owning domain; a test that
+greps this file dies the day it moves, and a test that calls the handler follows it.

--- a/deploy/dogfood/rig/tests/README.md
+++ b/deploy/dogfood/rig/tests/README.md
@@ -34,7 +34,7 @@ row and states the defect it replaces, so a future reader can tell what the asse
 | 1a·1b | R-D04 | a workspace link carries a short-lived, path-scoped view token, never a durable bearer |
 | 2a·2b | R-D05 | credential stores are sealed, `0600` in a `0700` dir; legacy plaintext migrates then goes |
 | 3 | R-D06 | the autonomous delegation regime may not `bot_say` or `meeting_delete` |
-| 4a·4b | R-D07 | `reaction_signal` is operator-only; `reactions_list` is scoped to the caller |
+| 4a·4b | R-D07 | `reaction_signal` steers only the caller's OWN reaction (ownership, not operator authority — cancelling the join you scheduled is the product); `reactions_list` is scoped to the caller |
 | 5 | R-D09 | concurrent sign-ins do not lose a token |
 | 6 | R-D10 | the transcript converters cannot read or write outside their directories |
 | 7a·7b | R-D11 | no account before the code is proven; identical answer either way; single-use codes |

--- a/deploy/dogfood/rig/tests/conftest.py
+++ b/deploy/dogfood/rig/tests/conftest.py
@@ -1,0 +1,141 @@
+"""The rig's first behavioural tests — and the harness that makes them possible.
+
+`vexa_control_mcp.py` is 5,033 lines and 53 verbs with **no test that calls one of them** (R-D20):
+the only file that touched it, `core/agent/tests/test_rig_stateless.py`, greps the source text. So
+the shell injection, the missing membership check and an operator gate that broke `bot_schedule`
+were all invisible to a green suite. Every one of them is a function call away.
+
+Two things stood in the way, and both are handled here rather than in each test:
+
+* **The MCP SDK.** The module builds its ASGI app at import time. A stub server is installed when
+  the real `mcp.server.mcpserver` is not importable, so a test run does not depend on an SDK
+  version being present. The stub registers tools exactly where the module reads them back
+  (`mcp._tool_manager._tools`), which is also what the `/do` bridge uses.
+* **The live host.** `VEXA_RIG_STATE_DIR` points every credential store at a tmp directory before
+  the module is imported, and `VEXA_FLOWS_API_KEY` is set so the import-time key read never opens
+  `~/.storm/flows-api-key`. Nothing in this suite reads or writes a real credential store.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import sys
+import tempfile
+import types
+
+RIG_DIR = pathlib.Path(__file__).resolve().parents[1]
+_STATE = pathlib.Path(tempfile.mkdtemp(prefix="rig-tests-"))
+
+# Set BEFORE the module is imported: both are read at import time.
+os.environ["VEXA_RIG_STATE_DIR"] = str(_STATE)
+os.environ.setdefault("VEXA_FLOWS_API_KEY", "test-flows-key")
+os.environ.setdefault("VEXA_MCP_DELEGATION_SECRET", "test-delegation-secret")
+os.environ.setdefault("VEXA_MCP_VIEW_SECRET", "test-view-secret")
+os.environ.setdefault("VEXA_RIG_IMPORT_DIR", str(_STATE / "imports"))
+
+if str(RIG_DIR) not in sys.path:
+    sys.path.insert(0, str(RIG_DIR))
+
+
+def _install_mcp_stub() -> None:
+    """A minimal `mcp.server.mcpserver` — enough for import, registration and the `/do` lookup."""
+    try:
+        importlib.import_module("mcp.server.mcpserver")
+        importlib.import_module("mcp.server.transport_security")
+        return
+    except Exception:  # noqa: BLE001 — absent or a different SDK generation; stub either way
+        pass
+
+    class _ToolManager:
+        def __init__(self):
+            self._tools = {}
+
+    class _Tool:
+        def __init__(self, fn):
+            self.fn = fn
+
+    class MCPServer:
+        def __init__(self, *a, **kw):
+            self._tool_manager = _ToolManager()
+
+        def tool(self, *a, **kw):
+            def deco(fn):
+                self._tool_manager._tools[fn.__name__] = _Tool(fn)
+                return fn
+            return deco
+
+        def prompt(self, *a, **kw):
+            def deco(fn):
+                return fn
+            return deco
+
+        def streamable_http_app(self, *a, **kw):
+            async def _app(scope, receive, send):  # pragma: no cover — never served in tests
+                raise RuntimeError("stub app")
+            return _app
+
+    class TransportSecuritySettings:
+        def __init__(self, **kw):
+            self.__dict__.update(kw)
+
+    root = types.ModuleType("mcp")
+    server = types.ModuleType("mcp.server")
+    mcpserver = types.ModuleType("mcp.server.mcpserver")
+    transport = types.ModuleType("mcp.server.transport_security")
+    mcpserver.MCPServer = MCPServer
+    transport.TransportSecuritySettings = TransportSecuritySettings
+    server.mcpserver, server.transport_security = mcpserver, transport
+    root.server = server
+    for name, mod in (("mcp", root), ("mcp.server", server),
+                      ("mcp.server.mcpserver", mcpserver),
+                      ("mcp.server.transport_security", transport)):
+        sys.modules[name] = mod
+
+
+_install_mcp_stub()
+
+import rig_secrets  # noqa: E402
+import vexa_control_mcp as rig  # noqa: E402
+
+STATE = _STATE
+
+
+def tool(name: str):
+    """The callable a client actually reaches — the registered, fully decorated tool body."""
+    return rig.mcp._tool_manager._tools[name].fn
+
+
+class HTTP:
+    """A recording stand-in for `rig._http`. Every test asserts on what the rig ASKED FOR, which
+    is where authorization lives: the subject on a query string, the header a secret travels in."""
+
+    def __init__(self, admin_uids=(), routes=None):
+        self.calls = []
+        self.admin_uids = {str(u) for u in admin_uids}
+        self.routes = routes or {}
+
+    def __call__(self, method, url, headers=None, body=None, timeout=40):
+        self.calls.append({"method": method, "url": url, "headers": headers or {}, "body": body})
+        for frag, answer in self.routes.items():
+            if frag in url:
+                return answer
+        if "/admin/users/" in url and method == "GET":
+            uid = url.rsplit("/", 1)[-1]
+            return 200, {"id": uid, "data": {"is_admin": uid in self.admin_uids}}
+        return 200, {}
+
+    def urls(self, frag=""):
+        return [c["url"] for c in self.calls if frag in c["url"]]
+
+
+def as_user(monkeypatch, uid="7", admin=False, routes=None) -> HTTP:
+    """Sign a test in as ``uid`` and route every HTTP call through a recorder."""
+    http = HTTP(admin_uids=[uid] if admin else [], routes=routes)
+    monkeypatch.setattr(rig, "_http", http)
+    monkeypatch.setattr(rig, "_admin_key", lambda: "test-admin-key")
+    rig._UID_ALIVE.clear()
+    rig.CURRENT.set(str(uid))
+    rig.CALL_SCOPE.set(None)
+    rig.CALL_TOKEN.set(None)
+    return http

--- a/deploy/dogfood/rig/tests/conftest.py
+++ b/deploy/dogfood/rig/tests/conftest.py
@@ -30,6 +30,9 @@ _STATE = pathlib.Path(tempfile.mkdtemp(prefix="rig-tests-"))
 # Set BEFORE the module is imported: both are read at import time.
 os.environ["VEXA_RIG_STATE_DIR"] = str(_STATE)
 os.environ.setdefault("VEXA_FLOWS_API_KEY", "test-flows-key")
+# F95 made this fail-closed at import: no default, and the process refuses to start without
+# it. A test value keeps the suite offline — it is never compared against anything real.
+os.environ.setdefault("INTERNAL_API_SECRET", "test-internal-secret")
 os.environ.setdefault("VEXA_MCP_DELEGATION_SECRET", "test-delegation-secret")
 os.environ.setdefault("VEXA_MCP_VIEW_SECRET", "test-view-secret")
 os.environ.setdefault("VEXA_RIG_IMPORT_DIR", str(_STATE / "imports"))

--- a/deploy/dogfood/rig/tests/test_authorization.py
+++ b/deploy/dogfood/rig/tests/test_authorization.py
@@ -29,18 +29,46 @@ def test_rd06_the_autonomous_regime_may_not_speak_or_delete(monkeypatch):
     assert out.get("refused") != "regime"
 
 
-def test_rd07_reaction_signal_is_operator_only(monkeypatch):
+def test_rd07_reaction_signal_steers_only_the_callers_own_reaction(monkeypatch):
     """GATE 4a (R-D07). `reaction_signal` posts with the lane's admin key and never checked the
     reaction against the caller, while `reactions_list` handed out every id instance-wide — so
-    `cancel` on a stranger's scheduled join was one call away for any signed-in user. It is the
-    verb `_operator_or_refuse` was written for, and it was the one the gate was left off."""
-    as_user(monkeypatch, "7", admin=False)
-    out = json.loads(tool("reaction_signal")("r-1", "cancel"))
-    assert out.get("refused") == "operator only"
+    `cancel` on a stranger's scheduled join was one call away for any signed-in user.
 
-    http = as_user(monkeypatch, "7", admin=True)
-    tool("reaction_signal")("r-1", "cancel")
-    assert any("/reactions/r-1/cancel" in u for u in http.urls())
+    The check is OWNERSHIP, not operator authority, and the difference is the product: a person
+    stopping the join THEY scheduled with `bot_schedule` is the ordinary path, so an admin-only
+    gate here would close the common case to fix the rare one. The decision is made by the service
+    that owns the row — `subject` on the signal route — never here by matching strings.
+    """
+    # A COLLEAGUE'S reaction: the owning service answers 403 and the verb refuses by name.
+    http = as_user(monkeypatch, "7",
+                   routes={"/reactions/r-theirs/cancel": (403, "that reaction is not yours")})
+    out = json.loads(tool("reaction_signal")("r-theirs", "cancel"))
+    assert out.get("refused") == "not_yours", out
+    assert "subject=7" in http.urls("/reactions/r-theirs")[0]
+
+    # THEIR OWN: it goes through, and the subject rides along so the service can decide.
+    http = as_user(monkeypatch, "7", routes={"/reactions/r-mine/cancel": (200, {"cancel": True})})
+    out = json.loads(tool("reaction_signal")("r-mine", "cancel"))
+    assert out.get("refused") is None, out
+    assert out["result"] == {"cancel": True}
+    url = http.urls("/reactions/r-mine/cancel")[0]
+    assert "subject=7" in url, url
+
+    # An id that does not exist is its OWN answer — telling somebody "not yours" about a reaction
+    # nobody has sends them off to re-derive an id instead of asking for a real one.
+    http = as_user(monkeypatch, "7", routes={"/reactions/r-ghost/cancel": (404, "no such reaction")})
+    assert json.loads(tool("reaction_signal")("r-ghost", "cancel"))["refused"] == "no_such_reaction"
+
+
+def test_rd07_reaction_signal_is_not_operator_gated(monkeypatch):
+    """The other half of the same ruling, pinned so it cannot drift back: an ordinary,
+    non-admin account reaches this verb. It was briefly `_operator_gate`d, which would have made
+    `bot_schedule` mint a reaction its own author could not cancel."""
+    http = as_user(monkeypatch, "7", admin=False,
+                   routes={"/reactions/r-mine/cancel": (200, {"cancel": True})})
+    out = json.loads(tool("reaction_signal")("r-mine", "cancel"))
+    assert out.get("refused") is None, out
+    assert http.urls("/reactions/r-mine/cancel"), "a non-admin never reached the service"
 
 
 def test_rd07_reactions_list_is_scoped_to_the_caller(monkeypatch):

--- a/deploy/dogfood/rig/tests/test_authorization.py
+++ b/deploy/dogfood/rig/tests/test_authorization.py
@@ -1,0 +1,98 @@
+"""R-D06 · R-D07 · R-D12 · R-D19 · R-D21 — who may do what, and over whose rows."""
+from __future__ import annotations
+
+import json
+
+from conftest import as_user, tool
+import vexa_control_mcp as rig
+
+
+def test_rd06_the_autonomous_regime_may_not_speak_or_delete(monkeypatch):
+    """GATE 3 (R-D06). Decision 7 said the autonomous client — a model dispatched with no person in
+    the loop — does not speak into a live room and does not delete meetings. The regime rode along
+    in every delegated token, was PRINTED at two places, and was read for authorization at none;
+    `bot_say`'s only guard was `asked_by_a_human`, an argument the calling model sets about itself.
+    """
+    as_user(monkeypatch, "7")
+    rig.CALL_SCOPE.set({"regime": "autonomous", "workspaces": ["team"]})
+
+    for verb, kwargs in (("bot_say", {"meeting_url": "https://meet.google.com/abc-defg-hij",
+                                      "text": "hello", "asked_by_a_human": True}),
+                         ("meeting_delete", {"meeting_id": "12"})):
+        out = json.loads(tool(verb)(**kwargs))
+        assert out.get("refused") == "regime", f"{verb} ran under the autonomous regime"
+
+    # …and the human regime is unaffected: the reduction is a ceiling on one dispatch shape, not a
+    # new refusal for the person's own agent.
+    rig.CALL_SCOPE.set({"regime": "human", "workspaces": "*"})
+    out = json.loads(tool("meeting_delete")(meeting_id="12"))
+    assert out.get("refused") != "regime"
+
+
+def test_rd07_reaction_signal_is_operator_only(monkeypatch):
+    """GATE 4a (R-D07). `reaction_signal` posts with the lane's admin key and never checked the
+    reaction against the caller, while `reactions_list` handed out every id instance-wide — so
+    `cancel` on a stranger's scheduled join was one call away for any signed-in user. It is the
+    verb `_operator_or_refuse` was written for, and it was the one the gate was left off."""
+    as_user(monkeypatch, "7", admin=False)
+    out = json.loads(tool("reaction_signal")("r-1", "cancel"))
+    assert out.get("refused") == "operator only"
+
+    http = as_user(monkeypatch, "7", admin=True)
+    tool("reaction_signal")("r-1", "cancel")
+    assert any("/reactions/r-1/cancel" in u for u in http.urls())
+
+
+def test_rd07_reactions_list_is_scoped_to_the_caller(monkeypatch):
+    """GATE 4b (R-D07). The operator projection, asked for as this person's."""
+    http = as_user(monkeypatch, "7")
+    tool("reactions_list")(status="failed")
+    urls = http.urls("/reactions")
+    assert urls and "subject=7" in urls[0], urls
+    assert "status=failed" in urls[0]
+
+
+def test_rd12_whats_waiting_asks_only_for_this_subject(monkeypatch):
+    """GATE 8 (R-D12). The tool nobody can avoid calling was fetching `{FLOWS}/reactions` with no
+    subject filter and reporting other tenants' flow names, step names and failure reasons as this
+    person's queue."""
+    http = as_user(monkeypatch, "7")
+    tool("whats_waiting")()
+    urls = http.urls("/reactions")
+    assert urls, "whats_waiting did not read the reaction queue at all"
+    assert all("subject=7" in u for u in urls), urls
+
+
+def test_rd19_whats_waiting_is_anon_guarded(monkeypatch):
+    """GATE 11 (R-D19). It was the one account tool with no `@_anon_guard`, so it set CALL_TOKEN by
+    hand: it accepted a credential in a call argument even with VEXA_RIG_MODE=0, and it CLEARED a
+    live token whenever the kwarg was absent — de-authenticating the first call every agent makes.
+    """
+    as_user(monkeypatch, "7")
+    rig.CURRENT.set(None)
+    rig.CALL_TOKEN.set("vxa_mcp_LIVE")
+
+    tool("whats_waiting")()                    # no token= kwarg
+    assert rig.CALL_TOKEN.get() == "vxa_mcp_LIVE", "a live token was cleared by the call"
+
+    monkeypatch.setattr(rig, "RIG_MODE", False)
+    rig.CALL_TOKEN.set(None)
+    tool("whats_waiting")(token="vxa_mcp_FROM_AN_ARGUMENT")
+    assert rig.CALL_TOKEN.get() is None, "a token argument authenticated with RIG_MODE off"
+
+
+def test_rd21_friction_instance_wide_routes_are_gated(monkeypatch):
+    """GATE 12 (R-D21). `friction_dump` returns the WHOLE instance's ledger — other people's
+    workspace names, file paths, meeting ids and free text — and `friction_fixed` mutates it; both
+    were open to any signed-in caller. And `friction_so_far` advertised "NO ACCOUNT NEEDED" one
+    line above `me()`, so an anonymous agent read the refusal as an empty ledger and filed again.
+    """
+    as_user(monkeypatch, "7", admin=False)
+    assert json.loads(tool("friction_dump")()).get("refused") == "operator only"
+    assert json.loads(tool("friction_fixed")(["1"], "abc123")).get("refused") == "operator only"
+
+    # The SUMMARY LINE is what a client shows and what a model acts on; the paragraph below it may
+    # quote the old claim as history, and that is the point of keeping it.
+    summary = (tool("friction_so_far").__doc__ or "").strip().splitlines()[0]
+    assert "NO ACCOUNT NEEDED" not in summary
+    assert "NEEDS AN ACCOUNT" in summary

--- a/deploy/dogfood/rig/tests/test_credential_store.py
+++ b/deploy/dogfood/rig/tests/test_credential_store.py
@@ -1,0 +1,85 @@
+"""R-D05 · R-D09 — the credential stores: sealed, owner-only, locked, and atomic."""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import threading
+
+import rig_secrets
+from conftest import STATE
+import vexa_control_mcp as rig
+
+
+def _enc(name: str) -> pathlib.Path:
+    return STATE / ".secrets" / f"{name}.enc"
+
+
+def test_rd05_credential_stores_are_sealed_and_owner_only():
+    """GATE 2a (R-D05). A minted token must not appear in any file on disk, and the file that holds
+    it must be 0600 in a 0700 directory.
+
+    The symptom this replaces, read off the live host: `-rw-rw-r-- ~/.storm/user-api-keys.json`,
+    `oauth/logins.json`, `oauth/email-codes.json` — every user's gateway key, every minted
+    `vxa_mcp_` token and every live sign-in code readable by any local account, on a box with four
+    other human users, while decision 25 said "encrypted at rest"."""
+    rig._token_put("vxa_mcp_SEALEDTOKENSAMPLE", {"uid": "7", "email": "a@b.c"})
+    rig_secrets.write("user-api-keys", {"7": "gwkey_SAMPLEVALUE"})
+
+    assert rig._tokens()["vxa_mcp_SEALEDTOKENSAMPLE"]["uid"] == "7"
+
+    leaked = []
+    for p in STATE.rglob("*"):
+        if p.is_file():
+            blob = p.read_bytes()
+            if b"vxa_mcp_SEALEDTOKENSAMPLE" in blob or b"gwkey_SAMPLEVALUE" in blob:
+                leaked.append(str(p))
+    assert leaked == [], f"plaintext credential on disk: {leaked}"
+
+    for name in ("mcp-tokens", "user-api-keys"):
+        p = _enc(name)
+        assert p.is_file(), f"{name} is not in the encrypted store"
+        assert oct(p.stat().st_mode & 0o777) == "0o600"
+        assert oct(p.parent.stat().st_mode & 0o777) == "0o700"
+
+
+def test_rd05_legacy_plaintext_is_migrated_then_removed():
+    """GATE 2b (R-D05). The plaintext file an older rig left behind is read once, sealed, verified,
+    and only then unlinked — a migration that deletes before it verifies is data loss."""
+    legacy = STATE / "legacy-store.json"
+    legacy.write_text(json.dumps({"tok_LEGACY": {"uid": "9"}}))
+    os.chmod(legacy, 0o664)
+
+    got = rig_secrets.read("legacy-store")
+
+    assert got == {"tok_LEGACY": {"uid": "9"}}, "the migration lost the contents"
+    assert not legacy.exists(), "the plaintext file survived the migration"
+    assert b"tok_LEGACY" not in _enc("legacy-store").read_bytes()
+    assert rig_secrets.read("legacy-store") == {"tok_LEGACY": {"uid": "9"}}
+
+
+def test_rd09_concurrent_writers_do_not_lose_a_token():
+    """GATE 5 (R-D09). Twenty concurrent sign-ins must leave twenty tokens.
+
+    Every credential file was an unlocked read-modify-write with a truncating save, and
+    `mcp-tokens.json` had three independent writers. Two sign-ins in the same second lost one
+    token; a crash between the read and the write emptied the store and signed everybody out
+    permanently. `rig_secrets.update` holds an exclusive flock across both halves and the write
+    underneath it is write-temp-and-replace."""
+    rig_secrets.write("race-store", {})
+    errors = []
+
+    def add(i):
+        try:
+            rig_secrets.update("race-store", lambda d: d.update({f"tok{i}": {"uid": str(i)}}) or d)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=add, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert len(rig_secrets.read("race-store")) == 20

--- a/deploy/dogfood/rig/tests/test_credential_store.py
+++ b/deploy/dogfood/rig/tests/test_credential_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import tempfile
 import threading
 
 import rig_secrets
@@ -83,3 +84,28 @@ def test_rd09_concurrent_writers_do_not_lose_a_token():
 
     assert errors == []
     assert len(rig_secrets.read("race-store")) == 20
+
+
+def test_the_store_survives_secret_stores_own_hardening():
+    """The rig hard-imports two `core/agent` modules, and #1428 changed BOTH under this branch —
+    `secret_store` (R-E13) and `git_redaction` (R-E09). This pins the coupling that matters most.
+
+    R-E13 split key generation off the read path, so `get()` no longer creates `.master.key`. That
+    is correct and it is exactly the kind of change that turns a consumer's "no credential yet"
+    into a silent failure. What this holds: a pure READ of an empty store creates nothing and
+    answers `{}`, a WRITE mints the key, and the round trip works — so an unconfigured rig still
+    gets encryption on first use rather than falling back to plaintext or raising on boot.
+    """
+    fresh = pathlib.Path(tempfile.mkdtemp(prefix="rig-fresh-"))
+    original, rig_secrets.STATE_DIR = rig_secrets.STATE_DIR, fresh
+    try:
+        assert rig_secrets.read("mcp-tokens") == {}
+        assert not (fresh / ".secrets/.master.key").exists(), \
+            "a pure read generated a key — R-E13's split has regressed under us"
+
+        rig_secrets.write("mcp-tokens", {"vxa_mcp_FRESH": {"uid": "1"}})
+        assert (fresh / ".secrets/.master.key").exists(), "a write did not mint a key"
+        assert rig_secrets.read("mcp-tokens") == {"vxa_mcp_FRESH": {"uid": "1"}}
+        assert b"vxa_mcp_FRESH" not in (fresh / ".secrets/mcp-tokens.enc").read_bytes()
+    finally:
+        rig_secrets.STATE_DIR = original

--- a/deploy/dogfood/rig/tests/test_no_plaintext_credentials.py
+++ b/deploy/dogfood/rig/tests/test_no_plaintext_credentials.py
@@ -1,0 +1,176 @@
+"""GATE 14 — the standing check: NO TOOL IN THIS SURFACE WRITES A CREDENTIAL IN PLAINTEXT.
+
+The three tests above prove today's stores are sealed. This one proves the NEXT one will be, which
+is the part that actually failed: the encrypted store existed, was declared by decision 25, and
+five separate writers in this file reached past it to `write_text(json.dumps(...))` at the default
+umask because that was the shorter line. A rule that lives only in a review is a rule that holds
+until the next hurry.
+
+It reads the AST rather than the text, so a rename, a reflow or a comment quoting the old shape
+does not move it, and it fails on the SHAPE — a credential-named target reaching a file write —
+rather than on a list of known filenames.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+RIG_DIR = pathlib.Path(__file__).resolve().parents[1]
+GUARDED = ("vexa_control_mcp.py", "vexa_oauth.py")
+
+#: Names that mean "this holds, or names, a credential". Deliberately broad — a false positive
+#: costs one `rig_secrets` call, a false negative costs a credential.
+CREDENTIALISH = re.compile(
+    r"token|api_?key|_key\b|keys\b|secret|password|credential|passwd|"
+    r"email_?codes?|sign_?in|login|oauth",
+    re.I)
+
+#: The store names each module declares. Each MUST be a plain string, never a path.
+STORE_CONSTANTS = {
+    "vexa_control_mcp.py": ["TOKENS_STORE", "EMAIL_CODES_STORE", "LOGINS_STORE",
+                            "REGIMES_STORE", "USER_KEYS_STORE"],
+    "vexa_oauth.py": ["CLIENTS", "CODES", "TOKENS"],
+}
+
+WRITE_METHODS = {"write_text", "write_bytes", "writelines"}
+
+
+def _trees():
+    for name in GUARDED:
+        p = RIG_DIR / name
+        yield name, p.read_text(), ast.parse(p.read_text())
+
+
+def test_credential_stores_are_names_not_paths():
+    """A store constant that is a `pathlib.Path` is a plaintext file waiting to be written to. Each
+    of these used to be exactly that: `HOME / ".storm/mcp-tokens.json"` and friends."""
+    bad = []
+    for name, _src, tree in _trees():
+        wanted = set(STORE_CONSTANTS[name])
+        seen = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in wanted:
+                    seen.add(target.id)
+                    if not (isinstance(node.value, ast.Constant)
+                            and isinstance(node.value.value, str)):
+                        bad.append(f"{name}:{node.lineno} {target.id} is not a store name")
+        missing = wanted - seen
+        assert not missing, f"{name}: store constants vanished: {sorted(missing)}"
+    assert bad == [], bad
+
+
+def _write_offences(name: str, src: str) -> list:
+    """Every credential-named target reaching a file write in ``src``."""
+    offences = []
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Call):
+            continue
+        target_src = ""
+        if isinstance(node.func, ast.Attribute) and node.func.attr in WRITE_METHODS:
+            target_src = ast.get_source_segment(src, node.func.value) or ""
+        elif isinstance(node.func, ast.Name) and node.func.id == "open":
+            mode = ""
+            for kw in node.keywords:
+                if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                    mode = str(kw.value.value)
+            if len(node.args) > 1 and isinstance(node.args[1], ast.Constant):
+                mode = str(node.args[1].value)
+            if any(m in mode for m in ("w", "a", "x", "+")):
+                target_src = ast.get_source_segment(src, node.args[0]) or ""
+        if target_src and CREDENTIALISH.search(target_src):
+            offences.append(f"{name}:{node.lineno} writes {target_src!r}")
+    return offences
+
+
+def test_the_gate_fails_on_the_shape_it_was_written_for():
+    """A gate nobody has watched fail is a gate nobody knows the state of (this suite's R-C10
+    lesson, applied to itself). These are the exact lines the review found, verbatim."""
+    was = ('TOKENS_FILE = HOME / ".storm/mcp-tokens.json"\n'
+           'def _mint(tok, uid):\n'
+           '    d = {tok: uid}\n'
+           '    TOKENS_FILE.write_text(json.dumps(d, indent=1))\n'
+           '    open(EMAIL_CODES, "w").write("...")\n')
+    assert len(_write_offences("was.py", was)) == 2, _write_offences("was.py", was)
+
+
+def test_no_credential_named_target_is_written_to_a_file():
+    """The shape itself: anything credential-named reaching `write_text`/`open(..., 'w')`.
+
+    `rig_secrets` is the one module allowed to write a credential, and it seals before it does."""
+    offences = []
+    for name, src, _tree in _trees():
+        offences += _write_offences(name, src)
+    assert offences == [], (
+        "a credential-named target is being written to a file directly; route it through "
+        f"rig_secrets.write/update instead: {offences}")
+
+
+def test_no_plaintext_credential_file_path_literals_remain():
+    """The literal shape of the defect, so it cannot come back under a new name: a credential-named
+    `.storm/*.json` string in the rig IS a plaintext store — that is the only thing that shape has
+    ever been here (`mcp-tokens.json`, `user-api-keys.json`, `oauth/logins.json`,
+    `oauth/email-codes.json`, `oauth/tokens.json`, `oauth/codes.json`)."""
+    offences = []
+    for name, _src, tree in _trees():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                # A BARE PATH literal, not a paragraph that happens to say "token" — the agent
+                # instructions in this file are prose about `.mcp.json` and say so at length.
+                if (re.fullmatch(r"[\w.~/-]+\.jsonl?", node.value)
+                        and CREDENTIALISH.search(node.value)):
+                    offences.append(f"{name}:{node.lineno} {node.value!r}")
+    assert offences == [], offences
+
+
+#: Thin wrappers that do nothing but forward to `rig_secrets` — proven to be exactly that below.
+_WRAPPERS = {"vexa_oauth.py": {"_load", "_save"}, "vexa_control_mcp.py": set()}
+
+
+def test_every_store_read_and_write_goes_through_rig_secrets():
+    """The store names are arguments to `rig_secrets` (or to a wrapper that is nothing else), and
+    to nothing more — so a future caller cannot reach one with `open()` and a name it built."""
+    offences = []
+    for name, src, tree in _trees():
+        wanted = set(STORE_CONSTANTS[name])
+        wrappers = _WRAPPERS[name]
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Name) and node.id in wanted
+                    and isinstance(node.ctx, ast.Load)):
+                continue
+            parent = _parent_call(tree, node)
+            f = parent.func if parent is not None else None
+            ok = ((isinstance(f, ast.Attribute) and isinstance(f.value, ast.Name)
+                   and f.value.id == "rig_secrets")
+                  or (isinstance(f, ast.Name) and f.id in wrappers))
+            if not ok:
+                offences.append(f"{name}:{node.lineno} {node.id} used outside rig_secrets "
+                                f"({ast.get_source_segment(src, parent) if parent else '?'})")
+    assert offences == [], offences
+
+
+def test_the_store_wrappers_forward_and_do_nothing_else():
+    """The exemption above is only safe while it is true: each wrapper's whole body is one call
+    into `rig_secrets`. A wrapper that grew a `write_text` would take the gate down with it."""
+    for name, _src, tree in _trees():
+        for fname in _WRAPPERS[name]:
+            fn = next((n for n in ast.walk(tree)
+                       if isinstance(n, ast.FunctionDef) and n.name == fname), None)
+            assert fn is not None, f"{name}: wrapper {fname} is gone — drop it from _WRAPPERS"
+            calls = [n for n in ast.walk(fn) if isinstance(n, ast.Call)]
+            assert calls, f"{name}:{fname} calls nothing"
+            for c in calls:
+                assert (isinstance(c.func, ast.Attribute)
+                        and isinstance(c.func.value, ast.Name)
+                        and c.func.value.id == "rig_secrets"), \
+                    f"{name}:{fname} does more than forward to rig_secrets"
+
+
+def _parent_call(tree, target):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and any(a is target for a in node.args):
+            return node
+    return None

--- a/deploy/dogfood/rig/tests/test_paths_and_errors.py
+++ b/deploy/dogfood/rig/tests/test_paths_and_errors.py
@@ -128,3 +128,13 @@ def test_rd14_the_credential_detector_is_the_one_the_api_uses():
     # The detector is lifted out of the file and run on its own by
     # core/agent/tests/test_workspace_credentials.py, so its prefixes are literals. Pin them here.
     assert rig._OUR_CREDENTIAL_PREFIXES == ("vxa_mcp_", rig.DELEGATION_PREFIX, rig.VIEW_PREFIX)
+
+    # …and an ORDINARY repository URL is not refused. This is the cost of delegating to the
+    # scrubber, and it is live: #1428 (R-E09) dropped the generic run's threshold from 36 to 24
+    # characters while this branch was open. Each time that threshold moves, the question "does
+    # workspace_attach still work on a normal repo?" is asked again — here.
+    for ordinary in ("https://github.com/Vexa-ai/vexa",
+                     "https://github.com/some-very-long-organisation-name/a-long-repository-name",
+                     "git@github.com:acme/kg.git",
+                     "https://gitlab.com/group/subgroup/project.git"):
+        assert not rig._refuse_credentials(ordinary), ordinary

--- a/deploy/dogfood/rig/tests/test_paths_and_errors.py
+++ b/deploy/dogfood/rig/tests/test_paths_and_errors.py
@@ -1,0 +1,130 @@
+"""R-D10 · R-D11 · R-D13 · R-D14 — untrusted strings: paths, addresses, exceptions, credentials."""
+from __future__ import annotations
+
+import json
+
+from conftest import STATE, as_user, tool
+import vexa_control_mcp as rig
+
+
+def test_rd10_transcript_converters_cannot_leave_their_directories(monkeypatch):
+    """GATE 6 (R-D10). `zoom_transcript_to_segments(name, path)` read ANY host path — and the
+    lines it matched came back as `speakers`, so it was an arbitrary file read with its own oracle
+    — and wrote to `~/.storm/caps/{name}.segments.json` with `name` unsanitized, so
+    `name="../../../../tmp/x"` wrote outside. `captions_to_segments` had the same traversal.
+    """
+    as_user(monkeypatch, "7")
+    outside = STATE / "outside.txt"
+    outside.write_text("[00:00:01.0 --> 00:00:02.0] Someone (Corp): secret\n")
+
+    out = json.loads(tool("zoom_transcript_to_segments")(name="ok", path=str(outside)))
+    assert "outside the import directory" in out.get("error", ""), out
+
+    for bad in ("../../../../tmp/x", "a/b", "with space", ""):
+        out = json.loads(tool("zoom_transcript_to_segments")(name=bad, path=str(outside)))
+        assert "name must match" in out.get("error", ""), (bad, out)
+        out = json.loads(tool("captions_to_segments")(video_id=bad))
+        assert "video_id must match" in out.get("error", ""), (bad, out)
+
+    # …and the legitimate shape still works, from inside the import directory.
+    inside = rig.IMPORT_DIR / "call.txt"
+    inside.parent.mkdir(parents=True, exist_ok=True)
+    inside.write_text("[00:00:01.0 --> 00:00:02.0] Someone (Corp): hello there\n")
+    out = json.loads(tool("zoom_transcript_to_segments")(name="call", path=str(inside)))
+    assert out.get("turns") == 1, out
+    assert (rig.CAPS_DIR / "call.segments.json").is_file()
+
+
+def test_rd11_start_onboarding_creates_no_account_and_answers_the_same_either_way(monkeypatch):
+    """GATE 7a (R-D11). `start_onboarding` needs no account and was CREATING the platform user
+    before any code was verified — so an unauthenticated caller minted accounts for addresses it
+    did not own — then answered "existing" vs "created", which made it an existence oracle over the
+    whole user table. It also mailed any address supplied, with only a per-address throttle.
+    """
+    sent = []
+    monkeypatch.setattr(rig, "_send_code", lambda email, code: sent.append((email, code)) or None)
+    http = as_user(monkeypatch, "7")
+    rig.CURRENT.set(None)
+    rig_state = rig.rig_secrets
+    rig_state.write(rig.EMAIL_CODES_STORE, {})
+    rig._CODE_SENDS.clear()
+
+    new = json.loads(tool("start_onboarding")("nobody@example.com"))
+    rig_state.write(rig.EMAIL_CODES_STORE, {})
+    existing = json.loads(tool("start_onboarding")("known@example.com"))
+
+    assert not [u for u in http.urls() if u.endswith("/admin/users")], \
+        "an account was created before the code was verified"
+    assert new["account"] == existing["account"], "the response still distinguishes the two"
+    assert len(sent) == 2
+
+    # …and the budget is a real ceiling, not a per-address one: the source of an anonymous call is
+    # this process, so this is the only rate limit there is to apply.
+    rig._CODE_SENDS.clear()
+    for i in range(rig.CODE_BUDGET):
+        rig_state.write(rig.EMAIL_CODES_STORE, {})
+        tool("start_onboarding")(f"a{i}@example.com")
+    rig_state.write(rig.EMAIL_CODES_STORE, {})
+    over = json.loads(tool("start_onboarding")("one-too-many@example.com"))
+    assert "too many sign-in codes" in over.get("error", ""), over
+
+
+def test_rd11_the_code_is_single_use_and_the_account_is_made_after_the_proof(monkeypatch):
+    """GATE 7b (R-D11). The code is spent on success, under the store's lock, before anything else
+    happens — a code that survived its own use is a second sign-in for anyone who saw the
+    transcript — and the account is created here, after the proof, never before it."""
+    monkeypatch.setattr(rig, "_send_code", lambda email, code: None)
+    http = as_user(monkeypatch, "7", routes={"/admin/users/email/": (404, {}),
+                                             "/admin/users": (200, {"id": 42})})
+    rig.CURRENT.set(None)
+    rig.rig_secrets.write(rig.EMAIL_CODES_STORE, {})
+    rig._CODE_SENDS.clear()
+
+    tool("start_onboarding")("new@example.com")
+    code = rig.rig_secrets.read(rig.EMAIL_CODES_STORE)["new@example.com"]["code"]
+
+    first = json.loads(tool("confirm_login")("new@example.com", code))
+    assert first.get("token", "").startswith("vxa_mcp_"), first
+    assert any(u.endswith("/admin/users") for u in http.urls()), \
+        "confirm_login did not create the account"
+
+    again = json.loads(tool("confirm_login")("new@example.com", code))
+    assert "no code is pending" in again.get("error", ""), again
+
+
+def test_rd13_the_do_bridge_never_echoes_a_credential(monkeypatch):
+    """GATE 9 (R-D13). The bridge returned `f"{type(e).__name__}: {e}"` verbatim over HTTP, and
+    the tool internals under it raise with the URLs and headers they were using — including
+    `psycopg.connect(url)` with the database password inside the DSN."""
+    err = RuntimeError("connect failed: postgres://vexa:s3cretpassword@db:5432/flows "
+                       "header X-Admin-API-Key: ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+    out = rig._safe_error(err)
+
+    assert "s3cretpassword" not in out
+    assert "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" not in out
+    assert "RuntimeError" in out, "the type is the diagnostic; masking it helps nobody"
+
+    monkeypatch.setattr(rig, "_admin_key", lambda: "short-admin-key")
+    rig._ADMIN_KEY_CACHE[:] = ["short-admin-key"]
+    assert "short-admin-key" not in rig._safe_error(RuntimeError("used short-admin-key"))
+
+
+def test_rd14_the_credential_detector_is_the_one_the_api_uses():
+    """GATE 10 (R-D14). `_refuse_credentials` claimed to be "the same detector the API uses" and was
+    a hand-rolled six-prefix copy: no `glpat-`, no generic long run, and a URL rule that required
+    BOTH `:` and `@` in the userinfo — so `https://<gitlab-pat>@gitlab.com/a/b`, exactly how git
+    writes a PAT into a remote, walked through."""
+    assert rig._refuse_credentials("glpat-AAAAAAAAAAAAAAAAAAAA")
+    assert rig._refuse_credentials("https://glpat-AAAAAAAAAAAAAAAAAAAA@gitlab.com/a/b")
+    assert rig._refuse_credentials("https://user:password@github.com/a/b")
+    assert rig._refuse_credentials("ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+
+    # …and our own auth argument is not a git credential: `token=` is 40 urlsafe characters, so a
+    # rule that only knows shapes would refuse every authenticated call to workspace_attach.
+    assert not rig._refuse_credentials("https://github.com/Vexa-ai/vexa", "main", "team",
+                                       "vxa_mcp_" + "A" * 32)
+    assert not rig._refuse_credentials(rig.DELEGATION_PREFIX + "A" * 40)
+    assert not rig._refuse_credentials(rig._view_token("7", "a/b.md"))
+    # The detector is lifted out of the file and run on its own by
+    # core/agent/tests/test_workspace_credentials.py, so its prefixes are literals. Pin them here.
+    assert rig._OUR_CREDENTIAL_PREFIXES == ("vxa_mcp_", rig.DELEGATION_PREFIX, rig.VIEW_PREFIX)

--- a/deploy/dogfood/rig/tests/test_view_links.py
+++ b/deploy/dogfood/rig/tests/test_view_links.py
@@ -1,0 +1,41 @@
+"""R-D04 — the link handed to a person is not a credential any more."""
+from __future__ import annotations
+
+import json
+import time
+
+from conftest import as_user, tool
+import vexa_control_mcp as rig
+
+
+def test_rd04_workspace_links_carry_no_durable_bearer(monkeypatch):
+    """GATE 1a (R-D04). `workspace_read` returns a link the agent is told to paste to the person.
+    That link used to carry the caller's `vxa_mcp_` bearer — a credential that never expires and
+    opens every tool — into chat scrollback, browser history and any Referer. Four call sites, none
+    gated by RIG_MODE. What comes back now is a view token scoped to one path."""
+    as_user(monkeypatch, "7", routes={"/api/workspace/file": (200, {"content": "hello"})})
+    rig.CALL_TOKEN.set("vxa_mcp_LIVEDURABLETOKEN")
+
+    out = json.loads(tool("workspace_read")("notes/one.md", token="vxa_mcp_LIVEDURABLETOKEN"))
+
+    blob = json.dumps(out)
+    assert "vxa_mcp_" not in blob, "a durable bearer token is still being minted into the link"
+    assert rig.VIEW_PREFIX in out["url"]
+
+
+def test_rd04_a_view_token_opens_one_path_and_expires():
+    """GATE 1b (R-D04). The token is bound to its path and to a deadline, so it cannot be
+    re-pointed at another file and does not outlive the conversation it was minted in."""
+    tok = rig._view_token("7", "notes/one.md")
+
+    assert rig._view_verify(tok, "notes/one.md") == "7"
+    assert rig._view_verify(tok, "notes/other.md") == "", "the token is not bound to its path"
+    assert rig._view_verify(tok[:-1] + ("0" if tok[-1] != "0" else "1"), "notes/one.md") == "", \
+        "a tampered MAC verified"
+    assert rig._view_verify("vxa_mcp_LIVEDURABLETOKEN", "notes/one.md") == "", \
+        "the viewer still accepts a durable bearer in the query string"
+
+    expired = rig._view_token("7", "notes/one.md", ttl=-1)
+    assert rig._view_verify(expired, "notes/one.md") == ""
+    assert rig.VIEW_TTL_S <= 3600, "a 'short-lived' view token should not outlive an hour"
+    assert time.time() > 0

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -2263,14 +2263,30 @@ def reaction_signal(reaction_id: str, verb: str, token: str = "") -> str:
              retrying/admitted. Use this when you have just satisfied the condition a
              step was waiting on and do not want to wait out its poll interval.
 
-    OPERATOR ONLY, for the same reason `fact_emit` and `flow_lifecycle` are (R-D07): this posts
-    with the lane's admin key and never checked the reaction against the caller, while
-    `reactions_list` was handing every id out instance-wide — so `cancel` on somebody else's
-    scheduled join was one call away for any signed-in user."""
-    _actor, refused = _operator_gate("reaction_signal")
-    if refused:
-        return refused
-    st, body = _http("POST", f"{FLOWS_API}/reactions/{reaction_id}/{verb}", _fkey(), {})
+    YOURS ONLY (R-D07). This posts with the lane's admin key and never checked the reaction against
+    the caller, while `reactions_list` was handing every id out instance-wide — so `cancel` on
+    somebody else's scheduled join was one call away for any signed-in user. The check is
+    OWNERSHIP, not operator authority: stopping the join you scheduled with `bot_schedule` is the
+    ordinary path, and an admin-only gate would close it to fix an unusual one. The decision is
+    made by the service that owns the row — `subject` on the signal route — never here by matching
+    strings."""
+    uid = me()
+    q = urllib.parse.urlencode({"subject": str(uid)})
+    st, body = _http("POST", f"{FLOWS_API}/reactions/{reaction_id}/{verb}?{q}", _fkey(), {})
+    if st == 403:
+        return json.dumps({
+            "refused": "not_yours", "reaction": reaction_id, "verb": verb,
+            "why": "that reaction belongs to somebody else's meeting, so it is not yours to steer",
+            "tell_your_person": "plainly, that you cannot act on it — do not retry it, and do not "
+                                "describe it.",
+            "do": "reactions_list() shows the ones that are yours.",
+        })
+    if st == 404:
+        return json.dumps({
+            "refused": "no_such_reaction", "reaction": reaction_id,
+            "why": "nothing on this instance has that id",
+            "do": "call reactions_list() and use an id from it — do not guess or re-derive one.",
+        })
     return _capped({"status": st, "result": body}, 3000)
 
 

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -24,6 +24,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+import rig_secrets                     # the sealed credential store + the ONE redactor (R-D05/D14)
 from mcp.server.mcpserver import MCPServer
 
 # The flows ENGINE is imported in-process by exactly one tool (fact_emit); every other flows
@@ -129,7 +130,7 @@ def _http(method: str, url: str, headers: dict | None = None, body=None, timeout
         except Exception:
             return e.code, raw
     except Exception as e:  # noqa: BLE001
-        return 0, f"{type(e).__name__}: {e}"
+        return 0, _safe_error(e)
 
 
 # ── the internal tier: ONE name, and no start without it (F95) ───────────────────────────────────
@@ -234,15 +235,29 @@ def _fkey():
     return {"X-Flows-Admin-Key": FLOWS_KEY}
 
 
+def _safe_error(e: BaseException) -> str:
+    """An exception rendered for a CALLER — type and message, with every credential shape masked.
+
+    R-D13: the `/do` bridge returned `f"{type(e).__name__}: {e}"` verbatim over HTTP, and the tool
+    internals under it raise with the URLs and headers they were using — `_gw_http`'s key,
+    `_admin_key()`, and `psycopg.connect(url)` with the database password inside the DSN. That was
+    the one path in this file that handed a raw internal message to a caller.
+
+    Shape-based masking does the work (`shared/git_redaction`); the values this process holds are
+    passed as `known` too, because a short secret no pattern would catch is still a secret.
+    """
+    known = [FLOWS_KEY, os.environ.get("VEXA_INTERNAL_API_SECRET", ""),
+             os.environ.get("INTERNAL_API_SECRET", ""), DELEGATION_SECRET]
+    known += list(_ADMIN_KEY_CACHE) + list(_USER_KEYS.values())
+    return rig_secrets.redact(f"{type(e).__name__}: {e}", *known)
+
+
 _USER_KEYS: dict = {}
-_USER_KEYS_FILE = None          # set once HOME is known, below
+USER_KEYS_STORE = "user-api-keys"    # a rig_secrets name, never a path — see rig_secrets.__doc__
 
 
 def _user_keys_disk() -> dict:
-    try:
-        return json.loads(_USER_KEYS_FILE.read_text())
-    except Exception:  # noqa: BLE001
-        return {}
+    return rig_secrets.read(USER_KEYS_STORE)
 
 
 def _user_key(uid: str, fresh: bool = False) -> str:
@@ -270,10 +285,7 @@ def _user_key(uid: str, fresh: bool = False) -> str:
     if key:
         _USER_KEYS[uid] = key
         try:
-            d = _user_keys_disk()
-            d[uid] = key
-            _USER_KEYS_FILE.parent.mkdir(parents=True, exist_ok=True)
-            _USER_KEYS_FILE.write_text(json.dumps(d, indent=1))
+            rig_secrets.update(USER_KEYS_STORE, lambda d: d.update({uid: key}) or d)
         except Exception:  # noqa: BLE001
             pass
     return key
@@ -306,30 +318,26 @@ SESSION_BIND: dict = {}
 RIG_MODE = os.environ.get("VEXA_RIG_MODE", "1") != "0"
 CALL_TOKEN = contextvars.ContextVar("vexa_call_token", default=None)
 SESSION_DIAG = True          # Mcp-Session-Id -> uid, for accounts created mid-conversation
-TOKENS_FILE = HOME / ".storm/mcp-tokens.json"
-_USER_KEYS_FILE = HOME / ".storm/user-api-keys.json"
 
-
-EMAIL_CODES = HOME / ".storm/oauth/email-codes.json"
-LOGINS = HOME / ".storm/oauth/logins.json"
-REGIMES = HOME / ".storm/oauth/regimes.json"
+# EVERY ONE OF THESE IS A CREDENTIAL MAP, AND NONE OF THEM IS A PATH ANY MORE (R-D05, R-D09).
+# They were plaintext JSON written at the default umask — on the live host, mode 0664: every user's
+# gateway API key, every minted vxa_mcp_ token and every live sign-in code readable by any local
+# account. They now go through `rig_secrets`, which seals each map with control_plane/secret_store
+# (encrypt-then-MAC), writes 0600 into a 0700 directory, and holds a lock across read-modify-write.
+# A name here is a STORE NAME, not a filename; the plaintext file an older rig left behind is
+# migrated on first read and then removed.
+TOKENS_STORE = "mcp-tokens"
+EMAIL_CODES_STORE = "oauth/email-codes"
+LOGINS_STORE = "oauth/logins"
+REGIMES_STORE = "oauth/regimes"
 
 
 def _regime(uid: str) -> dict:
-    try:
-        return json.loads(REGIMES.read_text()).get(str(uid), {"mode": "cloud"})
-    except Exception:
-        return {"mode": "cloud"}
+    return rig_secrets.read(REGIMES_STORE).get(str(uid), {"mode": "cloud"})
 
 
 def _regime_set(uid: str, rec: dict) -> None:
-    try:
-        d = json.loads(REGIMES.read_text())
-    except Exception:
-        d = {}
-    d[str(uid)] = rec
-    REGIMES.parent.mkdir(parents=True, exist_ok=True)
-    REGIMES.write_text(json.dumps(d, indent=1))
+    rig_secrets.update(REGIMES_STORE, lambda d: d.update({str(uid): rec}) or d)
 LOGIN_TTL = 900
 
 # The welcome every sign-in response hands the agent, whichever door the person came through.
@@ -347,17 +355,12 @@ WELCOME_BEATS = [
 
 
 def _logins() -> dict:
-    try:
-        d = json.loads(LOGINS.read_text())
-    except Exception:
-        d = {}
     now = time.time()
-    return {k: v for k, v in d.items() if v.get("exp", 0) > now}
+    return {k: v for k, v in rig_secrets.read(LOGINS_STORE).items() if v.get("exp", 0) > now}
 
 
 def _logins_save(d: dict) -> None:
-    LOGINS.parent.mkdir(parents=True, exist_ok=True)
-    LOGINS.write_text(json.dumps(d, indent=1))
+    rig_secrets.write(LOGINS_STORE, d)
 
 
 def _account_for(email: str):
@@ -376,16 +379,17 @@ def _account_for(email: str):
     return uid, existed
 
 
+def _token_put(tok: str, rec: dict) -> None:
+    """THE only writer of the token map (R-D09). There used to be three, each an unlocked
+    read-modify-write with a truncating save: two sign-ins in the same second lost one token, and a
+    crash between read and write emptied the store and signed everybody out permanently."""
+    rig_secrets.update(TOKENS_STORE, lambda d: d.update({tok: rec}) or d)
+
+
 def _mint_token(uid: str, email: str) -> str:
     import secrets
     tok = "vxa_mcp_" + secrets.token_urlsafe(24)
-    f = HOME / ".storm/mcp-tokens.json"
-    try:
-        d = json.loads(f.read_text())
-    except Exception:
-        d = {}
-    d[tok] = {"uid": uid, "email": email}
-    f.write_text(json.dumps(d, indent=1))
+    _token_put(tok, {"uid": uid, "email": email})
     return tok
 
 
@@ -520,13 +524,63 @@ def _ui_meeting_url(platform: str, native: str, title: str = "", row_id=None) ->
     return f"{UI_BASE}/?{_up.urlencode(q)}"
 
 
-def _ws_url(path: str, token: str) -> str:
-    """The cloud URL a human can open for a workspace file, viewable with the caller's own
-    credential. Handed out alongside every path so the agent never names an unopenable file."""
+VIEW_PREFIX = "vxv_"
+VIEW_TTL_S = int(os.environ.get("VEXA_MCP_VIEW_TTL_S", "900"))
+
+
+def _view_key() -> bytes:
+    return rig_secrets.signing_key("view", env="VEXA_MCP_VIEW_SECRET")
+
+
+def _view_token(uid: str, path: str, ttl: int = 0) -> str:
+    """A SHORT-LIVED, PATH-SCOPED view token — ``vxv_<uid>.<exp>.<path-hash>.<mac>`` (R-D04).
+
+    What this replaces: the durable ``vxa_mcp_`` bearer was being minted straight into the URL the
+    agent is told to `paste_this_link` to the person — four call sites, none gated by RIG_MODE — so
+    a credential that never expires and opens every tool ended up in chat scrollback, browser
+    history and any Referer header. This one opens ONE file, for fifteen minutes, and is useless
+    for anything else: the path is bound into the MAC, so it cannot be re-pointed, and the token
+    carries no authority the ``/w/`` viewer does not grant it.
+    """
+    exp = int(time.time()) + (ttl or VIEW_TTL_S)
+    ph = hashlib.sha256(path.strip("/").encode()).hexdigest()[:16]
+    msg = f"{uid}.{exp}.{ph}".encode()
+    mac = hmac.new(_view_key(), msg, hashlib.sha256).hexdigest()[:32]
+    return f"{VIEW_PREFIX}{uid}.{exp}.{ph}.{mac}"
+
+
+def _view_verify(tok: str, path: str) -> str:
+    """The uid this view token grants for THIS path, or "" — expired, forged, or for another file."""
+    if not isinstance(tok, str) or not tok.startswith(VIEW_PREFIX):
+        return ""
+    parts = tok[len(VIEW_PREFIX):].split(".")
+    if len(parts) != 4:
+        return ""
+    uid, exp_s, ph, mac = parts
+    try:
+        exp = int(exp_s)
+    except ValueError:
+        return ""
+    if time.time() >= exp:
+        return ""
+    if ph != hashlib.sha256(path.strip("/").encode()).hexdigest()[:16]:
+        return ""
+    want = hmac.new(_view_key(), f"{uid}.{exp}.{ph}".encode(), hashlib.sha256).hexdigest()[:32]
+    return uid if hmac.compare_digest(want, mac) else ""
+
+
+def _ws_url(path: str, uid: str) -> str:
+    """The cloud URL a human can open for one workspace file.
+
+    Takes a UID, never a token: the second argument used to be the caller's durable bearer and it
+    went into the query string verbatim. Handing a link to a person is not a reason to hand them a
+    credential — see `_view_token`.
+    """
     base = CANONICAL.rsplit("/mcp", 1)[0]
     import urllib.parse as _up
-    return f"{base}/w/{_up.quote(path.strip(chr(47)))}?token={token}" if token else \
-           f"{base}/w/{_up.quote(path.strip(chr(47)))}"
+    quoted = _up.quote(path.strip(chr(47)))
+    uid = str(uid or "").strip()
+    return f"{base}/w/{quoted}?token={_view_token(uid, path)}" if uid else f"{base}/w/{quoted}"
 
 
 def _frontmatter_keys(content: str):
@@ -654,6 +708,24 @@ _F_BTN = ""
 
 
 
+#: Sign-in codes this process will MAIL per window, across all addresses (R-D11). `start_onboarding`
+#: takes no account, so per-address throttling alone left one anonymous caller able to mail an
+#: arbitrary list; this is the only "source" a stateless MCP tool can see.
+CODE_BUDGET = int(os.environ.get("VEXA_RIG_CODE_BUDGET", "20"))
+CODE_BUDGET_WINDOW_S = int(os.environ.get("VEXA_RIG_CODE_WINDOW_S", "600"))
+_CODE_SENDS: list = []
+
+
+def _code_budget() -> bool:
+    """True when there is budget to mail one more code, and spends it. False when there is not."""
+    now = time.time()
+    _CODE_SENDS[:] = [t for t in _CODE_SENDS if t > now - CODE_BUDGET_WINDOW_S]
+    if len(_CODE_SENDS) >= CODE_BUDGET:
+        return False
+    _CODE_SENDS.append(now)
+    return True
+
+
 def _send_code(email: str, code: str) -> str | None:
     """Deliver the sign-in code over the same channel the product lives on. Returns an error
     string, or None on success."""
@@ -673,14 +745,11 @@ def _send_code(email: str, code: str) -> str | None:
             srv.send_message(m)
         return None
     except Exception as e:
-        return f"{type(e).__name__}: {e}"
+        return _safe_error(e)
 
 
 def _tokens() -> dict:
-    try:
-        return json.loads(TOKENS_FILE.read_text())
-    except Exception:
-        return {}
+    return rig_secrets.read(TOKENS_STORE)
 
 
 # ── DELEGATED TOKENS ────────────────────────────────────────────────────────────────────────────
@@ -780,6 +849,35 @@ def _scope_allows(scope, slug: str) -> bool:
     if ws == "*":
         return True
     return isinstance(ws, list) and str(slug) in {str(w) for w in ws}
+
+
+# ── DECISION 7, ENFORCED (R-D06) ────────────────────────────────────────────────────────────────
+# The delegation scope's `regime` was LOGGED at two places and read for authorization at none, so
+# the autonomous client — a model dispatched with no person in the loop — kept both verbs that
+# reach outside the machine. `bot_say`'s only guard was `asked_by_a_human`, an argument the calling
+# model sets about itself; `meeting_delete` had none at all. The reduction existed as prose in
+# TOOL-USAGE.md, which is not a control.
+#
+# HUMAN is the only regime these two are in. Anything else — autonomous, or a regime this build has
+# never heard of — is refused, because a scope naming an unknown regime is a scope we cannot
+# reason about and the fail direction on an irreversible verb is closed.
+HUMAN_REGIME = "human"
+HUMAN_ONLY_VERBS = {
+    "bot_say": "speaks out loud to everyone in a live meeting",
+    "meeting_delete": "erases a meeting and its transcript permanently, and cannot be undone",
+}
+
+
+def _regime_of(scope) -> str:
+    """The regime this call was delegated under, or "" when it is not a delegated call at all."""
+    return str((scope or {}).get("regime") or "").strip().lower() if isinstance(scope, dict) else ""
+
+
+def _regime_forbids(verb: str, scope) -> str:
+    """Why ``verb`` is refused under this delegation's regime, or "" when it may proceed."""
+    if verb not in HUMAN_ONLY_VERBS or scope is None:
+        return ""
+    return "" if _regime_of(scope) == HUMAN_REGIME else HUMAN_ONLY_VERBS[verb]
 
 
 GHOST_UID = contextvars.ContextVar("vexa_ghost_uid", default=None)
@@ -901,6 +999,27 @@ def _operator_or_refuse(verb: str) -> str:
     raise _NotOperator(verb, f"uid {uid}", "not an instance admin")
 
 
+#: What an operator verb tells a caller it refused. One string, because five call sites each
+#: writing their own is how `reaction_signal`, `friction_dump` and `friction_fixed` came to have
+#: none at all — a gate you have to remember to copy is a gate that is missing somewhere.
+_OPERATOR_WHAT_TO_DO = ("An instance admin can run this. A harness or other non-person producer "
+                        "should use flows-api POST /events or /events/batch with the lane's "
+                        "admin key.")
+
+
+def _operator_gate(verb: str, what_to_do: str = "") -> tuple[str, str]:
+    """``(actor, "")`` when the caller holds operator authority, else ``("", <refusal json>)``.
+
+    The uniform shape for every operator verb — `_operator_or_refuse` raises, and an exception that
+    each call site has to remember to catch is exactly the kind of gate that gets left off."""
+    try:
+        return _operator_or_refuse(verb), ""
+    except _NotOperator as e:
+        return "", json.dumps({"refused": "operator only", "verb": e.verb, "who": e.who,
+                               "why": e.why,
+                               "what_to_do": what_to_do or _OPERATOR_WHAT_TO_DO})
+
+
 # A uid this process resolved that no longer names a real account. Cached so the check costs one
 # admin-api call per identity per minute, not one per tool call.
 _UID_ALIVE: dict[str, tuple[float, bool]] = {}
@@ -1002,6 +1121,20 @@ def _anon_guard(fn):
         # the caller. A NAMED slug on a scoped (autonomous) delegation must be in the isolation set.
         slug = (kw.get("slug") or "").strip()
         scope = CALL_SCOPE.get()
+        # REGIME, enforced in the same one place, for the same reason (R-D06). Decision 7 said the
+        # autonomous client does not speak in a room and does not delete meetings; until now that
+        # sentence lived in a markdown file and the token's own `regime` claim was only printed.
+        why = _regime_forbids(fn.__name__, scope)
+        if why:
+            return json.dumps({
+                "refused": "regime",
+                "verb": fn.__name__,
+                "why": f"this session was dispatched WITHOUT a person in the loop, and this verb "
+                       f"{why}",
+                "tell_your_person": "nothing — there is no person in this session. Record what you "
+                                    "wanted to do and stop; do not retry it and do not look for "
+                                    "another route to it.",
+            })
         if slug and scope is not None and not _scope_allows(scope, slug):
             return json.dumps({
                 "refused": "out_of_scope",
@@ -1406,11 +1539,15 @@ working.</p>""", "Connected")
             fpath = _up.unquote(scope["path"][3:])
             q = dict(_up.parse_qsl((scope.get("query_string") or b"").decode()))
             t = q.get("token", "")
-            rec = vexa_oauth.resolve_token(t, CANONICAL) if t else None
-            rec = rec or (_tokens().get(t) if t else None)
+            # VIEW TOKENS ONLY (R-D04). A durable bearer in a query string is the thing this
+            # route existed to leak, so it is not accepted here even though it would resolve: a
+            # viewer that still honours the old shape leaves every pasted link a live credential
+            # and keeps the habit alive on the minting side.
+            view_uid = _view_verify(t, fpath) if t else ""
+            rec = {"uid": view_uid} if view_uid else None
             if not rec:
-                b = _login_page("<p>This file needs a signed-in link — ask your agent for "
-                                "one.</p>", "Not signed in")
+                b = _login_page("<p>This link has expired, or it is not a view link for this "
+                                "file. Ask your agent for a fresh one.</p>", "Not signed in")
                 await send({"type": "http.response.start", "status": 401, "headers": [
                     (b"content-type", b"text/html; charset=utf-8"),
                     (b"content-length", str(len(b)).encode())]})
@@ -1569,10 +1706,10 @@ working.</p>""", "Connected")
                     body = out.encode() if isinstance(out, str) else json.dumps(out).encode()
                     status = 200
                 except TypeError as e:
-                    body = json.dumps({"error": f"bad arguments: {e}"}).encode()
+                    body = json.dumps({"error": "bad arguments: " + rig_secrets.redact(e)}).encode()
                     status = 400
                 except Exception as e:
-                    body = json.dumps({"error": f"{type(e).__name__}: {e}"}).encode()
+                    body = json.dumps({"error": _safe_error(e)}).encode()
                     status = 500
             await send({"type": "http.response.start", "status": status, "headers": [
                 (b"content-type", b"application/json; charset=utf-8"),
@@ -1636,10 +1773,8 @@ working.</p>""", "Connected")
                 else:
                     _rec = _logins().get(_c)
                     if _rec and _rec.get("token"):
-                        _d = _tokens()
-                        _d[_c] = {"uid": _rec["uid"], "email": _rec["email"],
-                                  "via": "setup-url"}
-                        (HOME / ".storm/mcp-tokens.json").write_text(json.dumps(_d, indent=1))
+                        _token_put(_c, {"uid": _rec["uid"], "email": _rec["email"],
+                                        "via": "setup-url"})
                         tok = _c
                     else:
                         # NEVER FALL THROUGH TO ANONYMOUS. A registration carrying a code we no
@@ -2030,14 +2165,9 @@ def flows_submit(name: str, on_event: str, steps: list[str],
 
     REFUSED while the company layer is missing: a flow submitted into an instance that cannot yet
     say who it works for is a machine configured for nobody."""
-    try:
-        _actor = _operator_or_refuse("flows_submit")
-    except _NotOperator as e:
-        return json.dumps({"refused": "operator only", "verb": e.verb, "who": e.who,
-                           "why": e.why,
-                           "what_to_do": "An instance admin can run this. A harness or other "
-                                         "non-person producer should use flows-api POST /events "
-                                         "or /events/batch with the lane's admin key."})
+    _actor, _refused = _operator_gate("flows_submit")
+    if _refused:
+        return _refused
     gated = _refuse_if_gated("flows_submit", me())
     if gated:
         return gated
@@ -2056,14 +2186,9 @@ def flow_lifecycle(name: str, version: int, verb: str, token: str = "") -> str:
     rewrites work already running.
 
     REFUSED while the company layer is missing, for the same reason flows_submit is."""
-    try:
-        _actor = _operator_or_refuse("flow_lifecycle")
-    except _NotOperator as e:
-        return json.dumps({"refused": "operator only", "verb": e.verb, "who": e.who,
-                           "why": e.why,
-                           "what_to_do": "An instance admin can run this. A harness or other "
-                                         "non-person producer should use flows-api POST /events "
-                                         "or /events/batch with the lane's admin key."})
+    _actor, _refused = _operator_gate("flow_lifecycle")
+    if _refused:
+        return _refused
     gated = _refuse_if_gated("flow_lifecycle", me())
     if gated:
         return gated
@@ -2078,9 +2203,15 @@ def flow_lifecycle(name: str, version: int, verb: str, token: str = "") -> str:
 def reactions_list(status: str = "", token: str = "") -> str:
     """The operator projection: what happened, why, and what is waiting.
 
-    status filters to one of admitted/running/blocked/retrying/failed/cancelled/done.\n\n    If you have not called whats_waiting() yet this session, call it first."""
-    me()   # account-scoped: this touches shared state
-    q = f"?status={status}" if status else ""
+    status filters to one of admitted/running/blocked/retrying/failed/cancelled/done.
+
+    YOURS ONLY. It used to answer with the whole instance's reactions, which is how an ordinary
+    user came to hold every other tenant's reaction ids (R-D07/R-D12); the flows route now scopes
+    on the subject, the way `timeline` always did.\n\n    If you have not called whats_waiting() yet this session, call it first."""
+    uid = me()   # account-scoped: this touches shared state
+    q = "?subject=" + urllib.parse.quote(str(uid))
+    if status:
+        q += "&status=" + urllib.parse.quote(status)
     st, body = _http("GET", f"{FLOWS_API}/reactions{q}", _fkey())
     return _capped({"status": st, "result": body}, 12000)
 
@@ -2130,8 +2261,15 @@ def reaction_signal(reaction_id: str, verb: str, token: str = "") -> str:
     cancel — stop it; on admitted/retrying/blocked/running
     wake   — re-check NOW something that is deliberately sleeping between polls; on
              retrying/admitted. Use this when you have just satisfied the condition a
-             step was waiting on and do not want to wait out its poll interval."""
-    me()   # account-scoped: this touches shared state
+             step was waiting on and do not want to wait out its poll interval.
+
+    OPERATOR ONLY, for the same reason `fact_emit` and `flow_lifecycle` are (R-D07): this posts
+    with the lane's admin key and never checked the reaction against the caller, while
+    `reactions_list` was handing every id out instance-wide — so `cancel` on somebody else's
+    scheduled join was one call away for any signed-in user."""
+    _actor, refused = _operator_gate("reaction_signal")
+    if refused:
+        return refused
     st, body = _http("POST", f"{FLOWS_API}/reactions/{reaction_id}/{verb}", _fkey(), {})
     return _capped({"status": st, "result": body}, 3000)
 
@@ -2147,14 +2285,9 @@ def fact_emit(event_type: str, source_event_id: str, subject_refs: dict,
     no-op rather than a duplicate.
 
     invite.received wants: organizer, url, start (epoch), ics_uid, title, group|null."""
-    try:
-        _actor = _operator_or_refuse("fact_emit")
-    except _NotOperator as e:
-        return json.dumps({"refused": "operator only", "verb": e.verb, "who": e.who,
-                           "why": e.why,
-                           "what_to_do": "An instance admin can run this. A harness or other "
-                                         "non-person producer should use flows-api POST /events "
-                                         "or /events/batch with the lane's admin key."})
+    _actor, _refused = _operator_gate("fact_emit")
+    if _refused:
+        return _refused
     import sys
     src = _flows_src()
     if src is None:
@@ -2207,7 +2340,7 @@ def workspace_tree(slug: str = "", token: str = "") -> str:
     sst, sbody = _http("GET", f"{AGENT_API}/api/workspace/git-remote-status{q}", {"X-User-Id": uid})
     if sst == 200 and isinstance(sbody, dict) and sbody.get("has_home"):
         home = f"{sbody.get('remote')} {sbody.get('url')} on {sbody.get('branch')}"
-    return _capped({"for_display": "every file here is reachable at <base>/w/<path>?token=... — but NEVER show a person these paths: they are arguments for workspace_read/write; show names and links", "status": st, "result": body, "git_home": home or "no git home — this workspace was not loaded from a repository"}, 8000)
+    return _capped({"for_display": "a file is opened with a SHORT-LIVED view link this server mints per file (workspace_read returns one) — never show a person a path: paths are arguments for workspace_read/write; show names and links", "status": st, "result": body, "git_home": home or "no git home — this workspace was not loaded from a repository"}, 8000)
 
 
 @mcp.tool()
@@ -2218,8 +2351,8 @@ def workspace_read(path: str, slug: str = "", token: str = "") -> str:
     q = f"?path={urllib.parse.quote(path)}" + (f"&slug={slug}" if slug else "")
     st, body = _http("GET", f"{AGENT_API}/api/workspace/file{q}", {"X-User-Id": uid})
     name = path.rsplit("/", 1)[-1]
-    return json.dumps({"status": st, "url": _ws_url(path, token or ""),
-                       "paste_this_link": f"[{name}]({_ws_url(path, token or '')})",
+    return json.dumps({"status": st, "url": _ws_url(path, uid),
+                       "paste_this_link": f"[{name}]({_ws_url(path, uid)})",
                        "never_show_the_path": "the path is an argument for tools; your "
                        "person sees the name and the link above, nothing slashed",
                        "result": body})[:12000]
@@ -2276,8 +2409,8 @@ def workspace_write(path: str, content: str, slug: str = "", token: str = "") ->
         return json.dumps({"refused": "not_written", "status": st, "path": rel,
                            "workspace": slug or "your own",
                            "why": resp if isinstance(resp, (str, dict)) else "write refused"})
-    return json.dumps({"url": _ws_url(rel, token or ""),
-                       "paste_this_link": "[" + rel.rsplit("/", 1)[-1] + "](" + _ws_url(rel, token or "") + ")",
+    return json.dumps({"url": _ws_url(rel, uid),
+                       "paste_this_link": "[" + rel.rsplit("/", 1)[-1] + "](" + _ws_url(rel, uid) + ")",
                        "written": rel, "bytes": len(content)})
 
 
@@ -2428,18 +2561,33 @@ _CREDENTIAL_REFUSAL = (
 )
 
 
+#: This server's OWN credential prefixes — `vxa_mcp_` (durable bearer), `vxd_` (delegation),
+#: `vxv_` (view link). Spelled as literals so the detector below can be lifted out of this file and
+#: executed on its own, which is how `core/agent/tests/test_workspace_credentials.py` checks the
+#: shipped code; a test in this directory pins them equal to the constants they mirror.
+_OUR_CREDENTIAL_PREFIXES = ("vxa_mcp_", "vxd_", "vxv_")
+
+
 def _refuse_credentials(*values) -> str:
-    """The refusal, or "" when nothing credential-shaped was passed. Same detector the API uses."""
-    tokenish = ("ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_")
+    """The refusal, or "" when nothing credential-shaped was passed.
+
+    IT NOW IS the detector the API uses (R-D14). The claim was made in this docstring and was
+    false: the copy below listed six GitHub prefixes and no ``glpat-``, no generic long run, and a
+    URL rule that required BOTH ``:`` and ``@`` in the userinfo — so ``https://<gitlab-pat>@gitlab.com/a/b``,
+    the exact shape git itself writes a PAT into, walked straight through. The scrubber's own
+    patterns decide instead: if `redact` would mask any part of the value, it is credential-shaped.
+    """
     for v in values:
-        text = str(v or "")
-        if any(t in text for t in tokenish):
+        text = str(v or "").strip()
+        if not text:
+            continue
+        # OUR OWN auth argument is not a git credential. `token=` is how this server is
+        # authenticated; it is 40 urlsafe characters, so the generic rule would refuse every
+        # authenticated call to workspace_attach if it were not named here.
+        if text.startswith(_OUR_CREDENTIAL_PREFIXES):
+            continue
+        if rig_secrets.looks_like_token(text) or rig_secrets.redact(text) != text:
             return _CREDENTIAL_REFUSAL
-        # https://user:password@host — a credential wearing a URL
-        if "://" in text:
-            userinfo = text.split("://", 1)[1].split("/", 1)[0]
-            if ":" in userinfo and "@" in userinfo:
-                return _CREDENTIAL_REFUSAL
     return ""
 
 
@@ -2693,6 +2841,40 @@ def meetings_list(token: str = "") -> str:
     return _capped({"status": st, "result": body}, 10000)
 
 
+# ── WHERE THE TRANSCRIPT CONVERTERS MAY READ AND WRITE (R-D10) ──────────────────────────────────
+# `zoom_transcript_to_segments(name, path)` took an unconstrained host path — matching lines came
+# back in `speakers`, so it was an arbitrary file read with the output as the oracle — and wrote to
+# `~/.storm/caps/{name}.segments.json` with `name` unsanitized, so `name="../../../../tmp/x"` wrote
+# outside. `captions_to_segments` had the same traversal in `video_id`.
+CAPS_DIR = rig_secrets.STATE_DIR / "caps"
+IMPORT_DIR = pathlib.Path(os.environ.get("VEXA_RIG_IMPORT_DIR") or (rig_secrets.STATE_DIR / "imports"))
+_SAFE_STEM = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _safe_stem(name: str) -> str:
+    """The file stem, or "" — one path segment of a closed alphabet, never a traversal."""
+    n = str(name or "").strip()
+    return n if _SAFE_STEM.match(n) else ""
+
+
+def _import_path(path: str):
+    """A caller-named source file, CONFINED to the import directories, or None.
+
+    Resolved before it is compared, so a symlink out of the directory is caught with the rest —
+    `startswith` on an unresolved string is the version of this check that does not work."""
+    try:
+        p = pathlib.Path(path).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+    for root in (IMPORT_DIR, CAPS_DIR):
+        try:
+            if p.is_relative_to(root.resolve()):
+                return p
+        except (OSError, ValueError):
+            continue
+    return None
+
+
 @mcp.tool()
 @_anon_guard
 def captions_to_segments(video_id: str, max_minutes: int = 45, token: str = "") -> str:
@@ -2702,9 +2884,13 @@ def captions_to_segments(video_id: str, max_minutes: int = 45, token: str = "") 
     Speaker 1..N rather than inventing identities — which is also what our own pipeline
     produces before attribution runs. Source stays in ~/.storm/caps/<id>.en.json3."""
     me()   # account-scoped: this touches shared state
-    src = HOME / ".storm/caps" / f"{video_id}.en.json3"
+    stem = _safe_stem(video_id)
+    if not stem:
+        return json.dumps({"error": "video_id must match ^[A-Za-z0-9_-]{1,64}$",
+                           "why": "it names a file in the caption directory and nothing else"})
+    src = CAPS_DIR / f"{stem}.en.json3"
     if not src.exists():
-        return json.dumps({"error": f"no captions at {src}"})
+        return json.dumps({"error": f"no captions for {stem}"})
     data = json.loads(src.read_text())
     events = [e for e in data.get("events", []) if e.get("segs")]
     turns, cur, speaker, last_end, start_t = [], [], 1, 0.0, 0.0
@@ -2734,13 +2920,13 @@ def captions_to_segments(video_id: str, max_minutes: int = 45, token: str = "") 
         last_end = t0 + e.get("dDurationMs", 2000) / 1000.0
     flush()
 
-    out = HOME / ".storm/caps" / f"{video_id}.segments.json"
+    out = CAPS_DIR / f"{stem}.segments.json"
     out.write_text(json.dumps([{"start": a, "end": b, "speaker": sp, "text": t}
                                for a, b, sp, t in turns]))
     words = sum(len(t.split()) for _, _, _, t in turns)
     # truncate the SAMPLE, never the payload -- slicing the rendered JSON produces invalid
     # JSON and the caller silently gets a string instead of a result.
-    return json.dumps({"video_id": video_id, "turns": len(turns), "words": words,
+    return json.dumps({"video_id": stem, "turns": len(turns), "words": words,
                        "speakers": len({sp for _, _, sp, _ in turns}),
                        "minutes": round(turns[-1][1] / 60, 1) if turns else 0,
                        "written": str(out),
@@ -2757,10 +2943,20 @@ def zoom_transcript_to_segments(name: str, path: str, token: str = "") -> str:
     affiliations, so it exercises attribution the way a real capture does. Consecutive lines
     from one speaker are merged into a turn."""
     me()   # account-scoped: this touches shared state
-    import re
-    src = pathlib.Path(path)
+    stem = _safe_stem(name)
+    if not stem:
+        return json.dumps({"error": "name must match ^[A-Za-z0-9_-]{1,64}$",
+                           "why": "it names the output file and nothing else"})
+    src = _import_path(path)
+    if src is None:
+        return json.dumps({"error": "that path is outside the import directory",
+                           "read_from": [str(IMPORT_DIR), str(CAPS_DIR)],
+                           "why": "this tool used to take any host path, and the lines it matched "
+                                  "came back as `speakers` — an arbitrary file read with its own "
+                                  "oracle. Put the transcript in the import directory first.",
+                           "set": "VEXA_RIG_IMPORT_DIR names it"})
     if not src.exists():
-        return json.dumps({"error": f"no transcript at {path}"})
+        return json.dumps({"error": f"no transcript at {src}"})
     pat = re.compile(r"^\[(\d+):(\d+):([\d.]+)\s*-->\s*(\d+):(\d+):([\d.]+)\]\s*([^:]{1,60}?):\s*(.*)$")
     turns = []
     for raw in src.read_text().splitlines():
@@ -2777,12 +2973,13 @@ def zoom_transcript_to_segments(name: str, path: str, token: str = "") -> str:
             turns[-1] = (turns[-1][0], b, sp, turns[-1][3] + " " + text)
         else:
             turns.append((a, b, sp, text))
-    out = HOME / ".storm/caps" / f"{name}.segments.json"
+    out = CAPS_DIR / f"{stem}.segments.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps([{"start": a, "end": b, "speaker": sp, "text": t}
                                for a, b, sp, t in turns]))
     from collections import Counter
     who = Counter(sp for _, _, sp, _ in turns)
-    return json.dumps({"name": name, "turns": len(turns),
+    return json.dumps({"name": stem, "turns": len(turns),
                        "words": sum(len(t.split()) for _, _, _, t in turns),
                        "speakers": [{"name": k, "turns": v} for k, v in who.most_common(10)],
                        "minutes": round(turns[-1][1] / 60, 1) if turns else 0,
@@ -3018,6 +3215,7 @@ def _write_json(uid: str, path: str, obj) -> bool:
 
 
 @mcp.tool()
+@_anon_guard
 def whats_waiting(token: str = "") -> str:
     """START HERE on every connection — EXCEPT the one case named below, which is common.
     Everything Vexa needs from this person, in one read.
@@ -3040,7 +3238,10 @@ def whats_waiting(token: str = "") -> str:
       blocked    — a reaction stopped on a human gate; answer it with reaction_signal(resume)
       stuck      — a reaction failing with a reason worth a human eye
     """
-    CALL_TOKEN.set(token or None)
+    # The token is set by @_anon_guard, which this tool used to be the ONE account tool without
+    # (R-D19). The manual set was two bugs at once: it accepted a credential in a call argument
+    # even when VEXA_RIG_MODE=0 turns that off, and it CLEARED a live token whenever the kwarg was
+    # absent — de-authenticating the first call every agent makes.
     uid = _subject()
     if not uid:
         # A GHOST IS NOT A NEWCOMER. This is the first call every agent makes, so the greeting it
@@ -3172,7 +3373,12 @@ def whats_waiting(token: str = "") -> str:
                   "be asked — a rough edge you route around silently is one nobody fixes.",
         })
 
-    st, body = _http("GET", f"{FLOWS_API}/reactions", _fkey())
+    # SCOPED TO THIS PERSON (R-D12). Unscoped, this — the tool nobody can avoid calling — read the
+    # whole instance's reactions and reported other tenants' flow names, step names and failure
+    # reasons as this person's queue. `timeline` two hundred lines up already proved the route
+    # takes a subject.
+    st, body = _http("GET", f"{FLOWS_API}/reactions?subject={urllib.parse.quote(str(uid))}",
+                     _fkey())
     for r in (body or {}).get("reactions", []) if isinstance(body, dict) else []:
         if r.get("status") == "blocked":
             items.append({"kind": "blocked", "id": r["id"],
@@ -4191,7 +4397,7 @@ def deeplink(target: str, ref: str = "", name: str = "", meeting: str = "", ws: 
 
     NEVER put prompt text in a link. name= is a preset NAME; the words behind it are a file
     only an admin can write, and that is the whole security of the ask link."""
-    me()
+    uid = me()
     import urllib.parse as _up
     em = _caller_email()
     as_q = f"as={_up.quote(em)}" if em else ""
@@ -4239,7 +4445,7 @@ def deeplink(target: str, ref: str = "", name: str = "", meeting: str = "", ws: 
         return json.dumps({"url": f"{UI_BASE}/?{as_q}" if as_q else UI_BASE,
                            "opens": "the terminal on their meetings list"})
     if target == "workspace_file":
-        return json.dumps({"url": _ws_url(ref, token or CALL_TOKEN.get() or ""),
+        return json.dumps({"url": _ws_url(ref, uid),
                            "opens": "the file, rendered"})
     if target in ("view", "pre_meeting", "during_meeting", "post_meeting"):
         # Composed layouts: the existing shell, filled deliberately. 'view' takes a raw pane
@@ -4291,7 +4497,7 @@ def _scheduled_joins(mid: str):
                 (f"sched-{mid}-%",)).fetchall()
         return [{"id": r[0], "flow": r[1], "step": r[2], "status": r[3]} for r in rows], None
     except Exception as e:  # noqa: BLE001
-        return None, f"{type(e).__name__}: {e}"[:200]
+        return None, _safe_error(e)[:200]
 
 
 @mcp.tool()
@@ -4551,7 +4757,7 @@ def workspace_pull(workspace: str = "", token: str = "") -> str:
     files = (body or {}).get("files", []) if isinstance(body, dict) else []
     return json.dumps({
         "regime": reg,
-        "files": [{"path": f, "url": _ws_url(f, token or "")} for f in files][:200],
+        "files": [{"path": f, "url": _ws_url(f, uid)} for f in files][:200],
         "do": "fetch each file you do not already have locally (workspace_read) and write "
               "it under local_path with the same relative path. Then work locally.",
     })[:14000]
@@ -4631,13 +4837,11 @@ def rehearse(state: str, subject: str, meeting: str = "2026-03-02", when: str = 
     `fresh` resets the subject and its derived organizer first, which DELETES them.
     `plan_only` resolves and guards every step and executes none.
     """
-    try:
-        _operator_or_refuse("rehearse")
-    except _NotOperator as e:
-        return json.dumps({"refused": "operator only", "verb": e.verb, "who": e.who, "why": e.why,
-                           "what_to_do": "An instance admin can run this. It injects facts and "
+    _actor, _refused = _operator_gate("rehearse", "An instance admin can run this. It injects facts and "
                                          "sends mail as other people, which is authority, not "
-                                         "authentication."})
+                                         "authentication.")
+    if _refused:
+        return _refused
     pkg = _rehearse_pkg()
     try:
         res = pkg.rehearse(state, subject, meeting=meeting, when=when, runner=runner, fresh=fresh,
@@ -4665,11 +4869,9 @@ def subject_reset(address: str = "", uid: str = "", token: str = "") -> str:
     It reads the emptiness back and reports whatever it could NOT remove under `remaining` — a
     reset that half worked and said "done" is worse than one that refused.
     """
-    try:
-        _operator_or_refuse("subject_reset")
-    except _NotOperator as e:
-        return json.dumps({"refused": "operator only", "verb": e.verb, "who": e.who, "why": e.why,
-                           "what_to_do": "An instance admin can run this — it deletes a person."})
+    _actor, _refused = _operator_gate("subject_reset", "An instance admin can run this — it deletes a person.")
+    if _refused:
+        return _refused
     pkg = _rehearse_pkg()
     if not (address or uid):
         return json.dumps({"refused": "name an address, or a uid with `uid=` for an account whose "
@@ -4782,7 +4984,11 @@ def report_friction(what_i_was_doing: str, what_went_wrong: str,
 @mcp.tool()
 @_anon_guard
 def friction_so_far(token: str = "") -> str:
-    """Everything reported through report_friction, newest first. NO ACCOUNT NEEDED.
+    """Everything reported through report_friction, newest first. NEEDS AN ACCOUNT.
+
+    It said "NO ACCOUNT NEEDED" and then called `me()` on the next line (R-D21), so an anonymous
+    agent that believed the docstring got a refusal it read as an empty ledger and filed the same
+    rough edge again.
 
     Useful before reporting: if the thing you hit is already here, add what is different about
     your case rather than filing it again."""
@@ -4827,7 +5033,16 @@ def friction_dump(since: str = "", status: str = "open", token: str = "") -> str
     status: "open" (the default — includes `recurring`, which is the most urgent work there is) ·
             "fixed" · "recurring" · "" for all.
 
-    When you fix something from it, close it: `friction_fixed([ids], "<commit or PR>")`."""
+    When you fix something from it, close it: `friction_fixed([ids], "<commit or PR>")`.
+
+    OPERATOR ONLY (R-D21). This is the WHOLE INSTANCE's ledger — other people's workspace names,
+    file paths, meeting ids and free text — and it was open to any signed-in caller. A person's own
+    reports come back from `friction_so_far`, which is scoped to them."""
+    _actor, _refused = _operator_gate(
+        "friction_dump", "An instance admin can run this — it reads every user's reports. Your own "
+                         "are in friction_so_far().")
+    if _refused:
+        return _refused
     uid = me()
     q = f"?since={urllib.parse.quote(since)}&status={urllib.parse.quote(status)}&format=md"
     st, body = _http("GET", f"{AGENT_API}/api/friction/dump{q}", {"X-User-Id": uid})
@@ -4845,7 +5060,15 @@ def friction_fixed(ids: list[str], fix_ref: str, token: str = "") -> str:
     `fix_ref` is whatever lets the next reader find the change — a commit sha, a PR url, a branch,
     or one sentence. Closing is CHEAP and meant to be: a record filed again after a fix flips itself
     to `recurring`, so a fix that did not hold announces itself instead of hiding. Close what you
-    addressed; do not close what you merely looked at."""
+    addressed; do not close what you merely looked at.
+
+    OPERATOR ONLY (R-D21), the mutating half of `friction_dump`: it marks records fixed across the
+    whole instance, and any signed-in caller could close anybody's."""
+    _actor, _refused = _operator_gate(
+        "friction_fixed", "An instance admin can run this — it closes records across every user's "
+                          "ledger.")
+    if _refused:
+        return _refused
     uid = me()
     if not str(fix_ref or "").strip():
         return json.dumps({"error": "fix_ref is required",
@@ -4984,22 +5207,16 @@ def start_onboarding(email: str) -> str:
     if "@" not in email or email.startswith("@") or email.endswith("@"):
         return json.dumps({"error": "that is not an email address"})
     import secrets
-    ak = {"X-Admin-API-Key": _admin_key()}
-    st, u = _http("GET", f"{ADMIN_API}/admin/users/email/{email}", ak)
-    returning = st == 200
-    if not returning:
-        st, u = _http("POST", f"{ADMIN_API}/admin/users", ak,
-                      {"email": email, "name": email.split("@")[0].title()})
-    uid = str((u or {}).get("id", ""))
-    if not uid:
-        return json.dumps({"error": "could not create the account", "status": st})
-    if not returning:
-        _http("POST", f"{AGENT_API}/api/workspace/init", {"X-User-Id": uid}, {})
-
-    try:
-        codes = json.loads(EMAIL_CODES.read_text())
-    except Exception:
-        codes = {}
+    if not _code_budget():
+        # RATE-LIMITED BY SOURCE (R-D11). This tool needs no account, so the only source this
+        # server can see is itself: a process-wide budget on codes MAILED. Without it, one
+        # anonymous caller in a loop makes us the mailer for an address list.
+        return json.dumps({
+            "error": "too many sign-in codes have been sent from this server just now",
+            "what_to_do": "Wait a minute and call start_onboarding(email) again. If your person "
+                          "already has a code from the last few minutes, use that one.",
+        })
+    codes = rig_secrets.read(EMAIL_CODES_STORE)
     live = codes.get(email)
     if live and time.time() < live.get("exp", 0) and live.get("tries", 0) < 5:
         # a code is already sitting in that inbox — reminting would invalidate it
@@ -5010,18 +5227,24 @@ def start_onboarding(email: str) -> str:
                           "confirm_login(email, code) — do not request another.",
         })
     code = f"{secrets.randbelow(1000000):06d}"
-    codes[email] = {"code": code, "uid": uid, "exp": time.time() + 900, "tries": 0}
-    EMAIL_CODES.parent.mkdir(parents=True, exist_ok=True)
-    EMAIL_CODES.write_text(json.dumps(codes, indent=1))
+    # NO ACCOUNT IS CREATED HERE (R-D11). It used to POST /admin/users before any code was
+    # verified, so an unauthenticated caller minted platform accounts for addresses it did not
+    # own — and the response then said "existing" or "created", which made this an existence
+    # oracle for the whole user table. The account is created in confirm_login, once the code
+    # coming back proves the caller can read that mailbox.
+    rig_secrets.update(EMAIL_CODES_STORE, lambda d: d.update(
+        {email: {"code": code, "exp": time.time() + LOGIN_TTL, "tries": 0}}) or d)
 
     err = _send_code(email, code)
     if err:
         return json.dumps({"error": "could not send the code", "detail": err,
-                           "try": "report_friction() and tell your person — the account "
-                                  "exists but the mail channel is down."})
+                           "try": "report_friction() and tell your person — the mail channel "
+                                  "is down."})
     return json.dumps({
         "code_sent_to": email,
-        "account": "existing — same person signing in again" if returning else "created",
+        # IDENTICAL EITHER WAY. Saying which of the two this was is the oracle.
+        "account": "a code is on its way — whether this address is new here or returning, the "
+                   "next step is the same",
         "what_to_do": "Ask your person for the 6-digit code that just arrived in that inbox. "
                       "Then call confirm_login(email, code). Do NOT guess codes and do not "
                       "try to read their mail — the code coming from the person IS the proof "
@@ -5045,49 +5268,44 @@ def confirm_login(email: str, code: str) -> str:
     of this conversation — you are authenticated immediately, nothing needs restarting."""
     email = (email or "").strip().lower()
     code = "".join(ch for ch in str(code) if ch.isdigit())
-    try:
-        codes = json.loads(EMAIL_CODES.read_text())
-    except Exception:
-        codes = {}
-    rec = codes.get(email)
+    rec = rig_secrets.read(EMAIL_CODES_STORE).get(email)
     if not rec:
         return json.dumps({"error": "no code is pending for that email",
                            "fix": "call start_onboarding(email) first"})
+
+    def _drop(d):
+        d.pop(email, None)
+        return d
+
     if time.time() > rec["exp"]:
-        codes.pop(email, None)
-        EMAIL_CODES.write_text(json.dumps(codes, indent=1))
+        rig_secrets.update(EMAIL_CODES_STORE, _drop)
         return json.dumps({"error": "that code expired",
                            "fix": "call start_onboarding(email) again for a fresh one"})
     if rec["tries"] >= 5:
-        codes.pop(email, None)
-        EMAIL_CODES.write_text(json.dumps(codes, indent=1))
+        rig_secrets.update(EMAIL_CODES_STORE, _drop)
         return json.dumps({"error": "too many wrong attempts — code invalidated",
                            "fix": "call start_onboarding(email) again"})
-    if code != rec["code"]:
-        rec["tries"] += 1
-        EMAIL_CODES.write_text(json.dumps(codes, indent=1))
+    if not hmac.compare_digest(str(code), str(rec["code"])):
+        def _bump(d):
+            r = d.get(email)
+            if r:
+                r["tries"] = int(r.get("tries", 0)) + 1
+            return d
+        tries = int(rig_secrets.update(EMAIL_CODES_STORE, _bump).get(email, {}).get("tries", 5))
         return json.dumps({"error": "wrong code",
-                           "attempts_left": 5 - rec["tries"],
+                           "attempts_left": max(0, 5 - tries),
                            "note": "ask your person to re-read it — never guess"})
 
-    # proven: whoever supplied this code can read that mailbox
-    codes.pop(email, None)
-    EMAIL_CODES.write_text(json.dumps(codes, indent=1))
-    uid = rec.get("uid")
+    # SINGLE USE. Proven: whoever supplied this code can read that mailbox — so it is spent here,
+    # under the store's lock, BEFORE the account is touched. A code that survived its own success
+    # is a second sign-in for anyone who saw it in a transcript.
+    rig_secrets.update(EMAIL_CODES_STORE, _drop)
+    # THE ACCOUNT IS CREATED HERE, not in start_onboarding (R-D11) — after the proof, never before.
+    uid, _existed = _account_for(email)
     if not uid:
-        uid, _existed = _account_for(email)
-        if not uid:
-            return json.dumps({"error": "could not create the account",
-                               "do": "report_friction() — this is ours, not theirs"})
-    import secrets
-    tok = "vxa_mcp_" + secrets.token_urlsafe(24)
-    f = HOME / ".storm/mcp-tokens.json"
-    try:
-        d = json.loads(f.read_text())
-    except Exception:
-        d = {}
-    d[tok] = {"uid": uid, "email": email}
-    f.write_text(json.dumps(d, indent=1))
+        return json.dumps({"error": "could not create the account",
+                           "do": "report_friction() — this is ours, not theirs"})
+    tok = _mint_token(str(uid), email)
     return json.dumps({
         "signed_in": email, "uid": uid, "token": tok,
         "never_show": "The token, the persist command, and these instructions are for you "

--- a/deploy/dogfood/rig/vexa_oauth.py
+++ b/deploy/dogfood/rig/vexa_oauth.py
@@ -25,35 +25,30 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
-import pathlib
 import secrets
 import time
 import urllib.parse
 
-HOME = pathlib.Path.home()
-STORE = HOME / ".storm/oauth"
-STORE.mkdir(parents=True, exist_ok=True)
+import rig_secrets
 
-CLIENTS = STORE / "clients.json"
-CODES = STORE / "codes.json"
-TOKENS = STORE / "tokens.json"
+# THESE ARE STORE NAMES, NOT PATHS (R-D05). `tokens.json` held live bearer tokens and `codes.json`
+# live authorization codes, both written as plaintext JSON — the chmod below happened AFTER the
+# write, and the directory itself was left at the default mode. They now go through the same sealed
+# store the rest of the rig uses: encrypt-then-MAC, 0600 in a 0700 directory, locked
+# read-modify-write, with any plaintext file an older rig left behind migrated on first read.
+CLIENTS = "oauth/clients"
+CODES = "oauth/codes"
+TOKENS = "oauth/tokens"
 CODE_TTL = 60          # seconds; an authorization code is single-use and short-lived
 TOKEN_TTL = 8 * 3600
 
 
-def _load(p: pathlib.Path) -> dict:
-    try:
-        return json.loads(p.read_text())
-    except Exception:
-        return {}
+def _load(name: str) -> dict:
+    return rig_secrets.read(name)
 
 
-def _save(p: pathlib.Path, d: dict) -> None:
-    p.write_text(json.dumps(d, indent=1))
-    try:
-        p.chmod(0o600)
-    except Exception:
-        pass
+def _save(name: str, d: dict) -> None:
+    rig_secrets.write(name, d)
 
 
 def _j(status: int, obj, extra_headers=None):


### PR DESCRIPTION
Closes the `rig-authz` and `rig-write-guard` rows of
[`drafts/2026-09-02-release-backlog.md`](https://github.com/DmitriyG228/biz/blob/main/drafts/2026-09-02-release-backlog.md)
§2 dispatches 2–3, against their entries in the full review. Owning issue:
[`DmitriyG228/biz#452`](https://github.com/DmitriyG228/biz/issues/452).

**COMMITMENTS IN THIS DRAFT — none.** No live store is touched, nothing is deployed, no external
recipient. The live-host remediation is written down below for the stage-1 worker to run; this PR
does not run it.

## For `security-hotfix` and `core-mcp` — what I touched in your files

Rebased onto `1bd89445b`, so **F95 and F96 are in and I did not re-litigate either**:

* `workspace_write` / `_write_json` are yours (F96). The only edit I made inside them is the
  `_ws_url(rel, token)` → `_ws_url(rel, uid)` signature change that R-D04 required. R-D01, R-D02,
  R-D23 are closed by your work, not mine.
* R-D03's env-name collapse is yours. I did not touch the `token=` query-param path or the `==`
  compare — that remainder is still open on your row.
* `INTERNAL_API_SECRET` is now required at import (F95), so the new test harness sets a throwaway
  value; nothing compares it to anything real.
* **For `core-mcp`:** every authorization change here is at the **tool-handler level** — inside the
  registered verb, or inside `_anon_guard` / `_operator_gate`, which every verb already goes
  through. Nothing keys off this file's path or line numbers, and the new tests call handlers
  through `mcp._tool_manager._tools` rather than grepping source, so both survive the split by
  owning domain. The one import-time coupling is `rig_secrets.agent_src()`, which **searches
  upward** for `core/agent` instead of counting `parents[3]` — deliberately, so the move does not
  break it silently.

## Per row: symptom → change → proof

| row | symptom | change | proof |
|---|---|---|---|
| **R-D04** | durable `vxa_mcp_` bearers minted into URLs the agent is told to paste to the person, 4 call sites, not gated by `RIG_MODE` | `_view_token`/`_view_verify` — HMAC over `uid.exp.sha256(path)`, 15 min; `_ws_url(path, uid)`; the `/w/` viewer accepts **only** view tokens (`vexa_control_mcp.py:527-586`, `:1546-1553`) | gates 1a·1b |
| **R-D05** | `~/.storm/*.json` plaintext at default umask — every gateway key, every minted token, every live sign-in code, mode 0664 | new `rig_secrets.py`: one sealed map per store through `control_plane/secret_store` (encrypt-then-MAC), `0600` in `0700`, legacy plaintext migrated then removed. All 9 stores routed (`vexa_control_mcp.py:322-341`, `:382-393`, `vexa_oauth.py:33-50`) | gates 2a·2b + 14 |
| **R-D06** | decision 7 prose-only: the delegated `regime` was logged twice, read for authorization never; `bot_say`'s guard was an argument the calling model sets about itself | `HUMAN_ONLY_VERBS` + `_regime_forbids`, enforced once in `_anon_guard` (`vexa_control_mcp.py:854-882`, `:1124-1138`) | gate 3 |
| **R-D07** | any signed-in user could `cancel` anyone's reaction; `reactions_list` handed out every id instance-wide | **owner scoping, not operator authority** — `reaction_signal` sends `subject=uid` and the owning service decides (`vexa_control_mcp.py:2256-2292`, `flows_api.py:363-388`, `flows_timeline/service.py:91-118`); `reactions_list` scoped the same way (`:2203-2216`) | gates 4a·4b·4c |
| **R-D09** | five unlocked read-modify-writes with truncating saves, three of them on one file | `rig_secrets.update()` — exclusive `flock` across read-modify-write, atomic replace underneath; one `_token_put` writer (`rig_secrets.py:156-180`, `vexa_control_mcp.py:382-386`) | gate 5 |
| **R-D10** | `zoom_transcript_to_segments` = arbitrary host-file read (matches leak back as `speakers`) + arbitrary write via `name`; same traversal in `captions_to_segments` | `_safe_stem` (`^[A-Za-z0-9_-]{1,64}$`) and `_import_path` (resolve-then-confine, so a symlink out is caught) (`vexa_control_mcp.py:2844-2878`) | gate 6 |
| **R-D11** | account created **before** any code was verified; response said "existing" vs "created" (an existence oracle); mail to any address | account created in `confirm_login` only; identical response either way; process-wide code budget; `hmac.compare_digest` on the code; single-use under the store lock (`vexa_control_mcp.py:714-729` (budget), `:5198` (`start_onboarding`), `:5264` (`confirm_login`)) | gates 7a·7b |
| **R-D12** | `whats_waiting` — the call nobody can avoid — read every tenant's reactions and reported their flow, step and failure reasons as this person's queue | `subject=uid` on the flows read; scoping implemented service-side in `flows_timeline.list_reactions` and reused by the route (`vexa_control_mcp.py:3380`, `core/flows/src/flows_timeline/service.py:51-84`, `flows_api.py:334-352`) | gates 8 + 4c |
| **R-D13** | the `/do` bridge echoed raw exception text; internals raise with URLs, headers and a DB password in a DSN | `_safe_error()` — shape-based `redact` from `shared/git_redaction` plus this process's own values as `known`; applied at all 6 echo sites (`vexa_control_mcp.py:238-255`) | gate 9 |
| **R-D14** | `_refuse_credentials` said "same detector the API uses" and was a six-prefix copy: no `glpat-`, no generic run, and a URL rule needing both `:` and `@` | imports `looks_like_token` / `redact`; our own `vxa_mcp_`/`vxd_`/`vxv_` prefixes exempted by name (`vexa_control_mcp.py:2568-2594`) | gate 10 + `core/agent/tests/test_workspace_credentials.py` |
| **R-D19** | the one account tool with no `@_anon_guard`: took a credential in an argument with `RIG_MODE=0`, and cleared a live token when the kwarg was absent | wrapped; manual `CALL_TOKEN.set` deleted (`vexa_control_mcp.py:3217-3227`) | gate 11 |
| **R-D21** | `friction_so_far` advertised "NO ACCOUNT NEEDED" above `me()`; `friction_dump`/`friction_fixed` gave any signed-in user the whole instance's ledger, and let them close it | docstring corrected; both instance-wide routes → `_operator_gate` (`vexa_control_mcp.py:4986` (`friction_so_far`), `:5024` (`friction_dump`), `:5057` (`friction_fixed`)) | gate 12 |
| **R-E12** | `echo '${f.b64}'` spliced into `sh -c` in the minutes seed route, validated nowhere, no identity check at all | strict base64 validation; payload on **stdin**; every path an argv parameter; the spawn extracted to `dockerSh.ts` so the proof is a call, not a grep | gate 13 |

Uniformity, as the contract asked: `_operator_gate(verb)` is now the single shape for operator
authority and all seven operator verbs go through it — five that had bespoke `try/except
_NotOperator` blocks, plus the three that had no gate at all. Five call sites each writing their
own refusal is how three verbs came to have none.

## Gates

**14 gates**, all green, none needing a container:

* `deploy/dogfood/rig/tests/` — **new; there were none** (R-D20). 22 tests. Behavioural: they call
  handlers through the tool registry against a stubbed `_http`, with every store pointed at a tmp
  directory. Includes the AST check (gate 14) that no tool writes a plaintext credential — and a
  test that runs that check against the pre-fix shape, so the gate is watched failing.
* `core/flows/tests/test_reactions_scope.py` — gate 4c, 9 tests, sqlite, offline.
* `clients/terminal/src/app/api/__tests__/minutesSeed.test.ts` — gate 13, 4 tests.

Rebased onto `caf73c99c` (#1428 `agent-api-authz`) and re-run there:

```
deploy/dogfood/rig                     24 passed
core/agent + core/flows + rehearse   1977 passed, 1 skipped
clients/terminal (seed route)           4 passed
pre-push static gates                 14/14 green   (pushed without --no-verify)
```

#1428 touched no rig file, but it changed **both** `core/agent` modules `rig_secrets` hard-imports
— `control_plane/secret_store.py` (R-E13: key generation split off the read path) and
`shared/git_redaction.py` (R-E09: the generic run's threshold 36 → 24). Both are correct and both
are load-bearing here, so each now has a test on this side: a pure read of an empty store creates
no key and answers `{}` while a write still mints one (otherwise an unconfigured rig silently
loses encryption), and an ordinary repository URL is still not refused by `_refuse_credentials`
(otherwise `workspace_attach` breaks the next time that threshold moves).

**Pre-existing on this base, not mine:** `clients/terminal` `src/canvas/__tests__/minutesLiveView.test.tsx`
(6) and `transcriptTerms.test.tsx` (12) fail with *"Element type is invalid… Check the render method
of `MeetingCanvasBody`"* — a component export, in files this PR does not touch
(`git diff --stat` over `clients/terminal` is one route file).

## Behaviour changes an operator should know about

1. **Existing `/w/…?token=<vxa_mcp_…>` links stop working.** That is the fix: a viewer that still
   honours the old shape leaves every pasted link a live credential and keeps the habit alive on
   the minting side. Agents mint fresh links from `workspace_read`.
2. **`friction_dump` and `friction_fixed` are now instance-admin only.** A person's own reports
   still come back from `friction_so_far`. **`reaction_signal` is NOT admin-gated** — it is
   owner-scoped: you may steer your own reactions and only your own.
3. **`start_onboarding` no longer creates the account** — `confirm_login` does. An address that
   never confirms leaves no user row. New knobs: `VEXA_RIG_CODE_BUDGET` (20) /
   `VEXA_RIG_CODE_WINDOW_S` (600).
4. **`zoom_transcript_to_segments` reads only from `VEXA_RIG_IMPORT_DIR`** (default
   `~/.storm/imports`) or `~/.storm/caps`.
5. **The rig now hard-imports `core/agent`.** `VEXA_AGENT_SRC` names the tree when the upward
   search cannot find it. Deliberately fatal: encryption and redaction that vanish when a path is
   wrong are worse than absent, because they read as present.

## The live stores — for the stage-1 worker, not run here

No stack was touched: no `~/.storm/*` file read or written, no rig restarted.

**Treat as exposed** — every one of these was world-readable on a shared host, so rotate rather
than re-permission: every user's **gateway API key** (`user-api-keys.json`), every minted
**`vxa_mcp_` token** (`mcp-tokens.json`, `oauth/logins.json`), every **OAuth bearer and
authorization code** (`oauth/tokens.json`, `oauth/codes.json`), and any **sign-in code** live at
the time (`oauth/email-codes.json` — these expire in 15 min, so only currently-live ones matter).

Order matters — stop the rig first, or the migration races a running process:

```bash
# 1. Stop the rig. The migration is a read-modify-delete; a live process racing it can lose a map.
# 2. Contain the exposure NOW, before anything else:
chmod 0700 ~/.storm ~/.storm/oauth
chmod 0600 ~/.storm/*.json ~/.storm/oauth/*.json
# 3. Back the stores up OUTSIDE the tree, owner-only:
umask 077 && tar czf ~/storm-preauthz-$(date +%Y%m%d).tgz -C ~ .storm
# 4. Set the store key so the ciphertext is not sealed under a key beside it:
#    VEXA_SECRETS_KEY, from the secret store, exported to the rig's environment.
# 5. Start the rig. The migration runs on FIRST READ of each map: seal → verify readback →
#    unlink the plaintext. Then confirm it happened:
ls -l ~/.storm/*.json ~/.storm/oauth/*.json     # expect: no such file
ls -l ~/.storm/.secrets/                        # expect: *.enc, 0600, dir 0700
# 6. Rotate. Migration preserves the values; it does not un-expose them.
#    - revoke every gateway API key the rig minted (admin-api), let _user_key re-mint on demand
#    - drop mcp-tokens + oauth/tokens so every client re-runs start_onboarding → confirm_login
#    - anyone holding a /w/ link gets a fresh one from their agent
```

`VEXA_SECRETS_KEY` is R-E08's row (`agent-api-authz`) and is not fixed here — without it the
generated key sits in the same directory as the ciphertext, which defends against a stray read, a
mis-scoped mount or a log, and **not** against a stolen volume or backup. Set it.
