### PR TITLE
[DEV] share-token-authz: the share leaves the link, and the store key stops being free in production (R-A08 · R-A13 · R-E08)

### DIFF
--- a/clients/terminal/src/app/App.tsx
+++ b/clients/terminal/src/app/App.tsx
@@ -20,6 +20,7 @@ import { AuthGate } from "./AuthGate";
 import { OnboardingGate } from "./OnboardingGate";
 import { SetupGate } from "./SetupGate";
 import { acceptInvite, acceptTranscriptShare, previewInvite, type InvitePreview } from "../surfaces/workspaceApi";
+import { redeemScaffoldShare } from "../minutes/scaffold";
 import "../surfaces";
 
 const roleLabel = (role: string) => (role === "viewer" ? "read-only" : "read & write");
@@ -104,10 +105,29 @@ function InviteGate({ children }: { children: ReactNode }) {
   //
   // Same stash-and-clean discipline as `?ask=`: the URL is cleaned on landing so a reload does not
   // re-open a spent arrival, and the id travels to MinutesShell through storage.
+  //
+  //  THE SHARE COMES OFF THE RECORD, NOT OFF THE URL (R-A08). When the meeting is not the reader's
+  //  own, the scaffold carries a restricted transcript grant. It used to ride this same link as
+  //  `&tshare=`, where a bearer credential enters every access log and proxy trace between us and
+  //  the inbox. It is redeemed here instead — one authenticated POST against the id the link
+  //  already carries — and the URL is cleaned only AFTER, because `location.replace` aborts the
+  //  request in flight. `redeemScaffoldShare` never throws and answers null for the ordinary
+  //  no-share case, so the arrival is never held up by it.
   useEffect(() => {
     if (!scaffold) return;
     try { localStorage.setItem("vexa.pendingScaffold", scaffold); } catch { /* locked-down storage */ }
-    if (!invite && !tshare) window.location.replace(window.location.pathname);
+    let live = true;
+    void (async () => {
+      const token = await redeemScaffoldShare(scaffold);
+      if (token) {
+        try {
+          const r = await acceptTranscriptShare(token);
+          if (r?.meeting_id != null) localStorage.setItem("vexa.openMeeting", String(r.meeting_id));
+        } catch (e) { console.error("scaffold transcript share redeem failed:", e); }
+      }
+      if (live && !invite && !tshare) window.location.replace(window.location.pathname);
+    })();
+    return () => { live = false; };
   }, [scaffold, invite, tshare]);
 
   // A `?meeting=` deep-link: stash the ref for the workbench first-view resolver, then clean the URL

--- a/clients/terminal/src/minutes/__tests__/scaffoldShare.test.ts
+++ b/clients/terminal/src/minutes/__tests__/scaffoldShare.test.ts
@@ -1,0 +1,49 @@
+/** R-A08 — the transcript share is redeemed against the scaffold id, never read off the URL.
+ *
+ *  The mailed link used to be `/?s=<id>&tshare=<share token>`: a bearer credential in a query
+ *  string, crossing a public hostname, the recipient's mail provider, every proxy between, and
+ *  whoever they forward it to. `worker/engine.py` states the opposite rule one file away for the
+ *  MCP delegation token; the weaker spelling sat on the more exposed artefact.
+ *
+ *  The client half is one function. It is here rather than inline in `App.tsx` for the reason the
+ *  module header gives: `scaffold.ts` is the ONLY place that knows the wire shape, so reconciling
+ *  with the server is an edit to one file.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { redeemScaffoldShare } from "../scaffold";
+
+const ok = (body: unknown) =>
+  vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })) as unknown as typeof fetch;
+
+describe("redeemScaffoldShare", () => {
+  it("posts to the scaffold's own id and returns the token", async () => {
+    const f = ok({ token: "97.tok-for-priya" });
+    expect(await redeemScaffoldShare("abc123", f)).toBe("97.tok-for-priya");
+    expect((f as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      .toBe("/api/scaffolds/abc123/share");
+    expect((f as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].method).toBe("POST");
+  });
+
+  it("returns null when the scaffold carries no share — the ordinary case, not a failure", async () => {
+    expect(await redeemScaffoldShare("abc123", ok({ token: null }))).toBeNull();
+  });
+
+  it("never throws: a refusal, a dead service and a body that is not JSON are all null", async () => {
+    const refused = vi.fn(async () => new Response("{}", { status: 404 })) as unknown as typeof fetch;
+    const dead = vi.fn(async () => { throw new Error("network"); }) as unknown as typeof fetch;
+    const junk = vi.fn(async () => new Response("<html>", { status: 200 })) as unknown as typeof fetch;
+    expect(await redeemScaffoldShare("abc123", refused)).toBeNull();
+    expect(await redeemScaffoldShare("abc123", dead)).toBeNull();
+    expect(await redeemScaffoldShare("abc123", junk)).toBeNull();
+  });
+
+  it("refuses an id that is not one, without calling the network", async () => {
+    const f = ok({ token: "x" });
+    expect(await redeemScaffoldShare("../../etc/passwd", f)).toBeNull();
+    expect((f as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("returns null for a token the server did not send as a string", async () => {
+    expect(await redeemScaffoldShare("abc123", ok({ token: 42 }))).toBeNull();
+  });
+});

--- a/clients/terminal/src/minutes/scaffold.ts
+++ b/clients/terminal/src/minutes/scaffold.ts
@@ -155,6 +155,43 @@ export function parseScaffold(raw: unknown): Scaffold | null {
   };
 }
 
+const SCAFFOLD_ID = /^[A-Za-z0-9_-]{1,128}$/;
+
+
+/** THE TRANSCRIPT SHARE, redeemed AGAINST THE SCAFFOLD ID (R-A08).
+ *
+ *  A scaffold about a meeting that is not the reader's own carries a restricted grant on that
+ *  meeting's transcript, minted by its owner. It used to ride the mailed link as `&tshare=<token>`
+ *  — a bearer credential in a query string, which enters every access log and proxy trace between
+ *  us and the recipient's inbox, and then whatever they forward. `core/agent/worker/engine.py`
+ *  states the rule for the MCP delegation token in as many words: *the token travels in a header,
+ *  never in the URL*. The link is now an id and nothing else, and this asks for the capability over
+ *  the authenticated session that already proved who the reader is.
+ *
+ *  NEVER THROWS, and null is the ordinary answer: most scaffolds are about the reader's own meeting
+ *  and carry no share at all. A caller that treated null as breakage would show an error on the
+ *  common path — and the one thing worse than a missing capability is a person told their link is
+ *  broken when it is not. */
+export async function redeemScaffoldShare(
+  id: string,
+  fetcher: typeof fetch = fetch,
+): Promise<string | null> {
+  if (!SCAFFOLD_ID.test(id)) return null;
+  try {
+    const res = await fetcher(`/api/scaffolds/${encodeURIComponent(id)}/share`, {
+      method: "POST", cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const body = await res.json() as { token?: unknown };
+    return typeof body?.token === "string" && body.token ? body.token : null;
+  } catch {
+    // A share we could not fetch is a meeting the reader may not see yet — worth a retry on the
+    // next open, never worth failing the arrival over. The chat still opens.
+    return null;
+  }
+}
+
+
 /** Fetch one scaffold AS THE SIGNED-IN IDENTITY. The server decides whether it is theirs; the
  *  client never asserts who it is for. A refusal is returned, never thrown — the caller renders a
  *  card that states the situation. */
@@ -162,7 +199,7 @@ export async function fetchScaffold(
   id: string,
   fetcher: typeof fetch = fetch,
 ): Promise<{ ok: true; scaffold: Scaffold } | { ok: false; refusal: ScaffoldRefusal }> {
-  if (!/^[A-Za-z0-9_-]{1,128}$/.test(id)) {
+  if (!SCAFFOLD_ID.test(id)) {
     return { ok: false, refusal: { reason: "malformed", status: 0, detail: "that is not a scaffold id" } };
   }
   let res: Response;

--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -1992,6 +1992,12 @@ def create_app(
             "minted_at": _iso(rec.get("minted_at")),
             "redeemed_at": _iso(rec.get("redeemed_at")),
             "redeemed_by": rec.get("redeemed_by"),
+            # WHETHER the transcript share was handed over, never WHAT it is (R-A08). This route is
+            # what a panel polls; a capability that rode every read would be a capability in every
+            # log that traffic touches — the shape the row exists to remove, one surface along.
+            # `has_share` is what the client branches on to decide whether to ask for it at all.
+            "has_share": bool(rec.get("share_token")),
+            "share_handed_at": _iso(rec.get("share_handed_at")),
         }
 
     def _scaffold_is_for(rec: dict, request: Request, subject: str) -> bool:
@@ -2011,8 +2017,27 @@ def create_app(
             return True
         return bool(global_layer.is_admin(settings, str(subject)))
 
+    def _scaffold_recipient_is(rec: dict, request: Request, subject: str) -> bool:
+        """Is this caller THE RECIPIENT — the three identity tests `_scaffold_is_for` runs, minus its
+        admin clause and with no service-key door.
+
+        Two predicates on purpose, because the two questions are different. Reading a scaffold is a
+        support surface and an instance admin has a reason to be on it. The transcript SHARE is a
+        bearer grant on somebody else's meeting: *may debug this record* is not *may watch this
+        meeting*, and collapsing them would hand every admin a capability the record was minted to
+        give one person (R-A08)."""
+        who = str(rec.get("who") or "").strip().lower()
+        email = (request.headers.get("x-user-email") or "").strip().lower()
+        if email and who and email == who:
+            return True
+        if rec.get("redeemed_by") and str(rec["redeemed_by"]) == str(subject):
+            return True
+        resolved = _email_subject_lookup(who) if who else None
+        return bool(resolved and str(resolved) == str(subject))
+
     def _compose_and_mint(*, who: str, subject: str, kind: str, opening: str, fm: dict,
-                          mid: str, mounts: list, group, refs_in, tabs, focus, provenance) -> dict:
+                          mid: str, mounts: list, group, refs_in, tabs, focus, provenance,
+                          share_token=None) -> dict:
         """Build the record and mint it. ONE composition, both mint routes.
 
         Factored when the hand-link route landed: two routes composing the same record from the same
@@ -2041,6 +2066,9 @@ def create_app(
             "tabs": tabs if tabs is not None else scaffolds_mod.frontmatter_list(fm, "tabs"),
             "focus": focus if focus is not None else (fm.get("focus") or ""),
             "provenance": dict(provenance or {}),
+            # THE SHARE LIVES ON THE RECORD, NOT IN THE LINK (R-A08). The recipient redeems it
+            # against the scaffold id over an authenticated request; nothing puts it in a URL.
+            "share_token": str(share_token) if share_token else None,
         })
 
     @app.post("/internal/scaffolds", status_code=201)
@@ -2133,15 +2161,15 @@ def create_app(
             who=who, subject=subject, kind=body.kind, opening=str(body.opening), fm=fm,
             mid=mid, mounts=mounts, group=group, refs_in=body.refs,
             tabs=body.tabs, focus=body.focus, provenance=body.provenance,
+            share_token=body.share_token,
         )
-        # The link carries the ID and, when the meeting is not the recipient's own, the capability
-        # that makes it visible. NOTHING ELSE: no preset name, no mount list, no prompt text. What a
-        # person forwards is an id bound to their address and a share bound to theirs.
+        # THE LINK IS AN ID. Nothing else: no preset name, no mount list, no prompt text — and since
+        # R-A08, no capability either. The share the caller minted is stored ON the record and the
+        # recipient redeems it against this id (`POST /api/scaffolds/<id>/share`), because a bearer
+        # token in a query string leaks into every access log and proxy trace it passes through —
+        # the rule `worker/engine.py` states for the delegation token, applied to the artefact that
+        # actually crosses a mail provider.
         url = f"{ui}/?s={rec['id']}"
-        if body.share_token:
-            from urllib.parse import quote as _quote
-
-            url += f"&tshare={_quote(str(body.share_token), safe='')}"
         logger.info("scaffold MINTED id=%s kind=%s who=%s meeting=%s mounts=%s opening=%s share=%s",
                     rec["id"], rec["kind"], who, rec.get("meeting"), mounts, rec["opening"],
                     bool(body.share_token))
@@ -2234,13 +2262,55 @@ def create_app(
         if not (_internal_caller(request) or _scaffold_is_for(rec, request, subject)):
             logger.warning("scaffold REFUSED id=%s subject=%s reason=not-the-recipient", scaffold_id, subject)
             raise HTTPException(status_code=404, detail="no such scaffold")
-        rec = scaffolds.redeem(scaffold_id, subject) or rec
+        # REDEEM ONLY FOR THE RECIPIENT (R-A13). An admin's debugging read used to stamp
+        # `redeemed_at`/`redeemed_by` with the ADMIN — and `scaffolds.redeem`'s own docstring calls
+        # that stamp "the only measurement the alpha ledger's 'seconds to act' column is made of".
+        #
+        # It is load-bearing twice over, which is why it is fixed here rather than left on the
+        # backlog: `redeemed_by == subject` is one of the three identity tests BOTH scaffold
+        # predicates run, so a stamp written by an admin's read promoted that admin to "the
+        # recipient" on every later call — including the share hand-out one route down, which is
+        # exactly the capability R-A08 exists to keep bound to one person.
+        if _scaffold_recipient_is(rec, request, subject):
+            rec = scaffolds.redeem(scaffold_id, subject) or rec
         try:
             return _scaffold_view(rec, subject)
         except scaffolds_mod.ScaffoldError as e:
             # The preset was there at mint and is not there now — an admin deleted or emptied it.
             # Say so; a silent empty opening is the failure that let the phase greeting win (F5).
             raise HTTPException(status_code=409, detail=str(e)) from e
+
+    @app.post("/api/scaffolds/{scaffold_id}/share")
+    def redeem_scaffold_share(scaffold_id: str, request: Request):
+        """The transcript share this record carries, handed to its RECIPIENT — the replacement for
+        `&tshare=` in the mailed link (R-A08).
+
+        A scaffold for a meeting that is not the reader's own carries a restricted grant, minted by
+        the meeting's owner in `core/flows` and passed to the mint. It used to ride the link's query
+        string, where a bearer credential enters every access log and proxy trace between us and the
+        recipient's inbox — and then whatever they forward. `worker/engine.py:1044-1046` states the
+        rule for the delegation token in as many words; this was the weaker spelling on the more
+        exposed artefact.
+
+        `{"token": null}` — not a 404 — when the record carries no share: most scaffolds are about
+        the reader's own meeting and carry no capability, and answering "not found" for the ordinary
+        case would teach the client to treat it as breakage.
+
+        A 404 for a stranger AND for an unknown id, exactly as the read route answers, so this route
+        cannot be used to discover that a scaffold id exists. An INSTANCE ADMIN gets the 404 too —
+        see `_scaffold_recipient_is` — and so does the internal tier: the mint hands the token IN,
+        and a route that handed it back out would be a second way to reach it."""
+        subject = subject_of(request)
+        rec = scaffolds.get(scaffold_id)
+        if rec is None or not _scaffold_recipient_is(rec, request, subject):
+            logger.warning("scaffold share REFUSED id=%s subject=%s reason=not-the-recipient",
+                           scaffold_id, subject)
+            raise HTTPException(status_code=404, detail="no such scaffold")
+        rec = scaffolds.hand_share(scaffold_id, subject) or rec
+        token = rec.get("share_token") or None
+        if token:
+            logger.info("scaffold share HANDED id=%s subject=%s", scaffold_id, subject)
+        return {"token": token}
 
     @app.get("/api/scaffolds")
     def list_scaffolds(request: Request, mine: bool = True, pending: bool = True):

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -441,10 +441,23 @@
     {
       "key": "VEXA_SECRETS_KEY",
       "class": "defaulted",
-      "default": "(empty \u2014 a 0600 key is generated under the workspaces secrets root on first use)",
+      "default": "(empty \u2014 outside production a 0600 key is generated under the workspaces secrets root on first use, with a warning; in production an empty value is a boot refusal)",
       "secret": true,
-      "description": "server-side key the credential store seals with (saved GitHub PAT + per-workspace deploy-key private halves); set it to hold the key outside the data volume",
-      "targets": []
+      "description": "server-side key the credential store seals with (saved GitHub PAT + per-workspace deploy-key private halves). EMPTY GENERATES ONE BESIDE THE CIPHERTEXT, under the workspaces secrets root \u2014 enough against a stray read, nothing against a stolen volume or a backup. It was settable on no deployment surface, so no deployment ever set it and every deployment quietly took the weaker property while the docs asserted the stronger one (R-E08). It is on compose and helm now, and with VEXA_ENV=production an unset value is a refusal naming the fix rather than a silent downgrade",
+      "targets": [
+        "compose",
+        "helm"
+      ]
+    },
+    {
+      "key": "VEXA_ENV",
+      "class": "defaulted",
+      "default": "development",
+      "description": "the deployment profile, spelled as the mcp and transcription services already spell it (`transcription/main.py`, `vexa_mcp/app.py`): anything but the exact word `production`, including unset, is a development posture. agent-api reads it in ONE place \u2014 the credential store, where production turns an unset VEXA_SECRETS_KEY from a generated key beside the ciphertext into a refusal (R-E08)",
+      "targets": [
+        "compose",
+        "helm"
+      ]
     },
     {
       "key": "VEXA_MCP_DELEGATION_TTL_SEC",

--- a/core/agent/control_plane/scaffolds.py
+++ b/core/agent/control_plane/scaffolds.py
@@ -505,6 +505,35 @@ class ScaffoldStore:
                     ids.remove(scaffold_id)
         return rec
 
+    def hand_share(self, scaffold_id: str, subject: str) -> Optional[dict]:
+        """Give this record's transcript share to its recipient, and record that it was given.
+
+        THE SHARE STOPPED RIDING THE LINK (R-A08). It used to be a query parameter on the mail's one
+        button — `{ui}/?s=<id>&tshare=<token>` — which is a bearer credential in a URL that crosses a
+        public hostname, the recipient's mail provider, every proxy in between, and whoever they
+        forward it to. `worker/engine.py` states the opposite rule one file away for the MCP
+        delegation token, and the weaker spelling was on the more exposed artefact.
+
+        So the token lives on the RECORD and is handed over an authenticated request instead. The
+        caller must already have been judged the recipient — this method does not authorize; the
+        route does, with a stricter predicate than the read uses (an admin may read the record and
+        may never hold the capability).
+
+        IDEMPOTENT FOR THE SAME SUBJECT, deliberately, and this is a considered departure from
+        "one-time": a strictly single-use hand-out turns one dropped response into a person
+        permanently unable to open the meeting they were invited to, which is a worse failure than
+        the one this fixes. The property that carries the security is that the token is never in a
+        URL and is only ever handed to the identity the record names. The record expires anyway
+        (`TTL_SECONDS`), so the capability is bounded in time rather than by a counter."""
+        rec = self.get(scaffold_id)
+        if rec is None:
+            return None
+        if rec.get("share_token") and not rec.get("share_handed_at"):
+            rec["share_handed_at"] = time.time()
+            rec["share_handed_to"] = str(subject)
+            self._put(rec)
+        return rec
+
     def for_recipient(self, address: str, *, pending_only: bool = True) -> list[dict]:
         """This address's scaffolds, most recently minted first."""
         key = _recipient_key(address)

--- a/core/agent/control_plane/secret_store.py
+++ b/core/agent/control_plane/secret_store.py
@@ -36,7 +36,7 @@ import os
 import re
 import secrets as _secrets
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 log = logging.getLogger(__name__)
 
@@ -47,6 +47,37 @@ _NAME_RE = re.compile(r"^[A-Za-z0-9_.@-]{1,128}(/[A-Za-z0-9_.@-]{1,128})*$")  # 
 
 
 ENV_KEY_NAME = "VEXA_SECRETS_KEY"   # the operator-supplied key (declared in config.v1.json)
+#: The deployment profile, spelled the way this repository already spells it
+#: (`transcription/main.py:154`, `vexa_mcp/app.py:587`): unset means `development`, and only the
+#: exact word `production` is production.
+ENV_PROFILE_NAME = "VEXA_ENV"
+
+
+class SecretStoreUnconfigured(RuntimeError):
+    """A production deployment that never gave the store a key to seal with (R-E08).
+
+    Raised on the WRITE path only. The docstring at the top of this module is honest that a
+    generated key sits beside the ciphertext and therefore defends a stray read and not a stolen
+    volume — but `VEXA_SECRETS_KEY` appeared in no compose file, no `.env.example` and no helm
+    values, so **no shipped deployment set it** and every deployment quietly took the weaker
+    property while the documentation asserted the stronger one. In production that is now a refusal
+    naming the fix, because a security claim nobody can act on is worse than no claim."""
+
+
+UNCONFIGURED_SENTENCE = (
+    "the credential store has no key to seal with: set VEXA_SECRETS_KEY (`openssl rand -hex 32`) "
+    "on this deployment. A key generated here would sit in the same directory as the ciphertext, "
+    "which is not encryption at rest in any sense worth claiming — outside production it is "
+    "generated with a warning instead."
+)
+
+
+def is_production(env: "Mapping[str, str] | None" = None) -> bool:
+    """Is this a production deployment? Only the exact word counts — `staging`, `dev`, a typo and an
+    unset value are all "not production", so a box nobody declared never fails closed on a property
+    it never claimed."""
+    src = os.environ if env is None else env
+    return str(src.get(ENV_PROFILE_NAME, "development") or "").strip().lower() == "production"
 
 
 def configured_key(explicit: str = "") -> str:
@@ -103,10 +134,21 @@ def master_key(root: str | Path, configured: str = "") -> bytes:
     there (32 random bytes, ``0600``) the first time anything is stored. Generation is racy-safe: a
     concurrent writer's file wins on re-read, so two boots cannot end up with two keys.
 
-    **Only the WRITE path may call this.** Reads go through ``read_key`` — see its docstring."""
+    **Only the WRITE path may call this.** Reads go through ``read_key`` — see its docstring.
+
+    IN PRODUCTION IT REFUSES rather than generating (R-E08): see ``SecretStoreUnconfigured``. Outside
+    production it generates and says so, every time, at WARNING — the store's honest level of
+    protection is a thing an operator should have to read past, not discover from a docstring."""
     existing = read_key(root, configured)
     if existing is not None:
         return existing
+    if is_production():
+        raise SecretStoreUnconfigured(UNCONFIGURED_SENTENCE)
+    log.warning(
+        "%s is unset, so the credential store is generating a key UNDER %s — beside the ciphertext "
+        "it seals. That defends a stray read, not a stolen volume or a backup. Acceptable in "
+        "development; in production this is a refusal. Set %s to hold the key outside the data "
+        "volume.", ENV_KEY_NAME, secrets_dir(root), ENV_KEY_NAME)
     kf = secrets_dir(root) / MASTER_KEY_FILENAME
     kf.parent.mkdir(parents=True, exist_ok=True)
     fresh = base64.b64encode(_secrets.token_bytes(32))
@@ -197,8 +239,12 @@ def put(root: str | Path, name: str, value: Optional[str], *, key_env: str = "")
         except FileNotFoundError:
             pass
         return False
+    # THE KEY FIRST, BEFORE ANY DISK IS TOUCHED. A production refusal (R-E08) that had already
+    # created the store directory would leave the deployment looking half-configured to the next
+    # reader — and the whole point of the refusal is that nothing about this store is half-done.
+    key = master_key(root, key_env)
     p.parent.mkdir(parents=True, exist_ok=True)
-    envelope = seal(val, master_key(root, key_env))
+    envelope = seal(val, key)
     tmp = p.with_name(f"{p.name}.{os.getpid()}.tmp")
     tmp.write_text(envelope, encoding="utf-8")
     _harden(tmp)

--- a/core/agent/tests/test_config_contract.py
+++ b/core/agent/tests/test_config_contract.py
@@ -214,7 +214,10 @@ def test_the_qwen_lane_dials_are_declared():
 # +1 on `flows-delivery`: VEXA_ROOM_MEETING, the post-meeting room signal the worker reads to
 # keep decision 22 (no desk write-back, no README refresh, no bot verbs on a finished meeting —
 # F103/F104). The widened scan this file's sibling test performs is what caught it undeclared.
-EXPECTED_DECLARED_KEYS = 87
+# 87 since VEXA_ENV was declared beside VEXA_SECRETS_KEY (R-E08): the profile word decides whether
+# an unset store key is a generated one or a boot refusal, so the two are read together and are
+# declared together.
+EXPECTED_DECLARED_KEYS = 88
 
 
 def test_the_declared_key_count_is_asserted_not_merely_printed():

--- a/core/agent/tests/test_scaffold.py
+++ b/core/agent/tests/test_scaffold.py
@@ -131,9 +131,14 @@ def test_the_url_carries_the_id_and_nothing_else(client):
         assert word not in url
 
 
-def test_a_share_token_rides_the_url_when_the_meeting_is_not_theirs(client):
+def test_a_share_token_does_not_ride_the_url(client):
+    """It used to (`&tshare=<token>`), one test below the one that says the link carries an id and
+    nothing else — the exception that made the rule above false. A bearer credential in a query
+    string leaks into every access log and proxy trace between us and the recipient's inbox, and
+    into whatever they forward (R-A08). The share now lives on the record and its recipient redeems
+    it against the id; the whole contract is in `test_scaffold_share.py`."""
     url = _mint(client, share_token="tok-abc.def").json()["url"]
-    assert "&tshare=tok-abc.def" in url
+    assert "tshare" not in url and "tok-abc.def" not in url
 
 
 def test_an_unknown_preset_fails_the_mint_not_the_click(client):

--- a/core/agent/tests/test_scaffold_share.py
+++ b/core/agent/tests/test_scaffold_share.py
@@ -1,0 +1,123 @@
+"""R-A08 — the transcript share stops travelling in the link's query string.
+
+`core/agent/worker/engine.py` states the rule one file away, about the MCP delegation token: *"THE
+TOKEN TRAVELS IN A HEADER, never in the URL… a credential in a query string leaks into every access
+log and proxy trace it passes through"*. The scaffold mail was the weaker spelling of the same rule
+on the MORE exposed artefact — `{ui}/?s=<id>&tshare=<share token>` crosses a public hostname, a
+recipient's mail provider, and whoever they forward it to.
+
+So the share is delivered by REDEMPTION BOUND TO THE SCAFFOLD ID: the record holds it, and the
+recipient asks for it once over an authenticated request. The link is an id and nothing else — which
+is what `test_the_url_carries_the_id_and_nothing_else` in `test_scaffold.py` already claimed, while
+one test below it pinned the exception.
+
+L2 throughout: a real FastAPI app over fakes, no redis, no runtime, no claude.
+"""
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from tests.test_scaffold import (  # the fixtures this row shares with the rest of the scaffold suite
+    INTERNAL, _as, _mint, client, stack,  # noqa: F401 — pytest fixtures by name
+)
+
+
+def _params(url: str) -> dict:
+    return {k: v[0] for k, v in parse_qs(urlsplit(url).query).items()}
+
+
+PRIYA = _as("priya@acme.test", "u_priya")
+STRANGER = _as("mallory@elsewhere.test", "u_mallory")
+
+
+# ── the link ─────────────────────────────────────────────────────────────────────────────────────
+
+def test_the_link_carries_no_share_token(client):
+    """The whole row in one assertion: an id, and nothing that is a credential."""
+    url = _mint(client, share_token="97.tok-for-priya").json()["url"]
+    assert set(_params(url)) == {"s"}
+    assert "97.tok-for-priya" not in url
+
+
+def test_the_link_is_still_the_same_link_when_there_is_no_share(client):
+    url = _mint(client).json()["url"]
+    assert set(_params(url)) == {"s"}
+
+
+# ── the redemption ───────────────────────────────────────────────────────────────────────────────
+
+def test_the_recipient_redeems_the_share_against_the_scaffold_id(client):
+    sid = _mint(client, share_token="97.tok-for-priya").json()["id"]
+    r = client.post(f"/api/scaffolds/{sid}/share", headers=PRIYA)
+    assert r.status_code == 200, r.text
+    assert r.json()["token"] == "97.tok-for-priya"
+
+
+def test_a_scaffold_with_no_share_answers_null_not_an_error(client):
+    """A null token is a fact, not a failure: most scaffolds are about the reader's own meeting and
+    carry no capability at all. A 404 here would make the client treat the ordinary case as broken."""
+    sid = _mint(client).json()["id"]
+    r = client.post(f"/api/scaffolds/{sid}/share", headers=PRIYA)
+    assert r.status_code == 200, r.text
+    assert r.json()["token"] is None
+
+
+def test_a_stranger_gets_no_token_and_cannot_learn_the_scaffold_exists(client):
+    sid = _mint(client, share_token="97.tok-for-priya").json()["id"]
+    r = client.post(f"/api/scaffolds/{sid}/share", headers=STRANGER)
+    assert r.status_code == 404
+    assert "97.tok-for-priya" not in r.text
+
+
+def test_an_admin_may_read_the_record_and_may_never_hold_the_capability(client, monkeypatch):
+    """The read route admits the instance admin — a scaffold is a support surface. The SHARE is not:
+    it is a bearer grant on somebody else's meeting transcript, and 'can debug this record' is not
+    'may watch this meeting'."""
+    from control_plane import global_layer
+    monkeypatch.setattr(global_layer, "is_admin", lambda *a, **k: True)
+    sid = _mint(client, share_token="97.tok-for-priya").json()["id"]
+    admin = _as("root@acme.test", "u_admin")
+    assert client.get(f"/api/scaffolds/{sid}", headers=admin).status_code == 200
+    r = client.post(f"/api/scaffolds/{sid}/share", headers=admin)
+    assert r.status_code == 404
+    assert "97.tok-for-priya" not in r.text
+
+
+def test_the_internal_tier_cannot_pull_a_share_back_out(client):
+    """The mint hands the token IN. Nothing hands it back out to the service tier — a flow that
+    needed it already had it, and a route that returned it would be a second way to reach it."""
+    sid = _mint(client, share_token="97.tok-for-priya").json()["id"]
+    r = client.post(f"/api/scaffolds/{sid}/share", headers={"X-Internal-Secret": INTERNAL})
+    assert r.status_code in (401, 404)
+    assert "97.tok-for-priya" not in r.text
+
+
+def test_a_reload_is_not_a_second_redemption(client):
+    """Idempotent FOR THE SAME RECIPIENT, and deliberately so — the same reasoning `redeem` already
+    applies to `redeemed_at`. Making it strictly single-use would turn one dropped response into a
+    person permanently unable to see the meeting they were invited to, which is a worse failure than
+    the one the row is about; the property that matters is that the token is never in a URL and is
+    only ever handed to the identity the record is bound to."""
+    sid = _mint(client, share_token="97.tok-for-priya").json()["id"]
+    first = client.post(f"/api/scaffolds/{sid}/share", headers=PRIYA).json()["token"]
+    second = client.post(f"/api/scaffolds/{sid}/share", headers=PRIYA).json()["token"]
+    assert first == second == "97.tok-for-priya"
+
+
+def test_the_hand_out_is_recorded_on_the_record(client):
+    """So an operator can answer 'did this person ever get the capability' without guessing."""
+    from control_plane.api import create_app  # noqa: F401 — the store is the app's; read it back
+    sid = _mint(client, share_token="97.tok-for-priya").json()["id"]
+    client.post(f"/api/scaffolds/{sid}/share", headers=PRIYA)
+    rec = client.get(f"/api/scaffolds/{sid}", headers=PRIYA).json()
+    assert rec.get("share_handed_at")
+
+
+def test_the_record_never_shows_the_token_on_the_read_route(client):
+    """The read is the surface a panel polls. A capability that rides every read is a capability in
+    every log the panel's traffic touches — the shape this row exists to remove."""
+    sid = _mint(client, share_token="97.tok-for-priya").json()["id"]
+    body = client.get(f"/api/scaffolds/{sid}", headers=PRIYA).text
+    assert "97.tok-for-priya" not in body

--- a/core/agent/tests/test_secrets_key_profile.py
+++ b/core/agent/tests/test_secrets_key_profile.py
@@ -102,7 +102,8 @@ def test_the_key_is_settable_on_every_shipped_deployment_surface():
     surfaces = {
         "compose": root / "deploy/compose/docker-compose.yml",
         ".env.example": root / "deploy/compose/.env.example",
-        "helm values": root / "deploy/helm/charts/vexa/values.yaml",
+        "helm secret": root / "deploy/helm/charts/vexa/templates/secret.yaml",
+        "helm agent-api env": root / "deploy/helm/charts/vexa/templates/deployment-agent-api.yaml",
     }
     missing = [name for name, p in surfaces.items()
                if not p.is_file() or "VEXA_SECRETS_KEY" not in p.read_text()]

--- a/core/agent/tests/test_secrets_key_profile.py
+++ b/core/agent/tests/test_secrets_key_profile.py
@@ -1,0 +1,129 @@
+"""R-E08 — "tokens encrypted at rest" has to mean something in production.
+
+`secret_store`'s own docstring is honest about the generated key: it sits in the same directory as
+the ciphertext, so it defends against a stray file read, a mis-scoped mount or a log, and NOT
+against a stolen volume or backup. The operator escape is `VEXA_SECRETS_KEY` — and it appeared in
+NO compose file, no `.env.example` and no helm values, so **no shipped deployment set it** and every
+deployment shipped the key beside the ciphertext while the claim said otherwise.
+
+Two halves, and neither works alone:
+
+* the deployment surfaces carry the key, so an operator has something to set;
+* generating one is a DEVELOPMENT convenience and says so — in production an unset key is a refusal
+  with a sentence naming the fix, not a silent downgrade of the property the docs assert.
+
+`VEXA_ENV` is the profile signal this repository already uses for exactly this
+(`core/meetings/services/transcription/src/transcription/main.py:154-155`,
+`core/meetings/services/mcp/src/vexa_mcp/app.py:587`), defaulting to `development` — so nothing
+that runs today changes, and the refusal engages precisely where the claim is load-bearing.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from control_plane import secret_store
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_key(monkeypatch):
+    """The host may export VEXA_SECRETS_KEY; each test here says which world it means."""
+    monkeypatch.delenv("VEXA_SECRETS_KEY", raising=False)
+    monkeypatch.delenv("VEXA_ENV", raising=False)
+
+
+def _keyfile(root: Path) -> Path:
+    return secret_store.secrets_dir(root) / secret_store.MASTER_KEY_FILENAME
+
+
+# ── production ───────────────────────────────────────────────────────────────────────────────────
+
+def test_production_refuses_to_generate_a_key_beside_the_ciphertext(tmp_path, monkeypatch):
+    monkeypatch.setenv("VEXA_ENV", "production")
+    with pytest.raises(secret_store.SecretStoreUnconfigured) as exc:
+        secret_store.put(tmp_path, "u_jane/github", "ghp_thetoken")
+    assert "VEXA_SECRETS_KEY" in str(exc.value)          # the sentence names the fix
+    assert not _keyfile(tmp_path).exists()               # …and nothing was written anyway
+    assert not (secret_store.secrets_dir(tmp_path) / "u_jane").exists()
+
+
+def test_production_with_a_configured_key_is_an_ordinary_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("VEXA_ENV", "production")
+    monkeypatch.setenv("VEXA_SECRETS_KEY", "an-operator-held-key")
+    assert secret_store.put(tmp_path, "u_jane/github", "ghp_thetoken") is True
+    assert secret_store.get(tmp_path, "u_jane/github") == "ghp_thetoken"
+    assert not _keyfile(tmp_path).exists()               # the key is the operator's, not ours
+
+
+def test_a_read_in_production_stays_a_read_and_never_raises(tmp_path, monkeypatch):
+    """The refusal belongs on the WRITE. `get` sits on the git hot path where "no credential" is an
+    ordinary answer (R-E13), and turning that into an exception would be a new failure, not a fix."""
+    monkeypatch.setenv("VEXA_ENV", "production")
+    assert secret_store.get(tmp_path, "u_jane/github") is None
+    assert secret_store.state(tmp_path, "u_jane/github") == secret_store.ABSENT
+    assert not _keyfile(tmp_path).exists()
+
+
+# ── development ──────────────────────────────────────────────────────────────────────────────────
+
+def test_development_still_generates_a_key_and_says_so_loudly(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger=secret_store.log.name):
+        assert secret_store.put(tmp_path, "u_jane/github", "ghp_thetoken") is True
+    assert secret_store.get(tmp_path, "u_jane/github") == "ghp_thetoken"
+    assert _keyfile(tmp_path).exists()
+    said = " ".join(r.getMessage() for r in caplog.records)
+    assert "VEXA_SECRETS_KEY" in said and "development" in said.lower()
+
+
+@pytest.mark.parametrize("env", ["", "development", "dev", "local", "test", "staging"])
+def test_every_non_production_profile_keeps_working(tmp_path, monkeypatch, env):
+    """Only `production` refuses. A profile nobody declared, and the staging box somebody stood up
+    this morning, must not fail closed on a property they never claimed."""
+    if env:
+        monkeypatch.setenv("VEXA_ENV", env)
+    assert secret_store.put(tmp_path / env, "u_jane/github", "ghp_x") is True
+
+
+# ── the other half: a deployment must have somewhere to set it ───────────────────────────────────
+
+def _repo_root() -> Path:
+    for p in Path(__file__).resolve().parents:
+        if (p / "deploy" / "compose" / "docker-compose.yml").is_file():
+            return p
+    raise FileNotFoundError("repo root not found")
+
+
+def test_the_key_is_settable_on_every_shipped_deployment_surface():
+    """The review's actual complaint, as a test: the escape hatch existed and no deployment could
+    reach it. A refusal an operator cannot act on is worse than the silent generation it replaced."""
+    root = _repo_root()
+    surfaces = {
+        "compose": root / "deploy/compose/docker-compose.yml",
+        ".env.example": root / "deploy/compose/.env.example",
+        "helm values": root / "deploy/helm/charts/vexa/values.yaml",
+    }
+    missing = [name for name, p in surfaces.items()
+               if not p.is_file() or "VEXA_SECRETS_KEY" not in p.read_text()]
+    assert missing == [], f"VEXA_SECRETS_KEY cannot be set on: {', '.join(missing)}"
+
+
+def _compose_env(service: str) -> list[str]:
+    import yaml
+    doc = yaml.safe_load((_repo_root() / "deploy/compose/docker-compose.yml").read_text())
+    env = ((doc.get("services") or {}).get(service) or {}).get("environment") or []
+    return [str(e) for e in env] if isinstance(env, list) else [f"{k}={v}" for k, v in env.items()]
+
+
+def test_agent_api_can_see_the_profile_it_is_judged_against():
+    """A refusal keyed on `VEXA_ENV` is worthless if the container never receives it."""
+    env = _compose_env("agent-api")
+    assert any(e.startswith("VEXA_ENV=") for e in env), \
+        "agent-api's compose environment does not carry VEXA_ENV"
+
+
+def test_agent_api_can_be_given_the_key_it_will_ask_for():
+    env = _compose_env("agent-api")
+    assert any(e.startswith("VEXA_SECRETS_KEY=") for e in env), \
+        "agent-api's compose environment cannot receive VEXA_SECRETS_KEY"

--- a/core/flows/tests/test_attendee_mail_shape.py
+++ b/core/flows/tests/test_attendee_mail_shape.py
@@ -223,10 +223,11 @@ def test_the_mail_is_exactly_head_blankline_report_then_the_button(monkeypatch, 
     assert msg["body"] == "HEAD for Acme Bank.\n\n## Decided\n- ship it"
     # the gap line and the button are the PORT's, not the step's
     assert notify_mod.compose(msg["body"], msg["link"]) == msg["body"] + "\n\n" + msg["link"] + "\n"
-    # THE BUTTON IS AN ID AND A CAPABILITY — the preset moved into the record (PRD §5.5).
-    assert set(_params(msg["link"])) == {"s", "tshare"}
-    assert _params(msg["link"])["tshare"] == "97.tok-ben@bank.test"
+    # THE BUTTON IS AN ID — the preset moved into the record (PRD §5.5), and so did the capability
+    # (R-A08: a bearer token in a query string leaks into every log the link passes through).
+    assert set(_params(msg["link"])) == {"s"}
     rec = scaffolds.for_("ben@bank.test")
+    assert rec["share_token"] == "97.tok-ben@bank.test"
     assert (rec["kind"], rec["opening"], rec["meeting"]) == \
         ("invite-offer", "minutes-review-invite", "97")
     # the preamble the head replaced is gone — including the mailbox line's double splice
@@ -235,16 +236,22 @@ def test_the_mail_is_exactly_head_blankline_report_then_the_button(monkeypatch, 
     assert "Open it and ask anything about the meeting" not in msg["body"]
 
 
-def test_everybody_in_the_room_gets_byte_identical_words(monkeypatch):
+def test_everybody_in_the_room_gets_byte_identical_words(monkeypatch, scaffolds):
     """The founder's simplification, as a test: two attendees, one report, and the ONLY thing that
-    may differ between their mails is the share token inside their own button."""
+    may differ between them is the share token on their own record.
+
+    Since R-A08 the mails are byte-identical INCLUDING the button, because the capability left the
+    URL — which makes the claim stronger than it was, not weaker: there is now nothing per-person in
+    the mail at all."""
     reg, ch = _rig(monkeypatch)
     out = reg.steps["email_attendees"](_ctx(dict(REFS), PRIOR))
 
     assert out.result["sent"] == 2 and out.result["followup"] == "on"
     assert len({m["body"] for m in ch.sent}) == 1
     assert len({m["subject"] for m in ch.sent}) == 1
-    assert {_params(m["link"])["tshare"] for m in ch.sent} == {
+    assert len({m["link"] for m in ch.sent}) == 2            # one id each, and only the id differs
+    assert all(set(_params(m["link"])) == {"s"} for m in ch.sent)
+    assert {scaffolds.for_(m["to"])["share_token"] for m in ch.sent} == {
         "97.tok-ben@bank.test", "97.tok-cara@bank.test"}
 
 

--- a/core/flows/tests/test_link_loop.py
+++ b/core/flows/tests/test_link_loop.py
@@ -61,10 +61,10 @@ class FakeScaffolds:
                             "meeting": None if meeting_id is None else str(meeting_id),
                             "refs": refs or {}, "share_token": share_token,
                             "provenance": provenance or {}})
-        url = f"https://app.example.test/?s=sc{len(self.minted)}"
-        if share_token:
-            url += f"&tshare={share_token}"
-        return url
+        # THE LINK IS AN ID (R-A08). The share the step minted is stored ON the record and its
+        # recipient redeems it against this id; agent-api stopped composing `&tshare=` into the url,
+        # so a fake that still did would be this suite pinning a contract that no longer exists.
+        return f"https://app.example.test/?s=sc{len(self.minted)}"
 
     def for_(self, address: str) -> dict:
         return next(m for m in self.minted if m["who"] == address)
@@ -279,7 +279,7 @@ def _attendee_rig(monkeypatch, *, mint, row=None):
 
 def test_a_minted_share_travels_in_the_link(monkeypatch, scaffolds):
     """The happy path, asserted on the artifact the attendee actually receives: one token per
-    attendee, restricted to them, carried on the button as `tshare`."""
+    attendee, restricted to them, and carried ON THE RECORD the button's id names (R-A08)."""
     minted = []
 
     def mint(uid, meeting_id, email, expires_in_sec=30 * 86400):
@@ -294,11 +294,10 @@ def test_a_minted_share_travels_in_the_link(monkeypatch, scaffolds):
     assert [m[1] for m in minted] == [97, 97]
     assert [m[2] for m in minted] == ["ben@bank.test", "cara@bank.test"]
     for msg in ch.sent:
-        params = _params(msg["link"])
-        assert set(params) == {"s", "tshare"}                    # an id and a capability, nothing else
-        assert params["tshare"] == f"97.secret-for-{msg['to']}"   # this attendee's OWN capability
+        assert set(_params(msg["link"])) == {"s"}                 # an id, and nothing that is a credential
         rec = scaffolds.for_(msg["to"])
-        assert rec["meeting"] == "97" and rec["share_token"] == params["tshare"]
+        assert rec["meeting"] == "97"
+        assert rec["share_token"] == f"97.secret-for-{msg['to']}"  # this attendee's OWN capability
         # the attendee mail carries the SECOND ASK, so the record says which kind of touch it is
         assert (rec["kind"], rec["opening"]) == ("invite-offer", "minutes-review-invite")
 

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -61,6 +61,15 @@ ADMIN_TOKEN=dev-admin-token
 # unconfigured deploy shared one published secret — mint your own, there is no default and the
 # services refuse to boot without it:  openssl rand -hex 32
 INTERNAL_API_SECRET=
+# The credential store's key: saved GitHub PATs and per-workspace deploy-key private halves are
+# sealed with it (R-E08). Leave it empty in development and a key is generated under the workspaces
+# volume, NEXT TO the ciphertext — enough against a stray read, nothing against a stolen volume or a
+# backup, and agent-api warns on every boot that does it. Set VEXA_ENV=production and this becomes
+# required: mint one and keep it outside the data volume.  openssl rand -hex 32
+VEXA_SECRETS_KEY=
+# The deployment profile — the same word the mcp and transcription services read. Anything but
+# `production` (including unset) is a development posture: generated store key, public docs.
+VEXA_ENV=development
 # The bot's display name in the meeting — the terminal omits bot_name on join, so this names every
 # bot it sends. Empty → Vexa. Restart meeting-api after changing; the terminal needs no rebuild.
 DEFAULT_BOT_NAME=

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -265,6 +265,18 @@ services:
       # Unset reads as "unknown" and the bar simply never fires (PRD decision 39).
       - VEXA_BUILD_SHA=${VEXA_BUILD_SHA:-${IMAGE_TAG:-dev}}
       - VEXA_WORKSPACES_DIR=/workspaces
+      # THE CREDENTIAL STORE'S KEY, and the profile that decides whether it may be absent (R-E08).
+      # `secret_store` seals saved PATs and per-workspace deploy-key private halves. With no key it
+      # GENERATES one under `<workspaces>/.secrets/`, beside the ciphertext it seals — which defends
+      # a stray read and not a stolen volume or a backup, and the module has always said so. It was
+      # settable nowhere, so no deployment ever set it and every deployment quietly took the weaker
+      # property. Mint one (`openssl rand -hex 32`) to hold the key outside the data volume.
+      #
+      # VEXA_ENV is the same profile word the mcp and transcription services already read: unset or
+      # anything but `production` keeps the generated key (with a warning on every boot that needs
+      # it); `production` makes an unset VEXA_SECRETS_KEY a refusal naming the fix.
+      - VEXA_SECRETS_KEY=${VEXA_SECRETS_KEY:-}
+      - VEXA_ENV=${VEXA_ENV:-development}
       # Lane M: the users.data.memberships[] index mirror over the admin-api internal edge
       # (policy/members.json in the workspace git repo stays authoritative; this is the listing cache).
       - VEXA_ADMIN_API_URL=http://admin-api:8001

--- a/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-agent-api.yaml
@@ -100,6 +100,16 @@ spec:
                   name: {{ include "vexa.adminTokenSecretName" . }}
                   key: VEXA_BOT_API_KEY
                   optional: true
+            # The credential store's key, and the profile that decides whether it may be absent
+            # (R-E08). See values.yaml `secrets.secretsKey`.
+            - name: VEXA_SECRETS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: VEXA_SECRETS_KEY
+                  optional: true
+            - name: VEXA_ENV
+              value: {{ .Values.vexaEnv | default "development" | quote }}
             - name: VEXA_AGENT_DEFAULT_SUBJECT
               value: {{ .Values.agentApi.defaultSubject | default "u_live" | quote }}
             - name: VEXA_AGENT_MODEL

--- a/deploy/helm/charts/vexa/templates/secret.yaml
+++ b/deploy/helm/charts/vexa/templates/secret.yaml
@@ -18,6 +18,11 @@ stringData:
   VEXA_SYSTEM_WEBHOOK_SECRET: {{ .Values.secrets.systemWebhookSecret | quote }}
   VEXA_DISPATCH_SIGNING_KEY: {{ .Values.secrets.dispatchSigningKey | default "dev-dispatch-signing-key" | quote }}
   NEXTAUTH_SECRET: {{ .Values.secrets.nextauthSecret | default "dev-nextauth-secret" | quote }}
+  # The credential store's key (R-E08). Empty is ALLOWED here and refused at boot only when
+  # `vexaEnv` is production — a chart that made it required would break every development install
+  # for a property those installs never claimed, and the refusal is meant to bite exactly where the
+  # "encrypted at rest" sentence is load-bearing.
+  VEXA_SECRETS_KEY: {{ .Values.secrets.secretsKey | default "" | quote }}
   {{- if .Values.secrets.botApiKey }}
   VEXA_BOT_API_KEY: {{ .Values.secrets.botApiKey | quote }}
   {{- end }}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -46,6 +46,11 @@ global:
 # VEXA_SERVICE_AUTHORITY_SECRET, VEXA_SYSTEM_WEBHOOK_SECRET, VEXA_DISPATCH_SIGNING_KEY,
 # VEXA_BOT_API_KEY, ANTHROPIC_API_KEY,
 # ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL, CLAUDE_CODE_OAUTH_TOKEN.
+# The deployment profile, the same word the mcp and transcription services read. Anything but
+# `production` (including unset) is a development posture; `production` makes an empty
+# `secrets.secretsKey` a boot refusal instead of a silently generated key (R-E08).
+vexaEnv: "development"
+
 secrets:
   existingSecretName: ""
   adminApiToken: "CHANGE_ME"        # admin-api auth + MeetingToken signing (== meeting-api ADMIN_TOKEN)
@@ -57,6 +62,11 @@ secrets:
   dispatchSigningKey: ""            # agent-api signs per-dispatch tokens (default dev key; k8s prod → set this)
   botApiKey: ""                     # agent-api → gateway "add bot from URL" key (optional)
   nextauthSecret: ""                # terminal next-auth session signing (default dev key; set in prod)
+  secretsKey: ""                    # agent-api credential store (saved PATs + deploy-key private
+                                    # halves). Empty → a key is generated INSIDE the workspaces
+                                    # volume beside the ciphertext, which is not encryption at rest
+                                    # against a stolen volume (R-E08); with vexaEnv=production an
+                                    # empty value is a refusal — `openssl rand -hex 32`
   # Model-provider auth (config.v1 `model_inference` capability, ADR-0026). ANTHROPIC_AUTH_TOKEN +
   # ANTHROPIC_BASE_URL are the OpenRouter/subscription pair (compose sources them from .env as a
   # single source of truth — here they live in the Secret). claudeCodeOauthToken


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.** Code, tests and deployment declarations only; nothing merged, deployed, published or sent outside the org.

Two security rows from the [2026-09-02 release backlog](https://github.com/DmitriyG228/biz/issues/449), owning issue [`DmitriyG228/biz#452`](https://github.com/DmitriyG228/biz/issues/452). Four commits, alternating: **the reproduction first, then the fix.** Base `minutes-mcp-viewer` @ `31c0b6e1c`.

---

## R-A08 — the transcript capability leaves the link

`{ui}/?s=<id>&tshare=<share token>` put a bearer credential in a query string on the one artefact that crosses a public hostname, the recipient's mail provider, every proxy between, and whoever they forward it to. `core/agent/worker/engine.py:1044-1046` states the opposite rule for the MCP delegation token in as many words — *the token travels in a header, never in the URL* — so this was the weaker spelling of one rule, sitting on the more exposed artefact. It also made `test_the_url_carries_the_id_and_nothing_else`, one test above it, false.

The share now lives **on the record** and its recipient redeems it against the scaffold id:

| | |
|---|---|
| `scaffolds.py:505-535` | `hand_share` — hands the token to the recipient, records `share_handed_at`/`share_handed_to` |
| `api.py:2283-2313` | `POST /api/scaffolds/{id}/share` — the route |
| `api.py:2020-2038` | `_scaffold_recipient_is` — a **stricter** predicate than the read's |
| `api.py:2062-2072`, `2160-2172` | the mint stores it and stops composing it |
| `api.py:1990-2000` | the read says `has_share` and `share_handed_at`, never the token |
| `scaffold.ts:161-193`, `App.tsx:107-131` | `redeemScaffoldShare`, and the `?s=` landing effect |

Three things worth pulling out of that table:

**An admin may debug a record and may never hold the capability.** The read route admits the instance admin — a scaffold is a support surface. A bearer grant on somebody else's meeting transcript is not, so the share route runs the read's three identity tests *minus* its admin clause and with no service-key door. The internal tier hands the token IN at mint and gets no way to pull it back out.

**The URL is cleaned only after the redemption.** `location.replace` aborts the request in flight; the old `?s=` effect replaced synchronously.

**Not strictly single-use, deliberately.** It is idempotent for the same recipient subject, the way `redeem` already treats `redeemed_at`. A one-shot hand-out turns a single dropped response into a person permanently unable to open the meeting they were invited to — a worse failure than the one being fixed. What carries the security is that the token is never in a URL and is only ever handed to the identity the record names; the record expires anyway (R-A10's `TTL_SECONDS`), so the capability is bounded by time rather than by a counter.

### R-A13 came with it, because it is load-bearing here

`api.py:2262-2276`. `read_scaffold` called `scaffolds.redeem` for **any** admitted caller, so an admin's debugging read stamped `redeemed_by` with the admin — and `scaffolds.redeem`'s own docstring calls that stamp *"the only measurement the alpha ledger's 'seconds to act' column is made of"*. It is worse than a spoiled metric: `redeemed_by == subject` is one of the three identity tests **both** scaffold predicates run, so a stamp written by an admin's read promoted that admin to "the recipient" on every later call — including the share hand-out one route down. The admin-refusal test is red without this change; that is how it was found.

---

## R-E08 — "encrypted at rest" stops being free in production

`secret_store`'s docstring was always honest: a generated key lands in the same directory as the ciphertext, so it defends a stray read, a mis-scoped mount or a log, and **not** a stolen volume or a backup. The escape was `VEXA_SECRETS_KEY` — and it appeared in no compose file, no `.env.example` and no helm values, so **no shipped deployment could set it**. Every deployment took the weaker property while the documentation asserted the stronger one.

Two halves, neither worth anything alone:

- **the deployment can set it** — `docker-compose.yml` (agent-api env), `.env.example`, helm `values.yaml` (`secrets.secretsKey`, `vexaEnv`), `templates/secret.yaml`, `templates/deployment-agent-api.yaml`;
- **generation is a development convenience and says so** — `secret_store.py:52-92` (`SecretStoreUnconfigured`, `is_production`) and `:137-152` (refuses in production, warns loudly every time it generates). `put` takes the key **before** touching disk (`:240-246`) so a refusal leaves nothing half-created.

`VEXA_ENV` is the profile word this repo already uses for exactly this (`transcription/main.py:154-155`, `vexa_mcp/app.py:587`), and only the exact word `production` counts — unset, `development`, `staging`, `local` and a typo are all "not production". **So nothing that runs today changes**, including the dogfood rig that #1430 routes through this same store, and the refusal bites precisely where the sentence is load-bearing.

**The read path is untouched, deliberately.** `get` sits on the git hot path where "no credential" is an ordinary answer (R-E13); turning that into an exception would be a new failure, not a fix. The refusal is on the write.

Declared in `config.v1.json`, and the declared-key tripwire bumped in the same commit as its own comment requires — resolved to **88** on rebase, because `flows-authz` added `VEXA_ROOM_MEETING` and this adds `VEXA_ENV`; the union is one more than either side alone.

Two of the thirteen tests assert the half with no code in it: the key must be settable on every shipped surface, and agent-api's container must actually receive the profile it is judged against. **A refusal an operator cannot act on is worse than the silent generation it replaces.**

---

## R-D03 — scoped, not done, and smaller than the brief

Read against the tip after #1430 landed, two of its three parts are already closed and I did not re-litigate either:

- the `==` compare — **already `hmac.compare_digest`** (`vexa_control_mcp.py:992`, plus `:569`, `:822`, `:5316`), landed with F95;
- the `/w/` durable-bearer acceptance — **already refused** (`:1540-1547`), landed as #1430's R-D04 view tokens.

What remains is the **`token=` call-argument fallback** (`:1118`) and the **`/do/<tool>?token=`** bridge, both gated by `RIG_MODE`, which defaults **on** (`:314-319`). #1430's author states the same in their PR body: *"I did not touch the `token=` query-param path or the `==` compare — that remainder is still open."*

It is left out of this PR on purpose: closing it means changing how the dogfood rig authenticates **today** — the file's own comment calls the query-string credential *"right for a fetch-only agent on a private host and wrong anywhere requests are logged"*, and flipping that default is a live behaviour change on the founder's running rig, not a hardening no-op. It wants its own change with its own witness, not a rider on two unrelated rows.

---

## Proof

- **Agent suite:** `1612 passed, 0 failed` (`uv run --frozen pytest` in `core/agent`). The `requests_unixsocket` standing red is gone — the line fixed it.
- **Terminal:** `1156 passed`, `tsc --noEmit` clean.
- **Flows:** `362 passed, 2 skipped, 0 failed`.
- **Gates:** all 14 pre-push gates green. `gate:config-contract` caught the undeclared `VEXA_ENV` on the first run and is the reason it is declared. Pushed **without** `--no-verify`.
- **Red first:** commits 1 and 3 are the tests alone — 5 failing for R-A08, 5 for R-E08 — against the tip they were written on.
- Rebased onto `31c0b6e1c` and re-proved after the rebase; one conflict, in the declared-key tripwire, resolved as the union of both lanes.

Run on `bbb`, in a fresh worktree.

---

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

> **Left unticked deliberately** — a legal certification only the submitting human may make. The
> same goes for the DCO `Signed-off-by` trailer.

## Docs diff (D6c)

`deploy/compose/.env.example` and the helm values carry the operator-facing explanation of
`VEXA_SECRETS_KEY` and `VEXA_ENV`, and `config.v1.json` is the reference surface for both. No
documented API shape changed: `POST /api/scaffolds/{id}/share` is new and internal to the terminal,
and the mailed link kept its documented form (`/?s=<id>`) — it lost an undocumented parameter.
