### PR TITLE
flows-delivery + transcript-truth: the report goes out once, to everyone, and we know when it did not

### DIFF
--- a/clients/terminal/src/canvas/__tests__/minutesLiveView.test.tsx
+++ b/clients/terminal/src/canvas/__tests__/minutesLiveView.test.tsx
@@ -127,6 +127,48 @@ describe("minutes live view — the raw transcript, and nothing else (PRD decisi
     expect(container.textContent).not.toContain("VEXA_LLM_BASE_URL");
   });
 
+  // ── R-C04 · the transcript is not edited ───────────────────────────────────────────────────
+  // Decision 34 deleted the in-product inference pipeline; two of its call sites survived in the
+  // segment mappers (`useMeeting.ts`), so every live, durable and fallback line was still being
+  // rewritten by `cleanTranscriptText`'s `DOMAIN_CORRECTIONS` table on its way to the screen —
+  // `Entropic`→`Anthropic`, `Cloud Code`→`Claude Code`, `Yalna Kunz`→`Yann LeCun` — with nothing
+  // marking the substitution, in the artefact a pilot treats as the record of what was said.
+  //
+  // The words below are the table's own entries, which is the point: they are the ones a passing
+  // test cannot be passing by accident.
+  const SAID = "Entropic ships Cloud Code, and Yalna Kunz disagrees with Deep Sea.";
+
+  it("a LIVE line reaches the screen exactly as it was said", async () => {
+    meetingsState = [meetingRow(true)];
+    liveState = { transcript: [{ id: "s1", speaker: "Jane", text: SAID, t: 1, completed: true }] };
+    await renderCanvas();
+
+    expect(container.textContent).toContain(SAID);
+    expect(container.textContent).not.toContain("Anthropic");
+    expect(container.textContent).not.toContain("Claude Code");
+    expect(container.textContent).not.toContain("Yann LeCun");
+    expect(container.textContent).not.toContain("DeepSeek");
+  });
+
+  it("a DURABLE line reaches the screen exactly as it was said", async () => {
+    meetingsState = [meetingRow(false)];
+    durableState.lines = [{ speaker: "Jane", text: SAID, t: 1 }];
+    await renderCanvas();
+
+    expect(container.textContent).toContain(SAID);
+    expect(container.textContent).not.toContain("Anthropic");
+  });
+
+  it("the live caption is the line, not a rewrite of it", async () => {
+    // `latestCaption` is what a viewer reads while a line is still being spoken — the same words,
+    // one render earlier, and therefore the same rule.
+    meetingsState = [meetingRow(true)];
+    liveState = { transcript: [{ id: "s1", speaker: "Jane", text: SAID, t: 1, completed: false }] };
+    await renderCanvas();
+
+    expect(container.textContent).toContain(SAID);
+  });
+
   it("the state card names the BOT, never the product's work", async () => {
     // At the door: the bot is on its way in and nothing has been heard. This window used to render
     // nothing at all, and the one after it read "Waiting for transcript — no new lines for 24s".

--- a/clients/terminal/src/canvas/useMeeting.ts
+++ b/clients/terminal/src/canvas/useMeeting.ts
@@ -62,11 +62,11 @@ function resolveMeeting(meetings: MeetingMock[], meetingId: string): MeetingMock
 function latestCaption(segments: { text: string; completed?: boolean }[]): string | undefined {
   for (let i = segments.length - 1; i >= 0; i--) {
     const seg = segments[i];
-    if (seg.text.trim() && seg.completed === false) return cleanTranscriptText(seg.text);
+    if (seg.text.trim() && seg.completed === false) return seg.text;
   }
   for (let i = segments.length - 1; i >= 0; i--) {
     const seg = segments[i];
-    if (seg.text.trim()) return cleanTranscriptText(seg.text);
+    if (seg.text.trim()) return seg.text;
   }
   return undefined;
 }
@@ -130,7 +130,7 @@ function normalizeSegments(segments: TranscriptSegment[] | null | undefined): Tr
     .map((segment) => ({
       id: segment.id,
       speaker: textOf(segment.speaker, "Speaker"),
-      text: cleanTranscriptText(textOf(segment.text)),
+      text: textOf(segment.text),
       ts: segment.ts,
       tsMs: segment.tsMs,
       completed: segment.completed,
@@ -186,7 +186,7 @@ function firstQuoteFor(name: string, segments: TranscriptSegment[]): string | un
     const text = textOf(segment.text);
     const speaker = textOf(segment.speaker);
     const haystack = normalizeSearchText(`${speaker} ${text}`);
-    if (haystack.includes(needle) || haystack.replace(/\s+/g, "").includes(compactNeedle)) return cleanTranscriptText(text);
+    if (haystack.includes(needle) || haystack.replace(/\s+/g, "").includes(compactNeedle)) return text;
   }
   return undefined;
 }
@@ -330,9 +330,19 @@ function useLiveMeetingState(meetingId?: string): MeetingState {
       insights: safeArray(selected.insights),
       docs: safeArray(selected.docs),
     };
-    const liveSegments = safeArray(live.transcript).map((s) => ({ id: s.id, speaker: s.speaker, text: cleanTranscriptText(s.text), ts: s.t, tsMs: s.tsMs, completed: s.completed }));
-    const recordedSegments = safeArray(durable.lines).map((s) => ({ speaker: s.speaker, text: cleanTranscriptText(s.text), ts: lineTs(s) }));
-    const fallbackSegments = normalizedSelected.transcript.map((s) => ({ speaker: s.speaker, text: cleanTranscriptText(s.text), ts: lineTs(s) }));
+    // THE TRANSCRIPT IS RENDERED AS IT WAS SAID. These three mappers — live, durable and
+    // fallback — each ran every line through `cleanTranscriptText`, whose `DOMAIN_CORRECTIONS`
+    // table silently rewrote words: `Entropic`->`Anthropic`, `Cloud Code`->`Claude Code`,
+    // `Yalna Kunz`->`Yann LeCun`. That is the deleted in-product inference pipeline still
+    // editing the record (decision 34 removed it; decision 12 makes the transcript the live
+    // canvas), with no indication, in the artefact a pilot treats as what was said.
+    //
+    // It was also breaking decision 35 mechanically: `splitTextIntoSpans` matches published
+    // terms against the text it is drawing, so a term the agent extracted from the RAW
+    // transcript could never match its own chip in the REWRITTEN one.
+    const liveSegments = safeArray(live.transcript).map((s) => ({ id: s.id, speaker: s.speaker, text: s.text, ts: s.t, tsMs: s.tsMs, completed: s.completed }));
+    const recordedSegments = safeArray(durable.lines).map((s) => ({ speaker: s.speaker, text: s.text, ts: lineTs(s) }));
+    const fallbackSegments = normalizedSelected.transcript.map((s) => ({ speaker: s.speaker, text: s.text, ts: lineTs(s) }));
     const segments = selected.session_uid ? liveSegments : (recordedSegments.length ? recordedSegments : fallbackSegments);
     const diagnostics = {
       liveConnected: live.connected,

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -666,6 +666,13 @@
       "targets": []
     },
     {
+      "key": "VEXA_ROOM_MEETING",
+      "class": "defaulted",
+      "default": "(unset \u2014 present only on a post-meeting room dispatch)",
+      "description": "the meeting this dispatch is the POST-MEETING RUN for, stamped when a room was authorised and absent on every other dispatch. Runtime-injected per dispatch, never a deploy surface. The worker reads it for the three things decision 22 says a room run must not do: no entity write-back and no desk-README refresh against the subject's own desk (both committed there, moved HEAD, and failed the meeting on process_meeting's own detector \u2014 F103), and no bot verbs in the MCP allow-set for a meeting that is over (F104). A POSITIVE signal rather than an inference from the mount set, because a room whose other attendees have no desks yet resolves to zero room mounts \u2014 the small-team case \u2014 so the mount shape answers 'not a room run' on a run that is one",
+      "targets": []
+    },
+    {
       "key": "VEXA_START",
       "class": "defaulted",
       "default": "{}",

--- a/core/agent/control_plane/dispatch.py
+++ b/core/agent/control_plane/dispatch.py
@@ -222,9 +222,17 @@ def build_mount_set(settings: Settings, subject: str, memberships: Optional[list
         # THE SUBJECT'S OWN DESK keeps its write bit — the runtime needs a writable cwd to start at
         # all (F59). Their OTHER activated workspaces are still demoted: those are neither the room
         # nor the subject's own desk, and a run scoped to one meeting has no business writing them.
-        active = [dict(m) if (m.get("primary") or (group and m.get("slug") == group))
-                  else {**m, "write": False, "primary": False}
-                  for m in active]
+        #
+        # ...UNLESS THE MEETING HAS A GROUP DESK THIS SUBJECT MAY WRITE, and then the reason for
+        # the write bit is gone: that desk becomes `primary` twenty lines down, so IT is the cwd
+        # the runtime needs, and decision 22's group half says in as many words that it is "the one
+        # desk you write to in this turn". Leaving the organiser's own desk writable beside it left
+        # a second writable content desk in a run whose whole contract is that it writes no desk —
+        # and something did write it: the entity write-back phase (decision 24) authors pages into
+        # every writable mount after every turn, which moved HEAD and tripped this step's own
+        # decision-22 detector on every `#group:` meeting (F103). The narrowing is applied AFTER
+        # the group mount is resolved below, because until then we do not know whether the subject
+        # can actually write it — a viewer's group desk must not cost them their cwd.
         if group and not any(m.get("slug") == group for m in active):
             # The meeting names a group the subject has not activated — resolve it directly through
             # the authoritative Lane-A seam so the run can maintain the group's memory. Membership
@@ -232,6 +240,16 @@ def build_mount_set(settings: Settings, subject: str, memberships: Optional[list
             g_mount = group_desk_mount(settings.workspaces_dir, subject, group)
             if g_mount is not None:
                 active.append(dict(g_mount))
+        # Now the demotion, with the group's write bit known. `writable_group` is the predicate the
+        # comment above turns on: with one, the subject's own desk joins the read-only room; with
+        # none, it keeps write and primary exactly as F59 requires.
+        writable_group = bool(group) and any(
+            m.get("slug") == group and m.get("write") for m in active)
+        active = [
+            dict(m) if ((m.get("primary") and not writable_group)
+                        or (group and m.get("slug") == group))
+            else {**m, "write": False, "primary": False}
+            for m in active]
     # THE CWD, STATED rather than reached by elimination. The group desk takes it when the meeting
     # has one AND this subject may actually write it; otherwise the subject's own desk keeps it.
     #
@@ -500,6 +518,20 @@ def build_unit_env(settings: Settings, invocation: dict, *, unit_id: str, token:
         "VEXA_WORKSPACE_STORE_URL": settings.workspace_store_url,
         "REDIS_URL": settings.redis_url,
     }
+    # THE ROOM, STATED TO THE WORKER. Present exactly when this dispatch is a post-meeting room
+    # run, absent on every other dispatch — a POSITIVE signal we always emit, never an inference
+    # from the mount shape. The worker cannot derive it: a room whose other attendees have no desks
+    # yet resolves to zero `role: "room"` mounts, which is precisely the small-team case, so
+    # "are there room mounts?" answers `no` on a run that IS one.
+    #
+    # It is read for two things the room run must not do, both of them decision 22 ("the run reads
+    # desks and writes ONE shared artefact whose home is the meeting row"):
+    #   * the entity write-back phase does not run (it authored pages into the organiser's desk
+    #     after every post-meeting turn, moved HEAD, and tripped the detector — F103);
+    #   * the bot verbs leave the toolbelt (a turn about a meeting that is over cannot usefully
+    #     stop a bot, and it filed four `bot_stop` calls trying — F104).
+    if room and room.get("meeting_id"):
+        env["VEXA_ROOM_MEETING"] = str(room["meeting_id"])
     # Attribution (D4 / WP-A1.2): the per-mount turn commit is authored by the dispatch PRINCIPAL (the
     # authenticated human whose input drives the turn), committer stays the platform. Until membership/
     # sharing lands (later WPs) the principal IS the subject; a caller that already resolved a distinct

--- a/core/agent/tests/test_config_contract.py
+++ b/core/agent/tests/test_config_contract.py
@@ -211,7 +211,10 @@ def test_the_qwen_lane_dials_are_declared():
 # gained while that branch was open: INTERNAL_API_SECRET (the security hotfix, PR #1424) and
 # VEXA_BUILD_SHA (the version bar, PR #1422). The union is duplicate-free and drops nothing
 # from either side.
-EXPECTED_DECLARED_KEYS = 86
+# +1 on `flows-delivery`: VEXA_ROOM_MEETING, the post-meeting room signal the worker reads to
+# keep decision 22 (no desk write-back, no README refresh, no bot verbs on a finished meeting —
+# F103/F104). The widened scan this file's sibling test performs is what caught it undeclared.
+EXPECTED_DECLARED_KEYS = 87
 
 
 def test_the_declared_key_count_is_asserted_not_merely_printed():

--- a/core/agent/tests/test_meeting_room.py
+++ b/core/agent/tests/test_meeting_room.py
@@ -603,11 +603,25 @@ def test_a_non_admin_subjects_post_meeting_dispatch_can_start(tmp_path):
         desks=[("b@x.test", "u_bob"), ("c@x.test", "u_carol")], group="g_acme"))
     by = {m["slug"]: m for m in stack}
     own = next(m for m in stack if m["role"] == "private")
-    assert own["write"] is True                                # its own desk: rw
     assert all(by[f"room:{s}"]["write"] is False for s in ("u_bob", "u_carol"))   # the room: ro
     assert by["g_acme"]["write"] is True                       # the group: rw when present
     assert by["g_acme"]["primary"] is True                     # ...and it is the cwd
     assert own["primary"] is False
+    # F59'S ACTUAL PROPERTY, asserted as itself: the cwd the runtime is handed is WRITABLE, so the
+    # worker can create `<cwd>/.claude` and the turn starts. This line used to read
+    # `own["write"] is True` instead, which was a PROXY for it — and the wrong one when the meeting
+    # has a group, because then the cwd is the group desk and the subject's own desk needs no write
+    # bit at all. That over-grant left a second writable content desk in a run whose contract is
+    # that it writes no desk; the entity write-back phase (decision 24) then authored pages into
+    # the organiser's desk after the turn, moved HEAD, and tripped `process_meeting`'s own
+    # decision-22 detector on every `#group:` meeting (F103). The two group-less cases — no group,
+    # and a group this subject may only read — are covered two tests down, and there the own desk
+    # keeps both bits.
+    from control_plane.dispatch import _worker_cwd
+    cwd = _worker_cwd(str(root), "u_org", stack)
+    assert cwd == str(root / "g_acme")
+    assert next(m for m in stack if m["path"] == cwd)["write"] is True
+    assert own["write"] is False                               # it is one of the room's desks now
 
 
 def test_the_same_subject_keeps_a_writable_desk_when_no_room_is_named(tmp_path):
@@ -628,9 +642,11 @@ def test_the_meetings_group_desk_is_the_one_writable_desk(tmp_path):
                             room=_room(desks=[("b@x.test", "u_bob")], group="g_acme"))
     writable = [m["slug"] for m in stack
                 if m["write"] and m["role"] not in ("global", "system")]
-    # the subject's own desk is writable too (F59) — what the group desk is UNIQUELY is the cwd
-    own_slug = next(m["slug"] for m in stack if m["role"] == "private")
-    assert writable == [own_slug, "g_acme"]
+    # THE ONE WRITABLE DESK, which is what this test has always been called. It used to assert
+    # `[own_slug, "g_acme"]` — two of them — under a comment excusing the first as F59's doing;
+    # F59 needs a writable CWD, and here the cwd is the group desk. See the fuller note in
+    # `test_a_non_admin_subjects_post_meeting_dispatch_can_start` above (F103).
+    assert writable == ["g_acme"]
     group = next(m for m in stack if m["slug"] == "g_acme")
     # it becomes the turn's cwd, so the run maintains the group's memory rather than a ro desk
     assert group["primary"] is True

--- a/core/agent/tests/test_post_meeting_run.py
+++ b/core/agent/tests/test_post_meeting_run.py
@@ -1,0 +1,264 @@
+"""THE POST-MEETING RUN WRITES ONE ARTEFACT AND NOTHING ELSE (decision 22).
+
+Two findings of 2026-09-03's rehearsal run, both of them the same shape — a general rule that is
+right everywhere else meeting a run whose contract is narrower, with nothing in between:
+
+  F103  the entity WRITE-BACK PHASE (decision 24: "the agent writes entities as a phase of every
+        turn") authored pages into the organiser's own desk after the post-meeting turn. HEAD
+        moved, `process_meeting`'s decision-22 detector failed the meeting — loudly and correctly
+        — and the minutes mail went nowhere. BOTH rehearsal states that reach a completed meeting
+        (`group-member`, `reply-pending`) died there, which is what made it look like two bugs.
+        Two things let it happen and both are closed here: on a `#group:` meeting the organiser's
+        desk was mounted writable beside the group's, and on every room run the phase ran at all.
+
+  F104  the same turn called `bot_stop` FOUR TIMES against a meeting that was over. The verbs were
+        in its toolbelt, and the answer they got (`{"stopped": false, "status": 404}`) reads as a
+        transient failure. Both halves are fixed, independently: the belt no longer carries the
+        bot verbs on a room run, and `bot_stop` answers the state for every other caller.
+
+No network, no docker: the mount stack and the worker env are pure functions of the dispatch.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from control_plane.dispatch import build_mount_set, build_unit_env
+from shared.config import load_settings
+
+SECRET = "test-delegation-secret"
+
+INV = {
+    "identity": {"subject": "58", "launcher": "user:58"},
+    "runner": "claude-code",
+    "workspaces": [{"id": "58", "mode": "rw"}],
+    "trigger": "message",
+    "context": {"kind": "none"},
+    "start": {"entrypoint": {"inline": "hi"}},
+}
+
+
+def _git_repo(d: Path, marker: str = "X") -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    run = lambda *a: subprocess.run(["git", *a], cwd=d, check=True, capture_output=True)
+    run("init", "-q", "-b", "main"); run("config", "user.email", "t@t"); run("config", "user.name", "t")
+    (d / "CLAUDE.md").write_text(marker); run("add", "-A"); run("commit", "-q", "-m", "seed")
+    return d
+
+
+def _seed(root: Path, subject: str) -> Path:
+    from shared.seeding import seed_workspace
+    ws = root / subject
+    ws.mkdir(parents=True)
+    (ws / "CLAUDE.md").write_text(f"SEED {subject}")
+    seed_workspace(ws, None)
+    return ws
+
+
+def _shared_ws(root: Path, ws_id: str, members: list[tuple[str, str]]) -> Path:
+    ws = root / ws_id
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / "README.md").write_text(f"group {ws_id}")
+    pol = ws / "policy"
+    pol.mkdir(parents=True, exist_ok=True)
+    (pol / "members.json").write_text(json.dumps(
+        [{"subject": s, "role": r} for s, r in members]))
+    return ws
+
+
+def _settings(tmp_path, root: Path, **over):
+    return load_settings(**{"workspaces_dir": str(root),
+                            "global_system_workspace_path": str(_git_repo(tmp_path / "global")),
+                            "internal_api_secret": "s3cr3t-internal",
+                            "mcp_url": "https://rig.example/mcp",
+                            "mcp_delegation_secret": SECRET, **over})
+
+
+def _room(meeting_id="42", desks=(), *, group=""):
+    book = dict(desks)
+    return {"meeting_id": meeting_id, "source": "invite:participants→admin-api",
+            "ordered": [(a, "unmatched-invite-order") for a, _ in desks],
+            "lookup": book.get, "read_max": None, "group_workspace_id": group}
+
+
+# ══ F103 · the mount set — one writable desk on a group meeting ══════════════════════════════
+def test_a_group_meetings_run_has_exactly_one_writable_desk_and_it_is_the_groups(tmp_path):
+    """The organiser's own desk is one of the room's desks, and the room is read-only. It kept a
+    write bit because F59 needed a writable CWD — but on a group meeting the CWD is the GROUP's
+    desk, so the grant bought nothing and cost the detector."""
+    root = tmp_path / "ws"
+    for s in ("58", "u_bob"):
+        _seed(root, s)
+    _shared_ws(root, "g_acme", [("58", "contributor")])
+    stack = build_mount_set(_settings(tmp_path, root), "58",
+                            room=_room(desks=[("b@x.test", "u_bob")], group="g_acme"))
+
+    desks = [m for m in stack if m["role"] not in ("global", "system")]
+    assert [m["slug"] for m in desks if m["write"]] == ["g_acme"]
+    own = next(m for m in stack if m["role"] == "private")
+    assert own["write"] is False and own["primary"] is False
+
+
+def test_without_a_group_the_organisers_desk_still_keeps_the_write_bit_it_needs(tmp_path):
+    """The other half of F59, and the reason the narrowing above is conditional: with no group
+    desk the subject's own desk IS the cwd, and a read-only cwd killed the worker before the model
+    ran (`OSError: [Errno 30] Read-only file system: .../.claude`)."""
+    root = tmp_path / "ws"
+    for s in ("58", "u_bob"):
+        _seed(root, s)
+    stack = build_mount_set(_settings(tmp_path, root), "58",
+                            room=_room(desks=[("b@x.test", "u_bob")]))
+
+    own = next(m for m in stack if m["role"] == "private")
+    assert own["write"] is True and own["primary"] is True
+
+
+def test_a_group_the_subject_may_only_read_never_costs_them_their_cwd(tmp_path):
+    """The narrowing turns on a WRITABLE group desk, not on the meeting merely naming one. A
+    viewer's group desk is read-only, so demoting the organiser's own desk beside it would leave
+    the run with no writable mount at all — F59 through a quieter door."""
+    root = tmp_path / "ws"
+    _seed(root, "58")
+    _shared_ws(root, "g_acme", [("u_somebody_else", "owner"), ("58", "viewer")])
+    stack = build_mount_set(_settings(tmp_path, root), "58", room=_room(group="g_acme"))
+
+    own = next(m for m in stack if m["role"] == "private")
+    assert own["write"] is True and own["primary"] is True
+    group = next((m for m in stack if m["slug"] == "g_acme"), None)
+    assert group is None or group["write"] is False
+
+
+# ══ F103/F104 · the worker is TOLD, positively, that this is a room run ══════════════════════
+def test_the_dispatch_stamps_the_room_meeting_and_only_on_a_room_run(tmp_path):
+    """A POSITIVE signal, because the mount shape cannot answer this question: a room whose other
+    attendees have no desks yet resolves to zero `role: "room"` mounts — the small-team case — and
+    "are there room mounts?" would then answer `no` on a run that is one."""
+    root = tmp_path / "ws"
+    _seed(root, "58")
+    settings = _settings(tmp_path, root)
+
+    plain = build_unit_env(settings, dict(INV), unit_id="u1", token="t")
+    assert "VEXA_ROOM_MEETING" not in plain
+
+    roomed = build_unit_env(settings, dict(INV), unit_id="u1", token="t",
+                            room=_room(meeting_id="97"))
+    assert roomed["VEXA_ROOM_MEETING"] == "97"
+
+
+def test_the_worker_reads_that_stamp_as_the_room_predicate(monkeypatch):
+    from worker.engine import room_run
+
+    monkeypatch.delenv("VEXA_ROOM_MEETING", raising=False)
+    assert room_run() == ""
+    monkeypatch.setenv("VEXA_ROOM_MEETING", "97")
+    assert room_run() == "97"
+
+
+# ══ F104 · the bot verbs leave the toolbelt when the meeting is over ═════════════════════════
+def test_a_post_meeting_turn_is_offered_no_bot_verbs():
+    """The meeting is OVER. `bot_stop` cannot help, and a tool that cannot help is a tool that can
+    be looped on — it was called four times in one turn."""
+    from worker.engine import VEXA_MCP_SERVER, VEXA_MCP_TOOLS, room_toolbelt
+
+    full = [f"mcp__{VEXA_MCP_SERVER}",
+            *(f"mcp__{VEXA_MCP_SERVER}__{t}" for t in VEXA_MCP_TOOLS)]
+    narrowed = room_toolbelt(full)
+
+    assert f"mcp__{VEXA_MCP_SERVER}__bot_stop" in full        # the belt this narrows
+    assert not [t for t in narrowed if t.startswith(f"mcp__{VEXA_MCP_SERVER}__bot")]
+    # ...and nothing else moved: the transcript is the whole point of the turn
+    assert f"mcp__{VEXA_MCP_SERVER}__meeting_transcript" in narrowed
+    assert f"mcp__{VEXA_MCP_SERVER}" in narrowed              # the server id itself stays
+    assert len(narrowed) == len(full) - len(
+        [t for t in VEXA_MCP_TOOLS if t.startswith("bot")])
+
+
+# ══ F103 · the two writers on the organiser's desk, both silenced while a room is open ═══════
+# `process_meeting`'s detector compares the organiser's desk HEAD before and after the turn and
+# fails the meeting when it moved. Two things moved it, and they fail differently — the write-back
+# phase only on a turn that learned a new name, the README refresh on any turn that changed a
+# section — which is why one looked intermittent and the other looked like a different bug.
+
+DESK = {"slug": "58", "path": "/w/58", "role": "private", "write": True, "primary": True}
+GROUP = {"slug": "g_acme", "path": "/w/g_acme", "role": "shared", "write": True, "primary": True}
+ROOM = {"slug": "room:u_bob", "path": "/w/u_bob", "role": "room", "write": False}
+SYSTEM = {"slug": "_system", "path": "/w/58/_system", "role": "system", "write": True}
+
+
+def test_the_write_back_phase_has_no_target_on_a_group_less_room_run(monkeypatch, tmp_path):
+    """The subject's desk is writable on this run ON PURPOSE — the runtime needs a writable cwd to
+    create `<cwd>/.claude` at all (F59) — so the write bit means "the process can start" here, not
+    "the turn may author here". The phase read it as the latter."""
+    from worker import engine
+
+    monkeypatch.setenv("VEXA_ROOM_MEETING", "97")
+    assert engine.writeback_candidates(["Priya Raman joined from Acme"],
+                                       [DESK, ROOM, SYSTEM]) == []
+
+
+def test_the_group_desk_is_still_a_write_back_target(monkeypatch):
+    """Narrowed, not disabled: decision 22's group half says the run maintains the group's desk,
+    so the phase keeps working there. (`missing_names` reads the workspace; an empty temp root
+    simply means every name is missing, which is what makes this assert non-trivially non-empty.)"""
+    from worker import engine
+
+    monkeypatch.setenv("VEXA_ROOM_MEETING", "97")
+    roots_seen = []
+    monkeypatch.setattr("shared.entities.missing_names",
+                        lambda roots, texts: roots_seen.extend(str(r) for r in roots) or ["Priya"])
+    out = engine.writeback_candidates(["Priya Raman joined"], [DESK, GROUP, ROOM, SYSTEM])
+
+    assert out == ["Priya"]
+    assert roots_seen == ["/w/g_acme"]          # the group's, and NOT the organiser's own
+
+
+def test_off_a_room_run_the_phase_targets_the_desk_exactly_as_before(monkeypatch):
+    """The scoping is to room mode and nothing else — a person's own chat still writes their desk."""
+    from worker import engine
+
+    monkeypatch.delenv("VEXA_ROOM_MEETING", raising=False)
+    roots_seen = []
+    monkeypatch.setattr("shared.entities.missing_names",
+                        lambda roots, texts: roots_seen.extend(str(r) for r in roots) or [])
+    engine.writeback_candidates(["Priya Raman joined"], [DESK, SYSTEM])
+
+    assert roots_seen == ["/w/58"]
+
+
+def test_the_desk_readme_refresh_does_not_touch_the_organisers_desk_on_a_room_run(monkeypatch,
+                                                                                   tmp_path):
+    """The refresh runs on EVERY turn and COMMITS `README.md` when a section changed, so it moves
+    HEAD without the write-back phase doing anything at all — the half that made this look
+    intermittent.
+
+    The desk is a REAL directory here on purpose: `refresh_desk_readme` returns None for a path
+    that is not one, so a fake path would make this test pass against the unfixed code for a
+    reason that has nothing to do with the room."""
+    from worker import engine
+
+    desk = {**DESK, "path": str(tmp_path)}
+    monkeypatch.setenv("VEXA_ROOM_MEETING", "97")
+    monkeypatch.setattr(engine, "desk_mounts", lambda mounts=None: (desk, []))
+    looked_at = []
+    monkeypatch.setattr("shared.desk_readme.update_readme",
+                        lambda root, **kw: looked_at.append(str(root)) or {"changed": False})
+
+    assert engine.refresh_desk_readme([desk, ROOM]) is None
+    assert looked_at == []          # it did not even read the organiser's desk
+
+
+def test_the_groups_readme_is_still_refreshed_on_a_group_meeting(monkeypatch, tmp_path):
+    """Decision 22's group half names the README explicitly — "the dashboard a member reads first
+    — make it true as of today". The narrowing must not take that with it."""
+    from worker import engine
+
+    monkeypatch.setenv("VEXA_ROOM_MEETING", "97")
+    group = {**GROUP, "path": str(tmp_path)}
+    monkeypatch.setattr(engine, "desk_mounts", lambda mounts=None: (group, []))
+    seen = {}
+    monkeypatch.setattr("shared.desk_readme.update_readme",
+                        lambda root, **kw: seen.update(root=str(root)) or {"changed": False})
+
+    assert engine.refresh_desk_readme([group]) == {"changed": False}
+    assert seen["root"] == str(tmp_path)

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -597,6 +597,15 @@ def refresh_desk_readme(mounts: "list[dict] | None" = None) -> "dict | None":
     desk, groups = desk_mounts(mounts)
     if not desk or not desk.get("path"):
         return None
+    # THE SECOND COMMITTER, and the one that fires even when the write-back phase has nothing to
+    # do: this runs on EVERY turn and commits `README.md` whenever a section changed. On a
+    # post-meeting room run against a group-less meeting the writable primary IS the organiser's
+    # own desk, so decision 26.4's refresh moved HEAD and decision 22's detector failed the
+    # meeting (F103). Same rule as the write-back's roots above, and it has to be stated twice
+    # because these are two different writers on one surface — the group's README is still
+    # maintained here, which is decision 22's group half in as many words.
+    if room_run() and str(desk.get("role") or "private") == "private":
+        return None
     root = Path(str(desk["path"]))
     if not root.is_dir():
         return None
@@ -668,12 +677,40 @@ def writeback_candidates(texts, mounts: list[dict] | None = None) -> list[str]:
     a two-minute model call."""
     from shared.entities import missing_names
 
-    roots = [Path(str(m.get("path") or "")) for m in (mounts if mounts is not None else active_mounts())
-             if m.get("write") and m.get("path")]
+    # A ROOM RUN DOES NO BOOKKEEPING ON THE SUBJECT'S OWN DESK (decision 22, F103). The post-meeting
+    # turn writes ONE shared artefact whose home is the meeting row; `drop_to_attendees` puts it on
+    # every desk in the room afterwards, organiser included. Decision 24 ("the agent writes entities
+    # as a phase of every turn") is right everywhere else and met this run with nothing in between:
+    # the phase authored pages into the organiser's desk after the turn, the commit moved HEAD, and
+    # `process_meeting`'s own decision-22 detector failed the meeting and its minutes mail. Both
+    # rehearsal states that reach a completed meeting died there.
+    #
+    # NARROWED, NOT DISABLED. The GROUP desk is the one desk a room run maintains, so it stays a
+    # target — and with the organiser's desk demoted for group meetings (dispatch.build_mount_set)
+    # the two cases come out right on their own: a group run has exactly one candidate root, a
+    # group-less run has none and the phase's fourth gate declines it.
+    #
+    # The write bit alone cannot express this. On a group-less room run the subject's desk is
+    # writable ON PURPOSE — the runtime needs a writable cwd to create `<cwd>/.claude` at all
+    # (F59) — so "writable" there means "the process can start", not "the turn may author here".
+    #
+    # ...and NEVER THE SYSTEM TIERS, room or no room. `_system` is chats, sessions, settings and
+    # identity — `desk_mounts` one screen up excludes it from "the desk" for exactly this reason —
+    # and `_global` is the organisation's, read-only for everyone but the admin's setup turn. They
+    # were reachable here only because both are writable, and the room narrowing would otherwise
+    # have made `_system` the LAST root standing on a group-less room run: entity pages authored
+    # into the private system tier, which is worse than what this is fixing.
+    #
     # DEFAULT FALSE (R-A15). Every other mount consumer reads the bit explicitly; this one
     # defaulted a missing key to writable, so a mount that LOST it — a fake, a future producer,
     # the read-only room mounts of a run with no primary — was silently promoted to a write
     # target for the phase. A write bit that has to be present to be true cannot be lost.
+    in_room = bool(room_run())
+    roots = [Path(str(m.get("path") or "")) for m in (mounts if mounts is not None else active_mounts())
+             if m.get("write") and m.get("path")
+             and str(m.get("role") or "private") not in ("system", "global")
+             and m.get("slug") not in ("_system", "_global")
+             and not (in_room and str(m.get("role") or "private") == "private")]
     if not roots:
         return []
     return missing_names(roots, [t for t in texts if t])
@@ -985,6 +1022,34 @@ VEXA_MCP_TOOLS = (
     # for its only verb is a turn that answers with an apology.
     "transcript_terms",
 )
+
+
+def room_run() -> str:
+    """The meeting this turn is the post-meeting run FOR, or `""` for every other dispatch.
+
+    Stamped by `control_plane.dispatch.build_unit_env` exactly when a room was authorised, so it
+    is a POSITIVE signal the platform always emits rather than an inference from the mount shape.
+    The mount shape cannot answer this: a room whose other attendees have no desks yet resolves to
+    zero `role: "room"` mounts — the small-team case — and "are there room mounts?" would then say
+    `no` on a run that is one."""
+    return (os.environ.get("VEXA_ROOM_MEETING") or "").strip()
+
+
+def room_toolbelt(tools: list[str]) -> list[str]:
+    """The MCP allow-set for a post-meeting turn: everything except the bot verbs.
+
+    The meeting is OVER. `bot_send`, `bot_stop`, `bot_say`, `bot_schedule` and `bots_running` can
+    do nothing useful about a room that has finished, and offering them is not neutral: on
+    2026-09-02 the post-meeting agent for uid 133 read the meeting as still live and called
+    `bot_stop` four times in one turn, each answered with a bare `{"stopped": false, "status":
+    404}` that reads as a transient failure rather than a terminal state (F104). A tool that
+    cannot help is a tool that can be looped on.
+
+    Advertised is not the same as callable, and both matter: the harness will not offer what is
+    not in `--allowedTools`, so this removes the option rather than relying on the model declining
+    it. `bot_stop` itself also learned to answer the state — the two fixes are independent because
+    the MCP serves callers this allow-set never reaches."""
+    return [t for t in tools if not t.startswith(f"mcp__{VEXA_MCP_SERVER}__bot")]
 
 
 def _delegation_dir(work: Path) -> "Path | None":
@@ -1412,10 +1477,14 @@ def main() -> None:  # pragma: no cover — the container entrypoint (wired in t
     # must enter the allow-set too or every tool call would stall on a permission prompt that no
     # human is there to answer.
     mcp_cfg, mcp_tools = mcp_delegation_config(work)
+    room = room_run()
+    if room:
+        mcp_tools = room_toolbelt(mcp_tools)
     if mcp_cfg:
         chat_tools = chat_tools + mcp_tools
-        log.info("agent-api worker: vexa MCP attached for owner=%s (delegated, scoped, short-lived)",
-                 os.environ.get("VEXA_OWNER"))
+        log.info("agent-api worker: vexa MCP attached for owner=%s (delegated, scoped, short-lived)"
+                 "%s", os.environ.get("VEXA_OWNER"),
+                 f" — post-meeting room {room}, bot verbs withheld" if room else "")
     # One harness instance owns the whole warm worker lifetime. That makes the steering handle
     # instance-scoped (Codex JSON-RPC process / Claude stdin) instead of a vendor-global mailbox.
     import worker.worker as _w
@@ -1431,6 +1500,11 @@ def main() -> None:  # pragma: no cover — the container entrypoint (wired in t
         # SAME session on purpose: the phase has to see what the turn just saw, and a fresh
         # session would have to be told the whole conversation to ask one bookkeeping question.
         # Small budget by TOOLSET rather than by a step cap the harness does not expose.
+        #
+        # A ROOM RUN REACHES THIS PHASE WITH NOTHING TO DO, by construction rather than by a switch
+        # here: `writeback_candidates` refuses the subject's own desk as a target while a room is
+        # open (F103), so the pre-pass returns an empty list and gate 4 declines. On a `#group:`
+        # meeting the group's desk IS a legitimate target and the phase still runs against it.
         writeback=lambda candidates: run_turn_over_workspace(
             work, writeback_prompt(candidates), model=model,
             allowed_tools=[*WRITEBACK_TOOLS, *mcp_tools], session=session,

--- a/core/flows/src/flows/loop.py
+++ b/core/flows/src/flows/loop.py
@@ -145,6 +145,28 @@ def tick(db: DB, registry: Registry, clock: Clock, *, emit=None, gate=None) -> b
     def _save_scratch() -> None:
         db.execute("UPDATE reaction SET scratch = :s WHERE reaction_id = :rid",
                    {"s": dumps(ctx.scratch), "rid": r.reaction_id})
+
+    def _checkpoint() -> None:
+        """MID-STEP: persist what has been done and push the lease out again.
+
+        A step is normally shorter than `LEASE_S` and needs none of this. The attendee fan-out is
+        not: it mints a transcript share, mints a scaffold and sends an SMTP message PER PERSON,
+        so a 20-person room at ~4 s each runs past 90 s. What happened then was silent and
+        expensive — `reclaim` returned the still-running reaction to the queue, a second worker
+        claimed it, and because scratch is only written when the step RETURNS that worker began
+        from an empty `sent` list: everybody already mailed was mailed a second time, with a
+        second share token each.
+
+        Both halves matter and they fail differently. Renewing the lease is what stops the second
+        worker existing; saving scratch is what makes the second worker harmless if it does (a
+        crash, a redeploy, a lease that expired anyway). One call buys both, so a step cannot take
+        the cheap half by accident."""
+        _save_scratch()
+        db.execute(
+            "UPDATE reaction SET lease_until = :lease, updated_at = :now WHERE reaction_id = :rid",
+            {"lease": clock.now() + LEASE_S, "now": clock.now(), "rid": r.reaction_id})
+
+    ctx.checkpoint = _checkpoint
     try:
         out = registry.steps[r.step](ctx)
         _save_scratch()
@@ -210,6 +232,11 @@ def _retry_or_fail(db: DB, r: Reaction, clock: Clock, why: str, *, retryable: bo
                WHERE reaction_id = :rid""",
             {"due": clock.now() + backoff, "why": why, "now": clock.now(), "rid": r.reaction_id})
     else:
+        # THE STEP'S OWN RECEIPT IS PART OF THE TERMINAL STATE, and nothing used to say so: only
+        # the `reaction` row was marked, the receipt stayed `reserved`, and `flows_timeline`
+        # renders `reserved` as `in_flight`. A permanently failed `email_minutes` therefore read
+        # as a report still on its way — the exact claim that module exists to make impossible.
+        receipts.fail(db, effect_key(r), why, clock)
         db.execute(
             """UPDATE reaction SET status = 'failed', reason = :why,
                       lease_until = NULL, updated_at = :now WHERE reaction_id = :rid""",

--- a/core/flows/src/flows/model.py
+++ b/core/flows/src/flows/model.py
@@ -63,11 +63,18 @@ class StepError(Exception):
         self.retryable = retryable
 
 
+def _no_checkpoint() -> None:
+    """The default `checkpoint`: a step called OUTSIDE the loop — which every unit test does — has
+    no lease to renew and no row to save into, and must still run unchanged."""
+    return None
+
+
 @dataclass
 class StepCtx:
     """Everything a step sees: the reaction's refs, its effect key, prior step results,
-    a DURABLE scratch dict (persisted after every step — survives worker restarts), and
-    emit() to publish a new fact (sub-flow composition)."""
+    a DURABLE scratch dict (persisted after every step — survives worker restarts),
+    emit() to publish a new fact (sub-flow composition), and checkpoint() for the steps whose
+    body outlives one lease."""
     reaction: Reaction
     effect_key: str
     prior: dict[str, dict]
@@ -75,6 +82,7 @@ class StepCtx:
     scratch: dict = field(default_factory=dict)
     emit: Any = None                      # (event_type, source_id, refs) -> int reactions created
     flow: Any = None                      # the governing Flow (params via ctx.flow.param(key))
+    checkpoint: Any = _no_checkpoint      # renew the lease + persist scratch, MID-step
 
     @property
     def reaction_id(self) -> str:

--- a/core/flows/src/flows/receipts.py
+++ b/core/flows/src/flows/receipts.py
@@ -35,6 +35,23 @@ def confirm(db: DB, key: str, result: dict, provider_ref: Optional[str], clock: 
         {"k": key, "res": dumps(result), "pref": provider_ref, "now": clock.now()})
 
 
+def fail(db: DB, key: str, reason: str, clock: Clock) -> None:
+    """The terminal branch's half of the receipt — the state NOTHING used to write.
+
+    `flows_timeline` turns `state = 'failed'` into a `reaction.failed` event and says why:
+    "the one thing an agent must not do is talk about a report it never delivered". Only
+    `reserve` and `confirm` existed, so `_RECEIPT_STATUS["failed"]` and the branch reading it were
+    unreachable and a permanently failed `email_minutes` rendered as `in_flight` for ever.
+
+    ONLY A RESERVED RECEIPT IS FAILED. An effect that HAPPENED stays confirmed whatever the
+    reaction does afterwards — the receipt records the world, not the row's mood — and
+    `confirmed_at` is left alone so "when did this land" keeps meaning that."""
+    db.execute(
+        """UPDATE effect_receipt SET state = 'failed', result = :res
+           WHERE effect_key = :k AND state = 'reserved'""",
+        {"k": key, "res": dumps({"error": str(reason)[:500]})})
+
+
 def prior(db: DB, reaction_id: str) -> dict[str, dict]:
     """Confirmed results of earlier steps, keyed by step name — a later step's inputs."""
     rows = db.execute(

--- a/core/flows/src/flows_defs/production.py
+++ b/core/flows/src/flows_defs/production.py
@@ -92,8 +92,38 @@ def _prompt(fname: str) -> str:
 
 
 def prompt_for(ctx, fname: str, default: str) -> str:
+    """The LIVE kick for one step, in the order the rest of this file already claims: the flow's
+    own `prompts` param, then the admin's `_global/prompts/<fname>`, then the baked default.
+
+    THE MIDDLE ONE DID NOT EXIST (R-B18). This function read the flow param and nothing else,
+    while `_shared_report_rules` asserted three screens down that "`prompt_for` reads a live
+    `_global` override before the baked file" and the decision-22 detector told the operator to go
+    and check "the LIVE kick (`_global` override, else `behavior/prompts/process-meeting.md`)".
+    An admin who edited that file changed nothing, and the one instruction an operator is given
+    when the detector fires pointed at a path the code never opened — which is worse than a
+    missing feature, because it sends the person debugging a failure to the wrong file.
+
+    `default` is the BAKED prompt, and it is baked at IMPORT (`PROCESS_KICKOFF = _prompt(...)`),
+    which is where the "hot reload" half of the claim came from. The `_global` read below is the
+    hot half and it is per-call, exactly as `mailtext.render` reads `_global/mail/<name>.md` on
+    every send — the same contract, the same directory, one screen apart, and now the same shape.
+
+    FAILS SOFT, twice over. An override that cannot be read (agent-api down, no uid in refs) and
+    an override that is EMPTY or whitespace both fall through to the baked text. An admin who
+    cleared the file by accident did not mean "dispatch a turn with no instructions"; `mailtext`
+    learned the same lesson and its comment says so."""
     over = (ctx.flow.param("prompts") or {}) if ctx.flow else {}
-    return over.get(fname, default)
+    if fname in over:
+        return over[fname]
+    uid = str((getattr(ctx, "refs", None) or {}).get("uid") or "")
+    if uid:
+        try:
+            live = ws_file(uid, f"prompts/{fname}", "_global")
+        except Exception:  # noqa: BLE001 — a prompt we cannot fetch is not a reason to fail a turn
+            live = None
+        if (live or "").strip():
+            return live
+    return default
 
 
 ONBOARD_KICKOFF = _prompt("onboard-person.md")
@@ -597,8 +627,9 @@ def build(reg: Registry, db) -> None:
                     f"HEAD moved {before[:9]} -> {after[:9]}. Landed: "
                     f"{'; '.join(ag.head_subjects(uid)) or '(unreadable)'}. The report IS the "
                     "reply; desks are written by drop_to_attendees. Remove the stray commit, then "
-                    "check the LIVE kick (`_global` override, else `behavior/prompts/"
-                    "process-meeting.md`) for a file-writing instruction that came back.",
+                    "check the LIVE kick (`_global/prompts/process-meeting.md` if an admin wrote "
+                    "one, else the baked `behavior/prompts/process-meeting.md`) for a "
+                    "file-writing instruction that came back.",
                     retryable=False)
             return Done({"report": reply[:6000], "group": group,
                          "room_read": ctx.scratch.get("room_read", [])})
@@ -622,8 +653,10 @@ def build(reg: Registry, db) -> None:
         either text.
 
         The WRITE NO FILES clause below stays anyway, and deliberately: `prompt_for` reads a live
-        `_global` override before the baked file, so an admin can put the old instruction back
-        without touching this repo. Belt and braces, with the detector as the actual guarantee.
+        `_global/prompts/<name>` override before the baked file, so an admin can put the old
+        instruction back without touching this repo. Belt and braces, with the detector as the
+        actual guarantee. (Until R-B18 that override was asserted here and performed nowhere — the
+        sentence was true of the design and false of the code for as long as both existed.)
         """
         block = (
             "\n\nTHE REPORT IS SHARED, AND IT IS YOUR REPLY. One report for this meeting, the "

--- a/core/flows/src/flows_defs/production.py
+++ b/core/flows/src/flows_defs/production.py
@@ -147,6 +147,22 @@ def _meeting_stamp(ctx, uid) -> str:
     depending on where the process was, which is the one thing a filename must never do.
     """
     import datetime
+    # COMPUTED ONCE PER REACTION, then stashed. Three moments ask for this stamp — the scaffold's
+    # mint (`_scaffold_refs`), the drop's own `day`, and `_note_path` inside the drop — and two of
+    # its three inputs can CHANGE between them: `mt.meeting_start` is an HTTP call that can fail
+    # and later succeed, and the last fallback below is the wall clock, which moves. A run that
+    # minted the mail's link at 19:47 and wrote the desk file at 19:52 named two different files;
+    # the Minutes tab opened the one nothing wrote and read "No page here yet". That is F58, and
+    # it re-opened on this second route after the `[:10]` slice was fixed on the first.
+    #
+    # `ctx.scratch` is the right home rather than a module global: it is per-reaction, it is
+    # persisted, and it therefore survives the worker restart between `email_minutes` and
+    # `drop_to_attendees` that a module global would not. Keyed by `uid` because the zone is that
+    # person's. `getattr` because unit tests hand this function a ctx that is only `refs`.
+    scratch = getattr(ctx, "scratch", None)
+    key = f"_meeting_stamp:{uid}"
+    if isinstance(scratch, dict) and scratch.get(key):
+        return str(scratch[key])
     start = ctx.refs.get("start")
     if not start:
         start = mt.meeting_start(uid, ctx.refs.get("meeting_id"), ctx.refs.get("native"))
@@ -161,8 +177,22 @@ def _meeting_stamp(ctx, uid) -> str:
     if not start:
         # Still deterministic and still not the server's clock: a meeting with no knowable
         # start is stamped in the same zone as one that has it.
-        return datetime.datetime.now(zone).strftime("%Y-%m-%d-%H%M")
-    return datetime.datetime.fromtimestamp(float(start), zone).strftime("%Y-%m-%d-%H%M")
+        stamp = datetime.datetime.now(zone).strftime("%Y-%m-%d-%H%M")
+    else:
+        stamp = datetime.datetime.fromtimestamp(float(start), zone).strftime("%Y-%m-%d-%H%M")
+    if isinstance(scratch, dict):
+        scratch[key] = stamp
+    return stamp
+
+# HOW MANY TIMES THE ATTENDEE FAN-OUT RETRIES AN UNREACHABLE ADDRESS before it goes on without
+# them. The step's own ceiling, deliberately not the engine's `MAX_ATTEMPTS`: what is being bounded
+# here is one person's mail server, not the health of the reaction, and the two must be able to
+# move independently. Below the ceiling a failure is retryable (a transient SMTP 421 is the case
+# this exists for); at it the step COMPLETES with the address named in `failed`, because the steps
+# after it — the desk drop that reaches the whole room — must not be held hostage by one bad
+# address in a twenty-person invite.
+ATTENDEE_MAIL_ATTEMPTS = 3
+
 
 def _note_path(ctx, uid, title) -> str:
     """THE ONE RECIPE for where a meeting's record lands on a desk:
@@ -954,6 +984,10 @@ def build(reg: Registry, db) -> None:
         # What each person was actually told, recorded as they are told it — in scratch, so a
         # retry that skips an already-mailed attendee still carries their entry forward.
         drops = list(ctx.scratch.setdefault("drops", []))
+        # THIS RUN's failures, keyed by address so a retry replaces the previous verdict instead
+        # of appending a second copy of it. The old list appended blindly, so an address that
+        # failed three times appeared three times in the receipt.
+        failures: dict[str, str] = {}
         for a in who:
             if a in sent:
                 continue
@@ -1019,10 +1053,33 @@ def build(reg: Registry, db) -> None:
                 drops.append({"to": a, "link": link})
                 ctx.scratch["drops"] = drops
             except Exception as e:  # noqa: BLE001 — one bad address never blocks the rest
-                ctx.scratch.setdefault("failed", []).append(f"{a}: {type(e).__name__}")
+                failures[a] = f"{a}: {type(e).__name__}: {e}"[:240]
+            # ONE HEARTBEAT PER PERSON. Everything above costs a share mint, a scaffold mint and
+            # an SMTP round trip, so a full room runs past the 90 s lease; without this the
+            # reclaimer hands the reaction to a second worker that starts from an empty `sent`
+            # and mails the whole room again, with a second share token each. `checkpoint` both
+            # renews the lease and persists what has been done — see `flows/loop.py`.
+            ctx.checkpoint()
+        failed = [failures[a] for a in sorted(failures)]
+        ctx.scratch["failed"] = failed
+        # A FAILED SEND IS RETRIED, not forgotten. It used to be neither: the address entered
+        # neither `sent` nor `drops`, the step returned `Done`, and one transient SMTP 421
+        # removed a person from a meeting they had attended — permanently and silently, because
+        # `Done` is what "the report went out" looks like from every consumer.
+        #
+        # ...and it is retried a BOUNDED number of times, then given up on OUT LOUD. Raising
+        # until the engine's own ceiling would fail the whole reaction, and `drop_to_attendees`
+        # runs after this step: one dead address in a twenty-person invite would then cost the
+        # other nineteen the record on their desk. The ceiling keeps both promises.
+        attempt = int(getattr(ctx.reaction, "attempt", 1) or 1)
+        if failed and attempt < ATTENDEE_MAIL_ATTEMPTS:
+            raise StepError(
+                f"could not mail {len(failed)} of {len(who)} attendee(s) for meeting {mid} "
+                f"(attempt {attempt} of {ATTENDEE_MAIL_ATTEMPTS}): " + " · ".join(failed)
+                + f". Mailed: {', '.join(sent) or 'nobody'}.", retryable=True)
         return Done({"sent": len(sent), "followup": "on", "to": sent, "meeting_id": mid,
                      "drops": drops,               # what drop_to_attendees writes, per person
-                     "failed": ctx.scratch.get("failed", [])})
+                     "failed": failed})
 
     # ── the drop — one meeting entity into each attendee's own workspace (PRD decision 20) ──
     def _yaml(value: str) -> str:
@@ -1056,7 +1113,7 @@ def build(reg: Registry, db) -> None:
         (F58). An id that does not match the file it is in is worse than no id: every consumer
         that resolves one from the other silently misses."""
         roster = ", ".join(_yaml(a) for a in participants)
-        return "\n".join([
+        lines = [
             "---",
             "type: meeting",
             f"id: {entity_id}",
@@ -1073,11 +1130,15 @@ def build(reg: Registry, db) -> None:
             "",
             (report or "").strip(),
             "",
-            "---",
-            "",
-            f"Open the meeting: {link}",
-            "",
-        ])
+        ]
+        # NO LINK, NO LINE. Since the drop room is the invite rather than the mailing list, a
+        # person who was not mailed has no share capability of their own — and a trailer reading
+        # "Open the meeting: " with nothing after it is a broken affordance, while somebody
+        # else's link would be the one thing a share token exists to prevent. They get the
+        # artefact, in full, and no button.
+        if str(link or "").strip():
+            lines += ["---", "", f"Open the meeting: {link}", ""]
+        return "\n".join(lines)
 
     def _index_entry(current: str, title: str, filename: str, day: str) -> str:
         """`kg/entities/meeting/index.md` with this meeting listed once.
@@ -1192,7 +1253,20 @@ def build(reg: Registry, db) -> None:
                              provenance={"flow": "post_meeting", "step": "drop_to_attendees",
                                          "reaction_id": str(getattr(ctx, "reaction_id", "") or ""),
                                          "minted_by": str(uid)})
-        room = [{"to": organizer, "link": organiser_link}] + list(att.get("drops") or [])
+        # THE ROOM IS THE INVITE, NOT THE MAILING LIST. This used to be
+        # `[organiser] + att["drops"]`, and `drops` is empty whenever the attendee MAIL was
+        # switched off (`attendee_followup`) or every attendee is outside the organiser's domain
+        # (PRD §16.2's allow-list, which governs mail and nothing else). A preference about mail
+        # was therefore silently a preference about whose desk the meeting reached — while
+        # `room_order` had already MOUNTED those same desks to write the report. Decision 20 says
+        # the drop goes into every attendee's workspace, creating it if absent; decision 22a says
+        # the organiser's always does. `drops` now supplies one thing only: that person's own
+        # share link, where they were mailed one.
+        links = {str((d or {}).get("to") or "").strip().lower(): str((d or {}).get("link") or "")
+                 for d in (att.get("drops") or [])}
+        room = [{"to": organizer, "link": organiser_link}]
+        room += [{"to": a, "link": links.get(a, "")}
+                 for a in roster if a != organizer.lower()]
         entity_id = filename[:-3] if filename.endswith(".md") else filename
         body = _drop_entity(title=title, day=day, entity_id=entity_id, date_prose=date_prose,
                             organizer=organizer, participants=roster, report=report, link="")
@@ -1218,6 +1292,7 @@ def build(reg: Registry, db) -> None:
                 failed.append(f"{a}: {type(e).__name__}: {e}"[:240])
             ctx.scratch["dropped"] = done
             ctx.scratch["drop_failed"] = failed
+            ctx.checkpoint()      # same shape as the fan-out above: N round trips, one lease
         if done:
             return Done({"dropped": len(done), "to": done, "failed": failed,
                          "entity": entity_path, "meeting_id": mid,

--- a/core/flows/src/flows_steps/mailtext.py
+++ b/core/flows/src/flows_steps/mailtext.py
@@ -185,6 +185,12 @@ def render(name: str, uid: str, values: Optional[dict] = None) -> tuple[str, str
             "mailbox": mailbox_address(), **(values or {})}
     for key, val in fill.items():
         token = re.compile(r"\{\{\s*" + re.escape(key) + r"\s*\}\}")
-        subject = token.sub(str(val), subject)
-        body = token.sub(str(val), body)
+        # A FUNCTION, NOT A STRING. `re.sub`'s replacement is escape-processed: a value containing
+        # `\1` or `\g` is read as a group reference and a value ending in a backslash raises
+        # `re.error` — and these values carry the ICS `SUMMARY`, which a human types into a
+        # calendar. One backslash in a meeting title raised out of `email_attendees`' try block
+        # and took the whole room's fan-out with it, forever, since the retry hit the same title.
+        # A lambda replacement is substituted literally; `_m` is the match nobody needs.
+        subject = token.sub(lambda _m, v=val: str(v), subject)
+        body = token.sub(lambda _m, v=val: str(v), body)
     return subject, body

--- a/core/flows/tests/test_attendee_drop.py
+++ b/core/flows/tests/test_attendee_drop.py
@@ -226,15 +226,26 @@ def test_the_organiser_is_dropped_on_even_when_their_minutes_mail_was_off(monkey
         store.of("anna@bank.test")
 
 
-def test_the_organiser_is_dropped_on_even_when_the_fan_out_mailed_nobody(monkeypatch):
-    """A meeting with no inside-domain attendee still happened to its organiser."""
+def test_the_whole_room_is_dropped_on_even_when_the_fan_out_mailed_nobody(monkeypatch):
+    """A meeting with no mail still happened — to the organiser AND to everyone in the room.
+
+    THIS ASSERTION WAS INVERTED UNTIL 2026-09-02 (R-B20). It read
+    `out.result["to"] == ["anna@bank.test"]` and pinned the defect: the drop built its room from
+    `email_attendees`' `drops`, so switching the attendee MAIL off — or simply having every
+    attendee outside the organiser's domain, which is PRD §16.2's default — also switched off the
+    attendee DESK DROP. A guard on the mail door was closing the desk door, and the test said that
+    was correct. Decision 20 puts the meeting entity in every attendee's workspace, creating it if
+    absent; decision 22a adds that the organiser's always receives it. The mail allow-list governs
+    the mail. What `drops` still governs is the LINK, and only that (see the test below)."""
     store = Store()
     reg = _rig(monkeypatch, store)
     prior = dict(PRIOR, email_attendees={"sent": 0, "drops": [], "skipped": "opted out"})
     out = reg.steps["drop_to_attendees"](_ctx(dict(REFS), prior))
 
-    assert out.result["to"] == ["anna@bank.test"]
-    assert store.of("ben@bank.test") is None
+    assert out.result["to"] == EVERYONE
+    assert store.of("ben@bank.test") is not None
+    # ...and with no mail, nobody was handed a share capability, so nobody's copy carries a button
+    assert "Open the meeting:" not in store.of("ben@bank.test")
 
 
 def test_no_report_means_no_drop_at_all(monkeypatch):

--- a/core/flows/tests/test_delivery_guarantees.py
+++ b/core/flows/tests/test_delivery_guarantees.py
@@ -1,0 +1,417 @@
+"""DELIVERY: the report goes out ONCE, to EVERYONE, and we know when it did not.
+
+Seven findings of the 2026-09-02 line-vs-main review sit under one sentence, and each breaks a
+different clause of it:
+
+  ONCE      R-B01  the attendee fan-out can outlive its 90 s lease, which has no renewal; the
+                   reclaiming worker restarts from an empty scratch, so a 20-person room is mailed
+                   twice, with two share tokens each.
+  EVERYONE  R-B20  the desk drop builds its room from `email_attendees`' `drops`, which is empty
+                   whenever the MAIL was switched off or every attendee is cross-domain — a guard
+                   on the mail door closing the desk door.
+            R-B23  a per-attendee send failure loses that person the mail permanently: the address
+                   enters neither `sent` nor `drops`, and nothing ever retries it.
+            R-B07  a backslash in the meeting title raises inside `re.sub`'s REPLACEMENT, so the
+                   whole fan-out for that room dies and retries into the same error forever.
+  WE KNOW   R-B03  claimed `MAX_ATTEMPTS` is unreachable for a step mixing `Wait` and `StepError`.
+                   IT IS NOT — the two tests under that heading are the evidence, and they PASS on
+                   the code the review read. A `Wait` is +1 (claim) then -1 (the Wait branch), so
+                   it is net zero; only an error-ending claim keeps its increment, and `attempt`
+                   therefore climbs by exactly one per `StepError`. Observed at `_retry_or_fail`
+                   for a step polling three times per dispatch: 1, 2, 3, 4, 5, 6 — backoff 5 s,
+                   30 s, 120 s, 600 s, 600 s, 600 s — then `failed`. The tests stay as pins.
+            R-B26  nothing ever wrote `effect_receipt.state = 'failed'`, so a permanently failed
+                   `email_minutes` renders as `in_flight` and the timeline module's own promise —
+                   "the one thing an agent must not do is talk about a report it never delivered"
+                   — is not kept.
+            R-B21  the note path is stamped at three moments with a wall-clock fallback, so the
+                   mail's path and the desk's path differ by minutes and the Minutes tab reads
+                   "No page here yet". This is F58 re-opening on a second route.
+
+No network, no sleeps: the engine tests run on the sqlite rig, the step tests call the step
+directly with the refs its flow would hand it.
+"""
+from __future__ import annotations
+
+import json
+
+import flows_defs.production as production
+import flows_steps.mailtext as mailtext
+import flows_steps.meeting as mt_mod
+import flows_steps.notify as notify_mod
+import pytest
+from flows import (Done, EventType, FakeClock, Reaction, Registry, SqliteDB, StepCtx, StepError,
+                   Wait, admit, escalate, reclaim, tick)
+from flows.loop import BACKOFF_S, LEASE_S, MAX_ATTEMPTS
+
+from test_link_loop import FakeChannel, FakeScaffolds, _StubDB
+
+
+# ── the rig ──────────────────────────────────────────────────────────────────────────────────
+class _Flow:
+    """The governing Flow, reduced to the one thing a step reads off it."""
+
+    def __init__(self, **params):
+        self._p = params
+
+    def param(self, key, default=None):
+        return self._p.get(key, default)
+
+
+def _ctx(refs: dict, prior: dict | None = None, scratch: dict | None = None, flow=None,
+         attempt: int = 1) -> StepCtx:
+    r = Reaction("rid", "sid", "e", refs, "f", 1, "step", "running", attempt, 0.0, None, None, None)
+    return StepCtx(reaction=r, effect_key="rid:step", prior=prior or {}, clock_now=1_700_000_000.0,
+                   scratch=scratch if scratch is not None else {}, flow=flow)
+
+
+REFS = {"uid": "7", "organizer": "anna@bank.test", "title": "Pilot sync", "meeting_id": 97,
+        "start": 1_700_003_600.0,          # 2023-11-14 23:13:20 UTC
+        "participants": ["anna@bank.test", "ben@bank.test", "cara@bank.test", "out@other.test"]}
+REPORT = "## Decided\n- ship it\n"
+PRIOR = {"process_meeting": {"report": REPORT, "group": "", "room_read": []}}
+
+
+def _mail_rig(monkeypatch, *, fail_for=(), title=None):
+    """`email_attendees` with agent-api, admin-api, the share mint and SMTP all replaced."""
+    reg = Registry()
+    production.build(reg, _StubDB())
+    ch = FakeChannel()
+    sent_to: list[str] = []
+
+    class _Ch:
+        name = "fake"
+
+        def send(self, to, subject, body, *, link=None, in_reply_to=None):
+            sent_to.append(to)
+            if to in fail_for:
+                raise OSError("SMTP 421 — try again later")
+            return ch.send(to, subject, body, link=link, in_reply_to=in_reply_to)
+
+    notify_mod.use(_Ch())
+    monkeypatch.setattr(production, "mint_scaffold", FakeScaffolds())
+    monkeypatch.setattr(production, "ws_file",
+                        lambda uid, path, slug=None: "# Acme Bank" if path == "README.md" else None)
+    monkeypatch.setattr(mailtext, "ws_file", lambda uid, path, slug=None: None)
+    monkeypatch.setattr(production, "setting",
+                        lambda uid, key: "" if key == "timezone" else True)
+    monkeypatch.setattr(production.mt, "meeting_row", lambda uid, mid, native=None: {"id": 97})
+    monkeypatch.setattr(production.mt, "mint_transcript_share",
+                        lambda uid, m, email, expires_in_sec=30 * 86400: f"97.tok-{email}")
+    return reg, ch, sent_to
+
+
+def teardown_function():
+    notify_mod.use(None)
+
+
+# ══ ONCE ════════════════════════════════════════════════════════════════════════════════════
+# R-B01 · the fan-out renews its own lease and persists what it has done, per person.
+def test_the_engine_gives_a_step_a_checkpoint_that_renews_the_lease_and_saves_scratch():
+    """The whole defect in one assertion: a step that runs LONGER THAN THE LEASE must be able to
+    say so. Without this, `reclaim` hands the reaction to a second worker while the first is still
+    mailing people, and the second starts from an EMPTY scratch — every attendee already mailed is
+    mailed again, with a second share token."""
+    db, clock, reg = SqliteDB(), FakeClock(), Registry()
+    seen: list[tuple[float, dict]] = []
+
+    @reg.step
+    def slow(ctx: StepCtx):
+        for i in range(3):
+            clock._t += 60.0                       # 180 s total, against LEASE_S = 90
+            ctx.scratch.setdefault("done", []).append(i)
+            ctx.checkpoint()
+            row = db.execute("SELECT lease_until, scratch FROM reaction")[0]
+            seen.append((row[0], row[1]))
+        return Done({"ok": True})
+
+    reg.flow(name="slow_flow", version=1, on=EventType("t.slow"), steps=[slow])
+    admit(db, reg, clock, source_event_id="s1", event_type="t.slow", subject_refs={})
+    assert tick(db, reg, clock) is True
+
+    # the lease was always in the future — the reclaimer never had a window
+    assert [lease for lease, _ in seen] == pytest.approx(
+        [1_000_060.0 + LEASE_S, 1_000_120.0 + LEASE_S, 1_000_180.0 + LEASE_S])
+    # ...and each person's progress was DURABLE before the next one was attempted
+    assert [json.loads(scratch) for _, scratch in seen] == [
+        {"done": [0]}, {"done": [0, 1]}, {"done": [0, 1, 2]}]
+
+
+def test_the_attendee_fan_out_checkpoints_once_per_person(monkeypatch):
+    """Not "the mechanism exists" but "the fan-out uses it" — the review's finding is about this
+    loop, whose per-person cost is a share mint plus a scaffold mint plus an SMTP round trip."""
+    reg, ch, _ = _mail_rig(monkeypatch)
+    ctx = _ctx(dict(REFS), PRIOR)
+    beats: list[int] = []
+    ctx.checkpoint = lambda: beats.append(1)
+
+    out = reg.steps["email_attendees"](ctx)
+    assert isinstance(out, Done) and out.result["sent"] == 2      # ben + cara, out@ is cross-domain
+    assert len(beats) == 2
+
+
+# ══ EVERYONE ════════════════════════════════════════════════════════════════════════════════
+# R-B20 · the drop room is the INVITE ROSTER; `drops` supplies the link and nothing else.
+class _Store:
+    def __init__(self):
+        self.files: dict[tuple[str, str], str] = {}
+        self.writes: list[tuple[str, str]] = []
+
+    def uid_of(self, email):
+        return "uid-" + email.split("@")[0]
+
+    def init(self, uid):
+        return None
+
+    def write(self, uid, path, content):
+        self.writes.append((uid, path))
+        self.files[(uid, path)] = content
+
+    def read(self, uid, path, slug=None):
+        return None if slug == "_global" else self.files.get((uid, path))
+
+    def dropped_to(self) -> set[str]:
+        return {uid for uid, path in self.writes if path.endswith(".md") and "index" not in path}
+
+
+def _drop_rig(monkeypatch, store):
+    reg = Registry()
+    production.build(reg, _StubDB())
+    monkeypatch.setattr(production, "ensure_platform_user", store.uid_of)
+    monkeypatch.setattr(production, "ws_file", store.read)
+    monkeypatch.setattr(production.ag, "workspace_init", store.init)
+    monkeypatch.setattr(production.ag, "workspace_write", store.write)
+    monkeypatch.setattr(production, "setting", lambda uid, key: "")
+    monkeypatch.setattr(production, "mint_scaffold", FakeScaffolds())
+    return reg
+
+
+def test_the_desk_drop_reaches_the_whole_room_even_when_the_mail_went_to_nobody(monkeypatch):
+    """`email_attendees` returns `drops: []` when the follow-up is switched off or when every
+    attendee is outside the organiser's domain. Decision 22's "the drop lands on it regardless"
+    then held for the organiser alone, while `room_order` had already READ those same desks."""
+    store = _Store()
+    reg = _drop_rig(monkeypatch, store)
+    prior = dict(PRIOR, email_attendees={"sent": 0, "followup": "off", "to": [], "drops": [],
+                                         "skipped": "opted out"})
+    out = reg.steps["drop_to_attendees"](_ctx(dict(REFS), prior))
+
+    assert isinstance(out, Done)
+    assert store.dropped_to() == {"uid-anna", "uid-ben", "uid-cara", "uid-out"}
+    assert out.result["dropped"] == 4
+
+
+def test_drops_supply_the_link_and_only_the_link(monkeypatch):
+    """A person who WAS mailed carries their own share link into their copy; a person who was not
+    still gets the artefact, with no link rather than somebody else's."""
+    store = _Store()
+    reg = _drop_rig(monkeypatch, store)
+    prior = dict(PRIOR, email_attendees={
+        "sent": 1, "meeting_id": 97, "to": ["ben@bank.test"],
+        "drops": [{"to": "ben@bank.test", "link": "http://ui/?s=ben"}]})
+    reg.steps["drop_to_attendees"](_ctx(dict(REFS), prior))
+
+    ben = store.files[("uid-ben", [p for _, p in store.writes if "index" not in p][0])]
+    out = store.files[("uid-out", [p for _, p in store.writes if "index" not in p][0])]
+    assert "Open the meeting: http://ui/?s=ben" in ben
+    assert "Open the meeting:" not in out          # no link is not somebody else's link
+    assert REPORT.strip() in out                   # ...but the artefact is all there
+
+
+# R-B23 · a send failure is retried, and when the retries are spent it is said out loud.
+def test_one_unreachable_address_is_retried_rather_than_silently_dropped(monkeypatch):
+    """Today the address enters neither `sent` nor `drops` and the step returns `Done`: one
+    transient SMTP 421 permanently removes a person from a meeting they attended."""
+    reg, ch, sent_to = _mail_rig(monkeypatch, fail_for={"cara@bank.test"})
+    scratch: dict = {}
+    with pytest.raises(StepError) as e:
+        reg.steps["email_attendees"](_ctx(dict(REFS), PRIOR, scratch=scratch))
+
+    assert e.value.retryable is True
+    assert "cara@bank.test" in str(e.value)
+    # the reachable attendee was mailed FIRST and is remembered, so the retry does not repeat it
+    assert scratch["sent"] == ["ben@bank.test"]
+
+
+def test_the_retry_does_not_re_mail_anybody_and_gives_up_loudly(monkeypatch):
+    """The ceiling is the point: a permanently bad address must not hold the room's desk drop
+    hostage forever. When the attempts are spent the step completes and names who was lost."""
+    reg, ch, sent_to = _mail_rig(monkeypatch, fail_for={"cara@bank.test"})
+    scratch = {"sent": ["ben@bank.test"], "drops": [{"to": "ben@bank.test", "link": "x"}]}
+    out = reg.steps["email_attendees"](
+        _ctx(dict(REFS), PRIOR, scratch=scratch, attempt=production.ATTENDEE_MAIL_ATTEMPTS))
+
+    assert isinstance(out, Done)
+    assert sent_to == ["cara@bank.test"]                       # ben was not mailed twice
+    assert out.result["sent"] == 1
+    assert any("cara@bank.test" in f for f in out.result["failed"])
+
+
+# R-B07 · a backslash in the title must not kill the fan-out.
+def test_a_backslash_in_a_value_does_not_raise_inside_the_replacement(monkeypatch):
+    """`re.sub`'s REPLACEMENT is escape-processed, so a value containing `\\1`, `\\g` or a trailing
+    backslash raises or corrupts — and `values` carries the ICS `SUMMARY`, which a person types."""
+    monkeypatch.setattr(mailtext, "ws_file", lambda uid, path, slug=None: None)
+    monkeypatch.setattr(mailtext, "company_name", lambda uid: "Acme Bank")
+    monkeypatch.setattr(mailtext, "mailbox_address", lambda: "vexa@acme.test")
+    monkeypatch.setitem(mailtext.DEFAULTS, "_backslash_probe",
+                        "subject: {{meeting}}\n---\nabout {{meeting}}")
+    title = r"Q3 planning \1 (backup C:\temp) \\"
+
+    subject, body = mailtext.render("_backslash_probe", "7", {"meeting": title})
+    assert subject == title
+    assert body == f"about {title}"
+
+
+def test_a_backslash_in_a_meeting_title_still_mails_the_whole_room(monkeypatch):
+    """The step-level version of the same defect: `email_attendees` raised out of its `try` and the
+    whole fan-out retried into the same error forever."""
+    reg, ch, sent_to = _mail_rig(monkeypatch)
+    refs = dict(REFS, title=r"Q3 planning \1 (backup C:\temp)")
+    out = reg.steps["email_attendees"](_ctx(refs, PRIOR))
+
+    assert isinstance(out, Done) and out.result["sent"] == 2
+    assert refs["title"] in ch.sent[0]["subject"] or refs["title"] in ch.sent[0]["body"]
+
+
+# ══ WE KNOW ═════════════════════════════════════════════════════════════════════════════════
+# R-B03 · a step that polls AND fails still reaches the ceiling.
+def test_a_step_that_waits_and_errors_by_turns_still_reaches_the_dead_letter():
+    """R-B03, REFUSED — and this is the refusal, written as a pin rather than as a paragraph.
+
+    The review read the two statements (`claim` does `attempt + 1`, the `Wait` branch does
+    `attempt - 1`) and concluded `r.attempt` is "always 1 at `_retry_or_fail`". It is not: a poll
+    is +1 then -1, which is NET ZERO, while an error-ending claim keeps its increment. `attempt`
+    therefore climbs by exactly one per `StepError` no matter how many polls are interleaved, the
+    backoff walks the whole `BACKOFF_S` ladder, and the sixth failure is terminal.
+
+    `feedback_turn` is the step the finding names, and it cannot loop either for a second reason:
+    `dispatched` and `t0` live in scratch, which survives a `StepError`, so the retries after the
+    first "agent silent for 10min" re-dispatch nothing and raise immediately.
+
+    Kept as a test because the property is worth pinning even though it already holds — the
+    counter is shared between two branches, which is the shape that eventually does break."""
+    db, clock, reg = SqliteDB(), FakeClock(), Registry()
+    calls = {"n": 0}
+
+    # THREE polls per dispatch, then the failure — the real shape. `feedback_turn` polls the agent
+    # every 10 minutes and raises only when the collect itself fails, so with one decrement per
+    # poll `attempt` was back at 1 by the time any error reached `_retry_or_fail`.
+    @reg.step
+    def poll_then_fail(ctx: StepCtx):
+        calls["n"] += 1
+        if calls["n"] % 4:
+            return Wait(seconds=600)
+        raise StepError("the agent is not answering")
+
+    reg.flow(name="sick", version=1, on=EventType("t.sick"), steps=[poll_then_fail])
+    admit(db, reg, clock, source_event_id="s1", event_type="t.sick", subject_refs={})
+
+    for _ in range(600):
+        reclaim(db, clock)
+        if tick(db, reg, clock):
+            continue
+        nxt = db.execute("SELECT MIN(next_run_at) FROM reaction "
+                         "WHERE status IN ('admitted','retrying')")[0][0]
+        if nxt is None:
+            break
+        clock._t = max(clock._t, nxt)
+    else:
+        raise AssertionError("the reaction never reached a terminal state — MAX_ATTEMPTS is "
+                             "unreachable for a step that mixes Wait and StepError")
+
+    status, reason = db.execute("SELECT status, reason FROM reaction")[0]
+    assert status == "failed"
+    assert "the agent is not answering" in reason
+    # a Wait still costs nothing: exactly MAX_ATTEMPTS failures, not fewer
+    assert calls["n"] == MAX_ATTEMPTS * 4          # three polls per attempt, six attempts
+
+
+def test_a_wait_still_burns_no_attempt():
+    """The other half of the same rule — the reason the decrement existed at all. A step that only
+    polls must be able to poll indefinitely."""
+    db, clock, reg = SqliteDB(), FakeClock(), Registry()
+    calls = {"n": 0}
+
+    @reg.step
+    def only_polls(ctx: StepCtx):
+        calls["n"] += 1
+        if calls["n"] < 20:
+            return Wait(seconds=10)
+        return Done({"ok": True})
+
+    reg.flow(name="patient", version=1, on=EventType("t.wait"), steps=[only_polls])
+    admit(db, reg, clock, source_event_id="s1", event_type="t.wait", subject_refs={})
+    for _ in range(60):
+        if not tick(db, reg, clock):
+            nxt = db.execute("SELECT MIN(next_run_at) FROM reaction "
+                             "WHERE status IN ('admitted','retrying')")[0][0]
+            if nxt is None:
+                break
+            clock._t = max(clock._t, nxt)
+    assert db.execute("SELECT status FROM reaction")[0][0] == "done"
+    assert calls["n"] == 20
+
+
+# R-B26 · the terminal branch writes the receipt it promised.
+def test_a_permanently_failed_step_marks_its_own_receipt_failed():
+    """`flows_timeline` turns `state = 'failed'` into a `reaction.failed` event and says the one
+    thing an agent must not do is talk about a report it never delivered. Nothing wrote that state,
+    so a permanently failed `email_minutes` rendered as `in_flight` forever."""
+    db, clock, reg = SqliteDB(), FakeClock(), Registry()
+
+    @reg.step
+    def never_works(ctx: StepCtx):
+        raise StepError("admin-api refused the mint", retryable=False)
+
+    reg.flow(name="doomed", version=1, on=EventType("t.doom"), steps=[never_works])
+    admit(db, reg, clock, source_event_id="s1", event_type="t.doom", subject_refs={})
+    tick(db, reg, clock)
+
+    assert db.execute("SELECT status FROM reaction")[0][0] == "failed"
+    state, result = db.execute("SELECT state, result FROM effect_receipt")[0]
+    assert state == "failed"
+    assert "admin-api refused the mint" in (result or "")
+
+
+def test_a_confirmed_receipt_is_never_re_marked_failed():
+    """The guard on the fix: an effect that HAPPENED stays confirmed whatever the reaction does
+    afterwards, or a retry of a later step would rewrite the mail's own history."""
+    db, clock, reg = SqliteDB(), FakeClock(), Registry()
+
+    @reg.step
+    def works(ctx: StepCtx):
+        return Done({"message_id": "<m@x>"})
+
+    @reg.step
+    def dies(ctx: StepCtx):
+        raise StepError("nope", retryable=False)
+
+    reg.flow(name="half", version=1, on=EventType("t.half"), steps=[works, dies])
+    admit(db, reg, clock, source_event_id="s1", event_type="t.half", subject_refs={})
+    for _ in range(4):
+        tick(db, reg, clock)
+
+    states = dict(db.execute("SELECT step, state FROM effect_receipt"))
+    assert states == {"works": "confirmed", "dies": "failed"}
+
+
+# R-B21 · the meeting's stamp is computed ONCE per reaction.
+def test_the_note_path_is_stamped_once_even_when_the_row_lookup_recovers(monkeypatch):
+    """`_meeting_stamp` falls back to the wall clock when there is no `refs.start` and the row
+    lookup fails — the documented case for a `meeting.completed` admitted through `POST /events`.
+    The path is then computed at THREE moments (the scaffold's mint, the drop, the frontmatter),
+    and the mail's path and the desk's path differ: the Minutes tab resolves to a file nothing
+    wrote and shows "No page here yet" (F58, on a second route)."""
+    monkeypatch.setattr(production, "setting", lambda uid, key: "")
+    answers = [None, 1_700_090_000.0]      # agent-api was down, then it came back
+
+    def flaky_start(uid, mid, native=None):
+        return answers.pop(0) if answers else 1_700_090_000.0
+
+    monkeypatch.setattr(mt_mod, "meeting_start", flaky_start)
+    ctx = _ctx({"uid": "7", "title": "Pilot sync", "meeting_id": 97}, scratch={})
+
+    first = production._note_path(ctx, "7", "Pilot sync")
+    second = production._note_path(ctx, "7", "Pilot sync")
+    assert first == second, "the mail's path and the desk's path must be one string"

--- a/core/flows/tests/test_delivery_guarantees.py
+++ b/core/flows/tests/test_delivery_guarantees.py
@@ -24,6 +24,11 @@ different clause of it:
                    `email_minutes` renders as `in_flight` and the timeline module's own promise —
                    "the one thing an agent must not do is talk about a report it never delivered"
                    — is not kept.
+            R-B18  the prompt "hot reload" did not exist. `prompt_for` read the flow's `prompts`
+                   param and nothing else, while this file asserted three screens down that it
+                   "reads a live `_global` override before the baked file" and the decision-22
+                   detector told the operator to go and check that override when it fired — a path
+                   the code never opened.
             R-B21  the note path is stamped at three moments with a wall-clock fallback, so the
                    mail's path and the desk's path differ by minutes and the Minutes tab reads
                    "No page here yet". This is F58 re-opening on a second route.
@@ -415,3 +420,61 @@ def test_the_note_path_is_stamped_once_even_when_the_row_lookup_recovers(monkeyp
     first = production._note_path(ctx, "7", "Pilot sync")
     second = production._note_path(ctx, "7", "Pilot sync")
     assert first == second, "the mail's path and the desk's path must be one string"
+
+
+# ══ R-B18 · the live prompt override, asserted for as long as it did not exist ═══════════════
+def _prompt_ctx(refs: dict, flow=None) -> StepCtx:
+    return _ctx(refs, flow=flow)
+
+
+def test_an_admins_global_prompt_override_is_what_the_turn_is_dispatched(monkeypatch):
+    """`mailtext.render` reads `_global/mail/<name>.md` on every send; this is the same contract
+    one screen away, and it was asserted in two places and performed in none."""
+    monkeypatch.setattr(production, "ws_file",
+                        lambda uid, path, slug=None:
+                        "ADMIN KICK" if (slug == "_global" and path == "prompts/x.md") else None)
+
+    assert production.prompt_for(_prompt_ctx({"uid": "7"}), "x.md", "BAKED") == "ADMIN KICK"
+
+
+def test_the_override_is_re_read_every_turn_so_an_edit_needs_no_restart(monkeypatch):
+    """The "hot" half. The baked default is read at module IMPORT (`PROCESS_KICKOFF = _prompt(...)`)
+    — which is where the claim of a hot reload came from, and it was the only half that existed."""
+    live = {"prompts/x.md": "FIRST"}
+    monkeypatch.setattr(production, "ws_file",
+                        lambda uid, path, slug=None: live.get(path) if slug == "_global" else None)
+    ctx = _prompt_ctx({"uid": "7"})
+
+    assert production.prompt_for(ctx, "x.md", "BAKED") == "FIRST"
+    live["prompts/x.md"] = "SECOND"                       # the admin edits between turns
+    assert production.prompt_for(ctx, "x.md", "BAKED") == "SECOND"
+
+
+def test_the_flow_param_still_wins_over_the_live_override(monkeypatch):
+    """Order unchanged where it already worked: a flow submitted with its own `prompts` is the most
+    specific statement there is, and an admin's file does not override one flow's own definition."""
+    monkeypatch.setattr(production, "ws_file", lambda uid, path, slug=None: "ADMIN KICK")
+    ctx = _prompt_ctx({"uid": "7"}, flow=_Flow(prompts={"x.md": "FLOW KICK"}))
+
+    assert production.prompt_for(ctx, "x.md", "BAKED") == "FLOW KICK"
+
+
+def test_an_emptied_or_unreadable_override_falls_back_to_the_baked_prompt(monkeypatch):
+    """Both fail-soft paths. An admin who cleared the file did not mean "dispatch a turn with no
+    instructions", and agent-api being down is not a reason to dispatch one either."""
+    monkeypatch.setattr(production, "ws_file", lambda uid, path, slug=None: "   \n\n")
+    assert production.prompt_for(_prompt_ctx({"uid": "7"}), "x.md", "BAKED") == "BAKED"
+
+    def boom(uid, path, slug=None):
+        raise OSError("agent-api unreachable")
+
+    monkeypatch.setattr(production, "ws_file", boom)
+    assert production.prompt_for(_prompt_ctx({"uid": "7"}), "x.md", "BAKED") == "BAKED"
+
+
+def test_with_no_uid_there_is_nothing_to_read_and_the_baked_prompt_ships(monkeypatch):
+    """`_global` is read AS somebody — the refs carry the uid. A step with none (the pre-`ensure_user`
+    part of a flow) must not raise looking for an override."""
+    monkeypatch.setattr(production, "ws_file",
+                        lambda uid, path, slug=None: pytest.fail("read _global with no uid"))
+    assert production.prompt_for(_prompt_ctx({}), "x.md", "BAKED") == "BAKED"

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -3883,6 +3883,18 @@ def bot_stop(meeting_url: str, token: str = "") -> str:
     if not platform:
         return json.dumps({"error": mid})
     st, r = _gw_http(uid, "DELETE", f"/bots/{platform}/{mid}")
+    # A MEETING THAT IS OVER IS AN ANSWER, NOT A FAILURE (F104). The gateway has no bot to stop
+    # once the meeting has ended, and this used to report that as `{"stopped": false,
+    # "status": 404}` — which reads exactly like a transient error, so a caller retries it. On
+    # 2026-09-02 the post-meeting agent called this four times in one turn against a meeting that
+    # had already finished. There is nothing to retry: say the state, and say that the thing the
+    # caller actually wants (the transcript) is there.
+    if st == 404:
+        return json.dumps({"stopped": False, "status": st, "state": "no bot in this meeting",
+                           "note": "nothing to stop — the meeting is over or the bot already "
+                                   "left. This is final, not a transient failure; do not retry. "
+                                   "meeting_transcript(meeting_url) returns everything it "
+                                   "captured."})
     return json.dumps({"stopped": st == 200, "status": st,
                        "note": "meeting_transcript(meeting_url) still returns everything "
                                "captured up to now"})


### PR DESCRIPTION
Dispatches **7** (`flows-delivery`) and **10** (`transcript-truth`) of the
[2026-09-02 release backlog](https://github.com/DmitriyG228/biz/issues/452), plus R-B18 from
dispatch 11 and the two findings handed over mid-flight (F103, F104).

**COMMITMENTS IN THIS PR — none.** Code and tests only; nothing merged, deployed or sent.

## Rows closed

| row | symptom | change | proof |
|---|---|---|---|
| **R-B01** | the attendee fan-out has no lease renewal; the reclaiming worker restarts from empty scratch and mails a 20-person room twice, two share tokens each | `StepCtx.checkpoint()` — persists scratch **and** pushes the lease out, one call (`flows/loop.py:145-168`, `flows/model.py:66-90`); called per person in `email_attendees` and per desk in `drop_to_attendees` | `test_delivery_guarantees.py` ×2 |
| **R-B07** | a backslash in a meeting title raises inside `re.sub`'s **replacement**, killing the whole room's fan-out forever | lambda replacement (`flows_steps/mailtext.py:186-196`) | ×2 |
| **R-B20** | switching off the attendee **mail** silently switched off the attendee **desk drop** | the drop room is the invite roster; `drops` supplies the link and only the link (`flows_defs/production.py`, `drop_to_attendees`) | ×2 + one inverted assertion corrected |
| **R-B21** | `note_path` stamped at three moments, wall-clock fallback → the mail's path and the desk's path differ and the Minutes tab reads "No page here yet" (**F58**, second route) | `_meeting_stamp` computed once per reaction, stashed in scratch | ×1 |
| **R-B23** | a per-attendee send failure lost that person the mail permanently — the address entered neither `sent` nor `drops` and the step returned `Done` | retried, bounded by the step's own `ATTENDEE_MAIL_ATTEMPTS = 3`, then completed with the address named in `failed` | ×2 |
| **R-B26** | nothing ever wrote `effect_receipt.state = 'failed'`, so a permanently failed `email_minutes` renders as `in_flight` | `receipts.fail()` from the terminal branch of `_retry_or_fail`; only a **reserved** receipt is failed | ×2 |
| **R-B18** | the `_global` prompt override was asserted in two places and performed in none — including in the message an operator gets when the decision-22 detector fires | `prompt_for` reads `_global/prompts/<name>` per call, between the flow param and the baked default; both claims corrected | ×5 |
| **R-C04** | the deleted inference pipeline still rewrote every transcript line (`Entropic`→`Anthropic`, `Cloud Code`→`Claude Code`) with no indication, in the artefact a pilot treats as the record | `cleanTranscriptText` removed from the seven sites that render a person's words | ×3 |
| **F103** | every completed meeting failed in `process_meeting` — **two** writers committing to the organiser's desk | mount narrowing + the write-back and README refresh both refuse the subject's own desk while a room is open | ×11 |
| **F104** | the post-meeting agent called `bot_stop` four times against a meeting that was over | `bot_*` leaves the room toolbelt; `bot_stop` answers the state on a 404 | (in the 11) |

## R-B03 — refused, with the evidence kept as a test

The review found that `claim` does `attempt + 1` while the `Wait` branch does `attempt - 1`, and
concluded `r.attempt` is *"always 1 at `_retry_or_fail`"* — so `MAX_ATTEMPTS` is unreachable, the
backoff never leaves 5 s, and `feedback_turn` re-dispatches forever.

**It is reachable.** A poll is +1 then −1, which is net zero; only an error-ending claim keeps its
increment, so `attempt` climbs by exactly one per `StepError` however many polls are interleaved.
Measured for a step polling three times per dispatch, at `_retry_or_fail`:

```
attempts seen: 1, 2, 3, 4, 5, 6     backoff 5s · 30s · 120s · 600s · 600s · 600s → failed
```

`feedback_turn` cannot loop for a second, independent reason: `dispatched` and `t0` live in
scratch, which survives a `StepError`, so every retry after the first "agent silent for 10min"
re-dispatches nothing and raises immediately.

Two tests keep the property pinned rather than deleting the finding —
`test_a_step_that_waits_and_errors_by_turns_still_reaches_the_dead_letter` carries the refusal as
its docstring. **The "no dead-letter state exists" half of that row was real**, and it is what
R-B26 fixes.

## What F103 turned out to be

Not one bug in two states. Both rehearsal states that reach a completed meeting
(`group-member`, `reply-pending`) died in `process_meeting`'s decision-22 detector, because two
different writers moved the organiser's desk HEAD:

1. the entity **write-back phase** (decision 24, "a phase of every turn") took its targets from
   every writable mount;
2. **`refresh_desk_readme`** (decision 26.4) runs on every turn and commits `README.md` whenever a
   section changed — so it moved HEAD with the phase doing nothing at all. That is the half that
   made the failure look intermittent.

Decision 24 and decision 26.4 are right everywhere else; decision 22 says *this* run writes no
desk. They met with nothing in between. Fixed at both roots, and at the mount level for group
meetings, rather than at the detector — the detector was correct and is untouched.

The signal is `VEXA_ROOM_MEETING`, stamped by `build_unit_env` when a room was authorised.
**Positive, not inferred**: a room whose other attendees have no desks yet resolves to zero
`role: "room"` mounts — the small-team case — so the mount shape would answer *"not a room run"*
on a run that is one.

## Notes for other branches

- ⚠️ **`deploy/dogfood/rig/vexa_control_mcp.py` is `core-mcp`'s file** (B1 splits it into
  `core/mcp/`). Eight lines inside `bot_stop`'s body; it should rebase onto the split cleanly.
- **`flows-authz`**: no overlap taken. This branch does not touch `flows_integrations/mailbox.py`,
  `flows_api.py`, `emailx.py`, `common.py`, or the intake steps. The one adjacency is
  `production.py`, where these hunks are `prompt_for`, `_meeting_stamp`/`_note_path`,
  `email_attendees` and `drop_to_attendees` — all outside `rsvp_accept`/`ack_by_email`.
- **`email_chat`'s `feedback_turn` has no room**, so F104's allow-set narrowing does not reach it.
  Flows dispatches it through the same `/api/chat` door a human chat uses, and there is no signal
  today that separates a machinery turn from a person's. Adding one is a body-asserted privilege
  and would need the internal-tier gate that `room` already has — a design call, not a smallest
  fix, so it is named here rather than guessed at.
- **`writeback_candidates` no longer targets `_system`/`_global`.** Forced by the narrowing (else
  `_system` would be the last root standing on a group-less room run, authoring entity pages into
  chats/sessions/settings), and it matches `desk_mounts`' own rule one screen up.

## Proof

| suite | result |
|---|---|
| `core/flows` | **273 passed**, 1 skipped (236 at base) |
| `core/agent` | **1589 passed** (1583 at base) |
| terminal vitest | **1147 passed**, 99 files |
| `pnpm typecheck` | clean |
| 13 static gates | all PASS |
| gate-script tests | 124/125 |
| pre-push gates | green (pushed without `--no-verify`) |

Two knowingly-red items, both **pre-existing on the line** and verified red on an untouched
worktree of the same tip:

- `core/flows tests/test_contract_smokes.py::test_admin_user_lookup_shapes` — the live-stack smoke,
  carrying the hardcoded `changeme` admin key that **R-B11** is about (`flows-authz`'s row).
- `gates.test.mjs` *"image-licenses vacuity"* — undeclared `litellm/litellm:main-v1.97.0` in
  `deploy/compose/docker-compose.yml`, arriving with the one-intelligence merge.

## Assertions moved, and why

Three existing tests asserted the defect. Each carries a note in place saying what changed:

- `test_the_organiser_is_dropped_on_even_when_the_fan_out_mailed_nobody` → `..._the_whole_room_...`
  (R-B20).
- `test_the_meetings_group_desk_is_the_one_writable_desk` had been asserting the **opposite of its
  own name**, with a comment excusing the second writable desk (F103).
- `test_a_non_admin_subjects_post_meeting_dispatch_can_start` now asserts F59's actual property —
  the cwd handed to the runtime is writable — instead of the proxy that broke here.
