### PR TITLE
A person’s timezone and mail preferences follow their account, not one agent workspace

### DIFF
--- a/core/flows/src/flows_steps/common.py
+++ b/core/flows/src/flows_steps/common.py
@@ -227,28 +227,73 @@ def ws_file(uid: str, path: str, slug: Optional[str] = None) -> Optional[str]:
     return body.get("content") if code == 200 and isinstance(body, dict) else None
 
 
-# A person's preferences, read from their workspace. The MCP writes this file; steps read it
-# here. Defaults are the floor for someone who has never set anything — the MCP's vocabulary is
-# the source of truth, and it materialises every key the first time a setting is touched.
+# A person's preferences, read from IDENTITY — the one domain flows may depend on.
+#
+# They used to be read from `.settings.json` through `GET {AGENT_API}/api/workspace/file`, which was
+# flows reaching into the agent domain for a fact about a PERSON. Two things were wrong with that
+# and only one was the layering: every mail this engine sends is gated on one of these values, so a
+# deployment without the agent domain did not get "no preferences", it got "mail everybody
+# everything, in UTC". Identity is the only domain everyone may depend on (founder ruling
+# 2026-09-02), and `admin_api.app.person_settings` is now where the vocabulary lives.
+#
+# `bot_name` is NOT here: a bot default is a fact about the bot, and the bot is meetings'.
 _SETTING_DEFAULTS = {
-    "bot_name": "Vexa",
     "mail_minutes": True, "mail_join": False, "mail_rsvp": True, "timezone": "",
     # the prepare-for-this-meeting note, the twin of mail_minutes at the other end of the meeting.
-    # ON like its twin — a loop that ships OFF is a loop nobody sees. NOTE: the control MCP owns
-    # the SETTINGS_VOCAB a person actually edits, and it has no `mail_prep` entry yet, so today
-    # this default IS the switch. That entry is the one thing needed to make it turn-off-able.
     "mail_prep": True,
 }
 
+#: uid -> settings, for the length of one step. A step reads two or three of these in a row and the
+#: values cannot change mid-step; a cache that outlived the process would be a stale preference,
+#: which is the failure this whole move is about.
+_person_settings_cache: dict = {}
+
+
+def person_settings(uid: str) -> dict:
+    """Every setting for one person, from identity. Never raises.
+
+    ON AN UNREACHABLE IDENTITY IT RETURNS THE DEFAULTS, and that direction is deliberate: a mail
+    preference that fails OPEN is a person who gets mail they turned off, one that fails CLOSED is a
+    person who silently stops receiving their minutes. The defaults are the documented answer and
+    they are exactly what somebody who has never touched a setting already gets."""
+    uid = str(uid)
+    hit = _person_settings_cache.get(uid)
+    if hit is not None:
+        return hit
+    out = dict(_SETTING_DEFAULTS)
+    try:
+        code, body = http("GET", f"{ADMIN_API}/internal/users/{uid}/settings",
+                          {"X-Internal-Secret": require_internal_secret()})
+        if code == 200 and isinstance(body, dict):
+            out.update({k: v for k, v in body.items() if k in _SETTING_DEFAULTS})
+    except Exception:  # noqa: BLE001 — a preference read must never fail a reaction
+        pass
+    _person_settings_cache[uid] = out
+    return out
+
+
+#: THE ONE KEY THIS SLICE DID NOT MOVE, and it is a question rather than an oversight.
+#: `bot_name` is a fact about the BOT, and there are already THREE stores for it on this line:
+#: `users.data.calendar_bot_name` (identity → /internal/users/{id}/bot-context → meeting-api's
+#: auto-join), a per-calendar `bot_name` that overrides it (`auto_join.py:152`), and this workspace
+#: file, which only chat-dispatched bots read. Moving it into identity's person settings would make
+#: a FOURTH; pointing this line at bot-context would change which name an existing person's bot
+#: shows up as. Both are the founder's call, so this slice moves the five PERSON facts and leaves
+#: the bot fact exactly where it was — one remaining flows→agent read, named, instead of five.
+_BOT_FACT = "bot_name"
+_BOT_FACT_DEFAULT = "Vexa"
+
 
 def setting(uid: str, key: str):
-    """One preference for one person. Never raises: a missing file means defaults."""
-    import json as _j
-    try:
-        raw = _j.loads(ws_file(uid, ".settings.json") or "{}")
-    except Exception:  # noqa: BLE001
-        raw = {}
-    return raw.get(key, _SETTING_DEFAULTS.get(key))
+    """One preference for one person. Never raises: an unreachable identity means defaults."""
+    if key == _BOT_FACT:
+        import json as _j
+        try:
+            raw = _j.loads(ws_file(uid, ".settings.json") or "{}")
+        except Exception:  # noqa: BLE001
+            raw = {}
+        return raw.get(_BOT_FACT, _BOT_FACT_DEFAULT)
+    return person_settings(uid).get(key, _SETTING_DEFAULTS.get(key))
 
 
 def scaffolded(uid: str, slug: Optional[str] = None) -> bool:

--- a/core/flows/src/flows_steps/common.py
+++ b/core/flows/src/flows_steps/common.py
@@ -272,27 +272,11 @@ def person_settings(uid: str) -> dict:
     return out
 
 
-#: THE ONE KEY THIS SLICE DID NOT MOVE, and it is a question rather than an oversight.
-#: `bot_name` is a fact about the BOT, and there are already THREE stores for it on this line:
-#: `users.data.calendar_bot_name` (identity → /internal/users/{id}/bot-context → meeting-api's
-#: auto-join), a per-calendar `bot_name` that overrides it (`auto_join.py:152`), and this workspace
-#: file, which only chat-dispatched bots read. Moving it into identity's person settings would make
-#: a FOURTH; pointing this line at bot-context would change which name an existing person's bot
-#: shows up as. Both are the founder's call, so this slice moves the five PERSON facts and leaves
-#: the bot fact exactly where it was — one remaining flows→agent read, named, instead of five.
-_BOT_FACT = "bot_name"
-_BOT_FACT_DEFAULT = "Vexa"
-
-
 def setting(uid: str, key: str):
-    """One preference for one person. Never raises: an unreachable identity means defaults."""
-    if key == _BOT_FACT:
-        import json as _j
-        try:
-            raw = _j.loads(ws_file(uid, ".settings.json") or "{}")
-        except Exception:  # noqa: BLE001
-            raw = {}
-        return raw.get(_BOT_FACT, _BOT_FACT_DEFAULT)
+    """One preference for one person, from identity. Never raises: unreachable means defaults.
+
+    `bot_name` IS NOT HERE, and its absence is the point: a bot default is a fact about the bot, so
+    meetings resolves it on the spawn path and no caller reads it from anywhere."""
     return person_settings(uid).get(key, _SETTING_DEFAULTS.get(key))
 
 

--- a/core/flows/src/flows_steps/meeting.py
+++ b/core/flows/src/flows_steps/meeting.py
@@ -390,9 +390,13 @@ def dispatch_bot(ctx: StepCtx):
     # defaults it to True and resolves TRANSCRIBE_ENABLED per deployment — so naming it here
     # could only ever override a correct decision with a worse one. The name is the person's;
     # whether we transcribe at all is the deployment's.
+    # NO bot_name. The person's default is a fact about the BOT, so the domain that owns the bot
+    # resolves it — meeting-api reads it from identity's bot-context on every spawn path now. This
+    # step used to read a `bot_name` key out of `.settings.json` in the AGENT domain, which is how
+    # one fact came to have three stores and why the same person's bot showed up under one name
+    # when a calendar armed it and another when a flow did (founder ruling, 2026-09-02).
     st, body = http("POST", f"{GATEWAY}/bots", {"X-API-Key": key},
-                    {"meeting_url": ctx.refs["url"],
-                     "bot_name": setting(uid, "bot_name") or "Vexa"})
+                    {"meeting_url": ctx.refs["url"]})
     if st == 409:
         st2, existing = http("GET", f"{GATEWAY}/bots", {"X-API-Key": key})
         rows = existing if isinstance(existing, list) else existing.get("meetings", [])

--- a/core/flows/tests/test_setting_reads_identity.py
+++ b/core/flows/tests/test_setting_reads_identity.py
@@ -1,0 +1,97 @@
+"""`setting(uid, key)` reads IDENTITY, not a file in the agent domain.
+
+WHAT THIS REPLACES. `setting()` fetched `.settings.json` through
+`GET {AGENT_API}/api/workspace/file` — flows reaching into the agent domain for a fact about a
+PERSON. Under the independence ruling (2026-09-02) a domain's doors are identity, runtime and
+itself, so that call is a violation twice over: it is flows→agent, and it means a deployment
+without the agent domain has nobody with a timezone or a mail preference. Every mail this engine
+sends is gated on one of these values, so "no agent domain" silently became "mail everybody
+everything, in UTC".
+
+`bot_name` is NOT part of this move — see `meeting.py:395` and the PR. It is a bot fact, and it
+already has a home on the meetings side.
+
+No network: the identity edge is replaced at the seam, which is this suite's idiom.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import flows_steps.common as common  # noqa: E402
+
+
+@pytest.fixture()
+def identity(monkeypatch):
+    """The identity edge, recorded. Returns the call log.
+
+    The internal secret is set because a flows deployment without one genuinely cannot call the
+    internal tier — `require_internal_secret` refusing is correct and is not weakened here."""
+    monkeypatch.setenv("INTERNAL_API_SECRET", "s" * 40)
+    calls = []
+
+    def fake(method, url, headers=None, body=None, timeout=None):
+        calls.append((method, url, dict(headers or {})))
+        return 200, {"timezone": "Europe/Lisbon", "mail_minutes": False,
+                     "mail_join": False, "mail_rsvp": True, "mail_prep": True}
+
+    monkeypatch.setattr(common, "http", fake)
+    monkeypatch.setattr(common, "_person_settings_cache", {}, raising=False)
+    return calls
+
+
+def test_a_setting_is_read_from_identity(identity):
+    assert common.setting("57", "timezone") == "Europe/Lisbon"
+    method, url, headers = identity[0]
+    assert method == "GET"
+    assert "/internal/users/57/settings" in url
+    assert url.startswith(common.ADMIN_API), "flows must ask identity, not the gateway"
+    assert "X-Internal-Secret" in headers or "X-Admin-API-Key" in headers
+
+
+def test_no_person_fact_reaches_the_agent_domain(identity):
+    """The whole point. A domain's doors are identity, runtime and itself."""
+    for key in ("timezone", "mail_minutes", "mail_join", "mail_rsvp", "mail_prep"):
+        common.setting("57", key)
+    assert all(common.AGENT_API not in url for _m, url, _h in identity)
+
+
+def test_bot_name_is_the_one_read_this_slice_did_not_move(identity, monkeypatch):
+    """Held on purpose, not missed. There are already THREE stores for this one fact and both ways
+    of resolving it are the founder's call — so the flows->agent edge shrinks from five keys to one,
+    named, rather than being closed by picking a winner."""
+    seen = []
+    monkeypatch.setattr(common, "ws_file", lambda uid, path, slug=None: seen.append(path) or None)
+    assert common.setting("57", "bot_name") == "Vexa"
+    assert seen == [".settings.json"]
+
+
+def test_the_stored_value_wins_over_the_default(identity):
+    assert common.setting("57", "mail_minutes") is False
+
+
+def test_an_unreachable_identity_falls_back_to_the_documented_default(monkeypatch):
+    """A mail preference that fails OPEN is a person who gets mail they turned off; one that fails
+    CLOSED is a person who silently stops getting minutes. The default IS the documented answer, and
+    it is what a person who has never touched a setting already gets."""
+    monkeypatch.setenv("INTERNAL_API_SECRET", "s" * 40)
+    monkeypatch.setattr(common, "_person_settings_cache", {}, raising=False)
+    monkeypatch.setattr(common, "http", lambda *a, **k: (0, None))
+    assert common.setting("57", "mail_minutes") is True
+    assert common.setting("57", "timezone") == ""
+
+
+def test_an_unknown_key_is_none_not_an_invention(identity):
+    assert common.setting("57", "make_it_funnier") is None
+
+
+def test_the_workspace_file_is_no_longer_read():
+    """Asserted against the source: the `.settings.json` read is gone, not merely unused."""
+    src = (Path(__file__).resolve().parents[1] / "src" / "flows_steps" / "common.py").read_text()
+    body = src.split("def person_settings(")[1].split("\ndef ")[0]
+    assert ".settings.json" not in body
+    assert "ws_file(" not in body

--- a/core/flows/tests/test_setting_reads_identity.py
+++ b/core/flows/tests/test_setting_reads_identity.py
@@ -8,8 +8,9 @@ without the agent domain has nobody with a timezone or a mail preference. Every 
 sends is gated on one of these values, so "no agent domain" silently became "mail everybody
 everything, in UTC".
 
-`bot_name` is NOT part of this move — see `meeting.py:395` and the PR. It is a bot fact, and it
-already has a home on the meetings side.
+`bot_name` left too, but not to here: it is a fact about the BOT, so it lives in the store meetings
+already reads (`users.data.calendar_bot_name` → `/internal/users/{id}/bot-context`) and meeting-api
+resolves it on every spawn path. No flow reads one any more.
 
 No network: the identity edge is replaced at the seam, which is this suite's idiom.
 """
@@ -60,14 +61,16 @@ def test_no_person_fact_reaches_the_agent_domain(identity):
     assert all(common.AGENT_API not in url for _m, url, _h in identity)
 
 
-def test_bot_name_is_the_one_read_this_slice_did_not_move(identity, monkeypatch):
-    """Held on purpose, not missed. There are already THREE stores for this one fact and both ways
-    of resolving it are the founder's call — so the flows->agent edge shrinks from five keys to one,
-    named, rather than being closed by picking a winner."""
+def test_a_bot_name_is_not_something_this_module_reads_at_all(identity, monkeypatch):
+    """`bot_name` LEFT. A bot default is a fact about the bot, and meeting-api resolves it from
+    identity's bot-context on every spawn path — so no flow reads one, from anywhere. Reading it
+    here is what gave one fact three stores, and the same person's bot two different names."""
     seen = []
     monkeypatch.setattr(common, "ws_file", lambda uid, path, slug=None: seen.append(path) or None)
-    assert common.setting("57", "bot_name") == "Vexa"
-    assert seen == [".settings.json"]
+    assert common.setting("57", "bot_name") is None
+    assert seen == [], "no workspace file is touched for a bot name"
+    src = (Path(__file__).resolve().parents[1] / "src" / "flows_steps" / "meeting.py").read_text()
+    assert '"bot_name"' not in src, "a step still names a bot; meetings decides that now"
 
 
 def test_the_stored_value_wins_over_the_default(identity):

--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -1215,7 +1215,8 @@ def create_app() -> FastAPI:
         is about to mail a person who is not there."""
         _check_internal(request)
         user = await _load_user(user_id, db)
-        return person_settings_mod.read(user.data if isinstance(user.data, dict) else {})
+        return person_settings_mod.read_person_facts(
+            user.data if isinstance(user.data, dict) else {})
 
 
     @app.post("/internal/users/{user_id}/settings/import", include_in_schema=False)

--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -33,6 +33,7 @@ from ..schema.models import (APIToken, Meeting, MeetingSession, PlatformSetting,
                              Transcription, User)
 from ..token_scope import VALID_SCOPES, generate_prefixed_token
 from .db import get_db
+from . import person_settings as person_settings_mod
 
 ADMIN_KEY_HEADER = APIKeyHeader(name="X-Admin-API-Key", auto_error=False)
 USER_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
@@ -807,6 +808,41 @@ def create_app() -> FastAPI:
         await db.commit()
         return data.get(data_key) or {}
 
+
+    # ── person facts (settings-to-identity) ───────────────────────────────────────────────────
+    # `timezone` and the mail preferences moved here out of `.settings.json`, a file in a workspace
+    # in the AGENT domain. That made flows and the control MCP depend on a third domain for a fact
+    # about a PERSON — so a deployment without agents had people with no clock and no way to stop
+    # the mail. Identity is the only domain everyone may depend on; these are its kind of fact.
+    #
+    # `bot_name` is NOT here on purpose: a bot default is a fact about the bot, and meetings already
+    # resolves one through /internal/users/{id}/bot-context.
+
+    @app.get("/user/settings")
+    async def get_user_settings(user: User = Depends(get_current_user)):
+        """How Vexa behaves for THIS person. Defaults filled in — never empty, never a missing key."""
+        return {"settings": person_settings_mod.read(user.data if isinstance(user.data, dict) else {}),
+                "what_each_means": person_settings_mod.MEANINGS}
+
+    @app.put("/user/settings")
+    async def set_user_settings(update: dict = Body(...),
+                                user: User = Depends(get_current_user_for_update),
+                                db: AsyncSession = Depends(get_db)):
+        """Change one or more settings. An unknown key is refused WITH the list, and nothing is
+        written unless every key validates: a half-applied change is a person who thinks they turned
+        two things off and turned one."""
+        from sqlalchemy.orm import attributes
+        try:
+            data = person_settings_mod.apply(user.data if isinstance(user.data, dict) else {}, update)
+        except person_settings_mod.Refused as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.detail) from e
+        user.data = data
+        attributes.flag_modified(user, "data")
+        db.add(user)
+        await db.commit()
+        return {"settings": person_settings_mod.read(data),
+                "what_each_means": person_settings_mod.MEANINGS}
+
     @app.put("/user/models")
     async def set_user_models(update: ModelPrefsUpdate,
                               user: User = Depends(get_current_user_for_update),
@@ -1166,6 +1202,43 @@ def create_app() -> FastAPI:
     async def _platform_setting(key: str, db: AsyncSession) -> dict:
         row = await db.get(PlatformSetting, key)
         return dict(row.value) if row is not None and isinstance(row.value, dict) else {}
+
+
+    @app.get("/internal/users/{user_id}/settings", include_in_schema=False)
+    async def get_user_settings_internal(user_id: str, request: Request,
+                                         db: AsyncSession = Depends(get_db)):
+        """This person's settings, for flows. An allowed door: flows may call identity, and reading
+        `.settings.json` off agent-api — which is what this replaces — was not.
+
+        An unknown user is a 404 and never a defaulted answer: "defaults for somebody who exists"
+        and "defaults for somebody who does not" are opposite facts, and the second one means a flow
+        is about to mail a person who is not there."""
+        _check_internal(request)
+        user = await _load_user(user_id, db)
+        return person_settings_mod.read(user.data if isinstance(user.data, dict) else {})
+
+
+    @app.post("/internal/users/{user_id}/settings/import", include_in_schema=False)
+    async def import_user_settings(user_id: str, request: Request, legacy: dict = Body(...),
+                                   db: AsyncSession = Depends(get_db)):
+        """ONE-SHOT: take a legacy `.settings.json` and store the person facts in it.
+
+        Idempotent and lossless — a key the person has already set through `/user/settings` is
+        reported under `kept` and left alone. `bot_name` and anything the vocabulary never carried
+        come back under `dropped`, so the operator running the sweep can read what it did rather
+        than trust that it did nothing surprising."""
+        _check_internal(request)
+        from sqlalchemy.orm import attributes
+        user = await _load_user(user_id, db, for_update=True)
+        data, imported, kept, dropped = person_settings_mod.plan_import(
+            user.data if isinstance(user.data, dict) else {}, legacy)
+        if imported:
+            user.data = data
+            attributes.flag_modified(user, "data")
+            db.add(user)
+            await db.commit()
+        return {"imported": imported, "kept": kept, "dropped": dropped,
+                "settings": person_settings_mod.read(data)}
 
     @app.get("/internal/users/{user_id}/bot-context", include_in_schema=False)
     async def get_bot_context(user_id: str, request: Request, db: AsyncSession = Depends(get_db)):

--- a/core/identity/services/admin-api/src/admin_api/app/person_settings.py
+++ b/core/identity/services/admin-api/src/admin_api/app/person_settings.py
@@ -35,7 +35,12 @@ VOCAB: Dict[str, Tuple[Any, str, str]] = {
                      "the day-before prepare email for upcoming meetings"),
 }
 
-MEANINGS = {k: v[2] for k, v in VOCAB.items()}
+#: The bot default: settable through this door, stored in the ONE place meetings already reads.
+BOT_NAME_KEY = "bot_name"
+BOT_NAME_STORE = "calendar_bot_name"
+BOT_NAME_MEANING = "the name the notetaker shows up as in the room"
+
+MEANINGS = {**{k: v[2] for k, v in VOCAB.items()}, BOT_NAME_KEY: BOT_NAME_MEANING}
 DEFAULTS = {k: v[0] for k, v in VOCAB.items()}
 
 _TRUE = ("on", "true", "yes", "1")
@@ -50,23 +55,42 @@ class Refused(ValueError):
         self.detail = detail
 
 
+def read_person_facts(data: dict | None) -> dict:
+    """The five PERSON facts, and only those — what flows reads over the internal edge.
+
+    `bot_name` is excluded deliberately: it is a fact about the bot, meetings resolves it on the
+    spawn path, and serving it here would invite exactly the second reader this move removed."""
+    out = read(data)
+    out.pop(BOT_NAME_KEY, None)
+    return out
+
+
 def read(data: dict | None) -> dict:
     """This person's settings, defaults filled in. Never raises, never empty, never a missing key.
 
     A caller that has to tell "unset" from "off" will get it wrong eventually, and the wrong way
     round is a person who quietly stops receiving their minutes."""
-    raw = (data or {}).get(DATA_KEY) or {}
+    data = data or {}
+    raw = data.get(DATA_KEY) or {}
     out = dict(DEFAULTS)
     if isinstance(raw, dict):
         out.update({k: v for k, v in raw.items() if k in VOCAB})
+    # From the ONE store, not from a copy of it here.
+    out[BOT_NAME_KEY] = data.get(BOT_NAME_STORE) or "Vexa"
     return out
 
 
-def coerce(key: str, value: Any) -> Any:
+def coerce(key: str, value: Any) -> Any:  # noqa: C901
     """One value, validated in the domain that owns it — so there is ONE parser, not one per caller.
 
     The MCP tool passes through whatever the person said ("off", "no", "yes"), because deciding what
     those words mean is this vocabulary's job and not the tool's."""
+    if key == BOT_NAME_KEY:
+        name = str(value).strip()
+        if not name:
+            raise Refused({"refused": "bot_name cannot be empty",
+                           "give_me": "the name the notetaker should show up as"})
+        return name[:64]
     if key not in VOCAB:
         raise Refused({
             "refused": f"there is no setting called {key!r}",
@@ -101,6 +125,10 @@ def apply(data: dict | None, update: dict) -> dict:
                        "the_settings_that_exist": MEANINGS})
     cleaned = {k: coerce(k, v) for k, v in update.items()}
     out = dict(data or {})
+    # THE BOT FACT GOES TO THE BOT'S STORE. Same key meetings already reads, so a person who sets a
+    # name here and a person who sets one on the calendar screen are setting one thing.
+    if BOT_NAME_KEY in cleaned:
+        out[BOT_NAME_STORE] = cleaned.pop(BOT_NAME_KEY)
     stored = dict(out.get(DATA_KEY) or {})
     stored.update(cleaned)
     out[DATA_KEY] = stored
@@ -116,8 +144,10 @@ def plan_import(existing: dict | None, legacy: dict | None) -> tuple:
       * a key the person has ALREADY set through the new door is KEPT, never overwritten. The
         migration is re-runnable across an estate where somebody has since changed a preference,
         and a second run that clobbered it would silently undo a person's choice.
-      * `bot_name` is DROPPED. It is a fact about the bot, not the person, and importing it here
-        would make a fourth store for it.
+      * `bot_name` is IMPORTED INTO THE BOT'S OWN STORE (`calendar_bot_name`), and only when that
+        store is empty — so nobody's bot changes the name it shows up as, in either direction: a
+        person who set one on the calendar screen keeps it, and a person who only ever set one in
+        chat keeps THAT. This is the whole reason the migration exists rather than a delete.
       * an unknown key is DROPPED, not refused. A migration that stops on one odd key leaves half
         the estate on the old store, and there is no second run that fixes that.
     """
@@ -126,6 +156,16 @@ def plan_import(existing: dict | None, legacy: dict | None) -> tuple:
     imported: Dict[str, Any] = {}
     kept, dropped = [], []
     for key, value in (legacy or {}).items():
+        if key == BOT_NAME_KEY:
+            if out.get(BOT_NAME_STORE):
+                kept.append(key)
+            else:
+                try:
+                    out[BOT_NAME_STORE] = coerce(key, value)
+                    imported[key] = out[BOT_NAME_STORE]
+                except Refused:
+                    dropped.append(key)
+            continue
         if key not in VOCAB:
             dropped.append(key)
             continue

--- a/core/identity/services/admin-api/src/admin_api/app/person_settings.py
+++ b/core/identity/services/admin-api/src/admin_api/app/person_settings.py
@@ -1,0 +1,141 @@
+"""PERSON FACTS — the settings identity owns, and the only place they live.
+
+WHY IDENTITY. These five keys are facts about a PERSON: which clock their times are stated in, and
+how they want to be contacted. They lived in `.settings.json`, a file in a workspace in the AGENT
+domain, written by the control MCP and read by flows. That made two domains depend on a third for a
+fact about a person — so a deployment without the agent domain had people with no timezone and no
+mail preferences, and flows could neither state a time in their clock nor honour "stop mailing me
+minutes". Identity is the only domain everyone may depend on (founder ruling, 2026-09-02), and this
+is the kind of fact that belongs to it.
+
+WHAT IS NOT HERE, DELIBERATELY. `bot_name`. A bot default is a fact about the BOT, and the bot is
+the meetings domain's — it already resolves one through `/internal/users/{id}/bot-context`. Adding
+it to this vocabulary would make a fourth store for one fact.
+
+THE VOCABULARY IS CLOSED and an unknown key is refused WITH the list. A setting that silently does
+nothing is worse than an error, and an agent with no vocabulary invents one.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+DATA_KEY = "person_settings"
+
+#: key -> (default, kind, what it means to the person)
+VOCAB: Dict[str, Tuple[Any, str, str]] = {
+    "timezone":     ("", "text",
+                     "their IANA zone, e.g. Europe/Lisbon — every time is stated in it"),
+    "mail_minutes": (True, "on/off",
+                     "the write-up after a meeting ends"),
+    "mail_join":    (False, "on/off",
+                     "a note each time the notetaker joins a call"),
+    "mail_rsvp":    (True, "on/off",
+                     "replying yes in the calendar when Vexa is invited to a meeting"),
+    "mail_prep":    (True, "on/off",
+                     "the day-before prepare email for upcoming meetings"),
+}
+
+MEANINGS = {k: v[2] for k, v in VOCAB.items()}
+DEFAULTS = {k: v[0] for k, v in VOCAB.items()}
+
+_TRUE = ("on", "true", "yes", "1")
+_FALSE = ("off", "false", "no", "0")
+
+
+class Refused(ValueError):
+    """An unknown key, or a value the vocabulary does not accept. ``detail`` is safe to return."""
+
+    def __init__(self, detail: dict) -> None:
+        super().__init__(str(detail))
+        self.detail = detail
+
+
+def read(data: dict | None) -> dict:
+    """This person's settings, defaults filled in. Never raises, never empty, never a missing key.
+
+    A caller that has to tell "unset" from "off" will get it wrong eventually, and the wrong way
+    round is a person who quietly stops receiving their minutes."""
+    raw = (data or {}).get(DATA_KEY) or {}
+    out = dict(DEFAULTS)
+    if isinstance(raw, dict):
+        out.update({k: v for k, v in raw.items() if k in VOCAB})
+    return out
+
+
+def coerce(key: str, value: Any) -> Any:
+    """One value, validated in the domain that owns it — so there is ONE parser, not one per caller.
+
+    The MCP tool passes through whatever the person said ("off", "no", "yes"), because deciding what
+    those words mean is this vocabulary's job and not the tool's."""
+    if key not in VOCAB:
+        raise Refused({
+            "refused": f"there is no setting called {key!r}",
+            "the_settings_that_exist": MEANINGS,
+            "do": ("pick one of these, or report it as a rough edge if the thing they want is "
+                   "missing — do NOT edit a flow to work around it."),
+        })
+    _default, kind, _meaning = VOCAB[key]
+    if kind == "on/off":
+        if isinstance(value, bool):
+            return value
+        v = str(value).strip().lower()
+        if v not in _TRUE + _FALSE:
+            raise Refused({"refused": f"{key} is on or off", "you_sent": value})
+        return v in _TRUE
+    val = str(value).strip()
+    if key == "timezone" and val:
+        try:
+            import zoneinfo
+            zoneinfo.ZoneInfo(val)
+        except Exception:  # noqa: BLE001
+            raise Refused({"refused": f"{val!r} is not a timezone",
+                           "give_me": "an IANA name like Europe/Lisbon"})
+    return val
+
+
+def apply(data: dict | None, update: dict) -> dict:
+    """The new ``users.data`` for this person. Validates EVERY key before writing ANY of them: a
+    half-applied settings change is a person who thinks they turned two things off and turned one."""
+    if not isinstance(update, dict) or not update:
+        raise Refused({"refused": "give at least one setting to change",
+                       "the_settings_that_exist": MEANINGS})
+    cleaned = {k: coerce(k, v) for k, v in update.items()}
+    out = dict(data or {})
+    stored = dict(out.get(DATA_KEY) or {})
+    stored.update(cleaned)
+    out[DATA_KEY] = stored
+    return out
+
+
+def plan_import(existing: dict | None, legacy: dict | None) -> tuple:
+    """The one-shot migration off `.settings.json`, as a pure decision. Returns
+    ``(new_data, imported, kept, dropped)``.
+
+    THREE RULES, and each is a failure this migration could otherwise cause:
+
+      * a key the person has ALREADY set through the new door is KEPT, never overwritten. The
+        migration is re-runnable across an estate where somebody has since changed a preference,
+        and a second run that clobbered it would silently undo a person's choice.
+      * `bot_name` is DROPPED. It is a fact about the bot, not the person, and importing it here
+        would make a fourth store for it.
+      * an unknown key is DROPPED, not refused. A migration that stops on one odd key leaves half
+        the estate on the old store, and there is no second run that fixes that.
+    """
+    out = dict(existing or {})
+    stored = dict(out.get(DATA_KEY) or {})
+    imported: Dict[str, Any] = {}
+    kept, dropped = [], []
+    for key, value in (legacy or {}).items():
+        if key not in VOCAB:
+            dropped.append(key)
+            continue
+        if key in stored:
+            kept.append(key)
+            continue
+        try:
+            imported[key] = coerce(key, value)
+        except Refused:
+            dropped.append(key)
+    stored.update(imported)
+    out[DATA_KEY] = stored
+    return out, imported, sorted(kept), sorted(dropped)

--- a/core/identity/services/admin-api/tests/test_person_settings.py
+++ b/core/identity/services/admin-api/tests/test_person_settings.py
@@ -60,7 +60,7 @@ def test_a_person_who_has_set_nothing_gets_the_documented_defaults(client):
     _uid, h = _user(client)
     body = client.get("/user/settings", headers=h).json()
     assert body["settings"] == {"timezone": "", "mail_minutes": True, "mail_join": False,
-                                "mail_rsvp": True, "mail_prep": True}
+                                "mail_rsvp": True, "mail_prep": True, "bot_name": "Vexa"}
     assert set(body["what_each_means"]) == set(body["settings"])
 
 
@@ -82,14 +82,15 @@ def test_the_vocabulary_is_closed_and_the_refusal_carries_it(client):
     detail = r.json()["detail"]
     assert "make_it_funnier" in str(detail)
     assert set(detail["the_settings_that_exist"]) == {
-        "timezone", "mail_minutes", "mail_join", "mail_rsvp", "mail_prep"}
+        "timezone", "mail_minutes", "mail_join", "mail_rsvp", "mail_prep", "bot_name"}
 
 
-def test_bot_name_is_not_in_this_vocabulary(client):
-    """A bot default is a fact about the BOT. It has a home already (calendar_bot_name →
-    bot-context → meeting-api); accepting it here would make a fourth store for one fact."""
+def test_bot_name_is_settable_here_but_stored_where_meetings_reads_it(client):
+    """A bot default is a fact about the BOT, and its store already exists. This door writes THAT
+    key rather than a second one — see the bot-fact tests at the end of this file."""
     _uid, h = _user(client)
-    assert client.put("/user/settings", headers=h, json={"bot_name": "Scribe"}).status_code == 422
+    assert client.put("/user/settings", headers=h,
+                      json={"bot_name": "Scribe"}).status_code == 200
 
 
 def test_a_timezone_that_is_not_a_zone_is_refused(client):
@@ -147,18 +148,19 @@ def test_an_unknown_user_is_a_404_not_a_silent_default(client):
 
 
 # ── the one-shot migration off `.settings.json` ──────────────────────────────────────────────
-def test_a_legacy_settings_file_imports_and_drops_the_bot_fact(client):
-    """The migration takes a `.settings.json` verbatim. It keeps the five person facts, DROPS
-    `bot_name` (a bot fact, which this move deliberately did not touch), and ignores keys nobody
-    ever supported rather than refusing the whole file — a migration that stops on one odd key
-    leaves half the estate on the old store."""
+def test_a_legacy_settings_file_imports_every_key_that_has_a_home(client):
+    """The migration takes a `.settings.json` verbatim: the five person facts land in identity,
+    `bot_name` lands in the BOT's own store, and a key nobody ever supported is ignored rather than
+    refused — a migration that stops on one odd key leaves half the estate on the old store, and
+    there is no second run that fixes that."""
     uid, h = _user(client, "legacy@vexa.ai")
     legacy = {"bot_name": "Scribe", "timezone": "Europe/Lisbon", "mail_minutes": False,
               "who_knows": 7}
     r = client.post(f"/internal/users/{uid}/settings/import", headers=_internal(), json=legacy)
     assert r.status_code == 200, r.text
-    assert r.json()["imported"] == {"timezone": "Europe/Lisbon", "mail_minutes": False}
-    assert r.json()["dropped"] == ["bot_name", "who_knows"]
+    assert r.json()["imported"] == {"bot_name": "Scribe", "timezone": "Europe/Lisbon",
+                                    "mail_minutes": False}
+    assert r.json()["dropped"] == ["who_knows"]
     assert client.get("/user/settings", headers=h).json()["settings"]["timezone"] == "Europe/Lisbon"
 
 
@@ -181,3 +183,69 @@ def test_the_import_is_closed_without_the_internal_secret(client):
     uid, _h = _user(client, "closed@vexa.ai")
     assert client.post(f"/internal/users/{uid}/settings/import",
                        json={"timezone": "UTC"}).status_code in (401, 403)
+
+
+# ── the bot fact: settable here, stored in the ONE place meetings reads ──────────────────────
+def test_bot_name_is_settable_and_lands_in_the_store_meetings_already_reads(client):
+    """NO FOURTH STORE (founder ruling). `users.data.calendar_bot_name` is the single source —
+    served on /internal/users/{id}/bot-context, which meeting-api reads on both spawn paths. This
+    door writes THAT key, so a name set here and a name set on the calendar screen are one thing."""
+    uid, h = _user(client, "botname@vexa.ai")
+    assert client.get("/user/settings", headers=h).json()["settings"]["bot_name"] == "Vexa"
+    r = client.put("/user/settings", headers=h, json={"bot_name": "Scribe"})
+    assert r.status_code == 200, r.text
+    assert r.json()["settings"]["bot_name"] == "Scribe"
+    # the SAME value the meetings domain resolves a spawn from
+    ctx = client.get(f"/internal/users/{uid}/bot-context", headers=_internal()).json()
+    assert ctx["bot_name"] == "Scribe"
+
+
+def test_the_calendar_screen_and_this_door_set_one_value(client):
+    uid, h = _user(client, "onestore@vexa.ai")
+    client.put("/user/settings", headers=h, json={"bot_name": "FromChat"})
+    assert client.get(f"/internal/users/{uid}/bot-context",
+                      headers=_internal()).json()["bot_name"] == "FromChat"
+
+
+def test_bot_name_is_absent_from_the_internal_settings_edge(client):
+    """flows does not read a bot name any more — meetings resolves it. Serving it here would invite
+    exactly the second reader this move removed."""
+    uid, h = _user(client, "notflows@vexa.ai")
+    client.put("/user/settings", headers=h, json={"bot_name": "Scribe"})
+    assert "bot_name" not in client.get(f"/internal/users/{uid}/settings",
+                                        headers=_internal()).json()
+
+
+def test_an_empty_bot_name_is_refused(client):
+    _uid, h = _user(client, "emptyname@vexa.ai")
+    assert client.put("/user/settings", headers=h, json={"bot_name": "  "}).status_code == 422
+
+
+def test_the_migration_leaves_an_existing_persons_bot_name_unchanged(client):
+    """THE POINT OF MIGRATING RATHER THAN DELETING. Somebody who set a name in chat keeps it, and
+    somebody who set one on the calendar screen keeps THAT — the import never changes the name a
+    person's bot shows up as, in either direction."""
+    # (a) a person whose only name was in the workspace file: it arrives, and the bot keeps it
+    uid_a, _ha = _user(client, "only-chat@vexa.ai")
+    r = client.post(f"/internal/users/{uid_a}/settings/import", headers=_internal(),
+                    json={"bot_name": "Scribe", "timezone": "Europe/Lisbon"})
+    assert r.status_code == 200, r.text
+    assert r.json()["imported"]["bot_name"] == "Scribe"
+    assert client.get(f"/internal/users/{uid_a}/bot-context",
+                      headers=_internal()).json()["bot_name"] == "Scribe"
+
+    # (b) a person who already had one on the calendar side: the import does NOT overwrite it
+    uid_b, hb = _user(client, "already-named@vexa.ai")
+    client.put("/user/settings", headers=hb, json={"bot_name": "Calendarius"})
+    r = client.post(f"/internal/users/{uid_b}/settings/import", headers=_internal(),
+                    json={"bot_name": "Scribe"})
+    assert r.json()["kept"] == ["bot_name"]
+    assert client.get(f"/internal/users/{uid_b}/bot-context",
+                      headers=_internal()).json()["bot_name"] == "Calendarius"
+
+    # (c) re-running the migration changes nothing
+    before = client.get(f"/internal/users/{uid_a}/bot-context", headers=_internal()).json()
+    client.post(f"/internal/users/{uid_a}/settings/import", headers=_internal(),
+                json={"bot_name": "SomethingElse"})
+    assert client.get(f"/internal/users/{uid_a}/bot-context",
+                      headers=_internal()).json() == before

--- a/core/identity/services/admin-api/tests/test_person_settings.py
+++ b/core/identity/services/admin-api/tests/test_person_settings.py
@@ -1,0 +1,183 @@
+"""Person facts move to identity — `/user/settings` and the internal edge flows reads.
+
+WHY THEY MOVE. `.settings.json` lived in a workspace in the AGENT domain, written by the control
+MCP and read by flows (`flows_steps/common.py:setting`). That made two domains depend on a third for
+a fact about a PERSON: with no agent domain deployed a person had no timezone and no mail
+preferences, so flows could not state a time in their clock or honour "stop mailing me minutes".
+Identity is the only domain everyone may depend on, and these six keys are facts about the person —
+so identity owns them.
+
+WHAT IS NOT HERE. `bot_name` is a fact about the BOT, not the person, and it already has a home on
+this line (`users.data.calendar_bot_name` → `/internal/users/{id}/bot-context` → meeting-api's
+auto-join). It is deliberately absent from this vocabulary; see the PR.
+
+Same testcontainers-PG harness as the other identity suites (skips without docker).
+"""
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+
+from admin_api.app import db as app_db
+from admin_api.app.main import create_app
+from admin_api.schema.models import Base
+from admin_api.schema.sync import ensure_schema_sync
+
+from conftest import requires_docker
+from test_stack_admin_api import ADMIN_TOKEN, INTERNAL_SECRET, _admin, _dispose_async_engine
+
+pytestmark = requires_docker
+
+
+@pytest.fixture()
+def client(pg_url, pg_async_url, monkeypatch):
+    sync_engine = create_engine(pg_url)
+    Base.metadata.drop_all(sync_engine)
+    ensure_schema_sync(sync_engine, Base)
+    sync_engine.dispose()
+    monkeypatch.setenv("ADMIN_API_TOKEN", ADMIN_TOKEN)
+    monkeypatch.setenv("INTERNAL_API_SECRET", INTERNAL_SECRET)
+    monkeypatch.setenv("DEV_MODE", "false")
+    app_db.configure(pg_async_url)
+    with TestClient(create_app()) as c:
+        yield c
+    _dispose_async_engine()
+
+
+def _internal():
+    return {"X-Internal-Secret": INTERNAL_SECRET}
+
+
+def _user(client, email="settings@vexa.ai"):
+    uid = client.post("/admin/users", headers=_admin(), json={"email": email}).json()["id"]
+    tok = client.post(f"/admin/users/{uid}/tokens?scopes=bot", headers=_admin()).json()["token"]
+    return uid, {"X-API-Key": tok}
+
+
+# ── the person's own door ────────────────────────────────────────────────────────────────────
+def test_a_person_who_has_set_nothing_gets_the_documented_defaults(client):
+    """Never empty, and never a missing key: a caller that has to distinguish "unset" from "off"
+    will get it wrong, and the wrong way round is a person who stops receiving their minutes."""
+    _uid, h = _user(client)
+    body = client.get("/user/settings", headers=h).json()
+    assert body["settings"] == {"timezone": "", "mail_minutes": True, "mail_join": False,
+                                "mail_rsvp": True, "mail_prep": True}
+    assert set(body["what_each_means"]) == set(body["settings"])
+
+
+def test_one_key_changes_and_the_others_do_not(client):
+    _uid, h = _user(client)
+    r = client.put("/user/settings", headers=h, json={"mail_minutes": False})
+    assert r.status_code == 200, r.text
+    after = r.json()["settings"]
+    assert after["mail_minutes"] is False
+    assert after["mail_rsvp"] is True and after["mail_prep"] is True
+
+
+def test_the_vocabulary_is_closed_and_the_refusal_carries_it(client):
+    """A setting that silently does nothing is worse than an error, and an agent with no vocabulary
+    invents one — so the refusal hands back the list rather than saying no."""
+    _uid, h = _user(client)
+    r = client.put("/user/settings", headers=h, json={"make_it_funnier": True})
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert "make_it_funnier" in str(detail)
+    assert set(detail["the_settings_that_exist"]) == {
+        "timezone", "mail_minutes", "mail_join", "mail_rsvp", "mail_prep"}
+
+
+def test_bot_name_is_not_in_this_vocabulary(client):
+    """A bot default is a fact about the BOT. It has a home already (calendar_bot_name →
+    bot-context → meeting-api); accepting it here would make a fourth store for one fact."""
+    _uid, h = _user(client)
+    assert client.put("/user/settings", headers=h, json={"bot_name": "Scribe"}).status_code == 422
+
+
+def test_a_timezone_that_is_not_a_zone_is_refused(client):
+    _uid, h = _user(client)
+    assert client.put("/user/settings", headers=h,
+                      json={"timezone": "Mars/Olympus"}).status_code == 422
+    r = client.put("/user/settings", headers=h, json={"timezone": "Europe/Lisbon"})
+    assert r.status_code == 200 and r.json()["settings"]["timezone"] == "Europe/Lisbon"
+
+
+def test_an_on_off_key_takes_the_words_a_person_uses(client):
+    """The MCP tool passes through whatever the person said. Parsing it HERE means one parser, in
+    the domain that owns the value — not one in every caller."""
+    _uid, h = _user(client)
+    for word, expected in (("off", False), ("yes", True), ("0", False), (True, True)):
+        r = client.put("/user/settings", headers=h, json={"mail_join": word})
+        assert r.status_code == 200, (word, r.text)
+        assert r.json()["settings"]["mail_join"] is expected
+
+
+def test_settings_are_per_person(client):
+    _uid_a, ha = _user(client, "a@vexa.ai")
+    _uid_b, hb = _user(client, "b@vexa.ai")
+    client.put("/user/settings", headers=ha, json={"mail_minutes": False})
+    assert client.get("/user/settings", headers=hb).json()["settings"]["mail_minutes"] is True
+
+
+def test_the_door_needs_a_credential(client):
+    assert client.get("/user/settings").status_code == 401
+    assert client.put("/user/settings", json={"mail_join": True}).status_code == 401
+
+
+# ── the internal edge flows reads ────────────────────────────────────────────────────────────
+def test_flows_reads_one_person_s_settings_over_the_internal_edge(client):
+    """flows may call identity — that is an allowed door. It may NOT call the agent domain, which
+    is what reading `.settings.json` was."""
+    uid, h = _user(client)
+    client.put("/user/settings", headers=h, json={"timezone": "Europe/Lisbon",
+                                                  "mail_prep": False})
+    r = client.get(f"/internal/users/{uid}/settings", headers=_internal())
+    assert r.status_code == 200, r.text
+    assert r.json() == {"timezone": "Europe/Lisbon", "mail_minutes": True, "mail_join": False,
+                        "mail_rsvp": True, "mail_prep": False}
+
+
+def test_the_internal_edge_is_closed_without_the_secret(client):
+    uid, _h = _user(client)
+    assert client.get(f"/internal/users/{uid}/settings").status_code in (401, 403)
+
+
+def test_an_unknown_user_is_a_404_not_a_silent_default(client):
+    """Defaults for a person who exists and defaults for a person who does not are opposite facts:
+    the second one means flows is about to mail somebody who is not there."""
+    assert client.get("/internal/users/999999/settings", headers=_internal()).status_code == 404
+
+
+# ── the one-shot migration off `.settings.json` ──────────────────────────────────────────────
+def test_a_legacy_settings_file_imports_and_drops_the_bot_fact(client):
+    """The migration takes a `.settings.json` verbatim. It keeps the five person facts, DROPS
+    `bot_name` (a bot fact, which this move deliberately did not touch), and ignores keys nobody
+    ever supported rather than refusing the whole file — a migration that stops on one odd key
+    leaves half the estate on the old store."""
+    uid, h = _user(client, "legacy@vexa.ai")
+    legacy = {"bot_name": "Scribe", "timezone": "Europe/Lisbon", "mail_minutes": False,
+              "who_knows": 7}
+    r = client.post(f"/internal/users/{uid}/settings/import", headers=_internal(), json=legacy)
+    assert r.status_code == 200, r.text
+    assert r.json()["imported"] == {"timezone": "Europe/Lisbon", "mail_minutes": False}
+    assert r.json()["dropped"] == ["bot_name", "who_knows"]
+    assert client.get("/user/settings", headers=h).json()["settings"]["timezone"] == "Europe/Lisbon"
+
+
+def test_the_import_never_overwrites_a_setting_the_person_already_changed(client):
+    """IDEMPOTENT AND LOSSLESS. The migration may be re-run — against an estate where somebody has
+    since set a preference through the new door. A second run that clobbered it would silently undo
+    a person's choice, which is the one thing a migration must never do."""
+    uid, h = _user(client, "already@vexa.ai")
+    client.put("/user/settings", headers=h, json={"mail_minutes": False})
+    r = client.post(f"/internal/users/{uid}/settings/import", headers=_internal(),
+                    json={"mail_minutes": True, "mail_rsvp": False})
+    assert r.status_code == 200, r.text
+    after = client.get("/user/settings", headers=h).json()["settings"]
+    assert after["mail_minutes"] is False, "the person's own change won"
+    assert after["mail_rsvp"] is False, "an untouched key still imported"
+    assert r.json()["kept"] == ["mail_minutes"]
+
+
+def test_the_import_is_closed_without_the_internal_secret(client):
+    uid, _h = _user(client, "closed@vexa.ai")
+    assert client.post(f"/internal/users/{uid}/settings/import",
+                       json={"timezone": "UTC"}).status_code in (401, 403)

--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -226,6 +226,11 @@ def build_production_app():
 
     app = create_app(
         transcript_store=transcript_store,
+        # The person's default bot name reaches the DIRECT spawn path too, resolved by the domain
+        # that owns the bot — same edge, same value, same precedence as the auto-join sweep.
+        fetch_bot_context=_bot_context_fetcher(
+            (os.getenv("ADMIN_API_URL") or "").rstrip("/"),
+            os.getenv("INTERNAL_API_SECRET") or ""),
         redis=segment_bus,
         meeting_repo=meeting_repo,
         runtime=runtime_client,
@@ -562,29 +567,7 @@ def _attach_background_loops(
 
         from .bot_spawn.auto_join import auto_join_tick
 
-        fetch_bot_context = None
-        if admin_api_url and internal_secret:
-            async def fetch_bot_context(user_id: int):
-                try:
-                    async with httpx.AsyncClient(timeout=10.0) as client:
-                        r = await client.get(
-                            f"{admin_api_url}/internal/users/{user_id}/bot-context",
-                            headers={"X-Internal-Secret": internal_secret},
-                        )
-                    if r.status_code != 200:
-                        return None
-                    body = r.json()
-                    return body if isinstance(body, dict) else None
-                except Exception:
-                    return None  # identity unreachable → the sweep skips the row this tick
-
-        async def publish_status(*, user_id, meeting_id, native_id, status, when):
-            frame = {"type": "meeting.status", "meeting_id": meeting_id,
-                     "native": native_id, "status": status, "when": when}
-            try:
-                await redis_client.publish(f"u:{user_id}:meetings", _json.dumps(frame))
-            except Exception:
-                pass  # best-effort, like the collector's publish
+        fetch_bot_context = _bot_context_fetcher(admin_api_url, internal_secret)
 
         async def _tick():
             await auto_join_tick(
@@ -740,6 +723,33 @@ def __getattr__(name: str):
     if name == "app":
         return build_production_app()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+
+def _bot_context_fetcher(admin_api_url: str, internal_secret: str):
+    """The per-user spawn context from identity, or None when no identity edge is configured.
+
+    ONE builder for BOTH spawn paths. The auto-join sweep has taken this edge since it existed; the
+    direct `POST /bots` path did not, which is why the same person's bot showed up under one name
+    when a calendar armed it and another when they asked for it in chat. Two fetchers would be two
+    answers to one question, so there is one, here.
+    """
+    if not admin_api_url or not internal_secret:
+        return None
+    import httpx as _httpx
+
+    async def fetch(user_id: int):
+        try:
+            async with _httpx.AsyncClient(timeout=10.0) as client:
+                r = await client.get(
+                    f"{admin_api_url}/internal/users/{user_id}/bot-context",
+                    headers={"X-Internal-Secret": internal_secret},
+                )
+            return r.json() if r.status_code == 200 else None
+        except Exception:  # noqa: BLE001 — a preference read never stops a bot joining
+            return None
+
+    return fetch
 
 
 def main() -> None:

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -157,6 +157,11 @@ def create_app(
     # bot_spawn ports
     meeting_repo: Optional["_bot_spawn.MeetingRepo"] = None,
     runtime: Optional["_bot_spawn.RuntimeClient"] = None,
+    # The per-user spawn context from identity — the SAME edge the auto-join sweep takes. It is
+    # here so the person's default bot name is resolved by the domain that owns the bot, on EVERY
+    # path a bot is spawned, rather than by each caller out of a store of its own (which is how one
+    # fact came to have three). None = no identity edge configured; a smaller answer, never an error.
+    fetch_bot_context: Optional[Callable[[int], Awaitable[Optional[dict]]]] = None,
     service_authority: Optional["object"] = None,
     # recordings ports
     recording_repo: Optional["_recordings.RecordingRepo"] = None,
@@ -267,6 +272,7 @@ def create_app(
         runtime,
         service_authority,
         transcript_stream_purge=_stream_purge,
+        fetch_bot_context=fetch_bot_context,
     ))
 
     # --- user-stop: DELETE /bots/{platform}/{native_meeting_id} (lifecycle/stop.py over redis) ---

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/adapters.py
@@ -995,7 +995,8 @@ class HttpRuntimeClient:
         return resp.json()
 
 
-def build_production_router(*, database_url: Optional[str] = None, runtime_api_url: Optional[str] = None):
+def build_production_router(*, database_url: Optional[str] = None, runtime_api_url: Optional[str] = None,
+                            fetch_bot_context=None):
     """Construct the bot-spawn router with real SQLAlchemy + httpx runtime adapters from env."""
     import httpx
     from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -1011,4 +1012,5 @@ def build_production_router(*, database_url: Optional[str] = None, runtime_api_u
     engine = build_engine(database_url)  # #635: env-steered pool
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     http = httpx.AsyncClient(timeout=30.0)
-    return build_router(SqlAlchemyMeetingRepo(session_factory), HttpRuntimeClient(http, runtime_api_url))
+    return build_router(SqlAlchemyMeetingRepo(session_factory), HttpRuntimeClient(http, runtime_api_url),
+                        fetch_bot_context=fetch_bot_context)

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -252,11 +252,19 @@ def build_router(
     authority=None,
     *,
     transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
+    fetch_bot_context: "Optional[Callable[[int], Awaitable[Optional[dict]]]]" = None,
 ) -> APIRouter:
     """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` + authority ports.
 
     ``transcript_stream_purge`` (redis-backed in prod, None offline) clears a fresh meeting's transcript
-    stream so it never inherits a reused row id's stale data — see ``request_bot``."""
+    stream so it never inherits a reused row id's stale data — see ``request_bot``.
+
+    ``fetch_bot_context`` is the per-user spawn context from identity — the SAME edge the auto-join
+    sweep already takes (``auto_join.py:324``). It is here so that the person's default bot name is
+    resolved by the domain that OWNS the bot, on every path a bot is spawned, rather than by each
+    caller out of a store of its own: that is how one fact came to have three (founder ruling,
+    2026-09-02 — no fourth store). None = no identity edge configured (offline / self-host), which
+    is a smaller answer and never an error."""
     router = APIRouter()
 
     @router.post("/bots", status_code=201)
@@ -441,6 +449,22 @@ def build_router(
 
         transcribe_enabled = _resolve_transcribe_enabled(body.get("transcribe_enabled"))
 
+        # THE NAME THIS PERSON'S BOT SHOWS UP AS. Precedence is auto-join's, unchanged: an explicit
+        # name on THIS request, then this person's default from identity, then the deployment's.
+        # Identity is not asked when the caller already named the bot — one fewer hop on a path a
+        # person is waiting on, and the answer could not change anything.
+        #
+        # A FAILED LOOKUP NEVER STOPS THE SPAWN. A name is a nicety; joining the call is the
+        # product, and failing it because a preference read timed out trades the thing they asked
+        # for against the label on it.
+        bot_name = body.get("bot_name")
+        if not bot_name and fetch_bot_context is not None:
+            try:
+                ctx = await fetch_bot_context(user_id)
+                bot_name = (ctx or {}).get("bot_name") or None
+            except Exception:  # noqa: BLE001
+                bot_name = None
+
         try:
             meeting = await request_bot(
                 repo,
@@ -449,7 +473,7 @@ def build_router(
                 user_id=user_id,
                 platform=platform,
                 native_meeting_id=native_meeting_id,
-                bot_name=body.get("bot_name"),
+                bot_name=bot_name,
                 passcode=passcode,
                 meeting_url=meeting_url,
                 teams_base_host=teams_base_host,

--- a/core/meetings/services/meeting-api/tests/test_person_bot_name.py
+++ b/core/meetings/services/meeting-api/tests/test_person_bot_name.py
@@ -1,0 +1,122 @@
+"""THE PERSON'S DEFAULT BOT NAME — one store, and meetings resolves it.
+
+There were three stores for one fact: `users.data.calendar_bot_name` (served on
+`/internal/users/{id}/bot-context`, which `auto_join.py:324` reads), a per-calendar override that
+beats it, and a `bot_name` key in a `.settings.json` file in the AGENT domain that only
+chat-dispatched bots read. So the same person's bot showed up under one name when a calendar armed
+it and another when they asked for it in chat, and nothing anywhere reconciled the two.
+
+Founder ruling, 2026-09-02: NO FOURTH STORE. The bot-context value is the single source. Meetings
+owns the bot, so meetings resolves the default — here, on the direct spawn path, exactly as
+auto-join already does on its own. Callers stop resolving it: the rig stops reading a workspace
+file, and flows stops passing a name at all.
+
+PRECEDENCE, and it is the same order auto-join uses:
+    an explicit bot_name on the request  >  this person's default  >  the deployment's
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from meeting_api.bot_spawn import build_router
+from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
+
+USER = 7
+HEADERS = {"x-user-id": str(USER)}
+URL = "https://meet.google.com/abc-defg-hij"
+
+
+@pytest.fixture(autouse=True)
+def _admin_token(monkeypatch):
+    """Minting a MeetingToken needs the deployment's secret — the same one every spawn test sets."""
+    monkeypatch.setenv("ADMIN_TOKEN", "test-admin-token")
+
+
+def _client(context=None, calls=None):
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+
+    async def fetch_bot_context(user_id: int):
+        if calls is not None:
+            calls.append(user_id)
+        return context
+
+    app = FastAPI()
+    app.include_router(build_router(repo, runtime, fetch_bot_context=fetch_bot_context))
+    return TestClient(app), runtime
+
+
+def _spawned_name(runtime):
+    """The name the bot actually goes into the room with, out of the recorded workload spec."""
+    import json
+    return json.dumps(runtime.specs[-1])
+
+
+def test_the_persons_default_is_used_when_the_caller_names_none(monkeypatch):
+    monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
+    client, runtime = _client(context={"bot_name": "Scribe"})
+    r = client.post("/bots", headers=HEADERS,
+                    json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                          "meeting_url": URL})
+    assert r.status_code == 201, r.text
+    assert "Scribe" in _spawned_name(runtime)
+
+
+def test_an_explicit_name_beats_the_persons_default():
+    client, runtime = _client(context={"bot_name": "Scribe"})
+    client.post("/bots", headers=HEADERS,
+                json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                      "meeting_url": URL, "bot_name": "JustThisOnce"})
+    body = _spawned_name(runtime)
+    assert "JustThisOnce" in body and "Scribe" not in body
+
+
+def test_the_deployment_default_still_applies_when_the_person_has_none(monkeypatch):
+    monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
+    client, runtime = _client(context={})
+    client.post("/bots", headers=HEADERS,
+                json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                      "meeting_url": URL})
+    assert "DeploymentBot" in _spawned_name(runtime)
+
+
+def test_an_unreachable_identity_never_stops_a_bot_joining(monkeypatch):
+    """A name is a nicety; joining the call is the product. Failing the spawn because a preference
+    lookup timed out would trade the thing they asked for against the label on it."""
+    monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+
+    async def boom(user_id: int):
+        raise RuntimeError("identity is down")
+
+    app = FastAPI()
+    app.include_router(build_router(repo, runtime, fetch_bot_context=boom))
+    r = TestClient(app).post("/bots", headers=HEADERS,
+                             json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                                   "meeting_url": URL})
+    assert r.status_code == 201, r.text
+    assert "DeploymentBot" in _spawned_name(runtime)
+
+
+def test_identity_is_not_asked_when_the_caller_already_named_the_bot():
+    """One fewer hop on the path a person is waiting on, and the answer could not change anything."""
+    calls = []
+    client, _runtime = _client(context={"bot_name": "Scribe"}, calls=calls)
+    client.post("/bots", headers=HEADERS,
+                json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                      "meeting_url": URL, "bot_name": "JustThisOnce"})
+    assert calls == []
+
+
+def test_a_deployment_with_no_identity_edge_still_spawns(monkeypatch):
+    """`fetch_bot_context=None` is the offline/self-host shape — no admin edge configured."""
+    monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    app = FastAPI()
+    app.include_router(build_router(repo, runtime))
+    r = TestClient(app).post("/bots", headers=HEADERS,
+                             json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                                   "meeting_url": URL})
+    assert r.status_code == 201, r.text
+    assert "DeploymentBot" in _spawned_name(runtime)

--- a/deploy/dogfood/bin/migrate-settings-to-identity.py
+++ b/deploy/dogfood/bin/migrate-settings-to-identity.py
@@ -6,12 +6,17 @@ the AGENT domain. They live in identity now (`admin_api.app.person_settings`), w
 domain flows and the MCP may depend on — so a deployment without the agent domain still has people
 with a clock and a way to stop the mail.
 
+`bot_name` moves too, into the store that ALREADY existed for it: `users.data.calendar_bot_name`,
+served on `/internal/users/{id}/bot-context`, which meeting-api reads on both spawn paths. NOBODY'S
+BOT CHANGES THE NAME IT SHOWS UP AS — that is the whole reason this is a migration and not a delete.
+A person who only ever set a name in chat keeps it; a person who set one on the calendar screen
+keeps THAT, and the import reports it under `kept` rather than overwriting it.
+
     python3 migrate-settings-to-identity.py --dry-run          # say what it would do
     python3 migrate-settings-to-identity.py                    # do it
 
 It is IDEMPOTENT: the import route keeps any key the person has already set through the new door,
-so re-running it cannot undo somebody's choice. `bot_name` is DROPPED — it is a fact about the bot,
-not the person, and this move deliberately did not touch it.
+so re-running it cannot undo somebody's choice.
 
 Reads the workspaces through agent-api (the domain that owns those files) and writes through
 admin-api's internal tier. Both are read from the environment; nothing is hardcoded and no container
@@ -101,8 +106,8 @@ def main() -> int:
         moved += 1
     verb = "would move" if args.dry_run else "moved"
     print(f"\n{verb} {moved}, nothing to do for {skipped}, failed {failed}")
-    # The legacy files are LEFT IN PLACE on purpose: this is reversible until somebody deletes them,
-    # and `bot_name` — the one key that did not move — is still read from them.
+    # The legacy files are LEFT IN PLACE on purpose: nothing reads them any more, so leaving them
+    # costs nothing and keeps this reversible until somebody deletes them deliberately.
     return 1 if failed else 0
 
 

--- a/deploy/dogfood/bin/migrate-settings-to-identity.py
+++ b/deploy/dogfood/bin/migrate-settings-to-identity.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""ONE-SHOT: move every `.settings.json` off the agent workspaces and into identity.
+
+`timezone` and the four mail preferences were facts about a PERSON kept in a file in a workspace in
+the AGENT domain. They live in identity now (`admin_api.app.person_settings`), which is the only
+domain flows and the MCP may depend on — so a deployment without the agent domain still has people
+with a clock and a way to stop the mail.
+
+    python3 migrate-settings-to-identity.py --dry-run          # say what it would do
+    python3 migrate-settings-to-identity.py                    # do it
+
+It is IDEMPOTENT: the import route keeps any key the person has already set through the new door,
+so re-running it cannot undo somebody's choice. `bot_name` is DROPPED — it is a fact about the bot,
+not the person, and this move deliberately did not touch it.
+
+Reads the workspaces through agent-api (the domain that owns those files) and writes through
+admin-api's internal tier. Both are read from the environment; nothing is hardcoded and no container
+is named.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+ADMIN_API = (os.environ.get("VEXA_ADMIN_API_URL") or "http://localhost:18457").rstrip("/")
+AGENT_API = (os.environ.get("VEXA_AGENT_API_URL") or "http://localhost:18500").rstrip("/")
+ADMIN_TOKEN = os.environ.get("VEXA_ADMIN_API_TOKEN") or os.environ.get("ADMIN_API_TOKEN") or ""
+INTERNAL_SECRET = os.environ.get("INTERNAL_API_SECRET") or ""
+
+
+def _req(method: str, url: str, headers: dict, body=None, timeout: int = 20):
+    req = urllib.request.Request(
+        url, method=method, headers={"content-type": "application/json", **headers},
+        data=json.dumps(body).encode() if body is not None else None)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 — internal service URL
+            raw = r.read().decode()
+            try:
+                return r.status, json.loads(raw)
+            except Exception:  # noqa: BLE001
+                return r.status, raw
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()[:300]
+    except Exception as e:  # noqa: BLE001
+        return 0, f"{type(e).__name__}: {e}"
+
+
+def users() -> list:
+    st, body = _req("GET", f"{ADMIN_API}/admin/users?limit=1000",
+                    {"X-Admin-API-Key": ADMIN_TOKEN})
+    if st != 200 or not isinstance(body, list):
+        print(f"could not list users: admin-api answered {st}: {str(body)[:200]}", file=sys.stderr)
+        return []
+    return body
+
+
+def legacy_settings(uid) -> dict | None:
+    """One person's `.settings.json`, through the domain that owns the file. None = nothing to do."""
+    st, body = _req("GET", f"{AGENT_API}/api/workspace/file?path=.settings.json",
+                    {"X-User-Id": str(uid)})
+    if st != 200 or not isinstance(body, dict):
+        return None
+    try:
+        parsed = json.loads(body.get("content") or "")
+    except Exception:  # noqa: BLE001
+        return None
+    return parsed if isinstance(parsed, dict) and parsed else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="report, write nothing")
+    args = ap.parse_args()
+    if not ADMIN_TOKEN or (not args.dry_run and not INTERNAL_SECRET):
+        print("set VEXA_ADMIN_API_TOKEN, and INTERNAL_API_SECRET to write", file=sys.stderr)
+        return 2
+
+    moved = skipped = failed = 0
+    for u in users():
+        uid, email = u.get("id"), u.get("email") or "?"
+        legacy = legacy_settings(uid)
+        if not legacy:
+            skipped += 1
+            continue
+        if args.dry_run:
+            print(f"  would import {uid} {email}: {sorted(legacy)}")
+            moved += 1
+            continue
+        st, body = _req("POST", f"{ADMIN_API}/internal/users/{uid}/settings/import",
+                        {"X-Internal-Secret": INTERNAL_SECRET}, legacy)
+        if st != 200 or not isinstance(body, dict):
+            print(f"  FAILED {uid} {email}: {st} {str(body)[:160]}", file=sys.stderr)
+            failed += 1
+            continue
+        print(f"  {uid} {email}: imported={sorted(body['imported'])} "
+              f"kept={body['kept']} dropped={body['dropped']}")
+        moved += 1
+    verb = "would move" if args.dry_run else "moved"
+    print(f"\n{verb} {moved}, nothing to do for {skipped}, failed {failed}")
+    # The legacy files are LEFT IN PLACE on purpose: this is reversible until somebody deletes them,
+    # and `bot_name` — the one key that did not move — is still read from them.
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -413,61 +413,78 @@ CONFIG_VOCAB = {
 UI_BASE = os.environ.get("VEXA_UI_URL", "http://localhost:18300")
 
 
-SETTINGS_PATH = ".settings.json"
+SETTINGS_PATH = ".settings.json"        # legacy: the file this used to write. Read by nothing now.
 
-# CLOSED VOCABULARY. key -> (default, kind, what it means to the person). An unknown key is
-# refused with this list: a setting that silently does nothing is worse than an error, and an
-# agent with no vocabulary invents one.
-SETTINGS_VOCAB = {
-    "bot_name":     ("Vexa", "text",
-                     "the name the notetaker shows up as in the room"),
-    "mail_minutes": (True, "on/off",
-                     "the write-up after a meeting ends"),
-    "mail_join":    (False, "on/off",
-                     "a note each time the notetaker joins a call"),
-    "mail_rsvp":    (True, "on/off",
-                     "replying yes in the calendar when Vexa is invited to a meeting"),
-    "mail_prep":    (True, "on/off",
-                     "the day-before prepare email for upcoming meetings"),
-    "timezone":     ("", "text",
-                     "their IANA zone, e.g. Europe/Lisbon — every time is stated in it"),
-}
+# THE VOCABULARY MOVED TO IDENTITY. It was a Python dict here and a file in a workspace in the AGENT
+# domain, which made flows and this server depend on a third domain for a fact about a PERSON — so a
+# deployment without agents had nobody with a timezone and no way to stop the mail, and every mail
+# the engine sends is gated on one of these values. `admin_api.app.person_settings` owns it now; this
+# server asks identity, with the caller's own key, and holds no copy of the list.
+#
+# `bot_name` is the ONE key still written here, and it is a question rather than an oversight: there
+# are already three stores for that one fact (identity's `calendar_bot_name` → bot-context →
+# meeting-api's auto-join, a per-calendar override, and this file). Moving it into identity's person
+# settings would make a fourth. Held for the founder; see the PR.
+_BOT_FACT = "bot_name"
+_BOT_FACT_DEFAULT = "Vexa"
+_BOT_FACT_MEANING = "the name the notetaker shows up as in the room"
 
 
 def _settings(uid: str) -> dict:
-    """This person's preferences, defaults filled in. Never raises, never empty."""
+    """This person's preferences, defaults filled in. Never raises, never empty.
+
+    The five PERSON facts come from identity; `bot_name` still comes from the workspace file, which
+    is the one thing this slice deliberately did not move."""
+    st, body = _http("GET", f"{ADMIN_API}/user/settings", {"X-API-Key": _user_key(uid)})
+    out = dict(body.get("settings") or {}) if st == 200 and isinstance(body, dict) else {}
     raw = _read_json(uid, SETTINGS_PATH, {}) or {}
-    out = {k: v[0] for k, v in SETTINGS_VOCAB.items()}
-    out.update({k: v for k, v in raw.items() if k in SETTINGS_VOCAB})
+    out[_BOT_FACT] = raw.get(_BOT_FACT, _BOT_FACT_DEFAULT)
     return out
 
 
-def _settings_set(uid: str, key: str, value) -> dict:
-    raw = _read_json(uid, SETTINGS_PATH, {}) or {}
-    raw[key] = value
-    _write_json(uid, SETTINGS_PATH, raw)
-    return _settings(uid)
+def _settings_meanings() -> dict:
+    """What each setting means, from the domain that owns it — never a second copy of the list."""
+    st, body = _http("GET", f"{ADMIN_API}/user/settings",
+                     {"X-API-Key": _user_key(_subject() or "")})
+    means = dict(body.get("what_each_means") or {}) if st == 200 and isinstance(body, dict) else {}
+    means[_BOT_FACT] = _BOT_FACT_MEANING
+    return means
+
+
+def _settings_set(uid: str, key: str, value):
+    """Set one setting. Returns (settings, refusal-or-None) — identity owns the vocabulary AND the
+    coercion, so "off"/"no"/"yes" are parsed once, there, and not in every caller."""
+    if key == _BOT_FACT:
+        raw = _read_json(uid, SETTINGS_PATH, {}) or {}
+        raw[_BOT_FACT] = str(value).strip() or _BOT_FACT_DEFAULT
+        _write_json(uid, SETTINGS_PATH, raw)
+        return _settings(uid), None
+    st, body = _http("PUT", f"{ADMIN_API}/user/settings", {"X-API-Key": _user_key(uid)},
+                     {key: value})
+    if st == 422 and isinstance(body, dict):
+        detail = body.get("detail")
+        if isinstance(detail, dict):
+            detail.setdefault("the_settings_that_exist", {})[_BOT_FACT] = _BOT_FACT_MEANING
+        return _settings(uid), detail
+    if st != 200:
+        return _settings(uid), {"refused": "identity could not be reached", "status": st}
+    return _settings(uid), None
 
 
 _TZ_FILE = HOME / ".storm/user-timezones.json"
 
 
 def _person_tz(uid: str, set_to: str = "") -> str:
-    """This person's IANA timezone, remembered across calls.
+    """This person's IANA timezone, remembered by IDENTITY across calls.
 
     Times were rendered on the server's clock, so a Lisbon person booking a standup was told it
-    would join at 19:15 when it was 17:15 where they stood. The agent knows their zone from its
-    own environment; we only have to be told once and then never state a bare time again.
-    """
+    would join at 19:15 when it was 17:15 where they stood. The agent knows their zone from its own
+    environment; we only have to be told once and then never state a bare time again. Whether a
+    string IS a zone is identity's judgement now, not a second `zoneinfo` check here."""
     uid = str(uid)
     if set_to:
-        try:
-            import zoneinfo
-            zoneinfo.ZoneInfo(set_to)
-        except Exception:  # noqa: BLE001
-            return _settings(uid).get("timezone", "")
-        _settings_set(uid, "timezone", set_to)
-        return set_to
+        after, refused = _settings_set(uid, "timezone", set_to)
+        return after.get("timezone", "") if not refused else _settings(uid).get("timezone", "")
     return _settings(uid).get("timezone", "")
 
 
@@ -4702,39 +4719,22 @@ def settings(key: str = "", value: str = "", token: str = "") -> str:
 
     on/off settings accept on/off, true/false, yes/no."""
     uid = me()
-    cur = _settings(uid)
     if not key:
         return json.dumps({
-            "settings": cur,
-            "what_each_means": {k: v[2] for k, v in SETTINGS_VOCAB.items()},
+            "settings": _settings(uid),
+            "what_each_means": _settings_meanings(),
             "to_change": "settings(key=..., value=...) — one at a time",
         })
-    if key not in SETTINGS_VOCAB:
-        return json.dumps({
-            "refused": f"there is no setting called {key!r}",
-            "the_settings_that_exist": {k: v[2] for k, v in SETTINGS_VOCAB.items()},
-            "do": "pick one of these, or report_friction() if the thing they want is missing "
-                  "— do NOT edit a flow to work around it.",
-        })
-    default, kind, meaning = SETTINGS_VOCAB[key]
-    if kind == "on/off":
-        v = str(value).strip().lower()
-        if v not in ("on", "off", "true", "false", "yes", "no", "1", "0"):
-            return json.dumps({"refused": f"{key} is on or off", "you_sent": value})
-        val = v in ("on", "true", "yes", "1")
-    else:
-        val = str(value).strip()
-        if key == "timezone" and val:
-            try:
-                import zoneinfo
-                zoneinfo.ZoneInfo(val)
-            except Exception:  # noqa: BLE001
-                return json.dumps({"refused": f"{val!r} is not a timezone",
-                                   "give_me": "an IANA name like Europe/Lisbon"})
-    after = _settings_set(uid, key, val)
+    after, refused = _settings_set(uid, key, value)
+    if refused:
+        return json.dumps({**refused,
+                           "do": "pick one of the settings above, or report_friction() if the "
+                                 "thing they want is missing — do NOT edit a flow to work around it."})
+    meaning = _settings_meanings().get(key, key)
     return json.dumps({
-        "changed": {key: val}, "settings": after,
-        "tell_your_person": f"Done — {meaning}: now {val!r}. It applies from the next meeting.",
+        "changed": {key: after.get(key)}, "settings": after,
+        "tell_your_person": f"Done — {meaning}: now {after.get(key)!r}. It applies from the next "
+                            f"meeting.",
         "scope": "this is theirs alone; nobody else's Vexa changed",
     })
 

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -425,53 +425,33 @@ SETTINGS_PATH = ".settings.json"        # legacy: the file this used to write. R
 # are already three stores for that one fact (identity's `calendar_bot_name` → bot-context →
 # meeting-api's auto-join, a per-calendar override, and this file). Moving it into identity's person
 # settings would make a fourth. Held for the founder; see the PR.
-_BOT_FACT = "bot_name"
-_BOT_FACT_DEFAULT = "Vexa"
-_BOT_FACT_MEANING = "the name the notetaker shows up as in the room"
-
-
 def _settings(uid: str) -> dict:
     """This person's preferences, defaults filled in. Never raises, never empty.
 
-    The five PERSON facts come from identity; `bot_name` still comes from the workspace file, which
-    is the one thing this slice deliberately did not move."""
+    All of them come from identity now, including `bot_name` — which identity stores in
+    `users.data.calendar_bot_name`, the ONE place meeting-api already reads a person's default from
+    on both spawn paths. This server holds no vocabulary and no copy of any value."""
     st, body = _http("GET", f"{ADMIN_API}/user/settings", {"X-API-Key": _user_key(uid)})
-    out = dict(body.get("settings") or {}) if st == 200 and isinstance(body, dict) else {}
-    raw = _read_json(uid, SETTINGS_PATH, {}) or {}
-    out[_BOT_FACT] = raw.get(_BOT_FACT, _BOT_FACT_DEFAULT)
-    return out
+    return dict(body.get("settings") or {}) if st == 200 and isinstance(body, dict) else {}
 
 
 def _settings_meanings() -> dict:
     """What each setting means, from the domain that owns it — never a second copy of the list."""
     st, body = _http("GET", f"{ADMIN_API}/user/settings",
                      {"X-API-Key": _user_key(_subject() or "")})
-    means = dict(body.get("what_each_means") or {}) if st == 200 and isinstance(body, dict) else {}
-    means[_BOT_FACT] = _BOT_FACT_MEANING
-    return means
+    return dict(body.get("what_each_means") or {}) if st == 200 and isinstance(body, dict) else {}
 
 
 def _settings_set(uid: str, key: str, value):
     """Set one setting. Returns (settings, refusal-or-None) — identity owns the vocabulary AND the
     coercion, so "off"/"no"/"yes" are parsed once, there, and not in every caller."""
-    if key == _BOT_FACT:
-        raw = _read_json(uid, SETTINGS_PATH, {}) or {}
-        raw[_BOT_FACT] = str(value).strip() or _BOT_FACT_DEFAULT
-        _write_json(uid, SETTINGS_PATH, raw)
-        return _settings(uid), None
     st, body = _http("PUT", f"{ADMIN_API}/user/settings", {"X-API-Key": _user_key(uid)},
                      {key: value})
     if st == 422 and isinstance(body, dict):
-        detail = body.get("detail")
-        if isinstance(detail, dict):
-            detail.setdefault("the_settings_that_exist", {})[_BOT_FACT] = _BOT_FACT_MEANING
-        return _settings(uid), detail
+        return _settings(uid), body.get("detail") if isinstance(body.get("detail"), dict) else body
     if st != 200:
         return _settings(uid), {"refused": "identity could not be reached", "status": st}
-    return _settings(uid), None
-
-
-_TZ_FILE = HOME / ".storm/user-timezones.json"
+    return dict((body or {}).get("settings") or {}), None
 
 
 def _person_tz(uid: str, set_to: str = "") -> str:
@@ -3778,13 +3758,20 @@ def bot_send(meeting_url: str, bot_name: str = "", token: str = "") -> str:
     # resolved ONCE: the request and the sentence we say back must name the same bot. An
     # earlier cut resolved it inline and left the reply reading the raw empty parameter —
     # "the bot is at the door as ''".
-    bot_name = bot_name or _settings(uid).get("bot_name") or "Vexa"
+    # NO DEFAULT RESOLVED HERE. An explicit name passes through; an absent one is meeting-api's to
+    # fill from the person's own default, which it reads from identity on every spawn path. This
+    # line used to read a workspace file, and that is how one fact came to have three stores.
+    bot_name = bot_name or ""
     # What the sentence CALLS the meeting. The url is the only name we reliably have here, and it
     # is the one the person just handed us — so it reads back as theirs rather than as an id.
     title_for_say = (meeting_url or "").strip() or f"{platform}/{mid}"
+    # What the room will actually see, resolved ONCE by the domain that decides it, so the sentence
+    # we say back and the name on the bot cannot differ.
+    said_name = bot_name or _settings(uid).get("bot_name") or "Vexa"
     st, r = _gw_http(uid, "POST", "/bots",
                      {"platform": platform, "native_meeting_id": mid,
-                      "meeting_url": meeting_url.strip(), "bot_name": bot_name})
+                      "meeting_url": meeting_url.strip(),
+                      **({"bot_name": bot_name} if bot_name else {})})
     if st not in (200, 201):
         if st == 409:
             return json.dumps({"already_there": True,
@@ -3826,8 +3813,8 @@ def bot_send(meeting_url: str, bot_name: str = "", token: str = "") -> str:
     # be fixed with an instruction — the tool was offering the link, labelled for exactly that use.
     # The panel is moved by the harness on this result; the sentence says what is about to happen.
     say = {
-        "in_call": f"The bot is in the call as '{bot_name}' — the transcript is beside this chat.",
-        "knocking": f"The bot is at the door of {title_for_say} as '{bot_name}'. Someone in the "
+        "in_call": f"The bot is in the call as '{said_name}' — the transcript is beside this chat.",
+        "knocking": f"The bot is at the door of {title_for_say} as '{said_name}'. Someone in the "
                     f"meeting has to let it in, same as any guest; the transcript opens beside "
                     f"this chat when it is admitted.",
         "failed": "The bot could not stay in the call. That is ours, not yours — I have "


### PR DESCRIPTION
**Delivers issue:** #1461

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle (the record of your harnessed loop)

- **C1 — person facts follow the account.** ran: wrote 11 tests against a `/user/settings` that did
  not exist yet, on admin-api's testcontainers lane · saw: 10 red, 1 green (the "unknown user is a
  404" row passed for the wrong reason — there was no route, so everything was a 404) · concluded:
  the one accidental pass told me the negative control was weak, so the route had to distinguish an
  unknown person from a defaulted one deliberately. Implemented against `users.data`, which already
  exists, so the DB schema seal is untouched — 68 columns / 9 tables, unchanged.

- **C1 — the fail direction.** ran: `test_an_unreachable_identity_falls_back_to_the_documented_default`
  with the identity edge replaced at the seam · saw: defaults returned, no exception · concluded:
  this is the direction that has to be chosen out loud. A mail preference failing OPEN sends mail
  somebody turned off; failing CLOSED silently stops their write-ups. The defaults are what a person
  who never touched a setting already has, so they are the honest answer.

- **C1 — flows stops reading the agent domain.** ran: the flows suite with `ws_file` recorded ·
  saw: `test_no_person_fact_reaches_the_agent_domain` green and the workspace read gone from the
  source · concluded: the coupling is removed, not merely unused — asserted against the source so it
  cannot come back quietly.

- **C2 — the notetaker's name.** ran: read the three stores before writing anything ·
  saw: `users.data.calendar_bot_name` → `/internal/users/{id}/bot-context` → `auto_join.py:324`; a
  per-calendar override beating it at `:152`; and the workspace file only chat-armed bots read ·
  concluded: **the store already existed.** Adding a fourth would have been the obvious move and the
  wrong one, so the direct spawn path was pointed at the one meetings already reads
  (`bot_spawn/router.py:461`) and every caller stopped resolving it.

- **C2 — nobody's bot changes name.** ran: `test_the_migration_leaves_an_existing_persons_bot_name_unchanged`,
  three ways — a chat-only name, a calendar-set name, and a re-run · saw: imported / `kept` /
  unchanged · concluded: this is the reason it is a migration and not a delete, and it is asserted in
  both directions rather than argued.

- **Whole-repo.** ran: admin-api, meeting-api, flows and agent suites at head · saw: 129 / 1328 (5
  skipped) / 290 of 291 / 1589 · concluded: the one failure is
  `flows tests/test_contract_smokes.py::test_admin_user_lookup_shapes`, which needs a live admin-api
  and fails identically on the parent commit — a pre-existing live-stack smoke, not a regression.

## Acceptance floor

Base `008a579ce`(C1) / `3a8012ac2`(C2 parent) → head `1699aa3ac`.

| Row | Evidence |
|---|---|
| A1 | `test_a_person_who_has_set_nothing_gets_the_documented_defaults`, `test_one_key_changes_and_the_others_do_not`, `test_flows_reads_one_person_s_settings_over_the_internal_edge`. RED at base: the routes do not exist. Flows' side: `test_no_person_fact_reaches_the_agent_domain` — the agent door is never called for the five keys. |
| A2 | `test_settings_are_per_person`, `test_a_setting_write_leaves_the_other_settings_alone`, `test_the_door_needs_a_credential`. Storage is `users.data.person_settings`; `gate:db-schema` green at head (68 columns / 9 tables, unchanged) — the negative control for "did this need a migration". |
| A3 | `test_the_migration_leaves_an_existing_persons_bot_name_unchanged` (three cases), plus `test_bot_name_is_settable_and_lands_in_the_store_meetings_already_reads` and `test_the_calendar_screen_and_this_door_set_one_value`. RED at base: chat-armed and calendar-armed spawns read different stores. |
| A4 | `test_an_unreachable_identity_never_stops_a_bot_joining` and `test_a_deployment_with_no_identity_edge_still_spawns` — both 201. Negative control: `test_the_persons_default_is_used_when_the_caller_names_none` shows the lookup genuinely happens when it can. |
| A- | admin-api 129 · meeting-api 1328/5 skipped · flows 290/291 · agent 1589. Gates `readme`, `config-contract`, `isolation`, `graph`, `schema`, `db-schema` green at head. The single flows failure is pre-existing at the parent commit. |

Rows exceeded: `test_identity_is_not_asked_when_the_caller_already_named_the_bot` — one fewer hop on
a path a person is waiting on, which the issue did not ask for.

## Docs diff (D6c)
`docs:` none. No documentation page describes these settings today: they are reachable only through
an agent verb, whose own description is the reference and is unchanged in substance. What changes is
where the value is stored, which no reader can observe. A page for per-person settings is worth
having and is a separate item, not something to invent inside this change.

## Security checks (required on the diff)
No new dependency and no new secret. The two credential-shaped surfaces were checked directly:
`/user/settings` requires the caller's own key (`test_the_door_needs_a_credential`, 401 on both
verbs), and `/internal/users/{id}/settings` requires the internal secret
(`test_the_internal_edge_is_closed_without_the_secret`). The migration route is on the same internal
tier (`test_the_import_is_closed_without_the_internal_secret`). No value here is a secret: the bot
name and the mail preferences are the person's own settings and are returned in the clear
deliberately.

## Validation request
Any competent non-author; the operator who runs the dogfood deployment is the natural signer.

**Deployment:** full compose, built from this branch at `1699aa3ac`, `deploy/compose/docker-compose.yml`,
long-lived instance, no env deltas from stock.

What to watch: set a timezone and turn minutes off, then confirm the next write-up mail does not
arrive and that times in the mails that do arrive are in the chosen zone; then confirm an existing
person's notetaker joins under the name it joined under yesterday. **Lite is not claimed** — it is
the deployment most likely to run without the agent tier, so it is the highest-value follow-up, and
nobody has run it.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
